### PR TITLE
Remove Admin dashboard link from sidebar

### DIFF
--- a/site/templates/partials/_sidebar.html.twig
+++ b/site/templates/partials/_sidebar.html.twig
@@ -31,13 +31,6 @@
                     </a>
                 </li>
 
-                <li class="nav-item">
-                    <a class="nav-link" href="{{ path('admin_dashboard') }}">
-                        <span class="nav-link-icon d-md-none d-lg-inline-block"><i class="ti ti-layout-dashboard"></i></span>
-                        <span class="nav-link-title">Admin Главная</span>
-                    </a>
-                </li>
-
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" data-bs-toggle="dropdown" data-bs-auto-close="false" role="button" aria-expanded="false">
 


### PR DESCRIPTION
## Summary
- remove the Admin Главная link from the primary sidebar navigation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0065d25388323bb382d7b619dfb58