### PR TITLE
feat(marketplace-ads): LoadOzonAdStatisticsRangeHandler orchestrator

### DIFF
--- a/site/config/packages/messenger.yaml
+++ b/site/config/packages/messenger.yaml
@@ -49,6 +49,7 @@ framework:
             App\MarketplaceAnalytics\Message\RecalcSnapshotsMessage: async
             App\MarketplaceAds\Message\ProcessAdRawDocumentMessage: async
             App\MarketplaceAds\Message\FetchOzonAdStatisticsMessage: async
+            App\MarketplaceAds\Message\LoadOzonAdStatisticsRangeMessage: async
 
             # Route your messages to the transports
             # 'App\Message\YourMessage': async

--- a/site/migrations/Version20260418000001.php
+++ b/site/migrations/Version20260418000001.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * MarketplaceAds: добавляет счётчики чанков `chunks_total` / `chunks_completed`
+ * в таблицу `marketplace_ad_load_jobs`.
+ *
+ * Нужны для корректной семантики завершения job'а: после Коммита 3 стало
+ * очевидно, что loaded_days не является надёжным признаком «все чанки
+ * отработали» (Ozon легитимно может вернуть меньше дней, чем запросили,
+ * и loaded_days в этом случае считается по покрытию чанка).
+ *
+ * chunks_total выставляется один раз при старте job'а в
+ * {@see \App\MarketplaceAds\MessageHandler\LoadOzonAdStatisticsRangeHandler}.
+ * chunks_completed инкрементируется атомарно после каждого успешного чанка
+ * в {@see \App\MarketplaceAds\MessageHandler\FetchOzonAdStatisticsHandler}.
+ */
+final class Version20260418000001 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'MarketplaceAds: add chunks_total / chunks_completed counters to marketplace_ad_load_jobs';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE marketplace_ad_load_jobs
+                ADD COLUMN chunks_total INT NOT NULL DEFAULT 0,
+                ADD COLUMN chunks_completed INT NOT NULL DEFAULT 0
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE marketplace_ad_load_jobs
+                DROP COLUMN chunks_completed,
+                DROP COLUMN chunks_total
+        SQL);
+    }
+}

--- a/site/src/MarketplaceAds/Entity/AdLoadJob.php
+++ b/site/src/MarketplaceAds/Entity/AdLoadJob.php
@@ -54,6 +54,12 @@ class AdLoadJob
     #[ORM\Column(type: 'integer', options: ['default' => 0])]
     private int $failedDays = 0;
 
+    #[ORM\Column(type: 'integer', options: ['default' => 0])]
+    private int $chunksTotal = 0;
+
+    #[ORM\Column(type: 'integer', options: ['default' => 0])]
+    private int $chunksCompleted = 0;
+
     #[ORM\Column(type: 'string', length: 20, enumType: AdLoadJobStatus::class, options: ['default' => 'pending'])]
     private AdLoadJobStatus $status;
 
@@ -126,6 +132,29 @@ class AdLoadJob
 
         $this->status = AdLoadJobStatus::COMPLETED;
         $this->finishedAt = new \DateTimeImmutable();
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    /**
+     * Устанавливает общее число чанков для задания. Вызывается из
+     * {@see \App\MarketplaceAds\MessageHandler\LoadOzonAdStatisticsRangeHandler}
+     * один раз на задание — после расчёта числа чанков по диапазону дат.
+     *
+     * chunksCompleted инкрементируется отдельно через Repository-метод
+     * (атомарный SQL UPDATE, параллельные воркеры).
+     */
+    public function setChunksTotal(int $total): void
+    {
+        if ($this->status->isTerminal()) {
+            throw new \DomainException(sprintf(
+                'Нельзя установить chunksTotal на задание в терминальном статусе: %s.',
+                $this->status->value,
+            ));
+        }
+
+        Assert::greaterThanEq($total, 1, 'chunksTotal должен быть >= 1.');
+
+        $this->chunksTotal = $total;
         $this->updatedAt = new \DateTimeImmutable();
     }
 
@@ -205,6 +234,16 @@ class AdLoadJob
     public function getFailedDays(): int
     {
         return $this->failedDays;
+    }
+
+    public function getChunksTotal(): int
+    {
+        return $this->chunksTotal;
+    }
+
+    public function getChunksCompleted(): int
+    {
+        return $this->chunksCompleted;
     }
 
     public function getStatus(): AdLoadJobStatus

--- a/site/src/MarketplaceAds/Message/LoadOzonAdStatisticsRangeMessage.php
+++ b/site/src/MarketplaceAds/Message/LoadOzonAdStatisticsRangeMessage.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Message;
+
+/**
+ * Верхний async-слой пайплайна загрузки рекламной статистики Ozon Performance.
+ *
+ * Обрабатывается {@see \App\MarketplaceAds\MessageHandler\LoadOzonAdStatisticsRangeHandler}:
+ * читает AdLoadJob по jobId, бьёт диапазон dateFrom..dateTo на чанки ≤ 62 дня
+ * (лимит Ozon API) и диспатчит N × {@see FetchOzonAdStatisticsMessage}.
+ *
+ * В сообщении единственное поле — jobId: companyId, dateFrom, dateTo лежат в
+ * AdLoadJob и читаются handler'ом. AdLoadJob — единственный source of truth,
+ * дублировать данные в Message смысла нет (а риск рассинхронизации — есть).
+ */
+final readonly class LoadOzonAdStatisticsRangeMessage
+{
+    public function __construct(
+        public string $jobId,
+    ) {
+    }
+}

--- a/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
@@ -248,6 +248,13 @@ final class FetchOzonAdStatisticsHandler
             ));
         }
 
