### PR TITLE
feat(Marketplace): auto-start daily pipeline after successful raw import

### DIFF
--- a/site/src/Marketplace/Application/Service/MarketplacePipelineAutoStarter.php
+++ b/site/src/Marketplace/Application/Service/MarketplacePipelineAutoStarter.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\Service;
+
+use App\Marketplace\Application\Command\StartMarketplaceRawProcessingCommand;
+use App\Marketplace\Application\StartMarketplaceRawProcessingAction;
+use App\Marketplace\Enum\PipelineTrigger;
+use App\Marketplace\Repository\MarketplaceRawProcessingRunRepository;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Автозапуск daily pipeline после успешного raw import.
+ *
+ * Используется из SyncWbReportHandler, SyncOzonReportHandler, SyncConnectionAction.
+ * Изолирует логику дедупликации и best-effort обработки ошибок.
+ *
+ * Дедупликация: если для raw document уже существует активный (не-terminal) run — пропустить.
+ * Best-effort: любой Throwable логируется, вызывающий код не прерывается.
+ */
+final readonly class MarketplacePipelineAutoStarter
+{
+    public function __construct(
+        private StartMarketplaceRawProcessingAction $startProcessingAction,
+        private MarketplaceRawProcessingRunRepository $runRepository,
+        private LoggerInterface $logger,
+    ) {}
+
+    /**
+     * Запускает daily pipeline для сохранённого raw document.
+     * Не бросает исключений — ошибки логируются.
+     */
+    public function tryStart(string $companyId, string $rawDocId): void
+    {
+        $existingRun = $this->runRepository->findLatestByRawDocument($companyId, $rawDocId);
+        if ($existingRun !== null && !$existingRun->getStatus()->isTerminal()) {
+            $this->logger->info('[AutoStart] Active run already exists, skipping', [
+                'raw_doc_id' => $rawDocId,
+                'run_id'     => $existingRun->getId(),
+                'status'     => $existingRun->getStatus()->value,
+            ]);
+
+            return;
+        }
+
+        try {
+            ($this->startProcessingAction)(new StartMarketplaceRawProcessingCommand(
+                $companyId,
+                $rawDocId,
+                PipelineTrigger::AUTO,
+            ));
+
+            $this->logger->info('[AutoStart] Daily pipeline started', [
+                'company_id' => $companyId,
+                'raw_doc_id' => $rawDocId,
+            ]);
+        } catch (\Throwable $e) {
+            $this->logger->error('[AutoStart] Failed to start daily pipeline', [
+                'company_id' => $companyId,
+                'raw_doc_id' => $rawDocId,
+                'error'      => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/site/src/Marketplace/Application/SyncConnectionAction.php
+++ b/site/src/Marketplace/Application/SyncConnectionAction.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace App\Marketplace\Application;
 
+use App\Marketplace\Application\Command\StartMarketplaceRawProcessingCommand;
 use App\Marketplace\Application\Command\SyncConnectionCommand;
 use App\Marketplace\Entity\MarketplaceRawDocument;
+use App\Marketplace\Enum\PipelineTrigger;
 use App\Marketplace\Repository\MarketplaceConnectionRepository;
+use App\Marketplace\Repository\MarketplaceRawProcessingRunRepository;
 use App\Marketplace\Service\Integration\MarketplaceAdapterRegistry;
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
 
 /**
@@ -26,6 +30,9 @@ final class SyncConnectionAction
         private readonly MarketplaceConnectionRepository $connectionRepository,
         private readonly MarketplaceAdapterRegistry $adapterRegistry,
         private readonly EntityManagerInterface $em,
+        private readonly StartMarketplaceRawProcessingAction $startProcessingAction,
+        private readonly MarketplaceRawProcessingRunRepository $runRepository,
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -62,12 +69,53 @@ final class SyncConnectionAction
             $connection->markSyncSuccess();
             $this->em->flush();
 
+            // Автозапуск daily pipeline (best-effort — не прерывает import flow)
+            $this->tryAutoStartPipeline($command->companyId, $rawDoc->getId());
+
             return $recordsCount;
         } catch (\Exception $e) {
             $connection->markSyncFailed($e->getMessage());
             $this->em->flush();
 
             throw $e;
+        }
+    }
+
+    /**
+     * Запускает daily pipeline для сохранённого raw document.
+     * Best-effort: ошибки логируются и не прерывают import flow.
+     * Дедупликация: если для документа уже есть активный (не-terminal) run — пропустить.
+     */
+    private function tryAutoStartPipeline(string $companyId, string $rawDocId): void
+    {
+        $existingRun = $this->runRepository->findLatestByRawDocument($companyId, $rawDocId);
+        if ($existingRun !== null && !$existingRun->getStatus()->isTerminal()) {
+            $this->logger->info('[AutoStart] Active run already exists, skipping', [
+                'raw_doc_id' => $rawDocId,
+                'run_id'     => $existingRun->getId(),
+                'status'     => $existingRun->getStatus()->value,
+            ]);
+
+            return;
+        }
+
+        try {
+            ($this->startProcessingAction)(new StartMarketplaceRawProcessingCommand(
+                $companyId,
+                $rawDocId,
+                PipelineTrigger::AUTO,
+            ));
+
+            $this->logger->info('[AutoStart] Daily pipeline started', [
+                'company_id' => $companyId,
+                'raw_doc_id' => $rawDocId,
+            ]);
+        } catch (\Throwable $e) {
+            $this->logger->error('[AutoStart] Failed to start daily pipeline', [
+                'company_id' => $companyId,
+                'raw_doc_id' => $rawDocId,
+                'error'      => $e->getMessage(),
+            ]);
         }
     }
 }

--- a/site/src/Marketplace/Application/SyncConnectionAction.php
+++ b/site/src/Marketplace/Application/SyncConnectionAction.php
@@ -4,15 +4,12 @@ declare(strict_types=1);
 
 namespace App\Marketplace\Application;
 
-use App\Marketplace\Application\Command\StartMarketplaceRawProcessingCommand;
 use App\Marketplace\Application\Command\SyncConnectionCommand;
+use App\Marketplace\Application\Service\MarketplacePipelineAutoStarter;
 use App\Marketplace\Entity\MarketplaceRawDocument;
-use App\Marketplace\Enum\PipelineTrigger;
 use App\Marketplace\Repository\MarketplaceConnectionRepository;
-use App\Marketplace\Repository\MarketplaceRawProcessingRunRepository;
 use App\Marketplace\Service\Integration\MarketplaceAdapterRegistry;
 use Doctrine\ORM\EntityManagerInterface;
-use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
 
 /**
@@ -30,9 +27,7 @@ final class SyncConnectionAction
         private readonly MarketplaceConnectionRepository $connectionRepository,
         private readonly MarketplaceAdapterRegistry $adapterRegistry,
         private readonly EntityManagerInterface $em,
-        private readonly StartMarketplaceRawProcessingAction $startProcessingAction,
-        private readonly MarketplaceRawProcessingRunRepository $runRepository,
-        private readonly LoggerInterface $logger,
+        private readonly MarketplacePipelineAutoStarter $pipelineAutoStarter,
     ) {
     }
 
@@ -70,7 +65,7 @@ final class SyncConnectionAction
             $this->em->flush();
 
             // Автозапуск daily pipeline (best-effort — не прерывает import flow)
-            $this->tryAutoStartPipeline($command->companyId, $rawDoc->getId());
+            $this->pipelineAutoStarter->tryStart($command->companyId, $rawDoc->getId());
 
             return $recordsCount;
         } catch (\Exception $e) {
@@ -78,44 +73,6 @@ final class SyncConnectionAction
             $this->em->flush();
 
             throw $e;
-        }
-    }
-
-    /**
-     * Запускает daily pipeline для сохранённого raw document.
-     * Best-effort: ошибки логируются и не прерывают import flow.
-     * Дедупликация: если для документа уже есть активный (не-terminal) run — пропустить.
-     */
-    private function tryAutoStartPipeline(string $companyId, string $rawDocId): void
-    {
-        $existingRun = $this->runRepository->findLatestByRawDocument($companyId, $rawDocId);
-        if ($existingRun !== null && !$existingRun->getStatus()->isTerminal()) {
-            $this->logger->info('[AutoStart] Active run already exists, skipping', [
-                'raw_doc_id' => $rawDocId,
-                'run_id'     => $existingRun->getId(),
-                'status'     => $existingRun->getStatus()->value,
-            ]);
-
-            return;
-        }
-
-        try {
-            ($this->startProcessingAction)(new StartMarketplaceRawProcessingCommand(
-                $companyId,
-                $rawDocId,
-                PipelineTrigger::AUTO,
-            ));
-
-            $this->logger->info('[AutoStart] Daily pipeline started', [
-                'company_id' => $companyId,
-                'raw_doc_id' => $rawDocId,
-            ]);
-        } catch (\Throwable $e) {
-            $this->logger->error('[AutoStart] Failed to start daily pipeline', [
-                'company_id' => $companyId,
-                'raw_doc_id' => $rawDocId,
-                'error'      => $e->getMessage(),
-            ]);
         }
     }
 }

--- a/site/src/Marketplace/MessageHandler/SyncOzonReportHandler.php
+++ b/site/src/Marketplace/MessageHandler/SyncOzonReportHandler.php
@@ -5,14 +5,11 @@ declare(strict_types=1);
 namespace App\Marketplace\MessageHandler;
 
 use App\Company\Entity\Company;
-use App\Marketplace\Application\Command\StartMarketplaceRawProcessingCommand;
-use App\Marketplace\Application\StartMarketplaceRawProcessingAction;
+use App\Marketplace\Application\Service\MarketplacePipelineAutoStarter;
 use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Entity\MarketplaceRawDocument;
 use App\Marketplace\Enum\MarketplaceType;
-use App\Marketplace\Enum\PipelineTrigger;
 use App\Marketplace\Message\SyncOzonReportMessage;
-use App\Marketplace\Repository\MarketplaceRawProcessingRunRepository;
 use App\Marketplace\Service\Integration\MarketplaceAdapterRegistry;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -35,8 +32,7 @@ final class SyncOzonReportHandler
         private readonly MarketplaceAdapterRegistry $adapterRegistry,
         private readonly LockFactory $lockFactory,
         private readonly LoggerInterface $logger,
-        private readonly StartMarketplaceRawProcessingAction $startProcessingAction,
-        private readonly MarketplaceRawProcessingRunRepository $runRepository,
+        private readonly MarketplacePipelineAutoStarter $pipelineAutoStarter,
     ) {
     }
 
@@ -140,7 +136,7 @@ final class SyncOzonReportHandler
             $this->em->flush();
 
             // Автозапуск daily pipeline (best-effort — не прерывает import flow)
-            $this->tryAutoStartPipeline($companyId, $rawDoc->getId());
+            $this->pipelineAutoStarter->tryStart($companyId, $rawDoc->getId());
         } catch (\Throwable $e) {
             $this->logger->error('Ozon daily sync failed', [
                 'company_id'    => $companyId,
@@ -159,44 +155,6 @@ final class SyncOzonReportHandler
                     'error' => $inner->getMessage(),
                 ]);
             }
-        }
-    }
-
-    /**
-     * Запускает daily pipeline для сохранённого raw document.
-     * Best-effort: ошибки логируются и не прерывают import flow.
-     * Дедупликация: если для документа уже есть активный (не-terminal) run — пропустить.
-     */
-    private function tryAutoStartPipeline(string $companyId, string $rawDocId): void
-    {
-        $existingRun = $this->runRepository->findLatestByRawDocument($companyId, $rawDocId);
-        if ($existingRun !== null && !$existingRun->getStatus()->isTerminal()) {
-            $this->logger->info('[AutoStart] Active run already exists, skipping', [
-                'raw_doc_id' => $rawDocId,
-                'run_id'     => $existingRun->getId(),
-                'status'     => $existingRun->getStatus()->value,
-            ]);
-
-            return;
-        }
-
-        try {
-            ($this->startProcessingAction)(new StartMarketplaceRawProcessingCommand(
-                $companyId,
-                $rawDocId,
-                PipelineTrigger::AUTO,
-            ));
-
-            $this->logger->info('[AutoStart] Daily pipeline started', [
-                'company_id' => $companyId,
-                'raw_doc_id' => $rawDocId,
-            ]);
-        } catch (\Throwable $e) {
-            $this->logger->error('[AutoStart] Failed to start daily pipeline', [
-                'company_id' => $companyId,
-                'raw_doc_id' => $rawDocId,
-                'error'      => $e->getMessage(),
-            ]);
         }
     }
 }

