### PR TITLE
feat(import): add ClientBank1CImportService skeleton (no logic yet)

### DIFF
--- a/site/src/Service/Import/ClientBank1CImportService.php
+++ b/site/src/Service/Import/ClientBank1CImportService.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Service\Import;
+
+use App\Entity\MoneyAccount;
+
+class ClientBank1CImportService
+{
+    /**
+     * Parse content of a Client Bank 1C export and return its header and documents sections.
+     *
+     * @param string $content Raw file content.
+     *
+     * @return array{
+     *     header: array<mixed>,
+     *     documents: array<mixed>
+     * } Parsed header and documents data.
+     */
+    public function parseHeaderAndDocuments(string $content): array
+    {
+        return [
+            'header' => [],
+            'documents' => [],
+        ];
+    }
+
+    /**
+     * Build preview data for the provided documents and statement account identifier.
+     *
+     * @param array<mixed> $documents Parsed document data.
+     * @param string $statementAccount Identifier of the account from the statement.
+     *
+     * @return array<int, string> Preview lines ready for display.
+     */
+    public function buildPreview(array $documents, string $statementAccount): array
+    {
+        return [];
+    }
+
+    /**
+     * Import preview data into the provided money account.
+     *
+     * @param array<int, array<string, mixed>> $preview Prepared preview rows ready for import.
+     * @param MoneyAccount $account Target account for the import.
+     * @param bool $overwrite Whether to overwrite existing data during import.
+     *
+     * @return array{
+     *     created: int,
+     *     duplicates: int,
+     *     errors: int,
+     *     minDate: ?\DateTimeInterface,
+     *     maxDate: ?\DateTimeInterface
+     * } Import summary statistics.
+     */
+    public function import(array $preview, MoneyAccount $account, bool $overwrite): array
+    {
+        return [
+            'created' => 0,
+            'duplicates' => 0,
+            'errors' => 0,
+            'minDate' => null,
+            'maxDate' => null,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add a ClientBank1CImportService skeleton with strict method signatures and PHPDoc comments

## Testing
- ⚠️ `composer install --no-interaction` *(fails: CONNECT tunnel failed when cloning composer/pcre.git from GitHub)*
- ⚠️ `php bin/console debug:container ClientBank1CImportService` *(fails: dependencies missing because composer install could not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68d2285be284832393db3e0daee5a933