### PR TITLE
Add cash flow category service refactor

### DIFF
--- a/site/migrations/Version20250901160000.php
+++ b/site/migrations/Version20250901160000.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250901160000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create cashflow categories table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE "cashflow_categories" (id UUID NOT NULL, parent_id UUID DEFAULT NULL, company_id UUID NOT NULL, name VARCHAR(255) NOT NULL, description TEXT DEFAULT NULL, status VARCHAR(255) NOT NULL, sort INT NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_CFC_PARENT ON "cashflow_categories" (parent_id)');
+        $this->addSql('CREATE INDEX IDX_CFC_COMPANY ON "cashflow_categories" (company_id)');
+        $this->addSql('ALTER TABLE "cashflow_categories" ADD CONSTRAINT FK_CFC_PARENT FOREIGN KEY (parent_id) REFERENCES "cashflow_categories" (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE "cashflow_categories" ADD CONSTRAINT FK_CFC_COMPANY FOREIGN KEY (company_id) REFERENCES "companies" (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('ALTER TABLE "cashflow_categories" DROP CONSTRAINT FK_CFC_PARENT');
+        $this->addSql('ALTER TABLE "cashflow_categories" DROP CONSTRAINT FK_CFC_COMPANY');
+        $this->addSql('DROP TABLE "cashflow_categories"');
+    }
+}

--- a/site/src/Controller/CashflowCategoryController.php
+++ b/site/src/Controller/CashflowCategoryController.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\CashflowCategory;
+use App\Form\CashflowCategoryType;
+use App\Repository\CashflowCategoryRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+use App\Service\ActiveCompanyService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/cashflow-categories')]
+class CashflowCategoryController extends AbstractController
+{
+    #[Route('/', name: 'cashflow_category_index', methods: ['GET'])]
+    public function index(
+        CashflowCategoryRepository $repo,
+        ActiveCompanyService $companyService
+    ): Response {
+        $company = $companyService->getActiveCompany();
+        $items = $repo->findRootByCompany($company);
+        return $this->render('cashflow_category/index.html.twig', [
+            'items' => $items,
+        ]);
+    }
+
+    #[Route('/new', name: 'cashflow_category_new', methods: ['GET', 'POST'])]
+    public function new(
+        Request $request,
+        CashflowCategoryRepository $repo,
+        EntityManagerInterface $em,
+        ActiveCompanyService $companyService
+    ): Response {
+        $company = $companyService->getActiveCompany();
+        $article = new CashflowCategory(Uuid::uuid4()->toString(), $company);
+
+        $parents = $repo->findBy(['company' => $company], ['sort' => 'ASC']);
+
+        $form = $this->createForm(CashflowCategoryType::class, $article, ['parents' => $parents]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            if ($article->getParent() && $article->getParent()->getLevel() >= 5) {
+                $this->addFlash('danger', 'Максимальная вложенность — 5 уровней');
+            } else {
+                $em->persist($article);
+                $em->flush();
+                return $this->redirectToRoute('cashflow_category_index');
+            }
+        }
+
+        return $this->render('cashflow_category/new.html.twig', [
+            'form' => $form->createView(),
+        ]);
+    }
+
+    #[Route('/{id}/edit', name: 'cashflow_category_edit', methods: ['GET', 'POST'])]
+    public function edit(
+        Request $request,
+        CashflowCategory $article,
+        CashflowCategoryRepository $repo,
+        EntityManagerInterface $em,
+        ActiveCompanyService $companyService
+    ): Response {
+        $company = $companyService->getActiveCompany();
+        if ($article->getCompany() !== $company) {
+            throw $this->createNotFoundException();
+        }
+
+        $parents = $repo->findBy(['company' => $company], ['sort' => 'ASC']);
+
+        $form = $this->createForm(CashflowCategoryType::class, $article, ['parents' => $parents]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            if ($article->getParent() && $article->getParent()->getLevel() >= 5) {
+                $this->addFlash('danger', 'Максимальная вложенность — 5 уровней');
+            } else {
+                $em->flush();
+                return $this->redirectToRoute('cashflow_category_index');
+            }
+        }
+
+        return $this->render('cashflow_category/edit.html.twig', [
+            'form' => $form->createView(),
+            'article' => $article,
+        ]);
+    }
+
+    #[Route('/{id}/delete', name: 'cashflow_category_delete', methods: ['POST'])]
+    public function delete(
+        Request $request,
+        CashflowCategory $article,
+        EntityManagerInterface $em,
+        ActiveCompanyService $companyService
+    ): Response {
+        $company = $companyService->getActiveCompany();
+        if ($article->getCompany() !== $company) {
+            throw $this->createNotFoundException();
+        }
+
+        if ($this->isCsrfTokenValid('delete'.$article->getId(), $request->request->get('_token'))) {
+            $em->remove($article);
+            $em->flush();
+        }
+
+        return $this->redirectToRoute('cashflow_category_index');
+    }
+}

