### PR TITLE
Make migrations idempotent: guard telegram_bots updated_at and index/constraint operations

### DIFF
--- a/site/migrations/Version20260101090000.php
+++ b/site/migrations/Version20260101090000.php
@@ -16,35 +16,45 @@ final class Version20260101090000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql("CREATE TABLE balance_categories (id UUID NOT NULL, company_id UUID NOT NULL, name VARCHAR(255) NOT NULL, code VARCHAR(64) DEFAULT NULL, type VARCHAR(32) NOT NULL, parent_id UUID DEFAULT NULL, level INT NOT NULL DEFAULT 1, sort_order INT NOT NULL DEFAULT 0, is_visible BOOLEAN NOT NULL DEFAULT true, PRIMARY KEY(id))");
-        $this->addSql("CREATE INDEX idx_balance_cat_company ON balance_categories (company_id)");
-        $this->addSql("CREATE INDEX idx_balance_cat_company_parent ON balance_categories (company_id, parent_id)");
-        $this->addSql("CREATE UNIQUE INDEX uniq_balance_cat_company_code ON balance_categories (company_id, code)");
-        $this->addSql("COMMENT ON COLUMN balance_categories.id IS '(DC2Type:guid)'");
-        $this->addSql("COMMENT ON COLUMN balance_categories.company_id IS '(DC2Type:guid)'");
-        $this->addSql("COMMENT ON COLUMN balance_categories.parent_id IS '(DC2Type:guid)'");
-        $this->addSql("ALTER TABLE balance_categories ADD CONSTRAINT FK_BALANCE_CATEGORIES_COMPANY FOREIGN KEY (company_id) REFERENCES companies (id) NOT DEFERRABLE INITIALLY IMMEDIATE");
-        $this->addSql("ALTER TABLE balance_categories ADD CONSTRAINT FK_BALANCE_CATEGORIES_PARENT FOREIGN KEY (parent_id) REFERENCES balance_categories (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE");
+        if (!$schema->hasTable('balance_categories')) {
+            $this->addSql("CREATE TABLE balance_categories (id UUID NOT NULL, company_id UUID NOT NULL, name VARCHAR(255) NOT NULL, code VARCHAR(64) DEFAULT NULL, type VARCHAR(32) NOT NULL, parent_id UUID DEFAULT NULL, level INT NOT NULL DEFAULT 1, sort_order INT NOT NULL DEFAULT 0, is_visible BOOLEAN NOT NULL DEFAULT true, PRIMARY KEY(id))");
+        }
 
