### PR TITLE
feat: add cash transaction and balance skeleton

### DIFF
--- a/site/migrations/Version20250904120101.php
+++ b/site/migrations/Version20250904120101.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250904120101 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'CashTransaction and MoneyAccountDailyBalance tables';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE cash_transaction (id UUID NOT NULL, company_id UUID NOT NULL, money_account_id UUID NOT NULL, counterparty_id UUID DEFAULT NULL, cashflow_category_id UUID DEFAULT NULL, direction VARCHAR(255) NOT NULL, amount NUMERIC(18, 2) NOT NULL, currency VARCHAR(3) NOT NULL, occurred_at DATE NOT NULL, booked_at DATE NOT NULL, description VARCHAR(1024) DEFAULT NULL, external_id VARCHAR(255) DEFAULT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX idx_company_account_occurred ON cash_transaction (company_id, money_account_id, occurred_at)');
+        $this->addSql('CREATE INDEX idx_company_occurred ON cash_transaction (company_id, occurred_at)');
+        $this->addSql('CREATE TABLE money_account_daily_balance (id UUID NOT NULL, company_id UUID NOT NULL, money_account_id UUID NOT NULL, date DATE NOT NULL, opening_balance NUMERIC(18, 2) NOT NULL, inflow NUMERIC(18, 2) NOT NULL, outflow NUMERIC(18, 2) NOT NULL, closing_balance NUMERIC(18, 2) NOT NULL, currency VARCHAR(3) NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE UNIQUE INDEX uniq_company_account_date ON money_account_daily_balance (company_id, money_account_id, date)');
+        $this->addSql('CREATE INDEX idx_company_date ON money_account_daily_balance (company_id, date)');
+        $this->addSql('CREATE INDEX idx_account_date ON money_account_daily_balance (money_account_id, date)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE cash_transaction');
+        $this->addSql('DROP TABLE money_account_daily_balance');
+    }
+}

--- a/site/src/DTO/CashTransactionDTO.php
+++ b/site/src/DTO/CashTransactionDTO.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\DTO;
+
+use App\Enum\CashDirection;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class CashTransactionDTO
+{
+    #[Assert\NotNull]
+    public string $companyId;
+
+    #[Assert\NotNull]
+    public string $moneyAccountId;
+
+    public ?string $counterpartyId = null;
+    public ?string $cashflowCategoryId = null;
+
+    #[Assert\Choice(callback: [CashDirection::class, 'cases'])]
+    public CashDirection $direction;
+
+    #[Assert\Positive]
+    public string $amount;
+
+    #[Assert\Length(3)]
+    public string $currency;
+
+    #[Assert\NotNull]
+    public \DateTimeImmutable $occurredAt;
+
+    public ?\DateTimeImmutable $bookedAt = null;
+
+    public ?string $description = null;
+    public ?string $externalId = null;
+
+    public function __construct()
+    {
+    }
+}

--- a/site/src/DTO/DailyBalancesDTO.php
+++ b/site/src/DTO/DailyBalancesDTO.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\DTO;
+
+class DailyBalancesDTO
+{
+    /** @var list<MoneyBalanceDTO> */
+    public array $balances;
+    public string $totalOpening;
+    public string $totalInflow;
+    public string $totalOutflow;
+    public string $totalClosing;
+    public string $currency;
+
+    /**
+     * @param list<MoneyBalanceDTO> $balances
+     */
+    public function __construct(array $balances, string $currency)
+    {
+        $this->balances = $balances;
+        $this->currency = $currency;
+        $this->totalOpening = $balances[0]->opening ?? '0';
+        $this->totalClosing = $balances[count($balances)-1]->closing ?? '0';
+        $this->totalInflow = '0';
+        $this->totalOutflow = '0';
+        foreach ($balances as $b) {
+            $this->totalInflow = bcadd($this->totalInflow, $b->inflow, 2);
+            $this->totalOutflow = bcadd($this->totalOutflow, $b->outflow, 2);
+        }
+    }
+}

