### PR TITLE
test(marketplace): unit tests for daily pipeline (Task 11)

### DIFF
--- a/site/tests/Builders/Marketplace/MarketplaceRawProcessingRunBuilder.php
+++ b/site/tests/Builders/Marketplace/MarketplaceRawProcessingRunBuilder.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Builders\Marketplace;
+
+use App\Marketplace\Entity\MarketplaceRawProcessingRun;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Enum\PipelineTrigger;
+
+final class MarketplaceRawProcessingRunBuilder
+{
+    public const DEFAULT_COMPANY_ID    = '11111111-1111-1111-1111-111111111111';
+    public const DEFAULT_RAW_DOC_ID    = '22222222-2222-2222-2222-222222222222';
+    public const DEFAULT_DOCUMENT_TYPE = 'sales_report';
+
+    private string $companyId    = self::DEFAULT_COMPANY_ID;
+    private string $rawDocumentId = self::DEFAULT_RAW_DOC_ID;
+    private MarketplaceType $marketplace = MarketplaceType::WILDBERRIES;
+    private string $documentType = self::DEFAULT_DOCUMENT_TYPE;
+    private PipelineTrigger $trigger = PipelineTrigger::AUTO;
+    private string $profileCode = self::DEFAULT_DOCUMENT_TYPE;
+
+    private function __construct() {}
+
+    public static function aRun(): self
+    {
+        return new self();
+    }
+
+    public function withCompanyId(string $companyId): self
+    {
+        $clone = clone $this;
+        $clone->companyId = $companyId;
+        return $clone;
+    }
+
+    public function withRawDocumentId(string $rawDocumentId): self
+    {
+        $clone = clone $this;
+        $clone->rawDocumentId = $rawDocumentId;
+        return $clone;
+    }
+
+    public function withMarketplace(MarketplaceType $marketplace): self
+    {
+        $clone = clone $this;
+        $clone->marketplace = $marketplace;
+        return $clone;
+    }
+
+    public function withDocumentType(string $documentType): self
+    {
+        $clone = clone $this;
+        $clone->documentType = $documentType;
+        $clone->profileCode  = $documentType;
+        return $clone;
+    }
+
+    public function withTrigger(PipelineTrigger $trigger): self
+    {
+        $clone = clone $this;
+        $clone->trigger = $trigger;
+        return $clone;
+    }
+
+    public function build(): MarketplaceRawProcessingRun
+    {
+        return new MarketplaceRawProcessingRun(
+            $this->companyId,
+            $this->rawDocumentId,
+            $this->marketplace,
+            $this->documentType,
+            $this->trigger,
+            $this->profileCode,
+        );
+    }
+}

--- a/site/tests/Builders/Marketplace/MarketplaceRawProcessingStepRunBuilder.php
+++ b/site/tests/Builders/Marketplace/MarketplaceRawProcessingStepRunBuilder.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Builders\Marketplace;
+
+use App\Marketplace\Entity\MarketplaceRawProcessingStepRun;
+use App\Marketplace\Enum\PipelineStep;
+
+final class MarketplaceRawProcessingStepRunBuilder
+{
+    public const DEFAULT_COMPANY_ID = '11111111-1111-1111-1111-111111111111';
+    public const DEFAULT_RUN_ID     = '33333333-3333-3333-3333-333333333333';
+
+    private string $companyId       = self::DEFAULT_COMPANY_ID;
+    private string $processingRunId = self::DEFAULT_RUN_ID;
+    private PipelineStep $step      = PipelineStep::SALES;
+
+    private function __construct() {}
+
+    public static function aStepRun(): self
+    {
+        return new self();
+    }
+
+    public function withCompanyId(string $companyId): self
+    {
+        $clone = clone $this;
+        $clone->companyId = $companyId;
+        return $clone;
+    }
+
+    public function withProcessingRunId(string $processingRunId): self
+    {
+        $clone = clone $this;
+        $clone->processingRunId = $processingRunId;
+        return $clone;
+    }
+
+    public function forStep(PipelineStep $step): self
+    {
+        $clone = clone $this;
+        $clone->step = $step;
+        return $clone;
+    }
+
+    public function build(): MarketplaceRawProcessingStepRun
+    {
+        return new MarketplaceRawProcessingStepRun(
+            $this->companyId,
+            $this->processingRunId,
+            $this->step,
+        );
+    }
+}

