### PR TITLE
Allow storing long Wildberries API keys

### DIFF
--- a/site/migrations/Version20250906100000.php
+++ b/site/migrations/Version20250906100000.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250906100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Change wildberries_api_key column type to TEXT';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "companies" ALTER COLUMN wildberries_api_key TYPE TEXT');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "companies" ALTER COLUMN wildberries_api_key TYPE VARCHAR(255)');
+    }
+}

--- a/site/src/Entity/Company.php
+++ b/site/src/Entity/Company.php
@@ -6,6 +6,7 @@ use App\Entity\Ozon\OzonProduct;
 use App\Entity\Wildberries\WildberriesSale;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Webmozart\Assert\Assert;
 
@@ -23,7 +24,7 @@ class Company
     #[ORM\Column(length: 12, nullable: true)]
     private ?string $inn = null;
 
-    #[ORM\Column(length: 255, nullable: true)]
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
     private ?string $wildberriesApiKey = null;
 
     #[ORM\Column(length: 255, nullable: true)]


### PR DESCRIPTION
## Summary
- allow the Company entity to persist longer Wildberries API keys by switching the field to a TEXT column
- add a Doctrine migration that updates the companies.wildberries_api_key column type to TEXT

## Testing
- not run (composer dependencies cannot be installed in this environment due to missing ext-redis and GitHub download restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68e238d1eee08323b5b813f98894d832