### PR TITLE
feat: add cash transaction pages

### DIFF
--- a/site/src/Controller/Finance/CashTransactionController.php
+++ b/site/src/Controller/Finance/CashTransactionController.php
@@ -1,0 +1,307 @@
+<?php
+
+namespace App\Controller\Finance;
+
+use App\DTO\CashTransactionDTO;
+use App\Entity\CashTransaction;
+use App\Entity\CashflowCategory;
+use App\Entity\Counterparty;
+use App\Entity\MoneyAccount;
+use App\Enum\CashDirection;
+use App\Repository\CashTransactionRepository;
+use App\Repository\CashflowCategoryRepository;
+use App\Repository\CounterpartyRepository;
+use App\Repository\MoneyAccountRepository;
+use App\Service\ActiveCompanyService;
+use App\Service\CashTransactionService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/finance/cash-transactions')]
+class CashTransactionController extends AbstractController
+{
+    public function __construct(private ActiveCompanyService $companyService)
+    {
+    }
+
+    #[Route('/', name: 'cash_transaction_index', methods: ['GET'])]
+    public function index(
+        Request $request,
+        CashTransactionRepository $txRepo,
+        MoneyAccountRepository $accountRepo,
+        CashflowCategoryRepository $categoryRepo,
+        CounterpartyRepository $counterpartyRepo
+    ): Response {
+        $company = $this->companyService->getActiveCompany();
+
+        $filters = [
+            'dateFrom' => $request->query->get('dateFrom'),
+            'dateTo' => $request->query->get('dateTo'),
+            'accountId' => $request->query->get('accountId'),
+            'categoryId' => $request->query->get('categoryId'),
+            'counterpartyId' => $request->query->get('counterpartyId'),
+            'direction' => $request->query->get('direction'),
+            'amountMin' => $request->query->get('amountMin'),
+            'amountMax' => $request->query->get('amountMax'),
+            'q' => $request->query->get('q'),
+        ];
+
+        $qb = $txRepo->createQueryBuilder('t')
+            ->andWhere('t.company = :company')
+            ->setParameter('company', $company)
+            ->orderBy('t.occurredAt', 'DESC');
+
+        if ($filters['dateFrom']) {
+            $qb->andWhere('t.occurredAt >= :df')->setParameter('df', new \DateTimeImmutable($filters['dateFrom']));
+        }
+        if ($filters['dateTo']) {
+            $qb->andWhere('t.occurredAt <= :dt')->setParameter('dt', new \DateTimeImmutable($filters['dateTo']));
+        }
+        if ($filters['accountId']) {
+            $qb->andWhere('t.moneyAccount = :acc')->setParameter('acc', $filters['accountId']);
+        }
+        if ($filters['categoryId']) {
+            $qb->andWhere('t.cashflowCategory = :cat')->setParameter('cat', $filters['categoryId']);
+        }
+        if ($filters['counterpartyId']) {
+            $qb->andWhere('t.counterparty = :cp')->setParameter('cp', $filters['counterpartyId']);
+        }
+        if ($filters['direction']) {
+            $qb->andWhere('t.direction = :dir')->setParameter('dir', $filters['direction']);
+        }
+        if ($filters['amountMin']) {
+            $qb->andWhere('t.amount >= :amin')->setParameter('amin', $filters['amountMin']);
+        }
+        if ($filters['amountMax']) {
+            $qb->andWhere('t.amount <= :amax')->setParameter('amax', $filters['amountMax']);
+        }
+        if ($filters['q']) {
+            $qb->andWhere('t.description LIKE :q')->setParameter('q', '%'.$filters['q'].'%');
+        }
+
+        $page = max(1, (int)$request->query->get('page', 1));
+        $limit = 20;
+        $qbCount = clone $qb;
+        $total = (int)$qbCount->select('COUNT(t.id)')->getQuery()->getSingleScalarResult();
+        $qb->setFirstResult(($page-1)*$limit)->setMaxResults($limit);
+        $transactions = $qb->getQuery()->getResult();
+
+        $pages = (int)ceil($total / $limit);
+        $pager = [
+            'current' => $page,
+            'pages' => $pages,
+            'hasPrevious' => $page > 1,
+            'hasNext' => $page < $pages,
+            'previous' => $page - 1,
+            'next' => $page + 1,
+        ];
+
+        $sumQb = clone $qbCount;
+        $sum = $sumQb->select(
+            "SUM(CASE WHEN t.direction = 'INFLOW' THEN t.amount ELSE 0 END) as inflow",
+            "SUM(CASE WHEN t.direction = 'OUTFLOW' THEN t.amount ELSE 0 END) as outflow"
+        )->getQuery()->getSingleResult();
+        $summary = [
+            'inflow' => $sum['inflow'] ?? 0,
+            'outflow' => $sum['outflow'] ?? 0,
+            'net' => ($sum['inflow'] ?? 0) - ($sum['outflow'] ?? 0),
+        ];
+
+        $accounts = $accountRepo->findBy(['company' => $company]);
+        $categories = $categoryRepo->findBy(['company' => $company], ['sort' => 'ASC']);
+        $counterparties = $counterpartyRepo->findBy(['company' => $company], ['name' => 'ASC']);
+
+        return $this->render('transaction/index.html.twig', [
+            'transactions' => $transactions,
+            'filters' => $filters,
+            'accounts' => $accounts,
+            'categories' => $categories,
+            'counterparties' => $counterparties,
+            'summary' => $summary,
+            'pager' => $pager,
+        ]);
+    }
+
+    #[Route('/new', name: 'cash_transaction_new', methods: ['GET','POST'])]
+    public function new(
+        Request $request,
+        CashTransactionService $service,
+        MoneyAccountRepository $accountRepo,
+        CashflowCategoryRepository $categoryRepo,
+        CounterpartyRepository $counterpartyRepo
+    ): Response {
+        $company = $this->companyService->getActiveCompany();
+        $dto = new CashTransactionDTO();
+        $dto->occurredAt = new \DateTimeImmutable('today');
+
+        $form = $this->createFormBuilder($dto)
+            ->add('occurredAt', DateType::class, ['widget' => 'single_text'])
+            ->add('moneyAccount', ChoiceType::class, [
+                'choices' => $accountRepo->findBy(['company' => $company]),
+                'choice_label' => fn(MoneyAccount $a) => $a->getName(),
+                'choice_value' => 'id',
+                'choice_attr' => fn(MoneyAccount $a) => ['data-currency' => $a->getCurrency()],
+            ])
+            ->add('direction', ChoiceType::class, [
+                'choices' => ['Приток' => CashDirection::INFLOW, 'Отток' => CashDirection::OUTFLOW],
+            ])
+            ->add('amount', NumberType::class, ['scale' => 2])
+            ->add('currency', ChoiceType::class, [
+                'choices' => ['RUB' => 'RUB'],
+                'disabled' => true,
+            ])
+            ->add('cashflowCategory', ChoiceType::class, [
+                'required' => false,
+                'choices' => $categoryRepo->findBy(['company' => $company], ['sort' => 'ASC']),
+                'choice_label' => fn(CashflowCategory $c) => str_repeat(' ', $c->getLevel()-1).$c->getName(),
+                'choice_value' => 'id',
+            ])
+            ->add('counterparty', ChoiceType::class, [
+                'required' => false,
+                'choices' => $counterpartyRepo->findBy(['company' => $company], ['name' => 'ASC']),
+                'choice_label' => 'name',
+                'choice_value' => 'id',
+            ])
+            ->add('description', TextareaType::class, ['required' => false])
+            ->getForm();
+
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid() && $this->isCsrfTokenValid('tx_formnew', $request->request->get('_token'))) {
+            /** @var CashTransactionDTO $data */
+            $data = $form->getData();
+            $account = $form->get('moneyAccount')->getData();
+            $data->companyId = $company->getId();
+            $data->moneyAccountId = $account->getId();
+            $data->currency = $account->getCurrency();
+            $cat = $form->get('cashflowCategory')->getData();
+            $cp = $form->get('counterparty')->getData();
+            $data->cashflowCategoryId = $cat?->getId();
+            $data->counterpartyId = $cp?->getId();
+            $service->add($data);
+            $this->addFlash('success', 'Транзакция добавлена');
+            return $this->redirectToRoute('cash_transaction_index');
+        }
+
+        return $this->render('transaction/new.html.twig', [
+            'form' => $form->createView(),
+            'tx' => null,
+        ]);
+    }
+
+    #[Route('/{id}', name: 'cash_transaction_show', methods: ['GET'])]
+    public function show(CashTransaction $tx): Response
+    {
+        $company = $this->companyService->getActiveCompany();
+        if ($tx->getCompany() !== $company) {
+            throw $this->createNotFoundException();
+        }
+
+        return $this->render('transaction/show.html.twig', [
+            'tx' => $tx,
+        ]);
+    }
+
+    #[Route('/{id}/edit', name: 'cash_transaction_edit', methods: ['GET','POST'])]
+    public function edit(
+        Request $request,
+        CashTransaction $tx,
+        CashTransactionService $service,
+        MoneyAccountRepository $accountRepo,
+        CashflowCategoryRepository $categoryRepo,
+        CounterpartyRepository $counterpartyRepo
+    ): Response {
+        $company = $this->companyService->getActiveCompany();
+        if ($tx->getCompany() !== $company) {
+            throw $this->createNotFoundException();
+        }
+
+        $dto = new CashTransactionDTO();
+        $dto->occurredAt = $tx->getOccurredAt();
+        $dto->amount = $tx->getAmount();
+        $dto->direction = $tx->getDirection();
+
+        $form = $this->createFormBuilder($dto)
+            ->add('occurredAt', DateType::class, ['widget' => 'single_text'])
+            ->add('moneyAccount', ChoiceType::class, [
+                'choices' => $accountRepo->findBy(['company' => $company]),
+                'choice_label' => fn(MoneyAccount $a) => $a->getName(),
+                'choice_value' => 'id',
+                'choice_attr' => fn(MoneyAccount $a) => ['data-currency' => $a->getCurrency()],
+                'data' => $tx->getMoneyAccount(),
+            ])
+            ->add('direction', ChoiceType::class, [
+                'choices' => ['Приток' => CashDirection::INFLOW, 'Отток' => CashDirection::OUTFLOW],
+                'data' => $tx->getDirection(),
+            ])
+            ->add('amount', NumberType::class, ['scale' => 2])
+            ->add('currency', ChoiceType::class, [
+                'choices' => [$tx->getCurrency() => $tx->getCurrency()],
+                'disabled' => true,
+            ])
+            ->add('cashflowCategory', ChoiceType::class, [
+                'required' => false,
+                'choices' => $categoryRepo->findBy(['company' => $company], ['sort' => 'ASC']),
+                'choice_label' => fn(CashflowCategory $c) => str_repeat(' ', $c->getLevel()-1).$c->getName(),
+                'choice_value' => 'id',
+                'data' => $tx->getCashflowCategory(),
+            ])
+            ->add('counterparty', ChoiceType::class, [
+                'required' => false,
+                'choices' => $counterpartyRepo->findBy(['company' => $company], ['name' => 'ASC']),
+                'choice_label' => 'name',
+                'choice_value' => 'id',
+                'data' => $tx->getCounterparty(),
+            ])
+            ->add('description', TextareaType::class, ['required' => false, 'data' => $tx->getDescription()])
+            ->getForm();
+
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid() && $this->isCsrfTokenValid('tx_form'.$tx->getId(), $request->request->get('_token'))) {
+            /** @var CashTransactionDTO $data */
+            $data = $form->getData();
+            $account = $form->get('moneyAccount')->getData();
+            $data->companyId = $company->getId();
+            $data->moneyAccountId = $account->getId();
+            $data->currency = $account->getCurrency();
+            $cat = $form->get('cashflowCategory')->getData();
+            $cp = $form->get('counterparty')->getData();
+            $data->cashflowCategoryId = $cat?->getId();
+            $data->counterpartyId = $cp?->getId();
+            $service->update($tx, $data);
+            $this->addFlash('success', 'Транзакция обновлена');
+            return $this->redirectToRoute('cash_transaction_index');
+        }
+
+        return $this->render('transaction/edit.html.twig', [
+            'form' => $form->createView(),
+            'tx' => $tx,
+        ]);
+    }
+
+    #[Route('/{id}/delete', name: 'cash_transaction_delete', methods: ['POST'])]
+    public function delete(Request $request, CashTransaction $tx, CashTransactionService $service): Response
+    {
+        $company = $this->companyService->getActiveCompany();
+        if ($tx->getCompany() !== $company) {
+            throw $this->createNotFoundException();
+        }
+
+        if ($this->isCsrfTokenValid('tx_delete'.$tx->getId(), $request->request->get('_token'))) {
+            $service->delete($tx);
+            $this->addFlash('success', 'Транзакция удалена');
+        } else {
+            $this->addFlash('danger', 'Неверный CSRF токен');
+        }
+
+        return $this->redirectToRoute('cash_transaction_index');
+    }
+}
+

