### PR TITLE
Fix date grouping in cash transaction query

### DIFF
--- a/site/src/Repository/CashTransactionRepository.php
+++ b/site/src/Repository/CashTransactionRepository.php
@@ -33,8 +33,8 @@ class CashTransactionRepository extends ServiceEntityRepository
             ->setParameter('account', $account)
             ->setParameter('from', $from->setTime(0, 0))
             ->setParameter('to', $to->setTime(23, 59, 59))
-            ->groupBy('date')
-            ->orderBy('date', 'ASC');
+            ->groupBy('DATE(t.occurredAt)')
+            ->orderBy('DATE(t.occurredAt)', 'ASC');
         return $qb->getQuery()->getArrayResult();
     }
 }


### PR DESCRIPTION
## Summary
- avoid DATE_FORMAT DQL error by grouping and ordering using DATE expression on occurredAt

## Testing
- `php bin/phpunit` (fails: Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`)


------
https://chatgpt.com/codex/tasks/task_e_68ba7868bc3483239efc35c52af11757