### PR TITLE
feat(marketplace): handle binary Ozon mutual settlement responses

### DIFF
--- a/site/src/Marketplace/Infrastructure/Api/Ozon/OzonMutualSettlementClient.php
+++ b/site/src/Marketplace/Infrastructure/Api/Ozon/OzonMutualSettlementClient.php
@@ -30,8 +30,8 @@ final readonly class OzonMutualSettlementClient
     private const POLL_MAX_WAIT_SECONDS = 60;
     private const POLL_INITIAL_DELAY_SECONDS = 2;
 
-    /** Content-Type подстроки, которые считаем текстовым/JSON ответом */
-    private const TEXT_CONTENT_TYPES = ['json', 'text/', 'xml'];
+    /** Content-Type подстроки, которые пробуем парсить как JSON */
+    private const JSON_CONTENT_TYPES = ['json'];
 
     public function __construct(
         private HttpClientInterface $httpClient,
@@ -109,7 +109,7 @@ final readonly class OzonMutualSettlementClient
             'status' => $statusCode,
             'content_type' => $contentType,
             'content_length' => $responseSize,
-            'body_preview' => mb_substr($responseBody, 0, 200),
+            'body_preview' => substr($responseBody, 0, 200),
         ]);
 
         if ($statusCode !== 200) {
@@ -123,8 +123,8 @@ final readonly class OzonMutualSettlementClient
             throw $exception;
         }
 
