### PR TITLE
Add preview step for 1C bank statement import

### DIFF
--- a/site/src/Controller/Finance/Bank1CImportController.php
+++ b/site/src/Controller/Finance/Bank1CImportController.php
@@ -5,44 +5,50 @@ namespace App\Controller\Finance;
 use App\Repository\MoneyAccountRepository;
 use App\Service\ActiveCompanyService;
 use App\Service\Bank1C\Bank1CImportService;
+use App\Service\Bank1C\Bank1CStatementParser;
+use App\Service\Bank1C\Dto\Bank1CDocument;
+use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/finance/imports/bank-1c')]
 class Bank1CImportController extends AbstractController
 {
-    public function __construct(private ActiveCompanyService $companyService)
-    {
+    private const SESSION_KEY = 'bank1c_import_previews';
+
+    public function __construct(
+        private ActiveCompanyService $companyService,
+        private LoggerInterface $logger,
+        private Bank1CStatementParser $statementParser,
+    ) {
     }
 
     #[Route('', name: 'bank1c_import_form', methods: ['GET'])]
-    public function form(MoneyAccountRepository $accountRepo): Response
+    public function form(Request $request): Response
     {
-        $company = $this->companyService->getActiveCompany();
-        $accounts = $accountRepo->findBy(['company' => $company]);
+        $session = $request->getSession();
+        if ($session instanceof SessionInterface) {
+            $token = $request->query->get('clear');
+            if (is_string($token) && '' !== $token) {
+                $this->removePreview($session, $token);
+            }
+            $this->purgeExpiredPreviews($session);
+        }
 
-        return $this->render('finance/import/bank1c/upload.html.twig', [
-            'accounts' => $accounts,
-        ]);
+        return $this->render('finance/import/bank1c/upload.html.twig');
     }
 
     #[Route('', name: 'bank1c_import_handle', methods: ['POST'])]
     public function handle(
         Request $request,
         MoneyAccountRepository $accountRepo,
-        Bank1CImportService $importService,
     ): Response {
         if (!$this->isCsrfTokenValid('bank1c_import', $request->request->get('_token'))) {
             throw $this->createAccessDeniedException();
-        }
-        $company = $this->companyService->getActiveCompany();
-        $accountId = $request->request->get('moneyAccount');
-        $account = $accountRepo->find($accountId);
-        if (!$account || $account->getCompany() !== $company) {
-            throw $this->createNotFoundException();
         }
         /** @var UploadedFile|null $file */
         $file = $request->files->get('statement');
@@ -58,7 +64,256 @@ class Bank1CImportController extends AbstractController
             return $this->redirectToRoute('bank1c_import_form');
         }
         $raw = file_get_contents($file->getPathname());
-        $result = $importService->import($company, $account, $raw, $file->getClientOriginalName());
+        if (false === $raw) {
+            $this->addFlash('danger', 'Не удалось прочитать файл');
+
+            return $this->redirectToRoute('bank1c_import_form');
+        }
+
+        try {
+            $statement = $this->statementParser->parse($raw);
+        } catch (\Throwable $e) {
+            $this->logger->error('Не удалось разобрать файл 1C', ['exception' => $e]);
+            $this->addFlash('danger', 'Не удалось разобрать файл. Проверьте формат.');
+
+            return $this->redirectToRoute('bank1c_import_form');
+        }
+
+        $accountNumberRaw = $statement->account['НомерСчета']
+            ?? ($statement->account['РасчСчет'] ?? ($statement->header['РасчСчет'] ?? null));
+        $normalizedAccount = $this->normalizeAccount($accountNumberRaw);
+        $bankName = $this->extractBankName($statement->header, $statement->account);
+
+        $company = $this->companyService->getActiveCompany();
+        $account = $normalizedAccount !== ''
+            ? $accountRepo->findOneByNormalizedAccountNumber($company, $normalizedAccount)
+            : null;
+
+        $operations = $this->buildPreviewOperations($statement->documents, $normalizedAccount);
+        $session = $request->getSession();
+        if (!$session instanceof SessionInterface) {
+            throw $this->createAccessDeniedException('Сессия недоступна');
+        }
+        $token = $this->storePreview($session, [
+            'raw' => $raw,
+            'filename' => $file->getClientOriginalName(),
+            'accountNumberRaw' => $accountNumberRaw,
+            'normalizedAccount' => $normalizedAccount,
+            'bankName' => $bankName,
+        ]);
+
+        $this->logger->info('Создано превью импорта 1C', [
+            'token' => $token,
+            'account_number' => $accountNumberRaw,
+            'account_found' => (bool) $account,
+            'bank' => $bankName,
+        ]);
+
+        return $this->render('finance/import/bank1c/preview.html.twig', [
+            'account' => $account,
+            'accountNumber' => $accountNumberRaw,
+            'bankName' => $bankName,
+            'operations' => $operations,
+            'token' => $token,
+            'canProceed' => null !== $account && '' !== $normalizedAccount,
+        ]);
+    }
+
+    /**
+     * @param Bank1CDocument[] $documents
+     * @return array<int, array<string, string|null>>
+     */
+    private function buildPreviewOperations(array $documents, ?string $normalizedAccount): array
+    {
+        $operations = [];
+        foreach (array_slice($documents, 0, 10) as $document) {
+            $operations[] = [
+                'date' => $this->resolveDocumentDate($document, $normalizedAccount),
+                'amount' => $document->amount,
+                'purpose' => $document->purpose,
+                'counterparty' => $this->resolveDocumentCounterparty($document, $normalizedAccount),
+                'number' => $document->number,
+                'type' => $document->type,
+            ];
+        }
+
+        return $operations;
+    }
+
+    private function resolveDocumentDate(Bank1CDocument $document, ?string $normalizedAccount): ?string
+    {
+        if ($normalizedAccount) {
+            $payer = $this->normalizeAccount($document->payerAccount);
+            $payee = $this->normalizeAccount($document->payeeAccount);
+            if ($payer === $normalizedAccount) {
+                return $document->dateDebited ?: ($document->date ?: $document->dateCredited);
+            }
+            if ($payee === $normalizedAccount) {
+                return $document->dateCredited ?: ($document->date ?: $document->dateDebited);
+            }
+        }
+
+        return $document->date ?? $document->dateCredited ?? $document->dateDebited;
+    }
+
+    private function resolveDocumentCounterparty(Bank1CDocument $document, ?string $normalizedAccount): ?string
+    {
+        if ($normalizedAccount) {
+            $payer = $this->normalizeAccount($document->payerAccount);
+            $payee = $this->normalizeAccount($document->payeeAccount);
+            if ($payer === $normalizedAccount && $document->payeeName) {
+                return $document->payeeName;
+            }
+            if ($payee === $normalizedAccount && $document->payerName) {
+                return $document->payerName;
+            }
+        }
+
+        return $document->payerName
+            ?: ($document->payeeName
+                ?: ($document->payerInn ?: ($document->payeeInn ?: null)));
+    }
+
+    private function normalizeAccount(?string $value): string
+    {
+        return preg_replace('/\D+/', '', (string) ($value ?? '')) ?? '';
+    }
+
+    private function extractBankName(array $header, array $account): ?string
+    {
+        foreach (['Банк', 'НаименованиеБанка', 'Банк1', 'БИК'] as $key) {
+            if (!empty($account[$key])) {
+                return $account[$key];
+            }
+            if (!empty($header[$key])) {
+                return $header[$key];
+            }
+        }
+
+        return null;
+    }
+
+    private function storePreview(SessionInterface $session, array $data): string
+    {
+        $this->purgeExpiredPreviews($session);
+        $token = bin2hex(random_bytes(16));
+        $payload = $session->get(self::SESSION_KEY, []);
+        $payload[$token] = $data + ['createdAt' => time()];
+        $session->set(self::SESSION_KEY, $payload);
+
+        return $token;
+    }
+
+    private function removePreview(SessionInterface $session, string $token): void
+    {
+        $payload = $session->get(self::SESSION_KEY, []);
+        if (isset($payload[$token])) {
+            unset($payload[$token]);
+            $session->set(self::SESSION_KEY, $payload);
+        }
+    }
+
+    private function purgeExpiredPreviews(SessionInterface $session, int $ttl = 3600): void
+    {
+        $payload = $session->get(self::SESSION_KEY, []);
+        $changed = false;
+        $threshold = time() - $ttl;
+        foreach ($payload as $token => $item) {
+            if (!is_array($item) || !isset($item['createdAt']) || $item['createdAt'] < $threshold) {
+                unset($payload[$token]);
+                $changed = true;
+            }
+        }
+        if ($changed) {
+            $session->set(self::SESSION_KEY, $payload);
+        }
+    }
+
+    #[Route('/confirm', name: 'bank1c_import_confirm', methods: ['POST'])]
+    public function confirm(
+        Request $request,
+        MoneyAccountRepository $accountRepo,
+        Bank1CImportService $importService,
+    ): Response {
+        $token = $request->request->get('token');
+        if (!is_string($token) || '' === $token) {
+            $this->addFlash('danger', 'Не найден идентификатор операции импорта. Повторите загрузку файла.');
+
+            return $this->redirectToRoute('bank1c_import_form');
+        }
+
+        if (!$this->isCsrfTokenValid('bank1c_import_confirm_'.$token, $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $session = $request->getSession();
+        if (!$session instanceof SessionInterface) {
+            throw $this->createAccessDeniedException('Сессия недоступна');
+        }
+        $payload = $session->get(self::SESSION_KEY, []);
+        $preview = $payload[$token] ?? null;
+        if (!is_array($preview) || !isset($preview['raw'])) {
+            $this->addFlash('danger', 'Данные превью не найдены. Повторите импорт.');
+
+            return $this->redirectToRoute('bank1c_import_form');
+        }
+
+        $raw = (string) $preview['raw'];
+
+        try {
+            $statement = $this->statementParser->parse($raw);
+        } catch (\Throwable $e) {
+            $this->removePreview($session, $token);
+            $this->logger->error('Не удалось повторно разобрать файл 1C при подтверждении', ['exception' => $e]);
+            $this->addFlash('danger', 'Не удалось обработать файл. Повторите импорт.');
+
+            return $this->redirectToRoute('bank1c_import_form');
+        }
+
+        $accountNumberRaw = $statement->account['НомерСчета']
+            ?? ($statement->account['РасчСчет'] ?? ($statement->header['РасчСчет'] ?? null));
+        $normalizedAccount = $this->normalizeAccount($accountNumberRaw);
+        $bankName = $this->extractBankName($statement->header, $statement->account);
+
+        $company = $this->companyService->getActiveCompany();
+        $account = $normalizedAccount !== ''
+            ? $accountRepo->findOneByNormalizedAccountNumber($company, $normalizedAccount)
+            : null;
+
+        if (!$account) {
+            $this->removePreview($session, $token);
+            $this->logger->warning('Подтверждение импорта 1C без найденного счёта', [
+                'token' => $token,
+                'account_number' => $accountNumberRaw,
+                'bank' => $bankName,
+            ]);
+            $this->addFlash('danger', sprintf(
+                'Счёт %s (%s) не найден в системе. Создайте счёт и повторите импорт.',
+                $accountNumberRaw ?: '—',
+                $bankName ?: 'банк не указан'
+            ));
+
+            return $this->redirectToRoute('bank1c_import_form');
+        }
+
+        $this->logger->info('Подтверждён импорт 1C', [
+            'token' => $token,
+            'account_id' => $account->getId(),
+            'account_number' => $accountNumberRaw,
+            'bank' => $bankName,
+        ]);
+
+        $result = $importService->import($company, $account, $raw, $preview['filename'] ?? null);
+
+        $this->removePreview($session, $token);
+
+        $this->logger->info('Импорт 1C завершён', [
+            'token' => $token,
+            'created' => $result->created,
+            'duplicates' => $result->duplicates,
+            'errors' => count($result->errors),
+            'bank' => $bankName,
+        ]);
 
         return $this->render('finance/import/bank1c/result.html.twig', [
             'result' => $result,

--- a/site/src/Repository/MoneyAccountRepository.php
+++ b/site/src/Repository/MoneyAccountRepository.php
@@ -69,4 +69,29 @@ class MoneyAccountRepository extends ServiceEntityRepository
 
         $qb->getQuery()->execute();
     }
+
+    public function findOneByNormalizedAccountNumber(Company $company, string $normalized): ?MoneyAccount
+    {
+        $normalized = preg_replace('/\D+/', '', $normalized);
+        if ('' === $normalized) {
+            return null;
+        }
+
+        $accounts = $this->createQueryBuilder('m')
+            ->andWhere('m.company = :company')
+            ->setParameter('company', $company)
+            ->getQuery()
+            ->getResult();
+
+        foreach ($accounts as $account) {
+            if ($account instanceof MoneyAccount) {
+                $accountNumber = preg_replace('/\D+/', '', (string) $account->getAccountNumber());
+                if ($accountNumber === $normalized && $account->isActive()) {
+                    return $account;
+                }
+            }
+        }
+
+        return null;
+    }
 }

--- a/site/templates/finance/import/bank1c/preview.html.twig
+++ b/site/templates/finance/import/bank1c/preview.html.twig
@@ -1,0 +1,107 @@
+{% extends 'base.html.twig' %}
+{% block title %}Превью импорта 1C{% endblock %}
+
+{% block breadcrumbs %}
+    {% include 'partials/_breadcrumbs.html.twig' with {
+        breadcrumbs: [
+            {'label':'Главная','path':'app_home_index'},
+            {'label':'Финансы'},
+            {'label':'Импорт','path':'bank1c_import_form'},
+            {'label':'Превью'}
+        ]
+    } %}
+{% endblock %}
+
+{% block content %}
+    <h2 class="page-title mb-3">Превью импорта</h2>
+
+    <div class="card mb-3">
+        <div class="card-body">
+            <div class="row g-3">
+                <div class="col-md-6">
+                    <h3 class="card-title">Данные выписки</h3>
+                    <dl class="row mb-0">
+                        <dt class="col-sm-5">Расчётный счёт</dt>
+                        <dd class="col-sm-7">{{ accountNumber ?: '—' }}</dd>
+                        <dt class="col-sm-5">Банк</dt>
+                        <dd class="col-sm-7">{{ bankName ?: '—' }}</dd>
+                    </dl>
+                </div>
+                {% if account %}
+                    <div class="col-md-6">
+                        <h3 class="card-title">Найденный счёт</h3>
+                        <dl class="row mb-0">
+                            <dt class="col-sm-5">Название</dt>
+                            <dd class="col-sm-7">{{ account.name }}</dd>
+                            <dt class="col-sm-5">Номер</dt>
+                            <dd class="col-sm-7">{{ account.accountNumber ?: '—' }}</dd>
+                            <dt class="col-sm-5">Банк</dt>
+                            <dd class="col-sm-7">{{ account.bankName ?: '—' }}</dd>
+                            <dt class="col-sm-5">Валюта</dt>
+                            <dd class="col-sm-7">{{ account.currency }}</dd>
+                        </dl>
+                    </div>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+
+    {% if not canProceed %}
+        <div class="alert alert-danger">
+            <p class="mb-2">Счёт из выписки не найден в системе или не указан.</p>
+            <p class="mb-2">РасчСчет: <strong>{{ accountNumber ?: '—' }}</strong></p>
+            <p class="mb-2">Банк: <strong>{{ bankName ?: '—' }}</strong></p>
+            <p class="mb-0">Создайте счёт в системе и повторите импорт.
+                {% if accountNumber %}
+                    <a href="{{ path('money_account_new') }}" class="alert-link">Создать счёт</a>
+                {% endif %}
+            </p>
+        </div>
+    {% endif %}
+
+    <div class="card mb-4">
+        <div class="card-header">
+            <h3 class="card-title">Первые операции</h3>
+            <div class="card-subtitle">Отображаются первые 10 операций из файла</div>
+        </div>
+        <div class="card-body">
+            {% if operations %}
+                <div class="table-responsive">
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                <th>Дата</th>
+                                <th>Сумма</th>
+                                <th>Назначение</th>
+                                <th>Контрагент</th>
+                                <th>Документ</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for op in operations %}
+                                <tr>
+                                    <td>{{ op.date ?: '—' }}</td>
+                                    <td>{{ op.amount ?: '—' }}</td>
+                                    <td>{{ op.purpose ?: '—' }}</td>
+                                    <td>{{ op.counterparty ?: '—' }}</td>
+                                    <td>{{ op.number ?: op.type ?: '—' }}</td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            {% else %}
+                <p class="text-muted mb-0">Операции не распознаны в загруженном файле.</p>
+            {% endif %}
+        </div>
+    </div>
+
+    <div class="d-flex gap-2 flex-wrap align-items-center">
+        <a href="{{ path('bank1c_import_form', {'clear': token}) }}" class="btn btn-outline-secondary">Отмена</a>
+        <form method="post" action="{{ path('bank1c_import_confirm') }}" class="d-inline">
+            <input type="hidden" name="_token" value="{{ csrf_token('bank1c_import_confirm_' ~ token) }}">
+            <input type="hidden" name="token" value="{{ token }}">
+            <button type="submit" class="btn btn-primary" {% if not canProceed %}disabled{% endif %}>Продолжить импорт</button>
+        </form>
+    </div>
+{% endblock %}

--- a/site/templates/finance/import/bank1c/upload.html.twig
+++ b/site/templates/finance/import/bank1c/upload.html.twig
@@ -17,39 +17,10 @@
     <form method="post" enctype="multipart/form-data">
         <input type="hidden" name="_token" value="{{ csrf_token('bank1c_import') }}">
         <div class="mb-3">
-            <label class="form-label">Счёт</label>
-            <select name="moneyAccount" id="moneyAccount" class="form-select" required>
-                {% for acc in accounts %}
-                    <option value="{{ acc.id }}" data-account="{{ acc.accountNumber }}" data-currency="{{ acc.currency }}">{{ acc.name }}</option>
-                {% endfor %}
-            </select>
-            <div class="form-hint" id="accountInfo"></div>
-        </div>
-        <div class="mb-3">
             <label class="form-label">Выписка (.txt)</label>
             <input type="file" name="statement" accept=".txt" required class="form-control">
         </div>
         <p class="text-muted">Формат 1CClientBankExchange, кодировка Windows-1251</p>
         <button type="submit" class="btn btn-primary">Импортировать</button>
     </form>
-{% endblock %}
-
-{% block scripts %}
-    {{ parent() }}
-    <script>
-        const select = document.getElementById('moneyAccount');
-        const info = document.getElementById('accountInfo');
-        if (select) {
-            function updateInfo() {
-                const opt = select.options[select.selectedIndex];
-                if (opt) {
-                    const acc = opt.dataset.account || '';
-                    const cur = opt.dataset.currency || '';
-                    info.textContent = acc ? acc + ' / ' + cur : '';
-                }
-            }
-            select.addEventListener('change', updateInfo);
-            updateInfo();
-        }
-    </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- drop the manual account selection from the 1C upload form
- parse uploaded statements to resolve the target account, build a preview, and keep temporary data in the session with logging
- add a confirmation action that revalidates the account, runs the existing import service, and report results

## Testing
- composer cs:check *(fails: php-cs-fixer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d132720afc832390101aa7e9718aa7