### PR TITLE
feat(marketplace-ads): add AdChunkProgress repository with idempotent INSERT

### DIFF
--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -73,6 +73,7 @@ services:
     App\Marketplace\Repository\MarketplaceOrderRepositoryInterface: '@App\Marketplace\Repository\MarketplaceOrderRepository'
     App\MarketplaceAnalytics\Repository\UnitEconomyCostMappingRepositoryInterface: '@App\MarketplaceAnalytics\Repository\UnitEconomyCostMappingRepository'
     App\MarketplaceAnalytics\Repository\ListingDailySnapshotRepositoryInterface: '@App\MarketplaceAnalytics\Repository\ListingDailySnapshotRepository'
+    App\MarketplaceAds\Repository\AdChunkProgressRepositoryInterface: '@App\MarketplaceAds\Repository\AdChunkProgressRepository'
 
     # ---------- Balance value providers ------------ #
     App\Balance\Provider\:

--- a/site/src/MarketplaceAds/Repository/AdChunkProgressRepository.php
+++ b/site/src/MarketplaceAds/Repository/AdChunkProgressRepository.php
@@ -40,6 +40,14 @@ final class AdChunkProgressRepository extends ServiceEntityRepository implements
         $dateFromNorm = $dateFrom->setTime(0, 0)->format('Y-m-d');
         $dateToNorm = $dateTo->setTime(0, 0)->format('Y-m-d');
 
