### PR TITLE
test(MarketplaceAds): builders + unit tests для guard-методов и AdCostDistributor

### DIFF
--- a/site/tests/Builders/MarketplaceAds/AdDocumentBuilder.php
+++ b/site/tests/Builders/MarketplaceAds/AdDocumentBuilder.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Builders\MarketplaceAds;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAds\Entity\AdDocument;
+
+final class AdDocumentBuilder
+{
+    public const DEFAULT_ID = '99999999-9999-9999-9999-999999999999';
+    public const DEFAULT_COMPANY_ID = '11111111-1111-1111-1111-111111111111';
+    public const DEFAULT_RAW_DOCUMENT_ID = '88888888-8888-8888-8888-888888888888';
+
+    private string $id = self::DEFAULT_ID;
+    private string $companyId = self::DEFAULT_COMPANY_ID;
+    private MarketplaceType $marketplace = MarketplaceType::WILDBERRIES;
+    private \DateTimeImmutable $reportDate;
+    private string $campaignId = 'CAMP-001';
+    private string $campaignName = 'Default campaign';
+    private string $parentSku = 'SKU-001';
+    private string $totalCost = '100.00';
+    private int $totalImpressions = 1000;
+    private int $totalClicks = 50;
+    private string $adRawDocumentId = self::DEFAULT_RAW_DOCUMENT_ID;
+
+    private function __construct()
+    {
+        $this->reportDate = new \DateTimeImmutable('2025-01-15');
+    }
+
+    public static function aDocument(): self
+    {
+        return new self();
+    }
+
+    public function withIndex(int $index): self
+    {
+        $clone = clone $this;
+        $clone->id = sprintf('99999999-9999-9999-9999-%012d', $index);
+        $clone->campaignId = sprintf('CAMP-%03d', $index);
+        $clone->parentSku = sprintf('SKU-%03d', $index);
+
+        return $clone;
+    }
+
+    public function withCompanyId(string $companyId): self
+    {
+        $clone = clone $this;
+        $clone->companyId = $companyId;
+
+        return $clone;
+    }
+
+    public function withCampaignId(string $campaignId): self
+    {
+        $clone = clone $this;
+        $clone->campaignId = $campaignId;
+
+        return $clone;
+    }
+
+    public function withParentSku(string $parentSku): self
+    {
+        $clone = clone $this;
+        $clone->parentSku = $parentSku;
+
+        return $clone;
+    }
+
+    public function withTotalCost(string $totalCost): self
+    {
+        $clone = clone $this;
+        $clone->totalCost = $totalCost;
+
+        return $clone;
+    }
+
+    public function withMarketplace(MarketplaceType $marketplace): self
+    {
+        $clone = clone $this;
+        $clone->marketplace = $marketplace;
+
+        return $clone;
+    }
+
+    public function withReportDate(\DateTimeImmutable $reportDate): self
+    {
+        $clone = clone $this;
+        $clone->reportDate = $reportDate;
+
+        return $clone;
+    }
+
+    public function withCampaignName(string $campaignName): self
+    {
+        $clone = clone $this;
+        $clone->campaignName = $campaignName;
+
+        return $clone;
+    }
+
+    public function withTotalImpressions(int $totalImpressions): self
+    {
+        $clone = clone $this;
+        $clone->totalImpressions = $totalImpressions;
+
+        return $clone;
+    }
+
+    public function withTotalClicks(int $totalClicks): self
+    {
+        $clone = clone $this;
+        $clone->totalClicks = $totalClicks;
+
+        return $clone;
+    }
+
+    public function withAdRawDocumentId(string $adRawDocumentId): self
+    {
+        $clone = clone $this;
+        $clone->adRawDocumentId = $adRawDocumentId;
+
+        return $clone;
+    }
+
+    public function build(): AdDocument
+    {
+        $doc = new AdDocument(
+            companyId: $this->companyId,
+            marketplace: $this->marketplace,
+            reportDate: $this->reportDate,
+            campaignId: $this->campaignId,
+            campaignName: $this->campaignName,
+            parentSku: $this->parentSku,
+            totalCost: $this->totalCost,
+            totalImpressions: $this->totalImpressions,
+            totalClicks: $this->totalClicks,
+            adRawDocumentId: $this->adRawDocumentId,
+        );
+
+        // Конструктор сам генерирует UUID v7 — перезаписываем на детерминированный DEFAULT_ID.
+        $idProperty = new \ReflectionProperty(AdDocument::class, 'id');
+        $idProperty->setAccessible(true);
+        $idProperty->setValue($doc, $this->id);
+
+        return $doc;
+    }
+}

