### PR TITLE
Add reusable ProjectDirection picker widget (Form Type, Twig theme, JS/CSS)

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1,2 +1,3 @@
 import './styles/app.css';
 import './react/dashboard_started.js';
+import './project_direction_picker.js';

--- a/site/assets/project_direction_picker.js
+++ b/site/assets/project_direction_picker.js
@@ -1,0 +1,224 @@
+function qs(root, sel) { return root.querySelector(sel); }
+function qsa(root, sel) { return Array.from(root.querySelectorAll(sel)); }
+
+function getBootstrap() {
+    // Tabler обычно включает Bootstrap bundle; если нет — graceful fallback
+    return window.bootstrap || null;
+}
+
+function initOnePicker(picker) {
+    if (picker.dataset.pdInited === '1') return;
+    picker.dataset.pdInited = '1';
+
+    const fieldId = picker.getAttribute('data-pd-field-id');
+    const select = qs(picker, `#${CSS.escape(fieldId)}`);
+    const display = qs(picker, '[data-pd-display]');
+    const clearBtn = qs(picker, '[data-pd-clear]');
+    const modal = picker.querySelector('.modal');
+    const selectedLabelEl = qs(modal, '[data-pd-selected-label]');
+    const search = qs(modal, '[data-pd-search]');
+    const expandAllBtn = qs(modal, '[data-pd-expand-all]');
+    const collapseAllBtn = qs(modal, '[data-pd-collapse-all]');
+
+    if (!select || !display || !modal) return;
+
+    const bs = getBootstrap();
+
+    function setValue(id, label) {
+        select.value = id || '';
+        select.dispatchEvent(new Event('change', { bubbles: true }));
+
+        display.value = label || '';
+        if (selectedLabelEl) selectedLabelEl.textContent = label || '—';
+
+        if (clearBtn) clearBtn.disabled = !id;
+    }
+
+    // sync from select -> display (important for existing code that sets select.value)
+    function syncFromSelect() {
+        const opt = select.options[select.selectedIndex];
+        const label = opt ? (opt.textContent || '').trim() : '';
+        // label в select может быть с отступами, поэтому берём без них, если есть data-label в дереве — но тут ок
+        display.value = label.replace(/^[\u00A0—\s]+/, '');
+        if (selectedLabelEl) selectedLabelEl.textContent = display.value || '—';
+        if (clearBtn) clearBtn.disabled = !select.value;
+        highlightSelected(select.value);
+    }
+
+    // highlight in tree
+    function highlightSelected(id) {
+        qsa(modal, '[data-pd-select]').forEach((btn) => {
+            btn.classList.remove('pd-selected');
+            btn.closest('.pd-row')?.classList.remove('pd-row-selected');
+        });
+
+        if (!id) return;
+
+        const btn = modal.querySelector(`[data-pd-select][data-id="${CSS.escape(id)}"]`);
+        if (btn) {
+            btn.classList.add('pd-selected');
+            btn.closest('.pd-row')?.classList.add('pd-row-selected');
+
+            // ensure parents expanded
+            let parent = btn.closest('.pd-node');
+            while (parent) {
+                const children = parent.querySelector(':scope > .pd-children');
+                if (children) {
+                    if (bs && bs.Collapse) {
+                        const inst = bs.Collapse.getOrCreateInstance(children, { toggle: false });
+                        inst.show();
+                    } else {
+                        children.classList.add('show');
+                    }
+                    const toggle = parent.querySelector(':scope .pd-toggle i');
+                    if (toggle) toggle.className = 'ti ti-chevron-down';
+                }
+                parent = parent.parentElement?.closest('.pd-node');
+            }
+        }
+    }
+
+    // toggle children
+    qsa(modal, '[data-pd-toggle]').forEach((btn) => {
+        btn.addEventListener('click', () => {
+            const targetSel = btn.getAttribute('data-target');
+            const target = targetSel ? modal.querySelector(targetSel) : null;
+            if (!target) return;
+
+            const icon = btn.querySelector('i');
+
+            if (bs && bs.Collapse) {
+                const inst = bs.Collapse.getOrCreateInstance(target, { toggle: false });
+                const isShown = target.classList.contains('show');
+                if (isShown) inst.hide(); else inst.show();
+                if (icon) icon.className = isShown ? 'ti ti-chevron-right' : 'ti ti-chevron-down';
+            } else {
+                const isShown = target.classList.contains('show');
+                target.classList.toggle('show', !isShown);
+                if (icon) icon.className = isShown ? 'ti ti-chevron-right' : 'ti ti-chevron-down';
+            }
+        });
+    });
+
+    // select node (only leaves)
+    qsa(modal, '[data-pd-select]').forEach((btn) => {
+        btn.addEventListener('click', () => {
+            const disabled = btn.getAttribute('data-disabled') === '1';
+            if (disabled) return;
+
+            const id = btn.getAttribute('data-id');
+            const label = btn.getAttribute('data-label') || btn.textContent.trim();
+            setValue(id, label);
+
+            if (bs && bs.Modal) {
+                const inst = bs.Modal.getOrCreateInstance(modal);
+                inst.hide();
+            } else {
+                modal.classList.remove('show');
+            }
+        });
+    });
+
+    // clear
+    if (clearBtn) {
+        clearBtn.addEventListener('click', () => setValue('', ''));
+    }
+
+    // expand/collapse all
+    function showOne(el) {
+        if (bs && bs.Collapse) {
+            const inst = bs.Collapse.getOrCreateInstance(el, { toggle: false });
+            inst.show();
+        } else {
+            el.classList.add('show');
+        }
+    }
+    function hideOne(el) {
+        if (bs && bs.Collapse) {
+            const inst = bs.Collapse.getOrCreateInstance(el, { toggle: false });
+            inst.hide();
+        } else {
+            el.classList.remove('show');
+        }
+    }
+
+    if (expandAllBtn) {
+        expandAllBtn.addEventListener('click', () => {
+            qsa(modal, '.pd-children').forEach(showOne);
+            qsa(modal, '.pd-toggle i').forEach((i) => { i.className = 'ti ti-chevron-down'; });
+        });
+    }
+    if (collapseAllBtn) {
+        collapseAllBtn.addEventListener('click', () => {
+            qsa(modal, '.pd-children').forEach(hideOne);
+            qsa(modal, '.pd-toggle i').forEach((i) => { i.className = 'ti ti-chevron-right'; });
+        });
+    }
+
+    // search (simple: hide nodes not matching, keep parents if any child matches)
+    function applySearch(query) {
+        const q = (query || '').trim().toLowerCase();
+        const nodes = qsa(modal, '[data-pd-node]');
+
+        if (!q) {
+            nodes.forEach((n) => n.classList.remove('d-none'));
+            return;
+        }
+
+        // mark matches
+        nodes.forEach((n) => {
+            const btn = n.querySelector('[data-pd-select]');
+            const label = (btn?.getAttribute('data-label') || btn?.textContent || '').toLowerCase();
+            const isMatch = label.includes(q);
+            n.classList.toggle('pd-match', isMatch);
+        });
+
+        // show node if match or has matching descendant
+        function hasMatchingDesc(node) {
+            if (node.classList.contains('pd-match')) return true;
+            const children = node.querySelectorAll(':scope > .pd-children > .pd-node');
+            for (const c of children) {
+                if (hasMatchingDesc(c)) return true;
+            }
+            return false;
+        }
+
+        nodes.forEach((n) => {
+            n.classList.toggle('d-none', !hasMatchingDesc(n));
+        });
+    }
+
+    if (search) {
+        search.addEventListener('input', () => applySearch(search.value));
+    }
+
+    // keep sync when select changes externally (document scripts)
+    select.addEventListener('change', syncFromSelect);
+    syncFromSelect();
+}
+
+export function initProjectDirectionPickers(root = document) {
+    qsa(root, '[data-pd-picker]').forEach(initOnePicker);
+}
+
+// init on DOM ready + on Turbo navigations + after dynamic inserts (MutationObserver)
+function boot() {
+    initProjectDirectionPickers(document);
+
+    const obs = new MutationObserver((mutations) => {
+        for (const m of mutations) {
+            m.addedNodes.forEach((n) => {
+                if (!(n instanceof HTMLElement)) return;
+                if (n.matches?.('[data-pd-picker]')) initOnePicker(n);
+                initProjectDirectionPickers(n);
+            });
+        }
+    });
+    obs.observe(document.body, { childList: true, subtree: true });
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', boot);
+} else {
+    boot();
+}

