### PR TITLE
feat: add Margin % and ROI % columns to Unit Extended

### DIFF
--- a/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedTable.tsx
+++ b/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedTable.tsx
@@ -60,7 +60,10 @@ function comparator(a: UnitExtendedItem, b: UnitExtendedItem, field: SortField):
     if (field === 'title') {
         return a.title.localeCompare(b.title, 'ru');
     }
-    return ((a[field] as number | null) ?? -Infinity) - ((b[field] as number | null) ?? -Infinity);
+    const valA = (a[field] as number | null) ?? -Infinity;
+    const valB = (b[field] as number | null) ?? -Infinity;
+    if (valA === valB) return 0;
+    return valA - valB;
 }
 
 function marginColor(v: number | null): string {
@@ -68,6 +71,10 @@ function marginColor(v: number | null): string {
     if (v < 5) return 'text-red';
     if (v <= 15) return 'text-yellow';
     return 'text-green';
+}
+
+function roiColor(v: number | null): string {
+    return v !== null && v < 0 ? 'text-red' : '';
 }
 
 function formatPercent(v: number | null): React.ReactNode {
@@ -190,7 +197,7 @@ const UnitExtendedTable: React.FC<UnitExtendedTableProps> = ({ items, totals, is
                                     <td className={`text-end ${marginColor(row.marginPercent)}`}>
                                         {formatPercent(row.marginPercent)}
                                     </td>
-                                    <td className={`text-end ${row.roiPercent !== null && row.roiPercent < 0 ? 'text-red' : ''}`}>
+                                    <td className={`text-end ${roiColor(row.roiPercent)}`}>
                                         {formatPercent(row.roiPercent)}
                                     </td>
                                     <td className="text-end">
@@ -249,7 +256,7 @@ const UnitExtendedTable: React.FC<UnitExtendedTableProps> = ({ items, totals, is
                             <td className={`text-end ${marginColor(totals.marginPercent)}`}>
                                 {formatPercent(totals.marginPercent)}
                             </td>
-                            <td className={`text-end ${totals.roiPercent !== null && totals.roiPercent < 0 ? 'text-red' : ''}`}>
+                            <td className={`text-end ${roiColor(totals.roiPercent)}`}>
                                 {formatPercent(totals.roiPercent)}
                             </td>
                             <td></td>

--- a/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedTable.tsx
+++ b/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedTable.tsx
@@ -14,7 +14,9 @@ type SortField =
     | 'logistics'
     | 'otherCosts'
     | 'totalCosts'
-    | 'profit';
+    | 'profit'
+    | 'marginPercent'
+    | 'roiPercent';
 
 type SortDir = 'asc' | 'desc';
 
@@ -50,13 +52,27 @@ const HEADERS: { field: SortField; label: string; align?: string }[] = [
     { field: 'otherCosts', label: 'Прочие затраты', align: 'text-end' },
     { field: 'totalCosts', label: 'Итого затрат', align: 'text-end' },
     { field: 'profit', label: 'Прибыль', align: 'text-end' },
+    { field: 'marginPercent', label: 'Маржа %', align: 'text-end' },
+    { field: 'roiPercent', label: 'ROI %', align: 'text-end' },
 ];
 
 function comparator(a: UnitExtendedItem, b: UnitExtendedItem, field: SortField): number {
     if (field === 'title') {
         return a.title.localeCompare(b.title, 'ru');
     }
-    return (a[field] as number) - (b[field] as number);
+    return ((a[field] as number | null) ?? -Infinity) - ((b[field] as number | null) ?? -Infinity);
+}
+
+function marginColor(v: number | null): string {
+    if (v === null) return '';
+    if (v < 5) return 'text-red';
+    if (v <= 15) return 'text-yellow';
+    return 'text-green';
+}
+
+function formatPercent(v: number | null): React.ReactNode {
+    if (v === null) return '\u2014';
+    return `${v.toFixed(1)}%`;
 }
 
 const UnitExtendedTable: React.FC<UnitExtendedTableProps> = ({ items, totals, isLoading }) => {
@@ -112,7 +128,7 @@ const UnitExtendedTable: React.FC<UnitExtendedTableProps> = ({ items, totals, is
         );
     }
 
-    const colCount = HEADERS.length + 1; // +1 for "Все затраты" column
+    const colCount = HEADERS.length + 1; // +1 for "Все затраты" button column
 
     return (
         <div className="table-responsive">
@@ -171,6 +187,12 @@ const UnitExtendedTable: React.FC<UnitExtendedTableProps> = ({ items, totals, is
                                             {formatMoney(row.profit)}
                                         </span>
                                     </td>
+                                    <td className={`text-end ${marginColor(row.marginPercent)}`}>
+                                        {formatPercent(row.marginPercent)}
+                                    </td>
+                                    <td className={`text-end ${row.roiPercent !== null && row.roiPercent < 0 ? 'text-red' : ''}`}>
+                                        {formatPercent(row.roiPercent)}
+                                    </td>
                                     <td className="text-end">
                                         <button
                                             type="button"
@@ -223,6 +245,12 @@ const UnitExtendedTable: React.FC<UnitExtendedTableProps> = ({ items, totals, is
                                 <span className={totals.profit >= 0 ? 'text-green' : 'text-red'}>
                                     {formatMoney(totals.profit)}
                                 </span>
+                            </td>
+                            <td className={`text-end ${marginColor(totals.marginPercent)}`}>
+                                {formatPercent(totals.marginPercent)}
+                            </td>
+                            <td className={`text-end ${totals.roiPercent !== null && totals.roiPercent < 0 ? 'text-red' : ''}`}>
+                                {formatPercent(totals.roiPercent)}
                             </td>
                             <td></td>
                         </tr>

--- a/site/assets/react/marketplace-analytics/unit-extended/unitExtended.types.ts
+++ b/site/assets/react/marketplace-analytics/unit-extended/unitExtended.types.ts
@@ -29,6 +29,8 @@ export interface UnitExtendedItem {
     otherCosts: number;
     totalCosts: number;
     profit: number;
+    marginPercent: number | null;
+    roiPercent: number | null;
     otherCostsBreakdown: CostGroupBreakdown[];
     allCostsBreakdown: CostGroupBreakdown[];
 }
@@ -43,6 +45,8 @@ export interface UnitExtendedTotals {
     otherCosts: number;
     totalCosts: number;
     profit: number;
+    marginPercent: number | null;
+    roiPercent: number | null;
 }
 
 export interface UnitExtendedResponse {

--- a/site/src/MarketplaceAnalytics/Infrastructure/Query/UnitExtendedQuery.php
+++ b/site/src/MarketplaceAnalytics/Infrastructure/Query/UnitExtendedQuery.php
@@ -137,6 +137,8 @@ final readonly class UnitExtendedQuery
                 'otherCosts' => $otherCosts,
                 'totalCosts' => $totalCostsVal,
                 'profit' => $profit,
+                'marginPercent' => $revenue > 0 ? round($profit / $revenue * 100, 1) : null,
+                'roiPercent' => $costPriceTotal > 0 ? round($profit / $costPriceTotal * 100, 1) : null,
                 'otherCostsBreakdown' => $otherBreakdown,
                 'allCostsBreakdown' => $allBreakdown,
             ];
@@ -160,6 +162,13 @@ final readonly class UnitExtendedQuery
         foreach ($totals as $key => $val) {
             $totals[$key] = is_float($val) ? round($val, 2) : $val;
         }
+
+        $totals['marginPercent'] = $totals['revenue'] > 0
+            ? round($totals['profit'] / $totals['revenue'] * 100, 1)
+            : null;
+        $totals['roiPercent'] = $totals['costPriceTotal'] > 0
+            ? round($totals['profit'] / $totals['costPriceTotal'] * 100, 1)
+            : null;
 
         // Limit items for response; totals remain complete
         $items = \array_slice($items, 0, $limit);


### PR DESCRIPTION
## Summary\n\n- Add **Маржа %** and **ROI %** columns to Unit Extended table (both per-listing and totals row)\n- Backend: compute `marginPercent = profit / revenue * 100` and `roiPercent = profit / costPriceTotal * 100` in `UnitExtendedQuery.php`\n- Frontend: new sortable columns with color coding (red < 5%, yellow 5–15%, green > 15% for margin; red for negative ROI)\n- Handle nullable values (null when divisor is zero, displayed as \"—\")\n\n## Test plan\n\n- [ ] Open `/marketplace-analytics/unit-extended` with Ozon selected\n- [ ] Verify Маржа % and ROI % columns appear with correct values\n- [ ] Verify color coding: red for margin < 5%, yellow for 5–15%, green for > 15%\n- [ ] Verify ROI % shows red for negative values\n- [ ] Verify totals row shows aggregated margin and ROI percentages\n- [ ] Verify sorting works on both new columns\n- [ ] Verify \"—\" displayed when revenue or cost price is zero\n\nhttps://claude.ai/code/session_01Dmaofk1xAcfVAbUeYkxyJd