### PR TITLE
Add company invite/member builders and tests

### DIFF
--- a/site/tests/Builders/Company/CompanyInviteBuilder.php
+++ b/site/tests/Builders/Company/CompanyInviteBuilder.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Builders\Company;
+
+use App\Company\Entity\Company;
+use App\Company\Entity\CompanyInvite;
+use App\Company\Entity\CompanyMember;
+use App\Company\Entity\User;
+use Webmozart\Assert\Assert;
+
+final class CompanyInviteBuilder
+{
+    public const DEFAULT_INVITE_ID = '55555555-5555-5555-5555-555555555555';
+    public const DEFAULT_EMAIL = 'operator@example.test';
+    public const DEFAULT_ROLE = CompanyMember::ROLE_OPERATOR;
+    public const DEFAULT_TOKEN_HASH = 'token-hash';
+    public const DEFAULT_EXPIRES_AT = '2026-01-01 00:00:00+00:00';
+    public const DEFAULT_CREATED_AT = '2024-01-01 00:00:00+00:00';
+
+    private string $id;
+    private Company $company;
+    private User $createdBy;
+    private string $email;
+    private string $role;
+    private string $tokenHash;
+    private \DateTimeImmutable $expiresAt;
+    private \DateTimeImmutable $createdAt;
+    private ?\DateTimeImmutable $acceptedAt;
+    private ?\DateTimeImmutable $revokedAt;
+    private ?User $acceptedByUser;
+
+    private function __construct()
+    {
+        $this->id = self::DEFAULT_INVITE_ID;
+        $this->company = CompanyBuilder::aCompany()->build();
+        $this->createdBy = UserBuilder::aUser()->build();
+        $this->email = self::DEFAULT_EMAIL;
+        $this->role = self::DEFAULT_ROLE;
+        $this->tokenHash = self::DEFAULT_TOKEN_HASH;
+        $this->expiresAt = new \DateTimeImmutable(self::DEFAULT_EXPIRES_AT);
+        $this->createdAt = new \DateTimeImmutable(self::DEFAULT_CREATED_AT);
+        $this->acceptedAt = null;
+        $this->revokedAt = null;
+        $this->acceptedByUser = null;
+    }
+
+    public static function anInvite(): self
+    {
+        return new self();
+    }
+
+    public function withId(string $id): self
+    {
+        Assert::uuid($id);
+
+        $clone = clone $this;
+        $clone->id = $id;
+
+        return $clone;
+    }
+
+    public function withCompany(Company $company): self
+    {
+        $clone = clone $this;
+        $clone->company = $company;
+
+        return $clone;
+    }
+
+    public function withCreatedBy(User $user): self
+    {
+        $clone = clone $this;
+        $clone->createdBy = $user;
+
+        return $clone;
+    }
+
+    public function withEmail(string $email): self
+    {
+        $clone = clone $this;
+        $clone->email = $email;
+
+        return $clone;
+    }
+
+    public function withRole(string $role): self
+    {
+        $clone = clone $this;
+        $clone->role = $role;
+
+        return $clone;
+    }
+
+    public function withTokenHash(string $tokenHash): self
+    {
+        $clone = clone $this;
+        $clone->tokenHash = $tokenHash;
+
+        return $clone;
+    }
+
+    public function withExpiresAt(\DateTimeImmutable $expiresAt): self
+    {
+        $clone = clone $this;
+        $clone->expiresAt = $expiresAt;
+
+        return $clone;
+    }
+
+    public function withCreatedAt(\DateTimeImmutable $createdAt): self
+    {
+        $clone = clone $this;
+        $clone->createdAt = $createdAt;
+
+        return $clone;
+    }
+
+    public function withPending(): self
+    {
+        $clone = clone $this;
+        $clone->acceptedAt = null;
+        $clone->revokedAt = null;
+        $clone->acceptedByUser = null;
+
+        return $clone;
+    }
+
+    public function withAcceptedAt(?\DateTimeImmutable $acceptedAt = null, ?User $acceptedBy = null): self
+    {
+        $clone = clone $this;
+        $clone->acceptedAt = $acceptedAt ?? new \DateTimeImmutable();
+        $clone->acceptedByUser = $acceptedBy ?? $clone->createdBy;
+        $clone->revokedAt = null;
+
+        return $clone;
+    }
+
+    public function withRevokedAt(?\DateTimeImmutable $revokedAt = null): self
+    {
+        $clone = clone $this;
+        $clone->revokedAt = $revokedAt ?? new \DateTimeImmutable();
+        $clone->acceptedAt = null;
+        $clone->acceptedByUser = null;
+
+        return $clone;
+    }
+
+    public function build(): CompanyInvite
+    {
+        $invite = new CompanyInvite(
+            $this->id,
+            $this->company,
+            $this->createdBy,
+            $this->email,
+            $this->role,
+            $this->tokenHash,
+            $this->expiresAt,
+            $this->createdAt,
+        );
+
+        if ($this->acceptedAt !== null) {
+            $invite->accept($this->acceptedByUser ?? $this->createdBy, $this->acceptedAt);
+        }
+
+        if ($this->revokedAt !== null) {
+            $invite->revoke($this->revokedAt);
+        }
+
+        return $invite;
+    }
+}

