### PR TITLE
Add SnapshotCalculationPolicy and extend MarketplaceFacade

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -116,6 +116,21 @@ getAdvertisingCostsForListingAndDate(string $companyId, string $listingId, \Date
 // Заказы по листингу и дате
 // @return OrderDTO[]
 getOrdersForListingAndDate(string $companyId, string $listingId, \DateTimeImmutable $date): array
+
+// Продажи по листингу и дате
+// @return SaleData[]
+getSalesForListingAndDate(string $companyId, string $listingId, \DateTimeImmutable $date): array
+
+// Возвраты по листингу и дате
+// @return ReturnData[]
+getReturnsForListingAndDate(string $companyId, string $listingId, \DateTimeImmutable $date): array
+
+// Затраты по листингу и дате
+// @return CostData[]
+getCostsForListingAndDate(string $companyId, string $listingId, \DateTimeImmutable $date): array
+
+// Себестоимость по листингу и дате (null если не задана)
+getCostPriceForListing(string $companyId, string $listingId, \DateTimeImmutable $date): ?string
 ```
 
 ---

--- a/site/src/Marketplace/Facade/MarketplaceFacade.php
+++ b/site/src/Marketplace/Facade/MarketplaceFacade.php
@@ -90,6 +90,7 @@ final readonly class MarketplaceFacade
             quantity: (int) $row['quantity'],
             pricePerUnit: $row['price_per_unit'],
             totalRevenue: $row['total_revenue'],
+            rawData: $row['raw_data'] !== null ? json_decode($row['raw_data'], true) : null,
         ), $rows);
     }
 

--- a/site/src/Marketplace/Facade/MarketplaceFacade.php
+++ b/site/src/Marketplace/Facade/MarketplaceFacade.php
@@ -5,15 +5,23 @@ declare(strict_types=1);
 namespace App\Marketplace\Facade;
 
 use App\Marketplace\DTO\AdvertisingCostDTO;
+use App\Marketplace\DTO\CostData;
 use App\Marketplace\DTO\OrderDTO;
+use App\Marketplace\DTO\ReturnData;
+use App\Marketplace\DTO\SaleData;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Inventory\CostPriceResolverInterface;
 use App\Marketplace\Repository\MarketplaceAdvertisingCostRepositoryInterface;
 use App\Marketplace\Repository\MarketplaceOrderRepositoryInterface;
+use Doctrine\DBAL\Connection;
 
 final readonly class MarketplaceFacade
 {
     public function __construct(
         private MarketplaceAdvertisingCostRepositoryInterface $advertisingCostRepository,
         private MarketplaceOrderRepositoryInterface $orderRepository,
+        private Connection $connection,
+        private CostPriceResolverInterface $costPriceResolver,
     ) {}
 
     /**
@@ -48,5 +56,118 @@ final readonly class MarketplaceFacade
         );
 
         return array_map(OrderDTO::fromEntity(...), $results);
+    }
+
+    /**
+     * @return SaleData[]
+     */
+    public function getSalesForListingAndDate(
+        string $companyId,
+        string $listingId,
+        \DateTimeImmutable $date,
+    ): array {
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT s.marketplace, s.external_order_id, s.sale_date, s.quantity,
+                    s.price_per_unit, s.total_revenue, s.cost_price, s.raw_data,
+                    l.marketplace_sku
+             FROM marketplace_sales s
+             JOIN marketplace_listings l ON s.listing_id = l.id
+             WHERE s.company_id = :companyId
+               AND s.listing_id = :listingId
+               AND s.sale_date = :date',
+            [
+                'companyId' => $companyId,
+                'listingId' => $listingId,
+                'date' => $date->format('Y-m-d'),
+            ],
+        );
+
+        return array_map(static fn(array $row) => new SaleData(
+            marketplace: MarketplaceType::from($row['marketplace']),
+            externalOrderId: $row['external_order_id'],
+            saleDate: new \DateTimeImmutable($row['sale_date']),
+            marketplaceSku: $row['marketplace_sku'],
+            quantity: (int) $row['quantity'],
+            pricePerUnit: $row['price_per_unit'],
+            totalRevenue: $row['total_revenue'],
+        ), $rows);
+    }
+
+    /**
+     * @return ReturnData[]
+     */
+    public function getReturnsForListingAndDate(
+        string $companyId,
+        string $listingId,
+        \DateTimeImmutable $date,
+    ): array {
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT r.marketplace, r.return_date, r.quantity, r.refund_amount,
+                    r.return_reason, l.marketplace_sku
+             FROM marketplace_returns r
+             JOIN marketplace_listings l ON r.listing_id = l.id
+             WHERE r.company_id = :companyId
+               AND r.listing_id = :listingId
+               AND r.return_date = :date',
+            [
+                'companyId' => $companyId,
+                'listingId' => $listingId,
+                'date' => $date->format('Y-m-d'),
+            ],
+        );
+
+        return array_map(static fn(array $row) => new ReturnData(
+            marketplace: MarketplaceType::from($row['marketplace']),
+            marketplaceSku: $row['marketplace_sku'],
+            returnDate: new \DateTimeImmutable($row['return_date']),
+            quantity: (int) $row['quantity'],
+            refundAmount: $row['refund_amount'],
+            returnReason: $row['return_reason'],
+        ), $rows);
+    }
+
+    /**
+     * @return CostData[]
+     */
+    public function getCostsForListingAndDate(
+        string $companyId,
+        string $listingId,
+        \DateTimeImmutable $date,
+    ): array {
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT c.marketplace, c.amount, c.cost_date, c.description, c.external_id,
+                    cat.code AS category_code, l.marketplace_sku
+             FROM marketplace_costs c
+             JOIN marketplace_cost_categories cat ON c.category_id = cat.id
+             LEFT JOIN marketplace_listings l ON c.listing_id = l.id
+             WHERE c.company_id = :companyId
+               AND c.listing_id = :listingId
+               AND c.cost_date = :date',
+            [
+                'companyId' => $companyId,
+                'listingId' => $listingId,
+                'date' => $date->format('Y-m-d'),
+            ],
+        );
+
+        return array_map(static fn(array $row) => new CostData(
+            marketplace: MarketplaceType::from($row['marketplace']),
+            categoryCode: $row['category_code'],
+            amount: $row['amount'],
+            costDate: new \DateTimeImmutable($row['cost_date']),
+            marketplaceSku: $row['marketplace_sku'] ?? null,
+            description: $row['description'],
+            externalId: $row['external_id'],
+        ), $rows);
+    }
+
+    public function getCostPriceForListing(
+        string $companyId,
+        string $listingId,
+        \DateTimeImmutable $date,
+    ): ?string {
+        $result = $this->costPriceResolver->resolve($companyId, $listingId, $date);
+
+        return bccomp($result, '0.00', 2) === 0 ? null : $result;
     }
 }

--- a/site/src/MarketplaceAnalytics/Domain/Service/SnapshotCalculationPolicy.php
+++ b/site/src/MarketplaceAnalytics/Domain/Service/SnapshotCalculationPolicy.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAnalytics\Domain\Service;
+
+use App\Marketplace\DTO\AdvertisingCostDTO;
+use App\Marketplace\Enum\AdvertisingType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Facade\MarketplaceFacade;
+use App\MarketplaceAnalytics\Domain\ValueObject\AdvertisingCpcMetrics;
+use App\MarketplaceAnalytics\Domain\ValueObject\AdvertisingDetails;
+use App\MarketplaceAnalytics\Domain\ValueObject\AdvertisingOtherMetrics;
+use App\MarketplaceAnalytics\Domain\ValueObject\CostBreakdown;
+use App\MarketplaceAnalytics\Domain\ValueObject\DataQualityFlags;
+use App\MarketplaceAnalytics\Entity\ListingDailySnapshot;
+use App\MarketplaceAnalytics\Enum\DataQualityFlag;
+use App\MarketplaceAnalytics\Repository\ListingDailySnapshotRepositoryInterface;
+use Ramsey\Uuid\Uuid;
+
+final readonly class SnapshotCalculationPolicy
+{
+    public function __construct(
+        private MarketplaceFacade $marketplaceFacade,
+        private CostMappingResolver $costMappingResolver,
+        private ListingDailySnapshotRepositoryInterface $snapshotRepository,
+    ) {}
+
+    public function calculateForListingDay(
+        string $companyId,
+        string $listingId,
+        \DateTimeImmutable $date,
+    ): ListingDailySnapshot {
+        $flags = DataQualityFlags::empty();
+
+        // 1. Sales
+        $sales = $this->marketplaceFacade->getSalesForListingAndDate($companyId, $listingId, $date);
+        $revenue = '0.00';
+        $salesQuantity = 0;
+        $marketplace = null;
+
+        foreach ($sales as $sale) {
+            $revenue = bcadd($revenue, $sale->totalRevenue, 2);
+            $salesQuantity += $sale->quantity;
+            $marketplace = $sale->marketplace->value;
+        }
+
+        $avgSalePrice = bccomp($revenue, '0.00', 2) > 0 && $salesQuantity > 0
+            ? bcdiv($revenue, (string) $salesQuantity, 2)
+            : '0.00';
+
+        // 2. Returns
+        $returns = $this->marketplaceFacade->getReturnsForListingAndDate($companyId, $listingId, $date);
+        $refunds = '0.00';
+        $returnsQuantity = 0;
+
+        foreach ($returns as $return) {
+            $refunds = bcadd($refunds, $return->refundAmount, 2);
+            $returnsQuantity += $return->quantity;
+            if ($marketplace === null) {
+                $marketplace = $return->marketplace->value;
+            }
+        }
+
+        // 3. Cost price
+        $costPrice = null;
+        if (!empty($sales) && $sales[0]->rawData !== null && isset($sales[0]->rawData['cost_price'])) {
+            $costPrice = (string) $sales[0]->rawData['cost_price'];
+        }
+        if ($costPrice === null) {
+            $costPrice = $this->marketplaceFacade->getCostPriceForListing($companyId, $listingId, $date);
+        }
+
+        $totalCostPrice = null;
+        if ($costPrice !== null) {
+            $totalCostPrice = bcmul($costPrice, (string) $salesQuantity, 2);
+        } else {
+            $flags = $flags->addFlag(DataQualityFlag::COST_PRICE_MISSING);
+        }
+
+        // 4. Costs (non-advertising)
+        $marketplace = $marketplace ?? 'wildberries';
+        $costs = $this->marketplaceFacade->getCostsForListingAndDate($companyId, $listingId, $date);
+        $costMap = [];
+
+        foreach ($costs as $costDTO) {
+            $type = $this->costMappingResolver->resolve($companyId, $marketplace, $costDTO->categoryCode);
+            if ($type->isAdvertising()) {
+                continue;
+            }
+            $costMap[$type->value] = bcadd($costMap[$type->value] ?? '0.00', $costDTO->amount, 2);
+        }
+
+        // 5. Advertising
+        $advCosts = $this->marketplaceFacade->getAdvertisingCostsForListingAndDate($companyId, $listingId, $date);
+
+        $cpcSpend = '0.00';
+        $cpcImpressions = 0;
+        $cpcClicks = 0;
+        $cpcOrders = 0;
+        $cpcRevenue = '0.00';
+        $otherSpend = '0.00';
+        $otherDetails = [];
+
+        foreach ($advCosts as $adv) {
+            if ($adv->advertisingType === AdvertisingType::CPC) {
+                $cpcSpend = bcadd($cpcSpend, $adv->amount, 2);
+                $cpcImpressions += $adv->analyticsData['impressions'] ?? 0;
+                $cpcClicks += $adv->analyticsData['clicks'] ?? 0;
+                $cpcOrders += $adv->analyticsData['orders'] ?? 0;
+                $cpcRevenue = bcadd($cpcRevenue, $adv->analyticsData['revenue'] ?? '0.00', 2);
+            } else {
+                $otherSpend = bcadd($otherSpend, $adv->amount, 2);
+                $otherDetails[] = [
+                    'type' => $adv->advertisingType->value,
+                    'amount' => $adv->amount,
+                    'campaign' => $adv->externalCampaignId,
+                ];
+            }
+        }
+
+        $ctr = $cpcImpressions > 0 ? (float) bcdiv(bcmul((string) $cpcClicks, '100', 2), (string) $cpcImpressions, 2) : 0.0;
+        $cr = $cpcClicks > 0 ? (float) bcdiv(bcmul((string) $cpcOrders, '100', 2), (string) $cpcClicks, 2) : 0.0;
+        $cpc = $cpcClicks > 0 ? bcdiv($cpcSpend, (string) $cpcClicks, 2) : '0.00';
+        $cpm = $cpcImpressions > 0 ? bcdiv(bcmul($cpcSpend, '1000', 2), (string) $cpcImpressions, 2) : '0.00';
+        $cpo = $cpcOrders > 0 ? bcdiv($cpcSpend, (string) $cpcOrders, 2) : '0.00';
+        $acos = bccomp($cpcRevenue, '0.00', 2) > 0
+            ? bcdiv(bcmul($cpcSpend, '100', 2), $cpcRevenue, 2)
+            : '0.00';
+
+        $cpcMetrics = new AdvertisingCpcMetrics(
+            spend: $cpcSpend,
+            impressions: $cpcImpressions,
+            clicks: $cpcClicks,
+            ctr: $ctr,
+            cpc: $cpc,
+            cpm: $cpm,
+            orders: $cpcOrders,
+            cpo: $cpo,
+            revenue: $cpcRevenue,
+            cr: $cr,
+            acos: $acos,
+        );
+
+        $otherMetrics = new AdvertisingOtherMetrics(
+            spend: $otherSpend,
+            details: $otherDetails,
+        );
+
+        $advertisingDetails = new AdvertisingDetails($cpcMetrics, $otherMetrics);
+
+        if ($cpcMetrics->isEmpty() && $otherMetrics->isEmpty()) {
+            $flags = $flags->addFlag(DataQualityFlag::API_ADVERTISING_MISSING);
+        }
+
+        $costMap['advertising_cpc'] = $cpcMetrics->spend;
+        $costMap['advertising_other'] = $otherMetrics->spend;
+        $costBreakdown = CostBreakdown::fromArray($costMap);
+
+        // 6. Orders
+        $orders = $this->marketplaceFacade->getOrdersForListingAndDate($companyId, $listingId, $date);
+        $ordersQuantity = count($orders);
+        $deliveredQuantity = 0;
+        foreach ($orders as $order) {
+            if ($order->status->value === 'delivered') {
+                $deliveredQuantity++;
+            }
+        }
+
+        // 7. DataQuality flags already built above
+
+        // 8. Upsert
+        $snapshot = $this->snapshotRepository->findOneByUniqueKey($companyId, $listingId, $date);
+        if ($snapshot === null) {
+            $snapshot = new ListingDailySnapshot(
+                Uuid::uuid7()->toString(),
+                $companyId,
+                $listingId,
+                MarketplaceType::from($marketplace),
+                $date,
+            );
+        }
+
+        $snapshot->recalculate(
+            $revenue,
+            $refunds,
+            $salesQuantity,
+            $returnsQuantity,
+            $ordersQuantity,
+            $deliveredQuantity,
+            $avgSalePrice,
+            $costPrice,
+            $totalCostPrice,
+            $costBreakdown->toArray(),
+            $advertisingDetails->toArray(),
+            $flags->toArray(),
+        );
+
+        $this->snapshotRepository->save($snapshot);
+
+        return $snapshot;
+    }
+}

--- a/site/src/MarketplaceAnalytics/Domain/Service/SnapshotCalculationPolicy.php
+++ b/site/src/MarketplaceAnalytics/Domain/Service/SnapshotCalculationPolicy.php
@@ -7,6 +7,7 @@ namespace App\MarketplaceAnalytics\Domain\Service;
 use App\Marketplace\DTO\AdvertisingCostDTO;
 use App\Marketplace\Enum\AdvertisingType;
 use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Enum\OrderStatus;
 use App\Marketplace\Facade\MarketplaceFacade;
 use App\MarketplaceAnalytics\Domain\ValueObject\AdvertisingCpcMetrics;
 use App\MarketplaceAnalytics\Domain\ValueObject\AdvertisingDetails;
@@ -162,7 +163,7 @@ final readonly class SnapshotCalculationPolicy
         $ordersQuantity = count($orders);
         $deliveredQuantity = 0;
         foreach ($orders as $order) {
-            if ($order->status->value === 'delivered') {
+            if ($order->status === OrderStatus::DELIVERED) {
                 $deliveredQuantity++;
             }
         }


### PR DESCRIPTION
## Summary

- `SnapshotCalculationPolicy` — 8-шаговый расчёт daily snapshot: sales, returns, cost price, costs (via CostMappingResolver), advertising (CPC+Other), orders, DataQualityFlags, upsert. Без flush
- `MarketplaceFacade` расширен 4 методами через DBAL для legacy entities: `getSalesForListingAndDate()`, `getReturnsForListingAndDate()`, `getCostsForListingAndDate()`, `getCostPriceForListing()`
- `ARCHITECTURE.md` обновлён с новыми Facade-методами

## Test plan

- [ ] SnapshotCalculationPolicy создаёт новый snapshot если не существует
- [ ] SnapshotCalculationPolicy обновляет существующий snapshot (upsert)
- [ ] Revenue/refunds корректно суммируются через bcadd
- [ ] CostPrice=null → COST_PRICE_MISSING flag
- [ ] Пустая реклама → API_ADVERTISING_MISSING flag
- [ ] CostBreakdown заполняется через CostMappingResolver (advertising categories пропускаются)
- [ ] Advertising metrics (CTR, CR, CPC, CPM, CPO, ACOS) корректно вычисляются
- [ ] Facade DBAL-методы возвращают корректные DTO с companyId-фильтрацией

https://claude.ai/code/session_01UhjVAFEeWoJF4Bf4TboQF5