### PR TITLE
fix: correct widget group mapping for package codes

### DIFF
--- a/site/src/MarketplaceAnalytics/Application/Service/WidgetServiceGroupMap.php
+++ b/site/src/MarketplaceAnalytics/Application/Service/WidgetServiceGroupMap.php
@@ -60,8 +60,8 @@ final class WidgetServiceGroupMap
             'ozon_supply_surplus'        => 'Услуги доставки и FBO',
             'ozon_storage'               => 'Услуги доставки и FBO',
             'ozon_logistic_pickup'       => 'Услуги доставки и FBO',
-            'ozon_package_materials'     => 'Услуги доставки и FBO',
-            'ozon_package_labor'         => 'Услуги доставки и FBO',
+            'ozon_package_materials'     => 'Другие услуги и штрафы',
+            'ozon_package_labor'         => 'Услуги партнёров',
             'ozon_warehouse_movement'    => 'Услуги доставки и FBO',
 
             // === Услуги партнёров ===

--- a/site/src/MarketplaceAnalytics/Application/Service/WidgetServiceGroupMap.php
+++ b/site/src/MarketplaceAnalytics/Application/Service/WidgetServiceGroupMap.php
@@ -52,7 +52,7 @@ final class WidgetServiceGroupMap
             'ozon_return_after_delivery' => 'Услуги доставки и FBO',
             'ozon_return_storage_pvz'    => 'Услуги доставки и FBO',
             'ozon_return_storage_wh'     => 'Услуги доставки и FBO',
-            // FBO (10 кодов):
+            // FBO (8 кодов):
             'ozon_crossdocking'          => 'Услуги доставки и FBO',
             'ozon_supply_shortage'       => 'Услуги доставки и FBO',
             'ozon_return_from_stock'     => 'Услуги доставки и FBO',
@@ -60,8 +60,6 @@ final class WidgetServiceGroupMap
             'ozon_supply_surplus'        => 'Услуги доставки и FBO',
             'ozon_storage'               => 'Услуги доставки и FBO',
             'ozon_logistic_pickup'       => 'Услуги доставки и FBO',
-            'ozon_package_materials'     => 'Другие услуги и штрафы',
-            'ozon_package_labor'         => 'Услуги партнёров',
             'ozon_warehouse_movement'    => 'Услуги доставки и FBO',
 
             // === Услуги партнёров ===
@@ -70,6 +68,7 @@ final class WidgetServiceGroupMap
             'ozon_storage_partner'       => 'Услуги партнёров',
             'ozon_acquiring'             => 'Услуги партнёров',
             'ozon_fulfillment'           => 'Услуги партнёров',
+            'ozon_package_labor'         => 'Услуги партнёров',
 
             // === Продвижение и реклама ===
             'ozon_cpc'                   => 'Продвижение и реклама',
@@ -82,6 +81,7 @@ final class WidgetServiceGroupMap
 
             // === Другие услуги и штрафы ===
             // Объединяем "Другие услуги и штрафы" + "Компенсации и декомпенсации"
+            'ozon_package_materials'     => 'Другие услуги и штрафы',
             'ozon_disposal'              => 'Другие услуги и штрафы',
             'ozon_ovh_processing'        => 'Другие услуги и штрафы',
             'ozon_penalty_undeliverable' => 'Другие услуги и штрафы',


### PR DESCRIPTION
## Summary

- `ozon_package_materials` перенесён из «Услуги доставки и FBO» → **«Другие услуги и штрафы»**
- `ozon_package_labor` перенесён из «Услуги доставки и FBO» → **«Услуги партнёров»**

Маппинг приведён в соответствие с группировкой в ЛК Ozon, что устраняет расхождение ~1 335 ₽/мес на дашборде MarketplaceAnalytics.

## Test plan

- [ ] Проверить виджет аналитики: суммы по группам «Услуги доставки и FBO», «Другие услуги и штрафы», «Услуги партнёров» совпадают с ЛК Ozon
- [ ] Убедиться, что общая сумма затрат не изменилась (перераспределение между группами)

https://claude.ai/code/session_018SpkC2QcNq8yyrA9xVsKEv