--- a/site/tests/Builders/Company/CompanyMemberBuilder.php
+++ b/site/tests/Builders/Company/CompanyMemberBuilder.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Builders\Company;
+
+use App\Company\Entity\Company;
+use App\Company\Entity\CompanyMember;
+use App\Company\Entity\User;
+use Webmozart\Assert\Assert;
+
+final class CompanyMemberBuilder
+{
+    public const DEFAULT_MEMBER_ID = '44444444-4444-4444-4444-444444444444';
+    public const DEFAULT_ROLE = CompanyMember::ROLE_OPERATOR;
+    public const DEFAULT_STATUS = CompanyMember::STATUS_ACTIVE;
+    public const DEFAULT_CREATED_AT = '2024-01-01 00:00:00+00:00';
+
+    private string $id;
+    private Company $company;
+    private User $user;
+    private string $role;
+    private string $status;
+    private \DateTimeImmutable $createdAt;
+
+    private function __construct()
+    {
+        $this->id = self::DEFAULT_MEMBER_ID;
+        $this->company = CompanyBuilder::aCompany()->build();
+        $this->user = UserBuilder::aUser()->build();
+        $this->role = self::DEFAULT_ROLE;
+        $this->status = self::DEFAULT_STATUS;
+        $this->createdAt = new \DateTimeImmutable(self::DEFAULT_CREATED_AT);
+    }
+
+    public static function aMember(): self
+    {
+        return new self();
+    }
+
+    public function withId(string $id): self
+    {
+        Assert::uuid($id);
+
+        $clone = clone $this;
+        $clone->id = $id;
+
+        return $clone;
+    }
+
+    public function withCompany(Company $company): self
+    {
+        $clone = clone $this;
+        $clone->company = $company;
+
+        return $clone;
+    }
+
+    public function withUser(User $user): self
+    {
+        $clone = clone $this;
+        $clone->user = $user;
+
+        return $clone;
+    }
+
+    public function withRole(string $role): self
+    {
+        $clone = clone $this;
+        $clone->role = $role;
+
+        return $clone;
+    }
+
+    public function withStatus(string $status): self
+    {
+        if (!in_array($status, [CompanyMember::STATUS_ACTIVE, CompanyMember::STATUS_DISABLED], true)) {
+            throw new \InvalidArgumentException('Unsupported status.');
+        }
+
+        $clone = clone $this;
+        $clone->status = $status;
+
+        return $clone;
+    }
+
+    public function withCreatedAt(\DateTimeImmutable $createdAt): self
+    {
+        $clone = clone $this;
+        $clone->createdAt = $createdAt;
+
+        return $clone;
+    }
+
+    public function asDisabled(): self
+    {
+        $clone = clone $this;
+        $clone->status = CompanyMember::STATUS_DISABLED;
+
+        return $clone;
+    }
+
+    public function build(): CompanyMember
+    {
+        $member = new CompanyMember($this->id, $this->company, $this->user, $this->role, $this->createdAt);
+
+        if ($this->status === CompanyMember::STATUS_DISABLED) {
+            $member->disable();
+        }
+
+        return $member;
+    }
+}

