### PR TITLE
Add marketplace fetcher infrastructure and Ozon/Wildberries fetchers

### DIFF
--- a/site/src/Marketplace/Application/Command/FetchMarketplaceDataCommand.php
+++ b/site/src/Marketplace/Application/Command/FetchMarketplaceDataCommand.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\Command;
+
+use App\Marketplace\Enum\MarketplaceType;
+
+final readonly class FetchMarketplaceDataCommand
+{
+    public function __construct(
+        public string $companyId,
+        public MarketplaceType $type,
+        public \DateTimeImmutable $dateFrom,
+    ) {
+    }
+}

--- a/site/src/Marketplace/Application/FetchMarketplaceDataAction.php
+++ b/site/src/Marketplace/Application/FetchMarketplaceDataAction.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Application\Command\FetchMarketplaceDataCommand;
+use App\Marketplace\Application\Command\ProcessMarketplaceRawDocumentCommand;
+use App\Marketplace\Entity\MarketplaceRawDocument;
+use App\Marketplace\Infrastructure\Api\MarketplaceFetcherRegistry;
+use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[AsMessageHandler]
+final readonly class FetchMarketplaceDataAction
+{
+    public function __construct(
+        private MarketplaceFetcherRegistry $fetcherRegistry,
+        private MarketplaceRawDocumentRepository $repository,
+        private EntityManagerInterface $entityManager,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    public function __invoke(FetchMarketplaceDataCommand $command): void
+    {
+        $fetcher = $this->fetcherRegistry->get($command->type);
+        $payload = $fetcher->fetch($command->companyId, $command->dateFrom);
+
+        $company = $this->entityManager->getReference(Company::class, $command->companyId);
+        $document = new MarketplaceRawDocument(
+            Uuid::uuid4()->toString(),
+            $company,
+            $command->type,
+            'raw_report',
+        );
+
+        // TODO: OOM Risk. In future PRs, stream payload directly to file instead of decoding large JSON into memory.
+        $decoded = json_decode($payload, true);
+        $rawData = is_array($decoded) ? $decoded : ['payload' => $payload];
+
+        $document
+            ->setPeriodFrom($command->dateFrom)
+            ->setPeriodTo($command->dateFrom)
+            ->setApiEndpoint('infrastructure.fetcher')
+            ->setRawData($rawData)
+            ->setRecordsCount(is_array($decoded) ? count($decoded) : 0);
+
+        $this->repository->save($document);
+
+        $this->messageBus->dispatch(new ProcessMarketplaceRawDocumentCommand(
+            companyId: $command->companyId,
+            rawDocId: $document->getId(),
+            kind: 'sales',
+        ));
+    }
+}

--- a/site/src/Marketplace/Infrastructure/Api/Contract/MarketplaceFetcherInterface.php
+++ b/site/src/Marketplace/Infrastructure/Api/Contract/MarketplaceFetcherInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Api\Contract;
+
+use App\Marketplace\Enum\MarketplaceType;
+
+interface MarketplaceFetcherInterface
+{
+    public function supports(MarketplaceType $type): bool;
+
+    public function fetch(string $companyId, \DateTimeImmutable $dateFrom): string;
+}

--- a/site/src/Marketplace/Infrastructure/Api/MarketplaceFetcherRegistry.php
+++ b/site/src/Marketplace/Infrastructure/Api/MarketplaceFetcherRegistry.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Api;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Infrastructure\Api\Contract\MarketplaceFetcherInterface;
+use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+
+final readonly class MarketplaceFetcherRegistry
+{
+    /**
+     * @var array<int, MarketplaceFetcherInterface>
+     */
+    private array $fetchers;
+
+    /**
+     * @param iterable<MarketplaceFetcherInterface> $fetchers
+     */
+    public function __construct(
+        #[TaggedIterator('marketplace.fetcher')]
+        iterable $fetchers,
+    ) {
+        $this->fetchers = $fetchers instanceof \Traversable ? iterator_to_array($fetchers, false) : (array) $fetchers;
+    }
+
+    public function get(MarketplaceType $type): MarketplaceFetcherInterface
+    {
+        foreach ($this->fetchers as $fetcher) {
+            if ($fetcher->supports($type)) {
+                return $fetcher;
+            }
+        }
+
+        throw new \RuntimeException(sprintf('Marketplace fetcher is not configured for type "%s".', $type->value));
+    }
+}

--- a/site/src/Marketplace/Infrastructure/Api/Ozon/OzonFetcher.php
+++ b/site/src/Marketplace/Infrastructure/Api/Ozon/OzonFetcher.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Api\Ozon;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Infrastructure\Api\Contract\MarketplaceFetcherInterface;
+use App\Marketplace\Infrastructure\Query\MarketplaceCredentialsQuery;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+#[AutoconfigureTag('marketplace.fetcher')]
+final readonly class OzonFetcher implements MarketplaceFetcherInterface
+{
+    private const BASE_URL = 'https://api-seller.ozon.ru';
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private MarketplaceCredentialsQuery $credentialsQuery,
+    ) {
+    }
+
+    public function supports(MarketplaceType $type): bool
+    {
+        return MarketplaceType::OZON === $type;
+    }
+
+    public function fetch(string $companyId, \DateTimeImmutable $dateFrom): string
+    {
+        $credentials = $this->credentialsQuery->getCredentials($companyId, MarketplaceType::OZON);
+        $apiKey = $credentials['api_key'] ?? null;
+        $clientId = $credentials['client_id'] ?? null;
+
+        if (null === $apiKey || '' === $apiKey || null === $clientId || '' === $clientId) {
+            throw new \RuntimeException('Ozon API credentials were not found.');
+        }
+
+        $response = $this->httpClient->request('POST', self::BASE_URL.'/v2/finance/transaction/list', [
+            'headers' => [
+                'Client-Id' => $clientId,
+                'Api-Key' => $apiKey,
+                'Content-Type' => 'application/json',
+            ],
+            'json' => [
+                'filter' => [
+                    'date' => [
+                        'from' => $dateFrom->format('Y-m-d\T00:00:00\Z'),
+                        'to' => $dateFrom->format('Y-m-d\T23:59:59\Z'),
+                    ],
+                ],
+                'page' => 1,
+                'page_size' => 1000,
+            ],
+        ]);
+
+        return $response->getContent();
+    }
+}

