### PR TITLE
fix(marketplace): rewrite mutual settlement parser for exact column layout

### DIFF
--- a/site/src/Marketplace/Application/LoadMutualSettlementAction.php
+++ b/site/src/Marketplace/Application/LoadMutualSettlementAction.php
@@ -144,12 +144,12 @@ final class LoadMutualSettlementAction
         try {
             $parsed = $this->processor->parse($absolutePath);
             $rawData['parsed'] = $parsed;
-            $recordsCount = $parsed['meta']['data_rows_found'] ?? 0;
+            $recordsCount = $parsed['meta']['rows_parsed'] ?? $parsed['totals']['rows_count'] ?? 0;
 
             $this->appLogger->info('LoadMutualSettlement: парсинг успешен', [
                 'companyId' => $companyId,
                 'recordsCount' => $recordsCount,
-                'sections' => count($parsed['sections'] ?? []),
+                'rows_parsed' => $parsed['meta']['rows_parsed'] ?? 0,
             ]);
         } catch (\Throwable $e) {
             $processingStatus = PipelineStatus::FAILED;

--- a/site/src/Marketplace/Application/Processor/OzonMutualSettlementProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonMutualSettlementProcessor.php
@@ -6,42 +6,26 @@ namespace App\Marketplace\Application\Processor;
 
 use App\Shared\Service\AppLogger;
 use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
 /**
  * Парсит XLSX «Отчёт о взаиморасчётах» Ozon в структурированный JSON.
  *
- * Использует anchor-based подход: ищет ключевые ячейки по тексту,
- * а не по фиксированным позициям строк. Это делает парсер устойчивым
- * к изменениям формата отчёта (добавление/удаление строк).
+ * Данные лежат в конкретных колонках (B, E, G, I, L), а не подряд.
+ * Колонки C, D, F, H, J, K — пустые или визуальные разделители/merged cells.
  *
  * Структура результата:
- *   - sections[]: массив секций {name, rows: [{name, amount}]}
- *   - totals: {total_accrued, total_compensation, total_payout}
- *   - meta: {sheet_title, rows_parsed, parsing_warnings[]}
+ *   - source_endpoint: string
+ *   - document_info: {payer_name, payer_inn, payer_kpp, receiver_name, receiver_inn, receiver_kpp, contract, period_from, period_to}
+ *   - opening_balance: {date, debit, credit}
+ *   - closing_balance: {date, debit, credit}
+ *   - rows[]: массив операций {type, document_number, document_date, row_date, debit, credit}
+ *   - compensations[]: массив компенсаций {name, sum_no_vat, sum_with_vat, vat_amount}
+ *   - totals: {rows_count, total_debit, total_credit}
+ *   - meta: {sheet_title, total_rows_in_sheet, rows_parsed}
  */
 final readonly class OzonMutualSettlementProcessor
 {
-    /**
-     * Якоря секций — текст в ячейке (column A), обозначающий начало секции.
-     * Ключ = нормализованный якорь (lowercase, trimmed), значение = имя секции.
-     */
-    private const SECTION_ANCHORS = [
-        'начисления за реализованный товар' => 'charges_sold_goods',
-        'начисления за доставку и возвраты' => 'charges_delivery_returns',
-        'компенсация недополученного дохода' => 'compensation_lost_income',
-        'компенсация' => 'compensation',
-        'прочие начисления' => 'other_charges',
-        'начисления за услуги' => 'charges_services',
-    ];
-
-    /** Якоря итоговых строк */
-    private const TOTAL_ANCHORS = [
-        'итого к выплате' => 'total_payout',
-        'итого начислено' => 'total_accrued',
-        'итого начисления' => 'total_accrued',
-        'итого компенсация' => 'total_compensation',
-    ];
-
     public function __construct(
         private AppLogger $appLogger,
     ) {
@@ -52,7 +36,7 @@ final readonly class OzonMutualSettlementProcessor
      *
      * @param string $filePath Абсолютный путь к XLSX-файлу
      *
-     * @return array{sections: array, totals: array, meta: array}
+     * @return array{source_endpoint: string, document_info: array, opening_balance: array, closing_balance: array, rows: array, compensations: array, totals: array, meta: array}
      *
      * @throws \RuntimeException если файл не читается или не содержит данных
      */
@@ -68,97 +52,41 @@ final readonly class OzonMutualSettlementProcessor
         $sheet = $spreadsheet->getActiveSheet();
         $sheetTitle = $sheet->getTitle();
         $highestRow = $sheet->getHighestRow();
-        $highestColumn = $sheet->getHighestColumn();
-        $maxColIndex = \PhpOffice\PhpSpreadsheet\Cell\Coordinate::columnIndexFromString($highestColumn);
 
         $this->appLogger->info('OzonMSProcessor: начало парсинга', [
             'file' => basename($filePath),
             'sheetTitle' => $sheetTitle,
             'rows' => $highestRow,
-            'columns' => $highestColumn,
         ]);
 
-        $sections = [];
-        $totals = [];
-        $warnings = [];
-        $currentSection = null;
-        $rowsParsed = 0;
-
-        for ($row = 1; $row <= $highestRow; $row++) {
-            $cellA = $this->getCellValue($sheet, 'A', $row);
-            $cellANormalized = $this->normalize($cellA);
-
-            if ('' === $cellANormalized) {
-                continue;
-            }
-
-            $rowsParsed++;
-
-            // Проверяем, это итоговая строка?
-            $totalKey = $this->matchAnchor($cellANormalized, self::TOTAL_ANCHORS);
-            if (null !== $totalKey) {
-                $amount = $this->findAmountInRow($sheet, $row, $maxColIndex);
-                $totals[$totalKey] = $amount;
-                continue;
-            }
-
-            // Проверяем, это начало новой секции?
-            $sectionKey = $this->matchAnchor($cellANormalized, self::SECTION_ANCHORS);
-            if (null !== $sectionKey) {
-                $sections[] = [
-                    'name' => $sectionKey,
-                    'title' => trim($cellA),
-                    'rows' => [],
-                ];
-                $currentSection = &$sections[array_key_last($sections)];
-                continue;
-            }
-
-            // Если мы внутри секции — ищем строки name + amount
-            if (null !== $currentSection) {
-                $amount = $this->findAmountInRow($sheet, $row, $maxColIndex);
-
-                // Пропускаем строки без суммы (подзаголовки, пустые)
-                if (null === $amount) {
-                    continue;
-                }
-
-                $currentSection['rows'][] = [
-                    'name' => trim($cellA),
-                    'amount' => $amount,
-                ];
-            }
-        }
-
-        unset($currentSection);
-
-        // Подсчитываем записи
-        $totalRows = 0;
-        foreach ($sections as $section) {
-            $totalRows += count($section['rows']);
-        }
-
-        if (0 === $totalRows && empty($totals)) {
-            $warnings[] = 'Не найдены строки с данными — возможно, формат отчёта изменился';
-        }
+        $documentInfo = $this->parseDocumentInfo($sheet);
+        $operationsData = $this->parseOperations($sheet, $highestRow);
+        $compensations = $this->parseCompensations($sheet, $highestRow);
 
         $result = [
-            'sections' => $sections,
-            'totals' => $totals,
+            'source_endpoint' => '/v1/finance/mutual-settlement',
+            'document_info' => $documentInfo,
+            'opening_balance' => $operationsData['opening_balance'],
+            'closing_balance' => $operationsData['closing_balance'],
+            'rows' => $operationsData['rows'],
+            'compensations' => $compensations,
+            'totals' => [
+                'rows_count' => count($operationsData['rows']),
+                'total_debit' => $operationsData['total_debit'],
+                'total_credit' => $operationsData['total_credit'],
+            ],
             'meta' => [
                 'sheet_title' => $sheetTitle,
                 'total_rows_in_sheet' => $highestRow,
-                'rows_parsed' => $rowsParsed,
-                'data_rows_found' => $totalRows,
-                'parsing_warnings' => $warnings,
+                'rows_parsed' => count($operationsData['rows']),
             ],
         ];
 
         $this->appLogger->info('OzonMSProcessor: парсинг завершён', [
-            'sections' => count($sections),
-            'dataRows' => $totalRows,
-            'totals' => array_keys($totals),
-            'warnings' => count($warnings),
+            'rows_parsed' => count($operationsData['rows']),
+            'compensations' => count($compensations),
+            'opening_balance' => $operationsData['opening_balance'],
+            'closing_balance' => $operationsData['closing_balance'],
         ]);
 
         $spreadsheet->disconnectWorksheets();
@@ -167,60 +95,348 @@ final readonly class OzonMutualSettlementProcessor
     }
 
     /**
-     * Ищет числовое значение (сумму) в строке, сканируя колонки B..maxCol.
-     * Возвращает последнее найденное число (обычно итог в правой колонке).
+     * Парсит реквизиты документа из заголовочных строк (R1-R12).
+     *
+     * R2 C: "Отчет о взаиморасчетах"
+     * R3 C: "за период с  01.01.2026 по 31.01.2026"
+     * R4 C: "по Договору оферты ... № ИР-104604/21  от 31.10.2021"
+     * R6 B: "Плательщик:"    J: "Получатель:"
+     * R7 B: payer_name        J: receiver_name
+     * R8 B: "ИНН" D: inn     J: "ИНН" L: inn
+     * R9 B: "КПП" D: kpp     J: "КПП" L: kpp
      */
-    private function findAmountInRow(\PhpOffice\PhpSpreadsheet\Worksheet\Worksheet $sheet, int $row, int $maxCol): ?float
+    private function parseDocumentInfo(Worksheet $sheet): array
     {
-        $lastAmount = null;
+        $info = [
+            'payer_name' => null,
+            'payer_inn' => null,
+            'payer_kpp' => null,
+            'receiver_name' => null,
+            'receiver_inn' => null,
+            'receiver_kpp' => null,
+            'contract' => null,
+            'period_from' => null,
+            'period_to' => null,
+        ];
 
-        for ($col = 2; $col <= $maxCol; $col++) {
-            $coordinate = \PhpOffice\PhpSpreadsheet\Cell\Coordinate::stringFromColumnIndex($col) . $row;
-            $cell = $sheet->getCell($coordinate);
-            $value = $cell->getCalculatedValue();
+        // Ищем период и договор в строках 1-12, колонка C
+        for ($row = 1; $row <= 12; $row++) {
+            $cellC = $this->getCellStringValue($sheet, 'C', $row);
 
-            if (null === $value || '' === $value) {
-                continue;
+            // Период: "за период с  01.01.2026 по 31.01.2026"
+            if (preg_match('/за\s+период\s+с\s+(\d{2}\.\d{2}\.\d{4})\s+по\s+(\d{2}\.\d{2}\.\d{4})/u', $cellC, $m)) {
+                $info['period_from'] = $this->convertDateDmy($m[1]);
+                $info['period_to'] = $this->convertDateDmy($m[2]);
             }
 
-            if (is_numeric($value)) {
-                $lastAmount = (float) $value;
-            } elseif (is_string($value)) {
-                // Пробуем распарсить строку вида "1 234 567.89" или "1234567,89"
-                $cleaned = (string) preg_replace('/\s+/u', '', $value);
-                $cleaned = str_replace(',', '.', $cleaned);
-                if (is_numeric($cleaned)) {
-                    $lastAmount = (float) $cleaned;
-                }
+            // Договор: "по Договору ... № ИР-104604/21  от 31.10.2021"
+            if (preg_match('/№\s*(.+?)\s{1,}от\s+(\d{2}\.\d{2}\.\d{4})/u', $cellC, $m)) {
+                $info['contract'] = trim($m[1]) . ' от ' . $m[2];
             }
         }
 
-        return $lastAmount;
+        // Ищем реквизиты в строках 1-12
+        for ($row = 1; $row <= 12; $row++) {
+            $cellB = $this->getCellStringValue($sheet, 'B', $row);
+            $normalizedB = $this->normalize($cellB);
+
+            // Строка с "плательщик:" — следующая строка содержит имя
+            if (str_contains($normalizedB, 'плательщик')) {
+                $info['payer_name'] = $this->getCellStringValueOrNull($sheet, 'B', $row + 1);
+                $info['receiver_name'] = $this->getCellStringValueOrNull($sheet, 'J', $row + 1);
+
+                // ИНН/КПП — через 2 и 3 строки от "Плательщик:"
+                $info['payer_inn'] = $this->getCellStringValueOrNull($sheet, 'D', $row + 2);
+                $info['payer_kpp'] = $this->getCellStringValueOrNull($sheet, 'D', $row + 3);
+                $info['receiver_inn'] = $this->getCellStringValueOrNull($sheet, 'L', $row + 2);
+                $info['receiver_kpp'] = $this->getCellStringValueOrNull($sheet, 'L', $row + 3);
+
+                break;
+            }
+        }
+
+        return $info;
     }
 
     /**
-     * Сопоставляет нормализованный текст ячейки с набором якорей.
+     * Парсит таблицу операций.
      *
-     * @param array<string, string> $anchors
+     * Заголовок: строка где B == "Наименование"
+     * Данные: следующие строки до "Конечное сальдо" включительно.
+     *
+     * Колонки операций:
+     *   B — Наименование (тип операции)
+     *   E — Документ ("№3648135 от 01.01.2026")
+     *   G — Дата
+     *   I — Сумма дебиторской задолженности
+     *   L — Сумма кредиторской задолженности
      */
-    private function matchAnchor(string $normalizedText, array $anchors): ?string
+    private function parseOperations(Worksheet $sheet, int $highestRow): array
     {
-        // Точное совпадение
-        if (isset($anchors[$normalizedText])) {
-            return $anchors[$normalizedText];
+        $openingBalance = ['date' => null, 'debit' => 0.0, 'credit' => 0.0];
+        $closingBalance = ['date' => null, 'debit' => 0.0, 'credit' => 0.0];
+        $rows = [];
+        $totalDebit = 0.0;
+        $totalCredit = 0.0;
+
+        // Ищем строку-заголовок: B == "Наименование"
+        $dataStartRow = null;
+        for ($row = 1; $row <= $highestRow; $row++) {
+            $cellB = $this->getCellStringValue($sheet, 'B', $row);
+            if ('наименование' === $this->normalize($cellB)) {
+                $dataStartRow = $row + 1;
+                break;
+            }
         }
 
-        // Совпадение по началу строки (для «Компенсация недополученного дохода за ...»)
-        foreach ($anchors as $anchor => $key) {
-            if (str_starts_with($normalizedText, $anchor)) {
-                return $key;
+        if (null === $dataStartRow) {
+            $this->appLogger->warning('OzonMSProcessor: не найден заголовок таблицы операций (B == "Наименование")');
+
+            return [
+                'opening_balance' => $openingBalance,
+                'closing_balance' => $closingBalance,
+                'rows' => [],
+                'total_debit' => 0.0,
+                'total_credit' => 0.0,
+            ];
+        }
+
+        for ($row = $dataStartRow; $row <= $highestRow; $row++) {
+            $cellB = $this->getCellStringValue($sheet, 'B', $row);
+            $normalizedB = $this->normalize($cellB);
+
+            if ('' === $normalizedB) {
+                continue;
             }
+
+            $debit = $this->parseNumericCell($sheet, 'I', $row);
+            $credit = $this->parseNumericCell($sheet, 'L', $row);
+            $dateValue = $this->parseDateCell($sheet, 'G', $row);
+
+            // Начальное сальдо
+            if (str_contains($normalizedB, 'начальное сальдо')) {
+                $openingBalance = [
+                    'date' => $dateValue,
+                    'debit' => $debit,
+                    'credit' => $credit,
+                ];
+                continue;
+            }
+
+            // Конечное сальдо — последняя строка данных
+            if (str_contains($normalizedB, 'конечное сальдо')) {
+                $closingBalance = [
+                    'date' => $dateValue,
+                    'debit' => $debit,
+                    'credit' => $credit,
+                ];
+                break;
+            }
+
+            // Обычная строка операции
+            $cellE = $this->getCellStringValue($sheet, 'E', $row);
+            $docInfo = $this->parseDocumentReference($cellE);
+
+            $rows[] = [
+                'type' => trim($cellB),
+                'document_number' => $docInfo['number'],
+                'document_date' => $docInfo['date'],
+                'row_date' => $dateValue,
+                'debit' => $debit,
+                'credit' => $credit,
+            ];
+
+            $totalDebit += $debit;
+            $totalCredit += $credit;
+        }
+
+        return [
+            'opening_balance' => $openingBalance,
+            'closing_balance' => $closingBalance,
+            'rows' => $rows,
+            'total_debit' => round($totalDebit, 2),
+            'total_credit' => round($totalCredit, 2),
+        ];
+    }
+
+    /**
+     * Парсит секцию компенсаций.
+     *
+     * Начало: строка где B содержит "Компенсации и прочие начисления"
+     *         (с нормализацией латинской "c" → кириллической "с")
+     * Заголовок: строка где B == "Наименование начисления"
+     * Колонки:
+     *   B — Наименование начисления
+     *   F — Сумма без НДС
+     *   K — Сумма с НДС
+     *   N — В том числе НДС
+     * Конец: строка где B == "Итого" или пустая строка после данных.
+     */
+    private function parseCompensations(Worksheet $sheet, int $highestRow): array
+    {
+        $compensations = [];
+
+        // Ищем начало секции компенсаций
+        $sectionStartRow = null;
+        for ($row = 1; $row <= $highestRow; $row++) {
+            $cellB = $this->getCellStringValue($sheet, 'B', $row);
+            $normalizedB = $this->normalizeMixedCyrillic($this->normalize($cellB));
+
+            if (str_contains($normalizedB, 'компенсации и прочие начисления')) {
+                $sectionStartRow = $row;
+                break;
+            }
+        }
+
+        if (null === $sectionStartRow) {
+            return [];
+        }
+
+        // Ищем заголовок: B == "Наименование начисления"
+        $dataStartRow = null;
+        for ($row = $sectionStartRow; $row <= min($sectionStartRow + 5, $highestRow); $row++) {
+            $cellB = $this->getCellStringValue($sheet, 'B', $row);
+            if (str_contains($this->normalize($cellB), 'наименование начисления')) {
+                $dataStartRow = $row + 1;
+                break;
+            }
+        }
+
+        if (null === $dataStartRow) {
+            return [];
+        }
+
+        for ($row = $dataStartRow; $row <= $highestRow; $row++) {
+            $cellB = $this->getCellStringValue($sheet, 'B', $row);
+            $normalizedB = $this->normalize($cellB);
+
+            if ('' === $normalizedB) {
+                continue;
+            }
+
+            // "Итого" — конец секции
+            if ('итого' === $normalizedB) {
+                break;
+            }
+
+            $compensations[] = [
+                'name' => trim($cellB),
+                'sum_no_vat' => $this->parseNumericCell($sheet, 'F', $row),
+                'sum_with_vat' => $this->parseNumericCell($sheet, 'K', $row),
+                'vat_amount' => $this->parseNumericCell($sheet, 'N', $row),
+            ];
+        }
+
+        return $compensations;
+    }
+
+    /**
+     * Парсит ссылку на документ из колонки E.
+     * Формат: "№3648135 от 01.01.2026"
+     *
+     * @return array{number: ?string, date: ?string}
+     */
+    private function parseDocumentReference(string $text): array
+    {
+        $text = trim($text);
+        if ('' === $text) {
+            return ['number' => null, 'date' => null];
+        }
+
+        $number = null;
+        $date = null;
+
+        if (preg_match('/№\s*(\S+)/u', $text, $m)) {
+            $number = $m[1];
+        }
+
+        if (preg_match('/от\s+(\d{2}\.\d{2}\.\d{4})/u', $text, $m)) {
+            $date = $this->convertDateDmy($m[1]);
+        }
+
+        return ['number' => $number, 'date' => $date];
+    }
+
+    /**
+     * Парсит числовое значение из ячейки.
+     * Обрабатывает: int, float, строки "1 234 567.89", "1234567,89".
+     */
+    private function parseNumericCell(Worksheet $sheet, string $column, int $row): float
+    {
+        $cell = $sheet->getCell($column . $row);
+        $value = $cell->getCalculatedValue();
+
+        if (null === $value || '' === $value) {
+            return 0.0;
+        }
+
+        if (is_numeric($value)) {
+            return round((float) $value, 2);
+        }
+
+        if (is_string($value)) {
+            $cleaned = (string) preg_replace('/\s+/u', '', $value);
+            $cleaned = str_replace(',', '.', $cleaned);
+            if (is_numeric($cleaned)) {
+                return round((float) $cleaned, 2);
+            }
+        }
+
+        return 0.0;
+    }
+
+    /**
+     * Парсит дату из ячейки. Значение может быть DateTime-объектом или строкой "dd.mm.yyyy".
+     */
+    private function parseDateCell(Worksheet $sheet, string $column, int $row): ?string
+    {
+        $cell = $sheet->getCell($column . $row);
+        $value = $cell->getCalculatedValue();
+
+        if (null === $value || '' === $value) {
+            return null;
+        }
+
+        // DateTime-объект (PhpSpreadsheet может вернуть)
+        if ($value instanceof \DateTimeInterface) {
+            return $value->format('Y-m-d');
+        }
+
+        // Числовой serial date из Excel
+        if (is_numeric($value)) {
+            try {
+                $dateTime = \PhpOffice\PhpSpreadsheet\Shared\Date::excelToDateTimeObject((float) $value);
+
+                return $dateTime->format('Y-m-d');
+            } catch (\Throwable) {
+                return null;
+            }
+        }
+
+        // Строка "dd.mm.yyyy"
+        if (is_string($value) && preg_match('/^(\d{2})\.(\d{2})\.(\d{4})$/', trim($value), $m)) {
+            return sprintf('%s-%s-%s', $m[3], $m[2], $m[1]);
+        }
+
+        // Строка "yyyy-mm-dd"
+        if (is_string($value) && preg_match('/^\d{4}-\d{2}-\d{2}$/', trim($value))) {
+            return trim($value);
         }
 
         return null;
     }
 
-    private function getCellValue(\PhpOffice\PhpSpreadsheet\Worksheet\Worksheet $sheet, string $column, int $row): string
+    /**
+     * Конвертирует дату dd.mm.yyyy → yyyy-mm-dd.
+     */
+    private function convertDateDmy(string $dmy): string
+    {
+        $parts = explode('.', $dmy);
+
+        return sprintf('%s-%s-%s', $parts[2], $parts[1], $parts[0]);
+    }
+
+    private function getCellStringValue(Worksheet $sheet, string $column, int $row): string
     {
         $cell = $sheet->getCell($column . $row);
         $value = $cell->getCalculatedValue();
@@ -232,13 +448,41 @@ final readonly class OzonMutualSettlementProcessor
         return (string) $value;
     }
 
+    /**
+     * Возвращает строковое значение или null если пусто.
+     */
+    private function getCellStringValueOrNull(Worksheet $sheet, string $column, int $row): ?string
+    {
+        $value = $this->getCellStringValue($sheet, $column, $row);
+        $trimmed = trim($value);
+
+        return '' === $trimmed ? null : $trimmed;
+    }
+
     private function normalize(string $text): string
     {
         $text = trim($text);
         $text = mb_strtolower($text);
-        // Убираем множественные пробелы
         $text = (string) preg_replace('/\s+/u', ' ', $text);
 
         return $text;
+    }
+
+    /**
+     * Нормализует смешанную кириллицу/латиницу.
+     * Заменяет латинские буквы, похожие на кириллические, на кириллические.
+     * Нужно для "Компенcации" (латинская "c" вместо кириллической "с").
+     */
+    private function normalizeMixedCyrillic(string $text): string
+    {
+        $map = [
+            'a' => 'а', 'c' => 'с', 'e' => 'е', 'o' => 'о',
+            'p' => 'р', 'x' => 'х', 'y' => 'у', 'k' => 'к',
+            'A' => 'А', 'C' => 'С', 'E' => 'Е', 'O' => 'О',
+            'P' => 'Р', 'X' => 'Х', 'H' => 'Н', 'K' => 'К',
+            'B' => 'В', 'M' => 'М', 'T' => 'Т',
+        ];
+
+        return strtr($text, $map);
     }
 }

--- a/site/src/MarketplaceAnalytics/Controller/Api/DebugReparseMutualSettlementController.php
+++ b/site/src/MarketplaceAnalytics/Controller/Api/DebugReparseMutualSettlementController.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAnalytics\Controller\Api;
+
+use App\Marketplace\Application\Processor\OzonMutualSettlementProcessor;
+use App\Marketplace\Enum\PipelineStatus;
+use App\Marketplace\Enum\PipelineStep;
+use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
+use App\Shared\Service\ActiveCompanyService;
+use App\Shared\Service\Storage\StorageService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Debug-эндпоинт для переобработки (reparse) бинарного raw-документа mutual settlement.
+ *
+ * Берёт файл с диска (raw_data.file_path), повторно парсит через OzonMutualSettlementProcessor,
+ * обновляет raw_data.parsed и статус документа.
+ *
+ * Использование:
+ *   POST /api/marketplace-analytics/debug/raw-document/{id}/reparse
+ */
+#[Route(
+    path: '/api/marketplace-analytics/debug/raw-document/{id}/reparse',
+    name: 'api_marketplace_analytics_debug_raw_document_reparse',
+    methods: ['POST'],
+)]
+#[IsGranted('ROLE_COMPANY_USER')]
+final class DebugReparseMutualSettlementController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $activeCompanyService,
+        private readonly MarketplaceRawDocumentRepository $rawDocumentRepository,
+        private readonly OzonMutualSettlementProcessor $processor,
+        private readonly StorageService $storageService,
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    public function __invoke(string $id): JsonResponse
+    {
+        $company = $this->activeCompanyService->getActiveCompany();
+        $companyId = (string) $company->getId();
+
+        $document = $this->rawDocumentRepository->find($id);
+
+        if (null === $document || (string) $document->getCompany()->getId() !== $companyId) {
+            throw $this->createNotFoundException('Raw-документ не найден.');
+        }
+
+        $rawData = $document->getRawData();
+
+        if (!isset($rawData['file_path'])) {
+            return $this->json([
+                'success' => false,
+                'error' => 'Документ не содержит file_path — переобработка невозможна.',
+            ], 422);
+        }
+
+        $absolutePath = $this->storageService->getAbsolutePath($rawData['file_path']);
+
+        if (!file_exists($absolutePath)) {
+            return $this->json([
+                'success' => false,
+                'error' => 'Файл не найден на диске: ' . $rawData['file_path'],
+            ], 404);
+        }
+
+        try {
+            $parsed = $this->processor->parse($absolutePath);
+
+            $rawData['parsed'] = $parsed;
+            unset($rawData['parsing_error']);
+            $document->setRawData($rawData);
+            $document->setRecordsCount($parsed['meta']['rows_parsed'] ?? $parsed['totals']['rows_count'] ?? 0);
+            $document->resetProcessingStatus();
+            $document->markCompleted();
+            $document->setSyncNotes('Reparsed at ' . (new \DateTimeImmutable())->format('Y-m-d H:i:s'));
+
+            $this->em->flush();
+
+            return $this->json([
+                'success' => true,
+                'rawDocumentId' => $document->getId(),
+                'rows_parsed' => $parsed['meta']['rows_parsed'] ?? 0,
+                'parsed' => $parsed,
+            ]);
+        } catch (\Throwable $e) {
+            $rawData['parsing_error'] = $e->getMessage();
+            $document->setRawData($rawData);
+            $document->resetProcessingStatus();
+            $document->markStepFailed(PipelineStep::COSTS);
+            $document->setSyncNotes('Reparse failed: ' . $e->getMessage());
+
+            $this->em->flush();
+
+            return $this->json([
+                'success' => false,
+                'error' => $e->getMessage(),
+            ], 500);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Rewrite `OzonMutualSettlementProcessor`** — parser now reads exact columns (B, E, G, I, L) instead of scanning column A, fixing `rows_parsed: 0` on real Ozon XLSX files where data columns are non-sequential
- **New structured output format** — `document_info` (payer/receiver INN/KPP, contract, period), `opening_balance`, `closing_balance`, `rows[]` with document references, `compensations[]` with VAT breakdown
- **Add reparse endpoint** `POST /api/marketplace-analytics/debug/raw-document/{id}/reparse` — re-parses existing documents from disk without re-downloading from Ozon API

## Details

Парсер возвращал `rows_parsed: 0` потому что искал данные в колонке A, а в реальном XLSX от Ozon данные лежат в колонках B, E, G, I, L (остальные — пустые merged cells).

Ключевые изменения:
- Операции: B (наименование), E (документ `№3648135 от 01.01.2026`), G (дата), I (дебет), L (кредит)
- Реквизиты: B/D (плательщик ИНН/КПП), J/L (получатель ИНН/КПП), C (период, договор)
- Компенсации: B (название), F (без НДС), K (с НДС), N (НДС)
- Нормализация смешанной кириллицы/латиницы для опечатки Ozon "Компенcации" (латинская `c`)
- Обработка Excel serial dates и datetime-объектов в ячейках дат

## Test plan

- [ ] Переобработать документ `845ac024-4a47-4745-98a2-a2a49d317e4e` через `POST /debug/raw-document/{id}/reparse`
- [ ] Проверить `rows_parsed > 0` в ответе debug-endpoint
- [ ] Проверить `opening_balance.credit == 1675894.78`, `closing_balance.credit == 1496173.11`
- [ ] Проверить `document_info.payer_inn == "616205833529"`
- [ ] Проверить `period_from == "2026-01-01"`, `period_to == "2026-01-31"`
- [ ] Найти строку "Требование о переводе третьему лицу" с `debit: 133750.00`
- [ ] Загрузить новый отчёт через `POST /debug/load-mutual-settlement?year=2026&month=1` — убедиться что парсинг работает

https://claude.ai/code/session_01DbWXqVzeEDYjBWRezW6sm7