### PR TITLE
Implement stock and sales update actions

### DIFF
--- a/site/templates/ozon/products.html.twig
+++ b/site/templates/ozon/products.html.twig
@@ -3,6 +3,8 @@
 {% block body %}
     <h1>Ozon Товары</h1>
     <a href="{{ path('ozon_products_sync') }}" class="btn btn-primary mb-2">Обновить</a>
+    <a href="{{ path('ozon_products_update_stocks') }}" class="btn btn-primary mb-2">Остатки</a>
+    <a href="{{ path('ozon_products_update_sales') }}" class="btn btn-primary mb-2">Продажи (30 дней)</a>
     <form action="{{ path('ozon_products_clear') }}" method="post" style="display:inline;" onsubmit="return confirm('Точно удалить все товары?');">
         <button type="submit" class="btn btn-danger mb-2">Очистить всё</button>
     </form>


### PR DESCRIPTION
## Summary
- add dependencies for updating Ozon product stocks and sales
- implement controller routes to update stocks and sales
- add buttons to products view to trigger updates

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*
- `./vendor/bin/phpunit --testdox` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688603ab78a48323a36dfb9960e43f8c