--- a/site/src/Marketplace/Infrastructure/Api/Wildberries/WbFetcher.php
+++ b/site/src/Marketplace/Infrastructure/Api/Wildberries/WbFetcher.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Api\Wildberries;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Infrastructure\Api\Contract\MarketplaceFetcherInterface;
+use App\Marketplace\Infrastructure\Query\MarketplaceCredentialsQuery;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+#[AutoconfigureTag('marketplace.fetcher')]
+final readonly class WbFetcher implements MarketplaceFetcherInterface
+{
+    private const BASE_URL = 'https://statistics-api.wildberries.ru';
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private MarketplaceCredentialsQuery $credentialsQuery,
+    ) {
+    }
+
+    public function supports(MarketplaceType $type): bool
+    {
+        return MarketplaceType::WILDBERRIES === $type;
+    }
+
+    public function fetch(string $companyId, \DateTimeImmutable $dateFrom): string
+    {
+        $credentials = $this->credentialsQuery->getCredentials($companyId, MarketplaceType::WILDBERRIES);
+        $apiKey = $credentials['api_key'] ?? null;
+
+        if (null === $apiKey || '' === $apiKey) {
+            throw new \RuntimeException('Wildberries API credentials were not found.');
+        }
+
+        $response = $this->httpClient->request('GET', self::BASE_URL.'/api/v5/supplier/reportDetailByPeriod', [
+            'headers' => [
+                'Authorization' => $apiKey,
+            ],
+            'query' => [
+                'dateFrom' => $dateFrom->format('Y-m-d'),
+                'dateTo' => $dateFrom->format('Y-m-d'),
+                'limit' => 100000,
+                'rrdid' => 0,
+            ],
+        ]);
+
+        return $response->getContent();
+    }
+}

--- a/site/src/Marketplace/Infrastructure/Query/MarketplaceCredentialsQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/MarketplaceCredentialsQuery.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Query;
+
+use App\Marketplace\Enum\MarketplaceType;
+use Doctrine\DBAL\Connection;
+
+final readonly class MarketplaceCredentialsQuery
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    /**
+     * @return array{api_key: string, client_id: ?string}|null
+     */
+    public function getCredentials(string $companyId, MarketplaceType $marketplace): ?array
+    {
+        $sql = <<<'SQL'
+            SELECT mc.api_key, mc.client_id
+            FROM marketplace_connections mc
+            WHERE mc.company_id = :company_id
+              AND mc.marketplace = :marketplace
+              AND mc.is_active = true
+            LIMIT 1
+        SQL;
+
+        $row = $this->connection->fetchAssociative($sql, [
+            'company_id' => $companyId,
+            'marketplace' => $marketplace->value,
+        ]);
+
+        if (false === $row) {
+            return null;
+        }
+
+        return [
+            'api_key' => (string) $row['api_key'],
+            'client_id' => null !== $row['client_id'] ? (string) $row['client_id'] : null,
+        ];
+    }
+}

--- a/site/src/Marketplace/Repository/MarketplaceRawDocumentRepository.php
+++ b/site/src/Marketplace/Repository/MarketplaceRawDocumentRepository.php
@@ -15,6 +15,12 @@ class MarketplaceRawDocumentRepository extends ServiceEntityRepository
         parent::__construct($registry, MarketplaceRawDocument::class);
     }
 
+    public function save(MarketplaceRawDocument $document): void
+    {
+        $this->getEntityManager()->persist($document);
+        $this->getEntityManager()->flush();
+    }
+
     /**
      * @return MarketplaceRawDocument[]
      */


### PR DESCRIPTION
### Motivation

- Introduce a pluggable marketplace fetching pipeline to retrieve raw marketplace data for companies and enqueue processing. 
- Support specific marketplace integrations (Ozon and Wildberries) that require credentials lookup and HTTP requests. 

### Description

- Add `FetchMarketplaceDataCommand` and `FetchMarketplaceDataAction` which use a `MarketplaceFetcherRegistry` to obtain a fetcher, store a `MarketplaceRawDocument`, and dispatch `ProcessMarketplaceRawDocumentCommand` for processing. 
- Add a `MarketplaceFetcherInterface` contract and a `MarketplaceFetcherRegistry` that collects services tagged with `marketplace.fetcher`. 
- Implement `OzonFetcher` and `WbFetcher` with HTTP client calls and credential retrieval via `MarketplaceCredentialsQuery`. 
- Add `MarketplaceCredentialsQuery::getCredentials` to pull API keys/client IDs from the DB and add `MarketplaceRawDocumentRepository::save` to persist documents. 

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaa3d8f3648323b0733af803e34bd6)