### PR TITLE
Remove redundant admin route name prefix

### DIFF
--- a/site/config/routes/admin.yaml
+++ b/site/config/routes/admin.yaml
@@ -2,4 +2,3 @@ admin_controllers:
   resource: ../../src/Admin/Controller/
   type: attribute
   prefix: /admin
-  name_prefix: admin_


### PR DESCRIPTION
## Summary
- remove the redundant admin name prefix from the route configuration so the admin_dashboard route is available

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfbea682c88323bbd6a9d1efa4e3bd