+        // Чанк физически отработан — инкрементим даже на пустом результате Ozon
+        // (ноль документов, ноль dispatch'ей): permanent/transient ошибки до сюда
+        // не доходят (rethrow / UnrecoverableMessageHandlingException выше).
+        // Финализация job'а по условию chunksCompleted == chunksTotal — в
+        // ProcessAdRawDocumentHandler (Коммит 5).
+        $this->adLoadJobRepository->incrementChunksCompleted($message->jobId);
+
         $this->logger->info('Ozon ad statistics chunk processed', [
             'jobId' => $message->jobId,
             'companyId' => $message->companyId,

--- a/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
@@ -253,7 +253,7 @@ final class FetchOzonAdStatisticsHandler
         // не доходят (rethrow / UnrecoverableMessageHandlingException выше).
         // Финализация job'а по условию chunksCompleted == chunksTotal — в
         // ProcessAdRawDocumentHandler (Коммит 5).
-        $this->adLoadJobRepository->incrementChunksCompleted($message->jobId);
+        $this->adLoadJobRepository->incrementChunksCompleted($message->jobId, $message->companyId);
 
         $this->logger->info('Ozon ad statistics chunk processed', [
             'jobId' => $message->jobId,

--- a/site/src/MarketplaceAds/MessageHandler/LoadOzonAdStatisticsRangeHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/LoadOzonAdStatisticsRangeHandler.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\MessageHandler;
+
+use App\MarketplaceAds\Enum\AdLoadJobStatus;
+use App\MarketplaceAds\Message\FetchOzonAdStatisticsMessage;
+use App\MarketplaceAds\Message\LoadOzonAdStatisticsRangeMessage;
+use App\MarketplaceAds\Repository\AdLoadJobRepository;
+use App\Shared\Service\AppLogger;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * Оркестратор пакетной загрузки рекламной статистики Ozon Performance.
+ *
+ * На входе — только jobId. Handler:
+ *  1) читает AdLoadJob (find() без company-guard: Message пришёл из нашего же
+ *     Action'а, ID сгенерирован внутри системы — это trusted-контекст);
+ *  2) если PENDING → markRunning + flush; если уже терминальный — no-op;
+ *     если RUNNING — продолжаем (это retry Messenger'а после сбоя на этапе
+ *     рассылки, idempotent dispatch покроет повторный заход);
+ *  3) бьёт диапазон dateFrom..dateTo на чанки ≤ 62 дня (лимит Ozon API,
+ *     см. {@see \App\MarketplaceAds\Infrastructure\Api\Ozon\OzonAdClient::fetchAdStatisticsRange});
+ *  4) при первом проходе (chunksTotal == 0) устанавливает chunksTotal + flush;
+ *     на retry — skip (chunksTotal уже выставлен);
+ *  5) диспатчит N × FetchOzonAdStatisticsMessage по одному на чанк.
+ *
+ * Финализация job'а (markCompleted) — ответственность ProcessAdRawDocumentHandler
+ * (Коммит 5): как только chunksCompleted == chunksTotal И все документы
+ * обработаны, он проверяет failed_days и помечает job completed / failed.
+ */
+#[AsMessageHandler]
+final class LoadOzonAdStatisticsRangeHandler
+{
+    // Лимит Ozon Performance API: диапазон запроса статистики не превышает
+    // 62 дня включительно. См. OzonAdClient::MAX_DAYS_PER_REQUEST.
+    private const CHUNK_MAX_DAYS = 62;
+
+    public function __construct(
+        private readonly AdLoadJobRepository $adLoadJobRepository,
+        private readonly MessageBusInterface $messageBus,
+        private readonly AppLogger $logger,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function __invoke(LoadOzonAdStatisticsRangeMessage $message): void
+    {
+        $job = $this->adLoadJobRepository->find($message->jobId);
+
+        if (null === $job) {
+            // Запись удалена / не существует — не ретраим (повторная попытка ничего не исправит).
+            $this->logger->warning('AdLoadJob not found for LoadOzonAdStatisticsRangeMessage', [
+                'jobId' => $message->jobId,
+            ]);
+
+            return;
+        }
+
+        if ($job->getStatus()->isTerminal()) {
+            $this->logger->info('AdLoadJob already finished, range dispatch skipped', [
+                'jobId' => $job->getId(),
+                'companyId' => $job->getCompanyId(),
+                'status' => $job->getStatus()->value,
+            ]);
+
+            return;
+        }
+
+        // markRunning только из PENDING; RUNNING — идемпотентный retry после сбоя
+        // рассылки (например, падение воркера между dispatch'ами).
+        if (AdLoadJobStatus::PENDING === $job->getStatus()) {
+            $job->markRunning();
+            $this->entityManager->flush();
+        }
+
+        $chunks = $this->splitIntoChunks($job->getDateFrom(), $job->getDateTo());
+
+        // chunksTotal выставляется один раз на задание. На retry после сбоя
+        // сразу после dispatch'а части чанков — value уже положительный,
+        // повторный set был бы бессмысленным (и пустым) UPDATE.
+        if (0 === $job->getChunksTotal()) {
+            $job->setChunksTotal(count($chunks));
+            $this->entityManager->flush();
+        }
+
+        foreach ($chunks as $chunk) {
+            $this->messageBus->dispatch(new FetchOzonAdStatisticsMessage(
+                jobId: $job->getId(),
+                companyId: $job->getCompanyId(),
+                dateFrom: $chunk['from']->format('Y-m-d'),
+                dateTo: $chunk['to']->format('Y-m-d'),
+            ));
+        }
+
+        $this->logger->info('Ozon ad statistics range dispatched', [
+            'jobId' => $job->getId(),
+            'companyId' => $job->getCompanyId(),
+            'dateFrom' => $job->getDateFrom()->format('Y-m-d'),
+            'dateTo' => $job->getDateTo()->format('Y-m-d'),
+            'totalDays' => $job->getTotalDays(),
+            'chunksCount' => count($chunks),
+        ]);
+
+        // TODO(commit 5): ProcessAdRawDocumentHandler finalizes job by chunksCompleted.
+    }
+
+    /**
+     * Разбивает диапазон на чанки не более CHUNK_MAX_DAYS дней включительно.
+     *
+     * 62 — МАКСИМУМ ВКЛЮЧИТЕЛЬНО, поэтому шаг курсора = +61 день:
+     *   [cursor, cursor+61] = ровно 62 дня с учётом обеих границ.
+     *
+     * @return list<array{from: \DateTimeImmutable, to: \DateTimeImmutable}>
+     */
+    private function splitIntoChunks(\DateTimeImmutable $dateFrom, \DateTimeImmutable $dateTo): array
+    {
+        $chunks = [];
+        $cursor = $dateFrom;
+        $stepDays = self::CHUNK_MAX_DAYS - 1;
+
+        while ($cursor <= $dateTo) {
+            $chunkEnd = $cursor->modify(sprintf('+%d days', $stepDays));
+            if ($chunkEnd > $dateTo) {
+                $chunkEnd = $dateTo;
+            }
+
+            $chunks[] = [
+                'from' => $cursor,
+                'to' => $chunkEnd,
+            ];
+
+            $cursor = $chunkEnd->modify('+1 day');
+        }
+
+        return $chunks;
+    }
+}

--- a/site/src/MarketplaceAds/MessageHandler/LoadOzonAdStatisticsRangeHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/LoadOzonAdStatisticsRangeHandler.php
@@ -93,6 +93,11 @@ final class LoadOzonAdStatisticsRangeHandler
             $this->entityManager->flush();
         }
 
