### PR TITLE
Prevent importmap escaping that showed code on page

### DIFF
--- a/site/templates/base.html.twig
+++ b/site/templates/base.html.twig
@@ -10,7 +10,7 @@
         {% block stylesheets %}{% endblock %}
     {% endblock %}
     {% block importmap %}
-        {{ importmap('app')|replace({'<script type="importmap"': '<script type="importmap" data-turbo-track="reload"'}) }}
+        {{ importmap('app')|replace({'<script type="importmap"': '<script type="importmap" data-turbo-track="reload"'})|raw }}
     {% endblock %}
 </head>
 <body class="layout-fluid layout-fluid-vertical">

--- a/site/templates/security/base.html.twig
+++ b/site/templates/security/base.html.twig
@@ -10,7 +10,7 @@
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@2.39.0/tabler-icons.min.css"/>
     {% endblock %}
     {% block importmap %}
-        {{ importmap('app')|replace({'<script type="importmap"': '<script type="importmap" data-turbo-track="reload"'}) }}
+        {{ importmap('app')|replace({'<script type="importmap"': '<script type="importmap" data-turbo-track="reload"'})|raw }}
     {% endblock %}
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Render importmap output as raw HTML to avoid importmap scripts displaying as page text

## Testing
- ⚠️ `php bin/phpunit` *(missing simple-phpunit.php)*
- ⚠️ `composer install --no-interaction` *(failed: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c46732f6788323905c0f2a136aab2d