### PR TITLE
feat(marketplace): add MarketplaceConnectionType enum for Seller vs Performance APIs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -76,6 +76,26 @@
 **Логика:** одна категория МП → одна статья (UniqueConstraint по `companyId + marketplace + costCategoryId`).
 Одна статья ← несколько категорий МП.
 Удалено: `isSystem`, `costCategoryCode`.
+
+### `MarketplaceConnection` — поля
+
+| Поле | Тип | Описание |
+|---|---|---|
+| `id` | `string` (UUID) | PK |
+| `company` | `Company` | ManyToOne (legacy паттерн) |
+| `marketplace` | `MarketplaceType` | WB, Ozon и др. |
+| `connectionType` | `MarketplaceConnectionType` | Тип подключения: `SELLER` (финансы/продажи/остатки) или `PERFORMANCE` (реклама). Дефолт — `SELLER` |
+| `apiKey` | `string` | Ключ API (для Ozon Performance — `client_secret`) |
+| `clientId` | `?string` | Client-Id для Ozon Seller API / `client_id` для Ozon Performance |
+| `isActive` | `bool` | Активно ли подключение |
+| `lastSyncAt` | `?DateTimeImmutable` | — |
+| `lastSuccessfulSyncAt` | `?DateTimeImmutable` | — |
+| `lastSyncError` | `?string` | — |
+| `settings` | `?array` | JSON с дополнительными настройками (напр. `project_direction_id`) |
+| `createdAt` / `updatedAt` | `DateTimeImmutable` | — |
+
+**Уникальность:** `UniqueConstraint` по `(company_id, marketplace, connection_type)` — одна компания может иметь два подключения к одному маркетплейсу (Seller + Performance), но только по одному каждого типа.
+
 | `Deal`, `ChargeType` | Deals | `Company $company` (legacy) |
 | `PLCategory`, `Document` и др. | legacy `src/Entity/` | `Company $company` (legacy) |
 
@@ -395,6 +415,18 @@ enum MarketplaceCostOperationType: string
 ```
 > Явная классификация операции затраты. Заменяет определение типа по знаку `amount`.
 
+### `src/Marketplace/Enum/MarketplaceConnectionType.php`
+```php
+enum MarketplaceConnectionType: string
+{
+    case SELLER      = 'seller';      // Основное (Seller API: финансы, продажи, остатки)
+    case PERFORMANCE = 'performance'; // Реклама (Performance API: OAuth2 Bearer)
+
+    public function getDisplayName(): string; // Основное / Реклама (Performance)
+}
+```
+> Тип подключения к маркетплейсу. У Ozon два независимых API: `api-seller.ozon.ru` (статический Client-Id + Api-Key) и `api-performance.ozon.ru` (OAuth2 client_id + client_secret). Позволяет одной компании иметь два подключения к одному маркетплейсу.
+
 ### `src/MarketplaceAds/Enum/AdRawDocumentStatus.php`
 ```php
 enum AdRawDocumentStatus: string
@@ -572,3 +604,4 @@ paths:
 | 1.3 | 2026-04-12 | MarketplaceAds: новый модуль обработки рекламных отчётов. Entity: `AdRawDocument` (raw JSONB + status DRAFT/PROCESSED), `AdDocument` (кампания × parent SKU за дату), `AdDocumentLine` (распределение на листинг). Domain Port `ListingSalesProviderInterface` с bulk `getSalesQuantitiesByListings` + реализация `ListingSalesProviderMarketplace` через Facade. Domain `AdCostDistributor`: распределение bcmath, при 0 продажах — равномерно, поправка округления на максимальную долю. В `MarketplaceFacade` добавлены `findListingsByMarketplaceSku` (без фильтра `is_active`, для исторических отчётов) и `getSalesQuantitiesForListings` (bulk GROUP BY, убирает N+1). |
 | 1.4 | 2026-04-12 | MarketplaceAds: `ProcessAdRawDocumentAction` — загрузка AdRawDocument (DRAFT) и конвертация в AdDocument + AdDocumentLine. Идемпотентность через `deleteByRawDocumentId`, частичный успех оставляет статус DRAFT. Bulk-prefetch листингов и продаж на уровне Action (2 запроса на документ), `AdCostDistributor` стал чистой функцией без DI. В `MarketplaceFacade` добавлен `findListingsByMarketplaceSkus` (bulk, сгруппирован по parentSku), в `ListingSalesProviderInterface` — `findListingsByParentSkus`. |
 | 1.5 | 2026-04-13 | MarketplaceAds: CLI-обвязка + Messenger-пайплайн (`marketplace-ads:load`, `marketplace-ads:reprocess`, `ProcessAdRawDocumentMessage`, `ProcessAdRawDocumentHandler`). Batch-flush в Load (единый flush по всему проходу), guardrails в Reprocess (--all / хотя бы один фильтр, batch clear BATCH_SIZE=50). `MarketplaceAdsFacade` — публичный API модуля: `getAdCostsForListingAndDate`, `getTotalAdCostForPeriod`. `AdDocumentQuery` — DBAL-запросы к `marketplace_ad_documents` JOIN `marketplace_ad_document_lines`. `AdCostForListingDTO` для передачи распределённых данных между модулями. |
