### PR TITLE
feat: add auto category template forms

### DIFF
--- a/site/migrations/Version20250908132000.php
+++ b/site/migrations/Version20250908132000.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250908132000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create auto_category_template and auto_category_condition tables';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE auto_category_template (id UUID NOT NULL, company_id UUID NOT NULL, target_category_id UUID DEFAULT NULL, name VARCHAR(255) NOT NULL, is_active BOOLEAN NOT NULL, direction VARCHAR(255) NOT NULL, priority INT NOT NULL, stop_on_match BOOLEAN NOT NULL, match_logic VARCHAR(255) NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_AC_TEMPLATE_COMPANY ON auto_category_template (company_id)');
+        $this->addSql('CREATE INDEX IDX_AC_TEMPLATE_CATEGORY ON auto_category_template (target_category_id)');
+
+        $this->addSql('CREATE TABLE auto_category_condition (id UUID NOT NULL, template_id UUID NOT NULL, field VARCHAR(255) NOT NULL, operator VARCHAR(255) NOT NULL, value TEXT NOT NULL, case_sensitive BOOLEAN NOT NULL, negate BOOLEAN NOT NULL, position INT NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_AC_CONDITION_TEMPLATE ON auto_category_condition (template_id)');
+
+        $this->addSql('ALTER TABLE auto_category_template ADD CONSTRAINT FK_AC_TEMPLATE_COMPANY FOREIGN KEY (company_id) REFERENCES companies (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE auto_category_template ADD CONSTRAINT FK_AC_TEMPLATE_CATEGORY FOREIGN KEY (target_category_id) REFERENCES "cashflow_categories" (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE auto_category_condition ADD CONSTRAINT FK_AC_CONDITION_TEMPLATE FOREIGN KEY (template_id) REFERENCES auto_category_template (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE auto_category_condition DROP CONSTRAINT FK_AC_CONDITION_TEMPLATE');
+        $this->addSql('ALTER TABLE auto_category_template DROP CONSTRAINT FK_AC_TEMPLATE_COMPANY');
+        $this->addSql('ALTER TABLE auto_category_template DROP CONSTRAINT FK_AC_TEMPLATE_CATEGORY');
+        $this->addSql('DROP TABLE auto_category_condition');
+        $this->addSql('DROP TABLE auto_category_template');
+    }
+}

--- a/site/src/Entity/AutoCategoryCondition.php
+++ b/site/src/Entity/AutoCategoryCondition.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Entity;
+
+use App\Enum\ConditionField;
+use App\Enum\ConditionOperator;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class AutoCategoryCondition
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid', unique: true)]
+    private string $id;
+
+    #[ORM\ManyToOne(inversedBy: 'conditions')]
+    #[ORM\JoinColumn(nullable: false)]
+    private AutoCategoryTemplate $template;
+
+    #[ORM\Column(enumType: ConditionField::class)]
+    private ConditionField $field;
+
+    #[ORM\Column(enumType: ConditionOperator::class)]
+    private ConditionOperator $operator;
+
+    #[ORM\Column(type: 'text')]
+    private string $value = '';
+
+    #[ORM\Column]
+    private bool $caseSensitive = false;
+
+    #[ORM\Column]
+    private bool $negate = false;
+
+    #[ORM\Column(type: 'integer')]
+    private int $position = 0;
+
+    public function __construct(string $id, AutoCategoryTemplate $template)
+    {
+        $this->id = $id;
+        $this->template = $template;
+    }
+
+    public function getId(): string { return $this->id; }
+    public function getTemplate(): AutoCategoryTemplate { return $this->template; }
+    public function getField(): ConditionField { return $this->field; }
+    public function setField(ConditionField $f): self { $this->field = $f; return $this; }
+    public function getOperator(): ConditionOperator { return $this->operator; }
+    public function setOperator(ConditionOperator $o): self { $this->operator = $o; return $this; }
+    public function getValue(): string { return $this->value; }
+    public function setValue(string $v): self { $this->value = $v; return $this; }
+    public function isCaseSensitive(): bool { return $this->caseSensitive; }
+    public function setCaseSensitive(bool $c): self { $this->caseSensitive = $c; return $this; }
+    public function isNegate(): bool { return $this->negate; }
+    public function setNegate(bool $n): self { $this->negate = $n; return $this; }
+    public function getPosition(): int { return $this->position; }
+    public function setPosition(int $p): self { $this->position = $p; return $this; }
+}

