### PR TITLE
Add breadcrumbs to document forms

### DIFF
--- a/site/templates/document/edit.html.twig
+++ b/site/templates/document/edit.html.twig
@@ -1,5 +1,15 @@
 {% extends 'base.html.twig' %}
 {% block title %}Редактирование документа{% endblock %}
+{% block breadcrumbs %}
+    {% include 'partials/_breadcrumbs.html.twig' with {
+        breadcrumbs: [
+            {'label': 'Главная', 'path': 'app_home_index'},
+            {'label': 'Финансы'},
+            {'label': 'Документы', 'path': 'document_index'},
+            {'label': 'Редактирование'}
+        ]
+    } %}
+{% endblock %}
 {% block body %}
     <div class="page-header d-print-none">
         <div class="container-xl">

--- a/site/templates/document/new.html.twig
+++ b/site/templates/document/new.html.twig
@@ -1,5 +1,15 @@
 {% extends 'base.html.twig' %}
 {% block title %}Новый документ{% endblock %}
+{% block breadcrumbs %}
+    {% include 'partials/_breadcrumbs.html.twig' with {
+        breadcrumbs: [
+            {'label': 'Главная', 'path': 'app_home_index'},
+            {'label': 'Финансы'},
+            {'label': 'Документы', 'path': 'document_index'},
+            {'label': 'Новый'}
+        ]
+    } %}
+{% endblock %}
 {% block body %}
     <div class="page-header d-print-none">
         <div class="container-xl">


### PR DESCRIPTION
## Summary
- add a breadcrumb trail to the document creation and edit templates so they match the rest of the UI navigation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc087bdcbc8323ae24ed92a91c5056