### PR TITLE
Make migrations idempotent: guard balance_categories, links, indexes, constraints and columns

### DIFF
--- a/site/migrations/Version20260101090000.php
+++ b/site/migrations/Version20260101090000.php
@@ -16,35 +16,45 @@ final class Version20260101090000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql("CREATE TABLE balance_categories (id UUID NOT NULL, company_id UUID NOT NULL, name VARCHAR(255) NOT NULL, code VARCHAR(64) DEFAULT NULL, type VARCHAR(32) NOT NULL, parent_id UUID DEFAULT NULL, level INT NOT NULL DEFAULT 1, sort_order INT NOT NULL DEFAULT 0, is_visible BOOLEAN NOT NULL DEFAULT true, PRIMARY KEY(id))");
-        $this->addSql("CREATE INDEX idx_balance_cat_company ON balance_categories (company_id)");
-        $this->addSql("CREATE INDEX idx_balance_cat_company_parent ON balance_categories (company_id, parent_id)");
-        $this->addSql("CREATE UNIQUE INDEX uniq_balance_cat_company_code ON balance_categories (company_id, code)");
-        $this->addSql("COMMENT ON COLUMN balance_categories.id IS '(DC2Type:guid)'");
-        $this->addSql("COMMENT ON COLUMN balance_categories.company_id IS '(DC2Type:guid)'");
-        $this->addSql("COMMENT ON COLUMN balance_categories.parent_id IS '(DC2Type:guid)'");
-        $this->addSql("ALTER TABLE balance_categories ADD CONSTRAINT FK_BALANCE_CATEGORIES_COMPANY FOREIGN KEY (company_id) REFERENCES companies (id) NOT DEFERRABLE INITIALLY IMMEDIATE");
-        $this->addSql("ALTER TABLE balance_categories ADD CONSTRAINT FK_BALANCE_CATEGORIES_PARENT FOREIGN KEY (parent_id) REFERENCES balance_categories (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE");
+        if (!$schema->hasTable('balance_categories')) {
+            $this->addSql("CREATE TABLE balance_categories (id UUID NOT NULL, company_id UUID NOT NULL, name VARCHAR(255) NOT NULL, code VARCHAR(64) DEFAULT NULL, type VARCHAR(32) NOT NULL, parent_id UUID DEFAULT NULL, level INT NOT NULL DEFAULT 1, sort_order INT NOT NULL DEFAULT 0, is_visible BOOLEAN NOT NULL DEFAULT true, PRIMARY KEY(id))");
+        }
 
