### PR TITLE
Add project direction support to cash transaction auto rules

### DIFF
--- a/site/migrations/Version20250915090000.php
+++ b/site/migrations/Version20250915090000.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250915090000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add project direction reference to cash transaction auto rules';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE cash_transaction_auto_rule ADD project_direction_id UUID DEFAULT NULL');
+        $this->addSql('CREATE INDEX idx_ctar_project_direction ON cash_transaction_auto_rule (project_direction_id)');
+        $this->addSql('ALTER TABLE cash_transaction_auto_rule ADD CONSTRAINT fk_ctar_project_direction FOREIGN KEY (project_direction_id) REFERENCES project_directions (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_ctar_project_direction');
+        $this->addSql('ALTER TABLE cash_transaction_auto_rule DROP CONSTRAINT fk_ctar_project_direction');
+        $this->addSql('ALTER TABLE cash_transaction_auto_rule DROP COLUMN project_direction_id');
+    }
+}

--- a/site/src/Controller/CashTransactionAutoRuleController.php
+++ b/site/src/Controller/CashTransactionAutoRuleController.php
@@ -14,6 +14,7 @@ use App\Repository\CashflowCategoryRepository;
 use App\Repository\CashTransactionAutoRuleRepository;
 use App\Repository\CashTransactionRepository;
 use App\Repository\CounterpartyRepository;
+use App\Repository\ProjectDirectionRepository;
 use App\Service\ActiveCompanyService;
 use App\Service\CashTransactionAutoRuleService;
 use Doctrine\ORM\EntityManagerInterface;
@@ -45,10 +46,12 @@ class CashTransactionAutoRuleController extends AbstractController
         ActiveCompanyService $companyService,
         CashflowCategoryRepository $categoryRepo,
         CounterpartyRepository $counterpartyRepo,
+        ProjectDirectionRepository $projectDirectionRepo,
     ): Response {
         $company = $companyService->getActiveCompany();
         $categories = $categoryRepo->findTreeByCompany($company);
         $counterparties = $counterpartyRepo->findBy(['company' => $company]);
+        $projectDirections = $projectDirectionRepo->findBy(['company' => $company], ['name' => 'ASC']);
 
         $rule = new CashTransactionAutoRule(
             Uuid::uuid4()->toString(),
@@ -61,6 +64,7 @@ class CashTransactionAutoRuleController extends AbstractController
         $form = $this->createForm(CashTransactionAutoRuleType::class, $rule, [
             'categories' => $categories,
             'counterparties' => $counterparties,
+            'projectDirections' => $projectDirections,
         ]);
         $form->handleRequest($request);
 
@@ -85,6 +89,7 @@ class CashTransactionAutoRuleController extends AbstractController
         ActiveCompanyService $companyService,
         CashflowCategoryRepository $categoryRepo,
         CounterpartyRepository $counterpartyRepo,
+        ProjectDirectionRepository $projectDirectionRepo,
     ): Response {
         $company = $companyService->getActiveCompany();
         $rule = $repo->find($id);
@@ -94,9 +99,11 @@ class CashTransactionAutoRuleController extends AbstractController
 
         $categories = $categoryRepo->findTreeByCompany($company);
         $counterparties = $counterpartyRepo->findBy(['company' => $company]);
+        $projectDirections = $projectDirectionRepo->findBy(['company' => $company], ['name' => 'ASC']);
         $form = $this->createForm(CashTransactionAutoRuleType::class, $rule, [
             'categories' => $categories,
             'counterparties' => $counterparties,
+            'projectDirections' => $projectDirections,
         ]);
         $form->handleRequest($request);
 

--- a/site/src/Entity/CashTransactionAutoRule.php
+++ b/site/src/Entity/CashTransactionAutoRule.php
@@ -37,6 +37,10 @@ class CashTransactionAutoRule
     #[ORM\JoinColumn(nullable: false, onDelete: 'RESTRICT')]
     private ?CashflowCategory $cashflowCategory = null;
 
+    #[ORM\ManyToOne(targetEntity: ProjectDirection::class)]
+    #[ORM\JoinColumn(onDelete: 'SET NULL')]
+    private ?ProjectDirection $projectDirection = null;
+
     /** @var Collection<int, CashTransactionAutoRuleCondition> */
     #[ORM\OneToMany(mappedBy: 'autoRule', targetEntity: CashTransactionAutoRuleCondition::class, cascade: ['persist', 'remove'], orphanRemoval: true)]
     private Collection $conditions;
@@ -122,6 +126,18 @@ class CashTransactionAutoRule
     public function setCashflowCategory(CashflowCategory $cashflowCategory): self
     {
         $this->cashflowCategory = $cashflowCategory;
+
+        return $this;
+    }
+
+    public function getProjectDirection(): ?ProjectDirection
+    {
+        return $this->projectDirection;
+    }
+
+    public function setProjectDirection(?ProjectDirection $projectDirection): self
+    {
+        $this->projectDirection = $projectDirection;
 
         return $this;
     }

--- a/site/src/Form/CashTransactionAutoRuleType.php
+++ b/site/src/Form/CashTransactionAutoRuleType.php
@@ -4,6 +4,7 @@ namespace App\Form;
 
 use App\Entity\CashflowCategory;
 use App\Entity\CashTransactionAutoRule;
+use App\Entity\ProjectDirection;
 use App\Enum\CashTransactionAutoRuleAction;
 use App\Enum\CashTransactionAutoRuleOperationType;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
@@ -56,6 +57,14 @@ class CashTransactionAutoRuleType extends AbstractType
                 },
                 'label' => 'Категория движения ДДС',
             ])
