### PR TITLE
feat(MarketplaceAds): UI для запуска и мониторинга загрузки рекламы Ozon (Задача 6)

### DIFF
--- a/site/src/Marketplace/Controller/MarketplaceController.php
+++ b/site/src/Marketplace/Controller/MarketplaceController.php
@@ -21,6 +21,7 @@ use App\Marketplace\Message\TriggerInitialSyncMessage;
 use App\Marketplace\Repository\MarketplaceConnectionRepository;
 use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
 use App\Marketplace\Service\Integration\MarketplaceAdapterRegistry;
+use App\MarketplaceAds\Repository\AdLoadJobRepository;
 use App\Company\Repository\ProjectDirectionRepository;
 use App\Shared\Service\ActiveCompanyService;
 use Doctrine\ORM\EntityManagerInterface;
@@ -51,6 +52,7 @@ class MarketplaceController extends AbstractController
         private readonly MessageBusInterface              $messageBus,
         private readonly ReprocessMarketplacePeriodAction $reprocessAction,
         private readonly SyncConnectionAction             $syncConnectionAction,
+        private readonly AdLoadJobRepository              $adLoadJobRepository,
     ) {
     }
 
@@ -71,10 +73,16 @@ class MarketplaceController extends AbstractController
             50,
         );
 
+        $activeOzonAdLoadJob = $this->adLoadJobRepository->findLatestActiveJobByCompanyAndMarketplace(
+            $company->getId(),
+            MarketplaceType::OZON,
+        );
+
         return $this->render('marketplace/index.html.twig', [
             'connections'           => $connections,
             'rawDocumentsPager'     => $rawDocumentsPager,
             'availableMarketplaces' => MarketplaceType::cases(),
+            'activeOzonAdLoadJob'   => $activeOzonAdLoadJob,
         ]);
     }
 

--- a/site/src/MarketplaceAds/Application/DispatchOzonAdLoadAction.php
+++ b/site/src/MarketplaceAds/Application/DispatchOzonAdLoadAction.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Application;
+
+use App\Marketplace\Enum\MarketplaceConnectionType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Facade\MarketplaceFacade;
+use App\MarketplaceAds\Entity\AdLoadJob;
+use App\MarketplaceAds\Message\LoadOzonAdStatisticsRangeMessage;
+use App\MarketplaceAds\Repository\AdLoadJobRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class DispatchOzonAdLoadAction
+{
+    public function __construct(
+        private readonly MarketplaceFacade $marketplaceFacade,
+        private readonly AdLoadJobRepository $adLoadJobRepository,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly MessageBusInterface $messageBus,
+    ) {}
+
+    public function __invoke(
+        string $companyId,
+        \DateTimeImmutable $dateFrom,
+        \DateTimeImmutable $dateTo,
+    ): AdLoadJob {
+        $credentials = $this->marketplaceFacade->getConnectionCredentials(
+            $companyId,
+            MarketplaceType::OZON,
+            MarketplaceConnectionType::PERFORMANCE,
+        );
+
+        if (null === $credentials) {
+            throw new \DomainException('Ozon Performance connection not configured');
+        }
+
+        $dateFromNorm = $dateFrom->setTime(0, 0);
+        $dateToNorm = $dateTo->setTime(0, 0);
+
+        if ($dateFromNorm > $dateToNorm) {
+            throw new \DomainException('Дата начала не может быть позже даты окончания.');
+        }
+
+        $yesterday = (new \DateTimeImmutable('yesterday'))->setTime(0, 0);
+        if ($dateToNorm > $yesterday) {
+            throw new \DomainException('Нельзя загружать данные за будущие даты. Дата окончания должна быть не позже вчерашнего дня.');
+        }
+
+        $activeJob = $this->adLoadJobRepository->findLatestActiveJobByCompanyAndMarketplace(
+            $companyId,
+            MarketplaceType::OZON,
+        );
+
+        if (null !== $activeJob) {
+            throw new \DomainException('Load already in progress');
+        }
+
+        $job = new AdLoadJob($companyId, MarketplaceType::OZON, $dateFrom, $dateTo);
+        $this->adLoadJobRepository->save($job);
+        $this->entityManager->flush();
+
+        $this->messageBus->dispatch(new LoadOzonAdStatisticsRangeMessage($job->getId()));
+
+        return $job;
+    }
+}

--- a/site/src/MarketplaceAds/Application/DispatchOzonAdLoadAction.php
+++ b/site/src/MarketplaceAds/Application/DispatchOzonAdLoadAction.php
@@ -62,7 +62,13 @@ final class DispatchOzonAdLoadAction
         $this->adLoadJobRepository->save($job);
         $this->entityManager->flush();
 
-        $this->messageBus->dispatch(new LoadOzonAdStatisticsRangeMessage($job->getId()));
+        try {
+            $this->messageBus->dispatch(new LoadOzonAdStatisticsRangeMessage($job->getId()));
+        } catch (\Throwable $e) {
+            $job->markFailed('Dispatch error: ' . $e->getMessage());
+            $this->entityManager->flush();
+            throw new \RuntimeException('Failed to queue ad load job: ' . $e->getMessage(), 0, $e);
+        }
 
         return $job;
     }

