### PR TITLE
fix(marketplace): fix mutual settlement request format, switch to AppLogger

### DIFF
--- a/site/src/Marketplace/Application/LoadMutualSettlementAction.php
+++ b/site/src/Marketplace/Application/LoadMutualSettlementAction.php
@@ -8,8 +8,8 @@ use App\Company\Entity\Company;
 use App\Marketplace\Entity\MarketplaceRawDocument;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Infrastructure\Api\Ozon\OzonMutualSettlementClient;
+use App\Shared\Service\AppLogger;
 use Doctrine\ORM\EntityManagerInterface;
-use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
 
 /**
@@ -25,7 +25,7 @@ final class LoadMutualSettlementAction
     public function __construct(
         private readonly OzonMutualSettlementClient $client,
         private readonly EntityManagerInterface $em,
-        private readonly LoggerInterface $logger,
+        private readonly AppLogger $appLogger,
     ) {
     }
 
@@ -39,7 +39,7 @@ final class LoadMutualSettlementAction
     ): array {
         $companyId = (string) $company->getId();
 
-        $this->logger->info('LoadMutualSettlement: начало', [
+        $this->appLogger->info('LoadMutualSettlement: начало', [
             'companyId' => $companyId,
             'periodFrom' => $periodFrom->format('Y-m-d'),
             'periodTo' => $periodTo->format('Y-m-d'),
@@ -69,7 +69,7 @@ final class LoadMutualSettlementAction
         $this->em->persist($rawDoc);
         $this->em->flush();
 
-        $this->logger->info('LoadMutualSettlement: сохранено', [
+        $this->appLogger->info('LoadMutualSettlement: сохранено', [
             'companyId' => $companyId,
             'rawDocumentId' => $rawDoc->getId(),
             'recordsCount' => $recordsCount,

--- a/site/src/Marketplace/Infrastructure/Api/Ozon/OzonMutualSettlementClient.php
+++ b/site/src/Marketplace/Infrastructure/Api/Ozon/OzonMutualSettlementClient.php
@@ -87,7 +87,7 @@ final readonly class OzonMutualSettlementClient
 
             $statusCode = $response->getStatusCode();
         } catch (\Exception $e) {
-            $this->appLogger->error('Ozon MS failed', $e, ['request_body' => $requestBody]);
+            $this->appLogger->error('Ozon MS failed', $e, ['companyId' => $companyId, 'request_body' => $requestBody]);
 
             throw new \RuntimeException(
                 sprintf('Ozon mutual settlement: ошибка соединения: %s', $e->getMessage()),
@@ -110,7 +110,7 @@ final readonly class OzonMutualSettlementClient
                 $statusCode,
                 mb_substr($responseBody, 0, 200),
             ));
-            $this->appLogger->error('Ozon MS failed', $exception, ['request_body' => $requestBody]);
+            $this->appLogger->error('Ozon MS failed', $exception, ['companyId' => $companyId, 'request_body' => $requestBody]);
 
             throw $exception;
         }

--- a/site/src/Marketplace/Infrastructure/Api/Ozon/OzonMutualSettlementClient.php
+++ b/site/src/Marketplace/Infrastructure/Api/Ozon/OzonMutualSettlementClient.php
@@ -6,7 +6,7 @@ namespace App\Marketplace\Infrastructure\Api\Ozon;
 
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Infrastructure\Query\MarketplaceCredentialsQuery;
-use Psr\Log\LoggerInterface;
+use App\Shared\Service\AppLogger;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -32,7 +32,7 @@ final readonly class OzonMutualSettlementClient
     public function __construct(
         private HttpClientInterface $httpClient,
         private MarketplaceCredentialsQuery $credentialsQuery,
-        private LoggerInterface $logger,
+        private AppLogger $appLogger,
     ) {
     }
 
@@ -66,45 +66,57 @@ final readonly class OzonMutualSettlementClient
         ];
 
         $requestBody = [
-            'date' => [
-                'from' => $periodFrom->format('Y-m-d'),
-                'to' => $periodTo->format('Y-m-d'),
-            ],
+            'date' => $periodFrom->format('Y-m'),
             'language' => 'DEFAULT',
         ];
 
-        $this->logger->info('Ozon mutual settlement: начало загрузки', [
+        $url = self::BASE_URL . self::ENDPOINT;
+
+        $this->appLogger->info('Ozon MS request', [
             'companyId' => $companyId,
-            'periodFrom' => $periodFrom->format('Y-m-d'),
-            'periodTo' => $periodTo->format('Y-m-d'),
+            'url' => $url,
+            'body' => $requestBody,
         ]);
 
-        $response = $this->httpClient->request('POST', self::BASE_URL . self::ENDPOINT, [
-            'headers' => $headers,
-            'json' => $requestBody,
-            'timeout' => self::REQUEST_TIMEOUT,
-        ]);
-
-        $statusCode = $response->getStatusCode();
-
-        if ($statusCode !== 200) {
-            $body = $response->getContent(false);
-            $this->logger->error('Ozon mutual settlement: ошибка API', [
-                'companyId' => $companyId,
-                'statusCode' => $statusCode,
-                'response' => mb_substr($body, 0, 500),
+        try {
+            $response = $this->httpClient->request('POST', $url, [
+                'headers' => $headers,
+                'json' => $requestBody,
+                'timeout' => self::REQUEST_TIMEOUT,
             ]);
 
-            throw new \RuntimeException(sprintf(
-                'Ozon mutual settlement API вернул HTTP %d: %s',
-                $statusCode,
-                mb_substr($body, 0, 200),
-            ));
+            $statusCode = $response->getStatusCode();
+        } catch (\Exception $e) {
+            $this->appLogger->error('Ozon MS failed', $e, ['request_body' => $requestBody]);
+
+            throw new \RuntimeException(
+                sprintf('Ozon mutual settlement: ошибка соединения: %s', $e->getMessage()),
+                0,
+                $e,
+            );
         }
 
-        $rawContent = $response->getContent();
-        $responseSize = strlen($rawContent);
-        $data = json_decode($rawContent, true, flags: \JSON_THROW_ON_ERROR);
+        $responseBody = $response->getContent(false);
+
+        $this->appLogger->info('Ozon MS response', [
+            'companyId' => $companyId,
+            'status' => $statusCode,
+            'body' => mb_substr($responseBody, 0, 1000),
+        ]);
+
+        if ($statusCode !== 200) {
+            $exception = new \RuntimeException(sprintf(
+                'Ozon mutual settlement API вернул HTTP %d: %s',
+                $statusCode,
+                mb_substr($responseBody, 0, 200),
+            ));
+            $this->appLogger->error('Ozon MS failed', $exception, ['request_body' => $requestBody]);
+
+            throw $exception;
+        }
+
+        $responseSize = strlen($responseBody);
+        $data = json_decode($responseBody, true, flags: \JSON_THROW_ON_ERROR);
 
         if (!is_array($data)) {
             throw new \RuntimeException('Ozon mutual settlement: ответ не является JSON-объектом.');
@@ -114,7 +126,7 @@ final readonly class OzonMutualSettlementClient
         // Код может быть на верхнем уровне или внутри result.code.
         $reportCode = $data['report_code'] ?? $data['result']['code'] ?? $data['code'] ?? null;
         if (null !== $reportCode && '' !== (string) $reportCode) {
-            $this->logger->info('Ozon mutual settlement: асинхронный режим, polling', [
+            $this->appLogger->info('Ozon MS: асинхронный режим, polling', [
                 'companyId' => $companyId,
                 'reportCode' => $reportCode,
             ]);
@@ -124,7 +136,7 @@ final readonly class OzonMutualSettlementClient
 
         $recordsCount = $this->countRecords($data);
 
-        $this->logger->info('Ozon mutual settlement: загрузка завершена', [
+        $this->appLogger->info('Ozon MS: загрузка завершена', [
             'companyId' => $companyId,
             'recordsCount' => $recordsCount,
             'responseSize' => $responseSize,


### PR DESCRIPTION
## Summary

- Fix Ozon `/v1/finance/mutual-settlement` request body format: change `{date: {from, to}}` to `{date: "YYYY-MM"}` — Ozon was returning HTTP 400 (`proto: invalid value for string field date`)
- Replace `LoggerInterface` with `AppLogger` in `OzonMutualSettlementClient` and `LoadMutualSettlementAction`
- Add detailed logging: request body before send, response status+body after receive, error with exception on failure

## Changed files

- `site/src/Marketplace/Infrastructure/Api/Ozon/OzonMutualSettlementClient.php` — request format fix + AppLogger + detailed logging
- `site/src/Marketplace/Application/LoadMutualSettlementAction.php` — AppLogger migration

## Test plan

- [ ] POST `/api/marketplace-analytics/debug/load-mutual-settlement?year=2026&month=1` returns success
- [ ] Check logs: "Ozon MS request" with `{date: "2026-01", language: "DEFAULT"}` body
- [ ] Check logs: "Ozon MS response" with status and response body
- [ ] If variant A (`date: "YYYY-MM"`) fails, try variant B/C per task description
- [ ] Raw document created in `marketplace_raw_documents`

https://claude.ai/code/session_01D74B8UCgndRKQn7GLeF4Yy