### PR TITLE
fix(Cash): иконка allowPlDocument и нативный DOM для модалки create-from

### DIFF
--- a/site/src/Cash/Application/CreateDocumentFromTransactionAction.php
+++ b/site/src/Cash/Application/CreateDocumentFromTransactionAction.php
@@ -29,6 +29,9 @@ final class CreateDocumentFromTransactionAction
         }
 
         $category = $tx->getCashflowCategory();
+        if ($category !== null && !$category->isAllowPlDocument()) {
+            throw new \DomainException('Для этой категории ДДС создание документов ОПиУ запрещено.');
+        }
         $plCategory = $category?->getPlCategory();
         $hasPLCategory = ($plCategory !== null);
 

--- a/site/templates/transaction/index.html.twig
+++ b/site/templates/transaction/index.html.twig
@@ -296,7 +296,7 @@
       bodyEl.innerHTML = '<div class="text-muted">Загрузка…</div>';
 
       // Показ модалки (Tabler/Bootstrap 5)
-      const modal = window.bootstrap?.Modal.getOrCreateInstance(modalEl);
+      const modal = window.bootstrap?.Modal?.getOrCreateInstance(modalEl);
       modal?.show();
 
       try {

--- a/site/templates/transaction/index.html.twig
+++ b/site/templates/transaction/index.html.twig
@@ -118,7 +118,10 @@
                                 {% elseif tx.remainingAmount == 0 and tx.documents is not empty %}
                                     <i class="ti ti-file-check text-success"
                                        title="Документы ОПиУ созданы на всю сумму"></i>
-                                {% elseif not tx.isTransfer and tx.remainingAmount > 0 %}
+                                {% elseif not tx.isTransfer
+                                             and tx.cashflowCategory
+                                             and tx.cashflowCategory.allowPlDocument
+                                             and tx.remainingAmount > 0 %}
                                     <i class="ti ti-file-plus"
                                        title="Можно создать документ ОПиУ"></i>
                                 {% else %}
@@ -370,6 +373,31 @@
         }
       }
 
+      function showCreateFromModal() {
+        const modalEl = document.getElementById('createFromWarningModal');
+        if (!modalEl) return;
+        modalEl.classList.add('show');
+        modalEl.style.display = 'block';
+        document.body.classList.add('modal-open');
+        const backdrop = document.createElement('div');
+        backdrop.className = 'modal-backdrop fade show';
+        backdrop.id = 'createFromBackdrop';
+        document.body.appendChild(backdrop);
+      }
+
+      function hideCreateFromModal() {
+        const modalEl = document.getElementById('createFromWarningModal');
+        if (!modalEl) return;
+        modalEl.classList.remove('show');
+        modalEl.style.display = '';
+        document.body.classList.remove('modal-open');
+        document.getElementById('createFromBackdrop')?.remove();
+      }
+
+      document.querySelector(
+        '#createFromWarningModal [data-bs-dismiss="modal"]'
+      )?.addEventListener('click', hideCreateFromModal);
+
       function disableCreateFromButton(txId) {
         const btn = document.querySelector(
           '.js-create-from[data-transaction-id="' + txId + '"]'
@@ -427,9 +455,7 @@
           document.getElementById('createFromCsrfToken').value = csrfToken;
           document.getElementById('createFromConfirmForm')
             .dataset.txId = txId;
-          window.bootstrap?.Modal?.getOrCreateInstance(
-            document.getElementById('createFromWarningModal')
-          )?.show();
+          showCreateFromModal();
           return;
         }
 
@@ -458,16 +484,12 @@
             });
             data = await res.json();
           } catch (err) {
-            window.bootstrap?.Modal?.getOrCreateInstance(
-              document.getElementById('createFromWarningModal')
-            )?.hide();
+            hideCreateFromModal();
             showFlash('Ошибка: не удалось создать документ.', 'danger');
             return;
           }
 
