### PR TITLE
Отображать только название статьи в транзакциях

### DIFF
--- a/site/templates/transaction/index.html.twig
+++ b/site/templates/transaction/index.html.twig
@@ -47,15 +47,7 @@
                     <td>{{ tx.moneyAccount.name }}</td>
                     <td class="text-end"><span class="text-{{ tx.direction.value == 'INFLOW' ? 'success' : 'danger' }}">{{ tx.direction.value == 'INFLOW' ? '+' : '-' }}{{ tx.amount|number_format(2, ',', ' ') }} {{ tx.currency }}</span></td>
                     <td>
-                        {% set chain = [] %}
-                        {% set c = tx.cashflowCategory %}
-                        {% for i in 0..10 %}
-                            {% if c %}
-                                {% set chain = [c.name]|merge(chain) %}
-                                {% set c = c.parent %}
-                            {% endif %}
-                        {% endfor %}
-                        {{ chain|join(' / ') }}
+                        {{ tx.cashflowCategory ? tx.cashflowCategory.name : '' }}
                     </td>
                     <td>{{ tx.counterparty ? tx.counterparty.name : '' }}</td>
                     <td>{{ tx.description }}</td>


### PR DESCRIPTION
## Summary
- show only the cashflow category name without full path in the transactions list

## Testing
- `composer install` *(fails: requires GitHub credentials)*
- `php bin/phpunit` *(fails: missing simple-phpunit due to absent vendor)*

------
https://chatgpt.com/codex/tasks/task_e_68baea0d32948323b60be7d4ca66acb0