### PR TITLE
Add Ozon returns/costs actions and align WB returns action

### DIFF
--- a/site/src/Marketplace/Application/ProcessOzonCostsAction.php
+++ b/site/src/Marketplace/Application/ProcessOzonCostsAction.php
@@ -1,0 +1,410 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Entity\MarketplaceCost;
+use App\Marketplace\Entity\MarketplaceCostCategory;
+use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Entity\MarketplaceRawDocument;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Infrastructure\Query\MarketplaceCostExistingExternalIdsQuery;
+use App\Marketplace\Repository\MarketplaceCostCategoryRepository;
+use App\Marketplace\Repository\MarketplaceListingRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\Uuid;
+
+final class ProcessOzonCostsAction
+{
+    private iterable $costCalculators;
+
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly MarketplaceCostCategoryRepository $costCategoryRepository,
+        private readonly MarketplaceListingRepository $listingRepository,
+        private readonly MarketplaceCostExistingExternalIdsQuery $costExistingExternalIdsQuery,
+        private readonly LoggerInterface $logger,
+        iterable $costCalculators,
+    ) {
+        $this->costCalculators = $costCalculators;
+    }
+
+    public function __invoke(string $companyId, string $rawDocId): int
+    {
+        $company = $this->em->find(Company::class, $companyId);
+        if (!$company instanceof Company) {
+            throw new \RuntimeException('Company not found: ' . $companyId);
+        }
+
+        $rawDoc = $this->em->find(MarketplaceRawDocument::class, $rawDocId);
+        if (!$rawDoc instanceof MarketplaceRawDocument) {
+            throw new \RuntimeException('Raw document not found: ' . $rawDocId);
+        }
+
+        $rawData = $rawDoc->getRawData();
+        $companyId = (string) $company->getId();
+        $synced = 0;
+        $batchSize = 100;
+
+        $this->logger->info('[Ozon] Starting costs processing', ['total_records' => count($rawData)]);
+
+        $allSkus = [];
+        foreach ($rawData as $op) {
+            foreach ($op['items'] ?? [] as $item) {
+                $sku = (string) ($item['sku'] ?? '');
+                if ($sku !== '') {
+                    $allSkus[$sku] = true;
+                }
+            }
+        }
+
+        $listingsCache = [];
+        if (!empty($allSkus)) {
+            $listingsCache = $this->listingRepository->findListingsBySkusIndexed(
+                $company,
+                MarketplaceType::OZON,
+                array_keys($allSkus),
+            );
+
+            $this->logger->info('[Ozon] Loaded listings for costs', [
+                'count' => count($listingsCache),
+            ]);
+        }
+
+        $newListingsCreated = 0;
+        foreach ($rawData as $op) {
+            foreach ($op['items'] ?? [] as $item) {
+                $sku = (string) ($item['sku'] ?? '');
+                if ($sku === '' || isset($listingsCache[$sku])) {
+                    continue;
+                }
+
+                $price = abs((float) ($op['amount'] ?? 0));
+                $listing = new MarketplaceListing(Uuid::uuid4()->toString(), $company, null, MarketplaceType::OZON);
+                $listing->setMarketplaceSku($sku);
+                $listing->setPrice((string) $price);
+                $listing->setName($item['name'] ?? null);
+                $this->em->persist($listing);
+
+                $listingsCache[$sku] = $listing;
+                $newListingsCreated++;
+            }
+        }
+
+        if ($newListingsCreated > 0) {
+            $this->em->flush();
+            $this->logger->info('[Ozon] Created missing listings for costs', ['count' => $newListingsCreated]);
+        }
+
+        $categoriesCache = [];
+        $allCategories = $this->costCategoryRepository->findBy([
+            'company' => $company,
+            'marketplace' => MarketplaceType::OZON,
+            'deletedAt' => null,
+        ]);
+
+        foreach ($allCategories as $cat) {
+            $categoriesCache[$cat->getCode()] = $cat;
+        }
+
+        $counter = 0;
+        $newCategoriesCreated = 0;
+        $lastFlushedCounter = 0;
+        $knownExternalIdsMap = [];
+        $pending = [];
+        $pendingIds = [];
+        $dedupBatchSize = $batchSize;
+
+        $processPendingBatch = function () use (
+            &$pending,
+            &$pendingIds,
+            &$knownExternalIdsMap,
+            &$counter,
+            &$synced,
+            &$newCategoriesCreated,
+            &$lastFlushedCounter,
+            &$categoriesCache,
+            &$listingsCache,
+            &$company,
+            $companyId,
+            $batchSize,
+        ): void {
+            if (empty($pendingIds)) {
+                return;
+            }
+
+            $dbExistingMap = $this->costExistingExternalIdsQuery->execute($companyId, $pendingIds);
+            $knownExternalIdsMap += $dbExistingMap;
+
+            foreach ($pending as $pendingItem) {
+                try {
+                    $entry = $pendingItem['entry'];
+                    $externalId = $entry['external_id'];
+
+                    if (isset($knownExternalIdsMap[$externalId])) {
+                        continue;
+                    }
+
+                    $listing = $pendingItem['listing'];
+                    $categoryCode = $entry['category_code'];
+                    $category = $categoriesCache[$categoryCode] ?? null;
+
+                    if (!$category) {
+                        $category = new MarketplaceCostCategory(
+                            Uuid::uuid4()->toString(),
+                            $company,
+                            MarketplaceType::OZON,
+                        );
+                        $category->setCode($categoryCode);
+                        $category->setName($entry['category_name']);
+
+                        $this->em->persist($category);
+                        $categoriesCache[$categoryCode] = $category;
+                        $newCategoriesCreated++;
+                    }
+
+                    $cost = new MarketplaceCost(
+                        Uuid::uuid4()->toString(),
+                        $company,
+                        MarketplaceType::OZON,
+                        $category,
+                    );
+
+                    $cost->setExternalId($externalId);
+                    $cost->setCostDate($entry['cost_date']);
+                    $cost->setAmount($entry['amount']);
+                    $cost->setDescription($entry['description']);
+
+                    if ($listing) {
+                        $cost->setListing($listing);
+                    }
+
+                    $this->em->persist($cost);
+                    $knownExternalIdsMap[$externalId] = true;
+                    $synced++;
+                    $counter++;
+                } catch (\Exception $e) {
+                    $this->logger->error('[Ozon] Failed to process cost', [
+                        'external_id' => $pendingItem['entry']['external_id'] ?? 'unknown',
+                        'error' => $e->getMessage(),
+                    ]);
+                    continue;
+                }
+            }
+
+            if (($counter - $lastFlushedCounter) >= $batchSize) {
+                $this->em->flush();
+                $this->em->clear();
+                $lastFlushedCounter = $counter;
+
+                $company = $this->em->find(Company::class, $companyId);
+                foreach ($categoriesCache as $code => $cat) {
+                    $categoriesCache[$code] = $this->em->getReference(
+                        MarketplaceCostCategory::class,
+                        $cat->getId(),
+                    );
+                }
+                foreach ($listingsCache as $k => $cachedListing) {
+                    $listingsCache[$k] = $this->em->getReference(
+                        MarketplaceListing::class,
+                        $cachedListing->getId(),
+                    );
+                }
+
+                gc_collect_cycles();
+                $this->logger->info('[Ozon] Costs batch', ['processed' => $counter, 'synced' => $synced]);
+            }
+
+            $pending = [];
+            $pendingIds = [];
+        };
+
+        foreach ($rawData as $op) {
+            try {
+                $operationId = (string) ($op['operation_id'] ?? '');
+                $operationDate = new \DateTimeImmutable($op['operation_date']);
+
+                $listing = null;
+                $firstItem = ($op['items'] ?? [])[0] ?? null;
+                if ($firstItem) {
+                    $sku = (string) ($firstItem['sku'] ?? '');
+                    $listing = $listingsCache[$sku] ?? null;
+                }
+
+                $costEntries = $this->extractOzonCostEntries($op, $operationId, $operationDate);
+
+                foreach ($costEntries as $entry) {
+                    $externalId = $entry['external_id'];
+
+                    if (isset($knownExternalIdsMap[$externalId])) {
+                        continue;
+                    }
+
+                    $pending[] = [
+                        'entry' => $entry,
+                        'listing' => $listing,
+                    ];
+                    $pendingIds[] = $externalId;
+
+                    if (count($pendingIds) >= $dedupBatchSize) {
+                        $processPendingBatch();
+                    }
+                }
+            } catch (\Exception $e) {
+                $this->logger->error('[Ozon] Failed to process operation for costs', [
+                    'operation_id' => $op['operation_id'] ?? 'unknown',
+                    'error' => $e->getMessage(),
+                ]);
+                continue;
+            }
+        }
+
+        if (!empty($pendingIds)) {
+            $processPendingBatch();
+        }
+
+        if ($counter % $batchSize !== 0) {
+            $this->em->flush();
+            $this->em->clear();
+        }
+
+        $this->logger->info('[Ozon] Costs processing completed', [
+            'total_synced' => $synced,
+            'new_categories' => $newCategoriesCreated,
+            'peak_memory' => round(memory_get_peak_usage(true) / 1024 / 1024, 2) . ' MB',
+        ]);
+
+        return $synced;
+    }
+
+    private function extractOzonCostEntries(array $op, string $operationId, \DateTimeImmutable $operationDate): array
+    {
+        $entries = [];
+
+        $commission = abs((float) ($op['sale_commission'] ?? 0));
+        if ($commission > 0) {
+            $entries[] = [
+                'external_id' => $operationId . '_commission',
+                'category_code' => 'ozon_sale_commission',
+                'category_name' => 'Комиссия Ozon за продажу',
+                'amount' => (string) $commission,
+                'cost_date' => $operationDate,
+                'description' => 'Комиссия за продажу',
+            ];
+        }
+
+        $delivery = abs((float) ($op['delivery_charge'] ?? 0));
+        if ($delivery > 0) {
+            $entries[] = [
+                'external_id' => $operationId . '_delivery',
+                'category_code' => 'ozon_delivery',
+                'category_name' => 'Доставка Ozon',
+                'amount' => (string) $delivery,
+                'cost_date' => $operationDate,
+                'description' => 'Стоимость доставки',
+            ];
+        }
+
+        $returnDelivery = abs((float) ($op['return_delivery_charge'] ?? 0));
+        if ($returnDelivery > 0) {
+            $entries[] = [
+                'external_id' => $operationId . '_return_delivery',
+                'category_code' => 'ozon_return_delivery',
+                'category_name' => 'Обратная доставка Ozon',
+                'amount' => (string) $returnDelivery,
+                'cost_date' => $operationDate,
+                'description' => 'Обратная доставка',
+            ];
+        }
+
+        $services = $op['services'] ?? [];
+        foreach ($services as $idx => $service) {
+            $serviceAmount = abs((float) ($service['price'] ?? 0));
+            if ($serviceAmount <= 0) {
+                continue;
+            }
+
+            $serviceName = $service['name'] ?? 'Неизвестная услуга';
+            $categoryCode = $this->resolveOzonServiceCategoryCode($serviceName);
+
+            $entries[] = [
+                'external_id' => $operationId . '_svc_' . $idx,
+                'category_code' => $categoryCode,
+                'category_name' => $this->resolveOzonServiceCategoryName($categoryCode),
+                'amount' => (string) $serviceAmount,
+                'cost_date' => $operationDate,
+                'description' => $serviceName,
+            ];
+        }
+
+        return $entries;
+    }
+
+    private function resolveOzonServiceCategoryCode(string $serviceName): string
+    {
+        $lower = mb_strtolower($serviceName);
+
+        if (str_contains($lower, 'логистик') || str_contains($lower, 'logistic')
+            || str_contains($lower, 'магистраль') || str_contains($lower, 'last mile')) {
+            return 'ozon_logistics';
+        }
+
+        if (str_contains($lower, 'обработк') || str_contains($lower, 'processing')
+            || str_contains($lower, 'сборк')) {
+            return 'ozon_processing';
+        }
+
+        if (str_contains($lower, 'хранени') || str_contains($lower, 'storage')
+            || str_contains($lower, 'размещени')) {
+            return 'ozon_storage';
+        }
+
+        if (str_contains($lower, 'эквайринг') || str_contains($lower, 'acquiring')
+            || str_contains($lower, 'приём платеж')) {
+            return 'ozon_acquiring';
+        }
+
+        if (str_contains($lower, 'продвижени') || str_contains($lower, 'реклам')
+            || str_contains($lower, 'promotion') || str_contains($lower, 'трафик')) {
+            return 'ozon_promotion';
+        }
+
+        if (str_contains($lower, 'подписк') || str_contains($lower, 'premium')
+            || str_contains($lower, 'subscription')) {
+            return 'ozon_subscription';
+        }
+
+        if (str_contains($lower, 'штраф') || str_contains($lower, 'penalty')
+            || str_contains($lower, 'неустойк')) {
+            return 'ozon_penalty';
+        }
+
+        if (str_contains($lower, 'компенсац') || str_contains($lower, 'compensation')
+            || str_contains($lower, 'возмещени')) {
+            return 'ozon_compensation';
+        }
+
+        return 'ozon_other_service';
+    }
+
+    private function resolveOzonServiceCategoryName(string $categoryCode): string
+    {
+        return match ($categoryCode) {
+            'ozon_sale_commission' => 'Комиссия Ozon за продажу',
+            'ozon_delivery' => 'Доставка Ozon',
+            'ozon_return_delivery' => 'Обратная доставка Ozon',
+            'ozon_logistics' => 'Логистика Ozon',
+            'ozon_processing' => 'Обработка отправления Ozon',
+            'ozon_storage' => 'Хранение на складе Ozon',
+            'ozon_acquiring' => 'Эквайринг Ozon',
+            'ozon_promotion' => 'Продвижение / реклама Ozon',
+            'ozon_subscription' => 'Подписка Ozon',
+            'ozon_penalty' => 'Штрафы Ozon',
+            'ozon_compensation' => 'Компенсации Ozon',
+            default => 'Прочие услуги Ozon',
+        };
+    }
+}

