### PR TITLE
debug(Marketplace): early return in sales-check to verify routing

### DIFF
--- a/site/src/Marketplace/Controller/Api/ReconciliationSalesCheckController.php
+++ b/site/src/Marketplace/Controller/Api/ReconciliationSalesCheckController.php
@@ -34,6 +34,9 @@ final class ReconciliationSalesCheckController extends AbstractController
     )]
     public function __invoke(Request $request): JsonResponse
     {
+        // TEMPORARY DEBUG — удалить после диагностики
+        return new JsonResponse(['debug' => 'reached', 'method' => $request->getMethod(), 'content' => $request->getContent()]);
+
         $company   = $this->activeCompanyService->getActiveCompany();
         $companyId = (string) $company->getId();
 


### PR DESCRIPTION
## Summary

- Временный early return в sales-check для диагностики — проверить доходит ли запрос до контроллера
- Возвращает `{debug: "reached", method: "...", content: "..."}` без выполнения SQL
- Удалить после диагностики

https://claude.ai/code/session_01Dmaofk1xAcfVAbUeYkxyJd