### PR TITLE
feat(marketplace): Ozon mutual settlement report loader

### DIFF
--- a/site/src/Marketplace/Application/LoadMutualSettlementAction.php
+++ b/site/src/Marketplace/Application/LoadMutualSettlementAction.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Entity\MarketplaceRawDocument;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Infrastructure\Api\Ozon\OzonMutualSettlementClient;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * Загружает отчёт «Взаиморасчёты» из Ozon API и сохраняет как raw-документ.
+ *
+ * Парсинг и маппинг в marketplace_costs — следующий этап.
+ */
+final class LoadMutualSettlementAction
+{
+    private const DOCUMENT_TYPE = 'mutual_settlement_report';
+    private const API_ENDPOINT = '/v1/finance/mutual-settlement';
+
+    public function __construct(
+        private readonly OzonMutualSettlementClient $client,
+        private readonly EntityManagerInterface $em,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @return array{rawDocumentId: string, recordsCount: int, responseSize: int}
+     */
+    public function __invoke(
+        Company $company,
+        \DateTimeImmutable $periodFrom,
+        \DateTimeImmutable $periodTo,
+    ): array {
+        $companyId = (string) $company->getId();
+
+        $this->logger->info('LoadMutualSettlement: начало', [
+            'companyId' => $companyId,
+            'periodFrom' => $periodFrom->format('Y-m-d'),
+            'periodTo' => $periodTo->format('Y-m-d'),
+        ]);
+
+        $result = $this->client->fetch($companyId, $periodFrom, $periodTo);
+
+        $rawData = $result['data'];
+        $recordsCount = $result['records_count'];
+        $responseJson = json_encode($rawData, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_UNICODE);
+
+        $rawDoc = new MarketplaceRawDocument(
+            Uuid::uuid4()->toString(),
+            $company,
+            MarketplaceType::OZON,
+            self::DOCUMENT_TYPE,
+        );
+        $rawDoc->setPeriodFrom($periodFrom);
+        $rawDoc->setPeriodTo($periodTo);
+        $rawDoc->setApiEndpoint(self::API_ENDPOINT);
+        $rawDoc->setRawData($rawData);
+        $rawDoc->setRecordsCount($recordsCount);
+
+        // Устанавливаем pending — парсер на следующем этапе
+        $rawDoc->resetProcessingStatus();
+
+        $this->em->persist($rawDoc);
+        $this->em->flush();
+
+        $this->logger->info('LoadMutualSettlement: сохранено', [
+            'companyId' => $companyId,
+            'rawDocumentId' => $rawDoc->getId(),
+            'recordsCount' => $recordsCount,
+            'responseSize' => strlen($responseJson),
+        ]);
+
+        return [
+            'rawDocumentId' => $rawDoc->getId(),
+            'recordsCount' => $recordsCount,
+            'responseSize' => strlen($responseJson),
+        ];
+    }
+}

--- a/site/src/Marketplace/Application/LoadMutualSettlementAction.php
+++ b/site/src/Marketplace/Application/LoadMutualSettlementAction.php
@@ -49,7 +49,7 @@ final class LoadMutualSettlementAction
 
         $rawData = $result['data'];
         $recordsCount = $result['records_count'];
-        $responseJson = json_encode($rawData, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_UNICODE);
+        $responseSize = $result['response_size'];
 
         $rawDoc = new MarketplaceRawDocument(
             Uuid::uuid4()->toString(),
@@ -73,13 +73,13 @@ final class LoadMutualSettlementAction
             'companyId' => $companyId,
             'rawDocumentId' => $rawDoc->getId(),
             'recordsCount' => $recordsCount,
-            'responseSize' => strlen($responseJson),
+            'responseSize' => $responseSize,
         ]);
 
         return [
             'rawDocumentId' => $rawDoc->getId(),
             'recordsCount' => $recordsCount,
-            'responseSize' => strlen($responseJson),
+            'responseSize' => $responseSize,
         ];
     }
 }

