### PR TITLE
feat(MarketplaceAds): AdRawDocument, AdDocument, AdDocumentLine entities + repositories + migration

### DIFF
--- a/site/migrations/Version20260412053206.php
+++ b/site/migrations/Version20260412053206.php
@@ -73,6 +73,7 @@ final class Version20260412053206 extends AbstractMigration
                 impressions INT NOT NULL,
                 clicks INT NOT NULL,
                 PRIMARY KEY(id),
+                CONSTRAINT uq_ad_document_line_document_listing UNIQUE (ad_document_id, listing_id),
                 CONSTRAINT fk_ad_document_line_document
                     FOREIGN KEY (ad_document_id)
                     REFERENCES marketplace_ad_documents (id)

--- a/site/migrations/Version20260412053206.php
+++ b/site/migrations/Version20260412053206.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260412053206 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'MarketplaceAds: create marketplace_ad_raw_documents, marketplace_ad_documents, marketplace_ad_document_lines';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE marketplace_ad_raw_documents (
+                id VARCHAR(36) NOT NULL,
+                company_id VARCHAR(36) NOT NULL,
+                marketplace VARCHAR(50) NOT NULL,
+                report_date DATE NOT NULL,
+                loaded_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                raw_payload TEXT NOT NULL,
+                status VARCHAR(20) NOT NULL DEFAULT 'draft',
+                created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                PRIMARY KEY(id),
+                CONSTRAINT uq_ad_raw_document_company_marketplace_date UNIQUE (company_id, marketplace, report_date)
+            )
+        SQL);
+        $this->addSql('CREATE INDEX idx_ad_raw_document_company ON marketplace_ad_raw_documents (company_id)');
+        $this->addSql('CREATE INDEX idx_ad_raw_document_company_marketplace ON marketplace_ad_raw_documents (company_id, marketplace)');
+        $this->addSql("COMMENT ON COLUMN marketplace_ad_raw_documents.report_date IS '(DC2Type:date_immutable)'");
+        $this->addSql("COMMENT ON COLUMN marketplace_ad_raw_documents.loaded_at IS '(DC2Type:datetime_immutable)'");
+        $this->addSql("COMMENT ON COLUMN marketplace_ad_raw_documents.created_at IS '(DC2Type:datetime_immutable)'");
+        $this->addSql("COMMENT ON COLUMN marketplace_ad_raw_documents.updated_at IS '(DC2Type:datetime_immutable)'");
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE marketplace_ad_documents (
+                id VARCHAR(36) NOT NULL,
+                company_id VARCHAR(36) NOT NULL,
+                marketplace VARCHAR(50) NOT NULL,
+                report_date DATE NOT NULL,
+                campaign_id VARCHAR(255) NOT NULL,
+                campaign_name VARCHAR(255) NOT NULL,
+                parent_sku VARCHAR(255) NOT NULL,
+                total_cost NUMERIC(14, 2) NOT NULL,
+                total_impressions INT NOT NULL,
+                total_clicks INT NOT NULL,
+                ad_raw_document_id VARCHAR(36) NOT NULL,
+                created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                PRIMARY KEY(id),
+                CONSTRAINT uq_ad_document_company_marketplace_date_campaign_sku
+                    UNIQUE (company_id, marketplace, report_date, campaign_id, parent_sku)
+            )
+        SQL);
+        $this->addSql('CREATE INDEX idx_ad_document_company ON marketplace_ad_documents (company_id)');
+        $this->addSql('CREATE INDEX idx_ad_document_company_date ON marketplace_ad_documents (company_id, report_date)');
+        $this->addSql('CREATE INDEX idx_ad_document_raw ON marketplace_ad_documents (ad_raw_document_id)');
+        $this->addSql("COMMENT ON COLUMN marketplace_ad_documents.report_date IS '(DC2Type:date_immutable)'");
+        $this->addSql("COMMENT ON COLUMN marketplace_ad_documents.created_at IS '(DC2Type:datetime_immutable)'");
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE marketplace_ad_document_lines (
+                id VARCHAR(36) NOT NULL,
+                ad_document_id VARCHAR(36) NOT NULL,
+                listing_id VARCHAR(36) NOT NULL,
+                share_percent NUMERIC(7, 4) NOT NULL,
+                cost NUMERIC(14, 2) NOT NULL,
+                impressions INT NOT NULL,
+                clicks INT NOT NULL,
+                PRIMARY KEY(id),
+                CONSTRAINT fk_ad_document_line_document
+                    FOREIGN KEY (ad_document_id)
+                    REFERENCES marketplace_ad_documents (id)
+                    ON DELETE CASCADE
+                    NOT DEFERRABLE INITIALLY IMMEDIATE
+            )
+        SQL);
+        $this->addSql('CREATE INDEX idx_ad_document_line_document ON marketplace_ad_document_lines (ad_document_id)');
+        $this->addSql('CREATE INDEX idx_ad_document_line_listing ON marketplace_ad_document_lines (listing_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE marketplace_ad_document_lines');
+        $this->addSql('DROP TABLE marketplace_ad_documents');
+        $this->addSql('DROP TABLE marketplace_ad_raw_documents');
+    }
+}