--- a/site/tests/Builders/MarketplaceAds/AdDocumentLineBuilder.php
+++ b/site/tests/Builders/MarketplaceAds/AdDocumentLineBuilder.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Builders\MarketplaceAds;
+
+use App\MarketplaceAds\Entity\AdDocument;
+use App\MarketplaceAds\Entity\AdDocumentLine;
+
+final class AdDocumentLineBuilder
+{
+    public const DEFAULT_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+    public const DEFAULT_LISTING_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+    private string $id = self::DEFAULT_ID;
+    private ?AdDocument $adDocument = null;
+    private string $adDocumentId = AdDocumentBuilder::DEFAULT_ID;
+    private string $listingId = self::DEFAULT_LISTING_ID;
+    private string $sharePercent = '100.00';
+    private string $cost = '100.00';
+    private int $impressions = 1000;
+    private int $clicks = 50;
+
+    private function __construct()
+    {
+    }
+
+    public static function aLine(): self
+    {
+        return new self();
+    }
+
+    public function withIndex(int $index): self
+    {
+        $clone = clone $this;
+        $clone->id = sprintf('aaaaaaaa-aaaa-aaaa-aaaa-%012d', $index);
+        $clone->listingId = sprintf('bbbbbbbb-bbbb-bbbb-bbbb-%012d', $index);
+
+        return $clone;
+    }
+
+    public function withAdDocument(AdDocument $adDocument): self
+    {
+        $clone = clone $this;
+        $clone->adDocument = $adDocument;
+        $clone->adDocumentId = $adDocument->getId();
+
+        return $clone;
+    }
+
+    public function withAdDocumentId(string $adDocumentId): self
+    {
+        $clone = clone $this;
+        $clone->adDocumentId = $adDocumentId;
+        // Сбрасываем предварительно выставленный AdDocument — его id нужно привести
+        // к новому значению, это делается лениво в build().
+        $clone->adDocument = null;
+
+        return $clone;
+    }
+
+    public function withListingId(string $listingId): self
+    {
+        $clone = clone $this;
+        $clone->listingId = $listingId;
+
+        return $clone;
+    }
+
+    public function withSharePercent(string $sharePercent): self
+    {
+        $clone = clone $this;
+        $clone->sharePercent = $sharePercent;
+
+        return $clone;
+    }
+
+    public function withCost(string $cost): self
+    {
+        $clone = clone $this;
+        $clone->cost = $cost;
+
+        return $clone;
+    }
+
+    public function withImpressions(int $impressions): self
+    {
+        $clone = clone $this;
+        $clone->impressions = $impressions;
+
+        return $clone;
+    }
+
+    public function withClicks(int $clicks): self
+    {
+        $clone = clone $this;
+        $clone->clicks = $clicks;
+
+        return $clone;
+    }
+
+    public function build(): AdDocumentLine
+    {
+        // AdDocumentLine хранит ManyToOne на AdDocument — чистый id туда передать нельзя.
+        // Если caller не дал объект через withAdDocument(), собираем минимальный stub.
+        $adDocument = $this->adDocument ?? AdDocumentBuilder::aDocument()->build();
+
+        if ($adDocument->getId() !== $this->adDocumentId) {
+            $adDocIdProperty = new \ReflectionProperty(AdDocument::class, 'id');
+            $adDocIdProperty->setAccessible(true);
+            $adDocIdProperty->setValue($adDocument, $this->adDocumentId);
+        }
+
+        $line = new AdDocumentLine(
+            adDocument: $adDocument,
+            listingId: $this->listingId,
+            sharePercent: $this->sharePercent,
+            cost: $this->cost,
+            impressions: $this->impressions,
+            clicks: $this->clicks,
+        );
+
+        $idProperty = new \ReflectionProperty(AdDocumentLine::class, 'id');
+        $idProperty->setAccessible(true);
+        $idProperty->setValue($line, $this->id);
+
+        return $line;
+    }
+}