+        // TODO(commit 5): защита от дубль-dispatch при retry оркестратора.
+        // AdRawDocument.UniqueConstraint(company_id, marketplace, report_date)
+        // уже защищает документы и loaded_days (created=0 на retry → инкремент=0).
+        // chunks_completed защитим в FetchOzonAdStatisticsHandler детекцией
+        // повтора: created=0 && updated>0 → не инкрементировать (это retry-fetch).
         foreach ($chunks as $chunk) {
             $this->messageBus->dispatch(new FetchOzonAdStatisticsMessage(
                 jobId: $job->getId(),

--- a/site/src/MarketplaceAds/MessageHandler/LoadOzonAdStatisticsRangeHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/LoadOzonAdStatisticsRangeHandler.php
@@ -72,9 +72,10 @@ final class LoadOzonAdStatisticsRangeHandler
 
         // markRunning только из PENDING; RUNNING — идемпотентный retry после сбоя
         // рассылки (например, падение воркера между dispatch'ами).
+        $needsFlush = false;
         if (AdLoadJobStatus::PENDING === $job->getStatus()) {
             $job->markRunning();
-            $this->entityManager->flush();
+            $needsFlush = true;
         }
 
         $chunks = $this->splitIntoChunks($job->getDateFrom(), $job->getDateTo());
@@ -84,6 +85,11 @@ final class LoadOzonAdStatisticsRangeHandler
         // повторный set был бы бессмысленным (и пустым) UPDATE.
         if (0 === $job->getChunksTotal()) {
             $job->setChunksTotal(count($chunks));
+            $needsFlush = true;
+        }
+
+        // Один flush на markRunning + setChunksTotal — меньше round-trip'ов.
+        if ($needsFlush) {
             $this->entityManager->flush();
         }
 

--- a/site/src/MarketplaceAds/Repository/AdLoadJobRepository.php
+++ b/site/src/MarketplaceAds/Repository/AdLoadJobRepository.php
@@ -30,6 +30,19 @@ class AdLoadJobRepository extends ServiceEntityRepository
         ]);
     }
 
