### PR TITLE
Add Redis service and set `REDIS_DSN` for migrations-empty-db job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ name: 🚀 Deploy to Production
 on:
     push:
         branches: [ master ]
+    pull_request:
 
 jobs:
     deploy:
@@ -85,3 +86,69 @@ jobs:
                     echo "✅ Миграции применены"
                   EOF
 
+    migrations-empty-db:
+        runs-on: ubuntu-latest
+
+        services:
+            postgres:
+                image: postgres:16
+                env:
+                    POSTGRES_DB: app
+                    POSTGRES_USER: app
+                    POSTGRES_PASSWORD: app
+                ports:
+                    - 5432:5432
+                options: >-
+                    --health-cmd="pg_isready -U app -d app"
+                    --health-interval=10s
+                    --health-timeout=5s
+                    --health-retries=5
+            redis:
+                image: redis:7-alpine
+                ports:
+                    - "6379:6379"
+                options: >-
+                    --health-cmd="redis-cli ping"
+                    --health-interval=10s
+                    --health-timeout=5s
+                    --health-retries=10
+
+        steps:
+            - name: 📦 Checkout repository
+              uses: actions/checkout@v4
+
+            - name: 🐘 Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: 8.2
+                  tools: composer
+
+            - name: 📦 Install dependencies
+              working-directory: site
+              run: composer install --no-interaction --prefer-dist --no-progress --no-scripts
+
+            - name: Install psql client
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y postgresql-client
+
+            - name: Create test database (app_test)
+              env:
+                  PGPASSWORD: app
+              run: |
+                  set -e
+                  if psql -h 127.0.0.1 -p 5432 -U app -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='app_test'" | grep -q 1; then
+                    echo "Database app_test already exists"
+                  else
+                    echo "Creating database app_test"
+                    psql -h 127.0.0.1 -p 5432 -U app -d postgres -c "CREATE DATABASE app_test"
+                  fi
+
+            - name: 🧬 Run Doctrine migrations
+              working-directory: site
+              env:
+                  APP_ENV: test
+                  APP_DEBUG: 0
+                  DATABASE_URL: "pgsql://app:app@127.0.0.1:5432/app?serverVersion=16&charset=utf8"
+                  REDIS_DSN: "redis://127.0.0.1:6379"
+              run: php bin/console doctrine:migrations:migrate --no-interaction


### PR DESCRIPTION
### Motivation
- The `migrations-empty-db` job failed during `doctrine:migrations:migrate` with `php_network_getaddresses: getaddrinfo for site-redis failed` because the Redis host used by the app is not available in CI. 
- Migrations must be runnable in CI without changing application code or composer files, so the workflow must provide a Redis service and override the runtime Redis DSN. 
- Keep changes restricted to workflow files under `.github/workflows/` and avoid touching application code or `composer.*` files. 

### Description
- Added a `redis` service to the `migrations-empty-db` job in `.github/workflows/deploy.yml` using `image: redis:7-alpine`, mapped port `6379:6379`, and a health check via `redis-cli ping`. 
- Set the migration step environment variable `REDIS_DSN` to `redis://127.0.0.1:6379` so the application resolves Redis to localhost during migrations. 
- Kept the existing `postgres` service and the `Install psql client` and `Create test database (app_test)` steps intact to ensure the test database exists before running migrations. 
- Only `/.github/workflows/deploy.yml` was modified. 

### Testing
- No automated CI jobs were executed as part of this workflow-only change. 
- The updated job can be validated by running the GitHub Actions job `migrations-empty-db`, which should create or skip creating `app_test` and then run `php bin/console doctrine:migrations:migrate` successfully with Redis reachable at `127.0.0.1:6379`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b8936c56c8323847829da32cc8bf2)