### PR TITLE
Fix cron jobs to run without TTY

### DIFF
--- a/docker/cron/app.cron
+++ b/docker/cron/app.cron
@@ -1,13 +1,13 @@
 # ┌─ min  ┌ hour ┌ dom ┌ mon ┌ dow
 # │       │      │     │     │
 # Каждые 5 минут: авто-правила ДДС
-*/5 * * * * docker exec -t site-php-cli php /app/bin/console app:cash:auto-rules --no-interaction >> /var/log/cron/app.log 2>&1
+*/5 * * * * docker exec site-php-cli php /app/bin/console app:cash:auto-rules --no-interaction >> /var/log/cron/app.log 2>&1
 
 # Раз в час: пересчёт оперативных P&L-агрегатов
-5 * * * * docker exec -t site-php-cli php /app/bin/console app:pl:rebuild --no-interaction >> /var/log/cron/app.log 2>&1
+5 * * * * docker exec site-php-cli php /app/bin/console app:pl:rebuild --no-interaction >> /var/log/cron/app.log 2>&1
 
 # Ежедневно в 02:10: снапшоты остатков по счетам
-10 2 * * * docker exec -t site-php-cli php /app/bin/console app:money-account:snapshot --no-interaction >> /var/log/cron/app.log 2>&1
+10 2 * * * docker exec site-php-cli php /app/bin/console app:money-account:snapshot --no-interaction >> /var/log/cron/app.log 2>&1
 
 # Ежедневно в 03:00: чистка логов/временных таблиц
-0 3 * * * docker exec -t site-php-cli php /app/bin/console app:maintenance:cleanup --env=prod >> /var/log/cron/app.log 2>&1
+0 3 * * * docker exec site-php-cli php /app/bin/console app:maintenance:cleanup --env=prod >> /var/log/cron/app.log 2>&1


### PR DESCRIPTION
## Summary
- remove TTY allocation from cron docker exec commands to avoid socket proxy 403 errors

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e3ec2cf00c83238f3b39fdcfc701ba