### PR TITLE
Add UsageCounter entity, repository and migration

### DIFF
--- a/site/migrations/Version20260318120000.php
+++ b/site/migrations/Version20260318120000.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260318120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create billing usage counter table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if ($schema->hasTable('billing_usage_counter')) {
+            return;
+        }
+
+        $this->addSql('CREATE TABLE billing_usage_counter (id UUID NOT NULL, company_id UUID NOT NULL, period_key VARCHAR(7) NOT NULL, metric VARCHAR(255) NOT NULL, used INT NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS uniq_billing_usage_counter_company_period_metric ON billing_usage_counter (company_id, period_key, metric)');
+
+        if ($schema->hasTable('company')) {
+            $this->addSql(
+                <<<'SQL'
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'fk_billing_usage_counter_company'
+    ) THEN
+        ALTER TABLE billing_usage_counter
+            ADD CONSTRAINT fk_billing_usage_counter_company
+            FOREIGN KEY (company_id) REFERENCES company (id)
+            ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;
+    END IF;
+END
+$$;
+SQL
+            );
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        if (!$schema->hasTable('billing_usage_counter')) {
+            return;
+        }
+
+        $this->addSql('DROP TABLE billing_usage_counter');
+    }
+}

--- a/src/Billing/Entity/UsageCounter.php
+++ b/src/Billing/Entity/UsageCounter.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Billing\Entity;
+
+use App\Company\Entity\Company;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: \App\Billing\Repository\UsageCounterRepository::class)]
+#[ORM\Table(name: 'billing_usage_counter')]
+#[ORM\UniqueConstraint(name: 'uniq_billing_usage_counter_company_period_metric', columns: ['company_id', 'period_key', 'metric'])]
+final class UsageCounter
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid')]
+    private string $id;
+
+    #[ORM\ManyToOne(targetEntity: Company::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private Company $company;
+
+    #[ORM\Column(name: 'period_key', type: 'string')]
+    private string $periodKey;
+
+    #[ORM\Column(type: 'string')]
+    private string $metric;
+
+    #[ORM\Column(type: 'integer')]
+    private int $used;
+
+    public function __construct(
+        string $id,
+        Company $company,
+        string $periodKey,
+        string $metric,
+        int $used,
+    ) {
+        $this->id = $id;
+        $this->company = $company;
+        $this->periodKey = $periodKey;
+        $this->metric = $metric;
+        $this->used = $used;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getCompany(): Company
+    {
+        return $this->company;
+    }
+
+    public function getPeriodKey(): string
+    {
+        return $this->periodKey;
+    }
+
+    public function getMetric(): string
+    {
+        return $this->metric;
+    }
+
+    public function getUsed(): int
+    {
+        return $this->used;
+    }
+}

--- a/src/Billing/Repository/UsageCounterRepository.php
+++ b/src/Billing/Repository/UsageCounterRepository.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Billing\Repository;
+
+use App\Billing\Entity\UsageCounter;
+use App\Company\Entity\Company;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Persistence\ManagerRegistry;
+use Ramsey\Uuid\Uuid;
+
+final class UsageCounterRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, UsageCounter::class);
+    }
+
+    public function findOne(Company $company, string $periodKey, string $metric): ?UsageCounter
+    {
+        return $this->findOneBy([
+            'company' => $company,
+            'periodKey' => $periodKey,
+            'metric' => $metric,
+        ]);
+    }
+
+    public function upsertIncrement(Company $company, string $periodKey, string $metric, int $by): void
+    {
+        $connection = $this->getEntityManager()->getConnection();
+
+        $sql = <<<'SQL'
+INSERT INTO billing_usage_counter (id, company_id, period_key, metric, used)
+VALUES (:id, :company_id, :period_key, :metric, :used)
+ON CONFLICT (company_id, period_key, metric)
+DO UPDATE SET used = billing_usage_counter.used + EXCLUDED.used
+SQL;
+
+        $connection->executeStatement(
+            $sql,
+            [
+                'id' => Uuid::uuid4()->toString(),
+                'company_id' => $company->getId(),
+                'period_key' => $periodKey,
+                'metric' => $metric,
+                'used' => $by,
+            ],
+            [
+                'id' => Types::GUID,
+                'company_id' => Types::GUID,
+                'period_key' => Types::STRING,
+                'metric' => Types::STRING,
+                'used' => Types::INTEGER,
+            ],
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Add an aggregated usage counter to store per-company, per-period, per-metric usage totals for billing and quota metering. 
- Keep Doctrine access inside a repository and provide an atomic upsert increment helper to ensure concurrency-safe increments.

### Description
- Added `UsageCounter` entity at `src/Billing/Entity/UsageCounter.php` with fields `id`, `company`, `periodKey`, `metric`, `used` and a unique constraint on `(company_id, period_key, metric)`.
- Added `UsageCounterRepository` at `src/Billing/Repository/UsageCounterRepository.php` with `findOne(Company $company, string $periodKey, string $metric): ?UsageCounter` and `upsertIncrement(Company $company, string $periodKey, string $metric, int $by): void` which executes an `INSERT ... ON CONFLICT` statement and generates UUIDs via `Ramsey\uuid`.
- Added Doctrine migration `site/migrations/Version20260318120000.php` to create `billing_usage_counter` table, add the unique index and conditionally add the FK using a guarded `DO $$ BEGIN ... END $$;` block per project migration rules.

### Testing
- No automated tests were run for this change. 
- Files were added and committed (`src/Billing/Entity/UsageCounter.php`, `src/Billing/Repository/UsageCounterRepository.php`, `site/migrations/Version20260318120000.php`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dc577fff88323af5f1e3016e4febd)