### PR TITLE
feat: auto-trigger daily pipeline after sales_report sync

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -484,4 +484,4 @@ paths:
 |---|---|---|
 | 1.0 | 2026-03-28 | Инициализация на основе архитектурного документа v1.3 |
 | 1.1 | 2026-03-31 | MarketplaceAnalytics: рефакторинг маппинга затрат — статья фиксированная (UnitEconomyCostType), категория МП выбирается из справочника (marketplace_cost_categories), убраны isSystem и costCategoryCode. Из Facade удалены remapCostMapping, resetCostMapping. |
-| 1.2 | 2026-04-10 | Marketplace: автозапуск daily pipeline после загрузки sales_report. Новый Message `ProcessDayReportMessage` (companyId, marketplace, date) → `ProcessDayReportHandler` диспатчит существующие `ProcessRawDocumentStepMessage` для каждого шага. SyncWb/OzonReportHandler диспатчат `ProcessDayReportMessage` после успешной загрузки. |
+| 1.2 | 2026-04-10 | Marketplace: автозапуск daily pipeline после загрузки sales_report. Новый Message `ProcessDayReportMessage` (companyId, rawDocumentId) → `ProcessDayReportHandler` сбрасывает статус конкретного документа и диспатчит `ProcessRawDocumentStepMessage` для каждого шага. SyncWb/OzonReportHandler диспатчат `ProcessDayReportMessage` после успешной загрузки. |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -484,3 +484,4 @@ paths:
 |---|---|---|
 | 1.0 | 2026-03-28 | Инициализация на основе архитектурного документа v1.3 |
 | 1.1 | 2026-03-31 | MarketplaceAnalytics: рефакторинг маппинга затрат — статья фиксированная (UnitEconomyCostType), категория МП выбирается из справочника (marketplace_cost_categories), убраны isSystem и costCategoryCode. Из Facade удалены remapCostMapping, resetCostMapping. |
+| 1.2 | 2026-04-10 | Marketplace: автозапуск daily pipeline после загрузки sales_report. Новый Message `ProcessDayReportMessage` (companyId, marketplace, date) → `ProcessDayReportHandler` диспатчит существующие `ProcessRawDocumentStepMessage` для каждого шага. SyncWb/OzonReportHandler диспатчат `ProcessDayReportMessage` после успешной загрузки. |

--- a/site/config/packages/messenger.yaml
+++ b/site/config/packages/messenger.yaml
@@ -30,6 +30,7 @@ framework:
             'App\Marketplace\Message\SyncOzonRealizationMessage': async    # ← НОВОЕ
             'App\Marketplace\Message\ImportInventoryCostPriceMessage': async    # ← НОВОЕ
             'App\Marketplace\Message\CloseMonthStageMessage': async    # ← НОВОЕ
+            'App\Marketplace\Message\ProcessDayReportMessage': async
             'App\Marketplace\Message\ProcessRawDocumentStepMessage': async
             'App\Marketplace\Message\ReprocessCostsMessage': async
             'App\Marketplace\Application\Command\FetchMarketplaceDataCommand': async

--- a/site/src/Marketplace/Message/ProcessDayReportMessage.php
+++ b/site/src/Marketplace/Message/ProcessDayReportMessage.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Message;
+
+/**
+ * Автозапуск daily pipeline обработки после загрузки sales_report.
+ *
+ * Диспатчится из SyncWb/OzonReportHandler после успешного сохранения
+ * MarketplaceRawDocument. Handler находит документы за дату и запускает
+ * три шага (sales/returns/costs) через ProcessRawDocumentStepMessage.
+ */
+final readonly class ProcessDayReportMessage
+{
+    public function __construct(
+        public string $companyId,
+        public string $marketplace,
+        public string $date,
+    ) {
+    }
+}

--- a/site/src/Marketplace/Message/ProcessDayReportMessage.php
+++ b/site/src/Marketplace/Message/ProcessDayReportMessage.php
@@ -8,15 +8,14 @@ namespace App\Marketplace\Message;
  * Автозапуск daily pipeline обработки после загрузки sales_report.
  *
  * Диспатчится из SyncWb/OzonReportHandler после успешного сохранения
