### PR TITLE
feat(marketplace-ads): finalize AdLoadJob lifecycle in ProcessAdRawDocumentHandler

### DIFF
--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -74,6 +74,7 @@ services:
     App\MarketplaceAnalytics\Repository\UnitEconomyCostMappingRepositoryInterface: '@App\MarketplaceAnalytics\Repository\UnitEconomyCostMappingRepository'
     App\MarketplaceAnalytics\Repository\ListingDailySnapshotRepositoryInterface: '@App\MarketplaceAnalytics\Repository\ListingDailySnapshotRepository'
     App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface: '@App\MarketplaceAds\Repository\AdLoadJobRepository'
+    App\MarketplaceAds\Repository\AdChunkProgressRepositoryInterface: '@App\MarketplaceAds\Repository\AdChunkProgressRepository'
 
     # ---------- Balance value providers ------------ #
     App\Balance\Provider\:

--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -73,6 +73,7 @@ services:
     App\Marketplace\Repository\MarketplaceOrderRepositoryInterface: '@App\Marketplace\Repository\MarketplaceOrderRepository'
     App\MarketplaceAnalytics\Repository\UnitEconomyCostMappingRepositoryInterface: '@App\MarketplaceAnalytics\Repository\UnitEconomyCostMappingRepository'
     App\MarketplaceAnalytics\Repository\ListingDailySnapshotRepositoryInterface: '@App\MarketplaceAnalytics\Repository\ListingDailySnapshotRepository'
+    App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface: '@App\MarketplaceAds\Repository\AdLoadJobRepository'
 
     # ---------- Balance value providers ------------ #
     App\Balance\Provider\:

--- a/site/migrations/Version20260418000002.php
+++ b/site/migrations/Version20260418000002.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * MarketplaceAds: вводит ledger-таблицу `marketplace_ad_chunk_progress` для
+ * идемпотентного учёта выгруженных чанков рекламной статистики.
+ *
+ * Мотивация (PR #1572, gemini/codex review):
+ *   Старая эвристика детекции retry оркестратора в FetchOzonAdStatisticsHandler
+ *   (`created === 0 && updated > 0`) ломалась в двух сценариях:
+ *     1) перезапуск загрузки того же периода с новым jobId — все документы
+ *        existing → chunks_completed никогда не инкрементился → новый job
+ *        застревал в RUNNING навсегда;
+ *     2) легитимный первый fetch чанка, где все дни уже были предзагружены
+ *        (CLI/manual pre-seed) — та же картина.
+ *
+ *   Ledger с UNIQUE (job_id, date_from, date_to) решает обе проблемы:
+ *   INSERT ... ON CONFLICT DO NOTHING атомарно отвечает «новый чанк» vs
+ *   «уже учтён», независимо от состояния AdRawDocument.
+ */
+final class Version20260418000002 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'MarketplaceAds: add marketplace_ad_chunk_progress ledger (idempotent chunks_completed gating)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE marketplace_ad_chunk_progress (
+                id UUID NOT NULL,
+                job_id UUID NOT NULL,
+                company_id UUID NOT NULL,
+                date_from DATE NOT NULL,
+                date_to DATE NOT NULL,
+                completed_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                PRIMARY KEY (id)
+            )
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            CREATE UNIQUE INDEX uniq_ad_chunk_progress_job_range
+                ON marketplace_ad_chunk_progress (job_id, date_from, date_to)
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            CREATE INDEX idx_ad_chunk_progress_company
+                ON marketplace_ad_chunk_progress (company_id)
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE marketplace_ad_chunk_progress');
+    }
+}

--- a/site/migrations/Version20260418000003.php
+++ b/site/migrations/Version20260418000003.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * MarketplaceAds: переводит учёт обработки рекламных документов с counter-based
+ * модели на AdLoadJob (processed_days/failed_days) на per-document статус
+ * FAILED у AdRawDocument.
+ *
+ * Мотивация (PR #1572, round 2):
+ *   Счётчики processed_days/failed_days на AdLoadJob инкрементировались через
+ *   raw DBAL UPDATE из разных воркеров и из catch-блока ProcessAdRawDocumentHandler.
+ *   При retry Messenger'а failed_days overshoot'ил (каждая попытка +1), а
+ *   «расхождение» с COUNT(AdRawDocument) ловилось только на финализации — в
+ *   error-branch tryFinalizeJob приходилось специально отключать, иначе job
+ *   помечался FAILED раньше, чем retry мог завершить работу.
+ *
+ *   Решение: факт обработки/ошибки живёт на самом документе как enum-статус
+ *   (PROCESSED / FAILED). Финализация считает COUNT(PROCESSED) + COUNT(FAILED)
+ *   и сравнивает с total COUNT в диапазоне — источник правды идемпотентен и
+ *   не требует обратных декрементов при retry.
+ *
+ * Изменения:
+ *   - marketplace_ad_raw_documents.processing_error TEXT NULL (причина FAILED);
+ *   - marketplace_ad_load_jobs: DROP COLUMN processed_days, failed_days.
+ */
+final class Version20260418000003 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'MarketplaceAds: move processing state from AdLoadJob counters to AdRawDocument.status (FAILED)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE marketplace_ad_raw_documents ADD COLUMN processing_error TEXT DEFAULT NULL');
+
+        $this->addSql('ALTER TABLE marketplace_ad_load_jobs DROP COLUMN processed_days');
+        $this->addSql('ALTER TABLE marketplace_ad_load_jobs DROP COLUMN failed_days');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE marketplace_ad_load_jobs ADD COLUMN processed_days INT NOT NULL DEFAULT 0');
+        $this->addSql('ALTER TABLE marketplace_ad_load_jobs ADD COLUMN failed_days INT NOT NULL DEFAULT 0');
+
+        $this->addSql('ALTER TABLE marketplace_ad_raw_documents DROP COLUMN processing_error');
+    }
+}

--- a/site/src/MarketplaceAds/Application/ProcessAdRawDocumentAction.php
+++ b/site/src/MarketplaceAds/Application/ProcessAdRawDocumentAction.php
@@ -50,7 +50,15 @@ final readonly class ProcessAdRawDocumentAction
             ?? throw new AdRawDocumentAlreadyProcessedException(sprintf('AdRawDocument %s не найден.', $adRawDocumentId));
 
         if (AdRawDocumentStatus::DRAFT !== $rawDocument->getStatus()) {
-            throw new AdRawDocumentAlreadyProcessedException(sprintf('AdRawDocument %s в статусе %s, ожидался draft.', $adRawDocumentId, $rawDocument->getStatus()->value));
+            // FAILED попадает сюда на retry после предыдущей неудачной обработки: Handler
+            // уже пометил документ через markFailedWithReason, job финализирован по
+            // COUNT(terminal). Возвращаемся короткой веткой — Handler поймает это
+            // исключение и тихо ACK'нет сообщение, Messenger больше не retry'ит.
+            throw new AdRawDocumentAlreadyProcessedException(sprintf(
+                'AdRawDocument %s в статусе %s, ожидался draft для обработки.',
+                $adRawDocumentId,
+                $rawDocument->getStatus()->value,
+            ));
         }
 
         $marketplace = $rawDocument->getMarketplace();

--- a/site/src/MarketplaceAds/Entity/AdChunkProgress.php
+++ b/site/src/MarketplaceAds/Entity/AdChunkProgress.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Entity;
+
+use App\MarketplaceAds\Repository\AdChunkProgressRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
+use Webmozart\Assert\Assert;
+
+/**
+ * Ledger-запись об успешно выгруженном чанке AdLoadJob'а.
+ *
+ * UNIQUE (job_id, date_from, date_to) превращает учёт chunks_completed в
+ * идемпотентную операцию: INSERT ... ON CONFLICT DO NOTHING вернёт 1 строку
+ * только при первой вставке, на retry'ях (оркестратор / Messenger) — 0.
+ * Это развязывает детекцию retry от состояния AdRawDocument (которое может
+ * быть existing по другим причинам: CLI-preload, новый jobId на уже
+ * загруженный период).
+ *
+ * Запись читается только в тестах и для поддержки — hot-path использует
+ * лишь INSERT через {@see AdChunkProgressRepository::tryMarkCompleted()}.
+ */
+#[ORM\Entity(repositoryClass: AdChunkProgressRepository::class)]
+#[ORM\Table(name: 'marketplace_ad_chunk_progress')]
+#[ORM\UniqueConstraint(name: 'uniq_ad_chunk_progress_job_range', columns: ['job_id', 'date_from', 'date_to'])]
+#[ORM\Index(columns: ['company_id'], name: 'idx_ad_chunk_progress_company')]
+class AdChunkProgress
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid', unique: true)]
+    private string $id;
+
+    #[ORM\Column(type: 'guid')]
+    private string $jobId;
+
+    #[ORM\Column(type: 'guid')]
+    private string $companyId;
+
+    #[ORM\Column(type: 'date_immutable')]
+    private \DateTimeImmutable $dateFrom;
+
+    #[ORM\Column(type: 'date_immutable')]
+    private \DateTimeImmutable $dateTo;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $completedAt;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $createdAt;
+
+    public function __construct(
+        string $jobId,
+        string $companyId,
+        \DateTimeImmutable $dateFrom,
+        \DateTimeImmutable $dateTo,
+    ) {
+        $this->id = Uuid::uuid7()->toString();
+        Assert::uuid($jobId);
+        Assert::uuid($companyId);
+
+        $dateFrom = $dateFrom->setTime(0, 0);
+        $dateTo = $dateTo->setTime(0, 0);
+
+        if ($dateFrom > $dateTo) {
+            throw new \DomainException('dateFrom не может быть позже dateTo.');
+        }
+
+        $this->jobId = $jobId;
+        $this->companyId = $companyId;
+        $this->dateFrom = $dateFrom;
+        $this->dateTo = $dateTo;
+        $this->completedAt = new \DateTimeImmutable();
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getJobId(): string
+    {
+        return $this->jobId;
+    }
+
+    public function getCompanyId(): string
+    {
+        return $this->companyId;
+    }
+
+    public function getDateFrom(): \DateTimeImmutable
+    {
+        return $this->dateFrom;
+    }
+
+    public function getDateTo(): \DateTimeImmutable
+    {
+        return $this->dateTo;
+    }
+
+    public function getCompletedAt(): \DateTimeImmutable
+    {
+        return $this->completedAt;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/site/src/MarketplaceAds/Entity/AdLoadJob.php
+++ b/site/src/MarketplaceAds/Entity/AdLoadJob.php
@@ -14,10 +14,15 @@ use Webmozart\Assert\Assert;
 /**
  * Задание на пакетную загрузку рекламных отчётов за период.
  *
- * Прогресс-счётчики (loadedDays/processedDays/failedDays) инкрементируются
- * параллельными воркерами и сознательно НЕ имеют guard-методов на Entity —
- * изменения идут атомарным `UPDATE ... SET x = x + :delta` через Repository,
- * минуя Doctrine UoW. См. {@see AdLoadJobRepository}.
+ * Прогресс-счётчик loadedDays и chunksCompleted инкрементируются параллельными
+ * воркерами без guard-методов на Entity: изменения идут атомарным
+ * `UPDATE ... SET x = x + :delta` через Repository, минуя Doctrine UoW. См.
+ * {@see AdLoadJobRepository}.
+ *
+ * Состояние «обработан / не обработан / ошибка» для каждого дня хранится НЕ на
+ * AdLoadJob, а на {@see AdRawDocument} как status (DRAFT / PROCESSED / FAILED).
+ * Финализация job'а считает терминальные документы в его диапазоне — counter-
+ * based поля processedDays/failedDays удалены (см. Version20260418000003).
  */
 #[ORM\Entity(repositoryClass: AdLoadJobRepository::class)]
 #[ORM\Table(name: 'marketplace_ad_load_jobs')]
@@ -47,12 +52,6 @@ class AdLoadJob
 
     #[ORM\Column(type: 'integer', options: ['default' => 0])]
     private int $loadedDays = 0;
-
-    #[ORM\Column(type: 'integer', options: ['default' => 0])]
-    private int $processedDays = 0;
-
-    #[ORM\Column(type: 'integer', options: ['default' => 0])]
-    private int $failedDays = 0;
 
     #[ORM\Column(type: 'integer', options: ['default' => 0])]
     private int $chunksTotal = 0;
@@ -176,8 +175,12 @@ class AdLoadJob
     }
 
     /**
-     * Доля выполненных шагов (loaded + failed) относительно totalDays, 0..100.
-     * Округление — до целого процента, чтобы UI не «дёргался» на долях.
+     * Доля выгруженных дней относительно totalDays, 0..100. Округление — до
+     * целого процента, чтобы UI не «дёргался» на долях.
+     *
+     * Считает только loadedDays (faktическая выгрузка из API). Ошибки парсинга
+     * и partial-успехи живут на AdRawDocument.status — для общего прогресса
+     * «скачано» они не релевантны.
      */
     public function getProgress(): int
     {
@@ -185,8 +188,7 @@ class AdLoadJob
             return 0;
         }
 
-        $done = $this->loadedDays + $this->failedDays;
-        $progress = (int) floor(($done * 100) / $this->totalDays);
+        $progress = (int) floor(($this->loadedDays * 100) / $this->totalDays);
 
         return min(100, max(0, $progress));
     }
@@ -224,16 +226,6 @@ class AdLoadJob
     public function getLoadedDays(): int
     {
         return $this->loadedDays;
-    }
-
-    public function getProcessedDays(): int
-    {
-        return $this->processedDays;
-    }
-
-    public function getFailedDays(): int
-    {
-        return $this->failedDays;
     }
 
     public function getChunksTotal(): int

--- a/site/src/MarketplaceAds/Entity/AdRawDocument.php
+++ b/site/src/MarketplaceAds/Entity/AdRawDocument.php
@@ -43,6 +43,9 @@ class AdRawDocument
     #[ORM\Column(type: 'string', length: 20, enumType: AdRawDocumentStatus::class, options: ['default' => 'draft'])]
     private AdRawDocumentStatus $status;
 
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $processingError = null;
+
     #[ORM\Column(type: 'datetime_immutable')]
     private \DateTimeImmutable $createdAt;
 
@@ -77,6 +80,29 @@ class AdRawDocument
         }
 
         $this->status = AdRawDocumentStatus::PROCESSED;
+        $this->processingError = null;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    /**
+     * Помечает документ как FAILED с сохранением причины.
+     *
+     * Терминальный статус: повторная обработка невозможна без reset/update.
+     * Guard-метод для case'ов, когда AdRawDocument уже managed в UoW. В
+     * async-хендлере ProcessAdRawDocumentHandler используется не этот метод,
+     * а атомарный DBAL-update через Repository::markFailedWithReason — он
+     * идемпотентен и не требует флаша.
+     */
+    public function markFailed(string $reason): void
+    {
+        Assert::notEmpty($reason, 'Причина ошибки не может быть пустой.');
+
+        if (AdRawDocumentStatus::PROCESSED === $this->status) {
+            throw new \DomainException('Нельзя пометить PROCESSED-документ как FAILED.');
+        }
+
+        $this->status = AdRawDocumentStatus::FAILED;
+        $this->processingError = $reason;
         $this->updatedAt = new \DateTimeImmutable();
     }
 
@@ -87,6 +113,7 @@ class AdRawDocument
         }
 
         $this->status = AdRawDocumentStatus::DRAFT;
+        $this->processingError = null;
         $this->updatedAt = new \DateTimeImmutable();
     }
 
@@ -94,6 +121,7 @@ class AdRawDocument
     {
         $this->rawPayload = $rawPayload;
         $this->status = AdRawDocumentStatus::DRAFT;
+        $this->processingError = null;
         $this->updatedAt = new \DateTimeImmutable();
     }
 
@@ -130,6 +158,11 @@ class AdRawDocument
     public function getStatus(): AdRawDocumentStatus
     {
         return $this->status;
+    }
+
+    public function getProcessingError(): ?string
+    {
+        return $this->processingError;
     }
 
     public function getCreatedAt(): \DateTimeImmutable

--- a/site/src/MarketplaceAds/Enum/AdRawDocumentStatus.php
+++ b/site/src/MarketplaceAds/Enum/AdRawDocumentStatus.php
@@ -6,22 +6,44 @@ namespace App\MarketplaceAds\Enum;
 
 /**
  * Статус сырого рекламного документа, загруженного из API маркетплейса.
+ *
+ * DRAFT       — начальное состояние после upsert'а из FetchOzonAdStatisticsHandler;
+ * PROCESSED   — Action отработал без ошибок и без пропусков SKU;
+ * FAILED      — исключение в Action ИЛИ частичный успех (остался в DRAFT после
+ *               транзакции). Терминальный статус, используется как единственный
+ *               источник правды об «этот документ не должен больше обрабатываться»
+ *               для финализации AdLoadJob: COUNT(PROCESSED) + COUNT(FAILED) ==
+ *               COUNT(total). До введения FAILED это же состояние считалось через
+ *               счётчики processed_days/failed_days на AdLoadJob — см.
+ *               Version20260418000003, которая эти счётчики убрала.
  */
 enum AdRawDocumentStatus: string
 {
     case DRAFT = 'draft';
     case PROCESSED = 'processed';
+    case FAILED = 'failed';
 
     public function getLabel(): string
     {
         return match ($this) {
             self::DRAFT => 'Черновик',
             self::PROCESSED => 'Обработан',
+            self::FAILED => 'Ошибка',
         };
     }
 
     public function isDraft(): bool
     {
         return self::DRAFT === $this;
+    }
+
+    /**
+     * true, если документ в терминальном состоянии (PROCESSED или FAILED) —
+     * повторная обработка не требуется. Handler / Action используют это для
+     * short-circuit'а на retry Messenger'а.
+     */
+    public function isTerminal(): bool
+    {
+        return self::PROCESSED === $this || self::FAILED === $this;
     }
 }

--- a/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
@@ -10,6 +10,7 @@ use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonAdClient;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonPermanentApiException;
 use App\MarketplaceAds\Message\FetchOzonAdStatisticsMessage;
 use App\MarketplaceAds\Message\ProcessAdRawDocumentMessage;
+use App\MarketplaceAds\Repository\AdChunkProgressRepositoryInterface;
 use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
 use App\MarketplaceAds\Repository\AdRawDocumentRepository;
 use App\Shared\Service\AppLogger;
@@ -34,7 +35,14 @@ use Symfony\Component\Messenger\MessageBusInterface;
  *     дней, чем запросили (дни без кампаний), и такие «пустые» дни всё равно
  *     должны учитываться как обработанные, иначе прогресс зависнет ниже 100%;
  *  6) dispatch ProcessAdRawDocumentMessage за каждый документ — уже ПОСЛЕ
- *     flush, чтобы следующий handler увидел документ в БД.
+ *     flush, чтобы следующий handler увидел документ в БД;
+ *  7) идемпотентно фиксируем факт завершения чанка в ledger-таблице
+ *     {@see \App\MarketplaceAds\Entity\AdChunkProgress}: INSERT ... ON CONFLICT
+ *     DO NOTHING возвращает true только при ПЕРВОЙ вставке (jobId, range);
+ *     только тогда инкрементим chunks_completed. Это защищает от overshoot
+ *     при retry оркестратора, retry Messenger'а после сбоя пост-flush и от
+ *     CLI-preload'а тех же дней (кейсы, в которых эвристика по created/updated
+ *     из прошлой итерации ломалась).
  *
  * Политика ошибок:
  *  - \InvalidArgumentException (range > 62 дней / from > to): permanent bug
@@ -58,6 +66,7 @@ final class FetchOzonAdStatisticsHandler
         private readonly OzonAdClient $ozonAdClient,
         private readonly AdRawDocumentRepository $adRawDocumentRepository,
         private readonly AdLoadJobRepositoryInterface $adLoadJobRepository,
+        private readonly AdChunkProgressRepositoryInterface $adChunkProgressRepository,
         private readonly EntityManagerInterface $entityManager,
         private readonly MessageBusInterface $messageBus,
         private readonly AppLogger $logger,
@@ -169,10 +178,10 @@ final class FetchOzonAdStatisticsHandler
             throw $e;
         }
 
-        /** @var list<AdRawDocument> $created */
-        $created = [];
-        /** @var list<AdRawDocument> $updated */
-        $updated = [];
+        /** @var list<AdRawDocument> $documents */
+        $documents = [];
+        $createdCount = 0;
+        $updatedCount = 0;
         $skippedDays = 0;
 
         foreach ($result as $dateString => $payload) {
@@ -210,16 +219,16 @@ final class FetchOzonAdStatisticsHandler
             if (null === $existing) {
                 $doc = new AdRawDocument($message->companyId, MarketplaceType::OZON, $reportDate, $json);
                 $this->adRawDocumentRepository->save($doc);
-                $created[] = $doc;
+                $documents[] = $doc;
+                ++$createdCount;
             } else {
                 // updatePayload() сам сбрасывает status в DRAFT и обновляет updatedAt —
                 // дополнительный resetToDraft() не нужен и привёл бы к двойному setter'у.
                 $existing->updatePayload($json);
-                $updated[] = $existing;
+                $documents[] = $existing;
+                ++$updatedCount;
             }
         }
-
-        $documents = array_merge($created, $updated);
 
         $this->entityManager->flush();
 
@@ -252,29 +261,32 @@ final class FetchOzonAdStatisticsHandler
             ));
         }
 
