### PR TITLE
Fix cash transaction template and add company selector

### DIFF
--- a/site/src/Controller/Finance/CashTransactionController.php
+++ b/site/src/Controller/Finance/CashTransactionController.php
@@ -12,6 +12,7 @@ use App\Repository\CashTransactionRepository;
 use App\Repository\CashflowCategoryRepository;
 use App\Repository\CounterpartyRepository;
 use App\Repository\MoneyAccountRepository;
+use App\Repository\CompanyRepository;
 use App\Service\ActiveCompanyService;
 use App\Service\CashTransactionService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -36,9 +37,11 @@ class CashTransactionController extends AbstractController
         CashTransactionRepository $txRepo,
         MoneyAccountRepository $accountRepo,
         CashflowCategoryRepository $categoryRepo,
-        CounterpartyRepository $counterpartyRepo
+        CounterpartyRepository $counterpartyRepo,
+        CompanyRepository $companyRepo
     ): Response {
         $company = $this->companyService->getActiveCompany();
+        $companies = $companyRepo->findByUser($this->getUser());
 
         $filters = [
             'dateFrom' => $request->query->get('dateFrom'),
@@ -128,6 +131,8 @@ class CashTransactionController extends AbstractController
             'counterparties' => $counterparties,
             'summary' => $summary,
             'pager' => $pager,
+            'companies' => $companies,
+            'company' => $company,
         ]);
     }
 

--- a/site/templates/transaction/index.html.twig
+++ b/site/templates/transaction/index.html.twig
@@ -14,6 +14,13 @@
 {% block content %}
 <div class="d-flex align-items-center mb-3">
     <h2 class="page-title">Транзакции (ДДС)</h2>
+    <form method="post" action="{{ path('company_set_active') }}" class="ms-3">
+        <select name="company_id" class="form-select" onchange="this.form.submit()">
+            {% for c in companies %}
+                <option value="{{ c.id }}" {% if c.id == company.id %}selected{% endif %}>{{ c.name }}</option>
+            {% endfor %}
+        </select>
+    </form>
     <div class="ms-auto d-print-none">
         <a href="{{ path('cash_transaction_new') }}" class="btn btn-primary">Добавить</a>
         <a href="#" class="btn btn-outline-secondary">Импорт</a>
@@ -50,9 +57,11 @@
                     <td>
                         {% set chain = [] %}
                         {% set c = tx.cashflowCategory %}
-                        {% for i in 0..10 if c %}
-                            {% set chain = [c.name]|merge(chain) %}
-                            {% set c = c.parent %}
+                        {% for i in 0..10 %}
+                            {% if c %}
+                                {% set chain = [c.name]|merge(chain) %}
+                                {% set c = c.parent %}
+                            {% endif %}
                         {% endfor %}
                         {{ chain|join(' / ') }}
                     </td>


### PR DESCRIPTION
## Summary
- add ability to switch active company on cash transaction page
- fix transaction template logic and markup

## Testing
- `php -l site/src/Controller/Finance/CashTransactionController.php`
- `composer install --no-interaction` *(failed: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b6942cbe1c8323a8125a2f1b3edbf9