### PR TITLE
Implement account balances report

### DIFF
--- a/site/src/Controller/Finance/ReportAccountBalancesController.php
+++ b/site/src/Controller/Finance/ReportAccountBalancesController.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Controller\Finance;
+
+use App\Entity\MoneyAccount;
+use App\Enum\MoneyAccountType;
+use App\Repository\MoneyAccountDailyBalanceRepository;
+use App\Repository\MoneyAccountRepository;
+use App\Service\ActiveCompanyService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/finance/reports/account-balances')]
+class ReportAccountBalancesController extends AbstractController
+{
+    public function __construct(
+        private ActiveCompanyService $activeCompanyService,
+        private MoneyAccountRepository $accountRepository,
+        private MoneyAccountDailyBalanceRepository $balanceRepository
+    ) {
+    }
+
+    #[Route('', name: 'report_account_balances_index', methods: ['GET'])]
+    public function index(Request $request): Response
+    {
+        $company = $this->activeCompanyService->getActiveCompany();
+
+        $dateParam = $request->query->get('date');
+        $date = $dateParam ? (new \DateTimeImmutable($dateParam))->setTime(0, 0) : new \DateTimeImmutable('today');
+
+        $accounts = $this->accountRepository->findBy(
+            ['company' => $company, 'isActive' => true],
+            ['type' => 'ASC', 'name' => 'ASC']
+        );
+
+        $accountsByCurrency = [];
+        $accountIds = [];
+        foreach ($accounts as $account) {
+            /** @var MoneyAccount $account */
+            $currency = $account->getCurrency();
+            if (!isset($accountsByCurrency[$currency])) {
+                $accountsByCurrency[$currency] = [
+                    MoneyAccountType::BANK->value => [],
+                    MoneyAccountType::CASH->value => [],
+                    MoneyAccountType::EWALLET->value => [],
+                ];
+            }
+            $accountsByCurrency[$currency][$account->getType()->value][] = $account;
+            $accountIds[] = $account->getId();
+        }
+
+        $balancesByAccountId = [];
+        if ($accountIds) {
+            $qb = $this->balanceRepository->createQueryBuilder('b')
+                ->innerJoin('b.moneyAccount', 'a')
+                ->addSelect('a')
+                ->where('b.company = :company')
+                ->andWhere('b.date <= :date')
+                ->andWhere('a.id IN (:accountIds)')
+                ->setParameter('company', $company)
+                ->setParameter('date', $date)
+                ->setParameter('accountIds', $accountIds)
+                ->orderBy('a.id', 'ASC')
+                ->addOrderBy('b.date', 'DESC');
+
+            $rows = $qb->getQuery()->getResult();
+            foreach ($rows as $row) {
+                /** @var \App\Entity\MoneyAccountDailyBalance $row */
+                $accId = $row->getMoneyAccount()->getId();
+                if (!isset($balancesByAccountId[$accId])) {
+                    $balancesByAccountId[$accId] = $row->getClosingBalance();
+                }
+            }
+        }
+
+        $totalsByCurrency = [];
+        foreach ($accountsByCurrency as $currency => $groups) {
+            $totalsByType = [
+                MoneyAccountType::BANK->value => '0.00',
+                MoneyAccountType::CASH->value => '0.00',
+                MoneyAccountType::EWALLET->value => '0.00',
+            ];
+            foreach ($groups as $type => $accs) {
+                foreach ($accs as $acc) {
+                    /** @var MoneyAccount $acc */
+                    $balance = $balancesByAccountId[$acc->getId()] ?? '0.00';
+                    $totalsByType[$type] = bcadd($totalsByType[$type], $balance, 2);
+                }
+            }
+            $totalCompany = bcadd(
+                bcadd($totalsByType[MoneyAccountType::BANK->value], $totalsByType[MoneyAccountType::CASH->value], 2),
+                $totalsByType[MoneyAccountType::EWALLET->value],
+                2
+            );
+            $totalsByCurrency[$currency] = [
+                'totalsByType' => $totalsByType,
+                'totalCompany' => $totalCompany,
+            ];
+        }
+
+        return $this->render('report/account_balances.html.twig', [
+            'company' => $company,
+            'date' => $date,
+            'accountsByCurrency' => $accountsByCurrency,
+            'balancesByAccountId' => $balancesByAccountId,
+            'totalsByCurrency' => $totalsByCurrency,
+        ]);
+    }
+}

--- a/site/templates/partials/_sidebar.html.twig
+++ b/site/templates/partials/_sidebar.html.twig
@@ -27,7 +27,7 @@
                     </a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="#">
+                    <a class="nav-link {{ current_route starts with 'report_account_balances' ? 'active' }}" href="{{ path('report_account_balances_index') }}">
                         <span class="nav-link-title">Остатки по счетам</span>
                     </a>
                 </li>

