### PR TITLE
Fix flash alert display

### DIFF
--- a/site/templates/partials/_flash.html.twig
+++ b/site/templates/partials/_flash.html.twig
@@ -1,6 +1,13 @@
-{% for label in ['success', 'error', 'notice', 'danger'] %}
-    {% for message in app.flashes(label) %}
-        <div class="alert alert-{{ label == 'error' ? 'danger' : (label == 'notice' ? 'info' : label) }} alert-dismissible" role="alert">
+{% set labelClassMap = {
+    'error': 'danger',
+    'notice': 'info',
+    'alert': 'warning',
+} %}
+
+{% for label, messages in app.flashes %}
+    {% set bootstrapLabel = labelClassMap[label]|default(label) %}
+    {% for message in messages %}
+        <div class="alert alert-{{ bootstrapLabel }} alert-dismissible" role="alert">
             {{ message }}
             <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
         </div>


### PR DESCRIPTION
## Summary
- render flash messages for all labels and map them to Bootstrap alert classes
- add explicit support for the `alert` flash label to ensure it is shown

## Testing
- composer cs:twig *(fails: twigcs binary is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d415cde3a483238ea0450dd046c204