### PR TITLE
feat(MarketplaceAds): dedicated marketplace_ads Monolog channel

### DIFF
--- a/site/config/packages/monolog.yaml
+++ b/site/config/packages/monolog.yaml
@@ -69,6 +69,7 @@ when@prod:
                 level: debug
                 channels: [marketplace_ads]
                 max_files: 14
+                formatter: monolog.formatter.json
 
             sentry:
                 type: service

--- a/site/config/packages/monolog.yaml
+++ b/site/config/packages/monolog.yaml
@@ -3,6 +3,7 @@ monolog:
         - deprecation
         - import.bank1c
         - recalc
+        - marketplace_ads
 
 when@dev:
     monolog:
@@ -11,17 +12,25 @@ when@dev:
                 type: stream
                 path: "%kernel.logs_dir%/%kernel.environment%.log"
                 level: debug # В локальный файл пишем подробно
-                channels: ["!event", "!doctrine"]
+                channels: ["!event", "!doctrine", "!marketplace_ads"]
+
+            marketplace_ads:
+                type: rotating_file
+                path: "%kernel.logs_dir%/marketplace_ads.log"
+                level: debug
+                channels: [marketplace_ads]
+                max_files: 14
 
             sentry:
                 type: service
                 id: Sentry\Monolog\Handler
                 level: error # В GlitchTip только ошибки
+                channels: ["!marketplace_ads"]
 
             console:
                 type: console
                 process_psr_3_messages: false
-                channels: ["!event", "!doctrine", "!console"]
+                channels: ["!event", "!doctrine", "!console", "!marketplace_ads"]
 
 when@test:
     monolog:
@@ -46,6 +55,7 @@ when@prod:
                 handler: nested
                 excluded_http_codes: [404, 405]
                 buffer_size: 50
+                channels: ["!marketplace_ads"]
 
             nested:
                 type: stream
@@ -53,15 +63,23 @@ when@prod:
                 level: debug
                 formatter: monolog.formatter.json
 
+            marketplace_ads:
+                type: rotating_file
+                path: "%kernel.logs_dir%/marketplace_ads.log"
+                level: debug
+                channels: [marketplace_ads]
+                max_files: 14
+
             sentry:
                 type: service
                 id: Sentry\Monolog\Handler
                 level: error # В GlitchTip только ошибки
+                channels: ["!marketplace_ads"]
 
             console:
                 type: console
                 process_psr_3_messages: false
-                channels: ["!event", "!doctrine"]
+                channels: ["!event", "!doctrine", "!marketplace_ads"]
 
             deprecation:
                 type: stream

--- a/site/src/MarketplaceAds/EventSubscriber/AdLoadJobFailureSubscriber.php
+++ b/site/src/MarketplaceAds/EventSubscriber/AdLoadJobFailureSubscriber.php
@@ -7,6 +7,7 @@ namespace App\MarketplaceAds\EventSubscriber;
 use App\MarketplaceAds\Message\FetchOzonAdStatisticsMessage;
 use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
@@ -29,7 +30,8 @@ final class AdLoadJobFailureSubscriber implements EventSubscriberInterface
 
     public function __construct(
         private readonly AdLoadJobRepositoryInterface $adLoadJobRepository,
-        private readonly LoggerInterface $logger,
+        #[Autowire(service: 'monolog.logger.marketplace_ads')]
+        private readonly LoggerInterface $marketplaceAdsLogger,
     ) {
     }
 
@@ -63,7 +65,7 @@ final class AdLoadJobFailureSubscriber implements EventSubscriberInterface
 
         $this->adLoadJobRepository->markFailed($message->jobId, $message->companyId, $reason);
 
