### PR TITLE
Allow AutoCategoryCondition instantiation without arguments

### DIFF
--- a/site/src/Entity/AutoCategoryCondition.php
+++ b/site/src/Entity/AutoCategoryCondition.php
@@ -5,6 +5,7 @@ namespace App\Entity;
 use App\Enum\ConditionField;
 use App\Enum\ConditionOperator;
 use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
 
 #[ORM\Entity]
 class AutoCategoryCondition
@@ -15,7 +16,7 @@ class AutoCategoryCondition
 
     #[ORM\ManyToOne(inversedBy: 'conditions')]
     #[ORM\JoinColumn(nullable: false)]
-    private AutoCategoryTemplate $template;
+    private ?AutoCategoryTemplate $template = null;
 
     #[ORM\Column(enumType: ConditionField::class)]
     private ConditionField $field;
@@ -35,14 +36,15 @@ class AutoCategoryCondition
     #[ORM\Column(type: 'integer')]
     private int $position = 0;
 
-    public function __construct(string $id, AutoCategoryTemplate $template)
+    public function __construct(?string $id = null, ?AutoCategoryTemplate $template = null)
     {
-        $this->id = $id;
+        $this->id = $id ?? Uuid::uuid4()->toString();
         $this->template = $template;
     }
 
     public function getId(): string { return $this->id; }
-    public function getTemplate(): AutoCategoryTemplate { return $this->template; }
+    public function getTemplate(): ?AutoCategoryTemplate { return $this->template; }
+    public function setTemplate(AutoCategoryTemplate $t): self { $this->template = $t; return $this; }
     public function getField(): ConditionField { return $this->field; }
     public function setField(ConditionField $f): self { $this->field = $f; return $this; }
     public function getOperator(): ConditionOperator { return $this->operator; }

--- a/site/src/Entity/AutoCategoryTemplate.php
+++ b/site/src/Entity/AutoCategoryTemplate.php
@@ -83,7 +83,15 @@ class AutoCategoryTemplate
     public function setMatchLogic(MatchLogic $m): self { $this->matchLogic = $m; return $this; }
     /** @return Collection<int, AutoCategoryCondition> */
     public function getConditions(): Collection { return $this->conditions; }
-    public function addCondition(AutoCategoryCondition $c): self { if(!$this->conditions->contains($c)){ $this->conditions->add($c); } return $this; }
+    public function addCondition(AutoCategoryCondition $c): self
+    {
+        if (!$this->conditions->contains($c)) {
+            $c->setTemplate($this);
+            $this->conditions->add($c);
+        }
+
+        return $this;
+    }
     public function removeCondition(AutoCategoryCondition $c): self { $this->conditions->removeElement($c); return $this; }
     public function getCreatedAt(): \DateTimeImmutable { return $this->createdAt; }
     public function setCreatedAt(\DateTimeImmutable $d): self { $this->createdAt = $d; return $this; }


### PR DESCRIPTION
## Summary
- allow AutoCategoryCondition to be created without constructor arguments and generate a UUID by default
- ensure AutoCategoryTemplate::addCondition sets the owning template

## Testing
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c1638e4f0c832382ac4bcfa812533e