### PR TITLE
Add payment calendar controller and UI

### DIFF
--- a/site/src/DTO/PaymentPlanDTO.php
+++ b/site/src/DTO/PaymentPlanDTO.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace App\DTO;
+
+use App\Entity\CashflowCategory;
+use App\Entity\Counterparty;
+use App\Entity\MoneyAccount;
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class PaymentPlanDTO
+{
+    #[Assert\NotNull]
+    public \DateTimeInterface $plannedAt;
+
+    #[Assert\NotEqualTo(0)]
+    public string $amount;
+
+    #[Assert\NotNull]
+    public ?CashflowCategory $cashflowCategory = null;
+
+    public ?MoneyAccount $moneyAccount = null;
+
+    public ?Counterparty $counterparty = null;
+
+    public ?string $comment = null;
+
+    public ?string $status = null;
+
+    public function __construct()
+    {
+        $this->plannedAt = new \DateTimeImmutable();
+        $this->amount = '0';
+    }
+}

--- a/site/src/Finance/Controller/PaymentCalendarController.php
+++ b/site/src/Finance/Controller/PaymentCalendarController.php
@@ -1,0 +1,329 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Finance\Controller;
+
+use App\DTO\PaymentPlanDTO;
+use App\Entity\CashflowCategory;
+use App\Entity\Company;
+use App\Entity\Counterparty;
+use App\Entity\MoneyAccount;
+use App\Entity\PaymentPlan;
+use App\Enum\PaymentPlanStatus as PaymentPlanStatusEnum;
+use App\Enum\PaymentPlanType as PaymentPlanTypeEnum;
+use App\Form\PaymentPlanType;
+use App\Repository\PaymentPlanRepository;
+use App\Service\CompanyContextService;
+use App\Service\PaymentPlan\PaymentPlanService;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+
+#[Route('/finance/payment-calendar')]
+final class PaymentCalendarController extends AbstractController
+{
+    public function __construct(
+        private CompanyContextService $companyContextService,
+        private PaymentPlanRepository $paymentPlanRepository,
+        private EntityManagerInterface $entityManager,
+        private PaymentPlanService $paymentPlanService,
+    ) {
+    }
+
+    #[Route('', name: 'payment_calendar_index', methods: ['GET'])]
+    public function index(Request $request): Response
+    {
+        $company = $this->companyContextService->getActiveCompanyOrThrow();
+
+        return $this->renderCalendar($request, $company, []);
+    }
+
+    #[Route('/new', name: 'payment_calendar_new', methods: ['GET', 'POST'])]
+    public function new(Request $request): Response
+    {
+        $company = $this->companyContextService->getActiveCompanyOrThrow();
+        $filters = $this->extractFilters($request);
+
+        $dto = new PaymentPlanDTO();
+        $form = $this->createForm(PaymentPlanType::class, $dto, [
+            'company' => $company,
+            'action' => $this->generateUrl('payment_calendar_new', $this->buildFilterQuery($filters)),
+        ]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid() && null !== $dto->cashflowCategory) {
+            $plan = new PaymentPlan(
+                Uuid::v4()->toRfc4122(),
+                $company,
+                $dto->cashflowCategory,
+                \DateTimeImmutable::createFromInterface($dto->plannedAt),
+                (string) $dto->amount
+            );
+
+            $this->paymentPlanService->applyCompanyScope($plan, $company);
+            $plan->setCashflowCategory($dto->cashflowCategory);
+            $plan->setPlannedAt(\DateTimeImmutable::createFromInterface($dto->plannedAt));
+            $plan->setAmount((float) $dto->amount);
+            $plan->setMoneyAccount($dto->moneyAccount);
+            $plan->setCounterparty($dto->counterparty);
+            $plan->setComment($dto->comment);
+
+            $resolvedType = $this->paymentPlanService->resolveTypeByCategory($dto->cashflowCategory);
+            $plan->setType(PaymentPlanTypeEnum::from($resolvedType));
+            $plan->setStatus($this->resolveStatus($dto->status));
+
+            $this->entityManager->persist($plan);
+            $this->entityManager->flush();
+
+            $this->addFlash('success', 'Создано');
+
+            return $this->redirectToRoute('payment_calendar_index', $this->buildFilterQuery($filters));
+        }
+
+        return $this->renderCalendar($request, $company, [
+            'form' => $form->createView(),
+            'showForm' => true,
+            'formTitle' => 'Новая запись',
+        ], $filters);
+    }
+
+    #[Route('/{id}/edit', name: 'payment_calendar_edit', methods: ['GET', 'POST'])]
+    public function edit(Request $request, PaymentPlan $plan): Response
+    {
+        $company = $this->companyContextService->getActiveCompanyOrThrow();
+
+        if ($plan->getCompany()->getId() !== $company->getId()) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $filters = $this->extractFilters($request);
+
+        $dto = new PaymentPlanDTO();
+        $dto->plannedAt = $plan->getPlannedAt();
+        $dto->amount = $plan->getAmount();
+        $dto->cashflowCategory = $plan->getCashflowCategory();
+        $dto->moneyAccount = $plan->getMoneyAccount();
+        $dto->counterparty = $plan->getCounterparty();
+        $dto->comment = $plan->getComment();
+        $dto->status = $plan->getStatus()->value;
+
+        $form = $this->createForm(PaymentPlanType::class, $dto, [
+            'company' => $company,
+            'action' => $this->generateUrl('payment_calendar_edit', array_merge(
+                ['id' => (string) $plan->getId()],
+                $this->buildFilterQuery($filters)
+            )),
+        ]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid() && null !== $dto->cashflowCategory) {
+            $this->paymentPlanService->applyCompanyScope($plan, $company);
+            $plan->setCashflowCategory($dto->cashflowCategory);
+            $plan->setPlannedAt(\DateTimeImmutable::createFromInterface($dto->plannedAt));
+            $plan->setAmount((float) $dto->amount);
+            $plan->setMoneyAccount($dto->moneyAccount);
+            $plan->setCounterparty($dto->counterparty);
+            $plan->setComment($dto->comment);
+
+            $resolvedType = $this->paymentPlanService->resolveTypeByCategory($dto->cashflowCategory);
+            $plan->setType(PaymentPlanTypeEnum::from($resolvedType));
+            $plan->setStatus($this->resolveStatus($dto->status));
+
+            $this->entityManager->flush();
+
+            $this->addFlash('success', 'Сохранено');
+
+            return $this->redirectToRoute('payment_calendar_index', $this->buildFilterQuery($filters));
+        }
+
+        return $this->renderCalendar($request, $company, [
+            'form' => $form->createView(),
+            'showForm' => true,
+            'formTitle' => 'Редактирование',
+        ], $filters);
+    }
+
+    /**
+     * @param array{
+     *     from: string,
+     *     to: string,
+     *     account_id: string,
+     *     category_id: string,
+     *     status: string,
+     *     counterparty_id: string
+     * } $filters
+     */
+    private function renderCalendar(Request $request, Company $company, array $extra, ?array $filters = null): Response
+    {
+        $filters ??= $this->extractFilters($request);
+
+        $plans = [];
+        $period = null;
+        $from = $this->parseDate($filters['from'] ?? null);
+        $to = $this->parseDate($filters['to'] ?? null);
+
+        if (null === $from || null === $to) {
+            $this->addFlash('danger', 'Пожалуйста, укажите период (from/to).');
+        } elseif ($from > $to) {
+            $this->addFlash('danger', 'Дата начала периода не может быть позже даты окончания.');
+        } else {
+            $plans = $this->loadPlans($company, $from, $to, $filters);
+            $period = ['from' => $from, 'to' => $to];
+        }
+
+        $filterQuery = $this->buildFilterQuery($filters);
+
+        $context = [
+            'plans' => $plans,
+            'filters' => $filters,
+            'filterQuery' => $filterQuery,
+            'period' => $period,
+            'accounts' => $this->entityManager->getRepository(MoneyAccount::class)->findBy(['company' => $company], ['name' => 'ASC']),
+            'categories' => $this->entityManager->getRepository(CashflowCategory::class)->findBy(['company' => $company], ['name' => 'ASC']),
+            'counterparties' => $this->entityManager->getRepository(Counterparty::class)->findBy(['company' => $company], ['name' => 'ASC']),
+            'statuses' => $this->statusChoices(),
+        ];
+
+        return $this->render('payment_calendar/index.html.twig', array_merge($context, $extra));
+    }
+
+    /**
+     * @return array{
+     *     from: string,
+     *     to: string,
+     *     account_id: string,
+     *     category_id: string,
+     *     status: string,
+     *     counterparty_id: string
+     * }
+     */
+    private function extractFilters(Request $request): array
+    {
+        return [
+            'from' => (string) $request->query->get('from', ''),
+            'to' => (string) $request->query->get('to', ''),
+            'account_id' => (string) $request->query->get('account_id', ''),
+            'category_id' => (string) $request->query->get('category_id', ''),
+            'status' => (string) $request->query->get('status', ''),
+            'counterparty_id' => (string) $request->query->get('counterparty_id', ''),
+        ];
+    }
+
+    private function parseDate(?string $value): ?\DateTimeImmutable
+    {
+        if (null === $value || '' === trim($value)) {
+            return null;
+        }
+
+        $date = \DateTimeImmutable::createFromFormat('Y-m-d', $value);
+        if (false === $date || $date->format('Y-m-d') !== $value) {
+            return null;
+        }
+
+        return $date;
+    }
+
+    /**
+     * @param array{
+     *     from: string,
+     *     to: string,
+     *     account_id: string,
+     *     category_id: string,
+     *     status: string,
+     *     counterparty_id: string
+     * } $filters
+     *
+     * @return array<string, string>
+     */
+    private function buildFilterQuery(array $filters): array
+    {
+        $result = [];
+
+        foreach ($filters as $key => $value) {
+            if (null !== $value && '' !== $value) {
+                $result[$key] = $value;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array{
+     *     from: string,
+     *     to: string,
+     *     account_id: string,
+     *     category_id: string,
+     *     status: string,
+     *     counterparty_id: string
+     * } $filters
+     *
+     * @return list<PaymentPlan>
+     */
+    private function loadPlans(Company $company, \DateTimeImmutable $from, \DateTimeImmutable $to, array $filters): array
+    {
+        $qb = $this->paymentPlanRepository->createQueryBuilder('plan')
+            ->andWhere('plan.company = :company')
+            ->andWhere('plan.plannedAt BETWEEN :from AND :to')
+            ->setParameter('company', $company)
+            ->setParameter('from', $from, Types::DATE_IMMUTABLE)
+            ->setParameter('to', $to, Types::DATE_IMMUTABLE)
+            ->orderBy('plan.plannedAt', 'ASC')
+            ->addOrderBy('plan.createdAt', 'ASC');
+
+        if (!empty($filters['account_id'])) {
+            $qb->andWhere('plan.moneyAccount = :accountId')
+                ->setParameter('accountId', $filters['account_id']);
+        }
+
+        if (!empty($filters['category_id'])) {
+            $qb->andWhere('plan.cashflowCategory = :categoryId')
+                ->setParameter('categoryId', $filters['category_id']);
+        }
+
+        if (!empty($filters['counterparty_id'])) {
+            $qb->andWhere('plan.counterparty = :counterpartyId')
+                ->setParameter('counterpartyId', $filters['counterparty_id']);
+        }
+
+        if (!empty($filters['status'])) {
+            $status = PaymentPlanStatusEnum::tryFrom((string) $filters['status']);
+            if ($status) {
+                $qb->andWhere('plan.status = :status')
+                    ->setParameter('status', $status);
+            }
+        }
+
+        /** @var list<PaymentPlan> $result */
+        $result = $qb->getQuery()->getResult();
+
+        return $result;
+    }
+
+    private function resolveStatus(?string $status): PaymentPlanStatusEnum
+    {
+        if (null === $status || '' === $status) {
+            return PaymentPlanStatusEnum::PLANNED;
+        }
+
+        return PaymentPlanStatusEnum::from($status);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function statusChoices(): array
+    {
+        $choices = [];
+
+        foreach (PaymentPlanStatusEnum::cases() as $status) {
+            $choices[$status->value] = $status->value;
+        }
+
+        return $choices;
+    }
+}

--- a/site/src/Form/PaymentPlanType.php
+++ b/site/src/Form/PaymentPlanType.php
@@ -1,0 +1,126 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Form;
+
+use App\DTO\PaymentPlanDTO;
+use App\Entity\CashflowCategory;
+use App\Entity\Company;
+use App\Entity\Counterparty;
+use App\Entity\MoneyAccount;
+use App\Enum\PaymentPlanStatus;
+use Doctrine\ORM\EntityRepository;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class PaymentPlanType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        /** @var Company|null $company */
+        $company = $options['company'];
+
+        $builder
+            ->add('plannedAt', DateType::class, [
+                'widget' => 'single_text',
+                'label' => 'Дата',
+            ])
+            ->add('amount', NumberType::class, [
+                'label' => 'Сумма',
+                'scale' => 2,
+                'input' => 'string',
+            ])
+            ->add('cashflowCategory', EntityType::class, [
+                'class' => CashflowCategory::class,
+                'label' => 'Категория',
+                'placeholder' => 'Выберите категорию',
+                'choice_label' => static fn (CashflowCategory $category): string => (string) $category->getName(),
+                'query_builder' => static function (EntityRepository $repository) use ($company) {
+                    $qb = $repository->createQueryBuilder('category')
+                        ->orderBy('category.name', 'ASC');
+
+                    if ($company) {
+                        $qb->andWhere('category.company = :company')
+                            ->setParameter('company', $company);
+                    }
+
+                    return $qb;
+                },
+            ])
+            ->add('moneyAccount', EntityType::class, [
+                'class' => MoneyAccount::class,
+                'label' => 'Счёт',
+                'required' => false,
+                'placeholder' => 'Любой счёт',
+                'choice_label' => static fn (MoneyAccount $account): string => (string) $account->getName(),
+                'query_builder' => static function (EntityRepository $repository) use ($company) {
+                    $qb = $repository->createQueryBuilder('account')
+                        ->orderBy('account.name', 'ASC');
+
+                    if ($company) {
+                        $qb->andWhere('account.company = :company')
+                            ->setParameter('company', $company);
+                    }
+
+                    return $qb;
+                },
+            ])
+            ->add('counterparty', EntityType::class, [
+                'class' => Counterparty::class,
+                'label' => 'Контрагент',
+                'required' => false,
+                'placeholder' => 'Без контрагента',
+                'choice_label' => static fn (Counterparty $counterparty): string => (string) $counterparty->getName(),
+                'query_builder' => static function (EntityRepository $repository) use ($company) {
+                    $qb = $repository->createQueryBuilder('counterparty')
+                        ->orderBy('counterparty.name', 'ASC');
+
+                    if ($company) {
+                        $qb->andWhere('counterparty.company = :company')
+                            ->setParameter('company', $company);
+                    }
+
+                    return $qb;
+                },
+            ])
+            ->add('status', ChoiceType::class, [
+                'label' => 'Статус',
+                'required' => false,
+                'placeholder' => 'По умолчанию (PLANNED)',
+                'choices' => $this->buildStatusChoices(),
+            ])
+            ->add('comment', TextareaType::class, [
+                'label' => 'Комментарий',
+                'required' => false,
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => PaymentPlanDTO::class,
+            'company' => null,
+        ]);
+        $resolver->setAllowedTypes('company', [Company::class, 'null']);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function buildStatusChoices(): array
+    {
+        $choices = [];
+
+        foreach (PaymentPlanStatus::cases() as $status) {
+            $choices[$status->value] = $status->value;
+        }
+
+        return $choices;
+    }
+}

--- a/site/src/Service/CompanyContextService.php
+++ b/site/src/Service/CompanyContextService.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\Company;
+
+final class CompanyContextService
+{
+    public function __construct(private ActiveCompanyService $activeCompanyService)
+    {
+    }
+
+    public function getActiveCompanyOrThrow(): Company
+    {
+        return $this->activeCompanyService->getActiveCompany();
+    }
+}

--- a/site/templates/payment_calendar/_form.html.twig
+++ b/site/templates/payment_calendar/_form.html.twig
@@ -1,0 +1,30 @@
+{{ form_start(form) }}
+<div class="row g-3">
+    <div class="col-sm-6 col-lg-4">
+        {{ form_row(form.plannedAt) }}
+    </div>
+    <div class="col-sm-6 col-lg-4">
+        {{ form_row(form.amount) }}
+    </div>
+    <div class="col-12 col-lg-6">
+        {{ form_row(form.cashflowCategory) }}
+        <div class="form-text">Тип операции определяется категорией</div>
+    </div>
+    <div class="col-sm-6 col-lg-4">
+        {{ form_row(form.moneyAccount) }}
+    </div>
+    <div class="col-sm-6 col-lg-4">
+        {{ form_row(form.counterparty) }}
+    </div>
+    <div class="col-sm-6 col-lg-4">
+        {{ form_row(form.status) }}
+    </div>
+    <div class="col-12">
+        {{ form_row(form.comment) }}
+    </div>
+</div>
+<div class="mt-4">
+    <button type="submit" class="btn btn-primary">Сохранить</button>
+    <a href="{{ path('payment_calendar_index', filterQuery ?? {}) }}" class="btn btn-outline-secondary">Отмена</a>
+</div>
+{{ form_end(form) }}

--- a/site/templates/payment_calendar/index.html.twig
+++ b/site/templates/payment_calendar/index.html.twig
@@ -1,0 +1,120 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Платёжный календарь{% endblock %}
+
+{% block body %}
+<div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-4">
+    <div>
+        <h1 class="mb-1">Платёжный календарь</h1>
+        {% if period %}
+            <div class="text-muted">Период: {{ period.from|date('Y-m-d') }} — {{ period.to|date('Y-m-d') }}</div>
+        {% endif %}
+    </div>
+    <div class="mt-3 mt-md-0">
+        <a class="btn btn-primary" href="{{ path('payment_calendar_new', filterQuery) }}">Добавить</a>
+    </div>
+</div>
+
+<form method="get" class="card card-body mb-4">
+    <div class="row g-3">
+        <div class="col-sm-6 col-lg-3">
+            <label for="filter-from" class="form-label">С</label>
+            <input type="date" id="filter-from" name="from" class="form-control" value="{{ filters.from }}" required>
+        </div>
+        <div class="col-sm-6 col-lg-3">
+            <label for="filter-to" class="form-label">По</label>
+            <input type="date" id="filter-to" name="to" class="form-control" value="{{ filters.to }}" required>
+        </div>
+        <div class="col-sm-6 col-lg-3">
+            <label for="filter-account" class="form-label">Счёт</label>
+            <select id="filter-account" name="account_id" class="form-select">
+                <option value="">Все</option>
+                {% for account in accounts %}
+                    <option value="{{ account.id }}" {% if filters.account_id == account.id %}selected{% endif %}>{{ account.name }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="col-sm-6 col-lg-3">
+            <label for="filter-category" class="form-label">Категория</label>
+            <select id="filter-category" name="category_id" class="form-select">
+                <option value="">Все</option>
+                {% for category in categories %}
+                    <option value="{{ category.id }}" {% if filters.category_id == category.id %}selected{% endif %}>{{ category.name }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="col-sm-6 col-lg-3">
+            <label for="filter-status" class="form-label">Статус</label>
+            <select id="filter-status" name="status" class="form-select">
+                <option value="">Все</option>
+                {% for value, label in statuses %}
+                    <option value="{{ value }}" {% if filters.status == value %}selected{% endif %}>{{ label }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="col-sm-6 col-lg-3">
+            <label for="filter-counterparty" class="form-label">Контрагент</label>
+            <select id="filter-counterparty" name="counterparty_id" class="form-select">
+                <option value="">Все</option>
+                {% for counterparty in counterparties %}
+                    <option value="{{ counterparty.id }}" {% if filters.counterparty_id == counterparty.id %}selected{% endif %}>{{ counterparty.name }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="col-12 d-flex gap-2">
+            <button type="submit" class="btn btn-primary">Применить</button>
+            <a href="{{ path('payment_calendar_index', {'from': filters.from, 'to': filters.to}) }}" class="btn btn-outline-secondary">Сбросить дополнительные фильтры</a>
+        </div>
+    </div>
+</form>
+
+<div class="card">
+    <div class="table-responsive">
+        <table class="table card-table table-vcenter">
+            <thead>
+                <tr>
+                    <th>Дата</th>
+                    <th>Категория</th>
+                    <th>Контрагент</th>
+                    <th class="text-end">Сумма</th>
+                    <th>Счёт</th>
+                    <th>Статус</th>
+                    <th>Комментарий</th>
+                    <th class="w-1">Действия</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for plan in plans %}
+                    <tr>
+                        <td>{{ plan.plannedAt|date('Y-m-d') }}</td>
+                        <td>{{ plan.cashflowCategory.name }}</td>
+                        <td>{{ plan.counterparty ? plan.counterparty.name : '—' }}</td>
+                        <td class="text-end">{{ plan.amount|number_format(2, '.', ' ') }}</td>
+                        <td>{{ plan.moneyAccount ? plan.moneyAccount.name : '—' }}</td>
+                        <td>{{ plan.status.value }}</td>
+                        <td>{{ plan.comment ?? '' }}</td>
+                        <td>
+                            <a class="btn btn-link p-0" href="{{ path('payment_calendar_edit', filterQuery|merge({'id': plan.id})) }}">Редактировать</a>
+                        </td>
+                    </tr>
+                {% else %}
+                    <tr>
+                        <td colspan="8" class="text-center text-muted">Записей не найдено</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+
+{% if showForm is defined and showForm and form is defined %}
+    <div class="card mt-4">
+        <div class="card-header">
+            <h2 class="card-title mb-0">{{ formTitle ?? 'Запись' }}</h2>
+        </div>
+        <div class="card-body">
+            {% include 'payment_calendar/_form.html.twig' with {form: form, filterQuery: filterQuery} %}
+        </div>
+    </div>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a payment calendar controller that lists plans in the active company scope with filtering, creation, and editing flows
- introduce a dedicated DTO and Symfony form type for validating and binding payment plan data
- render payment calendar and form templates and provide a company context service wrapper

## Testing
- php -l site/src/Finance/Controller/PaymentCalendarController.php
- php -l site/src/Form/PaymentPlanType.php
- php -l site/src/DTO/PaymentPlanDTO.php
- php -l site/src/Service/CompanyContextService.php
- php bin/console lint:twig templates/payment_calendar *(fails: missing Composer dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68efa6e567c083238eddf9bdb00b89b9