### PR TITLE
feat(Marketplace): temporary OVH migration check endpoint

### DIFF
--- a/site/assets/react/reconciliation/widgets/ReconciliationWidget.tsx
+++ b/site/assets/react/reconciliation/widgets/ReconciliationWidget.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback } from "react";
+import { httpJson } from "../../shared/http/client";
 import { useUploadReconciliation } from "../hooks/useUploadReconciliation";
 import { useSessionResult } from "../hooks/useSessionResult";
 import { useReconciliationHistory } from "../hooks/useReconciliationHistory";
@@ -14,6 +15,22 @@ const ReconciliationWidget: React.FC = () => {
     const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
     const [lastUploadResult, setLastUploadResult] = useState<ReconciliationSession | null>(null);
     const [historyPage, setHistoryPage] = useState(1);
+
+    // TEMPORARY — удалить после проверки миграции OVH
+    const [ovhResult, setOvhResult] = useState<unknown>(null);
+    const [ovhLoading, setOvhLoading] = useState(false);
+
+    const handleOvhCheck = useCallback(async () => {
+        setOvhLoading(true);
+        try {
+            const data = await httpJson("/api/marketplace/reconciliation/debug/ovh-check");
+            setOvhResult(data);
+        } catch (e: any) {
+            setOvhResult({ error: e?.message ?? "Ошибка" });
+        } finally {
+            setOvhLoading(false);
+        }
+    }, []);
 
     const uploadHook = useUploadReconciliation();
     const sessionQuery = useSessionResult(activeSessionId);
@@ -101,10 +118,25 @@ const ReconciliationWidget: React.FC = () => {
             {/* Result view */}
             {view === "result" && (
                 <div>
-                    <button className="btn btn-ghost-secondary btn-sm mb-3" onClick={handleBack}>
-                        <i className="ti ti-arrow-left me-1" />
-                        Назад к сверке
-                    </button>
+                    <div className="d-flex align-items-center mb-3">
+                        <button className="btn btn-ghost-secondary btn-sm" onClick={handleBack}>
+                            <i className="ti ti-arrow-left me-1" />
+                            Назад к сверке
+                        </button>
+                        {/* TEMPORARY — удалить после проверки миграции OVH */}
+                        <button
+                            className="btn btn-outline-warning btn-sm ms-2"
+                            onClick={handleOvhCheck}
+                            disabled={ovhLoading}
+                        >
+                            {ovhLoading ? "Загрузка..." : "OVH Check"}
+                        </button>
+                    </div>
+                    {ovhResult && (
+                        <pre className="bg-dark text-light p-3 rounded mb-3" style={{ fontSize: "0.8rem", maxHeight: "400px", overflow: "auto" }}>
+                            {JSON.stringify(ovhResult, null, 2)}
+                        </pre>
+                    )}
 
                     {sessionQuery.isLoading && (
                         <div className="card card-body">

--- a/site/src/Marketplace/Controller/Api/ReconciliationOvhCheckController.php
+++ b/site/src/Marketplace/Controller/Api/ReconciliationOvhCheckController.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Controller\Api;
+
+use App\Shared\Service\ActiveCompanyService;
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * TEMPORARY — удалить после проверки миграции OVH.
+ *
+ * Проверяет что категория ozon_ovh_processing создана и записи мигрированы.
+ */
+#[IsGranted('ROLE_USER')]
+final class ReconciliationOvhCheckController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $activeCompanyService,
+        private readonly Connection $connection,
+    ) {
+    }
+
+    #[Route(
+        '/api/marketplace/reconciliation/debug/ovh-check',
+        name: 'api_marketplace_reconciliation_debug_ovh_check',
+        methods: ['GET'],
+    )]
+    public function __invoke(): JsonResponse
+    {
+        $company   = $this->activeCompanyService->getActiveCompany();
+        $companyId = (string) $company->getId();
+
+        // 1. category_exists
+        $categoryRow = $this->connection->fetchAssociative(
+            <<<'SQL'
+            SELECT id, code, name
+            FROM marketplace_cost_categories
+            WHERE code = 'ozon_ovh_processing'
+              AND company_id = :companyId
+            SQL,
+            ['companyId' => $companyId],
+        );
+
+        $categoryExists = $categoryRow ?: null;
+
+        // 2. records_with_new_code
+        if ($categoryExists !== null) {
+            $count = (int) $this->connection->fetchOne(
+                <<<'SQL'
+                SELECT COUNT(*)
+                FROM marketplace_costs
+                WHERE category_id = :categoryId
+                  AND company_id = :companyId
+                SQL,
+                [
+                    'categoryId' => $categoryExists['id'],
+                    'companyId'  => $companyId,
+                ],
+            );
+            $recordsWithNewCode = ['count' => $count];
+        } else {
+            $recordsWithNewCode = ['count' => 0, 'error' => 'category not found'];
+        }
+
+        // 3. raw_data_sample — записи ozon_supply_additional за январь 2026
+        $supplyAdditionalId = $this->connection->fetchOne(
+            <<<'SQL'
+            SELECT id
+            FROM marketplace_cost_categories
+            WHERE code = 'ozon_supply_additional'
+              AND company_id = :companyId
+            SQL,
+            ['companyId' => $companyId],
+        );
+
+        $rawDataSample = [];
+        if ($supplyAdditionalId !== false) {
+            $rows = $this->connection->fetchAllAssociative(
+                <<<'SQL'
+                SELECT c.id, c.cost_date::text AS cost_date, c.amount, c.raw_data
+                FROM marketplace_costs c
+                WHERE c.category_id = :categoryId
+                  AND c.company_id = :companyId
+                  AND c.cost_date >= '2026-01-01'
+                  AND c.cost_date <= '2026-01-31'
+                LIMIT 10
+                SQL,
+                [
+                    'categoryId' => $supplyAdditionalId,
+                    'companyId'  => $companyId,
+                ],
+            );
+
+            foreach ($rows as $i => $row) {
+                $rawData = json_decode($row['raw_data'] ?? '{}', true);
+
+                $entry = [
+                    'id'        => $row['id'],
+                    'cost_date' => $row['cost_date'],
+                    'amount'    => $row['amount'],
+                ];
+
+                if ($i < 3) {
+                    // Первые 3 — полный JSON
+                    $entry['raw_data'] = $rawData;
+                } else {
+                    // Остальные — только ключи type/name/service_name
+                    $keys = ['type', 'name', 'service_name', 'operation_type', 'operation_type_name'];
+                    $summary = [];
+                    foreach ($keys as $key) {
+                        if (isset($rawData[$key])) {
+                            $summary[$key] = $rawData[$key];
+                        }
+                    }
+                    $entry['raw_data_keys'] = $summary;
+                }
+
+                $rawDataSample[] = $entry;
+            }
+        }
+
+        return $this->json([
+            'category_exists'       => $categoryExists,
+            'records_with_new_code' => $recordsWithNewCode,
+            'raw_data_sample'       => $rawDataSample,
+        ], 200, [], ['json_encode_options' => JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE]);
+    }
+}


### PR DESCRIPTION
## Summary

- Временный debug-эндпоинт для проверки что категория `ozon_ovh_processing` создана и записи мигрированы после деплоя задачи 10
- Кнопка «OVH Check» в UI сверки для быстрой проверки без curl/Postman

### Backend — `ReconciliationOvhCheckController.php` (NEW, TEMPORARY)

`GET /api/marketplace/reconciliation/debug/ovh-check` возвращает:
- `category_exists` — есть ли `ozon_ovh_processing` в `marketplace_cost_categories`
- `records_with_new_code` — сколько записей уже на новой категории
- `raw_data_sample` — до 10 записей `ozon_supply_additional` за январь 2026 (первые 3 с полным raw_data JSON, остальные — только ключи type/name/service_name)

Все запросы с `company_id` (IDOR-safe).

### Frontend — `ReconciliationWidget.tsx` (MODIFIED)

- Кнопка `btn-outline-warning btn-sm` «OVH Check» рядом с «Назад к сверке»
- По клику GET → endpoint, результат в `<pre>` блоке (raw JSON)

## Test plan

- [ ] Открыть результат сверки, нажать «OVH Check»
- [ ] Проверить что `category_exists` = null (до переобработки) или заполнен (после)
- [ ] Проверить что `records_with_new_code.count` соответствует ожиданию
- [ ] Проверить что `raw_data_sample` показывает записи с raw_data

https://claude.ai/code/session_01Dmaofk1xAcfVAbUeYkxyJd