### PR TITLE
feat(Marketplace): add FinalizeMarketplaceRawProcessingAction — run finalization

### DIFF
--- a/site/config/packages/messenger.yaml
+++ b/site/config/packages/messenger.yaml
@@ -32,6 +32,7 @@ framework:
             'App\Marketplace\Message\CloseMonthStageMessage': async    # ← НОВОЕ
             'App\Marketplace\Message\StartMarketplaceRawProcessingMessage': async
             'App\Marketplace\Message\RunMarketplaceRawProcessingStepMessage': async
+            'App\Marketplace\Message\FinalizeMarketplaceRawProcessingMessage': async
             # ProcessMarketplaceRawDocumentCommand dispatched async из StartMarketplaceRawProcessingHandler.
             # Ручной flow (ReprocessMarketplacePeriodAction) вызывает ProcessMarketplaceRawDocumentAction
             # напрямую, минуя bus — это изменение не влияет на ручной flow.

--- a/site/src/Marketplace/Application/Command/FinalizeMarketplaceRawProcessingCommand.php
+++ b/site/src/Marketplace/Application/Command/FinalizeMarketplaceRawProcessingCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\Command;
+
+/**
+ * Команда финализации daily processing run.
+ *
+ * Передаётся в FinalizeMarketplaceRawProcessingAction.
+ * Не является Messenger-сообщением — только Application-команда.
+ */
+final readonly class FinalizeMarketplaceRawProcessingCommand
+{
+    public function __construct(
+        public string $companyId,
+        public string $processingRunId,
+    ) {}
+}