--- a/site/src/Marketplace/Application/ProcessOzonReturnsAction.php
+++ b/site/src/Marketplace/Application/ProcessOzonReturnsAction.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Entity\MarketplaceRawDocument;
+use App\Marketplace\Entity\MarketplaceReturn;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Repository\MarketplaceListingRepository;
+use App\Marketplace\Repository\MarketplaceReturnRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\Uuid;
+
+final class ProcessOzonReturnsAction
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly MarketplaceReturnRepository $returnRepository,
+        private readonly MarketplaceListingRepository $listingRepository,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(string $companyId, string $rawDocId): int
+    {
+        $company = $this->em->find(Company::class, $companyId);
+        if (!$company instanceof Company) {
+            throw new \RuntimeException('Company not found: ' . $companyId);
+        }
+
+        $rawDoc = $this->em->find(MarketplaceRawDocument::class, $rawDocId);
+        if (!$rawDoc instanceof MarketplaceRawDocument) {
+            throw new \RuntimeException('Raw document not found: ' . $rawDocId);
+        }
+
+        $rawData = $rawDoc->getRawData();
+        $companyId = (string) $company->getId();
+        $rawDocId = (string) $rawDoc->getId();
+        $synced = 0;
+        $batchSize = 250;
+
+        $returnsData = array_filter($rawData, static function (array $op): bool {
+            return ($op['type'] ?? '') === 'returns';
+        });
+
+        if (empty($returnsData)) {
+            $this->logger->info('[Ozon] No returns to process');
+
+            return 0;
+        }
+
+        $this->logger->info('[Ozon] Starting returns processing', [
+            'total_filtered' => count($returnsData),
+        ]);
+
+        $allExternalIds = array_map(static fn (array $op): string => (string) $op['operation_id'], $returnsData);
+        $existingIdsMap = $this->returnRepository->getExistingExternalIds($companyId, $allExternalIds);
+
+        $allSkus = [];
+        foreach ($returnsData as $op) {
+            foreach ($op['items'] ?? [] as $item) {
+                $sku = (string) ($item['sku'] ?? '');
+                if ($sku !== '') {
+                    $allSkus[$sku] = true;
+                }
+            }
+        }
+        $allSkus = array_keys($allSkus);
+
+        $listingsCache = $this->listingRepository->findListingsBySkusIndexed(
+            $company,
+            MarketplaceType::OZON,
+            $allSkus,
+        );
+
+        $newListingsCreated = 0;
+
+        foreach ($returnsData as $op) {
+            $price = abs((float) ($op['amount'] ?? 0));
+
+            foreach ($op['items'] ?? [] as $item) {
+                $sku = (string) ($item['sku'] ?? '');
+                if ($sku === '' || isset($listingsCache[$sku])) {
+                    continue;
+                }
+
+                $listing = new MarketplaceListing(Uuid::uuid4()->toString(), $company, null, MarketplaceType::OZON);
+                $listing->setMarketplaceSku($sku);
+                $listing->setPrice((string) $price);
+                $listing->setName($item['name'] ?? null);
+                $this->em->persist($listing);
+
+                $listingsCache[$sku] = $listing;
+                $newListingsCreated++;
+            }
+        }
+
+        if ($newListingsCreated > 0) {
+            $this->em->flush();
+            $this->logger->info('[Ozon] Created missing listings for returns', ['count' => $newListingsCreated]);
+        }
+
+        $counter = 0;
+
+        foreach ($returnsData as $op) {
+            try {
+                $externalReturnId = (string) $op['operation_id'];
+
+                if (isset($existingIdsMap[$externalReturnId])) {
+                    continue;
+                }
+
+                $items = $op['items'] ?? [];
+                $firstItem = $items[0] ?? null;
+                $sku = $firstItem ? (string) ($firstItem['sku'] ?? '') : '';
+
+                $listing = $listingsCache[$sku] ?? null;
+                if (!$listing) {
+                    $this->logger->warning('[Ozon] No listing for return', ['sku' => $sku]);
+                    continue;
+                }
+
+                $amount = abs((float) ($op['amount'] ?? 0));
+
+                $return = new MarketplaceReturn(
+                    Uuid::uuid4()->toString(),
+                    $company,
+                    $listing,
+                    MarketplaceType::OZON,
+                );
+
+                $return->setExternalReturnId($externalReturnId);
+                $return->setReturnDate(new \DateTimeImmutable($op['operation_date']));
+                $return->setQuantity(1);
+                $return->setRefundAmount((string) $amount);
+                $return->setReturnReason($op['operation_type_name'] ?? null);
+                $return->setRawDocumentId($rawDocId);
+
+                $this->em->persist($return);
+                $existingIdsMap[$externalReturnId] = true;
+
+                $synced++;
+                $counter++;
+
+                if ($counter % $batchSize === 0) {
+                    $this->em->flush();
+                    $this->em->clear();
+
+                    $company = $this->em->find(Company::class, $companyId);
+                    foreach ($listingsCache as $k => $cachedListing) {
+                        $listingsCache[$k] = $this->em->getReference(
+                            MarketplaceListing::class,
+                            $cachedListing->getId(),
+                        );
+                    }
+
+                    gc_collect_cycles();
+                    $this->logger->info('[Ozon] Returns batch', ['processed' => $counter, 'synced' => $synced]);
+                }
+            } catch (\Exception $e) {
+                $this->logger->error('[Ozon] Failed to process return', [
+                    'operation_id' => $op['operation_id'] ?? 'unknown',
+                    'error' => $e->getMessage(),
+                ]);
+                continue;
+            }
+        }
+
+        if ($counter % $batchSize !== 0) {
+            $this->em->flush();
+            $this->em->clear();
+        }
+
+        $this->logger->info('[Ozon] Returns processing completed', ['total_synced' => $synced]);
+
+        return $synced;
+    }
+}

