### PR TITLE
feat: add cash flow report

### DIFF
--- a/site/src/Controller/Finance/ReportCashflowController.php
+++ b/site/src/Controller/Finance/ReportCashflowController.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace App\Controller\Finance;
+
+use App\Repository\CashTransactionRepository;
+use App\Repository\CashflowCategoryRepository;
+use App\Repository\MoneyAccountDailyBalanceRepository;
+use App\Repository\MoneyAccountRepository;
+use App\Service\ActiveCompanyService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/finance/reports/cashflow')]
+class ReportCashflowController extends AbstractController
+{
+    public function __construct(
+        private ActiveCompanyService $activeCompanyService,
+        private CashflowCategoryRepository $categoryRepository,
+        private CashTransactionRepository $transactionRepository,
+        private MoneyAccountRepository $accountRepository,
+        private MoneyAccountDailyBalanceRepository $balanceRepository
+    ) {
+    }
+
+    #[Route('', name: 'report_cashflow_index', methods: ['GET'])]
+    public function index(Request $request): Response
+    {
+        $company = $this->activeCompanyService->getActiveCompany();
+
+        $group = $request->query->get('group', 'month');
+        $fromParam = $request->query->get('from');
+        $toParam = $request->query->get('to');
+        $today = new \DateTimeImmutable('today');
+        $currentQuarter = (int) floor(((int)$today->format('n') - 1) / 3);
+        $quarterStartMonth = $currentQuarter * 3 + 1;
+        $defaultFrom = new \DateTimeImmutable($today->format('Y') . '-' . sprintf('%02d', $quarterStartMonth) . '-01');
+        $defaultTo = $defaultFrom->modify('+3 months -1 day');
+
+        $from = $fromParam ? new \DateTimeImmutable($fromParam) : $defaultFrom;
+        $to = $toParam ? new \DateTimeImmutable($toParam) : $defaultTo;
+        if ($from > $to) {
+            [$from, $to] = [$to, $from];
+        }
+
+        $periods = $this->buildPeriods($from, $to, $group);
+        $periodCount = count($periods);
+
+        // Load categories tree
+        $categories = $this->categoryRepository->findTreeByCompany($company);
+        $categoryMap = [];
+        foreach ($categories as $cat) {
+            $categoryMap[$cat->getId()] = [
+                'entity' => $cat,
+                'totals' => [], // currency => [period => amount]
+            ];
+        }
+
+        // Fetch transactions
+        $rows = $this->transactionRepository->createQueryBuilder('t')
+            ->select('IDENTITY(t.cashflowCategory) AS category', 't.direction', 't.amount', 't.currency', 't.occurredAt')
+            ->where('t.company = :company')
+            ->andWhere('t.occurredAt BETWEEN :from AND :to')
+            ->setParameter('company', $company)
+            ->setParameter('from', $from->setTime(0,0))
+            ->setParameter('to', $to->setTime(23,59,59))
+            ->getQuery()->getArrayResult();
+
+        $companyTotals = [];
+        foreach ($rows as $row) {
+            $catId = $row['category'];
+            if (!$catId || !isset($categoryMap[$catId])) {
+                continue;
+            }
+            $amount = (float) $row['amount'];
+            if ($row['direction'] === 'OUTFLOW') {
+                $amount = -$amount;
+            }
+            $currency = $row['currency'];
+            $periodIndex = $this->findPeriodIndex($periods, $row['occurredAt']);
+            if ($periodIndex === null) {
+                continue;
+            }
+            if (!isset($categoryMap[$catId]['totals'][$currency])) {
+                $categoryMap[$catId]['totals'][$currency] = array_fill(0, $periodCount, 0.0);
+            }
+            $categoryMap[$catId]['totals'][$currency][$periodIndex] += $amount;
+            $companyTotals[$currency][$periodIndex] = ($companyTotals[$currency][$periodIndex] ?? 0) + $amount;
+        }
+
+        // Aggregate totals up the tree
+        foreach (array_reverse($categories) as $cat) {
+            $parent = $cat->getParent();
+            if ($parent && isset($categoryMap[$parent->getId()])) {
+                $childTotals = $categoryMap[$cat->getId()]['totals'];
+                foreach ($childTotals as $currency => $vals) {
+                    if (!isset($categoryMap[$parent->getId()]['totals'][$currency])) {
+                        $categoryMap[$parent->getId()]['totals'][$currency] = array_fill(0, $periodCount, 0.0);
+                    }
+                    foreach ($vals as $idx => $val) {
+                        $categoryMap[$parent->getId()]['totals'][$currency][$idx] += $val;
+                    }
+                }
+            }
+        }
+
+        // Build category tree for template
+        $rootCategories = [];
+        foreach ($categories as $cat) {
+            if (!$cat->getParent()) {
+                $rootCategories[] = $cat;
+            }
+        }
+
+        // Opening balances per currency
+        $accounts = $this->accountRepository->findBy(['company' => $company]);
+        $openingByCurrency = [];
+        foreach ($accounts as $account) {
+            $balance = $this->balanceRepository->findLastBefore($company, $account, $from);
+            if ($balance) {
+                $currency = $account->getCurrency();
+                $openingByCurrency[$currency] = ($openingByCurrency[$currency] ?? 0) + (float) $balance->getClosingBalance();
+            }
+        }
+
+        $openings = [];
+        $closings = [];
+        $currencies = array_unique(array_merge(array_keys($openingByCurrency), array_keys($companyTotals)));
+        foreach ($currencies as $currency) {
+            $opening = $openingByCurrency[$currency] ?? 0.0;
+            $openings[$currency] = [];
+            $closings[$currency] = [];
+            $current = $opening;
+            for ($i = 0; $i < $periodCount; $i++) {
+                $openings[$currency][$i] = $current;
+                $net = $companyTotals[$currency][$i] ?? 0;
+                $current += $net;
+                $closings[$currency][$i] = $current;
+            }
+        }
+
+        return $this->render('report/cashflow.html.twig', [
+            'company' => $company,
+            'group' => $group,
+            'date_from' => $from,
+            'date_to' => $to,
+            'periods' => $periods,
+            'categories' => $rootCategories,
+            'categoryTotals' => $categoryMap,
+            'openings' => $openings,
+            'closings' => $closings,
+        ]);
+    }
+
+    private function buildPeriods(\DateTimeImmutable $from, \DateTimeImmutable $to, string $group): array
+    {
+        $periods = [];
+        $current = $from;
+        while ($current <= $to) {
+            switch ($group) {
+                case 'day':
+                    $start = $current;
+                    $end = $current;
+                    $label = $current->format('d.m.Y');
+                    $current = $current->modify('+1 day');
+                    break;
+                case 'week':
+                    $start = $current;
+                    $end = min($start->modify('+6 days'), $to);
+                    $label = $start->format('d.m') . '-' . $end->format('d.m');
+                    $current = $end->modify('+1 day');
+                    break;
+                case 'quarter':
+                    $startMonth = (int)($current->format('n')); 
+                    $startMonth = (int)floor(($startMonth - 1) / 3) * 3 + 1;
+                    $start = new \DateTimeImmutable($current->format('Y') . '-' . sprintf('%02d', $startMonth) . '-01');
+                    $end = min($start->modify('+3 months -1 day'), $to);
+                    $label = 'Q' . (((int)(($startMonth - 1) / 3)) + 1) . ' ' . $start->format('Y');
+                    $current = $end->modify('+1 day');
+                    break;
+                case 'year':
+                    $start = new \DateTimeImmutable($current->format('Y-01-01'));
+                    $end = min($start->modify('+1 year -1 day'), $to);
+                    $label = $start->format('Y');
+                    $current = $end->modify('+1 day');
+                    break;
+                case 'month':
+                default:
+                    $start = new \DateTimeImmutable($current->format('Y-m-01'));
+                    $end = min($start->modify('+1 month -1 day'), $to);
+                    $label = $start->format('m.Y');
+                    $current = $end->modify('+1 day');
+                    break;
+            }
+            $periods[] = ['label' => $label, 'start' => $start, 'end' => $end];
+        }
+        return $periods;
+    }
+
+    private function findPeriodIndex(array $periods, \DateTimeInterface $date): ?int
+    {
+        foreach ($periods as $idx => $p) {
+            if ($date >= $p['start'] && $date <= $p['end']) {
+                return $idx;
+            }
+        }
+        return null;
+    }
+}

