### PR TITLE
feat(MarketplaceAds): add count/markCompleted repo methods + interfaces

### DIFF
--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -74,6 +74,8 @@ services:
     App\MarketplaceAnalytics\Repository\UnitEconomyCostMappingRepositoryInterface: '@App\MarketplaceAnalytics\Repository\UnitEconomyCostMappingRepository'
     App\MarketplaceAnalytics\Repository\ListingDailySnapshotRepositoryInterface: '@App\MarketplaceAnalytics\Repository\ListingDailySnapshotRepository'
     App\MarketplaceAds\Repository\AdChunkProgressRepositoryInterface: '@App\MarketplaceAds\Repository\AdChunkProgressRepository'
+    App\MarketplaceAds\Repository\AdRawDocumentRepositoryInterface: '@App\MarketplaceAds\Repository\AdRawDocumentRepository'
+    App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface: '@App\MarketplaceAds\Repository\AdLoadJobRepository'
 
     # ---------- Balance value providers ------------ #
     App\Balance\Provider\:

--- a/site/src/MarketplaceAds/Repository/AdLoadJobRepository.php
+++ b/site/src/MarketplaceAds/Repository/AdLoadJobRepository.php
@@ -10,7 +10,7 @@ use App\MarketplaceAds\Enum\AdLoadJobStatus;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
-class AdLoadJobRepository extends ServiceEntityRepository
+class AdLoadJobRepository extends ServiceEntityRepository implements AdLoadJobRepositoryInterface
 {
     public function __construct(ManagerRegistry $registry)
     {
@@ -140,6 +140,36 @@ class AdLoadJobRepository extends ServiceEntityRepository
                 SQL,
             [
                 'reason' => $reason,
+                'jobId' => $jobId,
+                'companyId' => $companyId,
+            ],
+        );
+    }
+
+    /**
+     * Помечает задание как COMPLETED через raw DBAL UPDATE (минуя UoW).
+     *
+     * Симметрично {@see self::markFailed()}: условие `status IN ('pending', 'running')`
+     * делает операцию идемпотентной — повторный вызов на уже терминальном задании
+     * (COMPLETED/FAILED) затронет 0 строк и не перезапишет finished_at.
+     *
+     * `company_id` в WHERE — встроенный IDOR-guard.
+     *
+     * @return int число обновлённых строк (0 если job уже терминальный или чужой)
+     */
+    public function markCompleted(string $jobId, string $companyId): int
+    {
+        return (int) $this->getEntityManager()->getConnection()->executeStatement(
+            <<<'SQL'
+                UPDATE marketplace_ad_load_jobs
+                SET status = 'completed',
+                    finished_at = NOW(),
+                    updated_at = NOW()
+                WHERE id = :jobId
+                  AND company_id = :companyId
+                  AND status IN ('pending', 'running')
+                SQL,
+            [
                 'jobId' => $jobId,
                 'companyId' => $companyId,
             ],

--- a/site/src/MarketplaceAds/Repository/AdLoadJobRepositoryInterface.php
+++ b/site/src/MarketplaceAds/Repository/AdLoadJobRepositoryInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Repository;
+
+interface AdLoadJobRepositoryInterface
+{
+    /**
+     * Помечает задание как COMPLETED через raw DBAL UPDATE (минуя UoW).
+     *
+     * Реализация обязана:
+     *  - ограничивать UPDATE `id = :id AND company_id = :companyId` (IDOR-guard);
+     *  - допускать переход только из активных статусов (`pending`, `running`):
+     *    повторный вызов на уже терминальном (COMPLETED/FAILED) задании должен
+     *    вернуть 0 — операция идемпотентна на уровне SQL;
+     *  - выставлять `finished_at = NOW()` и `updated_at = NOW()`.
+     *
+     * @return int число обновлённых строк (0 если job уже терминальный или чужой)
+     */
+    public function markCompleted(string $jobId, string $companyId): int;
+}

--- a/site/src/MarketplaceAds/Repository/AdRawDocumentRepository.php
+++ b/site/src/MarketplaceAds/Repository/AdRawDocumentRepository.php
@@ -9,11 +9,38 @@ use App\MarketplaceAds\Enum\AdRawDocumentStatus;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
-class AdRawDocumentRepository extends ServiceEntityRepository
+class AdRawDocumentRepository extends ServiceEntityRepository implements AdRawDocumentRepositoryInterface
 {
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, AdRawDocument::class);
+    }
+
+    public function countByCompanyMarketplaceAndDateRange(
+        string $companyId,
+        string $marketplace,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        ?AdRawDocumentStatus $statusFilter = null,
+    ): int {
+        $sql = 'SELECT COUNT(*) FROM marketplace_ad_raw_documents
+                WHERE company_id = :company_id
+                  AND marketplace = :marketplace
+                  AND report_date BETWEEN :from AND :to';
+
+        $params = [
+            'company_id' => $companyId,
+            'marketplace' => $marketplace,
+            'from' => $from->format('Y-m-d'),
+            'to' => $to->format('Y-m-d'),
+        ];
+
+        if (null !== $statusFilter) {
+            $sql .= ' AND status = :status';
+            $params['status'] = $statusFilter->value;
+        }
+
+        return (int) $this->getEntityManager()->getConnection()->fetchOne($sql, $params);
     }
 
     /**

--- a/site/src/MarketplaceAds/Repository/AdRawDocumentRepositoryInterface.php
+++ b/site/src/MarketplaceAds/Repository/AdRawDocumentRepositoryInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Repository;
+
+use App\MarketplaceAds\Enum\AdRawDocumentStatus;
+
+interface AdRawDocumentRepositoryInterface
+{
+    /**
+     * Количество raw-документов компании за период для конкретного маркетплейса.
+     *
+     * Реализация обязана:
+     *  - ограничивать выборку `company_id = :companyId` (IDOR-guard на уровне SQL);
+     *  - сравнивать `report_date` включительно по обеим границам `[$from, $to]`;
+     *  - при переданном `$statusFilter` добавлять условие `status = :status`.
+     *
+     * @param string                   $marketplace  значение {@see \App\Marketplace\Enum\MarketplaceType::value}
+     * @param AdRawDocumentStatus|null $statusFilter null — считать во всех статусах
+     */
+    public function countByCompanyMarketplaceAndDateRange(
+        string $companyId,
+        string $marketplace,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        ?AdRawDocumentStatus $statusFilter = null,
+    ): int;
+}

