### PR TITLE
fix: prevent sidebar dropdown auto-close

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -24,6 +24,9 @@ document.addEventListener('DOMContentLoaded', () => {
     .forEach((link) => {
       link.addEventListener('click', (event) => {
         event.preventDefault();
+        // Prevent the click from bubbling up, which would
+        // immediately close the menu in some browsers.
+        event.stopPropagation();
         const menu = link.nextElementSibling;
         if (menu) {
           const isOpen = menu.classList.toggle('show');


### PR DESCRIPTION
## Summary
- keep sidebar dropdowns open by stopping click propagation when Tabler JS isn't available

## Testing
- `composer install --no-ansi --no-progress` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c43c7a258c83238ab8727f01b9ef44