### PR TITLE
Add token-based cashflow report API access

### DIFF
--- a/site/src/Controller/Finance/ReportCashflowController.php
+++ b/site/src/Controller/Finance/ReportCashflowController.php
@@ -5,7 +5,6 @@ namespace App\Controller\Finance;
 use App\Report\Cashflow\CashflowReportBuilder;
 use App\Report\Cashflow\CashflowReportParams;
 use App\Report\Cashflow\CashflowReportRequestMapper;
-use App\Repository\CompanyRepository;
 use App\Service\ActiveCompanyService;
 use App\Service\ReportApiKeyManager;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -16,19 +15,17 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 
-#[Route('/finance/reports/cashflow')]
 class ReportCashflowController extends AbstractController
 {
     public function __construct(
         private ActiveCompanyService $activeCompanyService,
         private ReportApiKeyManager $keys,
-        private CompanyRepository $companyRepo,
         private CashflowReportRequestMapper $mapper,
         private CashflowReportBuilder $builder,
     ) {
     }
 
-    #[Route('', name: 'report_cashflow_index', methods: ['GET'])]
+    #[Route('/finance/reports/cashflow', name: 'report_cashflow_index', methods: ['GET'])]
     public function index(Request $request): Response
     {
         $company = $this->activeCompanyService->getActiveCompany();
@@ -52,7 +49,7 @@ class ReportCashflowController extends AbstractController
             return new JsonResponse(['error' => 'token_required'], 401);
         }
 
-        $company = $this->keys->findCompanyByRawKey($token, $this->companyRepo);
+        $company = $this->keys->findCompanyByRawKey($token);
         if (!$company) {
             return new JsonResponse(['error' => 'unauthorized'], 401);
         }
@@ -97,7 +94,7 @@ class ReportCashflowController extends AbstractController
             return new JsonResponse(['error' => 'token_required'], 401);
         }
 
-        $company = $this->keys->findCompanyByRawKey($token, $this->companyRepo);
+        $company = $this->keys->findCompanyByRawKey($token);
         if (!$company) {
             return new JsonResponse(['error' => 'unauthorized'], 401);
         }

--- a/site/src/Entity/ReportApiKey.php
+++ b/site/src/Entity/ReportApiKey.php
@@ -12,6 +12,7 @@ use Ramsey\Uuid\Uuid;
 #[ORM\Index(name: 'idx_report_api_key_company', columns: ['company_id'])]
 #[ORM\Index(name: 'idx_report_api_key_key_prefix', columns: ['key_prefix'])]
 #[ORM\Index(name: 'idx_report_api_key_is_active', columns: ['is_active'])]
+#[ORM\Index(name: 'idx_report_api_key_prefix_active', columns: ['key_prefix', 'is_active'])]
 class ReportApiKey
 {
     #[ORM\Id]

--- a/site/src/Repository/ReportApiKeyRepository.php
+++ b/site/src/Repository/ReportApiKeyRepository.php
@@ -34,15 +34,16 @@ class ReportApiKeyRepository extends ServiceEntityRepository
     }
 
     /**
+     * Возвращает активные ключи по префиксу (напр., 'rk_live_').
+     *
      * @return ReportApiKey[]
      */
     public function findActiveByPrefix(string $prefix): array
     {
-        return $this->createQueryBuilder('rak')
-            ->andWhere('rak.keyPrefix = :prefix')
-            ->andWhere('rak.isActive = :active')
-            ->setParameter('prefix', $prefix)
-            ->setParameter('active', true)
+        return $this->createQueryBuilder('k')
+            ->andWhere('k.isActive = true')
+            ->andWhere('k.keyPrefix = :p')
+            ->setParameter('p', $prefix)
             ->getQuery()
             ->getResult();
     }

--- a/site/templates/settings/report_api_key.html.twig
+++ b/site/templates/settings/report_api_key.html.twig
@@ -27,11 +27,12 @@
                     </form>
                 </div>
 
-                <div class="mt-4">
-                    <h3 class="h5">Использование в Google Sheets</h3>
-                    <p class="text-muted mb-2">Пример формулы для импорта отчёта по движению денежных средств:</p>
-                    <pre class="bg-light p-3 rounded"><code>{{ '=IMPORTDATA("' ~ app.request.schemeAndHttpHost ~ '/api/public/reports/cashflow.csv?token=ВАШ_КЛЮЧ&from=2025-09-01&to=2025-09-30")' }}</code></pre>
-                </div>
+                <h2 class="h5 mt-4">Как подключить Google Sheets</h2>
+                <p>Ключ передаётся через query-параметр <code>token</code> (IMPORTDATA не шлёт заголовки):</p>
+                <pre>=IMPORTDATA("{{ app.request.schemeAndHttpHost }}/api/public/reports/cashflow.csv?token=ВАШ_КЛЮЧ&from=2025-09-01&to=2025-09-30")</pre>
+                <p>JSON для Apps Script:</p>
+                <pre>{{ app.request.schemeAndHttpHost }}/api/public/reports/cashflow.json?token=ВАШ_КЛЮЧ&from=2025-09-01&to=2025-09-30</pre>
+                <p class="text-muted">Сохраните ключ — он показывается один раз при генерации.</p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- ensure report API keys can be queried by prefix with the expected composite index
- add a raw token company lookup that verifies expiration before marking usage
- expose token-protected public cashflow JSON/CSV endpoints and document query usage in settings

## Testing
- composer run cs:check *(fails: php-cs-fixer binary missing prior to installing vendor packages)*
- composer install *(fails: GitHub authentication required to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68cd7d454958832396c77f02194430c0