### PR TITLE
fix(marketplace): hide connection-type block unless Ozon is selected

### DIFF
--- a/site/templates/marketplace/index.html.twig
+++ b/site/templates/marketplace/index.html.twig
@@ -265,14 +265,15 @@
                             </select>
                         </div>
 
-                        <div class="mb-3">
+                        {# Блок «Тип подключения» — показывается только для Ozon (Performance API есть только у Ozon). #}
+                        <div class="mb-3" id="field-connection-type" style="display: none;">
                             <label class="form-label required">Тип подключения</label>
                             <div class="form-selectgroup form-selectgroup-pills" id="connection-type-group">
                                 <label class="form-selectgroup-item">
                                     <input type="radio" name="connection_type" value="seller" class="form-selectgroup-input" id="connection-type-seller" checked>
                                     <span class="form-selectgroup-label">Основное (Seller API)</span>
                                 </label>
-                                <label class="form-selectgroup-item" id="connection-type-performance-wrapper" style="display: none;">
+                                <label class="form-selectgroup-item">
                                     <input type="radio" name="connection_type" value="performance" class="form-selectgroup-input" id="connection-type-performance">
                                     <span class="form-selectgroup-label">Реклама (Performance API)</span>
                                 </label>
@@ -521,15 +522,15 @@
         // Управление модалом «Новое подключение»: переключение типа (Seller/Performance),
         // видимость поля Client-Id (для Seller + Ozon), подмена form.action.
         (function () {
-            var form               = document.getElementById('form-add-connection');
-            var marketplaceSelect  = document.getElementById('connection-marketplace');
-            var perfWrapper        = document.getElementById('connection-type-performance-wrapper');
-            var perfRadio          = document.getElementById('connection-type-performance');
-            var sellerRadio        = document.getElementById('connection-type-seller');
-            var sellerBlock        = form.querySelector('[data-connection-type-fields="seller"]');
-            var perfBlock          = form.querySelector('[data-connection-type-fields="performance"]');
-            var sellerClientField  = document.getElementById('field-seller-client-id');
-            var sellerClientInput  = document.getElementById('input-seller-client-id');
+            var form                 = document.getElementById('form-add-connection');
+            var marketplaceSelect    = document.getElementById('connection-marketplace');
+            var connectionTypeField  = document.getElementById('field-connection-type');
+            var perfRadio            = document.getElementById('connection-type-performance');
+            var sellerRadio          = document.getElementById('connection-type-seller');
+            var sellerBlock          = form.querySelector('[data-connection-type-fields="seller"]');
+            var perfBlock            = form.querySelector('[data-connection-type-fields="performance"]');
+            var sellerClientField    = document.getElementById('field-seller-client-id');
+            var sellerClientInput    = document.getElementById('input-seller-client-id');
 
             function setDisabledAll(block, disabled) {
                 block.querySelectorAll('input, select, textarea').forEach(function (el) {
@@ -567,26 +568,30 @@
                 }
             }
 
-            marketplaceSelect.addEventListener('change', function () {
-                // Performance API — только Ozon. Для остальных маркетплейсов
-                // скрываем опцию и откатываемся на Seller, если она была выбрана.
-                if (this.value === 'ozon') {
-                    perfWrapper.style.display = '';
+            function applyMarketplace() {
+                // Блок «Тип подключения» показываем только для Ozon — Performance API
+                // существует только у Ozon. Для остальных маркетплейсов блок скрыт,
+                // а тип принудительно сбрасываем на Seller, чтобы форма отправляла
+                // корректные данные на правильный endpoint.
+                if (marketplaceSelect.value === 'ozon') {
+                    connectionTypeField.style.display = '';
                 } else {
-                    perfWrapper.style.display = 'none';
+                    connectionTypeField.style.display = 'none';
                     if (perfRadio.checked) {
                         sellerRadio.checked = true;
                     }
                 }
                 applyConnectionType();
-            });
+            }
+
+            marketplaceSelect.addEventListener('change', applyMarketplace);
 
             [sellerRadio, perfRadio].forEach(function (radio) {
                 radio.addEventListener('change', applyConnectionType);
             });
 
-            // Инициализация (seller + marketplace не выбран).
-            applyConnectionType();
+            // Инициализация: маркетплейс не выбран → блок скрыт, тип = seller.
+            applyMarketplace();
         })();
 
         // Sync period modal — подставляем action с connectionId


### PR DESCRIPTION
## Summary

- «Тип подключения» в модалке «Новое подключение» теперь скрыт по умолчанию и появляется только при выборе Ozon (Performance API существует только у Ozon).
- Переключение с Ozon на другой маркетплейс скрывает блок и принудительно сбрасывает тип на `seller`, чтобы форма POST'илась на правильный endpoint (`marketplace_connection_create`).
- Существующая логика переключения Seller-полей (Client-Id только для Ozon, API Key) не задета — она по-прежнему работает через `applyConnectionType()`.

## Что именно изменилось

- `site/templates/marketplace/index.html.twig`
  - Обернул блок `<div class="mb-3">` с radio «Основное / Реклама» в контейнер `#field-connection-type` с `style="display: none;"` по умолчанию.
  - Снял inline `display: none` с `label#connection-type-performance-wrapper` — теперь за видимость отвечает только внешний контейнер.
  - В JS вынес маркетплейс-зависимую часть в `applyMarketplace()` и вызываю её на `change` селекта + один раз при инициализации. Переименовал `perfWrapper` → `connectionTypeField`.

## Test plan

- [ ] Открыть модалку «Новое подключение» → блок «Тип подключения» НЕ виден.
- [ ] Выбрать Wildberries / Яндекс.Маркет / СберМегаМаркет → блок по-прежнему скрыт, поля Seller (API ключ) видны, Client-Id скрыт.
- [ ] Выбрать Ozon → блок появляется с двумя radio; по умолчанию выбран Seller; видны поля Seller API + Client-Id.
- [ ] Ozon → переключить на «Реклама (Performance API)» → Seller-поля скрываются, показываются Client ID / Client Secret; `form.action` = performance endpoint.
- [ ] Ozon с выбранным Performance → переключить маркетплейс на WB → блок «Тип подключения» скрывается, radio возвращается к Seller, форма POST'ится на seller endpoint.
- [ ] Сабмит Seller (любой маркетплейс) — подключение создаётся, Performance-поля не уезжают в POST (они `disabled`).
- [ ] Сабмит Ozon Performance — подключение создаётся, Seller-поля не уезжают в POST.

https://claude.ai/code/session_01LGH4YXxBr3G7PxT7nyyfm7