### PR TITLE
feat(MarketplaceAds): filter Ozon campaigns by state for recent ranges

### DIFF
--- a/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
+++ b/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
@@ -51,10 +51,11 @@ class OzonAdClient implements AdPlatformClientInterface
     private const POLL_INTERVAL_SECONDS = 5;
     private const CACHE_KEY_TOKEN_PREFIX = 'ozon_perf_token_';
 
-    // Для «свежих» диапазонов (dateTo в пределах этого окна от сегодня) отсекаем
+    // Для «свежих» диапазонов (dateFrom в пределах этого окна от сегодня) отсекаем
     // явно неактивные кампании на клиенте, чтобы не спрашивать у Ozon статистику
-    // по архивам. Для backfill-а более старых периодов фильтр не применяется —
-    // архивная сегодня кампания могла откручиваться тогда.
+    // по архивам. Для backfill-а более старых периодов (или длинных чанков,
+    // которые начинаются до cutoff) фильтр не применяется — архивная сегодня
+    // кампания могла откручиваться тогда.
     private const RECENT_DAYS_THRESHOLD = 14;
     private const ACTIVE_CAMPAIGN_STATES = [
         'CAMPAIGN_STATE_RUNNING',
@@ -210,14 +211,19 @@ class OzonAdClient implements AdPlatformClientInterface
                 $clientSecret,
                 fn (string $token): array => $this->listSkuCampaigns($token),
             );
-            $campaignsCount = count($campaigns);
 
             $this->marketplaceAdsLogger->info('Ozon Performance: получен список SKU-кампаний (range)', [
                 'companyId' => $companyId,
-                'count' => $campaignsCount,
+                'count' => count($campaigns),
             ]);
 
             $campaigns = $this->filterCampaignsForDateRange($campaigns, $dateFrom, $dateTo);
+            // $campaignsCount отражает число кампаний, которые реально пойдут в
+            // /statistics (после клиентского фильтра по state) — итоговый
+            // summary-лог должен показывать фактическую работу, а не размер
+            // списка из Ozon. Детализация «до/после» уже есть в
+            // `Campaigns filtered by state`.
+            $campaignsCount = count($campaigns);
 
             /** @var array<string, array<string, array{campaign_id: string, campaign_name: string, rows: list<array{sku: string, spend: string, views: int, clicks: int}>}>> $byDate */
             $byDate = [];
