### PR TITLE
Add project direction selection for cash transactions

### DIFF
--- a/site/migrations/Version20250919000000.php
+++ b/site/migrations/Version20250919000000.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250919000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add project_direction relation to cash_transaction';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE cash_transaction ADD project_direction_id UUID DEFAULT NULL');
+        $this->addSql('CREATE INDEX idx_ct_project_direction ON cash_transaction (project_direction_id)');
+        $this->addSql('ALTER TABLE cash_transaction ADD CONSTRAINT fk_ct_project_direction FOREIGN KEY (project_direction_id) REFERENCES project_directions (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE cash_transaction DROP CONSTRAINT fk_ct_project_direction');
+        $this->addSql('DROP INDEX idx_ct_project_direction');
+        $this->addSql('ALTER TABLE cash_transaction DROP COLUMN project_direction_id');
+    }
+}

--- a/site/src/DTO/CashTransactionDTO.php
+++ b/site/src/DTO/CashTransactionDTO.php
@@ -16,6 +16,7 @@ class CashTransactionDTO
 
     public ?string $counterpartyId = null;
     public ?string $cashflowCategoryId = null;
+    public ?string $projectDirectionId = null;
 
     #[Assert\Choice(callback: [CashDirection::class, 'cases'])]
     public CashDirection $direction;

--- a/site/src/Entity/CashTransaction.php
+++ b/site/src/Entity/CashTransaction.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use App\Enum\CashDirection;
+use App\Entity\ProjectDirection;
 use App\Repository\CashTransactionRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Webmozart\Assert\Assert;
@@ -30,6 +31,10 @@ class CashTransaction
 
     #[ORM\ManyToOne(targetEntity: CashflowCategory::class)]
     private ?CashflowCategory $cashflowCategory = null;
+
+    #[ORM\ManyToOne(targetEntity: ProjectDirection::class)]
+    #[ORM\JoinColumn(onDelete: 'SET NULL')]
+    private ?ProjectDirection $projectDirection = null;
 
     #[ORM\Column(enumType: CashDirection::class)]
     private CashDirection $direction;
@@ -122,6 +127,18 @@ class CashTransaction
     public function setCashflowCategory(?CashflowCategory $c): self
     {
         $this->cashflowCategory = $c;
+
+        return $this;
+    }
+
+    public function getProjectDirection(): ?ProjectDirection
+    {
+        return $this->projectDirection;
+    }
+
+    public function setProjectDirection(?ProjectDirection $projectDirection): self
+    {
+        $this->projectDirection = $projectDirection;
 
         return $this;
     }

--- a/site/src/Form/CashTransactionType.php
+++ b/site/src/Form/CashTransactionType.php
@@ -6,10 +6,12 @@ use App\DTO\CashTransactionDTO;
 use App\Entity\CashflowCategory;
 use App\Entity\Company;
 use App\Entity\MoneyAccount;
+use App\Entity\ProjectDirection;
 use App\Enum\CashDirection;
 use App\Repository\CashflowCategoryRepository;
 use App\Repository\CounterpartyRepository;
 use App\Repository\MoneyAccountRepository;
+use App\Repository\ProjectDirectionRepository;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
@@ -26,6 +28,7 @@ class CashTransactionType extends AbstractType
         private MoneyAccountRepository $accountRepo,
         private CashflowCategoryRepository $categoryRepo,
         private CounterpartyRepository $counterpartyRepo,
+        private ProjectDirectionRepository $projectDirectionRepo,
     ) {
     }
 
@@ -60,6 +63,13 @@ class CashTransactionType extends AbstractType
                 'choice_attr' => fn (CashflowCategory $c) => $c->getChildren()->count() > 0 ? ['disabled' => 'disabled'] : [],
                 'mapped' => false,
             ])
+            ->add('projectDirection', ChoiceType::class, [
+                'required' => false,
+                'choices' => $company ? $this->projectDirectionRepo->findBy(['company' => $company], ['name' => 'ASC']) : [],
+                'choice_label' => fn (ProjectDirection $projectDirection) => $projectDirection->getName(),
+                'choice_value' => 'id',
+                'mapped' => false,
+            ])
             ->add('counterparty', ChoiceType::class, [
                 'required' => false,
                 'choices' => $company ? $this->counterpartyRepo->findBy(['company' => $company], ['name' => 'ASC']) : [],
@@ -81,8 +91,10 @@ class CashTransactionType extends AbstractType
 
             $cat = $form->get('cashflowCategory')->getData();
             $cp = $form->get('counterparty')->getData();
+            $projectDirection = $form->get('projectDirection')->getData();
             $data->cashflowCategoryId = $cat?->getId();
             $data->counterpartyId = $cp?->getId();
+            $data->projectDirectionId = $projectDirection?->getId();
         }, 1);
     }
 

