### PR TITLE
Add PL category metadata and form fields

### DIFF
--- a/site/migrations/Version20251001120000.php
+++ b/site/migrations/Version20251001120000.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20251001120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add metadata fields to pl_categories';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE pl_categories
+    ADD code VARCHAR(64) DEFAULT NULL,
+    ADD type VARCHAR(16) NOT NULL DEFAULT 'LEAF_INPUT',
+    ADD format VARCHAR(16) NOT NULL DEFAULT 'MONEY',
+    ADD weight_in_parent NUMERIC(10,4) NOT NULL DEFAULT 1.0000,
+    ADD is_visible BOOLEAN NOT NULL DEFAULT TRUE,
+    ADD formula TEXT DEFAULT NULL,
+    ADD calc_order INT DEFAULT NULL
+");
+        $this->addSql("CREATE UNIQUE INDEX IF NOT EXISTS uniq_plcat_company_code ON pl_categories (company_id, code)");
+        $this->addSql("CREATE INDEX IF NOT EXISTS idx_plcat_company_parent_sort ON pl_categories (company_id, parent_id, sort_order)");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("DROP INDEX IF EXISTS idx_plcat_company_parent_sort");
+        $this->addSql("DROP INDEX IF EXISTS uniq_plcat_company_code");
+        $this->addSql("ALTER TABLE pl_categories
+    DROP COLUMN code,
+    DROP COLUMN type,
+    DROP COLUMN format,
+    DROP COLUMN weight_in_parent,
+    DROP COLUMN is_visible,
+    DROP COLUMN formula,
+    DROP COLUMN calc_order
+");
+    }
+}

--- a/site/src/Enum/PLCategoryType.php
+++ b/site/src/Enum/PLCategoryType.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+enum PLCategoryType: string
+{
+    case LEAF_INPUT = 'LEAF_INPUT'; // лист, данные из фактов/агрегатов
+    case SUBTOTAL   = 'SUBTOTAL';   // итоговая строка (subtotal)
+    case KPI        = 'KPI';        // расчётный показатель (формула)
+}

--- a/site/src/Enum/PLValueFormat.php
+++ b/site/src/Enum/PLValueFormat.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+enum PLValueFormat: string
+{
+    case MONEY   = 'MONEY';
+    case PERCENT = 'PERCENT';
+    case RATIO   = 'RATIO';
+    case QTY     = 'QTY';
+}

--- a/site/src/Form/PLCategoryType.php
+++ b/site/src/Form/PLCategoryType.php
@@ -3,10 +3,16 @@
 namespace App\Form;
 
 use App\Entity\PLCategory;
+use App\Enum\PLCategoryType;
+use App\Enum\PLValueFormat;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -29,6 +35,47 @@ class PLCategoryType extends AbstractType
                 },
                 'required' => false,
                 'label' => 'Родитель',
+            ])
+            ->add('code', TextType::class, [
+                'label' => 'Код (уникален в компании)',
+                'required' => false,
+                'attr' => ['placeholder' => 'REV_WB, COGS, EBITDA ...'],
+            ])
+            ->add('type', ChoiceType::class, [
+                'label' => 'Тип строки',
+                'choices' => [
+                    'Лист (из фактов)' => PLCategoryType::LEAF_INPUT,
+                    'Итог (subtotal)'  => PLCategoryType::SUBTOTAL,
+                    'Показатель (KPI)' => PLCategoryType::KPI,
+                ],
+            ])
+            ->add('format', ChoiceType::class, [
+                'label' => 'Формат',
+                'choices' => [
+                    'Деньги' => PLValueFormat::MONEY,
+                    '%'      => PLValueFormat::PERCENT,
+                    'Коэф.'  => PLValueFormat::RATIO,
+                    'Кол-во' => PLValueFormat::QTY,
+                ],
+            ])
+            ->add('weightInParent', NumberType::class, [
+                'label' => 'Вес в родителе',
+                'html5' => true,
+                'scale' => 4,
+                'required' => false,
+            ])
+            ->add('isVisible', CheckboxType::class, [
+                'label' => 'Показывать',
+                'required' => false,
+            ])
+            ->add('formula', TextareaType::class, [
+                'label' => 'Формула (для KPI/особых итогов)',
+                'required' => false,
+                'attr' => ['rows' => 3, 'placeholder' => 'Напр.: REV_TOTAL - VAR_COSTS_TOTAL'],
+            ])
+            ->add('calcOrder', \Symfony\Component\Form\Extension\Core\Type\IntegerType::class, [
+                'label' => 'Порядок расчёта',
+                'required' => false,
             ]);
     }
 


### PR DESCRIPTION
## Summary
- add enums describing PL category type and value format
- extend PLCategory entity with metadata fields and persistence
- expose new metadata fields in PLCategory form and schema migration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df8263160c8323bf6b97da9c500e11