### PR TITLE
Make migrations idempotent: guard balance_category constraints and bot_links.updated_at

### DIFF
--- a/site/migrations/Version20260101090000.php
+++ b/site/migrations/Version20260101090000.php
@@ -16,35 +16,45 @@ final class Version20260101090000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql("CREATE TABLE balance_categories (id UUID NOT NULL, company_id UUID NOT NULL, name VARCHAR(255) NOT NULL, code VARCHAR(64) DEFAULT NULL, type VARCHAR(32) NOT NULL, parent_id UUID DEFAULT NULL, level INT NOT NULL DEFAULT 1, sort_order INT NOT NULL DEFAULT 0, is_visible BOOLEAN NOT NULL DEFAULT true, PRIMARY KEY(id))");
-        $this->addSql("CREATE INDEX idx_balance_cat_company ON balance_categories (company_id)");
-        $this->addSql("CREATE INDEX idx_balance_cat_company_parent ON balance_categories (company_id, parent_id)");
-        $this->addSql("CREATE UNIQUE INDEX uniq_balance_cat_company_code ON balance_categories (company_id, code)");
-        $this->addSql("COMMENT ON COLUMN balance_categories.id IS '(DC2Type:guid)'");
-        $this->addSql("COMMENT ON COLUMN balance_categories.company_id IS '(DC2Type:guid)'");
-        $this->addSql("COMMENT ON COLUMN balance_categories.parent_id IS '(DC2Type:guid)'");
-        $this->addSql("ALTER TABLE balance_categories ADD CONSTRAINT FK_BALANCE_CATEGORIES_COMPANY FOREIGN KEY (company_id) REFERENCES companies (id) NOT DEFERRABLE INITIALLY IMMEDIATE");
-        $this->addSql("ALTER TABLE balance_categories ADD CONSTRAINT FK_BALANCE_CATEGORIES_PARENT FOREIGN KEY (parent_id) REFERENCES balance_categories (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE");
+        if (!$schema->hasTable('balance_categories')) {
+            $this->addSql("CREATE TABLE balance_categories (id UUID NOT NULL, company_id UUID NOT NULL, name VARCHAR(255) NOT NULL, code VARCHAR(64) DEFAULT NULL, type VARCHAR(32) NOT NULL, parent_id UUID DEFAULT NULL, level INT NOT NULL DEFAULT 1, sort_order INT NOT NULL DEFAULT 0, is_visible BOOLEAN NOT NULL DEFAULT true, PRIMARY KEY(id))");
+        }
 
