### PR TITLE
Fix manual dismissal for payment calendar modal

### DIFF
--- a/site/templates/payment_calendar/index.html.twig
+++ b/site/templates/payment_calendar/index.html.twig
@@ -357,6 +357,20 @@
                     modalElement.setAttribute('aria-modal', 'true');
                     modalElement.scrollTop = 0;
 
+                    var dismissButtons = modalElement.querySelectorAll('[data-bs-dismiss="modal"]');
+                    var hideModal = function () {
+                        modalElement.classList.remove('show');
+                        modalElement.style.display = 'none';
+                        modalElement.setAttribute('aria-hidden', 'true');
+                        modalElement.removeAttribute('aria-modal');
+                    };
+
+                    dismissButtons.forEach(function (button) {
+                        button.addEventListener('click', function () {
+                            hideModal();
+                        });
+                    });
+
                     return;
                 }
 


### PR DESCRIPTION
## Summary
- add a JavaScript fallback to close the payment calendar modal when Bootstrap is unavailable
- ensure the cancel and close buttons hide the modal in the editing form

## Testing
- php bin/console lint:twig templates/payment_calendar/index.html.twig *(fails: missing Composer dependencies in the container)*

------
https://chatgpt.com/codex/tasks/task_e_6909c1980e58832397a09aa4bb3f3ae6