### PR TITLE
feat(Marketplace): expose listing aggregate queries via MarketplaceFacade

### DIFF
--- a/site/src/Marketplace/DTO/ListingCostCategoryAggregateDTO.php
+++ b/site/src/Marketplace/DTO/ListingCostCategoryAggregateDTO.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\DTO;
+
+final readonly class ListingCostCategoryAggregateDTO
+{
+    public function __construct(
+        public string $listingId,
+        public string $categoryCode,
+        public string $categoryName,
+        public string $netAmount,
+        public string $costsAmount,
+        public string $stornoAmount,
+    ) {}
+}

--- a/site/src/Marketplace/DTO/ListingMetaDTO.php
+++ b/site/src/Marketplace/DTO/ListingMetaDTO.php
@@ -8,7 +8,7 @@ final readonly class ListingMetaDTO
 {
     public function __construct(
         public string $id,
-        public string $title,
+        public ?string $title,
         public string $sku,
         public string $marketplace,
     ) {}

--- a/site/src/Marketplace/DTO/ListingMetaDTO.php
+++ b/site/src/Marketplace/DTO/ListingMetaDTO.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\DTO;
+
+final readonly class ListingMetaDTO
+{
+    public function __construct(
+        public string $id,
+        public string $title,
+        public string $sku,
+        public string $marketplace,
+    ) {}
+}

--- a/site/src/Marketplace/DTO/ListingReturnAggregateDTO.php
+++ b/site/src/Marketplace/DTO/ListingReturnAggregateDTO.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\DTO;
+
+final readonly class ListingReturnAggregateDTO
+{
+    public function __construct(
+        public string $listingId,
+        public string $returnsTotal,
+        public int $returnsQuantity,
+    ) {}
+}

--- a/site/src/Marketplace/DTO/ListingSalesAggregateDTO.php
+++ b/site/src/Marketplace/DTO/ListingSalesAggregateDTO.php
@@ -8,7 +8,7 @@ final readonly class ListingSalesAggregateDTO
 {
     public function __construct(
         public string $listingId,
-        public string $title,
+        public ?string $title,
         public string $sku,
         public string $marketplace,
         public string $revenue,

--- a/site/src/Marketplace/DTO/ListingSalesAggregateDTO.php
+++ b/site/src/Marketplace/DTO/ListingSalesAggregateDTO.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\DTO;
+
+final readonly class ListingSalesAggregateDTO
+{
+    public function __construct(
+        public string $listingId,
+        public string $title,
+        public string $sku,
+        public string $marketplace,
+        public string $revenue,
+        public int $quantity,
+        public string $costPriceTotal,
+        public int $costPriceQuantity,
+    ) {}
+}

--- a/site/src/Marketplace/Facade/MarketplaceFacade.php
+++ b/site/src/Marketplace/Facade/MarketplaceFacade.php
@@ -13,6 +13,10 @@ use App\Marketplace\DTO\SaleData;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Inventory\CostPriceResolverInterface;
 use App\Marketplace\Infrastructure\Query\CostCategoriesQuery;
+use App\Marketplace\Infrastructure\Query\ListingCostAggregateQuery;
+use App\Marketplace\Infrastructure\Query\ListingMetaQuery;
+use App\Marketplace\Infrastructure\Query\ListingReturnAggregateQuery;
+use App\Marketplace\Infrastructure\Query\ListingSalesAggregateQuery;
 use App\Marketplace\Repository\MarketplaceAdvertisingCostRepositoryInterface;
 use App\Marketplace\Repository\MarketplaceOrderRepositoryInterface;
 use Doctrine\DBAL\Connection;
@@ -25,6 +29,10 @@ final readonly class MarketplaceFacade
         private Connection $connection,
         private CostPriceResolverInterface $costPriceResolver,
         private CostCategoriesQuery $costCategoriesQuery,
+        private ListingSalesAggregateQuery $salesAggregateQuery,
+        private ListingReturnAggregateQuery $returnAggregateQuery,
+        private ListingCostAggregateQuery $costAggregateQuery,
+        private ListingMetaQuery $listingMetaQuery,
     ) {}
 
     /**
@@ -345,5 +353,52 @@ final readonly class MarketplaceFacade
         }
 
         return $result;
+    }
+
+    /**
+     * @return array<string, \App\Marketplace\DTO\ListingSalesAggregateDTO> keyed by listingId
+     */
+    public function getSalesAggregatesByListing(
+        string $companyId,
+        ?string $marketplace,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+    ): array {
+        return $this->salesAggregateQuery->executeByPeriod($companyId, $marketplace, $from, $to);
+    }
+
+    /**
+     * @return array<string, \App\Marketplace\DTO\ListingReturnAggregateDTO> keyed by listingId
+     */
+    public function getReturnAggregatesByListing(
+        string $companyId,
+        ?string $marketplace,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+    ): array {
+        return $this->returnAggregateQuery->executeByPeriod($companyId, $marketplace, $from, $to);
+    }
+
+    /**
+     * @return array<string, list<\App\Marketplace\DTO\ListingCostCategoryAggregateDTO>> keyed by listingId
+     */
+    public function getCostAggregatesByListing(
+        string $companyId,
+        ?string $marketplace,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+    ): array {
+        return $this->costAggregateQuery->executeByPeriod($companyId, $marketplace, $from, $to);
+    }
+
+    /**
+     * @param  list<string> $listingIds
+     * @return array<string, \App\Marketplace\DTO\ListingMetaDTO> keyed by id
+     */
+    public function getListingsMetaByIds(
+        string $companyId,
+        array $listingIds,
+    ): array {
+        return $this->listingMetaQuery->findByIds($companyId, $listingIds);
     }
 }

--- a/site/src/Marketplace/Infrastructure/Query/ListingCostAggregateQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/ListingCostAggregateQuery.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Query;
+
+use App\Marketplace\DTO\ListingCostCategoryAggregateDTO;
+use DateTimeImmutable;
+use Doctrine\DBAL\Connection;
+
+final readonly class ListingCostAggregateQuery
+{
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    /**
+     * @return array<string, list<ListingCostCategoryAggregateDTO>> keyed by listingId
+     */
+    public function executeByPeriod(
+        string $companyId,
+        ?string $marketplace,
+        DateTimeImmutable $from,
+        DateTimeImmutable $to,
+    ): array {
+        $mpFilter = $marketplace !== null ? 'AND c.marketplace = :marketplace' : '';
+
+        $rows = $this->connection->fetchAllAssociative(
+            <<<SQL
+            SELECT
+                c.listing_id,
+                cc.code                                                       AS category_code,
+                cc.name                                                       AS category_name,
+                SUM(c.amount)                                                 AS net_amount,
+                SUM(CASE WHEN c.amount > 0 THEN c.amount ELSE 0 END)        AS costs_amount,
+                SUM(CASE WHEN c.amount < 0 THEN ABS(c.amount) ELSE 0 END)  AS storno_amount
+            FROM marketplace_costs c
+            JOIN marketplace_cost_categories cc ON cc.id = c.category_id
+            WHERE c.company_id = :companyId
+              AND c.cost_date >= :periodFrom
+              AND c.cost_date <= :periodTo
+              AND c.listing_id IS NOT NULL
+              {$mpFilter}
+            GROUP BY c.listing_id, cc.code, cc.name
+            SQL,
+            array_filter([
+                'companyId'   => $companyId,
+                'periodFrom'  => $from->format('Y-m-d'),
+                'periodTo'    => $to->format('Y-m-d'),
+                'marketplace' => $marketplace,
+            ], static fn ($v) => $v !== null),
+        );
+
+        $result = [];
+        foreach ($rows as $row) {
+            $result[$row['listing_id']][] = new ListingCostCategoryAggregateDTO(
+                listingId:     $row['listing_id'],
+                categoryCode:  $row['category_code'],
+                categoryName:  $row['category_name'],
+                netAmount:     (string) $row['net_amount'],
+                costsAmount:   (string) $row['costs_amount'],
+                stornoAmount:  (string) $row['storno_amount'],
+            );
+        }
+
+        return $result;
+    }
+}

--- a/site/src/Marketplace/Infrastructure/Query/ListingMetaQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/ListingMetaQuery.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Query;
+
+use App\Marketplace\DTO\ListingMetaDTO;
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+
+final readonly class ListingMetaQuery
+{
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    /**
+     * @param list<string> $listingIds
+     * @return array<string, ListingMetaDTO> keyed by id
+     */
+    public function findByIds(string $companyId, array $listingIds): array
+    {
+        if ($listingIds === []) {
+            return [];
+        }
+
+        $rows = $this->connection->fetchAllAssociative(
+            <<<SQL
+            SELECT
+                l.id,
+                l.name            AS listing_title,
+                l.marketplace_sku AS listing_sku,
+                l.marketplace     AS listing_marketplace
+            FROM marketplace_listings l
+            WHERE l.id IN (:ids)
+              AND l.company_id = :companyId
+            SQL,
+            [
+                'ids'       => array_values($listingIds),
+                'companyId' => $companyId,
+            ],
+            ['ids' => ArrayParameterType::STRING],
+        );
+
+        $result = [];
+        foreach ($rows as $row) {
+            $result[$row['id']] = new ListingMetaDTO(
+                id:          $row['id'],
+                title:       $row['listing_title'],
+                sku:         $row['listing_sku'],
+                marketplace: $row['listing_marketplace'],
+            );
+        }
+
+        return $result;
+    }
+}

--- a/site/src/Marketplace/Infrastructure/Query/ListingReturnAggregateQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/ListingReturnAggregateQuery.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Query;
+
+use App\Marketplace\DTO\ListingReturnAggregateDTO;
+use DateTimeImmutable;
+use Doctrine\DBAL\Connection;
+
+final readonly class ListingReturnAggregateQuery
+{
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    /**
+     * @return array<string, ListingReturnAggregateDTO> keyed by listingId
+     */
+    public function executeByPeriod(
+        string $companyId,
+        ?string $marketplace,
+        DateTimeImmutable $from,
+        DateTimeImmutable $to,
+    ): array {
+        $mpFilter = $marketplace !== null ? 'AND r.marketplace = :marketplace' : '';
+
+        $rows = $this->connection->fetchAllAssociative(
+            <<<SQL
+            SELECT
+                r.listing_id,
+                SUM(r.refund_amount) AS returns_total,
+                SUM(r.quantity)      AS returns_quantity
+            FROM marketplace_returns r
+            WHERE r.company_id = :companyId
+              AND r.return_date >= :periodFrom
+              AND r.return_date <= :periodTo
+              {$mpFilter}
+            GROUP BY r.listing_id
+            SQL,
+            array_filter([
+                'companyId'   => $companyId,
+                'periodFrom'  => $from->format('Y-m-d'),
+                'periodTo'    => $to->format('Y-m-d'),
+                'marketplace' => $marketplace,
+            ], static fn ($v) => $v !== null),
+        );
+
+        $result = [];
+        foreach ($rows as $row) {
+            $result[$row['listing_id']] = new ListingReturnAggregateDTO(
+                listingId:       $row['listing_id'],
+                returnsTotal:    (string) $row['returns_total'],
+                returnsQuantity: (int) $row['returns_quantity'],
+            );
+        }
+
+        return $result;
+    }
+}

--- a/site/src/Marketplace/Infrastructure/Query/ListingSalesAggregateQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/ListingSalesAggregateQuery.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Query;
+
+use App\Marketplace\DTO\ListingSalesAggregateDTO;
+use DateTimeImmutable;
+use Doctrine\DBAL\Connection;
+
+final readonly class ListingSalesAggregateQuery
+{
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    /**
+     * @return array<string, ListingSalesAggregateDTO> keyed by listingId
+     */
+    public function executeByPeriod(
+        string $companyId,
+        ?string $marketplace,
+        DateTimeImmutable $from,
+        DateTimeImmutable $to,
+    ): array {
+        $mpFilter = $marketplace !== null ? 'AND s.marketplace = :marketplace' : '';
+
+        $rows = $this->connection->fetchAllAssociative(
+            <<<SQL
+            SELECT
+                s.listing_id,
+                l.name                AS listing_title,
+                l.marketplace_sku     AS listing_sku,
+                l.marketplace         AS listing_marketplace,
+                SUM(s.total_revenue)  AS revenue,
+                SUM(s.quantity)       AS quantity,
+                SUM(CASE WHEN s.cost_price IS NOT NULL THEN s.cost_price * s.quantity ELSE 0 END) AS cost_price_total,
+                SUM(CASE WHEN s.cost_price IS NOT NULL THEN s.quantity ELSE 0 END) AS cost_price_quantity
+            FROM marketplace_sales s
+            JOIN marketplace_listings l ON l.id = s.listing_id
+            WHERE s.company_id = :companyId
+              AND s.sale_date >= :periodFrom
+              AND s.sale_date <= :periodTo
+              {$mpFilter}
+            GROUP BY s.listing_id, l.name, l.marketplace_sku, l.marketplace
+            SQL,
+            array_filter([
+                'companyId'   => $companyId,
+                'periodFrom'  => $from->format('Y-m-d'),
+                'periodTo'    => $to->format('Y-m-d'),
+                'marketplace' => $marketplace,
+            ], static fn ($v) => $v !== null),
+        );
+
+        $result = [];
+        foreach ($rows as $row) {
+            $result[$row['listing_id']] = new ListingSalesAggregateDTO(
+                listingId:         $row['listing_id'],
+                title:             $row['listing_title'],
+                sku:               $row['listing_sku'],
+                marketplace:       $row['listing_marketplace'],
+                revenue:           (string) $row['revenue'],
+                quantity:          (int) $row['quantity'],
+                costPriceTotal:    (string) $row['cost_price_total'],
+                costPriceQuantity: (int) $row['cost_price_quantity'],
+            );
+        }
+
+        return $result;
+    }
+}


### PR DESCRIPTION
## Summary
- Extended `MarketplaceFacade` with 4 pure-delegation methods exposing listing aggregate queries:
  - `getSalesAggregatesByListing()` → `ListingSalesAggregateQuery::executeByPeriod()`
  - `getReturnAggregatesByListing()` → `ListingReturnAggregateQuery::executeByPeriod()`
  - `getCostAggregatesByListing()` → `ListingCostAggregateQuery::executeByPeriod()`
  - `getListingsMetaByIds()` → `ListingMetaQuery::findByIds()`
- 4 new Query dependencies injected via constructor promotion
- No logic in Facade methods (PATTERNS.md §7)

## Test plan
- [x] PHP lint passes
- [ ] Consumers (Action/Controller) to be wired up in follow-up tasks
- [ ] `ARCHITECTURE.md` to be updated with the 4 new Facade methods