### PR TITLE
feat(MarketplaceAds): DTO, ListingSalesProviderInterface, AdCostDistributor + tests

### DIFF
--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -228,3 +228,7 @@ services:
     App\Shared\Security\Contract\SecretKeyProviderInterface: '@App\Shared\Security\Service\FileBasedSecretKeyProvider'
     App\Shared\Security\Contract\FieldEncryptionServiceInterface: '@App\Shared\Security\Service\SodiumFieldEncryptionService'
     App\Shared\Security\Contract\SecretRotationServiceInterface: '@App\Shared\Security\Service\SecretRotationService'
+
+    # ---------- MarketplaceAds ---------- #
+    App\MarketplaceAds\Domain\Service\ListingSalesProviderInterface:
+        '@App\MarketplaceAds\Infrastructure\ListingSalesProviderMarketplace'

--- a/site/src/Marketplace/Facade/MarketplaceFacade.php
+++ b/site/src/Marketplace/Facade/MarketplaceFacade.php
@@ -234,4 +234,74 @@ final readonly class MarketplaceFacade
     ): array {
         return $this->costCategoriesQuery->fetchForCompanyAndMarketplace($companyId, $marketplace);
     }
+
+    /**
+     * Находит все листинги (включая неактивные) по marketplace SKU (родительский артикул / nm_id в WB).
+     * Без фильтра is_active — нужен при обработке исторических отчётов, когда листинг мог быть
+     * деактивирован после даты отчёта.
+     *
+     * @return list<array{id: string, parentSku: string}>
+     */
+    public function findListingsByMarketplaceSku(
+        string $companyId,
+        string $marketplace,
+        string $marketplaceSku,
+    ): array {
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT l.id, l.marketplace_sku AS parent_sku
+             FROM marketplace_listings l
+             WHERE l.company_id = :companyId
+               AND l.marketplace = :marketplace
+               AND l.marketplace_sku = :marketplaceSku',
+            [
+                'companyId'     => $companyId,
+                'marketplace'   => $marketplace,
+                'marketplaceSku' => $marketplaceSku,
+            ],
+        );
+
+        return array_map(static fn(array $row) => [
+            'id'        => $row['id'],
+            'parentSku' => $row['parent_sku'],
+        ], $rows);
+    }
+
+    /**
+     * Bulk-запрос продаж для набора листингов за одну дату.
+     * Листинги без продаж в результате отсутствуют (caller должен подставить 0 самостоятельно).
+     *
+     * @param  string[]           $listingIds
+     * @return array<string, int> listingId => суммарное количество продаж
+     */
+    public function getSalesQuantitiesForListings(
+        string $companyId,
+        array $listingIds,
+        \DateTimeImmutable $date,
+    ): array {
+        if ($listingIds === []) {
+            return [];
+        }
+
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT s.listing_id, SUM(s.quantity) AS total_quantity
+             FROM marketplace_sales s
+             WHERE s.company_id = :companyId
+               AND s.listing_id IN (:listingIds)
+               AND s.sale_date = :date
+             GROUP BY s.listing_id',
+            [
+                'companyId'  => $companyId,
+                'listingIds' => $listingIds,
+                'date'       => $date->format('Y-m-d'),
+            ],
+            ['listingIds' => Connection::PARAM_STR_ARRAY],
+        );
+
+        $result = [];
+        foreach ($rows as $row) {
+            $result[$row['listing_id']] = (int) $row['total_quantity'];
+        }
+
+        return $result;
+    }
 }

--- a/site/src/MarketplaceAds/Application/DTO/AdRawEntry.php
+++ b/site/src/MarketplaceAds/Application/DTO/AdRawEntry.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Application\DTO;
+
+final readonly class AdRawEntry
+{
+    public function __construct(
+        public string $campaignId,
+        public string $campaignName,
+        public string $parentSku,
+        public string $cost,
+        public int $impressions,
+        public int $clicks,
+    ) {}
+}

