### PR TITLE
test(marketplace-ads): single-day chunk and time normalization coverage

### DIFF
--- a/site/tests/Integration/MarketplaceAds/AdChunkProgressRepositoryTest.php
+++ b/site/tests/Integration/MarketplaceAds/AdChunkProgressRepositoryTest.php
@@ -151,6 +151,44 @@ final class AdChunkProgressRepositoryTest extends IntegrationTestCase
         );
     }
 
+    public function testMarkChunkCompletedAcceptsSingleDayChunk(): void
+    {
+        $job = $this->seedJob(self::COMPANY_ID);
+        $sameDay = new \DateTimeImmutable('2026-03-15');
+
+        $inserted = $this->repository->markChunkCompleted(
+            $job->getId(),
+            self::COMPANY_ID,
+            $sameDay,
+            $sameDay,
+        );
+
+        self::assertTrue($inserted);
+        self::assertSame(1, $this->repository->countCompletedChunks($job->getId(), self::COMPANY_ID));
+    }
+
+    public function testMarkChunkCompletedNormalizesTimeOnDuplicate(): void
+    {
+        $job = $this->seedJob(self::COMPANY_ID);
+
+        $first = $this->repository->markChunkCompleted(
+            $job->getId(),
+            self::COMPANY_ID,
+            new \DateTimeImmutable('2026-03-01 10:00'),
+            new \DateTimeImmutable('2026-03-03 10:00'),
+        );
+        $second = $this->repository->markChunkCompleted(
+            $job->getId(),
+            self::COMPANY_ID,
+            new \DateTimeImmutable('2026-03-01 15:30'),
+            new \DateTimeImmutable('2026-03-03 23:59'),
+        );
+
+        self::assertTrue($first);
+        self::assertFalse($second, 'Нормализация времени до 00:00 обязана делать UNIQUE-ключ одинаковым');
+        self::assertSame(1, $this->repository->countCompletedChunks($job->getId(), self::COMPANY_ID));
+    }
+
     public function testMarkChunkCompletedRejectsInvertedDateRange(): void
     {
         $job = $this->seedJob(self::COMPANY_ID);


### PR DESCRIPTION
## Summary
- Adds `testMarkChunkCompletedAcceptsSingleDayChunk` — verifies `dateFrom == dateTo` is accepted (boundary case for the `dateFrom <= dateTo` guard added in #1574).
- Adds `testMarkChunkCompletedNormalizesTimeOnDuplicate` — two calls with identical calendar dates but different times collapse to one row, proving `setTime(0, 0)` makes the UNIQUE key time-insensitive (regression guard for the normalization in `AdChunkProgressRepository::markChunkCompleted`).

## Scope
Tests only. Entity, Repository implementation, `services.yaml`, and Builder are untouched.

## Test plan
- [ ] `make test` (or PHPUnit on `tests/Integration/MarketplaceAds/AdChunkProgressRepositoryTest.php`) — both new tests pass.
- [ ] Existing 11 tests in the same file still pass.

https://claude.ai/code/session_017w2PUM68Bq2CT6tMSLxbAX