### PR TITLE
Validate UUID inputs for auto rules enqueue command

### DIFF
--- a/site/tests/Unit/Command/CashAutoRulesEnqueueCommandTest.php
+++ b/site/tests/Unit/Command/CashAutoRulesEnqueueCommandTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Tests\Unit\Command;
+
+use App\Command\CashAutoRulesEnqueueCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class CashAutoRulesEnqueueCommandTest extends TestCase
+{
+    public function testExecuteFailsWhenAccountsContainNonUuid(): void
+    {
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::never())->method('dispatch');
+
+        $command = new CashAutoRulesEnqueueCommand($bus);
+        $tester = new CommandTester($command);
+
+        $exitCode = $tester->execute([
+            'companyId' => '19621cff-b028-45d9-9193-11f47ad9a8b2',
+            '--accounts' => 'acc-1,acc-2',
+        ]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString('Опция --accounts должна содержать UUID', $tester->getDisplay());
+    }
+}


### PR DESCRIPTION
## Summary
- validate the accounts option in the cash auto rules enqueue command and refuse non-UUID values
- add a unit test covering the failure scenario for invalid account identifiers

## Testing
- composer test:unit *(fails: phpunit binary is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e176253eac8323b9bf4047e175cbd0