### PR TITLE
refactor(marketplace-analytics): sticky header + frozen name column in UnitEconomicsTable

### DIFF
--- a/site/assets/react/marketplace-analytics/components/UnitEconomicsTable.tsx
+++ b/site/assets/react/marketplace-analytics/components/UnitEconomicsTable.tsx
@@ -7,100 +7,232 @@ interface UnitEconomicsTableProps {
     isLoading: boolean;
 }
 
+function toNum(v: string | number | null | undefined): number {
+    if (v === null || v === undefined) return 0;
+    return typeof v === 'string' ? parseFloat(v) : v;
+}
+
+function sumCosts(row: UnitEconomicsRow): number {
+    return (
+        toNum(row.commission)
+        + toNum(row.logistics_to)
+        + toNum(row.logistics_back)
+        + toNum(row.storage)
+        + toNum(row.advertising_cpc)
+        + toNum(row.advertising_other)
+        + toNum(row.advertising_external)
+        + toNum(row.acquiring)
+        + toNum(row.penalties)
+        + toNum(row.acceptance)
+        + toNum(row.other_costs)
+    );
+}
+
+function calcTotalCosts(row: UnitEconomicsRow): number | null {
+    if (row.total_cost_price === null) return null;
+    return toNum(row.total_cost_price) + sumCosts(row);
+}
+
 function calcProfit(row: UnitEconomicsRow): number | null {
     if (row.total_cost_price === null) return null;
+    return toNum(row.revenue) - toNum(row.refunds) - (calcTotalCosts(row) ?? 0);
+}
 
