### PR TITLE
feat(MarketplaceAnalytics): CostMappingResolver — переход на categoryId (#62)

### DIFF
--- a/site/src/Marketplace/DTO/CostData.php
+++ b/site/src/Marketplace/DTO/CostData.php
@@ -11,6 +11,7 @@ readonly class CostData
         public string $categoryCode, // Код категории затрат
         public string $amount,
         public \DateTimeImmutable $costDate,
+        public ?string $categoryId = null,  // UUID категории затрат (для CostMappingResolver)
         public ?string $marketplaceSku = null, // Nullable для общих затрат
         public ?string $description = null,
         public ?string $externalId = null,

--- a/site/src/Marketplace/Facade/MarketplaceFacade.php
+++ b/site/src/Marketplace/Facade/MarketplaceFacade.php
@@ -140,7 +140,7 @@ final readonly class MarketplaceFacade
     ): array {
         $rows = $this->connection->fetchAllAssociative(
             'SELECT c.marketplace, c.amount, c.cost_date, c.description, c.external_id,
-                    cat.code AS category_code, l.marketplace_sku
+                    cat.id AS category_id, cat.code AS category_code, l.marketplace_sku
              FROM marketplace_costs c
              JOIN marketplace_cost_categories cat ON c.category_id = cat.id
              LEFT JOIN marketplace_listings l ON c.listing_id = l.id
@@ -159,6 +159,7 @@ final readonly class MarketplaceFacade
             categoryCode: $row['category_code'],
             amount: $row['amount'],
             costDate: new \DateTimeImmutable($row['cost_date']),
+            categoryId: $row['category_id'],
             marketplaceSku: $row['marketplace_sku'] ?? null,
             description: $row['description'],
             externalId: $row['external_id'],

--- a/site/src/MarketplaceAnalytics/Domain/Service/SnapshotCalculationPolicy.php
+++ b/site/src/MarketplaceAnalytics/Domain/Service/SnapshotCalculationPolicy.php
@@ -16,6 +16,7 @@ use App\MarketplaceAnalytics\Domain\ValueObject\CostBreakdown;
 use App\MarketplaceAnalytics\Domain\ValueObject\DataQualityFlags;
 use App\MarketplaceAnalytics\Entity\ListingDailySnapshot;
 use App\MarketplaceAnalytics\Enum\DataQualityFlag;
+use App\MarketplaceAnalytics\Enum\UnitEconomyCostType;
 use App\MarketplaceAnalytics\Repository\ListingDailySnapshotRepositoryInterface;
 use Ramsey\Uuid\Uuid;
 
@@ -85,7 +86,9 @@ final readonly class SnapshotCalculationPolicy
         $costMap = [];
 
         foreach ($costs as $costDTO) {
-            $type = $this->costMappingResolver->resolve($companyId, $marketplace, $costDTO->categoryCode);
+            $type = $costDTO->categoryId !== null
+                ? $this->costMappingResolver->resolve($companyId, $marketplace, $costDTO->categoryId)
+                : UnitEconomyCostType::OTHER;
             if ($type->isAdvertising()) {
                 continue;
             }

--- a/site/tests/Unit/MarketplaceAnalytics/Domain/Service/CostMappingResolverTest.php
+++ b/site/tests/Unit/MarketplaceAnalytics/Domain/Service/CostMappingResolverTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\MarketplaceAnalytics\Domain\Service;
 
-use App\Marketplace\Enum\MarketplaceType;
 use App\MarketplaceAnalytics\Domain\Service\CostMappingResolver;
 use App\MarketplaceAnalytics\Enum\UnitEconomyCostType;
 use App\MarketplaceAnalytics\Repository\UnitEconomyCostMappingRepositoryInterface;
@@ -13,97 +12,74 @@ use PHPUnit\Framework\TestCase;
 
 final class CostMappingResolverTest extends TestCase
 {
-    private const COMPANY_ID = '11111111-1111-1111-1111-111111111111';
+    private const COMPANY_ID  = '11111111-1111-1111-1111-111111111111';
     private const MARKETPLACE = 'wildberries';
-    private const COST_CODE = 'logistics_delivery';
+    private const CATEGORY_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
 
     public function testResolveReturnsUserMappingWhenExists(): void
     {
         $mapping = UnitEconomyCostMappingBuilder::aMapping()
-            ->withCostCategoryCode(self::COST_CODE)
+            ->withCostCategoryId(self::CATEGORY_ID)
             ->withUnitEconomyCostType(UnitEconomyCostType::LOGISTICS_TO)
             ->build();
 
         $repo = $this->createMock(UnitEconomyCostMappingRepositoryInterface::class);
-        $repo->method('findOneByKey')
-            ->with(self::COMPANY_ID, MarketplaceType::WILDBERRIES, self::COST_CODE)
+        $repo->method('findOneByCategoryId')
+            ->with(self::COMPANY_ID, self::MARKETPLACE, self::CATEGORY_ID)
             ->willReturn($mapping);
 
         $resolver = new CostMappingResolver($repo);
 
         self::assertSame(
             UnitEconomyCostType::LOGISTICS_TO,
-            $resolver->resolve(self::COMPANY_ID, self::MARKETPLACE, self::COST_CODE),
-        );
-    }
-
-    public function testResolveReturnsFallbackToSystemMapping(): void
-    {
-        $systemMapping = UnitEconomyCostMappingBuilder::aMapping()
-            ->asSystem()
-            ->withCostCategoryCode(self::COST_CODE)
-            ->withUnitEconomyCostType(UnitEconomyCostType::LOGISTICS_TO)
-            ->build();
-
-        $repo = $this->createMock(UnitEconomyCostMappingRepositoryInterface::class);
-        $repo->method('findOneByKey')->willReturn(null);
-        $repo->method('findSystemMapping')
-            ->with(MarketplaceType::WILDBERRIES, self::COST_CODE)
-            ->willReturn($systemMapping);
-
-        $resolver = new CostMappingResolver($repo);
-
-        self::assertSame(
-            UnitEconomyCostType::LOGISTICS_TO,
-            $resolver->resolve(self::COMPANY_ID, self::MARKETPLACE, self::COST_CODE),
+            $resolver->resolve(self::COMPANY_ID, self::MARKETPLACE, self::CATEGORY_ID),
         );
     }
 
     public function testResolveReturnsOtherWhenNoMappingFound(): void
     {
         $repo = $this->createMock(UnitEconomyCostMappingRepositoryInterface::class);
-        $repo->method('findOneByKey')->willReturn(null);
-        $repo->method('findSystemMapping')->willReturn(null);
+        $repo->method('findOneByCategoryId')->willReturn(null);
 
         $resolver = new CostMappingResolver($repo);
 
         self::assertSame(
             UnitEconomyCostType::OTHER,
-            $resolver->resolve(self::COMPANY_ID, self::MARKETPLACE, self::COST_CODE),
+            $resolver->resolve(self::COMPANY_ID, self::MARKETPLACE, self::CATEGORY_ID),
         );
     }
 
-    public function testIsAdvertisingCategoryReturnsTrueForCpcCode(): void
+    public function testIsAdvertisingCategoryReturnsTrueForCpcMapping(): void
     {
         $mapping = UnitEconomyCostMappingBuilder::aMapping()
-            ->withCostCategoryCode('advertising_cpc')
+            ->withCostCategoryId(self::CATEGORY_ID)
             ->withUnitEconomyCostType(UnitEconomyCostType::ADVERTISING_CPC)
             ->build();
 
         $repo = $this->createMock(UnitEconomyCostMappingRepositoryInterface::class);
-        $repo->method('findOneByKey')->willReturn($mapping);
+        $repo->method('findOneByCategoryId')->willReturn($mapping);
 
         $resolver = new CostMappingResolver($repo);
 
         self::assertTrue(
-            $resolver->isAdvertisingCategory(self::COMPANY_ID, self::MARKETPLACE, 'advertising_cpc'),
+            $resolver->isAdvertisingCategory(self::COMPANY_ID, self::MARKETPLACE, self::CATEGORY_ID),
         );
     }
 
-    public function testIsAdvertisingCategoryReturnsFalseForLogisticsCode(): void
+    public function testIsAdvertisingCategoryReturnsFalseForLogisticsMapping(): void
     {
         $mapping = UnitEconomyCostMappingBuilder::aMapping()
-            ->withCostCategoryCode(self::COST_CODE)
+            ->withCostCategoryId(self::CATEGORY_ID)
             ->withUnitEconomyCostType(UnitEconomyCostType::LOGISTICS_TO)
             ->build();
 
         $repo = $this->createMock(UnitEconomyCostMappingRepositoryInterface::class);
-        $repo->method('findOneByKey')->willReturn($mapping);
+        $repo->method('findOneByCategoryId')->willReturn($mapping);
 
         $resolver = new CostMappingResolver($repo);
 
         self::assertFalse(
-            $resolver->isAdvertisingCategory(self::COMPANY_ID, self::MARKETPLACE, self::COST_CODE),
+            $resolver->isAdvertisingCategory(self::COMPANY_ID, self::MARKETPLACE, self::CATEGORY_ID),
         );
     }
 }


### PR DESCRIPTION
## Summary

- `CostData` DTO: добавлено поле `?string $categoryId` (UUID из `marketplace_cost_categories`)
- `MarketplaceFacade::getCostsForListingAndDate`: добавлен `cat.id AS category_id` в SELECT
- `SnapshotCalculationPolicy`: резолв типа затраты по `categoryId` вместо `categoryCode`; fallback `OTHER` при null
- `CostMappingResolverTest`: переписан под новый интерфейс (`findOneByCategoryId`, `withCostCategoryId`)

`CostMappingResolver` изменений не потребовал — уже соответствовал спеке после #61.

## Зависимости

- Зависит от: #59, #61
- Нужен для: #27 (SnapshotCalculationPolicy)

https://claude.ai/code/session_014kcqDj1ZMpEiqCwNxBdKcG