### PR TITLE
Add bcmath extension to PHP production images

### DIFF
--- a/site/docker/production/php-cli/Dockerfile
+++ b/site/docker/production/php-cli/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.2-fpm-alpine AS builder
 
 RUN apk add --no-cache libpq-dev \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
-    && docker-php-ext-install pdo_pgsql opcache
+    && docker-php-ext-install pdo_pgsql opcache bcmath
 
 RUN apk add --no-cache unzip
 
@@ -23,7 +23,7 @@ FROM php:8.2-cli-alpine
 
 RUN apk add --no-cache libpq-dev bash coreutils \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
-    && docker-php-ext-install pdo_pgsql opcache
+    && docker-php-ext-install pdo_pgsql opcache bcmath
 
 RUN mv $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
 

--- a/site/docker/production/php-fpm/Dockerfile
+++ b/site/docker/production/php-fpm/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.2-cli-alpine AS builder
 
 RUN apk add --no-cache libpq-dev \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
-    && docker-php-ext-install pdo_pgsql opcache
+    && docker-php-ext-install pdo_pgsql opcache bcmath
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
 
@@ -22,7 +22,7 @@ FROM php:8.2-fpm-alpine
 
 RUN apk add --no-cache libpq-dev fcgi \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
-    && docker-php-ext-install pdo_pgsql opcache
+    && docker-php-ext-install pdo_pgsql opcache bcmath
 
 RUN mv $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
 


### PR DESCRIPTION
## Summary
- install bcmath extension in production php-fpm image
- install bcmath extension in production php-cli image

## Testing
- `docker --version` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68b87fbcd97083238ccbce8b6809bacc