### PR TITLE
Fix active company lookup for invited operators (CompanyMember)

### DIFF
--- a/site/src/Company/Repository/CompanyMemberRepository.php
+++ b/site/src/Company/Repository/CompanyMemberRepository.php
@@ -62,4 +62,39 @@ class CompanyMemberRepository extends ServiceEntityRepository
             ->getQuery()
             ->getOneOrNullResult();
     }
+
+    public function findActiveOneByCompanyAndUser(Company $company, User $user): ?CompanyMember
+    {
+        return $this->createQueryBuilder('companyMember')
+            ->andWhere('companyMember.company = :company')
+            ->andWhere('companyMember.user = :user')
+            ->andWhere('companyMember.status = :status')
+            ->setParameter('company', $company)
+            ->setParameter('user', $user)
+            ->setParameter('status', CompanyMember::STATUS_ACTIVE)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    public function findFirstActiveCompanyForUser(User $user): ?Company
+    {
+        $company = $this->createQueryBuilder('companyMember')
+            ->select('company')
+            ->innerJoin('companyMember.company', 'company')
+            ->andWhere('companyMember.user = :user')
+            ->andWhere('companyMember.status = :status')
+            ->setParameter('user', $user)
+            ->setParameter('status', CompanyMember::STATUS_ACTIVE)
+            ->orderBy('companyMember.createdAt', 'ASC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        if ($company instanceof Company) {
+            return $company;
+        }
+
+        return null;
+    }
 }

--- a/site/src/Shared/Service/ActiveCompanyService.php
+++ b/site/src/Shared/Service/ActiveCompanyService.php
@@ -3,6 +3,7 @@
 namespace App\Shared\Service;
 
 use App\Company\Entity\Company;
+use App\Company\Repository\CompanyMemberRepository;
 use App\Repository\CompanyRepository;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -13,6 +14,7 @@ class ActiveCompanyService
     public function __construct(
         private RequestStack $requestStack,
         private CompanyRepository $companyRepository,
+        private CompanyMemberRepository $companyMemberRepository,
         private Security $security,
     ) {
     }
@@ -23,14 +25,27 @@ class ActiveCompanyService
         $id = $session->get('active_company_id');
         $user = $this->security->getUser();
 
+        if ($user === null) {
+            throw new NotFoundHttpException();
+        }
+
         if ($id) {
             $company = $this->companyRepository->find($id);
-            if ($company && $company->getUser() === $user) {
+            if (
+                $company
+                && (
+                    $company->getUser() === $user
+                    || $this->companyMemberRepository->findActiveOneByCompanyAndUser($company, $user) !== null
+                )
+            ) {
                 return $company;
             }
         }
 
         $company = $this->companyRepository->findOneBy(['user' => $user]);
+        if (!$company) {
+            $company = $this->companyMemberRepository->findFirstActiveCompanyForUser($user);
+        }
         if (!$company) {
             throw new NotFoundHttpException();
         }


### PR DESCRIPTION
### Motivation
- `ActiveCompanyService::getActiveCompany()` previously resolved active company only via `Company.user`, which caused `NotFoundHttpException` for invited operators who are `CompanyMember` but not owners.

### Description
- Added `CompanyMemberRepository::findActiveOneByCompanyAndUser(Company $company, User $user): ?CompanyMember` to check active membership for a specific company and user.
- Added `CompanyMemberRepository::findFirstActiveCompanyForUser(User $user): ?Company` to return the first active company for a user by membership.
- Injected `CompanyMemberRepository` into `ActiveCompanyService` and updated `getActiveCompany()` so it: throws `NotFoundHttpException` if user is `null`, accepts session `active_company_id` when the user is either the company owner or an active member, and falls back to the owner company then to the first active member company, writing the resolved company id back to session while preserving existing owner behavior.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979a94f0c38832397d3d830d6f43875)