--- a/site/src/DTO/MoneyBalanceDTO.php
+++ b/site/src/DTO/MoneyBalanceDTO.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\DTO;
+
+class MoneyBalanceDTO
+{
+    public \DateTimeImmutable $date;
+    public string $opening;
+    public string $inflow;
+    public string $outflow;
+    public string $closing;
+    public string $currency;
+
+    public function __construct(\DateTimeImmutable $date, string $opening, string $inflow, string $outflow, string $closing, string $currency)
+    {
+        $this->date = $date;
+        $this->opening = $opening;
+        $this->inflow = $inflow;
+        $this->outflow = $outflow;
+        $this->closing = $closing;
+        $this->currency = $currency;
+    }
+}

--- a/site/src/Entity/CashTransaction.php
+++ b/site/src/Entity/CashTransaction.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Entity;
+
+use App\Enum\CashDirection;
+use Doctrine\ORM\Mapping as ORM;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity(repositoryClass: \App\Repository\CashTransactionRepository::class)]
+#[ORM\Table(name: 'cash_transaction')]
+#[ORM\Index(name: 'idx_company_account_occurred', columns: ['company_id', 'money_account_id', 'occurred_at'])]
+#[ORM\Index(name: 'idx_company_occurred', columns: ['company_id', 'occurred_at'])]
+class CashTransaction
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid', unique: true)]
+    private ?string $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Company::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'RESTRICT')]
+    private Company $company;
+
+    #[ORM\ManyToOne(targetEntity: MoneyAccount::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'RESTRICT')]
+    private MoneyAccount $moneyAccount;
+
+    #[ORM\ManyToOne(targetEntity: Counterparty::class)]
+    private ?Counterparty $counterparty = null;
+
+    #[ORM\ManyToOne(targetEntity: CashflowCategory::class)]
+    private ?CashflowCategory $cashflowCategory = null;
+
+    #[ORM\Column(enumType: CashDirection::class)]
+    private CashDirection $direction;
+
+    #[ORM\Column(type: 'decimal', precision: 18, scale: 2)]
+    private string $amount;
+
+    #[ORM\Column(length: 3)]
+    private string $currency;
+
+    #[ORM\Column(type: 'date_immutable')]
+    private \DateTimeImmutable $occurredAt;
+
+    #[ORM\Column(type: 'date_immutable')]
+    private \DateTimeImmutable $bookedAt;
+
+    #[ORM\Column(type: 'string', length: 1024, nullable: true)]
+    private ?string $description = null;
+
+    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    private ?string $externalId = null;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: 'datetime')]
+    private \DateTimeInterface $updatedAt;
+
+    public function __construct(string $id, Company $company, MoneyAccount $account, CashDirection $direction, string $amount, string $currency, \DateTimeImmutable $occurredAt)
+    {
+        Assert::uuid($id);
+        $this->id = $id;
+        $this->company = $company;
+        $this->moneyAccount = $account;
+        $this->direction = $direction;
+        $this->amount = $amount;
+        $this->currency = strtoupper($currency);
+        $this->occurredAt = $occurredAt;
+        $this->bookedAt = $occurredAt;
+        $this->createdAt = new \DateTimeImmutable();
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?string { return $this->id; }
+    public function getCompany(): Company { return $this->company; }
+    public function getMoneyAccount(): MoneyAccount { return $this->moneyAccount; }
+    public function getCounterparty(): ?Counterparty { return $this->counterparty; }
+    public function setCounterparty(?Counterparty $c): self { $this->counterparty = $c; return $this; }
+    public function getCashflowCategory(): ?CashflowCategory { return $this->cashflowCategory; }
+    public function setCashflowCategory(?CashflowCategory $c): self { $this->cashflowCategory = $c; return $this; }
+    public function getDirection(): CashDirection { return $this->direction; }
+    public function setDirection(CashDirection $d): self { $this->direction = $d; return $this; }
+    public function getAmount(): string { return $this->amount; }
+    public function setAmount(string $a): self { $this->amount = $a; return $this; }
+    public function getCurrency(): string { return $this->currency; }
+    public function setCurrency(string $c): self { $this->currency = strtoupper($c); return $this; }
+    public function getOccurredAt(): \DateTimeImmutable { return $this->occurredAt; }
+    public function setOccurredAt(\DateTimeImmutable $o): self { $this->occurredAt = $o; return $this; }
+    public function getBookedAt(): \DateTimeImmutable { return $this->bookedAt; }
+    public function setBookedAt(\DateTimeImmutable $b): self { $this->bookedAt = $b; return $this; }
+    public function getDescription(): ?string { return $this->description; }
+    public function setDescription(?string $d): self { $this->description = $d; return $this; }
+    public function getExternalId(): ?string { return $this->externalId; }
+    public function setExternalId(?string $e): self { $this->externalId = $e; return $this; }
+    public function getCreatedAt(): \DateTimeImmutable { return $this->createdAt; }
+    public function getUpdatedAt(): \DateTimeInterface { return $this->updatedAt; }
+    public function setUpdatedAt(\DateTimeInterface $u): self { $this->updatedAt = $u; return $this; }
+}