@@ -486,11 +492,14 @@ class OzonAdClient implements AdPlatformClientInterface
     /**
      * Клиентский фильтр кампаний по state для «свежих» диапазонов.
      *
-     * Для $dateTo старше RECENT_DAYS_THRESHOLD дней (backfill) — возвращает
-     * все кампании без изменений: архивная сегодня кампания могла крутиться
-     * в запрошенный период. Для недавних диапазонов оставляет только
-     * ACTIVE_CAMPAIGN_STATES (+ пустой state, на всякий случай) и логирует
-     * разбивку отсечённых состояний в канал marketplace_ads.
+     * backfillMode определяется по $dateFrom: если начало диапазона старше
+     * RECENT_DAYS_THRESHOLD дней, весь чанк считаем backfill-ом и возвращаем
+     * кампании без изменений — иначе при длинных чанках (до 62 дней),
+     * заканчивающихся сегодня, мы бы дропнули рекламу, которая была активна
+     * в начале диапазона, а сегодня уже в ARCHIVED. Для недавних диапазонов
+     * (оба конца в пределах 14 дней) оставляем только ACTIVE_CAMPAIGN_STATES
+     * (+ пустой state) и логируем разбивку отсечённых состояний в канал
+     * marketplace_ads.
      *
      * @param list<array{id: string, title: string, state: string}> $campaigns
      *
@@ -503,7 +512,9 @@ class OzonAdClient implements AdPlatformClientInterface
     ): array {
         $today = new \DateTimeImmutable('today', new \DateTimeZone('Europe/Moscow'));
         $cutoffDate = $today->modify('-'.self::RECENT_DAYS_THRESHOLD.' days');
-        $backfillMode = $dateTo < $cutoffDate;
+        // Решаем по $dateFrom: если хотя бы один день чанка старше cutoff —
+        // нельзя дропать ARCHIVED/INACTIVE, они могли откручиваться тогда.
+        $backfillMode = $dateFrom < $cutoffDate;
 
         if ($backfillMode) {
             $this->marketplaceAdsLogger->info('Campaigns filtered by state', [

--- a/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
+++ b/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
@@ -113,7 +113,7 @@ class OzonAdClient implements AdPlatformClientInterface
             'count' => count($campaigns),
         ]);
 
-        $campaigns = $this->filterCampaignsForDateRange($campaigns, $date, $date);
+        $campaigns = $this->filterCampaignsForDateRange($campaigns, $date);
 
         if ([] === $campaigns) {
             return '{"rows": []}';
@@ -217,7 +217,7 @@ class OzonAdClient implements AdPlatformClientInterface
                 'count' => count($campaigns),
             ]);
 
-            $campaigns = $this->filterCampaignsForDateRange($campaigns, $dateFrom, $dateTo);
+            $campaigns = $this->filterCampaignsForDateRange($campaigns, $dateFrom);
             // $campaignsCount отражает число кампаний, которые реально пойдут в
             // /statistics (после клиентского фильтра по state) — итоговый
             // summary-лог должен показывать фактическую работу, а не размер
@@ -508,7 +508,6 @@ class OzonAdClient implements AdPlatformClientInterface
     private function filterCampaignsForDateRange(
         array $campaigns,
         \DateTimeImmutable $dateFrom,
-        \DateTimeImmutable $dateTo,
     ): array {
         $today = new \DateTimeImmutable('today', new \DateTimeZone('Europe/Moscow'));
         $cutoffDate = $today->modify('-'.self::RECENT_DAYS_THRESHOLD.' days');

--- a/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
+++ b/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
@@ -51,6 +51,17 @@ class OzonAdClient implements AdPlatformClientInterface
     private const POLL_INTERVAL_SECONDS = 5;
     private const CACHE_KEY_TOKEN_PREFIX = 'ozon_perf_token_';
 
+    // Для «свежих» диапазонов (dateTo в пределах этого окна от сегодня) отсекаем
+    // явно неактивные кампании на клиенте, чтобы не спрашивать у Ozon статистику
+    // по архивам. Для backfill-а более старых периодов фильтр не применяется —
+    // архивная сегодня кампания могла откручиваться тогда.
+    private const RECENT_DAYS_THRESHOLD = 14;
+    private const ACTIVE_CAMPAIGN_STATES = [
+        'CAMPAIGN_STATE_RUNNING',
+        'CAMPAIGN_STATE_PLANNED',
+        'CAMPAIGN_STATE_STOPPED',
+    ];
+
     /**
      * Счётчик итераций последнего pollReport() — используется инструментированием
      * fetchAdStatisticsRange(), чтобы не ломать публичную сигнатуру pollReport
@@ -100,6 +111,8 @@ class OzonAdClient implements AdPlatformClientInterface
             'companyId' => $companyId,
             'count' => count($campaigns),
         ]);
+
+        $campaigns = $this->filterCampaignsForDateRange($campaigns, $date, $date);
 
         if ([] === $campaigns) {
             return '{"rows": []}';
@@ -203,6 +216,8 @@ class OzonAdClient implements AdPlatformClientInterface
                 'companyId' => $companyId,
                 'count' => $campaignsCount,
             ]);
+
+            $campaigns = $this->filterCampaignsForDateRange($campaigns, $dateFrom, $dateTo);
 
             /** @var array<string, array<string, array{campaign_id: string, campaign_name: string, rows: list<array{sku: string, spend: string, views: int, clicks: int}>}>> $byDate */
             $byDate = [];
