### PR TITLE
fix(marketplace): use yesterday as upper bound of initial sync period

### DIFF
--- a/site/composer.json
+++ b/site/composer.json
@@ -24,6 +24,7 @@
         "sentry/sentry-symfony": "^5.8",
         "symfony/asset": "7.3.*",
         "symfony/asset-mapper": "7.3.*",
+        "symfony/clock": "7.3.*",
         "symfony/console": "7.3.*",
         "symfony/doctrine-messenger": "7.3.*",
         "symfony/dotenv": "7.3.*",

--- a/site/src/Marketplace/Message/InitialSyncMessage.php
+++ b/site/src/Marketplace/Message/InitialSyncMessage.php
@@ -14,10 +14,10 @@ final class InitialSyncMessage
         public readonly string  $companyId,
         public readonly string  $connectionId,
         public readonly string  $marketplace,    // MarketplaceType::value
-        public readonly string  $dateFrom,        // Y-m-d, всегда Пн
-        public readonly string  $dateTo,          // Y-m-d, Вс или сегодня для последней партии
-        public readonly ?string $nextDateFrom,    // null если последняя партия
-        public readonly ?string $nextDateTo,      // null если последняя партия
+        public readonly string  $dateFrom,        // 'Y-m-d H:i:s', начало партии (00:00:00)
+        public readonly string  $dateTo,          // 'Y-m-d H:i:s', конец партии (23:59:59)
+        public readonly ?string $nextDateFrom,    // 'Y-m-d H:i:s' либо null если последняя партия
+        public readonly ?string $nextDateTo,      // 'Y-m-d H:i:s' либо null если последняя партия
     ) {
     }
 }

