### PR TITLE
Restrict document type enum to P&L relevant cases

### DIFF
--- a/site/migrations/Version20250929120000.php
+++ b/site/migrations/Version20250929120000.php
@@ -28,25 +28,19 @@ BEGIN
     ) THEN
         ALTER TABLE documents
             ADD CONSTRAINT documents_type_enum_check CHECK (type IN (
-                'SALES_INVOICE',
-                'DELIVERY_NOTE',
                 'SERVICE_ACT',
+                'SALES_DELIVERY_NOTE',
                 'COMMISSION_REPORT',
-                'MARKETPLACE_REPORT',
-                'CASH_RECEIPT',
-                'SUPPLIER_INVOICE',
-                'MATERIAL_WRITE_OFF_ACT',
-                'MANUFACTURING_ACT',
-                'COST_ALLOCATION',
-                'AD_ACT',
-                'RENT_ACT',
-                'UTILITIES_ACT',
-                'BANK_FEES_ACT',
-                'PAYROLL_SHEET',
-                'ADVANCE_REPORT',
-                'BANK_STATEMENT',
-                'LOAN_INTEREST_STATEMENT',
-                'FX_REVALUATION_ACT',
+                'PURCHASE_INVOICE',
+                'ACCEPTANCE_ACT',
+                'WRITE_OFF_ACT',
+                'INVENTORY_SHEET',
+                'LOAN_AND_SCHEDULE',
+                'PAYROLL_ACCRUAL',
+                'DEPRECIATION',
+                'TAXES_AND_CONTRIBUTIONS',
+                'FX_PENALTIES',
+                'SALES_OR_PURCHASE_RETURN',
                 'OTHER'
             ));
     END IF;

