### PR TITLE
Add public cashflow report API endpoints

### DIFF
--- a/site/src/Controller/Finance/ReportCashflowController.php
+++ b/site/src/Controller/Finance/ReportCashflowController.php
@@ -3,11 +3,16 @@
 namespace App\Controller\Finance;
 
 use App\Report\Cashflow\CashflowReportBuilder;
+use App\Report\Cashflow\CashflowReportParams;
 use App\Report\Cashflow\CashflowReportRequestMapper;
+use App\Repository\CompanyRepository;
 use App\Service\ActiveCompanyService;
+use App\Service\ReportApiKeyManager;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/finance/reports/cashflow')]
@@ -15,8 +20,10 @@ class ReportCashflowController extends AbstractController
 {
     public function __construct(
         private ActiveCompanyService $activeCompanyService,
-        private CashflowReportBuilder $builder,
+        private ReportApiKeyManager $keys,
+        private CompanyRepository $companyRepo,
         private CashflowReportRequestMapper $mapper,
+        private CashflowReportBuilder $builder,
     ) {
     }
 
@@ -24,9 +31,98 @@ class ReportCashflowController extends AbstractController
     public function index(Request $request): Response
     {
         $company = $this->activeCompanyService->getActiveCompany();
+        /** @var CashflowReportParams $params */
         $params = $this->mapper->fromRequest($request, $company);
         $payload = $this->builder->build($params);
 
         return $this->render('finance/report/cashflow.html.twig', $payload);
+    }
+
+    #[Route('/api/public/reports/cashflow.json', name: 'api_report_cashflow_json', methods: ['GET'])]
+    public function apiJson(Request $r): Response
+    {
+        $token = (string) $r->query->get('token', '');
+        if ($token === '') {
+            return new JsonResponse(['error' => 'token_required'], 401);
+        }
+
+        $company = $this->keys->findCompanyByRawKey($token, $this->companyRepo);
+        if (!$company) {
+            return new JsonResponse(['error' => 'unauthorized'], 401);
+        }
+
+        /** @var CashflowReportParams $params */
+        $params = $this->mapper->fromRequest($r, $company);
+        $payload = $this->builder->build($params);
+
+        return $this->json([
+            'company' => $payload['company']->getId(),
+            'group' => $payload['group'],
+            'date_from' => $payload['date_from']->format('Y-m-d'),
+            'date_to' => $payload['date_to']->format('Y-m-d'),
+            'periods' => array_map(
+                fn ($p) => [
+                    'start' => $p['start']->format('Y-m-d'),
+                    'end' => $p['end']->format('Y-m-d'),
+                    'label' => $p['label'],
+                ],
+                $payload['periods']
+            ),
+            'categories' => array_map(
+                fn ($c) => ['id' => $c->getId(), 'name' => $c->getName()],
+                $payload['categories']
+            ),
+            'categoryTotals' => $payload['categoryTotals'],
+            'openings' => $payload['openings'],
+            'closings' => $payload['closings'],
+        ]);
+    }
+
+    #[Route('/api/public/reports/cashflow.csv', name: 'api_report_cashflow_csv', methods: ['GET'])]
+    public function apiCsv(Request $r): Response
+    {
+        $token = (string) $r->query->get('token', '');
+        if ($token === '') {
+            return new JsonResponse(['error' => 'token_required'], 401);
+        }
+
+        $company = $this->keys->findCompanyByRawKey($token, $this->companyRepo);
+        if (!$company) {
+            return new JsonResponse(['error' => 'unauthorized'], 401);
+        }
+
+        /** @var CashflowReportParams $params */
+        $params = $this->mapper->fromRequest($r, $company);
+        $payload = $this->builder->build($params);
+
+        $periods = $payload['periods'];
+        $categoryTotals = $payload['categoryTotals'];
+        $openings = $payload['openings'];
+        $closings = $payload['closings'];
+
+        $resp = new StreamedResponse(function () use ($periods, $categoryTotals, $openings, $closings) {
+            $out = \fopen('php://output', 'w');
+            \fputcsv($out, ['Период', 'КатегорияID', 'Валюта', 'Сальдо нач.', 'Нетто', 'Сальдо кон.']);
+            foreach ($periods as $i => $p) {
+                $label = $p['label'];
+                foreach ($categoryTotals as $catId => $catRow) {
+                    if (!isset($catRow['totals'])) {
+                        continue;
+                    }
+
+                    foreach ($catRow['totals'] as $currency => $vals) {
+                        $opening = $openings[$currency][$i] ?? 0.0;
+                        $net = $vals[$i] ?? 0.0;
+                        $closing = $closings[$currency][$i] ?? 0.0;
+                        \fputcsv($out, [$label, $catId, $currency, $opening, $net, $closing]);
+                    }
+                }
+            }
+            \fclose($out);
+        });
+        $resp->headers->set('Content-Type', 'text/csv; charset=UTF-8');
+        $resp->headers->set('Cache-Control', 'max-age=60');
+
+        return $resp;
     }
 }

--- a/site/src/Repository/ReportApiKeyRepository.php
+++ b/site/src/Repository/ReportApiKeyRepository.php
@@ -33,6 +33,20 @@ class ReportApiKeyRepository extends ServiceEntityRepository
             ->getResult();
     }
 
+    /**
+     * @return ReportApiKey[]
+     */
+    public function findActiveByPrefix(string $prefix): array
+    {
+        return $this->createQueryBuilder('rak')
+            ->andWhere('rak.keyPrefix = :prefix')
+            ->andWhere('rak.isActive = :active')
+            ->setParameter('prefix', $prefix)
+            ->setParameter('active', true)
+            ->getQuery()
+            ->getResult();
+    }
+
     public function deactivateAll(Company $company): int
     {
         return $this->createQueryBuilder('rak')

--- a/site/src/Service/ReportApiKeyManager.php
+++ b/site/src/Service/ReportApiKeyManager.php
@@ -4,6 +4,7 @@ namespace App\Service;
 
 use App\Entity\Company;
 use App\Entity\ReportApiKey;
+use App\Repository\CompanyRepository;
 use App\Repository\ReportApiKeyRepository;
 use Doctrine\ORM\EntityManagerInterface;
 
@@ -60,5 +61,35 @@ class ReportApiKeyManager
         }
 
         return false;
+    }
+
+    public function findCompanyByRawKey(string $raw, CompanyRepository $repo): ?Company
+    {
+        if (!\str_starts_with($raw, 'rk_')) {
+            return null;
+        }
+
+        $prefix = \substr($raw, 0, 8);
+        $candidates = $this->reportApiKeyRepository->findActiveByPrefix($prefix);
+
+        foreach ($candidates as $candidate) {
+            if (!\password_verify($raw, $candidate->getKeyHash())) {
+                continue;
+            }
+
+            $companyId = $candidate->getCompany()->getId();
+            $candidate->markAsUsed();
+            $this->entityManager->flush();
+
+            if ($companyId === null) {
+                return null;
+            }
+
+            $company = $repo->find($companyId);
+
+            return $company ?? $candidate->getCompany();
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## Summary
- add unauthenticated JSON and CSV cashflow report endpoints that authenticate via report API tokens
- reuse the existing request mapper and builder to generate payloads for the new API responses
- support resolving companies from raw report keys by prefix lookup in the API key repository

## Testing
- composer run cs:check *(fails: php-cs-fixer not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6add3a1c832398336274fd7a3dbe