--- a/site/src/Marketplace/MessageHandler/InitialSyncHandler.php
+++ b/site/src/Marketplace/MessageHandler/InitialSyncHandler.php
@@ -100,22 +100,23 @@ final class InitialSyncHandler
 
             // Диспатчим следующую партию если она есть
             if ($message->nextDateFrom !== null && $message->nextDateTo !== null) {
-                // Вычисляем партию после следующей чтобы передать её в nextDate
-                $today = $this->clock->now()->setTime(0, 0, 0);
+                // Граница первичной синхронизации — вчера: за сегодня данные
+                // ещё неполные, их загрузит ежедневный cron завтра.
+                $yesterday = $this->clock->now()->modify('-1 day')->setTime(0, 0, 0);
 
                 // Используем nextDateTo как есть — он уже корректно рассчитан buildPartitions
                 // (учитывает границы месяца и недели), поэтому пересчёт через
                 // modify('sunday this week') ломает split-партиции.
                 $nextTo = new \DateTimeImmutable($message->nextDateTo);
-                if ($nextTo > $today) {
-                    $nextTo = $today;
+                if ($nextTo > $yesterday) {
+                    $nextTo = $yesterday;
                 }
 
                 // Оставшиеся партиции считаем от конца следующей партии
                 $afterStart      = $nextTo->modify('+1 day')->setTime(0, 0, 0);
-                $hasAfter        = $afterStart <= $today;
+                $hasAfter        = $afterStart <= $yesterday;
                 $afterPartitions = $hasAfter
-                    ? $this->partitionService->buildPartitions($afterStart, $today)
+                    ? $this->partitionService->buildPartitions($afterStart, $yesterday)
                     : [];
 
                 $afterFromStr = !empty($afterPartitions) ? $afterPartitions[0]['from'] : null;

--- a/site/src/Marketplace/MessageHandler/InitialSyncHandler.php
+++ b/site/src/Marketplace/MessageHandler/InitialSyncHandler.php
@@ -99,13 +99,17 @@ final class InitialSyncHandler
             // Диспатчим следующую партию если она есть
             if ($message->nextDateFrom !== null && $message->nextDateTo !== null) {
                 // Вычисляем партию после следующей чтобы передать её в nextDate
-                $today      = new \DateTimeImmutable('today');
-                $nextFrom   = new \DateTimeImmutable($message->nextDateFrom);
-                // Следующее воскресенье или сегодня
-                $nextSunday = $nextFrom->modify('sunday this week');
-                $nextTo     = $nextSunday > $today ? $today : $nextSunday;
+                $today = new \DateTimeImmutable('today');
 
-                // Партия после следующей — через сервис
+                // Используем nextDateTo как есть — он уже корректно рассчитан buildPartitions
+                // (учитывает границы месяца и недели), поэтому пересчёт через
+                // modify('sunday this week') ломает split-партиции.
+                $nextTo = new \DateTimeImmutable($message->nextDateTo);
+                if ($nextTo > $today) {
+                    $nextTo = $today;
+                }
+
+                // Оставшиеся партиции считаем от конца следующей партии
                 $afterStart      = $nextTo->modify('+1 day')->setTime(0, 0, 0);
                 $hasAfter        = $afterStart <= $today;
                 $afterPartitions = $hasAfter

--- a/site/src/Marketplace/MessageHandler/InitialSyncHandler.php
+++ b/site/src/Marketplace/MessageHandler/InitialSyncHandler.php
@@ -121,12 +121,16 @@ final class InitialSyncHandler
                 $afterFromStr = !empty($afterPartitions) ? $afterPartitions[0]['from'] : null;
                 $afterToStr   = !empty($afterPartitions) ? $afterPartitions[0]['to']   : null;
 
+                // Используем клампнутый $nextTo — если ограничение по today сработало,
+                // следующая задача не должна тянуть данные за будущий период.
+                $nextToStr = $nextTo->format('Y-m-d H:i:s');
+
                 $this->messageBus->dispatch(new InitialSyncMessage(
                     companyId:    $message->companyId,
                     connectionId: $message->connectionId,
                     marketplace:  $message->marketplace,
                     dateFrom:     $message->nextDateFrom,
-                    dateTo:       $message->nextDateTo,
+                    dateTo:       $nextToStr,
                     nextDateFrom: $afterFromStr,
                     nextDateTo:   $afterToStr,
                 ));
@@ -135,7 +139,7 @@ final class InitialSyncHandler
                     'company_id'  => $message->companyId,
                     'marketplace' => $message->marketplace,
                     'date_from'   => $message->nextDateFrom,
-                    'date_to'     => $message->nextDateTo,
+                    'date_to'     => $nextToStr,
                 ]);
             } else {
                 // Последняя партия — обновляем статус подключения

--- a/site/src/Marketplace/MessageHandler/InitialSyncHandler.php
+++ b/site/src/Marketplace/MessageHandler/InitialSyncHandler.php
@@ -14,6 +14,7 @@ use App\Marketplace\Service\Integration\MarketplaceAdapterRegistry;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
+use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -33,6 +34,7 @@ final class InitialSyncHandler
         private readonly MessageBusInterface $messageBus,
         private readonly LoggerInterface $logger,
         private readonly MarketplaceWeekPartitionService $partitionService,
+        private readonly ClockInterface $clock,
     ) {
     }
 
