### PR TITLE
Update docker socket proxy image tag

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -162,7 +162,7 @@ services:
             - default
 
     socket-proxy:
-        image: tecnativa/docker-socket-proxy:0.2.3
+        image: tecnativa/docker-socket-proxy:0.2.4
         environment:
             - LOG=1
             - EVENTS=1


### PR DESCRIPTION
## Summary
- update the production docker-compose configuration to use the tecnativa/docker-socket-proxy:0.2.4 image, which is available in the registry

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3de6abfec8323abf570c78ab1b3ed