### PR TITLE
feat: add auto categorization templates and integration

### DIFF
--- a/site/src/Controller/Finance/AutoCategoryTemplateController.php
+++ b/site/src/Controller/Finance/AutoCategoryTemplateController.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace App\Controller\Finance;
+
+use App\Entity\AutoCategoryTemplate;
+use App\Entity\CashTransaction;
+use App\Enum\AutoTemplateScope;
+use App\Enum\AutoTemplateDirection;
+use App\Enum\MatchLogic;
+use App\Form\AutoCategoryTemplateType;
+use App\Repository\AutoCategoryTemplateRepository;
+use App\Repository\CashTransactionRepository;
+use App\Service\ActiveCompanyService;
+use App\Service\AutoCategory\ConditionEvaluatorInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Ramsey\Uuid\Uuid;
+
+#[Route('/finance/auto-templates')]
+#[IsGranted('ROLE_USER')]
+class AutoCategoryTemplateController extends AbstractController
+{
+    public function __construct(private ActiveCompanyService $companyService)
+    {
+    }
+
+    #[Route('/', name: 'auto_template_index', methods: ['GET'])]
+    public function index(AutoCategoryTemplateRepository $repo): Response
+    {
+        $company = $this->companyService->getActiveCompany();
+        $templates = $repo->findBy([
+            'company' => $company,
+            'scope' => AutoTemplateScope::CASHFLOW,
+        ], ['priority' => 'ASC']);
+
+        return $this->render('auto_template/index.html.twig', [
+            'templates' => $templates,
+        ]);
+    }
+
+    #[Route('/new', name: 'auto_template_new', methods: ['GET', 'POST'])]
+    public function new(Request $request, EntityManagerInterface $em): Response
+    {
+        $company = $this->companyService->getActiveCompany();
+        $template = new AutoCategoryTemplate(Uuid::uuid4()->toString(), $company);
+        $template->setScope(AutoTemplateScope::CASHFLOW);
+
+        $form = $this->createForm(AutoCategoryTemplateType::class, $template);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $em->persist($template);
+            $em->flush();
+            return $this->redirectToRoute('auto_template_index');
+        }
+
+        return $this->render('auto_template/form.html.twig', [
+            'form' => $form->createView(),
+        ]);
+    }
+
+    #[Route('/{id}/edit', name: 'auto_template_edit', methods: ['GET', 'POST'])]
+    public function edit(Request $request, AutoCategoryTemplate $template, EntityManagerInterface $em): Response
+    {
+        $company = $this->companyService->getActiveCompany();
+        if ($template->getCompany() !== $company) {
+            throw $this->createNotFoundException();
+        }
+
+        $form = $this->createForm(AutoCategoryTemplateType::class, $template);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $em->flush();
+            return $this->redirectToRoute('auto_template_index');
+        }
+
+        return $this->render('auto_template/form.html.twig', [
+            'form' => $form->createView(),
+            'template' => $template,
+        ]);
+    }
+
+    #[Route('/{id}/toggle', name: 'auto_template_toggle', methods: ['POST'])]
+    public function toggle(Request $request, AutoCategoryTemplate $template, EntityManagerInterface $em): Response
+    {
+        $company = $this->companyService->getActiveCompany();
+        if ($template->getCompany() !== $company) {
+            throw $this->createNotFoundException();
+        }
+        $template->setIsActive(!$template->isActive());
+        $em->flush();
+        $referer = $request->headers->get('referer');
+        return $referer ? $this->redirect($referer) : $this->redirectToRoute('auto_template_index');
+    }
+
+    #[Route('/{id}/delete', name: 'auto_template_delete', methods: ['POST'])]
+    public function delete(AutoCategoryTemplate $template, EntityManagerInterface $em): Response
+    {
+        $company = $this->companyService->getActiveCompany();
+        if ($template->getCompany() !== $company) {
+            throw $this->createNotFoundException();
+        }
+        $em->remove($template);
+        $em->flush();
+        return $this->redirectToRoute('auto_template_index');
+    }
+
+    #[Route('/{id}/test', name: 'auto_template_test', methods: ['GET', 'POST'])]
+    public function test(
+        Request $request,
+        AutoCategoryTemplate $template,
+        CashTransactionRepository $txRepo,
+        ConditionEvaluatorInterface $evaluator
+    ): Response {
+        $company = $this->companyService->getActiveCompany();
+        if ($template->getCompany() !== $company) {
+            throw $this->createNotFoundException();
+        }
+
+        $operations = $txRepo->findBy(
+            ['company' => $company],
+            ['occurredAt' => 'DESC'],
+            50
+        );
+
+        $result = null;
+        $selected = null;
+
+        if ($request->isMethod('POST')) {
+            $txId = $request->request->get('tx');
+            /** @var CashTransaction|null $tx */
+            $tx = $txRepo->find($txId);
+            if ($tx && $tx->getCompany() === $company) {
+                $selected = $tx;
+                $operation = [
+                    'plat_inn' => null,
+                    'pol_inn' => null,
+                    'description' => $tx->getDescription() ?? '',
+                    'amount' => $tx->getAmount(),
+                    'counterparty_name_raw' => $tx->getCounterparty()?->getName(),
+                    'payer_account' => null,
+                    'payee_account' => null,
+                    'payer_bic' => null,
+                    'payee_bank' => null,
+                    'doc_number' => $tx->getExternalId(),
+                    'date' => $tx->getOccurredAt(),
+                    'money_account' => $tx->getMoneyAccount()->getId(),
+                    'counterparty_id' => $tx->getCounterparty()?->getId(),
+                    'counterparty_type' => $tx->getCounterparty()?->getType()->value ?? null,
+                ];
+
+                $condResults = [];
+                foreach ($template->getConditions() as $cond) {
+                    $condResults[] = [
+                        'field' => $cond->getField()->value,
+                        'operator' => $cond->getOperator()->value,
+                        'value' => $cond->getValue(),
+                        'result' => $evaluator->isConditionMatched($operation, $cond),
+                    ];
+                }
+                $matches = $template->getMatchLogic() === MatchLogic::ALL
+                    ? !in_array(false, array_column($condResults, 'result'), true)
+                    : in_array(true, array_column($condResults, 'result'), true);
+
+                $result = [
+                    'conditions' => $condResults,
+                    'category' => $matches ? $template->getTargetCategory() : null,
+                ];
+            }
+        }
+
+        return $this->render('auto_template/test.html.twig', [
+            'template' => $template,
+            'operations' => $operations,
+            'selected' => $selected,
+            'result' => $result,
+        ]);
+    }
+}
+

