### PR TITLE
Add CompanyMemberRepository and CompanyInviteRepository

### DIFF
--- a/site/src/Company/Repository/CompanyInviteRepository.php
+++ b/site/src/Company/Repository/CompanyInviteRepository.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Company\Repository;
+
+use App\Company\Entity\Company;
+use App\Company\Entity\CompanyInvite;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<CompanyInvite>
+ */
+class CompanyInviteRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, CompanyInvite::class);
+    }
+
+    public function findPendingByCompanyAndEmail(Company $company, string $email, \DateTimeImmutable $now): ?CompanyInvite
+    {
+        return $this->createQueryBuilder('invite')
+            ->andWhere('invite.company = :company')
+            ->andWhere('invite.email = :email')
+            ->andWhere('invite.acceptedAt IS NULL')
+            ->andWhere('invite.revokedAt IS NULL')
+            ->andWhere('invite.expiresAt > :now')
+            ->setParameter('company', $company)
+            ->setParameter('email', mb_strtolower($email))
+            ->setParameter('now', $now)
+            ->orderBy('invite.createdAt', 'DESC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    public function findOneByTokenHash(string $tokenHash): ?CompanyInvite
+    {
+        return $this->createQueryBuilder('invite')
+            ->andWhere('invite.tokenHash = :tokenHash')
+            ->setParameter('tokenHash', $tokenHash)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    /**
+     * @return list<CompanyInvite>
+     */
+    public function findPendingByCompany(Company $company, \DateTimeImmutable $now): array
+    {
+        /** @var list<CompanyInvite> $result */
+        $result = $this->createQueryBuilder('invite')
+            ->andWhere('invite.company = :company')
+            ->andWhere('invite.acceptedAt IS NULL')
+            ->andWhere('invite.revokedAt IS NULL')
+            ->andWhere('invite.expiresAt > :now')
+            ->setParameter('company', $company)
+            ->setParameter('now', $now)
+            ->orderBy('invite.createdAt', 'DESC')
+            ->getQuery()
+            ->getResult();
+
+        return $result;
+    }
+}

--- a/site/src/Company/Repository/CompanyMemberRepository.php
+++ b/site/src/Company/Repository/CompanyMemberRepository.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Company\Repository;
+
+use App\Company\Entity\Company;
+use App\Company\Entity\CompanyMember;
+use App\Company\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<CompanyMember>
+ */
+class CompanyMemberRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, CompanyMember::class);
+    }
+
+    /**
+     * @return list<CompanyMember>
+     */
+    public function findActiveByCompany(Company $company): array
+    {
+        /** @var list<CompanyMember> $result */
+        $result = $this->createQueryBuilder('member')
+            ->andWhere('member.company = :company')
+            ->andWhere('member.status = :status')
+            ->setParameter('company', $company)
+            ->setParameter('status', CompanyMember::STATUS_ACTIVE)
+            ->orderBy('member.createdAt', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return $result;
+    }
+
+    public function findOneByCompanyAndUser(Company $company, User $user): ?CompanyMember
+    {
+        return $this->createQueryBuilder('member')
+            ->andWhere('member.company = :company')
+            ->andWhere('member.user = :user')
+            ->setParameter('company', $company)
+            ->setParameter('user', $user)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide repository helpers for company member and invite lookups required by company management flows.
- Add queries to fetch active members, find a member by company and user, and to manage pending invites and token lookups.

### Description
- Add `site/src/Company/Repository/CompanyMemberRepository.php` with `findActiveByCompany(Company $company): array` and `findOneByCompanyAndUser(Company $company, User $user): ?CompanyMember` implemented using the Doctrine query builder.
- Add `site/src/Company/Repository/CompanyInviteRepository.php` with `findPendingByCompanyAndEmail(Company $company, string $email, \DateTimeImmutable $now): ?CompanyInvite`, `findOneByTokenHash(string $tokenHash): ?CompanyInvite`, and `findPendingByCompany(Company $company, \DateTimeImmutable $now): array` implemented using the Doctrine query builder and appropriate status/expiry checks.
- Both classes extend `ServiceEntityRepository` and include ordering and limits where appropriate to return consistent results.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978a54b0fd88323be5a4714afffe335)