### PR TITLE
refactor(MarketplaceAds): drop dead processedDays/failedDays from AdLoadJob

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 > **Живой документ.** Обновляется после каждого нового модуля или изменения публичного контракта.
 > Читается: Claude Code (через CLAUDE.md) и Claude.ai Projects (через Knowledge).
-> Версия: 1.0 / 2026-03-28
+> Версия: 1.11 / 2026-04-19
 
 ---
 
@@ -54,6 +54,8 @@
 | `AdRawDocument` | MarketplaceAds | `string $companyId` ✅ |
 | `AdDocument` | MarketplaceAds | `string $companyId` ✅ |
 | `AdDocumentLine` | MarketplaceAds | `string $companyId` ✅ |
+| `AdLoadJob` | MarketplaceAds | `string $companyId` ✅ |
+| `AdChunkProgress` | MarketplaceAds | через `jobId` (IDOR через AdLoadJob) |
 | `ProductImport` | Catalog | `string $companyId` ✅ |
 | `ProductBarcode` | Catalog | `string $companyId` ✅ |
 | `ProductPurchasePrice` | Catalog | `string $companyId` ✅ |
@@ -97,6 +99,35 @@
 | `createdAt` / `updatedAt` | `DateTimeImmutable` | — |
 
 **Уникальность:** `UniqueConstraint` по `(company_id, marketplace, connection_type)` — одна компания может иметь два подключения к одному маркетплейсу (Seller + Performance), но только по одному каждого типа.
+
+### `AdLoadJob` — поля
+
+| Поле | Тип | Описание |
+|---|---|---|
+| `id` | `string` (UUID v7) | PK |
+| `companyId` | `string` (UUID) | Неизменяем, без setter |
+| `marketplace` | `MarketplaceType` | WB, Ozon |
+| `dateFrom` / `dateTo` | `DateTimeImmutable` | Диапазон загрузки (нормализован до 00:00, включительно) |
+| `totalDays` | `int` | Автосчёт из diff + 1 в конструкторе |
+| `loadedDays` | `int` | Атомарный счётчик фактически загруженных дней (raw SQL `UPDATE ... SET loaded_days = loaded_days + :delta`, минуя UoW) |
+| `chunksTotal` | `int` | Кол-во чанков по 62 дня, проставляется один раз в `LoadOzonAdStatisticsRangeHandler` |
+| `status` | `AdLoadJobStatus` | `pending` / `running` / `completed` / `failed` |
+| `failureReason` | `?string` | Причина FAILED |
+| `startedAt` / `finishedAt` | `?DateTimeImmutable` | — |
+| `createdAt` / `updatedAt` | `DateTimeImmutable` | — |
+
+**Финализация job'а** выполняется через COUNT по `marketplace_ad_raw_documents`: per-document FAILED-статус `AdRawDocument` — источник правды. Отдельные диагностические счётчики `processed_days` / `failed_days` удалены как мёртвые.
+
+### `AdChunkProgress` — поля
+
+| Поле | Тип | Описание |
+|---|---|---|
+| `id` | `string` (UUID v7) | PK |
+| `jobId` | `string` (UUID) | Ссылка на `AdLoadJob` |
+| `dateFrom` / `dateTo` | `DateTimeImmutable` | Диапазон чанка (нормализован до 00:00) |
+| `completedAt` | `DateTimeImmutable` | Время фиксации успеха |
+
+**Уникальность:** `UniqueConstraint` по `(job_id, date_from, date_to)` — делает фиксацию чанка идемпотентной на уровне БД. При Messenger-retry `FetchOzonAdStatisticsHandler` тот же чанк упрётся в uq-нарушение и не приведёт к двойному инкременту `loadedDays`.
 
 ---
 
@@ -263,6 +294,87 @@ getCostCategoriesForCompany(string $companyId, string $marketplace): array
 // должен явно указать SELLER или PERFORMANCE.
 // @return array{api_key: string, client_id: ?string}|null
 getConnectionCredentials(string $companyId, MarketplaceType $marketplace, MarketplaceConnectionType $connectionType): ?array
