### PR TITLE
fix(marketplace): cleanup sales before reprocessing Ozon raw document

### DIFF
--- a/site/migrations/Version20260414000000.php
+++ b/site/migrations/Version20260414000000.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Индекс на marketplace_sales.raw_document_id.
+ *
+ * OzonSalesRawProcessor::process() чистит записи по raw_document_id перед
+ * повторной обработкой (и OzonCostsRawProcessor делает аналогично — там индекс
+ * idx_cost_raw_document уже существует). Без индекса DELETE превращается в
+ * sequential scan по всей таблице.
+ *
+ * Парный индекс на marketplace_returns.raw_document_id не добавляется — там
+ * DELETE по этому столбцу пока не выполняется.
+ */
+final class Version20260414000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add index on marketplace_sales.raw_document_id to support DELETE by raw document during reprocessing';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_sale_raw_document ON marketplace_sales (raw_document_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS idx_sale_raw_document');
+    }
+}

--- a/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
@@ -8,10 +8,12 @@ use App\Company\Entity\Company;
 use App\Marketplace\Application\ProcessOzonSalesAction;
 use App\Marketplace\Application\Service\MarketplaceCostPriceResolver;
 use App\Marketplace\Application\Service\OzonListingEnsureService;
+use App\Marketplace\Entity\MarketplaceRawDocument;
 use App\Marketplace\Entity\MarketplaceSale;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Enum\StagingRecordType;
 use App\Marketplace\Repository\MarketplaceSaleRepository;
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
@@ -21,6 +23,7 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
     public function __construct(
         private readonly ProcessOzonSalesAction $action,
         private readonly EntityManagerInterface $em,
+        private readonly Connection $connection,
         private readonly MarketplaceSaleRepository $saleRepository,
         private readonly OzonListingEnsureService $listingEnsureService,
         private readonly MarketplaceCostPriceResolver $costPriceResolver,
@@ -40,7 +43,73 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
 
     public function process(string $companyId, string $rawDocId): int
     {
-        return ($this->action)($companyId, $rawDocId);
+        $rawDoc = $this->em->find(MarketplaceRawDocument::class, $rawDocId);
+        if (!$rawDoc instanceof MarketplaceRawDocument) {
+            throw new \RuntimeException('Raw document not found: ' . $rawDocId);
+        }
+
+        $periodFrom = $rawDoc->getPeriodFrom()->format('Y-m-d');
+        $periodTo   = $rawDoc->getPeriodTo()->format('Y-m-d');
+
+        $this->connection->beginTransaction();
+
+        try {
+            // 1. Удалить записи этого raw-документа (для повторной обработки).
+            //    document_id IS NULL — не трогаем уже закрытые в ОПиУ.
+            $deletedByDoc = (int) $this->connection->executeStatement(
+                'DELETE FROM marketplace_sales
+                 WHERE raw_document_id = :docId
+                   AND document_id IS NULL',
+                ['docId' => $rawDocId],
+            );
+
+            // 2. Удалить legacy-записи без raw_document_id за тот же период
+            //    (результат работы старого ProcessOzonSalesAction до внедрения raw_document_id).
+            $deletedLegacy = (int) $this->connection->executeStatement(
+                'DELETE FROM marketplace_sales
+                 WHERE raw_document_id IS NULL
+                   AND document_id IS NULL
+                   AND company_id = :companyId
+                   AND marketplace = :marketplace
+                   AND sale_date BETWEEN :periodFrom AND :periodTo',
+                [
+                    'companyId'   => $companyId,
+                    'marketplace' => MarketplaceType::OZON->value,
+                    'periodFrom'  => $periodFrom,
+                    'periodTo'    => $periodTo,
+                ],
+            );
+
+            if ($deletedByDoc > 0 || $deletedLegacy > 0) {
+                $this->logger->info(
+                    sprintf(
+                        '[Ozon] Очищено %d sales (по raw_document_id) + %d legacy sales за период %s—%s перед обработкой документа %s',
+                        $deletedByDoc,
+                        $deletedLegacy,
+                        $periodFrom,
+                        $periodTo,
+                        $rawDocId,
+                    ),
+                    [
+                        'raw_doc_id'     => $rawDocId,
+                        'company_id'     => $companyId,
+                        'deleted_by_doc' => $deletedByDoc,
+                        'deleted_legacy' => $deletedLegacy,
+                        'period_from'    => $periodFrom,
+                        'period_to'      => $periodTo,
+                    ],
+                );
+            }
+
+            $result = ($this->action)($companyId, $rawDocId);
+
+            $this->connection->commit();
+
+            return $result;
+        } catch (\Throwable $e) {
+            $this->connection->rollBack();
+            throw $e;
+        }
     }
 
     /**

--- a/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
@@ -63,15 +63,23 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
                 ['docId' => $rawDocId],
             );
 
-            // 2. Удалить legacy-записи без raw_document_id за тот же период
-            //    (результат работы старого ProcessOzonSalesAction до внедрения raw_document_id).
+            // 2. Удалить legacy-записи без raw_document_id за тот же период.
+            //    AND price_per_unit > 0 — отсекает storno-записи, которые создаёт
+            //    OzonSalesRawProcessor::processBatch() (negative accruals_for_sale,
+            //    suffix _storno, price_per_unit < 0). ProcessOzonSalesAction их не
+            //    пересоздаёт (фильтр accruals_for_sale > 0), поэтому без этого
+            //    условия DELETE навсегда потерял бы storno. Старый легаси-поток
+            //    (ProcessOzonSalesAction до внедрения raw_document_id) всегда
+            //    создавал записи с положительным price_per_unit — они под фильтр
+            //    попадают.
             $deletedLegacy = (int) $this->connection->executeStatement(
                 'DELETE FROM marketplace_sales
                  WHERE raw_document_id IS NULL
                    AND document_id IS NULL
                    AND company_id = :companyId
                    AND marketplace = :marketplace
-                   AND sale_date BETWEEN :periodFrom AND :periodTo',
+                   AND sale_date BETWEEN :periodFrom AND :periodTo
+                   AND price_per_unit > 0',
                 [
                     'companyId'   => $companyId,
                     'marketplace' => MarketplaceType::OZON->value,

--- a/site/src/Marketplace/Entity/MarketplaceSale.php
+++ b/site/src/Marketplace/Entity/MarketplaceSale.php
@@ -13,6 +13,7 @@ use Webmozart\Assert\Assert;
 #[ORM\Table(name: 'marketplace_sales')]
 #[ORM\Index(columns: ['company_id', 'sale_date'], name: 'idx_company_sale_date')]
 #[ORM\Index(columns: ['marketplace', 'external_order_id'], name: 'idx_marketplace_order')]
+#[ORM\Index(columns: ['raw_document_id'], name: 'idx_sale_raw_document')]
 #[ORM\UniqueConstraint(name: 'uniq_marketplace_srid', columns: ['marketplace', 'external_order_id'])]
 class MarketplaceSale
 {


### PR DESCRIPTION
## Проблема

При повторной обработке raw-документов `OzonSalesRawProcessor` создавал дубли в `marketplace_sales`, потому что не удалял старые записи перед вставкой. Также оставались legacy-записи без `raw_document_id` от старого `ProcessOzonSalesAction` (до внедрения FK на raw-документ).

## Решение

В `OzonSalesRawProcessor::process()` перед вызовом `ProcessOzonSalesAction` добавлены два DELETE внутри explicit-транзакции:

1. **Этот raw-документ:** `DELETE FROM marketplace_sales WHERE raw_document_id = :docId AND document_id IS NULL`
2. **Legacy за период:** `DELETE FROM marketplace_sales WHERE raw_document_id IS NULL AND document_id IS NULL AND company_id = :id AND marketplace = 'ozon' AND sale_date BETWEEN :from AND :to`

Период берётся из `MarketplaceRawDocument::periodFrom`/`periodTo`.

## Решения по scope

- **Только `marketplace_sales`** — `returns`/`costs` не трогаем (SRP, у них свои процессоры; `OzonCostsRawProcessor` уже чистит себя сам).
- **`AND document_id IS NULL` во всех DELETE** — защита записей, закрытых в ОПиУ (тот же паттерн, что и в `OzonCostsRawProcessor::process()`).
- **Explicit транзакция через `Connection::beginTransaction()`** — DELETE + persist/flush из `ProcessOzonSalesAction` атомарны; при ошибке `flush()` удалённые записи восстанавливаются через `rollBack()`.
- **`processBatch()` не трогаем** — у него нет контекста `rawDocId` (TODO в интерфейсе `MarketplaceRawProcessorInterface`).

## Изменённые файлы

- `site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php` — добавлен `Doctrine\DBAL\Connection` в конструктор (autowire), переписан `process()` с очисткой и транзакцией.

## Логирование

Если что-то удалено, пишется info-лог:
`[Ozon] Очищено N sales (по raw_document_id) + M legacy sales за период X—Y перед обработкой документа Z`

## Test plan

- [ ] Загрузить Ozon sales raw-документ, обработать — создаются sales с `raw_document_id`.
- [ ] Повторно обработать тот же raw-документ — старые записи удаляются, новые вставляются, дублей в `marketplace_sales` нет.
- [ ] Перед повторной обработкой часть записей привязать к `Document` (ОПиУ): `document_id` должен остаться, они не удаляются.
- [ ] Создать legacy-записи без `raw_document_id` за период документа — при обработке удаляются (кроме тех, у кого выставлен `document_id`).
- [ ] Эмулировать исключение в `ProcessOzonSalesAction` — транзакция откатывается, старые sales остаются на месте.

https://claude.ai/code/session_019vAaXCYrBsAqQxv4etok9i