### PR TITLE
Guard balance category migration for existing schema

### DIFF
--- a/site/migrations/Version20260101090000.php
+++ b/site/migrations/Version20260101090000.php
@@ -16,35 +16,45 @@ final class Version20260101090000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql("CREATE TABLE balance_categories (id UUID NOT NULL, company_id UUID NOT NULL, name VARCHAR(255) NOT NULL, code VARCHAR(64) DEFAULT NULL, type VARCHAR(32) NOT NULL, parent_id UUID DEFAULT NULL, level INT NOT NULL DEFAULT 1, sort_order INT NOT NULL DEFAULT 0, is_visible BOOLEAN NOT NULL DEFAULT true, PRIMARY KEY(id))");
-        $this->addSql("CREATE INDEX idx_balance_cat_company ON balance_categories (company_id)");
-        $this->addSql("CREATE INDEX idx_balance_cat_company_parent ON balance_categories (company_id, parent_id)");
-        $this->addSql("CREATE UNIQUE INDEX uniq_balance_cat_company_code ON balance_categories (company_id, code)");
-        $this->addSql("COMMENT ON COLUMN balance_categories.id IS '(DC2Type:guid)'");
-        $this->addSql("COMMENT ON COLUMN balance_categories.company_id IS '(DC2Type:guid)'");
-        $this->addSql("COMMENT ON COLUMN balance_categories.parent_id IS '(DC2Type:guid)'");
-        $this->addSql("ALTER TABLE balance_categories ADD CONSTRAINT FK_BALANCE_CATEGORIES_COMPANY FOREIGN KEY (company_id) REFERENCES companies (id) NOT DEFERRABLE INITIALLY IMMEDIATE");
-        $this->addSql("ALTER TABLE balance_categories ADD CONSTRAINT FK_BALANCE_CATEGORIES_PARENT FOREIGN KEY (parent_id) REFERENCES balance_categories (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE");
+        if (!$schema->hasTable('balance_categories')) {
+            $this->addSql("CREATE TABLE balance_categories (id UUID NOT NULL, company_id UUID NOT NULL, name VARCHAR(255) NOT NULL, code VARCHAR(64) DEFAULT NULL, type VARCHAR(32) NOT NULL, parent_id UUID DEFAULT NULL, level INT NOT NULL DEFAULT 1, sort_order INT NOT NULL DEFAULT 0, is_visible BOOLEAN NOT NULL DEFAULT true, PRIMARY KEY(id))");
+        }
 
