### PR TITLE
feat(Shared,MarketplaceAds): bronze-storage infrastructure for Ozon Ads

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -162,6 +162,7 @@ services:
                 condition: service_healthy
         volumes:
             - site_storage:/app/var/storage
+            - site_company_storage:/app/var/storage/companies
             - site_var_log:/app/var/log
         # ⬇️ FIX: увеличен start_period — даём время на cache:warmup при первом старте
         healthcheck:
@@ -193,6 +194,7 @@ services:
                 condition: service_healthy
         volumes:
             - site_storage:/app/var/storage
+            - site_company_storage:/app/var/storage/companies
             - site_var_log:/app/var/log
 
     site-messenger-worker:
@@ -211,6 +213,7 @@ services:
                 condition: service_healthy
         volumes:
             - site_storage:/app/var/storage
+            - site_company_storage:/app/var/storage/companies
             - site_var_log:/app/var/log
         # ⬇️ FIX: Даём воркеру завершить текущее сообщение при остановке
         stop_grace_period: 60s
@@ -299,6 +302,7 @@ services:
 
 volumes:
     site_storage:
+    site_company_storage:
     site_var_log:
     traefik-certs:
     postgres_data:

--- a/site/docker/production/entrypoint-cli.sh
+++ b/site/docker/production/entrypoint-cli.sh
@@ -3,12 +3,16 @@ set -eu
 
 STORAGE_DIR="/app/var/storage"
 IMPORT_DIR="$STORAGE_DIR/cash-file-imports"
+COMPANY_DIR="$STORAGE_DIR/companies"
 LOG_DIR="/app/var/log"
 
 mkdir -p "$IMPORT_DIR"
+mkdir -p "$COMPANY_DIR"
 mkdir -p "$LOG_DIR"
 chown -R www-data:www-data "$STORAGE_DIR"
 chmod -R 0775 "$STORAGE_DIR"
+chown -R www-data:www-data "$COMPANY_DIR"
+chmod -R 0775 "$COMPANY_DIR"
 chown -R www-data:www-data "$LOG_DIR"
 chmod -R 0775 "$LOG_DIR"
 

--- a/site/docker/production/entrypoint-init-storage.sh
+++ b/site/docker/production/entrypoint-init-storage.sh
@@ -3,15 +3,19 @@ set -eu
 
 STORAGE_DIR="/app/var/storage"
 IMPORT_DIR="$STORAGE_DIR/cash-file-imports"
+COMPANY_DIR="$STORAGE_DIR/companies"
 LOG_DIR="/app/var/log"
 
 # 1) создаём директории (после mount volume они могут быть пустыми)
 mkdir -p "$IMPORT_DIR"
+mkdir -p "$COMPANY_DIR"
 mkdir -p "$LOG_DIR"
 
 # 2) права: владелец www-data, группа www-data, чтобы и FPM и воркеры могли читать/писать
 chown -R www-data:www-data "$STORAGE_DIR"
 chmod -R 0775 "$STORAGE_DIR"
+chown -R www-data:www-data "$COMPANY_DIR"
+chmod -R 0775 "$COMPANY_DIR"
 chown -R www-data:www-data "$LOG_DIR"
 chmod -R 0775 "$LOG_DIR"
 

--- a/site/migrations/Version20260420044142.php
+++ b/site/migrations/Version20260420044142.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * MarketplaceAds: добавить поля для bronze-хранения сырого ответа рекламных API
+ * в marketplace_ad_raw_documents.
+ *
+ * Поля:
+ *  - storage_path    — относительный путь к файлу внутри storageRoot
+ *  - file_hash       — sha256 содержимого файла (hex, 64 символа)
+ *  - file_size_bytes — размер файла в байтах
+ *
+ * Частичный индекс idx_ad_raw_docs_file_hash нужен для поиска дубликатов
+ * по содержимому и только для документов с уже сохранённым файлом.
+ */
+final class Version20260420044142 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'MarketplaceAds: add storage_path / file_hash / file_size_bytes columns to marketplace_ad_raw_documents';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE marketplace_ad_raw_documents ADD COLUMN storage_path VARCHAR(512) DEFAULT NULL');
+        $this->addSql('ALTER TABLE marketplace_ad_raw_documents ADD COLUMN file_hash CHAR(64) DEFAULT NULL');
+        $this->addSql('ALTER TABLE marketplace_ad_raw_documents ADD COLUMN file_size_bytes BIGINT DEFAULT NULL');
+        $this->addSql('CREATE INDEX idx_ad_raw_docs_file_hash ON marketplace_ad_raw_documents (file_hash) WHERE file_hash IS NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS idx_ad_raw_docs_file_hash');
+        $this->addSql('ALTER TABLE marketplace_ad_raw_documents DROP COLUMN storage_path');
+        $this->addSql('ALTER TABLE marketplace_ad_raw_documents DROP COLUMN file_hash');
+        $this->addSql('ALTER TABLE marketplace_ad_raw_documents DROP COLUMN file_size_bytes');
+    }
+}

