### PR TITLE
Implement PL nature resolver and UI badges

### DIFF
--- a/site/src/Controller/DocumentController.php
+++ b/site/src/Controller/DocumentController.php
@@ -3,11 +3,13 @@
 namespace App\Controller;
 
 use App\Entity\Document;
+use App\Enum\PlNature;
 use App\Form\DocumentType;
 use App\Repository\CounterpartyRepository;
 use App\Repository\DocumentRepository;
 use App\Repository\PLCategoryRepository;
 use App\Service\ActiveCompanyService;
+use App\Service\PlNatureResolver;
 use Doctrine\ORM\EntityManagerInterface;
 use Ramsey\Uuid\Uuid;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -19,13 +21,20 @@ use Symfony\Component\Routing\Attribute\Route;
 class DocumentController extends AbstractController
 {
     #[Route('/', name: 'document_index', methods: ['GET'])]
-    public function index(DocumentRepository $repo, ActiveCompanyService $companyService): Response
+    public function index(DocumentRepository $repo, ActiveCompanyService $companyService, PlNatureResolver $natureResolver): Response
     {
         $company = $companyService->getActiveCompany();
         $items = $repo->findByCompany($company);
 
+        $documentNatures = [];
+        foreach ($items as $item) {
+            $id = $item->getId() ?? spl_object_hash($item);
+            $documentNatures[$id] = $this->buildNatureView($natureResolver->forDocument($item));
+        }
+
         return $this->render('document/index.html.twig', [
             'items' => $items,
+            'documentNatures' => $documentNatures,
         ]);
     }
 
@@ -56,15 +65,34 @@ class DocumentController extends AbstractController
     }
 
     #[Route('/{id}', name: 'document_show', methods: ['GET'])]
-    public function show(Document $document, ActiveCompanyService $companyService): Response
+    public function show(Document $document, ActiveCompanyService $companyService, PlNatureResolver $natureResolver): Response
     {
         $company = $companyService->getActiveCompany();
         if ($document->getCompany() !== $company) {
             throw $this->createNotFoundException();
         }
 
+        $documentNature = $this->buildNatureView($natureResolver->forDocument($document));
+        $operationViews = [];
+        foreach ($document->getOperations() as $operation) {
+            $nature = $natureResolver->forOperation($operation);
+            $category = $operation->getPlCategory();
+            $natureValue = $nature?->value;
+            $operationViews[] = [
+                'operation' => $operation,
+                'categoryName' => $category?->getName(),
+                'nature' => $natureValue,
+                'natureLabel' => $natureValue === PlNature::INCOME->value ? 'Доход' : ($natureValue === PlNature::EXPENSE->value ? 'Расход' : null),
+                'badgeClass' => $natureValue === PlNature::INCOME->value ? 'bg-green-lt text-green' : ($natureValue === PlNature::EXPENSE->value ? 'bg-red-lt text-red' : ''),
+                'isFallback' => $category === null && $nature !== null,
+                'needsCategorization' => $category === null && $nature === null,
+            ];
+        }
+
         return $this->render('document/show.html.twig', [
             'item' => $document,
+            'documentNature' => $documentNature,
+            'operationViews' => $operationViews,
         ]);
     }
 
@@ -110,5 +138,33 @@ class DocumentController extends AbstractController
         }
 
         return $this->redirectToRoute('document_index');
+    }
+
+    /**
+     * @return array{value: string|null, label: string, badgeClass: string}
+     */
+    private function buildNatureView(PlNature|string|null $nature): array
+    {
+        if ($nature instanceof PlNature) {
+            return [
+                'value' => $nature->value,
+                'label' => $nature === PlNature::INCOME ? 'Доход' : 'Расход',
+                'badgeClass' => $nature === PlNature::INCOME ? 'bg-green-lt text-green' : 'bg-red-lt text-red',
+            ];
+        }
+
+        if ($nature === 'MIXED') {
+            return [
+                'value' => 'MIXED',
+                'label' => 'Mixed',
+                'badgeClass' => 'bg-purple-lt text-purple',
+            ];
+        }
+
+        return [
+            'value' => $nature ?? 'UNKNOWN',
+            'label' => 'Неизвестно',
+            'badgeClass' => 'bg-secondary',
+        ];
     }
 }

