### PR TITLE
fix(MarketplaceAds): finalize AdLoadJob when Ozon returns 0 documents

### DIFF
--- a/site/src/MarketplaceAds/Application/Service/AdLoadJobFinalizer.php
+++ b/site/src/MarketplaceAds/Application/Service/AdLoadJobFinalizer.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Application\Service;
+
+use App\MarketplaceAds\Enum\AdLoadJobStatus;
+use App\MarketplaceAds\Enum\AdRawDocumentStatus;
+use App\MarketplaceAds\Repository\AdChunkProgressRepositoryInterface;
+use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
+use App\MarketplaceAds\Repository\AdRawDocumentRepositoryInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Идемпотентная финализация AdLoadJob.
+ *
+ * Вызывается из нескольких точек:
+ *  - ProcessAdRawDocumentHandler после перевода документа в терминальный статус;
+ *  - FetchOzonAdStatisticsHandler после markChunkCompleted — это покрывает случай,
+ *    когда Ozon вернул 0 документов за чанк и per-document handler никогда не
+ *    запускался (иначе job навечно завис бы в RUNNING).
+ *
+ * Решение принимается по COUNT(*) в БД, а не по локальным счётчикам — это
+ * устойчиво к параллельным воркерам. markCompleted/markFailed имеют SQL-guard
+ * `status IN (pending, running)` и обновят строку только один раз, поэтому
+ * одновременный вызов из разных воркеров безопасен.
+ */
+final readonly class AdLoadJobFinalizer
+{
+    public function __construct(
+        private AdLoadJobRepositoryInterface $jobRepository,
+        private AdRawDocumentRepositoryInterface $documentRepository,
+        private AdChunkProgressRepositoryInterface $chunkProgressRepository,
+        #[Autowire(service: 'monolog.logger.marketplace_ads')]
+        private LoggerInterface $marketplaceAdsLogger,
+    ) {
+    }
+
+    public function tryFinalize(string $jobId, string $companyId): void
+    {
+        $job = $this->jobRepository->findByIdAndCompany($jobId, $companyId);
+        if (null === $job) {
+            return;
+        }
+
+        if (AdLoadJobStatus::RUNNING !== $job->getStatus()) {
+            return;
+        }
+
+        $completedChunks = $this->chunkProgressRepository->countCompletedChunks($jobId, $companyId);
+        if ($completedChunks < $job->getChunksTotal()) {
+            return;
+        }
+
+        $marketplaceValue = $job->getMarketplace()->value;
+        $dateFrom = $job->getDateFrom();
+        $dateTo = $job->getDateTo();
+
+        $totalDocs = $this->documentRepository->countByCompanyMarketplaceAndDateRange(
+            $companyId,
+            $marketplaceValue,
+            $dateFrom,
+            $dateTo,
+        );
+        $processedDocs = $this->documentRepository->countByCompanyMarketplaceAndDateRange(
+            $companyId,
+            $marketplaceValue,
+            $dateFrom,
+            $dateTo,
+            AdRawDocumentStatus::PROCESSED,
+        );
+        $failedDocs = $this->documentRepository->countByCompanyMarketplaceAndDateRange(
+            $companyId,
+            $marketplaceValue,
+            $dateFrom,
+            $dateTo,
+            AdRawDocumentStatus::FAILED,
+        );
+
+        // Остались DRAFT-документы — финализацию делать рано: их добьёт
+        // следующий вызов после обработки оставшихся документов.
+        if ($processedDocs + $failedDocs < $totalDocs) {
+            return;
+        }
+
+        if (0 === $failedDocs) {
+            $affected = $this->jobRepository->markCompleted($jobId, $companyId);
+            if ($affected > 0) {
+                $this->marketplaceAdsLogger->info('AdLoadJob completed', [
+                    'jobId' => $jobId,
+                    'companyId' => $companyId,
+                    'totalDocs' => $totalDocs,
+                ]);
+            }
+
+            return;
+        }
+
+        $reason = sprintf('Partial failure: %d of %d documents failed', $failedDocs, $totalDocs);
+        $affected = $this->jobRepository->markFailed($jobId, $companyId, $reason);
+        if ($affected > 0) {
+            $this->marketplaceAdsLogger->warning('AdLoadJob finalized with failures', [
+                'jobId' => $jobId,
+                'companyId' => $companyId,
+                'totalDocs' => $totalDocs,
+                'failedDocs' => $failedDocs,
+                'processedDocs' => $processedDocs,
+            ]);
+        }
+    }
+}

--- a/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\MarketplaceAds\MessageHandler;
 
 use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAds\Application\Service\AdLoadJobFinalizer;
 use App\MarketplaceAds\Entity\AdRawDocument;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonAdClient;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonPermanentApiException;
@@ -49,8 +50,12 @@ use Symfony\Component\Messenger\MessageBusInterface;
  *    message уйдёт в failed-транспорт — его разбирает оператор.
  *
  * Порядок операций строгий: save() → flush() → incrementLoadedDays() →
- * dispatch(ProcessAdRawDocumentMessage). Иначе ProcessAdRawDocumentHandler
- * может стартовать до появления документа в БД.
+ * dispatch(ProcessAdRawDocumentMessage) → tryFinalize. Иначе
+ * ProcessAdRawDocumentHandler может стартовать до появления документа в БД.
+ *
+ * tryFinalize после dispatch — необходимый триггер для случая, когда Ozon
+ * вернул 0 документов за период: per-document handler'ы никогда не
+ * запустятся, и без прямого вызова finalizer здесь job застрянет в RUNNING.
  */
 #[AsMessageHandler]
 final class FetchOzonAdStatisticsHandler
