### PR TITLE
feat(MarketplaceAds): ProcessAdRawDocumentAction — raw → AdDocument

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -198,6 +198,12 @@ findListingById(string $companyId, string $listingId): ?ActiveListingDTO
 // @return list<array{id: string, parentSku: string}>
 findListingsByMarketplaceSku(string $companyId, string $marketplace, string $marketplaceSku): array
 
+// Bulk-вариант findListingsByMarketplaceSku: один запрос на набор SKU, сгруппирован по parentSku.
+// SKU без листингов в результате отсутствуют.
+// @param  string[] $marketplaceSkus
+// @return array<string, list<array{id: string, parentSku: string}>> parentSku => listings
+findListingsByMarketplaceSkus(string $companyId, string $marketplace, array $marketplaceSkus): array
+
 // Bulk-запрос продаж для набора листингов за одну дату (GROUP BY listing_id)
 // Листинги без продаж отсутствуют в результате (caller сам подставляет 0)
 // @param  string[]           $listingIds
@@ -528,3 +534,4 @@ paths:
 | 1.1 | 2026-03-31 | MarketplaceAnalytics: рефакторинг маппинга затрат — статья фиксированная (UnitEconomyCostType), категория МП выбирается из справочника (marketplace_cost_categories), убраны isSystem и costCategoryCode. Из Facade удалены remapCostMapping, resetCostMapping. |
 | 1.2 | 2026-04-10 | Marketplace: автозапуск daily pipeline после загрузки sales_report. Новый Message `ProcessDayReportMessage` (companyId, rawDocumentId) → `ProcessDayReportHandler` сбрасывает статус конкретного документа и диспатчит `ProcessRawDocumentStepMessage` для каждого шага. SyncWb/OzonReportHandler диспатчат `ProcessDayReportMessage` после успешной загрузки. |
 | 1.3 | 2026-04-12 | MarketplaceAds: новый модуль обработки рекламных отчётов. Entity: `AdRawDocument` (raw JSONB + status DRAFT/PROCESSED), `AdDocument` (кампания × parent SKU за дату), `AdDocumentLine` (распределение на листинг). Domain Port `ListingSalesProviderInterface` с bulk `getSalesQuantitiesByListings` + реализация `ListingSalesProviderMarketplace` через Facade. Domain `AdCostDistributor`: распределение bcmath, при 0 продажах — равномерно, поправка округления на максимальную долю. В `MarketplaceFacade` добавлены `findListingsByMarketplaceSku` (без фильтра `is_active`, для исторических отчётов) и `getSalesQuantitiesForListings` (bulk GROUP BY, убирает N+1). |
+| 1.4 | 2026-04-12 | MarketplaceAds: `ProcessAdRawDocumentAction` — загрузка AdRawDocument (DRAFT) и конвертация в AdDocument + AdDocumentLine. Идемпотентность через `deleteByRawDocumentId`, частичный успех оставляет статус DRAFT. Bulk-prefetch листингов и продаж на уровне Action (2 запроса на документ), `AdCostDistributor` стал чистой функцией без DI. В `MarketplaceFacade` добавлен `findListingsByMarketplaceSkus` (bulk, сгруппирован по parentSku), в `ListingSalesProviderInterface` — `findListingsByParentSkus`. |

--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -246,3 +246,8 @@ services:
 
     App\MarketplaceAds\Infrastructure\Api\Wildberries\WildberriesAdClient:
         tags: ['marketplace_ads.platform_client']
+
+    # Обработка AdRawDocument → AdDocument + AdDocumentLine
+    App\MarketplaceAds\Application\ProcessAdRawDocumentAction:
+        arguments:
+            $parsers: !tagged_iterator marketplace_ads.raw_data_parser