--- a/site/src/Marketplace/Infrastructure/Api/Ozon/OzonMutualSettlementClient.php
+++ b/site/src/Marketplace/Infrastructure/Api/Ozon/OzonMutualSettlementClient.php
@@ -37,7 +37,7 @@ final readonly class OzonMutualSettlementClient
     }
 
     /**
-     * @return array{data: array, records_count: int} Полный ответ API + количество записей
+     * @return array{data: array, records_count: int, response_size: int} Полный ответ API + количество записей + размер ответа в байтах
      *
      * @throws \RuntimeException если credentials не найдены или API вернул ошибку
      */
@@ -67,8 +67,8 @@ final readonly class OzonMutualSettlementClient
 
         $requestBody = [
             'date' => [
-                'from' => $periodFrom->format('Y-m-d\T00:00:00.000\Z'),
-                'to' => $periodTo->format('Y-m-d\T23:59:59.999\Z'),
+                'from' => $periodFrom->format('Y-m-d'),
+                'to' => $periodTo->format('Y-m-d'),
             ],
             'language' => 'DEFAULT',
         ];
@@ -102,7 +102,13 @@ final readonly class OzonMutualSettlementClient
             ));
         }
 
-        $data = $response->toArray();
+        $rawContent = $response->getContent();
+        $responseSize = strlen($rawContent);
+        $data = json_decode($rawContent, true, flags: \JSON_THROW_ON_ERROR);
+
+        if (!is_array($data)) {
+            throw new \RuntimeException('Ozon mutual settlement: ответ не является JSON-объектом.');
+        }
 
         // Проверяем: если API вернул report_code — это асинхронный режим
         $reportCode = $data['report_code'] ?? null;
@@ -120,12 +126,13 @@ final readonly class OzonMutualSettlementClient
         $this->logger->info('Ozon mutual settlement: загрузка завершена', [
             'companyId' => $companyId,
             'recordsCount' => $recordsCount,
-            'responseSize' => strlen(json_encode($data, \JSON_THROW_ON_ERROR)),
+            'responseSize' => $responseSize,
         ]);
 
         return [
             'data' => $data,
             'records_count' => $recordsCount,
+            'response_size' => $responseSize,
         ];
     }
 
@@ -168,7 +175,7 @@ final readonly class OzonMutualSettlementClient
                 // Если есть ссылка на файл — скачать и вернуть как JSON
                 $fileUrl = (string) ($data['file'] ?? '');
                 if ('' !== $fileUrl) {
-                    return $this->downloadReport($headers, $fileUrl);
+                    return $this->downloadReport($fileUrl);
                 }
 
                 return $data;
@@ -199,14 +206,14 @@ final readonly class OzonMutualSettlementClient
     /**
      * Скачивание файла отчёта и попытка преобразования в JSON.
      *
-     * @param array<string, string> $headers
+     * Не передаём API credentials — fileUrl обычно pre-signed ссылка
+     * на внешнее хранилище (Yandex Cloud / AWS), авторизация не нужна.
      *
      * @return array Содержимое отчёта в формате массива
      */
-    private function downloadReport(array $headers, string $fileUrl): array
+    private function downloadReport(string $fileUrl): array
     {
         $response = $this->httpClient->request('GET', $fileUrl, [
-            'headers' => $headers,
             'timeout' => self::REQUEST_TIMEOUT,
         ]);
 

--- a/site/src/Marketplace/Infrastructure/Api/Ozon/OzonMutualSettlementClient.php
+++ b/site/src/Marketplace/Infrastructure/Api/Ozon/OzonMutualSettlementClient.php
@@ -110,9 +110,10 @@ final readonly class OzonMutualSettlementClient
             throw new \RuntimeException('Ozon mutual settlement: ответ не является JSON-объектом.');
         }
 
