### PR TITLE
feat: localize cash auto rule form options

### DIFF
--- a/site/src/Form/CashTransactionAutoRuleType.php
+++ b/site/src/Form/CashTransactionAutoRuleType.php
@@ -24,10 +24,28 @@ class CashTransactionAutoRuleType extends AbstractType
             ->add('action', EnumType::class, [
                 'class' => CashTransactionAutoRuleAction::class,
                 'label' => 'Действие с операцией ДДС',
+                'choice_label' => function (CashTransactionAutoRuleAction $choice) {
+                    return match ($choice) {
+                        CashTransactionAutoRuleAction::FILL => 'Заполнить поля операции',
+                        CashTransactionAutoRuleAction::UPDATE => 'Изменить поля операции',
+                    };
+                },
             ])
             ->add('operationType', EnumType::class, [
                 'class' => CashTransactionAutoRuleOperationType::class,
                 'label' => 'Тип операции',
+                'choices' => [
+                    CashTransactionAutoRuleOperationType::OUTFLOW,
+                    CashTransactionAutoRuleOperationType::INFLOW,
+                    CashTransactionAutoRuleOperationType::ANY,
+                ],
+                'choice_label' => function (CashTransactionAutoRuleOperationType $choice) {
+                    return match ($choice) {
+                        CashTransactionAutoRuleOperationType::OUTFLOW => 'Отток',
+                        CashTransactionAutoRuleOperationType::INFLOW => 'Приток',
+                        CashTransactionAutoRuleOperationType::ANY => 'Любое',
+                    };
+                },
             ])
             ->add('cashflowCategory', EntityType::class, [
                 'class' => CashflowCategory::class,


### PR DESCRIPTION
## Summary
- localize cash transaction auto rule action options
- localize cash transaction auto rule operation type options and order them

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ad1bee0c832394ae34fd01551b53