--- a/site/src/Enum/DocumentType.php
+++ b/site/src/Enum/DocumentType.php
@@ -6,34 +6,26 @@ namespace App\Enum;
 
 enum DocumentType: string
 {
-    // Доходы
-    case SALES_INVOICE = 'SALES_INVOICE';            // Счет-фактура/реализация
-    case DELIVERY_NOTE = 'DELIVERY_NOTE';            // Накладная / УПД
-    case SERVICE_ACT = 'SERVICE_ACT';                // Акт выполненных работ
-    case COMMISSION_REPORT = 'COMMISSION_REPORT';    // Отчет комиссионера/агента
-    case MARKETPLACE_REPORT = 'MARKETPLACE_REPORT';  // Отчет маркетплейса
-    case CASH_RECEIPT = 'CASH_RECEIPT';              // ККТ чек (прямые продажи)
+    // Доходы / реализация
+    case SERVICE_ACT = 'SERVICE_ACT';                       // Акт выполненных работ / оказанных услуг
+    case SALES_DELIVERY_NOTE = 'SALES_DELIVERY_NOTE';       // Товарная накладная (реализация)
+    case COMMISSION_REPORT = 'COMMISSION_REPORT';           // Отчёт комиссионера / агента
 
-    // Закупки/COGS
-    case SUPPLIER_INVOICE = 'SUPPLIER_INVOICE';      // Счет/сф от поставщика
-    case MATERIAL_WRITE_OFF_ACT = 'MATERIAL_WRITE_OFF_ACT';
-    case MANUFACTURING_ACT = 'MANUFACTURING_ACT';    // Акт подрядчика (пошив)
-    case COST_ALLOCATION = 'COST_ALLOCATION';        // Калькуляция/распределение
+    // Закупки / COGS / склад
+    case PURCHASE_INVOICE = 'PURCHASE_INVOICE';             // Накладная от поставщика (закупка)
+    case ACCEPTANCE_ACT = 'ACCEPTANCE_ACT';                 // Акт приёмки-передачи
+    case WRITE_OFF_ACT = 'WRITE_OFF_ACT';                   // Акт списания
+    case INVENTORY_SHEET = 'INVENTORY_SHEET';               // Инвентаризационная опись
 
-    // OPEX
-    case AD_ACT = 'AD_ACT';                          // Реклама/инфлюенсеры
-    case RENT_ACT = 'RENT_ACT';
-    case UTILITIES_ACT = 'UTILITIES_ACT';            // Коммуналка/связь/интернет
-    case BANK_FEES_ACT = 'BANK_FEES_ACT';            // Банковские комиссии
-    case PAYROLL_SHEET = 'PAYROLL_SHEET';
-    case ADVANCE_REPORT = 'ADVANCE_REPORT';
+    // Финансовые / операционные / прочие
+    case LOAN_AND_SCHEDULE = 'LOAN_AND_SCHEDULE';           // Кредитный договор / график платежей
+    case PAYROLL_ACCRUAL = 'PAYROLL_ACCRUAL';               // Начисление заработной платы
+    case DEPRECIATION = 'DEPRECIATION';                     // Амортизация ОС
+    case TAXES_AND_CONTRIBUTIONS = 'TAXES_AND_CONTRIBUTIONS'; // Начисление налогов и взносов
+    case FX_PENALTIES = 'FX_PENALTIES';                     // Курсовые разницы, штрафы, пени
+    case SALES_OR_PURCHASE_RETURN = 'SALES_OR_PURCHASE_RETURN'; // Возврат от покупателя / поставщику
 
-    // Финансовые
-    case BANK_STATEMENT = 'BANK_STATEMENT';
-    case LOAN_INTEREST_STATEMENT = 'LOAN_INTEREST_STATEMENT';
-    case FX_REVALUATION_ACT = 'FX_REVALUATION_ACT';
-
-    // Прочее
+    /** @deprecated Только для обратной совместимости со старыми записями. Не использовать в новом коде и не показывать в UI. */
     case OTHER = 'OTHER';
 
     public static function fromLegacy(string $value): self
@@ -41,25 +33,19 @@ enum DocumentType: string
         $v = strtoupper(trim($value));
 
         return match ($v) {
-            'НАКЛАДНАЯ', 'ТОРГ-12', 'УПД' => self::DELIVERY_NOTE,
-            'ОТЧЕТ КОМИССИОНЕРА', 'ОТЧЕТ АГЕНТА' => self::COMMISSION_REPORT,
-            'ОТЧЕТ МАРКЕТПЛЕЙСА', 'WB', 'OZON', 'YANDEX' => self::MARKETPLACE_REPORT,
-            'АКТ', 'АКТ ВЫПОЛНЕННЫХ РАБОТ' => self::SERVICE_ACT,
-            'СЧЕТ-ФАКТУРА', 'РЕАЛИЗАЦИЯ' => self::SALES_INVOICE,
-            'СЧЕТ ПОСТАВЩИКА', 'СФ ПОСТАВЩИКА' => self::SUPPLIER_INVOICE,
-            'АКТ ПОДРЯДЧИКА', 'ПОШИВ' => self::MANUFACTURING_ACT,
-            'СПИСАНИЕ МАТЕРИАЛОВ' => self::MATERIAL_WRITE_OFF_ACT,
-            'КАЛЬКУЛЯЦИЯ', 'РАСПРЕДЕЛЕНИЕ ЗАТРАТ' => self::COST_ALLOCATION,
-            'РЕКЛАМА', 'АКТ РЕКЛАМЫ' => self::AD_ACT,
-            'АРЕНДА' => self::RENT_ACT,
-            'КОММУНАЛЬНЫЕ', 'СВЯЗЬ', 'ИНТЕРНЕТ' => self::UTILITIES_ACT,
-            'КОМИССИЯ БАНКА' => self::BANK_FEES_ACT,
-            'ВЕДОМОСТЬ ЗП', 'ЗАРПЛАТА' => self::PAYROLL_SHEET,
-            'АВАНСОВЫЙ ОТЧЕТ' => self::ADVANCE_REPORT,
-            'ВЫПИСКА БАНКА' => self::BANK_STATEMENT,
-            'ПРОЦЕНТЫ ПО КРЕДИТУ' => self::LOAN_INTEREST_STATEMENT,
-            'КУРСОВЫЕ РАЗНИЦЫ' => self::FX_REVALUATION_ACT,
-            'ЧЕК', 'ККТ' => self::CASH_RECEIPT,
+            'НАКЛАДНАЯ', 'ТОРГ-12', 'УПД', 'СЧЕТ-ФАКТУРА', 'РЕАЛИЗАЦИЯ', 'ЧЕК', 'ККТ' => self::SALES_DELIVERY_NOTE,
+            'АКТ', 'АКТ ВЫПОЛНЕННЫХ РАБОТ', 'АКТ ОКАЗАННЫХ УСЛУГ' => self::SERVICE_ACT,
+            'ОТЧЕТ КОМИССИОНЕРА', 'ОТЧЕТ АГЕНТА', 'ОТЧЕТ МАРКЕТПЛЕЙСА', 'WB', 'OZON', 'YANDEX' => self::COMMISSION_REPORT,
+            'СЧЕТ ПОСТАВЩИКА', 'СФ ПОСТАВЩИКА' => self::PURCHASE_INVOICE,
+            'АКТ ПОДРЯДЧИКА', 'ПОШИВ', 'АКТ ПРИЕМКИ-ПЕРЕДАЧИ' => self::ACCEPTANCE_ACT,
+            'СПИСАНИЕ МАТЕРИАЛОВ', 'АКТ СПИСАНИЯ' => self::WRITE_OFF_ACT,
+            'ИНВЕНТАРИЗАЦИЯ', 'ИНВЕНТАРИЗАЦИОННАЯ ОПИСЬ' => self::INVENTORY_SHEET,
+            'ПРОЦЕНТЫ ПО КРЕДИТУ', 'КРЕДИТНЫЙ ДОГОВОР', 'ГРАФИК ПЛАТЕЖЕЙ' => self::LOAN_AND_SCHEDULE,
+            'ВЕДОМОСТЬ ЗП', 'ЗАРПЛАТА', 'НАЧИСЛЕНИЕ ЗАРПЛАТЫ' => self::PAYROLL_ACCRUAL,
+            'АМОРТИЗАЦИЯ', 'АМОРТИЗАЦИЯ ОС' => self::DEPRECIATION,
+            'НАЛОГИ', 'ВЗНОСЫ', 'НАЧИСЛЕНИЕ НАЛОГОВ', 'НАЧИСЛЕНИЕ ВЗНОСОВ' => self::TAXES_AND_CONTRIBUTIONS,
+            'КУРСОВЫЕ РАЗНИЦЫ', 'ШТРАФЫ', 'ПЕНИ' => self::FX_PENALTIES,
+            'ВОЗВРАТ ОТ ПОКУПАТЕЛЯ', 'ВОЗВРАТ ПОСТАВЩИКУ', 'ВОЗВРАТ' => self::SALES_OR_PURCHASE_RETURN,
             default => self::OTHER,
         };
     }
