### PR TITLE
fix(marketplace): always load all missing Ozon realization months

### DIFF
--- a/site/src/Marketplace/Controller/MarketplaceController.php
+++ b/site/src/Marketplace/Controller/MarketplaceController.php
@@ -286,7 +286,7 @@ class MarketplaceController extends AbstractController
         }
 
         $connectionId = $connection->getId();
-        $now          = new \DateTimeImmutable();
+        $now          = new \DateTimeImmutable('now', new \DateTimeZone('Europe/Moscow'));
         $monthsToSync = $this->resolveRealizationMonths($companyId, $now);
 
         if (empty($monthsToSync)) {
@@ -626,26 +626,20 @@ class MarketplaceController extends AbstractController
     // -------------------------------------------------------------------------
 
     /**
-     * Определяет какие месяцы нужно загрузить для realization:
-     *   - нет документов → все закрытые месяцы с января текущего года
-     *   - есть документы → только прошлый месяц (обновление)
-     *
      * @return array<int, array{0: int, 1: int}>  [[year, month], ...]
      */
     private function resolveRealizationMonths(string $companyId, \DateTimeImmutable $now): array
     {
-        $lastMonth      = $now->modify('first day of last month');
-        $lastMonthYear  = (int) $lastMonth->format('Y');
-        $lastMonthMonth = (int) $lastMonth->format('n');
+        $lastClosed     = $now->modify('first day of last month');
+        $lastClosedYear = (int) $lastClosed->format('Y');
+        $currentYear    = (int) $now->format('Y');
 
-        $hasAny = $this->realizationStatusQuery->hasAny($companyId);
-
-        if ($hasAny) {
-            return [[$lastMonthYear, $lastMonthMonth]];
+        if ($lastClosedYear < $currentYear) {
+            return [];
         }
 
-        $currentYear  = (int) $now->format('Y');
-        $loadedMonths = $this->realizationStatusQuery->loadedMonths($companyId);
+        $lastClosedMonth = (int) $lastClosed->format('n');
+        $loadedMonths    = $this->realizationStatusQuery->loadedMonths($companyId);
 
         $months = [];
         $cursor = new \DateTimeImmutable(sprintf('%d-01-01', $currentYear));
@@ -654,7 +648,7 @@ class MarketplaceController extends AbstractController
             $year  = (int) $cursor->format('Y');
             $month = (int) $cursor->format('n');
 
-            if ($year > $lastMonthYear || ($year === $lastMonthYear && $month > $lastMonthMonth)) {
+            if ($year > $lastClosedYear || ($year === $lastClosedYear && $month > $lastClosedMonth)) {
                 break;
             }
 

--- a/site/src/Marketplace/Infrastructure/Query/OzonRealizationStatusQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/OzonRealizationStatusQuery.php
@@ -6,37 +6,10 @@ namespace App\Marketplace\Infrastructure\Query;
 
 use Doctrine\DBAL\Connection;
 
-/**
- * Проверяет наличие загруженных realization-документов Ozon для компании.
- * Используется в контроллере для определения стратегии загрузки:
- *   - нет документов → первичная загрузка с начала года
- *   - есть документы → загрузить только прошлый месяц
- */
 final class OzonRealizationStatusQuery
 {
     public function __construct(private readonly Connection $connection)
     {
-    }
-
-    /**
-     * Есть ли хоть один realization-документ Ozon для компании?
-     */
-    public function hasAny(string $companyId): bool
-    {
-        $count = $this->connection->fetchOne(
-            'SELECT COUNT(*) FROM marketplace_raw_documents
-             WHERE company_id = :companyId
-               AND marketplace = :marketplace
-               AND document_type = :documentType
-             LIMIT 1',
-            [
-                'companyId'    => $companyId,
-                'marketplace'  => 'ozon',
-                'documentType' => 'realization',
-            ],
-        );
-
-        return (int) $count > 0;
     }
 
     /**

--- a/site/tests/Unit/Marketplace/Controller/ResolveRealizationMonthsTest.php
+++ b/site/tests/Unit/Marketplace/Controller/ResolveRealizationMonthsTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Controller;
+
+use App\Marketplace\Controller\MarketplaceController;
+use App\Marketplace\Infrastructure\Query\OzonRealizationStatusQuery;
+use Doctrine\DBAL\Connection as DbalConnection;
+use PHPUnit\Framework\TestCase;
+
+final class ResolveRealizationMonthsTest extends TestCase
+{
+    private \ReflectionMethod $method;
+    private MarketplaceController $controller;
+    private DbalConnection $dbalConnection;
+
+    protected function setUp(): void
+    {
+        $this->dbalConnection = $this->createMock(DbalConnection::class);
+        $statusQuery = new OzonRealizationStatusQuery($this->dbalConnection);
+
+        $ref = new \ReflectionClass(MarketplaceController::class);
+        $this->controller = $ref->newInstanceWithoutConstructor();
+
+        $prop = $ref->getProperty('realizationStatusQuery');
+        $prop->setValue($this->controller, $statusQuery);
+
+        $this->method = $ref->getMethod('resolveRealizationMonths');
+    }
+
+    private function invoke(string $companyId, \DateTimeImmutable $now): array
+    {
+        return $this->method->invoke($this->controller, $companyId, $now);
+    }
+
+    private function stubLoadedMonths(array $months): void
+    {
+        $rows = array_map(static fn(string $m) => ['month' => $m], $months);
+
+        $this->dbalConnection
+            ->method('fetchAllAssociative')
+            ->willReturn($rows);
+    }
+
+    public function testAllMonthsMissingReturnsJanToMarch(): void
+    {
+        $this->stubLoadedMonths([]);
+
+        $now = new \DateTimeImmutable('2026-04-17', new \DateTimeZone('Europe/Moscow'));
+
+        self::assertSame([[2026, 1], [2026, 2], [2026, 3]], $this->invoke('company-1', $now));
+    }
+
+    public function testPartiallyLoadedSkipsExisting(): void
+    {
+        $this->stubLoadedMonths(['2026-02']);
+
+        $now = new \DateTimeImmutable('2026-04-17', new \DateTimeZone('Europe/Moscow'));
+
+        self::assertSame([[2026, 1], [2026, 3]], $this->invoke('company-1', $now));
+    }
+
+    public function testAllLoadedReturnsEmpty(): void
+    {
+        $this->stubLoadedMonths(['2026-01', '2026-02', '2026-03']);
+
+        $now = new \DateTimeImmutable('2026-04-17', new \DateTimeZone('Europe/Moscow'));
+
+        self::assertSame([], $this->invoke('company-1', $now));
+    }
+
+    public function testJanuaryReturnsEmptyBecauseNoClosedMonths(): void
+    {
+        $this->stubLoadedMonths([]);
+
+        $now = new \DateTimeImmutable('2026-01-10', new \DateTimeZone('Europe/Moscow'));
+
+        self::assertSame([], $this->invoke('company-1', $now));
+    }
+
+    public function testFebruaryReturnsOnlyJanuary(): void
+    {
+        $this->stubLoadedMonths([]);
+
+        $now = new \DateTimeImmutable('2026-02-15', new \DateTimeZone('Europe/Moscow'));
+
+        self::assertSame([[2026, 1]], $this->invoke('company-1', $now));
+    }
+
+    public function testDecemberReturnsAllElevenMonths(): void
+    {
+        $this->stubLoadedMonths([]);
+
+        $now = new \DateTimeImmutable('2026-12-05', new \DateTimeZone('Europe/Moscow'));
+
+        $expected = [];
+        for ($m = 1; $m <= 11; $m++) {
+            $expected[] = [2026, $m];
+        }
+
+        self::assertSame($expected, $this->invoke('company-1', $now));
+    }
+
+    public function testRepeatedClickStillReturnsMissingMonths(): void
+    {
+        $this->stubLoadedMonths(['2026-01', '2026-02']);
+
+        $now = new \DateTimeImmutable('2026-04-17', new \DateTimeZone('Europe/Moscow'));
+
+        self::assertSame([[2026, 3]], $this->invoke('company-1', $now));
+    }
+}


### PR DESCRIPTION
## Summary

- Кнопка «Реализация» на `/marketplace` теперь при **каждом** клике ставит в очередь все недостающие месяцы с января текущего года до последнего закрытого, а не только прошлый месяц при повторном нажатии
- Добавлена явная таймзона `Europe/Moscow` в `syncRealization()` — единообразие с `SyncWbReportHandler` и `SyncOzonReportHandler`
- Удалён неиспользуемый метод `hasAny()` из `OzonRealizationStatusQuery`

## Что изменилось

| Файл | Изменение |
|------|-----------|
| `MarketplaceController::syncRealization()` | `new DateTimeImmutable()` → `new DateTimeImmutable('now', new DateTimeZone('Europe/Moscow'))` |
| `MarketplaceController::resolveRealizationMonths()` | Убрана ветка `hasAny → только прошлый месяц`. Теперь всегда: полный список Янв–lastClosed минус `loadedMonths()` |
| `OzonRealizationStatusQuery` | Удалён `hasAny()` (единственный вызов был в контроллере) |
| `ResolveRealizationMonthsTest` | 7 unit-тестов на все ветки `resolveRealizationMonths()` |

## Test plan

- [x] `testAllMonthsMissingReturnsJanToMarch` — апрель, ничего не загружено → 3 месяца
- [x] `testPartiallyLoadedSkipsExisting` — загружен только февраль → январь + март
- [x] `testAllLoadedReturnsEmpty` — все 3 загружены → пустой результат
- [x] `testJanuaryReturnsEmptyBecauseNoClosedMonths` — январь, нет закрытых месяцев → []
- [x] `testFebruaryReturnsOnlyJanuary` — февраль → только январь
- [x] `testDecemberReturnsAllElevenMonths` — декабрь → 11 месяцев
- [x] `testRepeatedClickStillReturnsMissingMonths` — повторный клик с частичной загрузкой → только пропущенные

https://claude.ai/code/session_011sKgj41KerYgQLyUWrkBSA