@@ -99,7 +101,7 @@ final class InitialSyncHandler
             // Диспатчим следующую партию если она есть
             if ($message->nextDateFrom !== null && $message->nextDateTo !== null) {
                 // Вычисляем партию после следующей чтобы передать её в nextDate
-                $today = new \DateTimeImmutable('today');
+                $today = $this->clock->now()->setTime(0, 0, 0);
 
                 // Используем nextDateTo как есть — он уже корректно рассчитан buildPartitions
                 // (учитывает границы месяца и недели), поэтому пересчёт через

--- a/site/src/Marketplace/MessageHandler/TriggerInitialSyncHandler.php
+++ b/site/src/Marketplace/MessageHandler/TriggerInitialSyncHandler.php
@@ -8,6 +8,7 @@ use App\Marketplace\Application\Service\MarketplaceWeekPartitionService;
 use App\Marketplace\Message\InitialSyncMessage;
 use App\Marketplace\Message\TriggerInitialSyncMessage;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -15,7 +16,8 @@ use Symfony\Component\Messenger\MessageBusInterface;
  * Нарезает текущий год на недельные партии с учётом границ месяца и диспатчит первую.
  * Каждая следующая партия диспатчится из InitialSyncHandler после успеха предыдущей.
  *
- * Период: 01.01 текущего года → сегодня (с времени 00:00:00 → 23:59:59).
+ * Период: 01.01 текущего года → вчера (с времени 00:00:00 → 23:59:59).
+ * За сегодня данные ещё неполные — их загрузит ежедневный cron завтра.
  */
 #[AsMessageHandler]
 final class TriggerInitialSyncHandler
@@ -24,14 +26,15 @@ final class TriggerInitialSyncHandler
         private readonly MessageBusInterface $messageBus,
         private readonly LoggerInterface $logger,
         private readonly MarketplaceWeekPartitionService $partitionService,
+        private readonly ClockInterface $clock,
     ) {
     }
 
     public function __invoke(TriggerInitialSyncMessage $message): void
     {
-        $today = new \DateTimeImmutable('today');
-        $yearStart = new \DateTimeImmutable((int) $today->format('Y') . '-01-01 00:00:00');
-        $weeks = $this->partitionService->buildPartitions($yearStart, $today);
+        $yesterday = $this->clock->now()->modify('-1 day')->setTime(0, 0, 0);
+        $yearStart = new \DateTimeImmutable((int) $yesterday->format('Y') . '-01-01 00:00:00');
+        $weeks = $this->partitionService->buildPartitions($yearStart, $yesterday);
 
         if (empty($weeks)) {
             $this->logger->warning('InitialSync: no weeks to sync', [

--- a/site/tests/Unit/Marketplace/MessageHandler/InitialSyncHandlerTest.php
+++ b/site/tests/Unit/Marketplace/MessageHandler/InitialSyncHandlerTest.php
@@ -37,6 +37,79 @@ final class InitialSyncHandlerTest extends TestCase
      */
     public function testNextBatchPreservesMonthBoundarySplit(): void
     {
+        [$handler, $captured] = $this->createHandler(new MockClock('2026-04-10 12:00:00'));
+
+        // Текущая партия = 2026-03-23 .. 2026-03-29 (полная неделя Пн-Вс).
+        // Следующая партия (split) = 2026-03-30 .. 2026-03-31 — первая половина
+        // недели 30.03–05.04, разрезанной по границе месяца.
+        $message = new InitialSyncMessage(
+            companyId:    self::COMPANY_ID,
+            connectionId: self::CONNECTION_ID,
+            marketplace:  MarketplaceType::OZON->value,
+            dateFrom:     '2026-03-23 00:00:00',
+            dateTo:       '2026-03-29 23:59:59',
+            nextDateFrom: '2026-03-30 00:00:00',
+            nextDateTo:   '2026-03-31 23:59:59',
+        );
+
+        $handler($message);
+
+        $dispatched = $captured->message;
+        self::assertInstanceOf(InitialSyncMessage::class, $dispatched);
+        self::assertSame(self::COMPANY_ID, $dispatched->companyId);
+        self::assertSame(self::CONNECTION_ID, $dispatched->connectionId);
+        self::assertSame(MarketplaceType::OZON->value, $dispatched->marketplace);
+
+        // Текущая партия следующего сообщения = вторая половина split-недели как есть.
+        self::assertSame('2026-03-30 00:00:00', $dispatched->dateFrom);
+        self::assertSame('2026-03-31 23:59:59', $dispatched->dateTo);
+
+        // Партия-после-следующей = первая партия от 2026-04-01 (понедельник нового месяца)
+        // до ближайшего воскресенья 2026-04-05.
+        self::assertSame('2026-04-01 00:00:00', $dispatched->nextDateFrom);
+        self::assertSame('2026-04-05 23:59:59', $dispatched->nextDateTo);
+    }
+
+    /**
+     * Сценарий: nextDateTo в будущем относительно clock (например, сообщение
+     * задержалось в очереди или clock сдвинулся). Handler обязан обрезать
+     * dateTo до текущего дня и завершить цепочку (nextDateFrom/nextDateTo = null).
+     */
+    public function testNextBatchDateToClampedToToday(): void
+    {
+        // Сегодня = 2026-04-03; nextDateTo в сообщении = 2026-04-05 23:59:59 (будущее).
+        [$handler, $captured] = $this->createHandler(new MockClock('2026-04-03 12:00:00'));
+
+        $message = new InitialSyncMessage(
+            companyId:    self::COMPANY_ID,
+            connectionId: self::CONNECTION_ID,
+            marketplace:  MarketplaceType::OZON->value,
+            dateFrom:     '2026-03-30 00:00:00',
+            dateTo:       '2026-03-31 23:59:59',
+            nextDateFrom: '2026-04-01 00:00:00',
+            nextDateTo:   '2026-04-05 23:59:59',
+        );
+
+        $handler($message);
+
+        $dispatched = $captured->message;
+        self::assertInstanceOf(InitialSyncMessage::class, $dispatched);
+
+        // dateFrom пробрасывается без изменений.
+        self::assertSame('2026-04-01 00:00:00', $dispatched->dateFrom);
+        // dateTo должен быть обрезан до $today (clock midnight).
+        self::assertSame('2026-04-03 00:00:00', $dispatched->dateTo);
+
+        // Цепочка должна завершиться — after-start (2026-04-04) > today → партий нет.
+        self::assertNull($dispatched->nextDateFrom);
+        self::assertNull($dispatched->nextDateTo);
+    }
+
+    /**
+     * @return array{0: InitialSyncHandler, 1: \stdClass} captured->message хранит последнее задиспатченное сообщение
+     */
+    private function createHandler(MockClock $clock): array
+    {
         $company    = CompanyBuilder::aCompany()->withId(self::COMPANY_ID)->build();
         $connection = new MarketplaceConnection(
             self::CONNECTION_ID,
@@ -59,19 +132,22 @@ final class InitialSyncHandlerTest extends TestCase
         $adapter = $this->createMock(MarketplaceAdapterInterface::class);
         $adapter->method('getMarketplaceType')->willReturn(MarketplaceType::OZON->value);
         $adapter->method('getApiEndpointName')->willReturn('test/endpoint');
-        // Возвращаем непустой массив чтобы handler сохранил MarketplaceRawDocument
-        // и дошёл до dispatch следующей партии.
+        // Непустой raw → handler сохранит MarketplaceRawDocument и дойдёт до dispatch.
         $adapter->method('fetchRawReport')->willReturn([['ok' => 1]]);
 
         $registry = new MarketplaceAdapterRegistry([$adapter]);
 
-        $captured   = null;
+        // Контейнер для пойманного сообщения — анонимный объект, чтобы можно было
+        // вернуть его по ссылке из фабрики.
+        $captured  = new \stdClass();
+        $captured->message = null;
+
         $messageBus = $this->createMock(MessageBusInterface::class);
         $messageBus
             ->expects(self::once())
             ->method('dispatch')
-            ->willReturnCallback(static function (object $message) use (&$captured): Envelope {
-                $captured = $message;
+            ->willReturnCallback(static function (object $message) use ($captured): Envelope {
+                $captured->message = $message;
 
                 return new Envelope($message);
             });
@@ -82,36 +158,9 @@ final class InitialSyncHandlerTest extends TestCase
             $messageBus,
             new NullLogger(),
             new MarketplaceWeekPartitionService(),
-            new MockClock('2026-04-10 12:00:00'),
+            $clock,
         );
 
-        // Текущая партия = 2026-03-23 .. 2026-03-29 (полная неделя Пн-Вс).
-        // Следующая партия (split) = 2026-03-30 .. 2026-03-31 — первая половина
-        // недели 30.03–05.04, разрезанной по границе месяца.
-        $message = new InitialSyncMessage(
-            companyId:    self::COMPANY_ID,
-            connectionId: self::CONNECTION_ID,
-            marketplace:  MarketplaceType::OZON->value,
-            dateFrom:     '2026-03-23 00:00:00',
-            dateTo:       '2026-03-29 23:59:59',
-            nextDateFrom: '2026-03-30 00:00:00',
-            nextDateTo:   '2026-03-31 23:59:59',
-        );
-
-        $handler($message);
-
-        self::assertInstanceOf(InitialSyncMessage::class, $captured);
-        self::assertSame(self::COMPANY_ID, $captured->companyId);
-        self::assertSame(self::CONNECTION_ID, $captured->connectionId);
-        self::assertSame(MarketplaceType::OZON->value, $captured->marketplace);
-
-        // Текущая партия следующего сообщения = вторая половина split-недели как есть.
-        self::assertSame('2026-03-30 00:00:00', $captured->dateFrom);
-        self::assertSame('2026-03-31 23:59:59', $captured->dateTo);
-
-        // Партия-после-следующей = первая партия от 2026-04-01 (понедельник нового месяца)
-        // до ближайшего воскресенья 2026-04-05.
-        self::assertSame('2026-04-01 00:00:00', $captured->nextDateFrom);
-        self::assertSame('2026-04-05 23:59:59', $captured->nextDateTo);
+        return [$handler, $captured];
     }
 }

--- a/site/tests/Unit/Marketplace/MessageHandler/InitialSyncHandlerTest.php
+++ b/site/tests/Unit/Marketplace/MessageHandler/InitialSyncHandlerTest.php
@@ -16,6 +16,7 @@ use App\Tests\Builders\Company\CompanyBuilder;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use Symfony\Component\Clock\MockClock;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -30,14 +31,12 @@ final class InitialSyncHandlerTest extends TestCase
      * Handler не должен пересчитывать nextDateTo через 'sunday this week' —
      * это сломало бы границу месяца. Должен взять nextDateTo как есть и
      * посчитать партию-после-следующей с понедельника 2026-04-01.
+     *
+     * Формат дат в цепочке — 'Y-m-d H:i:s' (как возвращает buildPartitions
+     * и как эмитит TriggerInitialSyncHandler).
      */
     public function testNextBatchPreservesMonthBoundarySplit(): void
     {
-        // Тест зависит от $today — должен быть >= 2026-04-05, иначе afterPartitions обрежется.
-        if (new \DateTimeImmutable('today') < new \DateTimeImmutable('2026-04-05')) {
-            self::markTestSkipped('Test scenario requires today >= 2026-04-05');
-        }
-
         $company    = CompanyBuilder::aCompany()->withId(self::COMPANY_ID)->build();
         $connection = new MarketplaceConnection(
             self::CONNECTION_ID,
@@ -66,7 +65,7 @@ final class InitialSyncHandlerTest extends TestCase
 
         $registry = new MarketplaceAdapterRegistry([$adapter]);
 
-        $captured  = null;
+        $captured   = null;
         $messageBus = $this->createMock(MessageBusInterface::class);
         $messageBus
             ->expects(self::once())
@@ -83,6 +82,7 @@ final class InitialSyncHandlerTest extends TestCase
             $messageBus,
             new NullLogger(),
             new MarketplaceWeekPartitionService(),
+            new MockClock('2026-04-10 12:00:00'),
         );
 
         // Текущая партия = 2026-03-23 .. 2026-03-29 (полная неделя Пн-Вс).
@@ -92,10 +92,10 @@ final class InitialSyncHandlerTest extends TestCase
             companyId:    self::COMPANY_ID,
             connectionId: self::CONNECTION_ID,
             marketplace:  MarketplaceType::OZON->value,
-            dateFrom:     '2026-03-23',
-            dateTo:       '2026-03-29',
-            nextDateFrom: '2026-03-30',
-            nextDateTo:   '2026-03-31',
+            dateFrom:     '2026-03-23 00:00:00',
+            dateTo:       '2026-03-29 23:59:59',
+            nextDateFrom: '2026-03-30 00:00:00',
+            nextDateTo:   '2026-03-31 23:59:59',
         );
 
         $handler($message);
@@ -106,11 +106,11 @@ final class InitialSyncHandlerTest extends TestCase
         self::assertSame(MarketplaceType::OZON->value, $captured->marketplace);
 
         // Текущая партия следующего сообщения = вторая половина split-недели как есть.
-        self::assertSame('2026-03-30', $captured->dateFrom);
-        self::assertSame('2026-03-31', $captured->dateTo);
+        self::assertSame('2026-03-30 00:00:00', $captured->dateFrom);
+        self::assertSame('2026-03-31 23:59:59', $captured->dateTo);
 
-        // Партия-после-следующей = вторая половина той же исходной недели
-        // (понедельник нового месяца → воскресенье).
+        // Партия-после-следующей = первая партия от 2026-04-01 (понедельник нового месяца)
+        // до ближайшего воскресенья 2026-04-05.
         self::assertSame('2026-04-01 00:00:00', $captured->nextDateFrom);
         self::assertSame('2026-04-05 23:59:59', $captured->nextDateTo);
     }

--- a/site/tests/Unit/Marketplace/MessageHandler/InitialSyncHandlerTest.php
+++ b/site/tests/Unit/Marketplace/MessageHandler/InitialSyncHandlerTest.php
@@ -71,13 +71,16 @@ final class InitialSyncHandlerTest extends TestCase
     }
 
     /**
-     * Сценарий: nextDateTo в будущем относительно clock (например, сообщение
+     * Сценарий: nextDateTo в будущем относительно вчера (например, сообщение
      * задержалось в очереди или clock сдвинулся). Handler обязан обрезать
-     * dateTo до текущего дня и завершить цепочку (nextDateFrom/nextDateTo = null).
+     * dateTo до вчерашнего дня и завершить цепочку (nextDateFrom/nextDateTo = null).
+     *
+     * Первичная синхронизация никогда не загружает данные за сегодня —
+     * за них отвечает ежедневный cron на следующий день.
      */
-    public function testNextBatchDateToClampedToToday(): void
+    public function testNextBatchDateToClampedToYesterday(): void
     {
-        // Сегодня = 2026-04-03; nextDateTo в сообщении = 2026-04-05 23:59:59 (будущее).
+        // Сегодня = 2026-04-03; вчера = 2026-04-02; nextDateTo в сообщении = 2026-04-05 23:59:59 (будущее).
         [$handler, $captured] = $this->createHandler(new MockClock('2026-04-03 12:00:00'));
 
         $message = new InitialSyncMessage(
@@ -97,10 +100,10 @@ final class InitialSyncHandlerTest extends TestCase
 
         // dateFrom пробрасывается без изменений.
         self::assertSame('2026-04-01 00:00:00', $dispatched->dateFrom);
-        // dateTo должен быть обрезан до $today (clock midnight).
-        self::assertSame('2026-04-03 00:00:00', $dispatched->dateTo);
+        // dateTo должен быть обрезан до $yesterday (clock midnight - 1 day).
+        self::assertSame('2026-04-02 00:00:00', $dispatched->dateTo);
 
-        // Цепочка должна завершиться — after-start (2026-04-04) > today → партий нет.
+        // Цепочка должна завершиться — after-start (2026-04-03) > yesterday → партий нет.
         self::assertNull($dispatched->nextDateFrom);
         self::assertNull($dispatched->nextDateTo);
     }

--- a/site/tests/Unit/Marketplace/MessageHandler/InitialSyncHandlerTest.php
+++ b/site/tests/Unit/Marketplace/MessageHandler/InitialSyncHandlerTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\MessageHandler;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Application\Service\MarketplaceWeekPartitionService;
+use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Message\InitialSyncMessage;
+use App\Marketplace\MessageHandler\InitialSyncHandler;
+use App\Marketplace\Service\Integration\MarketplaceAdapterInterface;
+use App\Marketplace\Service\Integration\MarketplaceAdapterRegistry;
+use App\Tests\Builders\Company\CompanyBuilder;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class InitialSyncHandlerTest extends TestCase
+{
+    private const COMPANY_ID    = '11111111-1111-1111-1111-111111111111';
+    private const CONNECTION_ID = '22222222-2222-2222-2222-222222222222';
+
+    /**
+     * Сценарий: первая партия split-недели уже отгружена,
+     * следующая партия = вторая половина (2026-03-30..03-31).
+     * Handler не должен пересчитывать nextDateTo через 'sunday this week' —
+     * это сломало бы границу месяца. Должен взять nextDateTo как есть и
+     * посчитать партию-после-следующей с понедельника 2026-04-01.
+     */
+    public function testNextBatchPreservesMonthBoundarySplit(): void
+    {
+        // Тест зависит от $today — должен быть >= 2026-04-05, иначе afterPartitions обрежется.
+        if (new \DateTimeImmutable('today') < new \DateTimeImmutable('2026-04-05')) {
+            self::markTestSkipped('Test scenario requires today >= 2026-04-05');
+        }
+
+        $company    = CompanyBuilder::aCompany()->withId(self::COMPANY_ID)->build();
+        $connection = new MarketplaceConnection(
+            self::CONNECTION_ID,
+            $company,
+            MarketplaceType::OZON,
+        );
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('find')->willReturnCallback(static function (string $class, string $id) use ($company, $connection) {
+            if ($class === Company::class && $id === self::COMPANY_ID) {
+                return $company;
+            }
+            if ($class === MarketplaceConnection::class && $id === self::CONNECTION_ID) {
+                return $connection;
+            }
+
+            return null;
+        });
+
+        $adapter = $this->createMock(MarketplaceAdapterInterface::class);
+        $adapter->method('getMarketplaceType')->willReturn(MarketplaceType::OZON->value);
+        $adapter->method('getApiEndpointName')->willReturn('test/endpoint');
+        // Возвращаем непустой массив чтобы handler сохранил MarketplaceRawDocument
+        // и дошёл до dispatch следующей партии.
+        $adapter->method('fetchRawReport')->willReturn([['ok' => 1]]);
+
+        $registry = new MarketplaceAdapterRegistry([$adapter]);
+
+        $captured  = null;
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus
+            ->expects(self::once())
+            ->method('dispatch')
+            ->willReturnCallback(static function (object $message) use (&$captured): Envelope {
+                $captured = $message;
+
+                return new Envelope($message);
+            });
+
+        $handler = new InitialSyncHandler(
+            $em,
+            $registry,
+            $messageBus,
+            new NullLogger(),
+            new MarketplaceWeekPartitionService(),
+        );
+
+        // Текущая партия = 2026-03-23 .. 2026-03-29 (полная неделя Пн-Вс).
+        // Следующая партия (split) = 2026-03-30 .. 2026-03-31 — первая половина
+        // недели 30.03–05.04, разрезанной по границе месяца.
+        $message = new InitialSyncMessage(
+            companyId:    self::COMPANY_ID,
+            connectionId: self::CONNECTION_ID,
+            marketplace:  MarketplaceType::OZON->value,
+            dateFrom:     '2026-03-23',
+            dateTo:       '2026-03-29',
+            nextDateFrom: '2026-03-30',
+            nextDateTo:   '2026-03-31',
+        );
+
+        $handler($message);
+
+        self::assertInstanceOf(InitialSyncMessage::class, $captured);
+        self::assertSame(self::COMPANY_ID, $captured->companyId);
+        self::assertSame(self::CONNECTION_ID, $captured->connectionId);
+        self::assertSame(MarketplaceType::OZON->value, $captured->marketplace);
+
+        // Текущая партия следующего сообщения = вторая половина split-недели как есть.
+        self::assertSame('2026-03-30', $captured->dateFrom);
+        self::assertSame('2026-03-31', $captured->dateTo);
+
+        // Партия-после-следующей = вторая половина той же исходной недели
+        // (понедельник нового месяца → воскресенье).
+        self::assertSame('2026-04-01 00:00:00', $captured->nextDateFrom);
+        self::assertSame('2026-04-05 23:59:59', $captured->nextDateTo);
+    }
+}


### PR DESCRIPTION
Закрыт в пользу #1528 — там история ветки чистая (один коммит поверх master), без конфликта от squash-merge #1526.