### PR TITLE
feat: add active company selection

### DIFF
--- a/site/src/Controller/CompanyController.php
+++ b/site/src/Controller/CompanyController.php
@@ -25,6 +25,21 @@ class CompanyController extends AbstractController
         ]);
     }
 
+    #[Route('/active', name: 'company_set_active', methods: ['POST'])]
+    public function setActive(Request $request, CompanyRepository $companyRepository): Response
+    {
+        $id = $request->request->get('company_id');
+        $company = $companyRepository->find($id);
+
+        if (!$company || $company->getUser() !== $this->getUser()) {
+            throw $this->createNotFoundException();
+        }
+
+        $request->getSession()->set('active_company_id', $company->getId());
+
+        return $this->redirect($request->headers->get('referer') ?: $this->generateUrl('app_home_index'));
+    }
+
     #[Route('/new', name: 'company_new', methods: ['GET', 'POST'])]
     public function new(Request $request, EntityManagerInterface $em): Response
     {

--- a/site/templates/base.html.twig
+++ b/site/templates/base.html.twig
@@ -16,7 +16,7 @@
 <header class="navbar-expand-md">
     <div class="collapse navbar-collapse" id="navbar-menu">
         <div class="navbar navbar-light">
-            <div class="container-xl">
+            <div class="container-xl d-flex justify-content-between">
                 <ul class="navbar-nav">
                     <li class="nav-item">
                         <a class="nav-link" href="{{ path('app_home_index') }}" >
@@ -57,6 +57,15 @@
                         </a>
                     </li>
                 </ul>
+                {% if app.user and app.user.companies|length > 0 %}
+                    <form method="post" action="{{ path('company_set_active') }}">
+                        <select name="company_id" class="form-select" onchange="this.form.submit()">
+                            {% for company in app.user.companies %}
+                                <option value="{{ company.id }}" {% if app.session.get('active_company_id') == company.id %}selected{% endif %}>{{ company.name }}</option>
+                            {% endfor %}
+                        </select>
+                    </form>
+                {% endif %}
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- allow selecting active company saved in session
- add company dropdown to header for quick switching

## Testing
- `php bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script)*


------
https://chatgpt.com/codex/tasks/task_e_68b5c246aa448323aa5b1c28a5721c6d