### PR TITLE
Add migrations-empty-db CI job to workflows/deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ name: 🚀 Deploy to Production
 on:
     push:
         branches: [ master ]
+    pull_request:
 
 jobs:
     deploy:
@@ -85,3 +86,42 @@ jobs:
                     echo "✅ Миграции применены"
                   EOF
 
+    migrations-empty-db:
+        runs-on: ubuntu-latest
+
+        services:
+            postgres:
+                image: postgres:16
+                env:
+                    POSTGRES_DB: app
+                    POSTGRES_USER: app
+                    POSTGRES_PASSWORD: app
+                ports:
+                    - 5432:5432
+                options: >-
+                    --health-cmd="pg_isready -U app -d app"
+                    --health-interval=10s
+                    --health-timeout=5s
+                    --health-retries=5
+
+        steps:
+            - name: 📦 Checkout repository
+              uses: actions/checkout@v4
+
+            - name: 🐘 Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: 8.2
+                  tools: composer
+
+            - name: 📦 Install dependencies
+              working-directory: site
+              run: composer install --no-interaction --prefer-dist --no-progress --no-scripts
+
+            - name: 🧬 Run Doctrine migrations
+              working-directory: site
+              env:
+                  APP_ENV: test
+                  APP_DEBUG: 0
+                  DATABASE_URL: "pgsql://app:app@127.0.0.1:5432/app?serverVersion=16&charset=utf8"
+              run: php bin/console doctrine:migrations:migrate --no-interaction


### PR DESCRIPTION
### Motivation
- Provide a separate GitHub Actions job that brings up Postgres and runs migrations against an empty DB to verify migrations apply.
- Prevent Composer auto-scripts (like `cache:clear`) from failing due to missing dev bundles by installing with `--no-scripts`.
- Run this validation on PRs and pushes to the main branch without changing application code, docs, or composer files.

### Description
- Modified ` .github/workflows/deploy.yml` to add a `migrations-empty-db` job and enabled `pull_request` trigger alongside existing `push` to `master`/`main`.
- Added a job that uses `runs-on: ubuntu-latest` and a `postgres:16` service with `POSTGRES_DB/USER/PASSWORD` set to `app` and a `pg_isready` healthcheck.
- Job steps (in order) are `actions/checkout@v4`, `shivammathur/setup-php@v2` with `php-version: 8.2` and `tools: composer`, `composer install --no-interaction --prefer-dist --no-progress --no-scripts` in `site/`, and `php bin/console doctrine:migrations:migrate --no-interaction` in `site/` with `APP_ENV=test`, `APP_DEBUG=0` and `DATABASE_URL` pointing to the local Postgres.

### Testing
- No automated CI jobs were executed as part of this change because it is a workflow configuration update only.
- No unit or integration tests were run by the script during this edit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b8936c56c8323847829da32cc8bf2)