### PR TITLE
feat: add Bank1C cash import UI flow skeleton

### DIFF
--- a/site/src/Controller/Cash/Bank1CImportController.php
+++ b/site/src/Controller/Cash/Bank1CImportController.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Controller\Cash;
+
+use App\Repository\MoneyAccountRepository;
+use App\Service\ActiveCompanyService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/cash/import/bank1c')]
+class Bank1CImportController extends AbstractController
+{
+    public function __construct(private readonly ActiveCompanyService $activeCompanyService)
+    {
+    }
+
+    #[Route('', name: 'cash_bank1c_import_upload', methods: ['GET'])]
+    public function upload(MoneyAccountRepository $accountRepository): Response
+    {
+        $company = $this->activeCompanyService->getActiveCompany();
+        $accounts = $accountRepository->findBy(['company' => $company]);
+
+        return $this->render('cash/bank1c_import_upload.html.twig', [
+            'accounts' => $accounts,
+        ]);
+    }
+
+    #[Route('/preview', name: 'cash_bank1c_import_preview', methods: ['POST'])]
+    public function preview(Request $request, MoneyAccountRepository $accountRepository): Response
+    {
+        if (!$this->isCsrfTokenValid('bank1c_import_upload', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $uploadedFile = $request->files->get('import_file');
+        if (!$uploadedFile instanceof UploadedFile) {
+            $this->addFlash('danger', 'Пожалуйста, выберите файл для импорта.');
+
+            return $this->redirectToRoute('cash_bank1c_import_upload');
+        }
+
+        $accountId = (string) $request->request->get('money_account_id');
+        $content = file_get_contents($uploadedFile->getPathname()) ?: '';
+        $session = $request->getSession();
+        $session->set('bank1c_import', [
+            'file_name' => $uploadedFile->getClientOriginalName(),
+            'file_content' => $content,
+            'account_id' => $accountId,
+        ]);
+
+        $company = $this->activeCompanyService->getActiveCompany();
+        $accounts = $accountRepository->findBy(['company' => $company]);
+        $selectedAccount = null;
+        foreach ($accounts as $account) {
+            if ($account->getId() === $accountId) {
+                $selectedAccount = $account;
+                break;
+            }
+        }
+
+        $previewRows = [
+            [
+                'date' => '2024-01-01',
+                'document' => 'Платёж 001',
+                'debit' => '10 000.00',
+                'credit' => '0.00',
+                'description' => 'Пример операции',
+            ],
+            [
+                'date' => '2024-01-02',
+                'document' => 'Платёж 002',
+                'debit' => '0.00',
+                'credit' => '2 500.00',
+                'description' => 'Заглушка для предпросмотра',
+            ],
+        ];
+
+        return $this->render('cash/bank1c_import_preview.html.twig', [
+            'filename' => $uploadedFile->getClientOriginalName(),
+            'selectedAccount' => $selectedAccount,
+            'previewRows' => $previewRows,
+        ]);
+    }
+
+    #[Route('/commit', name: 'cash_bank1c_import_commit', methods: ['POST'])]
+    public function commit(Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('bank1c_import_commit', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        return new Response('Not implemented', Response::HTTP_NOT_IMPLEMENTED);
+    }
+}

--- a/site/templates/cash/bank1c_import_preview.html.twig
+++ b/site/templates/cash/bank1c_import_preview.html.twig
@@ -1,0 +1,70 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Предпросмотр импорта 1С{% endblock %}
+
+{% block body %}
+    <div class="page-header d-print-none">
+        <div class="container-xl">
+            <div class="row g-2 align-items-center">
+                <div class="col">
+                    <h2 class="page-title">Предпросмотр импорта банковской выписки 1С</h2>
+                    <div class="text-muted small">
+                        Файл: <strong>{{ filename }}</strong>
+                        {% if selectedAccount %}
+                            · Счёт: <strong>{{ selectedAccount.name }}</strong>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="container-xl mt-3">
+        <div class="card mb-3">
+            <div class="table-responsive">
+                <table class="table card-table">
+                    <thead>
+                        <tr>
+                            <th>Дата</th>
+                            <th>Документ</th>
+                            <th class="text-end">Приход</th>
+                            <th class="text-end">Расход</th>
+                            <th>Описание</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for row in previewRows %}
+                            <tr>
+                                <td>{{ row.date }}</td>
+                                <td>{{ row.document }}</td>
+                                <td class="text-end">{{ row.debit }}</td>
+                                <td class="text-end">{{ row.credit }}</td>
+                                <td>{{ row.description }}</td>
+                            </tr>
+                        {% else %}
+                            <tr>
+                                <td colspan="5" class="text-center text-muted">Нет данных для предпросмотра</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <div class="card">
+            <div class="card-body">
+                <form action="{{ path('cash_bank1c_import_commit') }}" method="post">
+                    <div class="form-check mb-3">
+                        <input class="form-check-input" type="checkbox" id="overwrite_duplicates" name="overwrite_duplicates" value="1">
+                        <label class="form-check-label" for="overwrite_duplicates">Перезаписывать дубли</label>
+                    </div>
+                    <input type="hidden" name="_token" value="{{ csrf_token('bank1c_import_commit') }}">
+                    <div class="d-flex justify-content-between">
+                        <a href="{{ path('cash_bank1c_import_upload') }}" class="btn btn-outline-secondary">Назад</a>
+                        <button type="submit" class="btn btn-primary">Продолжить импорт</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/site/templates/cash/bank1c_import_upload.html.twig
+++ b/site/templates/cash/bank1c_import_upload.html.twig
@@ -1,0 +1,46 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Импорт выписки 1С{% endblock %}
+
+{% block body %}
+    <div class="page-header d-print-none">
+        <div class="container-xl">
+            <div class="row g-2 align-items-center">
+                <div class="col">
+                    <h2 class="page-title">Импорт банковской выписки 1С</h2>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="container-xl mt-3">
+        <div class="card">
+            <div class="card-body">
+                <form action="{{ path('cash_bank1c_import_preview') }}" method="post" enctype="multipart/form-data">
+                    <div class="mb-3">
+                        <label class="form-label required" for="import_file">Файл выгрузки</label>
+                        <input type="file" class="form-control" id="import_file" name="import_file" required>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label required" for="money_account_id">Счёт</label>
+                        <select class="form-select" id="money_account_id" name="money_account_id" required>
+                            {% if accounts is not empty %}
+                                <option value="">Выберите счёт</option>
+                                {% for account in accounts %}
+                                    <option value="{{ account.id }}">{{ account.name }}</option>
+                                {% endfor %}
+                            {% else %}
+                                <option value="" disabled selected>Нет доступных счетов</option>
+                            {% endif %}
+                        </select>
+                    </div>
+                    <input type="hidden" name="_token" value="{{ csrf_token('bank1c_import_upload') }}">
+                    <div class="d-flex justify-content-end gap-2">
+                        <a href="{{ path('cash_bank1c_import_upload') }}" class="btn btn-outline-secondary">Отмена</a>
+                        <button type="submit" class="btn btn-primary">Импортировать</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a dedicated Bank1CImportController with upload, preview, and commit endpoints
- scaffold Twig templates to drive the three-step Bank1C import flow

## Testing
- composer run cs:check *(fails: php-cs-fixer not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d229119df08323939b0ccf84df81a7