### PR TITLE
Wrap document operations in cards

### DIFF
--- a/site/templates/document/edit.html.twig
+++ b/site/templates/document/edit.html.twig
@@ -26,9 +26,13 @@
                     <label class="form-label">Операции</label>
                     <div data-collection-holder data-prototype="{{ form_widget(form.operations.vars.prototype)|e('html_attr') }}">
                         {% for op in form.operations %}
-                            <div class="mb-2">
-                                {{ form_widget(op) }}
-                                <button type="button" class="btn btn-sm btn-danger remove-item">Удалить</button>
+                            <div class="card mb-3 document-operation-card">
+                                <div class="card-body">
+                                    {{ form_widget(op) }}
+                                </div>
+                                <div class="card-footer text-end">
+                                    <button type="button" class="btn btn-sm btn-danger remove-item">Удалить</button>
+                                </div>
                             </div>
                         {% endfor %}
                     </div>
@@ -45,18 +49,41 @@
     document.addEventListener('DOMContentLoaded', function() {
         document.querySelectorAll('[data-collection-holder]').forEach(function(collectionHolder) {
             const addButton = collectionHolder.parentElement.querySelector('.add_item_link');
+            const createOperationCard = function(formHtml) {
+                const card = document.createElement('div');
+                card.classList.add('card', 'mb-3', 'document-operation-card');
+
+                const cardBody = document.createElement('div');
+                cardBody.classList.add('card-body');
+                cardBody.innerHTML = formHtml;
+                card.appendChild(cardBody);
+
+                const cardFooter = document.createElement('div');
+                cardFooter.classList.add('card-footer', 'text-end');
+                const removeButton = document.createElement('button');
+                removeButton.type = 'button';
+                removeButton.classList.add('btn', 'btn-sm', 'btn-danger', 'remove-item');
+                removeButton.textContent = 'Удалить';
+                cardFooter.appendChild(removeButton);
+                card.appendChild(cardFooter);
+
+                return card;
+            };
+
             addButton.addEventListener('click', function() {
                 const prototype = collectionHolder.dataset.prototype;
-                const index = collectionHolder.children.length;
-                let newForm = prototype.replace(/__name__/g, index);
-                const div = document.createElement('div');
-                div.classList.add('mb-2');
-                div.innerHTML = newForm + '<button type="button" class="btn btn-sm btn-danger remove-item">Удалить</button>';
-                collectionHolder.appendChild(div);
+                const index = collectionHolder.querySelectorAll('.document-operation-card').length;
+                const newForm = prototype.replace(/__name__/g, index);
+                const card = createOperationCard(newForm);
+                collectionHolder.appendChild(card);
             });
+
             collectionHolder.addEventListener('click', function(e){
                 if (e.target && e.target.classList.contains('remove-item')) {
-                    e.target.closest('div.mb-2').remove();
+                    const card = e.target.closest('.document-operation-card');
+                    if (card) {
+                        card.remove();
+                    }
                 }
             });
         });

--- a/site/templates/document/new.html.twig
+++ b/site/templates/document/new.html.twig
@@ -26,9 +26,13 @@
                     <label class="form-label">Операции</label>
                     <div data-collection-holder data-prototype="{{ form_widget(form.operations.vars.prototype)|e('html_attr') }}">
                         {% for op in form.operations %}
-                            <div class="mb-2">
-                                {{ form_widget(op) }}
-                                <button type="button" class="btn btn-sm btn-danger remove-item">Удалить</button>
+                            <div class="card mb-3 document-operation-card">
+                                <div class="card-body">
+                                    {{ form_widget(op) }}
+                                </div>
+                                <div class="card-footer text-end">
+                                    <button type="button" class="btn btn-sm btn-danger remove-item">Удалить</button>
+                                </div>
                             </div>
                         {% endfor %}
                     </div>
@@ -45,18 +49,41 @@
     document.addEventListener('DOMContentLoaded', function() {
         document.querySelectorAll('[data-collection-holder]').forEach(function(collectionHolder) {
             const addButton = collectionHolder.parentElement.querySelector('.add_item_link');
+            const createOperationCard = function(formHtml) {
+                const card = document.createElement('div');
+                card.classList.add('card', 'mb-3', 'document-operation-card');
+
+                const cardBody = document.createElement('div');
+                cardBody.classList.add('card-body');
+                cardBody.innerHTML = formHtml;
+                card.appendChild(cardBody);
+
+                const cardFooter = document.createElement('div');
+                cardFooter.classList.add('card-footer', 'text-end');
+                const removeButton = document.createElement('button');
+                removeButton.type = 'button';
+                removeButton.classList.add('btn', 'btn-sm', 'btn-danger', 'remove-item');
+                removeButton.textContent = 'Удалить';
+                cardFooter.appendChild(removeButton);
+                card.appendChild(cardFooter);
+
+                return card;
+            };
+
             addButton.addEventListener('click', function() {
                 const prototype = collectionHolder.dataset.prototype;
-                const index = collectionHolder.children.length;
-                let newForm = prototype.replace(/__name__/g, index);
-                const div = document.createElement('div');
-                div.classList.add('mb-2');
-                div.innerHTML = newForm + '<button type="button" class="btn btn-sm btn-danger remove-item">Удалить</button>';
-                collectionHolder.appendChild(div);
+                const index = collectionHolder.querySelectorAll('.document-operation-card').length;
+                const newForm = prototype.replace(/__name__/g, index);
+                const card = createOperationCard(newForm);
+                collectionHolder.appendChild(card);
             });
+
             collectionHolder.addEventListener('click', function(e){
                 if (e.target && e.target.classList.contains('remove-item')) {
-                    e.target.closest('div.mb-2').remove();
+                    const card = e.target.closest('.document-operation-card');
+                    if (card) {
+                        card.remove();
+                    }
                 }
             });
         });


### PR DESCRIPTION
## Summary
- wrap each document operation form entry in a dedicated card container on the create and edit pages
- update the dynamic collection JavaScript to generate and remove card-wrapped operation forms consistently

## Testing
- php bin/console lint:twig templates/document *(fails: missing Composer dependencies in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbff6bf2788323b347c21b5c241d92