### PR TITLE
Catalog: set purchase price action without implicit company context

### DIFF
--- a/site/src/Catalog/Application/SetPurchasePriceAction.php
+++ b/site/src/Catalog/Application/SetPurchasePriceAction.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application;
+
+use App\Catalog\DTO\SetPurchasePriceCommand;
+use App\Catalog\Domain\PurchasePriceTimelinePolicy;
+use App\Catalog\Entity\ProductPurchasePrice;
+use App\Catalog\Infrastructure\ProductRepository;
+use App\Catalog\Infrastructure\Repository\ProductPurchasePriceRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Uid\Uuid;
+
+final class SetPurchasePriceAction
+{
+    public function __construct(
+        private readonly ProductRepository $productRepository,
+        private readonly ProductPurchasePriceRepository $productPurchasePriceRepository,
+        private readonly PurchasePriceTimelinePolicy $purchasePriceTimelinePolicy,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function __invoke(SetPurchasePriceCommand $command): string
+    {
+        $this->assertCommandIsValid($command);
+
+        $product = $this->productRepository->getOneForCompanyByIdsOrNull($command->companyId, $command->productId);
+        if (null === $product) {
+            throw new NotFoundHttpException();
+        }
+
+        $activePrice = $this->productPurchasePriceRepository->findActiveAtDate(
+            $command->companyId,
+            $command->productId,
+            $command->effectiveFrom,
+        );
+
+        $nextPrice = $this->productPurchasePriceRepository->findNextAfterDate(
+            $command->companyId,
+            $command->productId,
+            $command->effectiveFrom,
+        );
+
+        $this->purchasePriceTimelinePolicy->assertNoOverlapWithNext(
+            $nextPrice?->getEffectiveFrom(),
+            $command->effectiveFrom,
+        );
+
+        if (null !== $activePrice) {
+            // Закрываем предыдущий активный интервал на день раньше новой цены.
+            $activePrice->closeAt($command->effectiveFrom->sub(new \DateInterval('P1D')));
+        }
+
+        $newPrice = new ProductPurchasePrice(
+            id: Uuid::v7()->toRfc4122(),
+            company: $product->getCompany(),
+            product: $product,
+            effectiveFrom: $command->effectiveFrom,
+            priceAmount: $command->priceAmount,
+            priceCurrency: strtoupper($command->currency),
+            note: $command->note,
+        );
+
+        $this->entityManager->persist($newPrice);
+        $this->entityManager->flush();
+
+        return $newPrice->getId();
+    }
+
+    private function assertCommandIsValid(SetPurchasePriceCommand $command): void
+    {
+        if ('' === trim($command->companyId ?? '')) {
+            throw new \DomainException('companyId обязателен.');
+        }
+
+        if ('' === trim($command->productId ?? '')) {
+            throw new \DomainException('productId обязателен.');
+        }
+
+        if ($command->priceAmount < 0) {
+            throw new \DomainException('priceAmount не может быть отрицательным.');
+        }
+
+        if (3 !== mb_strlen(trim($command->currency ?? ''))) {
+            throw new \DomainException('currency должен содержать 3 символа.');
+        }
+    }
+}

--- a/site/src/Catalog/Controller/ProductPurchasePriceSetController.php
+++ b/site/src/Catalog/Controller/ProductPurchasePriceSetController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Controller;
+
+use App\Catalog\Application\SetPurchasePriceAction;
+use App\Catalog\DTO\SetPurchasePriceCommand;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class ProductPurchasePriceSetController extends AbstractController
+{
+    #[Route('/catalog/products/{id}/purchase-prices', name: 'catalog_products_purchase_prices_set', methods: ['POST'])]
+    public function __invoke(string $id, Request $request, SetPurchasePriceAction $setPurchasePriceAction): JsonResponse
+    {
+        $payload = $request->toArray();
+
+        $command = new SetPurchasePriceCommand();
+        $command->companyId = (string) ($payload['companyId'] ?? '');
+        $command->productId = $id;
+        $command->effectiveFrom = new \DateTimeImmutable((string) ($payload['effectiveFrom'] ?? 'now'));
+        $command->priceAmount = (int) ($payload['priceAmount'] ?? 0);
+        $command->currency = (string) ($payload['currency'] ?? 'RUB');
+        $command->note = isset($payload['note']) ? (string) $payload['note'] : null;
+        $command->userId = isset($payload['userId']) ? (string) $payload['userId'] : null;
+
+        $priceId = $setPurchasePriceAction($command);
+
+        return $this->json(['id' => $priceId]);
+    }
+}

--- a/site/src/Catalog/DTO/SetPurchasePriceCommand.php
+++ b/site/src/Catalog/DTO/SetPurchasePriceCommand.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\DTO;
+
+final class SetPurchasePriceCommand
+{
+    public string $companyId;
+    public string $productId;
+    public \DateTimeImmutable $effectiveFrom;
+    public int $priceAmount;
+    public string $currency = 'RUB';
+    public ?string $note = null;
+    public ?string $userId = null;
+}

--- a/site/src/Catalog/Domain/PurchasePriceTimelinePolicy.php
+++ b/site/src/Catalog/Domain/PurchasePriceTimelinePolicy.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Domain;
+
+final class PurchasePriceTimelinePolicy
+{
+    public function assertNoOverlapWithNext(?\DateTimeImmutable $nextFrom, \DateTimeImmutable $newFrom): void
+    {
+        if (null !== $nextFrom && $newFrom >= $nextFrom) {
+            throw new \DomainException(sprintf(
+                'Нельзя установить цену с даты %s, потому что уже есть цена начиная с %s.',
+                $newFrom->format('Y-m-d'),
+                $nextFrom->format('Y-m-d')
+            ));
+        }
+    }
+}

--- a/site/src/Catalog/Infrastructure/ProductRepository.php
+++ b/site/src/Catalog/Infrastructure/ProductRepository.php
@@ -87,6 +87,21 @@ final class ProductRepository
         return $count > 0;
     }
 
