### PR TITLE
feat: add project directions reference

### DIFF
--- a/site/migrations/Version20250910121000.php
+++ b/site/migrations/Version20250910121000.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250910121000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create project_directions table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE project_directions (id UUID NOT NULL, company_id UUID NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX idx_project_directions_company ON project_directions (company_id)');
+        $this->addSql('ALTER TABLE project_directions ADD CONSTRAINT fk_project_directions_company FOREIGN KEY (company_id) REFERENCES companies (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE project_directions');
+    }
+}

--- a/site/src/Controller/ProjectDirectionController.php
+++ b/site/src/Controller/ProjectDirectionController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\ProjectDirection;
+use App\Form\ProjectDirectionType;
+use App\Repository\ProjectDirectionRepository;
+use App\Service\ActiveCompanyService;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/project-directions')]
+class ProjectDirectionController extends AbstractController
+{
+    #[Route('/', name: 'project_direction_index', methods: ['GET'])]
+    public function index(ProjectDirectionRepository $repo, ActiveCompanyService $companyService): Response
+    {
+        $company = $companyService->getActiveCompany();
+        $items = $repo->findByCompany($company);
+        return $this->render('project_direction/index.html.twig', [
+            'items' => $items,
+        ]);
+    }
+
+    #[Route('/new', name: 'project_direction_new', methods: ['GET', 'POST'])]
+    public function new(Request $request, EntityManagerInterface $em, ActiveCompanyService $companyService): Response
+    {
+        $company = $companyService->getActiveCompany();
+        $direction = new ProjectDirection(Uuid::uuid4()->toString(), $company, '');
+        $form = $this->createForm(ProjectDirectionType::class, $direction);
+        $form->handleRequest($request);
+        if ($form->isSubmitted() && $form->isValid()) {
+            $em->persist($direction);
+            $em->flush();
+            return $this->redirectToRoute('project_direction_index');
+        }
+        return $this->render('project_direction/new.html.twig', [
+            'form' => $form->createView(),
+        ]);
+    }
+
+    #[Route('/{id}/edit', name: 'project_direction_edit', methods: ['GET', 'POST'])]
+    public function edit(ProjectDirection $direction, Request $request, EntityManagerInterface $em, ActiveCompanyService $companyService): Response
+    {
+        $company = $companyService->getActiveCompany();
+        if ($direction->getCompany() !== $company) {
+            throw $this->createNotFoundException();
+        }
+        $form = $this->createForm(ProjectDirectionType::class, $direction);
+        $form->handleRequest($request);
+        if ($form->isSubmitted() && $form->isValid()) {
+            $em->flush();
+            return $this->redirectToRoute('project_direction_index');
+        }
+        return $this->render('project_direction/edit.html.twig', [
+            'form' => $form->createView(),
+            'item' => $direction,
+        ]);
+    }
+
+    #[Route('/{id}/delete', name: 'project_direction_delete', methods: ['POST'])]
+    public function delete(ProjectDirection $direction, Request $request, EntityManagerInterface $em, ActiveCompanyService $companyService): Response
+    {
+        $company = $companyService->getActiveCompany();
+        if ($direction->getCompany() !== $company) {
+            throw $this->createNotFoundException();
+        }
+        if ($this->isCsrfTokenValid('delete'.$direction->getId(), $request->request->get('_token'))) {
+            $em->remove($direction);
+            $em->flush();
+        }
+        return $this->redirectToRoute('project_direction_index');
+    }
+}

--- a/site/src/Entity/ProjectDirection.php
+++ b/site/src/Entity/ProjectDirection.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\ProjectDirectionRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity(repositoryClass: ProjectDirectionRepository::class)]
+#[ORM\Table(name: 'project_directions')]
+class ProjectDirection
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid', unique: true)]
+    private ?string $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Company::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private Company $company;
+
+    #[ORM\Column(length: 255)]
+    private string $name;
+
+    public function __construct(string $id, Company $company, string $name)
+    {
+        Assert::uuid($id);
+        $this->id = $id;
+        $this->company = $company;
+        $this->name = $name;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getCompany(): Company
+    {
+        return $this->company;
+    }
+
+    public function setCompany(Company $company): self
+    {
+        $this->company = $company;
+        return $this;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+        return $this;
+    }
+}