+```
+
+---
+
+## Repository — ключевые методы MarketplaceAds
+
+> Контракты репозиториев, используемых handler'ами Ozon Ads pipeline.
+> Все методы — IDOR-safe: `company_id` в WHERE там, где применимо.
+
+### `AdLoadJobRepository` (`src/MarketplaceAds/Repository/AdLoadJobRepository.php`)
+```php
+// Загрузка с IDOR-проверкой по companyId
+findByIdAndCompany(string $id, string $companyId): ?AdLoadJob
+
+// Trusted-контекст (Messenger-хендлеры): ID сгенерирован внутри системы
+find($id, $lockMode = null, $lockVersion = null): ?AdLoadJob
+
+// Последние задания компании по маркетплейсу (DESC по createdAt)
+// @return list<AdLoadJob>
+findRecentByCompanyAndMarketplace(string $companyId, MarketplaceType $marketplace, int $limit = 20): array
+
+// Последний активный (PENDING/RUNNING) job — гейт, чтобы не запускать второй параллельно
+findLatestActiveJobByCompanyAndMarketplace(string $companyId, MarketplaceType $marketplace): ?AdLoadJob
+
+// Активный job, чей диапазон включает дату — маппинг raw-документа → job
+findActiveJobCoveringDate(string $companyId, MarketplaceType $marketplace, \DateTimeImmutable $date): ?AdLoadJob
+
+// Атомарный UPDATE loaded_days = loaded_days + :delta (parallel-safe, минуя UoW).
+// @return int число обновлённых строк (0 если jobId/companyId не совпал)
+incrementLoadedDays(string $jobId, string $companyId, int $delta = 1): int
+
+// Идемпотентные terminal-переходы (raw DBAL UPDATE с guard status IN pending/running)
+markCompleted(string $jobId, string $companyId): int
+markFailed(string $jobId, string $companyId, string $reason): int
+```
+
+### `AdChunkProgressRepository` (`src/MarketplaceAds/Repository/AdChunkProgressRepository.php`)
+```php
+// Идемпотентная фиксация успеха чанка. true — фиксация прошла;
+// false — чанк уже был помечен (Messenger retry) → caller должен пропустить
+// инкремент счётчиков, иначе получим double-counting.
+markChunkCompleted(
+    string $jobId,
+    string $companyId,
+    \DateTimeImmutable $dateFrom,
+    \DateTimeImmutable $dateTo,
+): bool
+
+// Кол-во зафиксированных чанков job'а — для сравнения с chunksTotal при финализации.
+// IDOR-guard: проверяет принадлежность jobId компании через SELECT к marketplace_ad_load_jobs
+// и кидает \DomainException при несоответствии.
+countCompletedChunks(string $jobId, string $companyId): int
+```
+
+### `AdRawDocumentRepository` (`src/MarketplaceAds/Repository/AdRawDocumentRepository.php`)
+```php
+// Загрузка с IDOR-проверкой
+findByIdAndCompany(string $id, string $companyId): ?AdRawDocument
+
+// Идемпотентный переход DRAFT → FAILED через raw DBAL (минуя UoW).
+// @return int 1 — успех, 0 — уже FAILED / не наш
+markFailedWithReason(string $documentId, string $companyId, string $reason): int
+
+// COUNT документов компании за период (опц. фильтр по статусу).
+// Используется в финализации job'а: (total == processed + failed) → markCompleted.
+countByCompanyMarketplaceAndDateRange(
+    string $companyId,
+    string $marketplace,
+    \DateTimeImmutable $from,
+    \DateTimeImmutable $to,
+    ?AdRawDocumentStatus $statusFilter = null,
+): int
+
+// Документы компании за период (DESC по report_date).
+// @return list<AdRawDocument>
+findByCompanyMarketplaceAndDateRange(
+    string $companyId,
+    string $marketplace,
+    \DateTimeImmutable $from,
+    \DateTimeImmutable $to,
+): array
 ```
 
 ---
@@ -438,9 +550,24 @@ enum AdRawDocumentStatus: string
 {
     case DRAFT     = 'draft';
     case PROCESSED = 'processed';
+    case FAILED    = 'failed';
 
-    public function getLabel(): string; // Черновик / Обработан
-    public function isDraft(): bool;    // true для DRAFT
+    public function getLabel(): string;   // Черновик / Обработан / Ошибка
+    public function isDraft(): bool;      // true для DRAFT
+    public function isTerminal(): bool;   // true для PROCESSED, FAILED
+}
+```
+
+### `src/MarketplaceAds/Enum/AdLoadJobStatus.php`
+```php
+enum AdLoadJobStatus: string
+{
+    case PENDING   = 'pending';
+    case RUNNING   = 'running';
+    case COMPLETED = 'completed';
+    case FAILED    = 'failed';
+
+    public function isTerminal(): bool; // true для COMPLETED, FAILED
 }
 ```
 
