### PR TITLE
Fix Ozon order persistence before status history

### DIFF
--- a/site/src/Service/Ozon/OzonOrderSyncService.php
+++ b/site/src/Service/Ozon/OzonOrderSyncService.php
@@ -48,6 +48,7 @@ readonly class OzonOrderSyncService
                 $order->setRaw($posting);
                 $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
                 $order->setUpdatedAt($now);
+                $this->em->persist($order);
                 $statusUpdatedAt = isset($posting['status_updated_at']) ? new \DateTimeImmutable($posting['status_updated_at']) : $now;
                 if ($order->getStatus() !== ($posting['status'] ?? '')) {
                     $order->setStatus($posting['status'] ?? '');
@@ -61,7 +62,6 @@ readonly class OzonOrderSyncService
                 } else {
                     $order->setStatusUpdatedAt($statusUpdatedAt);
                 }
-                $this->em->persist($order);
 
                 $items = $posting['products'] ?? $posting['items'] ?? [];
                 if (!$items || $forceDetails) {
@@ -131,6 +131,7 @@ readonly class OzonOrderSyncService
                 $order->setRaw($posting);
                 $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
                 $order->setUpdatedAt($now);
+                $this->em->persist($order);
                 $statusUpdatedAt = isset($posting['status_updated_at']) ? new \DateTimeImmutable($posting['status_updated_at']) : $now;
                 if ($order->getStatus() !== ($posting['status'] ?? '')) {
                     $order->setStatus($posting['status'] ?? '');
@@ -144,7 +145,6 @@ readonly class OzonOrderSyncService
                 } else {
                     $order->setStatusUpdatedAt($statusUpdatedAt);
                 }
-                $this->em->persist($order);
 
                 $items = $posting['products'] ?? [];
                 if (!$items || $forceDetails) {


### PR DESCRIPTION
## Summary
- ensure orders are persisted before adding status history during Ozon sync

## Testing
- `php -l src/Service/Ozon/OzonOrderSyncService.php`
- `./vendor/bin/phpunit tests/Service/OzonOrderSyncServiceTest.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4d4533fc832396e16bfe4d5d0cc1