### PR TITLE
Add category tree to cashflow API payload

### DIFF
--- a/site/src/Controller/Api/PublicCashflowReportController.php
+++ b/site/src/Controller/Api/PublicCashflowReportController.php
@@ -61,6 +61,7 @@ final class PublicCashflowReportController extends AbstractController
                                 ),
             'openings'       => $payload['openings'],
             'closings'       => $payload['closings'],
+            'categoryTree'   => $payload['categoryTree'],
         ]);
     }
 


### PR DESCRIPTION
## Summary
- build a flat category tree from the existing cashflow category hierarchy and append it to the report payload
- expose the new categoryTree field in the public cashflow JSON response

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cda530b1c08323a487adec66afe3e5