--- a/site/migrations/Version20260412053206.php
+++ b/site/migrations/Version20260412053206.php
@@ -18,8 +18,8 @@ final class Version20260412053206 extends AbstractMigration
     {
         $this->addSql(<<<'SQL'
             CREATE TABLE marketplace_ad_raw_documents (
-                id VARCHAR(36) NOT NULL,
-                company_id VARCHAR(36) NOT NULL,
+                id UUID NOT NULL,
+                company_id UUID NOT NULL,
                 marketplace VARCHAR(50) NOT NULL,
                 report_date DATE NOT NULL,
                 loaded_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
@@ -40,8 +40,8 @@ final class Version20260412053206 extends AbstractMigration
 
         $this->addSql(<<<'SQL'
             CREATE TABLE marketplace_ad_documents (
-                id VARCHAR(36) NOT NULL,
-                company_id VARCHAR(36) NOT NULL,
+                id UUID NOT NULL,
+                company_id UUID NOT NULL,
                 marketplace VARCHAR(50) NOT NULL,
                 report_date DATE NOT NULL,
                 campaign_id VARCHAR(255) NOT NULL,
@@ -50,7 +50,7 @@ final class Version20260412053206 extends AbstractMigration
                 total_cost NUMERIC(14, 2) NOT NULL,
                 total_impressions INT NOT NULL,
                 total_clicks INT NOT NULL,
-                ad_raw_document_id VARCHAR(36) NOT NULL,
+                ad_raw_document_id UUID NOT NULL,
                 created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
                 PRIMARY KEY(id),
                 CONSTRAINT uq_ad_document_company_marketplace_date_campaign_sku
@@ -65,9 +65,9 @@ final class Version20260412053206 extends AbstractMigration
 
         $this->addSql(<<<'SQL'
             CREATE TABLE marketplace_ad_document_lines (
-                id VARCHAR(36) NOT NULL,
-                ad_document_id VARCHAR(36) NOT NULL,
-                listing_id VARCHAR(36) NOT NULL,
+                id UUID NOT NULL,
+                ad_document_id UUID NOT NULL,
+                listing_id UUID NOT NULL,
                 share_percent NUMERIC(7, 4) NOT NULL,
                 cost NUMERIC(14, 2) NOT NULL,
                 impressions INT NOT NULL,

--- a/site/src/MarketplaceAds/Entity/AdDocument.php
+++ b/site/src/MarketplaceAds/Entity/AdDocument.php
@@ -75,6 +75,7 @@ class AdDocument
         Assert::uuid($companyId);
         Assert::uuid($adRawDocumentId);
         Assert::notEmpty($campaignId);
+        Assert::notEmpty($campaignName);
         Assert::notEmpty($parentSku);
 
         $this->companyId        = $companyId;

--- a/site/src/MarketplaceAds/Entity/AdDocument.php
+++ b/site/src/MarketplaceAds/Entity/AdDocument.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Entity;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAds\Repository\AdDocumentRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity(repositoryClass: AdDocumentRepository::class)]
+#[ORM\Table(name: 'marketplace_ad_documents')]
+#[ORM\UniqueConstraint(
+    name: 'uq_ad_document_company_marketplace_date_campaign_sku',
+    columns: ['company_id', 'marketplace', 'report_date', 'campaign_id', 'parent_sku'],
+)]
+#[ORM\Index(columns: ['company_id'], name: 'idx_ad_document_company')]
+#[ORM\Index(columns: ['company_id', 'report_date'], name: 'idx_ad_document_company_date')]
+#[ORM\Index(columns: ['ad_raw_document_id'], name: 'idx_ad_document_raw')]
+class AdDocument
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid', unique: true)]
+    private string $id;
+
+    #[ORM\Column(type: 'guid')]
+    private string $companyId;
+
+    #[ORM\Column(type: 'string', length: 50, enumType: MarketplaceType::class)]
+    private MarketplaceType $marketplace;
+
+    #[ORM\Column(type: 'date_immutable')]
+    private \DateTimeImmutable $reportDate;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private string $campaignId;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private string $campaignName;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private string $parentSku;
+
+    #[ORM\Column(type: 'decimal', precision: 14, scale: 2)]
+    private string $totalCost;
+
+    #[ORM\Column(type: 'integer')]
+    private int $totalImpressions;
+
+    #[ORM\Column(type: 'integer')]
+    private int $totalClicks;
+
+    #[ORM\Column(type: 'guid')]
+    private string $adRawDocumentId;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $createdAt;
+
+    public function __construct(
+        string $companyId,
+        MarketplaceType $marketplace,
+        \DateTimeImmutable $reportDate,
+        string $campaignId,
+        string $campaignName,
+        string $parentSku,
+        string $totalCost,
+        int $totalImpressions,
+        int $totalClicks,
+        string $adRawDocumentId,
+    ) {
+        $this->id = Uuid::uuid7()->toString();
+        Assert::uuid($this->id);
+        Assert::uuid($companyId);
+        Assert::uuid($adRawDocumentId);
+        Assert::notEmpty($campaignId);
+        Assert::notEmpty($parentSku);
+
+        $this->companyId        = $companyId;
+        $this->marketplace      = $marketplace;
+        $this->reportDate       = $reportDate;
+        $this->campaignId       = $campaignId;
+        $this->campaignName     = $campaignName;
+        $this->parentSku        = $parentSku;
+        $this->totalCost        = $totalCost;
+        $this->totalImpressions = $totalImpressions;
+        $this->totalClicks      = $totalClicks;
+        $this->adRawDocumentId  = $adRawDocumentId;
+        $this->createdAt        = new \DateTimeImmutable();
+    }
+
+    public function getId(): string { return $this->id; }
+    public function getCompanyId(): string { return $this->companyId; }
+    public function getMarketplace(): MarketplaceType { return $this->marketplace; }
+    public function getReportDate(): \DateTimeImmutable { return $this->reportDate; }
+    public function getCampaignId(): string { return $this->campaignId; }
+    public function getCampaignName(): string { return $this->campaignName; }
+    public function getParentSku(): string { return $this->parentSku; }
+    public function getTotalCost(): string { return $this->totalCost; }
+    public function getTotalImpressions(): int { return $this->totalImpressions; }
+    public function getTotalClicks(): int { return $this->totalClicks; }
+    public function getAdRawDocumentId(): string { return $this->adRawDocumentId; }
+    public function getCreatedAt(): \DateTimeImmutable { return $this->createdAt; }
+}

--- a/site/src/MarketplaceAds/Entity/AdDocumentLine.php
+++ b/site/src/MarketplaceAds/Entity/AdDocumentLine.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Entity;
+
+use App\MarketplaceAds\Repository\AdDocumentLineRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity(repositoryClass: AdDocumentLineRepository::class)]
+#[ORM\Table(name: 'marketplace_ad_document_lines')]
+#[ORM\Index(columns: ['ad_document_id'], name: 'idx_ad_document_line_document')]
+#[ORM\Index(columns: ['listing_id'], name: 'idx_ad_document_line_listing')]
+class AdDocumentLine
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid', unique: true)]
+    private string $id;
+
+    #[ORM\ManyToOne(targetEntity: AdDocument::class)]
+    #[ORM\JoinColumn(name: 'ad_document_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private AdDocument $adDocument;
+
+    #[ORM\Column(type: 'guid')]
+    private string $listingId;
+
+    #[ORM\Column(type: 'decimal', precision: 7, scale: 4)]
+    private string $sharePercent;
+
+    #[ORM\Column(type: 'decimal', precision: 14, scale: 2)]
+    private string $cost;
+
+    #[ORM\Column(type: 'integer')]
+    private int $impressions;
+
+    #[ORM\Column(type: 'integer')]
+    private int $clicks;
+
+    public function __construct(
+        AdDocument $adDocument,
+        string $listingId,
+        string $sharePercent,
+        string $cost,
+        int $impressions,
+        int $clicks,
+    ) {
+        $this->id = Uuid::uuid7()->toString();
+        Assert::uuid($this->id);
+        Assert::uuid($listingId);
+
+        $this->adDocument   = $adDocument;
+        $this->listingId    = $listingId;
+        $this->sharePercent = $sharePercent;
+        $this->cost         = $cost;
+        $this->impressions  = $impressions;
+        $this->clicks       = $clicks;
+    }
+
+    public function getId(): string { return $this->id; }
+    public function getAdDocument(): AdDocument { return $this->adDocument; }
+    public function getAdDocumentId(): string { return $this->adDocument->getId(); }
+    public function getListingId(): string { return $this->listingId; }
+    public function getSharePercent(): string { return $this->sharePercent; }
+    public function getCost(): string { return $this->cost; }
+    public function getImpressions(): int { return $this->impressions; }
+    public function getClicks(): int { return $this->clicks; }
+}

--- a/site/src/MarketplaceAds/Entity/AdDocumentLine.php
+++ b/site/src/MarketplaceAds/Entity/AdDocumentLine.php
@@ -11,6 +11,10 @@ use Webmozart\Assert\Assert;
 
 #[ORM\Entity(repositoryClass: AdDocumentLineRepository::class)]
 #[ORM\Table(name: 'marketplace_ad_document_lines')]
+#[ORM\UniqueConstraint(
+    name: 'uq_ad_document_line_document_listing',
+    columns: ['ad_document_id', 'listing_id'],
+)]
 #[ORM\Index(columns: ['ad_document_id'], name: 'idx_ad_document_line_document')]
 #[ORM\Index(columns: ['listing_id'], name: 'idx_ad_document_line_listing')]
 class AdDocumentLine

