### PR TITLE
Install Redis extension in production PHP-FPM image

### DIFF
--- a/site/docker/production/php-fpm/Dockerfile
+++ b/site/docker/production/php-fpm/Dockerfile
@@ -13,6 +13,12 @@ WORKDIR /app
 COPY ./composer.json ./composer.lock ./
 
 
+# ⬇️ Добавляем ext-redis для стадии builder (чтобы composer видел расширение)
+RUN apk add --no-cache $PHPIZE_DEPS \
+    && pecl install redis \
+    && docker-php-ext-enable redis \
+    && apk del $PHPIZE_DEPS
+
 RUN composer install --no-dev --prefer-dist --no-progress --no-scripts --optimize-autoloader \
     && rm -rf /root/.composer/cache
 
@@ -23,6 +29,12 @@ FROM php:8.2-fpm-alpine
 RUN apk add --no-cache libpq-dev fcgi \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
     && docker-php-ext-install pdo_pgsql opcache bcmath
+
+# ⬇️ Добавляем ext-redis для рантайма PHP-FPM
+RUN apk add --no-cache $PHPIZE_DEPS \
+    && pecl install redis \
+    && docker-php-ext-enable redis \
+    && apk del $PHPIZE_DEPS
 
 RUN mv $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
 


### PR DESCRIPTION
## Summary
- install the redis PHP extension in the production PHP-FPM builder stage so Composer sees ext-redis
- enable the redis PHP extension in the runtime PHP-FPM stage to provide the required extension

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e143ce4e40832380c7bf609b016284