+| 1.6 | 2026-04-15 | Marketplace: новый enum `MarketplaceConnectionType` (`SELLER` / `PERFORMANCE`). Entity `MarketplaceConnection` получила поле `connectionType` (дефолт `SELLER`), `UniqueConstraint` расширен до `(company_id, marketplace, connection_type)`. Позволяет одной компании хранить отдельные подключения к Ozon Seller API и Ozon Performance API. |

--- a/site/migrations/Version20260415000000.php
+++ b/site/migrations/Version20260415000000.php
@@ -16,6 +16,13 @@ use Doctrine\Migrations\AbstractMigration;
  * (company_id, marketplace).
  *
  * Существующие записи получают значение 'seller' через DEFAULT.
+ *
+ * ВНИМАНИЕ: down() совместим только с данными, которые укладываются в старое
+ * ограничение уникальности (company_id, marketplace). Если в таблице появились
+ * записи с connection_type = 'performance' для той же пары (company_id, marketplace),
+ * где уже есть 'seller', откат упадёт на CREATE UNIQUE INDEX uniq_company_marketplace
+ * из-за дубликата. Автоматического удаления PERFORMANCE-записей миграция сознательно
+ * не делает — откат при «грязной» БД требует ручной чистки данных оператором.
  */
 final class Version20260415000000 extends AbstractMigration
 {

--- a/site/migrations/Version20260415000000.php
+++ b/site/migrations/Version20260415000000.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Добавляет тип подключения (connection_type) к marketplace_connections.
+ *
+ * Одна компания может иметь несколько подключений к одному маркетплейсу,
+ * различающихся типом (например, Ozon Seller API и Ozon Performance API).
+ * Уникальность теперь по (company_id, marketplace, connection_type) вместо
+ * (company_id, marketplace).
+ *
+ * Существующие записи получают значение 'seller' через DEFAULT.
+ */
+final class Version20260415000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add connection_type to marketplace_connections and widen unique constraint to (company_id, marketplace, connection_type)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if (!$schema->hasTable('marketplace_connections')) {
+            return;
+        }
+
+        $table = $schema->getTable('marketplace_connections');
+
+        if (!$table->hasColumn('connection_type')) {
+            $this->addSql(
+                "ALTER TABLE marketplace_connections ADD COLUMN connection_type VARCHAR(20) NOT NULL DEFAULT 'seller'"
+            );
+        }
+
+        $this->addSql('DROP INDEX IF EXISTS uniq_company_marketplace');
+
+        $this->addSql(<<<'SQL'
+            CREATE UNIQUE INDEX IF NOT EXISTS uniq_company_marketplace_type
+            ON marketplace_connections (company_id, marketplace, connection_type)
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        if (!$schema->hasTable('marketplace_connections')) {
+            return;
+        }
+
+        $this->addSql('DROP INDEX IF EXISTS uniq_company_marketplace_type');
+
+        $this->addSql(<<<'SQL'
+            CREATE UNIQUE INDEX IF NOT EXISTS uniq_company_marketplace
+            ON marketplace_connections (company_id, marketplace)
+        SQL);
+
+        $table = $schema->getTable('marketplace_connections');
+
+        if ($table->hasColumn('connection_type')) {
+            $this->addSql('ALTER TABLE marketplace_connections DROP COLUMN connection_type');
+        }
+    }
+}

--- a/site/src/Marketplace/Application/CloseMonthStageAction.php
+++ b/site/src/Marketplace/Application/CloseMonthStageAction.php
@@ -13,6 +13,7 @@ use App\Marketplace\Application\DTO\PreflightResult;
 use App\Marketplace\Application\Source\MarketplaceDataSourceInterface;
 use App\Marketplace\DTO\PLEntryDTO;
 use App\Marketplace\Enum\CloseStage;
+use App\Marketplace\Enum\MarketplaceConnectionType;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Infrastructure\Query\UnprocessedCostsQuery;
 use App\Marketplace\Repository\MarketplaceConnectionRepository;