--- a/site/src/MarketplaceAds/Entity/AdRawDocument.php
+++ b/site/src/MarketplaceAds/Entity/AdRawDocument.php
@@ -55,8 +55,10 @@ class AdRawDocument
     #[ORM\Column(type: 'string', length: 64, nullable: true)]
     private ?string $fileHash = null;
 
+    // Doctrine hydrates BIGINT as string by default (см. MoneyFundMovement::$amountMinor) —
+    // на типизированном ?int возникал бы TypeError при загрузке.
     #[ORM\Column(type: 'bigint', nullable: true)]
-    private ?int $fileSizeBytes = null;
+    private ?string $fileSizeBytes = null;
 
     #[ORM\Column(type: 'datetime_immutable')]
     private \DateTimeImmutable $updatedAt;
@@ -125,9 +127,11 @@ class AdRawDocument
 
     public function setFileStorage(string $path, string $hash, int $size): void
     {
+        Assert::greaterThanEq($size, 0, 'Размер файла не может быть отрицательным.');
+
         $this->storagePath = $path;
         $this->fileHash = $hash;
-        $this->fileSizeBytes = $size;
+        $this->fileSizeBytes = (string) $size;
         $this->updatedAt = new \DateTimeImmutable();
     }
 
@@ -193,6 +197,6 @@ class AdRawDocument
 
     public function getFileSizeBytes(): ?int
     {
-        return $this->fileSizeBytes;
+        return null !== $this->fileSizeBytes ? (int) $this->fileSizeBytes : null;
     }
 }

--- a/site/src/MarketplaceAds/Entity/AdRawDocument.php
+++ b/site/src/MarketplaceAds/Entity/AdRawDocument.php
@@ -49,6 +49,15 @@ class AdRawDocument
     #[ORM\Column(type: 'text', nullable: true)]
     private ?string $processingError = null;
 
+    #[ORM\Column(type: 'string', length: 512, nullable: true)]
+    private ?string $storagePath = null;
+
+    #[ORM\Column(type: 'string', length: 64, nullable: true)]
+    private ?string $fileHash = null;
+
+    #[ORM\Column(type: 'bigint', nullable: true)]
+    private ?int $fileSizeBytes = null;
+
     #[ORM\Column(type: 'datetime_immutable')]
     private \DateTimeImmutable $updatedAt;
 
@@ -114,6 +123,14 @@ class AdRawDocument
         $this->updatedAt = new \DateTimeImmutable();
     }
 
+    public function setFileStorage(string $path, string $hash, int $size): void
+    {
+        $this->storagePath = $path;
+        $this->fileHash = $hash;
+        $this->fileSizeBytes = $size;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
     public function getId(): string
     {
         return $this->id;
@@ -162,5 +179,20 @@ class AdRawDocument
     public function getUpdatedAt(): \DateTimeImmutable
     {
         return $this->updatedAt;
+    }
+
+    public function getStoragePath(): ?string
+    {
+        return $this->storagePath;
+    }
+
+    public function getFileHash(): ?string
+    {
+        return $this->fileHash;
+    }
+
+    public function getFileSizeBytes(): ?int
+    {
+        return $this->fileSizeBytes;
     }
 }

--- a/site/src/Shared/Service/Storage/StorageService.php
+++ b/site/src/Shared/Service/Storage/StorageService.php
@@ -51,6 +51,41 @@ final class StorageService
         ];
     }
 
