### PR TITLE
Add 1C import button to transactions toolbar

### DIFF
--- a/site/templates/transaction/index.html.twig
+++ b/site/templates/transaction/index.html.twig
@@ -16,7 +16,7 @@
     <h2 class="page-title">Транзакции (ДДС)</h2>
     <div class="ms-auto d-print-none">
         <a href="{{ path('cash_transaction_new') }}" class="btn btn-primary">Добавить</a>
-        <a href="#" class="btn btn-outline-secondary">Импорт</a>
+        <a href="{{ path('bank1c_import_form') }}" class="btn btn-outline-secondary">Импорт 1C</a>
         <a href="#" class="btn btn-outline-secondary">Экспорт</a>
         <form method="post" action="{{ path('cash_transaction_clear') }}" class="d-inline">
             <button type="submit" class="btn btn-outline-danger">Очистить</button>


### PR DESCRIPTION
## Summary
- Add link to Bank1C import form in cash transaction list toolbar

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: Requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68bf161a53e483239aabf11b1cfacf44