### PR TITLE
Show admin login authentication errors

### DIFF
--- a/site/src/Admin/Controller/Security/AdminAuthController.php
+++ b/site/src/Admin/Controller/Security/AdminAuthController.php
@@ -17,9 +17,12 @@ final class AdminAuthController extends AbstractController
             return $this->redirectToRoute('admin_dashboard');
         }
 
+        $error = $authUtils->getLastAuthenticationError();
+
         return $this->render('admin/security/login.html.twig', [
             'last_username' => $authUtils->getLastUsername(),
-            'error' => $authUtils->getLastAuthenticationError(),
+            'error' => $error,
+            'error_message' => $error ? 'Неверный логин или пароль' : null,
         ]);
     }
 }

--- a/site/templates/admin/security/login.html.twig
+++ b/site/templates/admin/security/login.html.twig
@@ -16,9 +16,9 @@
         <div class="card-body">
           <h2 class="card-title text-center mb-4">Вход в админ-панель</h2>
 
-          {% if error %}
+          {% if error_message %}
             <div class="alert alert-danger" role="alert">
-              {{ error.messageKey|trans(error.messageData, 'security') }}
+              {{ error_message }}
             </div>
           {% endif %}
 


### PR DESCRIPTION
## Summary
- capture the last admin authentication error in the controller
- expose a friendly error message for failed admin login attempts
- render the message in the admin login template when credentials are invalid

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfccefcbc4832385c95560921e4ab3