### PR TITLE
feat(Marketplace): add RunMarketplaceRawProcessingStepAction for step execution

### DIFF
--- a/site/config/packages/messenger.yaml
+++ b/site/config/packages/messenger.yaml
@@ -31,6 +31,7 @@ framework:
             'App\Marketplace\Message\ImportInventoryCostPriceMessage': async    # ← НОВОЕ
             'App\Marketplace\Message\CloseMonthStageMessage': async    # ← НОВОЕ
             'App\Marketplace\Message\StartMarketplaceRawProcessingMessage': async
+            'App\Marketplace\Message\RunMarketplaceRawProcessingStepMessage': async
             # ProcessMarketplaceRawDocumentCommand dispatched async из StartMarketplaceRawProcessingHandler.
             # Ручной flow (ReprocessMarketplacePeriodAction) вызывает ProcessMarketplaceRawDocumentAction
             # напрямую, минуя bus — это изменение не влияет на ручной flow.

--- a/site/src/Marketplace/Application/Command/RunMarketplaceRawProcessingStepCommand.php
+++ b/site/src/Marketplace/Application/Command/RunMarketplaceRawProcessingStepCommand.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\Command;
+
+/**
+ * Команда выполнения одного шага daily processing run.
+ *
+ * Передаётся в RunMarketplaceRawProcessingStepAction.
+ * Не является Messenger-сообщением — только Application-команда.
+ */
+final readonly class RunMarketplaceRawProcessingStepCommand
+{
+    public function __construct(
+        public string $companyId,
+        public string $processingRunId,
+        public string $stepRunId,
+    ) {}
+}

--- a/site/src/Marketplace/Application/RunMarketplaceRawProcessingStepAction.php
+++ b/site/src/Marketplace/Application/RunMarketplaceRawProcessingStepAction.php
@@ -135,8 +135,9 @@ final class RunMarketplaceRawProcessingStepAction
             ]);
 
             return $processedCount;
