### PR TITLE
Wire bank 1C import controller to service flow

### DIFF
--- a/site/src/Controller/Cash/Bank1CImportController.php
+++ b/site/src/Controller/Cash/Bank1CImportController.php
@@ -31,92 +31,196 @@ class Bank1CImportController extends AbstractController
         ]);
     }
 
-    #[Route('/preview', name: 'cash_bank1c_import_preview', methods: ['POST'])]
+    #[Route('/preview', name: 'cash_bank1c_import_preview', methods: ['GET', 'POST'])]
     public function preview(Request $request, MoneyAccountRepository $accountRepository): Response
     {
-        if (!$this->isCsrfTokenValid('bank1c_import_upload', (string) $request->request->get('_token'))) {
-            throw $this->createAccessDeniedException();
+        $session = $request->getSession();
+
+        if ($request->isMethod('POST')) {
+            if (!$this->isCsrfTokenValid('bank1c_import_upload', (string) $request->request->get('_token'))) {
+                throw $this->createAccessDeniedException();
+            }
+
+            $uploadedFile = $request->files->get('import_file');
+            if (!$uploadedFile instanceof UploadedFile) {
+                $this->addFlash('danger', 'Пожалуйста, выберите файл для импорта.');
+
+                return $this->redirectToRoute('cash_bank1c_import_upload');
+            }
+
+            $accountId = (string) $request->request->get('money_account_id');
+            if ($accountId === '') {
+                $this->addFlash('danger', 'Пожалуйста, выберите счёт.');
+
+                return $this->redirectToRoute('cash_bank1c_import_upload');
+            }
+
+            $company = $this->activeCompanyService->getActiveCompany();
+            $selectedAccount = $accountRepository->find($accountId);
+            if ($selectedAccount === null || $selectedAccount->getCompany() !== $company) {
+                $this->addFlash('danger', 'Выбранный счёт недоступен.');
+
+                return $this->redirectToRoute('cash_bank1c_import_upload');
+            }
+
+            $rawContent = file_get_contents($uploadedFile->getPathname());
+            if ($rawContent === false) {
+                $this->addFlash('danger', 'Не удалось прочитать файл импорта.');
+
+                return $this->redirectToRoute('cash_bank1c_import_upload');
+            }
+
+            $content = mb_convert_encoding($rawContent, 'UTF-8', 'CP1251');
+
+            $parsedData = $this->clientBank1CImportService->parseHeaderAndDocuments($content);
+            $statementAccountValue = $parsedData['header']['РасчСчет'] ?? null;
+            $statementAccount = is_string($statementAccountValue) ? $statementAccountValue : null;
+
+            $statementAccountNormalized = $this->normalizeAccountNumber($statementAccount);
+            $selectedAccountNormalized = $this->normalizeAccountNumber($selectedAccount->getAccountNumber());
+
+            if (
+                $statementAccountNormalized === null
+                || $selectedAccountNormalized === null
+                || $statementAccountNormalized !== $selectedAccountNormalized
+            ) {
+                $this->addFlash(
+                    'danger',
+                    sprintf(
+                        'Выбран неверный банк или выписка: в файле указан счёт %s',
+                        $statementAccount ?? 'не указан',
+                    ),
+                );
+
+                return $this->redirectToRoute('cash_bank1c_import_upload');
+            }
+
+            $documents = is_array($parsedData['documents']) ? $parsedData['documents'] : [];
+            $preview = $this->clientBank1CImportService->buildPreview($documents, $statementAccount);
+
+            $session->set('bank1c_import', [
+                'file_name' => $uploadedFile->getClientOriginalName(),
+                'account_id' => $selectedAccount->getId(),
+                'statement_account' => $statementAccount,
+                'preview' => $preview,
+            ]);
         }
 
-        $uploadedFile = $request->files->get('import_file');
-        if (!$uploadedFile instanceof UploadedFile) {
-            $this->addFlash('danger', 'Пожалуйста, выберите файл для импорта.');
+        $state = $session->get('bank1c_import');
+        if (!is_array($state) || !isset($state['preview'], $state['account_id'])) {
+            $this->addFlash('danger', 'Сессия предпросмотра не найдена. Пожалуйста, загрузите файл заново.');
 
             return $this->redirectToRoute('cash_bank1c_import_upload');
         }
-
-        $accountId = (string) $request->request->get('money_account_id');
-        $content = file_get_contents($uploadedFile->getPathname()) ?: '';
 
         $company = $this->activeCompanyService->getActiveCompany();
-        $accounts = $accountRepository->findBy(['company' => $company]);
         $selectedAccount = null;
-        foreach ($accounts as $account) {
-            if ($account->getId() === $accountId) {
-                $selectedAccount = $account;
-                break;
-            }
+        if (is_string($state['account_id'])) {
+            $selectedAccount = $accountRepository->find($state['account_id']);
         }
 
-        $parsedData = $this->clientBank1CImportService->parseHeaderAndDocuments($content);
-        $statementAccount = $parsedData['header']['РасчСчет'] ?? null;
-        $statementAccountValue = is_string($statementAccount) ? $statementAccount : null;
-        $selectedAccountNumber = $selectedAccount?->getAccountNumber();
-
-        if (
-            $statementAccountValue === null
-            || $selectedAccountNumber === null
-            || $statementAccountValue !== $selectedAccountNumber
-        ) {
-            $this->addFlash(
-                'danger',
-                sprintf(
-                    'Выбран неверный банк или выписка: в файле указан счёт %s',
-                    $statementAccountValue ?? 'не указан',
-                ),
-            );
+        if ($selectedAccount === null || $selectedAccount->getCompany() !== $company) {
+            $this->addFlash('danger', 'Выбранный счёт недоступен.');
 
             return $this->redirectToRoute('cash_bank1c_import_upload');
         }
 
-        $session = $request->getSession();
-        $session->set('bank1c_import', [
-            'file_name' => $uploadedFile->getClientOriginalName(),
-            'file_content' => $content,
-            'account_id' => $accountId,
-        ]);
+        $preview = is_array($state['preview']) ? $state['preview'] : [];
+        $totalRows = count($preview);
+        $perPage = 100;
+        $page = max(1, (int) $request->query->get('page', 1));
+        $pages = (int) ceil($totalRows / $perPage);
+        if ($pages < 1) {
+            $pages = 1;
+        }
 
-        $previewRows = [
-            [
-                'date' => '2024-01-01',
-                'document' => 'Платёж 001',
-                'debit' => '10 000.00',
-                'credit' => '0.00',
-                'description' => 'Пример операции',
-            ],
-            [
-                'date' => '2024-01-02',
-                'document' => 'Платёж 002',
-                'debit' => '0.00',
-                'credit' => '2 500.00',
-                'description' => 'Заглушка для предпросмотра',
-            ],
-        ];
+        if ($page > $pages) {
+            $page = $pages;
+        }
+
+        $offset = ($page - 1) * $perPage;
+        $previewRows = array_slice($preview, $offset, $perPage);
+
+        $pager = null;
+        if ($totalRows > $perPage) {
+            $pager = [
+                'current' => $page,
+                'pages' => $pages,
+                'hasPrevious' => $page > 1,
+                'hasNext' => $page < $pages,
+                'previous' => max(1, $page - 1),
+                'next' => min($pages, $page + 1),
+            ];
+        }
 
         return $this->render('cash/bank1c_import_preview.html.twig', [
-            'filename' => $uploadedFile->getClientOriginalName(),
+            'filename' => is_string($state['file_name'] ?? null) ? $state['file_name'] : null,
             'selectedAccount' => $selectedAccount,
             'previewRows' => $previewRows,
+            'pager' => $pager,
+            'totalRows' => $totalRows,
         ]);
     }
 
     #[Route('/commit', name: 'cash_bank1c_import_commit', methods: ['POST'])]
-    public function commit(Request $request): Response
+    public function commit(Request $request, MoneyAccountRepository $accountRepository): Response
     {
         if (!$this->isCsrfTokenValid('bank1c_import_commit', (string) $request->request->get('_token'))) {
             throw $this->createAccessDeniedException();
         }
 
-        return new Response('Not implemented', Response::HTTP_NOT_IMPLEMENTED);
+        $session = $request->getSession();
+        $state = $session->get('bank1c_import');
+
+        if (!is_array($state) || !isset($state['preview'], $state['account_id'])) {
+            $this->addFlash('danger', 'Сессия импорта не найдена. Пожалуйста, загрузите файл заново.');
+
+            return $this->redirectToRoute('cash_bank1c_import_upload');
+        }
+
+        $preview = $state['preview'];
+        if (!is_array($preview)) {
+            $this->addFlash('danger', 'Данные для импорта повреждены. Пожалуйста, повторите загрузку файла.');
+
+            return $this->redirectToRoute('cash_bank1c_import_upload');
+        }
+
+        $company = $this->activeCompanyService->getActiveCompany();
+        $account = null;
+        if (is_string($state['account_id'])) {
+            $account = $accountRepository->find($state['account_id']);
+        }
+
+        if ($account === null || $account->getCompany() !== $company) {
+            $this->addFlash('danger', 'Выбранный счёт недоступен. Пожалуйста, повторите загрузку файла.');
+
+            return $this->redirectToRoute('cash_bank1c_import_upload');
+        }
+
+        $overwrite = $request->request->getBoolean('overwrite_duplicates', false);
+
+        $summary = $this->clientBank1CImportService->import($preview, $account, $overwrite);
+
+        $session->remove('bank1c_import');
+
+        return $this->render('cash/bank1c_import_result.html.twig', [
+            'filename' => is_string($state['file_name'] ?? null) ? $state['file_name'] : null,
+            'selectedAccount' => $account,
+            'summary' => $summary,
+        ]);
+    }
+
+    private function normalizeAccountNumber(?string $accountNumber): ?string
+    {
+        if ($accountNumber === null) {
+            return null;
+        }
+
+        $normalized = preg_replace('/[^0-9]/', '', $accountNumber);
+        if ($normalized === null || $normalized === '') {
+            return null;
+        }
+
+        return $normalized;
     }
 }

--- a/site/templates/cash/bank1c_import_preview.html.twig
+++ b/site/templates/cash/bank1c_import_preview.html.twig
@@ -13,6 +13,9 @@
                         {% if selectedAccount %}
                             · Счёт: <strong>{{ selectedAccount.name }}</strong>
                         {% endif %}
+                        {% if totalRows is defined %}
+                            · Всего операций: <strong>{{ totalRows }}</strong>
+                        {% endif %}
                     </div>
                 </div>
             </div>
@@ -27,23 +30,59 @@
                         <tr>
                             <th>Дата</th>
                             <th>Документ</th>
-                            <th class="text-end">Приход</th>
-                            <th class="text-end">Расход</th>
-                            <th>Описание</th>
+                            <th>Контрагент</th>
+                            <th>Назначение</th>
+                            <th class="text-end">Сумма</th>
+                            <th>Статус контрагента</th>
                         </tr>
                     </thead>
                     <tbody>
                         {% for row in previewRows %}
+                            {% set direction = row.direction ?? '' %}
+                            {% set isInflow = direction == 'inflow' %}
+                            {% set isOutflow = direction == 'outflow' %}
+                            {% set counterpartyName = direction == 'outflow' ? row.receiverName : row.payerName %}
+                            {% set counterpartyInn = direction == 'outflow' ? row.receiverInn : row.payerInn %}
+                            {% set counterpartyDisplay = counterpartyName ? counterpartyName : '—' %}
+                            {% if counterpartyInn %}
+                                {% set counterpartyDisplay = counterpartyDisplay ~ ' (' ~ counterpartyInn ~ ')' %}
+                            {% endif %}
+                            {% if direction == 'self-transfer' %}
+                                {% set counterpartyDisplay = 'Перевод между своими счетами' %}
+                            {% endif %}
+                            {% set amountClass = isInflow ? 'text-success' : (isOutflow ? 'text-danger' : '') %}
                             <tr>
-                                <td>{{ row.date }}</td>
-                                <td>{{ row.document }}</td>
-                                <td class="text-end">{{ row.debit }}</td>
-                                <td class="text-end">{{ row.credit }}</td>
-                                <td>{{ row.description }}</td>
+                                <td>{{ row.docDate ?? '—' }}</td>
+                                <td>
+                                    {% if row.docType %}<span class="text-muted">{{ row.docType }}</span>{% endif %}
+                                    {% if row.docNumber %}<div class="fw-semibold">№ {{ row.docNumber }}</div>{% endif %}
+                                    {% if not row.docType and not row.docNumber %}—{% endif %}
+                                </td>
+                                <td>{{ counterpartyDisplay }}</td>
+                                <td>{{ row.purpose ?? '—' }}</td>
+                                <td class="text-end">
+                                    {% if row.amount is not null %}
+                                        <span class="{{ amountClass }}">
+                                            {% if isInflow %}+{% elseif isOutflow %}-{% endif %}
+                                            {{ row.amount|number_format(2, ',', ' ') }}
+                                        </span>
+                                    {% else %}
+                                        —
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if row.counterpartyStatus == 'FOUND' %}
+                                        <span class="badge bg-success">Найден</span>
+                                    {% elseif row.counterpartyStatus == 'WILL_CREATE' %}
+                                        <span class="badge bg-warning text-dark">Будет создан</span>
+                                    {% else %}
+                                        <span class="badge bg-secondary">Неизвестно</span>
+                                    {% endif %}
+                                </td>
                             </tr>
                         {% else %}
                             <tr>
-                                <td colspan="5" class="text-center text-muted">Нет данных для предпросмотра</td>
+                                <td colspan="6" class="text-center text-muted">Нет данных для предпросмотра</td>
                             </tr>
                         {% endfor %}
                     </tbody>
@@ -66,5 +105,6 @@
                 </form>
             </div>
         </div>
+        {% include 'partials/_pagination.html.twig' with {pager: pager} %}
     </div>
 {% endblock %}

--- a/site/templates/cash/bank1c_import_result.html.twig
+++ b/site/templates/cash/bank1c_import_result.html.twig
@@ -1,0 +1,73 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Результат импорта 1С{% endblock %}
+
+{% block body %}
+    <div class="page-header d-print-none">
+        <div class="container-xl">
+            <div class="row g-2 align-items-center">
+                <div class="col">
+                    <h2 class="page-title">Импорт банковской выписки 1С завершён</h2>
+                    <div class="text-muted small">
+                        {% if filename %}
+                            Файл: <strong>{{ filename }}</strong>
+                        {% endif %}
+                        {% if selectedAccount %}
+                            · Счёт: <strong>{{ selectedAccount.name }}</strong>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="container-xl mt-3">
+        <div class="row g-3">
+            <div class="col-12 col-lg-6">
+                <div class="card h-100">
+                    <div class="card-header">
+                        <h3 class="card-title mb-0">Итоги обработки</h3>
+                    </div>
+                    <ul class="list-group list-group-flush">
+                        <li class="list-group-item d-flex justify-content-between">
+                            <span>Создано операций</span>
+                            <span class="fw-bold text-success">{{ summary.created ?? 0 }}</span>
+                        </li>
+                        <li class="list-group-item d-flex justify-content-between">
+                            <span>Найдено дублей</span>
+                            <span class="fw-bold text-warning">{{ summary.duplicates ?? 0 }}</span>
+                        </li>
+                        <li class="list-group-item d-flex justify-content-between">
+                            <span>Ошибок</span>
+                            <span class="fw-bold text-danger">{{ summary.errors ?? 0 }}</span>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <div class="col-12 col-lg-6">
+                <div class="card h-100">
+                    <div class="card-header">
+                        <h3 class="card-title mb-0">Диапазон дат</h3>
+                    </div>
+                    <ul class="list-group list-group-flush">
+                        <li class="list-group-item d-flex justify-content-between">
+                            <span>Минимальная дата</span>
+                            <span class="fw-bold">{{ summary.minDate ? summary.minDate|date('d.m.Y') : '—' }}</span>
+                        </li>
+                        <li class="list-group-item d-flex justify-content-between">
+                            <span>Максимальная дата</span>
+                            <span class="fw-bold">{{ summary.maxDate ? summary.maxDate|date('d.m.Y') : '—' }}</span>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+        <div class="card mt-3">
+            <div class="card-body d-flex justify-content-between flex-column flex-md-row gap-2">
+                <a href="{{ path('cash_bank1c_import_upload') }}" class="btn btn-outline-secondary">Импортировать ещё файл</a>
+                <a href="{{ path('cash_transaction_index') }}" class="btn btn-primary">Перейти к операциям</a>
+            </div>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- process uploaded Client Bank 1C files through the service to build preview data, store it in session and paginate 100 rows per page
- validate the statement account against the selected account and call the import service from the commit action with the overwrite option
- refresh the preview table layout and add a dedicated results screen with created/duplicate/error counters and date range

## Testing
- composer cs:check *(fails: php-cs-fixer not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2d99851308323aa43b75af6062b14