+    /**
+     * Находит задание по ID БЕЗ проверки company_id.
+     *
+     * IDOR-safe только в trusted-контексте: Messenger-хендлерах, где ID был
+     * сгенерирован внутри системы (см. LoadOzonAdStatisticsRangeHandler — в
+     * Message приходит только jobId). Для любого вызова, исходящего из
+     * HTTP-запроса, использовать {@see self::findByIdAndCompany()}.
+     */
+    public function find($id, $lockMode = null, $lockVersion = null): ?AdLoadJob
+    {
+        return parent::find($id, $lockMode, $lockVersion);
+    }
+
     public function findLatestActiveJobByCompanyAndMarketplace(
         string $companyId,
         MarketplaceType $marketplace,
@@ -94,6 +107,36 @@ class AdLoadJobRepository extends ServiceEntityRepository
     public function incrementFailedDays(string $jobId, string $companyId, int $delta = 1): int
     {
         return $this->atomicIncrement('failed_days', $jobId, $companyId, $delta);
+    }
+
+    /**
+     * Атомарный UPDATE `chunks_completed = chunks_completed + :delta`. В отличие
+     * от остальных счётчиков, company_id в WHERE не добавляем: метод зовётся
+     * только из {@see \App\MarketplaceAds\MessageHandler\FetchOzonAdStatisticsHandler}
+     * с jobId из собственного Message — companyId уже «прошит» в job через
+     * LoadOzonAdStatisticsRangeHandler.
+     */
+    public function incrementChunksCompleted(string $jobId, int $delta = 1): int
+    {
+        if ($delta < 1) {
+            throw new \InvalidArgumentException(sprintf(
+                'Инкремент должен быть >= 1, передано: %d',
+                $delta,
+            ));
+        }
+
+        return (int) $this->getEntityManager()->getConnection()->executeStatement(
+            <<<'SQL'
+                UPDATE marketplace_ad_load_jobs
+                SET chunks_completed = chunks_completed + :delta,
+                    updated_at = NOW()
+                WHERE id = :jobId
+                SQL,
+            [
+                'delta' => $delta,
+                'jobId' => $jobId,
+            ],
+        );
     }
 
     /**

--- a/site/src/MarketplaceAds/Repository/AdLoadJobRepository.php
+++ b/site/src/MarketplaceAds/Repository/AdLoadJobRepository.php
@@ -110,13 +110,15 @@ class AdLoadJobRepository extends ServiceEntityRepository
     }
 
     /**
-     * Атомарный UPDATE `chunks_completed = chunks_completed + :delta`. В отличие
-     * от остальных счётчиков, company_id в WHERE не добавляем: метод зовётся
-     * только из {@see \App\MarketplaceAds\MessageHandler\FetchOzonAdStatisticsHandler}
-     * с jobId из собственного Message — companyId уже «прошит» в job через
-     * LoadOzonAdStatisticsRangeHandler.
+     * Атомарный UPDATE `chunks_completed = chunks_completed + :delta`.
+     *
+     * `company_id` в WHERE — встроенный IDOR-guard, как у остальных инкрементов
+     * ({@see self::incrementLoadedDays}). Если jobId не принадлежит переданной
+     * компании, UPDATE затронет 0 строк.
+     *
+     * @return int число обновлённых строк (0 или 1)
      */
-    public function incrementChunksCompleted(string $jobId, int $delta = 1): int
+    public function incrementChunksCompleted(string $jobId, string $companyId, int $delta = 1): int
     {
         if ($delta < 1) {
             throw new \InvalidArgumentException(sprintf(
@@ -131,10 +133,12 @@ class AdLoadJobRepository extends ServiceEntityRepository
                 SET chunks_completed = chunks_completed + :delta,
                     updated_at = NOW()
                 WHERE id = :jobId
+                  AND company_id = :companyId
                 SQL,
             [
                 'delta' => $delta,
                 'jobId' => $jobId,
+                'companyId' => $companyId,
             ],
         );
     }

--- a/site/tests/Builders/MarketplaceAds/AdLoadJobBuilder.php
+++ b/site/tests/Builders/MarketplaceAds/AdLoadJobBuilder.php
@@ -23,6 +23,8 @@ final class AdLoadJobBuilder
     private int $loadedDays = 0;
     private int $processedDays = 0;
     private int $failedDays = 0;
+    private int $chunksTotal = 0;
+    private int $chunksCompleted = 0;
 
     private function __construct()
     {
@@ -119,6 +121,22 @@ final class AdLoadJobBuilder
         return $clone;
     }
 
+    public function withChunksTotal(int $total): self
+    {
+        $clone = clone $this;
+        $clone->chunksTotal = $total;
+
+        return $clone;
+    }
+
+    public function withChunksCompleted(int $completed): self
+    {
+        $clone = clone $this;
+        $clone->chunksCompleted = $completed;
+
+        return $clone;
+    }
+
     public function build(): AdLoadJob
     {
         $job = new AdLoadJob(
@@ -141,6 +159,12 @@ final class AdLoadJobBuilder
         }
         if ($this->failedDays !== 0) {
             $this->setProperty($job, 'failedDays', $this->failedDays);
+        }
+        if ($this->chunksTotal !== 0) {
+            $this->setProperty($job, 'chunksTotal', $this->chunksTotal);
+        }
+        if ($this->chunksCompleted !== 0) {
+            $this->setProperty($job, 'chunksCompleted', $this->chunksCompleted);
         }
 
         if (AdLoadJobStatus::PENDING !== $this->status) {

--- a/site/tests/Integration/MarketplaceAds/AdLoadJobRepositoryTest.php
+++ b/site/tests/Integration/MarketplaceAds/AdLoadJobRepositoryTest.php
@@ -354,6 +354,86 @@ final class AdLoadJobRepositoryTest extends IntegrationTestCase
         self::assertSame(0, $reloaded->getFailedDays());
     }
 
+    public function testIncrementChunksCompletedIsAtomic(): void
+    {
+        $this->seedCompany(self::COMPANY_ID, self::OWNER_ID, 'a@example.test');
+        $this->em->flush();
+
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(1)
+            ->build();
+        $this->repository->save($job);
+        $this->em->flush();
+        $jobId = $job->getId();
+        $this->em->clear();
+
+        // 100 последовательных инкрементов: каждый вызов — независимая SQL-транзакция,
+        // read-modify-write race исключён (значение хранится только в БД).
+        for ($i = 0; $i < 100; ++$i) {
+            $affected = $this->repository->incrementChunksCompleted($jobId);
+            self::assertSame(1, $affected);
+        }
+
+        $reloaded = $this->repository->findByIdAndCompany($jobId, self::COMPANY_ID);
+        self::assertNotNull($reloaded);
+        self::assertSame(100, $reloaded->getChunksCompleted());
+    }
+
+    /**
+     * @dataProvider nonPositiveDeltaProvider
+     */
+    public function testIncrementChunksCompletedRejectsNonPositiveDelta(int $delta): void
+    {
+        $this->seedCompany(self::COMPANY_ID, self::OWNER_ID, 'a@example.test');
+        $this->em->flush();
+
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(1)
+            ->build();
+        $this->repository->save($job);
+        $this->em->flush();
+        $jobId = $job->getId();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/Инкремент должен быть >= 1/');
+
+        $this->repository->incrementChunksCompleted($jobId, $delta);
+    }
+
+    public function testFindReturnsJobWithoutCompanyCheck(): void
+    {
+        $this->seedCompany(self::COMPANY_ID, self::OWNER_ID, 'a@example.test');
+        $this->em->flush();
+
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(1)
+            ->build();
+        $this->repository->save($job);
+        $this->em->flush();
+        $jobId = $job->getId();
+        $this->em->clear();
+
+        // find() — trusted-контекст (Messenger-хендлеры); company_id не фигурирует в WHERE.
+        $found = $this->repository->find($jobId);
+
+        self::assertNotNull($found);
+        self::assertSame($jobId, $found->getId());
+        self::assertSame(self::COMPANY_ID, $found->getCompanyId());
+    }
+
+    public function testFindReturnsNullForUnknownId(): void
+    {
+        $this->seedCompany(self::COMPANY_ID, self::OWNER_ID, 'a@example.test');
+        $this->em->flush();
+
+        $found = $this->repository->find('00000000-0000-0000-0000-000000000000');
+
+        self::assertNull($found);
+    }
+
     public function testIncrementBypassesUnitOfWorkAndUpdatesDirectly(): void
     {
         $this->seedCompany(self::COMPANY_ID, self::OWNER_ID, 'a@example.test');

--- a/site/tests/Integration/MarketplaceAds/AdLoadJobRepositoryTest.php
+++ b/site/tests/Integration/MarketplaceAds/AdLoadJobRepositoryTest.php
@@ -354,9 +354,10 @@ final class AdLoadJobRepositoryTest extends IntegrationTestCase
         self::assertSame(0, $reloaded->getFailedDays());
     }
 
-    public function testIncrementChunksCompletedIsAtomic(): void
+    public function testIncrementChunksCompletedIsAtomicAndIDORSafe(): void
     {
         $this->seedCompany(self::COMPANY_ID, self::OWNER_ID, 'a@example.test');
+        $this->seedCompany(self::OTHER_COMPANY_ID, self::OTHER_OWNER_ID, 'b@example.test');
         $this->em->flush();
 
         $job = AdLoadJobBuilder::aJob()
@@ -371,13 +372,22 @@ final class AdLoadJobRepositoryTest extends IntegrationTestCase
         // 100 последовательных инкрементов: каждый вызов — независимая SQL-транзакция,
         // read-modify-write race исключён (значение хранится только в БД).
         for ($i = 0; $i < 100; ++$i) {
-            $affected = $this->repository->incrementChunksCompleted($jobId);
+            $affected = $this->repository->incrementChunksCompleted($jobId, self::COMPANY_ID);
             self::assertSame(1, $affected);
         }
 
         $reloaded = $this->repository->findByIdAndCompany($jobId, self::COMPANY_ID);
         self::assertNotNull($reloaded);
         self::assertSame(100, $reloaded->getChunksCompleted());
+
+        // IDOR-guard: попытка инкрементить под чужой компанией — 0 затронутых строк.
+        $leaked = $this->repository->incrementChunksCompleted($jobId, self::OTHER_COMPANY_ID);
+        self::assertSame(0, $leaked);
+
+        $this->em->clear();
+        $reloaded = $this->repository->findByIdAndCompany($jobId, self::COMPANY_ID);
+        self::assertNotNull($reloaded);
+        self::assertSame(100, $reloaded->getChunksCompleted(), 'Счётчик не должен измениться от чужого company_id');
     }
 
     /**
@@ -399,7 +409,7 @@ final class AdLoadJobRepositoryTest extends IntegrationTestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('/Инкремент должен быть >= 1/');
 
-        $this->repository->incrementChunksCompleted($jobId, $delta);
+        $this->repository->incrementChunksCompleted($jobId, self::COMPANY_ID, $delta);
     }
 
     public function testFindReturnsJobWithoutCompanyCheck(): void

--- a/site/tests/Unit/MarketplaceAds/AdLoadJobTest.php
+++ b/site/tests/Unit/MarketplaceAds/AdLoadJobTest.php
@@ -196,4 +196,75 @@ final class AdLoadJobTest extends TestCase
 
         self::assertSame(10, $job->getProgress());
     }
+
+    public function testNewJobHasZeroChunksTotalAndCompleted(): void
+    {
+        $job = AdLoadJobBuilder::aJob()->build();
+
+        self::assertSame(0, $job->getChunksTotal());
+        self::assertSame(0, $job->getChunksCompleted());
+    }
+
+    public function testSetChunksTotalFromPendingPersistsValue(): void
+    {
+        $job = AdLoadJobBuilder::aJob()->build();
+        self::assertSame(AdLoadJobStatus::PENDING, $job->getStatus());
+
+        $job->setChunksTotal(7);
+
+        self::assertSame(7, $job->getChunksTotal());
+    }
+
+    public function testSetChunksTotalFromRunningPersistsValue(): void
+    {
+        // Retry-сценарий: job уже RUNNING, chunksTotal ещё можно поставить
+        // (в продакшн-коде это не произойдёт — handler проверяет chunksTotal === 0,
+        // но guard Entity должен позволять установку из активных статусов).
+        $job = AdLoadJobBuilder::aJob()->asRunning()->build();
+
+        $job->setChunksTotal(3);
+
+        self::assertSame(3, $job->getChunksTotal());
+    }
+
+    public function testSetChunksTotalOnCompletedThrows(): void
+    {
+        $job = AdLoadJobBuilder::aJob()->asCompleted()->build();
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('Нельзя установить chunksTotal на задание в терминальном статусе');
+
+        $job->setChunksTotal(5);
+    }
+
+    public function testSetChunksTotalOnFailedThrows(): void
+    {
+        $job = AdLoadJobBuilder::aJob()->asFailed('test')->build();
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('Нельзя установить chunksTotal на задание в терминальном статусе');
+
+        $job->setChunksTotal(5);
+    }
+
+    /**
+     * @dataProvider invalidChunksTotalProvider
+     */
+    public function testSetChunksTotalRejectsZeroOrNegative(int $total): void
+    {
+        $job = AdLoadJobBuilder::aJob()->build();
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $job->setChunksTotal($total);
+    }
+
+    public static function invalidChunksTotalProvider(): array
+    {
+        return [
+            'zero' => [0],
+            'negative' => [-1],
+            'large negative' => [-100],
+        ];
+    }
 }

--- a/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
@@ -102,7 +102,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $jobRepo->expects(self::never())->method('incrementFailedDays');
         $jobRepo->expects(self::once())
             ->method('incrementChunksCompleted')
-            ->with(self::JOB_ID)
+            ->with(self::JOB_ID, self::COMPANY_ID)
             ->willReturnCallback(static function () use (&$callOrder): int {
                 $callOrder[] = 'incrementChunksCompleted';
 
@@ -163,7 +163,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             ->willReturn(1);
         $jobRepo->expects(self::once())
             ->method('incrementChunksCompleted')
-            ->with(AdLoadJobBuilder::DEFAULT_ID)
+            ->with(AdLoadJobBuilder::DEFAULT_ID, self::COMPANY_ID)
             ->willReturn(1);
 
         $ozonClient = $this->createMock(OzonAdClient::class);
@@ -420,7 +420,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         // chunksCompleted инкрементится один раз на сообщение.
         $jobRepo->expects(self::once())
             ->method('incrementChunksCompleted')
-            ->with(AdLoadJobBuilder::DEFAULT_ID)
+            ->with(AdLoadJobBuilder::DEFAULT_ID, self::COMPANY_ID)
             ->willReturn(1);
 
         // Невалидный UTF-8 во втором дне — json_encode() без JSON_THROW_ON_ERROR вернёт false.
@@ -557,7 +557,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $jobRepo->expects(self::never())->method('markFailed');
         $jobRepo->expects(self::once())
             ->method('incrementChunksCompleted')
-            ->with(AdLoadJobBuilder::DEFAULT_ID)
+            ->with(AdLoadJobBuilder::DEFAULT_ID, self::COMPANY_ID)
             ->willReturn(1);
 
         $ozonClient = $this->createMock(OzonAdClient::class);
@@ -603,7 +603,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $jobRepo->expects(self::never())->method('incrementFailedDays');
         $jobRepo->expects(self::once())
             ->method('incrementChunksCompleted')
-            ->with(AdLoadJobBuilder::DEFAULT_ID)
+            ->with(AdLoadJobBuilder::DEFAULT_ID, self::COMPANY_ID)
             ->willReturn(1);
 
         $ozonClient = $this->createMock(OzonAdClient::class);

--- a/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
@@ -100,6 +100,14 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
                 return 1;
             });
         $jobRepo->expects(self::never())->method('incrementFailedDays');
+        $jobRepo->expects(self::once())
+            ->method('incrementChunksCompleted')
+            ->with(self::JOB_ID)
+            ->willReturnCallback(static function () use (&$callOrder): int {
+                $callOrder[] = 'incrementChunksCompleted';
+
+                return 1;
+            });
 
         $dispatchedIds = [];
         $messageBus = $this->createMock(MessageBusInterface::class);
@@ -124,9 +132,9 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
 
         self::assertCount(3, $savedDocs);
         self::assertSame(
-            ['flush', 'incrementLoadedDays', 'dispatch', 'dispatch', 'dispatch'],
+            ['flush', 'incrementLoadedDays', 'dispatch', 'dispatch', 'dispatch', 'incrementChunksCompleted'],
             $callOrder,
-            'save→flush→incrementLoadedDays→dispatch — строгий порядок, иначе race с ProcessAdRawDocumentHandler',
+            'save→flush→incrementLoadedDays→dispatch→incrementChunksCompleted — строгий порядок',
         );
         self::assertSame(
             array_map(static fn (AdRawDocument $d): string => $d->getId(), $savedDocs),
@@ -152,6 +160,10 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $jobRepo->expects(self::once())
             ->method('incrementLoadedDays')
             ->with(AdLoadJobBuilder::DEFAULT_ID, self::COMPANY_ID, 1)
+            ->willReturn(1);
+        $jobRepo->expects(self::once())
+            ->method('incrementChunksCompleted')
+            ->with(AdLoadJobBuilder::DEFAULT_ID)
             ->willReturn(1);
 
         $ozonClient = $this->createMock(OzonAdClient::class);
@@ -201,6 +213,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $jobRepo->expects(self::never())->method('markFailed');
         $jobRepo->expects(self::never())->method('incrementLoadedDays');
         $jobRepo->expects(self::never())->method('incrementFailedDays');
+        $jobRepo->expects(self::never())->method('incrementChunksCompleted');
 
         $ozonClient = $this->createMock(OzonAdClient::class);
         $ozonClient->expects(self::never())->method('fetchAdStatisticsRange');
@@ -230,6 +243,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $jobRepo = $this->createMock(AdLoadJobRepository::class);
         $jobRepo->method('findByIdAndCompany')->willReturn(null);
         $jobRepo->expects(self::never())->method('markFailed');
+        $jobRepo->expects(self::never())->method('incrementChunksCompleted');
 
         $ozonClient = $this->createMock(OzonAdClient::class);
         $ozonClient->expects(self::never())->method('fetchAdStatisticsRange');
@@ -265,6 +279,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             )
             ->willReturn(1);
         $jobRepo->expects(self::never())->method('incrementFailedDays');
+        $jobRepo->expects(self::never())->method('incrementChunksCompleted');
 
         $ozonClient = $this->createMock(OzonAdClient::class);
         $ozonClient->method('fetchAdStatisticsRange')
@@ -305,6 +320,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             )
             ->willReturn(1);
         $jobRepo->expects(self::never())->method('incrementFailedDays');
+        $jobRepo->expects(self::never())->method('incrementChunksCompleted');
 
         $ozonClient = $this->createMock(OzonAdClient::class);
         $ozonClient->method('fetchAdStatisticsRange')
@@ -343,6 +359,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $jobRepo->expects(self::never())->method('markFailed');
         $jobRepo->expects(self::never())->method('incrementFailedDays');
         $jobRepo->expects(self::never())->method('incrementLoadedDays');
+        $jobRepo->expects(self::never())->method('incrementChunksCompleted');
 
         $apiException = new \RuntimeException('Ozon 502 Bad Gateway');
 
@@ -399,6 +416,12 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             ->with(AdLoadJobBuilder::DEFAULT_ID, self::COMPANY_ID, 1)
             ->willReturn(1);
         $jobRepo->expects(self::never())->method('markFailed');
+        // Чанк физически отработан (частичный json-fail не срывает чанк) —
+        // chunksCompleted инкрементится один раз на сообщение.
+        $jobRepo->expects(self::once())
+            ->method('incrementChunksCompleted')
+            ->with(AdLoadJobBuilder::DEFAULT_ID)
+            ->willReturn(1);
 
         // Невалидный UTF-8 во втором дне — json_encode() без JSON_THROW_ON_ERROR вернёт false.
         $ozonClient = $this->createMock(OzonAdClient::class);
@@ -440,6 +463,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $jobRepo = $this->createMock(AdLoadJobRepository::class);
         $jobRepo->method('findByIdAndCompany')->willReturn($job);
         $jobRepo->method('incrementLoadedDays')->willReturn(1);
+        $jobRepo->method('incrementChunksCompleted')->willReturn(1);
 
         $ozonClient = $this->createMock(OzonAdClient::class);
         $ozonClient->method('fetchAdStatisticsRange')->willReturn([
@@ -489,6 +513,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
                 self::stringContains('Invalid date format'),
             )
             ->willReturn(1);
+        $jobRepo->expects(self::never())->method('incrementChunksCompleted');
 
         $ozonClient = $this->createMock(OzonAdClient::class);
         $ozonClient->expects(self::never())->method('fetchAdStatisticsRange');
@@ -530,6 +555,10 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             ->willReturn(1);
         $jobRepo->expects(self::never())->method('incrementFailedDays');
         $jobRepo->expects(self::never())->method('markFailed');
+        $jobRepo->expects(self::once())
+            ->method('incrementChunksCompleted')
+            ->with(AdLoadJobBuilder::DEFAULT_ID)
+            ->willReturn(1);
 
         $ozonClient = $this->createMock(OzonAdClient::class);
         $ozonClient->method('fetchAdStatisticsRange')->willReturn([
@@ -557,11 +586,12 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         ));
     }
 
-    public function testOzonReturnsNoDaysStillCountsEntireChunkAsLoaded(): void
+    public function testOzonReturnsNoDaysStillCountsEntireChunkAsLoadedAndIncrementsChunksCompleted(): void
     {
         // Крайний случай: Ozon вернул пустой массив (ни одной кампании за весь чанк).
         // Чанк отработал успешно → все chunkDays дней должны попасть в loaded_days,
-        // иначе job зависнет в RUNNING с прогрессом < 100%.
+        // а chunksCompleted — вырасти на 1 (иначе chunksTotal никогда не совпадёт
+        // с chunksCompleted и ProcessAdRawDocumentHandler не финализирует job).
         $job = AdLoadJobBuilder::aJob()->asRunning()->build();
 
         $jobRepo = $this->createMock(AdLoadJobRepository::class);
@@ -571,6 +601,10 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             ->with(AdLoadJobBuilder::DEFAULT_ID, self::COMPANY_ID, 3)
             ->willReturn(1);
         $jobRepo->expects(self::never())->method('incrementFailedDays');
+        $jobRepo->expects(self::once())
+            ->method('incrementChunksCompleted')
+            ->with(AdLoadJobBuilder::DEFAULT_ID)
+            ->willReturn(1);
 
         $ozonClient = $this->createMock(OzonAdClient::class);
         $ozonClient->method('fetchAdStatisticsRange')->willReturn([]);
@@ -612,6 +646,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
                 self::stringContains('2026-02-31'),
             )
             ->willReturn(1);
+        $jobRepo->expects(self::never())->method('incrementChunksCompleted');
 
         $ozonClient = $this->createMock(OzonAdClient::class);
         $ozonClient->expects(self::never())->method('fetchAdStatisticsRange');

--- a/site/tests/Unit/MarketplaceAds/LoadOzonAdStatisticsRangeHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/LoadOzonAdStatisticsRangeHandlerTest.php
@@ -1,0 +1,289 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MarketplaceAds;
+
+use App\MarketplaceAds\Entity\AdLoadJob;
+use App\MarketplaceAds\Enum\AdLoadJobStatus;
+use App\MarketplaceAds\Message\FetchOzonAdStatisticsMessage;
+use App\MarketplaceAds\Message\LoadOzonAdStatisticsRangeMessage;
+use App\MarketplaceAds\MessageHandler\LoadOzonAdStatisticsRangeHandler;
+use App\MarketplaceAds\Repository\AdLoadJobRepository;
+use App\Shared\Service\AppLogger;
+use App\Tests\Builders\MarketplaceAds\AdLoadJobBuilder;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Sentry\State\HubInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * Unit-тесты LoadOzonAdStatisticsRangeHandler.
+ *
+ * Ключевые инварианты:
+ *  - разбиение диапазона: 62-дневное окно включительно (шаг cursor = +61 день);
+ *  - markRunning + setChunksTotal выполняются только на первом проходе;
+ *  - на retry (RUNNING + chunksTotal > 0) — идемпотентный dispatch без повторного set;
+ *  - терминальный и отсутствующий job — no-op (OzonAdClient не дёргается,
+ *    FetchOzonAdStatisticsMessage не отправляется).
+ */
+final class LoadOzonAdStatisticsRangeHandlerTest extends TestCase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-111111111111';
+
+    public function testSingleDayRangeProducesOneChunk(): void
+    {
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withDateRange(
+                new \DateTimeImmutable('2026-01-15'),
+                new \DateTimeImmutable('2026-01-15'),
+            )
+            ->build();
+
+        $dispatched = $this->runHandlerAndCaptureDispatch($job, expectedChunks: 1);
+
+        self::assertCount(1, $dispatched);
+        self::assertSame('2026-01-15', $dispatched[0]->dateFrom);
+        self::assertSame('2026-01-15', $dispatched[0]->dateTo);
+    }
+
+    public function testExactly62DayRangeProducesOneChunk(): void
+    {
+        // 62 дня включительно: 2026-01-01..2026-03-03.
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withDateRange(
+                new \DateTimeImmutable('2026-01-01'),
+                new \DateTimeImmutable('2026-03-03'),
+            )
+            ->build();
+
+        $dispatched = $this->runHandlerAndCaptureDispatch($job, expectedChunks: 1);
+
+        self::assertCount(1, $dispatched);
+        self::assertSame('2026-01-01', $dispatched[0]->dateFrom);
+        self::assertSame('2026-03-03', $dispatched[0]->dateTo);
+        self::assertSame(62, $job->getTotalDays());
+    }
+
+    public function test63DayRangeProducesTwoChunks(): void
+    {
+        // 63 дня: 2026-01-01..2026-03-04 → [01-01..03-03] + [03-04..03-04].
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withDateRange(
+                new \DateTimeImmutable('2026-01-01'),
+                new \DateTimeImmutable('2026-03-04'),
+            )
+            ->build();
+
+        $dispatched = $this->runHandlerAndCaptureDispatch($job, expectedChunks: 2);
+
+        self::assertCount(2, $dispatched);
+        self::assertSame('2026-01-01', $dispatched[0]->dateFrom);
+        self::assertSame('2026-03-03', $dispatched[0]->dateTo);
+        self::assertSame('2026-03-04', $dispatched[1]->dateFrom);
+        self::assertSame('2026-03-04', $dispatched[1]->dateTo);
+    }
+
+    public function testFullYearRangeProducesSixChunks(): void
+    {
+        // 365 дней: 2026-01-01..2026-12-31. Ровно 5 × 62 = 310 + один хвостовой 55-дневный чанк.
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withDateRange(
+                new \DateTimeImmutable('2026-01-01'),
+                new \DateTimeImmutable('2026-12-31'),
+            )
+            ->build();
+
+        $dispatched = $this->runHandlerAndCaptureDispatch($job, expectedChunks: 6);
+
+        self::assertCount(6, $dispatched);
+        self::assertSame('2026-01-01', $dispatched[0]->dateFrom);
+        self::assertSame('2026-12-31', $dispatched[5]->dateTo);
+
+        $totalDays = 0;
+        foreach ($dispatched as $msg) {
+            $from = new \DateTimeImmutable($msg->dateFrom);
+            $to = new \DateTimeImmutable($msg->dateTo);
+            $days = (int) $from->diff($to)->days + 1;
+            self::assertLessThanOrEqual(62, $days, 'chunk exceeds Ozon limit');
+            $totalDays += $days;
+        }
+        self::assertSame(365, $totalDays, 'sum of chunk lengths must equal total days');
+    }
+
+    public function testPendingJobTransitionsToRunningAndSetsChunksTotal(): void
+    {
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withDateRange(
+                new \DateTimeImmutable('2026-01-01'),
+                new \DateTimeImmutable('2026-03-04'), // 63 дня → 2 чанка
+            )
+            ->build();
+
+        self::assertSame(AdLoadJobStatus::PENDING, $job->getStatus());
+        self::assertSame(0, $job->getChunksTotal());
+
+        $jobRepo = $this->createMock(AdLoadJobRepository::class);
+        $jobRepo->method('find')->willReturn($job);
+
+        // Два flush ожидаем: после markRunning() и после setChunksTotal().
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::exactly(2))->method('flush');
+
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::exactly(2))
+            ->method('dispatch')
+            ->willReturnCallback(static fn (object $m): Envelope => new Envelope($m));
+
+        $handler = $this->createHandler($jobRepo, $messageBus, $em);
+        $handler(new LoadOzonAdStatisticsRangeMessage($job->getId()));
+
+        self::assertSame(AdLoadJobStatus::RUNNING, $job->getStatus());
+        self::assertSame(2, $job->getChunksTotal(), 'chunksTotal должен совпасть с числом реальных чанков');
+        self::assertNotNull($job->getStartedAt());
+    }
+
+    public function testRunningJobSkipsMarkRunningAndSkipsSetChunksTotalIfAlreadySet(): void
+    {
+        // Retry-сценарий: воркер упал после dispatch'а части чанков,
+        // Messenger ретраит LoadOzonAdStatisticsRangeMessage. Job уже в RUNNING,
+        // chunksTotal выставлен — повторный set / markRunning недопустим.
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withDateRange(
+                new \DateTimeImmutable('2026-01-01'),
+                new \DateTimeImmutable('2026-03-04'),
+            )
+            ->withChunksTotal(2)
+            ->asRunning()
+            ->build();
+
+        self::assertSame(AdLoadJobStatus::RUNNING, $job->getStatus());
+        self::assertSame(2, $job->getChunksTotal());
+        $startedAtBefore = $job->getStartedAt();
+
+        $jobRepo = $this->createMock(AdLoadJobRepository::class);
+        $jobRepo->method('find')->willReturn($job);
+
+        // Ни одного flush: markRunning не вызван (job уже RUNNING),
+        // setChunksTotal не вызван (chunksTotal уже 2).
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::never())->method('flush');
+
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::exactly(2))
+            ->method('dispatch')
+            ->willReturnCallback(static fn (object $m): Envelope => new Envelope($m));
+
+        $handler = $this->createHandler($jobRepo, $messageBus, $em);
+        $handler(new LoadOzonAdStatisticsRangeMessage($job->getId()));
+
+        self::assertSame(AdLoadJobStatus::RUNNING, $job->getStatus());
+        self::assertSame(2, $job->getChunksTotal(), 'chunksTotal не должен переписываться на retry');
+        self::assertSame($startedAtBefore, $job->getStartedAt(), 'startedAt фиксируется только один раз');
+    }
+
+    public function testCompletedJobIsSkipped(): void
+    {
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->asCompleted()
+            ->build();
+
+        $this->assertTerminalJobIsNoOp($job);
+    }
+
+    public function testFailedJobIsSkipped(): void
+    {
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->asFailed('previous run')
+            ->build();
+
+        $this->assertTerminalJobIsNoOp($job);
+    }
+
+    public function testJobNotFoundLogsWarningAndReturns(): void
+    {
+        $jobRepo = $this->createMock(AdLoadJobRepository::class);
+        $jobRepo->method('find')->willReturn(null);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::never())->method('flush');
+
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::never())->method('dispatch');
+
+        $handler = $this->createHandler($jobRepo, $messageBus, $em);
+
+        // Не ретраим, не бросаем — просто возвращаемся.
+        $handler(new LoadOzonAdStatisticsRangeMessage('00000000-0000-0000-0000-000000000000'));
+
+        $this->addToAssertionCount(1);
+    }
+
+    private function assertTerminalJobIsNoOp(AdLoadJob $job): void
+    {
+        self::assertTrue($job->getStatus()->isTerminal());
+
+        $jobRepo = $this->createMock(AdLoadJobRepository::class);
+        $jobRepo->method('find')->willReturn($job);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::never())->method('flush');
+
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::never())->method('dispatch');
+
+        $handler = $this->createHandler($jobRepo, $messageBus, $em);
+        $handler(new LoadOzonAdStatisticsRangeMessage($job->getId()));
+    }
+
+    /**
+     * @return list<FetchOzonAdStatisticsMessage>
+     */
+    private function runHandlerAndCaptureDispatch(AdLoadJob $job, int $expectedChunks): array
+    {
+        $jobRepo = $this->createMock(AdLoadJobRepository::class);
+        $jobRepo->method('find')->willReturn($job);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+
+        /** @var list<FetchOzonAdStatisticsMessage> $dispatched */
+        $dispatched = [];
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::exactly($expectedChunks))
+            ->method('dispatch')
+            ->willReturnCallback(static function (object $msg) use (&$dispatched): Envelope {
+                self::assertInstanceOf(FetchOzonAdStatisticsMessage::class, $msg);
+                $dispatched[] = $msg;
+
+                return new Envelope($msg);
+            });
+
+        $handler = $this->createHandler($jobRepo, $messageBus, $em);
+        $handler(new LoadOzonAdStatisticsRangeMessage($job->getId()));
+
+        return $dispatched;
+    }
+
+    private function createHandler(
+        AdLoadJobRepository $jobRepo,
+        MessageBusInterface $messageBus,
+        EntityManagerInterface $em,
+    ): LoadOzonAdStatisticsRangeHandler {
+        return new LoadOzonAdStatisticsRangeHandler(
+            $jobRepo,
+            $messageBus,
+            new AppLogger(new NullLogger(), $this->createMock(HubInterface::class)),
+            $em,
+        );
+    }
+}

