### PR TITLE
feat(Marketplace): add read-side and UI for pipeline run/step statuses

### DIFF
--- a/site/src/Marketplace/Controller/MarketplaceController.php
+++ b/site/src/Marketplace/Controller/MarketplaceController.php
@@ -496,9 +496,14 @@ class MarketplaceController extends AbstractController
     #[Route('/run/{runId}/retry', name: 'marketplace_run_retry', methods: ['POST'])]
     public function retryRun(
         string $runId,
+        Request $request,
         RetryMarketplaceRawProcessingAction $action,
     ): Response {
         $company = $this->companyService->getActiveCompany();
+
+        if (!$this->isCsrfTokenValid('retry' . $runId, $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Invalid CSRF token.');
+        }
 
         try {
             ($action)(new RetryMarketplaceRawProcessingCommand(
@@ -518,9 +523,14 @@ class MarketplaceController extends AbstractController
     public function retryRunStep(
         string $runId,
         string $stepId,
+        Request $request,
         RetryMarketplaceRawProcessingStepAction $action,
     ): Response {
         $company = $this->companyService->getActiveCompany();
+
+        if (!$this->isCsrfTokenValid('retry_step' . $stepId, $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Invalid CSRF token.');
+        }
 
         try {
             ($action)(new RetryMarketplaceRawProcessingStepCommand(

--- a/site/src/Marketplace/Controller/MarketplaceController.php
+++ b/site/src/Marketplace/Controller/MarketplaceController.php
@@ -19,6 +19,8 @@ use App\Marketplace\Application\ProcessMarketplaceRawDocumentAction;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Infrastructure\Query\OzonRealizationStatusQuery;
 use App\Marketplace\Infrastructure\Query\RawDocumentsListQuery;
+use App\Marketplace\Infrastructure\Query\RawProcessingRunDetailsQuery;
+use App\Marketplace\Infrastructure\Query\RawProcessingRunsListQuery;
 use App\Marketplace\Message\SyncOzonRealizationMessage;
 use App\Marketplace\Message\TriggerInitialSyncMessage;
 use App\Marketplace\Repository\MarketplaceConnectionRepository;
@@ -49,6 +51,7 @@ class MarketplaceController extends AbstractController
         private readonly MarketplaceAdapterRegistry       $adapterRegistry,
         private readonly OzonRealizationStatusQuery       $realizationStatusQuery,
         private readonly RawDocumentsListQuery            $rawDocumentsListQuery,
+        private readonly RawProcessingRunsListQuery       $runListQuery,
         private readonly ProjectDirectionRepository       $projectDirectionRepository,
         private readonly EntityManagerInterface           $em,
         private readonly MessageBusInterface              $messageBus,
@@ -74,10 +77,20 @@ class MarketplaceController extends AbstractController
             50,
         );
 
+        $docIds = array_map(
+            static fn($doc) => $doc->getId(),
+            iterator_to_array($rawDocumentsPager->getCurrentPageResults()),
+        );
+        $runStatusesByDocId = $this->runListQuery->fetchLatestForDocuments(
+            (string) $company->getId(),
+            $docIds,
+        );
+
         return $this->render('marketplace/index.html.twig', [
             'connections'           => $connections,
             'rawDocumentsPager'     => $rawDocumentsPager,
             'availableMarketplaces' => MarketplaceType::cases(),
+            'runStatusesByDocId'    => $runStatusesByDocId,
         ]);
     }
 
@@ -462,6 +475,22 @@ class MarketplaceController extends AbstractController
         }
 
         return $this->redirectToRoute('marketplace_index');
+    }
+
+    #[Route('/run/{runId}', name: 'marketplace_run_detail', methods: ['GET'])]
+    public function runDetail(string $runId, RawProcessingRunDetailsQuery $query): Response
+    {
+        $company = $this->companyService->getActiveCompany();
+
+        $run = $query->fetch((string) $company->getId(), $runId);
+
+        if ($run === null) {
+            throw $this->createNotFoundException('Processing run not found.');
+        }
+
+        return $this->render('marketplace/raw_processing_run_detail.html.twig', [
+            'run' => $run,
+        ]);
     }
 
     #[Route('/run/{runId}/retry', name: 'marketplace_run_retry', methods: ['POST'])]

--- a/site/src/Marketplace/Controller/MarketplaceController.php
+++ b/site/src/Marketplace/Controller/MarketplaceController.php
@@ -516,7 +516,7 @@ class MarketplaceController extends AbstractController
             $this->addFlash('error', $e->getMessage());
         }
 
-        return $this->redirectToRoute('marketplace_index');
+        return $this->redirectToRoute('marketplace_run_detail', ['runId' => $runId]);
     }
 
     #[Route('/run/{runId}/step/{stepId}/retry', name: 'marketplace_run_step_retry', methods: ['POST'])]
@@ -544,7 +544,7 @@ class MarketplaceController extends AbstractController
             $this->addFlash('error', $e->getMessage());
         }
 
-        return $this->redirectToRoute('marketplace_index');
+        return $this->redirectToRoute('marketplace_run_detail', ['runId' => $runId]);
     }
 
     #[Route('/reprocess', name: 'marketplace_reprocess', methods: ['POST'])]

--- a/site/src/Marketplace/Infrastructure/Query/RawProcessingRunDetailsQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/RawProcessingRunDetailsQuery.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Query;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * Read-model: полные данные одного processing run + его шагов.
+ * Используется для детальной страницы статуса pipeline.
+ */
+final class RawProcessingRunDetailsQuery
+{
+    public function __construct(private readonly Connection $connection) {}
+
+    /**
+     * Возвращает данные run и его шагов.
+     * null — если run не найден или не принадлежит companyId (IDOR-safe).
+     *
+     * @return array{
+     *     id: string,
+     *     raw_document_id: string,
+     *     status: string,
+     *     pipeline_trigger: string,
+     *     started_at: string,
+     *     finished_at: string|null,
+     *     last_error_message: string|null,
+     *     summary: array|null,
+     *     details: array|null,
+     *     steps: list<array{
+     *         id: string,
+     *         step: string,
+     *         status: string,
+     *         started_at: string|null,
+     *         finished_at: string|null,
+     *         processed_count: int,
+     *         failed_count: int,
+     *         skipped_count: int,
+     *         error_message: string|null,
+     *     }>
+     * }|null
+     */
+    public function fetch(string $companyId, string $runId): ?array
+    {
+        $run = $this->connection->fetchAssociative(
+            'SELECT id, raw_document_id, status, pipeline_trigger,
+                    started_at, finished_at, last_error_message, summary, details
+             FROM marketplace_raw_processing_runs
+             WHERE id = ? AND company_id = ?',
+            [$runId, $companyId],
+        );
+
+        if ($run === false) {
+            return null;
+        }
+
+        $run['summary'] = $run['summary'] !== null ? json_decode($run['summary'], true) : null;
+        $run['details'] = $run['details'] !== null ? json_decode($run['details'], true) : null;
+
+        $steps = $this->connection->executeQuery(
+            'SELECT id, step, status, started_at, finished_at,
+                    processed_count, failed_count, skipped_count, error_message
+             FROM marketplace_raw_processing_step_runs
+             WHERE processing_run_id = ? AND company_id = ?
+             ORDER BY created_at ASC',
+            [$runId, $companyId],
+        )->fetchAllAssociative();
+
+        $run['steps'] = $steps;
+
+        return $run;
+    }
+}

--- a/site/src/Marketplace/Infrastructure/Query/RawProcessingRunDetailsQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/RawProcessingRunDetailsQuery.php
@@ -55,8 +55,10 @@ final class RawProcessingRunDetailsQuery
             return null;
         }
 
-        $run['summary'] = $run['summary'] !== null ? json_decode($run['summary'], true) : null;
-        $run['details'] = $run['details'] !== null ? json_decode($run['details'], true) : null;
+        $run['summary'] = $run['summary'] !== null
+            ? json_decode($run['summary'], true, 512, JSON_THROW_ON_ERROR) : null;
+        $run['details'] = $run['details'] !== null
+            ? json_decode($run['details'], true, 512, JSON_THROW_ON_ERROR) : null;
 
         $steps = $this->connection->executeQuery(
             'SELECT id, step, status, started_at, finished_at,

--- a/site/src/Marketplace/Infrastructure/Query/RawProcessingRunsListQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/RawProcessingRunsListQuery.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Query;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+
+/**
+ * Read-model: последний processing run для набора raw documents.
+ * Используется для отображения статуса pipeline в списке документов.
+ */
+final class RawProcessingRunsListQuery
+{
+    public function __construct(private readonly Connection $connection) {}
+
+    /**
+     * Возвращает последний run для каждого документа из списка.
+     *
+     * @param  string[] $rawDocumentIds
+     * @return array<string, array{id: string, status: string, pipeline_trigger: string, started_at: string, finished_at: string|null, last_error_message: string|null}>
+     *         Ключ — raw_document_id
+     */
+    public function fetchLatestForDocuments(string $companyId, array $rawDocumentIds): array
+    {
+        if (empty($rawDocumentIds)) {
+            return [];
+        }
+
+        $rows = $this->connection->executeQuery(
+            'SELECT r.id, r.raw_document_id, r.status, r.pipeline_trigger,
+                    r.started_at, r.finished_at, r.last_error_message
+             FROM marketplace_raw_processing_runs r
+             WHERE r.company_id = :companyId
+               AND r.raw_document_id IN (:docIds)
+             ORDER BY r.started_at DESC',
+            ['companyId' => $companyId, 'docIds' => $rawDocumentIds],
+            ['docIds' => ArrayParameterType::STRING],
+        )->fetchAllAssociative();
+
+        // Берём первую строку по каждому docId — она наибольшая по started_at (ORDER BY DESC)
+        $result = [];
+        foreach ($rows as $row) {
+            $docId = $row['raw_document_id'];
+            if (!isset($result[$docId])) {
+                $result[$docId] = $row;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/site/templates/marketplace/index.html.twig
+++ b/site/templates/marketplace/index.html.twig
@@ -133,13 +133,14 @@
                         <th>Создано</th>
                         <th>Пропущено</th>
                         <th>Дата</th>
+                        <th>Pipeline</th>
                         <th></th>
                     </tr>
                     </thead>
                     <tbody>
                     {% if rawDocumentsPager.nbResults == 0 %}
                         <tr>
-                            <td colspan="8" class="text-center text-muted">Нет данных</td>
+                            <td colspan="9" class="text-center text-muted">Нет данных</td>
                         </tr>
                     {% else %}
                         {% for doc in rawDocumentsPager.currentPageResults %}
@@ -151,6 +152,22 @@
                                 <td><span class="badge bg-success text-success-fg">{{ doc.recordsCreated }}</span></td>
                                 <td><span class="badge bg-secondary">{{ doc.recordsSkipped }}</span></td>
                                 <td><small>{{ doc.syncedAt|date('d.m.Y H:i') }}</small></td>
+                                <td>
+                                    {% set run = runStatusesByDocId[doc.id] ?? null %}
+                                    {% if run %}
+                                        {% set badge = {pending: 'warning', running: 'info', completed: 'success', failed: 'danger'} %}
+                                        {% set label = {pending: 'Ожидает', running: 'Выполняется', completed: 'Завершён', failed: 'Ошибка'} %}
+                                        <a href="{{ path('marketplace_run_detail', {runId: run.id}) }}"
+                                           class="badge bg-{{ badge[run.status] ?? 'secondary' }} text-decoration-none">
+                                            {% if run.status == 'running' %}
+                                                <span class="spinner-border spinner-border-sm me-1" style="width:.6rem;height:.6rem"></span>
+                                            {% endif %}
+                                            {{ label[run.status] ?? run.status }}
+                                        </a>
+                                    {% else %}
+                                        <span class="text-muted small">—</span>
+                                    {% endif %}
+                                </td>
                                 <td class="text-end">
                                     <div class="btn-list">
                                         <a href="{{ path('marketplace_raw_view', {id: doc.id}) }}" class="btn btn-sm btn-ghost-primary" target="_blank">JSON</a>
@@ -172,7 +189,7 @@
                             </tr>
                             {% if doc.unprocessedCostsCount is defined and doc.unprocessedCostsCount > 0 %}
                                 <tr class="bg-warning-lt">
-                                    <td colspan="8">
+                                    <td colspan="9">
                                         <div class="d-flex align-items-center">
                                             <div>
                                                 <strong>Нераспознано затрат: {{ doc.unprocessedCostsCount }}</strong>

--- a/site/templates/marketplace/index.html.twig
+++ b/site/templates/marketplace/index.html.twig
@@ -143,6 +143,8 @@
                             <td colspan="9" class="text-center text-muted">Нет данных</td>
                         </tr>
                     {% else %}
+                        {% set run_badge = {pending: 'warning', running: 'info', completed: 'success', failed: 'danger'} %}
+                        {% set run_label = {pending: 'Ожидает', running: 'Выполняется', completed: 'Завершён', failed: 'Ошибка'} %}
                         {% for doc in rawDocumentsPager.currentPageResults %}
                             <tr>
                                 <td><span class="badge bg-azure text-azure-fg">{{ doc.marketplace.displayName }}</span></td>
@@ -155,14 +157,12 @@
                                 <td>
                                     {% set run = runStatusesByDocId[doc.id] ?? null %}
                                     {% if run %}
-                                        {% set badge = {pending: 'warning', running: 'info', completed: 'success', failed: 'danger'} %}
-                                        {% set label = {pending: 'Ожидает', running: 'Выполняется', completed: 'Завершён', failed: 'Ошибка'} %}
                                         <a href="{{ path('marketplace_run_detail', {runId: run.id}) }}"
-                                           class="badge bg-{{ badge[run.status] ?? 'secondary' }} text-decoration-none">
+                                           class="badge bg-{{ run_badge[run.status] ?? 'secondary' }} text-decoration-none">
                                             {% if run.status == 'running' %}
                                                 <span class="spinner-border spinner-border-sm me-1" style="width:.6rem;height:.6rem"></span>
                                             {% endif %}
-                                            {{ label[run.status] ?? run.status }}
+                                            {{ run_label[run.status] ?? run.status }}
                                         </a>
                                     {% else %}
                                         <span class="text-muted small">—</span>

--- a/site/templates/marketplace/raw_processing_run_detail.html.twig
+++ b/site/templates/marketplace/raw_processing_run_detail.html.twig
@@ -36,6 +36,7 @@
                 {% if run.status == 'failed' %}
                     <div class="card-actions">
                         <form method="post" action="{{ path('marketplace_run_retry', {runId: run.id}) }}">
+                            <input type="hidden" name="_token" value="{{ csrf_token('retry' ~ run.id) }}">
                             <button type="submit" class="btn btn-danger btn-sm"
                                     onclick="return confirm('Повторить весь pipeline? Будут перезапущены только FAILED шаги.')">
                                 Повторить весь run
@@ -145,6 +146,7 @@
                                         <form method="post"
                                               action="{{ path('marketplace_run_step_retry', {runId: run.id, stepId: step.id}) }}"
                                               style="display:inline">
+                                            <input type="hidden" name="_token" value="{{ csrf_token('retry_step' ~ step.id) }}">
                                             <button type="submit" class="btn btn-sm btn-danger"
                                                     onclick="return confirm('Повторить шаг {{ step_label[step.step] ?? step.step }}?')">
                                                 Retry

--- a/site/templates/marketplace/raw_processing_run_detail.html.twig
+++ b/site/templates/marketplace/raw_processing_run_detail.html.twig
@@ -1,0 +1,164 @@
+{% extends 'marketplace/layout.html.twig' %}
+
+{% set active_tab = 'marketplace' %}
+
+{% block tab_content %}
+    {% set badge_color = {pending: 'warning', running: 'info', completed: 'success', failed: 'danger'} %}
+    {% set status_label = {pending: 'Ожидает', running: 'Выполняется', completed: 'Завершён', failed: 'Ошибка'} %}
+    {% set step_label = {sales: 'Продажи', returns: 'Возвраты', costs: 'Затраты'} %}
+
+    <div class="p-3">
+
+        {# Breadcrumb #}
+        <div class="mb-3">
+            <a href="{{ path('marketplace_index') }}" class="btn btn-sm btn-ghost-secondary">
+                &larr; Назад к документам
+            </a>
+        </div>
+
+        {# Run header #}
+        <div class="card mb-3">
+            <div class="card-header">
+                <div class="col">
+                    <h3 class="card-title">
+                        Processing Run
+                        <span class="badge bg-{{ badge_color[run.status] ?? 'secondary' }} ms-2">
+                            {% if run.status == 'running' %}
+                                <span class="spinner-border spinner-border-sm me-1" style="width:.6rem;height:.6rem"></span>
+                            {% endif %}
+                            {{ status_label[run.status] ?? run.status }}
+                        </span>
+                    </h3>
+                    <div class="card-subtitle text-muted">
+                        <small>ID: {{ run.id }}</small>
+                    </div>
+                </div>
+                {% if run.status == 'failed' %}
+                    <div class="card-actions">
+                        <form method="post" action="{{ path('marketplace_run_retry', {runId: run.id}) }}">
+                            <button type="submit" class="btn btn-danger btn-sm"
+                                    onclick="return confirm('Повторить весь pipeline? Будут перезапущены только FAILED шаги.')">
+                                Повторить весь run
+                            </button>
+                        </form>
+                    </div>
+                {% endif %}
+            </div>
+            <div class="card-body">
+                <div class="row g-3">
+                    <div class="col-auto">
+                        <div class="text-muted small">Запуск</div>
+                        <div>{{ run.started_at ? run.started_at|date('d.m.Y H:i:s') : '—' }}</div>
+                    </div>
+                    <div class="col-auto">
+                        <div class="text-muted small">Завершение</div>
+                        <div>{{ run.finished_at ? run.finished_at|date('d.m.Y H:i:s') : '—' }}</div>
+                    </div>
+                    <div class="col-auto">
+                        <div class="text-muted small">Триггер</div>
+                        <div>{{ run.pipeline_trigger == 'auto' ? 'Автоматически' : 'Вручную' }}</div>
+                    </div>
+                </div>
+
+                {% if run.last_error_message %}
+                    <div class="alert alert-danger mt-3 mb-0">
+                        <div class="d-flex">
+                            <div>
+                                <strong>Ошибка:</strong> {{ run.last_error_message }}
+                            </div>
+                        </div>
+                    </div>
+                {% endif %}
+
+                {% if run.summary %}
+                    <div class="mt-3">
+                        <div class="text-muted small mb-1">Итоги</div>
+                        <div class="d-flex flex-wrap gap-2">
+                            {% for key, value in run.summary %}
+                                <span class="badge bg-secondary">{{ key }}: {{ value }}</span>
+                            {% endfor %}
+                        </div>
+                    </div>
+                {% endif %}
+            </div>
+        </div>
+
+        {# Steps table #}
+        <div class="card">
+            <div class="card-header">
+                <h3 class="card-title">Шаги</h3>
+            </div>
+            <div class="table-responsive">
+                <table class="table card-table table-vcenter">
+                    <thead>
+                    <tr>
+                        <th>Шаг</th>
+                        <th>Статус</th>
+                        <th>Начало</th>
+                        <th>Конец</th>
+                        <th>Обработано</th>
+                        <th>Ошибок</th>
+                        <th>Пропущено</th>
+                        <th>Ошибка</th>
+                        <th></th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% if run.steps is empty %}
+                        <tr>
+                            <td colspan="9" class="text-center text-muted">Нет шагов</td>
+                        </tr>
+                    {% else %}
+                        {% for step in run.steps %}
+                            <tr>
+                                <td><strong>{{ step_label[step.step] ?? step.step }}</strong></td>
+                                <td>
+                                    <span class="badge bg-{{ badge_color[step.status] ?? 'secondary' }}">
+                                        {% if step.status == 'running' %}
+                                            <span class="spinner-border spinner-border-sm me-1" style="width:.5rem;height:.5rem"></span>
+                                        {% endif %}
+                                        {{ status_label[step.status] ?? step.status }}
+                                    </span>
+                                </td>
+                                <td><small>{{ step.started_at ? step.started_at|date('H:i:s') : '—' }}</small></td>
+                                <td><small>{{ step.finished_at ? step.finished_at|date('H:i:s') : '—' }}</small></td>
+                                <td>{{ step.processed_count }}</td>
+                                <td>
+                                    {% if step.failed_count > 0 %}
+                                        <span class="text-danger">{{ step.failed_count }}</span>
+                                    {% else %}
+                                        {{ step.failed_count }}
+                                    {% endif %}
+                                </td>
+                                <td>{{ step.skipped_count }}</td>
+                                <td>
+                                    {% if step.error_message %}
+                                        <span class="text-danger small" title="{{ step.error_message }}">
+                                            {{ step.error_message|slice(0, 60) }}{% if step.error_message|length > 60 %}…{% endif %}
+                                        </span>
+                                    {% else %}
+                                        <span class="text-muted">—</span>
+                                    {% endif %}
+                                </td>
+                                <td class="text-end">
+                                    {% if step.status == 'failed' %}
+                                        <form method="post"
+                                              action="{{ path('marketplace_run_step_retry', {runId: run.id, stepId: step.id}) }}"
+                                              style="display:inline">
+                                            <button type="submit" class="btn btn-sm btn-danger"
+                                                    onclick="return confirm('Повторить шаг {{ step_label[step.step] ?? step.step }}?')">
+                                                Retry
+                                            </button>
+                                        </form>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    {% endif %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+    </div>
+{% endblock %}


### PR DESCRIPTION
## Summary

- Add `RawProcessingRunsListQuery` (DBAL) — batch-fetches latest run status per document; used on the index page
- Add `RawProcessingRunDetailsQuery` (DBAL) — IDOR-safe fetch of one run + its step runs; used on the detail page
- `MarketplaceController.index()` — collect doc IDs from current page, load run statuses, pass `runStatusesByDocId` to template
- New `GET /marketplace/run/{runId}` (`runDetail`) — renders the pipeline run detail page
- `index.html.twig` — new "Pipeline" column with color-coded status badge (pending/running/completed/failed), links to detail page
- `raw_processing_run_detail.html.twig` — run header (status, trigger, dates, error, summary), steps table with processed/failed/skipped counts and error messages, retry buttons for failed run and individual failed steps
- Old manual buttons (process-sales, process-returns, process-costs) are untouched

## Test plan

- [ ] Index page: "Pipeline" column shows correct badge for each doc (pending=yellow, running=blue+spinner, completed=green, failed=red), "—" when no run exists
- [ ] Index page: clicking badge navigates to detail page for the correct run
- [ ] Detail page: all step statuses and counts are visible
- [ ] Detail page: `last_error_message` shown in red alert when run is FAILED
- [ ] Detail page: "Повторить весь run" button visible only when run status is FAILED
- [ ] Detail page: "Retry" button visible per step only when step status is FAILED
- [ ] IDOR: accessing run belonging to another company returns 404
- [ ] Old manual buttons (process-sales/returns/costs) still present and functional

https://claude.ai/code/session_01CXxMtBDyMhgK7qsWqtx99f