### PR TITLE
Fix PHP CLI builder apk command

### DIFF
--- a/site/docker/production/php-cli/Dockerfile
+++ b/site/docker/production/php-cli/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --no-cache libpq-dev \
 RUN apk add --no-cache $PHPIZE_DEPS \
     && pecl install redis \
     && docker-php-ext-enable redis \
-    && apk del $PHPIZE_DEPS \
+    && apk del $PHPIZE_DEPS
 
 RUN apk add --no-cache unzip
 


### PR DESCRIPTION
## Summary
- remove an unintended line continuation in the PHP CLI production Dockerfile so the redis build dependencies are cleaned up correctly

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e147c7df048323b3a571855e58894f