### PR TITLE
feat(Marketplace): add brand_commission and correction mappings to OzonServiceCategoryMap

### DIFF
--- a/site/src/Admin/Controller/DiagnosticController.php
+++ b/site/src/Admin/Controller/DiagnosticController.php
@@ -197,6 +197,30 @@ final class DiagnosticController extends AbstractController
         return new JsonResponse($rows);
     }
 
+    #[Route('/ozon-unknown-services', name: 'ozon_unknown_services', methods: ['GET'])]
+    public function ozonUnknownServices(Connection $connection): JsonResponse
+    {
+        $rows = $connection->fetchAllAssociative(
+            <<<'SQL'
+            SELECT
+                mc.description,
+                COUNT(*)        AS cnt,
+                SUM(mc.amount)  AS total_amount,
+                MIN(mc.cost_date)::text AS first_seen,
+                MAX(mc.cost_date)::text AS last_seen
+            FROM marketplace_costs mc
+            JOIN marketplace_cost_categories mcc ON mcc.id = mc.category_id
+            WHERE mcc.code      = 'ozon_other_service'
+              AND mc.marketplace = 'ozon'
+            GROUP BY mc.description
+            ORDER BY cnt DESC
+            LIMIT 50
+            SQL,
+        );
+
+        return new JsonResponse($rows);
+    }
+
     #[Route('/delete-wb-costs-no-listing/{companyId}', name: 'delete_wb_costs_no_listing', methods: ['GET'], requirements: ['companyId' => '[0-9a-f-]{36}'])]
     public function deleteWbCostsNoListing(string $companyId, Request $request, Connection $connection): JsonResponse
     {

--- a/site/src/Marketplace/Application/Processor/OzonServiceCategoryMap.php
+++ b/site/src/Marketplace/Application/Processor/OzonServiceCategoryMap.php
@@ -26,7 +26,7 @@ final class OzonServiceCategoryMap
      * Версия словаря — обновлять при любом изменении маппинга.
      * Используется в /marketplace/costs/debug/map-version для проверки деплоя.
      */
-    public const VERSION = '2026-03-23.6';
+    public const VERSION = '2026-04-08.1';
 
     /**
      * @var array<string, string|null>
@@ -105,6 +105,9 @@ final class OzonServiceCategoryMap
         // === ШТРАФЫ / УДЕРЖАНИЯ ===
         'OperationMarketplaceWithHoldingForUndeliverableGoods'   => 'ozon_penalty_undeliverable',
 
+        // === КОМИССИИ ===
+        'MarketplaceServiceBrandCommission'                      => 'ozon_brand_commission',
+
         // === ПРОЧЕЕ ===
         'MarketplaceServiceItemMarkingItems'                     => 'ozon_marking',
         'MarketplaceServiceItemReturnFromStock'                  => 'ozon_return_from_stock',
@@ -139,6 +142,8 @@ final class OzonServiceCategoryMap
         'Обработка операционных ошибок продавца: отгрузка в нерекомендованный слот' => 'ozon_penalty_undeliverable',
         'Обработка брака с приемки'                              => 'ozon_supply_additional',
         'Временное размещение товара партнерами'                  => 'ozon_storage_partner',
+        'Корректировка суммы акта о премии'                      => 'ozon_premium_correction',
+        'Корректировки стоимости услуг'                          => 'ozon_service_correction',
     ];
 
     /**
@@ -265,6 +270,9 @@ final class OzonServiceCategoryMap
             'ozon_return_from_stock'     => 'Комплектация для вывоза продавцом Ozon',
             'ozon_agency_fee'            => 'Агентская услуга 3PL Global Ozon',
             'ozon_disposal'              => 'Утилизация товара Ozon',
+            'ozon_brand_commission'      => 'Брендовая комиссия Ozon',
+            'ozon_premium_correction'    => 'Корректировка премии Ozon',
+            'ozon_service_correction'    => 'Корректировка стоимости услуг Ozon',
             default                      => 'Прочие услуги Ozon',
         };
     }


### PR DESCRIPTION
## Summary

Добавлены три новых маппинга в `OzonServiceCategoryMap`:

| Service name | Category code | Название |
|---|---|---|
| `MarketplaceServiceBrandCommission` | `ozon_brand_commission` | Брендовая комиссия Ozon |
| `Корректировка суммы акта о премии` | `ozon_premium_correction` | Корректировка премии Ozon |
| `Корректировки стоимости услуг` | `ozon_service_correction` | Корректировка стоимости услуг Ozon |

- VERSION: `2026-03-23.6` → `2026-04-08.1`

## Test plan

- [ ] После переобработки затрат за затронутые периоды — `ozon_other_service` не содержит эти три service names
- [ ] `GET /marketplace/costs/debug/map-version` возвращает `2026-04-08.1`