### PR TITLE
feat(MarketplaceAds): admin debug endpoints for Ozon Performance API

### DIFF
--- a/site/src/Company/Facade/CompanyFacade.php
+++ b/site/src/Company/Facade/CompanyFacade.php
@@ -33,4 +33,17 @@ final class CompanyFacade
     {
         return $this->repository->getAllActiveCompanyIds();
     }
+
+    /**
+     * Возвращает компании по списку ID как простые DTO-массивы,
+     * чтобы вызывающий модуль не тянул Entity.
+     *
+     * @param list<string> $companyIds
+     *
+     * @return list<array{id: string, name: string}>
+     */
+    public function getCompaniesByIds(array $companyIds): array
+    {
+        return $this->repository->findByIds($companyIds);
+    }
 }

--- a/site/src/Company/Infrastructure/Repository/CompanyRepository.php
+++ b/site/src/Company/Infrastructure/Repository/CompanyRepository.php
@@ -49,4 +49,32 @@ class CompanyRepository extends ServiceEntityRepository
 
         return $this->connection->fetchFirstColumn($sql);
     }
+
+    /**
+     * @param list<string> $companyIds
+     *
+     * @return list<array{id: string, name: string}>
+     */
+    public function findByIds(array $companyIds): array
+    {
+        if ([] === $companyIds) {
+            return [];
+        }
+
+        $rows = $this->createQueryBuilder('c')
+            ->select('c.id AS id', 'c.name AS name')
+            ->where('c.id IN (:ids)')
+            ->setParameter('ids', array_values($companyIds))
+            ->orderBy('c.name', 'ASC')
+            ->getQuery()
+            ->getArrayResult();
+
+        return array_map(
+            static fn (array $r): array => [
+                'id' => (string) $r['id'],
+                'name' => (string) $r['name'],
+            ],
+            $rows,
+        );
+    }
 }

--- a/site/src/MarketplaceAds/Controller/Api/Admin/OzonDebugController.php
+++ b/site/src/MarketplaceAds/Controller/Api/Admin/OzonDebugController.php
@@ -61,7 +61,18 @@ final class OzonDebugController extends AbstractController
         }
 
         $token = $result['access_token'];
-        $tokenPrefix = '' === $token ? '' : mb_substr($token, 0, 20).'...';
+        if ('' === $token) {
+            $tokenPrefix = '';
+        } elseif (mb_strlen($token) > 20) {
+            $tokenPrefix = mb_substr($token, 0, 20).'...';
+        } else {
+            $tokenPrefix = $token;
+        }
+
+        $rawBody = $result['ozon_raw_body'];
+        if (array_key_exists('access_token', $rawBody)) {
+            $rawBody['access_token'] = '***REDACTED***';
+        }
 
         return $this->json([
             'companyId' => $companyId,
@@ -69,7 +80,7 @@ final class OzonDebugController extends AbstractController
             'expires_in' => $result['expires_in'],
             'issued_at' => $result['issued_at'],
             'ozon_raw_response_status' => $result['ozon_raw_response_status'],
-            'ozon_raw_body' => $result['ozon_raw_body'],
+            'ozon_raw_body' => $rawBody,
         ]);
     }
 

--- a/site/src/MarketplaceAds/Controller/Api/Admin/OzonDebugController.php
+++ b/site/src/MarketplaceAds/Controller/Api/Admin/OzonDebugController.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Controller\Api\Admin;
+
+use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonDebugFetcher;
+use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonPermanentApiException;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Admin debug endpoints для ручной отладки Ozon Performance API.
+ *
+ * Все методы:
+ *  - требуют ROLE_SUPER_ADMIN,
+ *  - принимают companyId (query / body),
+ *  - возвращают JsonResponse с сырыми ответами Ozon (без скрытия ошибок),
+ *  - логируют факт вызова в канал marketplace_ads.
+ *
+ * Это debug-инструмент: он намеренно обходит async-пайплайн, не создаёт
+ * AdLoadJob/AdRawDocument и ничего не пишет в БД.
+ */
+#[IsGranted('ROLE_SUPER_ADMIN')]
+final class OzonDebugController extends AbstractController
+{
+    public function __construct(
+        private readonly OzonDebugFetcher $debugFetcher,
+        #[Autowire(service: 'monolog.logger.marketplace_ads')]
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    #[Route(
+        '/api/marketplace-ads/admin/ozon/debug/token',
+        name: 'marketplace_ads_admin_ozon_debug_token',
+        methods: ['GET'],
+    )]
+    public function token(Request $request): JsonResponse
+    {
+        $companyId = $this->requireCompanyId($request->query->get('companyId'));
+        if ($companyId instanceof JsonResponse) {
+            return $companyId;
+        }
+
+        $this->logger->info('Ozon debug call: token', ['companyId' => $companyId]);
+
+        try {
+            $result = $this->debugFetcher->fetchAccessToken($companyId);
+        } catch (OzonPermanentApiException $e) {
+            return $this->error($e->getMessage(), 400);
+        } catch (\Throwable $e) {
+            return $this->error($e->getMessage(), 502, $e);
+        }
+
+        $token = $result['access_token'];
+        $tokenPrefix = '' === $token ? '' : mb_substr($token, 0, 20).'...';
+
+        return $this->json([
+            'companyId' => $companyId,
+            'access_token_prefix' => $tokenPrefix,
+            'expires_in' => $result['expires_in'],
+            'issued_at' => $result['issued_at'],
+            'ozon_raw_response_status' => $result['ozon_raw_response_status'],
+            'ozon_raw_body' => $result['ozon_raw_body'],
+        ]);
+    }
+
+    #[Route(
+        '/api/marketplace-ads/admin/ozon/debug/campaigns',
+        name: 'marketplace_ads_admin_ozon_debug_campaigns',
+        methods: ['GET'],
+    )]
+    public function campaigns(Request $request): JsonResponse
+    {
+        $companyId = $this->requireCompanyId($request->query->get('companyId'));
+        if ($companyId instanceof JsonResponse) {
+            return $companyId;
+        }
+
+        $this->logger->info('Ozon debug call: campaigns', ['companyId' => $companyId]);
+
+        try {
+            $result = $this->debugFetcher->listCampaigns($companyId);
+        } catch (OzonPermanentApiException $e) {
+            return $this->error($e->getMessage(), 400);
+        } catch (\Throwable $e) {
+            return $this->error($e->getMessage(), 502, $e);
+        }
+
+        return $this->json([
+            'companyId' => $companyId,
+            'status_code' => $result['status_code'],
+            'total' => $result['total'],
+            'states_breakdown' => $result['states_breakdown'],
+            'list' => $result['list'],
+            'raw_body' => $result['raw_body'],
+        ]);
+    }
+
+    #[Route(
+        '/api/marketplace-ads/admin/ozon/debug/statistics/request',
+        name: 'marketplace_ads_admin_ozon_debug_statistics_request',
+        methods: ['POST'],
+    )]
+    public function statisticsRequest(Request $request): JsonResponse
+    {
+        $payload = json_decode($request->getContent(), true);
+        if (!is_array($payload)) {
+            return $this->error('Body: ожидается JSON-объект', 400);
+        }
+
+        $companyId = $this->requireCompanyId($payload['companyId'] ?? null);
+        if ($companyId instanceof JsonResponse) {
+            return $companyId;
+        }
+
+        $campaigns = $payload['campaigns'] ?? null;
+        if (!is_array($campaigns) || [] === $campaigns) {
+            return $this->error('campaigns: массив с ID обязателен', 400);
+        }
+        $campaignIds = [];
+        foreach ($campaigns as $c) {
+            if (is_scalar($c)) {
+                $id = trim((string) $c);
+                if ('' !== $id) {
+                    $campaignIds[] = $id;
+                }
+            }
+        }
+        if ([] === $campaignIds) {
+            return $this->error('campaigns: не нашлось валидных ID', 400);
+        }
+
+        $fromStr = isset($payload['from']) ? (string) $payload['from'] : '';
+        $toStr = isset($payload['to']) ? (string) $payload['to'] : '';
+        $dateFrom = \DateTimeImmutable::createFromFormat('!Y-m-d', $fromStr);
+        $dateTo = \DateTimeImmutable::createFromFormat('!Y-m-d', $toStr);
+        if (false === $dateFrom || $dateFrom->format('Y-m-d') !== $fromStr) {
+            return $this->error('from: ожидается YYYY-MM-DD', 400);
+        }
+        if (false === $dateTo || $dateTo->format('Y-m-d') !== $toStr) {
+            return $this->error('to: ожидается YYYY-MM-DD', 400);
+        }
+
+        $groupBy = isset($payload['groupBy']) ? (string) $payload['groupBy'] : 'NO_GROUP_BY';
+
+        $this->logger->info('Ozon debug call: statistics/request', [
+            'companyId' => $companyId,
+            'campaigns' => $campaignIds,
+            'from' => $fromStr,
+            'to' => $toStr,
+            'groupBy' => $groupBy,
+        ]);
+
+        try {
+            $result = $this->debugFetcher->requestStatistics($companyId, $campaignIds, $dateFrom, $dateTo, $groupBy);
+        } catch (\InvalidArgumentException $e) {
+            return $this->error($e->getMessage(), 400);
+        } catch (OzonPermanentApiException $e) {
+            return $this->error($e->getMessage(), 400);
+        } catch (\Throwable $e) {
+            return $this->error($e->getMessage(), 502, $e);
+        }
+
+        return $this->json([
+            'companyId' => $companyId,
+            'request_body' => $result['request_body'],
+            'uuid' => $result['uuid'],
+            'ozon_status_code' => $result['ozon_status_code'],
+            'ozon_raw_response' => $result['ozon_raw_response'],
+        ]);
+    }
+
+    #[Route(
+        '/api/marketplace-ads/admin/ozon/debug/statistics/status',
+        name: 'marketplace_ads_admin_ozon_debug_statistics_status',
+        methods: ['GET'],
+    )]
+    public function statisticsStatus(Request $request): JsonResponse
+    {
+        $companyId = $this->requireCompanyId($request->query->get('companyId'));
+        if ($companyId instanceof JsonResponse) {
+            return $companyId;
+        }
+
+        $uuid = trim((string) $request->query->get('uuid', ''));
+        if ('' === $uuid) {
+            return $this->error('uuid: обязательный параметр', 400);
+        }
+
+        $this->logger->info('Ozon debug call: statistics/status', [
+            'companyId' => $companyId,
+            'uuid' => $uuid,
+        ]);
+
+        try {
+            $result = $this->debugFetcher->checkStatus($companyId, $uuid);
+        } catch (\InvalidArgumentException $e) {
+            return $this->error($e->getMessage(), 400);
+        } catch (OzonPermanentApiException $e) {
+            return $this->error($e->getMessage(), 400);
+        } catch (\Throwable $e) {
+            return $this->error($e->getMessage(), 502, $e);
+        }
+
+        return $this->json([
+            'companyId' => $companyId,
+            'uuid' => $result['uuid'],
+            'state' => $result['state'],
+            'status_code' => $result['status_code'],
+            'ozon_raw_response' => $result['ozon_raw_response'],
+        ]);
+    }
+
+    #[Route(
+        '/api/marketplace-ads/admin/ozon/debug/statistics/download',
+        name: 'marketplace_ads_admin_ozon_debug_statistics_download',
+        methods: ['GET'],
+    )]
+    public function statisticsDownload(Request $request): Response
+    {
+        $companyId = $this->requireCompanyId($request->query->get('companyId'));
+        if ($companyId instanceof JsonResponse) {
+            return $companyId;
+        }
+
+        $uuid = trim((string) $request->query->get('uuid', ''));
+        if ('' === $uuid) {
+            return $this->error('uuid: обязательный параметр', 400);
+        }
+
+        $raw = '1' === (string) $request->query->get('raw', '0');
+
+        $this->logger->info('Ozon debug call: statistics/download', [
+            'companyId' => $companyId,
+            'uuid' => $uuid,
+            'raw' => $raw,
+        ]);
+
+        try {
+            $result = $this->debugFetcher->downloadReport($companyId, $uuid);
+        } catch (\InvalidArgumentException $e) {
+            return $this->error($e->getMessage(), 400);
+        } catch (OzonPermanentApiException $e) {
+            return $this->error($e->getMessage(), 400);
+        } catch (\Throwable $e) {
+            return $this->error($e->getMessage(), 502, $e);
+        }
+
+        if ($raw) {
+            $filename = sprintf('ozon-report-%s.%s', $uuid, $result['was_zip'] ? 'zip' : 'csv');
+            $response = new Response($result['raw_bytes']);
+            $response->headers->set(
+                'Content-Type',
+                $result['was_zip'] ? 'application/zip' : 'text/csv; charset=utf-8',
+            );
+            $response->headers->set(
+                'Content-Disposition',
+                $response->headers->makeDisposition(
+                    ResponseHeaderBag::DISPOSITION_ATTACHMENT,
+                    $filename,
+                ),
+            );
+
+            return $response;
+        }
+
+        return $this->json([
+            'companyId' => $companyId,
+            'uuid' => $uuid,
+            'was_zip' => $result['was_zip'],
+            'size_bytes' => $result['size_bytes'],
+            'content_preview' => $result['content_preview'],
+            'files_in_zip' => $result['files_in_zip'],
+        ]);
+    }
+
+    private function requireCompanyId(mixed $raw): JsonResponse|string
+    {
+        if (!is_string($raw)) {
+            return $this->error('companyId: обязательный параметр', 400);
+        }
+        $value = trim($raw);
+        if ('' === $value) {
+            return $this->error('companyId: обязательный параметр', 400);
+        }
+        if (1 !== preg_match('/^[0-9a-fA-F-]{32,36}$/', $value)) {
+            return $this->error('companyId: ожидается UUID', 400);
+        }
+
+        return $value;
+    }
+
+    private function error(string $message, int $status, ?\Throwable $e = null): JsonResponse
+    {
+        $payload = ['error' => $message];
+        if (null !== $e) {
+            $payload['exception_class'] = $e::class;
+        }
+
+        return $this->json($payload, $status);
+    }
+}

