### PR TITLE
fix: import storno sales with negative accruals_for_sale

### DIFF
--- a/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
@@ -59,7 +59,7 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
 
         $salesData = array_filter($rawRows, static function (array $op): bool {
             return ($op['type'] ?? '') === 'orders'
-                && (float) ($op['accruals_for_sale'] ?? 0) > 0;
+                && (float) ($op['accruals_for_sale'] ?? 0) != 0;
         });
 
         if (empty($salesData)) {
@@ -83,7 +83,12 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
         $allExternalIds = array_values(array_map(
             static function (array $op): string {
                 $postingNumber = $op['posting']['posting_number'] ?? '';
-                return $postingNumber !== '' ? $postingNumber : (string) ($op['operation_id'] ?? '');
+                $externalId = $postingNumber !== '' ? $postingNumber : (string) ($op['operation_id'] ?? '');
+                // Storno operations get a suffix to avoid UNIQUE constraint conflict
+                if ((float) ($op['accruals_for_sale'] ?? 0) < 0) {
+                    $externalId .= '_storno';
+                }
+                return $externalId;
             },
             $salesData,
         ));
@@ -92,6 +97,14 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
         foreach ($salesData as $op) {
             $postingNumber = $op['posting']['posting_number'] ?? '';
             $externalId = $postingNumber !== '' ? $postingNumber : (string) ($op['operation_id'] ?? '');
+
+            $accrual  = (float) ($op['accruals_for_sale'] ?? 0);
+            $isStorno = $accrual < 0;
+
+            // Storno operations get a suffix to avoid UNIQUE constraint conflict
+            if ($isStorno) {
+                $externalId .= '_storno';
+            }
 
             if ($externalId === '' || isset($existingMap[$externalId])) {
                 continue;
@@ -109,7 +122,6 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
                 continue;
             }
 
-            $accrual  = (float) ($op['accruals_for_sale'] ?? 0);
             $saleDate = new \DateTimeImmutable($op['operation_date']);
 
             $sale = new MarketplaceSale(
@@ -124,7 +136,8 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
             $sale->setQuantity(count($op['items'] ?? []) ?: 1);
             $sale->setPricePerUnit((string) $accrual);
             $sale->setTotalRevenue((string) $accrual);
-            $sale->setCostPrice($this->costPriceResolver->resolveForSale($listing, $saleDate));
+            // Storno: no goods shipped, cost_price must be null
+            $sale->setCostPrice($isStorno ? null : $this->costPriceResolver->resolveForSale($listing, $saleDate));
             $sale->setRawData($op);
 
             $this->em->persist($sale);


### PR DESCRIPTION
## Summary

- OzonSalesRawProcessor фильтровал `accruals_for_sale > 0`, отбрасывая сторно-операции (отмены продаж с отрицательной суммой)
- Это вызывало расхождение 2 402₽ между API и xlsx за февраль 2026 (2 отменённых заказа по 1 201₽)
- Фильтр изменён на `!= 0` — сторно загружается с суффиксом `_storno` в external_order_id
- `cost_price = null` для сторно (товар не отгружался)

**После деплоя:** `bin/console app:marketplace:reprocess <companyId> ozon 2026-02-01 2026-02-28`

## Test plan

- [ ] Переимпорт продаж за февраль — сторно-записи появляются в marketplace_sales
- [ ] Сверка xlsx февраль — дельта продаж = 0
- [ ] Unit Extended — выручка совпадает с xlsx
- [ ] Закрытие месяца — не сломалось

https://claude.ai/code/session_01Dmaofk1xAcfVAbUeYkxyJd