### PR TITLE
feat(MarketplaceAds): dedicated «Реклама» page under Маркетплейсы

### DIFF
--- a/site/config/packages/twig.yaml
+++ b/site/config/packages/twig.yaml
@@ -8,6 +8,7 @@ twig:
         '%kernel.project_dir%/templates/loan': Loan
         '%kernel.project_dir%/templates/telegram': Telegram
         '%kernel.project_dir%/templates/marketplace': Marketplace
+        '%kernel.project_dir%/templates/marketplace_ads': MarketplaceAds
         '%kernel.project_dir%/templates/moy_sklad': MoySklad
         '%kernel.project_dir%/templates/finance': Finance
         '%kernel.project_dir%/templates/partials': Partials

--- a/site/src/Marketplace/Controller/MarketplaceController.php
+++ b/site/src/Marketplace/Controller/MarketplaceController.php
@@ -21,7 +21,6 @@ use App\Marketplace\Message\TriggerInitialSyncMessage;
 use App\Marketplace\Repository\MarketplaceConnectionRepository;
 use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
 use App\Marketplace\Service\Integration\MarketplaceAdapterRegistry;
-use App\MarketplaceAds\Repository\AdLoadJobRepository;
 use App\Company\Repository\ProjectDirectionRepository;
 use App\Shared\Service\ActiveCompanyService;
 use Doctrine\ORM\EntityManagerInterface;
@@ -52,7 +51,6 @@ class MarketplaceController extends AbstractController
         private readonly MessageBusInterface              $messageBus,
         private readonly ReprocessMarketplacePeriodAction $reprocessAction,
         private readonly SyncConnectionAction             $syncConnectionAction,
-        private readonly AdLoadJobRepository              $adLoadJobRepository,
     ) {
     }
 
@@ -73,16 +71,10 @@ class MarketplaceController extends AbstractController
             50,
         );
 
-        $activeOzonAdLoadJob = $this->adLoadJobRepository->findLatestActiveJobByCompanyAndMarketplace(
-            $company->getId(),
-            MarketplaceType::OZON,
-        );
-
         return $this->render('marketplace/index.html.twig', [
             'connections'           => $connections,
             'rawDocumentsPager'     => $rawDocumentsPager,
             'availableMarketplaces' => MarketplaceType::cases(),
-            'activeOzonAdLoadJob'   => $activeOzonAdLoadJob,
         ]);
     }
 

--- a/site/src/MarketplaceAds/Controller/AdsIndexController.php
+++ b/site/src/MarketplaceAds/Controller/AdsIndexController.php
@@ -10,7 +10,6 @@ use App\Marketplace\Facade\MarketplaceFacade;
 use App\MarketplaceAds\Repository\AdLoadJobRepository;
 use App\Shared\Service\ActiveCompanyService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -25,7 +24,7 @@ final class AdsIndexController extends AbstractController
     ) {}
 
     #[Route('/marketplace-ads', name: 'marketplace_ads_index', methods: ['GET'])]
-    public function __invoke(Request $request): Response
+    public function __invoke(): Response
     {
         $company = $this->activeCompanyService->getActiveCompany();
         $companyId = (string) $company->getId();

--- a/site/src/MarketplaceAds/Controller/AdsIndexController.php
+++ b/site/src/MarketplaceAds/Controller/AdsIndexController.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Controller;
+
+use App\Marketplace\Enum\MarketplaceConnectionType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Facade\MarketplaceFacade;
+use App\MarketplaceAds\Repository\AdLoadJobRepository;
+use App\Shared\Service\ActiveCompanyService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_COMPANY_USER')]
+final class AdsIndexController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $activeCompanyService,
+        private readonly MarketplaceFacade $marketplaceFacade,
+        private readonly AdLoadJobRepository $adLoadJobRepository,
+    ) {}
+
+    #[Route('/marketplace-ads', name: 'marketplace_ads_index', methods: ['GET'])]
+    public function __invoke(Request $request): Response
+    {
+        $company = $this->activeCompanyService->getActiveCompany();
+        $companyId = (string) $company->getId();
+
+        $credentials = $this->marketplaceFacade->getConnectionCredentials(
+            $companyId,
+            MarketplaceType::OZON,
+            MarketplaceConnectionType::PERFORMANCE,
+        );
+
+        $activeAdLoadJob = $this->adLoadJobRepository->findLatestActiveJobByCompanyAndMarketplace(
+            $companyId,
+            MarketplaceType::OZON,
+        );
+
+        return $this->render('marketplace_ads/index.html.twig', [
+            'hasPerformanceConnection' => null !== $credentials,
+            'activeAdLoadJob' => $activeAdLoadJob,
+        ]);
+    }
+}

--- a/site/src/MarketplaceAds/Controller/Api/AdLoadJobsListController.php
+++ b/site/src/MarketplaceAds/Controller/Api/AdLoadJobsListController.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Controller\Api;
+
+use App\MarketplaceAds\Repository\AdLoadJobRepository;
+use App\Shared\Service\ActiveCompanyService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route('/api/marketplace-ads/load-jobs', name: 'marketplace_ads_load_jobs_list', methods: ['GET'])]
+#[IsGranted('ROLE_COMPANY_USER')]
+final class AdLoadJobsListController extends AbstractController
+{
+    private const LIMIT = 20;
+
+    public function __construct(
+        private readonly ActiveCompanyService $activeCompanyService,
+        private readonly AdLoadJobRepository $adLoadJobRepository,
+    ) {}
+
+    public function __invoke(): JsonResponse
+    {
+        $company = $this->activeCompanyService->getActiveCompany();
+        $companyId = (string) $company->getId();
+
+        $jobs = $this->adLoadJobRepository->findRecentByCompany($companyId, self::LIMIT);
+
+        $items = array_map(
+            static fn ($job): array => [
+                'id' => $job->getId(),
+                'status' => $job->getStatus()->value,
+                'dateFrom' => $job->getDateFrom()->format('Y-m-d'),
+                'dateTo' => $job->getDateTo()->format('Y-m-d'),
+                'chunksTotal' => $job->getChunksTotal(),
+                'createdAt' => $job->getCreatedAt()->format('d.m.Y H:i'),
+                'finishedAt' => $job->getFinishedAt()?->format('d.m.Y H:i'),
+                'lastError' => $job->getFailureReason(),
+            ],
+            $jobs,
+        );
+
+        return $this->json(['items' => $items]);
+    }
+}

--- a/site/src/MarketplaceAds/Controller/Api/AdLoadJobsListController.php
+++ b/site/src/MarketplaceAds/Controller/Api/AdLoadJobsListController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\MarketplaceAds\Controller\Api;
 
+use App\Marketplace\Enum\MarketplaceType;
 use App\MarketplaceAds\Repository\AdLoadJobRepository;
 use App\Shared\Service\ActiveCompanyService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -27,7 +28,11 @@ final class AdLoadJobsListController extends AbstractController
         $company = $this->activeCompanyService->getActiveCompany();
         $companyId = (string) $company->getId();
 
