### PR TITLE
Expand Wildberries integration with orders UI

### DIFF
--- a/site/src/Api/Wildberries/WildberriesReportsApiClient.php
+++ b/site/src/Api/Wildberries/WildberriesReportsApiClient.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Api\Wildberries;
+
+use App\Entity\Company;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class WildberriesReportsApiClient
+{
+    private const BASE_URL = 'https://statistics-api.wildberries.ru/api/v1';
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private ?LoggerInterface $logger = null,
+    ) {
+        $this->logger ??= new NullLogger();
+    }
+
+    /**
+     * @throws TransportExceptionInterface
+     * @throws DecodingExceptionInterface
+     */
+    public function fetchDetailedSales(Company $company, \DateTimeImmutable $dateFrom, \DateTimeImmutable $dateTo, array $query = []): array
+    {
+        $apiKey = $company->getWildberriesApiKey();
+        if (!$apiKey) {
+            throw new \InvalidArgumentException('Wildberries API key is not configured for company '.$company->getId());
+        }
+
+        $params = array_merge([
+            'dateFrom' => $dateFrom->format(\DATE_ATOM),
+            'dateTo' => $dateTo->format(\DATE_ATOM),
+            'flag' => 0,
+        ], $query);
+
+        return $this->request($apiKey, '/supplier/sales', $params);
+    }
+
+    /**
+     * @throws TransportExceptionInterface
+     * @throws DecodingExceptionInterface
+     */
+    private function request(string $apiKey, string $path, array $query): array
+    {
+        $response = $this->httpClient->request('GET', rtrim(self::BASE_URL, '/').$path, [
+            'headers' => $this->headers($apiKey),
+            'query' => $query,
+        ]);
+
+        $this->logger->info('Wildberries API request', [
+            'path' => $path,
+            'query' => $query,
+            'status' => $response->getStatusCode(),
+        ]);
+
+        return $response->toArray(false);
+    }
+
+    private function headers(string $apiKey): array
+    {
+        return [
+            'Authorization' => $apiKey,
+            'Accept' => 'application/json',
+        ];
+    }
+}

--- a/site/src/Controller/Wildberries/WildberriesOrderController.php
+++ b/site/src/Controller/Wildberries/WildberriesOrderController.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Controller\Wildberries;
+
+use App\Entity\Company;
+use App\Entity\User;
+use App\Repository\Wildberries\WildberriesSaleRepository;
+use DateTimeImmutable;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class WildberriesOrderController extends AbstractController
+{
+    public function __construct(private LoggerInterface $logger)
+    {
+    }
+
+    #[Route('/wildberries/orders', name: 'wildberries_orders')]
+    public function index(Request $request, WildberriesSaleRepository $repository): Response
+    {
+        $user = $this->getUser();
+        if (!$user instanceof User) {
+            throw $this->createAccessDeniedException('User is not authenticated');
+        }
+
+        $company = $user->getCompanies()[0] ?? null;
+        if (!$company instanceof Company) {
+            throw $this->createNotFoundException('Компания не найдена для пользователя');
+        }
+
+        $page = max(1, (int) $request->query->get('page', 1));
+        $status = $request->query->get('status');
+        $orderType = $request->query->get('orderType');
+        $fromRaw = $request->query->get('from');
+        $toRaw = $request->query->get('to');
+
+        $filters = [];
+        if (is_string($status) && '' !== $status) {
+            $filters['status'] = $status;
+        }
+        if (is_string($orderType) && '' !== $orderType) {
+            $filters['orderType'] = $orderType;
+        }
+
+        $filtersForTemplate = [
+            'status' => $status,
+            'orderType' => $orderType,
+            'from' => $fromRaw,
+            'to' => $toRaw,
+        ];
+
+        if (is_string($fromRaw) && '' !== $fromRaw) {
+            try {
+                $filters['from'] = new DateTimeImmutable($fromRaw);
+            } catch (\Exception $exception) {
+                $this->addFlash('error', sprintf('Некорректная дата начала "%s"', $fromRaw));
+                $this->logger->warning('Invalid Wildberries from date', [
+                    'value' => $fromRaw,
+                    'exception' => $exception->getMessage(),
+                    'companyId' => $company->getId(),
+                ]);
+            }
+        }
+
+        if (is_string($toRaw) && '' !== $toRaw) {
+            try {
+                $filters['to'] = new DateTimeImmutable($toRaw);
+            } catch (\Exception $exception) {
+                $this->addFlash('error', sprintf('Некорректная дата окончания "%s"', $toRaw));
+                $this->logger->warning('Invalid Wildberries to date', [
+                    'value' => $toRaw,
+                    'exception' => $exception->getMessage(),
+                    'companyId' => $company->getId(),
+                ]);
+            }
+        }
+
+        $pagination = $repository->paginateByCompany($company, $page, 50, $filters);
+
+        return $this->render('wildberries/orders/index.html.twig', [
+            'pagination' => $pagination,
+            'filters' => $filtersForTemplate,
+        ]);
+    }
+}