-        $this->addSql("CREATE TABLE balance_category_links (id UUID NOT NULL, company_id UUID NOT NULL, category_id UUID NOT NULL, source_type VARCHAR(64) NOT NULL, source_id UUID DEFAULT NULL, sign INT NOT NULL DEFAULT 1, position INT NOT NULL DEFAULT 0, PRIMARY KEY(id))");
-        $this->addSql("CREATE INDEX idx_balance_link_company ON balance_category_links (company_id)");
-        $this->addSql("CREATE INDEX idx_balance_link_company_category ON balance_category_links (company_id, category_id)");
-        $this->addSql("CREATE UNIQUE INDEX uniq_balance_link ON balance_category_links (company_id, category_id, source_type, source_id)");
-        $this->addSql("COMMENT ON COLUMN balance_category_links.id IS '(DC2Type:guid)'");
-        $this->addSql("COMMENT ON COLUMN balance_category_links.company_id IS '(DC2Type:guid)'");
-        $this->addSql("COMMENT ON COLUMN balance_category_links.category_id IS '(DC2Type:guid)'");
-        $this->addSql("COMMENT ON COLUMN balance_category_links.source_id IS '(DC2Type:guid)'");
-        $this->addSql("ALTER TABLE balance_category_links ADD CONSTRAINT FK_BALANCE_LINK_COMPANY FOREIGN KEY (company_id) REFERENCES companies (id) NOT DEFERRABLE INITIALLY IMMEDIATE");
-        $this->addSql("ALTER TABLE balance_category_links ADD CONSTRAINT FK_BALANCE_LINK_CATEGORY FOREIGN KEY (category_id) REFERENCES balance_categories (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE");
+        if ($schema->hasTable('balance_categories')) {
+            $this->addSql("CREATE INDEX IF NOT EXISTS idx_balance_cat_company ON balance_categories (company_id)");
+            $this->addSql("CREATE INDEX IF NOT EXISTS idx_balance_cat_company_parent ON balance_categories (company_id, parent_id)");
+            $this->addSql("CREATE UNIQUE INDEX IF NOT EXISTS uniq_balance_cat_company_code ON balance_categories (company_id, code)");
+            $this->addSql("COMMENT ON COLUMN balance_categories.id IS '(DC2Type:guid)'");
+            $this->addSql("COMMENT ON COLUMN balance_categories.company_id IS '(DC2Type:guid)'");
+            $this->addSql("COMMENT ON COLUMN balance_categories.parent_id IS '(DC2Type:guid)'");
+            $this->addSql("DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE lower(conname) = lower('FK_BALANCE_CATEGORIES_COMPANY')) THEN ALTER TABLE balance_categories ADD CONSTRAINT FK_BALANCE_CATEGORIES_COMPANY FOREIGN KEY (company_id) REFERENCES companies (id) NOT DEFERRABLE INITIALLY IMMEDIATE; END IF; END $$;");
+            $this->addSql("DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE lower(conname) = lower('FK_BALANCE_CATEGORIES_PARENT')) THEN ALTER TABLE balance_categories ADD CONSTRAINT FK_BALANCE_CATEGORIES_PARENT FOREIGN KEY (parent_id) REFERENCES balance_categories (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE; END IF; END $$;");
+        }
+
+        if (!$schema->hasTable('balance_category_links')) {
+            $this->addSql("CREATE TABLE balance_category_links (id UUID NOT NULL, company_id UUID NOT NULL, category_id UUID NOT NULL, source_type VARCHAR(64) NOT NULL, source_id UUID DEFAULT NULL, sign INT NOT NULL DEFAULT 1, position INT NOT NULL DEFAULT 0, PRIMARY KEY(id))");
+        }
+
+        if ($schema->hasTable('balance_category_links')) {
+            $this->addSql("CREATE INDEX IF NOT EXISTS idx_balance_link_company ON balance_category_links (company_id)");
+            $this->addSql("CREATE INDEX IF NOT EXISTS idx_balance_link_company_category ON balance_category_links (company_id, category_id)");
+            $this->addSql("CREATE UNIQUE INDEX IF NOT EXISTS uniq_balance_link ON balance_category_links (company_id, category_id, source_type, source_id)");
+            $this->addSql("COMMENT ON COLUMN balance_category_links.id IS '(DC2Type:guid)'");
+            $this->addSql("COMMENT ON COLUMN balance_category_links.company_id IS '(DC2Type:guid)'");
+            $this->addSql("COMMENT ON COLUMN balance_category_links.category_id IS '(DC2Type:guid)'");
+            $this->addSql("COMMENT ON COLUMN balance_category_links.source_id IS '(DC2Type:guid)'");
+            $this->addSql("DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE lower(conname) = lower('FK_BALANCE_LINK_COMPANY')) THEN ALTER TABLE balance_category_links ADD CONSTRAINT FK_BALANCE_LINK_COMPANY FOREIGN KEY (company_id) REFERENCES companies (id) NOT DEFERRABLE INITIALLY IMMEDIATE; END IF; END $$;");
+            $this->addSql("DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE lower(conname) = lower('FK_BALANCE_LINK_CATEGORY')) THEN ALTER TABLE balance_category_links ADD CONSTRAINT FK_BALANCE_LINK_CATEGORY FOREIGN KEY (category_id) REFERENCES balance_categories (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE; END IF; END $$;");
+        }
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE balance_category_links DROP CONSTRAINT FK_BALANCE_LINK_CATEGORY');
-        $this->addSql('ALTER TABLE balance_category_links DROP CONSTRAINT FK_BALANCE_LINK_COMPANY');
-        $this->addSql('ALTER TABLE balance_categories DROP CONSTRAINT FK_BALANCE_CATEGORIES_COMPANY');
-        $this->addSql('ALTER TABLE balance_categories DROP CONSTRAINT FK_BALANCE_CATEGORIES_PARENT');
-        $this->addSql('DROP TABLE balance_category_links');
-        $this->addSql('DROP TABLE balance_categories');
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_constraint WHERE lower(conname) = lower('FK_BALANCE_LINK_CATEGORY')) THEN ALTER TABLE balance_category_links DROP CONSTRAINT FK_BALANCE_LINK_CATEGORY; END IF; END $$;");
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_constraint WHERE lower(conname) = lower('FK_BALANCE_LINK_COMPANY')) THEN ALTER TABLE balance_category_links DROP CONSTRAINT FK_BALANCE_LINK_COMPANY; END IF; END $$;");
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_constraint WHERE lower(conname) = lower('FK_BALANCE_CATEGORIES_COMPANY')) THEN ALTER TABLE balance_categories DROP CONSTRAINT FK_BALANCE_CATEGORIES_COMPANY; END IF; END $$;");
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_constraint WHERE lower(conname) = lower('FK_BALANCE_CATEGORIES_PARENT')) THEN ALTER TABLE balance_categories DROP CONSTRAINT FK_BALANCE_CATEGORIES_PARENT; END IF; END $$;");
+        $this->addSql('DROP TABLE IF EXISTS balance_category_links');
+        $this->addSql('DROP TABLE IF EXISTS balance_categories');
     }
 }

