### PR TITLE
Add account edit with opening balance and Tabler styling

### DIFF
--- a/site/templates/profile/money_account/_form.html.twig
+++ b/site/templates/profile/money_account/_form.html.twig
@@ -1,4 +1,10 @@
 {{ form_start(form) }}
-    {{ form_widget(form) }}
-    <button class="btn btn-primary">Save</button>
+<div class="card">
+    <div class="card-body">
+        {{ form_widget(form) }}
+    </div>
+    <div class="card-footer text-end">
+        <button class="btn btn-primary">{{ button_label|default('Save') }}</button>
+    </div>
+</div>
 {{ form_end(form) }}

--- a/site/templates/profile/money_account/edit.html.twig
+++ b/site/templates/profile/money_account/edit.html.twig
@@ -1,18 +1,18 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}New Account{% endblock %}
+{% block title %}Edit Account{% endblock %}
 
 {% block body %}
     <div class="page-header d-print-none">
         <div class="container-xl">
             <div class="row g-2 align-items-center">
                 <div class="col">
-                    <h2 class="page-title">New Money Account</h2>
+                    <h2 class="page-title">Edit Money Account</h2>
                 </div>
             </div>
         </div>
     </div>
     <div class="container-xl mt-3">
-        {% include 'profile/money_account/_form.html.twig' with {'form': form, 'button_label': 'Create'} %}
+        {% include 'profile/money_account/_form.html.twig' with {'form': form, 'button_label': 'Update'} %}
     </div>
 {% endblock %}

--- a/site/templates/profile/money_account/index.html.twig
+++ b/site/templates/profile/money_account/index.html.twig
@@ -24,6 +24,7 @@
                             <th>Name</th>
                             <th>Type</th>
                             <th>Currency</th>
+                            <th class="w-1"></th>
                         </tr>
                     </thead>
                     <tbody>
@@ -32,10 +33,15 @@
                             <td>{{ acc.name }}</td>
                             <td>{{ acc.type.value }}</td>
                             <td>{{ acc.currency }}</td>
+                            <td class="text-end">
+                                <a href="{{ path('money_account_edit', {'id': acc.id}) }}" class="btn btn-icon" title="Edit">
+                                    <i class="ti ti-pencil"></i>
+                                </a>
+                            </td>
                         </tr>
                     {% else %}
                         <tr>
-                            <td colspan="3" class="text-center">No accounts.</td>
+                            <td colspan="4" class="text-center">No accounts.</td>
                         </tr>
                     {% endfor %}
                     </tbody>


### PR DESCRIPTION
## Summary
- allow editing money accounts with opening balance and date
- recalc daily balances when account data changes
- apply Tabler card styling to account forms and add edit button

## Testing
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*
- `php bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`)*

------
https://chatgpt.com/codex/tasks/task_e_68baf89279a483238f44f365d9382c88