### PR TITLE
Fix APP_ENV value for production containers

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -96,7 +96,7 @@ services:
         restart: always
         environment:
             DATABASE_URL: pgsql://app:${POSTGRES_PASSWORD}@site-postgres:5432/app
-            APP_ENV: PROD
+            APP_ENV: prod
             APP_SECRET: ${APP_SECRET}
             REDIS_DSN: redis://site-redis:6379
             MESSENGER_TRANSPORT_DSN: redis://site-redis:6379/messages
@@ -112,7 +112,7 @@ services:
         container_name: site-php-cli
         environment:
             DATABASE_URL: pgsql://app:${POSTGRES_PASSWORD}@site-postgres:5432/app
-            APP_ENV: PROD
+            APP_ENV: prod
             APP_SECRET: ${APP_SECRET}
             REDIS_DSN: redis://site-redis:6379
             MESSENGER_TRANSPORT_DSN: redis://site-redis:6379/messages
@@ -130,7 +130,7 @@ services:
         command: php bin/console messenger:consume async -vv --time-limit=3600
         environment:
             DATABASE_URL: pgsql://app:${POSTGRES_PASSWORD}@site-postgres:5432/app
-            APP_ENV: PROD
+            APP_ENV: prod
             APP_SECRET: ${APP_SECRET}
             REDIS_DSN: redis://site-redis:6379
             MESSENGER_TRANSPORT_DSN: redis://site-redis:6379/messages


### PR DESCRIPTION
## Summary
- ensure the production PHP containers use `APP_ENV=prod` so Symfony boots with the proper environment and messenger transport configuration

## Testing
- not run (infrastructure change)


------
https://chatgpt.com/codex/tasks/task_e_68e170fbb9b48323a88cca5749df87ec