--- a/site/tests/Unit/Marketplace/Application/FinalizeMarketplaceRawProcessingActionTest.php
+++ b/site/tests/Unit/Marketplace/Application/FinalizeMarketplaceRawProcessingActionTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Application;
+
+use App\Marketplace\Application\Command\FinalizeMarketplaceRawProcessingCommand;
+use App\Marketplace\Application\FinalizeMarketplaceRawProcessingAction;
+use App\Marketplace\Enum\PipelineStatus;
+use App\Marketplace\Repository\MarketplaceRawProcessingRunRepository;
+use App\Marketplace\Repository\MarketplaceRawProcessingStepRunRepository;
+use App\Tests\Builders\Marketplace\MarketplaceRawProcessingRunBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceRawProcessingStepRunBuilder;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+final class FinalizeMarketplaceRawProcessingActionTest extends TestCase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-111111111111';
+
+    public function testAllStepsCompletedFinalizesRunAsCompleted(): void
+    {
+        $run = MarketplaceRawProcessingRunBuilder::aRun()->withCompanyId(self::COMPANY_ID)->build();
+
+        $step1 = MarketplaceRawProcessingStepRunBuilder::aStepRun()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withProcessingRunId($run->getId())
+            ->build();
+        $step1->markRunning();
+        $step1->markCompleted(10, 0, 0);
+
+        $step2 = MarketplaceRawProcessingStepRunBuilder::aStepRun()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withProcessingRunId($run->getId())
+            ->build();
+        $step2->markRunning();
+        $step2->markCompleted(5, 1, 2);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('flush');
+
+        $action = $this->buildAction($run, [$step1, $step2], $em);
+        $action(new FinalizeMarketplaceRawProcessingCommand(self::COMPANY_ID, $run->getId()));
+
+        self::assertSame(PipelineStatus::COMPLETED, $run->getStatus());
+        self::assertNotNull($run->getFinishedAt());
+        self::assertNull($run->getLastErrorMessage());
+
+        $summary = $run->getSummary();
+        self::assertSame(15, $summary['total_processed']);
+        self::assertSame(1, $summary['total_failed']);
+        self::assertSame(2, $summary['total_skipped']);
+        self::assertSame(2, $summary['steps_total']);
+        self::assertSame(2, $summary['steps_completed']);
+        self::assertSame(0, $summary['steps_failed']);
+    }
+
+    public function testOneFailedStepFinalizesRunAsFailed(): void
+    {
+        $run = MarketplaceRawProcessingRunBuilder::aRun()->withCompanyId(self::COMPANY_ID)->build();
+
+        $step1 = MarketplaceRawProcessingStepRunBuilder::aStepRun()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withProcessingRunId($run->getId())
+            ->build();
+        $step1->markRunning();
+        $step1->markCompleted(10, 0, 0);
+
+        $step2 = MarketplaceRawProcessingStepRunBuilder::aStepRun()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withProcessingRunId($run->getId())
+            ->build();
+        $step2->markRunning();
+        $step2->markFailed('processor error', 3, 1, 0);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('flush');
+
+        $action = $this->buildAction($run, [$step1, $step2], $em);
+        $action(new FinalizeMarketplaceRawProcessingCommand(self::COMPANY_ID, $run->getId()));
+
+        self::assertSame(PipelineStatus::FAILED, $run->getStatus());
+        self::assertNotNull($run->getLastErrorMessage());
+        self::assertStringContainsString('processor error', $run->getLastErrorMessage());
+
+        $summary = $run->getSummary();
+        self::assertSame(1, $summary['steps_failed']);
+        self::assertSame(1, $summary['steps_completed']);
+    }
+
+    public function testNonTerminalStepDefersFinalization(): void
+    {
+        $run = MarketplaceRawProcessingRunBuilder::aRun()->withCompanyId(self::COMPANY_ID)->build();
+
+        $stepCompleted = MarketplaceRawProcessingStepRunBuilder::aStepRun()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withProcessingRunId($run->getId())
+            ->build();
+        $stepCompleted->markRunning();
+        $stepCompleted->markCompleted(5, 0, 0);
+
+        $stepStillRunning = MarketplaceRawProcessingStepRunBuilder::aStepRun()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withProcessingRunId($run->getId())
+            ->build();
+        $stepStillRunning->markRunning(); // not terminal
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->never())->method('flush');
+
+        $action = $this->buildAction($run, [$stepCompleted, $stepStillRunning], $em);
+        $action(new FinalizeMarketplaceRawProcessingCommand(self::COMPANY_ID, $run->getId()));
+
+        // run should remain RUNNING
+        self::assertSame(PipelineStatus::RUNNING, $run->getStatus());
+    }
+
+    public function testAlreadyTerminalRunIsIdempotent(): void
+    {
+        $run = MarketplaceRawProcessingRunBuilder::aRun()->withCompanyId(self::COMPANY_ID)->build();
+        $run->markCompleted();
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->never())->method('flush');
+
+        $action = $this->buildAction($run, [], $em);
+        $action(new FinalizeMarketplaceRawProcessingCommand(self::COMPANY_ID, $run->getId()));
+
+        self::assertSame(PipelineStatus::COMPLETED, $run->getStatus());
+    }
+
+    public function testRunNotFoundThrows(): void
+    {
+        $runRepo = $this->createMock(MarketplaceRawProcessingRunRepository::class);
+        $runRepo->method('findByIdAndCompany')->willReturn(null);
+
+        $action = new FinalizeMarketplaceRawProcessingAction(
+            $runRepo,
+            $this->createMock(MarketplaceRawProcessingStepRunRepository::class),
+            $this->createMock(EntityManagerInterface::class),
+            new NullLogger(),
+        );
+
+        $this->expectException(\DomainException::class);
+
+        $action(new FinalizeMarketplaceRawProcessingCommand(self::COMPANY_ID, 'no-such-run'));
+    }
+
+    // -------------------------------------------------------------------------
+
+    private function buildAction(
+        \App\Marketplace\Entity\MarketplaceRawProcessingRun $run,
+        array $stepRuns,
+        ?EntityManagerInterface $em = null,
+    ): FinalizeMarketplaceRawProcessingAction {
+        $runRepo = $this->createMock(MarketplaceRawProcessingRunRepository::class);
+        $runRepo->method('findByIdAndCompany')->willReturn($run);
+
+        $stepRepo = $this->createMock(MarketplaceRawProcessingStepRunRepository::class);
+        $stepRepo->method('findByRunId')->willReturn($stepRuns);
+
+        return new FinalizeMarketplaceRawProcessingAction(
+            $runRepo,
+            $stepRepo,
+            $em ?? $this->createMock(EntityManagerInterface::class),
+            new NullLogger(),
+        );
+    }
+}

--- a/site/tests/Unit/Marketplace/Application/MarketplacePipelineAutoStarterTest.php
+++ b/site/tests/Unit/Marketplace/Application/MarketplacePipelineAutoStarterTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Application;
+
+use App\Marketplace\Application\Command\StartMarketplaceRawProcessingCommand;
+use App\Marketplace\Application\Service\MarketplacePipelineAutoStarter;
+use App\Marketplace\Application\StartMarketplaceRawProcessingAction;
+use App\Marketplace\Enum\PipelineTrigger;
+use App\Marketplace\Repository\MarketplaceRawProcessingRunRepository;
+use App\Tests\Builders\Marketplace\MarketplaceRawProcessingRunBuilder;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+final class MarketplacePipelineAutoStarterTest extends TestCase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-111111111111';
+    private const RAW_DOC_ID = '22222222-2222-2222-2222-222222222222';
+
+    public function testStartsPipelineWhenNoExistingRun(): void
+    {
+        $runRepo = $this->createMock(MarketplaceRawProcessingRunRepository::class);
+        $runRepo->method('findLatestByRawDocument')->willReturn(null);
+
+        $startAction = $this->createMock(StartMarketplaceRawProcessingAction::class);
+        $startAction->expects($this->once())
+            ->method('__invoke')
+            ->with($this->callback(function (StartMarketplaceRawProcessingCommand $cmd): bool {
+                return $cmd->companyId === self::COMPANY_ID
+                    && $cmd->rawDocumentId === self::RAW_DOC_ID
+                    && $cmd->trigger === PipelineTrigger::AUTO;
+            }))
+            ->willReturn('new-run-id');
+
+        $starter = new MarketplacePipelineAutoStarter($startAction, $runRepo, new NullLogger());
+        $starter->tryStart(self::COMPANY_ID, self::RAW_DOC_ID);
+    }
+
+    public function testStartsPipelineWhenPreviousRunIsTerminal(): void
+    {
+        $completedRun = MarketplaceRawProcessingRunBuilder::aRun()->withCompanyId(self::COMPANY_ID)->build();
+        $completedRun->markCompleted();
+
+        $runRepo = $this->createMock(MarketplaceRawProcessingRunRepository::class);
+        $runRepo->method('findLatestByRawDocument')->willReturn($completedRun);
+
+        $startAction = $this->createMock(StartMarketplaceRawProcessingAction::class);
+        $startAction->expects($this->once())->method('__invoke')->willReturn('new-run-id');
+
+        $starter = new MarketplacePipelineAutoStarter($startAction, $runRepo, new NullLogger());
+        $starter->tryStart(self::COMPANY_ID, self::RAW_DOC_ID);
+    }
+
+    public function testSkipsPipelineWhenActiveRunExists(): void
+    {
+        $activeRun = MarketplaceRawProcessingRunBuilder::aRun()->withCompanyId(self::COMPANY_ID)->build();
+        // run is RUNNING (non-terminal)
+
+        $runRepo = $this->createMock(MarketplaceRawProcessingRunRepository::class);
+        $runRepo->method('findLatestByRawDocument')->willReturn($activeRun);
+
+        $startAction = $this->createMock(StartMarketplaceRawProcessingAction::class);
+        $startAction->expects($this->never())->method('__invoke');
+
+        $starter = new MarketplacePipelineAutoStarter($startAction, $runRepo, new NullLogger());
+        $starter->tryStart(self::COMPANY_ID, self::RAW_DOC_ID);
+    }
+
+    public function testDoesNotPropagateExceptionsFromStartAction(): void
+    {
+        $runRepo = $this->createMock(MarketplaceRawProcessingRunRepository::class);
+        $runRepo->method('findLatestByRawDocument')->willReturn(null);
+
+        $startAction = $this->createMock(StartMarketplaceRawProcessingAction::class);
+        $startAction->method('__invoke')->willThrowException(new \DomainException('document not found'));
+
+        $starter = new MarketplacePipelineAutoStarter($startAction, $runRepo, new NullLogger());
+
+        // must not throw
+        $starter->tryStart(self::COMPANY_ID, self::RAW_DOC_ID);
+
+        $this->addToAssertionCount(1); // confirm no exception
+    }
+
+    public function testDoesNotPropagateRuntimeExceptionFromStartAction(): void
+    {
+        $runRepo = $this->createMock(MarketplaceRawProcessingRunRepository::class);
+        $runRepo->method('findLatestByRawDocument')->willReturn(null);
+
+        $startAction = $this->createMock(StartMarketplaceRawProcessingAction::class);
+        $startAction->method('__invoke')->willThrowException(new \RuntimeException('unexpected infra error'));
+
+        $starter = new MarketplacePipelineAutoStarter($startAction, $runRepo, new NullLogger());
+
+        // must not throw — best-effort
+        $starter->tryStart(self::COMPANY_ID, self::RAW_DOC_ID);
+
+        $this->addToAssertionCount(1);
+    }
+}

