### PR TITLE
Show project direction hierarchy and disable parent nodes in forms

### DIFF
--- a/site/src/Cash/Form/Transaction/CashTransactionAutoRuleType.php
+++ b/site/src/Cash/Form/Transaction/CashTransactionAutoRuleType.php
@@ -61,7 +61,10 @@ class CashTransactionAutoRuleType extends AbstractType
             ->add('projectDirection', EntityType::class, [
                 'class' => ProjectDirection::class,
                 'choices' => $options['projectDirections'],
-                'choice_label' => fn (ProjectDirection $item) => $item->getName(),
+                'choice_label' => function (ProjectDirection $item) {
+                    return str_repeat('—', $item->getLevel() - 1).' '.$item->getName();
+                },
+                'choice_attr' => fn (ProjectDirection $item) => $item->getChildren()->count() > 0 ? ['disabled' => 'disabled'] : [],
                 'placeholder' => 'Не выбрано',
                 'required' => false,
                 'label' => 'Направление / проект',

--- a/site/src/Cash/Form/Transaction/CashTransactionType.php
+++ b/site/src/Cash/Form/Transaction/CashTransactionType.php
@@ -65,9 +65,10 @@ class CashTransactionType extends AbstractType
             ])
             ->add('projectDirection', ChoiceType::class, [
                 'required' => false,
-                'choices' => $company ? $this->projectDirectionRepo->findBy(['company' => $company], ['name' => 'ASC']) : [],
-                'choice_label' => fn (ProjectDirection $projectDirection) => $projectDirection->getName(),
+                'choices' => $company ? $this->projectDirectionRepo->findTreeByCompany($company) : [],
+                'choice_label' => fn (ProjectDirection $projectDirection) => str_repeat("\u{a0}", $projectDirection->getLevel() - 1).$projectDirection->getName(),
                 'choice_value' => 'id',
+                'choice_attr' => fn (ProjectDirection $projectDirection) => $projectDirection->getChildren()->count() > 0 ? ['disabled' => 'disabled'] : [],
                 'mapped' => false,
             ])
             ->add('counterparty', ChoiceType::class, [

--- a/site/src/Form/DocumentOperationType.php
+++ b/site/src/Form/DocumentOperationType.php
@@ -44,7 +44,10 @@ class DocumentOperationType extends AbstractType
             ->add('projectDirection', EntityType::class, [
                 'class' => ProjectDirection::class,
                 'choices' => $options['project_directions'],
-                'choice_label' => 'name',
+                'choice_label' => function (ProjectDirection $item) {
+                    return str_repeat('—', $item->getLevel() - 1).' '.$item->getName();
+                },
+                'choice_attr' => fn (ProjectDirection $item) => $item->getChildren()->count() > 0 ? ['disabled' => 'disabled'] : [],
                 'required' => false,
                 'label' => 'Проект',
                 'attr' => [

--- a/site/src/Form/DocumentType.php
+++ b/site/src/Form/DocumentType.php
@@ -50,7 +50,10 @@ class DocumentType extends AbstractType
             ->add('projectDirection', EntityType::class, [
                 'class' => ProjectDirection::class,
                 'choices' => $options['project_directions'],
-                'choice_label' => 'name',
+                'choice_label' => function (ProjectDirection $item) {
+                    return str_repeat('—', $item->getLevel() - 1).' '.$item->getName();
+                },
+                'choice_attr' => fn (ProjectDirection $item) => $item->getChildren()->count() > 0 ? ['disabled' => 'disabled'] : [],
                 'placeholder' => '—',
                 'required' => false,
                 'label' => 'Проект',


### PR DESCRIPTION
### Motivation
- Project selectors should display hierarchical project structure with indentation so users can see nesting.
- Parent nodes (folders) must be unselectable to prevent choosing non-leaf project groups.

### Description
- In `site/src/Cash/Form/Transaction/CashTransactionType.php` the `projectDirection` field now uses `findTreeByCompany($company)`, indents labels with `str_repeat("\u{a0}", $projectDirection->getLevel() - 1)` and adds `choice_attr` to disable items that have children.
- In `site/src/Form/DocumentType.php` and `site/src/Form/DocumentOperationType.php` the `projectDirection` selectors now indent labels with `str_repeat('—', $item->getLevel() - 1)` and add `choice_attr` to disable nodes with children.
- In `site/src/Cash/Form/Transaction/CashTransactionAutoRuleType.php` the `projectDirection` field was updated to indent labels and disable parent nodes using the same logic as above.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e1fbc07e88323a0b5950429b991bf)