### PR TITLE
Add active company selector in header

### DIFF
--- a/site/templates/base.html.twig
+++ b/site/templates/base.html.twig
@@ -13,8 +13,9 @@
     {% include 'partials/_sidebar.html.twig' %}
     <div class="page-wrapper">
         <header class="navbar navbar-expand-md d-print-none">
-            <div class="container-xl">
+            <div class="container-xl d-flex justify-content-between align-items-center">
                 <h1 class="navbar-brand">Сервис</h1>
+                {% include 'partials/_active_company_widget.html.twig' %}
             </div>
         </header>
         <div class="page-body">

--- a/site/templates/partials/_active_company_widget.html.twig
+++ b/site/templates/partials/_active_company_widget.html.twig
@@ -1,0 +1,10 @@
+{% if app.user %}
+    {% set activeCompanyId = app.session.get('active_company_id') %}
+    <form action="{{ path('company_set_active') }}" method="post" class="ms-3">
+        <select name="company_id" class="form-select" onchange="this.form.submit()">
+            {% for company in app.user.companies %}
+                <option value="{{ company.id }}" {% if company.id == activeCompanyId %}selected{% endif %}>{{ company.name }}</option>
+            {% endfor %}
+        </select>
+    </form>
+{% endif %}


### PR DESCRIPTION
## Summary
- add active company select dropdown to the top navigation

## Testing
- `php bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script)*
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b7cf1557648323a63d1d06600255fc