### PR TITLE
Add async processing flow for cash transaction auto rules

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -119,6 +119,23 @@ services:
         depends_on:
             - site-postgres
             - site-redis
+    site-messenger-worker:
+        build:
+            context: site
+            dockerfile: docker/production/php-cli/Dockerfile
+        container_name: site-messenger-worker
+        restart: always
+        command: php bin/console messenger:consume async -vv --time-limit=3600
+        environment:
+            DATABASE_URL: pgsql://app:${POSTGRES_PASSWORD}@site-postgres:5432/app
+            APP_ENV: PROD
+            APP_SECRET: ${APP_SECRET}
+            REDIS_DSN: redis://site-redis:6379
+        networks:
+            - default
+        depends_on:
+            - site-postgres
+            - site-redis
     site-postgres:
         image: postgres:15-alpine
         container_name: symfony-postgres

--- a/site/config/packages/messenger.yaml
+++ b/site/config/packages/messenger.yaml
@@ -21,6 +21,8 @@ framework:
             messenger.bus.default: []
 
         routing:
+            App\Message\ApplyAutoRulesForTransaction: async
+            App\Message\EnqueueAutoRulesForRange: async
             App\Message\TestMessengerPing: async
             Symfony\Component\Mailer\Messenger\SendEmailMessage: async
             Symfony\Component\Notifier\Message\ChatMessage: async

