### PR TITLE
feat(MarketplaceAds): finalize AdLoadJob as FAILED when Messenger retries exhausted

### DIFF
--- a/site/src/MarketplaceAds/EventSubscriber/AdLoadJobFailureSubscriber.php
+++ b/site/src/MarketplaceAds/EventSubscriber/AdLoadJobFailureSubscriber.php
@@ -57,8 +57,8 @@ final class AdLoadJobFailureSubscriber implements EventSubscriberInterface
             : $throwable;
 
         $reason = $rootCause::class.': '.$rootCause->getMessage();
-        if (\strlen($reason) > self::REASON_MAX_LENGTH) {
-            $reason = substr($reason, 0, self::REASON_MAX_LENGTH);
+        if (mb_strlen($reason, 'UTF-8') > self::REASON_MAX_LENGTH) {
+            $reason = mb_substr($reason, 0, self::REASON_MAX_LENGTH, 'UTF-8');
         }
 
         $this->adLoadJobRepository->markFailed($message->jobId, $message->companyId, $reason);

--- a/site/src/MarketplaceAds/EventSubscriber/AdLoadJobFailureSubscriber.php
+++ b/site/src/MarketplaceAds/EventSubscriber/AdLoadJobFailureSubscriber.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\EventSubscriber;
+
+use App\MarketplaceAds\Message\FetchOzonAdStatisticsMessage;
+use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+
+/**
+ * Финализирует AdLoadJob как FAILED, когда FetchOzonAdStatisticsMessage
+ * окончательно исчерпал все Messenger retries.
+ *
+ * Без этого job'ы зависают в RUNNING навсегда: FetchOzonAdStatisticsHandler
+ * помечает job FAILED только на permanent-ошибках (OzonPermanentApiException,
+ * InvalidArgumentException). Transient-ошибки (502, таймауты, сетевые падения)
+ * после исчерпания retries уходят в failure transport без обновления статуса.
+ *
+ * Идемпотентен: markFailed на уровне SQL имеет guard `status IN (pending, running)`,
+ * повторный вызов на уже терминальном задании — no-op.
+ */
+final class AdLoadJobFailureSubscriber implements EventSubscriberInterface
+{
+    private const REASON_MAX_LENGTH = 1000;
+
+    public function __construct(
+        private readonly AdLoadJobRepositoryInterface $adLoadJobRepository,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            WorkerMessageFailedEvent::class => 'onMessageFailed',
+        ];
+    }
+
+    public function onMessageFailed(WorkerMessageFailedEvent $event): void
+    {
+        if ($event->willRetry()) {
+            return;
+        }
+
+        $message = $event->getEnvelope()->getMessage();
+        if (!$message instanceof FetchOzonAdStatisticsMessage) {
+            return;
+        }
+
+        $throwable = $event->getThrowable();
+        $rootCause = $throwable instanceof HandlerFailedException && null !== $throwable->getPrevious()
+            ? $throwable->getPrevious()
+            : $throwable;
+
+        $reason = $rootCause::class.': '.$rootCause->getMessage();
+        if (\strlen($reason) > self::REASON_MAX_LENGTH) {
+            $reason = substr($reason, 0, self::REASON_MAX_LENGTH);
+        }
+
+        $this->adLoadJobRepository->markFailed($message->jobId, $message->companyId, $reason);
+
+        $this->logger->warning('AdLoadJob marked as failed after retries exhausted', [
+            'job_id' => $message->jobId,
+            'company_id' => $message->companyId,
+            'message_type' => $message::class,
+            'error_class' => $rootCause::class,
+            'error_message' => $rootCause->getMessage(),
+        ]);
+    }
+}

