### PR TITLE
Add PL categories and documents

### DIFF
--- a/site/migrations/Version20250907000000.php
+++ b/site/migrations/Version20250907000000.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250907000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add PL categories and documents';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE pl_categories (id UUID NOT NULL, company_id UUID NOT NULL, parent_id UUID DEFAULT NULL, name VARCHAR(255) NOT NULL, level INT NOT NULL, sort_order INT NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_PL_CATEGORY_COMPANY ON pl_categories (company_id)');
+        $this->addSql('CREATE INDEX IDX_PL_CATEGORY_PARENT ON pl_categories (parent_id)');
+        $this->addSql('ALTER TABLE pl_categories ADD CONSTRAINT FK_PL_CATEGORY_COMPANY FOREIGN KEY (company_id) REFERENCES companies (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE pl_categories ADD CONSTRAINT FK_PL_CATEGORY_PARENT FOREIGN KEY (parent_id) REFERENCES pl_categories (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
+
+        $this->addSql('CREATE TABLE documents (id UUID NOT NULL, company_id UUID NOT NULL, date TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, number VARCHAR(255) DEFAULT NULL, type VARCHAR(255) NOT NULL, description TEXT DEFAULT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_DOCUMENT_COMPANY ON documents (company_id)');
+        $this->addSql('ALTER TABLE documents ADD CONSTRAINT FK_DOCUMENT_COMPANY FOREIGN KEY (company_id) REFERENCES companies (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+
+        $this->addSql('CREATE TABLE document_operations (id UUID NOT NULL, document_id UUID NOT NULL, category_id UUID NOT NULL, counterparty_id UUID DEFAULT NULL, amount NUMERIC(15, 2) NOT NULL, comment VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_DOC_OPER_DOCUMENT ON document_operations (document_id)');
+        $this->addSql('CREATE INDEX IDX_DOC_OPER_CATEGORY ON document_operations (category_id)');
+        $this->addSql('CREATE INDEX IDX_DOC_OPER_COUNTERPARTY ON document_operations (counterparty_id)');
+        $this->addSql('ALTER TABLE document_operations ADD CONSTRAINT FK_DOC_OPER_DOCUMENT FOREIGN KEY (document_id) REFERENCES documents (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE document_operations ADD CONSTRAINT FK_DOC_OPER_CATEGORY FOREIGN KEY (category_id) REFERENCES pl_categories (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE document_operations ADD CONSTRAINT FK_DOC_OPER_COUNTERPARTY FOREIGN KEY (counterparty_id) REFERENCES counterparties (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE document_operations DROP CONSTRAINT FK_DOC_OPER_DOCUMENT');
+        $this->addSql('ALTER TABLE document_operations DROP CONSTRAINT FK_DOC_OPER_CATEGORY');
+        $this->addSql('ALTER TABLE document_operations DROP CONSTRAINT FK_DOC_OPER_COUNTERPARTY');
+        $this->addSql('ALTER TABLE documents DROP CONSTRAINT FK_DOCUMENT_COMPANY');
+        $this->addSql('ALTER TABLE pl_categories DROP CONSTRAINT FK_PL_CATEGORY_COMPANY');
+        $this->addSql('ALTER TABLE pl_categories DROP CONSTRAINT FK_PL_CATEGORY_PARENT');
+        $this->addSql('DROP TABLE document_operations');
+        $this->addSql('DROP TABLE documents');
+        $this->addSql('DROP TABLE pl_categories');
+    }
+}

