### PR TITLE
feat: add cash transaction auto rules directory

### DIFF
--- a/site/migrations/Version20250908090000.php
+++ b/site/migrations/Version20250908090000.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250908090000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add cash transaction auto rules';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE cash_transaction_auto_rule (id UUID NOT NULL, company_id UUID NOT NULL, cashflow_category_id UUID NOT NULL, name VARCHAR(255) NOT NULL, action VARCHAR(255) NOT NULL, operation_type VARCHAR(255) NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX idx_ctar_company ON cash_transaction_auto_rule (company_id)');
+        $this->addSql('CREATE INDEX idx_ctar_category ON cash_transaction_auto_rule (cashflow_category_id)');
+        $this->addSql('ALTER TABLE cash_transaction_auto_rule ADD CONSTRAINT FK_CTAR_COMPANY FOREIGN KEY (company_id) REFERENCES companies (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE cash_transaction_auto_rule ADD CONSTRAINT FK_CTAR_CATEGORY FOREIGN KEY (cashflow_category_id) REFERENCES cashflow_categories (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE cash_transaction_auto_rule DROP CONSTRAINT FK_CTAR_COMPANY');
+        $this->addSql('ALTER TABLE cash_transaction_auto_rule DROP CONSTRAINT FK_CTAR_CATEGORY');
+        $this->addSql('DROP TABLE cash_transaction_auto_rule');
+    }
+}

--- a/site/src/Controller/CashTransactionAutoRuleController.php
+++ b/site/src/Controller/CashTransactionAutoRuleController.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\CashTransactionAutoRule;
+use App\Enum\CashTransactionAutoRuleAction;
+use App\Enum\CashTransactionAutoRuleOperationType;
+use App\Form\CashTransactionAutoRuleType;
+use App\Repository\CashTransactionAutoRuleRepository;
+use App\Repository\CashflowCategoryRepository;
+use App\Service\ActiveCompanyService;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/cash-transaction-auto-rules')]
+class CashTransactionAutoRuleController extends AbstractController
+{
+    #[Route('/', name: 'cash_transaction_auto_rule_index', methods: ['GET'])]
+    public function index(CashTransactionAutoRuleRepository $repo, ActiveCompanyService $companyService): Response
+    {
+        $company = $companyService->getActiveCompany();
+        $items = $repo->findByCompany($company);
+
+        return $this->render('cash_transaction_auto_rule/index.html.twig', [
+            'items' => $items,
+        ]);
+    }
+
+    #[Route('/new', name: 'cash_transaction_auto_rule_new', methods: ['GET', 'POST'])]
+    public function new(
+        Request $request,
+        EntityManagerInterface $em,
+        ActiveCompanyService $companyService,
+        CashflowCategoryRepository $categoryRepo
+    ): Response {
+        $company = $companyService->getActiveCompany();
+        $categories = $categoryRepo->findTreeByCompany($company);
+
+        $rule = new CashTransactionAutoRule(
+            Uuid::uuid4()->toString(),
+            $company,
+            '',
+            CashTransactionAutoRuleAction::FILL,
+            CashTransactionAutoRuleOperationType::ANY
+        );
+
+        $form = $this->createForm(CashTransactionAutoRuleType::class, $rule, ['categories' => $categories]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $em->persist($rule);
+            $em->flush();
+            return $this->redirectToRoute('cash_transaction_auto_rule_index');
+        }
+
+        return $this->render('cash_transaction_auto_rule/new.html.twig', [
+            'form' => $form->createView(),
+        ]);
+    }
+
+    #[Route('/{id}/edit', name: 'cash_transaction_auto_rule_edit', methods: ['GET', 'POST'])]
+    public function edit(
+        string $id,
+        Request $request,
+        CashTransactionAutoRuleRepository $repo,
+        EntityManagerInterface $em,
+        ActiveCompanyService $companyService,
+        CashflowCategoryRepository $categoryRepo
+    ): Response {
+        $company = $companyService->getActiveCompany();
+        $rule = $repo->find($id);
+        if (!$rule || $rule->getCompany() !== $company) {
+            throw $this->createNotFoundException();
+        }
+
+        $categories = $categoryRepo->findTreeByCompany($company);
+        $form = $this->createForm(CashTransactionAutoRuleType::class, $rule, ['categories' => $categories]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $em->flush();
+            return $this->redirectToRoute('cash_transaction_auto_rule_index');
+        }
+
+        return $this->render('cash_transaction_auto_rule/edit.html.twig', [
+            'form' => $form->createView(),
+            'item' => $rule,
+        ]);
+    }
+
+    #[Route('/{id}/delete', name: 'cash_transaction_auto_rule_delete', methods: ['POST'])]
+    public function delete(
+        string $id,
+        Request $request,
+        CashTransactionAutoRuleRepository $repo,
+        EntityManagerInterface $em,
+        ActiveCompanyService $companyService
+    ): Response {
+        $company = $companyService->getActiveCompany();
+        $rule = $repo->find($id);
+        if (!$rule || $rule->getCompany() !== $company) {
+            throw $this->createNotFoundException();
+        }
+
+        if ($this->isCsrfTokenValid('delete'.$rule->getId(), $request->request->get('_token'))) {
+            $em->remove($rule);
+            $em->flush();
+        }
+
+        return $this->redirectToRoute('cash_transaction_auto_rule_index');
+    }
+}

