### PR TITLE
feat(marketplace-analytics): WidgetServiceGroupMap + WidgetSummaryQuery

### DIFF
--- a/site/src/MarketplaceAnalytics/Application/Service/WidgetServiceGroupMap.php
+++ b/site/src/MarketplaceAnalytics/Application/Service/WidgetServiceGroupMap.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAnalytics\Application\Service;
+
+/**
+ * Маппинг категорий затрат Ozon к widgetGroup для витрины аналитики.
+ *
+ * Используется в WidgetSummaryQuery для агрегации затрат по 5 группам
+ * виджета на дашборде MarketplaceAnalytics.
+ *
+ * Отличия от OzonXlsxServiceGroupMap:
+ *  - "Услуги доставки" + "Услуги FBO" объединены в "Услуги доставки и FBO"
+ *  - "Другие услуги и штрафы" + "Компенсации и декомпенсации" объединены
+ *    в "Другие услуги и штрафы"
+ *
+ * Fallback для неизвестных кодов: 'Другие услуги и штрафы'.
+ */
+final class WidgetServiceGroupMap
+{
+    /**
+     * @return array<string, string> category_code → widgetGroup
+     */
+    public static function getCategoryToWidgetGroup(): array
+    {
+        return [
+            // === Вознаграждение ===
+            'ozon_sale_commission'       => 'Вознаграждение',
+            'ozon_brand_commission'      => 'Вознаграждение',
+
+            // === Услуги доставки и FBO ===
+            // Объединяем "Услуги доставки" + "Услуги FBO" из OzonXlsxServiceGroupMap
+            // Доставка (20 кодов):
+            'ozon_logistic_direct'       => 'Услуги доставки и FBO',
+            'ozon_logistic_direct_vdc'   => 'Услуги доставки и FBO',
+            'ozon_logistic_direct_trans' => 'Услуги доставки и FBO',
+            'ozon_logistic_delivery'     => 'Услуги доставки и FBO',
+            'ozon_logistic_kgt'          => 'Услуги доставки и FBO',
+            'ozon_logistic_return'       => 'Услуги доставки и FBO',
+            'ozon_logistic_return_trans' => 'Услуги доставки и FBO',
+            'ozon_logistic_inbound'      => 'Услуги доставки и FBO',
+            'ozon_logistic_inbound_seller' => 'Услуги доставки и FBO',
+            'ozon_dropoff_pvz'           => 'Услуги доставки и FBO',
+            'ozon_dropoff_ff'            => 'Услуги доставки и FBO',
+            'ozon_dropoff_sc'            => 'Услуги доставки и FBO',
+            'ozon_dropoff_ppz'           => 'Услуги доставки и FBO',
+            'ozon_delivery'              => 'Услуги доставки и FBO',
+            'ozon_return_delivery'       => 'Услуги доставки и FBO',
+            'ozon_return_partial'        => 'Услуги доставки и FBO',
+            'ozon_return_not_delivered'  => 'Услуги доставки и FBO',
+            'ozon_return_after_delivery' => 'Услуги доставки и FBO',
+            'ozon_return_storage_pvz'    => 'Услуги доставки и FBO',
+            'ozon_return_storage_wh'     => 'Услуги доставки и FBO',
+            // FBO (10 кодов):
+            'ozon_crossdocking'          => 'Услуги доставки и FBO',
+            'ozon_supply_shortage'       => 'Услуги доставки и FBO',
+            'ozon_return_from_stock'     => 'Услуги доставки и FBO',
+            'ozon_supply_additional'     => 'Услуги доставки и FBO',
+            'ozon_supply_surplus'        => 'Услуги доставки и FBO',
+            'ozon_storage'               => 'Услуги доставки и FBO',
+            'ozon_logistic_pickup'       => 'Услуги доставки и FBO',
+            'ozon_package_materials'     => 'Услуги доставки и FBO',
+            'ozon_package_labor'         => 'Услуги доставки и FBO',
+            'ozon_warehouse_movement'    => 'Услуги доставки и FBO',
+
+            // === Услуги партнёров ===
+            'ozon_logistic_last_mile'    => 'Услуги партнёров',
+            'ozon_return_pvz'            => 'Услуги партнёров',
+            'ozon_storage_partner'       => 'Услуги партнёров',
+            'ozon_acquiring'             => 'Услуги партнёров',
+            'ozon_fulfillment'           => 'Услуги партнёров',
+
+            // === Продвижение и реклама ===
+            'ozon_cpc'                   => 'Продвижение и реклама',
+            'ozon_premium_promotion'     => 'Продвижение и реклама',
+            'ozon_premium_cashback'      => 'Продвижение и реклама',
+            'ozon_reviews'               => 'Продвижение и реклама',
+            'ozon_seller_bonus'          => 'Продвижение и реклама',
+            'ozon_marketing_action'      => 'Продвижение и реклама',
+            'ozon_stars_membership'      => 'Продвижение и реклама',
+
+            // === Другие услуги и штрафы ===
+            // Объединяем "Другие услуги и штрафы" + "Компенсации и декомпенсации"
+            'ozon_disposal'              => 'Другие услуги и штрафы',
+            'ozon_ovh_processing'        => 'Другие услуги и штрафы',
+            'ozon_penalty_undeliverable' => 'Другие услуги и штрафы',
+            'ozon_marking'               => 'Другие услуги и штрафы',
+            'ozon_agency_fee'            => 'Другие услуги и штрафы',
+            'ozon_early_payment'         => 'Другие услуги и штрафы',
+            'ozon_flexible_payment'      => 'Другие услуги и штрафы',
+            'ozon_installment'           => 'Другие услуги и штрафы',
+            'ozon_premium_correction'    => 'Другие услуги и штрафы',
+            'ozon_service_correction'    => 'Другие услуги и штрафы',
+            'ozon_other_service'         => 'Другие услуги и штрафы',
+            'ozon_compensation'          => 'Другие услуги и штрафы',
+            'ozon_decompensation'        => 'Другие услуги и штрафы',
+        ];
+    }
+}

