### PR TITLE
feat(Marketplace): add retry flow for failed processing runs and steps

### DIFF
--- a/site/src/Marketplace/Application/Command/RetryMarketplaceRawProcessingCommand.php
+++ b/site/src/Marketplace/Application/Command/RetryMarketplaceRawProcessingCommand.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\Command;
+
+final readonly class RetryMarketplaceRawProcessingCommand
+{
+    public function __construct(
+        public string $companyId,
+        public string $processingRunId,
+    ) {}
+}

--- a/site/src/Marketplace/Application/Command/RetryMarketplaceRawProcessingStepCommand.php
+++ b/site/src/Marketplace/Application/Command/RetryMarketplaceRawProcessingStepCommand.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\Command;
+
+final readonly class RetryMarketplaceRawProcessingStepCommand
+{
+    public function __construct(
+        public string $companyId,
+        public string $processingRunId,
+        public string $stepRunId,
+    ) {}
+}

--- a/site/src/Marketplace/Application/RetryMarketplaceRawProcessingAction.php
+++ b/site/src/Marketplace/Application/RetryMarketplaceRawProcessingAction.php
@@ -36,26 +36,28 @@ final class RetryMarketplaceRawProcessingAction
             throw new \DomainException('Processing run not found.');
         }
 
-        // Guard: только FAILED run можно ретраить
-        $run->resetForRetry();
-
         $stepRuns = $this->stepRunRepository->findByRunId($command->companyId, $command->processingRunId);
 
-        $resetStepIds = [];
-        foreach ($stepRuns as $stepRun) {
-            if ($stepRun->getStatus() === PipelineStatus::FAILED) {
-                $stepRun->resetForRetry();
-                $resetStepIds[] = $stepRun->getId();
-            }
+        $failedSteps = array_filter($stepRuns, static fn($s) => $s->getStatus() === PipelineStatus::FAILED);
+
+        if (empty($failedSteps)) {
+            throw new \DomainException('No failed steps found to retry.');
+        }
+
+        // Guard: только FAILED run можно ретраить (проверяется после того как known FAILED шаги)
+        $run->resetForRetry();
+
+        foreach ($failedSteps as $stepRun) {
+            $stepRun->resetForRetry();
         }
 
         $this->em->flush();
 
-        foreach ($resetStepIds as $stepRunId) {
+        foreach ($failedSteps as $stepRun) {
             $this->messageBus->dispatch(new RunMarketplaceRawProcessingStepMessage(
                 companyId:       $command->companyId,
                 processingRunId: $command->processingRunId,
-                stepRunId:       $stepRunId,
+                stepRunId:       $stepRun->getId(),
             ));
         }
     }

--- a/site/src/Marketplace/Application/RetryMarketplaceRawProcessingAction.php
+++ b/site/src/Marketplace/Application/RetryMarketplaceRawProcessingAction.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application;
+
+use App\Marketplace\Application\Command\RetryMarketplaceRawProcessingCommand;
+use App\Marketplace\Enum\PipelineStatus;
+use App\Marketplace\Message\RunMarketplaceRawProcessingStepMessage;
+use App\Marketplace\Repository\MarketplaceRawProcessingRunRepository;
+use App\Marketplace\Repository\MarketplaceRawProcessingStepRunRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * Повторно запускает failed processing run.
+ *
+ * Сбрасывает все FAILED шаги в PENDING, run — в RUNNING.
+ * COMPLETED шаги не трогаются — дублирование данных недопустимо.
+ * Dispatch выполняется только для сброшенных шагов.
+ */
+final class RetryMarketplaceRawProcessingAction
+{
+    public function __construct(
+        private readonly MarketplaceRawProcessingRunRepository $runRepository,
+        private readonly MarketplaceRawProcessingStepRunRepository $stepRunRepository,
+        private readonly EntityManagerInterface $em,
+        private readonly MessageBusInterface $messageBus,
+    ) {}
+
+    public function __invoke(RetryMarketplaceRawProcessingCommand $command): void
+    {
+        $run = $this->runRepository->findByIdAndCompany($command->processingRunId, $command->companyId);
+
+        if ($run === null) {
+            throw new \DomainException('Processing run not found.');
+        }
+
+        // Guard: только FAILED run можно ретраить
+        $run->resetForRetry();
+
+        $stepRuns = $this->stepRunRepository->findByRunId($command->companyId, $command->processingRunId);
+
+        $resetStepIds = [];
+        foreach ($stepRuns as $stepRun) {
+            if ($stepRun->getStatus() === PipelineStatus::FAILED) {
+                $stepRun->resetForRetry();
+                $resetStepIds[] = $stepRun->getId();
+            }
+        }
+
+        $this->em->flush();
+
+        foreach ($resetStepIds as $stepRunId) {
+            $this->messageBus->dispatch(new RunMarketplaceRawProcessingStepMessage(
+                companyId:       $command->companyId,
+                processingRunId: $command->processingRunId,
+                stepRunId:       $stepRunId,
+            ));
+        }
+    }
+}

--- a/site/src/Marketplace/Application/RetryMarketplaceRawProcessingStepAction.php
+++ b/site/src/Marketplace/Application/RetryMarketplaceRawProcessingStepAction.php
@@ -45,13 +45,18 @@ final class RetryMarketplaceRawProcessingStepAction
             throw new \DomainException('Step run does not belong to the given processing run.');
         }
 