--- a/site/src/Form/ProjectDirectionType.php
+++ b/site/src/Form/ProjectDirectionType.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\ProjectDirection;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ProjectDirectionType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('name', TextType::class, [
+            'label' => 'Наименование',
+        ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => ProjectDirection::class,
+        ]);
+    }
+}

--- a/site/src/Repository/ProjectDirectionRepository.php
+++ b/site/src/Repository/ProjectDirectionRepository.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Company;
+use App\Entity\ProjectDirection;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class ProjectDirectionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ProjectDirection::class);
+    }
+
+    /**
+     * @return ProjectDirection[]
+     */
+    public function findByCompany(Company $company): array
+    {
+        return $this->createQueryBuilder('d')
+            ->andWhere('d.company = :company')
+            ->setParameter('company', $company)
+            ->orderBy('d.name', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/site/templates/partials/_sidebar.html.twig
+++ b/site/templates/partials/_sidebar.html.twig
@@ -65,6 +65,9 @@
                         <a class="dropdown-item {{ current_route starts with 'pl_category_' ? 'active' : '' }}" href="{{ path('pl_category_index') }}">
                             <span class="nav-link-title">Статьи ОПиУ (P&amp;L)</span>
                         </a>
+                        <a class="dropdown-item {{ current_route starts with 'project_direction_' ? 'active' : '' }}" href="{{ path('project_direction_index') }}">
+                            <span class="nav-link-title">Направления</span>
+                        </a>
                     </div>
                 </li>
 

--- a/site/templates/project_direction/edit.html.twig
+++ b/site/templates/project_direction/edit.html.twig
@@ -1,0 +1,24 @@
+{% extends 'base.html.twig' %}
+{% block title %}Редактирование направления{% endblock %}
+
+{% block body %}
+    <div class="page-header d-print-none">
+        <div class="container-xl">
+            <div class="row g-2 align-items-center">
+                <div class="col">
+                    <h2 class="page-title">Редактирование направления</h2>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="container-xl mt-3">
+        <div class="card">
+            <div class="card-body">
+                {{ form_start(form) }}
+                {{ form_widget(form) }}
+                <button class="btn btn-primary mt-3">Сохранить</button>
+                {{ form_end(form) }}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/site/templates/project_direction/index.html.twig
+++ b/site/templates/project_direction/index.html.twig
@@ -1,0 +1,47 @@
+{% extends 'base.html.twig' %}
+{% block title %}Направления{% endblock %}
+
+{% block body %}
+    <div class="page-header d-print-none">
+        <div class="container-xl">
+            <div class="row g-2 align-items-center">
+                <div class="col">
+                    <h2 class="page-title">Направления</h2>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="container-xl mt-3">
+        <div class="card">
+            <div class="card-body">
+                <div class="mb-3 text-end">
+                    <a href="{{ path('project_direction_new') }}" class="btn btn-success">+ Добавить</a>
+                </div>
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>Наименование</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    {% for item in items %}
+                        <tr>
+                            <td>{{ item.name }}</td>
+                            <td class="text-end">
+                                <a href="{{ path('project_direction_edit', {id: item.id}) }}" class="btn btn-sm btn-warning">✏️</a>
+                                <form method="post" action="{{ path('project_direction_delete', {id: item.id}) }}" style="display:inline;" onsubmit="return confirm('Удалить?');">
+                                    <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ item.id) }}">
+                                    <button class="btn btn-sm btn-danger">🗑</button>
+                                </form>
+                            </td>
+                        </tr>
+                    {% else %}
+                        <tr><td colspan="2" class="text-center">Нет данных</td></tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/site/templates/project_direction/new.html.twig
+++ b/site/templates/project_direction/new.html.twig
@@ -1,0 +1,24 @@
+{% extends 'base.html.twig' %}
+{% block title %}Новое направление{% endblock %}
+
+{% block body %}
+    <div class="page-header d-print-none">
+        <div class="container-xl">
+            <div class="row g-2 align-items-center">
+                <div class="col">
+                    <h2 class="page-title">Новое направление</h2>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="container-xl mt-3">
+        <div class="card">
+            <div class="card-body">
+                {{ form_start(form) }}
+                {{ form_widget(form) }}
+                <button class="btn btn-primary mt-3">Сохранить</button>
+                {{ form_end(form) }}
+            </div>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add ProjectDirection entity with CRUD pages and menu entry
- create migration for project_directions table

## Testing
- `php bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c19c2fb77483239968e8624c9f629a