### PR TITLE
Create `app_test` DB before running migrations in CI workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ name: 🚀 Deploy to Production
 on:
     push:
         branches: [ master ]
+    pull_request:
 
 jobs:
     deploy:
@@ -85,3 +86,48 @@ jobs:
                     echo "✅ Миграции применены"
                   EOF
 
+    migrations-empty-db:
+        runs-on: ubuntu-latest
+
+        services:
+            postgres:
+                image: postgres:16
+                env:
+                    POSTGRES_DB: app
+                    POSTGRES_USER: app
+                    POSTGRES_PASSWORD: app
+                ports:
+                    - 5432:5432
+                options: >-
+                    --health-cmd="pg_isready -U app -d app"
+                    --health-interval=10s
+                    --health-timeout=5s
+                    --health-retries=5
+
+        steps:
+            - name: 📦 Checkout repository
+              uses: actions/checkout@v4
+
+            - name: 🐘 Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: 8.2
+                  tools: composer
+
+            - name: 📦 Install dependencies
+              working-directory: site
+              run: composer install --no-interaction --prefer-dist --no-progress --no-scripts
+
+            - name: Create test database
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y postgresql-client
+                  PGPASSWORD=app psql -h 127.0.0.1 -p 5432 -U app -d postgres -c "SELECT 'CREATE DATABASE app_test' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'app_test')\gexec"
+
+            - name: 🧬 Run Doctrine migrations
+              working-directory: site
+              env:
+                  APP_ENV: test
+                  APP_DEBUG: 0
+                  DATABASE_URL: "pgsql://app:app@127.0.0.1:5432/app?serverVersion=16&charset=utf8"
+              run: php bin/console doctrine:migrations:migrate --no-interaction


### PR DESCRIPTION
### Motivation
- The `migrations-empty-db` job failed because `APP_ENV=test` makes the app expect an `app_test` database while the Postgres service was created with `POSTGRES_DB=app`.
- The goal is to ensure the empty test database exists before running Doctrine migrations so migrations do not error with `database "app_test" does not exist`.
- Only workflow files under `.github/workflows/` should be changed and application code or `composer.*` files must remain untouched.
- Composer install must continue to run with `--no-scripts` to avoid running auto-scripts during CI.

### Description
- Updated the workflow file `.github/workflows/deploy.yml` to add a `Create test database` step in the `migrations-empty-db` job. 
- The new step is placed after the `composer install --no-scripts` step and before the migrations step. 
- The step installs `postgresql-client` and runs `PGPASSWORD=app psql -h 127.0.0.1 -p 5432 -U app -d postgres -c "SELECT 'CREATE DATABASE app_test' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'app_test')\gexec"` to create `app_test` only if it does not exist. 
- No changes were made to application code, migration files, or `composer.*` and the `composer install` invocation was kept with `--no-scripts`.

### Testing
- No automated CI jobs were executed as part of this change because it is a workflow configuration update only. 
- There are no unit or integration tests run by this edit. 
- The change is ready to be validated by running the updated GitHub Actions workflow which should now create `app_test` and proceed to run migrations. 
- No automated failures were produced by local edits to the workflow file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b8936c56c8323847829da32cc8bf2)