### PR TITLE
Align DocumentOperation form fields horizontally

### DIFF
--- a/site/templates/document/_operation_form.html.twig
+++ b/site/templates/document/_operation_form.html.twig
@@ -1,0 +1,12 @@
+<div class="row g-3 align-items-end">
+    <div class="col-md-5">
+        {{ form_row(operationForm.category) }}
+    </div>
+    <div class="col-md-3">
+        {{ form_row(operationForm.amount) }}
+    </div>
+    <div class="col-md-4">
+        {{ form_row(operationForm.counterparty) }}
+    </div>
+</div>
+{{ form_row(operationForm.comment) }}

--- a/site/templates/document/edit.html.twig
+++ b/site/templates/document/edit.html.twig
@@ -24,11 +24,14 @@
                 {{ form_row(form.description) }}
                 <div class="mb-3">
                     <label class="form-label">Операции</label>
-                    <div data-collection-holder data-prototype="{{ form_widget(form.operations.vars.prototype)|e('html_attr') }}">
+                    {% set operationPrototype %}
+                        {% include 'document/_operation_form.html.twig' with { operationForm: form.operations.vars.prototype } %}
+                    {% endset %}
+                    <div data-collection-holder data-prototype="{{ operationPrototype|e('html_attr') }}">
                         {% for op in form.operations %}
                             <div class="card mb-3 document-operation-card">
                                 <div class="card-body">
-                                    {{ form_widget(op) }}
+                                    {% include 'document/_operation_form.html.twig' with { operationForm: op } %}
                                 </div>
                                 <div class="card-footer text-end">
                                     <button type="button" class="btn btn-sm btn-danger remove-item">Удалить</button>

--- a/site/templates/document/new.html.twig
+++ b/site/templates/document/new.html.twig
@@ -24,11 +24,14 @@
                 {{ form_row(form.description) }}
                 <div class="mb-3">
                     <label class="form-label">Операции</label>
-                    <div data-collection-holder data-prototype="{{ form_widget(form.operations.vars.prototype)|e('html_attr') }}">
+                    {% set operationPrototype %}
+                        {% include 'document/_operation_form.html.twig' with { operationForm: form.operations.vars.prototype } %}
+                    {% endset %}
+                    <div data-collection-holder data-prototype="{{ operationPrototype|e('html_attr') }}">
                         {% for op in form.operations %}
                             <div class="card mb-3 document-operation-card">
                                 <div class="card-body">
-                                    {{ form_widget(op) }}
+                                    {% include 'document/_operation_form.html.twig' with { operationForm: op } %}
                                 </div>
                                 <div class="card-footer text-end">
                                     <button type="button" class="btn btn-sm btn-danger remove-item">Удалить</button>


### PR DESCRIPTION
## Summary
- display category, amount, and counterparty on the same row when editing document operations
- reuse a dedicated Twig partial for operation forms and prototypes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc0628129c832399e0bd63a5a51abc