### PR TITLE
Add code style tooling configs and composer scripts

### DIFF
--- a/site/.php-cs-fixer.php
+++ b/site/.php-cs-fixer.php
@@ -1,0 +1,20 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__ . '/src')
+    ->in(__DIR__ . '/tests')
+    ->name('*.php')
+    ->ignoreVCSIgnored(true);
+
+return (new PhpCsFixer\Config())
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@Symfony' => true,
+        '@Symfony:risky' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
+        'phpdoc_align' => ['align' => 'left'],
+        'native_function_invocation' => false,
+        'declare_strict_types' => false,
+    ])
+    ->setFinder($finder);

--- a/site/.twig-cs-fixer.php
+++ b/site/.twig-cs-fixer.php
@@ -1,0 +1,9 @@
+<?php
+
+use FriendsOfTwig\Twigcs\Config\Config;
+use FriendsOfTwig\Twigcs\Ruleset\Official;
+
+return (new Config())
+    ->setSeverity('warning') // 'warning' или 'error'
+    ->setRuleset(new Official())
+    ->setPaths([__DIR__ . '/templates']);

--- a/site/composer.json
+++ b/site/composer.json
@@ -78,6 +78,10 @@
         "symfony/polyfill-php82": "*"
     },
     "scripts": {
+        "cs:check": "php-cs-fixer fix --dry-run --diff",
+        "cs:fix": "php-cs-fixer fix",
+        "cs:phpcs": "phpcs --standard=PSR12 src tests",
+        "cs:twig": "twigcs --config .twig-cs-fixer.php templates",
         "auto-scripts": {
             "cache:clear": "symfony-cmd",
             "assets:install %PUBLIC_DIR%": "symfony-cmd",
@@ -101,7 +105,10 @@
     },
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "^4.1",
+        "friendsofphp/php-cs-fixer": "^3.64",
+        "friendsoftwig/twigcs": "^6.1",
         "phpunit/phpunit": "^11.5",
+        "squizlabs/php_codesniffer": "^3.10",
         "symfony/browser-kit": "7.3.*",
         "symfony/css-selector": "7.3.*",
         "symfony/debug-bundle": "7.3.*",


### PR DESCRIPTION
## Summary
- add php-cs-fixer configuration for PHP sources and tests
- add twigcs configuration targeting Twig templates
- register code style composer scripts and declare related dev dependencies

## Testing
- composer require --dev friendsofphp/php-cs-fixer squizlabs/php_codesniffer friendsoftwig/twigcs *(fails: Packagist access returned 403 CONNECT tunnel error)*
- composer cs:check *(fails: php-cs-fixer binary missing because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cc000041ec8323b7e9ebb7e06aa649