### PR TITLE
feat(marketplace): add DBAL MarketplaceListingPreloadQuery for fast preload by SKU

### DIFF
--- a/site/src/Marketplace/Infrastructure/Query/MarketplaceListingPreloadQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/MarketplaceListingPreloadQuery.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Query;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+
+final class MarketplaceListingPreloadQuery
+{
+    public function __construct(
+        private readonly Connection $connection,
+    ) {
+    }
+
+    /**
+     * @param list<string> $skus
+     *
+     * @return array<int, array{id:string, marketplace_sku:string, size:?string}>
+     */
+    public function fetchBySkus(string $companyId, string $marketplaceValue, array $skus): array
+    {
+        $normalizedSkus = [];
+
+        foreach ($skus as $sku) {
+            $value = trim((string) $sku);
+            if ('' === $value) {
+                continue;
+            }
+
+            $normalizedSkus[$value] = true;
+        }
+
+        $normalizedSkus = array_keys($normalizedSkus);
+        if ([] === $normalizedSkus) {
+            return [];
+        }
+
+        $rows = [];
+
+        foreach (array_chunk($normalizedSkus, 1000) as $skuChunk) {
+            $chunkRows = $this->connection->fetchAllAssociative(
+                'SELECT id, marketplace_sku, size
+                 FROM marketplace_listings
+                 WHERE company_id = :companyId
+                   AND marketplace = :marketplace
+                   AND marketplace_sku IN (:skus)',
+                [
+                    'companyId' => $companyId,
+                    'marketplace' => $marketplaceValue,
+                    'skus' => $skuChunk,
+                ],
+                [
+                    'skus' => ArrayParameterType::STRING,
+                ]
+            );
+
+            foreach ($chunkRows as $row) {
+                $rows[] = [
+                    'id' => (string) $row['id'],
+                    'marketplace_sku' => (string) $row['marketplace_sku'],
+                    'size' => isset($row['size']) ? (string) $row['size'] : null,
+                ];
+            }
+        }
+
+        return $rows;
+    }
+}

--- a/site/tests/Integration/Marketplace/MarketplaceListingPreloadQueryTest.php
+++ b/site/tests/Integration/Marketplace/MarketplaceListingPreloadQueryTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Marketplace;
+
+use App\Company\Entity\Company;
+use App\Company\Entity\User;
+use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Infrastructure\Query\MarketplaceListingPreloadQuery;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+
+final class MarketplaceListingPreloadQueryTest extends IntegrationTestCase
+{
+    public function testFetchBySkusReturnsMatchingRows(): void
+    {
+        $user = (new User('11111111-1111-4111-8111-111111111111'))
+            ->setEmail('integration-preload@example.com')
+            ->setPassword('secret');
+
+        $company = (new Company('22222222-2222-4222-8222-222222222222', $user))
+            ->setName('Integration Company');
+
+        $listingA = (new MarketplaceListing(
+            '33333333-3333-4333-8333-333333333333',
+            $company,
+            null,
+            MarketplaceType::WILDBERRIES
+        ))
+            ->setMarketplaceSku('SKU-1')
+            ->setSize(null)
+            ->setPrice('100.00');
+
+        $listingB = (new MarketplaceListing(
+            '44444444-4444-4444-8444-444444444444',
+            $company,
+            null,
+            MarketplaceType::WILDBERRIES
+        ))
+            ->setMarketplaceSku('SKU-2')
+            ->setSize('XL')
+            ->setPrice('200.00');
+
+        $this->em->persist($user);
+        $this->em->persist($company);
+        $this->em->persist($listingA);
+        $this->em->persist($listingB);
+        $this->em->flush();
+
+        /** @var MarketplaceListingPreloadQuery $query */
+        $query = self::getContainer()->get(MarketplaceListingPreloadQuery::class);
+
+        $rows = $query->fetchBySkus(
+            (string) $company->getId(),
+            MarketplaceType::WILDBERRIES->value,
+            [' SKU-1 ', '', 'SKU-2', 'SKU-1', 'MISSING']
+        );
+
+        self::assertCount(2, $rows);
+
+        $bySku = [];
+        foreach ($rows as $row) {
+            $bySku[$row['marketplace_sku']] = $row;
+        }
+
+        self::assertArrayHasKey('SKU-1', $bySku);
+        self::assertSame('33333333-3333-4333-8333-333333333333', $bySku['SKU-1']['id']);
+        self::assertSame('UNKNOWN', $bySku['SKU-1']['size']);
+
+        self::assertArrayHasKey('SKU-2', $bySku);
+        self::assertSame('44444444-4444-4444-8444-444444444444', $bySku['SKU-2']['id']);
+        self::assertSame('XL', $bySku['SKU-2']['size']);
+    }
+
+    public function testFetchBySkusReturnsEmptyArrayForEmptyInput(): void
+    {
+        /** @var MarketplaceListingPreloadQuery $query */
+        $query = self::getContainer()->get(MarketplaceListingPreloadQuery::class);
+
+        self::assertSame([], $query->fetchBySkus('company', MarketplaceType::WILDBERRIES->value, []));
+        self::assertSame([], $query->fetchBySkus('company', MarketplaceType::WILDBERRIES->value, [' ', "\t", '']));
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a fast read-only DBAL query to preload marketplace listings by SKU (and size) for sync/lookup code paths without touching existing services.
- Ensure the query is safe and lightweight (returns arrays, not Entities) and works against the real `marketplace_listings` mapping.
- Keep `MarketplaceSyncService` and other existing code unchanged while enabling bulk lookups by SKU.

### Description
- Added `App\Marketplace\Infrastructure\Query\MarketplaceListingPreloadQuery` that depends on `Doctrine\DBAL\Connection` and exposes `fetchBySkus(string $companyId, string $marketplaceValue, array $skus): array`.
- Implemented SKU normalization (trim, remove empty, deduplicate) with chunking at 1000 SKUs and a DBAL `IN (:skus)` query using `ArrayParameterType::STRING` to fetch `id`, `marketplace_sku`, and `size` from `marketplace_listings`.
- Added integration test `site/tests/Integration/Marketplace/MarketplaceListingPreloadQueryTest.php` which creates a company and two listings via ORM (including `size = NULL` case), calls the query with messy input, and asserts returned rows and empty-input behavior.

### Testing
- Ran syntax checks with `php -l` on `site/src/Marketplace/Infrastructure/Query/MarketplaceListingPreloadQuery.php` and the new test file, both of which reported no syntax errors.
- Attempted to run the integration test with `cd site && php bin/phpunit tests/Integration/Marketplace/MarketplaceListingPreloadQueryTest.php`, but it failed in this environment due to a missing `vendor/symfony/phpunit-bridge/bin/simple-phpunit.php` (no local vendor binaries installed).
- The new files were added and the change was recorded (commit created) after implementing the query and test files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9c5163eac832388cb6bc8b992eb45)