--- a/site/src/Controller/DocumentController.php
+++ b/site/src/Controller/DocumentController.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Document;
+use App\Form\DocumentType;
+use App\Repository\DocumentRepository;
+use App\Repository\PLCategoryRepository;
+use App\Repository\CounterpartyRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+use App\Service\ActiveCompanyService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/documents')]
+class DocumentController extends AbstractController
+{
+    #[Route('/', name: 'document_index', methods: ['GET'])]
+    public function index(DocumentRepository $repo, ActiveCompanyService $companyService): Response
+    {
+        $company = $companyService->getActiveCompany();
+        $items = $repo->findByCompany($company);
+        return $this->render('document/index.html.twig', [
+            'items' => $items,
+        ]);
+    }
+
+    #[Route('/new', name: 'document_new', methods: ['GET', 'POST'])]
+    public function new(Request $request, DocumentRepository $repo, PLCategoryRepository $catRepo, CounterpartyRepository $cpRepo, EntityManagerInterface $em, ActiveCompanyService $companyService): Response
+    {
+        $company = $companyService->getActiveCompany();
+        $document = new Document(Uuid::uuid4()->toString(), $company);
+
+        $categories = $catRepo->findTreeByCompany($company);
+        $counterparties = $cpRepo->findBy(['company' => $company]);
+        $form = $this->createForm(DocumentType::class, $document, [
+            'categories' => $categories,
+            'counterparties' => $counterparties,
+        ]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $em->persist($document);
+            $em->flush();
+            return $this->redirectToRoute('document_index');
+        }
+
+        return $this->render('document/new.html.twig', [
+            'form' => $form->createView(),
+        ]);
+    }
+
+    #[Route('/{id}', name: 'document_show', methods: ['GET'])]
+    public function show(Document $document, ActiveCompanyService $companyService): Response
+    {
+        $company = $companyService->getActiveCompany();
+        if ($document->getCompany() !== $company) {
+            throw $this->createNotFoundException();
+        }
+
+        return $this->render('document/show.html.twig', [
+            'item' => $document,
+        ]);
+    }
+
+    #[Route('/{id}/edit', name: 'document_edit', methods: ['GET', 'POST'])]
+    public function edit(Request $request, Document $document, PLCategoryRepository $catRepo, CounterpartyRepository $cpRepo, EntityManagerInterface $em, ActiveCompanyService $companyService): Response
+    {
+        $company = $companyService->getActiveCompany();
+        if ($document->getCompany() !== $company) {
+            throw $this->createNotFoundException();
+        }
+
+        $categories = $catRepo->findTreeByCompany($company);
+        $counterparties = $cpRepo->findBy(['company' => $company]);
+        $form = $this->createForm(DocumentType::class, $document, [
+            'categories' => $categories,
+            'counterparties' => $counterparties,
+        ]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $em->flush();
+            return $this->redirectToRoute('document_index');
+        }
+
+        return $this->render('document/edit.html.twig', [
+            'form' => $form->createView(),
+            'item' => $document,
+        ]);
+    }
+
+    #[Route('/{id}/delete', name: 'document_delete', methods: ['POST'])]
+    public function delete(Request $request, Document $document, EntityManagerInterface $em, ActiveCompanyService $companyService): Response
+    {
+        $company = $companyService->getActiveCompany();
+        if ($document->getCompany() !== $company) {
+            throw $this->createNotFoundException();
+        }
+
+        if ($this->isCsrfTokenValid('delete'.$document->getId(), $request->request->get('_token'))) {
+            $em->remove($document);
+            $em->flush();
+        }
+
+        return $this->redirectToRoute('document_index');
+    }
+}

