### PR TITLE
Remove negative prefix for outflow amounts in bank import

### DIFF
--- a/site/src/Service/Import/ClientBank1CImportService.php
+++ b/site/src/Service/Import/ClientBank1CImportService.php
@@ -415,9 +415,6 @@ class ClientBank1CImportService
             return null;
         }
         $amount = number_format(abs((float) $rawAmount), 2, '.', '');
-        if (CashDirection::OUTFLOW === $direction) {
-            $amount = '-'.$amount;
-        }
 
         return $amount;
     }


### PR DESCRIPTION
## Summary
- stop prefixing outflow amounts with a minus sign when resolving imported amounts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbc9b4dcc083239068346af62797ac