### PR TITLE
feat(MarketplaceAds): bronze layer with ZIP extraction for Ozon Ads

### DIFF
--- a/site/src/MarketplaceAds/Controller/Api/Admin/DownloadBronzeController.php
+++ b/site/src/MarketplaceAds/Controller/Api/Admin/DownloadBronzeController.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Controller\Api\Admin;
+
+use App\MarketplaceAds\Repository\AdRawDocumentRepository;
+use App\Shared\Service\Storage\StorageService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Скачивание сырого bronze-файла рекламного отчёта Ozon (ZIP или CSV).
+ *
+ * Endpoint только для super-admin'ов (общая инфраструктурная диагностика —
+ * IDOR-проверка по company_id здесь намеренно отключена, как и у соседнего
+ * /api/marketplace-ads/admin/logs). Для rank-and-file пользователей bronze
+ * остаётся недоступным, прямой URL — единственный способ получить файл.
+ */
+#[Route(
+    '/api/marketplace-ads/admin/bronze/{documentId}/download',
+    name: 'marketplace_ads_admin_bronze_download',
+    methods: ['GET'],
+)]
+#[IsGranted('ROLE_SUPER_ADMIN')]
+final class DownloadBronzeController extends AbstractController
+{
+    public function __construct(
+        private readonly AdRawDocumentRepository $adRawDocumentRepository,
+        private readonly StorageService $storageService,
+    ) {
+    }
+
+    public function __invoke(string $documentId): Response
+    {
+        $document = $this->adRawDocumentRepository->find($documentId);
+        if (null === $document) {
+            throw $this->createNotFoundException('AdRawDocument not found');
+        }
+
+        $storagePath = $document->getStoragePath();
+        if (null === $storagePath) {
+            // Старые документы (до миграции на bronze) не имеют сохранённого
+            // raw-файла — возвращаем 404 с явным текстом вместо общего «not found»,
+            // чтобы оператор понял причину.
+            throw $this->createNotFoundException('Bronze file missing: document has no storage_path');
+        }
+
+        $absolutePath = $this->storageService->getAbsolutePath($storagePath);
+        if (!is_file($absolutePath)) {
+            throw $this->createNotFoundException('Bronze file missing: file not found on disk');
+        }
+
+        $extension = str_ends_with(strtolower($storagePath), '.zip') ? 'zip' : 'csv';
+        $contentType = 'zip' === $extension ? 'application/zip' : 'text/csv';
+        $filename = basename($storagePath);
+
+        $response = new StreamedResponse(static function () use ($absolutePath): void {
+            readfile($absolutePath);
+        });
+        $response->headers->set('Content-Type', $contentType);
+        $response->headers->set(
+            'Content-Disposition',
+            $response->headers->makeDisposition(
+                ResponseHeaderBag::DISPOSITION_ATTACHMENT,
+                $filename,
+            ),
+        );
+
+        $sizeBytes = $document->getFileSizeBytes();
+        if (null !== $sizeBytes) {
+            $response->headers->set('Content-Length', (string) $sizeBytes);
+        }
+
+        return $response;
+    }
+}

--- a/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
+++ b/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
@@ -70,6 +70,18 @@ class OzonAdClient implements AdPlatformClientInterface
      */
     private int $lastPollAttempts = 0;
 
