### PR TITLE
feat(MarketplaceAds): improve diagnostics for Ozon Performance API

### DIFF
--- a/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
+++ b/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
@@ -794,8 +794,15 @@ class OzonAdClient implements AdPlatformClientInterface
         }
 
         if ($statusCode < 200 || $statusCode >= 300) {
-            $body = $response->getContent(false);
-            $bodyPreview = mb_strimwidth($body, 0, 2000, '...');
+            try {
+                $body = $response->getContent(false);
+                $bodyPreview = mb_strimwidth($body, 0, 2000, '...');
+            } catch (TransportExceptionInterface) {
+                // Если соединение оборвётся после получения заголовков, но до
+                // дочитывания тела — всё равно отдаём наверх HTTP-код, чтобы
+                // диагностический статус не был подменён TransportException'ом.
+                $bodyPreview = '<body unavailable>';
+            }
             throw new \RuntimeException(sprintf('Ozon Performance: %s %s вернул HTTP %d, body: %s', $method, $urlOrPath, $statusCode, $bodyPreview));
         }
 

--- a/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
+++ b/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
@@ -474,6 +474,14 @@ class OzonAdClient implements AdPlatformClientInterface
         \DateTimeImmutable $dateTo,
         string $groupBy,
     ): string {
+        $this->logger->debug('Ozon Performance POST /statistics payload', [
+            'campaign_count' => count($campaignIds),
+            'from' => $dateFrom->format('Y-m-d'),
+            'to' => $dateTo->format('Y-m-d'),
+            'groupBy' => $groupBy,
+            'campaigns' => $campaignIds,
+        ]);
+
         $response = $this->authorizedRequest('POST', self::STATISTICS_PATH, $token, [
             'json' => [
                 'campaigns' => $campaignIds,
@@ -786,7 +794,9 @@ class OzonAdClient implements AdPlatformClientInterface
         }
 
         if ($statusCode < 200 || $statusCode >= 300) {
-            throw new \RuntimeException(sprintf('Ozon Performance: %s %s вернул HTTP %d', $method, $urlOrPath, $statusCode));
+            $body = $response->getContent(false);
+            $bodyPreview = mb_strimwidth($body, 0, 2000, '...');
+            throw new \RuntimeException(sprintf('Ozon Performance: %s %s вернул HTTP %d, body: %s', $method, $urlOrPath, $statusCode, $bodyPreview));
         }
 
         return $response;

--- a/site/tests/Unit/MarketplaceAds/OzonAdClientTest.php
+++ b/site/tests/Unit/MarketplaceAds/OzonAdClientTest.php
@@ -486,6 +486,37 @@ final class OzonAdClientTest extends TestCase
     }
 
     // -----------------------------------------------------------------
+    // HTTP non-2xx body propagation: RuntimeException message должен
+    // включать и код, и тело ответа (для диагностики 400 от /statistics).
+    // -----------------------------------------------------------------
+    public function testAuthorizedRequestIncludesResponseBodyInExceptionOnHttp400(): void
+    {
+        $http = new MockHttpClient([
+            // 1) token
+            new MockResponse($this->tokenBody('TKN-400')),
+            // 2) GET /campaign
+            new MockResponse($this->campaignListBody(1)),
+            // 3) POST /statistics → 400 с диагностическим телом
+            new MockResponse('{"error":"invalid campaign id"}', ['http_code' => 400]),
+        ]);
+
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger);
+
+        try {
+            $client->fetchAdStatisticsRange(
+                self::COMPANY_ID,
+                new \DateTimeImmutable('2026-03-01'),
+                new \DateTimeImmutable('2026-03-01'),
+            );
+            self::fail('Expected RuntimeException');
+        } catch (\RuntimeException $e) {
+            $msg = $e->getMessage();
+            self::assertStringContainsString('HTTP 400', $msg);
+            self::assertStringContainsString('invalid campaign id', $msg);
+        }
+    }
+
+    // -----------------------------------------------------------------
     // g) Backward-compat: fetchAdStatistics($companyId, $date) still works
     // -----------------------------------------------------------------
     public function testFetchAdStatisticsLegacyContractRemainsStable(): void


### PR DESCRIPTION
## Summary
- `authorizedRequest` now attaches the response body to the non-2xx `RuntimeException` (truncated to 2000 chars via `mb_strimwidth`) so Ozon's diagnostic payload surfaces in logs instead of only the HTTP status. 401 is still routed through `withAuthRetry`, 403 stays as `OzonPermanentApiException`.
- `requestStatistics` logs the `/statistics` POST payload at DEBUG with `campaign_count`, `from`, `to`, `groupBy`, and the full `campaigns` list — so post-mortem analysis shows which ids were submitted when Ozon rejects the batch.
- `OzonAdClientTest` gains a regression test: HTTP 400 with body `{"error":"invalid campaign id"}` must produce a `RuntimeException` whose message contains both `HTTP 400` and `invalid campaign id`.

## Test plan
- [x] `bin/phpunit tests/Unit/MarketplaceAds/OzonAdClientTest.php` — 14 tests, 153 assertions, all pass.

https://claude.ai/code/session_01R4uiRFRwt1w7uRCiiaA1wL