-        // Проверяем: если API вернул report_code — это асинхронный режим
-        $reportCode = $data['report_code'] ?? null;
-        if (null !== $reportCode && '' !== $reportCode) {
+        // Проверяем: если API вернул report_code — это асинхронный режим.
+        // Код может быть на верхнем уровне или внутри result.code.
+        $reportCode = $data['report_code'] ?? $data['result']['code'] ?? $data['code'] ?? null;
+        if (null !== $reportCode && '' !== (string) $reportCode) {
             $this->logger->info('Ozon mutual settlement: асинхронный режим, polling', [
                 'companyId' => $companyId,
                 'reportCode' => $reportCode,
@@ -169,11 +170,14 @@ final readonly class OzonMutualSettlementClient
             }
 
             $data = $response->toArray();
-            $status = (string) ($data['status'] ?? '');
+
+            // /v1/report/info возвращает status и file внутри result,
+            // но на всякий случай проверяем и верхний уровень.
+            $report = $data['result'] ?? $data;
+            $status = (string) ($report['status'] ?? $data['status'] ?? '');
 
             if ('success' === $status || 'completed' === $status) {
-                // Если есть ссылка на файл — скачать и вернуть как JSON
-                $fileUrl = (string) ($data['file'] ?? '');
+                $fileUrl = (string) ($report['file'] ?? $data['file'] ?? '');
                 if ('' !== $fileUrl) {
                     return $this->downloadReport($fileUrl);
                 }
@@ -185,7 +189,7 @@ final readonly class OzonMutualSettlementClient
                 throw new \RuntimeException(sprintf(
                     'Ozon отчёт %s завершился с ошибкой: %s',
                     $reportCode,
-                    (string) ($data['error'] ?? 'unknown'),
+                    (string) ($report['error'] ?? $data['error'] ?? 'unknown'),
                 ));
             }
 

--- a/site/src/Marketplace/Infrastructure/Api/Ozon/OzonMutualSettlementClient.php
+++ b/site/src/Marketplace/Infrastructure/Api/Ozon/OzonMutualSettlementClient.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Api\Ozon;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Infrastructure\Query\MarketplaceCredentialsQuery;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Загружает отчёт «Взаиморасчёты» (mutual settlement) из Ozon Seller API.
+ *
+ * Endpoint: POST /v1/finance/mutual-settlement
+ * Авторизация: Client-Id + Api-Key (те же, что для transaction/list).
+ *
+ * Метод возвращает данные синхронно (JSON).
+ * Если API вернёт report_code (асинхронный режим), клиент реализует
+ * polling /v1/report/info с exponential backoff до готовности.
+ */
+final readonly class OzonMutualSettlementClient
+{
+    private const BASE_URL = 'https://api-seller.ozon.ru';
+    private const ENDPOINT = '/v1/finance/mutual-settlement';
+    private const REPORT_INFO_ENDPOINT = '/v1/report/info';
+
+    private const REQUEST_TIMEOUT = 120;
+    private const POLL_MAX_WAIT_SECONDS = 60;
+    private const POLL_INITIAL_DELAY_SECONDS = 2;
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private MarketplaceCredentialsQuery $credentialsQuery,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @return array{data: array, records_count: int} Полный ответ API + количество записей
+     *
+     * @throws \RuntimeException если credentials не найдены или API вернул ошибку
+     */
+    public function fetch(
+        string $companyId,
+        \DateTimeImmutable $periodFrom,
+        \DateTimeImmutable $periodTo,
+    ): array {
+        $credentials = $this->credentialsQuery->getCredentials($companyId, MarketplaceType::OZON);
+
+        if (null === $credentials) {
+            throw new \RuntimeException('Ozon API credentials не найдены для компании.');
+        }
+
+        $apiKey = $credentials['api_key'];
+        $clientId = $credentials['client_id'] ?? null;
+
+        if ('' === $apiKey || null === $clientId || '' === $clientId) {
+            throw new \RuntimeException('Ozon API credentials неполные: отсутствует api_key или client_id.');
+        }
+
+        $headers = [
+            'Client-Id' => $clientId,
+            'Api-Key' => $apiKey,
+            'Content-Type' => 'application/json',
+        ];
+
+        $requestBody = [
+            'date' => [
+                'from' => $periodFrom->format('Y-m-d\T00:00:00.000\Z'),
+                'to' => $periodTo->format('Y-m-d\T23:59:59.999\Z'),
+            ],
+            'language' => 'DEFAULT',
+        ];
+
+        $this->logger->info('Ozon mutual settlement: начало загрузки', [
+            'companyId' => $companyId,
+            'periodFrom' => $periodFrom->format('Y-m-d'),
+            'periodTo' => $periodTo->format('Y-m-d'),
+        ]);
+
+        $response = $this->httpClient->request('POST', self::BASE_URL . self::ENDPOINT, [
+            'headers' => $headers,
+            'json' => $requestBody,
+            'timeout' => self::REQUEST_TIMEOUT,
+        ]);
+
+        $statusCode = $response->getStatusCode();
+
+        if ($statusCode !== 200) {
+            $body = $response->getContent(false);
+            $this->logger->error('Ozon mutual settlement: ошибка API', [
+                'companyId' => $companyId,
+                'statusCode' => $statusCode,
+                'response' => mb_substr($body, 0, 500),
+            ]);
+
+            throw new \RuntimeException(sprintf(
+                'Ozon mutual settlement API вернул HTTP %d: %s',
+                $statusCode,
+                mb_substr($body, 0, 200),
+            ));
+        }
+
+        $data = $response->toArray();
+
+        // Проверяем: если API вернул report_code — это асинхронный режим
+        $reportCode = $data['report_code'] ?? null;
+        if (null !== $reportCode && '' !== $reportCode) {
+            $this->logger->info('Ozon mutual settlement: асинхронный режим, polling', [
+                'companyId' => $companyId,
+                'reportCode' => $reportCode,
+            ]);
+
+            $data = $this->pollReport($headers, (string) $reportCode);
+        }
+
+        $recordsCount = $this->countRecords($data);
+
+        $this->logger->info('Ozon mutual settlement: загрузка завершена', [
+            'companyId' => $companyId,
+            'recordsCount' => $recordsCount,
+            'responseSize' => strlen(json_encode($data, \JSON_THROW_ON_ERROR)),
+        ]);
+
+        return [
+            'data' => $data,
+            'records_count' => $recordsCount,
+        ];
+    }
+
+    /**
+     * Polling отчёта с exponential backoff.
+     *
+     * @param array<string, string> $headers
+     *
+     * @return array Полный ответ API
+     */
+    private function pollReport(array $headers, string $reportCode): array
+    {
+        $delay = self::POLL_INITIAL_DELAY_SECONDS;
+        $totalWaited = 0;
+
+        while ($totalWaited < self::POLL_MAX_WAIT_SECONDS) {
+            sleep($delay);
+            $totalWaited += $delay;
+
+            $response = $this->httpClient->request('POST', self::BASE_URL . self::REPORT_INFO_ENDPOINT, [
+                'headers' => $headers,
+                'json' => ['code' => $reportCode],
+                'timeout' => self::REQUEST_TIMEOUT,
+            ]);
+
+            $statusCode = $response->getStatusCode();
+
+            if ($statusCode !== 200) {
+                throw new \RuntimeException(sprintf(
+                    'Ozon report/info вернул HTTP %d для report_code=%s',
+                    $statusCode,
+                    $reportCode,
+                ));
+            }
+
+            $data = $response->toArray();
+            $status = (string) ($data['status'] ?? '');
+
+            if ('success' === $status || 'completed' === $status) {
+                // Если есть ссылка на файл — скачать и вернуть как JSON
+                $fileUrl = (string) ($data['file'] ?? '');
+                if ('' !== $fileUrl) {
+                    return $this->downloadReport($headers, $fileUrl);
+                }
+
+                return $data;
+            }
+
+            if ('failed' === $status || 'error' === $status) {
+                throw new \RuntimeException(sprintf(
+                    'Ozon отчёт %s завершился с ошибкой: %s',
+                    $reportCode,
+                    (string) ($data['error'] ?? 'unknown'),
+                ));
+            }
+
+            // Exponential backoff: 2, 4, 8, 16...
+            $delay = min($delay * 2, self::POLL_MAX_WAIT_SECONDS - $totalWaited);
+            if ($delay <= 0) {
+                break;
+            }
+        }
+
+        throw new \RuntimeException(sprintf(
+            'Ozon отчёт %s не готов за %d секунд',
+            $reportCode,
+            self::POLL_MAX_WAIT_SECONDS,
+        ));
+    }
+
+    /**
+     * Скачивание файла отчёта и попытка преобразования в JSON.
+     *
+     * @param array<string, string> $headers
+     *
+     * @return array Содержимое отчёта в формате массива
+     */
+    private function downloadReport(array $headers, string $fileUrl): array
+    {
+        $response = $this->httpClient->request('GET', $fileUrl, [
+            'headers' => $headers,
+            'timeout' => self::REQUEST_TIMEOUT,
+        ]);
+
+        $content = $response->getContent();
+        $contentType = $response->getHeaders()['content-type'][0] ?? '';
+
+        // Если ответ — JSON
+        if (str_contains($contentType, 'json')) {
+            $decoded = json_decode($content, true, flags: \JSON_THROW_ON_ERROR);
+
+            return is_array($decoded) ? $decoded : ['raw' => $content];
+        }
+
+        // CSV или другой формат — оборачиваем в JSON-структуру
+        return ['raw_content' => $content, 'content_type' => $contentType];
+    }
+
+    /**
+     * Подсчитывает количество записей в ответе.
+     *
+     * Структура ответа может варьироваться, пробуем типичные варианты.
+     */
+    private function countRecords(array $data): int
+    {
+        // result.rows или result
+        if (isset($data['result']) && is_array($data['result'])) {
+            if (isset($data['result']['rows']) && is_array($data['result']['rows'])) {
+                return count($data['result']['rows']);
+            }
+
+            return count($data['result']);
+        }
+
+        // rows на верхнем уровне
+        if (isset($data['rows']) && is_array($data['rows'])) {
+            return count($data['rows']);
+        }
+
+        return 0;
+    }
+}

--- a/site/src/MarketplaceAnalytics/Controller/Api/DebugLoadMutualSettlementController.php
+++ b/site/src/MarketplaceAnalytics/Controller/Api/DebugLoadMutualSettlementController.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAnalytics\Controller\Api;
+
+use App\Marketplace\Application\LoadMutualSettlementAction;
+use App\Shared\Service\ActiveCompanyService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Debug-эндпоинт для ручной загрузки отчёта «Взаиморасчёты» из Ozon API.
+ *
+ * Загружает raw-данные за указанный месяц и сохраняет в marketplace_raw_documents.
+ * Парсинг и маппинг в marketplace_costs НЕ выполняется — только сохранение raw.
+ *
+ * Использование:
+ *   POST /api/marketplace-analytics/debug/load-mutual-settlement?year=2026&month=1
+ */
+#[Route(
+    path: '/api/marketplace-analytics/debug/load-mutual-settlement',
+    name: 'api_marketplace_analytics_debug_load_mutual_settlement',
+    methods: ['POST'],
+)]
+#[IsGranted('ROLE_COMPANY_USER')]
+final class DebugLoadMutualSettlementController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $activeCompanyService,
+        private readonly LoadMutualSettlementAction $loadAction,
+    ) {
+    }
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        $year = $request->query->getInt('year', 0);
+        $month = $request->query->getInt('month', 0);
+
+        if ($year < 2020 || $year > 2030) {
+            return $this->json(['error' => 'year is required (2020-2030)'], 422);
+        }
+
+        if ($month < 1 || $month > 12) {
+            return $this->json(['error' => 'month is required (1-12)'], 422);
+        }
+
+        $company = $this->activeCompanyService->getActiveCompany();
+
+        $periodFrom = new \DateTimeImmutable(sprintf('%d-%02d-01', $year, $month));
+        $periodTo = $periodFrom->modify('last day of this month');
+
+        try {
+            $result = ($this->loadAction)($company, $periodFrom, $periodTo);
+        } catch (\RuntimeException $e) {
+            return $this->json([
+                'success' => false,
+                'error' => $e->getMessage(),
+            ], 500);
+        }
+
+        $responseSize = $result['responseSize'];
+        $formattedSize = $responseSize >= 1024
+            ? round($responseSize / 1024, 1) . 'KB'
+            : $responseSize . 'B';
+
+        return $this->json([
+            'success' => true,
+            'rawDocumentId' => $result['rawDocumentId'],
+            'period' => [
+                'from' => $periodFrom->format('Y-m-d'),
+                'to' => $periodTo->format('Y-m-d'),
+            ],
+            'recordsCount' => $result['recordsCount'],
+            'responseSize' => $formattedSize,
+        ]);
+    }
+}

