### PR TITLE
feat(Marketplace): add reconciliation React widget

### DIFF
--- a/site/assets/react/reconciliation-page.tsx
+++ b/site/assets/react/reconciliation-page.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { ErrorBoundary } from "./shared/ui/ErrorBoundary";
+import ReconciliationWidget from "./reconciliation/widgets/ReconciliationWidget";
+
+function mountReconciliationPage() {
+    const el = document.getElementById("reconciliation-root");
+    if (!el || (el as any).__reactRoot) return;
+
+    const root = createRoot(el);
+    (el as any).__reactRoot = root;
+
+    root.render(
+        <ErrorBoundary widgetName="Reconciliation">
+            <ReconciliationWidget />
+        </ErrorBoundary>,
+    );
+}
+
+window.addEventListener("DOMContentLoaded", mountReconciliationPage);

--- a/site/assets/react/reconciliation/components/ReconciliationHistory.tsx
+++ b/site/assets/react/reconciliation/components/ReconciliationHistory.tsx
@@ -1,0 +1,185 @@
+import React from "react";
+import type { ReconciliationHistoryItem } from "../reconciliation.types";
+
+interface ReconciliationHistoryProps {
+    items: ReconciliationHistoryItem[];
+    total: number;
+    page: number;
+    onPageChange: (page: number) => void;
+    onViewSession: (sessionId: string) => void;
+    isLoading: boolean;
+}
+
+const STATUS_BADGE: Record<string, { cls: string; label: string }> = {
+    completed: { cls: "bg-green-lt text-green", label: "Завершена" },
+    failed: { cls: "bg-red-lt text-red", label: "Ошибка" },
+    pending: { cls: "bg-muted-lt text-muted", label: "В процессе" },
+};
+
+function formatDate(iso: string): string {
+    try {
+        return new Intl.DateTimeFormat("ru-RU", {
+            day: "2-digit",
+            month: "2-digit",
+            year: "numeric",
+            hour: "2-digit",
+            minute: "2-digit",
+        }).format(new Date(iso));
+    } catch {
+        return iso;
+    }
+}
+
+const ReconciliationHistory: React.FC<ReconciliationHistoryProps> = ({
+    items,
+    total,
+    page,
+    onPageChange,
+    onViewSession,
+    isLoading,
+}) => {
+    const limit = 20;
+    const totalPages = Math.max(1, Math.ceil(total / limit));
+
+    if (isLoading) {
+        return (
+            <div className="card">
+                <div className="card-body">
+                    <div className="d-flex align-items-center gap-2">
+                        <div className="spinner-border spinner-border-sm" role="status" />
+                        <div className="text-muted">Загрузка...</div>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    if (items.length === 0) {
+        return (
+            <div className="card">
+                <div className="card-body">
+                    <div className="empty">
+                        <p className="empty-title">Нет истории сверок</p>
+                        <p className="empty-subtitle text-muted">
+                            Загрузите первый отчёт на вкладке &laquo;Новая сверка&raquo;
+                        </p>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="card">
+            <div className="card-header">
+                <h3 className="card-title">История сверок</h3>
+                <div className="card-options">
+                    <span className="text-muted small">Всего: {total}</span>
+                </div>
+            </div>
+            <div className="table-responsive">
+                <table className="table table-vcenter card-table">
+                    <thead>
+                        <tr>
+                            <th>Дата</th>
+                            <th>Период</th>
+                            <th>Файл</th>
+                            <th>Статус</th>
+                            <th>Действие</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {items.map((item) => {
+                            const badge = STATUS_BADGE[item.status] ?? STATUS_BADGE.pending;
+                            return (
+                                <tr key={item.id}>
+                                    <td className="text-nowrap">{formatDate(item.createdAt)}</td>
+                                    <td className="text-nowrap">
+                                        {item.periodFrom} &mdash; {item.periodTo}
+                                    </td>
+                                    <td>{item.originalFilename}</td>
+                                    <td>
+                                        <span className={`badge ${badge.cls}`}>{badge.label}</span>
+                                    </td>
+                                    <td>
+                                        {item.status === "completed" && (
+                                            <button
+                                                className="btn btn-sm btn-ghost-primary"
+                                                onClick={() => onViewSession(item.id)}
+                                            >
+                                                <i className="ti ti-eye me-1" />
+                                                Посмотреть
+                                            </button>
+                                        )}
+                                    </td>
+                                </tr>
+                            );
+                        })}
+                    </tbody>
+                </table>
+            </div>
+
+            {/* Pagination */}
+            {totalPages > 1 && (
+                <div className="card-footer d-flex align-items-center">
+                    <p className="m-0 text-muted">
+                        Страница {page} из {totalPages}
+                    </p>
+                    <ul className="pagination m-0 ms-auto">
+                        <li className={`page-item ${page <= 1 ? "disabled" : ""}`}>
+                            <button
+                                className="page-link"
+                                onClick={() => onPageChange(page - 1)}
+                                disabled={page <= 1}
+                            >
+                                <i className="ti ti-chevron-left" />
+                            </button>
+                        </li>
+                        {Array.from({ length: totalPages }, (_, i) => i + 1)
+                            .filter(
+                                (p) => p === 1 || p === totalPages || Math.abs(p - page) <= 1,
+                            )
+                            .reduce<(number | "ellipsis")[]>((acc, p, idx, arr) => {
+                                if (idx > 0) {
+                                    const prev = arr[idx - 1];
+                                    if (prev !== undefined && p - prev > 1) acc.push("ellipsis");
+                                }
+                                acc.push(p);
+                                return acc;
+                            }, [])
+                            .map((item, idx) =>
+                                item === "ellipsis" ? (
+                                    <li key={`e-${idx}`} className="page-item disabled">
+                                        <span className="page-link">&hellip;</span>
+                                    </li>
+                                ) : (
+                                    <li
+                                        key={item}
+                                        className={`page-item ${item === page ? "active" : ""}`}
+                                    >
+                                        <button
+                                            className="page-link"
+                                            onClick={() => onPageChange(item)}
+                                        >
+                                            {item}
+                                        </button>
+                                    </li>
+                                ),
+                            )}
+                        <li className={`page-item ${page >= totalPages ? "disabled" : ""}`}>
+                            <button
+                                className="page-link"
+                                onClick={() => onPageChange(page + 1)}
+                                disabled={page >= totalPages}
+                            >
+                                <i className="ti ti-chevron-right" />
+                            </button>
+                        </li>
+                    </ul>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default ReconciliationHistory;

--- a/site/assets/react/reconciliation/components/ReconciliationTable.tsx
+++ b/site/assets/react/reconciliation/components/ReconciliationTable.tsx
@@ -1,0 +1,165 @@
+import React, { useState } from "react";
+import type { ReconciliationSession } from "../reconciliation.types";
+
+interface ReconciliationTableProps {
+    session: ReconciliationSession;
+}
+
+/**
+ * Форматирование числа: разделитель тысяч, 2 знака, символ ₽
+ */
+function formatRub(value: number): string {
+    return new Intl.NumberFormat("ru-RU", {
+        style: "currency",
+        currency: "RUB",
+        maximumFractionDigits: 2,
+    }).format(value);
+}
+
+const ReconciliationTable: React.FC<ReconciliationTableProps> = ({ session }) => {
+    const [showOnlyMismatch, setShowOnlyMismatch] = useState(false);
+
+    const result = session.result;
+    if (!result) return null;
+
+    const groups = showOnlyMismatch
+        ? result.group_comparison.filter((g) => g.status === "mismatch")
+        : result.group_comparison;
+
+    const isMatched = result.status === "matched";
+
+    return (
+        <div className="card">
+            {/* Header */}
+            <div className="card-header">
+                <div className="d-flex align-items-center justify-content-between w-100">
+                    <div>
+                        <h3 className="card-title mb-1">Результат сверки</h3>
+                        <div className="text-muted small">
+                            {session.periodFrom} &mdash; {session.periodTo}
+                            <span className="mx-2">&middot;</span>
+                            {session.originalFilename}
+                            <span className="mx-2">&middot;</span>
+                            {result.xlsx_lines_count} строк в xlsx
+                        </div>
+                    </div>
+                    <div>
+                        {isMatched ? (
+                            <span className="badge bg-green-lt text-green">
+                                <i className="ti ti-check me-1" />
+                                Совпадает
+                            </span>
+                        ) : (
+                            <span className="badge bg-red-lt text-red">
+                                <i className="ti ti-alert-triangle me-1" />
+                                Расхождение
+                            </span>
+                        )}
+                    </div>
+                </div>
+            </div>
+
+            <div className="card-body">
+                {/* Summary row */}
+                <div className="table-responsive mb-4">
+                    <table className="table table-vcenter card-table">
+                        <thead>
+                            <tr>
+                                <th>API нетто</th>
+                                <th>xlsx comparable</th>
+                                <th>xlsx total</th>
+                                <th>Дельта</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>{formatRub(result.api_net_amount)}</td>
+                                <td>{formatRub(result.xlsx_comparable)}</td>
+                                <td>{formatRub(result.xlsx_total)}</td>
+                                <td className={result.delta !== 0 ? "text-red fw-bold" : "text-green"}>
+                                    {formatRub(result.delta)}
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                {/* Filter toggle */}
+                <div className="d-flex align-items-center mb-3">
+                    <span className="fw-semibold me-3">Группы услуг</span>
+                    <label className="form-check form-switch mb-0">
+                        <input
+                            className="form-check-input"
+                            type="checkbox"
+                            checked={showOnlyMismatch}
+                            onChange={(e) => setShowOnlyMismatch(e.target.checked)}
+                        />
+                        <span className="form-check-label">Только расхождения</span>
+                    </label>
+                </div>
+
+                {/* Groups table */}
+                <div className="table-responsive">
+                    <table className="table table-vcenter card-table">
+                        <thead>
+                            <tr>
+                                <th>Группа услуг</th>
+                                <th className="text-end">Сумма API</th>
+                                <th className="text-end">Сумма XLS</th>
+                                <th className="text-end">Дельта</th>
+                                <th>Статус</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {groups.length === 0 && (
+                                <tr>
+                                    <td colSpan={5} className="text-center text-muted">
+                                        {showOnlyMismatch
+                                            ? "Расхождений не найдено"
+                                            : "Нет данных для отображения"}
+                                    </td>
+                                </tr>
+                            )}
+                            {groups.map((g) => (
+                                <tr key={g.serviceGroup}>
+                                    <td>
+                                        <div>{g.serviceGroup}</div>
+                                        {g.apiCategories.length > 0 && (
+                                            <div className="text-muted small">
+                                                {g.apiCategories.join(", ")}
+                                            </div>
+                                        )}
+                                    </td>
+                                    <td className="text-end">{formatRub(g.apiAmount)}</td>
+                                    <td className="text-end">{formatRub(g.xlsAmount)}</td>
+                                    <td
+                                        className={`text-end ${
+                                            g.delta !== 0 ? "text-red fw-bold" : ""
+                                        }`}
+                                    >
+                                        {formatRub(g.delta)}
+                                    </td>
+                                    <td>
+                                        {g.status === "matched" ? (
+                                            <span className="badge bg-green-lt text-green">
+                                                <i className="ti ti-check me-1" />
+                                                Совпадает
+                                            </span>
+                                        ) : (
+                                            <span className="badge bg-red-lt text-red">
+                                                <i className="ti ti-alert-triangle me-1" />
+                                                Расхождение
+                                            </span>
+                                        )}
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ReconciliationTable;

--- a/site/assets/react/reconciliation/components/ReconciliationUpload.tsx
+++ b/site/assets/react/reconciliation/components/ReconciliationUpload.tsx
@@ -1,0 +1,146 @@
+import React, { useCallback, useRef, useState } from "react";
+
+interface ReconciliationUploadProps {
+    onUpload: (file: File, periodFrom: string, periodTo: string) => void;
+    isLoading: boolean;
+    error: string | null;
+}
+
+const ReconciliationUpload: React.FC<ReconciliationUploadProps> = ({
+    onUpload,
+    isLoading,
+    error,
+}) => {
+    const [file, setFile] = useState<File | null>(null);
+    const [periodFrom, setPeriodFrom] = useState("");
+    const [periodTo, setPeriodTo] = useState("");
+    const [dragOver, setDragOver] = useState(false);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    const handleFile = useCallback((f: File | null) => {
+        if (!f) return;
+        const ext = f.name.split(".").pop()?.toLowerCase();
+        if (ext !== "xlsx") return;
+        setFile(f);
+    }, []);
+
+    const handleDrop = useCallback(
+        (e: React.DragEvent) => {
+            e.preventDefault();
+            setDragOver(false);
+            const dropped = e.dataTransfer.files[0];
+            if (dropped) handleFile(dropped);
+        },
+        [handleFile],
+    );
+
+    const handleSubmit = useCallback(() => {
+        if (!file || !periodFrom || !periodTo) return;
+        onUpload(file, periodFrom, periodTo);
+    }, [file, periodFrom, periodTo, onUpload]);
+
+    const canSubmit = file !== null && periodFrom !== "" && periodTo !== "" && !isLoading;
+
+    return (
+        <div className="card">
+            <div className="card-header">
+                <h3 className="card-title">Загрузка отчёта</h3>
+            </div>
+            <div className="card-body">
+                <div className="text-muted mb-3">
+                    Загрузите файл из ЛК Ozon &rarr; Финансы &rarr; Документы &rarr; Отчёт
+                    по начислениям
+                </div>
+
+                {/* Drag-and-drop zone */}
+                <div
+                    className={`border rounded p-4 text-center mb-3 ${
+                        dragOver ? "border-primary bg-blue-lt" : "border-secondary"
+                    }`}
+                    onDragOver={(e) => {
+                        e.preventDefault();
+                        setDragOver(true);
+                    }}
+                    onDragLeave={() => setDragOver(false)}
+                    onDrop={handleDrop}
+                    style={{ cursor: "pointer" }}
+                    onClick={() => inputRef.current?.click()}
+                >
+                    <input
+                        ref={inputRef}
+                        type="file"
+                        accept=".xlsx"
+                        className="d-none"
+                        onChange={(e) => handleFile(e.target.files?.[0] ?? null)}
+                    />
+                    {file ? (
+                        <div>
+                            <i className="ti ti-file-spreadsheet me-2" />
+                            <span className="fw-semibold">{file.name}</span>
+                            <span className="text-muted ms-2">
+                                ({(file.size / 1024 / 1024).toFixed(1)} МБ)
+                            </span>
+                        </div>
+                    ) : (
+                        <div className="text-muted">
+                            <i className="ti ti-upload me-2" />
+                            Перетащите .xlsx файл сюда или нажмите для выбора
+                        </div>
+                    )}
+                </div>
+
+                {/* Date fields */}
+                <div className="row mb-3">
+                    <div className="col-sm-6">
+                        <label className="form-label">Период с</label>
+                        <input
+                            type="date"
+                            className="form-control"
+                            value={periodFrom}
+                            onChange={(e) => setPeriodFrom(e.target.value)}
+                            disabled={isLoading}
+                        />
+                    </div>
+                    <div className="col-sm-6">
+                        <label className="form-label">Период по</label>
+                        <input
+                            type="date"
+                            className="form-control"
+                            value={periodTo}
+                            onChange={(e) => setPeriodTo(e.target.value)}
+                            disabled={isLoading}
+                        />
+                    </div>
+                </div>
+
+                {/* Error */}
+                {error && (
+                    <div className="alert alert-danger" role="alert">
+                        {error}
+                    </div>
+                )}
+
+                {/* Submit */}
+                <button
+                    className="btn btn-primary"
+                    disabled={!canSubmit}
+                    onClick={handleSubmit}
+                >
+                    {isLoading ? (
+                        <>
+                            <span className="spinner-border spinner-border-sm me-2" />
+                            Сверка...
+                        </>
+                    ) : (
+                        <>
+                            <i className="ti ti-analyze me-1" />
+                            Запустить сверку
+                        </>
+                    )}
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default ReconciliationUpload;

--- a/site/assets/react/reconciliation/hooks/useReconciliationHistory.ts
+++ b/site/assets/react/reconciliation/hooks/useReconciliationHistory.ts
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+import { useAbortableQuery } from "../../shared/hooks/useAbortableQuery";
+import type {
+    ReconciliationHistoryItem,
+    ReconciliationHistoryResponse,
+} from "../reconciliation.types";
+
+interface UseReconciliationHistoryResult {
+    isLoading: boolean;
+    error: string | null;
+    items: ReconciliationHistoryItem[];
+    total: number;
+}
+
+/**
+ * Query-хук: список прошлых сверок с пагинацией.
+ *
+ * GET /api/marketplace/reconciliation/history?page={page}&limit=20
+ */
+export function useReconciliationHistory(page: number): UseReconciliationHistoryResult {
+    const { isLoading, data, error, run } = useAbortableQuery<ReconciliationHistoryResponse>();
+
+    useEffect(() => {
+        void run({
+            url: "/api/marketplace/reconciliation/history",
+            query: { page, limit: 20 },
+        });
+    }, [page, run]);
+
+    return {
+        isLoading,
+        error,
+        items: data?.items ?? [],
+        total: data?.total ?? 0,
+    };
+}

--- a/site/assets/react/reconciliation/hooks/useSessionResult.ts
+++ b/site/assets/react/reconciliation/hooks/useSessionResult.ts
@@ -1,0 +1,33 @@
+import { useEffect } from "react";
+import { useAbortableQuery } from "../../shared/hooks/useAbortableQuery";
+import type { ReconciliationSession } from "../reconciliation.types";
+
+interface UseSessionResultResult {
+    isLoading: boolean;
+    error: string | null;
+    session: ReconciliationSession | null;
+}
+
+/**
+ * Query-хук: получить результат конкретной сверки (для просмотра из истории).
+ *
+ * GET /api/marketplace/reconciliation/{id}
+ * enabled: sessionId !== null
+ */
+export function useSessionResult(sessionId: string | null): UseSessionResultResult {
+    const { isLoading, data, error, run } = useAbortableQuery<ReconciliationSession>();
+
+    useEffect(() => {
+        if (!sessionId) return;
+
+        void run({
+            url: `/api/marketplace/reconciliation/${sessionId}`,
+        });
+    }, [sessionId, run]);
+
+    return {
+        isLoading,
+        error,
+        session: data ?? null,
+    };
+}

--- a/site/assets/react/reconciliation/hooks/useUploadReconciliation.ts
+++ b/site/assets/react/reconciliation/hooks/useUploadReconciliation.ts
@@ -1,0 +1,115 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ApiError } from "../../shared/http/client";
+import type { ReconciliationSession, ReconciliationUploadResponse } from "../reconciliation.types";
+
+interface UseUploadReconciliationResult {
+    isLoading: boolean;
+    error: string | null;
+    session: ReconciliationSession | null;
+    upload: (file: File, periodFrom: string, periodTo: string, marketplace?: string) => void;
+    reset: () => void;
+}
+
+/**
+ * Mutation-хук: загрузить xlsx и получить результат сверки.
+ *
+ * POST /api/marketplace/reconciliation/upload (multipart/form-data)
+ *
+ * httpJson не подходит для FormData (он ставит Content-Type: application/json),
+ * поэтому используем raw fetch с тем же паттерном abort + state.
+ */
+export function useUploadReconciliation(): UseUploadReconciliationResult {
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [session, setSession] = useState<ReconciliationSession | null>(null);
+    const abortRef = useRef<AbortController | null>(null);
+
+    const upload = useCallback(
+        (file: File, periodFrom: string, periodTo: string, marketplace = "ozon") => {
+            abortRef.current?.abort();
+            const ac = new AbortController();
+            abortRef.current = ac;
+
+            setIsLoading(true);
+            setError(null);
+            setSession(null);
+
+            const formData = new FormData();
+            formData.append("file", file);
+            formData.append("periodFrom", periodFrom);
+            formData.append("periodTo", periodTo);
+            formData.append("marketplace", marketplace);
+
+            fetch("/api/marketplace/reconciliation/upload", {
+                method: "POST",
+                body: formData,
+                credentials: "same-origin",
+                signal: ac.signal,
+            })
+                .then(async (res) => {
+                    const payload = await res.json() as ReconciliationUploadResponse & { error?: string };
+
+                    if (!res.ok) {
+                        throw new ApiError(
+                            payload.error ?? payload.errorMessage ?? `HTTP ${res.status}`,
+                            res.status === 422 ? "validation" : "server",
+                            res.status,
+                            payload,
+                        );
+                    }
+
+                    return payload;
+                })
+                .then((data) => {
+                    if (ac.signal.aborted) return;
+
+                    // Формируем полную ReconciliationSession из ответа upload
+                    const uploaded: ReconciliationSession = {
+                        id: data.id,
+                        marketplace,
+                        periodFrom,
+                        periodTo,
+                        originalFilename: file.name,
+                        status: data.status,
+                        result: data.result ?? null,
+                        errorMessage: data.errorMessage ?? null,
+                        createdAt: new Date().toISOString(),
+                    };
+
+                    setSession(uploaded);
+                    setIsLoading(false);
+
+                    if (data.status === "failed") {
+                        setError(data.errorMessage ?? "Сверка завершилась с ошибкой.");
+                    }
+                })
+                .catch((e: unknown) => {
+                    if (e instanceof Error && e.name === "AbortError") return;
+
+                    const message =
+                        e instanceof ApiError
+                            ? e.message
+                            : "Не удалось загрузить файл. Повторите попытку.";
+
+                    if (!ac.signal.aborted) {
+                        setError(message);
+                        setIsLoading(false);
+                    }
+                });
+        },
+        [],
+    );
+
+    const reset = useCallback(() => {
+        setSession(null);
+        setError(null);
+    }, []);
+
+    useEffect(() => {
+        return () => {
+            abortRef.current?.abort();
+        };
+    }, []);
+
+    return { isLoading, error, session, upload, reset };
+}

--- a/site/assets/react/reconciliation/reconciliation.types.ts
+++ b/site/assets/react/reconciliation/reconciliation.types.ts
@@ -1,0 +1,70 @@
+/**
+ * Типы для модуля сверки маркетплейса (reconciliation)
+ *
+ * Структура соответствует ответу CostReconciliationQuery::reconcile()
+ */
+
+/** Сверка одной serviceGroup (из поля group_comparison) */
+export interface GroupComparison {
+    serviceGroup: string;
+    apiAmount: number;
+    xlsAmount: number;
+    delta: number;
+    status: "matched" | "mismatch";
+    apiCategories: string[];
+}
+
+/** Полный результат reconcile() — поле result в ответе API */
+export interface ReconcileResult {
+    status: "matched" | "mismatch";
+    api_net_amount: number;
+    api_costs_amount: number;
+    api_storno_amount: number;
+    return_revenue: number;
+    xlsx_comparable: number;
+    xlsx_total: number;
+    delta: number;
+    xlsx_period: string;
+    xlsx_lines_count: number;
+    group_comparison: GroupComparison[];
+}
+
+/** Сессия сверки (ответ API GET /api/marketplace/reconciliation/{id}) */
+export interface ReconciliationSession {
+    id: string;
+    marketplace: string;
+    periodFrom: string;
+    periodTo: string;
+    originalFilename: string;
+    status: "pending" | "completed" | "failed";
+    result: ReconcileResult | null;
+    errorMessage?: string | null;
+    createdAt: string;
+}
+
+/** Ответ POST /api/marketplace/reconciliation/upload */
+export interface ReconciliationUploadResponse {
+    id: string;
+    status: "completed" | "failed";
+    result?: ReconcileResult | null;
+    errorMessage?: string | null;
+}
+
+/** Элемент списка (ответ API /history — без поля result) */
+export interface ReconciliationHistoryItem {
+    id: string;
+    marketplace: string;
+    periodFrom: string;
+    periodTo: string;
+    originalFilename: string;
+    status: "pending" | "completed" | "failed";
+    createdAt: string;
+}
+
+/** Список сессий с пагинацией (ответ API /history) */
+export interface ReconciliationHistoryResponse {
+    items: ReconciliationHistoryItem[];
+    total: number;
+    page: number;
+    limit: number;
+}

--- a/site/assets/react/reconciliation/widgets/ReconciliationWidget.tsx
+++ b/site/assets/react/reconciliation/widgets/ReconciliationWidget.tsx
@@ -1,0 +1,152 @@
+import React, { useState, useCallback } from "react";
+import { useUploadReconciliation } from "../hooks/useUploadReconciliation";
+import { useSessionResult } from "../hooks/useSessionResult";
+import { useReconciliationHistory } from "../hooks/useReconciliationHistory";
+import ReconciliationUpload from "../components/ReconciliationUpload";
+import ReconciliationTable from "../components/ReconciliationTable";
+import ReconciliationHistory from "../components/ReconciliationHistory";
+import type { ReconciliationSession } from "../reconciliation.types";
+
+type View = "upload" | "result" | "history";
+
+const ReconciliationWidget: React.FC = () => {
+    const [view, setView] = useState<View>("upload");
+    const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+    const [lastUploadResult, setLastUploadResult] = useState<ReconciliationSession | null>(null);
+    const [historyPage, setHistoryPage] = useState(1);
+
+    const uploadHook = useUploadReconciliation();
+    const sessionQuery = useSessionResult(activeSessionId);
+    const historyQuery = useReconciliationHistory(historyPage);
+
+    // Upload callback
+    const handleUpload = useCallback(
+        (file: File, periodFrom: string, periodTo: string) => {
+            uploadHook.upload(file, periodFrom, periodTo);
+        },
+        [uploadHook],
+    );
+
+    // After successful upload — show result
+    const prevSession = React.useRef(uploadHook.session);
+    React.useEffect(() => {
+        if (uploadHook.session && uploadHook.session !== prevSession.current) {
+            prevSession.current = uploadHook.session;
+            if (uploadHook.session.status === "completed") {
+                setLastUploadResult(uploadHook.session);
+                setActiveSessionId(null);
+                setView("result");
+            }
+        }
+    }, [uploadHook.session]);
+
+    // View session from history
+    const handleViewSession = useCallback((sessionId: string) => {
+        setLastUploadResult(null);
+        setActiveSessionId(sessionId);
+        setView("result");
+    }, []);
+
+    // Back to upload
+    const handleBack = useCallback(() => {
+        setActiveSessionId(null);
+        setLastUploadResult(null);
+        uploadHook.reset();
+        setView("upload");
+    }, [uploadHook]);
+
+    // Determine which session to show in result view
+    const displaySession: ReconciliationSession | null =
+        lastUploadResult ?? sessionQuery.session;
+
+    return (
+        <div>
+            {/* Tabs */}
+            <ul className="nav nav-tabs mb-3">
+                <li className="nav-item">
+                    <button
+                        className={`nav-link ${view === "upload" || view === "result" ? "active" : ""}`}
+                        onClick={() => {
+                            if (view === "result") {
+                                handleBack();
+                            } else {
+                                setView("upload");
+                            }
+                        }}
+                    >
+                        <i className="ti ti-upload me-1" />
+                        Новая сверка
+                    </button>
+                </li>
+                <li className="nav-item">
+                    <button
+                        className={`nav-link ${view === "history" ? "active" : ""}`}
+                        onClick={() => setView("history")}
+                    >
+                        <i className="ti ti-history me-1" />
+                        История
+                    </button>
+                </li>
+            </ul>
+
+            {/* Upload view */}
+            {view === "upload" && (
+                <ReconciliationUpload
+                    onUpload={handleUpload}
+                    isLoading={uploadHook.isLoading}
+                    error={uploadHook.error}
+                />
+            )}
+
+            {/* Result view */}
+            {view === "result" && (
+                <div>
+                    <button className="btn btn-ghost-secondary btn-sm mb-3" onClick={handleBack}>
+                        <i className="ti ti-arrow-left me-1" />
+                        Назад к сверке
+                    </button>
+
+                    {sessionQuery.isLoading && (
+                        <div className="card card-body">
+                            <div className="d-flex align-items-center gap-2">
+                                <div className="spinner-border spinner-border-sm" role="status" />
+                                <div className="text-muted">Загрузка результата...</div>
+                            </div>
+                        </div>
+                    )}
+
+                    {sessionQuery.error && !displaySession && (
+                        <div className="alert alert-danger">{sessionQuery.error}</div>
+                    )}
+
+                    {displaySession?.status === "completed" && (
+                        <ReconciliationTable session={displaySession} />
+                    )}
+
+                    {displaySession?.status === "failed" && (
+                        <div className="alert alert-danger">
+                            <div className="fw-semibold">Сверка завершилась с ошибкой</div>
+                            <div className="text-muted">
+                                {displaySession.errorMessage ?? "Неизвестная ошибка"}
+                            </div>
+                        </div>
+                    )}
+                </div>
+            )}
+
+            {/* History view */}
+            {view === "history" && (
+                <ReconciliationHistory
+                    items={historyQuery.items}
+                    total={historyQuery.total}
+                    page={historyPage}
+                    onPageChange={setHistoryPage}
+                    onViewSession={handleViewSession}
+                    isLoading={historyQuery.isLoading}
+                />
+            )}
+        </div>
+    );
+};
+
+export default ReconciliationWidget;

--- a/site/src/Marketplace/Controller/Api/ReconciliationUploadController.php
+++ b/site/src/Marketplace/Controller/Api/ReconciliationUploadController.php
@@ -41,9 +41,9 @@ final class ReconciliationUploadController extends AbstractController
         $companyId = (string) $company->getId();
 
         $file        = $request->files->get('file');
-        $periodFrom  = $request->request->get('periodFrom', '');
-        $periodTo    = $request->request->get('periodTo', '');
-        $marketplace = $request->request->get('marketplace', 'ozon');
+        $periodFrom  = (string) $request->request->get('periodFrom', '');
+        $periodTo    = (string) $request->request->get('periodTo', '');
+        $marketplace = (string) $request->request->get('marketplace', 'ozon');
 
         // --- Валидация ---
 

--- a/site/vite.config.js
+++ b/site/vite.config.js
@@ -16,6 +16,7 @@ export default defineConfig({
                 dashboard: "./assets/react/dashboard_started.tsx", // Точка ./ обязательна!
                 marketplace_analytics_kpi: "./assets/react/marketplace_analytics_kpi.tsx",
                 marketplace_analytics_page: "./assets/react/marketplace-analytics-page.tsx",
+                reconciliation_page: "./assets/react/reconciliation-page.tsx",
             },
         }
     },


### PR DESCRIPTION
## Summary

- **reconciliation.types.ts** — типы, соответствующие ответу CostReconciliationQuery::reconcile()
- **useUploadReconciliation** — mutation-хук для POST /upload (FormData с abort + state)
- **useSessionResult** — query-хук для GET /{id} через useAbortableQuery
- **useReconciliationHistory** — query-хук для GET /history с пагинацией
- **ReconciliationUpload.tsx** — drag-drop загрузка xlsx + выбор периода дат
- **ReconciliationTable.tsx** — summary + группы услуг с фильтром «только расхождения»
- **ReconciliationHistory.tsx** — таблица истории с Tabler-пагинацией
- **ReconciliationWidget.tsx** — smart container с табами (Новая сверка / История)
- **reconciliation-page.tsx** — entrypoint с ErrorBoundary
- **vite.config.js** — добавлен reconciliation_page entry

### Адаптации к реальному проекту

- Папка `assets/react/reconciliation/` (не `features/`) — по паттерну `marketplace-analytics/`
- `httpJson` + `useAbortableQuery` вместо TanStack Query (не установлен в проекте)
- `@tabler/icons-webfont` CSS-классы вместо `@tabler/icons-react`
- Entrypoint: `DOMContentLoaded` + `__reactRoot` guard

## Test plan

- [ ] Vite build проходит без ошибок
- [ ] Виджет монтируется в `<div id="reconciliation-root">`
- [ ] Upload: drag-drop + кнопка выбора файла, валидация .xlsx
- [ ] Upload: POST FormData → результат сверки или ошибка
- [ ] Table: summary row + group_comparison + фильтр «только расхождения»
- [ ] History: пагинация, кнопка «Посмотреть» → загрузка результата
- [ ] Tabs: переключение upload / history / result

https://claude.ai/code/session_01Dmaofk1xAcfVAbUeYkxyJd