### PR TITLE
Initialize default status for Ozon orders

### DIFF
--- a/site/src/Entity/Ozon/OzonOrder.php
+++ b/site/src/Entity/Ozon/OzonOrder.php
@@ -28,7 +28,7 @@ class OzonOrder
     private string $scheme;
 
     #[ORM\Column(length: 255)]
-    private string $status;
+    private string $status = '';
 
     #[ORM\Column(type: 'datetime_immutable')]
     private \DateTimeImmutable $statusUpdatedAt;


### PR DESCRIPTION
## Summary
- initialize `OzonOrder::$status` to empty string to avoid uninitialized property access when syncing orders

## Testing
- `composer install --no-interaction --no-progress` *(fails: Failed to clone https://github.com/symfony/flex.git via https, ssh protocols, aborting)*


------
https://chatgpt.com/codex/tasks/task_e_68bd4a8e5f348323aa57004a7e8b312b