-          window.bootstrap?.Modal?.getOrCreateInstance(
-            document.getElementById('createFromWarningModal')
-          )?.hide();
+          hideCreateFromModal();
 
           if (data.error) {
             showFlash('Ошибка: ' + data.message, 'danger');

--- a/site/templates/transaction/index.html.twig
+++ b/site/templates/transaction/index.html.twig
@@ -427,7 +427,7 @@
           document.getElementById('createFromCsrfToken').value = csrfToken;
           document.getElementById('createFromConfirmForm')
             .dataset.txId = txId;
-          window.bootstrap?.Modal.getOrCreateInstance(
+          window.bootstrap?.Modal?.getOrCreateInstance(
             document.getElementById('createFromWarningModal')
           )?.show();
           return;
@@ -458,14 +458,14 @@
             });
             data = await res.json();
           } catch (err) {
-            window.bootstrap?.Modal.getOrCreateInstance(
+            window.bootstrap?.Modal?.getOrCreateInstance(
               document.getElementById('createFromWarningModal')
             )?.hide();
             showFlash('Ошибка: не удалось создать документ.', 'danger');
             return;
           }
 
-          window.bootstrap?.Modal.getOrCreateInstance(
+          window.bootstrap?.Modal?.getOrCreateInstance(
             document.getElementById('createFromWarningModal')
           )?.hide();
 

--- a/site/templates/transaction/index.html.twig
+++ b/site/templates/transaction/index.html.twig
@@ -427,9 +427,9 @@
           document.getElementById('createFromCsrfToken').value = csrfToken;
           document.getElementById('createFromConfirmForm')
             .dataset.txId = txId;
-          bootstrap.Modal.getOrCreateInstance(
+          window.bootstrap?.Modal.getOrCreateInstance(
             document.getElementById('createFromWarningModal')
-          ).show();
+          )?.show();
           return;
         }
 
@@ -458,16 +458,16 @@
             });
             data = await res.json();
           } catch (err) {
-            bootstrap.Modal.getOrCreateInstance(
+            window.bootstrap?.Modal.getOrCreateInstance(
               document.getElementById('createFromWarningModal')
-            ).hide();
+            )?.hide();
             showFlash('Ошибка: не удалось создать документ.', 'danger');
             return;
           }
 
-          bootstrap.Modal.getOrCreateInstance(
+          window.bootstrap?.Modal.getOrCreateInstance(
             document.getElementById('createFromWarningModal')
-          ).hide();
+          )?.hide();
 
           if (data.error) {
             showFlash('Ошибка: ' + data.message, 'danger');

--- a/site/templates/transaction/index.html.twig
+++ b/site/templates/transaction/index.html.twig
@@ -118,7 +118,7 @@
                                 {% elseif tx.remainingAmount == 0 and tx.documents is not empty %}
                                     <i class="ti ti-file-check text-success"
                                        title="Документы ОПиУ созданы на всю сумму"></i>
-                                {% elseif tx.cashflowCategory and tx.cashflowCategory.allowPlDocument and tx.remainingAmount > 0 %}
+                                {% elseif not tx.isTransfer and tx.remainingAmount > 0 %}
                                     <i class="ti ti-file-plus"
                                        title="Можно создать документ ОПиУ"></i>
                                 {% else %}

--- a/site/templates/transaction/index.html.twig
+++ b/site/templates/transaction/index.html.twig
@@ -167,7 +167,7 @@
                                         <i class="ti ti-settings-automation me-2"></i> Автоправило
                                         </button>
 
-                                        {% if not tx.isTransfer and tx.cashflowCategory and tx.cashflowCategory.allowPlDocument %}
+                                        {% if not tx.isTransfer %}
                                           {% set createFromDisabled = tx.isHasViolatedDocument or tx.remainingAmount <= 0 %}
                                           <button type="button"
                                                   class="dropdown-item d-flex align-items-center gap-2 js-create-from {{ createFromDisabled ? 'disabled' : '' }}"


### PR DESCRIPTION
## Summary

- Иконка `ti-file-plus` (строка 121): возвращены условия `cashflowCategory` и `cashflowCategory.allowPlDocument` — иконка показывается только когда у категории ДДС есть привязанная категория ОПиУ
- Модалка `createFromWarningModal`: Bootstrap Modal API (`window.bootstrap?.Modal?`) заменён на нативный DOM — устраняет race condition при асинхронной загрузке Bootstrap
- Добавлены функции `showCreateFromModal()` / `hideCreateFromModal()` с управлением backdrop
- Добавлен обработчик `click` на `[data-bs-dismiss="modal"]` → `hideCreateFromModal()` для корректного закрытия при отсутствии Bootstrap

## Test plan

- [ ] Транзакция с `cashflowCategory.allowPlDocument = true` → иконка `ti-file-plus` видна
- [ ] Транзакция без cashflowCategory или с `allowPlDocument = false` → иконка не показывается
- [ ] Нажать «Создать на основании» на транзакции без категории ОПиУ → модальное окно открывается
- [ ] Кнопка «Отмена» закрывает модалку (и backdrop исчезает)
- [ ] Bootstrap загружен асинхронно / не загружен → нет JS-ошибок, модалка работает

https://claude.ai/code/session_01DZ295fnYqfXJ4MXyHhBg4s