### PR TITLE
Add finance lock date field to company form

### DIFF
--- a/site/src/Form/CompanyType.php
+++ b/site/src/Form/CompanyType.php
@@ -4,6 +4,7 @@ namespace App\Form;
 
 use App\Entity\Company;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -32,6 +33,12 @@ class CompanyType extends AbstractType
             ->add('ozonApiKey', TextType::class, [
                 'label' => 'Ozon API ключ',
                 'required' => false,
+            ])
+            ->add('financeLockBefore', DateType::class, [
+                'widget' => 'single_text',
+                'required' => false,
+                'label' => 'Дата запрета редактирования',
+                'attr' => ['class' => 'form-control'],
             ]);
     }
 

--- a/site/templates/company/edit.html.twig
+++ b/site/templates/company/edit.html.twig
@@ -31,6 +31,9 @@
                     {{ form_widget(form.ozonApiKey, {'attr': {'class': 'form-control'}}) }}
                     {{ form_errors(form.ozonApiKey) }}
                 </div>
+                <div class="mb-3">
+                    {{ form_row(form.financeLockBefore) }}
+                </div>
                 <button class="btn btn-primary">{{ company is defined ? 'Сохранить' : 'Создать' }}</button>
                 <a href="{{ path('company_index') }}" class="btn btn-secondary">Назад</a>
                 {{ form_end(form) }}

--- a/site/templates/company/new.html.twig
+++ b/site/templates/company/new.html.twig
@@ -31,6 +31,9 @@
                     {{ form_widget(form.ozonApiKey, {'attr': {'class': 'form-control'}}) }}
                     {{ form_errors(form.ozonApiKey) }}
                 </div>
+                <div class="mb-3">
+                    {{ form_row(form.financeLockBefore) }}
+                </div>
                 <button class="btn btn-primary">{{ company is defined ? 'Сохранить' : 'Создать' }}</button>
                 <a href="{{ path('company_index') }}" class="btn btn-secondary">Назад</a>
                 {{ form_end(form) }}


### PR DESCRIPTION
## Summary
- add the finance lock date field to the company form using a single-date widget
- render the finance lock date input in the company create and edit templates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9637d1e548323b853af41d0f80062