--- a/site/src/Marketplace/Application/ProcessWbReturnsAction.php
+++ b/site/src/Marketplace/Application/ProcessWbReturnsAction.php
@@ -40,17 +40,21 @@ final class ProcessWbReturnsAction
         }
 
         $rawData = $rawDoc->getRawData();
+        $companyId = (string) $company->getId();
+        $rawDocId = (string) $rawDoc->getId();
         $synced = 0;
         $batchSize = 250;
 
         $returnsData = array_filter($rawData, static function (array $item): bool {
             $docType = $item['doc_type_name'] ?? '';
+
             return in_array($docType, ['Возврат', 'возврат', 'Return'], true)
                 && (float) ($item['retail_price'] ?? 0) > 0;
         });
 
         if (empty($returnsData)) {
             $this->logger->info('[WB] No returns to process');
+
             return 0;
         }
 
@@ -72,44 +76,53 @@ final class ProcessWbReturnsAction
         foreach ($returnsData as $item) {
             $nmId = (string) ($item['nm_id'] ?? '');
             $tsName = $item['ts_name'] ?? null;
-            $size = (trim((string) $tsName) !== '') ? trim((string) $tsName) : 'UNKNOWN';
+            $size = trim((string) $tsName) !== '' ? trim((string) $tsName) : 'UNKNOWN';
             $cacheKey = $nmId . '_' . $size;
 
-            if (!isset($listingsCache[$cacheKey])) {
-                $listing = $this->listingResolver->resolve($company, $nmId, $tsName, [
-                    'sa_name'      => $item['sa_name'] ?? '',
-                    'brand_name'   => $item['brand_name'] ?? '',
-                    'subject_name' => $item['subject_name'] ?? '',
-                    'retail_price' => $item['retail_price'] ?? 0,
-                ]);
-                $listingsCache[$cacheKey] = $listing;
-                $newListingsCreated++;
+            if (isset($listingsCache[$cacheKey])) {
+                continue;
             }
+
+            $listing = $this->listingResolver->resolve($company, $nmId, $size, [
+                'nm_id' => $nmId,
+                'ts_name' => $size,
+                'sa_name' => (string) ($item['sa_name'] ?? ''),
+                'brand_name' => (string) ($item['brand_name'] ?? ''),
+                'subject_name' => (string) ($item['subject_name'] ?? ''),
+                'retail_price' => (string) ($item['retail_price'] ?? '0'),
+            ]);
+
+            $listingsCache[$cacheKey] = $listing;
+            $newListingsCreated++;
         }
 
         if ($newListingsCreated > 0) {
             $this->em->flush();
-            $this->logger->info('[WB] Created missing listings for returns', [
-                'count' => $newListingsCreated,
-            ]);
+            $this->logger->info('[WB] Created missing listings for returns', ['count' => $newListingsCreated]);
         }
 
         $counter = 0;
+
         foreach ($returnsData as $item) {
             try {
                 $externalReturnId = (string) $item['srid'];
+
                 if (isset($existingSridsMap[$externalReturnId])) {
                     continue;
                 }
 
                 $nmId = (string) ($item['nm_id'] ?? '');
                 $tsName = $item['ts_name'] ?? null;
-                $size = (trim((string) $tsName) !== '') ? trim((string) $tsName) : 'UNKNOWN';
+                $size = trim((string) $tsName) !== '' ? trim((string) $tsName) : 'UNKNOWN';
                 $cacheKey = $nmId . '_' . $size;
+
                 $listing = $listingsCache[$cacheKey] ?? null;
 
-                if ($listing === null) {
-                    $this->logger->error('[WB] Listing missing from cache', ['nm_id' => $nmId]);
+                if (!$listing) {
+                    $this->logger->error('[WB] Listing missing from cache (logic error)', [
+                        'nm_id' => $nmId,
+                        'ts_name' => $size,
+                    ]);
                     continue;
                 }
 
@@ -129,30 +142,37 @@ final class ProcessWbReturnsAction
 
                 $this->em->persist($return);
                 $existingSridsMap[$externalReturnId] = true;
+
                 $synced++;
                 $counter++;
 
                 if ($counter % $batchSize === 0) {
                     $this->em->flush();
                     $this->em->clear();
+
                     $company = $this->em->find(Company::class, $companyId);
-                    foreach ($listingsCache as $k => $cached) {
+
+                    foreach ($listingsCache as $k => $cachedListing) {
                         $listingsCache[$k] = $this->em->getReference(
                             MarketplaceListing::class,
-                            $cached->getId(),
+                            $cachedListing->getId(),
                         );
                     }
+
                     gc_collect_cycles();
+
                     $this->logger->info('[WB] Returns batch', [
                         'processed' => $counter,
-                        'memory'    => round(memory_get_usage(true) / 1024 / 1024, 2) . ' MB',
+                        'synced' => $synced,
+                        'memory' => round(memory_get_usage(true) / 1024 / 1024, 2) . ' MB',
                     ]);
                 }
-            } catch (\Throwable $e) {
-                $this->logger->error('[WB] Failed to process return', [
-                    'srid'  => $item['srid'] ?? 'unknown',
+            } catch (\Exception $e) {
+                $this->logger->error('[WB] Failed to process return item', [
+                    'srid' => $item['srid'] ?? 'unknown',
                     'error' => $e->getMessage(),
                 ]);
+                continue;
             }
         }
 
@@ -162,6 +182,7 @@ final class ProcessWbReturnsAction
         }
 
         $this->logger->info('[WB] Returns processing completed', ['total_synced' => $synced]);
+
         return $synced;
     }
 }


### PR DESCRIPTION
### Motivation
- Split marketplace raw-processing logic into reusable application actions to mirror existing `MarketplaceSyncService` flows for returns and costs. 
- Provide dedicated processors for Ozon returns and Ozon costs with inline listing creation as required, and align Wildberries returns handling with bulk preload / batch processing behavior. 
- Preserve existing batch semantics (`flush()`, `clear()`, `gc_collect_cycles()`) to keep memory / DB behaviour unchanged.

### Description
- Added `ProcessOzonReturnsAction` (new) implementing Ozon returns processing based on `ProcessOzonSalesAction` and `MarketplaceSyncService::processOzonReturnsFromRawDocument()`, including inline `MarketplaceListing` creation for missing SKUs and full batch/dedup flow. 
- Added `ProcessOzonCostsAction` (new) implementing Ozon costs processing based on `ProcessWbCostsAction` and `MarketplaceSyncService::processOzonCostsFromRawDocument()`, including constructor with the exact signature requested, inline listing creation, cost entry extraction, category resolution helpers (`extractOzonCostEntries`, `resolveOzonServiceCategoryCode`, `resolveOzonServiceCategoryName`) and batch deduplication. 
- Updated `ProcessWbReturnsAction` to follow the bulk-preload + batch-processing pattern from `MarketplaceSyncService::processReturnsFromRaw()` and to persist `rawDocId` on created `MarketplaceReturn` entities. 
- All three classes use `namespace App\Marketplace\Application`, are `final`, expose `public function __invoke(string $companyId, string $rawDocId): int`, and keep the required startup checks (find Company / find RawDocument + `RuntimeException`) and unchanged batching logic.

### Testing
- Ran syntax checks with `php -l` for the three modified/added files: `site/src/Marketplace/Application/ProcessWbReturnsAction.php`, `site/src/Marketplace/Application/ProcessOzonReturnsAction.php`, and `site/src/Marketplace/Application/ProcessOzonCostsAction.php`, and all returned "No syntax errors detected". 
- No unit/integration tests were added or modified in this change; only static PHP linting was executed and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abe290283083238067ac3f1fa91101)