### PR TITLE
Add migration to align marketplace_costs with MarketplaceCost (listing relation)

### DIFF
--- a/site/migrations/Version20260322010000.php
+++ b/site/migrations/Version20260322010000.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260322010000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Align marketplace_costs schema with MarketplaceCost entity mapping (listing relation)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if (!$schema->hasTable('marketplace_costs')) {
+            return;
+        }
+
+        $table = $schema->getTable('marketplace_costs');
+
+        if (!$table->hasColumn('listing_id')) {
+            $this->addSql('ALTER TABLE marketplace_costs ADD listing_id UUID DEFAULT NULL');
+        }
+
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_cost_listing ON marketplace_costs (listing_id)');
+
+        if ($schema->hasTable('marketplace_listings')) {
+            $this->addSql('ALTER TABLE marketplace_costs DROP CONSTRAINT IF EXISTS FK_COST_LISTING');
+            $this->addSql('ALTER TABLE marketplace_costs ADD CONSTRAINT FK_COST_LISTING FOREIGN KEY (listing_id) REFERENCES marketplace_listings (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        if (!$schema->hasTable('marketplace_costs')) {
+            return;
+        }
+
+        $this->addSql('ALTER TABLE marketplace_costs DROP CONSTRAINT IF EXISTS FK_COST_LISTING');
+        $this->addSql('DROP INDEX IF EXISTS idx_cost_listing');
+
+        $table = $schema->getTable('marketplace_costs');
+        if ($table->hasColumn('listing_id')) {
+            $this->addSql('ALTER TABLE marketplace_costs DROP COLUMN listing_id');
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Align the database schema with the `MarketplaceCost` entity which now contains a `listing` relation to support denormalized listing/product lookups.
- Provide proper indexing and referential behavior for listing lookups and cascades by adding an indexed foreign key.

### Description
- Added a new Doctrine migration `site/migrations/Version20260322010000.php` that adds a nullable `listing_id` UUID column to `marketplace_costs` when missing.
- The migration creates the `idx_cost_listing` index and adds the `FK_COST_LISTING` foreign key to `marketplace_listings(id)` with `ON DELETE SET NULL`.
- The `down()` method removes the foreign key and index and drops the `listing_id` column if it exists.

### Testing
- Ran `php -l site/migrations/Version20260322010000.php` which returned no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d325184988323aee44ab347e38de7)