### PR TITLE
Add composite index for Ozon order incremental sync

### DIFF
--- a/site/migrations/Version20240604000000.php
+++ b/site/migrations/Version20240604000000.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240604000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add composite index for ozon orders incremental sync';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE INDEX idx_company_scheme_ozon_updated_at ON ozon_orders (company_id, scheme, ozon_updated_at)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_company_scheme_ozon_updated_at');
+    }
+}

--- a/site/src/Entity/Ozon/OzonOrder.php
+++ b/site/src/Entity/Ozon/OzonOrder.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Index(name: 'idx_scheme', columns: ['scheme'])]
 #[ORM\Index(name: 'idx_status', columns: ['status'])]
 #[ORM\Index(name: 'idx_ozon_updated_at', columns: ['ozon_updated_at'])]
+#[ORM\Index(name: 'idx_company_scheme_ozon_updated_at', columns: ['company_id', 'scheme', 'ozon_updated_at'])]
 class OzonOrder
 {
     #[ORM\Id]


### PR DESCRIPTION
## Summary
- add Doctrine mapping for a composite index covering company, scheme, and updated timestamp on Ozon orders
- create a migration that adds the supporting database index for incremental sync queries

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e68c2c86f48323b9241788aeb2e4d2