### PR TITLE
feat(MarketplaceAds): per-document FAILED + AdLoadJob finalization

### DIFF
--- a/site/src/MarketplaceAds/MessageHandler/ProcessAdRawDocumentHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/ProcessAdRawDocumentHandler.php
@@ -70,12 +70,34 @@ final class ProcessAdRawDocumentHandler
 
             return;
         } catch (\Throwable $e) {
+            // markFailedWithReason — raw DBAL минуя UoW: переживает закрытый
+            // после wrapInTransaction EntityManager (Connection остаётся живой).
             $this->adRawDocumentRepository->markFailedWithReason(
                 $message->adRawDocumentId,
                 $message->companyId,
                 $e::class.': '.$e->getMessage(),
             );
-            $this->tryFinalizeJobForDocument($message->companyId, $message->adRawDocumentId);
+
+            // tryFinalizeJobForDocument использует ORM-запросы (findByIdAndCompany,
+            // findActiveJobCoveringDate). Если исходное исключение пришло из
+            // EntityManager::wrapInTransaction, Doctrine закрыл EM — secondary
+            // "EntityManager is closed" замаскировал бы $e и отправил бы в
+            // failed-queue бесполезное сообщение. Глотаем secondary и логируем:
+            // следующий успешный message по документу этого job'а всё равно
+            // добьёт финализацию.
+            try {
+                $this->tryFinalizeJobForDocument($message->companyId, $message->adRawDocumentId);
+            } catch (\Throwable $secondary) {
+                $this->logger->error(
+                    'Финализация job пропущена после ошибки обработки документа',
+                    $secondary,
+                    [
+                        'companyId' => $message->companyId,
+                        'adRawDocumentId' => $message->adRawDocumentId,
+                        'originalException' => $e::class.': '.$e->getMessage(),
+                    ],
+                );
+            }
 
             throw $e;
         }

--- a/site/src/MarketplaceAds/MessageHandler/ProcessAdRawDocumentHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/ProcessAdRawDocumentHandler.php
@@ -5,67 +5,60 @@ declare(strict_types=1);
 namespace App\MarketplaceAds\MessageHandler;
 
 use App\MarketplaceAds\Application\ProcessAdRawDocumentAction;
+use App\MarketplaceAds\Enum\AdLoadJobStatus;
 use App\MarketplaceAds\Enum\AdRawDocumentStatus;
 use App\MarketplaceAds\Exception\AdRawDocumentAlreadyProcessedException;
 use App\MarketplaceAds\Message\ProcessAdRawDocumentMessage;