@@ -60,6 +65,7 @@ final class FetchOzonAdStatisticsHandler
         private readonly AdRawDocumentRepository $adRawDocumentRepository,
         private readonly AdLoadJobRepository $adLoadJobRepository,
         private readonly AdChunkProgressRepositoryInterface $adChunkProgressRepository,
+        private readonly AdLoadJobFinalizer $adLoadJobFinalizer,
         private readonly EntityManagerInterface $entityManager,
         private readonly MessageBusInterface $messageBus,
         private readonly AppLogger $logger,
@@ -272,6 +278,12 @@ final class FetchOzonAdStatisticsHandler
                 $doc->getId(),
             ));
         }
+
+        // Пытаемся финализировать job — покрывает кейс, когда Ozon вернул 0
+        // документов за период: ProcessAdRawDocumentHandler в этом случае
+        // никогда не запустится, и без явной попытки здесь job навечно завис
+        // бы в RUNNING при markChunkCompleted для последнего чанка.
+        $this->adLoadJobFinalizer->tryFinalize($message->jobId, $message->companyId);
 
         $this->marketplaceAdsLogger->info('Ozon ad statistics chunk processed', [
             'jobId' => $message->jobId,

--- a/site/src/MarketplaceAds/MessageHandler/ProcessAdRawDocumentHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/ProcessAdRawDocumentHandler.php
@@ -5,11 +5,10 @@ declare(strict_types=1);
 namespace App\MarketplaceAds\MessageHandler;
 
 use App\MarketplaceAds\Application\ProcessAdRawDocumentAction;
-use App\MarketplaceAds\Enum\AdLoadJobStatus;
+use App\MarketplaceAds\Application\Service\AdLoadJobFinalizer;
 use App\MarketplaceAds\Enum\AdRawDocumentStatus;
 use App\MarketplaceAds\Exception\AdRawDocumentAlreadyProcessedException;
 use App\MarketplaceAds\Message\ProcessAdRawDocumentMessage;
-use App\MarketplaceAds\Repository\AdChunkProgressRepositoryInterface;
 use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
 use App\MarketplaceAds\Repository\AdRawDocumentRepositoryInterface;
 use App\Shared\Service\AppLogger;
@@ -32,11 +31,9 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
  *
  * Финализация AdLoadJob:
  *  - после любого терминального исхода (PROCESSED/FAILED) handler пытается
- *    финализировать job, который покрывает дату документа: если все чанки
- *    зафиксированы И все документы за период в терминальном статусе, job
- *    переводится в COMPLETED (при отсутствии failed-документов) или FAILED
- *    (если хотя бы один документ failed). Решение принимается по COUNT(*)
- *    в БД, а не по локальным счётчикам — это устойчиво к параллельным воркерам.
+ *    финализировать job, который покрывает дату документа; сама логика
+ *    финализации вынесена в {@see AdLoadJobFinalizer} и шарится с
+ *    FetchOzonAdStatisticsHandler (для кейса «0 документов за чанк»).
  */
 #[AsMessageHandler]
 final class ProcessAdRawDocumentHandler
@@ -45,7 +42,7 @@ final class ProcessAdRawDocumentHandler
         private readonly ProcessAdRawDocumentAction $action,
         private readonly AdRawDocumentRepositoryInterface $adRawDocumentRepository,
         private readonly AdLoadJobRepositoryInterface $adLoadJobRepository,
-        private readonly AdChunkProgressRepositoryInterface $adChunkProgressRepository,
+        private readonly AdLoadJobFinalizer $adLoadJobFinalizer,
         private readonly EntityManagerInterface $entityManager,
         private readonly AppLogger $logger,
         #[Autowire(service: 'monolog.logger.marketplace_ads')]
@@ -146,7 +143,7 @@ final class ProcessAdRawDocumentHandler
     }
 
     /**
-     * Находит активный job, покрывающий дату документа, и пытается финализировать.
+     * Находит активный job, покрывающий дату документа, и делегирует финализацию.
      *
      * Документ перечитывается заново — статус мог измениться внутри __invoke
      * (DRAFT → FAILED). Если job не найден (например, уже завершён другим воркером
@@ -168,87 +165,6 @@ final class ProcessAdRawDocumentHandler
             return;
         }
 
-        $this->tryFinalizeJob($job->getId(), $companyId);
-    }
-
-    /**
-     * Идемпотентная попытка финализации job'а.
-     *
-     * Все условия проверяются по актуальному состоянию БД (COUNT по чанкам и
-     * документам), что позволяет нескольким параллельным воркерам безопасно
-     * вызывать метод одновременно — markCompleted/markFailed имеют SQL-guard
-     * `status IN (pending, running)` и обновят строку только один раз.
-     */
-    private function tryFinalizeJob(string $jobId, string $companyId): void
-    {
-        $job = $this->adLoadJobRepository->findByIdAndCompany($jobId, $companyId);
-        if (null === $job) {
-            return;
-        }
-
-        if (AdLoadJobStatus::RUNNING !== $job->getStatus()) {
-            return;
-        }
-
-        $completedChunks = $this->adChunkProgressRepository->countCompletedChunks($jobId, $companyId);
-        if ($completedChunks < $job->getChunksTotal()) {
-            return;
-        }
-
-        $marketplaceValue = $job->getMarketplace()->value;
-        $dateFrom = $job->getDateFrom();
-        $dateTo = $job->getDateTo();
-
-        $totalDocs = $this->adRawDocumentRepository->countByCompanyMarketplaceAndDateRange(
-            $companyId,
-            $marketplaceValue,
-            $dateFrom,
-            $dateTo,
-        );
-        $processedDocs = $this->adRawDocumentRepository->countByCompanyMarketplaceAndDateRange(
-            $companyId,
-            $marketplaceValue,
-            $dateFrom,
-            $dateTo,
-            AdRawDocumentStatus::PROCESSED,
-        );
-        $failedDocs = $this->adRawDocumentRepository->countByCompanyMarketplaceAndDateRange(
-            $companyId,
-            $marketplaceValue,
-            $dateFrom,
-            $dateTo,
-            AdRawDocumentStatus::FAILED,
-        );
-
-        // Остались DRAFT-документы — финализацию делать рано: их добьёт
-        // следующий вызов handler'а после обработки оставшихся документов.
-        if ($processedDocs + $failedDocs < $totalDocs) {
-            return;
-        }
-
-        if (0 === $failedDocs) {
-            $affected = $this->adLoadJobRepository->markCompleted($jobId, $companyId);
-            if ($affected > 0) {
-                $this->marketplaceAdsLogger->info('AdLoadJob completed', [
-                    'jobId' => $jobId,
-                    'companyId' => $companyId,
-                    'totalDocs' => $totalDocs,
-                ]);
-            }
-
-            return;
-        }
-
-        $reason = sprintf('Partial failure: %d of %d documents failed', $failedDocs, $totalDocs);
-        $affected = $this->adLoadJobRepository->markFailed($jobId, $companyId, $reason);
-        if ($affected > 0) {
-            $this->marketplaceAdsLogger->warning('AdLoadJob finalized with failures', [
-                'jobId' => $jobId,
-                'companyId' => $companyId,
-                'totalDocs' => $totalDocs,
-                'failedDocs' => $failedDocs,
-                'processedDocs' => $processedDocs,
-            ]);
-        }
+        $this->adLoadJobFinalizer->tryFinalize($job->getId(), $companyId);
     }
 }