@@ -328,7 +343,7 @@ class OzonAdClient implements AdPlatformClientInterface
     }
 
     /**
-     * @param list<array{id: string, title: string}> $batch
+     * @param list<array{id: string, title: string, state: string}> $batch
      *
      * @return array{0: list<string>, 1: array<string, string>}
      */
@@ -425,13 +440,13 @@ class OzonAdClient implements AdPlatformClientInterface
     }
 
     /**
-     * Возвращает все SKU-кампании компании — включая остановленные, архивные
-     * и неактивные. Фильтр по state = RUNNING специально снят: для backfill-а
-     * за прошедшую дату нужны и кампании, которые сегодня уже остановлены,
-     * но вчера откручивались. Кампании без активности на $date просто вернут
-     * пустые строки из /statistics и отфильтруются дальше.
+     * Возвращает все SKU-кампании компании вместе с их state. Фильтр по state
+     * на уровне query-параметра GET /api/client/campaign не передаётся —
+     * Ozon API может тихо проигнорировать неподдерживаемый параметр. Отсев
+     * архивных/неактивных кампаний выполняется на клиенте через
+     * {@see self::filterCampaignsForDateRange()} только для «свежих» диапазонов.
      *
-     * @return list<array{id: string, title: string}>
+     * @return list<array{id: string, title: string, state: string}>
      */
     private function listSkuCampaigns(string $token): array
     {
@@ -461,10 +476,65 @@ class OzonAdClient implements AdPlatformClientInterface
             $result[] = [
                 'id' => $id,
                 'title' => (string) ($campaign['title'] ?? $campaign['name'] ?? ''),
+                'state' => (string) ($campaign['state'] ?? ''),
             ];
         }
 
         return $result;
