### PR TITLE
Add Monolog channels for Ozon services

### DIFF
--- a/site/config/packages/monolog.yaml
+++ b/site/config/packages/monolog.yaml
@@ -3,6 +3,8 @@ monolog:
         - deprecation # Deprecations are logged in the dedicated "deprecation" channel when it exists
         - import.bank1c
         - recalc
+        - ozon.sync
+        - ozon.http
 
 when@dev:
     monolog:

--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -33,3 +33,13 @@ services:
     App\Service\RateLimiter\ReportsApiRateLimiter:
         arguments:
             $factory: '@?limiter.reports_api'
+
+    # Логгер для HTTP-клиента Ozon
+    App\Api\Ozon\OzonApiClient:
+        arguments:
+            $logger: '@monolog.logger.ozon.http'
+
+    # Логгер для синка заказов
+    App\Service\Ozon\OzonOrderSyncService:
+        arguments:
+            $logger: '@monolog.logger.ozon.sync'


### PR DESCRIPTION
## Summary
- add dedicated Monolog channels for Ozon sync and HTTP logs
- wire Monolog channel-specific loggers into the Ozon API client and order sync service

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e628e5a50c8323a2cc9fcb4cc4843e