### PR TITLE
Handle missing rate limiter component gracefully

### DIFF
--- a/site/config/packages/rate_limiter.php
+++ b/site/config/packages/rate_limiter.php
@@ -1,0 +1,19 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $container): void {
+    if (!class_exists('Symfony\\Component\\RateLimiter\\RateLimiterFactory')) {
+        return;
+    }
+
+    $container->extension('framework', [
+        'rate_limiter' => [
+            'reports_api' => [
+                'policy' => 'fixed_window',
+                'limit' => 60,
+                'interval' => '1 minute',
+            ],
+        ],
+    ]);
+};

--- a/site/config/packages/rate_limiter.yaml
+++ b/site/config/packages/rate_limiter.yaml
@@ -1,6 +1,0 @@
-framework:
-  rate_limiter:
-    reports_api:
-      policy: 'fixed_window'
-      limit: 60
-      interval: '1 minute'


### PR DESCRIPTION
## Summary
- replace the rate limiter YAML configuration with a PHP configurator that only registers settings when the RateLimiter component is available

## Testing
- ⚠️ `php bin/console lint:container` (fails: missing Composer dependencies in the container)


------
https://chatgpt.com/codex/tasks/task_e_68cd873177748323891d9d8fd26966f7