--- a/site/tests/Unit/MarketplaceAds/Application/Service/AdLoadJobFinalizerTest.php
+++ b/site/tests/Unit/MarketplaceAds/Application/Service/AdLoadJobFinalizerTest.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MarketplaceAds\Application\Service;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAds\Application\Service\AdLoadJobFinalizer;
+use App\MarketplaceAds\Enum\AdRawDocumentStatus;
+use App\MarketplaceAds\Repository\AdChunkProgressRepositoryInterface;
+use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
+use App\MarketplaceAds\Repository\AdRawDocumentRepositoryInterface;
+use App\Tests\Builders\MarketplaceAds\AdLoadJobBuilder;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * Unit-тесты {@see AdLoadJobFinalizer}: логика идемпотентной финализации job'а.
+ *
+ * Покрываемые инварианты:
+ *  - Job отсутствует / не RUNNING → no-op.
+ *  - completedChunks < chunksTotal → no-op (рано финализировать).
+ *  - Есть DRAFT-документы (processed+failed < total) → no-op.
+ *  - Все документы processed, 0 failed → markCompleted + info-лог.
+ *  - Хотя бы один failed → markFailed с reason + warning-лог.
+ *  - Race: markCompleted вернул 0 → info-лог не пишется, исключений нет.
+ *  - 0 документов за период (Ozon вернул пусто): total=0 → markCompleted.
+ */
+final class AdLoadJobFinalizerTest extends TestCase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-111111111111';
+    private const JOB_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+    /** @var AdLoadJobRepositoryInterface&MockObject */
+    private AdLoadJobRepositoryInterface $jobRepo;
+    /** @var AdRawDocumentRepositoryInterface&MockObject */
+    private AdRawDocumentRepositoryInterface $rawDocRepo;
+    /** @var AdChunkProgressRepositoryInterface&MockObject */
+    private AdChunkProgressRepositoryInterface $chunkRepo;
+    private AdLoadJobFinalizer $finalizer;
+
+    protected function setUp(): void
+    {
+        $this->jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $this->rawDocRepo = $this->createMock(AdRawDocumentRepositoryInterface::class);
+        $this->chunkRepo = $this->createMock(AdChunkProgressRepositoryInterface::class);
+
+        $this->finalizer = new AdLoadJobFinalizer(
+            $this->jobRepo,
+            $this->rawDocRepo,
+            $this->chunkRepo,
+            new NullLogger(),
+        );
+    }
+
+    public function testJobNotFoundIsNoOp(): void
+    {
+        $this->jobRepo->expects(self::once())
+            ->method('findByIdAndCompany')
+            ->with(self::JOB_ID, self::COMPANY_ID)
+            ->willReturn(null);
+
+        $this->chunkRepo->expects(self::never())->method('countCompletedChunks');
+        $this->rawDocRepo->expects(self::never())->method('countByCompanyMarketplaceAndDateRange');
+        $this->jobRepo->expects(self::never())->method('markCompleted');
+        $this->jobRepo->expects(self::never())->method('markFailed');
+
+        $this->finalizer->tryFinalize(self::JOB_ID, self::COMPANY_ID);
+    }
+
+    public function testTerminalJobIsNoOp(): void
+    {
+        $job = $this->buildJob()->asCompleted()->build();
+
+        $this->jobRepo->method('findByIdAndCompany')->willReturn($job);
+
+        $this->chunkRepo->expects(self::never())->method('countCompletedChunks');
+        $this->rawDocRepo->expects(self::never())->method('countByCompanyMarketplaceAndDateRange');
+        $this->jobRepo->expects(self::never())->method('markCompleted');
+        $this->jobRepo->expects(self::never())->method('markFailed');
+
+        $this->finalizer->tryFinalize(self::JOB_ID, self::COMPANY_ID);
+    }
+
+    public function testChunksIncompleteIsNoOp(): void
+    {
+        $job = $this->buildJob()->withChunksTotal(3)->asRunning()->build();
+
+        $this->jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $this->chunkRepo->expects(self::once())
+            ->method('countCompletedChunks')
+            ->willReturn(2);
+
+        $this->rawDocRepo->expects(self::never())->method('countByCompanyMarketplaceAndDateRange');
+        $this->jobRepo->expects(self::never())->method('markCompleted');
+        $this->jobRepo->expects(self::never())->method('markFailed');
+
+        $this->finalizer->tryFinalize(self::JOB_ID, self::COMPANY_ID);
+    }
+
+    public function testDraftsRemainingIsNoOp(): void
+    {
+        $job = $this->buildJob()->withChunksTotal(1)->asRunning()->build();
+
+        $this->jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $this->chunkRepo->method('countCompletedChunks')->willReturn(1);
+        // 5 total, 3 processed + 1 failed = 4 терминальных, остался 1 DRAFT.
+        $this->mockDocCounts(total: 5, processed: 3, failed: 1);
+
+        $this->jobRepo->expects(self::never())->method('markCompleted');
+        $this->jobRepo->expects(self::never())->method('markFailed');
+
+        $this->finalizer->tryFinalize(self::JOB_ID, self::COMPANY_ID);
+    }
+
+    public function testMarkCompletedWhenAllProcessedNoFailures(): void
+    {
+        $job = $this->buildJob()->withChunksTotal(2)->asRunning()->build();
+
+        $this->jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $this->chunkRepo->method('countCompletedChunks')->willReturn(2);
+        $this->mockDocCounts(total: 5, processed: 5, failed: 0);
+
+        $this->jobRepo->expects(self::once())
+            ->method('markCompleted')
+            ->with(self::JOB_ID, self::COMPANY_ID)
+            ->willReturn(1);
+        $this->jobRepo->expects(self::never())->method('markFailed');
+
+        $this->finalizer->tryFinalize(self::JOB_ID, self::COMPANY_ID);
+    }
+
+    public function testMarkFailedWhenSomeDocsFailed(): void
+    {
+        $job = $this->buildJob()->withChunksTotal(2)->asRunning()->build();
+
+        $this->jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $this->chunkRepo->method('countCompletedChunks')->willReturn(2);
+        $this->mockDocCounts(total: 5, processed: 3, failed: 2);
+
+        $this->jobRepo->expects(self::never())->method('markCompleted');
+        $this->jobRepo->expects(self::once())
+            ->method('markFailed')
+            ->with(
+                self::JOB_ID,
+                self::COMPANY_ID,
+                'Partial failure: 2 of 5 documents failed',
+            )
+            ->willReturn(1);
+
+        $this->finalizer->tryFinalize(self::JOB_ID, self::COMPANY_ID);
+    }
+
+    public function testRaceIdempotencyMarkCompletedReturnsZero(): void
+    {
+        // Параллельный воркер уже перевёл job в COMPLETED → markCompleted вернул 0.
+        // Метод обязан завершиться без исключения, markFailed не вызывается.
+        $job = $this->buildJob()->withChunksTotal(1)->asRunning()->build();
+
+        $this->jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $this->chunkRepo->method('countCompletedChunks')->willReturn(1);
+        $this->mockDocCounts(total: 1, processed: 1, failed: 0);
+
+        $this->jobRepo->expects(self::once())
+            ->method('markCompleted')
+            ->willReturn(0);
+        $this->jobRepo->expects(self::never())->method('markFailed');
+
+        $this->finalizer->tryFinalize(self::JOB_ID, self::COMPANY_ID);
+    }
+
+    public function testZeroDocumentsTriggersMarkCompleted(): void
+    {
+        // Ozon вернул пусто за весь период → ProcessAdRawDocumentHandler никогда
+        // не запустится; финализация должна случиться из FetchOzonAdStatisticsHandler
+        // при total=0. processed+failed (0) == total (0), failed=0 → markCompleted.
+        $job = $this->buildJob()->withChunksTotal(1)->asRunning()->build();
+
+        $this->jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $this->chunkRepo->method('countCompletedChunks')->willReturn(1);
+        $this->mockDocCounts(total: 0, processed: 0, failed: 0);
+
+        $this->jobRepo->expects(self::once())
+            ->method('markCompleted')
+            ->with(self::JOB_ID, self::COMPANY_ID)
+            ->willReturn(1);
+        $this->jobRepo->expects(self::never())->method('markFailed');
+
+        $this->finalizer->tryFinalize(self::JOB_ID, self::COMPANY_ID);
+    }
+
+    private function mockDocCounts(int $total, int $processed, int $failed): void
+    {
+        $this->rawDocRepo->expects(self::exactly(3))
+            ->method('countByCompanyMarketplaceAndDateRange')
+            ->willReturnCallback(
+                static function (
+                    string $companyId,
+                    string $marketplace,
+                    \DateTimeImmutable $from,
+                    \DateTimeImmutable $to,
+                    ?AdRawDocumentStatus $status = null,
+                ) use ($total, $processed, $failed): int {
+                    return match ($status) {
+                        null => $total,
+                        AdRawDocumentStatus::PROCESSED => $processed,
+                        AdRawDocumentStatus::FAILED => $failed,
+                        default => 0,
+                    };
+                },
+            );
+    }
+
+    private function buildJob(): AdLoadJobBuilder
+    {
+        return AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withDateRange(
+                new \DateTimeImmutable('2026-03-01'),
+                new \DateTimeImmutable('2026-03-10'),
+            );
+    }
+}

