### PR TITLE
Add import regression tests for parser and idempotency

### DIFF
--- a/site/tests/Controller/Cash/AccountStrictMatchTest.php
+++ b/site/tests/Controller/Cash/AccountStrictMatchTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Tests\Controller\Cash;
+
+use App\Entity\Company;
+use App\Entity\MoneyAccount;
+use App\Entity\User;
+use App\Enum\MoneyAccountType;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class AccountStrictMatchTest extends WebTestCase
+{
+    public function testPreviewStopsWhenStatementAccountDiffersFromSelectedAccount(): void
+    {
+        $client = static::createClient();
+        $container = static::getContainer();
+        $em = $container->get('doctrine.orm.entity_manager');
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $em->createQuery('DELETE FROM App\\Entity\\CashTransaction t')->execute();
+        $em->createQuery('DELETE FROM App\\Entity\\Counterparty c')->execute();
+        $em->createQuery('DELETE FROM App\\Entity\\MoneyAccount a')->execute();
+        $em->createQuery('DELETE FROM App\\Entity\\Company c')->execute();
+        $em->createQuery('DELETE FROM App\\Entity\\User u')->execute();
+
+        $user = new User(Uuid::uuid4()->toString());
+        $user->setEmail('bank-import@example.com');
+        $user->setPassword($hasher->hashPassword($user, 'password'));
+
+        $company = new Company(Uuid::uuid4()->toString(), $user);
+        $company->setName('BankImport');
+
+        $account = new MoneyAccount(Uuid::uuid4()->toString(), $company, MoneyAccountType::BANK, 'Основной счёт', 'RUB');
+        $account->setAccountNumber('40702810900000000001');
+
+        $em->persist($user);
+        $em->persist($company);
+        $em->persist($account);
+        $em->flush();
+
+        $client->loginUser($user);
+        $session = $container->get('session');
+        $session->set('active_company_id', $company->getId());
+        $session->save();
+
+        $csrfManager = $container->get('security.csrf.token_manager');
+        $token = $csrfManager->getToken('bank1c_import_upload')->getValue();
+
+        $utf8Content = <<<TXT
+1CClientBankExchange
+РасчСчет=40702810900000000002
+ДатаНачала=01.01.2024
+ДатаКонца=31.01.2024
+КонецФайла
+TXT;
+        $cpContent = mb_convert_encoding($utf8Content, 'CP1251', 'UTF-8');
+        $tmpFile = tempnam(sys_get_temp_dir(), 'bank1c');
+        file_put_contents($tmpFile, $cpContent);
+
+        $uploadedFile = new UploadedFile($tmpFile, 'statement.txt', 'text/plain', null, true);
+
+        $client->request('POST', '/cash/import/bank1c/preview', [
+            'money_account_id' => $account->getId(),
+            '_token' => $token,
+        ], [
+            'import_file' => $uploadedFile,
+        ]);
+
+        self::assertTrue($client->getResponse()->isRedirect('/cash/import/bank1c'));
+
+        $responseSession = $client->getRequest()->getSession();
+        $flashes = $responseSession->getFlashBag()->peek('danger');
+        self::assertNotEmpty($flashes);
+        self::assertStringContainsString('Выбран неверный банк или выписка', $flashes[0]);
+        self::assertFalse($responseSession->has('bank1c_import'));
+
+        @unlink($tmpFile);
+    }
+}

