### PR TITLE
Add SubscriptionIntegration entity, repository and migration

### DIFF
--- a/site/migrations/Version20260316120000.php
+++ b/site/migrations/Version20260316120000.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260316120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create billing subscription integration table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if ($schema->hasTable('billing_subscription_integration')) {
+            return;
+        }
+
+        $this->addSql('CREATE TABLE billing_subscription_integration (id UUID NOT NULL, subscription_id UUID NOT NULL, integration_id UUID NOT NULL, status VARCHAR(16) NOT NULL, started_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, ended_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS uniq_billing_subscription_integration_subscription_integration ON billing_subscription_integration (subscription_id, integration_id)');
+
+        if ($schema->hasTable('billing_subscription')) {
+            $this->addSql('ALTER TABLE billing_subscription_integration ADD CONSTRAINT fk_billing_subscription_integration_subscription FOREIGN KEY (subscription_id) REFERENCES billing_subscription (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        }
+
+        if ($schema->hasTable('billing_integration')) {
+            $this->addSql('ALTER TABLE billing_subscription_integration ADD CONSTRAINT fk_billing_subscription_integration_integration FOREIGN KEY (integration_id) REFERENCES billing_integration (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        if (!$schema->hasTable('billing_subscription_integration')) {
+            return;
+        }
+
+        $this->addSql('DROP TABLE billing_subscription_integration');
+    }
+}

--- a/src/Billing/Entity/SubscriptionIntegration.php
+++ b/src/Billing/Entity/SubscriptionIntegration.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Billing\Entity;
+
+use App\Billing\Enum\SubscriptionIntegrationStatus;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: \App\Billing\Repository\SubscriptionIntegrationRepository::class)]
+#[ORM\Table(name: 'billing_subscription_integration')]
+#[ORM\UniqueConstraint(name: 'uniq_billing_subscription_integration_subscription_integration', columns: ['subscription_id', 'integration_id'])]
+final class SubscriptionIntegration
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid')]
+    private string $id;
+
+    #[ORM\ManyToOne(targetEntity: Subscription::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private Subscription $subscription;
+
+    #[ORM\ManyToOne(targetEntity: Integration::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private Integration $integration;
+
+    #[ORM\Column(type: 'string', enumType: SubscriptionIntegrationStatus::class)]
+    private SubscriptionIntegrationStatus $status;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $startedAt;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $endedAt;
+
+    public function __construct(
+        string $id,
+        Subscription $subscription,
+        Integration $integration,
+        SubscriptionIntegrationStatus $status,
+        ?\DateTimeImmutable $startedAt,
+        ?\DateTimeImmutable $endedAt,
+    ) {
+        $this->id = $id;
+        $this->subscription = $subscription;
+        $this->integration = $integration;
+        $this->status = $status;
+        $this->startedAt = $startedAt;
+        $this->endedAt = $endedAt;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getSubscription(): Subscription
+    {
+        return $this->subscription;
+    }
+
+    public function getIntegration(): Integration
+    {
+        return $this->integration;
+    }
+
+    public function getStatus(): SubscriptionIntegrationStatus
+    {
+        return $this->status;
+    }
+
+    public function getStartedAt(): ?\DateTimeImmutable
+    {
+        return $this->startedAt;
+    }
+
+    public function getEndedAt(): ?\DateTimeImmutable
+    {
+        return $this->endedAt;
+    }
+}

--- a/src/Billing/Repository/SubscriptionIntegrationRepository.php
+++ b/src/Billing/Repository/SubscriptionIntegrationRepository.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Billing\Repository;
+
+use App\Billing\Entity\Subscription;
+use App\Billing\Entity\SubscriptionIntegration;
+use App\Billing\Enum\SubscriptionIntegrationStatus;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+final class SubscriptionIntegrationRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, SubscriptionIntegration::class);
+    }
+
+    /**
+     * @return SubscriptionIntegration[]
+     */
+    public function findActiveForSubscription(Subscription $subscription): array
+    {
+        return $this->createQueryBuilder('subscriptionIntegration')
+            ->andWhere('subscriptionIntegration.subscription = :subscription')
+            ->andWhere('subscriptionIntegration.status = :status')
+            ->setParameter('subscription', $subscription)
+            ->setParameter('status', SubscriptionIntegrationStatus::ACTIVE)
+            ->orderBy('subscriptionIntegration.startedAt', 'ASC')
+            ->addOrderBy('subscriptionIntegration.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function isIntegrationEnabled(Subscription $subscription, string $integrationCode): bool
+    {
+        $count = $this->createQueryBuilder('subscriptionIntegration')
+            ->select('COUNT(subscriptionIntegration.id)')
+            ->innerJoin('subscriptionIntegration.integration', 'integration')
+            ->andWhere('subscriptionIntegration.subscription = :subscription')
+            ->andWhere('subscriptionIntegration.status = :status')
+            ->andWhere('integration.code = :code')
+            ->setParameter('subscription', $subscription)
+            ->setParameter('status', SubscriptionIntegrationStatus::ACTIVE)
+            ->setParameter('code', $integrationCode)
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        return (int) $count > 0;
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce a model to represent per-subscription integration configuration and lifecycle (start/end/status) in the Billing module.
- Ensure status uses the existing enum `SubscriptionIntegrationStatus` instead of raw strings, following billing module rules.
- Provide repository helpers to encapsulate Doctrine queries and keep controllers/services from using EntityManager directly.

### Description
- Add entity `App\Billing\Entity\SubscriptionIntegration` with fields `id`, `subscription` (ManyToOne, cascade), `integration` (ManyToOne), `status` (enum `SubscriptionIntegrationStatus`), `startedAt`, and `endedAt`, and a unique constraint on `(subscription_id, integration_id)`; file `src/Billing/Entity/SubscriptionIntegration.php`.
- Add repository `App\Billing\Repository\SubscriptionIntegrationRepository` with methods `findActiveForSubscription(Subscription $subscription): array` and `isIntegrationEnabled(Subscription $subscription, string $integrationCode): bool`, implemented with QueryBuilder; file `src/Billing/Repository/SubscriptionIntegrationRepository.php`.
- Add migration `site/migrations/Version20260316120000.php` creating table `billing_subscription_integration` with `status` stored as `VARCHAR(16)` and foreign keys to `billing_subscription` and `billing_integration`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697db2caed448323bf5c5ab1da55ade9)