--- a/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\MarketplaceAds;
 
+use App\MarketplaceAds\Application\Service\AdLoadJobFinalizer;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonAdClient;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonPermanentApiException;
 use App\MarketplaceAds\Message\FetchOzonAdStatisticsMessage;
@@ -14,6 +15,7 @@ use App\MarketplaceAds\Repository\AdLoadJobRepository;
 use App\MarketplaceAds\Repository\AdRawDocumentRepository;
 use App\Shared\Service\AppLogger;
 use App\Tests\Builders\MarketplaceAds\AdLoadJobBuilder;
+use DG\BypassFinals;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -21,6 +23,12 @@ use Sentry\State\HubInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Messenger\MessageBusInterface;
+
+// Bootstrap pins BypassFinals to an allowlist; finalizer is final readonly — extend
+// the allowlist so PHPUnit can double it.
+BypassFinals::allowPaths([
+    '*/src/MarketplaceAds/Application/Service/AdLoadJobFinalizer.php',
+]);
 
 /**
  * Unit-тесты FetchOzonAdStatisticsHandler.
@@ -39,6 +47,8 @@ use Symfony\Component\Messenger\MessageBusInterface;
  * 11. json_encode() === false для одного дня: день пропускается, остальные загружаются.
  * 12. Невалидный формат даты в Message: markFailed + UnrecoverableMessageHandlingException.
  * 13. Календарно-невалидная дата (2026-02-31): markFailed + UnrecoverableMessageHandlingException.
+ * 14. Happy-path: AdLoadJobFinalizer::tryFinalize вызывается ПОСЛЕ markChunkCompleted —
+ *     без этого job с нулём документов от Ozon навечно залип бы в RUNNING.
  */
 final class FetchOzonAdStatisticsHandlerTest extends TestCase
 {
@@ -172,6 +182,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             $rawRepo,
             $jobRepo,
             $chunkProgressRepo,
+            $this->createMock(AdLoadJobFinalizer::class),
             $em,
             $messageBus,
             $logger,
@@ -718,6 +729,69 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         ));
     }
 
