### PR TITLE
Add report API key entity and schema

### DIFF
--- a/site/migrations/Version20250920000000.php
+++ b/site/migrations/Version20250920000000.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250920000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create report_api_key table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE report_api_key (id UUID NOT NULL, company_id UUID NOT NULL, key_prefix VARCHAR(16) NOT NULL, key_hash TEXT NOT NULL, scopes VARCHAR(255) DEFAULT \'reports:read\' NOT NULL, is_active BOOLEAN DEFAULT true NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, last_used_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, expires_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX idx_report_api_key_company ON report_api_key (company_id)');
+        $this->addSql('CREATE INDEX idx_report_api_key_key_prefix ON report_api_key (key_prefix)');
+        $this->addSql('CREATE INDEX idx_report_api_key_is_active ON report_api_key (is_active)');
+        $this->addSql('ALTER TABLE report_api_key ADD CONSTRAINT fk_report_api_key_company FOREIGN KEY (company_id) REFERENCES companies (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE report_api_key DROP CONSTRAINT fk_report_api_key_company');
+        $this->addSql('DROP TABLE report_api_key');
+    }
+}

--- a/site/src/Entity/ReportApiKey.php
+++ b/site/src/Entity/ReportApiKey.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\ReportApiKeyRepository;
+use DateTimeImmutable;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
+
+#[ORM\Entity(repositoryClass: ReportApiKeyRepository::class)]
+#[ORM\Table(name: '`report_api_key`')]
+#[ORM\Index(name: 'idx_report_api_key_company', columns: ['company_id'])]
+#[ORM\Index(name: 'idx_report_api_key_key_prefix', columns: ['key_prefix'])]
+#[ORM\Index(name: 'idx_report_api_key_is_active', columns: ['is_active'])]
+class ReportApiKey
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid', unique: true)]
+    private ?string $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Company::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private Company $company;
+
+    #[ORM\Column(length: 16)]
+    private string $keyPrefix;
+
+    #[ORM\Column(type: 'text')]
+    private string $keyHash;
+
+    #[ORM\Column(length: 255)]
+    private string $scopes = 'reports:read';
+
+    #[ORM\Column(type: 'boolean')]
+    private bool $isActive = true;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?DateTimeImmutable $lastUsedAt = null;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?DateTimeImmutable $expiresAt = null;
+
+    public function __construct(Company $company, string $keyPrefix, string $keyHash)
+    {
+        $this->id = Uuid::uuid4()->toString();
+        $this->company = $company;
+        $this->keyPrefix = $keyPrefix;
+        $this->keyHash = $keyHash;
+        $this->createdAt = new DateTimeImmutable();
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getCompany(): Company
+    {
+        return $this->company;
+    }
+
+    public function getKeyPrefix(): string
+    {
+        return $this->keyPrefix;
+    }
+
+    public function getKeyHash(): string
+    {
+        return $this->keyHash;
+    }
+
+    public function getScopes(): string
+    {
+        return $this->scopes;
+    }
+
+    public function setScopes(string $scopes): self
+    {
+        $this->scopes = $scopes;
+
+        return $this;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->isActive;
+    }
+
+    public function deactivate(): void
+    {
+        $this->isActive = false;
+    }
+
+    public function activate(): void
+    {
+        $this->isActive = true;
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getLastUsedAt(): ?DateTimeImmutable
+    {
+        return $this->lastUsedAt;
+    }
+
+    public function markAsUsed(?DateTimeImmutable $usedAt = null): void
+    {
+        $this->lastUsedAt = $usedAt ?? new DateTimeImmutable();
+    }
+
+    public function getExpiresAt(): ?DateTimeImmutable
+    {
+        return $this->expiresAt;
+    }
+
+    public function setExpiresAt(?DateTimeImmutable $expiresAt): void
+    {
+        $this->expiresAt = $expiresAt;
+    }
+}

--- a/site/src/Repository/ReportApiKeyRepository.php
+++ b/site/src/Repository/ReportApiKeyRepository.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Company;
+use App\Entity\ReportApiKey;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<ReportApiKey>
+ */
+class ReportApiKeyRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ReportApiKey::class);
+    }
+
+    /**
+     * @return ReportApiKey[]
+     */
+    public function findActiveByCompanyAndPrefix(Company $company, string $prefix): array
+    {
+        return $this->createQueryBuilder('rak')
+            ->andWhere('rak.company = :company')
+            ->andWhere('rak.keyPrefix = :prefix')
+            ->andWhere('rak.isActive = :active')
+            ->setParameter('company', $company)
+            ->setParameter('prefix', $prefix)
+            ->setParameter('active', true)
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function deactivateAll(Company $company): int
+    {
+        return $this->createQueryBuilder('rak')
+            ->update()
+            ->set('rak.isActive', ':inactive')
+            ->andWhere('rak.company = :company')
+            ->setParameter('inactive', false)
+            ->setParameter('company', $company)
+            ->getQuery()
+            ->execute();
+    }
+}


### PR DESCRIPTION
## Summary
- add ReportApiKey entity with lifecycle helpers and Doctrine mapping
- create repository with helpers for fetching and bulk deactivation
- add migration to create report_api_key table with indexes and cascade delete

## Testing
- composer validate

------
https://chatgpt.com/codex/tasks/task_e_68cd59f974bc83239de372adb9b84f2a