### PR TITLE
Add PL monthly snapshot entity and migration

### DIFF
--- a/site/migrations/Version20250910123000.php
+++ b/site/migrations/Version20250910123000.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250910123000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create PL monthly snapshots table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("CREATE TABLE pl_monthly_snapshots (id UUID NOT NULL, company_id UUID NOT NULL, pl_category_id UUID DEFAULT NULL, period VARCHAR(7) NOT NULL, amount_income NUMERIC(18, 2) NOT NULL, amount_expense NUMERIC(18, 2) NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))");
+        $this->addSql('CREATE UNIQUE INDEX uniq_pl_monthly_company_cat_period ON pl_monthly_snapshots (company_id, pl_category_id, period)');
+        $this->addSql('CREATE INDEX idx_pl_monthly_company_period ON pl_monthly_snapshots (company_id, period)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE pl_monthly_snapshots');
+    }
+}

--- a/site/src/Entity/PLMonthlySnapshot.php
+++ b/site/src/Entity/PLMonthlySnapshot.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\\Entity;
+
+use App\\Repository\\PLMonthlySnapshotRepository;
+use Doctrine\\ORM\\Mapping as ORM;
+use Webmozart\\Assert\\Assert;
+
+#[ORM\\Entity(repositoryClass: PLMonthlySnapshotRepository::class)]
+#[ORM\\Table(name: 'pl_monthly_snapshots')]
+#[ORM\\UniqueConstraint(name: 'uniq_pl_monthly_company_cat_period', columns: ['company_id', 'pl_category_id', 'period'])]
+#[ORM\\Index(name: 'idx_pl_monthly_company_period', columns: ['company_id', 'period'])]
+class PLMonthlySnapshot
+{
+    #[ORM\\Id]
+    #[ORM\\Column(type: 'guid', unique: true)]
+    private ?string $id = null;
+
+    #[ORM\\ManyToOne(targetEntity: Company::class)]
+    #[ORM\\JoinColumn(nullable: false, onDelete: 'RESTRICT')]
+    private Company $company;
+
+    #[ORM\\ManyToOne(targetEntity: PLCategory::class)]
+    #[ORM\\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    private ?PLCategory $plCategory = null;
+
+    #[ORM\\Column(length: 7)]
+    private string $period;
+
+    #[ORM\\Column(type: 'decimal', precision: 18, scale: 2)]
+    private string $amountIncome = '0';
+
+    #[ORM\\Column(type: 'decimal', precision: 18, scale: 2)]
+    private string $amountExpense = '0';
+
+    #[ORM\\Column(type: 'datetime_immutable')]
+    private \\DateTimeImmutable $updatedAt;
+
+    public function __construct(string $id, Company $company, string $period, ?PLCategory $category)
+    {
+        Assert::uuid($id);
+        $this->id = $id;
+        $this->company = $company;
+        $this->period = $period;
+        $this->plCategory = $category;
+        $this->updatedAt = new \\DateTimeImmutable();
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getCompany(): Company
+    {
+        return $this->company;
+    }
+
+    public function setCompany(Company $company): self
+    {
+        $this->company = $company;
+
+        return $this;
+    }
+
+    public function getPlCategory(): ?PLCategory
+    {
+        return $this->plCategory;
+    }
+
+    public function setPlCategory(?PLCategory $category): self
+    {
+        $this->plCategory = $category;
+
+        return $this;
+    }
+
+    public function getPeriod(): string
+    {
+        return $this->period;
+    }
+
+    public function setPeriod(string $period): self
+    {
+        $this->period = $period;
+
+        return $this;
+    }
+
+    public function getAmountIncome(): string
+    {
+        return $this->amountIncome;
+    }
+
+    public function setAmountIncome(string $amount): self
+    {
+        $this->amountIncome = $amount;
+
+        return $this;
+    }
+
+    public function getAmountExpense(): string
+    {
+        return $this->amountExpense;
+    }
+
+    public function setAmountExpense(string $amount): self
+    {
+        $this->amountExpense = $amount;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): \\DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(\\DateTimeImmutable $updatedAt): self
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+}

--- a/site/src/Repository/PLMonthlySnapshotRepository.php
+++ b/site/src/Repository/PLMonthlySnapshotRepository.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\\Repository;
+
+use App\\Entity\\PLMonthlySnapshot;
+use Doctrine\\Bundle\\DoctrineBundle\\Repository\\ServiceEntityRepository;
+use Doctrine\\Persistence\\ManagerRegistry;
+
+class PLMonthlySnapshotRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, PLMonthlySnapshot::class);
+    }
+}


### PR DESCRIPTION
## Summary
- add the PLMonthlySnapshot doctrine entity and repository
- create the database migration for the pl_monthly_snapshots table with indexes and uniqueness constraints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbdcd238248323b8d4b4f5360a026a