### PR TITLE
Display cashflow categories as hierarchical tree

### DIFF
--- a/site/src/Controller/Finance/CashTransactionController.php
+++ b/site/src/Controller/Finance/CashTransactionController.php
@@ -121,7 +121,7 @@ class CashTransactionController extends AbstractController
         ];
 
         $accounts = $accountRepo->findBy(['company' => $company]);
-        $categories = $categoryRepo->findBy(['company' => $company], ['sort' => 'ASC']);
+        $categories = $categoryRepo->findTreeByCompany($company);
         $counterparties = $counterpartyRepo->findBy(['company' => $company], ['name' => 'ASC']);
 
         return $this->render('transaction/index.html.twig', [
@@ -232,9 +232,10 @@ class CashTransactionController extends AbstractController
             ])
             ->add('cashflowCategory', ChoiceType::class, [
                 'required' => false,
-                'choices' => $categoryRepo->findBy(['company' => $company], ['sort' => 'ASC']),
+                'choices' => $categoryRepo->findTreeByCompany($company),
                 'choice_label' => fn(CashflowCategory $c) => str_repeat(' ', $c->getLevel()-1).$c->getName(),
                 'choice_value' => 'id',
+                'choice_attr' => fn(CashflowCategory $c) => $c->getChildren()->count() > 0 ? ['disabled' => 'disabled'] : [],
                 'data' => $tx->getCashflowCategory(),
                 'mapped' => false,
             ])

--- a/site/src/Form/CashTransactionType.php
+++ b/site/src/Form/CashTransactionType.php
@@ -55,9 +55,10 @@ class CashTransactionType extends AbstractType
             ])
             ->add('cashflowCategory', ChoiceType::class, [
                 'required' => false,
-                'choices' => $company ? $this->categoryRepo->findBy(['company' => $company], ['sort' => 'ASC']) : [],
+                'choices' => $company ? $this->categoryRepo->findTreeByCompany($company) : [],
                 'choice_label' => fn (CashflowCategory $c) => str_repeat(' ', $c->getLevel()-1).$c->getName(),
                 'choice_value' => 'id',
+                'choice_attr' => fn (CashflowCategory $c) => $c->getChildren()->count() > 0 ? ['disabled' => 'disabled'] : [],
                 'mapped' => false,
             ])
             ->add('counterparty', ChoiceType::class, [

--- a/site/src/Repository/CashflowCategoryRepository.php
+++ b/site/src/Repository/CashflowCategoryRepository.php
@@ -30,4 +30,27 @@ class CashflowCategoryRepository extends ServiceEntityRepository
             ->getQuery()
             ->getResult();
     }
+
+    /**
+     * Возвращает список категорий в порядке вложенности
+     *
+     * @return CashflowCategory[]
+     */
+    public function findTreeByCompany(Company $company): array
+    {
+        $roots = $this->findRootByCompany($company);
+        $result = [];
+        foreach ($roots as $root) {
+            $this->collectTree($root, $result);
+        }
+        return $result;
+    }
+
+    private function collectTree(CashflowCategory $category, array &$result): void
+    {
+        $result[] = $category;
+        foreach ($category->getChildren() as $child) {
+            $this->collectTree($child, $result);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Build hierarchical list of cashflow categories in repository
- Render category tree in CashTransaction forms and disable parent nodes
- Show hierarchical categories in transaction list filters

## Testing
- `php -l site/src/Repository/CashflowCategoryRepository.php`
- `php -l site/src/Form/CashTransactionType.php`
- `php -l site/src/Controller/Finance/CashTransactionController.php`
- `composer install --no-interaction --no-progress` *(failed: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bb00437f4c83239ff37813d1178e8d