### PR TITLE
Move public cashflow report API to dedicated controller

### DIFF
--- a/site/src/Controller/Api/PublicCashflowReportController.php
+++ b/site/src/Controller/Api/PublicCashflowReportController.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Controller\Api;
+
+use App\Report\Cashflow\CashflowReportBuilder;
+use App\Report\Cashflow\CashflowReportRequestMapper;
+use App\Service\ReportApiKeyManager;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class PublicCashflowReportController extends AbstractController
+{
+    public function __construct(
+        private ReportApiKeyManager $keys,
+        private CashflowReportRequestMapper $mapper,
+        private CashflowReportBuilder $builder,
+    ) {}
+
+    #[Route('/api/public/reports/cashflow.json', name: 'api_report_cashflow_json', methods: ['GET'])]
+    public function json(Request $r, #[Autowire(service: 'limiter.reports_api')] RateLimiterFactory $reportsApiLimiter): Response
+    {
+        $token = (string) $r->query->get('token', '');
+        $limiter = $reportsApiLimiter->create($token ?: ($r->getClientIp() ?? 'anon'));
+        if (!$limiter->consume(1)->isAccepted()) {
+            return new JsonResponse(['error' => 'rate_limited'], 429);
+        }
+        if ($token === '') {
+            return new JsonResponse(['error' => 'token_required'], 401);
+        }
+
+        $company = $this->keys->findCompanyByRawKey($token);
+        if (!$company) {
+            return new JsonResponse(['error' => 'unauthorized'], 401);
+        }
+
+        $params  = $this->mapper->fromRequest($r, $company);
+        $payload = $this->builder->build($params);
+
+        return $this->json([
+            'company'        => $payload['company']->getId(),
+            'group'          => $payload['group'],
+            'date_from'      => $payload['date_from']->format('Y-m-d'),
+            'date_to'        => $payload['date_to']->format('Y-m-d'),
+            'periods'        => array_map(fn($p) => [
+                                    'start' => $p['start']->format('Y-m-d'),
+                                    'end'   => $p['end']->format('Y-m-d'),
+                                    'label' => $p['label'],
+                                ], $payload['periods']),
+            'categories'     => array_map(fn($c) => ['id' => $c->getId(), 'name' => $c->getName()], $payload['categories']),
+            'categoryTotals' => $payload['categoryTotals'],
+            'openings'       => $payload['openings'],
+            'closings'       => $payload['closings'],
+        ]);
+    }
+
+    #[Route('/api/public/reports/cashflow.csv', name: 'api_report_cashflow_csv', methods: ['GET'])]
+    public function csv(Request $r, #[Autowire(service: 'limiter.reports_api')] RateLimiterFactory $reportsApiLimiter): Response
+    {
+        $token = (string) $r->query->get('token', '');
+        $limiter = $reportsApiLimiter->create($token ?: ($r->getClientIp() ?? 'anon'));
+        if (!$limiter->consume(1)->isAccepted()) {
+            return new JsonResponse(['error' => 'rate_limited'], 429);
+        }
+        if ($token === '') {
+            return new JsonResponse(['error' => 'token_required'], 401);
+        }
+
+        $company = $this->keys->findCompanyByRawKey($token);
+        if (!$company) {
+            return new JsonResponse(['error' => 'unauthorized'], 401);
+        }
+
+        $params  = $this->mapper->fromRequest($r, $company);
+        $payload = $this->builder->build($params);
+
+        $periods        = $payload['periods'];
+        $categoryTotals = $payload['categoryTotals'];
+        $openings       = $payload['openings'];
+        $closings       = $payload['closings'];
+
+        $resp = new StreamedResponse(function () use ($periods, $categoryTotals, $openings, $closings) {
+            $out = fopen('php://output', 'w');
+            fputcsv($out, ['Период', 'КатегорияID', 'Валюта', 'Сальдо нач.', 'Нетто', 'Сальдо кон.']);
+            foreach ($periods as $i => $p) {
+                $label = $p['label'];
+                foreach ($categoryTotals as $catId => $catRow) {
+                    if (!isset($catRow['totals'])) {
+                        continue;
+                    }
+                    foreach ($catRow['totals'] as $currency => $vals) {
+                        $opening = $openings[$currency][$i] ?? 0.0;
+                        $net     = $vals[$i] ?? 0.0;
+                        $closing = $closings[$currency][$i] ?? 0.0;
+                        fputcsv($out, [$label, $catId, $currency, $opening, $net, $closing]);
+                    }
+                }
+            }
+            fclose($out);
+        });
+        $resp->headers->set('Content-Type', 'text/csv; charset=UTF-8');
+        $resp->headers->set('Cache-Control', 'max-age=60');
+
+        return $resp;
+    }
+}

--- a/site/src/Controller/Finance/ReportCashflowController.php
+++ b/site/src/Controller/Finance/ReportCashflowController.php
@@ -6,19 +6,15 @@ use App\Report\Cashflow\CashflowReportBuilder;
 use App\Report\Cashflow\CashflowReportParams;
 use App\Report\Cashflow\CashflowReportRequestMapper;
 use App\Service\ActiveCompanyService;
-use App\Service\ReportApiKeyManager;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Routing\Attribute\Route;
 
 class ReportCashflowController extends AbstractController
 {
     public function __construct(
         private ActiveCompanyService $activeCompanyService,
-        private ReportApiKeyManager $keys,
         private CashflowReportRequestMapper $mapper,
         private CashflowReportBuilder $builder,
     ) {
@@ -35,86 +31,4 @@ class ReportCashflowController extends AbstractController
         return $this->render('finance/report/cashflow.html.twig', $payload);
     }
 
-    #[Route('/api/public/reports/cashflow.json', name: 'api_report_cashflow_json', methods: ['GET'])]
-    public function apiJson(Request $r): Response
-    {
-        $token = (string) $r->query->get('token', '');
-        if ($token === '') {
-            return new JsonResponse(['error' => 'token_required'], 401);
-        }
-
-        $company = $this->keys->findCompanyByRawKey($token);
-        if (!$company) {
-            return new JsonResponse(['error' => 'unauthorized'], 401);
-        }
-
-        $params = $this->mapper->fromRequest($r, $company);
-        $payload = $this->builder->build($params);
-
-        return $this->json([
-            'company'        => $payload['company']->getId(),
-            'group'          => $payload['group'],
-            'date_from'      => $payload['date_from']->format('Y-m-d'),
-            'date_to'        => $payload['date_to']->format('Y-m-d'),
-            'periods'        => array_map(fn($p) => [
-                'start' => $p['start']->format('Y-m-d'),
-                'end'   => $p['end']->format('Y-m-d'),
-                'label' => $p['label'],
-            ], $payload['periods']),
-            'categories'     => array_map(fn($c) => [
-                'id'   => $c->getId(),
-                'name' => $c->getName(),
-            ], $payload['categories']),
-            'categoryTotals' => $payload['categoryTotals'],
-            'openings'       => $payload['openings'],
-            'closings'       => $payload['closings'],
-        ]);
-    }
-
-    #[Route('/api/public/reports/cashflow.csv', name: 'api_report_cashflow_csv', methods: ['GET'])]
-    public function apiCsv(Request $r): Response
-    {
-        $token = (string) $r->query->get('token', '');
-        if ($token === '') {
-            return new JsonResponse(['error' => 'token_required'], 401);
-        }
-
-        $company = $this->keys->findCompanyByRawKey($token);
-        if (!$company) {
-            return new JsonResponse(['error' => 'unauthorized'], 401);
-        }
-
-        $params = $this->mapper->fromRequest($r, $company);
-        $payload = $this->builder->build($params);
-
-        $periods        = $payload['periods'];
-        $categoryTotals = $payload['categoryTotals'];
-        $openings       = $payload['openings'];
-        $closings       = $payload['closings'];
-
-        $resp = new StreamedResponse(function () use ($periods, $categoryTotals, $openings, $closings) {
-            $out = \fopen('php://output', 'w');
-            \fputcsv($out, ['Период', 'КатегорияID', 'Валюта', 'Сальдо нач.', 'Нетто', 'Сальдо кон.']);
-            foreach ($periods as $i => $p) {
-                $label = $p['label'];
-                foreach ($categoryTotals as $catId => $catRow) {
-                    if (!isset($catRow['totals'])) {
-                        continue;
-                    }
-
-                    foreach ($catRow['totals'] as $currency => $vals) {
-                        $opening = $openings[$currency][$i] ?? 0.0;
-                        $net     = $vals[$i] ?? 0.0;
-                        $closing = $closings[$currency][$i] ?? 0.0;
-                        \fputcsv($out, [$label, $catId, $currency, $opening, $net, $closing]);
-                    }
-                }
-            }
-            \fclose($out);
-        });
-
-        $resp->headers->set('Content-Type', 'text/csv; charset=UTF-8');
-        $resp->headers->set('Cache-Control', 'max-age=60');
-        return $resp;
-    }
 }


### PR DESCRIPTION
## Summary
- add a dedicated API controller that serves the public cashflow JSON and CSV endpoints with rate limiting
- remove the API methods from the finance controller so its route prefix no longer hides the public endpoints

## Testing
- `php bin/console cache:clear` *(fails: Composer dependencies missing in the environment)*
- `php bin/console cache:warmup` *(fails: Symfony runtime missing because Composer install cannot run in the environment)*
- `php bin/console debug:router` *(fails: Symfony runtime missing because Composer install cannot run in the environment)*
- `curl -I https://app.2bstock.ru/api/public/reports/cashflow.json?...` *(fails: proxy returns HTTP 403 so the request cannot be completed from the container)*
- `curl -I https://app.2bstock.ru/api/public/reports/cashflow.csv?...` *(fails: proxy returns HTTP 403 so the request cannot be completed from the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd851626c08323b012bc886ac6ac18