--- a/site/tests/Builders/MarketplaceAds/AdRawDocumentBuilder.php
+++ b/site/tests/Builders/MarketplaceAds/AdRawDocumentBuilder.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Builders\MarketplaceAds;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAds\Entity\AdRawDocument;
+
+final class AdRawDocumentBuilder
+{
+    public const DEFAULT_ID = '88888888-8888-8888-8888-888888888888';
+    public const DEFAULT_COMPANY_ID = '11111111-1111-1111-1111-111111111111';
+    public const DEFAULT_RAW_PAYLOAD = '{"rows":[]}';
+
+    private string $id = self::DEFAULT_ID;
+    private string $companyId = self::DEFAULT_COMPANY_ID;
+    private MarketplaceType $marketplace = MarketplaceType::WILDBERRIES;
+    private \DateTimeImmutable $reportDate;
+    private string $rawPayload = self::DEFAULT_RAW_PAYLOAD;
+    private bool $processed = false;
+
+    private function __construct()
+    {
+        $this->reportDate = new \DateTimeImmutable('2025-01-15');
+    }
+
+    public static function aRawDocument(): self
+    {
+        return new self();
+    }
+
+    public function withIndex(int $index): self
+    {
+        $clone = clone $this;
+        $clone->id = sprintf('88888888-8888-8888-8888-%012d', $index);
+
+        return $clone;
+    }
+
+    public function withCompanyId(string $companyId): self
+    {
+        $clone = clone $this;
+        $clone->companyId = $companyId;
+
+        return $clone;
+    }
+
+    public function withMarketplace(MarketplaceType $marketplace): self
+    {
+        $clone = clone $this;
+        $clone->marketplace = $marketplace;
+
+        return $clone;
+    }
+
+    public function withReportDate(\DateTimeImmutable $reportDate): self
+    {
+        $clone = clone $this;
+        $clone->reportDate = $reportDate;
+
+        return $clone;
+    }
+
+    public function withRawPayload(string $rawPayload): self
+    {
+        $clone = clone $this;
+        $clone->rawPayload = $rawPayload;
+
+        return $clone;
+    }
+
+    public function asProcessed(): self
+    {
+        $clone = clone $this;
+        $clone->processed = true;
+
+        return $clone;
+    }
+
+    public function build(): AdRawDocument
+    {
+        $doc = new AdRawDocument(
+            companyId: $this->companyId,
+            marketplace: $this->marketplace,
+            reportDate: $this->reportDate,
+            rawPayload: $this->rawPayload,
+        );
+
+        // Конструктор генерирует UUID v7, но Builder обязан выдавать детерминированный ID
+        // (DEFAULT_ID или полученный через withIndex()), иначе тесты не могут ссылаться на сущность по ID.
+        $idProperty = new \ReflectionProperty(AdRawDocument::class, 'id');
+        $idProperty->setAccessible(true);
+        $idProperty->setValue($doc, $this->id);
+
+        if ($this->processed) {
+            $doc->markAsProcessed();
+        }
+
+        return $doc;
+    }
+}

--- a/site/tests/Integration/MarketplaceAds/ProcessAdRawDocumentActionTest.php
+++ b/site/tests/Integration/MarketplaceAds/ProcessAdRawDocumentActionTest.php
@@ -21,7 +21,7 @@ final class ProcessAdRawDocumentActionTest extends IntegrationTestCase
     private const COMPANY_ID = '11111111-1111-1111-1111-000000000001';
     private const OWNER_ID   = '22222222-2222-2222-2222-000000000001';
 
-    public function testProcessesOzonRawDocumentAndCreatesAdDocuments(): void
+    public function testProcessesRawDocumentAndCreatesAdDocuments(): void
     {
         $company = $this->seedCompany();
         $this->seedListing($company, 'SKU-PARENT-1', 'L', '55555555-5555-5555-5555-000000000001');
@@ -64,7 +64,7 @@ final class ProcessAdRawDocumentActionTest extends IntegrationTestCase
         self::assertSame('100.00', $sumCost);
     }
 
-    public function testPartialProcessingLeavesDocumentInDraftWhenSomeSkusNotFound(): void
+    public function testSkipsUnknownSkuAndLeavesRawDocumentInDraft(): void
     {
         $company = $this->seedCompany();
         $this->seedListing($company, 'SKU-KNOWN', 'UNKNOWN', '55555555-5555-5555-5555-000000000010');
@@ -127,7 +127,7 @@ final class ProcessAdRawDocumentActionTest extends IntegrationTestCase
         self::assertSame('CAMP-OK', $adDocuments[0]->getCampaignId());
     }
 