--- a/site/src/MarketplaceAds/Application/DTO/CostDistributionResult.php
+++ b/site/src/MarketplaceAds/Application/DTO/CostDistributionResult.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Application\DTO;
+
+final readonly class CostDistributionResult
+{
+    public function __construct(
+        public string $listingId,
+        public string $sharePercent,
+        public string $cost,
+        public int $impressions,
+        public int $clicks,
+    ) {}
+}

--- a/site/src/MarketplaceAds/Domain/Service/AdCostDistributor.php
+++ b/site/src/MarketplaceAds/Domain/Service/AdCostDistributor.php
@@ -36,14 +36,12 @@ final class AdCostDistributor
 
         $count = count($listings);
 
-        // Шаг 1: Получаем продажи по каждому листингу
-        $salesByListing = [];
+        // Шаг 1: Получаем продажи по всем листингам одним запросом
+        $listingIds     = array_column($listings, 'id');
+        $salesByListing = $this->salesProvider->getSalesQuantitiesByListings($companyId, $listingIds, $date);
+        // Листинги без продаж отсутствуют в ответе — проставляем 0
         foreach ($listings as $listing) {
-            $salesByListing[$listing['id']] = $this->salesProvider->getSalesQuantityForDate(
-                $companyId,
-                $listing['id'],
-                $date,
-            );
+            $salesByListing[$listing['id']] ??= 0;
         }
 
         $totalSales = (int) array_sum($salesByListing);

--- a/site/src/MarketplaceAds/Domain/Service/AdCostDistributor.php
+++ b/site/src/MarketplaceAds/Domain/Service/AdCostDistributor.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Domain\Service;
+
+use App\MarketplaceAds\Application\DTO\CostDistributionResult;
+
+final class AdCostDistributor
+{
+    private const WEIGHT_SCALE = 10;
+
+    public function __construct(
+        private readonly ListingSalesProviderInterface $salesProvider,
+    ) {}
+
+    /**
+     * Распределить рекламные затраты по листингам пропорционально продажам.
+     * При отсутствии продаж — равномерное распределение.
+     * Контроль округления: разница прибавляется к строке с наибольшей долей.
+     *
+     * @param  array{id: string, parentSku: string}[] $listings
+     * @return CostDistributionResult[]
+     */
+    public function distribute(
+        string $companyId,
+        array $listings,
+        \DateTimeImmutable $date,
+        string $totalCost,
+        int $totalImpressions,
+        int $totalClicks,
+    ): array {
+        if (empty($listings)) {
+            return [];
+        }
+
+        $count = count($listings);
+
+        // Шаг 1: Получаем продажи по каждому листингу
+        $salesByListing = [];
+        foreach ($listings as $listing) {
+            $salesByListing[$listing['id']] = $this->salesProvider->getSalesQuantityForDate(
+                $companyId,
+                $listing['id'],
+                $date,
+            );
+        }
+
+        $totalSales = (int) array_sum($salesByListing);
+
+        // Шаг 2: Вычисляем веса с высокой точностью
+        if ($totalSales > 0) {
+            $weights = [];
+            foreach ($listings as $listing) {
+                $weights[$listing['id']] = bcdiv(
+                    (string) $salesByListing[$listing['id']],
+                    (string) $totalSales,
+                    self::WEIGHT_SCALE,
+                );
+            }
+        } else {
+            // Равномерное распределение
+            $evenWeight = bcdiv('1', (string) $count, self::WEIGHT_SCALE);
+            $weights    = [];
+            foreach ($listings as $listing) {
+                $weights[$listing['id']] = $evenWeight;
+            }
+        }
+
+        // Шаг 3: Найти листинг с наибольшим весом для поправки округления
+        $maxWeightId = array_key_first($weights);
+        foreach ($weights as $id => $w) {
+            if (bccomp($w, $weights[$maxWeightId], self::WEIGHT_SCALE) > 0) {
+                $maxWeightId = $id;
+            }
+        }
+
+        // Шаг 4: Вычислить значения по каждому листингу (с усечением до нужной точности)
+        $results        = [];
+        $sumCost        = '0.00';
+        $sumShare       = '0.00';
+        $sumImpressions = 0;
+        $sumClicks      = 0;
+
+        foreach ($listings as $listing) {
+            $id = $listing['id'];
+            $w  = $weights[$id];
+
+            $cost         = bcmul($totalCost, $w, 2);
+            $sharePercent = bcmul($w, '100', 2);
+            $impressions  = (int) bcmul((string) $totalImpressions, $w, 0);
+            $clicks       = (int) bcmul((string) $totalClicks, $w, 0);
+
+            $sumCost        = bcadd($sumCost, $cost, 2);
+            $sumShare       = bcadd($sumShare, $sharePercent, 2);
+            $sumImpressions += $impressions;
+            $sumClicks      += $clicks;
+
+            $results[$id] = new CostDistributionResult(
+                listingId:    $id,
+                sharePercent: $sharePercent,
+                cost:         $cost,
+                impressions:  $impressions,
+                clicks:       $clicks,
+            );
+        }
+
+        // Шаг 5: Поправка округления — добавляем разницу к строке с наибольшей долей
+        $maxItem = $results[$maxWeightId];
+
+        $results[$maxWeightId] = new CostDistributionResult(
+            listingId:    $maxItem->listingId,
+            sharePercent: bcadd($maxItem->sharePercent, bcsub('100.00', $sumShare, 2), 2),
+            cost:         bcadd($maxItem->cost, bcsub($totalCost, $sumCost, 2), 2),
+            impressions:  $maxItem->impressions + ($totalImpressions - $sumImpressions),
+            clicks:       $maxItem->clicks + ($totalClicks - $sumClicks),
+        );
+
+        return array_values($results);
+    }
+}

