### PR TITLE
Fix cash transaction form save

### DIFF
--- a/site/src/Controller/Finance/CashTransactionController.php
+++ b/site/src/Controller/Finance/CashTransactionController.php
@@ -143,7 +143,7 @@ class CashTransactionController extends AbstractController
         $dto = new CashTransactionDTO();
         $dto->occurredAt = new \DateTimeImmutable('today');
 
-        $form = $this->createFormBuilder($dto, ['csrf_protection' => false])
+        $form = $this->createFormBuilder($dto)
             ->add('occurredAt', DateType::class, ['widget' => 'single_text'])
             ->add('moneyAccount', ChoiceType::class, [
                 'choices' => $accountRepo->findBy(['company' => $company]),
@@ -179,7 +179,7 @@ class CashTransactionController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isSubmitted() && $this->isCsrfTokenValid('tx_formnew', $request->request->get('_token'))) {
+        if ($form->isSubmitted()) {
             /** @var CashTransactionDTO $data */
             $data = $form->getData();
             $account = $form->get('moneyAccount')->getData();
@@ -236,7 +236,7 @@ class CashTransactionController extends AbstractController
         $dto->amount = $tx->getAmount();
         $dto->direction = $tx->getDirection();
 
-        $form = $this->createFormBuilder($dto, ['csrf_protection' => false])
+        $form = $this->createFormBuilder($dto)
             ->add('occurredAt', DateType::class, ['widget' => 'single_text'])
             ->add('moneyAccount', ChoiceType::class, [
                 'choices' => $accountRepo->findBy(['company' => $company]),
@@ -276,7 +276,7 @@ class CashTransactionController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isSubmitted() && $this->isCsrfTokenValid('tx_form'.$tx->getId(), $request->request->get('_token'))) {
+        if ($form->isSubmitted()) {
             /** @var CashTransactionDTO $data */
             $data = $form->getData();
             $account = $form->get('moneyAccount')->getData();

--- a/site/templates/transaction/_form.html.twig
+++ b/site/templates/transaction/_form.html.twig
@@ -1,5 +1,5 @@
 {{ form_start(form) }}
-<input type="hidden" name="_token" value="{{ csrf_token('tx_form' ~ (tx.id|default('new'))) }}">
+{{ form_widget(form._token) }}
 <div class="card">
     <div class="card-body">
         <div class="mb-3">


### PR DESCRIPTION
## Summary
- Rely on Symfony's built-in CSRF handling for cash transaction forms
- Include hidden CSRF field in transaction form template

## Testing
- `php -l src/Controller/Finance/CashTransactionController.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: requires GitHub OAuth token)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e1e1582083238ede181635c1c799