+    /**
+     * @return array{storagePath: string, fileHash: string, sizeBytes: int, mimeType: ?string}
+     */
+    public function storeBytes(string $bytes, string $relativePath): array
+    {
+        $relativePath = ltrim($relativePath, '/');
+        $targetDir = dirname($relativePath);
+
+        if ('.' !== $targetDir && '' !== $targetDir) {
+            $this->ensureDir($targetDir);
+        }
+
+        $absolutePath = $this->storageRoot.'/'.$relativePath;
+
+        if (false === file_put_contents($absolutePath, $bytes, \LOCK_EX)) {
+            throw new \RuntimeException(sprintf('Failed to write storage file "%s".', $absolutePath));
+        }
+
+        $fileHash = hash('sha256', $bytes);
+        $sizeBytes = strlen($bytes);
+
+        $finfo = finfo_open(\FILEINFO_MIME_TYPE);
+        $mimeType = false !== $finfo ? (finfo_buffer($finfo, $bytes) ?: null) : null;
+        if (false !== $finfo) {
+            finfo_close($finfo);
+        }
+
+        return [
+            'storagePath' => $relativePath,
+            'fileHash' => $fileHash,
+            'sizeBytes' => $sizeBytes,
+            'mimeType' => $mimeType,
+        ];
+    }
+
     public function getAbsolutePath(string $relativePath): string
     {
         return $this->storageRoot.'/'.ltrim($relativePath, '/');

--- a/site/src/Shared/Service/Storage/StorageService.php
+++ b/site/src/Shared/Service/Storage/StorageService.php
@@ -57,6 +57,15 @@ final class StorageService
     public function storeBytes(string $bytes, string $relativePath): array
     {
         $relativePath = ltrim($relativePath, '/');
+
+        // Защита от Path Traversal: любой сегмент '..' позволил бы выйти за storageRoot.
+        // Split по '/' вместо str_contains, чтобы имена файлов вроде "..zip" не срабатывали как false-positive.
+        foreach (explode('/', $relativePath) as $segment) {
+            if ('..' === $segment) {
+                throw new \InvalidArgumentException(sprintf('Path traversal segment detected in "%s".', $relativePath));
+            }
+        }
+
         $targetDir = dirname($relativePath);
 
         if ('.' !== $targetDir && '' !== $targetDir) {

--- a/site/src/Shared/Service/Storage/StorageService.php
+++ b/site/src/Shared/Service/Storage/StorageService.php
@@ -73,13 +73,28 @@ final class StorageService
         }
 
         $absolutePath = $this->storageRoot.'/'.$relativePath;
+        $sizeBytes = strlen($bytes);
 
-        if (false === file_put_contents($absolutePath, $bytes, \LOCK_EX)) {
+        // file_put_contents может вернуть int < strlen($bytes) при disk-full / quota-exceeded /
+        // прерванной записи — в этом случае на диске окажется truncated-файл, но метод тихо
+        // вернёт success. Для бронзы это недопустимо: caller сохранит hash + size от полного
+        // буфера, а downstream получит битый артефакт. Поэтому сверяем записанный объём.
+        $written = file_put_contents($absolutePath, $bytes, \LOCK_EX);
+        if (false === $written) {
             throw new \RuntimeException(sprintf('Failed to write storage file "%s".', $absolutePath));
+        }
+        if ($written !== $sizeBytes) {
+            // Удаляем частично записанный файл, чтобы downstream не подхватил битый payload.
+            @unlink($absolutePath);
+            throw new \RuntimeException(sprintf(
+                'Short write to storage file "%s": wrote %d of %d bytes.',
+                $absolutePath,
+                $written,
+                $sizeBytes,
+            ));
         }
 
         $fileHash = hash('sha256', $bytes);
-        $sizeBytes = strlen($bytes);
 
         $finfo = finfo_open(\FILEINFO_MIME_TYPE);
         $mimeType = false !== $finfo ? (finfo_buffer($finfo, $bytes) ?: null) : null;

--- a/site/tests/Integration/Shared/Storage/StorageServiceIntegrationTest.php
+++ b/site/tests/Integration/Shared/Storage/StorageServiceIntegrationTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Shared\Storage;
+
+use App\Shared\Service\Storage\StorageService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Полный цикл storeBytes → файл на диске → getAbsolutePath → чтение.
+ * Интеграционный, без Symfony kernel — работает с реальным временным каталогом.
+ */
+final class StorageServiceIntegrationTest extends TestCase
+{
+    private string $storageRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->storageRoot = sys_get_temp_dir().'/storage-service-int-'.bin2hex(random_bytes(6));
+        if (!mkdir($this->storageRoot, 0o775, true) && !is_dir($this->storageRoot)) {
+            self::fail('Failed to prepare integration storage root');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->storageRoot)) {
+            $this->removeDir($this->storageRoot);
+        }
+        parent::tearDown();
+    }
+
+    public function testStoreBytesRoundTripThroughGetAbsolutePath(): void
+    {
+        $service = new StorageService($this->storageRoot);
+        $bytes = "integration-payload\n".random_bytes(256);
+        $relativePath = 'companies/11111111-1111-1111-1111-111111111111/marketplace-ads/ozon/bronze/2026/04/20/report.bin';
+
+        $result = $service->storeBytes($bytes, $relativePath);
+
+        self::assertSame($relativePath, $result['storagePath']);
+
+        $absolute = $service->getAbsolutePath($result['storagePath']);
+        self::assertSame($this->storageRoot.'/'.$relativePath, $absolute);
+        self::assertFileExists($absolute);
+
+        $readBack = file_get_contents($absolute);
+        self::assertSame($bytes, $readBack);
+        self::assertSame(hash('sha256', $readBack), $result['fileHash']);
+        self::assertSame(strlen($readBack), $result['sizeBytes']);
+    }
+
+    private function removeDir(string $dir): void
+    {
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($iterator as $file) {
+            /** @var \SplFileInfo $file */
+            if ($file->isDir()) {
+                rmdir($file->getPathname());
+            } else {
+                unlink($file->getPathname());
+            }
+        }
+
+        rmdir($dir);
+    }
+}

--- a/site/tests/Unit/MarketplaceAds/AdRawDocumentTest.php
+++ b/site/tests/Unit/MarketplaceAds/AdRawDocumentTest.php
@@ -124,4 +124,27 @@ final class AdRawDocumentTest extends TestCase
             'already FAILED'    => [AdRawDocumentStatus::FAILED],
         ];
     }