--- a/site/tests/Functional/Company/CompanyMemberInviteFlowTest.php
+++ b/site/tests/Functional/Company/CompanyMemberInviteFlowTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Company;
+
+use App\Company\Entity\CompanyInvite;
+use App\Company\Repository\CompanyInviteRepository;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\CompanyInviteBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+
+final class CompanyMemberInviteFlowTest extends WebTestCaseBase
+{
+    public function testInviteCreatesCompanyInvite(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $em = $this->em();
+        $owner = UserBuilder::aUser()->withEmail('owner@example.test')->build();
+        $company = CompanyBuilder::aCompany()->withOwner($owner)->build();
+        $companyId = $company->getId();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        $client->loginUser($owner);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', $companyId);
+        $session->save();
+
+        $csrfManager = $client->getContainer()->get('security.csrf.token_manager');
+        $token = $csrfManager->getToken('company_invite_operator')->getValue();
+
+        $client->request('POST', sprintf('/company/%s/users/invite', $companyId), [
+            'company_invite_operator' => [
+                'email' => 'operator@example.test',
+                '_token' => $token,
+            ],
+        ]);
+
+        self::assertTrue($client->getResponse()->isRedirect());
+
+        $inviteRepository = $this->em()->getRepository(CompanyInvite::class);
+        $invite = $inviteRepository->findPendingByCompanyAndEmail(
+            $company,
+            'operator@example.test',
+            new \DateTimeImmutable()
+        );
+
+        self::assertNotNull($invite);
+    }
+
+    public function testRevokeInviteSetsRevokedAt(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $em = $this->em();
+        $owner = UserBuilder::aUser()->withEmail('owner@example.test')->build();
+        $company = CompanyBuilder::aCompany()->withOwner($owner)->build();
+        $invite = CompanyInviteBuilder::anInvite()
+            ->withCompany($company)
+            ->withCreatedBy($owner)
+            ->withEmail('operator@example.test')
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->persist($invite);
+        $em->flush();
+
+        $client->loginUser($owner);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', $company->getId());
+        $session->save();
+
+        $csrfManager = $client->getContainer()->get('security.csrf.token_manager');
+        $token = $csrfManager->getToken('invite_revoke_'.$invite->getId())->getValue();
+
+        $client->request('POST', sprintf('/company/%s/invites/%s/revoke', $company->getId(), $invite->getId()), [
+            '_token' => $token,
+        ]);
+
+        self::assertTrue($client->getResponse()->isRedirect());
+
+        /** @var CompanyInviteRepository $inviteRepository */
+        $inviteRepository = $this->em()->getRepository(CompanyInvite::class);
+        $updatedInvite = $inviteRepository->find($invite->getId());
+
+        self::assertNotNull($updatedInvite);
+        self::assertNotNull($updatedInvite->getRevokedAt());
+    }
+}