+    }
+
+    /**
+     * Клиентский фильтр кампаний по state для «свежих» диапазонов.
+     *
+     * Для $dateTo старше RECENT_DAYS_THRESHOLD дней (backfill) — возвращает
+     * все кампании без изменений: архивная сегодня кампания могла крутиться
+     * в запрошенный период. Для недавних диапазонов оставляет только
+     * ACTIVE_CAMPAIGN_STATES (+ пустой state, на всякий случай) и логирует
+     * разбивку отсечённых состояний в канал marketplace_ads.
+     *
+     * @param list<array{id: string, title: string, state: string}> $campaigns
+     *
+     * @return list<array{id: string, title: string, state: string}>
+     */
+    private function filterCampaignsForDateRange(
+        array $campaigns,
+        \DateTimeImmutable $dateFrom,
+        \DateTimeImmutable $dateTo,
+    ): array {
+        $today = new \DateTimeImmutable('today', new \DateTimeZone('Europe/Moscow'));
+        $cutoffDate = $today->modify('-'.self::RECENT_DAYS_THRESHOLD.' days');
+        $backfillMode = $dateTo < $cutoffDate;
+
+        if ($backfillMode) {
+            $this->marketplaceAdsLogger->info('Campaigns filtered by state', [
+                'totalCampaigns' => count($campaigns),
+                'filteredCampaigns' => count($campaigns),
+                'skippedStates' => [],
+                'backfillMode' => true,
+            ]);
+
+            return $campaigns;
+        }
+
+        $filtered = [];
+        $skippedStates = [];
+        foreach ($campaigns as $campaign) {
+            $state = $campaign['state'];
+            if ('' === $state || in_array($state, self::ACTIVE_CAMPAIGN_STATES, true)) {
+                $filtered[] = $campaign;
+                continue;
+            }
+            $skippedStates[$state] = ($skippedStates[$state] ?? 0) + 1;
+        }
+
+        $this->marketplaceAdsLogger->info('Campaigns filtered by state', [
+            'totalCampaigns' => count($campaigns),
+            'filteredCampaigns' => count($filtered),
+            'skippedStates' => $skippedStates,
+            'backfillMode' => false,
+        ]);
+
+        return $filtered;
     }
 
     /**

--- a/site/tests/Unit/MarketplaceAds/OzonAdClientTest.php
+++ b/site/tests/Unit/MarketplaceAds/OzonAdClientTest.php
@@ -520,6 +520,120 @@ final class OzonAdClientTest extends TestCase
     }
 
     // -----------------------------------------------------------------
+    // h) Campaign filter: old range (dateTo > 14 days ago) — keep all campaigns
+    //    including ARCHIVED / INACTIVE (backfill). Log marked backfillMode=true.
+    // -----------------------------------------------------------------
+    public function testFilterCampaignsBackfillModeKeepsAllCampaigns(): void
+    {
+        $campaignList = $this->campaignListBodyWithStates([
+            ['id' => '111', 'title' => 'Running',  'state' => 'CAMPAIGN_STATE_RUNNING'],
+            ['id' => '222', 'title' => 'Archived', 'state' => 'CAMPAIGN_STATE_ARCHIVED'],
+            ['id' => '333', 'title' => 'Inactive', 'state' => 'CAMPAIGN_STATE_INACTIVE'],
+            ['id' => '444', 'title' => 'NoState',  'state' => ''],
+        ]);
+
+        $http = $this->buildHttpClientForRange(
+            tokenBody: $this->tokenBody('TKN-BF'),
+            campaignListBody: $campaignList,
+            statisticsBody: '{"UUID":"uuid-bf"}',
+            stateBody: $this->stateReadyBody('/api/client/statistics/report?UUID=uuid-bf'),
+            downloadCsv: "date;campaign_id;campaign_name;sku;spend;views;clicks\n",
+        );
+
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+
+        // Far-past range — guaranteed older than 14 days regardless of run date.
+        $dateFrom = (new \DateTimeImmutable('today'))->modify('-60 days');
+        $dateTo = (new \DateTimeImmutable('today'))->modify('-30 days');
+
+        $client->fetchAdStatisticsRange(self::COMPANY_ID, $dateFrom, $dateTo);
+
+        $record = $this->findLogRecord('Campaigns filtered by state');
+        self::assertSame('info', $record['level']);
+        self::assertSame(4, $record['context']['totalCampaigns']);
+        self::assertSame(4, $record['context']['filteredCampaigns']);
+        self::assertSame([], $record['context']['skippedStates']);
+        self::assertTrue($record['context']['backfillMode']);
+    }
+
+    // -----------------------------------------------------------------
+    // i) Campaign filter: recent range (dateTo within 14 days) — drop
+    //    ARCHIVED / INACTIVE, keep RUNNING / PLANNED / STOPPED.
+    // -----------------------------------------------------------------
+    public function testFilterCampaignsRecentRangeKeepsOnlyActiveStates(): void
+    {
+        $campaignList = $this->campaignListBodyWithStates([
+            ['id' => '111', 'title' => 'Running',  'state' => 'CAMPAIGN_STATE_RUNNING'],
+            ['id' => '222', 'title' => 'Planned',  'state' => 'CAMPAIGN_STATE_PLANNED'],
+            ['id' => '333', 'title' => 'Stopped',  'state' => 'CAMPAIGN_STATE_STOPPED'],
+            ['id' => '444', 'title' => 'Archived', 'state' => 'CAMPAIGN_STATE_ARCHIVED'],
+            ['id' => '555', 'title' => 'Inactive', 'state' => 'CAMPAIGN_STATE_INACTIVE'],
+        ]);
+
+        $requests = [];
+        $responses = $this->scriptedResponsesWithRecording($requests, [
+            new MockResponse($this->tokenBody('TKN-R')),
+            new MockResponse($campaignList),
+            new MockResponse('{"UUID":"uuid-r"}'),
+            new MockResponse($this->stateReadyBody('/api/client/statistics/report?UUID=uuid-r')),
+            new MockResponse("date;campaign_id;campaign_name;sku;spend;views;clicks\n"),
+        ]);
+
+        $http = new MockHttpClient($responses);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+
+        // Recent range — dateTo is within 14-day window from today.
+        $dateFrom = (new \DateTimeImmutable('today'))->modify('-5 days');
+        $dateTo = (new \DateTimeImmutable('today'))->modify('-1 day');
+
+        $client->fetchAdStatisticsRange(self::COMPANY_ID, $dateFrom, $dateTo);
+
+        $record = $this->findLogRecord('Campaigns filtered by state');
+        self::assertSame(5, $record['context']['totalCampaigns']);
+        self::assertSame(3, $record['context']['filteredCampaigns']);
+        self::assertFalse($record['context']['backfillMode']);
+        self::assertSame(
+            ['CAMPAIGN_STATE_ARCHIVED' => 1, 'CAMPAIGN_STATE_INACTIVE' => 1],
+            $record['context']['skippedStates'],
+        );
+
+        // Exactly 5 HTTP requests (one stats batch of 3 filtered campaigns).
+        self::assertCount(5, $requests, 'Expected 5 HTTP requests: token, /campaign, /statistics, /state, /download');
+    }
+
+    // -----------------------------------------------------------------
+    // j) Campaign filter: recent range, empty state → campaign preserved.
+    // -----------------------------------------------------------------
+    public function testFilterCampaignsRecentRangeKeepsEmptyState(): void
+    {
+        $campaignList = $this->campaignListBodyWithStates([
+            ['id' => '111', 'title' => 'NoState',  'state' => ''],
+            ['id' => '222', 'title' => 'Archived', 'state' => 'CAMPAIGN_STATE_ARCHIVED'],
+        ]);
+
+        $http = $this->buildHttpClientForRange(
+            tokenBody: $this->tokenBody('TKN-E'),
+            campaignListBody: $campaignList,
+            statisticsBody: '{"UUID":"uuid-e"}',
+            stateBody: $this->stateReadyBody('/api/client/statistics/report?UUID=uuid-e'),
+            downloadCsv: "date;campaign_id;campaign_name;sku;spend;views;clicks\n",
+        );
+
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+
+        $dateFrom = (new \DateTimeImmutable('today'))->modify('-3 days');
+        $dateTo = (new \DateTimeImmutable('today'))->modify('-1 day');
+
+        $client->fetchAdStatisticsRange(self::COMPANY_ID, $dateFrom, $dateTo);
+
+        $record = $this->findLogRecord('Campaigns filtered by state');
+        self::assertFalse($record['context']['backfillMode']);
+        self::assertSame(2, $record['context']['totalCampaigns']);
+        self::assertSame(1, $record['context']['filteredCampaigns']);
+        self::assertSame(['CAMPAIGN_STATE_ARCHIVED' => 1], $record['context']['skippedStates']);
+    }
+
+    // -----------------------------------------------------------------
     // g) Backward-compat: fetchAdStatistics($companyId, $date) still works
     // -----------------------------------------------------------------
     public function testFetchAdStatisticsLegacyContractRemainsStable(): void
@@ -605,6 +719,27 @@ final class OzonAdClientTest extends TestCase
                 'id' => $id,
                 'title' => 'Campaign '.chr(64 + $i),
                 'advObjectType' => 'SKU',
+            ];
+        }
+
+        return json_encode(['list' => $list], JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * /campaign list with explicit state per campaign (covers the client-side
+     * filter by state).
+     *
+     * @param list<array{id: string, title: string, state: string}> $campaigns
+     */
+    private function campaignListBodyWithStates(array $campaigns): string
+    {
+        $list = [];
+        foreach ($campaigns as $c) {
+            $list[] = [
+                'id' => $c['id'],
+                'title' => $c['title'],
+                'advObjectType' => 'SKU',
+                'state' => $c['state'],
             ];
         }
 

--- a/site/tests/Unit/MarketplaceAds/OzonAdClientTest.php
+++ b/site/tests/Unit/MarketplaceAds/OzonAdClientTest.php
@@ -602,6 +602,46 @@ final class OzonAdClientTest extends TestCase
     }
 
     // -----------------------------------------------------------------