--- a/site/templates/report/account_balances.html.twig
+++ b/site/templates/report/account_balances.html.twig
@@ -1,0 +1,79 @@
+{% extends 'base.html.twig' %}
+
+{% block breadcrumbs %}
+    {% include 'partials/_breadcrumbs.html.twig' with {
+        breadcrumbs: [
+            {'label': 'Главная', 'path': 'app_home_index'},
+            {'label': 'Финансы'},
+            {'label': 'Остатки по счетам / кассам / кошелькам', 'path': 'report_account_balances_index'}
+        ]
+    } %}
+{% endblock %}
+
+{% block content %}
+<div class="d-flex align-items-center mb-3">
+    <h2 class="page-title">Остатки по счетам / кассам / кошелькам</h2>
+</div>
+
+<form method="get" class="row g-2 mb-3">
+    <div class="col-auto">
+        <input type="date" name="date" value="{{ date|date('Y-m-d') }}" class="form-control"/>
+    </div>
+    <div class="col-auto">
+        <button type="submit" class="btn btn-primary">Показать</button>
+    </div>
+</form>
+
+{% set typeLabels = {'bank': 'Банк', 'cash': 'Касса', 'ewallet': 'Кошелёк'} %}
+
+{% for currency, groups in accountsByCurrency %}
+    <div class="card mb-4">
+        <div class="card-header">
+            <h3 class="card-title">Валюта: {{ currency }}</h3>
+        </div>
+        <div class="table-responsive">
+            <table class="table table-bordered table-striped">
+                <thead>
+                <tr>
+                    <th>Тип</th>
+                    <th>Счёт</th>
+                    <th>Остаток</th>
+                </tr>
+                </thead>
+                <tbody>
+                {% for type, accounts in groups %}
+                    {% if accounts|length > 0 %}
+                        {% for account in accounts %}
+                            <tr>
+                                {% if loop.first %}
+                                    <td rowspan="{{ accounts|length }}" class="align-middle">{{ typeLabels[type] }}</td>
+                                {% endif %}
+                                <td>{{ account.name }}</td>
+                                {% set bal = balancesByAccountId[account.id]|default('0') %}
+                                <td class="text-end">{{ bal|number_format(2, '.', ' ') }}</td>
+                            </tr>
+                        {% endfor %}
+                    {% endif %}
+                {% endfor %}
+                <tr>
+                    <td colspan="2" class="text-end">Подытог Банк</td>
+                    <td class="text-end">{{ totalsByCurrency[currency].totalsByType.bank|number_format(2, '.', ' ') }}</td>
+                </tr>
+                <tr>
+                    <td colspan="2" class="text-end">Подытог Касса</td>
+                    <td class="text-end">{{ totalsByCurrency[currency].totalsByType.cash|number_format(2, '.', ' ') }}</td>
+                </tr>
+                <tr>
+                    <td colspan="2" class="text-end">Подытог Кошелёк</td>
+                    <td class="text-end">{{ totalsByCurrency[currency].totalsByType.ewallet|number_format(2, '.', ' ') }}</td>
+                </tr>
+                <tr>
+                    <td colspan="2" class="text-end fw-bold">Итог по компании ({{ currency }})</td>
+                    <td class="text-end fw-bold">{{ totalsByCurrency[currency].totalCompany|number_format(2, '.', ' ') }}</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+{% endfor %}
+{% endblock %}

--- a/site/tests/Controller/ReportAccountBalancesControllerTest.php
+++ b/site/tests/Controller/ReportAccountBalancesControllerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Entity\Company;
+use App\Entity\MoneyAccount;
+use App\Entity\MoneyAccountDailyBalance;
+use App\Entity\User;
+use App\Enum\MoneyAccountType;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class ReportAccountBalancesControllerTest extends WebTestCase
+{
+    public function testIndex(): void
+    {
+        $client = static::createClient();
+        $container = static::getContainer();
+        $em = $container->get('doctrine.orm.entity_manager');
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $em->createQuery('DELETE FROM App\\Entity\\MoneyAccountDailyBalance b')->execute();
+        $em->createQuery('DELETE FROM App\\Entity\\MoneyAccount a')->execute();
+        $em->createQuery('DELETE FROM App\\Entity\\Company c')->execute();
+        $em->createQuery('DELETE FROM App\\Entity\\User u')->execute();
+
+        $user = new User(Uuid::uuid4()->toString());
+        $user->setEmail('test@example.com');
+        $user->setPassword($hasher->hashPassword($user, 'password'));
+        $company = new Company(Uuid::uuid4()->toString(), $user);
+        $company->setName('TestCo');
+        $account = new MoneyAccount(Uuid::uuid4()->toString(), $company, MoneyAccountType::BANK, 'Main', 'RUB');
+        $account->setOpeningBalance('0');
+        $account->setOpeningBalanceDate(new \DateTimeImmutable('2024-01-01'));
+        $balance = new MoneyAccountDailyBalance(
+            Uuid::uuid4()->toString(),
+            $company,
+            $account,
+            new \DateTimeImmutable('today'),
+            '0', '0', '0', '100', 'RUB'
+        );
+
+        $em->persist($user);
+        $em->persist($company);
+        $em->persist($account);
+        $em->persist($balance);
+        $em->flush();
+
+        $client->loginUser($user);
+        $client->request('GET', '/finance/reports/account-balances');
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('h2.page-title', 'Остатки по счетам / кассам / кошелькам');
+    }
+}


### PR DESCRIPTION
## Summary
- add report controller to show money account balances by date
- render balances grouped by currency and account type
- link report from sidebar and cover with basic functional test

## Testing
- `php bin/phpunit tests/Controller/ReportAccountBalancesControllerTest.php` *(fails: Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`)*
- `php bin/console lint:twig templates/report/account_balances.html.twig` *(fails: Symfony Runtime is missing. Try running "composer require symfony/runtime".)*

------
https://chatgpt.com/codex/tasks/task_e_68bad432f4a88323a39900886c05d87c