### PR TITLE
fix(MarketplaceAds): open mark-FAILED modal via Tabler bs-toggle

### DIFF
--- a/site/templates/marketplace_ads/index.html.twig
+++ b/site/templates/marketplace_ads/index.html.twig
@@ -262,7 +262,7 @@
                                 ? '<td><button type="button" class="btn btn-sm btn-outline-danger" '
                                     + 'data-bs-toggle="modal" '
                                     + 'data-bs-target="#modal-mark-ad-load-job-failed" '
-                                    + 'data-mark-failed data-job-id="' + escapeHtml(job.id) + '">'
+                                    + 'data-job-id="' + escapeHtml(job.id) + '">'
                                     + 'Пометить FAILED</button></td>'
                                 : '<td></td>';
                             return '<tr>'
@@ -410,9 +410,7 @@
                 if (!markFailedModalEl) return;
                 var BootstrapModal = window.bootstrap && window.bootstrap.Modal;
                 if (BootstrapModal) {
-                    var instance = BootstrapModal.getInstance(markFailedModalEl)
-                        || BootstrapModal.getOrCreateInstance(markFailedModalEl);
-                    instance.hide();
+                    BootstrapModal.getOrCreateInstance(markFailedModalEl).hide();
                     return;
                 }
                 var closeBtn = markFailedModalEl.querySelector('[data-bs-dismiss="modal"]');

--- a/site/templates/marketplace_ads/index.html.twig
+++ b/site/templates/marketplace_ads/index.html.twig
@@ -260,6 +260,8 @@
                             var canMarkFailed = isCompanyOwner && (job.status === 'pending' || job.status === 'running');
                             var actionsCell = canMarkFailed
                                 ? '<td><button type="button" class="btn btn-sm btn-outline-danger" '
+                                    + 'data-bs-toggle="modal" '
+                                    + 'data-bs-target="#modal-mark-ad-load-job-failed" '
                                     + 'data-mark-failed data-job-id="' + escapeHtml(job.id) + '">'
                                     + 'Пометить FAILED</button></td>'
                                 : '<td></td>';
@@ -404,20 +406,26 @@
             var markFailedReasonEl = document.getElementById('mark-failed-reason');
             var markFailedJobId = null;
 
-            var openMarkFailedModal = function (jobId) {
-                markFailedJobId = jobId;
-                if (markFailedReasonEl) markFailedReasonEl.value = '';
+            var hideMarkFailedModal = function () {
+                if (!markFailedModalEl) return;
                 var BootstrapModal = window.bootstrap && window.bootstrap.Modal;
-                if (BootstrapModal && markFailedModalEl) {
-                    BootstrapModal.getOrCreateInstance(markFailedModalEl).show();
+                if (BootstrapModal) {
+                    var instance = BootstrapModal.getInstance(markFailedModalEl)
+                        || BootstrapModal.getOrCreateInstance(markFailedModalEl);
+                    instance.hide();
+                    return;
                 }
+                var closeBtn = markFailedModalEl.querySelector('[data-bs-dismiss="modal"]');
+                if (closeBtn) closeBtn.click();
             };
 
-            document.addEventListener('click', function (e) {
-                var btn = e.target.closest('[data-mark-failed]');
-                if (!btn) return;
-                openMarkFailedModal(btn.dataset.jobId);
-            });
+            if (markFailedModalEl) {
+                markFailedModalEl.addEventListener('show.bs.modal', function (event) {
+                    var trigger = event.relatedTarget;
+                    markFailedJobId = trigger ? trigger.getAttribute('data-job-id') : null;
+                    if (markFailedReasonEl) markFailedReasonEl.value = '';
+                });
+            }
 
             if (markFailedBtn) {
                 markFailedBtn.addEventListener('click', function () {
@@ -441,10 +449,7 @@
                             if (res.ok) {
                                 window.location.reload();
                             } else {
-                                var BootstrapModal = window.bootstrap && window.bootstrap.Modal;
-                                if (BootstrapModal && markFailedModalEl) {
-                                    BootstrapModal.getOrCreateInstance(markFailedModalEl).hide();
-                                }
+                                hideMarkFailedModal();
                                 alert('Ошибка: ' + ((res.data && res.data.error) || 'Неизвестная ошибка'));
                                 markFailedBtn.disabled = false;
                                 markFailedBtn.innerHTML = original;


### PR DESCRIPTION
## Summary

- На странице `/marketplace-ads` клик по кнопке «Пометить FAILED» в строке истории загрузок был no-op: открытие модалки было жёстко завязано на `window.bootstrap.Modal`, который Tabler-бандл из CDN на проде надёжно не экспонирует (аналогичные fallback-ветки уже есть в `payment_calendar/index.html.twig` и `marketplace/listings/index.html.twig`).
- На динамически рендеримой кнопке теперь используется декларативное `data-bs-toggle="modal" data-bs-target="#modal-mark-ad-load-job-failed"` — тот же путь, что для «Загрузить за период» в этом же шаблоне. `jobId` читается в обработчике `show.bs.modal` через `event.relatedTarget`.
- `hide()` модалки при ошибочном ответе API имеет fallback через клик по `[data-bs-dismiss="modal"]`, если `window.bootstrap` недоступен.
- Backend (`MarkAdLoadJobFailedController`, `AdLoadJobRepository::markFailed`) и тесты (`MarkAdLoadJobFailedControllerTest`) не трогали — они корректны.

## Test plan

- [ ] Под `ROLE_COMPANY_OWNER` при наличии активного AdLoadJob (pending/running) в таблице «История загрузок» появляется кнопка «Пометить FAILED».
- [ ] Клик по ней открывает модалку «Пометить задание как FAILED».
- [ ] Ввод причины и нажатие «Пометить FAILED» → `POST /api/marketplace-ads/admin/load-jobs/{jobId}/mark-failed` → 200 → страница перезагружается → job в статусе `failed`.
- [ ] Пустая/пробельная причина → alert «Укажите причину», запрос не уходит.
- [ ] 404/403 от API → показывается alert с текстом ошибки, модалка закрывается, кнопка разблокируется.
- [ ] Под `ROLE_COMPANY_USER` кнопка и модалка не рендерятся.
- [ ] Регресс-чек: декларативная кнопка «Загрузить за период» продолжает работать.

https://claude.ai/code/session_01UaayixCSTdGfaLDT4DMaaw