### PR TITLE
Add lifecycle methods and enforce invariants on SubscriptionIntegration

### DIFF
--- a/site/migrations/Version20260316120000.php
+++ b/site/migrations/Version20260316120000.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260316120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create billing subscription integration table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if ($schema->hasTable('billing_subscription_integration')) {
+            return;
+        }
+
+        $this->addSql('CREATE TABLE billing_subscription_integration (id UUID NOT NULL, subscription_id UUID NOT NULL, integration_id UUID NOT NULL, status VARCHAR(16) NOT NULL, started_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, ended_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS uniq_billing_subscription_integration_subscription_integration ON billing_subscription_integration (subscription_id, integration_id)');
+
+        if ($schema->hasTable('billing_subscription')) {
+            $this->addSql('ALTER TABLE billing_subscription_integration ADD CONSTRAINT fk_billing_subscription_integration_subscription FOREIGN KEY (subscription_id) REFERENCES billing_subscription (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        }
+
+        if ($schema->hasTable('billing_integration')) {
+            $this->addSql('ALTER TABLE billing_subscription_integration ADD CONSTRAINT fk_billing_subscription_integration_integration FOREIGN KEY (integration_id) REFERENCES billing_integration (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        if (!$schema->hasTable('billing_subscription_integration')) {
+            return;
+        }
+
+        $this->addSql('DROP TABLE billing_subscription_integration');
+    }
+}

--- a/src/Billing/Entity/SubscriptionIntegration.php
+++ b/src/Billing/Entity/SubscriptionIntegration.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Billing\Entity;
+
+use App\Billing\Enum\SubscriptionIntegrationStatus;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: \App\Billing\Repository\SubscriptionIntegrationRepository::class)]
+#[ORM\Table(name: 'billing_subscription_integration')]
+#[ORM\UniqueConstraint(name: 'uniq_billing_subscription_integration_subscription_integration', columns: ['subscription_id', 'integration_id'])]
+final class SubscriptionIntegration
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid')]
+    private string $id;
+
+    #[ORM\ManyToOne(targetEntity: Subscription::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private Subscription $subscription;
+
+    #[ORM\ManyToOne(targetEntity: Integration::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private Integration $integration;
+
+    #[ORM\Column(type: 'string', enumType: SubscriptionIntegrationStatus::class)]
+    private SubscriptionIntegrationStatus $status;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $startedAt;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $endedAt;
+
+    public function __construct(
+        string $id,
+        Subscription $subscription,
+        Integration $integration,
+        ?\DateTimeImmutable $startedAt = null,
+    ) {
+        $this->id = $id;
+        $this->subscription = $subscription;
+        $this->integration = $integration;
+        $this->status = SubscriptionIntegrationStatus::ACTIVE;
+        $this->startedAt = $startedAt ?? new \DateTimeImmutable();
+        $this->endedAt = null;
+    }
+
+    public function activate(\DateTimeImmutable $at): void
+    {
+        if ($this->status === SubscriptionIntegrationStatus::ACTIVE) {
+            throw new \LogicException('Subscription integration is already active.');
+        }
+
+        $this->status = SubscriptionIntegrationStatus::ACTIVE;
+        $this->startedAt = $at;
+        $this->endedAt = null;
+    }
+
+    public function disable(\DateTimeImmutable $at): void
+    {
+        if ($this->status === SubscriptionIntegrationStatus::DISABLED) {
+            throw new \LogicException('Subscription integration is already disabled.');
+        }
+
+        $this->status = SubscriptionIntegrationStatus::DISABLED;
+        $this->endedAt = $at;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getSubscription(): Subscription
+    {
+        return $this->subscription;
+    }
+
+    public function getIntegration(): Integration
+    {
+        return $this->integration;
+    }
+
+    public function getStatus(): SubscriptionIntegrationStatus
+    {
+        return $this->status;
+    }
+
+    public function getStartedAt(): ?\DateTimeImmutable
+    {
+        return $this->startedAt;
+    }
+
+    public function getEndedAt(): ?\DateTimeImmutable
+    {
+        return $this->endedAt;
+    }
+}

--- a/src/Billing/Repository/SubscriptionIntegrationRepository.php
+++ b/src/Billing/Repository/SubscriptionIntegrationRepository.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Billing\Repository;
+
+use App\Billing\Entity\Subscription;
+use App\Billing\Entity\SubscriptionIntegration;
+use App\Billing\Enum\SubscriptionIntegrationStatus;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+final class SubscriptionIntegrationRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, SubscriptionIntegration::class);
+    }
+
+    /**
+     * @return SubscriptionIntegration[]
+     */
+    public function findActiveForSubscription(Subscription $subscription): array
+    {
+        return $this->createQueryBuilder('subscriptionIntegration')
+            ->andWhere('subscriptionIntegration.subscription = :subscription')
+            ->andWhere('subscriptionIntegration.status = :status')
+            ->setParameter('subscription', $subscription)
+            ->setParameter('status', SubscriptionIntegrationStatus::ACTIVE)
+            ->orderBy('subscriptionIntegration.startedAt', 'ASC')
+            ->addOrderBy('subscriptionIntegration.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function isIntegrationEnabled(Subscription $subscription, string $integrationCode): bool
+    {
+        $count = $this->createQueryBuilder('subscriptionIntegration')
+            ->select('COUNT(subscriptionIntegration.id)')
+            ->innerJoin('subscriptionIntegration.integration', 'integration')
+            ->andWhere('subscriptionIntegration.subscription = :subscription')
+            ->andWhere('subscriptionIntegration.status = :status')
+            ->andWhere('integration.code = :code')
+            ->setParameter('subscription', $subscription)
+            ->setParameter('status', SubscriptionIntegrationStatus::ACTIVE)
+            ->setParameter('code', $integrationCode)
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        return (int) $count > 0;
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure `SubscriptionIntegration` models a mutable lifecycle (start/end/status) and prevents invalid states such as an ACTIVE integration without a `startedAt` timestamp.

### Description
- Change `SubscriptionIntegration::__construct` to default the `status` to `SubscriptionIntegrationStatus::ACTIVE`, set `startedAt` to now when not provided, and initialize `endedAt` to `null` in `src/Billing/Entity/SubscriptionIntegration.php`.
- Add lifecycle methods `activate(
DateTimeImmutable $at)` and `disable(
DateTimeImmutable $at)` that enforce invariants and throw a `LogicException` on invalid transitions.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697db2caed448323bf5c5ab1da55ade9)