### PR TITLE
Cash: add CreateDocumentFromTransactionAction + CashTransactionCreateFromController

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -127,6 +127,9 @@ createDocumentFromCashTransaction(
     string $companyId,
     CreateDocumentCommand $command,  // App\Cash\Application\DTO\CreateDocumentCommand
 ): string  // ID созданного Document
+
+// Обновить PL-регистр за день документа (вызывать после flush в Action)
+updatePLRegisterForDocument(string $documentId): void
 ```
 
 > **Остальные Facade** добавлять сюда по мере реализации модулей.

--- a/site/src/Cash/Application/CreateDocumentFromTransactionAction.php
+++ b/site/src/Cash/Application/CreateDocumentFromTransactionAction.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Cash\Application;
+
+use App\Cash\Application\DTO\CreateDocumentCommand;
+use App\Cash\Application\DTO\CreateDocumentResult;
+use App\Cash\Entity\Transaction\CashTransaction;
+use App\Finance\Facade\FinanceFacade;
+use Doctrine\ORM\EntityManagerInterface;
+
+final class CreateDocumentFromTransactionAction
+{
+    public function __construct(
+        private readonly FinanceFacade $financeFacade,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function __invoke(CashTransaction $tx, bool $confirmed): CreateDocumentResult
+    {
+        if ($tx->isTransfer()) {
+            throw new \DomainException('Для переводов нельзя создать документ ОПиУ.');
+        }
+
+        if ($tx->getRemainingAmount() <= 0) {
+            throw new \DomainException('Транзакция уже полностью разнесена.');
+        }
+
+        $category = $tx->getCashflowCategory();
+        $plCategory = $category?->getPlCategory();
+        $hasPLCategory = ($plCategory !== null);
+
+        $amount = number_format($tx->getRemainingAmount(), 2, '.', '');
+
+        if ($hasPLCategory) {
+            $command = new CreateDocumentCommand(
+                cashTransactionId: $tx->getId(),
+                occurredAt: $tx->getOccurredAt(),
+                amount: $amount,
+                counterpartyId: $tx->getCounterparty()?->getId(),
+                projectDirectionId: $tx->getProjectDirection()?->getId(),
+                plCategoryId: $plCategory->getId(),
+                createdWithViolation: false,
+            );
+
+            $documentId = $this->financeFacade->createDocumentFromCashTransaction(
+                $tx->getCompany()->getId(),
+                $command,
+            );
+
+            $this->entityManager->flush();
+
+            return new CreateDocumentResult(
+                needsConfirmation: false,
+                documentId: $documentId,
+                hasViolation: false,
+                warningMessage: '',
+            );
+        }
+
+        if (!$confirmed) {
+            return new CreateDocumentResult(
+                needsConfirmation: true,
+                documentId: null,
+                hasViolation: false,
+                warningMessage: 'У категории ДДС не задана категория ОПиУ. '
+                    . 'Документ будет создан с частично заполненными данными — '
+                    . 'дата, сумма, контрагент, проект. '
+                    . 'Категорию ОПиУ нужно будет указать вручную.',
+            );
+        }
+
+        $command = new CreateDocumentCommand(
+            cashTransactionId: $tx->getId(),
+            occurredAt: $tx->getOccurredAt(),
+            amount: $amount,
+            counterpartyId: $tx->getCounterparty()?->getId(),
+            projectDirectionId: $tx->getProjectDirection()?->getId(),
+            plCategoryId: null,
+            createdWithViolation: true,
+        );
+
+        $documentId = $this->financeFacade->createDocumentFromCashTransaction(
+            $tx->getCompany()->getId(),
+            $command,
+        );
+
+        $tx->markAsHavingViolatedDocument();
+
+        $this->entityManager->flush();
+
+        return new CreateDocumentResult(
+            needsConfirmation: false,
+            documentId: $documentId,
+            hasViolation: true,
+            warningMessage: '',
+        );
+    }
+}

--- a/site/src/Cash/Application/CreateDocumentFromTransactionAction.php
+++ b/site/src/Cash/Application/CreateDocumentFromTransactionAction.php
@@ -87,8 +87,6 @@ final class CreateDocumentFromTransactionAction
             $command,
         );
 
-        $tx->markAsHavingViolatedDocument();
-
         $this->entityManager->flush();
 
         return new CreateDocumentResult(

--- a/site/src/Cash/Application/CreateDocumentFromTransactionAction.php
+++ b/site/src/Cash/Application/CreateDocumentFromTransactionAction.php
@@ -51,6 +51,7 @@ final class CreateDocumentFromTransactionAction
             );
 
             $this->entityManager->flush();
+            $this->financeFacade->updatePLRegisterForDocument($documentId);
 
             return new CreateDocumentResult(
                 needsConfirmation: false,
@@ -88,6 +89,7 @@ final class CreateDocumentFromTransactionAction
         );
 
         $this->entityManager->flush();
+        $this->financeFacade->updatePLRegisterForDocument($documentId);
 
         return new CreateDocumentResult(
             needsConfirmation: false,

--- a/site/src/Cash/Controller/Transaction/CashTransactionCreateFromController.php
+++ b/site/src/Cash/Controller/Transaction/CashTransactionCreateFromController.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Cash\Controller\Transaction;
+
+use App\Cash\Application\CreateDocumentFromTransactionAction;
+use App\Cash\Entity\Transaction\CashTransaction;
+use App\Shared\Service\ActiveCompanyService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class CashTransactionCreateFromController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $activeCompanyService,
+        private readonly CreateDocumentFromTransactionAction $action,
+    ) {
+    }
+
+    #[Route(
+        '/finance/cash-transactions/{id}/create-from',
+        name: 'cash_transaction_create_from',
+        methods: ['POST']
+    )]
+    public function __invoke(Request $request, CashTransaction $tx): JsonResponse
+    {
+        $company = $this->activeCompanyService->getActiveCompany();
+
+        if ($tx->getCompany()->getId() !== $company->getId()) {
+            return new JsonResponse(['error' => true, 'message' => 'Доступ запрещён.'], 403);
+        }
+
+        $token = (string) $request->request->get('_token', '');
+        if (!$this->isCsrfTokenValid('cash_transaction_create_from', $token)) {
+            return new JsonResponse(['error' => true, 'message' => 'Неверный CSRF-токен.'], 403);
+        }
+
+        $confirmed = (bool) $request->request->get('confirmed', false);
+
+        try {
+            $result = ($this->action)($tx, $confirmed);
+        } catch (\DomainException $e) {
+            return new JsonResponse(['error' => true, 'message' => $e->getMessage()], 422);
+        }
+
+        if ($result->needsConfirmation) {
+            return new JsonResponse([
+                'needsConfirmation' => true,
+                'warningMessage'    => $result->warningMessage,
+            ]);
+        }
+
+        if ($result->hasViolation) {
+            return new JsonResponse([
+                'redirect' => $this->generateUrl('document_edit', ['id' => $result->documentId]),
+            ]);
+        }
+
+        return new JsonResponse([
+            'success' => true,
+            'flash'   => 'Документ ОПиУ создан.',
+        ]);
+    }
+}

--- a/site/src/Cash/Controller/Transaction/CashTransactionCreateFromController.php
+++ b/site/src/Cash/Controller/Transaction/CashTransactionCreateFromController.php
@@ -38,7 +38,7 @@ final class CashTransactionCreateFromController extends AbstractController
             return new JsonResponse(['error' => true, 'message' => 'Неверный CSRF-токен.'], 403);
         }
 
-        $confirmed = (bool) $request->request->get('confirmed', false);
+        $confirmed = filter_var($request->request->get('confirmed', false), FILTER_VALIDATE_BOOLEAN);
 
         try {
             $result = ($this->action)($tx, $confirmed);
@@ -53,7 +53,7 @@ final class CashTransactionCreateFromController extends AbstractController
             ]);
         }
 
-        if ($result->hasViolation) {
+        if ($result->hasViolation && $result->documentId !== null) {
             return new JsonResponse([
                 'redirect' => $this->generateUrl('document_edit', ['id' => $result->documentId]),
             ]);

--- a/site/src/Finance/Facade/FinanceFacade.php
+++ b/site/src/Finance/Facade/FinanceFacade.php
@@ -12,12 +12,14 @@ use App\Finance\Application\Command\CreatePLDocumentCommand;
 use App\Finance\Application\Command\CreatePLDocumentOperationCommand;
 use App\Finance\Application\CreatePLDocumentAction;
 use App\Finance\Application\DeletePLDocumentAction;
+use App\Finance\Application\Service\PLRegisterUpdater;
 use App\Finance\Entity\Document;
 use App\Finance\Entity\DocumentOperation;
 use App\Finance\Enum\DocumentStatus;
 use App\Finance\Enum\DocumentType;
 use App\Finance\Enum\PLDocumentSource;
 use App\Finance\Enum\PLDocumentStream;
+use App\Finance\Repository\DocumentRepository;
 use App\Finance\Repository\PLCategoryRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Ramsey\Uuid\Uuid;
@@ -39,6 +41,8 @@ final class FinanceFacade
         private readonly CounterpartyRepository $counterpartyRepository,
         private readonly ProjectDirectionRepository $projectDirectionRepository,
         private readonly PLCategoryRepository $plCategoryRepository,
+        private readonly DocumentRepository $documentRepository,
+        private readonly PLRegisterUpdater $plRegisterUpdater,
         private readonly EntityManagerInterface $entityManager,
     ) {
     }
@@ -166,6 +170,7 @@ final class FinanceFacade
 
         $document = new Document(Uuid::uuid4()->toString(), $tx->getCompany());
         $document->setDate($command->occurredAt);
+        $document->setType(DocumentType::CASHFLOW_EXPENSE);
         $document->setDescription($tx->getDescription());
         $document->setCounterparty($counterparty);
         $document->setProjectDirection($projectDirection);
@@ -189,5 +194,22 @@ final class FinanceFacade
         $this->entityManager->persist($document);
 
         return $document->getId();
+    }
+
+    /**
+     * Обновляет PL-регистр за день документа.
+     * Вызывать после flush() в Action.
+     *
+     * @throws \DomainException если документ не найден
+     */
+    public function updatePLRegisterForDocument(string $documentId): void
+    {
+        $document = $this->documentRepository->find($documentId);
+
+        if (!$document) {
+            throw new \DomainException('Документ не найден.');
+        }
+
+        $this->plRegisterUpdater->updateForDocument($document);
     }
 }


### PR DESCRIPTION
## Summary

### Задача 5 — `CreateDocumentFromTransactionAction`
- **Сценарий A**: категория ДДС имеет маппинг PLCategory → создаёт документ с `DocumentType::CASHFLOW_EXPENSE`, обновляет PL-регистр, возвращает `needsConfirmation: false`
- **Сценарий B шаг 1**: нет маппинга, `confirmed=false` → нет обращений к БД, возвращает `needsConfirmation: true` с текстом модалки
- **Сценарий B шаг 2**: нет маппинга, `confirmed=true` → создаёт документ с флагом нарушения, обновляет PL-регистр, возвращает `hasViolation: true`
- Guards: `isTransfer()` и `getRemainingAmount() <= 0` бросают `DomainException`
- `flush()` ровно один раз в конце каждой ветки

### Задача 6 — `CashTransactionCreateFromController`
- `POST /finance/cash-transactions/{id}/create-from`
- IDOR-проверка через `ActiveCompanyService` → 403
- CSRF-валидация (токен `cash_transaction_create_from`) → 403
- `DomainException` → 422
- `needsConfirmation: true` → возвращает JSON с `warningMessage`
- `hasViolation: true` → возвращает `redirect` на `document_edit`
- Сценарий A → `{'success': true, 'flash': 'Документ ОПиУ создан.'}`

### `FinanceFacade` (сопутствующие правки)
- Добавлен `DocumentType::CASHFLOW_EXPENSE` для создаваемых документов
- Добавлен метод `updatePLRegisterForDocument(string $documentId): void`

## Test plan

- [ ] Сценарий A: tx с категорией → документ создан, тип `CASHFLOW_EXPENSE`, PL-регистр обновлён
- [ ] Сценарий B шаг 1: tx без маппинга, `confirmed=false` → ничего не сохранено, вернулся `needsConfirmation=true`
- [ ] Сценарий B шаг 2: tx без маппинга, `confirmed=true` → документ создан с `createdWithViolation=true`, tx помечена
- [ ] Guard: tx-перевод → 422
- [ ] Guard: tx полностью разнесена → 422
- [ ] IDOR: чужая tx → 403
- [ ] CSRF: неверный токен → 403

https://claude.ai/code/session_01DUD7GfSTjmmrQhUdRFULd8