--- a/site/src/Service/CashTransactionService.php
+++ b/site/src/Service/CashTransactionService.php
@@ -6,6 +6,8 @@ use App\DTO\CashTransactionDTO;
 use App\Entity\CashTransaction;
 use App\Entity\Company;
 use App\Entity\MoneyAccount;
+use App\Entity\Counterparty;
+use App\Entity\CashflowCategory;
 use App\Enum\CashDirection;
 use App\Exception\CurrencyMismatchException;
 use App\Repository\CashTransactionRepository;
@@ -34,5 +36,48 @@ class CashTransactionService
         $this->em->flush();
         $this->balanceService->recalculateDailyRange($company, $account, $from, $to);
         return $tx;
+    }
+
+    public function update(CashTransaction $tx, CashTransactionDTO $dto): CashTransaction
+    {
+        $company = $tx->getCompany();
+        $oldAccount = $tx->getMoneyAccount();
+        $oldDate = $tx->getOccurredAt();
+        $account = $this->em->getReference(MoneyAccount::class, $dto->moneyAccountId);
+        if ($dto->currency !== $account->getCurrency()) {
+            throw new CurrencyMismatchException();
+        }
+        $tx->setMoneyAccount($account)
+            ->setDirection($dto->direction)
+            ->setAmount($dto->amount)
+            ->setCurrency($dto->currency)
+            ->setOccurredAt($dto->occurredAt)
+            ->setDescription($dto->description);
+
+        $counterparty = $dto->counterpartyId ? $this->em->getReference(Counterparty::class, $dto->counterpartyId) : null;
+        $category = $dto->cashflowCategoryId ? $this->em->getReference(CashflowCategory::class, $dto->cashflowCategoryId) : null;
+        $tx->setCounterparty($counterparty)->setCashflowCategory($category);
+
+        $this->em->flush();
+
+        $from = min($dto->occurredAt, $oldDate)->setTime(0,0);
+        $to = new \DateTimeImmutable('today');
+        $this->balanceService->recalculateDailyRange($company, $oldAccount, $from, $to);
+        if ($oldAccount !== $account) {
+            $this->balanceService->recalculateDailyRange($company, $account, $from, $to);
+        }
+
+        return $tx;
+    }
+
+    public function delete(CashTransaction $tx): void
+    {
+        $company = $tx->getCompany();
+        $account = $tx->getMoneyAccount();
+        $from = $tx->getOccurredAt()->setTime(0,0);
+        $to = new \DateTimeImmutable('today');
+        $this->em->remove($tx);
+        $this->em->flush();
+        $this->balanceService->recalculateDailyRange($company, $account, $from, $to);
     }
 }