--- a/site/src/MarketplaceAds/Entity/AdRawDocument.php
+++ b/site/src/MarketplaceAds/Entity/AdRawDocument.php
@@ -58,6 +58,7 @@ class AdRawDocument
         $this->id = Uuid::uuid7()->toString();
         Assert::uuid($this->id);
         Assert::uuid($companyId);
+        Assert::notEmpty($rawPayload);
 
         $this->companyId   = $companyId;
         $this->marketplace = $marketplace;

--- a/site/src/MarketplaceAds/Entity/AdRawDocument.php
+++ b/site/src/MarketplaceAds/Entity/AdRawDocument.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Entity;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAds\Enum\AdRawDocumentStatus;
+use App\MarketplaceAds\Repository\AdRawDocumentRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity(repositoryClass: AdRawDocumentRepository::class)]
+#[ORM\Table(name: 'marketplace_ad_raw_documents')]
+#[ORM\UniqueConstraint(
+    name: 'uq_ad_raw_document_company_marketplace_date',
+    columns: ['company_id', 'marketplace', 'report_date'],
+)]
+#[ORM\Index(columns: ['company_id'], name: 'idx_ad_raw_document_company')]
+#[ORM\Index(columns: ['company_id', 'marketplace'], name: 'idx_ad_raw_document_company_marketplace')]
+class AdRawDocument
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid', unique: true)]
+    private string $id;
+
+    #[ORM\Column(type: 'guid')]
+    private string $companyId;
+
+    #[ORM\Column(type: 'string', length: 50, enumType: MarketplaceType::class)]
+    private MarketplaceType $marketplace;
+
+    #[ORM\Column(type: 'date_immutable')]
+    private \DateTimeImmutable $reportDate;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $loadedAt;
+
+    #[ORM\Column(type: 'text')]
+    private string $rawPayload;
+
+    #[ORM\Column(type: 'string', length: 20, enumType: AdRawDocumentStatus::class, options: ['default' => 'draft'])]
+    private AdRawDocumentStatus $status;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $updatedAt;
+
+    public function __construct(
+        string $companyId,
+        MarketplaceType $marketplace,
+        \DateTimeImmutable $reportDate,
+        string $rawPayload,
+    ) {
+        $this->id = Uuid::uuid7()->toString();
+        Assert::uuid($this->id);
+        Assert::uuid($companyId);
+
+        $this->companyId   = $companyId;
+        $this->marketplace = $marketplace;
+        $this->reportDate  = $reportDate;
+        $this->rawPayload  = $rawPayload;
+        $this->status      = AdRawDocumentStatus::DRAFT;
+        $this->loadedAt    = new \DateTimeImmutable();
+        $this->createdAt   = new \DateTimeImmutable();
+        $this->updatedAt   = new \DateTimeImmutable();
+    }
+
+    public function markAsProcessed(): void
+    {
+        if ($this->status === AdRawDocumentStatus::PROCESSED) {
+            throw new \DomainException('Документ уже обработан.');
+        }
+
+        $this->status    = AdRawDocumentStatus::PROCESSED;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function resetToDraft(): void
+    {
+        if ($this->status === AdRawDocumentStatus::DRAFT) {
+            throw new \DomainException('Документ уже в статусе черновик.');
+        }
+
+        $this->status    = AdRawDocumentStatus::DRAFT;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function updatePayload(string $rawPayload): void
+    {
+        $this->rawPayload = $rawPayload;
+        $this->status     = AdRawDocumentStatus::DRAFT;
+        $this->updatedAt  = new \DateTimeImmutable();
+    }
+
+    public function getId(): string { return $this->id; }
+    public function getCompanyId(): string { return $this->companyId; }
+    public function getMarketplace(): MarketplaceType { return $this->marketplace; }
+    public function getReportDate(): \DateTimeImmutable { return $this->reportDate; }
+    public function getLoadedAt(): \DateTimeImmutable { return $this->loadedAt; }
+    public function getRawPayload(): string { return $this->rawPayload; }
+    public function getStatus(): AdRawDocumentStatus { return $this->status; }
+    public function getCreatedAt(): \DateTimeImmutable { return $this->createdAt; }
+    public function getUpdatedAt(): \DateTimeImmutable { return $this->updatedAt; }
+}

--- a/site/src/MarketplaceAds/Repository/AdDocumentLineRepository.php
+++ b/site/src/MarketplaceAds/Repository/AdDocumentLineRepository.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Repository;
+
+use App\MarketplaceAds\Entity\AdDocumentLine;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+final class AdDocumentLineRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, AdDocumentLine::class);
+    }
+
+    public function save(AdDocumentLine $line): void
+    {
+        $this->getEntityManager()->persist($line);
+    }
+
+    /**
+     * @return AdDocumentLine[]
+     */
+    public function findByAdDocumentId(string $adDocumentId): array
+    {
+        return $this->createQueryBuilder('l')
+            ->where('l.adDocument = :adDocumentId')
+            ->setParameter('adDocumentId', $adDocumentId)
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/site/src/MarketplaceAds/Repository/AdDocumentLineRepository.php
+++ b/site/src/MarketplaceAds/Repository/AdDocumentLineRepository.php
@@ -23,11 +23,14 @@ final class AdDocumentLineRepository extends ServiceEntityRepository
     /**
      * @return AdDocumentLine[]
      */
-    public function findByAdDocumentId(string $adDocumentId): array
+    public function findByAdDocumentId(string $adDocumentId, string $companyId): array
     {
         return $this->createQueryBuilder('l')
+            ->join('l.adDocument', 'd')
             ->where('l.adDocument = :adDocumentId')
+            ->andWhere('d.companyId = :companyId')
             ->setParameter('adDocumentId', $adDocumentId)
+            ->setParameter('companyId', $companyId)
             ->getQuery()
             ->getResult();
     }

--- a/site/src/MarketplaceAds/Repository/AdDocumentRepository.php
+++ b/site/src/MarketplaceAds/Repository/AdDocumentRepository.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Repository;
+
+use App\MarketplaceAds\Entity\AdDocument;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+final class AdDocumentRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, AdDocument::class);
+    }
+
+    public function save(AdDocument $document): void
+    {
+        $this->getEntityManager()->persist($document);
+    }
+
+    public function findByIdAndCompany(string $id, string $companyId): ?AdDocument
+    {
+        return $this->findOneBy([
+            'id'        => $id,
+            'companyId' => $companyId,
+        ]);
+    }
+
+    public function deleteByRawDocumentId(string $companyId, string $adRawDocumentId): void
+    {
+        $this->createQueryBuilder('d')
+            ->delete()
+            ->where('d.companyId = :companyId')
+            ->andWhere('d.adRawDocumentId = :adRawDocumentId')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('adRawDocumentId', $adRawDocumentId)
+            ->getQuery()
+            ->execute();
+    }
+}

