### PR TITLE
Add DB upsert support for PL totals and snapshots

### DIFF
--- a/site/src/Repository/PLDailyTotalRepository.php
+++ b/site/src/Repository/PLDailyTotalRepository.php
@@ -3,13 +3,65 @@
 namespace App\Repository;
 
 use App\Entity\PLDailyTotal;
+use DateTimeImmutable;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Persistence\ManagerRegistry;
+use Ramsey\Uuid\Uuid;
 
 class PLDailyTotalRepository extends ServiceEntityRepository
 {
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, PLDailyTotal::class);
+    }
+
+    public function upsert(
+        string $companyId,
+        ?string $categoryId,
+        DateTimeImmutable $date,
+        string $amountIncome,
+        string $amountExpense,
+        bool $replace,
+        ?DateTimeImmutable $timestamp = null,
+    ): void {
+        $timestamp ??= new DateTimeImmutable();
+
+        $connection = $this->getEntityManager()->getConnection();
+
+        $sql = sprintf(
+            <<<'SQL'
+INSERT INTO pl_daily_totals (id, company_id, pl_category_id, date, amount_income, amount_expense, created_at, updated_at)
+VALUES (:id, :company_id, :category_id, :date, :amount_income, :amount_expense, :created_at, :updated_at)
+ON CONFLICT (company_id, pl_category_id, date) DO UPDATE SET
+    amount_income = %s,
+    amount_expense = %s,
+    updated_at = EXCLUDED.updated_at
+SQL,
+            $replace ? 'EXCLUDED.amount_income' : 'pl_daily_totals.amount_income + EXCLUDED.amount_income',
+            $replace ? 'EXCLUDED.amount_expense' : 'pl_daily_totals.amount_expense + EXCLUDED.amount_expense',
+        );
+
+        $connection->executeStatement(
+            $sql,
+            [
+                'id' => Uuid::uuid4()->toString(),
+                'company_id' => $companyId,
+                'category_id' => $categoryId,
+                'date' => $date,
+                'amount_income' => $amountIncome,
+                'amount_expense' => $amountExpense,
+                'created_at' => $timestamp,
+                'updated_at' => $timestamp,
+            ],
+            [
+                'id' => Types::GUID,
+                'company_id' => Types::GUID,
+                'category_id' => Types::GUID,
+                'date' => Types::DATE_IMMUTABLE,
+                'created_at' => Types::DATETIME_IMMUTABLE,
+                'updated_at' => Types::DATETIME_IMMUTABLE,
+            ],
+        );
     }
 }

--- a/site/src/Repository/PLMonthlySnapshotRepository.php
+++ b/site/src/Repository/PLMonthlySnapshotRepository.php
@@ -1,15 +1,60 @@
 <?php
 
-namespace App\\Repository;
+namespace App\Repository;
 
-use App\\Entity\\PLMonthlySnapshot;
-use Doctrine\\Bundle\\DoctrineBundle\\Repository\\ServiceEntityRepository;
-use Doctrine\\Persistence\\ManagerRegistry;
+use App\Entity\PLMonthlySnapshot;
+use DateTimeImmutable;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Persistence\ManagerRegistry;
+use Ramsey\Uuid\Uuid;
 
 class PLMonthlySnapshotRepository extends ServiceEntityRepository
 {
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, PLMonthlySnapshot::class);
+    }
+
+    public function upsert(
+        string $companyId,
+        ?string $categoryId,
+        string $period,
+        string $amountIncome,
+        string $amountExpense,
+        ?DateTimeImmutable $updatedAt = null,
+    ): void {
+        $updatedAt ??= new DateTimeImmutable();
+
+        $connection = $this->getEntityManager()->getConnection();
+
+        $sql = <<<'SQL'
+INSERT INTO pl_monthly_snapshots (id, company_id, pl_category_id, period, amount_income, amount_expense, updated_at)
+VALUES (:id, :company_id, :category_id, :period, :amount_income, :amount_expense, :updated_at)
+ON CONFLICT (company_id, pl_category_id, period) DO UPDATE SET
+    amount_income = EXCLUDED.amount_income,
+    amount_expense = EXCLUDED.amount_expense,
+    updated_at = EXCLUDED.updated_at
+SQL;
+
+        $connection->executeStatement(
+            $sql,
+            [
+                'id' => Uuid::uuid4()->toString(),
+                'company_id' => $companyId,
+                'category_id' => $categoryId,
+                'period' => $period,
+                'amount_income' => $amountIncome,
+                'amount_expense' => $amountExpense,
+                'updated_at' => $updatedAt,
+            ],
+            [
+                'id' => Types::GUID,
+                'company_id' => Types::GUID,
+                'category_id' => Types::GUID,
+                'period' => Types::STRING,
+                'updated_at' => Types::DATETIME_IMMUTABLE,
+            ],
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add PostgreSQL upsert helpers to the PL daily total and monthly snapshot repositories
- update PL register and snapshot services to use the new repository methods and validate identifiers

## Testing
- php -l site/src/Repository/PLDailyTotalRepository.php
- php -l site/src/Repository/PLMonthlySnapshotRepository.php
- php -l site/src/Service/PLRegisterUpdater.php
- php -l site/src/Service/PLSnapshotBuilder.php

------
https://chatgpt.com/codex/tasks/task_e_68dbe88e12848323916fdc66bd0a1c71