-        // Guard: только FAILED шаг можно ретраить
-        $stepRun->resetForRetry();
-
         // Если run был FAILED — перевести в RUNNING чтобы финализатор мог завершить run
         if ($run->getStatus() === PipelineStatus::FAILED) {
             $run->resetForRetry();
         }
+
+        // Run должен быть RUNNING (изначально или после сброса выше)
+        if ($run->getStatus() !== PipelineStatus::RUNNING) {
+            throw new \DomainException('Cannot retry a step for a run that is not in RUNNING or FAILED state.');
+        }
+
+        // Guard: только FAILED шаг можно ретраить
+        $stepRun->resetForRetry();
 
         $this->em->flush();
 

--- a/site/src/Marketplace/Application/RetryMarketplaceRawProcessingStepAction.php
+++ b/site/src/Marketplace/Application/RetryMarketplaceRawProcessingStepAction.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application;
+
+use App\Marketplace\Application\Command\RetryMarketplaceRawProcessingStepCommand;
+use App\Marketplace\Enum\PipelineStatus;
+use App\Marketplace\Message\RunMarketplaceRawProcessingStepMessage;
+use App\Marketplace\Repository\MarketplaceRawProcessingRunRepository;
+use App\Marketplace\Repository\MarketplaceRawProcessingStepRunRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * Повторно запускает один failed шаг processing run.
+ *
+ * Сбрасывает FAILED шаг в PENDING.
+ * Если run был FAILED — сбрасывает его в RUNNING.
+ */
+final class RetryMarketplaceRawProcessingStepAction
+{
+    public function __construct(
+        private readonly MarketplaceRawProcessingRunRepository $runRepository,
+        private readonly MarketplaceRawProcessingStepRunRepository $stepRunRepository,
+        private readonly EntityManagerInterface $em,
+        private readonly MessageBusInterface $messageBus,
+    ) {}
+
+    public function __invoke(RetryMarketplaceRawProcessingStepCommand $command): void
+    {
+        $run = $this->runRepository->findByIdAndCompany($command->processingRunId, $command->companyId);
+
+        if ($run === null) {
+            throw new \DomainException('Processing run not found.');
+        }
+
+        $stepRun = $this->stepRunRepository->findByIdAndCompany($command->stepRunId, $command->companyId);
+
+        if ($stepRun === null) {
+            throw new \DomainException('Step run not found.');
+        }
+
+        if ($stepRun->getProcessingRunId() !== $command->processingRunId) {
+            throw new \DomainException('Step run does not belong to the given processing run.');
+        }
+
+        // Guard: только FAILED шаг можно ретраить
+        $stepRun->resetForRetry();
+
+        // Если run был FAILED — перевести в RUNNING чтобы финализатор мог завершить run
+        if ($run->getStatus() === PipelineStatus::FAILED) {
+            $run->resetForRetry();
+        }
+
+        $this->em->flush();
+
+        $this->messageBus->dispatch(new RunMarketplaceRawProcessingStepMessage(
+            companyId:       $command->companyId,
+            processingRunId: $command->processingRunId,
+            stepRunId:       $command->stepRunId,
+        ));
+    }
+}