-    public function testIdempotentReprocessDeletesPreviousAdDocuments(): void
+    public function testIdempotentReprocessing(): void
     {
         $company = $this->seedCompany();
         $this->seedListing($company, 'SKU-IDEM', 'UNKNOWN', '55555555-5555-5555-5555-000000000020');

--- a/site/tests/Unit/MarketplaceAds/AdCostDistributorTest.php
+++ b/site/tests/Unit/MarketplaceAds/AdCostDistributorTest.php
@@ -250,4 +250,132 @@ final class AdCostDistributorTest extends TestCase
         self::assertSame('0.00', $results[1]->cost);
         self::assertSame('0.00', $results[1]->sharePercent);
     }
+
+    // -------------------------------------------------------------------------
+    // Обязательные кейсы по спецификации задачи (см. раздел 8.2 в to_do)
+    // -------------------------------------------------------------------------
+
+    public function testDistributesProportionallyBySales(): void
+    {
+        // Три листинга с продажами 10, 25, 15 → доли 20 %, 50 %, 30 %.
+        $results = $this->distributor->distribute(
+            [$this->makeListing('A'), $this->makeListing('B'), $this->makeListing('C')],
+            ['A' => 10, 'B' => 25, 'C' => 15],
+            '100.00',
+            1000,
+            200,
+        );
+
+        self::assertCount(3, $results);
+
+        $byId = [];
+        foreach ($results as $r) {
+            $byId[$r->listingId] = $r;
+        }
+
+        self::assertSame('20.00', $byId['A']->cost);
+        self::assertSame('50.00', $byId['B']->cost);
+        self::assertSame('30.00', $byId['C']->cost);
+
+        self::assertSame('20.00', $byId['A']->sharePercent);
+        self::assertSame('50.00', $byId['B']->sharePercent);
+        self::assertSame('30.00', $byId['C']->sharePercent);
+
+        self::assertSame('100.00', $this->sumCosts($results));
+        self::assertSame('100.00', $this->sumShares($results));
+        self::assertSame(1000, $this->sumImpressions($results));
+        self::assertSame(200, $this->sumClicks($results));
+    }
+
+    public function testDistributesEvenlyWhenNoSales(): void
+    {
+        // Три листинга, продажи = 0 у всех → каждый получает примерно равную долю.
+        // Проверяем главное свойство: суммы совпадают с исходными totals (без потери копеек).
+        $results = $this->distributor->distribute(
+            [$this->makeListing('A'), $this->makeListing('B'), $this->makeListing('C')],
+            ['A' => 0, 'B' => 0, 'C' => 0],
+            '30.00',
+            300,
+            30,
+        );
+
+        self::assertCount(3, $results);
+        self::assertSame('30.00', $this->sumCosts($results));
+        self::assertSame('100.00', $this->sumShares($results));
+        self::assertSame(300, $this->sumImpressions($results));
+        self::assertSame(30, $this->sumClicks($results));
+
+        // Разница между максимальным и минимальным cost не превышает одной "поправки"
+        // (все веса равны 1/3, отклонение может быть только от округления bcmul).
+        $costs = array_map(static fn ($r) => (float) $r->cost, $results);
+        self::assertLessThanOrEqual(
+            0.05,
+            max($costs) - min($costs),
+            'Распределение должно быть равномерным',
+        );
+    }
+
+    public function testSingleListingGets100Percent(): void
+    {
+        $results = $this->distributor->distribute(
+            [$this->makeListing('ONLY')],
+            ['ONLY' => 42],
+            '123.45',
+            777,
+            88,
+        );
+
+        self::assertCount(1, $results);
+        self::assertSame('ONLY', $results[0]->listingId);
+        self::assertSame('100.00', $results[0]->sharePercent);
+        self::assertSame('123.45', $results[0]->cost);
+        self::assertSame(777, $results[0]->impressions);
+        self::assertSame(88, $results[0]->clicks);
+    }
+
+    public function testRoundingHandledCorrectly(): void
+    {
+        // Три листинга, cost = '100.00', продажи 1, 1, 1.
+        // 100 / 3 даёт 33.33 на каждого; сумма = 99.99 → поправка приводит к 100.00.
+        $results = $this->distributor->distribute(
+            [$this->makeListing('A'), $this->makeListing('B'), $this->makeListing('C')],
+            ['A' => 1, 'B' => 1, 'C' => 1],
+            '100.00',
+            300,
+            30,
+        );
+
+        self::assertCount(3, $results);
+        self::assertSame(
+            '100.00',
+            $this->sumCosts($results),
+            'Сумма cost по строкам должна быть ровно 100.00, а не 99.99',
+        );
+        self::assertSame('100.00', $this->sumShares($results));
+    }
+
+    public function testImpressionsAndClicksRoundedCorrectly(): void
+    {
+        // Impressions = 100, три листинга с равными продажами.
+        // 100 * 1/3 (усечение до int) = 33 на каждого; сумма 99 → поправка приводит к 100.
+        $results = $this->distributor->distribute(
+            [$this->makeListing('A'), $this->makeListing('B'), $this->makeListing('C')],
+            ['A' => 5, 'B' => 5, 'C' => 5],
+            '9.00',
+            100,
+            50,
+        );
+
+        self::assertCount(3, $results);
+        self::assertSame(
+            100,
+            $this->sumImpressions($results),
+            'Сумма impressions по строкам должна быть ровно 100, а не 99',
+        );
+        self::assertSame(
+            50,
+            $this->sumClicks($results),
+            'Сумма clicks по строкам должна быть ровно 50',
+        );
+    }
 }