--- a/site/migrations/Version20260115105426.php
+++ b/site/migrations/Version20260115105426.php
@@ -31,7 +31,7 @@ final class Version20260115105426 extends AbstractMigration
         $this->addSql('COMMENT ON COLUMN cash_bank_import_cursor.updated_at IS \'(DC2Type:datetime_immutable)\'');
         $this->addSql('ALTER TABLE cash_bank_connection ADD CONSTRAINT FK_B43A74ED979B1AD6 FOREIGN KEY (company_id) REFERENCES "companies" (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
         $this->addSql('ALTER TABLE cash_bank_import_cursor ADD CONSTRAINT FK_FEBA0CA0979B1AD6 FOREIGN KEY (company_id) REFERENCES "companies" (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
-        $this->addSql('ALTER TABLE balance_categories DROP CONSTRAINT fk_balance_categories_parent');
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_constraint WHERE lower(conname) = lower('fk_balance_categories_parent')) THEN ALTER TABLE balance_categories DROP CONSTRAINT fk_balance_categories_parent; END IF; END $$;");
         $this->addSql('DROP INDEX idx_balance_cat_company_parent');
         $this->addSql('DROP INDEX uniq_balance_cat_company_code');
         $this->addSql('ALTER TABLE balance_categories ALTER type TYPE VARCHAR(255)');
@@ -41,17 +41,22 @@ final class Version20260115105426 extends AbstractMigration
         $this->addSql('DROP INDEX uniq_balance_link');
         $this->addSql('ALTER TABLE balance_category_links ALTER source_type TYPE VARCHAR(255)');
         $this->addSql('ALTER INDEX idx_balance_link_company RENAME TO IDX_D79DC3BA979B1AD6');
-        $this->addSql('ALTER TABLE bot_links ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL');
-        $this->addSql('COMMENT ON COLUMN bot_links.updated_at IS \'(DC2Type:datetime_immutable)\'');
+        if ($schema->hasTable('bot_links') && !$schema->getTable('bot_links')->hasColumn('updated_at')) {
+            $this->addSql('ALTER TABLE bot_links ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL');
+        }
+
+        if ($schema->hasTable('bot_links') && $schema->getTable('bot_links')->hasColumn('updated_at')) {
+            $this->addSql('COMMENT ON COLUMN bot_links.updated_at IS \'(DC2Type:datetime_immutable)\'');
+        }
         $this->addSql('ALTER TABLE cash_transaction ALTER allocated_amount DROP DEFAULT');
         $this->addSql('ALTER INDEX idx_cashflow_categories_pl_category RENAME TO IDX_EAB5C38D98B34054');
         $this->addSql('ALTER TABLE document_operations DROP CONSTRAINT fk_doc_ops_project_direction');
         $this->addSql('ALTER TABLE document_operations ALTER project_direction_id DROP NOT NULL');
-        $this->addSql('ALTER INDEX idx_doc_oper_project_direction RENAME TO IDX_89D7F81E85D43DF4');
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_class WHERE relname = 'idx_doc_oper_project_direction') THEN ALTER INDEX idx_doc_oper_project_direction RENAME TO IDX_89D7F81E85D43DF4; END IF; END $$;");
         $this->addSql('ALTER TABLE documents ALTER project_direction_id DROP NOT NULL');
         $this->addSql('ALTER TABLE documents ALTER status TYPE VARCHAR(255)');
         $this->addSql('ALTER INDEX idx_documents_cash_transaction RENAME TO IDX_A2B07288435DB913');
