### PR TITLE
feat: version external_order_id for repeated sales after storno

### DIFF
--- a/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
@@ -137,31 +137,56 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
             // existingMap строится ПОСЛЕ cleanup — иначе только что удалённые
             // external_id попадут в карту и insert-цикл ошибочно пропустит их
             // как «уже существующие», оставляя пустоты в marketplace_sales.
-            $allExternalIds = array_values(array_map(
-                static function (array $op): string {
-                    $postingNumber = $op['posting']['posting_number'] ?? '';
-                    $externalId = $postingNumber !== '' ? $postingNumber : (string) ($op['operation_id'] ?? '');
-                    // Storno operations get a suffix to avoid UNIQUE constraint conflict
-                    if ((float) ($op['accruals_for_sale'] ?? 0) < 0) {
-                        $externalId .= '_storno';
-                    }
-                    return $externalId;
-                },
-                $salesData,
-            ));
-            $existingMap = $this->saleRepository->getExistingExternalIds($companyId, $allExternalIds);
 
+            // Сортируем по operation_date ASC для корректного назначения версий
+            // при повторных продажах (sale → storno → re-sale по одному posting_number).
+            usort($salesData, static fn (array $a, array $b): int => ($a['operation_date'] ?? '') <=> ($b['operation_date'] ?? ''));
+
+            // Вычисляем базовые ключи (без версий) для предварительной загрузки existingMap
+            $baseKeys = [];
             foreach ($salesData as $op) {
                 $postingNumber = $op['posting']['posting_number'] ?? '';
-                $externalId = $postingNumber !== '' ? $postingNumber : (string) ($op['operation_id'] ?? '');
+                $baseKey = $postingNumber !== '' ? $postingNumber : (string) ($op['operation_id'] ?? '');
+                if ((float) ($op['accruals_for_sale'] ?? 0) < 0) {
+                    $baseKey .= '_storno';
+                }
+                $baseKeys[] = $baseKey;
+            }
+            $existingMap = $this->saleRepository->getExistingExternalIds($companyId, array_values(array_unique($baseKeys)));
+
+            // Назначаем версионные externalId с учётом existingMap и повторов внутри батча.
+            // Счётчик для каждого baseKey стартует с учётом уже занятых версий в БД.
+            $counters = [];
+            $computedIds = [];
+            foreach ($salesData as $i => $op) {
+                $postingNumber = $op['posting']['posting_number'] ?? '';
+                $baseKey = $postingNumber !== '' ? $postingNumber : (string) ($op['operation_id'] ?? '');
+                if ((float) ($op['accruals_for_sale'] ?? 0) < 0) {
+                    $baseKey .= '_storno';
+                }
+
+                if (!isset($counters[$baseKey])) {
+                    $counters[$baseKey] = isset($existingMap[$baseKey]) ? 1 : 0;
+                }
+
+                $counters[$baseKey]++;
+                $computedIds[$i] = $counters[$baseKey] > 1
+                    ? $baseKey . '_v' . $counters[$baseKey]
+                    : $baseKey;
+            }
+
+            // Проверяем версионные ключи _v2, _v3... на существование в БД
+            $versionedKeys = array_filter($computedIds, static fn (string $id): bool => str_contains($id, '_v'));
+            if ($versionedKeys !== []) {
+                $versionedExisting = $this->saleRepository->getExistingExternalIds($companyId, array_values(array_unique($versionedKeys)));
+                $existingMap = array_merge($existingMap, $versionedExisting);
+            }
+
+            foreach ($salesData as $i => $op) {
+                $externalId = $computedIds[$i];
 
                 $accrual  = (float) ($op['accruals_for_sale'] ?? 0);
                 $isStorno = $accrual < 0;
-
-                // Storno operations get a suffix to avoid UNIQUE constraint conflict
-                if ($isStorno) {
-                    $externalId .= '_storno';
-                }
 
                 if ($externalId === '' || isset($existingMap[$externalId])) {
                     continue;

--- a/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
@@ -142,28 +142,22 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
             // при повторных продажах (sale → storno → re-sale по одному posting_number).
             usort($salesData, static fn (array $a, array $b): int => ($a['operation_date'] ?? '') <=> ($b['operation_date'] ?? ''));
 
-            // Вычисляем базовые ключи (без версий) для предварительной загрузки existingMap
-            $baseKeys = [];
-            foreach ($salesData as $op) {
-                $postingNumber = $op['posting']['posting_number'] ?? '';
-                $baseKey = $postingNumber !== '' ? $postingNumber : (string) ($op['operation_id'] ?? '');
-                if ((float) ($op['accruals_for_sale'] ?? 0) < 0) {
-                    $baseKey .= '_storno';
-                }
-                $baseKeys[] = $baseKey;
-            }
-            $existingMap = $this->saleRepository->getExistingExternalIds($companyId, array_values(array_unique($baseKeys)));
-
-            // Назначаем версионные externalId с учётом existingMap и повторов внутри батча.
-            // Счётчик для каждого baseKey стартует с учётом уже занятых версий в БД.
-            $counters = [];
-            $computedIds = [];
+            $baseKeysMap = [];
             foreach ($salesData as $i => $op) {
                 $postingNumber = $op['posting']['posting_number'] ?? '';
                 $baseKey = $postingNumber !== '' ? $postingNumber : (string) ($op['operation_id'] ?? '');
                 if ((float) ($op['accruals_for_sale'] ?? 0) < 0) {
                     $baseKey .= '_storno';
                 }
+                $baseKeysMap[$i] = $baseKey;
+            }
+
+            $existingMap = $this->saleRepository->getExistingExternalIds($companyId, array_values(array_unique($baseKeysMap)));
+
+            $counters = [];
+            $computedIds = [];
+            foreach ($salesData as $i => $op) {
+                $baseKey = $baseKeysMap[$i];
 
                 if (!isset($counters[$baseKey])) {
                     $counters[$baseKey] = isset($existingMap[$baseKey]) ? 1 : 0;
@@ -175,11 +169,23 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
                     : $baseKey;
             }
 
-            // Проверяем версионные ключи _v2, _v3... на существование в БД
-            $versionedKeys = array_filter($computedIds, static fn (string $id): bool => str_contains($id, '_v'));
+            $versionedKeys = array_filter($computedIds, static fn (string $id): bool => (bool) preg_match('/_v\d+$/', $id));
             if ($versionedKeys !== []) {
                 $versionedExisting = $this->saleRepository->getExistingExternalIds($companyId, array_values(array_unique($versionedKeys)));
-                $existingMap = array_merge($existingMap, $versionedExisting);
+                if ($versionedExisting !== []) {
+                    $existingMap = array_merge($existingMap, $versionedExisting);
+                    foreach ($computedIds as $i => $id) {
+                        if (!isset($versionedExisting[$id])) {
+                            continue;
+                        }
+                        $baseKey = $baseKeysMap[$i];
+                        while (isset($existingMap[$id])) {
+                            $counters[$baseKey]++;
+                            $id = $baseKey . '_v' . $counters[$baseKey];
+                        }
+                        $computedIds[$i] = $id;
+                    }
+                }
             }
 
             foreach ($salesData as $i => $op) {

--- a/site/tests/Unit/Marketplace/Application/Processor/OzonSalesRawProcessorVersioningTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/OzonSalesRawProcessorVersioningTest.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Application\Processor;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Application\Processor\OzonSalesRawProcessor;
+use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Entity\MarketplaceSale;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Repository\MarketplaceSaleRepository;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * Тесты версионирования external_order_id при повторных продажах
+ * (sale → storno → re-sale по одному posting_number).
+ */
+final class OzonSalesRawProcessorVersioningTest extends TestCase
+{
+    /** @var list<string> */
+    private array $persistedExternalIds = [];
+
+    /**
+     * Sale → storno → re-sale по одному posting_number.
+     * Третья операция должна получить суффикс _v2.
+     */
+    public function testResaleAfterStornoGetsVersionSuffix(): void
+    {
+        $processor = $this->buildProcessor(existingIds: []);
+
+        $processor->processBatch('company-1', MarketplaceType::OZON, [
+            $this->makeOp('X', +1584, '2026-02-24 10:00:00'),
+            $this->makeOp('X', -1584, '2026-02-24 12:00:00'),
+            $this->makeOp('X', +1584, '2026-02-24 14:00:00'),
+        ]);
+
+        self::assertSame(['X', 'X_storno', 'X_v2'], $this->persistedExternalIds);
+    }
+
+    /**
+     * Повторное сторно: sale → storno → re-sale → storno.
+     */
+    public function testDoubleStornoGetsVersionSuffix(): void
+    {
+        $processor = $this->buildProcessor(existingIds: []);
+
+        $processor->processBatch('company-1', MarketplaceType::OZON, [
+            $this->makeOp('A', +1584, '2026-02-24 10:00:00'),
+            $this->makeOp('A', -1584, '2026-02-24 12:00:00'),
+            $this->makeOp('A', +1584, '2026-02-24 14:00:00'),
+            $this->makeOp('A', -1584, '2026-02-24 16:00:00'),
+        ]);
+
+        self::assertSame(['A', 'A_storno', 'A_v2', 'A_storno_v2'], $this->persistedExternalIds);
+    }
+
+    /**
+     * Базовый ключ уже есть в БД → первая regular получает _v2.
+     */
+    public function testExistingInDbStartsFromV2(): void
+    {
+        $processor = $this->buildProcessor(existingIds: ['A']);
+
+        $processor->processBatch('company-1', MarketplaceType::OZON, [
+            $this->makeOp('A', +1584, '2026-02-24 14:00:00'),
+        ]);
+
+        self::assertSame(['A_v2'], $this->persistedExternalIds);
+    }
+
+    /**
+     * Обычный случай без повторов — поведение не меняется.
+     */
+    public function testNoDuplicatesNoVersionSuffix(): void
+    {
+        $processor = $this->buildProcessor(existingIds: []);
+
+        $processor->processBatch('company-1', MarketplaceType::OZON, [
+            $this->makeOp('A', +1584, '2026-02-24 10:00:00'),
+            $this->makeOp('B', +2000, '2026-02-24 11:00:00'),
+            $this->makeOp('C', +500,  '2026-02-24 12:00:00'),
+        ]);
+
+        self::assertSame(['A', 'B', 'C'], $this->persistedExternalIds);
+    }
+
+    /**
+     * Только storno, без regular — создаётся одна запись.
+     */
+    public function testSingleStornoNoVersion(): void
+    {
+        $processor = $this->buildProcessor(existingIds: []);
+
+        $processor->processBatch('company-1', MarketplaceType::OZON, [
+            $this->makeOp('A', -1584, '2026-02-24 12:00:00'),
+        ]);
+
+        self::assertSame(['A_storno'], $this->persistedExternalIds);
+    }
+
+    /**
+     * Неупорядоченные по дате входные данные — сортировка по operation_date ASC.
+     */
+    public function testUnsortedInputIsSortedChronologically(): void
+    {
+        $processor = $this->buildProcessor(existingIds: []);
+
+        $processor->processBatch('company-1', MarketplaceType::OZON, [
+            $this->makeOp('X', +1584, '2026-02-24 14:00:00'),
+            $this->makeOp('X', -1584, '2026-02-24 12:00:00'),
+            $this->makeOp('X', +1584, '2026-02-24 10:00:00'),
+        ]);
+
+        self::assertSame(['X', 'X_storno', 'X_v2'], $this->persistedExternalIds);
+    }
+
+    /**
+     * Existing в БД + повтор в батче.
+     */
+    public function testExistingPlusRepeatInBatch(): void
+    {
+        $processor = $this->buildProcessor(existingIds: ['A', 'A_storno']);
+
+        $processor->processBatch('company-1', MarketplaceType::OZON, [
+            $this->makeOp('A', +1584, '2026-02-25 10:00:00'),
+            $this->makeOp('A', -1584, '2026-02-25 12:00:00'),
+        ]);
+
+        self::assertSame(['A_v2', 'A_storno_v2'], $this->persistedExternalIds);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * @param list<string> $existingIds
+     */
+    private function buildProcessor(array $existingIds): OzonSalesRawProcessor
+    {
+        $this->persistedExternalIds = [];
+
+        $company = (new \ReflectionClass(Company::class))->newInstanceWithoutConstructor();
+        $this->setProperty($company, 'id', 'company-1');
+
+        $listing = (new \ReflectionClass(MarketplaceListing::class))->newInstanceWithoutConstructor();
+        $this->setProperty($listing, 'id', 'listing-1');
+        $this->setProperty($listing, 'company', $company);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('find')->willReturn($company);
+        $em->method('persist')->willReturnCallback(function (object $entity): void {
+            if ($entity instanceof MarketplaceSale) {
+                $this->persistedExternalIds[] = $entity->getExternalOrderId();
+            }
+        });
+
+        $existingMap = array_fill_keys($existingIds, true);
+
+        $saleRepository = $this->createMock(MarketplaceSaleRepository::class);
+        $saleRepository->method('getExistingExternalIds')
+            ->willReturnCallback(static function (string $companyId, array $ids) use ($existingMap): array {
+                $result = [];
+                foreach ($ids as $id) {
+                    if (isset($existingMap[$id])) {
+                        $result[$id] = true;
+                    }
+                }
+                return $result;
+            });
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('isTransactionActive')->willReturn(false);
+
+        $processor = (new \ReflectionClass(OzonSalesRawProcessor::class))->newInstanceWithoutConstructor();
+        $this->setProperty($processor, 'em', $em);
+        $this->setProperty($processor, 'connection', $connection);
+        $this->setProperty($processor, 'saleRepository', $saleRepository);
+        $this->setProperty($processor, 'logger', new NullLogger());
+        $this->setProperty($processor, 'cleanedUpRawDocId', null);
+
+        // OzonListingEnsureService — final class, create via reflection
+        $listingEnsureRef = (new \ReflectionClass(\App\Marketplace\Application\Service\OzonListingEnsureService::class))->newInstanceWithoutConstructor();
+        $this->setProperty($processor, 'listingEnsureService', $listingEnsureRef);
+
+        $costPriceRef = (new \ReflectionClass(\App\Marketplace\Application\Service\MarketplaceCostPriceResolver::class))->newInstanceWithoutConstructor();
+        $innerResolver = $this->createMock(\App\Marketplace\Inventory\CostPriceResolverInterface::class);
+        $innerResolver->method('resolve')->willReturn('0.00');
+        $this->setProperty($costPriceRef, 'costPriceResolver', $innerResolver);
+        $this->setProperty($processor, 'costPriceResolver', $costPriceRef);
+
+        $listingRepo = $this->createMock(\App\Marketplace\Repository\MarketplaceListingRepository::class);
+        $listingRepo->method('findListingsBySkusIndexed')->willReturn(['SKU1' => $listing]);
+        $this->setProperty($listingEnsureRef, 'listingRepository', $listingRepo);
+
+        $upsertQuery = (new \ReflectionClass(\App\Marketplace\Infrastructure\Query\OzonListingUpsertQuery::class))->newInstanceWithoutConstructor();
+        $this->setProperty($listingEnsureRef, 'upsertQuery', $upsertQuery);
+
+        return $processor;
+    }
+
+    private function setProperty(object $obj, string $name, mixed $value): void
+    {
+        $ref = new \ReflectionProperty($obj, $name);
+        $ref->setAccessible(true);
+        $ref->setValue($obj, $value);
+    }
+
+    private function makeOp(string $postingNumber, float $accrual, string $date): array
+    {
+        return [
+            'type' => 'orders',
+            'operation_type' => $accrual < 0 ? 'OperationAgentStornoDeliveredToCustomer' : 'OperationAgentDeliveredToCustomer',
+            'operation_id' => 'op_' . md5($postingNumber . $accrual . $date),
+            'operation_date' => $date,
+            'accruals_for_sale' => $accrual,
+            'posting' => ['posting_number' => $postingNumber],
+            'items' => [['sku' => 'SKU1', 'name' => 'Test Product']],
+        ];
+    }
+}

--- a/site/tests/Unit/Marketplace/Application/Processor/OzonSalesRawProcessorVersioningTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/OzonSalesRawProcessorVersioningTest.php
@@ -133,6 +133,35 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
         self::assertSame(['A_v2', 'A_storno_v2'], $this->persistedExternalIds);
     }
 
+    /**
+     * В БД уже есть A и A_v2 → следующая sale должна получить A_v3, не A_v2.
+     */
+    public function testExistingVersionedInDbBumpsToNextFree(): void
+    {
+        $processor = $this->buildProcessor(existingIds: ['A', 'A_v2']);
+
+        $processor->processBatch('company-1', MarketplaceType::OZON, [
+            $this->makeOp('A', +1584, '2026-02-26 10:00:00'),
+        ]);
+
+        self::assertSame(['A_v3'], $this->persistedExternalIds);
+    }
+
+    /**
+     * В БД A, A_storno, A_v2, A_storno_v2 → следующая пара получает _v3.
+     */
+    public function testFullCycleExistingBumpsToV3(): void
+    {
+        $processor = $this->buildProcessor(existingIds: ['A', 'A_storno', 'A_v2', 'A_storno_v2']);
+
+        $processor->processBatch('company-1', MarketplaceType::OZON, [
+            $this->makeOp('A', +1584, '2026-02-27 10:00:00'),
+            $this->makeOp('A', -1584, '2026-02-27 12:00:00'),
+        ]);
+
+        self::assertSame(['A_v3', 'A_storno_v3'], $this->persistedExternalIds);
+    }
+
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Этап 4.3**: При повторных продажах по одному `posting_number` (sale → storno → re-sale) процессор теперь назначает версионные суффиксы: `X`, `X_storno`, `X_v2`, `X_storno_v2` — вместо падения на unique constraint
- Батч сортируется по `operation_date ASC` перед обработкой для корректного порядка версий
- Версионные ключи (`_v2`, `_v3`...) дополнительно проверяются в БД для предотвращения коллизий при повторной обработке

### Изменённые файлы

| Файл | Что изменилось |
|---|---|
| `OzonSalesRawProcessor::processBatch()` | Сортировка по дате, вычисление baseKey + counter, назначение версионных externalId |
| `OzonSalesRawProcessorVersioningTest` | 7 unit-тестов: resale after storno, double storno, existing in DB, no duplicates, single storno, unsorted input, existing + repeat |

### Схема версионирования

```
posting_number X, accrual > 0  → X
posting_number X, accrual < 0  → X_storno
posting_number X, accrual > 0  → X_v2
posting_number X, accrual < 0  → X_storno_v2
```

## Test plan

- [x] 7 unit-тестов в `OzonSalesRawProcessorVersioningTest` — все проходят
- [x] Smoke-тест `tests/Unit/Marketplace/` — 93 теста, 0 failures
- [ ] Проверить на staging с реальными данными Ozon, содержащими повторные продажи

https://claude.ai/code/session_01GSjUdUM3e6CTqMRF6dLgcy