-        $this->addSql("CREATE TABLE balance_category_links (id UUID NOT NULL, company_id UUID NOT NULL, category_id UUID NOT NULL, source_type VARCHAR(64) NOT NULL, source_id UUID DEFAULT NULL, sign INT NOT NULL DEFAULT 1, position INT NOT NULL DEFAULT 0, PRIMARY KEY(id))");
-        $this->addSql("CREATE INDEX idx_balance_link_company ON balance_category_links (company_id)");
-        $this->addSql("CREATE INDEX idx_balance_link_company_category ON balance_category_links (company_id, category_id)");
-        $this->addSql("CREATE UNIQUE INDEX uniq_balance_link ON balance_category_links (company_id, category_id, source_type, source_id)");
-        $this->addSql("COMMENT ON COLUMN balance_category_links.id IS '(DC2Type:guid)'");
-        $this->addSql("COMMENT ON COLUMN balance_category_links.company_id IS '(DC2Type:guid)'");
-        $this->addSql("COMMENT ON COLUMN balance_category_links.category_id IS '(DC2Type:guid)'");
-        $this->addSql("COMMENT ON COLUMN balance_category_links.source_id IS '(DC2Type:guid)'");
-        $this->addSql("ALTER TABLE balance_category_links ADD CONSTRAINT FK_BALANCE_LINK_COMPANY FOREIGN KEY (company_id) REFERENCES companies (id) NOT DEFERRABLE INITIALLY IMMEDIATE");
-        $this->addSql("ALTER TABLE balance_category_links ADD CONSTRAINT FK_BALANCE_LINK_CATEGORY FOREIGN KEY (category_id) REFERENCES balance_categories (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE");
+        if ($schema->hasTable('balance_categories')) {
+            $this->addSql("CREATE INDEX IF NOT EXISTS idx_balance_cat_company ON balance_categories (company_id)");
+            $this->addSql("CREATE INDEX IF NOT EXISTS idx_balance_cat_company_parent ON balance_categories (company_id, parent_id)");
+            $this->addSql("CREATE UNIQUE INDEX IF NOT EXISTS uniq_balance_cat_company_code ON balance_categories (company_id, code)");
+            $this->addSql("COMMENT ON COLUMN balance_categories.id IS '(DC2Type:guid)'");
+            $this->addSql("COMMENT ON COLUMN balance_categories.company_id IS '(DC2Type:guid)'");
+            $this->addSql("COMMENT ON COLUMN balance_categories.parent_id IS '(DC2Type:guid)'");
+            $this->addSql("DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE lower(conname) = lower('FK_BALANCE_CATEGORIES_COMPANY')) THEN ALTER TABLE balance_categories ADD CONSTRAINT FK_BALANCE_CATEGORIES_COMPANY FOREIGN KEY (company_id) REFERENCES companies (id) NOT DEFERRABLE INITIALLY IMMEDIATE; END IF; END $$;");
+            $this->addSql("DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE lower(conname) = lower('FK_BALANCE_CATEGORIES_PARENT')) THEN ALTER TABLE balance_categories ADD CONSTRAINT FK_BALANCE_CATEGORIES_PARENT FOREIGN KEY (parent_id) REFERENCES balance_categories (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE; END IF; END $$;");
+        }
+
+        if (!$schema->hasTable('balance_category_links')) {
+            $this->addSql("CREATE TABLE balance_category_links (id UUID NOT NULL, company_id UUID NOT NULL, category_id UUID NOT NULL, source_type VARCHAR(64) NOT NULL, source_id UUID DEFAULT NULL, sign INT NOT NULL DEFAULT 1, position INT NOT NULL DEFAULT 0, PRIMARY KEY(id))");
+        }
+
+        if ($schema->hasTable('balance_category_links')) {
+            $this->addSql("CREATE INDEX IF NOT EXISTS idx_balance_link_company ON balance_category_links (company_id)");
+            $this->addSql("CREATE INDEX IF NOT EXISTS idx_balance_link_company_category ON balance_category_links (company_id, category_id)");
+            $this->addSql("CREATE UNIQUE INDEX IF NOT EXISTS uniq_balance_link ON balance_category_links (company_id, category_id, source_type, source_id)");
+            $this->addSql("COMMENT ON COLUMN balance_category_links.id IS '(DC2Type:guid)'");
+            $this->addSql("COMMENT ON COLUMN balance_category_links.company_id IS '(DC2Type:guid)'");
+            $this->addSql("COMMENT ON COLUMN balance_category_links.category_id IS '(DC2Type:guid)'");
+            $this->addSql("COMMENT ON COLUMN balance_category_links.source_id IS '(DC2Type:guid)'");
+            $this->addSql("DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE lower(conname) = lower('FK_BALANCE_LINK_COMPANY')) THEN ALTER TABLE balance_category_links ADD CONSTRAINT FK_BALANCE_LINK_COMPANY FOREIGN KEY (company_id) REFERENCES companies (id) NOT DEFERRABLE INITIALLY IMMEDIATE; END IF; END $$;");
+            $this->addSql("DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE lower(conname) = lower('FK_BALANCE_LINK_CATEGORY')) THEN ALTER TABLE balance_category_links ADD CONSTRAINT FK_BALANCE_LINK_CATEGORY FOREIGN KEY (category_id) REFERENCES balance_categories (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE; END IF; END $$;");
+        }
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE balance_category_links DROP CONSTRAINT FK_BALANCE_LINK_CATEGORY');
-        $this->addSql('ALTER TABLE balance_category_links DROP CONSTRAINT FK_BALANCE_LINK_COMPANY');
-        $this->addSql('ALTER TABLE balance_categories DROP CONSTRAINT FK_BALANCE_CATEGORIES_COMPANY');
-        $this->addSql('ALTER TABLE balance_categories DROP CONSTRAINT FK_BALANCE_CATEGORIES_PARENT');
-        $this->addSql('DROP TABLE balance_category_links');
-        $this->addSql('DROP TABLE balance_categories');
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_constraint WHERE lower(conname) = lower('FK_BALANCE_LINK_CATEGORY')) THEN ALTER TABLE balance_category_links DROP CONSTRAINT FK_BALANCE_LINK_CATEGORY; END IF; END $$;");
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_constraint WHERE lower(conname) = lower('FK_BALANCE_LINK_COMPANY')) THEN ALTER TABLE balance_category_links DROP CONSTRAINT FK_BALANCE_LINK_COMPANY; END IF; END $$;");
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_constraint WHERE lower(conname) = lower('FK_BALANCE_CATEGORIES_COMPANY')) THEN ALTER TABLE balance_categories DROP CONSTRAINT FK_BALANCE_CATEGORIES_COMPANY; END IF; END $$;");
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_constraint WHERE lower(conname) = lower('FK_BALANCE_CATEGORIES_PARENT')) THEN ALTER TABLE balance_categories DROP CONSTRAINT FK_BALANCE_CATEGORIES_PARENT; END IF; END $$;");
+        $this->addSql('DROP TABLE IF EXISTS balance_category_links');
+        $this->addSql('DROP TABLE IF EXISTS balance_categories');
     }
 }