--- a/site/tests/Unit/Marketplace/Application/RetryMarketplaceRawProcessingActionTest.php
+++ b/site/tests/Unit/Marketplace/Application/RetryMarketplaceRawProcessingActionTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Application;
+
+use App\Marketplace\Application\Command\RetryMarketplaceRawProcessingCommand;
+use App\Marketplace\Application\RetryMarketplaceRawProcessingAction;
+use App\Marketplace\Enum\PipelineStatus;
+use App\Marketplace\Message\RunMarketplaceRawProcessingStepMessage;
+use App\Marketplace\Repository\MarketplaceRawProcessingRunRepository;
+use App\Marketplace\Repository\MarketplaceRawProcessingStepRunRepository;
+use App\Tests\Builders\Marketplace\MarketplaceRawProcessingRunBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceRawProcessingStepRunBuilder;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class RetryMarketplaceRawProcessingActionTest extends TestCase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-111111111111';
+
+    public function testHappyPathResetsFailedStepsAndDispatches(): void
+    {
+        $run = MarketplaceRawProcessingRunBuilder::aRun()->withCompanyId(self::COMPANY_ID)->build();
+        $run->markFailed('error');
+
+        $step1 = MarketplaceRawProcessingStepRunBuilder::aStepRun()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withProcessingRunId($run->getId())
+            ->build();
+        $step1->markRunning();
+        $step1->markFailed('step1 error', 0, 0, 0);
+
+        $step2 = MarketplaceRawProcessingStepRunBuilder::aStepRun()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withProcessingRunId($run->getId())
+            ->build();
+        $step2->markRunning();
+        $step2->markCompleted(5, 0, 0); // already completed — should not be reset
+
+        $dispatched = [];
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->method('dispatch')
+            ->willReturnCallback(function (object $message) use (&$dispatched) {
+                $dispatched[] = $message;
+                return new Envelope($message);
+            });
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('flush');
+
+        $action = $this->buildAction($run, [$step1, $step2], $bus, $em);
+        $action(new RetryMarketplaceRawProcessingCommand(self::COMPANY_ID, $run->getId()));
+
+        // run reset to RUNNING
+        self::assertSame(PipelineStatus::RUNNING, $run->getStatus());
+        // only the failed step reset
+        self::assertSame(PipelineStatus::PENDING, $step1->getStatus());
+        // completed step untouched
+        self::assertSame(PipelineStatus::COMPLETED, $step2->getStatus());
+        // dispatch only for reset step
+        self::assertCount(1, $dispatched);
+        self::assertInstanceOf(RunMarketplaceRawProcessingStepMessage::class, $dispatched[0]);
+    }
+
+    public function testRunNotFoundThrows(): void
+    {
+        $runRepo = $this->createMock(MarketplaceRawProcessingRunRepository::class);
+        $runRepo->method('findByIdAndCompany')->willReturn(null);
+
+        $action = new RetryMarketplaceRawProcessingAction(
+            $runRepo,
+            $this->createMock(MarketplaceRawProcessingStepRunRepository::class),
+            $this->createMock(EntityManagerInterface::class),
+            $this->createMock(MessageBusInterface::class),
+        );
+
+        $this->expectException(\DomainException::class);
+
+        $action(new RetryMarketplaceRawProcessingCommand(self::COMPANY_ID, 'no-run'));
+    }
+
+    public function testNoFailedStepsThrows(): void
+    {
+        $run = MarketplaceRawProcessingRunBuilder::aRun()->withCompanyId(self::COMPANY_ID)->build();
+        $run->markFailed('error');
+
+        $step = MarketplaceRawProcessingStepRunBuilder::aStepRun()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withProcessingRunId($run->getId())
+            ->build();
+        $step->markRunning();
+        $step->markCompleted(5, 0, 0);
+
+        $action = $this->buildAction($run, [$step]);
+
+        $this->expectException(\DomainException::class);
+
+        $action(new RetryMarketplaceRawProcessingCommand(self::COMPANY_ID, $run->getId()));
+    }
+
+    public function testRetryingNonFailedRunThrows(): void
+    {
+        $run = MarketplaceRawProcessingRunBuilder::aRun()->withCompanyId(self::COMPANY_ID)->build();
+        // run stays RUNNING (not FAILED)
+
+        $step = MarketplaceRawProcessingStepRunBuilder::aStepRun()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withProcessingRunId($run->getId())
+            ->build();
+        $step->markRunning();
+        $step->markFailed('step error');
+
+        $action = $this->buildAction($run, [$step]);
+
+        $this->expectException(\DomainException::class);
+
+        $action(new RetryMarketplaceRawProcessingCommand(self::COMPANY_ID, $run->getId()));
+    }
+
+    // -------------------------------------------------------------------------
+
+    private function buildAction(
+        \App\Marketplace\Entity\MarketplaceRawProcessingRun $run,
+        array $stepRuns,
+        ?MessageBusInterface $bus = null,
+        ?EntityManagerInterface $em = null,
+    ): RetryMarketplaceRawProcessingAction {
+        $runRepo = $this->createMock(MarketplaceRawProcessingRunRepository::class);
+        $runRepo->method('findByIdAndCompany')->willReturn($run);
+
+        $stepRepo = $this->createMock(MarketplaceRawProcessingStepRunRepository::class);
+        $stepRepo->method('findByRunId')->willReturn($stepRuns);
+
+        return new RetryMarketplaceRawProcessingAction(
+            $runRepo,
+            $stepRepo,
+            $em ?? $this->createMock(EntityManagerInterface::class),
+            $bus ?? $this->createMock(MessageBusInterface::class),
+        );
+    }
+}

