### PR TITLE
Add admin read-only Plans view and PlanAdminQueryService

### DIFF
--- a/site/composer.json
+++ b/site/composer.json
@@ -66,7 +66,8 @@
     },
     "autoload": {
         "psr-4": {
-            "App\\": "src/"
+            "App\\": "src/",
+            "App\\Billing\\": "../src/Billing/"
         }
     },
     "autoload-dev": {

--- a/site/config/packages/doctrine.yaml
+++ b/site/config/packages/doctrine.yaml
@@ -60,6 +60,12 @@ doctrine:
                 dir: '%kernel.project_dir%/src/Company/Entity'
                 prefix: 'App\Company\Entity'
                 alias: Company
+            Billing:
+                type: attribute
+                is_bundle: false
+                dir: '%kernel.project_dir%/../src/Billing/Entity'
+                prefix: 'App\Billing\Entity'
+                alias: Billing
         controller_resolver:
             auto_mapping: false
 

--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -18,6 +18,10 @@ services:
     App\:
         resource: '../src/'
 
+    App\Billing\:
+        resource: '%kernel.project_dir%/../src/Billing/'
+        exclude: '%kernel.project_dir%/../src/Billing/{Contract,Dto,Entity,Enum,Event,EventListener,Fixture,Repository,README.md}'
+
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
         # Клиент Redis для сессий

--- a/site/src/Admin/Controller/Billing/PlanAdminController.php
+++ b/site/src/Admin/Controller/Billing/PlanAdminController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Admin\Controller\Billing;
+
+use App\Billing\Service\Admin\PlanAdminQueryService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_ADMIN')]
+#[Route('/admin/billing/plans', name: 'admin_billing_plans_')]
+final class PlanAdminController extends AbstractController
+{
+    #[Route('', name: 'list', methods: ['GET'])]
+    public function list(PlanAdminQueryService $planAdminQueryService): Response
+    {
+        return $this->render('admin/billing/plans/list.html.twig', [
+            'plans' => $planAdminQueryService->getPlans(),
+        ]);
+    }
+
+    #[Route('/{id}', name: 'show', methods: ['GET'])]
+    public function show(string $id, PlanAdminQueryService $planAdminQueryService): Response
+    {
+        $plan = $planAdminQueryService->getPlan($id);
+        if (null === $plan) {
+            throw $this->createNotFoundException('План не найден.');
+        }
+
+        return $this->render('admin/billing/plans/show.html.twig', [
+            'plan' => $plan,
+            'planFeatures' => $planAdminQueryService->getPlanFeatures($plan),
+        ]);
+    }
+}

--- a/site/templates/admin/billing/index.html.twig
+++ b/site/templates/admin/billing/index.html.twig
@@ -11,7 +11,7 @@
         </div>
         <div class="card-body">
           <ul class="list-unstyled mb-0">
-            <li><a href="#">Plans</a></li>
+            <li><a href="{{ path('admin_billing_plans_list') }}">Plans</a></li>
             <li><a href="#">Features</a></li>
             <li><a href="#">Integrations</a></li>
             <li><a href="#">Subscriptions</a></li>

--- a/site/templates/admin/billing/plans/list.html.twig
+++ b/site/templates/admin/billing/plans/list.html.twig
@@ -1,0 +1,57 @@
+{% extends 'admin/base.html.twig' %}
+
+{% block title %}Admin · Billing · Plans{% endblock %}
+
+{% block body %}
+  <div class="row row-cards">
+    <div class="col-12">
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">Plans</h3>
+        </div>
+        <div class="card-body">
+          {% if plans is empty %}
+            <p class="text-muted mb-0">Планы пока не добавлены.</p>
+          {% else %}
+            <div class="table-responsive">
+              <table class="table table-vcenter table-striped">
+                <thead>
+                <tr>
+                  <th>Code</th>
+                  <th>Name</th>
+                  <th>Price</th>
+                  <th>Period</th>
+                  <th>Active</th>
+                  <th>Created</th>
+                </tr>
+                </thead>
+                <tbody>
+                {% for plan in plans %}
+                  <tr>
+                    <td>
+                      <a href="{{ path('admin_billing_plans_show', { id: plan.id }) }}">
+                        {{ plan.code }}
+                      </a>
+                    </td>
+                    <td>{{ plan.name }}</td>
+                    <td>{{ plan.priceAmount }} {{ plan.priceCurrency }}</td>
+                    <td>{{ plan.billingPeriod.value }}</td>
+                    <td>
+                      {% if plan.isActive %}
+                        <span class="badge bg-green">Да</span>
+                      {% else %}
+                        <span class="badge bg-muted">Нет</span>
+                      {% endif %}
+                    </td>
+                    <td>{{ plan.createdAt|date('Y-m-d H:i') }}</td>
+                  </tr>
+                {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/site/templates/admin/billing/plans/show.html.twig
+++ b/site/templates/admin/billing/plans/show.html.twig
@@ -1,0 +1,96 @@
+{% extends 'admin/base.html.twig' %}
+
+{% block title %}Admin · Billing · {{ plan.name }}{% endblock %}
+
+{% block body %}
+  <div class="row row-cards">
+    <div class="col-12">
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">Plan {{ plan.name }}</h3>
+          <div class="card-actions">
+            <a href="{{ path('admin_billing_plans_list') }}" class="btn btn-sm btn-outline-secondary">
+              Назад к списку
+            </a>
+          </div>
+        </div>
+        <div class="card-body">
+          <div class="table-responsive">
+            <table class="table table-vcenter">
+              <tbody>
+              <tr>
+                <th>Code</th>
+                <td>{{ plan.code }}</td>
+              </tr>
+              <tr>
+                <th>Name</th>
+                <td>{{ plan.name }}</td>
+              </tr>
+              <tr>
+                <th>Price</th>
+                <td>{{ plan.priceAmount }} {{ plan.priceCurrency }}</td>
+              </tr>
+              <tr>
+                <th>Period</th>
+                <td>{{ plan.billingPeriod.value }}</td>
+              </tr>
+              <tr>
+                <th>Active</th>
+                <td>
+                  {% if plan.isActive %}
+                    <span class="badge bg-green">Да</span>
+                  {% else %}
+                    <span class="badge bg-muted">Нет</span>
+                  {% endif %}
+                </td>
+              </tr>
+              <tr>
+                <th>Created</th>
+                <td>{{ plan.createdAt|date('Y-m-d H:i') }}</td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row row-cards">
+    <div class="col-12">
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">Plan features</h3>
+        </div>
+        <div class="card-body">
+          {% if planFeatures is empty %}
+            <p class="text-muted mb-0">Для этого плана нет настроенных фич.</p>
+          {% else %}
+            <div class="table-responsive">
+              <table class="table table-vcenter table-striped">
+                <thead>
+                <tr>
+                  <th>Feature</th>
+                  <th>Value</th>
+                  <th>Soft limit</th>
+                  <th>Hard limit</th>
+                </tr>
+                </thead>
+                <tbody>
+                {% for planFeature in planFeatures %}
+                  <tr>
+                    <td>{{ planFeature.feature.code }}</td>
+                    <td>{{ planFeature.value }}</td>
+                    <td>{{ planFeature.softLimit ?? '—' }}</td>
+                    <td>{{ planFeature.hardLimit ?? '—' }}</td>
+                  </tr>
+                {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/src/Billing/Repository/PlanRepository.php
+++ b/src/Billing/Repository/PlanRepository.php
@@ -35,6 +35,18 @@ final class PlanRepository extends ServiceEntityRepository
     /**
      * @return Plan[]
      */
+    public function findAllOrderedByCreatedAt(): array
+    {
+        return $this->createQueryBuilder('plan')
+            ->orderBy('plan.createdAt', 'DESC')
+            ->addOrderBy('plan.code', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * @return Plan[]
+     */
     public function findAllActiveOrdered(): array
     {
         return $this->createQueryBuilder('plan')

--- a/src/Billing/Service/Admin/PlanAdminQueryService.php
+++ b/src/Billing/Service/Admin/PlanAdminQueryService.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Billing\Service\Admin;
+
+use App\Billing\Entity\Plan;
+use App\Billing\Entity\PlanFeature;
+use App\Billing\Repository\PlanFeatureRepository;
+use App\Billing\Repository\PlanRepository;
+
+final class PlanAdminQueryService
+{
+    public function __construct(
+        private readonly PlanRepository $planRepository,
+        private readonly PlanFeatureRepository $planFeatureRepository,
+    ) {
+    }
+
+    /**
+     * @return Plan[]
+     */
+    public function getPlans(): array
+    {
+        return $this->planRepository->findAllOrderedByCreatedAt();
+    }
+
+    public function getPlan(string $id): ?Plan
+    {
+        return $this->planRepository->find($id);
+    }
+
+    /**
+     * @return PlanFeature[]
+     */
+    public function getPlanFeatures(Plan $plan): array
+    {
+        return $this->planFeatureRepository->findByPlan($plan);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal read-only admin UI for Billing Plans so admins can browse plans and their features without editing them. 
- Keep controllers lightweight and avoid direct Doctrine usage by moving DB access into a dedicated query service (`PlanAdminQueryService`).
- Wire the existing `src/Billing` module into the Symfony `site/` app so templates and services can use billing entities and repositories.

### Description
- Added a query service `src/Billing/Service/Admin/PlanAdminQueryService.php` that reads plans and plan features via `PlanRepository` and `PlanFeatureRepository` and exposes `getPlans()`, `getPlan()` and `getPlanFeatures()`.
- Extended `src/Billing/Repository/PlanRepository.php` with `findAllOrderedByCreatedAt()` for ordered plan listing.
- Implemented a lightweight controller `site/src/Admin/Controller/Billing/PlanAdminController.php` with routes `GET /admin/billing/plans` and `GET /admin/billing/plans/{id}` guarded by `ROLE_ADMIN`, and which delegates all reads to `PlanAdminQueryService`.
- Added read-only Twig templates `site/templates/admin/billing/plans/list.html.twig` and `site/templates/admin/billing/plans/show.html.twig` and linked the billing index to the plans list in `site/templates/admin/billing/index.html.twig`.
- Wired the billing module into the `site/` app by updating `site/composer.json` PSR-4 autoload, `site/config/packages/doctrine.yaml` to include `App\Billing\Entity` mappings, and `site/config/services.yaml` to register `App\Billing\` services (excluding entity/repository folders).

### Testing
- No automated tests were executed as part of this change (no test run requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e35b5aa208323a3776b2f9dac7913)