--- a/site/tests/Service/Import/ClientBank1CImportServiceTestCase.php
+++ b/site/tests/Service/Import/ClientBank1CImportServiceTestCase.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace App\Tests\Service\Import;
+
+use App\Entity\CashTransaction;
+use App\Entity\Company;
+use App\Entity\Counterparty;
+use App\Entity\MoneyAccount;
+use App\Entity\User;
+use App\Enum\MoneyAccountType;
+use App\Repository\CashTransactionRepository;
+use App\Repository\CounterpartyRepository;
+use App\Service\AccountBalanceService;
+use App\Service\ActiveCompanyService;
+use App\Service\Import\ClientBank1CImportService;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\ORM\Tools\Setup;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+abstract class ClientBank1CImportServiceTestCase extends TestCase
+{
+    protected EntityManager $em;
+    protected ClientBank1CImportService $service;
+    protected CashTransactionRepository $transactionRepository;
+    protected CounterpartyRepository $counterpartyRepository;
+    protected MoneyAccount $account;
+    protected Company $company;
+    /** @var AccountBalanceService&MockObject */
+    protected AccountBalanceService $accountBalanceService;
+
+    protected function setUp(): void
+    {
+        $config = Setup::createAttributeMetadataConfiguration([__DIR__ . '/../../../src/Entity'], true);
+        $this->em = EntityManager::create(['driver' => 'pdo_sqlite', 'memory' => true], $config);
+
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->createSchema([
+            $this->em->getClassMetadata(User::class),
+            $this->em->getClassMetadata(Company::class),
+            $this->em->getClassMetadata(MoneyAccount::class),
+            $this->em->getClassMetadata(CashTransaction::class),
+            $this->em->getClassMetadata(Counterparty::class),
+        ]);
+
+        $registry = new SimpleManagerRegistry($this->em);
+        $this->transactionRepository = new CashTransactionRepository($registry);
+        $this->counterpartyRepository = new CounterpartyRepository($registry);
+        $this->accountBalanceService = $this->createMock(AccountBalanceService::class);
+
+        $user = new User(Uuid::uuid4()->toString());
+        $user->setEmail('import@example.com');
+        $user->setPassword('password');
+
+        $this->company = new Company(Uuid::uuid4()->toString(), $user);
+        $this->company->setName('Test Company');
+
+        $this->account = new MoneyAccount(Uuid::uuid4()->toString(), $this->company, MoneyAccountType::BANK, 'Main account', 'RUB');
+        $this->account->setAccountNumber('40702810900000000001');
+
+        $this->em->persist($user);
+        $this->em->persist($this->company);
+        $this->em->persist($this->account);
+        $this->em->flush();
+
+        $activeCompanyService = new StubActiveCompanyService($this->company);
+
+        $this->service = new ClientBank1CImportService(
+            $activeCompanyService,
+            $this->counterpartyRepository,
+            $this->transactionRepository,
+            $this->em,
+            $this->accountBalanceService,
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->em)) {
+            $this->em->close();
+        }
+
+        parent::tearDown();
+    }
+}
+
+class SimpleManagerRegistry implements ManagerRegistry
+{
+    public function __construct(private EntityManager $em)
+    {
+    }
+
+    public function getDefaultConnectionName()
+    {
+        return 'default';
+    }
+
+    public function getConnection($name = null)
+    {
+        return $this->em->getConnection();
+    }
+
+    public function getConnections()
+    {
+        return [$this->em->getConnection()];
+    }
+
+    public function getConnectionNames()
+    {
+        return ['default'];
+    }
+
+    public function getDefaultManagerName()
+    {
+        return 'default';
+    }
+
+    public function getManager($name = null)
+    {
+        return $this->em;
+    }
+
+    public function getManagers()
+    {
+        return ['default' => $this->em];
+    }
+
+    public function resetManager($name = null)
+    {
+        return $this->em;
+    }
+
+    public function getAliasNamespace($alias)
+    {
+        return 'App\\Entity';
+    }
+
+    public function getManagerNames()
+    {
+        return ['default'];
+    }
+
+    public function getRepository($persistentObject, $persistentManagerName = null)
+    {
+        return $this->em->getRepository($persistentObject);
+    }
+
+    public function getManagerForClass($class)
+    {
+        return $this->em;
+    }
+}
+
+class StubActiveCompanyService extends ActiveCompanyService
+{
+    public function __construct(private Company $company)
+    {
+    }
+
+    public function getActiveCompany(): Company
+    {
+        return $this->company;
+    }
+}

