### PR TITLE
Handle UTF-8 bank statement imports

### DIFF
--- a/site/tests/Controller/Cash/AccountStrictMatchTest.php
+++ b/site/tests/Controller/Cash/AccountStrictMatchTest.php
@@ -79,4 +79,82 @@ TXT;
 
         @unlink($tmpFile);
     }
+
+    public function testPreviewWorksWithUtf8EncodedFile(): void
+    {
+        $client = static::createClient();
+        $container = static::getContainer();
+        $em = $container->get('doctrine.orm.entity_manager');
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $em->createQuery('DELETE FROM App\\Entity\\CashTransaction t')->execute();
+        $em->createQuery('DELETE FROM App\\Entity\\Counterparty c')->execute();
+        $em->createQuery('DELETE FROM App\\Entity\\MoneyAccount a')->execute();
+        $em->createQuery('DELETE FROM App\\Entity\\Company c')->execute();
+        $em->createQuery('DELETE FROM App\\Entity\\User u')->execute();
+
+        $user = new User(Uuid::uuid4()->toString());
+        $user->setEmail('bank-import-utf8@example.com');
+        $user->setPassword($hasher->hashPassword($user, 'password'));
+
+        $company = new Company(Uuid::uuid4()->toString(), $user);
+        $company->setName('BankImportUTF8');
+
+        $account = new MoneyAccount(Uuid::uuid4()->toString(), $company, MoneyAccountType::BANK, 'Основной счёт', 'RUB');
+        $account->setAccountNumber('40702810900000000001');
+
+        $em->persist($user);
+        $em->persist($company);
+        $em->persist($account);
+        $em->flush();
+
+        $client->loginUser($user);
+        $session = $container->get('session');
+        $session->set('active_company_id', $company->getId());
+        $session->save();
+
+        $csrfManager = $container->get('security.csrf.token_manager');
+        $token = $csrfManager->getToken('bank1c_import_upload')->getValue();
+
+        $utf8Content = <<<TXT
+1CClientBankExchange
+РасчСчет=40702810900000000001
+ДатаНачала=01.01.2024
+ДатаКонца=31.01.2024
+СекцияДокумент=Платежное поручение
+Номер=1
+Дата=15.01.2024
+Сумма=1000.00
+Плательщик=ООО «Тест»
+ПлательщикИНН=1234567890
+ПлательщикСчет=40702810900000000001
+Получатель=ООО «Поставщик»
+ПолучательИНН=0987654321
+ПолучательСчет=40702810900000000002
+ДатаСписано=15.01.2024
+НазначениеПлатежа=Оплата услуг
+КонецДокумента
+КонецФайла
+TXT;
+
+        $tmpFile = tempnam(sys_get_temp_dir(), 'bank1c');
+        file_put_contents($tmpFile, $utf8Content);
+
+        $uploadedFile = new UploadedFile($tmpFile, 'statement_utf8.txt', 'text/plain', null, true);
+
+        $client->request('POST', '/cash/import/bank1c/preview', [
+            'money_account_id' => $account->getId(),
+            '_token' => $token,
+        ], [
+            'import_file' => $uploadedFile,
+        ]);
+
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('Предпросмотр импорта банковской выписки 1С', $client->getResponse()->getContent());
+
+        $responseSession = $client->getRequest()->getSession();
+        self::assertTrue($responseSession->has('bank1c_import'));
+
+        @unlink($tmpFile);
+    }
 }


### PR DESCRIPTION
## Summary
- detect the source encoding of uploaded 1C bank statements and convert to UTF-8 only when needed
- strip UTF-8 BOM markers so parsed headers match expected keys
- cover the UTF-8 flow with a functional controller test

## Testing
- not run (phpunit unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d38f388b148323b92449be2b6c9895