### PR TITLE
feat(Marketplace): add reconciliation API controllers

### DIFF
--- a/site/src/Marketplace/Controller/Api/ReconciliationExportController.php
+++ b/site/src/Marketplace/Controller/Api/ReconciliationExportController.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Controller\Api;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Экспорт результата сверки в xlsx.
+ */
+#[IsGranted('ROLE_USER')]
+final class ReconciliationExportController extends AbstractController
+{
+    #[Route('/api/marketplace/reconciliation/{id}/export', name: 'api_marketplace_reconciliation_export', methods: ['GET'])]
+    public function __invoke(string $id): JsonResponse
+    {
+        // TODO: P1 — реализовать экспорт результата сверки в xlsx
+        return new JsonResponse(['error' => 'Export not implemented yet'], 501);
+    }
+}

--- a/site/src/Marketplace/Controller/Api/ReconciliationHistoryController.php
+++ b/site/src/Marketplace/Controller/Api/ReconciliationHistoryController.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Controller\Api;
+
+use App\Marketplace\Repository\ReconciliationSessionRepository;
+use App\Shared\Service\ActiveCompanyService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Список сессий сверки с пагинацией.
+ */
+#[IsGranted('ROLE_USER')]
+final class ReconciliationHistoryController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $activeCompanyService,
+        private readonly ReconciliationSessionRepository $sessionRepository,
+    ) {
+    }
+
+    #[Route('/api/marketplace/reconciliation/history', name: 'api_marketplace_reconciliation_history', methods: ['GET'])]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $company   = $this->activeCompanyService->getActiveCompany();
+        $companyId = (string) $company->getId();
+
+        $page  = max(1, $request->query->getInt('page', 1));
+        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
+        $offset = ($page - 1) * $limit;
+
+        $sessions = $this->sessionRepository->findByCompanyOrderedByDate($companyId, $limit, $offset);
+        $total    = $this->sessionRepository->countByCompany($companyId);
+
+        $items = array_map(static fn ($s) => [
+            'id'               => $s->getId(),
+            'marketplace'      => $s->getMarketplace(),
+            'periodFrom'       => $s->getPeriodFrom()->format('Y-m-d'),
+            'periodTo'         => $s->getPeriodTo()->format('Y-m-d'),
+            'originalFilename' => $s->getOriginalFilename(),
+            'status'           => $s->getStatus()->value,
+            'createdAt'        => $s->getCreatedAt()->format('c'),
+        ], $sessions);
+
+        return $this->json([
+            'items' => $items,
+            'total' => $total,
+            'page'  => $page,
+            'limit' => $limit,
+        ]);
+    }
+}

--- a/site/src/Marketplace/Controller/Api/ReconciliationResultController.php
+++ b/site/src/Marketplace/Controller/Api/ReconciliationResultController.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Controller\Api;
+
+use App\Marketplace\Repository\ReconciliationSessionRepository;
+use App\Shared\Service\ActiveCompanyService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Получение результата конкретной сессии сверки.
+ */
+#[IsGranted('ROLE_USER')]
+final class ReconciliationResultController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $activeCompanyService,
+        private readonly ReconciliationSessionRepository $sessionRepository,
+    ) {
+    }
+
+    #[Route('/api/marketplace/reconciliation/{id}', name: 'api_marketplace_reconciliation_result', methods: ['GET'])]
+    public function __invoke(string $id): JsonResponse
+    {
+        $company   = $this->activeCompanyService->getActiveCompany();
+        $companyId = (string) $company->getId();
+
+        $session = $this->sessionRepository->findByIdAndCompany($id, $companyId);
+
+        if ($session === null) {
+            throw $this->createNotFoundException();
+        }
+
+        return $this->json([
+            'id'               => $session->getId(),
+            'marketplace'      => $session->getMarketplace(),
+            'periodFrom'       => $session->getPeriodFrom()->format('Y-m-d'),
+            'periodTo'         => $session->getPeriodTo()->format('Y-m-d'),
+            'originalFilename' => $session->getOriginalFilename(),
+            'status'           => $session->getStatus()->value,
+            'result'           => $session->getDecodedResult(),
+            'createdAt'        => $session->getCreatedAt()->format('c'),
+        ]);
+    }
+}

--- a/site/src/Marketplace/Controller/Api/ReconciliationUploadController.php
+++ b/site/src/Marketplace/Controller/Api/ReconciliationUploadController.php
@@ -50,7 +50,7 @@ final class ReconciliationUploadController extends AbstractController
             return $this->json(['error' => 'Файл не загружен.'], 400);
         }
 