--- a/site/src/Marketplace/Controller/MarketplaceController.php
+++ b/site/src/Marketplace/Controller/MarketplaceController.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace App\Marketplace\Controller;
 
+use App\Marketplace\Application\Command\RetryMarketplaceRawProcessingCommand;
+use App\Marketplace\Application\Command\RetryMarketplaceRawProcessingStepCommand;
 use App\Marketplace\Application\ProcessOzonRealizationAction;
 use App\Marketplace\Application\ReprocessMarketplacePeriodAction;
+use App\Marketplace\Application\RetryMarketplaceRawProcessingAction;
+use App\Marketplace\Application\RetryMarketplaceRawProcessingStepAction;
 use App\Marketplace\Application\SyncConnectionAction;
 use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Entity\MarketplaceListing;
@@ -455,6 +459,50 @@ class MarketplaceController extends AbstractController
             }
         } catch (\Exception $e) {
             $this->addFlash('error', 'Ошибка обработки реализации: ' . $e->getMessage());
+        }
+
+        return $this->redirectToRoute('marketplace_index');
+    }
+
+    #[Route('/run/{runId}/retry', name: 'marketplace_run_retry', methods: ['POST'])]
+    public function retryRun(
+        string $runId,
+        RetryMarketplaceRawProcessingAction $action,
+    ): Response {
+        $company = $this->companyService->getActiveCompany();
+
+        try {
+            ($action)(new RetryMarketplaceRawProcessingCommand(
+                companyId:       (string) $company->getId(),
+                processingRunId: $runId,
+            ));
+
+            $this->addFlash('success', 'Повторный запуск pipeline запущен.');
+        } catch (\DomainException $e) {
+            $this->addFlash('error', $e->getMessage());
+        }
+
+        return $this->redirectToRoute('marketplace_index');
+    }
+
+    #[Route('/run/{runId}/step/{stepId}/retry', name: 'marketplace_run_step_retry', methods: ['POST'])]
+    public function retryRunStep(
+        string $runId,
+        string $stepId,
+        RetryMarketplaceRawProcessingStepAction $action,
+    ): Response {
+        $company = $this->companyService->getActiveCompany();
+
+        try {
+            ($action)(new RetryMarketplaceRawProcessingStepCommand(
+                companyId:       (string) $company->getId(),
+                processingRunId: $runId,
+                stepRunId:       $stepId,
+            ));
+
+            $this->addFlash('success', 'Повторный запуск шага запущен.');
+        } catch (\DomainException $e) {
+            $this->addFlash('error', $e->getMessage());
         }
 
         return $this->redirectToRoute('marketplace_index');

--- a/site/src/Marketplace/Entity/MarketplaceRawProcessingRun.php
+++ b/site/src/Marketplace/Entity/MarketplaceRawProcessingRun.php
@@ -112,6 +112,17 @@ class MarketplaceRawProcessingRun
         $this->details = $details;
     }
 
