### PR TITLE
feat(Marketplace): week partition service + sync handlers

### DIFF
--- a/site/src/Marketplace/MessageHandler/InitialSyncHandler.php
+++ b/site/src/Marketplace/MessageHandler/InitialSyncHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Marketplace\MessageHandler;
 
 use App\Company\Entity\Company;
+use App\Marketplace\Application\Service\MarketplaceWeekPartitionService;
 use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Entity\MarketplaceRawDocument;
 use App\Marketplace\Enum\MarketplaceType;
@@ -31,6 +32,7 @@ final class InitialSyncHandler
         private readonly MarketplaceAdapterRegistry $adapterRegistry,
         private readonly MessageBusInterface $messageBus,
         private readonly LoggerInterface $logger,
+        private readonly MarketplaceWeekPartitionService $partitionService,
     ) {
     }
 
@@ -56,7 +58,7 @@ final class InitialSyncHandler
 
         $marketplace = MarketplaceType::from($message->marketplace);
         $fromDate    = new \DateTimeImmutable($message->dateFrom);
-        $toDate      = new \DateTimeImmutable($message->dateTo . ' 23:59:59');
+        $toDate      = new \DateTimeImmutable($message->dateTo);
 
         try {
             $adapter = $this->adapterRegistry->get($marketplace);
@@ -97,16 +99,21 @@ final class InitialSyncHandler
             // Диспатчим следующую партию если она есть
             if ($message->nextDateFrom !== null && $message->nextDateTo !== null) {
                 // Вычисляем партию после следующей чтобы передать её в nextDate
-                $nextFrom   = new \DateTimeImmutable($message->nextDateFrom);
-                $afterFrom  = $nextFrom->modify('+7 days');
-                $afterTo    = $afterFrom->modify('+6 days');
                 $today      = new \DateTimeImmutable('today');
+                $nextFrom   = new \DateTimeImmutable($message->nextDateFrom);
+                // Следующее воскресенье или сегодня
+                $nextSunday = $nextFrom->modify('sunday this week');
+                $nextTo     = $nextSunday > $today ? $today : $nextSunday;
 
-                $hasAfter       = $afterFrom <= $today;
-                $afterFromStr   = $hasAfter ? $afterFrom->format('Y-m-d') : null;
-                $afterToStr     = $hasAfter
-                    ? ($afterTo > $today ? $today->format('Y-m-d') : $afterTo->format('Y-m-d'))
-                    : null;
+                // Партия после следующей — через сервис
+                $afterStart      = $nextTo->modify('+1 day')->setTime(0, 0, 0);
+                $hasAfter        = $afterStart <= $today;
+                $afterPartitions = $hasAfter
+                    ? $this->partitionService->buildPartitions($afterStart, $today)
+                    : [];
+
+                $afterFromStr = !empty($afterPartitions) ? $afterPartitions[0]['from'] : null;
+                $afterToStr   = !empty($afterPartitions) ? $afterPartitions[0]['to']   : null;
 
                 $this->messageBus->dispatch(new InitialSyncMessage(
                     companyId:    $message->companyId,

--- a/site/src/Marketplace/MessageHandler/SyncWbReportHandler.php
+++ b/site/src/Marketplace/MessageHandler/SyncWbReportHandler.php
@@ -86,7 +86,8 @@ final class SyncWbReportHandler
 
         try {
             $adapter   = $this->adapterRegistry->get(MarketplaceType::WILDBERRIES);
-            $yesterday = new \DateTimeImmutable('yesterday');
+            $msk       = new \DateTimeZone('Europe/Moscow');
+            $yesterday = new \DateTimeImmutable('yesterday', $msk);
             $fromDate  = $yesterday->setTime(0, 0, 0);
             $toDate    = $yesterday->setTime(23, 59, 59);
 

--- a/site/src/Marketplace/MessageHandler/TriggerInitialSyncHandler.php
+++ b/site/src/Marketplace/MessageHandler/TriggerInitialSyncHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Marketplace\MessageHandler;
 
+use App\Marketplace\Application\Service\MarketplaceWeekPartitionService;
 use App\Marketplace\Message\InitialSyncMessage;
 use App\Marketplace\Message\TriggerInitialSyncMessage;
 use Psr\Log\LoggerInterface;
@@ -11,12 +12,10 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
- * Нарезает текущий год на недельные партии Пн–Вс и диспатчит первую.
+ * Нарезает текущий год на недельные партии с учётом границ месяца и диспатчит первую.
  * Каждая следующая партия диспатчится из InitialSyncHandler после успеха предыдущей.
  *
- * Правило первой партии:
- * - Берём 01.01 текущего года
- * - Если это не Пн — откатываемся до ближайшего предыдущего Пн (захватываем конец прошлого года)
+ * Период: 01.01 текущего года → сегодня (с времени 00:00:00 → 23:59:59).
  */
 #[AsMessageHandler]
 final class TriggerInitialSyncHandler
@@ -24,12 +23,15 @@ final class TriggerInitialSyncHandler
     public function __construct(
         private readonly MessageBusInterface $messageBus,
         private readonly LoggerInterface $logger,
+        private readonly MarketplaceWeekPartitionService $partitionService,
     ) {
     }
 
     public function __invoke(TriggerInitialSyncMessage $message): void
     {
-        $weeks = $this->buildWeeks();
+        $today = new \DateTimeImmutable('today');
+        $yearStart = new \DateTimeImmutable((int) $today->format('Y') . '-01-01 00:00:00');
+        $weeks = $this->partitionService->buildPartitions($yearStart, $today);
 
         if (empty($weeks)) {
             $this->logger->warning('InitialSync: no weeks to sync', [
@@ -63,40 +65,4 @@ final class TriggerInitialSyncHandler
         ]);
     }
 
-    /**
-     * Строит список недельных партий от первого Пн ≤ 01.01 до сегодня.
-     *
-     * @return array<int, array{from: string, to: string}>
-     */
-    private function buildWeeks(): array
-    {
-        $today = new \DateTimeImmutable('today');
-        $yearStart = new \DateTimeImmutable((int) $today->format('Y') . '-01-01');
-
-        // Откатываемся до ближайшего предыдущего Пн (или оставляем если уже Пн)
-        $dayOfWeek = (int) $yearStart->format('N'); // 1=Пн, 7=Вс
-        $firstMonday = $dayOfWeek === 1
-            ? $yearStart
-            : $yearStart->modify('-' . ($dayOfWeek - 1) . ' days');
-
-        $weeks  = [];
-        $monday = $firstMonday;
-
-        while ($monday <= $today) {
-            $sunday = $monday->modify('+6 days'); // Вс
-
-            // Последняя партия — до сегодня если неделя неполная
-            $partitionEnd = $sunday > $today ? $today : $sunday;
-
-            $weeks[] = [
-                'from' => $monday->format('Y-m-d'),
-                'to'   => $partitionEnd->format('Y-m-d'),
-            ];
-
-            // Следующий Пн
-            $monday = $monday->modify('+7 days');
-        }
-
-        return $weeks;
-    }
 }

--- a/site/tests/Unit/Marketplace/Application/Service/MarketplaceWeekPartitionServiceTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/MarketplaceWeekPartitionServiceTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Application\Service;
+
+use App\Marketplace\Application\Service\MarketplaceWeekPartitionService;
+use PHPUnit\Framework\TestCase;
+
+final class MarketplaceWeekPartitionServiceTest extends TestCase
+{
+    private MarketplaceWeekPartitionService $service;
+
+    protected function setUp(): void
+    {
+        $this->service = new MarketplaceWeekPartitionService();
+    }
+
+    /**
+     * from=2026-01-01 (чт) → первая партия до ближайшего Вс (04.01), без отката до Пн.
+     */
+    public function testFirstPartitionStartsOnJanFirst(): void
+    {
+        $partitions = $this->service->buildPartitions(
+            new \DateTimeImmutable('2026-01-01'),
+            new \DateTimeImmutable('2026-01-11'),
+        );
+
+        self::assertSame('2026-01-01 00:00:00', $partitions[0]['from']);
+        self::assertSame('2026-01-04 23:59:59', $partitions[0]['to']);
+
+        self::assertSame('2026-01-05 00:00:00', $partitions[1]['from']);
+        self::assertSame('2026-01-11 23:59:59', $partitions[1]['to']);
+    }
+
+    /**
+     * Полная неделя Пн–Вс без пересечения границы месяца → одна партия.
+     */
+    public function testFullWeekNoMonthBoundary(): void
+    {
+        $partitions = $this->service->buildPartitions(
+            new \DateTimeImmutable('2026-01-05'),
+            new \DateTimeImmutable('2026-01-11'),
+        );
+
+        self::assertCount(1, $partitions);
+        self::assertSame('2026-01-05 00:00:00', $partitions[0]['from']);
+        self::assertSame('2026-01-11 23:59:59', $partitions[0]['to']);
+    }
+
+    /**
+     * Неделя 30.03–05.04 пересекает границу месяца → разбивается на две партии.
+     */
+    public function testMonthBoundarySplitsWeek(): void
+    {
+        $partitions = $this->service->buildPartitions(
+            new \DateTimeImmutable('2026-03-30'),
+            new \DateTimeImmutable('2026-04-05'),
+        );
+
+        self::assertCount(2, $partitions);
+
+        self::assertSame('2026-03-30 00:00:00', $partitions[0]['from']);
+        self::assertSame('2026-03-31 23:59:59', $partitions[0]['to']);
+
+        self::assertSame('2026-04-01 00:00:00', $partitions[1]['from']);
+        self::assertSame('2026-04-05 23:59:59', $partitions[1]['to']);
+    }
+
+    /**
+     * Неполная неделя обрезается до $to, не выходит за его пределы.
+     */
+    public function testLastPartitionClampedToTo(): void
+    {
+        // from=2026-01-05 (Пн), to=2026-01-08 (Чт) — неполная неделя
+        $partitions = $this->service->buildPartitions(
+            new \DateTimeImmutable('2026-01-05'),
+            new \DateTimeImmutable('2026-01-08'),
+        );
+
+        self::assertCount(1, $partitions);
+        self::assertSame('2026-01-05 00:00:00', $partitions[0]['from']);
+        self::assertSame('2026-01-08 23:59:59', $partitions[0]['to']);
+    }
+
+    /**
+     * $from > $to → пустой массив.
+     */
+    public function testEmptyWhenFromAfterTo(): void
+    {
+        $partitions = $this->service->buildPartitions(
+            new \DateTimeImmutable('2026-01-10'),
+            new \DateTimeImmutable('2026-01-05'),
+        );
+
+        self::assertSame([], $partitions);
+    }
+
+    /**
+     * $from == $to → одна партия из одного дня.
+     */
+    public function testSingleDayPartition(): void
+    {
+        $partitions = $this->service->buildPartitions(
+            new \DateTimeImmutable('2026-01-07'),
+            new \DateTimeImmutable('2026-01-07'),
+        );
+
+        self::assertCount(1, $partitions);
+        self::assertSame('2026-01-07 00:00:00', $partitions[0]['from']);
+        self::assertSame('2026-01-07 23:59:59', $partitions[0]['to']);
+    }
+}


### PR DESCRIPTION
## Summary

- **Задача #1:** Новый сервис `MarketplaceWeekPartitionService` — нарезка периода на недельные партии с учётом границ месяца
- **Задача #2:** Фикс timezone в `SyncWbReportHandler` — использует `Europe/Moscow` как `SyncOzonReportHandler`
- **Задача #3:** Рефакторинг `TriggerInitialSyncHandler` — заменен `buildWeeks()` на `MarketplaceWeekPartitionService`

## Детали

### MarketplaceWeekPartitionService
- `final readonly class`, без зависимостей — чистая логика дат
- `buildPartitions(DateTimeImmutable $from, DateTimeImmutable $to): array`
- Возвращает `array of ['from' => 'Y-m-d H:i:s', 'to' => 'Y-m-d H:i:s']`
  - `from` → `00:00:00`, `to` → `23:59:59`
- Разбивает периоды на недельные партии (Пн–Вс), учитывая границы месяца
- Timezone-safe через `modify('last day of this month')`

### SyncWbReportHandler
- Теперь явно использует `DateTimeZone('Europe/Moscow')` при создании дат
- Согласовано с `SyncOzonReportHandler`
- Фиксит ошибку "вчера" в UTC-контексте до 03:00 MSK

### TriggerInitialSyncHandler
- Заменён приватный `buildWeeks()` (35 строк) на вызов `MarketplaceWeekPartitionService`
- Упростил код, избежал дублирования логики
- Поведение: начинает с `01.01` текущего года (раньше откатывался до первого Пн)

## Test plan

- [ ] `MarketplaceWeekPartitionService`: примеры из задачи (01.01–15.01, 30.03–05.04)
- [ ] `SyncWbReportHandler`: WB-синк в Docker корректно определяет "вчера" по MSK
- [ ] `TriggerInitialSyncHandler`: логирует корректные батчи за год

https://claude.ai/code/session_01KZDF4YxQtZc4ZoPVK5hmNd