@@ -114,6 +115,7 @@ final class CloseMonthStageAction
         $connection = $this->connectionRepository->findByCompanyIdAndMarketplace(
             $command->companyId,
             $marketplace,
+            MarketplaceConnectionType::SELLER,
         );
         if ($connection !== null) {
             $projectDirectionId = $connection->getProjectDirectionId();

--- a/site/src/Marketplace/Command/MarketplaceSyncCommand.php
+++ b/site/src/Marketplace/Command/MarketplaceSyncCommand.php
@@ -4,6 +4,7 @@ namespace App\Marketplace\Command;
 
 use App\Company\Entity\Company;
 use App\Marketplace\Facade\MarketplaceSyncFacade;
+use App\Marketplace\Enum\MarketplaceConnectionType;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Repository\MarketplaceConnectionRepository;
 use App\Company\Facade\CompanyFacade;
@@ -80,7 +81,11 @@ class MarketplaceSyncCommand extends Command
         foreach ($companies as $company) {
             $io->section('Компания: '.$company->getName());
 
-            $connection = $this->connectionRepository->findByMarketplace($company, $marketplace);
+            $connection = $this->connectionRepository->findByMarketplace(
+                $company,
+                $marketplace,
+                MarketplaceConnectionType::SELLER,
+            );
 
             if (!$connection || !$connection->isActive()) {
                 $io->warning('Подключение неактивно, пропускаем');

--- a/site/src/Marketplace/Controller/MarketplaceController.php
+++ b/site/src/Marketplace/Controller/MarketplaceController.php
@@ -12,6 +12,7 @@ use App\Marketplace\Entity\MarketplaceListing;
 use App\Marketplace\Application\Command\ProcessMarketplaceRawDocumentCommand;
 use App\Marketplace\Application\Command\SyncConnectionCommand;
 use App\Marketplace\Application\ProcessMarketplaceRawDocumentAction;
+use App\Marketplace\Enum\MarketplaceConnectionType;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Infrastructure\Query\OzonRealizationStatusQuery;
 use App\Marketplace\Infrastructure\Query\RawDocumentsListQuery;
@@ -86,7 +87,11 @@ class MarketplaceController extends AbstractController
         $apiKey      = $request->request->get('api_key');
         $clientId    = $request->request->get('client_id');
 
-        $existing = $this->connectionRepository->findByMarketplace($company, $marketplace);
+        $existing = $this->connectionRepository->findByMarketplace(
+            $company,
+            $marketplace,
+            MarketplaceConnectionType::SELLER,
+        );
 
         if ($existing) {
             $this->addFlash('error', 'Подключение к ' . $marketplace->getDisplayName() . ' уже существует');

--- a/site/src/Marketplace/Entity/MarketplaceConnection.php
+++ b/site/src/Marketplace/Entity/MarketplaceConnection.php
@@ -3,6 +3,7 @@
 namespace App\Marketplace\Entity;
 
 use App\Company\Entity\Company;
+use App\Marketplace\Enum\MarketplaceConnectionType;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Repository\MarketplaceConnectionRepository;
 use Doctrine\ORM\Mapping as ORM;
@@ -11,7 +12,7 @@ use Webmozart\Assert\Assert;
 #[ORM\Entity(repositoryClass: MarketplaceConnectionRepository::class)]
 #[ORM\Table(name: 'marketplace_connections')]
 #[ORM\Index(columns: ['company_id'], name: 'idx_connection_company')]
-#[ORM\UniqueConstraint(name: 'uniq_company_marketplace', columns: ['company_id', 'marketplace'])]
+#[ORM\UniqueConstraint(name: 'uniq_company_marketplace_type', columns: ['company_id', 'marketplace', 'connection_type'])]
 class MarketplaceConnection
 {
     #[ORM\Id]
@@ -24,6 +25,9 @@ class MarketplaceConnection
 
     #[ORM\Column(type: 'string', enumType: MarketplaceType::class)]
     private MarketplaceType $marketplace;
+
+    #[ORM\Column(type: 'string', length: 20, enumType: MarketplaceConnectionType::class)]
+    private MarketplaceConnectionType $connectionType = MarketplaceConnectionType::SELLER;
 
     #[ORM\Column(type: 'text')]
     private string $apiKey; // TODO: Encrypt in production
@@ -56,11 +60,13 @@ class MarketplaceConnection
         string $id,
         Company $company,
         MarketplaceType $marketplace,
+        MarketplaceConnectionType $connectionType = MarketplaceConnectionType::SELLER,
     ) {
         Assert::uuid($id);
         $this->id = $id;
         $this->company = $company;
         $this->marketplace = $marketplace;
+        $this->connectionType = $connectionType;
         $this->createdAt = new \DateTimeImmutable();
         $this->updatedAt = new \DateTimeImmutable();
     }
@@ -78,6 +84,11 @@ class MarketplaceConnection
     public function getMarketplace(): MarketplaceType
     {
         return $this->marketplace;
+    }
+
+    public function getConnectionType(): MarketplaceConnectionType
+    {
+        return $this->connectionType;
     }
 
     public function getApiKey(): string

--- a/site/src/Marketplace/Enum/MarketplaceConnectionType.php
+++ b/site/src/Marketplace/Enum/MarketplaceConnectionType.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Enum;
+
+enum MarketplaceConnectionType: string
+{
+    case SELLER = 'seller';
+    case PERFORMANCE = 'performance';
+
+    public function getDisplayName(): string
+    {
+        return match ($this) {
+            self::SELLER => 'Основное',
+            self::PERFORMANCE => 'Реклама (Performance)',
+        };
+    }
+}

--- a/site/src/Marketplace/Repository/MarketplaceConnectionRepository.php
+++ b/site/src/Marketplace/Repository/MarketplaceConnectionRepository.php
@@ -4,6 +4,7 @@ namespace App\Marketplace\Repository;
 
 use App\Company\Entity\Company;
 use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Enum\MarketplaceConnectionType;
 use App\Marketplace\Enum\MarketplaceType;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -28,15 +29,26 @@ class MarketplaceConnectionRepository extends ServiceEntityRepository
             ->getResult();
     }
 
+    /**
+     * Найти подключение для компании по маркетплейсу и типу.
+     *
+     * Тип по умолчанию — SELLER, это сохраняет поведение вызовов без явного типа
+     * (основные API-клиенты и UI пока работают только с Seller API).
+     * Для Performance API вызывающий обязан передать MarketplaceConnectionType::PERFORMANCE
+     * явно — иначе будет возвращено Seller-подключение.
+     */
     public function findByMarketplace(
         Company $company,
         MarketplaceType $marketplace,
+        MarketplaceConnectionType $connectionType = MarketplaceConnectionType::SELLER,
     ): ?MarketplaceConnection {
         return $this->createQueryBuilder('c')
             ->where('c.company = :company')
             ->andWhere('c.marketplace = :marketplace')
+            ->andWhere('c.connectionType = :connectionType')
             ->setParameter('company', $company)
             ->setParameter('marketplace', $marketplace)
+            ->setParameter('connectionType', $connectionType)
             ->getQuery()
             ->getOneOrNullResult();
     }
@@ -56,17 +68,30 @@ class MarketplaceConnectionRepository extends ServiceEntityRepository
     }
 
     /**
-     * Найти подключение по UUID компании и маркетплейсу.
+     * Найти подключение по UUID компании, маркетплейсу и типу.
      * Используется в worker-контексте где Company entity не загружена.
+     *
+     * Тип по умолчанию — SELLER, это сохраняет поведение вызовов без явного типа.
+     * Для Performance API вызывающий обязан передать MarketplaceConnectionType::PERFORMANCE
+     * явно — иначе будет возвращено Seller-подключение.
      */
     public function findByCompanyIdAndMarketplace(
         string $companyId,
         MarketplaceType $marketplace,
+        MarketplaceConnectionType $connectionType = MarketplaceConnectionType::SELLER,
     ): ?MarketplaceConnection {
         $conn = $this->getEntityManager()->getConnection();
         $id   = $conn->fetchOne(
-            'SELECT id FROM marketplace_connections WHERE company_id = :companyId AND marketplace = :marketplace LIMIT 1',
-            ['companyId' => $companyId, 'marketplace' => $marketplace->value],
+            'SELECT id FROM marketplace_connections
+             WHERE company_id = :companyId
+               AND marketplace = :marketplace
+               AND connection_type = :connectionType
+             LIMIT 1',
+            [
+                'companyId'      => $companyId,
+                'marketplace'    => $marketplace->value,
+                'connectionType' => $connectionType->value,
+            ],
         );
 
         if (!$id) {

--- a/site/src/Marketplace/Service/Integration/OzonAdapter.php
+++ b/site/src/Marketplace/Service/Integration/OzonAdapter.php
@@ -7,6 +7,7 @@ use App\Marketplace\DTO\CostData;
 use App\Marketplace\DTO\ReturnData;
 use App\Marketplace\DTO\SaleData;
 use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Enum\MarketplaceConnectionType;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Repository\MarketplaceConnectionRepository;
 use Psr\Log\LoggerInterface;
@@ -370,7 +371,8 @@ class OzonAdapter implements MarketplaceAdapterInterface
     {
         return $this->connectionRepository->findByMarketplace(
             $company,
-            MarketplaceType::OZON
+            MarketplaceType::OZON,
+            MarketplaceConnectionType::SELLER,
         );
     }
 }

--- a/site/src/Marketplace/Service/Integration/WildberriesAdapter.php
+++ b/site/src/Marketplace/Service/Integration/WildberriesAdapter.php
@@ -7,6 +7,7 @@ use App\Marketplace\DTO\CostData;
 use App\Marketplace\DTO\ReturnData;
 use App\Marketplace\DTO\SaleData;
 use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Enum\MarketplaceConnectionType;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Repository\MarketplaceConnectionRepository;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -293,7 +294,8 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
     {
         return $this->connectionRepository->findByMarketplace(
             $company,
-            MarketplaceType::WILDBERRIES
+            MarketplaceType::WILDBERRIES,
+            MarketplaceConnectionType::SELLER,
         );
     }
 }

--- a/site/src/MarketplaceAds/Command/LoadAdDataCommand.php
+++ b/site/src/MarketplaceAds/Command/LoadAdDataCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\MarketplaceAds\Command;
 
 use App\Company\Facade\CompanyFacade;
+use App\Marketplace\Enum\MarketplaceConnectionType;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Repository\MarketplaceConnectionRepository;
 use App\MarketplaceAds\Entity\AdRawDocument;
@@ -197,7 +198,11 @@ final class LoadAdDataCommand extends Command
         \DateTimeImmutable $reportDate,
         OutputInterface $output,
     ): AdRawDocument|string {
-        $connection = $this->connectionRepository->findByCompanyIdAndMarketplace($companyId, $marketplace);
+        $connection = $this->connectionRepository->findByCompanyIdAndMarketplace(
+            $companyId,
+            $marketplace,
+            MarketplaceConnectionType::SELLER,
+        );
 
         if (null === $connection || !$connection->isActive()) {
             $output->writeln(sprintf(


### PR DESCRIPTION
## Summary

Вводит понятие «тип подключения» для `MarketplaceConnection`, чтобы одна компания могла иметь два независимых подключения к одному маркетплейсу. Основной драйвер — Ozon, у которого два независимых API с разными credentials:

- **Seller API** (`api-seller.ozon.ru`) — финансы, продажи, остатки. Авторизация: статический `Client-Id` + `Api-Key`.
- **Performance API** (`api-performance.ozon.ru`) — реклама. Авторизация: OAuth2 `client_id` + `client_secret` → Bearer-токен (30 мин).

### Изменения

- **`src/Marketplace/Enum/MarketplaceConnectionType.php`** — новый enum со значениями `SELLER` / `PERFORMANCE` и методом `getDisplayName()` ("Основное" / "Реклама (Performance)").
- **`src/Marketplace/Entity/MarketplaceConnection.php`** — добавлено поле `connectionType` (дефолт `SELLER`), getter и опциональный параметр в конструкторе. `UniqueConstraint` расширен с `(company_id, marketplace)` до `(company_id, marketplace, connection_type)`.
- **`migrations/Version20260415000000.php`** — `ADD COLUMN connection_type VARCHAR(20) NOT NULL DEFAULT 'seller'` (существующие записи автоматически получают `'seller'`), пересоздание уникального индекса. Реализован `down()` для отката.
- **`ARCHITECTURE.md`** — обновлены разделы Entity и Enum, добавлена запись в Changelog 1.6.

### Заметка

В исходной миграции `Version20260211070759.php` уникальность создана как `CREATE UNIQUE INDEX uniq_company_marketplace`, а не как named CONSTRAINT. Поэтому в новой миграции используется `DROP INDEX IF EXISTS` вместо `DROP CONSTRAINT` (как было предложено в ТЗ) — `DROP CONSTRAINT` упал бы с ошибкой «constraint does not exist».

## Test plan

- [ ] `bin/console doctrine:migrations:migrate` применяется без ошибок на БД с существующими записями в `marketplace_connections`
- [ ] После миграции существующие записи имеют `connection_type = 'seller'`
- [ ] `bin/console doctrine:schema:validate` проходит без расхождений
- [ ] Создание второй записи с тем же `(company_id, marketplace)`, но другим `connection_type` проходит; дубликат с тем же триплетом — падает на unique constraint
- [ ] `down()` миграции корректно восстанавливает исходное состояние (только если нет записей с `PERFORMANCE`)

https://claude.ai/code/session_017RvK4Bnp7h5sNT7dJiHZj5