--- a/site/tests/Unit/MarketplaceAds/LoadOzonAdStatisticsRangeHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/LoadOzonAdStatisticsRangeHandlerTest.php
@@ -133,9 +133,9 @@ final class LoadOzonAdStatisticsRangeHandlerTest extends TestCase
         $jobRepo = $this->createMock(AdLoadJobRepository::class);
         $jobRepo->method('find')->willReturn($job);
 
-        // Два flush ожидаем: после markRunning() и после setChunksTotal().
+        // Один объединённый flush: markRunning() + setChunksTotal() коммитим одним round-trip'ом.
         $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects(self::exactly(2))->method('flush');
+        $em->expects(self::once())->method('flush');
 
         $messageBus = $this->createMock(MessageBusInterface::class);
         $messageBus->expects(self::exactly(2))


### PR DESCRIPTION
## Summary

Коммит 4 в пайплайне Ozon Performance. Введён оркестратор `LoadOzonAdStatisticsRangeHandler`, который принимает `jobId`, бьёт диапазон `dateFrom..dateTo` на чанки ≤ 62 дня включительно и диспатчит N × `FetchOzonAdStatisticsMessage`.

### Изменения
- **`AdLoadJob`** — поля `chunks_total` / `chunks_completed` + guard `setChunksTotal()` (Assert ≥ 1, DomainException на терминальных статусах).
- **`AdLoadJobRepository`** — `find()` в trusted-контексте (без company-guard, задокументировано) + атомарный `incrementChunksCompleted()` через raw `UPDATE`.
- **`Version20260418000001`** — миграция добавляет два `NOT NULL DEFAULT 0` счётчика.
- **`LoadOzonAdStatisticsRangeMessage`** — readonly DTO с одним `jobId`; routing `async` в `messenger.yaml`.
- **`LoadOzonAdStatisticsRangeHandler`** — оркестратор: `find()` → skip на терминале / отсутствующем job → `markRunning` только из PENDING → разбиение диапазона → `setChunksTotal` один раз → dispatch N сообщений.
- **`FetchOzonAdStatisticsHandler`** — на успешной обработке чанка (включая пустой ответ Ozon) инкрементит `chunks_completed`.