--- a/site/src/Entity/Company.php
+++ b/site/src/Entity/Company.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use App\Entity\Ozon\OzonProduct;
+use App\Entity\Wildberries\WildberriesSale;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -41,12 +42,16 @@ class Company
     #[ORM\OneToMany(targetEntity: OzonProduct::class, mappedBy: 'company', orphanRemoval: true)]
     private Collection $ozonProducts;
 
+    #[ORM\OneToMany(targetEntity: WildberriesSale::class, mappedBy: 'company', orphanRemoval: true)]
+    private Collection $wildberriesSales;
+
     public function __construct(string $id, User $user)
     {
         Assert::uuid($id);
         $this->id = $id;
         $this->user = $user;
         $this->ozonProducts = new ArrayCollection();
+        $this->wildberriesSales = new ArrayCollection();
     }
 
     public function getId(): ?string
@@ -129,6 +134,11 @@ class Company
     public function getOzonProducts(): Collection
     {
         return $this->ozonProducts;
+    }
+
+    public function getWildberriesSales(): Collection
+    {
+        return $this->wildberriesSales;
     }
 
     public function getFinanceLockBefore(): ?\DateTimeImmutable

--- a/site/src/Entity/Wildberries/WildberriesSale.php
+++ b/site/src/Entity/Wildberries/WildberriesSale.php
@@ -1,0 +1,278 @@
+<?php
+
+namespace App\Entity\Wildberries;
+
+use App\Entity\Company;
+use App\Repository\Wildberries\WildberriesSaleRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: WildberriesSaleRepository::class)]
+#[ORM\Table(name: '`wildberries_sales`')]
+#[ORM\UniqueConstraint(name: 'uniq_wb_sale_company_srid', columns: ['company_id', 'srid'])]
+class WildberriesSale
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid', unique: true)]
+    private ?string $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Company::class, inversedBy: 'wildberriesSales')]
+    #[ORM\JoinColumn(name: 'company_id', nullable: false, onDelete: 'CASCADE')]
+    private Company $company;
+
+    #[ORM\Column(length: 64)]
+    private string $srid;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $soldAt;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $supplierArticle = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $techSize = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $barcode = null;
+
+    #[ORM\Column(type: 'integer')]
+    private int $quantity = 0;
+
+    #[ORM\Column(type: 'decimal', precision: 15, scale: 2)]
+    private string $price = '0.00';
+
+    #[ORM\Column(type: 'decimal', precision: 15, scale: 2)]
+    private string $finishedPrice = '0.00';
+
+    #[ORM\Column(type: 'decimal', precision: 15, scale: 2, nullable: true)]
+    private ?string $forPay = null;
+
+    #[ORM\Column(type: 'decimal', precision: 15, scale: 2, nullable: true)]
+    private ?string $deliveryAmount = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $orderType = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $saleStatus = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $warehouseName = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $oblast = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $odid = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $saleId = null;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $statusUpdatedAt = null;
+
+    #[ORM\Column(type: 'json')]
+    private array $raw = [];
+
+    public function __construct(string $id, Company $company, string $srid)
+    {
+        $this->id = $id;
+        $this->company = $company;
+        $this->srid = $srid;
+        $this->soldAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getCompany(): Company
+    {
+        return $this->company;
+    }
+
+    public function setCompany(Company $company): void
+    {
+        $this->company = $company;
+    }
+
+    public function getSrid(): string
+    {
+        return $this->srid;
+    }
+
+    public function setSrid(string $srid): void
+    {
+        $this->srid = $srid;
+    }
+
+    public function getSoldAt(): \DateTimeImmutable
+    {
+        return $this->soldAt;
+    }
+
+    public function setSoldAt(\DateTimeImmutable $soldAt): void
+    {
+        $this->soldAt = $soldAt;
+    }
+
+    public function getSupplierArticle(): ?string
+    {
+        return $this->supplierArticle;
+    }
+
+    public function setSupplierArticle(?string $supplierArticle): void
+    {
+        $this->supplierArticle = $supplierArticle;
+    }
+
+    public function getTechSize(): ?string
+    {
+        return $this->techSize;
+    }
+
+    public function setTechSize(?string $techSize): void
+    {
+        $this->techSize = $techSize;
+    }
+
+    public function getBarcode(): ?string
+    {
+        return $this->barcode;
+    }
+
+    public function setBarcode(?string $barcode): void
+    {
+        $this->barcode = $barcode;
+    }
+
+    public function getQuantity(): int
+    {
+        return $this->quantity;
+    }
+
+    public function setQuantity(int $quantity): void
+    {
+        $this->quantity = $quantity;
+    }
+
+    public function getPrice(): string
+    {
+        return $this->price;
+    }
+
+    public function setPrice(string $price): void
+    {
+        $this->price = $price;
+    }
+
+    public function getFinishedPrice(): string
+    {
+        return $this->finishedPrice;
+    }
+
+    public function setFinishedPrice(string $finishedPrice): void
+    {
+        $this->finishedPrice = $finishedPrice;
+    }
+
+    public function getForPay(): ?string
+    {
+        return $this->forPay;
+    }
+
+    public function setForPay(?string $forPay): void
+    {
+        $this->forPay = $forPay;
+    }
+
+    public function getDeliveryAmount(): ?string
+    {
+        return $this->deliveryAmount;
+    }
+
+    public function setDeliveryAmount(?string $deliveryAmount): void
+    {
+        $this->deliveryAmount = $deliveryAmount;
+    }
+
+    public function getOrderType(): ?string
+    {
+        return $this->orderType;
+    }
+
+    public function setOrderType(?string $orderType): void
+    {
+        $this->orderType = $orderType;
+    }
+
+    public function getSaleStatus(): ?string
+    {
+        return $this->saleStatus;
+    }
+
+    public function setSaleStatus(?string $saleStatus): void
+    {
+        $this->saleStatus = $saleStatus;
+    }
+
+    public function getWarehouseName(): ?string
+    {
+        return $this->warehouseName;
+    }
+
+    public function setWarehouseName(?string $warehouseName): void
+    {
+        $this->warehouseName = $warehouseName;
+    }
+
+    public function getOblast(): ?string
+    {
+        return $this->oblast;
+    }
+
+    public function setOblast(?string $oblast): void
+    {
+        $this->oblast = $oblast;
+    }
+
+    public function getOdid(): ?string
+    {
+        return $this->odid;
+    }
+
+    public function setOdid(?string $odid): void
+    {
+        $this->odid = $odid;
+    }
+
+    public function getSaleId(): ?string
+    {
+        return $this->saleId;
+    }
+
+    public function setSaleId(?string $saleId): void
+    {
+        $this->saleId = $saleId;
+    }
+
+    public function getStatusUpdatedAt(): ?\DateTimeImmutable
+    {
+        return $this->statusUpdatedAt;
+    }
+
+    public function setStatusUpdatedAt(?\DateTimeImmutable $statusUpdatedAt): void
+    {
+        $this->statusUpdatedAt = $statusUpdatedAt;
+    }
+
+    public function getRaw(): array
+    {
+        return $this->raw;
+    }
+
+    public function setRaw(array $raw): void
+    {
+        $this->raw = $raw;
+    }
+}