-        $this->addSql("CREATE TABLE balance_category_links (id UUID NOT NULL, company_id UUID NOT NULL, category_id UUID NOT NULL, source_type VARCHAR(64) NOT NULL, source_id UUID DEFAULT NULL, sign INT NOT NULL DEFAULT 1, position INT NOT NULL DEFAULT 0, PRIMARY KEY(id))");
-        $this->addSql("CREATE INDEX idx_balance_link_company ON balance_category_links (company_id)");
-        $this->addSql("CREATE INDEX idx_balance_link_company_category ON balance_category_links (company_id, category_id)");
-        $this->addSql("CREATE UNIQUE INDEX uniq_balance_link ON balance_category_links (company_id, category_id, source_type, source_id)");
-        $this->addSql("COMMENT ON COLUMN balance_category_links.id IS '(DC2Type:guid)'");
-        $this->addSql("COMMENT ON COLUMN balance_category_links.company_id IS '(DC2Type:guid)'");
-        $this->addSql("COMMENT ON COLUMN balance_category_links.category_id IS '(DC2Type:guid)'");
-        $this->addSql("COMMENT ON COLUMN balance_category_links.source_id IS '(DC2Type:guid)'");
-        $this->addSql("ALTER TABLE balance_category_links ADD CONSTRAINT FK_BALANCE_LINK_COMPANY FOREIGN KEY (company_id) REFERENCES companies (id) NOT DEFERRABLE INITIALLY IMMEDIATE");
-        $this->addSql("ALTER TABLE balance_category_links ADD CONSTRAINT FK_BALANCE_LINK_CATEGORY FOREIGN KEY (category_id) REFERENCES balance_categories (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE");
+        if ($schema->hasTable('balance_categories')) {
+            $this->addSql("CREATE INDEX IF NOT EXISTS idx_balance_cat_company ON balance_categories (company_id)");
+            $this->addSql("CREATE INDEX IF NOT EXISTS idx_balance_cat_company_parent ON balance_categories (company_id, parent_id)");
+            $this->addSql("CREATE UNIQUE INDEX IF NOT EXISTS uniq_balance_cat_company_code ON balance_categories (company_id, code)");
+            $this->addSql("COMMENT ON COLUMN balance_categories.id IS '(DC2Type:guid)'");
+            $this->addSql("COMMENT ON COLUMN balance_categories.company_id IS '(DC2Type:guid)'");
+            $this->addSql("COMMENT ON COLUMN balance_categories.parent_id IS '(DC2Type:guid)'");
+            $this->addSql("DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE lower(conname) = lower('FK_BALANCE_CATEGORIES_COMPANY')) THEN ALTER TABLE balance_categories ADD CONSTRAINT FK_BALANCE_CATEGORIES_COMPANY FOREIGN KEY (company_id) REFERENCES companies (id) NOT DEFERRABLE INITIALLY IMMEDIATE; END IF; END $$;");
+            $this->addSql("DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE lower(conname) = lower('FK_BALANCE_CATEGORIES_PARENT')) THEN ALTER TABLE balance_categories ADD CONSTRAINT FK_BALANCE_CATEGORIES_PARENT FOREIGN KEY (parent_id) REFERENCES balance_categories (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE; END IF; END $$;");
+        }
+
+        if (!$schema->hasTable('balance_category_links')) {
+            $this->addSql("CREATE TABLE balance_category_links (id UUID NOT NULL, company_id UUID NOT NULL, category_id UUID NOT NULL, source_type VARCHAR(64) NOT NULL, source_id UUID DEFAULT NULL, sign INT NOT NULL DEFAULT 1, position INT NOT NULL DEFAULT 0, PRIMARY KEY(id))");
+        }
+
+        if ($schema->hasTable('balance_category_links')) {
+            $this->addSql("CREATE INDEX IF NOT EXISTS idx_balance_link_company ON balance_category_links (company_id)");
+            $this->addSql("CREATE INDEX IF NOT EXISTS idx_balance_link_company_category ON balance_category_links (company_id, category_id)");
+            $this->addSql("CREATE UNIQUE INDEX IF NOT EXISTS uniq_balance_link ON balance_category_links (company_id, category_id, source_type, source_id)");
+            $this->addSql("COMMENT ON COLUMN balance_category_links.id IS '(DC2Type:guid)'");
+            $this->addSql("COMMENT ON COLUMN balance_category_links.company_id IS '(DC2Type:guid)'");
+            $this->addSql("COMMENT ON COLUMN balance_category_links.category_id IS '(DC2Type:guid)'");
+            $this->addSql("COMMENT ON COLUMN balance_category_links.source_id IS '(DC2Type:guid)'");
+            $this->addSql("DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE lower(conname) = lower('FK_BALANCE_LINK_COMPANY')) THEN ALTER TABLE balance_category_links ADD CONSTRAINT FK_BALANCE_LINK_COMPANY FOREIGN KEY (company_id) REFERENCES companies (id) NOT DEFERRABLE INITIALLY IMMEDIATE; END IF; END $$;");
+            $this->addSql("DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE lower(conname) = lower('FK_BALANCE_LINK_CATEGORY')) THEN ALTER TABLE balance_category_links ADD CONSTRAINT FK_BALANCE_LINK_CATEGORY FOREIGN KEY (category_id) REFERENCES balance_categories (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE; END IF; END $$;");
+        }
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE balance_category_links DROP CONSTRAINT FK_BALANCE_LINK_CATEGORY');
-        $this->addSql('ALTER TABLE balance_category_links DROP CONSTRAINT FK_BALANCE_LINK_COMPANY');
-        $this->addSql('ALTER TABLE balance_categories DROP CONSTRAINT FK_BALANCE_CATEGORIES_COMPANY');
-        $this->addSql('ALTER TABLE balance_categories DROP CONSTRAINT FK_BALANCE_CATEGORIES_PARENT');
-        $this->addSql('DROP TABLE balance_category_links');
-        $this->addSql('DROP TABLE balance_categories');
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_constraint WHERE lower(conname) = lower('FK_BALANCE_LINK_CATEGORY')) THEN ALTER TABLE balance_category_links DROP CONSTRAINT FK_BALANCE_LINK_CATEGORY; END IF; END $$;");
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_constraint WHERE lower(conname) = lower('FK_BALANCE_LINK_COMPANY')) THEN ALTER TABLE balance_category_links DROP CONSTRAINT FK_BALANCE_LINK_COMPANY; END IF; END $$;");
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_constraint WHERE lower(conname) = lower('FK_BALANCE_CATEGORIES_COMPANY')) THEN ALTER TABLE balance_categories DROP CONSTRAINT FK_BALANCE_CATEGORIES_COMPANY; END IF; END $$;");
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_constraint WHERE lower(conname) = lower('FK_BALANCE_CATEGORIES_PARENT')) THEN ALTER TABLE balance_categories DROP CONSTRAINT FK_BALANCE_CATEGORIES_PARENT; END IF; END $$;");
+        $this->addSql('DROP TABLE IF EXISTS balance_category_links');
+        $this->addSql('DROP TABLE IF EXISTS balance_categories');
     }
 }

