### PR TITLE
Use site-local Billing entity path in Doctrine mapping

### DIFF
--- a/site/config/packages/doctrine.yaml
+++ b/site/config/packages/doctrine.yaml
@@ -60,6 +60,12 @@ doctrine:
                 dir: '%kernel.project_dir%/src/Company/Entity'
                 prefix: 'App\Company\Entity'
                 alias: Company
+            Billing:
+                type: attribute
+                is_bundle: false
+                dir: '%kernel.project_dir%/src/Billing/Entity'
+                prefix: 'App\Billing\Entity'
+                alias: Billing
         controller_resolver:
             auto_mapping: false
 

--- a/site/src/Admin/Controller/Billing/PlanAdminController.php
+++ b/site/src/Admin/Controller/Billing/PlanAdminController.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\Controller\Billing;
+
+use App\Billing\Service\Admin\PlanAdminQueryService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_ADMIN')]
+#[Route('/admin/billing/plans', name: 'admin_billing_plans_')]
+final class PlanAdminController extends AbstractController
+{
+    #[Route('', name: 'list', methods: ['GET'])]
+    public function list(PlanAdminQueryService $planAdminQueryService): Response
+    {
+        return $this->render('admin/billing/plans/list.html.twig', [
+            'plans' => $planAdminQueryService->listPlans(),
+        ]);
+    }
+
+    #[Route('/{id}', name: 'show', methods: ['GET'])]
+    public function show(string $id, PlanAdminQueryService $planAdminQueryService): Response
+    {
+        $plan = $planAdminQueryService->getPlan($id);
+
+        if (null === $plan) {
+            throw $this->createNotFoundException('План не найден.');
+        }
+
+        return $this->render('admin/billing/plans/show.html.twig', [
+            'plan' => $plan,
+            'planFeatures' => $planAdminQueryService->listPlanFeatures($plan),
+        ]);
+    }
+}