-        $this->addSql("CREATE TABLE balance_category_links (id UUID NOT NULL, company_id UUID NOT NULL, category_id UUID NOT NULL, source_type VARCHAR(64) NOT NULL, source_id UUID DEFAULT NULL, sign INT NOT NULL DEFAULT 1, position INT NOT NULL DEFAULT 0, PRIMARY KEY(id))");
-        $this->addSql("CREATE INDEX idx_balance_link_company ON balance_category_links (company_id)");
-        $this->addSql("CREATE INDEX idx_balance_link_company_category ON balance_category_links (company_id, category_id)");
-        $this->addSql("CREATE UNIQUE INDEX uniq_balance_link ON balance_category_links (company_id, category_id, source_type, source_id)");
-        $this->addSql("COMMENT ON COLUMN balance_category_links.id IS '(DC2Type:guid)'");
-        $this->addSql("COMMENT ON COLUMN balance_category_links.company_id IS '(DC2Type:guid)'");
-        $this->addSql("COMMENT ON COLUMN balance_category_links.category_id IS '(DC2Type:guid)'");
-        $this->addSql("COMMENT ON COLUMN balance_category_links.source_id IS '(DC2Type:guid)'");
-        $this->addSql("ALTER TABLE balance_category_links ADD CONSTRAINT FK_BALANCE_LINK_COMPANY FOREIGN KEY (company_id) REFERENCES companies (id) NOT DEFERRABLE INITIALLY IMMEDIATE");
-        $this->addSql("ALTER TABLE balance_category_links ADD CONSTRAINT FK_BALANCE_LINK_CATEGORY FOREIGN KEY (category_id) REFERENCES balance_categories (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE");
+        if ($schema->hasTable('balance_categories')) {
+            $this->addSql("CREATE INDEX IF NOT EXISTS idx_balance_cat_company ON balance_categories (company_id)");
+            $this->addSql("CREATE INDEX IF NOT EXISTS idx_balance_cat_company_parent ON balance_categories (company_id, parent_id)");
+            $this->addSql("CREATE UNIQUE INDEX IF NOT EXISTS uniq_balance_cat_company_code ON balance_categories (company_id, code)");
+            $this->addSql("COMMENT ON COLUMN balance_categories.id IS '(DC2Type:guid)'");
+            $this->addSql("COMMENT ON COLUMN balance_categories.company_id IS '(DC2Type:guid)'");
+            $this->addSql("COMMENT ON COLUMN balance_categories.parent_id IS '(DC2Type:guid)'");
+            $this->addSql("DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'FK_BALANCE_CATEGORIES_COMPANY') THEN ALTER TABLE balance_categories ADD CONSTRAINT FK_BALANCE_CATEGORIES_COMPANY FOREIGN KEY (company_id) REFERENCES companies (id) NOT DEFERRABLE INITIALLY IMMEDIATE; END IF; END $$;");
+            $this->addSql("DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'FK_BALANCE_CATEGORIES_PARENT') THEN ALTER TABLE balance_categories ADD CONSTRAINT FK_BALANCE_CATEGORIES_PARENT FOREIGN KEY (parent_id) REFERENCES balance_categories (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE; END IF; END $$;");
+        }
+
+        if (!$schema->hasTable('balance_category_links')) {
+            $this->addSql("CREATE TABLE balance_category_links (id UUID NOT NULL, company_id UUID NOT NULL, category_id UUID NOT NULL, source_type VARCHAR(64) NOT NULL, source_id UUID DEFAULT NULL, sign INT NOT NULL DEFAULT 1, position INT NOT NULL DEFAULT 0, PRIMARY KEY(id))");
+        }
+
+        if ($schema->hasTable('balance_category_links')) {
+            $this->addSql("CREATE INDEX IF NOT EXISTS idx_balance_link_company ON balance_category_links (company_id)");
+            $this->addSql("CREATE INDEX IF NOT EXISTS idx_balance_link_company_category ON balance_category_links (company_id, category_id)");
+            $this->addSql("CREATE UNIQUE INDEX IF NOT EXISTS uniq_balance_link ON balance_category_links (company_id, category_id, source_type, source_id)");
+            $this->addSql("COMMENT ON COLUMN balance_category_links.id IS '(DC2Type:guid)'");
+            $this->addSql("COMMENT ON COLUMN balance_category_links.company_id IS '(DC2Type:guid)'");
+            $this->addSql("COMMENT ON COLUMN balance_category_links.category_id IS '(DC2Type:guid)'");
+            $this->addSql("COMMENT ON COLUMN balance_category_links.source_id IS '(DC2Type:guid)'");
+            $this->addSql("DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'FK_BALANCE_LINK_COMPANY') THEN ALTER TABLE balance_category_links ADD CONSTRAINT FK_BALANCE_LINK_COMPANY FOREIGN KEY (company_id) REFERENCES companies (id) NOT DEFERRABLE INITIALLY IMMEDIATE; END IF; END $$;");
+            $this->addSql("DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'FK_BALANCE_LINK_CATEGORY') THEN ALTER TABLE balance_category_links ADD CONSTRAINT FK_BALANCE_LINK_CATEGORY FOREIGN KEY (category_id) REFERENCES balance_categories (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE; END IF; END $$;");
+        }
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE balance_category_links DROP CONSTRAINT FK_BALANCE_LINK_CATEGORY');
-        $this->addSql('ALTER TABLE balance_category_links DROP CONSTRAINT FK_BALANCE_LINK_COMPANY');
-        $this->addSql('ALTER TABLE balance_categories DROP CONSTRAINT FK_BALANCE_CATEGORIES_COMPANY');
-        $this->addSql('ALTER TABLE balance_categories DROP CONSTRAINT FK_BALANCE_CATEGORIES_PARENT');
-        $this->addSql('DROP TABLE balance_category_links');
-        $this->addSql('DROP TABLE balance_categories');
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'FK_BALANCE_LINK_CATEGORY') THEN ALTER TABLE balance_category_links DROP CONSTRAINT FK_BALANCE_LINK_CATEGORY; END IF; END $$;");
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'FK_BALANCE_LINK_COMPANY') THEN ALTER TABLE balance_category_links DROP CONSTRAINT FK_BALANCE_LINK_COMPANY; END IF; END $$;");
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'FK_BALANCE_CATEGORIES_COMPANY') THEN ALTER TABLE balance_categories DROP CONSTRAINT FK_BALANCE_CATEGORIES_COMPANY; END IF; END $$;");
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'FK_BALANCE_CATEGORIES_PARENT') THEN ALTER TABLE balance_categories DROP CONSTRAINT FK_BALANCE_CATEGORIES_PARENT; END IF; END $$;");
+        $this->addSql('DROP TABLE IF EXISTS balance_category_links');
+        $this->addSql('DROP TABLE IF EXISTS balance_categories');
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent migration failures when some or all `balance_categories`/`balance_category_links` objects already exist so new migrations can be applied in order.
- Make the `up` migration idempotent and the `down` migration resilient to partially-applied schemas.

### Description
- Update `site/migrations/Version20260101090000.php` to wrap table creation with `if (!$schema->hasTable(...))` guards and to guard subsequent operations with `if ($schema->hasTable(...))` checks.
- Use `CREATE INDEX IF NOT EXISTS` and `CREATE UNIQUE INDEX IF NOT EXISTS` for indexes, add `COMMENT` statements unchanged, and add constraint creation inside `DO $$ BEGIN ... END $$;` blocks that check `pg_constraint` to avoid duplicate-constraint errors; constraint names use the existing `FK_*` identifiers.
- Make `down` use `DO $$ BEGIN IF EXISTS ... END $$;` to drop constraints only when present and use `DROP TABLE IF EXISTS` for tables.

### Testing
- No automated tests were executed for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968c914d01083239cca0bb0957e7927)