### PR TITLE
feat(marketplace-analytics): debug endpoint for revenue reconciliation

### DIFF
--- a/site/src/MarketplaceAnalytics/Controller/Api/DebugRevenueReconciliationController.php
+++ b/site/src/MarketplaceAnalytics/Controller/Api/DebugRevenueReconciliationController.php
@@ -42,8 +42,8 @@ final class DebugRevenueReconciliationController extends AbstractController
     {
         $periodStr = (string) $request->query->get('period', '');
 
-        if ($periodStr === '' || preg_match('/^\d{4}-\d{2}$/', $periodStr) !== 1) {
-            return $this->json(['error' => 'period is required in Y-m format (e.g. 2026-02)'], 422);
+        if ($periodStr === '' || preg_match('/^\d{4}-(0[1-9]|1[0-2])$/', $periodStr) !== 1) {
+            return $this->json(['error' => 'period is required in Y-m format with month 01-12 (e.g. 2026-02)'], 422);
         }
 
         try {
@@ -52,10 +52,9 @@ final class DebugRevenueReconciliationController extends AbstractController
             return $this->json(['error' => 'Invalid period value'], 422);
         }
 
-        $periodTo     = $periodFrom->modify('last day of this month');
-        $nextDay1     = $periodTo->modify('+1 day');
-        $nextDay2     = $periodTo->modify('+2 days');
+        $periodTo      = $periodFrom->modify('last day of this month');
         $breakdownFrom = $periodTo->modify('-2 days');
+        $breakdownTo   = $periodTo->modify('+2 days');
 
         $company   = $this->activeCompanyService->getActiveCompany();
         $companyId = (string) $company->getId();
@@ -69,7 +68,7 @@ final class DebugRevenueReconciliationController extends AbstractController
             'total_revenue'    => $this->fetchTotalRevenue($companyId, $periodFrom, $periodTo),
             'orphan_rows'      => $this->fetchOrphanRows($companyId, $periodFrom, $periodTo),
             'duplicates'       => $this->fetchDuplicates($companyId, $periodFrom, $periodTo),
-            'daily_breakdown'  => $this->fetchDailyBreakdown($companyId, $breakdownFrom, $nextDay2),
+            'daily_breakdown'  => $this->fetchDailyBreakdown($companyId, $breakdownFrom, $breakdownTo),
             'raw_documents'    => $this->fetchRawDocuments($companyId, $periodFrom, $periodTo),
         ]);
     }
@@ -184,6 +183,8 @@ final class DebugRevenueReconciliationController extends AbstractController
 
     /**
      * Дневная разбивка по sale_date (accrual_date) для выбранного диапазона.
+     * Дни без продаж возвращаются с count=0/sum=0, чтобы оператор мог отличить
+     * «нет данных за день» от «день не попал в выборку».
      *
      * @return list<array{accrual_date: string, count: int, sum: string}>
      */
@@ -204,7 +205,6 @@ final class DebugRevenueReconciliationController extends AbstractController
               AND s.sale_date  >= :periodFrom
               AND s.sale_date  <= :periodTo
             GROUP BY s.sale_date
-            ORDER BY s.sale_date
             SQL,
             [
                 'companyId'  => $companyId,
@@ -213,14 +213,27 @@ final class DebugRevenueReconciliationController extends AbstractController
             ],
         );
 
