### PR TITLE
fix(marketplace): cleanup returns before reprocessing Ozon raw document

### DIFF
--- a/site/src/Marketplace/Application/Processor/OzonReturnsRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonReturnsRawProcessor.php
@@ -118,7 +118,6 @@ final class OzonReturnsRawProcessor implements MarketplaceRawProcessorInterface
         try {
             if ($shouldCleanup) {
                 $this->cleanupLegacyReturns($companyId, $rawDocId);
-                $this->cleanedUpRawDocId = $rawDocId;
             }
 
             // existingMap строится ПОСЛЕ cleanup — иначе только что удалённые
@@ -197,6 +196,14 @@ final class OzonReturnsRawProcessor implements MarketplaceRawProcessorInterface
 
             if ($useTransaction) {
                 $this->connection->commit();
+            }
+
+            // Marker выставляется ТОЛЬКО после успешного commit — иначе
+            // откат транзакции оставил бы in-memory флаг установленным,
+            // и retry в том же worker-процессе пропустил бы cleanup,
+            // считая стороние legacy-строки валидными через existingMap.
+            if ($shouldCleanup) {
+                $this->cleanedUpRawDocId = $rawDocId;
             }
         } catch (\Throwable $e) {
             if ($useTransaction && $this->connection->isTransactionActive()) {

--- a/site/src/Marketplace/Application/Processor/OzonReturnsRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonReturnsRawProcessor.php
@@ -8,20 +8,30 @@ use App\Company\Entity\Company;
 use App\Marketplace\Application\ProcessOzonReturnsAction;
 use App\Marketplace\Application\Service\MarketplaceCostPriceResolver;
 use App\Marketplace\Application\Service\OzonListingEnsureService;
+use App\Marketplace\Entity\MarketplaceRawDocument;
 use App\Marketplace\Entity\MarketplaceReturn;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Enum\StagingRecordType;
 use App\Marketplace\Repository\MarketplaceReturnRepository;
 use App\Marketplace\Repository\MarketplaceSaleRepository;
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
 
 final class OzonReturnsRawProcessor implements MarketplaceRawProcessorInterface
 {
+    /**
+     * Последний rawDocId, для которого уже выполнена очистка legacy-записей
+     * в рамках текущего жизненного цикла процессора. Нужен для идемпотентности,
+     * когда один rawDocument разбит на несколько батчей.
+     */
+    private ?string $cleanedUpRawDocId = null;
+
     public function __construct(
         private readonly ProcessOzonReturnsAction $action,
         private readonly EntityManagerInterface $em,
+        private readonly Connection $connection,
         private readonly MarketplaceReturnRepository $returnRepository,
         private readonly OzonListingEnsureService $listingEnsureService,
         private readonly MarketplaceSaleRepository $saleRepository,
@@ -42,7 +52,25 @@ final class OzonReturnsRawProcessor implements MarketplaceRawProcessorInterface
 
     public function process(string $companyId, string $rawDocId): int
     {
-        return ($this->action)($companyId, $rawDocId);
+        $rawDoc = $this->em->find(MarketplaceRawDocument::class, $rawDocId);
+        if (!$rawDoc instanceof MarketplaceRawDocument) {
+            throw new \RuntimeException('Raw document not found: ' . $rawDocId);
+        }
+
+        $this->connection->beginTransaction();
+
+        try {
+            $this->cleanupLegacyReturns($companyId, $rawDocId);
+
+            $result = ($this->action)($companyId, $rawDocId);
+
+            $this->connection->commit();
+
+            return $result;
+        } catch (\Throwable $e) {
+            $this->connection->rollBack();
+            throw $e;
+        }
     }
 
     /**
@@ -77,76 +105,164 @@ final class OzonReturnsRawProcessor implements MarketplaceRawProcessorInterface
         // Идемпотентное создание/загрузка листингов (безопасно при параллельной обработке)
         $listingsCache = $this->listingEnsureService->ensureListings($company, $skusWithNames);
 
-        // Дедупликация
-        $allExternalIds = array_values(array_map(
-            static function (array $op): string {
-                $postingNumber = $op['posting']['posting_number'] ?? '';
-                return $postingNumber !== '' ? $postingNumber : (string) ($op['operation_id'] ?? '');
-            },
-            $rawRows,
-        ));
-        $existingMap = $this->returnRepository->getExistingExternalIds($companyId, $allExternalIds);
+        // Очистка legacy-записей + вставка идут в одной транзакции.
+        // Очистка запускается только один раз для каждого rawDocId
+        // (daily pipeline может разбивать один raw документ на несколько батчей).
+        $shouldCleanup  = $rawDocId !== null && $this->cleanedUpRawDocId !== $rawDocId;
+        $useTransaction = $rawDocId !== null;
 
-        foreach ($rawRows as $op) {
-            $postingNumber = $op['posting']['posting_number'] ?? '';
-            $externalId = $postingNumber !== '' ? $postingNumber : (string) ($op['operation_id'] ?? '');
-
-            if ($externalId === '' || isset($existingMap[$externalId])) {
-                continue;
-            }
-
-            $firstItem = ($op['items'] ?? [])[0] ?? null;
-            $sku = $firstItem ? (string) ($firstItem['sku'] ?? '') : '';
-            $listing = $listingsCache[$sku] ?? null;
-
-            if (!$listing) {
-                $this->logger->warning('[Ozon] processBatch returns: listing not found', [
-                    'external_id'    => $externalId,
-                    'operation_type' => $op['operation_type'] ?? '',
-                    'sku'            => $sku,
-                ]);
-                continue;
-            }
-
-            // Ищем связанную продажу по posting_number для получения costPrice
-            $sale = null;
-            if ($postingNumber !== '') {
-                $sale = $this->saleRepository->findByMarketplaceOrder(
-                    $company,
-                    MarketplaceType::OZON,
-                    $postingNumber,
-                );
-            }
-
-            $refundAmount = abs((float) ($op['accruals_for_sale'] ?? 0));
-            if ($refundAmount <= 0) {
-                $refundAmount = abs((float) ($op['amount'] ?? 0));
-            }
-
-            $returnDate = new \DateTimeImmutable($op['operation_date']);
-
-            $return = new MarketplaceReturn(
-                Uuid::uuid4()->toString(),
-                $company,
-                $listing,
-                MarketplaceType::OZON,
-            );
-
-            $return->setExternalReturnId($externalId);
-            $return->setReturnDate($returnDate);
-            $return->setQuantity(count($op['items'] ?? []) ?: 1);
-            $return->setRefundAmount((string) $refundAmount);
-            $return->setReturnReason($op['operation_type_name'] ?? null);
-            $return->setCostPrice($this->costPriceResolver->resolveForReturn($listing, $sale, $op));
-            $return->setRawData($op);
-            if ($rawDocId !== null) {
-                $return->setRawDocumentId($rawDocId);
-            }
-
-            $this->em->persist($return);
-            $existingMap[$externalId] = true;
+        if ($useTransaction) {
+            $this->connection->beginTransaction();
         }
 
-        $this->em->flush();
+        try {
+            if ($shouldCleanup) {
+                $this->cleanupLegacyReturns($companyId, $rawDocId);
+                $this->cleanedUpRawDocId = $rawDocId;
+            }
+
+            // existingMap строится ПОСЛЕ cleanup — иначе только что удалённые
+            // external_id попадут в карту и insert-цикл ошибочно пропустит их
+            // как «уже существующие», оставляя пустоты в marketplace_returns.
+            $allExternalIds = array_values(array_map(
+                static function (array $op): string {
+                    $postingNumber = $op['posting']['posting_number'] ?? '';
+                    return $postingNumber !== '' ? $postingNumber : (string) ($op['operation_id'] ?? '');
+                },
+                $rawRows,
+            ));
+            $existingMap = $this->returnRepository->getExistingExternalIds($companyId, $allExternalIds);
+
+            foreach ($rawRows as $op) {
+                $postingNumber = $op['posting']['posting_number'] ?? '';
+                $externalId = $postingNumber !== '' ? $postingNumber : (string) ($op['operation_id'] ?? '');
+
+                if ($externalId === '' || isset($existingMap[$externalId])) {
+                    continue;
+                }
+
+                $firstItem = ($op['items'] ?? [])[0] ?? null;
+                $sku = $firstItem ? (string) ($firstItem['sku'] ?? '') : '';
+                $listing = $listingsCache[$sku] ?? null;
+
+                if (!$listing) {
+                    $this->logger->warning('[Ozon] processBatch returns: listing not found', [
+                        'external_id'    => $externalId,
+                        'operation_type' => $op['operation_type'] ?? '',
+                        'sku'            => $sku,
+                    ]);
+                    continue;
+                }
+
+                // Ищем связанную продажу по posting_number для получения costPrice
+                $sale = null;
+                if ($postingNumber !== '') {
+                    $sale = $this->saleRepository->findByMarketplaceOrder(
+                        $company,
+                        MarketplaceType::OZON,
+                        $postingNumber,
+                    );
+                }
+
+                $refundAmount = abs((float) ($op['accruals_for_sale'] ?? 0));
+                if ($refundAmount <= 0) {
+                    $refundAmount = abs((float) ($op['amount'] ?? 0));
+                }
+
+                $returnDate = new \DateTimeImmutable($op['operation_date']);
+
+                $return = new MarketplaceReturn(
+                    Uuid::uuid4()->toString(),
+                    $company,
+                    $listing,
+                    MarketplaceType::OZON,
+                );
+
+                $return->setExternalReturnId($externalId);
+                $return->setReturnDate($returnDate);
+                $return->setQuantity(count($op['items'] ?? []) ?: 1);
+                $return->setRefundAmount((string) $refundAmount);
+                $return->setReturnReason($op['operation_type_name'] ?? null);
+                $return->setCostPrice($this->costPriceResolver->resolveForReturn($listing, $sale, $op));
+                $return->setRawData($op);
+                if ($rawDocId !== null) {
+                    $return->setRawDocumentId($rawDocId);
+                }
+
+                $this->em->persist($return);
+                $existingMap[$externalId] = true;
+            }
+
+            $this->em->flush();
+
+            if ($useTransaction) {
+                $this->connection->commit();
+            }
+        } catch (\Throwable $e) {
+            if ($useTransaction && $this->connection->isTransactionActive()) {
+                $this->connection->rollBack();
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Удаляет записи текущего raw-документа (идемпотентный повтор обработки)
+     * и legacy-записи без raw_document_id за тот же период.
+     *
+     * `document_id IS NULL` — не трогаем уже закрытые в ОПиУ записи.
+     */
+    private function cleanupLegacyReturns(string $companyId, string $rawDocId): void
+    {
+        $rawDoc = $this->em->find(MarketplaceRawDocument::class, $rawDocId);
+        if (!$rawDoc instanceof MarketplaceRawDocument) {
+            return;
+        }
+
+        $periodFrom = $rawDoc->getPeriodFrom()->format('Y-m-d');
+        $periodTo   = $rawDoc->getPeriodTo()->format('Y-m-d');
+
+        $deletedByDoc = (int) $this->connection->executeStatement(
+            'DELETE FROM marketplace_returns
+             WHERE raw_document_id = :docId
+               AND document_id IS NULL',
+            ['docId' => $rawDocId],
+        );
+
+        $deletedLegacy = (int) $this->connection->executeStatement(
+            'DELETE FROM marketplace_returns
+             WHERE raw_document_id IS NULL
+               AND document_id IS NULL
+               AND company_id = :companyId
+               AND marketplace = :marketplace
+               AND return_date BETWEEN :periodFrom AND :periodTo',
+            [
+                'companyId'   => $companyId,
+                'marketplace' => MarketplaceType::OZON->value,
+                'periodFrom'  => $periodFrom,
+                'periodTo'    => $periodTo,
+            ],
+        );
+
+        if ($deletedByDoc > 0 || $deletedLegacy > 0) {
+            $this->logger->info(
+                sprintf(
+                    '[Ozon] Очищено %d returns (по raw_document_id) + %d legacy returns за период %s—%s перед обработкой документа %s',
+                    $deletedByDoc,
+                    $deletedLegacy,
+                    $periodFrom,
+                    $periodTo,
+                    $rawDocId,
+                ),
+                [
+                    'raw_doc_id'     => $rawDocId,
+                    'company_id'     => $companyId,
+                    'deleted_by_doc' => $deletedByDoc,
+                    'deleted_legacy' => $deletedLegacy,
+                    'period_from'    => $periodFrom,
+                    'period_to'      => $periodTo,
+                ],
+            );
+        }
     }
 }

--- a/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
@@ -125,7 +125,6 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
         try {
             if ($shouldCleanup) {
                 $this->cleanupLegacySales($companyId, $rawDocId);
-                $this->cleanedUpRawDocId = $rawDocId;
             }
 
             // existingMap строится ПОСЛЕ cleanup — иначе только что удалённые
@@ -202,6 +201,14 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
 
             if ($useTransaction) {
                 $this->connection->commit();
+            }
+
+            // Marker выставляется ТОЛЬКО после успешного commit — иначе
+            // откат транзакции оставил бы in-memory флаг установленным,
+            // и retry в том же worker-процессе пропустил бы cleanup,
+            // считая стороние legacy-строки валидными через existingMap.
+            if ($shouldCleanup) {
+                $this->cleanedUpRawDocId = $rawDocId;
             }
         } catch (\Throwable $e) {
             if ($useTransaction && $this->connection->isTransactionActive()) {


### PR DESCRIPTION
## Summary

Миррорит логику `OzonSalesRawProcessor` на возвраты: перед вставкой удаляются записи текущего raw-документа (идемпотентный повтор) и legacy-записи без `raw_document_id` за тот же период. `document_id IS NULL` защищает уже закрытые в ОПиУ записи.

- Добавлен `Doctrine\DBAL\Connection` в конструктор `OzonReturnsRawProcessor`.
- Новый метод `cleanupLegacyReturns()` выполняет два `DELETE` на `marketplace_returns`: по `raw_document_id` и по периоду `return_date` для legacy-записей.
- Очистка работает в обоих путях — `process()` и `processBatch()` — обёрнута в explicit-транзакцию вместе со вставкой. В `processBatch()` есть guard `$cleanedUpRawDocId` против повторного cleanup при разбивке raw-документа на несколько батчей.
- `existingMap` строится **после** cleanup, иначе только что удалённые `external_id` ошибочно отсекли бы новые вставки.
- Логирование: `[Ozon] Очищено N returns (по raw_document_id) + M legacy returns за период ...`.

Отличие от sales: в returns нет clause `AND price_per_unit > 0` — storno-логики с отрицательными суммами в возвратах нет, `refundAmount` всегда `abs(...)`.

## Test plan

- [ ] Повторная обработка одного raw-документа не создаёт дубли `marketplace_returns`.
- [ ] Legacy-записи (`raw_document_id IS NULL`) за период документа удаляются перед вставкой.
- [ ] Записи с непустым `document_id` (закрытые в ОПиУ) не удаляются.
- [ ] `processBatch()` с одним `rawDocId` в нескольких батчах выполняет cleanup только один раз.
- [ ] Ошибка на этапе вставки приводит к rollback всей транзакции (cleanup тоже откатывается).

https://claude.ai/code/session_01V6NZz3tntqob4VVgGxNWy6