### PR TITLE
Add document creation action for loan schedule items

### DIFF
--- a/site/src/Loan/Controller/LoanController.php
+++ b/site/src/Loan/Controller/LoanController.php
@@ -11,6 +11,7 @@ use App\Loan\Form\LoanPaymentScheduleType;
 use App\Loan\Form\LoanScheduleUploadType;
 use App\Loan\Repository\LoanPaymentScheduleRepository;
 use App\Loan\Repository\LoanRepository;
+use App\Loan\Service\LoanScheduleToDocumentService;
 use App\Service\ActiveCompanyService;
 use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
@@ -313,5 +314,44 @@ class LoanController extends AbstractController
         });
 
         return $response;
+    }
+
+    #[Route(
+        '/{loanId}/schedule/{itemId}/create-document',
+        name: 'loan_schedule_create_document',
+        methods: ['POST']
+    )]
+    public function createDocumentFromSchedule(
+        string $loanId,
+        string $itemId,
+        Request $request,
+        LoanRepository $loanRepository,
+        LoanPaymentScheduleRepository $paymentScheduleRepository,
+        LoanScheduleToDocumentService $scheduleToDocumentService,
+        ActiveCompanyService $activeCompanyService,
+        EntityManagerInterface $entityManager
+    ): Response {
+        $company = $activeCompanyService->getActiveCompany();
+        $loan = $loanRepository->find($loanId);
+
+        if (null === $loan || $loan->getCompany() !== $company) {
+            throw $this->createNotFoundException();
+        }
+
+        $schedule = $paymentScheduleRepository->find($itemId);
+        if (null === $schedule || $schedule->getLoan() !== $loan) {
+            throw $this->createNotFoundException();
+        }
+
+        if (!$this->isCsrfTokenValid('loan_schedule_create_document_'.$itemId, (string) $request->request->get('_token'))) {
+            return $this->redirectToRoute('loan_schedule', ['id' => $loan->getId()]);
+        }
+
+        $document = $scheduleToDocumentService->createDocumentFromSchedule($loan, $schedule);
+
+        $entityManager->persist($document);
+        $entityManager->flush();
+
+        return $this->redirectToRoute('document_edit', ['id' => $document->getId()]);
     }
 }

--- a/site/templates/loan/schedule.html.twig
+++ b/site/templates/loan/schedule.html.twig
@@ -55,6 +55,14 @@
                                     <td class="text-end">
                                         <div class="btn-list">
                                             <a href="{{ path('loan_schedule_edit', {loanId: loan.id, itemId: item.id}) }}" class="btn btn-sm btn-outline-primary">✏️</a>
+                                            <form method="post"
+                                                  action="{{ path('loan_schedule_create_document', {loanId: loan.id, itemId: item.id}) }}"
+                                                  class="d-inline">
+                                                <input type="hidden" name="_token" value="{{ csrf_token('loan_schedule_create_document_' ~ item.id) }}">
+                                                <button class="btn btn-sm btn-outline-success" type="submit" title="Создать документ ОПиУ по этому платежу">
+                                                    <i class="ti ti-file-plus"></i>
+                                                </button>
+                                            </form>
                                             <form method="post" action="{{ path('loan_schedule_delete', {loanId: loan.id, itemId: item.id}) }}" class="d-inline" onsubmit="return confirm('Удалить платеж?');">
                                                 <input type="hidden" name="_token" value="{{ csrf_token('loan_schedule_delete_' ~ item.id) }}">
                                                 <button class="btn btn-sm btn-outline-danger" type="submit">🗑️</button>


### PR DESCRIPTION
## Summary
- add controller action to create a document from a loan schedule payment using LoanScheduleToDocumentService
- persist created document and redirect to edit page
- add a button in the payment schedule view to trigger document creation with CSRF protection

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c67c8ac508323aebb362cb030e328)