### PR TITLE
fix(marketplace-ads): safely stringify Ozon API error payload

### DIFF
--- a/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
+++ b/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
@@ -485,7 +485,7 @@ final class OzonAdClient implements AdPlatformClientInterface
 
         $data = $this->decodeJson($response->getContent(false), 'statistics request');
 
-        $uuid = isset($data['UUID']) ? (string) $data['UUID'] : (string) ($data['uuid'] ?? '');
+        $uuid = isset($data['UUID']) ? $this->stringifyApiField($data['UUID']) : $this->stringifyApiField($data['uuid'] ?? null);
         if ('' === $uuid) {
             throw new \RuntimeException('Ozon Performance: ответ /statistics не содержит UUID');
         }
@@ -509,9 +509,9 @@ final class OzonAdClient implements AdPlatformClientInterface
             );
             $data = $this->decodeJson($response->getContent(false), 'statistics state');
 
-            $state = (string) ($data['state'] ?? '');
+            $state = $this->stringifyApiField($data['state'] ?? null);
             if ('OK' === $state || 'READY' === $state) {
-                $link = (string) ($data['link'] ?? ($data['report']['link'] ?? ''));
+                $link = $this->stringifyApiField($data['link'] ?? ($data['report']['link'] ?? null));
                 if ('' === $link) {
                     // Старые версии API не отдают link отдельно — отчёт скачивается
                     // по фиксированному /report?UUID=…
@@ -528,7 +528,12 @@ final class OzonAdClient implements AdPlatformClientInterface
             }
 
             if ('ERROR' === $state || 'CANCELLED' === $state || 'NOT_FOUND' === $state) {
-                throw new \RuntimeException(sprintf('Ozon Performance: отчёт %s завершился со статусом %s: %s', $uuid, $state, (string) ($data['error'] ?? '')));
+                throw new \RuntimeException(sprintf(
+                    'Ozon Performance: отчёт %s завершился со статусом %s: %s',
+                    $uuid,
+                    $state,
+                    $this->stringifyApiField($data['error'] ?? null),
+                ));
             }
 
             sleep(self::POLL_INTERVAL_SECONDS);
@@ -804,5 +809,27 @@ final class OzonAdClient implements AdPlatformClientInterface
         }
 
         return $data;
+    }
+
+    /**
+     * Безопасный stringify поля ответа Ozon Performance API.
+     *
+     * Ozon может вернуть в поле error структурированное значение ({"code": "...", "details": [...]}).
+     * Прямой `(string) $value` на массиве/объекте даёт литерал "Array" + PHP Warning и теряет
+     * диагностическую информацию в сообщении исключения. Используем json_encode как fallback.
+     */
+    private function stringifyApiField(mixed $value): string
+    {
+        if (null === $value) {
+            return '';
+        }
+
+        if (is_scalar($value)) {
+            return (string) $value;
+        }
+
+        $encoded = json_encode($value, \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES);
+
+        return false === $encoded ? 'non-serializable error payload' : $encoded;
     }
 }

--- a/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
+++ b/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
@@ -485,7 +485,7 @@ final class OzonAdClient implements AdPlatformClientInterface
 
         $data = $this->decodeJson($response->getContent(false), 'statistics request');
 
-        $uuid = isset($data['UUID']) ? $this->stringifyApiField($data['UUID']) : $this->stringifyApiField($data['uuid'] ?? null);
+        $uuid = $this->stringifyApiField($data['UUID'] ?? $data['uuid'] ?? null);
         if ('' === $uuid) {
             throw new \RuntimeException('Ozon Performance: ответ /statistics не содержит UUID');
         }
