### PR TITLE
feat(MarketplaceAds): GET /statistics/list debug endpoint

### DIFF
--- a/site/src/MarketplaceAds/Controller/Api/Admin/OzonDebugController.php
+++ b/site/src/MarketplaceAds/Controller/Api/Admin/OzonDebugController.php
@@ -117,6 +117,47 @@ final class OzonDebugController extends AbstractController
     }
 
     #[Route(
+        '/api/marketplace-ads/admin/ozon/debug/statistics/list',
+        name: 'marketplace_ads_admin_ozon_debug_statistics_list',
+        methods: ['GET'],
+    )]
+    public function statisticsList(Request $request): JsonResponse
+    {
+        $companyId = $this->requireCompanyId($request->query->get('companyId'));
+        if ($companyId instanceof JsonResponse) {
+            return $companyId;
+        }
+
+        $page = (int) $request->query->get('page', '1');
+        $pageSize = (int) $request->query->get('pageSize', '50');
+
+        $this->logger->info('Ozon debug call: statistics/list', [
+            'companyId' => $companyId,
+            'page' => $page,
+            'pageSize' => $pageSize,
+        ]);
+
+        try {
+            $result = $this->debugFetcher->listReports($companyId, $page, $pageSize);
+        } catch (\InvalidArgumentException $e) {
+            return $this->error($e->getMessage(), 400);
+        } catch (OzonPermanentApiException $e) {
+            return $this->error($e->getMessage(), 400);
+        } catch (\Throwable $e) {
+            return $this->error($e->getMessage(), 502, $e);
+        }
+
+        return $this->json([
+            'companyId' => $companyId,
+            'status_code' => $result['status_code'],
+            'total' => $result['total'],
+            'states_breakdown' => $result['states_breakdown'],
+            'items' => $result['items'],
+            'raw_body' => $result['raw_body'],
+        ]);
+    }
+
+    #[Route(
         '/api/marketplace-ads/admin/ozon/debug/statistics/request',
         name: 'marketplace_ads_admin_ozon_debug_statistics_request',
         methods: ['POST'],

--- a/site/src/MarketplaceAds/Controller/Api/Admin/OzonDebugController.php
+++ b/site/src/MarketplaceAds/Controller/Api/Admin/OzonDebugController.php
@@ -151,6 +151,7 @@ final class OzonDebugController extends AbstractController
             'companyId' => $companyId,
             'status_code' => $result['status_code'],
             'total' => $result['total'],
+            'page_items_count' => $result['page_items_count'],
             'states_breakdown' => $result['states_breakdown'],
             'items' => $result['items'],
             'raw_body' => $result['raw_body'],

--- a/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonDebugFetcher.php
+++ b/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonDebugFetcher.php
@@ -177,6 +177,7 @@ final class OzonDebugFetcher
      *   status_code: int,
      *   items: list<array<string, mixed>>,
      *   total: int,
+     *   page_items_count: int,
      *   states_breakdown: array<string, int>,
      *   raw_body: array<string, mixed>,
      * }
@@ -250,10 +251,13 @@ final class OzonDebugFetcher
             $statesBreakdown[$key] = ($statesBreakdown[$key] ?? 0) + 1;
         }
 
+        $apiTotal = isset($data['total']) && is_numeric($data['total']) ? (int) $data['total'] : null;
+
         return [
             'status_code' => $statusCode,
             'items' => $items,
-            'total' => count($items),
+            'total' => $apiTotal ?? count($items),
+            'page_items_count' => count($items),
             'states_breakdown' => $statesBreakdown,
             'raw_body' => $data,
         ];

--- a/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonDebugFetcher.php
+++ b/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonDebugFetcher.php
@@ -31,6 +31,7 @@ final class OzonDebugFetcher
     private const STATISTICS_PATH = '/api/client/statistics';
     private const STATISTICS_STATE_PATH = '/api/client/statistics/%s';
     private const STATISTICS_REPORT_PATH = '/api/client/statistics/report';
+    private const STATISTICS_LIST_PATH = '/api/client/statistics/list';
 
     private const REQUEST_TIMEOUT = 30;
     private const DOWNLOAD_TIMEOUT = 120;
