### PR TITLE
feat: add conditions to cash transaction auto rules

### DIFF
--- a/site/migrations/Version20250911130000.php
+++ b/site/migrations/Version20250911130000.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250911130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create cash_transaction_auto_rule_condition table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE cash_transaction_auto_rule_condition (id UUID NOT NULL, auto_rule_id UUID NOT NULL, field VARCHAR(255) NOT NULL, operator VARCHAR(255) NOT NULL, counterparty_id UUID DEFAULT NULL, value VARCHAR(255) DEFAULT NULL, value_to VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX idx_ctarc_rule ON cash_transaction_auto_rule_condition (auto_rule_id)');
+        $this->addSql('ALTER TABLE cash_transaction_auto_rule_condition ADD CONSTRAINT fk_ctarc_rule FOREIGN KEY (auto_rule_id) REFERENCES cash_transaction_auto_rule (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE cash_transaction_auto_rule_condition ADD CONSTRAINT fk_ctarc_counterparty FOREIGN KEY (counterparty_id) REFERENCES "counterparty" (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE cash_transaction_auto_rule_condition');
+    }
+}

--- a/site/src/Entity/CashTransactionAutoRuleCondition.php
+++ b/site/src/Entity/CashTransactionAutoRuleCondition.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Entity;
+
+use App\Enum\CashTransactionAutoRuleConditionField;
+use App\Enum\CashTransactionAutoRuleConditionOperator;
+use App\Repository\CashTransactionAutoRuleConditionRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity(repositoryClass: CashTransactionAutoRuleConditionRepository::class)]
+#[ORM\Table(name: 'cash_transaction_auto_rule_condition')]
+#[ORM\Index(name: 'idx_ctarc_rule', columns: ['auto_rule_id'])]
+class CashTransactionAutoRuleCondition
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid', unique: true)]
+    private ?string $id = null;
+
+    #[ORM\ManyToOne(targetEntity: CashTransactionAutoRule::class, inversedBy: 'conditions')]
+    #[ORM\JoinColumn(name: 'auto_rule_id', nullable: false, onDelete: 'CASCADE')]
+    private ?CashTransactionAutoRule $autoRule = null;
+
+    #[ORM\Column(enumType: CashTransactionAutoRuleConditionField::class)]
+    private CashTransactionAutoRuleConditionField $field;
+
+    #[ORM\Column(enumType: CashTransactionAutoRuleConditionOperator::class)]
+    private CashTransactionAutoRuleConditionOperator $operator;
+
+    #[ORM\ManyToOne(targetEntity: Counterparty::class)]
+    private ?Counterparty $counterparty = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $value = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $valueTo = null;
+
+    public function __construct(
+        string $id,
+        CashTransactionAutoRule $autoRule,
+        CashTransactionAutoRuleConditionField $field,
+        CashTransactionAutoRuleConditionOperator $operator,
+        ?string $value = null,
+        ?string $valueTo = null,
+        ?Counterparty $counterparty = null
+    ) {
+        Assert::uuid($id);
+        $this->id = $id;
+        $this->autoRule = $autoRule;
+        $this->field = $field;
+        $this->operator = $operator;
+        $this->value = $value;
+        $this->valueTo = $valueTo;
+        $this->counterparty = $counterparty;
+    }
+
+    public function getId(): ?string { return $this->id; }
+    public function getAutoRule(): ?CashTransactionAutoRule { return $this->autoRule; }
+    public function setAutoRule(?CashTransactionAutoRule $rule): self { $this->autoRule = $rule; return $this; }
+    public function getField(): CashTransactionAutoRuleConditionField { return $this->field; }
+    public function setField(CashTransactionAutoRuleConditionField $field): self { $this->field = $field; return $this; }
+    public function getOperator(): CashTransactionAutoRuleConditionOperator { return $this->operator; }
+    public function setOperator(CashTransactionAutoRuleConditionOperator $operator): self { $this->operator = $operator; return $this; }
+    public function getCounterparty(): ?Counterparty { return $this->counterparty; }
+    public function setCounterparty(?Counterparty $counterparty): self { $this->counterparty = $counterparty; return $this; }
+    public function getValue(): ?string { return $this->value; }
+    public function setValue(?string $value): self { $this->value = $value; return $this; }
+    public function getValueTo(): ?string { return $this->valueTo; }
+    public function setValueTo(?string $valueTo): self { $this->valueTo = $valueTo; return $this; }
+}