+        // Репозиторий пишет через DBAL в обход UoW и доменного конструктора
+        // AdChunkProgress, поэтому инвариант dateFrom ≤ dateTo обязан быть
+        // продублирован здесь — иначе перевёрнутый диапазон сохранится и
+        // будет накручивать countCompletedChunks.
+        if ($dateFromNorm > $dateToNorm) {
+            throw new \DomainException('dateFrom не может быть позже dateTo.');
+        }
+
         $affected = (int) $this->getEntityManager()->getConnection()->executeStatement(
             <<<'SQL'
                 INSERT INTO marketplace_ad_chunk_progress
@@ -81,6 +89,17 @@ final class AdChunkProgressRepository extends ServiceEntityRepository implements
      */
     private function assertJobBelongsToCompany(string $jobId, string $companyId): void
     {
+        // Ранняя валидация формата UUID: без неё Postgres упадёт на уровне
+        // драйвера (invalid input syntax for type uuid) и превратит IDOR-guard
+        // в 500-ошибку вместо обещанного интерфейсом \DomainException.
+        if (!Uuid::isValid($jobId) || !Uuid::isValid($companyId)) {
+            throw new \DomainException(sprintf(
+                'AdLoadJob %s не найден или не принадлежит компании %s.',
+                $jobId,
+                $companyId,
+            ));
+        }
+
         $found = $this->getEntityManager()->getConnection()->fetchOne(
             'SELECT 1 FROM marketplace_ad_load_jobs WHERE id = :jobId AND company_id = :companyId',
             [

--- a/site/src/MarketplaceAds/Repository/AdChunkProgressRepository.php
+++ b/site/src/MarketplaceAds/Repository/AdChunkProgressRepository.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Repository;
+
+use App\MarketplaceAds\Entity\AdChunkProgress;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * Репозиторий {@see AdChunkProgress} — идемпотентная фиксация факта
+ * завершения чанка и подсчёт выполненных чанков для задания.
+ *
+ * Реализован поверх DBAL (минуя Doctrine UoW), чтобы параллельные
+ * Messenger-воркеры могли безопасно писать строки в одну таблицу:
+ *  - `INSERT ... ON CONFLICT DO NOTHING` делает запись идемпотентной
+ *    на уровне БД (см. UNIQUE `uq_ad_chunk_progress_job_dates`);
+ *  - `SELECT COUNT(*)` читает актуальное состояние без участия UoW.
+ */
+final class AdChunkProgressRepository extends ServiceEntityRepository implements AdChunkProgressRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, AdChunkProgress::class);
+    }
+
+    public function markChunkCompleted(
+        string $jobId,
+        string $companyId,
+        \DateTimeImmutable $dateFrom,
+        \DateTimeImmutable $dateTo,
+    ): bool {
+        $this->assertJobBelongsToCompany($jobId, $companyId);
+
+        // Нормализуем до начала суток — симметрично AdChunkProgress::__construct
+        // и AdLoadJob::__construct. Колонка date_from/date_to имеет тип DATE,
+        // но явная нормализация делает поведение независимым от настроек драйвера.
+        $dateFromNorm = $dateFrom->setTime(0, 0)->format('Y-m-d');
+        $dateToNorm = $dateTo->setTime(0, 0)->format('Y-m-d');
+
+        $affected = (int) $this->getEntityManager()->getConnection()->executeStatement(
+            <<<'SQL'
+                INSERT INTO marketplace_ad_chunk_progress
+                    (id, job_id, date_from, date_to, completed_at)
+                VALUES
+                    (:id, :jobId, :dateFrom, :dateTo, NOW())
+                ON CONFLICT (job_id, date_from, date_to) DO NOTHING
+                SQL,
+            [
+                'id' => Uuid::uuid7()->toString(),
+                'jobId' => $jobId,
+                'dateFrom' => $dateFromNorm,
+                'dateTo' => $dateToNorm,
+            ],
+        );
+
+        // Postgres возвращает число фактически вставленных строк:
+        // 1 — впервые, 0 — конфликт по UNIQUE (чанк уже отмечен).
+        return 1 === $affected;
+    }
+
+    public function countCompletedChunks(string $jobId, string $companyId): int
+    {
+        $this->assertJobBelongsToCompany($jobId, $companyId);
+
+        return (int) $this->getEntityManager()->getConnection()->fetchOne(
+            'SELECT COUNT(*) FROM marketplace_ad_chunk_progress WHERE job_id = :jobId',
+            ['jobId' => $jobId],
+        );
+    }
+
+    /**
+     * IDOR-guard: отдельный SELECT к marketplace_ad_load_jobs.
+     *
+     * В отличие от `WHERE id = :jobId AND company_id = :companyId` прямо
+     * в INSERT/SELECT, здесь чанк-таблица не хранит company_id. Поэтому
+     * принадлежность проверяется через родительскую marketplace_ad_load_jobs;
+     * при несоответствии — явный \DomainException (а не тихие 0 строк).
+     */
+    private function assertJobBelongsToCompany(string $jobId, string $companyId): void
+    {
+        $found = $this->getEntityManager()->getConnection()->fetchOne(
+            'SELECT 1 FROM marketplace_ad_load_jobs WHERE id = :jobId AND company_id = :companyId',
+            [
+                'jobId' => $jobId,
+                'companyId' => $companyId,
+            ],
+        );
+
+        if (false === $found) {
+            throw new \DomainException(sprintf(
+                'AdLoadJob %s не найден или не принадлежит компании %s.',
+                $jobId,
+                $companyId,
+            ));
+        }
+    }
+}

--- a/site/src/MarketplaceAds/Repository/AdChunkProgressRepositoryInterface.php
+++ b/site/src/MarketplaceAds/Repository/AdChunkProgressRepositoryInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Repository;
+
+interface AdChunkProgressRepositoryInterface
+{
+    /**
+     * Идемпотентно фиксирует успешное завершение чанка
+     * [$dateFrom, $dateTo] для задания $jobId.
+     *
+     * Реализация обязана:
+     *  - проверить, что $jobId принадлежит $companyId (IDOR-guard); иначе
+     *    бросить {@see \DomainException};
+     *  - выполнить `INSERT ... ON CONFLICT (job_id, date_from, date_to) DO NOTHING`.
+     *
+     * @return bool true если запись вставлена впервые, false если такой
+     *              чанк уже отмечен (повторный вызов при Messenger retry).
+     *
+     * @throws \DomainException если $jobId не принадлежит $companyId
+     */
+    public function markChunkCompleted(
+        string $jobId,
+        string $companyId,
+        \DateTimeImmutable $dateFrom,
+        \DateTimeImmutable $dateTo,
+    ): bool;
+
+    /**
+     * Количество зафиксированных чанков для задания $jobId.
+     *
+     * Реализация обязана проверить принадлежность $jobId компании
+     * $companyId перед запросом — аналогично {@see self::markChunkCompleted}.
+     *
+     * @throws \DomainException если $jobId не принадлежит $companyId
+     */
+    public function countCompletedChunks(string $jobId, string $companyId): int;
+}

--- a/site/tests/Builders/MarketplaceAds/AdChunkProgressBuilder.php
+++ b/site/tests/Builders/MarketplaceAds/AdChunkProgressBuilder.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Builders\MarketplaceAds;
+
+use App\MarketplaceAds\Entity\AdChunkProgress;
+
+final class AdChunkProgressBuilder
+{
+    public const DEFAULT_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+    public const DEFAULT_JOB_ID = AdLoadJobBuilder::DEFAULT_ID;
+
+    private string $id = self::DEFAULT_ID;
+    private string $jobId = self::DEFAULT_JOB_ID;
+    private \DateTimeImmutable $dateFrom;
+    private \DateTimeImmutable $dateTo;
+
+    private function __construct()
+    {
+        $this->dateFrom = new \DateTimeImmutable('2026-03-01');
+        $this->dateTo = new \DateTimeImmutable('2026-03-03');
+    }
+
+    public static function aProgress(): self
+    {
+        return new self();
+    }
+
+    public function withIndex(int $index): self
+    {
+        $clone = clone $this;
+        $clone->id = sprintf('cccccccc-cccc-cccc-cccc-%012d', $index);
+
+        return $clone;
+    }
+
+    public function withJobId(string $jobId): self
+    {
+        $clone = clone $this;
+        $clone->jobId = $jobId;
+
+        return $clone;
+    }
+
+    public function withDateRange(\DateTimeImmutable $dateFrom, \DateTimeImmutable $dateTo): self
+    {
+        $clone = clone $this;
+        $clone->dateFrom = $dateFrom;
+        $clone->dateTo = $dateTo;
+
+        return $clone;
+    }
+
+    public function build(): AdChunkProgress
+    {
+        $progress = new AdChunkProgress(
+            jobId: $this->jobId,
+            dateFrom: $this->dateFrom,
+            dateTo: $this->dateTo,
+        );
+
+        // Конструктор генерирует UUID v7, Builder обязан выдавать детерминированный ID.
+        $reflection = new \ReflectionProperty(AdChunkProgress::class, 'id');
+        $reflection->setAccessible(true);
+        $reflection->setValue($progress, $this->id);
+
+        return $progress;
+    }
+}

--- a/site/tests/Integration/MarketplaceAds/AdChunkProgressRepositoryTest.php
+++ b/site/tests/Integration/MarketplaceAds/AdChunkProgressRepositoryTest.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\MarketplaceAds;
+
+use App\Company\Entity\Company;
+use App\MarketplaceAds\Entity\AdLoadJob;
+use App\MarketplaceAds\Repository\AdChunkProgressRepository;
+use App\MarketplaceAds\Repository\AdLoadJobRepository;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Builders\MarketplaceAds\AdLoadJobBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+
+final class AdChunkProgressRepositoryTest extends IntegrationTestCase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-000000000001';
+    private const OTHER_COMPANY_ID = '11111111-1111-1111-1111-000000000002';
+    private const OWNER_ID = '22222222-2222-2222-2222-000000000001';
+    private const OTHER_OWNER_ID = '22222222-2222-2222-2222-000000000002';
+
+    private AdChunkProgressRepository $repository;
+    private AdLoadJobRepository $jobRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = self::getContainer()->get(AdChunkProgressRepository::class);
+        $this->jobRepository = self::getContainer()->get(AdLoadJobRepository::class);
+    }
+
+    public function testMarkChunkCompletedReturnsTrueOnFirstInsert(): void
+    {
+        $job = $this->seedJob(self::COMPANY_ID);
+
+        $inserted = $this->repository->markChunkCompleted(
+            $job->getId(),
+            self::COMPANY_ID,
+            new \DateTimeImmutable('2026-03-01'),
+            new \DateTimeImmutable('2026-03-03'),
+        );
+
+        self::assertTrue($inserted);
+        self::assertSame(1, $this->repository->countCompletedChunks($job->getId(), self::COMPANY_ID));
+    }
+
+    public function testMarkChunkCompletedReturnsFalseOnDuplicate(): void
+    {
+        $job = $this->seedJob(self::COMPANY_ID);
+        $dateFrom = new \DateTimeImmutable('2026-03-01');
+        $dateTo = new \DateTimeImmutable('2026-03-03');
+
+        $first = $this->repository->markChunkCompleted($job->getId(), self::COMPANY_ID, $dateFrom, $dateTo);
+        $second = $this->repository->markChunkCompleted($job->getId(), self::COMPANY_ID, $dateFrom, $dateTo);
+
+        self::assertTrue($first, 'Первая вставка должна пройти');
+        self::assertFalse($second, 'Повторная вставка того же чанка должна вернуть false (ON CONFLICT DO NOTHING)');
+        self::assertSame(1, $this->repository->countCompletedChunks($job->getId(), self::COMPANY_ID));
+    }
+
+    public function testMarkChunkCompletedAllowsDifferentRangesOnSameJob(): void
+    {
+        $job = $this->seedJob(self::COMPANY_ID);
+
+        $a = $this->repository->markChunkCompleted(
+            $job->getId(),
+            self::COMPANY_ID,
+            new \DateTimeImmutable('2026-03-01'),
+            new \DateTimeImmutable('2026-03-03'),
+        );
+        $b = $this->repository->markChunkCompleted(
+            $job->getId(),
+            self::COMPANY_ID,
+            new \DateTimeImmutable('2026-03-04'),
+            new \DateTimeImmutable('2026-03-06'),
+        );
+
+        self::assertTrue($a);
+        self::assertTrue($b);
+        self::assertSame(2, $this->repository->countCompletedChunks($job->getId(), self::COMPANY_ID));
+    }
+
+    public function testCountCompletedChunksReturnsZeroForFreshJob(): void
+    {
+        $job = $this->seedJob(self::COMPANY_ID);
+
+        self::assertSame(0, $this->repository->countCompletedChunks($job->getId(), self::COMPANY_ID));
+    }
+
+    public function testCountCompletedChunksReflectsMultipleInserts(): void
+    {
+        $job = $this->seedJob(self::COMPANY_ID);
+
+        // 5 разных чанков × 3 дня
+        for ($i = 0; $i < 5; ++$i) {
+            $this->repository->markChunkCompleted(
+                $job->getId(),
+                self::COMPANY_ID,
+                new \DateTimeImmutable(sprintf('2026-03-%02d', 1 + $i * 3)),
+                new \DateTimeImmutable(sprintf('2026-03-%02d', 3 + $i * 3)),
+            );
+        }
+
+        self::assertSame(5, $this->repository->countCompletedChunks($job->getId(), self::COMPANY_ID));
+    }
+
+    public function testMarkChunkCompletedRejectsForeignCompanyIDOR(): void
+    {
+        $job = $this->seedJob(self::COMPANY_ID);
+        $this->seedCompany(self::OTHER_COMPANY_ID, self::OTHER_OWNER_ID, 'b@example.test');
+        $this->em->flush();
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessageMatches('/не принадлежит компании/');
+
+        $this->repository->markChunkCompleted(
+            $job->getId(),
+            self::OTHER_COMPANY_ID,
+            new \DateTimeImmutable('2026-03-01'),
+            new \DateTimeImmutable('2026-03-03'),
+        );
+    }
+
+    public function testCountCompletedChunksRejectsForeignCompanyIDOR(): void
+    {
+        $job = $this->seedJob(self::COMPANY_ID);
+        $this->seedCompany(self::OTHER_COMPANY_ID, self::OTHER_OWNER_ID, 'b@example.test');
+        $this->em->flush();
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessageMatches('/не принадлежит компании/');
+
+        $this->repository->countCompletedChunks($job->getId(), self::OTHER_COMPANY_ID);
+    }
+
+    public function testMarkChunkCompletedRejectsUnknownJob(): void
+    {
+        $this->seedCompany(self::COMPANY_ID, self::OWNER_ID, 'a@example.test');
+        $this->em->flush();
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessageMatches('/не найден или не принадлежит/');
+
+        $this->repository->markChunkCompleted(
+            '00000000-0000-0000-0000-000000000000',
+            self::COMPANY_ID,
+            new \DateTimeImmutable('2026-03-01'),
+            new \DateTimeImmutable('2026-03-03'),
+        );
+    }
+
+    public function testCascadeDeleteRemovesProgressWhenJobIsDeleted(): void
+    {
+        $job = $this->seedJob(self::COMPANY_ID);
+
+        $this->repository->markChunkCompleted(
+            $job->getId(),
+            self::COMPANY_ID,
+            new \DateTimeImmutable('2026-03-01'),
+            new \DateTimeImmutable('2026-03-03'),
+        );
+        $this->repository->markChunkCompleted(
+            $job->getId(),
+            self::COMPANY_ID,
+            new \DateTimeImmutable('2026-03-04'),
+            new \DateTimeImmutable('2026-03-06'),
+        );
+
+        // Sanity: прогресс есть.
+        $conn = $this->em->getConnection();
+        self::assertSame(
+            2,
+            (int) $conn->fetchOne('SELECT COUNT(*) FROM marketplace_ad_chunk_progress WHERE job_id = :id', ['id' => $job->getId()]),
+        );
+
+        // Удаляем родительский job — FK ON DELETE CASCADE обязан убрать прогресс.
+        $managedJob = $this->jobRepository->find($job->getId());
+        self::assertNotNull($managedJob);
+        $this->em->remove($managedJob);
+        $this->em->flush();
+
+        self::assertSame(
+            0,
+            (int) $conn->fetchOne('SELECT COUNT(*) FROM marketplace_ad_chunk_progress WHERE job_id = :id', ['id' => $job->getId()]),
+        );
+    }
+
+    private function seedJob(string $companyId): AdLoadJob
+    {
+        $this->seedCompany($companyId, self::OWNER_ID, 'a@example.test');
+        $this->em->flush();
+
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId($companyId)
+            ->withIndex(1)
+            ->build();
+
+        $this->jobRepository->save($job);
+        $this->em->flush();
+
+        return $job;
+    }
+
+    private function seedCompany(string $companyId, string $ownerId, string $email): Company
+    {
+        $owner = UserBuilder::aUser()
+            ->withId($ownerId)
+            ->withEmail($email)
+            ->build();
+
+        $company = CompanyBuilder::aCompany()
+            ->withId($companyId)
+            ->withOwner($owner)
+            ->build();
+
+        $this->em->persist($owner);
+        $this->em->persist($company);
+
+        return $company;
+    }
+}