--- a/site/tests/Unit/Marketplace/Application/RunMarketplaceRawProcessingStepActionTest.php
+++ b/site/tests/Unit/Marketplace/Application/RunMarketplaceRawProcessingStepActionTest.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Application;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Application\Command\RunMarketplaceRawProcessingStepCommand;
+use App\Marketplace\Application\Processor\MarketplaceRawProcessorInterface;
+use App\Marketplace\Application\Processor\MarketplaceRawProcessorRegistryInterface;
+use App\Marketplace\Application\RunMarketplaceRawProcessingStepAction;
+use App\Marketplace\Domain\Service\ResolveMarketplaceRawProcessingProfile;
+use App\Marketplace\Entity\MarketplaceRawDocument;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Enum\PipelineStatus;
+use App\Marketplace\Enum\PipelineStep;
+use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
+use App\Marketplace\Repository\MarketplaceRawProcessingRunRepository;
+use App\Marketplace\Repository\MarketplaceRawProcessingStepRunRepository;
+use App\Tests\Builders\Marketplace\MarketplaceRawProcessingRunBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceRawProcessingStepRunBuilder;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+final class RunMarketplaceRawProcessingStepActionTest extends TestCase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-111111111111';
+    private const RUN_ID     = '33333333-3333-3333-3333-333333333333';
+    private const STEP_ID    = '44444444-4444-4444-4444-444444444444';
+    private const RAW_DOC_ID = '22222222-2222-2222-2222-222222222222';
+
+    public function testHappyPathPendingStepBecomesCompleted(): void
+    {
+        $run     = MarketplaceRawProcessingRunBuilder::aRun()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withRawDocumentId(self::RAW_DOC_ID)
+            ->build();
+        $stepRun = MarketplaceRawProcessingStepRunBuilder::aStepRun()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withProcessingRunId($run->getId())
+            ->forStep(PipelineStep::SALES)
+            ->build();
+
+        $processor = $this->createMock(MarketplaceRawProcessorInterface::class);
+        $processor->method('process')->with(self::COMPANY_ID, self::RAW_DOC_ID)->willReturn(42);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->atLeast(2))->method('flush'); // once for RUNNING, once for COMPLETED
+
+        $action = $this->buildAction(
+            run: $run,
+            stepRun: $stepRun,
+            processorReturn: 42,
+            em: $em,
+        );
+
+        $processed = $action(new RunMarketplaceRawProcessingStepCommand(
+            self::COMPANY_ID,
+            $run->getId(),
+            $stepRun->getId(),
+        ));
+
+        self::assertSame(42, $processed);
+        self::assertSame(PipelineStatus::COMPLETED, $stepRun->getStatus());
+        self::assertSame(42, $stepRun->getProcessedCount());
+    }
+
+    public function testTerminalStepIsSkippedIdempotently(): void
+    {
+        $run     = MarketplaceRawProcessingRunBuilder::aRun()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withRawDocumentId(self::RAW_DOC_ID)
+            ->build();
+        $stepRun = MarketplaceRawProcessingStepRunBuilder::aStepRun()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withProcessingRunId($run->getId())
+            ->forStep(PipelineStep::SALES)
+            ->build();
+
+        // put step into terminal state
+        $stepRun->markRunning();
+        $stepRun->markCompleted(10, 0, 0);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->never())->method('flush');
+
+        $action = $this->buildAction(run: $run, stepRun: $stepRun, processorReturn: 0, em: $em);
+
+        $result = $action(new RunMarketplaceRawProcessingStepCommand(
+            self::COMPANY_ID,
+            $run->getId(),
+            $stepRun->getId(),
+        ));
+
+        self::assertSame(0, $result);
+    }
+
+    public function testRunNotFoundThrows(): void
+    {
+        $runRepo = $this->createMock(MarketplaceRawProcessingRunRepository::class);
+        $runRepo->method('findByIdAndCompany')->willReturn(null);
+
+        $action = new RunMarketplaceRawProcessingStepAction(
+            $runRepo,
+            $this->createMock(MarketplaceRawProcessingStepRunRepository::class),
+            $this->createMock(MarketplaceRawDocumentRepository::class),
+            $this->createMock(MarketplaceRawProcessorRegistryInterface::class),
+            new ResolveMarketplaceRawProcessingProfile(),
+            $this->createMock(EntityManagerInterface::class),
+            new NullLogger(),
+        );
+
+        $this->expectException(\DomainException::class);
+
+        $action(new RunMarketplaceRawProcessingStepCommand(self::COMPANY_ID, self::RUN_ID, self::STEP_ID));
+    }
+
+    public function testStepRunNotFoundThrows(): void
+    {
+        $run = MarketplaceRawProcessingRunBuilder::aRun()->withCompanyId(self::COMPANY_ID)->build();
+
+        $runRepo = $this->createMock(MarketplaceRawProcessingRunRepository::class);
+        $runRepo->method('findByIdAndCompany')->willReturn($run);
+
+        $stepRepo = $this->createMock(MarketplaceRawProcessingStepRunRepository::class);
+        $stepRepo->method('findByIdAndCompany')->willReturn(null);
+
+        $action = new RunMarketplaceRawProcessingStepAction(
+            $runRepo,
+            $stepRepo,
+            $this->createMock(MarketplaceRawDocumentRepository::class),
+            $this->createMock(MarketplaceRawProcessorRegistryInterface::class),
+            new ResolveMarketplaceRawProcessingProfile(),
+            $this->createMock(EntityManagerInterface::class),
+            new NullLogger(),
+        );
+
+        $this->expectException(\DomainException::class);
+
+        $action(new RunMarketplaceRawProcessingStepCommand(self::COMPANY_ID, $run->getId(), self::STEP_ID));
+    }
+
+    public function testStepRunFromDifferentRunThrows(): void
+    {
+        $run = MarketplaceRawProcessingRunBuilder::aRun()->withCompanyId(self::COMPANY_ID)->build();
+        // step belonging to a different run
+        $stepRun = MarketplaceRawProcessingStepRunBuilder::aStepRun()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withProcessingRunId('ffffffff-ffff-ffff-ffff-ffffffffffff')
+            ->build();
+
+        $runRepo = $this->createMock(MarketplaceRawProcessingRunRepository::class);
+        $runRepo->method('findByIdAndCompany')->willReturn($run);
+
+        $stepRepo = $this->createMock(MarketplaceRawProcessingStepRunRepository::class);
+        $stepRepo->method('findByIdAndCompany')->willReturn($stepRun);
+
+        $action = new RunMarketplaceRawProcessingStepAction(
+            $runRepo,
+            $stepRepo,
+            $this->createMock(MarketplaceRawDocumentRepository::class),
+            $this->createMock(MarketplaceRawProcessorRegistryInterface::class),
+            new ResolveMarketplaceRawProcessingProfile(),
+            $this->createMock(EntityManagerInterface::class),
+            new NullLogger(),
+        );
+
+        $this->expectException(\DomainException::class);
+
+        $action(new RunMarketplaceRawProcessingStepCommand(self::COMPANY_ID, $run->getId(), $stepRun->getId()));
+    }
+
+    public function testDomainExceptionFromProcessorMarksStepFailed(): void
+    {
+        $run     = MarketplaceRawProcessingRunBuilder::aRun()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withRawDocumentId(self::RAW_DOC_ID)
+            ->build();
+        $stepRun = MarketplaceRawProcessingStepRunBuilder::aStepRun()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withProcessingRunId($run->getId())
+            ->forStep(PipelineStep::SALES)
+            ->build();
+
+        $action = $this->buildAction(
+            run: $run,
+            stepRun: $stepRun,
+            processorException: new \DomainException('business error'),
+        );
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('business error');
+
+        try {
+            $action(new RunMarketplaceRawProcessingStepCommand(
+                self::COMPANY_ID,
+                $run->getId(),
+                $stepRun->getId(),
+            ));
+        } finally {
+            self::assertSame(PipelineStatus::FAILED, $stepRun->getStatus());
+            self::assertSame('business error', $stepRun->getErrorMessage());
+        }
+    }
+
+    public function testInfraErrorKeepsStepRunning(): void
+    {
+        $run     = MarketplaceRawProcessingRunBuilder::aRun()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withRawDocumentId(self::RAW_DOC_ID)
+            ->build();
+        $stepRun = MarketplaceRawProcessingStepRunBuilder::aStepRun()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withProcessingRunId($run->getId())
+            ->forStep(PipelineStep::SALES)
+            ->build();
+
+        $action = $this->buildAction(
+            run: $run,
+            stepRun: $stepRun,
+            processorException: new \RuntimeException('db connection lost'),
+        );
+
+        $this->expectException(\RuntimeException::class);
+
+        try {
+            $action(new RunMarketplaceRawProcessingStepCommand(
+                self::COMPANY_ID,
+                $run->getId(),
+                $stepRun->getId(),
+            ));
+        } finally {
+            // step must remain RUNNING so Messenger can retry
+            self::assertSame(PipelineStatus::RUNNING, $stepRun->getStatus());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+
+    private function buildAction(
+        \App\Marketplace\Entity\MarketplaceRawProcessingRun $run,
+        \App\Marketplace\Entity\MarketplaceRawProcessingStepRun $stepRun,
+        int $processorReturn = 0,
+        ?\Throwable $processorException = null,
+        ?EntityManagerInterface $em = null,
+    ): RunMarketplaceRawProcessingStepAction {
+        $runRepo = $this->createMock(MarketplaceRawProcessingRunRepository::class);
+        $runRepo->method('findByIdAndCompany')->willReturn($run);
+
+        $stepRepo = $this->createMock(MarketplaceRawProcessingStepRunRepository::class);
+        $stepRepo->method('findByIdAndCompany')->willReturn($stepRun);
+
+        $company = $this->createMock(Company::class);
+        $company->method('getId')->willReturn(self::COMPANY_ID);
+
+        $doc = $this->createMock(MarketplaceRawDocument::class);
+        $doc->method('getCompany')->willReturn($company);
+        $doc->method('getDocumentType')->willReturn('sales_report');
+        $doc->method('getMarketplace')->willReturn(MarketplaceType::WILDBERRIES);
+
+        $docRepo = $this->createMock(MarketplaceRawDocumentRepository::class);
+        $docRepo->method('find')->willReturn($doc);
+
+        $processor = $this->createMock(MarketplaceRawProcessorInterface::class);
+        if ($processorException !== null) {
+            $processor->method('process')->willThrowException($processorException);
+        } else {
+            $processor->method('process')->willReturn($processorReturn);
+        }
+
+        $registry = $this->createMock(MarketplaceRawProcessorRegistryInterface::class);
+        $registry->method('get')->willReturn($processor);
+
+        return new RunMarketplaceRawProcessingStepAction(
+            $runRepo,
+            $stepRepo,
+            $docRepo,
+            $registry,
+            new ResolveMarketplaceRawProcessingProfile(),
+            $em ?? $this->createMock(EntityManagerInterface::class),
+            new NullLogger(),
+        );
+    }
+}

--- a/site/tests/Unit/Marketplace/Application/StartMarketplaceRawProcessingActionTest.php
+++ b/site/tests/Unit/Marketplace/Application/StartMarketplaceRawProcessingActionTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Application;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Application\Command\StartMarketplaceRawProcessingCommand;
+use App\Marketplace\Application\StartMarketplaceRawProcessingAction;
+use App\Marketplace\Domain\Service\ResolveMarketplaceRawProcessingProfile;
+use App\Marketplace\Entity\MarketplaceRawDocument;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Enum\PipelineTrigger;
+use App\Marketplace\Message\StartMarketplaceRawProcessingMessage;
+use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class StartMarketplaceRawProcessingActionTest extends TestCase
+{
+    private const COMPANY_ID  = '11111111-1111-1111-1111-111111111111';
+    private const RAW_DOC_ID  = '22222222-2222-2222-2222-222222222222';
+
+    public function testHappyPathCreateRunAndStepsAndDispatches(): void
+    {
+        $doc = $this->makeDoc(self::COMPANY_ID, 'sales_report', MarketplaceType::WILDBERRIES);
+
+        $docRepo = $this->createMock(MarketplaceRawDocumentRepository::class);
+        $docRepo->method('find')->with(self::RAW_DOC_ID)->willReturn($doc);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $persistedEntities = [];
+        $em->method('persist')->willReturnCallback(function ($entity) use (&$persistedEntities) {
+            $persistedEntities[] = $entity;
+        });
+        $em->expects($this->once())->method('flush');
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())
+            ->method('dispatch')
+            ->with($this->isInstanceOf(StartMarketplaceRawProcessingMessage::class))
+            ->willReturn(new Envelope(new StartMarketplaceRawProcessingMessage(self::COMPANY_ID, 'run-id')));
+
+        $action = new StartMarketplaceRawProcessingAction(
+            $docRepo,
+            new ResolveMarketplaceRawProcessingProfile(),
+            $em,
+            $bus,
+        );
+
+        $runId = $action(new StartMarketplaceRawProcessingCommand(
+            self::COMPANY_ID,
+            self::RAW_DOC_ID,
+            PipelineTrigger::AUTO,
+        ));
+
+        self::assertNotEmpty($runId);
+        // 1 run + 3 step runs (SALES, RETURNS, COSTS)
+        self::assertCount(4, $persistedEntities);
+    }
+
+    public function testThrowsWhenDocumentNotFound(): void
+    {
+        $docRepo = $this->createMock(MarketplaceRawDocumentRepository::class);
+        $docRepo->method('find')->willReturn(null);
+
+        $action = new StartMarketplaceRawProcessingAction(
+            $docRepo,
+            new ResolveMarketplaceRawProcessingProfile(),
+            $this->createMock(EntityManagerInterface::class),
+            $this->createMock(MessageBusInterface::class),
+        );
+
+        $this->expectException(\DomainException::class);
+
+        $action(new StartMarketplaceRawProcessingCommand(self::COMPANY_ID, self::RAW_DOC_ID, PipelineTrigger::MANUAL));
+    }
+
+    public function testThrowsWhenDocumentBelongsToDifferentCompany(): void
+    {
+        $doc = $this->makeDoc('99999999-9999-9999-9999-999999999999', 'sales_report', MarketplaceType::WILDBERRIES);
+
+        $docRepo = $this->createMock(MarketplaceRawDocumentRepository::class);
+        $docRepo->method('find')->willReturn($doc);
+
+        $action = new StartMarketplaceRawProcessingAction(
+            $docRepo,
+            new ResolveMarketplaceRawProcessingProfile(),
+            $this->createMock(EntityManagerInterface::class),
+            $this->createMock(MessageBusInterface::class),
+        );
+
+        $this->expectException(\DomainException::class);
+
+        $action(new StartMarketplaceRawProcessingCommand(self::COMPANY_ID, self::RAW_DOC_ID, PipelineTrigger::MANUAL));
+    }
+
+    public function testThrowsForRealizationDocument(): void
+    {
+        $doc = $this->makeDoc(self::COMPANY_ID, 'realization', MarketplaceType::OZON);
+
+        $docRepo = $this->createMock(MarketplaceRawDocumentRepository::class);
+        $docRepo->method('find')->willReturn($doc);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->never())->method('flush');
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->never())->method('dispatch');
+
+        $action = new StartMarketplaceRawProcessingAction(
+            $docRepo,
+            new ResolveMarketplaceRawProcessingProfile(),
+            $em,
+            $bus,
+        );
+
+        $this->expectException(\DomainException::class);
+
+        $action(new StartMarketplaceRawProcessingCommand(self::COMPANY_ID, self::RAW_DOC_ID, PipelineTrigger::MANUAL));
+    }
+
+    private function makeDoc(string $companyId, string $documentType, MarketplaceType $marketplace): MarketplaceRawDocument
+    {
+        $company = $this->createMock(Company::class);
+        $company->method('getId')->willReturn($companyId);
+
+        $doc = $this->createMock(MarketplaceRawDocument::class);
+        $doc->method('getId')->willReturn(self::RAW_DOC_ID);
+        $doc->method('getCompany')->willReturn($company);
+        $doc->method('getDocumentType')->willReturn($documentType);
+        $doc->method('getMarketplace')->willReturn($marketplace);
+
+        return $doc;
+    }
+}