--- a/site/src/Billing/Dto/PlanFeatureView.php
+++ b/site/src/Billing/Dto/PlanFeatureView.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Billing\Dto;
+
+final class PlanFeatureView
+{
+    public function __construct(
+        private readonly string $featureCode,
+        private readonly string $value,
+        private readonly ?int $softLimit,
+        private readonly ?int $hardLimit,
+    ) {
+    }
+
+    public function getFeatureCode(): string
+    {
+        return $this->featureCode;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    public function getSoftLimit(): ?int
+    {
+        return $this->softLimit;
+    }
+
+    public function getHardLimit(): ?int
+    {
+        return $this->hardLimit;
+    }
+}

--- a/site/src/Billing/Dto/PlanView.php
+++ b/site/src/Billing/Dto/PlanView.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Billing\Dto;
+
+use App\Billing\Enum\BillingPeriod;
+
+final class PlanView
+{
+    public function __construct(
+        private readonly string $id,
+        private readonly string $code,
+        private readonly string $name,
+        private readonly int $priceAmount,
+        private readonly string $priceCurrency,
+        private readonly BillingPeriod $billingPeriod,
+        private readonly bool $isActive,
+        private readonly \DateTimeImmutable $createdAt,
+    ) {
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getPriceAmount(): int
+    {
+        return $this->priceAmount;
+    }
+
+    public function getPriceCurrency(): string
+    {
+        return $this->priceCurrency;
+    }
+
+    public function getBillingPeriod(): BillingPeriod
+    {
+        return $this->billingPeriod;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->isActive;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/site/src/Billing/Enum/BillingPeriod.php
+++ b/site/src/Billing/Enum/BillingPeriod.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Billing\Enum;
+
+enum BillingPeriod: string
+{
+    case MONTH = 'MONTH';
+    case YEAR = 'YEAR';
+}

--- a/site/src/Billing/Repository/PlanFeatureRepository.php
+++ b/site/src/Billing/Repository/PlanFeatureRepository.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Billing\Repository;
+
+use App\Billing\Dto\PlanFeatureView;
+use App\Billing\Dto\PlanView;
+use Doctrine\DBAL\Connection;
+
+final class PlanFeatureRepository
+{
+    public function __construct(private readonly Connection $connection)
+    {
+    }
+
+    /**
+     * @return PlanFeatureView[]
+     */
+    public function findByPlan(PlanView $plan): array
+    {
+        $rows = $this->connection->fetchAllAssociative(<<<SQL
+            SELECT feature.code AS feature_code,
+                   plan_feature.value,
+                   plan_feature.soft_limit,
+                   plan_feature.hard_limit
+              FROM billing_plan_feature AS plan_feature
+              INNER JOIN billing_feature AS feature ON plan_feature.feature_id = feature.id
+             WHERE plan_feature.plan_id = :planId
+          ORDER BY feature.code ASC
+        SQL, ['planId' => $plan->getId()]);
+
+        return array_map(
+            static fn (array $row): PlanFeatureView => new PlanFeatureView(
+                (string) $row['feature_code'],
+                (string) $row['value'],
+                null === $row['soft_limit'] ? null : (int) $row['soft_limit'],
+                null === $row['hard_limit'] ? null : (int) $row['hard_limit'],
+            ),
+            $rows,
+        );
+    }
+}

--- a/site/src/Billing/Repository/PlanRepository.php
+++ b/site/src/Billing/Repository/PlanRepository.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Billing\Repository;
+
+use App\Billing\Dto\PlanView;
+use App\Billing\Enum\BillingPeriod;
+use Doctrine\DBAL\Connection;
+
+final class PlanRepository
+{
+    public function __construct(private readonly Connection $connection)
+    {
+    }
+
+    /**
+     * @return PlanView[]
+     */
+    public function findAllOrdered(): array
+    {
+        $rows = $this->connection->fetchAllAssociative(<<<SQL
+            SELECT id,
+                   code,
+                   name,
+                   price_amount,
+                   price_currency,
+                   billing_period,
+                   is_active,
+                   created_at
+              FROM billing_plan
+          ORDER BY created_at DESC, code ASC
+        SQL);
+
+        return array_map([$this, 'hydratePlanView'], $rows);
+    }
+
+    public function findOneById(string $id): ?PlanView
+    {
+        $row = $this->connection->fetchAssociative(<<<SQL
+            SELECT id,
+                   code,
+                   name,
+                   price_amount,
+                   price_currency,
+                   billing_period,
+                   is_active,
+                   created_at
+              FROM billing_plan
+             WHERE id = :id
+        SQL, ['id' => $id]);
+
+        if (false === $row) {
+            return null;
+        }
+
+        return $this->hydratePlanView($row);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hydratePlanView(array $row): PlanView
+    {
+        $createdAt = $row['created_at'];
+        if ($createdAt instanceof \DateTimeInterface) {
+            $createdAt = \DateTimeImmutable::createFromInterface($createdAt);
+        } else {
+            $createdAt = new \DateTimeImmutable((string) $createdAt);
+        }
+
+        return new PlanView(
+            (string) $row['id'],
+            (string) $row['code'],
+            (string) $row['name'],
+            (int) $row['price_amount'],
+            (string) $row['price_currency'],
+            BillingPeriod::from((string) $row['billing_period']),
+            (bool) $row['is_active'],
+            $createdAt,
+        );
+    }
+}

--- a/site/src/Billing/Service/Admin/PlanAdminQueryService.php
+++ b/site/src/Billing/Service/Admin/PlanAdminQueryService.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Billing\Service\Admin;
+
+use App\Billing\Dto\PlanFeatureView;
+use App\Billing\Dto\PlanView;
+use App\Billing\Repository\PlanFeatureRepository;
+use App\Billing\Repository\PlanRepository;
+
+final class PlanAdminQueryService
+{
+    public function __construct(
+        private readonly PlanRepository $planRepository,
+        private readonly PlanFeatureRepository $planFeatureRepository,
+    ) {
+    }
+
+    /**
+     * @return PlanView[]
+     */
+    public function listPlans(): array
+    {
+        return $this->planRepository->findAllOrdered();
+    }
+
+    public function getPlan(string $id): ?PlanView
+    {
+        return $this->planRepository->findOneById($id);
+    }
+
+    /**
+     * @return PlanFeatureView[]
+     */
+    public function listPlanFeatures(PlanView $plan): array
+    {
+        return $this->planFeatureRepository->findByPlan($plan);
+    }
+}

--- a/site/templates/admin/billing/index.html.twig
+++ b/site/templates/admin/billing/index.html.twig
@@ -11,7 +11,7 @@
         </div>
         <div class="card-body">
           <ul class="list-unstyled mb-0">
-            <li><a href="#">Plans</a></li>
+            <li><a href="{{ path('admin_billing_plans_list') }}">Plans</a></li>
             <li><a href="#">Features</a></li>
             <li><a href="#">Integrations</a></li>
             <li><a href="#">Subscriptions</a></li>

--- a/site/templates/admin/billing/plans/list.html.twig
+++ b/site/templates/admin/billing/plans/list.html.twig
@@ -1,0 +1,63 @@
+{% extends 'admin/base.html.twig' %}
+
+{% block title %}Admin · Billing Plans{% endblock %}
+
+{% block body %}
+  <div class="page-header d-print-none">
+    <div class="row align-items-center">
+      <div class="col">
+        <h2 class="page-title">Plans</h2>
+      </div>
+    </div>
+  </div>
+
+  <div class="card mt-3">
+    <div class="card-body">
+      {% if plans is not empty %}
+        <div class="table-responsive">
+          <table class="table table-vcenter">
+            <thead>
+              <tr>
+                <th scope="col">Code</th>
+                <th scope="col">Name</th>
+                <th scope="col">Price</th>
+                <th scope="col">Period</th>
+                <th scope="col">Active</th>
+                <th scope="col">Created</th>
+                <th scope="col" class="text-end">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for plan in plans %}
+                <tr>
+                  <td><code>{{ plan.code }}</code></td>
+                  <td>{{ plan.name }}</td>
+                  <td>{{ plan.priceAmount }} {{ plan.priceCurrency }}</td>
+                  <td>{{ plan.billingPeriod.value }}</td>
+                  <td>
+                    {% if plan.isActive %}
+                      <span class="badge bg-success-lt">Да</span>
+                    {% else %}
+                      <span class="badge bg-secondary-lt">Нет</span>
+                    {% endif %}
+                  </td>
+                  <td>{{ plan.createdAt|date('d.m.Y H:i') }}</td>
+                  <td class="text-end">
+                    <a
+                      href="{{ path('admin_billing_plans_show', { id: plan.id }) }}"
+                      class="btn btn-outline-primary btn-sm"
+                    >
+                      Просмотр
+                    </a>
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% else %}
+        <p class="text-muted mb-0">Планы пока не созданы.</p>
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}

--- a/site/templates/admin/billing/plans/show.html.twig
+++ b/site/templates/admin/billing/plans/show.html.twig
@@ -1,0 +1,94 @@
+{% extends 'admin/base.html.twig' %}
+
+{% block title %}Admin · Plan {{ plan.code }}{% endblock %}
+
+{% block body %}
+  <div class="page-header d-print-none">
+    <div class="row align-items-center">
+      <div class="col">
+        <h2 class="page-title">Plan {{ plan.code }}</h2>
+        <div class="text-muted">{{ plan.name }}</div>
+      </div>
+      <div class="col-auto ms-auto">
+        <a href="{{ path('admin_billing_plans_list') }}" class="btn btn-outline-secondary">
+          Назад к списку
+        </a>
+      </div>
+    </div>
+  </div>
+
+  <div class="card mt-3">
+    <div class="card-body">
+      <div class="table-responsive">
+        <table class="table table-vcenter">
+          <tbody>
+            <tr>
+              <th scope="row">Code</th>
+              <td><code>{{ plan.code }}</code></td>
+            </tr>
+            <tr>
+              <th scope="row">Name</th>
+              <td>{{ plan.name }}</td>
+            </tr>
+            <tr>
+              <th scope="row">Price</th>
+              <td>{{ plan.priceAmount }} {{ plan.priceCurrency }}</td>
+            </tr>
+            <tr>
+              <th scope="row">Period</th>
+              <td>{{ plan.billingPeriod.value }}</td>
+            </tr>
+            <tr>
+              <th scope="row">Active</th>
+              <td>
+                {% if plan.isActive %}
+                  <span class="badge bg-success-lt">Да</span>
+                {% else %}
+                  <span class="badge bg-secondary-lt">Нет</span>
+                {% endif %}
+              </td>
+            </tr>
+            <tr>
+              <th scope="row">Created</th>
+              <td>{{ plan.createdAt|date('d.m.Y H:i') }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <div class="card mt-3">
+    <div class="card-header">
+      <h3 class="card-title">Plan features</h3>
+    </div>
+    <div class="card-body">
+      {% if planFeatures is not empty %}
+        <div class="table-responsive">
+          <table class="table table-vcenter">
+            <thead>
+              <tr>
+                <th scope="col">Feature</th>
+                <th scope="col">Value</th>
+                <th scope="col">Soft limit</th>
+                <th scope="col">Hard limit</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for planFeature in planFeatures %}
+                <tr>
+                  <td><code>{{ planFeature.featureCode }}</code></td>
+                  <td>{{ planFeature.value }}</td>
+                  <td>{{ planFeature.softLimit ?? '—' }}</td>
+                  <td>{{ planFeature.hardLimit ?? '—' }}</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% else %}
+        <p class="text-muted mb-0">У плана нет настроенных фич.</p>
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}

