### PR TITLE
fix: route OperationAgentStornoDeliveredToCustomer в sales

### DIFF
--- a/site/src/Marketplace/Application/Processor/OzonCostsRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonCostsRawProcessor.php
@@ -382,8 +382,12 @@ final class OzonCostsRawProcessor implements MarketplaceRawProcessorInterface
             $opAmount  = abs($rawAmount);
             $opType    = $op['type'] ?? '';
 
-            // Пропускаем только продажи (не затраты)
-            if ($opAmount > 0.001 && $opType !== 'orders') {
+            // Пропускаем продажи и сторно продаж (выручка учитывается в sales, не в costs)
+            $opOperationType = $op['operation_type'] ?? '';
+            if ($opAmount > 0.001
+                && $opType !== 'orders'
+                && $opOperationType !== 'OperationAgentStornoDeliveredToCustomer'
+            ) {
                 if ($opType === 'compensation') {
                     // Компенсации: разделяем по знаку исходного amount на две разные категории.
                     // rawAmount >= 0 = компенсация от Ozon (доход продавца) → ozon_compensation → STORNO

--- a/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
@@ -90,8 +90,15 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
         }
 
         $salesData = array_filter($rawRows, static function (array $op): bool {
-            return ($op['type'] ?? '') === 'orders'
-                && (float) ($op['accruals_for_sale'] ?? 0) != 0;
+            if ((float) ($op['accruals_for_sale'] ?? 0) == 0) {
+                return false;
+            }
+
+            $type = $op['type'] ?? '';
+            $operationType = $op['operation_type'] ?? '';
+
+            return $type === 'orders'
+                || $operationType === 'OperationAgentStornoDeliveredToCustomer';
         });
 
         if (empty($salesData)) {

--- a/site/src/Marketplace/Infrastructure/Normalizer/Ozon/OzonReportRowClassifier.php
+++ b/site/src/Marketplace/Infrastructure/Normalizer/Ozon/OzonReportRowClassifier.php
@@ -29,10 +29,15 @@ final readonly class OzonReportRowClassifier implements RowClassifierInterface
 
         // returns:
         // ClientReturnAgentOperation = реальный возврат товара покупателем → RETURN
+        // OperationAgentStornoDeliveredToCustomer = сторно начисления продажи → SALE
         // OperationItemReturn = затраты на обработку возврата (логистика) → COST
         if ($type === 'returns') {
             if ($operationType === 'ClientReturnAgentOperation') {
                 return StagingRecordType::RETURN;
+            }
+
+            if ($operationType === 'OperationAgentStornoDeliveredToCustomer') {
+                return StagingRecordType::SALE;
             }
 
             return StagingRecordType::COST;

--- a/site/tests/Unit/Marketplace/Application/Processor/OzonCostsRawProcessorTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/OzonCostsRawProcessorTest.php
@@ -385,6 +385,62 @@ final class OzonCostsRawProcessorTest extends TestCase
         }
     }
 
+    /**
+     * OperationAgentStornoDeliveredToCustomer (сторно продажи) — НЕ должна создавать
+     * _main cost entry, т.к. выручка учитывается в OzonSalesRawProcessor.
+     * Commission/delivery storno обрабатываются отдельными полями и не затрагиваются.
+     */
+    public function testStornoDeliveredToCustomerProducesNoMainEntry(): void
+    {
+        $entries = $this->extractEntries([
+            'operation_id'           => '2001',
+            'operation_type'         => 'OperationAgentStornoDeliveredToCustomer',
+            'operation_type_name'    => 'Сторно доставки покупателю',
+            'operation_date'         => '2026-02-16 12:00:00',
+            'sale_commission'        => 0,
+            'delivery_charge'        => 0,
+            'return_delivery_charge' => 0,
+            'amount'                 => -1201.00,
+            'accruals_for_sale'      => -1201.00,
+            'type'                   => 'returns',
+            'items'                  => [['sku' => '444', 'name' => 'Товар']],
+            'services'               => [],
+        ]);
+
+        $mainEntry = array_filter($entries, static fn (array $e) => str_ends_with($e['external_id'], '_main'));
+        self::assertEmpty($mainEntry, 'Сторно продажи не должно создавать _main cost entry');
+    }
+
+    /**
+     * OperationAgentStornoDeliveredToCustomer with commission refund —
+     * commission storno SHOULD still be extracted as a separate cost entry.
+     */
+    public function testStornoDeliveredToCustomerStillExtractsCommission(): void
+    {
+        $entries = $this->extractEntries([
+            'operation_id'           => '2002',
+            'operation_type'         => 'OperationAgentStornoDeliveredToCustomer',
+            'operation_type_name'    => 'Сторно доставки покупателю',
+            'operation_date'         => '2026-02-16 12:00:00',
+            'sale_commission'        => 150.00,
+            'delivery_charge'        => 0,
+            'return_delivery_charge' => 0,
+            'amount'                 => -1051.00,
+            'accruals_for_sale'      => -1201.00,
+            'type'                   => 'returns',
+            'items'                  => [['sku' => '444', 'name' => 'Товар']],
+            'services'               => [],
+        ]);
+
+        $commission = $this->findEntry($entries, 'ozon_sale_commission');
+        self::assertNotNull($commission, 'Возврат комиссии при сторно должен создать запись');
+        self::assertEqualsWithDelta(150.00, (float) $commission['amount'], 0.001);
+        self::assertSame(MarketplaceCostOperationType::STORNO, $commission['operation_type']);
+
+        $mainEntry = array_filter($entries, static fn (array $e) => str_ends_with($e['external_id'], '_main'));
+        self::assertEmpty($mainEntry, 'Сторно продажи не должно создавать _main cost entry даже с комиссией');
+    }
+
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------

--- a/site/tests/Unit/Marketplace/Infrastructure/OzonReportRowClassifierTest.php
+++ b/site/tests/Unit/Marketplace/Infrastructure/OzonReportRowClassifierTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Infrastructure;
+
+use App\Marketplace\Enum\StagingRecordType;
+use App\Marketplace\Infrastructure\Normalizer\Ozon\OzonReportRowClassifier;
+use PHPUnit\Framework\TestCase;
+
+final class OzonReportRowClassifierTest extends TestCase
+{
+    private OzonReportRowClassifier $classifier;
+
+    protected function setUp(): void
+    {
+        $this->classifier = new OzonReportRowClassifier();
+    }
+
+    public function testOrdersClassifiedAsSale(): void
+    {
+        $row = ['type' => 'orders', 'operation_type' => 'OperationAgentDeliveredToCustomer'];
+
+        self::assertSame(StagingRecordType::SALE, $this->classifier->classify($row));
+    }
+
+    public function testClientReturnClassifiedAsReturn(): void
+    {
+        $row = ['type' => 'returns', 'operation_type' => 'ClientReturnAgentOperation'];
+
+        self::assertSame(StagingRecordType::RETURN, $this->classifier->classify($row));
+    }
+
+    public function testStornoDeliveredToCustomerClassifiedAsSale(): void
+    {
+        $row = ['type' => 'returns', 'operation_type' => 'OperationAgentStornoDeliveredToCustomer'];
+
+        self::assertSame(StagingRecordType::SALE, $this->classifier->classify($row));
+    }
+
+    public function testOperationItemReturnClassifiedAsCost(): void
+    {
+        $row = ['type' => 'returns', 'operation_type' => 'OperationItemReturn'];
+
+        self::assertSame(StagingRecordType::COST, $this->classifier->classify($row));
+    }
+
+    public function testServicesClassifiedAsCost(): void
+    {
+        $row = ['type' => 'services', 'operation_type' => 'OperationMarketplaceServiceStorage'];
+
+        self::assertSame(StagingRecordType::COST, $this->classifier->classify($row));
+    }
+
+    public function testCompensationClassifiedAsCost(): void
+    {
+        $row = ['type' => 'compensation', 'operation_type' => 'MarketplaceSellerCompensationOperation'];
+
+        self::assertSame(StagingRecordType::COST, $this->classifier->classify($row));
+    }
+
+    public function testOtherClassifiedAsCost(): void
+    {
+        $row = ['type' => 'other', 'operation_type' => 'OperationMarketplaceCostPerClick'];
+
+        self::assertSame(StagingRecordType::COST, $this->classifier->classify($row));
+    }
+
+    public function testUnknownTypeClassifiedAsOther(): void
+    {
+        $row = ['type' => 'unknown', 'operation_type' => ''];
+
+        self::assertSame(StagingRecordType::OTHER, $this->classifier->classify($row));
+    }
+}


### PR DESCRIPTION
## Summary

- **Баг:** операция `OperationAgentStornoDeliveredToCustomer` (сторно доставки — отмена начисления продажи) с `type='returns'` и `accruals_for_sale < 0` классифицировалась как COST вместо SALE. Выручка не уменьшалась на сумму сторно, что давало расхождение с отчётом Ozon «Начисления» (+2 402 ₽ у Сухоносова за февраль 2026)
- **Classifier:** добавлен маршрут `OperationAgentStornoDeliveredToCustomer` → SALE bucket (до fallback на COST)
- **Sales processor:** фильтр расширен — принимает не только `type='orders'`, но и `operation_type='OperationAgentStornoDeliveredToCustomer'`. Существующая `_storno`-логика (суффикс + отрицательный `total_revenue`) работает без изменений
- **Costs processor:** `_main` fallback исключает `OperationAgentStornoDeliveredToCustomer` (предотвращает двойной учёт). Commission/delivery storno по-прежнему извлекаются отдельными entries

## Test plan

- [x] `php bin/phpunit tests/Unit/Marketplace/` — 86 tests, 0 failures
- [ ] Переобработать данные Сухоносова за февраль 2026, проверить что `sales.total_revenue` сошлась с отчётом Ozon
- [ ] Проверить через `/api/debug/sales-breakdown?marketplace=ozon&from=2026-02-01&to=2026-02-28&format=summary` что `breakdown_by_external_id_pattern.storno` содержит ожидаемые −2 402 ₽
- [ ] Убедиться что `marketplace_costs` не содержит `_main` записей для `OperationAgentStornoDeliveredToCustomer`

### Новые тесты

- `OzonReportRowClassifierTest` — 8 кейсов, все ветки classify() включая storno
- `OzonCostsRawProcessorTest` — 2 кейса: storno без `_main` entry + storno с commission (commission извлекается, `_main` нет)

https://claude.ai/code/session_01GSjUdUM3e6CTqMRF6dLgcy