--- a/site/src/Repository/Wildberries/WildberriesSaleRepository.php
+++ b/site/src/Repository/Wildberries/WildberriesSaleRepository.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Repository\Wildberries;
+
+use App\Entity\Company;
+use App\Entity\Wildberries\WildberriesSale;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<WildberriesSale>
+ */
+class WildberriesSaleRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, WildberriesSale::class);
+    }
+
+    public function findOneByCompanyAndSrid(Company $company, string $srid): ?WildberriesSale
+    {
+        return $this->createQueryBuilder('sale')
+            ->andWhere('sale.company = :company')
+            ->andWhere('sale.srid = :srid')
+            ->setParameter('company', $company)
+            ->setParameter('srid', $srid)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    /**
+     * @param array<string, mixed> $filters
+     *
+     * @return array{items: list<WildberriesSale>, total: int, currentPage: int, pages: int, perPage: int}
+     */
+    public function paginateByCompany(Company $company, int $page, int $perPage = 50, array $filters = []): array
+    {
+        $page = max(1, $page);
+        $perPage = max(1, $perPage);
+
+        $qb = $this->createQueryBuilder('sale')
+            ->andWhere('sale.company = :company')
+            ->setParameter('company', $company);
+
+        if (!empty($filters['status'])) {
+            $qb->andWhere('sale.saleStatus = :status')
+                ->setParameter('status', $filters['status']);
+        }
+
+        if (!empty($filters['orderType'])) {
+            $qb->andWhere('sale.orderType = :orderType')
+                ->setParameter('orderType', $filters['orderType']);
+        }
+
+        if (!empty($filters['from'])) {
+            $qb->andWhere('sale.soldAt >= :from')
+                ->setParameter('from', $filters['from']);
+        }
+
+        if (!empty($filters['to'])) {
+            $qb->andWhere('sale.soldAt <= :to')
+                ->setParameter('to', $filters['to']);
+        }
+
+        $qb->orderBy('sale.statusUpdatedAt', 'DESC')
+            ->addOrderBy('sale.soldAt', 'DESC');
+
+        $query = $qb->getQuery();
+        $query->setMaxResults($perPage);
+        $query->setFirstResult(($page - 1) * $perPage);
+
+        $paginator = new Paginator($query, true);
+        $total = count($paginator);
+        $pages = (int) ceil($total / $perPage);
+
+        if ($pages > 0 && $page > $pages) {
+            $page = $pages;
+            $query->setFirstResult(($page - 1) * $perPage);
+            $paginator = new Paginator($query, true);
+        }
+
+        return [
+            'items' => iterator_to_array($paginator, false),
+            'total' => $total,
+            'currentPage' => $page,
+            'pages' => $pages,
+            'perPage' => $perPage,
+        ];
+    }
+}