-        return array_map(
-            static fn (array $r): array => [
-                'accrual_date' => (string) $r['accrual_date'],
-                'count'        => (int) $r['cnt'],
-                'sum'          => (string) ($r['total'] ?? '0'),
-            ],
-            $rows,
-        );
+        $byDate = [];
+        foreach ($rows as $r) {
+            $byDate[(string) $r['accrual_date']] = [
+                'count' => (int) $r['cnt'],
+                'sum'   => (string) ($r['total'] ?? '0'),
+            ];
+        }
+
+        $result = [];
+        $cursor = $from;
+        while ($cursor <= $to) {
+            $date = $cursor->format('Y-m-d');
+            $result[] = [
+                'accrual_date' => $date,
+                'count'        => $byDate[$date]['count'] ?? 0,
+                'sum'          => $byDate[$date]['sum'] ?? '0',
+            ];
+            $cursor = $cursor->modify('+1 day');
+        }
+
+        return $result;
     }
 
     /**

--- a/site/src/MarketplaceAnalytics/Controller/Api/DebugRevenueReconciliationController.php
+++ b/site/src/MarketplaceAnalytics/Controller/Api/DebugRevenueReconciliationController.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAnalytics\Controller\Api;
+
+use App\Shared\Service\ActiveCompanyService;
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Временный debug-endpoint для диагностики расхождения выручки
+ * (SUM(total_revenue) по marketplace_sales vs данные в ЛК Ozon).
+ *
+ * Маппинг терминологии Ozon → DB:
+ *   amount          → marketplace_sales.total_revenue
+ *   posting_number  → marketplace_sales.external_order_id
+ *   accrual_date    → marketplace_sales.sale_date
+ *
+ * Использование:
+ *   GET /api/marketplace-analytics/debug/revenue-reconciliation?period=2026-02
+ */
+#[Route(
+    path: '/api/marketplace-analytics/debug/revenue-reconciliation',
+    name: 'api_marketplace_analytics_debug_revenue_reconciliation',
+    methods: ['GET'],
+)]
+#[IsGranted('ROLE_COMPANY_USER')]
+final class DebugRevenueReconciliationController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $activeCompanyService,
+        private readonly Connection $connection,
+    ) {
+    }
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        $periodStr = (string) $request->query->get('period', '');
+
+        if ($periodStr === '' || preg_match('/^\d{4}-\d{2}$/', $periodStr) !== 1) {
+            return $this->json(['error' => 'period is required in Y-m format (e.g. 2026-02)'], 422);
+        }
+
+        try {
+            $periodFrom = new \DateTimeImmutable($periodStr . '-01');
+        } catch (\Exception) {
+            return $this->json(['error' => 'Invalid period value'], 422);
+        }
+
+        $periodTo     = $periodFrom->modify('last day of this month');
+        $nextDay1     = $periodTo->modify('+1 day');
+        $nextDay2     = $periodTo->modify('+2 days');
+        $breakdownFrom = $periodTo->modify('-2 days');
+
+        $company   = $this->activeCompanyService->getActiveCompany();
+        $companyId = (string) $company->getId();
+
+        return new JsonResponse([
+            'period' => [
+                'value' => $periodStr,
+                'from'  => $periodFrom->format('Y-m-d'),
+                'to'    => $periodTo->format('Y-m-d'),
+            ],
+            'total_revenue'    => $this->fetchTotalRevenue($companyId, $periodFrom, $periodTo),
+            'orphan_rows'      => $this->fetchOrphanRows($companyId, $periodFrom, $periodTo),
+            'duplicates'       => $this->fetchDuplicates($companyId, $periodFrom, $periodTo),
+            'daily_breakdown'  => $this->fetchDailyBreakdown($companyId, $breakdownFrom, $nextDay2),
+            'raw_documents'    => $this->fetchRawDocuments($companyId, $periodFrom, $periodTo),
+        ]);
+    }
+
+    /**
+     * @return array{count: int, sum: string}
+     */
+    private function fetchTotalRevenue(
+        string $companyId,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+    ): array {
+        $row = $this->connection->fetchAssociative(
+            <<<'SQL'
+            SELECT
+                COUNT(*)                          AS cnt,
+                COALESCE(SUM(s.total_revenue), 0) AS total
+            FROM marketplace_sales s
+            WHERE s.company_id  = :companyId
+              AND s.marketplace = 'ozon'
+              AND s.sale_date  >= :periodFrom
+              AND s.sale_date  <= :periodTo
+            SQL,
+            [
+                'companyId'  => $companyId,
+                'periodFrom' => $from->format('Y-m-d'),
+                'periodTo'   => $to->format('Y-m-d'),
+            ],
+        );
+
+        return [
+            'count' => (int) ($row['cnt'] ?? 0),
+            'sum'   => (string) ($row['total'] ?? '0'),
+        ];
+    }
+
+    /**
+     * @return array{count: int, sum: string}
+     */
+    private function fetchOrphanRows(
+        string $companyId,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+    ): array {
+        $row = $this->connection->fetchAssociative(
+            <<<'SQL'
+            SELECT
+                COUNT(*)                          AS cnt,
+                COALESCE(SUM(s.total_revenue), 0) AS total
+            FROM marketplace_sales s
+            WHERE s.company_id      = :companyId
+              AND s.marketplace    = 'ozon'
+              AND s.sale_date     >= :periodFrom
+              AND s.sale_date     <= :periodTo
+              AND s.raw_document_id IS NULL
+            SQL,
+            [
+                'companyId'  => $companyId,
+                'periodFrom' => $from->format('Y-m-d'),
+                'periodTo'   => $to->format('Y-m-d'),
+            ],
+        );
+
+        return [
+            'count' => (int) ($row['cnt'] ?? 0),
+            'sum'   => (string) ($row['total'] ?? '0'),
+        ];
+    }
+
+    /**
+     * posting_number (external_order_id) с COUNT > 1 — первые 20 шт.
+     *
+     * @return list<array{posting_number: string, count: int, sum: string}>
+     */
+    private function fetchDuplicates(
+        string $companyId,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+    ): array {
+        $rows = $this->connection->fetchAllAssociative(
+            <<<'SQL'
+            SELECT
+                s.external_order_id               AS posting_number,
+                COUNT(*)                          AS cnt,
+                COALESCE(SUM(s.total_revenue), 0) AS total
+            FROM marketplace_sales s
+            WHERE s.company_id  = :companyId
+              AND s.marketplace = 'ozon'
+              AND s.sale_date  >= :periodFrom
+              AND s.sale_date  <= :periodTo
+            GROUP BY s.external_order_id
+            HAVING COUNT(*) > 1
+            ORDER BY COUNT(*) DESC, s.external_order_id
+            LIMIT 20
+            SQL,
+            [
+                'companyId'  => $companyId,
+                'periodFrom' => $from->format('Y-m-d'),
+                'periodTo'   => $to->format('Y-m-d'),
+            ],
+        );
+
+        return array_map(
+            static fn (array $r): array => [
+                'posting_number' => (string) $r['posting_number'],
+                'count'          => (int) $r['cnt'],
+                'sum'            => (string) ($r['total'] ?? '0'),
+            ],
+            $rows,
+        );
+    }
+
+    /**
+     * Дневная разбивка по sale_date (accrual_date) для выбранного диапазона.
+     *
+     * @return list<array{accrual_date: string, count: int, sum: string}>
+     */
+    private function fetchDailyBreakdown(
+        string $companyId,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+    ): array {
+        $rows = $this->connection->fetchAllAssociative(
+            <<<'SQL'
+            SELECT
+                s.sale_date::text                 AS accrual_date,
+                COUNT(*)                          AS cnt,
+                COALESCE(SUM(s.total_revenue), 0) AS total
+            FROM marketplace_sales s
+            WHERE s.company_id  = :companyId
+              AND s.marketplace = 'ozon'
+              AND s.sale_date  >= :periodFrom
+              AND s.sale_date  <= :periodTo
+            GROUP BY s.sale_date
+            ORDER BY s.sale_date
+            SQL,
+            [
+                'companyId'  => $companyId,
+                'periodFrom' => $from->format('Y-m-d'),
+                'periodTo'   => $to->format('Y-m-d'),
+            ],
+        );
+
+        return array_map(
+            static fn (array $r): array => [
+                'accrual_date' => (string) $r['accrual_date'],
+                'count'        => (int) $r['cnt'],
+                'sum'          => (string) ($r['total'] ?? '0'),
+            ],
+            $rows,
+        );
+    }
+
+    /**
+     * raw_document_id → количество строк marketplace_sales за период,
+     * привязанных к этому документу.
+     *
+     * @return list<array{raw_document_id: string|null, count: int, sum: string}>
+     */
+    private function fetchRawDocuments(
+        string $companyId,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+    ): array {
+        $rows = $this->connection->fetchAllAssociative(
+            <<<'SQL'
+            SELECT
+                s.raw_document_id                 AS raw_document_id,
+                COUNT(*)                          AS cnt,
+                COALESCE(SUM(s.total_revenue), 0) AS total
+            FROM marketplace_sales s
+            WHERE s.company_id  = :companyId
+              AND s.marketplace = 'ozon'
+              AND s.sale_date  >= :periodFrom
+              AND s.sale_date  <= :periodTo
+            GROUP BY s.raw_document_id
+            ORDER BY COUNT(*) DESC, s.raw_document_id NULLS LAST
+            SQL,
+            [
+                'companyId'  => $companyId,
+                'periodFrom' => $from->format('Y-m-d'),
+                'periodTo'   => $to->format('Y-m-d'),
+            ],
+        );
+
+        return array_map(
+            static fn (array $r): array => [
+                'raw_document_id' => $r['raw_document_id'] !== null ? (string) $r['raw_document_id'] : null,
+                'count'           => (int) $r['cnt'],
+                'sum'             => (string) ($r['total'] ?? '0'),
+            ],
+            $rows,
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `GET /api/marketplace-analytics/debug/revenue-reconciliation?period=Y-m` to diagnose Ozon revenue discrepancies against LK Ozon.
- Returns `total_revenue`, `orphan_rows` (no `raw_document_id`), `duplicates` (top-20 posting_number with COUNT>1), `daily_breakdown` (last 3 days of period + first 2 of next month), and per-`raw_document_id` aggregates.
- Uses `ActiveCompanyService`, filters by `marketplace = 'ozon'`.

## Terminology mapping (Ozon → DB)
`marketplace_sales` has no `amount` / `posting_number` / `accrual_date` columns. The controller maps:
- `amount` → `total_revenue`
- `posting_number` → `external_order_id` (for Ozon these are identical — see `OzonSalesRawProcessor.php:135`)
- `accrual_date` → `sale_date`

JSON response keys use the requested Ozon terminology for readability.

## Test plan
- [ ] `GET /api/marketplace-analytics/debug/revenue-reconciliation?period=2026-02` returns 200 with all 5 sections for an authenticated company user.
- [ ] Missing/invalid `period` returns 422.
- [ ] Verify SUM matches direct SQL against `marketplace_sales` for a known company.
- [ ] Confirm `daily_breakdown` covers Feb 26/27/28 + Mar 01/02 for `period=2026-02`.

https://claude.ai/code/session_01R2jQxMrcgCnQqX7r4twuJi