+    /**
+     * Сырые выгрузки отчётов, собранные в последнем вызове
+     * fetchAdStatisticsRange() / fetchAdStatistics(). Используются handler'ом
+     * для сохранения bronze-слоя: один chunk может содержать несколько
+     * физических запросов к Ozon (батчи по 10 кампаний), и каждому
+     * соответствует отдельный отчёт-файл. Сбрасывается на старте каждой
+     * публичной операции fetch — НЕ читать между вызовами.
+     *
+     * @var list<OzonReportDownload>
+     */
+    private array $lastChunkDownloads = [];
+
     public function __construct(
         private readonly HttpClientInterface $httpClient,
         private readonly MarketplaceFacade $marketplaceFacade,
@@ -92,6 +104,8 @@ class OzonAdClient implements AdPlatformClientInterface
 
     public function fetchAdStatistics(string $companyId, \DateTimeImmutable $date): string
     {
+        $this->lastChunkDownloads = [];
+
         $credentials = $this->resolveCredentials($companyId);
         $clientId = $credentials['client_id'];
         $clientSecret = $credentials['client_secret'];
@@ -143,14 +157,17 @@ class OzonAdClient implements AdPlatformClientInterface
                 fn (string $token): string => $this->pollReport($token, $uuid),
             );
 
-            $csv = $this->withAuthRetry(
+            $download = $this->withAuthRetry(
                 $companyId,
                 $clientId,
                 $clientSecret,
-                fn (string $token): string => $this->downloadReport($token, $reportLink),
+                fn (string $token): OzonReportDownload => $this->downloadReport($token, $reportLink, $uuid),
             );
+            // Сохраняем успешный download для bronze-слоя — только ПОСЛЕ withAuthRetry,
+            // чтобы 401-ретрай не зафиксировал неуспешную выгрузку.
+            $this->lastChunkDownloads[] = $download;
 
-            foreach ($this->convertCsvToRows($csv, $namesById) as $row) {
+            foreach ($this->convertCsvToRows($download->csvContent, $namesById) as $row) {
                 $rows[] = $row;
             }
         }
@@ -184,6 +201,8 @@ class OzonAdClient implements AdPlatformClientInterface
         \DateTimeImmutable $dateFrom,
         \DateTimeImmutable $dateTo,
     ): array {
+        $this->lastChunkDownloads = [];
+
         $startedAt = microtime(true);
         // chunkDays считаем ещё до assertValidRange, чтобы лог ошибки содержал
         // фактический входной диапазон (даже если он > 62 дней).
@@ -255,14 +274,17 @@ class OzonAdClient implements AdPlatformClientInterface
                 // суммируем по всем батчам.
                 $totalPollAttempts += $this->lastPollAttempts;
 
-                $csv = $this->withAuthRetry(
+                $download = $this->withAuthRetry(
                     $companyId,
                     $clientId,
                     $clientSecret,
-                    fn (string $token): string => $this->downloadReport($token, $reportLink),
+                    fn (string $token): OzonReportDownload => $this->downloadReport($token, $reportLink, $uuid),
                 );
+                // Сохраняем успешный download для bronze-слоя — только ПОСЛЕ withAuthRetry,
+                // чтобы 401-ретрай не зафиксировал неуспешную выгрузку.
+                $this->lastChunkDownloads[] = $download;
 
-                foreach ($this->convertCsvToRowsByDate($csv, $namesById) as $date => $campaignsForDate) {
+                foreach ($this->convertCsvToRowsByDate($download->csvContent, $namesById) as $date => $campaignsForDate) {
                     // Батчи не пересекаются по campaign_id (array_chunk), поэтому коллизий
                     // внутри одной даты не будет — просто складываем кампании подряд.
                     foreach ($campaignsForDate as $campaignId => $campaign) {
@@ -642,7 +664,19 @@ class OzonAdClient implements AdPlatformClientInterface
         throw new \RuntimeException(sprintf('Ozon Performance: отчёт %s не готов за %d секунд', $uuid, self::POLL_MAX_ATTEMPTS * self::POLL_INTERVAL_SECONDS));
     }
 
-    private function downloadReport(string $token, string $reportLink): string
+    /**
+     * Скачивает отчёт и распаковывает ZIP-архив, если Ozon вернул сжатый ответ.
+     *
+     * Ozon Performance чаще возвращает ZIP для длинных диапазонов/мульти-файловых
+     * отчётов. Без распаковки fgetcsv() получал бы magic-bytes «PK\x03\x04», не
+     * находил заголовок CSV и тихо возвращал нулевой набор строк — root cause
+     * бага «rows_count=0 при наличии рекламы».
+     *
+     * $rawBytes в возвращаемом OzonReportDownload — всегда оригинальный ответ
+     * (ZIP или plain CSV), $csvContent — уже распакованный и конкатенированный
+     * CSV. Для plain-ответа оба поля совпадают по содержимому.
+     */
+    private function downloadReport(string $token, string $reportLink, string $reportUuid): OzonReportDownload
     {
         // link может прийти и абсолютным (https://...), и относительным (/api/...).
         $url = str_starts_with($reportLink, 'http://') || str_starts_with($reportLink, 'https://')
@@ -650,8 +684,119 @@ class OzonAdClient implements AdPlatformClientInterface
             : self::BASE_URL.$reportLink;
 
         $response = $this->authorizedRequest('GET', $url, $token, [], absoluteUrl: true);
+        $rawBytes = $response->getContent(false);
 
-        return $response->getContent(false);
+        // Magic bytes локального ZIP-заголовка (PKZIP): 50 4B 03 04.
+        $wasZip = strlen($rawBytes) >= 4 && "PK\x03\x04" === substr($rawBytes, 0, 4);
+
+        if ($wasZip) {
+            $extracted = $this->extractCsvFromZip($rawBytes, $reportUuid);
+            $csvContent = $extracted['csvContent'];
+            $filesInZip = $extracted['filesInZip'];
+        } else {
+            $csvContent = $rawBytes;
+            $filesInZip = 0;
+        }
+
+        $sizeBytes = strlen($rawBytes);
+        $sha256 = hash('sha256', $rawBytes);
+
+        $this->marketplaceAdsLogger->info('Ozon report downloaded', [
+            'report_uuid' => $reportUuid,
+            'was_zip' => $wasZip,
+            'size_bytes' => $sizeBytes,
+            'csv_size_bytes' => strlen($csvContent),
+            'files_in_zip' => $wasZip ? $filesInZip : null,
+        ]);
+
+        return new OzonReportDownload(
+            rawBytes: $rawBytes,
+            csvContent: $csvContent,
+            wasZip: $wasZip,
+            sizeBytes: $sizeBytes,
+            sha256: $sha256,
+            reportUuid: $reportUuid,
+            filesInZip: $filesInZip,
+        );
+    }
+
+    /**
+     * Распаковывает ZIP через временный файл: ZipArchive::open() работает только
+     * с путями в ФС, стрим-чтение из памяти не поддерживается. Собирает все
+     * .csv-файлы из архива, конкатенируя их через "\n"; файлы без .csv-расширения
+     * игнорирует (мусорные записи / manifest-файлы).
+     *
+     * @return array{csvContent: string, filesInZip: int}
+     *
+     * @throws \RuntimeException если архив повреждён либо не содержит ни одного CSV
+     */
+    private function extractCsvFromZip(string $zipBytes, string $reportUuid): array
+    {
+        $tmpPath = tempnam(sys_get_temp_dir(), 'ozon-bronze-');
+        if (false === $tmpPath) {
+            throw new \RuntimeException('Ozon Performance: не удалось создать временный файл для распаковки ZIP');
+        }
+
+        try {
+            if (false === file_put_contents($tmpPath, $zipBytes)) {
+                throw new \RuntimeException('Ozon Performance: не удалось записать ZIP во временный файл');
+            }
+
+            $zip = new \ZipArchive();
+            $openResult = $zip->open($tmpPath);
+            if (true !== $openResult) {
+                throw new \RuntimeException(sprintf(
+                    'Ozon Performance: не удалось открыть ZIP-отчёт (uuid=%s, size=%d bytes, ZipArchive error code=%d)',
+                    $reportUuid,
+                    strlen($zipBytes),
+                    is_int($openResult) ? $openResult : -1,
+                ));
+            }
+
+            try {
+                $filesInZip = $zip->numFiles;
+                $csvParts = [];
+                for ($i = 0; $i < $filesInZip; ++$i) {
+                    $name = $zip->getNameIndex($i);
+                    if (false === $name) {
+                        continue;
+                    }
+                    if (!str_ends_with(strtolower($name), '.csv')) {
+                        continue;
+                    }
+                    $content = $zip->getFromIndex($i);
+                    if (false === $content) {
+                        continue;
+                    }
+                    $csvParts[] = $content;
+                }
+            } finally {
+                $zip->close();
+            }
+
+            if ([] === $csvParts) {
+                throw new \RuntimeException(sprintf(
+                    'Ozon Performance: ZIP-отчёт %s не содержит CSV-файлов (всего записей в архиве: %d)',
+                    $reportUuid,
+                    $filesInZip,
+                ));
+            }
+
+            return [
+                'csvContent' => implode("\n", $csvParts),
+                'filesInZip' => $filesInZip,
+            ];
+        } finally {
+            @unlink($tmpPath);
+        }
+    }
+
+    /**
+     * @return list<OzonReportDownload>
+     */
+    public function getLastChunkDownloads(): array
+    {
+        return $this->lastChunkDownloads;
     }
 
     /**

--- a/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
+++ b/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
@@ -768,6 +768,18 @@ class OzonAdClient implements AdPlatformClientInterface
                     if (false === $content) {
                         continue;
                     }
+                    // Для всех CSV-частей кроме первой отрезаем строку заголовка:
+                    // Ozon в мульти-файловом ZIP дублирует header в каждой части,
+                    // и без отрезания iterateCsvAssocRows() распарсит "header2" как
+                    // данные — для range-загрузок parseDateField('date') упадёт,
+                    // для single-day загрузок появится фантомная строка
+                    // campaign_id="campaign_id" с нулями в spend/views/clicks.
+                    if ([] !== $csvParts) {
+                        $newlinePos = strpos($content, "\n");
+                        if (false !== $newlinePos) {
+                            $content = substr($content, $newlinePos + 1);
+                        }
+                    }
                     $csvParts[] = $content;
                 }
             } finally {

--- a/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonReportDownload.php
+++ b/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonReportDownload.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Infrastructure\Api\Ozon;
+
+/**
+ * Сырой ответ /api/client/statistics/report — контейнер для bronze-слоя.
+ *
+ * Ozon Performance API отдаёт отчёт либо как обычный CSV, либо (чаще для длинных
+ * диапазонов и мульти-файловых отчётов) как ZIP-архив с одним/несколькими CSV
+ * внутри. Bronze-слой должен хранить bytes «как есть» — поэтому $rawBytes
+ * всегда содержит оригинальный ответ Ozon без модификаций, а $csvContent —
+ * уже распакованный и готовый к парсингу CSV (для plain-CSV они идентичны).
+ */
+final readonly class OzonReportDownload
+{
+    public function __construct(
+        public string $rawBytes,
+        public string $csvContent,
+        public bool $wasZip,
+        public int $sizeBytes,
+        public string $sha256,
+        public string $reportUuid,
+        public int $filesInZip,
+    ) {
+    }
+}

--- a/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
@@ -228,42 +228,55 @@ final class FetchOzonAdStatisticsHandler
 
         // Bronze-слой: сохраняем сырой ответ Ozon (ZIP или CSV) на диск ДО flush,
         // чтобы storage_path попал в один UPDATE/INSERT c документом. Принцип
-        // «1 bronze = 1 chunk»: все AdRawDocument'ы этого чанка получают
-        // одинаковый storage_path (первый физический download батча кампаний).
-        // Если каунт кампаний > 10 и чанк пошёл в несколько батчей — остальные
-        // downloads не сохраняются, это приемлемо (в проде большинство компаний
-        // укладывается в один батч; ослабление аудита для краевого кейса).
+        // «1 bronze = 1 chunk»: все AdRawDocument'ы чанка ссылаются на один
+        // физический файл. Если campaigns > 10, чанк режется на несколько
+        // батчей и Ozon возвращает несколько разных отчётов — тогда
+        // сохранять только первый было бы нечестно (file_hash на документах
+        // не соответствовал бы полным данным). В этом случае bronze
+        // принудительно НЕ пишется: storage_path/file_hash/file_size_bytes
+        // остаются null, в канал marketplace_ads летит warning с batchCount.
+        // Правильное решение (per-batch файлы со связью N:M c документами)
+        // — отдельная задача.
         $downloads = $this->ozonAdClient->getLastChunkDownloads();
         if ([] !== $downloads && [] !== $documents) {
-            $firstDownload = $downloads[0];
-            $extension = $firstDownload->wasZip ? 'zip' : 'csv';
-            $relativePath = sprintf(
-                'companies/%s/marketplace-ads/ozon/bronze/%s/%s.%s',
-                $message->companyId,
-                $dateFrom->format('Y-m-d'),
-                $firstDownload->reportUuid,
-                $extension,
-            );
+            if (count($downloads) > 1) {
+                $this->marketplaceAdsLogger->warning('Multi-batch chunk: bronze file not saved (known limitation)', [
+                    'jobId' => $message->jobId,
+                    'companyId' => $message->companyId,
+                    'dateFrom' => $dateFrom->format('Y-m-d'),
+                    'dateTo' => $dateTo->format('Y-m-d'),
+                    'batchCount' => count($downloads),
+                ]);
+            } else {
+                $firstDownload = $downloads[0];
+                $extension = $firstDownload->wasZip ? 'zip' : 'csv';
+                $relativePath = sprintf(
+                    'companies/%s/marketplace-ads/ozon/bronze/%s/%s.%s',
+                    $message->companyId,
+                    $dateFrom->format('Y-m-d'),
+                    $firstDownload->reportUuid,
+                    $extension,
+                );
 
-            $stored = $this->storageService->storeBytes($firstDownload->rawBytes, $relativePath);
-            $size = (int) $stored['sizeBytes'];
+                $stored = $this->storageService->storeBytes($firstDownload->rawBytes, $relativePath);
+                $size = (int) $stored['sizeBytes'];
 
-            foreach ($documents as $doc) {
-                $doc->setFileStorage($stored['storagePath'], $stored['fileHash'], $size);
+                foreach ($documents as $doc) {
+                    $doc->setFileStorage($stored['storagePath'], $stored['fileHash'], $size);
+                }
+
+                $this->marketplaceAdsLogger->info('Ozon bronze file stored', [
+                    'jobId' => $message->jobId,
+                    'companyId' => $message->companyId,
+                    'dateFrom' => $message->dateFrom,
+                    'dateTo' => $message->dateTo,
+                    'reportUuid' => $firstDownload->reportUuid,
+                    'storagePath' => $stored['storagePath'],
+                    'sizeBytes' => $size,
+                    'wasZip' => $firstDownload->wasZip,
+                    'documentsLinked' => count($documents),
+                ]);
             }
-
-            $this->marketplaceAdsLogger->info('Ozon bronze file stored', [
-                'jobId' => $message->jobId,
-                'companyId' => $message->companyId,
-                'dateFrom' => $message->dateFrom,
-                'dateTo' => $message->dateTo,
-                'reportUuid' => $firstDownload->reportUuid,
-                'storagePath' => $stored['storagePath'],
-                'sizeBytes' => $size,
-                'wasZip' => $firstDownload->wasZip,
-                'documentsLinked' => count($documents),
-                'downloadsInChunk' => count($downloads),
-            ]);
         }
 
         $this->entityManager->flush();

--- a/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
@@ -15,6 +15,7 @@ use App\MarketplaceAds\Repository\AdChunkProgressRepositoryInterface;
 use App\MarketplaceAds\Repository\AdLoadJobRepository;
 use App\MarketplaceAds\Repository\AdRawDocumentRepository;
 use App\Shared\Service\AppLogger;
+use App\Shared\Service\Storage\StorageService;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -68,6 +69,7 @@ final class FetchOzonAdStatisticsHandler
         private readonly AdLoadJobFinalizer $adLoadJobFinalizer,
         private readonly EntityManagerInterface $entityManager,
         private readonly MessageBusInterface $messageBus,
+        private readonly StorageService $storageService,
         private readonly AppLogger $logger,
         #[Autowire(service: 'monolog.logger.marketplace_ads')]
         private readonly LoggerInterface $marketplaceAdsLogger,
@@ -222,6 +224,46 @@ final class FetchOzonAdStatisticsHandler
                 $existing->updatePayload($json);
                 $documents[] = $existing;
             }
+        }
+
+        // Bronze-слой: сохраняем сырой ответ Ozon (ZIP или CSV) на диск ДО flush,
+        // чтобы storage_path попал в один UPDATE/INSERT c документом. Принцип
+        // «1 bronze = 1 chunk»: все AdRawDocument'ы этого чанка получают
+        // одинаковый storage_path (первый физический download батча кампаний).
+        // Если каунт кампаний > 10 и чанк пошёл в несколько батчей — остальные
+        // downloads не сохраняются, это приемлемо (в проде большинство компаний
+        // укладывается в один батч; ослабление аудита для краевого кейса).
+        $downloads = $this->ozonAdClient->getLastChunkDownloads();
+        if ([] !== $downloads && [] !== $documents) {
+            $firstDownload = $downloads[0];
+            $extension = $firstDownload->wasZip ? 'zip' : 'csv';
+            $relativePath = sprintf(
+                'companies/%s/marketplace-ads/ozon/bronze/%s/%s.%s',
+                $message->companyId,
+                $dateFrom->format('Y-m-d'),
+                $firstDownload->reportUuid,
+                $extension,
+            );
+
+            $stored = $this->storageService->storeBytes($firstDownload->rawBytes, $relativePath);
+            $size = (int) $stored['sizeBytes'];
+
+            foreach ($documents as $doc) {
+                $doc->setFileStorage($stored['storagePath'], $stored['fileHash'], $size);
+            }
+
+            $this->marketplaceAdsLogger->info('Ozon bronze file stored', [
+                'jobId' => $message->jobId,
+                'companyId' => $message->companyId,
+                'dateFrom' => $message->dateFrom,
+                'dateTo' => $message->dateTo,
+                'reportUuid' => $firstDownload->reportUuid,
+                'storagePath' => $stored['storagePath'],
+                'sizeBytes' => $size,
+                'wasZip' => $firstDownload->wasZip,
+                'documentsLinked' => count($documents),
+                'downloadsInChunk' => count($downloads),
+            ]);
         }
 
         $this->entityManager->flush();

--- a/site/tests/Integration/MarketplaceAds/Controller/Api/Admin/DownloadBronzeControllerTest.php
+++ b/site/tests/Integration/MarketplaceAds/Controller/Api/Admin/DownloadBronzeControllerTest.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\MarketplaceAds\Controller\Api\Admin;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAds\Entity\AdRawDocument;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Builders\MarketplaceAds\AdRawDocumentBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+
+final class DownloadBronzeControllerTest extends WebTestCaseBase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-b00000000001';
+    private const ADMIN_ID = '22222222-2222-2222-2222-b00000000001';
+    private const OWNER_ID = '22222222-2222-2222-2222-b00000000002';
+
+    /**
+     * @var list<string>
+     */
+    private array $createdPaths = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdPaths as $path) {
+            if (is_file($path)) {
+                @unlink($path);
+            }
+        }
+        $this->createdPaths = [];
+        parent::tearDown();
+    }
+
+    public function testReturnsZipFileForSuperAdmin(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $admin = $this->createSuperAdmin('bronze-zip@example.test');
+        $this->persistCompany($admin);
+
+        $doc = $this->persistDocument(
+            AdRawDocumentBuilder::aRawDocument()
+                ->withIndex(1)
+                ->withCompanyId(self::COMPANY_ID)
+                ->withMarketplace(MarketplaceType::OZON)
+                ->withReportDate(new \DateTimeImmutable('2026-04-01'))
+                ->build(),
+        );
+
+        $zipBytes = $this->writeStorageFile(
+            sprintf('companies/%s/marketplace-ads/ozon/bronze/2026-04-01/uuid-zip.zip', self::COMPANY_ID),
+            "PK\x03\x04fake-zip-bytes",
+        );
+        $doc->setFileStorage(
+            sprintf('companies/%s/marketplace-ads/ozon/bronze/2026-04-01/uuid-zip.zip', self::COMPANY_ID),
+            hash('sha256', $zipBytes),
+            strlen($zipBytes),
+        );
+        $this->em()->flush();
+
+        $this->loginAs($client, $admin, self::COMPANY_ID);
+
+        $client->request('GET', $this->url($doc->getId()));
+
+        self::assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertSame('application/zip', $response->headers->get('Content-Type'));
+        self::assertStringContainsString('attachment', (string) $response->headers->get('Content-Disposition'));
+        self::assertStringContainsString('uuid-zip.zip', (string) $response->headers->get('Content-Disposition'));
+        self::assertSame((string) strlen($zipBytes), $response->headers->get('Content-Length'));
+    }
+
+    public function testReturnsCsvFileForSuperAdmin(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $admin = $this->createSuperAdmin('bronze-csv@example.test');
+        $this->persistCompany($admin);
+
+        $doc = $this->persistDocument(
+            AdRawDocumentBuilder::aRawDocument()
+                ->withIndex(2)
+                ->withCompanyId(self::COMPANY_ID)
+                ->withMarketplace(MarketplaceType::OZON)
+                ->withReportDate(new \DateTimeImmutable('2026-04-02'))
+                ->build(),
+        );
+
+        $csvBytes = "date,campaign_id,sku,spend\n2026-04-02,1,SKU,100";
+        $this->writeStorageFile(
+            sprintf('companies/%s/marketplace-ads/ozon/bronze/2026-04-02/uuid-csv.csv', self::COMPANY_ID),
+            $csvBytes,
+        );
+        $doc->setFileStorage(
+            sprintf('companies/%s/marketplace-ads/ozon/bronze/2026-04-02/uuid-csv.csv', self::COMPANY_ID),
+            hash('sha256', $csvBytes),
+            strlen($csvBytes),
+        );
+        $this->em()->flush();
+
+        $this->loginAs($client, $admin, self::COMPANY_ID);
+
+        $client->request('GET', $this->url($doc->getId()));
+
+        self::assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertSame('text/csv', $response->headers->get('Content-Type'));
+        self::assertStringContainsString('attachment', (string) $response->headers->get('Content-Disposition'));
+        self::assertStringContainsString('uuid-csv.csv', (string) $response->headers->get('Content-Disposition'));
+    }
+
+    public function testReturns403ForCompanyOwnerWithoutSuperAdmin(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('bronze-owner@example.test')
+            ->withRoles(['ROLE_COMPANY_OWNER'])
+            ->build();
+        $this->persistCompany($owner);
+
+        $doc = $this->persistDocument(
+            AdRawDocumentBuilder::aRawDocument()
+                ->withIndex(3)
+                ->withCompanyId(self::COMPANY_ID)
+                ->withMarketplace(MarketplaceType::OZON)
+                ->withReportDate(new \DateTimeImmutable('2026-04-03'))
+                ->build(),
+        );
+
+        $this->loginAs($client, $owner, self::COMPANY_ID);
+
+        $client->request('GET', $this->url($doc->getId()));
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testReturns404ForNonexistentDocument(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $admin = $this->createSuperAdmin('bronze-404-missing@example.test');
+        $this->persistCompany($admin);
+
+        $this->loginAs($client, $admin, self::COMPANY_ID);
+
+        $client->request('GET', $this->url('00000000-0000-0000-0000-000000000000'));
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    public function testReturns404WhenDocumentHasNoStoragePath(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $admin = $this->createSuperAdmin('bronze-404-nopath@example.test');
+        $this->persistCompany($admin);
+
+        // Legacy-документ: storage_path = null — бронза не сохранялась до миграции.
+        $doc = $this->persistDocument(
+            AdRawDocumentBuilder::aRawDocument()
+                ->withIndex(4)
+                ->withCompanyId(self::COMPANY_ID)
+                ->withMarketplace(MarketplaceType::OZON)
+                ->withReportDate(new \DateTimeImmutable('2026-04-04'))
+                ->build(),
+        );
+
+        self::assertNull($doc->getStoragePath(), 'sanity: AdRawDocument без bronze не имеет storage_path');
+
+        $this->loginAs($client, $admin, self::COMPANY_ID);
+
+        $client->request('GET', $this->url($doc->getId()));
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    public function testReturns404WhenStorageFileMissingOnDisk(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $admin = $this->createSuperAdmin('bronze-404-nofile@example.test');
+        $this->persistCompany($admin);
+
+        $doc = $this->persistDocument(
+            AdRawDocumentBuilder::aRawDocument()
+                ->withIndex(5)
+                ->withCompanyId(self::COMPANY_ID)
+                ->withMarketplace(MarketplaceType::OZON)
+                ->withReportDate(new \DateTimeImmutable('2026-04-05'))
+                ->build(),
+        );
+
+        // storage_path проставлен, но сам файл не создан на диске —
+        // эмулируем случай, когда bronze был вычищен снаружи (ретеншн / ручная чистка).
+        $doc->setFileStorage(
+            sprintf('companies/%s/marketplace-ads/ozon/bronze/2026-04-05/missing.zip', self::COMPANY_ID),
+            str_repeat('0', 64),
+            123,
+        );
+        $this->em()->flush();
+
+        $this->loginAs($client, $admin, self::COMPANY_ID);
+
+        $client->request('GET', $this->url($doc->getId()));
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    private function createSuperAdmin(string $email): object
+    {
+        return UserBuilder::aUser()
+            ->withId(self::ADMIN_ID)
+            ->withEmail($email)
+            ->withRoles(['ROLE_COMPANY_OWNER', 'ROLE_SUPER_ADMIN'])
+            ->build();
+    }
+
+    private function persistCompany(object $owner): void
+    {
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+        $em = $this->em();
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+    }
+
+    private function persistDocument(AdRawDocument $doc): AdRawDocument
+    {
+        $em = $this->em();
+        $em->persist($doc);
+        $em->flush();
+
+        return $doc;
+    }
+
+    private function writeStorageFile(string $relativePath, string $bytes): string
+    {
+        $storageRoot = (string) static::getContainer()->getParameter('app.storage_root');
+        $absolute = $storageRoot.'/'.$relativePath;
+        $dir = dirname($absolute);
+        if (!is_dir($dir) && !mkdir($dir, 0o777, true) && !is_dir($dir)) {
+            throw new \RuntimeException(sprintf('Failed to create test storage dir "%s"', $dir));
+        }
+        file_put_contents($absolute, $bytes);
+        $this->createdPaths[] = $absolute;
+
+        return $bytes;
+    }
+
+    private function url(string $documentId): string
+    {
+        return '/api/marketplace-ads/admin/bronze/'.$documentId.'/download';
+    }
+
+    private function loginAs($client, $user, string $companyId): void
+    {
+        $client->loginUser($user);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', $companyId);
+        $session->save();
+    }
+}

--- a/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace App\Tests\Unit\MarketplaceAds;
 
 use App\MarketplaceAds\Application\Service\AdLoadJobFinalizer;
+use App\MarketplaceAds\Entity\AdRawDocument;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonAdClient;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonPermanentApiException;
+use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonReportDownload;
 use App\MarketplaceAds\Message\FetchOzonAdStatisticsMessage;
 use App\MarketplaceAds\Message\ProcessAdRawDocumentMessage;
 use App\MarketplaceAds\MessageHandler\FetchOzonAdStatisticsHandler;
@@ -14,6 +16,7 @@ use App\MarketplaceAds\Repository\AdChunkProgressRepositoryInterface;
 use App\MarketplaceAds\Repository\AdLoadJobRepository;
 use App\MarketplaceAds\Repository\AdRawDocumentRepository;
 use App\Shared\Service\AppLogger;
+use App\Shared\Service\Storage\StorageService;
 use App\Tests\Builders\MarketplaceAds\AdLoadJobBuilder;
 use DG\BypassFinals;
 use Doctrine\ORM\EntityManagerInterface;
@@ -25,9 +28,10 @@ use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 // Bootstrap pins BypassFinals to an allowlist; finalizer is final readonly — extend
-// the allowlist so PHPUnit can double it.
+// the allowlist so PHPUnit can double it. StorageService тоже final — нужен для bronze-тестов.
 BypassFinals::allowPaths([
     '*/src/MarketplaceAds/Application/Service/AdLoadJobFinalizer.php',
+    '*/src/Shared/Service/Storage/StorageService.php',
 ]);
 
 /**
@@ -185,6 +189,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             $this->createMock(AdLoadJobFinalizer::class),
             $em,
             $messageBus,
+            $this->createMock(StorageService::class),
             $logger,
             $marketplaceAdsLogger,
         );
@@ -792,6 +797,291 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         ));
     }
 
+    /**
+     * Bronze-сценарий 1: happy-path.
+     *
+     * OzonAdClient вернул один download, handler обязан вызвать StorageService::storeBytes
+     * с путём `companies/{cid}/marketplace-ads/ozon/bronze/{dateFrom}/{uuid}.{zip|csv}`
+     * и прописать результат в setFileStorage() каждого AdRawDocument чанка.
+     */
+    public function testHappyPathSavesBronzeFileAndSetsStoragePathOnDocument(): void
+    {
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withDateRange(new \DateTimeImmutable(self::DATE_FROM), new \DateTimeImmutable(self::DATE_TO))
+            ->asRunning()
+            ->build();
+
+        $jobRepo = $this->createMock(AdLoadJobRepository::class);
+        $jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $jobRepo->method('incrementLoadedDays')->willReturn(1);
+
+        $download = new OzonReportDownload(
+            rawBytes: "PK\x03\x04raw-zip-bytes",
+            csvContent: "date,campaign_id,sku,spend\n2026-03-01,1,SKU,100",
+            wasZip: true,
+            sizeBytes: 16,
+            sha256: str_repeat('a', 64),
+            reportUuid: 'report-uuid-001',
+            filesInZip: 1,
+        );
+
+        $ozonClient = $this->createMock(OzonAdClient::class);
+        $ozonClient->method('fetchAdStatisticsRange')->willReturn([
+            '2026-03-01' => ['rows' => [['spend' => 100]]],
+        ]);
+        $ozonClient->method('getLastChunkDownloads')->willReturn([$download]);
+
+        $rawRepo = $this->createMock(AdRawDocumentRepository::class);
+        $rawRepo->method('findByMarketplaceAndDate')->willReturn(null);
+        $savedDoc = null;
+        $rawRepo->expects(self::once())
+            ->method('save')
+            ->willReturnCallback(static function (AdRawDocument $doc) use (&$savedDoc): void {
+                $savedDoc = $doc;
+            });
+
+        $storageService = $this->createMock(StorageService::class);
+        $storageService->expects(self::once())
+            ->method('storeBytes')
+            ->with(
+                "PK\x03\x04raw-zip-bytes",
+                sprintf(
+                    'companies/%s/marketplace-ads/ozon/bronze/%s/report-uuid-001.zip',
+                    self::COMPANY_ID,
+                    self::DATE_FROM,
+                ),
+            )
+            ->willReturn([
+                'storagePath' => 'companies/'.self::COMPANY_ID.'/marketplace-ads/ozon/bronze/'.self::DATE_FROM.'/report-uuid-001.zip',
+                'fileHash' => str_repeat('b', 64),
+                'sizeBytes' => 16,
+                'mimeType' => 'application/zip',
+            ]);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::once())->method('flush');
+
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->method('dispatch')->willReturnCallback(
+            static fn (object $m): Envelope => new Envelope($m),
+        );
+
+        $chunkProgressRepo = $this->createMock(AdChunkProgressRepositoryInterface::class);
+        $chunkProgressRepo->method('markChunkCompleted')->willReturn(true);
+
+        $handler = $this->createHandler(
+            $ozonClient,
+            $rawRepo,
+            $jobRepo,
+            $chunkProgressRepo,
+            $em,
+            $messageBus,
+            null,
+            $storageService,
+        );
+        $handler(new FetchOzonAdStatisticsMessage(
+            self::JOB_ID,
+            self::COMPANY_ID,
+            self::DATE_FROM,
+            self::DATE_TO,
+        ));
+
+        self::assertNotNull($savedDoc);
+        self::assertSame(
+            'companies/'.self::COMPANY_ID.'/marketplace-ads/ozon/bronze/'.self::DATE_FROM.'/report-uuid-001.zip',
+            $savedDoc->getStoragePath(),
+        );
+        self::assertSame(str_repeat('b', 64), $savedDoc->getFileHash());
+        self::assertSame(16, $savedDoc->getFileSizeBytes());
+    }
+
+    /**
+     * Bronze-сценарий 2: несколько документов одного чанка ссылаются на ОДИН bronze-файл.
+     *
+     * Принцип «1 bronze = 1 chunk»: storeBytes должен быть вызван ровно один раз,
+     * а setFileStorage каждого из трёх AdRawDocument получает одинаковые
+     * storage_path/file_hash/size (первый download батча).
+     */
+    public function testMultipleDocumentsInChunkShareSameBronzeFile(): void
+    {
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withDateRange(new \DateTimeImmutable(self::DATE_FROM), new \DateTimeImmutable(self::DATE_TO))
+            ->asRunning()
+            ->build();
+
+        $jobRepo = $this->createMock(AdLoadJobRepository::class);
+        $jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $jobRepo->method('incrementLoadedDays')->willReturn(1);
+
+        $download = new OzonReportDownload(
+            rawBytes: 'csv-raw-bytes',
+            csvContent: 'csv-raw-bytes',
+            wasZip: false,
+            sizeBytes: 13,
+            sha256: str_repeat('c', 64),
+            reportUuid: 'shared-uuid',
+            filesInZip: 0,
+        );
+
+        $ozonClient = $this->createMock(OzonAdClient::class);
+        $ozonClient->method('fetchAdStatisticsRange')->willReturn([
+            '2026-03-01' => ['rows' => [['spend' => 100]]],
+            '2026-03-02' => ['rows' => [['spend' => 200]]],
+            '2026-03-03' => ['rows' => [['spend' => 300]]],
+        ]);
+        $ozonClient->method('getLastChunkDownloads')->willReturn([$download]);
+
+        $savedDocs = [];
+        $rawRepo = $this->createMock(AdRawDocumentRepository::class);
+        $rawRepo->method('findByMarketplaceAndDate')->willReturn(null);
+        $rawRepo->expects(self::exactly(3))
+            ->method('save')
+            ->willReturnCallback(static function (AdRawDocument $doc) use (&$savedDocs): void {
+                $savedDocs[] = $doc;
+            });
+
+        $storageService = $this->createMock(StorageService::class);
+        // Критически важно: storeBytes вызывается РОВНО ОДИН раз для всего чанка,
+        // даже при трёх документах — иначе мы бы дублировали bronze-файлы.
+        $storageService->expects(self::once())
+            ->method('storeBytes')
+            ->willReturn([
+                'storagePath' => 'companies/'.self::COMPANY_ID.'/marketplace-ads/ozon/bronze/'.self::DATE_FROM.'/shared-uuid.csv',
+                'fileHash' => str_repeat('d', 64),
+                'sizeBytes' => 13,
+                'mimeType' => 'text/csv',
+            ]);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::once())->method('flush');
+
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->method('dispatch')->willReturnCallback(
+            static fn (object $m): Envelope => new Envelope($m),
+        );
+
+        $chunkProgressRepo = $this->createMock(AdChunkProgressRepositoryInterface::class);
+        $chunkProgressRepo->method('markChunkCompleted')->willReturn(true);
+
+        $handler = $this->createHandler(
+            $ozonClient,
+            $rawRepo,
+            $jobRepo,
+            $chunkProgressRepo,
+            $em,
+            $messageBus,
+            null,
+            $storageService,
+        );
+        $handler(new FetchOzonAdStatisticsMessage(
+            self::JOB_ID,
+            self::COMPANY_ID,
+            self::DATE_FROM,
+            self::DATE_TO,
+        ));
+
+        self::assertCount(3, $savedDocs);
+        $expectedPath = 'companies/'.self::COMPANY_ID.'/marketplace-ads/ozon/bronze/'.self::DATE_FROM.'/shared-uuid.csv';
+        foreach ($savedDocs as $doc) {
+            self::assertSame($expectedPath, $doc->getStoragePath(), 'все документы чанка должны ссылаться на один bronze-файл');
+            self::assertSame(str_repeat('d', 64), $doc->getFileHash());
+            self::assertSame(13, $doc->getFileSizeBytes());
+        }
+    }
+
+    /**
+     * Bronze-сценарий 3: формат пути.
+     *
+     * Проверяет, что handler строит путь вида
+     * `companies/{companyId}/marketplace-ads/ozon/bronze/{yyyy-mm-dd}/{uuid}.{zip|csv}`
+     * и что {yyyy-mm-dd} — это именно dateFrom чанка (не dateTo и не текущая дата).
+     */
+    public function testBronzePathContainsCompanyIdAndDate(): void
+    {
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withDateRange(new \DateTimeImmutable(self::DATE_FROM), new \DateTimeImmutable(self::DATE_TO))
+            ->asRunning()
+            ->build();
+
+        $jobRepo = $this->createMock(AdLoadJobRepository::class);
+        $jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $jobRepo->method('incrementLoadedDays')->willReturn(1);
+
+        $download = new OzonReportDownload(
+            rawBytes: "PK\x03\x04abc",
+            csvContent: 'unpacked',
+            wasZip: true,
+            sizeBytes: 7,
+            sha256: str_repeat('e', 64),
+            reportUuid: '0197f1e2-3456-7890-abcd-ef0123456789',
+            filesInZip: 1,
+        );
+
+        $ozonClient = $this->createMock(OzonAdClient::class);
+        $ozonClient->method('fetchAdStatisticsRange')->willReturn([
+            self::DATE_FROM => ['rows' => []],
+        ]);
+        $ozonClient->method('getLastChunkDownloads')->willReturn([$download]);
+
+        $rawRepo = $this->createMock(AdRawDocumentRepository::class);
+        $rawRepo->method('findByMarketplaceAndDate')->willReturn(null);
+        $rawRepo->method('save');
+
+        $capturedPath = null;
+        $storageService = $this->createMock(StorageService::class);
+        $storageService->expects(self::once())
+            ->method('storeBytes')
+            ->willReturnCallback(static function (string $bytes, string $path) use (&$capturedPath): array {
+                $capturedPath = $path;
+
+                return [
+                    'storagePath' => $path,
+                    'fileHash' => str_repeat('f', 64),
+                    'sizeBytes' => strlen($bytes),
+                    'mimeType' => 'application/zip',
+                ];
+            });
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->method('dispatch')->willReturnCallback(
+            static fn (object $m): Envelope => new Envelope($m),
+        );
+
+        $chunkProgressRepo = $this->createMock(AdChunkProgressRepositoryInterface::class);
+        $chunkProgressRepo->method('markChunkCompleted')->willReturn(true);
+
+        $handler = $this->createHandler(
+            $ozonClient,
+            $rawRepo,
+            $jobRepo,
+            $chunkProgressRepo,
+            $em,
+            $messageBus,
+            null,
+            $storageService,
+        );
+        $handler(new FetchOzonAdStatisticsMessage(
+            self::JOB_ID,
+            self::COMPANY_ID,
+            self::DATE_FROM,
+            self::DATE_TO,
+        ));
+
+        self::assertSame(
+            sprintf(
+                'companies/%s/marketplace-ads/ozon/bronze/%s/%s.zip',
+                self::COMPANY_ID,
+                self::DATE_FROM,
+                '0197f1e2-3456-7890-abcd-ef0123456789',
+            ),
+            $capturedPath,
+        );
+    }
+
     private function createHandler(
         OzonAdClient $ozonClient,
         AdRawDocumentRepository $rawRepo,
@@ -800,6 +1090,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         EntityManagerInterface $em,
         MessageBusInterface $messageBus,
         ?AdLoadJobFinalizer $finalizer = null,
+        ?StorageService $storageService = null,
     ): FetchOzonAdStatisticsHandler {
         return new FetchOzonAdStatisticsHandler(
             $ozonClient,
@@ -809,6 +1100,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             $finalizer ?? $this->createMock(AdLoadJobFinalizer::class),
             $em,
             $messageBus,
+            $storageService ?? $this->createMock(StorageService::class),
             new AppLogger(new NullLogger(), $this->createMock(HubInterface::class)),
             new NullLogger(),
         );

--- a/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
@@ -1082,6 +1082,125 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         );
     }
 
+    /**
+     * Bronze-сценарий 4: multi-batch чанк (campaigns > 10 → несколько Ozon-отчётов).
+     *
+     * При батчинге Ozon возвращает несколько независимых ZIP-файлов, и сохранять
+     * только первый было бы нечестно: file_hash на всех AdRawDocument'ах чанка
+     * не соответствовал бы полным данным. В таком случае storeBytes НЕ вызывается
+     * вовсе, документы остаются со storage_path=null, а в marketplace_ads-канал
+     * пишется warning с batchCount.
+     */
+    public function testMultiBatchChunkDoesNotSaveBronzeButLogsWarning(): void
+    {
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withDateRange(new \DateTimeImmutable(self::DATE_FROM), new \DateTimeImmutable(self::DATE_TO))
+            ->asRunning()
+            ->build();
+
+        $jobRepo = $this->createMock(AdLoadJobRepository::class);
+        $jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $jobRepo->method('incrementLoadedDays')->willReturn(1);
+
+        // Два download'а — эмулируют >10 кампаний, разнесённых по двум батчам
+        // внутри одного вызова fetchAdStatisticsRange().
+        $download1 = new OzonReportDownload(
+            rawBytes: "PK\x03\x04batch-1",
+            csvContent: 'csv-batch-1',
+            wasZip: true,
+            sizeBytes: 10,
+            sha256: str_repeat('a', 64),
+            reportUuid: 'uuid-batch-1',
+            filesInZip: 1,
+        );
+        $download2 = new OzonReportDownload(
+            rawBytes: "PK\x03\x04batch-2",
+            csvContent: 'csv-batch-2',
+            wasZip: true,
+            sizeBytes: 10,
+            sha256: str_repeat('b', 64),
+            reportUuid: 'uuid-batch-2',
+            filesInZip: 1,
+        );
+
+        $ozonClient = $this->createMock(OzonAdClient::class);
+        $ozonClient->method('fetchAdStatisticsRange')->willReturn([
+            '2026-03-01' => ['rows' => [['spend' => 100]]],
+            '2026-03-02' => ['rows' => [['spend' => 200]]],
+        ]);
+        $ozonClient->method('getLastChunkDownloads')->willReturn([$download1, $download2]);
+
+        $savedDocs = [];
+        $rawRepo = $this->createMock(AdRawDocumentRepository::class);
+        $rawRepo->method('findByMarketplaceAndDate')->willReturn(null);
+        $rawRepo->method('save')->willReturnCallback(static function (AdRawDocument $doc) use (&$savedDocs): void {
+            $savedDocs[] = $doc;
+        });
+
+        // Критический инвариант: при multi-batch бронза НЕ пишется на диск.
+        $storageService = $this->createMock(StorageService::class);
+        $storageService->expects(self::never())->method('storeBytes');
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::once())->method('flush');
+
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->method('dispatch')->willReturnCallback(
+            static fn (object $m): Envelope => new Envelope($m),
+        );
+
+        $chunkProgressRepo = $this->createMock(AdChunkProgressRepositoryInterface::class);
+        $chunkProgressRepo->method('markChunkCompleted')->willReturn(true);
+
+        $marketplaceAdsLogger = new class extends NullLogger {
+            /** @var array<string, mixed>|null */
+            public ?array $warningContext = null;
+
+            public function warning(string|\Stringable $message, array $context = []): void
+            {
+                if (str_contains((string) $message, 'Multi-batch chunk')) {
+                    $this->warningContext = $context;
+                }
+                parent::warning($message, $context);
+            }
+        };
+
+        $handler = new FetchOzonAdStatisticsHandler(
+            $ozonClient,
+            $rawRepo,
+            $jobRepo,
+            $chunkProgressRepo,
+            $this->createMock(AdLoadJobFinalizer::class),
+            $em,
+            $messageBus,
+            $storageService,
+            new AppLogger(new NullLogger(), $this->createMock(HubInterface::class)),
+            $marketplaceAdsLogger,
+        );
+
+        $handler(new FetchOzonAdStatisticsMessage(
+            self::JOB_ID,
+            self::COMPANY_ID,
+            self::DATE_FROM,
+            self::DATE_TO,
+        ));
+
+        self::assertNotNull($marketplaceAdsLogger->warningContext, 'warning "Multi-batch chunk" должен быть залогирован');
+        self::assertSame(self::JOB_ID, $marketplaceAdsLogger->warningContext['jobId']);
+        self::assertSame(self::COMPANY_ID, $marketplaceAdsLogger->warningContext['companyId']);
+        self::assertSame(self::DATE_FROM, $marketplaceAdsLogger->warningContext['dateFrom']);
+        self::assertSame(self::DATE_TO, $marketplaceAdsLogger->warningContext['dateTo']);
+        self::assertSame(2, $marketplaceAdsLogger->warningContext['batchCount']);
+
+        self::assertNotEmpty($savedDocs, 'документы должны создаваться даже без bronze');
+        foreach ($savedDocs as $doc) {
+            self::assertNull($doc->getStoragePath(), 'storage_path обязан оставаться null при multi-batch');
+            self::assertNull($doc->getFileHash(), 'file_hash обязан оставаться null при multi-batch');
+            self::assertNull($doc->getFileSizeBytes(), 'file_size_bytes обязан оставаться null при multi-batch');
+        }
+    }
+
     private function createHandler(
         OzonAdClient $ozonClient,
         AdRawDocumentRepository $rawRepo,

--- a/site/tests/Unit/MarketplaceAds/OzonAdClientTest.php
+++ b/site/tests/Unit/MarketplaceAds/OzonAdClientTest.php
@@ -8,6 +8,7 @@ use App\Marketplace\Enum\MarketplaceConnectionType;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Facade\MarketplaceFacade;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonAdClient;
+use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonReportDownload;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\AbstractLogger;
@@ -711,7 +712,242 @@ final class OzonAdClientTest extends TestCase
     }
 
     // -----------------------------------------------------------------
+    // Bronze: ZIP detection + extraction
+    // -----------------------------------------------------------------
+    public function testDownloadReportDetectsZipAndExtractsCsv(): void
+    {
+        $csvInsideZip = $this->loadFixture('ozon_range_iso.csv');
+        $zipBytes = $this->buildZipBytes(['report.csv' => $csvInsideZip]);
+
+        $http = $this->buildHttpClientForRange(
+            tokenBody: $this->tokenBody('TKN-Z1'),
+            campaignListBody: $this->campaignListBody(3),
+            statisticsBody: '{"UUID":"uuid-zip-1"}',
+            stateBody: $this->stateReadyBody('/api/client/statistics/report?UUID=uuid-zip-1'),
+            downloadCsv: $zipBytes,
+        );
+
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+
+        $result = $client->fetchAdStatisticsRange(
+            self::COMPANY_ID,
+            new \DateTimeImmutable('2026-03-01'),
+            new \DateTimeImmutable('2026-03-05'),
+        );
+
+        // Парсинг распакованного CSV обязан дать те же 5 дат × 3 кампании, что и для plain-CSV.
+        self::assertCount(5, $result);
+        self::assertSame(['2026-03-01', '2026-03-02', '2026-03-03', '2026-03-04', '2026-03-05'], array_keys($result));
+        self::assertCount(3, $result['2026-03-01']['campaigns']);
+
+        $downloads = $client->getLastChunkDownloads();
+        self::assertCount(1, $downloads);
+        self::assertTrue($downloads[0]->wasZip);
+        self::assertSame(1, $downloads[0]->filesInZip);
+        self::assertSame($zipBytes, $downloads[0]->rawBytes);
+        self::assertSame('uuid-zip-1', $downloads[0]->reportUuid);
+
+        $record = $this->findLogRecord('Ozon report downloaded');
+        self::assertTrue($record['context']['was_zip']);
+        self::assertSame(1, $record['context']['files_in_zip']);
+        self::assertSame(strlen($zipBytes), $record['context']['size_bytes']);
+        self::assertSame(strlen($csvInsideZip), $record['context']['csv_size_bytes']);
+    }
+
+    public function testDownloadReportHandlesMultipleCsvInZip(): void
+    {
+        // Первая «половина» CSV — заголовок + 3 строки первых трёх дат,
+        // вторая «половина» — заголовок + 3 строки последних двух дат.
+        // После конкатенации через "\n" парсер находит оба заголовка, но
+        // fgetcsv работает построчно и итерирует все data-строки одинаково.
+        $part1 = "date;campaign_id;campaign_name;sku;spend;views;clicks\n"
+            ."2026-03-01;111;Campaign A;SKU-1;10.50;100;5\n"
+            ."2026-03-02;111;Campaign A;SKU-1;11.50;110;6\n";
+        $part2 = "date;campaign_id;campaign_name;sku;spend;views;clicks\n"
+            ."2026-03-03;111;Campaign A;SKU-1;12.50;120;7\n";
+
+        $zipBytes = $this->buildZipBytes([
+            'report-part-1.csv' => $part1,
+            'manifest.json' => '{"ignored":true}',
+            'report-part-2.csv' => $part2,
+        ]);
+
+        $http = $this->buildHttpClientForRange(
+            tokenBody: $this->tokenBody('TKN-Z2'),
+            campaignListBody: $this->campaignListBody(1),
+            statisticsBody: '{"UUID":"uuid-zip-multi"}',
+            stateBody: $this->stateReadyBody('/api/client/statistics/report?UUID=uuid-zip-multi'),
+            downloadCsv: $zipBytes,
+        );
+
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+
+        $client->fetchAdStatisticsRange(
+            self::COMPANY_ID,
+            new \DateTimeImmutable('2026-03-01'),
+            new \DateTimeImmutable('2026-03-03'),
+        );
+
+        $downloads = $client->getLastChunkDownloads();
+        self::assertCount(1, $downloads);
+        self::assertTrue($downloads[0]->wasZip);
+        // filesInZip считает ВСЕ файлы в архиве включая manifest.json; CSV-only
+        // отфильтровывается уже при склейке csvContent.
+        self::assertSame(3, $downloads[0]->filesInZip);
+        self::assertStringContainsString('2026-03-01;111', $downloads[0]->csvContent);
+        self::assertStringContainsString('2026-03-03;111', $downloads[0]->csvContent);
+        // manifest.json не должен попасть в csvContent.
+        self::assertStringNotContainsString('"ignored"', $downloads[0]->csvContent);
+    }
+
+    public function testDownloadReportThrowsOnCorruptedZip(): void
+    {
+        // Обрезанный ZIP: magic bytes PK\x03\x04 присутствуют (→ wasZip=true),
+        // но остальное — мусор, ZipArchive::open() вернёт код ошибки.
+        $corrupted = "PK\x03\x04".str_repeat("\x00", 16).'garbage';
+
+        $http = $this->buildHttpClientForRange(
+            tokenBody: $this->tokenBody('TKN-Z3'),
+            campaignListBody: $this->campaignListBody(1),
+            statisticsBody: '{"UUID":"uuid-zip-bad"}',
+            stateBody: $this->stateReadyBody('/api/client/statistics/report?UUID=uuid-zip-bad'),
+            downloadCsv: $corrupted,
+        );
+
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+
+        try {
+            $client->fetchAdStatisticsRange(
+                self::COMPANY_ID,
+                new \DateTimeImmutable('2026-03-01'),
+                new \DateTimeImmutable('2026-03-01'),
+            );
+            self::fail('Expected RuntimeException for corrupted ZIP');
+        } catch (\RuntimeException $e) {
+            $msg = $e->getMessage();
+            self::assertStringContainsString('uuid-zip-bad', $msg);
+            self::assertStringContainsString('ZIP', $msg);
+        }
+    }
+
+    public function testDownloadReportPassesPlainCsvUnchanged(): void
+    {
+        $csv = $this->loadFixture('ozon_range_iso.csv');
+
+        $http = $this->buildHttpClientForRange(
+            tokenBody: $this->tokenBody('TKN-Z4'),
+            campaignListBody: $this->campaignListBody(3),
+            statisticsBody: '{"UUID":"uuid-plain"}',
+            stateBody: $this->stateReadyBody('/api/client/statistics/report?UUID=uuid-plain'),
+            downloadCsv: $csv,
+        );
+
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+
+        $client->fetchAdStatisticsRange(
+            self::COMPANY_ID,
+            new \DateTimeImmutable('2026-03-01'),
+            new \DateTimeImmutable('2026-03-05'),
+        );
+
+        $downloads = $client->getLastChunkDownloads();
+        self::assertCount(1, $downloads);
+        self::assertFalse($downloads[0]->wasZip);
+        self::assertSame(0, $downloads[0]->filesInZip);
+        // Для plain-CSV rawBytes и csvContent содержательно совпадают.
+        self::assertSame($csv, $downloads[0]->rawBytes);
+        self::assertSame($csv, $downloads[0]->csvContent);
+        self::assertSame('uuid-plain', $downloads[0]->reportUuid);
+
+        $record = $this->findLogRecord('Ozon report downloaded');
+        self::assertFalse($record['context']['was_zip']);
+        self::assertNull($record['context']['files_in_zip']);
+    }
+
+    public function testRawBytesPreservedInResult(): void
+    {
+        // Инвариант: для wasZip=true rawBytes — исходный ZIP (непригодный
+        // для fgetcsv), csvContent — распакованный CSV. Bronze-хранилище
+        // обязано получить ИМЕННО rawBytes, иначе replay-парсинг сломается.
+        $csv = "date;campaign_id;campaign_name;sku;spend;views;clicks\n"
+            ."2026-03-01;111;Campaign A;SKU-1;1.00;10;1\n";
+        $zipBytes = $this->buildZipBytes(['report.csv' => $csv]);
+
+        $http = $this->buildHttpClientForRange(
+            tokenBody: $this->tokenBody('TKN-Z5'),
+            campaignListBody: $this->campaignListBody(1),
+            statisticsBody: '{"UUID":"uuid-raw-zip"}',
+            stateBody: $this->stateReadyBody('/api/client/statistics/report?UUID=uuid-raw-zip'),
+            downloadCsv: $zipBytes,
+        );
+
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+
+        $client->fetchAdStatisticsRange(
+            self::COMPANY_ID,
+            new \DateTimeImmutable('2026-03-01'),
+            new \DateTimeImmutable('2026-03-01'),
+        );
+
+        $downloads = $client->getLastChunkDownloads();
+        self::assertCount(1, $downloads);
+        /** @var OzonReportDownload $download */
+        $download = $downloads[0];
+
+        self::assertTrue($download->wasZip);
+        // rawBytes — PK-magic, НЕ начинается с CSV-заголовка.
+        self::assertSame("PK\x03\x04", substr($download->rawBytes, 0, 4));
+        self::assertStringStartsNotWith('date;', $download->rawBytes);
+
+        // csvContent — уже распакованный CSV, начинается с заголовка.
+        self::assertStringStartsWith('date;campaign_id', $download->csvContent);
+        self::assertNotSame($download->rawBytes, $download->csvContent);
+
+        // sha256 и sizeBytes считаются по rawBytes (а не csvContent) —
+        // bronze-хранилище и UI-диагностика работают с исходным файлом.
+        self::assertSame(hash('sha256', $zipBytes), $download->sha256);
+        self::assertSame(strlen($zipBytes), $download->sizeBytes);
+    }
+
+    // -----------------------------------------------------------------
     // helpers
+    // -----------------------------------------------------------------
+
+    /**
+     * Собирает валидный ZIP-архив в памяти, записывая через ZipArchive во
+     * временный файл и считывая bytes. Даёт гарантированно валидную
+     * последовательность заголовков и central directory (file_put_contents
+     * + ручное формирование ZIP-заголовков хрупко и часто проваливает
+     * ZipArchive::open() по тонкостям CRC/сжатия).
+     *
+     * @param array<string, string> $files name => content
+     */
+    private function buildZipBytes(array $files): string
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'ozon-test-zip-');
+        self::assertNotFalse($tmp, 'Failed to create temp file');
+
+        try {
+            $zip = new \ZipArchive();
+            $opened = $zip->open($tmp, \ZipArchive::OVERWRITE);
+            self::assertTrue(true === $opened, 'ZipArchive::open() must succeed');
+
+            foreach ($files as $name => $content) {
+                $zip->addFromString($name, $content);
+            }
+            $zip->close();
+
+            $bytes = file_get_contents($tmp);
+            self::assertNotFalse($bytes, 'Failed to read back zip');
+
+            return $bytes;
+        } finally {
+            @unlink($tmp);
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // legacy helpers (preserved)
     // -----------------------------------------------------------------
 
     /**

--- a/site/tests/Unit/MarketplaceAds/OzonAdClientTest.php
+++ b/site/tests/Unit/MarketplaceAds/OzonAdClientTest.php
@@ -756,10 +756,11 @@ final class OzonAdClientTest extends TestCase
 
     public function testDownloadReportHandlesMultipleCsvInZip(): void
     {
-        // Первая «половина» CSV — заголовок + 3 строки первых трёх дат,
-        // вторая «половина» — заголовок + 3 строки последних двух дат.
-        // После конкатенации через "\n" парсер находит оба заголовка, но
-        // fgetcsv работает построчно и итерирует все data-строки одинаково.
+        // Первая часть CSV — заголовок + 2 строки первых двух дат,
+        // вторая часть — заголовок + 1 строка третьей даты.
+        // Ozon в мульти-файловом ZIP дублирует header в каждой CSV-части:
+        // без удаления повторных заголовков parseDateField() упадёт на
+        // "date" (строка header2, попавшая в поток data-строк).
         $part1 = "date;campaign_id;campaign_name;sku;spend;views;clicks\n"
             ."2026-03-01;111;Campaign A;SKU-1;10.50;100;5\n"
             ."2026-03-02;111;Campaign A;SKU-1;11.50;110;6\n";
@@ -782,11 +783,21 @@ final class OzonAdClientTest extends TestCase
 
         $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
 
-        $client->fetchAdStatisticsRange(
+        $result = $client->fetchAdStatisticsRange(
             self::COMPANY_ID,
             new \DateTimeImmutable('2026-03-01'),
             new \DateTimeImmutable('2026-03-03'),
         );
+
+        // Полный прогон парсера: данные обеих частей должны объединиться в
+        // три даты × одна кампания. Без фикса «drop repeated headers»
+        // fetchAdStatisticsRange выкинул бы RuntimeException на parseDateField('date').
+        self::assertSame(['2026-03-01', '2026-03-02', '2026-03-03'], array_keys($result));
+        foreach ($result as $date => $payload) {
+            self::assertCount(1, $payload['campaigns'], "дата $date должна содержать 1 кампанию");
+            self::assertSame('111', $payload['campaigns'][0]['campaign_id']);
+            self::assertCount(1, $payload['campaigns'][0]['rows'], "дата $date должна содержать 1 строку SKU");
+        }
 
         $downloads = $client->getLastChunkDownloads();
         self::assertCount(1, $downloads);
@@ -798,6 +809,13 @@ final class OzonAdClientTest extends TestCase
         self::assertStringContainsString('2026-03-03;111', $downloads[0]->csvContent);
         // manifest.json не должен попасть в csvContent.
         self::assertStringNotContainsString('"ignored"', $downloads[0]->csvContent);
+        // Заголовок "date;campaign_id;..." должен присутствовать в csvContent
+        // ровно один раз — у первой CSV-части. Повторы отрезаются при склейке.
+        self::assertSame(
+            1,
+            substr_count($downloads[0]->csvContent, 'date;campaign_id;campaign_name;sku;spend;views;clicks'),
+            'заголовок должен встречаться в csvContent ровно один раз после объединения частей',
+        );
     }
 
     public function testDownloadReportThrowsOnCorruptedZip(): void


### PR DESCRIPTION
## Summary

- **Root cause fix**: Ozon `/api/client/statistics/report` returns either plain CSV or a ZIP archive (`PK\x03\x04`). Without unpacking, `fgetcsv()` read the magic bytes as the first CSV row and silently yielded zero rows — source of the "rows_count=0 при наличии рекламы" bug.
- **Bronze layer**: every successful Ozon chunk download is persisted to disk at `companies/{cid}/marketplace-ads/ozon/bronze/{yyyy-mm-dd}/{reportUuid}.{zip|csv}`; all `AdRawDocument` entities in the chunk share one `storage_path` / `file_hash` / `file_size_bytes`.
- **Admin download endpoint**: `GET /api/marketplace-ads/admin/bronze/{documentId}/download` streams the raw bronze file for diagnostics (ROLE_SUPER_ADMIN only, 404 when missing).

### Key changes

- New `OzonReportDownload` value object: `rawBytes`, `csvContent`, `wasZip`, `sizeBytes`, `sha256`, `reportUuid`, `filesInZip`.
- `OzonAdClient::downloadReport()`: detects ZIP via magic bytes, extracts all `.csv` entries via `ZipArchive` (temp file + `implode("\n", $parts)` — `ZipArchive::open()` has no in-memory stream support). Exposes `getLastChunkDownloads()` so the handler can persist bronze.
- `FetchOzonAdStatisticsHandler`: injects `StorageService`, calls `storeBytes()` once per chunk before `flush()`, propagates the result to every document via `setFileStorage()`. Logs `Ozon bronze file stored` for observability.
- `DownloadBronzeController`: `#[IsGranted('ROLE_SUPER_ADMIN')]` only, `StreamedResponse` with `Content-Type` (zip/csv), `Content-Disposition: attachment`, `Content-Length` when known; 404 branches for missing document / null `storage_path` / missing file on disk.
- **Backward compat**: legacy AdRawDocuments with `storage_path=null` still work end-to-end; `rawPayload` JSON and `storage_path` are not mutually exclusive.

### Tests

- `OzonAdClientTest` (5 cases): ZIP detection + extraction, multi-CSV in ZIP with non-CSV entries ignored, corrupted ZIP throws, plain CSV passes unchanged, `rawBytes` stays raw while `csvContent` is unpacked.
- `FetchOzonAdStatisticsHandlerTest` (3 cases): bronze saved and linked to document; multiple documents in chunk share one bronze file (exactly one `storeBytes` call); path contains `{companyId}` and `{dateFrom}`.
- `DownloadBronzeControllerTest` (6 cases): ZIP happy path (`application/zip`), CSV happy path (`text/csv`), 403 without SUPER_ADMIN, 404 for missing document, 404 for null `storage_path` (legacy docs), 404 for missing file on disk.

## Test plan

- [ ] `php bin/phpunit tests/Unit/MarketplaceAds/OzonAdClientTest.php`
- [ ] `php bin/phpunit tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php`
- [ ] `php bin/phpunit tests/Integration/MarketplaceAds/Controller/Api/Admin/DownloadBronzeControllerTest.php`
- [ ] Smoke: trigger an Ozon ad backfill chunk — verify `storage_path` populated on new `AdRawDocument` rows and `rows_count > 0` in `Ozon ad statistics fetched` log.
- [ ] Smoke: `GET /api/marketplace-ads/admin/bronze/{documentId}/download` as super-admin returns the original ZIP/CSV.

https://claude.ai/code/session_011Qb396tghpEyr3eZDZo9jE