### PR TITLE
Add manual Ozon orders sync

### DIFF
--- a/site/src/Controller/Ozon/OzonOrderController.php
+++ b/site/src/Controller/Ozon/OzonOrderController.php
@@ -6,11 +6,15 @@ use App\Entity\Ozon\OzonOrder;
 use App\Entity\Ozon\OzonOrderItem;
 use App\Repository\Ozon\OzonOrderRepository;
 use App\Repository\Ozon\OzonOrderStatusHistoryRepository;
+use App\Service\Ozon\OzonOrderSyncService;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeZone;
 
 class OzonOrderController extends AbstractController
 {
@@ -45,6 +49,18 @@ class OzonOrderController extends AbstractController
         return $this->render('ozon/orders/index.html.twig', [
             'orders' => $orders,
         ]);
+    }
+
+    #[Route('/ozon/orders/sync', name: 'ozon_orders_sync')]
+    public function sync(OzonOrderSyncService $syncService): Response
+    {
+        $company = $this->getUser()->getCompanies()[0];
+        $to = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+        $since = $to->sub(new DateInterval('P3D'));
+        $syncService->syncFbs($company, $since, $to);
+        $syncService->syncFbo($company, $since, $to);
+        $this->addFlash('success', 'Ozon заказы обновлены!');
+        return $this->redirectToRoute('ozon_orders');
     }
 
     #[Route('/ozon/orders/{id}', name: 'ozon_order_show')]

--- a/site/templates/ozon/orders/index.html.twig
+++ b/site/templates/ozon/orders/index.html.twig
@@ -2,6 +2,7 @@
 
 {% block body %}
 <h1>Ozon Orders</h1>
+<a href="{{ path('ozon_orders_sync') }}" class="btn btn-primary mb-2">Обновить</a>
 <table class="table">
     <thead>
     <tr>


### PR DESCRIPTION
## Summary
- allow manual sync of recent Ozon orders via a new controller route
- add refresh button on orders page

## Testing
- `php bin/phpunit` (fails: Unable to find the `simple-phpunit.php` script)
- `composer install --no-progress` (fails: 403 from GitHub requiring authentication)


------
https://chatgpt.com/codex/tasks/task_e_68bd43c073f88323a2c31ab6d1c8886f