--- a/site/src/Marketplace/Application/FinalizeMarketplaceRawProcessingAction.php
+++ b/site/src/Marketplace/Application/FinalizeMarketplaceRawProcessingAction.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application;
+
+use App\Marketplace\Application\Command\FinalizeMarketplaceRawProcessingCommand;
+use App\Marketplace\Entity\MarketplaceRawProcessingStepRun;
+use App\Marketplace\Enum\PipelineStatus;
+use App\Marketplace\Repository\MarketplaceRawProcessingRunRepository;
+use App\Marketplace\Repository\MarketplaceRawProcessingStepRunRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Финализирует daily processing run после завершения всех обязательных шагов.
+ *
+ * Логика:
+ *   - Run уже в terminal-статусе → return (идемпотентно).
+ *   - Есть незавершённые (не-terminal) шаги → return (ждём).
+ *   - Все шаги terminal и нет FAILED → run = COMPLETED + aggregated summary/details.
+ *   - Хотя бы один шаг FAILED → run = FAILED + lastErrorMessage + summary/details.
+ *
+ * Вызывается из FinalizeMarketplaceRawProcessingHandler после каждого
+ * терминального события шага. Идемпотентен: повторный вызов безопасен.
+ */
+final class FinalizeMarketplaceRawProcessingAction
+{
+    public function __construct(
+        private readonly MarketplaceRawProcessingRunRepository $runRepository,
+        private readonly MarketplaceRawProcessingStepRunRepository $stepRunRepository,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    public function __invoke(FinalizeMarketplaceRawProcessingCommand $cmd): void
+    {
+        // 1. Загрузить run с IDOR-проверкой
+        $run = $this->runRepository->findByIdAndCompany($cmd->processingRunId, $cmd->companyId);
+        if ($run === null) {
+            throw new \DomainException(sprintf(
+                'Processing run "%s" not found for company "%s".',
+                $cmd->processingRunId,
+                $cmd->companyId,
+            ));
+        }
+
+        // 2. Идемпотентность: run уже в terminal-статусе — ничего не делаем
+        if ($run->getStatus()->isTerminal()) {
+            $this->logger->info('[Finalize] Run already in terminal state, skipping', [
+                'processing_run_id' => $cmd->processingRunId,
+                'status'            => $run->getStatus()->value,
+            ]);
+
+            return;
+        }
+
+        // 3. Загрузить все шаги run
+        $stepRuns = $this->stepRunRepository->findByRunId($cmd->companyId, $cmd->processingRunId);
+
+        if (empty($stepRuns)) {
+            // Шагов нет — run тривиально завершён (warning, но не ошибка)
+            $this->logger->warning('[Finalize] No step runs found, completing run immediately', [
+                'processing_run_id' => $cmd->processingRunId,
+            ]);
+
+            $run->markCompleted(['steps_total' => 0, 'steps_completed' => 0, 'steps_failed' => 0]);
+            $this->entityManager->flush();
+
+            return;
+        }
+
+        // 4. Проверить: все ли шаги в terminal-статусе?
+        foreach ($stepRuns as $stepRun) {
+            if (!$stepRun->getStatus()->isTerminal()) {
+                $this->logger->info('[Finalize] Step still running, deferring finalization', [
+                    'processing_run_id' => $cmd->processingRunId,
+                    'step'              => $stepRun->getStep()->value,
+                    'status'            => $stepRun->getStatus()->value,
+                ]);
+
+                return;
+            }
+        }
+
+        // 5. Все шаги terminal — агрегировать summary и details
+        $failedStepRuns = array_values(array_filter(
+            $stepRuns,
+            static fn(MarketplaceRawProcessingStepRun $sr) => $sr->getStatus() === PipelineStatus::FAILED,
+        ));
+
+        $summary = $this->buildSummary($stepRuns, $failedStepRuns);
+        $details = $this->buildDetails($stepRuns);
+
+        // 6. Финализировать run
+        if (count($failedStepRuns) > 0) {
+            $errorMessage = $this->buildErrorMessage($failedStepRuns);
+
+            $run->markFailed($errorMessage, $summary, $details);
+
+            $this->logger->error('[Finalize] Run finalized as FAILED', [
+                'processing_run_id' => $cmd->processingRunId,
+                'failed_steps'      => array_map(
+                    static fn(MarketplaceRawProcessingStepRun $sr) => $sr->getStep()->value,
+                    $failedStepRuns,
+                ),
+                'error'             => $errorMessage,
+            ]);
+        } else {
+            $run->markCompleted($summary, $details);
+
+            $this->logger->info('[Finalize] Run finalized as COMPLETED', [
+                'processing_run_id' => $cmd->processingRunId,
+                'total_processed'   => $summary['total_processed'],
+            ]);
+        }
+
+        $this->entityManager->flush();
+    }
+
+    /**
+     * @param MarketplaceRawProcessingStepRun[] $stepRuns
+     * @param MarketplaceRawProcessingStepRun[] $failedStepRuns
+     * @return array<string, int>
+     */
+    private function buildSummary(array $stepRuns, array $failedStepRuns): array
+    {
+        return [
+            'total_processed' => (int) array_sum(array_map(
+                static fn(MarketplaceRawProcessingStepRun $sr) => $sr->getProcessedCount(),
+                $stepRuns,
+            )),
+            'total_failed' => (int) array_sum(array_map(
+                static fn(MarketplaceRawProcessingStepRun $sr) => $sr->getFailedCount(),
+                $stepRuns,
+            )),
+            'total_skipped' => (int) array_sum(array_map(
+                static fn(MarketplaceRawProcessingStepRun $sr) => $sr->getSkippedCount(),
+                $stepRuns,
+            )),
+            'steps_total'     => count($stepRuns),
+            'steps_completed' => count($stepRuns) - count($failedStepRuns),
+            'steps_failed'    => count($failedStepRuns),
+        ];
+    }
+
+    /**
+     * @param MarketplaceRawProcessingStepRun[] $stepRuns
+     * @return array{steps: array<int, array<string, mixed>>}
+     */
+    private function buildDetails(array $stepRuns): array
+    {
+        $steps = array_map(static function (MarketplaceRawProcessingStepRun $sr): array {
+            $step = [
+                'step'      => $sr->getStep()->value,
+                'status'    => $sr->getStatus()->value,
+                'processed' => $sr->getProcessedCount(),
+                'failed'    => $sr->getFailedCount(),
+                'skipped'   => $sr->getSkippedCount(),
+            ];
+
+            if ($sr->getErrorMessage() !== null) {
+                $step['error'] = $sr->getErrorMessage();
+            }
+
+            return $step;
+        }, $stepRuns);
+
+        return ['steps' => $steps];
+    }
+
+    /**
+     * @param MarketplaceRawProcessingStepRun[] $failedStepRuns
+     */
+    private function buildErrorMessage(array $failedStepRuns): string
+    {
+        $parts = array_map(
+            static fn(MarketplaceRawProcessingStepRun $sr) => sprintf(
+                '[%s] %s',
+                $sr->getStep()->value,
+                $sr->getErrorMessage() ?? 'Unknown error',
+            ),
+            $failedStepRuns,
+        );
+
+        return implode('; ', $parts);
+    }
+}

--- a/site/src/Marketplace/Application/FinalizeMarketplaceRawProcessingAction.php
+++ b/site/src/Marketplace/Application/FinalizeMarketplaceRawProcessingAction.php
@@ -58,18 +58,6 @@ final class FinalizeMarketplaceRawProcessingAction
         // 3. Загрузить все шаги run
         $stepRuns = $this->stepRunRepository->findByRunId($cmd->companyId, $cmd->processingRunId);
 
-        if (empty($stepRuns)) {
-            // Шагов нет — run тривиально завершён (warning, но не ошибка)
-            $this->logger->warning('[Finalize] No step runs found, completing run immediately', [
-                'processing_run_id' => $cmd->processingRunId,
-            ]);
-
-            $run->markCompleted(['steps_total' => 0, 'steps_completed' => 0, 'steps_failed' => 0]);
-            $this->entityManager->flush();
-
-            return;
-        }
-
         // 4. Проверить: все ли шаги в terminal-статусе?
         foreach ($stepRuns as $stepRun) {
             if (!$stepRun->getStatus()->isTerminal()) {
@@ -125,19 +113,20 @@ final class FinalizeMarketplaceRawProcessingAction
      */
     private function buildSummary(array $stepRuns, array $failedStepRuns): array
     {
+        $totals = array_reduce(
+            $stepRuns,
+            static function (array $carry, MarketplaceRawProcessingStepRun $sr): array {
+                $carry['total_processed'] += $sr->getProcessedCount();
+                $carry['total_failed']    += $sr->getFailedCount();
+                $carry['total_skipped']   += $sr->getSkippedCount();
+
+                return $carry;
+            },
+            ['total_processed' => 0, 'total_failed' => 0, 'total_skipped' => 0],
+        );
+
         return [
-            'total_processed' => (int) array_sum(array_map(
-                static fn(MarketplaceRawProcessingStepRun $sr) => $sr->getProcessedCount(),
-                $stepRuns,
-            )),
-            'total_failed' => (int) array_sum(array_map(
-                static fn(MarketplaceRawProcessingStepRun $sr) => $sr->getFailedCount(),
-                $stepRuns,
-            )),
-            'total_skipped' => (int) array_sum(array_map(
-                static fn(MarketplaceRawProcessingStepRun $sr) => $sr->getSkippedCount(),
-                $stepRuns,
-            )),
+            ...$totals,
             'steps_total'     => count($stepRuns),
             'steps_completed' => count($stepRuns) - count($failedStepRuns),
             'steps_failed'    => count($failedStepRuns),

--- a/site/src/Marketplace/Message/FinalizeMarketplaceRawProcessingMessage.php
+++ b/site/src/Marketplace/Message/FinalizeMarketplaceRawProcessingMessage.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Message;
+
+/**
+ * Сообщение для асинхронной финализации daily processing run.
+ *
+ * Отправляется из RunMarketplaceRawProcessingStepHandler после каждого
+ * терминального завершения шага (COMPLETED или FAILED без retry).
+ *
+ * Только scalar ID — worker-safe.
+ */
+final readonly class FinalizeMarketplaceRawProcessingMessage
+{
+    public function __construct(
+        public string $companyId,       // scalar UUID — worker-safe
+        public string $processingRunId, // scalar UUID — worker-safe
+    ) {}
+}

--- a/site/src/Marketplace/MessageHandler/FinalizeMarketplaceRawProcessingHandler.php
+++ b/site/src/Marketplace/MessageHandler/FinalizeMarketplaceRawProcessingHandler.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\MessageHandler;
+
+use App\Marketplace\Application\Command\FinalizeMarketplaceRawProcessingCommand;
+use App\Marketplace\Application\FinalizeMarketplaceRawProcessingAction;
+use App\Marketplace\Message\FinalizeMarketplaceRawProcessingMessage;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Финализирует daily processing run после завершения всех обязательных шагов.
+ *
+ * Worker-safe: нет Request, Session, Security.
+ * companyId, processingRunId переданы через Message — не из сессии.
+ *
+ * Обработка ошибок:
+ *   - DomainException (run не найден, уже terminal) →
+ *     логируется, сообщение ackнуто без retry.
+ *   - Прочие исключения (инфраструктура: DB down) →
+ *     пробрасываются, Messenger делает retry по retry_strategy.
+ */
+#[AsMessageHandler]
+final class FinalizeMarketplaceRawProcessingHandler
+{
+    public function __construct(
+        private readonly FinalizeMarketplaceRawProcessingAction $action,
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    public function __invoke(FinalizeMarketplaceRawProcessingMessage $message): void
+    {
+        try {
+            ($this->action)(new FinalizeMarketplaceRawProcessingCommand(
+                $message->companyId,
+                $message->processingRunId,
+            ));
+        } catch (\DomainException $e) {
+            // Бизнес-ошибка (run не найден, уже terminal) — нет смысла делать retry.
+            $this->logger->error('[FinalizeHandler] Finalization failed, no retry', [
+                'processing_run_id' => $message->processingRunId,
+                'company_id'        => $message->companyId,
+                'error'             => $e->getMessage(),
+            ]);
+            // Не перебрасываем — Messenger считает сообщение обработанным.
+        }
+        // Прочие исключения (Throwable) пробрасываются → retry по messenger.yaml retry_strategy.
+    }
+}

--- a/site/src/Marketplace/MessageHandler/RunMarketplaceRawProcessingStepHandler.php
+++ b/site/src/Marketplace/MessageHandler/RunMarketplaceRawProcessingStepHandler.php
@@ -6,49 +6,65 @@ namespace App\Marketplace\MessageHandler;
 
 use App\Marketplace\Application\Command\RunMarketplaceRawProcessingStepCommand;
 use App\Marketplace\Application\RunMarketplaceRawProcessingStepAction;
+use App\Marketplace\Message\FinalizeMarketplaceRawProcessingMessage;
 use App\Marketplace\Message\RunMarketplaceRawProcessingStepMessage;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
  * Запускает выполнение одного шага daily processing run.
+ * После терминального завершения шага (COMPLETED или FAILED без retry)
+ * диспатчит FinalizeMarketplaceRawProcessingMessage для проверки финализации run.
  *
  * Worker-safe: нет Request, Session, Security.
- * companyId, processingRunId, stepRunId переданы через Message — не из сессии.
  *
  * Обработка ошибок:
- *   - DomainException (бизнес-ошибка: шаг failed, инвалидное состояние) →
- *     логируется, сообщение ackнуто без retry. Step помечен FAILED в БД.
- *   - Прочие исключения (инфраструктура: DB down, etc.) →
- *     пробрасываются, Messenger делает retry по retry_strategy.
+ *   - DomainException (бизнес-ошибка: шаг FAILED, no retry) →
+ *     логируется, dispatch Finalize, сообщение ackнуто.
+ *   - Прочие исключения (инфраструктура: DB down) →
+ *     пробрасываются (Finalize НЕ диспатчится — шаг ещё RUNNING, будет retry).
  */
 #[AsMessageHandler]
 final class RunMarketplaceRawProcessingStepHandler
 {
     public function __construct(
         private readonly RunMarketplaceRawProcessingStepAction $action,
+        private readonly MessageBusInterface $bus,
         private readonly LoggerInterface $logger,
     ) {}
 
     public function __invoke(RunMarketplaceRawProcessingStepMessage $message): void
     {
+        $shouldFinalize = false;
+
         try {
             ($this->action)(new RunMarketplaceRawProcessingStepCommand(
                 $message->companyId,
                 $message->processingRunId,
                 $message->stepRunId,
             ));
+            $shouldFinalize = true; // шаг COMPLETED — инициировать финализацию
         } catch (\DomainException $e) {
             // Бизнес-ошибка: шаг уже помечен FAILED в Action.
-            // Нет смысла делать retry — проблема в данных, не в инфраструктуре.
+            // Нет смысла делать retry — инициируем финализацию run.
             $this->logger->error('[RunStepHandler] Step execution failed, no retry', [
                 'step_run_id'       => $message->stepRunId,
                 'processing_run_id' => $message->processingRunId,
                 'company_id'        => $message->companyId,
                 'error'             => $e->getMessage(),
             ]);
+            $shouldFinalize = true; // шаг FAILED терминально — инициировать финализацию
             // Не перебрасываем — Messenger считает сообщение обработанным.
         }
-        // Прочие исключения (Throwable) пробрасываются → retry по messenger.yaml retry_strategy.
+        // Прочие исключения (Throwable) пробрасываются → retry по messenger.yaml.
+        // Finalize НЕ диспатчится: шаг остаётся в RUNNING, повторная попытка ещё впереди.
+
+        if ($shouldFinalize) {
+            $this->bus->dispatch(new FinalizeMarketplaceRawProcessingMessage(
+                $message->companyId,
+                $message->processingRunId,
+            ));
+        }
     }
 }


### PR DESCRIPTION
## Summary

- `FinalizeMarketplaceRawProcessingCommand` — Application DTO: `companyId`, `processingRunId`
- `FinalizeMarketplaceRawProcessingAction` — финализирует run после завершения всех шагов
- `FinalizeMarketplaceRawProcessingMessage` — scalar-only Messenger message (worker-safe)
- `FinalizeMarketplaceRawProcessingHandler` — worker-safe handler с разделением бизнес/инфра ошибок
- `RunMarketplaceRawProcessingStepHandler` — обновлён: dispatch Finalize после terminal-завершения шага

## Логика финализации

```
FinalizeMarketplaceRawProcessingAction:
  run уже terminal → return (идемпотентно)
  есть не-terminal шаги → return (ждём остальных)
  все шаги terminal, нет FAILED → run.markCompleted(summary, details)
  хотя бы один шаг FAILED → run.markFailed(errorMessage, summary, details)
```

## Поток (полный pipeline)

```
StartMarketplaceRawProcessingAction
  → create Run + StepRuns (PENDING)
  → dispatch StartMarketplaceRawProcessingMessage [async]

StartMarketplaceRawProcessingHandler (worker)
  → dispatch RunMarketplaceRawProcessingStepMessage × N [async]

RunMarketplaceRawProcessingStepHandler (worker)
  → RunMarketplaceRawProcessingStepAction → COMPLETED/FAILED
  → dispatch FinalizeMarketplaceRawProcessingMessage [async]

FinalizeMarketplaceRawProcessingHandler (worker)
  → FinalizeMarketplaceRawProcessingAction:
      все шаги terminal → run.markCompleted / run.markFailed
```

## Поведение ошибок

| Тип | Поведение |
|---|---|
| `DomainException` в Finalize | Run not found / уже terminal — ack, no retry |
| `Throwable` в Finalize | Infra error — propagate, Messenger retry |
| Dispatch Finalize только при terminal шаге | Infra retry шага → Finalize не диспатчится |

## summary/details на уровне run

**summary:**
```json
{"total_processed": 450, "total_failed": 0, "total_skipped": 0, "steps_total": 3, "steps_completed": 3, "steps_failed": 0}
```

**details:**
```json
{"steps": [{"step": "sales", "status": "completed", "processed": 200, "failed": 0, "skipped": 0}, ...]}
```

## Ограничения

- `MarketplaceJobLog` не используется как источник истины о статусе run
- Monthly/realization flow не затронут
- Существующие processors не изменены

## Test plan

- [ ] Все 3 шага COMPLETED → run.status = COMPLETED, summary агрегирован
- [ ] Один шаг FAILED → run.status = FAILED, lastErrorMessage содержит `[step] error`
- [ ] Несколько шагов FAILED → lastErrorMessage = `[sales] err1; [costs] err2`
- [ ] Finalize при незавершённом шаге → run остаётся RUNNING
- [ ] Повторный Finalize при уже COMPLETED run → return без ошибки (идемпотентность)
- [ ] Run не найден → DomainException, handler ackает без retry

https://claude.ai/code/session_01CXxMtBDyMhgK7qsWqtx99f