--- a/site/src/Entity/MoneyAccountDailyBalance.php
+++ b/site/src/Entity/MoneyAccountDailyBalance.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity(repositoryClass: \App\Repository\MoneyAccountDailyBalanceRepository::class)]
+#[ORM\Table(name: 'money_account_daily_balance')]
+#[ORM\UniqueConstraint(name: 'uniq_company_account_date', columns: ['company_id','money_account_id','date'])]
+#[ORM\Index(name: 'idx_company_date', columns: ['company_id','date'])]
+#[ORM\Index(name: 'idx_account_date', columns: ['money_account_id','date'])]
+class MoneyAccountDailyBalance
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid', unique: true)]
+    private ?string $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Company::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'RESTRICT')]
+    private Company $company;
+
+    #[ORM\ManyToOne(targetEntity: MoneyAccount::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'RESTRICT')]
+    private MoneyAccount $moneyAccount;
+
+    #[ORM\Column(type: 'date_immutable')]
+    private \DateTimeImmutable $date;
+
+    #[ORM\Column(type: 'decimal', precision: 18, scale: 2)]
+    private string $openingBalance;
+
+    #[ORM\Column(type: 'decimal', precision: 18, scale: 2)]
+    private string $inflow;
+
+    #[ORM\Column(type: 'decimal', precision: 18, scale: 2)]
+    private string $outflow;
+
+    #[ORM\Column(type: 'decimal', precision: 18, scale: 2)]
+    private string $closingBalance;
+
+    #[ORM\Column(length: 3)]
+    private string $currency;
+
+    public function __construct(string $id, Company $company, MoneyAccount $account, \DateTimeImmutable $date, string $opening, string $inflow, string $outflow, string $closing, string $currency)
+    {
+        Assert::uuid($id);
+        $this->id = $id;
+        $this->company = $company;
+        $this->moneyAccount = $account;
+        $this->date = $date;
+        $this->openingBalance = $opening;
+        $this->inflow = $inflow;
+        $this->outflow = $outflow;
+        $this->closingBalance = $closing;
+        $this->currency = strtoupper($currency);
+    }
+
+    public function getDate(): \DateTimeImmutable { return $this->date; }
+    public function getOpeningBalance(): string { return $this->openingBalance; }
+    public function getInflow(): string { return $this->inflow; }
+    public function getOutflow(): string { return $this->outflow; }
+    public function getClosingBalance(): string { return $this->closingBalance; }
+    public function setOpeningBalance(string $o): self { $this->openingBalance = $o; return $this; }
+    public function setInflow(string $i): self { $this->inflow = $i; return $this; }
+    public function setOutflow(string $o): self { $this->outflow = $o; return $this; }
+    public function setClosingBalance(string $c): self { $this->closingBalance = $c; return $this; }
+}