@@ -614,3 +741,4 @@ paths:
 | 1.8 | 2026-04-15 | MarketplaceAds: `OzonAdClient` реализован для работы с Ozon Performance API (`https://api-performance.ozon.ru`). Credentials забираются через `MarketplaceFacade::getConnectionCredentials(..., PERFORMANCE)`; OAuth2 access-token кэшируется в Symfony Cache с TTL = `expires_in - 300`. Пайплайн `fetchAdStatistics()`: листинг SKU-кампаний → async `/api/client/statistics` батчами по 100 кампаний → polling состояния (5 сек × 36 попыток = 3 мин) → скачивание CSV → парсинг через `fgetcsv` над `php://memory` (RFC 4180, автодетект `,` или `;`) → JSON `{"rows":[{campaign_id, campaign_name, sku, spend, views, clicks}]}`. `withAuthRetry()` один раз ретраит запрос при 401 (через внутренний `OzonAuthExpiredException`), 403 сигнализируется как permanent failure без ретрая. |
 | 1.9 | 2026-04-15 | MarketplaceAds: команды CLI переименованы в единый паттерн `app:marketplace-ads:*` — `marketplace-ads:load` → `app:marketplace-ads:load`, `marketplace-ads:reprocess` → `app:marketplace-ads:reprocess`. Приводит именование к общему для проекта префиксу `app:` (как у `app:marketplace:wb-daily-sync` и пр.). |
 | 1.10 | 2026-04-15 | Marketplace: UI модалки «Новое подключение» (`templates/marketplace/index.html.twig`) поддерживает два типа подключения — «Основное (Seller API)» и «Реклама (Performance API)». Тип `performance` доступен только при выборе Ozon, иначе опция скрыта и автоматически откатывается на `seller`. Form `action` переключается между `marketplace_connection_create` и `marketplace_connection_performance_create` без перезагрузки страницы; неактивный блок полей `disabled`, чтобы лишние поля не попадали в POST. В списке активных подключений для Performance подключения: суффикс «(Реклама)» к названию маркетплейса, скрыты кнопки «Синхронизировать», «За период», «Реализация», «Переобработать», строка синхронизации — статическая «—» (поллер статуса не запускается). |
+| 1.11 | 2026-04-19 | MarketplaceAds: серия задач по Ozon Ads pipeline. Новые Entity: `AdLoadJob` (пакетная загрузка за период, атомарный счётчик `loadedDays` через raw SQL), `AdChunkProgress` (идемпотентная фиксация успеха чанка через `UniqueConstraint` `(job_id, date_from, date_to)`). Новый Message `LoadOzonAdStatisticsRangeMessage` + handler-оркестратор: PENDING → RUNNING, разбиение диапазона на чанки ≤ 62 дня (лимит Ozon Performance API), dispatch `FetchOzonAdStatisticsMessage` на каждый чанк. `FetchOzonAdStatisticsHandler`: upsert AdRawDocument + идемпотентный `markChunkCompleted` + inc `loadedDays` только при успешной фиксации чанка. Enum `AdRawDocumentStatus` расширен кейсом `FAILED` (+`isTerminal()`); финализация job'а перешла на per-document статус и считает через `countByCompanyMarketplaceAndDateRange`. Удалены мёртвые counter-поля `processedDays` / `failedDays` из `AdLoadJob` (миграция `Version20260419080739`). Новые методы репозиториев: `AdLoadJobRepository::markCompleted` / `markFailed` / `findRecentByCompanyAndMarketplace`; `AdChunkProgressRepository::markChunkCompleted` / `countCompletedChunks`; `AdRawDocumentRepository::markFailedWithReason` / `countByCompanyMarketplaceAndDateRange` / `findByCompanyMarketplaceAndDateRange`. |