--- a/site/src/Enum/CashTransactionAutoRuleConditionField.php
+++ b/site/src/Enum/CashTransactionAutoRuleConditionField.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Enum;
+
+enum CashTransactionAutoRuleConditionField: string
+{
+    case COUNTERPARTY = 'COUNTERPARTY';
+    case COUNTERPARTY_NAME = 'COUNTERPARTY_NAME';
+    case INN = 'INN';
+    case DATE = 'DATE';
+    case AMOUNT = 'AMOUNT';
+    case DESCRIPTION = 'DESCRIPTION';
+}

--- a/site/src/Enum/CashTransactionAutoRuleConditionOperator.php
+++ b/site/src/Enum/CashTransactionAutoRuleConditionOperator.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enum;
+
+enum CashTransactionAutoRuleConditionOperator: string
+{
+    case EQUAL = 'EQUAL';
+    case GREATER_THAN = 'GREATER_THAN';
+    case LESS_THAN = 'LESS_THAN';
+    case BETWEEN = 'BETWEEN';
+    case CONTAINS = 'CONTAINS';
+}

--- a/site/src/Form/CashTransactionAutoRuleConditionType.php
+++ b/site/src/Form/CashTransactionAutoRuleConditionType.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\CashTransactionAutoRuleCondition;
+use App\Entity\Counterparty;
+use App\Enum\CashTransactionAutoRuleConditionField;
+use App\Enum\CashTransactionAutoRuleConditionOperator;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EnumType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class CashTransactionAutoRuleConditionType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('field', EnumType::class, [
+                'class' => CashTransactionAutoRuleConditionField::class,
+                'label' => 'Поле',
+                'choice_label' => function (CashTransactionAutoRuleConditionField $choice) {
+                    return match ($choice) {
+                        CashTransactionAutoRuleConditionField::COUNTERPARTY => 'Контрагент (точное совпадение)',
+                        CashTransactionAutoRuleConditionField::COUNTERPARTY_NAME => 'Название контрагента содержит',
+                        CashTransactionAutoRuleConditionField::INN => 'ИНН контрагента',
+                        CashTransactionAutoRuleConditionField::DATE => 'Дата операции',
+                        CashTransactionAutoRuleConditionField::AMOUNT => 'Сумма',
+                        CashTransactionAutoRuleConditionField::DESCRIPTION => 'Описание содержит',
+                    };
+                },
+            ])
+            ->add('operator', EnumType::class, [
+                'class' => CashTransactionAutoRuleConditionOperator::class,
+                'label' => 'Оператор',
+                'choice_label' => function (CashTransactionAutoRuleConditionOperator $choice) {
+                    return match ($choice) {
+                        CashTransactionAutoRuleConditionOperator::EQUAL => '=',
+                        CashTransactionAutoRuleConditionOperator::GREATER_THAN => '>',
+                        CashTransactionAutoRuleConditionOperator::LESS_THAN => '<',
+                        CashTransactionAutoRuleConditionOperator::BETWEEN => 'Диапазон',
+                        CashTransactionAutoRuleConditionOperator::CONTAINS => 'Содержит',
+                    };
+                },
+            ])
+            ->add('counterparty', EntityType::class, [
+                'class' => Counterparty::class,
+                'choices' => $options['counterparties'],
+                'required' => false,
+                'label' => 'Контрагент',
+            ])
+            ->add('value', TextType::class, [
+                'required' => false,
+                'label' => 'Значение',
+            ])
+            ->add('valueTo', TextType::class, [
+                'required' => false,
+                'label' => 'Значение до',
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => CashTransactionAutoRuleCondition::class,
+            'counterparties' => [],
+        ]);
+    }
+}

--- a/site/src/Form/CashTransactionAutoRuleType.php
+++ b/site/src/Form/CashTransactionAutoRuleType.php
@@ -4,12 +4,14 @@ namespace App\Form;
 
 use App\Entity\CashTransactionAutoRule;
 use App\Entity\CashflowCategory;
+use App\Form\CashTransactionAutoRuleConditionType;
 use App\Enum\CashTransactionAutoRuleAction;
 use App\Enum\CashTransactionAutoRuleOperationType;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\EnumType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -54,6 +56,16 @@ class CashTransactionAutoRuleType extends AbstractType
                     return str_repeat('—', $item->getLevel() - 1) . ' ' . $item->getName();
                 },
                 'label' => 'Категория движения ДДС',
