### PR TITLE
fix(Marketplace): fix dead code in resolveServiceCategoryCode

### DIFF
--- a/site/src/Marketplace/Application/Processor/OzonCostsRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonCostsRawProcessor.php
@@ -393,9 +393,7 @@ final class OzonCostsRawProcessor implements MarketplaceRawProcessorInterface
 
     private function resolveServiceCategoryCode(string $serviceName, ?array $rawOp = null): string
     {
-        $code = OzonServiceCategoryMap::resolve($serviceName, $this->logger);
-
-        if ($code === null) {
+        if (!OzonServiceCategoryMap::isKnown($serviceName) && !OzonServiceCategoryMap::isZeroMarker($serviceName)) {
             // Неизвестный service_name — логируем для мониторинга в админке
             $this->mappingErrorLogger->log(
                 companyId:     $this->currentCompanyId,
@@ -407,11 +405,11 @@ final class OzonCostsRawProcessor implements MarketplaceRawProcessorInterface
                 amount:        abs((float) ($rawOp['amount'] ?? 0)),
                 sampleRaw:     $rawOp,
             );
-
-            return 'ozon_other_service';
         }
 
-        return $code;
+        $code = OzonServiceCategoryMap::resolve($serviceName, $this->logger);
+
+        return $code ?? 'ozon_other_service';
     }
 
     private function resolveCategoryName(string $categoryCode): string


### PR DESCRIPTION
## Summary

Исправлен мёртвый код в `OzonCostsRawProcessor::resolveServiceCategoryCode()`.

### Было (баг)

`MappingErrorLogger::log()` вызывался только когда `resolve()` возвращал `null`.  
Но `resolve()` возвращает `null` **только для нулевых маркеров** (значение `null` в MAP).  
Нулевые маркеры при этом уже отфильтровываются ранее через `isZeroMarker()` → `continue`.  
Итог: `MappingErrorLogger` **никогда не вызывался**.

### Стало (fix)

Логирование происходит **до** вызова `resolve()`, используя `isKnown()` + `isZeroMarker()`:
- не в MAP и не нулевой маркер → логируем как неизвестный
- нулевой маркер → тихо пропускаем (уже обработан выше в стеке)
- известный → логирование не нужно

```php
if (!OzonServiceCategoryMap::isKnown($serviceName) && !OzonServiceCategoryMap::isZeroMarker($serviceName)) {
    $this->mappingErrorLogger->log(...);
}
$code = OzonServiceCategoryMap::resolve($serviceName, $this->logger);
return $code ?? 'ozon_other_service';
```

https://claude.ai/code/session_016BQ1soVTTXUjqNt8S4T5NV