-        $jobs = $this->adLoadJobRepository->findRecentByCompany($companyId, self::LIMIT);
+        $jobs = $this->adLoadJobRepository->findRecentByCompanyAndMarketplace(
+            $companyId,
+            MarketplaceType::OZON,
+            self::LIMIT,
+        );
 
         $items = array_map(
             static fn ($job): array => [

--- a/site/src/MarketplaceAds/Controller/Api/AdRawDocumentsListController.php
+++ b/site/src/MarketplaceAds/Controller/Api/AdRawDocumentsListController.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Controller\Api;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAds\Repository\AdRawDocumentRepository;
+use App\Shared\Service\ActiveCompanyService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route('/api/marketplace-ads/raw-documents', name: 'marketplace_ads_raw_documents_list', methods: ['GET'])]
+#[IsGranted('ROLE_COMPANY_USER')]
+final class AdRawDocumentsListController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $activeCompanyService,
+        private readonly AdRawDocumentRepository $rawDocumentRepository,
+    ) {}
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        $company = $this->activeCompanyService->getActiveCompany();
+        $companyId = (string) $company->getId();
+
+        $dateFromStr = $request->query->get('dateFrom');
+        $dateToStr = $request->query->get('dateTo');
+
+        if (null === $dateFromStr && null === $dateToStr) {
+            $dateTo = (new \DateTimeImmutable('today'))->setTime(0, 0);
+            $dateFrom = $dateTo->modify('-30 days');
+        } else {
+            $dateFrom = $this->parseDate((string) $dateFromStr);
+            $dateTo = $this->parseDate((string) $dateToStr);
+
+            if (null === $dateFrom || null === $dateTo) {
+                return $this->json(['message' => 'Неверный формат даты. Ожидается YYYY-MM-DD.'], 400);
+            }
+        }
+
+        $documents = $this->rawDocumentRepository->findByCompanyMarketplaceAndDateRange(
+            $companyId,
+            MarketplaceType::OZON->value,
+            $dateFrom,
+            $dateTo,
+        );
+
+        $items = array_map(
+            static fn ($doc): array => [
+                'id' => $doc->getId(),
+                'reportDate' => $doc->getReportDate()->format('Y-m-d'),
+                'status' => $doc->getStatus()->value,
+                'loadedAt' => $doc->getLoadedAt()->format('d.m.Y H:i'),
+                'processingError' => $doc->getProcessingError(),
+            ],
+            $documents,
+        );
+
+        return $this->json(['items' => $items]);
+    }
+
+    private function parseDate(string $value): ?\DateTimeImmutable
+    {
+        $parsed = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
+
+        if (false === $parsed || $parsed->format('Y-m-d') !== $value) {
+            return null;
+        }
+
+        return $parsed;
+    }
+}

--- a/site/src/MarketplaceAds/Repository/AdLoadJobRepository.php
+++ b/site/src/MarketplaceAds/Repository/AdLoadJobRepository.php
@@ -43,6 +43,17 @@ class AdLoadJobRepository extends ServiceEntityRepository implements AdLoadJobRe
         return parent::find($id, $lockMode, $lockVersion);
     }
 