-    return (
-        parseFloat(row.revenue)
-        - parseFloat(row.refunds)
-        - parseFloat(row.total_cost_price)
-        - parseFloat(row.logistics_to)
-        - parseFloat(row.logistics_back)
-        - parseFloat(row.storage)
-        - parseFloat(row.advertising_cpc)
-        - parseFloat(row.advertising_other)
-        - parseFloat(row.advertising_external)
-        - parseFloat(row.commission)
-        - parseFloat(row.acquiring)
-        - parseFloat(row.penalties)
-        - parseFloat(row.acceptance)
-        - parseFloat(row.other_costs)
-    );
+function calcMarginPercent(row: UnitEconomicsRow): number | null {
+    const profit = calcProfit(row);
+    if (profit === null) return null;
+    const revenue = toNum(row.revenue);
+    if (revenue <= 0) return null;
+    return (profit / revenue) * 100;
+}
+
+function marginClass(m: number | null): string {
+    if (m === null) return 'text-secondary';
+    if (m >= 30) return 'text-green fw-medium';
+    if (m >= 15) return 'text-azure fw-medium';
+    if (m >= 5) return 'text-orange fw-medium';
+    return 'text-red fw-medium';
+}
+
+function profitClass(p: number | null): string {
+    if (p === null) return 'text-warning';
+    return p >= 0 ? 'text-green fw-medium' : 'text-red fw-medium';
+}
+
+function formatPercent(v: number | null): string {
+    if (v === null) return '\u2014';
+    return `${v.toFixed(1)}%`;
 }
 
 interface Totals {
     revenue: number;
     refunds: number;
+    sales_quantity: number;
+    returns_quantity: number;
     total_cost_price: number | null;
     commission: number;
-    logistics: number;
+    logistics_to: number;
+    logistics_back: number;
     storage: number;
-    advertising: number;
-    acquiring: number;
-    acceptance: number;
-    penalties: number;
+    advertising_cpc: number;
     other_costs: number;
+    total_costs: number | null;
     profit: number | null;
+    margin: number | null;
 }
 
 function calcTotals(items: UnitEconomicsRow[]): Totals {
-    let hasMissingData = false;
+    let hasMissingCost = false;
     let costSum = 0;
 
-    let revenue = 0;
-    let refunds = 0;
-    let commission = 0;
-    let logistics = 0;
-    let storage = 0;
-    let advertising = 0;
-    let acquiring = 0;
-    let acceptance = 0;
-    let penalties = 0;
-    let other_costs = 0;
+    const acc = {
+        revenue: 0,
+        refunds: 0,
+        sales_quantity: 0,
+        returns_quantity: 0,
+        commission: 0,
+        logistics_to: 0,
+        logistics_back: 0,
+        storage: 0,
+        advertising_cpc: 0,
+        advertising_other: 0,
+        advertising_external: 0,
+        acquiring: 0,
+        penalties: 0,
+        acceptance: 0,
+        other_costs: 0,
+    };
 
     for (const row of items) {
-        revenue += parseFloat(row.revenue);
-        refunds += parseFloat(row.refunds);
-        commission += parseFloat(row.commission);
-        logistics += parseFloat(row.logistics_to) + parseFloat(row.logistics_back);
-        storage += parseFloat(row.storage);
-        advertising += parseFloat(row.advertising_cpc) + parseFloat(row.advertising_other) + parseFloat(row.advertising_external);
-        acquiring += parseFloat(row.acquiring);
-        acceptance += parseFloat(row.acceptance);
-        penalties += parseFloat(row.penalties);
-        other_costs += parseFloat(row.other_costs);
+        acc.revenue += toNum(row.revenue);
+        acc.refunds += toNum(row.refunds);
+        acc.sales_quantity += row.sales_quantity;
+        acc.returns_quantity += row.returns_quantity;
+        acc.commission += toNum(row.commission);
+        acc.logistics_to += toNum(row.logistics_to);
+        acc.logistics_back += toNum(row.logistics_back);
+        acc.storage += toNum(row.storage);
+        acc.advertising_cpc += toNum(row.advertising_cpc);
+        acc.advertising_other += toNum(row.advertising_other);
+        acc.advertising_external += toNum(row.advertising_external);
+        acc.acquiring += toNum(row.acquiring);
+        acc.penalties += toNum(row.penalties);
+        acc.acceptance += toNum(row.acceptance);
+        acc.other_costs += toNum(row.other_costs);
 
         if (row.total_cost_price !== null) {
-            costSum += parseFloat(row.total_cost_price);
+            costSum += toNum(row.total_cost_price);
         } else {
-            hasMissingData = true;
+            hasMissingCost = true;
         }
     }
 
-    const profitSum = revenue - refunds - costSum - commission - logistics - storage - advertising - acquiring - acceptance - penalties - other_costs;
+    const allCostsSumWithoutCostPrice =
+        acc.commission + acc.logistics_to + acc.logistics_back + acc.storage
+        + acc.advertising_cpc + acc.advertising_other + acc.advertising_external
+        + acc.acquiring + acc.penalties + acc.acceptance + acc.other_costs;
+
+    const total_costs = hasMissingCost ? null : (costSum + allCostsSumWithoutCostPrice);
+    const profit = hasMissingCost ? null : (acc.revenue - acc.refunds - (total_costs ?? 0));
+    const margin = (profit !== null && acc.revenue > 0) ? (profit / acc.revenue) * 100 : null;
 
     return {
-        revenue,
-        refunds,
-        total_cost_price: hasMissingData ? null : costSum,
-        commission,
-        logistics,
-        storage,
-        advertising,
-        acquiring,
-        acceptance,
-        penalties,
-        other_costs,
-        profit: hasMissingData ? null : profitSum,
+        revenue: acc.revenue,
+        refunds: acc.refunds,
+        sales_quantity: acc.sales_quantity,
+        returns_quantity: acc.returns_quantity,
+        total_cost_price: hasMissingCost ? null : costSum,
+        commission: acc.commission,
+        logistics_to: acc.logistics_to,
+        logistics_back: acc.logistics_back,
+        storage: acc.storage,
+        advertising_cpc: acc.advertising_cpc,
+        other_costs: acc.other_costs,
+        total_costs,
+        profit,
+        margin,
     };
 }
 
