### PR TITLE
feat(marketplace-analytics): API-контроллер сводки виджетов

### DIFF
--- a/site/src/MarketplaceAnalytics/Controller/Api/GetWidgetsSummaryController.php
+++ b/site/src/MarketplaceAnalytics/Controller/Api/GetWidgetsSummaryController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\MarketplaceAnalytics\Controller\Api;
 
+use App\Marketplace\Enum\MarketplaceType;
 use App\MarketplaceAnalytics\Infrastructure\Query\WidgetSummaryQuery;
 use App\Shared\Service\ActiveCompanyService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -30,9 +31,38 @@ final class GetWidgetsSummaryController extends AbstractController
     {
         $company = $this->activeCompanyService->getActiveCompany();
 
-        $marketplace = $request->query->get('marketplace') ?: null;
-        $periodFrom = new \DateTimeImmutable($request->query->getString('periodFrom'));
-        $periodTo = new \DateTimeImmutable($request->query->getString('periodTo'));
+        $marketplace = $request->query->get('marketplace');
+        if ($marketplace === null || $marketplace === '') {
+            $marketplace = null;
+        } else {
+            $validValues = array_map(
+                static fn (MarketplaceType $t): string => $t->value,
+                MarketplaceType::cases(),
+            );
+            if (!in_array($marketplace, $validValues, true)) {
+                return $this->json([
+                    'error' => 'Invalid marketplace. Allowed: ' . implode(', ', $validValues),
+                ], 422);
+            }
+        }
+
+        $periodFromStr = $request->query->get('periodFrom', '');
+        $periodToStr   = $request->query->get('periodTo', '');
+
+        if ($periodFromStr === '' || $periodToStr === '') {
+            return $this->json(['error' => 'periodFrom and periodTo are required'], 422);
+        }
+
+        try {
+            $periodFrom = new \DateTimeImmutable($periodFromStr);
+            $periodTo   = new \DateTimeImmutable($periodToStr);
+        } catch (\Exception) {
+            return $this->json(['error' => 'Invalid date format. Expected Y-m-d'], 422);
+        }
+
+        if ($periodFrom > $periodTo) {
+            return $this->json(['error' => 'periodFrom must be <= periodTo'], 422);
+        }
 
         $current = $this->widgetQuery->getSummary(
             $company->getId(),

--- a/site/src/MarketplaceAnalytics/Controller/Api/GetWidgetsSummaryController.php
+++ b/site/src/MarketplaceAnalytics/Controller/Api/GetWidgetsSummaryController.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAnalytics\Controller\Api;
+
+use App\MarketplaceAnalytics\Infrastructure\Query\WidgetSummaryQuery;
+use App\Shared\Service\ActiveCompanyService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route(
+    path: '/api/marketplace-analytics/unit-extended/widgets',
+    name: 'api_marketplace_analytics_widgets_summary',
+    methods: ['GET'],
+)]
+#[IsGranted('ROLE_COMPANY_USER')]
+final class GetWidgetsSummaryController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $activeCompanyService,
+        private readonly WidgetSummaryQuery $widgetQuery,
+    ) {
+    }
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        $company = $this->activeCompanyService->getActiveCompany();
+
+        $marketplace = $request->query->get('marketplace') ?: null;
+        $periodFrom = new \DateTimeImmutable($request->query->getString('periodFrom'));
+        $periodTo = new \DateTimeImmutable($request->query->getString('periodTo'));
+
+        $current = $this->widgetQuery->getSummary(
+            $company->getId(),
+            $marketplace,
+            $periodFrom,
+            $periodTo,
+        );
+
+        $days = $periodFrom->diff($periodTo)->days;
+        $prevTo = $periodFrom->modify('-1 day');
+        $prevFrom = $prevTo->modify("-{$days} days");
+
+        $previous = $this->widgetQuery->getSummary(
+            $company->getId(),
+            $marketplace,
+            $prevFrom,
+            $prevTo,
+        );
+
+        return new JsonResponse([
+            'current'  => $current,
+            'previous' => $previous,
+            'period'   => [
+                'from'         => $periodFrom->format('Y-m-d'),
+                'to'           => $periodTo->format('Y-m-d'),
+                'previousFrom' => $prevFrom->format('Y-m-d'),
+                'previousTo'   => $prevTo->format('Y-m-d'),
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

- `GetWidgetsSummaryController` (`src/MarketplaceAnalytics/Controller/Api/`): новый GET-эндпоинт `/api/marketplace-analytics/unit-extended/widgets`. Возвращает сводку widgetGroups за выбранный период плюс сравнительные данные за предыдущий период такой же длины.
- Делегирует в `WidgetSummaryQuery` дважды (current/previous), без бизнес-логики.

## Контракт

**Запрос:** `GET /api/marketplace-analytics/unit-extended/widgets?marketplace=ozon&periodFrom=2026-03-01&periodTo=2026-03-31`

**Параметры:**
- `marketplace` — string, nullable (консистентно с `UnitExtendedController`)
- `periodFrom`, `periodTo` — Y-m-d

**Ответ:**
```json
{
  "current":  { "revenue": ..., "widgetGroups": [ ... ], ... },
  "previous": { "revenue": ..., "widgetGroups": [ ... ], ... },
  "period": {
    "from": "2026-03-01",
    "to":   "2026-03-31",
    "previousFrom": "2026-01-30",
    "previousTo":   "2026-02-28"
  }
}
```

Сдвиг previous-периода назад на ту же длину (`days = periodFrom.diff(periodTo).days`, `prevTo = from - 1d`, `prevFrom = prevTo - days`).

## Notes

- `final class extends AbstractController`, `declare(strict_types=1)`, метод `__invoke`.
- Маршрут через `#[Route]` атрибут (имя: `api_marketplace_analytics_widgets_summary`).
- `#[IsGranted('ROLE_COMPANY_USER')]` — консистентно с `UnitExtendedController`.
- Constructor injection: `ActiveCompanyService`, `WidgetSummaryQuery` (private readonly).
- IDOR: `getActiveCompany()` → `$company->getId()` пробрасывается в Query.
- Детализация группы не требует отдельного эндпоинта — `categories` уже внутри `widgetGroups`.

## Test plan

- [ ] `GET …/widgets?marketplace=ozon&periodFrom=2026-03-01&periodTo=2026-03-31` возвращает JSON с тремя ключами: `current`, `previous`, `period`.
- [ ] `previousFrom`/`previousTo` корректно сдвинуты на длину периода (для 31-дневного периода → диапазон 28–31 дней назад в зависимости от длины).
- [ ] Пустой `marketplace` → `null` (фильтра по площадке нет).
- [ ] Без авторизации → 403/redirect (`ROLE_COMPANY_USER` обязателен).
- [ ] Без `periodFrom`/`periodTo` → ошибка парсинга `\DateTimeImmutable` (контроллер предполагает обязательность).

https://claude.ai/code/session_011a7EqDhmEpw1wTZi4oX8US