--- a/site/src/MarketplaceAds/Controller/Api/OzonAdInitialLoadController.php
+++ b/site/src/MarketplaceAds/Controller/Api/OzonAdInitialLoadController.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Controller\Api;
+
+use App\MarketplaceAds\Application\DispatchOzonAdLoadAction;
+use App\Shared\Service\ActiveCompanyService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route('/api/marketplace-ads/ozon/initial-load', name: 'marketplace_ads_ozon_initial_load', methods: ['POST'])]
+#[IsGranted('ROLE_COMPANY_USER')]
+final class OzonAdInitialLoadController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $companyService,
+        private readonly DispatchOzonAdLoadAction $dispatchAction,
+    ) {}
+
+    public function __invoke(): JsonResponse
+    {
+        $company = $this->companyService->getActiveCompany();
+        $companyId = $company->getId();
+
+        $now = new \DateTimeImmutable();
+        $dateFrom = new \DateTimeImmutable($now->format('Y') . '-01-01');
+        $dateTo = (new \DateTimeImmutable('yesterday'))->setTime(0, 0);
+
+        try {
+            $job = ($this->dispatchAction)($companyId, $dateFrom, $dateTo);
+
+            return $this->json([
+                'jobId' => $job->getId(),
+                'statusUrl' => $this->generateUrl(
+                    'marketplace_ads_ozon_load_job_status',
+                    ['jobId' => $job->getId()],
+                ),
+            ]);
+        } catch (\DomainException $e) {
+            return $this->json(['message' => $e->getMessage()], 400);
+        }
+    }
+}

--- a/site/src/MarketplaceAds/Controller/Api/OzonAdLoadJobStatusController.php
+++ b/site/src/MarketplaceAds/Controller/Api/OzonAdLoadJobStatusController.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Controller\Api;
+
+use App\MarketplaceAds\Enum\AdRawDocumentStatus;
+use App\MarketplaceAds\Repository\AdChunkProgressRepository;
+use App\MarketplaceAds\Repository\AdLoadJobRepository;
+use App\MarketplaceAds\Repository\AdRawDocumentRepository;
+use App\Shared\Service\ActiveCompanyService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route('/api/marketplace-ads/ozon/load-jobs/{jobId}/status', name: 'marketplace_ads_ozon_load_job_status', methods: ['GET'])]
+#[IsGranted('ROLE_COMPANY_USER')]
+final class OzonAdLoadJobStatusController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $companyService,
+        private readonly AdLoadJobRepository $adLoadJobRepository,
+        private readonly AdChunkProgressRepository $chunkProgressRepository,
+        private readonly AdRawDocumentRepository $rawDocumentRepository,
+    ) {}
+
+    public function __invoke(string $jobId): JsonResponse
+    {
+        $company = $this->companyService->getActiveCompany();
+        $companyId = $company->getId();
+
+        $job = $this->adLoadJobRepository->findByIdAndCompany($jobId, $companyId);
+
+        if (null === $job) {
+            return $this->json(['message' => 'Задание не найдено.'], 404);
+        }
+
+        $completedChunks = $this->chunkProgressRepository->countCompletedChunks($jobId, $companyId);
+
+        $marketplace = $job->getMarketplace()->value;
+        $dateFrom = $job->getDateFrom();
+        $dateTo = $job->getDateTo();
+
+        $totalDocs = $this->rawDocumentRepository->countByCompanyMarketplaceAndDateRange(
+            $companyId, $marketplace, $dateFrom, $dateTo,
+        );
+        $processedDocs = $this->rawDocumentRepository->countByCompanyMarketplaceAndDateRange(
+            $companyId, $marketplace, $dateFrom, $dateTo, AdRawDocumentStatus::PROCESSED,
+        );
+        $failedDocs = $this->rawDocumentRepository->countByCompanyMarketplaceAndDateRange(
+            $companyId, $marketplace, $dateFrom, $dateTo, AdRawDocumentStatus::FAILED,
+        );
+
+        $chunksTotal = $job->getChunksTotal();
+        $progress = $chunksTotal > 0
+            ? min(100, (int) floor(($completedChunks / $chunksTotal) * 100))
+            : 0;
+
+        return $this->json([
+            'jobId' => $job->getId(),
+            'status' => $job->getStatus()->value,
+            'dateFrom' => $job->getDateFrom()->format('d.m.Y H:i'),
+            'dateTo' => $job->getDateTo()->format('d.m.Y H:i'),
+            'totalDays' => $job->getTotalDays(),
+            'chunksTotal' => $chunksTotal,
+            'completedChunks' => $completedChunks,
+            'totalDocs' => $totalDocs,
+            'processedDocs' => $processedDocs,
+            'failedDocs' => $failedDocs,
+            'progress' => $progress,
+            'lastError' => $job->getFailureReason(),
+            'startedAt' => $job->getStartedAt()?->format('d.m.Y H:i'),
+            'finishedAt' => $job->getFinishedAt()?->format('d.m.Y H:i'),
+        ]);
+    }
+}