--- a/site/src/Marketplace/Facade/MarketplaceFacade.php
+++ b/site/src/Marketplace/Facade/MarketplaceFacade.php
@@ -267,6 +267,48 @@ final readonly class MarketplaceFacade
     }
 
     /**
+     * Bulk-вариант {@see self::findListingsByMarketplaceSku()}: один запрос на набор SKU.
+     * Результат сгруппирован по parentSku; SKU без листингов в ключах отсутствуют
+     * (caller должен обработать их отдельно).
+     *
+     * @param  string[] $marketplaceSkus
+     * @return array<string, list<array{id: string, parentSku: string}>> parentSku => listings
+     */
+    public function findListingsByMarketplaceSkus(
+        string $companyId,
+        string $marketplace,
+        array $marketplaceSkus,
+    ): array {
+        if ($marketplaceSkus === []) {
+            return [];
+        }
+
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT l.id, l.marketplace_sku AS parent_sku
+             FROM marketplace_listings l
+             WHERE l.company_id = :companyId
+               AND l.marketplace = :marketplace
+               AND l.marketplace_sku IN (:marketplaceSkus)',
+            [
+                'companyId'       => $companyId,
+                'marketplace'     => $marketplace,
+                'marketplaceSkus' => array_values(array_unique($marketplaceSkus)),
+            ],
+            ['marketplaceSkus' => Connection::PARAM_STR_ARRAY],
+        );
+
+        $result = [];
+        foreach ($rows as $row) {
+            $result[$row['parent_sku']][] = [
+                'id'        => $row['id'],
+                'parentSku' => $row['parent_sku'],
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
      * Bulk-запрос продаж для набора листингов за одну дату.
      * Листинги без продаж в результате отсутствуют (caller должен подставить 0 самостоятельно).
      *

--- a/site/src/MarketplaceAds/Application/ProcessAdRawDocumentAction.php
+++ b/site/src/MarketplaceAds/Application/ProcessAdRawDocumentAction.php
@@ -82,6 +82,26 @@ final readonly class ProcessAdRawDocumentAction
             $this->adDocumentRepository->deleteByRawDocumentId($companyId, $adRawDocumentId);
 
             foreach ($entries as $entry) {
+                // AdDocument требует непустой campaignName (Assert::notEmpty). Если парсер отдал
+                // пустое имя (поле отсутствовало в payload), пропускаем запись: без проверки
+                // здесь конструктор AdDocument выбросит исключение и откатит всю транзакцию,
+                // убив частичный успех для остальных записей.
+                if ($entry->campaignName === '') {
+                    $hasErrors = true;
+                    ++$skippedEntries;
+                    $this->logger->warning(
+                        'AdRawEntry пропущена: отсутствует campaignName',
+                        [
+                            'adRawDocumentId' => $adRawDocumentId,
+                            'companyId'       => $companyId,
+                            'marketplace'     => $marketplace->value,
+                            'campaignId'      => $entry->campaignId,
+                            'parentSku'       => $entry->parentSku,
+                        ],
+                    );
+                    continue;
+                }
+
                 $listings = $this->listingSalesProvider->findListingsByParentSku(
                     $companyId,
                     $marketplace->value,
@@ -141,11 +161,10 @@ final readonly class ProcessAdRawDocumentAction
                 ++$processedCount;
             }
 
-            $this->entityManager->flush();
-
+            // wrapInTransaction сам вызовет flush() и commit() после выхода из closure;
+            // изменение статуса rawDocument попадёт в тот же flush, т.к. сущность managed.
             if (!$hasErrors) {
                 $rawDocument->markAsProcessed();
-                $this->entityManager->flush();
             }
         });
 

--- a/site/src/MarketplaceAds/Application/ProcessAdRawDocumentAction.php
+++ b/site/src/MarketplaceAds/Application/ProcessAdRawDocumentAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\MarketplaceAds\Application;
 
+use App\MarketplaceAds\Application\DTO\AdRawEntry;
 use App\MarketplaceAds\Domain\Service\AdCostDistributor;
 use App\MarketplaceAds\Domain\Service\ListingSalesProviderInterface;
 use App\MarketplaceAds\Entity\AdDocument;
@@ -23,7 +24,8 @@ use Doctrine\ORM\EntityManagerInterface;
  * - идемпотентность: повторный запуск удаляет ранее созданные AdDocument и создаёт заново;
  * - частичный успех: если часть SKU не найдена, остальные записи обрабатываются,
  *   raw-документ остаётся в DRAFT для ручного разбора;
- * - статус PROCESSED ставится только при полной обработке без пропусков.
+ * - статус PROCESSED ставится только при полной обработке без пропусков;
+ * - bulk-fetch листингов и продаж: два запроса на весь документ вместо N+1.
  */
 final readonly class ProcessAdRawDocumentAction
 {
@@ -63,6 +65,43 @@ final readonly class ProcessAdRawDocumentAction
         $entries    = $parser->parse($rawDocument->getRawPayload());
         $reportDate = $rawDocument->getReportDate();
 
+        // Шаг 1: bulk-prefetch листингов по всем уникальным parentSku из валидных записей.
+        // Записи с пустым campaignName конструктор AdDocument отвергнет (Assert::notEmpty);
+        // их тоже исключаем из предзагрузки, чтобы не тянуть лишние данные.
+        $validEntries = array_values(array_filter(
+            $entries,
+            static fn(AdRawEntry $e) => $e->campaignName !== '',
+        ));
+
+        $parentSkus = array_values(array_unique(array_map(
+            static fn(AdRawEntry $e) => $e->parentSku,
+            $validEntries,
+        )));
+
+        $listingsByParentSku = $parentSkus === []
+            ? []
+            : $this->listingSalesProvider->findListingsByParentSkus(
+                $companyId,
+                $marketplace->value,
+                $parentSkus,
+            );
+
+        // Шаг 2: bulk-prefetch продаж по всем найденным листингам за дату отчёта.
+        $allListingIds = [];
+        foreach ($listingsByParentSku as $listings) {
+            foreach ($listings as $listing) {
+                $allListingIds[] = $listing['id'];
+            }
+        }
+
+        $salesByListing = $allListingIds === []
+            ? []
+            : $this->listingSalesProvider->getSalesQuantitiesByListings(
+                $companyId,
+                $allListingIds,
+                $reportDate,
+            );
+
         $hasErrors       = false;
         $skippedEntries  = 0;
         $processedCount  = 0;
@@ -74,6 +113,8 @@ final readonly class ProcessAdRawDocumentAction
             $marketplace,
             $reportDate,
             $entries,
+            $listingsByParentSku,
+            $salesByListing,
             &$hasErrors,
             &$skippedEntries,
             &$processedCount,
@@ -102,11 +143,7 @@ final readonly class ProcessAdRawDocumentAction
                     continue;
                 }
 
-                $listings = $this->listingSalesProvider->findListingsByParentSku(
-                    $companyId,
-                    $marketplace->value,
-                    $entry->parentSku,
-                );
+                $listings = $listingsByParentSku[$entry->parentSku] ?? [];
 
                 if ($listings === []) {
                     $hasErrors = true;
@@ -125,9 +162,8 @@ final readonly class ProcessAdRawDocumentAction
                 }
 
                 $distribution = $this->costDistributor->distribute(
-                    companyId:        $companyId,
                     listings:         $listings,
-                    date:             $reportDate,
+                    salesByListing:   $salesByListing,
                     totalCost:        $entry->cost,
                     totalImpressions: $entry->impressions,
                     totalClicks:      $entry->clicks,

--- a/site/src/MarketplaceAds/Application/ProcessAdRawDocumentAction.php
+++ b/site/src/MarketplaceAds/Application/ProcessAdRawDocumentAction.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Application;
+
+use App\MarketplaceAds\Domain\Service\AdCostDistributor;
+use App\MarketplaceAds\Domain\Service\ListingSalesProviderInterface;
+use App\MarketplaceAds\Entity\AdDocument;
+use App\MarketplaceAds\Entity\AdDocumentLine;
+use App\MarketplaceAds\Enum\AdRawDocumentStatus;
+use App\MarketplaceAds\Infrastructure\Api\Contract\AdRawDataParserInterface;
+use App\MarketplaceAds\Repository\AdDocumentRepository;
+use App\MarketplaceAds\Repository\AdRawDocumentRepository;
+use App\Shared\Service\AppLogger;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Обрабатывает AdRawDocument: парсит payload, маппит SKU на листинги,
+ * распределяет рекламные затраты и создаёт AdDocument + AdDocumentLine.
+ *
+ * Контракт:
+ * - идемпотентность: повторный запуск удаляет ранее созданные AdDocument и создаёт заново;
+ * - частичный успех: если часть SKU не найдена, остальные записи обрабатываются,
+ *   raw-документ остаётся в DRAFT для ручного разбора;
+ * - статус PROCESSED ставится только при полной обработке без пропусков.
+ */
+final readonly class ProcessAdRawDocumentAction
+{
+    /**
+     * @param iterable<AdRawDataParserInterface> $parsers
+     */
+    public function __construct(
+        private AdRawDocumentRepository $rawDocumentRepository,
+        private AdDocumentRepository $adDocumentRepository,
+        private iterable $parsers,
+        private ListingSalesProviderInterface $listingSalesProvider,
+        private AdCostDistributor $costDistributor,
+        private EntityManagerInterface $entityManager,
+        private AppLogger $logger,
+    ) {}
+
+    public function __invoke(string $companyId, string $adRawDocumentId): void
+    {
+        $rawDocument = $this->rawDocumentRepository->findByIdAndCompany($adRawDocumentId, $companyId)
+            ?? throw new \DomainException(sprintf('AdRawDocument %s не найден.', $adRawDocumentId));
+
+        if ($rawDocument->getStatus() !== AdRawDocumentStatus::DRAFT) {
+            throw new \DomainException(sprintf(
+                'AdRawDocument %s в статусе %s, ожидался draft.',
+                $adRawDocumentId,
+                $rawDocument->getStatus()->value,
+            ));
+        }
+
+        $marketplace = $rawDocument->getMarketplace();
+        $parser      = $this->selectParser($marketplace->value)
+            ?? throw new \DomainException(sprintf(
+                'Парсер для площадки %s не найден.',
+                $marketplace->value,
+            ));
+
+        $entries    = $parser->parse($rawDocument->getRawPayload());
+        $reportDate = $rawDocument->getReportDate();
+
+        $hasErrors       = false;
+        $skippedEntries  = 0;
+        $processedCount  = 0;
+
+        $this->entityManager->wrapInTransaction(function () use (
+            $rawDocument,
+            $companyId,
+            $adRawDocumentId,
+            $marketplace,
+            $reportDate,
+            $entries,
+            &$hasErrors,
+            &$skippedEntries,
+            &$processedCount,
+        ): void {
+            // Идемпотентность: удаляем старые AdDocument и их строки (каскад по FK).
+            $this->adDocumentRepository->deleteByRawDocumentId($companyId, $adRawDocumentId);
+
+            foreach ($entries as $entry) {
+                $listings = $this->listingSalesProvider->findListingsByParentSku(
+                    $companyId,
+                    $marketplace->value,
+                    $entry->parentSku,
+                );
+
+                if ($listings === []) {
+                    $hasErrors = true;
+                    ++$skippedEntries;
+                    $this->logger->warning(
+                        'AdRawEntry пропущена: листинги по parentSku не найдены',
+                        [
+                            'adRawDocumentId' => $adRawDocumentId,
+                            'companyId'       => $companyId,
+                            'marketplace'     => $marketplace->value,
+                            'parentSku'       => $entry->parentSku,
+                            'campaignId'      => $entry->campaignId,
+                        ],
+                    );
+                    continue;
+                }
+
+                $distribution = $this->costDistributor->distribute(
+                    companyId:        $companyId,
+                    listings:         $listings,
+                    date:             $reportDate,
+                    totalCost:        $entry->cost,
+                    totalImpressions: $entry->impressions,
+                    totalClicks:      $entry->clicks,
+                );
+
+                $adDocument = new AdDocument(
+                    companyId:        $companyId,
+                    marketplace:      $marketplace,
+                    reportDate:       $reportDate,
+                    campaignId:       $entry->campaignId,
+                    campaignName:     $entry->campaignName,
+                    parentSku:        $entry->parentSku,
+                    totalCost:        $entry->cost,
+                    totalImpressions: $entry->impressions,
+                    totalClicks:      $entry->clicks,
+                    adRawDocumentId:  $adRawDocumentId,
+                );
+                $this->entityManager->persist($adDocument);
+
+                foreach ($distribution as $line) {
+                    $this->entityManager->persist(new AdDocumentLine(
+                        adDocument:   $adDocument,
+                        listingId:    $line->listingId,
+                        sharePercent: $line->sharePercent,
+                        cost:         $line->cost,
+                        impressions:  $line->impressions,
+                        clicks:       $line->clicks,
+                    ));
+                }
+
+                ++$processedCount;
+            }
+
+            $this->entityManager->flush();
+
+            if (!$hasErrors) {
+                $rawDocument->markAsProcessed();
+                $this->entityManager->flush();
+            }
+        });
+
+        if ($hasErrors) {
+            $this->logger->info(
+                'Частичная обработка AdRawDocument: документ остаётся в DRAFT',
+                [
+                    'adRawDocumentId' => $adRawDocumentId,
+                    'companyId'       => $companyId,
+                    'processedCount'  => $processedCount,
+                    'skippedCount'    => $skippedEntries,
+                ],
+            );
+        }
+    }
+
+    private function selectParser(string $marketplace): ?AdRawDataParserInterface
+    {
+        foreach ($this->parsers as $parser) {
+            if ($parser->supports($marketplace)) {
+                return $parser;
+            }
+        }
+
+        return null;
+    }
+}

--- a/site/src/MarketplaceAds/Domain/Service/AdCostDistributor.php
+++ b/site/src/MarketplaceAds/Domain/Service/AdCostDistributor.php
@@ -6,13 +6,14 @@ namespace App\MarketplaceAds\Domain\Service;
 
 use App\MarketplaceAds\Application\DTO\CostDistributionResult;
 
-final class AdCostDistributor
+/**
+ * Чистая функция распределения рекламных затрат по листингам.
+ * Данные о продажах передаются снаружи — это позволяет caller'у выполнить один bulk-запрос
+ * для всех листингов сразу и избежать N+1 при обработке большого количества кампаний.
+ */
+final readonly class AdCostDistributor
 {
     private const WEIGHT_SCALE = 10;
-
-    public function __construct(
-        private readonly ListingSalesProviderInterface $salesProvider,
-    ) {}
 
     /**
      * Распределить рекламные затраты по листингам пропорционально продажам.
@@ -20,12 +21,12 @@ final class AdCostDistributor
      * Контроль округления: разница прибавляется к строке с наибольшей долей.
      *
      * @param  array{id: string, parentSku: string}[] $listings
+     * @param  array<string, int>                     $salesByListing listingId => quantity (отсутствующие = 0)
      * @return CostDistributionResult[]
      */
     public function distribute(
-        string $companyId,
         array $listings,
-        \DateTimeImmutable $date,
+        array $salesByListing,
         string $totalCost,
         int $totalImpressions,
         int $totalClicks,
@@ -36,22 +37,20 @@ final class AdCostDistributor
 
         $count = count($listings);
 
-        // Шаг 1: Получаем продажи по всем листингам одним запросом
-        $listingIds     = array_column($listings, 'id');
-        $salesByListing = $this->salesProvider->getSalesQuantitiesByListings($companyId, $listingIds, $date);
-        // Листинги без продаж отсутствуют в ответе — проставляем 0
+        // Нормализуем продажи: листинги без записи получают 0.
+        $sales = [];
         foreach ($listings as $listing) {
-            $salesByListing[$listing['id']] ??= 0;
+            $sales[$listing['id']] = $salesByListing[$listing['id']] ?? 0;
         }
 
-        $totalSales = (int) array_sum($salesByListing);
+        $totalSales = (int) array_sum($sales);
 
-        // Шаг 2: Вычисляем веса с высокой точностью
+        // Шаг 1: Вычисляем веса с высокой точностью
         if ($totalSales > 0) {
             $weights = [];
             foreach ($listings as $listing) {
                 $weights[$listing['id']] = bcdiv(
-                    (string) $salesByListing[$listing['id']],
+                    (string) $sales[$listing['id']],
                     (string) $totalSales,
                     self::WEIGHT_SCALE,
                 );
@@ -65,7 +64,7 @@ final class AdCostDistributor
             }
         }
 
-        // Шаг 3: Найти листинг с наибольшим весом для поправки округления
+        // Шаг 2: Найти листинг с наибольшим весом для поправки округления
         $maxWeightId = array_key_first($weights);
         foreach ($weights as $id => $w) {
             if (bccomp($w, $weights[$maxWeightId], self::WEIGHT_SCALE) > 0) {
@@ -73,7 +72,7 @@ final class AdCostDistributor
             }
         }
 
-        // Шаг 4: Вычислить значения по каждому листингу (с усечением до нужной точности)
+        // Шаг 3: Вычислить значения по каждому листингу (с усечением до нужной точности)
         $results        = [];
         $sumCost        = '0.00';
         $sumShare       = '0.00';
@@ -103,7 +102,7 @@ final class AdCostDistributor
             );
         }
 
-        // Шаг 5: Поправка округления — добавляем разницу к строке с наибольшей долей
+        // Шаг 4: Поправка округления — добавляем разницу к строке с наибольшей долей
         $maxItem = $results[$maxWeightId];
 
         $results[$maxWeightId] = new CostDistributionResult(

--- a/site/src/MarketplaceAds/Domain/Service/ListingSalesProviderInterface.php
+++ b/site/src/MarketplaceAds/Domain/Service/ListingSalesProviderInterface.php
@@ -30,4 +30,18 @@ interface ListingSalesProviderInterface
         string $marketplace,
         string $parentSku,
     ): array;
+
+    /**
+     * Bulk-вариант {@see self::findListingsByParentSku()}: одним запросом возвращает листинги
+     * для всех переданных parentSku, сгруппированные по parentSku. SKU без листингов в ключах
+     * результата отсутствуют.
+     *
+     * @param  string[] $parentSkus
+     * @return array<string, list<array{id: string, parentSku: string}>>
+     */
+    public function findListingsByParentSkus(
+        string $companyId,
+        string $marketplace,
+        array $parentSkus,
+    ): array;
 }

--- a/site/src/MarketplaceAds/Infrastructure/ListingSalesProviderMarketplace.php
+++ b/site/src/MarketplaceAds/Infrastructure/ListingSalesProviderMarketplace.php
@@ -37,4 +37,15 @@ final readonly class ListingSalesProviderMarketplace implements ListingSalesProv
     ): array {
         return $this->marketplaceFacade->findListingsByMarketplaceSku($companyId, $marketplace, $parentSku);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findListingsByParentSkus(
+        string $companyId,
+        string $marketplace,
+        array $parentSkus,
+    ): array {
+        return $this->marketplaceFacade->findListingsByMarketplaceSkus($companyId, $marketplace, $parentSkus);
+    }
 }

