### PR TITLE
Normalize negative amounts before building analytics cost breakdown

### DIFF
--- a/site/src/MarketplaceAnalytics/Domain/Service/SnapshotCalculationPolicy.php
+++ b/site/src/MarketplaceAnalytics/Domain/Service/SnapshotCalculationPolicy.php
@@ -89,7 +89,8 @@ final readonly class SnapshotCalculationPolicy
             if ($type->isAdvertising()) {
                 continue;
             }
-            $costMap[$type->value] = bcadd($costMap[$type->value] ?? '0.00', $costDTO->amount, 2);
+            $normalizedAmount = $this->normalizeAmountForCostBreakdown($costDTO->amount);
+            $costMap[$type->value] = bcadd($costMap[$type->value] ?? '0.00', $normalizedAmount, 2);
         }
 
         // 5. Advertising
@@ -104,17 +105,19 @@ final readonly class SnapshotCalculationPolicy
         $otherDetails = [];
 
         foreach ($advCosts as $adv) {
+            $normalizedAmount = $this->normalizeAmountForCostBreakdown($adv->amount);
+
             if ($adv->advertisingType === AdvertisingType::CPC) {
-                $cpcSpend = bcadd($cpcSpend, $adv->amount, 2);
+                $cpcSpend = bcadd($cpcSpend, $normalizedAmount, 2);
                 $cpcImpressions += $adv->analyticsData['impressions'] ?? 0;
                 $cpcClicks += $adv->analyticsData['clicks'] ?? 0;
                 $cpcOrders += $adv->analyticsData['orders'] ?? 0;
                 $cpcRevenue = bcadd($cpcRevenue, $adv->analyticsData['revenue'] ?? '0.00', 2);
             } else {
-                $otherSpend = bcadd($otherSpend, $adv->amount, 2);
+                $otherSpend = bcadd($otherSpend, $normalizedAmount, 2);
                 $otherDetails[] = [
                     'type' => $adv->advertisingType->value,
-                    'amount' => $adv->amount,
+                    'amount' => $normalizedAmount,
                     'campaign' => $adv->externalCampaignId,
                 ];
             }
@@ -200,5 +203,14 @@ final readonly class SnapshotCalculationPolicy
         $this->snapshotRepository->save($snapshot);
 
         return $snapshot;
+    }
+
+    private function normalizeAmountForCostBreakdown(string $amount): string
+    {
+        if (bccomp($amount, '0.00', 2) < 0) {
+            return ltrim($amount, '-');
+        }
+
+        return $amount;
     }
 }


### PR DESCRIPTION
### Motivation
- `CostBreakdown` enforces that all cost values are >= 0, and negative raw amounts (for example `-1.11`) caused `Webmozart\Assert\InvalidArgumentException` during `RecalcSnapshotsMessage` handling.
- `MarketplaceFacade::getCostsForListingAndDate()` and advertising sources can return `amount` values with a negative sign, which were previously aggregated unchanged in `SnapshotCalculationPolicy` and broke the invariant.

### Description
- Normalize negative `amount` values when aggregating non-advertising costs into the `costMap` by calling a new helper `normalizeAmountForCostBreakdown(string): string` before `bcadd`.
- Apply the same normalization to advertising spend aggregation (`cpcSpend`, `otherSpend`) and to persisted advertising `details` so advertising entries no longer carry a leading `-`.
- The change is localized to `site/src/MarketplaceAnalytics/Domain/Service/SnapshotCalculationPolicy.php` and does not modify `CostBreakdown` behavior for non-negative inputs.

### Testing
- Ran `php -l site/src/MarketplaceAnalytics/Domain/Service/SnapshotCalculationPolicy.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca821eeff48323b21b7be2a95ac981)