### PR TITLE
Fix invalid parameter collections in repositories

### DIFF
--- a/site/src/Repository/CashTransactionRepository.php
+++ b/site/src/Repository/CashTransactionRepository.php
@@ -7,7 +7,6 @@ use App\Entity\Company;
 use App\Entity\MoneyAccount;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
-use Doctrine\Common\Collections\ArrayCollection;
 
 class CashTransactionRepository extends ServiceEntityRepository
 {
@@ -28,12 +27,12 @@ class CashTransactionRepository extends ServiceEntityRepository
             ->where('t.company = :company')
             ->andWhere('t.moneyAccount = :account')
             ->andWhere('t.occurredAt BETWEEN :from AND :to')
-            ->setParameters(new ArrayCollection([
+            ->setParameters([
                 'company' => $company,
                 'account' => $account,
                 'from' => $from->setTime(0,0),
                 'to' => $to->setTime(23,59,59),
-            ]))
+            ])
             ->groupBy('date')
             ->orderBy('date', 'ASC');
         return $qb->getQuery()->getArrayResult();

--- a/site/src/Repository/MoneyAccountDailyBalanceRepository.php
+++ b/site/src/Repository/MoneyAccountDailyBalanceRepository.php
@@ -6,9 +6,7 @@ use App\Entity\Company;
 use App\Entity\MoneyAccount;
 use App\Entity\MoneyAccountDailyBalance;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
-use Doctrine\DBAL\Connection;
 use Doctrine\Persistence\ManagerRegistry;
-use Doctrine\Common\Collections\ArrayCollection;
 
 class MoneyAccountDailyBalanceRepository extends ServiceEntityRepository
 {
@@ -23,11 +21,11 @@ class MoneyAccountDailyBalanceRepository extends ServiceEntityRepository
             ->where('b.company = :company')
             ->andWhere('b.moneyAccount = :account')
             ->andWhere('b.date < :date')
-            ->setParameters(new ArrayCollection([
+            ->setParameters([
                 'company' => $company,
                 'account' => $account,
                 'date' => $date->setTime(0,0)
-            ]))
+            ])
             ->orderBy('b.date', 'DESC')
             ->setMaxResults(1)
             ->getQuery()->getOneOrNullResult();

--- a/site/src/Service/AccountBalanceService.php
+++ b/site/src/Service/AccountBalanceService.php
@@ -8,8 +8,6 @@ use App\Entity\Company;
 use App\Entity\MoneyAccount;
 use App\Repository\CashTransactionRepository;
 use App\Repository\MoneyAccountDailyBalanceRepository;
-use Ramsey\Uuid\Uuid;
-use Doctrine\Common\Collections\ArrayCollection;
 
 class AccountBalanceService
 {
@@ -48,7 +46,7 @@ class AccountBalanceService
         $snapshots = $this->balanceRepo->createQueryBuilder('b')
             ->where('b.company = :c')->andWhere('b.moneyAccount = :a')
             ->andWhere('b.date BETWEEN :f AND :t')
-            ->setParameters(new ArrayCollection(['c'=>$company,'a'=>$account,'f'=>$from,'t'=>$to]))
+            ->setParameters(['c'=>$company,'a'=>$account,'f'=>$from,'t'=>$to])
             ->orderBy('b.date','ASC')
             ->getQuery()->getResult();
         $balances = [];


### PR DESCRIPTION
## Summary
- avoid passing `ArrayCollection` with raw values to Doctrine query builders
- replace with simple arrays to prevent `getType` errors on entities

## Testing
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b99dd402188323aba89bae3ddb8de5