### PR TITLE
Add WB commissioner XLSX format validator and integrate into upload flow

### DIFF
--- a/site/src/Marketplace/Wildberries/Controller/WildberriesCommissionerReportController.php
+++ b/site/src/Marketplace/Wildberries/Controller/WildberriesCommissionerReportController.php
@@ -6,6 +6,7 @@ namespace App\Marketplace\Wildberries\Controller;
 
 use App\Marketplace\Wildberries\Entity\WildberriesCommissionerXlsxReport;
 use App\Marketplace\Wildberries\Form\WildberriesCommissionerReportUploadType;
+use App\Marketplace\Wildberries\Service\CommissionerReport\WbCommissionerXlsxFormatValidator;
 use App\Service\ActiveCompanyService;
 use App\Service\Storage\StorageService;
 use Doctrine\Persistence\ManagerRegistry;
@@ -23,6 +24,7 @@ final class WildberriesCommissionerReportController extends AbstractController
         private readonly ManagerRegistry $doctrine,
         private readonly ActiveCompanyService $companyContext,
         private readonly StorageService $storageService,
+        private readonly WbCommissionerXlsxFormatValidator $formatValidator,
     ) {
     }
 
@@ -58,6 +60,9 @@ final class WildberriesCommissionerReportController extends AbstractController
                 );
 
                 $stored = $this->storageService->storeUploadedFile($file, $storagePath);
+                $validationResult = $this->formatValidator->validate(
+                    $this->storageService->getAbsolutePath($stored['storagePath'])
+                );
 
                 $report = new WildberriesCommissionerXlsxReport($reportId, $company, new \DateTimeImmutable());
                 $report->setPeriodStart($data['periodStart']);
@@ -65,7 +70,16 @@ final class WildberriesCommissionerReportController extends AbstractController
                 $report->setStoragePath($stored['storagePath']);
                 $report->setFileHash($stored['fileHash']);
                 $report->setOriginalFilename($stored['originalFilename']);
+                $report->setHeadersHash($validationResult->headersHash);
+                $report->setFormatStatus($validationResult->status);
+                $report->setWarningsJson([] !== $validationResult->warnings ? $validationResult->warnings : null);
+                $report->setErrorsJson([] !== $validationResult->errors ? $validationResult->errors : null);
+                $report->setWarningsCount(count($validationResult->warnings));
+                $report->setErrorsCount(count($validationResult->errors));
                 $report->setStatus('uploaded');
+                if ('failed_format' === $validationResult->status) {
+                    $report->setStatus('failed');
+                }
 
                 $em = $this->doctrine->getManager();
                 $em->persist($report);

--- a/site/src/Marketplace/Wildberries/Service/CommissionerReport/Dto/ValidationResultDTO.php
+++ b/site/src/Marketplace/Wildberries/Service/CommissionerReport/Dto/ValidationResultDTO.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Wildberries\Service\CommissionerReport\Dto;
+
+final readonly class ValidationResultDTO
+{
+    /**
+     * @param list<string|null> $headersNormalized
+     * @param list<string> $requiredMissing
+     * @param list<string> $warnings
+     * @param list<string> $errors
+     */
+    public function __construct(
+        public array $headersNormalized,
+        public string $headersHash,
+        public array $requiredMissing,
+        public array $warnings,
+        public array $errors,
+        public string $status,
+    ) {
+    }
+}