--- a/site/tests/Functional/Company/InviteAcceptExistingUserTest.php
+++ b/site/tests/Functional/Company/InviteAcceptExistingUserTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Company;
+
+use App\Company\Entity\CompanyInvite;
+use App\Company\Entity\CompanyMember;
+use App\Company\Repository\CompanyMemberRepository;
+use App\Company\Service\InviteTokenService;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\CompanyInviteBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+
+final class InviteAcceptExistingUserTest extends WebTestCaseBase
+{
+    public function testAcceptInviteCreatesMemberAndMarksInviteAccepted(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $em = $this->em();
+        $owner = UserBuilder::aUser()->withEmail('owner@example.test')->build();
+        $company = CompanyBuilder::aCompany()->withOwner($owner)->build();
+        $existingUser = UserBuilder::aUser()->withEmail('operator@example.test')->build();
+        $tokenService = new InviteTokenService();
+        $plainToken = 'existing-user-token';
+        $tokenHash = $tokenService->hashToken($plainToken);
+        $invite = CompanyInviteBuilder::anInvite()
+            ->withCompany($company)
+            ->withCreatedBy($owner)
+            ->withEmail($existingUser->getEmail())
+            ->withTokenHash($tokenHash)
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->persist($existingUser);
+        $em->persist($invite);
+        $em->flush();
+
+        $client->loginUser($existingUser);
+        $csrfManager = $client->getContainer()->get('security.csrf.token_manager');
+        $token = $csrfManager->getToken('invite_accept_'.$invite->getId())->getValue();
+
+        $client->request('POST', sprintf('/invite/%s/accept', $plainToken), [
+            '_token' => $token,
+        ]);
+
+        self::assertTrue($client->getResponse()->isRedirect());
+
+        /** @var CompanyMemberRepository $memberRepository */
+        $memberRepository = $this->em()->getRepository(CompanyMember::class);
+        $member = $memberRepository->findOneByCompanyAndUser($company, $existingUser);
+
+        self::assertNotNull($member);
+
+        $updatedInvite = $this->em()->getRepository(CompanyInvite::class)->find($invite->getId());
+        self::assertNotNull($updatedInvite);
+        self::assertNotNull($updatedInvite->getAcceptedAt());
+    }
+}

--- a/site/tests/Functional/Company/InviteRegistrationFlowTest.php
+++ b/site/tests/Functional/Company/InviteRegistrationFlowTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Company;
+
+use App\Company\Entity\Company;
+use App\Company\Entity\CompanyInvite;
+use App\Company\Entity\CompanyMember;
+use App\Company\Entity\User;
+use App\Company\Service\InviteTokenService;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\CompanyInviteBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+
+final class InviteRegistrationFlowTest extends WebTestCaseBase
+{
+    public function testInviteRegistrationCreatesMemberWithoutNewCompany(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $em = $this->em();
+        $owner = UserBuilder::aUser()->withEmail('owner@example.test')->build();
+        $company = CompanyBuilder::aCompany()->withOwner($owner)->build();
+        $tokenService = new InviteTokenService();
+        $plainToken = 'registration-token';
+        $tokenHash = $tokenService->hashToken($plainToken);
+        $inviteEmail = 'newuser@example.test';
+        $invite = CompanyInviteBuilder::anInvite()
+            ->withCompany($company)
+            ->withCreatedBy($owner)
+            ->withEmail($inviteEmail)
+            ->withTokenHash($tokenHash)
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->persist($invite);
+        $em->flush();
+
+        $csrfManager = $client->getContainer()->get('security.csrf.token_manager');
+        $token = $csrfManager->getToken('registration_form')->getValue();
+
+        $client->request('POST', sprintf('/register?invite=%s', $plainToken), [
+            'registration_form' => [
+                'email' => $inviteEmail,
+                'plainPassword' => 'password123',
+                'agreeTerms' => 1,
+                'website' => '',
+                '_token' => $token,
+            ],
+        ]);
+
+        $statusCode = $client->getResponse()->getStatusCode();
+        self::assertNotSame(401, $statusCode);
+        self::assertNotSame(403, $statusCode);
+
+        $userRepository = $this->em()->getRepository(User::class);
+        $registeredUser = $userRepository->findOneBy(['email' => $inviteEmail]);
+
+        self::assertNotNull($registeredUser);
+
+        $companyRepository = $this->em()->getRepository(Company::class);
+        self::assertSame(1, $companyRepository->count([]));
+
+        $memberRepository = $this->em()->getRepository(CompanyMember::class);
+        $member = $memberRepository->findOneByCompanyAndUser($company, $registeredUser);
+
+        self::assertNotNull($member);
+
+        $updatedInvite = $this->em()->getRepository(CompanyInvite::class)->find($invite->getId());
+        self::assertNotNull($updatedInvite);
+        self::assertNotNull($updatedInvite->getAcceptedAt());
+    }
+}

