### PR TITLE
Fix circular reference in public cashflow JSON response

### DIFF
--- a/site/src/Controller/Api/PublicCashflowReportController.php
+++ b/site/src/Controller/Api/PublicCashflowReportController.php
@@ -53,7 +53,12 @@ final class PublicCashflowReportController extends AbstractController
                                     'label' => $p['label'],
                                 ], $payload['periods']),
             'categories'     => array_map(fn($c) => ['id' => $c->getId(), 'name' => $c->getName()], $payload['categories']),
-            'categoryTotals' => $payload['categoryTotals'],
+            'categoryTotals' => array_map(
+                                    static fn(array $row): array => [
+                                        'totals' => $row['totals'],
+                                    ],
+                                    $payload['categoryTotals']
+                                ),
             'openings'       => $payload['openings'],
             'closings'       => $payload['closings'],
         ]);


### PR DESCRIPTION
## Summary
- strip entity references from the public cashflow JSON response so the payload contains only scalar data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd90ecd7dc8323a893606162ff0229