--- a/site/migrations/Version20260115105426.php
+++ b/site/migrations/Version20260115105426.php
@@ -41,17 +41,22 @@ final class Version20260115105426 extends AbstractMigration
         $this->addSql('DROP INDEX uniq_balance_link');
         $this->addSql('ALTER TABLE balance_category_links ALTER source_type TYPE VARCHAR(255)');
         $this->addSql('ALTER INDEX idx_balance_link_company RENAME TO IDX_D79DC3BA979B1AD6');
-        $this->addSql('ALTER TABLE bot_links ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL');
-        $this->addSql('COMMENT ON COLUMN bot_links.updated_at IS \'(DC2Type:datetime_immutable)\'');
+        if ($schema->hasTable('bot_links') && !$schema->getTable('bot_links')->hasColumn('updated_at')) {
+            $this->addSql('ALTER TABLE bot_links ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL');
+        }
+
+        if ($schema->hasTable('bot_links') && $schema->getTable('bot_links')->hasColumn('updated_at')) {
+            $this->addSql('COMMENT ON COLUMN bot_links.updated_at IS \'(DC2Type:datetime_immutable)\'');
+        }
         $this->addSql('ALTER TABLE cash_transaction ALTER allocated_amount DROP DEFAULT');
         $this->addSql('ALTER INDEX idx_cashflow_categories_pl_category RENAME TO IDX_EAB5C38D98B34054');
         $this->addSql('ALTER TABLE document_operations DROP CONSTRAINT fk_doc_ops_project_direction');
         $this->addSql('ALTER TABLE document_operations ALTER project_direction_id DROP NOT NULL');
-        $this->addSql('ALTER INDEX idx_doc_oper_project_direction RENAME TO IDX_89D7F81E85D43DF4');
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_class WHERE relname = 'idx_doc_oper_project_direction') THEN ALTER INDEX idx_doc_oper_project_direction RENAME TO IDX_89D7F81E85D43DF4; END IF; END $$;");
         $this->addSql('ALTER TABLE documents ALTER project_direction_id DROP NOT NULL');
         $this->addSql('ALTER TABLE documents ALTER status TYPE VARCHAR(255)');
         $this->addSql('ALTER INDEX idx_documents_cash_transaction RENAME TO IDX_A2B07288435DB913');
-        $this->addSql('ALTER INDEX idx_documents_project_direction RENAME TO IDX_A2B0728885D43DF4');
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_class WHERE relname = 'idx_documents_project_direction') THEN ALTER INDEX idx_documents_project_direction RENAME TO IDX_A2B0728885D43DF4; END IF; END $$;");
         $this->addSql('ALTER TABLE finance_loan ALTER start_date TYPE DATE');
         $this->addSql('ALTER TABLE finance_loan ALTER end_date TYPE DATE');
         $this->addSql('COMMENT ON COLUMN finance_loan.start_date IS \'(DC2Type:date_immutable)\'');
@@ -59,11 +64,15 @@ final class Version20260115105426 extends AbstractMigration
         $this->addSql('ALTER TABLE finance_loan_payment_schedule ALTER due_date TYPE DATE');
         $this->addSql('COMMENT ON COLUMN finance_loan_payment_schedule.due_date IS \'(DC2Type:date_immutable)\'');
         $this->addSql('DROP INDEX idx_pl_daily_company_cat_date');
-        $this->addSql('ALTER TABLE telegram_bots DROP CONSTRAINT fk_dacd6ed979b1ad6');
-        $this->addSql('DROP INDEX idx_dacd6ed979b1ad6');
-        $this->addSql('ALTER TABLE telegram_bots ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL');
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_constraint WHERE lower(conname) = lower('fk_dacd6ed979b1ad6')) THEN ALTER TABLE telegram_bots DROP CONSTRAINT fk_dacd6ed979b1ad6; END IF; END $$;");
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_class WHERE relname = 'idx_dacd6ed979b1ad6') THEN DROP INDEX idx_dacd6ed979b1ad6; END IF; END $$;");
+        if ($schema->hasTable('telegram_bots') && !$schema->getTable('telegram_bots')->hasColumn('updated_at')) {
+            $this->addSql('ALTER TABLE telegram_bots ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL');
+        }
         $this->addSql('ALTER TABLE telegram_bots DROP company_id');