--- a/site/src/Service/Wildberries/WildberriesSalesImporter.php
+++ b/site/src/Service/Wildberries/WildberriesSalesImporter.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Service\Wildberries;
+
+use App\Api\Wildberries\WildberriesReportsApiClient;
+use App\Entity\Company;
+use App\Entity\Wildberries\WildberriesSale;
+use App\Repository\Wildberries\WildberriesSaleRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Ramsey\Uuid\Uuid;
+
+readonly class WildberriesSalesImporter
+{
+    public function __construct(
+        private WildberriesReportsApiClient $client,
+        private EntityManagerInterface $entityManager,
+        private WildberriesSaleRepository $salesRepository,
+        private ?LoggerInterface $logger = null,
+    ) {
+        $this->logger ??= new NullLogger();
+    }
+
+    public function import(Company $company, \DateTimeImmutable $dateFrom, \DateTimeImmutable $dateTo): int
+    {
+        $apiKey = $company->getWildberriesApiKey();
+        if (!$apiKey) {
+            $this->logger->warning('Wildberries API key is missing, skipping import', [
+                'companyId' => $company->getId(),
+            ]);
+
+            return 0;
+        }
+
+        $rows = $this->client->fetchDetailedSales($company, $dateFrom, $dateTo);
+        $processed = 0;
+
+        foreach ($rows as $row) {
+            $srid = (string) ($row['srid'] ?? '');
+            if ('' === $srid) {
+                continue;
+            }
+
+            $sale = $this->salesRepository->findOneByCompanyAndSrid($company, $srid);
+            if (!$sale) {
+                $sale = new WildberriesSale(Uuid::uuid4()->toString(), $company, $srid);
+            }
+
+            $soldAt = isset($row['date']) ? new \DateTimeImmutable($row['date']) : $dateFrom;
+            $sale->setSoldAt($soldAt);
+            $sale->setSupplierArticle($row['supplierArticle'] ?? null);
+            $sale->setTechSize($row['techSize'] ?? null);
+            $sale->setBarcode($row['barcode'] ?? null);
+            $sale->setQuantity((int) ($row['quantity'] ?? 0));
+            $sale->setPrice((string) ($row['price'] ?? '0'));
+            $sale->setFinishedPrice((string) ($row['finishedPrice'] ?? $sale->getPrice()));
+            $sale->setForPay(isset($row['forPay']) ? (string) $row['forPay'] : null);
+            $sale->setDeliveryAmount(isset($row['deliveryAmount']) ? (string) $row['deliveryAmount'] : null);
+            $sale->setOrderType(isset($row['orderType']) ? (string) $row['orderType'] : null);
+            $sale->setSaleStatus(isset($row['saleStatus']) ? (string) $row['saleStatus'] : null);
+            $sale->setWarehouseName(isset($row['warehouseName']) ? (string) $row['warehouseName'] : null);
+            $sale->setOblast(isset($row['oblast']) ? (string) $row['oblast'] : null);
+            $sale->setOdid(isset($row['odid']) ? (string) $row['odid'] : null);
+            $sale->setSaleId(isset($row['saleID']) ? (string) $row['saleID'] : null);
+
+            $statusUpdatedAt = null;
+            if (!empty($row['lastChangeDate'])) {
+                try {
+                    $statusUpdatedAt = new \DateTimeImmutable($row['lastChangeDate']);
+                } catch (\Exception $exception) {
+                    $this->logger->warning('Failed to parse Wildberries lastChangeDate', [
+                        'companyId' => $company->getId(),
+                        'value' => $row['lastChangeDate'],
+                        'exception' => $exception->getMessage(),
+                    ]);
+                }
+            }
+
+            if ($statusUpdatedAt instanceof \DateTimeImmutable) {
+                $sale->setStatusUpdatedAt($statusUpdatedAt);
+            } elseif (null === $sale->getStatusUpdatedAt()) {
+                $sale->setStatusUpdatedAt($soldAt);
+            }
+            $sale->setRaw($row);
+
+            $this->entityManager->persist($sale);
+            ++$processed;
+        }
+
+        if ($processed > 0) {
+            $this->entityManager->flush();
+        }
+
+        return $processed;
+    }
+}