--- a/site/migrations/Version20260115105426.php
+++ b/site/migrations/Version20260115105426.php
@@ -41,8 +41,13 @@ final class Version20260115105426 extends AbstractMigration
         $this->addSql('DROP INDEX uniq_balance_link');
         $this->addSql('ALTER TABLE balance_category_links ALTER source_type TYPE VARCHAR(255)');
         $this->addSql('ALTER INDEX idx_balance_link_company RENAME TO IDX_D79DC3BA979B1AD6');
-        $this->addSql('ALTER TABLE bot_links ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL');
-        $this->addSql('COMMENT ON COLUMN bot_links.updated_at IS \'(DC2Type:datetime_immutable)\'');
+        if ($schema->hasTable('bot_links') && !$schema->getTable('bot_links')->hasColumn('updated_at')) {
+            $this->addSql('ALTER TABLE bot_links ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL');
+        }
+
+        if ($schema->hasTable('bot_links') && $schema->getTable('bot_links')->hasColumn('updated_at')) {
+            $this->addSql('COMMENT ON COLUMN bot_links.updated_at IS \'(DC2Type:datetime_immutable)\'');
+        }
         $this->addSql('ALTER TABLE cash_transaction ALTER allocated_amount DROP DEFAULT');
         $this->addSql('ALTER INDEX idx_cashflow_categories_pl_category RENAME TO IDX_EAB5C38D98B34054');
         $this->addSql('ALTER TABLE document_operations DROP CONSTRAINT fk_doc_ops_project_direction');
@@ -114,7 +119,9 @@ final class Version20260115105426 extends AbstractMigration
         $this->addSql('ALTER TABLE "telegram_bots" DROP updated_at');
         $this->addSql('ALTER TABLE "telegram_bots" ADD CONSTRAINT fk_dacd6ed979b1ad6 FOREIGN KEY (company_id) REFERENCES companies (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
         $this->addSql('CREATE INDEX idx_dacd6ed979b1ad6 ON "telegram_bots" (company_id)');
-        $this->addSql('ALTER TABLE "bot_links" DROP updated_at');
+        if ($schema->hasTable('bot_links') && $schema->getTable('bot_links')->hasColumn('updated_at')) {
+            $this->addSql('ALTER TABLE "bot_links" DROP updated_at');
+        }
         $this->addSql('ALTER INDEX idx_eab5c38d98b34054 RENAME TO idx_cashflow_categories_pl_category');
         $this->addSql('ALTER TABLE finance_loan ALTER start_date TYPE DATE');
         $this->addSql('ALTER TABLE finance_loan ALTER end_date TYPE DATE');


### PR DESCRIPTION
### Motivation
- Prevent migration failures when tables, indexes, columns, or constraints already exist or differ only by case, which caused errors like the `bot_links.updated_at` duplicate column during migration runs. 
- Ensure migrations can be safely re-run across environments with varying existing schema state.

### Description
- In `site/migrations/Version20260101090000.php` wrap table creation with `if (!$schema->hasTable(...))` and conditionally run index/column/comment statements when the table exists. 
- Use `CREATE INDEX IF NOT EXISTS` and `CREATE UNIQUE INDEX IF NOT EXISTS` and retain `COMMENT` statements for columns. 
- Create/drop foreign keys inside `DO $$ BEGIN ... END $$;` blocks that check `lower(conname) = lower('...')` for case-insensitive existence checks and use `DROP TABLE IF EXISTS` in `down`. 
- In `site/migrations/Version20260115105426.php` guard adding the `bot_links.updated_at` column and its `COMMENT` with `$schema->hasTable()` / `$schema->getTable()->hasColumn()` checks and make the `down` path drop the column only when present.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968c914d01083239cca0bb0957e7927)