--- a/site/src/Enum/CashDirection.php
+++ b/site/src/Enum/CashDirection.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enum;
+
+enum CashDirection: string
+{
+    case INFLOW = 'INFLOW';
+    case OUTFLOW = 'OUTFLOW';
+}

--- a/site/src/Exception/CurrencyMismatchException.php
+++ b/site/src/Exception/CurrencyMismatchException.php
@@ -1,0 +1,4 @@
+<?php
+namespace App\Exception;
+
+class CurrencyMismatchException extends \DomainException {}

--- a/site/src/Exception/ForbiddenCompanyAccessException.php
+++ b/site/src/Exception/ForbiddenCompanyAccessException.php
@@ -1,0 +1,4 @@
+<?php
+namespace App\Exception;
+
+class ForbiddenCompanyAccessException extends \RuntimeException {}

--- a/site/src/Exception/NegativeAmountException.php
+++ b/site/src/Exception/NegativeAmountException.php
@@ -1,0 +1,4 @@
+<?php
+namespace App\Exception;
+
+class NegativeAmountException extends \DomainException {}

--- a/site/src/Exception/SnapshotIntegrityException.php
+++ b/site/src/Exception/SnapshotIntegrityException.php
@@ -1,0 +1,4 @@
+<?php
+namespace App\Exception;
+
+class SnapshotIntegrityException extends \RuntimeException {}

--- a/site/src/Repository/CashTransactionRepository.php
+++ b/site/src/Repository/CashTransactionRepository.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\CashTransaction;
+use App\Entity\Company;
+use App\Entity\MoneyAccount;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class CashTransactionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, CashTransaction::class);
+    }
+
+    /**
+     * @return list<array{date:string,inflow:string,outflow:string}>
+     */
+    public function sumByDay(Company $company, MoneyAccount $account, \DateTimeImmutable $from, \DateTimeImmutable $to): array
+    {
+        $qb = $this->createQueryBuilder('t')
+            ->select("DATE(t.occurredAt) as date",
+                "SUM(CASE WHEN t.direction = 'INFLOW' THEN t.amount ELSE 0 END) as inflow",
+                "SUM(CASE WHEN t.direction = 'OUTFLOW' THEN t.amount ELSE 0 END) as outflow")
+            ->where('t.company = :company')
+            ->andWhere('t.moneyAccount = :account')
+            ->andWhere('t.occurredAt BETWEEN :from AND :to')
+            ->setParameters([
+                'company' => $company,
+                'account' => $account,
+                'from' => $from->setTime(0,0),
+                'to' => $to->setTime(23,59,59),
+            ])
+            ->groupBy('date')
+            ->orderBy('date', 'ASC');
+        return $qb->getQuery()->getArrayResult();
+    }
+}

