### PR TITLE
fix(marketplace): use yesterday as upper bound of initial sync period

### DIFF
--- a/site/src/Marketplace/MessageHandler/InitialSyncHandler.php
+++ b/site/src/Marketplace/MessageHandler/InitialSyncHandler.php
@@ -100,22 +100,23 @@ final class InitialSyncHandler
 
             // Диспатчим следующую партию если она есть
             if ($message->nextDateFrom !== null && $message->nextDateTo !== null) {
-                // Вычисляем партию после следующей чтобы передать её в nextDate
-                $today = $this->clock->now()->setTime(0, 0, 0);
+                // Граница первичной синхронизации — вчера: за сегодня данные
+                // ещё неполные, их загрузит ежедневный cron завтра.
+                $yesterday = $this->clock->now()->modify('-1 day')->setTime(0, 0, 0);
 
                 // Используем nextDateTo как есть — он уже корректно рассчитан buildPartitions
                 // (учитывает границы месяца и недели), поэтому пересчёт через
                 // modify('sunday this week') ломает split-партиции.
                 $nextTo = new \DateTimeImmutable($message->nextDateTo);
-                if ($nextTo > $today) {
-                    $nextTo = $today;
+                if ($nextTo > $yesterday) {
+                    $nextTo = $yesterday;
                 }
 
                 // Оставшиеся партиции считаем от конца следующей партии
                 $afterStart      = $nextTo->modify('+1 day')->setTime(0, 0, 0);
-                $hasAfter        = $afterStart <= $today;
+                $hasAfter        = $afterStart <= $yesterday;
                 $afterPartitions = $hasAfter
-                    ? $this->partitionService->buildPartitions($afterStart, $today)
+                    ? $this->partitionService->buildPartitions($afterStart, $yesterday)
                     : [];
 
                 $afterFromStr = !empty($afterPartitions) ? $afterPartitions[0]['from'] : null;

--- a/site/src/Marketplace/MessageHandler/TriggerInitialSyncHandler.php
+++ b/site/src/Marketplace/MessageHandler/TriggerInitialSyncHandler.php
@@ -8,6 +8,7 @@ use App\Marketplace\Application\Service\MarketplaceWeekPartitionService;
 use App\Marketplace\Message\InitialSyncMessage;
 use App\Marketplace\Message\TriggerInitialSyncMessage;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -15,7 +16,8 @@ use Symfony\Component\Messenger\MessageBusInterface;
  * Нарезает текущий год на недельные партии с учётом границ месяца и диспатчит первую.
  * Каждая следующая партия диспатчится из InitialSyncHandler после успеха предыдущей.
  *
- * Период: 01.01 текущего года → сегодня (с времени 00:00:00 → 23:59:59).
+ * Период: 01.01 текущего года → вчера (с времени 00:00:00 → 23:59:59).
+ * За сегодня данные ещё неполные — их загрузит ежедневный cron завтра.
  */
 #[AsMessageHandler]
 final class TriggerInitialSyncHandler
@@ -24,14 +26,15 @@ final class TriggerInitialSyncHandler
         private readonly MessageBusInterface $messageBus,
         private readonly LoggerInterface $logger,
         private readonly MarketplaceWeekPartitionService $partitionService,
+        private readonly ClockInterface $clock,
     ) {
     }
 
     public function __invoke(TriggerInitialSyncMessage $message): void
     {
-        $today = new \DateTimeImmutable('today');
-        $yearStart = new \DateTimeImmutable((int) $today->format('Y') . '-01-01 00:00:00');
-        $weeks = $this->partitionService->buildPartitions($yearStart, $today);
+        $yesterday = $this->clock->now()->modify('-1 day')->setTime(0, 0, 0);
+        $yearStart = new \DateTimeImmutable((int) $yesterday->format('Y') . '-01-01 00:00:00');
+        $weeks = $this->partitionService->buildPartitions($yearStart, $yesterday);
 
         if (empty($weeks)) {
             $this->logger->warning('InitialSync: no weeks to sync', [

--- a/site/tests/Unit/Marketplace/MessageHandler/InitialSyncHandlerTest.php
+++ b/site/tests/Unit/Marketplace/MessageHandler/InitialSyncHandlerTest.php
@@ -71,13 +71,16 @@ final class InitialSyncHandlerTest extends TestCase
     }
 
     /**
-     * Сценарий: nextDateTo в будущем относительно clock (например, сообщение
+     * Сценарий: nextDateTo в будущем относительно вчера (например, сообщение
      * задержалось в очереди или clock сдвинулся). Handler обязан обрезать
-     * dateTo до текущего дня и завершить цепочку (nextDateFrom/nextDateTo = null).
+     * dateTo до вчерашнего дня и завершить цепочку (nextDateFrom/nextDateTo = null).
+     *
+     * Первичная синхронизация никогда не загружает данные за сегодня —
+     * за них отвечает ежедневный cron на следующий день.
      */
-    public function testNextBatchDateToClampedToToday(): void
+    public function testNextBatchDateToClampedToYesterday(): void
     {
-        // Сегодня = 2026-04-03; nextDateTo в сообщении = 2026-04-05 23:59:59 (будущее).
+        // Сегодня = 2026-04-03; вчера = 2026-04-02; nextDateTo в сообщении = 2026-04-05 23:59:59 (будущее).
         [$handler, $captured] = $this->createHandler(new MockClock('2026-04-03 12:00:00'));
 
         $message = new InitialSyncMessage(
@@ -97,10 +100,10 @@ final class InitialSyncHandlerTest extends TestCase
 
         // dateFrom пробрасывается без изменений.
         self::assertSame('2026-04-01 00:00:00', $dispatched->dateFrom);
-        // dateTo должен быть обрезан до $today (clock midnight).
-        self::assertSame('2026-04-03 00:00:00', $dispatched->dateTo);
+        // dateTo должен быть обрезан до $yesterday (clock midnight - 1 day).
+        self::assertSame('2026-04-02 00:00:00', $dispatched->dateTo);
 
-        // Цепочка должна завершиться — after-start (2026-04-04) > today → партий нет.
+        // Цепочка должна завершиться — after-start (2026-04-03) > yesterday → партий нет.
         self::assertNull($dispatched->nextDateFrom);
         self::assertNull($dispatched->nextDateTo);
     }


### PR DESCRIPTION
### Дополнительный фикс: граница первичной загрузки

Первичная синхронизация загружала данные включая текущий день, 
хотя данные за сегодня ещё неполные (их загрузит ежедневный cron завтра).

Исправлено: период первичной загрузки теперь 01.01 → вчера.
Затронуты `TriggerInitialSyncHandler` и `InitialSyncHandler`.
Ежедневный cron (`SyncOzonReportHandler`) не затронут — у него своя логика
с `new \DateTimeImmutable('yesterday', new \DateTimeZone('Europe/Moscow'))`.

### Изменения
- `TriggerInitialSyncHandler` — внедрён `ClockInterface`, период считается от
  `clock->now()->modify('-1 day')->setTime(0,0,0)`. `yearStart` берётся от года
  `yesterday` (корректно для 1 января).
- `InitialSyncHandler` — clamp `nextTo` теперь сравнивается с `yesterday`, а не
  с `today`. Тест `testNextBatchDateToClampedToYesterday` обновлён под новую
  семантику.

### Контекст
Продолжение #1526 (фикс split-недели на границе месяца). При ревью обнаружено,
что вся initial-sync цепочка ошибочно использовала `today` как верхнюю границу,
тогда как daily cron берёт `yesterday`. Теперь обе системы согласованы.

Заменяет #1527 (там был конфликт из-за squash-merge истории #1526).

https://claude.ai/code/session_01CGR8YtSqkhDHDKAsscawAR