--- a/site/src/Entity/AutoCategoryTemplate.php
+++ b/site/src/Entity/AutoCategoryTemplate.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Entity;
+
+use App\Enum\AutoTemplateDirection;
+use App\Enum\MatchLogic;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class AutoCategoryTemplate
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid', unique: true)]
+    private string $id;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: false)]
+    private Company $company;
+
+    #[ORM\Column(length: 255)]
+    private string $name = '';
+
+    #[ORM\Column]
+    private bool $isActive = true;
+
+    #[ORM\Column(enumType: AutoTemplateDirection::class)]
+    private AutoTemplateDirection $direction = AutoTemplateDirection::ANY;
+
+    #[ORM\ManyToOne(targetEntity: CashflowCategory::class)]
+    private ?CashflowCategory $targetCategory = null;
+
+    #[ORM\Column(type: 'integer')]
+    private int $priority = 100;
+
+    #[ORM\Column(type: 'boolean')]
+    private bool $stopOnMatch = false;
+
+    #[ORM\Column(enumType: MatchLogic::class)]
+    private MatchLogic $matchLogic = MatchLogic::ALL;
+
+    #[ORM\OneToMany(mappedBy: 'template', targetEntity: AutoCategoryCondition::class, cascade: ['persist', 'remove'], orphanRemoval: true)]
+    private Collection $conditions;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $updatedAt;
+
+    public function __construct(string $id, Company $company)
+    {
+        $this->id = $id;
+        $this->company = $company;
+        $this->conditions = new ArrayCollection();
+        $now = new \DateTimeImmutable();
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+    }
+
+    public function getId(): string { return $this->id; }
+    public function getCompany(): Company { return $this->company; }
+    public function getName(): string { return $this->name; }
+    public function setName(string $name): self { $this->name = $name; return $this; }
+    public function isActive(): bool { return $this->isActive; }
+    public function setIsActive(bool $active): self { $this->isActive = $active; return $this; }
+    public function getDirection(): AutoTemplateDirection { return $this->direction; }
+    public function setDirection(AutoTemplateDirection $d): self { $this->direction = $d; return $this; }
+    public function getTargetCategory(): ?CashflowCategory { return $this->targetCategory; }
+    public function setTargetCategory(?CashflowCategory $c): self { $this->targetCategory = $c; return $this; }
+    public function getPriority(): int { return $this->priority; }
+    public function setPriority(int $p): self { $this->priority = $p; return $this; }
+    public function getStopOnMatch(): bool { return $this->stopOnMatch; }
+    public function setStopOnMatch(bool $s): self { $this->stopOnMatch = $s; return $this; }
+    public function getMatchLogic(): MatchLogic { return $this->matchLogic; }
+    public function setMatchLogic(MatchLogic $m): self { $this->matchLogic = $m; return $this; }
+    /** @return Collection<int, AutoCategoryCondition> */
+    public function getConditions(): Collection { return $this->conditions; }
+    public function addCondition(AutoCategoryCondition $c): self { if(!$this->conditions->contains($c)){ $this->conditions->add($c); } return $this; }
+    public function removeCondition(AutoCategoryCondition $c): self { $this->conditions->removeElement($c); return $this; }
+    public function getCreatedAt(): \DateTimeImmutable { return $this->createdAt; }
+    public function setCreatedAt(\DateTimeImmutable $d): self { $this->createdAt = $d; return $this; }
+    public function getUpdatedAt(): \DateTimeImmutable { return $this->updatedAt; }
+    public function setUpdatedAt(\DateTimeImmutable $d): self { $this->updatedAt = $d; return $this; }
+}

