### PR TITLE
Fix QueryBuilder parameter type for Doctrine 3

### DIFF
--- a/site/src/Repository/CashTransactionRepository.php
+++ b/site/src/Repository/CashTransactionRepository.php
@@ -7,6 +7,7 @@ use App\Entity\Company;
 use App\Entity\MoneyAccount;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Common\Collections\ArrayCollection;
 
 class CashTransactionRepository extends ServiceEntityRepository
 {
@@ -27,12 +28,12 @@ class CashTransactionRepository extends ServiceEntityRepository
             ->where('t.company = :company')
             ->andWhere('t.moneyAccount = :account')
             ->andWhere('t.occurredAt BETWEEN :from AND :to')
-            ->setParameters([
+            ->setParameters(new ArrayCollection([
                 'company' => $company,
                 'account' => $account,
                 'from' => $from->setTime(0,0),
                 'to' => $to->setTime(23,59,59),
-            ])
+            ]))
             ->groupBy('date')
             ->orderBy('date', 'ASC');
         return $qb->getQuery()->getArrayResult();

--- a/site/src/Repository/MoneyAccountDailyBalanceRepository.php
+++ b/site/src/Repository/MoneyAccountDailyBalanceRepository.php
@@ -8,6 +8,7 @@ use App\Entity\MoneyAccountDailyBalance;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\DBAL\Connection;
 use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Common\Collections\ArrayCollection;
 
 class MoneyAccountDailyBalanceRepository extends ServiceEntityRepository
 {
@@ -22,11 +23,11 @@ class MoneyAccountDailyBalanceRepository extends ServiceEntityRepository
             ->where('b.company = :company')
             ->andWhere('b.moneyAccount = :account')
             ->andWhere('b.date < :date')
-            ->setParameters([
+            ->setParameters(new ArrayCollection([
                 'company' => $company,
                 'account' => $account,
                 'date' => $date->setTime(0,0)
-            ])
+            ]))
             ->orderBy('b.date', 'DESC')
             ->setMaxResults(1)
             ->getQuery()->getOneOrNullResult();

--- a/site/src/Service/AccountBalanceService.php
+++ b/site/src/Service/AccountBalanceService.php
@@ -9,6 +9,7 @@ use App\Entity\MoneyAccount;
 use App\Repository\CashTransactionRepository;
 use App\Repository\MoneyAccountDailyBalanceRepository;
 use Ramsey\Uuid\Uuid;
+use Doctrine\Common\Collections\ArrayCollection;
 
 class AccountBalanceService
 {
@@ -47,7 +48,7 @@ class AccountBalanceService
         $snapshots = $this->balanceRepo->createQueryBuilder('b')
             ->where('b.company = :c')->andWhere('b.moneyAccount = :a')
             ->andWhere('b.date BETWEEN :f AND :t')
-            ->setParameters(['c'=>$company,'a'=>$account,'f'=>$from,'t'=>$to])
+            ->setParameters(new ArrayCollection(['c'=>$company,'a'=>$account,'f'=>$from,'t'=>$to]))
             ->orderBy('b.date','ASC')
             ->getQuery()->getResult();
         $balances = [];


### PR DESCRIPTION
## Summary
- use ArrayCollection for QueryBuilder::setParameters to satisfy doctrine requirements

## Testing
- `composer install` (failed: CONNECT tunnel failed 403, preventing dependency installation)

------
https://chatgpt.com/codex/tasks/task_e_68b9921704108323ababab22832609ae