### PR TITLE
Fix date grouping in cash transaction summary

### DIFF
--- a/site/src/Repository/CashTransactionRepository.php
+++ b/site/src/Repository/CashTransactionRepository.php
@@ -21,9 +21,11 @@ class CashTransactionRepository extends ServiceEntityRepository
     public function sumByDay(Company $company, MoneyAccount $account, \DateTimeImmutable $from, \DateTimeImmutable $to): array
     {
         $qb = $this->createQueryBuilder('t')
-            ->select("DATE_FORMAT(t.occurredAt, '%Y-%m-%d') as date",
+            ->select(
+                'DATE(t.occurredAt) as date',
                 "SUM(CASE WHEN t.direction = 'INFLOW' THEN t.amount ELSE 0 END) as inflow",
-                "SUM(CASE WHEN t.direction = 'OUTFLOW' THEN t.amount ELSE 0 END) as outflow")
+                "SUM(CASE WHEN t.direction = 'OUTFLOW' THEN t.amount ELSE 0 END) as outflow"
+            )
             ->where('t.company = :company')
             ->andWhere('t.moneyAccount = :account')
             ->andWhere('t.occurredAt BETWEEN :from AND :to')


### PR DESCRIPTION
## Summary
- group cash transactions by date using Doctrine's `DATE` function instead of unsupported `DATE_FORMAT`

## Testing
- `composer install` *(fails: curl error 56 while downloading symfony/flex - CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6f330b788323adf5e1d6d501aed8