### PR TITLE
Pin openspout to PHP 8.2 compatible release

### DIFF
--- a/site/composer.json
+++ b/site/composer.json
@@ -13,7 +13,7 @@
         "doctrine/doctrine-bundle": "^2.15",
         "doctrine/doctrine-migrations-bundle": "^3.4",
         "doctrine/orm": "^3.5",
-        "openspout/openspout": "*",
+        "openspout/openspout": "^4.0",
         "pagerfanta/doctrine-orm-adapter": "^4.7",
         "phpdocumentor/reflection-docblock": "^5.6",
         "phpstan/phpdoc-parser": "^2.1",

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d4964caa3c918fa63516df2b37654ec6",
+    "content-hash": "269904b9548c06e4a20998a8b11fb237",
     "packages": [
         {
             "name": "babdev/pagerfanta-bundle",
@@ -1623,20 +1623,21 @@
         },
         {
             "name": "openspout/openspout",
-            "version": "v5.2.0",
+            "version": "v4.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/openspout/openspout.git",
-                "reference": "22ba807c918484efc27e80d67d30c36ac28ff8dc"
+                "reference": "41f045c1f632e1474e15d4c7bc3abcb4a153563d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/openspout/openspout/zipball/22ba807c918484efc27e80d67d30c36ac28ff8dc",
-                "reference": "22ba807c918484efc27e80d67d30c36ac28ff8dc",
+                "url": "https://api.github.com/repos/openspout/openspout/zipball/41f045c1f632e1474e15d4c7bc3abcb4a153563d",
+                "reference": "41f045c1f632e1474e15d4c7bc3abcb4a153563d",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-fileinfo": "*",
                 "ext-filter": "*",
                 "ext-libxml": "*",
                 "ext-xmlreader": "*",
@@ -1645,13 +1646,13 @@
             },
             "require-dev": {
                 "ext-zlib": "*",
-                "friendsofphp/php-cs-fixer": "^3.92.3",
-                "infection/infection": "^0.31.9",
-                "phpbench/phpbench": "^1.4.3",
-                "phpstan/phpstan": "^2.1.33",
-                "phpstan/phpstan-phpunit": "^2.0.11",
-                "phpstan/phpstan-strict-rules": "^2.0.7",
-                "phpunit/phpunit": "^12.5.4"
+                "friendsofphp/php-cs-fixer": "^3.86.0",
+                "infection/infection": "^0.31.2",
+                "phpbench/phpbench": "^1.4.1",
+                "phpstan/phpstan": "^2.1.22",
+                "phpstan/phpstan-phpunit": "^2.0.7",
+                "phpstan/phpstan-strict-rules": "^2.0.6",
+                "phpunit/phpunit": "^12.3.7"
             },
             "suggest": {
                 "ext-iconv": "To handle non UTF-8 CSV files (if \"php-mbstring\" is not already installed or is too limited)",
@@ -1699,7 +1700,7 @@
             ],
             "support": {
                 "issues": "https://github.com/openspout/openspout/issues",
-                "source": "https://github.com/openspout/openspout/tree/v5.2.0"
+                "source": "https://github.com/openspout/openspout/tree/v4.32.0"
             },
             "funding": [
                 {
@@ -1711,7 +1712,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-19T13:28:49+00:00"
+            "time": "2025-09-03T16:03:54+00:00"
         },
         {
             "name": "pagerfanta/core",


### PR DESCRIPTION
### Motivation
- The project previously had `openspout/openspout` locked to a v5 release that requires PHP ~8.3+, which is incompatible with the repository's current PHP 8.2 runtime.  
- Pinning to a 4.x release restores compatibility with PHP 8.2 and prevents composer install failures in CI and local PHP 8.2 environments.  

### Description
- Updated `site/composer.json` to require `openspout/openspout` as `^4.0` instead of `*`.  
- Regenerated `site/composer.lock`, downgrading `openspout/openspout` from `v5.2.0` to `v4.32.0` and updating related lockfile metadata.  
- Ran `composer update openspout/openspout --ignore-platform-req=ext-redis` to update the lockfile and install dependencies in this environment.  

### Testing
- Executed `composer update openspout/openspout --ignore-platform-req=ext-redis`, which completed and wrote an updated `composer.lock` containing `openspout` v4.32.0.  
- The `post-update` auto-scripts ran but `importmap:install` failed with a CDN fetch error (jsdelivr returned HTTP 403), causing the script to exit with an error.  
- No PHPUnit test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69537ebc2c188323a8d72fc51467d78f)