--- a/site/src/MarketplaceAds/Domain/Service/ListingSalesProviderInterface.php
+++ b/site/src/MarketplaceAds/Domain/Service/ListingSalesProviderInterface.php
@@ -7,18 +7,21 @@ namespace App\MarketplaceAds\Domain\Service;
 interface ListingSalesProviderInterface
 {
     /**
-     * Получить количество продаж листинга за дату.
+     * Bulk-получение количества продаж для набора листингов за дату.
+     * Листинги без продаж отсутствуют в результате (caller получает 0 по умолчанию).
      *
-     * @return int количество проданных единиц
+     * @param  string[]           $listingIds
+     * @return array<string, int> listingId => количество продаж
      */
-    public function getSalesQuantityForDate(
+    public function getSalesQuantitiesByListings(
         string $companyId,
-        string $listingId,
+        array $listingIds,
         \DateTimeImmutable $date,
-    ): int;
+    ): array;
 
     /**
-     * Получить все листинги по родительскому SKU и площадке.
+     * Получить все листинги (включая неактивные) по родительскому SKU и площадке.
+     * Необходимо для корректной обработки исторических отчётов.
      *
      * @return list<array{id: string, parentSku: string}>
      */

--- a/site/src/MarketplaceAds/Domain/Service/ListingSalesProviderInterface.php
+++ b/site/src/MarketplaceAds/Domain/Service/ListingSalesProviderInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Domain\Service;
+
+interface ListingSalesProviderInterface
+{
+    /**
+     * Получить количество продаж листинга за дату.
+     *
+     * @return int количество проданных единиц
+     */
+    public function getSalesQuantityForDate(
+        string $companyId,
+        string $listingId,
+        \DateTimeImmutable $date,
+    ): int;
+
+    /**
+     * Получить все листинги по родительскому SKU и площадке.
+     *
+     * @return list<array{id: string, parentSku: string}>
+     */
+    public function findListingsByParentSku(
+        string $companyId,
+        string $marketplace,
+        string $parentSku,
+    ): array;
+}

--- a/site/src/MarketplaceAds/Infrastructure/ListingSalesProviderMarketplace.php
+++ b/site/src/MarketplaceAds/Infrastructure/ListingSalesProviderMarketplace.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Infrastructure;
+
+use App\Marketplace\Facade\MarketplaceFacade;
+use App\MarketplaceAds\Domain\Service\ListingSalesProviderInterface;
+
+final readonly class ListingSalesProviderMarketplace implements ListingSalesProviderInterface
+{
+    public function __construct(
+        private MarketplaceFacade $marketplaceFacade,
+    ) {}
+
+    public function getSalesQuantityForDate(
+        string $companyId,
+        string $listingId,
+        \DateTimeImmutable $date,
+    ): int {
+        $sales = $this->marketplaceFacade->getSalesForListingAndDate($companyId, $listingId, $date);
+
+        $total = 0;
+        foreach ($sales as $sale) {
+            $total += $sale->quantity;
+        }
+
+        return $total;
+    }
+
+    /**
+     * Находит все активные листинги с данным marketplaceSku (nm_id) на указанной площадке.
+     * В WB nm_id — родительский артикул, общий для всех размеров одного товара.
+     *
+     * @return list<array{id: string, parentSku: string}>
+     */
+    public function findListingsByParentSku(
+        string $companyId,
+        string $marketplace,
+        string $parentSku,
+    ): array {
+        $allListings = $this->marketplaceFacade->getActiveListings($companyId, $marketplace);
+
+        $result = [];
+        foreach ($allListings as $listing) {
+            if ($listing->marketplaceSku === $parentSku) {
+                $result[] = ['id' => $listing->id, 'parentSku' => $listing->marketplaceSku];
+            }
+        }
+
+        return $result;
+    }
+}

--- a/site/src/MarketplaceAds/Infrastructure/ListingSalesProviderMarketplace.php
+++ b/site/src/MarketplaceAds/Infrastructure/ListingSalesProviderMarketplace.php
@@ -13,41 +13,28 @@ final readonly class ListingSalesProviderMarketplace implements ListingSalesProv
         private MarketplaceFacade $marketplaceFacade,
     ) {}
 
