### PR TITLE
Add admin login and Tabler admin layout

### DIFF
--- a/site/config/packages/security.yaml
+++ b/site/config/packages/security.yaml
@@ -34,6 +34,17 @@ security:
                 # where to redirect after logout
                 # target: app_any_route
 
+        admin:
+            pattern: ^/admin(?!/login)
+            context: admin
+            lazy: true
+            form_login:
+                login_path: admin_auth_login
+                check_path: admin_auth_login
+                enable_csrf: true
+            logout:
+                path: app_logout
+
             # activate different ways to authenticate
             # https://symfony.com/doc/current/security.html#the-firewall
 
@@ -51,6 +62,8 @@ security:
         # - { path: ^/admin, roles: ROLE_ADMIN }
         - { path: ^/login, roles: PUBLIC_ACCESS }
         - { path: ^/register, roles: PUBLIC_ACCESS }
+        - { path: ^/admin/login$, roles: PUBLIC_ACCESS }
+        - { path: ^/admin, roles: ROLE_ADMIN }
         - { path: ^/, roles: ROLE_USER }
 
 when@test:

--- a/site/src/Admin/Controller/Security/AdminAuthController.php
+++ b/site/src/Admin/Controller/Security/AdminAuthController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Admin\Controller\Security;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
+
+#[Route('/admin', name: 'admin_auth_')]
+final class AdminAuthController extends AbstractController
+{
+    #[Route('/login', name: 'login', methods: ['GET', 'POST'])]
+    public function login(AuthenticationUtils $authUtils): Response
+    {
+        if ($this->isGranted('ROLE_ADMIN')) {
+            return $this->redirectToRoute('admin_dashboard');
+        }
+
+        return $this->render('admin/security/login.html.twig', [
+            'last_username' => $authUtils->getLastUsername(),
+            'error' => $authUtils->getLastAuthenticationError(),
+        ]);
+    }
+}

--- a/site/templates/admin/base.html.twig
+++ b/site/templates/admin/base.html.twig
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>{% block title %}Admin · {{ app.request.host }}{% endblock %}</title>
+
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.2.0/dist/css/tabler.min.css"/>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@2.39.0/tabler-icons.min.css"/>
+
+  {% block admin_styles %}{% endblock %}
+</head>
+<body class="layout-fluid">
+  <div class="page">
+    {% include 'admin/partials/_sidebar.html.twig' %}
+    <div class="page-wrapper">
+      {% include 'admin/partials/_header.html.twig' %}
+
+      <div class="page-body">
+        <div class="container-xl">
+          {% block body %}{% endblock %}
+        </div>
+      </div>
+
+      {% include 'admin/partials/_footer.html.twig' %}
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/@tabler/core@1.2.0/dist/js/tabler.min.js"></script>
+  {% block admin_scripts %}{% endblock %}
+</body>
+</html>

--- a/site/templates/admin/dashboard/index.html.twig
+++ b/site/templates/admin/dashboard/index.html.twig
@@ -1,29 +1,24 @@
-<!DOCTYPE html>
-<html lang="ru">
-<head>
-  <meta charset="UTF-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <title>{{ title }}</title>
-  {# Можно использовать Tabler из CDN, чтобы не трогать сборку ассетов #}
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.2.0/dist/css/tabler.min.css"/>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@2.39.0/tabler-icons.min.css"/>
-</head>
-<body class="page">
-  <div class="page-body">
-    <div class="container-xl mt-4">
+{% extends 'admin/base.html.twig' %}
+{% block title %}Admin · Dashboard{% endblock %}
+
+{% block body %}
+  <div class="row row-cards">
+    <div class="col-12">
       <div class="card">
         <div class="card-header">
-          <h3 class="card-title">Админ-панель · Главная</h3>
+          <h3 class="card-title">Добро пожаловать в админ-панель</h3>
         </div>
         <div class="card-body">
-          <p class="text-muted">Тестовый экран. Маршрут: <code>/admin</code>, имя: <code>admin_dashboard</code>.</p>
+          <p class="text-muted">Тестовый экран. Здесь появятся метрики, очереди, статусы интеграций.</p>
         </div>
-      </div>
-      <div class="mt-3">
-        <a href="/" class="btn btn-outline-secondary"><i class="ti ti-arrow-left"></i> На сайт</a>
       </div>
     </div>
   </div>
-  <script src="https://cdn.jsdelivr.net/npm/@tabler/core@1.2.0/dist/js/tabler.min.js"></script>
-</body>
-</html>
+
+  {% include 'admin/partials/_danger_zone.html.twig' with {
+    items: [
+      { title: 'Очистить кэш', desc: 'Принудительная очистка кэша приложения.', action: '#', icon: 'ti ti-eraser' },
+      { title: 'Пауза интеграций', desc: 'Глобальный kill-switch интеграций.', action: '#', icon: 'ti ti-player-pause' }
+    ]
+  } %}
+{% endblock %}

--- a/site/templates/admin/partials/_danger_zone.html.twig
+++ b/site/templates/admin/partials/_danger_zone.html.twig
@@ -1,0 +1,46 @@
+<div class="row row-cards mt-3">
+  <div class="col-12">
+    <div class="card border-danger">
+      <div class="card-header">
+        <h3 class="card-title text-danger">Danger Zone</h3>
+      </div>
+      <div class="card-body">
+        <p class="text-muted">Опасные действия требуют подтверждения и могут повлиять на работу системы.</p>
+        <div class="row g-3">
+          {% for i in items|default([]) %}
+            <div class="col-md-6">
+              <div class="card">
+                <div class="card-body">
+                  <div class="d-flex">
+                    <div class="me-3"><i class="{{ i.icon|default('ti ti-alert-triangle') }}"></i></div>
+                    <div>
+                      <div class="h4">{{ i.title }}</div>
+                      <div class="text-muted">{{ i.desc }}</div>
+                    </div>
+                  </div>
+                  <div class="mt-3">
+                    <a href="{{ i.action }}" class="btn btn-outline-danger" data-confirm="true">Запустить</a>
+                  </div>
+                </div>
+              </div>
+            </div>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% block admin_scripts %}
+  {{ parent() }}
+  <script>
+    document.addEventListener('click', function (e) {
+      const btn = e.target.closest('[data-confirm="true"]');
+      if (btn) {
+        if (!confirm('Вы уверены? Это опасное действие.')) {
+          e.preventDefault();
+        }
+      }
+    });
+  </script>
+{% endblock %}

