### PR TITLE
feat(MarketplaceAds): admin endpoint for reading marketplace_ads.log tail

### DIFF
--- a/site/src/MarketplaceAds/Controller/Api/Admin/MarketplaceAdsLogsController.php
+++ b/site/src/MarketplaceAds/Controller/Api/Admin/MarketplaceAdsLogsController.php
@@ -156,7 +156,7 @@ final class MarketplaceAdsLogsController extends AbstractController
                 fseek($handle, $position);
                 $chunk = (string) fread($handle, $readSize);
                 $buffer = $chunk . $buffer;
-                $newlines = substr_count($buffer, "\n");
+                $newlines += substr_count($chunk, "\n");
             }
         } finally {
             fclose($handle);

--- a/site/src/MarketplaceAds/Controller/Api/Admin/MarketplaceAdsLogsController.php
+++ b/site/src/MarketplaceAds/Controller/Api/Admin/MarketplaceAdsLogsController.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Controller\Api\Admin;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route(
+    '/api/marketplace-ads/admin/logs',
+    name: 'marketplace_ads_admin_logs',
+    methods: ['GET'],
+)]
+#[IsGranted('ROLE_COMPANY_OWNER')]
+final class MarketplaceAdsLogsController extends AbstractController
+{
+    private const DEFAULT_LINES = 200;
+    private const MAX_LINES = 1000;
+    private const MIN_LINES = 1;
+    private const SMALL_FILE_THRESHOLD_BYTES = 10 * 1024 * 1024;
+    private const TAIL_CHUNK_SIZE = 8192;
+
+    public function __construct(
+        #[Autowire('%kernel.logs_dir%')]
+        private readonly string $logsDir,
+    ) {}
+
+    public function __invoke(Request $request): Response
+    {
+        $lines = $this->resolveLines($request->query->get('lines'));
+        $search = $this->resolveSearch($request->query->get('search'));
+
+        $logFile = $this->findLatestLogFile();
+
+        if (null === $logFile) {
+            return $this->textResponse('No log file yet');
+        }
+
+        $tail = $this->readTail($logFile, $lines);
+
+        if (null !== $search && '' !== $search) {
+            $tail = array_values(array_filter(
+                $tail,
+                static fn (string $line): bool => str_contains($line, $search),
+            ));
+        }
+
+        return $this->textResponse(implode("\n", $tail));
+    }
+
+    private function resolveLines(mixed $raw): int
+    {
+        if (null === $raw || '' === $raw) {
+            return self::DEFAULT_LINES;
+        }
+
+        $value = (int) $raw;
+
+        if ($value < self::MIN_LINES) {
+            return self::MIN_LINES;
+        }
+
+        if ($value > self::MAX_LINES) {
+            return self::MAX_LINES;
+        }
+
+        return $value;
+    }
+
+    private function resolveSearch(mixed $raw): ?string
+    {
+        if (!is_string($raw)) {
+            return null;
+        }
+
+        $trimmed = trim($raw);
+
+        return '' === $trimmed ? null : $trimmed;
+    }
+
+    private function findLatestLogFile(): ?string
+    {
+        $pattern = rtrim($this->logsDir, '/') . '/marketplace_ads*.log';
+        $matches = glob($pattern);
+
+        if (false === $matches || [] === $matches) {
+            return null;
+        }
+
+        $latest = null;
+        $latestMtime = -1;
+        foreach ($matches as $file) {
+            if (!is_file($file)) {
+                continue;
+            }
+            $mtime = filemtime($file);
+            if (false === $mtime) {
+                continue;
+            }
+            if ($mtime > $latestMtime) {
+                $latestMtime = $mtime;
+                $latest = $file;
+            }
+        }
+
+        return $latest;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function readTail(string $file, int $lines): array
+    {
+        $size = filesize($file);
+
+        if (false === $size || 0 === $size) {
+            return [];
+        }
+
+        if ($size <= self::SMALL_FILE_THRESHOLD_BYTES) {
+            $all = file($file, FILE_IGNORE_NEW_LINES);
+            if (false === $all) {
+                return [];
+            }
+
+            return array_values(array_slice($all, -$lines));
+        }
+
+        return $this->readTailChunked($file, $lines);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function readTailChunked(string $file, int $lines): array
+    {
+        $handle = fopen($file, 'rb');
+        if (false === $handle) {
+            return [];
+        }
+
+        try {
+            fseek($handle, 0, SEEK_END);
+            $position = ftell($handle);
+            $buffer = '';
+            $newlines = 0;
+
+            while ($position > 0 && $newlines <= $lines) {
+                $readSize = (int) min(self::TAIL_CHUNK_SIZE, $position);
+                $position -= $readSize;
+                fseek($handle, $position);
+                $chunk = (string) fread($handle, $readSize);
+                $buffer = $chunk . $buffer;
+                $newlines = substr_count($buffer, "\n");
+            }
+        } finally {
+            fclose($handle);
+        }
+
+        $all = explode("\n", $buffer);
+
+        if ('' === end($all)) {
+            array_pop($all);
+        }
+
+        return array_values(array_slice($all, -$lines));
+    }
+
+    private function textResponse(string $body): Response
+    {
+        return new Response(
+            $body,
+            Response::HTTP_OK,
+            ['Content-Type' => 'text/plain; charset=utf-8'],
+        );
+    }
+}

--- a/site/src/MarketplaceAds/Controller/Api/Admin/MarketplaceAdsLogsController.php
+++ b/site/src/MarketplaceAds/Controller/Api/Admin/MarketplaceAdsLogsController.php
@@ -16,7 +16,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
     name: 'marketplace_ads_admin_logs',
     methods: ['GET'],
 )]