+            ])
+            ->add('conditions', CollectionType::class, [
+                'entry_type' => CashTransactionAutoRuleConditionType::class,
+                'entry_options' => [
+                    'counterparties' => $options['counterparties'],
+                ],
+                'allow_add' => true,
+                'allow_delete' => true,
+                'by_reference' => false,
+                'label' => 'Правила',
             ]);
     }
 
@@ -62,6 +74,7 @@ class CashTransactionAutoRuleType extends AbstractType
         $resolver->setDefaults([
             'data_class' => CashTransactionAutoRule::class,
             'categories' => [],
+            'counterparties' => [],
         ]);
     }
 }

--- a/site/src/Repository/CashTransactionAutoRuleConditionRepository.php
+++ b/site/src/Repository/CashTransactionAutoRuleConditionRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\CashTransactionAutoRuleCondition;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<CashTransactionAutoRuleCondition>
+ */
+class CashTransactionAutoRuleConditionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, CashTransactionAutoRuleCondition::class);
+    }
+}

--- a/site/templates/cash_transaction_auto_rule/edit.html.twig
+++ b/site/templates/cash_transaction_auto_rule/edit.html.twig
@@ -15,10 +15,49 @@
         <div class="card">
             <div class="card-body">
                 {{ form_start(form) }}
-                {{ form_widget(form) }}
+                {{ form_row(form.name) }}
+                {{ form_row(form.action) }}
+                {{ form_row(form.operationType) }}
+                {{ form_row(form.cashflowCategory) }}
+                <div class="mb-3">
+                    <label class="form-label">Правила</label>
+                    <div data-collection-holder data-prototype="{{ form_widget(form.conditions.vars.prototype)|e('html_attr') }}">
+                        {% for cond in form.conditions %}
+                            <div class="mb-2">
+                                {{ form_widget(cond) }}
+                                <button type="button" class="btn btn-sm btn-danger remove-item">Удалить</button>
+                            </div>
+                        {% endfor %}
+                    </div>
+                    <button type="button" class="btn btn-sm btn-secondary add_item_link mt-2">+ Правило</button>
+                </div>
                 <button class="btn btn-primary mt-3">Сохранить</button>
                 {{ form_end(form) }}
             </div>
         </div>
     </div>
+{% endblock %}
+
+{% block javascripts %}
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        document.querySelectorAll('[data-collection-holder]').forEach(function(collectionHolder) {
+            const addButton = collectionHolder.parentElement.querySelector('.add_item_link');
+            addButton.addEventListener('click', function() {
+                const prototype = collectionHolder.dataset.prototype;
+                const index = collectionHolder.children.length;
+                let newForm = prototype.replace(/__name__/g, index);
+                const div = document.createElement('div');
+                div.classList.add('mb-2');
+                div.innerHTML = newForm + '<button type="button" class="btn btn-sm btn-danger remove-item">Удалить</button>';
+                collectionHolder.appendChild(div);
+            });
+            collectionHolder.addEventListener('click', function(e){
+                if (e.target && e.target.classList.contains('remove-item')) {
+                    e.target.closest('div.mb-2').remove();
+                }
+            });
+        });
+    });
+</script>
 {% endblock %}

--- a/site/templates/cash_transaction_auto_rule/new.html.twig
+++ b/site/templates/cash_transaction_auto_rule/new.html.twig
@@ -15,10 +15,49 @@
         <div class="card">
             <div class="card-body">
                 {{ form_start(form) }}
-                {{ form_widget(form) }}
+                {{ form_row(form.name) }}
+                {{ form_row(form.action) }}
+                {{ form_row(form.operationType) }}
+                {{ form_row(form.cashflowCategory) }}
+                <div class="mb-3">
+                    <label class="form-label">Правила</label>
+                    <div data-collection-holder data-prototype="{{ form_widget(form.conditions.vars.prototype)|e('html_attr') }}">
+                        {% for cond in form.conditions %}
+                            <div class="mb-2">
+                                {{ form_widget(cond) }}
+                                <button type="button" class="btn btn-sm btn-danger remove-item">Удалить</button>
+                            </div>
+                        {% endfor %}
+                    </div>
+                    <button type="button" class="btn btn-sm btn-secondary add_item_link mt-2">+ Правило</button>
+                </div>
                 <button class="btn btn-primary mt-3">Сохранить</button>
                 {{ form_end(form) }}
             </div>
         </div>
     </div>
