### PR TITLE
feat(MarketplaceAds): cron loader + reprocess CLI + async Messenger pipeline

### DIFF
--- a/site/config/packages/messenger.yaml
+++ b/site/config/packages/messenger.yaml
@@ -44,6 +44,7 @@ framework:
             Symfony\Component\Notifier\Message\ChatMessage: async
             Symfony\Component\Notifier\Message\SmsMessage: async
             App\MarketplaceAnalytics\Message\RecalcSnapshotsMessage: async
+            App\MarketplaceAds\Message\ProcessAdRawDocumentMessage: async
 
             # Route your messages to the transports
             # 'App\Message\YourMessage': async

--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -251,3 +251,8 @@ services:
     App\MarketplaceAds\Application\ProcessAdRawDocumentAction:
         arguments:
             $parsers: !tagged_iterator marketplace_ads.raw_data_parser
+
+    # CLI-загрузчик рекламных отчётов получает все API-клиенты через tagged_iterator.
+    App\MarketplaceAds\Command\LoadAdDataCommand:
+        arguments:
+            $platformClients: !tagged_iterator marketplace_ads.platform_client

--- a/site/src/MarketplaceAds/Command/LoadAdDataCommand.php
+++ b/site/src/MarketplaceAds/Command/LoadAdDataCommand.php
@@ -240,7 +240,10 @@ final class LoadAdDataCommand extends Command
         }
 
         $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
