### PR TITLE
fix: open modal using Tabler JS

### DIFF
--- a/site/templates/transaction/index.html.twig
+++ b/site/templates/transaction/index.html.twig
@@ -153,9 +153,12 @@
         bodyEl.innerHTML = '<div class="text-danger">Ошибка загрузки</div>';
       }
 
-      // Показ модалки (Bootstrap 5)
-      const modal = new bootstrap.Modal(modalEl);
-      modal.show();
+      // Показ модалки (Tabler/Bootstrap 5)
+      const ModalClass = window.Tabler?.Modal || window.bootstrap?.Modal;
+      if (ModalClass) {
+        const modal = new ModalClass(modalEl);
+        modal.show();
+      }
 
       // Обработка submit "Применить" внутри модалки (AJAX)
       modalEl.addEventListener('submit', async (ev) => {


### PR DESCRIPTION
## Summary
- handle modal display with Tabler or Bootstrap JS fallback

## Testing
- `php bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`)*
- `php bin/console lint:twig templates/transaction/index.html.twig` *(fails: Dependencies are missing. Try running "composer install".)*

------
https://chatgpt.com/codex/tasks/task_e_68c44e0712508323bc4eb77a78eca914