+            ->add('projectDirection', EntityType::class, [
+                'class' => ProjectDirection::class,
+                'choices' => $options['projectDirections'],
+                'choice_label' => fn (ProjectDirection $item) => $item->getName(),
+                'placeholder' => 'Не выбрано',
+                'required' => false,
+                'label' => 'Направление / проект',
+            ])
             ->add('conditions', CollectionType::class, [
                 'entry_type' => CashTransactionAutoRuleConditionType::class,
                 'entry_options' => [
@@ -74,6 +83,7 @@ class CashTransactionAutoRuleType extends AbstractType
             'data_class' => CashTransactionAutoRule::class,
             'categories' => [],
             'counterparties' => [],
+            'projectDirections' => [],
         ]);
     }
 }

--- a/site/src/Service/CashTransactionAutoRuleService.php
+++ b/site/src/Service/CashTransactionAutoRuleService.php
@@ -136,7 +136,7 @@ class CashTransactionAutoRuleService
     /**
      * Применить правило к одной транзакции.
      * Возвращает true, если были изменения; false — если изменений не было.
-     * NB: в текущей модели правила меняют только Категорию ДДС.
+     * NB: в текущей модели правила меняют Категорию ДДС и Направление/Проект.
      */
     public function applyRule(CashTransactionAutoRule $rule, CashTransaction $t): bool
     {
@@ -148,19 +148,28 @@ class CashTransactionAutoRuleService
         }
 
         $category = $rule->getCashflowCategory(); // в сущности правила поле not-null
