### PR TITLE
fix: prevent turbo importmap duplication

### DIFF
--- a/site/templates/base.html.twig
+++ b/site/templates/base.html.twig
@@ -9,6 +9,9 @@
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@2.39.0/tabler-icons.min.css"/>
         {% block stylesheets %}{% endblock %}
     {% endblock %}
+    {% block importmap %}
+        {{ importmap('app')|replace({'<script type="importmap"': '<script type="importmap" data-turbo-track="reload"'}) }}
+    {% endblock %}
 </head>
 <body class="layout-fluid layout-fluid-vertical">
 <div class="page">
@@ -33,7 +36,6 @@
 <script src="https://cdn.jsdelivr.net/npm/@tabler/core@1.2.0/dist/js/tabler.min.js"></script>
 
 {% block scripts %}
-    {{ importmap('app') }}
     {% block javascripts %}{% endblock %}
 {% endblock %}
 </body>

--- a/site/templates/security/base.html.twig
+++ b/site/templates/security/base.html.twig
@@ -9,9 +9,8 @@
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.2.0/dist/css/tabler.min.css" />
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@2.39.0/tabler-icons.min.css"/>
     {% endblock %}
-
-    {% block javascripts %}
-        {% block importmap %}{{ importmap('app') }}{% endblock %}
+    {% block importmap %}
+        {{ importmap('app')|replace({'<script type="importmap"': '<script type="importmap" data-turbo-track="reload"'}) }}
     {% endblock %}
 </head>
 <body>
@@ -28,4 +27,5 @@
 <script
     src="https://cdn.jsdelivr.net/npm/@tabler/core@1.2.0/dist/js/tabler.min.js">
 </script>
+{% block javascripts %}{% endblock %}
 </html>


### PR DESCRIPTION
## Summary
- prevent duplicate import map evaluation by Turbo by moving the import map to the page head and marking it with `data-turbo-track="reload"`

## Testing
- `php bin/console lint:twig templates/base.html.twig templates/security/base.html.twig` *(fails: Symfony Runtime is missing)*
- `php bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`)*

------
https://chatgpt.com/codex/tasks/task_e_68c46389f6508323ac20abc67f769ac4