### PR TITLE
chore(marketplace): mark legacy Ozon sales/returns process() path as @deprecated

### DIFF
--- a/site/src/Marketplace/Application/ProcessOzonReturnsAction.php
+++ b/site/src/Marketplace/Application/ProcessOzonReturnsAction.php
@@ -15,6 +15,9 @@ use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
 
+/**
+ * @deprecated Use OzonReturnsRawProcessor::processBatch() via ProcessMarketplaceRawDocumentAction.
+ */
 final class ProcessOzonReturnsAction
 {
     public function __construct(

--- a/site/src/Marketplace/Application/ProcessOzonSalesAction.php
+++ b/site/src/Marketplace/Application/ProcessOzonSalesAction.php
@@ -15,6 +15,9 @@ use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
 
+/**
+ * @deprecated Use OzonSalesRawProcessor::processBatch() via ProcessMarketplaceRawDocumentAction.
+ */
 final class ProcessOzonSalesAction
 {
     public function __construct(

--- a/site/src/Marketplace/Application/Processor/OzonReturnsRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonReturnsRawProcessor.php
@@ -50,6 +50,9 @@ final class OzonReturnsRawProcessor implements MarketplaceRawProcessorInterface
         return $type === MarketplaceType::OZON->value && $kind === 'returns';
     }
 
+    /**
+     * @deprecated Use processBatch() instead. This method delegates to legacy ProcessOzonReturnsAction which lacks OperationItemReturn → costs classification. No active callers in production.
+     */
     public function process(string $companyId, string $rawDocId): int
     {
         $rawDoc = $this->em->find(MarketplaceRawDocument::class, $rawDocId);

--- a/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
@@ -48,6 +48,9 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
         return $type === MarketplaceType::OZON->value && $kind === 'sales';
     }
 
+    /**
+     * @deprecated Use processBatch() instead. This method delegates to legacy ProcessOzonSalesAction which lacks storno classification and version suffix logic. No active callers in production.
+     */
     public function process(string $companyId, string $rawDocId): int
     {
         $rawDoc = $this->em->find(MarketplaceRawDocument::class, $rawDocId);

--- a/site/src/Marketplace/Facade/MarketplaceSyncFacade.php
+++ b/site/src/Marketplace/Facade/MarketplaceSyncFacade.php
@@ -72,11 +72,17 @@ final readonly class MarketplaceSyncFacade
         return 0;
     }
 
+    /**
+     * @deprecated No active callers. Use ProcessMarketplaceRawDocumentAction directly.
+     */
     public function processSalesFromRaw(string $companyId, string $rawDocId): int
     {
         return ($this->processRawDocumentAction)(new ProcessMarketplaceRawDocumentCommand($companyId, $rawDocId, 'sales'));
     }
 
+    /**
+     * @deprecated No active callers. Use ProcessMarketplaceRawDocumentAction directly.
+     */
     public function processReturnsFromRaw(string $companyId, string $rawDocId): int
     {
         return ($this->processRawDocumentAction)(new ProcessMarketplaceRawDocumentCommand($companyId, $rawDocId, 'returns'));


### PR DESCRIPTION
## Summary
- Помечены `@deprecated` мёртвые части sales/returns-потока Ozon, выявленные в аудите этапа 4.4
- Runtime-поведение не меняется — только PHPDoc-аннотации
- Активные пути (`processBatch()` через `ProcessMarketplaceRawDocumentAction`) и `processCostsFromRaw()` не тронуты

## Что помечено
- `ProcessOzonSalesAction` (класс)
- `ProcessOzonReturnsAction` (класс)
- `OzonSalesRawProcessor::process()` (метод — не класс, т.к. `processBatch()` активен)
- `OzonReturnsRawProcessor::process()` (метод)
- `MarketplaceSyncFacade::processSalesFromRaw()` / `processReturnsFromRaw()`

## Контекст
Аудит этапа 4.4 подтвердил: `OzonSalesRawProcessor::process()` и `OzonReturnsRawProcessor::process()` достижимы только через `ProcessRawDocumentAction` → `MarketplaceSyncFacade::processSalesFromRaw/processReturnsFromRaw`, у которых нет ни одного вызывающего места в `src/` или `tests/`. Старые `ProcessOzon{Sales,Returns}Action` не содержат фиксов из этапов 1–3 (storno-классификация, `_v2` версионирование, `OperationItemReturn` → costs).

## Test plan
- [x] `php -l` на всех 5 изменённых файлах — ok
- [ ] `make site-test-unit` — прогнать локально (в этом environment нет vendor/docker)

https://claude.ai/code/session_01UFSHRCQgYk2r5xGtau5tJh