+        $projectDirection = $rule->getProjectDirection();
         $action = $rule->getAction();
 
         // Семантика:
         // FILL   — ставим категорию только если у транзакции она пуста
         // UPDATE — перезаписываем всегда
         if (CashTransactionAutoRuleAction::FILL === $action) {
-            if (null === $t->getCashflowCategory()) {
+            if (null === $t->getCashflowCategory() && null !== $category) {
                 $t->setCashflowCategory($category);
+                $changed = true;
+            }
+            if (null === $t->getProjectDirection() && null !== $projectDirection) {
+                $t->setProjectDirection($projectDirection);
                 $changed = true;
             }
         } else { // UPDATE
             if ($t->getCashflowCategory() !== $category) {
                 $t->setCashflowCategory($category);
+                $changed = true;
+            }
+            if ($t->getProjectDirection() !== $projectDirection) {
+                $t->setProjectDirection($projectDirection);
                 $changed = true;
             }
         }

--- a/site/templates/cash_transaction_auto_rule/check.html.twig
+++ b/site/templates/cash_transaction_auto_rule/check.html.twig
@@ -34,7 +34,7 @@
         <thead>
           <tr>
             <th>Дата</th><th>Счет</th><th class="text-end">Сумма</th>
-            <th>Статья</th><th>Контрагент</th><th>Описание</th><th></th>
+            <th>Статья</th><th>Проект</th><th>Контрагент</th><th>Описание</th><th></th>
           </tr>
         </thead>
         <tbody>
@@ -44,6 +44,7 @@
             <td>{{ t.moneyAccount.name }}</td>
             <td class="text-end">{{ t.amount|number_format(2, ',', ' ') }} {{ t.currency }}</td>
             <td>{{ t.cashflowCategory ? t.cashflowCategory.name : '' }}</td>
+            <td>{{ t.projectDirection ? t.projectDirection.name : '' }}</td>
             <td>{{ t.counterparty ? t.counterparty.name : '' }}</td>
             <td>{{ t.description }}</td>
             <td class="text-nowrap">
@@ -51,7 +52,7 @@
             </td>
           </tr>
         {% else %}
-          <tr><td colspan="7" class="text-center text-muted">Совпадений нет</td></tr>
+          <tr><td colspan="8" class="text-center text-muted">Совпадений нет</td></tr>
         {% endfor %}
         </tbody>
       </table>

--- a/site/templates/cash_transaction_auto_rule/edit.html.twig
+++ b/site/templates/cash_transaction_auto_rule/edit.html.twig
@@ -19,6 +19,7 @@
                 {{ form_row(form.action) }}
                 {{ form_row(form.operationType) }}
                 {{ form_row(form.cashflowCategory) }}
+                {{ form_row(form.projectDirection) }}
                 <div class="mb-3">
                     <label class="form-label">Правила</label>
                     <div data-collection-holder data-prototype="{{ form_widget(form.conditions.vars.prototype)|e('html_attr') }}">

--- a/site/templates/cash_transaction_auto_rule/index.html.twig
+++ b/site/templates/cash_transaction_auto_rule/index.html.twig
@@ -24,6 +24,7 @@
                             <th>Действие</th>
                             <th>Тип операции</th>
                             <th>Категория</th>
+                            <th>Направление / проект</th>
                             <th></th>
                         </tr>
                     </thead>
@@ -34,6 +35,7 @@
                             <td>{{ item.action.name }}</td>
                             <td>{{ item.operationType.name }}</td>
                             <td>{{ item.cashflowCategory.name }}</td>
+                            <td>{{ item.projectDirection ? item.projectDirection.name : '' }}</td>
                             <td class="text-end">
                                 <a href="{{ path('cash_transaction_auto_rule_check', {id: item.id}) }}" class="btn btn-sm btn-secondary">пров.</a>
                                 <a href="{{ path('cash_transaction_auto_rule_edit', {id: item.id}) }}" class="btn btn-sm btn-warning">✏️</a>
@@ -44,7 +46,7 @@
                             </td>
                         </tr>
                     {% else %}
-                        <tr><td colspan="5" class="text-center">Нет данных</td></tr>
+                        <tr><td colspan="6" class="text-center">Нет данных</td></tr>
                     {% endfor %}
                     </tbody>
                 </table>

--- a/site/templates/cash_transaction_auto_rule/new.html.twig
+++ b/site/templates/cash_transaction_auto_rule/new.html.twig
@@ -19,6 +19,7 @@
                 {{ form_row(form.action) }}
                 {{ form_row(form.operationType) }}
                 {{ form_row(form.cashflowCategory) }}
+                {{ form_row(form.projectDirection) }}
                 <div class="mb-3">
                     <label class="form-label">Правила</label>
                     <div data-collection-holder data-prototype="{{ form_widget(form.conditions.vars.prototype)|e('html_attr') }}">


### PR DESCRIPTION
## Summary
- allow cash transaction auto rules to persist the selected project direction alongside cashflow category
- expose project direction selection throughout the auto rule forms, listings, and preview table
- add a database migration to store the optional project direction reference for auto rules

## Testing
- php bin/phpunit *(fails: simple-phpunit.php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dd5108947c832380d65ce604d6dd6b