--- a/site/tests/Unit/Company/CompanyInviteEntityTest.php
+++ b/site/tests/Unit/Company/CompanyInviteEntityTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Company;
+
+use App\Company\Entity\CompanyInvite;
+use App\Tests\Builders\Company\CompanyInviteBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class CompanyInviteEntityTest extends TestCase
+{
+    public function testPendingStatus(): void
+    {
+        $now = new \DateTimeImmutable('2025-01-01 10:00:00+00:00');
+        $invite = CompanyInviteBuilder::anInvite()
+            ->withPending()
+            ->withExpiresAt($now->modify('+1 day'))
+            ->build();
+
+        self::assertSame(CompanyInvite::STATUS_PENDING, $invite->getStatus($now));
+    }
+
+    public function testExpiredStatus(): void
+    {
+        $now = new \DateTimeImmutable('2025-01-01 10:00:00+00:00');
+        $invite = CompanyInviteBuilder::anInvite()
+            ->withPending()
+            ->withExpiresAt($now->modify('-1 day'))
+            ->build();
+
+        self::assertSame(CompanyInvite::STATUS_EXPIRED, $invite->getStatus($now));
+    }
+
+    public function testAcceptedStatus(): void
+    {
+        $invite = CompanyInviteBuilder::anInvite()
+            ->withAcceptedAt(new \DateTimeImmutable('2025-01-02 10:00:00+00:00'))
+            ->build();
+
+        self::assertSame(CompanyInvite::STATUS_ACCEPTED, $invite->getStatus());
+    }
+
+    public function testRevokedStatus(): void
+    {
+        $invite = CompanyInviteBuilder::anInvite()
+            ->withRevokedAt(new \DateTimeImmutable('2025-01-02 10:00:00+00:00'))
+            ->build();
+
+        self::assertSame(CompanyInvite::STATUS_REVOKED, $invite->getStatus());
+    }
+
+    public function testAcceptSetsAcceptedAtAndAcceptedBy(): void
+    {
+        $invite = CompanyInviteBuilder::anInvite()->build();
+        $user = UserBuilder::aUser()->build();
+        $acceptedAt = new \DateTimeImmutable('2025-01-02 10:00:00+00:00');
+
+        $invite->accept($user, $acceptedAt);
+
+        self::assertSame($acceptedAt, $invite->getAcceptedAt());
+        self::assertSame($user, $invite->getAcceptedByUser());
+    }
+}