--- a/site/tests/Unit/Marketplace/Domain/ResolveMarketplaceRawProcessingProfileTest.php
+++ b/site/tests/Unit/Marketplace/Domain/ResolveMarketplaceRawProcessingProfileTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Domain;
+
+use App\Marketplace\Domain\Service\ResolveMarketplaceRawProcessingProfile;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Enum\PipelineStep;
+use PHPUnit\Framework\TestCase;
+
+final class ResolveMarketplaceRawProcessingProfileTest extends TestCase
+{
+    private ResolveMarketplaceRawProcessingProfile $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new ResolveMarketplaceRawProcessingProfile();
+    }
+
+    public function testSalesReportIsDailyPipeline(): void
+    {
+        $profile = $this->resolver->resolve(MarketplaceType::WILDBERRIES, 'sales_report');
+
+        self::assertTrue($profile->isDailyPipeline);
+        self::assertNull($profile->skipReason);
+        self::assertContains(PipelineStep::SALES, $profile->requiredSteps);
+        self::assertContains(PipelineStep::RETURNS, $profile->requiredSteps);
+        self::assertContains(PipelineStep::COSTS, $profile->requiredSteps);
+        self::assertCount(3, $profile->requiredSteps);
+    }
+
+    public function testSalesReportRequiresAllThreeSteps(): void
+    {
+        $profile = $this->resolver->resolve(MarketplaceType::OZON, 'sales_report');
+
+        self::assertTrue($profile->requiresStep(PipelineStep::SALES));
+        self::assertTrue($profile->requiresStep(PipelineStep::RETURNS));
+        self::assertTrue($profile->requiresStep(PipelineStep::COSTS));
+    }
+
+    public function testSalesReportWorksForAllMarketplaces(): void
+    {
+        foreach (MarketplaceType::cases() as $marketplace) {
+            $profile = $this->resolver->resolve($marketplace, 'sales_report');
+            self::assertTrue($profile->isDailyPipeline, "Expected daily pipeline for {$marketplace->value}");
+        }
+    }
+
+    public function testRealizationIsOutsideDailyFlow(): void
+    {
+        $profile = $this->resolver->resolve(MarketplaceType::OZON, 'realization');
+
+        self::assertFalse($profile->isDailyPipeline);
+        self::assertEmpty($profile->requiredSteps);
+        self::assertNotNull($profile->skipReason);
+        self::assertStringContainsString('realization', $profile->skipReason);
+    }
+
+    public function testRealizationDoesNotRequireAnyStep(): void
+    {
+        $profile = $this->resolver->resolve(MarketplaceType::OZON, 'realization');
+
+        self::assertFalse($profile->requiresStep(PipelineStep::SALES));
+        self::assertFalse($profile->requiresStep(PipelineStep::RETURNS));
+        self::assertFalse($profile->requiresStep(PipelineStep::COSTS));
+    }
+
+    public function testUnknownDocumentTypeIsOutsideDailyFlow(): void
+    {
+        $profile = $this->resolver->resolve(MarketplaceType::WILDBERRIES, 'some_other_report');
+
+        self::assertFalse($profile->isDailyPipeline);
+        self::assertEmpty($profile->requiredSteps);
+        self::assertNotNull($profile->skipReason);
+    }
+
+    public function testUnknownDocumentTypeSkipReasonMentionsDocumentType(): void
+    {
+        $profile = $this->resolver->resolve(MarketplaceType::WILDBERRIES, 'mystery_doc');
+
+        self::assertStringContainsString('mystery_doc', $profile->skipReason);
+    }
+}