--- a/site/src/Controller/PLCategoryController.php
+++ b/site/src/Controller/PLCategoryController.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\PLCategory;
+use App\Form\PLCategoryType;
+use App\Repository\PLCategoryRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+use App\Service\ActiveCompanyService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/pl-categories')]
+class PLCategoryController extends AbstractController
+{
+    #[Route('/', name: 'pl_category_index', methods: ['GET'])]
+    public function index(PLCategoryRepository $repo, ActiveCompanyService $companyService): Response
+    {
+        $company = $companyService->getActiveCompany();
+        $items = $repo->findRootByCompany($company);
+        return $this->render('pl_category/index.html.twig', [
+            'items' => $items,
+        ]);
+    }
+
+    #[Route('/new', name: 'pl_category_new', methods: ['GET', 'POST'])]
+    public function new(Request $request, PLCategoryRepository $repo, EntityManagerInterface $em, ActiveCompanyService $companyService): Response
+    {
+        $company = $companyService->getActiveCompany();
+        $category = new PLCategory(Uuid::uuid4()->toString(), $company);
+
+        $parents = $repo->findTreeByCompany($company);
+        $form = $this->createForm(PLCategoryType::class, $category, ['parents' => $parents]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            if ($category->getParent() && $category->getParent()->getLevel() >= 5) {
+                $this->addFlash('danger', 'Максимальная вложенность — 5 уровней');
+            } else {
+                $em->persist($category);
+                $em->flush();
+                return $this->redirectToRoute('pl_category_index');
+            }
+        }
+
+        return $this->render('pl_category/new.html.twig', [
+            'form' => $form->createView(),
+        ]);
+    }
+
+    #[Route('/{id}/edit', name: 'pl_category_edit', methods: ['GET', 'POST'])]
+    public function edit(Request $request, PLCategory $category, PLCategoryRepository $repo, EntityManagerInterface $em, ActiveCompanyService $companyService): Response
+    {
+        $company = $companyService->getActiveCompany();
+        if ($category->getCompany() !== $company) {
+            throw $this->createNotFoundException();
+        }
+
+        $parents = $repo->findTreeByCompany($company);
+        $form = $this->createForm(PLCategoryType::class, $category, ['parents' => $parents]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            if ($category->getParent() && $category->getParent()->getLevel() >= 5) {
+                $this->addFlash('danger', 'Максимальная вложенность — 5 уровней');
+            } else {
+                $em->flush();
+                return $this->redirectToRoute('pl_category_index');
+            }
+        }
+
+        return $this->render('pl_category/edit.html.twig', [
+            'form' => $form->createView(),
+            'item' => $category,
+        ]);
+    }
+
+    #[Route('/{id}/delete', name: 'pl_category_delete', methods: ['POST'])]
+    public function delete(Request $request, PLCategory $category, EntityManagerInterface $em, ActiveCompanyService $companyService): Response
+    {
+        $company = $companyService->getActiveCompany();
+        if ($category->getCompany() !== $company) {
+            throw $this->createNotFoundException();
+        }
+
+        if ($this->isCsrfTokenValid('delete'.$category->getId(), $request->request->get('_token'))) {
+            $em->remove($category);
+            $em->flush();
+        }
+
+        return $this->redirectToRoute('pl_category_index');
+    }
+}

--- a/site/src/Entity/Document.php
+++ b/site/src/Entity/Document.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Webmozart\Assert\Assert;
+use App\Repository\DocumentRepository;
+use App\Entity\Company;
+
+#[ORM\Entity(repositoryClass: DocumentRepository::class)]
+#[ORM\Table(name: 'documents')]
+class Document
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid', unique: true)]
+    private ?string $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Company::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private Company $company;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $date;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $number = null;
+
+    #[ORM\Column(length: 255)]
+    private string $type;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $description = null;
+
+    #[ORM\OneToMany(mappedBy: 'document', targetEntity: DocumentOperation::class, cascade: ['persist', 'remove'], orphanRemoval: true)]
+    private Collection $operations;
+
+    public function __construct(string $id, Company $company)
+    {
+        Assert::uuid($id);
+        $this->id = $id;
+        $this->company = $company;
+        $this->date = new \DateTimeImmutable();
+        $this->operations = new ArrayCollection();
+    }
+
+    public function getId(): ?string { return $this->id; }
+    public function getCompany(): Company { return $this->company; }
+    public function setCompany(Company $company): self { $this->company = $company; return $this; }
+    public function getDate(): \DateTimeImmutable { return $this->date; }
+    public function setDate(\DateTimeImmutable $date): self { $this->date = $date; return $this; }
+    public function getNumber(): ?string { return $this->number; }
+    public function setNumber(?string $number): self { $this->number = $number; return $this; }
+    public function getType(): string { return $this->type; }
+    public function setType(string $type): self { $this->type = $type; return $this; }
+    public function getDescription(): ?string { return $this->description; }
+    public function setDescription(?string $description): self { $this->description = $description; return $this; }
+    /** @return Collection<int, DocumentOperation> */
+    public function getOperations(): Collection { return $this->operations; }
+    public function addOperation(DocumentOperation $op): self
+    {
+        if (!$this->operations->contains($op)) {
+            $this->operations->add($op);
+            $op->setDocument($this);
+        }
+        return $this;
+    }
+    public function removeOperation(DocumentOperation $op): self
+    {
+        if ($this->operations->removeElement($op)) {
+            if ($op->getDocument() === $this) {
+                $op->setDocument(null);
+            }
+        }
+        return $this;
+    }
+}

