### PR TITLE
Align cash transaction auto rule form fields

### DIFF
--- a/site/templates/cash_transaction_auto_rule/edit.html.twig
+++ b/site/templates/cash_transaction_auto_rule/edit.html.twig
@@ -16,10 +16,22 @@
             <div class="card-body">
                 {{ form_start(form) }}
                 {{ form_row(form.name) }}
-                {{ form_row(form.action) }}
-                {{ form_row(form.operationType) }}
-                {{ form_row(form.cashflowCategory) }}
-                {{ form_row(form.projectDirection) }}
+                <div class="row">
+                    <div class="col-md-6">
+                        {{ form_row(form.action) }}
+                    </div>
+                    <div class="col-md-6">
+                        {{ form_row(form.operationType) }}
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-md-6">
+                        {{ form_row(form.cashflowCategory) }}
+                    </div>
+                    <div class="col-md-6">
+                        {{ form_row(form.projectDirection) }}
+                    </div>
+                </div>
                 <div class="mb-3">
                     <label class="form-label">Правила</label>
                     <div data-collection-holder data-prototype="{{ form_widget(form.conditions.vars.prototype)|e('html_attr') }}">

--- a/site/templates/cash_transaction_auto_rule/new.html.twig
+++ b/site/templates/cash_transaction_auto_rule/new.html.twig
@@ -16,10 +16,22 @@
             <div class="card-body">
                 {{ form_start(form) }}
                 {{ form_row(form.name) }}
-                {{ form_row(form.action) }}
-                {{ form_row(form.operationType) }}
-                {{ form_row(form.cashflowCategory) }}
-                {{ form_row(form.projectDirection) }}
+                <div class="row">
+                    <div class="col-md-6">
+                        {{ form_row(form.action) }}
+                    </div>
+                    <div class="col-md-6">
+                        {{ form_row(form.operationType) }}
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-md-6">
+                        {{ form_row(form.cashflowCategory) }}
+                    </div>
+                    <div class="col-md-6">
+                        {{ form_row(form.projectDirection) }}
+                    </div>
+                </div>
                 <div class="mb-3">
                     <label class="form-label">Правила</label>
                     <div data-collection-holder data-prototype="{{ form_widget(form.conditions.vars.prototype)|e('html_attr') }}">


### PR DESCRIPTION
## Summary
- display the action and operation type inputs on the same row in the auto rule form
- display the cashflow category and project direction inputs on the same row in the auto rule form

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68dd5614e8608323baf98bb588dddec3