### PR TITLE
Add admin billing plans (list/show) and PlanAdminQueryService

### DIFF
--- a/site/composer.json
+++ b/site/composer.json
@@ -66,7 +66,8 @@
     },
     "autoload": {
         "psr-4": {
-            "App\\": "src/"
+            "App\\": "src/",
+            "App\\Billing\\": "../src/Billing/"
         }
     },
     "autoload-dev": {

--- a/site/config/packages/doctrine.yaml
+++ b/site/config/packages/doctrine.yaml
@@ -24,6 +24,12 @@ doctrine:
                 dir: '%kernel.project_dir%/src/Entity'
                 prefix: 'App\Entity'
                 alias: App
+            Billing:
+                type: attribute
+                is_bundle: false
+                dir: '%kernel.project_dir%/../src/Billing/Entity'
+                prefix: 'App\Billing\Entity'
+                alias: Billing
             Ai:
                 type: attribute
                 is_bundle: false

--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -18,6 +18,9 @@ services:
     App\:
         resource: '../src/'
 
+    App\Billing\:
+        resource: '%kernel.project_dir%/../src/Billing'
+
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
         # Клиент Redis для сессий

--- a/site/src/Admin/Controller/Billing/PlanAdminController.php
+++ b/site/src/Admin/Controller/Billing/PlanAdminController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Admin\Controller\Billing;
+
+use App\Billing\Service\Admin\PlanAdminQueryService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_ADMIN')]
+#[Route('/admin/billing/plans', name: 'admin_billing_plans_')]
+final class PlanAdminController extends AbstractController
+{
+    #[Route('', name: 'list', methods: ['GET'])]
+    public function list(PlanAdminQueryService $planAdminQueryService): Response
+    {
+        return $this->render('admin/billing/plans/list.html.twig', [
+            'plans' => $planAdminQueryService->getPlans(),
+        ]);
+    }
+
+    #[Route('/{id}', name: 'show', methods: ['GET'])]
+    public function show(string $id, PlanAdminQueryService $planAdminQueryService): Response
+    {
+        $plan = $planAdminQueryService->getPlan($id);
+        if (null === $plan) {
+            throw $this->createNotFoundException('План не найден.');
+        }
+
+        return $this->render('admin/billing/plans/show.html.twig', [
+            'plan' => $plan,
+            'planFeatures' => $planAdminQueryService->getPlanFeatures($plan),
+        ]);
+    }
+}

--- a/site/templates/admin/billing/index.html.twig
+++ b/site/templates/admin/billing/index.html.twig
@@ -11,7 +11,7 @@
         </div>
         <div class="card-body">
           <ul class="list-unstyled mb-0">
-            <li><a href="#">Plans</a></li>
+            <li><a href="{{ path('admin_billing_plans_list') }}">Plans</a></li>
             <li><a href="#">Features</a></li>
             <li><a href="#">Integrations</a></li>
             <li><a href="#">Subscriptions</a></li>

--- a/site/templates/admin/billing/plans/list.html.twig
+++ b/site/templates/admin/billing/plans/list.html.twig
@@ -1,0 +1,60 @@
+{% extends 'admin/base.html.twig' %}
+
+{% block title %}Admin · Billing планы{% endblock %}
+
+{% block body %}
+  <div class="page-header d-print-none">
+    <div class="row align-items-center">
+      <div class="col">
+        <h2 class="page-title">Планы биллинга</h2>
+      </div>
+    </div>
+  </div>
+
+  <div class="card mt-3">
+    <div class="card-body">
+      {% if plans is not empty %}
+        <div class="table-responsive">
+          <table class="table table-vcenter">
+            <thead>
+              <tr>
+                <th scope="col">Код</th>
+                <th scope="col">Название</th>
+                <th scope="col">Цена</th>
+                <th scope="col">Период</th>
+                <th scope="col">Активен</th>
+                <th scope="col">Создан</th>
+                <th scope="col" class="text-end">Детали</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for plan in plans %}
+                <tr>
+                  <td><code>{{ plan.code }}</code></td>
+                  <td>{{ plan.name }}</td>
+                  <td>{{ plan.priceAmount }} {{ plan.priceCurrency }}</td>
+                  <td>{{ plan.billingPeriod.value }}</td>
+                  <td>
+                    {% if plan.isActive %}
+                      <span class="badge bg-success-lt">Да</span>
+                    {% else %}
+                      <span class="badge bg-secondary-lt">Нет</span>
+                    {% endif %}
+                  </td>
+                  <td>{{ plan.createdAt|date('d.m.Y H:i') }}</td>
+                  <td class="text-end">
+                    <a class="btn btn-primary btn-sm" href="{{ path('admin_billing_plans_show', { id: plan.id }) }}">
+                      Открыть
+                    </a>
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% else %}
+        <p class="text-muted mb-0">Планы пока не созданы.</p>
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}

