### PR TITLE
Fix cashflow report outflow sign handling

### DIFF
--- a/site/src/Controller/Finance/ReportCashflowController.php
+++ b/site/src/Controller/Finance/ReportCashflowController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller\Finance;
 
+use App\Enum\CashDirection;
 use App\Repository\CashTransactionRepository;
 use App\Repository\CashflowCategoryRepository;
 use App\Repository\MoneyAccountDailyBalanceRepository;
@@ -74,7 +75,10 @@ class ReportCashflowController extends AbstractController
                 continue;
             }
             $amount = (float) $row['amount'];
-            $amount = $row['direction'] === 'OUTFLOW'
+            $direction = $row['direction'] instanceof CashDirection
+                ? $row['direction']->value
+                : $row['direction'];
+            $amount = $direction === CashDirection::OUTFLOW->value
                 ? -abs($amount)
                 : abs($amount);
             $currency = $row['currency'];


### PR DESCRIPTION
## Summary
- fix cashflow report to treat outflow transactions as negative by handling enum CashDirection

## Testing
- `composer install --no-interaction --no-progress --ansi` *(fails: Failed to clone https://github.com/symfony/runtime.git)*
- `php vendor/bin/phpunit` *(fails: Could not open input file: vendor/bin/phpunit)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2209607083238414fd3cb6186942