--- a/site/src/Service/CashTransactionService.php
+++ b/site/src/Service/CashTransactionService.php
@@ -8,6 +8,7 @@ use App\Entity\CashTransaction;
 use App\Entity\Company;
 use App\Entity\Counterparty;
 use App\Entity\MoneyAccount;
+use App\Entity\ProjectDirection;
 use App\Exception\CurrencyMismatchException;
 use App\Repository\CashTransactionRepository;
 use Doctrine\ORM\EntityManagerInterface;
@@ -49,11 +50,15 @@ class CashTransactionService
         $category = $dto->cashflowCategoryId
             ? $this->em->getReference(CashflowCategory::class, $dto->cashflowCategoryId)
             : null;
+        $projectDirection = $dto->projectDirectionId
+            ? $this->em->getReference(ProjectDirection::class, $dto->projectDirectionId)
+            : null;
 
         $tx
             ->setDescription($dto->description)
             ->setCounterparty($counterparty)
-            ->setCashflowCategory($category);
+            ->setCashflowCategory($category)
+            ->setProjectDirection($projectDirection);
 
         if ($dto->externalId) {
             $tx->setExternalId($dto->externalId);
@@ -86,7 +91,10 @@ class CashTransactionService
 
         $counterparty = $dto->counterpartyId ? $this->em->getReference(Counterparty::class, $dto->counterpartyId) : null;
         $category = $dto->cashflowCategoryId ? $this->em->getReference(CashflowCategory::class, $dto->cashflowCategoryId) : null;
-        $tx->setCounterparty($counterparty)->setCashflowCategory($category);
+        $projectDirection = $dto->projectDirectionId ? $this->em->getReference(ProjectDirection::class, $dto->projectDirectionId) : null;
+        $tx->setCounterparty($counterparty)
+            ->setCashflowCategory($category)
+            ->setProjectDirection($projectDirection);
 
         $this->em->flush();
 

--- a/site/templates/transaction/_form.html.twig
+++ b/site/templates/transaction/_form.html.twig
@@ -29,10 +29,17 @@
                 <div class="invalid-feedback d-block">{{ form_errors(form.currency) }}</div>
             </div>
         </div>
-        <div class="mb-3">
-            {{ form_label(form.cashflowCategory, 'Статья ДДС', {'label_attr': {'class': 'form-label'}}) }}
-            {{ form_widget(form.cashflowCategory, {'attr': {'class': 'form-select'}}) }}
-            <div class="invalid-feedback d-block">{{ form_errors(form.cashflowCategory) }}</div>
+        <div class="row g-2">
+            <div class="col-md-6">
+                {{ form_label(form.cashflowCategory, 'Статья ДДС', {'label_attr': {'class': 'form-label'}}) }}
+                {{ form_widget(form.cashflowCategory, {'attr': {'class': 'form-select'}}) }}
+                <div class="invalid-feedback d-block">{{ form_errors(form.cashflowCategory) }}</div>
+            </div>
+            <div class="col-md-6">
+                {{ form_label(form.projectDirection, 'Проект', {'label_attr': {'class': 'form-label'}}) }}
+                {{ form_widget(form.projectDirection, {'attr': {'class': 'form-select'}}) }}
+                <div class="invalid-feedback d-block">{{ form_errors(form.projectDirection) }}</div>
+            </div>
         </div>
         <div class="mb-3">
             {{ form_label(form.counterparty, 'Контрагент', {'label_attr': {'class': 'form-label'}}) }}


### PR DESCRIPTION
## Summary
- allow cash transactions to reference an optional project direction entity
- expose project selection in cash transaction create and edit forms and align project with cashflow category in the UI
- persist the relation through DTO/service updates and database migration

## Testing
- php -l site/src/Entity/CashTransaction.php
- php -l site/src/Service/CashTransactionService.php
- php -l site/src/Controller/Finance/CashTransactionController.php
- php -l site/src/Form/CashTransactionType.php
- php -l site/src/DTO/CashTransactionDTO.php
- php -l site/migrations/Version20250919000000.php

------
https://chatgpt.com/codex/tasks/task_e_68cd3d4d75e48323b6a02542eb9b95c6