-#[IsGranted('ROLE_COMPANY_OWNER')]
+#[IsGranted('ROLE_SUPER_ADMIN')]
 final class MarketplaceAdsLogsController extends AbstractController
 {
     private const DEFAULT_LINES = 200;

--- a/site/templates/marketplace_ads/index.html.twig
+++ b/site/templates/marketplace_ads/index.html.twig
@@ -9,7 +9,7 @@
                 <div class="col">
                     <h2 class="page-title">Реклама маркетплейсов</h2>
                 </div>
-                {% if is_granted('ROLE_COMPANY_OWNER') %}
+                {% if is_granted('ROLE_SUPER_ADMIN') %}
                     <div class="col-auto ms-auto">
                         <a href="{{ path('marketplace_ads_admin_logs', {'lines': 500}) }}"
                            target="_blank"

--- a/site/templates/marketplace_ads/index.html.twig
+++ b/site/templates/marketplace_ads/index.html.twig
@@ -9,6 +9,16 @@
                 <div class="col">
                     <h2 class="page-title">Реклама маркетплейсов</h2>
                 </div>
+                {% if is_granted('ROLE_COMPANY_OWNER') %}
+                    <div class="col-auto ms-auto">
+                        <a href="{{ path('marketplace_ads_admin_logs', {'lines': 500}) }}"
+                           target="_blank"
+                           rel="noopener"
+                           class="btn btn-outline-secondary btn-sm">
+                            Открыть логи
+                        </a>
+                    </div>
+                {% endif %}
             </div>
         </div>
     </div>

--- a/site/tests/Integration/MarketplaceAds/Controller/Api/Admin/MarketplaceAdsLogsControllerTest.php
+++ b/site/tests/Integration/MarketplaceAds/Controller/Api/Admin/MarketplaceAdsLogsControllerTest.php
@@ -11,8 +11,8 @@ use App\Tests\Support\Kernel\WebTestCaseBase;
 final class MarketplaceAdsLogsControllerTest extends WebTestCaseBase
 {
     private const COMPANY_ID = '11111111-1111-1111-1111-a00000000001';
-    private const OWNER_ID = '22222222-2222-2222-2222-a00000000001';
-    private const OTHER_USER_ID = '22222222-2222-2222-2222-a00000000002';
+    private const ADMIN_ID = '22222222-2222-2222-2222-a00000000001';
+    private const OWNER_ID = '22222222-2222-2222-2222-a00000000002';
 
     private const URL = '/api/marketplace-ads/admin/logs';
 
@@ -22,22 +22,23 @@ final class MarketplaceAdsLogsControllerTest extends WebTestCaseBase
         parent::tearDown();
     }
 
-    public function testReturns200AndTailForCompanyOwner(): void
+    public function testReturns200AndTailForSuperAdmin(): void
     {
         $client = static::createClient();
         $this->resetDb();
         $em = $this->em();
 
-        $owner = UserBuilder::aUser()
-            ->withId(self::OWNER_ID)
-            ->withEmail('ads-logs-owner@example.test')
+        $admin = UserBuilder::aUser()
+            ->withId(self::ADMIN_ID)
+            ->withEmail('ads-logs-admin@example.test')
+            ->withRoles(['ROLE_COMPANY_OWNER', 'ROLE_SUPER_ADMIN'])
             ->build();
         $company = CompanyBuilder::aCompany()
             ->withId(self::COMPANY_ID)
-            ->withOwner($owner)
+            ->withOwner($admin)
             ->build();
 
-        $em->persist($owner);
+        $em->persist($admin);
         $em->persist($company);
         $em->flush();
 
@@ -47,7 +48,7 @@ final class MarketplaceAdsLogsControllerTest extends WebTestCaseBase
             'line-3',
         ]);
 
