### PR TITLE
Rename PL category form type to avoid enum conflict

### DIFF
--- a/site/src/Controller/PLCategoryController.php
+++ b/site/src/Controller/PLCategoryController.php
@@ -3,7 +3,7 @@
 namespace App\Controller;
 
 use App\Entity\PLCategory;
-use App\Form\PLCategoryType;
+use App\Form\PLCategoryFormType;
 use App\Repository\PLCategoryRepository;
 use App\Service\ActiveCompanyService;
 use Doctrine\ORM\EntityManagerInterface;
@@ -34,7 +34,7 @@ class PLCategoryController extends AbstractController
         $category = new PLCategory(Uuid::uuid4()->toString(), $company);
 
         $parents = $repo->findTreeByCompany($company);
-        $form = $this->createForm(PLCategoryType::class, $category, ['parents' => $parents]);
+        $form = $this->createForm(PLCategoryFormType::class, $category, ['parents' => $parents]);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -62,7 +62,7 @@ class PLCategoryController extends AbstractController
         }
 
         $parents = $repo->findTreeByCompany($company);
-        $form = $this->createForm(PLCategoryType::class, $category, ['parents' => $parents]);
+        $form = $this->createForm(PLCategoryFormType::class, $category, ['parents' => $parents]);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {

--- a/site/src/Form/PLCategoryFormType.php
+++ b/site/src/Form/PLCategoryFormType.php
@@ -3,7 +3,7 @@
 namespace App\Form;
 
 use App\Entity\PLCategory;
-use App\Enum\PLCategoryType;
+use App\Enum\PLCategoryType as PLCategoryTypeEnum;
 use App\Enum\PLValueFormat;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
@@ -16,7 +16,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class PLCategoryType extends AbstractType
+class PLCategoryFormType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
@@ -44,9 +44,9 @@ class PLCategoryType extends AbstractType
             ->add('type', ChoiceType::class, [
                 'label' => 'Тип строки',
                 'choices' => [
-                    'Лист (из фактов)' => PLCategoryType::LEAF_INPUT,
-                    'Итог (subtotal)'  => PLCategoryType::SUBTOTAL,
-                    'Показатель (KPI)' => PLCategoryType::KPI,
+                    'Лист (из фактов)' => PLCategoryTypeEnum::LEAF_INPUT,
+                    'Итог (subtotal)'  => PLCategoryTypeEnum::SUBTOTAL,
+                    'Показатель (KPI)' => PLCategoryTypeEnum::KPI,
                 ],
             ])
             ->add('format', ChoiceType::class, [


### PR DESCRIPTION
## Summary
- rename the PL category form class to `PLCategoryFormType` to avoid conflicting with the enum of the same name
- update the form to alias the enum and adjust controller references to the new class name

## Testing
- composer dump-autoload

------
https://chatgpt.com/codex/tasks/task_e_68df85996c2c83238a8c5f1e430ab922