### PR TITLE
fix: restore remapCostMapping to ARCHITECTURE.md MarketplaceAnalyticsFacade

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -143,6 +143,13 @@ addCostMapping(string $companyId, string $marketplace, UnitEconomyCostType $unit
 // Удалить маппинг
 // Выбрасывает DomainException если маппинг не найден
 deleteCostMapping(string $companyId, string $mappingId): void
+
+// Переназначить статью юнит-экономики для маппинга (API только, UI кнопки нет)
+remapCostMapping(
+    string $companyId,
+    string $mappingId,
+    UnitEconomyCostType $newType,
+): UnitEconomyCostMapping
 ```
 
 ### `MarketplaceFacade` (`src/Marketplace/Facade/MarketplaceFacade.php`)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -145,11 +145,8 @@ addCostMapping(string $companyId, string $marketplace, UnitEconomyCostType $unit
 deleteCostMapping(string $companyId, string $mappingId): void
 
 // Переназначить статью юнит-экономики для маппинга (API только, UI кнопки нет)
-remapCostMapping(
-    string $companyId,
-    string $mappingId,
-    UnitEconomyCostType $newType,
-): UnitEconomyCostMapping
+// Выбрасывает DomainException если маппинг не найден
+remapCostMapping(string $companyId, string $mappingId, UnitEconomyCostType $newType): UnitEconomyCostMapping
 ```
 
 ### `MarketplaceFacade` (`src/Marketplace/Facade/MarketplaceFacade.php`)


### PR DESCRIPTION
## Summary

- Восстановлен `remapCostMapping()` в секции `MarketplaceAnalyticsFacade` в `ARCHITECTURE.md`
- Метод существует в коде (`MarketplaceAnalyticsFacade.php`) и API-контроллере (`CostMappingRemapController`), но был случайно удалён из документации в #1348
- Добавлен комментарий: _API только, UI кнопки нет_

https://claude.ai/code/session_014kcqDj1ZMpEiqCwNxBdKcG