--- a/site/src/MarketplaceAds/Controller/Api/OzonAdLoadRangeController.php
+++ b/site/src/MarketplaceAds/Controller/Api/OzonAdLoadRangeController.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Controller\Api;
+
+use App\MarketplaceAds\Application\DispatchOzonAdLoadAction;
+use App\Shared\Service\ActiveCompanyService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route('/api/marketplace-ads/ozon/load-range', name: 'marketplace_ads_ozon_load_range', methods: ['POST'])]
+#[IsGranted('ROLE_COMPANY_OWNER')]
+final class OzonAdLoadRangeController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $companyService,
+        private readonly DispatchOzonAdLoadAction $dispatchAction,
+    ) {}
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        $company = $this->companyService->getActiveCompany();
+        $companyId = $company->getId();
+
+        $body = json_decode($request->getContent(), true) ?? [];
+        $dateFromStr = (string) ($body['dateFrom'] ?? '');
+        $dateToStr = (string) ($body['dateTo'] ?? '');
+
+        $dateFrom = \DateTimeImmutable::createFromFormat('!Y-m-d', $dateFromStr);
+        $dateTo = \DateTimeImmutable::createFromFormat('!Y-m-d', $dateToStr);
+
+        if (false === $dateFrom || false === $dateTo) {
+            return $this->json(['message' => 'Неверный формат даты. Ожидается YYYY-MM-DD.'], 400);
+        }
+
+        try {
+            $job = ($this->dispatchAction)($companyId, $dateFrom, $dateTo);
+
+            return $this->json([
+                'jobId' => $job->getId(),
+                'statusUrl' => $this->generateUrl(
+                    'marketplace_ads_ozon_load_job_status',
+                    ['jobId' => $job->getId()],
+                ),
+            ]);
+        } catch (\DomainException | \InvalidArgumentException $e) {
+            return $this->json(['message' => $e->getMessage()], 400);
+        }
+    }
+}

--- a/site/src/MarketplaceAds/Controller/Api/OzonAdLoadRangeController.php
+++ b/site/src/MarketplaceAds/Controller/Api/OzonAdLoadRangeController.php
@@ -33,7 +33,11 @@ final class OzonAdLoadRangeController extends AbstractController
         $dateFrom = \DateTimeImmutable::createFromFormat('!Y-m-d', $dateFromStr);
         $dateTo = \DateTimeImmutable::createFromFormat('!Y-m-d', $dateToStr);
 
-        if (false === $dateFrom || false === $dateTo) {
+        if (false === $dateFrom || $dateFrom->format('Y-m-d') !== $dateFromStr) {
+            return $this->json(['message' => 'Неверный формат даты. Ожидается YYYY-MM-DD.'], 400);
+        }
+
+        if (false === $dateTo || $dateTo->format('Y-m-d') !== $dateToStr) {
             return $this->json(['message' => 'Неверный формат даты. Ожидается YYYY-MM-DD.'], 400);
         }
 

--- a/site/templates/marketplace/index.html.twig
+++ b/site/templates/marketplace/index.html.twig
@@ -71,6 +71,32 @@
                                                 <small>Ошибка: {{ connection.lastSyncError|slice(0, 100) }}</small>
                                             </div>
                                         {% endif %}
+                                        {% if not isSeller and connection.marketplace.value == 'ozon' and activeOzonAdLoadJob is not null %}
+                                            <div class="mt-2" id="ozon-ad-load-widget"
+                                                 data-ad-job-id="{{ activeOzonAdLoadJob.id }}"
+                                                 data-ad-job-status="{{ activeOzonAdLoadJob.status.value }}">
+                                                {% if activeOzonAdLoadJob.status.isTerminal %}
+                                                    {% if activeOzonAdLoadJob.status.value == 'completed' %}
+                                                        <div class="alert alert-success mb-0 py-2">
+                                                            <small>Реклама Ozon загружена</small>
+                                                        </div>
+                                                    {% else %}
+                                                        <div class="alert alert-danger mb-0 py-2">
+                                                            <small>Ошибка загрузки: {{ activeOzonAdLoadJob.failureReason }}</small>
+                                                        </div>
+                                                    {% endif %}
+                                                {% else %}
+                                                    <div class="d-flex align-items-center gap-2 mb-1">
+                                                        <span class="spinner-border spinner-border-sm text-indigo"></span>
+                                                        <small class="text-muted">Загрузка рекламы Ozon...</small>
+                                                    </div>
+                                                    <div class="progress mb-1" style="height:6px;">
+                                                        <div class="progress-bar bg-indigo" id="ozon-ad-progress-bar" style="width:0%"></div>
+                                                    </div>
+                                                    <small class="text-muted" id="ozon-ad-counters">Чанков: —, Документов: —</small>
+                                                {% endif %}
+                                            </div>
+                                        {% endif %}
                                     </div>
                                     <div class="col-auto">
                                         <span class="badge bg-{{ connection.isActive ? 'success' : 'secondary' }}">
@@ -104,6 +130,20 @@
                                                         data-marketplace="{{ connection.marketplace.value }}">
                                                     Переобработать
                                                 </button>
+                                            {% elseif connection.marketplace.value == 'ozon' %}
+                                                <button type="button"
+                                                        class="btn btn-sm btn-outline-indigo"
+                                                        data-ozon-initial-load="1">
+                                                    Загрузить рекламу с начала года
+                                                </button>
+                                                {% if is_granted('ROLE_COMPANY_OWNER') %}
+                                                    <button type="button"
+                                                            class="btn btn-sm btn-outline-secondary"
+                                                            data-bs-toggle="modal"
+                                                            data-bs-target="#modal-ozon-ad-load-range">
+                                                        Загрузить за период
+                                                    </button>
+                                                {% endif %}
                                             {% endif %}
                                             <form method="post" action="{{ path('marketplace_connection_toggle', {id: connection.id}) }}" style="display:inline">
                                                 <input type="hidden" name="_token" value="{{ csrf_token('toggle' ~ connection.id) }}">
@@ -484,6 +524,36 @@
         </div>
     </div>
 
+    {# Modal: Загрузить рекламу Ozon за произвольный период (только ROLE_COMPANY_OWNER) #}
+    {% if is_granted('ROLE_COMPANY_OWNER') %}
+    <div class="modal modal-blur fade" id="modal-ozon-ad-load-range" tabindex="-1" role="dialog" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Загрузить рекламу Ozon за период</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label class="form-label required">Дата начала</label>
+                        <input type="date" id="ozon-ad-range-from" class="form-control" required
+                               value="{{ 'now'|date_modify('first day of last month')|date('Y-m-d') }}">
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label required">Дата окончания</label>
+                        <input type="date" id="ozon-ad-range-to" class="form-control" required
+                               value="{{ 'now'|date_modify('last day of last month')|date('Y-m-d') }}">
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn" data-bs-dismiss="modal">Отмена</button>
+                    <button type="button" class="btn btn-indigo" id="btn-ozon-ad-load-range">Загрузить</button>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
     {# Modal: Пакетная обработка за месяц #}
     <div class="modal modal-blur fade" id="bulkProcessModal" tabindex="-1" role="dialog" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered" role="document">
@@ -731,6 +801,106 @@
                         .catch(function () { /* сеть недоступна — продолжаем опрос */ });
                 }, 15000);
             });