--- a/site/src/Entity/DocumentOperation.php
+++ b/site/src/Entity/DocumentOperation.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Webmozart\Assert\Assert;
+use App\Repository\DocumentOperationRepository;
+use Ramsey\Uuid\Uuid;
+
+#[ORM\Entity(repositoryClass: DocumentOperationRepository::class)]
+#[ORM\Table(name: 'document_operations')]
+class DocumentOperation
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid', unique: true)]
+    private ?string $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Document::class, inversedBy: 'operations')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Document $document = null;
+
+    #[ORM\ManyToOne(targetEntity: PLCategory::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private PLCategory $category;
+
+    #[ORM\Column(type: 'decimal', precision: 15, scale: 2)]
+    private string $amount;
+
+    #[ORM\ManyToOne(targetEntity: Counterparty::class)]
+    private ?Counterparty $counterparty = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $comment = null;
+
+    public function __construct(?string $id = null)
+    {
+        $id = $id ?? Uuid::uuid4()->toString();
+        Assert::uuid($id);
+        $this->id = $id;
+    }
+
+    public function getId(): ?string { return $this->id; }
+    public function getDocument(): ?Document { return $this->document; }
+    public function setDocument(?Document $document): self { $this->document = $document; return $this; }
+    public function getCategory(): PLCategory { return $this->category; }
+    public function setCategory(PLCategory $category): self { $this->category = $category; return $this; }
+    public function getAmount(): string { return $this->amount; }
+    public function setAmount(string $amount): self { $this->amount = $amount; return $this; }
+    public function getCounterparty(): ?Counterparty { return $this->counterparty; }
+    public function setCounterparty(?Counterparty $counterparty): self { $this->counterparty = $counterparty; return $this; }
+    public function getComment(): ?string { return $this->comment; }
+    public function setComment(?string $comment): self { $this->comment = $comment; return $this; }
+}

--- a/site/src/Entity/PLCategory.php
+++ b/site/src/Entity/PLCategory.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Webmozart\Assert\Assert;
+use App\Repository\PLCategoryRepository;
+use App\Entity\Company;
+
+#[ORM\Entity(repositoryClass: PLCategoryRepository::class)]
+#[ORM\Table(name: 'pl_categories')]
+class PLCategory
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid', unique: true)]
+    private ?string $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Company::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private Company $company;
+
+    #[ORM\Column(length: 255)]
+    private string $name;
+
+    #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
+    private ?self $parent = null;
+
+    #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent')]
+    #[ORM\OrderBy(['sortOrder' => 'ASC'])]
+    private Collection $children;
+
+    #[ORM\Column(type: 'integer')]
+    private int $level = 1;
+
+    #[ORM\Column(type: 'integer')]
+    private int $sortOrder = 0;
+
+    public function __construct(string $id, Company $company)
+    {
+        Assert::uuid($id);
+        $this->id = $id;
+        $this->company = $company;
+        $this->children = new ArrayCollection();
+    }
+
+    public function getId(): ?string { return $this->id; }
+    public function getCompany(): Company { return $this->company; }
+    public function setCompany(Company $company): self { $this->company = $company; return $this; }
+    public function getName(): string { return $this->name; }
+    public function setName(string $name): self { $this->name = $name; return $this; }
+    public function getParent(): ?self { return $this->parent; }
+    public function setParent(?self $parent): self
+    {
+        $this->parent = $parent;
+        $this->level = $parent ? $parent->getLevel() + 1 : 1;
+        Assert::range($this->level, 1, 5);
+        return $this;
+    }
+    public function getChildren(): Collection { return $this->children; }
+    public function getLevel(): int { return $this->level; }
+    public function setLevel(int $level): self { $this->level = $level; return $this; }
+    public function getSortOrder(): int { return $this->sortOrder; }
+    public function setSortOrder(int $sortOrder): self { $this->sortOrder = $sortOrder; return $this; }
+}

