### PR TITLE
Fix missing PHPIZE dependencies for nginx build stage

### DIFF
--- a/site/docker/production/nginx/Dockerfile
+++ b/site/docker/production/nginx/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:8.2-cli-alpine AS builder
 
-RUN apk add --no-cache libpq-dev \
+RUN apk add --no-cache libpq-dev $PHPIZE_DEPS \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
     && docker-php-ext-install pdo_pgsql opcache bcmath \
     && pecl install redis \


### PR DESCRIPTION
## Summary
- ensure the production nginx builder image installs PHPIZE dependencies before pecl installs redis

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e14cd34728832396b0302c0b7de9a8