- * MarketplaceRawDocument. Handler находит документы за дату и запускает
- * три шага (sales/returns/costs) через ProcessRawDocumentStepMessage.
+ * MarketplaceRawDocument. Handler сбрасывает статус конкретного документа
+ * и запускает три шага (sales/returns/costs) через ProcessRawDocumentStepMessage.
  */
 final readonly class ProcessDayReportMessage
 {
     public function __construct(
         public string $companyId,
-        public string $marketplace,
-        public string $date,
+        public string $rawDocumentId,
     ) {
     }
 }

--- a/site/src/Marketplace/MessageHandler/ProcessDayReportHandler.php
+++ b/site/src/Marketplace/MessageHandler/ProcessDayReportHandler.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\MessageHandler;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Enum\PipelineStep;
+use App\Marketplace\Message\ProcessDayReportMessage;
+use App\Marketplace\Message\ProcessRawDocumentStepMessage;
+use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * Запускает daily pipeline (sales/returns/costs) для всех sales_report
+ * документов за указанную дату компании+маркетплейса.
+ *
+ * Идемпотентен: перезапускает pipeline даже если за эту дату уже был запуск.
+ */
+#[AsMessageHandler]
+final class ProcessDayReportHandler
+{
+    public function __construct(
+        private readonly MarketplaceRawDocumentRepository $repository,
+        private readonly MessageBusInterface $bus,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(ProcessDayReportMessage $message): void
+    {
+        $marketplace = MarketplaceType::from($message->marketplace);
+        $date = new \DateTimeImmutable($message->date);
+
+        $documents = $this->repository->findByCompanyAndPeriod(
+            $message->companyId,
+            $marketplace,
+            $date,
+            $date,
+            'sales_report',
+        );
+
+        if ($documents === []) {
+            $this->logger->warning('No sales_report documents found for auto-processing', [
+                'company_id'  => $message->companyId,
+                'marketplace' => $message->marketplace,
+                'date'        => $message->date,
+            ]);
+
+            return;
+        }
+
+        foreach ($documents as $doc) {
+            $doc->resetProcessingStatus();
+        }
+
+        $this->entityManager->flush();
+
+        foreach ($documents as $doc) {
+            foreach (PipelineStep::cases() as $step) {
+                $this->bus->dispatch(new ProcessRawDocumentStepMessage(
+                    rawDocumentId: $doc->getId(),
+                    step: $step->value,
+                    companyId: $message->companyId,
+                ));
+            }
+        }
+
+        $this->logger->info('Auto-dispatched pipeline for day report', [
+            'company_id'      => $message->companyId,
+            'marketplace'     => $message->marketplace,
+            'date'            => $message->date,
+            'documents_count' => count($documents),
+        ]);
+    }
+}

--- a/site/src/Marketplace/MessageHandler/ProcessDayReportHandler.php
+++ b/site/src/Marketplace/MessageHandler/ProcessDayReportHandler.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Marketplace\MessageHandler;
 
-use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Enum\PipelineStep;
 use App\Marketplace\Message\ProcessDayReportMessage;
 use App\Marketplace\Message\ProcessRawDocumentStepMessage;
@@ -12,13 +11,14 @@ use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
- * Запускает daily pipeline (sales/returns/costs) для всех sales_report
- * документов за указанную дату компании+маркетплейса.
+ * Запускает daily pipeline (sales/returns/costs) для конкретного
+ * MarketplaceRawDocument после его загрузки.
  *
- * Идемпотентен: перезапускает pipeline даже если за эту дату уже был запуск.
+ * Идемпотентен: перезапускает pipeline даже если документ уже был обработан.
  */
 #[AsMessageHandler]
 final class ProcessDayReportHandler
@@ -33,48 +33,35 @@ final class ProcessDayReportHandler
 
     public function __invoke(ProcessDayReportMessage $message): void
     {
-        $marketplace = MarketplaceType::from($message->marketplace);
-        $date = new \DateTimeImmutable($message->date, new \DateTimeZone('Europe/Moscow'));
+        $doc = $this->repository->find($message->rawDocumentId);
 
-        $documents = $this->repository->findByCompanyAndPeriod(
-            $message->companyId,
-            $marketplace,
-            $date,
-            $date,
-            'sales_report',
-        );
-
-        if ($documents === []) {
-            $this->logger->warning('No sales_report documents found for auto-processing', [
-                'company_id'  => $message->companyId,
-                'marketplace' => $message->marketplace,
-                'date'        => $message->date,
-            ]);
-
-            return;
+        if ($doc === null) {
+            throw new UnrecoverableMessageHandlingException(
+                sprintf('MarketplaceRawDocument not found: %s', $message->rawDocumentId),
+            );
         }
 
-        foreach ($documents as $doc) {
-            $doc->resetProcessingStatus();
+        if ((string) $doc->getCompany()->getId() !== $message->companyId) {
+            throw new UnrecoverableMessageHandlingException(
+                sprintf('IDOR: document %s does not belong to company %s', $message->rawDocumentId, $message->companyId),
+            );
         }
 
+        $doc->resetProcessingStatus();
         $this->entityManager->flush();
 
-        foreach ($documents as $doc) {
-            foreach (PipelineStep::cases() as $step) {
-                $this->bus->dispatch(new ProcessRawDocumentStepMessage(
-                    rawDocumentId: $doc->getId(),
-                    step: $step->value,
-                    companyId: $message->companyId,
-                ));
-            }
+        foreach (PipelineStep::cases() as $step) {
+            $this->bus->dispatch(new ProcessRawDocumentStepMessage(
+                rawDocumentId: $doc->getId(),
+                step: $step->value,
+                companyId: $message->companyId,
+            ));
         }
 
-        $this->logger->info('Auto-dispatched pipeline for day report', [
+        $this->logger->info('Auto-dispatched pipeline for raw document', [
             'company_id'      => $message->companyId,
-            'marketplace'     => $message->marketplace,
-            'date'            => $message->date,
-            'documents_count' => count($documents),
+            'raw_document_id' => $message->rawDocumentId,
+            'marketplace'     => $doc->getMarketplace()->value,
         ]);
     }
 }

--- a/site/src/Marketplace/MessageHandler/ProcessDayReportHandler.php
+++ b/site/src/Marketplace/MessageHandler/ProcessDayReportHandler.php
@@ -34,7 +34,7 @@ final class ProcessDayReportHandler
     public function __invoke(ProcessDayReportMessage $message): void
     {
         $marketplace = MarketplaceType::from($message->marketplace);
-        $date = new \DateTimeImmutable($message->date);
+        $date = new \DateTimeImmutable($message->date, new \DateTimeZone('Europe/Moscow'));
 
         $documents = $this->repository->findByCompanyAndPeriod(
             $message->companyId,

--- a/site/src/Marketplace/MessageHandler/SyncOzonReportHandler.php
+++ b/site/src/Marketplace/MessageHandler/SyncOzonReportHandler.php
@@ -88,6 +88,8 @@ final class SyncOzonReportHandler
         $connection->markSyncStarted();
         $this->em->flush();
 
+        $rawDocId = null;
+
         try {
             $adapter  = $this->adapterRegistry->get(MarketplaceType::OZON);
             //$fromDate = new \DateTimeImmutable(sprintf('-%d days', self::SYNC_PERIOD_DAYS));
@@ -124,10 +126,12 @@ final class SyncOzonReportHandler
             $this->em->persist($rawDoc);
             $this->em->flush();
 
+            $rawDocId = $rawDoc->getId();
+
             $this->logger->info('Ozon raw report saved', [
                 'company_id'    => $companyId,
                 'connection_id' => $connectionId,
-                'raw_doc_id'    => $rawDoc->getId(),
+                'raw_doc_id'    => $rawDocId,
                 'records_count' => count($rawData),
                 'period'        => $fromDate->format('Y-m-d') . ' - ' . $toDate->format('Y-m-d'),
             ]);
@@ -135,17 +139,6 @@ final class SyncOzonReportHandler
             $connection = $this->em->find(MarketplaceConnection::class, $connectionId);
             $connection->markSyncSuccess();
             $this->em->flush();
-
-            $this->messageBus->dispatch(new ProcessDayReportMessage(
-                companyId: $companyId,
-                marketplace: MarketplaceType::OZON->value,
-                date: $toDate->format('Y-m-d'),
-            ));
-
-            $this->logger->info('Dispatched auto-processing for Ozon day report', [
-                'company_id' => $companyId,
-                'date'       => $toDate->format('Y-m-d'),
-            ]);
         } catch (\Throwable $e) {
             $this->logger->error('Ozon daily sync failed', [
                 'company_id'    => $companyId,
@@ -164,6 +157,26 @@ final class SyncOzonReportHandler
                     'error' => $inner->getMessage(),
                 ]);
             }
+
+            return;
+        }
+
+        try {
+            $this->messageBus->dispatch(new ProcessDayReportMessage(
+                companyId: $companyId,
+                rawDocumentId: $rawDocId,
+            ));
+
+            $this->logger->info('Dispatched auto-processing for Ozon day report', [
+                'company_id'      => $companyId,
+                'raw_document_id' => $rawDocId,
+            ]);
+        } catch (\Throwable $e) {
+            $this->logger->error('Failed to dispatch auto-processing for Ozon', [
+                'company_id'      => $companyId,
+                'raw_document_id' => $rawDocId,
+                'error'           => $e->getMessage(),
+            ]);
         }
     }
 }

--- a/site/src/Marketplace/MessageHandler/SyncOzonReportHandler.php
+++ b/site/src/Marketplace/MessageHandler/SyncOzonReportHandler.php
@@ -8,6 +8,7 @@ use App\Company\Entity\Company;
 use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Entity\MarketplaceRawDocument;
 use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Message\ProcessDayReportMessage;
 use App\Marketplace\Message\SyncOzonReportMessage;
 use App\Marketplace\Service\Integration\MarketplaceAdapterRegistry;
 use Doctrine\ORM\EntityManagerInterface;
@@ -15,10 +16,11 @@ use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
  * Загружает сырые данные Ozon за последние 3 дня и сохраняет MarketplaceRawDocument.
- * Без обработки продаж/возвратов — только загрузка.
+ * После успешной загрузки диспатчит ProcessDayReportMessage для автозапуска pipeline.
  */
 #[AsMessageHandler]
 final class SyncOzonReportHandler
@@ -31,6 +33,7 @@ final class SyncOzonReportHandler
         private readonly MarketplaceAdapterRegistry $adapterRegistry,
         private readonly LockFactory $lockFactory,
         private readonly LoggerInterface $logger,
+        private readonly MessageBusInterface $messageBus,
     ) {
     }
 
@@ -132,6 +135,17 @@ final class SyncOzonReportHandler
             $connection = $this->em->find(MarketplaceConnection::class, $connectionId);
             $connection->markSyncSuccess();
             $this->em->flush();
+
+            $this->messageBus->dispatch(new ProcessDayReportMessage(
+                companyId: $companyId,
+                marketplace: MarketplaceType::OZON->value,
+                date: $toDate->format('Y-m-d'),
+            ));
+
+            $this->logger->info('Dispatched auto-processing for Ozon day report', [
+                'company_id' => $companyId,
+                'date'       => $toDate->format('Y-m-d'),
+            ]);
         } catch (\Throwable $e) {
             $this->logger->error('Ozon daily sync failed', [
                 'company_id'    => $companyId,

--- a/site/src/Marketplace/MessageHandler/SyncWbReportHandler.php
+++ b/site/src/Marketplace/MessageHandler/SyncWbReportHandler.php
@@ -87,6 +87,8 @@ final class SyncWbReportHandler
         $connection->markSyncStarted();
         $this->em->flush();
 
+        $rawDocId = null;
+
         try {
             $adapter   = $this->adapterRegistry->get(MarketplaceType::WILDBERRIES);
             $msk       = new \DateTimeZone('Europe/Moscow');
@@ -122,27 +124,18 @@ final class SyncWbReportHandler
             $this->em->persist($rawDoc);
             $this->em->flush();
 
+            $rawDocId = $rawDoc->getId();
+
             $this->logger->info('WB raw report saved', [
                 'company_id'    => $companyId,
                 'connection_id' => $connectionId,
-                'raw_doc_id'    => $rawDoc->getId(),
+                'raw_doc_id'    => $rawDocId,
                 'records_count' => count($rawData),
                 'period'        => $fromDate->format('Y-m-d') . ' - ' . $toDate->format('Y-m-d'),
             ]);
 
             $connection->markSyncSuccess();
             $this->em->flush();
-
-            $this->messageBus->dispatch(new ProcessDayReportMessage(
-                companyId: $companyId,
-                marketplace: MarketplaceType::WILDBERRIES->value,
-                date: $yesterday->format('Y-m-d'),
-            ));
-
-            $this->logger->info('Dispatched auto-processing for WB day report', [
-                'company_id' => $companyId,
-                'date'       => $yesterday->format('Y-m-d'),
-            ]);
         } catch (\Throwable $e) {
             $this->logger->error('WB daily sync failed', [
                 'company_id'    => $companyId,
@@ -161,6 +154,26 @@ final class SyncWbReportHandler
                     'error' => $inner->getMessage(),
                 ]);
             }
+
+            return;
+        }
+
+        try {
+            $this->messageBus->dispatch(new ProcessDayReportMessage(
+                companyId: $companyId,
+                rawDocumentId: $rawDocId,
+            ));
+
+            $this->logger->info('Dispatched auto-processing for WB day report', [
+                'company_id'     => $companyId,
+                'raw_document_id' => $rawDocId,
+            ]);
+        } catch (\Throwable $e) {
+            $this->logger->error('Failed to dispatch auto-processing for WB', [
+                'company_id'      => $companyId,
+                'raw_document_id' => $rawDocId,
+                'error'           => $e->getMessage(),
+            ]);
         }
     }
 }

--- a/site/src/Marketplace/MessageHandler/SyncWbReportHandler.php
+++ b/site/src/Marketplace/MessageHandler/SyncWbReportHandler.php
@@ -8,6 +8,7 @@ use App\Company\Entity\Company;
 use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Entity\MarketplaceRawDocument;
 use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Message\ProcessDayReportMessage;
 use App\Marketplace\Message\SyncWbReportMessage;
 use App\Marketplace\Service\Integration\MarketplaceAdapterRegistry;
 use Doctrine\ORM\EntityManagerInterface;
@@ -15,10 +16,11 @@ use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
  * Загружает сырые данные WB за предыдущий день и сохраняет MarketplaceRawDocument.
- * Без обработки продаж/возвратов/затрат — только загрузка.
+ * После успешной загрузки диспатчит ProcessDayReportMessage для автозапуска pipeline.
  */
 #[AsMessageHandler]
 final class SyncWbReportHandler
@@ -30,6 +32,7 @@ final class SyncWbReportHandler
         private readonly MarketplaceAdapterRegistry $adapterRegistry,
         private readonly LockFactory $lockFactory,
         private readonly LoggerInterface $logger,
+        private readonly MessageBusInterface $messageBus,
     ) {
     }
 
@@ -129,6 +132,17 @@ final class SyncWbReportHandler
 
             $connection->markSyncSuccess();
             $this->em->flush();
+
+            $this->messageBus->dispatch(new ProcessDayReportMessage(
+                companyId: $companyId,
+                marketplace: MarketplaceType::WILDBERRIES->value,
+                date: $yesterday->format('Y-m-d'),
+            ));
+
+            $this->logger->info('Dispatched auto-processing for WB day report', [
+                'company_id' => $companyId,
+                'date'       => $yesterday->format('Y-m-d'),
+            ]);
         } catch (\Throwable $e) {
             $this->logger->error('WB daily sync failed', [
                 'company_id'    => $companyId,


### PR DESCRIPTION
## Summary

- Новый `ProcessDayReportMessage` + `ProcessDayReportHandler` — связывает загрузку sales_report с запуском существующего daily pipeline (sales/returns/costs)
- `SyncWbReportHandler` и `SyncOzonReportHandler` диспатчат `ProcessDayReportMessage` после успешного сохранения `MarketplaceRawDocument`
- Routing `ProcessDayReportMessage → async` добавлен в `messenger.yaml`

## Что НЕ затронуто

- Существующий pipeline (шаги Sales → Returns → Costs)
- Кнопка «Обработать месяц» (PipelineTrigger::MANUAL)
- Обработка ошибок внутри pipeline
- Существующие Entity и их структура

## Идемпотентность

Pipeline перезапускается через `resetProcessingStatus()` без проверок «уже обработано».

## Цепочка вызовов

```
Cron → SyncHandler → ProcessDayReportMessage (async)
                        → ProcessDayReportHandler
                            → ProcessRawDocumentStepMessage × 3 (async)
                                → ProcessRawDocumentStepMessageHandler
                                    → ProcessMarketplaceRawDocumentAction
```

## Test plan

- [ ] WB sync: после успешной загрузки проверить что `ProcessDayReportMessage` появляется в очереди
- [ ] Ozon sync: аналогично
- [ ] При пустом ответе API (empty rawData) — dispatch НЕ происходит
- [ ] При ошибке загрузки — dispatch НЕ происходит
- [ ] Handler находит raw documents за дату и диспатчит 3 step-сообщения на каждый документ
- [ ] Повторный запуск за ту же дату — pipeline перезапускается без ошибок

https://claude.ai/code/session_011Y8uGxmZtWTyBLypY9TyMi