### PR TITLE
Fix date extraction in cash transaction query

### DIFF
--- a/site/src/Repository/CashTransactionRepository.php
+++ b/site/src/Repository/CashTransactionRepository.php
@@ -22,7 +22,7 @@ class CashTransactionRepository extends ServiceEntityRepository
     {
         $qb = $this->createQueryBuilder('t')
             ->select(
-                "SUBSTRING(t.occurredAt, 1, 10) as date",
+                "DATE(t.occurredAt) as date",
                 "SUM(CASE WHEN t.direction = 'INFLOW' THEN t.amount ELSE 0 END) as inflow",
                 "SUM(CASE WHEN t.direction = 'OUTFLOW' THEN t.amount ELSE 0 END) as outflow"
             )


### PR DESCRIPTION
## Summary
- avoid PostgreSQL substring on date by casting occurredAt to DATE for daily sums

## Testing
- `php bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`)*
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ba98da43908323aa8afb28334af99f