### PR TITLE
fix: correct query parameters collection type

### DIFF
--- a/site/src/Repository/MoneyAccountDailyBalanceRepository.php
+++ b/site/src/Repository/MoneyAccountDailyBalanceRepository.php
@@ -21,11 +21,9 @@ class MoneyAccountDailyBalanceRepository extends ServiceEntityRepository
             ->where('b.company = :company')
             ->andWhere('b.moneyAccount = :account')
             ->andWhere('b.date < :date')
-            ->setParameters([
-                'company' => $company,
-                'account' => $account,
-                'date' => $date->setTime(0,0)
-            ])
+            ->setParameter('company', $company)
+            ->setParameter('account', $account)
+            ->setParameter('date', $date->setTime(0,0))
             ->orderBy('b.date', 'DESC')
             ->setMaxResults(1)
             ->getQuery()->getOneOrNullResult();


### PR DESCRIPTION
## Summary
- replace `setParameters` array usage with individual `setParameter` calls in `MoneyAccountDailyBalanceRepository`

## Testing
- `php -l site/src/Repository/MoneyAccountDailyBalanceRepository.php`
- `composer install` *(fails: requires GitHub token)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c741c1c88323a82f79ee9e08ca11