### PR TITLE
Configure Redis-backed lock factory

### DIFF
--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -24,6 +24,14 @@ services:
         arguments:
             - '%env(REDIS_DSN)%'
 
+    Symfony\Component\Lock\Store\RedisStore:
+        arguments:
+            - '@session.redis'
+
+    Symfony\Component\Lock\LockFactory:
+        arguments:
+            - '@Symfony\Component\Lock\Store\RedisStore'
+
     # Обработчик сессий Redis
     Symfony\Component\HttpFoundation\Session\Storage\Handler\RedisSessionHandler:
         arguments:


### PR DESCRIPTION
## Summary
- configure the Symfony Lock component to use Redis for locking
- wire the LockFactory service to reuse the existing Redis session client

## Testing
- composer test *(fails: phpunit binary missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e689a7fff08323b3af31b0506270f6