### PR TITLE
fix(Marketplace): detailed error handling in sales-check endpoint

### DIFF
--- a/site/src/Marketplace/Controller/Api/ReconciliationSalesCheckController.php
+++ b/site/src/Marketplace/Controller/Api/ReconciliationSalesCheckController.php
@@ -46,6 +46,24 @@ final class ReconciliationSalesCheckController extends AbstractController
             return $this->json(['error' => 'periodFrom and periodTo are required'], 400);
         }
 
+        try {
+            return $this->buildResponse($companyId, $marketplace, $periodFrom, $periodTo);
+        } catch (\Throwable $e) {
+            return new JsonResponse([
+                'error' => $e->getMessage(),
+                'file'  => $e->getFile() . ':' . $e->getLine(),
+                'trace' => array_slice(explode("\n", $e->getTraceAsString()), 0, 5),
+            ], 500);
+        }
+    }
+
+    private function buildResponse(
+        string $companyId,
+        string $marketplace,
+        string $periodFrom,
+        string $periodTo,
+    ): JsonResponse {
+
         $params = [
             'companyId'   => $companyId,
             'marketplace' => $marketplace,


### PR DESCRIPTION
## Summary

- Обёрнул SQL-запросы в `try/catch(\Throwable)` с детальным ответом (message, file:line, trace top-5)
- Вынес логику запросов в приватный `buildResponse()` для чистоты `__invoke`
- Проверил что `s.company_id = :companyId` с UUID-строкой — тот же паттерн что в `SalesReturnsTotalQuery`

## Test plan

- [ ] POST с корректными данными → JSON ответ как раньше
- [ ] POST с некорректным periodFrom → 500 с детальной ошибкой (message, file, trace)

https://claude.ai/code/session_01Dmaofk1xAcfVAbUeYkxyJd