-        if ($date === false) {
+        // createFromFormat нормализует несуществующие даты (например, 2026-02-31 → 2026-03-03)
+        // и возвращает DateTimeImmutable, а не false. Roundtrip-проверка отсекает такие
+        // случаи: валидная дата должна сериализоваться обратно в исходную строку.
+        if ($date === false || $date->format('Y-m-d') !== $value) {
             throw new \InvalidArgumentException(sprintf('Invalid date: %s', $value));
         }
 

--- a/site/src/MarketplaceAds/Command/LoadAdDataCommand.php
+++ b/site/src/MarketplaceAds/Command/LoadAdDataCommand.php
@@ -1,0 +1,281 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Command;
+
+use App\Company\Facade\CompanyFacade;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Repository\MarketplaceConnectionRepository;
+use App\MarketplaceAds\Entity\AdRawDocument;
+use App\MarketplaceAds\Infrastructure\Api\Contract\AdPlatformClientInterface;
+use App\MarketplaceAds\Message\ProcessAdRawDocumentMessage;
+use App\MarketplaceAds\Repository\AdRawDocumentRepository;
+use App\Shared\Service\AppLogger;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * Cron-команда: загружает рекламные отчёты маркетплейсов за дату (по умолчанию — за вчера)
+ * и ставит задачи на их обработку через Messenger.
+ *
+ * Для каждой пары (company × marketplace):
+ *   1) берём JSON через AdPlatformClientInterface;
+ *   2) upsert-им AdRawDocument (уникальный ключ company + marketplace + report_date);
+ *   3) отправляем ProcessAdRawDocumentMessage в async-транспорт.
+ *
+ * Ошибки API/отсутствия клиента/подключения логируются, но не прерывают цикл —
+ * cron должен попробовать обработать всё, что может.
+ */
+#[AsCommand(
+    name: 'marketplace-ads:load',
+    description: 'Загружает рекламную статистику маркетплейсов за дату и ставит обработку в очередь.',
+)]
+final class LoadAdDataCommand extends Command
+{
+    private const MARKETPLACE_ALL = 'all';
+
+    /** @var array<string, MarketplaceType> псевдонимы CLI → MarketplaceType */
+    private const MARKETPLACE_ALIASES = [
+        'wb'          => MarketplaceType::WILDBERRIES,
+        'wildberries' => MarketplaceType::WILDBERRIES,
+        'ozon'        => MarketplaceType::OZON,
+    ];
+
+    /**
+     * @param iterable<AdPlatformClientInterface> $platformClients
+     */
+    public function __construct(
+        private readonly CompanyFacade $companyFacade,
+        private readonly MarketplaceConnectionRepository $connectionRepository,
+        private readonly AdRawDocumentRepository $rawDocumentRepository,
+        private readonly iterable $platformClients,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly MessageBusInterface $bus,
+        private readonly AppLogger $logger,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                'date',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Дата отчёта (YYYY-MM-DD). По умолчанию — вчера.',
+                'yesterday',
+            )
+            ->addOption(
+                'marketplace',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Маркетплейс: wb, ozon, all.',
+                self::MARKETPLACE_ALL,
+            )
+            ->addOption(
+                'company-id',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'UUID компании. Если не указан — берутся все активные компании.',
+                null,
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        try {
+            $reportDate = $this->parseDate((string) $input->getOption('date'));
+        } catch (\Throwable) {
+            $output->writeln('<error>Неверный формат --date. Ожидается YYYY-MM-DD или "yesterday".</error>');
+
+            return Command::FAILURE;
+        }
+
+        try {
+            $marketplaces = $this->resolveMarketplaces((string) $input->getOption('marketplace'));
+        } catch (\InvalidArgumentException $e) {
+            $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
+
+            return Command::FAILURE;
+        }
+
+        $companyIdOption = $input->getOption('company-id');
+        $companyIds      = $companyIdOption !== null && $companyIdOption !== ''
+            ? [(string) $companyIdOption]
+            : $this->companyFacade->getAllActiveCompanyIds();
+
+        if ($companyIds === []) {
+            $output->writeln('<comment>Нет компаний для загрузки.</comment>');
+
+            return Command::SUCCESS;
+        }
+
+        $loaded  = 0;
+        $skipped = 0;
+        $failed  = 0;
+
+        foreach ($companyIds as $companyId) {
+            foreach ($marketplaces as $marketplace) {
+                $result = $this->loadForCompanyAndMarketplace($companyId, $marketplace, $reportDate, $output);
+
+                match ($result) {
+                    'loaded'  => ++$loaded,
+                    'skipped' => ++$skipped,
+                    'failed'  => ++$failed,
+                };
+            }
+        }
+
+        $output->writeln(sprintf(
+            '<info>Готово. Загружено: %d, пропущено: %d, ошибок: %d.</info>',
+            $loaded,
+            $skipped,
+            $failed,
+        ));
+
+        return $failed > 0 ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    /**
+     * @return 'loaded'|'skipped'|'failed'
+     */
+    private function loadForCompanyAndMarketplace(
+        string $companyId,
+        MarketplaceType $marketplace,
+        \DateTimeImmutable $reportDate,
+        OutputInterface $output,
+    ): string {
+        $connection = $this->connectionRepository->findByCompanyIdAndMarketplace($companyId, $marketplace);
+
+        if ($connection === null || !$connection->isActive()) {
+            $output->writeln(sprintf(
+                '<comment>[%s / %s] пропуск: нет активного подключения.</comment>',
+                $companyId,
+                $marketplace->value,
+            ));
+
+            return 'skipped';
+        }
+
+        $client = $this->selectClient($marketplace->value);
+
+        if ($client === null) {
+            $this->logger->warning('Отсутствует AdPlatformClient для маркетплейса', [
+                'companyId'   => $companyId,
+                'marketplace' => $marketplace->value,
+            ]);
+
+            return 'skipped';
+        }
+
+        try {
+            $payload = $client->fetchAdStatistics($companyId, $reportDate);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Ошибка загрузки рекламной статистики',
+                $e,
+                [
+                    'companyId'   => $companyId,
+                    'marketplace' => $marketplace->value,
+                    'reportDate'  => $reportDate->format('Y-m-d'),
+                ],
+            );
+            $output->writeln(sprintf(
+                '<error>[%s / %s] ошибка API: %s</error>',
+                $companyId,
+                $marketplace->value,
+                $e->getMessage(),
+            ));
+
+            return 'failed';
+        }
+
+        $existing = $this->rawDocumentRepository->findByMarketplaceAndDate(
+            $companyId,
+            $marketplace->value,
+            $reportDate,
+        );
+
+        if ($existing !== null) {
+            $existing->updatePayload($payload);
+            $rawDocument = $existing;
+        } else {
+            $rawDocument = new AdRawDocument(
+                companyId:   $companyId,
+                marketplace: $marketplace,
+                reportDate:  $reportDate,
+                rawPayload:  $payload,
+            );
+            $this->rawDocumentRepository->save($rawDocument);
+        }
+
+        $this->entityManager->flush();
+
+        $this->bus->dispatch(new ProcessAdRawDocumentMessage(
+            companyId:       $companyId,
+            adRawDocumentId: $rawDocument->getId(),
+        ));
+
+        $output->writeln(sprintf(
+            '<info>[%s / %s] загружено (doc=%s).</info>',
+            $companyId,
+            $marketplace->value,
+            $rawDocument->getId(),
+        ));
+
+        return 'loaded';
+    }
+
+    private function parseDate(string $value): \DateTimeImmutable
+    {
+        if ($value === 'yesterday' || $value === '') {
+            return new \DateTimeImmutable('yesterday');
+        }
+
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
+        if ($date === false) {
+            throw new \InvalidArgumentException(sprintf('Invalid date: %s', $value));
+        }
+
+        return $date;
+    }
+
+    /**
+     * @return list<MarketplaceType>
+     */
+    private function resolveMarketplaces(string $value): array
+    {
+        $value = strtolower($value);
+
+        if ($value === self::MARKETPLACE_ALL) {
+            return [MarketplaceType::WILDBERRIES, MarketplaceType::OZON];
+        }
+
+        if (!isset(self::MARKETPLACE_ALIASES[$value])) {
+            throw new \InvalidArgumentException(sprintf(
+                'Неизвестный --marketplace=%s. Допустимо: wb, ozon, all.',
+                $value,
+            ));
+        }
+
+        return [self::MARKETPLACE_ALIASES[$value]];
+    }
+
+    private function selectClient(string $marketplace): ?AdPlatformClientInterface
+    {
+        foreach ($this->platformClients as $client) {
+            if ($client->supports($marketplace)) {
+                return $client;
+            }
+        }
+
+        return null;
+    }
+}

--- a/site/src/MarketplaceAds/Command/LoadAdDataCommand.php
+++ b/site/src/MarketplaceAds/Command/LoadAdDataCommand.php
@@ -27,7 +27,10 @@ use Symfony\Component\Messenger\MessageBusInterface;
  * Для каждой пары (company × marketplace):
  *   1) берём JSON через AdPlatformClientInterface;
  *   2) upsert-им AdRawDocument (уникальный ключ company + marketplace + report_date);
- *   3) отправляем ProcessAdRawDocumentMessage в async-транспорт.
+ *   3) копим подготовленный документ, а единый flush делаем в конце прохода по всем парам,
+ *      чтобы на N компаниях × M площадках не получить N*M отдельных транзакций.
+ *   4) только после успешного flush отправляем ProcessAdRawDocumentMessage в async-транспорт —
+ *      иначе воркер заберёт сообщение до того, как документ появится в БД.
  *
  * Ошибки API/отсутствия клиента/подключения логируются, но не прерывают цикл —
  * cron должен попробовать обработать всё, что может.
