### PR TITLE
feat(marketplace-analytics): фронтенд виджетов сводки

### DIFF
--- a/site/assets/react/marketplace-analytics/unit-extended/widgets/WidgetCard.tsx
+++ b/site/assets/react/marketplace-analytics/unit-extended/widgets/WidgetCard.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { formatMoney } from '../../utils/utils';
+import type { WidgetCardConfig, WidgetsSummary, WidgetType } from './widgets.types';
+
+interface WidgetCardProps {
+    config: WidgetCardConfig;
+    current: WidgetsSummary;
+    previous: WidgetsSummary;
+    isExpanded: boolean;
+    isExpandable: boolean;
+    onToggle: (key: string) => void;
+}
+
+/**
+ * Подсчёт процента изменения current vs previous.
+ * Возвращает null если предыдущий период == 0 (нельзя поделить).
+ */
+function calcDeltaPercent(current: number, previous: number): number | null {
+    if (previous === 0) {
+        return null;
+    }
+    return ((current - previous) / Math.abs(previous)) * 100;
+}
+
+/**
+ * Цвет дельта-бейджа в зависимости от типа виджета и направления изменения.
+ *
+ * income / profit: рост (+) = зелёный, падение (-) = красный
+ * expense:         рост (+) = красный,  падение (-) = зелёный
+ */
+function getBadgeColor(type: WidgetType, delta: number): 'green' | 'red' | 'secondary' {
+    if (delta === 0) {
+        return 'secondary';
+    }
+    const isPositive = delta > 0;
+    if (type === 'expense') {
+        return isPositive ? 'red' : 'green';
+    }
+    return isPositive ? 'green' : 'red';
+}
+
+const WidgetCard: React.FC<WidgetCardProps> = ({
+    config,
+    current,
+    previous,
+    isExpanded,
+    isExpandable,
+    onToggle,
+}) => {
+    const currentValue = config.getValue(current);
+    const previousValue = config.getValue(previous);
+    const delta = calcDeltaPercent(currentValue, previousValue);
+
+    const handleClick = () => {
+        if (isExpandable) {
+            onToggle(config.key);
+        }
+    };
+
+    const cardClass = [
+        'card',
+        'h-100',
+        isExpandable ? 'cursor-pointer' : '',
+        isExpanded ? 'border-primary' : '',
+    ]
+        .filter(Boolean)
+        .join(' ');
+
+    return (
+        <div
+            className={cardClass}
+            onClick={handleClick}
+            role={isExpandable ? 'button' : undefined}
+            tabIndex={isExpandable ? 0 : undefined}
+            onKeyDown={(e) => {
+                if (isExpandable && (e.key === 'Enter' || e.key === ' ')) {
+                    e.preventDefault();
+                    onToggle(config.key);
+                }
+            }}
+        >
+            <div className="card-body">
+                <div className="d-flex align-items-center mb-2">
+                    <i className={`${config.icon} me-2 text-muted`} />
+                    <div className="subheader">{config.label}</div>
+                </div>
+
+                <div className="h2 mb-1">{formatMoney(currentValue)}</div>
+
+                <div className="d-flex align-items-center">
+                    {delta === null ? (
+                        <span className="text-secondary small">—</span>
+                    ) : (
+                        <span
+                            className={`badge bg-${getBadgeColor(config.type, delta)}-lt`}
+                        >
+                            {delta > 0 ? '+' : ''}
+                            {delta.toFixed(1)}%
+                        </span>
+                    )}
+                    <span className="text-muted small ms-2">
+                        пред: {formatMoney(previousValue)}
+                    </span>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default WidgetCard;

--- a/site/assets/react/marketplace-analytics/unit-extended/widgets/WidgetDetailPanel.tsx
+++ b/site/assets/react/marketplace-analytics/unit-extended/widgets/WidgetDetailPanel.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { formatMoney } from '../../utils/utils';
+import type { CostGroupBreakdown } from '../unitExtended.types';
+
+interface WidgetDetailPanelProps {
+    groups: CostGroupBreakdown[];
+}
+
+/**
+ * Раскрытая детализация затрат:
+ * - заголовок группы (fw-bold) с суммами
+ * - строки категорий (ps-4, text-secondary) с суммами
+ */
+const WidgetDetailPanel: React.FC<WidgetDetailPanelProps> = ({ groups }) => {
+    if (groups.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="card">
+            <div className="table-responsive">
+                <table className="table table-vcenter card-table">
+                    <thead>
+                        <tr>
+                            <th>КАТЕГОРИЯ</th>
+                            <th className="text-end">НАЧИСЛЕНО</th>
+                            <th className="text-end">СТОРНО</th>
+                            <th className="text-end">НЕТТО</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {groups.map((group) => (
+                            <React.Fragment key={group.serviceGroup}>
+                                <tr>
+                                    <td className="fw-bold">{group.serviceGroup}</td>
+                                    <td className="text-end fw-bold">
+                                        {formatMoney(group.costsAmount)}
+                                    </td>
+                                    <td className="text-end fw-bold">
+                                        {formatMoney(group.stornoAmount)}
+                                    </td>
+                                    <td className="text-end fw-bold">
+                                        {formatMoney(group.netAmount)}
+                                    </td>
+                                </tr>
+                                {group.categories.map((cat) => (
+                                    <tr key={`${group.serviceGroup}::${cat.code}`}>
+                                        <td className="ps-4 text-secondary">{cat.name}</td>
+                                        <td className="text-end text-secondary">
+                                            {formatMoney(cat.costsAmount)}
+                                        </td>
+                                        <td className="text-end text-secondary">
+                                            {formatMoney(cat.stornoAmount)}
+                                        </td>
+                                        <td className="text-end text-secondary">
+                                            {formatMoney(cat.netAmount)}
+                                        </td>
+                                    </tr>
+                                ))}
+                            </React.Fragment>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    );
+};
+
+export default WidgetDetailPanel;

--- a/site/assets/react/marketplace-analytics/unit-extended/widgets/WidgetsGrid.tsx
+++ b/site/assets/react/marketplace-analytics/unit-extended/widgets/WidgetsGrid.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import type { CostGroupBreakdown } from '../unitExtended.types';
+import WidgetCard from './WidgetCard';
+import WidgetDetailPanel from './WidgetDetailPanel';
+import { WIDGETS, WIDGET_KEY_TO_GROUPS } from './widgetsConfig';
+import type { WidgetsApiResponse } from './widgets.types';
+
+interface WidgetsGridProps {
+    summary: WidgetsApiResponse | null;
+    isLoading: boolean;
+    expandedKey: string | null;
+    expandedGroups: CostGroupBreakdown[];
+    onToggle: (key: string) => void;
+}
+
+/**
+ * Заглушка карточки во время загрузки (placeholder-glow).
+ */
+const WidgetCardSkeleton: React.FC = () => (
+    <div className="card h-100 placeholder-glow">
+        <div className="card-body">
+            <div className="placeholder col-6 mb-3" />
+            <div className="placeholder placeholder-lg col-8 mb-2" />
+            <div className="placeholder col-5" />
+        </div>
+    </div>
+);
+
+/**
+ * Сетка из 8 виджетов + детализация под выбранным виджетом.
+ */
+const WidgetsGrid: React.FC<WidgetsGridProps> = ({
+    summary,
+    isLoading,
+    expandedKey,
+    expandedGroups,
+    onToggle,
+}) => {
+    if (isLoading || !summary) {
+        return (
+            <div className="row row-cards mb-3">
+                {WIDGETS.map((w) => (
+                    <div key={w.key} className="col-sm-6 col-lg-3">
+                        <WidgetCardSkeleton />
+                    </div>
+                ))}
+            </div>
+        );
+    }
+
+    const { current, previous } = summary;
+
+    return (
+        <>
+            <div className="row row-cards mb-3">
+                {WIDGETS.map((config) => {
+                    const isExpandable = Boolean(WIDGET_KEY_TO_GROUPS[config.key]);
+                    const isExpanded = expandedKey === config.key;
+                    return (
+                        <div key={config.key} className="col-sm-6 col-lg-3">
+                            <WidgetCard
+                                config={config}
+                                current={current}
+                                previous={previous}
+                                isExpanded={isExpanded}
+                                isExpandable={isExpandable}
+                                onToggle={onToggle}
+                            />
+                        </div>
+                    );
+                })}
+            </div>
+
+            {expandedKey && expandedGroups.length > 0 && (
+                <div className="mb-3">
+                    <WidgetDetailPanel groups={expandedGroups} />
+                </div>
+            )}
+        </>
+    );
+};
+
+export default WidgetsGrid;

--- a/site/assets/react/marketplace-analytics/unit-extended/widgets/WidgetsGrid.tsx
+++ b/site/assets/react/marketplace-analytics/unit-extended/widgets/WidgetsGrid.tsx
@@ -8,6 +8,7 @@ import type { WidgetsApiResponse } from './widgets.types';
 interface WidgetsGridProps {
     summary: WidgetsApiResponse | null;
     isLoading: boolean;
+    error: string | null;
     expandedKey: string | null;
     expandedGroups: CostGroupBreakdown[];
     onToggle: (key: string) => void;
@@ -28,15 +29,30 @@ const WidgetCardSkeleton: React.FC = () => (
 
 /**
  * Сетка из 8 виджетов + детализация под выбранным виджетом.
+ *
+ * Состояния:
+ *  - error                       → alert
+ *  - isLoading                   → 8 skeleton-карточек
+ *  - !summary && !isLoading      → пусто (initial state до первого fetch)
+ *  - summary                     → карточки + опционально WidgetDetailPanel
  */
 const WidgetsGrid: React.FC<WidgetsGridProps> = ({
     summary,
     isLoading,
+    error,
     expandedKey,
     expandedGroups,
     onToggle,
 }) => {
-    if (isLoading || !summary) {
+    if (error) {
+        return (
+            <div className="alert alert-danger mb-3" role="alert">
+                {error}
+            </div>
+        );
+    }
+
+    if (isLoading) {
         return (
             <div className="row row-cards mb-3">
                 {WIDGETS.map((w) => (
@@ -46,6 +62,10 @@ const WidgetsGrid: React.FC<WidgetsGridProps> = ({
                 ))}
             </div>
         );
+    }
+
+    if (!summary) {
+        return null;
     }
 
     const { current, previous } = summary;

--- a/site/assets/react/marketplace-analytics/unit-extended/widgets/useWidgets.ts
+++ b/site/assets/react/marketplace-analytics/unit-extended/widgets/useWidgets.ts
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useAbortableQuery } from '../../../shared/hooks/useAbortableQuery';
+import type { CostGroupBreakdown } from '../unitExtended.types';
+import { WIDGET_KEY_TO_GROUPS } from './widgetsConfig';
+import type { WidgetsApiResponse, WidgetsSummary } from './widgets.types';
+
+interface UseWidgetsParams {
+    marketplace: string;
+    periodFrom: string;
+    periodTo: string;
+}
+
+interface UseWidgetsResult {
+    summary: WidgetsApiResponse | null;
+    isLoading: boolean;
+    error: string | null;
+    expandedKey: string | null;
+    expandedGroups: CostGroupBreakdown[];
+    toggleWidget: (key: string) => void;
+}
+
+/**
+ * Хук для загрузки сводки виджетов и управления раскрытием детализации.
+ */
+export function useWidgets(params: UseWidgetsParams): UseWidgetsResult {
+    const { isLoading, data, error, run } = useAbortableQuery<WidgetsApiResponse>();
+    const [expandedKey, setExpandedKey] = useState<string | null>(null);
+
+    const load = useCallback(() => {
+        if (!params.periodFrom || !params.periodTo) {
+            return;
+        }
+
+        const query: Record<string, string> = {
+            periodFrom: params.periodFrom,
+            periodTo: params.periodTo,
+        };
+
+        if (params.marketplace) {
+            query.marketplace = params.marketplace;
+        }
+
+        void run({
+            url: '/api/marketplace-analytics/unit-extended/widgets',
+            query,
+        });
+    }, [params.marketplace, params.periodFrom, params.periodTo, run]);
+
+    useEffect(() => {
+        load();
+    }, [load]);
+
+    const toggleWidget = useCallback((key: string) => {
+        setExpandedKey((prev) => (prev === key ? null : key));
+    }, []);
+
+    const expandedGroups = useMemo<CostGroupBreakdown[]>(() => {
+        if (!expandedKey || !data) {
+            return [];
+        }
+
+        const groupNames = WIDGET_KEY_TO_GROUPS[expandedKey];
+        if (!groupNames || groupNames.length === 0) {
+            return [];
+        }
+
+        const current: WidgetsSummary = data.current;
+        return current.widgetGroups.filter((g) => groupNames.includes(g.serviceGroup));
+    }, [expandedKey, data]);
+
+    return {
+        summary: data,
+        isLoading,
+        error,
+        expandedKey,
+        expandedGroups,
+        toggleWidget,
+    };
+}

--- a/site/assets/react/marketplace-analytics/unit-extended/widgets/useWidgets.ts
+++ b/site/assets/react/marketplace-analytics/unit-extended/widgets/useWidgets.ts
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useAbortableQuery } from '../../../shared/hooks/useAbortableQuery';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ApiError } from '../../../shared/http/client';
 import type { CostGroupBreakdown } from '../unitExtended.types';
+import { fetchWidgetsSummary } from './widgets.api';
 import { WIDGET_KEY_TO_GROUPS } from './widgetsConfig';
 import type { WidgetsApiResponse, WidgetsSummary } from './widgets.types';
 
@@ -21,34 +22,60 @@ interface UseWidgetsResult {
 
 /**
  * Хук для загрузки сводки виджетов и управления раскрытием детализации.
+ *
+ * Использует fetchWidgetsSummary как единую точку входа в API
+ * (URL и query инкапсулированы там). Abort предыдущего запроса при
+ * смене параметров и при unmount.
  */
 export function useWidgets(params: UseWidgetsParams): UseWidgetsResult {
-    const { isLoading, data, error, run } = useAbortableQuery<WidgetsApiResponse>();
+    const [data, setData] = useState<WidgetsApiResponse | null>(null);
+    const [isLoading, setIsLoading] = useState<boolean>(false);
+    const [error, setError] = useState<string | null>(null);
     const [expandedKey, setExpandedKey] = useState<string | null>(null);
+    const abortRef = useRef<AbortController | null>(null);
 
-    const load = useCallback(() => {
+    useEffect(() => {
         if (!params.periodFrom || !params.periodTo) {
             return;
         }
 
-        const query: Record<string, string> = {
-            periodFrom: params.periodFrom,
-            periodTo: params.periodTo,
+        // Отменяем предыдущий запрос
+        abortRef.current?.abort();
+        const ac = new AbortController();
+        abortRef.current = ac;
+
+        setIsLoading(true);
+        setError(null);
+
+        fetchWidgetsSummary(
+            params.marketplace,
+            params.periodFrom,
+            params.periodTo,
+            ac.signal,
+        )
+            .then((response) => {
+                if (ac.signal.aborted) {
+                    return;
+                }
+                setData(response);
+                setIsLoading(false);
+            })
+            .catch((e: unknown) => {
+                // AbortError — не считаем ошибкой
+                if ((e as { name?: string })?.name === 'AbortError' || ac.signal.aborted) {
+                    return;
+                }
+                const message = e instanceof ApiError
+                    ? e.message
+                    : 'Не удалось загрузить данные. Повторите попытку.';
+                setError(message);
+                setIsLoading(false);
+            });
+
+        return () => {
+            ac.abort();
         };
-
-        if (params.marketplace) {
-            query.marketplace = params.marketplace;
-        }
-
-        void run({
-            url: '/api/marketplace-analytics/unit-extended/widgets',
-            query,
-        });
-    }, [params.marketplace, params.periodFrom, params.periodTo, run]);
-
-    useEffect(() => {
-        load();
-    }, [load]);
+    }, [params.marketplace, params.periodFrom, params.periodTo]);
 
     const toggleWidget = useCallback((key: string) => {
         setExpandedKey((prev) => (prev === key ? null : key));

--- a/site/assets/react/marketplace-analytics/unit-extended/widgets/widgets.api.ts
+++ b/site/assets/react/marketplace-analytics/unit-extended/widgets/widgets.api.ts
@@ -1,0 +1,26 @@
+import { httpJson } from '../../../shared/http/client';
+import type { WidgetsApiResponse } from './widgets.types';
+
+/**
+ * Получить сводку виджетов MarketplaceAnalytics за период
+ * (current + previous + period).
+ */
+export function fetchWidgetsSummary(
+    marketplace: string,
+    periodFrom: string,
+    periodTo: string,
+    signal?: AbortSignal,
+): Promise<WidgetsApiResponse> {
+    return httpJson<WidgetsApiResponse>(
+        '/api/marketplace-analytics/unit-extended/widgets',
+        {
+            method: 'GET',
+            query: {
+                marketplace,
+                periodFrom,
+                periodTo,
+            },
+            signal,
+        },
+    );
+}

--- a/site/assets/react/marketplace-analytics/unit-extended/widgets/widgets.types.ts
+++ b/site/assets/react/marketplace-analytics/unit-extended/widgets/widgets.types.ts
@@ -1,0 +1,32 @@
+import type { CostGroupBreakdown } from '../unitExtended.types';
+
+export interface WidgetsSummary {
+    revenue: number;
+    returnsTotal: number;
+    costPriceTotal: number;
+    totalCosts: number;
+    profit: number;
+    marginPercent: number | null;
+    widgetGroups: CostGroupBreakdown[];
+}
+
+export interface WidgetsApiResponse {
+    current: WidgetsSummary;
+    previous: WidgetsSummary;
+    period: {
+        from: string;
+        to: string;
+        previousFrom: string;
+        previousTo: string;
+    };
+}
+
+export type WidgetType = 'income' | 'expense' | 'profit';
+
+export interface WidgetCardConfig {
+    key: string;
+    label: string;
+    type: WidgetType;
+    icon: string;
+    getValue: (s: WidgetsSummary) => number;
+}

--- a/site/assets/react/marketplace-analytics/unit-extended/widgets/widgetsConfig.ts
+++ b/site/assets/react/marketplace-analytics/unit-extended/widgets/widgetsConfig.ts
@@ -1,0 +1,86 @@
+import type { WidgetCardConfig, WidgetsSummary } from './widgets.types';
+
+/**
+ * Считает сумму netAmount по выбранным widgetGroup.
+ */
+function getGroupNet(s: WidgetsSummary, ...names: string[]): number {
+    return s.widgetGroups
+        .filter((g) => names.includes(g.serviceGroup))
+        .reduce((sum, g) => sum + g.netAmount, 0);
+}
+
+/**
+ * Конфигурация 8 виджетов витрины MarketplaceAnalytics.
+ */
+export const WIDGETS: readonly WidgetCardConfig[] = [
+    {
+        key: 'revenue',
+        label: 'Выручка',
+        type: 'income',
+        icon: 'ti ti-cash',
+        getValue: (s) => s.revenue,
+    },
+    {
+        key: 'returns',
+        label: 'Возвраты',
+        type: 'expense',
+        icon: 'ti ti-arrow-back',
+        getValue: (s) => s.returnsTotal,
+    },
+    {
+        key: 'commission',
+        label: 'Вознаграждение',
+        type: 'expense',
+        icon: 'ti ti-receipt',
+        getValue: (s) => getGroupNet(s, 'Вознаграждение'),
+    },
+    {
+        key: 'delivery_fbo',
+        label: 'Услуги доставки и FBO',
+        type: 'expense',
+        icon: 'ti ti-truck-delivery',
+        getValue: (s) => getGroupNet(s, 'Услуги доставки и FBO'),
+    },
+    {
+        key: 'partners',
+        label: 'Услуги партнёров',
+        type: 'expense',
+        icon: 'ti ti-users',
+        getValue: (s) => getGroupNet(s, 'Услуги партнёров'),
+    },
+    {
+        key: 'promo',
+        label: 'Продвижение и реклама',
+        type: 'expense',
+        icon: 'ti ti-speakerphone',
+        getValue: (s) => getGroupNet(s, 'Продвижение и реклама'),
+    },
+    {
+        key: 'other',
+        label: 'Другие услуги и штрафы',
+        type: 'expense',
+        icon: 'ti ti-alert-triangle',
+        getValue: (s) => getGroupNet(s, 'Другие услуги и штрафы'),
+    },
+    {
+        key: 'profit',
+        label: 'Прибыль',
+        type: 'profit',
+        icon: 'ti ti-trending-up',
+        getValue: (s) => s.profit,
+    },
+];
+
+/**
+ * Маппинг ключа виджета → список serviceGroup, которые раскрываются
+ * в WidgetDetailPanel при клике.
+ *
+ * Виджеты revenue/returns/profit не раскрываются (нет групп).
+ */
+export const WIDGET_KEY_TO_GROUPS: Record<string, string[]> = {
+    commission: ['Вознаграждение'],
+    delivery_fbo: ['Услуги доставки и FBO'],
+    partners: ['Услуги партнёров'],
+    promo: ['Продвижение и реклама'],
+    other: ['Другие услуги и штрафы'],
+};


### PR DESCRIPTION
## Что делает

Frontend для витрины виджетов MarketplaceAnalytics: 8 карточек (revenue, returns, 5 групп затрат, profit) + раскрытие детализации затрат под выбранным виджетом. Под капотом — `httpJson` + `useAbortableQuery` (без TanStack Query), `@tabler/icons-webfont` (классы `ti ti-*`).

## Файлы (`site/assets/react/marketplace-analytics/unit-extended/widgets/`)

- **`widgets.types.ts`** — `WidgetsSummary`, `WidgetsApiResponse`, `WidgetType`, `WidgetCardConfig`. `widgetGroups` переиспользует `CostGroupBreakdown` из `../unitExtended.types`.
- **`widgetsConfig.ts`** — `WIDGETS` (8 конфигов: revenue, returns, commission, delivery_fbo, partners, promo, other, profit) + `WIDGET_KEY_TO_GROUPS` + helper `getGroupNet`.
- **`widgets.api.ts`** — `fetchWidgetsSummary(marketplace, periodFrom, periodTo, signal?)` → `GET /api/marketplace-analytics/unit-extended/widgets`.
- **`useWidgets.ts`** — хук на `useAbortableQuery`, возвращает `{summary, isLoading, error, expandedKey, expandedGroups, toggleWidget}`.
- **`WidgetCard.tsx`** — dumb: `formatMoney`, иконка `<i className={config.icon} />`. Дельта: `income`/`profit` — рост зелёный, `expense` — рост красный.
- **`WidgetDetailPanel.tsx`** — dumb: таблица КАТЕГОРИЯ/НАЧИСЛЕНО/СТОРНО/НЕТТО, заголовок группы (`fw-bold`) + строки категорий (`ps-4 text-secondary`).
- **`WidgetsGrid.tsx`** — сетка `col-sm-6 col-lg-3`, `placeholder-glow` skeleton при загрузке, `WidgetDetailPanel` под сеткой при `expandedKey && expandedGroups.length > 0`.

## Архитектура

- Smart/Dumb split: `useWidgets` отвечает за загрузку и состояние раскрытия, компоненты — чистый рендеринг.
- API: `httpJson` (race-safe) через `useAbortableQuery` (auto-abort при unmount/повторе).
- Стек строго совпадает с уже существующим `useUnitExtended.ts` — без введения новых зависимостей.

## Test plan

- [ ] Открыть страницу UnitExtended → виджеты загружаются параллельно с таблицей.
- [ ] Сменить marketplace / период → запрос перестраивается (старый отменяется).
- [ ] Кликнуть по карточке `commission` / `delivery_fbo` / `partners` / `promo` / `other` → под сеткой раскрывается `WidgetDetailPanel` с группой и подкатегориями.
- [ ] Повторный клик по той же карточке → панель закрывается; клик по другой раскрываемой → переключается.
- [ ] `revenue` / `returns` / `profit` — не раскрываются, не имеют `cursor-pointer`.
- [ ] Дельта-бейджи: рост выручки/прибыли — зелёный, рост затрат/возвратов — красный.
- [ ] Загрузка → 8 placeholder-glow карточек.

## Контекст

Завершает trio задач MarketplaceAnalytics widget UI:
- Backend map + query: #1514
- Backend API контроллер: #1515
- Frontend (этот PR)

Интеграция (рендер `<WidgetsGrid>` в `UnitExtendedWidget.tsx`) — отдельной задачей.