### PR TITLE
Add Ozon orders enqueue command

### DIFF
--- a/site/src/Command/OzonOrdersEnqueueCommand.php
+++ b/site/src/Command/OzonOrdersEnqueueCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Command;
+
+use App\Message\Ozon\SyncOzonOrders;
+use App\Repository\CompanyRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[AsCommand(name: 'ozon:orders:enqueue')]
+final class OzonOrdersEnqueueCommand extends Command
+{
+    public function __construct(
+        private CompanyRepository $companies,
+        private MessageBusInterface $bus,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $list = $this->companies->findAllWithOzonCredentials();
+        $count = 0;
+
+        foreach ($list as $company) {
+            $id = $company->getId();
+            // Две схемы: FBS и FBO. Окно и статус рассчитает/подтянет Handler.
+            $this->bus->dispatch(new SyncOzonOrders((string) $id, 'FBS'));
+            $this->bus->dispatch(new SyncOzonOrders((string) $id, 'FBO'));
+            $count += 2;
+        }
+
+        $output->writeln(sprintf('Enqueued %d tasks for %d companies', $count, count($list)));
+
+        return Command::SUCCESS;
+    }
+}

--- a/site/src/Repository/CompanyRepository.php
+++ b/site/src/Repository/CompanyRepository.php
@@ -28,4 +28,14 @@ class CompanyRepository extends ServiceEntityRepository
     {
         return $this->findOneBy(['name' => $name]);
     }
+
+    public function findAllWithOzonCredentials(): array
+    {
+        return $this->createQueryBuilder('c')
+            ->andWhere("c.ozonSellerId IS NOT NULL AND c.ozonSellerId <> ''")
+            ->andWhere("c.ozonApiKey   IS NOT NULL AND c.ozonApiKey   <> ''")
+            ->orderBy('c.name', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
 }


### PR DESCRIPTION
## Summary
- add repository helper to fetch companies with Ozon credentials
- add console command to enqueue FBS/FBO Ozon order sync jobs for each company

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e644dc78288323b5c21e244c52078f