### PR TITLE
Fix transaction filters and remove company selector

### DIFF
--- a/site/src/Controller/Finance/CashTransactionController.php
+++ b/site/src/Controller/Finance/CashTransactionController.php
@@ -12,7 +12,6 @@ use App\Repository\CashTransactionRepository;
 use App\Repository\CashflowCategoryRepository;
 use App\Repository\CounterpartyRepository;
 use App\Repository\MoneyAccountRepository;
-use App\Repository\CompanyRepository;
 use App\Service\ActiveCompanyService;
 use App\Service\CashTransactionService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -37,11 +36,9 @@ class CashTransactionController extends AbstractController
         CashTransactionRepository $txRepo,
         MoneyAccountRepository $accountRepo,
         CashflowCategoryRepository $categoryRepo,
-        CounterpartyRepository $counterpartyRepo,
-        CompanyRepository $companyRepo
+        CounterpartyRepository $counterpartyRepo
     ): Response {
         $company = $this->companyService->getActiveCompany();
-        $companies = $companyRepo->findByUser($this->getUser());
 
         $filters = [
             'dateFrom' => $request->query->get('dateFrom'),
@@ -131,8 +128,6 @@ class CashTransactionController extends AbstractController
             'counterparties' => $counterparties,
             'summary' => $summary,
             'pager' => $pager,
-            'companies' => $companies,
-            'company' => $company,
         ]);
     }
 

--- a/site/templates/transaction/_filters.html.twig
+++ b/site/templates/transaction/_filters.html.twig
@@ -27,7 +27,12 @@
                     <select name="categoryId" class="form-select">
                         <option value="">Все</option>
                         {% for c in categories %}
-                            <option value="{{ c.id }}" {% if filters.categoryId == c.id %}selected{% endif %}>{{ ('&nbsp;&nbsp;'|raw)|repeat(c.level-1) }}{{ c.name }}</option>
+                            <option value="{{ c.id }}" {% if filters.categoryId == c.id %}selected{% endif %}>
+                                {% if c.level > 1 %}
+                                    {% for i in 1..(c.level - 1) %}&nbsp;&nbsp;{% endfor %}
+                                {% endif %}
+                                {{ c.name }}
+                            </option>
                         {% endfor %}
                     </select>
                 </div>

--- a/site/templates/transaction/index.html.twig
+++ b/site/templates/transaction/index.html.twig
@@ -14,13 +14,6 @@
 {% block content %}
 <div class="d-flex align-items-center mb-3">
     <h2 class="page-title">Транзакции (ДДС)</h2>
-    <form method="post" action="{{ path('company_set_active') }}" class="ms-3">
-        <select name="company_id" class="form-select" onchange="this.form.submit()">
-            {% for c in companies %}
-                <option value="{{ c.id }}" {% if c.id == company.id %}selected{% endif %}>{{ c.name }}</option>
-            {% endfor %}
-        </select>
-    </form>
     <div class="ms-auto d-print-none">
         <a href="{{ path('cash_transaction_new') }}" class="btn btn-primary">Добавить</a>
         <a href="#" class="btn btn-outline-secondary">Импорт</a>


### PR DESCRIPTION
## Summary
- fix category filter indentation without repeat filter
- drop active company selector from transactions page

## Testing
- `php bin/phpunit` *(fails: Unable to find simple-phpunit.php because dependencies missing after composer install 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b69c4e72b4832396b3473b3679694a