### PR TITLE
fix: correct regex delimiter escaping

### DIFF
--- a/site/src/Service/AutoCategory/ConditionEvaluator.php
+++ b/site/src/Service/AutoCategory/ConditionEvaluator.php
@@ -103,7 +103,10 @@ class ConditionEvaluator implements ConditionEvaluatorInterface
         }
         $delim = '/';
         $mod = $caseSensitive ? '' : 'i';
-        $regex = $delim . str_replace($delim, '\' . $delim, $pattern) . $delim . $mod;
+        // Escape delimiter in pattern to build a valid regular expression.
+        // Need to prefix delimiter with a single backslash. In single quoted
+        // strings, we write "\\" to represent one backslash character.
+        $regex = $delim . str_replace($delim, '\\' . $delim, $pattern) . $delim . $mod;
         $result = @preg_match($regex, $value);
         return $result === 1;
     }


### PR DESCRIPTION
## Summary
- fix parse error in ConditionEvaluator by properly escaping the regex delimiter

## Testing
- `php -l site/src/Service/AutoCategory/ConditionEvaluator.php`
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c1225116608323b6af6b2ddbab1ab7