--- a/site/assets/styles/app.css
+++ b/site/assets/styles/app.css
@@ -107,3 +107,29 @@ body {
 .modal.modal-blur .modal-footer {
     color: inherit;
 }
+
+/* ProjectDirection Picker (Tabler) */
+.pd-tree-wrap {
+    max-height: 340px;            /* фиксированная высота области дерева */
+    overflow: auto;               /* скролл внутри */
+    border: 1px solid var(--tblr-border-color, #d9e2ef);
+    border-radius: .5rem;
+    padding: .25rem;
+    background: var(--tblr-bg-surface, #fff);
+}
+
+.pd-node { padding-left: .25rem; }
+.pd-row { padding: .15rem .35rem; border-radius: .35rem; }
+.pd-row:hover { background: rgba(10,21,72,.05); }
+
+.pd-kind { width: 18px; display: inline-flex; justify-content: center; }
+.pd-spacer { width: 32px; display: inline-block; }
+
+.pd-toggle.btn { height: 24px; width: 24px; padding: 0; }
+
+.pd-name { font-size: .875rem; line-height: 1.15rem; }
+
+.pd-row-selected { background: rgba(10,21,72,.08); }
+.pd-selected { font-weight: 600; }
+
+.pd-children { margin-left: 14px; border-left: 1px dashed rgba(10,21,72,.15); padding-left: 10px; }

--- a/site/config/packages/twig.yaml
+++ b/site/config/packages/twig.yaml
@@ -1,6 +1,8 @@
 twig:
     default_path: '%kernel.project_dir%/templates'
-    form_themes: ['bootstrap_5_layout.html.twig']
+    form_themes:
+        - 'bootstrap_5_layout.html.twig'
+        - 'form/project_direction_picker_theme.html.twig'
     paths:
         '%kernel.project_dir%/templates/balance': Balance
         '%kernel.project_dir%/templates/loan': Loan

--- a/site/src/Cash/Form/Transaction/CashTransactionAutoRuleType.php
+++ b/site/src/Cash/Form/Transaction/CashTransactionAutoRuleType.php
@@ -8,6 +8,7 @@ use App\Cash\Enum\Transaction\CashTransactionAutoRuleAction;
 use App\Cash\Enum\Transaction\CashTransactionAutoRuleOperationType;
 use App\Entity\Counterparty;
 use App\Entity\ProjectDirection;
+use App\Form\Type\ProjectDirectionPickerType;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
@@ -58,7 +59,7 @@ class CashTransactionAutoRuleType extends AbstractType
                 },
                 'label' => 'Категория движения ДДС',
             ])