--- a/site/tests/Unit/MarketplaceAds/EventSubscriber/AdLoadJobFailureSubscriberTest.php
+++ b/site/tests/Unit/MarketplaceAds/EventSubscriber/AdLoadJobFailureSubscriberTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MarketplaceAds\EventSubscriber;
+
+use App\MarketplaceAds\EventSubscriber\AdLoadJobFailureSubscriber;
+use App\MarketplaceAds\Message\FetchOzonAdStatisticsMessage;
+use App\MarketplaceAds\Message\ProcessAdRawDocumentMessage;
+use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+
+/**
+ * Unit-тесты AdLoadJobFailureSubscriber.
+ *
+ * Проверяемые инварианты:
+ *  1. willRetry=true → no-op (Messenger ещё сделает попытку).
+ *  2. Message не FetchOzonAdStatisticsMessage → игнорируется.
+ *  3. Исчерпанные retries → markFailed с reason вида "<Class>: <message>".
+ *  4. HandlerFailedException раскручивается до previous.
+ *  5. reason усекается до 1000 символов.
+ */
+final class AdLoadJobFailureSubscriberTest extends TestCase
+{
+    private const JOB_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+    private const COMPANY_ID = '11111111-1111-1111-1111-111111111111';
+
+    public function testWillRetryTrueIsNoOp(): void
+    {
+        $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $repo->expects(self::never())->method('markFailed');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::never())->method('warning');
+
+        $envelope = new Envelope(new FetchOzonAdStatisticsMessage(
+            self::JOB_ID,
+            self::COMPANY_ID,
+            '2026-03-01',
+            '2026-03-03',
+        ));
+        $event = new WorkerMessageFailedEvent($envelope, 'async', new \RuntimeException('transient'));
+        $event->setForRetry();
+
+        self::assertTrue($event->willRetry(), 'sanity: событие помечено для ретрая');
+
+        (new AdLoadJobFailureSubscriber($repo, $logger))->onMessageFailed($event);
+    }
+
+    public function testNonFetchMessageIsIgnored(): void
+    {
+        $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $repo->expects(self::never())->method('markFailed');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::never())->method('warning');
+
+        $envelope = new Envelope(new ProcessAdRawDocumentMessage(
+            self::COMPANY_ID,
+            'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        ));
+        $event = new WorkerMessageFailedEvent($envelope, 'async', new \RuntimeException('boom'));
+
+        self::assertFalse($event->willRetry());
+
+        (new AdLoadJobFailureSubscriber($repo, $logger))->onMessageFailed($event);
+    }
+
+    public function testExhaustedRetriesMarkJobAsFailed(): void
+    {
+        $expectedReason = \RuntimeException::class.': Ozon 502 Bad Gateway';
+
+        $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $repo->expects(self::once())
+            ->method('markFailed')
+            ->with(self::JOB_ID, self::COMPANY_ID, $expectedReason)
+            ->willReturn(1);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with(
+                'AdLoadJob marked as failed after retries exhausted',
+                self::callback(static function (array $context): bool {
+                    return self::JOB_ID === $context['job_id']
+                        && self::COMPANY_ID === $context['company_id']
+                        && FetchOzonAdStatisticsMessage::class === $context['message_type']
+                        && \RuntimeException::class === $context['error_class']
+                        && 'Ozon 502 Bad Gateway' === $context['error_message'];
+                }),
+            );
+
+        $envelope = new Envelope(new FetchOzonAdStatisticsMessage(
+            self::JOB_ID,
+            self::COMPANY_ID,
+            '2026-03-01',
+            '2026-03-03',
+        ));
+        $event = new WorkerMessageFailedEvent(
+            $envelope,
+            'async',
+            new \RuntimeException('Ozon 502 Bad Gateway'),
+        );
+
+        self::assertFalse($event->willRetry());
+
+        (new AdLoadJobFailureSubscriber($repo, $logger))->onMessageFailed($event);
+    }
+
+    public function testHandlerFailedExceptionUnwrapsToPrevious(): void
+    {
+        $previous = new \RuntimeException('real cause');
+
+        $envelope = new Envelope(new FetchOzonAdStatisticsMessage(
+            self::JOB_ID,
+            self::COMPANY_ID,
+            '2026-03-01',
+            '2026-03-03',
+        ));
+        $wrapper = new HandlerFailedException($envelope, [$previous]);
+
+        self::assertSame($previous, $wrapper->getPrevious(), 'sanity: HandlerFailedException.previous === real cause');
+
+        $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $repo->expects(self::once())
+            ->method('markFailed')
+            ->with(
+                self::JOB_ID,
+                self::COMPANY_ID,
+                \RuntimeException::class.': real cause',
+            )
+            ->willReturn(1);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with(
+                self::anything(),
+                self::callback(static function (array $context): bool {
+                    return \RuntimeException::class === $context['error_class']
+                        && 'real cause' === $context['error_message'];
+                }),
+            );
+
+        $event = new WorkerMessageFailedEvent($envelope, 'async', $wrapper);
+
+        (new AdLoadJobFailureSubscriber($repo, $logger))->onMessageFailed($event);
+    }
+
+    public function testReasonIsTruncatedTo1000Chars(): void
+    {
+        $longMessage = str_repeat('A', 5000);
+
+        $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $repo->expects(self::once())
+            ->method('markFailed')
+            ->with(
+                self::JOB_ID,
+                self::COMPANY_ID,
+                self::callback(static function (string $reason): bool {
+                    return \strlen($reason) <= 1000;
+                }),
+            )
+            ->willReturn(1);
+
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $envelope = new Envelope(new FetchOzonAdStatisticsMessage(
+            self::JOB_ID,
+            self::COMPANY_ID,
+            '2026-03-01',
+            '2026-03-03',
+        ));
+        $event = new WorkerMessageFailedEvent($envelope, 'async', new \RuntimeException($longMessage));
+
+        (new AdLoadJobFailureSubscriber($repo, $logger))->onMessageFailed($event);
+    }
+}