+    public function resetForRetry(): void
+    {
+        if ($this->status !== PipelineStatus::FAILED) {
+            throw new \DomainException('Only FAILED runs can be reset for retry.');
+        }
+
+        $this->status = PipelineStatus::RUNNING;
+        $this->finishedAt = null;
+        $this->lastErrorMessage = null;
+    }
+
     public function getId(): string { return $this->id; }
     public function getCompanyId(): string { return $this->companyId; }
     public function getRawDocumentId(): string { return $this->rawDocumentId; }

--- a/site/src/Marketplace/Entity/MarketplaceRawProcessingRun.php
+++ b/site/src/Marketplace/Entity/MarketplaceRawProcessingRun.php
@@ -121,6 +121,8 @@ class MarketplaceRawProcessingRun
         $this->status = PipelineStatus::RUNNING;
         $this->finishedAt = null;
         $this->lastErrorMessage = null;
+        $this->summary = null;
+        $this->details = null;
     }
 
     public function getId(): string { return $this->id; }

--- a/site/src/Marketplace/Entity/MarketplaceRawProcessingStepRun.php
+++ b/site/src/Marketplace/Entity/MarketplaceRawProcessingStepRun.php
@@ -136,6 +136,21 @@ class MarketplaceRawProcessingStepRun
         $this->detailsJson = $detailsJson;
     }
 
+    public function resetForRetry(): void
+    {
+        if ($this->status !== PipelineStatus::FAILED) {
+            throw new \DomainException('Only FAILED step runs can be retried.');
+        }
+
+        $this->status = PipelineStatus::PENDING;
+        $this->startedAt = null;
+        $this->finishedAt = null;
+        $this->errorMessage = null;
+        $this->processedCount = 0;
+        $this->failedCount = 0;
+        $this->skippedCount = 0;
+    }
+
     public function getId(): string { return $this->id; }
     public function getCompanyId(): string { return $this->companyId; }
     public function getProcessingRunId(): string { return $this->processingRunId; }

--- a/site/src/Marketplace/Entity/MarketplaceRawProcessingStepRun.php
+++ b/site/src/Marketplace/Entity/MarketplaceRawProcessingStepRun.php
@@ -149,6 +149,8 @@ class MarketplaceRawProcessingStepRun
         $this->processedCount = 0;
         $this->failedCount = 0;
         $this->skippedCount = 0;
+        $this->createdEntitiesJson = null;
+        $this->detailsJson = null;
     }
 
     public function getId(): string { return $this->id; }


### PR DESCRIPTION
## Summary

- Add `resetForRetry()` guard methods to `MarketplaceRawProcessingRun` (FAILED → RUNNING) and `MarketplaceRawProcessingStepRun` (FAILED → PENDING, resets counters/timestamps)
- Add `RetryMarketplaceRawProcessingAction` — resets all FAILED steps of a run (COMPLETED steps untouched to avoid duplicate data), resets run to RUNNING, dispatches `RunMarketplaceRawProcessingStepMessage` per reset step
- Add `RetryMarketplaceRawProcessingStepAction` — resets one FAILED step, resets run to RUNNING if it was FAILED, dispatches step message
- Add two controller routes: `POST /marketplace/run/{runId}/retry` and `POST /marketplace/run/{runId}/step/{stepId}/retry`
- Old manual buttons (process-sales, process-returns, process-costs) are not touched per task constraint

## Test plan

- [ ] Verify retry whole run: FAILED run with mixed FAILED/COMPLETED steps → only FAILED steps reset to PENDING, run to RUNNING, messages dispatched
- [ ] Verify retry single step: FAILED step reset to PENDING, FAILED run reset to RUNNING, message dispatched
- [ ] Verify guard: retrying a non-FAILED run throws `DomainException`
- [ ] Verify guard: retrying a non-FAILED step throws `DomainException`
- [ ] Verify IDOR: run/step belonging to another company returns "not found"
- [ ] Verify finalization: after retry completes all steps, `FinalizeMarketplaceRawProcessingAction` correctly marks run COMPLETED

https://claude.ai/code/session_01CXxMtBDyMhgK7qsWqtx99f