### PR TITLE
fix: persist cash transaction

### DIFF
--- a/site/src/Controller/Finance/CashTransactionController.php
+++ b/site/src/Controller/Finance/CashTransactionController.php
@@ -159,6 +159,7 @@ class CashTransactionController extends AbstractController
             ->add('currency', ChoiceType::class, [
                 'choices' => ['RUB' => 'RUB'],
                 'disabled' => true,
+                'mapped' => false,
             ])
             ->add('cashflowCategory', ChoiceType::class, [
                 'required' => false,

--- a/site/templates/transaction/_form.html.twig
+++ b/site/templates/transaction/_form.html.twig
@@ -26,6 +26,7 @@
             <div class="col-md-6">
                 {{ form_label(form.currency, 'Валюта', {'label_attr': {'class': 'form-label'}}) }}
                 {{ form_widget(form.currency, {'attr': {'class': 'form-control', 'readonly': true}}) }}
+                <div class="invalid-feedback d-block">{{ form_errors(form.currency) }}</div>
             </div>
         </div>
         <div class="mb-3">


### PR DESCRIPTION
## Summary
- mark currency field in cash transaction form as unmapped
- show currency validation errors in the form

## Testing
- `php bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`.)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c96090148323bdfb92230b47ddbc