### PR TITLE
fix: include bootstrap for transaction modal

### DIFF
--- a/site/templates/base.html.twig
+++ b/site/templates/base.html.twig
@@ -29,6 +29,7 @@
         </div>
     </div>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@tabler/core@1.2.0/dist/js/tabler.min.js"></script>
 {% block scripts %}{% block javascripts %}{% endblock %}{% endblock %}
 </body>


### PR DESCRIPTION
## Summary
- include Bootstrap bundle before Tabler to expose `bootstrap` global

## Testing
- `php bin/phpunit` *(fails: unable to find simple-phpunit.php)*
- `composer install` *(fails: GitHub 403 when downloading symfony/flex)*

------
https://chatgpt.com/codex/tasks/task_e_68c3fb98cff8832392bcd7e643837f84