--- a/site/tests/Service/Import/IdempotencyTest.php
+++ b/site/tests/Service/Import/IdempotencyTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Tests\Service\Import;
+
+class IdempotencyTest extends ClientBank1CImportServiceTestCase
+{
+    public function testRepeatedImportCountsDuplicatesAndSupportsOverwrite(): void
+    {
+        $row = [
+            'docType' => 'Платежное поручение',
+            'docNumber' => 'INV-1',
+            'docDate' => '2024-01-05',
+            'amount' => 1500.25,
+            'payerName' => 'ООО Плательщик',
+            'payerInn' => '7701000000',
+            'payerAccount' => '40702810900000000003',
+            'receiverName' => 'ООО Получатель',
+            'receiverInn' => '7712000000',
+            'receiverAccount' => '40702810900000000004',
+            'dateDebit' => '2024-01-05',
+            'dateCredit' => null,
+            'purpose' => 'Оплата по договору',
+            'direction' => 'outflow',
+        ];
+
+        $summaryFirst = $this->service->import([$row], $this->account, false);
+        self::assertSame(1, $summaryFirst['created']);
+        self::assertSame(0, $summaryFirst['duplicates']);
+        self::assertSame(0, $summaryFirst['errors']);
+
+        $summarySecond = $this->service->import([$row], $this->account, false);
+        self::assertSame(0, $summarySecond['created']);
+        self::assertSame(1, $summarySecond['duplicates']);
+        self::assertSame(0, $summarySecond['errors']);
+
+        $rowUpdated = $row;
+        $rowUpdated['purpose'] = 'Обновлённое назначение';
+
+        $summaryOverwrite = $this->service->import([$rowUpdated], $this->account, true);
+        self::assertSame(0, $summaryOverwrite['created']);
+        self::assertSame(1, $summaryOverwrite['duplicates']);
+        self::assertSame(0, $summaryOverwrite['errors']);
+
+        $transactions = $this->transactionRepository->findAll();
+        self::assertCount(1, $transactions);
+        self::assertSame('Обновлённое назначение', $transactions[0]->getDescription());
+    }
+}

--- a/site/tests/Service/Import/InternalTransferTest.php
+++ b/site/tests/Service/Import/InternalTransferTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Tests\Service\Import;
+
+class InternalTransferTest extends ClientBank1CImportServiceTestCase
+{
+    public function testKeywordBasedTransferMarksTransactionAndSkipsCounterparty(): void
+    {
+        $row = [
+            'docType' => 'Платежное поручение',
+            'docNumber' => 'TR-1',
+            'docDate' => '2024-02-01',
+            'amount' => 2500,
+            'payerName' => 'ООО Источник',
+            'payerInn' => '7701999999',
+            'payerAccount' => '40702810900000000001',
+            'receiverName' => 'ООО Получатель',
+            'receiverInn' => '7712888888',
+            'receiverAccount' => '40702810900000000002',
+            'dateDebit' => '2024-02-02',
+            'dateCredit' => null,
+            'purpose' => 'Перевод средств между счетами компании',
+            'direction' => 'self-transfer',
+        ];
+
+        $summary = $this->service->import([$row], $this->account, false);
+        self::assertSame(1, $summary['created']);
+        self::assertSame(0, $summary['duplicates']);
+
+        $transactions = $this->transactionRepository->findAll();
+        self::assertCount(1, $transactions);
+
+        $transaction = $transactions[0];
+        self::assertTrue($transaction->isTransfer());
+        self::assertNull($transaction->getCounterparty());
+    }
+}