@@ -67,25 +53,19 @@ enum DocumentType: string
     public function label(): string
     {
         return match ($this) {
-            self::SALES_INVOICE => 'Счет-фактура / Реализация',
-            self::DELIVERY_NOTE => 'Накладная / УПД',
-            self::SERVICE_ACT => 'Акт выполненных работ',
-            self::COMMISSION_REPORT => 'Отчет комиссионера / агента',
-            self::MARKETPLACE_REPORT => 'Отчет маркетплейса',
-            self::CASH_RECEIPT => 'ККТ чек (прямые продажи)',
-            self::SUPPLIER_INVOICE => 'Счет поставщика',
-            self::MATERIAL_WRITE_OFF_ACT => 'Списание материалов',
-            self::MANUFACTURING_ACT => 'Акт подрядчика (пошив)',
-            self::COST_ALLOCATION => 'Калькуляция / распределение',
-            self::AD_ACT => 'Реклама / инфлюенсеры',
-            self::RENT_ACT => 'Аренда',
-            self::UTILITIES_ACT => 'Коммунальные / связь / интернет',
-            self::BANK_FEES_ACT => 'Банковские комиссии',
-            self::PAYROLL_SHEET => 'Ведомость зарплаты',
-            self::ADVANCE_REPORT => 'Авансовый отчет',
-            self::BANK_STATEMENT => 'Выписка банка',
-            self::LOAN_INTEREST_STATEMENT => 'Проценты по кредиту',
-            self::FX_REVALUATION_ACT => 'Курсовые разницы',
+            self::SERVICE_ACT => 'Акт выполненных работ / оказанных услуг',
+            self::SALES_DELIVERY_NOTE => 'Товарная накладная (реализация)',
+            self::COMMISSION_REPORT => 'Отчёт комиссионера / агента',
+            self::PURCHASE_INVOICE => 'Накладная от поставщика (закупка)',
+            self::ACCEPTANCE_ACT => 'Акт приёмки-передачи',
+            self::WRITE_OFF_ACT => 'Акт списания',
+            self::INVENTORY_SHEET => 'Инвентаризационная опись',
+            self::LOAN_AND_SCHEDULE => 'Кредитный договор / график платежей',
+            self::PAYROLL_ACCRUAL => 'Начисление заработной платы',
+            self::DEPRECIATION => 'Амортизация ОС',
+            self::TAXES_AND_CONTRIBUTIONS => 'Начисление налогов и взносов',
+            self::FX_PENALTIES => 'Курсовые разницы, штрафы, пени',
+            self::SALES_OR_PURCHASE_RETURN => 'Возврат от покупателя / поставщику',
             self::OTHER => 'Прочее',
         };
     }