--- a/site/src/Repository/MoneyAccountDailyBalanceRepository.php
+++ b/site/src/Repository/MoneyAccountDailyBalanceRepository.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Company;
+use App\Entity\MoneyAccount;
+use App\Entity\MoneyAccountDailyBalance;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\Connection;
+use Doctrine\Persistence\ManagerRegistry;
+
+class MoneyAccountDailyBalanceRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, MoneyAccountDailyBalance::class);
+    }
+
+    public function findLastBefore(Company $company, MoneyAccount $account, \DateTimeImmutable $date): ?MoneyAccountDailyBalance
+    {
+        return $this->createQueryBuilder('b')
+            ->where('b.company = :company')
+            ->andWhere('b.moneyAccount = :account')
+            ->andWhere('b.date < :date')
+            ->setParameters([
+                'company' => $company,
+                'account' => $account,
+                'date' => $date->setTime(0,0)
+            ])
+            ->orderBy('b.date', 'DESC')
+            ->setMaxResults(1)
+            ->getQuery()->getOneOrNullResult();
+    }
+
+    /**
+     * @param iterable<array<string,mixed>> $rows
+     */
+    public function upsertMany(iterable $rows): void
+    {
+        if (empty($rows)) {
+            return;
+        }
+        $conn = $this->getEntityManager()->getConnection();
+        $values = [];
+        $params = [];
+        $i = 0;
+        foreach ($rows as $row) {
+            $values[] = '(:company'.$i.', :account'.$i.', :date'.$i.', :opening'.$i.', :inflow'.$i.', :outflow'.$i.', :closing'.$i.', :currency'.$i.')';
+            $params['company'.$i] = $row['company_id'];
+            $params['account'.$i] = $row['money_account_id'];
+            $params['date'.$i] = $row['date'];
+            $params['opening'.$i] = $row['opening_balance'];
+            $params['inflow'.$i] = $row['inflow'];
+            $params['outflow'.$i] = $row['outflow'];
+            $params['closing'.$i] = $row['closing_balance'];
+            $params['currency'.$i] = $row['currency'];
+            $i++;
+        }
+        $sql = 'INSERT INTO money_account_daily_balance (company_id, money_account_id, date, opening_balance, inflow, outflow, closing_balance, currency) VALUES '
+            . implode(',', $values)
+            . ' ON CONFLICT (company_id, money_account_id, date) DO UPDATE SET opening_balance = excluded.opening_balance, inflow = excluded.inflow, outflow = excluded.outflow, closing_balance = excluded.closing_balance, currency = excluded.currency';
+        $conn->executeStatement($sql, $params);
+    }
+}

--- a/site/src/Service/AccountBalanceService.php
+++ b/site/src/Service/AccountBalanceService.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Service;
+
+use App\DTO\DailyBalancesDTO;
+use App\DTO\MoneyBalanceDTO;
+use App\Entity\Company;
+use App\Entity\MoneyAccount;
+use App\Repository\CashTransactionRepository;
+use App\Repository\MoneyAccountDailyBalanceRepository;
+use Ramsey\Uuid\Uuid;
+
+class AccountBalanceService
+{
+    public function __construct(
+        private CashTransactionRepository $txRepo,
+        private MoneyAccountDailyBalanceRepository $balanceRepo,
+    ) {}
+
+    public function getBalanceOnDate(Company $company, MoneyAccount $account, \DateTimeImmutable $date): MoneyBalanceDTO
+    {
+        $date = $date->setTime(0,0);
+        $snapshot = $this->balanceRepo->findOneBy([
+            'company' => $company,
+            'moneyAccount' => $account,
+            'date' => $date,
+        ]);
+        if (!$snapshot) {
+            $this->recalculateDailyRange($company, $account, $date, $date);
+            $snapshot = $this->balanceRepo->findOneBy([
+                'company' => $company,
+                'moneyAccount' => $account,
+                'date' => $date,
+            ]);
+        }
+        return new MoneyBalanceDTO($snapshot->getDate(), $snapshot->getOpeningBalance(), $snapshot->getInflow(), $snapshot->getOutflow(), $snapshot->getClosingBalance(), $account->getCurrency());
+    }
+
+    /**
+     * @return DailyBalancesDTO
+     */
+    public function getBalancesForPeriod(Company $company, MoneyAccount $account, \DateTimeImmutable $from, \DateTimeImmutable $to): DailyBalancesDTO
+    {
+        $from = $from->setTime(0,0);
+        $to = $to->setTime(0,0);
+        $this->recalculateDailyRange($company, $account, $from, $to);
+        $snapshots = $this->balanceRepo->createQueryBuilder('b')
+            ->where('b.company = :c')->andWhere('b.moneyAccount = :a')
+            ->andWhere('b.date BETWEEN :f AND :t')
+            ->setParameters(['c'=>$company,'a'=>$account,'f'=>$from,'t'=>$to])
+            ->orderBy('b.date','ASC')
+            ->getQuery()->getResult();
+        $balances = [];
+        foreach ($snapshots as $s) {
+            $balances[] = new MoneyBalanceDTO($s->getDate(), $s->getOpeningBalance(), $s->getInflow(), $s->getOutflow(), $s->getClosingBalance(), $account->getCurrency());
+        }
+        return new DailyBalancesDTO($balances, $account->getCurrency());
+    }
+
+    public function recalculateDailyRange(Company $company, MoneyAccount $account, \DateTimeImmutable $from, \DateTimeImmutable $to): void
+    {
+        $from = $from->setTime(0,0);
+        $to = $to->setTime(0,0);
+        $prev = $this->balanceRepo->findLastBefore($company, $account, $from);
+        $opening = $prev ? $prev->getClosingBalance() : $account->getOpeningBalance();
+        $rows = [];
+        $txAgg = $this->txRepo->sumByDay($company, $account, $from, $to);
+        $map = [];
+        foreach ($txAgg as $row) {
+            $map[$row['date']] = $row;
+        }
+        $current = clone $from;
+        while ($current <= $to) {
+            $key = $current->format('Y-m-d');
+            $in = $map[$key]['inflow'] ?? '0';
+            $out = $map[$key]['outflow'] ?? '0';
+            $closing = bcsub(bcadd($opening, $in, 2), $out, 2);
+            $rows[] = [
+                'company_id' => $company->getId(),
+                'money_account_id' => $account->getId(),
+                'date' => $key,
+                'opening_balance' => $opening,
+                'inflow' => $in,
+                'outflow' => $out,
+                'closing_balance' => $closing,
+                'currency' => $account->getCurrency(),
+            ];
+            $opening = $closing;
+            $current = $current->modify('+1 day');
+        }
+        $this->balanceRepo->upsertMany($rows);
+    }
+}