--- a/site/templates/admin/billing/plans/show.html.twig
+++ b/site/templates/admin/billing/plans/show.html.twig
@@ -1,0 +1,81 @@
+{% extends 'admin/base.html.twig' %}
+
+{% block title %}Admin · План {{ plan.code }}{% endblock %}
+
+{% block body %}
+  <div class="page-header d-print-none">
+    <div class="row align-items-center">
+      <div class="col">
+        <h2 class="page-title">План {{ plan.name }}</h2>
+        <div class="text-muted mt-1">{{ plan.code }}</div>
+      </div>
+      <div class="col-auto ms-auto">
+        <a class="btn" href="{{ path('admin_billing_plans_list') }}">Назад к списку</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="card mt-3">
+    <div class="card-body">
+      <dl class="row mb-0">
+        <dt class="col-12 col-md-3 text-muted">Код</dt>
+        <dd class="col-12 col-md-9"><code>{{ plan.code }}</code></dd>
+
+        <dt class="col-12 col-md-3 text-muted">Название</dt>
+        <dd class="col-12 col-md-9">{{ plan.name }}</dd>
+
+        <dt class="col-12 col-md-3 text-muted">Цена</dt>
+        <dd class="col-12 col-md-9">{{ plan.priceAmount }} {{ plan.priceCurrency }}</dd>
+
+        <dt class="col-12 col-md-3 text-muted">Период</dt>
+        <dd class="col-12 col-md-9">{{ plan.billingPeriod.value }}</dd>
+
+        <dt class="col-12 col-md-3 text-muted">Активен</dt>
+        <dd class="col-12 col-md-9">
+          {% if plan.isActive %}
+            <span class="badge bg-success-lt">Да</span>
+          {% else %}
+            <span class="badge bg-secondary-lt">Нет</span>
+          {% endif %}
+        </dd>
+
+        <dt class="col-12 col-md-3 text-muted">Создан</dt>
+        <dd class="col-12 col-md-9">{{ plan.createdAt|date('d.m.Y H:i') }}</dd>
+      </dl>
+    </div>
+  </div>
+
+  <div class="card mt-3">
+    <div class="card-header">
+      <h3 class="card-title">Фичи плана</h3>
+    </div>
+    <div class="card-body">
+      {% if planFeatures is not empty %}
+        <div class="table-responsive">
+          <table class="table table-vcenter">
+            <thead>
+              <tr>
+                <th scope="col">Feature</th>
+                <th scope="col">Значение</th>
+                <th scope="col">Soft limit</th>
+                <th scope="col">Hard limit</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for planFeature in planFeatures %}
+                <tr>
+                  <td><code>{{ planFeature.feature.code }}</code></td>
+                  <td>{{ planFeature.value }}</td>
+                  <td>{{ planFeature.softLimit is not null ? planFeature.softLimit : '—' }}</td>
+                  <td>{{ planFeature.hardLimit is not null ? planFeature.hardLimit : '—' }}</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% else %}
+        <p class="text-muted mb-0">Для плана нет настроенных фич.</p>
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}

--- a/src/Billing/Repository/PlanRepository.php
+++ b/src/Billing/Repository/PlanRepository.php
@@ -45,4 +45,16 @@ final class PlanRepository extends ServiceEntityRepository
             ->getQuery()
             ->getResult();
     }
+
+    /**
+     * @return Plan[]
+     */
+    public function findAllOrdered(): array
+    {
+        return $this->createQueryBuilder('plan')
+            ->orderBy('plan.createdAt', 'DESC')
+            ->addOrderBy('plan.code', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/src/Billing/Service/Admin/PlanAdminQueryService.php
+++ b/src/Billing/Service/Admin/PlanAdminQueryService.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Billing\Service\Admin;
+
+use App\Billing\Entity\Plan;
+use App\Billing\Entity\PlanFeature;
+use App\Billing\Repository\PlanFeatureRepository;
+use App\Billing\Repository\PlanRepository;
+
+final class PlanAdminQueryService
+{
+    public function __construct(
+        private readonly PlanRepository $planRepository,
+        private readonly PlanFeatureRepository $planFeatureRepository,
+    ) {
+    }
+
+    /**
+     * @return Plan[]
+     */
+    public function getPlans(): array
+    {
+        return $this->planRepository->findAllOrdered();
+    }
+
+    public function getPlan(string $id): ?Plan
+    {
+        return $this->planRepository->find($id);
+    }
+
+    /**
+     * @return PlanFeature[]
+     */
+    public function getPlanFeatures(Plan $plan): array
+    {
+        return $this->planFeatureRepository->findByPlan($plan);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, read-only admin UI to browse billing `Plan` entities and their `PlanFeature`s without adding editing functionality.
- Keep Doctrine access inside repository/service layer by introducing a dedicated admin query service for billing reads.
- Expose Billing domain classes to the `site` application so admin pages can load billing entities via Doctrine mappings and autoloading.

### Description
- Added a read-only controller `App\Admin\Controller\Billing\PlanAdminController` with routes `GET /admin/billing/plans` (list) and `GET /admin/billing/plans/{id}` (show) protected by `ROLE_ADMIN` and delegating reads to a service.
- Implemented `App\Billing\Service\Admin\PlanAdminQueryService` that uses `PlanRepository` and `PlanFeatureRepository` to return plans and plan features; controller does not access Doctrine directly.
- Added `PlanRepository::findAllOrdered()` to provide an ordered plan list for the admin UI.
- Created Twig templates `site/templates/admin/billing/plans/list.html.twig` and `site/templates/admin/billing/plans/show.html.twig` to display fields `code`, `name`, `price`, `billingPeriod`, `isActive`, `createdAt` and plan features (`feature.code`, `value`, `softLimit`, `hardLimit`) in the show view.
- Wired Billing into the `site` app by updating `site/composer.json` (PSR-4 for `App\Billing\`), `site/config/services.yaml` (service resource for `App\Billing\`), and `site/config/packages/doctrine.yaml` (ORM mapping for `App\Billing\Entity`).
- Minor UX: linked billing dashboard entry to the new plans list; the UI is strictly read-only and contains no forms.

### Testing
- No automated tests were run as part of this change (no `phpunit`/CI executed in this rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e3aea805c83238d459cb1dfcd2dac)