+    /**
+     * Сценарий 14: happy-path вызывает AdLoadJobFinalizer::tryFinalize.
+     *
+     * Без этого вызова задание, по которому Ozon вернул 0 документов за весь
+     * период, зависнет в RUNNING навечно: ProcessAdRawDocumentHandler не
+     * запустится, и триггера финализации не будет.
+     */
+    public function testHappyPathCallsFinalizerAfterMarkChunkCompleted(): void
+    {
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withDateRange(new \DateTimeImmutable(self::DATE_FROM), new \DateTimeImmutable(self::DATE_TO))
+            ->asRunning()
+            ->build();
+
+        $jobRepo = $this->createMock(AdLoadJobRepository::class);
+        $jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $jobRepo->method('incrementLoadedDays')->willReturn(1);
+
+        $ozonClient = $this->createMock(OzonAdClient::class);
+        $ozonClient->method('fetchAdStatisticsRange')->willReturn([]);
+
+        $rawRepo = $this->createMock(AdRawDocumentRepository::class);
+        $em = $this->createMock(EntityManagerInterface::class);
+        $messageBus = $this->createMock(MessageBusInterface::class);
+
+        $markedChunk = false;
+        $chunkProgressRepo = $this->createMock(AdChunkProgressRepositoryInterface::class);
+        $chunkProgressRepo->method('markChunkCompleted')
+            ->willReturnCallback(static function () use (&$markedChunk): bool {
+                $markedChunk = true;
+
+                return true;
+            });
+
+        $finalizer = $this->createMock(AdLoadJobFinalizer::class);
+        $finalizer->expects(self::once())
+            ->method('tryFinalize')
+            ->with(self::JOB_ID, self::COMPANY_ID)
+            ->willReturnCallback(static function () use (&$markedChunk): void {
+                self::assertTrue(
+                    $markedChunk,
+                    'tryFinalize должен вызываться ПОСЛЕ markChunkCompleted',
+                );
+            });
+
+        $handler = $this->createHandler(
+            $ozonClient,
+            $rawRepo,
+            $jobRepo,
+            $chunkProgressRepo,
+            $em,
+            $messageBus,
+            $finalizer,
+        );
+        $handler(new FetchOzonAdStatisticsMessage(
+            self::JOB_ID,
+            self::COMPANY_ID,
+            self::DATE_FROM,
+            self::DATE_TO,
+        ));
+    }
+
     private function createHandler(
         OzonAdClient $ozonClient,
         AdRawDocumentRepository $rawRepo,
@@ -725,12 +799,14 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         AdChunkProgressRepositoryInterface $chunkProgressRepo,
         EntityManagerInterface $em,
         MessageBusInterface $messageBus,
+        ?AdLoadJobFinalizer $finalizer = null,
     ): FetchOzonAdStatisticsHandler {
         return new FetchOzonAdStatisticsHandler(
             $ozonClient,
             $rawRepo,
             $jobRepo,
             $chunkProgressRepo,
+            $finalizer ?? $this->createMock(AdLoadJobFinalizer::class),
             $em,
             $messageBus,
             new AppLogger(new NullLogger(), $this->createMock(HubInterface::class)),

--- a/site/tests/Unit/MarketplaceAds/ProcessAdRawDocumentHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/ProcessAdRawDocumentHandlerTest.php
@@ -6,11 +6,10 @@ namespace App\Tests\Unit\MarketplaceAds;
 
 use App\Marketplace\Enum\MarketplaceType;
 use App\MarketplaceAds\Application\ProcessAdRawDocumentAction;
-use App\MarketplaceAds\Enum\AdRawDocumentStatus;
+use App\MarketplaceAds\Application\Service\AdLoadJobFinalizer;
 use App\MarketplaceAds\Exception\AdRawDocumentAlreadyProcessedException;
 use App\MarketplaceAds\Message\ProcessAdRawDocumentMessage;
 use App\MarketplaceAds\MessageHandler\ProcessAdRawDocumentHandler;
-use App\MarketplaceAds\Repository\AdChunkProgressRepositoryInterface;
 use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
 use App\MarketplaceAds\Repository\AdRawDocumentRepositoryInterface;
 use App\Shared\Service\AppLogger;
@@ -23,24 +22,26 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Sentry\State\HubInterface;
 
-// Bootstrap pins BypassFinals to an allowlist; extend it so the action under test
-// can be doubled without touching the global bootstrap configuration.
+// Bootstrap pins BypassFinals to an allowlist; extend it so the action and finalizer
+// under test can be doubled without touching the global bootstrap configuration.
 BypassFinals::allowPaths([
     '*/src/MarketplaceAds/Application/ProcessAdRawDocumentAction.php',
+    '*/src/MarketplaceAds/Application/Service/AdLoadJobFinalizer.php',
 ]);
 
 /**
- * Unit-тесты {@see ProcessAdRawDocumentHandler}: per-document FAILED + финализация job'а.
+ * Unit-тесты {@see ProcessAdRawDocumentHandler}: per-document FAILED + делегирование финализации.
  *
- * Покрываемые инварианты:
- *  - PROCESSED-документ запускает попытку финализации.
+ * Покрываемые инварианты handler'а:
+ *  - PROCESSED-документ → AdLoadJobFinalizer::tryFinalize(jobId) вызывается.
  *  - DRAFT после Action → markFailedWithReason + return без throw.
  *  - Исключение из Action → markFailedWithReason + tryFinalize + rethrow.
- *  - AdRawDocumentAlreadyProcessedException → swallow, без вызова финализации.
- *  - Финализация: COMPLETED, если failed=0; FAILED с reason, если failed>0.
- *  - Финализация пропускается, если completedChunks < chunksTotal или есть DRAFT-документы.
- *  - Нет активного job на дату → tryFinalize выходит молча.
- *  - Race idempotency: markCompleted вернул 0 → info-лог не пишется.
+ *  - AdRawDocumentAlreadyProcessedException → swallow, finalizer не вызывается.
+ *  - Нет активного job на дату → finalizer не вызывается.
+ *  - Secondary exception после Action-failure не маскирует оригинал.
+ *
+ * Сама логика финализации (chunksTotal, COUNT-и, markCompleted/markFailed) живёт
+ * в {@see AdLoadJobFinalizer} и покрыта {@see AdLoadJobFinalizerTest}.
  */
 final class ProcessAdRawDocumentHandlerTest extends TestCase
 {
@@ -54,8 +55,8 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
     private AdRawDocumentRepositoryInterface $rawDocRepo;
     /** @var AdLoadJobRepositoryInterface&MockObject */
     private AdLoadJobRepositoryInterface $jobRepo;
-    /** @var AdChunkProgressRepositoryInterface&MockObject */
-    private AdChunkProgressRepositoryInterface $chunkRepo;
+    /** @var AdLoadJobFinalizer&MockObject */
+    private AdLoadJobFinalizer $finalizer;
     /** @var EntityManagerInterface&MockObject */
     private EntityManagerInterface $entityManager;
     private AppLogger $logger;
@@ -66,7 +67,7 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
         $this->action = $this->createMock(ProcessAdRawDocumentAction::class);
         $this->rawDocRepo = $this->createMock(AdRawDocumentRepositoryInterface::class);
         $this->jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
-        $this->chunkRepo = $this->createMock(AdChunkProgressRepositoryInterface::class);
+        $this->finalizer = $this->createMock(AdLoadJobFinalizer::class);
         $this->entityManager = $this->createMock(EntityManagerInterface::class);
         $this->logger = new AppLogger(new NullLogger(), $this->createMock(HubInterface::class));
 
@@ -74,17 +75,17 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
             $this->action,
             $this->rawDocRepo,
             $this->jobRepo,
-            $this->chunkRepo,
+            $this->finalizer,
             $this->entityManager,
             $this->logger,
             new NullLogger(),
         );
     }
 
-    public function testProcessedDocumentTriggersFinalizationCheck(): void
+    public function testProcessedDocumentTriggersFinalizer(): void
     {
         $document = $this->buildProcessedDocument();
-        $job = $this->buildRunningJob(chunksTotal: 1);
+        $job = $this->buildRunningJob();
 
         $this->action->expects(self::once())
             ->method('__invoke')
@@ -102,22 +103,10 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
         $this->jobRepo->expects(self::once())
             ->method('findActiveJobCoveringDate')
             ->willReturn($job);
-        $this->jobRepo->expects(self::once())
-            ->method('findByIdAndCompany')
-            ->with(self::JOB_ID, self::COMPANY_ID)
-            ->willReturn($job);
 
-        $this->chunkRepo->expects(self::once())
-            ->method('countCompletedChunks')
-            ->willReturn(1);
-
-        // chunks complete → читаем COUNT по документам.
-        $this->mockDocCounts(total: 1, processed: 1, failed: 0);
-
-        $this->jobRepo->expects(self::once())
-            ->method('markCompleted')
-            ->with(self::JOB_ID, self::COMPANY_ID)
-            ->willReturn(1);
+        $this->finalizer->expects(self::once())
+            ->method('tryFinalize')
+            ->with(self::JOB_ID, self::COMPANY_ID);
 
         ($this->handler)(new ProcessAdRawDocumentMessage(self::COMPANY_ID, self::DOCUMENT_ID));
     }
@@ -145,10 +134,11 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
             )
             ->willReturn(1);
 
