### PR TITLE
Task #43-44: Unit tests for CostMappingResolver and DefaultCostMappingSeedPolicy

### DIFF
--- a/site/tests/Unit/MarketplaceAnalytics/Domain/Service/CostMappingResolverTest.php
+++ b/site/tests/Unit/MarketplaceAnalytics/Domain/Service/CostMappingResolverTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MarketplaceAnalytics\Domain\Service;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAnalytics\Domain\Service\CostMappingResolver;
+use App\MarketplaceAnalytics\Enum\UnitEconomyCostType;
+use App\MarketplaceAnalytics\Repository\UnitEconomyCostMappingRepositoryInterface;
+use App\Tests\Builders\MarketplaceAnalytics\UnitEconomyCostMappingBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class CostMappingResolverTest extends TestCase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-111111111111';
+    private const MARKETPLACE = 'wildberries';
+    private const COST_CODE = 'logistics_delivery';
+
+    public function testResolveReturnsUserMappingWhenExists(): void
+    {
+        $mapping = UnitEconomyCostMappingBuilder::aMapping()
+            ->withCostCategoryCode(self::COST_CODE)
+            ->withUnitEconomyCostType(UnitEconomyCostType::LOGISTICS_TO)
+            ->build();
+
+        $repo = $this->createMock(UnitEconomyCostMappingRepositoryInterface::class);
+        $repo->method('findOneByKey')
+            ->with(self::COMPANY_ID, MarketplaceType::WILDBERRIES, self::COST_CODE)
+            ->willReturn($mapping);
+
+        $resolver = new CostMappingResolver($repo);
+
+        self::assertSame(
+            UnitEconomyCostType::LOGISTICS_TO,
+            $resolver->resolve(self::COMPANY_ID, self::MARKETPLACE, self::COST_CODE),
+        );
+    }
+
+    public function testResolveReturnsFallbackToSystemMapping(): void
+    {
+        $systemMapping = UnitEconomyCostMappingBuilder::aMapping()
+            ->asSystem()
+            ->withCostCategoryCode(self::COST_CODE)
+            ->withUnitEconomyCostType(UnitEconomyCostType::LOGISTICS_TO)
+            ->build();
+
+        $repo = $this->createMock(UnitEconomyCostMappingRepositoryInterface::class);
+        $repo->method('findOneByKey')->willReturn(null);
+        $repo->method('findSystemMapping')
+            ->with(MarketplaceType::WILDBERRIES, self::COST_CODE)
+            ->willReturn($systemMapping);
+
+        $resolver = new CostMappingResolver($repo);
+
+        self::assertSame(
+            UnitEconomyCostType::LOGISTICS_TO,
+            $resolver->resolve(self::COMPANY_ID, self::MARKETPLACE, self::COST_CODE),
+        );
+    }
+
+    public function testResolveReturnsOtherWhenNoMappingFound(): void
+    {
+        $repo = $this->createMock(UnitEconomyCostMappingRepositoryInterface::class);
+        $repo->method('findOneByKey')->willReturn(null);
+        $repo->method('findSystemMapping')->willReturn(null);
+
+        $resolver = new CostMappingResolver($repo);
+
+        self::assertSame(
+            UnitEconomyCostType::OTHER,
+            $resolver->resolve(self::COMPANY_ID, self::MARKETPLACE, self::COST_CODE),
+        );
+    }
+
+    public function testIsAdvertisingCategoryReturnsTrueForCpcCode(): void
+    {
+        $mapping = UnitEconomyCostMappingBuilder::aMapping()
+            ->withCostCategoryCode('advertising_cpc')
+            ->withUnitEconomyCostType(UnitEconomyCostType::ADVERTISING_CPC)
+            ->build();
+
+        $repo = $this->createMock(UnitEconomyCostMappingRepositoryInterface::class);
+        $repo->method('findOneByKey')->willReturn($mapping);
+
+        $resolver = new CostMappingResolver($repo);
+
+        self::assertTrue(
+            $resolver->isAdvertisingCategory(self::COMPANY_ID, self::MARKETPLACE, 'advertising_cpc'),
+        );
+    }
+
+    public function testIsAdvertisingCategoryReturnsFalseForLogisticsCode(): void
+    {
+        $mapping = UnitEconomyCostMappingBuilder::aMapping()
+            ->withCostCategoryCode(self::COST_CODE)
+            ->withUnitEconomyCostType(UnitEconomyCostType::LOGISTICS_TO)
+            ->build();
+
+        $repo = $this->createMock(UnitEconomyCostMappingRepositoryInterface::class);
+        $repo->method('findOneByKey')->willReturn($mapping);
+
+        $resolver = new CostMappingResolver($repo);
+
+        self::assertFalse(
+            $resolver->isAdvertisingCategory(self::COMPANY_ID, self::MARKETPLACE, self::COST_CODE),
+        );
+    }
+}