--- a/site/src/Form/DocumentOperationType.php
+++ b/site/src/Form/DocumentOperationType.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\DocumentOperation;
+use App\Entity\PLCategory;
+use App\Entity\Counterparty;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class DocumentOperationType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('category', EntityType::class, [
+                'class' => PLCategory::class,
+                'choices' => $options['categories'],
+                'choice_label' => function (PLCategory $item) {
+                    return str_repeat('—', $item->getLevel() - 1) . ' ' . $item->getName();
+                },
+                'label' => 'Категория',
+            ])
+            ->add('amount', NumberType::class, [
+                'label' => 'Сумма',
+            ])
+            ->add('counterparty', EntityType::class, [
+                'class' => Counterparty::class,
+                'choices' => $options['counterparties'],
+                'choice_label' => 'name',
+                'required' => false,
+                'label' => 'Контрагент',
+            ])
+            ->add('comment', TextType::class, [
+                'required' => false,
+                'label' => 'Комментарий',
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => DocumentOperation::class,
+            'categories' => [],
+            'counterparties' => [],
+        ]);
+    }
+}

--- a/site/src/Form/DocumentType.php
+++ b/site/src/Form/DocumentType.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\Document;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class DocumentType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('date', DateTimeType::class, [
+                'widget' => 'single_text',
+                'label' => 'Дата',
+            ])
+            ->add('number', TextType::class, [
+                'required' => false,
+                'label' => 'Номер',
+            ])
+            ->add('type', TextType::class, [
+                'label' => 'Тип',
+            ])
+            ->add('description', TextareaType::class, [
+                'required' => false,
+                'label' => 'Описание',
+            ])
+            ->add('operations', CollectionType::class, [
+                'entry_type' => DocumentOperationType::class,
+                'entry_options' => [
+                    'categories' => $options['categories'],
+                    'counterparties' => $options['counterparties'],
+                ],
+                'allow_add' => true,
+                'allow_delete' => true,
+                'by_reference' => false,
+                'label' => 'Операции',
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Document::class,
+            'categories' => [],
+            'counterparties' => [],
+        ]);
+    }
+}

--- a/site/src/Form/PLCategoryType.php
+++ b/site/src/Form/PLCategoryType.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\PLCategory;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class PLCategoryType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('name', TextType::class, [
+                'label' => 'Наименование',
+            ])
+            ->add('sortOrder', IntegerType::class, [
+                'label' => 'Сортировка',
+            ])
+            ->add('parent', EntityType::class, [
+                'class' => PLCategory::class,
+                'choices' => $options['parents'],
+                'choice_label' => function (PLCategory $item) {
+                    return str_repeat('—', $item->getLevel() - 1) . ' ' . $item->getName();
+                },
+                'required' => false,
+                'label' => 'Родитель',
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => PLCategory::class,
+            'parents' => [],
+        ]);
+    }
+}

--- a/site/src/Repository/DocumentOperationRepository.php
+++ b/site/src/Repository/DocumentOperationRepository.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\DocumentOperation;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class DocumentOperationRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, DocumentOperation::class);
+    }
+}

