### PR TITLE
Add Ozon stock and sales services

### DIFF
--- a/site/migrations/Version20250727000000.php
+++ b/site/migrations/Version20250727000000.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250727000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add Ozon product stock and sales tables';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE "ozon_product_stocks" (id UUID NOT NULL, product_id UUID NOT NULL, company_id UUID NOT NULL, qty INT NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_OZON_PRODUCT_STOCK_PRODUCT ON "ozon_product_stocks" (product_id)');
+        $this->addSql('CREATE INDEX IDX_OZON_PRODUCT_STOCK_COMPANY ON "ozon_product_stocks" (company_id)');
+        $this->addSql('COMMENT ON COLUMN "ozon_product_stocks".updated_at IS \'(DC2Type:datetime_immutable)\'');
+        $this->addSql('ALTER TABLE "ozon_product_stocks" ADD CONSTRAINT FK_OZON_STOCK_PRODUCT FOREIGN KEY (product_id) REFERENCES "ozon_products" (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE "ozon_product_stocks" ADD CONSTRAINT FK_OZON_STOCK_COMPANY FOREIGN KEY (company_id) REFERENCES "companies" (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+
+        $this->addSql('CREATE TABLE "ozon_product_sales" (id UUID NOT NULL, product_id UUID NOT NULL, company_id UUID NOT NULL, qty INT NOT NULL, date_from TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, date_to TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_OZON_PRODUCT_SALES_PRODUCT ON "ozon_product_sales" (product_id)');
+        $this->addSql('CREATE INDEX IDX_OZON_PRODUCT_SALES_COMPANY ON "ozon_product_sales" (company_id)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_OZON_PRODUCT_SALES_PERIOD ON "ozon_product_sales" (product_id, company_id, date_from, date_to)');
+        $this->addSql('COMMENT ON COLUMN "ozon_product_sales".date_from IS \'(DC2Type:datetime_immutable)\'');
+        $this->addSql('COMMENT ON COLUMN "ozon_product_sales".date_to IS \'(DC2Type:datetime_immutable)\'');
+        $this->addSql('ALTER TABLE "ozon_product_sales" ADD CONSTRAINT FK_OZON_SALES_PRODUCT FOREIGN KEY (product_id) REFERENCES "ozon_products" (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE "ozon_product_sales" ADD CONSTRAINT FK_OZON_SALES_COMPANY FOREIGN KEY (company_id) REFERENCES "companies" (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "ozon_product_stocks" DROP CONSTRAINT FK_OZON_STOCK_PRODUCT');
+        $this->addSql('ALTER TABLE "ozon_product_stocks" DROP CONSTRAINT FK_OZON_STOCK_COMPANY');
+        $this->addSql('ALTER TABLE "ozon_product_sales" DROP CONSTRAINT FK_OZON_SALES_PRODUCT');
+        $this->addSql('ALTER TABLE "ozon_product_sales" DROP CONSTRAINT FK_OZON_SALES_COMPANY');
+        $this->addSql('DROP TABLE "ozon_product_stocks"');
+        $this->addSql('DROP TABLE "ozon_product_sales"');
+    }
+}

--- a/site/src/Entity/Ozon/OzonProductSales.php
+++ b/site/src/Entity/Ozon/OzonProductSales.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Entity\Ozon;
+
+use App\Entity\Company;
+use Doctrine\ORM\Mapping as ORM;
+use App\Repository\Ozon\OzonProductSalesRepository;
+
+#[ORM\Entity(repositoryClass: OzonProductSalesRepository::class)]
+#[ORM\Table(name: '`ozon_product_sales`')]
+#[ORM\UniqueConstraint(name: 'uniq_sales_period', columns: ['product_id', 'company_id', 'date_from', 'date_to'])]
+class OzonProductSales
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid', unique: true)]
+    private ?string $id = null;
+
+    #[ORM\ManyToOne(targetEntity: OzonProduct::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private OzonProduct $product;
+
+    #[ORM\ManyToOne(targetEntity: Company::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private Company $company;
+
+    #[ORM\Column(type: 'integer')]
+    private int $qty = 0;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $dateFrom;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $dateTo;
+
+    public function __construct(string $id, OzonProduct $product, Company $company, \DateTimeImmutable $dateFrom, \DateTimeImmutable $dateTo)
+    {
+        $this->id = $id;
+        $this->product = $product;
+        $this->company = $company;
+        $this->dateFrom = $dateFrom;
+        $this->dateTo = $dateTo;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getProduct(): OzonProduct
+    {
+        return $this->product;
+    }
+
+    public function setProduct(OzonProduct $product): void
+    {
+        $this->product = $product;
+    }
+
+    public function getCompany(): Company
+    {
+        return $this->company;
+    }
+
+    public function setCompany(Company $company): void
+    {
+        $this->company = $company;
+    }
+
+    public function getQty(): int
+    {
+        return $this->qty;
+    }
+
+    public function setQty(int $qty): void
+    {
+        $this->qty = $qty;
+    }
+
+    public function getDateFrom(): \DateTimeImmutable
+    {
+        return $this->dateFrom;
+    }
+
+    public function setDateFrom(\DateTimeImmutable $dateFrom): void
+    {
+        $this->dateFrom = $dateFrom;
+    }
+
+    public function getDateTo(): \DateTimeImmutable
+    {
+        return $this->dateTo;
+    }
+
+    public function setDateTo(\DateTimeImmutable $dateTo): void
+    {
+        $this->dateTo = $dateTo;
+    }
+}