--- a/site/src/Shared/Service/AppLogger.php
+++ b/site/src/Shared/Service/AppLogger.php
@@ -28,6 +28,15 @@ class AppLogger
     }
 
     /**
+     * Предупреждение: нештатная, но не фатальная ситуация (пишется в файл/консоль).
+     * Не отправляется в Sentry автоматически.
+     */
+    public function warning(string $message, array $context = []): void
+    {
+        $this->logger->warning($message, $context);
+    }
+
+    /**
      * Фиксация ошибок с отправкой в Sentry
      */
     public function error(string $message, \Throwable $exception = null, array $context = []): void

--- a/site/tests/Integration/MarketplaceAds/ProcessAdRawDocumentActionTest.php
+++ b/site/tests/Integration/MarketplaceAds/ProcessAdRawDocumentActionTest.php
@@ -94,6 +94,39 @@ final class ProcessAdRawDocumentActionTest extends IntegrationTestCase
         self::assertSame('CAMP-1', $adDocuments[0]->getCampaignId());
     }
 
+    public function testSkipsEntriesWithEmptyCampaignNameWithoutAbortingWholeDocument(): void
+    {
+        $company = $this->seedCompany();
+        $this->seedListing($company, 'SKU-GOOD', 'UNKNOWN', '55555555-5555-5555-5555-000000000040');
+        $this->seedListing($company, 'SKU-NONAME', 'UNKNOWN', '55555555-5555-5555-5555-000000000041');
+        $this->em->flush();
+
+        // Вторая запись без campaign_name — парсер отдаст AdRawEntry с пустым campaignName,
+        // который не пройдёт Assert::notEmpty в конструкторе AdDocument. Проверяем, что
+        // Action это ловит и не ломает обработку первой записи.
+        $rawDocumentId = $this->seedOzonRawDocument([
+            ['campaign_id' => 'CAMP-OK', 'campaign_name' => 'OK', 'sku' => 'SKU-GOOD',
+             'spend' => 30.00, 'views' => 300, 'clicks' => 10],
+            ['campaign_id' => 'CAMP-NONAME', 'sku' => 'SKU-NONAME',
+             'spend' => 40.00, 'views' => 400, 'clicks' => 20],
+        ]);
+
+        ($this->action())(self::COMPANY_ID, $rawDocumentId);
+
+        $this->em->clear();
+
+        $rawDocument = $this->em->getRepository(AdRawDocument::class)->find($rawDocumentId);
+        self::assertSame(
+            AdRawDocumentStatus::DRAFT,
+            $rawDocument->getStatus(),
+            'При пропущенных записях raw-документ должен остаться в DRAFT',
+        );
+
+        $adDocuments = $this->em->getRepository(AdDocument::class)->findBy(['adRawDocumentId' => $rawDocumentId]);
+        self::assertCount(1, $adDocuments, 'Запись без campaignName пропущена, валидная обработана');
+        self::assertSame('CAMP-OK', $adDocuments[0]->getCampaignId());
+    }
+
     public function testIdempotentReprocessDeletesPreviousAdDocuments(): void
     {
         $company = $this->seedCompany();

--- a/site/tests/Integration/MarketplaceAds/ProcessAdRawDocumentActionTest.php
+++ b/site/tests/Integration/MarketplaceAds/ProcessAdRawDocumentActionTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\MarketplaceAds;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAds\Application\ProcessAdRawDocumentAction;
+use App\MarketplaceAds\Entity\AdDocument;
+use App\MarketplaceAds\Entity\AdDocumentLine;
+use App\MarketplaceAds\Entity\AdRawDocument;
+use App\MarketplaceAds\Enum\AdRawDocumentStatus;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+
+final class ProcessAdRawDocumentActionTest extends IntegrationTestCase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-000000000001';
+    private const OWNER_ID   = '22222222-2222-2222-2222-000000000001';
+
+    public function testProcessesOzonRawDocumentAndCreatesAdDocuments(): void
+    {
+        $company = $this->seedCompany();
+        $this->seedListing($company, 'SKU-PARENT-1', 'L', '55555555-5555-5555-5555-000000000001');
+        $this->seedListing($company, 'SKU-PARENT-1', 'XL', '55555555-5555-5555-5555-000000000002');
+        $this->em->flush();
+
+        $rawDocumentId = $this->seedOzonRawDocument([
+            ['campaign_id' => 'CAMP-A', 'campaign_name' => 'Осенняя', 'sku' => 'SKU-PARENT-1',
+             'spend' => 100.00, 'views' => 1000, 'clicks' => 40],
+        ]);
+
+        ($this->action())(self::COMPANY_ID, $rawDocumentId);
+
+        $this->em->clear();
+
+        $rawDocument = $this->em->getRepository(AdRawDocument::class)->find($rawDocumentId);
+        self::assertInstanceOf(AdRawDocument::class, $rawDocument);
+        self::assertSame(AdRawDocumentStatus::PROCESSED, $rawDocument->getStatus());
+
+        $adDocuments = $this->em->getRepository(AdDocument::class)->findBy(['adRawDocumentId' => $rawDocumentId]);
+        self::assertCount(1, $adDocuments);
+
+        $adDocument = $adDocuments[0];
+        self::assertSame('CAMP-A', $adDocument->getCampaignId());
+        self::assertSame('Осенняя', $adDocument->getCampaignName());
+        self::assertSame('SKU-PARENT-1', $adDocument->getParentSku());
+        self::assertSame('100.00', $adDocument->getTotalCost());
+        self::assertSame(1000, $adDocument->getTotalImpressions());
+        self::assertSame(40, $adDocument->getTotalClicks());
+
+        /** @var AdDocumentLine[] $lines */
+        $lines = $this->em->getRepository(AdDocumentLine::class)->findBy(['adDocument' => $adDocument->getId()]);
+        self::assertCount(2, $lines);
+
+        // Продаж нет → равномерное распределение 50/50 + поправка округления → 100.00 суммарно.
+        $sumCost = '0.00';
+        foreach ($lines as $line) {
+            $sumCost = bcadd($sumCost, $line->getCost(), 2);
+        }
+        self::assertSame('100.00', $sumCost);
+    }
+
+    public function testPartialProcessingLeavesDocumentInDraftWhenSomeSkusNotFound(): void
+    {
+        $company = $this->seedCompany();
+        $this->seedListing($company, 'SKU-KNOWN', 'UNKNOWN', '55555555-5555-5555-5555-000000000010');
+        $this->em->flush();
+
+        $rawDocumentId = $this->seedOzonRawDocument([
+            ['campaign_id' => 'CAMP-1', 'campaign_name' => 'Кампания 1', 'sku' => 'SKU-KNOWN',
+             'spend' => 50.00, 'views' => 500, 'clicks' => 25],
+            ['campaign_id' => 'CAMP-2', 'campaign_name' => 'Кампания 2', 'sku' => 'SKU-MISSING',
+             'spend' => 80.00, 'views' => 800, 'clicks' => 30],
+        ]);
+
+        ($this->action())(self::COMPANY_ID, $rawDocumentId);
+
+        $this->em->clear();
+
+        $rawDocument = $this->em->getRepository(AdRawDocument::class)->find($rawDocumentId);
+        self::assertSame(
+            AdRawDocumentStatus::DRAFT,
+            $rawDocument->getStatus(),
+            'Документ должен остаться в DRAFT при частичной обработке',
+        );
+
+        $adDocuments = $this->em->getRepository(AdDocument::class)->findBy(['adRawDocumentId' => $rawDocumentId]);
+        self::assertCount(1, $adDocuments, 'Только известный SKU должен быть обработан');
+        self::assertSame('SKU-KNOWN', $adDocuments[0]->getParentSku());
+        self::assertSame('CAMP-1', $adDocuments[0]->getCampaignId());
+    }
+
+    public function testIdempotentReprocessDeletesPreviousAdDocuments(): void
+    {
+        $company = $this->seedCompany();
+        $this->seedListing($company, 'SKU-IDEM', 'UNKNOWN', '55555555-5555-5555-5555-000000000020');
+        $this->em->flush();
+
+        $rawDocumentId = $this->seedOzonRawDocument([
+            ['campaign_id' => 'CAMP-X', 'campaign_name' => 'X', 'sku' => 'SKU-IDEM',
+             'spend' => 10.00, 'views' => 100, 'clicks' => 5],
+        ]);
+
+        $action = $this->action();
+        $action(self::COMPANY_ID, $rawDocumentId);
+        $this->em->clear();
+
+        // Сброс в draft и повторная обработка.
+        /** @var AdRawDocument $rawDocument */
+        $rawDocument = $this->em->getRepository(AdRawDocument::class)->find($rawDocumentId);
+        $rawDocument->resetToDraft();
+        $this->em->flush();
+        $this->em->clear();
+
+        $action(self::COMPANY_ID, $rawDocumentId);
+        $this->em->clear();
+
+        $adDocuments = $this->em->getRepository(AdDocument::class)->findBy(['adRawDocumentId' => $rawDocumentId]);
+        self::assertCount(1, $adDocuments, 'Повторная обработка не должна дублировать AdDocument');
+    }
+
+    public function testThrowsWhenDocumentIsNotDraft(): void
+    {
+        $company = $this->seedCompany();
+        $this->seedListing($company, 'SKU-Y', 'UNKNOWN', '55555555-5555-5555-5555-000000000030');
+        $this->em->flush();
+
+        $rawDocumentId = $this->seedOzonRawDocument([
+            ['campaign_id' => 'C', 'campaign_name' => 'N', 'sku' => 'SKU-Y',
+             'spend' => 1.00, 'views' => 1, 'clicks' => 0],
+        ]);
+
+        $action = $this->action();
+        $action(self::COMPANY_ID, $rawDocumentId);
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('ожидался draft');
+
+        $action(self::COMPANY_ID, $rawDocumentId);
+    }
+
+    public function testThrowsWhenDocumentNotFound(): void
+    {
+        $this->seedCompany();
+        $this->em->flush();
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('не найден');
+
+        ($this->action())(self::COMPANY_ID, '99999999-9999-9999-9999-999999999999');
+    }
+
+    private function action(): ProcessAdRawDocumentAction
+    {
+        return self::getContainer()->get(ProcessAdRawDocumentAction::class);
+    }
+
+    private function seedCompany(): Company
+    {
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('ads-owner@example.test')
+            ->build();
+
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $this->em->persist($owner);
+        $this->em->persist($company);
+
+        return $company;
+    }
+
+    private function seedListing(Company $company, string $parentSku, string $size, string $listingId): MarketplaceListing
+    {
+        $listing = new MarketplaceListing($listingId, $company, null, MarketplaceType::OZON);
+        $listing->setMarketplaceSku($parentSku);
+        $listing->setSize($size);
+        $listing->setPrice('0.00');
+
+        $this->em->persist($listing);
+
+        return $listing;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $rows
+     */
+    private function seedOzonRawDocument(array $rows): string
+    {
+        $payload = json_encode(['rows' => $rows], JSON_THROW_ON_ERROR);
+
+        $rawDocument = new AdRawDocument(
+            companyId:   self::COMPANY_ID,
+            marketplace: MarketplaceType::OZON,
+            reportDate:  new \DateTimeImmutable('2026-04-10'),
+            rawPayload:  $payload,
+        );
+
+        $this->em->persist($rawDocument);
+        $this->em->flush();
+
+        return $rawDocument->getId();
+    }
+}

--- a/site/tests/Unit/MarketplaceAds/AdCostDistributorTest.php
+++ b/site/tests/Unit/MarketplaceAds/AdCostDistributorTest.php
@@ -6,45 +6,20 @@ namespace App\Tests\Unit\MarketplaceAds;
 
 use App\MarketplaceAds\Application\DTO\CostDistributionResult;
 use App\MarketplaceAds\Domain\Service\AdCostDistributor;
-use App\MarketplaceAds\Domain\Service\ListingSalesProviderInterface;
 use PHPUnit\Framework\TestCase;
 
 final class AdCostDistributorTest extends TestCase
 {
-    private readonly \DateTimeImmutable $date;
+    private AdCostDistributor $distributor;
 
     protected function setUp(): void
     {
-        $this->date = new \DateTimeImmutable('2026-04-01');
+        $this->distributor = new AdCostDistributor();
     }
 
     // -------------------------------------------------------------------------
     // Вспомогательные методы
     // -------------------------------------------------------------------------
-
-    /**
-     * @param array<string, int> $salesByListingId  listingId => quantity
-     */
-    private function buildProvider(array $salesByListingId): ListingSalesProviderInterface
-    {
-        $provider = $this->createMock(ListingSalesProviderInterface::class);
-        $provider
-            ->method('getSalesQuantitiesByListings')
-            ->willReturnCallback(
-                static function (string $companyId, array $listingIds, \DateTimeImmutable $date) use ($salesByListingId): array {
-                    $result = [];
-                    foreach ($listingIds as $id) {
-                        if (isset($salesByListingId[$id])) {
-                            $result[$id] = $salesByListingId[$id];
-                        }
-                    }
-
-                    return $result;
-                },
-            );
-
-        return $provider;
-    }
 
     private function makeListing(string $id, string $parentSku = 'SKU-1'): array
     {
@@ -87,21 +62,16 @@ final class AdCostDistributorTest extends TestCase
 
     public function testEmptyListingsReturnsEmpty(): void
     {
-        $distributor = new AdCostDistributor($this->buildProvider([]));
-
-        $result = $distributor->distribute('company-1', [], $this->date, '100.00', 1000, 50);
+        $result = $this->distributor->distribute([], [], '100.00', 1000, 50);
 
         self::assertSame([], $result);
     }
 
     public function testSingleListingGetsFullAmount(): void
     {
-        $distributor = new AdCostDistributor($this->buildProvider(['A' => 5]));
-
-        $results = $distributor->distribute(
-            'company-1',
+        $results = $this->distributor->distribute(
             [$this->makeListing('A')],
-            $this->date,
+            ['A' => 5],
             '99.99',
             500,
             30,
@@ -117,12 +87,9 @@ final class AdCostDistributorTest extends TestCase
 
     public function testSingleListingNoSalesGetsFullAmount(): void
     {
-        $distributor = new AdCostDistributor($this->buildProvider([]));
-
-        $results = $distributor->distribute(
-            'company-1',
+        $results = $this->distributor->distribute(
             [$this->makeListing('A')],
-            $this->date,
+            [],
             '50.00',
             200,
             10,
@@ -137,12 +104,9 @@ final class AdCostDistributorTest extends TestCase
 
     public function testTwoListingsEqualSalesGetFiftyPercent(): void
     {
-        $distributor = new AdCostDistributor($this->buildProvider(['A' => 10, 'B' => 10]));
-
-        $results = $distributor->distribute(
-            'company-1',
+        $results = $this->distributor->distribute(
             [$this->makeListing('A'), $this->makeListing('B')],
-            $this->date,
+            ['A' => 10, 'B' => 10],
             '100.00',
             1000,
             100,
@@ -160,12 +124,9 @@ final class AdCostDistributorTest extends TestCase
     public function testProportionalDistributionBySales(): void
     {
         // A:2 sales, B:1 sale → 2/3 and 1/3
-        $distributor = new AdCostDistributor($this->buildProvider(['A' => 2, 'B' => 1]));
-
-        $results = $distributor->distribute(
-            'company-1',
+        $results = $this->distributor->distribute(
             [$this->makeListing('A'), $this->makeListing('B')],
-            $this->date,
+            ['A' => 2, 'B' => 1],
             '30.00',
             300,
             60,
@@ -184,12 +145,9 @@ final class AdCostDistributorTest extends TestCase
 
     public function testEqualDistributionWhenNoSales(): void
     {
-        $distributor = new AdCostDistributor($this->buildProvider([]));
-
-        $results = $distributor->distribute(
-            'company-1',
+        $results = $this->distributor->distribute(
             [$this->makeListing('A'), $this->makeListing('B'), $this->makeListing('C')],
-            $this->date,
+            [],
             '10.00',
             100,
             30,
@@ -206,12 +164,9 @@ final class AdCostDistributorTest extends TestCase
     public function testRoundingCorrectionOnCostSum(): void
     {
         // 3 equal listings, cost = '10.00' — 10/3 cannot divide evenly
-        $distributor = new AdCostDistributor($this->buildProvider([]));
-
-        $results = $distributor->distribute(
-            'company-1',
+        $results = $this->distributor->distribute(
             [$this->makeListing('A'), $this->makeListing('B'), $this->makeListing('C')],
-            $this->date,
+            [],
             '10.00',
             100,
             30,
@@ -227,17 +182,14 @@ final class AdCostDistributorTest extends TestCase
     public function testRoundingCorrectionOnLargerSet(): void
     {
         // 7 equal listings, cost = '100.00' — 100/7 repeating decimal
-        $distributor = new AdCostDistributor($this->buildProvider([]));
-
         $listings = [];
         for ($i = 1; $i <= 7; $i++) {
             $listings[] = $this->makeListing("L{$i}");
         }
 
-        $results = $distributor->distribute(
-            'company-1',
+        $results = $this->distributor->distribute(
             $listings,
-            $this->date,
+            [],
             '100.00',
             700,
             70,
@@ -252,12 +204,9 @@ final class AdCostDistributorTest extends TestCase
 
     public function testZeroCostProducesZeroDistribution(): void
     {
-        $distributor = new AdCostDistributor($this->buildProvider(['A' => 5, 'B' => 5]));
-
-        $results = $distributor->distribute(
-            'company-1',
+        $results = $this->distributor->distribute(
             [$this->makeListing('A'), $this->makeListing('B')],
-            $this->date,
+            ['A' => 5, 'B' => 5],
             '0.00',
             0,
             0,
@@ -271,17 +220,34 @@ final class AdCostDistributorTest extends TestCase
 
     public function testReturnTypeIsArrayOfCostDistributionResult(): void
     {
-        $distributor = new AdCostDistributor($this->buildProvider(['A' => 1]));
-
-        $results = $distributor->distribute(
-            'company-1',
+        $results = $this->distributor->distribute(
             [$this->makeListing('A')],
-            $this->date,
+            ['A' => 1],
             '10.00',
             100,
             10,
         );
 
         self::assertContainsOnlyInstancesOf(CostDistributionResult::class, $results);
+    }
+
+    public function testListingWithoutSalesEntryTreatedAsZero(): void
+    {
+        // Один листинг с продажами, другой отсутствует в карте — должен получить 0 продаж.
+        $results = $this->distributor->distribute(
+            [$this->makeListing('A'), $this->makeListing('B')],
+            ['A' => 10],
+            '50.00',
+            100,
+            20,
+        );
+
+        self::assertCount(2, $results);
+        self::assertSame('A', $results[0]->listingId);
+        self::assertSame('50.00', $results[0]->cost);
+        self::assertSame('100.00', $results[0]->sharePercent);
+        self::assertSame('B', $results[1]->listingId);
+        self::assertSame('0.00', $results[1]->cost);
+        self::assertSame('0.00', $results[1]->sharePercent);
     }
 }


### PR DESCRIPTION
## Summary

Задача 5 модуля MarketplaceAds. `ProcessAdRawDocumentAction` берёт `AdRawDocument` в `DRAFT`, выбирает парсер по marketplace через tagged iterator, парсит payload и для каждого `AdRawEntry` находит листинги по `parentSku`, распределяет стоимость через `AdCostDistributor`, создаёт `AdDocument` + `AdDocumentLine`.

## Ключевые свойства

- **Идемпотентно**: старые `AdDocument` по `rawDocumentId` удаляются до вставки новых (каскад FK уносит `AdDocumentLine`).
- **Транзакционно**: всё внутри `EntityManager::wrapInTransaction` — ошибка откатывает и удаление, и вставки.
- **Частичный успех**: если листинги по `parentSku` не найдены, запись пропускается, остальные обрабатываются, документ остаётся в `DRAFT` с `info`-логом "Частичная обработка, N записей пропущено".
- **`PROCESSED`** ставится только при полной обработке без пропусков.
- **Выбор парсера**: iterable `!tagged_iterator marketplace_ads.raw_data_parser`, первый `supports($marketplace->value)` выигрывает.
- **DomainException**: документ не найден / не в DRAFT / нет парсера для marketplace.

## Изменения

- `src/MarketplaceAds/Application/ProcessAdRawDocumentAction.php` — новый Action
- `src/Shared/Service/AppLogger.php` — добавлен `warning()` для нештатных, но не фатальных ситуаций
- `config/services.yaml` — регистрация Action с `!tagged_iterator marketplace_ads.raw_data_parser`
- `tests/Integration/MarketplaceAds/ProcessAdRawDocumentActionTest.php` — 5 сценариев

## Test plan

- [x] Unit-тесты всех MarketplaceAds (парсеры, distributor) — 32 теста зелёные
- [x] `php bin/console debug:container` подтверждает корректную автоинъекцию (tagged iterator, AdCostDistributor, AppLogger, EM, оба Repository)
- [ ] CI прогонит integration-тесты:
  - `testProcessesOzonRawDocumentAndCreatesAdDocuments` — happy path
  - `testPartialProcessingLeavesDocumentInDraftWhenSomeSkusNotFound` — SKU не найден, другие обработаны
  - `testIdempotentReprocessDeletesPreviousAdDocuments` — повторная обработка не дублирует
  - `testThrowsWhenDocumentIsNotDraft`, `testThrowsWhenDocumentNotFound` — границы

https://claude.ai/code/session_01Gu7CykSgN6uKBwbyqvvgym