--- a/site/src/Marketplace/Wildberries/Service/CommissionerReport/WbCommissionerXlsxFormatValidator.php
+++ b/site/src/Marketplace/Wildberries/Service/CommissionerReport/WbCommissionerXlsxFormatValidator.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Wildberries\Service\CommissionerReport;
+
+use App\Cash\Service\Import\File\FileTabularReader;
+use App\Marketplace\Wildberries\Service\CommissionerReport\Dto\ValidationResultDTO;
+
+final class WbCommissionerXlsxFormatValidator
+{
+    private const REQUIRED_HEADERS = [
+        'Услуги по доставке товара покупателю',
+        'Эквайринг/Комиссии за организацию платежей',
+        'Вознаграждение Вайлдберриз (ВВ), без НДС',
+        'НДС с Вознаграждения Вайлдберриз',
+        'Возмещение за выдачу и возврат товаров на ПВЗ',
+        'Хранение',
+        'Возмещение издержек по перевозке/по складским операциям с товаром',
+        'Удержания',
+        'Обоснование для оплаты',
+        'Тип документа',
+        'Виды логистики, штрафов и корректировок ВВ',
+        'Тип платежа за Эквайринг/Комиссии за организацию платежей',
+        'Дата продажи',
+        'Дата заказа покупателем',
+    ];
+
+    public function __construct(private readonly FileTabularReader $tabularReader)
+    {
+    }
+
+    public function validate(string $absoluteFilePath): ValidationResultDTO
+    {
+        $headersRaw = $this->tabularReader->readHeader($absoluteFilePath);
+        $headersNormalized = array_map([$this, 'normalizeHeader'], $headersRaw);
+        $headersHash = hash('sha256', json_encode($headersNormalized, JSON_UNESCAPED_UNICODE));
+
+        $warnings = [];
+        $errors = [];
+
+        if ([] === $headersNormalized) {
+            $errors[] = 'Не удалось прочитать заголовки файла.';
+        }
+
+        $emptyIndexes = [];
+        foreach ($headersNormalized as $index => $header) {
+            if (null === $header || '' === $header) {
+                $emptyIndexes[] = $index + 1;
+            }
+        }
+
+        if ([] !== $emptyIndexes) {
+            $warnings[] = sprintf('Пустые заголовки в колонках: %s.', implode(', ', $emptyIndexes));
+        }
+
+        $headerValues = array_values(array_filter(
+            $headersNormalized,
+            static fn (?string $header) => null !== $header && '' !== $header
+        ));
+        $headerCounts = array_count_values($headerValues);
+        $duplicateHeaders = array_keys(array_filter($headerCounts, static fn (int $count) => $count > 1));
+
+        if ([] !== $duplicateHeaders) {
+            $warnings[] = sprintf('Дубликаты заголовков: %s.', implode(', ', $duplicateHeaders));
+        }
+
+        $requiredMissing = array_values(array_diff(self::REQUIRED_HEADERS, $headerValues));
+        if ([] !== $requiredMissing) {
+            $errors[] = sprintf('Не найдены обязательные заголовки: %s.', implode(', ', $requiredMissing));
+        }
+
+        if ([] !== $requiredMissing) {
+            $status = 'failed_format';
+        } elseif ([] !== $warnings) {
+            $status = 'processed_with_warnings';
+        } else {
+            $status = 'processed';
+        }
+
+        return new ValidationResultDTO(
+            $headersNormalized,
+            $headersHash,
+            $requiredMissing,
+            $warnings,
+            $errors,
+            $status
+        );
+    }
+
+    private function normalizeHeader(?string $header): ?string
+    {
+        if (null === $header) {
+            return null;
+        }
+
+        $trimmed = trim($header);
+        if ('' === $trimmed) {
+            return null;
+        }
+
+        return preg_replace('/\s+/', ' ', $trimmed);
+    }
+}

--- a/site/src/Service/Storage/StorageService.php
+++ b/site/src/Service/Storage/StorageService.php
@@ -50,4 +50,9 @@ final class StorageService
             'originalFilename' => $originalFilename,
         ];
     }
+
+    public function getAbsolutePath(string $relativePath): string
+    {
+        return $this->storageRoot.'/'.ltrim($relativePath, '/');
+    }
 }


### PR DESCRIPTION
### Motivation
- Добавить проверку формата XLSX для «Еженедельный детализированный отчет WB», чтобы гарантировать наличие обязательных заголовков и собрать метаданные заголовков. 
- Использовать существующий табличный ридер для чтения заголовков и сохранить результаты в сущности отчёта. 
- Фиксировать статус формата и предупреждения/ошибки для дальнейшей обработки импорта.

### Description
- Добавлен сервис-валидатор `WbCommissionerXlsxFormatValidator` в `site/src/Marketplace/Wildberries/Service/CommissionerReport/WbCommissionerXlsxFormatValidator.php`, который читает заголовки через `FileTabularReader`, нормализует их (`trim`, `\s+ -> ' '`), считает `headersHash`, проверяет хардкодный список обязательных заголовков и формирует `warnings`/`errors` и `status` (`failed_format` / `processed_with_warnings` / `processed`).
- Добавлен DTO `ValidationResultDTO` в `site/src/Marketplace/Wildberries/Service/CommissionerReport/Dto/ValidationResultDTO.php` для передачи результатов в контроллер.
- Внедрена интеграция в загрузочный поток: в `WildberriesCommissionerReportController::new` после сохранения файла вызывается валидатор и результат сохраняется в сущности `WildberriesCommissionerXlsxReport` (`headersHash`, `formatStatus`, `warningsJson`, `errorsJson`, `warningsCount`, `errorsCount`), при `failed_format` статус отчёта переводится в `failed`.
- Добавлен вспомогательный метод `getAbsolutePath` в `StorageService` (`site/src/Service/Storage/StorageService.php`) для получения абсолютного пути к сохранённому файлу.

### Testing
- Попытка локально выполнить валидатор через `php -r 'require "site/vendor/autoload.php"; ...'` была сделана для файла `/mnt/data/Еженедельный детализированный отчет №594609000_42880 - 1.xlsx`, но выполнение упало с ошибкой из-за отсутствия `site/vendor/autoload.php` (среда dev не инициализирована), поэтому ручная валидация не завершилась успешно. 
- Автоматических тестов в CI или `make site-test` не запускалось в этой сессии.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69731798822c8323b0aa919c67c069c1)