-        // Job не найден на дату → tryFinalize выходит no-op'ом, но он реально вызывается.
+        // Job не найден на дату → finalizer не вызывается.
         $this->jobRepo->expects(self::once())
             ->method('findActiveJobCoveringDate')
             ->willReturn(null);
+        $this->finalizer->expects(self::never())->method('tryFinalize');
 
         ($this->handler)(new ProcessAdRawDocumentMessage(self::COMPANY_ID, self::DOCUMENT_ID));
     }
@@ -176,6 +166,7 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
         $this->rawDocRepo->expects(self::once())
             ->method('findByIdAndCompany')
             ->willReturn(null);
+        $this->finalizer->expects(self::never())->method('tryFinalize');
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('boom');
@@ -222,82 +213,7 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
         $this->rawDocRepo->expects(self::never())->method('markFailedWithReason');
         $this->rawDocRepo->expects(self::never())->method('findByIdAndCompany');
         $this->jobRepo->expects(self::never())->method('findActiveJobCoveringDate');
-        $this->jobRepo->expects(self::never())->method('findByIdAndCompany');
-        $this->chunkRepo->expects(self::never())->method('countCompletedChunks');
-
-        ($this->handler)(new ProcessAdRawDocumentMessage(self::COMPANY_ID, self::DOCUMENT_ID));
-    }
-
-    public function testFinalizationMarksCompletedWhenAllProcessedNoFailures(): void
-    {
-        $document = $this->buildProcessedDocument();
-        $job = $this->buildRunningJob(chunksTotal: 2);
-
-        $this->primeSuccessPath($document, $job);
-        $this->chunkRepo->method('countCompletedChunks')->willReturn(2);
-        $this->mockDocCounts(total: 5, processed: 5, failed: 0);
-
-        $this->jobRepo->expects(self::once())
-            ->method('markCompleted')
-            ->with(self::JOB_ID, self::COMPANY_ID)
-            ->willReturn(1);
-        $this->jobRepo->expects(self::never())->method('markFailed');
-
-        ($this->handler)(new ProcessAdRawDocumentMessage(self::COMPANY_ID, self::DOCUMENT_ID));
-    }
-
-    public function testFinalizationMarksFailedWhenSomeDocsFailed(): void
-    {
-        $document = $this->buildProcessedDocument();
-        $job = $this->buildRunningJob(chunksTotal: 2);
-
-        $this->primeSuccessPath($document, $job);
-        $this->chunkRepo->method('countCompletedChunks')->willReturn(2);
-        $this->mockDocCounts(total: 5, processed: 3, failed: 2);
-
-        $this->jobRepo->expects(self::never())->method('markCompleted');
-        $this->jobRepo->expects(self::once())
-            ->method('markFailed')
-            ->with(
-                self::JOB_ID,
-                self::COMPANY_ID,
-                'Partial failure: 2 of 5 documents failed',
-            )
-            ->willReturn(1);
-
-        ($this->handler)(new ProcessAdRawDocumentMessage(self::COMPANY_ID, self::DOCUMENT_ID));
-    }
-
-    public function testFinalizationSkippedWhenChunksIncomplete(): void
-    {
-        $document = $this->buildProcessedDocument();
-        $job = $this->buildRunningJob(chunksTotal: 3);
-
-        $this->primeSuccessPath($document, $job);
-        // Зафиксировано 2 из 3 чанков — рано финализировать.
-        $this->chunkRepo->expects(self::once())
-            ->method('countCompletedChunks')
-            ->willReturn(2);
-
-        $this->rawDocRepo->expects(self::never())->method('countByCompanyMarketplaceAndDateRange');
-        $this->jobRepo->expects(self::never())->method('markCompleted');
-        $this->jobRepo->expects(self::never())->method('markFailed');
-
-        ($this->handler)(new ProcessAdRawDocumentMessage(self::COMPANY_ID, self::DOCUMENT_ID));
-    }
-
-    public function testFinalizationSkippedWhenDraftsRemain(): void
-    {
-        $document = $this->buildProcessedDocument();
-        $job = $this->buildRunningJob(chunksTotal: 1);
-
-        $this->primeSuccessPath($document, $job);
-        $this->chunkRepo->method('countCompletedChunks')->willReturn(1);
-        // 5 всего, 3 processed + 1 failed = 4 терминальных, остался 1 DRAFT.
-        $this->mockDocCounts(total: 5, processed: 3, failed: 1);
-
-        $this->jobRepo->expects(self::never())->method('markCompleted');
-        $this->jobRepo->expects(self::never())->method('markFailed');
+        $this->finalizer->expects(self::never())->method('tryFinalize');
 
         ($this->handler)(new ProcessAdRawDocumentMessage(self::COMPANY_ID, self::DOCUMENT_ID));
     }
