### PR TITLE
Initialize sidebar dropdowns in base template

### DIFF
--- a/site/templates/base.html.twig
+++ b/site/templates/base.html.twig
@@ -31,6 +31,20 @@
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@tabler/core@1.2.0/dist/js/tabler.min.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  document
+    .querySelectorAll('#sidebar-menu .nav-item.dropdown > a.nav-link.dropdown-toggle[data-bs-toggle="dropdown"]')
+    .forEach(function (el) {
+      el.addEventListener('click', function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        const dd = bootstrap.Dropdown.getOrCreateInstance(el, { autoClose: false });
+        dd.toggle();
+      });
+    });
+});
+</script>
 {% block scripts %}
     {{ importmap('app') }}
     {% block javascripts %}{% endblock %}


### PR DESCRIPTION
## Summary
- add script to bootstrap sidebar dropdowns and prevent navigation on # links

## Testing
- `php bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script)*

------
https://chatgpt.com/codex/tasks/task_e_68c42209bf10832382b39c0e2226a25f