+        })();
+
+        // Кнопка «Загрузить рекламу с начала года»
+        (function () {
+            var btns = document.querySelectorAll('[data-ozon-initial-load]');
+            btns.forEach(function (btn) {
+                btn.addEventListener('click', function () {
+                    btn.disabled = true;
+                    btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Запуск...';
+                    fetch('{{ path('marketplace_ads_ozon_initial_load') }}', {
+                        method: 'POST',
+                        credentials: 'same-origin',
+                        headers: {'X-Requested-With': 'XMLHttpRequest'},
+                    })
+                        .then(function (r) { return r.json().then(function (d) { return {ok: r.ok, data: d}; }); })
+                        .then(function (res) {
+                            if (res.ok) {
+                                window.location.reload();
+                            } else {
+                                alert('Ошибка: ' + (res.data.message ?? 'Неизвестная ошибка'));
+                                btn.disabled = false;
+                                btn.innerHTML = 'Загрузить рекламу с начала года';
+                            }
+                        })
+                        .catch(function (err) {
+                            alert('Ошибка сети: ' + err.message);
+                            btn.disabled = false;
+                            btn.innerHTML = 'Загрузить рекламу с начала года';
+                        });
+                });
+            });
+        })();
+
+        // Кнопка «Загрузить за период» в модалке
+        (function () {
+            var btn = document.getElementById('btn-ozon-ad-load-range');
+            if (!btn) return;
+            btn.addEventListener('click', function () {
+                var dateFrom = (document.getElementById('ozon-ad-range-from') || {}).value;
+                var dateTo   = (document.getElementById('ozon-ad-range-to') || {}).value;
+                if (!dateFrom || !dateTo) { alert('Укажите обе даты'); return; }
+                btn.disabled = true;
+                btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Запуск...';
+                fetch('{{ path('marketplace_ads_ozon_load_range') }}', {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
+                    body: JSON.stringify({dateFrom: dateFrom, dateTo: dateTo}),
+                })
+                    .then(function (r) { return r.json().then(function (d) { return {ok: r.ok, data: d}; }); })
+                    .then(function (res) {
+                        if (res.ok) {
+                            window.location.reload();
+                        } else {
+                            var BootstrapModal = window.bootstrap && window.bootstrap.Modal;
+                            if (BootstrapModal) {
+                                BootstrapModal.getOrCreateInstance(document.getElementById('modal-ozon-ad-load-range')).hide();
+                            }
+                            alert('Ошибка: ' + (res.data.message ?? 'Неизвестная ошибка'));
+                            btn.disabled = false;
+                            btn.innerHTML = 'Загрузить';
+                        }
+                    })
+                    .catch(function (err) {
+                        alert('Ошибка сети: ' + err.message);
+                        btn.disabled = false;
+                        btn.innerHTML = 'Загрузить';
+                    });
+            });
+        })();
+
+        // Поллер прогресса загрузки рекламы Ozon (15 сек)
+        (function () {
+            var widget = document.getElementById('ozon-ad-load-widget');
+            if (!widget) return;
+            var status = widget.dataset.adJobStatus;
+            if (status === 'completed' || status === 'failed') return; // терминальный — не поллим
+
+            var jobId    = widget.dataset.adJobId;
+            var statusUrl = '/api/marketplace-ads/ozon/load-jobs/' + jobId + '/status';
+            var bar      = document.getElementById('ozon-ad-progress-bar');
+            var counters = document.getElementById('ozon-ad-counters');
+
+            var interval = setInterval(function () {
+                fetch(statusUrl, {headers: {'X-Requested-With': 'XMLHttpRequest'}})
+                    .then(function (r) { return r.json(); })
+                    .then(function (data) {
+                        if (bar) bar.style.width = data.progress + '%';
+                        if (counters) {
+                            counters.textContent = 'Чанков: ' + data.completedChunks + '/' + data.chunksTotal
+                                + ', Документов: ' + data.totalDocs
+                                + ' (' + data.processedDocs + ' обработано, ' + data.failedDocs + ' ошибок)';
+                        }
+                        if (data.status === 'completed' || data.status === 'failed') {
+                            clearInterval(interval);
+                            window.location.reload();
+                        }
+                    })
+                    .catch(function () { /* сеть — продолжаем */ });
+            }, 15000);
         })();
     </script>
 {% endblock %}

