### PR TITLE
Add DocumentType enum and migrate document types

### DIFF
--- a/site/migrations/Version20250929120000.php
+++ b/site/migrations/Version20250929120000.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use App\Enum\DocumentType;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250929120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Normalize document type values to DocumentType enum and add supporting index/check';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->normalizeTypes();
+
+        if ('postgresql' === $this->connection->getDatabasePlatform()->getName()) {
+            $this->addSql(<<<'SQL'
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'documents_type_enum_check'
+    ) THEN
+        ALTER TABLE documents
+            ADD CONSTRAINT documents_type_enum_check CHECK (type IN (
+                'SALES_INVOICE',
+                'DELIVERY_NOTE',
+                'SERVICE_ACT',
+                'COMMISSION_REPORT',
+                'MARKETPLACE_REPORT',
+                'CASH_RECEIPT',
+                'SUPPLIER_INVOICE',
+                'MATERIAL_WRITE_OFF_ACT',
+                'MANUFACTURING_ACT',
+                'COST_ALLOCATION',
+                'AD_ACT',
+                'RENT_ACT',
+                'UTILITIES_ACT',
+                'BANK_FEES_ACT',
+                'PAYROLL_SHEET',
+                'ADVANCE_REPORT',
+                'BANK_STATEMENT',
+                'LOAN_INTEREST_STATEMENT',
+                'FX_REVALUATION_ACT',
+                'OTHER'
+            ));
+    END IF;
+END $$;
+SQL);
+        }
+
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_documents_company_type_date ON documents (company_id, type, date DESC)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        if ('postgresql' === $this->connection->getDatabasePlatform()->getName()) {
+            $this->addSql(<<<'SQL'
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'documents_type_enum_check'
+    ) THEN
+        ALTER TABLE documents DROP CONSTRAINT documents_type_enum_check;
+    END IF;
+END $$;
+SQL);
+        }
+
+        $this->addSql('DROP INDEX IF EXISTS idx_documents_company_type_date');
+    }
+
+    private function normalizeTypes(): void
+    {
+        $rows = $this->connection->fetchAllAssociative('SELECT id, type FROM documents');
+
+        foreach ($rows as $row) {
+            $current = $row['type'];
+            $normalized = $current === null || '' === trim((string) $current)
+                ? DocumentType::OTHER->value
+                : DocumentType::fromLegacy((string) $current)->value;
+
+            if ($normalized !== $current) {
+                $this->connection->update('documents', ['type' => $normalized], ['id' => $row['id']]);
+            }
+        }
+    }
+}

--- a/site/src/Entity/Document.php
+++ b/site/src/Entity/Document.php
@@ -2,10 +2,12 @@
 
 namespace App\Entity;
 
+use App\Enum\DocumentType;
 use App\Repository\DocumentRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as AssertConstraints;
 use Webmozart\Assert\Assert;
 
 #[ORM\Entity(repositoryClass: DocumentRepository::class)]
@@ -26,8 +28,9 @@ class Document
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $number = null;
 
-    #[ORM\Column(length: 255)]
-    private string $type;
+    #[ORM\Column(enumType: DocumentType::class)]
+    #[AssertConstraints\NotNull]
+    private DocumentType $type;
 
     #[ORM\Column(type: 'text', nullable: true)]
     private ?string $description = null;
@@ -42,6 +45,7 @@ class Document
         $this->company = $company;
         $this->date = new \DateTimeImmutable();
         $this->operations = new ArrayCollection();
+        $this->type = DocumentType::OTHER;
     }
 
     public function getId(): ?string
@@ -85,14 +89,27 @@ class Document
         return $this;
     }
 
-    public function getType(): string
+    public function getType(): DocumentType
     {
         return $this->type;
     }
 
-    public function setType(string $type): self
+    public function setType(DocumentType $type): self
     {
         $this->type = $type;
+
+        return $this;
+    }
+
+    public function getTypeValue(): string
+    {
+        return $this->type->value;
+    }
+
+    /** @deprecated временно для миграций/старых вызовов */
+    public function setTypeFromString(string $legacy): self
+    {
+        $this->type = DocumentType::fromLegacy($legacy);
 
         return $this;
     }