--- a/site/templates/base.html.twig
+++ b/site/templates/base.html.twig
@@ -1,100 +1,33 @@
 <!DOCTYPE html>
-<html lang="RU">
+<html lang="ru">
 <head>
     <meta charset="UTF-8">
-    <title>{% block title %}Welcome!{% endblock %}</title>
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>⚫️</text><text y=%221.3em%22 x=%220.2em%22 font-size=%2276%22 fill=%22%23fff%22>sf</text></svg>">
-    {% block stylesheets %}
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.2.0/dist/css/tabler.min.css" />
-    {% endblock %}
-
-    {% block javascripts %}
-       {# {% block importmap %}{{ importmap('app') }}{% endblock %}#}
+    <title>{% block title %}Сервис{% endblock %}</title>
+    {% block styles %}
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.2.0/dist/css/tabler.min.css"/>
+        {% block stylesheets %}{% endblock %}
     {% endblock %}
 </head>
 <body>
-<header class="navbar-expand-md">
-    <div class="collapse navbar-collapse" id="navbar-menu">
-        <div class="navbar navbar-light">
-            <div class="container-xl d-flex justify-content-between">
-                <ul class="navbar-nav">
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{ path('app_home_index') }}" >
-                            {#<span class="nav-link-icon d-md-none d-lg-inline-block"><!-- Download SVG icon from http://tabler-icons.io/i/home -->
-                                  <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M5 12l-2 0l9 -9l9 9l-2 0" /><path d="M5 12v7a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-7" /><path d="M9 21v-6a2 2 0 0 1 2 -2h2a2 2 0 0 1 2 2v6" /></svg>
-                            </span>#}
-                            <span class="nav-link-title">Главная</span>
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{ path('ozon_products') }}" >
-                            {#<span class="nav-link-icon d-md-none d-lg-inline-block"><!-- Download SVG icon from http://tabler-icons.io/i/home -->
-                                  <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M5 12l-2 0l9 -9l9 9l-2 0" /><path d="M5 12v7a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-7" /><path d="M9 21v-6a2 2 0 0 1 2 -2h2a2 2 0 0 1 2 2v6" /></svg>
-                            </span>#}
-                            <span class="nav-link-title">Озон</span>
-                        </a>
-                    </li>
-
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{ path('ozon_products_test') }}" >
-                            {#<span class="nav-link-icon d-md-none d-lg-inline-block"><!-- Download SVG icon from http://tabler-icons.io/i/home -->
-                                  <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M5 12l-2 0l9 -9l9 9l-2 0" /><path d="M5 12v7a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-7" /><path d="M9 21v-6a2 2 0 0 1 2 -2h2a2 2 0 0 1 2 2v6" /></svg>
-                            </span>#}
-                            <span class="nav-link-title">Озон Test</span>
-                        </a>
-                    </li>
-
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{ path('company_index') }}">
-                            <span class="nav-link-icon d-md-none d-lg-inline-block">
-                                <!-- Tabler Icon Building -->
-                                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor" fill="none">
-                                    <path d="M3 21v-13l9-4l9 4v13" />
-                                    <path d="M13 13h4v8h-10v-6h6v6" />
-                                </svg>
-                            </span>
-                            <span class="nav-link-title">Компании</span>
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{ path('cashflow_category_index') }}">
-                            <span class="nav-link-title">ДДС</span>
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{ path('counterparty_index') }}">
-                            <span class="nav-link-title">Контрагенты</span>
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{ path('money_account_index') }}">
-                            <span class="nav-link-title">Счета</span>
-                        </a>
-                    </li>
-                </ul>
-                {% if app.user and app.user.companies|length > 0 %}
-                    <form method="post" action="{{ path('company_set_active') }}">
-                        <select name="company_id" class="form-select" onchange="this.form.submit()">
-                            {% for company in app.user.companies %}
-                                <option value="{{ company.id }}" {% if app.session.get('active_company_id') == company.id %}selected{% endif %}>{{ company.name }}</option>
-                            {% endfor %}
-                        </select>
-                    </form>
-                {% endif %}
-            </div>
-        </div>
-
-    </div>
+<div class="page">
+    {% include 'partials/_sidebar.html.twig' %}
     <div class="page-wrapper">
