### PR TITLE
Fix BC math function references in account balance services

### DIFF
--- a/site/src/DTO/DailyBalancesDTO.php
+++ b/site/src/DTO/DailyBalancesDTO.php
@@ -2,6 +2,8 @@
 
 namespace App\DTO;
 
+use function bcadd;
+
 class DailyBalancesDTO
 {
     /** @var list<MoneyBalanceDTO> */

--- a/site/src/Service/AccountBalanceService.php
+++ b/site/src/Service/AccountBalanceService.php
@@ -8,6 +8,8 @@ use App\Entity\Company;
 use App\Entity\MoneyAccount;
 use App\Repository\CashTransactionRepository;
 use App\Repository\MoneyAccountDailyBalanceRepository;
+use function bcadd;
+use function bcsub;
 
 class AccountBalanceService
 {


### PR DESCRIPTION
## Summary
- import `bcadd`/`bcsub` functions so they resolve correctly inside namespaces

## Testing
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68baa664b6b88323a31f487f9ea65c2e