### PR TITLE
Fix docker socket proxy image tag

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -162,7 +162,7 @@ services:
             - default
 
     socket-proxy:
-        image: tecnativa/docker-socket-proxy:0.2.4
+        image: tecnativa/docker-socket-proxy:0.2.6
         environment:
             - LOG=1
             - EVENTS=1


### PR DESCRIPTION
## Summary
- update the docker socket proxy image tag to a version that exists in the registry

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3dfa0f87c83239fbe4c0b20200dad