### PR TITLE
fix: null out orphaned category_id before recreating FK

### DIFF
--- a/site/migrations/Version20260406000001.php
+++ b/site/migrations/Version20260406000001.php
@@ -53,8 +53,6 @@ final class Version20260406000001 extends AbstractMigration
                 NOT DEFERRABLE INITIALLY IMMEDIATE
         SQL);
 
-        // Delete orphaned costs where category was removed via ON DELETE SET NULL
-        $this->addSql('DELETE FROM marketplace_costs WHERE category_id IS NULL');
         $this->addSql('ALTER TABLE marketplace_costs ALTER COLUMN category_id SET NOT NULL');
     }
 }

--- a/site/migrations/Version20260406000001.php
+++ b/site/migrations/Version20260406000001.php
@@ -16,9 +16,17 @@ final class Version20260406000001 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $this->addSql('ALTER TABLE marketplace_costs DROP CONSTRAINT IF EXISTS FK_COST_CATEGORY');
         $this->addSql('ALTER TABLE marketplace_costs ALTER COLUMN category_id DROP NOT NULL');
 
-        $this->addSql('ALTER TABLE marketplace_costs DROP CONSTRAINT IF EXISTS FK_COST_CATEGORY');
+        // Null out orphaned category_id references before creating the new FK
+        $this->addSql(<<<'SQL'
+            UPDATE marketplace_costs
+            SET category_id = NULL
+            WHERE category_id IS NOT NULL
+              AND category_id NOT IN (SELECT id FROM marketplace_cost_categories)
+        SQL);
+
         $this->addSql(<<<'SQL'
             ALTER TABLE marketplace_costs
                 ADD CONSTRAINT FK_COST_CATEGORY
@@ -32,16 +40,19 @@ final class Version20260406000001 extends AbstractMigration
     public function down(Schema $schema): void
     {
         $this->addSql('ALTER TABLE marketplace_costs DROP CONSTRAINT IF EXISTS FK_COST_CATEGORY');
+
+        // Delete orphaned costs where category was removed via ON DELETE SET NULL
+        $this->addSql('DELETE FROM marketplace_costs WHERE category_id IS NULL');
+
         $this->addSql(<<<'SQL'
             ALTER TABLE marketplace_costs
                 ADD CONSTRAINT FK_COST_CATEGORY
                 FOREIGN KEY (category_id)
                 REFERENCES marketplace_cost_categories (id)
+                ON DELETE RESTRICT
                 NOT DEFERRABLE INITIALLY IMMEDIATE
         SQL);
 
-        // Delete orphaned costs where category was removed via ON DELETE SET NULL
-        $this->addSql('DELETE FROM marketplace_costs WHERE category_id IS NULL');
         $this->addSql('ALTER TABLE marketplace_costs ALTER COLUMN category_id SET NOT NULL');
     }
 }

--- a/site/migrations/Version20260406000001.php
+++ b/site/migrations/Version20260406000001.php
@@ -53,6 +53,8 @@ final class Version20260406000001 extends AbstractMigration
                 NOT DEFERRABLE INITIALLY IMMEDIATE
         SQL);
 
+        // Delete orphaned costs where category was removed via ON DELETE SET NULL
+        $this->addSql('DELETE FROM marketplace_costs WHERE category_id IS NULL');
         $this->addSql('ALTER TABLE marketplace_costs ALTER COLUMN category_id SET NOT NULL');
     }
 }


### PR DESCRIPTION
## Summary
- Migration `Version20260406000001` failed on deploy: existing `marketplace_costs` rows reference deleted `marketplace_cost_categories` (`category_id = 0d13f0c3-...` not present)
- Fix: drop old FK first, then `UPDATE ... SET category_id = NULL` for orphaned references, then create new FK with `ON DELETE SET NULL`

## Test plan
- [ ] Run `doctrine:migrations:migrate` — migration passes without FK violation
- [ ] Verify orphaned costs now have `category_id = NULL`
- [ ] `/marketplace/costs` page renders correctly, showing "—" for costs without category

https://claude.ai/code/session_01JaiX6pY24Js9FekN1jEZ4B