### PR TITLE
Expose cashflow category totals tree via API

### DIFF
--- a/site/src/Controller/Api/PublicCashflowReportController.php
+++ b/site/src/Controller/Api/PublicCashflowReportController.php
@@ -61,6 +61,7 @@ final class PublicCashflowReportController extends AbstractController
                                 ),
             'openings'       => $payload['openings'],
             'closings'       => $payload['closings'],
+            'tree'           => $payload['tree'],
             'categoryTree'   => $payload['categoryTree'],
         ]);
     }


### PR DESCRIPTION
## Summary
- build a hierarchical tree of cashflow categories with aggregated totals
- return the new tree structure in the cashflow report payload
- expose the tree data from the public cashflow report JSON endpoint

## Testing
- php -l site/src/Report/Cashflow/CashflowReportBuilder.php
- php -l site/src/Controller/Api/PublicCashflowReportController.php

------
https://chatgpt.com/codex/tasks/task_e_68ce5f8cbd6483238f1bbf19366d606e