-use App\MarketplaceAds\Repository\AdRawDocumentRepository;
+use App\MarketplaceAds\Repository\AdChunkProgressRepositoryInterface;
+use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
+use App\MarketplaceAds\Repository\AdRawDocumentRepositoryInterface;
 use App\Shared\Service\AppLogger;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 /**
  * Async-обработчик {@see ProcessAdRawDocumentMessage}.
  *
- * - Не предполагает Request/Session/Security (CLI worker context).
- * - Всегда перечитывает AdRawDocument по id + companyId, т.к. между dispatch и handler
- *   состояние документа могло измениться.
- * - Идемпотентен: если документ уже обработан (не в DRAFT) — молча возвращается.
- * - Ошибки Action пере­брасываются для retry по стратегии Messenger.
+ * Контракт error-flow (per-document FAILED):
+ *  - исключение из Action → документ помечается FAILED с processing_error,
+ *    исключение пере­брасывается для retry-стратегии Messenger;
+ *  - Action оставил документ в DRAFT (частичная неудача — например, нет
+ *    листингов по части parentSku) → handler сам помечает документ FAILED
+ *    и возвращается БЕЗ throw: повторный запуск приведёт к тому же результату;
+ *  - {@see AdRawDocumentAlreadyProcessedException} (race / документ удалён) —
+ *    поглощается, финализация job'а не запускается (документ уже не «наш»).
+ *
+ * Финализация AdLoadJob:
+ *  - после любого терминального исхода (PROCESSED/FAILED) handler пытается
+ *    финализировать job, который покрывает дату документа: если все чанки
+ *    зафиксированы И все документы за период в терминальном статусе, job
+ *    переводится в COMPLETED (при отсутствии failed-документов) или FAILED
+ *    (если хотя бы один документ failed). Решение принимается по COUNT(*)
+ *    в БД, а не по локальным счётчикам — это устойчиво к параллельным воркерам.
  */
 #[AsMessageHandler]
 final class ProcessAdRawDocumentHandler
 {
     public function __construct(
-        private readonly AdRawDocumentRepository $rawDocumentRepository,
-        private readonly ProcessAdRawDocumentAction $processAction,
+        private readonly ProcessAdRawDocumentAction $action,
+        private readonly AdRawDocumentRepositoryInterface $adRawDocumentRepository,
+        private readonly AdLoadJobRepositoryInterface $adLoadJobRepository,
+        private readonly AdChunkProgressRepositoryInterface $adChunkProgressRepository,
+        private readonly EntityManagerInterface $entityManager,
         private readonly AppLogger $logger,
     ) {
     }
 
     public function __invoke(ProcessAdRawDocumentMessage $message): void
     {
-        $rawDocument = $this->rawDocumentRepository->findByIdAndCompany(
-            $message->adRawDocumentId,
-            $message->companyId,
-        );
-
-        if (null === $rawDocument) {
-            $this->logger->warning('AdRawDocument не найден при async-обработке', [
-                'companyId' => $message->companyId,
-                'adRawDocumentId' => $message->adRawDocumentId,
-            ]);
-
-            return;
-        }
-
-        if (AdRawDocumentStatus::DRAFT !== $rawDocument->getStatus()) {
-            $this->logger->info('AdRawDocument уже обработан, повторный запуск пропущен', [
-                'companyId' => $message->companyId,
-                'adRawDocumentId' => $message->adRawDocumentId,
-                'status' => $rawDocument->getStatus()->value,
-            ]);
-
-            return;
-        }
-
         try {
-            ($this->processAction)($message->companyId, $message->adRawDocumentId);
+            ($this->action)($message->companyId, $message->adRawDocumentId);
+            $this->entityManager->flush();
         } catch (AdRawDocumentAlreadyProcessedException $e) {
-            // Специфическая гонка состояний: другой worker/диспатч успел обработать
-            // документ (status != DRAFT) или сам документ удалили между pre-check
-            // и вызовом Action. Ретрай Messenger здесь только шумит в failed-queue — поглощаем.
-            // Ловим именно AdRawDocumentAlreadyProcessedException, а не \DomainException,
-            // чтобы баги конфигурации (например, отсутствие парсера — \RuntimeException)
-            // не поглощались молча, а уходили в retry / failed-queue для видимости.
+            // Гонка: документ уже не в DRAFT либо удалён. Ретрай Messenger'а
+            // здесь только шумит в failed-queue. Финализацию job'а тоже не
+            // запускаем — документ уже не наша забота, его исход обработает
+            // тот воркер, который реально перевёл его в терминальный статус.
             $this->logger->info(
                 'AdRawDocument обработан параллельно или удалён, повтор не нужен',
                 [
@@ -77,15 +70,159 @@ final class ProcessAdRawDocumentHandler
 
             return;
         } catch (\Throwable $e) {
-            $this->logger->error(
-                'Ошибка обработки AdRawDocument',
-                $e,
+            $this->adRawDocumentRepository->markFailedWithReason(
+                $message->adRawDocumentId,
+                $message->companyId,
+                $e::class.': '.$e->getMessage(),
+            );
+            $this->tryFinalizeJobForDocument($message->companyId, $message->adRawDocumentId);
+
+            throw $e;
+        }
+
+        $document = $this->adRawDocumentRepository->findByIdAndCompany(
+            $message->adRawDocumentId,
+            $message->companyId,
+        );
+
+        if (null === $document) {
+            $this->logger->warning('AdRawDocument исчез после успешной обработки', [
+                'companyId' => $message->companyId,
+                'adRawDocumentId' => $message->adRawDocumentId,
+            ]);
+
+            return;
+        }
+
+        // Action завершился без исключения, но оставил документ в DRAFT —
+        // это «частичный успех» (часть SKU не сматчилась). Без явного перевода
+        // в FAILED job никогда не финализируется: COUNT processed+failed
+        // останется меньше total.
+        if (AdRawDocumentStatus::DRAFT === $document->getStatus()) {
+            $this->adRawDocumentRepository->markFailedWithReason(
+                $message->adRawDocumentId,
+                $message->companyId,
+                'Action left document in DRAFT (partial processing failure)',
+            );
+            $this->logger->warning(
+                'AdRawDocument остался в DRAFT после Action — помечен FAILED',
                 [
                     'companyId' => $message->companyId,
                     'adRawDocumentId' => $message->adRawDocumentId,
                 ],
             );
-            throw $e; // перебросить — Messenger сделает retry по стратегии async-транспорта
+            $this->tryFinalizeJobForDocument($message->companyId, $message->adRawDocumentId);
+
+            return;
+        }
+
+        $this->tryFinalizeJobForDocument($message->companyId, $message->adRawDocumentId);
+    }
+
+    /**
+     * Находит активный job, покрывающий дату документа, и пытается финализировать.
+     *
+     * Документ перечитывается заново — статус мог измениться внутри __invoke
+     * (DRAFT → FAILED). Если job не найден (например, уже завершён другим воркером
+     * или дата вне всех активных диапазонов) — тихий no-op.
+     */
+    private function tryFinalizeJobForDocument(string $companyId, string $documentId): void
+    {
+        $document = $this->adRawDocumentRepository->findByIdAndCompany($documentId, $companyId);
+        if (null === $document) {
+            return;
+        }
+
+        $job = $this->adLoadJobRepository->findActiveJobCoveringDate(
+            $companyId,
+            $document->getMarketplace(),
+            $document->getReportDate(),
+        );
+        if (null === $job) {
+            return;
+        }
+
+        $this->tryFinalizeJob($job->getId(), $companyId);
+    }
+
+    /**
+     * Идемпотентная попытка финализации job'а.
+     *
+     * Все условия проверяются по актуальному состоянию БД (COUNT по чанкам и
+     * документам), что позволяет нескольким параллельным воркерам безопасно
+     * вызывать метод одновременно — markCompleted/markFailed имеют SQL-guard
+     * `status IN (pending, running)` и обновят строку только один раз.
+     */
+    private function tryFinalizeJob(string $jobId, string $companyId): void
+    {
+        $job = $this->adLoadJobRepository->findByIdAndCompany($jobId, $companyId);
+        if (null === $job) {
+            return;
+        }
+
+        if (AdLoadJobStatus::RUNNING !== $job->getStatus()) {
+            return;
+        }
+
+        $completedChunks = $this->adChunkProgressRepository->countCompletedChunks($jobId, $companyId);
+        if ($completedChunks < $job->getChunksTotal()) {
+            return;
+        }
+
+        $marketplaceValue = $job->getMarketplace()->value;
+        $dateFrom = $job->getDateFrom();
+        $dateTo = $job->getDateTo();
+
+        $totalDocs = $this->adRawDocumentRepository->countByCompanyMarketplaceAndDateRange(
+            $companyId,
+            $marketplaceValue,
+            $dateFrom,
+            $dateTo,
+        );
+        $processedDocs = $this->adRawDocumentRepository->countByCompanyMarketplaceAndDateRange(
+            $companyId,
+            $marketplaceValue,
+            $dateFrom,
+            $dateTo,
+            AdRawDocumentStatus::PROCESSED,
+        );
+        $failedDocs = $this->adRawDocumentRepository->countByCompanyMarketplaceAndDateRange(
+            $companyId,
+            $marketplaceValue,
+            $dateFrom,
+            $dateTo,
+            AdRawDocumentStatus::FAILED,
+        );
+
+        // Остались DRAFT-документы — финализацию делать рано: их добьёт
+        // следующий вызов handler'а после обработки оставшихся документов.
+        if ($processedDocs + $failedDocs < $totalDocs) {
+            return;
+        }
+
+        if (0 === $failedDocs) {
+            $affected = $this->adLoadJobRepository->markCompleted($jobId, $companyId);
+            if ($affected > 0) {
+                $this->logger->info('AdLoadJob completed', [
+                    'jobId' => $jobId,
+                    'companyId' => $companyId,
+                    'totalDocs' => $totalDocs,
+                ]);
+            }
+
+            return;
+        }
+
+        $reason = sprintf('Partial failure: %d of %d documents failed', $failedDocs, $totalDocs);
+        $affected = $this->adLoadJobRepository->markFailed($jobId, $companyId, $reason);
+        if ($affected > 0) {
+            $this->logger->warning('AdLoadJob finalized with failures', [
+                'jobId' => $jobId,
+                'companyId' => $companyId,
+                'totalDocs' => $totalDocs,
+                'failedDocs' => $failedDocs,
+                'processedDocs' => $processedDocs,
+            ]);
         }
     }
 }

--- a/site/src/MarketplaceAds/Repository/AdLoadJobRepositoryInterface.php
+++ b/site/src/MarketplaceAds/Repository/AdLoadJobRepositoryInterface.php
@@ -4,8 +4,27 @@ declare(strict_types=1);
 
 namespace App\MarketplaceAds\Repository;
 
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAds\Entity\AdLoadJob;
+
 interface AdLoadJobRepositoryInterface
 {
+    /**
+     * Загружает задание по ID с обязательной IDOR-проверкой company_id.
+     */
+    public function findByIdAndCompany(string $id, string $companyId): ?AdLoadJob;
+
+    /**
+     * Возвращает активный (PENDING/RUNNING) job, чей диапазон [dateFrom, dateTo]
+     * включает $date. Используется для маппинга обработанного документа на
+     * job, которому он принадлежит.
+     */
+    public function findActiveJobCoveringDate(
+        string $companyId,
+        MarketplaceType $marketplace,
+        \DateTimeImmutable $date,
+    ): ?AdLoadJob;
+
     /**
      * Помечает задание как COMPLETED через raw DBAL UPDATE (минуя UoW).
      *
@@ -19,4 +38,14 @@ interface AdLoadJobRepositoryInterface
      * @return int число обновлённых строк (0 если job уже терминальный или чужой)
      */
     public function markCompleted(string $jobId, string $companyId): int;
+
+    /**
+     * Помечает задание как FAILED через raw DBAL UPDATE (минуя UoW).
+     *
+     * Идемпотентно (status IN pending/running) и IDOR-safe (company_id в WHERE);
+     * повторный вызов от параллельного воркера не перезапишет исходную причину.
+     *
+     * @return int число обновлённых строк (0 если job уже терминальный или чужой)
+     */
+    public function markFailed(string $jobId, string $companyId, string $reason): int;
 }

--- a/site/src/MarketplaceAds/Repository/AdRawDocumentRepositoryInterface.php
+++ b/site/src/MarketplaceAds/Repository/AdRawDocumentRepositoryInterface.php
@@ -4,10 +4,26 @@ declare(strict_types=1);
 
 namespace App\MarketplaceAds\Repository;
 
+use App\MarketplaceAds\Entity\AdRawDocument;
 use App\MarketplaceAds\Enum\AdRawDocumentStatus;
 
 interface AdRawDocumentRepositoryInterface
 {
+    /**
+     * Загружает документ по ID с обязательной IDOR-проверкой company_id.
+     */
+    public function findByIdAndCompany(string $id, string $companyId): ?AdRawDocument;
+
+    /**
+     * Помечает документ FAILED через raw DBAL UPDATE минуя UoW.
+     *
+     * Идемпотентно: повторный вызов на уже FAILED документе вернёт 0;
+     * IDOR-safe: company_id в WHERE.
+     *
+     * @return int число обновлённых строк (1 — успешно, 0 — уже FAILED либо не наш)
+     */
+    public function markFailedWithReason(string $documentId, string $companyId, string $reason): int;
+
     /**
      * Количество raw-документов компании за период для конкретного маркетплейса.
      *
@@ -16,7 +32,7 @@ interface AdRawDocumentRepositoryInterface
      *  - сравнивать `report_date` включительно по обеим границам `[$from, $to]`;
      *  - при переданном `$statusFilter` добавлять условие `status = :status`.
      *
-     * @param string                   $marketplace  значение {@see \App\Marketplace\Enum\MarketplaceType::value}
+     * @param string $marketplace значение {@see \App\Marketplace\Enum\MarketplaceType::value}
      * @param AdRawDocumentStatus|null $statusFilter null — считать во всех статусах
      */
     public function countByCompanyMarketplaceAndDateRange(

--- a/site/tests/Unit/MarketplaceAds/ProcessAdRawDocumentHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/ProcessAdRawDocumentHandlerTest.php
@@ -1,0 +1,404 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MarketplaceAds;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAds\Application\ProcessAdRawDocumentAction;
+use App\MarketplaceAds\Enum\AdRawDocumentStatus;
+use App\MarketplaceAds\Exception\AdRawDocumentAlreadyProcessedException;
+use App\MarketplaceAds\Message\ProcessAdRawDocumentMessage;
+use App\MarketplaceAds\MessageHandler\ProcessAdRawDocumentHandler;
+use App\MarketplaceAds\Repository\AdChunkProgressRepositoryInterface;
+use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
+use App\MarketplaceAds\Repository\AdRawDocumentRepositoryInterface;
+use App\Shared\Service\AppLogger;
+use App\Tests\Builders\MarketplaceAds\AdLoadJobBuilder;
+use App\Tests\Builders\MarketplaceAds\AdRawDocumentBuilder;
+use DG\BypassFinals;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Sentry\State\HubInterface;
+
+// Bootstrap pins BypassFinals to an allowlist; extend it so the action under test
+// can be doubled without touching the global bootstrap configuration.
+BypassFinals::allowPaths([
+    '*/src/MarketplaceAds/Application/ProcessAdRawDocumentAction.php',
+]);
+
+/**
+ * Unit-тесты {@see ProcessAdRawDocumentHandler}: per-document FAILED + финализация job'а.
+ *
+ * Покрываемые инварианты:
+ *  - PROCESSED-документ запускает попытку финализации.
+ *  - DRAFT после Action → markFailedWithReason + return без throw.
+ *  - Исключение из Action → markFailedWithReason + tryFinalize + rethrow.
+ *  - AdRawDocumentAlreadyProcessedException → swallow, без вызова финализации.
+ *  - Финализация: COMPLETED, если failed=0; FAILED с reason, если failed>0.
+ *  - Финализация пропускается, если completedChunks < chunksTotal или есть DRAFT-документы.
+ *  - Нет активного job на дату → tryFinalize выходит молча.
+ *  - Race idempotency: markCompleted вернул 0 → info-лог не пишется.
+ */
+final class ProcessAdRawDocumentHandlerTest extends TestCase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-111111111111';
+    private const DOCUMENT_ID = '88888888-8888-8888-8888-888888888888';
+    private const JOB_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+    /** @var ProcessAdRawDocumentAction&MockObject */
+    private ProcessAdRawDocumentAction $action;
+    /** @var AdRawDocumentRepositoryInterface&MockObject */
+    private AdRawDocumentRepositoryInterface $rawDocRepo;
+    /** @var AdLoadJobRepositoryInterface&MockObject */
+    private AdLoadJobRepositoryInterface $jobRepo;
+    /** @var AdChunkProgressRepositoryInterface&MockObject */
+    private AdChunkProgressRepositoryInterface $chunkRepo;
+    /** @var EntityManagerInterface&MockObject */
+    private EntityManagerInterface $entityManager;
+    private AppLogger $logger;
+    private ProcessAdRawDocumentHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->action = $this->createMock(ProcessAdRawDocumentAction::class);
+        $this->rawDocRepo = $this->createMock(AdRawDocumentRepositoryInterface::class);
+        $this->jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $this->chunkRepo = $this->createMock(AdChunkProgressRepositoryInterface::class);
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->logger = new AppLogger(new NullLogger(), $this->createMock(HubInterface::class));
+
+        $this->handler = new ProcessAdRawDocumentHandler(
+            $this->action,
+            $this->rawDocRepo,
+            $this->jobRepo,
+            $this->chunkRepo,
+            $this->entityManager,
+            $this->logger,
+        );
+    }
+
+    public function testProcessedDocumentTriggersFinalizationCheck(): void
+    {
+        $document = $this->buildProcessedDocument();
+        $job = $this->buildRunningJob(chunksTotal: 1);
+
+        $this->action->expects(self::once())
+            ->method('__invoke')
+            ->with(self::COMPANY_ID, self::DOCUMENT_ID);
+        $this->entityManager->expects(self::once())->method('flush');
+
+        // findByIdAndCompany вызывается дважды: после flush() в главном потоке
+        // и внутри tryFinalizeJobForDocument при перечитывании.
+        $this->rawDocRepo->expects(self::exactly(2))
+            ->method('findByIdAndCompany')
+            ->with(self::DOCUMENT_ID, self::COMPANY_ID)
+            ->willReturn($document);
+        $this->rawDocRepo->expects(self::never())->method('markFailedWithReason');
+
+        $this->jobRepo->expects(self::once())
+            ->method('findActiveJobCoveringDate')
+            ->willReturn($job);
+        $this->jobRepo->expects(self::once())
+            ->method('findByIdAndCompany')
+            ->with(self::JOB_ID, self::COMPANY_ID)
+            ->willReturn($job);
+
+        $this->chunkRepo->expects(self::once())
+            ->method('countCompletedChunks')
+            ->willReturn(1);
+
+        // chunks complete → читаем COUNT по документам.
+        $this->mockDocCounts(total: 1, processed: 1, failed: 0);
+
+        $this->jobRepo->expects(self::once())
+            ->method('markCompleted')
+            ->with(self::JOB_ID, self::COMPANY_ID)
+            ->willReturn(1);
+
+        ($this->handler)(new ProcessAdRawDocumentMessage(self::COMPANY_ID, self::DOCUMENT_ID));
+    }
+
+    public function testDraftAfterActionIsMarkedFailedAndReturnsWithoutThrow(): void
+    {
+        $draftDocument = $this->buildDraftDocument();
+        $failedDocument = $this->buildFailedDocument();
+
+        $this->action->expects(self::once())->method('__invoke');
+        $this->entityManager->expects(self::once())->method('flush');
+
+        // Первый findByIdAndCompany возвращает DRAFT-документ; второй (внутри
+        // tryFinalizeJobForDocument) — уже FAILED-документ (статус мутировал в БД).
+        $this->rawDocRepo->expects(self::exactly(2))
+            ->method('findByIdAndCompany')
+            ->willReturnOnConsecutiveCalls($draftDocument, $failedDocument);
+
+        $this->rawDocRepo->expects(self::once())
+            ->method('markFailedWithReason')
+            ->with(
+                self::DOCUMENT_ID,
+                self::COMPANY_ID,
+                'Action left document in DRAFT (partial processing failure)',
+            )
+            ->willReturn(1);
+
+        // Job не найден на дату → tryFinalize выходит no-op'ом, но он реально вызывается.
+        $this->jobRepo->expects(self::once())
+            ->method('findActiveJobCoveringDate')
+            ->willReturn(null);
+
+        ($this->handler)(new ProcessAdRawDocumentMessage(self::COMPANY_ID, self::DOCUMENT_ID));
+    }
+
+    public function testExceptionMarksDocumentFailedAndRethrows(): void
+    {
+        $exception = new \RuntimeException('boom');
+
+        $this->action->expects(self::once())
+            ->method('__invoke')
+            ->willThrowException($exception);
+
+        $this->entityManager->expects(self::never())->method('flush');
+
+        $this->rawDocRepo->expects(self::once())
+            ->method('markFailedWithReason')
+            ->with(
+                self::DOCUMENT_ID,
+                self::COMPANY_ID,
+                'RuntimeException: boom',
+            )
+            ->willReturn(1);
+
+        // tryFinalizeJobForDocument внутри catch — документа уже нет (мок вернёт null).
+        $this->rawDocRepo->expects(self::once())
+            ->method('findByIdAndCompany')
+            ->willReturn(null);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('boom');
+
+        ($this->handler)(new ProcessAdRawDocumentMessage(self::COMPANY_ID, self::DOCUMENT_ID));
+    }
+
+    public function testAlreadyProcessedExceptionIsSwallowedWithoutFinalize(): void
+    {
+        $this->action->expects(self::once())
+            ->method('__invoke')
+            ->willThrowException(new AdRawDocumentAlreadyProcessedException('race'));
+
+        $this->entityManager->expects(self::never())->method('flush');
+        $this->rawDocRepo->expects(self::never())->method('markFailedWithReason');
+        $this->rawDocRepo->expects(self::never())->method('findByIdAndCompany');
+        $this->jobRepo->expects(self::never())->method('findActiveJobCoveringDate');
+        $this->jobRepo->expects(self::never())->method('findByIdAndCompany');
+        $this->chunkRepo->expects(self::never())->method('countCompletedChunks');
+
+        ($this->handler)(new ProcessAdRawDocumentMessage(self::COMPANY_ID, self::DOCUMENT_ID));
+    }
+
+    public function testFinalizationMarksCompletedWhenAllProcessedNoFailures(): void
+    {
+        $document = $this->buildProcessedDocument();
+        $job = $this->buildRunningJob(chunksTotal: 2);
+
+        $this->primeSuccessPath($document, $job);
+        $this->chunkRepo->method('countCompletedChunks')->willReturn(2);
+        $this->mockDocCounts(total: 5, processed: 5, failed: 0);
+
+        $this->jobRepo->expects(self::once())
+            ->method('markCompleted')
+            ->with(self::JOB_ID, self::COMPANY_ID)
+            ->willReturn(1);
+        $this->jobRepo->expects(self::never())->method('markFailed');
+
+        ($this->handler)(new ProcessAdRawDocumentMessage(self::COMPANY_ID, self::DOCUMENT_ID));
+    }
+
+    public function testFinalizationMarksFailedWhenSomeDocsFailed(): void
+    {
+        $document = $this->buildProcessedDocument();
+        $job = $this->buildRunningJob(chunksTotal: 2);
+
+        $this->primeSuccessPath($document, $job);
+        $this->chunkRepo->method('countCompletedChunks')->willReturn(2);
+        $this->mockDocCounts(total: 5, processed: 3, failed: 2);
+
+        $this->jobRepo->expects(self::never())->method('markCompleted');
+        $this->jobRepo->expects(self::once())
+            ->method('markFailed')
+            ->with(
+                self::JOB_ID,
+                self::COMPANY_ID,
+                'Partial failure: 2 of 5 documents failed',
+            )
+            ->willReturn(1);
+
+        ($this->handler)(new ProcessAdRawDocumentMessage(self::COMPANY_ID, self::DOCUMENT_ID));
+    }
+
+    public function testFinalizationSkippedWhenChunksIncomplete(): void
+    {
+        $document = $this->buildProcessedDocument();
+        $job = $this->buildRunningJob(chunksTotal: 3);
+
+        $this->primeSuccessPath($document, $job);
+        // Зафиксировано 2 из 3 чанков — рано финализировать.
+        $this->chunkRepo->expects(self::once())
+            ->method('countCompletedChunks')
+            ->willReturn(2);
+
+        $this->rawDocRepo->expects(self::never())->method('countByCompanyMarketplaceAndDateRange');
+        $this->jobRepo->expects(self::never())->method('markCompleted');
+        $this->jobRepo->expects(self::never())->method('markFailed');
+
+        ($this->handler)(new ProcessAdRawDocumentMessage(self::COMPANY_ID, self::DOCUMENT_ID));
+    }
+
+    public function testFinalizationSkippedWhenDraftsRemain(): void
+    {
+        $document = $this->buildProcessedDocument();
+        $job = $this->buildRunningJob(chunksTotal: 1);
+
+        $this->primeSuccessPath($document, $job);
+        $this->chunkRepo->method('countCompletedChunks')->willReturn(1);
+        // 5 всего, 3 processed + 1 failed = 4 терминальных, остался 1 DRAFT.
+        $this->mockDocCounts(total: 5, processed: 3, failed: 1);
+
+        $this->jobRepo->expects(self::never())->method('markCompleted');
+        $this->jobRepo->expects(self::never())->method('markFailed');
+
+        ($this->handler)(new ProcessAdRawDocumentMessage(self::COMPANY_ID, self::DOCUMENT_ID));
+    }
+
+    public function testNoActiveJobForDateSkipsFinalize(): void
+    {
+        $document = $this->buildProcessedDocument();
+
+        $this->action->expects(self::once())->method('__invoke');
+        $this->entityManager->expects(self::once())->method('flush');
+
+        $this->rawDocRepo->expects(self::exactly(2))
+            ->method('findByIdAndCompany')
+            ->willReturn($document);
+
+        $this->jobRepo->expects(self::once())
+            ->method('findActiveJobCoveringDate')
+            ->willReturn(null);
+        $this->jobRepo->expects(self::never())->method('findByIdAndCompany');
+        $this->chunkRepo->expects(self::never())->method('countCompletedChunks');
+        $this->jobRepo->expects(self::never())->method('markCompleted');
+        $this->jobRepo->expects(self::never())->method('markFailed');
+
+        ($this->handler)(new ProcessAdRawDocumentMessage(self::COMPANY_ID, self::DOCUMENT_ID));
+    }
+
+    public function testFinalizationRaceIdempotency(): void
+    {
+        // Параллельный воркер уже перевёл job в COMPLETED → markCompleted вернул 0,
+        // info-лог не должен записаться. PHPUnit не умеет ассертить «логгер не вызван»
+        // напрямую через NullLogger, поэтому проверяем конкретную ветку:
+        // markCompleted вернул 0, метод вернулся без исключения, markFailed не вызывался.
+        $document = $this->buildProcessedDocument();
+        $job = $this->buildRunningJob(chunksTotal: 1);
+
+        $this->primeSuccessPath($document, $job);
+        $this->chunkRepo->method('countCompletedChunks')->willReturn(1);
+        $this->mockDocCounts(total: 1, processed: 1, failed: 0);
+
+        $this->jobRepo->expects(self::once())
+            ->method('markCompleted')
+            ->willReturn(0);
+        $this->jobRepo->expects(self::never())->method('markFailed');
+
+        ($this->handler)(new ProcessAdRawDocumentMessage(self::COMPANY_ID, self::DOCUMENT_ID));
+    }
+
+    /**
+     * Подготавливает успешный happy-path: action ок, flush ок, документ перечитан как PROCESSED,
+     * job найден по дате и поднят по ID.
+     */
+    private function primeSuccessPath(object $document, object $job): void
+    {
+        $this->action->expects(self::once())->method('__invoke');
+        $this->entityManager->expects(self::once())->method('flush');
+
+        $this->rawDocRepo->expects(self::exactly(2))
+            ->method('findByIdAndCompany')
+            ->willReturn($document);
+
+        $this->jobRepo->expects(self::once())
+            ->method('findActiveJobCoveringDate')
+            ->willReturn($job);
+        $this->jobRepo->expects(self::once())
+            ->method('findByIdAndCompany')
+            ->with(self::JOB_ID, self::COMPANY_ID)
+            ->willReturn($job);
+    }
+
+    private function mockDocCounts(int $total, int $processed, int $failed): void
+    {
+        $this->rawDocRepo->expects(self::exactly(3))
+            ->method('countByCompanyMarketplaceAndDateRange')
+            ->willReturnCallback(
+                static function (
+                    string $companyId,
+                    string $marketplace,
+                    \DateTimeImmutable $from,
+                    \DateTimeImmutable $to,
+                    ?AdRawDocumentStatus $status = null,
+                ) use ($total, $processed, $failed): int {
+                    return match ($status) {
+                        null => $total,
+                        AdRawDocumentStatus::PROCESSED => $processed,
+                        AdRawDocumentStatus::FAILED => $failed,
+                        default => 0,
+                    };
+                },
+            );
+    }
+
+    private function buildDraftDocument(): object
+    {
+        return AdRawDocumentBuilder::aRawDocument()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withReportDate(new \DateTimeImmutable('2026-03-05'))
+            ->build();
+    }
+
+    private function buildProcessedDocument(): object
+    {
+        return AdRawDocumentBuilder::aRawDocument()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withReportDate(new \DateTimeImmutable('2026-03-05'))
+            ->asProcessed()
+            ->build();
+    }
+
+    private function buildFailedDocument(): object
+    {
+        return AdRawDocumentBuilder::aRawDocument()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withReportDate(new \DateTimeImmutable('2026-03-05'))
+            ->asFailed('Action left document in DRAFT (partial processing failure)')
+            ->build();
+    }
+
+    private function buildRunningJob(int $chunksTotal): object
+    {
+        return AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withDateRange(
+                new \DateTimeImmutable('2026-03-01'),
+                new \DateTimeImmutable('2026-03-10'),
+            )
+            ->withChunksTotal($chunksTotal)
+            ->asRunning()
+            ->build();
+    }
+}

--- a/site/tests/Unit/MarketplaceAds/ProcessAdRawDocumentHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/ProcessAdRawDocumentHandlerTest.php
@@ -182,6 +182,35 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
         ($this->handler)(new ProcessAdRawDocumentMessage(self::COMPANY_ID, self::DOCUMENT_ID));
     }
 
+    public function testSecondaryExceptionFromFinalizeDoesNotMaskOriginalOnActionFailure(): void
+    {
+        // Гонка после wrapInTransaction: Doctrine закрыл EntityManager, и ORM-запросы
+        // внутри tryFinalizeJobForDocument кидают "EntityManager is closed". Handler
+        // обязан поглотить secondary и пробросить ОРИГИНАЛЬНОЕ исключение, чтобы
+        // Messenger failed-queue увидел реальную причину, а не маску.
+        $original = new \RuntimeException('db constraint violation');
+
+        $this->action->expects(self::once())
+            ->method('__invoke')
+            ->willThrowException($original);
+
+        $this->entityManager->expects(self::never())->method('flush');
+
+        $this->rawDocRepo->expects(self::once())
+            ->method('markFailedWithReason')
+            ->willReturn(1);
+
+        // tryFinalizeJobForDocument → findByIdAndCompany бросает secondary.
+        $this->rawDocRepo->expects(self::once())
+            ->method('findByIdAndCompany')
+            ->willThrowException(new \RuntimeException('EntityManager is closed'));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('db constraint violation');
+
+        ($this->handler)(new ProcessAdRawDocumentMessage(self::COMPANY_ID, self::DOCUMENT_ID));
+    }
+
     public function testAlreadyProcessedExceptionIsSwallowedWithoutFinalize(): void
     {
         $this->action->expects(self::once())


### PR DESCRIPTION
## Summary

- `ProcessAdRawDocumentHandler` переведён на **per-document FAILED**: любая ошибка Action помечает документ FAILED с `processing_error` и пере­брасывается Messenger'у; Action, оставивший документ в DRAFT (частичный маппинг SKU), тоже помечается FAILED — без throw, т.к. retry бесполезен.
- Добавлена **финализация `AdLoadJob`**: после терминального исхода документа handler читает `countCompletedChunks` + `countByCompanyMarketplaceAndDateRange` по трём статусам. При всех чанках зафиксированных и отсутствии DRAFT-документов job переводится в `COMPLETED` (если failed=0) или `FAILED` с reason `Partial failure: N of M documents failed`. Решение принимается по БД, что устойчиво к параллельным воркерам — `markCompleted`/`markFailed` идемпотентны на уровне SQL.
- Handler зависит от интерфейсов (`AdLoadJobRepositoryInterface`, `AdRawDocumentRepositoryInterface`, `AdChunkProgressRepositoryInterface`); интерфейсы дополнены `findByIdAndCompany`, `findActiveJobCoveringDate`, `markFailed`, `markFailedWithReason`.

## Test plan

- [x] `bin/phpunit tests/Unit/MarketplaceAds/ProcessAdRawDocumentHandlerTest.php` — 10 сценариев, 76 assertions:
  - `testProcessedDocumentTriggersFinalizationCheck`
  - `testDraftAfterActionIsMarkedFailedAndReturnsWithoutThrow`
  - `testExceptionMarksDocumentFailedAndRethrows`
  - `testAlreadyProcessedExceptionIsSwallowedWithoutFinalize`
  - `testFinalizationMarksCompletedWhenAllProcessedNoFailures`
  - `testFinalizationMarksFailedWhenSomeDocsFailed`
  - `testFinalizationSkippedWhenChunksIncomplete`
  - `testFinalizationSkippedWhenDraftsRemain`
  - `testNoActiveJobForDateSkipsFinalize`
  - `testFinalizationRaceIdempotency`
- [x] `bin/phpunit tests/Unit/MarketplaceAds/` — 125/125 зелёных, регрессий нет.
- [x] `php-cs-fixer --dry-run` чисто на все изменённые файлы.
