### PR TITLE
feat: add manual daily balance verification report

### DIFF
--- a/site/src/Controller/Report/BalanceVerifyController.php
+++ b/site/src/Controller/Report/BalanceVerifyController.php
@@ -1,0 +1,175 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Controller\Report;
+
+use App\Repository\MoneyAccountDailyBalanceRepository;
+use App\Repository\MoneyAccountRepository;
+use App\Service\ActiveCompanyService;
+use App\Service\AccountBalanceService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use function bcadd;
+use function bccomp;
+use function bcsub;
+
+#[IsGranted('ROLE_USER')]
+class BalanceVerifyController extends AbstractController
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private MoneyAccountRepository $accountRepository,
+        private MoneyAccountDailyBalanceRepository $balanceRepository,
+        private ActiveCompanyService $companyService,
+        private AccountBalanceService $accountBalanceService,
+    ) {
+    }
+
+    #[Route('/reports/balance-verify', name: 'app_reports_balance_verify', methods: ['GET', 'POST'])]
+    public function __invoke(Request $request): Response
+    {
+        $company = $this->companyService->getActiveCompany();
+        $accounts = $this->accountRepository->findBy(['company' => $company], ['name' => 'ASC']);
+
+        $to = new \DateTimeImmutable('today');
+        $from = $to->modify('-2 days');
+        $selectedAccountId = null;
+        $expectedJson = <<<JSON
+{
+  "currency": "RUB",
+  "rows": [
+    {"date":"2024-01-01","opening":"120000.00","inflow":"0.00","outflow":"0.00","closing":"120000.00"},
+    {"date":"2024-01-02","opening":"120000.00","inflow":"5000.00","outflow":"0.00","closing":"125000.00"},
+    {"date":"2024-01-03","opening":"125000.00","inflow":"0.00","outflow":"2000.00","closing":"123000.00"}
+  ]
+}
+JSON;
+        $resultRows = null;
+        $totals = null;
+        $recalc = false;
+
+        if ($request->isMethod('POST')) {
+            $this->denyAccessUnlessGranted('ROLE_USER');
+            if (!$this->isCsrfTokenValid('balance_verify', $request->request->get('_token'))) {
+                throw $this->createAccessDeniedException();
+            }
+            $selectedAccountId = $request->request->get('account_id');
+            $fromParam = $request->request->get('from');
+            $toParam = $request->request->get('to');
+            $recalc = (bool)$request->request->get('recalc');
+            $expectedJson = (string)$request->request->get('expected_json', $expectedJson);
+
+            $from = $fromParam ? new \DateTimeImmutable($fromParam) : $from;
+            $to = $toParam ? new \DateTimeImmutable($toParam) : $to;
+
+            $account = null;
+            foreach ($accounts as $a) {
+                if ($a->getId() === $selectedAccountId) {
+                    $account = $a;
+                    break;
+                }
+            }
+            if (!$account && $accounts) {
+                $account = $accounts[0];
+                $selectedAccountId = $account->getId();
+            }
+
+            if ($account) {
+                if ($recalc) {
+                    $this->accountBalanceService->recalculateDailyRange($company, $account, $from, $to);
+                }
+                $qb = $this->balanceRepository->createQueryBuilder('b')
+                    ->where('b.company = :company')
+                    ->andWhere('b.moneyAccount = :account')
+                    ->andWhere('b.date BETWEEN :from AND :to')
+                    ->setParameter('company', $company)
+                    ->setParameter('account', $account)
+                    ->setParameter('from', $from->setTime(0, 0))
+                    ->setParameter('to', $to->setTime(0, 0))
+                    ->orderBy('b.date', 'ASC');
+                $rows = $qb->getQuery()->getResult();
+                $actual = [];
+                foreach ($rows as $row) {
+                    /** @var \App\Entity\MoneyAccountDailyBalance $row */
+                    $key = $row->getDate()->format('Y-m-d');
+                    $actual[$key] = [
+                        'opening' => $row->getOpeningBalance(),
+                        'inflow' => $row->getInflow(),
+                        'outflow' => $row->getOutflow(),
+                        'closing' => $row->getClosingBalance(),
+                    ];
+                }
+
+                $expectedData = json_decode($expectedJson, true);
+                $expected = [];
+                if (is_array($expectedData['rows'] ?? null)) {
+                    foreach ($expectedData['rows'] as $r) {
+                        if (isset($r['date'])) {
+                            $expected[$r['date']] = [
+                                'opening' => $r['opening'] ?? '0.00',
+                                'inflow' => $r['inflow'] ?? '0.00',
+                                'outflow' => $r['outflow'] ?? '0.00',
+                                'closing' => $r['closing'] ?? '0.00',
+                            ];
+                        }
+                    }
+                }
+                $dates = array_unique(array_merge(array_keys($expected), array_keys($actual)));
+                sort($dates);
+                $ok = 0;
+                $mismatches = 0;
+                $resultRows = [];
+                foreach ($dates as $d) {
+                    $exp = $expected[$d] ?? null;
+                    $act = $actual[$d] ?? null;
+                    $status = 'OK';
+                    if ($exp === null && $act !== null) {
+                        $status = 'UNEXPECTED';
+                    } elseif ($exp !== null && $act === null) {
+                        $status = 'MISSING';
+                    } elseif ($exp !== null && $act !== null) {
+                        foreach (['opening', 'inflow', 'outflow', 'closing'] as $f) {
+                            if (bccomp($exp[$f], $act[$f], 2) !== 0) {
+                                $status = 'MISMATCH';
+                                break;
+                            }
+                        }
+                        if ($status === 'OK') {
+                            $calc = bcsub(bcadd($act['opening'], $act['inflow'], 2), $act['outflow'], 2);
+                            if (bccomp($calc, $act['closing'], 2) !== 0) {
+                                $status = 'CONSISTENCY_FAIL';
+                            }
+                        }
+                    }
+                    if ($status === 'OK') {
+                        $ok++;
+                    } else {
+                        $mismatches++;
+                    }
+                    $resultRows[] = [
+                        'date' => $d,
+                        'expected' => $exp,
+                        'actual' => $act,
+                        'status' => $status,
+                    ];
+                }
+                $totals = ['ok' => $ok, 'mismatches' => $mismatches];
+            }
+        }
+
+        return $this->render('reports/balance_verify.html.twig', [
+            'accounts' => $accounts,
+            'selected_account_id' => $selectedAccountId,
+            'date_from' => $from,
+            'date_to' => $to,
+            'expected_json' => $expectedJson,
+            'resultRows' => $resultRows,
+            'totals' => $totals,
+            'recalc' => $recalc,
+        ]);
+    }
+}