+
+    public function getOneForCompanyByIdsOrNull(string $companyId, string $productId): ?Product
+    {
+        return $this->entityManager->createQueryBuilder()
+            ->select('p')
+            ->from(Product::class, 'p')
+            ->andWhere('p.id = :productId')
+            ->andWhere('IDENTITY(p.company) = :companyId')
+            ->setParameter('productId', $productId)
+            ->setParameter('companyId', $companyId)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
     public function getOneForCompanyOrNull(string $id, Company $company): ?Product
     {
         return $this->entityManager->createQueryBuilder()

--- a/site/src/Catalog/Infrastructure/Repository/ProductPurchasePriceRepository.php
+++ b/site/src/Catalog/Infrastructure/Repository/ProductPurchasePriceRepository.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Infrastructure\Repository;
+
+use App\Catalog\Entity\ProductPurchasePrice;
+use Doctrine\ORM\EntityManagerInterface;
+
+final class ProductPurchasePriceRepository
+{
+    public function __construct(private readonly EntityManagerInterface $entityManager)
+    {
+    }
+
+    public function findActiveAtDate(string $companyId, string $productId, \DateTimeImmutable $at): ?ProductPurchasePrice
+    {
+        return $this->entityManager->createQueryBuilder()
+            ->select('pp')
+            ->from(ProductPurchasePrice::class, 'pp')
+            ->andWhere('IDENTITY(pp.company) = :companyId')
+            ->andWhere('IDENTITY(pp.product) = :productId')
+            ->andWhere('pp.effectiveFrom <= :at')
+            ->andWhere('(pp.effectiveTo IS NULL OR pp.effectiveTo >= :at)')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('productId', $productId)
+            ->setParameter('at', $at)
+            ->orderBy('pp.effectiveFrom', 'DESC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    public function findNextAfterDate(string $companyId, string $productId, \DateTimeImmutable $from): ?ProductPurchasePrice
+    {
+        return $this->entityManager->createQueryBuilder()
+            ->select('pp')
+            ->from(ProductPurchasePrice::class, 'pp')
+            ->andWhere('IDENTITY(pp.company) = :companyId')
+            ->andWhere('IDENTITY(pp.product) = :productId')
+            ->andWhere('pp.effectiveFrom > :from')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('productId', $productId)
+            ->setParameter('from', $from)
+            ->orderBy('pp.effectiveFrom', 'ASC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+}
+

--- a/site/tests/Integration/Catalog/SetPurchasePriceActionTest.php
+++ b/site/tests/Integration/Catalog/SetPurchasePriceActionTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Catalog;
+
+use App\Catalog\Application\SetPurchasePriceAction;
+use App\Catalog\DTO\SetPurchasePriceCommand;
+use App\Catalog\Entity\Product;
+use App\Catalog\Entity\ProductPurchasePrice;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+
+final class SetPurchasePriceActionTest extends IntegrationTestCase
+{
+    public function testFirstInsertCreatesRecord(): void
+    {
+        [$companyId, $productId] = $this->createBaseFixtures(
+            'owner-set-price-a@example.test',
+            '11111111-1111-1111-1111-111111111991',
+            '33333333-3333-3333-3333-333333333991'
+        );
+
+        $command = $this->makeCommand($companyId, $productId, '2026-04-01', 10000, 'Первая цена');
+        $priceId = $this->action()($command);
+
+        $loaded = $this->em()->getRepository(ProductPurchasePrice::class)->find($priceId);
+        self::assertInstanceOf(ProductPurchasePrice::class, $loaded);
+        self::assertSame('2026-04-01', $loaded->getEffectiveFrom()->format('Y-m-d'));
+        self::assertNull($loaded->getEffectiveTo());
+    }
+
+    public function testSecondInsertClosesPreviousRecord(): void
+    {
+        [$companyId, $productId] = $this->createBaseFixtures(
+            'owner-set-price-b@example.test',
+            '11111111-1111-1111-1111-111111111992',
+            '33333333-3333-3333-3333-333333333992'
+        );
+
+        $this->action()($this->makeCommand($companyId, $productId, '2026-04-01', 10000, 'Начальная цена'));
+        $this->action()($this->makeCommand($companyId, $productId, '2026-04-15', 12000, 'Новая цена'));
+
+        $prices = $this->em()->getRepository(ProductPurchasePrice::class)->findBy([], ['effectiveFrom' => 'ASC']);
+        self::assertCount(2, $prices);
+        self::assertSame('2026-04-14', $prices[0]->getEffectiveTo()?->format('Y-m-d'));
+        self::assertNull($prices[1]->getEffectiveTo());
+    }
+
+    public function testInsertOverlappingFutureRecordThrowsDomainException(): void
+    {
+        [$companyId, $productId] = $this->createBaseFixtures(
+            'owner-set-price-c@example.test',
+            '11111111-1111-1111-1111-111111111993',
+            '33333333-3333-3333-3333-333333333993'
+        );
+
+        $this->action()($this->makeCommand($companyId, $productId, '2026-05-10', 15000, 'Будущая цена'));
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('Нельзя установить цену с даты 2026-05-10, потому что уже есть цена начиная с 2026-05-10.');
+
+        $this->action()($this->makeCommand($companyId, $productId, '2026-05-10', 11000, 'Конфликтная цена'));
+    }
+
+    private function makeCommand(string $companyId, string $productId, string $effectiveFrom, int $amount, ?string $note): SetPurchasePriceCommand
+    {
+        $command = new SetPurchasePriceCommand();
+        $command->companyId = $companyId;
+        $command->productId = $productId;
+        $command->effectiveFrom = new \DateTimeImmutable($effectiveFrom);
+        $command->priceAmount = $amount;
+        $command->currency = 'RUB';
+        $command->note = $note;
+
+        return $command;
+    }
+
+    private function createBaseFixtures(string $email, string $companyId, string $productId): array
+    {
+        $owner = UserBuilder::aUser()->withEmail($email)->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId($companyId)
+            ->withOwner($owner)
+            ->withName('Company for purchase price tests')
+            ->build();
+
+        $product = (new Product($productId, $company))
+            ->setName('Product for purchase price tests')
+            ->setSku('SKU-'.$productId)
+            ->setPurchasePrice('100.00');
+
+        $this->em()->persist($owner);
+        $this->em()->persist($company);
+        $this->em()->persist($product);
+        $this->em()->flush();
+
+        return [$companyId, $productId];
+    }
+
+    private function action(): SetPurchasePriceAction
+    {
+        return self::getContainer()->get(SetPurchasePriceAction::class);
+    }
+}


### PR DESCRIPTION
### Motivation
- Сделать write-use-case установки закупочной цены явным по компании: убрать неявный `ActiveCompanyService` и передавать `companyId` в команду. 
- Обеспечить корректную логику timeline: закрывать предыдущую запись на `effectiveFrom - 1 day` и запрещать наложение с существующей следующей записью.

### Description
- Изменён `SetPurchasePriceAction` чтобы принимать `SetPurchasePriceCommand` с `companyId` и больше не использовать `ActiveCompanyService`, валидация входных полей добавлена в `assertCommandIsValid` (`site/src/Catalog/Application/SetPurchasePriceAction.php`).
- Обновлён DTO `SetPurchasePriceCommand` с полями `companyId`, `productId`, `effectiveFrom`, `priceAmount`, `currency`, `note`, `userId` (`site/src/Catalog/DTO/SetPurchasePriceCommand.php`).
- Добавлен инфраструктурный репозиторий цен `ProductPurchasePriceRepository` с методами `findActiveAtDate(...)` и `findNextAfterDate(...)` и добавлен scoped lookup продукта `getOneForCompanyByIdsOrNull(...)` в `ProductRepository` (`site/src/Catalog/Infrastructure/Repository/ProductPurchasePriceRepository.php`, `site/src/Catalog/Infrastructure/ProductRepository.php`).
- Доменная политика оставлена чистой PHP и переименована в `assertNoOverlapWithNext(...)` с русским `DomainException` при перекрытии (`site/src/Catalog/Domain/PurchasePriceTimelinePolicy.php`), контроллер теперь мапит `companyId`/`userId` в команду (`site/src/Catalog/Controller/ProductPurchasePriceSetController.php`).
- Интеграционный тест `tests/Integration/Catalog/SetPurchasePriceActionTest.php` добавлен и покрывает: первая вставка, вторая вставка закрывает предыдущую запись на день-1, и попытка вставки, перекрывающей будущую запись, бросает `DomainException`.

### Testing
- Синтаксические проверки `php -l` выполнены для всех изменённых файлов и теста и прошли успешно.
- Запуск `composer test:smoke` выявил существующие ошибки в другом модуле (Telegram) и завершился неуспешно, эти ошибки не связаны с изменениями в каталоге.
- Интеграционные тесты (`./vendor/bin/phpunit tests/Integration/Catalog/SetPurchasePriceActionTest.php`) не смогли завершиться в этой среде из‑за отсутствующего PDO драйвера PostgreSQL (`could not find driver`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b43c17a4c8323a452dd2614b75efc)