### PR TITLE
Arrange document form fields in a single row

### DIFF
--- a/site/templates/document/edit.html.twig
+++ b/site/templates/document/edit.html.twig
@@ -10,9 +10,17 @@
         <div class="card">
             <div class="card-body">
                 {{ form_start(form) }}
-                {{ form_row(form.date) }}
-                {{ form_row(form.number) }}
-                {{ form_row(form.type) }}
+                <div class="row">
+                    <div class="col-md-4">
+                        {{ form_row(form.date) }}
+                    </div>
+                    <div class="col-md-4">
+                        {{ form_row(form.number) }}
+                    </div>
+                    <div class="col-md-4">
+                        {{ form_row(form.type) }}
+                    </div>
+                </div>
                 {{ form_row(form.description) }}
                 <div class="mb-3">
                     <label class="form-label">Операции</label>

--- a/site/templates/document/new.html.twig
+++ b/site/templates/document/new.html.twig
@@ -10,9 +10,17 @@
         <div class="card">
             <div class="card-body">
                 {{ form_start(form) }}
-                {{ form_row(form.date) }}
-                {{ form_row(form.number) }}
-                {{ form_row(form.type) }}
+                <div class="row">
+                    <div class="col-md-4">
+                        {{ form_row(form.date) }}
+                    </div>
+                    <div class="col-md-4">
+                        {{ form_row(form.number) }}
+                    </div>
+                    <div class="col-md-4">
+                        {{ form_row(form.type) }}
+                    </div>
+                </div>
                 {{ form_row(form.description) }}
                 <div class="mb-3">
                     <label class="form-label">Операции</label>


### PR DESCRIPTION
## Summary
- place the document creation date, number, and type fields on a shared row in the document form templates

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbfd90754483239f82046ab7b1e872