### PR TITLE
feat(Marketplace): temporary endpoint to create ozon_ovh_processing category

### DIFF
--- a/site/src/Marketplace/Controller/Api/ReconciliationCreateOvhCategoryController.php
+++ b/site/src/Marketplace/Controller/Api/ReconciliationCreateOvhCategoryController.php
@@ -39,16 +39,20 @@ final class ReconciliationCreateOvhCategoryController extends AbstractController
         $company   = $this->activeCompanyService->getActiveCompany();
         $companyId = (string) $company->getId();
 
-        // Проверяем существует ли уже (учитываем soft delete как в MarketplaceCostCategoryResolver)
+        // Проверяем существует ли уже (marketplace + deleted_at как в MarketplaceCostCategoryResolver)
         $existing = $this->connection->fetchAssociative(
             <<<'SQL'
             SELECT id, code, name
             FROM marketplace_cost_categories
             WHERE code = 'ozon_ovh_processing'
               AND company_id = :companyId
+              AND marketplace = :marketplace
               AND deleted_at IS NULL
             SQL,
-            ['companyId' => $companyId],
+            [
+                'companyId'   => $companyId,
+                'marketplace' => MarketplaceType::OZON->value,
+            ],
         );
 
         if ($existing !== false) {

--- a/site/src/Marketplace/Controller/Api/ReconciliationCreateOvhCategoryController.php
+++ b/site/src/Marketplace/Controller/Api/ReconciliationCreateOvhCategoryController.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Controller\Api;
+
+use App\Marketplace\Application\Processor\OzonServiceCategoryMap;
+use App\Marketplace\Application\Service\MarketplaceCostCategoryResolver;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Shared\Service\ActiveCompanyService;
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * TEMPORARY — удалить после создания категории ozon_ovh_processing.
+ *
+ * Создаёт запись в marketplace_cost_categories если её ещё нет.
+ */
+#[IsGranted('ROLE_USER')]
+final class ReconciliationCreateOvhCategoryController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $activeCompanyService,
+        private readonly MarketplaceCostCategoryResolver $categoryResolver,
+        private readonly Connection $connection,
+    ) {
+    }
+
+    #[Route(
+        '/api/marketplace/reconciliation/debug/create-ovh-category',
+        name: 'api_marketplace_reconciliation_debug_create_ovh',
+        methods: ['POST'],
+    )]
+    public function __invoke(): JsonResponse
+    {
+        $company   = $this->activeCompanyService->getActiveCompany();
+        $companyId = (string) $company->getId();
+
+        // Проверяем существует ли уже
+        $existing = $this->connection->fetchAssociative(
+            <<<'SQL'
+            SELECT id, code, name
+            FROM marketplace_cost_categories
+            WHERE code = 'ozon_ovh_processing'
+              AND company_id = :companyId
+            SQL,
+            ['companyId' => $companyId],
+        );
+
+        if ($existing !== false) {
+            return $this->json([
+                'created' => false,
+                'message' => 'Категория уже существует',
+                'id'      => $existing['id'],
+                'code'    => $existing['code'],
+                'name'    => $existing['name'],
+            ]);
+        }
+
+        // Создаём через стандартный resolver (find-or-create + flush)
+        $categoryName = OzonServiceCategoryMap::getCategoryName('ozon_ovh_processing');
+        $category = $this->categoryResolver->resolve(
+            $company,
+            MarketplaceType::OZON,
+            'ozon_ovh_processing',
+            $categoryName,
+        );
+
+        return $this->json([
+            'created' => true,
+            'id'      => $category->getId(),
+            'code'    => 'ozon_ovh_processing',
+            'name'    => $categoryName,
+        ]);
+    }
+}

--- a/site/src/Marketplace/Controller/Api/ReconciliationCreateOvhCategoryController.php
+++ b/site/src/Marketplace/Controller/Api/ReconciliationCreateOvhCategoryController.php
@@ -39,13 +39,14 @@ final class ReconciliationCreateOvhCategoryController extends AbstractController
         $company   = $this->activeCompanyService->getActiveCompany();
         $companyId = (string) $company->getId();
 
-        // Проверяем существует ли уже
+        // Проверяем существует ли уже (учитываем soft delete как в MarketplaceCostCategoryResolver)
         $existing = $this->connection->fetchAssociative(
             <<<'SQL'
             SELECT id, code, name
             FROM marketplace_cost_categories
             WHERE code = 'ozon_ovh_processing'
               AND company_id = :companyId
+              AND deleted_at IS NULL
             SQL,
             ['companyId' => $companyId],
         );


### PR DESCRIPTION
## Summary

- Временный эндпоинт для создания категории `ozon_ovh_processing` в `marketplace_cost_categories` перед переимпортом затрат
- Использует стандартный `MarketplaceCostCategoryResolver::resolve()` (find-or-create + flush)

### Backend — `ReconciliationCreateOvhCategoryController.php` (NEW, TEMPORARY)

`POST /api/marketplace/reconciliation/debug/create-ovh-category`
- Проверяет наличие категории `ozon_ovh_processing` для активной компании
- Если уже есть → `{"created": false, "id": "...", ...}`
- Если нет → создаёт через resolver → `{"created": true, "id": "...", "code": "ozon_ovh_processing", "name": "Дополнительная обработка ОВХ Ozon"}`
- IDOR-safe (ActiveCompanyService)

### План использования после деплоя

1. `curl -X POST .../debug/create-ovh-category` — создать категорию
2. `bin/console app:marketplace:reprocess <companyId> ozon 2026-01-01 2026-01-31` — переимпорт затрат
3. Кнопка «OVH Check» в UI — убедиться что `records_with_new_code > 0`
4. Загрузить xlsx → дельта по «Другие услуги и штрафы» и «Услуги FBO» = 0

## Test plan

- [ ] POST `/api/marketplace/reconciliation/debug/create-ovh-category` → `created: true`
- [ ] Повторный POST → `created: false, message: "Категория уже существует"`
- [ ] OVH Check → `category_exists` заполнен

https://claude.ai/code/session_01Dmaofk1xAcfVAbUeYkxyJd