--- a/site/templates/marketplace/index.html.twig
+++ b/site/templates/marketplace/index.html.twig
@@ -72,9 +72,11 @@
                                             </div>
                                         {% endif %}
                                         {% if not isSeller and connection.marketplace.value == 'ozon' and activeOzonAdLoadJob is not null %}
-                                            <div class="mt-2" id="ozon-ad-load-widget"
+                                            <div class="mt-2"
+                                                 id="ozon-ad-load-widget-{{ connection.id }}"
                                                  data-ad-job-id="{{ activeOzonAdLoadJob.id }}"
-                                                 data-ad-job-status="{{ activeOzonAdLoadJob.status.value }}">
+                                                 data-ad-job-status="{{ activeOzonAdLoadJob.status.value }}"
+                                                 data-status-url="{{ path('marketplace_ads_ozon_load_job_status', {jobId: activeOzonAdLoadJob.id}) }}">
                                                 {% if activeOzonAdLoadJob.status.isTerminal %}
                                                     {% if activeOzonAdLoadJob.status.value == 'completed' %}
                                                         <div class="alert alert-success mb-0 py-2">
@@ -91,9 +93,9 @@
                                                         <small class="text-muted">Загрузка рекламы Ozon...</small>
                                                     </div>
                                                     <div class="progress mb-1" style="height:6px;">
-                                                        <div class="progress-bar bg-indigo" id="ozon-ad-progress-bar" style="width:0%"></div>
+                                                        <div class="progress-bar bg-indigo ozon-ad-progress-bar" style="width:0%"></div>
                                                     </div>
-                                                    <small class="text-muted" id="ozon-ad-counters">Чанков: —, Документов: —</small>
+                                                    <small class="text-muted ozon-ad-counters">Чанков: —, Документов: —</small>
                                                 {% endif %}
                                             </div>
                                         {% endif %}
@@ -874,33 +876,32 @@
 
         // Поллер прогресса загрузки рекламы Ozon (15 сек)
         (function () {
-            var widget = document.getElementById('ozon-ad-load-widget');
-            if (!widget) return;
-            var status = widget.dataset.adJobStatus;
-            if (status === 'completed' || status === 'failed') return; // терминальный — не поллим
+            document.querySelectorAll('[data-ad-job-id]').forEach(function (widget) {
+                var status = widget.dataset.adJobStatus;
+                if (status === 'completed' || status === 'failed') return;
 
-            var jobId    = widget.dataset.adJobId;
-            var statusUrl = '/api/marketplace-ads/ozon/load-jobs/' + jobId + '/status';
-            var bar      = document.getElementById('ozon-ad-progress-bar');
-            var counters = document.getElementById('ozon-ad-counters');
+                var statusUrl = widget.dataset.statusUrl;
+                var bar      = widget.querySelector('.ozon-ad-progress-bar');
+                var counters = widget.querySelector('.ozon-ad-counters');
 
-            var interval = setInterval(function () {
-                fetch(statusUrl, {headers: {'X-Requested-With': 'XMLHttpRequest'}})
-                    .then(function (r) { return r.json(); })
-                    .then(function (data) {
-                        if (bar) bar.style.width = data.progress + '%';
-                        if (counters) {
-                            counters.textContent = 'Чанков: ' + data.completedChunks + '/' + data.chunksTotal
-                                + ', Документов: ' + data.totalDocs
-                                + ' (' + data.processedDocs + ' обработано, ' + data.failedDocs + ' ошибок)';
-                        }
-                        if (data.status === 'completed' || data.status === 'failed') {
-                            clearInterval(interval);
-                            window.location.reload();
-                        }
-                    })
-                    .catch(function () { /* сеть — продолжаем */ });
-            }, 15000);
+                var interval = setInterval(function () {
+                    fetch(statusUrl, {headers: {'X-Requested-With': 'XMLHttpRequest'}})
+                        .then(function (r) { return r.json(); })
+                        .then(function (data) {
+                            if (bar) bar.style.width = data.progress + '%';
+                            if (counters) {
+                                counters.textContent = 'Чанков: ' + data.completedChunks + '/' + data.chunksTotal
+                                    + ', Документов: ' + data.totalDocs
+                                    + ' (' + data.processedDocs + ' обработано, ' + data.failedDocs + ' ошибок)';
+                            }
+                            if (data.status === 'completed' || data.status === 'failed') {
+                                clearInterval(interval);
+                                window.location.reload();
+                            }
+                        })
+                        .catch(function () { /* сеть — продолжаем */ });
+                }, 15000);
+            });
         })();
     </script>
 {% endblock %}