--- a/site/src/MarketplaceAnalytics/Controller/Api/DebugViewRawDocumentController.php
+++ b/site/src/MarketplaceAnalytics/Controller/Api/DebugViewRawDocumentController.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAnalytics\Controller\Api;
+
+use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
+use App\Shared\Service\ActiveCompanyService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Debug-эндпоинт для просмотра содержимого raw-документа.
+ *
+ * Возвращает полный raw_data как JSON для анализа структуры ответа Ozon API.
+ *
+ * Использование:
+ *   GET /api/marketplace-analytics/debug/raw-document/{id}
+ */
+#[Route(
+    path: '/api/marketplace-analytics/debug/raw-document/{id}',
+    name: 'api_marketplace_analytics_debug_raw_document_view',
+    methods: ['GET'],
+)]
+#[IsGranted('ROLE_COMPANY_USER')]
+final class DebugViewRawDocumentController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $activeCompanyService,
+        private readonly MarketplaceRawDocumentRepository $rawDocumentRepository,
+    ) {
+    }
+
+    public function __invoke(string $id): JsonResponse
+    {
+        $company = $this->activeCompanyService->getActiveCompany();
+        $companyId = (string) $company->getId();
+
+        $document = $this->rawDocumentRepository->find($id);
+
+        if (null === $document || (string) $document->getCompany()->getId() !== $companyId) {
+            throw $this->createNotFoundException('Raw-документ не найден.');
+        }
+
+        return new JsonResponse([
+            'id' => $document->getId(),
+            'documentType' => $document->getDocumentType(),
+            'marketplace' => $document->getMarketplace()->value,
+            'periodFrom' => $document->getPeriodFrom()->format('Y-m-d'),
+            'periodTo' => $document->getPeriodTo()->format('Y-m-d'),
+            'syncedAt' => $document->getSyncedAt()->format('Y-m-d H:i:s'),
+            'recordsCount' => $document->getRecordsCount(),
+            'processingStatus' => $document->getProcessingStatus()?->value,
+            'apiEndpoint' => $document->getApiEndpoint(),
+            'rawData' => $document->getRawData(),
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

- Добавлен `OzonMutualSettlementClient` — клиент Ozon Seller API для загрузки отчёта «Взаиморасчёты» (`POST /v1/finance/mutual-settlement`). Поддерживает синхронный ответ и async-fallback с polling `/v1/report/info` (exponential backoff, таймаут 60 сек)
- Добавлен `LoadMutualSettlementAction` — Action для загрузки и сохранения raw-документа с `document_type = 'mutual_settlement_report'` и `processing_status = pending`
- Добавлен debug-endpoint `POST /api/marketplace-analytics/debug/load-mutual-settlement?year=2026&month=1` для ручного запуска загрузки
- Добавлен debug-endpoint `GET /api/marketplace-analytics/debug/raw-document/{id}` для просмотра полного `raw_data` документа

**Этап 1 — только загрузка и сохранение raw.** Парсинг и маппинг в `marketplace_costs` — следующий этап.

## Детали реализации

| Файл | Назначение |
|---|---|
| `src/Marketplace/Infrastructure/Api/Ozon/OzonMutualSettlementClient.php` | HTTP-клиент Ozon API (Symfony HttpClient, Client-Id + Api-Key) |
| `src/Marketplace/Application/LoadMutualSettlementAction.php` | Оркестрация: fetch → создание MarketplaceRawDocument → flush |
| `src/MarketplaceAnalytics/Controller/Api/DebugLoadMutualSettlementController.php` | POST endpoint загрузки |
| `src/MarketplaceAnalytics/Controller/Api/DebugViewRawDocumentController.php` | GET endpoint просмотра raw-данных |

- IDOR защита через `ActiveCompanyService::getActiveCompany()` + проверка `company_id`
- Credentials из `MarketplaceCredentialsQuery` (тот же источник что `OzonFetcher`)
- Логирование запроса/ответа через `LoggerInterface`

## Test plan

- [ ] Вызвать `POST /api/marketplace-analytics/debug/load-mutual-settlement?year=2026&month=1` — убедиться что raw-документ создан и `rawDocumentId` возвращён
- [ ] Вызвать `GET /api/marketplace-analytics/debug/raw-document/{id}` — убедиться что полный `raw_data` возвращается
- [ ] Проверить что `document_type = 'mutual_settlement_report'` и `processing_status = 'pending'` в БД
- [ ] Проверить IDOR: запросить чужой raw-документ → 404
- [ ] Проверить что данные НЕ парсятся в `marketplace_costs`

https://claude.ai/code/session_01D74B8UCgndRKQn7GLeF4Yy