### PR TITLE
Add PL daily totals entity and migration

### DIFF
--- a/site/migrations/Version20250930120000.php
+++ b/site/migrations/Version20250930120000.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250930120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create PL daily totals table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("CREATE TABLE pl_daily_totals (id UUID NOT NULL, company_id UUID NOT NULL, pl_category_id UUID DEFAULT NULL, date DATE NOT NULL, amount_income NUMERIC(18, 2) NOT NULL, amount_expense NUMERIC(18, 2) NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))");
+        $this->addSql('CREATE UNIQUE INDEX uniq_pl_daily_company_cat_date ON pl_daily_totals (company_id, pl_category_id, date)');
+        $this->addSql('CREATE INDEX idx_pl_daily_company_date ON pl_daily_totals (company_id, date)');
+        $this->addSql('CREATE INDEX idx_pl_daily_company_cat_date ON pl_daily_totals (company_id, pl_category_id, date)');
+
+        if ('postgresql' === $this->connection->getDatabasePlatform()->getName()) {
+            $this->addSql('ALTER TABLE pl_daily_totals ADD CONSTRAINT chk_pl_daily_totals_amounts CHECK (amount_income >= 0 AND amount_expense >= 0)');
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE pl_daily_totals');
+    }
+}

--- a/site/src/Entity/PLDailyTotal.php
+++ b/site/src/Entity/PLDailyTotal.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\PLDailyTotalRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity(repositoryClass: PLDailyTotalRepository::class)]
+#[ORM\Table(name: 'pl_daily_totals')]
+#[ORM\UniqueConstraint(name: 'uniq_pl_daily_company_cat_date', columns: ['company_id', 'pl_category_id', 'date'])]
+#[ORM\Index(name: 'idx_pl_daily_company_date', columns: ['company_id', 'date'])]
+#[ORM\Index(name: 'idx_pl_daily_company_cat_date', columns: ['company_id', 'pl_category_id', 'date'])]
+class PLDailyTotal
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid', unique: true)]
+    private ?string $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Company::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'RESTRICT')]
+    private Company $company;
+
+    #[ORM\ManyToOne(targetEntity: PLCategory::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    private ?PLCategory $plCategory = null;
+
+    #[ORM\Column(type: 'date_immutable')]
+    private \DateTimeImmutable $date;
+
+    #[ORM\Column(type: 'decimal', precision: 18, scale: 2)]
+    private string $amountIncome = '0';
+
+    #[ORM\Column(type: 'decimal', precision: 18, scale: 2)]
+    private string $amountExpense = '0';
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $updatedAt;
+
+    public function __construct(string $id, Company $company, \DateTimeImmutable $date, ?PLCategory $category)
+    {
+        Assert::uuid($id);
+        $this->id = $id;
+        $this->company = $company;
+        $this->date = $date;
+        $this->plCategory = $category;
+        $this->createdAt = new \DateTimeImmutable();
+        $this->updatedAt = $this->createdAt;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getCompany(): Company
+    {
+        return $this->company;
+    }
+
+    public function setCompany(Company $company): self
+    {
+        $this->company = $company;
+
+        return $this;
+    }
+
+    public function getPlCategory(): ?PLCategory
+    {
+        return $this->plCategory;
+    }
+
+    public function setPlCategory(?PLCategory $category): self
+    {
+        $this->plCategory = $category;
+
+        return $this;
+    }
+
+    public function getDate(): \DateTimeImmutable
+    {
+        return $this->date;
+    }
+
+    public function setDate(\DateTimeImmutable $date): self
+    {
+        $this->date = $date;
+
+        return $this;
+    }
+
+    public function getAmountIncome(): string
+    {
+        return $this->amountIncome;
+    }
+
+    public function setAmountIncome(string $amount): self
+    {
+        $this->amountIncome = $amount;
+
+        return $this;
+    }
+
+    public function getAmountExpense(): string
+    {
+        return $this->amountExpense;
+    }
+
+    public function setAmountExpense(string $amount): self
+    {
+        $this->amountExpense = $amount;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeImmutable $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(\DateTimeImmutable $updatedAt): self
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+}

--- a/site/src/Repository/PLDailyTotalRepository.php
+++ b/site/src/Repository/PLDailyTotalRepository.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\PLDailyTotal;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class PLDailyTotalRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, PLDailyTotal::class);
+    }
+}


### PR DESCRIPTION
## Summary
- add the PLDailyTotal entity mirroring existing daily balance style and relationships
- register a Doctrine repository for PLDailyTotal
- introduce a migration that creates the pl_daily_totals table with supporting indexes and a PostgreSQL check constraint

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbdb77681083238f22d068cc1b09f0