### PR TITLE
Ensure cron log directory exists during deploy

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -55,6 +55,9 @@ ssh $SERVER_USER@$SERVER_HOST << EOF
   unzip -o app.zip -d ./current
   rm app.zip
 
+  echo "🪵 Создаю директорию для логов cron..."
+  mkdir -p ./current/var/log/cron
+
   echo "📄 Копирую .env.prod внутрь каталога site/"
   cp $ENV_FILE ./current/site/.env
   cp $ENV_FILE ./current/.env


### PR DESCRIPTION
## Summary
- ensure the deploy script creates the var/log/cron directory so cron tasks can append to app.log without errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3f37877cc8323b232b5604286dfd2