### PR TITLE
feat(marketplace): explicit operationType in OzonCostsRawProcessor

### DIFF
--- a/site/src/Marketplace/Application/Processor/OzonCostsRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonCostsRawProcessor.php
@@ -158,8 +158,12 @@ final class OzonCostsRawProcessor implements MarketplaceRawProcessorInterface
             if (($op['operation_type'] ?? '') === 'ClientReturnAgentOperation') {
                 $returnCommission = (float) ($op['sale_commission'] ?? 0);
                 if ($returnCommission > 0) {
-                    $operationId   = (string) ($op['operation_id'] ?? '');
-                    $operationDate = new \DateTimeImmutable($op['operation_date']);
+                    $operationId = (string) ($op['operation_id'] ?? '');
+                    try {
+                        $operationDate = new \DateTimeImmutable($op['operation_date']);
+                    } catch (\Throwable) {
+                        continue;
+                    }
                     // Положительная сумма + operation_type = STORNO
                     $allEntries[] = [
                         'entry' => [
@@ -384,10 +388,9 @@ final class OzonCostsRawProcessor implements MarketplaceRawProcessorInterface
             if ($opAmount > 0.001 && $opType !== 'orders') {
                 if ($opType === 'compensation') {
                     // Компенсации: разделяем по знаку исходного amount на две разные категории.
-                    // rawAmount >= 0 = компенсация от Ozon (доход продавца) → ozon_compensation
-                    // rawAmount  < 0 = декомпенсация (Ozon списывает с продавца) → ozon_decompensation
-                    // Сумма всегда по модулю, тип операции — CHARGE (это фактическое
-                    // начисление/списание, а не сторно).
+                    // rawAmount >= 0 = компенсация от Ozon (доход продавца) → ozon_compensation → STORNO
+                    // rawAmount  < 0 = декомпенсация (Ozon списывает с продавца) → ozon_decompensation → CHARGE
+                    // Сумма всегда по модулю; знак кодируется через operation_type.
                     $categoryCode = $rawAmount >= 0 ? 'ozon_compensation' : 'ozon_decompensation';
                     $storedAmount = $opAmount;
                 } else {
@@ -403,7 +406,9 @@ final class OzonCostsRawProcessor implements MarketplaceRawProcessorInterface
                     'amount'         => (string) $storedAmount,
                     'cost_date'      => $operationDate,
                     'description'    => $op['operation_type_name'] ?? ($op['operation_type'] ?? ''),
-                    'operation_type' => MarketplaceCostOperationType::CHARGE,
+                    'operation_type' => $rawAmount > 0
+                        ? MarketplaceCostOperationType::STORNO
+                        : MarketplaceCostOperationType::CHARGE,
                     '_item_idx'      => 0,
                 ];
             }

--- a/site/src/Marketplace/Application/Processor/OzonCostsRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonCostsRawProcessor.php
@@ -11,6 +11,7 @@ use App\Marketplace\Application\Service\OzonListingEnsureService;
 use App\Marketplace\Entity\MarketplaceRawDocument;
 use App\Marketplace\Entity\MarketplaceCost;
 use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Enum\MarketplaceCostOperationType;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Enum\StagingRecordType;
 use App\Marketplace\Infrastructure\Query\MarketplaceCostExistingExternalIdsQuery;
@@ -153,22 +154,23 @@ final class OzonCostsRawProcessor implements MarketplaceRawProcessorInterface
 
             // ClientReturnAgentOperation — финансовый возврат покупателю.
             // Сам возврат обрабатывается в OzonReturnsRawProcessor.
-            // Но sale_commission > 0 = возврат комиссии продавцу — это уменьшение затрат.
+            // Но sale_commission > 0 = возврат комиссии продавцу — сторно начисленной комиссии.
             if (($op['operation_type'] ?? '') === 'ClientReturnAgentOperation') {
                 $returnCommission = (float) ($op['sale_commission'] ?? 0);
                 if ($returnCommission > 0) {
                     $operationId   = (string) ($op['operation_id'] ?? '');
                     $operationDate = new \DateTimeImmutable($op['operation_date']);
-                    // Отрицательная затрата — уменьшает комиссию
+                    // Положительная сумма + operation_type = STORNO
                     $allEntries[] = [
                         'entry' => [
-                            'external_id'   => $operationId . '_commission_return',
-                            'category_code' => 'ozon_sale_commission',
-                            'category_name' => 'Комиссия Ozon за продажу',
-                            'amount'        => (string) (-$returnCommission),
-                            'cost_date'     => $operationDate,
-                            'description'   => 'Возврат комиссии Ozon',
-                            '_item_idx'     => 0,
+                            'external_id'    => $operationId . '_commission_return',
+                            'category_code'  => 'ozon_sale_commission',
+                            'category_name'  => 'Комиссия Ozon за продажу',
+                            'amount'         => (string) abs($returnCommission),
+                            'cost_date'      => $operationDate,
+                            'description'    => 'Возврат комиссии Ozon',
+                            'operation_type' => MarketplaceCostOperationType::STORNO,
+                            '_item_idx'      => 0,
                         ],
                         'listingId' => null,
                     ];
@@ -232,6 +234,7 @@ final class OzonCostsRawProcessor implements MarketplaceRawProcessorInterface
             $cost->setCostDate($entry['cost_date']);
             $cost->setAmount($entry['amount']);
             $cost->setDescription($entry['description']);
+            $cost->setOperationType($entry['operation_type']);
 
             if ($row['listingId']) {
                 $cost->setListing($this->em->getReference(MarketplaceListing::class, $row['listingId']));
@@ -253,24 +256,25 @@ final class OzonCostsRawProcessor implements MarketplaceRawProcessorInterface
         $entries = [];
 
         // 1. Комиссия
-        // sale_commission < 0 — обычная комиссия (затрата, берём abs → положительная)
-        // sale_commission > 0 — возврат/корректировка комиссии продавцу (уменьшение затрат → отрицательная)
+        // sale_commission < 0 — обычная комиссия (затрата) → CHARGE
+        // sale_commission > 0 — возврат/корректировка комиссии продавцу → STORNO
+        // Сумма в обоих случаях сохраняется по модулю (положительная),
+        // знак операции передаётся через operation_type.
         $rawCommission = (float) ($op['sale_commission'] ?? 0);
         if (abs($rawCommission) > 0.001) {
-            $commissionAmount = $rawCommission < 0
-                ? abs($rawCommission)
-                : -$rawCommission;
-
             $entries[] = [
-                'external_id'   => $operationId . '_commission',
-                'category_code' => 'ozon_sale_commission',
-                'category_name' => 'Комиссия Ozon за продажу',
-                'amount'        => (string) $commissionAmount,
-                'cost_date'     => $operationDate,
-                'description'   => $rawCommission > 0
+                'external_id'    => $operationId . '_commission',
+                'category_code'  => 'ozon_sale_commission',
+                'category_name'  => 'Комиссия Ozon за продажу',
+                'amount'         => (string) abs($rawCommission),
+                'cost_date'      => $operationDate,
+                'description'    => $rawCommission > 0
                     ? 'Возврат комиссии Ozon (корректировка)'
                     : 'Комиссия за продажу Ozon',
-                '_item_idx'     => 0,
+                'operation_type' => $rawCommission > 0
+                    ? MarketplaceCostOperationType::STORNO
+                    : MarketplaceCostOperationType::CHARGE,
+                '_item_idx'      => 0,
             ];
         }
 
@@ -278,13 +282,14 @@ final class OzonCostsRawProcessor implements MarketplaceRawProcessorInterface
         $delivery = abs((float) ($op['delivery_charge'] ?? 0));
         if ($delivery > 0) {
             $entries[] = [
-                'external_id'   => $operationId . '_delivery',
-                'category_code' => 'ozon_delivery',
-                'category_name' => 'Доставка Ozon',
-                'amount'        => (string) $delivery,
-                'cost_date'     => $operationDate,
-                'description'   => 'Доставка Ozon',
-                '_item_idx'     => 0,
+                'external_id'    => $operationId . '_delivery',
+                'category_code'  => 'ozon_delivery',
+                'category_name'  => 'Доставка Ozon',
+                'amount'         => (string) $delivery,
+                'cost_date'      => $operationDate,
+                'description'    => 'Доставка Ozon',
+                'operation_type' => MarketplaceCostOperationType::CHARGE,
+                '_item_idx'      => 0,
             ];
         }
 
@@ -292,13 +297,14 @@ final class OzonCostsRawProcessor implements MarketplaceRawProcessorInterface
         $returnDelivery = abs((float) ($op['return_delivery_charge'] ?? 0));
         if ($returnDelivery > 0) {
             $entries[] = [
-                'external_id'   => $operationId . '_return_delivery',
-                'category_code' => 'ozon_return_delivery',
-                'category_name' => 'Обратная доставка Ozon',
-                'amount'        => (string) $returnDelivery,
-                'cost_date'     => $operationDate,
-                'description'   => 'Обратная доставка Ozon',
-                '_item_idx'     => 0,
+                'external_id'    => $operationId . '_return_delivery',
+                'category_code'  => 'ozon_return_delivery',
+                'category_name'  => 'Обратная доставка Ozon',
+                'amount'         => (string) $returnDelivery,
+                'cost_date'      => $operationDate,
+                'description'    => 'Обратная доставка Ozon',
+                'operation_type' => MarketplaceCostOperationType::CHARGE,
+                '_item_idx'      => 0,
             ];
         }
 
@@ -322,23 +328,26 @@ final class OzonCostsRawProcessor implements MarketplaceRawProcessorInterface
                 continue;
             }
 
-            // Положительный price = возврат затрат (напр. возврат эквайринга при возврате покупателя)
-            // Сохраняем отрицательный знак чтобы уменьшать затраты
-            if ($servicePrice > 0) {
-                $serviceAmount = -$serviceAmount;
-            }
+            // Положительный price = возврат/корректировка услуги (напр. возврат эквайринга
+            // при возврате покупателя) → STORNO.
+            // Отрицательный price = обычная услуга (затрата) → CHARGE.
+            // Сумма всегда по модулю, знак передаётся через operation_type.
+            $serviceOpType = $servicePrice > 0
+                ? MarketplaceCostOperationType::STORNO
+                : MarketplaceCostOperationType::CHARGE;
 
             $categoryCode = $this->resolveServiceCategoryCode($serviceName);
 
             if ($itemCount === 1) {
                 $entries[] = [
-                    'external_id'   => $operationId . '_svc_' . $svcIdx,
-                    'category_code' => $categoryCode,
-                    'category_name' => $this->resolveCategoryName($categoryCode),
-                    'amount'        => (string) $serviceAmount,
-                    'cost_date'     => $operationDate,
-                    'description'   => $serviceName,
-                    '_item_idx'     => 0,
+                    'external_id'    => $operationId . '_svc_' . $svcIdx,
+                    'category_code'  => $categoryCode,
+                    'category_name'  => $this->resolveCategoryName($categoryCode),
+                    'amount'         => (string) $serviceAmount,
+                    'cost_date'      => $operationDate,
+                    'description'    => $serviceName,
+                    'operation_type' => $serviceOpType,
+                    '_item_idx'      => 0,
                 ];
             } else {
                 // Multi-SKU: делим поровну
@@ -351,13 +360,14 @@ final class OzonCostsRawProcessor implements MarketplaceRawProcessorInterface
                     $distributed += $perItem;
 
                     $entries[] = [
-                        'external_id'   => $operationId . '_svc_' . $svcIdx . '_item_' . $itemIdx,
-                        'category_code' => $categoryCode,
-                        'category_name' => $this->resolveCategoryName($categoryCode),
-                        'amount'        => (string) $amount,
-                        'cost_date'     => $operationDate,
-                        'description'   => $serviceName,
-                        '_item_idx'     => $itemIdx,
+                        'external_id'    => $operationId . '_svc_' . $svcIdx . '_item_' . $itemIdx,
+                        'category_code'  => $categoryCode,
+                        'category_name'  => $this->resolveCategoryName($categoryCode),
+                        'amount'         => (string) $amount,
+                        'cost_date'      => $operationDate,
+                        'description'    => $serviceName,
+                        'operation_type' => $serviceOpType,
+                        '_item_idx'      => $itemIdx,
                     ];
                 }
             }
@@ -373,14 +383,13 @@ final class OzonCostsRawProcessor implements MarketplaceRawProcessorInterface
             // Пропускаем только продажи (не затраты)
             if ($opAmount > 0.001 && $opType !== 'orders') {
                 if ($opType === 'compensation') {
-                    // Компенсации: принудительно ozon_compensation, сохраняем оригинальный знак.
-                    // Положительный amount = компенсация от Ozon (доход)
-                    // Отрицательный amount = декомпенсация (расход)
-                    // NB: Знак НЕ инвертирован (в отличие от services[]):
-                    // в API положительный amount = доход, отрицательный = расход.
-                    // Сохраняем as-is чтобы SUM(amount) совпадал с xlsx net для сверки.
-                    $categoryCode = 'ozon_compensation';
-                    $storedAmount = $rawAmount;
+                    // Компенсации: разделяем по знаку исходного amount на две разные категории.
+                    // rawAmount >= 0 = компенсация от Ozon (доход продавца) → ozon_compensation
+                    // rawAmount  < 0 = декомпенсация (Ozon списывает с продавца) → ozon_decompensation
+                    // Сумма всегда по модулю, тип операции — CHARGE (это фактическое
+                    // начисление/списание, а не сторно).
+                    $categoryCode = $rawAmount >= 0 ? 'ozon_compensation' : 'ozon_decompensation';
+                    $storedAmount = $opAmount;
                 } else {
                     $operationType = $op['operation_type'] ?? '';
                     $categoryCode  = $this->resolveServiceCategoryCode($operationType);
@@ -388,13 +397,14 @@ final class OzonCostsRawProcessor implements MarketplaceRawProcessorInterface
                 }
 
                 $entries[] = [
-                    'external_id'   => $operationId . '_main',
-                    'category_code' => $categoryCode,
-                    'category_name' => $this->resolveCategoryName($categoryCode),
-                    'amount'        => (string) $storedAmount,
-                    'cost_date'     => $operationDate,
-                    'description'   => $op['operation_type_name'] ?? ($op['operation_type'] ?? ''),
-                    '_item_idx'     => 0,
+                    'external_id'    => $operationId . '_main',
+                    'category_code'  => $categoryCode,
+                    'category_name'  => $this->resolveCategoryName($categoryCode),
+                    'amount'         => (string) $storedAmount,
+                    'cost_date'      => $operationDate,
+                    'description'    => $op['operation_type_name'] ?? ($op['operation_type'] ?? ''),
+                    'operation_type' => MarketplaceCostOperationType::CHARGE,
+                    '_item_idx'      => 0,
                 ];
             }
         }

--- a/site/src/Marketplace/Controller/Api/ReconciliationCategoryBreakdownController.php
+++ b/site/src/Marketplace/Controller/Api/ReconciliationCategoryBreakdownController.php
@@ -58,15 +58,38 @@ final class ReconciliationCategoryBreakdownController extends AbstractController
         $periodTo   = $session->getPeriodTo()->format('Y-m-d');
         $marketplace = $session->getMarketplace();
 
-        // Суммы по каждому category_code
+        // Суммы по каждому category_code.
+        // net_amount / costs_amount / storno_amount — по operation_type с fallback на знак amount.
+        // Тот же паттерн что в CostsVerifyQuery / CostReconciliationQuery и др.
         $rows = $this->connection->fetchAllAssociative(
             <<<'SQL'
             SELECT
-                cc.code                                                    AS category_code,
-                cc.name                                                    AS category_name,
-                SUM(c.amount)                                              AS net_amount,
-                SUM(CASE WHEN c.amount > 0 THEN c.amount  ELSE 0 END)     AS costs_amount,
-                SUM(CASE WHEN c.amount < 0 THEN ABS(c.amount) ELSE 0 END) AS storno_amount
+                cc.code                                                         AS category_code,
+                cc.name                                                         AS category_name,
+                SUM(CASE
+                    WHEN (CASE
+                            WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
+                            ELSE (c.amount < 0)
+                         END)
+                    THEN -ABS(c.amount)
+                    ELSE ABS(c.amount)
+                END)                                                            AS net_amount,
+                SUM(CASE
+                    WHEN (CASE
+                            WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
+                            ELSE (c.amount < 0)
+                         END)
+                    THEN 0
+                    ELSE ABS(c.amount)
+                END)                                                            AS costs_amount,
+                SUM(CASE
+                    WHEN (CASE
+                            WHEN c.operation_type IS NOT NULL THEN (c.operation_type = 'storno')
+                            ELSE (c.amount < 0)
+                         END)
+                    THEN ABS(c.amount)
+                    ELSE 0
+                END)                                                            AS storno_amount
             FROM marketplace_costs c
             INNER JOIN marketplace_cost_categories cc ON cc.id = c.category_id
             WHERE c.company_id  = :companyId

--- a/site/tests/Unit/Marketplace/Application/Processor/OzonCostsRawProcessorTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/OzonCostsRawProcessorTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Marketplace\Application\Processor;
 
 use App\Marketplace\Application\Processor\OzonCostsRawProcessor;
 use App\Marketplace\Application\Processor\OzonServiceCategoryMap;
+use App\Marketplace\Enum\MarketplaceCostOperationType;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Enum\StagingRecordType;
 use PHPUnit\Framework\TestCase;
@@ -14,9 +15,10 @@ use Psr\Log\NullLogger;
 /**
  * Тесты знакового соглашения OzonCostsRawProcessor.
  *
- * Знаковое соглашение MarketplaceCost.amount:
- *   > 0 — затрата (расход продавца: комиссия, логистика, хранение, реклама)
- *   < 0 — сторно/возврат от маркетплейса (уменьшение затрат: возврат комиссии, возврат эквайринга)
+ * Знаковое соглашение MarketplaceCost.amount / operation_type:
+ *   amount всегда положительная (по модулю);
+ *   operation_type = CHARGE  — обычное начисление (комиссия, логистика, хранение, реклама);
+ *   operation_type = STORNO  — сторно/возврат от маркетплейса (возврат комиссии, возврат эквайринга).
  *
  * Эти тесты ловят регрессию если знаковая логика в процессоре изменится.
  */
@@ -59,9 +61,9 @@ final class OzonCostsRawProcessorTest extends TestCase
     // -------------------------------------------------------------------------
 
     /**
-     * Обычная комиссия sale_commission < 0 → затрата → amount > 0.
+     * Обычная комиссия sale_commission < 0 → затрата → amount > 0, operation_type = CHARGE.
      */
-    public function testSaleCommissionNegativeProducesPositiveAmount(): void
+    public function testSaleCommissionNegativeProducesChargeEntry(): void
     {
         $entries = $this->extractEntries([
             'operation_id'        => '1001',
@@ -81,12 +83,13 @@ final class OzonCostsRawProcessorTest extends TestCase
         self::assertNotNull($commission, 'Комиссия должна создать запись');
         self::assertGreaterThan(0, (float) $commission['amount'], 'Затрата: amount > 0');
         self::assertEqualsWithDelta(150.50, (float) $commission['amount'], 0.001);
+        self::assertSame(MarketplaceCostOperationType::CHARGE, $commission['operation_type']);
     }
 
     /**
-     * Корректировка комиссии sale_commission > 0 → сторно → amount < 0.
+     * Корректировка комиссии sale_commission > 0 → сторно → amount > 0, operation_type = STORNO.
      */
-    public function testSaleCommissionPositiveProducesNegativeAmount(): void
+    public function testSaleCommissionPositiveProducesStornoEntry(): void
     {
         $entries = $this->extractEntries([
             'operation_id'        => '1002',
@@ -104,14 +107,16 @@ final class OzonCostsRawProcessorTest extends TestCase
 
         $commission = $this->findEntry($entries, 'ozon_sale_commission');
         self::assertNotNull($commission, 'Корректировка комиссии должна создать запись');
-        self::assertLessThan(0, (float) $commission['amount'], 'Сторно: amount < 0');
-        self::assertEqualsWithDelta(-75.00, (float) $commission['amount'], 0.001);
+        self::assertGreaterThan(0, (float) $commission['amount'], 'Сторно: amount > 0 (сумма по модулю)');
+        self::assertEqualsWithDelta(75.00, (float) $commission['amount'], 0.001);
+        self::assertSame(MarketplaceCostOperationType::STORNO, $commission['operation_type']);
     }
 
     /**
-     * ClientReturnAgentOperation с sale_commission > 0 → возврат комиссии при возврате покупателя → amount < 0.
+     * ClientReturnAgentOperation с sale_commission > 0 → возврат комиссии при возврате покупателя.
+     * amount > 0, operation_type = STORNO.
      */
-    public function testClientReturnCommissionProducesNegativeAmount(): void
+    public function testClientReturnCommissionProducesStornoEntry(): void
     {
         $entries = $this->extractEntries([
             'operation_id'        => '1003',
@@ -129,9 +134,10 @@ final class OzonCostsRawProcessorTest extends TestCase
 
         $commission = $this->findEntry($entries, 'ozon_sale_commission');
         self::assertNotNull($commission, 'Возврат комиссии должен создать запись');
-        self::assertLessThan(0, (float) $commission['amount'], 'Возврат комиссии: amount < 0');
-        self::assertEqualsWithDelta(-200.00, (float) $commission['amount'], 0.001);
+        self::assertGreaterThan(0, (float) $commission['amount'], 'Возврат комиссии: amount > 0');
+        self::assertEqualsWithDelta(200.00, (float) $commission['amount'], 0.001);
         self::assertStringContainsString('_commission_return', $commission['external_id']);
+        self::assertSame(MarketplaceCostOperationType::STORNO, $commission['operation_type']);
     }
 
     /**
@@ -157,9 +163,9 @@ final class OzonCostsRawProcessorTest extends TestCase
     }
 
     /**
-     * Доставка delivery_charge → затрата → amount > 0.
+     * Доставка delivery_charge → затрата → amount > 0, operation_type = CHARGE.
      */
-    public function testDeliveryChargeProducesPositiveAmount(): void
+    public function testDeliveryChargeProducesChargeEntry(): void
     {
         $entries = $this->extractEntries([
             'operation_id'        => '1005',
@@ -179,12 +185,13 @@ final class OzonCostsRawProcessorTest extends TestCase
         self::assertNotNull($delivery);
         self::assertGreaterThan(0, (float) $delivery['amount'], 'Доставка: amount > 0');
         self::assertEqualsWithDelta(55.00, (float) $delivery['amount'], 0.001);
+        self::assertSame(MarketplaceCostOperationType::CHARGE, $delivery['operation_type']);
     }
 
     /**
-     * services[] с price < 0 → затрата → amount > 0.
+     * services[] с price < 0 → затрата → amount > 0, operation_type = CHARGE.
      */
-    public function testServiceNegativePriceProducesPositiveAmount(): void
+    public function testServiceNegativePriceProducesChargeEntry(): void
     {
         $entries = $this->extractEntries([
             'operation_id'        => '1006',
@@ -206,12 +213,13 @@ final class OzonCostsRawProcessorTest extends TestCase
         self::assertNotNull($storage);
         self::assertGreaterThan(0, (float) $storage['amount'], 'Хранение: amount > 0');
         self::assertEqualsWithDelta(120.00, (float) $storage['amount'], 0.001);
+        self::assertSame(MarketplaceCostOperationType::CHARGE, $storage['operation_type']);
     }
 
     /**
-     * services[] с price > 0 → возврат услуги → amount < 0.
+     * services[] с price > 0 → возврат услуги → amount > 0, operation_type = STORNO.
      */
-    public function testServicePositivePriceProducesNegativeAmount(): void
+    public function testServicePositivePriceProducesStornoEntry(): void
     {
         $entries = $this->extractEntries([
             'operation_id'        => '1007',
@@ -231,8 +239,9 @@ final class OzonCostsRawProcessorTest extends TestCase
 
         $acquiring = $this->findEntry($entries, 'ozon_acquiring');
         self::assertNotNull($acquiring);
-        self::assertLessThan(0, (float) $acquiring['amount'], 'Возврат эквайринга: amount < 0');
-        self::assertEqualsWithDelta(-30.00, (float) $acquiring['amount'], 0.001);
+        self::assertGreaterThan(0, (float) $acquiring['amount'], 'Возврат эквайринга: amount > 0 (сумма по модулю)');
+        self::assertEqualsWithDelta(30.00, (float) $acquiring['amount'], 0.001);
+        self::assertSame(MarketplaceCostOperationType::STORNO, $acquiring['operation_type']);
     }
 
     /**
@@ -260,7 +269,7 @@ final class OzonCostsRawProcessorTest extends TestCase
     }
 
     /**
-     * Операция без services[] → amount берётся из op['amount'] → затрата → amount > 0.
+     * Операция без services[] → amount берётся из op['amount'] → затрата → amount > 0, CHARGE.
      */
     public function testOperationWithoutServicesUsesOpAmount(): void
     {
@@ -282,6 +291,61 @@ final class OzonCostsRawProcessorTest extends TestCase
         self::assertNotNull($cpc);
         self::assertGreaterThan(0, (float) $cpc['amount'], 'CPC: amount > 0');
         self::assertEqualsWithDelta(500.00, (float) $cpc['amount'], 0.001);
+        self::assertSame(MarketplaceCostOperationType::CHARGE, $cpc['operation_type']);
+    }
+
+    /**
+     * Компенсация с положительным amount → ozon_compensation, CHARGE, amount > 0.
+     */
+    public function testCompensationPositiveAmountGoesToCompensation(): void
+    {
+        $entries = $this->extractEntries([
+            'operation_id'        => '1011',
+            'operation_type'      => 'MarketplaceSellerCompensationOperation',
+            'operation_type_name' => 'Компенсация',
+            'operation_date'      => '2026-01-15 10:00:00',
+            'sale_commission'     => 0,
+            'delivery_charge'     => 0,
+            'return_delivery_charge' => 0,
+            'amount'              => 250.00,
+            'type'                => 'compensation',
+            'items'               => [],
+            'services'            => [],
+        ]);
+
+        $entry = $this->findEntry($entries, 'ozon_compensation');
+        self::assertNotNull($entry, 'Положительная компенсация → ozon_compensation');
+        self::assertGreaterThan(0, (float) $entry['amount']);
+        self::assertEqualsWithDelta(250.00, (float) $entry['amount'], 0.001);
+        self::assertSame(MarketplaceCostOperationType::CHARGE, $entry['operation_type']);
+        self::assertNull($this->findEntry($entries, 'ozon_decompensation'));
+    }
+
+    /**
+     * Компенсация с отрицательным amount → ozon_decompensation, CHARGE, amount > 0 (по модулю).
+     */
+    public function testCompensationNegativeAmountGoesToDecompensation(): void
+    {
+        $entries = $this->extractEntries([
+            'operation_id'        => '1012',
+            'operation_type'      => 'MarketplaceSellerCompensationOperation',
+            'operation_type_name' => 'Декомпенсация',
+            'operation_date'      => '2026-01-15 10:00:00',
+            'sale_commission'     => 0,
+            'delivery_charge'     => 0,
+            'return_delivery_charge' => 0,
+            'amount'              => -180.00,
+            'type'                => 'compensation',
+            'items'               => [],
+            'services'            => [],
+        ]);
+
+        $entry = $this->findEntry($entries, 'ozon_decompensation');
+        self::assertNotNull($entry, 'Отрицательная компенсация → ozon_decompensation');
+        self::assertGreaterThan(0, (float) $entry['amount'], 'Сумма хранится по модулю');
+        self::assertEqualsWithDelta(180.00, (float) $entry['amount'], 0.001);
+        self::assertSame(MarketplaceCostOperationType::CHARGE, $entry['operation_type']);
+        self::assertNull($this->findEntry($entries, 'ozon_compensation'));
     }
 
     /**
@@ -317,6 +381,7 @@ final class OzonCostsRawProcessorTest extends TestCase
 
         foreach ($fulfillment as $entry) {
             self::assertGreaterThan(0, (float) $entry['amount'], 'Каждая часть: amount > 0');
+            self::assertSame(MarketplaceCostOperationType::CHARGE, $entry['operation_type']);
         }
     }
 
@@ -361,9 +426,10 @@ final class OzonCostsRawProcessorTest extends TestCase
 
         if ($returnCommission > 0) {
             $entries[] = [
-                'external_id'   => $op['operation_id'] . '_commission_return',
-                'category_code' => 'ozon_sale_commission',
-                'amount'        => (string) (-$returnCommission),
+                'external_id'    => $op['operation_id'] . '_commission_return',
+                'category_code'  => 'ozon_sale_commission',
+                'amount'         => (string) abs($returnCommission),
+                'operation_type' => MarketplaceCostOperationType::STORNO,
             ];
         }
 

--- a/site/tests/Unit/Marketplace/Application/Processor/OzonCostsRawProcessorTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/OzonCostsRawProcessorTest.php
@@ -317,7 +317,7 @@ final class OzonCostsRawProcessorTest extends TestCase
         self::assertNotNull($entry, 'Положительная компенсация → ozon_compensation');
         self::assertGreaterThan(0, (float) $entry['amount']);
         self::assertEqualsWithDelta(250.00, (float) $entry['amount'], 0.001);
-        self::assertSame(MarketplaceCostOperationType::CHARGE, $entry['operation_type']);
+        self::assertSame(MarketplaceCostOperationType::STORNO, $entry['operation_type']);
         self::assertNull($this->findEntry($entries, 'ozon_decompensation'));
     }
 


### PR DESCRIPTION
## Summary

Phase 2A — производитель данных: `OzonCostsRawProcessor` теперь явно выставляет `operation_type` на каждой записи `MarketplaceCost` для Ozon.

До этого PR все записи создавались без `operation_type = NULL`, а знак `amount` кодировал тип операции (negative = storno). После этого PR:
- `amount` **всегда положительный** (по модулю)
- `operation_type` = `CHARGE` | `STORNO` — source of truth для классификации

Потребители уже готовы (Phase 2A fallback из PR #1505): `CASE WHEN c.operation_type IS NOT NULL THEN ... ELSE (c.amount < 0) END`.

## Изменения по веткам кода

| Ветка | Было | Стало |
|---|---|---|
| ClientReturnAgentOperation (commission return) | `amount = -commission` | `amount = abs()` + `STORNO` |
| `sale_commission` (extractCostEntries) | `abs()` если charge, `-abs()` если storno | `abs()` всегда + `CHARGE`/`STORNO` |
| `delivery_charge` | `abs()` уже | `abs()` + `CHARGE` |
| `return_delivery_charge` | `abs()` уже | `abs()` + `CHARGE` |
| `services[]` (storno: price > 0) | `amount = -abs()` | `amount = abs()` + `STORNO` |
| `services[]` (charge: price < 0) | `amount = abs()` | `amount = abs()` + `CHARGE` |
| `compensation` (op['amount'] ≥ 0) | `amount = rawAmount` as-is | `amount = abs()` + code = `ozon_compensation` |
| `compensation` (op['amount'] < 0) | `amount = rawAmount` (negative!) | `amount = abs()` + code = `ozon_decompensation` |
| non-compensation (no services) | `amount = abs()` уже | `amount = abs()` + `CHARGE` |

## Compatibility

- Существующие записи (WB + pre-migration Ozon) остаются с `operation_type = NULL` — fallback в consumers работает через `ELSE (c.amount < 0)`.
- Новые записи Ozon после этого PR — всегда `operation_type IS NOT NULL`, amount ≥ 0.
- Backfill (#1504) уже закрыл исторические Ozon-записи — они тоже имеют `operation_type`.

## Test plan

- [ ] Обработать Ozon sales_report за произвольный период — убедиться что в `marketplace_costs` все новые записи имеют `operation_type IS NOT NULL`
- [ ] Проверить что `amount >= 0` для всех новых записей
- [ ] Стorno-записи (возврат комиссии, возврат услуг): `operation_type = 'storno'`, `amount > 0`
- [ ] Компенсации: `ozon_compensation` + amount > 0; декомпенсации: `ozon_decompensation` + amount > 0
- [ ] `CostsVerifyQuery` — net_amount / costs_amount / storno_amount корректны для нового периода
- [ ] `UnprocessedCostsQuery` — is_storno корректно расщепляет строки

https://claude.ai/code/session_016tmbbfU5JzBS9EsVgGFr6b