--- a/site/templates/partials/_sidebar.html.twig
+++ b/site/templates/partials/_sidebar.html.twig
@@ -38,7 +38,7 @@
                         <span class="nav-link-title text-muted"> Отчеты </span>
                     </a>
                     <div class="dropdown-menu">
-                        <a class="dropdown-item " href="#">
+                        <a class="dropdown-item {{ current_route starts with 'report_cashflow' ? 'active' : '' }}" href="{{ path('report_cashflow_index') }}">
                             <span class="nav-link-title">Отчет ДДС</span>
                         </a>
                         <a class="dropdown-item " href="#">

--- a/site/templates/report/cashflow.html.twig
+++ b/site/templates/report/cashflow.html.twig
@@ -1,0 +1,91 @@
+{% extends 'base.html.twig' %}
+
+{% block breadcrumbs %}
+    {% include 'partials/_breadcrumbs.html.twig' with {
+        breadcrumbs: [
+            {'label': 'Главная', 'path': 'app_home_index'},
+            {'label': 'Финансы'},
+            {'label': 'Отчет ДДС', 'path': 'report_cashflow_index'}
+        ]
+    } %}
+{% endblock %}
+
+{% block content %}
+<div class="d-flex align-items-center mb-3">
+    <h2 class="page-title">Отчет ДДС</h2>
+</div>
+
+<form method="get" class="row g-2 mb-3">
+    <div class="col-auto">
+        <input type="date" name="from" value="{{ date_from|date('Y-m-d') }}" class="form-control"/>
+    </div>
+    <div class="col-auto">
+        <input type="date" name="to" value="{{ date_to|date('Y-m-d') }}" class="form-control"/>
+    </div>
+    <input type="hidden" name="group" value="{{ group }}" id="group-input"/>
+    <div class="col-auto">
+        <div class="btn-group" role="group">
+            <button type="submit" class="btn btn-outline-primary {% if group == 'day' %}active{% endif %}" onclick="document.getElementById('group-input').value='day'">По дням</button>
+            <button type="submit" class="btn btn-outline-primary {% if group == 'week' %}active{% endif %}" onclick="document.getElementById('group-input').value='week'">По неделям</button>
+            <button type="submit" class="btn btn-outline-primary {% if group == 'month' %}active{% endif %}" onclick="document.getElementById('group-input').value='month'">По месяцам</button>
+            <button type="submit" class="btn btn-outline-primary {% if group == 'quarter' %}active{% endif %}" onclick="document.getElementById('group-input').value='quarter'">По кварталам</button>
+            <button type="submit" class="btn btn-outline-primary {% if group == 'year' %}active{% endif %}" onclick="document.getElementById('group-input').value='year'">По годам</button>
+        </div>
+    </div>
+    <div class="col-auto">
+        <button type="submit" class="btn btn-primary">Показать</button>
+    </div>
+</form>
+
+{% set periodCount = periods|length %}
+{% import _self as macros %}
+
+{% macro render_category(cat, totals, currency, periodCount) %}
+<tr>
+    <td style="padding-left: {{ (cat.level - 1) * 20 }}px">{{ cat.name }}</td>
+    {% for i in 0..periodCount-1 %}
+        <td class="text-end">{{ (totals[cat.id].totals[currency][i] ?? 0)|number_format(2, ',', ' ') }}</td>
+    {% endfor %}
+</tr>
+{% for child in cat.children %}
+    {{ _self.render_category(child, totals, currency, periodCount) }}
+{% endfor %}
+{% endmacro %}
+
+{% for currency, values in openings %}
+    <div class="card mb-4">
+        <div class="card-header">
+            <h3 class="card-title">Валюта: {{ currency }}</h3>
+        </div>
+        <div class="table-responsive">
+            <table class="table table-bordered table-striped">
+                <thead>
+                    <tr>
+                        <th>Категория</th>
+                        {% for p in periods %}
+                            <th>{{ p.label }}</th>
+                        {% endfor %}
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr class="fw-bold">
+                        <td>Сальдо на начало</td>
+                        {% for i in 0..periodCount-1 %}
+                            <td class="text-end">{{ openings[currency][i]|number_format(2, ',', ' ') }}</td>
+                        {% endfor %}
+                    </tr>
+                    {% for cat in categories %}
+                        {{ macros.render_category(cat, categoryTotals, currency, periodCount) }}
+                    {% endfor %}
+                    <tr class="fw-bold">
+                        <td>Сальдо на конец</td>
+                        {% for i in 0..periodCount-1 %}
+                            <td class="text-end">{{ closings[currency][i]|number_format(2, ',', ' ') }}</td>
+                        {% endfor %}
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+{% endfor %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement hierarchical cash flow report with flexible period grouping
- compute opening and closing balances and aggregate totals by category
- add cash flow report link in sidebar menu

## Testing
- `php -d detect_unicode=0 bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script)*
- `composer install` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1c8154f08323b93b57155c575fbd