### PR TITLE
Add Billing Subscription entity, repository and migration

### DIFF
--- a/site/migrations/Version20260315120000.php
+++ b/site/migrations/Version20260315120000.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260315120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create billing subscription table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if ($schema->hasTable('billing_subscription')) {
+            return;
+        }
+
+        $this->addSql('CREATE TABLE billing_subscription (id UUID NOT NULL, company_id UUID NOT NULL, plan_id UUID NOT NULL, status VARCHAR(16) NOT NULL, trial_ends_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, current_period_start TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, current_period_end TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, cancel_at_period_end BOOLEAN NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_billing_subscription_company ON billing_subscription (company_id)');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_billing_subscription_status ON billing_subscription (status)');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_billing_subscription_current_period_end ON billing_subscription (current_period_end)');
+        $this->addSql('ALTER TABLE billing_subscription ADD CONSTRAINT fk_billing_subscription_company FOREIGN KEY (company_id) REFERENCES company (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE billing_subscription ADD CONSTRAINT fk_billing_subscription_plan FOREIGN KEY (plan_id) REFERENCES billing_plan (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        if (!$schema->hasTable('billing_subscription')) {
+            return;
+        }
+
+        $this->addSql('DROP TABLE billing_subscription');
+    }
+}

--- a/src/Billing/Entity/Subscription.php
+++ b/src/Billing/Entity/Subscription.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Billing\Entity;
+
+use App\Billing\Enum\SubscriptionStatus;
+use App\Company\Entity\Company;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: \App\Billing\Repository\SubscriptionRepository::class)]
+#[ORM\Table(name: 'billing_subscription')]
+#[ORM\Index(name: 'idx_billing_subscription_company', columns: ['company_id'])]
+#[ORM\Index(name: 'idx_billing_subscription_status', columns: ['status'])]
+#[ORM\Index(name: 'idx_billing_subscription_current_period_end', columns: ['current_period_end'])]
+final class Subscription
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid')]
+    private string $id;
+
+    #[ORM\ManyToOne(targetEntity: Company::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private Company $company;
+
+    #[ORM\ManyToOne(targetEntity: Plan::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private Plan $plan;
+
+    #[ORM\Column(type: 'string', enumType: SubscriptionStatus::class)]
+    private SubscriptionStatus $status;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $trialEndsAt;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $currentPeriodStart;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $currentPeriodEnd;
+
+    #[ORM\Column(type: 'boolean')]
+    private bool $cancelAtPeriodEnd;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $createdAt;
+
+    public function __construct(
+        string $id,
+        Company $company,
+        Plan $plan,
+        SubscriptionStatus $status,
+        ?\DateTimeImmutable $trialEndsAt,
+        \DateTimeImmutable $currentPeriodStart,
+        \DateTimeImmutable $currentPeriodEnd,
+        bool $cancelAtPeriodEnd,
+        \DateTimeImmutable $createdAt,
+    ) {
+        $this->id = $id;
+        $this->company = $company;
+        $this->plan = $plan;
+        $this->status = $status;
+        $this->trialEndsAt = $trialEndsAt;
+        $this->currentPeriodStart = $currentPeriodStart;
+        $this->currentPeriodEnd = $currentPeriodEnd;
+        $this->cancelAtPeriodEnd = $cancelAtPeriodEnd;
+        $this->createdAt = $createdAt;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getCompany(): Company
+    {
+        return $this->company;
+    }
+
+    public function getPlan(): Plan
+    {
+        return $this->plan;
+    }
+
+    public function getStatus(): SubscriptionStatus
+    {
+        return $this->status;
+    }
+
+    public function getTrialEndsAt(): ?\DateTimeImmutable
+    {
+        return $this->trialEndsAt;
+    }
+
+    public function getCurrentPeriodStart(): \DateTimeImmutable
+    {
+        return $this->currentPeriodStart;
+    }
+
+    public function getCurrentPeriodEnd(): \DateTimeImmutable
+    {
+        return $this->currentPeriodEnd;
+    }
+
+    public function isCancelAtPeriodEnd(): bool
+    {
+        return $this->cancelAtPeriodEnd;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/src/Billing/Repository/SubscriptionRepository.php
+++ b/src/Billing/Repository/SubscriptionRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Billing\Repository;
+
+use App\Billing\Entity\Subscription;
+use App\Billing\Enum\SubscriptionStatus;
+use App\Company\Entity\Company;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+final class SubscriptionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Subscription::class);
+    }
+
+    public function findCurrentForCompany(Company $company): ?Subscription
+    {
+        return $this->createQueryBuilder('subscription')
+            ->andWhere('subscription.company = :company')
+            ->andWhere('subscription.status IN (:statuses)')
+            ->andWhere('subscription.currentPeriodEnd >= :now')
+            ->setParameter('company', $company)
+            ->setParameter('statuses', [
+                SubscriptionStatus::ACTIVE,
+                SubscriptionStatus::TRIAL,
+                SubscriptionStatus::GRACE,
+            ])
+            ->setParameter('now', new \DateTimeImmutable())
+            ->addOrderBy(
+                'CASE '
+                . 'WHEN subscription.status = :active THEN 1 '
+                . 'WHEN subscription.status = :trial THEN 2 '
+                . 'WHEN subscription.status = :grace THEN 3 '
+                . 'ELSE 4 END'
+            )
+            ->addOrderBy('subscription.currentPeriodEnd', 'DESC')
+            ->setParameter('active', SubscriptionStatus::ACTIVE)
+            ->setParameter('trial', SubscriptionStatus::TRIAL)
+            ->setParameter('grace', SubscriptionStatus::GRACE)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce a first-class `Subscription` entity to track company billing subscriptions and lifecycle timestamps.
- Ensure `status` is represented by the `SubscriptionStatus` enum in code while being stored as a string in the database.
- Provide a repository-level lookup to encapsulate Doctrine usage and pick the correct active subscription for a company.

### Description
- Add `src/Billing/Entity/Subscription.php` implementing the `Subscription` entity with fields `id`, `company`, `plan`, `status` (enum mapped), `trialEndsAt`, `currentPeriodStart`, `currentPeriodEnd`, `cancelAtPeriodEnd`, and `createdAt`.
- Add `src/Billing/Repository/SubscriptionRepository.php` with `findCurrentForCompany(Company $company): ?Subscription` that filters by status and `currentPeriodEnd >= now` and prioritizes `ACTIVE > TRIAL > GRACE` then orders by `currentPeriodEnd`.
- Add migration `site/migrations/Version20260315120000.php` to create the `billing_subscription` table with indexes on `company_id`, `status`, and `current_period_end` and foreign keys to `company` and `billing_plan`.
- Map `status` as a string column in DB and map it to `SubscriptionStatus` enum in the entity.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697da86d8e288323ab00af24f7657a28)