-        $this->logger->warning('AdLoadJob marked as failed after retries exhausted', [
+        $this->marketplaceAdsLogger->warning('AdLoadJob marked as failed after retries exhausted', [
             'job_id' => $message->jobId,
             'company_id' => $message->companyId,
             'message_type' => $message::class,

--- a/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
+++ b/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
@@ -9,6 +9,7 @@ use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Facade\MarketplaceFacade;
 use App\MarketplaceAds\Infrastructure\Api\Contract\AdPlatformClientInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
@@ -62,6 +63,8 @@ class OzonAdClient implements AdPlatformClientInterface
         private readonly MarketplaceFacade $marketplaceFacade,
         private readonly CacheInterface $cache,
         private readonly LoggerInterface $logger,
+        #[Autowire(service: 'monolog.logger.marketplace_ads')]
+        private readonly LoggerInterface $marketplaceAdsLogger,
     ) {
     }
 
@@ -81,7 +84,7 @@ class OzonAdClient implements AdPlatformClientInterface
         $clientId = $credentials['client_id'];
         $clientSecret = $credentials['client_secret'];
 
-        $this->logger->info('Ozon Performance: начало загрузки статистики', [
+        $this->marketplaceAdsLogger->info('Ozon Performance: начало загрузки статистики', [
             'companyId' => $companyId,
             'date' => $date->format('Y-m-d'),
         ]);
@@ -93,7 +96,7 @@ class OzonAdClient implements AdPlatformClientInterface
             fn (string $token): array => $this->listSkuCampaigns($token),
         );
 
-        $this->logger->info('Ozon Performance: получен список SKU-кампаний', [
+        $this->marketplaceAdsLogger->info('Ozon Performance: получен список SKU-кампаний', [
             'companyId' => $companyId,
             'count' => count($campaigns),
         ]);
@@ -113,7 +116,7 @@ class OzonAdClient implements AdPlatformClientInterface
                 fn (string $token): string => $this->requestStatistics($token, $campaignIds, $date, $date, 'NO_GROUP_BY'),
             );
 
-            $this->logger->info('Ozon Performance: запрошен отчёт', [
+            $this->marketplaceAdsLogger->info('Ozon Performance: запрошен отчёт', [
                 'companyId' => $companyId,
                 'reportUuid' => $uuid,
                 'campaignCount' => count($campaignIds),
@@ -182,7 +185,7 @@ class OzonAdClient implements AdPlatformClientInterface
             $clientId = $credentials['client_id'];
             $clientSecret = $credentials['client_secret'];
 
-            $this->logger->info('Ozon Performance: начало загрузки статистики (range)', [
+            $this->marketplaceAdsLogger->info('Ozon Performance: начало загрузки статистики (range)', [
                 'companyId' => $companyId,
                 'dateFrom' => $dateFrom->format('Y-m-d'),
                 'dateTo' => $dateTo->format('Y-m-d'),
@@ -196,7 +199,7 @@ class OzonAdClient implements AdPlatformClientInterface
             );
             $campaignsCount = count($campaigns);
 
-            $this->logger->info('Ozon Performance: получен список SKU-кампаний (range)', [
+            $this->marketplaceAdsLogger->info('Ozon Performance: получен список SKU-кампаний (range)', [
                 'companyId' => $companyId,
                 'count' => $campaignsCount,
             ]);
@@ -214,7 +217,7 @@ class OzonAdClient implements AdPlatformClientInterface
                     fn (string $token): string => $this->requestStatistics($token, $campaignIds, $dateFrom, $dateTo, 'DATE'),
                 );
 
-                $this->logger->info('Ozon Performance: запрошен отчёт (range)', [
+                $this->marketplaceAdsLogger->info('Ozon Performance: запрошен отчёт (range)', [
                     'companyId' => $companyId,
                     'reportUuid' => $uuid,
                     'campaignCount' => count($campaignIds),
@@ -255,7 +258,7 @@ class OzonAdClient implements AdPlatformClientInterface
                 $result[$date] = ['campaigns' => array_values($campaignsMap)];
             }
 
-            $this->logger->info('Ozon ad statistics fetched', [
+            $this->marketplaceAdsLogger->info('Ozon ad statistics fetched', [
                 'company_id' => $companyId,
                 'date_from' => $dateFrom->format('Y-m-d'),
                 'date_to' => $dateTo->format('Y-m-d'),
@@ -361,7 +364,7 @@ class OzonAdClient implements AdPlatformClientInterface
         try {
             return $callback($token);
         } catch (OzonAuthExpiredException) {
-            $this->logger->info('Ozon Performance: токен отклонён (401), повторяю с новым', [
+            $this->marketplaceAdsLogger->info('Ozon Performance: токен отклонён (401), повторяю с новым', [
                 'companyId' => $companyId,
             ]);
             $token = $this->getAccessToken($companyId, $clientId, $clientSecret, forceRefresh: true);
@@ -483,7 +486,7 @@ class OzonAdClient implements AdPlatformClientInterface
         $from = $dateFrom->setTime(0, 0, 0)->setTimezone($utc)->format('Y-m-d\TH:i:s\Z');
         $to = $dateTo->setTime(23, 59, 59)->setTimezone($utc)->format('Y-m-d\TH:i:s\Z');
 
-        $this->logger->debug('Ozon Performance POST /statistics payload', [
+        $this->marketplaceAdsLogger->debug('Ozon Performance POST /statistics payload', [
             'campaign_count' => count($campaignIds),
             'from' => $from,
             'to' => $to,
@@ -535,7 +538,7 @@ class OzonAdClient implements AdPlatformClientInterface
                     $link = self::STATISTICS_REPORT_PATH.'?UUID='.rawurlencode($uuid);
                 }
 
-                $this->logger->info('Ozon Performance: отчёт готов', [
+                $this->marketplaceAdsLogger->info('Ozon Performance: отчёт готов', [
                     'reportUuid' => $uuid,
                     'attempts' => $attempt,
                     'waitedSeconds' => round(microtime(true) - $startedAt, 1),

--- a/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
@@ -15,6 +15,8 @@ use App\MarketplaceAds\Repository\AdLoadJobRepository;
 use App\MarketplaceAds\Repository\AdRawDocumentRepository;
 use App\Shared\Service\AppLogger;
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -61,6 +63,8 @@ final class FetchOzonAdStatisticsHandler
         private readonly EntityManagerInterface $entityManager,
         private readonly MessageBusInterface $messageBus,
         private readonly AppLogger $logger,
+        #[Autowire(service: 'monolog.logger.marketplace_ads')]
+        private readonly LoggerInterface $marketplaceAdsLogger,
     ) {
     }
 
@@ -72,7 +76,7 @@ final class FetchOzonAdStatisticsHandler
         );
 
         if (null === $job) {
-            $this->logger->warning('AdLoadJob не найден при загрузке Ozon-чанка, сообщение проигнорировано', [
+            $this->marketplaceAdsLogger->warning('AdLoadJob не найден при загрузке Ozon-чанка, сообщение проигнорировано', [
                 'jobId' => $message->jobId,
                 'companyId' => $message->companyId,
             ]);
@@ -81,7 +85,7 @@ final class FetchOzonAdStatisticsHandler
         }
 
         if ($job->getStatus()->isTerminal()) {
-            $this->logger->info('AdLoadJob уже завершён, загрузка чанка пропущена', [
+            $this->marketplaceAdsLogger->info('AdLoadJob уже завершён, загрузка чанка пропущена', [
                 'jobId' => $message->jobId,
                 'companyId' => $message->companyId,
                 'status' => $job->getStatus()->value,
@@ -228,7 +232,7 @@ final class FetchOzonAdStatisticsHandler
         );
 
         if (!$marked) {
-            $this->logger->info('chunk already marked completed', [
+            $this->marketplaceAdsLogger->info('chunk already marked completed', [
                 'job_id' => $message->jobId,
                 'company_id' => $message->companyId,
                 'date_from' => $message->dateFrom,
@@ -252,7 +256,7 @@ final class FetchOzonAdStatisticsHandler
             if ($skippedDays > 0) {
                 // Per-document FAILED-статус AdRawDocument — источник правды по
                 // неуспехам; здесь оставляем предупреждение для наблюдаемости чанка.
-                $this->logger->warning('Ozon ad chunk had skipped days', [
+                $this->marketplaceAdsLogger->warning('Ozon ad chunk had skipped days', [
                     'jobId' => $message->jobId,
                     'companyId' => $message->companyId,
                     'dateFrom' => $message->dateFrom,
@@ -269,7 +273,7 @@ final class FetchOzonAdStatisticsHandler
             ));
         }
 
-        $this->logger->info('Ozon ad statistics chunk processed', [
+        $this->marketplaceAdsLogger->info('Ozon ad statistics chunk processed', [
             'jobId' => $message->jobId,
             'companyId' => $message->companyId,
             'dateFrom' => $message->dateFrom,

--- a/site/src/MarketplaceAds/MessageHandler/LoadOzonAdStatisticsRangeHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/LoadOzonAdStatisticsRangeHandler.php
@@ -8,8 +8,9 @@ use App\MarketplaceAds\Enum\AdLoadJobStatus;
 use App\MarketplaceAds\Message\FetchOzonAdStatisticsMessage;
 use App\MarketplaceAds\Message\LoadOzonAdStatisticsRangeMessage;
 use App\MarketplaceAds\Repository\AdLoadJobRepository;
-use App\Shared\Service\AppLogger;
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -42,7 +43,8 @@ final class LoadOzonAdStatisticsRangeHandler
     public function __construct(
         private readonly AdLoadJobRepository $adLoadJobRepository,
         private readonly MessageBusInterface $messageBus,
-        private readonly AppLogger $logger,
+        #[Autowire(service: 'monolog.logger.marketplace_ads')]
+        private readonly LoggerInterface $marketplaceAdsLogger,
         private readonly EntityManagerInterface $entityManager,
     ) {
     }
@@ -53,7 +55,7 @@ final class LoadOzonAdStatisticsRangeHandler
 
         if (null === $job) {
             // Запись удалена / не существует — не ретраим (повторная попытка ничего не исправит).
-            $this->logger->warning('AdLoadJob not found for LoadOzonAdStatisticsRangeMessage', [
+            $this->marketplaceAdsLogger->warning('AdLoadJob not found for LoadOzonAdStatisticsRangeMessage', [
                 'jobId' => $message->jobId,
             ]);
 
@@ -61,7 +63,7 @@ final class LoadOzonAdStatisticsRangeHandler
         }
 
         if ($job->getStatus()->isTerminal()) {
-            $this->logger->info('AdLoadJob already finished, range dispatch skipped', [
+            $this->marketplaceAdsLogger->info('AdLoadJob already finished, range dispatch skipped', [
                 'jobId' => $job->getId(),
                 'companyId' => $job->getCompanyId(),
                 'status' => $job->getStatus()->value,
@@ -102,7 +104,7 @@ final class LoadOzonAdStatisticsRangeHandler
             ));
         }
 
-        $this->logger->info('Ozon ad statistics range dispatched', [
+        $this->marketplaceAdsLogger->info('Ozon ad statistics range dispatched', [
             'jobId' => $job->getId(),
             'companyId' => $job->getCompanyId(),
             'dateFrom' => $job->getDateFrom()->format('Y-m-d'),

--- a/site/src/MarketplaceAds/MessageHandler/ProcessAdRawDocumentHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/ProcessAdRawDocumentHandler.php
@@ -14,6 +14,8 @@ use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
 use App\MarketplaceAds\Repository\AdRawDocumentRepositoryInterface;
 use App\Shared\Service\AppLogger;
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 /**
@@ -46,6 +48,8 @@ final class ProcessAdRawDocumentHandler
         private readonly AdChunkProgressRepositoryInterface $adChunkProgressRepository,
         private readonly EntityManagerInterface $entityManager,
         private readonly AppLogger $logger,
+        #[Autowire(service: 'monolog.logger.marketplace_ads')]
+        private readonly LoggerInterface $marketplaceAdsLogger,
     ) {
     }
 
@@ -59,7 +63,7 @@ final class ProcessAdRawDocumentHandler
             // здесь только шумит в failed-queue. Финализацию job'а тоже не
             // запускаем — документ уже не наша забота, его исход обработает
             // тот воркер, который реально перевёл его в терминальный статус.
-            $this->logger->info(
+            $this->marketplaceAdsLogger->info(
                 'AdRawDocument обработан параллельно или удалён, повтор не нужен',
                 [
                     'companyId' => $message->companyId,
@@ -108,7 +112,7 @@ final class ProcessAdRawDocumentHandler
         );
 
         if (null === $document) {
-            $this->logger->warning('AdRawDocument исчез после успешной обработки', [
+            $this->marketplaceAdsLogger->warning('AdRawDocument исчез после успешной обработки', [
                 'companyId' => $message->companyId,
                 'adRawDocumentId' => $message->adRawDocumentId,
             ]);
@@ -126,7 +130,7 @@ final class ProcessAdRawDocumentHandler
                 $message->companyId,
                 'Action left document in DRAFT (partial processing failure)',
             );
-            $this->logger->warning(
+            $this->marketplaceAdsLogger->warning(
                 'AdRawDocument остался в DRAFT после Action — помечен FAILED',
                 [
                     'companyId' => $message->companyId,
@@ -225,7 +229,7 @@ final class ProcessAdRawDocumentHandler
         if (0 === $failedDocs) {
             $affected = $this->adLoadJobRepository->markCompleted($jobId, $companyId);
             if ($affected > 0) {
-                $this->logger->info('AdLoadJob completed', [
+                $this->marketplaceAdsLogger->info('AdLoadJob completed', [
                     'jobId' => $jobId,
                     'companyId' => $companyId,
                     'totalDocs' => $totalDocs,
@@ -238,7 +242,7 @@ final class ProcessAdRawDocumentHandler
         $reason = sprintf('Partial failure: %d of %d documents failed', $failedDocs, $totalDocs);
         $affected = $this->adLoadJobRepository->markFailed($jobId, $companyId, $reason);
         if ($affected > 0) {
-            $this->logger->warning('AdLoadJob finalized with failures', [
+            $this->marketplaceAdsLogger->warning('AdLoadJob finalized with failures', [
                 'jobId' => $jobId,
                 'companyId' => $companyId,
                 'totalDocs' => $totalDocs,

--- a/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
@@ -153,13 +153,14 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             ->method('markChunkCompleted')
             ->willReturn(false);
 
-        $hub = $this->createMock(HubInterface::class);
-        $logger = new class(new NullLogger(), $hub) extends AppLogger {
+        $logger = new AppLogger(new NullLogger(), $this->createMock(HubInterface::class));
+
+        $marketplaceAdsLogger = new class extends NullLogger {
             public bool $infoLogged = false;
 
-            public function info(string $message, array $context = []): void
+            public function info(string|\Stringable $message, array $context = []): void
             {
-                if (str_contains($message, 'chunk already marked completed')) {
+                if (str_contains((string) $message, 'chunk already marked completed')) {
                     $this->infoLogged = true;
                 }
                 parent::info($message, $context);
@@ -174,6 +175,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             $em,
             $messageBus,
             $logger,
+            $marketplaceAdsLogger,
         );
 
         $handler(new FetchOzonAdStatisticsMessage(
@@ -183,7 +185,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             self::DATE_TO,
         ));
 
-        self::assertTrue($logger->infoLogged, 'info-лог "chunk already marked completed" должен быть записан');
+        self::assertTrue($marketplaceAdsLogger->infoLogged, 'info-лог "chunk already marked completed" должен быть записан');
     }
 
     /**
@@ -732,6 +734,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             $em,
             $messageBus,
             new AppLogger(new NullLogger(), $this->createMock(HubInterface::class)),
+            new NullLogger(),
         );
     }
 }

--- a/site/tests/Unit/MarketplaceAds/LoadOzonAdStatisticsRangeHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/LoadOzonAdStatisticsRangeHandlerTest.php
@@ -10,12 +10,10 @@ use App\MarketplaceAds\Message\FetchOzonAdStatisticsMessage;
 use App\MarketplaceAds\Message\LoadOzonAdStatisticsRangeMessage;
 use App\MarketplaceAds\MessageHandler\LoadOzonAdStatisticsRangeHandler;
 use App\MarketplaceAds\Repository\AdLoadJobRepository;
-use App\Shared\Service\AppLogger;
 use App\Tests\Builders\MarketplaceAds\AdLoadJobBuilder;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
-use Sentry\State\HubInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -282,7 +280,7 @@ final class LoadOzonAdStatisticsRangeHandlerTest extends TestCase
         return new LoadOzonAdStatisticsRangeHandler(
             $jobRepo,
             $messageBus,
-            new AppLogger(new NullLogger(), $this->createMock(HubInterface::class)),
+            new NullLogger(),
             $em,
         );
     }

--- a/site/tests/Unit/MarketplaceAds/OzonAdClientTest.php
+++ b/site/tests/Unit/MarketplaceAds/OzonAdClientTest.php
@@ -75,7 +75,7 @@ final class OzonAdClientTest extends TestCase
             downloadCsv: $csv,
         );
 
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
 
         $result = $client->fetchAdStatisticsRange(
             self::COMPANY_ID,
@@ -121,7 +121,7 @@ final class OzonAdClientTest extends TestCase
             downloadCsv: $this->loadFixture('ozon_range_dmy.csv'),
         );
 
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
 
         $resultDmy = $client->fetchAdStatisticsRange(
             self::COMPANY_ID,
@@ -137,7 +137,7 @@ final class OzonAdClientTest extends TestCase
             stateBody: $this->stateReadyBody('/api/client/statistics/report?UUID=uuid-b2'),
             downloadCsv: $this->loadFixture('ozon_range_iso.csv'),
         );
-        $clientIso = new OzonAdClient($httpIso, $this->facade, new ArrayAdapter(), $this->logger);
+        $clientIso = new OzonAdClient($httpIso, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
         $resultIso = $clientIso->fetchAdStatisticsRange(
             self::COMPANY_ID,
             new \DateTimeImmutable('2026-03-01'),
@@ -160,7 +160,7 @@ final class OzonAdClientTest extends TestCase
             downloadCsv: $this->loadFixture('ozon_range_invalid_date.csv'),
         );
 
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessageMatches('/не удалось распарсить дату/u');
@@ -181,6 +181,7 @@ final class OzonAdClientTest extends TestCase
             new MockHttpClient([]),
             $this->facade,
             new ArrayAdapter(),
+            $this->logger,
             $this->logger,
         );
 
@@ -203,6 +204,7 @@ final class OzonAdClientTest extends TestCase
             new MockHttpClient([]),
             $this->facade,
             new ArrayAdapter(),
+            $this->logger,
             $this->logger,
         );
 
@@ -246,7 +248,7 @@ final class OzonAdClientTest extends TestCase
         ]);
 
         $http = new MockHttpClient($responses);
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
 
         $result = $client->fetchAdStatisticsRange(
             self::COMPANY_ID,
@@ -288,7 +290,7 @@ final class OzonAdClientTest extends TestCase
             downloadCsv: $this->loadFixture('ozon_range_cyrillic_header.csv'),
         );
 
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
 
         $result = $client->fetchAdStatisticsRange(
             self::COMPANY_ID,
@@ -317,7 +319,7 @@ final class OzonAdClientTest extends TestCase
             downloadCsv: $this->loadFixture('ozon_range_iso.csv'),
         );
 
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
 
         $client->fetchAdStatisticsRange(
             self::COMPANY_ID,
@@ -353,6 +355,7 @@ final class OzonAdClientTest extends TestCase
             new MockHttpClient([]),
             $this->facade,
             new ArrayAdapter(),
+            $this->logger,
             $this->logger,
         );
 
@@ -397,7 +400,7 @@ final class OzonAdClientTest extends TestCase
             stateBody: json_encode(['state' => 'ERROR', 'error' => 'нет прав'], JSON_THROW_ON_ERROR),
         );
 
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
 
         try {
             $client->fetchAdStatisticsRange(
@@ -433,7 +436,7 @@ final class OzonAdClientTest extends TestCase
             stateBody: json_encode(['state' => 'ERROR', 'error' => $errorPayload], JSON_THROW_ON_ERROR),
         );
 
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
 
         try {
             $client->fetchAdStatisticsRange(
@@ -469,7 +472,7 @@ final class OzonAdClientTest extends TestCase
             stateBody: json_encode(['state' => 'ERROR', 'error' => $errorPayload], JSON_THROW_ON_ERROR),
         );
 
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
 
         try {
             $client->fetchAdStatisticsRange(
@@ -500,7 +503,7 @@ final class OzonAdClientTest extends TestCase
             new MockResponse('{"error":"invalid campaign id"}', ['http_code' => 400]),
         ]);
 
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
 
         try {
             $client->fetchAdStatisticsRange(
@@ -529,7 +532,7 @@ final class OzonAdClientTest extends TestCase
             downloadCsv: $this->loadFixture('ozon_single_day_legacy.csv'),
         );
 
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
 
         $json = $client->fetchAdStatistics(self::COMPANY_ID, new \DateTimeImmutable('2026-03-01'));
 

--- a/site/tests/Unit/MarketplaceAds/ProcessAdRawDocumentHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/ProcessAdRawDocumentHandlerTest.php
@@ -77,6 +77,7 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
             $this->chunkRepo,
             $this->entityManager,
             $this->logger,
+            new NullLogger(),
         );
     }
 


### PR DESCRIPTION
## Summary

Выделенный Monolog-канал `marketplace_ads` для диагностических логов модуля MarketplaceAds.

- `monolog.yaml`: новый канал + `rotating_file` handler с `max_files: 14` (две недели истории), пишет в `%kernel.logs_dir%/marketplace_ads.log`. Канал исключён из `main`/`sentry`/`console` в `when@dev` и `when@prod`.
- 5 классов (`AdLoadJobFailureSubscriber`, `OzonAdClient`, `FetchOzonAdStatisticsHandler`, `LoadOzonAdStatisticsRangeHandler`, `ProcessAdRawDocumentHandler`) получают `LoggerInterface $marketplaceAdsLogger` через `#[Autowire(service: 'monolog.logger.marketplace_ads')]` — на него уходят info/warning/debug.
- `error`-вызовы остаются на общем `AppLogger` → Sentry/GlitchTip (существующий Monolog handler, level=error).

## Why

Высокочастотные диагностические логи Ozon Performance (токены, отчёты, чанки) засоряют основной лог и Sentry. Выделенный канал даёт:
- изолированный файл для оперативного разбора инцидентов;
- автоматическую ротацию (14 дней);
- чистый Sentry: только `error`-level.

## Test plan

- [x] `php -l` по всем изменённым файлам — синтаксис чистый.
- [x] Unit-тесты обновлены: добавлен мок для второго LoggerInterface-аргумента (NullLogger в большинстве случаев).
- [x] `AdLoadJobFailureSubscriberTest` не требует правок — позиции конструктора сохранены.
- [ ] После merge — убедиться, что в проде `var/log/marketplace_ads.log` появляется и ротируется.
- [ ] После merge — подтвердить, что Sentry больше не получает info/warning от MarketplaceAds.

https://claude.ai/code/session_01CiiWKcdVukbyLnXn8PtwKB