### PR TITLE
Fix danger zone partial script injection

### DIFF
--- a/site/templates/admin/dashboard/index.html.twig
+++ b/site/templates/admin/dashboard/index.html.twig
@@ -22,3 +22,17 @@
     ]
   } %}
 {% endblock %}
+
+{% block admin_scripts %}
+  {{ parent() }}
+  <script>
+    document.addEventListener('click', function (e) {
+      const btn = e.target.closest('[data-confirm="true"]');
+      if (btn) {
+        if (!confirm('Вы уверены? Это опасное действие.')) {
+          e.preventDefault();
+        }
+      }
+    });
+  </script>
+{% endblock %}

--- a/site/templates/admin/partials/_danger_zone.html.twig
+++ b/site/templates/admin/partials/_danger_zone.html.twig
@@ -30,17 +30,3 @@
     </div>
   </div>
 </div>
-
-{% block admin_scripts %}
-  {{ parent() }}
-  <script>
-    document.addEventListener('click', function (e) {
-      const btn = e.target.closest('[data-confirm="true"]');
-      if (btn) {
-        if (!confirm('Вы уверены? Это опасное действие.')) {
-          e.preventDefault();
-        }
-      }
-    });
-  </script>
-{% endblock %}


### PR DESCRIPTION
## Summary
- remove the script block from the danger zone partial to avoid calling parent() in an included template
- move the confirmation script into the dashboard template's admin_scripts block so it still runs after rendering

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfcde3f5848323993c79bde9e0477b