### PR TITLE
Fix app_test creation in migrations-empty-db job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ name: 🚀 Deploy to Production
 on:
     push:
         branches: [ master ]
+    pull_request:
 
 jobs:
     deploy:
@@ -85,3 +86,59 @@ jobs:
                     echo "✅ Миграции применены"
                   EOF
 
+    migrations-empty-db:
+        runs-on: ubuntu-latest
+
+        services:
+            postgres:
+                image: postgres:16
+                env:
+                    POSTGRES_DB: app
+                    POSTGRES_USER: app
+                    POSTGRES_PASSWORD: app
+                ports:
+                    - 5432:5432
+                options: >-
+                    --health-cmd="pg_isready -U app -d app"
+                    --health-interval=10s
+                    --health-timeout=5s
+                    --health-retries=5
+
+        steps:
+            - name: 📦 Checkout repository
+              uses: actions/checkout@v4
+
+            - name: 🐘 Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: 8.2
+                  tools: composer
+
+            - name: 📦 Install dependencies
+              working-directory: site
+              run: composer install --no-interaction --prefer-dist --no-progress --no-scripts
+
+            - name: Install psql client
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y postgresql-client
+
+            - name: Create test database (app_test)
+              env:
+                  PGPASSWORD: app
+              run: |
+                  set -e
+                  if psql -h 127.0.0.1 -p 5432 -U app -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='app_test'" | grep -q 1; then
+                    echo "Database app_test already exists"
+                  else
+                    echo "Creating database app_test"
+                    psql -h 127.0.0.1 -p 5432 -U app -d postgres -c "CREATE DATABASE app_test"
+                  fi
+
+            - name: 🧬 Run Doctrine migrations
+              working-directory: site
+              env:
+                  APP_ENV: test
+                  APP_DEBUG: 0
+                  DATABASE_URL: "pgsql://app:app@127.0.0.1:5432/app?serverVersion=16&charset=utf8"
+              run: php bin/console doctrine:migrations:migrate --no-interaction


### PR DESCRIPTION
### Motivation
- The previous `Create test database` step used `\gexec` which produced a `syntax error at or near "\"` and caused CI to fail.
- The CI job must ensure the `app_test` database exists before running `doctrine:migrations:migrate` under `APP_ENV=test`.
- Changes are limited to workflow files under `.github/workflows/` and must not modify application code, migrations, or `composer.*` files.
- `composer install` must remain invoked with `--no-scripts` in the workflow.

### Description
- Updated the workflow file `/.github/workflows/deploy.yml` to replace the broken step with two steps: `Install psql client` and `Create test database (app_test)`. 
- The `Install psql client` step runs `sudo apt-get update` and `sudo apt-get install -y postgresql-client` to ensure `psql` is available. 
- The `Create test database (app_test)` step uses an existence check with `psql -tAc "SELECT 1 FROM pg_database WHERE datname='app_test'"` and runs `CREATE DATABASE app_test` only if needed. 
- The new steps are placed after the `composer install --no-scripts` step and before the `🧬 Run Doctrine migrations` step, and no application or composer files were changed.

### Testing
- No automated CI jobs were executed as part of this change because it is a workflow configuration edit only. 
- The change should prevent the previous `\gexec` syntax error by using a standard `psql` existence check and explicit `CREATE DATABASE` command. 
- The modified workflow can be validated by running the updated GitHub Actions job `migrations-empty-db`, which should create or skip creating `app_test` and then run migrations. 
- No automated failures were produced by the local workflow update itself.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b8936c56c8323847829da32cc8bf2)