### PR TITLE
feat(Marketplace): add RunUserReconciliationAction

### DIFF
--- a/site/src/Marketplace/Application/Command/RunUserReconciliationAction.php
+++ b/site/src/Marketplace/Application/Command/RunUserReconciliationAction.php
@@ -42,8 +42,10 @@ final class RunUserReconciliationAction
             $session->markCompleted($reconcileResult);
             $this->em->flush();
         } catch (\Throwable $e) {
-            $session->markFailed(mb_substr($e->getMessage(), 0, 1024));
-            $this->em->flush();
+            if ($session->getStatus()->isPending()) {
+                $session->markFailed(mb_substr($e->getMessage(), 0, 1024));
+                $this->em->flush();
+            }
 
             throw $e;
         }

--- a/site/src/Marketplace/Application/Command/RunUserReconciliationAction.php
+++ b/site/src/Marketplace/Application/Command/RunUserReconciliationAction.php
@@ -7,7 +7,6 @@ namespace App\Marketplace\Application\Command;
 use App\Marketplace\Application\Reconciliation\OzonReportParserFacade;
 use App\Marketplace\Entity\ReconciliationSession;
 use App\Marketplace\Infrastructure\Query\CostReconciliationQuery;
-use App\Marketplace\Repository\ReconciliationSessionRepository;
 use Doctrine\ORM\EntityManagerInterface;
 
 /**
@@ -21,7 +20,6 @@ final class RunUserReconciliationAction
     public function __construct(
         private readonly OzonReportParserFacade $parserFacade,
         private readonly CostReconciliationQuery $reconciliationQuery,
-        private readonly ReconciliationSessionRepository $sessionRepository,
         private readonly EntityManagerInterface $em,
     ) {
     }
@@ -29,7 +27,7 @@ final class RunUserReconciliationAction
     public function __invoke(string $companyId, ReconciliationSession $session): void
     {
         try {
-            $reportResult = $this->parserFacade->parseFromPath(
+            $reportResult = $this->parserFacade->parseFromStoragePath(
                 $session->getStoredFilePath(),
             );
 
@@ -44,7 +42,7 @@ final class RunUserReconciliationAction
             $session->markCompleted($reconcileResult);
             $this->em->flush();
         } catch (\Throwable $e) {
-            $session->markFailed($e->getMessage());
+            $session->markFailed(mb_substr($e->getMessage(), 0, 1024));
             $this->em->flush();
 
             throw $e;

--- a/site/src/Marketplace/Application/Command/RunUserReconciliationAction.php
+++ b/site/src/Marketplace/Application/Command/RunUserReconciliationAction.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\Command;
+
+use App\Marketplace\Application\Reconciliation\OzonReportParserFacade;
+use App\Marketplace\Entity\ReconciliationSession;
+use App\Marketplace\Infrastructure\Query\CostReconciliationQuery;
+use App\Marketplace\Repository\ReconciliationSessionRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Use-case: запустить сверку xlsx с данными marketplace_costs.
+ *
+ * Отличие от ReconcileCostsAction: результат пишется в ReconciliationSession,
+ * а не в MarketplaceMonthClose.settings.
+ */
+final class RunUserReconciliationAction
+{
+    public function __construct(
+        private readonly OzonReportParserFacade $parserFacade,
+        private readonly CostReconciliationQuery $reconciliationQuery,
+        private readonly ReconciliationSessionRepository $sessionRepository,
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    public function __invoke(string $companyId, ReconciliationSession $session): void
+    {
+        try {
+            $reportResult = $this->parserFacade->parseFromPath(
+                $session->getStoredFilePath(),
+            );
+
+            $reconcileResult = $this->reconciliationQuery->reconcile(
+                $companyId,
+                $session->getMarketplace(),
+                $session->getPeriodFrom()->format('Y-m-d'),
+                $session->getPeriodTo()->format('Y-m-d'),
+                $reportResult,
+            );
+
+            $session->markCompleted($reconcileResult);
+            $this->em->flush();
+        } catch (\Throwable $e) {
+            $session->markFailed($e->getMessage());
+            $this->em->flush();
+
+            throw $e;
+        }
+    }
+}

--- a/site/src/Marketplace/Application/RunUserReconciliationAction.php
+++ b/site/src/Marketplace/Application/RunUserReconciliationAction.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Marketplace\Application\Command;
+namespace App\Marketplace\Application;
 
 use App\Marketplace\Application\Reconciliation\OzonReportParserFacade;
 use App\Marketplace\Entity\ReconciliationSession;
@@ -43,8 +43,12 @@ final class RunUserReconciliationAction
             $this->em->flush();
         } catch (\Throwable $e) {
             if ($session->getStatus()->isPending()) {
-                $session->markFailed(mb_substr($e->getMessage(), 0, 1024));
-                $this->em->flush();
+                try {
+                    $session->markFailed(mb_substr($e->getMessage(), 0, 1024));
+                    $this->em->flush();
+                } catch (\Throwable) {
+                    // Не маскируем оригинальную ошибку
+                }
             }
 
             throw $e;


### PR DESCRIPTION
## Summary

- **RunUserReconciliationAction** — Action для оркестрации сверки xlsx с данными `marketplace_costs`. Парсит файл, запускает `CostReconciliationQuery::reconcile()`, сохраняет результат в `ReconciliationSession`.
- Отличие от существующего `ReconcileCostsAction`: результат пишется в `ReconciliationSession`, а не в `MarketplaceMonthClose.settings`

### Поток
1. `OzonReportParserFacade::parseFromPath()` — парсинг xlsx
2. `CostReconciliationQuery::reconcile()` — сверка с БД
3. `session->markCompleted($result)` — сохранение результата
4. `em->flush()` — единственная точка flush

### При ошибке
`session->markFailed($e->getMessage())` → flush → re-throw

## Test plan

- [ ] Убедиться что Action вызывается из контроллера (будет в следующей задаче)
- [ ] Happy path: xlsx парсится, reconcile возвращает результат, session.status = completed
- [ ] Error path: невалидный xlsx → session.status = failed, exception пробрасывается

https://claude.ai/code/session_01Dmaofk1xAcfVAbUeYkxyJd