### PR TITLE
Allow uppercase txt extension for bank import

### DIFF
--- a/site/src/Controller/Finance/Bank1CImportController.php
+++ b/site/src/Controller/Finance/Bank1CImportController.php
@@ -49,7 +49,8 @@ class Bank1CImportController extends AbstractController
             $this->addFlash('danger', 'Файл не загружен');
             return $this->redirectToRoute('bank1c_import_form');
         }
-        if ($file->getSize() > 10 * 1024 * 1024 || $file->getClientOriginalExtension() !== 'txt') {
+        $extension = strtolower($file->getClientOriginalExtension() ?? '');
+        if ($file->getSize() > 10 * 1024 * 1024 || $extension !== 'txt') {
             $this->addFlash('danger', 'Недопустимый файл');
             return $this->redirectToRoute('bank1c_import_form');
         }


### PR DESCRIPTION
## Summary
- allow uploading 1C bank statements when the uploaded file has an uppercase TXT extension by normalizing it before validation

## Testing
- not run (composer install failed because downloading dependencies from GitHub is blocked in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68c98d0ac6148323acea6c9177cdab30