### PR TITLE
Fix parameter handling in cash transaction repository

### DIFF
--- a/site/src/Repository/CashTransactionRepository.php
+++ b/site/src/Repository/CashTransactionRepository.php
@@ -27,12 +27,10 @@ class CashTransactionRepository extends ServiceEntityRepository
             ->where('t.company = :company')
             ->andWhere('t.moneyAccount = :account')
             ->andWhere('t.occurredAt BETWEEN :from AND :to')
-            ->setParameters([
-                'company' => $company,
-                'account' => $account,
-                'from' => $from->setTime(0,0),
-                'to' => $to->setTime(23,59,59),
-            ])
+            ->setParameter('company', $company)
+            ->setParameter('account', $account)
+            ->setParameter('from', $from->setTime(0, 0))
+            ->setParameter('to', $to->setTime(23, 59, 59))
             ->groupBy('date')
             ->orderBy('date', 'ASC');
         return $qb->getQuery()->getArrayResult();


### PR DESCRIPTION
## Summary
- fix Doctrine QueryBuilder parameter setup in CashTransactionRepository

## Testing
- `php -l site/src/Repository/CashTransactionRepository.php`
- `composer install --no-interaction` *(fails: CONNECT tunnel failed 403)*
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ca290d70832397c16acf365d1c86