### PR TITLE
Fetch Wildberries order statuses

### DIFF
--- a/site/src/Api/Wildberries/WildberriesReportsApiClient.php
+++ b/site/src/Api/Wildberries/WildberriesReportsApiClient.php
@@ -44,6 +44,26 @@ class WildberriesReportsApiClient
      * @throws TransportExceptionInterface
      * @throws DecodingExceptionInterface
      */
+    public function fetchOrders(Company $company, \DateTimeImmutable $dateFrom, \DateTimeImmutable $dateTo, array $query = []): array
+    {
+        $apiKey = $company->getWildberriesApiKey();
+        if (!$apiKey) {
+            throw new \InvalidArgumentException('Wildberries API key is not configured for company '.$company->getId());
+        }
+
+        $params = array_merge([
+            'dateFrom' => $dateFrom->format(\DATE_ATOM),
+            'dateTo' => $dateTo->format(\DATE_ATOM),
+            'flag' => 0,
+        ], $query);
+
+        return $this->request($apiKey, '/supplier/orders', $params);
+    }
+
+    /**
+     * @throws TransportExceptionInterface
+     * @throws DecodingExceptionInterface
+     */
     private function request(string $apiKey, string $path, array $query): array
     {
         $response = $this->httpClient->request('GET', rtrim(self::BASE_URL, '/').$path, [


### PR DESCRIPTION
## Summary
- add a Wildberries reports API client helper to call the supplier orders endpoint
- enrich the Wildberries sales importer with order status data when sales payload lacks `saleStatus`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2414b48488323ba6ba749e27be338