### PR TITLE
Fix cash transaction index aggregate query

### DIFF
--- a/site/src/Controller/Finance/CashTransactionController.php
+++ b/site/src/Controller/Finance/CashTransactionController.php
@@ -87,8 +87,11 @@ class CashTransactionController extends AbstractController
 
         $page = max(1, (int)$request->query->get('page', 1));
         $limit = 20;
+
         $qbCount = clone $qb;
+        $qbCount->resetDQLPart('orderBy');
         $total = (int)$qbCount->select('COUNT(t.id)')->getQuery()->getSingleScalarResult();
+
         $qb->setFirstResult(($page-1)*$limit)->setMaxResults($limit);
         $transactions = $qb->getQuery()->getResult();
 


### PR DESCRIPTION
## Summary
- prevent grouping error on transaction index

## Testing
- `php bin/phpunit` *(fails: unable to find simple-phpunit.php)*
- `composer install` *(fails: GitHub token required)*

------
https://chatgpt.com/codex/tasks/task_e_68b68fe50e6c8323854ee107630ea4b7