+
+    public function testGettersReturnNullByDefault(): void
+    {
+        $doc = AdRawDocumentBuilder::aRawDocument()->build();
+
+        self::assertNull($doc->getStoragePath());
+        self::assertNull($doc->getFileHash());
+        self::assertNull($doc->getFileSizeBytes());
+    }
+
+    public function testSetFileStorageSetsAllThreeFieldsAtomically(): void
+    {
+        $doc = AdRawDocumentBuilder::aRawDocument()->build();
+        $path = 'companies/11111111-1111-1111-1111-111111111111/marketplace-ads/ozon/bronze/2026/04/20/x.zip';
+        $hash = str_repeat('a', 64);
+        $size = 12345;
+
+        $doc->setFileStorage($path, $hash, $size);
+
+        self::assertSame($path, $doc->getStoragePath());
+        self::assertSame($hash, $doc->getFileHash());
+        self::assertSame($size, $doc->getFileSizeBytes());
+    }
 }

--- a/site/tests/Unit/Shared/Service/Storage/StorageServiceTest.php
+++ b/site/tests/Unit/Shared/Service/Storage/StorageServiceTest.php
@@ -77,6 +77,16 @@ final class StorageServiceTest extends TestCase
         self::assertStringStartsWith('text/', $result['mimeType']);
     }
 
