### PR TITLE
Fix public cashflow JSON action signature

### DIFF
--- a/site/src/Controller/Api/PublicCashflowReportController.php
+++ b/site/src/Controller/Api/PublicCashflowReportController.php
@@ -23,7 +23,7 @@ final class PublicCashflowReportController extends AbstractController
     ) {}
 
     #[Route('/api/public/reports/cashflow.json', name: 'api_report_cashflow_json', methods: ['GET'])]
-    public function json(Request $r, #[Autowire(service: 'limiter.reports_api')] RateLimiterFactory $reportsApiLimiter): Response
+    public function jsonReport(Request $r, #[Autowire(service: 'limiter.reports_api')] RateLimiterFactory $reportsApiLimiter): JsonResponse
     {
         $token = (string) $r->query->get('token', '');
         $limiter = $reportsApiLimiter->create($token ?: ($r->getClientIp() ?? 'anon'));


### PR DESCRIPTION
## Summary
- rename the public cashflow JSON action so it no longer overrides AbstractController::json
- keep the action returning a JsonResponse via the framework helper

## Testing
- php bin/phpunit *(fails: Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`)*

------
https://chatgpt.com/codex/tasks/task_e_68cd88c53210832397c80cc72b595884