--- a/site/src/Repository/DocumentRepository.php
+++ b/site/src/Repository/DocumentRepository.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Document;
+use App\Entity\Company;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class DocumentRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Document::class);
+    }
+
+    /**
+     * @return Document[]
+     */
+    public function findByCompany(Company $company): array
+    {
+        return $this->createQueryBuilder('d')
+            ->andWhere('d.company = :company')
+            ->setParameter('company', $company)
+            ->orderBy('d.date', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/site/src/Repository/PLCategoryRepository.php
+++ b/site/src/Repository/PLCategoryRepository.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\PLCategory;
+use App\Entity\Company;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class PLCategoryRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, PLCategory::class);
+    }
+
+    /**
+     * @return PLCategory[]
+     */
+    public function findRootByCompany(Company $company): array
+    {
+        return $this->createQueryBuilder('c')
+            ->andWhere('c.company = :company')
+            ->andWhere('c.parent IS NULL')
+            ->setParameter('company', $company)
+            ->orderBy('c.sortOrder', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * @return PLCategory[]
+     */
+    public function findTreeByCompany(Company $company): array
+    {
+        $roots = $this->findRootByCompany($company);
+        $result = [];
+        foreach ($roots as $root) {
+            $this->collectTree($root, $result);
+        }
+        return $result;
+    }
+
+    private function collectTree(PLCategory $category, array &$result): void
+    {
+        $result[] = $category;
+        foreach ($category->getChildren() as $child) {
+            $this->collectTree($child, $result);
+        }
+    }
+}

--- a/site/templates/document/edit.html.twig
+++ b/site/templates/document/edit.html.twig
@@ -1,0 +1,57 @@
+{% extends 'base.html.twig' %}
+{% block title %}Редактирование документа{% endblock %}
+{% block body %}
+    <div class="page-header d-print-none">
+        <div class="container-xl">
+            <h2 class="page-title">Редактирование документа</h2>
+        </div>
+    </div>
+    <div class="container-xl mt-3">
+        <div class="card">
+            <div class="card-body">
+                {{ form_start(form) }}
+                {{ form_row(form.date) }}
+                {{ form_row(form.number) }}
+                {{ form_row(form.type) }}
+                {{ form_row(form.description) }}
+                <div class="mb-3">
+                    <label class="form-label">Операции</label>
+                    <div data-collection-holder data-prototype="{{ form_widget(form.operations.vars.prototype)|e('html_attr') }}">
+                        {% for op in form.operations %}
+                            <div class="mb-2">
+                                {{ form_widget(op) }}
+                                <button type="button" class="btn btn-sm btn-danger remove-item">Удалить</button>
+                            </div>
+                        {% endfor %}
+                    </div>
+                    <button type="button" class="btn btn-sm btn-secondary add_item_link mt-2">+ Добавить операцию</button>
+                </div>
+                <button class="btn btn-primary">Сохранить</button>
+                {{ form_end(form) }}
+            </div>
+        </div>
+    </div>
+{% endblock %}
+{% block javascripts %}
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        document.querySelectorAll('[data-collection-holder]').forEach(function(collectionHolder) {
+            const addButton = collectionHolder.parentElement.querySelector('.add_item_link');
+            addButton.addEventListener('click', function() {
+                const prototype = collectionHolder.dataset.prototype;
+                const index = collectionHolder.children.length;
+                let newForm = prototype.replace(/__name__/g, index);
+                const div = document.createElement('div');
+                div.classList.add('mb-2');
+                div.innerHTML = newForm + '<button type="button" class="btn btn-sm btn-danger remove-item">Удалить</button>';
+                collectionHolder.appendChild(div);
+            });
+            collectionHolder.addEventListener('click', function(e){
+                if (e.target && e.target.classList.contains('remove-item')) {
+                    e.target.closest('div.mb-2').remove();
+                }
+            });
+        });
+    });
+</script>
+{% endblock %}