--- a/site/src/Entity/DocumentOperation.php
+++ b/site/src/Entity/DocumentOperation.php
@@ -68,6 +68,16 @@ class DocumentOperation
         return $this;
     }
 
+    public function getPlCategory(): ?PLCategory
+    {
+        return isset($this->category) ? $this->category : null;
+    }
+
+    public function setPlCategory(PLCategory $category): self
+    {
+        return $this->setCategory($category);
+    }
+
     public function getAmount(): string
     {
         return $this->amount;

--- a/site/src/Enum/PlNature.php
+++ b/site/src/Enum/PlNature.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+enum PlNature: string
+{
+    case INCOME = 'INCOME';
+    case EXPENSE = 'EXPENSE';
+
+    public function sign(): int
+    {
+        return $this === self::INCOME ? 1 : -1;
+    }
+}

--- a/site/src/Service/PlNatureResolver.php
+++ b/site/src/Service/PlNatureResolver.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\Document;
+use App\Entity\DocumentOperation;
+use App\Enum\DocumentType;
+use App\Enum\PlNature;
+
+final class PlNatureResolver
+{
+    public function forOperation(DocumentOperation $op): ?PlNature
+    {
+        $category = method_exists($op, 'getPlCategory')
+            ? $op->getPlCategory()
+            : (method_exists($op, 'getCategory') ? $op->getCategory() : null);
+
+        if ($category) {
+            return $category->nature();
+        }
+
+        $document = $op->getDocument();
+
+        return $document ? $this->byDocumentType($document->getType()) : null;
+    }
+
+    /**
+     * @return PlNature|string
+     */
+    public function forDocument(Document $doc): PlNature|string
+    {
+        $hasIncome = false;
+        $hasExpense = false;
+
+        foreach ($doc->getOperations() as $operation) {
+            $nature = $this->forOperation($operation);
+
+            if ($nature === PlNature::INCOME) {
+                $hasIncome = true;
+            }
+
+            if ($nature === PlNature::EXPENSE) {
+                $hasExpense = true;
+            }
+
+            if ($hasIncome && $hasExpense) {
+                return 'MIXED';
+            }
+        }
+
+        if (!$doc->getOperations()->count()) {
+            return $this->byDocumentType($doc->getType()) ?? 'UNKNOWN';
+        }
+
+        if (!$hasIncome && !$hasExpense) {
+            return 'UNKNOWN';
+        }
+
+        return $hasIncome ? PlNature::INCOME : PlNature::EXPENSE;
+    }
+
+    private function byDocumentType(DocumentType $type): ?PlNature
+    {
+        return match ($type) {
+            DocumentType::SALES_INVOICE,
+            DocumentType::DELIVERY_NOTE,
+            DocumentType::SERVICE_ACT,
+            DocumentType::COMMISSION_REPORT,
+            DocumentType::MARKETPLACE_REPORT,
+            DocumentType::CASH_RECEIPT,
+            DocumentType::BANK_STATEMENT,
+            DocumentType::FX_REVALUATION_ACT => PlNature::INCOME,
+
+            DocumentType::SUPPLIER_INVOICE,
+            DocumentType::MATERIAL_WRITE_OFF_ACT,
+            DocumentType::MANUFACTURING_ACT,
+            DocumentType::COST_ALLOCATION,
+            DocumentType::AD_ACT,
+            DocumentType::RENT_ACT,
+            DocumentType::UTILITIES_ACT,
+            DocumentType::BANK_FEES_ACT,
+            DocumentType::PAYROLL_SHEET,
+            DocumentType::ADVANCE_REPORT,
+            DocumentType::LOAN_INTEREST_STATEMENT => PlNature::EXPENSE,
+
+            DocumentType::OTHER => null,
+        };
+    }
+}

--- a/site/templates/document/index.html.twig
+++ b/site/templates/document/index.html.twig
@@ -22,6 +22,7 @@
                             <th>Дата</th>
                             <th>Номер</th>
                             <th>Тип</th>
+                            <th>Природа</th>
                             <th></th>
                         </tr>
                     </thead>
@@ -31,6 +32,12 @@
                                 <td>{{ item.date|date('Y-m-d H:i') }}</td>
                                 <td>{{ item.number }}</td>
                                 <td><span class="badge bg-blue-lt">{{ item.type.label }}</span></td>
+                                {% set docNature = documentNatures[item.id] ?? null %}
+                                <td>
+                                    {% if docNature %}
+                                        <span class="badge {{ docNature.badgeClass }}">{{ docNature.label }}</span>
+                                    {% endif %}
+                                </td>
                                 <td class="text-end">
                                     <a href="{{ path('document_show', {'id': item.id}) }}" class="btn btn-sm btn-info">👁</a>
                                     <a href="{{ path('document_edit', {'id': item.id}) }}" class="btn btn-sm btn-warning">✏️</a>
@@ -41,7 +48,7 @@
                                 </td>
                             </tr>
                         {% else %}
-                            <tr><td colspan="4" class="text-center">Нет данных</td></tr>
+                            <tr><td colspan="5" class="text-center">Нет данных</td></tr>
                         {% endfor %}
                     </tbody>
                 </table>

--- a/site/templates/document/show.html.twig
+++ b/site/templates/document/show.html.twig
@@ -15,7 +15,12 @@
                     <dt class="col-sm-3">Номер</dt>
                     <dd class="col-sm-9">{{ item.number }}</dd>
                     <dt class="col-sm-3">Тип</dt>
-                    <dd class="col-sm-9"><span class="badge bg-blue-lt">{{ item.type.label }}</span></dd>
+                    <dd class="col-sm-9">
+                        <span class="badge bg-blue-lt">{{ item.type.label }}</span>
+                        {% if documentNature is defined %}
+                            <span class="badge {{ documentNature.badgeClass }}">{{ documentNature.label }}</span>
+                        {% endif %}
+                    </dd>
                     <dt class="col-sm-3">Описание</dt>
                     <dd class="col-sm-9">{{ item.description }}</dd>
                 </dl>
@@ -24,21 +29,42 @@
                     <thead>
                         <tr>
                             <th>Категория</th>
+                            <th>Природа</th>
                             <th>Сумма</th>
                             <th>Контрагент</th>
                             <th>Комментарий</th>
                         </tr>
                     </thead>
                     <tbody>
-                        {% for op in item.operations %}
+                        {% for view in operationViews %}
+                            {% set op = view.operation %}
                             <tr>
-                                <td>{{ op.category.name }}</td>
+                                <td>
+                                    {% if view.categoryName %}
+                                        {{ view.categoryName }}
+                                    {% else %}
+                                        <span class="text-warning">Без категории</span>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if view.natureLabel %}
+                                        <span class="badge {{ view.badgeClass }}">{{ view.natureLabel }}</span>
+                                        {% if view.isFallback %}
+                                            <span class="text-muted small">по типу документа</span>
+                                            <span class="text-warning small ms-1">нужно указать статью</span>
+                                        {% endif %}
+                                    {% elseif view.needsCategorization %}
+                                        <span class="badge bg-warning-lt text-warning">Нужно указать статью</span>
+                                    {% else %}
+                                        <span class="badge bg-secondary">—</span>
+                                    {% endif %}
+                                </td>
                                 <td>{{ op.amount }}</td>
                                 <td>{{ op.counterparty ? op.counterparty.name : '' }}</td>
                                 <td>{{ op.comment }}</td>
                             </tr>
                         {% else %}
