### PR TITLE
fix: update security namespace

### DIFF
--- a/site/src/Service/ActiveCompanyService.php
+++ b/site/src/Service/ActiveCompanyService.php
@@ -5,7 +5,7 @@ namespace App\Service;
 use App\Entity\Company;
 use App\Repository\CompanyRepository;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class ActiveCompanyService


### PR DESCRIPTION
## Summary
- use bundle Security service for ActiveCompanyService

## Testing
- `composer install` *(fails: requires GitHub token)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cb1fff40832392e3c85426e1770d