--- a/site/templates/document/index.html.twig
+++ b/site/templates/document/index.html.twig
@@ -1,0 +1,51 @@
+{% extends 'base.html.twig' %}
+{% block title %}Документы{% endblock %}
+{% block body %}
+    <div class="page-header d-print-none">
+        <div class="container-xl">
+            <div class="row g-2 align-items-center">
+                <div class="col">
+                    <h2 class="page-title">Документы</h2>
+                </div>
+                <div class="col-auto ms-auto d-print-none">
+                    <a href="{{ path('document_new') }}" class="btn btn-primary">+ Добавить документ</a>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="container-xl mt-3">
+        <div class="card">
+            <div class="table-responsive">
+                <table class="table card-table">
+                    <thead>
+                        <tr>
+                            <th>Дата</th>
+                            <th>Номер</th>
+                            <th>Тип</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for item in items %}
+                            <tr>
+                                <td>{{ item.date|date('Y-m-d H:i') }}</td>
+                                <td>{{ item.number }}</td>
+                                <td>{{ item.type }}</td>
+                                <td class="text-end">
+                                    <a href="{{ path('document_show', {'id': item.id}) }}" class="btn btn-sm btn-info">👁</a>
+                                    <a href="{{ path('document_edit', {'id': item.id}) }}" class="btn btn-sm btn-warning">✏️</a>
+                                    <form method="post" action="{{ path('document_delete', {'id': item.id}) }}" class="d-inline" onsubmit="return confirm('Вы уверены?');">
+                                        <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ item.id) }}">
+                                        <button class="btn btn-sm btn-danger">🗑</button>
+                                    </form>
+                                </td>
+                            </tr>
+                        {% else %}
+                            <tr><td colspan="4" class="text-center">Нет данных</td></tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/site/templates/document/new.html.twig
+++ b/site/templates/document/new.html.twig
@@ -1,0 +1,57 @@
+{% extends 'base.html.twig' %}
+{% block title %}Новый документ{% endblock %}
+{% block body %}
+    <div class="page-header d-print-none">
+        <div class="container-xl">
+            <h2 class="page-title">Новый документ</h2>
+        </div>
+    </div>
+    <div class="container-xl mt-3">
+        <div class="card">
+            <div class="card-body">
+                {{ form_start(form) }}
+                {{ form_row(form.date) }}
+                {{ form_row(form.number) }}
+                {{ form_row(form.type) }}
+                {{ form_row(form.description) }}
+                <div class="mb-3">
+                    <label class="form-label">Операции</label>
+                    <div data-collection-holder data-prototype="{{ form_widget(form.operations.vars.prototype)|e('html_attr') }}">
+                        {% for op in form.operations %}
+                            <div class="mb-2">
+                                {{ form_widget(op) }}
+                                <button type="button" class="btn btn-sm btn-danger remove-item">Удалить</button>
+                            </div>
+                        {% endfor %}
+                    </div>
+                    <button type="button" class="btn btn-sm btn-secondary add_item_link mt-2">+ Добавить операцию</button>
+                </div>
+                <button class="btn btn-primary">Сохранить</button>
+                {{ form_end(form) }}
+            </div>
+        </div>
+    </div>
+{% endblock %}
+{% block javascripts %}
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        document.querySelectorAll('[data-collection-holder]').forEach(function(collectionHolder) {
+            const addButton = collectionHolder.parentElement.querySelector('.add_item_link');
+            addButton.addEventListener('click', function() {
+                const prototype = collectionHolder.dataset.prototype;
+                const index = collectionHolder.children.length;
+                let newForm = prototype.replace(/__name__/g, index);
+                const div = document.createElement('div');
+                div.classList.add('mb-2');
+                div.innerHTML = newForm + '<button type="button" class="btn btn-sm btn-danger remove-item">Удалить</button>';
+                collectionHolder.appendChild(div);
+            });
+            collectionHolder.addEventListener('click', function(e){
+                if (e.target && e.target.classList.contains('remove-item')) {
+                    e.target.closest('div.mb-2').remove();
+                }
+            });
+        });
+    });
+</script>
+{% endblock %}