-        $this->addSql('ALTER INDEX idx_documents_project_direction RENAME TO IDX_A2B0728885D43DF4');
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_class WHERE relname = 'idx_documents_project_direction') THEN ALTER INDEX idx_documents_project_direction RENAME TO IDX_A2B0728885D43DF4; END IF; END $$;");
         $this->addSql('ALTER TABLE finance_loan ALTER start_date TYPE DATE');
         $this->addSql('ALTER TABLE finance_loan ALTER end_date TYPE DATE');
         $this->addSql('COMMENT ON COLUMN finance_loan.start_date IS \'(DC2Type:date_immutable)\'');
@@ -59,11 +64,17 @@ final class Version20260115105426 extends AbstractMigration
         $this->addSql('ALTER TABLE finance_loan_payment_schedule ALTER due_date TYPE DATE');
         $this->addSql('COMMENT ON COLUMN finance_loan_payment_schedule.due_date IS \'(DC2Type:date_immutable)\'');
         $this->addSql('DROP INDEX idx_pl_daily_company_cat_date');
-        $this->addSql('ALTER TABLE telegram_bots DROP CONSTRAINT fk_dacd6ed979b1ad6');
-        $this->addSql('DROP INDEX idx_dacd6ed979b1ad6');
-        $this->addSql('ALTER TABLE telegram_bots ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL');
-        $this->addSql('ALTER TABLE telegram_bots DROP company_id');
-        $this->addSql('COMMENT ON COLUMN telegram_bots.updated_at IS \'(DC2Type:datetime_immutable)\'');
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_constraint WHERE lower(conname) = lower('fk_dacd6ed979b1ad6')) THEN ALTER TABLE telegram_bots DROP CONSTRAINT fk_dacd6ed979b1ad6; END IF; END $$;");
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_class WHERE relname = 'idx_dacd6ed979b1ad6') THEN DROP INDEX idx_dacd6ed979b1ad6; END IF; END $$;");
+        if ($schema->hasTable('telegram_bots') && !$schema->getTable('telegram_bots')->hasColumn('updated_at')) {
+            $this->addSql('ALTER TABLE telegram_bots ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL');
+        }
+        if ($schema->hasTable('telegram_bots') && $schema->getTable('telegram_bots')->hasColumn('company_id')) {
+            $this->addSql('ALTER TABLE telegram_bots DROP company_id');
+        }
+        if ($schema->hasTable('telegram_bots') && $schema->getTable('telegram_bots')->hasColumn('updated_at')) {
+            $this->addSql('COMMENT ON COLUMN telegram_bots.updated_at IS \'(DC2Type:datetime_immutable)\'');
+        }
         $this->addSql('ALTER INDEX idx_wb_report_detail_mappings_company RENAME TO IDX_C7426B75979B1AD6');
         $this->addSql('ALTER TABLE wildberries_rnp_daily ALTER orders_count_spp DROP DEFAULT');
         $this->addSql('ALTER TABLE wildberries_rnp_daily ALTER orders_sum_spp_minor DROP DEFAULT');
@@ -85,9 +96,9 @@ final class Version20260115105426 extends AbstractMigration
         $this->addSql('ALTER TABLE documents ALTER project_direction_id SET NOT NULL');
         $this->addSql('ALTER TABLE documents ALTER status TYPE VARCHAR(32)');
         $this->addSql('ALTER INDEX idx_a2b07288435db913 RENAME TO idx_documents_cash_transaction');
