### PR TITLE
Configure messenger transport DSN in prod compose

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -99,6 +99,7 @@ services:
             APP_ENV: PROD
             APP_SECRET: ${APP_SECRET}
             REDIS_DSN: redis://site-redis:6379
+            MESSENGER_TRANSPORT_DSN: redis://site-redis:6379/messages
         networks:
             - default
         depends_on:
@@ -114,6 +115,7 @@ services:
             APP_ENV: PROD
             APP_SECRET: ${APP_SECRET}
             REDIS_DSN: redis://site-redis:6379
+            MESSENGER_TRANSPORT_DSN: redis://site-redis:6379/messages
         networks:
             - default
         depends_on:
@@ -131,6 +133,7 @@ services:
             APP_ENV: PROD
             APP_SECRET: ${APP_SECRET}
             REDIS_DSN: redis://site-redis:6379/messages
+            MESSENGER_TRANSPORT_DSN: redis://site-redis:6379/messages
         networks:
             - default
         depends_on:


### PR DESCRIPTION
## Summary
- ensure the production PHP containers receive a Messenger transport DSN so the async worker can consume jobs from Redis

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1618a9af083238816c53a7879d64b