+        <header class="navbar navbar-expand-md d-print-none">
+            <div class="container-xl">
+                <h1 class="navbar-brand">Сервис</h1>
+            </div>
+        </header>
         <div class="page-body">
             <div class="container-xl">
-                {% block body %}{% endblock %}
+                {% block breadcrumbs %}{% endblock %}
+                {{ include('partials/_flash.html.twig') }}
+                {% block content %}{% block body %}{% endblock %}{% endblock %}
             </div>
         </div>
     </div>
-</header>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/@tabler/core@1.2.0/dist/js/tabler.min.js"></script>
+{% block scripts %}{% block javascripts %}{% endblock %}{% endblock %}
 </body>
-<script
-    src="https://cdn.jsdelivr.net/npm/@tabler/core@1.2.0/dist/js/tabler.min.js">
-</script>
 </html>
+

--- a/site/templates/partials/_breadcrumbs.html.twig
+++ b/site/templates/partials/_breadcrumbs.html.twig
@@ -1,0 +1,16 @@
+{% if breadcrumbs is defined and breadcrumbs %}
+    <nav aria-label="breadcrumb" class="mb-3">
+        <ol class="breadcrumb">
+            {% for crumb in breadcrumbs %}
+                <li class="breadcrumb-item{% if loop.last %} active{% endif %}">
+                    {% if crumb.path is defined and crumb.path and not loop.last %}
+                        <a href="{{ path(crumb.path) }}">{{ crumb.label }}</a>
+                    {% else %}
+                        {{ crumb.label }}
+                    {% endif %}
+                </li>
+            {% endfor %}
+        </ol>
+    </nav>
+{% endif %}
+