@@ -95,11 +75,20 @@ enum DocumentType: string
      */
     public static function choices(): array
     {
-        $choices = [];
-        foreach (self::cases() as $case) {
-            $choices[$case->label()] = $case;
-        }
-
-        return $choices;
+        return [
+            self::SERVICE_ACT->label() => self::SERVICE_ACT,
+            self::SALES_DELIVERY_NOTE->label() => self::SALES_DELIVERY_NOTE,
+            self::COMMISSION_REPORT->label() => self::COMMISSION_REPORT,
+            self::PURCHASE_INVOICE->label() => self::PURCHASE_INVOICE,
+            self::ACCEPTANCE_ACT->label() => self::ACCEPTANCE_ACT,
+            self::WRITE_OFF_ACT->label() => self::WRITE_OFF_ACT,
+            self::INVENTORY_SHEET->label() => self::INVENTORY_SHEET,
+            self::LOAN_AND_SCHEDULE->label() => self::LOAN_AND_SCHEDULE,
+            self::PAYROLL_ACCRUAL->label() => self::PAYROLL_ACCRUAL,
+            self::DEPRECIATION->label() => self::DEPRECIATION,
+            self::TAXES_AND_CONTRIBUTIONS->label() => self::TAXES_AND_CONTRIBUTIONS,
+            self::FX_PENALTIES->label() => self::FX_PENALTIES,
+            self::SALES_OR_PURCHASE_RETURN->label() => self::SALES_OR_PURCHASE_RETURN,
+        ];
     }
 }

--- a/site/src/Service/PlNatureResolver.php
+++ b/site/src/Service/PlNatureResolver.php
@@ -64,27 +64,21 @@ final class PlNatureResolver
     private function byDocumentType(DocumentType $type): ?PlNature
     {
         return match ($type) {
-            DocumentType::SALES_INVOICE,
-            DocumentType::DELIVERY_NOTE,
             DocumentType::SERVICE_ACT,
-            DocumentType::COMMISSION_REPORT,
-            DocumentType::MARKETPLACE_REPORT,
-            DocumentType::CASH_RECEIPT,
-            DocumentType::BANK_STATEMENT,
-            DocumentType::FX_REVALUATION_ACT => PlNature::INCOME,
+            DocumentType::SALES_DELIVERY_NOTE,
+            DocumentType::COMMISSION_REPORT => PlNature::INCOME,
 
-            DocumentType::SUPPLIER_INVOICE,
-            DocumentType::MATERIAL_WRITE_OFF_ACT,
-            DocumentType::MANUFACTURING_ACT,
-            DocumentType::COST_ALLOCATION,
-            DocumentType::AD_ACT,
-            DocumentType::RENT_ACT,
-            DocumentType::UTILITIES_ACT,
-            DocumentType::BANK_FEES_ACT,
-            DocumentType::PAYROLL_SHEET,
-            DocumentType::ADVANCE_REPORT,
-            DocumentType::LOAN_INTEREST_STATEMENT => PlNature::EXPENSE,
+            DocumentType::PURCHASE_INVOICE,
+            DocumentType::ACCEPTANCE_ACT,
+            DocumentType::WRITE_OFF_ACT,
+            DocumentType::INVENTORY_SHEET,
+            DocumentType::LOAN_AND_SCHEDULE,
+            DocumentType::PAYROLL_ACCRUAL,
+            DocumentType::DEPRECIATION,
+            DocumentType::TAXES_AND_CONTRIBUTIONS,
+            DocumentType::FX_PENALTIES => PlNature::EXPENSE,
 
+            DocumentType::SALES_OR_PURCHASE_RETURN,
             DocumentType::OTHER => null,
         };
     }