@@ -316,77 +232,9 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
         $this->jobRepo->expects(self::once())
             ->method('findActiveJobCoveringDate')
             ->willReturn(null);
-        $this->jobRepo->expects(self::never())->method('findByIdAndCompany');
-        $this->chunkRepo->expects(self::never())->method('countCompletedChunks');
-        $this->jobRepo->expects(self::never())->method('markCompleted');
-        $this->jobRepo->expects(self::never())->method('markFailed');
+        $this->finalizer->expects(self::never())->method('tryFinalize');
 
         ($this->handler)(new ProcessAdRawDocumentMessage(self::COMPANY_ID, self::DOCUMENT_ID));
-    }
-
-    public function testFinalizationRaceIdempotency(): void
-    {
-        // Параллельный воркер уже перевёл job в COMPLETED → markCompleted вернул 0,
-        // info-лог не должен записаться. PHPUnit не умеет ассертить «логгер не вызван»
-        // напрямую через NullLogger, поэтому проверяем конкретную ветку:
-        // markCompleted вернул 0, метод вернулся без исключения, markFailed не вызывался.
-        $document = $this->buildProcessedDocument();
-        $job = $this->buildRunningJob(chunksTotal: 1);
-
-        $this->primeSuccessPath($document, $job);
-        $this->chunkRepo->method('countCompletedChunks')->willReturn(1);
-        $this->mockDocCounts(total: 1, processed: 1, failed: 0);
-
-        $this->jobRepo->expects(self::once())
-            ->method('markCompleted')
-            ->willReturn(0);
-        $this->jobRepo->expects(self::never())->method('markFailed');
-
-        ($this->handler)(new ProcessAdRawDocumentMessage(self::COMPANY_ID, self::DOCUMENT_ID));
-    }
-
-    /**
-     * Подготавливает успешный happy-path: action ок, flush ок, документ перечитан как PROCESSED,
-     * job найден по дате и поднят по ID.
-     */
-    private function primeSuccessPath(object $document, object $job): void
-    {
-        $this->action->expects(self::once())->method('__invoke');
-        $this->entityManager->expects(self::once())->method('flush');
-
-        $this->rawDocRepo->expects(self::exactly(2))
-            ->method('findByIdAndCompany')
-            ->willReturn($document);
-
-        $this->jobRepo->expects(self::once())
-            ->method('findActiveJobCoveringDate')
-            ->willReturn($job);
-        $this->jobRepo->expects(self::once())
-            ->method('findByIdAndCompany')
-            ->with(self::JOB_ID, self::COMPANY_ID)
-            ->willReturn($job);
-    }
-
-    private function mockDocCounts(int $total, int $processed, int $failed): void
-    {
-        $this->rawDocRepo->expects(self::exactly(3))
-            ->method('countByCompanyMarketplaceAndDateRange')
-            ->willReturnCallback(
-                static function (
-                    string $companyId,
-                    string $marketplace,
-                    \DateTimeImmutable $from,
-                    \DateTimeImmutable $to,
-                    ?AdRawDocumentStatus $status = null,
-                ) use ($total, $processed, $failed): int {
-                    return match ($status) {
-                        null => $total,
-                        AdRawDocumentStatus::PROCESSED => $processed,
-                        AdRawDocumentStatus::FAILED => $failed,
-                        default => 0,
-                    };
-                },
-            );
     }
 
     private function buildDraftDocument(): object