--- a/site/src/Entity/CashTransactionAutoRule.php
+++ b/site/src/Entity/CashTransactionAutoRule.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Entity;
+
+use App\Enum\CashTransactionAutoRuleAction;
+use App\Enum\CashTransactionAutoRuleOperationType;
+use App\Repository\CashTransactionAutoRuleRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity(repositoryClass: CashTransactionAutoRuleRepository::class)]
+#[ORM\Table(name: 'cash_transaction_auto_rule')]
+#[ORM\Index(name: 'idx_ctar_company', columns: ['company_id'])]
+#[ORM\Index(name: 'idx_ctar_category', columns: ['cashflow_category_id'])]
+class CashTransactionAutoRule
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid', unique: true)]
+    private ?string $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Company::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private Company $company;
+
+    #[ORM\Column(length: 255)]
+    private string $name;
+
+    #[ORM\Column(enumType: CashTransactionAutoRuleAction::class)]
+    private CashTransactionAutoRuleAction $action;
+
+    #[ORM\Column(enumType: CashTransactionAutoRuleOperationType::class)]
+    private CashTransactionAutoRuleOperationType $operationType;
+
+    #[ORM\ManyToOne(targetEntity: CashflowCategory::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'RESTRICT')]
+    private ?CashflowCategory $cashflowCategory = null;
+
+    public function __construct(
+        string $id,
+        Company $company,
+        string $name,
+        CashTransactionAutoRuleAction $action,
+        CashTransactionAutoRuleOperationType $operationType,
+        ?CashflowCategory $cashflowCategory = null
+    ) {
+        Assert::uuid($id);
+        $this->id = $id;
+        $this->company = $company;
+        $this->name = $name;
+        $this->action = $action;
+        $this->operationType = $operationType;
+        if ($cashflowCategory) {
+            $this->cashflowCategory = $cashflowCategory;
+        }
+    }
+
+    public function getId(): ?string { return $this->id; }
+    public function getCompany(): Company { return $this->company; }
+    public function setCompany(Company $company): self { $this->company = $company; return $this; }
+    public function getName(): string { return $this->name; }
+    public function setName(string $name): self { $this->name = $name; return $this; }
+    public function getAction(): CashTransactionAutoRuleAction { return $this->action; }
+    public function setAction(CashTransactionAutoRuleAction $action): self { $this->action = $action; return $this; }
+    public function getOperationType(): CashTransactionAutoRuleOperationType { return $this->operationType; }
+    public function setOperationType(CashTransactionAutoRuleOperationType $operationType): self { $this->operationType = $operationType; return $this; }
+    public function getCashflowCategory(): ?CashflowCategory { return $this->cashflowCategory; }
+    public function setCashflowCategory(CashflowCategory $cashflowCategory): self { $this->cashflowCategory = $cashflowCategory; return $this; }
+}

--- a/site/src/Enum/CashTransactionAutoRuleAction.php
+++ b/site/src/Enum/CashTransactionAutoRuleAction.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enum;
+
+enum CashTransactionAutoRuleAction: string
+{
+    case FILL = 'FILL';
+    case UPDATE = 'UPDATE';
+}

--- a/site/src/Enum/CashTransactionAutoRuleOperationType.php
+++ b/site/src/Enum/CashTransactionAutoRuleOperationType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enum;
+
+enum CashTransactionAutoRuleOperationType: string
+{
+    case INFLOW = 'INFLOW';
+    case OUTFLOW = 'OUTFLOW';
+    case ANY = 'ANY';
+}

--- a/site/src/Form/CashTransactionAutoRuleType.php
+++ b/site/src/Form/CashTransactionAutoRuleType.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\CashTransactionAutoRule;
+use App\Entity\CashflowCategory;
+use App\Enum\CashTransactionAutoRuleAction;
+use App\Enum\CashTransactionAutoRuleOperationType;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EnumType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class CashTransactionAutoRuleType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('name', TextType::class, [
+                'label' => 'Название автоправила',
+            ])
+            ->add('action', EnumType::class, [
+                'class' => CashTransactionAutoRuleAction::class,
+                'label' => 'Действие с операцией ДДС',
+            ])
+            ->add('operationType', EnumType::class, [
+                'class' => CashTransactionAutoRuleOperationType::class,
+                'label' => 'Тип операции',
+            ])
+            ->add('cashflowCategory', EntityType::class, [
+                'class' => CashflowCategory::class,
+                'choices' => $options['categories'],
+                'choice_label' => function (CashflowCategory $item) {
+                    return str_repeat('—', $item->getLevel() - 1) . ' ' . $item->getName();
+                },
+                'label' => 'Категория движения ДДС',
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => CashTransactionAutoRule::class,
+            'categories' => [],
+        ]);
+    }
+}