-    public function getSalesQuantityForDate(
+    /**
+     * {@inheritdoc}
+     */
+    public function getSalesQuantitiesByListings(
         string $companyId,
-        string $listingId,
+        array $listingIds,
         \DateTimeImmutable $date,
-    ): int {
-        $sales = $this->marketplaceFacade->getSalesForListingAndDate($companyId, $listingId, $date);
-
-        $total = 0;
-        foreach ($sales as $sale) {
-            $total += $sale->quantity;
-        }
-
-        return $total;
+    ): array {
+        return $this->marketplaceFacade->getSalesQuantitiesForListings($companyId, $listingIds, $date);
     }
 
     /**
-     * Находит все активные листинги с данным marketplaceSku (nm_id) на указанной площадке.
+     * Находит все листинги (включая неактивные) с данным marketplaceSku на указанной площадке.
      * В WB nm_id — родительский артикул, общий для всех размеров одного товара.
      *
-     * @return list<array{id: string, parentSku: string}>
+     * {@inheritdoc}
      */
     public function findListingsByParentSku(
         string $companyId,
         string $marketplace,
         string $parentSku,
     ): array {
-        $allListings = $this->marketplaceFacade->getActiveListings($companyId, $marketplace);
-
-        $result = [];
-        foreach ($allListings as $listing) {
-            if ($listing->marketplaceSku === $parentSku) {
-                $result[] = ['id' => $listing->id, 'parentSku' => $listing->marketplaceSku];
-            }
-        }
-
-        return $result;
+        return $this->marketplaceFacade->findListingsByMarketplaceSku($companyId, $marketplace, $parentSku);
     }
 }

