### PR TITLE
feat(marketplace-ads): add AdChunkProgress entity for per-chunk idempotency

### DIFF
--- a/site/migrations/Version20260418000002.php
+++ b/site/migrations/Version20260418000002.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * MarketplaceAds: создание таблицы `marketplace_ad_chunk_progress` —
+ * фактов завершения чанков загрузки рекламной статистики.
+ *
+ * Уникальный индекс `(job_id, date_from, date_to)` гарантирует идемпотентность
+ * на уровне БД: повторная обработка того же чанка (Messenger retry) не
+ * породит дубликата и не инкрементит `chunks_completed` дважды.
+ *
+ * FK на `marketplace_ad_load_jobs(id)` с `ON DELETE CASCADE` — при удалении
+ * job'а прогресс чанков уходит вместе с ним (сирот не остаётся).
+ */
+final class Version20260418000002 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'MarketplaceAds: create marketplace_ad_chunk_progress table for per-chunk idempotency';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE marketplace_ad_chunk_progress (
+                id UUID NOT NULL,
+                job_id UUID NOT NULL,
+                date_from DATE NOT NULL,
+                date_to DATE NOT NULL,
+                completed_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                PRIMARY KEY(id),
+                CONSTRAINT uq_ad_chunk_progress_job_dates UNIQUE (job_id, date_from, date_to),
+                CONSTRAINT fk_ad_chunk_progress_job
+                    FOREIGN KEY (job_id)
+                    REFERENCES marketplace_ad_load_jobs (id)
+                    ON DELETE CASCADE
+                    NOT DEFERRABLE INITIALLY IMMEDIATE
+            )
+        SQL);
+        $this->addSql('CREATE INDEX idx_ad_chunk_progress_job ON marketplace_ad_chunk_progress (job_id)');
+        $this->addSql("COMMENT ON COLUMN marketplace_ad_chunk_progress.date_from IS '(DC2Type:date_immutable)'");
+        $this->addSql("COMMENT ON COLUMN marketplace_ad_chunk_progress.date_to IS '(DC2Type:date_immutable)'");
+        $this->addSql("COMMENT ON COLUMN marketplace_ad_chunk_progress.completed_at IS '(DC2Type:datetime_immutable)'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE marketplace_ad_chunk_progress');
+    }
+}

--- a/site/migrations/Version20260418000002.php
+++ b/site/migrations/Version20260418000002.php
@@ -43,7 +43,9 @@ final class Version20260418000002 extends AbstractMigration
                     NOT DEFERRABLE INITIALLY IMMEDIATE
             )
         SQL);
-        $this->addSql('CREATE INDEX idx_ad_chunk_progress_job ON marketplace_ad_chunk_progress (job_id)');
+        // Отдельный индекс по (job_id) не создаём: UNIQUE
+        // (job_id, date_from, date_to) имеет job_id ведущей колонкой
+        // и покрывает lookup'ы `WHERE job_id = ?` без отдельного индекса.
         $this->addSql("COMMENT ON COLUMN marketplace_ad_chunk_progress.date_from IS '(DC2Type:date_immutable)'");
         $this->addSql("COMMENT ON COLUMN marketplace_ad_chunk_progress.date_to IS '(DC2Type:date_immutable)'");
         $this->addSql("COMMENT ON COLUMN marketplace_ad_chunk_progress.completed_at IS '(DC2Type:datetime_immutable)'");

