### PR TITLE
Fix counterparty choice label

### DIFF
--- a/site/src/Form/CashTransactionAutoRuleConditionType.php
+++ b/site/src/Form/CashTransactionAutoRuleConditionType.php
@@ -48,6 +48,7 @@ class CashTransactionAutoRuleConditionType extends AbstractType
             ->add('counterparty', EntityType::class, [
                 'class' => Counterparty::class,
                 'choices' => $options['counterparties'],
+                'choice_label' => 'name',
                 'required' => false,
                 'label' => 'Контрагент',
             ])


### PR DESCRIPTION
## Summary
- fix counterparty dropdown in cash transaction rule form by specifying choice label

## Testing
- `composer install` *(fails: CONNECT tunnel failed 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b54d32448323bd8136ffbfeefe21