### PR TITLE
Install bcmath extension

### DIFF
--- a/site/composer.json
+++ b/site/composer.json
@@ -7,6 +7,7 @@
         "php": ">=8.2",
         "ext-ctype": "*",
         "ext-iconv": "*",
+        "ext-bcmath": "*",
         "doctrine/dbal": "^3",
         "doctrine/doctrine-bundle": "^2.15",
         "doctrine/doctrine-migrations-bundle": "^3.4",

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8fc3b353aabf8730e624003e1f313bd2",
+    "content-hash": "629c7518a5e1db863f0401860c87f1cb",
     "packages": [
         {
             "name": "brick/math",
@@ -10291,7 +10291,8 @@
     "platform": {
         "php": ">=8.2",
         "ext-ctype": "*",
-        "ext-iconv": "*"
+        "ext-iconv": "*",
+        "ext-bcmath": "*"
     },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"

--- a/site/docker/development/php-cli/Dockerfile
+++ b/site/docker/development/php-cli/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache libpq-dev bash coreutils git linux-headers \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
     && git clone --branch $XDEBUG_VERSION --depth 1 https://github.com/xdebug/xdebug.git /usr/src/php/ext/xdebug \
     && docker-php-ext-configure xdebug --enable-xdebug-dev \
-    && docker-php-ext-install pdo_pgsql xdebug \
+    && docker-php-ext-install pdo_pgsql xdebug bcmath \
     && apk del git linux-headers
 
 RUN mv $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini

--- a/site/docker/development/php-fpm/Dockerfile
+++ b/site/docker/development/php-fpm/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache libpq-dev fcgi git linux-headers \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
     && git clone --branch $XDEBUG_VERSION --depth 1 https://github.com/xdebug/xdebug.git /usr/src/php/ext/xdebug \
     && docker-php-ext-configure xdebug --enable-xdebug-dev \
-    && docker-php-ext-install pdo_pgsql xdebug \
+    && docker-php-ext-install pdo_pgsql xdebug bcmath \
     && apk del git linux-headers
 
 RUN mv $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini

--- a/site/docker/production/php-cli/Dockerfile
+++ b/site/docker/production/php-cli/Dockerfile
@@ -23,7 +23,7 @@ FROM php:8.2-cli-alpine
 
 RUN apk add --no-cache libpq-dev bash coreutils \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
-    && docker-php-ext-install pdo_pgsql opcache
+    && docker-php-ext-install pdo_pgsql opcache bcmath
 
 RUN mv $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
 

--- a/site/docker/production/php-fpm/Dockerfile
+++ b/site/docker/production/php-fpm/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.2-cli-alpine AS builder
 
 RUN apk add --no-cache libpq-dev \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
-    && docker-php-ext-install pdo_pgsql opcache
+    && docker-php-ext-install pdo_pgsql opcache bcmath
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
 
@@ -22,7 +22,7 @@ FROM php:8.2-fpm-alpine
 
 RUN apk add --no-cache libpq-dev fcgi \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
-    && docker-php-ext-install pdo_pgsql opcache
+    && docker-php-ext-install pdo_pgsql opcache bcmath
 
 RUN mv $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
 


### PR DESCRIPTION
## Summary
- require `ext-bcmath` for precise arithmetic
- install bcmath extension in PHP CLI/FPM Docker images

## Testing
- `composer update ext-bcmath --no-interaction --no-progress` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68baa80f6f6483238ceaec2203e1d13f