@@ -42,9 +45,9 @@ final class LoadAdDataCommand extends Command
 
     /** @var array<string, MarketplaceType> псевдонимы CLI → MarketplaceType */
     private const MARKETPLACE_ALIASES = [
-        'wb'          => MarketplaceType::WILDBERRIES,
+        'wb' => MarketplaceType::WILDBERRIES,
         'wildberries' => MarketplaceType::WILDBERRIES,
-        'ozon'        => MarketplaceType::OZON,
+        'ozon' => MarketplaceType::OZON,
     ];
 
     /**
@@ -107,30 +110,63 @@ final class LoadAdDataCommand extends Command
         }
 
         $companyIdOption = $input->getOption('company-id');
-        $companyIds      = $companyIdOption !== null && $companyIdOption !== ''
-            ? [(string) $companyIdOption]
-            : $this->companyFacade->getAllActiveCompanyIds();
+        if (null !== $companyIdOption && '' !== $companyIdOption) {
+            $companyId = (string) $companyIdOption;
+            // Валидируем наличие компании на границе CLI → иначе при опечатке UUID
+            // команда молча напишет «нет активного подключения» по каждому маркетплейсу,
+            // и оператор не поймёт, что ошибка в аргументе.
+            if (null === $this->companyFacade->findById($companyId)) {
+                $output->writeln(sprintf(
+                    '<error>Компания не найдена: --company-id=%s.</error>',
+                    $companyId,
+                ));
 
-        if ($companyIds === []) {
+                return Command::FAILURE;
+            }
+            $companyIds = [$companyId];
+        } else {
+            $companyIds = $this->companyFacade->getAllActiveCompanyIds();
+        }
+
+        if ([] === $companyIds) {
             $output->writeln('<comment>Нет компаний для загрузки.</comment>');
 
             return Command::SUCCESS;
         }
 
-        $loaded  = 0;
+        /** @var list<AdRawDocument> $preparedDocuments */
+        $preparedDocuments = [];
         $skipped = 0;
-        $failed  = 0;
+        $failed = 0;
 
         foreach ($companyIds as $companyId) {
             foreach ($marketplaces as $marketplace) {
-                $result = $this->loadForCompanyAndMarketplace($companyId, $marketplace, $reportDate, $output);
+                $result = $this->prepareForCompanyAndMarketplace($companyId, $marketplace, $reportDate, $output);
 
-                match ($result) {
-                    'loaded'  => ++$loaded,
-                    'skipped' => ++$skipped,
-                    'failed'  => ++$failed,
-                };
+                if ($result instanceof AdRawDocument) {
+                    $preparedDocuments[] = $result;
+                } elseif ('failed' === $result) {
+                    ++$failed;
+                } else {
+                    ++$skipped;
+                }
             }
+        }
+
+        // Один flush на весь прогон — N*M подготовленных документов фиксируются
+        // в единой транзакции. Если flush упадёт, ни одно сообщение не уйдёт
+        // в очередь, и следующий cron повторит цикл чисто.
+        if ([] !== $preparedDocuments) {
+            $this->entityManager->flush();
+        }
+
+        $loaded = 0;
+        foreach ($preparedDocuments as $document) {
+            $this->bus->dispatch(new ProcessAdRawDocumentMessage(
+                companyId: $document->getCompanyId(),
+                adRawDocumentId: $document->getId(),
+            ));
+            ++$loaded;
         }
 
         $output->writeln(sprintf(
@@ -140,21 +176,30 @@ final class LoadAdDataCommand extends Command
             $failed,
         ));
 
-        return $failed > 0 ? Command::FAILURE : Command::SUCCESS;
+        // Частичный провал (есть и успехи, и ошибки) не поднимаем до FAILURE —
+        // cron-мониторинг не должен алертить, если 1 компания из 100 провалилась.
+        // FAILURE возвращаем только когда всё упало и нечего было загружать.
+        if ($failed > 0 && 0 === $loaded) {
+            return Command::FAILURE;
+        }
+
+        return Command::SUCCESS;
     }
 
     /**
-     * @return 'loaded'|'skipped'|'failed'
+     * Готовит (persist/updatePayload) AdRawDocument без flush.
+     *
+     * @return AdRawDocument|'skipped'|'failed'
      */