--- a/site/src/Service/CashTransactionService.php
+++ b/site/src/Service/CashTransactionService.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Service;
+
+use App\DTO\CashTransactionDTO;
+use App\Entity\CashTransaction;
+use App\Entity\Company;
+use App\Entity\MoneyAccount;
+use App\Enum\CashDirection;
+use App\Exception\CurrencyMismatchException;
+use App\Repository\CashTransactionRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+
+class CashTransactionService
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private AccountBalanceService $balanceService,
+        private CashTransactionRepository $txRepo
+    ) {}
+
+    public function add(CashTransactionDTO $dto): CashTransaction
+    {
+        $company = $this->em->getReference(Company::class, $dto->companyId);
+        $account = $this->em->getReference(MoneyAccount::class, $dto->moneyAccountId);
+        if ($dto->currency !== $account->getCurrency()) {
+            throw new CurrencyMismatchException();
+        }
+        $tx = new CashTransaction(Uuid::uuid4()->toString(), $company, $account, $dto->direction, $dto->amount, $dto->currency, $dto->occurredAt);
+        $this->em->persist($tx);
+        $from = $dto->occurredAt->setTime(0,0);
+        $to = new \DateTimeImmutable('today');
+        $this->em->flush();
+        $this->balanceService->recalculateDailyRange($company, $account, $from, $to);
+        return $tx;
+    }
+}

