### PR TITLE
fix(marketplace): propagate rawDocId through processBatch

### DIFF
--- a/site/src/Marketplace/Application/ProcessMarketplaceRawDocumentAction.php
+++ b/site/src/Marketplace/Application/ProcessMarketplaceRawDocumentAction.php
@@ -122,7 +122,12 @@ final readonly class ProcessMarketplaceRawDocumentAction
             if (count($buckets[$bucketKey]) >= 500) {
                 if ($bucketKey === $targetBucketKey) {
                     $processor = $this->processorRegistry->get($type, $marketplace);
-                    $processor->processBatch($command->companyId, $marketplace, $buckets[$bucketKey]);
+                    $processor->processBatch(
+                        $command->companyId,
+                        $marketplace,
+                        $buckets[$bucketKey],
+                        $command->rawDocId,
+                    );
                     $totalProcessed += count($buckets[$bucketKey]);
                     $this->entityManager->clear();
                     $this->costCategoryResolver->resetCache();
@@ -143,7 +148,12 @@ final readonly class ProcessMarketplaceRawDocumentAction
 
             $type = StagingRecordType::from($bucketKey);
             $processor = $this->processorRegistry->get($type, $marketplace);
-            $processor->processBatch($command->companyId, $marketplace, $bucketRows);
+            $processor->processBatch(
+                $command->companyId,
+                $marketplace,
+                $bucketRows,
+                $command->rawDocId,
+            );
             $totalProcessed += count($bucketRows);
             $this->entityManager->clear();
             $this->costCategoryResolver->resetCache();

--- a/site/src/Marketplace/Application/Processor/MarketplaceOtherProcessor.php
+++ b/site/src/Marketplace/Application/Processor/MarketplaceOtherProcessor.php
@@ -21,8 +21,12 @@ final readonly class MarketplaceOtherProcessor implements MarketplaceRawProcesso
     /**
      * @param array<int, array<string, mixed>> $rawRows
      */
-    public function processBatch(string $companyId, MarketplaceType $marketplace, array $rawRows): void
-    {
+    public function processBatch(
+        string $companyId,
+        MarketplaceType $marketplace,
+        array $rawRows,
+        ?string $rawDocId = null,
+    ): void {
         // TODO: save to staging table for unknown operations
     }
 

--- a/site/src/Marketplace/Application/Processor/MarketplaceRawProcessorInterface.php
+++ b/site/src/Marketplace/Application/Processor/MarketplaceRawProcessorInterface.php
@@ -19,10 +19,17 @@ interface MarketplaceRawProcessorInterface
 
     public function process(string $companyId, string $rawDocId): int;
 
-    // TODO: передавать rawDocId через интерфейс processBatch() — отдельная задача
-
     /**
+     * Обработка батча из daily pipeline.
+     * rawDocId проставляется на создаваемые entity (raw_document_id)
+     * и используется для очистки legacy-записей перед вставкой.
+     *
      * @param array<int, array<string, mixed>> $rawRows
      */
-    public function processBatch(string $companyId, MarketplaceType $marketplace, array $rawRows): void;
+    public function processBatch(
+        string $companyId,
+        MarketplaceType $marketplace,
+        array $rawRows,
+        ?string $rawDocId = null,
+    ): void;
 }

--- a/site/src/Marketplace/Application/Processor/OzonReturnsRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonReturnsRawProcessor.php
@@ -48,8 +48,12 @@ final class OzonReturnsRawProcessor implements MarketplaceRawProcessorInterface
     /**
      * @param array<int, array<string, mixed>> $rawRows
      */
-    public function processBatch(string $companyId, MarketplaceType $marketplace, array $rawRows): void
-    {
+    public function processBatch(
+        string $companyId,
+        MarketplaceType $marketplace,
+        array $rawRows,
+        ?string $rawDocId = null,
+    ): void {
         if (empty($rawRows)) {
             return;
         }
@@ -135,6 +139,9 @@ final class OzonReturnsRawProcessor implements MarketplaceRawProcessorInterface
             $return->setReturnReason($op['operation_type_name'] ?? null);
             $return->setCostPrice($this->costPriceResolver->resolveForReturn($listing, $sale, $op));
             $return->setRawData($op);
+            if ($rawDocId !== null) {
+                $return->setRawDocumentId($rawDocId);
+            }
 
             $this->em->persist($return);
             $existingMap[$externalId] = true;

--- a/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
@@ -55,66 +55,10 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
             throw new \RuntimeException('Raw document not found: ' . $rawDocId);
         }
 
-        $periodFrom = $rawDoc->getPeriodFrom()->format('Y-m-d');
-        $periodTo   = $rawDoc->getPeriodTo()->format('Y-m-d');
-
         $this->connection->beginTransaction();
 
         try {
-            // 1. Удалить записи этого raw-документа (для повторной обработки).
-            //    document_id IS NULL — не трогаем уже закрытые в ОПиУ.
-            $deletedByDoc = (int) $this->connection->executeStatement(
-                'DELETE FROM marketplace_sales
-                 WHERE raw_document_id = :docId
-                   AND document_id IS NULL',
-                ['docId' => $rawDocId],
-            );
-
-            // 2. Удалить legacy-записи без raw_document_id за тот же период.
-            //    AND price_per_unit > 0 — отсекает storno-записи, которые создаёт
-            //    OzonSalesRawProcessor::processBatch() (negative accruals_for_sale,
-            //    suffix _storno, price_per_unit < 0). ProcessOzonSalesAction их не
-            //    пересоздаёт (фильтр accruals_for_sale > 0), поэтому без этого
-            //    условия DELETE навсегда потерял бы storno. Старый легаси-поток
-            //    (ProcessOzonSalesAction до внедрения raw_document_id) всегда
-            //    создавал записи с положительным price_per_unit — они под фильтр
-            //    попадают.
-            $deletedLegacy = (int) $this->connection->executeStatement(
-                'DELETE FROM marketplace_sales
-                 WHERE raw_document_id IS NULL
-                   AND document_id IS NULL
-                   AND company_id = :companyId
-                   AND marketplace = :marketplace
-                   AND sale_date BETWEEN :periodFrom AND :periodTo
-                   AND price_per_unit > 0',
-                [
-                    'companyId'   => $companyId,
-                    'marketplace' => MarketplaceType::OZON->value,
-                    'periodFrom'  => $periodFrom,
-                    'periodTo'    => $periodTo,
-                ],
-            );
-
-            if ($deletedByDoc > 0 || $deletedLegacy > 0) {
-                $this->logger->info(
-                    sprintf(
-                        '[Ozon] Очищено %d sales (по raw_document_id) + %d legacy sales за период %s—%s перед обработкой документа %s',
-                        $deletedByDoc,
-                        $deletedLegacy,
-                        $periodFrom,
-                        $periodTo,
-                        $rawDocId,
-                    ),
-                    [
-                        'raw_doc_id'     => $rawDocId,
-                        'company_id'     => $companyId,
-                        'deleted_by_doc' => $deletedByDoc,
-                        'deleted_legacy' => $deletedLegacy,
-                        'period_from'    => $periodFrom,
-                        'period_to'      => $periodTo,
-                    ],
-                );
-            }
+            $this->cleanupLegacySales($companyId, $rawDocId);
 
             $result = ($this->action)($companyId, $rawDocId);
 

--- a/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
@@ -168,20 +168,6 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
         // Идемпотентное создание/загрузка листингов (безопасно при параллельной обработке)
         $listingsCache = $this->listingEnsureService->ensureListings($company, $skusWithNames);
 
-        $allExternalIds = array_values(array_map(
-            static function (array $op): string {
-                $postingNumber = $op['posting']['posting_number'] ?? '';
-                $externalId = $postingNumber !== '' ? $postingNumber : (string) ($op['operation_id'] ?? '');
-                // Storno operations get a suffix to avoid UNIQUE constraint conflict
-                if ((float) ($op['accruals_for_sale'] ?? 0) < 0) {
-                    $externalId .= '_storno';
-                }
-                return $externalId;
-            },
-            $salesData,
-        ));
-        $existingMap = $this->saleRepository->getExistingExternalIds($companyId, $allExternalIds);
-
         // Очистка legacy-записей + вставка идут в одной транзакции.
         // Очистка запускается только один раз для каждого rawDocId
         // (daily pipeline может разбивать один raw документ на несколько батчей).
@@ -197,6 +183,23 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
                 $this->cleanupLegacySales($companyId, $rawDocId);
                 $this->cleanedUpRawDocId = $rawDocId;
             }
+
+            // existingMap строится ПОСЛЕ cleanup — иначе только что удалённые
+            // external_id попадут в карту и insert-цикл ошибочно пропустит их
+            // как «уже существующие», оставляя пустоты в marketplace_sales.
+            $allExternalIds = array_values(array_map(
+                static function (array $op): string {
+                    $postingNumber = $op['posting']['posting_number'] ?? '';
+                    $externalId = $postingNumber !== '' ? $postingNumber : (string) ($op['operation_id'] ?? '');
+                    // Storno operations get a suffix to avoid UNIQUE constraint conflict
+                    if ((float) ($op['accruals_for_sale'] ?? 0) < 0) {
+                        $externalId .= '_storno';
+                    }
+                    return $externalId;
+                },
+                $salesData,
+            ));
+            $existingMap = $this->saleRepository->getExistingExternalIds($companyId, $allExternalIds);
 
             foreach ($salesData as $op) {
                 $postingNumber = $op['posting']['posting_number'] ?? '';

--- a/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
@@ -20,6 +20,13 @@ use Ramsey\Uuid\Uuid;
 
 final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
 {
+    /**
+     * Последний rawDocId, для которого уже выполнена очистка legacy-записей
+     * в рамках текущего жизненного цикла процессора. Нужен для идемпотентности,
+     * когда один rawDocument разбит на несколько батчей (>500 строк).
+     */
+    private ?string $cleanedUpRawDocId = null;
+
     public function __construct(
         private readonly ProcessOzonSalesAction $action,
         private readonly EntityManagerInterface $em,
@@ -123,8 +130,12 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
     /**
      * @param array<int, array<string, mixed>> $rawRows
      */
-    public function processBatch(string $companyId, MarketplaceType $marketplace, array $rawRows): void
-    {
+    public function processBatch(
+        string $companyId,
+        MarketplaceType $marketplace,
+        array $rawRows,
+        ?string $rawDocId = null,
+    ): void {
         if (empty($rawRows)) {
             return;
         }
@@ -171,56 +182,149 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
         ));
         $existingMap = $this->saleRepository->getExistingExternalIds($companyId, $allExternalIds);
 
-        foreach ($salesData as $op) {
-            $postingNumber = $op['posting']['posting_number'] ?? '';
-            $externalId = $postingNumber !== '' ? $postingNumber : (string) ($op['operation_id'] ?? '');
+        // Очистка legacy-записей + вставка идут в одной транзакции.
+        // Очистка запускается только один раз для каждого rawDocId
+        // (daily pipeline может разбивать один raw документ на несколько батчей).
+        $shouldCleanup  = $rawDocId !== null && $this->cleanedUpRawDocId !== $rawDocId;
+        $useTransaction = $rawDocId !== null;
 
-            $accrual  = (float) ($op['accruals_for_sale'] ?? 0);
-            $isStorno = $accrual < 0;
-
-            // Storno operations get a suffix to avoid UNIQUE constraint conflict
-            if ($isStorno) {
-                $externalId .= '_storno';
-            }
-
-            if ($externalId === '' || isset($existingMap[$externalId])) {
-                continue;
-            }
-
-            $firstItem = ($op['items'] ?? [])[0] ?? null;
-            $sku = $firstItem ? (string) ($firstItem['sku'] ?? '') : '';
-            $listing = $listingsCache[$sku] ?? null;
-
-            if (!$listing) {
-                $this->logger->warning('[Ozon] processBatch sales: listing not found', [
-                    'external_id' => $externalId,
-                    'sku'         => $sku,
-                ]);
-                continue;
-            }
-
-            $saleDate = new \DateTimeImmutable($op['operation_date']);
-
-            $sale = new MarketplaceSale(
-                Uuid::uuid4()->toString(),
-                $company,
-                $listing,
-                MarketplaceType::OZON,
-            );
-
-            $sale->setExternalOrderId($externalId);
-            $sale->setSaleDate($saleDate);
-            $sale->setQuantity(count($op['items'] ?? []) ?: 1);
-            $sale->setPricePerUnit((string) $accrual);
-            $sale->setTotalRevenue((string) $accrual);
-            // Storno: no goods shipped, cost_price must be null
-            $sale->setCostPrice($isStorno ? null : $this->costPriceResolver->resolveForSale($listing, $saleDate));
-            $sale->setRawData($op);
-
-            $this->em->persist($sale);
-            $existingMap[$externalId] = true;
+        if ($useTransaction) {
+            $this->connection->beginTransaction();
         }
 
-        $this->em->flush();
+        try {
+            if ($shouldCleanup) {
+                $this->cleanupLegacySales($companyId, $rawDocId);
+                $this->cleanedUpRawDocId = $rawDocId;
+            }
+
+            foreach ($salesData as $op) {
+                $postingNumber = $op['posting']['posting_number'] ?? '';
+                $externalId = $postingNumber !== '' ? $postingNumber : (string) ($op['operation_id'] ?? '');
+
+                $accrual  = (float) ($op['accruals_for_sale'] ?? 0);
+                $isStorno = $accrual < 0;
+
+                // Storno operations get a suffix to avoid UNIQUE constraint conflict
+                if ($isStorno) {
+                    $externalId .= '_storno';
+                }
+
+                if ($externalId === '' || isset($existingMap[$externalId])) {
+                    continue;
+                }
+
+                $firstItem = ($op['items'] ?? [])[0] ?? null;
+                $sku = $firstItem ? (string) ($firstItem['sku'] ?? '') : '';
+                $listing = $listingsCache[$sku] ?? null;
+
+                if (!$listing) {
+                    $this->logger->warning('[Ozon] processBatch sales: listing not found', [
+                        'external_id' => $externalId,
+                        'sku'         => $sku,
+                    ]);
+                    continue;
+                }
+
+                $saleDate = new \DateTimeImmutable($op['operation_date']);
+
+                $sale = new MarketplaceSale(
+                    Uuid::uuid4()->toString(),
+                    $company,
+                    $listing,
+                    MarketplaceType::OZON,
+                );
+
+                $sale->setExternalOrderId($externalId);
+                $sale->setSaleDate($saleDate);
+                $sale->setQuantity(count($op['items'] ?? []) ?: 1);
+                $sale->setPricePerUnit((string) $accrual);
+                $sale->setTotalRevenue((string) $accrual);
+                // Storno: no goods shipped, cost_price must be null
+                $sale->setCostPrice($isStorno ? null : $this->costPriceResolver->resolveForSale($listing, $saleDate));
+                $sale->setRawData($op);
+                if ($rawDocId !== null) {
+                    $sale->setRawDocumentId($rawDocId);
+                }
+
+                $this->em->persist($sale);
+                $existingMap[$externalId] = true;
+            }
+
+            $this->em->flush();
+
+            if ($useTransaction) {
+                $this->connection->commit();
+            }
+        } catch (\Throwable $e) {
+            if ($useTransaction && $this->connection->isTransactionActive()) {
+                $this->connection->rollBack();
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Удаляет записи текущего raw-документа (идемпотентный повтор обработки)
+     * и legacy-записи без raw_document_id за тот же период.
+     *
+     * - `document_id IS NULL` — не трогаем уже закрытые в ОПиУ записи.
+     * - `price_per_unit > 0` в легаси-DELETE — отсекает storno-записи
+     *   (negative accruals_for_sale, суффикс `_storno`, price_per_unit < 0),
+     *   которых у старого потока `ProcessOzonSalesAction` не было.
+     */
+    private function cleanupLegacySales(string $companyId, string $rawDocId): void
+    {
+        $rawDoc = $this->em->find(MarketplaceRawDocument::class, $rawDocId);
+        if (!$rawDoc instanceof MarketplaceRawDocument) {
+            return;
+        }
+
+        $periodFrom = $rawDoc->getPeriodFrom()->format('Y-m-d');
+        $periodTo   = $rawDoc->getPeriodTo()->format('Y-m-d');
+
+        $deletedByDoc = (int) $this->connection->executeStatement(
+            'DELETE FROM marketplace_sales
+             WHERE raw_document_id = :docId
+               AND document_id IS NULL',
+            ['docId' => $rawDocId],
+        );
+
+        $deletedLegacy = (int) $this->connection->executeStatement(
+            'DELETE FROM marketplace_sales
+             WHERE raw_document_id IS NULL
+               AND document_id IS NULL
+               AND company_id = :companyId
+               AND marketplace = :marketplace
+               AND sale_date BETWEEN :periodFrom AND :periodTo
+               AND price_per_unit > 0',
+            [
+                'companyId'   => $companyId,
+                'marketplace' => MarketplaceType::OZON->value,
+                'periodFrom'  => $periodFrom,
+                'periodTo'    => $periodTo,
+            ],
+        );
+
+        if ($deletedByDoc > 0 || $deletedLegacy > 0) {
+            $this->logger->info(
+                sprintf(
+                    '[Ozon] Очищено %d sales (по raw_document_id) + %d legacy sales за период %s—%s перед обработкой документа %s',
+                    $deletedByDoc,
+                    $deletedLegacy,
+                    $periodFrom,
+                    $periodTo,
+                    $rawDocId,
+                ),
+                [
+                    'raw_doc_id'     => $rawDocId,
+                    'company_id'     => $companyId,
+                    'deleted_by_doc' => $deletedByDoc,
+                    'deleted_legacy' => $deletedLegacy,
+                    'period_from'    => $periodFrom,
+                    'period_to'      => $periodTo,
+                ],
+            );
+        }
     }
 }

--- a/site/src/Marketplace/Application/Processor/WbCostsRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/WbCostsRawProcessor.php
@@ -59,8 +59,12 @@ final class WbCostsRawProcessor implements MarketplaceRawProcessorInterface
     /**
      * @param array<int, array<string, mixed>> $rawRows
      */
-    public function processBatch(string $companyId, MarketplaceType $marketplace, array $rawRows): void
-    {
+    public function processBatch(
+        string $companyId,
+        MarketplaceType $marketplace,
+        array $rawRows,
+        ?string $rawDocId = null,
+    ): void {
         if (empty($rawRows)) {
             return;
         }
@@ -240,6 +244,9 @@ final class WbCostsRawProcessor implements MarketplaceRawProcessorInterface
             );
 
             $cost->setExternalId($externalId);
+            if ($rawDocId !== null) {
+                $cost->setRawDocumentId($rawDocId);
+            }
             $cost->setCostDate($costData['cost_date']);
             $cost->setAmount($costData['amount']);
             $cost->setDescription($costData['description']);

--- a/site/src/Marketplace/Application/Processor/WbReturnsRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/WbReturnsRawProcessor.php
@@ -52,8 +52,12 @@ final class WbReturnsRawProcessor implements MarketplaceRawProcessorInterface
     /**
      * @param array<int, array<string, mixed>> $rawRows
      */
-    public function processBatch(string $companyId, MarketplaceType $marketplace, array $rawRows): void
-    {
+    public function processBatch(
+        string $companyId,
+        MarketplaceType $marketplace,
+        array $rawRows,
+        ?string $rawDocId = null,
+    ): void {
         if (empty($rawRows)) {
             return;
         }
@@ -149,6 +153,9 @@ final class WbReturnsRawProcessor implements MarketplaceRawProcessorInterface
             $return->setReturnReason($item['supplier_oper_name'] ?? '');
             $return->setCostPrice($this->costPriceResolver->resolveForReturn($listing, $sale, $item));
             $return->setRawData($item);
+            if ($rawDocId !== null) {
+                $return->setRawDocumentId($rawDocId);
+            }
 
             if ($sale !== null) {
                 $return->setSale($sale);

--- a/site/src/Marketplace/Application/Processor/WbSalesRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/WbSalesRawProcessor.php
@@ -50,8 +50,12 @@ final class WbSalesRawProcessor implements MarketplaceRawProcessorInterface
     /**
      * @param array<int, array<string, mixed>> $rawRows
      */
-    public function processBatch(string $companyId, MarketplaceType $marketplace, array $rawRows): void
-    {
+    public function processBatch(
+        string $companyId,
+        MarketplaceType $marketplace,
+        array $rawRows,
+        ?string $rawDocId = null,
+    ): void {
         if (empty($rawRows)) {
             return;
         }
@@ -142,6 +146,9 @@ final class WbSalesRawProcessor implements MarketplaceRawProcessorInterface
             $sale->setTotalRevenue((string) abs((float) ($item['retail_amount'] ?? 0)));
             $sale->setCostPrice($this->costPriceResolver->resolveForSale($listing, $saleDate));
             $sale->setRawData($item);
+            if ($rawDocId !== null) {
+                $sale->setRawDocumentId($rawDocId);
+            }
 
             $this->em->persist($sale);
             $existingMap[$srid] = true;

--- a/site/tests/Unit/Marketplace/MarketplaceRawProcessorRegistryTest.php
+++ b/site/tests/Unit/Marketplace/MarketplaceRawProcessorRegistryTest.php
@@ -26,7 +26,7 @@ final class MarketplaceRawProcessorRegistryTest extends TestCase
                 return 5;
             }
 
-            public function processBatch(string $companyId, MarketplaceType $marketplace, array $rawRows): void {}
+            public function processBatch(string $companyId, MarketplaceType $marketplace, array $rawRows, ?string $rawDocId = null): void {}
         };
 
         $repo = $this->createMock(MarketplaceRawDocumentRepository::class);
@@ -42,7 +42,7 @@ final class MarketplaceRawProcessorRegistryTest extends TestCase
                     return 0;
                 }
 
-                public function processBatch(string $companyId, MarketplaceType $marketplace, array $rawRows): void {}
+                public function processBatch(string $companyId, MarketplaceType $marketplace, array $rawRows, ?string $rawDocId = null): void {}
             },
             $target,
         ], $repo);


### PR DESCRIPTION
## Summary

- Fixes the root cause of the 229 Ozon sales rows persisted with `raw_document_id = NULL`: the daily pipeline orchestrator calls `processBatch()`, but sales/returns processors neither accepted nor propagated `rawDocId`, so rows inserted via the daily path were never stamped.
- `MarketplaceRawProcessorInterface::processBatch()` now accepts `?string $rawDocId = null`; `ProcessMarketplaceRawDocumentAction` passes `$command->rawDocId` at both call sites.
- `OzonSalesRawProcessor::processBatch()` now stamps `raw_document_id`, runs the same legacy cleanup as `process()` (DELETE by `raw_document_id AND document_id IS NULL` + NULL-rawDoc cleanup over the batch's sale-date window with `price_per_unit > 0` so storno pairs and already-filed rows are preserved), and wraps cleanup + persist + flush in an explicit DBAL transaction. A `$cleanedUpRawDocId` tracking field makes the cleanup idempotent across multi-batch invocations for the same document.
- `OzonReturnsRawProcessor`, `WbSalesRawProcessor`, `WbReturnsRawProcessor`, `WbCostsRawProcessor`: accept `rawDocId` and call `setRawDocumentId()` on each new entity before persist. `MarketplaceOtherProcessor`: signature-only update.
- `MarketplaceRawProcessorRegistryTest`: anonymous-class stubs updated to conform to the new interface signature.

## Test plan

- [ ] `vendor/bin/phpunit tests/Unit/Marketplace/MarketplaceRawProcessorRegistryTest.php` passes on CI (could not run locally — `vendor/` not installed in this environment).
- [ ] Reprocess an Ozon raw document via the daily pipeline and confirm every inserted `marketplace_sales` row has the matching `raw_document_id`.
- [ ] Reprocess a raw document with more than 500 operations and confirm cleanup runs once, without wiping prior batches' inserts.
- [ ] Reprocess a document twice; confirm already-filed rows (`document_id IS NOT NULL`) and storno rows (`price_per_unit < 0`) are not deleted.
- [ ] Verify WB sales / returns / costs now also get `raw_document_id` stamped via the daily pipeline.

https://claude.ai/code/session_01SemPnHsPDYibiPaUiYA6j1