### PR TITLE
feat(MarketplaceAds): daily Ozon Ads cron for yesterday

### DIFF
--- a/docker/cron/app.cron
+++ b/docker/cron/app.cron
@@ -10,6 +10,9 @@
 # Ночная синхронизация отчётов Ozon по реализации.
 0 4 * * * php bin/console app:marketplace:ozon-daily-sync --no-interaction >> /var/log/cron/app.log 2>&1
 
+# Ежедневная загрузка рекламы Ozon за вчера для всех компаний с активным Performance-подключением.
+30 4 * * * php bin/console app:marketplace-ads:ozon-daily-sync --no-interaction >> /var/log/cron/app.log 2>&1
+
 # 10-е число каждого месяца в 6:00 Загрузка отчётов о реализации Ozon
 0 6 5 * * php bin/console app:marketplace:ozon-realization-sync --env=prod >> /var/log/cron/app.log 2>&1
 

--- a/site/src/MarketplaceAds/Command/OzonAdDailySyncCommand.php
+++ b/site/src/MarketplaceAds/Command/OzonAdDailySyncCommand.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Command;
+
+use App\MarketplaceAds\Application\DispatchOzonAdLoadAction;
+use App\MarketplaceAds\Infrastructure\Query\ActiveOzonPerformanceConnectionsQuery;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Ежедневная загрузка Ozon Ads за вчерашний день для всех компаний
+ * с активным Performance-подключением.
+ *
+ * Cron: 30 4 * * * php bin/console app:marketplace-ads:ozon-daily-sync
+ *
+ * Команда тонкая: получает список активных Ozon Performance подключений через DBAL Query,
+ * для каждой компании вызывает {@see DispatchOzonAdLoadAction} с датой = «вчера».
+ * Ошибки отдельной компании не должны прерывать обработку остальных.
+ */
+#[AsCommand(
+    name: 'app:marketplace-ads:ozon-daily-sync',
+    description: 'Ежедневная загрузка рекламы Ozon за вчерашний день по всем компаниям с активным Performance-подключением.',
+)]
+final class OzonAdDailySyncCommand extends Command
+{
+    public function __construct(
+        private readonly ActiveOzonPerformanceConnectionsQuery $connectionsQuery,
+        private readonly DispatchOzonAdLoadAction $dispatchAction,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $companyIds = $this->connectionsQuery->getCompanyIds();
+        $total = count($companyIds);
+
+        if (0 === $total) {
+            $output->writeln('<info>Нет активных Ozon Performance подключений.</info>');
+
+            return Command::SUCCESS;
+        }
+
+        $yesterday = (new \DateTimeImmutable('yesterday'))->setTime(0, 0);
+
+        $dispatched = 0;
+        foreach ($companyIds as $companyId) {
+            try {
+                ($this->dispatchAction)($companyId, $yesterday, $yesterday);
+                ++$dispatched;
+            } catch (\DomainException $e) {
+                $this->logger->warning('Пропуск компании при ежедневной загрузке Ozon Ads', [
+                    'companyId' => $companyId,
+                    'reason' => $e->getMessage(),
+                ]);
+            } catch (\Throwable $e) {
+                $this->logger->error('Ошибка при ежедневной загрузке Ozon Ads', [
+                    'companyId' => $companyId,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+
+            $output->writeln(sprintf('Dispatched %d of %d companies', $dispatched, $total));
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/site/src/MarketplaceAds/Infrastructure/Query/ActiveOzonPerformanceConnectionsQuery.php
+++ b/site/src/MarketplaceAds/Infrastructure/Query/ActiveOzonPerformanceConnectionsQuery.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Infrastructure\Query;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * DBAL Query: идентификаторы компаний с активным Ozon Performance подключением.
+ *
+ * Используется в cron-команде ежедневной загрузки Ozon Ads, чтобы пройтись
+ * ровно по тем компаниям, у которых настроен Performance API.
+ */
+final class ActiveOzonPerformanceConnectionsQuery
+{
+    public function __construct(
+        private readonly Connection $connection,
+    ) {
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getCompanyIds(): array
+    {
+        $rows = $this->connection->fetchFirstColumn(
+            'SELECT company_id
+             FROM marketplace_connections
+             WHERE marketplace = :marketplace
+               AND connection_type = :connectionType
+               AND is_active = true
+             ORDER BY created_at ASC',
+            [
+                'marketplace' => 'ozon',
+                'connectionType' => 'performance',
+            ],
+        );
+
+        return array_values(array_map(static fn ($id): string => (string) $id, $rows));
+    }
+}

--- a/site/src/MarketplaceAds/Infrastructure/Query/ActiveOzonPerformanceConnectionsQuery.php
+++ b/site/src/MarketplaceAds/Infrastructure/Query/ActiveOzonPerformanceConnectionsQuery.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\MarketplaceAds\Infrastructure\Query;
 
+use App\Marketplace\Enum\MarketplaceConnectionType;
+use App\Marketplace\Enum\MarketplaceType;
 use Doctrine\DBAL\Connection;
 
 /**
@@ -32,11 +34,11 @@ final class ActiveOzonPerformanceConnectionsQuery
                AND is_active = true
              ORDER BY created_at ASC',
             [
-                'marketplace' => 'ozon',
-                'connectionType' => 'performance',
+                'marketplace' => MarketplaceType::OZON->value,
+                'connectionType' => MarketplaceConnectionType::PERFORMANCE->value,
             ],
         );
 
-        return array_values(array_map(static fn ($id): string => (string) $id, $rows));
+        return array_map(static fn ($id): string => (string) $id, $rows);
     }
 }

--- a/site/tests/Integration/MarketplaceAds/ActiveOzonPerformanceConnectionsQueryTest.php
+++ b/site/tests/Integration/MarketplaceAds/ActiveOzonPerformanceConnectionsQueryTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\MarketplaceAds;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Enum\MarketplaceConnectionType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAds\Infrastructure\Query\ActiveOzonPerformanceConnectionsQuery;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class ActiveOzonPerformanceConnectionsQueryTest extends IntegrationTestCase
+{
+    private const COMPANY_PERF_ACTIVE_1 = '11111111-1111-1111-1111-0a0000000001';
+    private const COMPANY_PERF_ACTIVE_2 = '11111111-1111-1111-1111-0a0000000002';
+    private const COMPANY_PERF_INACTIVE = '11111111-1111-1111-1111-0a0000000003';
+    private const COMPANY_SELLER_ONLY = '11111111-1111-1111-1111-0a0000000004';
+
+    private ActiveOzonPerformanceConnectionsQuery $query;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->query = self::getContainer()->get(ActiveOzonPerformanceConnectionsQuery::class);
+    }
+
+    public function testReturnsOnlyCompaniesWithActivePerformanceConnection(): void
+    {
+        $activeOne = $this->seedCompany(self::COMPANY_PERF_ACTIVE_1, 'perf-active-1@example.test', 1);
+        $activeTwo = $this->seedCompany(self::COMPANY_PERF_ACTIVE_2, 'perf-active-2@example.test', 2);
+        $inactive = $this->seedCompany(self::COMPANY_PERF_INACTIVE, 'perf-inactive@example.test', 3);
+        $sellerOnly = $this->seedCompany(self::COMPANY_SELLER_ONLY, 'seller-only@example.test', 4);
+
+        $this->em->persist($this->buildConnection($activeOne, MarketplaceType::OZON, MarketplaceConnectionType::PERFORMANCE, true));
+        $this->em->persist($this->buildConnection($activeTwo, MarketplaceType::OZON, MarketplaceConnectionType::PERFORMANCE, true));
+        $this->em->persist($this->buildConnection($inactive, MarketplaceType::OZON, MarketplaceConnectionType::PERFORMANCE, false));
+        $this->em->persist($this->buildConnection($sellerOnly, MarketplaceType::OZON, MarketplaceConnectionType::SELLER, true));
+
+        $this->em->flush();
+
+        $companyIds = $this->query->getCompanyIds();
+
+        self::assertContains(self::COMPANY_PERF_ACTIVE_1, $companyIds);
+        self::assertContains(self::COMPANY_PERF_ACTIVE_2, $companyIds);
+        self::assertNotContains(self::COMPANY_PERF_INACTIVE, $companyIds, 'Inactive performance connections must be excluded');
+        self::assertNotContains(self::COMPANY_SELLER_ONLY, $companyIds, 'Seller-only companies must be excluded even for Ozon');
+        self::assertCount(2, $companyIds);
+    }
+
+    public function testDoesNotReturnSellerOzonConnection(): void
+    {
+        $company = $this->seedCompany(self::COMPANY_SELLER_ONLY, 'seller-only@example.test', 1);
+        $this->em->persist($this->buildConnection($company, MarketplaceType::OZON, MarketplaceConnectionType::SELLER, true));
+        $this->em->flush();
+
+        self::assertSame([], $this->query->getCompanyIds());
+    }
+
+    public function testDoesNotReturnInactivePerformanceConnection(): void
+    {
+        $company = $this->seedCompany(self::COMPANY_PERF_INACTIVE, 'perf-inactive@example.test', 1);
+        $this->em->persist($this->buildConnection($company, MarketplaceType::OZON, MarketplaceConnectionType::PERFORMANCE, false));
+        $this->em->flush();
+
+        self::assertSame([], $this->query->getCompanyIds());
+    }
+
+    public function testReturnsEmptyListWhenNoConnections(): void
+    {
+        self::assertSame([], $this->query->getCompanyIds());
+    }
+
+    private function seedCompany(string $companyId, string $email, int $index): Company
+    {
+        $owner = UserBuilder::aUser()
+            ->withIndex($index)
+            ->withEmail($email)
+            ->build();
+
+        $company = CompanyBuilder::aCompany()
+            ->withId($companyId)
+            ->withOwner($owner)
+            ->build();
+
+        $this->em->persist($owner);
+        $this->em->persist($company);
+
+        return $company;
+    }
+
+    private function buildConnection(
+        Company $company,
+        MarketplaceType $marketplace,
+        MarketplaceConnectionType $type,
+        bool $isActive,
+    ): MarketplaceConnection {
+        $connection = new MarketplaceConnection(
+            Uuid::uuid4()->toString(),
+            $company,
+            $marketplace,
+            $type,
+        );
+        $connection->setApiKey('api-key');
+        $connection->setClientId('client-id');
+        $connection->setIsActive($isActive);
+
+        return $connection;
+    }
+}

--- a/site/tests/Unit/MarketplaceAds/Command/OzonAdDailySyncCommandTest.php
+++ b/site/tests/Unit/MarketplaceAds/Command/OzonAdDailySyncCommandTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MarketplaceAds\Command;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAds\Application\DispatchOzonAdLoadAction;
+use App\MarketplaceAds\Command\OzonAdDailySyncCommand;
+use App\MarketplaceAds\Entity\AdLoadJob;
+use App\MarketplaceAds\Infrastructure\Query\ActiveOzonPerformanceConnectionsQuery;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class OzonAdDailySyncCommandTest extends TestCase
+{
+    private const COMPANY_1 = '11111111-1111-1111-1111-000000000001';
+    private const COMPANY_2 = '11111111-1111-1111-1111-000000000002';
+    private const COMPANY_3 = '11111111-1111-1111-1111-000000000003';
+
+    public function testDispatchesForEachCompanyWithYesterdayDate(): void
+    {
+        $yesterday = (new \DateTimeImmutable('yesterday'))->setTime(0, 0);
+        $companyIds = [self::COMPANY_1, self::COMPANY_2, self::COMPANY_3];
+
+        $query = $this->createMock(ActiveOzonPerformanceConnectionsQuery::class);
+        $query->method('getCompanyIds')->willReturn($companyIds);
+
+        $action = $this->createMock(DispatchOzonAdLoadAction::class);
+
+        $receivedCompanies = [];
+        $action
+            ->expects(self::exactly(3))
+            ->method('__invoke')
+            ->willReturnCallback(function (string $companyId, \DateTimeImmutable $from, \DateTimeImmutable $to) use ($yesterday, &$receivedCompanies): AdLoadJob {
+                self::assertEquals($yesterday, $from);
+                self::assertEquals($yesterday, $to);
+                $receivedCompanies[] = $companyId;
+
+                return new AdLoadJob($companyId, MarketplaceType::OZON, $from, $to);
+            });
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::never())->method('warning');
+        $logger->expects(self::never())->method('error');
+
+        $tester = $this->makeTester($query, $action, $logger);
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertSame($companyIds, $receivedCompanies);
+
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('Dispatched 1 of 3 companies', $display);
+        self::assertStringContainsString('Dispatched 2 of 3 companies', $display);
+        self::assertStringContainsString('Dispatched 3 of 3 companies', $display);
+    }
+
+    public function testSucceedsWhenNoCompanies(): void
+    {
+        $query = $this->createMock(ActiveOzonPerformanceConnectionsQuery::class);
+        $query->method('getCompanyIds')->willReturn([]);
+
+        $action = $this->createMock(DispatchOzonAdLoadAction::class);
+        $action->expects(self::never())->method('__invoke');
+
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $tester = $this->makeTester($query, $action, $logger);
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('Нет активных Ozon Performance подключений', $tester->getDisplay());
+    }
+
+    public function testContinuesAfterDomainExceptionOnOneCompany(): void
+    {
+        $companyIds = [self::COMPANY_1, self::COMPANY_2, self::COMPANY_3];
+
+        $query = $this->createMock(ActiveOzonPerformanceConnectionsQuery::class);
+        $query->method('getCompanyIds')->willReturn($companyIds);
+
+        $action = $this->createMock(DispatchOzonAdLoadAction::class);
+        $received = [];
+        $action
+            ->expects(self::exactly(3))
+            ->method('__invoke')
+            ->willReturnCallback(function (string $companyId, \DateTimeImmutable $from, \DateTimeImmutable $to) use (&$received): AdLoadJob {
+                $received[] = $companyId;
+
+                if (self::COMPANY_2 === $companyId) {
+                    throw new \DomainException('Load already in progress');
+                }
+
+                return new AdLoadJob($companyId, MarketplaceType::OZON, $from, $to);
+            });
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('warning');
+        $logger->expects(self::never())->method('error');
+
+        $tester = $this->makeTester($query, $action, $logger);
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertSame($companyIds, $received, 'All companies must be attempted, even after a DomainException');
+    }
+
+    public function testContinuesAfterThrowableOnOneCompany(): void
+    {
+        $companyIds = [self::COMPANY_1, self::COMPANY_2, self::COMPANY_3];
+
+        $query = $this->createMock(ActiveOzonPerformanceConnectionsQuery::class);
+        $query->method('getCompanyIds')->willReturn($companyIds);
+
+        $action = $this->createMock(DispatchOzonAdLoadAction::class);
+        $received = [];
+        $action
+            ->expects(self::exactly(3))
+            ->method('__invoke')
+            ->willReturnCallback(function (string $companyId, \DateTimeImmutable $from, \DateTimeImmutable $to) use (&$received): AdLoadJob {
+                $received[] = $companyId;
+
+                if (self::COMPANY_1 === $companyId) {
+                    throw new \RuntimeException('API timeout');
+                }
+
+                return new AdLoadJob($companyId, MarketplaceType::OZON, $from, $to);
+            });
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::never())->method('warning');
+        $logger->expects(self::once())->method('error');
+
+        $tester = $this->makeTester($query, $action, $logger);
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertSame($companyIds, $received, 'All companies must be attempted, even after a Throwable');
+    }
+
+    private function makeTester(
+        ActiveOzonPerformanceConnectionsQuery $query,
+        DispatchOzonAdLoadAction $action,
+        LoggerInterface $logger,
+    ): CommandTester {
+        $command = new OzonAdDailySyncCommand($query, $action, $logger);
+
+        return new CommandTester($command);
+    }
+}


### PR DESCRIPTION
## Summary

Ежедневная CLI-команда `app:marketplace-ads:ozon-daily-sync` автоматически запускает загрузку рекламы Ozon за вчерашний день для всех компаний с активным Performance-подключением. Запуск через supercronic в 04:30 MSK.

- Новый DBAL-запрос `ActiveOzonPerformanceConnectionsQuery::getCompanyIds()` — фильтр `marketplace = 'ozon' AND connection_type = 'performance' AND is_active = true`.
- Тонкая команда `OzonAdDailySyncCommand` итерируется по companyIds, вызывает `DispatchOzonAdLoadAction(companyId, yesterday, yesterday)`. `DomainException` (например, «load already in progress») → warning, `\Throwable` → error; цикл не прерывается.
- Прогресс в output: `Dispatched N of M companies`.
- В `docker/cron/app.cron` добавлена строка `30 4 * * * app:marketplace-ads:ozon-daily-sync` рядом с существующей Ozon-записью `0 4 * * *`.

## Test plan

- [x] `site/tests/Unit/MarketplaceAds/Command/OzonAdDailySyncCommandTest.php` — happy path (3 компании × yesterday), пустой список, `DomainException` на одной компании не ломает остальных, любой `\Throwable` тоже.
- [x] `site/tests/Integration/MarketplaceAds/ActiveOzonPerformanceConnectionsQueryTest.php` — возвращает только активный PERFORMANCE, игнорирует SELLER и `is_active=false`, корректная длина списка.
- [ ] CI: unit + integration suites прогнать.

https://claude.ai/code/session_01WWfZYRQ59x2UTQL6Jeg9RV