### PR TITLE
feat(cash): add rawData/docType/docNumber/externalId/isTransfer to CashTransaction + migration

### DIFF
--- a/site/migrations/Version20250921000000.php
+++ b/site/migrations/Version20250921000000.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250921000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add document and transfer metadata to cash_transaction';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE cash_transaction ADD doc_type VARCHAR(64) DEFAULT NULL");
+        $this->addSql("ALTER TABLE cash_transaction ADD doc_number VARCHAR(64) DEFAULT NULL");
+        $this->addSql("ALTER TABLE cash_transaction ADD is_transfer BOOLEAN NOT NULL DEFAULT false");
+        $this->addSql("ALTER TABLE cash_transaction ADD raw_data JSON NOT NULL DEFAULT '[]'");
+        $this->addSql("ALTER TABLE cash_transaction ALTER external_id TYPE VARCHAR(128)");
+        $this->addSql('CREATE UNIQUE INDEX uniq_cash_transaction_external_id ON cash_transaction (external_id)');
+        $this->addSql("ALTER TABLE cash_transaction ALTER COLUMN is_transfer DROP DEFAULT");
+        $this->addSql("ALTER TABLE cash_transaction ALTER COLUMN raw_data DROP DEFAULT");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX uniq_cash_transaction_external_id');
+        $this->addSql("ALTER TABLE cash_transaction ALTER external_id TYPE VARCHAR(255)");
+        $this->addSql('ALTER TABLE cash_transaction DROP COLUMN raw_data');
+        $this->addSql('ALTER TABLE cash_transaction DROP COLUMN is_transfer');
+        $this->addSql('ALTER TABLE cash_transaction DROP COLUMN doc_number');
+        $this->addSql('ALTER TABLE cash_transaction DROP COLUMN doc_type');
+    }
+}

--- a/site/src/Entity/CashTransaction.php
+++ b/site/src/Entity/CashTransaction.php
@@ -54,8 +54,20 @@ class CashTransaction
     #[ORM\Column(type: 'string', length: 1024, nullable: true)]
     private ?string $description = null;
 
-    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    #[ORM\Column(length: 64, nullable: true)]
+    private ?string $docType = null;
+
+    #[ORM\Column(length: 64, nullable: true)]
+    private ?string $docNumber = null;
+
+    #[ORM\Column(length: 128, nullable: true, unique: true)]
     private ?string $externalId = null;
+
+    #[ORM\Column(type: 'boolean')]
+    private bool $isTransfer = false;
+
+    #[ORM\Column(type: 'json')]
+    private array $rawData = [];
 
     #[ORM\Column(type: 'datetime_immutable')]
     private \DateTimeImmutable $createdAt;
@@ -215,6 +227,30 @@ class CashTransaction
         return $this;
     }
 
+    public function getDocType(): ?string
+    {
+        return $this->docType;
+    }
+
+    public function setDocType(?string $docType): self
+    {
+        $this->docType = $docType;
+
+        return $this;
+    }
+
+    public function getDocNumber(): ?string
+    {
+        return $this->docNumber;
+    }
+
+    public function setDocNumber(?string $docNumber): self
+    {
+        $this->docNumber = $docNumber;
+
+        return $this;
+    }
+
     public function getExternalId(): ?string
     {
         return $this->externalId;
@@ -223,6 +259,30 @@ class CashTransaction
     public function setExternalId(?string $e): self
     {
         $this->externalId = $e;
+
+        return $this;
+    }
+
+    public function isTransfer(): bool
+    {
+        return $this->isTransfer;
+    }
+
+    public function setIsTransfer(bool $isTransfer): self
+    {
+        $this->isTransfer = $isTransfer;
+
+        return $this;
+    }
+
+    public function getRawData(): array
+    {
+        return $this->rawData;
+    }
+
+    public function setRawData(array $rawData): self
+    {
+        $this->rawData = $rawData;
 
         return $this;
     }


### PR DESCRIPTION
## Summary
- add document metadata, transfer flag, raw payload mapping, and tighten externalId on CashTransaction
- introduce migration to add the new columns and unique index for externalId

## Testing
- `php bin/console doctrine:schema:validate` *(fails: missing Symfony Runtime because Composer dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d223507fe8832397b0caefe26beced