### PR TITLE
feat(pl-category): безопасный рефактор + CRUD-UI для дерева P&L

### DIFF
--- a/site/migrations/Version20251001000001.php
+++ b/site/migrations/Version20251001000001.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20251001000001 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Extend PL categories with codes, types, visibility and formatting';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE pl_categories
+        ADD COLUMN code VARCHAR(64) DEFAULT NULL,
+        ADD COLUMN type VARCHAR(16) NOT NULL DEFAULT 'LEAF_INPUT',
+        ADD COLUMN format VARCHAR(16) NOT NULL DEFAULT 'MONEY',
+        ADD COLUMN weight_in_parent NUMERIC(10, 4) NOT NULL DEFAULT '1.0000',
+        ADD COLUMN is_visible BOOLEAN NOT NULL DEFAULT TRUE,
+        ADD COLUMN formula TEXT DEFAULT NULL,
+        ADD COLUMN calc_order INT DEFAULT NULL
+    ");
+        $this->addSql("CREATE UNIQUE INDEX uniq_plcat_company_code ON pl_categories (company_id, code)");
+        $this->addSql("CREATE INDEX idx_plcat_company_parent_sort ON pl_categories (company_id, parent_id, sort_order)");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS idx_plcat_company_parent_sort');
+        $this->addSql('DROP INDEX IF EXISTS uniq_plcat_company_code');
+        $this->addSql("ALTER TABLE pl_categories
+        DROP COLUMN code,
+        DROP COLUMN type,
+        DROP COLUMN format,
+        DROP COLUMN weight_in_parent,
+        DROP COLUMN is_visible,
+        DROP COLUMN formula,
+        DROP COLUMN calc_order
+    ");
+    }
+}

--- a/site/src/Controller/PLCategoryController.php
+++ b/site/src/Controller/PLCategoryController.php
@@ -5,47 +5,54 @@ namespace App\Controller;
 use App\Entity\PLCategory;
 use App\Form\PLCategoryType;
 use App\Repository\PLCategoryRepository;
-use App\Service\ActiveCompanyService;
+use App\Service\CompanyContextService;
+use App\Service\PLCategoryTree;
 use Doctrine\ORM\EntityManagerInterface;