--- a/site/templates/partials/_sidebar.html.twig
+++ b/site/templates/partials/_sidebar.html.twig
@@ -105,6 +105,17 @@
                         </a>
                     </div>
                 </li>
+                {#---- Wildberries ---#}
+                <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle" href="#" data-bs-toggle="dropdown" data-bs-auto-close="false" role="button" aria-expanded="false">
+                        <span class="nav-link-title text-muted"> Wildberries </span>
+                    </a>
+                    <div class="dropdown-menu" data-bs-popper="static">
+                        <a class="dropdown-item {{ current_route starts with 'wildberries_orders' ? 'active' : '' }}" href="{{ path('wildberries_orders') }}">
+                            <span class="nav-link-title">Заказы</span>
+                        </a>
+                    </div>
+                </li>
                 {#---- Profile ---#}
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" data-bs-toggle="dropdown" data-bs-auto-close="false" role="button" aria-expanded="false">

--- a/site/templates/wildberries/orders/index.html.twig
+++ b/site/templates/wildberries/orders/index.html.twig
@@ -1,0 +1,117 @@
+{% extends 'base.html.twig' %}
+
+{% block body %}
+    {% for message in app.flashes('success') %}
+        <div class="alert alert-success" role="alert">
+            {{ message }}
+        </div>
+    {% endfor %}
+    {% for message in app.flashes('error') %}
+        <div class="alert alert-danger" role="alert">
+            {{ message }}
+        </div>
+    {% endfor %}
+
+    <h1 class="mb-4">Заказы Wildberries</h1>
+
+    <form method="get" class="row g-2 mb-4">
+        <div class="col-md-3">
+            <label for="filter-status" class="form-label">Статус</label>
+            <input id="filter-status" type="text" name="status" value="{{ filters.status }}" class="form-control" placeholder="пример: delivered">
+        </div>
+        <div class="col-md-3">
+            <label for="filter-order-type" class="form-label">Тип заказа</label>
+            <input id="filter-order-type" type="text" name="orderType" value="{{ filters.orderType }}" class="form-control" placeholder="пример: FBO">
+        </div>
+        <div class="col-md-3">
+            <label for="filter-from" class="form-label">Дата c</label>
+            <input id="filter-from" type="datetime-local" name="from" value="{{ filters.from }}" class="form-control">
+        </div>
+        <div class="col-md-3">
+            <label for="filter-to" class="form-label">Дата по</label>
+            <input id="filter-to" type="datetime-local" name="to" value="{{ filters.to }}" class="form-control">
+        </div>
+        <div class="col-12 d-flex justify-content-end gap-2 mt-2">
+            <a href="{{ path('wildberries_orders') }}" class="btn btn-outline-secondary">Сбросить</a>
+            <button type="submit" class="btn btn-primary">Применить</button>
+        </div>
+    </form>
+
+    <div class="table-responsive">
+        <table class="table table-striped align-middle">
+            <thead>
+            <tr>
+                <th>Дата продажи</th>
+                <th>SRID</th>
+                <th>Sale ID</th>
+                <th>ODID</th>
+                <th>Статус</th>
+                <th>Тип заказа</th>
+                <th>Кол-во</th>
+                <th>Цена</th>
+                <th>Итого</th>
+                <th>К выплате</th>
+                <th>Доставка</th>
+                <th>Склад</th>
+                <th>Регион</th>
+                <th>Обновлено</th>
+                <th>Raw</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for sale in pagination.items %}
+                <tr>
+                    <td>{{ sale.soldAt|date('Y-m-d H:i') }}</td>
+                    <td>{{ sale.srid }}</td>
+                    <td>{{ sale.saleId ?? '—' }}</td>
+                    <td>{{ sale.odid ?? '—' }}</td>
+                    <td>{{ sale.saleStatus ?? '—' }}</td>
+                    <td>{{ sale.orderType ?? '—' }}</td>
+                    <td>{{ sale.quantity }}</td>
+                    <td>{{ sale.price }}</td>
+                    <td>{{ sale.finishedPrice }}</td>
+                    <td>{{ sale.forPay ?? '—' }}</td>
+                    <td>{{ sale.deliveryAmount ?? '—' }}</td>
+                    <td>{{ sale.warehouseName ?? '—' }}</td>
+                    <td>{{ sale.oblast ?? '—' }}</td>
+                    <td>{{ sale.statusUpdatedAt ? sale.statusUpdatedAt|date('Y-m-d H:i') : '—' }}</td>
+                    <td>
+                        <details>
+                            <summary>Показать</summary>
+                            <pre class="mb-0"><code>{{ sale.raw|json_encode(constant('JSON_PRETTY_PRINT')) }}</code></pre>
+                        </details>
+                    </td>
+                </tr>
+            {% else %}
+                <tr>
+                    <td colspan="15" class="text-center">Данные о заказах отсутствуют</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    {% if pagination.pages > 1 %}
+        {% set baseParams = {} %}
+        {% for key, value in filters %}
+            {% if value is not empty %}
+                {% set baseParams = baseParams|merge({ (key): value }) %}
+            {% endif %}
+        {% endfor %}
+        <nav aria-label="Wildberries orders pagination">
+            <ul class="pagination">
+                <li class="page-item {{ pagination.currentPage <= 1 ? 'disabled' : '' }}">
+                    <a class="page-link" href="{{ path('wildberries_orders', baseParams|merge({'page': pagination.currentPage - 1})) }}">Назад</a>
+                </li>
+                {% for pageNumber in 1..pagination.pages %}
+                    <li class="page-item {{ pageNumber == pagination.currentPage ? 'active' : '' }}">
+                        <a class="page-link" href="{{ path('wildberries_orders', baseParams|merge({'page': pageNumber})) }}">{{ pageNumber }}</a>
+                    </li>
+                {% endfor %}
+                <li class="page-item {{ pagination.currentPage >= pagination.pages ? 'disabled' : '' }}">
+                    <a class="page-link" href="{{ path('wildberries_orders', baseParams|merge({'page': pagination.currentPage + 1})) }}">Вперёд</a>
+                </li>
+            </ul>
+        </nav>
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
# What & Why
- Сохранили полные raw-данные и дополнительные атрибуты продаж Wildberries для последующей аналитики и отслеживания статусов.
- Добавили пагинированный репозиторий, контроллер и страницу «Заказы Wildberries» с фильтрами по статусу, типу и датам.
- Вынесли новый раздел Wildberries в главное меню для быстрого доступа.

# Changes
- [ ] Миграции Doctrine добавлены
- [ ] Индексы на частые фильтры (`company_id`, `created_at`) проверены
- [ ] Транзакционность/идемпотентность для импортов обеспечена
- [ ] Тесты: unit/integration добавлены/обновлены
- [ ] Документация/ADR обновлены (если меняется архитектура)

# Screenshots / Schemas
- n/a

# Risk & Rollback
- Средний: потребуется добавить миграцию для новых колонок и учесть изменения при откате.

------
https://chatgpt.com/codex/tasks/task_e_68e22c00ac9083238b3650caea747cb9