-        $this->loginAs($client, $owner, self::COMPANY_ID);
+        $this->loginAs($client, $admin, self::COMPANY_ID);
 
         $client->request('GET', self::URL);
 
@@ -62,7 +63,7 @@ final class MarketplaceAdsLogsControllerTest extends WebTestCaseBase
         self::assertStringContainsString('line-3', $body);
     }
 
-    public function testReturns403ForCompanyUserWithoutOwnerRole(): void
+    public function testReturns403ForCompanyOwnerWithoutSuperAdmin(): void
     {
         $client = static::createClient();
         $this->resetDb();
@@ -71,24 +72,18 @@ final class MarketplaceAdsLogsControllerTest extends WebTestCaseBase
         $owner = UserBuilder::aUser()
             ->withId(self::OWNER_ID)
             ->withEmail('ads-logs-403-owner@example.test')
+            ->withRoles(['ROLE_COMPANY_OWNER'])
             ->build();
         $company = CompanyBuilder::aCompany()
             ->withId(self::COMPANY_ID)
             ->withOwner($owner)
             ->build();
 
-        $regular = UserBuilder::aUser()
-            ->withId(self::OTHER_USER_ID)
-            ->withEmail('ads-logs-403-user@example.test')
-            ->withRoles(['ROLE_COMPANY_USER'])
-            ->build();
-
         $em->persist($owner);
         $em->persist($company);
-        $em->persist($regular);
         $em->flush();
 
-        $this->loginAs($client, $regular, self::COMPANY_ID);
+        $this->loginAs($client, $owner, self::COMPANY_ID);
 
         $client->request('GET', self::URL);
 
@@ -117,20 +112,21 @@ final class MarketplaceAdsLogsControllerTest extends WebTestCaseBase
 
         $this->cleanupLogFiles();
 
-        $owner = UserBuilder::aUser()
-            ->withId(self::OWNER_ID)
+        $admin = UserBuilder::aUser()
+            ->withId(self::ADMIN_ID)
             ->withEmail('ads-logs-nofile@example.test')
+            ->withRoles(['ROLE_COMPANY_OWNER', 'ROLE_SUPER_ADMIN'])
             ->build();
         $company = CompanyBuilder::aCompany()
             ->withId(self::COMPANY_ID)
-            ->withOwner($owner)
+            ->withOwner($admin)
             ->build();
 
-        $em->persist($owner);
+        $em->persist($admin);
         $em->persist($company);
         $em->flush();
 
-        $this->loginAs($client, $owner, self::COMPANY_ID);
+        $this->loginAs($client, $admin, self::COMPANY_ID);
 
         $client->request('GET', self::URL);
 
@@ -144,16 +140,17 @@ final class MarketplaceAdsLogsControllerTest extends WebTestCaseBase
         $this->resetDb();
         $em = $this->em();
 
-        $owner = UserBuilder::aUser()
-            ->withId(self::OWNER_ID)
+        $admin = UserBuilder::aUser()
+            ->withId(self::ADMIN_ID)
             ->withEmail('ads-logs-lines@example.test')
+            ->withRoles(['ROLE_COMPANY_OWNER', 'ROLE_SUPER_ADMIN'])
             ->build();
         $company = CompanyBuilder::aCompany()
             ->withId(self::COMPANY_ID)
-            ->withOwner($owner)
+            ->withOwner($admin)
             ->build();
 
-        $em->persist($owner);
+        $em->persist($admin);
         $em->persist($company);
         $em->flush();
 
@@ -163,7 +160,7 @@ final class MarketplaceAdsLogsControllerTest extends WebTestCaseBase
         }
         $this->writeLogFile('marketplace_ads-2026-04-19.log', $rows);
 