--- a/site/src/Marketplace/MessageHandler/SyncOzonReportHandler.php
+++ b/site/src/Marketplace/MessageHandler/SyncOzonReportHandler.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace App\Marketplace\MessageHandler;
 
 use App\Company\Entity\Company;
+use App\Marketplace\Application\Command\StartMarketplaceRawProcessingCommand;
+use App\Marketplace\Application\StartMarketplaceRawProcessingAction;
 use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Entity\MarketplaceRawDocument;
 use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Enum\PipelineTrigger;
 use App\Marketplace\Message\SyncOzonReportMessage;
+use App\Marketplace\Repository\MarketplaceRawProcessingRunRepository;
 use App\Marketplace\Service\Integration\MarketplaceAdapterRegistry;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -31,6 +35,8 @@ final class SyncOzonReportHandler
         private readonly MarketplaceAdapterRegistry $adapterRegistry,
         private readonly LockFactory $lockFactory,
         private readonly LoggerInterface $logger,
+        private readonly StartMarketplaceRawProcessingAction $startProcessingAction,
+        private readonly MarketplaceRawProcessingRunRepository $runRepository,
     ) {
     }
 
@@ -132,6 +138,9 @@ final class SyncOzonReportHandler
             $connection = $this->em->find(MarketplaceConnection::class, $connectionId);
             $connection->markSyncSuccess();
             $this->em->flush();
