### PR TITLE
Install redis extension in production php-fpm image

### DIFF
--- a/site/docker/production/php-fpm/Dockerfile
+++ b/site/docker/production/php-fpm/Dockerfile
@@ -4,6 +4,12 @@ RUN apk add --no-cache libpq-dev \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
     && docker-php-ext-install pdo_pgsql opcache bcmath
 
+# Install ext-redis for the build stage so that Composer sees the extension
+RUN apk add --no-cache $PHPIZE_DEPS \
+    && pecl install redis \
+    && docker-php-ext-enable redis \
+    && apk del $PHPIZE_DEPS
+
 ENV COMPOSER_ALLOW_SUPERUSER 1
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/bin --filename=composer --quiet


### PR DESCRIPTION
## Summary
- install the redis PHP extension in the production php-fpm builder stage to satisfy Composer requirements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e144d726288323a075f26786f03492