### PR TITLE
fix(marketplace-analytics): sticky header + frozen column в UnitExtendedTable

### DIFF
--- a/site/assets/react/marketplace-analytics/components/UnitEconomicsTable.tsx
+++ b/site/assets/react/marketplace-analytics/components/UnitEconomicsTable.tsx
@@ -207,12 +207,18 @@ const nameColStyle: React.CSSProperties = {
 };
 
 // Inline-CSS для sticky/frozen. Pseudo-элементы и hover-состояния нельзя выразить через style=.
+// Двойная обёртка: внешний .ue-scroll-wrapper даёт рамку + скругление и клипует скроллбар
+// внутрь радиуса, внутренний .ue-scroll — собственно scroll-контейнер с явной max-height,
+// к которому и прилипает sticky-шапка и frozen-колонка.
 const TABLE_STYLES = `
-.ue-scroll {
-    max-height: 70vh;
-    overflow: auto;
+.ue-scroll-wrapper {
     border: 1px solid var(--tblr-border-color, rgba(0,0,0,0.1));
-    border-radius: 4px;
+    border-radius: var(--tblr-border-radius, 4px);
+    overflow: hidden;
+}
+.ue-scroll {
+    max-height: calc(100vh - 280px);
+    overflow: auto;
 }
 .ue-table {
     border-collapse: separate;
@@ -225,13 +231,14 @@ const TABLE_STYLES = `
     position: sticky;
     top: 0;
     z-index: 2;
