### PR TITLE
Add Doctrine migration rules, PR template, and CI job to run migrations on empty DB

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Что сделано
+- …
+
+## Чеклист (обязательный)
+- [ ] Изменения не ломают текущий функционал
+- [ ] Если есть изменения схемы/миграции — выполнен чеклист миграций ниже
+
+### Чеклист миграций
+- [ ] `bin/console doctrine:migrations:migrate --no-interaction` проходит на чистой БД
+- [ ] Нет `ALTER TABLE` без guard `hasTable`
+- [ ] Все `ADD CONSTRAINT` выполнены условно (IF NOT EXISTS / pg_constraint)
+- [ ] Имена constraints/индексов заданы явно (`fk_`, `uniq_`, `idx_`)
+- [ ] Нет `doctrine:schema:update --force` и ручных SQL правок схемы

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  migrations-empty-db:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: app
+          POSTGRES_USER: app
+          POSTGRES_PASSWORD: app
+        ports:
+          - "5432:5432"
+        options: >-
+          --health-cmd="pg_isready -U app -d app"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer
+      - name: Composer install
+        working-directory: site
+        run: composer install --no-interaction --prefer-dist --no-progress --no-dev
+      - name: Run migrations on empty DB
+        working-directory: site
+        env:
+          DATABASE_URL: "pgsql://app:app@127.0.0.1:5432/app?serverVersion=16&charset=utf8"
+          APP_ENV: test
+        run: php bin/console doctrine:migrations:migrate --no-interaction

--- a/docs/rules/migrations.md
+++ b/docs/rules/migrations.md
@@ -1,0 +1,50 @@
+# Правила миграций Doctrine
+
+## 1) Любая миграция обязана проходить на чистой базе
+**Definition of Done для PR со схемой:**
+- поднять пустой Postgres
+- выполнить: `bin/console doctrine:migrations:migrate --no-interaction`
+- миграции проходят без ошибок
+
+## 2) Запрещены ALTER/ADD CONSTRAINT без guard-проверок
+### 2.1 ALTER TABLE
+Перед любыми SQL по таблице:
+- `if (!$schema->hasTable('table_name')) { return; }`
+
+### 2.2 Добавление колонок/индексов
+- Добавлять только после проверки существования (Schema API или системные таблицы)
+
+### 2.3 FK/UNIQUE/CONSTRAINT
+Нельзя делать “в лоб”:
+- `ALTER TABLE ... ADD CONSTRAINT ...`
+
+Нужно делать условно через PostgreSQL:
+- `DO $$ BEGIN IF NOT EXISTS(...) THEN ALTER TABLE ... ADD CONSTRAINT ...; END IF; END $$;`
+
+## 3) Имена constraints/индексов задаём явно
+Формат:
+- `fk_<table>_<ref>`
+- `uniq_<table>_<cols>`
+- `idx_<table>_<cols>`
+
+## 4) Запрет на schema:update и ручной SQL в проде
+Запрещено:
+- `doctrine:schema:update --force`
+- ручные изменения схемы в проде
+Любые изменения схемы — только миграцией.
+
+## 5) Ветки и мердж миграций
+Перед мерджем PR:
+- rebase на актуальный main
+- повторный прогон миграций на чистой базе
+
+## 6) 1 PR = 1 смысловая миграция
+Одна бизнес-правка схемы → один файл миграции (по возможности).
+
+## 7) Чеклист для ревью миграции
+- [ ] `migrate` проходит на чистой БД
+- [ ] нет `ALTER TABLE ...` без `hasTable` guard
+- [ ] все `ADD CONSTRAINT` обёрнуты в `IF NOT EXISTS` (pg_constraint)
+- [ ] у constraints/индексов явные имена по стандарту
+- [ ] нет ручных SQL “на всякий случай”
+- [ ] PR сделан после rebase на main


### PR DESCRIPTION
### Motivation
- Prevent recurring migration failures like `already exists` / `table does not exist` by enforcing rules and checks for Doctrine migrations.
- Make migration review deterministic by adding a concise checklist that requires running migrations on a clean database. 
- Automate the verification step in CI so migrations are validated on `pull_request` and `push` to `main`/`master`.

### Description
- Added `docs/rules/migrations.md` with the required Doctrine migration rules and the exact review checklist text. 
- Added ` .github/pull_request_template.md` containing a short PR template and the migration checklist (including `bin/console doctrine:migrations:migrate --no-interaction`).
- Added ` .github/workflows/ci.yml` defining a `migrations-empty-db` job that uses `services: postgres` (image `postgres:16`), sets `POSTGRES_*` env, runs `shivammathur/setup-php@v2` with `php-version: '8.2'`, runs `composer install` in `site/`, exports `DATABASE_URL` and runs `php bin/console doctrine:migrations:migrate --no-interaction` in `site/`.
- All changes are limited to `docs/` and `.github/` as required and do not modify application/business code, `composer.json`, existing migrations, or add other services.

### Testing
- No automated tests were executed locally for these documentation and CI configuration changes. 
- The new GitHub Actions workflow is configured to run on `pull_request` and `push` to `main`/`master` and will exercise migrations against a fresh Postgres service in CI. 
- Repository changes were added and committed (three files created) and the workflow YAML and files were saved to the repo for CI validation on the platform.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b7f2eb4b48323bdb30dfe9d23d13a)