### PR TITLE
Add Import 1C button to transaction list

### DIFF
--- a/site/templates/transaction/index.html.twig
+++ b/site/templates/transaction/index.html.twig
@@ -16,6 +16,12 @@
     <h2 class="page-title">Транзакции (ДДС)</h2>
     <div class="ms-auto d-print-none">
         <a href="{{ path('cash_transaction_new') }}" class="btn btn-primary">Добавить</a>
+        <a href="/cash/import/bank1c"
+           class="btn btn-primary"
+           data-testid="btn-import-1c">
+            <i class="ti ti-upload me-1"></i>
+            Импорт 1С
+        </a>
         <a href="#" class="btn btn-outline-secondary">Экспорт</a>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- add an "Импорт 1С" action button in the cash transaction list header linking to /cash/import/bank1c

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d387c9ef0c8323956bd1a110b62310