-        // Детекция retry оркестратора: если ни одного нового документа не создано,
-        // но есть существующие — тот же чанк уже обрабатывался. chunks_completed
-        // на нём инкрементился в прошлый раз; повторный инкремент привёл бы к
-        // overshoot (chunksCompleted > chunksTotal) и ложной финализации раньше
-        // времени. Матрица:
-        //   created > 0                  → первый fetch (были данные) → increment
-        //   created = 0, updated = 0     → первый fetch (Ozon вернул пусто) → increment
-        //   created = 0, updated > 0     → retry оркестратора → skip
-        // loaded_days тут всё равно overshoot'ит на retry (coverage-based), но
-        // это не критично: финализация в ProcessAdRawDocumentHandler смотрит на
-        // COUNT(AdRawDocument в диапазоне job'а), а он идемпотентен через
-        // UniqueConstraint(company_id, marketplace, report_date).
-        $isRetryOfOrchestrator = [] === $created && [] !== $updated;
+        // Идемпотентный учёт chunks_completed через ledger-таблицу
+        // marketplace_ad_chunk_progress с UNIQUE (job_id, date_from, date_to).
+        // tryMarkCompleted возвращает true только при ПЕРВОЙ вставке пары
+        // (jobId, range). Любой повтор — retry оркестратора, retry Messenger'а
+        // после сбоя пост-flush, новый jobId на уже загруженный период — вернёт
+        // false, и мы не инкрементим chunks_completed (иначе overshoot →
+        // ложная финализация). Решение заменяет старую эвристику по
+        // (created=0 && updated>0), которая ломалась на CLI-preloaded данных
+        // и на кросс-job re-fetch.
+        $chunkNewlyCompleted = $this->adChunkProgressRepository->tryMarkCompleted(
+            $message->jobId,
+            $message->companyId,
+            $dateFrom,
+            $dateTo,
+        );
 
-        if (!$isRetryOfOrchestrator) {
+        if ($chunkNewlyCompleted) {
             $this->adLoadJobRepository->incrementChunksCompleted($message->jobId, $message->companyId);
         } else {
-            $this->logger->info('Ozon ad statistics chunk re-fetch detected, skipping chunks_completed', [
+            $this->logger->info('Ozon ad statistics chunk already accounted in ledger, chunks_completed skipped', [
                 'jobId' => $message->jobId,
                 'companyId' => $message->companyId,
                 'dateFrom' => $message->dateFrom,
                 'dateTo' => $message->dateTo,
-                'updatedCount' => count($updated),
+                'documentsCreated' => $createdCount,
+                'documentsUpdated' => $updatedCount,
             ]);
         }
 
@@ -284,10 +296,11 @@ final class FetchOzonAdStatisticsHandler
             'dateFrom' => $message->dateFrom,
             'dateTo' => $message->dateTo,
             'chunkDays' => $chunkDays,
-            'documentsCreated' => count($created),
-            'documentsUpdated' => count($updated),
+            'documentsCreated' => $createdCount,
+            'documentsUpdated' => $updatedCount,
             'daysLoaded' => $loadedDelta,
             'daysSkipped' => $skippedDays,
+            'chunkNewlyCompleted' => $chunkNewlyCompleted,
         ]);
     }
 }

--- a/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
@@ -10,7 +10,7 @@ use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonAdClient;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonPermanentApiException;
 use App\MarketplaceAds\Message\FetchOzonAdStatisticsMessage;
 use App\MarketplaceAds\Message\ProcessAdRawDocumentMessage;
-use App\MarketplaceAds\Repository\AdLoadJobRepository;
+use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
 use App\MarketplaceAds\Repository\AdRawDocumentRepository;
 use App\Shared\Service\AppLogger;
 use Doctrine\ORM\EntityManagerInterface;
@@ -57,7 +57,7 @@ final class FetchOzonAdStatisticsHandler
     public function __construct(
         private readonly OzonAdClient $ozonAdClient,
         private readonly AdRawDocumentRepository $adRawDocumentRepository,
-        private readonly AdLoadJobRepository $adLoadJobRepository,
+        private readonly AdLoadJobRepositoryInterface $adLoadJobRepository,
         private readonly EntityManagerInterface $entityManager,
         private readonly MessageBusInterface $messageBus,
         private readonly AppLogger $logger,
@@ -169,8 +169,10 @@ final class FetchOzonAdStatisticsHandler
             throw $e;
         }
 
-        /** @var list<AdRawDocument> $documents */
-        $documents = [];
+        /** @var list<AdRawDocument> $created */
+        $created = [];
+        /** @var list<AdRawDocument> $updated */
+        $updated = [];
         $skippedDays = 0;
 
         foreach ($result as $dateString => $payload) {
@@ -208,14 +210,16 @@ final class FetchOzonAdStatisticsHandler
             if (null === $existing) {
                 $doc = new AdRawDocument($message->companyId, MarketplaceType::OZON, $reportDate, $json);
                 $this->adRawDocumentRepository->save($doc);
-                $documents[] = $doc;
+                $created[] = $doc;
             } else {
                 // updatePayload() сам сбрасывает status в DRAFT и обновляет updatedAt —
                 // дополнительный resetToDraft() не нужен и привёл бы к двойному setter'у.
                 $existing->updatePayload($json);
-                $documents[] = $existing;
+                $updated[] = $existing;
             }
         }
+
+        $documents = array_merge($created, $updated);
 
         $this->entityManager->flush();
 
@@ -248,12 +252,31 @@ final class FetchOzonAdStatisticsHandler
             ));
         }
 
-        // Чанк физически отработан — инкрементим даже на пустом результате Ozon
-        // (ноль документов, ноль dispatch'ей): permanent/transient ошибки до сюда
-        // не доходят (rethrow / UnrecoverableMessageHandlingException выше).
-        // Финализация job'а по условию chunksCompleted == chunksTotal — в
-        // ProcessAdRawDocumentHandler (Коммит 5).
-        $this->adLoadJobRepository->incrementChunksCompleted($message->jobId, $message->companyId);
+        // Детекция retry оркестратора: если ни одного нового документа не создано,
+        // но есть существующие — тот же чанк уже обрабатывался. chunks_completed
+        // на нём инкрементился в прошлый раз; повторный инкремент привёл бы к
+        // overshoot (chunksCompleted > chunksTotal) и ложной финализации раньше
+        // времени. Матрица:
+        //   created > 0                  → первый fetch (были данные) → increment
+        //   created = 0, updated = 0     → первый fetch (Ozon вернул пусто) → increment
+        //   created = 0, updated > 0     → retry оркестратора → skip
+        // loaded_days тут всё равно overshoot'ит на retry (coverage-based), но
+        // это не критично: финализация в ProcessAdRawDocumentHandler смотрит на
+        // COUNT(AdRawDocument в диапазоне job'а), а он идемпотентен через
+        // UniqueConstraint(company_id, marketplace, report_date).
+        $isRetryOfOrchestrator = [] === $created && [] !== $updated;
+
+        if (!$isRetryOfOrchestrator) {
+            $this->adLoadJobRepository->incrementChunksCompleted($message->jobId, $message->companyId);
+        } else {
+            $this->logger->info('Ozon ad statistics chunk re-fetch detected, skipping chunks_completed', [
+                'jobId' => $message->jobId,
+                'companyId' => $message->companyId,
+                'dateFrom' => $message->dateFrom,
+                'dateTo' => $message->dateTo,
+                'updatedCount' => count($updated),
+            ]);
+        }
 
         $this->logger->info('Ozon ad statistics chunk processed', [
             'jobId' => $message->jobId,
@@ -261,7 +284,8 @@ final class FetchOzonAdStatisticsHandler
             'dateFrom' => $message->dateFrom,
             'dateTo' => $message->dateTo,
             'chunkDays' => $chunkDays,
-            'documentsUpserted' => count($documents),
+            'documentsCreated' => count($created),
+            'documentsUpdated' => count($updated),
             'daysLoaded' => $loadedDelta,
             'daysSkipped' => $skippedDays,
         ]);

--- a/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
@@ -50,9 +50,8 @@ use Symfony\Component\Messenger\MessageBusInterface;
  *  - OzonPermanentApiException (403, missing credentials): permanent →
  *    markFailed(job) + UnrecoverableMessageHandlingException.
  *  - Прочие \Throwable (5xx, сеть, JSON-ошибки): transient → rethrow
- *    (Messenger ретраит по стратегии async). failed_days здесь НЕ инкрементим:
- *    при max_retries=3 получили бы +chunkDays на каждую попытку (итого 4·chunkDays
- *    для одного реально упавшего чанка), что ломает прогресс. Когда retry'и
+ *    (Messenger ретраит по стратегии async). Прогресс чанка не двигаем: при
+ *    max_retries=3 overshoot'или бы счётчики на каждую попытку. Когда retry'и
  *    исчерпаются, message уйдёт в failed-транспорт — его разбирает оператор.
  *
  * Порядок операций строгий: save() → flush() → incrementLoadedDays() →
