### PR TITLE
Validate CSRF token on messenger ping form submission

### DIFF
--- a/site/src/Controller/MessengerPingController.php
+++ b/site/src/Controller/MessengerPingController.php
@@ -24,6 +24,10 @@ final class MessengerPingController extends AbstractController
         MessageBusInterface $bus
     ): Response {
         if ($request->isMethod('POST')) {
+            if (!$this->isCsrfTokenValid('messenger_ping', (string) $request->request->get('_token'))) {
+                throw $this->createAccessDeniedException('Invalid CSRF token.');
+            }
+
             $id = bin2hex(random_bytes(8));
             $bus->dispatch(new TestMessengerPing($id, $companyCtx->getActiveCompany()->getId()));
             return $this->redirectToRoute('admin_messenger_ping', ['id' => $id]);


### PR DESCRIPTION
## Summary
- ensure the messenger ping controller verifies the CSRF token before dispatching a test message

## Testing
- php -l src/Controller/MessengerPingController.php

------
https://chatgpt.com/codex/tasks/task_e_68e16bf82594832386073f41ae4dea00