--- a/site/src/MarketplaceAnalytics/Infrastructure/Query/WidgetSummaryQuery.php
+++ b/site/src/MarketplaceAnalytics/Infrastructure/Query/WidgetSummaryQuery.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAnalytics\Infrastructure\Query;
+
+use App\Marketplace\Facade\MarketplaceFacade;
+use App\MarketplaceAnalytics\Application\Service\WidgetServiceGroupMap;
+
+/**
+ * Сводка для виджета MarketplaceAnalytics за период.
+ *
+ * Повторяет агрегацию UnitExtendedQuery, но без per-listing detail:
+ * возвращает только итоговые числа и разбивку затрат по widgetGroup
+ * (5 групп WidgetServiceGroupMap).
+ */
+final readonly class WidgetSummaryQuery
+{
+    private const FALLBACK_GROUP = 'Другие услуги и штрафы';
+
+    /** @var list<string> */
+    private const WIDGET_GROUPS = [
+        'Вознаграждение',
+        'Услуги доставки и FBO',
+        'Услуги партнёров',
+        'Продвижение и реклама',
+        'Другие услуги и штрафы',
+    ];
+
+    public function __construct(
+        private MarketplaceFacade $marketplaceFacade,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     revenue: float,
+     *     returnsTotal: float,
+     *     costPriceTotal: float,
+     *     totalCosts: float,
+     *     profit: float,
+     *     marginPercent: float|null,
+     *     widgetGroups: list<array<string, mixed>>,
+     * }
+     */
+    public function getSummary(
+        string $companyId,
+        ?string $marketplace,
+        \DateTimeImmutable $dateFrom,
+        \DateTimeImmutable $dateTo,
+    ): array {
+        $sales = $this->marketplaceFacade->getSalesAggregatesByListing($companyId, $marketplace, $dateFrom, $dateTo);
+        $returns = $this->marketplaceFacade->getReturnAggregatesByListing($companyId, $marketplace, $dateFrom, $dateTo);
+        $costs = $this->marketplaceFacade->getCostAggregatesByListing($companyId, $marketplace, $dateFrom, $dateTo);
+
+        $codeToGroup = WidgetServiceGroupMap::getCategoryToWidgetGroup();
+
+        $revenue = 0.0;
+        $returnsTotal = 0.0;
+        $costPriceTotal = 0.0;
+
+        $groups = [];
+        foreach (self::WIDGET_GROUPS as $groupName) {
+            $groups[$groupName] = [
+                'serviceGroup' => $groupName,
+                'costsAmount'  => 0.0,
+                'stornoAmount' => 0.0,
+                'netAmount'    => 0.0,
+                'categories'   => [],
+            ];
+        }
+
+        // Merge all unique listing IDs from three sources so listings
+        // with only returns or costs are not lost
+        $allListingIds = array_unique(array_merge(
+            array_keys($sales),
+            array_keys($returns),
+            array_keys($costs),
+        ));
+
+        foreach ($allListingIds as $listingId) {
+            $sale = $sales[$listingId] ?? null;
+            $ret = $returns[$listingId] ?? null;
+            $listingCosts = $costs[$listingId] ?? [];
+
+            if ($sale !== null) {
+                $revenue += (float) $sale->revenue;
+                $costPriceTotal += (float) $sale->costPriceTotal;
+            }
+
+            if ($ret !== null) {
+                $returnsTotal += (float) $ret->returnsTotal;
+            }
+
+            foreach ($listingCosts as $cat) {
+                $group = $codeToGroup[$cat->categoryCode] ?? self::FALLBACK_GROUP;
+
+                $costsAmt = (float) $cat->costsAmount;
+                $stornoAmt = (float) $cat->stornoAmount;
+                $netAmt = (float) $cat->netAmount;
+
+                $groups[$group]['costsAmount'] += $costsAmt;
+                $groups[$group]['stornoAmount'] += $stornoAmt;
+                $groups[$group]['netAmount'] += $netAmt;
+
+                // Агрегируем одинаковые categoryCode внутри группы
+                $code = $cat->categoryCode;
+                if (!isset($groups[$group]['categories'][$code])) {
+                    $groups[$group]['categories'][$code] = [
+                        'code'         => $code,
+                        'name'         => $cat->categoryName,
+                        'costsAmount'  => 0.0,
+                        'stornoAmount' => 0.0,
+                        'netAmount'    => 0.0,
+                    ];
+                }
+
+                $groups[$group]['categories'][$code]['costsAmount'] += $costsAmt;
+                $groups[$group]['categories'][$code]['stornoAmount'] += $stornoAmt;
+                $groups[$group]['categories'][$code]['netAmount'] += $netAmt;
+            }
+        }
+
+        // Build widgetGroups list with rounding and sorting
+        $widgetGroups = [];
+        $totalCosts = 0.0;
+        foreach ($groups as $group) {
+            $categories = [];
+            foreach ($group['categories'] as $cat) {
+                $categories[] = [
+                    'code'         => $cat['code'],
+                    'name'         => $cat['name'],
+                    'costsAmount'  => round($cat['costsAmount'], 2),
+                    'stornoAmount' => round($cat['stornoAmount'], 2),
+                    'netAmount'    => round($cat['netAmount'], 2),
+                ];
+            }
+
+            // Sort categories inside group by costsAmount DESC
+            usort($categories, static fn (array $a, array $b): int => $b['costsAmount'] <=> $a['costsAmount']);
+
+            $netAmount = round($group['netAmount'], 2);
+            $totalCosts += $netAmount;
+
+            $widgetGroups[] = [
+                'serviceGroup' => $group['serviceGroup'],
+                'costsAmount'  => round($group['costsAmount'], 2),
+                'stornoAmount' => round($group['stornoAmount'], 2),
+                'netAmount'    => $netAmount,
+                'categories'   => $categories,
+            ];
+        }
+
+        // Sort widgetGroups by netAmount DESC
+        usort($widgetGroups, static fn (array $a, array $b): int => $b['netAmount'] <=> $a['netAmount']);
+
+        $totalCosts = round($totalCosts, 2);
+        $revenue = round($revenue, 2);
+        $returnsTotal = round($returnsTotal, 2);
+        $costPriceTotal = round($costPriceTotal, 2);
+        $profit = round($revenue - $returnsTotal - $costPriceTotal - $totalCosts, 2);
+
+        $marginPercent = $revenue > 0 ? round($profit / $revenue * 100, 1) : null;
+
+        return [
+            'revenue'        => $revenue,
+            'returnsTotal'   => $returnsTotal,
+            'costPriceTotal' => $costPriceTotal,
+            'totalCosts'     => $totalCosts,
+            'profit'         => $profit,
+            'marginPercent'  => $marginPercent,
+            'widgetGroups'   => $widgetGroups,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

- `WidgetServiceGroupMap` (`src/MarketplaceAnalytics/Application/Service/`): маппинг 57 категорий затрат Ozon к 5 widget-группам для дашборда. Объединяет `Услуги доставки` + `Услуги FBO` в `Услуги доставки и FBO` и `Другие услуги и штрафы` + `Компенсации и декомпенсации` в `Другие услуги и штрафы`. Проверено `array_diff` с `OzonXlsxServiceGroupMap` — все 57 кодов распределены, без потерь и лишних.
- `WidgetSummaryQuery` (`src/MarketplaceAnalytics/Infrastructure/Query/`): агрегация по периоду через `MarketplaceFacade` (sales/returns/costs aggregates) без per-listing detail. Возвращает `revenue`, `returnsTotal`, `costPriceTotal`, `totalCosts`, `profit`, `marginPercent` и `widgetGroups` в формате `CostGroupBreakdown` с категориями внутри группы (для раскрытия на фронте).

## Group counts

| Group | Codes |
|---|---|
| Вознаграждение | 2 |
| Услуги доставки и FBO | 30 |
| Услуги партнёров | 5 |
| Продвижение и реклама | 7 |
| Другие услуги и штрафы | 13 |
| **Total** | **57** |

## Notes

- `final readonly class` + `declare(strict_types=1)`, `MarketplaceFacade` через constructor injection (не `Connection`).
- Fallback для неизвестных кодов → `'Другие услуги и штрафы'`.
- Агрегация одинаковых `categoryCode` внутри группы, округление всех float до 2 знаков (`round(..., 2)`), `marginPercent` — до 1 знака.
- Сортировки: `widgetGroups` по `netAmount` DESC, `categories` внутри по `costsAmount` DESC.
- Не используются `unit_economy_cost_mappings` и `OzonXlsxServiceGroupMap`.
- Только чтение — никаких `flush()`/`persist()`.

## Test plan

- [ ] Verify `WidgetServiceGroupMap::getCategoryToWidgetGroup()` returns 57 codes distributed across 5 groups as per the table above.
- [ ] Verify `WidgetSummaryQuery::getSummary()` with empty data returns zeros and `marginPercent=null`.
- [ ] Verify `profit = revenue - returnsTotal - costPriceTotal - totalCosts` and `totalCosts = sum(widgetGroups[].netAmount)`.
- [ ] Verify unknown `categoryCode` falls back to `'Другие услуги и штрафы'`.
- [ ] Verify sorting: `widgetGroups` by `netAmount` DESC, `categories` by `costsAmount` DESC.

https://claude.ai/code/session_011a7EqDhmEpw1wTZi4oX8US