--- a/site/src/Enum/AutoTemplateDirection.php
+++ b/site/src/Enum/AutoTemplateDirection.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enum;
+
+enum AutoTemplateDirection: string
+{
+    case ANY = 'any';
+    case INFLOW = 'inflow';
+    case OUTFLOW = 'outflow';
+}

--- a/site/src/Enum/ConditionField.php
+++ b/site/src/Enum/ConditionField.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Enum;
+
+enum ConditionField: string
+{
+    case PLAT_INN = 'plat_inn';
+    case POL_INN = 'pol_inn';
+    case DESCRIPTION = 'description';
+    case AMOUNT = 'amount';
+    case COUNTERPARTY_NAME_RAW = 'counterparty_name_raw';
+    case MONEY_ACCOUNT = 'money_account';
+    case DOC_NUMBER = 'doc_number';
+    case DATE = 'date';
+}

--- a/site/src/Enum/ConditionOperator.php
+++ b/site/src/Enum/ConditionOperator.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Enum;
+
+enum ConditionOperator: string
+{
+    case EQUALS = 'equals';
+    case CONTAINS = 'contains';
+    case REGEX = 'regex';
+    case BETWEEN = 'between';
+    case IN = 'in';
+    case NOT_CONTAINS = 'not_contains';
+    case NOT_EQUALS = 'not_equals';
+}

--- a/site/src/Enum/MatchLogic.php
+++ b/site/src/Enum/MatchLogic.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enum;
+
+enum MatchLogic: string
+{
+    case ALL = 'all';
+    case ANY = 'any';
+}