--- a/site/tests/Unit/MarketplaceAds/AdCostDistributorTest.php
+++ b/site/tests/Unit/MarketplaceAds/AdCostDistributorTest.php
@@ -29,9 +29,18 @@ final class AdCostDistributorTest extends TestCase
     {
         $provider = $this->createMock(ListingSalesProviderInterface::class);
         $provider
-            ->method('getSalesQuantityForDate')
+            ->method('getSalesQuantitiesByListings')
             ->willReturnCallback(
-                static fn(string $companyId, string $listingId) => $salesByListingId[$listingId] ?? 0,
+                static function (string $companyId, array $listingIds, \DateTimeImmutable $date) use ($salesByListingId): array {
+                    $result = [];
+                    foreach ($listingIds as $id) {
+                        if (isset($salesByListingId[$id])) {
+                            $result[$id] = $salesByListingId[$id];
+                        }
+                    }
+
+                    return $result;
+                },
             );
 
         return $provider;

--- a/site/tests/Unit/MarketplaceAds/AdCostDistributorTest.php
+++ b/site/tests/Unit/MarketplaceAds/AdCostDistributorTest.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MarketplaceAds;
+
+use App\MarketplaceAds\Application\DTO\CostDistributionResult;
+use App\MarketplaceAds\Domain\Service\AdCostDistributor;
+use App\MarketplaceAds\Domain\Service\ListingSalesProviderInterface;
+use PHPUnit\Framework\TestCase;
+
+final class AdCostDistributorTest extends TestCase
+{
+    private readonly \DateTimeImmutable $date;
+
+    protected function setUp(): void
+    {
+        $this->date = new \DateTimeImmutable('2026-04-01');
+    }
+
+    // -------------------------------------------------------------------------
+    // Вспомогательные методы
+    // -------------------------------------------------------------------------
+
+    /**
+     * @param array<string, int> $salesByListingId  listingId => quantity
+     */
+    private function buildProvider(array $salesByListingId): ListingSalesProviderInterface
+    {
+        $provider = $this->createMock(ListingSalesProviderInterface::class);
+        $provider
+            ->method('getSalesQuantityForDate')
+            ->willReturnCallback(
+                static fn(string $companyId, string $listingId) => $salesByListingId[$listingId] ?? 0,
+            );
+
+        return $provider;
+    }
+
+    private function makeListing(string $id, string $parentSku = 'SKU-1'): array
+    {
+        return ['id' => $id, 'parentSku' => $parentSku];
+    }
+
+    private function sumCosts(array $results): string
+    {
+        $sum = '0.00';
+        foreach ($results as $r) {
+            $sum = bcadd($sum, $r->cost, 2);
+        }
+
+        return $sum;
+    }
+
+    private function sumShares(array $results): string
+    {
+        $sum = '0.00';
+        foreach ($results as $r) {
+            $sum = bcadd($sum, $r->sharePercent, 2);
+        }
+
+        return $sum;
+    }
+
+    private function sumImpressions(array $results): int
+    {
+        return array_sum(array_map(static fn(CostDistributionResult $r) => $r->impressions, $results));
+    }
+
+    private function sumClicks(array $results): int
+    {
+        return array_sum(array_map(static fn(CostDistributionResult $r) => $r->clicks, $results));
+    }
+
+    // -------------------------------------------------------------------------
+    // Тесты
+    // -------------------------------------------------------------------------
+
+    public function testEmptyListingsReturnsEmpty(): void
+    {
+        $distributor = new AdCostDistributor($this->buildProvider([]));
+
+        $result = $distributor->distribute('company-1', [], $this->date, '100.00', 1000, 50);
+
+        self::assertSame([], $result);
+    }
+
+    public function testSingleListingGetsFullAmount(): void
+    {
+        $distributor = new AdCostDistributor($this->buildProvider(['A' => 5]));
+
+        $results = $distributor->distribute(
+            'company-1',
+            [$this->makeListing('A')],
+            $this->date,
+            '99.99',
+            500,
+            30,
+        );
+
+        self::assertCount(1, $results);
+        self::assertSame('A', $results[0]->listingId);
+        self::assertSame('99.99', $results[0]->cost);
+        self::assertSame('100.00', $results[0]->sharePercent);
+        self::assertSame(500, $results[0]->impressions);
+        self::assertSame(30, $results[0]->clicks);
+    }
+
+    public function testSingleListingNoSalesGetsFullAmount(): void
+    {
+        $distributor = new AdCostDistributor($this->buildProvider([]));
+
+        $results = $distributor->distribute(
+            'company-1',
+            [$this->makeListing('A')],
+            $this->date,
+            '50.00',
+            200,
+            10,
+        );
+
+        self::assertCount(1, $results);
+        self::assertSame('50.00', $results[0]->cost);
+        self::assertSame('100.00', $results[0]->sharePercent);
+        self::assertSame(200, $results[0]->impressions);
+        self::assertSame(10, $results[0]->clicks);
+    }
+
+    public function testTwoListingsEqualSalesGetFiftyPercent(): void
+    {
+        $distributor = new AdCostDistributor($this->buildProvider(['A' => 10, 'B' => 10]));
+
+        $results = $distributor->distribute(
+            'company-1',
+            [$this->makeListing('A'), $this->makeListing('B')],
+            $this->date,
+            '100.00',
+            1000,
+            100,
+        );
+
+        self::assertCount(2, $results);
+        self::assertSame('50.00', $results[0]->cost);
+        self::assertSame('50.00', $results[0]->sharePercent);
+        self::assertSame(500, $results[0]->impressions);
+        self::assertSame(50, $results[0]->clicks);
+        self::assertSame('50.00', $results[1]->cost);
+        self::assertSame('50.00', $results[1]->sharePercent);
+    }
+
+    public function testProportionalDistributionBySales(): void
+    {
+        // A:2 sales, B:1 sale → 2/3 and 1/3
+        $distributor = new AdCostDistributor($this->buildProvider(['A' => 2, 'B' => 1]));
+
+        $results = $distributor->distribute(
+            'company-1',
+            [$this->makeListing('A'), $this->makeListing('B')],
+            $this->date,
+            '30.00',
+            300,
+            60,
+        );
+
+        self::assertCount(2, $results);
+        self::assertSame('30.00', $this->sumCosts($results));
+        self::assertSame('100.00', $this->sumShares($results));
+        self::assertSame(300, $this->sumImpressions($results));
+        self::assertSame(60, $this->sumClicks($results));
+
+        // A gets ~2/3, B gets ~1/3
+        self::assertSame('B', $results[1]->listingId);
+        self::assertGreaterThan((float) $results[1]->cost, (float) $results[0]->cost);
+    }
+
+    public function testEqualDistributionWhenNoSales(): void
+    {
+        $distributor = new AdCostDistributor($this->buildProvider([]));
+
+        $results = $distributor->distribute(
+            'company-1',
+            [$this->makeListing('A'), $this->makeListing('B'), $this->makeListing('C')],
+            $this->date,
+            '10.00',
+            100,
+            30,
+        );
+
+        self::assertCount(3, $results);
+        // Sums must match exactly
+        self::assertSame('10.00', $this->sumCosts($results));
+        self::assertSame('100.00', $this->sumShares($results));
+        self::assertSame(100, $this->sumImpressions($results));
+        self::assertSame(30, $this->sumClicks($results));
+    }
+
+    public function testRoundingCorrectionOnCostSum(): void
+    {
+        // 3 equal listings, cost = '10.00' — 10/3 cannot divide evenly
+        $distributor = new AdCostDistributor($this->buildProvider([]));
+
+        $results = $distributor->distribute(
+            'company-1',
+            [$this->makeListing('A'), $this->makeListing('B'), $this->makeListing('C')],
+            $this->date,
+            '10.00',
+            100,
+            30,
+        );
+
+        // Total must be exact regardless of per-row rounding
+        self::assertSame('10.00', $this->sumCosts($results));
+        self::assertSame('100.00', $this->sumShares($results));
+        self::assertSame(100, $this->sumImpressions($results));
+        self::assertSame(30, $this->sumClicks($results));
+    }
+
+    public function testRoundingCorrectionOnLargerSet(): void
+    {
+        // 7 equal listings, cost = '100.00' — 100/7 repeating decimal
+        $distributor = new AdCostDistributor($this->buildProvider([]));
+
+        $listings = [];
+        for ($i = 1; $i <= 7; $i++) {
+            $listings[] = $this->makeListing("L{$i}");
+        }
+
+        $results = $distributor->distribute(
+            'company-1',
+            $listings,
+            $this->date,
+            '100.00',
+            700,
+            70,
+        );
+
+        self::assertCount(7, $results);
+        self::assertSame('100.00', $this->sumCosts($results));
+        self::assertSame('100.00', $this->sumShares($results));
+        self::assertSame(700, $this->sumImpressions($results));
+        self::assertSame(70, $this->sumClicks($results));
+    }
+
+    public function testZeroCostProducesZeroDistribution(): void
+    {
+        $distributor = new AdCostDistributor($this->buildProvider(['A' => 5, 'B' => 5]));
+
+        $results = $distributor->distribute(
+            'company-1',
+            [$this->makeListing('A'), $this->makeListing('B')],
+            $this->date,
+            '0.00',
+            0,
+            0,
+        );
+
+        self::assertCount(2, $results);
+        self::assertSame('0.00', $this->sumCosts($results));
+        self::assertSame(0, $this->sumImpressions($results));
+        self::assertSame(0, $this->sumClicks($results));
+    }
+
+    public function testReturnTypeIsArrayOfCostDistributionResult(): void
+    {
+        $distributor = new AdCostDistributor($this->buildProvider(['A' => 1]));
+
+        $results = $distributor->distribute(
+            'company-1',
+            [$this->makeListing('A')],
+            $this->date,
+            '10.00',
+            100,
+            10,
+        );
+
+        self::assertContainsOnlyInstancesOf(CostDistributionResult::class, $results);
+    }
+}


### PR DESCRIPTION
## Summary

- **`AdRawEntry`** (`Application/DTO/`) — унифицированная запись из raw-ответа площадки (campaignId, campaignName, parentSku, cost, impressions, clicks).
- **`CostDistributionResult`** (`Application/DTO/`) — результат распределения затрат на конкретный листинг.
- **`ListingSalesProviderInterface`** (`Domain/Service/`) — Port для получения данных о продажах. Объявлен в модуле `MarketplaceAds`, реализация снаружи (Dependency Inversion).
- **`AdCostDistributor`** (`Domain/Service/`) — доменный сервис распределения затрат: пропорционально продажам, при 0 продажах — равномерно, поправка округления на строку с наибольшей долей. Все расчёты через `bcmath`.
- **`ListingSalesProviderMarketplace`** (`Infrastructure/`) — реализует Port через `MarketplaceFacade` без прямого импорта Repository/Service из модуля Marketplace.
- Binding зарегистрирован в `config/services.yaml`.

## Test plan
- [x] `php bin/console cache:clear` — OK (DI компилируется)
- [x] `phpunit tests/Unit/MarketplaceAds/AdCostDistributorTest.php` — 10/10 ✓
- [x] Покрытие: пустой список, 1 листинг с/без продаж, 2 листинга равные, пропорциональные, 0 продаж (3 листинга), контроль округления (7 листингов), нулевые затраты
- [ ] CI pipeline зелёный

https://claude.ai/code/session_01Gu7CykSgN6uKBwbyqvvgym