--- a/site/tests/Entity/DocumentTest.php
+++ b/site/tests/Entity/DocumentTest.php
@@ -24,10 +24,10 @@ final class DocumentTest extends TestCase
     public function testSetTypeUpdatesValue(): void
     {
         $document = $this->createDocument();
-        $document->setType(DocumentType::AD_ACT);
+        $document->setType(DocumentType::PAYROLL_ACCRUAL);
 
-        self::assertSame(DocumentType::AD_ACT, $document->getType());
-        self::assertSame('AD_ACT', $document->getTypeValue());
+        self::assertSame(DocumentType::PAYROLL_ACCRUAL, $document->getType());
+        self::assertSame('PAYROLL_ACCRUAL', $document->getTypeValue());
     }
 
     private function createDocument(): Document

--- a/site/tests/Enum/DocumentTypeFromLegacyTest.php
+++ b/site/tests/Enum/DocumentTypeFromLegacyTest.php
@@ -11,12 +11,12 @@ final class DocumentTypeFromLegacyTest extends TestCase
 {
     public function testDeliveryNoteMapping(): void
     {
-        self::assertSame(DocumentType::DELIVERY_NOTE, DocumentType::fromLegacy('Накладная'));
+        self::assertSame(DocumentType::SALES_DELIVERY_NOTE, DocumentType::fromLegacy('Накладная'));
     }
 
     public function testMarketplaceReportMapping(): void
     {
-        self::assertSame(DocumentType::MARKETPLACE_REPORT, DocumentType::fromLegacy('Отчет маркетплейса'));
+        self::assertSame(DocumentType::COMMISSION_REPORT, DocumentType::fromLegacy('Отчет маркетплейса'));
     }
 
     public function testUnknownMappingFallsBackToOther(): void

--- a/site/tests/Service/PlNatureResolverTest.php
+++ b/site/tests/Service/PlNatureResolverTest.php
@@ -23,7 +23,7 @@ final class PlNatureResolverTest extends TestCase
 
         $company = $this->createCompany();
         $document = new Document(Uuid::uuid4()->toString(), $company);
-        $document->setType(DocumentType::SUPPLIER_INVOICE);
+        $document->setType(DocumentType::PURCHASE_INVOICE);
 
         $revenueRoot = $this->createCategory($company, 'Revenue');
         $revenueChild = $this->createCategory($company, 'Marketplace Sales', $revenueRoot);
@@ -41,7 +41,7 @@ final class PlNatureResolverTest extends TestCase
 
         $company = $this->createCompany();
         $document = new Document(Uuid::uuid4()->toString(), $company);
-        $document->setType(DocumentType::MARKETPLACE_REPORT);
+        $document->setType(DocumentType::SALES_DELIVERY_NOTE);
 
         $operation = new DocumentOperation();
         $operation->setDocument($document);
@@ -55,7 +55,7 @@ final class PlNatureResolverTest extends TestCase
 
         $company = $this->createCompany();
         $document = new Document(Uuid::uuid4()->toString(), $company);
-        $document->setType(DocumentType::MARKETPLACE_REPORT);
+        $document->setType(DocumentType::SALES_DELIVERY_NOTE);
 
         $revenueRoot = $this->createCategory($company, 'Revenue');
         $revenueChild = $this->createCategory($company, 'Marketplace Sales', $revenueRoot);


### PR DESCRIPTION
## Summary
- replace the document type enum with the curated P&L-related set while keeping OTHER deprecated for legacy records
- adjust PL nature resolution, legacy normalization, and tests to honor the new document type list

## Testing
- `composer test` *(fails: phpunit: not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1f5dd7e0832387e706d753af0747