### PR TITLE
Handle Unicode 1C import preview and confirmation

### DIFF
--- a/site/templates/finance/import/bank1c/preview.html.twig
+++ b/site/templates/finance/import/bank1c/preview.html.twig
@@ -25,6 +25,8 @@
                         <dd class="col-sm-7">{{ accountNumber ?: '—' }}</dd>
                         <dt class="col-sm-5">Банк</dt>
                         <dd class="col-sm-7">{{ bankName ?: '—' }}</dd>
+                        <dt class="col-sm-5">БИК</dt>
+                        <dd class="col-sm-7">{{ bankBik ?: '—' }}</dd>
                     </dl>
                 </div>
                 {% if account %}
@@ -51,6 +53,7 @@
             <p class="mb-2">Счёт из выписки не найден в системе или не указан.</p>
             <p class="mb-2">РасчСчет: <strong>{{ accountNumber ?: '—' }}</strong></p>
             <p class="mb-2">Банк: <strong>{{ bankName ?: '—' }}</strong></p>
+            <p class="mb-2">БИК: <strong>{{ bankBik ?: '—' }}</strong></p>
             <p class="mb-0">Создайте счёт в системе и повторите импорт.
                 {% if accountNumber %}
                     <a href="{{ path('money_account_new') }}" class="alert-link">Создать счёт</a>


### PR DESCRIPTION
## Summary
- validate 1C uploads against ASCII/UTF-16LE signatures before preview
- normalize statement encoding to UTF-8 for Unicode files and show bank BIK in preview
- persist normalized data for confirmation with improved logging around preview/import flow

## Testing
- php bin/phpunit *(fails: Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`)*

------
https://chatgpt.com/codex/tasks/task_e_68d153c805fc8323abcd39dd7d59b0de