@@ -418,7 +266,7 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
             ->build();
     }
 
-    private function buildRunningJob(int $chunksTotal): object
+    private function buildRunningJob(): object
     {
         return AdLoadJobBuilder::aJob()
             ->withCompanyId(self::COMPANY_ID)
@@ -427,7 +275,7 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
                 new \DateTimeImmutable('2026-03-01'),
                 new \DateTimeImmutable('2026-03-10'),
             )
-            ->withChunksTotal($chunksTotal)
+            ->withChunksTotal(1)
             ->asRunning()
             ->build();
     }


### PR DESCRIPTION
## Summary

- AdLoadJob finalization used to live only inside `ProcessAdRawDocumentHandler`. If Ozon returned **0 documents** for the requested period, that handler never fired and the job stayed in `RUNNING` forever.
- Extract the finalization logic into a new `AdLoadJobFinalizer` service (`Application/Service/AdLoadJobFinalizer.php`) and reuse it from both handlers.
- `FetchOzonAdStatisticsHandler` now calls `$finalizer->tryFinalize()` on the happy-path right after `markChunkCompleted` and `dispatch(ProcessAdRawDocumentMessage)` — this covers the «empty chunk» case where per-document handlers never run.
- `ProcessAdRawDocumentHandler` keeps `tryFinalizeJobForDocument()` (finds the job by document date) and delegates the finalize step to `AdLoadJobFinalizer`.
- Finalization condition itself is unchanged (COUNT-based, idempotent, IDOR-safe). `AdChunkProgress` is not touched.

## Tests

- New `tests/Unit/MarketplaceAds/Application/Service/AdLoadJobFinalizerTest` — covers all finalize branches, including the new `total=0 → markCompleted` case for «Ozon returned nothing».
- `ProcessAdRawDocumentHandlerTest` — now mocks `AdLoadJobFinalizer` directly and asserts delegation (removed the finalize-internals scenarios that moved to the finalizer test).
- `FetchOzonAdStatisticsHandlerTest` — added `testHappyPathCallsFinalizerAfterMarkChunkCompleted` asserting strict order `markChunkCompleted → tryFinalize`; existing scenarios wired up with a finalizer mock.

## Test plan

- [ ] `php bin/phpunit tests/Unit/MarketplaceAds/Application/Service/AdLoadJobFinalizerTest.php`
- [ ] `php bin/phpunit tests/Unit/MarketplaceAds/ProcessAdRawDocumentHandlerTest.php`
- [ ] `php bin/phpunit tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php`
- [ ] Manual check: trigger an AdLoadJob for a period with no Ozon campaigns — verify it reaches `COMPLETED` instead of sticking in `RUNNING`.

https://claude.ai/code/session_01M1SQT3Zveaun7wLxhz5yX3