### PR TITLE
Add getter for money account in daily balance entity

### DIFF
--- a/site/src/Entity/MoneyAccountDailyBalance.php
+++ b/site/src/Entity/MoneyAccountDailyBalance.php
@@ -55,7 +55,7 @@ class MoneyAccountDailyBalance
         $this->closingBalance = $closing;
         $this->currency = strtoupper($currency);
     }
-
+    public function getMoneyAccount(): MoneyAccount { return $this->moneyAccount; }
     public function getDate(): \DateTimeImmutable { return $this->date; }
     public function getOpeningBalance(): string { return $this->openingBalance; }
     public function getInflow(): string { return $this->inflow; }


### PR DESCRIPTION
## Summary
- expose associated MoneyAccount on MoneyAccountDailyBalance so report can access account ID

## Testing
- `composer install` *(fails: CONNECT tunnel failed, GitHub token required)*


------
https://chatgpt.com/codex/tasks/task_e_68bacba938dc8323a23a0e2d0bacb0de