### PR TITLE
Add check preview for cash transaction rules

### DIFF
--- a/site/src/Controller/CashTransactionAutoRuleController.php
+++ b/site/src/Controller/CashTransactionAutoRuleController.php
@@ -5,8 +5,12 @@ namespace App\Controller;
 use App\Entity\CashTransactionAutoRule;
 use App\Enum\CashTransactionAutoRuleAction;
 use App\Enum\CashTransactionAutoRuleOperationType;
+use App\Enum\CashDirection;
+use App\Enum\CashTransactionAutoRuleConditionField;
+use App\Enum\CashTransactionAutoRuleConditionOperator;
 use App\Form\CashTransactionAutoRuleType;
 use App\Repository\CashTransactionAutoRuleRepository;
+use App\Repository\CashTransactionRepository;
 use App\Repository\CashflowCategoryRepository;
 use App\Repository\CounterpartyRepository;
 use App\Service\ActiveCompanyService;
@@ -100,6 +104,111 @@ class CashTransactionAutoRuleController extends AbstractController
         return $this->render('cash_transaction_auto_rule/edit.html.twig', [
             'form' => $form->createView(),
             'item' => $rule,
+        ]);
+    }
+
+    #[Route('/{id}/check', name: 'cash_transaction_auto_rule_check', methods: ['GET'])]
+    public function check(
+        string $id,
+        Request $request,
+        ActiveCompanyService $companyService,
+        CashTransactionAutoRuleRepository $ruleRepo,
+        CashTransactionRepository $txRepo
+    ): Response {
+        $company = $companyService->getActiveCompany();
+        $rule = $ruleRepo->find($id);
+        if (!$rule || $rule->getCompany() !== $company) {
+            throw $this->createNotFoundException();
+        }
+
+        $qb = $txRepo->createQueryBuilder('t')
+            ->andWhere('t.company = :company')
+            ->setParameter('company', $company)
+            ->orderBy('t.occurredAt', 'DESC');
+
+        // 1) Фильтр по типу операции (если не ANY)
+        if ($rule->getOperationType() !== CashTransactionAutoRuleOperationType::ANY) {
+            $dir = $rule->getOperationType() === CashTransactionAutoRuleOperationType::INFLOW
+                ? CashDirection::INFLOW
+                : CashDirection::OUTFLOW;
+            $qb->andWhere('t.direction = :dir')->setParameter('dir', $dir);
+        }
+
+        // Опциональные границы периода предпросмотра (?dateFrom, ?dateTo)
+        if ($dFrom = $request->query->get('dateFrom')) {
+            $qb->andWhere('t.occurredAt >= :from')->setParameter('from', new \DateTimeImmutable($dFrom.' 00:00:00'));
+        }
+        if ($dTo = $request->query->get('dateTo')) {
+            $qb->andWhere('t.occurredAt <= :to')->setParameter('to', new \DateTimeImmutable($dTo.' 23:59:59'));
+        }
+
+        // 2) Условия правила (AND)
+        $needJoinCp = false;
+        foreach ($rule->getConditions() as $idx => $cond) {
+            $p = 'p'.$idx; // параметр
+            switch ($cond->getField()) {
+                case CashTransactionAutoRuleConditionField::COUNTERPARTY:
+                    // operator = EQUAL; значение — entity
+                    $qb->andWhere('t.counterparty = :'.$p)->setParameter($p, $cond->getCounterparty());
+                    break;
+
+                case CashTransactionAutoRuleConditionField::COUNTERPARTY_NAME:
+                    $needJoinCp = true;
+                    $qb->andWhere('LOWER(cp.name) LIKE :'.$p)
+                       ->setParameter($p, '%'.mb_strtolower(str_replace('ё','е',(string)$cond->getValue())).'%');
+                    break;
+
+                case CashTransactionAutoRuleConditionField::INN:
+                    $needJoinCp = true;
+                    $qb->andWhere('cp.inn = :'.$p)->setParameter($p, preg_replace('/\D+/', '', (string)$cond->getValue()));
+                    break;
+
+                case CashTransactionAutoRuleConditionField::DATE:
+                    if ($cond->getOperator() === CashTransactionAutoRuleConditionOperator::BETWEEN) {
+                        $qb->andWhere('t.occurredAt BETWEEN :'.$p.'From AND :'.$p.'To')
+                           ->setParameter($p.'From', new \DateTimeImmutable($cond->getValue().' 00:00:00'))
+                           ->setParameter($p.'To',   new \DateTimeImmutable($cond->getValueTo().' 23:59:59'));
+                    } else {
+                        // трактуем EQUAL как «в пределах суток»
+                        $qb->andWhere('t.occurredAt BETWEEN :'.$p.'From AND :'.$p.'To')
+                           ->setParameter($p.'From', new \DateTimeImmutable($cond->getValue().' 00:00:00'))
+                           ->setParameter($p.'To',   new \DateTimeImmutable($cond->getValue().' 23:59:59'));
+                    }
+                    break;
+
+                case CashTransactionAutoRuleConditionField::AMOUNT:
+                    $val = (float)str_replace(',', '.', (string)$cond->getValue());
+                    if ($cond->getOperator() === CashTransactionAutoRuleConditionOperator::BETWEEN) {
+                        $val2 = (float)str_replace(',', '.', (string)$cond->getValueTo());
+                        $qb->andWhere('t.amount BETWEEN :'.$p.'A AND :'.$p.'B')
+                           ->setParameter($p.'A', $val)->setParameter($p.'B', $val2);
+                    } elseif ($cond->getOperator() === CashTransactionAutoRuleConditionOperator::GREATER_THAN) {
+                        $qb->andWhere('t.amount > :'.$p)->setParameter($p, $val);
+                    } elseif ($cond->getOperator() === CashTransactionAutoRuleConditionOperator::LESS_THAN) {
+                        $qb->andWhere('t.amount < :'.$p)->setParameter($p, $val);
+                    } else { // EQUAL
+                        $qb->andWhere('t.amount = :'.$p)->setParameter($p, $val);
+                    }
+                    break;
+
+                case CashTransactionAutoRuleConditionField::DESCRIPTION:
+                    $qb->andWhere('LOWER(COALESCE(t.description, \'\')) LIKE :'.$p)
+                       ->setParameter($p, '%'.mb_strtolower(str_replace('ё','е',(string)$cond->getValue())).'%');
+                    break;
+            }
+        }
+        if ($needJoinCp) {
+            $qb->leftJoin('t.counterparty', 'cp');
+        }
+
+        // Ограничение предпросмотра
+        $limit = min((int)$request->query->get('limit', 200), 1000);
+        $transactions = $qb->setMaxResults($limit)->getQuery()->getResult();
+
+        return $this->render('cash_transaction_auto_rule/check.html.twig', [
+            'rule' => $rule,
+            'transactions' => $transactions,
+            'limit' => $limit,
         ]);
     }
 

