### PR TITLE
Add company invite services (InviteTokenService, CompanyInviteManager)

### DIFF
--- a/site/src/Company/DTO/CompanyInviteResult.php
+++ b/site/src/Company/DTO/CompanyInviteResult.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Company\DTO;
+
+use App\Company\Entity\CompanyInvite;
+use App\Company\Entity\CompanyMember;
+
+final class CompanyInviteResult
+{
+    public function __construct(
+        public readonly string $type,
+        public readonly ?CompanyInvite $invite = null,
+        public readonly ?CompanyMember $member = null,
+        public readonly ?string $plainToken = null,
+    ) {
+    }
+}

--- a/site/src/Company/Entity/CompanyInvite.php
+++ b/site/src/Company/Entity/CompanyInvite.php
@@ -158,6 +158,12 @@ class CompanyInvite
         $this->revokedAt = $at ?? new \DateTimeImmutable();
     }
 
+    public function renewToken(string $tokenHash, \DateTimeImmutable $expiresAt): void
+    {
+        $this->tokenHash = $tokenHash;
+        $this->expiresAt = $expiresAt;
+    }
+
     public function isPending(?\DateTimeImmutable $now = null): bool
     {
         return $this->getStatus($now) === self::STATUS_PENDING;

--- a/site/src/Company/Service/CompanyInviteManager.php
+++ b/site/src/Company/Service/CompanyInviteManager.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace App\Company\Service;
+
+use App\Company\DTO\CompanyInviteResult;
+use App\Company\Entity\Company;
+use App\Company\Entity\CompanyInvite;
+use App\Company\Entity\CompanyMember;
+use App\Company\Entity\User;
+use App\Company\Repository\CompanyInviteRepository;
+use App\Company\Repository\CompanyMemberRepository;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+
+class CompanyInviteManager
+{
+    private const INVITE_TTL_HOURS = 72;
+
+    public function __construct(
+        private EntityManagerInterface $em,
+        private CompanyInviteRepository $inviteRepository,
+        private CompanyMemberRepository $memberRepository,
+        private UserRepository $userRepository,
+        private InviteTokenService $tokenService,
+    ) {
+    }
+
+    public function inviteOperator(
+        Company $company,
+        string $email,
+        User $actor,
+        \DateTimeImmutable $now = null,
+    ): CompanyInviteResult {
+        $this->assertOwner($company, $actor);
+
+        $normalizedEmail = \mb_strtolower(\trim($email));
+        $now = $now ?? new \DateTimeImmutable();
+
+        $existingUser = $this->userRepository->findOneBy(['email' => $normalizedEmail]);
+        if ($existingUser instanceof User) {
+            $member = $this->memberRepository->findOneByCompanyAndUser($company, $existingUser);
+            if (!$member) {
+                $member = new CompanyMember(
+                    id: Uuid::uuid4()->toString(),
+                    company: $company,
+                    user: $existingUser,
+                    role: CompanyMember::ROLE_OPERATOR,
+                    createdAt: $now,
+                );
+                $this->em->persist($member);
+                $this->em->flush();
+            }
+
+            return new CompanyInviteResult(
+                type: 'member_created',
+                member: $member,
+            );
+        }
+
+        $plainToken = $this->tokenService->generatePlainToken();
+        $tokenHash = $this->tokenService->hashToken($plainToken);
+        $expiresAt = $now->modify(sprintf('+%d hours', self::INVITE_TTL_HOURS));
+
+        $invite = $this->inviteRepository->findPendingByCompanyAndEmail($company, $normalizedEmail, $now);
+        if ($invite) {
+            $invite->renewToken($tokenHash, $expiresAt);
+            $this->em->flush();
+
+            return new CompanyInviteResult(
+                type: 'invite_renewed',
+                invite: $invite,
+                plainToken: $plainToken,
+            );
+        }
+
+        $invite = new CompanyInvite(
+            id: Uuid::uuid4()->toString(),
+            company: $company,
+            createdBy: $actor,
+            email: $normalizedEmail,
+            role: CompanyMember::ROLE_OPERATOR,
+            tokenHash: $tokenHash,
+            expiresAt: $expiresAt,
+            createdAt: $now,
+        );
+        $this->em->persist($invite);
+        $this->em->flush();
+
+        return new CompanyInviteResult(
+            type: 'invite_created',
+            invite: $invite,
+            plainToken: $plainToken,
+        );
+    }
+
+    public function acceptInvite(
+        string $plainToken,
+        User $user,
+        \DateTimeImmutable $now = null,
+    ): void {
+        $now = $now ?? new \DateTimeImmutable();
+        $tokenHash = $this->tokenService->hashToken($plainToken);
+
+        $invite = $this->inviteRepository->findOneByTokenHash($tokenHash);
+        if (!$invite) {
+            throw new \RuntimeException('Invite not found.');
+        }
+
+        if (!$invite->isPending($now)) {
+            throw new \RuntimeException('Invite is not pending.');
+        }
+
+        if ($invite->getEmail() !== $user->getEmail()) {
+            throw new \RuntimeException('Invite email does not match user.');
+        }
+
+        $member = $this->memberRepository->findOneByCompanyAndUser($invite->getCompany(), $user);
+        if (!$member) {
+            $member = new CompanyMember(
+                id: Uuid::uuid4()->toString(),
+                company: $invite->getCompany(),
+                user: $user,
+                role: CompanyMember::ROLE_OPERATOR,
+                createdAt: $now,
+            );
+            $this->em->persist($member);
+        }
+
+        $invite->accept($user, $now);
+        $this->em->flush();
+    }
+
+    public function revokeInvite(
+        CompanyInvite $invite,
+        User $actor,
+        \DateTimeImmutable $now = null,
+    ): void {
+        $this->assertOwner($invite->getCompany(), $actor);
+        $invite->revoke($now ?? new \DateTimeImmutable());
+        $this->em->flush();
+    }
+
+    private function assertOwner(Company $company, User $actor): void
+    {
+        if ($company->getUser() !== $actor) {
+            throw new \RuntimeException('Only the company owner can manage invites.');
+        }
+    }
+}

--- a/site/src/Company/Service/InviteTokenService.php
+++ b/site/src/Company/Service/InviteTokenService.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Company\Service;
+
+class InviteTokenService
+{
+    public function generatePlainToken(): string
+    {
+        return \bin2hex(\random_bytes(32));
+    }
+
+    public function hashToken(string $plainToken): string
+    {
+        return \hash('sha256', $plainToken);
+    }
+}


### PR DESCRIPTION
### Motivation
- Implement company operator invite flow including token generation, acceptance and revocation so owners can invite operators to a company.
- Provide a simple DTO for UI to display invite results and allow renewing invite tokens when re-sending invitations.
- Store a fixed TTL for invites (`INVITE_TTL_HOURS = 72`) and ensure only company owners can manage invites.

### Description
- Added `InviteTokenService` with `generatePlainToken()` and `hashToken()` for secure token creation and hashing.
- Added `CompanyInviteManager` implementing `inviteOperator()`, `acceptInvite()`, and `revokeInvite()` and wired it to `EntityManagerInterface`, `CompanyInviteRepository`, `CompanyMemberRepository`, `UserRepository`, and `InviteTokenService`.
- Introduced `CompanyInviteResult` DTO to return `type`, `invite`, `member`, and `plainToken` for UI consumption.
- Added `renewToken(string $tokenHash, \DateTimeImmutable $expiresAt)` to `CompanyInvite` to update the token hash and expiry when reissuing invites, and used a 72 hour TTL via `INVITE_TTL_HOURS`.
- The manager normalizes emails, checks owner via `assertOwner()`, creates `CompanyMember` immediately if the user exists, reuses or creates pending invites otherwise, and throws `\RuntimeException` on invalid accept/revoke conditions.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978abdc15a88323b5137fa34920a434)