### PR TITLE
Fix map key type for daily balance recalculation

### DIFF
--- a/site/src/Service/AccountBalanceService.php
+++ b/site/src/Service/AccountBalanceService.php
@@ -66,7 +66,8 @@ class AccountBalanceService
         $txAgg = $this->txRepo->sumByDay($company, $account, $from, $to);
         $map = [];
         foreach ($txAgg as $row) {
-            $map[$row['date']] = $row;
+            $dateKey = $row['date'] instanceof \DateTimeInterface ? $row['date']->format('Y-m-d') : $row['date'];
+            $map[$dateKey] = $row;
         }
         $current = clone $from;
         while ($current <= $to) {


### PR DESCRIPTION
## Summary
- avoid illegal offset type by converting DateTime to string when mapping tx sums

## Testing
- `php bin/phpunit` *(fails: Unable to find the simple-phpunit.php script in vendor/symfony/phpunit-bridge/bin/)*
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68baa37eae1c8323872395eef86f2f5e