--- a/site/tests/Unit/MarketplaceAds/AdRawDocumentTest.php
+++ b/site/tests/Unit/MarketplaceAds/AdRawDocumentTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MarketplaceAds;
+
+use App\MarketplaceAds\Enum\AdRawDocumentStatus;
+use App\Tests\Builders\MarketplaceAds\AdRawDocumentBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class AdRawDocumentTest extends TestCase
+{
+    public function testMarkAsProcessedFromDraft(): void
+    {
+        $doc = AdRawDocumentBuilder::aRawDocument()->build();
+
+        self::assertSame(AdRawDocumentStatus::DRAFT, $doc->getStatus());
+
+        $updatedAtBefore = $doc->getUpdatedAt();
+        // Даём секунде проскочить, чтобы сравнение updatedAt не было идентичным.
+        usleep(1000);
+
+        $doc->markAsProcessed();
+
+        self::assertSame(AdRawDocumentStatus::PROCESSED, $doc->getStatus());
+        self::assertGreaterThanOrEqual($updatedAtBefore, $doc->getUpdatedAt());
+    }
+
+    public function testMarkAsProcessedFromProcessedThrows(): void
+    {
+        $doc = AdRawDocumentBuilder::aRawDocument()->asProcessed()->build();
+
+        self::assertSame(AdRawDocumentStatus::PROCESSED, $doc->getStatus());
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('уже обработан');
+
+        $doc->markAsProcessed();
+    }
+
+    public function testResetToDraft(): void
+    {
+        $doc = AdRawDocumentBuilder::aRawDocument()->asProcessed()->build();
+
+        self::assertSame(AdRawDocumentStatus::PROCESSED, $doc->getStatus());
+
+        $doc->resetToDraft();
+
+        self::assertSame(AdRawDocumentStatus::DRAFT, $doc->getStatus());
+    }
+
+    public function testResetToDraftFromDraftThrows(): void
+    {
+        $doc = AdRawDocumentBuilder::aRawDocument()->build();
+
+        self::assertSame(AdRawDocumentStatus::DRAFT, $doc->getStatus());
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('уже в статусе черновик');
+
+        $doc->resetToDraft();
+    }
+
+    public function testUpdatePayloadResetsToDraft(): void
+    {
+        $doc = AdRawDocumentBuilder::aRawDocument()->asProcessed()->build();
+
+        self::assertSame(AdRawDocumentStatus::PROCESSED, $doc->getStatus());
+
+        $newPayload = '{"rows":[{"sku":"NEW","spend":42}]}';
+        $doc->updatePayload($newPayload);
+
+        self::assertSame(AdRawDocumentStatus::DRAFT, $doc->getStatus());
+        self::assertSame($newPayload, $doc->getRawPayload());
+    }
+}