-        $this->addSql('COMMENT ON COLUMN telegram_bots.updated_at IS \'(DC2Type:datetime_immutable)\'');
+        if ($schema->hasTable('telegram_bots') && $schema->getTable('telegram_bots')->hasColumn('updated_at')) {
+            $this->addSql('COMMENT ON COLUMN telegram_bots.updated_at IS \'(DC2Type:datetime_immutable)\'');
+        }
         $this->addSql('ALTER INDEX idx_wb_report_detail_mappings_company RENAME TO IDX_C7426B75979B1AD6');
         $this->addSql('ALTER TABLE wildberries_rnp_daily ALTER orders_count_spp DROP DEFAULT');
         $this->addSql('ALTER TABLE wildberries_rnp_daily ALTER orders_sum_spp_minor DROP DEFAULT');
@@ -85,9 +94,9 @@ final class Version20260115105426 extends AbstractMigration
         $this->addSql('ALTER TABLE documents ALTER project_direction_id SET NOT NULL');
         $this->addSql('ALTER TABLE documents ALTER status TYPE VARCHAR(32)');
         $this->addSql('ALTER INDEX idx_a2b07288435db913 RENAME TO idx_documents_cash_transaction');
-        $this->addSql('ALTER INDEX idx_a2b0728885d43df4 RENAME TO idx_documents_project_direction');
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_class WHERE relname = 'idx_a2b0728885d43df4') THEN ALTER INDEX idx_a2b0728885d43df4 RENAME TO idx_documents_project_direction; END IF; END $$;");
         $this->addSql('ALTER TABLE document_operations ALTER project_direction_id SET NOT NULL');
-        $this->addSql('ALTER INDEX idx_89d7f81e85d43df4 RENAME TO idx_doc_oper_project_direction');
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_class WHERE relname = 'idx_89d7f81e85d43df4') THEN ALTER INDEX idx_89d7f81e85d43df4 RENAME TO idx_doc_oper_project_direction; END IF; END $$;");
         $this->addSql('CREATE INDEX idx_pl_daily_company_cat_date ON pl_daily_totals (company_id, pl_category_id, date, project_direction_id)');
         $this->addSql('ALTER TABLE wildberries_rnp_daily ALTER orders_count_spp SET DEFAULT 0');
         $this->addSql('ALTER TABLE wildberries_rnp_daily ALTER orders_sum_spp_minor SET DEFAULT 0');
@@ -114,7 +123,9 @@ final class Version20260115105426 extends AbstractMigration
         $this->addSql('ALTER TABLE "telegram_bots" DROP updated_at');
         $this->addSql('ALTER TABLE "telegram_bots" ADD CONSTRAINT fk_dacd6ed979b1ad6 FOREIGN KEY (company_id) REFERENCES companies (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
         $this->addSql('CREATE INDEX idx_dacd6ed979b1ad6 ON "telegram_bots" (company_id)');
-        $this->addSql('ALTER TABLE "bot_links" DROP updated_at');
+        if ($schema->hasTable('bot_links') && $schema->getTable('bot_links')->hasColumn('updated_at')) {
+            $this->addSql('ALTER TABLE "bot_links" DROP updated_at');
+        }
         $this->addSql('ALTER INDEX idx_eab5c38d98b34054 RENAME TO idx_cashflow_categories_pl_category');
         $this->addSql('ALTER TABLE finance_loan ALTER start_date TYPE DATE');
         $this->addSql('ALTER TABLE finance_loan ALTER end_date TYPE DATE');


### PR DESCRIPTION
### Motivation
- Prevent migration failures caused by already-existing columns, missing indexes, or duplicate constraints by making migration steps safe to re-run against existing schemas. 
- Avoid SQL errors like `Duplicate column` or `SQLSTATE[42704]` during `doctrine:migrations:migrate` on databases that diverge slightly from the generated migration assumptions.

### Description
- In `site/migrations/Version20260115105426.php` guard adding and commenting `bot_links.updated_at` and `telegram_bots.updated_at` with schema checks to skip when the column already exists. 
- Replace unconditional index/constraint renames and drops with guarded `DO $$ BEGIN IF EXISTS (...) THEN ... END IF; END $$;` blocks for index and constraint operations to avoid failing when those objects are absent. 
- In `site/migrations/Version20260101090000.php` make table creation conditional (`$schema->hasTable`), use `CREATE INDEX IF NOT EXISTS` for indexes, wrap foreign-key additions/drops in guarded `DO $$` blocks, and use `DROP TABLE IF EXISTS` in the down migration to make teardown safe.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968c914d01083239cca0bb0957e7927)