--- a/site/tests/Integration/MarketplaceAds/AdLoadJobRepositoryTest.php
+++ b/site/tests/Integration/MarketplaceAds/AdLoadJobRepositoryTest.php
@@ -411,6 +411,138 @@ final class AdLoadJobRepositoryTest extends IntegrationTestCase
         self::assertSame(7, $dbValue);
     }
 
+    public function testMarkCompletedFromRunningReturnsOneAndPersistsCompleted(): void
+    {
+        $this->seedCompany(self::COMPANY_ID, self::OWNER_ID, 'a@example.test');
+        $this->em->flush();
+
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(1)
+            ->asRunning()
+            ->build();
+        $this->repository->save($job);
+        $this->em->flush();
+        $jobId = $job->getId();
+        $this->em->clear();
+
+        $affected = $this->repository->markCompleted($jobId, self::COMPANY_ID);
+
+        self::assertSame(1, $affected);
+
+        $conn = $this->em->getConnection();
+        $row = $conn->fetchAssociative(
+            'SELECT status, finished_at FROM marketplace_ad_load_jobs WHERE id = :id',
+            ['id' => $jobId],
+        );
+        self::assertSame(AdLoadJobStatus::COMPLETED->value, $row['status']);
+        self::assertNotNull($row['finished_at']);
+    }
+
+    public function testMarkCompletedFromPendingReturnsOne(): void
+    {
+        $this->seedCompany(self::COMPANY_ID, self::OWNER_ID, 'a@example.test');
+        $this->em->flush();
+
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(1)
+            ->build(); // default — PENDING
+        $this->repository->save($job);
+        $this->em->flush();
+        $jobId = $job->getId();
+
+        $affected = $this->repository->markCompleted($jobId, self::COMPANY_ID);
+
+        self::assertSame(1, $affected);
+
+        $this->em->clear();
+        $reloaded = $this->repository->findByIdAndCompany($jobId, self::COMPANY_ID);
+        self::assertNotNull($reloaded);
+        self::assertSame(AdLoadJobStatus::COMPLETED, $reloaded->getStatus());
+        self::assertNotNull($reloaded->getFinishedAt());
+    }
+
+    public function testMarkCompletedIsIdempotentOnAlreadyCompleted(): void
+    {
+        $this->seedCompany(self::COMPANY_ID, self::OWNER_ID, 'a@example.test');
+        $this->em->flush();
+
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(1)
+            ->asCompleted()
+            ->build();
+        $this->repository->save($job);
+        $this->em->flush();
+        $jobId = $job->getId();
+
+        // finished_at задан билдером — зафиксируем его до повторного вызова,
+        // чтобы проверить неизменность (markCompleted обязан быть идемпотентным).
+        $conn = $this->em->getConnection();
+        $finishedAtBefore = $conn->fetchOne(
+            'SELECT finished_at FROM marketplace_ad_load_jobs WHERE id = :id',
+            ['id' => $jobId],
+        );
+
+        $affected = $this->repository->markCompleted($jobId, self::COMPANY_ID);
+        self::assertSame(0, $affected);
+
+        $finishedAtAfter = $conn->fetchOne(
+            'SELECT finished_at FROM marketplace_ad_load_jobs WHERE id = :id',
+            ['id' => $jobId],
+        );
+        self::assertSame($finishedAtBefore, $finishedAtAfter);
+    }
+
+    public function testMarkCompletedOnFailedIsBlockedByGuard(): void
+    {
+        $this->seedCompany(self::COMPANY_ID, self::OWNER_ID, 'a@example.test');
+        $this->em->flush();
+
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(1)
+            ->asFailed('something went wrong')
+            ->build();
+        $this->repository->save($job);
+        $this->em->flush();
+        $jobId = $job->getId();
+
+        $affected = $this->repository->markCompleted($jobId, self::COMPANY_ID);
+        self::assertSame(0, $affected);
+
+        $this->em->clear();
+        $reloaded = $this->repository->findByIdAndCompany($jobId, self::COMPANY_ID);
+        self::assertNotNull($reloaded);
+        self::assertSame(AdLoadJobStatus::FAILED, $reloaded->getStatus());
+        self::assertSame('something went wrong', $reloaded->getFailureReason());
+    }
+
+    public function testMarkCompletedIgnoresWrongCompanyIdIDOR(): void
+    {
+        $this->seedCompany(self::COMPANY_ID, self::OWNER_ID, 'a@example.test');
+        $this->seedCompany(self::OTHER_COMPANY_ID, self::OTHER_OWNER_ID, 'b@example.test');
+        $this->em->flush();
+
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(1)
+            ->asRunning()
+            ->build();
+        $this->repository->save($job);
+        $this->em->flush();
+        $jobId = $job->getId();
+
+        $affected = $this->repository->markCompleted($jobId, self::OTHER_COMPANY_ID);
+        self::assertSame(0, $affected);
+
+        $this->em->clear();
+        $reloaded = $this->repository->findByIdAndCompany($jobId, self::COMPANY_ID);
+        self::assertNotNull($reloaded);
+        self::assertSame(AdLoadJobStatus::RUNNING, $reloaded->getStatus());
+    }
+
     private function seedCompany(string $companyId, string $ownerId, string $email): Company
     {
         $owner = UserBuilder::aUser()

--- a/site/tests/Integration/MarketplaceAds/AdRawDocumentRepositoryTest.php
+++ b/site/tests/Integration/MarketplaceAds/AdRawDocumentRepositoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Integration\MarketplaceAds;
 
 use App\Company\Entity\Company;
+use App\Marketplace\Enum\MarketplaceType;
 use App\MarketplaceAds\Enum\AdRawDocumentStatus;
 use App\MarketplaceAds\Repository\AdRawDocumentRepository;
 use App\Tests\Builders\Company\CompanyBuilder;
@@ -114,6 +115,228 @@ final class AdRawDocumentRepositoryTest extends IntegrationTestCase
             ['id' => $doc->getId()],
         );
         self::assertSame(AdRawDocumentStatus::DRAFT->value, $status);