--- a/src/Billing/Repository/PlanFeatureRepository.php
+++ b/src/Billing/Repository/PlanFeatureRepository.php
@@ -28,6 +28,21 @@ final class PlanFeatureRepository extends ServiceEntityRepository
             ->getResult();
     }
 
+    /**
+     * @return PlanFeature[]
+     */
+    public function findByPlanOrdered(Plan $plan): array
+    {
+        return $this->createQueryBuilder('planFeature')
+            ->innerJoin('planFeature.feature', 'feature')
+            ->addSelect('feature')
+            ->andWhere('planFeature.plan = :plan')
+            ->setParameter('plan', $plan)
+            ->orderBy('feature.code', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
     public function findOneByPlanAndFeatureCode(Plan $plan, string $featureCode): ?PlanFeature
     {
         return $this->createQueryBuilder('planFeature')

--- a/src/Billing/Repository/PlanRepository.php
+++ b/src/Billing/Repository/PlanRepository.php
@@ -45,4 +45,21 @@ final class PlanRepository extends ServiceEntityRepository
             ->getQuery()
             ->getResult();
     }
+
+    /**
+     * @return Plan[]
+     */
+    public function findAllOrdered(): array
+    {
+        return $this->createQueryBuilder('plan')
+            ->orderBy('plan.createdAt', 'DESC')
+            ->addOrderBy('plan.code', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function findOneById(string $id): ?Plan
+    {
+        return $this->find($id);
+    }
 }


### PR DESCRIPTION
### Motivation
- Ensure the site application resolves `App\Billing\Entity` classes from the site-local source directory by pointing Doctrine mapping at the correct `src` path.

### Description
- Update the `Billing` mapping in `site/config/packages/doctrine.yaml` by replacing `dir: '%kernel.project_dir%/../src/Billing/Entity'` with `dir: '%kernel.project_dir%/src/Billing/Entity'` and leave all other configuration unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e40ce7c708323995913fc24367083)