-        $this->loginAs($client, $owner, self::COMPANY_ID);
+        $this->loginAs($client, $admin, self::COMPANY_ID);
 
         $client->request('GET', self::URL . '?lines=10');
 
@@ -181,16 +178,17 @@ final class MarketplaceAdsLogsControllerTest extends WebTestCaseBase
         $this->resetDb();
         $em = $this->em();
 
-        $owner = UserBuilder::aUser()
-            ->withId(self::OWNER_ID)
+        $admin = UserBuilder::aUser()
+            ->withId(self::ADMIN_ID)
             ->withEmail('ads-logs-search@example.test')
+            ->withRoles(['ROLE_COMPANY_OWNER', 'ROLE_SUPER_ADMIN'])
             ->build();
         $company = CompanyBuilder::aCompany()
             ->withId(self::COMPANY_ID)
-            ->withOwner($owner)
+            ->withOwner($admin)
             ->build();
 
-        $em->persist($owner);
+        $em->persist($admin);
         $em->persist($company);
         $em->flush();
 
@@ -201,7 +199,7 @@ final class MarketplaceAdsLogsControllerTest extends WebTestCaseBase
             'random stuff',
         ]);
 
-        $this->loginAs($client, $owner, self::COMPANY_ID);
+        $this->loginAs($client, $admin, self::COMPANY_ID);
 
         $client->request('GET', self::URL . '?search=ozon');
 
@@ -219,16 +217,17 @@ final class MarketplaceAdsLogsControllerTest extends WebTestCaseBase
         $this->resetDb();
         $em = $this->em();
 
-        $owner = UserBuilder::aUser()
-            ->withId(self::OWNER_ID)
+        $admin = UserBuilder::aUser()
+            ->withId(self::ADMIN_ID)
             ->withEmail('ads-logs-latest@example.test')
+            ->withRoles(['ROLE_COMPANY_OWNER', 'ROLE_SUPER_ADMIN'])
             ->build();
         $company = CompanyBuilder::aCompany()
             ->withId(self::COMPANY_ID)
-            ->withOwner($owner)
+            ->withOwner($admin)
             ->build();
 
-        $em->persist($owner);
+        $em->persist($admin);
         $em->persist($company);
         $em->flush();
 
@@ -237,7 +236,7 @@ final class MarketplaceAdsLogsControllerTest extends WebTestCaseBase
         touch($oldPath, time() - 3600);
         touch($newPath, time());
 
-        $this->loginAs($client, $owner, self::COMPANY_ID);
+        $this->loginAs($client, $admin, self::COMPANY_ID);
 
         $client->request('GET', self::URL);
 