--- a/site/src/Enum/DocumentType.php
+++ b/site/src/Enum/DocumentType.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+enum DocumentType: string
+{
+    // Доходы
+    case SALES_INVOICE = 'SALES_INVOICE';            // Счет-фактура/реализация
+    case DELIVERY_NOTE = 'DELIVERY_NOTE';            // Накладная / УПД
+    case SERVICE_ACT = 'SERVICE_ACT';                // Акт выполненных работ
+    case COMMISSION_REPORT = 'COMMISSION_REPORT';    // Отчет комиссионера/агента
+    case MARKETPLACE_REPORT = 'MARKETPLACE_REPORT';  // Отчет маркетплейса
+    case CASH_RECEIPT = 'CASH_RECEIPT';              // ККТ чек (прямые продажи)
+
+    // Закупки/COGS
+    case SUPPLIER_INVOICE = 'SUPPLIER_INVOICE';      // Счет/сф от поставщика
+    case MATERIAL_WRITE_OFF_ACT = 'MATERIAL_WRITE_OFF_ACT';
+    case MANUFACTURING_ACT = 'MANUFACTURING_ACT';    // Акт подрядчика (пошив)
+    case COST_ALLOCATION = 'COST_ALLOCATION';        // Калькуляция/распределение
+
+    // OPEX
+    case AD_ACT = 'AD_ACT';                          // Реклама/инфлюенсеры
+    case RENT_ACT = 'RENT_ACT';
+    case UTILITIES_ACT = 'UTILITIES_ACT';            // Коммуналка/связь/интернет
+    case BANK_FEES_ACT = 'BANK_FEES_ACT';            // Банковские комиссии
+    case PAYROLL_SHEET = 'PAYROLL_SHEET';
+    case ADVANCE_REPORT = 'ADVANCE_REPORT';
+
+    // Финансовые
+    case BANK_STATEMENT = 'BANK_STATEMENT';
+    case LOAN_INTEREST_STATEMENT = 'LOAN_INTEREST_STATEMENT';
+    case FX_REVALUATION_ACT = 'FX_REVALUATION_ACT';
+
+    // Прочее
+    case OTHER = 'OTHER';
+
+    public static function fromLegacy(string $value): self
+    {
+        $v = strtoupper(trim($value));
+
+        return match ($v) {
+            'НАКЛАДНАЯ', 'ТОРГ-12', 'УПД' => self::DELIVERY_NOTE,
+            'ОТЧЕТ КОМИССИОНЕРА', 'ОТЧЕТ АГЕНТА' => self::COMMISSION_REPORT,
+            'ОТЧЕТ МАРКЕТПЛЕЙСА', 'WB', 'OZON', 'YANDEX' => self::MARKETPLACE_REPORT,
+            'АКТ', 'АКТ ВЫПОЛНЕННЫХ РАБОТ' => self::SERVICE_ACT,
+            'СЧЕТ-ФАКТУРА', 'РЕАЛИЗАЦИЯ' => self::SALES_INVOICE,
+            'СЧЕТ ПОСТАВЩИКА', 'СФ ПОСТАВЩИКА' => self::SUPPLIER_INVOICE,
+            'АКТ ПОДРЯДЧИКА', 'ПОШИВ' => self::MANUFACTURING_ACT,
+            'СПИСАНИЕ МАТЕРИАЛОВ' => self::MATERIAL_WRITE_OFF_ACT,
+            'КАЛЬКУЛЯЦИЯ', 'РАСПРЕДЕЛЕНИЕ ЗАТРАТ' => self::COST_ALLOCATION,
+            'РЕКЛАМА', 'АКТ РЕКЛАМЫ' => self::AD_ACT,
+            'АРЕНДА' => self::RENT_ACT,
+            'КОММУНАЛЬНЫЕ', 'СВЯЗЬ', 'ИНТЕРНЕТ' => self::UTILITIES_ACT,
+            'КОМИССИЯ БАНКА' => self::BANK_FEES_ACT,
+            'ВЕДОМОСТЬ ЗП', 'ЗАРПЛАТА' => self::PAYROLL_SHEET,
+            'АВАНСОВЫЙ ОТЧЕТ' => self::ADVANCE_REPORT,
+            'ВЫПИСКА БАНКА' => self::BANK_STATEMENT,
+            'ПРОЦЕНТЫ ПО КРЕДИТУ' => self::LOAN_INTEREST_STATEMENT,
+            'КУРСОВЫЕ РАЗНИЦЫ' => self::FX_REVALUATION_ACT,
+            'ЧЕК', 'ККТ' => self::CASH_RECEIPT,
+            default => self::OTHER,
+        };
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::SALES_INVOICE => 'Счет-фактура / Реализация',
+            self::DELIVERY_NOTE => 'Накладная / УПД',
+            self::SERVICE_ACT => 'Акт выполненных работ',
+            self::COMMISSION_REPORT => 'Отчет комиссионера / агента',
+            self::MARKETPLACE_REPORT => 'Отчет маркетплейса',
+            self::CASH_RECEIPT => 'ККТ чек (прямые продажи)',
+            self::SUPPLIER_INVOICE => 'Счет поставщика',
+            self::MATERIAL_WRITE_OFF_ACT => 'Списание материалов',
+            self::MANUFACTURING_ACT => 'Акт подрядчика (пошив)',
+            self::COST_ALLOCATION => 'Калькуляция / распределение',
+            self::AD_ACT => 'Реклама / инфлюенсеры',
+            self::RENT_ACT => 'Аренда',
+            self::UTILITIES_ACT => 'Коммунальные / связь / интернет',
+            self::BANK_FEES_ACT => 'Банковские комиссии',
+            self::PAYROLL_SHEET => 'Ведомость зарплаты',
+            self::ADVANCE_REPORT => 'Авансовый отчет',
+            self::BANK_STATEMENT => 'Выписка банка',
+            self::LOAN_INTEREST_STATEMENT => 'Проценты по кредиту',
+            self::FX_REVALUATION_ACT => 'Курсовые разницы',
+            self::OTHER => 'Прочее',
+        };
+    }
+
+    /**
+     * @return array<string, self>
+     */
+    public static function choices(): array
+    {
+        $choices = [];
+        foreach (self::cases() as $case) {
+            $choices[$case->label()] = $case;
+        }
+
+        return $choices;
+    }
+}

