### PR TITLE
Add CLI commands for PL register and snapshot recalculation

### DIFF
--- a/site/src/Command/PlRegisterRecalcCommand.php
+++ b/site/src/Command/PlRegisterRecalcCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Command;
+
+use App\Repository\CompanyRepository;
+use App\Service\PLRegisterUpdater;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'app:pl:register:recalc',
+    description: 'Пересчитывает регистр P&L за диапазон дат.'
+)]
+class PlRegisterRecalcCommand extends Command
+{
+    public function __construct(
+        private readonly CompanyRepository $companyRepo,
+        private readonly PLRegisterUpdater $updater
+    ) { parent::__construct(); }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('companyId', InputArgument::REQUIRED)
+            ->addArgument('from', InputArgument::REQUIRED) // YYYY-MM-DD
+            ->addArgument('to', InputArgument::REQUIRED);  // YYYY-MM-DD
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $company = $this->companyRepo->find($input->getArgument('companyId'));
+        $from = new \DateTimeImmutable($input->getArgument('from'));
+        $to   = new \DateTimeImmutable($input->getArgument('to'));
+
+        $this->updater->recalcRange($company, $from, $to);
+        $output->writeln('Done');
+
+        return Command::SUCCESS;
+    }
+}

--- a/site/src/Command/PlSnapshotRebuildCommand.php
+++ b/site/src/Command/PlSnapshotRebuildCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Command;
+
+use App\Repository\CompanyRepository;
+use App\Service\PLSnapshotBuilder;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'app:pl:snapshot:rebuild',
+    description: 'Пересобирает месячные снапшоты P&L за диапазон периодов.'
+)]
+class PlSnapshotRebuildCommand extends Command
+{
+    public function __construct(
+        private readonly CompanyRepository $companyRepo,
+        private readonly PLSnapshotBuilder $builder
+    ) { parent::__construct(); }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('companyId', InputArgument::REQUIRED)
+            ->addArgument('from', InputArgument::REQUIRED) // YYYY-MM
+            ->addArgument('to', InputArgument::REQUIRED);  // YYYY-MM
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $company = $this->companyRepo->find($input->getArgument('companyId'));
+        $from = (string) $input->getArgument('from');
+        $to   = (string) $input->getArgument('to');
+
+        $this->builder->rebuildRange($company, $from, $to);
+        $output->writeln('Done');
+
+        return Command::SUCCESS;
+    }
+}


### PR DESCRIPTION
## Summary
- add CLI command to recalculate PL daily register totals over a date range
- add CLI command to rebuild monthly PL snapshots over a period range

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbe3e85bf48323afda0ef3c4d7e3a0