--- a/site/src/Entity/CashflowCategory.php
+++ b/site/src/Entity/CashflowCategory.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Entity;
+
+use App\Enum\CashflowCategoryStatus;
+use App\Repository\CashflowCategoryRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity(repositoryClass: CashflowCategoryRepository::class)]
+#[ORM\Table(name: '`cashflow_categories`')]
+class CashflowCategory
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid', unique: true)]
+    private ?string $id = null;
+
+    #[ORM\Column(length: 255)]
+    private string $name;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $description = null;
+
+    #[ORM\Column(enumType: CashflowCategoryStatus::class)]
+    private CashflowCategoryStatus $status;
+
+    #[ORM\Column(type: 'integer')]
+    private int $sort = 0;
+
+    #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
+    private ?self $parent = null;
+
+    #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent', orphanRemoval: true)]
+    #[ORM\OrderBy(['sort' => 'ASC'])]
+    private Collection $children;
+
+    #[ORM\ManyToOne(targetEntity: Company::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private Company $company;
+
+    public function __construct(string $id, Company $company)
+    {
+        Assert::uuid($id);
+        $this->id = $id;
+        $this->company = $company;
+        $this->status = CashflowCategoryStatus::ACTIVE;
+        $this->children = new ArrayCollection();
+    }
+
+    public function getId(): ?string { return $this->id; }
+    public function getName(): string { return $this->name; }
+    public function setName(string $name): self { $this->name = $name; return $this; }
+    public function getDescription(): ?string { return $this->description; }
+    public function setDescription(?string $description): self { $this->description = $description; return $this; }
+    public function getStatus(): CashflowCategoryStatus { return $this->status; }
+    public function setStatus(CashflowCategoryStatus $status): self { $this->status = $status; return $this; }
+    public function getSort(): int { return $this->sort; }
+    public function setSort(int $sort): self { $this->sort = $sort; return $this; }
+    public function getParent(): ?self { return $this->parent; }
+    public function setParent(?self $parent): self { $this->parent = $parent; return $this; }
+    public function getChildren(): Collection { return $this->children; }
+    public function getCompany(): Company { return $this->company; }
+    public function setCompany(Company $company): self { $this->company = $company; return $this; }
+
+    public function getLevel(): int
+    {
+        return $this->parent ? $this->parent->getLevel() + 1 : 1;
+    }
+}

--- a/site/src/Enum/CashflowCategoryStatus.php
+++ b/site/src/Enum/CashflowCategoryStatus.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enum;
+
+enum CashflowCategoryStatus: string
+{
+    case ACTIVE = 'active';
+    case DISABLED = 'disabled';
+}

--- a/site/src/Form/CashflowCategoryType.php
+++ b/site/src/Form/CashflowCategoryType.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\CashflowCategory;
+use App\Enum\CashflowCategoryStatus;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EnumType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class CashflowCategoryType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('name', TextType::class, [
+                'label' => 'Наименование',
+            ])
+            ->add('description', TextareaType::class, [
+                'label' => 'Описание',
+                'required' => false,
+            ])
+            ->add('status', EnumType::class, [
+                'class' => CashflowCategoryStatus::class,
+                'label' => 'Статус',
+            ])
+            ->add('sort', IntegerType::class, [
+                'label' => 'Сортировка',
+            ])
+            ->add('parent', EntityType::class, [
+                'class' => CashflowCategory::class,
+                'choices' => $options['parents'],
+                'choice_label' => function (CashflowCategory $item) {
+                    return str_repeat('—', $item->getLevel() - 1) . ' ' . $item->getName();
+                },
+                'required' => false,
+                'label' => 'Родитель',
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => CashflowCategory::class,
+            'parents' => [],
+        ]);
+    }
+}

