### PR TITLE
fix: correct counterparty table reference in migration

### DIFF
--- a/site/migrations/Version20250907000000.php
+++ b/site/migrations/Version20250907000000.php
@@ -32,7 +32,7 @@ final class Version20250907000000 extends AbstractMigration
         $this->addSql('CREATE INDEX IDX_DOC_OPER_COUNTERPARTY ON document_operations (counterparty_id)');
         $this->addSql('ALTER TABLE document_operations ADD CONSTRAINT FK_DOC_OPER_DOCUMENT FOREIGN KEY (document_id) REFERENCES documents (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
         $this->addSql('ALTER TABLE document_operations ADD CONSTRAINT FK_DOC_OPER_CATEGORY FOREIGN KEY (category_id) REFERENCES pl_categories (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
-        $this->addSql('ALTER TABLE document_operations ADD CONSTRAINT FK_DOC_OPER_COUNTERPARTY FOREIGN KEY (counterparty_id) REFERENCES counterparties (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE document_operations ADD CONSTRAINT FK_DOC_OPER_COUNTERPARTY FOREIGN KEY (counterparty_id) REFERENCES "counterparty" (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
 
     public function down(Schema $schema): void


### PR DESCRIPTION
## Summary
- fix foreign key reference in document_operations migration to use the existing `counterparty` table

## Testing
- `php -l migrations/Version20250907000000.php`
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3571980c8323890be7130131bbfa