### PR TITLE
Remove duplicate redis installation in PHP-FPM Dockerfile

### DIFF
--- a/site/docker/production/php-fpm/Dockerfile
+++ b/site/docker/production/php-fpm/Dockerfile
@@ -19,12 +19,6 @@ WORKDIR /app
 COPY ./composer.json ./composer.lock ./
 
 
-# ⬇️ Добавляем ext-redis для стадии builder (чтобы composer видел расширение)
-RUN apk add --no-cache $PHPIZE_DEPS \
-    && pecl install redis \
-    && docker-php-ext-enable redis \
-    && apk del $PHPIZE_DEPS
-
 RUN composer install --no-dev --prefer-dist --no-progress --no-scripts --optimize-autoloader \
     && rm -rf /root/.composer/cache
 


### PR DESCRIPTION
## Summary
- remove the duplicate pecl redis installation step in the PHP-FPM production Dockerfile
- prevent docker builds from failing when the redis extension is already present

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e14acd9f808323bae2bb9025ce9fa3