### PR TITLE
Add missing cash transaction show route

### DIFF
--- a/site/src/Controller/Finance/CashTransactionController.php
+++ b/site/src/Controller/Finance/CashTransactionController.php
@@ -126,6 +126,19 @@ class CashTransactionController extends AbstractController
         ]);
     }
 
+    #[Route('/{id}', name: 'cash_transaction_show', requirements: ['id' => '\\d+'], methods: ['GET'])]
+    public function show(CashTransaction $tx): Response
+    {
+        $company = $this->companyService->getActiveCompany();
+        if ($tx->getCompany() !== $company) {
+            throw $this->createNotFoundException();
+        }
+
+        return $this->render('transaction/show.html.twig', [
+            'tx' => $tx,
+        ]);
+    }
+
     /**
      * @throws ORMException
      */


### PR DESCRIPTION
## Summary
- add a show route for cash transactions so existing templates can link to it
- ensure the action checks the active company before rendering the transaction details

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd54dfaefc8323ae55ab8fc07d1c18