### PR TITLE
refactor(Marketplace): consume operation_type with sign fallback (Phase 2A)

### DIFF
--- a/site/src/Marketplace/DTO/CostData.php
+++ b/site/src/Marketplace/DTO/CostData.php
@@ -19,6 +19,18 @@ readonly class CostData
         public ?string $nmId = null,
         public ?string $tsName = null,
         public ?string $barcode = null,
+        /**
+         * 'charge' | 'storno' | null.
+         *
+         * Source of truth для классификации "начисление vs сторно" post-Phase-2A.
+         * Populated MarketplaceFacade::getCostsForListingAndDate() с fallback:
+         *   - если в БД c.operation_type IS NOT NULL → берём как есть
+         *   - если NULL (legacy WB / pre-backfill Ozon) → derive из знака amount:
+         *     amount < 0 → 'storno', иначе 'charge'.
+         *
+         * Адаптерам (Ozon/Wildberries) можно не передавать — оставится null.
+         */
+        public ?string $operationType = null,
     ) {
     }
 }

--- a/site/src/Marketplace/Facade/MarketplaceFacade.php
+++ b/site/src/Marketplace/Facade/MarketplaceFacade.php
@@ -170,7 +170,7 @@ final readonly class MarketplaceFacade
         return array_map(static function (array $row): CostData {
             $operationType = $row['operation_type'] ?? null;
             if ($operationType === null) {
-                $operationType = ((float) $row['amount']) < 0 ? 'storno' : 'charge';
+                $operationType = bccomp((string) $row['amount'], '0.00', 2) < 0 ? 'storno' : 'charge';
             }
 
             return new CostData(

--- a/site/src/Marketplace/Facade/MarketplaceFacade.php
+++ b/site/src/Marketplace/Facade/MarketplaceFacade.php
@@ -148,6 +148,7 @@ final readonly class MarketplaceFacade
     ): array {
         $rows = $this->connection->fetchAllAssociative(
             'SELECT c.marketplace, c.amount, c.cost_date, c.description, c.external_id,
+                    c.operation_type,
                     cat.id AS category_id, cat.code AS category_code, l.marketplace_sku
              FROM marketplace_costs c
              JOIN marketplace_cost_categories cat ON c.category_id = cat.id
@@ -162,16 +163,28 @@ final readonly class MarketplaceFacade
             ],
         );
 
-        return array_map(static fn(array $row) => new CostData(
-            marketplace: MarketplaceType::from($row['marketplace']),
-            categoryCode: $row['category_code'],
-            amount: $row['amount'],
-            costDate: new \DateTimeImmutable($row['cost_date']),
-            categoryId: $row['category_id'],
-            marketplaceSku: $row['marketplace_sku'] ?? null,
-            description: $row['description'],
-            externalId: $row['external_id'],
-        ), $rows);
+        // operationType: source of truth post-Phase-2A — берём из c.operation_type;
+        // для legacy rows (WB / pre-backfill Ozon) где колонка NULL — derive из знака amount:
+        //   amount < 0 → 'storno', иначе → 'charge'.
+        // TODO Phase 2B: убрать fallback после полного backfill operation_type для всех marketplace'ов.
+        return array_map(static function (array $row): CostData {
+            $operationType = $row['operation_type'] ?? null;
+            if ($operationType === null) {
+                $operationType = ((float) $row['amount']) < 0 ? 'storno' : 'charge';
+            }
+
+            return new CostData(
+                marketplace: MarketplaceType::from($row['marketplace']),
+                categoryCode: $row['category_code'],
+                amount: $row['amount'],
+                costDate: new \DateTimeImmutable($row['cost_date']),
+                categoryId: $row['category_id'],
+                marketplaceSku: $row['marketplace_sku'] ?? null,
+                description: $row['description'],
+                externalId: $row['external_id'],
+                operationType: $operationType,
+            );
+        }, $rows);
     }
 
     /**

--- a/site/src/Marketplace/Infrastructure/Query/CostReconciliationQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/CostReconciliationQuery.php
@@ -36,12 +36,32 @@ final class CostReconciliationQuery
         string $periodTo,
         array $reportResult,
     ): array {
+        // costs_amount / storno_amount классифицируются по operation_type с fallback на знак amount:
+        //   - operation_type IS NOT NULL (новая схема, Ozon post-backfill) → берём operation_type
+        //   - operation_type IS NULL (legacy: WB, pre-Phase-2A) → падаем на sign амаунта
+        // ABS() применяется безусловно — безопасно в обоих режимах:
+        //   pre-migration storno:  amount < 0 → ABS(amount) > 0
+        //   post-migration storno: amount > 0 → ABS(amount) = amount > 0
         $apiStats = $this->connection->fetchAssociative(
             <<<'SQL'
             SELECT
                 SUM(c.amount)                                               AS net_amount,
-                SUM(CASE WHEN c.amount > 0 THEN c.amount  ELSE 0 END)     AS costs_amount,
-                SUM(CASE WHEN c.amount < 0 THEN ABS(c.amount) ELSE 0 END) AS storno_amount,
+                SUM(CASE
+                    WHEN (CASE
+                            WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
+                            ELSE (c.amount < 0)
+                         END)
+                    THEN 0
+                    ELSE c.amount
+                END)                                                        AS costs_amount,
+                SUM(CASE
+                    WHEN (CASE
+                            WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
+                            ELSE (c.amount < 0)
+                         END)
+                    THEN ABS(c.amount)
+                    ELSE 0
+                END)                                                        AS storno_amount,
                 COALESCE((
                     SELECT SUM(r.refund_amount)
                     FROM marketplace_returns r
@@ -135,14 +155,30 @@ final class CostReconciliationQuery
         string $periodTo,
         array $xlsxGroupTotals,
     ): array {
-        // Наши суммы по категориям
+        // Наши суммы по категориям.
+        // costs_amount / storno_amount классифицируются по operation_type (с fallback на знак)
+        // — та же логика что в reconcile() выше.
         $apiByCategory = $this->connection->fetchAllAssociative(
             <<<'SQL'
             SELECT
                 cc.code                                                        AS category_code,
                 SUM(c.amount)                                                  AS net_amount,
-                SUM(CASE WHEN c.amount > 0 THEN c.amount  ELSE 0 END)         AS costs_amount,
-                SUM(CASE WHEN c.amount < 0 THEN ABS(c.amount) ELSE 0 END)     AS storno_amount
+                SUM(CASE
+                    WHEN (CASE
+                            WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
+                            ELSE (c.amount < 0)
+                         END)
+                    THEN 0
+                    ELSE c.amount
+                END)                                                           AS costs_amount,
+                SUM(CASE
+                    WHEN (CASE
+                            WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
+                            ELSE (c.amount < 0)
+                         END)
+                    THEN ABS(c.amount)
+                    ELSE 0
+                END)                                                           AS storno_amount
             FROM marketplace_costs c
             INNER JOIN marketplace_cost_categories cc ON cc.id = c.category_id
             WHERE c.company_id  = :companyId

--- a/site/src/Marketplace/Infrastructure/Query/CostReconciliationQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/CostReconciliationQuery.php
@@ -36,23 +36,32 @@ final class CostReconciliationQuery
         string $periodTo,
         array $reportResult,
     ): array {
-        // costs_amount / storno_amount классифицируются по operation_type с fallback на знак amount:
+        // net_amount / costs_amount / storno_amount классифицируются по operation_type с fallback на знак amount:
         //   - operation_type IS NOT NULL (новая схема, Ozon post-backfill) → берём operation_type
         //   - operation_type IS NULL (legacy: WB, pre-Phase-2A) → падаем на sign амаунта
         // ABS() применяется безусловно — безопасно в обоих режимах:
         //   pre-migration storno:  amount < 0 → ABS(amount) > 0
         //   post-migration storno: amount > 0 → ABS(amount) = amount > 0
+        // net_amount = charges − stornos (через signed-ABS), а не raw SUM —
+        // raw SUM ломается для post-migration: storno с amount > 0 не вычитается.
         $apiStats = $this->connection->fetchAssociative(
             <<<'SQL'
             SELECT
-                SUM(c.amount)                                               AS net_amount,
+                SUM(CASE
+                    WHEN (CASE
+                            WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
+                            ELSE (c.amount < 0)
+                         END)
+                    THEN -ABS(c.amount)
+                    ELSE ABS(c.amount)
+                END)                                                        AS net_amount,
                 SUM(CASE
                     WHEN (CASE
                             WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
                             ELSE (c.amount < 0)
                          END)
                     THEN 0
-                    ELSE c.amount
+                    ELSE ABS(c.amount)
                 END)                                                        AS costs_amount,
                 SUM(CASE
                     WHEN (CASE
@@ -156,20 +165,27 @@ final class CostReconciliationQuery
         array $xlsxGroupTotals,
     ): array {
         // Наши суммы по категориям.
-        // costs_amount / storno_amount классифицируются по operation_type (с fallback на знак)
-        // — та же логика что в reconcile() выше.
+        // net_amount / costs_amount / storno_amount классифицируются по operation_type
+        // (с fallback на знак) — та же логика что в reconcile() выше.
         $apiByCategory = $this->connection->fetchAllAssociative(
             <<<'SQL'
             SELECT
                 cc.code                                                        AS category_code,
-                SUM(c.amount)                                                  AS net_amount,
+                SUM(CASE
+                    WHEN (CASE
+                            WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
+                            ELSE (c.amount < 0)
+                         END)
+                    THEN -ABS(c.amount)
+                    ELSE ABS(c.amount)
+                END)                                                           AS net_amount,
                 SUM(CASE
                     WHEN (CASE
                             WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
                             ELSE (c.amount < 0)
                          END)
                     THEN 0
-                    ELSE c.amount
+                    ELSE ABS(c.amount)
                 END)                                                           AS costs_amount,
                 SUM(CASE
                     WHEN (CASE

--- a/site/src/Marketplace/Infrastructure/Query/CostsVerifyQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/CostsVerifyQuery.php
@@ -92,14 +92,21 @@ final class CostsVerifyQuery
                 cc.code                                                         AS category_code,
                 cc.name                                                         AS category_name,
                 COUNT(c.id)                                                     AS count,
-                SUM(c.amount)                                                   AS net_amount,
+                SUM(CASE
+                    WHEN (CASE
+                            WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
+                            ELSE (c.amount < 0)
+                         END)
+                    THEN -ABS(c.amount)
+                    ELSE ABS(c.amount)
+                END)                                                            AS net_amount,
                 SUM(CASE
                     WHEN (CASE
                             WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
                             ELSE (c.amount < 0)
                          END)
                     THEN 0
-                    ELSE c.amount
+                    ELSE ABS(c.amount)
                 END)                                                            AS costs_amount,
                 SUM(CASE
                     WHEN (CASE
@@ -118,7 +125,14 @@ final class CostsVerifyQuery
               AND c.cost_date  >= :periodFrom
               AND c.cost_date  <= :periodTo
             GROUP BY cc.code, cc.name
-            ORDER BY SUM(c.amount) DESC
+            ORDER BY SUM(CASE
+                        WHEN (CASE
+                                WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
+                                ELSE (c.amount < 0)
+                             END)
+                        THEN -ABS(c.amount)
+                        ELSE ABS(c.amount)
+                    END) DESC
             SQL,
             [
                 'companyId'   => $companyId,
@@ -162,19 +176,26 @@ final class CostsVerifyQuery
         string $periodFrom,
         string $periodTo,
     ): array {
-        // costs_amount / storno_amount — по operation_type с fallback на знак (см. totalsByCategory).
+        // net_amount / costs_amount / storno_amount — по operation_type с fallback на знак (см. totalsByCategory).
         $row = $this->connection->fetchAssociative(
             <<<'SQL'
             SELECT
                 COUNT(c.id)                                            AS total_count,
-                SUM(c.amount)                                          AS net_amount,
+                SUM(CASE
+                    WHEN (CASE
+                            WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
+                            ELSE (c.amount < 0)
+                         END)
+                    THEN -ABS(c.amount)
+                    ELSE ABS(c.amount)
+                END)                                                   AS net_amount,
                 SUM(CASE
                     WHEN (CASE
                             WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
                             ELSE (c.amount < 0)
                          END)
                     THEN 0
-                    ELSE c.amount
+                    ELSE ABS(c.amount)
                 END)                                                   AS costs_amount,
                 SUM(CASE
                     WHEN (CASE

--- a/site/src/Marketplace/Infrastructure/Query/CostsVerifyQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/CostsVerifyQuery.php
@@ -83,6 +83,9 @@ final class CostsVerifyQuery
         string $periodFrom,
         string $periodTo,
     ): array {
+        // costs_amount / storno_amount классифицируются по operation_type с fallback на знак amount.
+        // Fallback нужен на период перехода: WB ещё эмитирует NULL operation_type,
+        // Ozon до бэкфилла — тоже NULL. После полной миграции (Phase 2B) fallback снимается.
         $rows = $this->connection->fetchAllAssociative(
             <<<'SQL'
             SELECT
@@ -90,8 +93,22 @@ final class CostsVerifyQuery
                 cc.name                                                         AS category_name,
                 COUNT(c.id)                                                     AS count,
                 SUM(c.amount)                                                   AS net_amount,
-                SUM(CASE WHEN c.amount > 0 THEN c.amount  ELSE 0 END)          AS costs_amount,
-                SUM(CASE WHEN c.amount < 0 THEN ABS(c.amount) ELSE 0 END)      AS storno_amount,
+                SUM(CASE
+                    WHEN (CASE
+                            WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
+                            ELSE (c.amount < 0)
+                         END)
+                    THEN 0
+                    ELSE c.amount
+                END)                                                            AS costs_amount,
+                SUM(CASE
+                    WHEN (CASE
+                            WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
+                            ELSE (c.amount < 0)
+                         END)
+                    THEN ABS(c.amount)
+                    ELSE 0
+                END)                                                            AS storno_amount,
                 COUNT(c.listing_id)                                             AS linked_to_sku,
                 COUNT(c.id) - COUNT(c.listing_id)                               AS general_costs
             FROM marketplace_costs c
@@ -145,13 +162,28 @@ final class CostsVerifyQuery
         string $periodFrom,
         string $periodTo,
     ): array {
+        // costs_amount / storno_amount — по operation_type с fallback на знак (см. totalsByCategory).
         $row = $this->connection->fetchAssociative(
             <<<'SQL'
             SELECT
                 COUNT(c.id)                                            AS total_count,
                 SUM(c.amount)                                          AS net_amount,
-                SUM(CASE WHEN c.amount > 0 THEN c.amount  ELSE 0 END) AS costs_amount,
-                SUM(CASE WHEN c.amount < 0 THEN ABS(c.amount) ELSE 0 END) AS storno_amount,
+                SUM(CASE
+                    WHEN (CASE
+                            WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
+                            ELSE (c.amount < 0)
+                         END)
+                    THEN 0
+                    ELSE c.amount
+                END)                                                   AS costs_amount,
+                SUM(CASE
+                    WHEN (CASE
+                            WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
+                            ELSE (c.amount < 0)
+                         END)
+                    THEN ABS(c.amount)
+                    ELSE 0
+                END)                                                   AS storno_amount,
                 COUNT(c.listing_id)                                    AS linked_to_sku,
                 COUNT(c.id) - COUNT(c.listing_id)                      AS general_costs
             FROM marketplace_costs c
@@ -364,7 +396,10 @@ final class CostsVerifyQuery
         string $periodFrom,
         string $periodTo,
     ): array {
-        // Возвращённая комиссия, которую мы УЖЕ пишем в marketplace_costs как отрицательную затрату
+        // Возвращённая комиссия. Storno определяется по operation_type с fallback на знак amount:
+        //   pre-Phase-2A (operation_type IS NULL): storno = amount < 0
+        //   post-Phase-2A (operation_type IS NOT NULL): storno = operation_type = 'storno'
+        // SUM(ABS(c.amount)) корректен в обоих режимах.
         $commissionReturned = (float) ($this->connection->fetchOne(
             <<<'SQL'
             SELECT COALESCE(SUM(ABS(c.amount)), 0)
@@ -375,7 +410,10 @@ final class CostsVerifyQuery
               AND c.cost_date  >= :periodFrom
               AND c.cost_date  <= :periodTo
               AND cc.code       = 'ozon_sale_commission'
-              AND c.amount      < 0
+              AND (CASE
+                      WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
+                      ELSE (c.amount < 0)
+                  END)
             SQL,
             [
                 'companyId'   => $companyId,

--- a/site/src/Marketplace/Infrastructure/Query/ListingCostAggregateQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/ListingCostAggregateQuery.php
@@ -26,6 +26,8 @@ final readonly class ListingCostAggregateQuery
     ): array {
         $mpFilter = $marketplace !== null ? 'AND c.marketplace = :marketplace' : '';
 
+        // costs_amount / storno_amount — по operation_type с fallback на знак amount.
+        // См. UnprocessedCostsQuery / CostsVerifyQuery для деталей паттерна.
         $rows = $this->connection->fetchAllAssociative(
             <<<SQL
             SELECT
@@ -33,8 +35,22 @@ final readonly class ListingCostAggregateQuery
                 cc.code                                                       AS category_code,
                 cc.name                                                       AS category_name,
                 SUM(c.amount)                                                 AS net_amount,
-                SUM(CASE WHEN c.amount > 0 THEN c.amount ELSE 0 END)        AS costs_amount,
-                SUM(CASE WHEN c.amount < 0 THEN ABS(c.amount) ELSE 0 END)  AS storno_amount
+                SUM(CASE
+                    WHEN (CASE
+                            WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
+                            ELSE (c.amount < 0)
+                         END)
+                    THEN 0
+                    ELSE c.amount
+                END)                                                          AS costs_amount,
+                SUM(CASE
+                    WHEN (CASE
+                            WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
+                            ELSE (c.amount < 0)
+                         END)
+                    THEN ABS(c.amount)
+                    ELSE 0
+                END)                                                          AS storno_amount
             FROM marketplace_costs c
             JOIN marketplace_cost_categories cc ON cc.id = c.category_id
             WHERE c.company_id = :companyId

--- a/site/src/Marketplace/Infrastructure/Query/ListingCostAggregateQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/ListingCostAggregateQuery.php
@@ -26,7 +26,7 @@ final readonly class ListingCostAggregateQuery
     ): array {
         $mpFilter = $marketplace !== null ? 'AND c.marketplace = :marketplace' : '';
 
-        // costs_amount / storno_amount — по operation_type с fallback на знак amount.
+        // net_amount / costs_amount / storno_amount — по operation_type с fallback на знак amount.
         // См. UnprocessedCostsQuery / CostsVerifyQuery для деталей паттерна.
         $rows = $this->connection->fetchAllAssociative(
             <<<SQL
@@ -34,14 +34,21 @@ final readonly class ListingCostAggregateQuery
                 c.listing_id,
                 cc.code                                                       AS category_code,
                 cc.name                                                       AS category_name,
-                SUM(c.amount)                                                 AS net_amount,
+                SUM(CASE
+                    WHEN (CASE
+                            WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
+                            ELSE (c.amount < 0)
+                         END)
+                    THEN -ABS(c.amount)
+                    ELSE ABS(c.amount)
+                END)                                                          AS net_amount,
                 SUM(CASE
                     WHEN (CASE
                             WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
                             ELSE (c.amount < 0)
                          END)
                     THEN 0
-                    ELSE c.amount
+                    ELSE ABS(c.amount)
                 END)                                                          AS costs_amount,
                 SUM(CASE
                     WHEN (CASE

--- a/site/src/Marketplace/Infrastructure/Query/PreflightCostsQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/PreflightCostsQuery.php
@@ -150,6 +150,8 @@ final class PreflightCostsQuery
         string $periodFrom,
         string $periodTo,
     ): array {
+        // costs_amount / storno_amount — по operation_type с fallback на знак amount.
+        // См. UnprocessedCostsQuery / CostsVerifyQuery для деталей паттерна.
         return $this->connection->fetchAllAssociative(
             <<<'SQL'
             SELECT
@@ -159,8 +161,22 @@ final class PreflightCostsQuery
                 m.include_in_pl                                                 AS include_in_pl,
                 m.is_negative                                                   AS is_negative,
                 COUNT(c.id)                                                     AS count,
-                SUM(CASE WHEN c.amount > 0 THEN c.amount  ELSE 0 END)          AS costs_amount,
-                SUM(CASE WHEN c.amount < 0 THEN ABS(c.amount) ELSE 0 END)      AS storno_amount,
+                SUM(CASE
+                    WHEN (CASE
+                            WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
+                            ELSE (c.amount < 0)
+                         END)
+                    THEN 0
+                    ELSE c.amount
+                END)                                                            AS costs_amount,
+                SUM(CASE
+                    WHEN (CASE
+                            WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
+                            ELSE (c.amount < 0)
+                         END)
+                    THEN ABS(c.amount)
+                    ELSE 0
+                END)                                                            AS storno_amount,
                 SUM(c.amount)                                                   AS net_amount,
                 COUNT(c.id) FILTER (WHERE c.document_id IS NOT NULL)           AS already_processed
             FROM marketplace_costs c

--- a/site/src/Marketplace/Infrastructure/Query/PreflightCostsQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/PreflightCostsQuery.php
@@ -150,7 +150,7 @@ final class PreflightCostsQuery
         string $periodFrom,
         string $periodTo,
     ): array {
-        // costs_amount / storno_amount — по operation_type с fallback на знак amount.
+        // net_amount / costs_amount / storno_amount — по operation_type с fallback на знак amount.
         // См. UnprocessedCostsQuery / CostsVerifyQuery для деталей паттерна.
         return $this->connection->fetchAllAssociative(
             <<<'SQL'
@@ -167,7 +167,7 @@ final class PreflightCostsQuery
                             ELSE (c.amount < 0)
                          END)
                     THEN 0
-                    ELSE c.amount
+                    ELSE ABS(c.amount)
                 END)                                                            AS costs_amount,
                 SUM(CASE
                     WHEN (CASE
@@ -177,7 +177,14 @@ final class PreflightCostsQuery
                     THEN ABS(c.amount)
                     ELSE 0
                 END)                                                            AS storno_amount,
-                SUM(c.amount)                                                   AS net_amount,
+                SUM(CASE
+                    WHEN (CASE
+                            WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
+                            ELSE (c.amount < 0)
+                         END)
+                    THEN -ABS(c.amount)
+                    ELSE ABS(c.amount)
+                END)                                                            AS net_amount,
                 COUNT(c.id) FILTER (WHERE c.document_id IS NOT NULL)           AS already_processed
             FROM marketplace_costs c
             INNER JOIN marketplace_cost_categories mcc ON mcc.id = c.category_id

--- a/site/src/Marketplace/Infrastructure/Query/UnprocessedCostsQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/UnprocessedCostsQuery.php
@@ -59,16 +59,17 @@ final class UnprocessedCostsQuery
     ): array {
         // Получаем все строки с разбивкой по категории И знаку (costs vs storno).
         //
-        // is_storno определяется по operation_type с fallback на знак amount:
+        // is_storno / costs_amount / storno_amount классифицируются по operation_type
+        // с fallback на знак amount:
         //   - operation_type IS NOT NULL (новая схема, Ozon post-backfill) → operation_type = 'storno'
         //   - operation_type IS NULL (legacy: WB-строки, unmigrated pre-Phase-2A) → amount < 0
         //
         // Fallback нужен на период перехода: WB ещё эмитирует NULL operation_type,
         // Ozon до бэкфилла тоже NULL. После полной миграции (Phase 2B) fallback снимается.
         //
-        // Note: costs_amount / storno_amount / total_amount используют сырой знак amount —
-        // они семантически корректны для обоих режимов (pre/post-migration), т.к. total_amount
-        // берётся через ABS(SUM()). Полный переход на always-positive amount — Phase 2B.
+        // Важно: все три поля (is_storno / costs_amount / storno_amount) используют одну
+        // и ту же классификацию, иначе для post-migration Ozon (amount > 0, operation_type='storno')
+        // строки помеченные is_storno=true попадут в costs_amount вместо storno_amount.
         $sql = <<<'SQL'
             SELECT
                 mcc.code                                                        AS cost_category_code,
@@ -78,8 +79,22 @@ final class UnprocessedCostsQuery
                     WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
                     ELSE (c.amount < 0)
                 END)                                                            AS is_storno,
-                SUM(CASE WHEN c.amount > 0 THEN c.amount  ELSE 0 END)          AS costs_amount,
-                SUM(CASE WHEN c.amount < 0 THEN ABS(c.amount) ELSE 0 END)      AS storno_amount,
+                SUM(CASE
+                    WHEN (CASE
+                            WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
+                            ELSE (c.amount < 0)
+                         END)
+                    THEN 0
+                    ELSE ABS(c.amount)
+                END)                                                            AS costs_amount,
+                SUM(CASE
+                    WHEN (CASE
+                            WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
+                            ELSE (c.amount < 0)
+                         END)
+                    THEN ABS(c.amount)
+                    ELSE 0
+                END)                                                            AS storno_amount,
                 ABS(SUM(c.amount))                                              AS total_amount,
                 m.is_negative                                                   AS mapping_is_negative,
                 m.sort_order                                                    AS sort_order,

--- a/site/src/Marketplace/Infrastructure/Query/UnprocessedCostsQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/UnprocessedCostsQuery.php
@@ -57,13 +57,27 @@ final class UnprocessedCostsQuery
         string $periodFrom,
         string $periodTo,
     ): array {
-        // Получаем все строки с разбивкой по категории И знаку (costs vs storno)
+        // Получаем все строки с разбивкой по категории И знаку (costs vs storno).
+        //
+        // is_storno определяется по operation_type с fallback на знак amount:
+        //   - operation_type IS NOT NULL (новая схема, Ozon post-backfill) → operation_type = 'storno'
+        //   - operation_type IS NULL (legacy: WB-строки, unmigrated pre-Phase-2A) → amount < 0
+        //
+        // Fallback нужен на период перехода: WB ещё эмитирует NULL operation_type,
+        // Ozon до бэкфилла тоже NULL. После полной миграции (Phase 2B) fallback снимается.
+        //
+        // Note: costs_amount / storno_amount / total_amount используют сырой знак amount —
+        // они семантически корректны для обоих режимов (pre/post-migration), т.к. total_amount
+        // берётся через ABS(SUM()). Полный переход на always-positive amount — Phase 2B.
         $sql = <<<'SQL'
             SELECT
                 mcc.code                                                        AS cost_category_code,
                 mcc.name                                                        AS cost_category_name,
                 m.pl_category_id                                                AS pl_category_id,
-                (c.amount < 0)                                                  AS is_storno,
+                (CASE
+                    WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
+                    ELSE (c.amount < 0)
+                END)                                                            AS is_storno,
                 SUM(CASE WHEN c.amount > 0 THEN c.amount  ELSE 0 END)          AS costs_amount,
                 SUM(CASE WHEN c.amount < 0 THEN ABS(c.amount) ELSE 0 END)      AS storno_amount,
                 ABS(SUM(c.amount))                                              AS total_amount,
@@ -87,11 +101,18 @@ final class UnprocessedCostsQuery
                 mcc.code,
                 mcc.name,
                 m.pl_category_id,
-                (c.amount < 0),
+                (CASE
+                    WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
+                    ELSE (c.amount < 0)
+                END),
                 m.is_negative,
                 m.sort_order
             HAVING ABS(SUM(c.amount)) > 0.001
-            ORDER BY m.sort_order ASC, mcc.name ASC, (c.amount < 0) ASC
+            ORDER BY m.sort_order ASC, mcc.name ASC,
+                (CASE
+                    WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
+                    ELSE (c.amount < 0)
+                END) ASC
         SQL;
 
         $rows = $this->connection->fetchAllAssociative($sql, [

--- a/site/src/MarketplaceAnalytics/Domain/Service/SnapshotCalculationPolicy.php
+++ b/site/src/MarketplaceAnalytics/Domain/Service/SnapshotCalculationPolicy.php
@@ -203,6 +203,19 @@ final readonly class SnapshotCalculationPolicy
         return $snapshot;
     }
 
+    /**
+     * Приводит amount к положительному значению для cost breakdown аналитики.
+     *
+     * Работает для обоих знаковых соглашений MarketplaceCost:
+     *   - legacy (WB, pre-migration Ozon): amount может быть отрицательным
+     *     для storno / возврата комиссии — функция делает abs.
+     *   - post-Phase-2A (Ozon после backfill): amount всегда положительный,
+     *     storno кодируется через operation_type='storno' — функция no-op.
+     *
+     * TODO Phase 2B: после полной миграции WB на always-positive amount
+     * (operation_type обязателен) эта нормализация становится излишней и
+     * может быть удалена вместе с fallback'ами в Query-классах.
+     */
     private function normalizeAmountForCostBreakdown(string $amount): string
     {
         if (bccomp($amount, '0.00', 2) < 0) {


### PR DESCRIPTION
## Summary

- **Task 5** — `UnprocessedCostsQuery`: переключён `is_storno` c знака amount на `operation_type` с NULL-fallback
- **Tasks 6.1-6.4** — единый CASE WHEN fallback паттерн в `CostReconciliationQuery`, `CostsVerifyQuery`, `PreflightCostsQuery`, `ListingCostAggregateQuery`
- **Task 6.5** — `SnapshotCalculationPolicy.normalizeAmountForCostBreakdown`: docblock + TODO Phase 2B (логика без изменений)
- **Task 6.6** — `CostData` DTO: добавлено поле `operationType`; `MarketplaceFacade::getCostsForListingAndDate()`: SELECT `c.operation_type` + populate с fallback

## SQL fallback pattern (Phase 2A — dual-mode)

```sql
CASE
  WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
  ELSE (c.amount < 0)
END
```

Позволяет одновременно обслуживать:
- **post-backfill Ozon** — `operation_type` заполнен → берём как есть
- **legacy WB / pre-backfill Ozon** — `operation_type IS NULL` → derive из знака amount

## Changed files

| File | Change |
|---|---|
| `Marketplace/DTO/CostData.php` | + `operationType: ?string` |
| `Marketplace/Facade/MarketplaceFacade.php` | SELECT `c.operation_type`, populate DTO с fallback |
| `Marketplace/Infrastructure/Query/UnprocessedCostsQuery.php` | `is_storno` → CASE WHEN fallback |
| `Marketplace/Infrastructure/Query/CostReconciliationQuery.php` | `costs_amount`/`storno_amount` → fallback |
| `Marketplace/Infrastructure/Query/CostsVerifyQuery.php` | 3 места → fallback |
| `Marketplace/Infrastructure/Query/PreflightCostsQuery.php` | `getCostsCategoryBreakdown` → fallback |
| `Marketplace/Infrastructure/Query/ListingCostAggregateQuery.php` | `executeByPeriod` → fallback |
| `MarketplaceAnalytics/Domain/Service/SnapshotCalculationPolicy.php` | docblock + TODO Phase 2B |

## Test plan

- [ ] Проверить unprocessed costs список — `is_storno` корректно определяется для Ozon (operation_type) и WB (знак amount)
- [ ] Проверить cost reconciliation — costs_amount/storno_amount соответствуют ожидаемым суммам
- [ ] Проверить preflight costs breakdown по категориям
- [ ] Проверить listing cost aggregate за период
- [ ] Проверить snapshot calculation — `normalizeAmountForCostBreakdown` без регрессий

https://claude.ai/code/session_016tmbbfU5JzBS9EsVgGFr6b