@@ -164,7 +163,7 @@ final class FetchOzonAdStatisticsHandler
             );
         } catch (\Throwable $e) {
             // Сетевые сбои / 5xx / JSON-ошибки — transient, Messenger сделает retry.
-            // failed_days НЕ инкрементим: иначе при max_retries=3 одна реальная
+            // loaded_days НЕ инкрементим: иначе при max_retries=3 одна реальная
             // поломка чанка даст +4·chunkDays (после каждого из 4 аттемптов),
             // прогресс задания уйдёт в минус / выше 100%.
             $this->logger->error('Transient failure loading Ozon ad statistics chunk', $e, [
@@ -236,7 +235,7 @@ final class FetchOzonAdStatisticsHandler
         // по count($documents): Ozon легитимно возвращает меньше дней, чем
         // запросили, если за какие-то дни вообще нет кампаний. Если брать
         // count($documents), такие «пустые» дни навсегда останутся
-        // непосчитанными в прогрессе, и (loaded + failed) не дорастёт до total.
+        // непосчитанными в прогрессе выгрузки.
         $loadedDelta = $chunkDays - $skippedDays;
         if ($loadedDelta > 0) {
             $this->adLoadJobRepository->incrementLoadedDays(
@@ -246,12 +245,19 @@ final class FetchOzonAdStatisticsHandler
             );
         }
 
+        // Skipped days (json_encode failure на конкретном дне) больше не
+        // попадают в отдельный счётчик на AdLoadJob: состояние обработки
+        // живёт на AdRawDocument.status, а skipped day НЕ создал документ и,
+        // значит, не влияет на общий total/terminal баланс финализации job'а.
+        // Факт скипа уже логируется выше (logger->warning на json_encode).
         if ($skippedDays > 0) {
-            $this->adLoadJobRepository->incrementFailedDays(
-                $message->jobId,
-                $message->companyId,
-                $skippedDays,
-            );
+            $this->logger->warning('Ozon ad statistics chunk: some days skipped at persistence', [
+                'jobId' => $message->jobId,
+                'companyId' => $message->companyId,
+                'dateFrom' => $message->dateFrom,
+                'dateTo' => $message->dateTo,
+                'skippedDays' => $skippedDays,
+            ]);
         }
 
         foreach ($documents as $doc) {

--- a/site/src/MarketplaceAds/MessageHandler/LoadOzonAdStatisticsRangeHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/LoadOzonAdStatisticsRangeHandler.php
@@ -30,7 +30,8 @@ use Symfony\Component\Messenger\MessageBusInterface;
  *
  * Финализация job'а (markCompleted) — ответственность ProcessAdRawDocumentHandler
  * (Коммит 5): как только chunksCompleted == chunksTotal И все документы
- * обработаны, он проверяет failed_days и помечает job completed / failed.
+ * терминальны (AdRawDocument.status ∈ PROCESSED|FAILED), он считает COUNT(FAILED)
+ * и помечает job completed / failed соответственно.
  */
 #[AsMessageHandler]
 final class LoadOzonAdStatisticsRangeHandler

--- a/site/src/MarketplaceAds/MessageHandler/LoadOzonAdStatisticsRangeHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/LoadOzonAdStatisticsRangeHandler.php
@@ -7,7 +7,7 @@ namespace App\MarketplaceAds\MessageHandler;
 use App\MarketplaceAds\Enum\AdLoadJobStatus;
 use App\MarketplaceAds\Message\FetchOzonAdStatisticsMessage;
 use App\MarketplaceAds\Message\LoadOzonAdStatisticsRangeMessage;
-use App\MarketplaceAds\Repository\AdLoadJobRepository;
+use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
 use App\Shared\Service\AppLogger;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -40,7 +40,7 @@ final class LoadOzonAdStatisticsRangeHandler
     private const CHUNK_MAX_DAYS = 62;
 
     public function __construct(
-        private readonly AdLoadJobRepository $adLoadJobRepository,
+        private readonly AdLoadJobRepositoryInterface $adLoadJobRepository,
         private readonly MessageBusInterface $messageBus,
         private readonly AppLogger $logger,
         private readonly EntityManagerInterface $entityManager,
@@ -93,11 +93,6 @@ final class LoadOzonAdStatisticsRangeHandler
             $this->entityManager->flush();
         }
 
-        // TODO(commit 5): защита от дубль-dispatch при retry оркестратора.
-        // AdRawDocument.UniqueConstraint(company_id, marketplace, report_date)
-        // уже защищает документы и loaded_days (created=0 на retry → инкремент=0).
-        // chunks_completed защитим в FetchOzonAdStatisticsHandler детекцией
-        // повтора: created=0 && updated>0 → не инкрементировать (это retry-fetch).
         foreach ($chunks as $chunk) {
             $this->messageBus->dispatch(new FetchOzonAdStatisticsMessage(
                 jobId: $job->getId(),
@@ -115,8 +110,6 @@ final class LoadOzonAdStatisticsRangeHandler
             'totalDays' => $job->getTotalDays(),
             'chunksCount' => count($chunks),
         ]);
-
-        // TODO(commit 5): ProcessAdRawDocumentHandler finalizes job by chunksCompleted.
     }
 
     /**

--- a/site/src/MarketplaceAds/MessageHandler/ProcessAdRawDocumentHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/ProcessAdRawDocumentHandler.php
@@ -105,12 +105,20 @@ final class ProcessAdRawDocumentHandler
                 ],
             );
 
-            // Инкрементим failed_days ДО rethrow: даже если Messenger уйдёт в retry
-            // и воркер упадёт, состояние прогресса job'а должно отражать факт ошибки.
-            // После исчерпания retries повторный инкремент будет приходить на тот
-            // же (jobId, companyId) — мы принимаем возможный overshoot failedDays
-            // при долгой retry-эскалации; финализация по COUNT остаётся корректной.
-            $this->incrementFailedAndTryFinalize($message->companyId, $marketplace, $reportDate);
+            // Инкрементим failed_days ДО rethrow: состояние прогресса job'а
+            // должно отражать факт текущей ошибки (UI/мониторинг), даже если
+            // Messenger уйдёт в retry. На retry счётчик может overshoot'нуть
+            // — принимаем этот UX-компромисс сознательно.
+            //
+            // НО: в error-ветке НЕ вызываем tryFinalizeJob. Иначе overshoot
+            // failed_days мог бы дотянуть (processed+failed) до COUNT(raw)
+            // раньше, чем retry успел отработать, и job был бы помечен FAILED,
+            // даже если последующий retry документа succeed'ит. Финализация
+            // разрешается только из success/partial-branch'ей, где документ
+            // точно вышел из DRAFT (PROCESSED или остался DRAFT после
+            // bez-exception прогона — обе ветки терминальны с точки зрения
+            // дальнейшей обработки сообщения).
+            $this->incrementFailedOnly($message->companyId, $marketplace, $reportDate);
 
             throw $e;
         }
@@ -183,6 +191,28 @@ final class ProcessAdRawDocumentHandler
 
         $this->adLoadJobRepository->incrementFailedDays($job->getId(), $companyId);
         $this->tryFinalizeJob($job->getId(), $companyId);
+    }
+
+    /**
+     * Инкрементит failed_days без попытки финализации.
+     *
+     * Используется только в error-ветке (catch \Throwable): Messenger сделает
+     * retry, и преждевременная финализация по overshoot'нутому счётчику
+     * означала бы markFailed задания, которое могло бы завершиться successful
+     * после последующих retries. Финализация остаётся за success/partial
+     * ветками и за status-endpoint'ом (TODO commit 6).
+     */
+    private function incrementFailedOnly(
+        string $companyId,
+        MarketplaceType $marketplace,
+        \DateTimeImmutable $reportDate,
+    ): void {
+        $job = $this->adLoadJobRepository->findActiveJobCoveringDate($companyId, $marketplace, $reportDate);
+        if (null === $job) {
+            return;
+        }
+
+        $this->adLoadJobRepository->incrementFailedDays($job->getId(), $companyId);
     }
 
     /**

--- a/site/src/MarketplaceAds/MessageHandler/ProcessAdRawDocumentHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/ProcessAdRawDocumentHandler.php
@@ -188,8 +188,12 @@ final class ProcessAdRawDocumentHandler
     /**
      * Пробует финализировать job после инкремента processed/failed счётчика.
      *
-     * Важно: после atomic increment данные в Doctrine UoW устарели. Читаем job
-     * заново из БД — это разовый SELECT, критичный для корректности.
+     * Важно: после atomic increment (DBAL UPDATE минуя UoW) состояние entity
+     * в Doctrine identity map устарело. Берём job через findFresh() — он
+     * принудительно refresh'ит закэшированный instance либо читает заново.
+     * Без этого на последнем документе `processed+failed` в памяти остался
+     * бы ниже COUNT(raw), финализация бы пропустилась и job застрял бы в
+     * RUNNING до следующего входящего сообщения (которого может и не быть).
      *
      * Условие финализации:
      *   chunksCompleted >= chunksTotal
@@ -204,7 +208,7 @@ final class ProcessAdRawDocumentHandler
      */
     private function tryFinalizeJob(string $jobId, string $companyId): void
     {
-        $job = $this->adLoadJobRepository->find($jobId);
+        $job = $this->adLoadJobRepository->findFresh($jobId);
         if (null === $job) {
             return;
         }

--- a/site/src/MarketplaceAds/MessageHandler/ProcessAdRawDocumentHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/ProcessAdRawDocumentHandler.php
@@ -22,17 +22,23 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
  *  - Не предполагает Request/Session/Security (CLI worker context).
  *  - Всегда перечитывает AdRawDocument по id + companyId: между dispatch и handler
  *    состояние документа могло измениться.
- *  - Идемпотентен: если документ уже обработан (не в DRAFT) — молча возвращается.
- *  - Инкрементирует AdLoadJob.{processedDays|failedDays} и триггерит финализацию
- *    задания, когда все чанки выгружены и все документы обработаны.
+ *  - Идемпотентен: если документ уже терминален (PROCESSED/FAILED) — молча
+ *    возвращается. На retry Messenger'а ProcessAdRawDocumentAction также ловит
+ *    non-DRAFT и бросает AdRawDocumentAlreadyProcessedException, которое мы
+ *    обрабатываем как skip.
+ *  - На ошибке / частичном успехе помечает документ FAILED с причиной через
+ *    атомарный SQL и триггерит финализацию AdLoadJob. Рекламный retry
+ *    инкрементов не даёт: повторный заход в Action увидит status=FAILED и
+ *    сразу short-circuit'ит, без двойного учёта.
  *
  * Финализация AdLoadJob ({@see self::tryFinalizeJob}) — condition:
  *   chunksCompleted >= chunksTotal
- *   AND COUNT(AdRawDocument в [dateFrom; dateTo]) == processedDays + failedDays
+ *   AND COUNT(total AdRawDocument в [dateFrom; dateTo]) == COUNT(PROCESSED) + COUNT(FAILED)
  *
  * loadedDays в условие не входит: он coverage-based (см. FetchOzonAdStatisticsHandler)
- * и может overshoot'ить при retry оркестратора. COUNT по AdRawDocument идемпотентен
- * благодаря UniqueConstraint(company_id, marketplace, report_date).
+ * и может overshoot'ить при retry оркестратора. COUNT по AdRawDocument
+ * идемпотентен благодаря UniqueConstraint(company_id, marketplace, report_date)
+ * и финальному status (PROCESSED или FAILED, оба терминальны).
  */
 #[AsMessageHandler]
 final class ProcessAdRawDocumentHandler
@@ -62,7 +68,7 @@ final class ProcessAdRawDocumentHandler
         }
 
         if (AdRawDocumentStatus::DRAFT !== $rawDocument->getStatus()) {
-            $this->logger->info('AdRawDocument уже обработан, повторный запуск пропущен', [
+            $this->logger->info('AdRawDocument уже терминален, повторный запуск пропущен', [
                 'companyId' => $message->companyId,
                 'adRawDocumentId' => $message->adRawDocumentId,
                 'status' => $rawDocument->getStatus()->value,
@@ -81,10 +87,8 @@ final class ProcessAdRawDocumentHandler
             ($this->processAction)($message->companyId, $message->adRawDocumentId);
         } catch (AdRawDocumentAlreadyProcessedException $e) {
             // Гонка состояний: другой worker обработал документ между pre-check и
-            // вызовом Action (или документ удалили). Мы НЕ инкрементируем
-            // processed/failed — это сделает тот воркер, который реально обработал.
-            // Ловим специфический тип исключения, чтобы баги конфигурации (например,
-            // отсутствие парсера — \RuntimeException) не поглощались молча.
+            // вызовом Action (или документ удалили). Не помечаем FAILED и не
+            // финализируем — это сделает воркер, который реально обработал.
             $this->logger->info(
                 'AdRawDocument обработан параллельно или удалён, повтор не нужен',
                 [
@@ -96,6 +100,12 @@ final class ProcessAdRawDocumentHandler
 
             return;
         } catch (\Throwable $e) {
+            // Помечаем документ FAILED с причиной и финализируем job. Финализация
+            // безопасна: `markFailedWithReason` идемпотентен (WHERE status =
+            // 'draft'), повторный заход из retry сразу short-circuit'ит в Action
+            // через AdRawDocumentAlreadyProcessedException. Rethrow нужен, чтобы
+            // Messenger видел падение — метрики/мониторинг/failed-queue при
+            // исчерпании retries.
             $this->logger->error(
                 'Ошибка обработки AdRawDocument',
                 $e,
@@ -105,20 +115,13 @@ final class ProcessAdRawDocumentHandler
                 ],
             );
 
-            // Инкрементим failed_days ДО rethrow: состояние прогресса job'а
-            // должно отражать факт текущей ошибки (UI/мониторинг), даже если
-            // Messenger уйдёт в retry. На retry счётчик может overshoot'нуть
-            // — принимаем этот UX-компромисс сознательно.
-            //
-            // НО: в error-ветке НЕ вызываем tryFinalizeJob. Иначе overshoot
-            // failed_days мог бы дотянуть (processed+failed) до COUNT(raw)
-            // раньше, чем retry успел отработать, и job был бы помечен FAILED,
-            // даже если последующий retry документа succeed'ит. Финализация
-            // разрешается только из success/partial-branch'ей, где документ
-            // точно вышел из DRAFT (PROCESSED или остался DRAFT после
-            // bez-exception прогона — обе ветки терминальны с точки зрения
-            // дальнейшей обработки сообщения).
-            $this->incrementFailedOnly($message->companyId, $marketplace, $reportDate);
+            $this->markDocumentFailedAndTryFinalize(
+                $message->companyId,
+                $message->adRawDocumentId,
+                $marketplace,
+                $reportDate,
+                $this->truncateReason($e->getMessage()),
+            );
 
             throw $e;
         }
@@ -143,7 +146,7 @@ final class ProcessAdRawDocumentHandler
         }
 
         if (AdRawDocumentStatus::PROCESSED === $afterProcessing->getStatus()) {
-            $this->incrementProcessedAndTryFinalize($message->companyId, $marketplace, $reportDate);
+            $this->tryFinalizeJob($message->companyId, $marketplace, $reportDate);
 
             return;
         }
@@ -151,10 +154,10 @@ final class ProcessAdRawDocumentHandler
         // Action вернулся без исключения, но документ остался DRAFT — это
         // частичный успех (см. ProcessAdRawDocumentAction: markAsProcessed()
         // вызывается только когда !hasErrors). С точки зрения AdLoadJob'а это
-        // failure: документ недообработан, считать как failed, чтобы условие
-        // финализации (processed + failed == COUNT(raw)) обязательно сошлось.
+        // failure: документ не должен оставаться в очереди обработки, считаем
+        // его терминальным через markFailedWithReason.
         $this->logger->warning(
-            'AdRawDocument остался в DRAFT после обработки — считаем как failure',
+            'AdRawDocument остался в DRAFT после обработки — помечаем как FAILED',
             [
                 'companyId' => $message->companyId,
                 'adRawDocumentId' => $message->adRawDocumentId,
@@ -162,113 +165,97 @@ final class ProcessAdRawDocumentHandler
             ],
         );
 
-        $this->incrementFailedAndTryFinalize($message->companyId, $marketplace, $reportDate);
+        $this->markDocumentFailedAndTryFinalize(
+            $message->companyId,
+            $message->adRawDocumentId,
+            $marketplace,
+            $reportDate,
+            'Partial processing: document remained in DRAFT after Action',
+        );
     }
 
-    private function incrementProcessedAndTryFinalize(
+    private function markDocumentFailedAndTryFinalize(
         string $companyId,
+        string $adRawDocumentId,
         MarketplaceType $marketplace,
         \DateTimeImmutable $reportDate,
+        string $reason,
     ): void {
-        $job = $this->adLoadJobRepository->findActiveJobCoveringDate($companyId, $marketplace, $reportDate);
-        if (null === $job) {
-            return;
-        }
-
-        $this->adLoadJobRepository->incrementProcessedDays($job->getId(), $companyId);
-        $this->tryFinalizeJob($job->getId(), $companyId);
-    }
-
-    private function incrementFailedAndTryFinalize(
-        string $companyId,
-        MarketplaceType $marketplace,
-        \DateTimeImmutable $reportDate,
-    ): void {
-        $job = $this->adLoadJobRepository->findActiveJobCoveringDate($companyId, $marketplace, $reportDate);
-        if (null === $job) {
-            return;
-        }
-
-        $this->adLoadJobRepository->incrementFailedDays($job->getId(), $companyId);
-        $this->tryFinalizeJob($job->getId(), $companyId);
+        // Идемпотентный SQL UPDATE (WHERE status='draft'): если параллельный
+        // воркер успел обработать документ как PROCESSED, 0 строк затронуто —
+        // финализацию всё равно попробуем, т.к. состояние в БД могло стать
+        // terminal независимо от текущей попытки.
+        $this->rawDocumentRepository->markFailedWithReason($adRawDocumentId, $companyId, $reason);
+        $this->tryFinalizeJob($companyId, $marketplace, $reportDate);
     }
 
     /**
-     * Инкрементит failed_days без попытки финализации.
-     *
-     * Используется только в error-ветке (catch \Throwable): Messenger сделает
-     * retry, и преждевременная финализация по overshoot'нутому счётчику
-     * означала бы markFailed задания, которое могло бы завершиться successful
-     * после последующих retries. Финализация остаётся за success/partial
-     * ветками и за status-endpoint'ом (TODO commit 6).
-     */
-    private function incrementFailedOnly(
-        string $companyId,
-        MarketplaceType $marketplace,
-        \DateTimeImmutable $reportDate,
-    ): void {
-        $job = $this->adLoadJobRepository->findActiveJobCoveringDate($companyId, $marketplace, $reportDate);
-        if (null === $job) {
-            return;
-        }
-
-        $this->adLoadJobRepository->incrementFailedDays($job->getId(), $companyId);
-    }
-
-    /**
-     * Пробует финализировать job после инкремента processed/failed счётчика.
-     *
-     * Важно: после atomic increment (DBAL UPDATE минуя UoW) состояние entity
-     * в Doctrine identity map устарело. Берём job через findFresh() — он
-     * принудительно refresh'ит закэшированный instance либо читает заново.
-     * Без этого на последнем документе `processed+failed` в памяти остался
-     * бы ниже COUNT(raw), финализация бы пропустилась и job застрял бы в
-     * RUNNING до следующего входящего сообщения (которого может и не быть).
+     * Пробует финализировать job по дате текущего документа.
      *
      * Условие финализации:
      *   chunksCompleted >= chunksTotal
-     *   AND COUNT(AdRawDocument в диапазоне job'а) == processedDays + failedDays
+     *   AND COUNT(AdRawDocument в диапазоне job'а) == COUNT(PROCESSED) + COUNT(FAILED)
+     *
+     * Important: после атомарного UPDATE статуса документа (минуя UoW)
+     * состояние job'а в Doctrine identity map может устареть — берём job через
+     * findFresh(), который принудительно refresh'ит закэшированный instance
+     * либо читает заново. Без этого на последнем документе chunksCompleted в
+     * памяти мог бы остаться ниже chunksTotal, и финализация пропустилась бы.
      *
      * Race между воркерами покрывается SQL-guard'ами в markCompleted/markFailed
      * (`WHERE status IN ('pending','running')`) — второй вызов затронет 0 строк.
-     *
-     * TODO(commit 6): status-endpoint должен триггерить tryFinalizeJob, если
-     * состояние финализации достигнуто, но job ещё RUNNING (консумер упал
-     * между инкрементом и tryFinalizeJob).
      */
-    private function tryFinalizeJob(string $jobId, string $companyId): void
-    {
-        $job = $this->adLoadJobRepository->findFresh($jobId);
+    private function tryFinalizeJob(
+        string $companyId,
+        MarketplaceType $marketplace,
+        \DateTimeImmutable $reportDate,
+    ): void {
+        $job = $this->adLoadJobRepository->findActiveJobCoveringDate($companyId, $marketplace, $reportDate);
         if (null === $job) {
             return;
         }
 
-        if (AdLoadJobStatus::RUNNING !== $job->getStatus()) {
+        $fresh = $this->adLoadJobRepository->findFresh($job->getId());
+        if (null === $fresh) {
             return;
         }
 
-        if ($job->getChunksCompleted() < $job->getChunksTotal()) {
+        if (AdLoadJobStatus::RUNNING !== $fresh->getStatus()) {
             return;
         }
 
-        $rawDocumentsCount = $this->rawDocumentRepository->countByCompanyMarketplaceAndDateRange(
+        if ($fresh->getChunksCompleted() < $fresh->getChunksTotal()) {
+            return;
+        }
+
+        $total = $this->rawDocumentRepository->countByCompanyMarketplaceAndDateRange(
             $companyId,
-            $job->getMarketplace()->value,
-            $job->getDateFrom(),
-            $job->getDateTo(),
+            $fresh->getMarketplace()->value,
+            $fresh->getDateFrom(),
+            $fresh->getDateTo(),
         );
 
-        if ($job->getProcessedDays() + $job->getFailedDays() < $rawDocumentsCount) {
+        $terminal = $this->rawDocumentRepository->countTerminalByCompanyMarketplaceAndDateRange(
+            $companyId,
+            $fresh->getMarketplace()->value,
+            $fresh->getDateFrom(),
+            $fresh->getDateTo(),
+        );
+
+        $processed = $terminal['processed'];
+        $failed = $terminal['failed'];
+
+        if ($processed + $failed < $total) {
             return;
         }
 
-        if (0 === $job->getFailedDays()) {
-            $this->adLoadJobRepository->markCompleted($jobId, $companyId);
+        if (0 === $failed) {
+            $this->adLoadJobRepository->markCompleted($fresh->getId(), $companyId);
             $this->logger->info('AdLoadJob completed', [
-                'jobId' => $jobId,
+                'jobId' => $fresh->getId(),
                 'companyId' => $companyId,
-                'processedDays' => $job->getProcessedDays(),
-                'rawDocumentsCount' => $rawDocumentsCount,
+                'processedDocs' => $processed,
+                'totalDocs' => $total,
             ]);
 
             return;
@@ -276,16 +263,32 @@ final class ProcessAdRawDocumentHandler
 
         $reason = sprintf(
             'Partial failure: %d/%d documents failed processing',
-            $job->getFailedDays(),
-            $rawDocumentsCount,
+            $failed,
+            $total,
         );
-        $this->adLoadJobRepository->markFailed($jobId, $companyId, $reason);
+        $this->adLoadJobRepository->markFailed($fresh->getId(), $companyId, $reason);
         $this->logger->warning('AdLoadJob finalized with failures', [
-            'jobId' => $jobId,
+            'jobId' => $fresh->getId(),
             'companyId' => $companyId,
-            'failedDays' => $job->getFailedDays(),
-            'processedDays' => $job->getProcessedDays(),
-            'rawDocumentsCount' => $rawDocumentsCount,
+            'failedDocs' => $failed,
+            'processedDocs' => $processed,
+            'totalDocs' => $total,
         ]);
+    }
+
+    /**
+     * Обрезает причину до безопасной длины для TEXT-колонки БД и логов.
+     * PostgreSQL TEXT без лимита, но массивный trace/stack в поле ошибки —
+     * это нагрузка на репликации и UI. Сообщение достаточно идентифицирует
+     * причину, trace остаётся в логе через $this->logger->error.
+     */
+    private function truncateReason(string $reason): string
+    {
+        $max = 2000;
+        if ('' === $reason) {
+            return 'Unknown failure';
+        }
+
+        return mb_strlen($reason) > $max ? mb_substr($reason, 0, $max) : $reason;
     }
 }

--- a/site/src/MarketplaceAds/MessageHandler/ProcessAdRawDocumentHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/ProcessAdRawDocumentHandler.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace App\MarketplaceAds\MessageHandler;
 
+use App\Marketplace\Enum\MarketplaceType;
 use App\MarketplaceAds\Application\ProcessAdRawDocumentAction;
+use App\MarketplaceAds\Enum\AdLoadJobStatus;
 use App\MarketplaceAds\Enum\AdRawDocumentStatus;
 use App\MarketplaceAds\Exception\AdRawDocumentAlreadyProcessedException;
 use App\MarketplaceAds\Message\ProcessAdRawDocumentMessage;
+use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
 use App\MarketplaceAds\Repository\AdRawDocumentRepository;
 use App\Shared\Service\AppLogger;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -15,11 +18,21 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 /**
  * Async-обработчик {@see ProcessAdRawDocumentMessage}.
  *
- * - Не предполагает Request/Session/Security (CLI worker context).
- * - Всегда перечитывает AdRawDocument по id + companyId, т.к. между dispatch и handler
- *   состояние документа могло измениться.
- * - Идемпотентен: если документ уже обработан (не в DRAFT) — молча возвращается.
- * - Ошибки Action пере­брасываются для retry по стратегии Messenger.
+ * Обязанности:
+ *  - Не предполагает Request/Session/Security (CLI worker context).
+ *  - Всегда перечитывает AdRawDocument по id + companyId: между dispatch и handler
+ *    состояние документа могло измениться.
+ *  - Идемпотентен: если документ уже обработан (не в DRAFT) — молча возвращается.
+ *  - Инкрементирует AdLoadJob.{processedDays|failedDays} и триггерит финализацию
+ *    задания, когда все чанки выгружены и все документы обработаны.
+ *
+ * Финализация AdLoadJob ({@see self::tryFinalizeJob}) — condition:
+ *   chunksCompleted >= chunksTotal
+ *   AND COUNT(AdRawDocument в [dateFrom; dateTo]) == processedDays + failedDays
+ *
+ * loadedDays в условие не входит: он coverage-based (см. FetchOzonAdStatisticsHandler)
+ * и может overshoot'ить при retry оркестратора. COUNT по AdRawDocument идемпотентен
+ * благодаря UniqueConstraint(company_id, marketplace, report_date).
  */
 #[AsMessageHandler]
 final class ProcessAdRawDocumentHandler
@@ -27,6 +40,7 @@ final class ProcessAdRawDocumentHandler
     public function __construct(
         private readonly AdRawDocumentRepository $rawDocumentRepository,
         private readonly ProcessAdRawDocumentAction $processAction,
+        private readonly AdLoadJobRepositoryInterface $adLoadJobRepository,
         private readonly AppLogger $logger,
     ) {
     }
@@ -57,15 +71,20 @@ final class ProcessAdRawDocumentHandler
             return;
         }
 
+        // Сохраняем атрибуты документа ДО вызова Action: marketplace/reportDate
+        // нужны при поиске job'а на любой ветке (успех / частичный / ошибка),
+        // а в ветке ошибки (rollback транзакции) entity может быть в detached-состоянии.
+        $marketplace = $rawDocument->getMarketplace();
+        $reportDate = $rawDocument->getReportDate();
+
         try {
             ($this->processAction)($message->companyId, $message->adRawDocumentId);
         } catch (AdRawDocumentAlreadyProcessedException $e) {
-            // Специфическая гонка состояний: другой worker/диспатч успел обработать
-            // документ (status != DRAFT) или сам документ удалили между pre-check
-            // и вызовом Action. Ретрай Messenger здесь только шумит в failed-queue — поглощаем.
-            // Ловим именно AdRawDocumentAlreadyProcessedException, а не \DomainException,
-            // чтобы баги конфигурации (например, отсутствие парсера — \RuntimeException)
-            // не поглощались молча, а уходили в retry / failed-queue для видимости.
+            // Гонка состояний: другой worker обработал документ между pre-check и
+            // вызовом Action (или документ удалили). Мы НЕ инкрементируем
+            // processed/failed — это сделает тот воркер, который реально обработал.
+            // Ловим специфический тип исключения, чтобы баги конфигурации (например,
+            // отсутствие парсера — \RuntimeException) не поглощались молча.
             $this->logger->info(
                 'AdRawDocument обработан параллельно или удалён, повтор не нужен',
                 [
@@ -85,7 +104,154 @@ final class ProcessAdRawDocumentHandler
                     'adRawDocumentId' => $message->adRawDocumentId,
                 ],
             );
-            throw $e; // перебросить — Messenger сделает retry по стратегии async-транспорта
+
+            // Инкрементим failed_days ДО rethrow: даже если Messenger уйдёт в retry
+            // и воркер упадёт, состояние прогресса job'а должно отражать факт ошибки.
+            // После исчерпания retries повторный инкремент будет приходить на тот
+            // же (jobId, companyId) — мы принимаем возможный overshoot failedDays
+            // при долгой retry-эскалации; финализация по COUNT остаётся корректной.
+            $this->incrementFailedAndTryFinalize($message->companyId, $marketplace, $reportDate);
+
+            throw $e;
         }
+
+        // Перечитываем документ: Action мог оставить его в DRAFT при частичном
+        // успехе (часть SKU не смапилась на листинги) — транзакция Action в этом
+        // случае не падает, но документ остаётся недообработанным.
+        $afterProcessing = $this->rawDocumentRepository->findByIdAndCompany(
+            $message->adRawDocumentId,
+            $message->companyId,
+        );
+
+        if (null === $afterProcessing) {
+            // Крайне маловероятно: документ был, Action отработал без исключений,
+            // но сейчас его нет. Защита, а не нормальная ветка.
+            $this->logger->warning('AdRawDocument исчез после обработки Action', [
+                'companyId' => $message->companyId,
+                'adRawDocumentId' => $message->adRawDocumentId,
+            ]);
+
+            return;
+        }
+
+        if (AdRawDocumentStatus::PROCESSED === $afterProcessing->getStatus()) {
+            $this->incrementProcessedAndTryFinalize($message->companyId, $marketplace, $reportDate);
+
+            return;
+        }
+
+        // Action вернулся без исключения, но документ остался DRAFT — это
+        // частичный успех (см. ProcessAdRawDocumentAction: markAsProcessed()
+        // вызывается только когда !hasErrors). С точки зрения AdLoadJob'а это
+        // failure: документ недообработан, считать как failed, чтобы условие
+        // финализации (processed + failed == COUNT(raw)) обязательно сошлось.
+        $this->logger->warning(
+            'AdRawDocument остался в DRAFT после обработки — считаем как failure',
+            [
+                'companyId' => $message->companyId,
+                'adRawDocumentId' => $message->adRawDocumentId,
+                'status' => $afterProcessing->getStatus()->value,
+            ],
+        );
+
+        $this->incrementFailedAndTryFinalize($message->companyId, $marketplace, $reportDate);
+    }
+
+    private function incrementProcessedAndTryFinalize(
+        string $companyId,
+        MarketplaceType $marketplace,
+        \DateTimeImmutable $reportDate,
+    ): void {
+        $job = $this->adLoadJobRepository->findActiveJobCoveringDate($companyId, $marketplace, $reportDate);
+        if (null === $job) {
+            return;
+        }
+
+        $this->adLoadJobRepository->incrementProcessedDays($job->getId(), $companyId);
+        $this->tryFinalizeJob($job->getId(), $companyId);
+    }
+
+    private function incrementFailedAndTryFinalize(
+        string $companyId,
+        MarketplaceType $marketplace,
+        \DateTimeImmutable $reportDate,
+    ): void {
+        $job = $this->adLoadJobRepository->findActiveJobCoveringDate($companyId, $marketplace, $reportDate);
+        if (null === $job) {
+            return;
+        }
+
+        $this->adLoadJobRepository->incrementFailedDays($job->getId(), $companyId);
+        $this->tryFinalizeJob($job->getId(), $companyId);
+    }
+
+    /**
+     * Пробует финализировать job после инкремента processed/failed счётчика.
+     *
+     * Важно: после atomic increment данные в Doctrine UoW устарели. Читаем job
+     * заново из БД — это разовый SELECT, критичный для корректности.
+     *
+     * Условие финализации:
+     *   chunksCompleted >= chunksTotal
+     *   AND COUNT(AdRawDocument в диапазоне job'а) == processedDays + failedDays
+     *
+     * Race между воркерами покрывается SQL-guard'ами в markCompleted/markFailed
+     * (`WHERE status IN ('pending','running')`) — второй вызов затронет 0 строк.
+     *
+     * TODO(commit 6): status-endpoint должен триггерить tryFinalizeJob, если
+     * состояние финализации достигнуто, но job ещё RUNNING (консумер упал
+     * между инкрементом и tryFinalizeJob).
+     */
+    private function tryFinalizeJob(string $jobId, string $companyId): void
+    {
+        $job = $this->adLoadJobRepository->find($jobId);
+        if (null === $job) {
+            return;
+        }
+
+        if (AdLoadJobStatus::RUNNING !== $job->getStatus()) {
+            return;
+        }
+
+        if ($job->getChunksCompleted() < $job->getChunksTotal()) {
+            return;
+        }
+
+        $rawDocumentsCount = $this->rawDocumentRepository->countByCompanyMarketplaceAndDateRange(
+            $companyId,
+            $job->getMarketplace()->value,
+            $job->getDateFrom(),
+            $job->getDateTo(),
+        );
+
+        if ($job->getProcessedDays() + $job->getFailedDays() < $rawDocumentsCount) {
+            return;
+        }
+
+        if (0 === $job->getFailedDays()) {
+            $this->adLoadJobRepository->markCompleted($jobId, $companyId);
+            $this->logger->info('AdLoadJob completed', [
+                'jobId' => $jobId,
+                'companyId' => $companyId,
+                'processedDays' => $job->getProcessedDays(),
+                'rawDocumentsCount' => $rawDocumentsCount,
+            ]);
+
+            return;
+        }
+
+        $reason = sprintf(
+            'Partial failure: %d/%d documents failed processing',
+            $job->getFailedDays(),
+            $rawDocumentsCount,
+        );
+        $this->adLoadJobRepository->markFailed($jobId, $companyId, $reason);
+        $this->logger->warning('AdLoadJob finalized with failures', [
+            'jobId' => $jobId,
+            'companyId' => $companyId,
+            'failedDays' => $job->getFailedDays(),
+            'processedDays' => $job->getProcessedDays(),
+            'rawDocumentsCount' => $rawDocumentsCount,
+        ]);
     }
 }

--- a/site/src/MarketplaceAds/Repository/AdChunkProgressRepository.php
+++ b/site/src/MarketplaceAds/Repository/AdChunkProgressRepository.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Repository;
+
+use App\MarketplaceAds\Entity\AdChunkProgress;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * Хранение записей о выгруженных чанках AdLoadJob'а.
+ *
+ * tryMarkCompleted — единственный hot-path метод: raw DBAL
+ * `INSERT ... ON CONFLICT DO NOTHING`, минуя Doctrine UoW (чтобы параллельные
+ * воркеры не боролись за identity map). UNIQUE (job_id, date_from, date_to)
+ * на уровне таблицы делает учёт атомарным и race-safe.
+ */
+class AdChunkProgressRepository extends ServiceEntityRepository implements AdChunkProgressRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, AdChunkProgress::class);
+    }
+
+    public function tryMarkCompleted(
+        string $jobId,
+        string $companyId,
+        \DateTimeImmutable $dateFrom,
+        \DateTimeImmutable $dateTo,
+    ): bool {
+        // Нормализация до 00:00: date_immutable хранит только дату, но сам
+        // \DateTimeImmutable несёт время — без нормализации PDO мог бы
+        // закинуть 'Y-m-d H:i:s' и попасть мимо колонки date.
+        $dateFrom = $dateFrom->setTime(0, 0);
+        $dateTo = $dateTo->setTime(0, 0);
+
+        $connection = $this->getEntityManager()->getConnection();
+        $now = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+
+        $affectedRows = (int) $connection->executeStatement(
+            <<<'SQL'
+                INSERT INTO marketplace_ad_chunk_progress
+                    (id, job_id, company_id, date_from, date_to, completed_at, created_at)
+                VALUES
+                    (:id, :jobId, :companyId, :dateFrom, :dateTo, :completedAt, :createdAt)
+                ON CONFLICT (job_id, date_from, date_to) DO NOTHING
+                SQL,
+            [
+                'id' => Uuid::uuid7()->toString(),
+                'jobId' => $jobId,
+                'companyId' => $companyId,
+                'dateFrom' => $dateFrom->format('Y-m-d'),
+                'dateTo' => $dateTo->format('Y-m-d'),
+                'completedAt' => $now,
+                'createdAt' => $now,
+            ],
+        );
+
+        return $affectedRows > 0;
+    }
+}

--- a/site/src/MarketplaceAds/Repository/AdChunkProgressRepositoryInterface.php
+++ b/site/src/MarketplaceAds/Repository/AdChunkProgressRepositoryInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Repository;
+
+/**
+ * Контракт ledger-репозитория {@see \App\MarketplaceAds\Entity\AdChunkProgress}.
+ *
+ * Вынесен в интерфейс, чтобы оставить concrete-класс `final` (CLAUDE.md) и
+ * мокать из unit-тестов хендлеров без подклассов.
+ */
+interface AdChunkProgressRepositoryInterface
+{
+    /**
+     * Идемпотентно фиксирует факт выгрузки чанка.
+     *
+     * Реализовано через `INSERT ... ON CONFLICT DO NOTHING`:
+     *  - первый вызов для (jobId, dateFrom, dateTo) → строка вставлена → true;
+     *  - любой повтор (retry оркестратора, retry Messenger'а после сбоя
+     *    пост-flush, кросс-job re-fetch того же периода) → 0 затронутых
+     *    строк → false.
+     *
+     * Возврат — единственный надёжный сигнал «этот чанк учтён впервые»,
+     * на основании которого FetchOzonAdStatisticsHandler инкрементит
+     * chunks_completed. created/updated счёт документов для этой цели
+     * недостаточен: AdRawDocument может быть existing из-за CLI-preload
+     * или нового jobId на уже загруженный период.
+     *
+     * @return bool true если запись создана (первая фиксация чанка),
+     *              false если уже существовала (retry любого рода)
+     */
+    public function tryMarkCompleted(
+        string $jobId,
+        string $companyId,
+        \DateTimeImmutable $dateFrom,
+        \DateTimeImmutable $dateTo,
+    ): bool;
+}

--- a/site/src/MarketplaceAds/Repository/AdLoadJobRepository.php
+++ b/site/src/MarketplaceAds/Repository/AdLoadJobRepository.php
@@ -43,6 +43,29 @@ class AdLoadJobRepository extends ServiceEntityRepository implements AdLoadJobRe
         return parent::find($id, $lockMode, $lockVersion);
     }
 
+    /**
+     * Читает job из БД, игнорируя identity map Doctrine.
+     *
+     * Атомарные инкременты (incrementProcessedDays/FailedDays/ChunksCompleted)
+     * идут через DBAL UPDATE минуя UoW. Обычный find() попадает в identity map
+     * и возвращает уже загруженный ранее instance со СТАРЫМИ значениями
+     * счётчиков — для финализационной проверки это фатально. Метод сначала
+     * refresh'ит закэшированный entity, либо читает его заново.
+     */
+    public function findFresh(string $jobId): ?AdLoadJob
+    {
+        $em = $this->getEntityManager();
+        $cached = $em->getUnitOfWork()->tryGetById($jobId, AdLoadJob::class);
+
+        if ($cached instanceof AdLoadJob) {
+            $em->refresh($cached);
+
+            return $cached;
+        }
+
+        return parent::find($jobId);
+    }
+
     public function findLatestActiveJobByCompanyAndMarketplace(
         string $companyId,
         MarketplaceType $marketplace,

--- a/site/src/MarketplaceAds/Repository/AdLoadJobRepository.php
+++ b/site/src/MarketplaceAds/Repository/AdLoadJobRepository.php
@@ -122,16 +122,6 @@ class AdLoadJobRepository extends ServiceEntityRepository implements AdLoadJobRe
         return $this->atomicIncrement('loaded_days', $jobId, $companyId, $delta);
     }
 
-    public function incrementProcessedDays(string $jobId, string $companyId, int $delta = 1): int
-    {
-        return $this->atomicIncrement('processed_days', $jobId, $companyId, $delta);
-    }
-
-    public function incrementFailedDays(string $jobId, string $companyId, int $delta = 1): int
-    {
-        return $this->atomicIncrement('failed_days', $jobId, $companyId, $delta);
-    }
-
     /**
      * Атомарный UPDATE `chunks_completed = chunks_completed + :delta`.
      *
@@ -238,7 +228,7 @@ class AdLoadJobRepository extends ServiceEntityRepository implements AdLoadJobRe
     {
         // Whitelist — защита от SQL-injection через имя колонки (параметризовать имя
         // колонки нельзя, только значение).
-        if (!in_array($column, ['loaded_days', 'processed_days', 'failed_days'], true)) {
+        if (!in_array($column, ['loaded_days'], true)) {
             throw new \InvalidArgumentException(sprintf('Недопустимое имя колонки: %s', $column));
         }
 

--- a/site/src/MarketplaceAds/Repository/AdLoadJobRepository.php
+++ b/site/src/MarketplaceAds/Repository/AdLoadJobRepository.php
@@ -10,7 +10,7 @@ use App\MarketplaceAds\Enum\AdLoadJobStatus;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
-class AdLoadJobRepository extends ServiceEntityRepository
+class AdLoadJobRepository extends ServiceEntityRepository implements AdLoadJobRepositoryInterface
 {
     public function __construct(ManagerRegistry $registry)
     {
@@ -137,6 +137,37 @@ class AdLoadJobRepository extends ServiceEntityRepository
                 SQL,
             [
                 'delta' => $delta,
+                'jobId' => $jobId,
+                'companyId' => $companyId,
+            ],
+        );
+    }
+
+    /**
+     * Помечает задание как COMPLETED через raw DBAL UPDATE (минуя UoW).
+     *
+     * Условие `status IN ('pending', 'running')` делает операцию идемпотентной:
+     * два воркера, финализирующие job параллельно (последний документ), не
+     * перезапишут finished_at — UPDATE второго затронет 0 строк. Также защита
+     * от случайного «воскрешения» уже FAILED job'а.
+     *
+     * `company_id` в WHERE — встроенный IDOR-guard.
+     *
+     * @return int число обновлённых строк (0 если job уже терминальный или чужой)
+     */
+    public function markCompleted(string $jobId, string $companyId): int
+    {
+        return (int) $this->getEntityManager()->getConnection()->executeStatement(
+            <<<'SQL'
+                UPDATE marketplace_ad_load_jobs
+                SET status = 'completed',
+                    finished_at = NOW(),
+                    updated_at = NOW()
+                WHERE id = :jobId
+                  AND company_id = :companyId
+                  AND status IN ('pending', 'running')
+                SQL,
+            [
                 'jobId' => $jobId,
                 'companyId' => $companyId,
             ],

--- a/site/src/MarketplaceAds/Repository/AdLoadJobRepositoryInterface.php
+++ b/site/src/MarketplaceAds/Repository/AdLoadJobRepositoryInterface.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Repository;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAds\Entity\AdLoadJob;
+
+/**
+ * Контракт репозитория AdLoadJob.
+ *
+ * Вынесен в интерфейс, чтобы:
+ *  - держать concrete-репозиторий `final` (правило CLAUDE.md) без потери возможности
+ *    мокать в unit-тестах хендлеров — PHPUnit мокает интерфейс без подклассов;
+ *  - зафиксировать явный контракт чтения/мутаций счётчиков и жизненного цикла
+ *    для Messenger-хендлеров и Controller/Action'ов.
+ *
+ * Атомарные инкременты (*_days, chunks_completed) и mark* реализованы на уровне
+ * repository через raw DBAL UPDATE — минуя Doctrine UoW, чтобы параллельные
+ * воркеры не затирали друг друга. Все мутации идемпотентны через SQL guard'ы.
+ */
+interface AdLoadJobRepositoryInterface
+{
+    public function save(AdLoadJob $job): void;
+
+    public function findByIdAndCompany(string $id, string $companyId): ?AdLoadJob;
+
+    /**
+     * Находит задание по ID БЕЗ проверки company_id.
+     *
+     * IDOR-safe только в trusted-контексте (Messenger-хендлеры, где jobId сгенерирован
+     * внутри системы). Для HTTP-запросов использовать {@see self::findByIdAndCompany()}.
+     */
+    public function find(string $id): ?AdLoadJob;
+
+    public function findLatestActiveJobByCompanyAndMarketplace(
+        string $companyId,
+        MarketplaceType $marketplace,
+    ): ?AdLoadJob;
+
+    public function findActiveJobCoveringDate(
+        string $companyId,
+        MarketplaceType $marketplace,
+        \DateTimeImmutable $date,
+    ): ?AdLoadJob;
+
+    public function incrementLoadedDays(string $jobId, string $companyId, int $delta = 1): int;
+
+    public function incrementProcessedDays(string $jobId, string $companyId, int $delta = 1): int;
+
+    public function incrementFailedDays(string $jobId, string $companyId, int $delta = 1): int;
+
+    public function incrementChunksCompleted(string $jobId, string $companyId, int $delta = 1): int;
+
+    /**
+     * Идемпотентно помечает задание как COMPLETED. SQL guard `status IN ('pending','running')`
+     * защищает от повторной финализации (два воркера дошли до tryFinalizeJob одновременно).
+     *
+     * @return int число обновлённых строк (0 если job уже терминальный или чужой)
+     */
+    public function markCompleted(string $jobId, string $companyId): int;
+
+    /**
+     * Идемпотентно помечает задание как FAILED с причиной. Повторные вызовы не
+     * перезаписывают исходную причину (SQL guard на статус).
+     *
+     * @return int число обновлённых строк (0 если job уже терминальный или чужой)
+     */
+    public function markFailed(string $jobId, string $companyId, string $reason): int;
+}

--- a/site/src/MarketplaceAds/Repository/AdLoadJobRepositoryInterface.php
+++ b/site/src/MarketplaceAds/Repository/AdLoadJobRepositoryInterface.php
@@ -34,6 +34,18 @@ interface AdLoadJobRepositoryInterface
      */
     public function find(string $id): ?AdLoadJob;
 
+    /**
+     * Возвращает job с актуальными значениями счётчиков из БД.
+     *
+     * Нужен после атомарных UPDATE через DBAL ({@see self::incrementProcessedDays()}
+     * и соседи) — они минуют Doctrine UoW, из-за чего обычный find() через
+     * identity map вернул бы in-memory instance со СТАРЫМИ значениями счётчиков.
+     * В tryFinalizeJob это критично: на последнем документе стейл-instance
+     * провалил бы условие `processed+failed >= COUNT(raw)` и финализация не
+     * произошла бы, job остался бы в RUNNING навсегда.
+     */
+    public function findFresh(string $jobId): ?AdLoadJob;
+
     public function findLatestActiveJobByCompanyAndMarketplace(
         string $companyId,
         MarketplaceType $marketplace,

--- a/site/src/MarketplaceAds/Repository/AdLoadJobRepositoryInterface.php
+++ b/site/src/MarketplaceAds/Repository/AdLoadJobRepositoryInterface.php
@@ -16,9 +16,11 @@ use App\MarketplaceAds\Entity\AdLoadJob;
  *  - зафиксировать явный контракт чтения/мутаций счётчиков и жизненного цикла
  *    для Messenger-хендлеров и Controller/Action'ов.
  *
- * Атомарные инкременты (*_days, chunks_completed) и mark* реализованы на уровне
- * repository через raw DBAL UPDATE — минуя Doctrine UoW, чтобы параллельные
- * воркеры не затирали друг друга. Все мутации идемпотентны через SQL guard'ы.
+ * Атомарные инкременты (loaded_days, chunks_completed) и mark* реализованы на
+ * уровне repository через raw DBAL UPDATE — минуя Doctrine UoW, чтобы
+ * параллельные воркеры не затирали друг друга. Все мутации идемпотентны через
+ * SQL guard'ы. Processed/failed-счётчики удалены: состояние обработки хранится
+ * на AdRawDocument.status, финализация считает терминальные документы.
  */
 interface AdLoadJobRepositoryInterface
 {
@@ -37,11 +39,11 @@ interface AdLoadJobRepositoryInterface
     /**
      * Возвращает job с актуальными значениями счётчиков из БД.
      *
-     * Нужен после атомарных UPDATE через DBAL ({@see self::incrementProcessedDays()}
+     * Нужен после атомарных UPDATE через DBAL ({@see self::incrementChunksCompleted()}
      * и соседи) — они минуют Doctrine UoW, из-за чего обычный find() через
      * identity map вернул бы in-memory instance со СТАРЫМИ значениями счётчиков.
-     * В tryFinalizeJob это критично: на последнем документе стейл-instance
-     * провалил бы условие `processed+failed >= COUNT(raw)` и финализация не
+     * В tryFinalizeJob это критично: на последнем чанке стейл-instance
+     * провалил бы условие `chunksCompleted >= chunksTotal` и финализация не
      * произошла бы, job остался бы в RUNNING навсегда.
      */
     public function findFresh(string $jobId): ?AdLoadJob;
@@ -58,10 +60,6 @@ interface AdLoadJobRepositoryInterface
     ): ?AdLoadJob;
 
     public function incrementLoadedDays(string $jobId, string $companyId, int $delta = 1): int;
-
-    public function incrementProcessedDays(string $jobId, string $companyId, int $delta = 1): int;
-
-    public function incrementFailedDays(string $jobId, string $companyId, int $delta = 1): int;
 
     public function incrementChunksCompleted(string $jobId, string $companyId, int $delta = 1): int;
 

--- a/site/src/MarketplaceAds/Repository/AdRawDocumentRepository.php
+++ b/site/src/MarketplaceAds/Repository/AdRawDocumentRepository.php
@@ -44,10 +44,9 @@ class AdRawDocumentRepository extends ServiceEntityRepository
     /**
      * Количество AdRawDocument компании по площадке в диапазоне дат включительно.
      *
-     * Используется для финализации AdLoadJob: condition «все документы обработаны» —
-     * это `COUNT(raw) == processed_days + failed_days`. Счётчик `loaded_days` в
-     * AdLoadJob coverage-based (chunkDays) и может overshoot'ить при retry
-     * оркестратора, поэтому использовать его в условии финализации нельзя.
+     * Используется как «итог» для финализации AdLoadJob: condition «все документы
+     * дошли до терминального состояния» — это
+     * `countByCompanyMarketplaceAndDateRange == countTerminalByCompanyMarketplaceAndDateRange`.
      * COUNT по AdRawDocument идемпотентен благодаря UniqueConstraint
      * (company_id, marketplace, report_date): повторный upsert за ту же дату
      * не создаст новую строку.
@@ -69,6 +68,92 @@ class AdRawDocumentRepository extends ServiceEntityRepository
             ->setParameter('to', $to->format('Y-m-d'))
             ->getQuery()
             ->getSingleScalarResult();
+    }
+
+    /**
+     * Количества PROCESSED и FAILED документов в диапазоне — одним SELECT'ом
+     * с GROUP BY status. Альтернатива двум отдельным COUNT-запросам.
+     *
+     * Используется {@see \App\MarketplaceAds\MessageHandler\ProcessAdRawDocumentHandler::tryFinalizeJob}:
+     *  - total == processed + failed → chunks closed AND все документы терминальны;
+     *  - failed == 0 → markCompleted, иначе markFailed с reason.
+     *
+     * Возврат: массив с гарантированными ключами 'processed' и 'failed' (0, если
+     * соответствующих записей нет — не приходится проверять `?? 0` на вызове).
+     *
+     * @return array{processed: int, failed: int}
+     */
+    public function countTerminalByCompanyMarketplaceAndDateRange(
+        string $companyId,
+        string $marketplace,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+    ): array {
+        $rows = $this->createQueryBuilder('r')
+            ->select('r.status AS status, COUNT(r.id) AS cnt')
+            ->where('r.companyId = :companyId')
+            ->andWhere('r.marketplace = :marketplace')
+            ->andWhere('r.reportDate BETWEEN :from AND :to')
+            ->andWhere('r.status IN (:terminal)')
+            ->groupBy('r.status')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('marketplace', $marketplace)
+            ->setParameter('from', $from->format('Y-m-d'))
+            ->setParameter('to', $to->format('Y-m-d'))
+            ->setParameter('terminal', [AdRawDocumentStatus::PROCESSED, AdRawDocumentStatus::FAILED])
+            ->getQuery()
+            ->getArrayResult();
+
+        $counts = ['processed' => 0, 'failed' => 0];
+        foreach ($rows as $row) {
+            $status = $row['status'] instanceof AdRawDocumentStatus ? $row['status'] : AdRawDocumentStatus::from((string) $row['status']);
+            if (AdRawDocumentStatus::PROCESSED === $status) {
+                $counts['processed'] = (int) $row['cnt'];
+            } elseif (AdRawDocumentStatus::FAILED === $status) {
+                $counts['failed'] = (int) $row['cnt'];
+            }
+        }
+
+        return $counts;
+    }
+
+    /**
+     * Идемпотентно помечает документ как FAILED с причиной через raw DBAL UPDATE.
+     *
+     * Условие `status != 'failed'` делает операцию повторно-безопасной: retry
+     * Messenger'а после уже-FAILED не перезапишет processing_error (первая
+     * причина сохраняется). Параллельный worker, успевший отработать документ
+     * до ошибки в нашем — проходит Action и markAsProcessed; после этого наш
+     * markFailedWithReason затронет 0 строк (WHERE не сойдётся: status =
+     * 'processed' ≠ 'failed' — НО мы не хотим «понижать» PROCESSED до FAILED).
+     * Поэтому guard сильнее: `status = 'draft'`.
+     *
+     * `company_id` в WHERE — встроенный IDOR-guard.
+     *
+     * @return int число обновлённых строк (0 если документ уже терминальный или чужой)
+     */
+    public function markFailedWithReason(string $id, string $companyId, string $reason): int
+    {
+        if ('' === $reason) {
+            throw new \InvalidArgumentException('Причина ошибки не может быть пустой.');
+        }
+
+        return (int) $this->getEntityManager()->getConnection()->executeStatement(
+            <<<'SQL'
+                UPDATE marketplace_ad_raw_documents
+                SET status = 'failed',
+                    processing_error = :reason,
+                    updated_at = NOW()
+                WHERE id = :id
+                  AND company_id = :companyId
+                  AND status = 'draft'
+                SQL,
+            [
+                'reason' => $reason,
+                'id' => $id,
+                'companyId' => $companyId,
+            ],
+        );
     }
 
     /**

--- a/site/src/MarketplaceAds/Repository/AdRawDocumentRepository.php
+++ b/site/src/MarketplaceAds/Repository/AdRawDocumentRepository.php
@@ -42,6 +42,36 @@ class AdRawDocumentRepository extends ServiceEntityRepository
     }
 
     /**
+     * Количество AdRawDocument компании по площадке в диапазоне дат включительно.
+     *
+     * Используется для финализации AdLoadJob: condition «все документы обработаны» —
+     * это `COUNT(raw) == processed_days + failed_days`. Счётчик `loaded_days` в
+     * AdLoadJob coverage-based (chunkDays) и может overshoot'ить при retry
+     * оркестратора, поэтому использовать его в условии финализации нельзя.
+     * COUNT по AdRawDocument идемпотентен благодаря UniqueConstraint
+     * (company_id, marketplace, report_date): повторный upsert за ту же дату
+     * не создаст новую строку.
+     */
+    public function countByCompanyMarketplaceAndDateRange(
+        string $companyId,
+        string $marketplace,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+    ): int {
+        return (int) $this->createQueryBuilder('r')
+            ->select('COUNT(r.id)')
+            ->where('r.companyId = :companyId')
+            ->andWhere('r.marketplace = :marketplace')
+            ->andWhere('r.reportDate BETWEEN :from AND :to')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('marketplace', $marketplace)
+            ->setParameter('from', $from->format('Y-m-d'))
+            ->setParameter('to', $to->format('Y-m-d'))
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    /**
      * @return AdRawDocument[]
      */
     public function findDrafts(string $companyId): array

--- a/site/tests/Builders/MarketplaceAds/AdLoadJobBuilder.php
+++ b/site/tests/Builders/MarketplaceAds/AdLoadJobBuilder.php
@@ -21,8 +21,6 @@ final class AdLoadJobBuilder
     private AdLoadJobStatus $status = AdLoadJobStatus::PENDING;
     private ?string $failureReason = null;
     private int $loadedDays = 0;
-    private int $processedDays = 0;
-    private int $failedDays = 0;
     private int $chunksTotal = 0;
     private int $chunksCompleted = 0;
 
@@ -105,22 +103,6 @@ final class AdLoadJobBuilder
         return $clone;
     }
 
-    public function withProcessed(int $days): self
-    {
-        $clone = clone $this;
-        $clone->processedDays = $days;
-
-        return $clone;
-    }
-
-    public function withFailed(int $days): self
-    {
-        $clone = clone $this;
-        $clone->failedDays = $days;
-
-        return $clone;
-    }
-
     public function withChunksTotal(int $total): self
     {
         $clone = clone $this;
@@ -153,12 +135,6 @@ final class AdLoadJobBuilder
         // Для произвольного состояния в тестах используем Reflection.
         if ($this->loadedDays !== 0) {
             $this->setProperty($job, 'loadedDays', $this->loadedDays);
-        }
-        if ($this->processedDays !== 0) {
-            $this->setProperty($job, 'processedDays', $this->processedDays);
-        }
-        if ($this->failedDays !== 0) {
-            $this->setProperty($job, 'failedDays', $this->failedDays);
         }
         if ($this->chunksTotal !== 0) {
             $this->setProperty($job, 'chunksTotal', $this->chunksTotal);

--- a/site/tests/Builders/MarketplaceAds/AdRawDocumentBuilder.php
+++ b/site/tests/Builders/MarketplaceAds/AdRawDocumentBuilder.php
@@ -19,6 +19,7 @@ final class AdRawDocumentBuilder
     private \DateTimeImmutable $reportDate;
     private string $rawPayload = self::DEFAULT_RAW_PAYLOAD;
     private bool $processed = false;
+    private ?string $failureReason = null;
 
     private function __construct()
     {
@@ -74,6 +75,16 @@ final class AdRawDocumentBuilder
     {
         $clone = clone $this;
         $clone->processed = true;
+        $clone->failureReason = null;
+
+        return $clone;
+    }
+
+    public function asFailed(string $reason = 'test failure'): self
+    {
+        $clone = clone $this;
+        $clone->processed = false;
+        $clone->failureReason = $reason;
 
         return $clone;
     }
@@ -95,6 +106,8 @@ final class AdRawDocumentBuilder
 
         if ($this->processed) {
             $doc->markAsProcessed();
+        } elseif (null !== $this->failureReason) {
+            $doc->markFailed($this->failureReason);
         }
 
         return $doc;

--- a/site/tests/Integration/MarketplaceAds/AdLoadJobRepositoryTest.php
+++ b/site/tests/Integration/MarketplaceAds/AdLoadJobRepositoryTest.php
@@ -266,30 +266,6 @@ final class AdLoadJobRepositoryTest extends IntegrationTestCase
         self::assertSame(5, $reloaded->getLoadedDays(), 'Счётчик не должен измениться от чужого company_id');
     }
 
-    public function testIncrementProcessedAndFailedDays(): void
-    {
-        $this->seedCompany(self::COMPANY_ID, self::OWNER_ID, 'a@example.test');
-        $this->em->flush();
-
-        $job = AdLoadJobBuilder::aJob()
-            ->withCompanyId(self::COMPANY_ID)
-            ->withIndex(1)
-            ->build();
-        $this->repository->save($job);
-        $this->em->flush();
-        $jobId = $job->getId();
-        $this->em->clear();
-
-        $this->repository->incrementProcessedDays($jobId, self::COMPANY_ID, 3);
-        $this->repository->incrementFailedDays($jobId, self::COMPANY_ID, 2);
-
-        $reloaded = $this->repository->findByIdAndCompany($jobId, self::COMPANY_ID);
-        self::assertNotNull($reloaded);
-        self::assertSame(3, $reloaded->getProcessedDays());
-        self::assertSame(2, $reloaded->getFailedDays());
-        self::assertSame(0, $reloaded->getLoadedDays());
-    }
-
     /**
      * @dataProvider nonPositiveDeltaProvider
      */
@@ -319,39 +295,6 @@ final class AdLoadJobRepositoryTest extends IntegrationTestCase
             'negative' => [-1],
             'large negative' => [-100],
         ];
-    }
-
-    public function testIncrementProcessedAndFailedAlsoRejectNonPositiveDelta(): void
-    {
-        $this->seedCompany(self::COMPANY_ID, self::OWNER_ID, 'a@example.test');
-        $this->em->flush();
-
-        $job = AdLoadJobBuilder::aJob()
-            ->withCompanyId(self::COMPANY_ID)
-            ->withIndex(1)
-            ->build();
-        $this->repository->save($job);
-        $this->em->flush();
-        $jobId = $job->getId();
-
-        try {
-            $this->repository->incrementProcessedDays($jobId, self::COMPANY_ID, 0);
-            self::fail('Expected InvalidArgumentException for processed delta = 0');
-        } catch (\InvalidArgumentException) {
-        }
-
-        try {
-            $this->repository->incrementFailedDays($jobId, self::COMPANY_ID, -5);
-            self::fail('Expected InvalidArgumentException for failed delta = -5');
-        } catch (\InvalidArgumentException) {
-        }
-
-        // Счётчики остались по нулям — невалидный вызов не дошёл до SQL.
-        $this->em->clear();
-        $reloaded = $this->repository->findByIdAndCompany($jobId, self::COMPANY_ID);
-        self::assertNotNull($reloaded);
-        self::assertSame(0, $reloaded->getProcessedDays());
-        self::assertSame(0, $reloaded->getFailedDays());
     }
 
     public function testIncrementChunksCompletedIsAtomicAndIDORSafe(): void

--- a/site/tests/Unit/MarketplaceAds/AdLoadJobTest.php
+++ b/site/tests/Unit/MarketplaceAds/AdLoadJobTest.php
@@ -88,8 +88,6 @@ final class AdLoadJobTest extends TestCase
 
         self::assertSame(AdLoadJobStatus::PENDING, $job->getStatus());
         self::assertSame(0, $job->getLoadedDays());
-        self::assertSame(0, $job->getProcessedDays());
-        self::assertSame(0, $job->getFailedDays());
         self::assertNull($job->getStartedAt());
         self::assertNull($job->getFinishedAt());
         self::assertNull($job->getFailureReason());
@@ -166,12 +164,13 @@ final class AdLoadJobTest extends TestCase
         $job->markFailed('вторая попытка');
     }
 
-    public function testGetProgressComputesPercentFromLoadedPlusFailed(): void
+    public function testGetProgressComputesPercentFromLoadedDays(): void
     {
-        // 10 дней, 3 loaded + 2 failed = 50%
+        // 10 дней, 5 loaded = 50%. После перехода состояния обработки на
+        // AdRawDocument.status прогресс на AdLoadJob отражает только факт
+        // выгрузки чанков (loaded_days), без ветвления по ошибкам.
         $job = AdLoadJobBuilder::aJob()
-            ->withLoaded(3)
-            ->withFailed(2)
+            ->withLoaded(5)
             ->build();
 
         self::assertSame(10, $job->getTotalDays());

--- a/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
@@ -145,6 +145,12 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
 
     public function testUpsertCallsUpdatePayloadForExistingDay(): void
     {
+        // Сценарий: единственный день уже есть в БД → upsert идёт по ветке
+        // `updated`, `created` пустой. Это классифицируется как retry оркестратора:
+        // chunks_completed на этом чанке инкрементился в прошлый раз, повторно —
+        // нельзя (иначе chunksCompleted > chunksTotal и ложная финализация).
+        // loaded_days всё равно увеличиваем по coverage чанка — он информационный
+        // и в условие финализации не входит (см. ProcessAdRawDocumentHandler).
         $job = AdLoadJobBuilder::aJob()->asRunning()->build();
 
         $existing = AdRawDocumentBuilder::aRawDocument()
@@ -161,10 +167,8 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             ->method('incrementLoadedDays')
             ->with(AdLoadJobBuilder::DEFAULT_ID, self::COMPANY_ID, 1)
             ->willReturn(1);
-        $jobRepo->expects(self::once())
-            ->method('incrementChunksCompleted')
-            ->with(AdLoadJobBuilder::DEFAULT_ID, self::COMPANY_ID)
-            ->willReturn(1);
+        // Retry-fetch: chunks_completed НЕ инкрементим.
+        $jobRepo->expects(self::never())->method('incrementChunksCompleted');
 
         $ozonClient = $this->createMock(OzonAdClient::class);
         $ozonClient->method('fetchAdStatisticsRange')->willReturn([
@@ -666,6 +670,132 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             AdLoadJobBuilder::DEFAULT_ID,
             self::COMPANY_ID,
             '2026-02-31',
+            self::DATE_TO,
+        ));
+    }
+
+    public function testRetryOfOrchestratorDoesNotIncrementChunksCompleted(): void
+    {
+        // Сценарий: оркестратор ретраится после частичного dispatch'а. Все 3 дня
+        // диапазона уже есть в БД → upsert классифицирует их как updated,
+        // created пустой. chunks_completed инкрементился на первом fetch'е —
+        // повторно нельзя. Re-dispatch ProcessAdRawDocumentMessage сохраняется
+        // (перепроцессинг идемпотентен на стороне handler'а).
+        $job = AdLoadJobBuilder::aJob()
+            ->withDateRange(new \DateTimeImmutable(self::DATE_FROM), new \DateTimeImmutable(self::DATE_TO))
+            ->asRunning()
+            ->build();
+
+        $existingByDate = [
+            '2026-03-01' => AdRawDocumentBuilder::aRawDocument()
+                ->withCompanyId(self::COMPANY_ID)
+                ->withMarketplace(MarketplaceType::OZON)
+                ->withReportDate(new \DateTimeImmutable('2026-03-01'))
+                ->withRawPayload('{"old":1}')
+                ->build(),
+            '2026-03-02' => AdRawDocumentBuilder::aRawDocument()
+                ->withCompanyId(self::COMPANY_ID)
+                ->withMarketplace(MarketplaceType::OZON)
+                ->withReportDate(new \DateTimeImmutable('2026-03-02'))
+                ->withRawPayload('{"old":2}')
+                ->build(),
+            '2026-03-03' => AdRawDocumentBuilder::aRawDocument()
+                ->withCompanyId(self::COMPANY_ID)
+                ->withMarketplace(MarketplaceType::OZON)
+                ->withReportDate(new \DateTimeImmutable('2026-03-03'))
+                ->withRawPayload('{"old":3}')
+                ->build(),
+        ];
+
+        $jobRepo = $this->createMock(AdLoadJobRepository::class);
+        $jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $jobRepo->method('incrementLoadedDays')->willReturn(1);
+        $jobRepo->expects(self::never())->method('incrementChunksCompleted');
+        $jobRepo->expects(self::never())->method('markFailed');
+
+        $ozonClient = $this->createMock(OzonAdClient::class);
+        $ozonClient->method('fetchAdStatisticsRange')->willReturn([
+            '2026-03-01' => ['rows' => [['spend' => 11]]],
+            '2026-03-02' => ['rows' => [['spend' => 22]]],
+            '2026-03-03' => ['rows' => [['spend' => 33]]],
+        ]);
+
+        $rawRepo = $this->createMock(AdRawDocumentRepository::class);
+        $rawRepo->method('findByMarketplaceAndDate')
+            ->willReturnCallback(static function (string $companyId, string $marketplace, \DateTimeImmutable $date) use ($existingByDate): ?AdRawDocument {
+                return $existingByDate[$date->format('Y-m-d')] ?? null;
+            });
+        $rawRepo->expects(self::never())->method('save');
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::once())->method('flush');
+
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::exactly(3))
+            ->method('dispatch')
+            ->willReturnCallback(static fn (object $m): Envelope => new Envelope($m));
+
+        $handler = $this->createHandler($ozonClient, $rawRepo, $jobRepo, $em, $messageBus);
+        $handler(new FetchOzonAdStatisticsMessage(
+            AdLoadJobBuilder::DEFAULT_ID,
+            self::COMPANY_ID,
+            self::DATE_FROM,
+            self::DATE_TO,
+        ));
+    }
+
+    public function testFirstFetchWithMixedCreatedAndUpdatedIncrementsChunksCompleted(): void
+    {
+        // Редкий сценарий: часть документов уже была после ручного/CLI запуска,
+        // часть создаётся впервые. created>0 → это всё ещё первый fetch на этом
+        // chunksCompleted-счётчике, инкрементим его.
+        $job = AdLoadJobBuilder::aJob()
+            ->withDateRange(new \DateTimeImmutable(self::DATE_FROM), new \DateTimeImmutable(self::DATE_TO))
+            ->asRunning()
+            ->build();
+
+        $existingOnMiddleDay = AdRawDocumentBuilder::aRawDocument()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withReportDate(new \DateTimeImmutable('2026-03-02'))
+            ->withRawPayload('{"old":true}')
+            ->build();
+
+        $jobRepo = $this->createMock(AdLoadJobRepository::class);
+        $jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $jobRepo->method('incrementLoadedDays')->willReturn(1);
+        $jobRepo->expects(self::once())
+            ->method('incrementChunksCompleted')
+            ->with(AdLoadJobBuilder::DEFAULT_ID, self::COMPANY_ID)
+            ->willReturn(1);
+
+        $ozonClient = $this->createMock(OzonAdClient::class);
+        $ozonClient->method('fetchAdStatisticsRange')->willReturn([
+            '2026-03-01' => ['rows' => [['spend' => 1]]],
+            '2026-03-02' => ['rows' => [['spend' => 2]]],
+            '2026-03-03' => ['rows' => [['spend' => 3]]],
+        ]);
+
+        $rawRepo = $this->createMock(AdRawDocumentRepository::class);
+        $rawRepo->method('findByMarketplaceAndDate')
+            ->willReturnCallback(static function (string $c, string $m, \DateTimeImmutable $d) use ($existingOnMiddleDay): ?AdRawDocument {
+                return '2026-03-02' === $d->format('Y-m-d') ? $existingOnMiddleDay : null;
+            });
+        $rawRepo->expects(self::exactly(2))->method('save'); // 2 новых дня
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::once())->method('flush');
+
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::exactly(3))
+            ->method('dispatch')
+            ->willReturnCallback(static fn (object $m): Envelope => new Envelope($m));
+
+        $handler = $this->createHandler($ozonClient, $rawRepo, $jobRepo, $em, $messageBus);
+        $handler(new FetchOzonAdStatisticsMessage(
+            AdLoadJobBuilder::DEFAULT_ID,
+            self::COMPANY_ID,
+            self::DATE_FROM,
             self::DATE_TO,
         ));
     }

--- a/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
@@ -37,9 +37,9 @@ use Symfony\Component\Messenger\MessageBusInterface;
  *    (который сам сбрасывает status в DRAFT — двойной resetToDraft() сломал бы entity).
  *  - Терминальный job и отсутствующий job — no-op, API Ozon не дёргается.
  *  - Error taxonomy: InvalidArgumentException + 403 → markFailed + Unrecoverable;
- *    прочие 5xx / сеть → incrementFailedDays(chunkDays) + rethrow (Messenger сам делает retry).
- *  - json_encode() === false для одного дня: этот день пропускается и попадает в failedDays,
- *    остальные дни загружаются как обычно. Это устойчивость к «кривой» записи без срыва чанка.
+ *    прочие 5xx / сеть → rethrow (Messenger сам делает retry, прогресс чанка не двигаем).
+ *  - json_encode() === false для одного дня: этот день пропускается, остальные дни
+ *    загружаются как обычно. Это устойчивость к «кривой» записи без срыва чанка.
  */
 final class FetchOzonAdStatisticsHandlerTest extends TestCase
 {
@@ -100,7 +100,6 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
 
                 return 1;
             });
-        $jobRepo->expects(self::never())->method('incrementFailedDays');
         $jobRepo->expects(self::once())
             ->method('incrementChunksCompleted')
             ->with(self::JOB_ID, self::COMPANY_ID)
@@ -224,7 +223,6 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $jobRepo->method('findByIdAndCompany')->willReturn($job);
         $jobRepo->expects(self::never())->method('markFailed');
         $jobRepo->expects(self::never())->method('incrementLoadedDays');
-        $jobRepo->expects(self::never())->method('incrementFailedDays');
         $jobRepo->expects(self::never())->method('incrementChunksCompleted');
 
         $ozonClient = $this->createMock(OzonAdClient::class);
@@ -290,7 +288,6 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
                 self::stringContains('Invalid date range'),
             )
             ->willReturn(1);
-        $jobRepo->expects(self::never())->method('incrementFailedDays');
         $jobRepo->expects(self::never())->method('incrementChunksCompleted');
 
         $ozonClient = $this->createMock(OzonAdClient::class);
@@ -331,7 +328,6 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
                 self::stringContains('Ozon API permanent failure'),
             )
             ->willReturn(1);
-        $jobRepo->expects(self::never())->method('incrementFailedDays');
         $jobRepo->expects(self::never())->method('incrementChunksCompleted');
 
         $ozonClient = $this->createMock(OzonAdClient::class);
@@ -369,7 +365,6 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $jobRepo = $this->createMock(AdLoadJobRepository::class);
         $jobRepo->method('findByIdAndCompany')->willReturn($job);
         $jobRepo->expects(self::never())->method('markFailed');
-        $jobRepo->expects(self::never())->method('incrementFailedDays');
         $jobRepo->expects(self::never())->method('incrementLoadedDays');
         $jobRepo->expects(self::never())->method('incrementChunksCompleted');
 
@@ -422,10 +417,6 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $jobRepo->expects(self::once())
             ->method('incrementLoadedDays')
             ->with(AdLoadJobBuilder::DEFAULT_ID, self::COMPANY_ID, 2)
-            ->willReturn(1);
-        $jobRepo->expects(self::once())
-            ->method('incrementFailedDays')
-            ->with(AdLoadJobBuilder::DEFAULT_ID, self::COMPANY_ID, 1)
             ->willReturn(1);
         $jobRepo->expects(self::never())->method('markFailed');
         // Чанк физически отработан (частичный json-fail не срывает чанк) —
@@ -565,7 +556,6 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             ->method('incrementLoadedDays')
             ->with(AdLoadJobBuilder::DEFAULT_ID, self::COMPANY_ID, 3) // chunkDays=3, не count($documents)=1
             ->willReturn(1);
-        $jobRepo->expects(self::never())->method('incrementFailedDays');
         $jobRepo->expects(self::never())->method('markFailed');
         $jobRepo->expects(self::once())
             ->method('incrementChunksCompleted')
@@ -612,7 +602,6 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             ->method('incrementLoadedDays')
             ->with(AdLoadJobBuilder::DEFAULT_ID, self::COMPANY_ID, 3)
             ->willReturn(1);
-        $jobRepo->expects(self::never())->method('incrementFailedDays');
         $jobRepo->expects(self::once())
             ->method('incrementChunksCompleted')
             ->with(AdLoadJobBuilder::DEFAULT_ID, self::COMPANY_ID)

--- a/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
@@ -12,6 +12,7 @@ use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonPermanentApiException;
 use App\MarketplaceAds\Message\FetchOzonAdStatisticsMessage;
 use App\MarketplaceAds\Message\ProcessAdRawDocumentMessage;
 use App\MarketplaceAds\MessageHandler\FetchOzonAdStatisticsHandler;
+use App\MarketplaceAds\Repository\AdChunkProgressRepositoryInterface;
 use App\MarketplaceAds\Repository\AdLoadJobRepository;
 use App\MarketplaceAds\Repository\AdRawDocumentRepository;
 use App\Shared\Service\AppLogger;
@@ -146,11 +147,11 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
     public function testUpsertCallsUpdatePayloadForExistingDay(): void
     {
         // Сценарий: единственный день уже есть в БД → upsert идёт по ветке
-        // `updated`, `created` пустой. Это классифицируется как retry оркестратора:
-        // chunks_completed на этом чанке инкрементился в прошлый раз, повторно —
-        // нельзя (иначе chunksCompleted > chunksTotal и ложная финализация).
-        // loaded_days всё равно увеличиваем по coverage чанка — он информационный
-        // и в условие финализации не входит (см. ProcessAdRawDocumentHandler).
+        // `updated`, `created` пустой. Ledger (AdChunkProgressRepository) для
+        // этого (jobId, range) уже содержит запись — tryMarkCompleted вернёт
+        // false, chunks_completed инкрементить не будем. loaded_days всё равно
+        // увеличиваем по coverage чанка — он информационный и в условие
+        // финализации не входит (см. ProcessAdRawDocumentHandler).
         $job = AdLoadJobBuilder::aJob()->asRunning()->build();
 
         $existing = AdRawDocumentBuilder::aRawDocument()
@@ -195,7 +196,14 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
                 return new Envelope($msg);
             });
 
-        $handler = $this->createHandler($ozonClient, $rawRepo, $jobRepo, $em, $messageBus);
+        $handler = $this->createHandler(
+            $ozonClient,
+            $rawRepo,
+            $jobRepo,
+            $em,
+            $messageBus,
+            $this->createChunkProgressRepoReturning(false), // ledger уже содержит эту пару — retry
+        );
         $handler(new FetchOzonAdStatisticsMessage(
             AdLoadJobBuilder::DEFAULT_ID,
             self::COMPANY_ID,
@@ -676,11 +684,11 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
 
     public function testRetryOfOrchestratorDoesNotIncrementChunksCompleted(): void
     {
-        // Сценарий: оркестратор ретраится после частичного dispatch'а. Все 3 дня
-        // диапазона уже есть в БД → upsert классифицирует их как updated,
-        // created пустой. chunks_completed инкрементился на первом fetch'е —
-        // повторно нельзя. Re-dispatch ProcessAdRawDocumentMessage сохраняется
-        // (перепроцессинг идемпотентен на стороне handler'а).
+        // Сценарий: оркестратор ретраится после частичного dispatch'а. Ledger
+        // уже содержит запись (jobId, dateFrom, dateTo) с первого fetch'а —
+        // tryMarkCompleted вернёт false, chunks_completed не инкрементим.
+        // Re-dispatch ProcessAdRawDocumentMessage сохраняется (перепроцессинг
+        // идемпотентен на стороне handler'а).
         $job = AdLoadJobBuilder::aJob()
             ->withDateRange(new \DateTimeImmutable(self::DATE_FROM), new \DateTimeImmutable(self::DATE_TO))
             ->asRunning()
@@ -735,7 +743,14 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             ->method('dispatch')
             ->willReturnCallback(static fn (object $m): Envelope => new Envelope($m));
 
-        $handler = $this->createHandler($ozonClient, $rawRepo, $jobRepo, $em, $messageBus);
+        $handler = $this->createHandler(
+            $ozonClient,
+            $rawRepo,
+            $jobRepo,
+            $em,
+            $messageBus,
+            $this->createChunkProgressRepoReturning(false), // retry: ledger уже содержит запись
+        );
         $handler(new FetchOzonAdStatisticsMessage(
             AdLoadJobBuilder::DEFAULT_ID,
             self::COMPANY_ID,
@@ -746,9 +761,12 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
 
     public function testFirstFetchWithMixedCreatedAndUpdatedIncrementsChunksCompleted(): void
     {
-        // Редкий сценарий: часть документов уже была после ручного/CLI запуска,
-        // часть создаётся впервые. created>0 → это всё ещё первый fetch на этом
-        // chunksCompleted-счётчике, инкрементим его.
+        // Сценарий: часть документов уже была после ручного/CLI preload'а,
+        // часть создаётся впервые. Для этого (jobId, range) в ledger'е записи
+        // НЕТ — tryMarkCompleted вернёт true (первая вставка), инкрементим
+        // chunks_completed. Это ключевой кейс: старая эвристика по
+        // created/updated могла бы пропустить инкремент при полном preload'е,
+        // ledger этого избегает.
         $job = AdLoadJobBuilder::aJob()
             ->withDateRange(new \DateTimeImmutable(self::DATE_FROM), new \DateTimeImmutable(self::DATE_TO))
             ->asRunning()
@@ -800,20 +818,167 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         ));
     }
 
+    public function testFirstFetchWithAllDaysPreExistingStillIncrementsChunksCompleted(): void
+    {
+        // Regression: раньше эвристика `created === [] && updated !== []`
+        // пропускала инкремент, если все дни чанка уже существовали в БД
+        // (например, CLI-preload до orchestrator-run'а). Новый jobId не
+        // продвигался бы, и job застрял бы в RUNNING. Ledger смотрит на
+        // (jobId, range): для нового job'а записи нет → tryMarkCompleted=true
+        // → chunks_completed инкрементится нормально.
+        $job = AdLoadJobBuilder::aJob()
+            ->withDateRange(new \DateTimeImmutable(self::DATE_FROM), new \DateTimeImmutable(self::DATE_TO))
+            ->asRunning()
+            ->build();
+
+        $existingByDate = [
+            '2026-03-01' => AdRawDocumentBuilder::aRawDocument()
+                ->withCompanyId(self::COMPANY_ID)
+                ->withMarketplace(MarketplaceType::OZON)
+                ->withReportDate(new \DateTimeImmutable('2026-03-01'))
+                ->build(),
+            '2026-03-02' => AdRawDocumentBuilder::aRawDocument()
+                ->withCompanyId(self::COMPANY_ID)
+                ->withMarketplace(MarketplaceType::OZON)
+                ->withReportDate(new \DateTimeImmutable('2026-03-02'))
+                ->build(),
+            '2026-03-03' => AdRawDocumentBuilder::aRawDocument()
+                ->withCompanyId(self::COMPANY_ID)
+                ->withMarketplace(MarketplaceType::OZON)
+                ->withReportDate(new \DateTimeImmutable('2026-03-03'))
+                ->build(),
+        ];
+
+        $jobRepo = $this->createMock(AdLoadJobRepository::class);
+        $jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $jobRepo->method('incrementLoadedDays')->willReturn(1);
+        // Ключевое отличие от testRetryOfOrchestrator... — несмотря на 0
+        // created + 3 updated, chunks_completed ДОЛЖЕН быть инкрементирован:
+        // ledger для этого jobId не содержит записи (первый fetch).
+        $jobRepo->expects(self::once())
+            ->method('incrementChunksCompleted')
+            ->with(AdLoadJobBuilder::DEFAULT_ID, self::COMPANY_ID)
+            ->willReturn(1);
+
+        $ozonClient = $this->createMock(OzonAdClient::class);
+        $ozonClient->method('fetchAdStatisticsRange')->willReturn([
+            '2026-03-01' => ['rows' => [['spend' => 1]]],
+            '2026-03-02' => ['rows' => [['spend' => 2]]],
+            '2026-03-03' => ['rows' => [['spend' => 3]]],
+        ]);
+
+        $rawRepo = $this->createMock(AdRawDocumentRepository::class);
+        $rawRepo->method('findByMarketplaceAndDate')
+            ->willReturnCallback(static function (string $c, string $m, \DateTimeImmutable $d) use ($existingByDate): ?AdRawDocument {
+                return $existingByDate[$d->format('Y-m-d')] ?? null;
+            });
+        $rawRepo->expects(self::never())->method('save');
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::once())->method('flush');
+
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::exactly(3))
+            ->method('dispatch')
+            ->willReturnCallback(static fn (object $m): Envelope => new Envelope($m));
+
+        $handler = $this->createHandler(
+            $ozonClient,
+            $rawRepo,
+            $jobRepo,
+            $em,
+            $messageBus,
+            $this->createChunkProgressRepoReturning(true), // первый fetch этого jobId
+        );
+        $handler(new FetchOzonAdStatisticsMessage(
+            AdLoadJobBuilder::DEFAULT_ID,
+            self::COMPANY_ID,
+            self::DATE_FROM,
+            self::DATE_TO,
+        ));
+    }
+
+    public function testLedgerTryMarkCompletedReceivesChunkRange(): void
+    {
+        // Контракт вызова ledger'а: handler обязан передать ТОЧНЫЕ jobId /
+        // companyId / dateFrom / dateTo из сообщения. Без этого UNIQUE-ключ
+        // (job_id, date_from, date_to) не сработает и идемпотентность
+        // рассыпется.
+        $job = AdLoadJobBuilder::aJob()
+            ->withDateRange(new \DateTimeImmutable(self::DATE_FROM), new \DateTimeImmutable(self::DATE_TO))
+            ->asRunning()
+            ->build();
+
+        $jobRepo = $this->createMock(AdLoadJobRepository::class);
+        $jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $jobRepo->method('incrementLoadedDays')->willReturn(1);
+        $jobRepo->method('incrementChunksCompleted')->willReturn(1);
+
+        $ozonClient = $this->createMock(OzonAdClient::class);
+        $ozonClient->method('fetchAdStatisticsRange')->willReturn([]);
+
+        $rawRepo = $this->createMock(AdRawDocumentRepository::class);
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('flush');
+        $messageBus = $this->createMock(MessageBusInterface::class);
+
+        $chunkProgressRepo = $this->createMock(AdChunkProgressRepositoryInterface::class);
+        $chunkProgressRepo->expects(self::once())
+            ->method('tryMarkCompleted')
+            ->with(
+                AdLoadJobBuilder::DEFAULT_ID,
+                self::COMPANY_ID,
+                self::callback(static fn (\DateTimeImmutable $d): bool => self::DATE_FROM === $d->format('Y-m-d')),
+                self::callback(static fn (\DateTimeImmutable $d): bool => self::DATE_TO === $d->format('Y-m-d')),
+            )
+            ->willReturn(true);
+
+        $handler = $this->createHandler(
+            $ozonClient,
+            $rawRepo,
+            $jobRepo,
+            $em,
+            $messageBus,
+            $chunkProgressRepo,
+        );
+        $handler(new FetchOzonAdStatisticsMessage(
+            AdLoadJobBuilder::DEFAULT_ID,
+            self::COMPANY_ID,
+            self::DATE_FROM,
+            self::DATE_TO,
+        ));
+    }
+
     private function createHandler(
         OzonAdClient $ozonClient,
         AdRawDocumentRepository $rawRepo,
         AdLoadJobRepository $jobRepo,
         EntityManagerInterface $em,
         MessageBusInterface $messageBus,
+        ?AdChunkProgressRepositoryInterface $chunkProgressRepo = null,
     ): FetchOzonAdStatisticsHandler {
         return new FetchOzonAdStatisticsHandler(
             $ozonClient,
             $rawRepo,
             $jobRepo,
+            $chunkProgressRepo ?? $this->createChunkProgressRepoReturning(true),
             $em,
             $messageBus,
             new AppLogger(new NullLogger(), $this->createMock(HubInterface::class)),
         );
+    }
+
+    /**
+     * Мок ledger-репозитория с фиксированным ответом.
+     *
+     * true  — «чанк учтён впервые», handler инкрементит chunks_completed;
+     * false — уже был учтён (любой retry), инкремент пропускается.
+     */
+    private function createChunkProgressRepoReturning(bool $isNew): AdChunkProgressRepositoryInterface
+    {
+        $mock = $this->createMock(AdChunkProgressRepositoryInterface::class);
+        $mock->method('tryMarkCompleted')->willReturn($isNew);
+
+        return $mock;
     }
 }

--- a/site/tests/Unit/MarketplaceAds/ProcessAdRawDocumentHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/ProcessAdRawDocumentHandlerTest.php
@@ -104,20 +104,25 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
 
     public function testFailedDocumentIncrementsJobFailedDaysAndRethrows(): void
     {
+        // Error-ветка: Throwable инкрементит failed_days, но финализацию
+        // tryFinalizeJob() не трогаем — Messenger сделает retry и возможный
+        // overshoot failed_days не должен преждевременно пометить job FAILED.
         $rawDoc = $this->newDraftDocument();
         $job = AdLoadJobBuilder::aJob()
             ->asRunning()
             ->withChunksTotal(5)
-            ->withChunksCompleted(1)
-            ->build();
+            ->withChunksCompleted(5)  // намеренно «закрыты все чанки» — если бы
+            ->withProcessed(9)        // финализация зашла в error-ветке, она бы
+            ->build();                // пометила job FAILED по overshoot'у.
 
         $rawRepo = $this->createMock(AdRawDocumentRepository::class);
-        // Only pre-read (до Action); после Throwable повторного pre/post read нет —
-        // Handler сразу идёт в incrementFailedAndTryFinalize по сохранённому marketplace/date.
+        // Only pre-read (до Action); после Throwable handler идёт прямо в
+        // incrementFailedOnly по сохранённому marketplace/date (без повторного read).
         $rawRepo->expects(self::once())
             ->method('findByIdAndCompany')
             ->with(self::RAW_DOC_ID, self::COMPANY_ID)
             ->willReturn($rawDoc);
+        $rawRepo->expects(self::never())->method('countByCompanyMarketplaceAndDateRange');
 
         $action = $this->createMock(ProcessAdRawDocumentAction::class);
         $action->method('__invoke')->willThrowException(new \RuntimeException('parser failure'));
@@ -131,9 +136,11 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
             ->with($job->getId(), self::COMPANY_ID)
             ->willReturn(1);
         $jobRepo->expects(self::never())->method('incrementProcessedDays');
-        $jobRepo->expects(self::once())->method('findFresh')->willReturn($job);
+        // КЛЮЧЕВОЕ: никаких find/findFresh и markCompleted/markFailed в error-ветке.
+        $jobRepo->expects(self::never())->method('findFresh');
+        $jobRepo->expects(self::never())->method('find');
         $jobRepo->expects(self::never())->method('markCompleted');
-        $jobRepo->expects(self::never())->method('markFailed'); // чанки ещё не все закрыты
+        $jobRepo->expects(self::never())->method('markFailed');
 
         $handler = $this->createHandler($rawRepo, $action, $jobRepo);
 

--- a/site/tests/Unit/MarketplaceAds/ProcessAdRawDocumentHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/ProcessAdRawDocumentHandlerTest.php
@@ -1,0 +1,437 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MarketplaceAds;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAds\Application\ProcessAdRawDocumentAction;
+use App\MarketplaceAds\Entity\AdLoadJob;
+use App\MarketplaceAds\Entity\AdRawDocument;
+use App\MarketplaceAds\Exception\AdRawDocumentAlreadyProcessedException;
+use App\MarketplaceAds\Message\ProcessAdRawDocumentMessage;
+use App\MarketplaceAds\MessageHandler\ProcessAdRawDocumentHandler;
+use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
+use App\MarketplaceAds\Repository\AdRawDocumentRepository;
+use App\Shared\Service\AppLogger;
+use App\Tests\Builders\MarketplaceAds\AdLoadJobBuilder;
+use App\Tests\Builders\MarketplaceAds\AdRawDocumentBuilder;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Sentry\State\HubInterface;
+
+/**
+ * Unit-тесты ProcessAdRawDocumentHandler.
+ *
+ * Что проверяем:
+ *  - инкремент AdLoadJob.processedDays на PROCESSED-ветке;
+ *  - инкремент AdLoadJob.failedDays на ветках Throwable и partial-DRAFT;
+ *  - no-op, если по дате документа нет активного job'а (CLI-команда вне job-flow);
+ *  - AdRawDocumentAlreadyProcessedException — race idempotency: НЕ инкрементим
+ *    (инкремент сделает воркер, который реально обработал документ);
+ *  - tryFinalizeJob условие: chunksCompleted>=chunksTotal AND
+ *    (processedDays+failedDays) >= COUNT(AdRawDocument в диапазоне);
+ *  - markCompleted при failedDays=0, markFailed с reason при failedDays>0;
+ *  - финализация идемпотентна: второй tryFinalizeJob на COMPLETED job'е не
+ *    вызывает markCompleted повторно.
+ */
+final class ProcessAdRawDocumentHandlerTest extends TestCase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-111111111111';
+    private const RAW_DOC_ID = '88888888-8888-8888-8888-888888888888';
+    private const REPORT_DATE = '2026-03-15';
+
+    public function testProcessedDocumentIncrementsJobProcessedDays(): void
+    {
+        $rawDoc = $this->newDraftDocument();
+        $job = AdLoadJobBuilder::aJob()
+            ->asRunning()
+            ->withChunksTotal(5)
+            ->withChunksCompleted(1) // чанки ещё не все закрыты — финализации не будет
+            ->build();
+
+        $rawRepo = $this->createMock(AdRawDocumentRepository::class);
+        $this->wireRawRepoPrePost($rawRepo, $rawDoc, $this->newProcessedDocument());
+
+        $action = $this->createMock(ProcessAdRawDocumentAction::class);
+        $action->expects(self::once())->method('__invoke')
+            ->with(self::COMPANY_ID, self::RAW_DOC_ID);
+
+        $jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $jobRepo->expects(self::once())
+            ->method('findActiveJobCoveringDate')
+            ->with(self::COMPANY_ID, MarketplaceType::OZON, self::callback(static fn (\DateTimeImmutable $d): bool => self::REPORT_DATE === $d->format('Y-m-d')))
+            ->willReturn($job);
+        $jobRepo->expects(self::once())
+            ->method('incrementProcessedDays')
+            ->with($job->getId(), self::COMPANY_ID)
+            ->willReturn(1);
+        $jobRepo->expects(self::never())->method('incrementFailedDays');
+        $jobRepo->expects(self::once())->method('find')->with($job->getId())->willReturn($job);
+        $jobRepo->expects(self::never())->method('markCompleted');
+        $jobRepo->expects(self::never())->method('markFailed');
+
+        $handler = $this->createHandler($rawRepo, $action, $jobRepo);
+        $handler($this->newMessage());
+    }
+
+    public function testNoActiveJobForDateSkipsIncrement(): void
+    {
+        // Документ обработался, но активного job'а, покрывающего его дату, нет
+        // (загружен CLI-командой вне orchestrator-flow). Основная ветка Action
+        // отработала — Handler не должен инкрементить и не должен упасть.
+        $rawDoc = $this->newDraftDocument();
+
+        $rawRepo = $this->createMock(AdRawDocumentRepository::class);
+        $this->wireRawRepoPrePost($rawRepo, $rawDoc, $this->newProcessedDocument());
+
+        $action = $this->createMock(ProcessAdRawDocumentAction::class);
+        $action->expects(self::once())->method('__invoke');
+
+        $jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $jobRepo->expects(self::once())
+            ->method('findActiveJobCoveringDate')
+            ->willReturn(null);
+        $jobRepo->expects(self::never())->method('incrementProcessedDays');
+        $jobRepo->expects(self::never())->method('incrementFailedDays');
+        $jobRepo->expects(self::never())->method('find');
+        $jobRepo->expects(self::never())->method('markCompleted');
+        $jobRepo->expects(self::never())->method('markFailed');
+
+        $handler = $this->createHandler($rawRepo, $action, $jobRepo);
+        $handler($this->newMessage());
+    }
+
+    public function testFailedDocumentIncrementsJobFailedDaysAndRethrows(): void
+    {
+        $rawDoc = $this->newDraftDocument();
+        $job = AdLoadJobBuilder::aJob()
+            ->asRunning()
+            ->withChunksTotal(5)
+            ->withChunksCompleted(1)
+            ->build();
+
+        $rawRepo = $this->createMock(AdRawDocumentRepository::class);
+        // Only pre-read (до Action); после Throwable повторного pre/post read нет —
+        // Handler сразу идёт в incrementFailedAndTryFinalize по сохранённому marketplace/date.
+        $rawRepo->expects(self::once())
+            ->method('findByIdAndCompany')
+            ->with(self::RAW_DOC_ID, self::COMPANY_ID)
+            ->willReturn($rawDoc);
+
+        $action = $this->createMock(ProcessAdRawDocumentAction::class);
+        $action->method('__invoke')->willThrowException(new \RuntimeException('parser failure'));
+
+        $jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $jobRepo->expects(self::once())
+            ->method('findActiveJobCoveringDate')
+            ->willReturn($job);
+        $jobRepo->expects(self::once())
+            ->method('incrementFailedDays')
+            ->with($job->getId(), self::COMPANY_ID)
+            ->willReturn(1);
+        $jobRepo->expects(self::never())->method('incrementProcessedDays');
+        $jobRepo->expects(self::once())->method('find')->willReturn($job);
+        $jobRepo->expects(self::never())->method('markCompleted');
+        $jobRepo->expects(self::never())->method('markFailed'); // чанки ещё не все закрыты
+
+        $handler = $this->createHandler($rawRepo, $action, $jobRepo);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('parser failure');
+        $handler($this->newMessage());
+    }
+
+    public function testPartialDraftAfterActionIncrementsFailedDays(): void
+    {
+        // Action не бросил исключение, но оставил документ в DRAFT (частичный
+        // успех в ProcessAdRawDocumentAction: markAsProcessed() вызывается только
+        // когда !hasErrors). С точки зрения job'а это failure — иначе условие
+        // финализации (processed + failed == COUNT(raw)) никогда не сойдётся.
+        $rawDoc = $this->newDraftDocument();
+        $stillDraftAfter = $this->newDraftDocument();
+        $job = AdLoadJobBuilder::aJob()
+            ->asRunning()
+            ->withChunksTotal(5)
+            ->withChunksCompleted(1)
+            ->build();
+
+        $rawRepo = $this->createMock(AdRawDocumentRepository::class);
+        $this->wireRawRepoPrePost($rawRepo, $rawDoc, $stillDraftAfter);
+
+        $action = $this->createMock(ProcessAdRawDocumentAction::class);
+        $action->expects(self::once())->method('__invoke');
+
+        $jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $jobRepo->expects(self::once())
+            ->method('findActiveJobCoveringDate')
+            ->willReturn($job);
+        $jobRepo->expects(self::once())
+            ->method('incrementFailedDays')
+            ->with($job->getId(), self::COMPANY_ID)
+            ->willReturn(1);
+        $jobRepo->expects(self::never())->method('incrementProcessedDays');
+        $jobRepo->expects(self::once())->method('find')->willReturn($job);
+
+        $handler = $this->createHandler($rawRepo, $action, $jobRepo);
+        $handler($this->newMessage());
+    }
+
+    public function testAlreadyProcessedExceptionDoesNotIncrementCounters(): void
+    {
+        // Специфическая гонка: между pre-check в handler'е и вызовом Action
+        // другой воркер успел обработать документ → Action бросает
+        // AdRawDocumentAlreadyProcessedException. Этот воркер НЕ инкрементит
+        // processed/failed — это сделает тот, кто реально обработал.
+        $rawDoc = $this->newDraftDocument();
+
+        $rawRepo = $this->createMock(AdRawDocumentRepository::class);
+        $rawRepo->expects(self::once())
+            ->method('findByIdAndCompany')
+            ->willReturn($rawDoc);
+
+        $action = $this->createMock(ProcessAdRawDocumentAction::class);
+        $action->method('__invoke')->willThrowException(new AdRawDocumentAlreadyProcessedException('already processed'));
+
+        $jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $jobRepo->expects(self::never())->method('findActiveJobCoveringDate');
+        $jobRepo->expects(self::never())->method('incrementProcessedDays');
+        $jobRepo->expects(self::never())->method('incrementFailedDays');
+        $jobRepo->expects(self::never())->method('find');
+        $jobRepo->expects(self::never())->method('markCompleted');
+        $jobRepo->expects(self::never())->method('markFailed');
+
+        $handler = $this->createHandler($rawRepo, $action, $jobRepo);
+        $handler($this->newMessage());
+    }
+
+    public function testJobFinalizedAsCompletedWhenAllConditionsMet(): void
+    {
+        $rawDoc = $this->newDraftDocument();
+        // После incrementProcessedDays → find() возвращает job в свежем состоянии:
+        // chunksCompleted == chunksTotal, processedDays=10, failedDays=0, COUNT(raw)=10.
+        $freshJob = AdLoadJobBuilder::aJob()
+            ->asRunning()
+            ->withChunksTotal(5)
+            ->withChunksCompleted(5)
+            ->withProcessed(10)
+            ->build();
+
+        $rawRepo = $this->createMock(AdRawDocumentRepository::class);
+        $this->wireRawRepoPrePost($rawRepo, $rawDoc, $this->newProcessedDocument());
+        $rawRepo->expects(self::once())
+            ->method('countByCompanyMarketplaceAndDateRange')
+            ->willReturn(10);
+
+        $action = $this->createMock(ProcessAdRawDocumentAction::class);
+        $action->expects(self::once())->method('__invoke');
+
+        $jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $jobRepo->method('findActiveJobCoveringDate')->willReturn($freshJob);
+        $jobRepo->expects(self::once())->method('incrementProcessedDays')->willReturn(1);
+        $jobRepo->method('find')->with($freshJob->getId())->willReturn($freshJob);
+        $jobRepo->expects(self::once())
+            ->method('markCompleted')
+            ->with($freshJob->getId(), self::COMPANY_ID)
+            ->willReturn(1);
+        $jobRepo->expects(self::never())->method('markFailed');
+
+        $handler = $this->createHandler($rawRepo, $action, $jobRepo);
+        $handler($this->newMessage());
+    }
+
+    public function testJobFinalizedAsFailedWhenHasFailures(): void
+    {
+        $rawDoc = $this->newDraftDocument();
+        $freshJob = AdLoadJobBuilder::aJob()
+            ->asRunning()
+            ->withChunksTotal(5)
+            ->withChunksCompleted(5)
+            ->withProcessed(8)
+            ->withFailed(2)
+            ->build();
+
+        $rawRepo = $this->createMock(AdRawDocumentRepository::class);
+        $this->wireRawRepoPrePost($rawRepo, $rawDoc, $this->newProcessedDocument());
+        $rawRepo->expects(self::once())
+            ->method('countByCompanyMarketplaceAndDateRange')
+            ->willReturn(10);
+
+        $action = $this->createMock(ProcessAdRawDocumentAction::class);
+        $action->expects(self::once())->method('__invoke');
+
+        $jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $jobRepo->method('findActiveJobCoveringDate')->willReturn($freshJob);
+        $jobRepo->expects(self::once())->method('incrementProcessedDays')->willReturn(1);
+        $jobRepo->method('find')->willReturn($freshJob);
+        $jobRepo->expects(self::never())->method('markCompleted');
+        $jobRepo->expects(self::once())
+            ->method('markFailed')
+            ->with(
+                $freshJob->getId(),
+                self::COMPANY_ID,
+                self::callback(static fn (string $reason): bool => str_contains($reason, '2/10') && str_contains($reason, 'Partial failure')),
+            )
+            ->willReturn(1);
+
+        $handler = $this->createHandler($rawRepo, $action, $jobRepo);
+        $handler($this->newMessage());
+    }
+
+    public function testJobNotFinalizedWhenChunksIncomplete(): void
+    {
+        $rawDoc = $this->newDraftDocument();
+        $job = AdLoadJobBuilder::aJob()
+            ->asRunning()
+            ->withChunksTotal(5)
+            ->withChunksCompleted(3) // не все чанки закрыты
+            ->withProcessed(10)
+            ->build();
+
+        $rawRepo = $this->createMock(AdRawDocumentRepository::class);
+        $this->wireRawRepoPrePost($rawRepo, $rawDoc, $this->newProcessedDocument());
+        // Если chunks incomplete — COUNT не запрашиваем (ранний return).
+        $rawRepo->expects(self::never())->method('countByCompanyMarketplaceAndDateRange');
+
+        $action = $this->createMock(ProcessAdRawDocumentAction::class);
+        $action->expects(self::once())->method('__invoke');
+
+        $jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $jobRepo->method('findActiveJobCoveringDate')->willReturn($job);
+        $jobRepo->expects(self::once())->method('incrementProcessedDays')->willReturn(1);
+        $jobRepo->method('find')->willReturn($job);
+        $jobRepo->expects(self::never())->method('markCompleted');
+        $jobRepo->expects(self::never())->method('markFailed');
+
+        $handler = $this->createHandler($rawRepo, $action, $jobRepo);
+        $handler($this->newMessage());
+    }
+
+    public function testJobNotFinalizedWhenDocumentsIncomplete(): void
+    {
+        $rawDoc = $this->newDraftDocument();
+        // chunks done, но processedDays=8, failedDays=0, COUNT(raw)=10 → ещё не
+        // все документы дошли до PROCESSED (или failed).
+        $job = AdLoadJobBuilder::aJob()
+            ->asRunning()
+            ->withChunksTotal(5)
+            ->withChunksCompleted(5)
+            ->withProcessed(8)
+            ->build();
+
+        $rawRepo = $this->createMock(AdRawDocumentRepository::class);
+        $this->wireRawRepoPrePost($rawRepo, $rawDoc, $this->newProcessedDocument());
+        $rawRepo->expects(self::once())
+            ->method('countByCompanyMarketplaceAndDateRange')
+            ->willReturn(10);
+
+        $action = $this->createMock(ProcessAdRawDocumentAction::class);
+        $action->expects(self::once())->method('__invoke');
+
+        $jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $jobRepo->method('findActiveJobCoveringDate')->willReturn($job);
+        $jobRepo->expects(self::once())->method('incrementProcessedDays')->willReturn(1);
+        $jobRepo->method('find')->willReturn($job);
+        $jobRepo->expects(self::never())->method('markCompleted');
+        $jobRepo->expects(self::never())->method('markFailed');
+
+        $handler = $this->createHandler($rawRepo, $action, $jobRepo);
+        $handler($this->newMessage());
+    }
+
+    public function testFinalizationRaceDoesNotDoubleMark(): void
+    {
+        // Два воркера обрабатывают два последних документа параллельно. Оба
+        // доходят до tryFinalizeJob. Второй увидит job уже в COMPLETED (т.к.
+        // markCompleted первого voркера прошёл и внутри SQL-guard'а второй
+        // UPDATE затронет 0 строк — но до этого мы даже не дойдём, т.к. guard
+        // на статус в начале tryFinalizeJob вернёт рано).
+        $rawDoc = $this->newDraftDocument();
+
+        $runningJob = AdLoadJobBuilder::aJob()
+            ->asRunning()
+            ->withChunksTotal(5)
+            ->withChunksCompleted(5)
+            ->withProcessed(10)
+            ->build();
+        $completedJob = AdLoadJobBuilder::aJob()
+            ->asCompleted()
+            ->withChunksTotal(5)
+            ->withChunksCompleted(5)
+            ->withProcessed(10)
+            ->build();
+
+        $rawRepo = $this->createMock(AdRawDocumentRepository::class);
+        $this->wireRawRepoPrePost($rawRepo, $rawDoc, $this->newProcessedDocument());
+        // countByRange зовётся при первом tryFinalize (status=RUNNING), при
+        // втором (status=COMPLETED) происходит ранний return до COUNT — но мы
+        // тестируем в одном __invoke один воркер, проверяем что find() возвращает
+        // COMPLETED job и markCompleted НЕ зовётся повторно.
+        $rawRepo->expects(self::never())->method('countByCompanyMarketplaceAndDateRange');
+
+        $action = $this->createMock(ProcessAdRawDocumentAction::class);
+        $action->expects(self::once())->method('__invoke');
+
+        $jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $jobRepo->method('findActiveJobCoveringDate')->willReturn($runningJob);
+        $jobRepo->expects(self::once())->method('incrementProcessedDays')->willReturn(1);
+        // Сценарий: пока мы инкрементили, другой воркер уже финализировал job'а.
+        // find() возвращает уже COMPLETED job, tryFinalizeJob делает early return.
+        $jobRepo->method('find')->willReturn($completedJob);
+        $jobRepo->expects(self::never())->method('markCompleted');
+        $jobRepo->expects(self::never())->method('markFailed');
+
+        $handler = $this->createHandler($rawRepo, $action, $jobRepo);
+        $handler($this->newMessage());
+    }
+
+    private function newDraftDocument(): AdRawDocument
+    {
+        return AdRawDocumentBuilder::aRawDocument()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withReportDate(new \DateTimeImmutable(self::REPORT_DATE))
+            ->build();
+    }
+
+    private function newProcessedDocument(): AdRawDocument
+    {
+        return AdRawDocumentBuilder::aRawDocument()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withReportDate(new \DateTimeImmutable(self::REPORT_DATE))
+            ->asProcessed()
+            ->build();
+    }
+
+    private function newMessage(): ProcessAdRawDocumentMessage
+    {
+        return new ProcessAdRawDocumentMessage(self::COMPANY_ID, self::RAW_DOC_ID);
+    }
+
+    private function wireRawRepoPrePost(
+        \PHPUnit\Framework\MockObject\MockObject $rawRepo,
+        AdRawDocument $pre,
+        AdRawDocument $post,
+    ): void {
+        // Handler зовёт findByIdAndCompany дважды на happy/partial-path: перед
+        // Action'ом (для pre-check DRAFT) и после (для проверки PROCESSED/DRAFT).
+        $rawRepo->expects(self::exactly(2))
+            ->method('findByIdAndCompany')
+            ->with(self::RAW_DOC_ID, self::COMPANY_ID)
+            ->willReturnOnConsecutiveCalls($pre, $post);
+    }
+
+    private function createHandler(
+        AdRawDocumentRepository $rawRepo,
+        ProcessAdRawDocumentAction $action,
+        AdLoadJobRepositoryInterface $jobRepo,
+    ): ProcessAdRawDocumentHandler {
+        return new ProcessAdRawDocumentHandler(
+            $rawRepo,
+            $action,
+            $jobRepo,
+            new AppLogger(new NullLogger(), $this->createMock(HubInterface::class)),
+        );
+    }
+}

--- a/site/tests/Unit/MarketplaceAds/ProcessAdRawDocumentHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/ProcessAdRawDocumentHandlerTest.php
@@ -6,7 +6,6 @@ namespace App\Tests\Unit\MarketplaceAds;
 
 use App\Marketplace\Enum\MarketplaceType;
 use App\MarketplaceAds\Application\ProcessAdRawDocumentAction;
-use App\MarketplaceAds\Entity\AdLoadJob;
 use App\MarketplaceAds\Entity\AdRawDocument;
 use App\MarketplaceAds\Exception\AdRawDocumentAlreadyProcessedException;
 use App\MarketplaceAds\Message\ProcessAdRawDocumentMessage;
@@ -23,17 +22,17 @@ use Sentry\State\HubInterface;
 /**
  * Unit-тесты ProcessAdRawDocumentHandler.
  *
- * Что проверяем:
- *  - инкремент AdLoadJob.processedDays на PROCESSED-ветке;
- *  - инкремент AdLoadJob.failedDays на ветках Throwable и partial-DRAFT;
- *  - no-op, если по дате документа нет активного job'а (CLI-команда вне job-flow);
- *  - AdRawDocumentAlreadyProcessedException — race idempotency: НЕ инкрементим
- *    (инкремент сделает воркер, который реально обработал документ);
- *  - tryFinalizeJob условие: chunksCompleted>=chunksTotal AND
- *    (processedDays+failedDays) >= COUNT(AdRawDocument в диапазоне);
- *  - markCompleted при failedDays=0, markFailed с reason при failedDays>0;
- *  - финализация идемпотентна: второй tryFinalizeJob на COMPLETED job'е не
- *    вызывает markCompleted повторно.
+ * Инварианты после перехода на per-document FAILED-статус:
+ *  - PROCESSED после Action → сразу tryFinalizeJob по дате документа.
+ *  - Throwable → markFailedWithReason (атомарный SQL) + tryFinalizeJob + rethrow.
+ *  - DRAFT после Action (partial success) → markFailedWithReason + tryFinalizeJob,
+ *    БЕЗ throw (Action транзакцию не откатил, повторять нечего).
+ *  - AdRawDocumentAlreadyProcessedException (гонка воркеров) → silent return,
+ *    без mark и без финализации: документ уже терминален, job финализирует
+ *    другой воркер или retry.
+ *  - Нет активного job'а по дате → ни mark, ни финализации не происходит.
+ *  - Финализация: chunks completed AND total == processed + failed;
+ *    failed == 0 → markCompleted, else markFailed(reason).
  */
 final class ProcessAdRawDocumentHandlerTest extends TestCase
 {
@@ -41,17 +40,20 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
     private const RAW_DOC_ID = '88888888-8888-8888-8888-888888888888';
     private const REPORT_DATE = '2026-03-15';
 
-    public function testProcessedDocumentIncrementsJobProcessedDays(): void
+    public function testProcessedDocumentTriggersFinalizationAttemptWithoutIncrement(): void
     {
         $rawDoc = $this->newDraftDocument();
         $job = AdLoadJobBuilder::aJob()
             ->asRunning()
             ->withChunksTotal(5)
-            ->withChunksCompleted(1) // чанки ещё не все закрыты — финализации не будет
+            ->withChunksCompleted(1) // ещё не все чанки — финализация выйдет рано
             ->build();
 
         $rawRepo = $this->createMock(AdRawDocumentRepository::class);
         $this->wireRawRepoPrePost($rawRepo, $rawDoc, $this->newProcessedDocument());
+        $rawRepo->expects(self::never())->method('markFailedWithReason');
+        $rawRepo->expects(self::never())->method('countByCompanyMarketplaceAndDateRange');
+        $rawRepo->expects(self::never())->method('countTerminalByCompanyMarketplaceAndDateRange');
 
         $action = $this->createMock(ProcessAdRawDocumentAction::class);
         $action->expects(self::once())->method('__invoke')
@@ -60,13 +62,12 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
         $jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
         $jobRepo->expects(self::once())
             ->method('findActiveJobCoveringDate')
-            ->with(self::COMPANY_ID, MarketplaceType::OZON, self::callback(static fn (\DateTimeImmutable $d): bool => self::REPORT_DATE === $d->format('Y-m-d')))
+            ->with(
+                self::COMPANY_ID,
+                MarketplaceType::OZON,
+                self::callback(static fn (\DateTimeImmutable $d): bool => self::REPORT_DATE === $d->format('Y-m-d')),
+            )
             ->willReturn($job);
-        $jobRepo->expects(self::once())
-            ->method('incrementProcessedDays')
-            ->with($job->getId(), self::COMPANY_ID)
-            ->willReturn(1);
-        $jobRepo->expects(self::never())->method('incrementFailedDays');
         $jobRepo->expects(self::once())->method('findFresh')->with($job->getId())->willReturn($job);
         $jobRepo->expects(self::never())->method('markCompleted');
         $jobRepo->expects(self::never())->method('markFailed');
@@ -75,15 +76,18 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
         $handler($this->newMessage());
     }
 
-    public function testNoActiveJobForDateSkipsIncrement(): void
+    public function testNoActiveJobForDateSkipsFinalization(): void
     {
         // Документ обработался, но активного job'а, покрывающего его дату, нет
-        // (загружен CLI-командой вне orchestrator-flow). Основная ветка Action
-        // отработала — Handler не должен инкрементить и не должен упасть.
+        // (загружен CLI-командой вне orchestrator-flow). Handler не должен
+        // падать и не должен пытаться финализировать / mark'ать.
         $rawDoc = $this->newDraftDocument();
 
         $rawRepo = $this->createMock(AdRawDocumentRepository::class);
         $this->wireRawRepoPrePost($rawRepo, $rawDoc, $this->newProcessedDocument());
+        $rawRepo->expects(self::never())->method('markFailedWithReason');
+        $rawRepo->expects(self::never())->method('countByCompanyMarketplaceAndDateRange');
+        $rawRepo->expects(self::never())->method('countTerminalByCompanyMarketplaceAndDateRange');
 
         $action = $this->createMock(ProcessAdRawDocumentAction::class);
         $action->expects(self::once())->method('__invoke');
@@ -92,8 +96,6 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
         $jobRepo->expects(self::once())
             ->method('findActiveJobCoveringDate')
             ->willReturn(null);
-        $jobRepo->expects(self::never())->method('incrementProcessedDays');
-        $jobRepo->expects(self::never())->method('incrementFailedDays');
         $jobRepo->expects(self::never())->method('findFresh');
         $jobRepo->expects(self::never())->method('markCompleted');
         $jobRepo->expects(self::never())->method('markFailed');
@@ -102,45 +104,57 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
         $handler($this->newMessage());
     }
 
-    public function testFailedDocumentIncrementsJobFailedDaysAndRethrows(): void
+    public function testExceptionMarksDocumentFailedFinalizesAndRethrows(): void
     {
-        // Error-ветка: Throwable инкрементит failed_days, но финализацию
-        // tryFinalizeJob() не трогаем — Messenger сделает retry и возможный
-        // overshoot failed_days не должен преждевременно пометить job FAILED.
+        // Error-ветка: Action бросил исключение. Handler должен
+        //  1) атомарно пометить документ FAILED с причиной,
+        //  2) триггерить финализацию (markFailed возможен, если это был
+        //     последний документ и все chunks закрыты),
+        //  3) rethrow'нуть исключение для Messenger retry / failed-queue.
         $rawDoc = $this->newDraftDocument();
-        $job = AdLoadJobBuilder::aJob()
+        $freshJob = AdLoadJobBuilder::aJob()
             ->asRunning()
             ->withChunksTotal(5)
-            ->withChunksCompleted(5)  // намеренно «закрыты все чанки» — если бы
-            ->withProcessed(9)        // финализация зашла в error-ветке, она бы
-            ->build();                // пометила job FAILED по overshoot'у.
+            ->withChunksCompleted(5) // все chunks закрыты — это последний документ
+            ->build();
 
         $rawRepo = $this->createMock(AdRawDocumentRepository::class);
-        // Only pre-read (до Action); после Throwable handler идёт прямо в
-        // incrementFailedOnly по сохранённому marketplace/date (без повторного read).
+        // Pre-read в handler'е (до Action); после Throwable повторного read нет.
         $rawRepo->expects(self::once())
             ->method('findByIdAndCompany')
             ->with(self::RAW_DOC_ID, self::COMPANY_ID)
             ->willReturn($rawDoc);
-        $rawRepo->expects(self::never())->method('countByCompanyMarketplaceAndDateRange');
+        $rawRepo->expects(self::once())
+            ->method('markFailedWithReason')
+            ->with(
+                self::RAW_DOC_ID,
+                self::COMPANY_ID,
+                self::callback(static fn (string $r): bool => str_contains($r, 'parser failure')),
+            )
+            ->willReturn(1);
+        $rawRepo->expects(self::once())
+            ->method('countByCompanyMarketplaceAndDateRange')
+            ->willReturn(10);
+        $rawRepo->expects(self::once())
+            ->method('countTerminalByCompanyMarketplaceAndDateRange')
+            ->willReturn(['processed' => 9, 'failed' => 1]);
 
         $action = $this->createMock(ProcessAdRawDocumentAction::class);
         $action->method('__invoke')->willThrowException(new \RuntimeException('parser failure'));
 
         $jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
-        $jobRepo->expects(self::once())
-            ->method('findActiveJobCoveringDate')
-            ->willReturn($job);
-        $jobRepo->expects(self::once())
-            ->method('incrementFailedDays')
-            ->with($job->getId(), self::COMPANY_ID)
-            ->willReturn(1);
-        $jobRepo->expects(self::never())->method('incrementProcessedDays');
-        // КЛЮЧЕВОЕ: никаких find/findFresh и markCompleted/markFailed в error-ветке.
-        $jobRepo->expects(self::never())->method('findFresh');
-        $jobRepo->expects(self::never())->method('find');
+        $jobRepo->expects(self::once())->method('findActiveJobCoveringDate')->willReturn($freshJob);
+        $jobRepo->expects(self::once())->method('findFresh')->willReturn($freshJob);
+        // Есть failed документ → markFailed (partial failure), НЕ markCompleted.
         $jobRepo->expects(self::never())->method('markCompleted');
-        $jobRepo->expects(self::never())->method('markFailed');
+        $jobRepo->expects(self::once())
+            ->method('markFailed')
+            ->with(
+                $freshJob->getId(),
+                self::COMPANY_ID,
+                self::callback(static fn (string $r): bool => str_contains($r, '1/10') && str_contains($r, 'Partial failure')),
+            )
+            ->willReturn(1);
 
         $handler = $this->createHandler($rawRepo, $action, $jobRepo);
 
@@ -149,12 +163,12 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
         $handler($this->newMessage());
     }
 
-    public function testPartialDraftAfterActionIncrementsFailedDays(): void
+    public function testPartialDraftAfterActionMarksDocumentFailedAndReturnsSilently(): void
     {
         // Action не бросил исключение, но оставил документ в DRAFT (частичный
-        // успех в ProcessAdRawDocumentAction: markAsProcessed() вызывается только
-        // когда !hasErrors). С точки зрения job'а это failure — иначе условие
-        // финализации (processed + failed == COUNT(raw)) никогда не сойдётся.
+        // успех в ProcessAdRawDocumentAction: markAsProcessed вызывается только
+        // когда !hasErrors). Handler помечает документ FAILED и идёт на
+        // финализацию, но НЕ throw'ит — Action транзакцию уже закоммитил.
         $rawDoc = $this->newDraftDocument();
         $stillDraftAfter = $this->newDraftDocument();
         $job = AdLoadJobBuilder::aJob()
@@ -165,45 +179,51 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
 
         $rawRepo = $this->createMock(AdRawDocumentRepository::class);
         $this->wireRawRepoPrePost($rawRepo, $rawDoc, $stillDraftAfter);
+        $rawRepo->expects(self::once())
+            ->method('markFailedWithReason')
+            ->with(
+                self::RAW_DOC_ID,
+                self::COMPANY_ID,
+                self::callback(static fn (string $r): bool => str_contains($r, 'Partial processing')),
+            )
+            ->willReturn(1);
 
         $action = $this->createMock(ProcessAdRawDocumentAction::class);
         $action->expects(self::once())->method('__invoke');
 
         $jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
-        $jobRepo->expects(self::once())
-            ->method('findActiveJobCoveringDate')
-            ->willReturn($job);
-        $jobRepo->expects(self::once())
-            ->method('incrementFailedDays')
-            ->with($job->getId(), self::COMPANY_ID)
-            ->willReturn(1);
-        $jobRepo->expects(self::never())->method('incrementProcessedDays');
+        $jobRepo->expects(self::once())->method('findActiveJobCoveringDate')->willReturn($job);
         $jobRepo->expects(self::once())->method('findFresh')->willReturn($job);
+        $jobRepo->expects(self::never())->method('markCompleted');
+        $jobRepo->expects(self::never())->method('markFailed');
 
         $handler = $this->createHandler($rawRepo, $action, $jobRepo);
+        // НЕ ожидаем throw — partial success в Action не бросает.
         $handler($this->newMessage());
     }
 
-    public function testAlreadyProcessedExceptionDoesNotIncrementCounters(): void
+    public function testAlreadyProcessedExceptionDoesNotMarkOrFinalize(): void
     {
         // Специфическая гонка: между pre-check в handler'е и вызовом Action
-        // другой воркер успел обработать документ → Action бросает
-        // AdRawDocumentAlreadyProcessedException. Этот воркер НЕ инкрементит
-        // processed/failed — это сделает тот, кто реально обработал.
+        // другой воркер успел обработать/завалить документ → Action бросает
+        // AdRawDocumentAlreadyProcessedException. Этот воркер НЕ должен
+        // переписывать markFailed — статус уже терминален — и не должен
+        // финализировать: другой воркер уже это сделал.
         $rawDoc = $this->newDraftDocument();
 
         $rawRepo = $this->createMock(AdRawDocumentRepository::class);
         $rawRepo->expects(self::once())
             ->method('findByIdAndCompany')
             ->willReturn($rawDoc);
+        $rawRepo->expects(self::never())->method('markFailedWithReason');
+        $rawRepo->expects(self::never())->method('countByCompanyMarketplaceAndDateRange');
+        $rawRepo->expects(self::never())->method('countTerminalByCompanyMarketplaceAndDateRange');
 
         $action = $this->createMock(ProcessAdRawDocumentAction::class);
-        $action->method('__invoke')->willThrowException(new AdRawDocumentAlreadyProcessedException('already processed'));
+        $action->method('__invoke')->willThrowException(new AdRawDocumentAlreadyProcessedException('already terminal'));
 
         $jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
         $jobRepo->expects(self::never())->method('findActiveJobCoveringDate');
-        $jobRepo->expects(self::never())->method('incrementProcessedDays');
-        $jobRepo->expects(self::never())->method('incrementFailedDays');
         $jobRepo->expects(self::never())->method('findFresh');
         $jobRepo->expects(self::never())->method('markCompleted');
         $jobRepo->expects(self::never())->method('markFailed');
@@ -212,16 +232,42 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
         $handler($this->newMessage());
     }
 
-    public function testJobFinalizedAsCompletedWhenAllConditionsMet(): void
+    public function testRetryAfterTerminalStatusIsIdempotent(): void
+    {
+        // Handler pre-check: документ уже в PROCESSED/FAILED → silent return.
+        // Эмулируем retry Messenger'а после предыдущей неудачной обработки,
+        // когда markFailedWithReason уже перевёл статус в FAILED.
+        $failedDoc = AdRawDocumentBuilder::aRawDocument()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withReportDate(new \DateTimeImmutable(self::REPORT_DATE))
+            ->asFailed('previous attempt')
+            ->build();
+
+        $rawRepo = $this->createMock(AdRawDocumentRepository::class);
+        $rawRepo->expects(self::once())
+            ->method('findByIdAndCompany')
+            ->willReturn($failedDoc);
+        $rawRepo->expects(self::never())->method('markFailedWithReason');
+
+        $action = $this->createMock(ProcessAdRawDocumentAction::class);
+        $action->expects(self::never())->method('__invoke');
+
+        $jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $jobRepo->expects(self::never())->method('findActiveJobCoveringDate');
+        $jobRepo->expects(self::never())->method('findFresh');
+
+        $handler = $this->createHandler($rawRepo, $action, $jobRepo);
+        $handler($this->newMessage());
+    }
+
+    public function testJobFinalizedAsCompletedWhenAllTerminalWithoutFailures(): void
     {
         $rawDoc = $this->newDraftDocument();
-        // После incrementProcessedDays → find() возвращает job в свежем состоянии:
-        // chunksCompleted == chunksTotal, processedDays=10, failedDays=0, COUNT(raw)=10.
         $freshJob = AdLoadJobBuilder::aJob()
             ->asRunning()
             ->withChunksTotal(5)
             ->withChunksCompleted(5)
-            ->withProcessed(10)
             ->build();
 
         $rawRepo = $this->createMock(AdRawDocumentRepository::class);
@@ -229,13 +275,15 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
         $rawRepo->expects(self::once())
             ->method('countByCompanyMarketplaceAndDateRange')
             ->willReturn(10);
+        $rawRepo->expects(self::once())
+            ->method('countTerminalByCompanyMarketplaceAndDateRange')
+            ->willReturn(['processed' => 10, 'failed' => 0]);
 
         $action = $this->createMock(ProcessAdRawDocumentAction::class);
         $action->expects(self::once())->method('__invoke');
 
         $jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
         $jobRepo->method('findActiveJobCoveringDate')->willReturn($freshJob);
-        $jobRepo->expects(self::once())->method('incrementProcessedDays')->willReturn(1);
         $jobRepo->method('findFresh')->with($freshJob->getId())->willReturn($freshJob);
         $jobRepo->expects(self::once())
             ->method('markCompleted')
@@ -254,8 +302,6 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
             ->asRunning()
             ->withChunksTotal(5)
             ->withChunksCompleted(5)
-            ->withProcessed(8)
-            ->withFailed(2)
             ->build();
 
         $rawRepo = $this->createMock(AdRawDocumentRepository::class);
@@ -263,13 +309,15 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
         $rawRepo->expects(self::once())
             ->method('countByCompanyMarketplaceAndDateRange')
             ->willReturn(10);
+        $rawRepo->expects(self::once())
+            ->method('countTerminalByCompanyMarketplaceAndDateRange')
+            ->willReturn(['processed' => 8, 'failed' => 2]);
 
         $action = $this->createMock(ProcessAdRawDocumentAction::class);
         $action->expects(self::once())->method('__invoke');
 
         $jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
         $jobRepo->method('findActiveJobCoveringDate')->willReturn($freshJob);
-        $jobRepo->expects(self::once())->method('incrementProcessedDays')->willReturn(1);
         $jobRepo->method('findFresh')->willReturn($freshJob);
         $jobRepo->expects(self::never())->method('markCompleted');
         $jobRepo->expects(self::once())
@@ -292,20 +340,19 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
             ->asRunning()
             ->withChunksTotal(5)
             ->withChunksCompleted(3) // не все чанки закрыты
-            ->withProcessed(10)
             ->build();
 
         $rawRepo = $this->createMock(AdRawDocumentRepository::class);
         $this->wireRawRepoPrePost($rawRepo, $rawDoc, $this->newProcessedDocument());
-        // Если chunks incomplete — COUNT не запрашиваем (ранний return).
+        // COUNT и terminal-COUNT не запрашиваем — ранний return по chunks guard'у.
         $rawRepo->expects(self::never())->method('countByCompanyMarketplaceAndDateRange');
+        $rawRepo->expects(self::never())->method('countTerminalByCompanyMarketplaceAndDateRange');
 
         $action = $this->createMock(ProcessAdRawDocumentAction::class);
         $action->expects(self::once())->method('__invoke');
 
         $jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
         $jobRepo->method('findActiveJobCoveringDate')->willReturn($job);
-        $jobRepo->expects(self::once())->method('incrementProcessedDays')->willReturn(1);
         $jobRepo->method('findFresh')->willReturn($job);
         $jobRepo->expects(self::never())->method('markCompleted');
         $jobRepo->expects(self::never())->method('markFailed');
@@ -317,13 +364,12 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
     public function testJobNotFinalizedWhenDocumentsIncomplete(): void
     {
         $rawDoc = $this->newDraftDocument();
-        // chunks done, но processedDays=8, failedDays=0, COUNT(raw)=10 → ещё не
-        // все документы дошли до PROCESSED (или failed).
+        // chunks done, processed+failed=9 < total=10 → ещё не все документы
+        // дошли до терминального состояния.
         $job = AdLoadJobBuilder::aJob()
             ->asRunning()
             ->withChunksTotal(5)
             ->withChunksCompleted(5)
-            ->withProcessed(8)
             ->build();
 
         $rawRepo = $this->createMock(AdRawDocumentRepository::class);
@@ -331,13 +377,15 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
         $rawRepo->expects(self::once())
             ->method('countByCompanyMarketplaceAndDateRange')
             ->willReturn(10);
+        $rawRepo->expects(self::once())
+            ->method('countTerminalByCompanyMarketplaceAndDateRange')
+            ->willReturn(['processed' => 8, 'failed' => 1]); // 9 < 10
 
         $action = $this->createMock(ProcessAdRawDocumentAction::class);
         $action->expects(self::once())->method('__invoke');
 
         $jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
         $jobRepo->method('findActiveJobCoveringDate')->willReturn($job);
-        $jobRepo->expects(self::once())->method('incrementProcessedDays')->willReturn(1);
         $jobRepo->method('findFresh')->willReturn($job);
         $jobRepo->expects(self::never())->method('markCompleted');
         $jobRepo->expects(self::never())->method('markFailed');
@@ -349,41 +397,32 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
     public function testFinalizationRaceDoesNotDoubleMark(): void
     {
         // Два воркера обрабатывают два последних документа параллельно. Оба
-        // доходят до tryFinalizeJob. Второй увидит job уже в COMPLETED (т.к.
-        // markCompleted первого voркера прошёл и внутри SQL-guard'а второй
-        // UPDATE затронет 0 строк — но до этого мы даже не дойдём, т.к. guard
-        // на статус в начале tryFinalizeJob вернёт рано).
+        // доходят до tryFinalizeJob. findFresh второго уже возвращает COMPLETED
+        // job — ранний return по status guard'у, markCompleted не зовётся.
         $rawDoc = $this->newDraftDocument();
 
         $runningJob = AdLoadJobBuilder::aJob()
             ->asRunning()
             ->withChunksTotal(5)
             ->withChunksCompleted(5)
-            ->withProcessed(10)
             ->build();
         $completedJob = AdLoadJobBuilder::aJob()
             ->asCompleted()
             ->withChunksTotal(5)
             ->withChunksCompleted(5)
-            ->withProcessed(10)
             ->build();
 
         $rawRepo = $this->createMock(AdRawDocumentRepository::class);
         $this->wireRawRepoPrePost($rawRepo, $rawDoc, $this->newProcessedDocument());
-        // countByRange зовётся при первом tryFinalize (status=RUNNING), при
-        // втором (status=COMPLETED) происходит ранний return до COUNT — но мы
-        // тестируем в одном __invoke один воркер, проверяем что find() возвращает
-        // COMPLETED job и markCompleted НЕ зовётся повторно.
+        // При COMPLETED-статусе ранний return → COUNT не запрашивается.
         $rawRepo->expects(self::never())->method('countByCompanyMarketplaceAndDateRange');
+        $rawRepo->expects(self::never())->method('countTerminalByCompanyMarketplaceAndDateRange');
 
         $action = $this->createMock(ProcessAdRawDocumentAction::class);
         $action->expects(self::once())->method('__invoke');
 
         $jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
         $jobRepo->method('findActiveJobCoveringDate')->willReturn($runningJob);
-        $jobRepo->expects(self::once())->method('incrementProcessedDays')->willReturn(1);
-        // Сценарий: пока мы инкрементили, другой воркер уже финализировал job'а.
-        // find() возвращает уже COMPLETED job, tryFinalizeJob делает early return.
         $jobRepo->method('findFresh')->willReturn($completedJob);
         $jobRepo->expects(self::never())->method('markCompleted');
         $jobRepo->expects(self::never())->method('markFailed');

--- a/site/tests/Unit/MarketplaceAds/ProcessAdRawDocumentHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/ProcessAdRawDocumentHandlerTest.php
@@ -67,7 +67,7 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
             ->with($job->getId(), self::COMPANY_ID)
             ->willReturn(1);
         $jobRepo->expects(self::never())->method('incrementFailedDays');
-        $jobRepo->expects(self::once())->method('find')->with($job->getId())->willReturn($job);
+        $jobRepo->expects(self::once())->method('findFresh')->with($job->getId())->willReturn($job);
         $jobRepo->expects(self::never())->method('markCompleted');
         $jobRepo->expects(self::never())->method('markFailed');
 
@@ -94,7 +94,7 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
             ->willReturn(null);
         $jobRepo->expects(self::never())->method('incrementProcessedDays');
         $jobRepo->expects(self::never())->method('incrementFailedDays');
-        $jobRepo->expects(self::never())->method('find');
+        $jobRepo->expects(self::never())->method('findFresh');
         $jobRepo->expects(self::never())->method('markCompleted');
         $jobRepo->expects(self::never())->method('markFailed');
 
@@ -131,7 +131,7 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
             ->with($job->getId(), self::COMPANY_ID)
             ->willReturn(1);
         $jobRepo->expects(self::never())->method('incrementProcessedDays');
-        $jobRepo->expects(self::once())->method('find')->willReturn($job);
+        $jobRepo->expects(self::once())->method('findFresh')->willReturn($job);
         $jobRepo->expects(self::never())->method('markCompleted');
         $jobRepo->expects(self::never())->method('markFailed'); // чанки ещё не все закрыты
 
@@ -171,7 +171,7 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
             ->with($job->getId(), self::COMPANY_ID)
             ->willReturn(1);
         $jobRepo->expects(self::never())->method('incrementProcessedDays');
-        $jobRepo->expects(self::once())->method('find')->willReturn($job);
+        $jobRepo->expects(self::once())->method('findFresh')->willReturn($job);
 
         $handler = $this->createHandler($rawRepo, $action, $jobRepo);
         $handler($this->newMessage());
@@ -197,7 +197,7 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
         $jobRepo->expects(self::never())->method('findActiveJobCoveringDate');
         $jobRepo->expects(self::never())->method('incrementProcessedDays');
         $jobRepo->expects(self::never())->method('incrementFailedDays');
-        $jobRepo->expects(self::never())->method('find');
+        $jobRepo->expects(self::never())->method('findFresh');
         $jobRepo->expects(self::never())->method('markCompleted');
         $jobRepo->expects(self::never())->method('markFailed');
 
@@ -229,7 +229,7 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
         $jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
         $jobRepo->method('findActiveJobCoveringDate')->willReturn($freshJob);
         $jobRepo->expects(self::once())->method('incrementProcessedDays')->willReturn(1);
-        $jobRepo->method('find')->with($freshJob->getId())->willReturn($freshJob);
+        $jobRepo->method('findFresh')->with($freshJob->getId())->willReturn($freshJob);
         $jobRepo->expects(self::once())
             ->method('markCompleted')
             ->with($freshJob->getId(), self::COMPANY_ID)
@@ -263,7 +263,7 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
         $jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
         $jobRepo->method('findActiveJobCoveringDate')->willReturn($freshJob);
         $jobRepo->expects(self::once())->method('incrementProcessedDays')->willReturn(1);
-        $jobRepo->method('find')->willReturn($freshJob);
+        $jobRepo->method('findFresh')->willReturn($freshJob);
         $jobRepo->expects(self::never())->method('markCompleted');
         $jobRepo->expects(self::once())
             ->method('markFailed')
@@ -299,7 +299,7 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
         $jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
         $jobRepo->method('findActiveJobCoveringDate')->willReturn($job);
         $jobRepo->expects(self::once())->method('incrementProcessedDays')->willReturn(1);
-        $jobRepo->method('find')->willReturn($job);
+        $jobRepo->method('findFresh')->willReturn($job);
         $jobRepo->expects(self::never())->method('markCompleted');
         $jobRepo->expects(self::never())->method('markFailed');
 
@@ -331,7 +331,7 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
         $jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
         $jobRepo->method('findActiveJobCoveringDate')->willReturn($job);
         $jobRepo->expects(self::once())->method('incrementProcessedDays')->willReturn(1);
-        $jobRepo->method('find')->willReturn($job);
+        $jobRepo->method('findFresh')->willReturn($job);
         $jobRepo->expects(self::never())->method('markCompleted');
         $jobRepo->expects(self::never())->method('markFailed');
 
@@ -377,7 +377,7 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
         $jobRepo->expects(self::once())->method('incrementProcessedDays')->willReturn(1);
         // Сценарий: пока мы инкрементили, другой воркер уже финализировал job'а.
         // find() возвращает уже COMPLETED job, tryFinalizeJob делает early return.
-        $jobRepo->method('find')->willReturn($completedJob);
+        $jobRepo->method('findFresh')->willReturn($completedJob);
         $jobRepo->expects(self::never())->method('markCompleted');
         $jobRepo->expects(self::never())->method('markFailed');
 


### PR DESCRIPTION
## Summary

Замыкает lifecycle `AdLoadJob` для Ozon Ads пайплайна (Commit 5): после обработки документа хендлер инкрементирует `processed_days` / `failed_days` и триггерит финализацию задания, когда `chunks_completed >= chunks_total` И `(processed + failed) >= COUNT(AdRawDocument в диапазоне)`.

## Ключевые решения

- **`AdLoadJobRepositoryInterface`** — согласно CLAUDE.md Repository помечен `final`, поэтому в тестах мокаем интерфейс, а не конкретный класс. Алиас настроен в `services.yaml`.
- **`AdLoadJobRepository::markCompleted($jobId, $companyId)`** — идемпотентный SQL, симметричный `markFailed`, guard `WHERE status IN ('pending','running')`. Возвращает `affectedRows`, защищает от double-mark при гонке воркеров.
- **`AdRawDocumentRepository::countByCompanyMarketplaceAndDateRange`** — новый идемпотентный COUNT, используется как условие финализации. Уникальность `(company_id, marketplace, report_date)` гарантирует, что retry оркестратора не раздувает счётчик.
- **`loaded_days` не трогаем** — coverage-based счётчик из Commit 3 остаётся информационным (для UI прогресса). Финализация построена поверх COUNT, чтобы не ломаться при retry.
- **`FetchOzonAdStatisticsHandler`** — детекция retry (`created=0 && updated>0`) → skip `incrementChunksCompleted` во избежание overshoot и ложной финализации раньше времени.
- **`ProcessAdRawDocumentHandler`**: после `ProcessAdRawDocumentAction`:
  - PROCESSED → `incrementProcessedDays`;
  - DRAFT (частичный успех) → warning + `incrementFailedDays` (иначе условие финализации не сойдётся);
  - `AdRawDocumentAlreadyProcessedException` → no-op (инкремент сделает реальный обработчик);
  - прочий `\Throwable` → `incrementFailedDays` + rethrow.
- **`tryFinalizeJob`**: перечитывает job из БД (UoW устарел после atomic increment), guard по статусу RUNNING, затем COUNT; `markCompleted` при `failed=0`, иначе `markFailed("Partial failure: N/M documents failed processing")`.

## Test plan

- [x] Unit-тесты `ProcessAdRawDocumentHandlerTest` (10 кейсов):
  - happy-path → `incrementProcessedDays`
  - no-active-job → skip (CLI-загрузка вне orchestrator-flow)
  - Throwable → `incrementFailedDays` + rethrow
  - partial-DRAFT → warning + `incrementFailedDays`
  - `AdRawDocumentAlreadyProcessedException` → no-op
  - all conditions met + `failed=0` → `markCompleted`
  - all conditions met + `failed>0` → `markFailed` с reason `"2/10"` / `"Partial failure"`
  - chunks incomplete → skip finalization (COUNT не запрашивается)
  - docs incomplete (processed+failed < COUNT) → skip finalization
  - race: second worker видит job уже COMPLETED → `markCompleted` не вызывается
- [x] `FetchOzonAdStatisticsHandlerTest` расширен retry-detection кейсами:
  - `testRetryOfOrchestratorDoesNotIncrementChunksCompleted` — все 3 документа уже существуют, `chunks_completed` не инкрементится.
  - `testFirstFetchWithMixedCreatedAndUpdatedIncrementsChunksCompleted` — 2 новых + 1 существующий, инкремент происходит.
  - Обновлён `testUpsertCallsUpdatePayloadForExistingDay`: `chunks_completed` → `never()`.
- [ ] Интеграционные/функциональные тесты в этом PR не добавлялись.
- [ ] `php bin/phpunit tests/Unit/MarketplaceAds` — локально не запускался (vendor/Docker недоступны в окружении), синтаксис всех изменённых файлов проверен `php -l`.
- [ ] `php bin/console debug:container App\\MarketplaceAds\\MessageHandler\\ProcessAdRawDocumentHandler` — проверить wiring `AdLoadJobRepositoryInterface` в CI.

https://claude.ai/code/session_017R8ccEN1ceFdpGPjdi19cT