### PR TITLE
Set docker socket proxy image to latest

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -162,7 +162,7 @@ services:
             - default
 
     socket-proxy:
-        image: tecnativa/docker-socket-proxy:0.2.4
+        image: tecnativa/docker-socket-proxy:latest
         environment:
             - LOG=1
             - EVENTS=1


### PR DESCRIPTION
## Summary
- update the production docker-compose socket proxy service to pull the latest tecnativa/docker-socket-proxy image tag

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3dfa0f87c83239fbe4c0b20200dad