### PR TITLE
Add bank statement import from 1C

### DIFF
--- a/site/migrations/Version20250908131500.php
+++ b/site/migrations/Version20250908131500.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250908131500 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add unique index for externalId';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE UNIQUE INDEX uniq_tx_company_account_external ON cash_transaction (company_id, money_account_id, external_id) WHERE external_id IS NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS uniq_tx_company_account_external');
+    }
+}

--- a/site/src/Controller/Finance/Bank1CImportController.php
+++ b/site/src/Controller/Finance/Bank1CImportController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Controller\Finance;
+
+use App\Repository\MoneyAccountRepository;
+use App\Service\ActiveCompanyService;
+use App\Service\Bank1C\Bank1CImportService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/finance/imports/bank-1c')]
+class Bank1CImportController extends AbstractController
+{
+    public function __construct(private ActiveCompanyService $companyService)
+    {
+    }
+
+    #[Route('', name: 'bank1c_import_form', methods: ['GET'])]
+    public function form(MoneyAccountRepository $accountRepo): Response
+    {
+        $company = $this->companyService->getActiveCompany();
+        $accounts = $accountRepo->findBy(['company' => $company]);
+        return $this->render('finance/import/bank1c/upload.html.twig', [
+            'accounts' => $accounts,
+        ]);
+    }
+
+    #[Route('', name: 'bank1c_import_handle', methods: ['POST'])]
+    public function handle(
+        Request $request,
+        MoneyAccountRepository $accountRepo,
+        Bank1CImportService $importService
+    ): Response {
+        if (!$this->isCsrfTokenValid('bank1c_import', $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+        $company = $this->companyService->getActiveCompany();
+        $accountId = $request->request->get('moneyAccount');
+        $account = $accountRepo->find($accountId);
+        if (!$account || $account->getCompany() !== $company) {
+            throw $this->createNotFoundException();
+        }
+        /** @var UploadedFile|null $file */
+        $file = $request->files->get('statement');
+        if (!$file) {
+            $this->addFlash('danger', 'Файл не загружен');
+            return $this->redirectToRoute('bank1c_import_form');
+        }
+        if ($file->getSize() > 10 * 1024 * 1024 || $file->getClientOriginalExtension() !== 'txt') {
+            $this->addFlash('danger', 'Недопустимый файл');
+            return $this->redirectToRoute('bank1c_import_form');
+        }
+        $raw = file_get_contents($file->getPathname());
+        $result = $importService->import($company, $account, $raw, $file->getClientOriginalName());
+        return $this->render('finance/import/bank1c/result.html.twig', [
+            'result' => $result,
+        ]);
+    }
+}

--- a/site/src/Service/Bank1C/Bank1CImportService.php
+++ b/site/src/Service/Bank1C/Bank1CImportService.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace App\Service\Bank1C;
+
+use App\DTO\CashTransactionDTO;
+use App\Entity\Company;
+use App\Entity\Counterparty;
+use App\Entity\MoneyAccount;
+use App\Enum\CashDirection;
+use App\Enum\CounterpartyType;
+use App\Repository\CashTransactionRepository;
+use App\Repository\CounterpartyRepository;
+use App\Service\Bank1C\Dto\Bank1CImportResult;
+use App\Service\Bank1C\Dto\Bank1CDocument;
+use App\Service\CashTransactionService;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+
+class Bank1CImportService
+{
+    public function __construct(
+        private Bank1CStatementParser $parser,
+        private CashTransactionService $txService,
+        private CounterpartyRepository $cpRepo,
+        private CashTransactionRepository $txRepo,
+        private EntityManagerInterface $em
+    ) {
+    }
+
+    public function import(Company $company, MoneyAccount $account, string $raw, ?string $filename = null): Bank1CImportResult
+    {
+        $result = new Bank1CImportResult();
+        $statement = $this->parser->parse($raw);
+        foreach ($statement->documents as $doc) {
+            $result->total++;
+            try {
+                $direction = $this->determineDirection($account, $doc);
+                $dateStr = $this->determineDate($direction, $doc);
+                $counterparty = $this->resolveCounterparty($company, $direction, $doc);
+
+                $externalId = hash('sha256', implode('|', [
+                    $doc->type,
+                    $doc->number,
+                    $doc->date,
+                    $doc->amount,
+                    $doc->payerAccount,
+                    $doc->payeeAccount,
+                ]));
+
+                if ($this->txRepo->findOneBy([
+                    'company' => $company,
+                    'moneyAccount' => $account,
+                    'externalId' => $externalId,
+                ])) {
+                    $result->duplicates++;
+                    continue;
+                }
+
+                $dto = new CashTransactionDTO();
+                $dto->companyId = $company->getId();
+                $dto->moneyAccountId = $account->getId();
+                $dto->direction = $direction;
+                $dto->amount = $doc->amount ?? '0';
+                $dto->currency = $account->getCurrency();
+                $dto->occurredAt = new \DateTimeImmutable($dateStr);
+                $dto->description = $doc->purpose;
+                $dto->externalId = $externalId;
+                if ($counterparty) {
+                    $dto->counterpartyId = $counterparty->getId();
+                }
+                $this->txService->add($dto);
+                $result->created++;
+                if (count($result->samples) < 10) {
+                    $result->samples[] = [
+                        'date' => $dateStr,
+                        'direction' => $direction->value,
+                        'amount' => $doc->amount ?? '0',
+                        'counterparty' => $counterparty?->getName(),
+                        'purpose' => $doc->purpose ?? '',
+                    ];
+                }
+            } catch (\Throwable $e) {
+                $result->errors[] = ($doc->number ?? '?') . ': ' . $e->getMessage();
+            }
+        }
+        return $result;
+    }
+
+    private function determineDirection(MoneyAccount $account, Bank1CDocument $doc): CashDirection
+    {
+        $acc = $account->getAccountNumber();
+        if ($doc->payerAccount === $acc && $doc->payeeAccount === $acc) {
+            return CashDirection::OUTFLOW;
+        }
+        if ($doc->payerAccount === $acc) {
+            return CashDirection::OUTFLOW;
+        }
+        return CashDirection::INFLOW;
+    }
+
+    private function determineDate(CashDirection $direction, Bank1CDocument $doc): string
+    {
+        if ($direction === CashDirection::INFLOW) {
+            return $doc->dateCredited ?: ($doc->date ?: 'today');
+        }
+        return $doc->dateDebited ?: ($doc->date ?: 'today');
+    }
+
+    private function resolveCounterparty(Company $company, CashDirection $direction, Bank1CDocument $doc): ?Counterparty
+    {
+        $name = $direction === CashDirection::INFLOW ? $doc->payerName : $doc->payeeName;
+        $inn = $direction === CashDirection::INFLOW ? $doc->payerInn : $doc->payeeInn;
+        if (!$name && !$inn) {
+            return null;
+        }
+        $counterparty = null;
+        if ($inn) {
+            $counterparty = $this->cpRepo->findOneBy(['company' => $company, 'inn' => $inn]);
+        }
+        if (!$counterparty && $name) {
+            $counterparty = $this->cpRepo->findOneBy(['company' => $company, 'name' => $name]);
+        }
+        if (!$counterparty && $name) {
+            $type = $this->guessCounterpartyType($name, $inn);
+            $counterparty = new Counterparty(Uuid::uuid4()->toString(), $company, $name, $type);
+            if ($inn) {
+                $counterparty->setInn($inn);
+            }
+            $this->em->persist($counterparty);
+            $this->em->flush();
+        }
+        return $counterparty;
+    }
+
+    private function guessCounterpartyType(string $name, ?string $inn): CounterpartyType
+    {
+        if ($inn && strlen($inn) === 12) {
+            return CounterpartyType::INDIVIDUAL_ENTREPRENEUR;
+        }
+        if (str_starts_with(mb_strtoupper($name), 'ИП')) {
+            return CounterpartyType::INDIVIDUAL_ENTREPRENEUR;
+        }
+        return CounterpartyType::LEGAL_ENTITY;
+    }
+}

--- a/site/src/Service/Bank1C/Bank1CStatementParser.php
+++ b/site/src/Service/Bank1C/Bank1CStatementParser.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Service\Bank1C;
+
+use App\Service\Bank1C\Dto\Bank1CDocument;
+use App\Service\Bank1C\Dto\Bank1CStatement;
+
+class Bank1CStatementParser
+{
+    public function parse(string $raw): Bank1CStatement
+    {
+        if (!mb_check_encoding($raw, 'UTF-8')) {
+            $raw = iconv('Windows-1251', 'UTF-8', $raw);
+        }
+        $raw = str_replace("\r\n", "\n", $raw);
+        $lines = preg_split('/\n/', trim($raw));
+        $state = 'HEADER';
+        $header = [];
+        $account = [];
+        $documents = [];
+        $current = null;
+
+        foreach ($lines as $line) {
+            $line = trim($line);
+            if ($line === '') {
+                continue;
+            }
+            if ($line === 'СекцияРасчСчет') {
+                $state = 'ACCOUNT';
+                continue;
+            }
+            if ($line === 'КонецРасчСчет') {
+                $state = 'AFTER_ACCOUNT';
+                continue;
+            }
+            if (str_starts_with($line, 'СекцияДокумент=')) {
+                $type = substr($line, strlen('СекцияДокумент='));
+                $current = new Bank1CDocument($type);
+                $state = 'DOC';
+                continue;
+            }
+            if ($line === 'КонецДокумента') {
+                if ($current) {
+                    $documents[] = $current;
+                }
+                $current = null;
+                $state = 'AFTER_DOC';
+                continue;
+            }
+            if ($line === 'КонецФайла') {
+                break;
+            }
+            [$key, $value] = array_map('trim', explode('=', $line, 2) + [1 => '']);
+            switch ($state) {
+                case 'HEADER':
+                    $header[$key] = $value;
+                    break;
+                case 'ACCOUNT':
+                    $account[$key] = $value;
+                    break;
+                case 'DOC':
+                    if ($current) {
+                        $current->raw[$key] = $value;
+                        switch ($key) {
+                            case 'Номер':
+                                $current->number = $value;
+                                break;
+                            case 'Дата':
+                                $current->date = $value;
+                                break;
+                            case 'Сумма':
+                                $current->amount = $value;
+                                break;
+                            case 'ПлательщикСчет':
+                                $current->payerAccount = $value;
+                                break;
+                            case 'ПолучательСчет':
+                                $current->payeeAccount = $value;
+                                break;
+                            case 'ДатаСписано':
+                                $current->dateDebited = $value;
+                                break;
+                            case 'ДатаПоступило':
+                                $current->dateCredited = $value;
+                                break;
+                            case 'Плательщик':
+                                $current->payerName = $value;
+                                break;
+                            case 'ПлательщикИНН':
+                                $current->payerInn = $value;
+                                break;
+                            case 'Получатель':
+                                $current->payeeName = $value;
+                                break;
+                            case 'ПолучательИНН':
+                                $current->payeeInn = $value;
+                                break;
+                            case 'НазначениеПлатежа':
+                                $current->purpose = $value;
+                                break;
+                        }
+                    }
+                    break;
+            }
+        }
+
+        return new Bank1CStatement($header, $account, $documents);
+    }
+}

--- a/site/src/Service/Bank1C/Dto/Bank1CDocument.php
+++ b/site/src/Service/Bank1C/Dto/Bank1CDocument.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Service\Bank1C\Dto;
+
+class Bank1CDocument
+{
+    public string $type;
+    public ?string $number = null;
+    public ?string $date = null;
+    public ?string $amount = null;
+    public ?string $payerAccount = null;
+    public ?string $payeeAccount = null;
+    public ?string $dateDebited = null;
+    public ?string $dateCredited = null;
+    public ?string $payerName = null;
+    public ?string $payerInn = null;
+    public ?string $payeeName = null;
+    public ?string $payeeInn = null;
+    public ?string $purpose = null;
+    /** @var array<string,string> */
+    public array $raw = [];
+
+    public function __construct(string $type)
+    {
+        $this->type = $type;
+    }
+}

--- a/site/src/Service/Bank1C/Dto/Bank1CImportResult.php
+++ b/site/src/Service/Bank1C/Dto/Bank1CImportResult.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Service\Bank1C\Dto;
+
+class Bank1CImportResult
+{
+    public int $total = 0;
+    public int $created = 0;
+    public int $duplicates = 0;
+    /** @var string[] */
+    public array $errors = [];
+    /** @var array<int,array<string,string>> */
+    public array $samples = [];
+}

--- a/site/src/Service/Bank1C/Dto/Bank1CStatement.php
+++ b/site/src/Service/Bank1C/Dto/Bank1CStatement.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Service\Bank1C\Dto;
+
+/**
+ * @template-immutable
+ */
+class Bank1CStatement
+{
+    /** @param array<string,string> $header */
+    public function __construct(
+        public array $header,
+        /** @param array<string,string> $account */
+        public array $account,
+        /** @var Bank1CDocument[] */
+        public array $documents
+    ) {
+    }
+}

--- a/site/src/Service/CashTransactionService.php
+++ b/site/src/Service/CashTransactionService.php
@@ -55,6 +55,10 @@ class CashTransactionService
             ->setCounterparty($counterparty)
             ->setCashflowCategory($category);
 
+        if ($dto->externalId) {
+            $tx->setExternalId($dto->externalId);
+        }
+
         $this->em->persist($tx);
         $from = $dto->occurredAt->setTime(0, 0);
         $to = new \DateTimeImmutable('today');

--- a/site/templates/finance/import/bank1c/result.html.twig
+++ b/site/templates/finance/import/bank1c/result.html.twig
@@ -1,0 +1,59 @@
+{% extends 'base.html.twig' %}
+{% block title %}Результат импорта{% endblock %}
+
+{% block breadcrumbs %}
+    {% include 'partials/_breadcrumbs.html.twig' with {
+        breadcrumbs: [
+            {'label':'Главная','path':'app_home_index'},
+            {'label':'Финансы'},
+            {'label':'Импорт','path':'bank1c_import_form'},
+            {'label':'Результат'}
+        ]
+    } %}
+{% endblock %}
+
+{% block content %}
+    <h2 class="page-title mb-3">Результат импорта</h2>
+    <div class="card mb-3">
+        <div class="card-body">
+            <div class="row">
+                <div class="col">Всего: {{ result.total }}</div>
+                <div class="col">Создано: {{ result.created }}</div>
+                <div class="col">Дубликаты: {{ result.duplicates }}</div>
+                <div class="col">Ошибки: {{ result.errors|length }}</div>
+            </div>
+        </div>
+    </div>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Дата</th>
+                <th>Направление</th>
+                <th>Сумма</th>
+                <th>Контрагент</th>
+                <th>Назначение</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for s in result.samples %}
+                <tr>
+                    <td>{{ s.date }}</td>
+                    <td>{{ s.direction }}</td>
+                    <td>{{ s.amount }}</td>
+                    <td>{{ s.counterparty }}</td>
+                    <td>{{ s.purpose }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% if result.errors %}
+        <div class="alert alert-danger">
+            <ul>
+                {% for e in result.errors %}
+                    <li>{{ e }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
+    <a href="{{ path('bank1c_import_form') }}" class="btn btn-primary">Импортировать ещё</a>
+{% endblock %}

--- a/site/templates/finance/import/bank1c/upload.html.twig
+++ b/site/templates/finance/import/bank1c/upload.html.twig
@@ -1,0 +1,55 @@
+{% extends 'base.html.twig' %}
+{% block title %}Импорт 1C{% endblock %}
+
+{% block breadcrumbs %}
+    {% include 'partials/_breadcrumbs.html.twig' with {
+        breadcrumbs: [
+            {'label':'Главная','path':'app_home_index'},
+            {'label':'Финансы'},
+            {'label':'Импорт'},
+            {'label':'1C'}
+        ]
+    } %}
+{% endblock %}
+
+{% block content %}
+    <h2 class="page-title mb-3">Импорт 1C</h2>
+    <form method="post" enctype="multipart/form-data">
+        <input type="hidden" name="_token" value="{{ csrf_token('bank1c_import') }}">
+        <div class="mb-3">
+            <label class="form-label">Счёт</label>
+            <select name="moneyAccount" id="moneyAccount" class="form-select" required>
+                {% for acc in accounts %}
+                    <option value="{{ acc.id }}" data-account="{{ acc.accountNumber }}" data-currency="{{ acc.currency }}">{{ acc.name }}</option>
+                {% endfor %}
+            </select>
+            <div class="form-hint" id="accountInfo"></div>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Выписка (.txt)</label>
+            <input type="file" name="statement" accept=".txt" required class="form-control">
+        </div>
+        <p class="text-muted">Формат 1CClientBankExchange, кодировка Windows-1251</p>
+        <button type="submit" class="btn btn-primary">Импортировать</button>
+    </form>
+{% endblock %}
+
+{% block scripts %}
+    {{ parent() }}
+    <script>
+        const select = document.getElementById('moneyAccount');
+        const info = document.getElementById('accountInfo');
+        if (select) {
+            function updateInfo() {
+                const opt = select.options[select.selectedIndex];
+                if (opt) {
+                    const acc = opt.dataset.account || '';
+                    const cur = opt.dataset.currency || '';
+                    info.textContent = acc ? acc + ' / ' + cur : '';
+                }
+            }
+            select.addEventListener('change', updateInfo);
+            updateInfo();
+        }
+    </script>
+{% endblock %}

--- a/site/tests/Service/Bank1CImportServiceTest.php
+++ b/site/tests/Service/Bank1CImportServiceTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Entity\CashTransaction;
+use App\Entity\CashflowCategory;
+use App\Entity\Company;
+use App\Entity\Counterparty;
+use App\Entity\MoneyAccount;
+use App\Entity\MoneyAccountDailyBalance;
+use App\Entity\User;
+use App\Enum\CashDirection;
+use App\Enum\MoneyAccountType;
+use App\Repository\CashTransactionRepository;
+use App\Repository\CounterpartyRepository;
+use App\Repository\MoneyAccountDailyBalanceRepository;
+use App\Service\AccountBalanceService;
+use App\Service\Bank1C\Bank1CImportService;
+use App\Service\Bank1C\Bank1CStatementParser;
+use App\Service\CashTransactionService;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\ORM\Tools\Setup;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+class SimpleManagerRegistry implements ManagerRegistry
+{
+    public function __construct(private EntityManager $em) {}
+    public function getDefaultConnectionName(){return 'default';}
+    public function getConnection($name = null){return $this->em->getConnection();}
+    public function getConnections(){return [$this->em->getConnection()];}
+    public function getConnectionNames(){return ['default'];}
+    public function getDefaultManagerName(){return 'default';}
+    public function getManager($name = null){return $this->em;}
+    public function getManagers(){return ['default' => $this->em];}
+    public function resetManager($name = null){return $this->em;}
+    public function getAliasNamespace($alias){return 'App\\Entity';}
+    public function getManagerNames(){return ['default'];}
+    public function getRepository($persistentObject, $persistentManagerName = null){return $this->em->getRepository($persistentObject);}
+    public function getManagerForClass($class){return $this->em;}
+}
+
+class Bank1CImportServiceTest extends TestCase
+{
+    private EntityManager $em;
+    private Bank1CImportService $importService;
+    private Company $company;
+    private MoneyAccount $account;
+
+    protected function setUp(): void
+    {
+        $config = Setup::createAttributeMetadataConfiguration([__DIR__.'/../../src/Entity'], true);
+        $conn = ['driver' => 'pdo_sqlite', 'memory' => true];
+        $this->em = EntityManager::create($conn, $config);
+        $schemaTool = new SchemaTool($this->em);
+        $classes = [
+            $this->em->getClassMetadata(User::class),
+            $this->em->getClassMetadata(Company::class),
+            $this->em->getClassMetadata(MoneyAccount::class),
+            $this->em->getClassMetadata(CashTransaction::class),
+            $this->em->getClassMetadata(MoneyAccountDailyBalance::class),
+            $this->em->getClassMetadata(CashflowCategory::class),
+            $this->em->getClassMetadata(Counterparty::class),
+        ];
+        $schemaTool->createSchema($classes);
+        $registry = new SimpleManagerRegistry($this->em);
+        $txRepo = new CashTransactionRepository($registry);
+        $cpRepo = new CounterpartyRepository($registry);
+        $balanceRepo = new MoneyAccountDailyBalanceRepository($registry);
+        $balanceService = new AccountBalanceService($txRepo, $balanceRepo);
+        $txService = new CashTransactionService($this->em, $balanceService, $txRepo);
+        $parser = new Bank1CStatementParser();
+        $this->importService = new Bank1CImportService($parser, $txService, $cpRepo, $txRepo, $this->em);
+
+        $user = new User(Uuid::uuid4()->toString());
+        $user->setEmail('t@example.com');
+        $user->setPassword('pass');
+        $this->company = new Company(Uuid::uuid4()->toString(), $user);
+        $this->company->setName('Test');
+        $this->account = new MoneyAccount(Uuid::uuid4()->toString(), $this->company, MoneyAccountType::BANK, 'Main', 'RUB');
+        $this->account->setAccountNumber('40702810726140001479');
+        $this->account->setOpeningBalance('0');
+        $this->account->setOpeningBalanceDate(new \DateTimeImmutable('2025-01-01'));
+        $this->em->persist($user);
+        $this->em->persist($this->company);
+        $this->em->persist($this->account);
+        $this->em->flush();
+    }
+
+    public function testImportCreatesTransactionsAndIsIdempotent(): void
+    {
+        $raw = <<<TXT
+1CClientBankExchange
+ВерсияФормата=1.02
+Кодировка=Windows
+Отправитель=Test
+Получатель=Me
+
+СекцияРасчСчет
+НомерСчета=40702810726140001479
+КонецРасчСчет
+
+СекцияДокумент=Платежное поручение
+Номер=649764
+Дата=29.08.2025
+Сумма=101449.51
+ПлательщикСчет=30302810100180000000
+Плательщик=ООО "РВБ"
+ПолучательСчет=40702810726140001479
+ДатаПоступило=29.08.2025
+НазначениеПлатежа=Оплата услуг
+КонецДокумента
+
+СекцияДокумент=Платежное поручение
+Номер=384
+Дата=29.08.2025
+Сумма=24000.00
+ПлательщикСчет=40702810726140001479
+ДатаСписано=29.08.2025
+Получатель=ООО "Получатель"
+ПолучательСчет=40802810426140004223
+НазначениеПлатежа=Оплата аренды
+КонецДокумента
+КонецФайла
+TXT;
+
+        $result1 = $this->importService->import($this->company, $this->account, $raw);
+        $this->assertSame(2, $result1->created);
+
+        $txs = $this->em->getRepository(CashTransaction::class)->findBy([], ['occurredAt' => 'ASC']);
+        $this->assertCount(2, $txs);
+        $in = $txs[0];
+        $out = $txs[1];
+        $this->assertEquals(CashDirection::INFLOW, $in->getDirection());
+        $this->assertEquals('101449.51', $in->getAmount());
+        $this->assertEquals('29.08.2025', $in->getOccurredAt()->format('d.m.Y'));
+        $this->assertEquals('Оплата услуг', $in->getDescription());
+        $this->assertEquals(CashDirection::OUTFLOW, $out->getDirection());
+        $this->assertEquals('24000.00', $out->getAmount());
+        $this->assertEquals('29.08.2025', $out->getOccurredAt()->format('d.m.Y'));
+        $this->assertEquals('Оплата аренды', $out->getDescription());
+
+        $result2 = $this->importService->import($this->company, $this->account, $raw);
+        $this->assertSame(0, $result2->created);
+        $this->assertSame(2, $result2->duplicates);
+
+        $balances = $this->em->getRepository(MoneyAccountDailyBalance::class)->findBy([
+            'moneyAccount' => $this->account,
+            'date' => new \DateTimeImmutable('2025-08-29'),
+        ]);
+        $this->assertCount(1, $balances);
+        $bal = $balances[0];
+        $this->assertSame('101449.51', $bal->getInflow());
+        $this->assertSame('24000.00', $bal->getOutflow());
+    }
+}

--- a/site/tests/Service/Bank1CStatementParserTest.php
+++ b/site/tests/Service/Bank1CStatementParserTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Service\Bank1C\Bank1CStatementParser;
+use PHPUnit\Framework\TestCase;
+
+class Bank1CStatementParserTest extends TestCase
+{
+    public function testParse(): void
+    {
+        $raw = <<<TXT
+1CClientBankExchange
+ВерсияФормата=1.02
+Кодировка=Windows
+Отправитель=Test
+Получатель=Me
+
+СекцияРасчСчет
+НомерСчета=40702810726140001479
+КонецРасчСчет
+
+СекцияДокумент=Платежное поручение
+Номер=649764
+Дата=29.08.2025
+Сумма=101449.51
+ПлательщикСчет=30302810100180000000
+Плательщик=ООО "РВБ"
+ПолучательСчет=40702810726140001479
+ДатаПоступило=29.08.2025
+НазначениеПлатежа=Оплата услуг
+КонецДокумента
+
+СекцияДокумент=Платежное поручение
+Номер=384
+Дата=29.08.2025
+Сумма=24000.00
+ПлательщикСчет=40702810726140001479
+ДатаСписано=29.08.2025
+Получатель=ООО "Получатель"
+ПолучательСчет=40802810426140004223
+НазначениеПлатежа=Оплата аренды
+КонецДокумента
+КонецФайла
+TXT;
+
+        $parser = new Bank1CStatementParser();
+        $stmt = $parser->parse($raw);
+        $this->assertGreaterThanOrEqual(2, count($stmt->documents));
+        $in = $stmt->documents[0];
+        $this->assertSame('Платежное поручение', $in->type);
+        $this->assertSame('101449.51', $in->amount);
+        $this->assertSame('30302810100180000000', $in->payerAccount);
+        $this->assertSame('40702810726140001479', $in->payeeAccount);
+        $this->assertSame('29.08.2025', $in->dateCredited);
+        $this->assertSame('Оплата услуг', $in->purpose);
+        $out = $stmt->documents[1];
+        $this->assertSame('24000.00', $out->amount);
+        $this->assertSame('40702810726140001479', $out->payerAccount);
+        $this->assertSame('29.08.2025', $out->dateDebited);
+        $this->assertSame('Оплата аренды', $out->purpose);
+    }
+}


### PR DESCRIPTION
## Summary
- support setting externalId when creating cash transactions
- parse 1CClientBankExchange statements and import as CashTransactions with idempotency
- add UI for uploading and reporting bank statement imports

## Testing
- `composer install` *(fails: Proxy CONNECT aborted / 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0fdabc608323961e2ab6bd4344c2