@@ -164,6 +165,97 @@ final class OzonDebugFetcher
             'total' => count($list),
             'states_breakdown' => $statesBreakdown,
             'list' => $list,
+        ];
+    }
+
+    /**
+     * Инвентаризация всех заказанных отчётов Ozon Performance на аккаунте.
+     * Даёт видимость «висящих» UUID'ов (NOT_STARTED/IN_PROGRESS), которые
+     * не видны в нашей БД, но продолжают занимать слоты очереди Ozon.
+     *
+     * @return array{
+     *   status_code: int,
+     *   items: list<array<string, mixed>>,
+     *   total: int,
+     *   states_breakdown: array<string, int>,
+     *   raw_body: array<string, mixed>,
+     * }
+     */
+    public function listReports(string $companyId, int $page = 1, int $pageSize = 50): array
+    {
+        if ($page < 1) {
+            throw new \InvalidArgumentException('page: должно быть >= 1');
+        }
+        if ($pageSize < 1 || $pageSize > 1000) {
+            throw new \InvalidArgumentException('pageSize: допустимо от 1 до 1000');
+        }
+
+        $token = $this->fetchAccessToken($companyId);
+        $accessToken = $token['access_token'];
+        if ('' === $accessToken) {
+            throw new \RuntimeException('Ozon Performance: access_token пустой в ответе, debug-list-reports прерван');
+        }
+
+        $this->marketplaceAdsLogger->info('Ozon debug: GET /statistics/list', [
+            'companyId' => $companyId,
+            'page' => $page,
+            'pageSize' => $pageSize,
+        ]);
+
+        try {
+            $response = $this->httpClient->request('GET', self::BASE_URL.self::STATISTICS_LIST_PATH, [
+                'headers' => [
+                    'Authorization' => 'Bearer '.$accessToken,
+                    'Content-Type' => 'application/json',
+                ],
+                'query' => [
+                    'page' => $page,
+                    'pageSize' => $pageSize,
+                ],
+                'timeout' => self::REQUEST_TIMEOUT,
+            ]);
+
+            $statusCode = $response->getStatusCode();
+        } catch (TransportExceptionInterface $e) {
+            throw new \RuntimeException('Ozon Performance: сеть недоступна (GET /statistics/list): '.$e->getMessage(), 0, $e);
+        }
+
+        try {
+            $body = $response->getContent(false);
+        } catch (TransportExceptionInterface $e) {
+            throw new \RuntimeException(sprintf(
+                'Ozon Performance: обрыв соединения при чтении тела (HTTP %d, GET /statistics/list): %s',
+                $statusCode,
+                $e->getMessage(),
+            ), 0, $e);
+        }
+
+        $data = $this->decodeJsonSafe($body);
+
+        $items = [];
+        foreach (['items', 'list', 'reports'] as $key) {
+            if (isset($data[$key]) && is_array($data[$key])) {
+                $items = array_values($data[$key]);
+                break;
+            }
+        }
+
+        $statesBreakdown = [];
+        foreach ($items as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+            $state = isset($item['state']) && is_scalar($item['state']) ? (string) $item['state'] : '';
+            $key = '' === $state ? '(empty)' : $state;
+            $statesBreakdown[$key] = ($statesBreakdown[$key] ?? 0) + 1;
+        }
+
+        return [
+            'status_code' => $statusCode,
+            'items' => $items,
+            'total' => count($items),
+            'states_breakdown' => $statesBreakdown,
+            'raw_body' => $data,
         ];
     }
 

--- a/site/templates/marketplace_ads/admin_debug.html.twig
+++ b/site/templates/marketplace_ads/admin_debug.html.twig
@@ -60,6 +60,25 @@
                     <div class="col-12">
                         <div class="card">
                             <div class="card-header">
