### PR TITLE
Load Tabler icon fonts for account page icons

### DIFF
--- a/site/templates/base.html.twig
+++ b/site/templates/base.html.twig
@@ -6,6 +6,7 @@
     <title>{% block title %}Сервис{% endblock %}</title>
     {% block styles %}
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.2.0/dist/css/tabler.min.css"/>
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@2.39.0/tabler-icons.min.css"/>
         {% block stylesheets %}{% endblock %}
     {% endblock %}
 </head>

--- a/site/templates/security/base.html.twig
+++ b/site/templates/security/base.html.twig
@@ -7,6 +7,7 @@
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>⚫️</text><text y=%221.3em%22 x=%220.2em%22 font-size=%2276%22 fill=%22%23fff%22>sf</text></svg>">
     {% block stylesheets %}
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.2.0/dist/css/tabler.min.css" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@2.39.0/tabler-icons.min.css"/>
     {% endblock %}
 
     {% block javascripts %}


### PR DESCRIPTION
## Summary
- Load Tabler icon fonts in base templates so `ti ti-pencil` icons render correctly

## Testing
- `php bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script; composer install required GitHub token and failed with 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bafb9b43dc8323a119f5aa4a980426