--- a/site/tests/Unit/Marketplace/Entity/MarketplaceRawProcessingRunTest.php
+++ b/site/tests/Unit/Marketplace/Entity/MarketplaceRawProcessingRunTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Entity;
+
+use App\Marketplace\Enum\PipelineStatus;
+use App\Tests\Builders\Marketplace\MarketplaceRawProcessingRunBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class MarketplaceRawProcessingRunTest extends TestCase
+{
+    public function testInitialStatusIsRunning(): void
+    {
+        $run = MarketplaceRawProcessingRunBuilder::aRun()->build();
+
+        self::assertSame(PipelineStatus::RUNNING, $run->getStatus());
+        self::assertNull($run->getFinishedAt());
+        self::assertNull($run->getLastErrorMessage());
+    }
+
+    public function testMarkCompleted(): void
+    {
+        $run = MarketplaceRawProcessingRunBuilder::aRun()->build();
+        $run->markCompleted(['total_processed' => 5], ['steps' => []]);
+
+        self::assertSame(PipelineStatus::COMPLETED, $run->getStatus());
+        self::assertNotNull($run->getFinishedAt());
+        self::assertNull($run->getLastErrorMessage());
+        self::assertSame(['total_processed' => 5], $run->getSummary());
+    }
+
+    public function testMarkFailed(): void
+    {
+        $run = MarketplaceRawProcessingRunBuilder::aRun()->build();
+        $run->markFailed('Something went wrong', ['total_processed' => 0]);
+
+        self::assertSame(PipelineStatus::FAILED, $run->getStatus());
+        self::assertNotNull($run->getFinishedAt());
+        self::assertSame('Something went wrong', $run->getLastErrorMessage());
+    }
+
+    public function testResetForRetryResetsToRunning(): void
+    {
+        $run = MarketplaceRawProcessingRunBuilder::aRun()->build();
+        $run->markFailed('error', ['steps_failed' => 1], ['steps' => []]);
+
+        $run->resetForRetry();
+
+        self::assertSame(PipelineStatus::RUNNING, $run->getStatus());
+        self::assertNull($run->getFinishedAt());
+        self::assertNull($run->getLastErrorMessage());
+        self::assertNull($run->getSummary());
+        self::assertNull($run->getDetails());
+    }
+
+    public function testResetForRetryThrowsWhenNotFailed(): void
+    {
+        $run = MarketplaceRawProcessingRunBuilder::aRun()->build();
+        // run is RUNNING, not FAILED
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('Only FAILED runs can be reset for retry.');
+
+        $run->resetForRetry();
+    }
+
+    public function testResetForRetryThrowsWhenCompleted(): void
+    {
+        $run = MarketplaceRawProcessingRunBuilder::aRun()->build();
+        $run->markCompleted();
+
+        $this->expectException(\DomainException::class);
+
+        $run->resetForRetry();
+    }
+
+    public function testIsTerminalForCompletedAndFailed(): void
+    {
+        $runCompleted = MarketplaceRawProcessingRunBuilder::aRun()->build();
+        $runCompleted->markCompleted();
+
+        $runFailed = MarketplaceRawProcessingRunBuilder::aRun()->build();
+        $runFailed->markFailed('error');
+
+        $runRunning = MarketplaceRawProcessingRunBuilder::aRun()->build();
+
+        self::assertTrue($runCompleted->getStatus()->isTerminal());
+        self::assertTrue($runFailed->getStatus()->isTerminal());
+        self::assertFalse($runRunning->getStatus()->isTerminal());
+    }
+}

