### PR TITLE
fix(Marketplace): recalculate reconciliation totals from group deltas

### DIFF
--- a/site/src/Marketplace/Application/RunUserReconciliationAction.php
+++ b/site/src/Marketplace/Application/RunUserReconciliationAction.php
@@ -57,6 +57,8 @@ final class RunUserReconciliationAction
                 $returnsTotal,
             );
 
+            $reconcileResult = $this->recalculateTotals($reconcileResult);
+
             $session->markCompleted($reconcileResult);
             $this->em->flush();
         } catch (\Throwable $e) {
@@ -106,14 +108,34 @@ final class RunUserReconciliationAction
 
         $reconcileResult['group_comparison'] = $groupComparison;
 
-        // Update overall status: mismatch if any group has mismatch
+        return $reconcileResult;
+    }
+
+    /**
+     * Пересчитать итоговые поля (xlsx_total, delta, status) на основе group_comparison.
+     *
+     * CostReconciliationQuery считает xlsx_total только из отрицательных xlsx-групп,
+     * поэтому положительные группы (компенсации) выпадают. Здесь мы пересчитываем
+     * итоги как сумму дельт по всем группам — если каждая группа совпала, итог тоже 0.
+     *
+     * @param array<string, mixed> $reconcileResult
+     * @return array<string, mixed>
+     */
+    private function recalculateTotals(array $reconcileResult): array
+    {
+        $groupComparison = $reconcileResult['group_comparison'] ?? [];
+
+        $totalDelta  = 0.0;
         $hasMismatch = false;
-        foreach ($groupComparison as $g) {
-            if ($g['status'] === 'mismatch') {
+
+        foreach ($groupComparison as $group) {
+            $totalDelta += abs($group['delta'] ?? 0);
+            if (($group['status'] ?? '') === 'mismatch') {
                 $hasMismatch = true;
-                break;
             }
         }
+
+        $reconcileResult['delta']  = round($totalDelta, 2);
         $reconcileResult['status'] = $hasMismatch ? 'mismatch' : 'matched';
 
         return $reconcileResult;


### PR DESCRIPTION
## Summary

- `CostReconciliationQuery::reconcile()` считает `xlsx_total` только из отрицательных xlsx-групп → положительные группы (компенсации +6 423,86 ₽) выпадают из xlsx-стороны, но попадают в `api_net_amount` → итоговая дельта = 6 423,86 при том что по группам всё совпадает
- Добавлен метод `recalculateTotals()` в `RunUserReconciliationAction` — пересчитывает итоговые `delta` и `status` как сумму дельт по всем группам из `group_comparison`
- `CostReconciliationQuery` **не модифицирован** (используется в закрытии месяца и debug-странице)
- Убран дублирующий блок пересчёта `status` из `enrichWithSalesAndReturns` — теперь единая точка в `recalculateTotals()`

## Test plan

- [ ] Загрузить xlsx за январь 2026
- [ ] По группам — все «Совпадает» (как было)
- [ ] Итоговая дельта в шапке — **0,00 ₽** (было 6 423,86 ₽)
- [ ] Общий статус — **Совпадает**

https://claude.ai/code/session_01Dmaofk1xAcfVAbUeYkxyJd