### PR TITLE
fix: default marketplace to Ozon on Unit Extended page

### DIFF
--- a/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedWidget.tsx
+++ b/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedWidget.tsx
@@ -19,7 +19,7 @@ function getFiltersFromUrl(): Filters {
     const params = new URLSearchParams(window.location.search);
     const currentMonth = getMonthRange(0);
     return {
-        marketplace: params.get('marketplace') ?? '',
+        marketplace: params.get('marketplace') ?? 'ozon',
         dateFrom: params.get('from') ?? currentMonth.from,
         dateTo: params.get('to') ?? currentMonth.to,
     };


### PR DESCRIPTION
## Summary

- Дефолтный фильтр маркетплейса на странице Unit Extended изменён с "Все" на "Ozon"
- Dropdown показывает "Ozon" выбранным при открытии страницы
- Запрос идёт с `?marketplace=ozon`, а не по всем маркетплейсам

https://claude.ai/code/session_01Dmaofk1xAcfVAbUeYkxyJd