--- a/site/tests/Unit/Marketplace/Entity/MarketplaceRawProcessingStepRunTest.php
+++ b/site/tests/Unit/Marketplace/Entity/MarketplaceRawProcessingStepRunTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Entity;
+
+use App\Marketplace\Enum\PipelineStatus;
+use App\Marketplace\Enum\PipelineStep;
+use App\Tests\Builders\Marketplace\MarketplaceRawProcessingStepRunBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class MarketplaceRawProcessingStepRunTest extends TestCase
+{
+    public function testInitialStatusIsPending(): void
+    {
+        $step = MarketplaceRawProcessingStepRunBuilder::aStepRun()->build();
+
+        self::assertSame(PipelineStatus::PENDING, $step->getStatus());
+        self::assertNull($step->getStartedAt());
+        self::assertNull($step->getFinishedAt());
+        self::assertSame(0, $step->getProcessedCount());
+    }
+
+    public function testMarkRunning(): void
+    {
+        $step = MarketplaceRawProcessingStepRunBuilder::aStepRun()->build();
+        $step->markRunning();
+
+        self::assertSame(PipelineStatus::RUNNING, $step->getStatus());
+        self::assertNotNull($step->getStartedAt());
+    }
+
+    public function testMarkRunningThrowsWhenTerminal(): void
+    {
+        $step = MarketplaceRawProcessingStepRunBuilder::aStepRun()->build();
+        $step->markRunning();
+        $step->markCompleted(5, 0, 0);
+
+        $this->expectException(\DomainException::class);
+        $step->markRunning();
+    }
+
+    public function testMarkCompleted(): void
+    {
+        $step = MarketplaceRawProcessingStepRunBuilder::aStepRun()->build();
+        $step->markRunning();
+        $step->markCompleted(10, 2, 1, ['sale_id' => 'x'], ['details']);
+
+        self::assertSame(PipelineStatus::COMPLETED, $step->getStatus());
+        self::assertNotNull($step->getFinishedAt());
+        self::assertSame(10, $step->getProcessedCount());
+        self::assertSame(2, $step->getFailedCount());
+        self::assertSame(1, $step->getSkippedCount());
+        self::assertNull($step->getErrorMessage());
+    }
+
+    public function testMarkFailed(): void
+    {
+        $step = MarketplaceRawProcessingStepRunBuilder::aStepRun()->build();
+        $step->markRunning();
+        $step->markFailed('processor error', 3, 1, 0);
+
+        self::assertSame(PipelineStatus::FAILED, $step->getStatus());
+        self::assertSame('processor error', $step->getErrorMessage());
+        self::assertSame(3, $step->getProcessedCount());
+        self::assertSame(1, $step->getFailedCount());
+    }
+
+    public function testMarkFailedThrowsWhenTerminal(): void
+    {
+        $step = MarketplaceRawProcessingStepRunBuilder::aStepRun()->build();
+        $step->markRunning();
+        $step->markCompleted(5, 0, 0);
+
+        $this->expectException(\DomainException::class);
+        $step->markFailed('late error');
+    }
+
+    public function testResetForRetryResetsToPending(): void
+    {
+        $step = MarketplaceRawProcessingStepRunBuilder::aStepRun()->build();
+        $step->markRunning();
+        $step->markFailed('step error', 3, 1, 0);
+
+        $step->resetForRetry();
+
+        self::assertSame(PipelineStatus::PENDING, $step->getStatus());
+        self::assertNull($step->getStartedAt());
+        self::assertNull($step->getFinishedAt());
+        self::assertNull($step->getErrorMessage());
+        self::assertSame(0, $step->getProcessedCount());
+        self::assertSame(0, $step->getFailedCount());
+        self::assertSame(0, $step->getSkippedCount());
+        self::assertNull($step->getCreatedEntitiesJson());
+        self::assertNull($step->getDetailsJson());
+    }
+
+    public function testResetForRetryThrowsWhenNotFailed(): void
+    {
+        $step = MarketplaceRawProcessingStepRunBuilder::aStepRun()->build();
+        // PENDING, not FAILED
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('Only FAILED step runs can be retried.');
+
+        $step->resetForRetry();
+    }
+
+    public function testResetForRetryThrowsWhenCompleted(): void
+    {
+        $step = MarketplaceRawProcessingStepRunBuilder::aStepRun()->build();
+        $step->markRunning();
+        $step->markCompleted(5, 0, 0);
+
+        $this->expectException(\DomainException::class);
+        $step->resetForRetry();
+    }
+
+    public function testStepAssignment(): void
+    {
+        $step = MarketplaceRawProcessingStepRunBuilder::aStepRun()
+            ->forStep(PipelineStep::RETURNS)
+            ->build();
+
+        self::assertSame(PipelineStep::RETURNS, $step->getStep());
+    }
+}