--- a/site/src/Repository/CashTransactionAutoRuleRepository.php
+++ b/site/src/Repository/CashTransactionAutoRuleRepository.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\CashTransactionAutoRule;
+use App\Entity\Company;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<CashTransactionAutoRule>
+ */
+class CashTransactionAutoRuleRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, CashTransactionAutoRule::class);
+    }
+
+    /**
+     * @return CashTransactionAutoRule[]
+     */
+    public function findByCompany(Company $company): array
+    {
+        return $this->findBy(['company' => $company], ['name' => 'ASC']);
+    }
+}

--- a/site/templates/cash_transaction_auto_rule/edit.html.twig
+++ b/site/templates/cash_transaction_auto_rule/edit.html.twig
@@ -1,0 +1,24 @@
+{% extends 'base.html.twig' %}
+{% block title %}Изменить автоправило{% endblock %}
+
+{% block body %}
+    <div class="page-header d-print-none">
+        <div class="container-xl">
+            <div class="row g-2 align-items-center">
+                <div class="col">
+                    <h2 class="page-title">Изменить автоправило</h2>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="container-xl mt-3">
+        <div class="card">
+            <div class="card-body">
+                {{ form_start(form) }}
+                {{ form_widget(form) }}
+                <button class="btn btn-primary mt-3">Сохранить</button>
+                {{ form_end(form) }}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/site/templates/cash_transaction_auto_rule/index.html.twig
+++ b/site/templates/cash_transaction_auto_rule/index.html.twig
@@ -1,0 +1,53 @@
+{% extends 'base.html.twig' %}
+{% block title %}Автоправила ДДС{% endblock %}
+
+{% block body %}
+    <div class="page-header d-print-none">
+        <div class="container-xl">
+            <div class="row g-2 align-items-center">
+                <div class="col">
+                    <h2 class="page-title">Автоправила ДДС</h2>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="container-xl mt-3">
+        <div class="card">
+            <div class="card-body">
+                <div class="mb-3 text-end">
+                    <a href="{{ path('cash_transaction_auto_rule_new') }}" class="btn btn-success">+ Добавить</a>
+                </div>
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>Название</th>
+                            <th>Действие</th>
+                            <th>Тип операции</th>
+                            <th>Категория</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    {% for item in items %}
+                        <tr>
+                            <td>{{ item.name }}</td>
+                            <td>{{ item.action.name }}</td>
+                            <td>{{ item.operationType.name }}</td>
+                            <td>{{ item.cashflowCategory.name }}</td>
+                            <td class="text-end">
+                                <a href="{{ path('cash_transaction_auto_rule_edit', {id: item.id}) }}" class="btn btn-sm btn-warning">✏️</a>
+                                <form method="post" action="{{ path('cash_transaction_auto_rule_delete', {id: item.id}) }}" style="display:inline;" onsubmit="return confirm('Удалить?');">
+                                    <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ item.id) }}">
+                                    <button class="btn btn-sm btn-danger">🗑</button>
+                                </form>
+                            </td>
+                        </tr>
+                    {% else %}
+                        <tr><td colspan="5" class="text-center">Нет данных</td></tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/site/templates/cash_transaction_auto_rule/new.html.twig
+++ b/site/templates/cash_transaction_auto_rule/new.html.twig
@@ -1,0 +1,24 @@
+{% extends 'base.html.twig' %}
+{% block title %}Новое автоправило{% endblock %}
+
+{% block body %}
+    <div class="page-header d-print-none">
+        <div class="container-xl">
+            <div class="row g-2 align-items-center">
+                <div class="col">
+                    <h2 class="page-title">Новое автоправило</h2>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="container-xl mt-3">
+        <div class="card">
+            <div class="card-body">
+                {{ form_start(form) }}
+                {{ form_widget(form) }}
+                <button class="btn btn-primary mt-3">Сохранить</button>
+                {{ form_end(form) }}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/site/templates/partials/_sidebar.html.twig
+++ b/site/templates/partials/_sidebar.html.twig
@@ -68,6 +68,9 @@
                         <a class="dropdown-item {{ current_route starts with 'project_direction_' ? 'active' : '' }}" href="{{ path('project_direction_index') }}">
                             <span class="nav-link-title">Направления</span>
                         </a>
+                        <a class="dropdown-item {{ current_route starts with 'cash_transaction_auto_rule_' ? 'active' : '' }}" href="{{ path('cash_transaction_auto_rule_index') }}">
+                            <span class="nav-link-title">Автоправила ДДС</span>
+                        </a>
                     </div>
                 </li>
 


### PR DESCRIPTION
## Summary
- add auto rules for cash transactions with action and operation type enums
- provide CRUD interface and menu entry
- introduce migration for new table

## Testing
- ⚠️ `composer install` *(failed: requires GitHub OAuth token)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a56928a88323927183b9c2fbcaa7