### PR TITLE
Finalize cash file import jobs on success or failure

### DIFF
--- a/site/src/Cash/MessageHandler/Import/CashFileImportHandler.php
+++ b/site/src/Cash/MessageHandler/Import/CashFileImportHandler.php
@@ -29,7 +29,9 @@ final class CashFileImportHandler
                 LockMode::PESSIMISTIC_WRITE
             );
             if (!$job instanceof CashFileImportJob) {
-                throw new \InvalidArgumentException('Cash file import job not found.');
+                $this->entityManager->commit();
+
+                return;
             }
 
             if (CashFileImportJob::STATUS_QUEUED !== $job->getStatus()) {
@@ -50,12 +52,20 @@ final class CashFileImportHandler
         try {
             $this->importService->import($job);
             $job->finishOk();
+            $job->setErrorMessage(null);
             $this->entityManager->flush();
         } catch (\Throwable $exception) {
-            $job->fail($exception->getMessage());
-            $this->entityManager->flush();
+            $message = sprintf(
+                '[%s] %s at %s:%d',
+                $exception::class,
+                $exception->getMessage(),
+                $exception->getFile(),
+                $exception->getLine()
+            );
+            $message = mb_substr($message, 0, 2000);
 
-            throw $exception;
+            $job->fail($message);
+            $this->entityManager->flush();
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Import jobs previously could remain in `processing` with null `finished_at` and `error_message` when unhandled exceptions occurred during import. 
- Ensure every import job is finalized (either `done` or `failed`) and that failures record a concise error message without changing business import logic.

### Description
- Modified `site/src/Cash/MessageHandler/Import/CashFileImportHandler.php` to commit-and-return when a job is not found, keeping existing behaviour for non-queued jobs. 
- On successful import the handler now calls `$job->finishOk()`, clears `error_message` with `$job->setErrorMessage(null)` and flushes the entity manager. 
- On exception the handler records a trimmed error string in the form `[%s] %s at %s:%d` (truncated to 2000 chars) and calls `$job->fail($message)` and flushes, without rethrowing the exception so the job is finalized and the message is not retried. 
- No new dependencies, tables or migrations were added and existing import logic inside `importService->import($job)` was not modified; no logger was present in the handler so no logger calls were added.

### Testing
- No automated tests were executed as part of this change. 
- Key manual verification steps to run in production are: run an import from UI, wait for message processing, and verify the corresponding `cash_file_import_jobs` row has `status` = `done` or `failed` and `finished_at` populated, and that `error_message` contains the recorded exception info when applicable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698751465f508323a8a63721e9a68f35)