--- a/site/src/Form/AutoCategoryConditionType.php
+++ b/site/src/Form/AutoCategoryConditionType.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\AutoCategoryCondition;
+use App\Enum\ConditionField;
+use App\Enum\ConditionOperator;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class AutoCategoryConditionType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $b, array $opt): void
+    {
+        $b
+            ->add('field', ChoiceType::class, [
+                'choices' => [
+                    'ИНН плательщика' => ConditionField::PLAT_INN,
+                    'ИНН получателя' => ConditionField::POL_INN,
+                    'Описание платежа (DESCRIPTION)' => ConditionField::DESCRIPTION,
+                    'Сумма (AMOUNT)' => ConditionField::AMOUNT,
+                    'Имя контрагента (raw)' => ConditionField::COUNTERPARTY_NAME_RAW,
+                    'Наш счёт' => ConditionField::MONEY_ACCOUNT,
+                    'Номер документа' => ConditionField::DOC_NUMBER,
+                    'Дата' => ConditionField::DATE,
+                ],
+                'placeholder' => 'Выберите поле',
+                'attr' => ['class' => 'form-select'],
+            ])
+            ->add('operator', ChoiceType::class, [
+                'choices' => [
+                    'Равно' => ConditionOperator::EQUALS,
+                    'Содержит' => ConditionOperator::CONTAINS,
+                    'Регулярное выражение' => ConditionOperator::REGEX,
+                    'Между (числа/дата)' => ConditionOperator::BETWEEN,
+                    'IN (список)' => ConditionOperator::IN,
+                    'Не содержит' => ConditionOperator::NOT_CONTAINS,
+                    'Не равно' => ConditionOperator::NOT_EQUALS,
+                ],
+                'placeholder' => 'Выберите оператор',
+                'attr' => ['class' => 'form-select'],
+            ])
+            // ВАЖНО: для строковых полей это обычное текстовое поле, куда пользователь ВРУЧНУЮ вводит триггер
+            ->add('value', TextType::class, [
+                'attr' => [
+                    'class' => 'form-control js-value',
+                    'placeholder' => 'Введите триггер (слово/фразу) или значение',
+                ],
+                'help' => 'Для "Содержит" введите слово или фразу. Для BETWEEN: мин..макс. Для IN: ["A","B"]. Для REGEX: корректный паттерн.',
+            ])
+            ->add('caseSensitive', CheckboxType::class, [
+                'required' => false,
+                'label' => 'Учитывать регистр (для строковых операторов)',
+            ])
+            ->add('negate', CheckboxType::class, [
+                'required' => false,
+                'label' => 'Инвертировать условие',
+            ])
+            ->add('position', HiddenType::class, [
+                'empty_data' => '0',
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults(['data_class' => AutoCategoryCondition::class]);
+    }
+}

--- a/site/src/Form/AutoCategoryTemplateType.php
+++ b/site/src/Form/AutoCategoryTemplateType.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\AutoCategoryTemplate;
+use App\Enum\AutoTemplateDirection;
+use App\Enum\MatchLogic;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class AutoCategoryTemplateType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $b, array $opt): void
+    {
+        $b
+            ->add('name', TextType::class, [
+                'attr' => ['class' => 'form-control', 'placeholder' => 'Например: Связь (ключевые слова)'],
+                'label' => 'Название шаблона',
+            ])
+            ->add('isActive', CheckboxType::class, [
+                'required' => false,
+                'label' => 'Активен',
+            ])
+            ->add('direction', ChoiceType::class, [
+                'choices' => [
+                    'Любое' => AutoTemplateDirection::ANY,
+                    'Приток' => AutoTemplateDirection::INFLOW,
+                    'Отток' => AutoTemplateDirection::OUTFLOW,
+                ],
+                'attr' => ['class' => 'form-select'],
+                'label' => 'Направление',
+            ])
+            ->add('targetCategory', null, [
+                'label' => 'Целевая статья ДДС',
+                'attr' => ['class' => 'form-select'],
+            ])
+            ->add('priority', IntegerType::class, [
+                'label' => 'Приоритет (меньше — выше)',
+                'empty_data' => '100',
+                'attr' => ['class' => 'form-control', 'min' => 0],
+            ])
+            ->add('stopOnMatch', CheckboxType::class, [
+                'required' => false,
+                'label' => 'Остановиться после совпадения',
+            ])
+            ->add('matchLogic', ChoiceType::class, [
+                'choices' => [
+                    'Все условия (AND)' => MatchLogic::ALL,
+                    'Любое условие (OR)' => MatchLogic::ANY,
+                ],
+                'attr' => ['class' => 'form-select'],
+                'label' => 'Логика совпадения',
+            ])
+            ->add('conditions', CollectionType::class, [
+                'entry_type' => AutoCategoryConditionType::class,
+                'allow_add' => true,
+                'allow_delete' => true,
+                'by_reference' => false,
+                'label' => 'Условия',
+                'prototype' => true,
+                'entry_options' => ['label' => false],
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults(['data_class' => AutoCategoryTemplate::class]);
+    }
+}

--- a/site/templates/auto_template/form.html.twig
+++ b/site/templates/auto_template/form.html.twig
@@ -1,0 +1,157 @@
+{% extends 'base.html.twig' %}
+
+{% block body %}
+<div class="page-body">
+  <div class="container-xl">
+    <div class="row row-cards">
+      <div class="col-12">
+        <form method="post">
+          <div class="card">
+            <div class="card-header">
+              <h3 class="card-title">Шаблон автокатегоризации ДДС</h3>
+            </div>
+            <div class="card-body">
+              <div class="row g-3">
+                <div class="col-md-6">
+                  <label class="form-label">Название</label>
+                  {{ form_widget(form.name) }}
+                </div>
+                <div class="col-md-3">
+                  <label class="form-label">Активен</label><br>
+                  {{ form_widget(form.isActive) }}
+                </div>
+                <div class="col-md-3">
+                  <label class="form-label">Направление</label>
+                  {{ form_widget(form.direction) }}
+                </div>
+                <div class="col-md-6">
+                  <label class="form-label">Целевая статья ДДС</label>
+                  {{ form_widget(form.targetCategory) }}
+                </div>
+                <div class="col-md-3">
+                  <label class="form-label">Приоритет</label>
+                  {{ form_widget(form.priority) }}
+                </div>
+                <div class="col-md-3">
+                  <label class="form-label">Логика совпадения</label>
+                  {{ form_widget(form.matchLogic) }}
+                </div>
+                <div class="col-md-6">
+                  <label class="form-label">Остановиться после совпадения</label><br>
+                  {{ form_widget(form.stopOnMatch) }}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="card mt-3">
+            <div class="card-header">
+              <h3 class="card-title">Условия</h3>
+              <div class="card-actions">
+                <button type="button" class="btn btn-sm btn-primary" id="add-condition">Добавить условие</button>
+              </div>
+            </div>
+            <div class="card-body">
+              <div data-collection-holder
+                   data-prototype="{{ form_widget(form.conditions.vars.prototype)|e('html_attr') }}">
+                {% for condForm in form.conditions %}
+                  <div class="border rounded p-3 mb-3 condition-item">
+                    <div class="row g-3 align-items-end">
+                      <div class="col-md-3">
+                        <label class="form-label">Поле</label>
+                        {{ form_widget(condForm.field, {'attr': {'class': 'form-select js-field'}}) }}
+                      </div>
+                      <div class="col-md-3">
+                        <label class="form-label">Оператор</label>
+                        {{ form_widget(condForm.operator, {'attr': {'class': 'form-select js-operator'}}) }}
+                      </div>
+                      <div class="col-md-4">
+                        <label class="form-label">Значение</label>
+                        {{ form_widget(condForm.value) }}
+                        <div class="form-hint js-hint">
+                          Для «Содержит» введите слово/фразу. BETWEEN: 1000..5000. IN: ["A","B"]. REGEX: корректный паттерн.
+                        </div>
+                      </div>
+                      <div class="col-md-2">
+                        <label class="form-label">Опции</label>
+                        <div class="form-check">
+                          {{ form_widget(condForm.caseSensitive, {'attr': {'class': 'form-check-input'}}) }}
+                          <label class="form-check-label">Учитывать регистр</label>
+                        </div>
+                        <div class="form-check">
+                          {{ form_widget(condForm.negate, {'attr': {'class': 'form-check-input'}}) }}
+                          <label class="form-check-label">Инвертировать</label>
+                        </div>
+                      </div>
+                      <div class="col-12 text-end">
+                        <button type="button" class="btn btn-link text-danger p-0 js-remove-condition">Удалить</button>
+                      </div>
+                      {{ form_widget(condForm.position) }}
+                    </div>
+                  </div>
+                {% endfor %}
+              </div>
+            </div>
+          </div>
+
+          <div class="mt-3 d-flex gap-2">
+            <button class="btn btn-primary" type="submit">Сохранить</button>
+            <a href="{{ path('auto_template_index') }}" class="btn btn-secondary">Отмена</a>
+          </div>
+
+          {{ form_rest(form) }}
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  (function(){
+    const holder = document.querySelector('[data-collection-holder]');
+    const addBtn = document.getElementById('add-condition');
+
+    function addForm() {
+      const prototype = holder.dataset.prototype;
+      const index = holder.querySelectorAll('.condition-item').length;
+      const html = prototype.replace(/__name__/g, index);
+      const div = document.createElement('div');
+      div.className = 'border rounded p-3 mb-3 condition-item';
+      div.innerHTML = html;
+      attachHandlers(div);
+      holder.appendChild(div);
+    }
+
+    function attachHandlers(scope) {
+      scope.querySelectorAll('.js-remove-condition').forEach(btn => {
+        btn.addEventListener('click', () => scope.remove());
+      });
+      const field = scope.querySelector('.js-field');
+      const op = scope.querySelector('.js-operator');
+      const hint = scope.querySelector('.js-hint');
+      const value = scope.querySelector('.js-value');
+
+      function refreshHint() {
+        const f = field?.value || '';
+        const o = op?.value || '';
+        if (['contains','eq','neq','ncontains','starts_with','ends_with','regex','in','not_in'].includes(o)) {
+          value.placeholder = 'Введите триггер (слово/фразу) или значение';
+          hint.textContent = 'Строковые: впишите триггер вручную. IN — JSON-массив. REGEX — корректный паттерн.';
+        } else if (o === 'between') {
+          value.placeholder = 'min..max (пример: 1000..5000 или 2025-01-01..2025-12-31)';
+          hint.textContent = 'BETWEEN: min..max для чисел или дат (YYYY-MM-DD).';
+        } else {
+          value.placeholder = 'Значение';
+          hint.textContent = 'Укажите значение. Для строк — можно вводить слова/фразы.';
+        }
+      }
+      field?.addEventListener('change', refreshHint);
+      op?.addEventListener('change', refreshHint);
+      refreshHint();
+    }
+
+    addBtn?.addEventListener('click', addForm);
+    document.querySelectorAll('.condition-item').forEach(attachHandlers);
+  })();
+</script>
+{% endblock %}

--- a/site/templates/auto_template/index.html.twig
+++ b/site/templates/auto_template/index.html.twig
@@ -1,0 +1,61 @@
+{% extends 'base.html.twig' %}
+{% block body %}
+<div class="page-body">
+  <div class="container-xl">
+    <div class="card">
+      <div class="card-header">
+        <h3 class="card-title">Шаблоны автокатегоризации ДДС</h3>
+        <div class="card-actions">
+          <a href="{{ path('auto_template_new') }}" class="btn btn-primary btn-sm">Создать шаблон</a>
+        </div>
+      </div>
+      <div class="table-responsive">
+        <table class="table card-table table-vcenter">
+          <thead>
+          <tr>
+            <th>Активен</th>
+            <th>Название</th>
+            <th>Направление</th>
+            <th>Категория</th>
+            <th>Приоритет</th>
+            <th>Условий</th>
+            <th class="w-1"></th>
+          </tr>
+          </thead>
+          <tbody>
+          {% for t in templates %}
+            <tr>
+              <td>
+                {% if t.isActive %}
+                  <span class="badge bg-green">Да</span>
+                {% else %}
+                  <span class="badge bg-secondary">Нет</span>
+                {% endif %}
+              </td>
+              <td>{{ t.name }}</td>
+              <td>{{ t.direction.value }}</td>
+              <td>{{ t.targetCategory.name ?? '—' }}</td>
+              <td>{{ t.priority }}</td>
+              <td>{{ t.conditions|length }}</td>
+              <td class="text-nowrap">
+                <a href="{{ path('auto_template_edit', {id: t.id}) }}" class="btn btn-sm">Ред.</a>
+                <a href="{{ path('auto_template_test', {id: t.id}) }}" class="btn btn-sm">Тест</a>
+                <form method="post" action="{{ path('auto_template_toggle', {id: t.id}) }}" style="display:inline">
+                  <button class="btn btn-sm">{{ t.isActive ? 'Выкл' : 'Вкл' }}</button>
+                </form>
+                <form method="post" action="{{ path('auto_template_delete', {id: t.id}) }}" style="display:inline"
+                      onsubmit="return confirm('Удалить шаблон?');">
+                  <button class="btn btn-sm btn-danger">Удалить</button>
+                </form>
+              </td>
+            </tr>
+          {% else %}
+            <tr><td colspan="7" class="text-center text-muted">Шаблонов пока нет</td></tr>
+          {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/site/templates/partials/_sidebar.html.twig
+++ b/site/templates/partials/_sidebar.html.twig
@@ -65,6 +65,9 @@
                         <a class="dropdown-item {{ current_route starts with 'pl_category_' ? 'active' : '' }}" href="{{ path('pl_category_index') }}">
                             <span class="nav-link-title">Категории P&amp;L</span>
                         </a>
+                        <a class="dropdown-item {{ current_route starts with 'auto_template_' ? 'active' : '' }}" href="{{ path('auto_template_index') }}">
+                            <span class="nav-link-title">Автоправила</span>
+                        </a>
                     </div>
                 </li>
 


### PR DESCRIPTION
## Summary
- introduce enums and entities for auto category templates and conditions
- add Symfony form types for templates and conditions with text input value
- create Tabler-based Twig templates for managing auto category templates
- add migrations for auto-category tables
- add "Автоправила" link in reference data menu

## Testing
- `composer install` *(fails: requires GitHub token)*
- `php bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`)*

------
https://chatgpt.com/codex/tasks/task_e_68c0116054c083239914ffd5c280fb15