--- a/site/migrations/Version20260419080739.php
+++ b/site/migrations/Version20260419080739.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * MarketplaceAds: удалить мёртвые counter-колонки processed_days / failed_days
+ * из marketplace_ad_load_jobs.
+ *
+ * Финализация job'а перешла на per-document FAILED-статус AdRawDocument:
+ * успех/неуспех задания считается через COUNT по marketplace_ad_raw_documents,
+ * отдельные диагностические счётчики в job'е больше не используются.
+ */
+final class Version20260419080739 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'MarketplaceAds: drop dead processed_days / failed_days columns from marketplace_ad_load_jobs';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE marketplace_ad_load_jobs DROP COLUMN processed_days');
+        $this->addSql('ALTER TABLE marketplace_ad_load_jobs DROP COLUMN failed_days');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE marketplace_ad_load_jobs ADD COLUMN processed_days INT NOT NULL DEFAULT 0');
+        $this->addSql('ALTER TABLE marketplace_ad_load_jobs ADD COLUMN failed_days INT NOT NULL DEFAULT 0');
+    }
+}

--- a/site/src/MarketplaceAds/Entity/AdLoadJob.php
+++ b/site/src/MarketplaceAds/Entity/AdLoadJob.php
@@ -14,9 +14,11 @@ use Webmozart\Assert\Assert;
 /**
  * Задание на пакетную загрузку рекламных отчётов за период.
  *
- * Прогресс-счётчики (loadedDays/processedDays/failedDays) инкрементируются
- * параллельными воркерами через атомарный `UPDATE ... SET x = x + :delta`
- * в Repository, минуя Doctrine UoW.
+ * Счётчик loadedDays инкрементируется параллельными воркерами через атомарный
+ * `UPDATE ... SET x = x + :delta` в Repository, минуя Doctrine UoW.
+ * Финализация (успех / неуспех) считается через COUNT по AdRawDocument:
+ * статус каждого документа (DRAFT/PROCESSED/FAILED) — источник правды, а не
+ * отдельные диагностические счётчики в job'е.
  */
 #[ORM\Entity(repositoryClass: AdLoadJobRepository::class)]
 #[ORM\Table(name: 'marketplace_ad_load_jobs')]
@@ -46,12 +48,6 @@ class AdLoadJob
 
     #[ORM\Column(type: 'integer', options: ['default' => 0])]
     private int $loadedDays = 0;
-
-    #[ORM\Column(type: 'integer', options: ['default' => 0])]
-    private int $processedDays = 0;
-
-    #[ORM\Column(type: 'integer', options: ['default' => 0])]
-    private int $failedDays = 0;
 
     #[ORM\Column(type: 'integer', options: ['default' => 0])]
     private int $chunksTotal = 0;
@@ -164,7 +160,7 @@ class AdLoadJob
     }
 
     /**
-     * Доля выполненных шагов (loaded + failed) относительно totalDays, 0..100.
+     * Доля загруженных дней относительно totalDays, 0..100.
      * Округление — до целого процента, чтобы UI не «дёргался» на долях.
      */
     public function getProgress(): int
@@ -173,8 +169,7 @@ class AdLoadJob
             return 0;
         }
 
-        $done = $this->loadedDays + $this->failedDays;
-        $progress = (int) floor(($done * 100) / $this->totalDays);
+        $progress = (int) floor(($this->loadedDays * 100) / $this->totalDays);
 
         return min(100, max(0, $progress));
     }
@@ -212,16 +207,6 @@ class AdLoadJob
     public function getLoadedDays(): int
     {
         return $this->loadedDays;
-    }
-
-    public function getProcessedDays(): int
-    {
-        return $this->processedDays;
-    }
-
-    public function getFailedDays(): int
-    {
-        return $this->failedDays;
     }
 
     public function getChunksTotal(): int

--- a/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
@@ -43,10 +43,8 @@ use Symfony\Component\Messenger\MessageBusInterface;
  *  - OzonPermanentApiException (403, missing credentials): permanent →
  *    markFailed(job) + UnrecoverableMessageHandlingException.
  *  - Прочие \Throwable (5xx, сеть, JSON-ошибки): transient → rethrow
- *    (Messenger ретраит по стратегии async). failed_days здесь НЕ инкрементим:
- *    при max_retries=3 получили бы +chunkDays на каждую попытку (итого 4·chunkDays
- *    для одного реально упавшего чанка), что ломает прогресс. Когда retry'и
- *    исчерпаются, message уйдёт в failed-транспорт — его разбирает оператор.
+ *    (Messenger ретраит по стратегии async). Когда retry'и исчерпаются,
+ *    message уйдёт в failed-транспорт — его разбирает оператор.
  *
  * Порядок операций строгий: save() → flush() → incrementLoadedDays() →
  * dispatch(ProcessAdRawDocumentMessage). Иначе ProcessAdRawDocumentHandler
