### PR TITLE
feat(MarketplaceAds): admin endpoint to manually mark AdLoadJob as FAILED

### DIFF
--- a/site/src/MarketplaceAds/Controller/Api/Admin/MarkAdLoadJobFailedController.php
+++ b/site/src/MarketplaceAds/Controller/Api/Admin/MarkAdLoadJobFailedController.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Controller\Api\Admin;
+
+use App\Company\Entity\User;
+use App\MarketplaceAds\Repository\AdLoadJobRepository;
+use App\Shared\Service\ActiveCompanyService;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route(
+    '/api/marketplace-ads/admin/load-jobs/{jobId}/mark-failed',
+    name: 'marketplace_ads_admin_mark_load_job_failed',
+    requirements: ['jobId' => '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'],
+    methods: ['POST'],
+)]
+#[IsGranted('ROLE_COMPANY_OWNER')]
+final class MarkAdLoadJobFailedController extends AbstractController
+{
+    private const REASON_MAX_LENGTH = 1000;
+
+    public function __construct(
+        private readonly ActiveCompanyService $activeCompanyService,
+        private readonly AdLoadJobRepository $adLoadJobRepository,
+        private readonly Security $security,
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    public function __invoke(string $jobId, Request $request): JsonResponse
+    {
+        $company = $this->activeCompanyService->getActiveCompany();
+        $companyId = (string) $company->getId();
+
+        $body = json_decode($request->getContent(), true) ?? [];
+        $rawReason = (string) ($body['reason'] ?? '');
+        $reason = trim($rawReason);
+
+        if ('' === $reason) {
+            return $this->json(['error' => 'reason required'], 400);
+        }
+
+        $reason = mb_substr($reason, 0, self::REASON_MAX_LENGTH);
+
+        $affected = $this->adLoadJobRepository->markFailed($jobId, $companyId, $reason);
+
+        if (0 === $affected) {
+            return $this->json(['error' => 'Job not found or already finalized'], 404);
+        }
+
+        $user = $this->security->getUser();
+        $this->logger->warning('AdLoadJob manually marked as failed', [
+            'job_id' => $jobId,
+            'company_id' => $companyId,
+            'reason' => $reason,
+            'user_id' => $user instanceof User ? $user->getId() : null,
+        ]);
+
+        return $this->json([
+            'jobId' => $jobId,
+            'status' => 'failed',
+        ]);
+    }
+}

--- a/site/templates/marketplace_ads/index.html.twig
+++ b/site/templates/marketplace_ads/index.html.twig
@@ -85,7 +85,8 @@
                     <h3 class="card-title">История загрузок</h3>
                 </div>
                 <div class="table-responsive">
-                    <table class="table card-table table-vcenter" id="ad-load-jobs-table">
+                    <table class="table card-table table-vcenter" id="ad-load-jobs-table"
+                           data-is-company-owner="{{ is_granted('ROLE_COMPANY_OWNER') ? '1' : '0' }}">
                         <thead>
                         <tr>
                             <th>Период</th>
@@ -94,10 +95,11 @@
                             <th>Создан</th>
                             <th>Завершён</th>
                             <th>Ошибка</th>
+                            <th>Действия</th>
                         </tr>
                         </thead>
                         <tbody>
-                        <tr><td colspan="6" class="text-center text-muted">Загрузка…</td></tr>
+                        <tr><td colspan="7" class="text-center text-muted">Загрузка…</td></tr>
                         </tbody>
                     </table>
                 </div>
@@ -144,6 +146,36 @@
 
         </div>
     </div>
+
+    {# ---------- Modal: Пометить AdLoadJob как FAILED ---------- #}
+    {% if is_granted('ROLE_COMPANY_OWNER') %}
+        <div class="modal modal-blur fade" id="modal-mark-ad-load-job-failed" tabindex="-1" role="dialog" aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title">Пометить задание как FAILED</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p class="text-muted">
+                            Задание будет переведено в статус FAILED. Действие необратимо.
+                        </p>
+                        <div class="mb-3">
+                            <label class="form-label required">Причина</label>
+                            <textarea id="mark-failed-reason" class="form-control" rows="3" maxlength="1000"
+                                      placeholder="Опишите причину ручной финализации"></textarea>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn" data-bs-dismiss="modal">Отмена</button>
+                        <button type="button" class="btn btn-danger" id="btn-mark-ad-load-job-failed">
+                            Пометить FAILED
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    {% endif %}
 
     {# ---------- Modal: Загрузить рекламу Ozon за произвольный период ---------- #}
     {% if hasPerformanceConnection and is_granted('ROLE_COMPANY_OWNER') %}
@@ -208,6 +240,9 @@
                 return '<span class="badge ' + row[0] + '">' + escapeHtml(row[1]) + '</span>';
             };
 
+            var jobsTable = document.getElementById('ad-load-jobs-table');
+            var isCompanyOwner = jobsTable && jobsTable.dataset.isCompanyOwner === '1';
+
             var loadJobs = function () {
                 var tbody = document.querySelector('#ad-load-jobs-table tbody');
                 fetch('{{ path('marketplace_ads_load_jobs_list') }}', {
@@ -218,10 +253,16 @@
                     .then(function (data) {
                         var items = (data && data.items) || [];
                         if (items.length === 0) {
-                            tbody.innerHTML = '<tr><td colspan="6" class="text-center text-muted">Нет данных</td></tr>';
+                            tbody.innerHTML = '<tr><td colspan="7" class="text-center text-muted">Нет данных</td></tr>';
                             return;
                         }
                         tbody.innerHTML = items.map(function (job) {
+                            var canMarkFailed = isCompanyOwner && (job.status === 'pending' || job.status === 'running');
+                            var actionsCell = canMarkFailed
+                                ? '<td><button type="button" class="btn btn-sm btn-outline-danger" '
+                                    + 'data-mark-failed data-job-id="' + escapeHtml(job.id) + '">'
+                                    + 'Пометить FAILED</button></td>'
+                                : '<td></td>';
                             return '<tr>'
                                 + '<td><small>' + escapeHtml(job.dateFrom) + ' — ' + escapeHtml(job.dateTo) + '</small></td>'
                                 + '<td>' + jobStatusBadge(job.status) + '</td>'
@@ -229,11 +270,12 @@
                                 + '<td><small>' + escapeHtml(job.createdAt) + '</small></td>'
                                 + '<td><small>' + escapeHtml(job.finishedAt || '—') + '</small></td>'
                                 + '<td><small class="text-danger">' + escapeHtml(job.lastError || '') + '</small></td>'
+                                + actionsCell
                                 + '</tr>';
                         }).join('');
                     })
                     .catch(function () {
-                        tbody.innerHTML = '<tr><td colspan="6" class="text-center text-danger">Ошибка загрузки</td></tr>';
+                        tbody.innerHTML = '<tr><td colspan="7" class="text-center text-danger">Ошибка загрузки</td></tr>';
                     });
             };
 
@@ -352,6 +394,66 @@
                             alert('Ошибка сети: ' + err.message);
                             rangeBtn.disabled = false;
                             rangeBtn.innerHTML = 'Загрузить';
+                        });
+                });
+            }
+
+            // Ручная пометка AdLoadJob как FAILED (только ROLE_COMPANY_OWNER)
+            var markFailedModalEl = document.getElementById('modal-mark-ad-load-job-failed');
+            var markFailedBtn = document.getElementById('btn-mark-ad-load-job-failed');
+            var markFailedReasonEl = document.getElementById('mark-failed-reason');
+            var markFailedJobId = null;
+
+            var openMarkFailedModal = function (jobId) {
+                markFailedJobId = jobId;
+                if (markFailedReasonEl) markFailedReasonEl.value = '';
+                var BootstrapModal = window.bootstrap && window.bootstrap.Modal;
+                if (BootstrapModal && markFailedModalEl) {
+                    BootstrapModal.getOrCreateInstance(markFailedModalEl).show();
+                }
+            };
+
+            document.addEventListener('click', function (e) {
+                var btn = e.target.closest('[data-mark-failed]');
+                if (!btn) return;
+                openMarkFailedModal(btn.dataset.jobId);
+            });
+
+            if (markFailedBtn) {
+                markFailedBtn.addEventListener('click', function () {
+                    if (!markFailedJobId) return;
+                    var reason = (markFailedReasonEl && markFailedReasonEl.value) || '';
+                    if (!reason.trim()) {
+                        alert('Укажите причину');
+                        return;
+                    }
+                    markFailedBtn.disabled = true;
+                    var original = markFailedBtn.innerHTML;
+                    markFailedBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Выполняется...';
+                    fetch('/api/marketplace-ads/admin/load-jobs/' + encodeURIComponent(markFailedJobId) + '/mark-failed', {
+                        method: 'POST',
+                        credentials: 'same-origin',
+                        headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
+                        body: JSON.stringify({reason: reason}),
+                    })
+                        .then(function (r) { return r.json().then(function (d) { return {ok: r.ok, data: d}; }); })
+                        .then(function (res) {
+                            if (res.ok) {
+                                window.location.reload();
+                            } else {
+                                var BootstrapModal = window.bootstrap && window.bootstrap.Modal;
+                                if (BootstrapModal && markFailedModalEl) {
+                                    BootstrapModal.getOrCreateInstance(markFailedModalEl).hide();
+                                }
+                                alert('Ошибка: ' + ((res.data && res.data.error) || 'Неизвестная ошибка'));
+                                markFailedBtn.disabled = false;
+                                markFailedBtn.innerHTML = original;
+                            }
+                        })
+                        .catch(function (err) {
+                            alert('Ошибка сети: ' + err.message);
+                            markFailedBtn.disabled = false;
+                            markFailedBtn.innerHTML = original;
                         });
                 });
             }

