### PR TITLE
feat: enable bcmath extension in nginx builder

### DIFF
--- a/site/docker/production/nginx/Dockerfile
+++ b/site/docker/production/nginx/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.2-cli-alpine AS builder
 
 RUN apk add --no-cache libpq-dev \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
-    && docker-php-ext-install pdo_pgsql opcache
+    && docker-php-ext-install pdo_pgsql opcache bcmath
 
 ENV APP_ENV prod
 ENV COMPOSER_ALLOW_SUPERUSER 1


### PR DESCRIPTION
## Summary
- install PHP bcmath extension in nginx builder image

## Testing
- `composer validate --strict`
- `docker build -f docker/production/nginx/Dockerfile .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baa9fcd1608323a2386df7d8854ad7