-use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\Nonstandard\Uuid;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-#[Route('/pl-categories')]
+#[Route('/pl/categories')]
 class PLCategoryController extends AbstractController
 {
-    #[Route('/', name: 'pl_category_index', methods: ['GET'])]
-    public function index(PLCategoryRepository $repo, ActiveCompanyService $companyService): Response
+    #[Route('', name: 'pl_category_index', methods: ['GET'])]
+    public function index(PLCategoryRepository $repository, CompanyContextService $context): Response
     {
-        $company = $companyService->getActiveCompany();
-        $items = $repo->findRootByCompany($company);
+        $company = $context->getCompany();
+        $items = $repository->qbForCompany($company)->getQuery()->getResult();
+        $tree = PLCategoryTree::build($items);
 
         return $this->render('pl_category/index.html.twig', [
-            'items' => $items,
+            'tree' => $tree,
         ]);
     }
 
     #[Route('/new', name: 'pl_category_new', methods: ['GET', 'POST'])]
-    public function new(Request $request, PLCategoryRepository $repo, EntityManagerInterface $em, ActiveCompanyService $companyService): Response
+    public function new(Request $request, EntityManagerInterface $entityManager, CompanyContextService $context, PLCategoryRepository $repository): Response
     {
-        $company = $companyService->getActiveCompany();
+        $company = $context->getCompany();
         $category = new PLCategory(Uuid::uuid4()->toString(), $company);
 
-        $parents = $repo->findTreeByCompany($company);
-        $form = $this->createForm(PLCategoryType::class, $category, ['parents' => $parents]);
+        if ($parentId = $request->query->get('parent')) {
+            $parent = $repository->find($parentId);
+            if ($parent && $parent->getCompany()->getId() === $company->getId()) {
+                $category->setParent($parent);
+                $category->setSortOrder($parent->getChildren()->count() + 1);
+            }
+        }
+
+        $form = $this->createForm(PLCategoryType::class, $category, ['company' => $company]);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            if ($category->getParent() && $category->getParent()->getLevel() >= 5) {
-                $this->addFlash('danger', 'Максимальная вложенность — 5 уровней');
-            } else {
-                $em->persist($category);
-                $em->flush();
+            $entityManager->persist($category);
+            $entityManager->flush();
 
-                return $this->redirectToRoute('pl_category_index');
-            }
+            $this->addFlash('success', 'Категория создана');
+
+            return $this->redirectToRoute('pl_category_index');
         }
 
         return $this->render('pl_category/new.html.twig', [
@@ -54,45 +61,143 @@ class PLCategoryController extends AbstractController
     }
 
     #[Route('/{id}/edit', name: 'pl_category_edit', methods: ['GET', 'POST'])]
-    public function edit(Request $request, PLCategory $category, PLCategoryRepository $repo, EntityManagerInterface $em, ActiveCompanyService $companyService): Response
+    public function edit(PLCategory $category, Request $request, EntityManagerInterface $entityManager, CompanyContextService $context): Response
     {
-        $company = $companyService->getActiveCompany();
-        if ($category->getCompany() !== $company) {
-            throw $this->createNotFoundException();
+        $this->denyAccessUnlessGranted('ROLE_USER');
+
+        $company = $context->getCompany();
+        if ($category->getCompany()->getId() !== $company->getId()) {
+            throw $this->createAccessDeniedException();
         }
 
-        $parents = $repo->findTreeByCompany($company);
-        $form = $this->createForm(PLCategoryType::class, $category, ['parents' => $parents]);
+        $form = $this->createForm(PLCategoryType::class, $category, ['company' => $company]);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            if ($category->getParent() && $category->getParent()->getLevel() >= 5) {
-                $this->addFlash('danger', 'Максимальная вложенность — 5 уровней');
-            } else {
-                $em->flush();
+            $entityManager->flush();
+            $this->addFlash('success', 'Сохранено');
 
-                return $this->redirectToRoute('pl_category_index');
-            }
+            return $this->redirectToRoute('pl_category_index');
         }
 
         return $this->render('pl_category/edit.html.twig', [
             'form' => $form->createView(),
-            'item' => $category,
+            'category' => $category,
         ]);
     }
 
     #[Route('/{id}/delete', name: 'pl_category_delete', methods: ['POST'])]
-    public function delete(Request $request, PLCategory $category, EntityManagerInterface $em, ActiveCompanyService $companyService): Response
+    public function delete(PLCategory $category, Request $request, EntityManagerInterface $entityManager, CompanyContextService $context): Response
     {
-        $company = $companyService->getActiveCompany();
-        if ($category->getCompany() !== $company) {
-            throw $this->createNotFoundException();
+        if (!$this->isCsrfTokenValid('del' . $category->getId(), $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
         }
 
-        if ($this->isCsrfTokenValid('delete'.$category->getId(), $request->request->get('_token'))) {
-            $em->remove($category);
-            $em->flush();
+        $company = $context->getCompany();
+        if ($category->getCompany()->getId() !== $company->getId()) {
+            throw $this->createAccessDeniedException();
         }
+
+        if ($category->getChildren()->count() > 0) {
+            $this->addFlash('warning', 'Удаление запрещено: есть дочерние категории.');
+
+            return $this->redirectToRoute('pl_category_index');
+        }
+
+        $entityManager->remove($category);
+        $entityManager->flush();
+
+        $this->addFlash('success', 'Удалено');
+
+        return $this->redirectToRoute('pl_category_index');
+    }
+
+    #[Route('/{id}/move-up', name: 'pl_category_move_up', methods: ['POST'])]
+    public function moveUp(PLCategory $category, Request $request, EntityManagerInterface $entityManager, CompanyContextService $context, PLCategoryRepository $repository): Response
+    {
+        if (!$this->isCsrfTokenValid('up' . $category->getId(), $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $company = $context->getCompany();
+        if ($category->getCompany()->getId() !== $company->getId()) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $siblings = $repository->createQueryBuilder('c')
+            ->andWhere('c.company = :company')
+            ->andWhere('c.parent = :parent')
+            ->setParameter('company', $company)
+            ->setParameter('parent', $category->getParent())
+            ->orderBy('c.sortOrder', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        $count = count($siblings);
+        for ($index = 0; $index < $count; $index++) {
+            if ($siblings[$index]->getId() === $category->getId() && $index > 0) {
+                $previous = $siblings[$index - 1];
+                $currentOrder = $category->getSortOrder();
+                $category->setSortOrder($previous->getSortOrder());
+                $previous->setSortOrder($currentOrder);
+                $entityManager->flush();
+                break;
+            }
+        }
+
+        return $this->redirectToRoute('pl_category_index');
+    }
+
+    #[Route('/{id}/move-down', name: 'pl_category_move_down', methods: ['POST'])]
+    public function moveDown(PLCategory $category, Request $request, EntityManagerInterface $entityManager, CompanyContextService $context, PLCategoryRepository $repository): Response
+    {
+        if (!$this->isCsrfTokenValid('down' . $category->getId(), $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $company = $context->getCompany();
+        if ($category->getCompany()->getId() !== $company->getId()) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $siblings = $repository->createQueryBuilder('c')
+            ->andWhere('c.company = :company')
+            ->andWhere('c.parent = :parent')
+            ->setParameter('company', $company)
+            ->setParameter('parent', $category->getParent())
+            ->orderBy('c.sortOrder', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        $count = count($siblings);
+        for ($index = 0; $index < $count; $index++) {
+            if ($siblings[$index]->getId() === $category->getId() && $index < $count - 1) {
+                $next = $siblings[$index + 1];
+                $currentOrder = $category->getSortOrder();
+                $category->setSortOrder($next->getSortOrder());
+                $next->setSortOrder($currentOrder);
+                $entityManager->flush();
+                break;
+            }
+        }
+
+        return $this->redirectToRoute('pl_category_index');
+    }
+
+    #[Route('/{id}/toggle-visible', name: 'pl_category_toggle_visible', methods: ['POST'])]
+    public function toggleVisible(PLCategory $category, Request $request, EntityManagerInterface $entityManager, CompanyContextService $context): Response
+    {
+        if (!$this->isCsrfTokenValid('vis' . $category->getId(), $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $company = $context->getCompany();
+        if ($category->getCompany()->getId() !== $company->getId()) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $category->setIsVisible(!$category->isVisible());
+        $entityManager->flush();
 
         return $this->redirectToRoute('pl_category_index');
     }

--- a/site/src/Entity/PLCategory.php
+++ b/site/src/Entity/PLCategory.php
@@ -2,15 +2,23 @@
 
 namespace App\Entity;
 
+use App\Enum\PLCategoryType;
+use App\Enum\PLValueFormat;
 use App\Enum\PlNature;
 use App\Repository\PLCategoryRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Webmozart\Assert\Assert;
 
 #[ORM\Entity(repositoryClass: PLCategoryRepository::class)]
-#[ORM\Table(name: 'pl_categories')]
+#[ORM\Table(
+    name: 'pl_categories',
+    uniqueConstraints: [new ORM\UniqueConstraint(name: 'uniq_plcat_company_code', columns: ['company_id', 'code'])],
+    indexes: [new ORM\Index(name: 'idx_plcat_company_parent_sort', columns: ['company_id', 'parent_id', 'sort_order'])]
+)]
+#[UniqueEntity(fields: ['company', 'code'], message: 'Код должен быть уникален в рамках компании.')]
 class PLCategory
 {
     #[ORM\Id]
@@ -23,6 +31,27 @@ class PLCategory
 
     #[ORM\Column(length: 255)]
     private string $name;
+
+    #[ORM\Column(length: 64, nullable: true)]
+    private ?string $code = null;
+
+    #[ORM\Column(enumType: PLCategoryType::class, options: ['default' => 'LEAF_INPUT'])]
+    private PLCategoryType $type = PLCategoryType::LEAF_INPUT;
+
+    #[ORM\Column(enumType: PLValueFormat::class, options: ['default' => 'MONEY'])]
+    private PLValueFormat $format = PLValueFormat::MONEY;
+
+    #[ORM\Column(type: 'decimal', precision: 10, scale: 4, options: ['default' => '1.0000'])]
+    private string $weightInParent = '1.0000';
+
+    #[ORM\Column(type: 'boolean', options: ['default' => true])]
+    private bool $isVisible = true;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $formula = null;
+
+    #[ORM\Column(type: 'integer', nullable: true)]
+    private ?int $calcOrder = null;
 
     #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
     private ?self $parent = null;
@@ -113,6 +142,90 @@ class PLCategory
     public function setSortOrder(int $sortOrder): self
     {
         $this->sortOrder = $sortOrder;
+
+        return $this;
+    }
+
+    public function getCode(): ?string
+    {
+        return $this->code;
+    }
+
+    public function setCode(?string $code): self
+    {
+        $this->code = $code ? mb_strtoupper(trim($code)) : null;
+
+        return $this;
+    }
+
+    public function getType(): PLCategoryType
+    {
+        return $this->type;
+    }
+
+    public function setType(PLCategoryType $type): self
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function getFormat(): PLValueFormat
+    {
+        return $this->format;
+    }
+
+    public function setFormat(PLValueFormat $format): self
+    {
+        $this->format = $format;
+
+        return $this;
+    }
+
+    public function getWeightInParent(): string
+    {
+        return $this->weightInParent;
+    }
+
+    public function setWeightInParent(string $weightInParent): self
+    {
+        $this->weightInParent = $weightInParent;
+
+        return $this;
+    }
+
+    public function isVisible(): bool
+    {
+        return $this->isVisible;
+    }
+
+    public function setIsVisible(bool $isVisible): self
+    {
+        $this->isVisible = $isVisible;
+
+        return $this;
+    }
+
+    public function getFormula(): ?string
+    {
+        return $this->formula;
+    }
+
+    public function setFormula(?string $formula): self
+    {
+        $this->formula = $formula;
+
+        return $this;
+    }
+
+    public function getCalcOrder(): ?int
+    {
+        return $this->calcOrder;
+    }
+
+    public function setCalcOrder(?int $calcOrder): self
+    {
+        $this->calcOrder = $calcOrder;
 
         return $this;
     }

--- a/site/src/Enum/PLCategoryType.php
+++ b/site/src/Enum/PLCategoryType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enum;
+
+enum PLCategoryType: string
+{
+    case LEAF_INPUT = 'LEAF_INPUT';
+    case SUBTOTAL = 'SUBTOTAL';
+    case KPI = 'KPI';
+}

--- a/site/src/Enum/PLValueFormat.php
+++ b/site/src/Enum/PLValueFormat.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enum;
+
+enum PLValueFormat: string
+{
+    case MONEY = 'MONEY';
+    case PERCENT = 'PERCENT';
+    case RATIO = 'RATIO';
+    case QTY = 'QTY';
+}

--- a/site/src/Form/PLCategoryType.php
+++ b/site/src/Form/PLCategoryType.php
@@ -2,10 +2,19 @@
 
 namespace App\Form;
 
+use App\Entity\Company;
 use App\Entity\PLCategory;
+use App\Enum\PLCategoryType as PLCategoryTypeEnum;
+use App\Enum\PLValueFormat;
+use App\Repository\PLCategoryRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -14,29 +23,74 @@ class PLCategoryType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        /** @var Company $company */
+        $company = $options['company'];
+
         $builder
             ->add('name', TextType::class, [
-                'label' => 'Наименование',
+                'label' => 'Название',
             ])
-            ->add('sortOrder', IntegerType::class, [
-                'label' => 'Сортировка',
+            ->add('code', TextType::class, [
+                'label' => 'Код (уникален в компании)',
+                'required' => false,
+                'attr' => ['placeholder' => 'REV_WB, COGS, EBITDA ...'],
             ])
             ->add('parent', EntityType::class, [
                 'class' => PLCategory::class,
-                'choices' => $options['parents'],
-                'choice_label' => function (PLCategory $item) {
-                    return str_repeat('—', $item->getLevel() - 1).' '.$item->getName();
-                },
-                'required' => false,
                 'label' => 'Родитель',
+                'required' => false,
+                'choice_label' => 'name',
+                'query_builder' => fn (PLCategoryRepository $repo) => $repo->qbForCompany($company),
+            ])
+            ->add('type', ChoiceType::class, [
+                'label' => 'Тип строки',
+                'choices' => [
+                    'Лист (из фактов)' => PLCategoryTypeEnum::LEAF_INPUT,
+                    'Итог (subtotal)' => PLCategoryTypeEnum::SUBTOTAL,
+                    'Показатель (KPI)' => PLCategoryTypeEnum::KPI,
+                ],
+            ])
+            ->add('format', ChoiceType::class, [
+                'label' => 'Формат',
+                'choices' => [
+                    'Деньги' => PLValueFormat::MONEY,
+                    '%' => PLValueFormat::PERCENT,
+                    'Коэф.' => PLValueFormat::RATIO,
+                    'Кол-во' => PLValueFormat::QTY,
+                ],
+            ])
+            ->add('weightInParent', NumberType::class, [
+                'label' => 'Вес в родителе',
+                'html5' => true,
+                'scale' => 4,
+            ])
+            ->add('sortOrder', IntegerType::class, [
+                'label' => 'Порядок',
+            ])
+            ->add('isVisible', CheckboxType::class, [
+                'label' => 'Показывать',
+                'required' => false,
+            ])
+            ->add('formula', TextareaType::class, [
+                'label' => 'Формула (KPI/особый итог)',
+                'required' => false,
+                'attr' => ['rows' => 3, 'placeholder' => 'REV_TOTAL - VAR_COSTS_TOTAL'],
+            ])
+            ->add('calcOrder', IntegerType::class, [
+                'label' => 'Порядок расчёта',
+                'required' => false,
+            ])
+            ->add('save', SubmitType::class, [
+                'label' => 'Сохранить',
+                'attr' => ['class' => 'btn btn-primary'],
             ]);
     }
 
     public function configureOptions(OptionsResolver $resolver): void
     {
+        $resolver->setRequired('company');
         $resolver->setDefaults([
             'data_class' => PLCategory::class,
-            'parents' => [],
         ]);
     }
 }

--- a/site/src/Repository/PLCategoryRepository.php
+++ b/site/src/Repository/PLCategoryRepository.php
@@ -5,6 +5,7 @@ namespace App\Repository;
 use App\Entity\Company;
 use App\Entity\PLCategory;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 
 class PLCategoryRepository extends ServiceEntityRepository
@@ -12,6 +13,15 @@ class PLCategoryRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, PLCategory::class);
+    }
+
+    public function qbForCompany(Company $company): QueryBuilder
+    {
+        return $this->createQueryBuilder('c')
+            ->andWhere('c.company = :company')
+            ->setParameter('company', $company)
+            ->orderBy('c.parent', 'ASC')
+            ->addOrderBy('c.sortOrder', 'ASC');
     }
 
     /**

--- a/site/src/Service/CompanyContextService.php
+++ b/site/src/Service/CompanyContextService.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Company;
+
+class CompanyContextService
+{
+    public function __construct(private readonly ActiveCompanyService $activeCompanyService)
+    {
+    }
+
+    public function getCompany(): Company
+    {
+        return $this->activeCompanyService->getActiveCompany();
+    }
+}

--- a/site/src/Service/PLCategoryTree.php
+++ b/site/src/Service/PLCategoryTree.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\PLCategory;
+
+final class PLCategoryTree
+{
+    /**
+     * @param PLCategory[] $flat
+     */
+    public static function build(array $flat): array
+    {
+        $byId = [];
+        foreach ($flat as $node) {
+            $byId[$node->getId()] = [
+                'id' => $node->getId(),
+                'name' => $node->getName(),
+                'code' => $node->getCode(),
+                'type' => $node->getType()->value,
+                'format' => $node->getFormat()->value,
+                'weightInParent' => $node->getWeightInParent(),
+                'isVisible' => $node->isVisible(),
+                'sortOrder' => $node->getSortOrder(),
+                'parentId' => $node->getParent()?->getId(),
+                'children' => [],
+                'entity' => $node,
+            ];
+        }
+
+        $roots = [];
+        foreach ($byId as $id => &$node) {
+            $parentId = $node['parentId'];
+            if ($parentId && isset($byId[$parentId])) {
+                $byId[$parentId]['children'][] = &$node;
+            } else {
+                $roots[] = &$node;
+            }
+        }
+
+        return $roots;
+    }
+}

--- a/site/templates/pl_category/edit.html.twig
+++ b/site/templates/pl_category/edit.html.twig
@@ -1,19 +1,27 @@
 {% extends 'base.html.twig' %}
 {% block title %}Редактирование категории P&L{% endblock %}
+
 {% block body %}
-    <div class="page-header d-print-none">
-        <div class="container-xl">
-            <h2 class="page-title">Редактирование {{ item.name }}</h2>
-        </div>
+<div class="page-body">
+  <div class="container-xl">
+    <div class="card">
+      <div class="card-header"><h3 class="card-title">Редактирование категории</h3></div>
+      <div class="card-body">
+        {{ form_start(form) }}
+          {{ form_row(form.name) }}
+          {{ form_row(form.code) }}
+          {{ form_row(form.parent) }}
+          {{ form_row(form.type) }}
+          {{ form_row(form.format) }}
+          {{ form_row(form.weightInParent) }}
+          {{ form_row(form.sortOrder) }}
+          {{ form_row(form.isVisible) }}
+          {{ form_row(form.formula) }}
+          {{ form_row(form.calcOrder) }}
+          <div class="mt-3">{{ form_row(form.save) }}</div>
+        {{ form_end(form) }}
+      </div>
     </div>
-    <div class="container-xl mt-3">
-        <div class="card">
-            <div class="card-body">
-                {{ form_start(form) }}
-                {{ form_widget(form) }}
-                <button class="btn btn-primary mt-2">Сохранить</button>
-                {{ form_end(form) }}
-            </div>
-        </div>
-    </div>
+  </div>
+</div>
 {% endblock %}

--- a/site/templates/pl_category/index.html.twig
+++ b/site/templates/pl_category/index.html.twig
@@ -1,48 +1,105 @@
 {% extends 'base.html.twig' %}
 {% block title %}Категории P&L{% endblock %}
 
-{% macro render_items(items, level) %}
-    <ul class="list-unstyled">
-    {% for item in items %}
-        <li>
-            <div class="d-flex align-items-center">
-                <span style="margin-left: {{ (level - 1) * 20 }}px;">{{ item.name }}</span>
-                <span class="ms-auto d-inline-flex gap-1">
-                    <a href="{{ path('pl_category_edit', {'id': item.id}) }}" class="btn btn-sm btn-warning">✏️</a>
-                    <form method="post" action="{{ path('pl_category_delete', {'id': item.id}) }}" class="d-inline" onsubmit="return confirm('Вы уверены?');">
-                        <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ item.id) }}">
-                        <button class="btn btn-sm btn-danger">🗑</button>
-                    </form>
-                </span>
-            </div>
-            {% if item.children|length > 0 %}
-                {{ _self.render_items(item.children, level + 1) }}
-            {% endif %}
-        </li>
-    {% endfor %}
-    </ul>
-{% endmacro %}
-
-{% import _self as macros %}
-
 {% block body %}
-    <div class="page-header d-print-none">
-        <div class="container-xl">
-            <div class="row g-2 align-items-center">
-                <div class="col">
-                    <h2 class="page-title">Категории P&amp;L</h2>
+<div class="page-body">
+  <div class="container-xl">
+    <div class="card">
+      <div class="card-header d-flex justify-content-between">
+        <h3 class="card-title">Категории P&amp;L</h3>
+        <a href="{{ path('pl_category_new') }}" class="btn btn-primary">+ Добавить корневую</a>
+      </div>
+
+      <div class="table-responsive">
+        <table class="table table-vcenter">
+          <thead>
+            <tr>
+              <th>Название</th>
+              <th>Код</th>
+              <th>Тип</th>
+              <th>Формат</th>
+              <th class="text-end">Вес</th>
+              <th class="text-center">Показывать</th>
+              <th class="text-end">Порядок</th>
+              <th class="w-1"></th>
+            </tr>
+          </thead>
+          <tbody>
+          {% macro row(node, level) %}
+            <tr>
+              <td style="padding-left: {{ level * 20 }}px">
+                {% if node.children|length %}
+                  <i class="ti ti-chevron-right me-1 js-toggle"></i>
+                {% else %}
+                  <i class="ti ti-circle-dot opacity-50 me-1"></i>
+                {% endif %}
+                {{ node.name }}
+              </td>
+              <td><code>{{ node.code ?? '—' }}</code></td>
+              <td>{{ node.type }}</td>
+              <td>{{ node.format }}</td>
+              <td class="text-end">{{ node.weightInParent }}</td>
+              <td class="text-center">
+                <form method="post" action="{{ path('pl_category_toggle_visible', {id: node.id}) }}">
+                  <input type="hidden" name="_token" value="{{ csrf_token('vis' ~ node.id) }}">
+                  <button class="btn btn-ghost-primary btn-sm" type="submit">{{ node.isVisible ? 'Да' : 'Нет' }}</button>
+                </form>
+              </td>
+              <td class="text-end">
+                <div class="btn-list">
+                  <form method="post" action="{{ path('pl_category_move_up', {id: node.id}) }}" class="d-inline">
+                    <input type="hidden" name="_token" value="{{ csrf_token('up' ~ node.id) }}">
+                    <button class="btn btn-icon btn-outline-secondary btn-sm" title="Вверх" type="submit"><i class="ti ti-arrow-up"></i></button>
+                  </form>
+                  <form method="post" action="{{ path('pl_category_move_down', {id: node.id}) }}" class="d-inline">
+                    <input type="hidden" name="_token" value="{{ csrf_token('down' ~ node.id) }}">
+                    <button class="btn btn-icon btn-outline-secondary btn-sm" title="Вниз" type="submit"><i class="ti ti-arrow-down"></i></button>
+                  </form>
                 </div>
-                <div class="col-auto ms-auto d-print-none">
-                    <a href="{{ path('pl_category_new') }}" class="btn btn-primary">+ Добавить категорию</a>
-                </div>
-            </div>
-        </div>
+              </td>
+              <td class="text-nowrap">
+                <a class="btn btn-ghost-secondary btn-sm" href="{{ path('pl_category_new', {parent: node.id}) }}"><i class="ti ti-plus"></i> Дочерняя</a>
+                <a class="btn btn-ghost-secondary btn-sm" href="{{ path('pl_category_edit', {id: node.id}) }}"><i class="ti ti-edit"></i> Ред.</a>
+                <form method="post" action="{{ path('pl_category_delete', {id: node.id}) }}" class="d-inline" onsubmit="return confirm('Удалить?');">
+                  <input type="hidden" name="_token" value="{{ csrf_token('del' ~ node.id) }}">
+                  <button class="btn btn-ghost-danger btn-sm" type="submit"><i class="ti ti-trash"></i></button>
+                </form>
+              </td>
+            </tr>
+            {% for child in node.children %}
+              {{ _self.row(child, level + 1) }}
+            {% endfor %}
+          {% endmacro %}
+
+          {% for root in tree %}
+            {{ _self.row(root, 0) }}
+          {% else %}
+            <tr><td colspan="8" class="text-muted">Категорий пока нет</td></tr>
+          {% endfor %}
+          </tbody>
+        </table>
+      </div>
     </div>
-    <div class="container-xl mt-3">
-        <div class="card">
-            <div class="card-body">
-                {{ macros.render_items(items, 1) }}
-            </div>
-        </div>
-    </div>
+  </div>
+</div>
+
+<script>
+document.querySelectorAll('.js-toggle').forEach(function (el) {
+  el.addEventListener('click', function () {
+    const tr = el.closest('tr');
+    const level = parseInt(tr.children[0].style.paddingLeft || '0', 10);
+    let next = tr.nextElementSibling;
+    el.classList.toggle('ti-chevron-right');
+    el.classList.toggle('ti-chevron-down');
+    while (next) {
+      const pad = parseInt(next.children[0].style.paddingLeft || '0', 10);
+      if (pad <= level) {
+        break;
+      }
+      next.classList.toggle('d-none');
+      next = next.nextElementSibling;
+    }
+  });
+});
+</script>
 {% endblock %}

--- a/site/templates/pl_category/new.html.twig
+++ b/site/templates/pl_category/new.html.twig
@@ -1,19 +1,27 @@
 {% extends 'base.html.twig' %}
 {% block title %}Новая категория P&L{% endblock %}
+
 {% block body %}
-    <div class="page-header d-print-none">
-        <div class="container-xl">
-            <h2 class="page-title">Новая категория P&amp;L</h2>
-        </div>
+<div class="page-body">
+  <div class="container-xl">
+    <div class="card">
+      <div class="card-header"><h3 class="card-title">Новая категория</h3></div>
+      <div class="card-body">
+        {{ form_start(form) }}
+          {{ form_row(form.name) }}
+          {{ form_row(form.code) }}
+          {{ form_row(form.parent) }}
+          {{ form_row(form.type) }}
+          {{ form_row(form.format) }}
+          {{ form_row(form.weightInParent) }}
+          {{ form_row(form.sortOrder) }}
+          {{ form_row(form.isVisible) }}
+          {{ form_row(form.formula) }}
+          {{ form_row(form.calcOrder) }}
+          <div class="mt-3">{{ form_row(form.save) }}</div>
+        {{ form_end(form) }}
+      </div>
     </div>
-    <div class="container-xl mt-3">
-        <div class="card">
-            <div class="card-body">
-                {{ form_start(form) }}
-                {{ form_widget(form) }}
-                <button class="btn btn-primary mt-2">Сохранить</button>
-                {{ form_end(form) }}
-            </div>
-        </div>
-    </div>
+  </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add PLCategoryType and PLValueFormat enums and extend the PLCategory entity with new fields, getters/setters, and database constraints
- introduce CompanyContextService, PLCategoryTree helper, and repository query builder to scope and build category trees
- rebuild PL category controller, form, templates, and add a migration to deliver full CRUD with tree UI interactions

## Testing
- `php bin/console lint:twig templates/pl_category` *(fails: dependencies missing; run composer install)*

------
https://chatgpt.com/codex/tasks/task_e_68de7db233b08323966f791381c41ea0