### PR TITLE
Ensure auto rule description matching ignores case

### DIFF
--- a/site/src/Controller/CashTransactionAutoRuleController.php
+++ b/site/src/Controller/CashTransactionAutoRuleController.php
@@ -17,6 +17,7 @@ use App\Repository\CounterpartyRepository;
 use App\Repository\ProjectDirectionRepository;
 use App\Service\ActiveCompanyService;
 use App\Service\CashTransactionAutoRuleService;
+use App\Util\StringNormalizer;
 use Doctrine\ORM\EntityManagerInterface;
 use Ramsey\Uuid\Uuid;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -166,8 +167,8 @@ class CashTransactionAutoRuleController extends AbstractController
 
                 case CashTransactionAutoRuleConditionField::COUNTERPARTY_NAME:
                     $needJoinCp = true;
-                    $qb->andWhere('LOWER(cp.name) LIKE :'.$p)
-                       ->setParameter($p, '%'.mb_strtolower(str_replace('ё', 'е', (string) $cond->getValue())).'%');
+                    $qb->andWhere("REPLACE(LOWER(COALESCE(cp.name, '')), 'ё', 'е') LIKE :$p")
+                       ->setParameter($p, '%'.StringNormalizer::normalize((string) $cond->getValue()).'%');
                     break;
 
                 case CashTransactionAutoRuleConditionField::INN:
@@ -204,8 +205,8 @@ class CashTransactionAutoRuleController extends AbstractController
                     break;
 
                 case CashTransactionAutoRuleConditionField::DESCRIPTION:
-                    $qb->andWhere('LOWER(COALESCE(t.description, \'\')) LIKE :'.$p)
-                       ->setParameter($p, '%'.mb_strtolower(str_replace('ё', 'е', (string) $cond->getValue())).'%');
+                    $qb->andWhere("REPLACE(LOWER(COALESCE(t.description, '')), 'ё', 'е') LIKE :$p")
+                       ->setParameter($p, '%'.StringNormalizer::normalize((string) $cond->getValue()).'%');
                     break;
             }
         }

--- a/site/src/Service/CashTransactionAutoRuleService.php
+++ b/site/src/Service/CashTransactionAutoRuleService.php
@@ -9,6 +9,7 @@ use App\Enum\CashTransactionAutoRuleAction;
 use App\Enum\CashTransactionAutoRuleConditionField;
 use App\Enum\CashTransactionAutoRuleConditionOperator;
 use App\Repository\CashTransactionAutoRuleRepository;
+use App\Util\StringNormalizer;
 use Doctrine\ORM\EntityManagerInterface;
 
 class CashTransactionAutoRuleService
@@ -58,7 +59,7 @@ class CashTransactionAutoRuleService
 
                     case CashTransactionAutoRuleConditionField::COUNTERPARTY_NAME:
                         $name = $t->getCounterparty()?->getName() ?? '';
-                        if (!$this->containsNormalized($name, $value)) {
+                        if (!StringNormalizer::contains($name, $value)) {
                             $ok = false;
                         }
                         break;
@@ -114,7 +115,7 @@ class CashTransactionAutoRuleService
 
                     case CashTransactionAutoRuleConditionField::DESCRIPTION:
                         $desc = $t->getDescription() ?? '';
-                        if (!$this->containsNormalized($desc, $value)) {
+                        if (!StringNormalizer::contains($desc, $value)) {
                             $ok = false;
                         }
                         break;
@@ -181,12 +182,4 @@ class CashTransactionAutoRuleService
         return $changed;
     }
 
-    private function containsNormalized(string $haystack, string $needle): bool
-    {
-        $norm = fn (string $s) => mb_strtolower(str_replace('ё', 'е', $s));
-        $h = $norm($haystack);
-        $n = $norm($needle);
-
-        return '' !== $n && false !== mb_strpos($h, $n);
-    }
 }

--- a/site/src/Util/StringNormalizer.php
+++ b/site/src/Util/StringNormalizer.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Util;
+
+final class StringNormalizer
+{
+    private function __construct()
+    {
+    }
+
+    public static function normalize(string $value): string
+    {
+        $value = mb_strtolower($value, 'UTF-8');
+
+        return str_replace('ё', 'е', $value);
+    }
+
+    public static function contains(string $haystack, string $needle): bool
+    {
+        $needle = self::normalize($needle);
+
+        if ('' === $needle) {
+            return false;
+        }
+
+        return false !== mb_strpos(self::normalize($haystack), $needle);
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable string normalizer for case-insensitive matching with ё replacement
- reuse the normalizer in the auto-rule service and preview query to keep description checks case-agnostic

## Testing
- composer test *(fails: phpunit not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de030b77088323aec137b329e712a1