--- a/site/src/Repository/CashflowCategoryRepository.php
+++ b/site/src/Repository/CashflowCategoryRepository.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\CashflowCategory;
+use App\Entity\Company;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<CashflowCategory>
+ */
+class CashflowCategoryRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, CashflowCategory::class);
+    }
+
+    /**
+     * @return CashflowCategory[]
+     */
+    public function findRootByCompany(Company $company): array
+    {
+        return $this->createQueryBuilder('c')
+            ->andWhere('c.company = :company')
+            ->andWhere('c.parent IS NULL')
+            ->setParameter('company', $company)
+            ->orderBy('c.sort', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/site/src/Service/ActiveCompanyService.php
+++ b/site/src/Service/ActiveCompanyService.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Company;
+use App\Repository\CompanyRepository;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\Security;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class ActiveCompanyService
+{
+    public function __construct(
+        private RequestStack $requestStack,
+        private CompanyRepository $companyRepository,
+        private Security $security
+    ) {
+    }
+
+    public function getActiveCompany(): Company
+    {
+        $id = $this->requestStack->getSession()->get('active_company_id');
+        $company = $this->companyRepository->find($id);
+        $user = $this->security->getUser();
+        if (!$company || $company->getUser() !== $user) {
+            throw new NotFoundHttpException();
+        }
+        return $company;
+    }
+}

--- a/site/templates/base.html.twig
+++ b/site/templates/base.html.twig
@@ -56,6 +56,11 @@
                             <span class="nav-link-title">Компании</span>
                         </a>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ path('cashflow_category_index') }}">
+                            <span class="nav-link-title">ДДС</span>
+                        </a>
+                    </li>
                 </ul>
                 {% if app.user and app.user.companies|length > 0 %}
                     <form method="post" action="{{ path('company_set_active') }}">

--- a/site/templates/cashflow_category/edit.html.twig
+++ b/site/templates/cashflow_category/edit.html.twig
@@ -1,0 +1,19 @@
+{% extends 'base.html.twig' %}
+{% block title %}Редактирование статьи ДДС{% endblock %}
+{% block body %}
+    <div class="page-header d-print-none">
+        <div class="container-xl">
+            <h2 class="page-title">Редактирование {{ article.name }}</h2>
+        </div>
+    </div>
+    <div class="container-xl mt-3">
+        <div class="card">
+            <div class="card-body">
+                {{ form_start(form) }}
+                {{ form_widget(form) }}
+                <button class="btn btn-primary mt-2">Сохранить</button>
+                {{ form_end(form) }}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/site/templates/cashflow_category/index.html.twig
+++ b/site/templates/cashflow_category/index.html.twig
@@ -1,0 +1,48 @@
+{% extends 'base.html.twig' %}
+{% block title %}Статьи ДДС{% endblock %}
+
+{% macro render_items(items, level) %}
+    <ul class="list-unstyled">
+    {% for item in items %}
+        <li>
+            <div style="margin-left: {{ (level - 1) * 20 }}px;">
+                {{ item.name }}
+                <span class="float-end">
+                    <a href="{{ path('cashflow_category_edit', {'id': item.id}) }}" class="btn btn-sm btn-warning">✏️</a>
+                    <form method="post" action="{{ path('cashflow_category_delete', {'id': item.id}) }}" style="display:inline;" onsubmit="return confirm('Вы уверены?');">
+                        <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ item.id) }}">
+                        <button class="btn btn-sm btn-danger">🗑</button>
+                    </form>
+                </span>
+            </div>
+            {% if item.children|length > 0 %}
+                {{ _self.render_items(item.children, level + 1) }}
+            {% endif %}
+        </li>
+    {% endfor %}
+    </ul>
+{% endmacro %}
+
+{% import _self as macros %}
+
+{% block body %}
+    <div class="page-header d-print-none">
+        <div class="container-xl">
+            <div class="row g-2 align-items-center">
+                <div class="col">
+                    <h2 class="page-title">Статьи ДДС</h2>
+                </div>
+                <div class="col-auto ms-auto d-print-none">
+                    <a href="{{ path('cashflow_category_new') }}" class="btn btn-primary">+ Добавить статью</a>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="container-xl mt-3">
+        <div class="card">
+            <div class="card-body">
+                {{ macros.render_items(items, 1) }}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/site/templates/cashflow_category/new.html.twig
+++ b/site/templates/cashflow_category/new.html.twig
@@ -1,0 +1,19 @@
+{% extends 'base.html.twig' %}
+{% block title %}Новая статья ДДС{% endblock %}
+{% block body %}
+    <div class="page-header d-print-none">
+        <div class="container-xl">
+            <h2 class="page-title">Новая статья ДДС</h2>
+        </div>
+    </div>
+    <div class="container-xl mt-3">
+        <div class="card">
+            <div class="card-body">
+                {{ form_start(form) }}
+                {{ form_widget(form) }}
+                <button class="btn btn-primary mt-2">Сохранить</button>
+                {{ form_end(form) }}
+            </div>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- rename CashFlowArticle to CashflowCategory and adjust related classes, routes and templates
- extract ActiveCompanyService to provide reusable active company lookup
- update navigation to point at cashflow categories

## Testing
- `composer install --no-interaction --prefer-dist` *(fails: CONNECT tunnel failed, response 403)*
- `php bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c590b378832394c40784ef267789