+    // j.1) Campaign filter: mixed range (starts >14 days ago, ends today) →
+    //      treated as backfill, ARCHIVED/INACTIVE kept. Guards against dropping
+    //      campaigns that were active in the older part of a long chunk.
+    // -----------------------------------------------------------------
+    public function testFilterCampaignsLongChunkEndingTodayIsBackfillMode(): void
+    {
+        $campaignList = $this->campaignListBodyWithStates([
+            ['id' => '111', 'title' => 'Running',  'state' => 'CAMPAIGN_STATE_RUNNING'],
+            ['id' => '222', 'title' => 'Archived', 'state' => 'CAMPAIGN_STATE_ARCHIVED'],
+            ['id' => '333', 'title' => 'Inactive', 'state' => 'CAMPAIGN_STATE_INACTIVE'],
+        ]);
+
+        $http = $this->buildHttpClientForRange(
+            tokenBody: $this->tokenBody('TKN-LC'),
+            campaignListBody: $campaignList,
+            statisticsBody: '{"UUID":"uuid-lc"}',
+            stateBody: $this->stateReadyBody('/api/client/statistics/report?UUID=uuid-lc'),
+            downloadCsv: "date;campaign_id;campaign_name;sku;spend;views;clicks\n",
+        );
+
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+
+        // dateFrom 30 days ago (< cutoff), dateTo today (>> cutoff).
+        // Must behave as backfill: all 3 campaigns kept despite dateTo being recent.
+        $dateFrom = (new \DateTimeImmutable('today'))->modify('-30 days');
+        $dateTo = new \DateTimeImmutable('today');
+
+        $client->fetchAdStatisticsRange(self::COMPANY_ID, $dateFrom, $dateTo);
+
+        $record = $this->findLogRecord('Campaigns filtered by state');
+        self::assertTrue(
+            $record['context']['backfillMode'],
+            'Chunk starting 30 days ago must be backfill even if it ends today',
+        );
+        self::assertSame(3, $record['context']['totalCampaigns']);
+        self::assertSame(3, $record['context']['filteredCampaigns']);
+        self::assertSame([], $record['context']['skippedStates']);
+    }
+
+    // -----------------------------------------------------------------
     // j) Campaign filter: recent range, empty state → campaign preserved.
     // -----------------------------------------------------------------
     public function testFilterCampaignsRecentRangeKeepsEmptyState(): void