--- a/site/src/Entity/Ozon/OzonProductStock.php
+++ b/site/src/Entity/Ozon/OzonProductStock.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Entity\Ozon;
+
+use App\Entity\Company;
+use Doctrine\ORM\Mapping as ORM;
+use App\Repository\Ozon\OzonProductStockRepository;
+
+#[ORM\Entity(repositoryClass: OzonProductStockRepository::class)]
+#[ORM\Table(name: '`ozon_product_stocks`')]
+class OzonProductStock
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid', unique: true)]
+    private ?string $id = null;
+
+    #[ORM\ManyToOne(targetEntity: OzonProduct::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private OzonProduct $product;
+
+    #[ORM\ManyToOne(targetEntity: Company::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private Company $company;
+
+    #[ORM\Column(type: 'integer')]
+    private int $qty = 0;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $updatedAt;
+
+    public function __construct(string $id, OzonProduct $product, Company $company)
+    {
+        $this->id = $id;
+        $this->product = $product;
+        $this->company = $company;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getProduct(): OzonProduct
+    {
+        return $this->product;
+    }
+
+    public function setProduct(OzonProduct $product): void
+    {
+        $this->product = $product;
+    }
+
+    public function getCompany(): Company
+    {
+        return $this->company;
+    }
+
+    public function setCompany(Company $company): void
+    {
+        $this->company = $company;
+    }
+
+    public function getQty(): int
+    {
+        return $this->qty;
+    }
+
+    public function setQty(int $qty): void
+    {
+        $this->qty = $qty;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(\DateTimeImmutable $updatedAt): void
+    {
+        $this->updatedAt = $updatedAt;
+    }
+}

--- a/site/src/Repository/Ozon/OzonProductSalesRepository.php
+++ b/site/src/Repository/Ozon/OzonProductSalesRepository.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Repository\Ozon;
+
+use App\Entity\Company;
+use App\Entity\Ozon\OzonProduct;
+use App\Entity\Ozon\OzonProductSales;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class OzonProductSalesRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, OzonProductSales::class);
+    }
+
+    public function findOneByPeriod(OzonProduct $product, Company $company, \DateTimeImmutable $from, \DateTimeImmutable $to): ?OzonProductSales
+    {
+        return $this->createQueryBuilder('s')
+            ->andWhere('s.product = :product')
+            ->andWhere('s.company = :company')
+            ->andWhere('s.dateFrom = :from')
+            ->andWhere('s.dateTo = :to')
+            ->setParameter('product', $product)
+            ->setParameter('company', $company)
+            ->setParameter('from', $from)
+            ->setParameter('to', $to)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+}

--- a/site/src/Repository/Ozon/OzonProductStockRepository.php
+++ b/site/src/Repository/Ozon/OzonProductStockRepository.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Repository\Ozon;
+
+use App\Entity\Company;
+use App\Entity\Ozon\OzonProduct;
+use App\Entity\Ozon\OzonProductStock;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class OzonProductStockRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, OzonProductStock::class);
+    }
+
+    public function findOneForDate(OzonProduct $product, Company $company, \DateTimeImmutable $date): ?OzonProductStock
+    {
+        $start = $date->setTime(0, 0);
+        $end = $start->modify('+1 day');
+
+        return $this->createQueryBuilder('s')
+            ->andWhere('s.product = :product')
+            ->andWhere('s.company = :company')
+            ->andWhere('s.updatedAt >= :start')
+            ->andWhere('s.updatedAt < :end')
+            ->setParameter('product', $product)
+            ->setParameter('company', $company)
+            ->setParameter('start', $start)
+            ->setParameter('end', $end)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+}