### Retry-идемпотентность
- `markRunning` только из PENDING (RUNNING → skip, это Messenger retry после сбоя воркера).
- `setChunksTotal` только если `chunksTotal == 0` (иначе пустой UPDATE).
- Терминальные / отсутствующие job'ы — no-op с warning/info-логом, без ретраев.

### Финализация
Финализация job'а (`markCompleted` когда `chunksCompleted == chunksTotal` и все документы обработаны) выносится в Коммит 5 и реализуется в `ProcessAdRawDocumentHandler`.

## Test plan

- [ ] `vendor/bin/phpunit tests/Unit/MarketplaceAds tests/Integration/MarketplaceAds` (unit + integration зелёные)
- [ ] `php bin/console doctrine:migrations:migrate --no-interaction` (миграция применяется)
- [ ] `php bin/console doctrine:schema:validate` (схема соответствует метаданным)
- [ ] `php bin/console debug:messenger` (`LoadOzonAdStatisticsRangeMessage` в транспорте `async`)
- [ ] `php bin/console debug:container LoadOzonAdStatisticsRangeHandler` (handler резолвится)

### Покрытие тестами
- `AdLoadJobTest`: +6 кейсов на `setChunksTotal` guard (PENDING/RUNNING set, терминал throws, 0/отрицательные значения через dataProvider).
- `AdLoadJobRepositoryTest`: +4 кейса (`incrementChunksCompleted` на 100 итерациях, отказ на `delta < 1`, `find()` без company-guard, `find()` для несуществующего id).
- `FetchOzonAdStatisticsHandlerTest`: патч всех 13 существующих кейсов — `expects(incrementChunksCompleted)` на happy-path / `expects(never)` на permanent/transient ошибках.
- `LoadOzonAdStatisticsRangeHandlerTest`: 9 новых кейсов — границы чанков (1 / 62 / 63 / 365 дней), PENDING→RUNNING переход + `chunksTotal` set, retry-skip на RUNNING, COMPLETED/FAILED no-op, job not found → warning.

https://claude.ai/code/session_012n2R6aDhUCnEXwkQSsq6ew