--- a/site/tests/Integration/MarketplaceAds/Controller/Api/Admin/MarketplaceAdsLogsControllerTest.php
+++ b/site/tests/Integration/MarketplaceAds/Controller/Api/Admin/MarketplaceAdsLogsControllerTest.php
@@ -1,0 +1,294 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\MarketplaceAds\Controller\Api\Admin;
+
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+
+final class MarketplaceAdsLogsControllerTest extends WebTestCaseBase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-a00000000001';
+    private const OWNER_ID = '22222222-2222-2222-2222-a00000000001';
+    private const OTHER_USER_ID = '22222222-2222-2222-2222-a00000000002';
+
+    private const URL = '/api/marketplace-ads/admin/logs';
+
+    protected function tearDown(): void
+    {
+        $this->cleanupLogFiles();
+        parent::tearDown();
+    }
+
+    public function testReturns200AndTailForCompanyOwner(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('ads-logs-owner@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        $this->writeLogFile('marketplace_ads-2026-04-19.log', [
+            'line-1',
+            'line-2',
+            'line-3',
+        ]);
+
+        $this->loginAs($client, $owner, self::COMPANY_ID);
+
+        $client->request('GET', self::URL);
+
+        self::assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertStringContainsString('text/plain', (string) $response->headers->get('Content-Type'));
+        self::assertStringContainsString('charset=utf-8', (string) $response->headers->get('Content-Type'));
+
+        $body = $response->getContent();
+        self::assertStringContainsString('line-1', $body);
+        self::assertStringContainsString('line-2', $body);
+        self::assertStringContainsString('line-3', $body);
+    }
+
+    public function testReturns403ForCompanyUserWithoutOwnerRole(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('ads-logs-403-owner@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $regular = UserBuilder::aUser()
+            ->withId(self::OTHER_USER_ID)
+            ->withEmail('ads-logs-403-user@example.test')
+            ->withRoles(['ROLE_COMPANY_USER'])
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->persist($regular);
+        $em->flush();
+
+        $this->loginAs($client, $regular, self::COMPANY_ID);
+
+        $client->request('GET', self::URL);
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testRedirectsOrDeniesWhenNotAuthenticated(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $client->request('GET', self::URL);
+
+        $response = $client->getResponse();
+        self::assertTrue(
+            $response->isRedirect() || 401 === $response->getStatusCode() || 403 === $response->getStatusCode(),
+            'Unauthenticated access must be redirected or denied, got ' . $response->getStatusCode(),
+        );
+    }
+
+    public function testReturns200WithMessageWhenNoLogFile(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+
+        $this->cleanupLogFiles();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('ads-logs-nofile@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        $this->loginAs($client, $owner, self::COMPANY_ID);
+
+        $client->request('GET', self::URL);
+
+        self::assertResponseIsSuccessful();
+        self::assertSame('No log file yet', $client->getResponse()->getContent());
+    }
+
+    public function testLinesParameterLimitsOutput(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('ads-logs-lines@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        $rows = [];
+        for ($i = 1; $i <= 50; ++$i) {
+            $rows[] = sprintf('row-%03d', $i);
+        }
+        $this->writeLogFile('marketplace_ads-2026-04-19.log', $rows);
+
+        $this->loginAs($client, $owner, self::COMPANY_ID);
+
+        $client->request('GET', self::URL . '?lines=10');
+
+        self::assertResponseIsSuccessful();
+        $body = $client->getResponse()->getContent();
+        $returned = $body === '' ? [] : explode("\n", $body);
+        self::assertLessThanOrEqual(10, count($returned));
+        self::assertStringContainsString('row-050', $body);
+        self::assertStringNotContainsString('row-001', $body);
+    }
+
+    public function testSearchFiltersLines(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('ads-logs-search@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        $this->writeLogFile('marketplace_ads-2026-04-19.log', [
+            'ozon ad loaded',
+            'wildberries ignored',
+            'ozon error 500',
+            'random stuff',
+        ]);
+
+        $this->loginAs($client, $owner, self::COMPANY_ID);
+
+        $client->request('GET', self::URL . '?search=ozon');
+
+        self::assertResponseIsSuccessful();
+        $body = $client->getResponse()->getContent();
+        self::assertStringContainsString('ozon ad loaded', $body);
+        self::assertStringContainsString('ozon error 500', $body);
+        self::assertStringNotContainsString('wildberries', $body);
+        self::assertStringNotContainsString('random stuff', $body);
+    }
+
+    public function testPicksLatestFileByMtime(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('ads-logs-latest@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        $oldPath = $this->writeLogFile('marketplace_ads-2026-04-18.log', ['stale-line']);
+        $newPath = $this->writeLogFile('marketplace_ads-2026-04-19.log', ['fresh-line']);
+        touch($oldPath, time() - 3600);
+        touch($newPath, time());
+
+        $this->loginAs($client, $owner, self::COMPANY_ID);
+
+        $client->request('GET', self::URL);
+
+        self::assertResponseIsSuccessful();
+        $body = $client->getResponse()->getContent();
+        self::assertStringContainsString('fresh-line', $body);
+        self::assertStringNotContainsString('stale-line', $body);
+    }
+
+    private function logsDir(): string
+    {
+        return static::getContainer()->getParameter('kernel.logs_dir');
+    }
+
+    /**
+     * @param list<string> $lines
+     */
+    private function writeLogFile(string $name, array $lines): string
+    {
+        $dir = $this->logsDir();
+        if (!is_dir($dir)) {
+            mkdir($dir, 0o777, true);
+        }
+        $path = $dir . '/' . $name;
+        file_put_contents($path, implode("\n", $lines) . "\n");
+
+        return $path;
+    }
+
+    private function cleanupLogFiles(): void
+    {
+        $dir = $this->logsDir();
+        if (!is_dir($dir)) {
+            return;
+        }
+        $matches = glob($dir . '/marketplace_ads*.log');
+        if (false === $matches) {
+            return;
+        }
+        foreach ($matches as $file) {
+            if (is_file($file)) {
+                @unlink($file);
+            }
+        }
+    }
+
+    private function loginAs($client, $user, string $companyId): void
+    {
+        $client->loginUser($user);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', $companyId);
+        $session->save();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `GET /api/marketplace-ads/admin/logs` (`ROLE_COMPANY_OWNER`) that returns the tail of the latest `var/log/marketplace_ads*.log` as `text/plain; charset=utf-8`.
- Supports `?lines=N` (default 200, clamped to 1..1000) and `?search=...` substring filter.
- File is picked from `%kernel.logs_dir%` by glob + mtime — no user-controlled path. If no file exists, returns 200 with body `No log file yet`.
- Small files (<10 MB) are read via `file()` + `array_slice`; larger files fall back to chunked seek-from-end.
- Adds an "Открыть логи" button in the MarketplaceAds page header, visible only to `ROLE_COMPANY_OWNER`, opening in a new tab with `lines=500`.

## Test plan
- [ ] `ROLE_COMPANY_OWNER` → 200 with tail content (`testReturns200AndTailForCompanyOwner`)
- [ ] `ROLE_COMPANY_USER` → 403 (`testReturns403ForCompanyUserWithoutOwnerRole`)
- [ ] Unauthenticated → redirect/401/403 (`testRedirectsOrDeniesWhenNotAuthenticated`)
- [ ] No log file → 200 `No log file yet` (`testReturns200WithMessageWhenNoLogFile`)
- [ ] `lines=10` returns at most 10 lines (`testLinesParameterLimitsOutput`)
- [ ] `search=ozon` filters by substring (`testSearchFiltersLines`)
- [ ] Multiple files → latest-by-mtime is picked (`testPicksLatestFileByMtime`)