### PR TITLE
Use BIGINT for UsageCounter.used, constrain period_key length, and rename upsertIncrement to upsertAdjust

### DIFF
--- a/site/migrations/Version20260318120000.php
+++ b/site/migrations/Version20260318120000.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260318120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create billing usage counter table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if ($schema->hasTable('billing_usage_counter')) {
+            return;
+        }
+
+        $this->addSql('CREATE TABLE billing_usage_counter (id UUID NOT NULL, company_id UUID NOT NULL, period_key VARCHAR(7) NOT NULL, metric VARCHAR(255) NOT NULL, used BIGINT NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS uniq_billing_usage_counter_company_period_metric ON billing_usage_counter (company_id, period_key, metric)');
+
+        if ($schema->hasTable('company')) {
+            $this->addSql(
+                <<<'SQL'
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'fk_billing_usage_counter_company'
+    ) THEN
+        ALTER TABLE billing_usage_counter
+            ADD CONSTRAINT fk_billing_usage_counter_company
+            FOREIGN KEY (company_id) REFERENCES company (id)
+            ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE;
+    END IF;
+END
+$$;
+SQL
+            );
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        if (!$schema->hasTable('billing_usage_counter')) {
+            return;
+        }
+
+        $this->addSql('DROP TABLE billing_usage_counter');
+    }
+}

--- a/src/Billing/Entity/UsageCounter.php
+++ b/src/Billing/Entity/UsageCounter.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Billing\Entity;
+
+use App\Company\Entity\Company;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: \App\Billing\Repository\UsageCounterRepository::class)]
+#[ORM\Table(name: 'billing_usage_counter')]
+#[ORM\UniqueConstraint(name: 'uniq_billing_usage_counter_company_period_metric', columns: ['company_id', 'period_key', 'metric'])]
+final class UsageCounter
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid')]
+    private string $id;
+
+    #[ORM\ManyToOne(targetEntity: Company::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private Company $company;
+
+    #[ORM\Column(name: 'period_key', type: 'string', length: 7)]
+    private string $periodKey;
+
+    #[ORM\Column(type: 'string')]
+    private string $metric;
+
+    #[ORM\Column(type: 'bigint')]
+    private int $used;
+
+    public function __construct(
+        string $id,
+        Company $company,
+        string $periodKey,
+        string $metric,
+        int $used,
+    ) {
+        $this->id = $id;
+        $this->company = $company;
+        $this->periodKey = $periodKey;
+        $this->metric = $metric;
+        $this->used = $used;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getCompany(): Company
+    {
+        return $this->company;
+    }
+
+    public function getPeriodKey(): string
+    {
+        return $this->periodKey;
+    }
+
+    public function getMetric(): string
+    {
+        return $this->metric;
+    }
+
+    public function getUsed(): int
+    {
+        return $this->used;
+    }
+}

--- a/src/Billing/Repository/UsageCounterRepository.php
+++ b/src/Billing/Repository/UsageCounterRepository.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Billing\Repository;
+
+use App\Billing\Entity\UsageCounter;
+use App\Company\Entity\Company;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Persistence\ManagerRegistry;
+use Ramsey\Uuid\Uuid;
+
+final class UsageCounterRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, UsageCounter::class);
+    }
+
+    public function findOne(Company $company, string $periodKey, string $metric): ?UsageCounter
+    {
+        return $this->findOneBy([
+            'company' => $company,
+            'periodKey' => $periodKey,
+            'metric' => $metric,
+        ]);
+    }
+
+    public function upsertAdjust(Company $company, string $periodKey, string $metric, int $by): void
+    {
+        $connection = $this->getEntityManager()->getConnection();
+
+        $sql = <<<'SQL'
+INSERT INTO billing_usage_counter (id, company_id, period_key, metric, used)
+VALUES (:id, :company_id, :period_key, :metric, :used)
+ON CONFLICT (company_id, period_key, metric)
+DO UPDATE SET used = billing_usage_counter.used + EXCLUDED.used
+SQL;
+
+        $connection->executeStatement(
+            $sql,
+            [
+                'id' => Uuid::uuid4()->toString(),
+                'company_id' => $company->getId(),
+                'period_key' => $periodKey,
+                'metric' => $metric,
+                'used' => $by,
+            ],
+            [
+                'id' => Types::GUID,
+                'company_id' => Types::GUID,
+                'period_key' => Types::STRING,
+                'metric' => Types::STRING,
+                'used' => Types::BIGINT,
+            ],
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure the `UsageCounter` entity matches the DB schema to prevent truncation/overflow by mapping `used` to `BIGINT` and constraining `period_key` to length `7`.
- Ensure DBAL binds use the correct type for `used` so increments/decrements are persisted correctly.
- Make the repository helper name neutral about sign by renaming `upsertIncrement` to `upsertAdjust` to reflect that the method can apply negative adjustments.

### Description
- Updated the `UsageCounter` entity at `src/Billing/Entity/UsageCounter.php` to set `period_key` length to `7` (`#[ORM\Column(name: 'period_key', type: 'string', length: 7)]`) and to map `used` as `bigint` (`#[ORM\Column(type: 'bigint')]`).
- Renamed `upsertIncrement` to `upsertAdjust` in `src/Billing/Repository/UsageCounterRepository.php` and updated the DBAL parameter binding for `used` to `Types::BIGINT`.
- Updated the migration `site/migrations/Version20260318120000.php` to create the `used` column as `BIGINT` in the `billing_usage_counter` table.
- Files modified: `src/Billing/Entity/UsageCounter.php`, `src/Billing/Repository/UsageCounterRepository.php`, and `site/migrations/Version20260318120000.php`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dc577fff88323af5f1e3016e4febd)