### PR TITLE
Use enum for audit log action

### DIFF
--- a/site/migrations/Version20260317210000.php
+++ b/site/migrations/Version20260317210000.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260317210000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add audit log table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE audit_log (id UUID NOT NULL, company_id UUID NOT NULL, entity_class VARCHAR(255) NOT NULL, entity_id VARCHAR(255) NOT NULL, action VARCHAR(16) NOT NULL, diff JSON DEFAULT NULL, actor_user_id UUID DEFAULT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX idx_audit_log_company_created_at ON audit_log (company_id, created_at)');
+        $this->addSql('CREATE INDEX idx_audit_log_entity_created_at ON audit_log (entity_class, entity_id, created_at)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE audit_log');
+    }
+}

--- a/site/src/Shared/Entity/AuditLog.php
+++ b/site/src/Shared/Entity/AuditLog.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Entity;
+
+use App\Shared\Enum\AuditLogAction;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'audit_log')]
+#[ORM\Index(name: 'idx_audit_log_company_created_at', columns: ['company_id', 'created_at'])]
+#[ORM\Index(name: 'idx_audit_log_entity_created_at', columns: ['entity_class', 'entity_id', 'created_at'])]
+class AuditLog
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid', unique: true)]
+    private string $id;
+
+    #[ORM\Column(name: 'company_id', type: 'guid')]
+    private string $companyId;
+
+    #[ORM\Column(name: 'entity_class', length: 255)]
+    private string $entityClass;
+
+    #[ORM\Column(name: 'entity_id', length: 255)]
+    private string $entityId;
+
+    #[ORM\Column(enumType: AuditLogAction::class)]
+    private AuditLogAction $action;
+
+    #[ORM\Column(type: 'json', nullable: true)]
+    private ?array $diff;
+
+    #[ORM\Column(name: 'actor_user_id', type: 'guid', nullable: true)]
+    private ?string $actorUserId;
+
+    #[ORM\Column(name: 'created_at', type: 'datetime_immutable')]
+    private \DateTimeImmutable $createdAt;
+
+    /**
+     * @param array<string, mixed>|null $diff
+     */
+    public function __construct(
+        string $companyId,
+        string $entityClass,
+        string $entityId,
+        AuditLogAction $action,
+        ?array $diff = null,
+        ?string $actorUserId = null,
+        ?\DateTimeImmutable $createdAt = null,
+    ) {
+        $this->id = Uuid::uuid4()->toString();
+        $this->companyId = $companyId;
+        $this->entityClass = $entityClass;
+        $this->entityId = $entityId;
+        $this->action = $action;
+        $this->diff = $diff;
+        $this->actorUserId = $actorUserId;
+        $this->createdAt = $createdAt ?? new \DateTimeImmutable();
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getCompanyId(): string
+    {
+        return $this->companyId;
+    }
+
+    public function getEntityClass(): string
+    {
+        return $this->entityClass;
+    }
+
+    public function getEntityId(): string
+    {
+        return $this->entityId;
+    }
+
+    public function getAction(): AuditLogAction
+    {
+        return $this->action;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getDiff(): ?array
+    {
+        return $this->diff;
+    }
+
+    public function getActorUserId(): ?string
+    {
+        return $this->actorUserId;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/site/src/Shared/Enum/AuditLogAction.php
+++ b/site/src/Shared/Enum/AuditLogAction.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Enum;
+
+enum AuditLogAction: string
+{
+    case CREATE = 'CREATE';
+    case UPDATE = 'UPDATE';
+    case SOFT_DELETE = 'SOFT_DELETE';
+    case RESTORE = 'RESTORE';
+}


### PR DESCRIPTION
### Motivation
- Replace an untyped string `action` with a PHP enum to enforce valid action values and improve type-safety when creating and querying audit records.

### Description
- Added `App\Shared\Enum\AuditLogAction` at `site/src/Shared/Enum/AuditLogAction.php` and updated `App\Shared\Entity\AuditLog` at `site/src/Shared/Entity/AuditLog.php` to use `AuditLogAction` via Doctrine `enumType`, adjusting the constructor signature and getters accordingly, while leaving the existing migration (`site/migrations/Version20260317210000.php`) compatible with a `VARCHAR(16)` `action` column.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698352991de083239895e9cd85512914)