-            ->add('projectDirection', EntityType::class, [
+            ->add('projectDirection', ProjectDirectionPickerType::class, [
                 'class' => ProjectDirection::class,
                 'choices' => $options['projectDirections'],
                 'choice_label' => function (ProjectDirection $item) {

--- a/site/src/Cash/Form/Transaction/CashTransactionType.php
+++ b/site/src/Cash/Form/Transaction/CashTransactionType.php
@@ -10,6 +10,7 @@ use App\Cash\Repository\Transaction\CashflowCategoryRepository;
 use App\DTO\CashTransactionDTO;
 use App\Entity\Company;
 use App\Entity\ProjectDirection;
+use App\Form\Type\ProjectDirectionPickerType;
 use App\Repository\CounterpartyRepository;
 use App\Repository\ProjectDirectionRepository;
 use Symfony\Component\Form\AbstractType;
@@ -63,11 +64,10 @@ class CashTransactionType extends AbstractType
                 'choice_attr' => fn (CashflowCategory $c) => !$c->getChildren()->isEmpty() ? ['disabled' => 'disabled'] : [],
                 'mapped' => false,
             ])
-            ->add('projectDirection', ChoiceType::class, [
+            ->add('projectDirection', ProjectDirectionPickerType::class, [
                 'required' => false,
                 'choices' => $company ? $this->projectDirectionRepo->findTreeByCompany($company) : [],
                 'choice_label' => fn (ProjectDirection $projectDirection) => str_repeat("\u{a0}", $projectDirection->getLevel() - 1).$projectDirection->getName(),
-                'choice_value' => 'id',
                 'choice_attr' => fn (ProjectDirection $projectDirection) => !$projectDirection->getChildren()->isEmpty() ? ['disabled' => 'disabled'] : [],
                 'mapped' => false,
             ])

--- a/site/src/Form/DocumentOperationType.php
+++ b/site/src/Form/DocumentOperationType.php
@@ -6,6 +6,7 @@ use App\Entity\Counterparty;
 use App\Entity\DocumentOperation;
 use App\Entity\PLCategory;
 use App\Entity\ProjectDirection;
+use App\Form\Type\ProjectDirectionPickerType;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
@@ -41,7 +42,7 @@ class DocumentOperationType extends AbstractType
                     'data-operation-counterparty' => 'true',
                 ],
             ])
-            ->add('projectDirection', EntityType::class, [
+            ->add('projectDirection', ProjectDirectionPickerType::class, [
                 'class' => ProjectDirection::class,
                 'choices' => $options['project_directions'],
                 'choice_label' => function (ProjectDirection $item) {

--- a/site/src/Form/DocumentType.php
+++ b/site/src/Form/DocumentType.php
@@ -6,6 +6,7 @@ use App\Entity\Counterparty;
 use App\Entity\Document;
 use App\Entity\ProjectDirection;
 use App\Enum\DocumentType as DocumentTypeEnum;
+use App\Form\Type\ProjectDirectionPickerType;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -47,7 +48,7 @@ class DocumentType extends AbstractType
                     'data-document-counterparty' => 'true',
                 ],
             ])
-            ->add('projectDirection', EntityType::class, [
+            ->add('projectDirection', ProjectDirectionPickerType::class, [
                 'class' => ProjectDirection::class,
                 'choices' => $options['project_directions'],
                 'choice_label' => function (ProjectDirection $item) {

--- a/site/src/Form/Type/ProjectDirectionPickerType.php
+++ b/site/src/Form/Type/ProjectDirectionPickerType.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Form\Type;
+
+use App\Entity\ProjectDirection;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ProjectDirectionPickerType extends EntityType
+{
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        parent::configureOptions($resolver);
+
+        $resolver->setDefaults([
+            'class' => ProjectDirection::class,
+            'required' => false,
+        ]);
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'project_direction_picker';
+    }
+}

--- a/site/templates/form/project_direction_picker_theme.html.twig
+++ b/site/templates/form/project_direction_picker_theme.html.twig
@@ -1,0 +1,176 @@
+{# Reusable ProjectDirection picker widget (Tabler/Bootstrap 5) #}
+
+{% block project_direction_picker_widget %}
+    {# ---- helpers ---- #}
+    {% set fieldId = form.vars.id %}
+    {% set fieldName = form.vars.full_name %}
+    {% set currentValue = form.vars.value %}
+    {% set attr = form.vars.attr|default({}) %}
+    {% set attrClass = (attr.class|default('')) %}
+    {% set placeholder = form.vars.placeholder is defined ? form.vars.placeholder : null %}
+
+    {# find current label #}
+    {% set currentLabel = '' %}
+    {% for c in form.vars.choices %}
+        {% if c.value == currentValue %}
+            {% set currentLabel = c.data ? c.data.name : c.label %}
+        {% endif %}
+    {% endfor %}
+    {% if currentValue is empty %}
+        {% set currentLabel = '' %}
+    {% endif %}
+
+    {% set modalId = 'pd_modal__' ~ fieldId %}
+    {% set treeId = 'pd_tree__' ~ fieldId %}
+    {% set inputId = 'pd_input__' ~ fieldId %}
+    {% set searchId = 'pd_search__' ~ fieldId %}
+
+    <div class="pd-picker" data-pd-picker data-pd-field-id="{{ fieldId }}">
+        {# IMPORTANT: keep real <select> in DOM, but hidden (existing scripts rely on .value) #}
+        <select
+            id="{{ fieldId }}"
+            name="{{ fieldName }}"
+            class="form-select d-none {{ attrClass }}"
+            {% if form.vars.required %}required="required"{% endif %}
+            {% for k,v in attr %}{% if k != 'class' %}{{ k }}="{{ v }}"{% endif %}{% endfor %}
+        >
+            {% if placeholder is not empty %}
+                <option value="" {% if currentValue is empty %}selected="selected"{% endif %}>{{ placeholder }}</option>
+            {% endif %}
+
+            {% for choice in form.vars.choices %}
+                <option
+                    value="{{ choice.value }}"
+                    {% if choice.value == currentValue %}selected="selected"{% endif %}
+                    {% for ak,av in choice.attr %}{{ ak }}="{{ av }}"{% endfor %}
+                >
+                    {{ choice.label }}
+                </option>
+            {% endfor %}
+        </select>
+
+        {# Visible control (Tabler) #}
+        <div class="input-group">
+            <input
+                id="{{ inputId }}"
+                type="text"
+                class="form-control"
+                value="{{ currentLabel }}"
+                placeholder="Выберите проект"
+                readonly
+                data-pd-display
+            />
+            <button
+                class="btn btn-outline-secondary"
+                type="button"
+                data-bs-toggle="modal"
+                data-bs-target="#{{ modalId }}"
+                data-pd-open
+                aria-label="Открыть выбор проекта"
+            >
+                <i class="ti ti-folder"></i>
+            </button>
+            <button
+                class="btn btn-outline-secondary"
+                type="button"
+                data-pd-clear
+                aria-label="Очистить выбор"
+                {% if currentValue is empty %}disabled{% endif %}
+            >
+                <i class="ti ti-x"></i>
+            </button>
+        </div>
+
+        {# Modal with tree #}
+        <div class="modal modal-blur fade" id="{{ modalId }}" tabindex="-1" aria-hidden="true">
+            <div class="modal-dialog modal-lg modal-dialog-centered">
+                <div class="modal-content">
+
+                    <div class="modal-header">
+                        <div>
+                            <h5 class="modal-title">Выбор проекта</h5>
+                            <div class="text-muted small">Выбирайте только конечные элементы (листья)</div>
+                        </div>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Закрыть"></button>
+                    </div>
+
+                    <div class="modal-body">
+                        <div class="d-flex gap-2 align-items-center mb-3">
+                            <div class="flex-fill">
+                                <input id="{{ searchId }}" type="text" class="form-control" placeholder="Поиск..." data-pd-search />
+                            </div>
+                            <button type="button" class="btn btn-outline-secondary" data-pd-expand-all>
+                                <i class="ti ti-arrows-diagonal-2"></i> Развернуть
+                            </button>
+                            <button type="button" class="btn btn-outline-secondary" data-pd-collapse-all>
+                                <i class="ti ti-arrows-diagonal-minimize-2"></i> Свернуть
+                            </button>
+                        </div>
+
+                        <div class="pd-tree-wrap" data-pd-scroll>
+                            <div id="{{ treeId }}" class="pd-tree" role="tree" aria-label="Дерево проектов">
+                                {% set allChoices = form.vars.choices %}
+
+                                {% macro render_nodes(allChoices, parentId, fieldId, level) %}
+                                    {% for ch in allChoices %}
+                                        {% set entity = ch.data %}
+                                        {% if entity %}
+                                            {% set p = entity.parent %}
+                                            {% set pId = p ? p.id : '' %}
+                                            {% if (parentId is empty and p is null) or (parentId is not empty and pId == parentId) %}
+                                                {% set nodeId = ch.value %}
+                                                {% set safeNodeId = (fieldId ~ '__' ~ nodeId)|replace({'-':''}) %}
+                                                {% set hasChildren = (entity.children is not empty and (entity.children|length) > 0) %}
+                                                <div class="pd-node" data-pd-node data-id="{{ nodeId }}" data-level="{{ level }}" data-has-children="{{ hasChildren ? '1' : '0' }}">
+                                                    <div class="pd-row d-flex align-items-center gap-2" role="treeitem" aria-expanded="{{ hasChildren ? 'false' : 'true' }}">
+                                                        {% if hasChildren %}
+                                                            <button type="button" class="btn btn-sm btn-ghost-secondary pd-toggle" data-pd-toggle data-target="#pd_collapse_{{ safeNodeId }}" aria-label="Свернуть/развернуть">
+                                                                <i class="ti ti-chevron-right"></i>
+                                                            </button>
+                                                            <span class="text-muted pd-kind" title="Группа"><i class="ti ti-folder"></i></span>
+                                                        {% else %}
+                                                            <span class="pd-spacer"></span>
+                                                            <span class="text-muted pd-kind" title="Элемент"><i class="ti ti-file"></i></span>
+                                                        {% endif %}
+
+                                                        <button
+                                                            type="button"
+                                                            class="btn btn-link p-0 text-start pd-select"
+                                                            data-pd-select
+                                                            data-id="{{ nodeId }}"
+                                                            data-label="{{ entity.name }}"
+                                                            {% if hasChildren %}data-disabled="1"{% endif %}
+                                                            style="text-decoration:none"
+                                                        >
+                                                            <span class="pd-name">{{ entity.name }}</span>
+                                                        </button>
+                                                    </div>
+
+                                                    {% if hasChildren %}
+                                                        <div class="pd-children collapse" id="pd_collapse_{{ safeNodeId }}">
+                                                            {{ _self.render_nodes(allChoices, nodeId, fieldId, level + 1) }}
+                                                        </div>
+                                                    {% endif %}
+                                                </div>
+                                            {% endif %}
+                                        {% endif %}
+                                    {% endfor %}
+                                {% endmacro %}
+
+                                {{ _self.render_nodes(allChoices, '', fieldId, 1) }}
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="modal-footer">
+                        <div class="text-muted small me-auto">
+                            Выбрано: <span data-pd-selected-label>{{ currentLabel ?: '—' }}</span>
+                        </div>
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Закрыть</button>
+                    </div>
+
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
### Motivation
- Provide a reusable UI for selecting `ProjectDirection` as a collapsible tree with search, fixed-height scroll and leaf-only selection. 
- Keep the original `<select>` in the DOM so existing scripts that read or set `select.value` and listen for `change` continue to work. 
- Replace inline `EntityType`/`ChoiceType` usages for `projectDirection` with a single picker to standardize UX across forms.

### Description
- Added a new form type `App\Form\Type\ProjectDirectionPickerType` (`site/src/Form/Type/ProjectDirectionPickerType.php`) that extends `EntityType` and sets the `ProjectDirection` class by default. 
- Introduced a Twig form theme `templates/form/project_direction_picker_theme.html.twig` which renders a hidden `<select>` and a visible input + modal tree, and registered it in `site/config/packages/twig.yaml`. 
- Implemented picker behavior in `site/assets/project_direction_picker.js` (init, expand/collapse all, leaf selection, search, clear, and syncing to the hidden `select` with `change` dispatch) and imported it from `site/assets/app.js`. 
- Added minimal styles to `site/assets/styles/app.css` to enforce fixed tree height, scrolling and compact rows, and replaced `projectDirection` field types in `CashTransactionType`, `CashTransactionAutoRuleType`, `DocumentType`, and `DocumentOperationType` to use `ProjectDirectionPickerType` while preserving existing options. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e788cf18083238a377d6183f5f52e)