### PR TITLE
Fix sidebar role detection without Twig break tag

### DIFF
--- a/site/templates/partials/_sidebar.html.twig
+++ b/site/templates/partials/_sidebar.html.twig
@@ -10,9 +10,8 @@
 {% if app.user %}
     {% set user_role_label = role_labels['ROLE_USER'] %}
     {% for role in role_priority %}
-        {% if role in app.user.roles %}
+        {% if role in app.user.roles and user_role_label is null %}
             {% set user_role_label = role_labels[role] ?? role %}
-            {% break %}
         {% endif %}
     {% endfor %}
 {% endif %}


### PR DESCRIPTION
## Summary
- adjust sidebar template to avoid using the unsupported Twig `break` tag when resolving the user role label
- ensure the first matching role in the priority list sets the label without further overrides

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfc45c63d883239c2bb7e0de9eddd0