### PR TITLE
feat: add API response debug button

### DIFF
--- a/site/templates/ozon/orders/index.html.twig
+++ b/site/templates/ozon/orders/index.html.twig
@@ -3,6 +3,7 @@
 {% block body %}
 <h1>Ozon Orders</h1>
 <a href="{{ path('ozon_orders_sync') }}" class="btn btn-primary mb-2">Обновить</a>
+<a href="{{ path('ozon_orders_api') }}" class="btn btn-secondary mb-2" target="_blank">Вывести на экран</a>
 <table class="table">
     <thead>
     <tr>


### PR DESCRIPTION
## Summary
- add API endpoint to display raw Ozon API order data
- show button to view Ozon API response in JSON

## Testing
- `php bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`)*
- `composer install` *(fails: requires GitHub token to download symfony/flex from dist)*

------
https://chatgpt.com/codex/tasks/task_e_68bd469a17e883238f35939a2fe49487