### PR TITLE
Load admin routes configuration

### DIFF
--- a/site/config/routes.yaml
+++ b/site/config/routes.yaml
@@ -3,3 +3,6 @@ controllers:
         path: ../src/Controller/
         namespace: App\Controller
     type: attribute
+
+admin:
+    resource: routes/admin.yaml


### PR DESCRIPTION
## Summary
- import the admin routing configuration file so attribute routes under /admin are registered

## Testing
- ⚠️ `php bin/console debug:router admin_auth_login` *(fails: dependencies are missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfca066bb48323b4cf3ec851193f43