### PR TITLE
Refine document edit layout

### DIFF
--- a/site/templates/document/edit.html.twig
+++ b/site/templates/document/edit.html.twig
@@ -12,11 +12,9 @@
 {% endblock %}
 {% block body %}
     <div class="page-header d-print-none">
-        <div class="container-xl">
-            <h2 class="page-title">Редактирование документа</h2>
-        </div>
+        <h2 class="page-title">Редактирование документа</h2>
     </div>
-    <div class="container-xl mt-3">
+    <div class="mt-3">
         <div class="card">
             <div class="card-body">
                 {{ form_start(form) }}


### PR DESCRIPTION
## Summary
- remove redundant container wrappers from the document edit page header and layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc0e1929c08323b1941099c4d3ea91