### PR TITLE
Fix direction display for cash transactions

### DIFF
--- a/site/templates/transaction/index.html.twig
+++ b/site/templates/transaction/index.html.twig
@@ -44,7 +44,9 @@
                     <td>{{ tx.occurredAt|date('d.m.Y') }}</td>
                     <td>{{ tx.moneyAccount.name }}</td>
                     <td>
-                        <span class="badge bg-{{ tx.direction == 'INFLOW' ? 'success' : 'danger' }}">{{ tx.direction == 'INFLOW' ? 'Приток' : 'Отток' }}</span>
+                        <span class="badge bg-{{ tx.direction.value == 'INFLOW' ? 'success' : 'danger' }}">
+                            {{ tx.direction.value == 'INFLOW' ? 'Приток' : 'Отток' }}
+                        </span>
                     </td>
                     <td class="text-end">{{ tx.amount|number_format(2, ',', ' ') }} {{ tx.currency }}</td>
                     <td>


### PR DESCRIPTION
## Summary
- fix cash transaction direction display to correctly show inflow or outflow

## Testing
- `php bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`)*

------
https://chatgpt.com/codex/tasks/task_e_68bab813a99c8323bc22c512559d65c5