### PR TITLE
Remove cash transaction clear action

### DIFF
--- a/site/src/Controller/Finance/CashTransactionController.php
+++ b/site/src/Controller/Finance/CashTransactionController.php
@@ -136,15 +136,6 @@ class CashTransactionController extends AbstractController
         ]);
     }
 
-    #[Route('/clear', name: 'cash_transaction_clear', methods: ['POST'])]
-    public function clear(CashTransactionService $service): Response
-    {
-        $service->clearAll();
-        $this->addFlash('success', 'Журнал очищен');
-
-        return $this->redirectToRoute('cash_transaction_index');
-    }
-
     /**
      * @throws ORMException
      */

--- a/site/src/Service/CashTransactionService.php
+++ b/site/src/Service/CashTransactionService.php
@@ -119,24 +119,4 @@ class CashTransactionService
         $this->balanceService->recalculateDailyRange($company, $account, $from, $to);
     }
 
-    /**
-     * Temporary method used during debugging to wipe all transactions and
-     * rebuild account balances from scratch.
-     */
-    public function clearAll(): void
-    {
-        // remove all transactions and existing daily balance snapshots
-        $this->em->createQuery('DELETE FROM App\\Entity\\CashTransaction t')->execute();
-        $this->em->createQuery('DELETE FROM App\\Entity\\MoneyAccountDailyBalance b')->execute();
-
-        // recalculate balances for every account to ensure snapshots are
-        // recreated with opening values
-        $accounts = $this->em->getRepository(MoneyAccount::class)->findAll();
-        $today = new \DateTimeImmutable('today');
-        foreach ($accounts as $account) {
-            /** @var MoneyAccount $account */
-            $company = $account->getCompany();
-            $this->balanceService->recalculateDailyRange($company, $account, $today, $today);
-        }
-    }
 }

--- a/site/templates/transaction/index.html.twig
+++ b/site/templates/transaction/index.html.twig
@@ -18,9 +18,6 @@
         <a href="{{ path('cash_transaction_new') }}" class="btn btn-primary">Добавить</a>
         <a href="{{ path('bank1c_import_form') }}" class="btn btn-outline-secondary">Импорт 1C</a>
         <a href="#" class="btn btn-outline-secondary">Экспорт</a>
-        <form method="post" action="{{ path('cash_transaction_clear') }}" class="d-inline">
-            <button type="submit" class="btn btn-outline-danger">Очистить</button>
-        </form>
     </div>
 </div>
 

--- a/site/tests/Service/CashTransactionServiceTest.php
+++ b/site/tests/Service/CashTransactionServiceTest.php
@@ -156,40 +156,4 @@ class CashTransactionServiceTest extends TestCase
         $this->assertSame($counterparty->getId(), $tx->getCounterparty()->getId());
     }
 
-    public function testClearAllRemovesTransactionsAndRebuildsBalances(): void
-    {
-        $user = new User(Uuid::uuid4()->toString());
-        $user->setEmail('t@example.com');
-        $user->setPassword('pass');
-        $company = new Company(Uuid::uuid4()->toString(), $user);
-        $company->setName('Test');
-        $account = new MoneyAccount(Uuid::uuid4()->toString(), $company, MoneyAccountType::BANK, 'Main', 'USD');
-        $account->setOpeningBalance('100');
-        $account->setOpeningBalanceDate(new \DateTimeImmutable('2024-01-01'));
-
-        $this->em->persist($user);
-        $this->em->persist($company);
-        $this->em->persist($account);
-        $this->em->flush();
-
-        $dto = new CashTransactionDTO();
-        $dto->companyId = $company->getId();
-        $dto->moneyAccountId = $account->getId();
-        $dto->direction = CashDirection::INFLOW;
-        $dto->amount = '50';
-        $dto->currency = 'USD';
-        $dto->occurredAt = new \DateTimeImmutable('2024-01-02');
-        $this->txService->add($dto);
-
-        $this->txService->clearAll();
-
-        $this->assertCount(0, $this->em->getRepository(CashTransaction::class)->findAll());
-        $balances = $this->em->getRepository(MoneyAccountDailyBalance::class)->findAll();
-        $this->assertCount(1, $balances);
-        $balance = $balances[0];
-        $this->assertSame('100', $balance->getOpeningBalance());
-        $this->assertSame('0', $balance->getInflow());
-        $this->assertSame('0', $balance->getOutflow());
-        $this->assertSame('100.00', $balance->getClosingBalance());
-    }
 }


### PR DESCRIPTION
## Summary
- remove the clear button from the cash transaction index view
- drop the controller action that previously cleared all cash transactions
- remove the `clearAll` helper from `CashTransactionService`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce9c4dd368832390bd51d801194f77