### PR TITLE
Sort Wildberries orders by latest sold date

### DIFF
--- a/site/src/Repository/Wildberries/WildberriesSaleRepository.php
+++ b/site/src/Repository/Wildberries/WildberriesSaleRepository.php
@@ -143,7 +143,7 @@ class WildberriesSaleRepository extends ServiceEntityRepository
                 ->setParameter('to', $filters['to']);
         }
 
-        $qb->orderBy('sale.soldAt', 'ASC');
+        $qb->orderBy('sale.soldAt', 'DESC');
 
         $query = $qb->getQuery();
         $query->setMaxResults($perPage);


### PR DESCRIPTION
## Summary
- switch the Wildberries orders pagination query to order by soldAt descending so the newest orders appear first

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e28064a850832399b5640130cd1abc