### PR TITLE
Make workspace responsive to screen resolution

### DIFF
--- a/site/assets/styles/app.css
+++ b/site/assets/styles/app.css
@@ -1,3 +1,19 @@
 body {
     background-color: white;
 }
+
+.page-body .container {
+    padding: 1rem;
+}
+
+@media (min-width: 768px) {
+    .page-body .container {
+        padding: 2rem;
+    }
+}
+
+@media (min-width: 1200px) {
+    .page-body .container {
+        padding: 3rem;
+    }
+}

--- a/site/templates/base.html.twig
+++ b/site/templates/base.html.twig
@@ -2,6 +2,7 @@
 <html lang="ru">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}Сервис{% endblock %}</title>
     {% block styles %}
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.2.0/dist/css/tabler.min.css"/>
@@ -13,13 +14,13 @@
     {% include 'partials/_sidebar.html.twig' %}
     <div class="page-wrapper">
         <header class="navbar navbar-expand-md d-print-none">
-            <div class="container-xl d-flex justify-content-between align-items-center">
+            <div class="container d-flex justify-content-between align-items-center">
                 <h1 class="navbar-brand">Сервис</h1>
                 {% include 'partials/_active_company_widget.html.twig' %}
             </div>
         </header>
         <div class="page-body">
-            <div class="container-xl">
+            <div class="container">
                 {% block breadcrumbs %}{% endblock %}
                 {{ include('partials/_flash.html.twig') }}
                 {% block content %}{% block body %}{% endblock %}{% endblock %}

--- a/site/templates/security/base.html.twig
+++ b/site/templates/security/base.html.twig
@@ -2,6 +2,7 @@
 <html lang="RU">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}Welcome!{% endblock %}</title>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>⚫️</text><text y=%221.3em%22 x=%220.2em%22 font-size=%2276%22 fill=%22%23fff%22>sf</text></svg>">
     {% block stylesheets %}
@@ -16,7 +17,7 @@
 <header class="navbar-expand-md">
     <div class="page-wrapper">
         <div class="page-body">
-            <div class="container-xl">
+            <div class="container">
                 {% block body %}{% endblock %}
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add viewport meta tag for mobile-friendly layouts
- use responsive container classes in templates
- adjust workspace padding with CSS media queries

## Testing
- `php bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`)*
- `composer install --no-interaction --no-progress` *(fails: curl error 56: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bab9b8772883238c715cff9ade941d