### PR TITLE
Use latest docker-socket-proxy image

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -162,7 +162,7 @@ services:
             - default
 
     socket-proxy:
-        image: tecnativa/docker-socket-proxy:0.2.6
+        image: tecnativa/docker-socket-proxy:latest
         environment:
             - LOG=1
             - EVENTS=1


### PR DESCRIPTION
## Summary
- update the docker-socket-proxy service to pull the latest available image tag to avoid missing manifest errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3e3714000832394afe3665176f52e