--- a/site/src/MarketplaceAds/Controller/Api/Admin/OzonDebugController.php
+++ b/site/src/MarketplaceAds/Controller/Api/Admin/OzonDebugController.php
@@ -141,8 +141,9 @@ final class OzonDebugController extends AbstractController
 
         $fromStr = isset($payload['from']) ? (string) $payload['from'] : '';
         $toStr = isset($payload['to']) ? (string) $payload['to'] : '';
-        $dateFrom = \DateTimeImmutable::createFromFormat('!Y-m-d', $fromStr);
-        $dateTo = \DateTimeImmutable::createFromFormat('!Y-m-d', $toStr);
+        $utc = new \DateTimeZone('UTC');
+        $dateFrom = \DateTimeImmutable::createFromFormat('!Y-m-d', $fromStr, $utc);
+        $dateTo = \DateTimeImmutable::createFromFormat('!Y-m-d', $toStr, $utc);
         if (false === $dateFrom || $dateFrom->format('Y-m-d') !== $fromStr) {
             return $this->error('from: ожидается YYYY-MM-DD', 400);
         }
@@ -292,7 +293,7 @@ final class OzonDebugController extends AbstractController
         if ('' === $value) {
             return $this->error('companyId: обязательный параметр', 400);
         }
-        if (1 !== preg_match('/^[0-9a-fA-F-]{32,36}$/', $value)) {
+        if (1 !== preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i', $value)) {
             return $this->error('companyId: ожидается UUID', 400);
         }
 

--- a/site/src/MarketplaceAds/Controller/OzonDebugPageController.php
+++ b/site/src/MarketplaceAds/Controller/OzonDebugPageController.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\MarketplaceAds\Controller;
 
+use App\Company\Facade\CompanyFacade;
 use App\MarketplaceAds\Infrastructure\Query\ActiveOzonPerformanceConnectionsQuery;
-use Doctrine\DBAL\Connection;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -17,7 +17,7 @@ final class OzonDebugPageController extends AbstractController
 {
     public function __construct(
         private readonly ActiveOzonPerformanceConnectionsQuery $connectionsQuery,
-        private readonly Connection $connection,
+        private readonly CompanyFacade $companyFacade,
     ) {
     }
 
@@ -25,20 +25,9 @@ final class OzonDebugPageController extends AbstractController
     {
         $companyIds = $this->connectionsQuery->getCompanyIds();
 
-        $companies = [];
-        if ([] !== $companyIds) {
-            $rows = $this->connection->fetchAllAssociative(
-                'SELECT id::text AS id, name FROM company WHERE id IN (:ids) ORDER BY name ASC',
-                ['ids' => $companyIds],
-                ['ids' => Connection::PARAM_STR_ARRAY],
-            );
-            foreach ($rows as $row) {
-                $companies[] = [
-                    'id' => (string) $row['id'],
-                    'name' => (string) $row['name'],
-                ];
-            }
-        }
+        $companies = [] === $companyIds
+            ? []
+            : $this->companyFacade->getCompaniesByIds($companyIds);
 
         return $this->render('marketplace_ads/admin_debug.html.twig', [
             'companies' => $companies,

--- a/site/src/MarketplaceAds/Controller/OzonDebugPageController.php
+++ b/site/src/MarketplaceAds/Controller/OzonDebugPageController.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Controller;
+
+use App\MarketplaceAds\Infrastructure\Query\ActiveOzonPerformanceConnectionsQuery;
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route('/marketplace-ads/admin/debug', name: 'marketplace_ads_admin_debug', methods: ['GET'])]
+#[IsGranted('ROLE_SUPER_ADMIN')]
+final class OzonDebugPageController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveOzonPerformanceConnectionsQuery $connectionsQuery,
+        private readonly Connection $connection,
+    ) {
+    }
+
+    public function __invoke(): Response
+    {
+        $companyIds = $this->connectionsQuery->getCompanyIds();
+
+        $companies = [];
+        if ([] !== $companyIds) {
+            $rows = $this->connection->fetchAllAssociative(
+                'SELECT id::text AS id, name FROM company WHERE id IN (:ids) ORDER BY name ASC',
+                ['ids' => $companyIds],
+                ['ids' => Connection::PARAM_STR_ARRAY],
+            );
+            foreach ($rows as $row) {
+                $companies[] = [
+                    'id' => (string) $row['id'],
+                    'name' => (string) $row['name'],
+                ];
+            }
+        }
+
+        return $this->render('marketplace_ads/admin_debug.html.twig', [
+            'companies' => $companies,
+        ]);
+    }
+}

--- a/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonDebugFetcher.php
+++ b/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonDebugFetcher.php
@@ -72,9 +72,18 @@ final class OzonDebugFetcher
             ]);
 
             $statusCode = $response->getStatusCode();