--- a/site/tests/Integration/MarketplaceAds/OzonAdInitialLoadControllerTest.php
+++ b/site/tests/Integration/MarketplaceAds/OzonAdInitialLoadControllerTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\MarketplaceAds;
+
+use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Enum\MarketplaceConnectionType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAds\Entity\AdLoadJob;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+use Ramsey\Uuid\Uuid;
+
+final class OzonAdInitialLoadControllerTest extends WebTestCaseBase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-a00000000001';
+    private const OWNER_ID   = '22222222-2222-2222-2222-a00000000001';
+
+    public function testHappyPathReturns200WithJobId(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('ozon-ads-init@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        $connection = new MarketplaceConnection(
+            Uuid::uuid4()->toString(),
+            $company,
+            MarketplaceType::OZON,
+            MarketplaceConnectionType::PERFORMANCE,
+        );
+        $connection->setApiKey('test-client-secret');
+        $connection->setClientId('test-client-id@advertising.performance.ozon.ru');
+        $em->persist($connection);
+        $em->flush();
+
+        $client->loginUser($owner);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', self::COMPANY_ID);
+        $session->save();
+
+        $client->request('POST', '/api/marketplace-ads/ozon/initial-load', [], [], [
+            'HTTP_X-Requested-With' => 'XMLHttpRequest',
+        ]);
+
+        self::assertResponseIsSuccessful();
+
+        $data = json_decode($client->getResponse()->getContent(), true);
+        self::assertArrayHasKey('jobId', $data);
+        self::assertArrayHasKey('statusUrl', $data);
+        self::assertNotEmpty($data['jobId']);
+
+        // Job was persisted to DB
+        $job = $em->find(AdLoadJob::class, $data['jobId']);
+        self::assertNotNull($job);
+        self::assertSame(self::COMPANY_ID, $job->getCompanyId());
+    }
+
+    public function testReturns400WhenNoPerformanceConnection(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('ozon-ads-no-conn@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        $client->loginUser($owner);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', self::COMPANY_ID);
+        $session->save();
+
+        $client->request('POST', '/api/marketplace-ads/ozon/initial-load', [], [], [
+            'HTTP_X-Requested-With' => 'XMLHttpRequest',
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
+
+        $data = json_decode($client->getResponse()->getContent(), true);
+        self::assertArrayHasKey('message', $data);
+        self::assertStringContainsString('Ozon Performance connection not configured', $data['message']);
+    }
+}

--- a/site/tests/Integration/MarketplaceAds/OzonAdLoadJobStatusControllerTest.php
+++ b/site/tests/Integration/MarketplaceAds/OzonAdLoadJobStatusControllerTest.php
@@ -6,8 +6,6 @@ namespace App\Tests\Integration\MarketplaceAds;
 
 use App\Marketplace\Enum\MarketplaceType;
 use App\MarketplaceAds\Entity\AdLoadJob;
-use App\MarketplaceAds\Entity\AdRawDocument;
-use App\MarketplaceAds\Enum\AdRawDocumentStatus;
 use App\Tests\Builders\Company\CompanyBuilder;
 use App\Tests\Builders\Company\UserBuilder;
 use App\Tests\Builders\MarketplaceAds\AdLoadJobBuilder;

--- a/site/tests/Integration/MarketplaceAds/OzonAdLoadJobStatusControllerTest.php
+++ b/site/tests/Integration/MarketplaceAds/OzonAdLoadJobStatusControllerTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\MarketplaceAds;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAds\Entity\AdLoadJob;
+use App\MarketplaceAds\Entity\AdRawDocument;
+use App\MarketplaceAds\Enum\AdRawDocumentStatus;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Builders\MarketplaceAds\AdLoadJobBuilder;
+use App\Tests\Builders\MarketplaceAds\AdRawDocumentBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+
+final class OzonAdLoadJobStatusControllerTest extends WebTestCaseBase
+{
+    private const COMPANY_ID       = '11111111-1111-1111-1111-b00000000001';
+    private const OTHER_COMPANY_ID = '11111111-1111-1111-1111-b00000000002';
+    private const OWNER_ID         = '22222222-2222-2222-2222-b00000000001';
+
+    public function testReturns200WithCorrectCounts(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('job-status@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withDateRange(new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-10'))
+            ->withChunksTotal(2)
+            ->build();
+        $em->persist($job);
+
+        $rawDoc1 = AdRawDocumentBuilder::aRawDocument()
+            ->withIndex(1)
+            ->withCompanyId(self::COMPANY_ID)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withReportDate(new \DateTimeImmutable('2026-01-01'))
+            ->asProcessed()
+            ->build();
+
+        $rawDoc2 = AdRawDocumentBuilder::aRawDocument()
+            ->withIndex(2)
+            ->withCompanyId(self::COMPANY_ID)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withReportDate(new \DateTimeImmutable('2026-01-02'))
+            ->asFailed('test error')
+            ->build();
+
+        $em->persist($rawDoc1);
+        $em->persist($rawDoc2);
+        $em->flush();
+
+        $client->loginUser($owner);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', self::COMPANY_ID);
+        $session->save();
+
+        $client->request('GET', '/api/marketplace-ads/ozon/load-jobs/' . $job->getId() . '/status');
+
+        self::assertResponseIsSuccessful();
+
+        $data = json_decode($client->getResponse()->getContent(), true);
+
+        self::assertSame($job->getId(), $data['jobId']);
+        self::assertSame('pending', $data['status']);
+        self::assertSame(10, $data['totalDays']);
+        self::assertSame(2, $data['chunksTotal']);
+        self::assertSame(0, $data['completedChunks']);
+        self::assertSame(2, $data['totalDocs']);
+        self::assertSame(1, $data['processedDocs']);
+        self::assertSame(1, $data['failedDocs']);
+        self::assertSame(0, $data['progress']);
+        self::assertNull($data['lastError']);
+    }
+
+    public function testReturns404ForNonExistentJob(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('job-status-404@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        $client->loginUser($owner);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', self::COMPANY_ID);
+        $session->save();
+
+        $client->request('GET', '/api/marketplace-ads/ozon/load-jobs/99999999-9999-9999-9999-999999999999/status');
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    public function testIdorReturns404ForOtherCompanysJob(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('job-status-idor@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $otherOwner = UserBuilder::aUser()
+            ->withId('22222222-2222-2222-2222-b00000000002')
+            ->withEmail('job-status-idor-other@example.test')
+            ->build();
+        $otherCompany = CompanyBuilder::aCompany()
+            ->withId(self::OTHER_COMPANY_ID)
+            ->withOwner($otherOwner)
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->persist($otherOwner);
+        $em->persist($otherCompany);
+        $em->flush();
+
+        // Job belongs to otherCompany
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::OTHER_COMPANY_ID)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->build();
+        $em->persist($job);
+        $em->flush();
+
+        // Logged in as owner of company (not otherCompany)
+        $client->loginUser($owner);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', self::COMPANY_ID);
+        $session->save();
+
+        $client->request('GET', '/api/marketplace-ads/ozon/load-jobs/' . $job->getId() . '/status');
+
+        self::assertResponseStatusCodeSame(404);
+    }
+}

--- a/site/tests/Unit/MarketplaceAds/Application/DispatchOzonAdLoadActionTest.php
+++ b/site/tests/Unit/MarketplaceAds/Application/DispatchOzonAdLoadActionTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MarketplaceAds\Application;
+
+use App\Marketplace\Enum\MarketplaceConnectionType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Facade\MarketplaceFacade;
+use App\MarketplaceAds\Application\DispatchOzonAdLoadAction;
+use App\MarketplaceAds\Entity\AdLoadJob;
+use App\MarketplaceAds\Message\LoadOzonAdStatisticsRangeMessage;
+use App\MarketplaceAds\Repository\AdLoadJobRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class DispatchOzonAdLoadActionTest extends TestCase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-000000000001';
+
+    private MarketplaceFacade $marketplaceFacade;
+    private AdLoadJobRepository $adLoadJobRepository;
+    private EntityManagerInterface $entityManager;
+    private MessageBusInterface $messageBus;
+    private DispatchOzonAdLoadAction $action;
+
+    protected function setUp(): void
+    {
+        $this->marketplaceFacade   = $this->createMock(MarketplaceFacade::class);
+        $this->adLoadJobRepository = $this->createMock(AdLoadJobRepository::class);
+        $this->entityManager       = $this->createMock(EntityManagerInterface::class);
+        $this->messageBus          = $this->createMock(MessageBusInterface::class);
+
+        $this->action = new DispatchOzonAdLoadAction(
+            $this->marketplaceFacade,
+            $this->adLoadJobRepository,
+            $this->entityManager,
+            $this->messageBus,
+        );
+    }
+
+    public function testHappyPath(): void
+    {
+        $this->marketplaceFacade
+            ->method('getConnectionCredentials')
+            ->with(self::COMPANY_ID, MarketplaceType::OZON, MarketplaceConnectionType::PERFORMANCE)
+            ->willReturn(['api_key' => 'secret', 'client_id' => 'client-abc']);
+
+        $this->adLoadJobRepository
+            ->method('findLatestActiveJobByCompanyAndMarketplace')
+            ->willReturn(null);
+
+        $this->adLoadJobRepository->expects(self::once())->method('save');
+        $this->entityManager->expects(self::once())->method('flush');
+
+        $this->messageBus
+            ->expects(self::once())
+            ->method('dispatch')
+            ->with(self::isInstanceOf(LoadOzonAdStatisticsRangeMessage::class))
+            ->willReturnCallback(static fn (object $msg) => new Envelope($msg));
+
+        $dateFrom = new \DateTimeImmutable('2026-01-01');
+        $dateTo   = new \DateTimeImmutable('yesterday');
+
+        $job = ($this->action)(self::COMPANY_ID, $dateFrom, $dateTo);
+
+        self::assertInstanceOf(AdLoadJob::class, $job);
+        self::assertSame(self::COMPANY_ID, $job->getCompanyId());
+        self::assertSame(MarketplaceType::OZON, $job->getMarketplace());
+    }
+
+    public function testThrowsWhenConnectionNotConfigured(): void
+    {
+        $this->marketplaceFacade
+            ->method('getConnectionCredentials')
+            ->willReturn(null);
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('Ozon Performance connection not configured');
+
+        ($this->action)(
+            self::COMPANY_ID,
+            new \DateTimeImmutable('2026-01-01'),
+            new \DateTimeImmutable('2026-01-31'),
+        );
+    }
+
+    public function testThrowsWhenDateFromAfterDateTo(): void
+    {
+        $this->marketplaceFacade
+            ->method('getConnectionCredentials')
+            ->willReturn(['api_key' => 'key', 'client_id' => null]);
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('Дата начала не может быть позже даты окончания');
+
+        ($this->action)(
+            self::COMPANY_ID,
+            new \DateTimeImmutable('2026-03-31'),
+            new \DateTimeImmutable('2026-03-01'),
+        );
+    }
+
+    public function testThrowsWhenDateToIsInFuture(): void
+    {
+        $this->marketplaceFacade
+            ->method('getConnectionCredentials')
+            ->willReturn(['api_key' => 'key', 'client_id' => null]);
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('Нельзя загружать данные за будущие даты');
+
+        ($this->action)(
+            self::COMPANY_ID,
+            new \DateTimeImmutable('2026-01-01'),
+            new \DateTimeImmutable('+7 days'),
+        );
+    }
+
+    public function testThrowsWhenActiveJobAlreadyExists(): void
+    {
+        $this->marketplaceFacade
+            ->method('getConnectionCredentials')
+            ->willReturn(['api_key' => 'key', 'client_id' => null]);
+
+        $existingJob = new AdLoadJob(
+            self::COMPANY_ID,
+            MarketplaceType::OZON,
+            new \DateTimeImmutable('2026-01-01'),
+            new \DateTimeImmutable('2026-01-31'),
+        );
+
+        $this->adLoadJobRepository
+            ->method('findLatestActiveJobByCompanyAndMarketplace')
+            ->willReturn($existingJob);
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('Load already in progress');
+
+        ($this->action)(
+            self::COMPANY_ID,
+            new \DateTimeImmutable('2026-01-01'),
+            new \DateTimeImmutable('yesterday'),
+        );
+    }
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **DispatchOzonAdLoadAction** — Application Action с полной валидацией: проверка PERFORMANCE-подключения через `MarketplaceFacade`, dateFrom≤dateTo, dateTo≤вчера, нет активного job'а → создаёт `AdLoadJob` (PENDING), flush, dispatch `LoadOzonAdStatisticsRangeMessage`
- **3 API-контроллера** в `MarketplaceAds/Controller/Api/`:
  - `POST /api/marketplace-ads/ozon/initial-load` (ROLE_COMPANY_USER) — с начала года по вчера
  - `POST /api/marketplace-ads/ozon/load-range` (ROLE_COMPANY_OWNER) — произвольный период JSON `{dateFrom, dateTo}`
  - `GET /api/marketplace-ads/ozon/load-jobs/{jobId}/status` (ROLE_COMPANY_USER) — IDOR-safe статус с COUNT-агрегатами по чанкам и документам
- **MarketplaceController.index** — подтягивает `activeOzonAdLoadJob` для Ozon PERFORMANCE и передаёт в шаблон
- **marketplace/index.html.twig** — для Performance-подключения Ozon: кнопка «Загрузить рекламу с начала года», модалка «Загрузить за период» (OWNER only), виджет прогресса (bootstrap progress-bar + счётчики чанков/документов), inline JS-поллер (setInterval 15 сек, reload при терминальном статусе)

## Test plan

- [x] Unit-тесты `DispatchOzonAdLoadActionTest` — 5 кейсов: happy path, нет подключения, dateFrom > dateTo, dateTo в будущем, активный job уже существует
- [x] Integration-тест `OzonAdInitialLoadControllerTest` — happy path 200 с jobId, 400 при отсутствии Performance-подключения
- [x] Integration-тест `OzonAdLoadJobStatusControllerTest` — 200 с корректными COUNT-агрегатами, 404 несуществующий jobId, 404 IDOR (чужой companyId)
- [x] PHP синтаксис всех файлов проверен (`php -l`)
- [ ] Integration/functional тесты требуют подключения к БД (site-postgres) — запускать в Docker-окружении

## Архитектурные решения

- `DispatchOzonAdLoadAction` в `Application/` (не Controller) — следует паттерну Action из PATTERNS.md §3
- IDOR-safe: статус-контроллер использует `findByIdAndCompany()`, не `find()`
- `MarketplaceController` модифицирован (допустимо по правилу legacy-зоны для существующего файла)
- JS-поллер инлайн в twig — по паттерну проекта
- `window.location.reload()` после успешного POST — простейший способ показать виджет нового job'а

https://claude.ai/code/session_014ACs4yfQZRK1jfyDLhfkRK
EOF
)