### PR TITLE
Normalize user emails on registration and login

### DIFF
--- a/site/src/Company/Entity/User.php
+++ b/site/src/Company/Entity/User.php
@@ -67,8 +67,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     public function setEmail(string $email): static
     {
-        Assert::email($email);
-        $this->email = $email;
+        $normalizedEmail = \mb_strtolower(\trim($email));
+        Assert::email($normalizedEmail);
+        $this->email = $normalizedEmail;
 
         return $this;
     }

--- a/site/src/Repository/UserRepository.php
+++ b/site/src/Repository/UserRepository.php
@@ -8,11 +8,12 @@ use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
+use Symfony\Component\Security\Core\User\UserLoaderInterface;
 
 /**
  * @extends ServiceEntityRepository<User>
  */
-class UserRepository extends ServiceEntityRepository implements PasswordUpgraderInterface
+class UserRepository extends ServiceEntityRepository implements PasswordUpgraderInterface, UserLoaderInterface
 {
     public function __construct(ManagerRegistry $registry)
     {
@@ -60,6 +61,13 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
             ->setParameter('since', $since)
             ->getQuery()
             ->getSingleScalarResult();
+    }
+
+    public function loadUserByIdentifier(string $identifier): ?User
+    {
+        $normalizedEmail = \mb_strtolower(\trim($identifier));
+
+        return $this->findOneBy(['email' => $normalizedEmail]);
     }
 
     //    /**


### PR DESCRIPTION
### Motivation
- Ensure emails are handled case-insensitively so registration and authentication always use a normalized (lowercase, trimmed) email and avoid duplicates or login failures due to casing.

### Description
- Update `App\Company\Entity\User::setEmail` to normalize the provided email with `trim()` and `mb_strtolower()` before validating with `Assert::email` and storing it.
- Implement `UserLoaderInterface` in `App\Repository\UserRepository` and add `loadUserByIdentifier(string $identifier)` that normalizes the identifier with `trim()` and `mb_strtolower()` and looks up the user by the normalized `email`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978b721d4ec8323a1b1f2c197d5ddfa)