### PR TITLE
chore(import): monolog import.bank1c + trigger recalc

### DIFF
--- a/site/config/packages/monolog.yaml
+++ b/site/config/packages/monolog.yaml
@@ -1,6 +1,8 @@
 monolog:
     channels:
         - deprecation # Deprecations are logged in the dedicated "deprecation" channel when it exists
+        - import.bank1c
+        - recalc
 
 when@dev:
     monolog:


### PR DESCRIPTION
## Summary
- add dedicated Monolog channels for the bank import and balance recalculation logs
- persist bank statement period metadata during 1C import and forward it for structured logging
- log import start/finish and trigger balance recalculation from the earliest new transaction through today

## Testing
- php -l site/src/Service/AccountBalanceService.php

------
https://chatgpt.com/codex/tasks/task_e_68d36f841f388323ab5562793117b0e0