--- a/site/src/Command/CashAutoRulesEnqueueCommand.php
+++ b/site/src/Command/CashAutoRulesEnqueueCommand.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Command;
+
+use App\Message\EnqueueAutoRulesForRange;
+use DateTimeImmutable;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[AsCommand(
+    name: 'app:cash:auto-rules:enqueue',
+    description: 'Ставит в очередь асинхронное применение автоправил ДДС для диапазона транзакций.'
+)]
+final class CashAutoRulesEnqueueCommand extends Command
+{
+    public function __construct(
+        private readonly MessageBusInterface $bus,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('companyId', InputArgument::REQUIRED, 'UUID компании')
+            ->addOption('from', null, InputOption::VALUE_OPTIONAL, 'Начальная дата (YYYY-MM-DD)')
+            ->addOption('to', null, InputOption::VALUE_OPTIONAL, 'Конечная дата (YYYY-MM-DD)')
+            ->addOption('accounts', null, InputOption::VALUE_OPTIONAL, 'Список ID счетов через запятую');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $companyId = (string) $input->getArgument('companyId');
+
+        $from = $this->parseDateOption((string) $input->getOption('from'));
+        if (false === $from) {
+            $output->writeln('<error>Опция --from должна быть в формате YYYY-MM-DD.</error>');
+
+            return Command::FAILURE;
+        }
+
+        $to = $this->parseDateOption((string) $input->getOption('to'));
+        if (false === $to) {
+            $output->writeln('<error>Опция --to должна быть в формате YYYY-MM-DD.</error>');
+
+            return Command::FAILURE;
+        }
+
+        $accountsOption = (string) $input->getOption('accounts');
+        $accountIds = null;
+        if ('' !== trim($accountsOption)) {
+            $accountIds = array_values(array_filter(
+                array_map('trim', explode(',', $accountsOption)),
+                static fn (string $value): bool => '' !== $value,
+            ));
+        }
+
+        $this->bus->dispatch(new EnqueueAutoRulesForRange(
+            $companyId,
+            $from,
+            $to,
+            $accountIds,
+        ));
+
+        $output->writeln('<info>Сообщение поставлено в очередь.</info>');
+        $output->writeln(sprintf('Компания: %s', $companyId));
+        $output->writeln(sprintf('Диапазон дат: %s — %s', $from?->format('Y-m-d') ?? 'не задан', $to?->format('Y-m-d') ?? 'не задан'));
+        $output->writeln(sprintf('Счета: %s', $accountIds ? implode(', ', $accountIds) : 'все счета'));
+        $output->writeln('Следите за прогрессом: php bin/console messenger:consume async -vv');
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @return DateTimeImmutable|false|null
+     */
+    private function parseDateOption(string $value): DateTimeImmutable|false|null
+    {
+        $trimmed = trim($value);
+        if ('' === $trimmed) {
+            return null;
+        }
+
+        try {
+            return new DateTimeImmutable($trimmed);
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+}

--- a/site/src/Message/ApplyAutoRulesForTransaction.php
+++ b/site/src/Message/ApplyAutoRulesForTransaction.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Message;
+
+use DateTimeImmutable;
+
+final readonly class ApplyAutoRulesForTransaction
+{
+    public function __construct(
+        public string $transactionId,
+        public string $companyId,
+        public DateTimeImmutable $createdAt,
+    ) {
+    }
+}

--- a/site/src/Message/EnqueueAutoRulesForRange.php
+++ b/site/src/Message/EnqueueAutoRulesForRange.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Message;
+
+use DateTimeImmutable;
+
+final readonly class EnqueueAutoRulesForRange
+{
+    /**
+     * @param list<string>|null $moneyAccountIds
+     */
+    public function __construct(
+        public string $companyId,
+        public ?DateTimeImmutable $from = null,
+        public ?DateTimeImmutable $to = null,
+        public ?array $moneyAccountIds = null,
+    ) {
+    }
+}

--- a/site/src/MessageHandler/ApplyAutoRulesForTransactionHandler.php
+++ b/site/src/MessageHandler/ApplyAutoRulesForTransactionHandler.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\MessageHandler;
+
+use App\Entity\CashTransaction;
+use App\Message\ApplyAutoRulesForTransaction;
+use App\Repository\CashTransactionRepository;
+use App\Service\CashTransactionAutoRuleService;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+final class ApplyAutoRulesForTransactionHandler
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly CashTransactionRepository $transactionRepository,
+        private readonly CashTransactionAutoRuleService $autoRuleService,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(ApplyAutoRulesForTransaction $message): void
+    {
+        $transaction = $this->transactionRepository->find($message->transactionId);
+
+        if (!$transaction instanceof CashTransaction) {
+            $this->logger->warning('Cash auto rules: transaction not found', [
+                'transactionId' => $message->transactionId,
+                'companyId' => $message->companyId,
+                'createdAt' => $message->createdAt->format(DATE_ATOM),
+            ]);
+
+            return;
+        }
+
+        $transactionCompanyId = $transaction->getCompany()->getId();
+        if (null === $transactionCompanyId || $transactionCompanyId !== $message->companyId) {
+            $this->logger->warning('Cash auto rules: company mismatch', [
+                'transactionId' => $message->transactionId,
+                'expectedCompanyId' => $message->companyId,
+                'actualCompanyId' => $transactionCompanyId,
+                'createdAt' => $message->createdAt->format(DATE_ATOM),
+            ]);
+
+            $this->entityManager->clear(CashTransaction::class);
+
+            return;
+        }
+
+        $rule = $this->autoRuleService->findMatchingRule($transaction);
+        $changed = false;
+        $ruleId = null;
+        $ruleName = null;
+
+        if (null !== $rule) {
+            $changed = $this->autoRuleService->applyRule($rule, $transaction);
+            $ruleId = $rule->getId();
+            $ruleName = $rule->getName();
+        }
+
+        $this->logger->info('Cash auto rules applied', [
+            'transactionId' => $transaction->getId(),
+            'companyId' => $message->companyId,
+            'messageCreatedAt' => $message->createdAt->format(DATE_ATOM),
+            'changed' => $changed,
+            'ruleId' => $ruleId,
+            'ruleName' => $ruleName,
+        ]);
+
+        $this->entityManager->clear(CashTransaction::class);
+    }
+}

--- a/site/src/MessageHandler/EnqueueAutoRulesForRangeHandler.php
+++ b/site/src/MessageHandler/EnqueueAutoRulesForRangeHandler.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\MessageHandler;
+
+use App\Entity\CashTransaction;
+use App\Entity\Company;
+use App\Message\ApplyAutoRulesForTransaction;
+use App\Message\EnqueueAutoRulesForRange;
+use App\Repository\CashTransactionRepository;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[AsMessageHandler]
+final class EnqueueAutoRulesForRangeHandler
+{
+    private const BATCH_SIZE = 500;
+
+    public function __construct(
+        private readonly MessageBusInterface $bus,
+        private readonly CashTransactionRepository $transactionRepository,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(EnqueueAutoRulesForRange $message): void
+    {
+        $startTime = microtime(true);
+
+        $company = $this->entityManager->getReference(Company::class, $message->companyId);
+
+        $qb = $this->transactionRepository->createQueryBuilder('t')
+            ->where('t.company = :company')
+            ->setParameter('company', $company)
+            ->orderBy('t.occurredAt', 'ASC');
+
+        if ($message->from instanceof DateTimeImmutable) {
+            $qb
+                ->andWhere('t.occurredAt >= :from')
+                ->setParameter('from', $message->from->setTime(0, 0, 0));
+        }
+
+        if ($message->to instanceof DateTimeImmutable) {
+            $qb
+                ->andWhere('t.occurredAt <= :to')
+                ->setParameter('to', $message->to->setTime(23, 59, 59));
+        }
+
+        if (null !== $message->moneyAccountIds && [] !== $message->moneyAccountIds) {
+            $qb
+                ->andWhere('t.moneyAccount IN (:accounts)')
+                ->setParameter('accounts', $message->moneyAccountIds);
+        }
+
+        $query = $qb->getQuery();
+        $query->setHint(Query::HINT_READ_ONLY, true);
+
+        $selected = 0;
+        $enqueued = 0;
+
+        foreach ($query->toIterable() as $transaction) {
+            ++$selected;
+
+            if (!$transaction instanceof CashTransaction) {
+                continue;
+            }
+
+            $this->bus->dispatch(new ApplyAutoRulesForTransaction(
+                (string) $transaction->getId(),
+                $message->companyId,
+                new DateTimeImmutable(),
+            ));
+
+            ++$enqueued;
+
+            if (0 === $selected % self::BATCH_SIZE) {
+                $this->entityManager->clear(CashTransaction::class);
+            }
+        }
+
+        $this->logger->info('Cash auto rules enqueue completed', [
+            'companyId' => $message->companyId,
+            'selected' => $selected,
+            'enqueued' => $enqueued,
+            'from' => $message->from?->format(DATE_ATOM),
+            'to' => $message->to?->format(DATE_ATOM),
+            'moneyAccountIds' => $message->moneyAccountIds,
+            'durationMs' => (int) ((microtime(true) - $startTime) * 1000),
+        ]);
+
+        $this->entityManager->clear(CashTransaction::class);
+    }
+}

--- a/site/tests/Integration/CashTransactionServiceTest.php
+++ b/site/tests/Integration/CashTransactionServiceTest.php
@@ -21,6 +21,8 @@ use Doctrine\ORM\Tools\Setup;
 use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 class SimpleManagerRegistry implements ManagerRegistry
 {
@@ -89,6 +91,14 @@ class SimpleManagerRegistry implements ManagerRegistry
     }
 }
 
+class NullMessageBus implements MessageBusInterface
+{
+    public function dispatch(object $message, array $stamps = []): Envelope
+    {
+        return new Envelope($message);
+    }
+}
+
 class CashTransactionServiceTest extends TestCase
 {
     private EntityManager $em;
@@ -114,7 +124,7 @@ class CashTransactionServiceTest extends TestCase
         $txRepo = new \App\Repository\CashTransactionRepository($registry);
         $balanceRepo = new \App\Repository\MoneyAccountDailyBalanceRepository($registry);
         $balanceService = new AccountBalanceService($txRepo, $balanceRepo);
-        $this->txService = new CashTransactionService($this->em, $balanceService, $txRepo);
+        $this->txService = new CashTransactionService($this->em, $balanceService, $txRepo, new NullMessageBus());
     }
 
     public function testAddPersistsAllFields(): void

--- a/site/tests/Service/AccountBalanceServiceTest.php
+++ b/site/tests/Service/AccountBalanceServiceTest.php
@@ -19,6 +19,8 @@ use Doctrine\ORM\Tools\Setup;
 use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 class SimpleManagerRegistry implements ManagerRegistry
 {
@@ -87,6 +89,14 @@ class SimpleManagerRegistry implements ManagerRegistry
     }
 }
 
+class NullMessageBus implements MessageBusInterface
+{
+    public function dispatch(object $message, array $stamps = []): Envelope
+    {
+        return new Envelope($message);
+    }
+}
+
 class AccountBalanceServiceTest extends TestCase
 {
     private EntityManager $em;
@@ -112,7 +122,7 @@ class AccountBalanceServiceTest extends TestCase
         $txRepo = new \App\Repository\CashTransactionRepository($registry);
         $this->balanceRepo = new MoneyAccountDailyBalanceRepository($registry);
         $this->balanceService = new AccountBalanceService($txRepo, $this->balanceRepo);
-        $this->txService = new CashTransactionService($this->em, $this->balanceService, $txRepo);
+        $this->txService = new CashTransactionService($this->em, $this->balanceService, $txRepo, new NullMessageBus());
     }
 
     public function testRecalculateBalances(): void


### PR DESCRIPTION
## Summary
- add Messenger messages and handlers to apply auto rules per transaction and enqueue ranges
- hook async auto rule dispatching into transaction service, bank import, and new CLI command
- route new messages to Redis transport and run a dedicated worker in production compose setup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e15aef06c483238209b601d53ed082