--- a/site/tests/Service/Import/ParserTest.php
+++ b/site/tests/Service/Import/ParserTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Tests\Service\Import;
+
+class ParserTest extends ClientBank1CImportServiceTestCase
+{
+    public function testParseHeaderAndDocuments(): void
+    {
+        $content = <<<TXT
+1CClientBankExchange
+ВерсияФормата=1.02
+РасчСчет=40702810900000000002
+СекцияДокумент=Платежное поручение
+Номер=123
+Дата=01.02.2024
+Сумма=1000.50
+КонецДокумента
+КонецФайла
+TXT;
+
+        $parsed = $this->service->parseHeaderAndDocuments($content);
+
+        self::assertArrayHasKey('header', $parsed);
+        self::assertArrayHasKey('documents', $parsed);
+        self::assertSame('1.02', $parsed['header']['ВерсияФормата']);
+        self::assertSame('40702810900000000002', $parsed['header']['РасчСчет']);
+        self::assertCount(1, $parsed['documents']);
+
+        $document = $parsed['documents'][0];
+        self::assertSame('Платежное поручение', $document['_doc_type']);
+        self::assertSame('123', $document['Номер']);
+        self::assertSame('01.02.2024', $document['Дата']);
+        self::assertSame('1000.50', $document['Сумма']);
+    }
+}

--- a/site/tests/Service/Import/SignAndDateTest.php
+++ b/site/tests/Service/Import/SignAndDateTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Tests\Service\Import;
+
+class SignAndDateTest extends ClientBank1CImportServiceTestCase
+{
+    public function testDirectionDeterminesAmountSignAndDates(): void
+    {
+        $rows = [
+            [
+                'docType' => 'Платежное поручение',
+                'docNumber' => 'OUT-1',
+                'docDate' => '2024-03-05',
+                'amount' => 150,
+                'payerAccount' => '40702810900000000001',
+                'receiverAccount' => '40702810900000000010',
+                'dateDebit' => '2024-03-10',
+                'dateCredit' => null,
+                'purpose' => 'Оплата поставщику',
+                'direction' => 'outflow',
+            ],
+            [
+                'docType' => 'Платёжное поручение',
+                'docNumber' => 'IN-1',
+                'docDate' => '2024-03-07',
+                'amount' => 200,
+                'payerAccount' => '40702810900000000020',
+                'receiverAccount' => '40702810900000000001',
+                'dateDebit' => null,
+                'dateCredit' => '2024-03-11',
+                'purpose' => 'Оплата покупателя',
+                'direction' => 'inflow',
+            ],
+            [
+                'docType' => 'Платёжное поручение',
+                'docNumber' => 'OUT-2',
+                'docDate' => '2024-03-15',
+                'amount' => 300,
+                'payerAccount' => '40702810900000000001',
+                'receiverAccount' => '40702810900000000030',
+                'dateDebit' => null,
+                'dateCredit' => null,
+                'purpose' => 'Оплата услуг',
+                'direction' => 'outflow',
+            ],
+        ];
+
+        $summary = $this->service->import($rows, $this->account, false);
+        self::assertSame(3, $summary['created']);
+        self::assertSame(0, $summary['errors']);
+
+        $transactions = $this->transactionRepository->findAll();
+        self::assertCount(3, $transactions);
+
+        $byNumber = [];
+        foreach ($transactions as $transaction) {
+            $byNumber[$transaction->getDocNumber()] = $transaction;
+        }
+
+        self::assertSame('-150.00', $byNumber['OUT-1']->getAmount());
+        self::assertSame('2024-03-10', $byNumber['OUT-1']->getOccurredAt()->format('Y-m-d'));
+
+        self::assertSame('200.00', $byNumber['IN-1']->getAmount());
+        self::assertSame('2024-03-11', $byNumber['IN-1']->getOccurredAt()->format('Y-m-d'));
+
+        self::assertSame('-300.00', $byNumber['OUT-2']->getAmount());
+        self::assertSame('2024-03-15', $byNumber['OUT-2']->getOccurredAt()->format('Y-m-d'));
+    }
+}


### PR DESCRIPTION
## Summary
- add an SQLite-backed ClientBank1CImportServiceTestCase to share Doctrine setup for import tests
- cover parser behaviour, duplicate handling, transfer detection and sign/date calculation with dedicated test cases
- verify the Bank1C preview controller blocks statements with mismatched account numbers

## Testing
- `bin/phpunit` *(fails: phpunit bridge not installed without Composer dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d384ecfa148323a45b501664b0d30b