-                            <tr><td colspan="4" class="text-center">Нет операций</td></tr>
+                            <tr><td colspan="5" class="text-center">Нет операций</td></tr>
                         {% endfor %}
                     </tbody>
                 </table>

--- a/site/tests/Service/PlNatureResolverTest.php
+++ b/site/tests/Service/PlNatureResolverTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Entity\Company;
+use App\Entity\Document;
+use App\Entity\DocumentOperation;
+use App\Entity\PLCategory;
+use App\Entity\User;
+use App\Enum\DocumentType;
+use App\Enum\PlNature;
+use App\Service\PlNatureResolver;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+final class PlNatureResolverTest extends TestCase
+{
+    public function testOperationCategoryOverridesDocumentType(): void
+    {
+        $resolver = new PlNatureResolver();
+
+        $company = $this->createCompany();
+        $document = new Document(Uuid::uuid4()->toString(), $company);
+        $document->setType(DocumentType::SUPPLIER_INVOICE);
+
+        $revenueRoot = $this->createCategory($company, 'Revenue');
+        $revenueChild = $this->createCategory($company, 'Marketplace Sales', $revenueRoot);
+
+        $operation = new DocumentOperation();
+        $operation->setDocument($document);
+        $operation->setCategory($revenueChild);
+
+        self::assertSame(PlNature::INCOME, $resolver->forOperation($operation));
+    }
+
+    public function testFallbackUsesDocumentTypeWhenCategoryMissing(): void
+    {
+        $resolver = new PlNatureResolver();
+
+        $company = $this->createCompany();
+        $document = new Document(Uuid::uuid4()->toString(), $company);
+        $document->setType(DocumentType::MARKETPLACE_REPORT);
+
+        $operation = new DocumentOperation();
+        $operation->setDocument($document);
+
+        self::assertSame(PlNature::INCOME, $resolver->forOperation($operation));
+    }
+
+    public function testDocumentReturnsMixedWhenHasIncomeAndExpenseOperations(): void
+    {
+        $resolver = new PlNatureResolver();
+
+        $company = $this->createCompany();
+        $document = new Document(Uuid::uuid4()->toString(), $company);
+        $document->setType(DocumentType::MARKETPLACE_REPORT);
+
+        $revenueRoot = $this->createCategory($company, 'Revenue');
+        $revenueChild = $this->createCategory($company, 'Marketplace Sales', $revenueRoot);
+        $expenseRoot = $this->createCategory($company, 'OPEX');
+        $expenseChild = $this->createCategory($company, 'Marketing', $expenseRoot);
+
+        $incomeOperation = new DocumentOperation();
+        $incomeOperation->setCategory($revenueChild);
+        $document->addOperation($incomeOperation);
+
+        $expenseOperation = new DocumentOperation();
+        $expenseOperation->setCategory($expenseChild);
+        $document->addOperation($expenseOperation);
+
+        self::assertSame('MIXED', $resolver->forDocument($document));
+    }
+
+    private function createCompany(): Company
+    {
+        $user = new User(Uuid::uuid4()->toString());
+        $user->setEmail('test@example.com');
+        $user->setPassword('secret');
+
+        return new Company(Uuid::uuid4()->toString(), $user);
+    }
+
+    private function createCategory(Company $company, string $name, ?PLCategory $parent = null): PLCategory
+    {
+        $category = new PLCategory(Uuid::uuid4()->toString(), $company);
+        $category->setName($name);
+        if ($parent) {
+            $category->setParent($parent);
+        }
+
+        return $category;
+    }
+}


### PR DESCRIPTION
## Summary
- add the PlNature enum and resolver to centralize income/expense detection with document fallbacks
- extend PLCategory and DocumentOperation helpers so operations can surface their nature
- surface nature badges across document views and cover the resolver with regression tests

## Testing
- not run (composer install/phpunit unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dbd364fb58832393a3727019567dcc