--- a/site/tests/Unit/Marketplace/MarketplaceLegacyManualProcessingRegressionTest.php
+++ b/site/tests/Unit/Marketplace/MarketplaceLegacyManualProcessingRegressionTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace;
+
+use App\Marketplace\Application\Command\ProcessMarketplaceRawDocumentCommand;
+use App\Marketplace\Application\Command\StartMarketplaceRawProcessingCommand;
+use App\Marketplace\Application\ProcessMarketplaceRawDocumentAction;
+use App\Marketplace\Application\ReprocessMarketplacePeriodAction;
+use App\Marketplace\Application\StartMarketplaceRawProcessingAction;
+use App\Marketplace\Domain\Service\ResolveMarketplaceRawProcessingProfile;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Enum\PipelineStep;
+use App\Marketplace\Enum\PipelineTrigger;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression: проверяет, что:
+ *   1. Ручной reprocess-flow (ReprocessMarketplacePeriodAction) не затронут daily pipeline.
+ *   2. Daily pipeline (StartMarketplaceRawProcessingAction) явно отклоняет realization.
+ *   3. ProfileResolver возвращает ожидаемые профили для каждого типа документа.
+ */
+final class MarketplaceLegacyManualProcessingRegressionTest extends TestCase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-111111111111';
+    private const RAW_DOC_ID = '22222222-2222-2222-2222-222222222222';
+
+    // -------------------------------------------------------------------------
+    // Profile resolver: контракт не изменился
+    // -------------------------------------------------------------------------
+
+    public function testSalesReportProfileHasSalesReturnsAndCostsSteps(): void
+    {
+        $resolver = new ResolveMarketplaceRawProcessingProfile();
+        $profile  = $resolver->resolve(MarketplaceType::WILDBERRIES, 'sales_report');
+
+        self::assertTrue($profile->isDailyPipeline);
+        self::assertCount(3, $profile->requiredSteps);
+        self::assertContains(PipelineStep::SALES, $profile->requiredSteps);
+        self::assertContains(PipelineStep::RETURNS, $profile->requiredSteps);
+        self::assertContains(PipelineStep::COSTS, $profile->requiredSteps);
+    }
+
+    public function testRealizationProfileIsExcludedFromDailyPipeline(): void
+    {
+        $resolver = new ResolveMarketplaceRawProcessingProfile();
+        $profile  = $resolver->resolve(MarketplaceType::OZON, 'realization');
+
+        self::assertFalse($profile->isDailyPipeline);
+        self::assertEmpty($profile->requiredSteps);
+        self::assertNotEmpty($profile->skipReason);
+    }
+
+    // -------------------------------------------------------------------------
+    // Daily pipeline must reject realization documents
+    // -------------------------------------------------------------------------
+
+    public function testDailyPipelineRejectsRealizationDocument(): void
+    {
+        $company = $this->createMock(\App\Company\Entity\Company::class);
+        $company->method('getId')->willReturn(self::COMPANY_ID);
+
+        $doc = $this->createMock(\App\Marketplace\Entity\MarketplaceRawDocument::class);
+        $doc->method('getCompany')->willReturn($company);
+        $doc->method('getDocumentType')->willReturn('realization');
+        $doc->method('getMarketplace')->willReturn(MarketplaceType::OZON);
+        $doc->method('getId')->willReturn(self::RAW_DOC_ID);
+
+        $docRepo = $this->createMock(\App\Marketplace\Repository\MarketplaceRawDocumentRepository::class);
+        $docRepo->method('find')->willReturn($doc);
+
+        $em  = $this->createMock(\Doctrine\ORM\EntityManagerInterface::class);
+        $em->expects($this->never())->method('flush');
+
+        $bus = $this->createMock(\Symfony\Component\Messenger\MessageBusInterface::class);
+        $bus->expects($this->never())->method('dispatch');
+
+        $action = new StartMarketplaceRawProcessingAction(
+            $docRepo,
+            new ResolveMarketplaceRawProcessingProfile(),
+            $em,
+            $bus,
+        );
+
+        $this->expectException(\DomainException::class);
+
+        $action(new StartMarketplaceRawProcessingCommand(
+            self::COMPANY_ID,
+            self::RAW_DOC_ID,
+            PipelineTrigger::MANUAL,
+        ));
+    }
+
+    // -------------------------------------------------------------------------
+    // Legacy ReprocessMarketplacePeriodAction: uses ProcessMarketplaceRawDocumentAction
+    // NOT StartMarketplaceRawProcessingAction — these are separate flows
+    // -------------------------------------------------------------------------
+
+    public function testLegacyReprocessActionDoesNotDependOnDailyPipeline(): void
+    {
+        // ReprocessMarketplacePeriodAction accepts ProcessMarketplaceRawDocumentAction (legacy).
+        // It must not depend on StartMarketplaceRawProcessingAction.
+        $reprocessRef = new \ReflectionClass(ReprocessMarketplacePeriodAction::class);
+        $constructor  = $reprocessRef->getConstructor();
+        $paramTypes   = array_map(
+            fn(\ReflectionParameter $p) => (string) $p->getType(),
+            $constructor->getParameters(),
+        );
+
+        self::assertContains(ProcessMarketplaceRawDocumentAction::class, $paramTypes,
+            'Legacy reprocess action must use ProcessMarketplaceRawDocumentAction');
+
+        self::assertNotContains(StartMarketplaceRawProcessingAction::class, $paramTypes,
+            'Legacy reprocess action must NOT depend on the daily pipeline start action');
+    }
+
+    public function testLegacyReprocessSalesReportCallsThreeStepCommands(): void
+    {
+        $company = $this->createMock(\App\Company\Entity\Company::class);
+        $company->method('getId')->willReturn(self::COMPANY_ID);
+
+        $doc = $this->createMock(\App\Marketplace\Entity\MarketplaceRawDocument::class);
+        $doc->method('getId')->willReturn(self::RAW_DOC_ID);
+        $doc->method('getDocumentType')->willReturn('sales_report');
+        $doc->method('getMarketplace')->willReturn(MarketplaceType::WILDBERRIES);
+
+        $docRepo = $this->createMock(\App\Marketplace\Repository\MarketplaceRawDocumentRepository::class);
+        $docRepo->method('findByCompanyAndPeriod')->willReturn([$doc]);
+
+        $kinds = [];
+        $processAction = $this->createMock(ProcessMarketplaceRawDocumentAction::class);
+        $processAction->method('__invoke')
+            ->willReturnCallback(function (ProcessMarketplaceRawDocumentCommand $cmd) use (&$kinds): int {
+                $kinds[] = $cmd->kind;
+                return 1;
+            });
+
+        $realizationAction = $this->createMock(\App\Marketplace\Application\ProcessOzonRealizationAction::class);
+        $realizationAction->expects($this->never())->method('__invoke');
+
+        $reprocess = new ReprocessMarketplacePeriodAction(
+            $docRepo,
+            $processAction,
+            $realizationAction,
+            new \Psr\Log\NullLogger(),
+        );
+
+        $stats = $reprocess(
+            self::COMPANY_ID,
+            'wildberries',
+            new \DateTimeImmutable('2025-01-01'),
+            new \DateTimeImmutable('2025-01-31'),
+            'sales_report',
+        );
+
+        self::assertSame(['sales', 'returns', 'costs'], $kinds);
+        self::assertSame(1, $stats['docs']);
+        self::assertSame(1, $stats['sales']);
+        self::assertSame(1, $stats['returns']);
+        self::assertSame(1, $stats['costs']);
+        self::assertSame(0, $stats['realization']);
+    }
+
+    public function testLegacyReprocessRealizationCallsRealizationActionNotPipelineSteps(): void
+    {
+        $doc = $this->createMock(\App\Marketplace\Entity\MarketplaceRawDocument::class);
+        $doc->method('getId')->willReturn(self::RAW_DOC_ID);
+        $doc->method('getDocumentType')->willReturn('realization');
+        $doc->method('getMarketplace')->willReturn(MarketplaceType::OZON);
+
+        $docRepo = $this->createMock(\App\Marketplace\Repository\MarketplaceRawDocumentRepository::class);
+        $docRepo->method('findByCompanyAndPeriod')->willReturn([$doc]);
+
+        $processAction = $this->createMock(ProcessMarketplaceRawDocumentAction::class);
+        $processAction->expects($this->never())->method('__invoke');
+
+        $realizationAction = $this->createMock(\App\Marketplace\Application\ProcessOzonRealizationAction::class);
+        $realizationAction->method('__invoke')
+            ->with(self::COMPANY_ID, self::RAW_DOC_ID)
+            ->willReturn(['created' => 3, 'updated' => 1]);
+
+        $reprocess = new ReprocessMarketplacePeriodAction(
+            $docRepo,
+            $processAction,
+            $realizationAction,
+            new \Psr\Log\NullLogger(),
+        );
+
+        $stats = $reprocess(
+            self::COMPANY_ID,
+            'ozon',
+            new \DateTimeImmutable('2025-01-01'),
+            new \DateTimeImmutable('2025-01-31'),
+            'realization',
+        );
+
+        self::assertSame(1, $stats['docs']);
+        self::assertSame(4, $stats['realization']); // 3 created + 1 updated
+        self::assertSame(0, $stats['sales']);
+    }
+}


### PR DESCRIPTION
## Summary

- Builders: `MarketplaceRawProcessingRunBuilder`, `MarketplaceRawProcessingStepRunBuilder`
- Entity guard tests: `MarketplaceRawProcessingRunTest`, `MarketplaceRawProcessingStepRunTest` — полное покрытие state-machine
- Domain service: `ResolveMarketplaceRawProcessingProfileTest` — sales_report → 3 шага; realization + unknown → outsideDailyFlow
- Action tests: Start, RunStep, Finalize, Retry — happy-path + все guard-ветки
- `MarketplacePipelineAutoStarterTest` — best-effort, дедупликация активного run
- `MarketplaceLegacyManualProcessingRegressionTest` — регрессия: legacy flow не зависит от daily pipeline, realization исключена

## Test plan

- [ ] `make site-test-unit` — все тесты в `tests/Unit/` проходят
- [ ] Убедиться что `tests/Unit/Marketplace/` содержит 11 новых файлов
- [ ] Проверить что legacy `ReprocessMarketplacePeriodAction` не сломан

https://claude.ai/code/session_01CXxMtBDyMhgK7qsWqtx99f