### PR TITLE
Add Tabler-style "Информеры" section to home page

### DIFF
--- a/site/templates/home/index.html.twig
+++ b/site/templates/home/index.html.twig
@@ -38,6 +38,85 @@
   </div>
 </div>
 
+<div class="row row-deck row-cards mb-4">
+  <div class="col-12">
+    <div class="d-flex align-items-center justify-content-between">
+      <h2 class="h3 mb-0">Информеры</h2>
+      <span class="text-muted">Последние 7 дней</span>
+    </div>
+  </div>
+  <div class="col-sm-6 col-lg-3">
+    <div class="card">
+      <div class="card-body">
+        <div class="subheader">Продажи</div>
+        <div class="h1 mb-1">75%</div>
+        <div class="d-flex align-items-center">
+          <span class="text-muted">Конверсия</span>
+          <span class="ms-auto text-green d-inline-flex align-items-center">
+            7%
+            <i class="ti ti-trending-up ms-1"></i>
+          </span>
+        </div>
+        <div class="progress progress-sm mt-3">
+          <div class="progress-bar bg-primary" style="width: 75%" role="progressbar" aria-label="Sales progress"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="col-sm-6 col-lg-3">
+    <div class="card">
+      <div class="card-body">
+        <div class="subheader">Выручка</div>
+        <div class="h1 mb-1">₽ 4 300</div>
+        <div class="text-green d-inline-flex align-items-center">
+          8%
+          <i class="ti ti-trending-up ms-1"></i>
+        </div>
+        <div class="mt-3">
+          <svg class="w-100" height="40" viewBox="0 0 100 40" fill="none" xmlns="http://www.w3.org/2000/svg" aria-label="Revenue trend">
+            <path d="M0 30 L8 28 L16 32 L24 26 L32 24 L40 29 L48 20 L56 22 L64 18 L72 21 L80 16 L88 20 L96 14 L100 16" stroke="var(--tblr-primary)" stroke-width="2" fill="none" />
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="col-sm-6 col-lg-3">
+    <div class="card">
+      <div class="card-body">
+        <div class="subheader">Новые клиенты</div>
+        <div class="h1 mb-1">6 782</div>
+        <div class="text-muted d-inline-flex align-items-center">
+          0%
+          <i class="ti ti-minus ms-1"></i>
+        </div>
+        <div class="mt-3">
+          <svg class="w-100" height="40" viewBox="0 0 100 40" fill="none" xmlns="http://www.w3.org/2000/svg" aria-label="New clients trend">
+            <path d="M0 22 L10 26 L20 20 L30 23 L40 19 L50 24 L60 18 L70 21 L80 17 L90 20 L100 16" stroke="var(--tblr-primary)" stroke-width="2" fill="none" />
+            <path d="M0 26 L10 24 L20 28 L30 25 L40 27 L50 23 L60 26 L70 22 L80 25 L90 21 L100 24" stroke="var(--tblr-border-color)" stroke-width="2" stroke-dasharray="4 3" fill="none" />
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="col-sm-6 col-lg-3">
+    <div class="card">
+      <div class="card-body">
+        <div class="subheader">Активные подписки</div>
+        <div class="h1 mb-1">2 986</div>
+        <div class="text-green d-inline-flex align-items-center">
+          4%
+          <i class="ti ti-trending-up ms-1"></i>
+        </div>
+        <div class="mt-3">
+          <svg class="w-100" height="40" viewBox="0 0 100 40" fill="none" xmlns="http://www.w3.org/2000/svg" aria-label="Subscriptions trend">
+            <path d="M0 35 L5 28 L10 32 L15 24 L20 30 L25 22 L30 28 L35 18 L40 26 L45 16 L50 24 L55 14 L60 22 L65 12 L70 20 L75 14 L80 22 L85 16 L90 24 L95 18 L100 26" stroke="var(--tblr-primary)" stroke-width="2" fill="none" />
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
     <div class="row g-3 mb-4">
         <div class="card mt-3">
             <div class="card-body">


### PR DESCRIPTION
### Motivation
- Add a compact KPI/informers area on the dashboard to surface recent metrics in a Tabler-like style for quick visual inspection.

### Description
- Updated `site/templates/home/index.html.twig` to insert a new `Информеры` row with Tabler-style cards and layout classes.
- Added four informer cards (`Продажи`, `Выручка`, `Новые клиенты`, `Активные подписки`) with placeholder values, small sparklines (inline SVG), progress bar and trend icons using existing Tabler classes. 
- This change is presentation-only and uses static placeholders for now so it can be wired to real KPIs later.

### Testing
- Started a local dev server using `php -S 0.0.0.0:8000 -t site/public` and confirmed the page loads without template errors. 
- Ran a Playwright script to navigate to `/` and capture a screenshot saved as `artifacts/home-informers.png`, which verifies the new section renders correctly. 
- No automated unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697afeb374f0832393ac512ea42e572e)