--- a/site/src/MarketplaceAds/Repository/AdRawDocumentRepository.php
+++ b/site/src/MarketplaceAds/Repository/AdRawDocumentRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\MarketplaceAds\Repository;
 
 use App\MarketplaceAds\Entity\AdRawDocument;
+use App\MarketplaceAds\Enum\AdRawDocumentStatus;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -49,7 +50,7 @@ final class AdRawDocumentRepository extends ServiceEntityRepository
             ->where('r.companyId = :companyId')
             ->andWhere('r.status = :status')
             ->setParameter('companyId', $companyId)
-            ->setParameter('status', 'draft')
+            ->setParameter('status', AdRawDocumentStatus::DRAFT)
             ->orderBy('r.reportDate', 'DESC')
             ->getQuery()
             ->getResult();

--- a/site/src/MarketplaceAds/Repository/AdRawDocumentRepository.php
+++ b/site/src/MarketplaceAds/Repository/AdRawDocumentRepository.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Repository;
+
+use App\MarketplaceAds\Entity\AdRawDocument;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+final class AdRawDocumentRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, AdRawDocument::class);
+    }
+
+    public function save(AdRawDocument $document): void
+    {
+        $this->getEntityManager()->persist($document);
+    }
+
+    public function findByIdAndCompany(string $id, string $companyId): ?AdRawDocument
+    {
+        return $this->findOneBy([
+            'id'        => $id,
+            'companyId' => $companyId,
+        ]);
+    }
+
+    public function findByMarketplaceAndDate(
+        string $companyId,
+        string $marketplace,
+        \DateTimeImmutable $reportDate,
+    ): ?AdRawDocument {
+        return $this->findOneBy([
+            'companyId'   => $companyId,
+            'marketplace' => $marketplace,
+            'reportDate'  => $reportDate,
+        ]);
+    }
+
+    /**
+     * @return AdRawDocument[]
+     */
+    public function findDrafts(string $companyId): array
+    {
+        return $this->createQueryBuilder('r')
+            ->where('r.companyId = :companyId')
+            ->andWhere('r.status = :status')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('status', 'draft')
+            ->orderBy('r.reportDate', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
+}


### PR DESCRIPTION
## Summary

- **`AdRawDocument`** (`marketplace_ad_raw_documents`) — сырой ответ API маркетплейса. Guard-методы `markAsProcessed()`, `resetToDraft()`, `updatePayload()`. UniqueConstraint по `(company_id, marketplace, report_date)`.
- **`AdDocument`** (`marketplace_ad_documents`) — обработанный рекламный документ за день по кампании и SKU. Ссылка на `AdRawDocument` через `string adRawDocumentId`. UniqueConstraint по `(company_id, marketplace, report_date, campaign_id, parent_sku)`.
- **`AdDocumentLine`** (`marketplace_ad_document_lines`) — строка распределения затрат по листингу. `ManyToOne → AdDocument` с `onDelete: CASCADE`. `listingId` — `string` (без ManyToOne на Marketplace).
- Репозитории с IDOR-защитой (`companyId` в каждом методе): `AdRawDocumentRepository`, `AdDocumentRepository`, `AdDocumentLineRepository`.
- Миграция `Version20260412053206`: создаёт три таблицы с FK, UniqueConstraint и индексами.

## Test plan
- [x] `doctrine:schema:validate --skip-sync` → `[OK] The mapping files are correct`
- [x] `cache:clear` → OK
- [x] Все Entity: `class` (не `final`), UUID v7 в конструкторе, `DateTimeImmutable`, decimal-поля как `string`
- [x] `companyId` неизменяем, `Assert::uuid` в конструкторе
- [ ] CI pipeline зелёный

https://claude.ai/code/session_01Gu7CykSgN6uKBwbyqvvgym