+    public function findRecentByCompany(string $companyId, int $limit = 20): array
+    {
+        return $this->createQueryBuilder('j')
+            ->where('j.companyId = :companyId')
+            ->setParameter('companyId', $companyId)
+            ->orderBy('j.createdAt', 'DESC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
+
     public function findLatestActiveJobByCompanyAndMarketplace(
         string $companyId,
         MarketplaceType $marketplace,

--- a/site/src/MarketplaceAds/Repository/AdLoadJobRepository.php
+++ b/site/src/MarketplaceAds/Repository/AdLoadJobRepository.php
@@ -43,11 +43,16 @@ class AdLoadJobRepository extends ServiceEntityRepository implements AdLoadJobRe
         return parent::find($id, $lockMode, $lockVersion);
     }
 
-    public function findRecentByCompany(string $companyId, int $limit = 20): array
-    {
+    public function findRecentByCompanyAndMarketplace(
+        string $companyId,
+        MarketplaceType $marketplace,
+        int $limit = 20,
+    ): array {
         return $this->createQueryBuilder('j')
             ->where('j.companyId = :companyId')
+            ->andWhere('j.marketplace = :marketplace')
             ->setParameter('companyId', $companyId)
+            ->setParameter('marketplace', $marketplace)
             ->orderBy('j.createdAt', 'DESC')
             ->setMaxResults($limit)
             ->getQuery()

--- a/site/src/MarketplaceAds/Repository/AdLoadJobRepositoryInterface.php
+++ b/site/src/MarketplaceAds/Repository/AdLoadJobRepositoryInterface.php
@@ -15,6 +15,13 @@ interface AdLoadJobRepositoryInterface
     public function findByIdAndCompany(string $id, string $companyId): ?AdLoadJob;
 
     /**
+     * Последние задания компании, отсортированные по createdAt DESC, ограничение $limit.
+     *
+     * @return list<AdLoadJob>
+     */
+    public function findRecentByCompany(string $companyId, int $limit = 20): array;
+
+    /**
      * Возвращает активный (PENDING/RUNNING) job, чей диапазон [dateFrom, dateTo]
      * включает $date. Используется для маппинга обработанного документа на
      * job, которому он принадлежит.

--- a/site/src/MarketplaceAds/Repository/AdLoadJobRepositoryInterface.php
+++ b/site/src/MarketplaceAds/Repository/AdLoadJobRepositoryInterface.php
@@ -15,11 +15,16 @@ interface AdLoadJobRepositoryInterface
     public function findByIdAndCompany(string $id, string $companyId): ?AdLoadJob;
 
     /**
-     * Последние задания компании, отсортированные по createdAt DESC, ограничение $limit.
+     * Последние задания компании по маркетплейсу, отсортированные по createdAt DESC,
+     * ограничение $limit.
      *
      * @return list<AdLoadJob>
      */
-    public function findRecentByCompany(string $companyId, int $limit = 20): array;
+    public function findRecentByCompanyAndMarketplace(
+        string $companyId,
+        MarketplaceType $marketplace,
+        int $limit = 20,
+    ): array;
 
     /**
      * Возвращает активный (PENDING/RUNNING) job, чей диапазон [dateFrom, dateTo]

--- a/site/src/MarketplaceAds/Repository/AdRawDocumentRepository.php
+++ b/site/src/MarketplaceAds/Repository/AdRawDocumentRepository.php
@@ -64,6 +64,25 @@ class AdRawDocumentRepository extends ServiceEntityRepository implements AdRawDo
         );
     }
 
+    public function findByCompanyMarketplaceAndDateRange(
+        string $companyId,
+        string $marketplace,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+    ): array {
+        return $this->createQueryBuilder('r')
+            ->where('r.companyId = :companyId')
+            ->andWhere('r.marketplace = :marketplace')
+            ->andWhere('r.reportDate BETWEEN :from AND :to')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('marketplace', $marketplace)
+            ->setParameter('from', $from->format('Y-m-d'))
+            ->setParameter('to', $to->format('Y-m-d'))
+            ->orderBy('r.reportDate', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
+
     public function save(AdRawDocument $document): void
     {
         $this->getEntityManager()->persist($document);

--- a/site/src/MarketplaceAds/Repository/AdRawDocumentRepositoryInterface.php
+++ b/site/src/MarketplaceAds/Repository/AdRawDocumentRepositoryInterface.php
@@ -42,4 +42,22 @@ interface AdRawDocumentRepositoryInterface
         \DateTimeImmutable $to,
         ?AdRawDocumentStatus $statusFilter = null,
     ): int;
+
+    /**
+     * Документы компании за период для конкретного маркетплейса, отсортированные по report_date DESC.
+     *
+     * Реализация обязана:
+     *  - ограничивать выборку `company_id = :companyId` (IDOR-guard на уровне SQL);
+     *  - сравнивать `report_date` включительно по обеим границам `[$from, $to]`.
+     *
+     * @param string $marketplace значение {@see \App\Marketplace\Enum\MarketplaceType::value}
+     *
+     * @return list<AdRawDocument>
+     */
+    public function findByCompanyMarketplaceAndDateRange(
+        string $companyId,
+        string $marketplace,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+    ): array;
 }

--- a/site/templates/marketplace/index.html.twig
+++ b/site/templates/marketplace/index.html.twig
@@ -71,34 +71,6 @@
                                                 <small>Ошибка: {{ connection.lastSyncError|slice(0, 100) }}</small>
                                             </div>
                                         {% endif %}
-                                        {% if not isSeller and connection.marketplace.value == 'ozon' and activeOzonAdLoadJob is not null %}
-                                            <div class="mt-2"
-                                                 id="ozon-ad-load-widget-{{ connection.id }}"
-                                                 data-ad-job-id="{{ activeOzonAdLoadJob.id }}"
-                                                 data-ad-job-status="{{ activeOzonAdLoadJob.status.value }}"
-                                                 data-status-url="{{ path('marketplace_ads_ozon_load_job_status', {jobId: activeOzonAdLoadJob.id}) }}">
-                                                {% if activeOzonAdLoadJob.status.isTerminal %}
-                                                    {% if activeOzonAdLoadJob.status.value == 'completed' %}
-                                                        <div class="alert alert-success mb-0 py-2">
-                                                            <small>Реклама Ozon загружена</small>
-                                                        </div>
-                                                    {% else %}
-                                                        <div class="alert alert-danger mb-0 py-2">
-                                                            <small>Ошибка загрузки: {{ activeOzonAdLoadJob.failureReason }}</small>
-                                                        </div>
-                                                    {% endif %}
-                                                {% else %}
-                                                    <div class="d-flex align-items-center gap-2 mb-1">
-                                                        <span class="spinner-border spinner-border-sm text-indigo"></span>
-                                                        <small class="text-muted">Загрузка рекламы Ozon...</small>
-                                                    </div>
-                                                    <div class="progress mb-1" style="height:6px;">
-                                                        <div class="progress-bar bg-indigo ozon-ad-progress-bar" style="width:0%"></div>
-                                                    </div>
-                                                    <small class="text-muted ozon-ad-counters">Чанков: —, Документов: —</small>
-                                                {% endif %}
-                                            </div>
-                                        {% endif %}
                                     </div>
                                     <div class="col-auto">
                                         <span class="badge bg-{{ connection.isActive ? 'success' : 'secondary' }}">
@@ -132,20 +104,6 @@
                                                         data-marketplace="{{ connection.marketplace.value }}">
                                                     Переобработать
                                                 </button>
-                                            {% elseif connection.marketplace.value == 'ozon' %}
-                                                <button type="button"
-                                                        class="btn btn-sm btn-outline-indigo"
-                                                        data-ozon-initial-load="1">
-                                                    Загрузить рекламу с начала года
-                                                </button>
-                                                {% if is_granted('ROLE_COMPANY_OWNER') %}
-                                                    <button type="button"
-                                                            class="btn btn-sm btn-outline-secondary"
-                                                            data-bs-toggle="modal"
-                                                            data-bs-target="#modal-ozon-ad-load-range">
-                                                        Загрузить за период
-                                                    </button>
-                                                {% endif %}
                                             {% endif %}
                                             <form method="post" action="{{ path('marketplace_connection_toggle', {id: connection.id}) }}" style="display:inline">
                                                 <input type="hidden" name="_token" value="{{ csrf_token('toggle' ~ connection.id) }}">
@@ -526,36 +484,6 @@
         </div>
     </div>
 
-    {# Modal: Загрузить рекламу Ozon за произвольный период (только ROLE_COMPANY_OWNER) #}
-    {% if is_granted('ROLE_COMPANY_OWNER') %}
-    <div class="modal modal-blur fade" id="modal-ozon-ad-load-range" tabindex="-1" role="dialog" aria-hidden="true">
-        <div class="modal-dialog modal-dialog-centered" role="document">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">Загрузить рекламу Ozon за период</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                </div>
-                <div class="modal-body">
-                    <div class="mb-3">
-                        <label class="form-label required">Дата начала</label>
-                        <input type="date" id="ozon-ad-range-from" class="form-control" required
-                               value="{{ 'now'|date_modify('first day of last month')|date('Y-m-d') }}">
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label required">Дата окончания</label>
-                        <input type="date" id="ozon-ad-range-to" class="form-control" required
-                               value="{{ 'now'|date_modify('last day of last month')|date('Y-m-d') }}">
-                    </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn" data-bs-dismiss="modal">Отмена</button>
-                    <button type="button" class="btn btn-indigo" id="btn-ozon-ad-load-range">Загрузить</button>
-                </div>
-            </div>
-        </div>
-    </div>
-    {% endif %}
-
     {# Modal: Пакетная обработка за месяц #}
     <div class="modal modal-blur fade" id="bulkProcessModal" tabindex="-1" role="dialog" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered" role="document">
@@ -805,103 +733,5 @@
             });
         })();
 
-        // Кнопка «Загрузить рекламу с начала года»
-        (function () {
-            var btns = document.querySelectorAll('[data-ozon-initial-load]');
-            btns.forEach(function (btn) {
-                btn.addEventListener('click', function () {
-                    btn.disabled = true;
-                    btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Запуск...';
-                    fetch('{{ path('marketplace_ads_ozon_initial_load') }}', {
-                        method: 'POST',
-                        credentials: 'same-origin',
-                        headers: {'X-Requested-With': 'XMLHttpRequest'},
-                    })
-                        .then(function (r) { return r.json().then(function (d) { return {ok: r.ok, data: d}; }); })
-                        .then(function (res) {
-                            if (res.ok) {
-                                window.location.reload();
-                            } else {
-                                alert('Ошибка: ' + (res.data.message ?? 'Неизвестная ошибка'));
-                                btn.disabled = false;
-                                btn.innerHTML = 'Загрузить рекламу с начала года';
-                            }
-                        })
-                        .catch(function (err) {
-                            alert('Ошибка сети: ' + err.message);
-                            btn.disabled = false;
-                            btn.innerHTML = 'Загрузить рекламу с начала года';
-                        });
-                });
-            });
-        })();
-
-        // Кнопка «Загрузить за период» в модалке
-        (function () {
-            var btn = document.getElementById('btn-ozon-ad-load-range');
-            if (!btn) return;
-            btn.addEventListener('click', function () {
-                var dateFrom = (document.getElementById('ozon-ad-range-from') || {}).value;
-                var dateTo   = (document.getElementById('ozon-ad-range-to') || {}).value;
-                if (!dateFrom || !dateTo) { alert('Укажите обе даты'); return; }
-                btn.disabled = true;
-                btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Запуск...';
-                fetch('{{ path('marketplace_ads_ozon_load_range') }}', {
-                    method: 'POST',
-                    credentials: 'same-origin',
-                    headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
-                    body: JSON.stringify({dateFrom: dateFrom, dateTo: dateTo}),
-                })
-                    .then(function (r) { return r.json().then(function (d) { return {ok: r.ok, data: d}; }); })
-                    .then(function (res) {
-                        if (res.ok) {
-                            window.location.reload();
-                        } else {
-                            var BootstrapModal = window.bootstrap && window.bootstrap.Modal;
-                            if (BootstrapModal) {
-                                BootstrapModal.getOrCreateInstance(document.getElementById('modal-ozon-ad-load-range')).hide();
-                            }
-                            alert('Ошибка: ' + (res.data.message ?? 'Неизвестная ошибка'));
-                            btn.disabled = false;
-                            btn.innerHTML = 'Загрузить';
-                        }
-                    })
-                    .catch(function (err) {
-                        alert('Ошибка сети: ' + err.message);
-                        btn.disabled = false;
-                        btn.innerHTML = 'Загрузить';
-                    });
-            });
-        })();
-
-        // Поллер прогресса загрузки рекламы Ozon (15 сек)
-        (function () {
-            document.querySelectorAll('[data-ad-job-id]').forEach(function (widget) {
-                var status = widget.dataset.adJobStatus;
-                if (status === 'completed' || status === 'failed') return;
-
-                var statusUrl = widget.dataset.statusUrl;
-                var bar      = widget.querySelector('.ozon-ad-progress-bar');
-                var counters = widget.querySelector('.ozon-ad-counters');
-
-                var interval = setInterval(function () {
-                    fetch(statusUrl, {headers: {'X-Requested-With': 'XMLHttpRequest'}})
-                        .then(function (r) { return r.json(); })
-                        .then(function (data) {
-                            if (bar) bar.style.width = data.progress + '%';
-                            if (counters) {
-                                counters.textContent = 'Чанков: ' + data.completedChunks + '/' + data.chunksTotal
-                                    + ', Документов: ' + data.totalDocs
-                                    + ' (' + data.processedDocs + ' обработано, ' + data.failedDocs + ' ошибок)';
-                            }
-                            if (data.status === 'completed' || data.status === 'failed') {
-                                clearInterval(interval);
-                                window.location.reload();
-                            }
-                        })
-                        .catch(function () { /* сеть — продолжаем */ });
-                }, 15000);
-            });
-        })();
     </script>
 {% endblock %}

--- a/site/templates/marketplace_ads/index.html.twig
+++ b/site/templates/marketplace_ads/index.html.twig
@@ -1,0 +1,388 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Реклама — Маркетплейсы{% endblock %}
+
+{% block body %}
+    <div class="page-header d-print-none">
+        <div class="container-xl">
+            <div class="row g-2 align-items-center">
+                <div class="col">
+                    <h2 class="page-title">Реклама маркетплейсов</h2>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="page-body">
+        <div class="container-xl">
+
+            {# ---------- Блок «Реклама Ozon» ---------- #}
+            <div class="card mb-3">
+                <div class="card-header">
+                    <h3 class="card-title">Реклама Ozon</h3>
+                </div>
+                <div class="card-body">
+                    {% if not hasPerformanceConnection %}
+                        <div class="alert alert-warning mb-0">
+                            <div class="d-flex">
+                                <div>
+                                    <h4 class="alert-title">Нет подключения к Ozon Performance API</h4>
+                                    <div class="text-muted">
+                                        Настройте Performance-подключение на странице
+                                        <a href="{{ path('marketplace_index') }}">Маркетплейсы</a>.
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    {% else %}
+                        <div class="btn-list">
+                            <button type="button" class="btn btn-indigo" data-ozon-initial-load="1">
+                                Загрузить с начала года
+                            </button>
+                            {% if is_granted('ROLE_COMPANY_OWNER') %}
+                                <button type="button" class="btn btn-outline-secondary"
+                                        data-bs-toggle="modal" data-bs-target="#modal-ozon-ad-load-range">
+                                    Загрузить за период
+                                </button>
+                            {% endif %}
+                        </div>
+
+                        {% if activeAdLoadJob is not null %}
+                            <div class="mt-3"
+                                 id="ozon-ad-load-widget"
+                                 data-ad-job-id="{{ activeAdLoadJob.id }}"
+                                 data-ad-job-status="{{ activeAdLoadJob.status.value }}"
+                                 data-status-url="{{ path('marketplace_ads_ozon_load_job_status', {jobId: activeAdLoadJob.id}) }}">
+                                {% if activeAdLoadJob.status.isTerminal %}
+                                    {% if activeAdLoadJob.status.value == 'completed' %}
+                                        <div class="alert alert-success mb-0 py-2">
+                                            <small>Реклама Ozon загружена</small>
+                                        </div>
+                                    {% else %}
+                                        <div class="alert alert-danger mb-0 py-2">
+                                            <small>Ошибка загрузки: {{ activeAdLoadJob.failureReason }}</small>
+                                        </div>
+                                    {% endif %}
+                                {% else %}
+                                    <div class="d-flex align-items-center gap-2 mb-1">
+                                        <span class="spinner-border spinner-border-sm text-indigo"></span>
+                                        <small class="text-muted">Загрузка рекламы Ozon...</small>
+                                    </div>
+                                    <div class="progress mb-1" style="height:6px;">
+                                        <div class="progress-bar bg-indigo ozon-ad-progress-bar" style="width:0%"></div>
+                                    </div>
+                                    <small class="text-muted ozon-ad-counters">Чанков: —, Документов: —</small>
+                                {% endif %}
+                            </div>
+                        {% endif %}
+                    {% endif %}
+                </div>
+            </div>
+
+            {# ---------- Блок «История загрузок» ---------- #}
+            <div class="card mb-3">
+                <div class="card-header">
+                    <h3 class="card-title">История загрузок</h3>
+                </div>
+                <div class="table-responsive">
+                    <table class="table card-table table-vcenter" id="ad-load-jobs-table">
+                        <thead>
+                        <tr>
+                            <th>Период</th>
+                            <th>Статус</th>
+                            <th>Чанки</th>
+                            <th>Создан</th>
+                            <th>Завершён</th>
+                            <th>Ошибка</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr><td colspan="6" class="text-center text-muted">Загрузка…</td></tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            {# ---------- Блок «Сырые документы» ---------- #}
+            <div class="card">
+                <div class="card-header">
+                    <h3 class="card-title">Сырые документы</h3>
+                </div>
+                <div class="card-body">
+                    <form id="raw-documents-filter" class="row g-2 align-items-end mb-3">
+                        <div class="col-auto">
+                            <label class="form-label">Дата с</label>
+                            <input type="date" id="raw-date-from" class="form-control"
+                                   value="{{ 'now'|date_modify('-30 days')|date('Y-m-d') }}">
+                        </div>
+                        <div class="col-auto">
+                            <label class="form-label">Дата по</label>
+                            <input type="date" id="raw-date-to" class="form-control"
+                                   value="{{ 'now'|date('Y-m-d') }}">
+                        </div>
+                        <div class="col-auto">
+                            <button type="submit" class="btn btn-primary">Показать</button>
+                        </div>
+                    </form>
+                </div>
+                <div class="table-responsive">
+                    <table class="table card-table table-vcenter" id="ad-raw-documents-table">
+                        <thead>
+                        <tr>
+                            <th>Дата отчёта</th>
+                            <th>Статус</th>
+                            <th>Загружен</th>
+                            <th>Ошибка обработки</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr><td colspan="4" class="text-center text-muted">Загрузка…</td></tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+        </div>
+    </div>
+
+    {# ---------- Modal: Загрузить рекламу Ozon за произвольный период ---------- #}
+    {% if hasPerformanceConnection and is_granted('ROLE_COMPANY_OWNER') %}
+        <div class="modal modal-blur fade" id="modal-ozon-ad-load-range" tabindex="-1" role="dialog" aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title">Загрузить рекламу Ozon за период</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="mb-3">
+                            <label class="form-label required">Дата начала</label>
+                            <input type="date" id="ozon-ad-range-from" class="form-control" required
+                                   value="{{ 'now'|date_modify('first day of last month')|date('Y-m-d') }}">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label required">Дата окончания</label>
+                            <input type="date" id="ozon-ad-range-to" class="form-control" required
+                                   value="{{ 'now'|date_modify('last day of last month')|date('Y-m-d') }}">
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn" data-bs-dismiss="modal">Отмена</button>
+                        <button type="button" class="btn btn-indigo" id="btn-ozon-ad-load-range">Загрузить</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    {% endif %}
+
+    <script>
+        (function () {
+            var escapeHtml = function (value) {
+                if (value === null || value === undefined) return '';
+                return String(value)
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;')
+                    .replace(/"/g, '&quot;')
+                    .replace(/'/g, '&#039;');
+            };
+
+            var jobStatusBadge = function (status) {
+                var map = {
+                    pending:   ['bg-secondary', 'Ожидает'],
+                    running:   ['bg-info',      'Выполняется'],
+                    completed: ['bg-success',   'Завершён'],
+                    failed:    ['bg-danger',    'Ошибка'],
+                };
+                var row = map[status] || ['bg-secondary', status];
+                return '<span class="badge ' + row[0] + '">' + escapeHtml(row[1]) + '</span>';
+            };
+
+            var docStatusBadge = function (status) {
+                var map = {
+                    draft:     ['bg-secondary', 'Черновик'],
+                    processed: ['bg-success',   'Обработан'],
+                    failed:    ['bg-danger',    'Ошибка'],
+                };
+                var row = map[status] || ['bg-secondary', status];
+                return '<span class="badge ' + row[0] + '">' + escapeHtml(row[1]) + '</span>';
+            };
+
+            var loadJobs = function () {
+                var tbody = document.querySelector('#ad-load-jobs-table tbody');
+                fetch('{{ path('marketplace_ads_load_jobs_list') }}', {
+                    credentials: 'same-origin',
+                    headers: {'X-Requested-With': 'XMLHttpRequest'},
+                })
+                    .then(function (r) { return r.json(); })
+                    .then(function (data) {
+                        var items = (data && data.items) || [];
+                        if (items.length === 0) {
+                            tbody.innerHTML = '<tr><td colspan="6" class="text-center text-muted">Нет данных</td></tr>';
+                            return;
+                        }
+                        tbody.innerHTML = items.map(function (job) {
+                            return '<tr>'
+                                + '<td><small>' + escapeHtml(job.dateFrom) + ' — ' + escapeHtml(job.dateTo) + '</small></td>'
+                                + '<td>' + jobStatusBadge(job.status) + '</td>'
+                                + '<td>' + escapeHtml(job.chunksTotal) + '</td>'
+                                + '<td><small>' + escapeHtml(job.createdAt) + '</small></td>'
+                                + '<td><small>' + escapeHtml(job.finishedAt || '—') + '</small></td>'
+                                + '<td><small class="text-danger">' + escapeHtml(job.lastError || '') + '</small></td>'
+                                + '</tr>';
+                        }).join('');
+                    })
+                    .catch(function () {
+                        tbody.innerHTML = '<tr><td colspan="6" class="text-center text-danger">Ошибка загрузки</td></tr>';
+                    });
+            };
+
+            var loadRawDocuments = function (dateFrom, dateTo) {
+                var tbody = document.querySelector('#ad-raw-documents-table tbody');
+                tbody.innerHTML = '<tr><td colspan="4" class="text-center text-muted">Загрузка…</td></tr>';
+
+                var url = '{{ path('marketplace_ads_raw_documents_list') }}';
+                if (dateFrom && dateTo) {
+                    url += '?dateFrom=' + encodeURIComponent(dateFrom) + '&dateTo=' + encodeURIComponent(dateTo);
+                }
+
+                fetch(url, {
+                    credentials: 'same-origin',
+                    headers: {'X-Requested-With': 'XMLHttpRequest'},
+                })
+                    .then(function (r) { return r.json().then(function (d) { return {ok: r.ok, data: d}; }); })
+                    .then(function (res) {
+                        if (!res.ok) {
+                            tbody.innerHTML = '<tr><td colspan="4" class="text-center text-danger">'
+                                + escapeHtml((res.data && res.data.message) || 'Ошибка загрузки') + '</td></tr>';
+                            return;
+                        }
+                        var items = (res.data && res.data.items) || [];
+                        if (items.length === 0) {
+                            tbody.innerHTML = '<tr><td colspan="4" class="text-center text-muted">Нет данных</td></tr>';
+                            return;
+                        }
+                        tbody.innerHTML = items.map(function (doc) {
+                            return '<tr>'
+                                + '<td>' + escapeHtml(doc.reportDate) + '</td>'
+                                + '<td>' + docStatusBadge(doc.status) + '</td>'
+                                + '<td><small>' + escapeHtml(doc.loadedAt) + '</small></td>'
+                                + '<td><small class="text-danger">' + escapeHtml(doc.processingError || '') + '</small></td>'
+                                + '</tr>';
+                        }).join('');
+                    })
+                    .catch(function () {
+                        tbody.innerHTML = '<tr><td colspan="4" class="text-center text-danger">Ошибка загрузки</td></tr>';
+                    });
+            };
+
+            document.addEventListener('DOMContentLoaded', function () {
+                loadJobs();
+
+                var fromEl = document.getElementById('raw-date-from');
+                var toEl   = document.getElementById('raw-date-to');
+                loadRawDocuments(fromEl.value, toEl.value);
+
+                var filterForm = document.getElementById('raw-documents-filter');
+                filterForm.addEventListener('submit', function (e) {
+                    e.preventDefault();
+                    loadRawDocuments(fromEl.value, toEl.value);
+                });
+            });
+
+            // Кнопка «Загрузить с начала года»
+            document.querySelectorAll('[data-ozon-initial-load]').forEach(function (btn) {
+                btn.addEventListener('click', function () {
+                    btn.disabled = true;
+                    var original = btn.innerHTML;
+                    btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Запуск...';
+                    fetch('{{ path('marketplace_ads_ozon_initial_load') }}', {
+                        method: 'POST',
+                        credentials: 'same-origin',
+                        headers: {'X-Requested-With': 'XMLHttpRequest'},
+                    })
+                        .then(function (r) { return r.json().then(function (d) { return {ok: r.ok, data: d}; }); })
+                        .then(function (res) {
+                            if (res.ok) {
+                                window.location.reload();
+                            } else {
+                                alert('Ошибка: ' + ((res.data && res.data.message) || 'Неизвестная ошибка'));
+                                btn.disabled = false;
+                                btn.innerHTML = original;
+                            }
+                        })
+                        .catch(function (err) {
+                            alert('Ошибка сети: ' + err.message);
+                            btn.disabled = false;
+                            btn.innerHTML = original;
+                        });
+                });
+            });
+
+            // Кнопка «Загрузить за период» в модалке
+            var rangeBtn = document.getElementById('btn-ozon-ad-load-range');
+            if (rangeBtn) {
+                rangeBtn.addEventListener('click', function () {
+                    var dateFrom = (document.getElementById('ozon-ad-range-from') || {}).value;
+                    var dateTo   = (document.getElementById('ozon-ad-range-to') || {}).value;
+                    if (!dateFrom || !dateTo) { alert('Укажите обе даты'); return; }
+                    rangeBtn.disabled = true;
+                    rangeBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Запуск...';
+                    fetch('{{ path('marketplace_ads_ozon_load_range') }}', {
+                        method: 'POST',
+                        credentials: 'same-origin',
+                        headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
+                        body: JSON.stringify({dateFrom: dateFrom, dateTo: dateTo}),
+                    })
+                        .then(function (r) { return r.json().then(function (d) { return {ok: r.ok, data: d}; }); })
+                        .then(function (res) {
+                            if (res.ok) {
+                                window.location.reload();
+                            } else {
+                                var BootstrapModal = window.bootstrap && window.bootstrap.Modal;
+                                if (BootstrapModal) {
+                                    BootstrapModal.getOrCreateInstance(document.getElementById('modal-ozon-ad-load-range')).hide();
+                                }
+                                alert('Ошибка: ' + ((res.data && res.data.message) || 'Неизвестная ошибка'));
+                                rangeBtn.disabled = false;
+                                rangeBtn.innerHTML = 'Загрузить';
+                            }
+                        })
+                        .catch(function (err) {
+                            alert('Ошибка сети: ' + err.message);
+                            rangeBtn.disabled = false;
+                            rangeBtn.innerHTML = 'Загрузить';
+                        });
+                });
+            }
+
+            // Поллер прогресса загрузки рекламы Ozon (15 сек)
+            document.querySelectorAll('[data-ad-job-id]').forEach(function (widget) {
+                var status = widget.dataset.adJobStatus;
+                if (status === 'completed' || status === 'failed') return;
+
+                var statusUrl = widget.dataset.statusUrl;
+                var bar       = widget.querySelector('.ozon-ad-progress-bar');
+                var counters  = widget.querySelector('.ozon-ad-counters');
+
+                var interval = setInterval(function () {
+                    fetch(statusUrl, {headers: {'X-Requested-With': 'XMLHttpRequest'}})
+                        .then(function (r) { return r.json(); })
+                        .then(function (data) {
+                            if (bar) bar.style.width = data.progress + '%';
+                            if (counters) {
+                                counters.textContent = 'Чанков: ' + data.completedChunks + '/' + data.chunksTotal
+                                    + ', Документов: ' + data.totalDocs
+                                    + ' (' + data.processedDocs + ' обработано, ' + data.failedDocs + ' ошибок)';
+                            }
+                            if (data.status === 'completed' || data.status === 'failed') {
+                                clearInterval(interval);
+                                window.location.reload();
+                            }
+                        })
+                        .catch(function () { /* сеть — продолжаем */ });
+                }, 15000);
+            });
+        })();
+    </script>
+{% endblock %}

--- a/site/templates/partials/_sidebar_marketplace.html.twig
+++ b/site/templates/partials/_sidebar_marketplace.html.twig
@@ -1,7 +1,8 @@
 {% set marketplace_path = app.request ? app.request.pathinfo : '' %}
 {% set marketplace_menu_active =
-    (current_route starts with 'marketplace_' and not (current_route starts with 'marketplace_analytics_'))
+    (current_route starts with 'marketplace_' and not (current_route starts with 'marketplace_analytics_') and not (current_route starts with 'marketplace_ads_'))
     or current_route starts with 'marketplace_analytics_'
+    or current_route starts with 'marketplace_ads_'
 %}
 <li class="nav-item dropdown {{ marketplace_menu_active ? 'show' : '' }}">
     <a class="nav-link dropdown-toggle {{ marketplace_menu_active ? 'show active' : '' }}" href="#" data-bs-toggle="dropdown" data-bs-auto-close="false" role="button" aria-expanded="{{ marketplace_menu_active ? 'true' : 'false' }}">
@@ -11,13 +12,22 @@
     {% set marketplace_menu_show = marketplace_menu_active ? 'show' : '' %}
     <div class="dropdown-menu {{ marketplace_menu_show }}">
         <div class="dropdown-menu-column">
-            {% set mp_charges_active = current_route starts with 'marketplace_' and not (current_route starts with 'marketplace_analytics_') and current_route != 'marketplace_reconciliation' %}
+            {% set mp_charges_active =
+                current_route starts with 'marketplace_'
+                and not (current_route starts with 'marketplace_analytics_')
+                and not (current_route starts with 'marketplace_ads_')
+                and current_route != 'marketplace_reconciliation'
+            %}
             <a class="dropdown-item {{ mp_charges_active ? 'active' : '' }}" href="{{ path('marketplace_index') }}">
                 <span>Начисления</span>
             </a>
             {% set mp_unit_active = current_route starts with 'marketplace_analytics_' %}
             <a class="dropdown-item {{ mp_unit_active ? 'active' : '' }}" href="{{ path('marketplace_analytics_unit_economics_index') }}">
                 <span>Unit-экономика</span>
+            </a>
+            {% set mp_ads_active = current_route starts with 'marketplace_ads_' %}
+            <a class="dropdown-item {{ mp_ads_active ? 'active' : '' }}" href="{{ path('marketplace_ads_index') }}">
+                <span>Реклама</span>
             </a>
             {% set mp_reconciliation_active = current_route == 'marketplace_reconciliation' %}
             <a class="dropdown-item {{ mp_reconciliation_active ? 'active' : '' }}" href="{{ path('marketplace_reconciliation') }}">

--- a/site/tests/Builders/MarketplaceAds/AdLoadJobBuilder.php
+++ b/site/tests/Builders/MarketplaceAds/AdLoadJobBuilder.php
@@ -24,6 +24,7 @@ final class AdLoadJobBuilder
     private int $processedDays = 0;
     private int $failedDays = 0;
     private int $chunksTotal = 0;
+    private ?\DateTimeImmutable $createdAt = null;
 
     private function __construct()
     {
@@ -128,6 +129,14 @@ final class AdLoadJobBuilder
         return $clone;
     }
 
+    public function withCreatedAt(\DateTimeImmutable $createdAt): self
+    {
+        $clone = clone $this;
+        $clone->createdAt = $createdAt;
+
+        return $clone;
+    }
+
     public function build(): AdLoadJob
     {
         $job = new AdLoadJob(
@@ -153,6 +162,10 @@ final class AdLoadJobBuilder
         }
         if ($this->chunksTotal !== 0) {
             $this->setProperty($job, 'chunksTotal', $this->chunksTotal);
+        }
+
+        if (null !== $this->createdAt) {
+            $this->setProperty($job, 'createdAt', $this->createdAt);
         }
 
         if (AdLoadJobStatus::PENDING !== $this->status) {

--- a/site/tests/Integration/MarketplaceAds/Controller/AdsIndexControllerTest.php
+++ b/site/tests/Integration/MarketplaceAds/Controller/AdsIndexControllerTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\MarketplaceAds\Controller;
+
+use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Enum\MarketplaceConnectionType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+use Ramsey\Uuid\Uuid;
+
+final class AdsIndexControllerTest extends WebTestCaseBase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-c00000000001';
+    private const OWNER_ID = '22222222-2222-2222-2222-c00000000001';
+
+    public function testReturns200WithoutPerformanceConnection(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('ads-index-no-conn@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        $client->loginUser($owner);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', self::COMPANY_ID);
+        $session->save();
+
+        $client->request('GET', '/marketplace-ads');
+
+        self::assertResponseIsSuccessful();
+
+        $content = $client->getResponse()->getContent();
+        self::assertStringContainsString('Реклама', $content);
+    }
+
+    public function testReturns200WithPerformanceConnection(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('ads-index-with-conn@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        $connection = new MarketplaceConnection(
+            Uuid::uuid4()->toString(),
+            $company,
+            MarketplaceType::OZON,
+            MarketplaceConnectionType::PERFORMANCE,
+        );
+        $connection->setApiKey('test-client-secret');
+        $connection->setClientId('test-client-id@advertising.performance.ozon.ru');
+        $em->persist($connection);
+        $em->flush();
+
+        $client->loginUser($owner);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', self::COMPANY_ID);
+        $session->save();
+
+        $client->request('GET', '/marketplace-ads');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testRedirectsWhenNotAuthenticated(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $client->request('GET', '/marketplace-ads');
+
+        $response = $client->getResponse();
+        self::assertTrue(
+            $response->isRedirect() || 401 === $response->getStatusCode() || 403 === $response->getStatusCode(),
+            'Unauthenticated access must be redirected or denied, got ' . $response->getStatusCode(),
+        );
+    }
+}

--- a/site/tests/Integration/MarketplaceAds/Controller/Api/AdLoadJobsListControllerTest.php
+++ b/site/tests/Integration/MarketplaceAds/Controller/Api/AdLoadJobsListControllerTest.php
@@ -17,7 +17,7 @@ final class AdLoadJobsListControllerTest extends WebTestCaseBase
     private const OWNER_ID = '22222222-2222-2222-2222-d00000000001';
     private const OTHER_OWNER_ID = '22222222-2222-2222-2222-d00000000002';
 
-    public function testReturnsOnlyOwnCompanyJobsSortedDesc(): void
+    public function testReturnsJobsOrderedByCreatedAtDesc(): void
     {
         $client = static::createClient();
         $this->resetDb();
@@ -47,20 +47,21 @@ final class AdLoadJobsListControllerTest extends WebTestCaseBase
         $em->persist($otherCompany);
         $em->flush();
 
+        $now = new \DateTimeImmutable('2026-04-19 12:00:00');
+
         $olderJob = AdLoadJobBuilder::aJob()
             ->withCompanyId(self::COMPANY_ID)
             ->withIndex(1)
             ->withDateRange(new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-10'))
+            ->withCreatedAt($now->modify('-2 seconds'))
             ->asCompleted()
             ->build();
-
-        // Небольшая задержка для корректного ORDER BY createdAt DESC
-        usleep(10000);
 
         $newerJob = AdLoadJobBuilder::aJob()
             ->withCompanyId(self::COMPANY_ID)
             ->withIndex(2)
             ->withDateRange(new \DateTimeImmutable('2026-02-01'), new \DateTimeImmutable('2026-02-10'))
+            ->withCreatedAt($now)
             ->asRunning()
             ->build();
 
@@ -68,6 +69,7 @@ final class AdLoadJobsListControllerTest extends WebTestCaseBase
             ->withCompanyId(self::OTHER_COMPANY_ID)
             ->withIndex(3)
             ->withDateRange(new \DateTimeImmutable('2026-03-01'), new \DateTimeImmutable('2026-03-10'))
+            ->withCreatedAt($now->modify('-1 second'))
             ->build();
 
         $em->persist($olderJob);
@@ -92,7 +94,7 @@ final class AdLoadJobsListControllerTest extends WebTestCaseBase
         self::assertSame($newerJob->getId(), $data['items'][0]['id']);
         self::assertSame($olderJob->getId(), $data['items'][1]['id']);
 
-        // Проверяем форму JSON
+        // Shape of the JSON item
         self::assertSame('running', $data['items'][0]['status']);
         self::assertSame('2026-02-01', $data['items'][0]['dateFrom']);
         self::assertSame('2026-02-10', $data['items'][0]['dateTo']);
@@ -121,16 +123,18 @@ final class AdLoadJobsListControllerTest extends WebTestCaseBase
         $em->persist($company);
         $em->flush();
 
+        $base = new \DateTimeImmutable('2026-04-19 12:00:00');
+
         for ($i = 1; $i <= 25; ++$i) {
             $job = AdLoadJobBuilder::aJob()
                 ->withCompanyId(self::COMPANY_ID)
                 ->withIndex($i)
                 ->withMarketplace(MarketplaceType::OZON)
+                ->withCreatedAt($base->modify(sprintf('-%d seconds', 25 - $i)))
                 ->build();
             $em->persist($job);
-            $em->flush();
-            usleep(5000);
         }
+        $em->flush();
 
         $client->loginUser($owner);
         $session = $client->getContainer()->get('session');
@@ -143,5 +147,70 @@ final class AdLoadJobsListControllerTest extends WebTestCaseBase
 
         $data = json_decode($client->getResponse()->getContent(), true);
         self::assertCount(20, $data['items']);
+    }
+
+    public function testReturnsOnlyOzonJobs(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('ads-jobs-ozon-only@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        $now = new \DateTimeImmutable('2026-04-19 12:00:00');
+
+        $ozon1 = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(1)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withCreatedAt($now->modify('-2 seconds'))
+            ->build();
+
+        $ozon2 = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(2)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withCreatedAt($now->modify('-1 second'))
+            ->build();
+
+        $wb = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(3)
+            ->withMarketplace(MarketplaceType::WILDBERRIES)
+            ->withCreatedAt($now)
+            ->build();
+
+        $em->persist($ozon1);
+        $em->persist($ozon2);
+        $em->persist($wb);
+        $em->flush();
+
+        $client->loginUser($owner);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', self::COMPANY_ID);
+        $session->save();
+
+        $client->request('GET', '/api/marketplace-ads/load-jobs');
+
+        self::assertResponseIsSuccessful();
+
+        $data = json_decode($client->getResponse()->getContent(), true);
+        self::assertCount(2, $data['items']);
+
+        $returnedIds = array_column($data['items'], 'id');
+        self::assertContains($ozon1->getId(), $returnedIds);
+        self::assertContains($ozon2->getId(), $returnedIds);
+        self::assertNotContains($wb->getId(), $returnedIds);
     }
 }

--- a/site/tests/Integration/MarketplaceAds/Controller/Api/AdLoadJobsListControllerTest.php
+++ b/site/tests/Integration/MarketplaceAds/Controller/Api/AdLoadJobsListControllerTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\MarketplaceAds\Controller\Api;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Builders\MarketplaceAds\AdLoadJobBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+
+final class AdLoadJobsListControllerTest extends WebTestCaseBase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-d00000000001';
+    private const OTHER_COMPANY_ID = '11111111-1111-1111-1111-d00000000002';
+    private const OWNER_ID = '22222222-2222-2222-2222-d00000000001';
+    private const OTHER_OWNER_ID = '22222222-2222-2222-2222-d00000000002';
+
+    public function testReturnsOnlyOwnCompanyJobsSortedDesc(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('ads-jobs-own@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $otherOwner = UserBuilder::aUser()
+            ->withId(self::OTHER_OWNER_ID)
+            ->withEmail('ads-jobs-other@example.test')
+            ->build();
+        $otherCompany = CompanyBuilder::aCompany()
+            ->withId(self::OTHER_COMPANY_ID)
+            ->withOwner($otherOwner)
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->persist($otherOwner);
+        $em->persist($otherCompany);
+        $em->flush();
+
+        $olderJob = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(1)
+            ->withDateRange(new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-10'))
+            ->asCompleted()
+            ->build();
+
+        // Небольшая задержка для корректного ORDER BY createdAt DESC
+        usleep(10000);
+
+        $newerJob = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(2)
+            ->withDateRange(new \DateTimeImmutable('2026-02-01'), new \DateTimeImmutable('2026-02-10'))
+            ->asRunning()
+            ->build();
+
+        $otherJob = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::OTHER_COMPANY_ID)
+            ->withIndex(3)
+            ->withDateRange(new \DateTimeImmutable('2026-03-01'), new \DateTimeImmutable('2026-03-10'))
+            ->build();
+
+        $em->persist($olderJob);
+        $em->persist($newerJob);
+        $em->persist($otherJob);
+        $em->flush();
+
+        $client->loginUser($owner);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', self::COMPANY_ID);
+        $session->save();
+
+        $client->request('GET', '/api/marketplace-ads/load-jobs');
+
+        self::assertResponseIsSuccessful();
+
+        $data = json_decode($client->getResponse()->getContent(), true);
+        self::assertArrayHasKey('items', $data);
+        self::assertCount(2, $data['items']);
+
+        // DESC by createdAt — newer first
+        self::assertSame($newerJob->getId(), $data['items'][0]['id']);
+        self::assertSame($olderJob->getId(), $data['items'][1]['id']);
+
+        // Проверяем форму JSON
+        self::assertSame('running', $data['items'][0]['status']);
+        self::assertSame('2026-02-01', $data['items'][0]['dateFrom']);
+        self::assertSame('2026-02-10', $data['items'][0]['dateTo']);
+        self::assertArrayHasKey('chunksTotal', $data['items'][0]);
+        self::assertArrayHasKey('createdAt', $data['items'][0]);
+        self::assertArrayHasKey('finishedAt', $data['items'][0]);
+        self::assertArrayHasKey('lastError', $data['items'][0]);
+    }
+
+    public function testLimitsTo20Items(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('ads-jobs-limit@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        for ($i = 1; $i <= 25; ++$i) {
+            $job = AdLoadJobBuilder::aJob()
+                ->withCompanyId(self::COMPANY_ID)
+                ->withIndex($i)
+                ->withMarketplace(MarketplaceType::OZON)
+                ->build();
+            $em->persist($job);
+            $em->flush();
+            usleep(5000);
+        }
+
+        $client->loginUser($owner);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', self::COMPANY_ID);
+        $session->save();
+
+        $client->request('GET', '/api/marketplace-ads/load-jobs');
+
+        self::assertResponseIsSuccessful();
+
+        $data = json_decode($client->getResponse()->getContent(), true);
+        self::assertCount(20, $data['items']);
+    }
+}

--- a/site/tests/Integration/MarketplaceAds/Controller/Api/AdRawDocumentsListControllerTest.php
+++ b/site/tests/Integration/MarketplaceAds/Controller/Api/AdRawDocumentsListControllerTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\MarketplaceAds\Controller\Api;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Builders\MarketplaceAds\AdRawDocumentBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+
+final class AdRawDocumentsListControllerTest extends WebTestCaseBase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-e00000000001';
+    private const OTHER_COMPANY_ID = '11111111-1111-1111-1111-e00000000002';
+    private const OWNER_ID = '22222222-2222-2222-2222-e00000000001';
+    private const OTHER_OWNER_ID = '22222222-2222-2222-2222-e00000000002';
+
+    public function testReturnsDocumentsFilteredByDateRange(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('ads-raw-range@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        $inside = AdRawDocumentBuilder::aRawDocument()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(1)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withReportDate(new \DateTimeImmutable('2026-03-15'))
+            ->build();
+
+        $before = AdRawDocumentBuilder::aRawDocument()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(2)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withReportDate(new \DateTimeImmutable('2026-02-28'))
+            ->build();
+
+        $after = AdRawDocumentBuilder::aRawDocument()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(3)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withReportDate(new \DateTimeImmutable('2026-04-01'))
+            ->build();
+
+        $em->persist($inside);
+        $em->persist($before);
+        $em->persist($after);
+        $em->flush();
+
+        $client->loginUser($owner);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', self::COMPANY_ID);
+        $session->save();
+
+        $client->request('GET', '/api/marketplace-ads/raw-documents?dateFrom=2026-03-01&dateTo=2026-03-31');
+
+        self::assertResponseIsSuccessful();
+
+        $data = json_decode($client->getResponse()->getContent(), true);
+        self::assertArrayHasKey('items', $data);
+        self::assertCount(1, $data['items']);
+        self::assertSame($inside->getId(), $data['items'][0]['id']);
+        self::assertSame('2026-03-15', $data['items'][0]['reportDate']);
+        self::assertArrayHasKey('status', $data['items'][0]);
+        self::assertArrayHasKey('loadedAt', $data['items'][0]);
+        self::assertArrayHasKey('processingError', $data['items'][0]);
+    }
+
+    public function testDefaultsToLast30DaysWhenNoDatesProvided(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('ads-raw-default@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        $today = new \DateTimeImmutable('today');
+
+        $recent = AdRawDocumentBuilder::aRawDocument()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(1)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withReportDate($today->modify('-5 days'))
+            ->build();
+
+        $old = AdRawDocumentBuilder::aRawDocument()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(2)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withReportDate($today->modify('-60 days'))
+            ->build();
+
+        $em->persist($recent);
+        $em->persist($old);
+        $em->flush();
+
+        $client->loginUser($owner);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', self::COMPANY_ID);
+        $session->save();
+
+        $client->request('GET', '/api/marketplace-ads/raw-documents');
+
+        self::assertResponseIsSuccessful();
+
+        $data = json_decode($client->getResponse()->getContent(), true);
+        self::assertCount(1, $data['items']);
+        self::assertSame($recent->getId(), $data['items'][0]['id']);
+    }
+
+    public function testReturns400ForInvalidDateFormat(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('ads-raw-invalid@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        $client->loginUser($owner);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', self::COMPANY_ID);
+        $session->save();
+
+        $client->request('GET', '/api/marketplace-ads/raw-documents?dateFrom=2026/03/01&dateTo=2026/03/31');
+
+        self::assertResponseStatusCodeSame(400);
+
+        $data = json_decode($client->getResponse()->getContent(), true);
+        self::assertArrayHasKey('message', $data);
+    }
+
+    public function testIdorDoesNotLeakOtherCompanyDocuments(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('ads-raw-idor@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $otherOwner = UserBuilder::aUser()
+            ->withId(self::OTHER_OWNER_ID)
+            ->withEmail('ads-raw-idor-other@example.test')
+            ->build();
+        $otherCompany = CompanyBuilder::aCompany()
+            ->withId(self::OTHER_COMPANY_ID)
+            ->withOwner($otherOwner)
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->persist($otherOwner);
+        $em->persist($otherCompany);
+        $em->flush();
+
+        $foreignDoc = AdRawDocumentBuilder::aRawDocument()
+            ->withCompanyId(self::OTHER_COMPANY_ID)
+            ->withIndex(1)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withReportDate(new \DateTimeImmutable('2026-03-05'))
+            ->build();
+
+        $em->persist($foreignDoc);
+        $em->flush();
+
+        $client->loginUser($owner);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', self::COMPANY_ID);
+        $session->save();
+
+        $client->request('GET', '/api/marketplace-ads/raw-documents?dateFrom=2026-03-01&dateTo=2026-03-31');
+
+        self::assertResponseIsSuccessful();
+
+        $data = json_decode($client->getResponse()->getContent(), true);
+        self::assertCount(0, $data['items']);
+    }
+}


### PR DESCRIPTION
## Summary
- Новая страница `/marketplace-ads` с кнопками «Загрузить с начала года» (ROLE_COMPANY_USER) и «Загрузить за период» (ROLE_COMPANY_OWNER), историей загрузок и списком сырых документов с фильтром по датам.
- Пункт «Реклама» в сайдбаре Маркетплейсов (после «Unit-экономики»).
- Рекламный UI перенесён с `/marketplace` (виджет, модалка, JS-хэндлеры удалены).

## Changes
- **Controllers**: `AdsIndexController`, `Api\AdLoadJobsListController`, `Api\AdRawDocumentsListController` (все под `ROLE_COMPANY_USER`, IDOR-safe через `ActiveCompanyService`).
- **Repository**:
  - `AdLoadJobRepository::findRecentByCompanyAndMarketplace(companyId, MarketplaceType, limit=20)`
  - `AdRawDocumentRepository::findByCompanyMarketplaceAndDateRange(companyId, marketplace, from, to)`
  - Интерфейсы обновлены.
- **Template**: `templates/marketplace_ads/index.html.twig` + twig-неймспейс `MarketplaceAds`.
- **Sidebar**: `_sidebar_marketplace.html.twig` — новый пункт «Реклама», корректная активация по префиксу `marketplace_ads_`.
- **Cleanup**: из `MarketplaceController::index` удалены `AdLoadJobRepository` и `activeOzonAdLoadJob`; из `marketplace/index.html.twig` — рекламный виджет, модалка и три JS-IIFE.

## Review fixes applied
- `findRecentByCompany` → `findRecentByCompanyAndMarketplace` — список задач фильтруется по OZON (иначе при появлении WB-рекламы они бы попали в «Рекламу Ozon»).
- `AdsIndexController::__invoke` — убран неиспользуемый `Request`.
- `AdLoadJobBuilder::withCreatedAt()` через Reflection — детерминированное упорядочение в тестах вместо `usleep()`.
- Добавлен `testReturnsOnlyOzonJobs` (2×OZON + 1×WILDBERRIES → отдаются только 2 OZON).

## Tests
- `AdsIndexControllerTest` — 200 без PERFORMANCE-подключения, 200 с подключением, редирект для неавторизованных.
- `AdLoadJobsListControllerTest` — сортировка по `createdAt DESC`, лимит 20, фильтр по OZON, IDOR (только своя компания).
- `AdRawDocumentsListControllerTest` — фильтр по датам, дефолтные 30 дней, 400 на невалидный формат, IDOR.

## Test plan
- [ ] `php bin/phpunit tests/Integration/MarketplaceAds/Controller`
- [ ] Ручная проверка `/marketplace-ads`: без Performance-подключения видно alert; с подключением — кнопки + виджет активного job'а.
- [ ] Grep `activeOzonAdLoadJob`, `data-ozon-initial-load`, `modal-ozon-ad-load-range`, `data-ad-job-id`, `ozon-ad-progress-bar` в `marketplace/index.html.twig` → ноль совпадений (подтверждено).
- [ ] Существующие endpoint'ы `/api/marketplace-ads/ozon/*` не трогались — проверить регрессией.

https://claude.ai/code