### PR TITLE
Ensure sidebar dropdown works without Tabler JS

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1,10 +1,33 @@
 import './bootstrap.js';
-/*
- * Welcome to your app's main JavaScript file!
- *
- * This file will be included onto the page via the importmap() Twig function,
- * which should already be in your base.html.twig.
- */
 import './styles/app.css';
 
-console.log('This log comes from assets/app.js - welcome to AssetMapper! 🎉');
+/**
+ * Simple dropdown handler for the vertical sidebar.
+ *
+ * Tabler's JavaScript is normally responsible for toggling dropdown
+ * menus. In environments where the library isn't loaded (for example
+ * when CDN assets are unavailable), the menu items would stop opening.
+ *
+ * The code below reproduces the required behaviour using vanilla
+ * JavaScript so that the menu continues to work even without the
+ * external dependency.
+ */
+document.addEventListener('DOMContentLoaded', () => {
+  // If Tabler's JavaScript is available, it will handle dropdowns itself.
+  // The fallback logic below runs only when Tabler isn't present.
+  if (typeof window.Tabler !== 'undefined') {
+    return;
+  }
+
+  document
+    .querySelectorAll('.navbar-vertical .nav-item.dropdown > .nav-link')
+    .forEach((link) => {
+      link.addEventListener('click', (event) => {
+        event.preventDefault();
+        const menu = link.nextElementSibling;
+        if (menu) {
+          menu.classList.toggle('show');
+        }
+      });
+    });
+});

--- a/site/assets/styles/app.css
+++ b/site/assets/styles/app.css
@@ -17,3 +17,16 @@ body {
         padding: 3rem;
     }
 }
+
+/*
+ * Fallback styles for dropdown menus in the sidebar. When Tabler's CSS
+ * is unavailable, ensure that the dropdown menu can still be toggled
+ * via the "show" class added by our JavaScript.
+ */
+.navbar-vertical .dropdown-menu {
+    display: none;
+}
+
+.navbar-vertical .dropdown-menu.show {
+    display: block;
+}

--- a/site/templates/base.html.twig
+++ b/site/templates/base.html.twig
@@ -31,7 +31,10 @@
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@tabler/core@1.2.0/dist/js/tabler.min.js"></script>
-{% block scripts %}{% block javascripts %}{% endblock %}{% endblock %}
+{% block scripts %}
+    {{ importmap('app') }}
+    {% block javascripts %}{% endblock %}
+{% endblock %}
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- Add vanilla JS handler to toggle sidebar dropdowns
- Provide fallback CSS for dropdown menus
- Load application script via importmap in base template
- Skip fallback handler when Tabler JS is available

## Testing
- `php bin/phpunit` *(fails: Could not open input file: bin/phpunit)*

------
https://chatgpt.com/codex/tasks/task_e_68c40d2ebf8c8323af43ce9a4aa12fa9