+
+            // Автозапуск daily pipeline (best-effort — не прерывает import flow)
+            $this->tryAutoStartPipeline($companyId, $rawDoc->getId());
         } catch (\Throwable $e) {
             $this->logger->error('Ozon daily sync failed', [
                 'company_id'    => $companyId,
@@ -150,6 +159,44 @@ final class SyncOzonReportHandler
                     'error' => $inner->getMessage(),
                 ]);
             }
+        }
+    }
+
+    /**
+     * Запускает daily pipeline для сохранённого raw document.
+     * Best-effort: ошибки логируются и не прерывают import flow.
+     * Дедупликация: если для документа уже есть активный (не-terminal) run — пропустить.
+     */
+    private function tryAutoStartPipeline(string $companyId, string $rawDocId): void
+    {
+        $existingRun = $this->runRepository->findLatestByRawDocument($companyId, $rawDocId);
+        if ($existingRun !== null && !$existingRun->getStatus()->isTerminal()) {
+            $this->logger->info('[AutoStart] Active run already exists, skipping', [
+                'raw_doc_id' => $rawDocId,
+                'run_id'     => $existingRun->getId(),
+                'status'     => $existingRun->getStatus()->value,
+            ]);
+
+            return;
+        }
+
+        try {
+            ($this->startProcessingAction)(new StartMarketplaceRawProcessingCommand(
+                $companyId,
+                $rawDocId,
+                PipelineTrigger::AUTO,
+            ));
+
+            $this->logger->info('[AutoStart] Daily pipeline started', [
+                'company_id' => $companyId,
+                'raw_doc_id' => $rawDocId,
+            ]);
+        } catch (\Throwable $e) {
+            $this->logger->error('[AutoStart] Failed to start daily pipeline', [
+                'company_id' => $companyId,
+                'raw_doc_id' => $rawDocId,
+                'error'      => $e->getMessage(),
+            ]);
         }
     }
 }

