### PR TITLE
feat(Marketplace): add operation_type to MarketplaceCost

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -383,6 +383,18 @@ enum PipelineTrigger: string
 }
 ```
 
+### `src/Marketplace/Enum/MarketplaceCostOperationType.php`
+```php
+enum MarketplaceCostOperationType: string
+{
+    case CHARGE = 'charge';   // Начисление
+    case STORNO = 'storno';   // Сторно
+
+    public function getDisplayName(): string; // Начисление / Сторно
+}
+```
+> Явная классификация операции затраты. Заменяет определение типа по знаку `amount`.
+
 ### `src/MarketplaceAds/Enum/AdRawDocumentStatus.php`
 ```php
 enum AdRawDocumentStatus: string

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,7 @@ Doctrine генерирует proxy-класс наследованием от E
 - `class` — Entity
 - `final class` — Builder, Action, Policy, Controller, Facade, Repository, Query, Handler
 - `final readonly class` — DTO, Message, stateless-сервисы
+- `enum` — без `final`. PHP enum'ы implicitly final, `final enum` — синтаксическая ошибка.
 
 ### Entity — новые модули
 - UUID v7: `Uuid::uuid7()->toString()` — генерируется в **конструкторе Entity**

--- a/site/migrations/Version20260413000000.php
+++ b/site/migrations/Version20260413000000.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260413000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add operation_type column and index to marketplace_costs';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE marketplace_costs ADD COLUMN operation_type VARCHAR(10) DEFAULT NULL');
+        $this->addSql('CREATE INDEX idx_cost_operation_type ON marketplace_costs (operation_type)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS idx_cost_operation_type');
+        $this->addSql('ALTER TABLE marketplace_costs DROP COLUMN operation_type');
+    }
+}

--- a/site/src/Marketplace/Entity/MarketplaceCost.php
+++ b/site/src/Marketplace/Entity/MarketplaceCost.php
@@ -71,7 +71,7 @@ class MarketplaceCost
     #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
     private ?Document $document = null;
 
-    #[ORM\Column(type: 'string', enumType: MarketplaceCostOperationType::class, nullable: true)]
+    #[ORM\Column(type: 'string', length: 10, enumType: MarketplaceCostOperationType::class, nullable: true)]
     private ?MarketplaceCostOperationType $operationType = null;
 
     public function __construct(

--- a/site/src/Marketplace/Entity/MarketplaceCost.php
+++ b/site/src/Marketplace/Entity/MarketplaceCost.php
@@ -4,6 +4,7 @@ namespace App\Marketplace\Entity;
 
 use App\Company\Entity\Company;
 use App\Finance\Entity\Document;
+use App\Marketplace\Enum\MarketplaceCostOperationType;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Repository\MarketplaceCostRepository;
 use Doctrine\ORM\Mapping as ORM;
@@ -16,6 +17,7 @@ use Webmozart\Assert\Assert;
 #[ORM\Index(columns: ['listing_id'], name: 'idx_cost_listing')]
 #[ORM\Index(columns: ['sale_id'], name: 'idx_cost_sale')]
 #[ORM\Index(columns: ['raw_document_id'], name: 'idx_cost_raw_document')]
+#[ORM\Index(columns: ['operation_type'], name: 'idx_cost_operation_type')]
 class MarketplaceCost
 {
     #[ORM\Id]
@@ -68,6 +70,9 @@ class MarketplaceCost
     #[ORM\ManyToOne(targetEntity: Document::class)]
     #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
     private ?Document $document = null;
+
+    #[ORM\Column(type: 'string', enumType: MarketplaceCostOperationType::class, nullable: true)]
+    private ?MarketplaceCostOperationType $operationType = null;
 
     public function __construct(
         string $id,
@@ -235,6 +240,19 @@ class MarketplaceCost
     {
         $this->document = $document;
         $this->updatedAt = new \DateTimeImmutable();
+        return $this;
+    }
+
+    public function getOperationType(): ?MarketplaceCostOperationType
+    {
+        return $this->operationType;
+    }
+
+    public function setOperationType(?MarketplaceCostOperationType $operationType): self
+    {
+        $this->operationType = $operationType;
+        $this->updatedAt = new \DateTimeImmutable();
+
         return $this;
     }
 }

--- a/site/src/Marketplace/Enum/MarketplaceCostOperationType.php
+++ b/site/src/Marketplace/Enum/MarketplaceCostOperationType.php
@@ -8,4 +8,12 @@ enum MarketplaceCostOperationType: string
 {
     case CHARGE = 'charge';
     case STORNO = 'storno';
+
+    public function getDisplayName(): string
+    {
+        return match ($this) {
+            self::CHARGE => 'Начисление',
+            self::STORNO => 'Сторно',
+        };
+    }
 }

--- a/site/src/Marketplace/Enum/MarketplaceCostOperationType.php
+++ b/site/src/Marketplace/Enum/MarketplaceCostOperationType.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Enum;
+
+enum MarketplaceCostOperationType: string
+{
+    case CHARGE = 'charge';
+    case STORNO = 'storno';
+}


### PR DESCRIPTION
## Summary
- Adds nullable `operation_type VARCHAR(10)` column and `idx_cost_operation_type` index to `marketplace_costs` (migration `Version20260413000000`).
- Introduces `App\Marketplace\Enum\MarketplaceCostOperationType` (`charge` / `storno`).
- Adds `$operationType` field with getter/setter on `MarketplaceCost` entity (setter touches `updatedAt`); registers matching `#[ORM\Index]`.

## Notes
- No data changes — backfill is a separate task per the spec.
- Used plain `enum` (PHP enums are implicitly final; `final enum` is a syntax error), matching the existing `MarketplaceType` convention.

## Test plan
- [ ] `php bin/console doctrine:migrations:migrate` applies cleanly on a fresh DB.
- [ ] `\d marketplace_costs` shows new `operation_type` column and `idx_cost_operation_type` index.
- [ ] Migration `down()` removes the index and column without errors.
- [ ] `doctrine:schema:validate` reports the entity in sync with the DB.