+    public function testStoreBytesRejectsPathTraversal(): void
+    {
+        $service = new StorageService($this->storageRoot);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Path traversal');
+
+        $service->storeBytes('x', 'companies/../../etc/passwd');
+    }
+
     public function testStoreBytesThrowsWhenWriteFails(): void
     {
         // storageRoot указывает на путь, где создать целевой подкаталог нельзя,

--- a/site/tests/Unit/Shared/Service/Storage/StorageServiceTest.php
+++ b/site/tests/Unit/Shared/Service/Storage/StorageServiceTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Service\Storage;
+
+use App\Shared\Service\Storage\StorageService;
+use PHPUnit\Framework\TestCase;
+
+final class StorageServiceTest extends TestCase
+{
+    private string $storageRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->storageRoot = sys_get_temp_dir().'/storage-service-test-'.bin2hex(random_bytes(6));
+        if (!mkdir($this->storageRoot, 0o775, true) && !is_dir($this->storageRoot)) {
+            self::fail('Failed to prepare test storage root');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->storageRoot)) {
+            $this->removeDir($this->storageRoot);
+        }
+        parent::tearDown();
+    }
+
+    public function testStoreBytesCreatesFileAndReturnsMetadata(): void
+    {
+        $service = new StorageService($this->storageRoot);
+        $bytes = "raw-payload-бинарные-данные";
+
+        $result = $service->storeBytes($bytes, 'companies/abc/file.bin');
+
+        self::assertSame('companies/abc/file.bin', $result['storagePath']);
+        self::assertSame(hash('sha256', $bytes), $result['fileHash']);
+        self::assertSame(strlen($bytes), $result['sizeBytes']);
+        self::assertFileExists($this->storageRoot.'/companies/abc/file.bin');
+        self::assertSame($bytes, file_get_contents($this->storageRoot.'/companies/abc/file.bin'));
+    }
+
+    public function testStoreBytesCreatesDirectoryIfMissing(): void
+    {
+        $service = new StorageService($this->storageRoot);
+
+        self::assertDirectoryDoesNotExist($this->storageRoot.'/a/b/c');
+
+        $service->storeBytes('x', 'a/b/c/file.txt');
+
+        self::assertDirectoryExists($this->storageRoot.'/a/b/c');
+        self::assertFileExists($this->storageRoot.'/a/b/c/file.txt');
+    }
+
+    public function testStoreBytesDetectsBinaryMimeType(): void
+    {
+        $service = new StorageService($this->storageRoot);
+        // ZIP magic bytes: PK\x03\x04 + минимальный end-of-central-dir
+        $zip = "PK\x03\x04\x0a\x00\x00\x00\x00\x00".str_repeat("\x00", 18)."PK\x05\x06".str_repeat("\x00", 18);
+
+        $result = $service->storeBytes($zip, 'bronze/archive.zip');
+
+        self::assertNotNull($result['mimeType']);
+        self::assertSame('application/zip', $result['mimeType']);
+    }
+
+    public function testStoreBytesDetectsTextMimeType(): void
+    {
+        $service = new StorageService($this->storageRoot);
+        $csv = "campaign_id,sku,spend\n123,ABC,45.67\n";
+
+        $result = $service->storeBytes($csv, 'bronze/report.csv');
+
+        self::assertNotNull($result['mimeType']);
+        self::assertStringStartsWith('text/', $result['mimeType']);
+    }
+
+    public function testStoreBytesThrowsWhenWriteFails(): void
+    {
+        // storageRoot указывает на путь, где создать целевой подкаталог нельзя,
+        // потому что в пути уже существует файл вместо директории.
+        $blocker = $this->storageRoot.'/blocker';
+        file_put_contents($blocker, 'occupies-path-as-file');
+
+        $service = new StorageService($this->storageRoot);
+
+        $this->expectException(\RuntimeException::class);
+
+        // 'blocker/file.bin' → ensureDir('blocker') упадёт, потому что 'blocker' — файл.
+        $service->storeBytes('x', 'blocker/file.bin');
+    }
+
+    private function removeDir(string $dir): void
+    {
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($iterator as $file) {
+            /** @var \SplFileInfo $file */
+            if ($file->isDir()) {
+                rmdir($file->getPathname());
+            } else {
+                unlink($file->getPathname());
+            }
+        }
+
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
## Summary

Задача A' — подготовить инфраструктуру для сохранения сырого ответа Ozon (ZIP/CSV) на диск. Сам fetch/разбор — задача B.

### StorageService
- Новый метод `storeBytes(string $bytes, string $relativePath): array` с atomic write через `LOCK_EX`, auto-`ensureDir`, возвращает `{storagePath, fileHash, sizeBytes, mimeType}`.
- Существующие `ensureDir` / `storeUploadedFile` / `getAbsolutePath` не трогали.

### AdRawDocument — bronze-поля
- Три nullable-поля: `storage_path VARCHAR(512)`, `file_hash CHAR(64)`, `file_size_bytes BIGINT`.
- Геттеры + атомарный `setFileStorage(path, hash, size)`.
- Миграция `Version20260420044142` + частичный индекс `idx_ad_raw_docs_file_hash` (только для `file_hash IS NOT NULL`).

### Docker (prod)
- Новый named volume `site_company_storage` → `/app/var/storage/companies`.
- Примонтирован к `site-php-fpm`, `site-php-cli`, `site-messenger-worker`.
- `scheduler` НЕ монтируем (он root — поломает permissions, логика из PR #1593).
- `entrypoint-init-storage.sh` и `entrypoint-cli.sh` создают каталог с owner `www-data:www-data` и `chmod 0775`.

### Что **не** делалось
- Не писали в `storage_path` — это задача B.
- Не добавляли admin-endpoint download bronze — это задача B.
- Не трогали параметр `app.storage_root` в `services.yaml` — путь остаётся относительным, от `storageRoot`.

## Test plan

- [x] `php -l` — все изменённые PHP-файлы без синтаксических ошибок
- [ ] `vendor/bin/phpunit tests/Unit/Shared/Service/Storage/StorageServiceTest.php` (5 кейсов)
- [ ] `vendor/bin/phpunit tests/Unit/MarketplaceAds/AdRawDocumentTest.php` (включая новые `testSetFileStorageSetsAllThreeFieldsAtomically`, `testGettersReturnNullByDefault`)
- [ ] `vendor/bin/phpunit tests/Integration/Shared/Storage/StorageServiceIntegrationTest.php` (roundtrip storeBytes → getAbsolutePath)
- [ ] `bin/console doctrine:migrations:migrate` локально и на stage
- [ ] Проверить, что named volume `site_company_storage` создаётся и монтируется в fpm/cli/worker (scheduler не трогает)

https://claude.ai/code/session_017ZA3G5YmsDrz1w6N4jTWdE