--- a/site/tests/Unit/MarketplaceAds/AdRawDocumentTest.php
+++ b/site/tests/Unit/MarketplaceAds/AdRawDocumentTest.php
@@ -17,12 +17,12 @@ final class AdRawDocumentTest extends TestCase
         self::assertSame(AdRawDocumentStatus::DRAFT, $doc->getStatus());
 
         $updatedAtBefore = $doc->getUpdatedAt();
-        // Даём секунде проскочить, чтобы сравнение updatedAt не было идентичным.
-        usleep(1000);
 
         $doc->markAsProcessed();
 
         self::assertSame(AdRawDocumentStatus::PROCESSED, $doc->getStatus());
+        // updatedAt не должен сдвигаться назад; равенство допустимо, если вызовы
+        // произошли в одну и ту же микросекунду (юнит-тест без клока).
         self::assertGreaterThanOrEqual($updatedAtBefore, $doc->getUpdatedAt());
     }
 


### PR DESCRIPTION
## Summary

Задача 8 из `to_do`: тесты и Builders для модуля `MarketplaceAds`.

### Builders — `site/tests/Builders/MarketplaceAds/`
- `AdRawDocumentBuilder` (`DEFAULT_ID = 88…`) — `withIndex`, `withCompanyId`, `withMarketplace`, `withReportDate`, `withRawPayload`, `asProcessed`
- `AdDocumentBuilder` (`DEFAULT_ID = 99…`) — `withIndex`, `withCompanyId`, `withCampaignId`, `withParentSku`, `withTotalCost` (+ with-хелперы: marketplace, reportDate, campaignName, totalImpressions/Clicks, adRawDocumentId)
- `AdDocumentLineBuilder` (`DEFAULT_ID = aaaa…`) — `withIndex`, `withAdDocumentId`, `withListingId`, `withSharePercent`, `withCost`

Все билдеры — `final class`, `private __construct()`, `with*()` возвращают `clone`. Конструкторы сущностей генерируют Uuid v7 сами, поэтому детерминированный `DEFAULT_ID` проставляется через `\ReflectionProperty` (в том же стиле, что `DealBuilder` и `CashTransactionBuilder`).

### Unit-тесты
- **`AdRawDocumentTest`** (новый, `site/tests/Unit/MarketplaceAds/`) — все ветки guard-методов:
  - `testMarkAsProcessedFromDraft` (OK)
  - `testMarkAsProcessedFromProcessedThrows` (`DomainException`)
  - `testResetToDraft` (OK)
  - `testResetToDraftFromDraftThrows` (`DomainException`)
  - `testUpdatePayloadResetsToDraft`
- **`AdCostDistributorTest`** — добавлены 5 обязательных кейсов из ТЗ:
  - `testDistributesProportionallyBySales` — 10/25/15 → 20 % / 50 % / 30 %
  - `testDistributesEvenlyWhenNoSales` — 3 листинга, продажи = 0
  - `testSingleListingGets100Percent`
  - `testRoundingHandledCorrectly` — cost `100.00`, продажи 1/1/1 → сумма `100.00`, а не `99.99`
  - `testImpressionsAndClicksRoundedCorrectly` — impressions 100 + 3 равных листинга → сумма 100, не 99

Существующие кейсы этого файла сохранены — они дают дополнительную регрессионную защиту.

### Integration-тесты
`ProcessAdRawDocumentActionTest` — 3 обязательных метода переименованы в канонические имена из ТЗ:
- `testProcessesRawDocumentAndCreatesAdDocuments` (happy path)
- `testSkipsUnknownSkuAndLeavesRawDocumentInDraft` (SKU не найден)
- `testIdempotentReprocessing` (повторный вызов не создаёт дублей)

Дополнительные кейсы (`testSkipsEntriesWithEmptyCampaignNameWithoutAbortingWholeDocument`, `testThrowsWhenDocumentIsNotDraft`, `testThrowsWhenDocumentNotFound`) сохранены.

Все файлы — с `declare(strict_types=1)`, `php -l` без ошибок.

## Test plan
- [ ] CI: `php bin/phpunit --filter MarketplaceAds` зелёный
- [ ] CI: PHPStan / CS-фиксеры зелёные
- [ ] Проверить, что билдеры используются без побочных эффектов: `AdRawDocumentBuilder::aRawDocument()->build()->getId() === AdRawDocumentBuilder::DEFAULT_ID`

https://claude.ai/code/session_01328uxbye8Hh3jNzhTrBtNv