-    private function loadForCompanyAndMarketplace(
+    private function prepareForCompanyAndMarketplace(
         string $companyId,
         MarketplaceType $marketplace,
         \DateTimeImmutable $reportDate,
         OutputInterface $output,
-    ): string {
+    ): AdRawDocument|string {
         $connection = $this->connectionRepository->findByCompanyIdAndMarketplace($companyId, $marketplace);
 
-        if ($connection === null || !$connection->isActive()) {
+        if (null === $connection || !$connection->isActive()) {
             $output->writeln(sprintf(
                 '<comment>[%s / %s] пропуск: нет активного подключения.</comment>',
                 $companyId,
@@ -166,9 +211,9 @@ final class LoadAdDataCommand extends Command
 
         $client = $this->selectClient($marketplace->value);
 
-        if ($client === null) {
+        if (null === $client) {
             $this->logger->warning('Отсутствует AdPlatformClient для маркетплейса', [
-                'companyId'   => $companyId,
+                'companyId' => $companyId,
                 'marketplace' => $marketplace->value,
             ]);
 
@@ -182,9 +227,9 @@ final class LoadAdDataCommand extends Command
                 'Ошибка загрузки рекламной статистики',
                 $e,
                 [
-                    'companyId'   => $companyId,
+                    'companyId' => $companyId,
                     'marketplace' => $marketplace->value,
-                    'reportDate'  => $reportDate->format('Y-m-d'),
+                    'reportDate' => $reportDate->format('Y-m-d'),
                 ],
             );
             $output->writeln(sprintf(
@@ -203,39 +248,32 @@ final class LoadAdDataCommand extends Command
             $reportDate,
         );
 
-        if ($existing !== null) {
+        if (null !== $existing) {
             $existing->updatePayload($payload);
             $rawDocument = $existing;
         } else {
             $rawDocument = new AdRawDocument(
-                companyId:   $companyId,
+                companyId: $companyId,
                 marketplace: $marketplace,
-                reportDate:  $reportDate,
-                rawPayload:  $payload,
+                reportDate: $reportDate,
+                rawPayload: $payload,
             );
             $this->rawDocumentRepository->save($rawDocument);
         }
 
-        $this->entityManager->flush();
-
-        $this->bus->dispatch(new ProcessAdRawDocumentMessage(
-            companyId:       $companyId,
-            adRawDocumentId: $rawDocument->getId(),
-        ));
-
         $output->writeln(sprintf(
-            '<info>[%s / %s] загружено (doc=%s).</info>',
+            '<info>[%s / %s] подготовлен (doc=%s).</info>',
             $companyId,
             $marketplace->value,
             $rawDocument->getId(),
         ));
 
-        return 'loaded';
+        return $rawDocument;
     }
 
     private function parseDate(string $value): \DateTimeImmutable
     {
-        if ($value === 'yesterday' || $value === '') {
+        if ('yesterday' === $value || '' === $value) {
             return new \DateTimeImmutable('yesterday');
         }
 
@@ -243,7 +281,7 @@ final class LoadAdDataCommand extends Command
         // createFromFormat нормализует несуществующие даты (например, 2026-02-31 → 2026-03-03)
         // и возвращает DateTimeImmutable, а не false. Roundtrip-проверка отсекает такие
         // случаи: валидная дата должна сериализоваться обратно в исходную строку.
-        if ($date === false || $date->format('Y-m-d') !== $value) {
+        if (false === $date || $date->format('Y-m-d') !== $value) {
             throw new \InvalidArgumentException(sprintf('Invalid date: %s', $value));
         }
 
@@ -257,15 +295,12 @@ final class LoadAdDataCommand extends Command
     {
         $value = strtolower($value);
 
-        if ($value === self::MARKETPLACE_ALL) {
+        if (self::MARKETPLACE_ALL === $value) {
             return [MarketplaceType::WILDBERRIES, MarketplaceType::OZON];
         }
 
         if (!isset(self::MARKETPLACE_ALIASES[$value])) {
-            throw new \InvalidArgumentException(sprintf(
-                'Неизвестный --marketplace=%s. Допустимо: wb, ozon, all.',
-                $value,
-            ));
+            throw new \InvalidArgumentException(sprintf('Неизвестный --marketplace=%s. Допустимо: wb, ozon, all.', $value));
         }
 
         return [self::MARKETPLACE_ALIASES[$value]];

--- a/site/src/MarketplaceAds/Command/ReprocessAdDataCommand.php
+++ b/site/src/MarketplaceAds/Command/ReprocessAdDataCommand.php
@@ -76,8 +76,12 @@ final class ReprocessAdDataCommand extends Command
         $dateOption = $input->getOption('date');
         $reportDate = null;
         if ($dateOption !== null && $dateOption !== '') {
-            $reportDate = \DateTimeImmutable::createFromFormat('!Y-m-d', (string) $dateOption);
-            if ($reportDate === false) {
+            $dateValue  = (string) $dateOption;
+            $reportDate = \DateTimeImmutable::createFromFormat('!Y-m-d', $dateValue);
+            // createFromFormat нормализует несуществующие даты (например, 2026-02-31 → 2026-03-03)
+            // и возвращает DateTimeImmutable, а не false. Roundtrip-проверка отсекает такие
+            // случаи: валидная дата должна сериализоваться обратно в исходную строку.
+            if ($reportDate === false || $reportDate->format('Y-m-d') !== $dateValue) {
                 $output->writeln('<error>Неверный формат --date. Ожидается YYYY-MM-DD.</error>');
 
                 return Command::FAILURE;
@@ -116,15 +120,20 @@ final class ReprocessAdDataCommand extends Command
             return Command::SUCCESS;
         }
 
-        $dispatched = 0;
-
+        // Сначала обновляем статусы всех документов, затем один flush,
+        // и только потом диспатч — это снимает N flush'ей на N документов
+        // и гарантирует, что статусы согласованно лежат в БД до того,
+        // как воркеры начнут их забирать.
         foreach ($documents as $document) {
             if ($document->getStatus() !== AdRawDocumentStatus::DRAFT) {
                 $document->resetToDraft();
             }
+        }
 
-            $this->entityManager->flush();
+        $this->entityManager->flush();
 
+        $dispatched = 0;
+        foreach ($documents as $document) {
             $this->bus->dispatch(new ProcessAdRawDocumentMessage(
                 companyId:       $document->getCompanyId(),
                 adRawDocumentId: $document->getId(),

--- a/site/src/MarketplaceAds/Command/ReprocessAdDataCommand.php
+++ b/site/src/MarketplaceAds/Command/ReprocessAdDataCommand.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Command;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAds\Enum\AdRawDocumentStatus;
+use App\MarketplaceAds\Message\ProcessAdRawDocumentMessage;
+use App\MarketplaceAds\Repository\AdRawDocumentRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * Переобработка AdRawDocument: находит raw-документы по фильтрам
+ * (--date, --marketplace, --company-id — все опциональные, любую комбинацию),
+ * сбрасывает их статус в DRAFT и ставит ProcessAdRawDocumentMessage в очередь.
+ *
+ * Используется, когда алгоритм обработки/распределения затрат изменился
+ * и нужно перегнать исторические данные без повторного обращения к API маркетплейса.
+ */
+#[AsCommand(
+    name: 'marketplace-ads:reprocess',
+    description: 'Переобрабатывает уже загруженные AdRawDocument по фильтрам (дата, площадка, компания).',
+)]
+final class ReprocessAdDataCommand extends Command
+{
+    /** @var array<string, MarketplaceType> псевдонимы CLI → MarketplaceType */
+    private const MARKETPLACE_ALIASES = [
+        'wb'          => MarketplaceType::WILDBERRIES,
+        'wildberries' => MarketplaceType::WILDBERRIES,
+        'ozon'        => MarketplaceType::OZON,
+    ];
+
+    public function __construct(
+        private readonly AdRawDocumentRepository $rawDocumentRepository,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly MessageBusInterface $bus,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                'date',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Дата отчёта (YYYY-MM-DD). Если не указана — любая дата.',
+                null,
+            )
+            ->addOption(
+                'marketplace',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Маркетплейс: wb или ozon. Если не указан — все площадки.',
+                null,
+            )
+            ->addOption(
+                'company-id',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'UUID компании. Если не указан — все компании.',
+                null,
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $dateOption = $input->getOption('date');
+        $reportDate = null;
+        if ($dateOption !== null && $dateOption !== '') {
+            $reportDate = \DateTimeImmutable::createFromFormat('!Y-m-d', (string) $dateOption);
+            if ($reportDate === false) {
+                $output->writeln('<error>Неверный формат --date. Ожидается YYYY-MM-DD.</error>');
+
+                return Command::FAILURE;
+            }
+        }
+
+        $marketplaceOption = $input->getOption('marketplace');
+        $marketplace       = null;
+        if ($marketplaceOption !== null && $marketplaceOption !== '') {
+            $key = strtolower((string) $marketplaceOption);
+            if (!isset(self::MARKETPLACE_ALIASES[$key])) {
+                $output->writeln(sprintf(
+                    '<error>Неизвестный --marketplace=%s. Допустимо: wb, ozon.</error>',
+                    $marketplaceOption,
+                ));
+
+                return Command::FAILURE;
+            }
+            $marketplace = self::MARKETPLACE_ALIASES[$key]->value;
+        }
+
+        $companyIdOption = $input->getOption('company-id');
+        $companyId       = $companyIdOption !== null && $companyIdOption !== ''
+            ? (string) $companyIdOption
+            : null;
+
+        $documents = $this->rawDocumentRepository->findByFilters(
+            companyId:   $companyId,
+            marketplace: $marketplace,
+            reportDate:  $reportDate,
+        );
+
+        if ($documents === []) {
+            $output->writeln('<comment>Документы по указанным фильтрам не найдены.</comment>');
+
+            return Command::SUCCESS;
+        }
+
+        $dispatched = 0;
+
+        foreach ($documents as $document) {
+            if ($document->getStatus() !== AdRawDocumentStatus::DRAFT) {
+                $document->resetToDraft();
+            }
+
+            $this->entityManager->flush();
+
+            $this->bus->dispatch(new ProcessAdRawDocumentMessage(
+                companyId:       $document->getCompanyId(),
+                adRawDocumentId: $document->getId(),
+            ));
+
+            ++$dispatched;
+        }
+
+        $output->writeln(sprintf(
+            '<info>Переобработка запущена: отправлено %d сообщений.</info>',
+            $dispatched,
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/site/src/MarketplaceAds/Command/ReprocessAdDataCommand.php
+++ b/site/src/MarketplaceAds/Command/ReprocessAdDataCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\MarketplaceAds\Command;
 
+use App\Company\Facade\CompanyFacade;
 use App\Marketplace\Enum\MarketplaceType;
 use App\MarketplaceAds\Enum\AdRawDocumentStatus;
 use App\MarketplaceAds\Message\ProcessAdRawDocumentMessage;
@@ -21,8 +22,14 @@ use Symfony\Component\Messenger\MessageBusInterface;
  * (--date, --marketplace, --company-id — все опциональные, любую комбинацию),
  * сбрасывает их статус в DRAFT и ставит ProcessAdRawDocumentMessage в очередь.
  *
- * Используется, когда алгоритм обработки/распределения затрат изменился
- * и нужно перегнать исторические данные без повторного обращения к API маркетплейса.
+ * Чтобы исключить случайный прогон «всего-по-всем-компаниям» при опечатке в CLI,
+ * команда требует либо хотя бы один фильтр, либо явный --all.
+ *
+ * Обработка идёт батчами: статусы обновляются и flush'атся пачками по BATCH_SIZE,
+ * после flush вызывается EntityManager::clear() — это удерживает identity map
+ * в ограниченном размере даже при десятках тысяч документов. Сообщения
+ * в очередь отправляются только после того, как все статусы закоммичены в БД,
+ * иначе воркер мог бы забрать документ раньше, чем увидит его DRAFT-статус.
  */
 #[AsCommand(
     name: 'marketplace-ads:reprocess',
@@ -32,13 +39,21 @@ final class ReprocessAdDataCommand extends Command
 {
     /** @var array<string, MarketplaceType> псевдонимы CLI → MarketplaceType */
     private const MARKETPLACE_ALIASES = [
-        'wb'          => MarketplaceType::WILDBERRIES,
+        'wb' => MarketplaceType::WILDBERRIES,
         'wildberries' => MarketplaceType::WILDBERRIES,
-        'ozon'        => MarketplaceType::OZON,
+        'ozon' => MarketplaceType::OZON,
     ];
+
+    /**
+     * Размер пачки для flush+clear. Эмпирически: на 50 объектах накладные
+     * расходы на лишние flush незначительны, зато identity map Doctrine
+     * не разрастается при очень больших выборках.
+     */
+    private const BATCH_SIZE = 50;
 
     public function __construct(
         private readonly AdRawDocumentRepository $rawDocumentRepository,
+        private readonly CompanyFacade $companyFacade,
         private readonly EntityManagerInterface $entityManager,
         private readonly MessageBusInterface $bus,
     ) {
@@ -68,6 +83,12 @@ final class ReprocessAdDataCommand extends Command
                 InputOption::VALUE_OPTIONAL,
                 'UUID компании. Если не указан — все компании.',
                 null,
+            )
+            ->addOption(
+                'all',
+                null,
+                InputOption::VALUE_NONE,
+                'Разрешить переобработку без единого фильтра (все компании × все даты × все площадки).',
             );
     }
 
@@ -75,13 +96,13 @@ final class ReprocessAdDataCommand extends Command
     {
         $dateOption = $input->getOption('date');
         $reportDate = null;
-        if ($dateOption !== null && $dateOption !== '') {
-            $dateValue  = (string) $dateOption;
+        if (null !== $dateOption && '' !== $dateOption) {
+            $dateValue = (string) $dateOption;
             $reportDate = \DateTimeImmutable::createFromFormat('!Y-m-d', $dateValue);
             // createFromFormat нормализует несуществующие даты (например, 2026-02-31 → 2026-03-03)
             // и возвращает DateTimeImmutable, а не false. Roundtrip-проверка отсекает такие
             // случаи: валидная дата должна сериализоваться обратно в исходную строку.
-            if ($reportDate === false || $reportDate->format('Y-m-d') !== $dateValue) {
+            if (false === $reportDate || $reportDate->format('Y-m-d') !== $dateValue) {
                 $output->writeln('<error>Неверный формат --date. Ожидается YYYY-MM-DD.</error>');
 
                 return Command::FAILURE;
@@ -89,8 +110,8 @@ final class ReprocessAdDataCommand extends Command
         }
 
         $marketplaceOption = $input->getOption('marketplace');
-        $marketplace       = null;
-        if ($marketplaceOption !== null && $marketplaceOption !== '') {
+        $marketplace = null;
+        if (null !== $marketplaceOption && '' !== $marketplaceOption) {
             $key = strtolower((string) $marketplaceOption);
             if (!isset(self::MARKETPLACE_ALIASES[$key])) {
                 $output->writeln(sprintf(
@@ -104,39 +125,82 @@ final class ReprocessAdDataCommand extends Command
         }
 
         $companyIdOption = $input->getOption('company-id');
-        $companyId       = $companyIdOption !== null && $companyIdOption !== ''
-            ? (string) $companyIdOption
-            : null;
+        $companyId = null;
+        if (null !== $companyIdOption && '' !== $companyIdOption) {
+            $companyId = (string) $companyIdOption;
+            // Валидируем наличие компании — иначе при опечатке UUID команда молча
+            // напишет «документы не найдены» и оператор решит, что всё обработано.
+            if (null === $this->companyFacade->findById($companyId)) {
+                $output->writeln(sprintf(
+                    '<error>Компания не найдена: --company-id=%s.</error>',
+                    $companyId,
+                ));
+
+                return Command::FAILURE;
+            }
+        }
+
+        $allFlag = (bool) $input->getOption('all');
+
+        // Без хотя бы одного фильтра команда переобработала бы всю историю по всем
+        // компаниям — слишком большой blast radius для опечатки. Требуем явное
+        // согласие через --all.
+        if (null === $companyId && null === $marketplace && null === $reportDate && !$allFlag) {
+            $output->writeln(
+                '<error>Требуется хотя бы один фильтр (--company-id / --marketplace / --date) '
+                .'или явный флаг --all для переобработки всей истории.</error>',
+            );
+
+            return Command::FAILURE;
+        }
 
         $documents = $this->rawDocumentRepository->findByFilters(
-            companyId:   $companyId,
+            companyId: $companyId,
             marketplace: $marketplace,
-            reportDate:  $reportDate,
+            reportDate: $reportDate,
         );
 
-        if ($documents === []) {
+        if ([] === $documents) {
             $output->writeln('<comment>Документы по указанным фильтрам не найдены.</comment>');
 
             return Command::SUCCESS;
         }
 
-        // Сначала обновляем статусы всех документов, затем один flush,
-        // и только потом диспатч — это снимает N flush'ей на N документов
-        // и гарантирует, что статусы согласованно лежат в БД до того,
-        // как воркеры начнут их забирать.
+        // Первый проход: сбрасываем статусы и фиксируем пачками. Параллельно
+        // собираем пары (companyId, id) для последующего dispatch — к моменту
+        // очистки identity map объекты Entity станут detached, поэтому
+        // запоминаем scalar-идентификаторы заранее.
+        /** @var list<array{companyId: string, id: string}> $toDispatch */
+        $toDispatch = [];
+        $batchIndex = 0;
+
         foreach ($documents as $document) {
-            if ($document->getStatus() !== AdRawDocumentStatus::DRAFT) {
+            if (AdRawDocumentStatus::DRAFT !== $document->getStatus()) {
                 $document->resetToDraft();
+            }
+
+            $toDispatch[] = [
+                'companyId' => $document->getCompanyId(),
+                'id' => $document->getId(),
+            ];
+
+            if (0 === ++$batchIndex % self::BATCH_SIZE) {
+                $this->entityManager->flush();
+                $this->entityManager->clear();
             }
         }
 
+        // Финальный flush для хвоста последней неполной пачки. clear()
+        // здесь делаем тоже — у команды дальше нет операций с identity map,
+        // а воркер в любом случае перечитает документ по id + companyId.
         $this->entityManager->flush();
+        $this->entityManager->clear();
 
         $dispatched = 0;
-        foreach ($documents as $document) {
+        foreach ($toDispatch as $ids) {
             $this->bus->dispatch(new ProcessAdRawDocumentMessage(
-                companyId:       $document->getCompanyId(),
-                adRawDocumentId: $document->getId(),
+                companyId: $ids['companyId'],
+                adRawDocumentId: $ids['id'],
             ));
 
             ++$dispatched;

--- a/site/src/MarketplaceAds/Message/ProcessAdRawDocumentMessage.php
+++ b/site/src/MarketplaceAds/Message/ProcessAdRawDocumentMessage.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Message;
+
+/**
+ * Асинхронное сообщение на обработку AdRawDocument:
+ * парсинг payload → распределение затрат → создание AdDocument + AdDocumentLine.
+ *
+ * Обрабатывается {@see \App\MarketplaceAds\MessageHandler\ProcessAdRawDocumentHandler}.
+ */
+final readonly class ProcessAdRawDocumentMessage
+{
+    public function __construct(
+        public string $companyId,
+        public string $adRawDocumentId,
+    ) {}
+}

--- a/site/src/MarketplaceAds/MessageHandler/ProcessAdRawDocumentHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/ProcessAdRawDocumentHandler.php
@@ -57,6 +57,20 @@ final class ProcessAdRawDocumentHandler
 
         try {
             ($this->processAction)($message->companyId, $message->adRawDocumentId);
+        } catch (\DomainException $e) {
+            // DomainException из Action означает гонку состояний: другой worker/диспатч успел
+            // обработать документ (status != DRAFT) или сам документ удалили между pre-check
+            // и вызовом Action. Ретрай Messenger здесь только шумит в failed-queue — поглощаем.
+            $this->logger->info(
+                'AdRawDocument обработан параллельно или удалён, повтор не нужен',
+                [
+                    'companyId'       => $message->companyId,
+                    'adRawDocumentId' => $message->adRawDocumentId,
+                    'reason'          => $e->getMessage(),
+                ],
+            );
+
+            return;
         } catch (\Throwable $e) {
             $this->logger->error(
                 'Ошибка обработки AdRawDocument',

--- a/site/src/MarketplaceAds/MessageHandler/ProcessAdRawDocumentHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/ProcessAdRawDocumentHandler.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\MessageHandler;
+
+use App\MarketplaceAds\Application\ProcessAdRawDocumentAction;
+use App\MarketplaceAds\Enum\AdRawDocumentStatus;
+use App\MarketplaceAds\Message\ProcessAdRawDocumentMessage;
+use App\MarketplaceAds\Repository\AdRawDocumentRepository;
+use App\Shared\Service\AppLogger;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Async-обработчик {@see ProcessAdRawDocumentMessage}.
+ *
+ * - Не предполагает Request/Session/Security (CLI worker context).
+ * - Всегда перечитывает AdRawDocument по id + companyId, т.к. между dispatch и handler
+ *   состояние документа могло измениться.
+ * - Идемпотентен: если документ уже обработан (не в DRAFT) — молча возвращается.
+ * - Ошибки Action пере­брасываются для retry по стратегии Messenger.
+ */
+#[AsMessageHandler]
+final class ProcessAdRawDocumentHandler
+{
+    public function __construct(
+        private readonly AdRawDocumentRepository $rawDocumentRepository,
+        private readonly ProcessAdRawDocumentAction $processAction,
+        private readonly AppLogger $logger,
+    ) {}
+
+    public function __invoke(ProcessAdRawDocumentMessage $message): void
+    {
+        $rawDocument = $this->rawDocumentRepository->findByIdAndCompany(
+            $message->adRawDocumentId,
+            $message->companyId,
+        );
+
+        if ($rawDocument === null) {
+            $this->logger->warning('AdRawDocument не найден при async-обработке', [
+                'companyId'       => $message->companyId,
+                'adRawDocumentId' => $message->adRawDocumentId,
+            ]);
+
+            return;
+        }
+
+        if ($rawDocument->getStatus() !== AdRawDocumentStatus::DRAFT) {
+            $this->logger->info('AdRawDocument уже обработан, повторный запуск пропущен', [
+                'companyId'       => $message->companyId,
+                'adRawDocumentId' => $message->adRawDocumentId,
+                'status'          => $rawDocument->getStatus()->value,
+            ]);
+
+            return;
+        }
+
+        try {
+            ($this->processAction)($message->companyId, $message->adRawDocumentId);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Ошибка обработки AdRawDocument',
+                $e,
+                [
+                    'companyId'       => $message->companyId,
+                    'adRawDocumentId' => $message->adRawDocumentId,
+                ],
+            );
+            throw $e; // перебросить — Messenger сделает retry по стратегии async-транспорта
+        }
+    }
+}

--- a/site/src/MarketplaceAds/Repository/AdRawDocumentRepository.php
+++ b/site/src/MarketplaceAds/Repository/AdRawDocumentRepository.php
@@ -55,4 +55,33 @@ final class AdRawDocumentRepository extends ServiceEntityRepository
             ->getQuery()
             ->getResult();
     }
+
+    /**
+     * Поиск raw-документов по произвольной комбинации фильтров. Все параметры опциональны:
+     * любой из них может быть null — тогда ограничение по этому полю не накладывается.
+     * Используется reprocess-командой для массовой переобработки.
+     *
+     * @return AdRawDocument[]
+     */
+    public function findByFilters(
+        ?string $companyId = null,
+        ?string $marketplace = null,
+        ?\DateTimeImmutable $reportDate = null,
+    ): array {
+        $qb = $this->createQueryBuilder('r')->orderBy('r.reportDate', 'DESC');
+
+        if ($companyId !== null) {
+            $qb->andWhere('r.companyId = :companyId')->setParameter('companyId', $companyId);
+        }
+
+        if ($marketplace !== null) {
+            $qb->andWhere('r.marketplace = :marketplace')->setParameter('marketplace', $marketplace);
+        }
+
+        if ($reportDate !== null) {
+            $qb->andWhere('r.reportDate = :reportDate')->setParameter('reportDate', $reportDate);
+        }
+
+        return $qb->getQuery()->getResult();
+    }
 }


### PR DESCRIPTION
## Summary

Задача 6 модуля MarketplaceAds: CLI-обвязка для загрузки рекламных отчётов и Messenger-пайплайн для их обработки.

- **`marketplace-ads:load`** — cron-команда, загружает рекламную статистику за дату (по умолчанию — вчера). Перебирает активные компании × площадки с активными `MarketplaceConnection`, вызывает `AdPlatformClient::fetchAdStatistics`, делает upsert `AdRawDocument` (`updatePayload` / создание) и диспатчит `ProcessAdRawDocumentMessage`. Опции: `--date=yesterday|Y-m-d`, `--marketplace=wb|ozon|all`, `--company-id=UUID`.
- **`marketplace-ads:reprocess`** — фильтрует уже загруженные raw-документы по произвольной комбинации `--date` / `--marketplace` / `--company-id` (любой набор), сбрасывает статус в DRAFT (если нужно) и ставит `ProcessAdRawDocumentMessage` в очередь. Полезно для прогона исторических данных после изменений в алгоритме распределения.
- **`ProcessAdRawDocumentMessage`** — `final readonly class`, только scalar: `companyId`, `adRawDocumentId`. Без Entity.
- **`ProcessAdRawDocumentHandler`** — `#[AsMessageHandler]`. Перечитывает документ по id + companyId, пропускает отсутствующие (warning) и уже не в DRAFT (info), чтобы не спамить failed-queue при гонке/повторных диспатчах. Вызов `ProcessAdRawDocumentAction` обёрнут в try/catch с логом + rethrow для ретраев Messenger.
- **`AdRawDocumentRepository::findByFilters(?companyId, ?marketplace, ?reportDate)`** — гибкий поиск, нужен reprocess-команде.
- **Routing**: `ProcessAdRawDocumentMessage → async` в `messenger.yaml`.
- **`services.yaml`**: `!tagged_iterator marketplace_ads.platform_client` для Load-команды — клиенты Ozon/WB подхватываются по тегу.

## Changes

- `src/MarketplaceAds/Command/LoadAdDataCommand.php` — новая команда
- `src/MarketplaceAds/Command/ReprocessAdDataCommand.php` — новая команда
- `src/MarketplaceAds/Message/ProcessAdRawDocumentMessage.php` — новый Message
- `src/MarketplaceAds/MessageHandler/ProcessAdRawDocumentHandler.php` — новый Handler
- `src/MarketplaceAds/Repository/AdRawDocumentRepository.php` — добавлен `findByFilters`
- `config/packages/messenger.yaml` — routing
- `config/services.yaml` — tagged_iterator для platform clients

## Caveats

- `OzonAdClient::fetchAdStatistics` и `WildberriesAdClient::fetchAdStatistics` — stub'ы (`throw new RuntimeException("not implemented yet")`) после Задачи 4. Load-команда корректно дёргает, логирует ошибку и идёт дальше. До реализации клиентов реального API-взаимодействия не будет — нужна отдельная задача.

## Test plan

- [x] `php -l` на всех новых/изменённых файлах — чисто
- [x] `php bin/console marketplace-ads:load --help` — работает, опции отображаются
- [x] `php bin/console marketplace-ads:reprocess --help` — работает, опции отображаются
- [x] `php bin/console debug:messenger` — `ProcessAdRawDocumentMessage → ProcessAdRawDocumentHandler`
- [x] `php bin/console debug:container ProcessAdRawDocumentHandler` — autowire подтверждён
- [x] `vendor/bin/phpunit --testsuite=unit --filter=MarketplaceAds` — 33/33 зелёные
- [ ] Integration-тесты команд (seed компания + connection + стаб-клиент → dry run с `sync://`-транспортом) — в отдельной задаче

https://claude.ai/code/session_01Gu7CykSgN6uKBwbyqvvgym