--- a/site/tests/Unit/Company/CompanyInviteManagerTest.php
+++ b/site/tests/Unit/Company/CompanyInviteManagerTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Company;
+
+use App\Company\Entity\CompanyInvite;
+use App\Company\Entity\CompanyMember;
+use App\Company\Repository\CompanyInviteRepository;
+use App\Company\Repository\CompanyMemberRepository;
+use App\Company\Service\CompanyInviteManager;
+use App\Company\Service\InviteTokenService;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\CompanyInviteBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+final class CompanyInviteManagerTest extends TestCase
+{
+    public function testInviteOperatorCreatesInviteForNewEmail(): void
+    {
+        $owner = UserBuilder::aUser()->build();
+        $company = CompanyBuilder::aCompany()->withOwner($owner)->build();
+        $now = new \DateTimeImmutable('2025-01-02 10:00:00+00:00');
+        $expectedToken = 'plain-token';
+        $expectedHash = hash('sha256', $expectedToken);
+        $expectedExpiresAt = $now->modify('+72 hours');
+
+        $tokenService = new class($expectedToken) extends InviteTokenService {
+            public function __construct(private string $token)
+            {
+            }
+
+            public function generatePlainToken(): string
+            {
+                return $this->token;
+            }
+        };
+
+        $inviteRepository = $this->createMock(CompanyInviteRepository::class);
+        $inviteRepository
+            ->expects(self::once())
+            ->method('findPendingByCompanyAndEmail')
+            ->with($company, 'operator@example.test', $now)
+            ->willReturn(null);
+
+        $memberRepository = $this->createMock(CompanyMemberRepository::class);
+
+        $capturedInvite = null;
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em
+            ->expects(self::once())
+            ->method('persist')
+            ->with(self::callback(function (CompanyInvite $invite) use (&$capturedInvite): bool {
+                $capturedInvite = $invite;
+
+                return true;
+            }));
+        $em->expects(self::once())->method('flush');
+
+        $manager = new CompanyInviteManager(
+            $em,
+            $inviteRepository,
+            $memberRepository,
+            $tokenService,
+        );
+
+        $result = $manager->inviteOperator($company, 'Operator@Example.Test', $owner, $now);
+
+        self::assertSame('invite_created', $result->type);
+        self::assertSame($expectedToken, $result->plainToken);
+        self::assertSame($capturedInvite, $result->invite);
+        self::assertNotNull($capturedInvite);
+        self::assertSame('operator@example.test', $capturedInvite->getEmail());
+        self::assertSame(CompanyMember::ROLE_OPERATOR, $capturedInvite->getRole());
+        self::assertSame($expectedHash, $capturedInvite->getTokenHash());
+        self::assertSame($expectedExpiresAt, $capturedInvite->getExpiresAt());
+    }
+
+    public function testInviteOperatorRenewsPendingInvite(): void
+    {
+        $owner = UserBuilder::aUser()->build();
+        $company = CompanyBuilder::aCompany()->withOwner($owner)->build();
+        $now = new \DateTimeImmutable('2025-02-01 12:00:00+00:00');
+        $expectedToken = 'renew-token';
+        $expectedHash = hash('sha256', $expectedToken);
+        $expectedExpiresAt = $now->modify('+72 hours');
+
+        $tokenService = new class($expectedToken) extends InviteTokenService {
+            public function __construct(private string $token)
+            {
+            }
+
+            public function generatePlainToken(): string
+            {
+                return $this->token;
+            }
+        };
+
+        $invite = CompanyInviteBuilder::anInvite()
+            ->withCompany($company)
+            ->withCreatedBy($owner)
+            ->withEmail('operator@example.test')
+            ->build();
+
+        $inviteRepository = $this->createMock(CompanyInviteRepository::class);
+        $inviteRepository
+            ->expects(self::once())
+            ->method('findPendingByCompanyAndEmail')
+            ->with($company, 'operator@example.test', $now)
+            ->willReturn($invite);
+
+        $memberRepository = $this->createMock(CompanyMemberRepository::class);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::once())->method('flush');
+        $em->expects(self::never())->method('persist');
+
+        $manager = new CompanyInviteManager(
+            $em,
+            $inviteRepository,
+            $memberRepository,
+            $tokenService,
+        );
+
+        $result = $manager->inviteOperator($company, 'operator@example.test', $owner, $now);
+
+        self::assertSame('invite_renewed', $result->type);
+        self::assertSame($expectedToken, $result->plainToken);
+        self::assertSame($invite, $result->invite);
+        self::assertSame($expectedHash, $invite->getTokenHash());
+        self::assertSame($expectedExpiresAt, $invite->getExpiresAt());
+    }
+
+    public function testAcceptInviteCreatesCompanyMemberAndMarksAccepted(): void
+    {
+        $owner = UserBuilder::aUser()->build();
+        $company = CompanyBuilder::aCompany()->withOwner($owner)->build();
+        $user = UserBuilder::aUser()->withEmail('operator@example.test')->build();
+        $plainToken = 'accept-token';
+        $tokenHash = hash('sha256', $plainToken);
+        $now = new \DateTimeImmutable('2025-03-01 12:00:00+00:00');
+
+        $invite = CompanyInviteBuilder::anInvite()
+            ->withCompany($company)
+            ->withCreatedBy($owner)
+            ->withEmail($user->getEmail())
+            ->withTokenHash($tokenHash)
+            ->withExpiresAt($now->modify('+1 day'))
+            ->build();
+
+        $inviteRepository = $this->createMock(CompanyInviteRepository::class);
+        $inviteRepository
+            ->expects(self::once())
+            ->method('findOneByTokenHash')
+            ->with($tokenHash)
+            ->willReturn($invite);
+
+        $memberRepository = $this->createMock(CompanyMemberRepository::class);
+        $memberRepository
+            ->expects(self::once())
+            ->method('findOneByCompanyAndUser')
+            ->with($company, $user)
+            ->willReturn(null);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em
+            ->expects(self::once())
+            ->method('persist')
+            ->with(self::isInstanceOf(CompanyMember::class));
+        $em->expects(self::once())->method('flush');
+
+        $manager = new CompanyInviteManager(
+            $em,
+            $inviteRepository,
+            $memberRepository,
+            new InviteTokenService(),
+        );
+
+        $manager->acceptInvite($plainToken, $user, $now);
+
+        self::assertSame($now, $invite->getAcceptedAt());
+        self::assertSame($user, $invite->getAcceptedByUser());
+    }
+}