+    }
+
+    public function testCountByCompanyMarketplaceAndDateRangeWithoutFilter(): void
+    {
+        $this->seedCompany(self::COMPANY_ID, self::OWNER_ID, 'a@example.test');
+
+        $from = new \DateTimeImmutable('2026-03-01');
+        $to = new \DateTimeImmutable('2026-03-10');
+
+        // Три документа OZON в диапазоне с разными статусами
+        $draft = AdRawDocumentBuilder::aRawDocument()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(1)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withReportDate(new \DateTimeImmutable('2026-03-02'))
+            ->build();
+
+        $processed = AdRawDocumentBuilder::aRawDocument()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(2)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withReportDate(new \DateTimeImmutable('2026-03-05'))
+            ->asProcessed()
+            ->build();
+
+        $failed = AdRawDocumentBuilder::aRawDocument()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(3)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withReportDate(new \DateTimeImmutable('2026-03-10'))
+            ->asFailed('oops')
+            ->build();
+
+        foreach ([$draft, $processed, $failed] as $doc) {
+            $this->repository->save($doc);
+        }
+        $this->em->flush();
+
+        $count = $this->repository->countByCompanyMarketplaceAndDateRange(
+            self::COMPANY_ID,
+            MarketplaceType::OZON->value,
+            $from,
+            $to,
+        );
+
+        self::assertSame(3, $count);
+    }
+
+    public function testCountFilteredByProcessedStatusOnly(): void
+    {
+        $this->seedThreeDocumentsPerStatus();
+
+        $count = $this->repository->countByCompanyMarketplaceAndDateRange(
+            self::COMPANY_ID,
+            MarketplaceType::OZON->value,
+            new \DateTimeImmutable('2026-03-01'),
+            new \DateTimeImmutable('2026-03-31'),
+            AdRawDocumentStatus::PROCESSED,
+        );
+
+        self::assertSame(1, $count);
+    }
+
+    public function testCountFilteredByFailedStatusOnly(): void
+    {
+        $this->seedThreeDocumentsPerStatus();
+
+        $count = $this->repository->countByCompanyMarketplaceAndDateRange(
+            self::COMPANY_ID,
+            MarketplaceType::OZON->value,
+            new \DateTimeImmutable('2026-03-01'),
+            new \DateTimeImmutable('2026-03-31'),
+            AdRawDocumentStatus::FAILED,
+        );
+
+        self::assertSame(1, $count);
+    }
+
+    public function testCountFilteredByDraftStatusOnly(): void
+    {
+        $this->seedThreeDocumentsPerStatus();
+
+        $count = $this->repository->countByCompanyMarketplaceAndDateRange(
+            self::COMPANY_ID,
+            MarketplaceType::OZON->value,
+            new \DateTimeImmutable('2026-03-01'),
+            new \DateTimeImmutable('2026-03-31'),
+            AdRawDocumentStatus::DRAFT,
+        );
+
+        self::assertSame(1, $count);
+    }
+
+    public function testCountReturnsZeroForOtherCompanyIDOR(): void
+    {
+        $this->seedCompany(self::COMPANY_ID, self::OWNER_ID, 'a@example.test');
+        $this->seedCompany(self::OTHER_COMPANY_ID, self::OTHER_OWNER_ID, 'b@example.test');
+
+        $doc = AdRawDocumentBuilder::aRawDocument()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(1)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withReportDate(new \DateTimeImmutable('2026-03-05'))
+            ->build();
+
+        $this->repository->save($doc);
+        $this->em->flush();
+
+        $count = $this->repository->countByCompanyMarketplaceAndDateRange(
+            self::OTHER_COMPANY_ID,
+            MarketplaceType::OZON->value,
+            new \DateTimeImmutable('2026-03-01'),
+            new \DateTimeImmutable('2026-03-10'),
+        );
+
+        self::assertSame(0, $count);
+    }
+
+    public function testCountExcludesDocumentsOutsideDateRange(): void
+    {
+        $this->seedCompany(self::COMPANY_ID, self::OWNER_ID, 'a@example.test');
+
+        $inside = AdRawDocumentBuilder::aRawDocument()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(1)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withReportDate(new \DateTimeImmutable('2026-03-15'))
+            ->build();
+
+        $before = AdRawDocumentBuilder::aRawDocument()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(2)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withReportDate(new \DateTimeImmutable('2026-02-28'))
+            ->build();
+
+        $after = AdRawDocumentBuilder::aRawDocument()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(3)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withReportDate(new \DateTimeImmutable('2026-04-01'))
+            ->build();
+
+        foreach ([$inside, $before, $after] as $doc) {
+            $this->repository->save($doc);
+        }
+        $this->em->flush();
+
+        $count = $this->repository->countByCompanyMarketplaceAndDateRange(
+            self::COMPANY_ID,
+            MarketplaceType::OZON->value,
+            new \DateTimeImmutable('2026-03-01'),
+            new \DateTimeImmutable('2026-03-31'),
+        );
+
+        self::assertSame(1, $count);
+    }
+
+    public function testCountExcludesDocumentsOfOtherMarketplace(): void
+    {
+        $this->seedCompany(self::COMPANY_ID, self::OWNER_ID, 'a@example.test');
+
+        $ozon = AdRawDocumentBuilder::aRawDocument()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(1)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withReportDate(new \DateTimeImmutable('2026-03-05'))
+            ->build();
+
+        $wb = AdRawDocumentBuilder::aRawDocument()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(2)
+            ->withMarketplace(MarketplaceType::WILDBERRIES)
+            ->withReportDate(new \DateTimeImmutable('2026-03-05'))
+            ->build();
+
+        foreach ([$ozon, $wb] as $doc) {
+            $this->repository->save($doc);
+        }
+        $this->em->flush();
+
+        $count = $this->repository->countByCompanyMarketplaceAndDateRange(
+            self::COMPANY_ID,
+            MarketplaceType::OZON->value,
+            new \DateTimeImmutable('2026-03-01'),
+            new \DateTimeImmutable('2026-03-10'),
+        );
+
+        self::assertSame(1, $count);
+    }
+
+    private function seedThreeDocumentsPerStatus(): void
+    {
+        $this->seedCompany(self::COMPANY_ID, self::OWNER_ID, 'a@example.test');
+
+        $draft = AdRawDocumentBuilder::aRawDocument()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(1)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withReportDate(new \DateTimeImmutable('2026-03-02'))
+            ->build();
+
+        $processed = AdRawDocumentBuilder::aRawDocument()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(2)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withReportDate(new \DateTimeImmutable('2026-03-05'))
+            ->asProcessed()
+            ->build();
+
+        $failed = AdRawDocumentBuilder::aRawDocument()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(3)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withReportDate(new \DateTimeImmutable('2026-03-10'))
+            ->asFailed('oops')
+            ->build();
+
+        foreach ([$draft, $processed, $failed] as $doc) {
+            $this->repository->save($doc);
+        }
+        $this->em->flush();
     }
 
     private function seedCompany(string $companyId, string $ownerId, string $email): Company