--- a/site/templates/cash_transaction_auto_rule/check.html.twig
+++ b/site/templates/cash_transaction_auto_rule/check.html.twig
@@ -1,0 +1,62 @@
+{% extends 'base.html.twig' %}
+{% block title %}Проверка правила — {{ rule.name }}{% endblock %}
+
+{% block body %}
+<div class="container-xl mt-3">
+  <div class="d-flex align-items-center mb-2">
+    <h2 class="page-title">Совпадения по правилу: {{ rule.name }}</h2>
+    <div class="ms-auto text-muted">Показано: {{ transactions|length }} (limit {{ limit }})</div>
+  </div>
+
+  <form method="get" class="card card-body mb-3">
+    <div class="row g-2">
+      <div class="col-md-3">
+        <label class="form-label">С даты</label>
+        <input type="date" name="dateFrom" value="{{ app.request.get('dateFrom') }}" class="form-control">
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">По дату</label>
+        <input type="date" name="dateTo" value="{{ app.request.get('dateTo') }}" class="form-control">
+      </div>
+      <div class="col-md-2">
+        <label class="form-label">Лимит</label>
+        <input type="number" name="limit" value="{{ app.request.get('limit') ?? 200 }}" class="form-control" min="10" max="1000">
+      </div>
+      <div class="col-md-2 align-self-end">
+        <button class="btn btn-primary">Обновить</button>
+      </div>
+    </div>
+  </form>
+
+  <div class="card">
+    <div class="table-responsive">
+      <table class="table table-vcenter">
+        <thead>
+          <tr>
+            <th>Дата</th><th>Счет</th><th class="text-end">Сумма</th>
+            <th>Статья</th><th>Контрагент</th><th>Описание</th><th></th>
+          </tr>
+        </thead>
+        <tbody>
+        {% for t in transactions %}
+          <tr>
+            <td>{{ t.occurredAt|date('d.m.Y') }}</td>
+            <td>{{ t.moneyAccount.name }}</td>
+            <td class="text-end">{{ t.amount|number_format(2, ',', ' ') }} {{ t.currency }}</td>
+            <td>{{ t.cashflowCategory ? t.cashflowCategory.name : '' }}</td>
+            <td>{{ t.counterparty ? t.counterparty.name : '' }}</td>
+            <td>{{ t.description }}</td>
+            <td class="text-nowrap">
+              <a class="btn btn-sm btn-info" href="{{ path('cash_transaction_show', {id: t.id}) }}">Просмотр</a>
+            </td>
+          </tr>
+        {% else %}
+          <tr><td colspan="7" class="text-center text-muted">Совпадений нет</td></tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+{% endblock %}
+

--- a/site/templates/cash_transaction_auto_rule/index.html.twig
+++ b/site/templates/cash_transaction_auto_rule/index.html.twig
@@ -35,6 +35,7 @@
                             <td>{{ item.operationType.name }}</td>
                             <td>{{ item.cashflowCategory.name }}</td>
                             <td class="text-end">
+                                <a href="{{ path('cash_transaction_auto_rule_check', {id: item.id}) }}" class="btn btn-sm btn-secondary">пров.</a>
                                 <a href="{{ path('cash_transaction_auto_rule_edit', {id: item.id}) }}" class="btn btn-sm btn-warning">✏️</a>
                                 <form method="post" action="{{ path('cash_transaction_auto_rule_delete', {id: item.id}) }}" style="display:inline;" onsubmit="return confirm('Удалить?');">
                                     <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ item.id) }}">


### PR DESCRIPTION
## Summary
- add preview button to cash transaction auto rule list
- implement check action to filter transactions by rule criteria
- create check template with date range, limit and transaction table

## Testing
- `composer install` (fails: No token given, aborting)


------
https://chatgpt.com/codex/tasks/task_e_68c2cc525c948323bf9e05c65c96ba8e