### PR TITLE
Add string conversion for CashflowCategory to fix form rendering

### DIFF
--- a/site/src/Entity/CashflowCategory.php
+++ b/site/src/Entity/CashflowCategory.php
@@ -68,4 +68,6 @@ class CashflowCategory
     {
         return $this->parent ? $this->parent->getLevel() + 1 : 1;
     }
+
+    public function __toString(): string { return $this->name; }
 }


### PR DESCRIPTION
## Summary
- provide __toString implementation for CashflowCategory so form fields can render choices

## Testing
- `composer install --no-interaction --no-progress --prefer-dist` (fails: Failed to clone https://github.com/symfony/flex.git)
- `./vendor/bin/phpunit` (fails: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68c1343790ac8323b67f775624f25767