-        } catch (\Throwable $e) {
-            $this->logger->error('[RunStep] Step failed', [
+        } catch (\DomainException $e) {
+            // Бизнес-ошибка: данные невалидны, retry не поможет — помечаем FAILED.
+            $this->logger->error('[RunStep] Step failed (domain error, no retry)', [
                 'step_run_id' => $cmd->stepRunId,
                 'step'        => $stepRun->getStep()->value,
                 'error'       => $e->getMessage(),
@@ -151,6 +152,17 @@ final class RunMarketplaceRawProcessingStepAction
                     'error'       => $flushError->getMessage(),
                 ]);
             }
+
+            throw $e;
+        } catch (\Throwable $e) {
+            // Инфраструктурная ошибка (DB, сеть и т.д.) — шаг остаётся в RUNNING,
+            // Messenger выполнит retry согласно retry_strategy.
+            // Не помечаем FAILED: terminal-статус заблокировал бы повторное выполнение.
+            $this->logger->error('[RunStep] Step failed (infra error, will retry)', [
+                'step_run_id' => $cmd->stepRunId,
+                'step'        => $stepRun->getStep()->value,
+                'error'       => $e->getMessage(),
+            ]);
 
             throw $e;
         }

--- a/site/src/Marketplace/Application/RunMarketplaceRawProcessingStepAction.php
+++ b/site/src/Marketplace/Application/RunMarketplaceRawProcessingStepAction.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application;
+
+use App\Marketplace\Application\Command\RunMarketplaceRawProcessingStepCommand;
+use App\Marketplace\Application\Processor\MarketplaceRawProcessorRegistryInterface;
+use App\Marketplace\Domain\Service\ResolveMarketplaceRawProcessingProfile;
+use App\Marketplace\Enum\PipelineStatus;
+use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
+use App\Marketplace\Repository\MarketplaceRawProcessingRunRepository;
+use App\Marketplace\Repository\MarketplaceRawProcessingStepRunRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Выполняет один шаг daily processing run через существующий raw processor.
+ *
+ * Действия:
+ *   1. Загрузить run и step run по companyId (IDOR-защита).
+ *   2. Проверить принадлежность step run к run.
+ *   3. Идемпотентно пропустить уже завершённые (terminal) шаги.
+ *   4. Загрузить raw document, проверить companyId.
+ *   5. Убедиться, что шаг входит в processing profile документа.
+ *   6. Перевести step в RUNNING (если ещё PENDING).
+ *   7. Найти нужный processor через registry (marketplace + step).
+ *   8. Выполнить processor->process(); обновить counts и status step run.
+ *   9. При ошибке — пометить step как FAILED, rethrow.
+ *
+ * НЕ изменяет ReprocessMarketplacePeriodAction и ручной flow.
+ */
+final class RunMarketplaceRawProcessingStepAction
+{
+    public function __construct(
+        private readonly MarketplaceRawProcessingRunRepository $runRepository,
+        private readonly MarketplaceRawProcessingStepRunRepository $stepRunRepository,
+        private readonly MarketplaceRawDocumentRepository $rawDocumentRepository,
+        private readonly MarketplaceRawProcessorRegistryInterface $processorRegistry,
+        private readonly ResolveMarketplaceRawProcessingProfile $profileResolver,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    /**
+     * @return int количество обработанных записей
+     * @throws \DomainException если run/step не найдены, шаг не в профиле, или обработка провалилась
+     */
+    public function __invoke(RunMarketplaceRawProcessingStepCommand $cmd): int
+    {
+        // 1. Загрузить run
+        $run = $this->runRepository->findByIdAndCompany($cmd->processingRunId, $cmd->companyId);
+        if ($run === null) {
+            throw new \DomainException(sprintf(
+                'Processing run "%s" not found for company "%s".',
+                $cmd->processingRunId,
+                $cmd->companyId,
+            ));
+        }
+
+        // 2. Загрузить step run
+        $stepRun = $this->stepRunRepository->findByIdAndCompany($cmd->stepRunId, $cmd->companyId);
+        if ($stepRun === null) {
+            throw new \DomainException(sprintf(
+                'Step run "%s" not found for company "%s".',
+                $cmd->stepRunId,
+                $cmd->companyId,
+            ));
+        }
+
+        // 3. Проверить принадлежность step run к run
+        if ($stepRun->getProcessingRunId() !== $run->getId()) {
+            throw new \DomainException(sprintf(
+                'Step run "%s" does not belong to processing run "%s".',
+                $cmd->stepRunId,
+                $cmd->processingRunId,
+            ));
+        }
+
+        // 4. Идемпотентно пропустить terminal-шаги
+        if ($stepRun->getStatus()->isTerminal()) {
+            $this->logger->info('[RunStep] Step run already in terminal state, skipping', [
+                'step_run_id' => $cmd->stepRunId,
+                'step'        => $stepRun->getStep()->value,
+                'status'      => $stepRun->getStatus()->value,
+            ]);
+
+            return 0;
+        }
+
+        // 5. Загрузить raw document (с IDOR-проверкой)
+        $doc = $this->rawDocumentRepository->find($run->getRawDocumentId());
+        if ($doc === null || $doc->getCompany()->getId() !== $cmd->companyId) {
+            throw new \DomainException(sprintf(
+                'Raw document "%s" not found for company "%s".',
+                $run->getRawDocumentId(),
+                $cmd->companyId,
+            ));
+        }
+
+        // 6. Проверить, что шаг входит в processing profile
+        $profile = $this->profileResolver->resolve($doc->getMarketplace(), $doc->getDocumentType());
+        if (!$profile->requiresStep($stepRun->getStep())) {
+            throw new \DomainException(sprintf(
+                'Step "%s" is not part of the processing profile for document type "%s".',
+                $stepRun->getStep()->value,
+                $doc->getDocumentType(),
+            ));
+        }
+
+        // 7. Перевести в RUNNING, если ещё PENDING
+        if ($stepRun->getStatus() === PipelineStatus::PENDING) {
+            $stepRun->markRunning();
+            $this->entityManager->flush();
+        }
+
+        // 8. Найти processor по marketplace + step
+        $processor = $this->processorRegistry->get(
+            $doc->getMarketplace()->value,
+            $doc->getMarketplace(),
+            $stepRun->getStep()->value,
+        );
+
+        // 9. Выполнить шаг
+        try {
+            $processedCount = $processor->process($cmd->companyId, $run->getRawDocumentId());
+
+            $stepRun->markCompleted($processedCount, 0, 0);
+            $this->entityManager->flush();
+
+            $this->logger->info('[RunStep] Step completed', [
+                'step_run_id'    => $cmd->stepRunId,
+                'step'           => $stepRun->getStep()->value,
+                'processed'      => $processedCount,
+            ]);
+
+            return $processedCount;
+        } catch (\Throwable $e) {
+            $this->logger->error('[RunStep] Step failed', [
+                'step_run_id' => $cmd->stepRunId,
+                'step'        => $stepRun->getStep()->value,
+                'error'       => $e->getMessage(),
+            ]);
+
+            try {
+                $stepRun->markFailed($e->getMessage() ?: 'Unknown processing error');
+                $this->entityManager->flush();
+            } catch (\Throwable $flushError) {
+                $this->logger->error('[RunStep] Failed to persist FAILED status', [
+                    'step_run_id' => $cmd->stepRunId,
+                    'error'       => $flushError->getMessage(),
+                ]);
+            }
+
+            throw $e;
+        }
+    }
+}

--- a/site/src/Marketplace/Message/RunMarketplaceRawProcessingStepMessage.php
+++ b/site/src/Marketplace/Message/RunMarketplaceRawProcessingStepMessage.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Message;
+
+/**
+ * Сообщение для асинхронного выполнения одного шага daily processing run.
+ *
+ * Отправляется из StartMarketplaceRawProcessingHandler для каждого PENDING шага.
+ * Обрабатывается RunMarketplaceRawProcessingStepHandler в worker-контексте.
+ *
+ * Только scalar ID — worker-safe.
+ */
+final readonly class RunMarketplaceRawProcessingStepMessage
+{
+    public function __construct(
+        public string $companyId,        // scalar UUID — worker-safe
+        public string $processingRunId,  // scalar UUID — worker-safe
+        public string $stepRunId,        // scalar UUID — worker-safe
+    ) {}
+}

--- a/site/src/Marketplace/MessageHandler/RunMarketplaceRawProcessingStepHandler.php
+++ b/site/src/Marketplace/MessageHandler/RunMarketplaceRawProcessingStepHandler.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\MessageHandler;
+
+use App\Marketplace\Application\Command\RunMarketplaceRawProcessingStepCommand;
+use App\Marketplace\Application\RunMarketplaceRawProcessingStepAction;
+use App\Marketplace\Message\RunMarketplaceRawProcessingStepMessage;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Запускает выполнение одного шага daily processing run.
+ *
+ * Worker-safe: нет Request, Session, Security.
+ * companyId, processingRunId, stepRunId переданы через Message — не из сессии.
+ *
+ * Обработка ошибок:
+ *   - DomainException (бизнес-ошибка: шаг failed, инвалидное состояние) →
+ *     логируется, сообщение ackнуто без retry. Step помечен FAILED в БД.
+ *   - Прочие исключения (инфраструктура: DB down, etc.) →
+ *     пробрасываются, Messenger делает retry по retry_strategy.
+ */
+#[AsMessageHandler]
+final class RunMarketplaceRawProcessingStepHandler
+{
+    public function __construct(
+        private readonly RunMarketplaceRawProcessingStepAction $action,
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    public function __invoke(RunMarketplaceRawProcessingStepMessage $message): void
+    {
+        try {
+            ($this->action)(new RunMarketplaceRawProcessingStepCommand(
+                $message->companyId,
+                $message->processingRunId,
+                $message->stepRunId,
+            ));
+        } catch (\DomainException $e) {
+            // Бизнес-ошибка: шаг уже помечен FAILED в Action.
+            // Нет смысла делать retry — проблема в данных, не в инфраструктуре.
+            $this->logger->error('[RunStepHandler] Step execution failed, no retry', [
+                'step_run_id'       => $message->stepRunId,
+                'processing_run_id' => $message->processingRunId,
+                'company_id'        => $message->companyId,
+                'error'             => $e->getMessage(),
+            ]);
+            // Не перебрасываем — Messenger считает сообщение обработанным.
+        }
+        // Прочие исключения (Throwable) пробрасываются → retry по messenger.yaml retry_strategy.
+    }
+}

--- a/site/src/Marketplace/MessageHandler/StartMarketplaceRawProcessingHandler.php
+++ b/site/src/Marketplace/MessageHandler/StartMarketplaceRawProcessingHandler.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Marketplace\MessageHandler;
 
-use App\Marketplace\Application\Command\ProcessMarketplaceRawDocumentCommand;
 use App\Marketplace\Entity\MarketplaceRawProcessingStepRun;
 use App\Marketplace\Enum\PipelineStatus;
+use App\Marketplace\Message\RunMarketplaceRawProcessingStepMessage;
 use App\Marketplace\Message\StartMarketplaceRawProcessingMessage;
 use App\Marketplace\Repository\MarketplaceRawProcessingRunRepository;
 use App\Marketplace\Repository\MarketplaceRawProcessingStepRunRepository;
@@ -20,7 +20,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
  *
  * Для каждого step run в состоянии PENDING:
  *   1. Переводит в RUNNING.
- *   2. Dispatch ProcessMarketplaceRawDocumentCommand → async worker.
+ *   2. Dispatch RunMarketplaceRawProcessingStepMessage → async worker.
  *
  * Worker-safe: нет Request, Session, Security.
  * companyId передан через Message — не из сессии.
@@ -81,20 +81,21 @@ final class StartMarketplaceRawProcessingHandler
         // а не только в памяти текущего процесса.
         $this->entityManager->flush();
 
-        // Phase 2: dispatch команды обработки для каждого шага
+        // Phase 2: dispatch сообщение выполнения для каждого шага
         $dispatched = 0;
         foreach ($toDispatch as $stepRun) {
             try {
-                $this->bus->dispatch(new ProcessMarketplaceRawDocumentCommand(
+                $this->bus->dispatch(new RunMarketplaceRawProcessingStepMessage(
                     $companyId,
-                    $run->getRawDocumentId(),
-                    $stepRun->getStep()->value,
+                    $processingRunId,
+                    $stepRun->getId(),
                 ));
                 $dispatched++;
             } catch (\Throwable $e) {
-                $this->logger->error('[StartProcessing] Failed to dispatch step command', [
+                $this->logger->error('[StartProcessing] Failed to dispatch step message', [
                     'processing_run_id' => $processingRunId,
                     'step'              => $stepRun->getStep()->value,
+                    'step_run_id'       => $stepRun->getId(),
                     'error'             => $e->getMessage(),
                 ]);
 
@@ -102,7 +103,7 @@ final class StartMarketplaceRawProcessingHandler
             }
         }
 
-        $this->logger->info('[StartProcessing] Dispatched step commands', [
+        $this->logger->info('[StartProcessing] Dispatched step messages', [
             'processing_run_id' => $processingRunId,
             'dispatched'        => $dispatched,
             'steps'             => array_map(

--- a/site/src/Marketplace/MessageHandler/StartMarketplaceRawProcessingHandler.php
+++ b/site/src/Marketplace/MessageHandler/StartMarketplaceRawProcessingHandler.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace App\Marketplace\MessageHandler;
 
-use App\Marketplace\Entity\MarketplaceRawProcessingStepRun;
 use App\Marketplace\Enum\PipelineStatus;
 use App\Marketplace\Message\RunMarketplaceRawProcessingStepMessage;
 use App\Marketplace\Message\StartMarketplaceRawProcessingMessage;
 use App\Marketplace\Repository\MarketplaceRawProcessingRunRepository;
 use App\Marketplace\Repository\MarketplaceRawProcessingStepRunRepository;
-use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -18,15 +16,12 @@ use Symfony\Component\Messenger\MessageBusInterface;
 /**
  * Обрабатывает запуск daily processing run.
  *
- * Для каждого step run в состоянии PENDING:
- *   1. Переводит в RUNNING.
- *   2. Dispatch RunMarketplaceRawProcessingStepMessage → async worker.
+ * Для каждого PENDING step run диспатчит RunMarketplaceRawProcessingStepMessage.
+ * Переход PENDING → RUNNING происходит в RunMarketplaceRawProcessingStepAction (шаг 7),
+ * что делает handler идемпотентным при retry: не-PENDING шаги пропускаются,
+ * а незадиспатченные PENDING-шаги будут отправлены повторно.
  *
  * Worker-safe: нет Request, Session, Security.
- * companyId передан через Message — не из сессии.
- *
- * Идемпотентен: при retry пропускает step runs не в PENDING,
- * flush() предшествует dispatch() — worker видит актуальный статус в БД.
  */
 #[AsMessageHandler]
 final class StartMarketplaceRawProcessingHandler
@@ -34,7 +29,6 @@ final class StartMarketplaceRawProcessingHandler
     public function __construct(
         private readonly MarketplaceRawProcessingRunRepository $runRepository,
         private readonly MarketplaceRawProcessingStepRunRepository $stepRunRepository,
-        private readonly EntityManagerInterface $entityManager,
         private readonly MessageBusInterface $bus,
         private readonly LoggerInterface $logger,
     ) {}
@@ -66,24 +60,17 @@ final class StartMarketplaceRawProcessingHandler
             return;
         }
 
-        // Phase 1: пометить PENDING-шаги как RUNNING
-        $toDispatch = [];
+        // Dispatch сообщение для каждого PENDING-шага.
+        // Не помечаем RUNNING здесь — RunMarketplaceRawProcessingStepAction делает это
+        // атомарно перед вызовом processor (шаг 7). Это позволяет корректно повторить
+        // StartMarketplaceRawProcessingMessage при сбое dispatch: на retry handler снова
+        // найдёт незадиспатченные PENDING-шаги и отправит сообщения.
+        $dispatched = 0;
         foreach ($stepRuns as $stepRun) {
             if ($stepRun->getStatus() !== PipelineStatus::PENDING) {
                 continue;
             }
 
-            $stepRun->markRunning();
-            $toDispatch[] = $stepRun;
-        }
-
-        // Flush до dispatch — worker видит статус RUNNING в БД,
-        // а не только в памяти текущего процесса.
-        $this->entityManager->flush();
-
-        // Phase 2: dispatch сообщение выполнения для каждого шага
-        $dispatched = 0;
-        foreach ($toDispatch as $stepRun) {
             try {
                 $this->bus->dispatch(new RunMarketplaceRawProcessingStepMessage(
                     $companyId,
@@ -106,10 +93,6 @@ final class StartMarketplaceRawProcessingHandler
         $this->logger->info('[StartProcessing] Dispatched step messages', [
             'processing_run_id' => $processingRunId,
             'dispatched'        => $dispatched,
-            'steps'             => array_map(
-                static fn(MarketplaceRawProcessingStepRun $sr) => $sr->getStep()->value,
-                $toDispatch,
-            ),
         ]);
     }
 }


### PR DESCRIPTION
## Summary

- `RunMarketplaceRawProcessingStepCommand` — Application DTO: `companyId`, `processingRunId`, `stepRunId`
- `RunMarketplaceRawProcessingStepAction` — выполняет один шаг через существующий raw processor
- `RunMarketplaceRawProcessingStepMessage` — scalar-only Messenger message (worker-safe)
- `RunMarketplaceRawProcessingStepHandler` — worker-safe handler с разделением бизнес/инфра ошибок

Также обновлён `StartMarketplaceRawProcessingHandler`: теперь диспатчит `RunMarketplaceRawProcessingStepMessage` (со `stepRunId`) вместо `ProcessMarketplaceRawDocumentCommand` — step tracking complete end-to-end.

## Поток выполнения (полный pipeline)

```
StartMarketplaceRawProcessingAction
  → create Run + StepRuns (PENDING)
  → dispatch StartMarketplaceRawProcessingMessage [async]

StartMarketplaceRawProcessingHandler (worker)
  → mark StepRuns RUNNING, flush
  → dispatch RunMarketplaceRawProcessingStepMessage × 3 [async]

RunMarketplaceRawProcessingStepHandler (worker)
  → RunMarketplaceRawProcessingStepAction:
      load run + stepRun (IDOR-safe)
      validate ownership + profile
      get processor from registry (marketplace + step)
      processor->process(companyId, rawDocId)
      markCompleted / markFailed
```

## Поведение ошибок

| Тип исключения | Поведение |
|---|---|
| `DomainException` | Step помечен FAILED в DB, сообщение ackнуто (нет retry) |
| Прочие (`Throwable`) | Пробрасывается → Messenger делает retry по `retry_strategy` |

## Ограничения

- Существующие raw processors не изменены
- `ReprocessMarketplacePeriodAction` и ручной flow не изменены
- `ProcessOzonRealizationAction` не затронут

## Test plan

- [ ] `sales_report` → Action создаёт Run + 3 step runs, handler диспатчит 3 `RunMarketplaceRawProcessingStepMessage`
- [ ] `RunMarketplaceRawProcessingStepAction` с WB+SALES → находит `WbSalesRawProcessor`, вызывает `process()`
- [ ] Успешное выполнение → step status `COMPLETED`, `processedCount` заполнен
- [ ] Ошибка processor → step status `FAILED`, исключение пробрасывается
- [ ] `realization` в профиле → `DomainException` "not part of the processing profile"
- [ ] Чужой `companyId` → `DomainException` (IDOR-защита)
- [ ] Terminal step при retry → Action логирует и возвращает 0 (нет паники)

https://claude.ai/code/session_01CXxMtBDyMhgK7qsWqtx99f