### PR DESCRIPTION
## Summary

- Extract `state` field per campaign in `OzonAdClient::listSkuCampaigns()`.
- New private helper `filterCampaignsForDateRange()`: for recent ranges
  (`dateTo` within `RECENT_DAYS_THRESHOLD = 14` days from today, Europe/Moscow)
  keep only `CAMPAIGN_STATE_RUNNING` / `CAMPAIGN_STATE_PLANNED` /
  `CAMPAIGN_STATE_STOPPED` (+ empty state). For backfill of older ranges — keep
  all campaigns (today-archived campaign could have been running back then).
- Wire the filter into both `fetchAdStatistics()` (single day) and
  `fetchAdStatisticsRange()` right before the `array_chunk` loop.
- Log the decision into `marketplace_ads` channel as `Campaigns filtered by state`
  with `totalCampaigns` / `filteredCampaigns` / `skippedStates` / `backfillMode`.

Filter is client-side (no `state` query-param on `GET /api/client/campaign`)
because Ozon API may silently ignore unsupported parameters.

## Test plan

- [x] `php -l` clean on both touched files
- [x] New unit tests in `OzonAdClientTest`:
  - backfill mode (`dateTo` 30 days ago) keeps ARCHIVED/INACTIVE/empty → `backfillMode=true` in log
  - recent range (dateTo yesterday) drops ARCHIVED/INACTIVE, keeps RUNNING/PLANNED/STOPPED, log reports `skippedStates` and `backfillMode=false`
  - recent range keeps empty-state campaign
- [ ] Existing tests continue to pass (all old-range fixtures default to backfill path, so they are unaffected by the filter)

https://claude.ai/code/session_01KtYgpAo9oygiMPbZaEK6tX