### PR TITLE
Add cashflow report JSON endpoint

### DIFF
--- a/site/src/Controller/Finance/ReportCashflowController.php
+++ b/site/src/Controller/Finance/ReportCashflowController.php
@@ -33,6 +33,18 @@ class ReportCashflowController extends AbstractController
         return $this->render('report/cashflow.html.twig', $payload);
     }
 
+    #[Route('/api/public/reports/cashflow.json', name: 'api_report_cashflow_json', methods: ['GET'])]
+    public function apiJson(Request $request): Response
+    {
+        [$rows, $columns, $params] = $this->buildCashflowPayload($request);
+
+        return $this->json([
+            'meta'    => $params,
+            'columns' => $columns,
+            'rows'    => $rows,
+        ]);
+    }
+
     private function buildCashflowPayload(Request $request): array
     {
         $company = $this->activeCompanyService->getActiveCompany();


### PR DESCRIPTION
## Summary
- add a public API route to expose the cashflow report payload as JSON
- reuse the existing payload builder to keep parity with the HTML view

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd5326adec8323a3bd4b06760b7391