### PR TITLE
feat(Marketplace): load compensation operations into marketplace_costs

### DIFF
--- a/site/src/Marketplace/Application/Processor/OzonCostsRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonCostsRawProcessor.php
@@ -364,25 +364,33 @@ final class OzonCostsRawProcessor implements MarketplaceRawProcessorInterface
         }
 
         // 5. Если services[] пустой — затраты в op['amount'] напрямую
-        // Применимо к: реклама, хранение, кросс-докинг, поставка, досрочная выплата и т.д.
+        // Применимо к: реклама, хранение, кросс-докинг, поставка, досрочная выплата, компенсации и т.д.
         if (empty($services)) {
-            $opAmount = abs((float) ($op['amount'] ?? 0));
-            $opType   = $op['type'] ?? '';
+            $rawAmount = (float) ($op['amount'] ?? 0);
+            $opAmount  = abs($rawAmount);
+            $opType    = $op['type'] ?? '';
 
-            // Пропускаем продажи и компенсации (не затраты)
-            // type=compensation включает как компенсации от Ozon (доход) так и декомпенсации (расход),
-            // но они учитываются нетто на стороне Ozon — в ОПиУ не включаем.
-            if ($opAmount > 0.001 && !in_array($opType, ['orders', 'compensation'], true)) {
-                $operationType = $op['operation_type'] ?? '';
-                $categoryCode  = $this->resolveServiceCategoryCode($operationType);
+            // Пропускаем только продажи (не затраты)
+            if ($opAmount > 0.001 && $opType !== 'orders') {
+                if ($opType === 'compensation') {
+                    // Компенсации: принудительно ozon_compensation, сохраняем оригинальный знак
+                    // Положительный amount = компенсация от Ozon (доход)
+                    // Отрицательный amount = декомпенсация (расход)
+                    $categoryCode = 'ozon_compensation';
+                    $storedAmount = $rawAmount;
+                } else {
+                    $operationType = $op['operation_type'] ?? '';
+                    $categoryCode  = $this->resolveServiceCategoryCode($operationType);
+                    $storedAmount  = $opAmount;
+                }
 
                 $entries[] = [
                     'external_id'   => $operationId . '_main',
                     'category_code' => $categoryCode,
                     'category_name' => $this->resolveCategoryName($categoryCode),
-                    'amount'        => (string) $opAmount,
+                    'amount'        => (string) $storedAmount,
                     'cost_date'     => $operationDate,
-                    'description'   => $op['operation_type_name'] ?? $operationType,
+                    'description'   => $op['operation_type_name'] ?? ($op['operation_type'] ?? ''),
                     '_item_idx'     => 0,
                 ];
             }

--- a/site/src/Marketplace/Application/Processor/OzonCostsRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonCostsRawProcessor.php
@@ -373,9 +373,12 @@ final class OzonCostsRawProcessor implements MarketplaceRawProcessorInterface
             // Пропускаем только продажи (не затраты)
             if ($opAmount > 0.001 && $opType !== 'orders') {
                 if ($opType === 'compensation') {
-                    // Компенсации: принудительно ozon_compensation, сохраняем оригинальный знак
+                    // Компенсации: принудительно ozon_compensation, сохраняем оригинальный знак.
                     // Положительный amount = компенсация от Ozon (доход)
                     // Отрицательный amount = декомпенсация (расход)
+                    // NB: Знак НЕ инвертирован (в отличие от services[]):
+                    // в API положительный amount = доход, отрицательный = расход.
+                    // Сохраняем as-is чтобы SUM(amount) совпадал с xlsx net для сверки.
                     $categoryCode = 'ozon_compensation';
                     $storedAmount = $rawAmount;
                 } else {

--- a/site/src/Marketplace/Application/Processor/OzonServiceCategoryMap.php
+++ b/site/src/Marketplace/Application/Processor/OzonServiceCategoryMap.php
@@ -26,7 +26,7 @@ final class OzonServiceCategoryMap
      * Версия словаря — обновлять при любом изменении маппинга.
      * Используется в /marketplace/costs/debug/map-version для проверки деплоя.
      */
-    public const VERSION = '2026-04-10.1';
+    public const VERSION = '2026-04-10.2';
 
     /**
      * @var array<string, string|null>
@@ -214,7 +214,8 @@ final class OzonServiceCategoryMap
 
         // Коды, генерируемые в OzonCostsRawProcessor::extractCostEntries() напрямую
         // + ozon_other_service — fallback для неизвестных service names
-        foreach (['ozon_sale_commission', 'ozon_delivery', 'ozon_return_delivery', 'ozon_other_service'] as $extra) {
+        // + ozon_compensation — принудительно для opType=compensation
+        foreach (['ozon_sale_commission', 'ozon_delivery', 'ozon_return_delivery', 'ozon_other_service', 'ozon_compensation'] as $extra) {
             if (!isset($codes[$extra])) {
                 $codes[$extra] = self::getCategoryName($extra);
             }
@@ -280,6 +281,7 @@ final class OzonServiceCategoryMap
             'ozon_premium_correction'    => 'Корректировка премии Ozon',
             'ozon_service_correction'    => 'Корректировка стоимости услуг Ozon',
             'ozon_ovh_processing'        => 'Дополнительная обработка ОВХ Ozon',
+            'ozon_compensation'          => 'Компенсации и декомпенсации Ozon',
             default                      => 'Прочие услуги Ozon',
         };
     }

--- a/site/src/Marketplace/Application/Reconciliation/OzonXlsxServiceGroupMap.php
+++ b/site/src/Marketplace/Application/Reconciliation/OzonXlsxServiceGroupMap.php
@@ -110,9 +110,9 @@ final class OzonXlsxServiceGroupMap
             'ozon_service_correction'    => 'Другие услуги и штрафы',
             'ozon_other_service'         => 'Другие услуги и штрафы',
 
-            // Компенсации и декомпенсации — не маппятся.
-            // Операции типа 'compensation' не загружаются в marketplace_costs (фильтр в OzonCostsRawProcessor).
-            // Расхождение по этой группе при сверке ожидаемо.
+            // === Компенсации и декомпенсации ===
+            // Типы: Компенсация, Декомпенсация
+            'ozon_compensation'          => 'Компенсации и декомпенсации',
         ];
     }
 }


### PR DESCRIPTION
## Summary

- Убран фильтр `compensation` из `OzonCostsRawProcessor` — компенсации теперь загружаются в `marketplace_costs`
- Принудительное присвоение `category_code = 'ozon_compensation'` (минуя fuzzy matcher) для `opType === 'compensation'`
- Сохранение оригинального знака amount (не abs): положительный = компенсация (доход), отрицательный = декомпенсация (расход), чтобы `SUM(amount)` совпадал с xlsx net для сверки
- Добавлен `ozon_compensation` в `OzonServiceCategoryMap` (getCategoryName, getAllCategoryCodes, VERSION bump)
- Добавлен маппинг `ozon_compensation` → «Компенсации и декомпенсации» в `OzonXlsxServiceGroupMap`

## Test plan

- [ ] Задеплоить, создать категорию `ozon_compensation` (через debug endpoint или автоматически при reprocess)
- [ ] Запустить `bin/console app:marketplace:reprocess <companyId> ozon 2026-01-01 2026-01-31`
- [ ] Проверить что в `marketplace_costs` появились записи с `category_code = 'ozon_compensation'`
- [ ] Запустить сверку — группа «Компенсации и декомпенсации» должна показать совпадение api_net ≈ xlsx_net

https://claude.ai/code/session_01Dmaofk1xAcfVAbUeYkxyJd