### PR TITLE
feat: refine auto rule form

### DIFF
--- a/site/src/Form/CashTransactionAutoRuleConditionType.php
+++ b/site/src/Form/CashTransactionAutoRuleConditionType.php
@@ -20,7 +20,8 @@ class CashTransactionAutoRuleConditionType extends AbstractType
         $builder
             ->add('field', EnumType::class, [
                 'class' => CashTransactionAutoRuleConditionField::class,
-                'label' => 'Поле',
+                'label' => 'Если у операции заполнено поле',
+                'row_attr' => ['class' => 'condition-field-row'],
                 'choice_label' => function (CashTransactionAutoRuleConditionField $choice) {
                     return match ($choice) {
                         CashTransactionAutoRuleConditionField::COUNTERPARTY => 'Контрагент (точное совпадение)',
@@ -35,6 +36,7 @@ class CashTransactionAutoRuleConditionType extends AbstractType
             ->add('operator', EnumType::class, [
                 'class' => CashTransactionAutoRuleConditionOperator::class,
                 'label' => 'Оператор',
+                'row_attr' => ['class' => 'condition-operator-row'],
                 'choice_label' => function (CashTransactionAutoRuleConditionOperator $choice) {
                     return match ($choice) {
                         CashTransactionAutoRuleConditionOperator::EQUAL => '=',
@@ -51,14 +53,17 @@ class CashTransactionAutoRuleConditionType extends AbstractType
                 'choice_label' => 'name',
                 'required' => false,
                 'label' => 'Контрагент',
+                'row_attr' => ['class' => 'condition-counterparty-row'],
             ])
             ->add('value', TextType::class, [
                 'required' => false,
-                'label' => 'Значение',
+                'label' => 'Содержит',
+                'row_attr' => ['class' => 'condition-value-row'],
             ])
             ->add('valueTo', TextType::class, [
                 'required' => false,
                 'label' => 'Значение до',
+                'row_attr' => ['class' => 'condition-value-to-row'],
             ]);
     }
 

--- a/site/templates/cash_transaction_auto_rule/edit.html.twig
+++ b/site/templates/cash_transaction_auto_rule/edit.html.twig
@@ -45,6 +45,70 @@
     document.addEventListener('DOMContentLoaded', function() {
         document.querySelectorAll('[data-collection-holder]').forEach(function(collectionHolder) {
             const addButton = collectionHolder.parentElement.querySelector('.add_item_link');
+
+            const initCondition = function(card) {
+                const fieldSelect = card.querySelector('[id$="_field"]');
+                const operatorSelect = card.querySelector('[id$="_operator"]');
+                const operatorRow = card.querySelector('.condition-operator-row');
+                const counterpartyRow = card.querySelector('.condition-counterparty-row');
+                const valueRow = card.querySelector('.condition-value-row');
+                const valueInput = valueRow ? valueRow.querySelector('input') : null;
+                const valueToRow = card.querySelector('.condition-value-to-row');
+
+                const update = function() {
+                    const val = fieldSelect.value;
+                    if (val === 'COUNTERPARTY') {
+                        operatorRow.style.display = 'none';
+                        operatorSelect.value = 'EQUAL';
+                        counterpartyRow.style.display = '';
+                        valueRow.style.display = 'none';
+                        valueToRow.style.display = 'none';
+                    } else if (val === 'COUNTERPARTY_NAME') {
+                        operatorRow.style.display = 'none';
+                        operatorSelect.value = 'CONTAINS';
+                        counterpartyRow.style.display = 'none';
+                        valueRow.style.display = '';
+                        valueToRow.style.display = 'none';
+                        if (valueInput) {
+                            valueInput.removeAttribute('inputmode');
+                            valueInput.oninput = null;
+                        }
+                    } else if (val === 'INN') {
+                        operatorRow.style.display = 'none';
+                        operatorSelect.value = 'CONTAINS';
+                        counterpartyRow.style.display = 'none';
+                        valueRow.style.display = '';
+                        valueToRow.style.display = 'none';
+                        if (valueInput) {
+                            valueInput.setAttribute('inputmode', 'numeric');
+                            valueInput.oninput = function() { this.value = this.value.replace(/\D/g, ''); };
+                        }
+                    } else if (val === 'DESCRIPTION') {
+                        operatorRow.style.display = 'none';
+                        operatorSelect.value = 'CONTAINS';
+                        counterpartyRow.style.display = 'none';
+                        valueRow.style.display = '';
+                        valueToRow.style.display = 'none';
+                        if (valueInput) {
+                            valueInput.removeAttribute('inputmode');
+                            valueInput.oninput = null;
+                        }
+                    } else {
+                        operatorRow.style.display = '';
+                        counterpartyRow.style.display = 'none';
+                        valueRow.style.display = '';
+                        valueToRow.style.display = '';
+                        if (valueInput) {
+                            valueInput.removeAttribute('inputmode');
+                            valueInput.oninput = null;
+                        }
+                    }
+                };
+
+                fieldSelect.addEventListener('change', update);
+                update();
+            };
+
             addButton.addEventListener('click', function() {
                 const prototype = collectionHolder.dataset.prototype;
                 const index = collectionHolder.children.length;
@@ -53,7 +117,11 @@
                 div.classList.add('card', 'mb-2');
                 div.innerHTML = '<div class="card-body">' + newForm + '<button type="button" class="btn btn-sm btn-danger remove-item">Удалить</button></div>';
                 collectionHolder.appendChild(div);
+                initCondition(div);
             });
+
+            collectionHolder.querySelectorAll('.card').forEach(initCondition);
+
             collectionHolder.addEventListener('click', function(e){
                 if (e.target && e.target.classList.contains('remove-item')) {
                     e.target.closest('div.card').remove();

--- a/site/templates/cash_transaction_auto_rule/new.html.twig
+++ b/site/templates/cash_transaction_auto_rule/new.html.twig
@@ -45,6 +45,70 @@
     document.addEventListener('DOMContentLoaded', function() {
         document.querySelectorAll('[data-collection-holder]').forEach(function(collectionHolder) {
             const addButton = collectionHolder.parentElement.querySelector('.add_item_link');
+
+            const initCondition = function(card) {
+                const fieldSelect = card.querySelector('[id$="_field"]');
+                const operatorSelect = card.querySelector('[id$="_operator"]');
+                const operatorRow = card.querySelector('.condition-operator-row');
+                const counterpartyRow = card.querySelector('.condition-counterparty-row');
+                const valueRow = card.querySelector('.condition-value-row');
+                const valueInput = valueRow ? valueRow.querySelector('input') : null;
+                const valueToRow = card.querySelector('.condition-value-to-row');
+
+                const update = function() {
+                    const val = fieldSelect.value;
+                    if (val === 'COUNTERPARTY') {
+                        operatorRow.style.display = 'none';
+                        operatorSelect.value = 'EQUAL';
+                        counterpartyRow.style.display = '';
+                        valueRow.style.display = 'none';
+                        valueToRow.style.display = 'none';
+                    } else if (val === 'COUNTERPARTY_NAME') {
+                        operatorRow.style.display = 'none';
+                        operatorSelect.value = 'CONTAINS';
+                        counterpartyRow.style.display = 'none';
+                        valueRow.style.display = '';
+                        valueToRow.style.display = 'none';
+                        if (valueInput) {
+                            valueInput.removeAttribute('inputmode');
+                            valueInput.oninput = null;
+                        }
+                    } else if (val === 'INN') {
+                        operatorRow.style.display = 'none';
+                        operatorSelect.value = 'CONTAINS';
+                        counterpartyRow.style.display = 'none';
+                        valueRow.style.display = '';
+                        valueToRow.style.display = 'none';
+                        if (valueInput) {
+                            valueInput.setAttribute('inputmode', 'numeric');
+                            valueInput.oninput = function() { this.value = this.value.replace(/\D/g, ''); };
+                        }
+                    } else if (val === 'DESCRIPTION') {
+                        operatorRow.style.display = 'none';
+                        operatorSelect.value = 'CONTAINS';
+                        counterpartyRow.style.display = 'none';
+                        valueRow.style.display = '';
+                        valueToRow.style.display = 'none';
+                        if (valueInput) {
+                            valueInput.removeAttribute('inputmode');
+                            valueInput.oninput = null;
+                        }
+                    } else {
+                        operatorRow.style.display = '';
+                        counterpartyRow.style.display = 'none';
+                        valueRow.style.display = '';
+                        valueToRow.style.display = '';
+                        if (valueInput) {
+                            valueInput.removeAttribute('inputmode');
+                            valueInput.oninput = null;
+                        }
+                    }
+                };
+
+                fieldSelect.addEventListener('change', update);
+                update();
+            };
+
             addButton.addEventListener('click', function() {
                 const prototype = collectionHolder.dataset.prototype;
                 const index = collectionHolder.children.length;
@@ -53,7 +117,11 @@
                 div.classList.add('card', 'mb-2');
                 div.innerHTML = '<div class="card-body">' + newForm + '<button type="button" class="btn btn-sm btn-danger remove-item">Удалить</button></div>';
                 collectionHolder.appendChild(div);
+                initCondition(div);
             });
+
+            collectionHolder.querySelectorAll('.card').forEach(initCondition);
+
             collectionHolder.addEventListener('click', function(e){
                 if (e.target && e.target.classList.contains('remove-item')) {
                     e.target.closest('div.card').remove();


### PR DESCRIPTION
## Summary
- tweak rule condition form labels
- add dynamic field handling for counterparty, name, inn, and description

## Testing
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c0be6f80832399a0924e3b4c6b23