### PR DESCRIPTION
## Summary

Задача 5a — добавлены два новых Repository-метода с интерфейсами и интеграционными тестами.

- `AdRawDocumentRepositoryInterface::countByCompanyMarketplaceAndDateRange(companyId, marketplace, from, to, ?status)` — DBAL `SELECT COUNT(*)` с IDOR-фильтром по `company_id`, `BETWEEN` по `report_date` и опциональным фильтром по статусу.
- `AdLoadJobRepositoryInterface::markCompleted(jobId, companyId): int` — raw UPDATE симметричный `markFailed`: `status IN ('pending','running')` → идемпотентный повторный вызов на терминальном статусе возвращает `0`; `company_id` в `WHERE` — встроенный IDOR-guard.
- Интерфейсы привязаны к реализациям в `site/config/services.yaml` (рядом с `AdChunkProgressRepositoryInterface`).
- Handler'ы (`ProcessAdRawDocumentHandler`, `FetchOzonAdStatisticsHandler`, `LoadOzonAdStatisticsRangeHandler`), Entity и миграции не тронуты.

## Tests

`AdRawDocumentRepositoryTest`:
- count без фильтра возвращает все в диапазоне
- count с фильтром PROCESSED / FAILED / DRAFT возвращает только соответствующие
- IDOR: чужой `companyId` → 0
- документ с датой вне диапазона не попадает
- документ другого marketplace не попадает

`AdLoadJobRepositoryTest`:
- markCompleted из RUNNING → 1 affected, status = COMPLETED, `finished_at` установлен
- markCompleted из PENDING → 1 affected
- markCompleted повтор на COMPLETED → 0 affected, `finished_at` не меняется
- markCompleted на FAILED → 0 affected, `failure_reason` сохранён
- IDOR: чужой `companyId` → 0 affected, статус не меняется

## Test plan

- [ ] `make site-test-int` — прогнать `--filter AdRawDocumentRepositoryTest` и `--filter AdLoadJobRepositoryTest` в интеграционном окружении.
- [ ] Убедиться, что DI-контейнер собирается с новыми биндингами интерфейсов.

https://claude.ai/code/session_01QXqpA3y15AYRYPi1JPPzVe