--- a/site/src/Service/Ozon/OzonProductSalesService.php
+++ b/site/src/Service/Ozon/OzonProductSalesService.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Service\Ozon;
+
+use App\Api\Ozon\OzonApiClient;
+use App\Entity\Company;
+use App\Entity\Ozon\OzonProduct;
+use App\Entity\Ozon\OzonProductSales;
+use App\Repository\Ozon\OzonProductRepository;
+use App\Repository\Ozon\OzonProductSalesRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+
+readonly class OzonProductSalesService
+{
+    public function __construct(
+        private OzonApiClient $client,
+        private EntityManagerInterface $em,
+        private OzonProductRepository $productRepository,
+        private OzonProductSalesRepository $salesRepository,
+    ) {}
+
+    public function createSalesReport(Company $company, \DateTimeImmutable $from, \DateTimeImmutable $to): string
+    {
+        return $this->client->createSalesReport(
+            $company->getOzonSellerId(),
+            $company->getOzonApiKey(),
+            $from,
+            $to
+        );
+    }
+
+    public function downloadAndParseReport(Company $company, string $taskId): array
+    {
+        $csv = $this->client->downloadSalesReport(
+            $company->getOzonSellerId(),
+            $company->getOzonApiKey(),
+            $taskId
+        );
+
+        if (!$csv) {
+            return [];
+        }
+
+        $lines = preg_split('/\r?\n/', trim($csv));
+        $rows = [];
+        foreach ($lines as $line) {
+            if ($line === '') {
+                continue;
+            }
+            $rows[] = str_getcsv($line, ';');
+        }
+
+        return $rows;
+    }
+
+    public function saveSales(Company $company, array $rows, \DateTimeImmutable $from, \DateTimeImmutable $to): void
+    {
+        foreach ($rows as $row) {
+            $offerId = $row[0] ?? null;
+            $qty = isset($row[1]) ? (int)$row[1] : 0;
+
+            if (!$offerId) {
+                continue;
+            }
+
+            $product = $this->productRepository->findOneBy([
+                'manufacturerSku' => $offerId,
+                'company' => $company,
+            ]);
+
+            if (!$product instanceof OzonProduct) {
+                continue;
+            }
+
+            $sale = $this->salesRepository->findOneByPeriod($product, $company, $from, $to);
+            if (!$sale) {
+                $sale = new OzonProductSales(Uuid::uuid4()->toString(), $product, $company, $from, $to);
+                $this->em->persist($sale);
+            }
+
+            $sale->setQty($qty);
+        }
+
+        $this->em->flush();
+    }
+}

--- a/site/src/Service/Ozon/OzonProductStockService.php
+++ b/site/src/Service/Ozon/OzonProductStockService.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Service\Ozon;
+
+use App\Api\Ozon\OzonApiClient;
+use App\Entity\Company;
+use App\Entity\Ozon\OzonProduct;
+use App\Entity\Ozon\OzonProductStock;
+use App\Repository\Ozon\OzonProductRepository;
+use App\Repository\Ozon\OzonProductStockRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+
+readonly class OzonProductStockService
+{
+    public function __construct(
+        private OzonApiClient $client,
+        private EntityManagerInterface $em,
+        private OzonProductRepository $productRepository,
+        private OzonProductStockRepository $stockRepository,
+    ) {}
+
+    public function updateStocks(Company $company): void
+    {
+        $stocks = $this->client->getStocks(
+            $company->getOzonSellerId(),
+            $company->getOzonApiKey()
+        );
+
+        foreach ($stocks as $item) {
+            $offerId = $item['offer_id'] ?? null;
+            if (!$offerId) {
+                continue;
+            }
+            $product = $this->productRepository->findOneBy([
+                'manufacturerSku' => $offerId,
+                'company' => $company,
+            ]);
+
+            if (!$product instanceof OzonProduct) {
+                continue;
+            }
+
+            $today = new \DateTimeImmutable('today');
+            $stock = $this->stockRepository->findOneForDate($product, $company, $today);
+
+            if (!$stock) {
+                $stock = new OzonProductStock(Uuid::uuid4()->toString(), $product, $company);
+                $this->em->persist($stock);
+            }
+
+            $stock->setQty((int)($item['stock'] ?? 0));
+            $stock->setUpdatedAt(new \DateTimeImmutable());
+        }
+
+        $this->em->flush();
+    }
+}


### PR DESCRIPTION
## Summary
- add entities `OzonProductStock` and `OzonProductSales`
- create repositories for stock and sales entities
- implement `OzonProductStockService` and `OzonProductSalesService`
- extend `OzonApiClient` with methods for stocks and sales reports
- add migration for new tables

## Testing
- `php -l src/Service/Ozon/OzonProductStockService.php`
- `php -l src/Service/Ozon/OzonProductSalesService.php`
- `php -l src/Api/Ozon/OzonApiClient.php`
- `php -l src/Repository/Ozon/OzonProductStockRepository.php`
- `php -l src/Repository/Ozon/OzonProductSalesRepository.php`
- `php -l src/Entity/Ozon/OzonProductStock.php`
- `php -l src/Entity/Ozon/OzonProductSales.php`
- `php -l migrations/Version20250727000000.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6885f8b732208323a6c7b1d7fc082a61