### PR TITLE
Add refresh flow for Wildberries orders

### DIFF
--- a/site/src/Command/WildberriesOrdersUpdateCommand.php
+++ b/site/src/Command/WildberriesOrdersUpdateCommand.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Company;
+use App\Repository\CompanyRepository;
+use App\Repository\Wildberries\WildberriesSaleRepository;
+use App\Service\Wildberries\WildberriesSalesImporter;
+use DateInterval;
+use DateTimeImmutable;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'app:wildberries:update-orders', description: 'Импортирует заказы Wildberries для компании')]
+class WildberriesOrdersUpdateCommand extends Command
+{
+    public function __construct(
+        private readonly CompanyRepository $companyRepository,
+        private readonly WildberriesSaleRepository $saleRepository,
+        private readonly WildberriesSalesImporter $salesImporter,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('company', null, InputOption::VALUE_REQUIRED, 'ID компании для обновления');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $companyId = (string) $input->getOption('company');
+        if ('' === $companyId) {
+            $output->writeln('<error>Необходимо указать компанию через --company</error>');
+
+            return Command::FAILURE;
+        }
+
+        /** @var Company|null $company */
+        $company = $this->companyRepository->find($companyId);
+        if (!$company) {
+            $output->writeln(sprintf('<error>Компания с идентификатором %s не найдена</error>', $companyId));
+
+            return Command::FAILURE;
+        }
+
+        $apiKey = $company->getWildberriesApiKey();
+        if (!$apiKey) {
+            $output->writeln('<comment>Для компании не задан Wildberries API ключ, импорт пропущен</comment>');
+
+            return Command::SUCCESS;
+        }
+
+        $dateTo = new DateTimeImmutable('now');
+        if (!$this->saleRepository->hasSalesForCompany($company)) {
+            $dateFrom = $dateTo->sub(new DateInterval('P80D'));
+            $this->logger->info('Wildberries initial sync period calculated', [
+                'companyId' => $company->getId(),
+                'dateFrom' => $dateFrom->format(DateTimeImmutable::ATOM),
+                'dateTo' => $dateTo->format(DateTimeImmutable::ATOM),
+            ]);
+        } else {
+            $oldestOpen = $this->saleRepository->findOldestOpenSoldAt($company);
+            if ($oldestOpen instanceof DateTimeImmutable) {
+                $dateFrom = $oldestOpen;
+            } else {
+                $latestSoldAt = $this->saleRepository->findLatestSoldAt($company);
+                if ($latestSoldAt instanceof DateTimeImmutable) {
+                    $dateFrom = $latestSoldAt->sub(new DateInterval('P3D'));
+                } else {
+                    $dateFrom = $dateTo->sub(new DateInterval('P3D'));
+                }
+            }
+
+            if ($dateFrom > $dateTo) {
+                $dateFrom = $dateTo;
+            }
+
+            $this->logger->info('Wildberries incremental sync period calculated', [
+                'companyId' => $company->getId(),
+                'dateFrom' => $dateFrom->format(DateTimeImmutable::ATOM),
+                'dateTo' => $dateTo->format(DateTimeImmutable::ATOM),
+            ]);
+        }
+
+        $processed = $this->salesImporter->import($company, $dateFrom, $dateTo);
+        $output->writeln(sprintf(
+            'Импорт завершён: %d записей (%s — %s)',
+            $processed,
+            $dateFrom->format('Y-m-d H:i'),
+            $dateTo->format('Y-m-d H:i'),
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/site/src/Controller/Wildberries/WildberriesOrderController.php
+++ b/site/src/Controller/Wildberries/WildberriesOrderController.php
@@ -7,15 +7,25 @@ use App\Entity\User;
 use App\Repository\Wildberries\WildberriesSaleRepository;
 use DateTimeImmutable;
 use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 class WildberriesOrderController extends AbstractController
 {
-    public function __construct(private LoggerInterface $logger)
-    {
+    public function __construct(
+        private LoggerInterface $logger,
+        private KernelInterface $kernel,
+        private CsrfTokenManagerInterface $csrfTokenManager,
+    ) {
     }
 
     #[Route('/wildberries/orders', name: 'wildberries_orders')]
@@ -84,5 +94,54 @@ class WildberriesOrderController extends AbstractController
             'pagination' => $pagination,
             'filters' => $filtersForTemplate,
         ]);
+    }
+
+    #[Route('/wildberries/orders/update', name: 'wildberries_orders_update', methods: ['POST'])]
+    public function update(Request $request): Response
+    {
+        $user = $this->getUser();
+        if (!$user instanceof User) {
+            throw $this->createAccessDeniedException('User is not authenticated');
+        }
+
+        $company = $user->getCompanies()[0] ?? null;
+        if (!$company instanceof Company) {
+            throw $this->createNotFoundException('Компания не найдена для пользователя');
+        }
+
+        $token = (string) $request->request->get('_token');
+        if (!$this->csrfTokenManager->isTokenValid(new CsrfToken('wildberries_orders_update', $token))) {
+            throw $this->createAccessDeniedException('Недопустимый CSRF токен');
+        }
+
+        $application = new Application($this->kernel);
+        $application->setAutoExit(false);
+
+        $input = new ArrayInput([
+            'command' => 'app:wildberries:update-orders',
+            '--company' => $company->getId(),
+        ]);
+        $output = new BufferedOutput();
+
+        try {
+            $exitCode = $application->run($input, $output);
+        } catch (\Throwable $exception) {
+            $this->logger->error('Wildberries orders update failed', [
+                'companyId' => $company->getId(),
+                'exception' => $exception->getMessage(),
+            ]);
+            $exitCode = Command::FAILURE;
+            $output->writeln($exception->getMessage());
+        }
+
+        $message = trim($output->fetch());
+
+        if (Command::SUCCESS === $exitCode) {
+            $this->addFlash('success', '' !== $message ? $message : 'Заказы Wildberries обновлены');
+        } else {
+            $this->addFlash('error', '' !== $message ? $message : 'Не удалось обновить заказы Wildberries');
+        }
+
+        return $this->redirectToRoute('wildberries_orders');
     }
 }

--- a/site/templates/wildberries/orders/index.html.twig
+++ b/site/templates/wildberries/orders/index.html.twig
@@ -12,7 +12,13 @@
         </div>
     {% endfor %}
 
-    <h1 class="mb-4">Заказы Wildberries</h1>
+    <div class="d-flex justify-content-between align-items-center mb-4 flex-wrap gap-2">
+        <h1 class="mb-0">Заказы Wildberries</h1>
+        <form method="post" action="{{ path('wildberries_orders_update') }}">
+            <input type="hidden" name="_token" value="{{ csrf_token('wildberries_orders_update') }}">
+            <button type="submit" class="btn btn-outline-primary">Обновить</button>
+        </form>
+    </div>
 
     <form method="get" class="row g-2 mb-4">
         <div class="col-md-3">


### PR DESCRIPTION
## Summary
- add a Wildberries orders sync console command that calculates initial and incremental load ranges
- expose an "Обновить" button in the Wildberries orders journal that runs the sync command via the controller with CSRF protection
- extend the sales repository with helpers to detect existing data and open orders to keep statuses up to date

## Testing
- php -l site/src/Command/WildberriesOrdersUpdateCommand.php
- php -l site/src/Controller/Wildberries/WildberriesOrderController.php
- php -l site/src/Repository/Wildberries/WildberriesSaleRepository.php

------
https://chatgpt.com/codex/tasks/task_e_68e23621479483238d6a581cf3749863