### PR TITLE
Align cashflow category button block to the right edge

### DIFF
--- a/site/templates/cashflow_category/index.html.twig
+++ b/site/templates/cashflow_category/index.html.twig
@@ -5,9 +5,9 @@
     <ul class="list-unstyled">
     {% for item in items %}
         <li>
-            <div style="margin-left: {{ (level - 1) * 20 }}px;">
-                {{ item.name }}
-                <span class="float-end">
+            <div>
+                <span style="margin-left: {{ (level - 1) * 20 }}px;">{{ item.name }}</span>
+                <span class="float-end m-0 p-0">
                     <a href="{{ path('cashflow_category_edit', {'id': item.id}) }}" class="btn btn-sm btn-warning">✏️</a>
                     <form method="post" action="{{ path('cashflow_category_delete', {'id': item.id}) }}" style="display:inline;" onsubmit="return confirm('Вы уверены?');">
                         <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ item.id) }}">


### PR DESCRIPTION
## Summary
- Ensure cashflow category action buttons align flush to the right with no extra spacing

## Testing
- `php -d memory_limit=1G bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`)*
- `composer install` *(fails: GitHub authentication required, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d38027348323ad70187073ed1e80