### PR TITLE
Remove role section from sidebar menu

### DIFF
--- a/site/templates/partials/_sidebar.html.twig
+++ b/site/templates/partials/_sidebar.html.twig
@@ -106,13 +106,6 @@
                         </a>
                     </div>
                 </li>
-                {% if user_roles is not empty %}
-                    <li class="nav-item px-3">
-                        <div class="text-muted small text-uppercase">Ваша роль</div>
-                        <div class="fw-semibold">{{ user_roles|join(', ') }}</div>
-                    </li>
-                {% endif %}
-
                 {#---- Profile ---#}
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" data-bs-toggle="dropdown" data-bs-auto-close="false" role="button" aria-expanded="false">


### PR DESCRIPTION
## Summary
- remove the "Ваша роль" block from the sidebar menu

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfe817f5c883239e2c573d75294d63