### PR TITLE
Install libzip/ext-zip in PHP Docker images (dev & prod)

### DIFF
--- a/site/docker/development/php-fpm/Dockerfile
+++ b/site/docker/development/php-fpm/Dockerfile
@@ -2,11 +2,11 @@ FROM php:8.2-fpm-alpine
 
 ENV XDEBUG_VERSION 3.4.1
 
-RUN apk add --no-cache libpq-dev fcgi git linux-headers \
+RUN apk add --no-cache libpq-dev libzip-dev fcgi git linux-headers \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
     && git clone --branch $XDEBUG_VERSION --depth 1 https://github.com/xdebug/xdebug.git /usr/src/php/ext/xdebug \
     && docker-php-ext-configure xdebug --enable-xdebug-dev \
-    && docker-php-ext-install pdo_pgsql xdebug bcmath \
+    && docker-php-ext-install pdo_pgsql xdebug bcmath zip \
     && apk del git linux-headers
 
 # ✅ Добавляем расширение phpredis, чтобы dev-окружение соответствовало требованиям транспорта Redis

--- a/site/docker/production/nginx/Dockerfile
+++ b/site/docker/production/nginx/Dockerfile
@@ -1,8 +1,8 @@
 FROM php:8.2-cli-alpine AS builder
 
-RUN apk add --no-cache libpq-dev $PHPIZE_DEPS \
+RUN apk add --no-cache libpq-dev libzip-dev $PHPIZE_DEPS \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
-    && docker-php-ext-install pdo_pgsql opcache bcmath \
+    && docker-php-ext-install pdo_pgsql opcache bcmath zip \
     && pecl install redis \
     && docker-php-ext-enable redis \
     && apk del --no-cache $PHPIZE_DEPS

--- a/site/docker/production/php-cli/Dockerfile
+++ b/site/docker/production/php-cli/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:8.2-fpm-alpine AS builder
 
-RUN apk add --no-cache libpq-dev \
+RUN apk add --no-cache libpq-dev libzip-dev \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
     && docker-php-ext-configure opcache --disable-opcache-jit \
-    && docker-php-ext-install pdo_pgsql opcache bcmath
+    && docker-php-ext-install pdo_pgsql opcache bcmath zip
 
 # ⬇️ ДОБАВЛЯЕМ ext-redis для стадии builder (чтобы composer не ругался на ext-redis)
 RUN apk add --no-cache $PHPIZE_DEPS \
@@ -33,10 +33,10 @@ RUN composer install --no-dev --prefer-dist --no-progress --no-scripts --optimiz
 
 FROM php:8.2-cli-alpine
 
-RUN apk add --no-cache libpq-dev bash coreutils \
+RUN apk add --no-cache libpq-dev libzip-dev bash coreutils \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
     && docker-php-ext-configure opcache --disable-opcache-jit \
-    && docker-php-ext-install pdo_pgsql opcache bcmath
+    && docker-php-ext-install pdo_pgsql opcache bcmath zip
 
 # ⬇️ ДОБАВЛЯЕМ ext-redis для рантайма (CLI-воркер)
 RUN apk add --no-cache $PHPIZE_DEPS \

--- a/site/docker/production/php-fpm/Dockerfile
+++ b/site/docker/production/php-fpm/Dockerfile
@@ -3,10 +3,10 @@ FROM php:8.2-cli-alpine AS builder
 # После ("щадящий" вариант):
 ENV MAKEFLAGS="-j1"
 
-RUN apk add --no-cache libpq-dev \
+RUN apk add --no-cache libpq-dev libzip-dev \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
     && docker-php-ext-configure opcache --disable-opcache-jit \
-    && docker-php-ext-install pdo_pgsql opcache bcmath
+    && docker-php-ext-install pdo_pgsql opcache bcmath zip
 
 # Install ext-redis for the build stage so that Composer sees the extension
 RUN apk add --no-cache $PHPIZE_DEPS \
@@ -35,10 +35,10 @@ RUN composer install --no-dev --prefer-dist --no-progress --no-scripts --optimiz
 ### FPM ###
 FROM php:8.2-fpm-alpine
 
-RUN apk add --no-cache libpq-dev fcgi \
+RUN apk add --no-cache libpq-dev libzip-dev fcgi \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
     && docker-php-ext-configure opcache --disable-opcache-jit \
-    && docker-php-ext-install pdo_pgsql opcache bcmath
+    && docker-php-ext-install pdo_pgsql opcache bcmath zip
 
 # ⬇️ Добавляем ext-redis для рантайма PHP-FPM
 RUN apk add --no-cache $PHPIZE_DEPS \


### PR DESCRIPTION
### Motivation
- Composer and some packages require the `ext-zip` extension which was missing in both development and production images.  
- Ensure parity between dev/runtime and build images so Composer can resolve `ext-zip` during builds.  
- Prevent runtime errors in production and development caused by missing `zip` support.  

### Description
- Added `libzip-dev` to `apk add` in `site/docker/development/php-fpm/Dockerfile`, `site/docker/production/php-fpm/Dockerfile`, `site/docker/production/php-cli/Dockerfile`, and the builder stage in `site/docker/production/nginx/Dockerfile`.  
- Enabled building/installing the PHP `zip` extension by adding `zip` to `docker-php-ext-install` in the updated Dockerfiles.  
- Kept existing `redis` and other extension install steps intact to preserve Composer/build behavior.  

### Testing
- No automated tests were run for this change.  
- Changes were staged and committed locally (`git` status and `git commit` were performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953541bb0b483239edccbdb1c8e1c78)