### PR TITLE
Ensure sidebar dropdown state handled without Tabler

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -26,7 +26,8 @@ document.addEventListener('DOMContentLoaded', () => {
         event.preventDefault();
         const menu = link.nextElementSibling;
         if (menu) {
-          menu.classList.toggle('show');
+          const isOpen = menu.classList.toggle('show');
+          link.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
         }
       });
     });


### PR DESCRIPTION
## Summary
- manage `aria-expanded` on sidebar dropdown fallback

## Testing
- `./bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script)*
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c41c8562a88323817037b123259d03