### PR TITLE
Fix landing nginx fallback to index

### DIFF
--- a/landing/docker/common/nginx/conf.d/default.conf
+++ b/landing/docker/common/nginx/conf.d/default.conf
@@ -15,7 +15,7 @@ server {
     add_header 'Access-Control-Allow-Headers' 'Origin,Content-Type,Accept,Authorization,X-Features' always;
 
     location / {
-        try_files $uri $uri/ =404;
+        try_files $uri $uri/ /index.html;
     }
 
     autoindex off;

--- a/landing/nginx/conf.d/default.conf
+++ b/landing/nginx/conf.d/default.conf
@@ -14,7 +14,7 @@ server {
     add_header 'Access-Control-Allow-Headers' 'Origin,Content-Type,Accept,Authorization,X-Features' always;
 
     location / {
-        try_files $uri $uri/ =404;
+        try_files $uri $uri/ /index.html;
     }
 
     location = /health {


### PR DESCRIPTION
## Summary
- serve the landing page through nginx with an index.html fallback so root requests are handled
- update both local and container nginx configs to ensure unknown paths return the SPA entrypoint

## Testing
- not run (configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68dfb5a0dfe8832399508f83309d208c