--- a/site/src/DTO/CashTransactionDTO.php
+++ b/site/src/DTO/CashTransactionDTO.php
@@ -3,6 +3,7 @@
 namespace App\DTO;
 
 use App\Enum\CashDirection;
+use App\Enum\CounterpartyType;
 use Symfony\Component\Validator\Constraints as Assert;
 
 class CashTransactionDTO
@@ -32,6 +33,15 @@ class CashTransactionDTO
 
     public ?string $description = null;
     public ?string $externalId = null;
+
+    public ?string $payerInn = null;
+    public ?string $payeeInn = null;
+    public ?string $counterpartyNameRaw = null;
+    public ?string $payerAccount = null;
+    public ?string $payeeAccount = null;
+    public ?string $payerBic = null;
+    public ?string $payeeBank = null;
+    public ?CounterpartyType $counterpartyType = null;
 
     public function __construct()
     {

--- a/site/src/Service/AutoCategory/AutoCategorizer.php
+++ b/site/src/Service/AutoCategory/AutoCategorizer.php
@@ -52,6 +52,7 @@ class AutoCategorizer implements AutoCategorizerInterface
         }
 
         $this->logger->info('auto_category', [
+            'company_id' => $company->getId(),
             'operationRef' => $operation['doc_number'] ?? null,
             'matched_template_id' => $matchedTemplateId,
             'conditions' => $matchedConditions,

--- a/site/templates/auto_template/form.html.twig
+++ b/site/templates/auto_template/form.html.twig
@@ -69,7 +69,7 @@
                         <label class="form-label">Значение</label>
                         {{ form_widget(condForm.value) }}
                         <div class="form-hint js-hint">
-                          Для «Содержит» введите слово/фразу. BETWEEN: 1000..5000. IN: ["A","B"]. REGEX: корректный паттерн.
+                          CONTAINS — слово/фраза. BETWEEN: min..max (числа или YYYY-MM-DD). IN: ["A","B"]. REGEX: валидный PCRE.
                         </div>
                       </div>
                       <div class="col-md-2">
@@ -136,10 +136,10 @@
         const o = op?.value || '';
         if (['contains','eq','neq','ncontains','starts_with','ends_with','regex','in','not_in'].includes(o)) {
           value.placeholder = 'Введите триггер (слово/фразу) или значение';
-          hint.textContent = 'Строковые: впишите триггер вручную. IN — JSON-массив. REGEX — корректный паттерн.';
+          hint.textContent = 'CONTAINS — слово/фраза. IN — ["A","B"]. REGEX — валидный PCRE.';
         } else if (o === 'between') {
           value.placeholder = 'min..max (пример: 1000..5000 или 2025-01-01..2025-12-31)';
-          hint.textContent = 'BETWEEN: min..max для чисел или дат (YYYY-MM-DD).';
+          hint.textContent = 'BETWEEN — min..max для чисел или дат (YYYY-MM-DD).';
         } else {
           value.placeholder = 'Значение';
           hint.textContent = 'Укажите значение. Для строк — можно вводить слова/фразы.';

--- a/site/templates/auto_template/test.html.twig
+++ b/site/templates/auto_template/test.html.twig
@@ -1,0 +1,55 @@
+{% extends 'base.html.twig' %}
+
+{% block body %}
+<div class="page-body">
+  <div class="container-xl">
+    <h3>Тест шаблона "{{ template.name }}"</h3>
+    <form method="post" class="mb-3">
+      <div class="mb-3">
+        <label class="form-label">Операция</label>
+        <select name="tx" class="form-select">
+          {% for o in operations %}
+            <option value="{{ o.id }}" {% if selected and selected.id == o.id %}selected{% endif %}>
+              {{ o.occurredAt|date('Y-m-d') }} — {{ o.amount }} — {{ o.description|default('') }}
+            </option>
+          {% endfor %}
+        </select>
+      </div>
+      <button class="btn btn-primary" type="submit">Проверить</button>
+      <a href="{{ path('auto_template_index') }}" class="btn btn-secondary">Назад</a>
+    </form>
+
+    {% if result %}
+      <h4>Результат</h4>
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Поле</th>
+            <th>Оператор</th>
+            <th>Значение</th>
+            <th>Совп.</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in result.conditions %}
+            <tr>
+              <td>{{ row.field }}</td>
+              <td>{{ row.operator }}</td>
+              <td>{{ row.value }}</td>
+              <td>{{ row.result ? 'Да' : 'Нет' }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      <div class="mt-2">
+        {% if result.category %}
+          Категория будет присвоена: {{ result.category.name }}
+        {% else %}
+          Совпадений нет.
+        {% endif %}
+      </div>
+    {% endif %}
+  </div>
+</div>
+{% endblock %}
+

--- a/site/templates/partials/_sidebar.html.twig
+++ b/site/templates/partials/_sidebar.html.twig
@@ -65,8 +65,8 @@
                         <a class="dropdown-item {{ current_route starts with 'pl_category_' ? 'active' : '' }}" href="{{ path('pl_category_index') }}">
                             <span class="nav-link-title">Статьи ОПиУ (P&amp;L)</span>
                         </a>
-                        <a class="dropdown-item {{ current_route starts with 'auto_template_' ? 'active' : '' }}" href="#">
-                            <span class="nav-link-title">Автоправила</span>
+                        <a class="dropdown-item {{ current_route starts with 'auto_template_' ? 'active' : '' }}" href="{{ path('auto_template_index') }}">
+                            <span class="nav-link-title">Автокатегоризация</span>
                         </a>
                     </div>
                 </li>

--- a/site/tests/Service/AccountBalanceServiceTest.php
+++ b/site/tests/Service/AccountBalanceServiceTest.php
@@ -6,6 +6,7 @@ use App\DTO\CashTransactionDTO;
 use App\Enum\CashDirection;
 use App\Service\AccountBalanceService;
 use App\Service\CashTransactionService;
+use App\Service\AutoCategory\AutoCategorizerInterface;
 use App\Entity\User;
 use App\Entity\Company;
 use App\Entity\MoneyAccount;
@@ -58,7 +59,8 @@ class AccountBalanceServiceTest extends TestCase
         $txRepo = new \App\Repository\CashTransactionRepository($registry);
         $balanceRepo = new \App\Repository\MoneyAccountDailyBalanceRepository($registry);
         $this->balanceService = new AccountBalanceService($txRepo, $balanceRepo);
-        $this->txService = new CashTransactionService($this->em, $this->balanceService, $txRepo);
+        $categorizer = $this->createMock(AutoCategorizerInterface::class);
+        $this->txService = new CashTransactionService($this->em, $this->balanceService, $txRepo, $categorizer);
     }
 
     public function testRecalculateBalances(): void

--- a/site/tests/Service/Bank1CImportServiceTest.php
+++ b/site/tests/Service/Bank1CImportServiceTest.php
@@ -18,6 +18,7 @@ use App\Service\AccountBalanceService;
 use App\Service\Bank1C\Bank1CImportService;
 use App\Service\Bank1C\Bank1CStatementParser;
 use App\Service\CashTransactionService;
+use App\Service\AutoCategory\AutoCategorizerInterface;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\ORM\Tools\Setup;
@@ -70,9 +71,10 @@ class Bank1CImportServiceTest extends TestCase
         $cpRepo = new CounterpartyRepository($registry);
         $balanceRepo = new MoneyAccountDailyBalanceRepository($registry);
         $balanceService = new AccountBalanceService($txRepo, $balanceRepo);
-        $txService = new CashTransactionService($this->em, $balanceService, $txRepo);
+        $categorizer = $this->createMock(AutoCategorizerInterface::class);
+        $txService = new CashTransactionService($this->em, $balanceService, $txRepo, $categorizer);
         $parser = new Bank1CStatementParser();
-        $this->importService = new Bank1CImportService($parser, $txService, $cpRepo, $txRepo, $this->em);
+        $this->importService = new Bank1CImportService($parser, $txService, $cpRepo, $txRepo, $this->em, $categorizer);
 
         $user = new User(Uuid::uuid4()->toString());
         $user->setEmail('t@example.com');

--- a/site/tests/Service/CashTransactionServiceTest.php
+++ b/site/tests/Service/CashTransactionServiceTest.php
@@ -8,6 +8,7 @@ use App\Enum\MoneyAccountType;
 use App\Enum\CounterpartyType;
 use App\Service\AccountBalanceService;
 use App\Service\CashTransactionService;
+use App\Service\AutoCategory\AutoCategorizerInterface;
 use App\Entity\User;
 use App\Entity\Company;
 use App\Entity\MoneyAccount;
@@ -64,7 +65,8 @@ class CashTransactionServiceTest extends TestCase
         $txRepo = new \App\Repository\CashTransactionRepository($registry);
         $balanceRepo = new \App\Repository\MoneyAccountDailyBalanceRepository($registry);
         $balanceService = new AccountBalanceService($txRepo, $balanceRepo);
-        $this->txService = new CashTransactionService($this->em, $balanceService, $txRepo);
+        $categorizer = $this->createMock(AutoCategorizerInterface::class);
+        $this->txService = new CashTransactionService($this->em, $balanceService, $txRepo, $categorizer);
     }
 
     public function testAddPersistsAllFields(): void


### PR DESCRIPTION
## Summary
- implement CRUD controller and testing view for auto-category templates
- validate regex conditions and add auto-categorization hooks
- expose auto-categorization in sidebar

## Testing
- `composer install` *(fails: CONNECT tunnel failed 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c1306b4560832395cec41e448f56bf