### PR TITLE
feat(marketplace): WB daily sync — period changed to yesterday only

### DIFF
--- a/site/src/Marketplace/Command/MarketplaceNightlySyncCommand.php
+++ b/site/src/Marketplace/Command/MarketplaceNightlySyncCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
- * Ежедневная загрузка сырых данных WB за последние 7 дней.
+ * Ежедневная загрузка сырых данных WB за предыдущий день.
  *
  * Cron: 0 3 * * * php bin/console app:marketplace:wb-daily-sync
  *
@@ -26,7 +26,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
  */
 #[AsCommand(
     name: 'app:marketplace:wb-daily-sync',
-    description: 'Ежедневная загрузка сырых данных WB за последние 7 дней',
+    description: 'Ежедневная загрузка сырых данных WB за предыдущий день',
 )]
 final class MarketplaceNightlySyncCommand extends Command
 {

--- a/site/src/Marketplace/MessageHandler/SyncWbReportHandler.php
+++ b/site/src/Marketplace/MessageHandler/SyncWbReportHandler.php
@@ -17,13 +17,12 @@ use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 /**
- * Загружает сырые данные WB за последние 7 дней и сохраняет MarketplaceRawDocument.
+ * Загружает сырые данные WB за предыдущий день и сохраняет MarketplaceRawDocument.
  * Без обработки продаж/возвратов/затрат — только загрузка.
  */
 #[AsMessageHandler]
 final class SyncWbReportHandler
 {
-    private const SYNC_PERIOD_DAYS = 7;
     private const LOCK_TTL_SECONDS = 600;
 
     public function __construct(
@@ -86,9 +85,10 @@ final class SyncWbReportHandler
         $this->em->flush();
 
         try {
-            $adapter  = $this->adapterRegistry->get(MarketplaceType::WILDBERRIES);
-            $fromDate = new \DateTimeImmutable(sprintf('-%d days', self::SYNC_PERIOD_DAYS));
-            $toDate   = new \DateTimeImmutable();
+            $adapter   = $this->adapterRegistry->get(MarketplaceType::WILDBERRIES);
+            $yesterday = new \DateTimeImmutable('yesterday');
+            $fromDate  = $yesterday->setTime(0, 0, 0);
+            $toDate    = $yesterday->setTime(23, 59, 59);
 
             $rawData = $adapter->fetchRawReport($company, $fromDate, $toDate);
 


### PR DESCRIPTION
## Summary

- Заменён 7-дневный скользящий период на фиксированный вчерашний день (00:00:00–23:59:59)
- Удалена константа `SYNC_PERIOD_DAYS = 7` из `SyncWbReportHandler`
- Обновлены docblock и `description` команды `MarketplaceNightlySyncCommand`

## Changes

**`SyncWbReportHandler.php`**
```php
// БЫЛО
private const SYNC_PERIOD_DAYS = 7;
$fromDate = new \DateTimeImmutable(sprintf('-%d days', self::SYNC_PERIOD_DAYS));
$toDate   = new \DateTimeImmutable();

// СТАЛО
$yesterday = new \DateTimeImmutable('yesterday');
$fromDate  = $yesterday->setTime(0, 0, 0);
$toDate    = $yesterday->setTime(23, 59, 59);
```

## Test plan

- [ ] Запустить `app:marketplace:wb-daily-sync` вручную и убедиться, что в логах период = вчерашний день
- [ ] Проверить, что `MarketplaceRawDocument.periodFrom` и `periodTo` совпадают с вчерашней датой

https://claude.ai/code/session_011MczU7g63qLPnZYdEU2MaZ