-const stickyStyle: React.CSSProperties = {
-    position: 'sticky',
-    left: 0,
-    background: 'var(--tblr-bg-surface)',
-    zIndex: 1,
+// Ширины колонок (px). Порядок соответствует порядку колонок в thead/tbody/tfoot.
+const W = {
+    name: 240,
+    revenue: 130,
+    salesQty: 80,
+    trend: 100, // зарезервировано под спарклайн (см. §2.2 задачи)
+    returnsQty: 75,
+    refunds: 90,
+    costTotal: 120,
+    costUnit: 95,
+    commission: 115,
+    logisticsTo: 110,
+    logisticsBack: 110,
+    storage: 95,
+    advertisingCpc: 100,
+    otherCosts: 95,
+    totalCosts: 125,
+    profit: 120,
+    margin: 85,
+} as const;
+
+const numColStyle = (minWidth: number): React.CSSProperties => ({
+    minWidth,
+    textAlign: 'right',
+    fontVariantNumeric: 'tabular-nums',
+});
+
+const nameColStyle: React.CSSProperties = {
+    minWidth: W.name,
+    maxWidth: W.name,
 };
+
+// Inline-CSS для sticky/frozen. Pseudo-элементы и hover-состояния нельзя выразить через style=.
+const TABLE_STYLES = `
+.ue-scroll {
+    max-height: 70vh;
+    overflow: auto;
+    border: 1px solid var(--tblr-border-color, rgba(0,0,0,0.1));
+    border-radius: 4px;
+}
+.ue-table {
+    border-collapse: separate;
+    border-spacing: 0;
+    width: max-content;
+    min-width: 100%;
+    margin: 0;
+}
+.ue-table thead th {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    background: var(--tblr-bg-surface);
+}
+.ue-table td.ue-frozen,
+.ue-table th.ue-frozen {
+    position: sticky;
+    left: 0;
+    background: var(--tblr-bg-surface);
+}
+.ue-table td.ue-frozen { z-index: 1; }
+.ue-table thead th.ue-frozen { z-index: 3; }
+.ue-table tfoot td.ue-frozen { z-index: 1; }
+.ue-table .ue-frozen::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    right: -4px;
+    bottom: 0;
+    width: 4px;
+    background: linear-gradient(to right, rgba(0,0,0,0.08), transparent);
+    pointer-events: none;
+}
+.ue-table tbody tr:hover td {
+    background: var(--tblr-bg-surface-secondary, rgba(0,0,0,0.03));
+}
+.ue-table tbody tr:hover td.ue-frozen {
+    background: var(--tblr-bg-surface-secondary, rgba(0,0,0,0.03));
+}
+`;
 
 const UnitEconomicsTable: React.FC<UnitEconomicsTableProps> = ({ items, isLoading }) => {
     if (isLoading) {
@@ -117,7 +249,7 @@ const UnitEconomicsTable: React.FC<UnitEconomicsTableProps> = ({ items, isLoadin
         return (
             <div className="empty">
                 <div className="empty-img">
-                    <i className="ti ti-package text-muted fs-1"></i>
+                    <i className="ti ti-package text-muted fs-1" />
                 </div>
                 <p className="empty-title">Нет данных за выбранный период</p>
             </div>
@@ -126,100 +258,168 @@ const UnitEconomicsTable: React.FC<UnitEconomicsTableProps> = ({ items, isLoadin
 
     const totals = calcTotals(items);
 
-    return (
-        <div className="table-responsive">
-            <table className="table table-vcenter card-table">
-                <thead>
-                    <tr>
-                        <th style={stickyStyle}>Товар</th>
-                        <th className="text-end">Выручка</th>
-                        <th className="text-end">Возвраты</th>
-                        <th className="text-end">Себест. итого</th>
-                        <th className="text-end">Комиссия МП</th>
-                        <th className="text-end">Логистика</th>
-                        <th className="text-end">Хранение</th>
-                        <th className="text-end">Реклама</th>
-                        <th className="text-end">Эквайринг</th>
-                        <th className="text-end">Приёмка</th>
-                        <th className="text-end">Штрафы</th>
-                        <th className="text-end">Прочие</th>
-                        <th className="text-end">Прибыль</th>
-                        <th className="w-1"></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {items.map((row) => {
-                        const profit = calcProfit(row);
-                        const logistics = parseFloat(row.logistics_to) + parseFloat(row.logistics_back);
-                        const advertising = parseFloat(row.advertising_cpc) + parseFloat(row.advertising_other) + parseFloat(row.advertising_external);
+    // TODO(sort): на th добавить onClick и визуальный индикатор; состояние — в useUnitEconomics.
+    // TODO(expand): рядом с `tr` держать expandedRowId и рендерить drilldown-строку по клику.
 
-                        return (
-                            <tr key={row.listing_id}>
-                                <td style={stickyStyle}>
-                                    <div>{row.listing_name || '\u2014'}</div>
-                                    <div className="text-muted small">{row.marketplace_sku}</div>
-                                </td>
-                                <td className="text-end">{formatMoney(row.revenue)}</td>
-                                <td className="text-end text-red">{formatMoney(row.refunds)}</td>
-                                <td className="text-end">
-                                    {row.total_cost_price !== null
-                                        ? formatMoney(row.total_cost_price)
-                                        : <span className="badge bg-muted-lt text-muted">Нет данных</span>
-                                    }
-                                </td>
-                                <td className="text-end">{formatMoney(row.commission)}</td>
-                                <td className="text-end">{formatMoney(logistics)}</td>
-                                <td className="text-end">{formatMoney(row.storage)}</td>
-                                <td className="text-end">{formatMoney(advertising)}</td>
-                                <td className="text-end">{formatMoney(row.acquiring)}</td>
-                                <td className="text-end">{formatMoney(row.acceptance)}</td>
-                                <td className="text-end">{formatMoney(row.penalties)}</td>
-                                <td className="text-end">{formatMoney(row.other_costs)}</td>
-                                <td className="text-end">
-                                    {profit !== null
-                                        ? <span className={profit >= 0 ? 'text-green' : 'text-red'}>{formatMoney(profit)}</span>
-                                        : <span className="text-muted">{'\u2014'}</span>
-                                    }
-                                </td>
-                                <td>
-                                    {row.has_quality_issues && (
-                                        <i className="ti ti-alert-triangle text-warning"></i>
-                                    )}
-                                </td>
-                            </tr>
-                        );
-                    })}
-                </tbody>
-                <tfoot>
-                    <tr className="fw-bold">
-                        <td style={stickyStyle}>Итого</td>
-                        <td className="text-end">{formatMoney(totals.revenue)}</td>
-                        <td className="text-end text-red">{formatMoney(totals.refunds)}</td>
-                        <td className="text-end">
-                            {totals.total_cost_price !== null
-                                ? formatMoney(totals.total_cost_price)
-                                : <span className="text-muted">{'\u2014'}</span>
-                            }
-                        </td>
-                        <td className="text-end">{formatMoney(totals.commission)}</td>
-                        <td className="text-end">{formatMoney(totals.logistics)}</td>
-                        <td className="text-end">{formatMoney(totals.storage)}</td>
-                        <td className="text-end">{formatMoney(totals.advertising)}</td>
-                        <td className="text-end">{formatMoney(totals.acquiring)}</td>
-                        <td className="text-end">{formatMoney(totals.acceptance)}</td>
-                        <td className="text-end">{formatMoney(totals.penalties)}</td>
-                        <td className="text-end">{formatMoney(totals.other_costs)}</td>
-                        <td className="text-end">
-                            {totals.profit !== null
-                                ? <span className={totals.profit >= 0 ? 'text-green' : 'text-red'}>{formatMoney(totals.profit)}</span>
-                                : <span className="text-muted">{'\u2014'}</span>
-                            }
-                        </td>
-                        <td></td>
-                    </tr>
-                </tfoot>
-            </table>
-        </div>
+    return (
+        <>
+            <style>{TABLE_STYLES}</style>
+            <div className="ue-scroll">
+                <table className="table table-vcenter card-table ue-table">
+                    <thead>
+                        <tr>
+                            <th className="ue-frozen" style={nameColStyle}>Наименование</th>
+                            <th style={numColStyle(W.revenue)}>Выручка</th>
+                            <th style={numColStyle(W.salesQty)}>Кол-во продаж</th>
+                            <th style={numColStyle(W.trend)}>Тренд</th>
+                            <th style={numColStyle(W.returnsQty)}>Возвраты (шт)</th>
+                            <th style={numColStyle(W.refunds)}>Возвраты (₽)</th>
+                            <th style={numColStyle(W.costTotal)}>Себестоимость</th>
+                            <th style={numColStyle(W.costUnit)}>Себест. ед.</th>
+                            <th style={numColStyle(W.commission)}>Комиссия</th>
+                            <th style={numColStyle(W.logisticsTo)}>Логистика (туда)</th>
+                            <th style={numColStyle(W.logisticsBack)}>Логистика (обр.)</th>
+                            <th style={numColStyle(W.storage)}>Хранение</th>
+                            <th style={numColStyle(W.advertisingCpc)}>Реклама (CPC)</th>
+                            <th style={numColStyle(W.otherCosts)}>Прочие</th>
+                            <th style={numColStyle(W.totalCosts)}>Итого затрат</th>
+                            <th style={numColStyle(W.profit)}>Прибыль</th>
+                            <th style={numColStyle(W.margin)}>Маржа %</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {items.map((row) => {
+                            const totalCosts = calcTotalCosts(row);
+                            const profit = calcProfit(row);
+                            const margin = calcMarginPercent(row);
+                            const costMissing = row.total_cost_price === null;
+
+                            return (
+                                <tr key={row.listing_id}>
+                                    <td className="ue-frozen" style={nameColStyle}>
+                                        <div className="d-flex align-items-center gap-1">
+                                            <span className="text-truncate">
+                                                {row.listing_name || '\u2014'}
+                                            </span>
+                                            {row.has_quality_issues && (
+                                                <i
+                                                    className="ti ti-alert-triangle text-warning ms-1"
+                                                    title="Есть предупреждения о качестве данных"
+                                                />
+                                            )}
+                                        </div>
+                                        <div className="text-muted small text-truncate">
+                                            {row.marketplace_sku}
+                                        </div>
+                                    </td>
+
+                                    <td style={numColStyle(W.revenue)}>{formatMoney(row.revenue)}</td>
+                                    <td style={numColStyle(W.salesQty)}>{row.sales_quantity}</td>
+                                    <td style={numColStyle(W.trend)}>
+                                        <span className="text-secondary">{'\u2014'}</span>
+                                    </td>
+                                    <td style={numColStyle(W.returnsQty)}>
+                                        <span className={row.returns_quantity > 0 ? 'text-red' : 'text-secondary'}>
+                                            {row.returns_quantity}
+                                        </span>
+                                    </td>
+                                    <td style={numColStyle(W.refunds)}>
+                                        <span className={toNum(row.refunds) > 0 ? 'text-red' : 'text-secondary'}>
+                                            {formatMoney(row.refunds)}
+                                        </span>
+                                    </td>
+                                    <td style={numColStyle(W.costTotal)}>
+                                        {costMissing
+                                            ? (
+                                                <span
+                                                    className="text-warning"
+                                                    title="Себестоимость не заполнена для части дней"
+                                                >
+                                                    {'\u2014'}
+                                                </span>
+                                            )
+                                            : formatMoney(row.total_cost_price)}
+                                    </td>
+                                    <td style={numColStyle(W.costUnit)}>
+                                        {row.avg_cost_price === null
+                                            ? <span className="text-warning">{'\u2014'}</span>
+                                            : formatMoney(row.avg_cost_price)}
+                                    </td>
+                                    <td style={numColStyle(W.commission)}>{formatMoney(row.commission)}</td>
+                                    <td style={numColStyle(W.logisticsTo)}>{formatMoney(row.logistics_to)}</td>
+                                    <td style={numColStyle(W.logisticsBack)}>{formatMoney(row.logistics_back)}</td>
+                                    <td style={numColStyle(W.storage)}>{formatMoney(row.storage)}</td>
+                                    <td style={numColStyle(W.advertisingCpc)}>{formatMoney(row.advertising_cpc)}</td>
+                                    <td style={numColStyle(W.otherCosts)}>{formatMoney(row.other_costs)}</td>
+                                    <td style={numColStyle(W.totalCosts)}>
+                                        {totalCosts === null
+                                            ? <span className="text-warning" title="Нет данных о себестоимости">{'\u2014'}</span>
+                                            : formatMoney(totalCosts)}
+                                    </td>
+                                    <td style={numColStyle(W.profit)}>
+                                        <span className={profitClass(profit)}>
+                                            {profit === null ? '\u2014' : formatMoney(profit)}
+                                        </span>
+                                    </td>
+                                    <td style={numColStyle(W.margin)}>
+                                        <span className={marginClass(margin)}>
+                                            {formatPercent(margin)}
+                                        </span>
+                                    </td>
+                                </tr>
+                            );
+                        })}
+                    </tbody>
+                    <tfoot>
+                        <tr className="fw-bold">
+                            <td className="ue-frozen" style={nameColStyle}>Итого</td>
+                            <td style={numColStyle(W.revenue)}>{formatMoney(totals.revenue)}</td>
+                            <td style={numColStyle(W.salesQty)}>{totals.sales_quantity}</td>
+                            <td style={numColStyle(W.trend)}>
+                                <span className="text-secondary">{'\u2014'}</span>
+                            </td>
+                            <td style={numColStyle(W.returnsQty)}>
+                                <span className={totals.returns_quantity > 0 ? 'text-red' : 'text-secondary'}>
+                                    {totals.returns_quantity}
+                                </span>
+                            </td>
+                            <td style={numColStyle(W.refunds)}>
+                                <span className={totals.refunds > 0 ? 'text-red' : 'text-secondary'}>
+                                    {formatMoney(totals.refunds)}
+                                </span>
+                            </td>
+                            <td style={numColStyle(W.costTotal)}>
+                                {totals.total_cost_price === null
+                                    ? <span className="text-warning">{'\u2014'}</span>
+                                    : formatMoney(totals.total_cost_price)}
+                            </td>
+                            <td style={numColStyle(W.costUnit)}>{'\u2014'}</td>
+                            <td style={numColStyle(W.commission)}>{formatMoney(totals.commission)}</td>
+                            <td style={numColStyle(W.logisticsTo)}>{formatMoney(totals.logistics_to)}</td>
+                            <td style={numColStyle(W.logisticsBack)}>{formatMoney(totals.logistics_back)}</td>
+                            <td style={numColStyle(W.storage)}>{formatMoney(totals.storage)}</td>
+                            <td style={numColStyle(W.advertisingCpc)}>{formatMoney(totals.advertising_cpc)}</td>
+                            <td style={numColStyle(W.otherCosts)}>{formatMoney(totals.other_costs)}</td>
+                            <td style={numColStyle(W.totalCosts)}>
+                                {totals.total_costs === null
+                                    ? <span className="text-warning">{'\u2014'}</span>
+                                    : formatMoney(totals.total_costs)}
+                            </td>
+                            <td style={numColStyle(W.profit)}>
+                                <span className={profitClass(totals.profit)}>
+                                    {totals.profit === null ? '\u2014' : formatMoney(totals.profit)}
+                                </span>
+                            </td>
+                            <td style={numColStyle(W.margin)}>
+                                <span className={marginClass(totals.margin)}>
+                                    {formatPercent(totals.margin)}
+                                </span>
+                            </td>
+                        </tr>
+                    </tfoot>
+                </table>
+            </div>
+        </>
     );
 };
 

--- a/site/assets/react/marketplace-analytics/components/UnitEconomicsTable.tsx
+++ b/site/assets/react/marketplace-analytics/components/UnitEconomicsTable.tsx
@@ -106,8 +106,9 @@ function calcTotals(items: UnitEconomicsRow[]): Totals {
     for (const row of items) {
         acc.revenue += toNum(row.revenue);
         acc.refunds += toNum(row.refunds);
-        acc.sales_quantity += row.sales_quantity;
-        acc.returns_quantity += row.returns_quantity;
+        // DBAL отдаёт SUM(integer) как строку — без toNum() получим конкатенацию.
+        acc.sales_quantity += toNum(row.sales_quantity);
+        acc.returns_quantity += toNum(row.returns_quantity);
         acc.commission += toNum(row.commission);
         acc.logistics_to += toNum(row.logistics_to);
         acc.logistics_back += toNum(row.logistics_back);

--- a/site/assets/react/marketplace-analytics/components/UnitEconomicsTable.tsx
+++ b/site/assets/react/marketplace-analytics/components/UnitEconomicsTable.tsx
@@ -9,7 +9,23 @@ interface UnitEconomicsTableProps {
 
 function toNum(v: string | number | null | undefined): number {
     if (v === null || v === undefined) return 0;
-    return typeof v === 'string' ? parseFloat(v) : v;
+    const n = typeof v === 'string' ? parseFloat(v) : v;
+    return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * «Прочие» в таблице: `other_costs` плюс все статьи, у которых нет отдельной колонки.
+ * Нужно для того, чтобы сумма видимых колонок совпадала с «Итого затрат».
+ */
+function calcOtherCostsDisplay(row: UnitEconomicsRow): number {
+    return (
+        toNum(row.other_costs)
+        + toNum(row.advertising_other)
+        + toNum(row.advertising_external)
+        + toNum(row.acquiring)
+        + toNum(row.penalties)
+        + toNum(row.acceptance)
+    );
 }
 
 function sumCosts(row: UnitEconomicsRow): number {
@@ -148,7 +164,10 @@ function calcTotals(items: UnitEconomicsRow[]): Totals {
         logistics_back: acc.logistics_back,
         storage: acc.storage,
         advertising_cpc: acc.advertising_cpc,
-        other_costs: acc.other_costs,
+        // Колонка «Прочие» агрегирует все статьи без собственной колонки —
+        // чтобы сумма видимых колонок совпадала с total_costs.
+        other_costs: acc.other_costs + acc.advertising_other + acc.advertising_external
+            + acc.acquiring + acc.penalties + acc.acceptance,
         total_costs,
         profit,
         margin,
@@ -351,7 +370,7 @@ const UnitEconomicsTable: React.FC<UnitEconomicsTableProps> = ({ items, isLoadin
                                     <td style={numColStyle(W.logisticsBack)}>{formatMoney(row.logistics_back)}</td>
                                     <td style={numColStyle(W.storage)}>{formatMoney(row.storage)}</td>
                                     <td style={numColStyle(W.advertisingCpc)}>{formatMoney(row.advertising_cpc)}</td>
-                                    <td style={numColStyle(W.otherCosts)}>{formatMoney(row.other_costs)}</td>
+                                    <td style={numColStyle(W.otherCosts)}>{formatMoney(calcOtherCostsDisplay(row))}</td>
                                     <td style={numColStyle(W.totalCosts)}>
                                         {totalCosts === null
                                             ? <span className="text-warning" title="Нет данных о себестоимости">{'\u2014'}</span>

--- a/site/src/MarketplaceAnalytics/Infrastructure/Query/PortfolioSummaryQuery.php
+++ b/site/src/MarketplaceAnalytics/Infrastructure/Query/PortfolioSummaryQuery.php
@@ -54,6 +54,9 @@ final readonly class PortfolioSummaryQuery
                          - COALESCE(SUM((cost_breakdown->>'advertising_other')::numeric), 0)
                          - COALESCE(SUM((cost_breakdown->>'advertising_external')::numeric), 0)
                          - COALESCE(SUM((cost_breakdown->>'commission')::numeric), 0)
+                         - COALESCE(SUM((cost_breakdown->>'acquiring')::numeric), 0)
+                         - COALESCE(SUM((cost_breakdown->>'penalties')::numeric), 0)
+                         - COALESCE(SUM((cost_breakdown->>'acceptance')::numeric), 0)
                          - COALESCE(SUM((cost_breakdown->>'other')::numeric), 0)
                 END AS total_profit
             FROM listing_daily_snapshots


### PR DESCRIPTION
## Summary

Рефакторинг UI-таблицы юнит-экономики (`/marketplace-analytics`) + баг-фикс в расчёте KPI на бэке. Scope — только основная вкладка `unit-economics`, `unit-extended` не затрагивается.

### Фронтенд — `UnitEconomicsTable.tsx`

- **Sticky header**: `thead th { position: sticky; top: 0 }`, `border-collapse: separate`. Шапка не уходит при вертикальной прокрутке.
- **Frozen первая колонка**: «Наименование» закреплена слева (`sticky left: 0`, 240px) с тенью через `::after`.
- **Скролл-контейнер** `.ue-scroll` с `max-height: 70vh`.
- **z-index-иерархия**: frozen body (1) < header (2) < corner (3). Hover-подсветка корректно покрывает frozen-ячейку.
- **Явные `min-width` + `font-variant-numeric: tabular-nums`** на числовых колонках.
- **17 колонок** согласно ТЗ: Возвраты разделены на шт/₽, добавлены «Себест. ед.», «Логистика (туда)», «Логистика (обр.)», «Итого затрат», «Маржа %». Зарезервирована пустая колонка «Тренд» под будущий спарклайн.
- **Пороговая раскраска маржи** через Tabler-классы: `text-green` ≥30%, `text-azure` ≥15%, `text-orange` ≥5%, `text-red` <5%.
- **NULL-handling**: `total_cost_price === null` → «—» с `text-warning` вместо `0 ₽`. Профит и итоговые затраты для такой строки тоже «—».
- **Иконка `has_quality_issues`** теперь инлайн в ячейке названия (`ti ti-alert-triangle text-warning`), отдельная служебная колонка удалена.
- **Точки расширения** (sort / expand) помечены TODO-комментариями без dead-кода.

### Бэкенд — `PortfolioSummaryQuery.php` (баг-фикс)

В SQL `total_profit` добавлены слагаемые `acquiring`, `penalties`, `acceptance`. Формула KPI на бэке теперь совпадает с фронт-расчётом `calcProfit` (раньше бэк пропускал эти три статьи → KPI «Прибыль портфолио» завышалась).

### Ограничения соблюдены

- API-контракт не менялся, `UnitEconomicsQuery` и контроллер не тронуты.
- HTTP-клиент прежний (`useAbortableQuery`), React Query / axios не добавлялись.
- Иконки через `@tabler/icons-webfont` (`<i className="ti ti-...">`), не React-пакет.
- Vite config, entrypoint, `unit-extended/` не менялись.
- Без `any` и `@ts-ignore`.

## Test plan

- [ ] Открыть `/marketplace-analytics`, прокрутить таблицу вниз — шапка залипает
- [ ] Прокрутить вправо — колонка «Наименование» остаётся прибита к левому краю, тень видна
- [ ] Hover по строке — подсветка покрывает и frozen-ячейку
- [ ] Листинг без себестоимости — «—» с предупреждающим цветом в Себестоимость / Итого затрат / Прибыль; Маржа = «—»
- [ ] Маржа раскрашивается по порогам (30 / 15 / 5)
- [ ] Возвраты с `quantity=0` — серые; с `>0` — красные
- [ ] `has_quality_issues=true` — треугольник рядом с названием
- [ ] Пагинация (>50 листингов) работает
- [ ] KPI «Прибыль» в `PortfolioSummary` теперь учитывает acquiring/penalties/acceptance (сверить с суммой по таблице)

https://claude.ai/code/session_01WhaGitW4ipQ344zLr63L6U