--- a/site/templates/admin/partials/_footer.html.twig
+++ b/site/templates/admin/partials/_footer.html.twig
@@ -1,0 +1,17 @@
+<footer class="footer footer-transparent d-print-none">
+  <div class="container-xl">
+    <div class="row text-center align-items-center flex-row-reverse">
+      <div class="col-lg-auto ms-lg-auto">
+        <ul class="list-inline list-inline-dots mb-0">
+          <li class="list-inline-item"><a href="#" class="link-secondary">Docs</a></li>
+          <li class="list-inline-item"><a href="#" class="link-secondary">Status</a></li>
+        </ul>
+      </div>
+      <div class="col-12 col-lg-auto mt-3 mt-lg-0">
+        <ul class="list-inline list-inline-dots mb-0">
+          <li class="list-inline-item">© {{ "now"|date("Y") }} Fin-Plan</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</footer>

--- a/site/templates/admin/partials/_header.html.twig
+++ b/site/templates/admin/partials/_header.html.twig
@@ -1,0 +1,25 @@
+<header class="navbar navbar-expand-md d-none d-lg-flex">
+  <div class="container-xl">
+    <div class="navbar-nav flex-row order-md-last">
+      <div class="nav-item dropdown">
+        <a href="#" class="nav-link d-flex lh-1 text-reset p-0" data-bs-toggle="dropdown" aria-label="Open user menu">
+          <span class="avatar avatar-sm">A</span>
+          <div class="d-none d-xl-block ps-2">
+            <div>{{ app.user ? app.user.email : 'Guest' }}</div>
+            <div class="mt-1 small text-muted">Admin</div>
+          </div>
+        </a>
+        <div class="dropdown-menu dropdown-menu-end dropdown-menu-arrow">
+          <a href="{{ path('admin_dashboard') }}" class="dropdown-item">Профиль (заглушка)</a>
+          <a href="{{ path('app_logout') }}" class="dropdown-item">Выход</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="navbar-nav">
+      <div class="nav-item">
+        <span class="nav-link">Админка</span>
+      </div>
+    </div>
+  </div>
+</header>

--- a/site/templates/admin/partials/_sidebar.html.twig
+++ b/site/templates/admin/partials/_sidebar.html.twig
@@ -1,0 +1,20 @@
+<aside class="navbar navbar-vertical navbar-expand-lg" data-bs-theme="light">
+  <div class="container-fluid">
+    <h1 class="navbar-brand navbar-brand-autodark">
+      <a href="{{ path('admin_dashboard') }}">Fin-Plan · Admin</a>
+    </h1>
+    <div class="navbar-collapse">
+      <ul class="navbar-nav">
+        <li class="nav-item">
+          <a class="nav-link {% if app.request.get('_route') starts with 'admin_dashboard' %}active{% endif %}"
+             href="{{ path('admin_dashboard') }}">
+            <span class="nav-link-icon d-md-none d-lg-inline-block">
+              <i class="ti ti-layout-dashboard"></i>
+            </span>
+            <span class="nav-link-title">Dashboard</span>
+          </a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</aside>

--- a/site/templates/admin/security/login.html.twig
+++ b/site/templates/admin/security/login.html.twig
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Admin Login</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.2.0/dist/css/tabler.min.css"/>
+</head>
+<body class="d-flex flex-column">
+  <div class="page page-center">
+    <div class="container-tight py-4">
+      <div class="text-center mb-4">
+        <a href="#" class="navbar-brand navbar-brand-autodark">Fin-Plan · Admin</a>
+      </div>
+      <form class="card card-md" method="post" action="{{ path('admin_auth_login') }}">
+        <div class="card-body">
+          <h2 class="card-title text-center mb-4">Вход в админ-панель</h2>
+
+          {% if error %}
+            <div class="alert alert-danger" role="alert">
+              {{ error.messageKey|trans(error.messageData, 'security') }}
+            </div>
+          {% endif %}
+
+          <div class="mb-3">
+            <label class="form-label">Email</label>
+            <input type="text" name="_username" value="{{ last_username }}" class="form-control" autocomplete="username" required>
+          </div>
+
+          <div class="mb-2">
+            <label class="form-label">Пароль</label>
+            <input type="password" name="_password" class="form-control" autocomplete="current-password" required>
+          </div>
+
+          <input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}"/>
+
+          <div class="form-footer">
+            <button type="submit" class="btn btn-primary w-100">Войти</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/@tabler/core@1.2.0/dist/js/tabler.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated AdminAuthController to render the new login form and redirect authenticated admins
- register an admin firewall and access control entries to protect the admin area while keeping login public
- introduce a Tabler-based admin layout with sidebar, header, footer, dashboard view, danger zone partial, and a custom login page

## Testing
- php bin/console lint:twig templates/admin *(fails: missing Composer dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc5719d94832397672afd4212cf95