### PR TITLE
feat(Marketplace): render preflight details in UI for costs_without_mapping

### DIFF
--- a/site/src/Marketplace/Application/DTO/PreflightCheck.php
+++ b/site/src/Marketplace/Application/DTO/PreflightCheck.php
@@ -16,6 +16,7 @@ final class PreflightCheck
         public readonly bool   $blocking,   // true — блокирует закрытие
         public readonly string $message,
         public readonly mixed  $value = null, // дополнительные данные (счётчик и т.п.)
+        public readonly array  $details = [], // структурированные данные для UI (список элементов и т.п.)
     ) {
     }
 
@@ -24,9 +25,9 @@ final class PreflightCheck
         return new self($key, $label, passed: true, blocking: false, message: $message, value: $value);
     }
 
-    public static function warning(string $key, string $label, string $message, mixed $value = null): self
+    public static function warning(string $key, string $label, string $message, mixed $value = null, array $details = []): self
     {
-        return new self($key, $label, passed: false, blocking: false, message: $message, value: $value);
+        return new self($key, $label, passed: false, blocking: false, message: $message, value: $value, details: $details);
     }
 
     public static function error(string $key, string $label, string $message, mixed $value = null): self

--- a/site/src/Marketplace/Application/DTO/PreflightResult.php
+++ b/site/src/Marketplace/Application/DTO/PreflightResult.php
@@ -64,6 +64,7 @@ final class PreflightResult
                 'blocking' => $c->blocking,
                 'message'  => $c->message,
                 'value'    => $c->value,
+                'details'  => $c->details,
             ],
             $this->checks,
         );

--- a/site/src/Marketplace/Application/MonthClosePreflightAction.php
+++ b/site/src/Marketplace/Application/MonthClosePreflightAction.php
@@ -215,11 +215,15 @@ final class MonthClosePreflightAction
 
         // Проверка 4: затраты без маппинга к ОПиУ (ПРЕДУПРЕЖДЕНИЕ — не блокирует)
         if ($withoutMapping > 0) {
+            $categoriesWithoutMapping = $this->costsQuery->getCategoriesWithoutMapping(
+                $command->companyId, $command->marketplace, $periodFrom, $periodTo,
+            );
             $checks[] = PreflightCheck::warning(
                 'costs_without_mapping',
                 'Маппинг затрат к ОПиУ',
                 sprintf('Затрат без маппинга к ОПиУ: %d шт. Они не попадут в ОПиУ. Настройте маппинг в разделе "Себестоимость".', $withoutMapping),
                 $withoutMapping,
+                details: $categoriesWithoutMapping,
             );
         } else {
             $checks[] = PreflightCheck::ok('costs_without_mapping', 'Маппинг затрат к ОПиУ', 'Все затраты имеют маппинг к ОПиУ');

--- a/site/src/Marketplace/Infrastructure/Query/PreflightCostsQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/PreflightCostsQuery.php
@@ -125,10 +125,11 @@ final class PreflightCostsQuery
                 AND m.company_id = mc.company_id
             WHERE mc.company_id  = :companyId
               AND mc.marketplace = :marketplace
-              AND mc.cost_date BETWEEN :periodFrom AND :periodTo
+              AND mc.cost_date >= :periodFrom
+              AND mc.cost_date <= :periodTo
               AND (m.id IS NULL OR m.pl_category_id IS NULL)
             GROUP BY cc.id, cc.name, cc.code
-            ORDER BY costs_count DESC
+            ORDER BY COUNT(mc.id) DESC
             SQL,
             [
                 'companyId'   => $companyId,

--- a/site/templates/marketplace/month_close/index.html.twig
+++ b/site/templates/marketplace/month_close/index.html.twig
@@ -323,11 +323,20 @@
                         const icon = check.passed
                             ? '<span class="text-success">✓</span>'
                             : (check.blocking ? '<span class="text-danger">✗</span>' : '<span class="text-warning">⚠</span>');
+                        let detailsHtml = '';
+                        if (check.details && check.details.length > 0) {
+                            detailsHtml = '<ul class="mt-1 mb-0 small text-muted">';
+                            check.details.forEach(item => {
+                                detailsHtml += `<li>${item.category_name} (${item.costs_count} шт.)</li>`;
+                            });
+                            detailsHtml += '</ul>';
+                        }
                         html += `<div class="list-group-item px-0 py-2 d-flex gap-2 align-items-start">
                         ${icon}
                         <div>
                             <div class="fw-medium small">${check.label}</div>
                             <div class="text-muted small">${check.message}</div>
+                            ${detailsHtml}
                         </div>
                      </div>`;
                     });


### PR DESCRIPTION
## Summary

- `PreflightResult::toArray()` — добавлен `'details' => $c->details` в сериализацию; поле теперь попадает в JSON-ответ preflight-эндпоинта
- JS в `index.html.twig` — при наличии `check.details` рендерит список категорий без маппинга под сообщением предупреждения `costs_without_mapping`: `<ul>` со строками `category_name (costs_count шт.)`

## Test plan

- [ ] Запустить preflight для этапа COSTS при наличии затрат без маппинга
- [ ] Убедиться, что под предупреждением "Маппинг затрат к ОПиУ" отображается список категорий с количеством затрат
- [ ] Убедиться, что для проверок без `details` (пустой массив) список не рендерится