### PR TITLE
Add test and fixture to ensure invalid non-XLSX file yields failed_format

### DIFF
--- a/site/tests/Fixtures/invalid-not-xlsx.xlsx
+++ b/site/tests/Fixtures/invalid-not-xlsx.xlsx
@@ -1,0 +1,1 @@
+This is not an XLSX file. It is plain text used to test format validation.

--- a/site/tests/Marketplace/Wildberries/CommissionerReport/WbCommissionerXlsxFormatValidatorTest.php
+++ b/site/tests/Marketplace/Wildberries/CommissionerReport/WbCommissionerXlsxFormatValidatorTest.php
@@ -27,6 +27,19 @@ final class WbCommissionerXlsxFormatValidatorTest extends TestCase
         self::assertNotSame('', $result->headersHash);
     }
 
+    public function testInvalidFileReturnsFailedFormat(): void
+    {
+        $validator = new WbCommissionerXlsxFormatValidator(new FileTabularReader());
+        $fixturePath = dirname(__DIR__, 3).'/Fixtures/invalid-not-xlsx.xlsx';
+
+        self::assertFileExists($fixturePath);
+
+        $result = $validator->validate($fixturePath);
+
+        self::assertSame(WbCommissionerXlsxFormatValidator::STATUS_FAILED, $result->status);
+        self::assertNotEmpty($result->errors);
+    }
+
     private function createFixture(): string
     {
         $tempPath = tempnam(sys_get_temp_dir(), 'wb_commissioner_');


### PR DESCRIPTION
### Motivation
- Prevent regression where uploading/validating a non-`.xlsx` file could result in a 500 error by asserting the validator returns a `failed_format` status and reports errors.

### Description
- Added a new test `testInvalidFileReturnsFailedFormat` to `site/tests/Marketplace/Wildberries/CommissionerReport/WbCommissionerXlsxFormatValidatorTest.php` that calls `WbCommissionerXlsxFormatValidator::validate()` and asserts the status is `WbCommissionerXlsxFormatValidator::STATUS_FAILED` and `errors` is not empty.
- Added fixture file `site/tests/Fixtures/invalid-not-xlsx.xlsx` containing plain text to simulate an invalid (non-XLSX) upload.
- The new test follows the existing project test patterns and uses `FileTabularReader` like other tests in the suite.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69734e713560832383c2699af78d269b)