-    background: var(--tblr-bg-surface);
+    background: var(--tblr-bg-surface, #ffffff);
+    border-bottom: 2px solid var(--tblr-border-color, rgba(0,0,0,0.1));
 }
 .ue-table td.ue-frozen,
 .ue-table th.ue-frozen {
     position: sticky;
     left: 0;
-    background: var(--tblr-bg-surface);
+    background: var(--tblr-bg-surface, #ffffff);
 }
 .ue-table td.ue-frozen { z-index: 1; }
 .ue-table thead th.ue-frozen { z-index: 3; }
@@ -284,8 +291,9 @@ const UnitEconomicsTable: React.FC<UnitEconomicsTableProps> = ({ items, isLoadin
     return (
         <>
             <style>{TABLE_STYLES}</style>
-            <div className="ue-scroll">
-                <table className="table table-vcenter card-table ue-table">
+            <div className="ue-scroll-wrapper">
+                <div className="ue-scroll">
+                    <table className="table table-vcenter card-table ue-table">
                     <thead>
                         <tr>
                             <th className="ue-frozen" style={nameColStyle}>Наименование</th>
@@ -437,7 +445,8 @@ const UnitEconomicsTable: React.FC<UnitEconomicsTableProps> = ({ items, isLoadin
                             </td>
                         </tr>
                     </tfoot>
-                </table>
+                    </table>
+                </div>
             </div>
         </>
     );

--- a/site/assets/react/marketplace-analytics/components/UnitEconomicsTable.tsx
+++ b/site/assets/react/marketplace-analytics/components/UnitEconomicsTable.tsx
@@ -212,7 +212,7 @@ const nameColStyle: React.CSSProperties = {
 // к которому и прилипает sticky-шапка и frozen-колонка.
 const TABLE_STYLES = `
 .ue-scroll-wrapper {
-    border: 1px solid var(--tblr-border-color, rgba(0,0,0,0.1));
+    border: 1px solid var(--tblr-border-color);
     border-radius: var(--tblr-border-radius, 4px);
     overflow: hidden;
 }
@@ -231,14 +231,14 @@ const TABLE_STYLES = `
     position: sticky;
     top: 0;
     z-index: 2;
-    background: var(--tblr-bg-surface, #ffffff);
-    border-bottom: 2px solid var(--tblr-border-color, rgba(0,0,0,0.1));
+    background: var(--tblr-bg-surface);
+    border-bottom: 2px solid var(--tblr-border-color);
 }
 .ue-table td.ue-frozen,
 .ue-table th.ue-frozen {
     position: sticky;
     left: 0;
-    background: var(--tblr-bg-surface, #ffffff);
+    background: var(--tblr-bg-surface);
 }
 .ue-table td.ue-frozen { z-index: 1; }
 .ue-table thead th.ue-frozen { z-index: 3; }
@@ -254,10 +254,10 @@ const TABLE_STYLES = `
     pointer-events: none;
 }
 .ue-table tbody tr:hover td {
-    background: var(--tblr-bg-surface-secondary, rgba(0,0,0,0.03));
+    background: var(--tblr-bg-surface-secondary);
 }
 .ue-table tbody tr:hover td.ue-frozen {
-    background: var(--tblr-bg-surface-secondary, rgba(0,0,0,0.03));
+    background: var(--tblr-bg-surface-secondary);
 }
 `;
 

--- a/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedTable.tsx
+++ b/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedTable.tsx
@@ -57,6 +57,7 @@ const TABLE_STYLES = `
     left: 0;
     background: var(--tblr-bg-surface);
     min-width: 240px;
+    max-width: 240px;
 }
 .ue-ext-table td.ue-ext-frozen { z-index: 1; }
 .ue-ext-table thead th.ue-ext-frozen { z-index: 3; }
@@ -215,8 +216,8 @@ const UnitExtendedTable: React.FC<UnitExtendedTableProps> = ({ items, totals, is
                             <React.Fragment key={row.listingId}>
                                 <tr>
                                     <td className="ue-ext-frozen">
-                                        <div>{row.title || '\u2014'}</div>
-                                        <div className="text-muted small">{row.sku}</div>
+                                        <div className="text-truncate">{row.title || '\u2014'}</div>
+                                        <div className="text-muted small text-truncate">{row.sku}</div>
                                     </td>
                                     <td className="text-end">{formatMoney(row.revenue)}</td>
                                     <td className="text-end">{row.quantity.toLocaleString('ru-RU')}</td>

--- a/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedTable.tsx
+++ b/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedTable.tsx
@@ -26,12 +26,58 @@ interface UnitExtendedTableProps {
     isLoading: boolean;
 }
 
-const stickyStyle: React.CSSProperties = {
-    position: 'sticky',
-    left: 0,
-    background: 'var(--tblr-bg-surface)',
-    zIndex: 1,
-};
+// Inline-CSS для sticky шапки + frozen первой колонки.
+// scroll-контейнер .ue-ext-scroll лежит внутри .card — тот уже имеет overflow:hidden
+// и border-radius, которые клипуют внутренний скроллбар, поэтому отдельного wrapper'а нет.
+// max-height рассчитан под текущий layout страницы (topbar + два page-header + табы +
+// фильтры + card-header ≈ 380px).
+const TABLE_STYLES = `
+.ue-ext-scroll {
+    max-height: calc(100vh - 380px);
+    min-height: 240px;
+    overflow: auto;
+}
+.ue-ext-table {
+    border-collapse: separate;
+    border-spacing: 0;
+    width: max-content;
+    min-width: 100%;
+    margin: 0;
+}
+.ue-ext-table thead th {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    background: var(--tblr-bg-surface);
+    border-bottom: 2px solid var(--tblr-border-color);
+}
+.ue-ext-table td.ue-ext-frozen,
+.ue-ext-table th.ue-ext-frozen {
+    position: sticky;
+    left: 0;
+    background: var(--tblr-bg-surface);
+    min-width: 240px;
+}
+.ue-ext-table td.ue-ext-frozen { z-index: 1; }
+.ue-ext-table thead th.ue-ext-frozen { z-index: 3; }
+.ue-ext-table tfoot td.ue-ext-frozen { z-index: 1; }
+.ue-ext-table .ue-ext-frozen::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    right: -4px;
+    bottom: 0;
+    width: 4px;
+    background: linear-gradient(to right, rgba(0,0,0,0.08), transparent);
+    pointer-events: none;
+}
+.ue-ext-table tbody tr:hover td {
+    background: var(--tblr-bg-surface-secondary);
+}
+.ue-ext-table tbody tr:hover td.ue-ext-frozen {
+    background: var(--tblr-bg-surface-secondary);
+}
+`;
 
 type ExpandedType = 'other' | 'all';
 
@@ -138,26 +184,28 @@ const UnitExtendedTable: React.FC<UnitExtendedTableProps> = ({ items, totals, is
     const colCount = HEADERS.length + 1; // +1 for "Все затраты" button column
 
     return (
-        <div className="table-responsive">
-            <table className="table table-vcenter card-table">
-                <thead>
-                    <tr>
-                        {HEADERS.map((h) => (
-                            <th
-                                key={h.field}
-                                className={`${h.align ?? ''} ${h.field === 'title' ? '' : ''}`}
-                                style={h.field === 'title' ? { ...stickyStyle, cursor: 'pointer' } : { cursor: 'pointer' }}
-                                onClick={() => handleSort(h.field)}
-                            >
-                                {h.label}
-                                {sortField === h.field && (
-                                    <i className={`ti ti-chevron-${sortDir === 'asc' ? 'up' : 'down'} ms-1`} />
-                                )}
-                            </th>
-                        ))}
-                        <th className="text-end">Все затраты</th>
-                    </tr>
-                </thead>
+        <>
+            <style>{TABLE_STYLES}</style>
+            <div className="ue-ext-scroll">
+                <table className="table table-vcenter card-table ue-ext-table">
+                    <thead>
+                        <tr>
+                            {HEADERS.map((h) => (
+                                <th
+                                    key={h.field}
+                                    className={`${h.align ?? ''} ${h.field === 'title' ? 'ue-ext-frozen' : ''}`}
+                                    style={{ cursor: 'pointer' }}
+                                    onClick={() => handleSort(h.field)}
+                                >
+                                    {h.label}
+                                    {sortField === h.field && (
+                                        <i className={`ti ti-chevron-${sortDir === 'asc' ? 'up' : 'down'} ms-1`} />
+                                    )}
+                                </th>
+                            ))}
+                            <th className="text-end">Все затраты</th>
+                        </tr>
+                    </thead>
                 <tbody>
                     {sorted.map((row) => {
                         const isOtherExpanded = expanded?.listingId === row.listingId && expanded?.type === 'other';
@@ -166,7 +214,7 @@ const UnitExtendedTable: React.FC<UnitExtendedTableProps> = ({ items, totals, is
                         return (
                             <React.Fragment key={row.listingId}>
                                 <tr>
-                                    <td style={stickyStyle}>
+                                    <td className="ue-ext-frozen">
                                         <div>{row.title || '\u2014'}</div>
                                         <div className="text-muted small">{row.sku}</div>
                                     </td>
@@ -238,7 +286,7 @@ const UnitExtendedTable: React.FC<UnitExtendedTableProps> = ({ items, totals, is
                 {totals && (
                     <tfoot>
                         <tr className="fw-bold">
-                            <td style={stickyStyle}>Итого</td>
+                            <td className="ue-ext-frozen">Итого</td>
                             <td className="text-end">{formatMoney(totals.revenue)}</td>
                             <td className="text-end">{totals.quantity.toLocaleString('ru-RU')}</td>
                             <td className="text-end text-red">{formatMoney(totals.returnsTotal)}</td>
@@ -263,8 +311,9 @@ const UnitExtendedTable: React.FC<UnitExtendedTableProps> = ({ items, totals, is
                         </tr>
                     </tfoot>
                 )}
-            </table>
-        </div>
+                </table>
+            </div>
+        </>
     );
 };
 


### PR DESCRIPTION
## Проблема

Sticky header на таблице Unit — расширенный не работал: при вертикальном скролле страницы шапка уезжала вместе с ней.

## Диагностика

В `UnitExtendedTable` вообще не было вертикального sticky — `stickyStyle` применялся только с `left: 0` (горизонтальный frozen первой колонки). Обёртка `.table-responsive` даёт `overflow-x: auto` без `max-height`, поэтому таблица росла по высоте и вертикальный скролл шёл через `.page-wrapper` (Tabler `layout-fluid-vertical`).

DOM-цепочка (из `layout-fluid-vertical`):
```
body (overflow: hidden)
  .page > .page-wrapper (overflow-y: auto — главный scroll)
    header topbar (~56px)
    .page-body > .content-max
      page-header "Аналитика маркетплейсов" (~60px)
      page-header с табами (~56px)
      .page-body (вложенный)
        .tab-pane > #react-unit-extended
          React page-header "Unit — расширенный" (~60px)
          UnitExtendedFilters (~70px)
          .card > .card-header (~40px) + table
```
Суммарно выше таблицы ≈ 340–380px.

## Фикс

Та же стратегия, что и в #1512:

- `.table-responsive` → `.ue-ext-scroll` с `max-height: calc(100vh - 380px)` и `min-height: 240px`. Отдельной внешней обёртки нет — `.card` уже даёт `overflow: hidden` и border-radius для клиппинга скроллбара.
- Класс `.ue-ext-table` с `border-collapse: separate` (обязательно для sticky), `border-spacing: 0`, `width: max-content; min-width: 100%`.
- `thead th`: `position: sticky; top: 0; z-index: 2` с `background: var(--tblr-bg-surface)` и `border-bottom: 2px solid var(--tblr-border-color)`.
- Frozen первая колонка: inline `stickyStyle` заменён на CSS-класс `.ue-ext-frozen` на td/th/tfoot-td. Z-index иерархия: body 1 < header 2 < corner 3.
- `::after` gradient справа от frozen + hover-подсветка включая frozen-ячейку.

Цветовые fallback (`#ffffff`, `rgba(0,0,0,…)`) у CSS-переменных не добавляются — консистентно с dark-mode ревью из #1512.

**Почему 380px (в #1512 было 280px):** на этой странице выше таблицы лежат дополнительно два page-header из `_tabs.html.twig` (заголовок «Аналитика маркетплейсов» + tabs nav ≈ 120px), плюс вложенная структура page-body.

## Test plan

- [ ] Скролл вниз: шапка таблицы остаётся на месте
- [ ] Скролл вправо: колонка «Наименование» остаётся слева
- [ ] Скролл одновременно в обоих направлениях: угловая ячейка шапки остаётся в углу
- [ ] tfoot «Итого» остаётся слева при горизонтальном скролле
- [ ] Hover на строке подсвечивает включая frozen-ячейку
- [ ] Контент не просвечивает сквозь шапку
- [ ] Сортировка по клику на th работает
- [ ] Раскрытие «Прочие затраты» / «Все затраты» работает
- [ ] Фильтры и KPI не тронуты

https://claude.ai/code/session_018AwXV93yMhsRfeomEpqRzR