### PR TITLE
Add money account setter to CashTransaction

### DIFF
--- a/site/src/Entity/CashTransaction.php
+++ b/site/src/Entity/CashTransaction.php
@@ -84,6 +84,7 @@ class CashTransaction
     public function getId(): ?string { return $this->id; }
     public function getCompany(): Company { return $this->company; }
     public function getMoneyAccount(): MoneyAccount { return $this->moneyAccount; }
+    public function setMoneyAccount(MoneyAccount $a): self { $this->moneyAccount = $a; return $this; }
     public function getCounterparty(): ?Counterparty { return $this->counterparty; }
     public function setCounterparty(?Counterparty $c): self { $this->counterparty = $c; return $this; }
     public function getCashflowCategory(): ?CashflowCategory { return $this->cashflowCategory; }


### PR DESCRIPTION
## Summary
- add MoneyAccount setter to CashTransaction entity so service can update account

## Testing
- `composer install --no-interaction --no-scripts` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c25a06a48323821b26a713805d53