### PR TITLE
Fix DATE function usage in CashTransactionRepository

### DIFF
--- a/site/src/Repository/CashTransactionRepository.php
+++ b/site/src/Repository/CashTransactionRepository.php
@@ -21,7 +21,7 @@ class CashTransactionRepository extends ServiceEntityRepository
     public function sumByDay(Company $company, MoneyAccount $account, \DateTimeImmutable $from, \DateTimeImmutable $to): array
     {
         $qb = $this->createQueryBuilder('t')
-            ->select("DATE(t.occurredAt) as date",
+            ->select("DATE_FORMAT(t.occurredAt, '%Y-%m-%d') as date",
                 "SUM(CASE WHEN t.direction = 'INFLOW' THEN t.amount ELSE 0 END) as inflow",
                 "SUM(CASE WHEN t.direction = 'OUTFLOW' THEN t.amount ELSE 0 END) as outflow")
             ->where('t.company = :company')


### PR DESCRIPTION
## Summary
- replace unsupported DATE function with DATE_FORMAT in CashTransactionRepository to avoid DQL error when grouping by day

## Testing
- `php bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script; dependencies not installed)*
- `composer install` *(fails: failed to download packages from GitHub: 403 response requiring token)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d3288bf483238509cd754a09da8b