-            $rawBody = $response->getContent(false);
         } catch (TransportExceptionInterface $e) {
             throw new \RuntimeException('Ozon Performance: сеть недоступна при получении токена: '.$e->getMessage(), 0, $e);
+        }
+
+        try {
+            $rawBody = $response->getContent(false);
+        } catch (TransportExceptionInterface $e) {
+            throw new \RuntimeException(sprintf(
+                'Ozon Performance: обрыв соединения при чтении тела (HTTP %d, token): %s',
+                $statusCode,
+                $e->getMessage(),
+            ), 0, $e);
         }
 
         $data = $this->decodeJsonSafe($rawBody);
@@ -122,9 +131,18 @@ final class OzonDebugFetcher
             ]);
 
             $statusCode = $response->getStatusCode();
-            $body = $response->getContent(false);
         } catch (TransportExceptionInterface $e) {
             throw new \RuntimeException('Ozon Performance: сеть недоступна (GET /campaign): '.$e->getMessage(), 0, $e);
+        }
+
+        try {
+            $body = $response->getContent(false);
+        } catch (TransportExceptionInterface $e) {
+            throw new \RuntimeException(sprintf(
+                'Ozon Performance: обрыв соединения при чтении тела (HTTP %d, GET /campaign): %s',
+                $statusCode,
+                $e->getMessage(),
+            ), 0, $e);
         }
 
         $data = $this->decodeJsonSafe($body);
@@ -212,9 +230,18 @@ final class OzonDebugFetcher
             ]);
 
             $statusCode = $response->getStatusCode();
-            $body = $response->getContent(false);
         } catch (TransportExceptionInterface $e) {
             throw new \RuntimeException('Ozon Performance: сеть недоступна (POST /statistics): '.$e->getMessage(), 0, $e);
+        }
+
+        try {
+            $body = $response->getContent(false);
+        } catch (TransportExceptionInterface $e) {
+            throw new \RuntimeException(sprintf(
+                'Ozon Performance: обрыв соединения при чтении тела (HTTP %d, POST /statistics): %s',
+                $statusCode,
+                $e->getMessage(),
+            ), 0, $e);
         }
 
         $data = $this->decodeJsonSafe($body);
@@ -272,9 +299,18 @@ final class OzonDebugFetcher
             );
 
             $statusCode = $response->getStatusCode();
-            $body = $response->getContent(false);
         } catch (TransportExceptionInterface $e) {
             throw new \RuntimeException('Ozon Performance: сеть недоступна (GET /statistics/{uuid}): '.$e->getMessage(), 0, $e);
+        }
+
+        try {
+            $body = $response->getContent(false);
+        } catch (TransportExceptionInterface $e) {
+            throw new \RuntimeException(sprintf(
+                'Ozon Performance: обрыв соединения при чтении тела (HTTP %d, GET /statistics/{uuid}): %s',
+                $statusCode,
+                $e->getMessage(),
+            ), 0, $e);
         }
 
         $data = $this->decodeJsonSafe($body);
@@ -342,9 +378,18 @@ final class OzonDebugFetcher
             ]);
 
             $statusCode = $response->getStatusCode();
