### PR TITLE
Fix active company lookup when session id missing

### DIFF
--- a/site/src/Service/ActiveCompanyService.php
+++ b/site/src/Service/ActiveCompanyService.php
@@ -19,12 +19,24 @@ class ActiveCompanyService
 
     public function getActiveCompany(): Company
     {
-        $id = $this->requestStack->getSession()->get('active_company_id');
-        $company = $this->companyRepository->find($id);
+        $session = $this->requestStack->getSession();
+        $id = $session->get('active_company_id');
         $user = $this->security->getUser();
-        if (!$company || $company->getUser() !== $user) {
+
+        if ($id) {
+            $company = $this->companyRepository->find($id);
+            if ($company && $company->getUser() === $user) {
+                return $company;
+            }
+        }
+
+        $company = $this->companyRepository->findOneBy(['user' => $user]);
+        if (!$company) {
             throw new NotFoundHttpException();
         }
+
+        $session->set('active_company_id', $company->getId());
+
         return $company;
     }
 }


### PR DESCRIPTION
## Summary
- handle missing active company id in `ActiveCompanyService` by falling back to user's first company and storing its id in session

## Testing
- `composer install --no-interaction --no-ansi` *(fails: curl error 56 while downloading packages: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `php -l src/Service/ActiveCompanyService.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5d01f00f083238434fa77ce8021ec