### PR TITLE
style: wrap auto-rule conditions in cards

### DIFF
--- a/site/templates/cash_transaction_auto_rule/edit.html.twig
+++ b/site/templates/cash_transaction_auto_rule/edit.html.twig
@@ -23,9 +23,11 @@
                     <label class="form-label">Правила</label>
                     <div data-collection-holder data-prototype="{{ form_widget(form.conditions.vars.prototype)|e('html_attr') }}">
                         {% for cond in form.conditions %}
-                            <div class="mb-2">
-                                {{ form_widget(cond) }}
-                                <button type="button" class="btn btn-sm btn-danger remove-item">Удалить</button>
+                            <div class="card mb-2">
+                                <div class="card-body">
+                                    {{ form_widget(cond) }}
+                                    <button type="button" class="btn btn-sm btn-danger remove-item">Удалить</button>
+                                </div>
                             </div>
                         {% endfor %}
                     </div>
@@ -48,13 +50,13 @@
                 const index = collectionHolder.children.length;
                 let newForm = prototype.replace(/__name__/g, index);
                 const div = document.createElement('div');
-                div.classList.add('mb-2');
-                div.innerHTML = newForm + '<button type="button" class="btn btn-sm btn-danger remove-item">Удалить</button>';
+                div.classList.add('card', 'mb-2');
+                div.innerHTML = '<div class="card-body">' + newForm + '<button type="button" class="btn btn-sm btn-danger remove-item">Удалить</button></div>';
                 collectionHolder.appendChild(div);
             });
             collectionHolder.addEventListener('click', function(e){
                 if (e.target && e.target.classList.contains('remove-item')) {
-                    e.target.closest('div.mb-2').remove();
+                    e.target.closest('div.card').remove();
                 }
             });
         });

--- a/site/templates/cash_transaction_auto_rule/new.html.twig
+++ b/site/templates/cash_transaction_auto_rule/new.html.twig
@@ -23,9 +23,11 @@
                     <label class="form-label">Правила</label>
                     <div data-collection-holder data-prototype="{{ form_widget(form.conditions.vars.prototype)|e('html_attr') }}">
                         {% for cond in form.conditions %}
-                            <div class="mb-2">
-                                {{ form_widget(cond) }}
-                                <button type="button" class="btn btn-sm btn-danger remove-item">Удалить</button>
+                            <div class="card mb-2">
+                                <div class="card-body">
+                                    {{ form_widget(cond) }}
+                                    <button type="button" class="btn btn-sm btn-danger remove-item">Удалить</button>
+                                </div>
                             </div>
                         {% endfor %}
                     </div>
@@ -48,13 +50,13 @@
                 const index = collectionHolder.children.length;
                 let newForm = prototype.replace(/__name__/g, index);
                 const div = document.createElement('div');
-                div.classList.add('mb-2');
-                div.innerHTML = newForm + '<button type="button" class="btn btn-sm btn-danger remove-item">Удалить</button>';
+                div.classList.add('card', 'mb-2');
+                div.innerHTML = '<div class="card-body">' + newForm + '<button type="button" class="btn btn-sm btn-danger remove-item">Удалить</button></div>';
                 collectionHolder.appendChild(div);
             });
             collectionHolder.addEventListener('click', function(e){
                 if (e.target && e.target.classList.contains('remove-item')) {
-                    e.target.closest('div.mb-2').remove();
+                    e.target.closest('div.card').remove();
                 }
             });
         });


### PR DESCRIPTION
## Summary
- show auto-rule conditions in individual Tabler cards on create/edit pages

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c1bc54c18883239c36224cc856ab26