--- a/site/src/Marketplace/MessageHandler/SyncWbReportHandler.php
+++ b/site/src/Marketplace/MessageHandler/SyncWbReportHandler.php
@@ -5,14 +5,11 @@ declare(strict_types=1);
 namespace App\Marketplace\MessageHandler;
 
 use App\Company\Entity\Company;
-use App\Marketplace\Application\Command\StartMarketplaceRawProcessingCommand;
-use App\Marketplace\Application\StartMarketplaceRawProcessingAction;
+use App\Marketplace\Application\Service\MarketplacePipelineAutoStarter;
 use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Entity\MarketplaceRawDocument;
 use App\Marketplace\Enum\MarketplaceType;
-use App\Marketplace\Enum\PipelineTrigger;
 use App\Marketplace\Message\SyncWbReportMessage;
-use App\Marketplace\Repository\MarketplaceRawProcessingRunRepository;
 use App\Marketplace\Service\Integration\MarketplaceAdapterRegistry;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -35,8 +32,7 @@ final class SyncWbReportHandler
         private readonly MarketplaceAdapterRegistry $adapterRegistry,
         private readonly LockFactory $lockFactory,
         private readonly LoggerInterface $logger,
-        private readonly StartMarketplaceRawProcessingAction $startProcessingAction,
-        private readonly MarketplaceRawProcessingRunRepository $runRepository,
+        private readonly MarketplacePipelineAutoStarter $pipelineAutoStarter,
     ) {
     }
 
