### PR TITLE
feat(marketplace-analytics): rename "other" widget and split compensations subgroup

### DIFF
--- a/site/assets/react/marketplace-analytics/unit-extended/widgets/WidgetDetailPanel.tsx
+++ b/site/assets/react/marketplace-analytics/unit-extended/widgets/WidgetDetailPanel.tsx
@@ -1,15 +1,81 @@
 import React from 'react';
 import { formatMoney } from '../../utils/utils';
-import type { CostGroupBreakdown } from '../unitExtended.types';
+import type { CostCategory, CostGroupBreakdown } from '../unitExtended.types';
+import { COMPENSATION_CODES } from './widgetsConfig';
 
 interface WidgetDetailPanelProps {
     groups: CostGroupBreakdown[];
 }
 
+interface SubgroupTotals {
+    costsAmount: number;
+    stornoAmount: number;
+    netAmount: number;
+}
+
+/**
+ * Группа, внутри которой категории дополнительно разбиваются
+ * на подгруппы (обычные услуги + компенсации).
+ */
+const OTHER_SERVICES_GROUP = 'Другие услуги и штрафы';
+const COMPENSATIONS_SUBGROUP_LABEL = 'Компенсации и декомпенсации';
+
+function sumCategories(categories: CostCategory[]): SubgroupTotals {
+    return categories.reduce<SubgroupTotals>(
+        (acc, c) => ({
+            costsAmount: acc.costsAmount + c.costsAmount,
+            stornoAmount: acc.stornoAmount + c.stornoAmount,
+            netAmount: acc.netAmount + c.netAmount,
+        }),
+        { costsAmount: 0, stornoAmount: 0, netAmount: 0 },
+    );
+}
+
+/**
+ * Блок «подзаголовок + строки категорий».
+ * Используется как для обычной группы, так и для каждой из подгрупп
+ * внутри «Другие услуги и штрафы».
+ */
+const SubgroupRows: React.FC<{
+    label: string;
+    categories: CostCategory[];
+    totals: SubgroupTotals;
+    rowKeyPrefix: string;
+}> = ({ label, categories, totals, rowKeyPrefix }) => (
+    <>
+        <tr>
+            <td className="fw-bold">{label}</td>
+            <td className="text-end fw-bold">{formatMoney(totals.costsAmount)}</td>
+            <td className="text-end fw-bold">{formatMoney(totals.stornoAmount)}</td>
+            <td className="text-end fw-bold">{formatMoney(totals.netAmount)}</td>
+        </tr>
+        {categories.map((cat) => (
+            <tr key={`${rowKeyPrefix}::${cat.code}`}>
+                <td className="ps-4 text-secondary">{cat.name}</td>
+                <td className="text-end text-secondary">
+                    {formatMoney(cat.costsAmount)}
+                </td>
+                <td className="text-end text-secondary">
+                    {formatMoney(cat.stornoAmount)}
+                </td>
+                <td className="text-end text-secondary">
+                    {formatMoney(cat.netAmount)}
+                </td>
+            </tr>
+        ))}
+    </>
+);
+
 /**
  * Раскрытая детализация затрат:
  * - заголовок группы (fw-bold) с суммами
  * - строки категорий (ps-4, text-secondary) с суммами
+ *
+ * Для группы «Другие услуги и штрафы» категории дополнительно
+ * разделяются на две визуальные подгруппы:
+ *  - «Другие услуги и штрафы» — всё, кроме кодов из COMPENSATION_CODES
+ *  - «Компенсации и декомпенсации» — только коды из COMPENSATION_CODES
+ * Суммы подгрупп в сумме дают netAmount всей группы.
  */
 const WidgetDetailPanel: React.FC<WidgetDetailPanelProps> = ({ groups }) => {
     if (groups.length === 0) {
@@ -29,36 +95,51 @@ const WidgetDetailPanel: React.FC<WidgetDetailPanelProps> = ({ groups }) => {
                         </tr>
                     </thead>
                     <tbody>
-                        {groups.map((group) => (
-                            <React.Fragment key={group.serviceGroup}>
-                                <tr>
-                                    <td className="fw-bold">{group.serviceGroup}</td>
-                                    <td className="text-end fw-bold">
-                                        {formatMoney(group.costsAmount)}
-                                    </td>
-                                    <td className="text-end fw-bold">
-                                        {formatMoney(group.stornoAmount)}
-                                    </td>
-                                    <td className="text-end fw-bold">
-                                        {formatMoney(group.netAmount)}
-                                    </td>
-                                </tr>
-                                {group.categories.map((cat) => (
-                                    <tr key={`${group.serviceGroup}::${cat.code}`}>
-                                        <td className="ps-4 text-secondary">{cat.name}</td>
-                                        <td className="text-end text-secondary">
-                                            {formatMoney(cat.costsAmount)}
-                                        </td>
-                                        <td className="text-end text-secondary">
-                                            {formatMoney(cat.stornoAmount)}
-                                        </td>
-                                        <td className="text-end text-secondary">
-                                            {formatMoney(cat.netAmount)}
-                                        </td>
-                                    </tr>
-                                ))}
-                            </React.Fragment>
-                        ))}
+                        {groups.map((group) => {
+                            if (group.serviceGroup === OTHER_SERVICES_GROUP) {
+                                const compensations = group.categories.filter((c) =>
+                                    COMPENSATION_CODES.includes(c.code),
+                                );
+                                const others = group.categories.filter(
+                                    (c) => !COMPENSATION_CODES.includes(c.code),
+                                );
+
+                                return (
+                                    <React.Fragment key={group.serviceGroup}>
+                                        {others.length > 0 && (
+                                            <SubgroupRows
+                                                label={OTHER_SERVICES_GROUP}
+                                                categories={others}
+                                                totals={sumCategories(others)}
+                                                rowKeyPrefix={`${group.serviceGroup}::other`}
+                                            />
+                                        )}
+                                        {compensations.length > 0 && (
+                                            <SubgroupRows
+                                                label={COMPENSATIONS_SUBGROUP_LABEL}
+                                                categories={compensations}
+                                                totals={sumCategories(compensations)}
+                                                rowKeyPrefix={`${group.serviceGroup}::comp`}
+                                            />
+                                        )}
+                                    </React.Fragment>
+                                );
+                            }
+
+                            return (
+                                <SubgroupRows
+                                    key={group.serviceGroup}
+                                    label={group.serviceGroup}
+                                    categories={group.categories}
+                                    totals={{
+                                        costsAmount: group.costsAmount,
+                                        stornoAmount: group.stornoAmount,
+                                        netAmount: group.netAmount,
+                                    }}
+                                    rowKeyPrefix={group.serviceGroup}
+                                />
+                            );
+                        })}
                     </tbody>
                 </table>
             </div>

--- a/site/assets/react/marketplace-analytics/unit-extended/widgets/WidgetDetailPanel.tsx
+++ b/site/assets/react/marketplace-analytics/unit-extended/widgets/WidgetDetailPanel.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { formatMoney } from '../../utils/utils';
 import type { CostCategory, CostGroupBreakdown } from '../unitExtended.types';
-import { COMPENSATION_CODES } from './widgetsConfig';
+import { COMPENSATION_CODES, OTHER_SERVICES_GROUP } from './widgetsConfig';
 
 interface WidgetDetailPanelProps {
     groups: CostGroupBreakdown[];
@@ -13,20 +13,16 @@ interface SubgroupTotals {
     netAmount: number;
 }
 
-/**
- * Группа, внутри которой категории дополнительно разбиваются
- * на подгруппы (обычные услуги + компенсации).
- */
-const OTHER_SERVICES_GROUP = 'Другие услуги и штрафы';
 const COMPENSATIONS_SUBGROUP_LABEL = 'Компенсации и декомпенсации';
 
 function sumCategories(categories: CostCategory[]): SubgroupTotals {
     return categories.reduce<SubgroupTotals>(
-        (acc, c) => ({
-            costsAmount: acc.costsAmount + c.costsAmount,
-            stornoAmount: acc.stornoAmount + c.stornoAmount,
-            netAmount: acc.netAmount + c.netAmount,
-        }),
+        (acc, c) => {
+            acc.costsAmount += c.costsAmount;
+            acc.stornoAmount += c.stornoAmount;
+            acc.netAmount += c.netAmount;
+            return acc;
+        },
         { costsAmount: 0, stornoAmount: 0, netAmount: 0 },
     );
 }
@@ -104,6 +100,22 @@ const WidgetDetailPanel: React.FC<WidgetDetailPanelProps> = ({ groups }) => {
                                     (c) => !COMPENSATION_CODES.includes(c.code),
                                 );
 
+                                // Fallback: если категорий нет вовсе — рендерим
+                                // одну строку-заголовок с итогами группы (как
+                                // у остальных виджетов), чтобы не оставлять
+                                // пустое тело таблицы.
+                                if (others.length === 0 && compensations.length === 0) {
+                                    return (
+                                        <SubgroupRows
+                                            key={group.serviceGroup}
+                                            label={group.serviceGroup}
+                                            categories={group.categories}
+                                            totals={group}
+                                            rowKeyPrefix={group.serviceGroup}
+                                        />
+                                    );
+                                }
+
                                 return (
                                     <React.Fragment key={group.serviceGroup}>
                                         {others.length > 0 && (
@@ -131,11 +143,7 @@ const WidgetDetailPanel: React.FC<WidgetDetailPanelProps> = ({ groups }) => {
                                     key={group.serviceGroup}
                                     label={group.serviceGroup}
                                     categories={group.categories}
-                                    totals={{
-                                        costsAmount: group.costsAmount,
-                                        stornoAmount: group.stornoAmount,
-                                        netAmount: group.netAmount,
-                                    }}
+                                    totals={group}
                                     rowKeyPrefix={group.serviceGroup}
                                 />
                             );

--- a/site/assets/react/marketplace-analytics/unit-extended/widgets/widgetsConfig.ts
+++ b/site/assets/react/marketplace-analytics/unit-extended/widgets/widgetsConfig.ts
@@ -57,7 +57,7 @@ export const WIDGETS: readonly WidgetCardConfig[] = [
     },
     {
         key: 'other',
-        label: 'Другие услуги и штрафы',
+        label: 'Прочее и компенсации',
         type: 'expense',
         icon: 'ti ti-alert-triangle',
         getValue: (s) => getGroupNet(s, 'Другие услуги и штрафы'),
@@ -82,5 +82,20 @@ export const WIDGET_KEY_TO_GROUPS: Record<string, string[]> = {
     delivery_fbo: ['Услуги доставки и FBO'],
     partners: ['Услуги партнёров'],
     promo: ['Продвижение и реклама'],
+    // Компенсации и декомпенсации на бэке входят в "Другие услуги и штрафы"
+    // (см. WidgetServiceGroupMap). На фронте они визуально разделяются
+    // на подгруппы в WidgetDetailPanel через COMPENSATION_CODES.
     other: ['Другие услуги и штрафы'],
 };
+
+/**
+ * Коды категорий, относящиеся к компенсациям и декомпенсациям.
+ *
+ * Используется в WidgetDetailPanel для визуального выделения
+ * подгруппы «Компенсации и декомпенсации» внутри группы
+ * «Другие услуги и штрафы».
+ */
+export const COMPENSATION_CODES: readonly string[] = [
+    'ozon_compensation',
+    'ozon_decompensation',
+];

--- a/site/assets/react/marketplace-analytics/unit-extended/widgets/widgetsConfig.ts
+++ b/site/assets/react/marketplace-analytics/unit-extended/widgets/widgetsConfig.ts
@@ -1,6 +1,14 @@
 import type { WidgetCardConfig, WidgetsSummary } from './widgets.types';
 
 /**
+ * Имя serviceGroup «Другие услуги и штрафы» на бэке (см. WidgetServiceGroupMap).
+ * Единая точка правды — используется и в WIDGET_KEY_TO_GROUPS, и в
+ * WidgetDetailPanel для определения группы, внутри которой нужно
+ * показать подгруппы «обычные услуги» + «компенсации».
+ */
+export const OTHER_SERVICES_GROUP = 'Другие услуги и штрафы';
+
+/**
  * Считает сумму netAmount по выбранным widgetGroup.
  */
 function getGroupNet(s: WidgetsSummary, ...names: string[]): number {
@@ -60,7 +68,7 @@ export const WIDGETS: readonly WidgetCardConfig[] = [
         label: 'Прочее и компенсации',
         type: 'expense',
         icon: 'ti ti-alert-triangle',
-        getValue: (s) => getGroupNet(s, 'Другие услуги и штрафы'),
+        getValue: (s) => getGroupNet(s, OTHER_SERVICES_GROUP),
     },
     {
         key: 'profit',
@@ -85,7 +93,7 @@ export const WIDGET_KEY_TO_GROUPS: Record<string, string[]> = {
     // Компенсации и декомпенсации на бэке входят в "Другие услуги и штрафы"
     // (см. WidgetServiceGroupMap). На фронте они визуально разделяются
     // на подгруппы в WidgetDetailPanel через COMPENSATION_CODES.
-    other: ['Другие услуги и штрафы'],
+    other: [OTHER_SERVICES_GROUP],
 };
 
 /**


### PR DESCRIPTION
## Summary

- Переименован виджет `other`: «Другие услуги и штрафы» → «**Прочее и компенсации**», чтобы было явно видно, что компенсации/декомпенсации учтены внутри.
- В `widgetsConfig.ts` добавлена константа `COMPENSATION_CODES` (`ozon_compensation`, `ozon_decompensation`).
- В `WidgetDetailPanel` при раскрытии группы «Другие услуги и штрафы» категории делятся на две визуальные подгруппы с собственными fw-bold заголовками и итогами:
  - **Другие услуги и штрафы** — всё, кроме `COMPENSATION_CODES`
  - **Компенсации и декомпенсации** — только `COMPENSATION_CODES`
- Пустая подгруппа не рендерится. Сумма обеих подгрупп = netAmount всей группы, т.е. значение виджета не меняется.

## Что НЕ тронуто

- `WidgetServiceGroupMap.php` — бэкенд-маппинг остаётся прежним.
- Количество виджетов (8) и сетка 4×2.
- Логика `getValue` в `widgetsConfig.ts`.
- Остальные виджеты (commission, delivery_fbo, partners, promo) — рендерятся как раньше.

## Test plan

- [ ] Открыть витрину MarketplaceAnalytics → виджет называется «Прочее и компенсации».
- [ ] Сумма виджета совпадает с прежней (netAmount группы «Другие услуги и штрафы»).
- [ ] Клик по виджету раскрывает таблицу деталей с двумя подгруппами:
  - [ ] «Другие услуги и штрафы» — обычные коды (ozon_disposal, ozon_other_service и т.д.).
  - [ ] «Компенсации и декомпенсации» — только `ozon_compensation` и `ozon_decompensation`.
- [ ] Сумма подгрупп = сумма в карточке виджета.
- [ ] Если в периоде нет компенсаций — блок «Компенсации и декомпенсации» не отображается.
- [ ] Остальные виджеты раскрываются одним заголовком, как раньше.
