### PR TITLE
Make cashflow category names link to edit form

### DIFF
--- a/site/templates/cashflow_category/index.html.twig
+++ b/site/templates/cashflow_category/index.html.twig
@@ -6,9 +6,8 @@
     {% for item in items %}
         <li>
             <div class="d-flex align-items-center">
-                <span style="margin-left: {{ (level - 1) * 20 }}px;">{{ item.name }}</span>
+                <a href="{{ path('cashflow_category_edit', {'id': item.id}) }}" class="text-reset text-decoration-none" style="margin-left: {{ (level - 1) * 20 }}px;">{{ item.name }}</a>
                 <span class="ms-auto d-inline-flex gap-1">
-                    <a href="{{ path('cashflow_category_edit', {'id': item.id}) }}" class="btn btn-sm btn-warning">✏️</a>
                     <form method="post" action="{{ path('cashflow_category_delete', {'id': item.id}) }}" class="d-inline" onsubmit="return confirm('Вы уверены?');">
                         <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ item.id) }}">
                         <button class="btn btn-sm btn-danger">🗑</button>


### PR DESCRIPTION
## Summary
- remove the dedicated edit button from the cashflow categories list
- link each cashflow category name directly to its edit form while retaining the delete action

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4d688c8d4832390c1486605ec11f3