### PR TITLE
feat(Marketplace): Sales Check button in reconciliation UI

### DIFF
--- a/site/assets/react/reconciliation/widgets/ReconciliationWidget.tsx
+++ b/site/assets/react/reconciliation/widgets/ReconciliationWidget.tsx
@@ -20,6 +20,10 @@ const ReconciliationWidget: React.FC = () => {
     const [ovhResult, setOvhResult] = useState<unknown>(null);
     const [ovhLoading, setOvhLoading] = useState(false);
 
+    // TEMPORARY — удалить после диагностики продаж
+    const [salesCheckResult, setSalesCheckResult] = useState<unknown>(null);
+    const [salesCheckLoading, setSalesCheckLoading] = useState(false);
+
     const handleOvhCheck = useCallback(async () => {
         setOvhLoading(true);
         try {
@@ -29,6 +33,26 @@ const ReconciliationWidget: React.FC = () => {
             setOvhResult({ error: e?.message ?? "Ошибка" });
         } finally {
             setOvhLoading(false);
+        }
+    }, []);
+
+    // TEMPORARY — удалить после диагностики продаж
+    const handleSalesCheck = useCallback(async (session: ReconciliationSession) => {
+        setSalesCheckLoading(true);
+        try {
+            const data = await httpJson("/api/marketplace/reconciliation/debug/sales-check", {
+                method: "POST",
+                body: JSON.stringify({
+                    periodFrom: session.periodFrom,
+                    periodTo: session.periodTo,
+                    marketplace: session.marketplace,
+                }),
+            });
+            setSalesCheckResult(data);
+        } catch (e: any) {
+            setSalesCheckResult({ error: e?.message ?? "Ошибка" });
+        } finally {
+            setSalesCheckLoading(false);
         }
     }, []);
 
@@ -131,10 +155,25 @@ const ReconciliationWidget: React.FC = () => {
                         >
                             {ovhLoading ? "Загрузка..." : "OVH Check"}
                         </button>
+                        {/* TEMPORARY — удалить после диагностики продаж */}
+                        {displaySession && (
+                            <button
+                                className="btn btn-outline-info btn-sm ms-2"
+                                onClick={() => handleSalesCheck(displaySession)}
+                                disabled={salesCheckLoading}
+                            >
+                                {salesCheckLoading ? "Загрузка..." : "Sales Check"}
+                            </button>
+                        )}
                     </div>
                     {ovhResult && (
                         <pre className="bg-dark text-light p-3 rounded mb-3" style={{ fontSize: "0.8rem", maxHeight: "400px", overflow: "auto" }}>
                             {JSON.stringify(ovhResult, null, 2)}
+                        </pre>
+                    )}
+                    {salesCheckResult && (
+                        <pre className="bg-dark text-light p-3 rounded mb-3" style={{ fontSize: "0.8rem", maxHeight: "400px", overflow: "auto" }}>
+                            {JSON.stringify(salesCheckResult, null, 2)}
                         </pre>
                     )}
 

--- a/site/src/Marketplace/Controller/Api/ReconciliationSalesCheckController.php
+++ b/site/src/Marketplace/Controller/Api/ReconciliationSalesCheckController.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Controller\Api;
+
+use App\Shared\Service\ActiveCompanyService;
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * TEMPORARY — удалить после диагностики расхождения в продажах.
+ *
+ * Диагностика: итоги продаж из marketplace_sales за период,
+ * разбивка по дням, граничные дни.
+ */
+#[IsGranted('ROLE_USER')]
+final class ReconciliationSalesCheckController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $activeCompanyService,
+        private readonly Connection $connection,
+    ) {
+    }
+
+    #[Route(
+        '/api/marketplace/reconciliation/debug/sales-check',
+        name: 'api_marketplace_reconciliation_debug_sales_check',
+        methods: ['POST'],
+    )]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $company   = $this->activeCompanyService->getActiveCompany();
+        $companyId = (string) $company->getId();
+
+        $payload     = json_decode($request->getContent(), true) ?? [];
+        $periodFrom  = $payload['periodFrom'] ?? '';
+        $periodTo    = $payload['periodTo'] ?? '';
+        $marketplace = $payload['marketplace'] ?? 'ozon';
+
+        if ($periodFrom === '' || $periodTo === '') {
+            return $this->json(['error' => 'periodFrom and periodTo are required'], 400);
+        }
+
+        $params = [
+            'companyId'   => $companyId,
+            'marketplace' => $marketplace,
+            'periodFrom'  => $periodFrom,
+            'periodTo'    => $periodTo,
+        ];
+
+        // 1. sales_total
+        $salesTotal = $this->connection->fetchAssociative(
+            <<<'SQL'
+            SELECT
+                COUNT(*)              AS count,
+                SUM(s.total_revenue)  AS total_revenue,
+                SUM(s.quantity)       AS total_quantity,
+                MIN(s.sale_date)::text AS min_date,
+                MAX(s.sale_date)::text AS max_date
+            FROM marketplace_sales s
+            WHERE s.company_id  = :companyId
+              AND s.marketplace = :marketplace
+              AND s.sale_date  >= :periodFrom
+              AND s.sale_date  <= :periodTo
+            SQL,
+            $params,
+        );
+
+        // 2. sales_by_date
+        $salesByDate = $this->connection->fetchAllAssociative(
+            <<<'SQL'
+            SELECT
+                s.sale_date::text AS sale_date,
+                COUNT(*)              AS count,
+                SUM(s.total_revenue)  AS total_revenue
+            FROM marketplace_sales s
+            WHERE s.company_id  = :companyId
+              AND s.marketplace = :marketplace
+              AND s.sale_date  >= :periodFrom
+              AND s.sale_date  <= :periodTo
+            GROUP BY s.sale_date
+            ORDER BY s.sale_date
+            SQL,
+            $params,
+        );
+
+        // 3. xlsx_sales_total — константа для удобства сравнения
+        $xlsxSalesTotal = 5794309.01;
+
+        // 4. boundary_sales — продажи на границах периода
+        $boundaryParams = [
+            'companyId'   => $companyId,
+            'marketplace' => $marketplace,
+        ];
+
+        $prevDay = (new \DateTimeImmutable($periodFrom))
+            ->modify('-1 day')
+            ->format('Y-m-d');
+
+        $nextDay = (new \DateTimeImmutable($periodTo))
+            ->modify('+1 day')
+            ->format('Y-m-d');
+
+        $prevDaySales = $this->connection->fetchAssociative(
+            <<<'SQL'
+            SELECT COUNT(*) AS count, COALESCE(SUM(s.total_revenue), 0) AS total_revenue
+            FROM marketplace_sales s
+            WHERE s.company_id  = :companyId
+              AND s.marketplace = :marketplace
+              AND s.sale_date   = :saleDate
+            SQL,
+            array_merge($boundaryParams, ['saleDate' => $prevDay]),
+        );
+
+        $nextDaySales = $this->connection->fetchAssociative(
+            <<<'SQL'
+            SELECT COUNT(*) AS count, COALESCE(SUM(s.total_revenue), 0) AS total_revenue
+            FROM marketplace_sales s
+            WHERE s.company_id  = :companyId
+              AND s.marketplace = :marketplace
+              AND s.sale_date   = :saleDate
+            SQL,
+            array_merge($boundaryParams, ['saleDate' => $nextDay]),
+        );
+
+        // delta
+        $apiTotal = (float) ($salesTotal['total_revenue'] ?? 0);
+        $delta    = round($apiTotal - $xlsxSalesTotal, 2);
+
+        return $this->json([
+            'sales_total'      => $salesTotal,
+            'sales_by_date'    => $salesByDate,
+            'xlsx_sales_total' => $xlsxSalesTotal,
+            'delta'            => $delta,
+            'boundary_sales'   => [
+                $prevDay => $prevDaySales,
+                $nextDay => $nextDaySales,
+            ],
+        ], 200, [], ['json_encode_options' => JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE]);
+    }
+}


### PR DESCRIPTION
## Summary

- Кнопка «Sales Check» (`btn-outline-info`) рядом с «OVH Check» на странице результата сверки
- POST `/api/marketplace/reconciliation/debug/sales-check` с `periodFrom`, `periodTo`, `marketplace` из текущей сессии
- Результат в `<pre>` блоке (raw JSON) — аналогично OVH Check
- Временный код для диагностики расхождения в продажах за февраль

## Test plan

- [ ] Открыть результат сверки — кнопка «Sales Check» видна рядом с «OVH Check»
- [ ] Клик → загрузка → JSON с `sales_total`, `sales_by_date`, `boundary_sales`, `delta`

https://claude.ai/code/session_01Dmaofk1xAcfVAbUeYkxyJd