### PR TITLE
Normalize user emails and fix UserLoaderInterface import

### DIFF
--- a/site/src/Company/Entity/User.php
+++ b/site/src/Company/Entity/User.php
@@ -67,8 +67,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     public function setEmail(string $email): static
     {
-        Assert::email($email);
-        $this->email = $email;
+        $normalizedEmail = \mb_strtolower(\trim($email));
+        Assert::email($normalizedEmail);
+        $this->email = $normalizedEmail;
 
         return $this;
     }

--- a/site/src/Repository/UserRepository.php
+++ b/site/src/Repository/UserRepository.php
@@ -8,11 +8,12 @@ use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
+use Symfony\Bridge\Doctrine\Security\User\UserLoaderInterface;
 
 /**
  * @extends ServiceEntityRepository<User>
  */
-class UserRepository extends ServiceEntityRepository implements PasswordUpgraderInterface
+class UserRepository extends ServiceEntityRepository implements PasswordUpgraderInterface, UserLoaderInterface
 {
     public function __construct(ManagerRegistry $registry)
     {
@@ -60,6 +61,13 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
             ->setParameter('since', $since)
             ->getQuery()
             ->getSingleScalarResult();
+    }
+
+    public function loadUserByIdentifier(string $identifier): ?User
+    {
+        $normalizedEmail = \mb_strtolower(\trim($identifier));
+
+        return $this->findOneBy(['email' => $normalizedEmail]);
     }
 
     //    /**


### PR DESCRIPTION
### Motivation
- Ensure user emails are handled case-insensitively to avoid duplicate accounts and login failures due to casing.
- Fix a runtime/class loading error caused by importing the wrong `UserLoaderInterface` which broke the build.

### Description
- Normalize the email in `App\Company\Entity\User::setEmail` using `trim()` and `mb_strtolower()` before validation and storage.
- Implement `loadUserByIdentifier(string $identifier): ?User` in `App\Repository\UserRepository` that normalizes the identifier and looks up the user by the normalized `email`.
- Replace the import with `Symfony\Bridge\Doctrine\Security\User\UserLoaderInterface` and add the interface to the repository class signature to resolve the missing interface error.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978b721d4ec8323a1b1f2c197d5ddfa)