--- a/site/templates/partials/_flash.html.twig
+++ b/site/templates/partials/_flash.html.twig
@@ -1,0 +1,9 @@
+{% for label in ['success', 'error', 'notice', 'danger'] %}
+    {% for message in app.flashes(label) %}
+        <div class="alert alert-{{ label == 'error' ? 'danger' : (label == 'notice' ? 'info' : label) }} alert-dismissible" role="alert">
+            {{ message }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+        </div>
+    {% endfor %}
+{% endfor %}
+

--- a/site/templates/partials/_pagination.html.twig
+++ b/site/templates/partials/_pagination.html.twig
@@ -1,0 +1,18 @@
+{% if pager is defined and pager %}
+    <nav class="mt-3" aria-label="pagination">
+        <ul class="pagination">
+            <li class="page-item{% if not pager.hasPrevious %} disabled{% endif %}">
+                <a class="page-link" href="{{ path(app.request.attributes.get('_route'), app.request.query.all|merge({'page': pager.previous})) }}">Пред</a>
+            </li>
+            {% for i in 1..pager.pages %}
+                <li class="page-item{% if pager.current == i %} active{% endif %}">
+                    <a class="page-link" href="{{ path(app.request.attributes.get('_route'), app.request.query.all|merge({'page': i})) }}">{{ i }}</a>
+                </li>
+            {% endfor %}
+            <li class="page-item{% if not pager.hasNext %} disabled{% endif %}">
+                <a class="page-link" href="{{ path(app.request.attributes.get('_route'), app.request.query.all|merge({'page': pager.next})) }}">След</a>
+            </li>
+        </ul>
+    </nav>
+{% endif %}
+

--- a/site/templates/partials/_sidebar.html.twig
+++ b/site/templates/partials/_sidebar.html.twig
@@ -1,0 +1,75 @@
+{% set current_route = app.request.attributes.get('_route') %}
+<aside class="navbar navbar-vertical navbar-expand-lg" data-bs-theme="light">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="{{ path('app_home_index') }}">Финансы</a>
+        <div class="collapse navbar-collapse" id="sidebar-menu">
+            <ul class="navbar-nav pt-lg-3">
+                <li class="nav-item mb-2">
+                    <span class="nav-link text-uppercase text-muted">Рабочая зона</span>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="#">
+                        <span class="nav-link-title">Чат-центр</span>
+                    </a>
+                </li>
+
+                <li class="nav-item mt-3 mb-2">
+                    <span class="nav-link text-uppercase text-muted">Финансы</span>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link {% if current_route == 'cash_transaction_index' %}active{% endif %}" href="{{ path('cash_transaction_index') }}">
+                        <span class="nav-link-title">Транзакции (ДДС)</span>
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="#">
+                        <span class="nav-link-title">Остатки по счетам</span>
+                    </a>
+                </li>
+
+                <li class="nav-item mt-3 mb-2">
+                    <span class="nav-link text-uppercase text-muted">Справочники</span>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link {% if current_route == 'money_account_index' %}active{% endif %}" href="{{ path('money_account_index') }}">
+                        <span class="nav-link-title">Счета/Кассы/Кошельки</span>
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link {% if current_route == 'counterparty_index' %}active{% endif %}" href="{{ path('counterparty_index') }}">
+                        <span class="nav-link-title">Контрагенты</span>
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link {% if current_route == 'cashflow_category_index' %}active{% endif %}" href="{{ path('cashflow_category_index') }}">
+                        <span class="nav-link-title">Статьи ДДС</span>
+                    </a>
+                </li>
+
+                <li class="nav-item mt-3 mb-2">
+                    <span class="nav-link text-uppercase text-muted">Отчеты</span>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="#">
+                        <span class="nav-link-title">Отчет ДДС</span>
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="#">
+                        <span class="nav-link-title">P&amp;L</span>
+                    </a>
+                </li>
+
+                <li class="nav-item mt-3 mb-2">
+                    <span class="nav-link text-uppercase text-muted">Настройки</span>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="#">
+                        <span class="nav-link-title">Профиль компании</span>
+                    </a>
+                </li>
+            </ul>
+        </div>
+    </div>
+</aside>
+

--- a/site/templates/transaction/_delete_modal.html.twig
+++ b/site/templates/transaction/_delete_modal.html.twig
@@ -1,0 +1,21 @@
+<div class="modal fade" id="delete-modal-{{ tx.id }}" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Подтверждение</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                Удалить транзакцию безвозвратно?
+            </div>
+            <div class="modal-footer">
+                <form method="post" action="{{ path('cash_transaction_delete', {id: tx.id}) }}">
+                    <input type="hidden" name="_token" value="{{ csrf_token('tx_delete' ~ tx.id) }}">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Отмена</button>
+                    <button type="submit" class="btn btn-danger">Удалить</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+

--- a/site/templates/transaction/_filters.html.twig
+++ b/site/templates/transaction/_filters.html.twig
@@ -1,0 +1,84 @@
+<form method="get" class="card" id="filter-form">
+    <div class="card-header" data-bs-toggle="collapse" data-bs-target="#filter-body" style="cursor:pointer;">
+        Фильтры
+    </div>
+    <div id="filter-body" class="collapse{% if filters %} show{% endif %}">
+        <div class="card-body">
+            <div class="row g-2">
+                <div class="col-md-3">
+                    <label class="form-label">Дата с</label>
+                    <input type="date" id="filter_date_from" name="dateFrom" value="{{ filters.dateFrom ?? '' }}" class="form-control"/>
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label">Дата по</label>
+                    <input type="date" id="filter_date_to" name="dateTo" value="{{ filters.dateTo ?? '' }}" class="form-control"/>
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label">Счет</label>
+                    <select name="accountId" class="form-select">
+                        <option value="">Все</option>
+                        {% for a in accounts %}
+                            <option value="{{ a.id }}" {% if filters.accountId == a.id %}selected{% endif %}>{{ a.name }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label">Статья ДДС</label>
+                    <select name="categoryId" class="form-select">
+                        <option value="">Все</option>
+                        {% for c in categories %}
+                            <option value="{{ c.id }}" {% if filters.categoryId == c.id %}selected{% endif %}>{{ ('&nbsp;&nbsp;'|raw)|repeat(c.level-1) }}{{ c.name }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+            </div>
+
+            <div class="row g-2 mt-2">
+                <div class="col-md-3">
+                    <label class="form-label">Контрагент</label>
+                    <select name="counterpartyId" class="form-select">
+                        <option value="">Все</option>
+                        {% for c in counterparties %}
+                            <option value="{{ c.id }}" {% if filters.counterpartyId == c.id %}selected{% endif %}>{{ c.name }}</option>
+                        {% endfor %}
+                    </select>
+                    {# TODO: searchable select #}
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label">Направление</label>
+                    <select name="direction" class="form-select">
+                        <option value="">Все</option>
+                        <option value="INFLOW" {% if filters.direction == 'INFLOW' %}selected{% endif %}>Приток</option>
+                        <option value="OUTFLOW" {% if filters.direction == 'OUTFLOW' %}selected{% endif %}>Отток</option>
+                    </select>
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label">Сумма от</label>
+                    <input type="number" step="0.01" name="amountMin" value="{{ filters.amountMin ?? '' }}" class="form-control"/>
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label">Сумма до</label>
+                    <input type="number" step="0.01" name="amountMax" value="{{ filters.amountMax ?? '' }}" class="form-control"/>
+                </div>
+            </div>
+
+            <div class="row g-2 mt-2">
+                <div class="col-md-6">
+                    <label class="form-label">Поиск</label>
+                    <input type="text" name="q" value="{{ filters.q ?? '' }}" class="form-control" placeholder="Описание"/>
+                </div>
+                <div class="col-md-6 d-flex align-items-end justify-content-end gap-2">
+                    <div class="btn-group me-auto" role="group">
+                        <button type="button" class="btn btn-outline-secondary" data-period="today">Сегодня</button>
+                        <button type="button" class="btn btn-outline-secondary" data-period="yesterday">Вчера</button>
+                        <button type="button" class="btn btn-outline-secondary" data-period="week">Текущая неделя</button>
+                        <button type="button" class="btn btn-outline-secondary" data-period="month">Текущий месяц</button>
+                    </div>
+                    <button type="submit" class="btn btn-primary">Применить</button>
+                    <a href="{{ path('cash_transaction_index') }}" class="btn btn-secondary">Сбросить</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</form>
+

--- a/site/templates/transaction/_form.html.twig
+++ b/site/templates/transaction/_form.html.twig
@@ -1,0 +1,55 @@
+{{ form_start(form) }}
+<input type="hidden" name="_token" value="{{ csrf_token('tx_form' ~ (tx.id|default('new'))) }}">
+<div class="card">
+    <div class="card-body">
+        <div class="mb-3">
+            {{ form_label(form.occurredAt, 'Дата', {'label_attr': {'class': 'form-label'}}) }}
+            {{ form_widget(form.occurredAt, {'attr': {'class': 'form-control'}}) }}
+            <div class="invalid-feedback d-block">{{ form_errors(form.occurredAt) }}</div>
+        </div>
+        <div class="mb-3">
+            {{ form_label(form.moneyAccount, 'Счет', {'label_attr': {'class': 'form-label'}}) }}
+            {{ form_widget(form.moneyAccount, {'attr': {'class': 'form-select'}}) }}
+            <div class="invalid-feedback d-block">{{ form_errors(form.moneyAccount) }}</div>
+        </div>
+        <div class="mb-3">
+            {{ form_label(form.direction, 'Направление', {'label_attr': {'class': 'form-label'}}) }}
+            {{ form_widget(form.direction, {'attr': {'class': 'form-select'}}) }}
+            <div class="invalid-feedback d-block">{{ form_errors(form.direction) }}</div>
+        </div>
+        <div class="row g-2">
+            <div class="col-md-6">
+                {{ form_label(form.amount, 'Сумма', {'label_attr': {'class': 'form-label'}}) }}
+                {{ form_widget(form.amount, {'attr': {'class': 'form-control', 'step': '0.01'}}) }}
+                <div class="invalid-feedback d-block">{{ form_errors(form.amount) }}</div>
+            </div>
+            <div class="col-md-6">
+                {{ form_label(form.currency, 'Валюта', {'label_attr': {'class': 'form-label'}}) }}
+                {{ form_widget(form.currency, {'attr': {'class': 'form-control', 'readonly': true}}) }}
+            </div>
+        </div>
+        <div class="mb-3">
+            {{ form_label(form.cashflowCategory, 'Статья ДДС', {'label_attr': {'class': 'form-label'}}) }}
+            {{ form_widget(form.cashflowCategory, {'attr': {'class': 'form-select'}}) }}
+            <div class="invalid-feedback d-block">{{ form_errors(form.cashflowCategory) }}</div>
+        </div>
+        <div class="mb-3">
+            {{ form_label(form.counterparty, 'Контрагент', {'label_attr': {'class': 'form-label'}}) }}
+            {{ form_widget(form.counterparty, {'attr': {'class': 'form-select'}}) }}
+            <div class="invalid-feedback d-block">{{ form_errors(form.counterparty) }}</div>
+        </div>
+        <div class="mb-3">
+            {{ form_label(form.description, 'Описание', {'label_attr': {'class': 'form-label'}}) }}
+            {{ form_widget(form.description, {'attr': {'class': 'form-control', 'rows': 3}}) }}
+            <div class="invalid-feedback d-block">{{ form_errors(form.description) }}</div>
+        </div>
+    </div>
+    <div class="card-footer text-end">
+        <button class="btn btn-primary" type="submit">Сохранить</button>
+        <a href="{{ path('cash_transaction_index') }}" class="btn btn-secondary">Отмена</a>
+    </div>
+</div>
+{{ form_end(form, {'render_rest': false}) }}
+
+{% block scripts %}{% endblock %}
+

--- a/site/templates/transaction/edit.html.twig
+++ b/site/templates/transaction/edit.html.twig
@@ -1,0 +1,35 @@
+{% extends 'base.html.twig' %}
+{% block title %}Редактирование транзакции{% endblock %}
+
+{% block breadcrumbs %}
+    {% include 'partials/_breadcrumbs.html.twig' with {
+        breadcrumbs: [
+            {'label':'Главная','path':'app_home_index'},
+            {'label':'Финансы'},
+            {'label':'Транзакции','path':'cash_transaction_index'},
+            {'label':'Редактирование'}
+        ]
+    } %}
+{% endblock %}
+
+{% block content %}
+    <h2 class="page-title mb-3">Редактирование транзакции</h2>
+    {{ include('transaction/_form.html.twig') }}
+{% endblock %}
+
+{% block scripts %}
+    {{ parent() }}
+    <script>
+        const acc = document.querySelector('#form_moneyAccount');
+        const cur = document.querySelector('#form_currency');
+        if (acc && cur) {
+            acc.addEventListener('change', e => {
+                const opt = acc.options[acc.selectedIndex];
+                cur.value = opt.dataset.currency || '';
+            });
+            const initOpt = acc.options[acc.selectedIndex];
+            cur.value = initOpt ? initOpt.dataset.currency : '';
+        }
+    </script>
+{% endblock %}
+

--- a/site/templates/transaction/index.html.twig
+++ b/site/templates/transaction/index.html.twig
@@ -1,0 +1,125 @@
+{% extends 'base.html.twig' %}
+{% block title %}Транзакции (ДДС){% endblock %}
+
+{% block breadcrumbs %}
+    {% include 'partials/_breadcrumbs.html.twig' with {
+        breadcrumbs: [
+            {'label': 'Главная', 'path': 'app_home_index'},
+            {'label': 'Финансы'},
+            {'label': 'Транзакции', 'path': 'cash_transaction_index'}
+        ]
+    } %}
+{% endblock %}
+
+{% block content %}
+<div class="d-flex align-items-center mb-3">
+    <h2 class="page-title">Транзакции (ДДС)</h2>
+    <div class="ms-auto d-print-none">
+        <a href="{{ path('cash_transaction_new') }}" class="btn btn-primary">Добавить</a>
+        <a href="#" class="btn btn-outline-secondary">Импорт</a>
+        <a href="#" class="btn btn-outline-secondary">Экспорт</a>
+    </div>
+</div>
+
+{{ include('transaction/_filters.html.twig') }}
+
+<div class="card mt-3">
+    <div class="table-responsive">
+        <table class="table table-striped table-hover">
+            <thead class="sticky-top">
+            <tr>
+                <th>Дата</th>
+                <th>Счет</th>
+                <th>Направление</th>
+                <th class="text-end">Сумма</th>
+                <th>Статья</th>
+                <th>Контрагент</th>
+                <th>Описание</th>
+                <th></th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for tx in transactions %}
+                <tr>
+                    <td>{{ tx.occurredAt|date('d.m.Y') }}</td>
+                    <td>{{ tx.moneyAccount.name }}</td>
+                    <td>
+                        <span class="badge bg-{{ tx.direction == 'INFLOW' ? 'success' : 'danger' }}">{{ tx.direction == 'INFLOW' ? 'Приток' : 'Отток' }}</span>
+                    </td>
+                    <td class="text-end">{{ tx.amount|number_format(2, ',', ' ') }} {{ tx.currency }}</td>
+                    <td>
+                        {% set chain = [] %}
+                        {% set c = tx.cashflowCategory %}
+                        {% for i in 0..10 if c %}
+                            {% set chain = [c.name]|merge(chain) %}
+                            {% set c = c.parent %}
+                        {% endfor %}
+                        {{ chain|join(' / ') }}
+                    </td>
+                    <td>{{ tx.counterparty ? tx.counterparty.name : '' }}</td>
+                    <td>{{ tx.description }}</td>
+                    <td class="text-nowrap">
+                        <a href="{{ path('cash_transaction_show', {id: tx.id}) }}" class="btn btn-sm btn-info">Просмотр</a>
+                        <a href="{{ path('cash_transaction_edit', {id: tx.id}) }}" class="btn btn-sm btn-warning">Редактировать</a>
+                        <button class="btn btn-sm btn-danger" data-bs-toggle="modal" data-bs-target="#delete-modal-{{ tx.id }}">Удалить</button>
+                        {{ include('transaction/_delete_modal.html.twig', {tx: tx}) }}
+                    </td>
+                </tr>
+            {% else %}
+                <tr>
+                    <td colspan="8" class="text-center text-muted">Нет транзакций</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+
+{% include 'partials/_pagination.html.twig' with {pager: pager} %}
+
+<div class="card mt-3">
+    <div class="card-body">
+        <div class="row mb-2">
+            <div class="col">Приток</div>
+            <div class="col text-end text-success">{{ summary.inflow|number_format(2, ',', ' ') }}</div>
+        </div>
+        <div class="row mb-2">
+            <div class="col">Отток</div>
+            <div class="col text-end text-danger">{{ summary.outflow|number_format(2, ',', ' ') }}</div>
+        </div>
+        <div class="row fw-bold">
+            <div class="col">Баланс движения</div>
+            <div class="col text-end">{{ summary.net|number_format(2, ',', ' ') }}</div>
+        </div>
+    </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+    {{ parent() }}
+    <script>
+        document.querySelectorAll('[data-period]').forEach(btn => {
+            btn.addEventListener('click', function () {
+                const from = document.querySelector('#filter_date_from');
+                const to = document.querySelector('#filter_date_to');
+                const now = new Date();
+                let start = new Date(now);
+                if (this.dataset.period === 'today') {
+                    start = now;
+                } else if (this.dataset.period === 'yesterday') {
+                    start.setDate(start.getDate() - 1);
+                    now.setDate(now.getDate() - 1);
+                } else if (this.dataset.period === 'week') {
+                    start.setDate(start.getDate() - start.getDay() + 1);
+                } else if (this.dataset.period === 'month') {
+                    start = new Date(now.getFullYear(), now.getMonth(), 1);
+                }
+                const fmt = d => d.toISOString().slice(0,10);
+                from.value = fmt(start);
+                to.value = fmt(now);
+            });
+        });
+    </script>
+{% endblock %}
+

--- a/site/templates/transaction/new.html.twig
+++ b/site/templates/transaction/new.html.twig
@@ -1,0 +1,35 @@
+{% extends 'base.html.twig' %}
+{% block title %}Новая транзакция{% endblock %}
+
+{% block breadcrumbs %}
+    {% include 'partials/_breadcrumbs.html.twig' with {
+        breadcrumbs: [
+            {'label':'Главная','path':'app_home_index'},
+            {'label':'Финансы'},
+            {'label':'Транзакции','path':'cash_transaction_index'},
+            {'label':'Новая'}
+        ]
+    } %}
+{% endblock %}
+
+{% block content %}
+    <h2 class="page-title mb-3">Новая транзакция</h2>
+    {{ include('transaction/_form.html.twig') }}
+{% endblock %}
+
+{% block scripts %}
+    {{ parent() }}
+    <script>
+        const acc = document.querySelector('#form_moneyAccount');
+        const cur = document.querySelector('#form_currency');
+        if (acc && cur) {
+            acc.addEventListener('change', e => {
+                const opt = acc.options[acc.selectedIndex];
+                cur.value = opt.dataset.currency || '';
+            });
+            const initOpt = acc.options[acc.selectedIndex];
+            cur.value = initOpt ? initOpt.dataset.currency : '';
+        }
+    </script>
+{% endblock %}
+

--- a/site/templates/transaction/show.html.twig
+++ b/site/templates/transaction/show.html.twig
@@ -1,0 +1,36 @@
+{% extends 'base.html.twig' %}
+{% block title %}Просмотр транзакции{% endblock %}
+
+{% block breadcrumbs %}
+    {% include 'partials/_breadcrumbs.html.twig' with {
+        breadcrumbs: [
+            {'label':'Главная','path':'app_home_index'},
+            {'label':'Финансы'},
+            {'label':'Транзакции','path':'cash_transaction_index'},
+            {'label':'Просмотр'}
+        ]
+    } %}
+{% endblock %}
+
+{% block content %}
+<div class="card">
+    <div class="card-body">
+        <dl class="row">
+            <dt class="col-md-3">Дата</dt><dd class="col-md-9">{{ tx.occurredAt|date('d.m.Y') }}</dd>
+            <dt class="col-md-3">Счет</dt><dd class="col-md-9">{{ tx.moneyAccount.name }}</dd>
+            <dt class="col-md-3">Направление</dt><dd class="col-md-9"><span class="badge bg-{{ tx.direction == 'INFLOW' ? 'success' : 'danger' }}">{{ tx.direction == 'INFLOW' ? 'Приток' : 'Отток' }}</span></dd>
+            <dt class="col-md-3">Сумма</dt><dd class="col-md-9 text-end">{{ tx.amount|number_format(2, ',', ' ') }} {{ tx.currency }}</dd>
+            <dt class="col-md-3">Статья</dt><dd class="col-md-9">{% set chain = [] %}{% set c = tx.cashflowCategory %}{% for i in 0..10 if c %}{% set chain = [c.name]|merge(chain) %}{% set c = c.parent %}{% endfor %}{{ chain|join(' / ') }}</dd>
+            <dt class="col-md-3">Контрагент</dt><dd class="col-md-9">{{ tx.counterparty ? tx.counterparty.name : '' }}</dd>
+            <dt class="col-md-3">Описание</dt><dd class="col-md-9">{{ tx.description }}</dd>
+        </dl>
+    </div>
+    <div class="card-footer text-end">
+        <a href="{{ path('cash_transaction_edit', {id: tx.id}) }}" class="btn btn-warning">Редактировать</a>
+        <button class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#delete-modal-{{ tx.id }}">Удалить</button>
+        <a href="{{ path('cash_transaction_index') }}" class="btn btn-secondary">Назад к списку</a>
+    </div>
+</div>
+{{ include('transaction/_delete_modal.html.twig', {tx: tx}) }}
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- add Tabler base layout with sidebar, breadcrumbs and flashes
- implement finance cash transaction CRUD with filters and summaries
- include reusable pagination and form templates

## Testing
- `./bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script)*
- `composer install` *(fails: requires GitHub token to download symfony/flex)*

------
https://chatgpt.com/codex/tasks/task_e_68b6858d254c8323be555672f6f7b516