### PR TITLE
Add report API key settings page

### DIFF
--- a/site/src/Controller/Settings/ReportApiKeyController.php
+++ b/site/src/Controller/Settings/ReportApiKeyController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Controller\Settings;
+
+use App\Service\ActiveCompanyService;
+use App\Service\ReportApiKeyManager;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/settings/report-api-key')]
+class ReportApiKeyController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $activeCompany,
+        private readonly ReportApiKeyManager $manager,
+    ) {
+    }
+
+    #[Route('', name: 'settings_report_api_key_index', methods: ['GET'])]
+    public function index(): Response
+    {
+        return $this->render('settings/report_api_key.html.twig');
+    }
+
+    #[Route('/generate', name: 'settings_report_api_key_generate', methods: ['POST'])]
+    public function generate(): Response
+    {
+        $company = $this->activeCompany->getActiveCompany();
+        $raw = $this->manager->createOrRegenerateForCompany($company);
+
+        $this->addFlash('success', 'Ключ создан. Сохраните: ' . $raw);
+
+        return $this->redirectToRoute('settings_report_api_key_index');
+    }
+
+    #[Route('/revoke', name: 'settings_report_api_key_revoke', methods: ['POST'])]
+    public function revoke(): Response
+    {
+        $company = $this->activeCompany->getActiveCompany();
+        $this->manager->revokeAll($company);
+
+        $this->addFlash('success', 'Все ключи отозваны.');
+
+        return $this->redirectToRoute('settings_report_api_key_index');
+    }
+}

--- a/site/templates/partials/_sidebar.html.twig
+++ b/site/templates/partials/_sidebar.html.twig
@@ -95,6 +95,7 @@
                     </a>
                     <div class="dropdown-menu" data-bs-popper="static">
                         <a class="dropdown-item" href="{{ path('company_index') }}"> Профиль компании </a>
+                        <a class="dropdown-item {{ current_route starts with 'settings_report_api_key_' ? 'active' : '' }}" href="{{ path('settings_report_api_key_index') }}">API-ключ отчётов</a>
                     </div>
                 </li>
 

--- a/site/templates/settings/report_api_key.html.twig
+++ b/site/templates/settings/report_api_key.html.twig
@@ -1,0 +1,38 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}API-ключ отчётов{% endblock %}
+
+{% block body %}
+    <div class="page-header d-print-none">
+        <div class="container-xl">
+            <div class="row g-2 align-items-center">
+                <div class="col">
+                    <h2 class="page-title">API-ключ отчётов</h2>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="container-xl mt-3">
+        <div class="card">
+            <div class="card-body">
+                <div class="d-flex flex-wrap gap-2">
+                    <form method="post" action="{{ path('settings_report_api_key_generate') }}" class="d-inline">
+                        <input type="hidden" name="_token" value="{{ csrf_token('settings_report_api_key_generate') }}">
+                        <button type="submit" class="btn btn-primary">Создать / Пересоздать</button>
+                    </form>
+                    <form method="post" action="{{ path('settings_report_api_key_revoke') }}" class="d-inline">
+                        <input type="hidden" name="_token" value="{{ csrf_token('settings_report_api_key_revoke') }}">
+                        <button type="submit" class="btn btn-outline-danger">Отозвать все</button>
+                    </form>
+                </div>
+
+                <div class="mt-4">
+                    <h3 class="h5">Использование в Google Sheets</h3>
+                    <p class="text-muted mb-2">Пример формулы для импорта отчёта по движению денежных средств:</p>
+                    <pre class="bg-light p-3 rounded"><code>{{ '=IMPORTDATA("' ~ app.request.schemeAndHttpHost ~ '/api/public/reports/cashflow.csv?token=ВАШ_КЛЮЧ&from=2025-09-01&to=2025-09-30")' }}</code></pre>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a settings controller to manage report API keys and trigger generation or revocation
- create a settings template with action buttons and Google Sheets usage guidance for the report API key
- expose the new report API key settings page inside the settings dropdown menu

## Testing
- php -l src/Controller/Settings/ReportApiKeyController.php
- php bin/console lint:twig templates/settings/report_api_key.html.twig *(fails: missing Symfony Runtime; composer install requires a GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68cd5dde30b08323bba82b743eaebbdf