### PR TITLE
Fix HTTPS routing for landing domain

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -54,11 +54,15 @@ services:
             - default
         labels:
             - traefik.enable=true
-            - traefik.http.routers.land.rule=Host(`2bstock.ru`)
+            - traefik.http.routers.land.rule=Host(`2bstock.ru`) || Host(`www.2bstock.ru`)
             - traefik.http.routers.land.entrypoints=https
             - traefik.http.routers.land.tls=true
             - traefik.http.routers.land.tls.certresolver=letsEncrypt
             - traefik.http.services.land.loadbalancer.server.port=80
+            - traefik.http.routers.land-http.rule=Host(`2bstock.ru`) || Host(`www.2bstock.ru`)
+            - traefik.http.routers.land-http.entrypoints=http
+            - traefik.http.routers.land-http.middlewares=redirect-to-https
+            - traefik.http.routers.land-http.priority=10
             - traefik.docker.network=traefik-public    # Явно указать сеть для Traefik
 
     site:


### PR DESCRIPTION
## Summary
- add HTTP router for 2bstock.ru to satisfy ACME HTTP challenge and redirect to HTTPS
- support both bare and www hostnames for the landing router

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfbb35810483238b0a030b4f0ce792