+{% endblock %}
+
+{% block javascripts %}
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        document.querySelectorAll('[data-collection-holder]').forEach(function(collectionHolder) {
+            const addButton = collectionHolder.parentElement.querySelector('.add_item_link');
+            addButton.addEventListener('click', function() {
+                const prototype = collectionHolder.dataset.prototype;
+                const index = collectionHolder.children.length;
+                let newForm = prototype.replace(/__name__/g, index);
+                const div = document.createElement('div');
+                div.classList.add('mb-2');
+                div.innerHTML = newForm + '<button type="button" class="btn btn-sm btn-danger remove-item">Удалить</button>';
+                collectionHolder.appendChild(div);
+            });
+            collectionHolder.addEventListener('click', function(e){
+                if (e.target && e.target.classList.contains('remove-item')) {
+                    e.target.closest('div.mb-2').remove();
+                }
+            });
+        });
+    });
+</script>
 {% endblock %}

--- a/site/tests/Entity/CashTransactionAutoRuleConditionTest.php
+++ b/site/tests/Entity/CashTransactionAutoRuleConditionTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Tests\Entity;
+
+use App\Entity\CashTransactionAutoRule;
+use App\Entity\CashTransactionAutoRuleCondition;
+use App\Entity\CashflowCategory;
+use App\Entity\Company;
+use App\Entity\User;
+use App\Enum\CashTransactionAutoRuleAction;
+use App\Enum\CashTransactionAutoRuleConditionField;
+use App\Enum\CashTransactionAutoRuleConditionOperator;
+use App\Enum\CashTransactionAutoRuleOperationType;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\ORM\Tools\Setup;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+class CashTransactionAutoRuleConditionTest extends TestCase
+{
+    private EntityManager $em;
+
+    protected function setUp(): void
+    {
+        $config = Setup::createAttributeMetadataConfiguration([__DIR__.'/../../src/Entity'], true);
+        $conn = ['driver' => 'pdo_sqlite', 'memory' => true];
+        $this->em = EntityManager::create($conn, $config);
+        $schemaTool = new SchemaTool($this->em);
+        $classes = [
+            $this->em->getClassMetadata(User::class),
+            $this->em->getClassMetadata(Company::class),
+            $this->em->getClassMetadata(CashflowCategory::class),
+            $this->em->getClassMetadata(CashTransactionAutoRule::class),
+            $this->em->getClassMetadata(CashTransactionAutoRuleCondition::class),
+        ];
+        $schemaTool->createSchema($classes);
+    }
+
+    public function testPersistRuleWithCondition(): void
+    {
+        $user = new User(Uuid::uuid4()->toString());
+        $user->setEmail('t@example.com');
+        $user->setPassword('pass');
+        $company = new Company(Uuid::uuid4()->toString(), $user);
+        $company->setName('Test Co');
+        $category = new CashflowCategory(Uuid::uuid4()->toString(), $company);
+        $category->setName('Sales');
+
+        $rule = new CashTransactionAutoRule(
+            Uuid::uuid4()->toString(),
+            $company,
+            'Rule',
+            CashTransactionAutoRuleAction::FILL,
+            CashTransactionAutoRuleOperationType::ANY,
+            $category
+        );
+
+        $condition = new CashTransactionAutoRuleCondition(
+            Uuid::uuid4()->toString(),
+            $rule,
+            CashTransactionAutoRuleConditionField::DESCRIPTION,
+            CashTransactionAutoRuleConditionOperator::CONTAINS,
+            'invoice'
+        );
+        $rule->addCondition($condition);
+
+        $this->em->persist($user);
+        $this->em->persist($company);
+        $this->em->persist($category);
+        $this->em->persist($rule);
+        $this->em->flush();
+        $this->em->clear();
+
+        $repo = $this->em->getRepository(CashTransactionAutoRule::class);
+        $saved = $repo->find($rule->getId());
+        $this->assertCount(1, $saved->getConditions());
+        $this->assertSame('invoice', $saved->getConditions()->first()->getValue());
+    }
+}


### PR DESCRIPTION
## Summary
- support multiple conditions for cash transaction auto rules
- expose condition fields/operators and allow UI to add/remove rules
- cover persistence of rule conditions and include DB migration

## Testing
- `php vendor/bin/phpunit` *(fails: Could not open input file)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b21c7f588323ba7b81963b6c8990