--- a/site/tests/Integration/MarketplaceAds/Controller/Api/Admin/MarkAdLoadJobFailedControllerTest.php
+++ b/site/tests/Integration/MarketplaceAds/Controller/Api/Admin/MarkAdLoadJobFailedControllerTest.php
@@ -1,0 +1,352 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\MarketplaceAds\Controller\Api\Admin;
+
+use App\MarketplaceAds\Entity\AdLoadJob;
+use App\MarketplaceAds\Enum\AdLoadJobStatus;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Builders\MarketplaceAds\AdLoadJobBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+
+final class MarkAdLoadJobFailedControllerTest extends WebTestCaseBase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-f00000000001';
+    private const OTHER_COMPANY_ID = '11111111-1111-1111-1111-f00000000002';
+    private const OWNER_ID = '22222222-2222-2222-2222-f00000000001';
+    private const OTHER_OWNER_ID = '22222222-2222-2222-2222-f00000000002';
+
+    public function testMarksPendingJobAsFailed(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('mark-failed-happy@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(1)
+            ->asRunning()
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->persist($job);
+        $em->flush();
+
+        $this->loginAs($client, $owner, self::COMPANY_ID);
+
+        $client->request(
+            'POST',
+            '/api/marketplace-ads/admin/load-jobs/' . $job->getId() . '/mark-failed',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json', 'HTTP_X-Requested-With' => 'XMLHttpRequest'],
+            json_encode(['reason' => 'Зависло, добиваем вручную']),
+        );
+
+        self::assertResponseIsSuccessful();
+
+        $data = json_decode($client->getResponse()->getContent(), true);
+        self::assertSame($job->getId(), $data['jobId']);
+        self::assertSame('failed', $data['status']);
+
+        $em->clear();
+        $reloaded = $em->find(AdLoadJob::class, $job->getId());
+        self::assertNotNull($reloaded);
+        self::assertSame(AdLoadJobStatus::FAILED, $reloaded->getStatus());
+        self::assertSame('Зависло, добиваем вручную', $reloaded->getFailureReason());
+        self::assertNotNull($reloaded->getFinishedAt());
+    }
+
+    public function testReturns400WhenReasonIsEmpty(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('mark-failed-empty@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(1)
+            ->asRunning()
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->persist($job);
+        $em->flush();
+
+        $this->loginAs($client, $owner, self::COMPANY_ID);
+
+        $client->request(
+            'POST',
+            '/api/marketplace-ads/admin/load-jobs/' . $job->getId() . '/mark-failed',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json', 'HTTP_X-Requested-With' => 'XMLHttpRequest'],
+            json_encode(['reason' => '']),
+        );
+
+        self::assertResponseStatusCodeSame(400);
+
+        $data = json_decode($client->getResponse()->getContent(), true);
+        self::assertSame('reason required', $data['error']);
+    }
+
+    public function testReturns400WhenReasonIsWhitespaceOnly(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('mark-failed-spaces@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(1)
+            ->asRunning()
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->persist($job);
+        $em->flush();
+
+        $this->loginAs($client, $owner, self::COMPANY_ID);
+
+        $client->request(
+            'POST',
+            '/api/marketplace-ads/admin/load-jobs/' . $job->getId() . '/mark-failed',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json', 'HTTP_X-Requested-With' => 'XMLHttpRequest'],
+            json_encode(['reason' => "   \t\n  "]),
+        );
+
+        self::assertResponseStatusCodeSame(400);
+
+        $data = json_decode($client->getResponse()->getContent(), true);
+        self::assertSame('reason required', $data['error']);
+    }
+
+    public function testReturns404WhenJobBelongsToAnotherCompany(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('mark-failed-idor-own@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $otherOwner = UserBuilder::aUser()
+            ->withId(self::OTHER_OWNER_ID)
+            ->withEmail('mark-failed-idor-other@example.test')
+            ->build();
+        $otherCompany = CompanyBuilder::aCompany()
+            ->withId(self::OTHER_COMPANY_ID)
+            ->withOwner($otherOwner)
+            ->build();
+
+        $otherJob = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::OTHER_COMPANY_ID)
+            ->withIndex(1)
+            ->asRunning()
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->persist($otherOwner);
+        $em->persist($otherCompany);
+        $em->persist($otherJob);
+        $em->flush();
+
+        $this->loginAs($client, $owner, self::COMPANY_ID);
+
+        $client->request(
+            'POST',
+            '/api/marketplace-ads/admin/load-jobs/' . $otherJob->getId() . '/mark-failed',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json', 'HTTP_X-Requested-With' => 'XMLHttpRequest'],
+            json_encode(['reason' => 'атака']),
+        );
+
+        self::assertResponseStatusCodeSame(404);
+
+        $data = json_decode($client->getResponse()->getContent(), true);
+        self::assertSame('Job not found or already finalized', $data['error']);
+
+        $em->clear();
+        $reloaded = $em->find(AdLoadJob::class, $otherJob->getId());
+        self::assertNotNull($reloaded);
+        self::assertSame(AdLoadJobStatus::RUNNING, $reloaded->getStatus());
+        self::assertNull($reloaded->getFailureReason());
+    }
+
+    public function testReturns404WhenJobIsAlreadyCompleted(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('mark-failed-completed@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(1)
+            ->asCompleted()
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->persist($job);
+        $em->flush();
+
+        $this->loginAs($client, $owner, self::COMPANY_ID);
+
+        $client->request(
+            'POST',
+            '/api/marketplace-ads/admin/load-jobs/' . $job->getId() . '/mark-failed',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json', 'HTTP_X-Requested-With' => 'XMLHttpRequest'],
+            json_encode(['reason' => 'поздно']),
+        );
+
+        self::assertResponseStatusCodeSame(404);
+
+        $data = json_decode($client->getResponse()->getContent(), true);
+        self::assertSame('Job not found or already finalized', $data['error']);
+
+        $em->clear();
+        $reloaded = $em->find(AdLoadJob::class, $job->getId());
+        self::assertSame(AdLoadJobStatus::COMPLETED, $reloaded->getStatus());
+    }
+
+    public function testReturns403WhenUserIsNotCompanyOwner(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('mark-failed-403-owner@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $regular = UserBuilder::aUser()
+            ->withId(self::OTHER_OWNER_ID)
+            ->withEmail('mark-failed-403-user@example.test')
+            ->withRoles(['ROLE_COMPANY_USER'])
+            ->build();
+
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(1)
+            ->asRunning()
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->persist($regular);
+        $em->persist($job);
+        $em->flush();
+
+        $this->loginAs($client, $regular, self::COMPANY_ID);
+
+        $client->request(
+            'POST',
+            '/api/marketplace-ads/admin/load-jobs/' . $job->getId() . '/mark-failed',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json', 'HTTP_X-Requested-With' => 'XMLHttpRequest'],
+            json_encode(['reason' => 'попытка']),
+        );
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testReturns404WhenJobIdIsNotUuid(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('mark-failed-notuuid@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        $this->loginAs($client, $owner, self::COMPANY_ID);
+
+        $client->request(
+            'POST',
+            '/api/marketplace-ads/admin/load-jobs/not-a-uuid/mark-failed',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json', 'HTTP_X-Requested-With' => 'XMLHttpRequest'],
+            json_encode(['reason' => 'x']),
+        );
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    private function loginAs($client, $user, string $companyId): void
+    {
+        $client->loginUser($user);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', $companyId);
+        $session->save();
+    }
+}


### PR DESCRIPTION
## Summary

Добавляет ручную финализацию зависших `AdLoadJob` для админских операций восстановления после сбоев пайплайна.

- **Controller** `MarkAdLoadJobFailedController` (`POST /api/marketplace-ads/admin/load-jobs/{jobId}/mark-failed`) под `ROLE_COMPANY_OWNER`. Читает JSON `{reason}`, валидирует (trim, непустой, обрезает до 1000 символов через `mb_substr`), вызывает `AdLoadJobRepository::markFailed($jobId, $companyId, $reason)`. IDOR-защита — `company_id` в `WHERE` SQL; guard на `status IN ('pending','running')` в самом `markFailed`.
- **Route-level UUID requirement** — битый `jobId` (не UUID) возвращает 404 из роутера без попытки SQL-запроса.
- **UI** — колонка «Действия» в таблице «История загрузок» (`templates/marketplace_ads/index.html.twig`): кнопка «Пометить FAILED» только для `pending/running` jobs и только для `ROLE_COMPANY_OWNER`; confirm-модалка с textarea reason; на успех `reload`, на 400/404 — alert.
- **Логирование** — `warning "AdLoadJob manually marked as failed"` с `job_id`, `company_id`, `reason`, `user_id`.

## Test plan

- [x] Integration-тесты: happy path (200 + `status=FAILED` + `lastError=reason` в БД)
- [x] Пустой `reason` → 400
- [x] `reason` из пробелов → 400
- [x] IDOR (чужой company) → 404, job в БД не изменён
- [x] Уже `COMPLETED` → 404, guard в `markFailed` блокирует
- [x] `ROLE_COMPANY_USER` без OWNER → 403
- [x] Невалидный `jobId` (не UUID) → 404 из роутера

> Тесты не запускались локально: в окружении нет `vendor/` и нет доступа к docker-демону. Требуется прогон на CI.

https://claude.ai/code/session_01QfZx5CnsunCNnSPUJW7ETi