### PR TITLE
Fix admin route prefix duplication

### DIFF
--- a/site/config/routes/admin.yaml
+++ b/site/config/routes/admin.yaml
@@ -1,4 +1,3 @@
 admin_controllers:
   resource: ../../src/Admin/Controller/
   type: attribute
-  prefix: /admin


### PR DESCRIPTION
## Summary
- remove the redundant /admin prefix from the admin routes configuration so attribute routes resolve correctly

## Testing
- Not run (dependencies missing in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfcb01eb54832389ee2af64f37ce65