--- a/site/tests/Unit/MarketplaceAnalytics/Domain/Service/DefaultCostMappingSeedPolicyTest.php
+++ b/site/tests/Unit/MarketplaceAnalytics/Domain/Service/DefaultCostMappingSeedPolicyTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MarketplaceAnalytics\Domain\Service;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAnalytics\Domain\Service\DefaultCostMappingSeedPolicy;
+use App\MarketplaceAnalytics\Entity\UnitEconomyCostMapping;
+use App\MarketplaceAnalytics\Enum\UnitEconomyCostType;
+use App\MarketplaceAnalytics\Repository\UnitEconomyCostMappingRepositoryInterface;
+use PHPUnit\Framework\TestCase;
+
+final class DefaultCostMappingSeedPolicyTest extends TestCase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-111111111111';
+    private const MARKETPLACE = 'wildberries';
+
+    public function testSeedCreatesSystemMappingsWhenNoneExist(): void
+    {
+        $saved = [];
+
+        $repo = $this->createMock(UnitEconomyCostMappingRepositoryInterface::class);
+        $repo->method('hasCompanyMappings')
+            ->with(self::COMPANY_ID, MarketplaceType::WILDBERRIES)
+            ->willReturn(false);
+        $repo->method('save')
+            ->willReturnCallback(static function (UnitEconomyCostMapping $mapping) use (&$saved): void {
+                $saved[] = $mapping;
+            });
+
+        $policy = new DefaultCostMappingSeedPolicy($repo);
+        $policy->seedForCompanyAndMarketplace(self::COMPANY_ID, self::MARKETPLACE);
+
+        self::assertCount(6, $saved);
+
+        foreach ($saved as $mapping) {
+            self::assertTrue($mapping->isSystem());
+        }
+    }
+
+    public function testSeedIsIdempotent(): void
+    {
+        $repo = $this->createMock(UnitEconomyCostMappingRepositoryInterface::class);
+        $repo->method('hasCompanyMappings')
+            ->with(self::COMPANY_ID, MarketplaceType::WILDBERRIES)
+            ->willReturn(true);
+        $repo->expects(self::never())->method('save');
+
+        $policy = new DefaultCostMappingSeedPolicy($repo);
+        $policy->seedForCompanyAndMarketplace(self::COMPANY_ID, self::MARKETPLACE);
+    }
+
+    public function testCreatedMappingsHaveCorrectTypes(): void
+    {
+        $saved = [];
+
+        $repo = $this->createMock(UnitEconomyCostMappingRepositoryInterface::class);
+        $repo->method('hasCompanyMappings')->willReturn(false);
+        $repo->method('save')
+            ->willReturnCallback(static function (UnitEconomyCostMapping $mapping) use (&$saved): void {
+                $saved[] = $mapping;
+            });
+
+        $policy = new DefaultCostMappingSeedPolicy($repo);
+        $policy->seedForCompanyAndMarketplace(self::COMPANY_ID, self::MARKETPLACE);
+
+        $typesByCode = [];
+        foreach ($saved as $mapping) {
+            $typesByCode[$mapping->getCostCategoryCode()] = $mapping->getUnitEconomyCostType();
+        }
+
+        self::assertSame(UnitEconomyCostType::ADVERTISING_CPC, $typesByCode['advertising_cpc']);
+        self::assertSame(UnitEconomyCostType::ADVERTISING_OTHER, $typesByCode['advertising_other']);
+        self::assertSame(UnitEconomyCostType::LOGISTICS_TO, $typesByCode['logistics_delivery']);
+        self::assertSame(UnitEconomyCostType::LOGISTICS_BACK, $typesByCode['logistics_return']);
+        self::assertSame(UnitEconomyCostType::STORAGE, $typesByCode['storage']);
+        self::assertSame(UnitEconomyCostType::COMMISSION, $typesByCode['commission']);
+    }
+}


### PR DESCRIPTION
## Summary

- `CostMappingResolverTest` — 5 unit-тестов: resolve с user/system/fallback маппингом, isAdvertisingCategory true/false
- `DefaultCostMappingSeedPolicyTest` — 3 unit-теста: seed создаёт 6 системных маппингов, idempotent при наличии, корректные типы
- Путь: `tests/Unit/MarketplaceAnalytics/Domain/Service/` — по конвенции проекта (не `tests/MarketplaceAnalytics/`)
- Mock-based, без flush(), используется `UnitEconomyCostMappingBuilder`

## Test plan

- [ ] `bin/phpunit tests/Unit/MarketplaceAnalytics/Domain/Service/CostMappingResolverTest.php` — 5 тестов pass
- [ ] `bin/phpunit tests/Unit/MarketplaceAnalytics/Domain/Service/DefaultCostMappingSeedPolicyTest.php` — 3 теста pass

https://claude.ai/code/session_01HLLFBLDv6GNYpLa6G7GiEH