@@ -136,7 +132,7 @@ final class SyncWbReportHandler
             $this->em->flush();
 
             // Автозапуск daily pipeline (best-effort — не прерывает import flow)
-            $this->tryAutoStartPipeline($companyId, $rawDoc->getId());
+            $this->pipelineAutoStarter->tryStart($companyId, $rawDoc->getId());
         } catch (\Throwable $e) {
             $this->logger->error('WB daily sync failed', [
                 'company_id'    => $companyId,
@@ -155,44 +151,6 @@ final class SyncWbReportHandler
                     'error' => $inner->getMessage(),
                 ]);
             }
-        }
-    }
-
-    /**
-     * Запускает daily pipeline для сохранённого raw document.
-     * Best-effort: ошибки логируются и не прерывают import flow.
-     * Дедупликация: если для документа уже есть активный (не-terminal) run — пропустить.
-     */
-    private function tryAutoStartPipeline(string $companyId, string $rawDocId): void
-    {
-        $existingRun = $this->runRepository->findLatestByRawDocument($companyId, $rawDocId);
-        if ($existingRun !== null && !$existingRun->getStatus()->isTerminal()) {
-            $this->logger->info('[AutoStart] Active run already exists, skipping', [
-                'raw_doc_id' => $rawDocId,
-                'run_id'     => $existingRun->getId(),
-                'status'     => $existingRun->getStatus()->value,
-            ]);
-
-            return;
-        }
-
-        try {
-            ($this->startProcessingAction)(new StartMarketplaceRawProcessingCommand(
-                $companyId,
-                $rawDocId,
-                PipelineTrigger::AUTO,
-            ));
-
-            $this->logger->info('[AutoStart] Daily pipeline started', [
-                'company_id' => $companyId,
-                'raw_doc_id' => $rawDocId,
-            ]);
-        } catch (\Throwable $e) {
-            $this->logger->error('[AutoStart] Failed to start daily pipeline', [
-                'company_id' => $companyId,
-                'raw_doc_id' => $rawDocId,
-                'error'      => $e->getMessage(),
-            ]);
         }
     }
 }

--- a/site/src/Marketplace/MessageHandler/SyncWbReportHandler.php
+++ b/site/src/Marketplace/MessageHandler/SyncWbReportHandler.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace App\Marketplace\MessageHandler;
 
 use App\Company\Entity\Company;
+use App\Marketplace\Application\Command\StartMarketplaceRawProcessingCommand;
+use App\Marketplace\Application\StartMarketplaceRawProcessingAction;
 use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Entity\MarketplaceRawDocument;
 use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Enum\PipelineTrigger;
 use App\Marketplace\Message\SyncWbReportMessage;
+use App\Marketplace\Repository\MarketplaceRawProcessingRunRepository;
 use App\Marketplace\Service\Integration\MarketplaceAdapterRegistry;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -31,6 +35,8 @@ final class SyncWbReportHandler
         private readonly MarketplaceAdapterRegistry $adapterRegistry,
         private readonly LockFactory $lockFactory,
         private readonly LoggerInterface $logger,
+        private readonly StartMarketplaceRawProcessingAction $startProcessingAction,
+        private readonly MarketplaceRawProcessingRunRepository $runRepository,
     ) {
     }
 
@@ -128,6 +134,9 @@ final class SyncWbReportHandler
 
             $connection->markSyncSuccess();
             $this->em->flush();
+
+            // Автозапуск daily pipeline (best-effort — не прерывает import flow)
+            $this->tryAutoStartPipeline($companyId, $rawDoc->getId());
         } catch (\Throwable $e) {
             $this->logger->error('WB daily sync failed', [
                 'company_id'    => $companyId,
@@ -146,6 +155,44 @@ final class SyncWbReportHandler
                     'error' => $inner->getMessage(),
                 ]);
             }