--- a/site/tests/Service/AccountBalanceServiceTest.php
+++ b/site/tests/Service/AccountBalanceServiceTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\DTO\CashTransactionDTO;
+use App\Enum\CashDirection;
+use App\Service\AccountBalanceService;
+use App\Service\CashTransactionService;
+use App\Entity\User;
+use App\Entity\Company;
+use App\Entity\MoneyAccount;
+use App\Enum\MoneyAccountType;
+use Doctrine\ORM\Tools\Setup;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+class SimpleManagerRegistry implements ManagerRegistry
+{
+    public function __construct(private EntityManager $em) {}
+    public function getDefaultConnectionName(){return 'default';}
+    public function getConnection($name = null){return $this->em->getConnection();}
+    public function getConnections(){return [$this->em->getConnection()];}
+    public function getConnectionNames(){return ['default'];}
+    public function getDefaultManagerName(){return 'default';}
+    public function getManager($name = null){return $this->em;}
+    public function getManagers(){return ['default' => $this->em];}
+    public function resetManager($name = null){return $this->em;}
+    public function getAliasNamespace($alias){return 'App\\Entity';}
+    public function getManagerNames(){return ['default'];}
+    public function getRepository($persistentObject, $persistentManagerName = null){return $this->em->getRepository($persistentObject);}
+    public function getManagerForClass($class){return $this->em;}
+}
+
+class AccountBalanceServiceTest extends TestCase
+{
+    private EntityManager $em;
+    private AccountBalanceService $balanceService;
+    private CashTransactionService $txService;
+
+    protected function setUp(): void
+    {
+        $config = Setup::createAttributeMetadataConfiguration([__DIR__.'/../../src/Entity'], true);
+        $conn = ['driver' => 'pdo_sqlite', 'memory' => true];
+        $this->em = EntityManager::create($conn, $config);
+        $schemaTool = new SchemaTool($this->em);
+        $classes = [
+            $this->em->getClassMetadata(User::class),
+            $this->em->getClassMetadata(Company::class),
+            $this->em->getClassMetadata(MoneyAccount::class),
+            $this->em->getClassMetadata(\App\Entity\CashTransaction::class),
+            $this->em->getClassMetadata(\App\Entity\MoneyAccountDailyBalance::class),
+        ];
+        $schemaTool->createSchema($classes);
+        $registry = new SimpleManagerRegistry($this->em);
+        $txRepo = new \App\Repository\CashTransactionRepository($registry);
+        $balanceRepo = new \App\Repository\MoneyAccountDailyBalanceRepository($registry);
+        $this->balanceService = new AccountBalanceService($txRepo, $balanceRepo);
+        $this->txService = new CashTransactionService($this->em, $this->balanceService, $txRepo);
+    }
+
+    public function testRecalculateBalances(): void
+    {
+        $user = new User(Uuid::uuid4()->toString());
+        $user->setEmail('t@example.com');
+        $user->setPassword('pass');
+        $company = new Company(Uuid::uuid4()->toString(), $user);
+        $company->setName('Test');
+        $account = new MoneyAccount(Uuid::uuid4()->toString(), $company, MoneyAccountType::BANK, 'Main', 'USD');
+        $account->setOpeningBalance('100');
+        $account->setOpeningBalanceDate(new \DateTimeImmutable('2024-01-01'));
+        $this->em->persist($user);
+        $this->em->persist($company);
+        $this->em->persist($account);
+        $this->em->flush();
+
+        $dto1 = new CashTransactionDTO();
+        $dto1->companyId = $company->getId();
+        $dto1->moneyAccountId = $account->getId();
+        $dto1->direction = CashDirection::INFLOW;
+        $dto1->amount = '50';
+        $dto1->currency = 'USD';
+        $dto1->occurredAt = new \DateTimeImmutable('2024-01-01');
+        $this->txService->add($dto1);
+
+        $dto2 = new CashTransactionDTO();
+        $dto2->companyId = $company->getId();
+        $dto2->moneyAccountId = $account->getId();
+        $dto2->direction = CashDirection::OUTFLOW;
+        $dto2->amount = '30';
+        $dto2->currency = 'USD';
+        $dto2->occurredAt = new \DateTimeImmutable('2024-01-02');
+        $this->txService->add($dto2);
+
+        $balances = $this->balanceService->getBalancesForPeriod($company, $account, new \DateTimeImmutable('2024-01-01'), new \DateTimeImmutable('2024-01-02'));
+        $this->assertCount(2, $balances->balances);
+        $this->assertSame('150', $balances->balances[0]->closing);
+        $this->assertSame('120', $balances->balances[1]->closing);
+    }
+}


### PR DESCRIPTION
## Summary
- add cash transaction entity and enums
- introduce daily balance snapshots and services to recalc balances
- provide basic unit test for balance recalculation

## Testing
- `composer install` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68b67c7429c0832388378828038ff19f