### PR TITLE
Gracefully handle missing reports API rate limiter

### DIFF
--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -29,3 +29,7 @@ services:
         arguments:
             - '@session.redis'
             - { prefix: 'sess_', ttl: 1209600 } # 14 дней
+
+    App\Service\RateLimiter\ReportsApiRateLimiter:
+        arguments:
+            $factory: '@?limiter.reports_api'

--- a/site/src/Service/RateLimiter/ReportsApiRateLimiter.php
+++ b/site/src/Service/RateLimiter/ReportsApiRateLimiter.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Service\RateLimiter;
+
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+
+final class ReportsApiRateLimiter
+{
+    public function __construct(private readonly ?object $factory = null)
+    {
+    }
+
+    public function consume(string $identifier, int $tokens = 1): bool
+    {
+        if ($this->factory !== null && is_a($this->factory, RateLimiterFactory::class, false)) {
+            return $this->factory->create($identifier)->consume($tokens)->isAccepted();
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- add a ReportsApiRateLimiter service that wraps the framework limiter and allows graceful fallback when the service is absent
- switch the public cashflow report controller to use the new service instead of directly autowiring limiter.reports_api
- register the wrapper service in the container so it receives the limiter when available

## Testing
- php -l src/Service/RateLimiter/ReportsApiRateLimiter.php
- php -l src/Controller/Api/PublicCashflowReportController.php
- composer install *(fails: GitHub token required to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8d2b1b64832380439a4044939cd9