-            $rawBytes = $response->getContent(false);
         } catch (TransportExceptionInterface $e) {
             throw new \RuntimeException('Ozon Performance: сеть недоступна (download): '.$e->getMessage(), 0, $e);
+        }
+
+        try {
+            $rawBytes = $response->getContent(false);
+        } catch (TransportExceptionInterface $e) {
+            throw new \RuntimeException(sprintf(
+                'Ozon Performance: обрыв соединения при чтении тела (HTTP %d, download): %s',
+                $statusCode,
+                $e->getMessage(),
+            ), 0, $e);
         }
 
         if ($statusCode < 200 || $statusCode >= 300) {

--- a/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonDebugFetcher.php
+++ b/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonDebugFetcher.php
@@ -1,0 +1,494 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Infrastructure\Api\Ozon;
+
+use App\Marketplace\Enum\MarketplaceConnectionType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Facade\MarketplaceFacade;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Диагностический клиент Ozon Performance API для admin debug-страницы.
+ *
+ * Намеренно параллелен {@see OzonAdClient}, а не встроен в него: здесь нет
+ * кэширования токена, ретраев, фильтра кампаний по state — каждый вызов
+ * выполняется «честно» и возвращает сырой ответ Ozon, чтобы оператор мог
+ * точечно воспроизводить 429/400 и сравнивать то, что уходит/приходит.
+ *
+ * Методы умышленно не скрывают HTTP-статусы и тела Ozon, чтобы debug-UI
+ * мог их отрисовать как есть.
+ */
+final class OzonDebugFetcher
+{
+    private const BASE_URL = 'https://api-performance.ozon.ru';
+    private const TOKEN_PATH = '/api/client/token';
+    private const CAMPAIGN_PATH = '/api/client/campaign';
+    private const STATISTICS_PATH = '/api/client/statistics';
+    private const STATISTICS_STATE_PATH = '/api/client/statistics/%s';
+    private const STATISTICS_REPORT_PATH = '/api/client/statistics/report';
+
+    private const REQUEST_TIMEOUT = 30;
+    private const DOWNLOAD_TIMEOUT = 120;
+
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly MarketplaceFacade $marketplaceFacade,
+        #[Autowire(service: 'monolog.logger.marketplace_ads')]
+        private readonly LoggerInterface $marketplaceAdsLogger,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *   access_token: string,
+     *   expires_in: int,
+     *   issued_at: string,
+     *   ozon_raw_response_status: int,
+     *   ozon_raw_body: array<string, mixed>,
+     * }
+     */
+    public function fetchAccessToken(string $companyId): array
+    {
+        $credentials = $this->resolveCredentials($companyId);
+
+        $this->marketplaceAdsLogger->info('Ozon debug: запрос токена', [
+            'companyId' => $companyId,
+        ]);
+
+        try {
+            $response = $this->httpClient->request('POST', self::BASE_URL.self::TOKEN_PATH, [
+                'headers' => ['Content-Type' => 'application/json'],
+                'json' => [
+                    'client_id' => $credentials['client_id'],
+                    'client_secret' => $credentials['client_secret'],
+                    'grant_type' => 'client_credentials',
+                ],
+                'timeout' => self::REQUEST_TIMEOUT,
+            ]);
+
+            $statusCode = $response->getStatusCode();
+            $rawBody = $response->getContent(false);
+        } catch (TransportExceptionInterface $e) {
+            throw new \RuntimeException('Ozon Performance: сеть недоступна при получении токена: '.$e->getMessage(), 0, $e);
+        }
+
+        $data = $this->decodeJsonSafe($rawBody);
+
+        $accessToken = isset($data['access_token']) && is_string($data['access_token']) ? $data['access_token'] : '';
+        $expiresIn = isset($data['expires_in']) && is_int($data['expires_in']) ? $data['expires_in'] : 0;
+
+        return [
+            'access_token' => $accessToken,
+            'expires_in' => $expiresIn,
+            'issued_at' => (new \DateTimeImmutable('now', new \DateTimeZone('Europe/Moscow')))->format(\DateTimeInterface::ATOM),
+            'ozon_raw_response_status' => $statusCode,
+            'ozon_raw_body' => $data,
+        ];
+    }
+
+    /**
+     * @return array{
+     *   status_code: int,
+     *   raw_body: array<string, mixed>,
+     *   total: int,
+     *   states_breakdown: array<string, int>,
+     *   list: list<array<string, mixed>>,
+     * }
+     */
+    public function listCampaigns(string $companyId): array
+    {
+        $token = $this->fetchAccessToken($companyId);
+        $accessToken = $token['access_token'];
+        if ('' === $accessToken) {
+            throw new \RuntimeException('Ozon Performance: access_token пустой в ответе, debug-list-campaigns прерван');
+        }
+
+        $this->marketplaceAdsLogger->info('Ozon debug: запрос списка кампаний', [
+            'companyId' => $companyId,
+        ]);
+
+        try {
+            $response = $this->httpClient->request('GET', self::BASE_URL.self::CAMPAIGN_PATH, [
+                'headers' => [
+                    'Authorization' => 'Bearer '.$accessToken,
+                    'Content-Type' => 'application/json',
+                ],
+                'timeout' => self::REQUEST_TIMEOUT,
+            ]);
+
+            $statusCode = $response->getStatusCode();
+            $body = $response->getContent(false);
+        } catch (TransportExceptionInterface $e) {
+            throw new \RuntimeException('Ozon Performance: сеть недоступна (GET /campaign): '.$e->getMessage(), 0, $e);
+        }
+
+        $data = $this->decodeJsonSafe($body);
+
+        $list = is_array($data['list'] ?? null) ? array_values($data['list']) : [];
+        $statesBreakdown = [];
+        foreach ($list as $campaign) {
+            if (!is_array($campaign)) {
+                continue;
+            }
+            $state = isset($campaign['state']) ? (string) $campaign['state'] : '';
+            $key = '' === $state ? '(empty)' : $state;
+            $statesBreakdown[$key] = ($statesBreakdown[$key] ?? 0) + 1;
+        }
+
+        return [
+            'status_code' => $statusCode,
+            'raw_body' => $data,
+            'total' => count($list),
+            'states_breakdown' => $statesBreakdown,
+            'list' => $list,
+        ];
+    }
+
+    /**
+     * @param list<string> $campaignIds
+     *
+     * @return array{
+     *   request_body: array<string, mixed>,
+     *   uuid: string,
+     *   ozon_status_code: int,
+     *   ozon_raw_response: array<string, mixed>,
+     * }
+     */
+    public function requestStatistics(
+        string $companyId,
+        array $campaignIds,
+        \DateTimeImmutable $dateFrom,
+        \DateTimeImmutable $dateTo,
+        string $groupBy,
+    ): array {
+        if ([] === $campaignIds) {
+            throw new \InvalidArgumentException('campaigns: массив не может быть пустым');
+        }
+        if (count($campaignIds) > 10) {
+            throw new \InvalidArgumentException('campaigns: максимум 10 ID в одном запросе');
+        }
+        if (!in_array($groupBy, ['NO_GROUP_BY', 'DATE'], true)) {
+            throw new \InvalidArgumentException('groupBy: допустимы только NO_GROUP_BY или DATE');
+        }
+        if ($dateFrom > $dateTo) {
+            throw new \InvalidArgumentException('from больше to');
+        }
+
+        $token = $this->fetchAccessToken($companyId);
+        $accessToken = $token['access_token'];
+        if ('' === $accessToken) {
+            throw new \RuntimeException('Ozon Performance: access_token пустой в ответе');
+        }
+
+        $utc = new \DateTimeZone('UTC');
+        $from = $dateFrom->setTime(0, 0, 0)->setTimezone($utc)->format('Y-m-d\TH:i:s\Z');
+        $to = $dateTo->setTime(23, 59, 59)->setTimezone($utc)->format('Y-m-d\TH:i:s\Z');
+
+        $requestBody = [
+            'campaigns' => array_values($campaignIds),
+            'from' => $from,
+            'to' => $to,
+            'groupBy' => $groupBy,
+        ];
+
+        $this->marketplaceAdsLogger->info('Ozon debug: POST /statistics', [
+            'companyId' => $companyId,
+            'request_body' => $requestBody,
+        ]);
+
+        try {
+            $response = $this->httpClient->request('POST', self::BASE_URL.self::STATISTICS_PATH, [
+                'headers' => [
+                    'Authorization' => 'Bearer '.$accessToken,
+                    'Content-Type' => 'application/json',
+                ],
+                'json' => $requestBody,
+                'timeout' => self::REQUEST_TIMEOUT,
+            ]);
+
+            $statusCode = $response->getStatusCode();
+            $body = $response->getContent(false);
+        } catch (TransportExceptionInterface $e) {
+            throw new \RuntimeException('Ozon Performance: сеть недоступна (POST /statistics): '.$e->getMessage(), 0, $e);
+        }
+
+        $data = $this->decodeJsonSafe($body);
+        $uuid = '';
+        if (isset($data['UUID']) && is_scalar($data['UUID'])) {
+            $uuid = (string) $data['UUID'];
+        } elseif (isset($data['uuid']) && is_scalar($data['uuid'])) {
+            $uuid = (string) $data['uuid'];
+        }
+
+        return [
+            'request_body' => $requestBody,
+            'uuid' => $uuid,
+            'ozon_status_code' => $statusCode,
+            'ozon_raw_response' => $data,
+        ];
+    }
+
+    /**
+     * @return array{
+     *   uuid: string,
+     *   state: string,
+     *   status_code: int,
+     *   ozon_raw_response: array<string, mixed>,
+     * }
+     */
+    public function checkStatus(string $companyId, string $uuid): array
+    {
+        if ('' === trim($uuid)) {
+            throw new \InvalidArgumentException('uuid: не может быть пустым');
+        }
+
+        $token = $this->fetchAccessToken($companyId);
+        $accessToken = $token['access_token'];
+        if ('' === $accessToken) {
+            throw new \RuntimeException('Ozon Performance: access_token пустой в ответе');
+        }
+
+        $this->marketplaceAdsLogger->info('Ozon debug: GET /statistics/{uuid}', [
+            'companyId' => $companyId,
+            'uuid' => $uuid,
+        ]);
+
+        try {
+            $response = $this->httpClient->request(
+                'GET',
+                self::BASE_URL.sprintf(self::STATISTICS_STATE_PATH, rawurlencode($uuid)),
+                [
+                    'headers' => [
+                        'Authorization' => 'Bearer '.$accessToken,
+                        'Content-Type' => 'application/json',
+                    ],
+                    'timeout' => self::REQUEST_TIMEOUT,
+                ],
+            );
+
+            $statusCode = $response->getStatusCode();
+            $body = $response->getContent(false);
+        } catch (TransportExceptionInterface $e) {
+            throw new \RuntimeException('Ozon Performance: сеть недоступна (GET /statistics/{uuid}): '.$e->getMessage(), 0, $e);
+        }
+
+        $data = $this->decodeJsonSafe($body);
+        $state = isset($data['state']) && is_scalar($data['state']) ? (string) $data['state'] : '';
+
+        return [
+            'uuid' => $uuid,
+            'state' => $state,
+            'status_code' => $statusCode,
+            'ozon_raw_response' => $data,
+        ];
+    }
+
+    /**
+     * @return array{
+     *   was_zip: bool,
+     *   size_bytes: int,
+     *   content_preview: string,
+     *   files_in_zip: list<array{name: string, size: int}>,
+     *   raw_bytes: string,
+     * }
+     */
+    public function downloadReport(string $companyId, string $uuid): array
+    {
+        if ('' === trim($uuid)) {
+            throw new \InvalidArgumentException('uuid: не может быть пустым');
+        }
+
+        $token = $this->fetchAccessToken($companyId);
+        $accessToken = $token['access_token'];
+        if ('' === $accessToken) {
+            throw new \RuntimeException('Ozon Performance: access_token пустой в ответе');
+        }
+
+        // Сначала спросим /statistics/{uuid}, чтобы взять link если он есть;
+        // иначе fallback на STATISTICS_REPORT_PATH?UUID=.
+        $status = $this->checkStatus($companyId, $uuid);
+        $link = '';
+        $rawResponse = $status['ozon_raw_response'];
+        if (isset($rawResponse['link']) && is_scalar($rawResponse['link'])) {
+            $link = (string) $rawResponse['link'];
+        } elseif (isset($rawResponse['report']['link']) && is_scalar($rawResponse['report']['link'])) {
+            $link = (string) $rawResponse['report']['link'];
+        }
+        if ('' === $link) {
+            $link = self::STATISTICS_REPORT_PATH.'?UUID='.rawurlencode($uuid);
+        }
+
+        $url = str_starts_with($link, 'http://') || str_starts_with($link, 'https://')
+            ? $link
+            : self::BASE_URL.$link;
+
+        $this->marketplaceAdsLogger->info('Ozon debug: download report', [
+            'companyId' => $companyId,
+            'uuid' => $uuid,
+            'url' => $url,
+        ]);
+
+        try {
+            $response = $this->httpClient->request('GET', $url, [
+                'headers' => [
+                    'Authorization' => 'Bearer '.$accessToken,
+                ],
+                'timeout' => self::DOWNLOAD_TIMEOUT,
+            ]);
+
+            $statusCode = $response->getStatusCode();
+            $rawBytes = $response->getContent(false);
+        } catch (TransportExceptionInterface $e) {
+            throw new \RuntimeException('Ozon Performance: сеть недоступна (download): '.$e->getMessage(), 0, $e);
+        }
+
+        if ($statusCode < 200 || $statusCode >= 300) {
+            throw new \RuntimeException(sprintf(
+                'Ozon Performance: download вернул HTTP %d, body=%s',
+                $statusCode,
+                mb_strimwidth($rawBytes, 0, 500, '...'),
+            ));
+        }
+
+        $wasZip = strlen($rawBytes) >= 4 && "PK\x03\x04" === substr($rawBytes, 0, 4);
+
+        if ($wasZip) {
+            $extracted = $this->extractZip($rawBytes);
+            $preview = mb_strimwidth($extracted['firstCsv'], 0, 500, '...');
+
+            return [
+                'was_zip' => true,
+                'size_bytes' => strlen($rawBytes),
+                'content_preview' => $preview,
+                'files_in_zip' => $extracted['files'],
+                'raw_bytes' => $rawBytes,
+            ];
+        }
+
+        return [
+            'was_zip' => false,
+            'size_bytes' => strlen($rawBytes),
+            'content_preview' => mb_strimwidth($rawBytes, 0, 2000, '...'),
+            'files_in_zip' => [],
+            'raw_bytes' => $rawBytes,
+        ];
+    }
+
+    /**
+     * @return array{api_key: string, client_id: string}|null
+     */
+    public function getCredentials(string $companyId): ?array
+    {
+        $credentials = $this->marketplaceFacade->getConnectionCredentials(
+            $companyId,
+            MarketplaceType::OZON,
+            MarketplaceConnectionType::PERFORMANCE,
+        );
+
+        if (null === $credentials) {
+            return null;
+        }
+
+        $clientId = (string) ($credentials['client_id'] ?? '');
+        $apiKey = (string) ($credentials['api_key'] ?? '');
+        if ('' === $clientId || '' === $apiKey) {
+            return null;
+        }
+
+        return ['api_key' => $apiKey, 'client_id' => $clientId];
+    }
+
+    /**
+     * @return array{client_id: string, client_secret: string}
+     */
+    private function resolveCredentials(string $companyId): array
+    {
+        $credentials = $this->getCredentials($companyId);
+        if (null === $credentials) {
+            throw new OzonPermanentApiException('Ozon Performance не подключен или credentials пустые');
+        }
+
+        return [
+            'client_id' => $credentials['client_id'],
+            'client_secret' => $credentials['api_key'],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJsonSafe(string $body): array
+    {
+        if ('' === trim($body)) {
+            return [];
+        }
+        try {
+            $decoded = json_decode($body, true, flags: \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return ['_raw' => mb_strimwidth($body, 0, 2000, '...'), '_invalid_json' => true];
+        }
+        if (!is_array($decoded)) {
+            return ['_raw' => $body, '_invalid_json' => false];
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @return array{files: list<array{name: string, size: int}>, firstCsv: string}
+     */
+    private function extractZip(string $zipBytes): array
+    {
+        $tmpPath = tempnam(sys_get_temp_dir(), 'ozon-debug-zip-');
+        if (false === $tmpPath) {
+            throw new \RuntimeException('Ozon debug: не удалось создать временный файл для ZIP');
+        }
+
+        try {
+            if (false === file_put_contents($tmpPath, $zipBytes)) {
+                throw new \RuntimeException('Ozon debug: не удалось записать ZIP во временный файл');
+            }
+
+            $zip = new \ZipArchive();
+            $opened = $zip->open($tmpPath);
+            if (true !== $opened) {
+                throw new \RuntimeException(sprintf(
+                    'Ozon debug: не удалось открыть ZIP (error code=%d)',
+                    is_int($opened) ? $opened : -1,
+                ));
+            }
+
+            try {
+                $files = [];
+                $firstCsv = '';
+                for ($i = 0; $i < $zip->numFiles; ++$i) {
+                    $name = $zip->getNameIndex($i);
+                    if (false === $name) {
+                        continue;
+                    }
+                    $stat = $zip->statIndex($i);
+                    $size = is_array($stat) && isset($stat['size']) ? (int) $stat['size'] : 0;
+                    $files[] = ['name' => $name, 'size' => $size];
+
+                    if ('' === $firstCsv && str_ends_with(strtolower($name), '.csv')) {
+                        $content = $zip->getFromIndex($i);
+                        if (false !== $content) {
+                            $firstCsv = $content;
+                        }
+                    }
+                }
+            } finally {
+                $zip->close();
+            }
+
+            return ['files' => $files, 'firstCsv' => $firstCsv];
+        } finally {
+            @unlink($tmpPath);
+        }
+    }
+}

--- a/site/templates/marketplace_ads/admin_debug.html.twig
+++ b/site/templates/marketplace_ads/admin_debug.html.twig
@@ -225,15 +225,23 @@
                                 + '. States: ' + JSON.stringify(res.data.states_breakdown || {});
                             checkboxes.innerHTML = '';
                             lastCampaigns.forEach(function (c) {
-                                var id = c.id || '';
-                                var title = c.title || c.name || '';
-                                var state = c.state || '';
+                                var id = String(c.id || '');
+                                var title = String(c.title || c.name || '');
+                                var state = String(c.state || '');
                                 var label = document.createElement('label');
                                 label.className = 'form-check form-check-inline';
-                                label.innerHTML = '<input class="form-check-input campaign-check" type="checkbox" value="'
-                                    + String(id).replace(/"/g, '&quot;') + '"> '
-                                    + '<span>' + String(id) + ' — ' + String(title) + ' <small class="text-muted">('
-                                    + String(state) + ')</small></span>';
+                                var input = document.createElement('input');
+                                input.className = 'form-check-input campaign-check';
+                                input.type = 'checkbox';
+                                input.value = id;
+                                var span = document.createElement('span');
+                                span.appendChild(document.createTextNode(' ' + id + ' — ' + title + ' '));
+                                var small = document.createElement('small');
+                                small.className = 'text-muted';
+                                small.textContent = '(' + state + ')';
+                                span.appendChild(small);
+                                label.appendChild(input);
+                                label.appendChild(span);
                                 checkboxes.appendChild(label);
                             });
                         } else {

--- a/site/templates/marketplace_ads/admin_debug.html.twig
+++ b/site/templates/marketplace_ads/admin_debug.html.twig
@@ -1,0 +1,338 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Ozon Debug — MarketplaceAds{% endblock %}
+
+{% block body %}
+    <div class="page-header d-print-none">
+        <div class="container-xl">
+            <h2 class="page-title">Ozon Performance Debug</h2>
+            <div class="text-muted">
+                Прямые вызовы Ozon Performance API в обход async-пайплайна.
+                Ничего не сохраняется в БД — все результаты только в ответе.
+            </div>
+        </div>
+    </div>
+
+    <div class="page-body">
+        <div class="container-xl">
+            {% if companies|length == 0 %}
+                <div class="alert alert-warning">
+                    Нет компаний с активным Ozon Performance подключением.
+                </div>
+            {% else %}
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <label class="form-label">Компания (только с Ozon Performance подключением)</label>
+                        <select id="debug-company-id" class="form-select">
+                            {% for company in companies %}
+                                <option value="{{ company.id }}">{{ company.name }} ({{ company.id }})</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                </div>
+
+                <div class="row g-3">
+                    <div class="col-md-6">
+                        <div class="card">
+                            <div class="card-header">
+                                <h3 class="card-title">1. Токен</h3>
+                            </div>
+                            <div class="card-body">
+                                <button type="button" class="btn btn-primary" id="btn-fetch-token">Получить токен</button>
+                            </div>
+                            <pre id="result-token" class="debug-pre">—</pre>
+                        </div>
+                    </div>
+
+                    <div class="col-md-6">
+                        <div class="card">
+                            <div class="card-header">
+                                <h3 class="card-title">2. Список кампаний</h3>
+                            </div>
+                            <div class="card-body">
+                                <button type="button" class="btn btn-primary" id="btn-fetch-campaigns">Получить кампании</button>
+                                <div class="mt-2 text-muted" id="campaigns-summary"></div>
+                            </div>
+                            <pre id="result-campaigns" class="debug-pre">—</pre>
+                        </div>
+                    </div>
+
+                    <div class="col-12">
+                        <div class="card">
+                            <div class="card-header">
+                                <h3 class="card-title">3. Запросить статистику</h3>
+                            </div>
+                            <div class="card-body">
+                                <div class="row g-2 mb-2">
+                                    <div class="col-md-3">
+                                        <label class="form-label">Дата с</label>
+                                        <input type="date" id="stats-from" class="form-control"
+                                               value="{{ 'now'|date_modify('-3 days')|date('Y-m-d') }}">
+                                    </div>
+                                    <div class="col-md-3">
+                                        <label class="form-label">Дата по</label>
+                                        <input type="date" id="stats-to" class="form-control"
+                                               value="{{ 'now'|date_modify('-3 days')|date('Y-m-d') }}">
+                                    </div>
+                                    <div class="col-md-3">
+                                        <label class="form-label">groupBy</label>
+                                        <select id="stats-group-by" class="form-select">
+                                            <option value="DATE">DATE</option>
+                                            <option value="NO_GROUP_BY">NO_GROUP_BY</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="mb-2">
+                                    <label class="form-label">Кампании (до 10)</label>
+                                    <div id="campaigns-checkboxes" class="mb-2 text-muted">
+                                        Сначала получите список кампаний (блок 2) — появятся чекбоксы.
+                                    </div>
+                                    <label class="form-label">Или введите ID вручную (через запятую)</label>
+                                    <input type="text" id="stats-manual-ids" class="form-control"
+                                           placeholder="12345,67890">
+                                </div>
+                                <button type="button" class="btn btn-primary" id="btn-request-stats">
+                                    Запросить
+                                </button>
+                                <div class="mt-2 text-muted">
+                                    Последний UUID: <code id="last-uuid">—</code>
+                                </div>
+                            </div>
+                            <pre id="result-stats" class="debug-pre">—</pre>
+                        </div>
+                    </div>
+
+                    <div class="col-md-6">
+                        <div class="card">
+                            <div class="card-header">
+                                <h3 class="card-title">4. Проверить статус</h3>
+                            </div>
+                            <div class="card-body">
+                                <div class="mb-2">
+                                    <label class="form-label">UUID</label>
+                                    <input type="text" id="status-uuid" class="form-control"
+                                           placeholder="uuid отчёта">
+                                </div>
+                                <button type="button" class="btn btn-primary" id="btn-check-status">Проверить</button>
+                            </div>
+                            <pre id="result-status" class="debug-pre">—</pre>
+                        </div>
+                    </div>
+
+                    <div class="col-md-6">
+                        <div class="card">
+                            <div class="card-header">
+                                <h3 class="card-title">5. Скачать отчёт</h3>
+                            </div>
+                            <div class="card-body">
+                                <div class="mb-2">
+                                    <label class="form-label">UUID</label>
+                                    <input type="text" id="download-uuid" class="form-control"
+                                           placeholder="uuid отчёта">
+                                </div>
+                                <button type="button" class="btn btn-primary" id="btn-download-preview">Превью</button>
+                                <a id="btn-download-raw" class="btn btn-outline-secondary" target="_blank" rel="noopener">
+                                    Сырой файл
+                                </a>
+                            </div>
+                            <pre id="result-download" class="debug-pre">—</pre>
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
+        </div>
+    </div>
+
+    <style>
+        .debug-pre {
+            max-height: 400px;
+            overflow: auto;
+            background: #1e1e1e;
+            color: #dcdcdc;
+            padding: 12px;
+            margin: 0;
+            font-size: 12px;
+            border-top: 1px solid #333;
+        }
+    </style>
+
+    <script>
+        (function () {
+            var companySel = document.getElementById('debug-company-id');
+            if (!companySel) { return; }
+
+            var pretty = function (value) {
+                try {
+                    return JSON.stringify(value, null, 2);
+                } catch (e) {
+                    return String(value);
+                }
+            };
+
+            var renderResult = function (elId, payload, okFlag) {
+                var el = document.getElementById(elId);
+                el.textContent = pretty(payload);
+                el.style.borderLeft = okFlag ? '4px solid #1a7f37' : '4px solid #d1242f';
+            };
+
+            var companyId = function () { return companySel.value; };
+
+            var withBusy = function (btn, cb) {
+                var original = btn.innerHTML;
+                btn.disabled = true;
+                btn.innerHTML = 'Выполняется...';
+                Promise.resolve(cb()).finally(function () {
+                    btn.disabled = false;
+                    btn.innerHTML = original;
+                });
+            };
+
+            var doFetch = function (url, init) {
+                init = init || {};
+                init.credentials = 'same-origin';
+                init.headers = Object.assign({'X-Requested-With': 'XMLHttpRequest'}, init.headers || {});
+                return fetch(url, init).then(function (r) {
+                    return r.json().then(function (data) {
+                        return {ok: r.ok, status: r.status, data: data};
+                    }).catch(function () {
+                        return {ok: r.ok, status: r.status, data: {error: 'Invalid JSON response'}};
+                    });
+                });
+            };
+
+            // ----- 1. Token -----
+            document.getElementById('btn-fetch-token').addEventListener('click', function (e) {
+                withBusy(e.currentTarget, function () {
+                    var url = '/api/marketplace-ads/admin/ozon/debug/token?companyId=' + encodeURIComponent(companyId());
+                    return doFetch(url).then(function (res) {
+                        renderResult('result-token', res.data, res.ok);
+                    });
+                });
+            });
+
+            // ----- 2. Campaigns -----
+            var lastCampaigns = [];
+            document.getElementById('btn-fetch-campaigns').addEventListener('click', function (e) {
+                withBusy(e.currentTarget, function () {
+                    var url = '/api/marketplace-ads/admin/ozon/debug/campaigns?companyId=' + encodeURIComponent(companyId());
+                    return doFetch(url).then(function (res) {
+                        renderResult('result-campaigns', res.data, res.ok);
+                        var summary = document.getElementById('campaigns-summary');
+                        var checkboxes = document.getElementById('campaigns-checkboxes');
+                        if (res.ok && res.data && Array.isArray(res.data.list)) {
+                            lastCampaigns = res.data.list;
+                            summary.textContent = 'Всего: ' + (res.data.total || 0)
+                                + '. States: ' + JSON.stringify(res.data.states_breakdown || {});
+                            checkboxes.innerHTML = '';
+                            lastCampaigns.forEach(function (c) {
+                                var id = c.id || '';
+                                var title = c.title || c.name || '';
+                                var state = c.state || '';
+                                var label = document.createElement('label');
+                                label.className = 'form-check form-check-inline';
+                                label.innerHTML = '<input class="form-check-input campaign-check" type="checkbox" value="'
+                                    + String(id).replace(/"/g, '&quot;') + '"> '
+                                    + '<span>' + String(id) + ' — ' + String(title) + ' <small class="text-muted">('
+                                    + String(state) + ')</small></span>';
+                                checkboxes.appendChild(label);
+                            });
+                        } else {
+                            lastCampaigns = [];
+                            summary.textContent = '';
+                        }
+                    });
+                });
+            });
+
+            // ----- 3. Request statistics -----
+            var lastUuid = '';
+            var setLastUuid = function (uuid) {
+                lastUuid = uuid || '';
+                document.getElementById('last-uuid').textContent = lastUuid || '—';
+                if (lastUuid) {
+                    var su = document.getElementById('status-uuid');
+                    var du = document.getElementById('download-uuid');
+                    if (!su.value) su.value = lastUuid;
+                    if (!du.value) du.value = lastUuid;
+                }
+            };
+
+            document.getElementById('btn-request-stats').addEventListener('click', function (e) {
+                withBusy(e.currentTarget, function () {
+                    var checked = Array.from(document.querySelectorAll('.campaign-check:checked')).map(function (el) { return el.value; });
+                    var manualRaw = document.getElementById('stats-manual-ids').value || '';
+                    var manual = manualRaw.split(',').map(function (s) { return s.trim(); }).filter(Boolean);
+                    var ids = checked.length ? checked : manual;
+                    if (!ids.length) {
+                        renderResult('result-stats', {error: 'Не выбрано ни одной кампании'}, false);
+                        return Promise.resolve();
+                    }
+                    var body = {
+                        companyId: companyId(),
+                        campaigns: ids.slice(0, 10),
+                        from: document.getElementById('stats-from').value,
+                        to: document.getElementById('stats-to').value,
+                        groupBy: document.getElementById('stats-group-by').value,
+                    };
+                    return doFetch('/api/marketplace-ads/admin/ozon/debug/statistics/request', {
+                        method: 'POST',
+                        headers: {'Content-Type': 'application/json'},
+                        body: JSON.stringify(body),
+                    }).then(function (res) {
+                        renderResult('result-stats', res.data, res.ok);
+                        if (res.ok && res.data && res.data.uuid) {
+                            setLastUuid(res.data.uuid);
+                        }
+                    });
+                });
+            });
+
+            // ----- 4. Check status -----
+            document.getElementById('btn-check-status').addEventListener('click', function (e) {
+                withBusy(e.currentTarget, function () {
+                    var uuid = document.getElementById('status-uuid').value.trim();
+                    if (!uuid) {
+                        renderResult('result-status', {error: 'uuid: обязательный параметр'}, false);
+                        return Promise.resolve();
+                    }
+                    var url = '/api/marketplace-ads/admin/ozon/debug/statistics/status'
+                        + '?companyId=' + encodeURIComponent(companyId())
+                        + '&uuid=' + encodeURIComponent(uuid);
+                    return doFetch(url).then(function (res) {
+                        renderResult('result-status', res.data, res.ok);
+                    });
+                });
+            });
+
+            // ----- 5. Download -----
+            var rawLink = document.getElementById('btn-download-raw');
+            var updateRawLink = function () {
+                var uuid = document.getElementById('download-uuid').value.trim();
+                if (!uuid) { rawLink.removeAttribute('href'); return; }
+                rawLink.href = '/api/marketplace-ads/admin/ozon/debug/statistics/download'
+                    + '?companyId=' + encodeURIComponent(companyId())
+                    + '&uuid=' + encodeURIComponent(uuid)
+                    + '&raw=1';
+            };
+            document.getElementById('download-uuid').addEventListener('input', updateRawLink);
+            companySel.addEventListener('change', updateRawLink);
+            updateRawLink();
+
+            document.getElementById('btn-download-preview').addEventListener('click', function (e) {
+                withBusy(e.currentTarget, function () {
+                    var uuid = document.getElementById('download-uuid').value.trim();
+                    if (!uuid) {
+                        renderResult('result-download', {error: 'uuid: обязательный параметр'}, false);
+                        return Promise.resolve();
+                    }
+                    var url = '/api/marketplace-ads/admin/ozon/debug/statistics/download'
+                        + '?companyId=' + encodeURIComponent(companyId())
+                        + '&uuid=' + encodeURIComponent(uuid);
+                    return doFetch(url).then(function (res) {
+                        renderResult('result-download', res.data, res.ok);
+                    });
+                });
+            });
+        })();
+    </script>
+{% endblock %}

--- a/site/templates/partials/_sidebar_marketplace.html.twig
+++ b/site/templates/partials/_sidebar_marketplace.html.twig
@@ -33,6 +33,12 @@
             <a class="dropdown-item {{ mp_reconciliation_active ? 'active' : '' }}" href="{{ path('marketplace_reconciliation') }}">
                 <span>Сверка</span>
             </a>
+            {% if is_granted('ROLE_SUPER_ADMIN') %}
+                {% set mp_ads_debug_active = current_route == 'marketplace_ads_admin_debug' %}
+                <a class="dropdown-item {{ mp_ads_debug_active ? 'active' : '' }}" href="{{ path('marketplace_ads_admin_debug') }}">
+                    <span>Ozon Debug</span>
+                </a>
+            {% endif %}
         </div>
     </div>
 </li>

--- a/site/tests/Integration/MarketplaceAds/Controller/Api/Admin/OzonDebugControllerTest.php
+++ b/site/tests/Integration/MarketplaceAds/Controller/Api/Admin/OzonDebugControllerTest.php
@@ -53,8 +53,10 @@ final class OzonDebugControllerTest extends WebTestCaseBase
         self::assertSame(self::COMPANY_ID, $data['companyId']);
         self::assertStringStartsWith('ACCESS-TOKEN-123456', $data['access_token_prefix']);
         self::assertLessThanOrEqual(23, strlen($data['access_token_prefix']));
+        self::assertStringNotContainsString('78901234567890', $data['access_token_prefix']);
         self::assertSame(1800, $data['expires_in']);
         self::assertSame(200, $data['ozon_raw_response_status']);
+        self::assertSame('***REDACTED***', $data['ozon_raw_body']['access_token']);
     }
 
     public function testTokenRequires403WithoutSuperAdmin(): void

--- a/site/tests/Integration/MarketplaceAds/Controller/Api/Admin/OzonDebugControllerTest.php
+++ b/site/tests/Integration/MarketplaceAds/Controller/Api/Admin/OzonDebugControllerTest.php
@@ -1,0 +1,363 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\MarketplaceAds\Controller\Api\Admin;
+
+use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Enum\MarketplaceConnectionType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class OzonDebugControllerTest extends WebTestCaseBase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-abcd00000001';
+    private const ADMIN_ID = '22222222-2222-2222-2222-abcd00000001';
+    private const OWNER_ID = '22222222-2222-2222-2222-abcd00000002';
+
+    private const URL_TOKEN = '/api/marketplace-ads/admin/ozon/debug/token';
+    private const URL_CAMPAIGNS = '/api/marketplace-ads/admin/ozon/debug/campaigns';
+    private const URL_STATS_REQUEST = '/api/marketplace-ads/admin/ozon/debug/statistics/request';
+    private const URL_STATS_STATUS = '/api/marketplace-ads/admin/ozon/debug/statistics/status';
+    private const URL_STATS_DOWNLOAD = '/api/marketplace-ads/admin/ozon/debug/statistics/download';
+
+    // ------------------------------------------------------------------
+    // Happy-path tests with MockHttpClient swapped into the container
+    // ------------------------------------------------------------------
+
+    public function testTokenHappyPath(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $this->setHttpClient($client, [
+            new MockResponse(json_encode([
+                'access_token' => 'ACCESS-TOKEN-123456789012345678901234567890',
+                'expires_in' => 1800,
+            ], \JSON_THROW_ON_ERROR)),
+        ]);
+
+        $admin = $this->seedAdminAndCompany();
+        $this->loginAs($client, $admin);
+
+        $client->request('GET', self::URL_TOKEN.'?companyId='.self::COMPANY_ID);
+
+        self::assertResponseIsSuccessful();
+        $data = $this->decode($client);
+        self::assertSame(self::COMPANY_ID, $data['companyId']);
+        self::assertStringStartsWith('ACCESS-TOKEN-123456', $data['access_token_prefix']);
+        self::assertLessThanOrEqual(23, strlen($data['access_token_prefix']));
+        self::assertSame(1800, $data['expires_in']);
+        self::assertSame(200, $data['ozon_raw_response_status']);
+    }
+
+    public function testTokenRequires403WithoutSuperAdmin(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $owner = $this->seedCompanyOwnerOnly();
+        $this->loginAs($client, $owner);
+
+        $client->request('GET', self::URL_TOKEN.'?companyId='.self::COMPANY_ID);
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testCampaignsHappyPath(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $this->setHttpClient($client, [
+            new MockResponse(json_encode([
+                'access_token' => 'TKN-short',
+                'expires_in' => 1800,
+            ], \JSON_THROW_ON_ERROR)),
+            new MockResponse(json_encode([
+                'list' => [
+                    ['id' => '111', 'title' => 'Running', 'state' => 'CAMPAIGN_STATE_RUNNING', 'advObjectType' => 'SKU'],
+                    ['id' => '222', 'title' => 'Archived', 'state' => 'CAMPAIGN_STATE_ARCHIVED', 'advObjectType' => 'SKU'],
+                    ['id' => '333', 'title' => 'Planned', 'state' => 'CAMPAIGN_STATE_PLANNED', 'advObjectType' => 'SKU'],
+                ],
+            ], \JSON_THROW_ON_ERROR)),
+        ]);
+
+        $admin = $this->seedAdminAndCompany();
+        $this->loginAs($client, $admin);
+
+        $client->request('GET', self::URL_CAMPAIGNS.'?companyId='.self::COMPANY_ID);
+
+        self::assertResponseIsSuccessful();
+        $data = $this->decode($client);
+        self::assertSame(3, $data['total']);
+        self::assertSame(
+            ['CAMPAIGN_STATE_RUNNING' => 1, 'CAMPAIGN_STATE_ARCHIVED' => 1, 'CAMPAIGN_STATE_PLANNED' => 1],
+            $data['states_breakdown'],
+        );
+        self::assertCount(3, $data['list']);
+    }
+
+    public function testCampaignsRequires403WithoutSuperAdmin(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $owner = $this->seedCompanyOwnerOnly();
+        $this->loginAs($client, $owner);
+
+        $client->request('GET', self::URL_CAMPAIGNS.'?companyId='.self::COMPANY_ID);
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testStatisticsRequestHappyPath(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $this->setHttpClient($client, [
+            new MockResponse(json_encode([
+                'access_token' => 'TKN-stats',
+                'expires_in' => 1800,
+            ], \JSON_THROW_ON_ERROR)),
+            new MockResponse(json_encode(['UUID' => 'uuid-happy-1'], \JSON_THROW_ON_ERROR)),
+        ]);
+
+        $admin = $this->seedAdminAndCompany();
+        $this->loginAs($client, $admin);
+
+        $client->request(
+            'POST',
+            self::URL_STATS_REQUEST,
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode([
+                'companyId' => self::COMPANY_ID,
+                'campaigns' => ['111', '222'],
+                'from' => '2026-04-17',
+                'to' => '2026-04-17',
+                'groupBy' => 'DATE',
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        self::assertResponseIsSuccessful();
+        $data = $this->decode($client);
+        self::assertSame('uuid-happy-1', $data['uuid']);
+        self::assertSame(200, $data['ozon_status_code']);
+        self::assertSame(['111', '222'], $data['request_body']['campaigns']);
+        self::assertSame('DATE', $data['request_body']['groupBy']);
+        // RFC3339 in UTC
+        self::assertStringEndsWith('Z', (string) $data['request_body']['from']);
+        self::assertStringEndsWith('Z', (string) $data['request_body']['to']);
+    }
+
+    public function testStatisticsRequestRequires403WithoutSuperAdmin(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $owner = $this->seedCompanyOwnerOnly();
+        $this->loginAs($client, $owner);
+
+        $client->request(
+            'POST',
+            self::URL_STATS_REQUEST,
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode([
+                'companyId' => self::COMPANY_ID,
+                'campaigns' => ['111'],
+                'from' => '2026-04-17',
+                'to' => '2026-04-17',
+                'groupBy' => 'DATE',
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testStatisticsStatusHappyPath(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $this->setHttpClient($client, [
+            new MockResponse(json_encode([
+                'access_token' => 'TKN-st',
+                'expires_in' => 1800,
+            ], \JSON_THROW_ON_ERROR)),
+            new MockResponse(json_encode([
+                'state' => 'PROCESSING',
+            ], \JSON_THROW_ON_ERROR)),
+        ]);
+
+        $admin = $this->seedAdminAndCompany();
+        $this->loginAs($client, $admin);
+
+        $client->request('GET', self::URL_STATS_STATUS.'?companyId='.self::COMPANY_ID.'&uuid=uuid-abc');
+
+        self::assertResponseIsSuccessful();
+        $data = $this->decode($client);
+        self::assertSame('uuid-abc', $data['uuid']);
+        self::assertSame('PROCESSING', $data['state']);
+        self::assertSame(200, $data['status_code']);
+    }
+
+    public function testStatisticsStatusRequires403WithoutSuperAdmin(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $owner = $this->seedCompanyOwnerOnly();
+        $this->loginAs($client, $owner);
+
+        $client->request('GET', self::URL_STATS_STATUS.'?companyId='.self::COMPANY_ID.'&uuid=uuid-xyz');
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testStatisticsDownloadHappyPath(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $csv = "date;campaign_id;campaign_name;sku;spend;views;clicks\n2026-04-17;111;Camp;SKU-1;1.00;10;2\n";
+        $this->setHttpClient($client, [
+            // token fetch for checkStatus
+            new MockResponse(json_encode([
+                'access_token' => 'TKN-dl-1',
+                'expires_in' => 1800,
+            ], \JSON_THROW_ON_ERROR)),
+            // /statistics/{uuid}
+            new MockResponse(json_encode([
+                'state' => 'OK',
+                'link' => '/api/client/statistics/report?UUID=uuid-dl',
+            ], \JSON_THROW_ON_ERROR)),
+            // token fetch for download
+            new MockResponse(json_encode([
+                'access_token' => 'TKN-dl-2',
+                'expires_in' => 1800,
+            ], \JSON_THROW_ON_ERROR)),
+            // download
+            new MockResponse($csv),
+        ]);
+
+        $admin = $this->seedAdminAndCompany();
+        $this->loginAs($client, $admin);
+
+        $client->request('GET', self::URL_STATS_DOWNLOAD.'?companyId='.self::COMPANY_ID.'&uuid=uuid-dl');
+
+        self::assertResponseIsSuccessful();
+        $data = $this->decode($client);
+        self::assertFalse($data['was_zip']);
+        self::assertSame(strlen($csv), $data['size_bytes']);
+        self::assertStringContainsString('campaign_id', $data['content_preview']);
+        self::assertSame([], $data['files_in_zip']);
+    }
+
+    public function testStatisticsDownloadRequires403WithoutSuperAdmin(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $owner = $this->seedCompanyOwnerOnly();
+        $this->loginAs($client, $owner);
+
+        $client->request('GET', self::URL_STATS_DOWNLOAD.'?companyId='.self::COMPANY_ID.'&uuid=uuid-xyz');
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    // ------------------------------------------------------------------
+    // helpers
+    // ------------------------------------------------------------------
+
+    /**
+     * @param list<MockResponse> $responses
+     */
+    private function setHttpClient(KernelBrowser $client, array $responses): void
+    {
+        $i = 0;
+        $callable = function (string $method, string $url, array $options) use ($responses, &$i): ResponseInterface {
+            if (!isset($responses[$i])) {
+                throw new \LogicException(sprintf('MockHttpClient: no scripted response for #%d (%s %s)', $i + 1, $method, $url));
+            }
+
+            return $responses[$i++];
+        };
+
+        $mock = new MockHttpClient($callable);
+        $client->getContainer()->set('http_client', $mock);
+    }
+
+    private function seedAdminAndCompany(): \App\Company\Entity\User
+    {
+        $em = $this->em();
+        $admin = UserBuilder::aUser()
+            ->withId(self::ADMIN_ID)
+            ->withEmail('ozon-debug-admin@example.test')
+            ->withRoles(['ROLE_COMPANY_OWNER', 'ROLE_SUPER_ADMIN'])
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($admin)
+            ->build();
+
+        $em->persist($admin);
+        $em->persist($company);
+        $em->flush();
+
+        $connection = new MarketplaceConnection(
+            Uuid::uuid4()->toString(),
+            $company,
+            MarketplaceType::OZON,
+            MarketplaceConnectionType::PERFORMANCE,
+        );
+        $connection->setApiKey('test-secret');
+        $connection->setClientId('test-client-id');
+        $em->persist($connection);
+        $em->flush();
+
+        return $admin;
+    }
+
+    private function seedCompanyOwnerOnly(): \App\Company\Entity\User
+    {
+        $em = $this->em();
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('ozon-debug-owner@example.test')
+            ->withRoles(['ROLE_COMPANY_OWNER'])
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        return $owner;
+    }
+
+    private function loginAs(KernelBrowser $client, \App\Company\Entity\User $user): void
+    {
+        $client->loginUser($user);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', self::COMPANY_ID);
+        $session->save();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(KernelBrowser $client): array
+    {
+        $body = (string) $client->getResponse()->getContent();
+        $data = json_decode($body, true, flags: \JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+
+        return $data;
+    }
+}


### PR DESCRIPTION
## Summary

DEBUG-эндпоинты под `ROLE_SUPER_ADMIN` для прямой отладки Ozon Performance API в обход асинхронного пайплайна. Не трогают `Lock`, не создают `AdLoadJob`/`AdRawDocument`, не пишут в БД — только логируют в канал `marketplace_ads`.

### Backend
- **`OzonDebugFetcher`** (`src/MarketplaceAds/Infrastructure/Api/Ozon/`) — отдельный сервис параллельно `OzonAdClient`: без кэширования токена, без ретраев, сырые ответы Ozon с `status_code` + `body`.
- **`OzonDebugController`** (`src/MarketplaceAds/Controller/Api/Admin/`) — 5 маршрутов `/api/marketplace-ads/admin/ozon/debug/*`:
  - `GET /token` — префикс access-токена (20 символов + `...`)
  - `GET /campaigns` — список SKU-кампаний + breakdown по state
  - `POST /statistics/request` — `campaigns[]`, `from`, `to`, `groupBy` (валидация ≤10, RFC3339 Z UTC)
  - `GET /statistics/status` — **одиночный** poll (без loop)
  - `GET /statistics/download` — preview отчёта + `?raw=1` для `application/octet-stream`
- UUID-валидация companyId через regex, строгие даты `!Y-m-d`, `OzonPermanentApiException → 400`, `Throwable → 502`.

### UI
- `OzonDebugPageController` + `templates/marketplace_ads/admin_debug.html.twig` на `/marketplace-ads/admin/debug` — селект Performance-компаний, 5 карточек с inline JS `fetch`, результаты в `<pre>` блоках.
- Пункт **«Ozon Debug»** в `_sidebar_marketplace.html.twig` под `is_granted('ROLE_SUPER_ADMIN')`.

### Tests
- `OzonDebugControllerTest` (Integration): 10 кейсов — happy-path + 403 на каждый эндпоинт, через `MockHttpClient` (override `http_client` в тест-контейнере), без моков `OzonAdClient`.

## Test plan

- [ ] `php bin/phpunit tests/Integration/MarketplaceAds/Controller/Api/Admin/OzonDebugControllerTest.php`
- [ ] Ручная проверка UI `/marketplace-ads/admin/debug` под SUPER_ADMIN: селект компаний, последовательно token → campaigns → statistics/request → status → download
- [ ] Проверка 403 под обычной ролью на страницу и API
- [ ] Логи в `var/log/marketplace_ads-*.log` с контекстом companyId

https://claude.ai/code/session_01MDkVjBcH27UuNKV4UjeKph