-        $this->addSql('ALTER INDEX idx_a2b0728885d43df4 RENAME TO idx_documents_project_direction');
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_class WHERE relname = 'idx_a2b0728885d43df4') THEN ALTER INDEX idx_a2b0728885d43df4 RENAME TO idx_documents_project_direction; END IF; END $$;");
         $this->addSql('ALTER TABLE document_operations ALTER project_direction_id SET NOT NULL');
-        $this->addSql('ALTER INDEX idx_89d7f81e85d43df4 RENAME TO idx_doc_oper_project_direction');
+        $this->addSql("DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_class WHERE relname = 'idx_89d7f81e85d43df4') THEN ALTER INDEX idx_89d7f81e85d43df4 RENAME TO idx_doc_oper_project_direction; END IF; END $$;");
         $this->addSql('CREATE INDEX idx_pl_daily_company_cat_date ON pl_daily_totals (company_id, pl_category_id, date, project_direction_id)');
         $this->addSql('ALTER TABLE wildberries_rnp_daily ALTER orders_count_spp SET DEFAULT 0');
         $this->addSql('ALTER TABLE wildberries_rnp_daily ALTER orders_sum_spp_minor SET DEFAULT 0');
@@ -114,7 +125,9 @@ final class Version20260115105426 extends AbstractMigration
         $this->addSql('ALTER TABLE "telegram_bots" DROP updated_at');
         $this->addSql('ALTER TABLE "telegram_bots" ADD CONSTRAINT fk_dacd6ed979b1ad6 FOREIGN KEY (company_id) REFERENCES companies (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
         $this->addSql('CREATE INDEX idx_dacd6ed979b1ad6 ON "telegram_bots" (company_id)');
-        $this->addSql('ALTER TABLE "bot_links" DROP updated_at');
+        if ($schema->hasTable('bot_links') && $schema->getTable('bot_links')->hasColumn('updated_at')) {
+            $this->addSql('ALTER TABLE "bot_links" DROP updated_at');
+        }
         $this->addSql('ALTER INDEX idx_eab5c38d98b34054 RENAME TO idx_cashflow_categories_pl_category');
         $this->addSql('ALTER TABLE finance_loan ALTER start_date TYPE DATE');
         $this->addSql('ALTER TABLE finance_loan ALTER end_date TYPE DATE');


### PR DESCRIPTION
### Motivation
- Prevent `doctrine:migrations:migrate` failures caused by DDL being re-applied against databases that already contain the same tables/indexes/columns/constraints. 
- Handle observed errors such as `Duplicate table/column`, `Undefined object/column`, and duplicate constraint/index errors when migrations are re-run or DB schema diverged.
- Ensure newly generated migrations can be executed in order without breaking the logic of Symfony/Doctrine migration filenames.

### Description
- Added existence guards in `site/migrations/Version20260101090000.php` so `balance_categories` and `balance_category_links` are only created when missing by checking `$schema->hasTable`, use `CREATE INDEX IF NOT EXISTS` for indexes, wrap FK additions in `DO $$ ... END $$;` blocks that check `pg_constraint` (case-insensitive), and use `DROP TABLE IF EXISTS` in `down`.
- Added multiple guards in `site/migrations/Version20260115105426.php`: replaced unconditional `DROP CONSTRAINT fk_balance_categories_parent` with a `DO $$` check, wrapped index renames in `DO $$` checks against `pg_class`, guarded adding/commenting `bot_links.updated_at` and `telegram_bots.updated_at` with `$schema->hasTable`/`hasColumn`, guarded dropping `telegram_bots.company_id` only when the column exists, and protected constraint/index drops for `telegram_bots` using `pg_constraint`/`pg_class` checks.
- Converted several unconditional DDL operations (index renames, constraint drops, column adds/drops) into idempotent operations so migrations skip steps when the target object is already absent or present.

### Testing
- No automated tests were run for these changes (`not run`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968c914d01083239cca0bb0957e7927)