### PR TITLE
fix: prevent currency field mapping when editing transactions

### DIFF
--- a/site/src/Controller/Finance/CashTransactionController.php
+++ b/site/src/Controller/Finance/CashTransactionController.php
@@ -255,6 +255,9 @@ class CashTransactionController extends AbstractController
             ->add('currency', ChoiceType::class, [
                 'choices' => [$tx->getCurrency() => $tx->getCurrency()],
                 'disabled' => true,
+                // поле валюты отображается только для пользователя
+                // и не должно изменять данные DTO
+                'mapped' => false,
             ])
             ->add('cashflowCategory', ChoiceType::class, [
                 'required' => false,


### PR DESCRIPTION
## Summary
- prevent currency field from mapping to DTO on edit form to avoid validation resets

## Testing
- `php -d memory_limit=1G vendor/bin/phpunit tests/Service/CashTransactionServiceTest.php` *(fails: Could not open input file: vendor/bin/phpunit)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f2805be08323bf723d24746629eb