### PR TITLE
fix(Marketplace): fix double JSON serialization in sales-check

### DIFF
--- a/site/assets/react/reconciliation/widgets/ReconciliationWidget.tsx
+++ b/site/assets/react/reconciliation/widgets/ReconciliationWidget.tsx
@@ -42,11 +42,11 @@ const ReconciliationWidget: React.FC = () => {
         try {
             const data = await httpJson("/api/marketplace/reconciliation/debug/sales-check", {
                 method: "POST",
-                body: JSON.stringify({
+                body: {
                     periodFrom: session.periodFrom,
                     periodTo: session.periodTo,
                     marketplace: session.marketplace,
-                }),
+                },
             });
             setSalesCheckResult(data);
         } catch (e: any) {

--- a/site/src/Marketplace/Controller/Api/ReconciliationSalesCheckController.php
+++ b/site/src/Marketplace/Controller/Api/ReconciliationSalesCheckController.php
@@ -34,9 +34,6 @@ final class ReconciliationSalesCheckController extends AbstractController
     )]
     public function __invoke(Request $request): JsonResponse
     {
-        // TEMPORARY DEBUG — удалить после диагностики
-        return new JsonResponse(['debug' => 'reached', 'method' => $request->getMethod(), 'content' => $request->getContent()]);
-
         $company   = $this->activeCompanyService->getActiveCompany();
         $companyId = (string) $company->getId();
 


### PR DESCRIPTION
## Summary

- **Fix double JSON serialization**: `httpJson()` already calls `JSON.stringify(opts.body)`, but the widget passed `body: JSON.stringify({...})` — resulting in a double-stringified body on the server. Fix: pass plain object.
- **Remove debug early return** from `ReconciliationSalesCheckController` — restore normal SQL logic.

## Root cause

`httpJson()` in `shared/http/client.ts` line 92: `body = JSON.stringify(opts.body)`. Passing a pre-stringified string as `opts.body` causes `JSON.stringify("...")` = `"\"...\""`.

## Test plan

- [ ] Click «Sales Check» → should return sales data JSON (not error, not debug stub)
- [ ] Verify `content` in response is proper JSON object, not escaped string

https://claude.ai/code/session_01Dmaofk1xAcfVAbUeYkxyJd