### PR TITLE
fix(Cash): показывать кнопку «Создать на основании» для всех транзакций кроме переводов

### DIFF
--- a/site/templates/transaction/index.html.twig
+++ b/site/templates/transaction/index.html.twig
@@ -167,7 +167,7 @@
                                         <i class="ti ti-settings-automation me-2"></i> Автоправило
                                         </button>
 
-                                        {% if not tx.isTransfer and tx.cashflowCategory and tx.cashflowCategory.allowPlDocument %}
+                                        {% if not tx.isTransfer %}
                                           {% set createFromDisabled = tx.isHasViolatedDocument or tx.remainingAmount <= 0 %}
                                           <button type="button"
                                                   class="dropdown-item d-flex align-items-center gap-2 js-create-from {{ createFromDisabled ? 'disabled' : '' }}"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Убрано лишнее условие `tx.cashflowCategory and tx.cashflowCategory.allowPlDocument` из шаблона `site/templates/transaction/index.html.twig`
- Кнопка «Создать на основании» теперь отображается для **всех** транзакций, кроме переводов (`isTransfer`)
- Логика сценариев A/B (с cashflowCategory / без) делегирована серверному `CreateDocumentFromTransactionAction`, не Twig

## Test plan

- [ ] Открыть список транзакций — кнопка «Создать на основании» видна для транзакций без cashflowCategory (сценарий B)
- [ ] Кнопка по-прежнему скрыта для переводов (`isTransfer = true`)
- [ ] Кнопка задизейблена если `isHasViolatedDocument = true` или `remainingAmount <= 0`

https://claude.ai/code/session_01DZ295fnYqfXJ4MXyHhBg4s
EOF
)