-        // Бинарный ответ (XLSX, CSV и т.д.) — сохраняем как base64
-        if (!$this->isTextContentType($contentType)) {
+        // Не-JSON ответ (XLSX, CSV и т.д.) — сохраняем как base64
+        if (!$this->isJsonContentType($contentType)) {
             $this->appLogger->info('Ozon MS: бинарный ответ, сохраняем как base64', [
                 'companyId' => $companyId,
                 'content_type' => $contentType,
@@ -152,11 +152,11 @@ final readonly class OzonMutualSettlementClient
         $data = json_decode($responseBody, true);
 
         if (!is_array($data)) {
-            // Текстовый но не JSON — сохраняем как текст в обёртке
+            // JSON Content-Type, но невалидный JSON — сохраняем как base64
             $data = [
                 '_text' => true,
                 'content_type' => $contentType,
-                'content' => $responseBody,
+                'content_base64' => base64_encode($responseBody),
                 'size_bytes' => $responseSize,
                 'period' => [
                     'from' => $periodFrom->format('Y-m-d'),
@@ -300,14 +300,16 @@ final readonly class OzonMutualSettlementClient
             'size_bytes' => $contentSize,
         ]);
 
-        // Если ответ — JSON
+        // Если ответ — JSON, пробуем распарсить
         if (str_contains($contentType, 'json')) {
             $decoded = json_decode($content, true);
 
-            return is_array($decoded) ? $decoded : ['raw' => $content];
+            if (is_array($decoded)) {
+                return $decoded;
+            }
         }
 
-        // Бинарный/текстовый файл — оборачиваем в base64
+        // Не-JSON или невалидный JSON — оборачиваем в base64
         return [
             '_binary' => true,
             'content_type' => $contentType,
@@ -347,15 +349,15 @@ final readonly class OzonMutualSettlementClient
         return 0;
     }
 
-    private function isTextContentType(string $contentType): bool
+    private function isJsonContentType(string $contentType): bool
     {
         if ('' === $contentType) {
             // Если Content-Type не указан — пробуем как JSON
             return true;
         }
 
-        foreach (self::TEXT_CONTENT_TYPES as $textType) {
-            if (str_contains($contentType, $textType)) {
+        foreach (self::JSON_CONTENT_TYPES as $jsonType) {
+            if (str_contains($contentType, $jsonType)) {
                 return true;
             }
         }

--- a/site/src/Marketplace/Infrastructure/Api/Ozon/OzonMutualSettlementClient.php
+++ b/site/src/Marketplace/Infrastructure/Api/Ozon/OzonMutualSettlementClient.php
@@ -15,9 +15,10 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  * Endpoint: POST /v1/finance/mutual-settlement
  * Авторизация: Client-Id + Api-Key (те же, что для transaction/list).
  *
- * Метод возвращает данные синхронно (JSON).
- * Если API вернёт report_code (асинхронный режим), клиент реализует
- * polling /v1/report/info с exponential backoff до готовности.
+ * Ответ может быть:
+ *   - JSON (синхронный режим)
+ *   - report_code (асинхронный режим → polling → файл)
+ *   - Бинарный файл (CSV/XLSX) — сохраняется как base64
  */
 final readonly class OzonMutualSettlementClient
 {
@@ -29,6 +30,9 @@ final readonly class OzonMutualSettlementClient
     private const POLL_MAX_WAIT_SECONDS = 60;
     private const POLL_INITIAL_DELAY_SECONDS = 2;
 
+    /** Content-Type подстроки, которые считаем текстовым/JSON ответом */
+    private const TEXT_CONTENT_TYPES = ['json', 'text/', 'xml'];
+
     public function __construct(
         private HttpClientInterface $httpClient,
         private MarketplaceCredentialsQuery $credentialsQuery,
@@ -37,7 +41,7 @@ final readonly class OzonMutualSettlementClient
     }
 
     /**
-     * @return array{data: array, records_count: int, response_size: int} Полный ответ API + количество записей + размер ответа в байтах
+     * @return array{data: array, records_count: int, response_size: int}
      *
      * @throws \RuntimeException если credentials не найдены или API вернул ошибку
      */
@@ -97,11 +101,15 @@ final readonly class OzonMutualSettlementClient
         }
 
         $responseBody = $response->getContent(false);
+        $contentType = $response->getHeaders(false)['content-type'][0] ?? '';
+        $responseSize = strlen($responseBody);
 
-        $this->appLogger->info('Ozon MS response', [
+        $this->appLogger->info('Ozon MS response headers', [
             'companyId' => $companyId,
             'status' => $statusCode,
-            'body' => mb_substr($responseBody, 0, 1000),
+            'content_type' => $contentType,
+            'content_length' => $responseSize,
+            'body_preview' => mb_substr($responseBody, 0, 200),
         ]);
 
         if ($statusCode !== 200) {
@@ -115,15 +123,55 @@ final readonly class OzonMutualSettlementClient
             throw $exception;
         }
 
-        $responseSize = strlen($responseBody);
-        $data = json_decode($responseBody, true, flags: \JSON_THROW_ON_ERROR);
+        // Бинарный ответ (XLSX, CSV и т.д.) — сохраняем как base64
+        if (!$this->isTextContentType($contentType)) {
+            $this->appLogger->info('Ozon MS: бинарный ответ, сохраняем как base64', [
+                'companyId' => $companyId,
+                'content_type' => $contentType,
+                'size_bytes' => $responseSize,
+            ]);
 
-        if (!is_array($data)) {
-            throw new \RuntimeException('Ozon mutual settlement: ответ не является JSON-объектом.');
+            $data = [
+                '_binary' => true,
+                'content_type' => $contentType,
+                'content_base64' => base64_encode($responseBody),
+                'size_bytes' => $responseSize,
+                'period' => [
+                    'from' => $periodFrom->format('Y-m-d'),
+                    'to' => $periodTo->format('Y-m-d'),
+                ],
+            ];
+
+            return [
+                'data' => $data,
+                'records_count' => 0,
+                'response_size' => $responseSize,
+            ];
         }
 
-        // Проверяем: если API вернул report_code — это асинхронный режим.
-        // Код может быть на верхнем уровне или внутри result.code.
+        $data = json_decode($responseBody, true);
+
+        if (!is_array($data)) {
+            // Текстовый но не JSON — сохраняем как текст в обёртке
+            $data = [
+                '_text' => true,
+                'content_type' => $contentType,
+                'content' => $responseBody,
+                'size_bytes' => $responseSize,
+                'period' => [
+                    'from' => $periodFrom->format('Y-m-d'),
+                    'to' => $periodTo->format('Y-m-d'),
+                ],
+            ];
+
+            return [
+                'data' => $data,
+                'records_count' => 0,
+                'response_size' => $responseSize,
+            ];
+        }
+
+        // JSON-ответ — проверяем асинхронный режим
         $reportCode = $data['report_code'] ?? $data['result']['code'] ?? $data['code'] ?? null;
         if (null !== $reportCode && '' !== (string) $reportCode) {
             $this->appLogger->info('Ozon MS: асинхронный режим, polling', [
@@ -131,7 +179,7 @@ final readonly class OzonMutualSettlementClient
                 'reportCode' => $reportCode,
             ]);
 
-            $data = $this->pollReport($headers, (string) $reportCode);
+            $data = $this->pollReport($headers, (string) $reportCode, $companyId, $periodFrom, $periodTo);
         }
 
         $recordsCount = $this->countRecords($data);
@@ -156,8 +204,13 @@ final readonly class OzonMutualSettlementClient
      *
      * @return array Полный ответ API
      */
-    private function pollReport(array $headers, string $reportCode): array
-    {
+    private function pollReport(
+        array $headers,
+        string $reportCode,
+        string $companyId,
+        \DateTimeImmutable $periodFrom,
+        \DateTimeImmutable $periodTo,
+    ): array {
         $delay = self::POLL_INITIAL_DELAY_SECONDS;
         $totalWaited = 0;
 
@@ -191,7 +244,7 @@ final readonly class OzonMutualSettlementClient
             if ('success' === $status || 'completed' === $status) {
                 $fileUrl = (string) ($report['file'] ?? $data['file'] ?? '');
                 if ('' !== $fileUrl) {
-                    return $this->downloadReport($fileUrl);
+                    return $this->downloadReport($fileUrl, $companyId, $periodFrom, $periodTo);
                 }
 
                 return $data;
@@ -220,40 +273,63 @@ final readonly class OzonMutualSettlementClient
     }
 
     /**
-     * Скачивание файла отчёта и попытка преобразования в JSON.
+     * Скачивание файла отчёта.
      *
      * Не передаём API credentials — fileUrl обычно pre-signed ссылка
      * на внешнее хранилище (Yandex Cloud / AWS), авторизация не нужна.
      *
      * @return array Содержимое отчёта в формате массива
      */
-    private function downloadReport(string $fileUrl): array
-    {
+    private function downloadReport(
+        string $fileUrl,
+        string $companyId,
+        \DateTimeImmutable $periodFrom,
+        \DateTimeImmutable $periodTo,
+    ): array {
         $response = $this->httpClient->request('GET', $fileUrl, [
             'timeout' => self::REQUEST_TIMEOUT,
         ]);
 
         $content = $response->getContent();
         $contentType = $response->getHeaders()['content-type'][0] ?? '';
+        $contentSize = strlen($content);
+
+        $this->appLogger->info('Ozon MS: скачан файл отчёта', [
+            'companyId' => $companyId,
+            'content_type' => $contentType,
+            'size_bytes' => $contentSize,
+        ]);
 
         // Если ответ — JSON
         if (str_contains($contentType, 'json')) {
-            $decoded = json_decode($content, true, flags: \JSON_THROW_ON_ERROR);
+            $decoded = json_decode($content, true);
 
             return is_array($decoded) ? $decoded : ['raw' => $content];
         }
 
-        // CSV или другой формат — оборачиваем в JSON-структуру
-        return ['raw_content' => $content, 'content_type' => $contentType];
+        // Бинарный/текстовый файл — оборачиваем в base64
+        return [
+            '_binary' => true,
+            'content_type' => $contentType,
+            'content_base64' => base64_encode($content),
+            'size_bytes' => $contentSize,
+            'period' => [
+                'from' => $periodFrom->format('Y-m-d'),
+                'to' => $periodTo->format('Y-m-d'),
+            ],
+        ];
     }
 
     /**
      * Подсчитывает количество записей в ответе.
-     *
-     * Структура ответа может варьироваться, пробуем типичные варианты.
      */
     private function countRecords(array $data): int
     {
+        // Бинарные/текстовые обёртки — записей нет
+        if (isset($data['_binary']) || isset($data['_text'])) {
+            return 0;
+        }
+
         // result.rows или result
         if (isset($data['result']) && is_array($data['result'])) {
             if (isset($data['result']['rows']) && is_array($data['result']['rows'])) {
@@ -269,5 +345,21 @@ final readonly class OzonMutualSettlementClient
         }
 
         return 0;
+    }
+
+    private function isTextContentType(string $contentType): bool
+    {
+        if ('' === $contentType) {
+            // Если Content-Type не указан — пробуем как JSON
+            return true;
+        }
+
+        foreach (self::TEXT_CONTENT_TYPES as $textType) {
+            if (str_contains($contentType, $textType)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/site/src/MarketplaceAnalytics/Controller/Api/DebugDownloadRawDocumentController.php
+++ b/site/src/MarketplaceAnalytics/Controller/Api/DebugDownloadRawDocumentController.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAnalytics\Controller\Api;
+
+use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
+use App\Shared\Service\ActiveCompanyService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Debug-эндпоинт для скачивания бинарного raw-документа.
+ *
+ * Декодирует base64 из raw_data.content_base64 и отдаёт файл
+ * с правильным Content-Type и Content-Disposition.
+ *
+ * Использование:
+ *   GET /api/marketplace-analytics/debug/raw-document/{id}/download
+ */
+#[Route(
+    path: '/api/marketplace-analytics/debug/raw-document/{id}/download',
+    name: 'api_marketplace_analytics_debug_raw_document_download',
+    methods: ['GET'],
+)]
+#[IsGranted('ROLE_COMPANY_USER')]
+final class DebugDownloadRawDocumentController extends AbstractController
+{
+    private const EXTENSION_MAP = [
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => 'xlsx',
+        'application/vnd.ms-excel' => 'xls',
+        'text/csv' => 'csv',
+        'application/csv' => 'csv',
+        'application/zip' => 'zip',
+        'application/octet-stream' => 'bin',
+    ];
+
+    public function __construct(
+        private readonly ActiveCompanyService $activeCompanyService,
+        private readonly MarketplaceRawDocumentRepository $rawDocumentRepository,
+    ) {
+    }
+
+    public function __invoke(string $id): Response
+    {
+        $company = $this->activeCompanyService->getActiveCompany();
+        $companyId = (string) $company->getId();
+
+        $document = $this->rawDocumentRepository->find($id);
+
+        if (null === $document || (string) $document->getCompany()->getId() !== $companyId) {
+            throw $this->createNotFoundException('Raw-документ не найден.');
+        }
+
+        $rawData = $document->getRawData();
+
+        if (empty($rawData['_binary']) || !isset($rawData['content_base64'])) {
+            throw $this->createNotFoundException('Документ не содержит бинарных данных.');
+        }
+
+        $contentType = $rawData['content_type'] ?? 'application/octet-stream';
+        $content = base64_decode($rawData['content_base64'], true);
+
+        if (false === $content) {
+            throw new \RuntimeException('Не удалось декодировать base64.');
+        }
+
+        $extension = self::EXTENSION_MAP[$contentType] ?? 'bin';
+        $periodFrom = $document->getPeriodFrom()->format('Y-m');
+        $filename = sprintf('mutual_settlement_%s.%s', $periodFrom, $extension);
+
+        return new Response($content, 200, [
+            'Content-Type' => $contentType,
+            'Content-Disposition' => sprintf('attachment; filename="%s"', $filename),
+            'Content-Length' => (string) strlen($content),
+        ]);
+    }
+}

--- a/site/src/MarketplaceAnalytics/Controller/Api/DebugDownloadRawDocumentController.php
+++ b/site/src/MarketplaceAnalytics/Controller/Api/DebugDownloadRawDocumentController.php
@@ -56,8 +56,8 @@ final class DebugDownloadRawDocumentController extends AbstractController
 
         $rawData = $document->getRawData();
 
-        if (empty($rawData['_binary']) || !isset($rawData['content_base64'])) {
-            throw $this->createNotFoundException('Документ не содержит бинарных данных.');
+        if ((empty($rawData['_binary']) && empty($rawData['_text'])) || !isset($rawData['content_base64'])) {
+            throw $this->createNotFoundException('Документ не содержит данных для скачивания.');
         }
 
         $contentType = $rawData['content_type'] ?? 'application/octet-stream';

--- a/site/src/MarketplaceAnalytics/Controller/Api/DebugLoadMutualSettlementController.php
+++ b/site/src/MarketplaceAnalytics/Controller/Api/DebugLoadMutualSettlementController.php
@@ -6,6 +6,7 @@ namespace App\MarketplaceAnalytics\Controller\Api;
 
 use App\Marketplace\Application\LoadMutualSettlementAction;
 use App\Shared\Service\ActiveCompanyService;
+use App\Shared\Service\AppLogger;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -32,6 +33,7 @@ final class DebugLoadMutualSettlementController extends AbstractController
     public function __construct(
         private readonly ActiveCompanyService $activeCompanyService,
         private readonly LoadMutualSettlementAction $loadAction,
+        private readonly AppLogger $appLogger,
     ) {
     }
 
@@ -55,7 +57,13 @@ final class DebugLoadMutualSettlementController extends AbstractController
 
         try {
             $result = ($this->loadAction)($company, $periodFrom, $periodTo);
-        } catch (\RuntimeException $e) {
+        } catch (\Exception $e) {
+            $this->appLogger->error('LoadMutualSettlement: ошибка', $e, [
+                'companyId' => (string) $company->getId(),
+                'year' => $year,
+                'month' => $month,
+            ]);
+
             return $this->json([
                 'success' => false,
                 'error' => $e->getMessage(),

--- a/site/src/MarketplaceAnalytics/Controller/Api/DebugViewRawDocumentController.php
+++ b/site/src/MarketplaceAnalytics/Controller/Api/DebugViewRawDocumentController.php
@@ -47,10 +47,10 @@ final class DebugViewRawDocumentController extends AbstractController
 
         $rawData = $document->getRawData();
 
-        // Для бинарных данных — показываем метаданные + превью base64
-        if (!empty($rawData['_binary']) && isset($rawData['content_base64'])) {
+        // Для бинарных/текстовых данных — показываем метаданные + превью base64
+        if ((!empty($rawData['_binary']) || !empty($rawData['_text'])) && isset($rawData['content_base64'])) {
             $rawDataPreview = $rawData;
-            $rawDataPreview['content_base64_preview'] = mb_substr($rawData['content_base64'], 0, 500);
+            $rawDataPreview['content_base64_preview'] = substr($rawData['content_base64'], 0, 500);
             unset($rawDataPreview['content_base64']);
             $rawDataPreview['download_url'] = '/api/marketplace-analytics/debug/raw-document/' . $id . '/download';
         }

--- a/site/src/MarketplaceAnalytics/Controller/Api/DebugViewRawDocumentController.php
+++ b/site/src/MarketplaceAnalytics/Controller/Api/DebugViewRawDocumentController.php
@@ -14,7 +14,8 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 /**
  * Debug-эндпоинт для просмотра содержимого raw-документа.
  *
- * Возвращает полный raw_data как JSON для анализа структуры ответа Ozon API.
+ * Для JSON-данных возвращает raw_data как есть.
+ * Для бинарных (_binary=true) — метаданные + первые 500 байт base64.
  *
  * Использование:
  *   GET /api/marketplace-analytics/debug/raw-document/{id}
@@ -44,6 +45,16 @@ final class DebugViewRawDocumentController extends AbstractController
             throw $this->createNotFoundException('Raw-документ не найден.');
         }
 
+        $rawData = $document->getRawData();
+
+        // Для бинарных данных — показываем метаданные + превью base64
+        if (!empty($rawData['_binary']) && isset($rawData['content_base64'])) {
+            $rawDataPreview = $rawData;
+            $rawDataPreview['content_base64_preview'] = mb_substr($rawData['content_base64'], 0, 500);
+            unset($rawDataPreview['content_base64']);
+            $rawDataPreview['download_url'] = '/api/marketplace-analytics/debug/raw-document/' . $id . '/download';
+        }
+
         return new JsonResponse([
             'id' => $document->getId(),
             'documentType' => $document->getDocumentType(),
@@ -54,7 +65,7 @@ final class DebugViewRawDocumentController extends AbstractController
             'recordsCount' => $document->getRecordsCount(),
             'processingStatus' => $document->getProcessingStatus()?->value,
             'apiEndpoint' => $document->getApiEndpoint(),
-            'rawData' => $document->getRawData(),
+            'rawData' => $rawDataPreview ?? $rawData,
         ]);
     }
 }

--- a/site/templates/marketplace/test.html.twig
+++ b/site/templates/marketplace/test.html.twig
@@ -441,13 +441,21 @@
                     method: 'POST',
                     headers: { 'X-Requested-With': 'XMLHttpRequest' }
                 })
-                .then(function (resp) { return resp.json().then(function (data) { return { ok: resp.ok, data: data }; }); })
+                .then(function (resp) {
+                    var ct = resp.headers.get('content-type') || '';
+                    if (ct.indexOf('json') === -1) {
+                        throw new Error('HTTP ' + resp.status + ': сервер вернул не JSON (возможно таймаут или редирект на логин)');
+                    }
+                    return resp.json().then(function (data) { return { ok: resp.ok, data: data }; });
+                })
                 .then(function (res) {
                     resetBtn();
 
                     if (res.ok && res.data.success) {
                         var d = res.data;
-                        var viewUrl = '/api/marketplace-analytics/debug/raw-document/' + encodeURIComponent(d.rawDocumentId);
+                        var docId = encodeURIComponent(d.rawDocumentId);
+                        var viewUrl = '/api/marketplace-analytics/debug/raw-document/' + docId;
+                        var downloadUrl = '/api/marketplace-analytics/debug/raw-document/' + docId + '/download';
 
                         var alert = el('div', {'class': 'alert alert-success'});
                         var header = el('div', {'class': 'd-flex align-items-center'});
@@ -461,13 +469,19 @@
                         table.appendChild(tableRowPlain('Записей', d.recordsCount));
                         table.appendChild(tableRowPlain('Размер ответа', d.responseSize));
 
-                        var link = el('a', {
+                        var viewLink = el('a', {
                             'href': viewUrl,
-                            'class': 'btn btn-sm btn-outline-azure',
+                            'class': 'btn btn-sm btn-outline-azure me-2',
                             'target': '_blank'
                         }, ['Открыть JSON']);
 
-                        var body = el('div', {'class': 'mt-2'}, [table, link]);
+                        var dlLink = el('a', {
+                            'href': downloadUrl,
+                            'class': 'btn btn-sm btn-outline-green',
+                            'target': '_blank'
+                        }, ['Скачать файл']);
+
+                        var body = el('div', {'class': 'mt-2'}, [table, viewLink, dlLink]);
                         alert.appendChild(body);
 
                         msResult.textContent = '';
@@ -480,7 +494,7 @@
                 })
                 .catch(function (err) {
                     resetBtn();
-                    showError('Ошибка сети', err.message);
+                    showError('Ошибка', err.message);
                 });
             });
         })();


### PR DESCRIPTION
## Summary

Ozon `/v1/finance/mutual-settlement` returns binary files (CSV/XLSX), not JSON. This caused `Doctrine\DBAL\Types\ConversionException` on `json_encode` of malformed UTF-8.

- **OzonMutualSettlementClient**: detect binary response by Content-Type, wrap as `{_binary: true, content_type, content_base64, size_bytes, period}` — safe for jsonb storage
- Also handles text-but-not-JSON responses with `{_text: true}` wrapper
- Logs Content-Type and first 200 bytes of every response for debugging
- `downloadReport()` also wraps binary files as base64
- **DebugLoadMutualSettlementController**: catch `\Exception` (not just `RuntimeException`), add `AppLogger` error logging
- **DebugViewRawDocumentController**: for binary docs shows metadata + base64 preview (500 chars) + `download_url`
- **New DebugDownloadRawDocumentController**: `GET .../raw-document/{id}/download` decodes base64, returns file with correct `Content-Type` and `Content-Disposition: attachment`
- **JS**: content-type check before JSON parse, added "Скачать файл" button

Supersedes #1547 (closed).

## Test plan

- [ ] POST `/api/marketplace-analytics/debug/load-mutual-settlement?year=2026&month=1` — succeeds without ConversionException
- [ ] Check logs: `Ozon MS response headers` with `content_type` and `body_preview`
- [ ] GET `.../debug/raw-document/{id}` — for binary shows metadata + download_url, no full base64
- [ ] GET `.../debug/raw-document/{id}/download` — downloads file with correct extension (xlsx/csv)
- [ ] Open downloaded file in Excel — verify data structure
- [ ] UI: "Скачать файл" button appears next to "Открыть JSON"
- [ ] Error case: red alert with readable error message (not JSON parse error)

https://claude.ai/code/session_01D74B8UCgndRKQn7GLeF4Yy