--- a/site/templates/partials/_sidebar.html.twig
+++ b/site/templates/partials/_sidebar.html.twig
@@ -44,6 +44,9 @@
                         <a class="dropdown-item " href="#">
                             <span class="nav-link-title">Отчет ОПиУ</span>
                         </a>
+                        <a class="dropdown-item {{ current_route == 'app_reports_balance_verify' ? 'active' : '' }}" href="{{ path('app_reports_balance_verify') }}">
+                            <span class="nav-link-title">Контроль пересчёта остатков</span>
+                        </a>
                     </div>
                 </li>
 

--- a/site/templates/reports/balance_verify.html.twig
+++ b/site/templates/reports/balance_verify.html.twig
@@ -1,0 +1,99 @@
+{% extends 'base.html.twig' %}
+
+{% block breadcrumbs %}
+    {% include 'partials/_breadcrumbs.html.twig' with {
+        breadcrumbs: [
+            {'label': 'Главная', 'path': 'app_home_index'},
+            {'label': 'Отчеты'},
+            {'label': 'Контроль пересчёта остатков', 'path': 'app_reports_balance_verify'}
+        ]
+    } %}
+{% endblock %}
+
+{% block content %}
+<div class="d-flex align-items-center mb-3">
+    <h2 class="page-title">Контроль пересчёта остатков</h2>
+</div>
+
+<form method="post" class="row g-2 mb-4">
+    <input type="hidden" name="_token" value="{{ csrf_token('balance_verify') }}"/>
+    <div class="col-12 col-md-3">
+        <select name="account_id" class="form-select">
+            {% for acc in accounts %}
+                <option value="{{ acc.id }}" {% if acc.id == selected_account_id %}selected{% endif %}>{{ acc.name }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="col-auto">
+        <input type="date" name="from" value="{{ date_from|date('Y-m-d') }}" class="form-control"/>
+    </div>
+    <div class="col-auto">
+        <input type="date" name="to" value="{{ date_to|date('Y-m-d') }}" class="form-control"/>
+    </div>
+    <div class="col-12">
+        <label class="form-check">
+            <input type="checkbox" name="recalc" value="1" class="form-check-input" {% if recalc %}checked{% endif %}>
+            <span class="form-check-label">Пересчитать перед проверкой</span>
+        </label>
+    </div>
+    <div class="col-12">
+        <textarea name="expected_json" rows="12" class="form-control">{{ expected_json }}</textarea>
+    </div>
+    <div class="col-12">
+        <button type="submit" class="btn btn-primary">Проверить</button>
+    </div>
+</form>
+
+{% if resultRows is not null %}
+<div class="card mb-3">
+    <div class="card-body">
+        <p class="mb-3">OK: {{ totals.ok }} rows verified, {{ totals.mismatches }} mismatches</p>
+        <div class="table-responsive">
+            <table class="table table-striped">
+                <thead>
+                <tr>
+                    <th>Date</th>
+                    <th>Opening [exp|act]</th>
+                    <th>Inflow [exp|act]</th>
+                    <th>Outflow [exp|act]</th>
+                    <th>Closing [exp|act]</th>
+                    <th>Status</th>
+                </tr>
+                </thead>
+                <tbody>
+                {% for row in resultRows %}
+                    {% set status = row.status %}
+                    {% set color = 'text-warning' %}
+                    {% if status == 'OK' %}
+                        {% set color = 'text-success' %}
+                    {% elseif status in ['MISMATCH', 'CONSISTENCY_FAIL'] %}
+                        {% set color = 'text-danger' %}
+                    {% endif %}
+                    <tr class="{{ color }}">
+                        <td>{{ row.date }}</td>
+                        <td>{{ row.expected.opening ?? '-' }} | {{ row.actual.opening ?? '-' }}</td>
+                        <td>{{ row.expected.inflow ?? '-' }} | {{ row.actual.inflow ?? '-' }}</td>
+                        <td>{{ row.expected.outflow ?? '-' }} | {{ row.actual.outflow ?? '-' }}</td>
+                        <td>{{ row.expected.closing ?? '-' }} | {{ row.actual.closing ?? '-' }}</td>
+                        <td>
+                            {% if status == 'OK' %}
+                                <span class="badge bg-success">OK</span>
+                            {% elseif status == 'MISMATCH' %}
+                                <span class="badge bg-danger">MISMATCH</span>
+                            {% elseif status == 'CONSISTENCY_FAIL' %}
+                                <span class="badge bg-danger">CONSISTENCY_FAIL</span>
+                            {% elseif status == 'MISSING' %}
+                                <span class="badge bg-warning text-dark">MISSING</span>
+                            {% elseif status == 'UNEXPECTED' %}
+                                <span class="badge bg-warning text-dark">UNEXPECTED</span>
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add balance verification report with optional recalculation and comparison against expected values
- render Tabler page for manual balance validation
- link report in sidebar menu

## Testing
- `php -l src/Controller/Report/BalanceVerifyController.php`
- `php bin/console lint:twig templates/reports/balance_verify.html.twig` *(fails: Symfony Runtime is missing)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c5224c76bc8323bc6ae715cbaa0e84