### PR TITLE
Allow default construction of rule condition

### DIFF
--- a/site/src/Entity/CashTransactionAutoRuleCondition.php
+++ b/site/src/Entity/CashTransactionAutoRuleCondition.php
@@ -6,6 +6,7 @@ use App\Enum\CashTransactionAutoRuleConditionField;
 use App\Enum\CashTransactionAutoRuleConditionOperator;
 use App\Repository\CashTransactionAutoRuleConditionRepository;
 use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
 use Webmozart\Assert\Assert;
 
 #[ORM\Entity(repositoryClass: CashTransactionAutoRuleConditionRepository::class)]
@@ -37,19 +38,24 @@ class CashTransactionAutoRuleCondition
     private ?string $valueTo = null;
 
     public function __construct(
-        string $id,
-        CashTransactionAutoRule $autoRule,
-        CashTransactionAutoRuleConditionField $field,
-        CashTransactionAutoRuleConditionOperator $operator,
+        ?string $id = null,
+        ?CashTransactionAutoRule $autoRule = null,
+        ?CashTransactionAutoRuleConditionField $field = null,
+        ?CashTransactionAutoRuleConditionOperator $operator = null,
         ?string $value = null,
         ?string $valueTo = null,
         ?Counterparty $counterparty = null
     ) {
+        $id = $id ?? Uuid::uuid4()->toString();
         Assert::uuid($id);
         $this->id = $id;
         $this->autoRule = $autoRule;
-        $this->field = $field;
-        $this->operator = $operator;
+        if ($field) {
+            $this->field = $field;
+        }
+        if ($operator) {
+            $this->operator = $operator;
+        }
         $this->value = $value;
         $this->valueTo = $valueTo;
         $this->counterparty = $counterparty;

--- a/site/tests/Entity/CashTransactionAutoRuleConditionTest.php
+++ b/site/tests/Entity/CashTransactionAutoRuleConditionTest.php
@@ -56,13 +56,11 @@ class CashTransactionAutoRuleConditionTest extends TestCase
             $category
         );
 
-        $condition = new CashTransactionAutoRuleCondition(
-            Uuid::uuid4()->toString(),
-            $rule,
-            CashTransactionAutoRuleConditionField::DESCRIPTION,
-            CashTransactionAutoRuleConditionOperator::CONTAINS,
-            'invoice'
-        );
+        $condition = new CashTransactionAutoRuleCondition();
+        $condition->setAutoRule($rule);
+        $condition->setField(CashTransactionAutoRuleConditionField::DESCRIPTION);
+        $condition->setOperator(CashTransactionAutoRuleConditionOperator::CONTAINS);
+        $condition->setValue('invoice');
         $rule->addCondition($condition);
 
         $this->em->persist($user);


### PR DESCRIPTION
## Summary
- Allow CashTransactionAutoRuleCondition to be instantiated without parameters
- Adjust unit test to use setters for rule condition

## Testing
- `composer install` (fails: curl error 56, requires GitHub token)
- `php bin/phpunit` (fails: Unable to find `simple-phpunit.php` script)


------
https://chatgpt.com/codex/tasks/task_e_68c1b7d5420c8323b4ec4f2c8b74418e