--- a/site/tests/Integration/MarketplaceAds/AdChunkProgressRepositoryTest.php
+++ b/site/tests/Integration/MarketplaceAds/AdChunkProgressRepositoryTest.php
@@ -151,6 +151,48 @@ final class AdChunkProgressRepositoryTest extends IntegrationTestCase
         );
     }
 
+    public function testMarkChunkCompletedRejectsInvertedDateRange(): void
+    {
+        $job = $this->seedJob(self::COMPANY_ID);
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessageMatches('/dateFrom не может быть позже dateTo/');
+
+        $this->repository->markChunkCompleted(
+            $job->getId(),
+            self::COMPANY_ID,
+            new \DateTimeImmutable('2026-03-10'),
+            new \DateTimeImmutable('2026-03-01'),
+        );
+    }
+
+    public function testMarkChunkCompletedRejectsMalformedUuid(): void
+    {
+        $this->seedCompany(self::COMPANY_ID, self::OWNER_ID, 'a@example.test');
+        $this->em->flush();
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessageMatches('/не найден или не принадлежит/');
+
+        $this->repository->markChunkCompleted(
+            'not-a-uuid',
+            self::COMPANY_ID,
+            new \DateTimeImmutable('2026-03-01'),
+            new \DateTimeImmutable('2026-03-03'),
+        );
+    }
+
+    public function testCountCompletedChunksRejectsMalformedUuid(): void
+    {
+        $this->seedCompany(self::COMPANY_ID, self::OWNER_ID, 'a@example.test');
+        $this->em->flush();
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessageMatches('/не найден или не принадлежит/');
+
+        $this->repository->countCompletedChunks('not-a-uuid', self::COMPANY_ID);
+    }
+
     public function testCascadeDeleteRemovesProgressWhenJobIsDeleted(): void
     {
         $job = $this->seedJob(self::COMPANY_ID);


### PR DESCRIPTION
## Summary

- Новый `AdChunkProgressRepositoryInterface` + `final AdChunkProgressRepository` (DBAL, минуя UoW) для идемпотентной фиксации завершения чанка и COUNT'а выполненных чанков.
- `markChunkCompleted` использует `INSERT ... ON CONFLICT (job_id, date_from, date_to) DO NOTHING` — БД-уровневая идемпотентность против Messenger retry.
- IDOR-guard через отдельный `SELECT 1 FROM marketplace_ad_load_jobs WHERE id = ? AND company_id = ?` перед каждой операцией: у `marketplace_ad_chunk_progress` нет собственной колонки `company_id`, поэтому принадлежность проверяется через родительскую таблицу; при несоответствии — `\DomainException`, а не тихие 0 строк.

## API

```php
public function markChunkCompleted(
    string $jobId,
    string $companyId,
    \DateTimeImmutable $dateFrom,
    \DateTimeImmutable $dateTo,
): bool;  // true = inserted, false = conflict

public function countCompletedChunks(string $jobId, string $companyId): int;
```

## Files

- `site/src/MarketplaceAds/Repository/AdChunkProgressRepositoryInterface.php`
- `site/src/MarketplaceAds/Repository/AdChunkProgressRepository.php` (`final`, extends `ServiceEntityRepository`, implements `...Interface`)
- `site/config/services.yaml` — binding Interface → Concrete (+1 строка, рядом с другими MarketplaceAnalytics / Marketplace biding'ами)
- `site/tests/Builders/MarketplaceAds/AdChunkProgressBuilder.php` — детерминированный `cccccccc-...` ID, `with*()`
- `site/tests/Integration/MarketplaceAds/AdChunkProgressRepositoryTest.php` — 9 сценариев

## Scope

Не трогает `AdLoadJob`/`AdLoadJobRepository`/хендлеры. Сам Entity `AdChunkProgress` тоже не тронут — `ServiceEntityRepository` саморегистрируется в DI; `#[ORM\Entity(repositoryClass: ...)]` добавим вместе с интеграцией в handler.

## Test plan

- [ ] `vendor/bin/phpunit tests/Integration/MarketplaceAds/AdChunkProgressRepositoryTest.php`
- [ ] **first insert** → `true`, count=1
- [ ] **duplicate** (`job_id` + тот же диапазон) → `false`, count=1
- [ ] **разные диапазоны на одном job** → оба `true`, count=2
- [ ] **count**: 0 для fresh job, 5 после 5 INSERT'ов
- [ ] **IDOR `markChunkCompleted`** (чужой `companyId`) → `\DomainException`
- [ ] **IDOR `countCompletedChunks`** (чужой `companyId`) → `\DomainException`
- [ ] **unknown job_id** → `\DomainException`
- [ ] **FK CASCADE**: `$em->remove($job); $em->flush()` удаляет все progress-строки

https://claude.ai/code/session_017w2PUM68Bq2CT6tMSLxbAX