### PR TITLE
Fix auto-rule modal trigger in cash transactions

### DIFF
--- a/site/templates/transaction/index.html.twig
+++ b/site/templates/transaction/index.html.twig
@@ -146,18 +146,18 @@
 
       bodyEl.innerHTML = '<div class="text-muted">Загрузка…</div>';
 
-      try {
-        const html = await fetch(url, {headers: {'X-Requested-With':'XMLHttpRequest'}}).then(r => r.text());
-        bodyEl.innerHTML = html;
-      } catch(err) {
-        bodyEl.innerHTML = '<div class="text-danger">Ошибка загрузки</div>';
-      }
-
       // Показ модалки (Tabler/Bootstrap 5)
       const ModalClass = window.Tabler?.Modal || window.bootstrap?.Modal;
       if (ModalClass) {
         const modal = new ModalClass(modalEl);
         modal.show();
+      }
+
+      try {
+        const html = await fetch(url, {headers: {'X-Requested-With':'XMLHttpRequest'}}).then(r => r.text());
+        bodyEl.innerHTML = html;
+      } catch(err) {
+        bodyEl.innerHTML = '<div class="text-danger">Ошибка загрузки</div>';
       }
 
       // Обработка submit "Применить" внутри модалки (AJAX)


### PR DESCRIPTION
## Summary
- show auto-rule modal immediately using Tabler/Bootstrap modal
- load auto-rule HTML asynchronously without blocking modal display

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c45085461c8323aa241c915a9f249f