+                                <h3 class="card-title">6. Список отчётов Ozon</h3>
+                                <div class="card-subtitle text-muted">
+                                    Инвентаризация всех заказанных отчётов — видно висящие
+                                    UUID'ы в NOT_STARTED/IN_PROGRESS, которых нет в нашей БД.
+                                </div>
+                            </div>
+                            <div class="card-body">
+                                <button type="button" class="btn btn-primary" id="btn-fetch-reports-list">
+                                    Получить список отчётов
+                                </button>
+                                <div class="mt-2" id="reports-list-summary"></div>
+                            </div>
+                            <pre id="result-reports-list" class="debug-pre">—</pre>
+                        </div>
+                    </div>
+
+                    <div class="col-12">
+                        <div class="card">
+                            <div class="card-header">
                                 <h3 class="card-title">3. Запросить статистику</h3>
                             </div>
                             <div class="card-body">
@@ -247,6 +266,51 @@
                         } else {
                             lastCampaigns = [];
                             summary.textContent = '';
+                        }
+                    });
+                });
+            });
+
+            // ----- 6. Reports list -----
+            var QUEUE_WARNING_THRESHOLD = 3;
+            var QUEUE_PENDING_STATES = ['NOT_STARTED', 'IN_PROGRESS'];
+
+            document.getElementById('btn-fetch-reports-list').addEventListener('click', function (e) {
+                withBusy(e.currentTarget, function () {
+                    var url = '/api/marketplace-ads/admin/ozon/debug/statistics/list'
+                        + '?companyId=' + encodeURIComponent(companyId());
+                    return doFetch(url).then(function (res) {
+                        renderResult('result-reports-list', res.data, res.ok);
+                        var summary = document.getElementById('reports-list-summary');
+                        summary.innerHTML = '';
+                        if (!res.ok || !res.data || !res.data.states_breakdown) {
+                            return;
+                        }
+                        var states = res.data.states_breakdown || {};
+                        var total = res.data.total || 0;
+                        var totalBadge = document.createElement('span');
+                        totalBadge.className = 'badge bg-secondary me-2';
+                        totalBadge.textContent = 'Всего: ' + total;
+                        summary.appendChild(totalBadge);
+                        Object.keys(states).forEach(function (state) {
+                            var count = states[state];
+                            var badge = document.createElement('span');
+                            var isPending = QUEUE_PENDING_STATES.indexOf(state) !== -1;
+                            var isWarning = isPending && count >= QUEUE_WARNING_THRESHOLD;
+                            badge.className = 'badge me-2 '
+                                + (isWarning ? 'bg-danger' : (isPending ? 'bg-warning' : 'bg-success'));
+                            badge.textContent = state + ': ' + count;
+                            summary.appendChild(badge);
+                        });
+                        var anyWarning = QUEUE_PENDING_STATES.some(function (s) {
+                            return (states[s] || 0) >= QUEUE_WARNING_THRESHOLD;
+                        });
+                        if (anyWarning) {
+                            var note = document.createElement('div');
+                            note.className = 'text-danger mt-2';
+                            note.textContent = 'Очередь Ozon выглядит забитой ('
+                                + QUEUE_WARNING_THRESHOLD + '+ отчётов в NOT_STARTED/IN_PROGRESS).';
+                            summary.appendChild(note);
                         }
                     });
                 });

--- a/site/templates/marketplace_ads/admin_debug.html.twig
+++ b/site/templates/marketplace_ads/admin_debug.html.twig
@@ -277,8 +277,12 @@
 
             document.getElementById('btn-fetch-reports-list').addEventListener('click', function (e) {
                 withBusy(e.currentTarget, function () {
+                    // pageSize=1000 — верхний предел Ozon, чтобы за один запрос увидеть
+                    // максимум очереди без UI-пагинации (UI-пагинация здесь избыточна
+                    // для ad-hoc debug).
                     var url = '/api/marketplace-ads/admin/ozon/debug/statistics/list'
-                        + '?companyId=' + encodeURIComponent(companyId());
+                        + '?companyId=' + encodeURIComponent(companyId())
+                        + '&pageSize=1000';
                     return doFetch(url).then(function (res) {
                         renderResult('result-reports-list', res.data, res.ok);
                         var summary = document.getElementById('reports-list-summary');
@@ -288,9 +292,12 @@
                         }
                         var states = res.data.states_breakdown || {};
                         var total = res.data.total || 0;
+                        var pageCount = res.data.page_items_count || 0;
                         var totalBadge = document.createElement('span');
                         totalBadge.className = 'badge bg-secondary me-2';
-                        totalBadge.textContent = 'Всего: ' + total;
+                        totalBadge.textContent = (total > pageCount)
+                            ? ('Всего в Ozon: ' + total + ' (на этой странице: ' + pageCount + ')')
+                            : ('Всего: ' + total);
                         summary.appendChild(totalBadge);
                         Object.keys(states).forEach(function (state) {
                             var count = states[state];

--- a/site/tests/Integration/MarketplaceAds/Controller/Api/Admin/OzonDebugControllerTest.php
+++ b/site/tests/Integration/MarketplaceAds/Controller/Api/Admin/OzonDebugControllerTest.php
@@ -24,6 +24,7 @@ final class OzonDebugControllerTest extends WebTestCaseBase
 
     private const URL_TOKEN = '/api/marketplace-ads/admin/ozon/debug/token';
     private const URL_CAMPAIGNS = '/api/marketplace-ads/admin/ozon/debug/campaigns';
+    private const URL_STATS_LIST = '/api/marketplace-ads/admin/ozon/debug/statistics/list';
     private const URL_STATS_REQUEST = '/api/marketplace-ads/admin/ozon/debug/statistics/request';
     private const URL_STATS_STATUS = '/api/marketplace-ads/admin/ozon/debug/statistics/status';
     private const URL_STATS_DOWNLOAD = '/api/marketplace-ads/admin/ozon/debug/statistics/download';
@@ -112,6 +113,56 @@ final class OzonDebugControllerTest extends WebTestCaseBase
         $this->loginAs($client, $owner);
 
         $client->request('GET', self::URL_CAMPAIGNS.'?companyId='.self::COMPANY_ID);
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testStatisticsListHappyPath(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $this->setHttpClient($client, [
+            new MockResponse(json_encode([
+                'access_token' => 'TKN-list',
+                'expires_in' => 1800,
+            ], \JSON_THROW_ON_ERROR)),
+            new MockResponse(json_encode([
+                'items' => [
+                    ['UUID' => 'uuid-1', 'state' => 'OK'],
+                    ['UUID' => 'uuid-2', 'state' => 'NOT_STARTED'],
+                    ['UUID' => 'uuid-3', 'state' => 'IN_PROGRESS'],
+                    ['UUID' => 'uuid-4', 'state' => 'IN_PROGRESS'],
+                ],
+                'total' => 4,
+            ], \JSON_THROW_ON_ERROR)),
+        ]);
+
+        $admin = $this->seedAdminAndCompany();
+        $this->loginAs($client, $admin);
+
+        $client->request('GET', self::URL_STATS_LIST.'?companyId='.self::COMPANY_ID);
+
+        self::assertResponseIsSuccessful();
+        $data = $this->decode($client);
+        self::assertSame(self::COMPANY_ID, $data['companyId']);
+        self::assertSame(200, $data['status_code']);
+        self::assertSame(4, $data['total']);
+        self::assertSame(
+            ['OK' => 1, 'NOT_STARTED' => 1, 'IN_PROGRESS' => 2],
+            $data['states_breakdown'],
+        );
+        self::assertCount(4, $data['items']);
+        self::assertSame('uuid-1', $data['items'][0]['UUID']);
+    }
+
+    public function testStatisticsListRequires403WithoutSuperAdmin(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $owner = $this->seedCompanyOwnerOnly();
+        $this->loginAs($client, $owner);
+
+        $client->request('GET', self::URL_STATS_LIST.'?companyId='.self::COMPANY_ID);
 
         self::assertResponseStatusCodeSame(403);
     }

--- a/site/tests/Integration/MarketplaceAds/Controller/Api/Admin/OzonDebugControllerTest.php
+++ b/site/tests/Integration/MarketplaceAds/Controller/Api/Admin/OzonDebugControllerTest.php
@@ -133,7 +133,7 @@ final class OzonDebugControllerTest extends WebTestCaseBase
                     ['UUID' => 'uuid-3', 'state' => 'IN_PROGRESS'],
                     ['UUID' => 'uuid-4', 'state' => 'IN_PROGRESS'],
                 ],
-                'total' => 4,
+                'total' => 127,
             ], \JSON_THROW_ON_ERROR)),
         ]);
 
@@ -146,13 +146,43 @@ final class OzonDebugControllerTest extends WebTestCaseBase
         $data = $this->decode($client);
         self::assertSame(self::COMPANY_ID, $data['companyId']);
         self::assertSame(200, $data['status_code']);
-        self::assertSame(4, $data['total']);
+        // total из Ozon (полная очередь), не count($items) первой страницы
+        self::assertSame(127, $data['total']);
+        self::assertSame(4, $data['page_items_count']);
         self::assertSame(
             ['OK' => 1, 'NOT_STARTED' => 1, 'IN_PROGRESS' => 2],
             $data['states_breakdown'],
         );
         self::assertCount(4, $data['items']);
         self::assertSame('uuid-1', $data['items'][0]['UUID']);
+    }
+
+    public function testStatisticsListFallsBackToItemsCountWhenNoTotalInResponse(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $this->setHttpClient($client, [
+            new MockResponse(json_encode([
+                'access_token' => 'TKN-list-2',
+                'expires_in' => 1800,
+            ], \JSON_THROW_ON_ERROR)),
+            new MockResponse(json_encode([
+                'items' => [
+                    ['UUID' => 'uuid-a', 'state' => 'OK'],
+                    ['UUID' => 'uuid-b', 'state' => 'OK'],
+                ],
+            ], \JSON_THROW_ON_ERROR)),
+        ]);
+
+        $admin = $this->seedAdminAndCompany();
+        $this->loginAs($client, $admin);
+
+        $client->request('GET', self::URL_STATS_LIST.'?companyId='.self::COMPANY_ID);
+
+        self::assertResponseIsSuccessful();
+        $data = $this->decode($client);
+        self::assertSame(2, $data['total']);
+        self::assertSame(2, $data['page_items_count']);
     }
 
     public function testStatisticsListRequires403WithoutSuperAdmin(): void


### PR DESCRIPTION
## Summary
- Добавлен 6-й debug endpoint `GET /api/marketplace-ads/admin/ozon/debug/statistics/list` для инвентаризации всех заказанных отчётов Ozon Performance — даёт видимость зомби-UUID'ов в `NOT_STARTED`/`IN_PROGRESS`, которых нет в нашей БД, но которые продолжают занимать слоты очереди Ozon.
- `OzonDebugFetcher::listReports()` проксирует `GET /api/client/statistics/list` с `page`/`pageSize` query-параметрами; нормализует ответ в `{items, total, states_breakdown, raw_body}`.
- Новый блок 6 «Список отчётов Ozon» в `admin_debug.html.twig` между блоками 2 (кампании) и 3 (запросить статистику) — логичный flow «выбрать компанию → проверить очередь → только потом запрашивать новый отчёт». Цветные badges по state + warning, если 3+ отчётов висят в `NOT_STARTED`/`IN_PROGRESS`.
- Только `ROLE_SUPER_ADMIN`, не создаёт ничего в БД, не трогает async-пайплайн.

## Границы
- Нет cancel/abandon UUID (в API Ozon отсутствует)
- Endpoint не используется async-пайплайном
- Ничего не сохраняется в БД — только ad-hoc просмотр

## Test plan
- [ ] `testStatisticsListHappyPath` — проверяет `states_breakdown`, `total`, items + верхний уровень JSON-ответа
- [ ] `testStatisticsListRequires403WithoutSuperAdmin` — 403 для не-SUPER_ADMIN
- [ ] Ручная проверка UI: выбрать компанию → кнопка «Получить список отчётов» → увидеть цветные badges по state; при 3+ `IN_PROGRESS` — красный алерт

https://claude.ai/code/session_01GsNzwXDbv1t69HxDLeKkWQ