@@ -157,9 +155,6 @@ final class FetchOzonAdStatisticsHandler
             );
         } catch (\Throwable $e) {
             // Сетевые сбои / 5xx / JSON-ошибки — transient, Messenger сделает retry.
-            // failed_days НЕ инкрементим: иначе при max_retries=3 одна реальная
-            // поломка чанка даст +4·chunkDays (после каждого из 4 аттемптов),
-            // прогресс задания уйдёт в минус / выше 100%.
             $this->logger->error('Transient failure loading Ozon ad statistics chunk', $e, [
                 'jobId' => $message->jobId,
                 'companyId' => $message->companyId,
@@ -244,7 +239,7 @@ final class FetchOzonAdStatisticsHandler
             // по count($documents): Ozon легитимно возвращает меньше дней, чем
             // запросили, если за какие-то дни вообще нет кампаний. Если брать
             // count($documents), такие «пустые» дни навсегда останутся
-            // непосчитанными в прогрессе, и (loaded + failed) не дорастёт до total.
+            // непосчитанными в прогрессе, и loaded не дорастёт до total.
             $loadedDelta = $chunkDays - $skippedDays;
             if ($loadedDelta > 0) {
                 $this->adLoadJobRepository->incrementLoadedDays(
@@ -255,11 +250,15 @@ final class FetchOzonAdStatisticsHandler
             }
 
             if ($skippedDays > 0) {
-                $this->adLoadJobRepository->incrementFailedDays(
-                    $message->jobId,
-                    $message->companyId,
-                    $skippedDays,
-                );
+                // Per-document FAILED-статус AdRawDocument — источник правды по
+                // неуспехам; здесь оставляем предупреждение для наблюдаемости чанка.
+                $this->logger->warning('Ozon ad chunk had skipped days', [
+                    'jobId' => $message->jobId,
+                    'companyId' => $message->companyId,
+                    'dateFrom' => $message->dateFrom,
+                    'dateTo' => $message->dateTo,
+                    'skippedDays' => $skippedDays,
+                ]);
             }
         }
 

--- a/site/src/MarketplaceAds/MessageHandler/LoadOzonAdStatisticsRangeHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/LoadOzonAdStatisticsRangeHandler.php
@@ -30,7 +30,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
  *
  * Финализация job'а (markCompleted) — ответственность ProcessAdRawDocumentHandler:
  * как только все чанки зафиксированы в marketplace_ad_chunk_progress И все документы
- * обработаны, он проверяет failed_days и помечает job completed / failed.
+ * обработаны, он считает COUNT по AdRawDocument и помечает job completed / failed.
  */
 #[AsMessageHandler]
 final class LoadOzonAdStatisticsRangeHandler

--- a/site/src/MarketplaceAds/Repository/AdLoadJobRepository.php
+++ b/site/src/MarketplaceAds/Repository/AdLoadJobRepository.php
@@ -115,16 +115,6 @@ class AdLoadJobRepository extends ServiceEntityRepository implements AdLoadJobRe
         return $this->atomicIncrement('loaded_days', $jobId, $companyId, $delta);
     }
 
-    public function incrementProcessedDays(string $jobId, string $companyId, int $delta = 1): int
-    {
-        return $this->atomicIncrement('processed_days', $jobId, $companyId, $delta);
-    }
-
-    public function incrementFailedDays(string $jobId, string $companyId, int $delta = 1): int
-    {
-        return $this->atomicIncrement('failed_days', $jobId, $companyId, $delta);
-    }
-
     /**
      * Помечает задание как FAILED через raw DBAL UPDATE (минуя UoW).
      *
@@ -196,7 +186,7 @@ class AdLoadJobRepository extends ServiceEntityRepository implements AdLoadJobRe
     {
         // Whitelist — защита от SQL-injection через имя колонки (параметризовать имя
         // колонки нельзя, только значение).
-        if (!in_array($column, ['loaded_days', 'processed_days', 'failed_days'], true)) {
+        if ('loaded_days' !== $column) {
             throw new \InvalidArgumentException(sprintf('Недопустимое имя колонки: %s', $column));
         }
 

--- a/site/tests/Builders/MarketplaceAds/AdLoadJobBuilder.php
+++ b/site/tests/Builders/MarketplaceAds/AdLoadJobBuilder.php
@@ -21,8 +21,6 @@ final class AdLoadJobBuilder
     private AdLoadJobStatus $status = AdLoadJobStatus::PENDING;
     private ?string $failureReason = null;
     private int $loadedDays = 0;
-    private int $processedDays = 0;
-    private int $failedDays = 0;
     private int $chunksTotal = 0;
     private ?\DateTimeImmutable $createdAt = null;
 
@@ -105,22 +103,6 @@ final class AdLoadJobBuilder
         return $clone;
     }
 
-    public function withProcessed(int $days): self
-    {
-        $clone = clone $this;
-        $clone->processedDays = $days;
-
-        return $clone;
-    }
-
-    public function withFailed(int $days): self
-    {
-        $clone = clone $this;
-        $clone->failedDays = $days;
-
-        return $clone;
-    }
-
     public function withChunksTotal(int $total): self
     {
         $clone = clone $this;
@@ -153,12 +135,6 @@ final class AdLoadJobBuilder
         // Для произвольного состояния в тестах используем Reflection.
         if ($this->loadedDays !== 0) {
             $this->setProperty($job, 'loadedDays', $this->loadedDays);
-        }
-        if ($this->processedDays !== 0) {
-            $this->setProperty($job, 'processedDays', $this->processedDays);
-        }
-        if ($this->failedDays !== 0) {
-            $this->setProperty($job, 'failedDays', $this->failedDays);
         }
         if ($this->chunksTotal !== 0) {
             $this->setProperty($job, 'chunksTotal', $this->chunksTotal);

--- a/site/tests/Integration/MarketplaceAds/AdLoadJobRepositoryTest.php
+++ b/site/tests/Integration/MarketplaceAds/AdLoadJobRepositoryTest.php
@@ -266,30 +266,6 @@ final class AdLoadJobRepositoryTest extends IntegrationTestCase
         self::assertSame(5, $reloaded->getLoadedDays(), 'Счётчик не должен измениться от чужого company_id');
     }
 
-    public function testIncrementProcessedAndFailedDays(): void
-    {
-        $this->seedCompany(self::COMPANY_ID, self::OWNER_ID, 'a@example.test');
-        $this->em->flush();
-
-        $job = AdLoadJobBuilder::aJob()
-            ->withCompanyId(self::COMPANY_ID)
-            ->withIndex(1)
-            ->build();
-        $this->repository->save($job);
-        $this->em->flush();
-        $jobId = $job->getId();
-        $this->em->clear();
-
-        $this->repository->incrementProcessedDays($jobId, self::COMPANY_ID, 3);
-        $this->repository->incrementFailedDays($jobId, self::COMPANY_ID, 2);
-
-        $reloaded = $this->repository->findByIdAndCompany($jobId, self::COMPANY_ID);
-        self::assertNotNull($reloaded);
-        self::assertSame(3, $reloaded->getProcessedDays());
-        self::assertSame(2, $reloaded->getFailedDays());
-        self::assertSame(0, $reloaded->getLoadedDays());
-    }
-
     /**
      * @dataProvider nonPositiveDeltaProvider
      */
@@ -319,39 +295,6 @@ final class AdLoadJobRepositoryTest extends IntegrationTestCase
             'negative' => [-1],
             'large negative' => [-100],
         ];
-    }
-
-    public function testIncrementProcessedAndFailedAlsoRejectNonPositiveDelta(): void
-    {
-        $this->seedCompany(self::COMPANY_ID, self::OWNER_ID, 'a@example.test');
-        $this->em->flush();
-
-        $job = AdLoadJobBuilder::aJob()
-            ->withCompanyId(self::COMPANY_ID)
-            ->withIndex(1)
-            ->build();
-        $this->repository->save($job);
-        $this->em->flush();
-        $jobId = $job->getId();
-
-        try {
-            $this->repository->incrementProcessedDays($jobId, self::COMPANY_ID, 0);
-            self::fail('Expected InvalidArgumentException for processed delta = 0');
-        } catch (\InvalidArgumentException) {
-        }
-
-        try {
-            $this->repository->incrementFailedDays($jobId, self::COMPANY_ID, -5);
-            self::fail('Expected InvalidArgumentException for failed delta = -5');
-        } catch (\InvalidArgumentException) {
-        }
-
-        // Счётчики остались по нулям — невалидный вызов не дошёл до SQL.
-        $this->em->clear();
-        $reloaded = $this->repository->findByIdAndCompany($jobId, self::COMPANY_ID);
-        self::assertNotNull($reloaded);
-        self::assertSame(0, $reloaded->getProcessedDays());
-        self::assertSame(0, $reloaded->getFailedDays());
     }
 
     public function testFindReturnsJobWithoutCompanyCheck(): void