+        }
+    }
+
+    /**
+     * Запускает daily pipeline для сохранённого raw document.
+     * Best-effort: ошибки логируются и не прерывают import flow.
+     * Дедупликация: если для документа уже есть активный (не-terminal) run — пропустить.
+     */
+    private function tryAutoStartPipeline(string $companyId, string $rawDocId): void
+    {
+        $existingRun = $this->runRepository->findLatestByRawDocument($companyId, $rawDocId);
+        if ($existingRun !== null && !$existingRun->getStatus()->isTerminal()) {
+            $this->logger->info('[AutoStart] Active run already exists, skipping', [
+                'raw_doc_id' => $rawDocId,
+                'run_id'     => $existingRun->getId(),
+                'status'     => $existingRun->getStatus()->value,
+            ]);
+
+            return;
+        }
+
+        try {
+            ($this->startProcessingAction)(new StartMarketplaceRawProcessingCommand(
+                $companyId,
+                $rawDocId,
+                PipelineTrigger::AUTO,
+            ));
+
+            $this->logger->info('[AutoStart] Daily pipeline started', [
+                'company_id' => $companyId,
+                'raw_doc_id' => $rawDocId,
+            ]);
+        } catch (\Throwable $e) {
+            $this->logger->error('[AutoStart] Failed to start daily pipeline', [
+                'company_id' => $companyId,
+                'raw_doc_id' => $rawDocId,
+                'error'      => $e->getMessage(),
+            ]);
         }
     }
 }


### PR DESCRIPTION
## Summary

- После успешного сохранения `sales_report` MarketplaceRawDocument в `SyncWbReportHandler`, `SyncOzonReportHandler` и `SyncConnectionAction` вызывается `tryAutoStartPipeline()`.
- Вызывает `StartMarketplaceRawProcessingAction` с `PipelineTrigger::AUTO`.
- **Дедупликация**: если для данного raw document уже существует активный (не-terminal) run — пропустить.
- **Best-effort**: любой `Throwable` логируется, import flow НЕ прерывается.
- `realization` документы не затронуты — они создаются в `ProcessOzonRealizationAction`, который не изменялся.
- Ручные кнопки синхронизации сохранены.

## Точки автозапуска

| Handler / Action | Маркетплейс | Тип документа | Trigger |
|---|---|---|---|
| `SyncWbReportHandler` | Wildberries | `sales_report` | AUTO |
| `SyncOzonReportHandler` | Ozon | `sales_report` | AUTO |
| `SyncConnectionAction` | WB / Ozon | `sales_report` | AUTO |

## Логика дедупликации

```
findLatestByRawDocument(companyId, rawDocId)
  → null                → запускаем (новый документ)
  → run.isTerminal()    → запускаем (предыдущий завершился, можно повторить)
  → run.!isTerminal()   → пропускаем (RUNNING/PENDING — уже идёт)
```

## Поток после изменений

```
SyncWbReportHandler / SyncOzonReportHandler / SyncConnectionAction
  → persist(rawDoc) + flush()
  → markSyncSuccess() + flush()
  → tryAutoStartPipeline(companyId, rawDoc.id)
      → [check dedup]
      → StartMarketplaceRawProcessingAction(trigger=AUTO)
          → create Run + StepRuns + dispatch StartMarketplaceRawProcessingMessage [async]
```

## Ограничения

- `ProcessOzonRealizationAction` не изменён
- Monthly / realization flow не изменён
- `messenger.yaml` не изменялся — новые messages не добавлялись

## Test plan

- [ ] После `SyncWbReportHandler` → создаётся `MarketplaceRawProcessingRun` с `trigger=auto`
- [ ] После `SyncOzonReportHandler` → то же
- [ ] После `SyncConnectionAction` → то же
- [ ] Повторный вызов при RUNNING run → auto-start пропускается, run не дублируется
- [ ] Повторный вызов при COMPLETED run → auto-start запускается (новый run)
- [ ] Ошибка в `StartMarketplaceRawProcessingAction` → import завершается успешно, ошибка логируется
- [ ] `ProcessOzonRealizationAction` → auto-start не вызывается (не трогали)

https://claude.ai/code/session_01CXxMtBDyMhgK7qsWqtx99f