--- a/site/src/Form/DocumentType.php
+++ b/site/src/Form/DocumentType.php
@@ -3,7 +3,9 @@
 namespace App\Form;
 
 use App\Entity\Document;
+use App\Enum\DocumentType as DocumentTypeEnum;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
@@ -24,8 +26,10 @@ class DocumentType extends AbstractType
                 'required' => false,
                 'label' => 'Номер',
             ])
-            ->add('type', TextType::class, [
+            ->add('type', ChoiceType::class, [
                 'label' => 'Тип',
+                'choices' => DocumentTypeEnum::choices(),
+                'choice_value' => static fn (?DocumentTypeEnum $type) => $type?->value,
             ])
             ->add('description', TextareaType::class, [
                 'required' => false,

--- a/site/src/Repository/DocumentRepository.php
+++ b/site/src/Repository/DocumentRepository.php
@@ -4,7 +4,9 @@ namespace App\Repository;
 
 use App\Entity\Company;
 use App\Entity\Document;
+use App\Enum\DocumentType;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Persistence\ManagerRegistry;
 
 class DocumentRepository extends ServiceEntityRepository
@@ -25,5 +27,46 @@ class DocumentRepository extends ServiceEntityRepository
             ->orderBy('d.date', 'DESC')
             ->getQuery()
             ->getResult();
+    }
+
+    /**
+     * @return Document[]
+     */
+    public function findByType(DocumentType $type, string $companyId, int $limit = 50): array
+    {
+        return $this->createQueryBuilder('d')
+            ->andWhere('IDENTITY(d.company) = :companyId')
+            ->andWhere('d.type = :type')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('type', $type->value)
+            ->orderBy('d.date', 'DESC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * @return array{count:int,sum:float}
+     */
+    public function aggregateByType(DocumentType $type, string $companyId, \DateTimeImmutable $from, \DateTimeImmutable $to): array
+    {
+        $result = $this->createQueryBuilder('d')
+            ->select('COUNT(DISTINCT d.id) AS doc_count')
+            ->addSelect('COALESCE(SUM(o.amount), 0) AS total_amount')
+            ->leftJoin('d.operations', 'o')
+            ->andWhere('IDENTITY(d.company) = :companyId')
+            ->andWhere('d.type = :type')
+            ->andWhere('d.date BETWEEN :from AND :to')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('type', $type->value)
+            ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
+            ->setParameter('to', $to, Types::DATETIME_IMMUTABLE)
+            ->getQuery()
+            ->getSingleResult();
+
+        return [
+            'count' => (int) ($result['doc_count'] ?? 0),
+            'sum' => (float) ($result['total_amount'] ?? 0.0),
+        ];
     }
 }

--- a/site/src/Serializer/DocumentTypeNormalizer.php
+++ b/site/src/Serializer/DocumentTypeNormalizer.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Serializer;
+
+use App\Enum\DocumentType;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
+use Symfony\Component\Serializer\Normalizer\ContextAwareDenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface;
+
+final class DocumentTypeNormalizer implements ContextAwareNormalizerInterface, ContextAwareDenormalizerInterface
+{
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof DocumentType;
+    }
+
+    public function normalize(mixed $object, ?string $format = null, array $context = []): string
+    {
+        \assert($object instanceof DocumentType);
+
+        return $object->value;
+    }
+
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return DocumentType::class === $type;
+    }
+
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): DocumentType
+    {
+        if (!\is_string($data) || '' === trim($data)) {
+            throw new NotNormalizableValueException('Document type must be a non-empty string.');
+        }
+
+        try {
+            return DocumentType::from($data);
+        } catch (\ValueError $e) {
+            throw new NotNormalizableValueException(sprintf('Unknown document type "%s".', $data), previous: $e);
+        }
+    }
+}

--- a/site/templates/document/index.html.twig
+++ b/site/templates/document/index.html.twig
@@ -30,7 +30,7 @@
                             <tr>
                                 <td>{{ item.date|date('Y-m-d H:i') }}</td>
                                 <td>{{ item.number }}</td>
-                                <td>{{ item.type }}</td>
+                                <td><span class="badge bg-blue-lt">{{ item.type.label }}</span></td>
                                 <td class="text-end">
                                     <a href="{{ path('document_show', {'id': item.id}) }}" class="btn btn-sm btn-info">👁</a>
                                     <a href="{{ path('document_edit', {'id': item.id}) }}" class="btn btn-sm btn-warning">✏️</a>

--- a/site/templates/document/show.html.twig
+++ b/site/templates/document/show.html.twig
@@ -3,7 +3,7 @@
 {% block body %}
     <div class="page-header d-print-none">
         <div class="container-xl">
-            <h2 class="page-title">Документ {{ item.type }}</h2>
+            <h2 class="page-title">Документ {{ item.type.label }}</h2>
         </div>
     </div>
     <div class="container-xl mt-3">
@@ -15,7 +15,7 @@
                     <dt class="col-sm-3">Номер</dt>
                     <dd class="col-sm-9">{{ item.number }}</dd>
                     <dt class="col-sm-3">Тип</dt>
-                    <dd class="col-sm-9">{{ item.type }}</dd>
+                    <dd class="col-sm-9"><span class="badge bg-blue-lt">{{ item.type.label }}</span></dd>
                     <dt class="col-sm-3">Описание</dt>
                     <dd class="col-sm-9">{{ item.description }}</dd>
                 </dl>

--- a/site/tests/Entity/DocumentTest.php
+++ b/site/tests/Entity/DocumentTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Entity;
+
+use App\Entity\Company;
+use App\Entity\Document;
+use App\Entity\User;
+use App\Enum\DocumentType;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+final class DocumentTest extends TestCase
+{
+    public function testDefaultTypeIsOther(): void
+    {
+        $document = $this->createDocument();
+
+        self::assertSame(DocumentType::OTHER, $document->getType());
+        self::assertSame('OTHER', $document->getTypeValue());
+    }
+
+    public function testSetTypeUpdatesValue(): void
+    {
+        $document = $this->createDocument();
+        $document->setType(DocumentType::AD_ACT);
+
+        self::assertSame(DocumentType::AD_ACT, $document->getType());
+        self::assertSame('AD_ACT', $document->getTypeValue());
+    }
+
+    private function createDocument(): Document
+    {
+        $user = new User(Uuid::uuid4()->toString());
+        $company = new Company(Uuid::uuid4()->toString(), $user);
+
+        return new Document(Uuid::uuid4()->toString(), $company);
+    }
+}

--- a/site/tests/Enum/DocumentTypeFromLegacyTest.php
+++ b/site/tests/Enum/DocumentTypeFromLegacyTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Enum;
+
+use App\Enum\DocumentType;
+use PHPUnit\Framework\TestCase;
+
+final class DocumentTypeFromLegacyTest extends TestCase
+{
+    public function testDeliveryNoteMapping(): void
+    {
+        self::assertSame(DocumentType::DELIVERY_NOTE, DocumentType::fromLegacy('Накладная'));
+    }
+
+    public function testMarketplaceReportMapping(): void
+    {
+        self::assertSame(DocumentType::MARKETPLACE_REPORT, DocumentType::fromLegacy('Отчет маркетплейса'));
+    }
+
+    public function testUnknownMappingFallsBackToOther(): void
+    {
+        self::assertSame(DocumentType::OTHER, DocumentType::fromLegacy('Неизвестная форма'));
+    }
+}


### PR DESCRIPTION
## Summary
- introduce the App\Enum\DocumentType backed enum with legacy mapping helpers and form labels
- persist Document entities with the enum, update forms/templates, and add serializer/repository helpers
- normalize existing data and add coverage for enum legacy mapping plus Document defaults

## Testing
- not run (composer install blocked by network restrictions)

------
https://chatgpt.com/codex/tasks/task_e_68dbce397dec8323b17b6fc7e6ad3c19