-        $extension = strtolower($file->getClientOriginalExtension());
+        $extension = $file->guessExtension();
         if ($extension !== 'xlsx') {
             return $this->json(['error' => 'Допустимый формат: .xlsx'], 400);
         }

--- a/site/src/Marketplace/Controller/Api/ReconciliationUploadController.php
+++ b/site/src/Marketplace/Controller/Api/ReconciliationUploadController.php
@@ -7,6 +7,7 @@ namespace App\Marketplace\Controller\Api;
 use App\Marketplace\Application\RunUserReconciliationAction;
 use App\Marketplace\Entity\ReconciliationSession;
 use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Enum\ReconciliationSessionStatus;
 use App\Shared\Service\ActiveCompanyService;
 use App\Shared\Service\Storage\StorageService;
 use Doctrine\ORM\EntityManagerInterface;
@@ -114,7 +115,7 @@ final class ReconciliationUploadController extends AbstractController
             return $this->json(['error' => 'Unexpected state: session still pending.'], 500);
         }
 
-        if ($session->getStatus() === \App\Marketplace\Enum\ReconciliationSessionStatus::FAILED) {
+        if ($session->getStatus() === ReconciliationSessionStatus::FAILED) {
             return $this->json([
                 'id'           => $session->getId(),
                 'status'       => $session->getStatus()->value,

--- a/site/src/Marketplace/Controller/Api/ReconciliationUploadController.php
+++ b/site/src/Marketplace/Controller/Api/ReconciliationUploadController.php
@@ -6,6 +6,7 @@ namespace App\Marketplace\Controller\Api;
 
 use App\Marketplace\Application\RunUserReconciliationAction;
 use App\Marketplace\Entity\ReconciliationSession;
+use App\Marketplace\Enum\MarketplaceType;
 use App\Shared\Service\ActiveCompanyService;
 use App\Shared\Service\Storage\StorageService;
 use Doctrine\ORM\EntityManagerInterface;
@@ -50,23 +51,27 @@ final class ReconciliationUploadController extends AbstractController
         }
 
         $extension = strtolower($file->getClientOriginalExtension());
-        if (!in_array($extension, ['xls', 'xlsx'], true)) {
-            return $this->json(['error' => 'Допустимые форматы: .xls, .xlsx'], 400);
+        if ($extension !== 'xlsx') {
+            return $this->json(['error' => 'Допустимый формат: .xlsx'], 400);
         }
 
         if ($file->getSize() > 50 * 1024 * 1024) {
             return $this->json(['error' => 'Максимальный размер файла: 50 МБ.'], 400);
         }
 
-        try {
-            $dateFrom = new \DateTimeImmutable($periodFrom);
-            $dateTo   = new \DateTimeImmutable($periodTo);
-        } catch (\Exception) {
+        $dateFrom = \DateTimeImmutable::createFromFormat('!Y-m-d', $periodFrom);
+        $dateTo   = \DateTimeImmutable::createFromFormat('!Y-m-d', $periodTo);
+
+        if ($dateFrom === false || $dateTo === false) {
             return $this->json(['error' => 'Некорректный формат дат. Ожидается Y-m-d.'], 400);
         }
 
         if ($dateFrom >= $dateTo) {
             return $this->json(['error' => 'periodFrom должен быть раньше periodTo.'], 400);
+        }
+
+        if (MarketplaceType::tryFrom($marketplace) === null) {
+            return $this->json(['error' => 'Неизвестный маркетплейс.'], 400);
         }
 
         // --- Сохранение файла ---

--- a/site/src/Marketplace/Controller/Api/ReconciliationUploadController.php
+++ b/site/src/Marketplace/Controller/Api/ReconciliationUploadController.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Controller\Api;
+
+use App\Marketplace\Application\RunUserReconciliationAction;
+use App\Marketplace\Entity\ReconciliationSession;
+use App\Shared\Service\ActiveCompanyService;
+use App\Shared\Service\Storage\StorageService;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Загрузка xlsx и запуск сверки затрат маркетплейса.
+ *
+ * TODO: если сверка станет долгой (>5с), вынести run в async Message/Handler
+ */
+#[IsGranted('ROLE_USER')]
+final class ReconciliationUploadController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $activeCompanyService,
+        private readonly StorageService $storageService,
+        private readonly RunUserReconciliationAction $reconciliationAction,
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    #[Route('/api/marketplace/reconciliation/upload', name: 'api_marketplace_reconciliation_upload', methods: ['POST'])]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $company   = $this->activeCompanyService->getActiveCompany();
+        $companyId = (string) $company->getId();
+
+        $file        = $request->files->get('file');
+        $periodFrom  = $request->request->get('periodFrom', '');
+        $periodTo    = $request->request->get('periodTo', '');
+        $marketplace = $request->request->get('marketplace', 'ozon');
+
+        // --- Валидация ---
+
+        if ($file === null) {
+            return $this->json(['error' => 'Файл не загружен.'], 400);
+        }
+
+        $extension = strtolower($file->getClientOriginalExtension());
+        if (!in_array($extension, ['xls', 'xlsx'], true)) {
+            return $this->json(['error' => 'Допустимые форматы: .xls, .xlsx'], 400);
+        }
+
+        if ($file->getSize() > 50 * 1024 * 1024) {
+            return $this->json(['error' => 'Максимальный размер файла: 50 МБ.'], 400);
+        }
+
+        try {
+            $dateFrom = new \DateTimeImmutable($periodFrom);
+            $dateTo   = new \DateTimeImmutable($periodTo);
+        } catch (\Exception) {
+            return $this->json(['error' => 'Некорректный формат дат. Ожидается Y-m-d.'], 400);
+        }
+
+        if ($dateFrom >= $dateTo) {
+            return $this->json(['error' => 'periodFrom должен быть раньше periodTo.'], 400);
+        }
+
+        // --- Сохранение файла ---
+
+        $relativePath = sprintf(
+            'marketplace/reconciliation/%s/%s/%s.xlsx',
+            $marketplace,
+            $dateFrom->format('Y-m'),
+            Uuid::uuid4()->toString(),
+        );
+        $stored = $this->storageService->storeUploadedFile($file, $relativePath);
+
+        // --- Создание сессии ---
+
+        $session = new ReconciliationSession(
+            $companyId,
+            $marketplace,
+            $dateFrom,
+            $dateTo,
+            $stored['originalFilename'],
+            $stored['storagePath'],
+        );
+
+        $this->em->persist($session);
+        $this->em->flush();
+
+        // --- Запуск сверки ---
+
+        try {
+            ($this->reconciliationAction)($companyId, $session);
+        } catch (\Throwable) {
+            // Action уже пометил сессию как failed и сделал flush
+        }
+
+        // --- Ответ ---
+
+        $session = $this->em->find(ReconciliationSession::class, $session->getId());
+
+        if ($session->getStatus()->isPending()) {
+            return $this->json(['error' => 'Unexpected state: session still pending.'], 500);
+        }
+
+        if ($session->getStatus() === \App\Marketplace\Enum\ReconciliationSessionStatus::FAILED) {
+            return $this->json([
+                'id'           => $session->getId(),
+                'status'       => $session->getStatus()->value,
+                'errorMessage' => $session->getErrorMessage(),
+            ], 422);
+        }
+
+        return $this->json([
+            'id'     => $session->getId(),
+            'status' => $session->getStatus()->value,
+            'result' => $session->getDecodedResult(),
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

- **ReconciliationUploadController** — `POST /api/marketplace/reconciliation/upload` — загрузка xlsx-файла, валидация (формат, размер, даты), сохранение через StorageService, создание ReconciliationSession и запуск сверки через RunUserReconciliationAction
- **ReconciliationResultController** — `GET /api/marketplace/reconciliation/{id}` — получение результата конкретной сессии сверки (IDOR-safe через `findByIdAndCompany`)
- **ReconciliationHistoryController** — `GET /api/marketplace/reconciliation/history?page=&limit=` — список сессий с пагинацией (без поля result для компактности ответа)
- **ReconciliationExportController** — `GET /api/marketplace/reconciliation/{id}/export` — заглушка 501 для будущего xlsx-экспорта

## Details

- Все контроллеры: `final class`, `__invoke`, `#[IsGranted('ROLE_USER')]`
- IDOR-защита: `ActiveCompanyService` + `companyId` во всех запросах к Repository
- Бизнес-логика вынесена в Action, контроллеры — только HTTP in/out
- Upload валидация: формат (.xls/.xlsx), размер (≤50 МБ), даты (periodFrom < periodTo)

## Test plan

- [ ] `POST /upload` с валидным xlsx — возвращает `id`, `status: completed`, `result`
- [ ] `POST /upload` без файла — 400
- [ ] `POST /upload` с некорректным форматом — 400
- [ ] `POST /upload` с periodFrom >= periodTo — 400
- [ ] `GET /{id}` с валидным id — возвращает сессию с result
- [ ] `GET /{id}` с чужим companyId — 404 (IDOR)
- [ ] `GET /history` — возвращает paginated список
- [ ] `GET /{id}/export` — 501

https://claude.ai/code/session_01Dmaofk1xAcfVAbUeYkxyJd