### PR TITLE
Add admin dashboard bounded context

### DIFF
--- a/site/config/routes/admin.yaml
+++ b/site/config/routes/admin.yaml
@@ -1,0 +1,5 @@
+admin_controllers:
+  resource: ../../src/Admin/Controller/
+  type: attribute
+  prefix: /admin
+  name_prefix: admin_

--- a/site/src/Admin/Controller/DashboardController.php
+++ b/site/src/Admin/Controller/DashboardController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Admin\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/admin', name: 'admin_')]
+final class DashboardController extends AbstractController
+{
+    #[Route('', name: 'dashboard', methods: ['GET'])]
+    public function index(): Response
+    {
+        return $this->render('admin/dashboard/index.html.twig', [
+            'title' => 'Admin · Dashboard (тестовая страница)',
+        ]);
+    }
+}

--- a/site/templates/admin/dashboard/index.html.twig
+++ b/site/templates/admin/dashboard/index.html.twig
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>{{ title }}</title>
+  {# Можно использовать Tabler из CDN, чтобы не трогать сборку ассетов #}
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.2.0/dist/css/tabler.min.css"/>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@2.39.0/tabler-icons.min.css"/>
+</head>
+<body class="page">
+  <div class="page-body">
+    <div class="container-xl mt-4">
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">Админ-панель · Главная</h3>
+        </div>
+        <div class="card-body">
+          <p class="text-muted">Тестовый экран. Маршрут: <code>/admin</code>, имя: <code>admin_dashboard</code>.</p>
+        </div>
+      </div>
+      <div class="mt-3">
+        <a href="/" class="btn btn-outline-secondary"><i class="ti ti-arrow-left"></i> На сайт</a>
+      </div>
+    </div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/@tabler/core@1.2.0/dist/js/tabler.min.js"></script>
+</body>
+</html>

--- a/site/templates/partials/_sidebar.html.twig
+++ b/site/templates/partials/_sidebar.html.twig
@@ -27,6 +27,13 @@
                     </a>
                 </li>
 
+                <li class="nav-item">
+                    <a class="nav-link" href="{{ path('admin_dashboard') }}">
+                        <span class="nav-link-icon d-md-none d-lg-inline-block"><i class="ti ti-layout-dashboard"></i></span>
+                        <span class="nav-link-title">Admin Главная</span>
+                    </a>
+                </li>
+
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" data-bs-toggle="dropdown" data-bs-auto-close="false" role="button" aria-expanded="false">
 


### PR DESCRIPTION
## Summary
- add attribute-based routing configuration for the new admin bounded context
- introduce an admin dashboard controller with a temporary Twig view
- expose a temporary "Admin Главная" navigation link pointing to the dashboard

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfbc2642408323b0c2d3a5af8a9b8c