### PR TITLE
Add auto rule matching and application for cash transactions

### DIFF
--- a/site/src/Service/CashTransactionAutoRuleService.php
+++ b/site/src/Service/CashTransactionAutoRuleService.php
@@ -1,0 +1,154 @@
+<?php
+namespace App\Service;
+
+use App\Entity\CashTransaction;
+use App\Entity\CashTransactionAutoRule;
+use App\Enum\CashDirection;
+use App\Enum\CashTransactionAutoRuleAction;
+use App\Enum\CashTransactionAutoRuleConditionField;
+use App\Enum\CashTransactionAutoRuleConditionOperator;
+use App\Repository\CashTransactionAutoRuleRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+class CashTransactionAutoRuleService
+{
+    public function __construct(
+        private CashTransactionAutoRuleRepository $ruleRepo,
+        private EntityManagerInterface $em
+    ) {}
+
+    /**
+     * Найти ПЕРВОЕ подходящее правило для транзакции (в пределах компании транзакции).
+     * Возвращает null, если ни одно правило не подошло.
+     */
+    public function findMatchingRule(CashTransaction $t): ?CashTransactionAutoRule
+    {
+        $company = $t->getCompany();
+        $rules = $this->ruleRepo->findByCompany($company); // уже есть в репозитории
+
+        foreach ($rules as $rule) {
+            // 1) Тип операции
+            $opType = $rule->getOperationType();
+            if ($opType->value !== 'ANY') {
+                if ($opType->value === 'INFLOW'  && $t->getDirection() !== CashDirection::INFLOW)  { continue; }
+                if ($opType->value === 'OUTFLOW' && $t->getDirection() !== CashDirection::OUTFLOW) { continue; }
+            }
+
+            // 2) Все условия (AND)
+            $ok = true;
+            foreach ($rule->getConditions() as $cond) {
+                $field    = $cond->getField();
+                $operator = $cond->getOperator();
+                $value    = (string) ($cond->getValue() ?? '');
+                $valueTo  = (string) ($cond->getValueTo() ?? '');
+
+                switch ($field) {
+                    case CashTransactionAutoRuleConditionField::COUNTERPARTY:
+                        // точное совпадение по выбранному контрагенту
+                        if ($t->getCounterparty() !== $cond->getCounterparty()) { $ok = false; }
+                        break;
+
+                    case CashTransactionAutoRuleConditionField::COUNTERPARTY_NAME:
+                        $name = $t->getCounterparty()?->getName() ?? '';
+                        if (!$this->containsNormalized($name, $value)) { $ok = false; }
+                        break;
+
+                    case CashTransactionAutoRuleConditionField::INN:
+                        $inn = preg_replace('/\D+/', '', (string)($t->getCounterparty()?->getInn() ?? ''));
+                        $val = preg_replace('/\D+/', '', $value);
+                        if ($inn !== $val) { $ok = false; }
+                        break;
+
+                    case CashTransactionAutoRuleConditionField::DATE:
+                        // EQUAL — в пределах суток; BETWEEN — включая границы
+                        $d = $t->getOccurredAt();
+                        if ($operator === CashTransactionAutoRuleConditionOperator::BETWEEN) {
+                            $from = new \DateTimeImmutable($value.' 00:00:00');
+                            $to   = new \DateTimeImmutable($valueTo.' 23:59:59');
+                            if ($d < $from || $d > $to) { $ok = false; }
+                        } else { // EQUAL
+                            $from = new \DateTimeImmutable($value.' 00:00:00');
+                            $to   = new \DateTimeImmutable($value.' 23:59:59');
+                            if ($d < $from || $d > $to) { $ok = false; }
+                        }
+                        break;
+
+                    case CashTransactionAutoRuleConditionField::AMOUNT:
+                        // amount хранится строкой; сравним через bccomp при масштабе 2
+                        $amt = $t->getAmount();
+                        $cmp = fn(string $a, string $b) => \bccomp($a, $b, 2);
+                        if ($operator === CashTransactionAutoRuleConditionOperator::BETWEEN) {
+                            if (!($cmp($amt, (string)$value) >= 0 && $cmp($amt, (string)$valueTo) <= 0)) { $ok = false; }
+                        } elseif ($operator === CashTransactionAutoRuleConditionOperator::GREATER_THAN) {
+                            if (!($cmp($amt, (string)$value) > 0)) { $ok = false; }
+                        } elseif ($operator === CashTransactionAutoRuleConditionOperator::LESS_THAN) {
+                            if (!($cmp($amt, (string)$value) < 0)) { $ok = false; }
+                        } else { // EQUAL
+                            if (!($cmp($amt, (string)$value) === 0)) { $ok = false; }
+                        }
+                        break;
+
+                    case CashTransactionAutoRuleConditionField::DESCRIPTION:
+                        $desc = $t->getDescription() ?? '';
+                        if (!$this->containsNormalized($desc, $value)) { $ok = false; }
+                        break;
+                }
+
+                if (!$ok) { break; }
+            }
+
+            if ($ok) {
+                return $rule;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Применить правило к одной транзакции.
+     * Возвращает true, если были изменения; false — если изменений не было.
+     * NB: в текущей модели правила меняют только Категорию ДДС.
+     */
+    public function applyRule(CashTransactionAutoRule $rule, CashTransaction $t): bool
+    {
+        $changed = false;
+
+        // безопасность по компании
+        if ($rule->getCompany() !== $t->getCompany()) {
+            return false;
+        }
+
+        $category = $rule->getCashflowCategory(); // в сущности правила поле not-null
+        $action   = $rule->getAction();
+
+        // Семантика:
+        // FILL   — ставим категорию только если у транзакции она пуста
+        // UPDATE — перезаписываем всегда
+        if ($action === CashTransactionAutoRuleAction::FILL) {
+            if ($t->getCashflowCategory() === null) {
+                $t->setCashflowCategory($category);
+                $changed = true;
+            }
+        } else { // UPDATE
+            if ($t->getCashflowCategory() !== $category) {
+                $t->setCashflowCategory($category);
+                $changed = true;
+            }
+        }
+
+        if ($changed) {
+            $this->em->flush(); // одна транзакция — можно сразу
+        }
+
+        return $changed;
+    }
+
+    private function containsNormalized(string $haystack, string $needle): bool
+    {
+        $norm = fn(string $s) => mb_strtolower(str_replace('ё','е',$s));
+        $h = $norm($haystack);
+        $n = $norm($needle);
+        return $n !== '' && mb_strpos($h, $n) !== false;
+    }
+}

--- a/site/templates/cash_transaction/_auto_rule_modal_body.html.twig
+++ b/site/templates/cash_transaction/_auto_rule_modal_body.html.twig
@@ -1,0 +1,25 @@
+{# Это только BODY модалки; сама модалка — ниже #}
+
+{% if rule %}
+  <div class="mb-2">
+    <div class="h3">Найдено автоправило</div>
+    <div class="text-muted">«{{ rule.name }}» ({{ rule.action.value }}, {{ rule.operationType.value }})</div>
+  </div>
+
+  <form id="autoRuleApplyForm" method="post"
+        action="{{ path('cash_transaction_auto_rule_apply_one', {transactionId: transaction.id}) }}">
+    <input type="hidden" name="ruleId" value="{{ rule.id }}">
+    {# CSRF не обязателен для AJAX, но можно добавить, если в проекте принято #}
+    <div class="d-flex gap-2 mt-3">
+      <button type="submit" class="btn btn-primary">Применить</button>
+      <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Закрыть</button>
+    </div>
+  </form>
+{% else %}
+  <div class="mb-2">
+    <div class="h3">Подходящих автоправил не найдено</div>
+  </div>
+  <div class="d-flex gap-2 mt-3">
+    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Закрыть</button>
+  </div>
+{% endif %}

--- a/site/templates/transaction/index.html.twig
+++ b/site/templates/transaction/index.html.twig
@@ -54,6 +54,12 @@
                     <td class="text-nowrap">
                         <a href="{{ path('cash_transaction_show', {id: tx.id}) }}" class="btn btn-sm btn-info">Просмотр</a>
                         <a href="{{ path('cash_transaction_edit', {id: tx.id}) }}" class="btn btn-sm btn-warning">Редактировать</a>
+                        <a href="{{ path('cash_transaction_auto_rule_match_one', {transactionId: tx.id}) }}"
+                           class="btn btn-sm btn-outline-secondary js-auto-rule"
+                           data-transaction-id="{{ tx.id }}"
+                           data-url="{{ path('cash_transaction_auto_rule_match_one', {transactionId: tx.id}) }}">
+                          A+
+                        </a>
                         <button class="btn btn-sm btn-danger" data-bs-toggle="modal" data-bs-target="#delete-modal-{{ tx.id }}">Удалить</button>
                         {{ include('transaction/_delete_modal.html.twig', {tx: tx}) }}
                     </td>
@@ -87,6 +93,20 @@
     </div>
     </div>
 </div>
+
+<div class="modal fade" id="autoRuleModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Автоправило</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Закрыть"></button>
+      </div>
+      <div class="modal-body" id="autoRuleModalBody">
+        <div class="text-muted">Загрузка…</div>
+      </div>
+    </div>
+  </div>
+</div>
 {% endblock %}
 
 {% block scripts %}
@@ -113,6 +133,56 @@
                 to.value = fmt(now);
             });
         });
+    </script>
+    <script>
+    document.addEventListener('click', async (e) => {
+      const btn = e.target.closest('.js-auto-rule');
+      if (!btn) return;
+
+      e.preventDefault();
+      const url = btn.dataset.url;
+      const modalEl = document.getElementById('autoRuleModal');
+      const bodyEl  = document.getElementById('autoRuleModalBody');
+
+      bodyEl.innerHTML = '<div class="text-muted">Загрузка…</div>';
+
+      try {
+        const html = await fetch(url, {headers: {'X-Requested-With':'XMLHttpRequest'}}).then(r => r.text());
+        bodyEl.innerHTML = html;
+      } catch(err) {
+        bodyEl.innerHTML = '<div class="text-danger">Ошибка загрузки</div>';
+      }
+
+      // Показ модалки (Bootstrap 5)
+      const modal = new bootstrap.Modal(modalEl);
+      modal.show();
+
+      // Обработка submit "Применить" внутри модалки (AJAX)
+      modalEl.addEventListener('submit', async (ev) => {
+        const f = ev.target;
+        if (f.id !== 'autoRuleApplyForm') return;
+        ev.preventDefault();
+
+        const formData = new FormData(f);
+        const res = await fetch(f.action, { method: 'POST', body: formData, headers: {'X-Requested-With': 'XMLHttpRequest'}});
+        const data = await res.json();
+
+        if (data.ok) {
+          bodyEl.innerHTML = `
+        <div class="alert alert-success mb-2">Применено: ${data.changed ? 'да' : 'без изменений'}</div>
+        <div>Правило: <b>${data.ruleName}</b> (${data.action})</div>
+        <div class="mt-3 text-end">
+          <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Закрыть</button>
+        </div>`;
+        } else {
+          bodyEl.innerHTML = `
+        <div class="alert alert-warning mb-2">${data.message ?? 'Не найдено'}</div>
+        <div class="mt-3 text-end">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Закрыть</button>
+        </div>`;
+        }
+      }, { once: true });
+    });
     </script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- introduce CashTransactionAutoRuleService to find and apply auto rules to transactions
- support matching/applying rules through new controller endpoints
- add UI for checking and applying auto rules from transaction list

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c3e29f78748323883711c786e266b5