### PR TITLE
Add sync stats feedback for Ozon orders

### DIFF
--- a/site/templates/ozon/orders/index.html.twig
+++ b/site/templates/ozon/orders/index.html.twig
@@ -1,6 +1,16 @@
 {% extends 'base.html.twig' %}
 
 {% block body %}
+{% for message in app.flashes('success') %}
+  <div class="alert alert-success" role="alert">
+    {{ message }}
+  </div>
+{% endfor %}
+{% for message in app.flashes('error') %}
+  <div class="alert alert-danger" role="alert">
+    {{ message }}
+  </div>
+{% endfor %}
 <h1>Ozon Orders</h1>
 <a href="{{ path('ozon_orders_sync') }}" class="btn btn-primary mb-2">Обновить</a>
 <a href="{{ path('ozon_orders_api') }}" class="btn btn-secondary mb-2" target="_blank">Вывести на экран</a>


### PR DESCRIPTION
## Summary
- aggregate FBS and FBO sync results, expose them in flash feedback, and log run details
- render success and error flash messages on the Ozon orders list page

## Testing
- php bin/console lint:twig templates/ozon/orders/index.html.twig *(fails: missing Composer dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cfca8c15ec8323ac97df5d47a0ea9e