### PR TITLE
Fix CashTransactionRepository grouping by alias

### DIFF
--- a/site/src/Repository/CashTransactionRepository.php
+++ b/site/src/Repository/CashTransactionRepository.php
@@ -33,8 +33,8 @@ class CashTransactionRepository extends ServiceEntityRepository
             ->setParameter('account', $account)
             ->setParameter('from', $from->setTime(0, 0))
             ->setParameter('to', $to->setTime(23, 59, 59))
-            ->groupBy("SUBSTRING(t.occurredAt, 1, 10)")
-            ->orderBy("SUBSTRING(t.occurredAt, 1, 10)", 'ASC');
+            ->groupBy('date')
+            ->orderBy('date', 'ASC');
         return $qb->getQuery()->getArrayResult();
     }
 }


### PR DESCRIPTION
## Summary
- group and order cash transaction sums by date alias instead of substring expression

## Testing
- `composer install --no-interaction` (fails: CONNECT tunnel failed, response 403)
- `vendor/bin/phpunit` (fails: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68ba8e09acc08323a7eda857af5b911c