### PR TITLE
Call ImportLogger->fail() on exceptions and always finish cash:file imports

### DIFF
--- a/site/src/Cash/Service/Import/File/CashFileImportService.php
+++ b/site/src/Cash/Service/Import/File/CashFileImportService.php
@@ -208,6 +208,11 @@ final class CashFileImportService
                 }
                 $this->accountBalanceService->recalculateDailyRange($company, $moneyAccount, $createdMinDate, $toDate);
             }
+        } catch (\Throwable $exception) {
+            if ($importLog) {
+                $this->importLogger->fail($importLog);
+            }
+            throw $exception;
         } finally {
             if ($importLog) {
                 $this->importLogger->finish($importLog);


### PR DESCRIPTION
### Motivation
- Ensure import logs for `cash:file` always record an end time and are marked failed when an exception occurs so the "Окончание" column is populated and failure state is visible.

### Description
- Added a `catch (\Throwable $exception)` block in `site/src/Cash/Service/Import/File/CashFileImportService.php` that calls `ImportLogger->fail($importLog)` when an exception is thrown and then rethrows the exception.
- Kept the `ImportLogger->finish($importLog)` call in the `finally` block so `finish()` is executed on all exit paths, including when `created = 0`.
- No other behavioral changes were made to the import logic or batching.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971c5aced4483239c6851fec04fb96b)