### PR TITLE
refactor(marketplace): единый справочник OzonCostCategory

### DIFF
--- a/site/src/Marketplace/Application/Processor/OzonServiceCategoryMap.php
+++ b/site/src/Marketplace/Application/Processor/OzonServiceCategoryMap.php
@@ -4,21 +4,18 @@ declare(strict_types=1);
 
 namespace App\Marketplace\Application\Processor;
 
+use App\Marketplace\Domain\OzonCostCategory;
 use Psr\Log\LoggerInterface;
 
 /**
- * Единственный источник истины для маппинга service name → category code (Ozon).
+ * Тонкий адаптер над OzonCostCategory для обратной совместимости.
  *
- * ПРАВИЛО: все маппинги только здесь. Другие классы используют только через resolve().
- * Никаких локальных копий SERVICE_CATEGORY_MAP в процессорах — это приводит к багам.
+ * Единственный источник истины — OzonCostCategory::all().
+ * Этот класс сохраняет прежние сигнатуры методов, чтобы не менять вызывающий код.
  *
- * Используется в: OzonCostsRawProcessor, OzonSalesRawProcessor.
- * Изменять маппинг только здесь — процессоры подхватят автоматически.
- *
- * Группировка для ОПиУ происходит ТОЛЬКО на уровне маппинга PLCategory.
- * Null = нулевой маркер (price всегда 0), пропустить без создания записи.
- *
- * После изменения маппинга — переобработать затраты за все затронутые периоды.
+ * Используется в: OzonCostsRawProcessor, RestoreMarketplaceCostCategoriesAction,
+ *                 CostsDebugController, ReconciliationCreateOvhCategoryController,
+ *                 DebugUnknownOperationsController.
  */
 final class OzonServiceCategoryMap
 {
@@ -26,150 +23,34 @@ final class OzonServiceCategoryMap
      * Версия словаря — обновлять при любом изменении маппинга.
      * Используется в /marketplace/costs/debug/map-version для проверки деплоя.
      */
-    public const VERSION = '2026-04-16.2';
+    public const VERSION = '2026-04-16.3';
 
     /**
-     * @var array<string, string|null>
+     * Service names из API Ozon, которые являются нулевыми маркерами (price = 0).
+     * Не соответствуют никакой категории — должны быть пропущены.
      */
-    private const MAP = [
-        // === ЛОГИСТИКА ПРЯМАЯ ===
-        'MarketplaceServiceItemDirectFlowLogistic'               => 'ozon_logistic_direct',
-        'MarketplaceServiceItemDirectFlowLogisticVDC'            => 'ozon_logistic_direct_vdc',
-        'MarketplaceServiceItemDirectFlowTrans'                  => 'ozon_logistic_direct_trans',
-        'MarketplaceDeliveryCostItem'                            => 'ozon_logistic_delivery',
-        'MarketplaceServiceItemDelivToCustomer'                  => 'ozon_logistic_last_mile',
-        'MarketplaceServiceItemRedistributionLastMileCourier'    => 'ozon_logistic_last_mile',
-        'MarketplaceServiceItemDeliveryKGT'                      => 'ozon_logistic_kgt',
-
-        // === ЛОГИСТИКА ОБРАТНАЯ ===
-        'MarketplaceServiceItemReturnFlowLogistic'               => 'ozon_logistic_return',
-        'MarketplaceServiceItemReturnFlowTrans'                  => 'ozon_logistic_return_trans',
-
-        // === ЛОГИСТИКА ПОСТАВКИ НА СКЛАД ===
-        'ItemAdvertisementForSupplierLogistic'                   => 'ozon_logistic_inbound',
-        'ItemAdvertisementForSupplierLogisticSeller'             => 'ozon_logistic_inbound_seller',
-        'MarketplaceServiceItemPickup'                           => 'ozon_logistic_pickup',
-
-        // === ОБРАБОТКА ОТПРАВЛЕНИЙ ===
-        'MarketplaceServiceItemFulfillment'                      => 'ozon_fulfillment',
-        'MarketplaceServiceItemDropoffFF'                        => 'ozon_dropoff_ff',
-        'MarketplaceServiceItemDropoffPVZ'                       => 'ozon_dropoff_pvz',
-        'MarketplaceServiceItemRedistributionDropOffApvz'        => 'ozon_dropoff_apvz',
-        'MarketplaceServiceItemDropoffSC'                        => 'ozon_dropoff_sc',
-        'MarketplaceServiceItemDropoffPPZ'                       => 'ozon_dropoff_ppz',
-
-        // === ОБРАБОТКА ВОЗВРАТОВ ===
-        'MarketplaceServiceItemRedistributionReturnsPVZ'         => 'ozon_return_pvz',
-        'MarketplaceServiceItemReturnPartGoodsCustomer'          => 'ozon_return_partial',
-        'MarketplaceNotDeliveredCostItem'                        => 'ozon_return_not_delivered',
-        'MarketplaceReturnAfterDeliveryCostItem'                 => 'ozon_return_after_delivery',
-        'MarketplaceReturnStorageServiceAtThePickupPointFbsItem' => 'ozon_return_storage_pvz',
-        'MarketplaceReturnStorageServiceInTheWarehouseFbsItem'   => 'ozon_return_storage_wh',
-
-        // === НУЛЕВЫЕ МАРКЕРЫ (пропускать, price = 0) ===
-        'MarketplaceServiceItemReturnNotDelivToCustomer'         => null,
-        'MarketplaceServiceItemReturnAfterDelivToCustomer'       => null,
-
-        // === УПАКОВКА ===
-        'MarketplaceServiceItemPackageMaterialsProvision'        => 'ozon_package_materials',
-        'MarketplaceServiceItemPackageRedistribution'            => 'ozon_package_labor',
-
-        // === ХРАНЕНИЕ ===
-        'OperationMarketplaceServiceStorage'                     => 'ozon_storage',
-        'MarketplaceServiceItemTemporaryStorageRedistribution'   => 'ozon_storage_partner',
-        'OperationMarketplaceItemTemporaryStorageRedistribution' => 'ozon_storage_partner',
-
-        // === КРОСС-ДОКИНГ / ПОСТАВКА НА FBO ===
-        'MarketplaceServiceItemCrossdocking'                     => 'ozon_crossdocking',
-        'OperationMarketplaceSupplyAdditional'                   => 'ozon_supply_additional',
-        'OperationMarketplaceServiceSupplyInboundCargoShortage'  => 'ozon_supply_shortage',
-        'OperationMarketplaceServiceSupplyInboundCargoSurplus'   => 'ozon_supply_surplus',
-
-        // === ЭКВАЙРИНГ ===
-        'MarketplaceRedistributionOfAcquiringOperation'          => 'ozon_acquiring',
-
-        // === РЕКЛАМА ===
-        'OperationMarketplaceCostPerClick'                       => 'ozon_cpc',
-        'MarketplaceMarketingActionCostItem'                     => 'ozon_marketing_action',
-        'MarketplaceSaleReviewsItem'                             => 'ozon_reviews',
-
-        // === ПРОДВИЖЕНИЕ / PREMIUM ===
-        'MarketplaceServicePremiumPromotion'                     => 'ozon_premium_promotion',
-        'MarketplaceServicePremiumCashbackIndividualPoints'      => 'ozon_premium_cashback',
-        'MarketplaceServiceItemElectronicServicesPremiumCashbackIndividualPoints' => 'ozon_premium_cashback',
-        'OperationMarketplaceServicePremiumCashbackIndividualPoints' => 'ozon_premium_cashback',
-        'ItemAgentServiceStarsMembership'                        => 'ozon_stars_membership',
-
-        // === ФИНАНСОВЫЕ УСЛУГИ ===
-        'OperationMarketplaceServiceEarlyPaymentAccrual'         => 'ozon_early_payment',
-        'MarketplaceServiceItemFlexiblePaymentSchedule'          => 'ozon_flexible_payment',
-        'MarketplaceServiceItemInstallment'                      => 'ozon_installment',
-
-        // === ШТРАФЫ / УДЕРЖАНИЯ ===
-        'OperationMarketplaceWithHoldingForUndeliverableGoods'   => 'ozon_penalty_undeliverable',
-
-        // === КОМИССИИ ===
-        'MarketplaceServiceBrandCommission'                      => 'ozon_brand_commission',
-
-        // === ПРОЧЕЕ ===
-        'MarketplaceServiceItemMarkingItems'                     => 'ozon_marking',
-        'MarketplaceServiceItemReturnFromStock'                  => 'ozon_return_from_stock',
-        'MarketplaceServiceSellerReturnsCargoAssortment'         => 'ozon_return_from_stock',
-        'OperationMarketplaceAgencyFeeAggregator3PLGlobal'       => 'ozon_agency_fee',
-        'MarketplaceServiceItemDisposalDetailed'                 => 'ozon_disposal',
-        'MarketplaceServiceProductMovementFromWarehouse'         => 'ozon_logistic_pickup',
-        'MarketplaceServiceVolumeWeightCharacsProcessing'        => 'ozon_ovh_processing',
-        'OperationMarketplaceServiceVolumeWeightCharacsProcessing' => 'ozon_ovh_processing',
-
-        // === АНГЛИЙСКИЕ operation_type ДЛЯ ОПЕРАЦИЙ БЕЗ services[] ===
-        // Эти operation_type приходят в поле op['operation_type'] когда services[] пустой
-        // При добавлении новых кодов — проверить маппинг через debug-эндпоинт
-        // GET /api/marketplace-analytics/debug/unknown-operations
-        'AccrualInternalClaim'                                   => 'ozon_compensation',
-        'DisposalReasonDamagedPackaging'                         => 'ozon_disposal',
-        'DisposalReasonScattered'                                => 'ozon_disposal',
-        'DisposalReasonFailedToPickupOnTime'                     => 'ozon_disposal',
-        'OperationReturnGoodsFBSofRMS'                           => 'ozon_return_delivery',
-        'OperationSellerReturnsCargoAssortmentInvalid'            => 'ozon_return_delivery',
-        'OperationSellerReturnsCargoAssortmentValid'              => 'ozon_return_delivery',
-        'SellerReturnsDeliveryToPickupPoint'                     => 'ozon_return_pvz',
-        'OperationMarketplaceServicePremiumCashbackBonusAccrual' => 'ozon_seller_bonus',
-        'OperationPointsForReviews'                              => 'ozon_reviews',
-        'OperationMarketplaceSupplyExpirationDateProcessing'     => 'ozon_supply_additional',
-        'OperationPromotionWithCostPerOrder'                     => 'ozon_marketing_action',
-        'OperationSubscriptionPremiumPlus'                       => 'ozon_premium_promotion',
-        'DefectRateDetailed'                                     => 'ozon_penalty_undeliverable',
-        'MarketplaceServiceItemReplenishment'                     => 'ozon_warehouse_movement',
-        'OperationMarketplaceWarehouseToWarehouseMovement'       => 'ozon_warehouse_movement',
-        'OperationMarketplaceModerationFine'                     => 'ozon_penalty_undeliverable',
-        'OperationModerationProhibitedContent'                   => 'ozon_penalty_undeliverable',
-        'OperationMarketplaceSupplyDefectProcessing'             => 'ozon_supply_additional',
-        'OperationMarketplaceServiceProcessingSpoilageSurplus'   => 'ozon_supply_additional',
-
-        // === РУССКОЯЗЫЧНЫЕ НАЗВАНИЯ (из op['operation_type_name'] для операций без services[]) ===
-        'Подписка Premium Plus'                                  => 'ozon_premium_promotion',
-        'Бонусы продавца - рассылка'                             => 'ozon_seller_bonus',
-        'Баллы за отзывы'                                        => 'ozon_reviews',
-        'Перемещение товаров между складами Ozon'                => 'ozon_warehouse_movement',
-        'Обработка сроков годности на FBO'                       => 'ozon_supply_additional',
-        'Модерация запрещённого контента'                        => 'ozon_penalty_undeliverable',
-        'Обработка операционных ошибок продавца: отгрузка в нерекомендованный слот' => 'ozon_penalty_undeliverable',
-        'Обработка брака с приемки'                              => 'ozon_supply_additional',
-        'Временное размещение товара партнерами'                  => 'ozon_storage_partner',
-        'Корректировка суммы акта о премии'                      => 'ozon_premium_correction',
-        'Корректировки стоимости услуг'                          => 'ozon_service_correction',
+    private const ZERO_MARKERS = [
+        'MarketplaceServiceItemReturnNotDelivToCustomer',
+        'MarketplaceServiceItemReturnAfterDelivToCustomer',
     ];
 
     /**
-     * Резолвит category code по точному имени service name.
+     * Резолвит category code по точному имени service name / operation type.
      * При неизвестном имени — логирует warning и возвращает fallback через fuzzy.
      *
      * @return string|null null = нулевой маркер, пропустить запись
      */
     public static function resolve(string $serviceName, LoggerInterface $logger): ?string
     {
-        if (array_key_exists($serviceName, self::MAP)) {
-            return self::MAP[$serviceName];
+        if (self::isZeroMarker($serviceName)) {
+            return null;
+        }
+
+        $category = OzonCostCategory::findByServiceName($serviceName)
+            ?? OzonCostCategory::findByOperationType($serviceName);
+
+        if ($category !== null) {
+            return $category->code;
         }
 
         $fallback = self::fuzzy($serviceName);
@@ -177,134 +58,75 @@ final class OzonServiceCategoryMap
         $logger->warning('ozon_unknown_service_name', [
             'service_name' => $serviceName,
             'resolved_to'  => $fallback,
-            'hint'         => 'Add to OzonServiceCategoryMap mapping',
+            'hint'         => 'Add to OzonCostCategory::all()',
         ]);
 
         return $fallback;
     }
 
     /**
-     * Проверяет является ли service name нулевым маркером (price = 0, пропустить).
+     * Статистика справочника для debug-эндпоинта.
      */
     public static function getMapStats(): array
     {
-        $map    = self::MAP;
-        $total  = count($map);
-        $nulls  = count(array_filter($map, static fn ($v) => $v === null));
-        $unique = count(array_unique(array_filter($map)));
+        $allCategories = OzonCostCategory::all();
+        $totalEntries  = count(self::ZERO_MARKERS);
+
+        foreach ($allCategories as $c) {
+            $totalEntries += count($c->serviceNames) + count($c->operationTypes);
+        }
 
         return [
-            'version'         => self::VERSION,
-            'total_entries'   => $total,
-            'zero_markers'    => $nulls,
-            'unique_categories' => $unique,
+            'version'           => self::VERSION,
+            'total_entries'     => $totalEntries,
+            'zero_markers'      => count(self::ZERO_MARKERS),
+            'unique_categories' => count($allCategories),
         ];
     }
 
+    /**
+     * Проверяет является ли service name нулевым маркером (price = 0, пропустить).
+     */
     public static function isZeroMarker(string $serviceName): bool
     {
-        return array_key_exists($serviceName, self::MAP) && self::MAP[$serviceName] === null;
-    }
-
-    public static function isKnown(string $serviceName): bool
-    {
-        return array_key_exists($serviceName, self::MAP)
-            && self::MAP[$serviceName] !== null;
+        return in_array($serviceName, self::ZERO_MARKERS, true);
     }
 
     /**
-     * Все уникальные category codes — из MAP + коды, генерируемые в extractCostEntries().
+     * Проверяет известен ли service name / operation type (не нулевой маркер).
+     */
+    public static function isKnown(string $serviceName): bool
+    {
+        return OzonCostCategory::findByServiceName($serviceName) !== null
+            || OzonCostCategory::findByOperationType($serviceName) !== null;
+    }
+
+    /**
+     * Все уникальные category codes с человекочитаемыми именами.
      *
      * @return array<string, string> code => human-readable name
      */
     public static function getAllCategoryCodes(): array
     {
         $codes = [];
-
-        foreach (self::MAP as $code) {
-            if ($code !== null && !isset($codes[$code])) {
-                $codes[$code] = self::getCategoryName($code);
-            }
-        }
-
-        // Коды, генерируемые в OzonCostsRawProcessor::extractCostEntries() напрямую
-        // + ozon_other_service — fallback для неизвестных service names
-        // + ozon_compensation — принудительно для opType=compensation
-        // + ozon_decompensation — sibling для будущего разделения по знаку amount
-        //   (OzonCostsRawProcessor пока не эмитирует, заведён как известная категория заранее)
-        foreach (['ozon_sale_commission', 'ozon_delivery', 'ozon_return_delivery', 'ozon_other_service', 'ozon_compensation', 'ozon_decompensation'] as $extra) {
-            if (!isset($codes[$extra])) {
-                $codes[$extra] = self::getCategoryName($extra);
-            }
+        foreach (OzonCostCategory::all() as $c) {
+            $codes[$c->code] = $c->name;
         }
 
         return $codes;
     }
 
+    /**
+     * Человекочитаемое имя category code.
+     */
     public static function getCategoryName(string $categoryCode): string
     {
-        return match ($categoryCode) {
-            'ozon_sale_commission'       => 'Комиссия Ozon за продажу',
-            'ozon_delivery'              => 'Доставка Ozon',
-            'ozon_return_delivery'       => 'Обратная доставка Ozon',
-            'ozon_logistic_direct'       => 'Логистика к покупателю Ozon',
-            'ozon_logistic_direct_vdc'   => 'Логистика к покупателю (вРЦ) Ozon',
-            'ozon_logistic_direct_trans' => 'Магистраль к покупателю Ozon',
-            'ozon_logistic_delivery'     => 'Доставка до покупателя Ozon',
-            'ozon_logistic_last_mile'    => 'Last mile Ozon',
-            'ozon_logistic_kgt'          => 'Доставка КГТ Ozon',
-            'ozon_logistic_return'       => 'Обратная логистика Ozon',
-            'ozon_logistic_return_trans' => 'Обратная магистраль Ozon',
-            'ozon_logistic_inbound'      => 'Кросс-докинг (поставка) Ozon',
-            'ozon_logistic_inbound_seller' => 'ТЭУ (поставка продавцом) Ozon',
-            'ozon_logistic_pickup'       => 'Выезд за товаром (Pick-up) Ozon',
-            'ozon_fulfillment'           => 'Сборка заказа Ozon',
-            'ozon_dropoff_ff'            => 'Обработка отправления FF Ozon',
-            'ozon_dropoff_pvz'           => 'Обработка отправления ПВЗ Ozon',
-            'ozon_dropoff_apvz'          => 'Дропофф АПВЗ Ozon',
-            'ozon_dropoff_sc'            => 'Обработка отправления СЦ Ozon',
-            'ozon_dropoff_ppz'           => 'Обработка отправления ППЗ Ozon',
-            'ozon_return_pvz'            => 'Перевыставление возврата ПВЗ Ozon',
-            'ozon_return_partial'        => 'Обработка частичного возврата Ozon',
-            'ozon_return_not_delivered'  => 'Возврат невостребованного товара Ozon',
-            'ozon_return_after_delivery' => 'Возврат после доставки Ozon',
-            'ozon_return_storage_pvz'    => 'Краткосрочное хранение возврата ПВЗ Ozon',
-            'ozon_return_storage_wh'     => 'Долгосрочное хранение возврата склад Ozon',
-            'ozon_package_materials'     => 'Упаковочные материалы Ozon',
-            'ozon_package_labor'         => 'Упаковка партнёрами Ozon',
-            'ozon_storage'               => 'Хранение на складе Ozon',
-            'ozon_storage_partner'       => 'Временное хранение у партнёров Ozon',
-            'ozon_seller_bonus'          => 'Бонусы продавца (рассылки) Ozon',
-            'ozon_warehouse_movement'    => 'Перемещение между складами Ozon',
-            'ozon_crossdocking'          => 'Кросс-докинг Ozon',
-            'ozon_supply_additional'     => 'Обработка товара в грузоместе FBO Ozon',
-            'ozon_supply_shortage'       => 'Бронирование места (неполный состав) Ozon',
-            'ozon_supply_surplus'        => 'Обработка излишков поставки Ozon',
-            'ozon_acquiring'             => 'Эквайринг Ozon',
-            'ozon_cpc'                   => 'Оплата за клик Ozon',
-            'ozon_marketing_action'      => 'Маркетинговые акции Ozon',
-            'ozon_reviews'               => 'Приобретение отзывов Ozon',
-            'ozon_premium_promotion'     => 'Продвижение Premium Ozon',
-            'ozon_premium_cashback'      => 'Бонусы продавца Premium Ozon',
-            'ozon_stars_membership'      => 'Звёздные товары Ozon',
-            'ozon_early_payment'         => 'Досрочная выплата Ozon',
-            'ozon_flexible_payment'      => 'Гибкий график выплат Ozon',
-            'ozon_installment'           => 'Продажа в рассрочку Ozon',
-            'ozon_penalty_undeliverable' => 'Удержание за недовложение Ozon',
-            'ozon_marking'               => 'Обязательная маркировка Ozon',
-            'ozon_return_from_stock'     => 'Комплектация для вывоза продавцом Ozon',
-            'ozon_agency_fee'            => 'Агентская услуга 3PL Global Ozon',
-            'ozon_disposal'              => 'Утилизация товара Ozon',
-            'ozon_brand_commission'      => 'Брендовая комиссия Ozon',
-            'ozon_premium_correction'    => 'Корректировка премии Ozon',
-            'ozon_service_correction'    => 'Корректировка стоимости услуг Ozon',
-            'ozon_ovh_processing'        => 'Дополнительная обработка ОВХ Ozon',
-            'ozon_compensation'          => 'Компенсации и декомпенсации Ozon',
-            'ozon_decompensation'        => 'Декомпенсация Ozon',
-            default                      => 'Прочие услуги Ozon',
-        };
+        return OzonCostCategory::findByCode($categoryCode)?->name ?? 'Прочие услуги Ozon';
     }
 
+    /**
+     * Fuzzy fallback для неизвестных service names.
+     */
     private static function fuzzy(string $serviceName): string
     {
         $lower = mb_strtolower($serviceName);

--- a/site/src/Marketplace/Application/Reconciliation/OzonXlsxServiceGroupMap.php
+++ b/site/src/Marketplace/Application/Reconciliation/OzonXlsxServiceGroupMap.php
@@ -4,117 +4,33 @@ declare(strict_types=1);
 
 namespace App\Marketplace\Application\Reconciliation;
 
+use App\Marketplace\Domain\OzonCostCategory;
+
 /**
+ * Тонкий адаптер над OzonCostCategory для обратной совместимости.
+ *
  * Маппинг наших категорий затрат к группам xlsx «Детализации начислений» Ozon.
- *
  * Используется ТОЛЬКО для сверки xlsx vs API данные.
- * НЕ влияет на маппинг к ОПиУ категориям (это OzonServiceCategoryMap).
  *
- * Группы верифицированы по реальным xlsx-файлам января и февраля 2026.
- *
- * @see OzonServiceCategoryMap — маппинг для ОПиУ (независимый)
+ * @see OzonCostCategory — единственный источник правды
  */
 final class OzonXlsxServiceGroupMap
 {
     /**
-     * @return array<string, string> category_code → serviceGroup (название группы в xlsx)
+     * @return array<string, string> category_code => serviceGroup (название группы в xlsx)
      */
     public static function getCategoryToServiceGroup(): array
     {
-        return [
-            // === Вознаграждение Ozon ===
-            // Типы: Вознаграждение за продажу, Возврат вознаграждения
-            'ozon_sale_commission'       => 'Вознаграждение Ozon',
-            'ozon_brand_commission'      => 'Вознаграждение Ozon',
+        /** @var array<string, string>|null $cache */
+        static $cache = null;
 
-            // === Продвижение и реклама ===
-            // Типы: Оплата за клик, Подписка Premium Plus, Бонусы продавца,
-            //       Бонусы продавца - рассылка, Баллы за отзывы, Продвижение с оплатой за заказ,
-            //       Звёздные товары
-            'ozon_cpc'                   => 'Продвижение и реклама',
-            'ozon_premium_promotion'     => 'Продвижение и реклама',
-            'ozon_premium_cashback'      => 'Продвижение и реклама',
-            'ozon_reviews'               => 'Продвижение и реклама',
-            'ozon_seller_bonus'          => 'Продвижение и реклама',
-            'ozon_marketing_action'      => 'Продвижение и реклама',
-            'ozon_stars_membership'      => 'Продвижение и реклама',
+        if ($cache === null) {
+            $cache = [];
+            foreach (OzonCostCategory::all() as $c) {
+                $cache[$c->code] = $c->xlsxGroup;
+            }
+        }
 
-            // === Услуги доставки ===
-            // Типы: Логистика, Логистика - отмена начисления,
-            //       Обратная логистика, Обработка возвратов Ozon,
-            //       Обработка отменённых и невостребованных товаров,
-            //       Обработка отправления Drop-off (ПВЗ), Обработка отправления Drop-off (СЦ),
-            //       Логистика вРЦ, Магистраль, Доставка КГТ, Возвраты после доставки
-            'ozon_logistic_direct'       => 'Услуги доставки',
-            'ozon_logistic_direct_vdc'   => 'Услуги доставки',
-            'ozon_logistic_direct_trans' => 'Услуги доставки',
-            'ozon_logistic_delivery'     => 'Услуги доставки',
-            'ozon_logistic_kgt'          => 'Услуги доставки',
-            'ozon_logistic_return'       => 'Услуги доставки',
-            'ozon_logistic_return_trans' => 'Услуги доставки',
-            'ozon_logistic_inbound'      => 'Услуги доставки',
-            'ozon_logistic_inbound_seller' => 'Услуги доставки',
-            'ozon_dropoff_pvz'           => 'Услуги доставки',
-            'ozon_dropoff_ff'            => 'Услуги доставки',
-            'ozon_dropoff_sc'            => 'Услуги доставки',
-            'ozon_dropoff_ppz'           => 'Услуги доставки',
-            'ozon_delivery'              => 'Услуги доставки',
-            'ozon_return_delivery'       => 'Услуги доставки',
-            'ozon_return_partial'        => 'Услуги доставки',
-            'ozon_return_not_delivered'  => 'Услуги доставки',
-            'ozon_return_after_delivery' => 'Услуги доставки',
-            'ozon_return_storage_pvz'    => 'Услуги доставки',
-            'ozon_return_storage_wh'     => 'Услуги доставки',
-
-            // === Услуги FBO ===
-            // Типы: Кросс-докинг, Бронирование места, Вывоз товара со склада: Доставка до ПВЗ,
-            //       Обработка брака, Обработка срока годности, Поштучная приёмка,
-            //       Подготовка к вывозу: Брак/Валид, Размещение товаров на складах,
-            //       Перемещение товаров между складами, Сборка заказа,
-            //       Упаковочные материалы, Упаковка партнёрами, Обработка излишков
-            'ozon_crossdocking'          => 'Услуги FBO',
-            'ozon_supply_shortage'       => 'Услуги FBO',
-            'ozon_return_from_stock'     => 'Услуги FBO',
-            'ozon_supply_additional'     => 'Услуги FBO',
-            'ozon_supply_surplus'        => 'Услуги FBO',
-            'ozon_storage'               => 'Услуги FBO',
-            'ozon_logistic_pickup'       => 'Услуги FBO',   // Вывоз товара со склада силами Ozon: Доставка до ПВЗ
-            'ozon_package_materials'     => 'Услуги FBO',
-            'ozon_package_labor'         => 'Услуги FBO',
-            'ozon_warehouse_movement'    => 'Услуги FBO',
-
-            // === Услуги партнёров ===
-            // Типы: Доставка до места выдачи, Доставка до места выдачи - отмена начисления,
-            //       Обработка возвратов/отмен/невыкупов партнёрами,
-            //       Обработка отправления Drop-off партнёрами (АПВЗ),
-            //       Временное размещение товара партнёрами, Эквайринг
-            'ozon_logistic_last_mile'    => 'Услуги партнёров',
-            'ozon_return_pvz'            => 'Услуги партнёров',
-            'ozon_storage_partner'       => 'Услуги партнёров',
-            'ozon_acquiring'             => 'Услуги партнёров',
-            'ozon_fulfillment'           => 'Услуги партнёров',
-            'ozon_dropoff_apvz'          => 'Услуги партнёров',  // Обработка отправления Drop-off партнёрами (АПВЗ)
-
-            // === Другие услуги и штрафы ===
-            // Типы: Утилизация товара (все виды), Модерация запрещённого контента,
-            //       Дополнительная обработка ОВХ, Обработка операционных ошибок продавца,
-            //       Маркировка, Агентская услуга, Финансовые услуги, Корректировки
-            'ozon_disposal'              => 'Другие услуги и штрафы',
-            'ozon_ovh_processing'        => 'Другие услуги и штрафы',
-            'ozon_penalty_undeliverable' => 'Другие услуги и штрафы',
-            'ozon_marking'               => 'Другие услуги и штрафы',
-            'ozon_agency_fee'            => 'Другие услуги и штрафы',
-            'ozon_early_payment'         => 'Другие услуги и штрафы',
-            'ozon_flexible_payment'      => 'Другие услуги и штрафы',
-            'ozon_installment'           => 'Другие услуги и штрафы',
-            'ozon_premium_correction'    => 'Другие услуги и штрафы',
-            'ozon_service_correction'    => 'Другие услуги и штрафы',
-            'ozon_other_service'         => 'Другие услуги и штрафы',
-
-            // === Компенсации и декомпенсации ===
-            // Типы: Компенсация, Декомпенсация
-            'ozon_compensation'          => 'Компенсации и декомпенсации',
-            'ozon_decompensation'        => 'Компенсации и декомпенсации',
-        ];
+        return $cache;
     }
 }

--- a/site/src/Marketplace/Domain/OzonCostCategory.php
+++ b/site/src/Marketplace/Domain/OzonCostCategory.php
@@ -1,0 +1,629 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Domain;
+
+/**
+ * Единый справочник категорий затрат Ozon — единственный источник правды.
+ *
+ * Каждый category_code описан полностью: имя, группа виджета, группа xlsx,
+ * список service_name (из services[].name API Ozon) и operation_type
+ * (из operation_type / operation_type_name для операций без services[]).
+ *
+ * Все остальные мапы (OzonServiceCategoryMap, WidgetServiceGroupMap,
+ * OzonXlsxServiceGroupMap) читают данные отсюда.
+ *
+ * При добавлении нового кода Ozon — добавить ТОЛЬКО сюда.
+ */
+final readonly class OzonCostCategory
+{
+    /**
+     * @param string[] $serviceNames   Имена сервисов из services[].name в API Ozon
+     * @param string[] $operationTypes Коды operation_type / operation_type_name для операций без services[]
+     */
+    public function __construct(
+        public string $code,
+        public string $name,
+        public string $widgetGroup,
+        public string $xlsxGroup,
+        public array $serviceNames = [],
+        public array $operationTypes = [],
+    ) {}
+
+    // -------------------------------------------------------------------------
+    // Registry
+    // -------------------------------------------------------------------------
+
+    /**
+     * @return OzonCostCategory[]
+     */
+    public static function all(): array
+    {
+        /** @var OzonCostCategory[]|null $cache */
+        static $cache = null;
+
+        if ($cache !== null) {
+            return $cache;
+        }
+
+        $cache = [
+            // =================================================================
+            // Вознаграждение
+            // =================================================================
+            new self(
+                code: 'ozon_sale_commission',
+                name: 'Комиссия Ozon за продажу',
+                widgetGroup: 'Вознаграждение',
+                xlsxGroup: 'Вознаграждение Ozon',
+            ),
+            new self(
+                code: 'ozon_brand_commission',
+                name: 'Брендовая комиссия Ozon',
+                widgetGroup: 'Вознаграждение',
+                xlsxGroup: 'Вознаграждение Ozon',
+                serviceNames: ['MarketplaceServiceBrandCommission'],
+            ),
+
+            // =================================================================
+            // Услуги доставки и FBO → Услуги доставки (xlsx)
+            // =================================================================
+            new self(
+                code: 'ozon_logistic_direct',
+                name: 'Логистика к покупателю Ozon',
+                widgetGroup: 'Услуги доставки и FBO',
+                xlsxGroup: 'Услуги доставки',
+                serviceNames: ['MarketplaceServiceItemDirectFlowLogistic'],
+            ),
+            new self(
+                code: 'ozon_logistic_direct_vdc',
+                name: 'Логистика к покупателю (вРЦ) Ozon',
+                widgetGroup: 'Услуги доставки и FBO',
+                xlsxGroup: 'Услуги доставки',
+                serviceNames: ['MarketplaceServiceItemDirectFlowLogisticVDC'],
+            ),
+            new self(
+                code: 'ozon_logistic_direct_trans',
+                name: 'Магистраль к покупателю Ozon',
+                widgetGroup: 'Услуги доставки и FBO',
+                xlsxGroup: 'Услуги доставки',
+                serviceNames: ['MarketplaceServiceItemDirectFlowTrans'],
+            ),
+            new self(
+                code: 'ozon_logistic_delivery',
+                name: 'Доставка до покупателя Ozon',
+                widgetGroup: 'Услуги доставки и FBO',
+                xlsxGroup: 'Услуги доставки',
+                serviceNames: ['MarketplaceDeliveryCostItem'],
+            ),
+            new self(
+                code: 'ozon_logistic_kgt',
+                name: 'Доставка КГТ Ozon',
+                widgetGroup: 'Услуги доставки и FBO',
+                xlsxGroup: 'Услуги доставки',
+                serviceNames: ['MarketplaceServiceItemDeliveryKGT'],
+            ),
+            new self(
+                code: 'ozon_logistic_return',
+                name: 'Обратная логистика Ozon',
+                widgetGroup: 'Услуги доставки и FBO',
+                xlsxGroup: 'Услуги доставки',
+                serviceNames: ['MarketplaceServiceItemReturnFlowLogistic'],
+            ),
+            new self(
+                code: 'ozon_logistic_return_trans',
+                name: 'Обратная магистраль Ozon',
+                widgetGroup: 'Услуги доставки и FBO',
+                xlsxGroup: 'Услуги доставки',
+                serviceNames: ['MarketplaceServiceItemReturnFlowTrans'],
+            ),
+            new self(
+                code: 'ozon_logistic_inbound',
+                name: 'Кросс-докинг (поставка) Ozon',
+                widgetGroup: 'Услуги доставки и FBO',
+                xlsxGroup: 'Услуги доставки',
+                serviceNames: ['ItemAdvertisementForSupplierLogistic'],
+            ),
+            new self(
+                code: 'ozon_logistic_inbound_seller',
+                name: 'ТЭУ (поставка продавцом) Ozon',
+                widgetGroup: 'Услуги доставки и FBO',
+                xlsxGroup: 'Услуги доставки',
+                serviceNames: ['ItemAdvertisementForSupplierLogisticSeller'],
+            ),
+            new self(
+                code: 'ozon_dropoff_pvz',
+                name: 'Обработка отправления ПВЗ Ozon',
+                widgetGroup: 'Услуги доставки и FBO',
+                xlsxGroup: 'Услуги доставки',
+                serviceNames: ['MarketplaceServiceItemDropoffPVZ'],
+            ),
+            new self(
+                code: 'ozon_dropoff_ff',
+                name: 'Обработка отправления FF Ozon',
+                widgetGroup: 'Услуги доставки и FBO',
+                xlsxGroup: 'Услуги доставки',
+                serviceNames: ['MarketplaceServiceItemDropoffFF'],
+            ),
+            new self(
+                code: 'ozon_dropoff_sc',
+                name: 'Обработка отправления СЦ Ozon',
+                widgetGroup: 'Услуги доставки и FBO',
+                xlsxGroup: 'Услуги доставки',
+                serviceNames: ['MarketplaceServiceItemDropoffSC'],
+            ),
+            new self(
+                code: 'ozon_dropoff_ppz',
+                name: 'Обработка отправления ППЗ Ozon',
+                widgetGroup: 'Услуги доставки и FBO',
+                xlsxGroup: 'Услуги доставки',
+                serviceNames: ['MarketplaceServiceItemDropoffPPZ'],
+            ),
+            new self(
+                code: 'ozon_delivery',
+                name: 'Доставка Ozon',
+                widgetGroup: 'Услуги доставки и FBO',
+                xlsxGroup: 'Услуги доставки',
+            ),
+            new self(
+                code: 'ozon_return_delivery',
+                name: 'Обратная доставка Ozon',
+                widgetGroup: 'Услуги доставки и FBO',
+                xlsxGroup: 'Услуги доставки',
+                operationTypes: [
+                    'OperationReturnGoodsFBSofRMS',
+                    'OperationSellerReturnsCargoAssortmentInvalid',
+                    'OperationSellerReturnsCargoAssortmentValid',
+                ],
+            ),
+            new self(
+                code: 'ozon_return_partial',
+                name: 'Обработка частичного возврата Ozon',
+                widgetGroup: 'Услуги доставки и FBO',
+                xlsxGroup: 'Услуги доставки',
+                serviceNames: ['MarketplaceServiceItemReturnPartGoodsCustomer'],
+            ),
+            new self(
+                code: 'ozon_return_not_delivered',
+                name: 'Возврат невостребованного товара Ozon',
+                widgetGroup: 'Услуги доставки и FBO',
+                xlsxGroup: 'Услуги доставки',
+                serviceNames: ['MarketplaceNotDeliveredCostItem'],
+            ),
+            new self(
+                code: 'ozon_return_after_delivery',
+                name: 'Возврат после доставки Ozon',
+                widgetGroup: 'Услуги доставки и FBO',
+                xlsxGroup: 'Услуги доставки',
+                serviceNames: ['MarketplaceReturnAfterDeliveryCostItem'],
+            ),
+            new self(
+                code: 'ozon_return_storage_pvz',
+                name: 'Краткосрочное хранение возврата ПВЗ Ozon',
+                widgetGroup: 'Услуги доставки и FBO',
+                xlsxGroup: 'Услуги доставки',
+                serviceNames: ['MarketplaceReturnStorageServiceAtThePickupPointFbsItem'],
+            ),
+            new self(
+                code: 'ozon_return_storage_wh',
+                name: 'Долгосрочное хранение возврата склад Ozon',
+                widgetGroup: 'Услуги доставки и FBO',
+                xlsxGroup: 'Услуги доставки',
+                serviceNames: ['MarketplaceReturnStorageServiceInTheWarehouseFbsItem'],
+            ),
+
+            // =================================================================
+            // Услуги доставки и FBO → Услуги FBO (xlsx)
+            // =================================================================
+            new self(
+                code: 'ozon_crossdocking',
+                name: 'Кросс-докинг Ozon',
+                widgetGroup: 'Услуги доставки и FBO',
+                xlsxGroup: 'Услуги FBO',
+                serviceNames: ['MarketplaceServiceItemCrossdocking'],
+            ),
+            new self(
+                code: 'ozon_supply_shortage',
+                name: 'Бронирование места (неполный состав) Ozon',
+                widgetGroup: 'Услуги доставки и FBO',
+                xlsxGroup: 'Услуги FBO',
+                serviceNames: ['OperationMarketplaceServiceSupplyInboundCargoShortage'],
+            ),
+            new self(
+                code: 'ozon_return_from_stock',
+                name: 'Комплектация для вывоза продавцом Ozon',
+                widgetGroup: 'Услуги доставки и FBO',
+                xlsxGroup: 'Услуги FBO',
+                serviceNames: [
+                    'MarketplaceServiceItemReturnFromStock',
+                    'MarketplaceServiceSellerReturnsCargoAssortment',
+                ],
+            ),
+            new self(
+                code: 'ozon_supply_additional',
+                name: 'Обработка товара в грузоместе FBO Ozon',
+                widgetGroup: 'Услуги доставки и FBO',
+                xlsxGroup: 'Услуги FBO',
+                serviceNames: ['OperationMarketplaceSupplyAdditional'],
+                operationTypes: [
+                    'OperationMarketplaceSupplyExpirationDateProcessing',
+                    'OperationMarketplaceSupplyDefectProcessing',
+                    'OperationMarketplaceServiceProcessingSpoilageSurplus',
+                    'Обработка сроков годности на FBO',
+                    'Обработка брака с приемки',
+                ],
+            ),
+            new self(
+                code: 'ozon_supply_surplus',
+                name: 'Обработка излишков поставки Ozon',
+                widgetGroup: 'Услуги доставки и FBO',
+                xlsxGroup: 'Услуги FBO',
+                serviceNames: ['OperationMarketplaceServiceSupplyInboundCargoSurplus'],
+            ),
+            new self(
+                code: 'ozon_storage',
+                name: 'Хранение на складе Ozon',
+                widgetGroup: 'Услуги доставки и FBO',
+                xlsxGroup: 'Услуги FBO',
+                serviceNames: ['OperationMarketplaceServiceStorage'],
+            ),
+            new self(
+                code: 'ozon_logistic_pickup',
+                name: 'Выезд за товаром (Pick-up) Ozon',
+                widgetGroup: 'Услуги доставки и FBO',
+                xlsxGroup: 'Услуги FBO',
+                serviceNames: [
+                    'MarketplaceServiceItemPickup',
+                    'MarketplaceServiceProductMovementFromWarehouse',
+                ],
+            ),
+            new self(
+                code: 'ozon_warehouse_movement',
+                name: 'Перемещение между складами Ozon',
+                widgetGroup: 'Услуги доставки и FBO',
+                xlsxGroup: 'Услуги FBO',
+                operationTypes: [
+                    'MarketplaceServiceItemReplenishment',
+                    'OperationMarketplaceWarehouseToWarehouseMovement',
+                    'Перемещение товаров между складами Ozon',
+                ],
+            ),
+
+            // =================================================================
+            // Услуги партнёров
+            // =================================================================
+            new self(
+                code: 'ozon_logistic_last_mile',
+                name: 'Last mile Ozon',
+                widgetGroup: 'Услуги партнёров',
+                xlsxGroup: 'Услуги партнёров',
+                serviceNames: [
+                    'MarketplaceServiceItemDelivToCustomer',
+                    'MarketplaceServiceItemRedistributionLastMileCourier',
+                ],
+            ),
+            new self(
+                code: 'ozon_return_pvz',
+                name: 'Перевыставление возврата ПВЗ Ozon',
+                widgetGroup: 'Услуги партнёров',
+                xlsxGroup: 'Услуги партнёров',
+                serviceNames: ['MarketplaceServiceItemRedistributionReturnsPVZ'],
+                operationTypes: ['SellerReturnsDeliveryToPickupPoint'],
+            ),
+            new self(
+                code: 'ozon_storage_partner',
+                name: 'Временное хранение у партнёров Ozon',
+                widgetGroup: 'Услуги партнёров',
+                xlsxGroup: 'Услуги партнёров',
+                serviceNames: [
+                    'MarketplaceServiceItemTemporaryStorageRedistribution',
+                    'OperationMarketplaceItemTemporaryStorageRedistribution',
+                ],
+                operationTypes: ['Временное размещение товара партнерами'],
+            ),
+            new self(
+                code: 'ozon_acquiring',
+                name: 'Эквайринг Ozon',
+                widgetGroup: 'Услуги партнёров',
+                xlsxGroup: 'Услуги партнёров',
+                serviceNames: ['MarketplaceRedistributionOfAcquiringOperation'],
+            ),
+            new self(
+                code: 'ozon_fulfillment',
+                name: 'Сборка заказа Ozon',
+                widgetGroup: 'Услуги партнёров',
+                xlsxGroup: 'Услуги партнёров',
+                serviceNames: ['MarketplaceServiceItemFulfillment'],
+            ),
+            new self(
+                code: 'ozon_package_labor',
+                name: 'Упаковка партнёрами Ozon',
+                widgetGroup: 'Услуги партнёров',
+                xlsxGroup: 'Услуги FBO',
+                serviceNames: ['MarketplaceServiceItemPackageRedistribution'],
+            ),
+            new self(
+                code: 'ozon_dropoff_apvz',
+                name: 'Дропофф АПВЗ Ozon',
+                widgetGroup: 'Услуги партнёров',
+                xlsxGroup: 'Услуги партнёров',
+                serviceNames: ['MarketplaceServiceItemRedistributionDropOffApvz'],
+            ),
+
+            // =================================================================
+            // Продвижение и реклама
+            // =================================================================
+            new self(
+                code: 'ozon_cpc',
+                name: 'Оплата за клик Ozon',
+                widgetGroup: 'Продвижение и реклама',
+                xlsxGroup: 'Продвижение и реклама',
+                serviceNames: ['OperationMarketplaceCostPerClick'],
+            ),
+            new self(
+                code: 'ozon_premium_promotion',
+                name: 'Продвижение Premium Ozon',
+                widgetGroup: 'Продвижение и реклама',
+                xlsxGroup: 'Продвижение и реклама',
+                serviceNames: ['MarketplaceServicePremiumPromotion'],
+                operationTypes: [
+                    'OperationSubscriptionPremiumPlus',
+                    'Подписка Premium Plus',
+                ],
+            ),
+            new self(
+                code: 'ozon_premium_cashback',
+                name: 'Бонусы продавца Premium Ozon',
+                widgetGroup: 'Продвижение и реклама',
+                xlsxGroup: 'Продвижение и реклама',
+                serviceNames: [
+                    'MarketplaceServicePremiumCashbackIndividualPoints',
+                    'MarketplaceServiceItemElectronicServicesPremiumCashbackIndividualPoints',
+                    'OperationMarketplaceServicePremiumCashbackIndividualPoints',
+                ],
+            ),
+            new self(
+                code: 'ozon_reviews',
+                name: 'Приобретение отзывов Ozon',
+                widgetGroup: 'Продвижение и реклама',
+                xlsxGroup: 'Продвижение и реклама',
+                serviceNames: ['MarketplaceSaleReviewsItem'],
+                operationTypes: [
+                    'OperationPointsForReviews',
+                    'Баллы за отзывы',
+                ],
+            ),
+            new self(
+                code: 'ozon_seller_bonus',
+                name: 'Бонусы продавца (рассылки) Ozon',
+                widgetGroup: 'Продвижение и реклама',
+                xlsxGroup: 'Продвижение и реклама',
+                operationTypes: [
+                    'OperationMarketplaceServicePremiumCashbackBonusAccrual',
+                    'Бонусы продавца - рассылка',
+                ],
+            ),
+            new self(
+                code: 'ozon_marketing_action',
+                name: 'Маркетинговые акции Ozon',
+                widgetGroup: 'Продвижение и реклама',
+                xlsxGroup: 'Продвижение и реклама',
+                serviceNames: ['MarketplaceMarketingActionCostItem'],
+                operationTypes: ['OperationPromotionWithCostPerOrder'],
+            ),
+            new self(
+                code: 'ozon_stars_membership',
+                name: 'Звёздные товары Ozon',
+                widgetGroup: 'Продвижение и реклама',
+                xlsxGroup: 'Продвижение и реклама',
+                serviceNames: ['ItemAgentServiceStarsMembership'],
+            ),
+
+            // =================================================================
+            // Другие услуги и штрафы
+            // =================================================================
+            new self(
+                code: 'ozon_package_materials',
+                name: 'Упаковочные материалы Ozon',
+                widgetGroup: 'Другие услуги и штрафы',
+                xlsxGroup: 'Услуги FBO',
+                serviceNames: ['MarketplaceServiceItemPackageMaterialsProvision'],
+            ),
+            new self(
+                code: 'ozon_disposal',
+                name: 'Утилизация товара Ozon',
+                widgetGroup: 'Другие услуги и штрафы',
+                xlsxGroup: 'Другие услуги и штрафы',
+                serviceNames: ['MarketplaceServiceItemDisposalDetailed'],
+                operationTypes: [
+                    'DisposalReasonDamagedPackaging',
+                    'DisposalReasonScattered',
+                    'DisposalReasonFailedToPickupOnTime',
+                ],
+            ),
+            new self(
+                code: 'ozon_ovh_processing',
+                name: 'Дополнительная обработка ОВХ Ozon',
+                widgetGroup: 'Другие услуги и штрафы',
+                xlsxGroup: 'Другие услуги и штрафы',
+                serviceNames: [
+                    'MarketplaceServiceVolumeWeightCharacsProcessing',
+                    'OperationMarketplaceServiceVolumeWeightCharacsProcessing',
+                ],
+            ),
+            new self(
+                code: 'ozon_penalty_undeliverable',
+                name: 'Удержание за недовложение Ozon',
+                widgetGroup: 'Другие услуги и штрафы',
+                xlsxGroup: 'Другие услуги и штрафы',
+                serviceNames: ['OperationMarketplaceWithHoldingForUndeliverableGoods'],
+                operationTypes: [
+                    'DefectRateDetailed',
+                    'OperationMarketplaceModerationFine',
+                    'OperationModerationProhibitedContent',
+                    'Модерация запрещённого контента',
+                    'Обработка операционных ошибок продавца: отгрузка в нерекомендованный слот',
+                ],
+            ),
+            new self(
+                code: 'ozon_marking',
+                name: 'Обязательная маркировка Ozon',
+                widgetGroup: 'Другие услуги и штрафы',
+                xlsxGroup: 'Другие услуги и штрафы',
+                serviceNames: ['MarketplaceServiceItemMarkingItems'],
+            ),
+            new self(
+                code: 'ozon_agency_fee',
+                name: 'Агентская услуга 3PL Global Ozon',
+                widgetGroup: 'Другие услуги и штрафы',
+                xlsxGroup: 'Другие услуги и штрафы',
+                serviceNames: ['OperationMarketplaceAgencyFeeAggregator3PLGlobal'],
+            ),
+            new self(
+                code: 'ozon_early_payment',
+                name: 'Досрочная выплата Ozon',
+                widgetGroup: 'Другие услуги и штрафы',
+                xlsxGroup: 'Другие услуги и штрафы',
+                serviceNames: ['OperationMarketplaceServiceEarlyPaymentAccrual'],
+            ),
+            new self(
+                code: 'ozon_flexible_payment',
+                name: 'Гибкий график выплат Ozon',
+                widgetGroup: 'Другие услуги и штрафы',
+                xlsxGroup: 'Другие услуги и штрафы',
+                serviceNames: ['MarketplaceServiceItemFlexiblePaymentSchedule'],
+            ),
+            new self(
+                code: 'ozon_installment',
+                name: 'Продажа в рассрочку Ozon',
+                widgetGroup: 'Другие услуги и штрафы',
+                xlsxGroup: 'Другие услуги и штрафы',
+                serviceNames: ['MarketplaceServiceItemInstallment'],
+            ),
+            new self(
+                code: 'ozon_premium_correction',
+                name: 'Корректировка премии Ozon',
+                widgetGroup: 'Другие услуги и штрафы',
+                xlsxGroup: 'Другие услуги и штрафы',
+                operationTypes: ['Корректировка суммы акта о премии'],
+            ),
+            new self(
+                code: 'ozon_service_correction',
+                name: 'Корректировка стоимости услуг Ozon',
+                widgetGroup: 'Другие услуги и штрафы',
+                xlsxGroup: 'Другие услуги и штрафы',
+                operationTypes: ['Корректировки стоимости услуг'],
+            ),
+            new self(
+                code: 'ozon_other_service',
+                name: 'Прочие услуги Ozon',
+                widgetGroup: 'Другие услуги и штрафы',
+                xlsxGroup: 'Другие услуги и штрафы',
+            ),
+
+            // =================================================================
+            // Компенсации и декомпенсации (xlsx) / Другие услуги и штрафы (widget)
+            // =================================================================
+            new self(
+                code: 'ozon_compensation',
+                name: 'Компенсации и декомпенсации Ozon',
+                widgetGroup: 'Другие услуги и штрафы',
+                xlsxGroup: 'Компенсации и декомпенсации',
+                operationTypes: ['AccrualInternalClaim'],
+            ),
+            new self(
+                code: 'ozon_decompensation',
+                name: 'Декомпенсация Ozon',
+                widgetGroup: 'Другие услуги и штрафы',
+                xlsxGroup: 'Компенсации и декомпенсации',
+            ),
+        ];
+
+        return $cache;
+    }
+
+    // -------------------------------------------------------------------------
+    // Lookup by code
+    // -------------------------------------------------------------------------
+
+    /**
+     * @return array<string, OzonCostCategory> code => category
+     */
+    public static function byCode(): array
+    {
+        /** @var array<string, OzonCostCategory>|null $map */
+        static $map = null;
+
+        if ($map === null) {
+            $map = [];
+            foreach (self::all() as $c) {
+                $map[$c->code] = $c;
+            }
+        }
+
+        return $map;
+    }
+
+    public static function findByCode(string $code): ?self
+    {
+        return self::byCode()[$code] ?? null;
+    }
+
+    // -------------------------------------------------------------------------
+    // Lookup by service name (services[].name in Ozon API)
+    // -------------------------------------------------------------------------
+
+    /**
+     * @return array<string, OzonCostCategory> serviceName => category
+     */
+    private static function serviceNameIndex(): array
+    {
+        /** @var array<string, OzonCostCategory>|null $index */
+        static $index = null;
+
+        if ($index === null) {
+            $index = [];
+            foreach (self::all() as $c) {
+                foreach ($c->serviceNames as $name) {
+                    $index[$name] = $c;
+                }
+            }
+        }
+
+        return $index;
+    }
+
+    public static function findByServiceName(string $serviceName): ?self
+    {
+        return self::serviceNameIndex()[$serviceName] ?? null;
+    }
+
+    // -------------------------------------------------------------------------
+    // Lookup by operation type (operation_type / operation_type_name)
+    // -------------------------------------------------------------------------
+
+    /**
+     * @return array<string, OzonCostCategory> operationType => category
+     */
+    private static function operationTypeIndex(): array
+    {
+        /** @var array<string, OzonCostCategory>|null $index */
+        static $index = null;
+
+        if ($index === null) {
+            $index = [];
+            foreach (self::all() as $c) {
+                foreach ($c->operationTypes as $opType) {
+                    $index[$opType] = $c;
+                }
+            }
+        }
+
+        return $index;
+    }
+
+    public static function findByOperationType(string $operationType): ?self
+    {
+        return self::operationTypeIndex()[$operationType] ?? null;
+    }
+}

--- a/site/src/MarketplaceAnalytics/Application/Service/WidgetServiceGroupMap.php
+++ b/site/src/MarketplaceAnalytics/Application/Service/WidgetServiceGroupMap.php
@@ -4,98 +4,33 @@ declare(strict_types=1);
 
 namespace App\MarketplaceAnalytics\Application\Service;
 
+use App\Marketplace\Domain\OzonCostCategory;
+
 /**
+ * Тонкий адаптер над OzonCostCategory для обратной совместимости.
+ *
  * Маппинг категорий затрат Ozon к widgetGroup для витрины аналитики.
- *
- * Используется в WidgetSummaryQuery для агрегации затрат по 5 группам
- * виджета на дашборде MarketplaceAnalytics.
- *
- * Отличия от OzonXlsxServiceGroupMap:
- *  - "Услуги доставки" + "Услуги FBO" объединены в "Услуги доставки и FBO"
- *  - "Другие услуги и штрафы" + "Компенсации и декомпенсации" объединены
- *    в "Другие услуги и штрафы"
+ * Используется в WidgetSummaryQuery для агрегации затрат по 5 группам.
  *
  * Fallback для неизвестных кодов: 'Другие услуги и штрафы'.
  */
 final class WidgetServiceGroupMap
 {
     /**
-     * @return array<string, string> category_code → widgetGroup
+     * @return array<string, string> category_code => widgetGroup
      */
     public static function getCategoryToWidgetGroup(): array
     {
-        return [
-            // === Вознаграждение ===
-            'ozon_sale_commission'       => 'Вознаграждение',
-            'ozon_brand_commission'      => 'Вознаграждение',
+        /** @var array<string, string>|null $cache */
+        static $cache = null;
 
-            // === Услуги доставки и FBO ===
-            // Объединяем "Услуги доставки" + "Услуги FBO" из OzonXlsxServiceGroupMap
-            // Доставка (20 кодов):
-            'ozon_logistic_direct'       => 'Услуги доставки и FBO',
-            'ozon_logistic_direct_vdc'   => 'Услуги доставки и FBO',
-            'ozon_logistic_direct_trans' => 'Услуги доставки и FBO',
-            'ozon_logistic_delivery'     => 'Услуги доставки и FBO',
-            'ozon_logistic_kgt'          => 'Услуги доставки и FBO',
-            'ozon_logistic_return'       => 'Услуги доставки и FBO',
-            'ozon_logistic_return_trans' => 'Услуги доставки и FBO',
-            'ozon_logistic_inbound'      => 'Услуги доставки и FBO',
-            'ozon_logistic_inbound_seller' => 'Услуги доставки и FBO',
-            'ozon_dropoff_pvz'           => 'Услуги доставки и FBO',
-            'ozon_dropoff_ff'            => 'Услуги доставки и FBO',
-            'ozon_dropoff_sc'            => 'Услуги доставки и FBO',
-            'ozon_dropoff_ppz'           => 'Услуги доставки и FBO',
-            'ozon_delivery'              => 'Услуги доставки и FBO',
-            'ozon_return_delivery'       => 'Услуги доставки и FBO',
-            'ozon_return_partial'        => 'Услуги доставки и FBO',
-            'ozon_return_not_delivered'  => 'Услуги доставки и FBO',
-            'ozon_return_after_delivery' => 'Услуги доставки и FBO',
-            'ozon_return_storage_pvz'    => 'Услуги доставки и FBO',
-            'ozon_return_storage_wh'     => 'Услуги доставки и FBO',
-            // FBO (8 кодов):
-            'ozon_crossdocking'          => 'Услуги доставки и FBO',
-            'ozon_supply_shortage'       => 'Услуги доставки и FBO',
-            'ozon_return_from_stock'     => 'Услуги доставки и FBO',
-            'ozon_supply_additional'     => 'Услуги доставки и FBO',
-            'ozon_supply_surplus'        => 'Услуги доставки и FBO',
-            'ozon_storage'               => 'Услуги доставки и FBO',
-            'ozon_logistic_pickup'       => 'Услуги доставки и FBO',
-            'ozon_warehouse_movement'    => 'Услуги доставки и FBO',
+        if ($cache === null) {
+            $cache = [];
+            foreach (OzonCostCategory::all() as $c) {
+                $cache[$c->code] = $c->widgetGroup;
+            }
+        }
 
-            // === Услуги партнёров ===
-            'ozon_logistic_last_mile'    => 'Услуги партнёров',
-            'ozon_return_pvz'            => 'Услуги партнёров',
-            'ozon_storage_partner'       => 'Услуги партнёров',
-            'ozon_acquiring'             => 'Услуги партнёров',
-            'ozon_fulfillment'           => 'Услуги партнёров',
-            'ozon_package_labor'         => 'Услуги партнёров',
-            'ozon_dropoff_apvz'          => 'Услуги партнёров',
-
-            // === Продвижение и реклама ===
-            'ozon_cpc'                   => 'Продвижение и реклама',
-            'ozon_premium_promotion'     => 'Продвижение и реклама',
-            'ozon_premium_cashback'      => 'Продвижение и реклама',
-            'ozon_reviews'               => 'Продвижение и реклама',
-            'ozon_seller_bonus'          => 'Продвижение и реклама',
-            'ozon_marketing_action'      => 'Продвижение и реклама',
-            'ozon_stars_membership'      => 'Продвижение и реклама',
-
-            // === Другие услуги и штрафы ===
-            // Объединяем "Другие услуги и штрафы" + "Компенсации и декомпенсации"
-            'ozon_package_materials'     => 'Другие услуги и штрафы',
-            'ozon_disposal'              => 'Другие услуги и штрафы',
-            'ozon_ovh_processing'        => 'Другие услуги и штрафы',
-            'ozon_penalty_undeliverable' => 'Другие услуги и штрафы',
-            'ozon_marking'               => 'Другие услуги и штрафы',
-            'ozon_agency_fee'            => 'Другие услуги и штрафы',
-            'ozon_early_payment'         => 'Другие услуги и штрафы',
-            'ozon_flexible_payment'      => 'Другие услуги и штрафы',
-            'ozon_installment'           => 'Другие услуги и штрафы',
-            'ozon_premium_correction'    => 'Другие услуги и штрафы',
-            'ozon_service_correction'    => 'Другие услуги и штрафы',
-            'ozon_other_service'         => 'Другие услуги и штрафы',
-            'ozon_compensation'          => 'Другие услуги и штрафы',
-            'ozon_decompensation'        => 'Другие услуги и штрафы',
-        ];
+        return $cache;
     }
 }

--- a/site/tests/Unit/Marketplace/Application/Processor/OzonServiceCategoryMapTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/OzonServiceCategoryMapTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Marketplace\Application\Processor;
 
 use App\Marketplace\Application\Processor\OzonServiceCategoryMap;
+use App\Marketplace\Domain\OzonCostCategory;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\AbstractLogger;
 use Psr\Log\LogLevel;
@@ -42,59 +43,84 @@ final class WarningCapturingLogger extends AbstractLogger
  * - getCategoryName не возвращает fallback 'Прочие услуги Ozon' для известных кодов
  * - resolve не логирует warning для известных service names
  *
- * Запуск: php bin/phpunit tests/Marketplace/Application/Processor/OzonServiceCategoryMapTest.php
+ * Запуск: php bin/phpunit tests/Unit/Marketplace/Application/Processor/OzonServiceCategoryMapTest.php
  */
 final class OzonServiceCategoryMapTest extends TestCase
 {
     /**
-     * Каждый service name из MAP должен резолвиться без warning
+     * Каждый service name из OzonCostCategory должен резолвиться без warning
      * и возвращать category code с правильным именем (не fallback).
      */
     public function testAllKnownServiceNamesResolveWithoutWarning(): void
     {
         $logger = new WarningCapturingLogger();
 
-        $knownServiceNames = $this->getKnownServiceNames();
+        foreach (OzonCostCategory::all() as $category) {
+            foreach ($category->serviceNames as $serviceName) {
+                $logger->reset();
+                $code = OzonServiceCategoryMap::resolve($serviceName, $logger);
 
-        foreach ($knownServiceNames as $serviceName) {
-            // Нулевые маркеры (null в MAP) — легитимны, пропускаем
-            if (OzonServiceCategoryMap::isZeroMarker($serviceName)) {
-                continue;
+                $this->assertFalse(
+                    $logger->hasWarnings(),
+                    sprintf('Service name "%s" triggered a warning — добавь в OzonCostCategory::all()', $serviceName),
+                );
+
+                $this->assertNotNull(
+                    $code,
+                    sprintf('Service name "%s" вернул null — только нулевые маркеры должны возвращать null', $serviceName),
+                );
+
+                $this->assertSame(
+                    $category->code,
+                    $code,
+                    sprintf('Service name "%s" резолвится в "%s", а не в ожидаемый "%s"', $serviceName, $code, $category->code),
+                );
             }
 
-            $logger->reset();
-            $code = OzonServiceCategoryMap::resolve($serviceName, $logger);
+            foreach ($category->operationTypes as $operationType) {
+                $logger->reset();
+                $code = OzonServiceCategoryMap::resolve($operationType, $logger);
 
-            $this->assertFalse(
-                $logger->hasWarnings(),
-                sprintf('Service name "%s" triggered a warning — добавь в OzonServiceCategoryMap::MAP', $serviceName),
-            );
+                $this->assertFalse(
+                    $logger->hasWarnings(),
+                    sprintf('Operation type "%s" triggered a warning — добавь в OzonCostCategory::all()', $operationType),
+                );
 
-            $this->assertNotNull(
-                $code,
-                sprintf('Service name "%s" вернул null — только нулевые маркеры должны возвращать null', $serviceName),
-            );
+                $this->assertNotNull(
+                    $code,
+                    sprintf('Operation type "%s" вернул null — только нулевые маркеры должны возвращать null', $operationType),
+                );
+
+                $this->assertSame(
+                    $category->code,
+                    $code,
+                    sprintf('Operation type "%s" резолвится в "%s", а не в ожидаемый "%s"', $operationType, $code, $category->code),
+                );
+            }
         }
     }
 
     /**
-     * Каждый category code из MAP должен иметь человекочитаемое имя в getCategoryName.
+     * Каждый category code из OzonCostCategory должен иметь человекочитаемое имя.
      * Если getCategoryName возвращает 'Прочие услуги Ozon' для известного кода —
-     * значит getCategoryName не синхронизирован с MAP.
+     * значит getCategoryName не синхронизирован с OzonCostCategory.
      */
     public function testAllCategoryCodesHaveProperNames(): void
     {
-        $codes = $this->getAllCategoryCodes();
+        foreach (OzonCostCategory::all() as $category) {
+            // ozon_other_service is the catch-all, its name IS 'Прочие услуги Ozon'
+            if ($category->code === 'ozon_other_service') {
+                continue;
+            }
 
-        foreach ($codes as $code) {
-            $name = OzonServiceCategoryMap::getCategoryName($code);
+            $name = OzonServiceCategoryMap::getCategoryName($category->code);
 
             $this->assertNotEquals(
                 'Прочие услуги Ozon',
                 $name,
                 sprintf(
-                    'Category code "%s" не имеет имени в getCategoryName — добавь его в match()',
-                    $code,
+                    'Category code "%s" не имеет имени в OzonCostCategory — добавь его в all()',
+                    $category->code,
                 ),
             );
         }
@@ -137,33 +163,5 @@ final class OzonServiceCategoryMapTest extends TestCase
                 sprintf('"%s" не должен быть нулевым маркером', $serviceName),
             );
         }
-    }
-
-    // -------------------------------------------------------------------------
-
-    /**
-     * Получаем все известные service names через Reflection.
-     * @return string[]
-     */
-    private function getKnownServiceNames(): array
-    {
-        $ref = new \ReflectionClass(OzonServiceCategoryMap::class);
-        $map = $ref->getConstants()['MAP'] ?? [];
-
-        return array_keys($map);
-    }
-
-    /**
-     * Получаем все уникальные category codes из MAP (без null).
-     * @return string[]
-     */
-    private function getAllCategoryCodes(): array
-    {
-        $ref = new \ReflectionClass(OzonServiceCategoryMap::class);
-        $map = $ref->getConstants()['MAP'] ?? [];
-
-        $codes = array_filter(array_unique(array_values($map)));
-
-        return array_values($codes);
     }
 }

--- a/site/tests/Unit/Marketplace/Domain/OzonCostCategoryTest.php
+++ b/site/tests/Unit/Marketplace/Domain/OzonCostCategoryTest.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Domain;
+
+use App\Marketplace\Domain\OzonCostCategory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Контрактный тест OzonCostCategory.
+ *
+ * Гарантирует целостность справочника:
+ * - нет дублей кодов, service_name, operation_type
+ * - все поля заполнены
+ * - widgetGroup / xlsxGroup из фиксированного набора
+ *
+ * Если кто-то добавит дубль или опечатку в группе — тест упадёт.
+ *
+ * Запуск: php bin/phpunit tests/Unit/Marketplace/Domain/OzonCostCategoryTest.php
+ */
+final class OzonCostCategoryTest extends TestCase
+{
+    /**
+     * Каждый код уникален.
+     */
+    public function testNoDuplicateCodes(): void
+    {
+        $codes = [];
+        foreach (OzonCostCategory::all() as $c) {
+            $this->assertArrayNotHasKey(
+                $c->code,
+                $codes,
+                sprintf('Дублирующийся code: "%s"', $c->code),
+            );
+            $codes[$c->code] = true;
+        }
+    }
+
+    /**
+     * Каждый service_name встречается ровно один раз во всём справочнике.
+     */
+    public function testNoDuplicateServiceNames(): void
+    {
+        $seen = [];
+        foreach (OzonCostCategory::all() as $c) {
+            foreach ($c->serviceNames as $name) {
+                $this->assertArrayNotHasKey(
+                    $name,
+                    $seen,
+                    sprintf(
+                        'service_name "%s" дублируется: в "%s" и "%s"',
+                        $name,
+                        $seen[$name] ?? '?',
+                        $c->code,
+                    ),
+                );
+                $seen[$name] = $c->code;
+            }
+        }
+    }
+
+    /**
+     * Каждый operation_type встречается ровно один раз во всём справочнике.
+     */
+    public function testNoDuplicateOperationTypes(): void
+    {
+        $seen = [];
+        foreach (OzonCostCategory::all() as $c) {
+            foreach ($c->operationTypes as $opType) {
+                $this->assertArrayNotHasKey(
+                    $opType,
+                    $seen,
+                    sprintf(
+                        'operation_type "%s" дублируется: в "%s" и "%s"',
+                        $opType,
+                        $seen[$opType] ?? '?',
+                        $c->code,
+                    ),
+                );
+                $seen[$opType] = $c->code;
+            }
+        }
+    }
+
+    /**
+     * Ни один ключ не встречается одновременно в serviceNames и operationTypes
+     * разных (или одной) категории.
+     */
+    public function testNoOverlapBetweenServiceNamesAndOperationTypes(): void
+    {
+        $serviceNames = [];
+        $operationTypes = [];
+
+        foreach (OzonCostCategory::all() as $c) {
+            foreach ($c->serviceNames as $name) {
+                $serviceNames[$name] = $c->code;
+            }
+            foreach ($c->operationTypes as $opType) {
+                $operationTypes[$opType] = $c->code;
+            }
+        }
+
+        $overlap = array_intersect_key($serviceNames, $operationTypes);
+        $this->assertEmpty(
+            $overlap,
+            sprintf('Ключи пересекаются между serviceNames и operationTypes: %s', implode(', ', array_keys($overlap))),
+        );
+    }
+
+    /**
+     * Каждый код имеет непустое имя.
+     */
+    public function testEveryCodeHasNonEmptyName(): void
+    {
+        foreach (OzonCostCategory::all() as $c) {
+            $this->assertNotEmpty(
+                $c->name,
+                sprintf('Код "%s" имеет пустое имя', $c->code),
+            );
+        }
+    }
+
+    /**
+     * Каждый код имеет непустой code.
+     */
+    public function testEveryCodeHasNonEmptyCode(): void
+    {
+        foreach (OzonCostCategory::all() as $c) {
+            $this->assertNotEmpty($c->code, 'Найден элемент с пустым code');
+        }
+    }
+
+    /**
+     * widgetGroup принадлежит фиксированному набору (5 групп).
+     */
+    public function testWidgetGroupBelongsToKnownSet(): void
+    {
+        $allowedGroups = [
+            'Вознаграждение',
+            'Услуги доставки и FBO',
+            'Услуги партнёров',
+            'Продвижение и реклама',
+            'Другие услуги и штрафы',
+        ];
+
+        foreach (OzonCostCategory::all() as $c) {
+            $this->assertContains(
+                $c->widgetGroup,
+                $allowedGroups,
+                sprintf('Код "%s" имеет неизвестный widgetGroup: "%s"', $c->code, $c->widgetGroup),
+            );
+        }
+    }
+
+    /**
+     * xlsxGroup принадлежит фиксированному набору (7 групп).
+     */
+    public function testXlsxGroupBelongsToKnownSet(): void
+    {
+        $allowedGroups = [
+            'Вознаграждение Ozon',
+            'Продвижение и реклама',
+            'Услуги доставки',
+            'Услуги FBO',
+            'Услуги партнёров',
+            'Другие услуги и штрафы',
+            'Компенсации и декомпенсации',
+        ];
+
+        foreach (OzonCostCategory::all() as $c) {
+            $this->assertContains(
+                $c->xlsxGroup,
+                $allowedGroups,
+                sprintf('Код "%s" имеет неизвестный xlsxGroup: "%s"', $c->code, $c->xlsxGroup),
+            );
+        }
+    }
+
+    /**
+     * findByCode возвращает корректную категорию.
+     */
+    public function testFindByCodeReturnsCorrectCategory(): void
+    {
+        foreach (OzonCostCategory::all() as $c) {
+            $found = OzonCostCategory::findByCode($c->code);
+            $this->assertNotNull($found, sprintf('findByCode("%s") вернул null', $c->code));
+            $this->assertSame($c->code, $found->code);
+            $this->assertSame($c->name, $found->name);
+        }
+    }
+
+    /**
+     * findByCode возвращает null для неизвестного кода.
+     */
+    public function testFindByCodeReturnsNullForUnknown(): void
+    {
+        $this->assertNull(OzonCostCategory::findByCode('nonexistent_code'));
+    }
+
+    /**
+     * findByServiceName возвращает корректную категорию для каждого service name.
+     */
+    public function testFindByServiceNameReturnsCorrectCategory(): void
+    {
+        foreach (OzonCostCategory::all() as $c) {
+            foreach ($c->serviceNames as $name) {
+                $found = OzonCostCategory::findByServiceName($name);
+                $this->assertNotNull($found, sprintf('findByServiceName("%s") вернул null', $name));
+                $this->assertSame(
+                    $c->code,
+                    $found->code,
+                    sprintf('findByServiceName("%s") вернул "%s", ожидается "%s"', $name, $found->code, $c->code),
+                );
+            }
+        }
+    }
+
+    /**
+     * findByOperationType возвращает корректную категорию для каждого operation type.
+     */
+    public function testFindByOperationTypeReturnsCorrectCategory(): void
+    {
+        foreach (OzonCostCategory::all() as $c) {
+            foreach ($c->operationTypes as $opType) {
+                $found = OzonCostCategory::findByOperationType($opType);
+                $this->assertNotNull($found, sprintf('findByOperationType("%s") вернул null', $opType));
+                $this->assertSame(
+                    $c->code,
+                    $found->code,
+                    sprintf('findByOperationType("%s") вернул "%s", ожидается "%s"', $opType, $found->code, $c->code),
+                );
+            }
+        }
+    }
+
+    /**
+     * byCode возвращает все категории.
+     */
+    public function testByCodeContainsAllCategories(): void
+    {
+        $byCode = OzonCostCategory::byCode();
+        $all    = OzonCostCategory::all();
+
+        $this->assertCount(count($all), $byCode);
+    }
+}


### PR DESCRIPTION
## Summary

- Создан `OzonCostCategory` (`src/Marketplace/Domain/`) — единый справочник всех 58 кодов затрат Ozon с полями: `code`, `name`, `widgetGroup`, `xlsxGroup`, `serviceNames[]`, `operationTypes[]`
- `OzonServiceCategoryMap`, `WidgetServiceGroupMap`, `OzonXlsxServiceGroupMap` переписаны как тонкие адаптеры — сигнатуры методов сохранены, вызывающий код не затронут
- Добавлен контрактный тест `OzonCostCategoryTest` (13 тестов, 725 assertions): уникальность кодов, отсутствие дублей service_name/operation_type, валидация групп из фиксированных наборов

## Мотивация

Данные о category_code были раскиданы по трём классам. Добавление нового кода в один класс без обновления остальных приводило к silent fallback в «Прочее». Теперь единый источник правды — если код не описан полностью, контрактный тест упадёт.

## Test plan

- [x] `OzonCostCategoryTest` — 13 тестов, 725 assertions (контрактный)
- [x] `OzonServiceCategoryMapTest` — 4 теста, 322 assertions (адаптер)
- [x] `OzonCostsRawProcessorTest` — 16 тестов, 53 assertions (процессор)
- [x] Полный unit-suite — 224 теста пройдены, 3 pre-existing ошибки в несвязанном `DefaultCostMappingSeedPolicyTest`
- [ ] Проверить виджеты аналитики, xlsx-сверку, импорт затрат — поведение не должно измениться

https://claude.ai/code/session_01Jey6TMj3n4ToYBnt9UL3h3