### PR TITLE
fix: avoid double sidebar dropdown init

### DIFF
--- a/site/templates/base.html.twig
+++ b/site/templates/base.html.twig
@@ -33,6 +33,10 @@
 <script src="https://cdn.jsdelivr.net/npm/@tabler/core@1.2.0/dist/js/tabler.min.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function () {
+  if (typeof window.Tabler === 'undefined') {
+    return;
+  }
+
   document
     .querySelectorAll('#sidebar-menu .nav-item.dropdown > a.nav-link.dropdown-toggle[data-bs-toggle="dropdown"]')
     .forEach(function (el) {


### PR DESCRIPTION
## Summary
- prevent duplicate dropdown handlers when Tabler isn't loaded

## Testing
- `php bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`.)*
- `composer install --no-interaction` *(fails: curl error 56 CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c43facae0c832397e1e0732f758c72