### PR TITLE
Add health endpoint to landing nginx config

### DIFF
--- a/landing/nginx/conf.d/default.conf
+++ b/landing/nginx/conf.d/default.conf
@@ -17,5 +17,11 @@ server {
         try_files $uri $uri/ =404;
     }
 
+    location = /health {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 'ok';
+    }
+
     autoindex off;
 }


### PR DESCRIPTION
## Summary
- add a dedicated /health location in the landing nginx config so the container passes health checks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfb3181e4c8323a37476a3977578f7