--- a/site/tests/Unit/MarketplaceAds/AdLoadJobTest.php
+++ b/site/tests/Unit/MarketplaceAds/AdLoadJobTest.php
@@ -88,8 +88,6 @@ final class AdLoadJobTest extends TestCase
 
         self::assertSame(AdLoadJobStatus::PENDING, $job->getStatus());
         self::assertSame(0, $job->getLoadedDays());
-        self::assertSame(0, $job->getProcessedDays());
-        self::assertSame(0, $job->getFailedDays());
         self::assertNull($job->getStartedAt());
         self::assertNull($job->getFinishedAt());
         self::assertNull($job->getFailureReason());
@@ -166,12 +164,11 @@ final class AdLoadJobTest extends TestCase
         $job->markFailed('вторая попытка');
     }
 
-    public function testGetProgressComputesPercentFromLoadedPlusFailed(): void
+    public function testGetProgressComputesPercentFromLoadedDays(): void
     {
-        // 10 дней, 3 loaded + 2 failed = 50%
+        // 10 дней, 5 loaded = 50%
         $job = AdLoadJobBuilder::aJob()
-            ->withLoaded(3)
-            ->withFailed(2)
+            ->withLoaded(5)
             ->build();
 
         self::assertSame(10, $job->getTotalDays());

--- a/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
@@ -68,7 +68,6 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             ->method('incrementLoadedDays')
             ->with(self::JOB_ID, self::COMPANY_ID, 3)
             ->willReturn(1);
-        $jobRepo->expects(self::never())->method('incrementFailedDays');
 
         $ozonClient = $this->createMock(OzonAdClient::class);
         $ozonClient->expects(self::once())
@@ -132,7 +131,6 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         // Duplicate chunk: counters must NOT be incremented to avoid double-counting
         // on Messenger retry — markChunkCompleted returning false is the guard.
         $jobRepo->expects(self::never())->method('incrementLoadedDays');
-        $jobRepo->expects(self::never())->method('incrementFailedDays');
 
         $ozonClient = $this->createMock(OzonAdClient::class);
         $ozonClient->method('fetchAdStatisticsRange')->willReturn([
@@ -245,7 +243,6 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $jobRepo = $this->createMock(AdLoadJobRepository::class);
         $jobRepo->method('findByIdAndCompany')->willReturn($job);
         $jobRepo->expects(self::never())->method('markFailed');
-        $jobRepo->expects(self::never())->method('incrementFailedDays');
         $jobRepo->expects(self::never())->method('incrementLoadedDays');
 
         $ozonClient = $this->createMock(OzonAdClient::class);
@@ -304,7 +301,6 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             ->method('incrementLoadedDays')
             ->with(AdLoadJobBuilder::DEFAULT_ID, self::COMPANY_ID, 3)
             ->willReturn(1);
-        $jobRepo->expects(self::never())->method('incrementFailedDays');
         $jobRepo->expects(self::never())->method('markFailed');
 
         $ozonClient = $this->createMock(OzonAdClient::class);
@@ -353,7 +349,6 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $jobRepo->method('findByIdAndCompany')->willReturn($job);
         $jobRepo->expects(self::never())->method('markFailed');
         $jobRepo->expects(self::never())->method('incrementLoadedDays');
-        $jobRepo->expects(self::never())->method('incrementFailedDays');
 
         $ozonClient = $this->createMock(OzonAdClient::class);
         $ozonClient->expects(self::never())->method('fetchAdStatisticsRange');
@@ -393,7 +388,6 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $jobRepo->method('findByIdAndCompany')->willReturn(null);
         $jobRepo->expects(self::never())->method('markFailed');
         $jobRepo->expects(self::never())->method('incrementLoadedDays');
-        $jobRepo->expects(self::never())->method('incrementFailedDays');
 
         $ozonClient = $this->createMock(OzonAdClient::class);
         $ozonClient->expects(self::never())->method('fetchAdStatisticsRange');
@@ -438,7 +432,6 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
                 self::stringContains('Invalid date range'),
             )
             ->willReturn(1);
-        $jobRepo->expects(self::never())->method('incrementFailedDays');
         $jobRepo->expects(self::never())->method('incrementLoadedDays');
 
         $ozonClient = $this->createMock(OzonAdClient::class);
@@ -539,7 +532,6 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             ->method('incrementLoadedDays')
             ->with(AdLoadJobBuilder::DEFAULT_ID, self::COMPANY_ID, 3) // chunkDays=3, не count($documents)=1
             ->willReturn(1);
-        $jobRepo->expects(self::never())->method('incrementFailedDays');
         $jobRepo->expects(self::never())->method('markFailed');
 
         $ozonClient = $this->createMock(OzonAdClient::class);
@@ -576,8 +568,10 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
     /**
      * Сценарий 11: json_encode() === false для одного дня.
      *
-     * Невалидный UTF-8 в одном дне → день попадает в failedDays, остальные
-     * загружаются как обычно. Чанк физически отработан → markChunkCompleted вызван.
+     * Невалидный UTF-8 в одном дне пропускается, остальные загружаются как обычно.
+     * Чанк физически отработан → markChunkCompleted вызван.
+     * loaded_days инкрементируется только на число успешно сохранённых дней
+     * (chunkDays - skippedDays).
      */
     public function testJsonEncodeFailureSkipsOnlyThatDay(): void
     {
@@ -591,10 +585,6 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $jobRepo->expects(self::once())
             ->method('incrementLoadedDays')
             ->with(AdLoadJobBuilder::DEFAULT_ID, self::COMPANY_ID, 2)
-            ->willReturn(1);
-        $jobRepo->expects(self::once())
-            ->method('incrementFailedDays')
-            ->with(AdLoadJobBuilder::DEFAULT_ID, self::COMPANY_ID, 1)
             ->willReturn(1);
         $jobRepo->expects(self::never())->method('markFailed');
 


### PR DESCRIPTION
## Summary

Финализация `AdLoadJob` полностью перешла на per-document FAILED-статус `AdRawDocument` — COUNT по `marketplace_ad_raw_documents` теперь источник правды. Диагностические счётчики `processed_days` / `failed_days` в `marketplace_ad_load_jobs` больше не используются и удалены вместе с инкрементами, геттерами и ссылками из тестов / builder'а / handler'а.

- **Entity `AdLoadJob`**: удалены поля `processedDays` / `failedDays` и геттеры. `getProgress()` теперь считает только от `loadedDays`.
- **`AdLoadJobRepository`**: удалены `incrementProcessedDays` / `incrementFailedDays`, whitelist в `atomicIncrement` сужен до `loaded_days`.
- **`FetchOzonAdStatisticsHandler`**: удалён вызов `incrementFailedDays` при `skippedDays > 0`. Заменён на `logger->warning` с тем же контекстом — per-day ошибки по-прежнему логируются внутри цикла.
- **`AdLoadJobBuilder`**: удалены `withProcessed` / `withFailed`.
- **Тесты**: удалены `testIncrementProcessedAndFailedDays`, `testIncrementProcessedAndFailedAlsoRejectNonPositiveDelta`; обновлены `testGetProgressComputesPercentFromLoadedDays` и `testJsonEncodeFailureSkipsOnlyThatDay`; убраны все устаревшие `expects(never())->method('incrementFailedDays')`.
- **Migration `Version20260419080739`**: `DROP COLUMN processed_days / failed_days`. Down-миграция восстанавливает колонки с `DEFAULT 0` для безопасного отката.
- **`ARCHITECTURE.md`**: добавлены описания Entity `AdLoadJob` / `AdChunkProgress`, расширен enum `AdRawDocumentStatus` (+`FAILED` / `isTerminal`), новая секция "Repository — ключевые методы MarketplaceAds", запись в Changelog 1.11.

## Границы

- Handler-логика финализации не менялась (она уже работает через COUNT).
- `AdChunkProgress` не трогался.

## Test plan

- [ ] `php bin/phpunit tests/Unit/MarketplaceAds/AdLoadJobTest.php`
- [ ] `php bin/phpunit tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php`
- [ ] `php bin/phpunit tests/Integration/MarketplaceAds/AdLoadJobRepositoryTest.php`
- [ ] `php bin/console doctrine:migrations:migrate --dry-run` — проверить, что up/down миграции генерируются без ошибок
- [ ] После применения миграции: `\d marketplace_ad_load_jobs` не показывает `processed_days` / `failed_days`, но `loaded_days` и `chunks_total` остаются