@@ -511,7 +511,7 @@ final class OzonAdClient implements AdPlatformClientInterface
 
             $state = $this->stringifyApiField($data['state'] ?? null);
             if ('OK' === $state || 'READY' === $state) {
-                $link = $this->stringifyApiField($data['link'] ?? ($data['report']['link'] ?? null));
+                $link = $this->stringifyApiField($data['link'] ?? $data['report']['link'] ?? null);
                 if ('' === $link) {
                     // Старые версии API не отдают link отдельно — отчёт скачивается
                     // по фиксированному /report?UUID=…

--- a/site/tests/Unit/MarketplaceAds/OzonAdClientTest.php
+++ b/site/tests/Unit/MarketplaceAds/OzonAdClientTest.php
@@ -386,6 +386,106 @@ final class OzonAdClientTest extends TestCase
     }
 
     // -----------------------------------------------------------------
+    // Error payload stringify: scalar error → сообщение содержит строку как есть
+    // -----------------------------------------------------------------
+    public function testPollReportWithStringErrorIncludesItVerbatim(): void
+    {
+        $http = $this->buildHttpClientForError(
+            tokenBody: $this->tokenBody('TKN-E1'),
+            campaignListBody: $this->campaignListBody(1),
+            statisticsBody: '{"UUID":"uuid-err-1"}',
+            stateBody: json_encode(['state' => 'ERROR', 'error' => 'нет прав'], JSON_THROW_ON_ERROR),
+        );
+
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger);
+
+        try {
+            $client->fetchAdStatisticsRange(
+                self::COMPANY_ID,
+                new \DateTimeImmutable('2026-03-01'),
+                new \DateTimeImmutable('2026-03-01'),
+            );
+            self::fail('Expected RuntimeException');
+        } catch (\RuntimeException $e) {
+            $msg = $e->getMessage();
+            self::assertStringContainsString('uuid-err-1', $msg);
+            self::assertStringContainsString('ERROR', $msg);
+            self::assertStringContainsString('нет прав', $msg);
+            self::assertStringNotContainsString('Array', $msg);
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Error payload stringify: object error → JSON с UNESCAPED_UNICODE/SLASHES
+    // -----------------------------------------------------------------
+    public function testPollReportWithObjectErrorSerializesAsJson(): void
+    {
+        $errorPayload = [
+            'code' => 'FORBIDDEN',
+            'message' => 'Нет доступа к /api/client/statistics',
+            'details' => ['scope' => 'advertising'],
+        ];
+
+        $http = $this->buildHttpClientForError(
+            tokenBody: $this->tokenBody('TKN-E2'),
+            campaignListBody: $this->campaignListBody(1),
+            statisticsBody: '{"UUID":"uuid-err-2"}',
+            stateBody: json_encode(['state' => 'ERROR', 'error' => $errorPayload], JSON_THROW_ON_ERROR),
+        );
+
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger);
+
+        try {
+            $client->fetchAdStatisticsRange(
+                self::COMPANY_ID,
+                new \DateTimeImmutable('2026-03-01'),
+                new \DateTimeImmutable('2026-03-01'),
+            );
+            self::fail('Expected RuntimeException');
+        } catch (\RuntimeException $e) {
+            $msg = $e->getMessage();
+            self::assertStringNotContainsString('Array', $msg);
+            self::assertStringContainsString('FORBIDDEN', $msg);
+            // UNESCAPED_UNICODE — кириллица НЕ как \u0420\u0435\u0433...
+            self::assertStringContainsString('Нет доступа', $msg);
+            self::assertStringNotContainsString('\\u04', $msg);
+            // UNESCAPED_SLASHES — /api/client/statistics без \/
+            self::assertStringContainsString('/api/client/statistics', $msg);
+            self::assertStringNotContainsString('\\/', $msg);
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Error payload stringify: list-array error → JSON-массив
+    // -----------------------------------------------------------------
+    public function testPollReportWithArrayErrorSerializesAsJson(): void
+    {
+        $errorPayload = ['Первая причина', 'Вторая причина'];
+
+        $http = $this->buildHttpClientForError(
+            tokenBody: $this->tokenBody('TKN-E3'),
+            campaignListBody: $this->campaignListBody(1),
+            statisticsBody: '{"UUID":"uuid-err-3"}',
+            stateBody: json_encode(['state' => 'ERROR', 'error' => $errorPayload], JSON_THROW_ON_ERROR),
+        );
+
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger);
+
+        try {
+            $client->fetchAdStatisticsRange(
+                self::COMPANY_ID,
+                new \DateTimeImmutable('2026-03-01'),
+                new \DateTimeImmutable('2026-03-01'),
+            );
+            self::fail('Expected RuntimeException');
+        } catch (\RuntimeException $e) {
+            $msg = $e->getMessage();
+            self::assertStringNotContainsString('Array', $msg);
+            self::assertStringContainsString('["Первая причина","Вторая причина"]', $msg);
+        }
+    }
+
+    // -----------------------------------------------------------------
     // g) Backward-compat: fetchAdStatistics($companyId, $date) still works
     // -----------------------------------------------------------------
     public function testFetchAdStatisticsLegacyContractRemainsStable(): void
@@ -498,6 +598,24 @@ final class OzonAdClientTest extends TestCase
             new MockResponse($statisticsBody),
             new MockResponse($stateBody),
             new MockResponse($downloadCsv),
+        ]);
+    }
+
+    /**
+     * Error HTTP sequence: token → /campaign → /statistics → /state (state=ERROR).
+     * Нет download-шага — pollReport() бросает исключение до него.
+     */
+    private function buildHttpClientForError(
+        string $tokenBody,
+        string $campaignListBody,
+        string $statisticsBody,
+        string $stateBody,
+    ): MockHttpClient {
+        return new MockHttpClient([
+            new MockResponse($tokenBody),
+            new MockResponse($campaignListBody),
+            new MockResponse($statisticsBody),
+            new MockResponse($stateBody),
         ]);
     }
 


### PR DESCRIPTION
## Summary

Ozon `/v1/report/info` возвращает поле `error` как строку, но под ошибкой API может прийти объект/массив. Прежнее `(string) $data['error']` кидало `Error: Object of class ... could not be converted to string` или пустую строку вместо `Array`.

Добавлен приватный helper `stringifyApiField(mixed $value): string`:
- `null` → `''`;
- scalar → `(string) $value`;
- array/object → `json_encode(..., JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)`;
- `json_encode === false` → `'non-serializable error payload'`.

Заменены 4 call-sites в `OzonAdClient::pollReport` (`uuid`/`state`/`link`/`error`).

## Test plan

- [x] `vendor/bin/phpunit tests/Unit/MarketplaceAds/OzonAdClientTest.php` — 13 тестов (148 assertions) зелёные.
- [ ] Smoke: boot контейнера без падений.

## Context

Отделено от PR #1568 (AdLoadJob scope). Ранее висело на `claude/plan-ozon-ads-loading-YCI0T`, revert'нуто там и вынесено в отдельную ветку по требованию ревью.

https://claude.ai/code/session_013aMVWufdKpd1XxQc55JVsU