### PR TITLE
feat(marketplace): add ozon_decompensation category to consumer maps

### DIFF
--- a/site/src/Marketplace/Application/Processor/OzonServiceCategoryMap.php
+++ b/site/src/Marketplace/Application/Processor/OzonServiceCategoryMap.php
@@ -26,7 +26,7 @@ final class OzonServiceCategoryMap
      * Версия словаря — обновлять при любом изменении маппинга.
      * Используется в /marketplace/costs/debug/map-version для проверки деплоя.
      */
-    public const VERSION = '2026-04-10.2';
+    public const VERSION = '2026-04-13.1';
 
     /**
      * @var array<string, string|null>
@@ -214,8 +214,8 @@ final class OzonServiceCategoryMap
 
         // Коды, генерируемые в OzonCostsRawProcessor::extractCostEntries() напрямую
         // + ozon_other_service — fallback для неизвестных service names
-        // + ozon_compensation — принудительно для opType=compensation
-        foreach (['ozon_sale_commission', 'ozon_delivery', 'ozon_return_delivery', 'ozon_other_service', 'ozon_compensation'] as $extra) {
+        // + ozon_compensation / ozon_decompensation — принудительно для opType=compensation
+        foreach (['ozon_sale_commission', 'ozon_delivery', 'ozon_return_delivery', 'ozon_other_service', 'ozon_compensation', 'ozon_decompensation'] as $extra) {
             if (!isset($codes[$extra])) {
                 $codes[$extra] = self::getCategoryName($extra);
             }
@@ -282,6 +282,7 @@ final class OzonServiceCategoryMap
             'ozon_service_correction'    => 'Корректировка стоимости услуг Ozon',
             'ozon_ovh_processing'        => 'Дополнительная обработка ОВХ Ozon',
             'ozon_compensation'          => 'Компенсации и декомпенсации Ozon',
+            'ozon_decompensation'        => 'Декомпенсация Ozon',
             default                      => 'Прочие услуги Ozon',
         };
     }

--- a/site/src/Marketplace/Application/Processor/OzonServiceCategoryMap.php
+++ b/site/src/Marketplace/Application/Processor/OzonServiceCategoryMap.php
@@ -214,7 +214,9 @@ final class OzonServiceCategoryMap
 
         // Коды, генерируемые в OzonCostsRawProcessor::extractCostEntries() напрямую
         // + ozon_other_service — fallback для неизвестных service names
-        // + ozon_compensation / ozon_decompensation — принудительно для opType=compensation
+        // + ozon_compensation — принудительно для opType=compensation
+        // + ozon_decompensation — sibling для будущего разделения по знаку amount
+        //   (OzonCostsRawProcessor пока не эмитирует, заведён как известная категория заранее)
         foreach (['ozon_sale_commission', 'ozon_delivery', 'ozon_return_delivery', 'ozon_other_service', 'ozon_compensation', 'ozon_decompensation'] as $extra) {
             if (!isset($codes[$extra])) {
                 $codes[$extra] = self::getCategoryName($extra);

--- a/site/src/Marketplace/Application/Reconciliation/OzonXlsxServiceGroupMap.php
+++ b/site/src/Marketplace/Application/Reconciliation/OzonXlsxServiceGroupMap.php
@@ -113,6 +113,7 @@ final class OzonXlsxServiceGroupMap
             // === Компенсации и декомпенсации ===
             // Типы: Компенсация, Декомпенсация
             'ozon_compensation'          => 'Компенсации и декомпенсации',
+            'ozon_decompensation'        => 'Компенсации и декомпенсации',
         ];
     }
 }


### PR DESCRIPTION
## Summary
- Adds `ozon_decompensation` as a sibling of `ozon_compensation` in the Ozon consumer-side maps:
  - `OzonServiceCategoryMap::getAllCategoryCodes()` — added to the "extra" codes list.
  - `OzonServiceCategoryMap::getCategoryName()` — new match arm `'ozon_decompensation' => 'Декомпенсация Ozon'`.
  - `OzonXlsxServiceGroupMap` — registered under the existing `Компенсации и декомпенсации` xlsx group.
- Bumps `OzonServiceCategoryMap::VERSION` to `2026-04-13.1` per the file's policy ("обновлять при любом изменении маппинга").

## Scope (Variant A)
- **Processor untouched.** `OzonCostsRawProcessor` still emits only `ozon_compensation` for every compensation operation regardless of sign. No behavior change.
- **Fixtures untouched.** `MarketplaceCostCategoriesFixtures` contains no Ozon seeds today — adding a singleton `ozon_decompensation` entry without a sibling `ozon_compensation` entry would be inconsistent, so fixtures are left alone.
- Preparatory infra only: the consumer maps now recognise the code as valid, so a future processor change can split compensation/decompensation without breaking category lookups.

## Test plan
- [ ] `php bin/console cache:clear` — no errors from the static const/match changes.
- [ ] `GET /marketplace/costs/debug/map-version` returns version `2026-04-13.1`.
- [ ] `OzonServiceCategoryMap::getAllCategoryCodes()` contains key `ozon_decompensation` with value `'Декомпенсация Ozon'`.
- [ ] `OzonXlsxServiceGroupMap::getCategoryToServiceGroup()` maps `ozon_decompensation` to `'Компенсации и декомпенсации'`.
- [ ] Existing reconciliation flows for `ozon_compensation` remain unchanged.