--- a/site/templates/document/show.html.twig
+++ b/site/templates/document/show.html.twig
@@ -1,0 +1,48 @@
+{% extends 'base.html.twig' %}
+{% block title %}Просмотр документа{% endblock %}
+{% block body %}
+    <div class="page-header d-print-none">
+        <div class="container-xl">
+            <h2 class="page-title">Документ {{ item.type }}</h2>
+        </div>
+    </div>
+    <div class="container-xl mt-3">
+        <div class="card">
+            <div class="card-body">
+                <dl class="row">
+                    <dt class="col-sm-3">Дата</dt>
+                    <dd class="col-sm-9">{{ item.date|date('Y-m-d H:i') }}</dd>
+                    <dt class="col-sm-3">Номер</dt>
+                    <dd class="col-sm-9">{{ item.number }}</dd>
+                    <dt class="col-sm-3">Тип</dt>
+                    <dd class="col-sm-9">{{ item.type }}</dd>
+                    <dt class="col-sm-3">Описание</dt>
+                    <dd class="col-sm-9">{{ item.description }}</dd>
+                </dl>
+                <h4>Операции</h4>
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>Категория</th>
+                            <th>Сумма</th>
+                            <th>Контрагент</th>
+                            <th>Комментарий</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for op in item.operations %}
+                            <tr>
+                                <td>{{ op.category.name }}</td>
+                                <td>{{ op.amount }}</td>
+                                <td>{{ op.counterparty ? op.counterparty.name : '' }}</td>
+                                <td>{{ op.comment }}</td>
+                            </tr>
+                        {% else %}
+                            <tr><td colspan="4" class="text-center">Нет операций</td></tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/site/templates/pl_category/edit.html.twig
+++ b/site/templates/pl_category/edit.html.twig
@@ -1,0 +1,19 @@
+{% extends 'base.html.twig' %}
+{% block title %}Редактирование категории P&L{% endblock %}
+{% block body %}
+    <div class="page-header d-print-none">
+        <div class="container-xl">
+            <h2 class="page-title">Редактирование {{ item.name }}</h2>
+        </div>
+    </div>
+    <div class="container-xl mt-3">
+        <div class="card">
+            <div class="card-body">
+                {{ form_start(form) }}
+                {{ form_widget(form) }}
+                <button class="btn btn-primary mt-2">Сохранить</button>
+                {{ form_end(form) }}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/site/templates/pl_category/index.html.twig
+++ b/site/templates/pl_category/index.html.twig
@@ -1,0 +1,48 @@
+{% extends 'base.html.twig' %}
+{% block title %}Категории P&L{% endblock %}
+
+{% macro render_items(items, level) %}
+    <ul class="list-unstyled">
+    {% for item in items %}
+        <li>
+            <div class="d-flex align-items-center">
+                <span style="margin-left: {{ (level - 1) * 20 }}px;">{{ item.name }}</span>
+                <span class="ms-auto d-inline-flex gap-1">
+                    <a href="{{ path('pl_category_edit', {'id': item.id}) }}" class="btn btn-sm btn-warning">✏️</a>
+                    <form method="post" action="{{ path('pl_category_delete', {'id': item.id}) }}" class="d-inline" onsubmit="return confirm('Вы уверены?');">
+                        <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ item.id) }}">
+                        <button class="btn btn-sm btn-danger">🗑</button>
+                    </form>
+                </span>
+            </div>
+            {% if item.children|length > 0 %}
+                {{ _self.render_items(item.children, level + 1) }}
+            {% endif %}
+        </li>
+    {% endfor %}
+    </ul>
+{% endmacro %}
+
+{% import _self as macros %}
+
+{% block body %}
+    <div class="page-header d-print-none">
+        <div class="container-xl">
+            <div class="row g-2 align-items-center">
+                <div class="col">
+                    <h2 class="page-title">Категории P&amp;L</h2>
+                </div>
+                <div class="col-auto ms-auto d-print-none">
+                    <a href="{{ path('pl_category_new') }}" class="btn btn-primary">+ Добавить категорию</a>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="container-xl mt-3">
+        <div class="card">
+            <div class="card-body">
+                {{ macros.render_items(items, 1) }}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/site/templates/pl_category/new.html.twig
+++ b/site/templates/pl_category/new.html.twig
@@ -1,0 +1,19 @@
+{% extends 'base.html.twig' %}
+{% block title %}Новая категория P&L{% endblock %}
+{% block body %}
+    <div class="page-header d-print-none">
+        <div class="container-xl">
+            <h2 class="page-title">Новая категория P&amp;L</h2>
+        </div>
+    </div>
+    <div class="container-xl mt-3">
+        <div class="card">
+            <div class="card-body">
+                {{ form_start(form) }}
+                {{ form_widget(form) }}
+                <button class="btn btn-primary mt-2">Сохранить</button>
+                {{ form_end(form) }}
+            </div>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add PLCategory entity and CRUD UI
- implement Document and DocumentOperation with inline operations editing
- create database migration for new entities

## Testing
- `php bin/console doctrine:migrations:diff --no-interaction` *(fails: Dependencies are missing)*
- `php bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3189db4883238858c35a5c68a800