--- a/site/src/MarketplaceAds/Entity/AdChunkProgress.php
+++ b/site/src/MarketplaceAds/Entity/AdChunkProgress.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
+use Webmozart\Assert\Assert;
+
+/**
+ * Факт успешного завершения одного чанка загрузки рекламной статистики
+ * для задания {@see AdLoadJob}.
+ *
+ * Уникальный индекс `(job_id, date_from, date_to)` делает запись
+ * идемпотентной на уровне БД: повторный вызов
+ * {@see \App\MarketplaceAds\MessageHandler\FetchOzonAdStatisticsHandler}
+ * для того же чанка (Messenger retry после частичного успеха) упрётся
+ * в uq-нарушение и не приведёт к двойному инкременту счётчиков job'а.
+ *
+ * Поля неизменяемы после конструктора — прогресс чанка либо есть,
+ * либо нет. Корректировка не предполагается: пересчёт выполняется
+ * удалением записи и повторной загрузкой чанка.
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'marketplace_ad_chunk_progress')]
+#[ORM\UniqueConstraint(
+    name: 'uq_ad_chunk_progress_job_dates',
+    columns: ['job_id', 'date_from', 'date_to'],
+)]
+#[ORM\Index(columns: ['job_id'], name: 'idx_ad_chunk_progress_job')]
+class AdChunkProgress
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid', unique: true)]
+    private string $id;
+
+    #[ORM\Column(type: 'guid')]
+    private string $jobId;
+
+    #[ORM\Column(type: 'date_immutable')]
+    private \DateTimeImmutable $dateFrom;
+
+    #[ORM\Column(type: 'date_immutable')]
+    private \DateTimeImmutable $dateTo;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $completedAt;
+
+    public function __construct(
+        string $jobId,
+        \DateTimeImmutable $dateFrom,
+        \DateTimeImmutable $dateTo,
+    ) {
+        $this->id = Uuid::uuid7()->toString();
+        Assert::uuid($this->id);
+        Assert::uuid($jobId);
+
+        // Нормализация до 00:00 — консистентно с AdLoadJob::__construct:
+        // без этого записи за «тот же чанк» с разным временем дня попадали бы
+        // мимо уникального индекса и ломали идемпотентность.
+        $dateFrom = $dateFrom->setTime(0, 0);
+        $dateTo = $dateTo->setTime(0, 0);
+
+        if ($dateFrom > $dateTo) {
+            throw new \DomainException('dateFrom не может быть позже dateTo.');
+        }
+
+        $this->jobId = $jobId;
+        $this->dateFrom = $dateFrom;
+        $this->dateTo = $dateTo;
+        $this->completedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getJobId(): string
+    {
+        return $this->jobId;
+    }
+
+    public function getDateFrom(): \DateTimeImmutable
+    {
+        return $this->dateFrom;
+    }
+
+    public function getDateTo(): \DateTimeImmutable
+    {
+        return $this->dateTo;
+    }
+
+    public function getCompletedAt(): \DateTimeImmutable
+    {
+        return $this->completedAt;
+    }
+}

--- a/site/src/MarketplaceAds/Entity/AdChunkProgress.php
+++ b/site/src/MarketplaceAds/Entity/AdChunkProgress.php
@@ -28,7 +28,6 @@ use Webmozart\Assert\Assert;
     name: 'uq_ad_chunk_progress_job_dates',
     columns: ['job_id', 'date_from', 'date_to'],
 )]
-#[ORM\Index(columns: ['job_id'], name: 'idx_ad_chunk_progress_job')]
 class AdChunkProgress
 {
     #[ORM\Id]

--- a/site/tests/Unit/MarketplaceAds/AdChunkProgressTest.php
+++ b/site/tests/Unit/MarketplaceAds/AdChunkProgressTest.php
@@ -18,10 +18,41 @@ final class AdChunkProgressTest extends TestCase
 
         $progress = new AdChunkProgress($jobId, $dateFrom, $dateTo);
 
-        self::assertNotSame('', $progress->getId());
+        self::assertTrue(Uuid::isValid($progress->getId()));
         self::assertSame($jobId, $progress->getJobId());
         self::assertSame('2026-03-01', $progress->getDateFrom()->format('Y-m-d'));
         self::assertSame('2026-03-10', $progress->getDateTo()->format('Y-m-d'));
         self::assertInstanceOf(\DateTimeImmutable::class, $progress->getCompletedAt());
+    }
+
+    public function testConstructorNormalizesDatesToMidnight(): void
+    {
+        // Без нормализации два чанка с одинаковыми календарными датами, но
+        // разным временем дня, считались бы разными на уровне UNIQUE
+        // (job_id, date_from, date_to) — идемпотентность повторной обработки
+        // чанка сломалась бы. Проверяем, что конструктор всегда приводит
+        // к началу суток.
+        $progress = new AdChunkProgress(
+            Uuid::uuid7()->toString(),
+            new \DateTimeImmutable('2026-03-01 15:30:45'),
+            new \DateTimeImmutable('2026-03-10 22:45:12'),
+        );
+
+        self::assertSame('00:00:00', $progress->getDateFrom()->format('H:i:s'));
+        self::assertSame('00:00:00', $progress->getDateTo()->format('H:i:s'));
+        self::assertSame('2026-03-01', $progress->getDateFrom()->format('Y-m-d'));
+        self::assertSame('2026-03-10', $progress->getDateTo()->format('Y-m-d'));
+    }
+
+    public function testConstructorRejectsInvertedRange(): void
+    {
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('dateFrom не может быть позже dateTo.');
+
+        new AdChunkProgress(
+            Uuid::uuid7()->toString(),
+            new \DateTimeImmutable('2026-03-10'),
+            new \DateTimeImmutable('2026-03-01'),
+        );
     }
 }

--- a/site/tests/Unit/MarketplaceAds/AdChunkProgressTest.php
+++ b/site/tests/Unit/MarketplaceAds/AdChunkProgressTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MarketplaceAds;
+
+use App\MarketplaceAds\Entity\AdChunkProgress;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+final class AdChunkProgressTest extends TestCase
+{
+    public function testConstructorPopulatesAllFields(): void
+    {
+        $jobId = Uuid::uuid7()->toString();
+        $dateFrom = new \DateTimeImmutable('2026-03-01');
+        $dateTo = new \DateTimeImmutable('2026-03-10');
+
+        $progress = new AdChunkProgress($jobId, $dateFrom, $dateTo);
+
+        self::assertNotSame('', $progress->getId());
+        self::assertSame($jobId, $progress->getJobId());
+        self::assertSame('2026-03-01', $progress->getDateFrom()->format('Y-m-d'));
+        self::assertSame('2026-03-10', $progress->getDateTo()->format('Y-m-d'));
+        self::assertInstanceOf(\DateTimeImmutable::class, $progress->getCompletedAt());
+    }
+}


### PR DESCRIPTION
## Summary

- Новая таблица `marketplace_ad_chunk_progress` — факт успешного завершения одного чанка загрузки рекламной статистики для `AdLoadJob`.
- UNIQUE `(job_id, date_from, date_to)` — БД-уровневая идемпотентность: Messenger retry после частичного успеха не породит дубликат и не инкрементит `chunks_completed` дважды.
- FK `job_id → marketplace_ad_load_jobs(id) ON DELETE CASCADE` — прогресс чанков уходит вместе с job'ом, сирот не остаётся.

## Files

- `site/src/MarketplaceAds/Entity/AdChunkProgress.php` — Entity с полями `id` (UUID v7 в конструкторе), `jobId`, `dateFrom`, `dateTo`, `completedAt`. Без setter'ов, без mutators после конструктора. Нормализация дат до 00:00 консистентна с `AdLoadJob::__construct`.
- `site/migrations/Version20260418000002.php` — `up()` создаёт таблицу с UNIQUE, INDEX и FK; `down()` — `DROP TABLE`.
- `site/tests/Unit/MarketplaceAds/AdChunkProgressTest.php` — smoke-тест: конструктор ставит все поля, `id` не пустой.

## Scope

Больше ничего не трогает: ни хендлеры, ни репозитории, ни `AdLoadJob`. Интеграция с `FetchOzonAdStatisticsHandler` (insert на успешный чанк + ловля unique-violation) — в отдельном коммите.

## Test plan

- [ ] `php bin/console doctrine:migrations:migrate` — миграция применяется чисто
- [ ] `php bin/console doctrine:migrations:migrate prev` — `down()` откатывает таблицу
- [ ] `vendor/bin/phpunit tests/Unit/MarketplaceAds/AdChunkProgressTest.php` — тест зелёный
- [ ] Manual: вставка двух записей с одинаковыми `(job_id, date_from, date_to)` падает на unique violation
- [ ] Manual: удаление строки из `marketplace_ad_load_jobs` каскадно удаляет связанные `marketplace_ad_chunk_progress`

https://claude.ai/code/session_017w2PUM68Bq2CT6tMSLxbAX