--- a/site/tests/Unit/Company/CompanyMemberEntityTest.php
+++ b/site/tests/Unit/Company/CompanyMemberEntityTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Company;
+
+use App\Company\Entity\CompanyMember;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\CompanyMemberBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class CompanyMemberEntityTest extends TestCase
+{
+    public function testCreateMemberHasDefaults(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+        $user = UserBuilder::aUser()->build();
+
+        $member = CompanyMemberBuilder::aMember()
+            ->withCompany($company)
+            ->withUser($user)
+            ->build();
+
+        self::assertSame($company, $member->getCompany());
+        self::assertSame($user, $member->getUser());
+        self::assertSame(CompanyMember::ROLE_OPERATOR, $member->getRole());
+        self::assertSame(CompanyMember::STATUS_ACTIVE, $member->getStatus());
+        self::assertInstanceOf(\DateTimeImmutable::class, $member->getCreatedAt());
+    }
+
+    public function testDisableEnableChangesStatus(): void
+    {
+        $member = CompanyMemberBuilder::aMember()->build();
+
+        $member->disable();
+
+        self::assertSame(CompanyMember::STATUS_DISABLED, $member->getStatus());
+
+        $member->enable();
+
+        self::assertSame(CompanyMember::STATUS_ACTIVE, $member->getStatus());
+    }
+}

--- a/site/tests/Unit/Company/InviteTokenServiceTest.php
+++ b/site/tests/Unit/Company/InviteTokenServiceTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Company;
+
+use App\Company\Service\InviteTokenService;
+use PHPUnit\Framework\TestCase;
+
+final class InviteTokenServiceTest extends TestCase
+{
+    public function testTokenNotEmpty(): void
+    {
+        $service = new InviteTokenService();
+
+        $token = $service->generatePlainToken();
+
+        self::assertNotSame('', $token);
+    }
+
+    public function testHashStableForSameToken(): void
+    {
+        $service = new InviteTokenService();
+
+        $hashOne = $service->hashToken('plain-token');
+        $hashTwo = $service->hashToken('plain-token');
+
+        self::assertSame($hashOne, $hashTwo);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide builders and test coverage for company member and invite domain objects and flows to prevent regressions.
- Cover token generation and invite lifecycle logic and validate `CompanyInviteManager` behavior for create/renew/accept scenarios.
- Add functional flows to exercise invite creation, revocation, acceptance for existing users and registration via invite.

### Description
- Added test builders `CompanyMemberBuilder` and `CompanyInviteBuilder` under `site/tests/Builders/Company` to create entities with sensible defaults and helpers. 
- Added unit tests under `site/tests/Unit/Company` for `CompanyMember`/`CompanyInvite` entities, `InviteTokenService`, and `CompanyInviteManager` covering defaults, status transitions, token hashing, invite creation/renew/accept logic. 
- Added functional tests under `site/tests/Functional/Company` for invite create/revoke flow, accepting an invite as an existing user, and registration flow using an invite. 
- Small test fixes: functional tests now use `$this->em()` to obtain the entity manager and added defensive `assertNotNull` checks, and a `CompanyInviteManager` unit test now asserts the persisted invite is not null.

### Testing
- No automated tests were executed as part of this change; the patch only adds test files and minor test fixes. 
- CI/Local test run is expected to execute the new unit and functional tests (not run here). 
- All new files were added and committed to the repository for subsequent CI verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978c58e296083238d06fadc88864755)