### PR TITLE
Fix unmapped CashTransaction form fields

### DIFF
--- a/site/src/Controller/Finance/CashTransactionController.php
+++ b/site/src/Controller/Finance/CashTransactionController.php
@@ -150,6 +150,7 @@ class CashTransactionController extends AbstractController
                 'choice_label' => fn(MoneyAccount $a) => $a->getName(),
                 'choice_value' => 'id',
                 'choice_attr' => fn(MoneyAccount $a) => ['data-currency' => $a->getCurrency()],
+                'mapped' => false,
             ])
             ->add('direction', ChoiceType::class, [
                 'choices' => ['Приток' => CashDirection::INFLOW, 'Отток' => CashDirection::OUTFLOW],
@@ -164,12 +165,14 @@ class CashTransactionController extends AbstractController
                 'choices' => $categoryRepo->findBy(['company' => $company], ['sort' => 'ASC']),
                 'choice_label' => fn(CashflowCategory $c) => str_repeat(' ', $c->getLevel()-1).$c->getName(),
                 'choice_value' => 'id',
+                'mapped' => false,
             ])
             ->add('counterparty', ChoiceType::class, [
                 'required' => false,
                 'choices' => $counterpartyRepo->findBy(['company' => $company], ['name' => 'ASC']),
                 'choice_label' => 'name',
                 'choice_value' => 'id',
+                'mapped' => false,
             ])
             ->add('description', TextareaType::class, ['required' => false])
             ->getForm();
@@ -238,6 +241,7 @@ class CashTransactionController extends AbstractController
                 'choice_value' => 'id',
                 'choice_attr' => fn(MoneyAccount $a) => ['data-currency' => $a->getCurrency()],
                 'data' => $tx->getMoneyAccount(),
+                'mapped' => false,
             ])
             ->add('direction', ChoiceType::class, [
                 'choices' => ['Приток' => CashDirection::INFLOW, 'Отток' => CashDirection::OUTFLOW],
@@ -254,6 +258,7 @@ class CashTransactionController extends AbstractController
                 'choice_label' => fn(CashflowCategory $c) => str_repeat(' ', $c->getLevel()-1).$c->getName(),
                 'choice_value' => 'id',
                 'data' => $tx->getCashflowCategory(),
+                'mapped' => false,
             ])
             ->add('counterparty', ChoiceType::class, [
                 'required' => false,
@@ -261,6 +266,7 @@ class CashTransactionController extends AbstractController
                 'choice_label' => 'name',
                 'choice_value' => 'id',
                 'data' => $tx->getCounterparty(),
+                'mapped' => false,
             ])
             ->add('description', TextareaType::class, ['required' => false, 'data' => $tx->getDescription()])
             ->getForm();


### PR DESCRIPTION
## Summary
- mark moneyAccount, cashflowCategory and counterparty form fields as unmapped
- prevent property accessor errors in CashTransactionController

## Testing
- `php -l src/Controller/Finance/CashTransactionController.php`
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a4f41d3483239277db694624f1e4