### PR TITLE
fix(marketplace-analytics): P&L sign convention for Unit widget

### DIFF
--- a/site/assets/react/marketplace-analytics/unit-extended/widgets/WidgetCard.tsx
+++ b/site/assets/react/marketplace-analytics/unit-extended/widgets/WidgetCard.tsx
@@ -22,22 +22,11 @@ function calcDeltaPercent(current: number, previous: number): number | null {
     return ((current - previous) / Math.abs(previous)) * 100;
 }
 
-/**
- * Цвет дельта-бейджа в зависимости от типа виджета и направления изменения.
- *
- * P&L-конвенция: расходы < 0, доходы > 0.
- * income / profit: рост (+) = зелёный, падение (-) = красный
- * expense:         дельта < 0 → расходы выросли → красный; > 0 → зелёный
- */
 function getBadgeColor(type: WidgetType, delta: number): 'green' | 'red' | 'secondary' {
     if (delta === 0) {
         return 'secondary';
     }
-    const isPositive = delta > 0;
-    if (type === 'expense') {
-        return isPositive ? 'green' : 'red';
-    }
-    return isPositive ? 'green' : 'red';
+    return delta > 0 ? 'green' : 'red';
 }
 
 const WidgetCard: React.FC<WidgetCardProps> = ({

--- a/site/assets/react/marketplace-analytics/unit-extended/widgets/WidgetCard.tsx
+++ b/site/assets/react/marketplace-analytics/unit-extended/widgets/WidgetCard.tsx
@@ -25,8 +25,9 @@ function calcDeltaPercent(current: number, previous: number): number | null {
 /**
  * Цвет дельта-бейджа в зависимости от типа виджета и направления изменения.
  *
+ * P&L-конвенция: расходы < 0, доходы > 0.
  * income / profit: рост (+) = зелёный, падение (-) = красный
- * expense:         рост (+) = красный,  падение (-) = зелёный
+ * expense:         дельта < 0 → расходы выросли → красный; > 0 → зелёный
  */
 function getBadgeColor(type: WidgetType, delta: number): 'green' | 'red' | 'secondary' {
     if (delta === 0) {
@@ -34,7 +35,7 @@ function getBadgeColor(type: WidgetType, delta: number): 'green' | 'red' | 'seco
     }
     const isPositive = delta > 0;
     if (type === 'expense') {
-        return isPositive ? 'red' : 'green';
+        return isPositive ? 'green' : 'red';
     }
     return isPositive ? 'green' : 'red';
 }

--- a/site/src/MarketplaceAnalytics/Infrastructure/Query/WidgetSummaryQuery.php
+++ b/site/src/MarketplaceAnalytics/Infrastructure/Query/WidgetSummaryQuery.php
@@ -11,8 +11,8 @@ use Doctrine\DBAL\Connection;
 /**
  * Сводка для виджета MarketplaceAnalytics за период.
  *
- * Возвращает только итоговые числа и разбивку затрат по widgetGroup
- * (5 групп WidgetServiceGroupMap).
+ * Все суммы возвращаются в P&L-конвенции (как в Ozon ЛК):
+ *   доходы > 0, расходы < 0, profit = revenue + returnsTotal + costPriceTotal + totalCosts.
  *
  * Затраты берутся напрямую из marketplace_costs БЕЗ фильтра listing_id IS NOT NULL,
  * чтобы захватить категории, не привязанные к листингу (CPC, хранение, кросс-докинг и т.п.).
@@ -76,14 +76,13 @@ final readonly class WidgetSummaryQuery
             ];
         }
 
-        // Sales / returns — суммируем по всем листингам
         foreach ($sales as $sale) {
             $revenue += (float) $sale->revenue;
-            $costPriceTotal += (float) $sale->costPriceTotal;
+            $costPriceTotal -= (float) $sale->costPriceTotal;
         }
 
         foreach ($returns as $ret) {
-            $returnsTotal += (float) $ret->returnsTotal;
+            $returnsTotal -= (float) $ret->returnsTotal;
         }
 
         // Costs — плоский список категорий (без листингов).
@@ -133,8 +132,7 @@ final readonly class WidgetSummaryQuery
                 ];
             }
 
-            // Sort categories inside group by costsAmount DESC
-            usort($categories, static fn (array $a, array $b): int => $b['costsAmount'] <=> $a['costsAmount']);
+            usort($categories, static fn (array $a, array $b): int => $a['netAmount'] <=> $b['netAmount']);
 
             $netAmount = round($group['netAmount'], 2);
             $totalCosts += $netAmount;
@@ -148,14 +146,13 @@ final readonly class WidgetSummaryQuery
             ];
         }
 
-        // Sort widgetGroups by netAmount DESC
-        usort($widgetGroups, static fn (array $a, array $b): int => $b['netAmount'] <=> $a['netAmount']);
+        usort($widgetGroups, static fn (array $a, array $b): int => $a['netAmount'] <=> $b['netAmount']);
 
         $totalCosts = round($totalCosts, 2);
         $revenue = round($revenue, 2);
         $returnsTotal = round($returnsTotal, 2);
         $costPriceTotal = round($costPriceTotal, 2);
-        $profit = round($revenue - $returnsTotal - $costPriceTotal - $totalCosts, 2);
+        $profit = round($revenue + $returnsTotal + $costPriceTotal + $totalCosts, 2);
 
         $marginPercent = $revenue > 0 ? round($profit / $revenue * 100, 1) : null;
 
@@ -172,6 +169,7 @@ final readonly class WidgetSummaryQuery
 
     /**
      * Затраты по всем категориям за период — БЕЗ фильтра по listing_id.
+     * Суммы в P&L-конвенции: расходы < 0, сторно > 0.
      *
      * В отличие от ListingCostAggregateQuery (per-listing) сюда попадают
      * категории затрат с listing_id = NULL (CPC, хранение, кросс-докинг и т.п.).
@@ -199,13 +197,13 @@ final readonly class WidgetSummaryQuery
                 cc.name                                                       AS category_name,
                 SUM(CASE
                     WHEN (c.operation_type = 'storno')
-                    THEN -ABS(c.amount)
-                    ELSE ABS(c.amount)
+                    THEN ABS(c.amount)
+                    ELSE -ABS(c.amount)
                 END)                                                          AS net_amount,
                 SUM(CASE
                     WHEN (c.operation_type = 'storno')
                     THEN 0
-                    ELSE ABS(c.amount)
+                    ELSE -ABS(c.amount)
                 END)                                                          AS costs_amount,
                 SUM(CASE
                     WHEN (c.operation_type = 'storno')
@@ -219,7 +217,7 @@ final readonly class WidgetSummaryQuery
               AND c.cost_date <= :periodTo
               {$mpFilter}
             GROUP BY cc.code, cc.name
-            ORDER BY costs_amount DESC
+            ORDER BY costs_amount ASC
             SQL,
             array_filter([
                 'companyId'   => $companyId,

--- a/site/tests/MarketplaceAnalytics/Infrastructure/Query/WidgetSummaryQueryPnlTest.php
+++ b/site/tests/MarketplaceAnalytics/Infrastructure/Query/WidgetSummaryQueryPnlTest.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\MarketplaceAnalytics\Infrastructure\Query;
+
+use App\Marketplace\DTO\ListingReturnAggregateDTO;
+use App\Marketplace\DTO\ListingSalesAggregateDTO;
+use App\Marketplace\Facade\MarketplaceFacade;
+use App\MarketplaceAnalytics\Infrastructure\Query\WidgetSummaryQuery;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+
+final class WidgetSummaryQueryPnlTest extends TestCase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-111111111111';
+
+    private MarketplaceFacade $facade;
+    private Connection $connection;
+    private WidgetSummaryQuery $query;
+
+    protected function setUp(): void
+    {
+        $this->facade = $this->createMock(MarketplaceFacade::class);
+        $this->connection = $this->createMock(Connection::class);
+        $this->query = new WidgetSummaryQuery($this->facade, $this->connection);
+    }
+
+    public function testReturnsNegativeReturnsTotal(): void
+    {
+        $this->stubSales([
+            new ListingSalesAggregateDTO('l1', 'Product', 'SKU1', 'ozon', '1000.00', 5, '0.00', 0),
+        ]);
+        $this->stubReturns([
+            new ListingReturnAggregateDTO('l1', '200.00', 2),
+        ]);
+        $this->stubCostRows([]);
+
+        $result = $this->executeSummary();
+
+        self::assertSame(1000.0, $result['revenue']);
+        self::assertSame(-200.0, $result['returnsTotal']);
+    }
+
+    public function testReturnsNegativeCostPriceTotal(): void
+    {
+        $this->stubSales([
+            new ListingSalesAggregateDTO('l1', 'Product', 'SKU1', 'ozon', '5000.00', 10, '800.00', 10),
+        ]);
+        $this->stubReturns([]);
+        $this->stubCostRows([]);
+
+        $result = $this->executeSummary();
+
+        self::assertSame(5000.0, $result['revenue']);
+        self::assertSame(-800.0, $result['costPriceTotal']);
+    }
+
+    public function testCostGroupNetAmountIsNegative(): void
+    {
+        $this->stubSales([]);
+        $this->stubReturns([]);
+        $this->stubCostRows([
+            ['category_code' => 'ozon_sale_commission', 'category_name' => 'Комиссия', 'costs_amount' => '-500.00', 'storno_amount' => '0.00', 'net_amount' => '-500.00'],
+        ]);
+
+        $result = $this->executeSummary();
+
+        $group = $this->findGroup($result['widgetGroups'], 'Вознаграждение');
+        self::assertNotNull($group);
+        self::assertSame(-500.0, $group['netAmount']);
+        self::assertSame(-500.0, $group['costsAmount']);
+        self::assertSame(0.0, $group['stornoAmount']);
+    }
+
+    public function testStornoIsPositiveInPnl(): void
+    {
+        $this->stubSales([]);
+        $this->stubReturns([]);
+        $this->stubCostRows([
+            ['category_code' => 'ozon_sale_commission', 'category_name' => 'Комиссия', 'costs_amount' => '-1000.00', 'storno_amount' => '300.00', 'net_amount' => '-700.00'],
+        ]);
+
+        $result = $this->executeSummary();
+
+        $group = $this->findGroup($result['widgetGroups'], 'Вознаграждение');
+        self::assertNotNull($group);
+        self::assertSame(-700.0, $group['netAmount']);
+        self::assertSame(300.0, $group['stornoAmount']);
+    }
+
+    public function testProfitFormulaAddition(): void
+    {
+        $this->stubSales([
+            new ListingSalesAggregateDTO('l1', 'Товар', 'SKU1', 'ozon', '5000.00', 10, '1000.00', 10),
+        ]);
+        $this->stubReturns([
+            new ListingReturnAggregateDTO('l1', '200.00', 1),
+        ]);
+        $this->stubCostRows([
+            ['category_code' => 'ozon_sale_commission', 'category_name' => 'Комиссия', 'costs_amount' => '-800.00', 'storno_amount' => '0.00', 'net_amount' => '-800.00'],
+            ['category_code' => 'ozon_logistic_direct', 'category_name' => 'FBO', 'costs_amount' => '-500.00', 'storno_amount' => '100.00', 'net_amount' => '-400.00'],
+        ]);
+
+        $result = $this->executeSummary();
+
+        // revenue=5000, returnsTotal=-200, costPriceTotal=-1000, totalCosts=-1200
+        // profit = 5000 + (-200) + (-1000) + (-1200) = 2600
+        self::assertSame(5000.0, $result['revenue']);
+        self::assertSame(-200.0, $result['returnsTotal']);
+        self::assertSame(-1000.0, $result['costPriceTotal']);
+        self::assertSame(-1200.0, $result['totalCosts']);
+        self::assertSame(2600.0, $result['profit']);
+    }
+
+    public function testMarginPercentCalculation(): void
+    {
+        $this->stubSales([
+            new ListingSalesAggregateDTO('l1', 'T', 'S', 'ozon', '10000.00', 10, '2000.00', 10),
+        ]);
+        $this->stubReturns([]);
+        $this->stubCostRows([
+            ['category_code' => 'ozon_sale_commission', 'category_name' => 'K', 'costs_amount' => '-3000.00', 'storno_amount' => '0.00', 'net_amount' => '-3000.00'],
+        ]);
+
+        $result = $this->executeSummary();
+
+        // profit = 10000 + 0 + (-2000) + (-3000) = 5000
+        // margin = 5000 / 10000 * 100 = 50.0
+        self::assertSame(5000.0, $result['profit']);
+        self::assertSame(50.0, $result['marginPercent']);
+    }
+
+    public function testEmptyDataReturnsZeros(): void
+    {
+        $this->stubSales([]);
+        $this->stubReturns([]);
+        $this->stubCostRows([]);
+
+        $result = $this->executeSummary();
+
+        self::assertSame(0.0, $result['revenue']);
+        self::assertSame(0.0, $result['returnsTotal']);
+        self::assertSame(0.0, $result['costPriceTotal']);
+        self::assertSame(0.0, $result['totalCosts']);
+        self::assertSame(0.0, $result['profit']);
+        self::assertNull($result['marginPercent']);
+    }
+
+    public function testWidgetGroupsSortedByNetAmountAscending(): void
+    {
+        $this->stubSales([]);
+        $this->stubReturns([]);
+        $this->stubCostRows([
+            ['category_code' => 'ozon_sale_commission', 'category_name' => 'Комиссия', 'costs_amount' => '-300.00', 'storno_amount' => '0.00', 'net_amount' => '-300.00'],
+            ['category_code' => 'ozon_logistic_direct', 'category_name' => 'FBO', 'costs_amount' => '-700.00', 'storno_amount' => '0.00', 'net_amount' => '-700.00'],
+            ['category_code' => 'ozon_cpc', 'category_name' => 'Реклама', 'costs_amount' => '-100.00', 'storno_amount' => '0.00', 'net_amount' => '-100.00'],
+        ]);
+
+        $result = $this->executeSummary();
+
+        $groupNames = array_map(
+            static fn (array $g): string => $g['serviceGroup'],
+            array_filter($result['widgetGroups'], static fn (array $g): bool => $g['netAmount'] !== 0.0),
+        );
+        $groupNames = array_values($groupNames);
+
+        self::assertSame('Услуги доставки и FBO', $groupNames[0]);
+        self::assertSame('Вознаграждение', $groupNames[1]);
+        self::assertSame('Продвижение и реклама', $groupNames[2]);
+    }
+
+    public function testCompensationStornoBecomesPositiveNet(): void
+    {
+        $this->stubSales([]);
+        $this->stubReturns([]);
+        $this->stubCostRows([
+            ['category_code' => 'ozon_compensation', 'category_name' => 'Компенсация', 'costs_amount' => '0.00', 'storno_amount' => '1799.00', 'net_amount' => '1799.00'],
+        ]);
+
+        $result = $this->executeSummary();
+
+        $group = $this->findGroup($result['widgetGroups'], 'Другие услуги и штрафы');
+        self::assertNotNull($group);
+        self::assertSame(1799.0, $group['netAmount']);
+
+        $cat = $group['categories'][0] ?? null;
+        self::assertNotNull($cat);
+        self::assertSame('ozon_compensation', $cat['code']);
+        self::assertSame(1799.0, $cat['netAmount']);
+    }
+
+    /**
+     * @param list<ListingSalesAggregateDTO> $sales
+     */
+    private function stubSales(array $sales): void
+    {
+        $keyed = [];
+        foreach ($sales as $s) {
+            $keyed[$s->listingId] = $s;
+        }
+        $this->facade->method('getSalesAggregatesByListing')->willReturn($keyed);
+    }
+
+    /**
+     * @param list<ListingReturnAggregateDTO> $returns
+     */
+    private function stubReturns(array $returns): void
+    {
+        $keyed = [];
+        foreach ($returns as $r) {
+            $keyed[$r->listingId] = $r;
+        }
+        $this->facade->method('getReturnAggregatesByListing')->willReturn($keyed);
+    }
+
+    /**
+     * @param list<array{category_code: string, category_name: string, costs_amount: string, storno_amount: string, net_amount: string}> $rows
+     */
+    private function stubCostRows(array $rows): void
+    {
+        $this->connection->method('fetchAllAssociative')->willReturn($rows);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function executeSummary(): array
+    {
+        return $this->query->getSummary(
+            self::COMPANY_ID,
+            'ozon',
+            new \DateTimeImmutable('2026-01-01'),
+            new \DateTimeImmutable('2026-01-31'),
+        );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $widgetGroups
+     * @return array<string, mixed>|null
+     */
+    private function findGroup(array $widgetGroups, string $serviceGroup): ?array
+    {
+        foreach ($widgetGroups as $g) {
+            if ($g['serviceGroup'] === $serviceGroup) {
+                return $g;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
Инвертированы знаки expense-групп на P&L-нотацию (как в Ozon ЛК). Расходы теперь с минусом, доходы с плюсом. Прибыль не изменилась.

### Изменения
- **WidgetSummaryQuery.php** — SQL инвертирован: CHARGE → `-ABS(amount)`, STORNO → `+ABS(amount)`. `returnsTotal` и `costPriceTotal` со знаком минус. Формула прибыли: `revenue + returnsTotal + costPriceTotal + totalCosts`
- **WidgetCard.tsx** — `getBadgeColor` для expense: положительная дельта (расходы уменьшились) = зелёный, отрицательная (выросли) = красный
- **WidgetSummaryQueryPnlTest.php** — 9 unit-тестов на P&L-конвенцию

## Test plan
- [x] 9 новых unit-тестов — все зелёные
- [ ] Ручная проверка виджета «Unit — расширенный» на проде: знаки совпадают с Ozon ЛК

https://claude.ai/code/session_01DbWXqVzeEDYjBWRezW6sm7