### PR TITLE
feat(marketplace-analytics): интеграция WidgetsGrid в UnitExtendedWidget

### DIFF
--- a/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedWidget.tsx
+++ b/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedWidget.tsx
@@ -1,5 +1,8 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { useUnitExtended } from './useUnitExtended';
+import { useWidgets } from './widgets/useWidgets';
+import WidgetsGrid from './widgets/WidgetsGrid';
+import { ErrorBoundary } from '../../shared/ui/ErrorBoundary';
 import { getMonthRange } from '../utils/utils';
 import type { MarketplaceOption } from '../types/analytics.types';
 import UnitExtendedFilters from './UnitExtendedFilters';
@@ -47,6 +50,12 @@ const UnitExtendedWidget: React.FC<UnitExtendedWidgetProps> = ({ marketplaces })
         periodTo: filters.dateTo,
     });
 
+    const widgets = useWidgets({
+        marketplace: filters.marketplace,
+        periodFrom: filters.dateFrom,
+        periodTo: filters.dateTo,
+    });
+
     const handleMarketplaceChange = useCallback((mp: string) => {
         setFilters((prev) => ({ ...prev, marketplace: mp }));
     }, []);
@@ -83,6 +92,17 @@ const UnitExtendedWidget: React.FC<UnitExtendedWidgetProps> = ({ marketplaces })
                 onDateToChange={handleDateToChange}
                 onDateRangeChange={handleDateRangeChange}
             />
+
+            <ErrorBoundary widgetName="UnitEconomyWidgets">
+                <WidgetsGrid
+                    summary={widgets.summary}
+                    isLoading={widgets.isLoading}
+                    error={widgets.error}
+                    expandedKey={widgets.expandedKey}
+                    expandedGroups={widgets.expandedGroups}
+                    onToggle={widgets.toggleWidget}
+                />
+            </ErrorBoundary>
 
             {isError && (
                 <div className="alert alert-danger mb-3">


### PR DESCRIPTION
## Что делает

Подключает виджеты сводки (созданные в #1516) к существующему `UnitExtendedWidget`. Виджеты появляются между фильтрами и таблицей, грузятся независимо от таблицы, изолированы `ErrorBoundary`.

## Изменения

Один файл — `site/assets/react/marketplace-analytics/unit-extended/UnitExtendedWidget.tsx` (+20 строк, ничего не удалено).

**1. +3 импорта:**
```ts
import { useWidgets } from './widgets/useWidgets';
import WidgetsGrid from './widgets/WidgetsGrid';
import { ErrorBoundary } from '../../shared/ui/ErrorBoundary';
```

**2. +1 хук** — `useWidgets` получает `marketplace/dateFrom/dateTo` из того же `filters` state, что и `useUnitExtended`. Оба хука перезапускаются при смене любого фильтра.

**3. +1 JSX-блок** между `<UnitExtendedFilters>` и table-error+`<UnitExtendedTable>`:
```tsx
<ErrorBoundary widgetName="UnitEconomyWidgets">
    <WidgetsGrid
        summary={widgets.summary}
        isLoading={widgets.isLoading}
        error={widgets.error}
        expandedKey={widgets.expandedKey}
        expandedGroups={widgets.expandedGroups}
        onToggle={widgets.toggleWidget}
    />
</ErrorBoundary>
```

## Отклонения от исходного спека

- `ErrorBoundary` — **named export** (`export class ErrorBoundary`), не default. Импорт скорректирован.
- `WidgetsGrid` — **default export**, не named. Импорт скорректирован.
- Добавлен обязательный prop `error={widgets.error}` (введён в #1516 после ревью gemini/codex). Без него теряется критерий "при ошибке виджетов таблица работает".

## Что НЕ затронуто

- Entrypoint
- Twig-шаблоны
- `vite.config.js`
- Существующая логика фильтров, URL-state, таблицы, table-error alert

## Test plan

- [ ] Открыть страницу UnitExtended → 8 placeholder-glow карточек, ниже — таблица c spinner.
- [ ] После загрузки → карточки с дельта-бейджами + таблица с данными.
- [ ] Клик по `commission` / `delivery_fbo` / `partners` / `promo` / `other` → раскрывается `WidgetDetailPanel` под сеткой.
- [ ] Сменить marketplace / период → оба запроса (виджеты + таблица) перезапускаются параллельно.
- [ ] Симулировать ошибку API виджетов → виджеты показывают `alert-danger`, таблица продолжает работать.
- [ ] Симулировать runtime-ошибку в `WidgetsGrid` → ErrorBoundary показывает fallback, таблица не падает.

## Контекст

Завершает интеграцию trio задач:
- Backend map + query: #1514
- Backend API контроллер: #1515
- Frontend (типы/API/хук/компоненты): #1516
- Интеграция (этот PR)