--- a/site/tests/Unit/MarketplaceAds/EventSubscriber/AdLoadJobFailureSubscriberTest.php
+++ b/site/tests/Unit/MarketplaceAds/EventSubscriber/AdLoadJobFailureSubscriberTest.php
@@ -151,6 +151,38 @@ final class AdLoadJobFailureSubscriberTest extends TestCase
         (new AdLoadJobFailureSubscriber($repo, $logger))->onMessageFailed($event);
     }
 
+    public function testReasonTruncationKeepsUtf8Valid(): void
+    {
+        // 5000 повторений кириллической буквы (2 байта UTF-8) = 10 000 байт.
+        // Байтовое substr порвало бы последний символ; mb_substr режет по символам.
+        $longMessage = str_repeat('ё', 5000);
+
+        $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $repo->expects(self::once())
+            ->method('markFailed')
+            ->with(
+                self::JOB_ID,
+                self::COMPANY_ID,
+                self::callback(static function (string $reason): bool {
+                    return mb_strlen($reason, 'UTF-8') <= 1000
+                        && mb_check_encoding($reason, 'UTF-8');
+                }),
+            )
+            ->willReturn(1);
+
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $envelope = new Envelope(new FetchOzonAdStatisticsMessage(
+            self::JOB_ID,
+            self::COMPANY_ID,
+            '2026-03-01',
+            '2026-03-03',
+        ));
+        $event = new WorkerMessageFailedEvent($envelope, 'async', new \RuntimeException($longMessage));
+
+        (new AdLoadJobFailureSubscriber($repo, $logger))->onMessageFailed($event);
+    }
+
     public function testReasonIsTruncatedTo1000Chars(): void
     {
         $longMessage = str_repeat('A', 5000);
@@ -162,7 +194,7 @@ final class AdLoadJobFailureSubscriberTest extends TestCase
                 self::JOB_ID,
                 self::COMPANY_ID,
                 self::callback(static function (string $reason): bool {
-                    return \strlen($reason) <= 1000;
+                    return mb_strlen($reason, 'UTF-8') <= 1000;
                 }),
             )
             ->willReturn(1);


### PR DESCRIPTION
## Summary

- Добавлен `AdLoadJobFailureSubscriber`, слушающий `WorkerMessageFailedEvent`: когда `FetchOzonAdStatisticsMessage` исчерпал Messenger retries (`willRetry() === false`), соответствующий `AdLoadJob` помечается FAILED через `AdLoadJobRepositoryInterface::markFailed` вместо того, чтобы висеть в RUNNING.
- `reason` собирается по root-cause исключению: если `WorkerMessageFailedEvent::getThrowable()` — `HandlerFailedException`, берётся `previous` (реальная ошибка из хендлера), иначе — сам throwable; формат `"<Class>: <message>"`, усекается до 1000 символов (защита от длинных stack-сообщений в `last_error TEXT`).
- Остальные Message игнорируются (`ProcessAdRawDocumentMessage` имеет собственный per-document error-flow в `ProcessAdRawDocumentHandler`).
- Subscriber идемпотентен: `markFailed` на уровне SQL имеет guard `status IN (pending, running)`, повторный вызов на уже терминальном job — no-op.
- Регистрация — через стандартный `autoconfigure: true` в `services.yaml` (ручной тег не нужен).

## Test plan

- [x] `php bin/phpunit --testsuite unit --filter AdLoadJobFailureSubscriberTest` — 5 тестов зелёные (26 ассершнов)
  - `testWillRetryTrueIsNoOp` — retry-ещё-будет → ни `markFailed`, ни `warning`
  - `testNonFetchMessageIsIgnored` — `ProcessAdRawDocumentMessage` → игнор
  - `testExhaustedRetriesMarkJobAsFailed` — `markFailed(jobId, companyId, "RuntimeException: ...")` + `warning`
  - `testHandlerFailedExceptionUnwrapsToPrevious` — reason берётся из `previous`, а не wrapper
  - `testReasonIsTruncatedTo1000Chars` — длинный message режется до 1000
- [ ] E2E / smoke на воркере — вне scope этой правки