### PR TITLE
feat(MarketplaceAds): persist Ozon report UUID + IDOR-safe polling

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -56,6 +56,7 @@
 | `AdDocumentLine` | MarketplaceAds | `string $companyId` ✅ |
 | `AdLoadJob` | MarketplaceAds | `string $companyId` ✅ |
 | `AdChunkProgress` | MarketplaceAds | через `jobId` (IDOR через AdLoadJob) |
+| `OzonAdPendingReport` | MarketplaceAds | `string $companyId` ✅ |
 | `ProductImport` | Catalog | `string $companyId` ✅ |
 | `ProductBarcode` | Catalog | `string $companyId` ✅ |
 | `ProductPurchasePrice` | Catalog | `string $companyId` ✅ |
@@ -128,6 +129,32 @@
 | `completedAt` | `DateTimeImmutable` | Время фиксации успеха |
 
 **Уникальность:** `UniqueConstraint` по `(job_id, date_from, date_to)` — делает фиксацию чанка идемпотентной на уровне БД. При Messenger-retry `FetchOzonAdStatisticsHandler` тот же чанк упрётся в uq-нарушение и не приведёт к двойному инкременту `loadedDays`.
+
+### `OzonAdPendingReport` — поля
+
+Таблица `marketplace_ad_pending_reports`. Фиксирует каждый запрошенный у Ozon
+Performance отчёт: UUID сохраняется ДО polling'а, что делает любой сбой
+pipeline'а (timeout, рестарт worker'а, exception) видимым для диагностики и
+даёт точку отталкивания для будущей resume-логики (задача 3).
+
+| Поле | Тип | Описание |
+|---|---|---|
+| `id` | `string` (UUID v7) | PK |
+| `companyId` | `string` (UUID) | Неизменяем, без setter |
+| `ozonUuid` | `string` | UUID отчёта в Ozon Performance (`POST /api/client/statistics.UUID`). Уникален |
+| `jobId` | `?string` (UUID) | Ссылка на `AdLoadJob`, если отчёт запрошен range-пайплайном; `null` для legacy `fetchAdStatistics()` |
+| `dateFrom` / `dateTo` | `DateTimeImmutable` | Диапазон отчёта |
+| `campaignIds` | `list<string>` | campaign IDs, отправленные в `POST /statistics` (jsonb) |
+| `state` | `string` | Canonical state из {@see OzonAdPendingReportState} |
+| `pollAttempts` | `int` | Счётчик итераций polling'а (обновляется raw DBAL) |
+| `lastCheckedAt` | `?DateTimeImmutable` | Время последней итерации |
+| `firstNonPendingAt` | `?DateTimeImmutable` | Первая итерация, на которой state сошёл с `NOT_STARTED`; фиксируется один раз (COALESCE-guard в Repository) |
+| `finalizedAt` | `?DateTimeImmutable` | Выставляется один раз при `markFinalized`; guard против повторной терминализации |
+| `errorMessage` | `?string` | Диагностика для state=ERROR / ABANDONED |
+| `requestedAt` | `DateTimeImmutable` | Время создания записи |
+| `createdAt` / `updatedAt` | `DateTimeImmutable` | — |
+
+**Уникальность:** `UniqueConstraint` по `ozon_uuid`. Индексы: `company_id`, `job_id`, `state`.
 
 ---
 
@@ -377,6 +404,57 @@ findByCompanyMarketplaceAndDateRange(
 ): array
 ```
 
+### `OzonAdPendingReportRepository` (`src/MarketplaceAds/Repository/OzonAdPendingReportRepository.php`)
+```php
+// Сохраняет запись о запрошенном отчёте (state = REQUESTED) + flush.
+// flush() намеренно внутри — caller (OzonAdClient::requestStatistics()) не должен
+// откладывать UoW: последующие шаги polling могут упасть, и без немедленного
+// сохранения UUID потеряется.
+// ВНИМАНИЕ: flush сбрасывает весь UoW — не держите грязные сущности в момент вызова.
+create(
+    string $companyId,
+    string $ozonUuid,
+    \DateTimeImmutable $dateFrom,
+    \DateTimeImmutable $dateTo,
+    array $campaignIds,
+    ?string $jobId,
+): OzonAdPendingReport
+
+// Инкрементально обновляет state/lastCheckedAt/pollAttempts (raw DBAL, минуя UoW).
+// firstNonPendingAt фиксируется через COALESCE — повторная передача не перезаписывает.
+// companyId в WHERE — defense-in-depth против IDOR (ozon_uuid сам по себе уникален,
+// но проверка company обязательна на каждой операции записи).
+// @return int число обновлённых строк (0 — ozonUuid не найден в company)
+updateState(
+    string $companyId,
+    string $ozonUuid,
+    string $state,
+    \DateTimeImmutable $lastCheckedAt,
+    int $pollAttempts,
+    ?\DateTimeImmutable $firstNonPendingAt = null,
+): int
+
+// Идемпотентный terminal-переход (state ∈ {OK, ERROR, ABANDONED}).
+// Guard `finalized_at IS NULL` не даёт перезаписать уже финализированную запись
+// (параллельный worker, пришедший позже к другому state, не стирает исходный).
+// @return int число обновлённых строк (0 — uuid не найден / уже финализирован)
+markFinalized(
+    string $companyId,
+    string $ozonUuid,
+    string $state,
+    ?string $errorMessage = null,
+): int
+
+// Загрузка с IDOR-проверкой
+findByOzonUuid(string $companyId, string $ozonUuid): ?OzonAdPendingReport
+
+// Все in-flight (REQUESTED / NOT_STARTED / IN_PROGRESS) записи конкретного job'а.
+// Для resume-логики (задача 3): Messenger-retry handler получает список UUID,
+// по которым нужно продолжать polling вместо нового POST /statistics.
+// @return list<OzonAdPendingReport>
+findInFlightByJob(string $companyId, string $jobId): array
+```
+
 ---
 
 ## Enum — актуальные значения
@@ -568,6 +646,32 @@ enum AdLoadJobStatus: string
     case FAILED    = 'failed';
 
     public function isTerminal(): bool; // true для COMPLETED, FAILED
+}
+```
+
+### `src/MarketplaceAds/Enum/OzonAdPendingReportState.php`
+```php
+// Canonical state для записей marketplace_ad_pending_reports.
+// Реализовано как final class с константами, а не PHP enum: исходные raw-значения
+// Ozon API (NOT_STARTED / IN_PROGRESS / OK / READY / ERROR / CANCELLED / NOT_FOUND)
+// приходят в state как есть, и clean-mapping «raw → canonical» выполняется в
+// OzonAdClient::pollReport(). Canonical набор:
+final class OzonAdPendingReportState
+{
+    public const REQUESTED   = 'REQUESTED';
+    public const NOT_STARTED = 'NOT_STARTED';
+    public const IN_PROGRESS = 'IN_PROGRESS';
+    public const OK          = 'OK';
+    public const ERROR       = 'ERROR';
+    public const ABANDONED   = 'ABANDONED';
+
+    // Состояния, в которых запись ещё не финализирована (finalized_at IS NULL).
+    public const IN_FLIGHT_STATES = ['REQUESTED', 'NOT_STARTED', 'IN_PROGRESS'];
+
+    // Терминальные: markFinalized() принимает только эти.
+    public const TERMINAL_STATES = ['OK', 'ERROR', 'ABANDONED'];
+
+    public static function isTerminal(string $state): bool;
 }
 ```
 

--- a/site/migrations/Version20260420120000.php
+++ b/site/migrations/Version20260420120000.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * MarketplaceAds: persistence для запрошенных отчётов Ozon Performance.
+ *
+ * Создаёт marketplace_ad_pending_reports — хранит UUID отчёта, запрошенного
+ * у Ozon Performance POST /api/client/statistics, вместе с контекстом запроса
+ * (company_id, date range, campaign_ids, привязанный AdLoadJob) и живым
+ * состоянием polling'а (state, poll_attempts, first_non_pending_at,
+ * last_checked_at, finalized_at, error_message).
+ *
+ * Цель: UUID не теряется при exception mid-polling, а каждая итерация
+ * pollReport фиксирует state/attempt в БД (было — только в локальной
+ * переменной процесса).
+ *
+ * Индексы:
+ *  - idx_ad_pending_report_company — отчёты конкретной компании;
+ *  - idx_ad_pending_report_job     — связь с AdLoadJob (resume on retry);
+ *  - idx_ad_pending_report_state   — поиск in-flight / abandoned записей;
+ *  - uq_ad_pending_report_ozon_uuid — UNIQUE на ozon_uuid (один UUID = одна запись).
+ */
+final class Version20260420120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'MarketplaceAds: create marketplace_ad_pending_reports for Ozon report UUID persistence';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE marketplace_ad_pending_reports (
+                id UUID NOT NULL,
+                company_id UUID NOT NULL,
+                ozon_uuid VARCHAR(64) NOT NULL,
+                date_from DATE NOT NULL,
+                date_to DATE NOT NULL,
+                campaign_ids JSON NOT NULL,
+                state VARCHAR(32) NOT NULL,
+                job_id UUID DEFAULT NULL,
+                requested_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                last_checked_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+                first_non_pending_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+                poll_attempts INT NOT NULL DEFAULT 0,
+                finalized_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+                error_message TEXT DEFAULT NULL,
+                created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                PRIMARY KEY (id)
+            )
+            SQL);
+        $this->addSql('CREATE UNIQUE INDEX uq_ad_pending_report_ozon_uuid ON marketplace_ad_pending_reports (ozon_uuid)');
+        $this->addSql('CREATE INDEX idx_ad_pending_report_company ON marketplace_ad_pending_reports (company_id)');
+        $this->addSql('CREATE INDEX idx_ad_pending_report_job ON marketplace_ad_pending_reports (job_id)');
+        $this->addSql('CREATE INDEX idx_ad_pending_report_state ON marketplace_ad_pending_reports (state)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE marketplace_ad_pending_reports');
+    }
+}

--- a/site/src/MarketplaceAds/Entity/OzonAdPendingReport.php
+++ b/site/src/MarketplaceAds/Entity/OzonAdPendingReport.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Entity;
+
+use App\MarketplaceAds\Enum\OzonAdPendingReportState;
+use App\MarketplaceAds\Repository\OzonAdPendingReportRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
+use Webmozart\Assert\Assert;
+
+/**
+ * Персистентный след одного отчёта Ozon Performance, запрошенного через
+ * POST /api/client/statistics.
+ *
+ * Создаётся {@see \App\MarketplaceAds\Infrastructure\Api\Ozon\OzonAdClient}
+ * сразу после получения UUID от Ozon (ещё до первого polling-шага), чтобы
+ * при любом последующем exception / таймауте / рестарте воркера сам UUID
+ * и контекст запроса (companyId, диапазон дат, campaignIds, привязанный
+ * AdLoadJob) не потерялись в локальной переменной PHP-процесса.
+ *
+ * На каждой итерации polling клиент обновляет state / lastCheckedAt /
+ * pollAttempts / firstNonPendingAt — это даёт диагностику «почему отчёт
+ * завис в NOT_STARTED 3 минуты» и служит базой для будущей логики
+ * восстановления (задача 3: resume on Messenger retry).
+ *
+ * Колонка state — VARCHAR с канон-значениями из
+ * {@see OzonAdPendingReportState}. Строка, а не enumType, чтобы Ozon-
+ * специфичные значения (например, неизвестный state из будущего API)
+ * можно было залогировать без миграции.
+ */
+#[ORM\Entity(repositoryClass: OzonAdPendingReportRepository::class)]
+#[ORM\Table(name: 'marketplace_ad_pending_reports')]
+#[ORM\Index(columns: ['company_id'], name: 'idx_ad_pending_report_company')]
+#[ORM\Index(columns: ['job_id'], name: 'idx_ad_pending_report_job')]
+#[ORM\Index(columns: ['state'], name: 'idx_ad_pending_report_state')]
+#[ORM\UniqueConstraint(
+    name: 'uq_ad_pending_report_ozon_uuid',
+    columns: ['ozon_uuid'],
+)]
+class OzonAdPendingReport
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid', unique: true)]
+    private string $id;
+
+    #[ORM\Column(type: 'guid')]
+    private string $companyId;
+
+    #[ORM\Column(type: 'string', length: 64)]
+    private string $ozonUuid;
+
+    #[ORM\Column(type: 'date_immutable')]
+    private \DateTimeImmutable $dateFrom;
+
+    #[ORM\Column(type: 'date_immutable')]
+    private \DateTimeImmutable $dateTo;
+
+    /**
+     * @var list<string>
+     */
+    #[ORM\Column(type: 'json')]
+    private array $campaignIds;
+
+    #[ORM\Column(type: 'string', length: 32)]
+    private string $state;
+
+    #[ORM\Column(type: 'guid', nullable: true)]
+    private ?string $jobId = null;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $requestedAt;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $lastCheckedAt = null;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $firstNonPendingAt = null;
+
+    #[ORM\Column(type: 'integer', options: ['default' => 0])]
+    private int $pollAttempts = 0;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $finalizedAt = null;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $errorMessage = null;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $updatedAt;
+
+    /**
+     * @param list<string> $campaignIds
+     */
+    public function __construct(
+        string $companyId,
+        string $ozonUuid,
+        \DateTimeImmutable $dateFrom,
+        \DateTimeImmutable $dateTo,
+        array $campaignIds,
+        ?string $jobId = null,
+    ) {
+        $this->id = Uuid::uuid7()->toString();
+        Assert::uuid($this->id);
+        Assert::uuid($companyId);
+        Assert::notEmpty($ozonUuid, 'ozonUuid не может быть пустым.');
+        if (null !== $jobId) {
+            Assert::uuid($jobId);
+        }
+
+        $dateFrom = $dateFrom->setTime(0, 0);
+        $dateTo = $dateTo->setTime(0, 0);
+
+        if ($dateFrom > $dateTo) {
+            throw new \DomainException('dateFrom не может быть позже dateTo.');
+        }
+
+        $this->companyId = $companyId;
+        $this->ozonUuid = $ozonUuid;
+        $this->dateFrom = $dateFrom;
+        $this->dateTo = $dateTo;
+        $this->campaignIds = array_values($campaignIds);
+        $this->jobId = $jobId;
+        $this->state = OzonAdPendingReportState::REQUESTED;
+        $now = new \DateTimeImmutable();
+        $this->requestedAt = $now;
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getCompanyId(): string
+    {
+        return $this->companyId;
+    }
+
+    public function getOzonUuid(): string
+    {
+        return $this->ozonUuid;
+    }
+
+    public function getDateFrom(): \DateTimeImmutable
+    {
+        return $this->dateFrom;
+    }
+
+    public function getDateTo(): \DateTimeImmutable
+    {
+        return $this->dateTo;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getCampaignIds(): array
+    {
+        return $this->campaignIds;
+    }
+
+    public function getState(): string
+    {
+        return $this->state;
+    }
+
+    public function getJobId(): ?string
+    {
+        return $this->jobId;
+    }
+
+    public function getRequestedAt(): \DateTimeImmutable
+    {
+        return $this->requestedAt;
+    }
+
+    public function getLastCheckedAt(): ?\DateTimeImmutable
+    {
+        return $this->lastCheckedAt;
+    }
+
+    public function getFirstNonPendingAt(): ?\DateTimeImmutable
+    {
+        return $this->firstNonPendingAt;
+    }
+
+    public function getPollAttempts(): int
+    {
+        return $this->pollAttempts;
+    }
+
+    public function getFinalizedAt(): ?\DateTimeImmutable
+    {
+        return $this->finalizedAt;
+    }
+
+    public function getErrorMessage(): ?string
+    {
+        return $this->errorMessage;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+}

--- a/site/src/MarketplaceAds/Enum/OzonAdPendingReportState.php
+++ b/site/src/MarketplaceAds/Enum/OzonAdPendingReportState.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Enum;
+
+/**
+ * Логические состояния записи {@see \App\MarketplaceAds\Entity\OzonAdPendingReport}.
+ *
+ * Реализовано как константный класс, а не PHP-enum: колонка state хранит строку
+ * (VARCHAR), чтобы Ozon-специфичные или неожиданные значения, пришедшие из
+ * GET /api/client/statistics/{uuid}, можно было залогировать в БД без миграции.
+ *
+ * Канонические значения:
+ *  - REQUESTED    — POST /statistics прошёл, UUID выдан, polling ещё не начинался.
+ *  - NOT_STARTED  — Ozon получил запрос, но отчёт ещё в очереди (проброс как есть).
+ *  - IN_PROGRESS  — Ozon начал формировать отчёт (проброс как есть).
+ *  - OK           — отчёт готов (Ozon OK/READY → нормализуем в OK).
+ *  - ERROR        — Ozon вернул ERROR/CANCELLED/NOT_FOUND.
+ *  - ABANDONED    — наш polling исчерпал POLL_MAX_ATTEMPTS, отчёт брошен.
+ */
+final class OzonAdPendingReportState
+{
+    public const REQUESTED = 'REQUESTED';
+    public const NOT_STARTED = 'NOT_STARTED';
+    public const IN_PROGRESS = 'IN_PROGRESS';
+    public const OK = 'OK';
+    public const ERROR = 'ERROR';
+    public const ABANDONED = 'ABANDONED';
+
+    /**
+     * Терминальные состояния — запись финализирована, polling завершён.
+     */
+    public const TERMINAL_STATES = [
+        self::OK,
+        self::ERROR,
+        self::ABANDONED,
+    ];
+
+    /**
+     * In-flight состояния — отчёт ещё не завершён, handler может восстановить
+     * polling. Используется {@see \App\MarketplaceAds\Repository\OzonAdPendingReportRepository::findInFlightByJob()}.
+     */
+    public const IN_FLIGHT_STATES = [
+        self::REQUESTED,
+        self::NOT_STARTED,
+        self::IN_PROGRESS,
+    ];
+
+    private function __construct()
+    {
+    }
+
+    public static function isTerminal(string $state): bool
+    {
+        return in_array($state, self::TERMINAL_STATES, true);
+    }
+}

--- a/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
+++ b/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
@@ -165,7 +165,7 @@ class OzonAdClient implements AdPlatformClientInterface
                 $companyId,
                 $clientId,
                 $clientSecret,
-                fn (string $token): string => $this->pollReport($token, $uuid),
+                fn (string $token): string => $this->pollReport($token, $companyId, $uuid),
             );
 
             $download = $this->withAuthRetry(
@@ -287,7 +287,7 @@ class OzonAdClient implements AdPlatformClientInterface
                     $companyId,
                     $clientId,
                     $clientSecret,
-                    fn (string $token): string => $this->pollReport($token, $uuid),
+                    fn (string $token): string => $this->pollReport($token, $companyId, $uuid),
                 );
                 // pollReport не возвращает attempts, чтобы не ломать публичную
                 // сигнатуру — счётчик читаем через $this->lastPollAttempts и
@@ -652,7 +652,7 @@ class OzonAdClient implements AdPlatformClientInterface
     /**
      * @return string ссылка на готовый отчёт (CSV)
      */
-    private function pollReport(string $token, string $uuid): string
+    private function pollReport(string $token, string $companyId, string $uuid): string
     {
         $startedAt = microtime(true);
 
@@ -682,6 +682,7 @@ class OzonAdClient implements AdPlatformClientInterface
             // COALESCE в updateState() защищает от перезаписи уже установленного timestamp.
             $firstNonPendingAt = ('' !== $state && 'NOT_STARTED' !== $state) ? $now : null;
             $this->pendingReportRepo->updateState(
+                $companyId,
                 $uuid,
                 $state,
                 $now,
@@ -697,7 +698,7 @@ class OzonAdClient implements AdPlatformClientInterface
                     $link = self::STATISTICS_REPORT_PATH.'?UUID='.rawurlencode($uuid);
                 }
 
-                $this->pendingReportRepo->markFinalized($uuid, OzonAdPendingReportState::OK);
+                $this->pendingReportRepo->markFinalized($companyId, $uuid, OzonAdPendingReportState::OK);
 
                 $this->marketplaceAdsLogger->info('Ozon Performance: отчёт готов', [
                     'reportUuid' => $uuid,
@@ -717,6 +718,7 @@ class OzonAdClient implements AdPlatformClientInterface
                 );
 
                 $this->pendingReportRepo->markFinalized(
+                    $companyId,
                     $uuid,
                     OzonAdPendingReportState::ERROR,
                     $errorMessage,
@@ -730,6 +732,7 @@ class OzonAdClient implements AdPlatformClientInterface
 
         $timeoutSeconds = self::POLL_MAX_ATTEMPTS * self::POLL_INTERVAL_SECONDS;
         $this->pendingReportRepo->markFinalized(
+            $companyId,
             $uuid,
             OzonAdPendingReportState::ABANDONED,
             sprintf('Polling timeout after %d seconds', $timeoutSeconds),

--- a/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
+++ b/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
@@ -7,7 +7,9 @@ namespace App\MarketplaceAds\Infrastructure\Api\Ozon;
 use App\Marketplace\Enum\MarketplaceConnectionType;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Facade\MarketplaceFacade;
+use App\MarketplaceAds\Enum\OzonAdPendingReportState;
 use App\MarketplaceAds\Infrastructure\Api\Contract\AdPlatformClientInterface;
+use App\MarketplaceAds\Repository\OzonAdPendingReportRepository;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Contracts\Cache\CacheInterface;
@@ -89,6 +91,7 @@ class OzonAdClient implements AdPlatformClientInterface
         private readonly LoggerInterface $logger,
         #[Autowire(service: 'monolog.logger.marketplace_ads')]
         private readonly LoggerInterface $marketplaceAdsLogger,
+        private readonly OzonAdPendingReportRepository $pendingReportRepo,
     ) {
     }
 
@@ -141,7 +144,15 @@ class OzonAdClient implements AdPlatformClientInterface
                 $companyId,
                 $clientId,
                 $clientSecret,
-                fn (string $token): string => $this->requestStatistics($token, $campaignIds, $date, $date, 'NO_GROUP_BY'),
+                fn (string $token): string => $this->requestStatistics(
+                    $token,
+                    $companyId,
+                    $campaignIds,
+                    $date,
+                    $date,
+                    'NO_GROUP_BY',
+                    null,
+                ),
             );
 
             $this->marketplaceAdsLogger->info('Ozon Performance: запрошен отчёт', [
@@ -200,6 +211,7 @@ class OzonAdClient implements AdPlatformClientInterface
         string $companyId,
         \DateTimeImmutable $dateFrom,
         \DateTimeImmutable $dateTo,
+        ?string $jobId = null,
     ): array {
         $this->lastChunkDownloads = [];
 
@@ -254,7 +266,15 @@ class OzonAdClient implements AdPlatformClientInterface
                     $companyId,
                     $clientId,
                     $clientSecret,
-                    fn (string $token): string => $this->requestStatistics($token, $campaignIds, $dateFrom, $dateTo, 'DATE'),
+                    fn (string $token): string => $this->requestStatistics(
+                        $token,
+                        $companyId,
+                        $campaignIds,
+                        $dateFrom,
+                        $dateTo,
+                        'DATE',
+                        $jobId,
+                    ),
                 );
 
                 $this->marketplaceAdsLogger->info('Ozon Performance: запрошен отчёт (range)', [
@@ -575,10 +595,12 @@ class OzonAdClient implements AdPlatformClientInterface
      */
     private function requestStatistics(
         string $token,
+        string $companyId,
         array $campaignIds,
         \DateTimeImmutable $dateFrom,
         \DateTimeImmutable $dateTo,
         string $groupBy,
+        ?string $jobId,
     ): string {
         // Caller передаёт DateTimeImmutable в своей TZ (в проде date.timezone=Europe/Moscow).
         // Ozon ждёт google.protobuf.Timestamp (RFC3339 в UTC), поэтому сначала фиксируем
@@ -612,6 +634,18 @@ class OzonAdClient implements AdPlatformClientInterface
             throw new \RuntimeException('Ozon Performance: ответ /statistics не содержит UUID');
         }
 
+        // Persist UUID сразу (persist + flush внутри create()), до любого polling'а —
+        // если следующий шаг упадёт exception'ом / таймаутом / рестартом воркера,
+        // запись останется в БД как видимая точка диагностики и база для resume-логики.
+        $this->pendingReportRepo->create(
+            companyId: $companyId,
+            ozonUuid: $uuid,
+            dateFrom: $dateFrom,
+            dateTo: $dateTo,
+            campaignIds: $campaignIds,
+            jobId: $jobId,
+        );
+
         return $uuid;
     }
 
@@ -632,6 +666,29 @@ class OzonAdClient implements AdPlatformClientInterface
             $data = $this->decodeJson($response->getContent(false), 'statistics state');
 
             $state = $this->stringifyApiField($data['state'] ?? null);
+            $now = new \DateTimeImmutable();
+            $waitedSeconds = round(microtime(true) - $startedAt, 1);
+
+            $this->marketplaceAdsLogger->info('Ozon poll iteration', [
+                'reportUuid' => $uuid,
+                'attempt' => $attempt,
+                'state' => $state,
+                'waitedSeconds' => $waitedSeconds,
+            ]);
+
+            // firstNonPendingAt фиксируется, как только отчёт сошёл с «NOT_STARTED»:
+            // IN_PROGRESS, OK/READY, ERROR/CANCELLED/NOT_FOUND и любой неизвестный
+            // не-пустой state — все означают, что Ozon начал работать с отчётом.
+            // COALESCE в updateState() защищает от перезаписи уже установленного timestamp.
+            $firstNonPendingAt = ('' !== $state && 'NOT_STARTED' !== $state) ? $now : null;
+            $this->pendingReportRepo->updateState(
+                $uuid,
+                $state,
+                $now,
+                $attempt,
+                $firstNonPendingAt,
+            );
+
             if ('OK' === $state || 'READY' === $state) {
                 $link = $this->stringifyApiField($data['link'] ?? $data['report']['link'] ?? null);
                 if ('' === $link) {
@@ -640,28 +697,45 @@ class OzonAdClient implements AdPlatformClientInterface
                     $link = self::STATISTICS_REPORT_PATH.'?UUID='.rawurlencode($uuid);
                 }
 
+                $this->pendingReportRepo->markFinalized($uuid, OzonAdPendingReportState::OK);
+
                 $this->marketplaceAdsLogger->info('Ozon Performance: отчёт готов', [
                     'reportUuid' => $uuid,
                     'attempts' => $attempt,
-                    'waitedSeconds' => round(microtime(true) - $startedAt, 1),
+                    'waitedSeconds' => $waitedSeconds,
                 ]);
 
                 return $link;
             }
 
             if ('ERROR' === $state || 'CANCELLED' === $state || 'NOT_FOUND' === $state) {
-                throw new \RuntimeException(sprintf(
+                $errorMessage = sprintf(
                     'Ozon Performance: отчёт %s завершился со статусом %s: %s',
                     $uuid,
                     $state,
                     $this->stringifyApiField($data['error'] ?? null),
-                ));
+                );
+
+                $this->pendingReportRepo->markFinalized(
+                    $uuid,
+                    OzonAdPendingReportState::ERROR,
+                    $errorMessage,
+                );
+
+                throw new \RuntimeException($errorMessage);
             }
 
             sleep(self::POLL_INTERVAL_SECONDS);
         }
 
-        throw new \RuntimeException(sprintf('Ozon Performance: отчёт %s не готов за %d секунд', $uuid, self::POLL_MAX_ATTEMPTS * self::POLL_INTERVAL_SECONDS));
+        $timeoutSeconds = self::POLL_MAX_ATTEMPTS * self::POLL_INTERVAL_SECONDS;
+        $this->pendingReportRepo->markFinalized(
+            $uuid,
+            OzonAdPendingReportState::ABANDONED,
+            sprintf('Polling timeout after %d seconds', $timeoutSeconds),
+        );
+
+        throw new \RuntimeException(sprintf('Ozon Performance: отчёт %s не готов за %d секунд', $uuid, $timeoutSeconds));
     }
 
     /**

--- a/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
@@ -137,6 +137,7 @@ final class FetchOzonAdStatisticsHandler
                 $message->companyId,
                 $dateFrom,
                 $dateTo,
+                $message->jobId,
             );
         } catch (\InvalidArgumentException $e) {
             // Диапазон > 62 дней или from > to — баг вызывающего кода,

--- a/site/src/MarketplaceAds/Repository/OzonAdPendingReportRepository.php
+++ b/site/src/MarketplaceAds/Repository/OzonAdPendingReportRepository.php
@@ -37,6 +37,13 @@ class OzonAdPendingReportRepository extends ServiceEntityRepository
      * в середине pipeline'а: последующие шаги (pollReport, downloadReport)
      * могут упасть, и без немедленного flush UUID не попадёт в БД.
      *
+     * ВНИМАНИЕ: flush() здесь сбрасывает ВЕСЬ Doctrine UoW, а не только эту
+     * entity. Вызывающий код не должен держать в UoW другие "грязные"
+     * сущности на момент вызова create() — иначе они попадут в БД
+     * непредвиденно. В контексте Messenger-handler'а это безопасно:
+     * FetchOzonAdStatisticsHandler пишет через отдельные Repository с raw
+     * DBAL и не накапливает UoW.
+     *
      * @param list<string> $campaignIds
      */
     public function create(
@@ -73,9 +80,14 @@ class OzonAdPendingReportRepository extends ServiceEntityRepository
      * Реализовано через raw DBAL: polling вызывается в цикле, persist/flush
      * здесь означал бы загрузку entity в UoW на каждой итерации.
      *
-     * @return int число обновлённых строк (0 — ozonUuid не найден)
+     * companyId в WHERE-clause — defense-in-depth против IDOR: даже если
+     * ozon_uuid уникален сам по себе, принадлежность к company проверяем
+     * на каждой операции записи.
+     *
+     * @return int число обновлённых строк (0 — ozonUuid не найден в этой company)
      */
     public function updateState(
+        string $companyId,
         string $ozonUuid,
         string $state,
         \DateTimeImmutable $lastCheckedAt,
@@ -93,12 +105,14 @@ class OzonAdPendingReportRepository extends ServiceEntityRepository
                         poll_attempts = :poll_attempts,
                         updated_at = NOW()
                     WHERE ozon_uuid = :ozon_uuid
+                      AND company_id = :company_id
                     SQL,
                 [
                     'state' => $state,
                     'last_checked_at' => $lastCheckedAt->format('Y-m-d H:i:s'),
                     'poll_attempts' => $pollAttempts,
                     'ozon_uuid' => $ozonUuid,
+                    'company_id' => $companyId,
                 ],
             );
         }
@@ -112,6 +126,7 @@ class OzonAdPendingReportRepository extends ServiceEntityRepository
                     first_non_pending_at = COALESCE(first_non_pending_at, :first_non_pending_at),
                     updated_at = NOW()
                 WHERE ozon_uuid = :ozon_uuid
+                  AND company_id = :company_id
                 SQL,
             [
                 'state' => $state,
@@ -119,6 +134,7 @@ class OzonAdPendingReportRepository extends ServiceEntityRepository
                 'poll_attempts' => $pollAttempts,
                 'first_non_pending_at' => $firstNonPendingAt->format('Y-m-d H:i:s'),
                 'ozon_uuid' => $ozonUuid,
+                'company_id' => $companyId,
             ],
         );
     }
@@ -131,10 +147,16 @@ class OzonAdPendingReportRepository extends ServiceEntityRepository
      * финализированную запись — параллельный воркер, который видел тот же
      * UUID и пришёл к OK позже, не стирает исходный ERROR/ABANDONED.
      *
-     * @return int число обновлённых строк (0 — uuid не найден или уже финализирован)
+     * companyId в WHERE-clause — defense-in-depth против IDOR (см. updateState).
+     *
+     * @return int число обновлённых строк (0 — uuid не найден в company, уже финализирован)
      */
-    public function markFinalized(string $ozonUuid, string $state, ?string $errorMessage = null): int
-    {
+    public function markFinalized(
+        string $companyId,
+        string $ozonUuid,
+        string $state,
+        ?string $errorMessage = null,
+    ): int {
         if (!OzonAdPendingReportState::isTerminal($state)) {
             throw new \InvalidArgumentException(sprintf(
                 'markFinalized принимает только терминальные state (OK/ERROR/ABANDONED), получено: %s',
@@ -150,19 +172,21 @@ class OzonAdPendingReportRepository extends ServiceEntityRepository
                     finalized_at = NOW(),
                     updated_at = NOW()
                 WHERE ozon_uuid = :ozon_uuid
+                  AND company_id = :company_id
                   AND finalized_at IS NULL
                 SQL,
             [
                 'state' => $state,
                 'error_message' => $errorMessage,
                 'ozon_uuid' => $ozonUuid,
+                'company_id' => $companyId,
             ],
         );
     }
 
-    public function findByOzonUuid(string $ozonUuid): ?OzonAdPendingReport
+    public function findByOzonUuid(string $companyId, string $ozonUuid): ?OzonAdPendingReport
     {
-        return $this->findOneBy(['ozonUuid' => $ozonUuid]);
+        return $this->findOneBy(['companyId' => $companyId, 'ozonUuid' => $ozonUuid]);
     }
 
     /**
@@ -173,13 +197,15 @@ class OzonAdPendingReportRepository extends ServiceEntityRepository
      *
      * @return list<OzonAdPendingReport>
      */
-    public function findInFlightByJob(string $jobId): array
+    public function findInFlightByJob(string $companyId, string $jobId): array
     {
         /** @var list<OzonAdPendingReport> $result */
         $result = $this->createQueryBuilder('r')
-            ->where('r.jobId = :jobId')
+            ->where('r.companyId = :companyId')
+            ->andWhere('r.jobId = :jobId')
             ->andWhere('r.state IN (:inFlightStates)')
             ->andWhere('r.finalizedAt IS NULL')
+            ->setParameter('companyId', $companyId)
             ->setParameter('jobId', $jobId)
             ->setParameter('inFlightStates', OzonAdPendingReportState::IN_FLIGHT_STATES)
             ->orderBy('r.requestedAt', 'ASC')

--- a/site/src/MarketplaceAds/Repository/OzonAdPendingReportRepository.php
+++ b/site/src/MarketplaceAds/Repository/OzonAdPendingReportRepository.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Repository;
+
+use App\MarketplaceAds\Entity\OzonAdPendingReport;
+use App\MarketplaceAds\Enum\OzonAdPendingReportState;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * Репозиторий записей о запрошенных отчётах Ozon Performance.
+ *
+ * {@see create()} сохраняет запись сразу (persist + flush), чтобы UUID был в БД
+ * ДО первой итерации polling'а — даже если handler упадёт на следующем шаге,
+ * зомби-UUID останется видимым для диагностики и будущей resume-логики.
+ *
+ * {@see updateState()} и {@see markFinalized()} идут через raw DBAL UPDATE,
+ * минуя UoW: они вызываются в горячем цикле polling'а, не должны триггерить
+ * hydration и безопасны для одновременной работы нескольких воркеров
+ * (на случай рестарта Messenger-job'а, когда два handler'а видят один и
+ * тот же in-flight UUID).
+ */
+class OzonAdPendingReportRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, OzonAdPendingReport::class);
+    }
+
+    /**
+     * Создаёт запись о запрошенном отчёте со state = REQUESTED и сразу flush'ит.
+     *
+     * Flush обязателен здесь (не откладывается на вызывающий Action), потому
+     * что create() вызывается из {@see \App\MarketplaceAds\Infrastructure\Api\Ozon\OzonAdClient::requestStatistics()}
+     * в середине pipeline'а: последующие шаги (pollReport, downloadReport)
+     * могут упасть, и без немедленного flush UUID не попадёт в БД.
+     *
+     * @param list<string> $campaignIds
+     */
+    public function create(
+        string $companyId,
+        string $ozonUuid,
+        \DateTimeImmutable $dateFrom,
+        \DateTimeImmutable $dateTo,
+        array $campaignIds,
+        ?string $jobId,
+    ): OzonAdPendingReport {
+        $entity = new OzonAdPendingReport(
+            companyId: $companyId,
+            ozonUuid: $ozonUuid,
+            dateFrom: $dateFrom,
+            dateTo: $dateTo,
+            campaignIds: $campaignIds,
+            jobId: $jobId,
+        );
+
+        $em = $this->getEntityManager();
+        $em->persist($entity);
+        $em->flush();
+
+        return $entity;
+    }
+
+    /**
+     * Обновляет state / lastCheckedAt / pollAttempts после очередной итерации polling.
+     *
+     * Если $firstNonPendingAt передан и ещё не установлен в БД — фиксируем.
+     * Guard-условие `first_non_pending_at IS NULL` защищает от перезаписи
+     * уже зафиксированного timestamp'а при повторных итерациях.
+     *
+     * Реализовано через raw DBAL: polling вызывается в цикле, persist/flush
+     * здесь означал бы загрузку entity в UoW на каждой итерации.
+     *
+     * @return int число обновлённых строк (0 — ozonUuid не найден)
+     */
+    public function updateState(
+        string $ozonUuid,
+        string $state,
+        \DateTimeImmutable $lastCheckedAt,
+        int $pollAttempts,
+        ?\DateTimeImmutable $firstNonPendingAt = null,
+    ): int {
+        $conn = $this->getEntityManager()->getConnection();
+
+        if (null === $firstNonPendingAt) {
+            return (int) $conn->executeStatement(
+                <<<'SQL'
+                    UPDATE marketplace_ad_pending_reports
+                    SET state = :state,
+                        last_checked_at = :last_checked_at,
+                        poll_attempts = :poll_attempts,
+                        updated_at = NOW()
+                    WHERE ozon_uuid = :ozon_uuid
+                    SQL,
+                [
+                    'state' => $state,
+                    'last_checked_at' => $lastCheckedAt->format('Y-m-d H:i:s'),
+                    'poll_attempts' => $pollAttempts,
+                    'ozon_uuid' => $ozonUuid,
+                ],
+            );
+        }
+
+        return (int) $conn->executeStatement(
+            <<<'SQL'
+                UPDATE marketplace_ad_pending_reports
+                SET state = :state,
+                    last_checked_at = :last_checked_at,
+                    poll_attempts = :poll_attempts,
+                    first_non_pending_at = COALESCE(first_non_pending_at, :first_non_pending_at),
+                    updated_at = NOW()
+                WHERE ozon_uuid = :ozon_uuid
+                SQL,
+            [
+                'state' => $state,
+                'last_checked_at' => $lastCheckedAt->format('Y-m-d H:i:s'),
+                'poll_attempts' => $pollAttempts,
+                'first_non_pending_at' => $firstNonPendingAt->format('Y-m-d H:i:s'),
+                'ozon_uuid' => $ozonUuid,
+            ],
+        );
+    }
+
+    /**
+     * Терминализирует запись: выставляет state (OK/ERROR/ABANDONED), finalized_at,
+     * optional errorMessage.
+     *
+     * Идемпотентно: guard `finalized_at IS NULL` не даст перезаписать уже
+     * финализированную запись — параллельный воркер, который видел тот же
+     * UUID и пришёл к OK позже, не стирает исходный ERROR/ABANDONED.
+     *
+     * @return int число обновлённых строк (0 — uuid не найден или уже финализирован)
+     */
+    public function markFinalized(string $ozonUuid, string $state, ?string $errorMessage = null): int
+    {
+        if (!OzonAdPendingReportState::isTerminal($state)) {
+            throw new \InvalidArgumentException(sprintf(
+                'markFinalized принимает только терминальные state (OK/ERROR/ABANDONED), получено: %s',
+                $state,
+            ));
+        }
+
+        return (int) $this->getEntityManager()->getConnection()->executeStatement(
+            <<<'SQL'
+                UPDATE marketplace_ad_pending_reports
+                SET state = :state,
+                    error_message = :error_message,
+                    finalized_at = NOW(),
+                    updated_at = NOW()
+                WHERE ozon_uuid = :ozon_uuid
+                  AND finalized_at IS NULL
+                SQL,
+            [
+                'state' => $state,
+                'error_message' => $errorMessage,
+                'ozon_uuid' => $ozonUuid,
+            ],
+        );
+    }
+
+    public function findByOzonUuid(string $ozonUuid): ?OzonAdPendingReport
+    {
+        return $this->findOneBy(['ozonUuid' => $ozonUuid]);
+    }
+
+    /**
+     * Все in-flight записи (REQUESTED / NOT_STARTED / IN_PROGRESS) для конкретного job'а.
+     * Пригодится для задачи 3 (resume on Messenger retry): handler при повторном
+     * запуске получит список UUID, по которым надо продолжать polling вместо
+     * нового POST /statistics.
+     *
+     * @return list<OzonAdPendingReport>
+     */
+    public function findInFlightByJob(string $jobId): array
+    {
+        /** @var list<OzonAdPendingReport> $result */
+        $result = $this->createQueryBuilder('r')
+            ->where('r.jobId = :jobId')
+            ->andWhere('r.state IN (:inFlightStates)')
+            ->andWhere('r.finalizedAt IS NULL')
+            ->setParameter('jobId', $jobId)
+            ->setParameter('inFlightStates', OzonAdPendingReportState::IN_FLIGHT_STATES)
+            ->orderBy('r.requestedAt', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return $result;
+    }
+}

--- a/site/tests/Integration/MarketplaceAds/OzonAdPendingReportRepositoryTest.php
+++ b/site/tests/Integration/MarketplaceAds/OzonAdPendingReportRepositoryTest.php
@@ -49,7 +49,7 @@ final class OzonAdPendingReportRepositoryTest extends IntegrationTestCase
 
         // Сразу читаем из БД без em->flush() — create() обязан flush'ить сам.
         $this->em->clear();
-        $found = $this->repository->findByOzonUuid('uuid-create-1');
+        $found = $this->repository->findByOzonUuid(self::COMPANY_ID, 'uuid-create-1');
 
         self::assertInstanceOf(OzonAdPendingReport::class, $found);
         self::assertSame(self::COMPANY_ID, $found->getCompanyId());
@@ -93,11 +93,11 @@ final class OzonAdPendingReportRepositoryTest extends IntegrationTestCase
         );
 
         $firstNow = new \DateTimeImmutable('2026-04-01 10:00:00');
-        $rows = $this->repository->updateState('uuid-upd-1', 'NOT_STARTED', $firstNow, 1);
+        $rows = $this->repository->updateState(self::COMPANY_ID, 'uuid-upd-1', 'NOT_STARTED', $firstNow, 1);
         self::assertSame(1, $rows);
 
         $this->em->clear();
-        $afterFirst = $this->repository->findByOzonUuid('uuid-upd-1');
+        $afterFirst = $this->repository->findByOzonUuid(self::COMPANY_ID, 'uuid-upd-1');
         self::assertNotNull($afterFirst);
         self::assertSame('NOT_STARTED', $afterFirst->getState());
         self::assertSame(1, $afterFirst->getPollAttempts());
@@ -107,10 +107,10 @@ final class OzonAdPendingReportRepositoryTest extends IntegrationTestCase
 
         // Second iteration — state moves off NOT_STARTED, firstNonPendingAt должен зафиксироваться.
         $secondNow = new \DateTimeImmutable('2026-04-01 10:00:05');
-        $this->repository->updateState('uuid-upd-1', 'IN_PROGRESS', $secondNow, 2, $secondNow);
+        $this->repository->updateState(self::COMPANY_ID, 'uuid-upd-1', 'IN_PROGRESS', $secondNow, 2, $secondNow);
 
         $this->em->clear();
-        $afterSecond = $this->repository->findByOzonUuid('uuid-upd-1');
+        $afterSecond = $this->repository->findByOzonUuid(self::COMPANY_ID, 'uuid-upd-1');
         self::assertNotNull($afterSecond);
         self::assertSame('IN_PROGRESS', $afterSecond->getState());
         self::assertSame(2, $afterSecond->getPollAttempts());
@@ -119,10 +119,10 @@ final class OzonAdPendingReportRepositoryTest extends IntegrationTestCase
 
         // Third iteration — firstNonPendingAt уже установлен → COALESCE обязан оставить исходный.
         $thirdNow = new \DateTimeImmutable('2026-04-01 10:00:10');
-        $this->repository->updateState('uuid-upd-1', 'IN_PROGRESS', $thirdNow, 3, $thirdNow);
+        $this->repository->updateState(self::COMPANY_ID, 'uuid-upd-1', 'IN_PROGRESS', $thirdNow, 3, $thirdNow);
 
         $this->em->clear();
-        $afterThird = $this->repository->findByOzonUuid('uuid-upd-1');
+        $afterThird = $this->repository->findByOzonUuid(self::COMPANY_ID, 'uuid-upd-1');
         self::assertNotNull($afterThird);
         self::assertSame(3, $afterThird->getPollAttempts());
         self::assertNotNull($afterThird->getFirstNonPendingAt());
@@ -139,6 +139,7 @@ final class OzonAdPendingReportRepositoryTest extends IntegrationTestCase
         $this->em->flush();
 
         $rows = $this->repository->updateState(
+            self::COMPANY_ID,
             'no-such-uuid',
             'IN_PROGRESS',
             new \DateTimeImmutable('2026-04-01 10:00:00'),
@@ -162,11 +163,11 @@ final class OzonAdPendingReportRepositoryTest extends IntegrationTestCase
             jobId: null,
         );
 
-        $rows = $this->repository->markFinalized('uuid-fin-ok', OzonAdPendingReportState::OK);
+        $rows = $this->repository->markFinalized(self::COMPANY_ID, 'uuid-fin-ok', OzonAdPendingReportState::OK);
         self::assertSame(1, $rows);
 
         $this->em->clear();
-        $finalized = $this->repository->findByOzonUuid('uuid-fin-ok');
+        $finalized = $this->repository->findByOzonUuid(self::COMPANY_ID, 'uuid-fin-ok');
         self::assertNotNull($finalized);
         self::assertSame(OzonAdPendingReportState::OK, $finalized->getState());
         self::assertNotNull($finalized->getFinalizedAt());
@@ -188,13 +189,14 @@ final class OzonAdPendingReportRepositoryTest extends IntegrationTestCase
         );
 
         $this->repository->markFinalized(
+            self::COMPANY_ID,
             'uuid-fin-err',
             OzonAdPendingReportState::ERROR,
             'Ozon API вернул ERROR: нет прав',
         );
 
         $this->em->clear();
-        $finalized = $this->repository->findByOzonUuid('uuid-fin-err');
+        $finalized = $this->repository->findByOzonUuid(self::COMPANY_ID, 'uuid-fin-err');
         self::assertNotNull($finalized);
         self::assertSame(OzonAdPendingReportState::ERROR, $finalized->getState());
         self::assertSame('Ozon API вернул ERROR: нет прав', $finalized->getErrorMessage());
@@ -214,14 +216,14 @@ final class OzonAdPendingReportRepositoryTest extends IntegrationTestCase
             jobId: null,
         );
 
-        $first = $this->repository->markFinalized('uuid-fin-idem', OzonAdPendingReportState::ERROR, 'boom');
-        $second = $this->repository->markFinalized('uuid-fin-idem', OzonAdPendingReportState::OK, 'should not overwrite');
+        $first = $this->repository->markFinalized(self::COMPANY_ID, 'uuid-fin-idem', OzonAdPendingReportState::ERROR, 'boom');
+        $second = $this->repository->markFinalized(self::COMPANY_ID, 'uuid-fin-idem', OzonAdPendingReportState::OK, 'should not overwrite');
 
         self::assertSame(1, $first, 'Первая финализация обязана обновить строку');
         self::assertSame(0, $second, 'Вторая финализация не должна затронуть ни одну строку');
 
         $this->em->clear();
-        $finalized = $this->repository->findByOzonUuid('uuid-fin-idem');
+        $finalized = $this->repository->findByOzonUuid(self::COMPANY_ID, 'uuid-fin-idem');
         self::assertNotNull($finalized);
         self::assertSame(OzonAdPendingReportState::ERROR, $finalized->getState());
         self::assertSame('boom', $finalized->getErrorMessage());
@@ -232,7 +234,7 @@ final class OzonAdPendingReportRepositoryTest extends IntegrationTestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('/только терминальные state/');
 
-        $this->repository->markFinalized('any-uuid', OzonAdPendingReportState::IN_PROGRESS);
+        $this->repository->markFinalized(self::COMPANY_ID, 'any-uuid', OzonAdPendingReportState::IN_PROGRESS);
     }
 
     public function testFindInFlightByJobReturnsOnlyInFlightRecords(): void
@@ -258,6 +260,7 @@ final class OzonAdPendingReportRepositoryTest extends IntegrationTestCase
             jobId: $job->getId(),
         );
         $this->repository->updateState(
+            self::COMPANY_ID,
             'uuid-if-2',
             'IN_PROGRESS',
             new \DateTimeImmutable('2026-04-01 10:00:00'),
@@ -274,7 +277,7 @@ final class OzonAdPendingReportRepositoryTest extends IntegrationTestCase
             campaignIds: ['333'],
             jobId: $job->getId(),
         );
-        $this->repository->markFinalized('uuid-done', OzonAdPendingReportState::OK);
+        $this->repository->markFinalized(self::COMPANY_ID, 'uuid-done', OzonAdPendingReportState::OK);
 
         // На другом job'е — тоже in-flight, но из другого job'а → не должна попасть.
         $this->repository->create(
@@ -287,12 +290,64 @@ final class OzonAdPendingReportRepositoryTest extends IntegrationTestCase
         );
 
         $this->em->clear();
-        $inFlight = $this->repository->findInFlightByJob($job->getId());
+        $inFlight = $this->repository->findInFlightByJob(self::COMPANY_ID, $job->getId());
 
         self::assertCount(2, $inFlight);
         $uuids = array_map(static fn (OzonAdPendingReport $r): string => $r->getOzonUuid(), $inFlight);
         sort($uuids);
         self::assertSame(['uuid-if-1', 'uuid-if-2'], $uuids);
+    }
+
+    public function testUpdateStateIgnoresRowOfForeignCompany(): void
+    {
+        // Запись создана под self::COMPANY_ID — любая попытка обновить её под
+        // другой company должна вернуть 0 строк и оставить state нетронутым.
+        // Это guard от IDOR: ozon_uuid уникален, но WHERE-clause дополнительно
+        // проверяет принадлежность к company.
+        $this->seedCompany();
+        $this->em->flush();
+
+        $this->repository->create(
+            companyId: self::COMPANY_ID,
+            ozonUuid: 'uuid-foreign',
+            dateFrom: new \DateTimeImmutable('2026-03-01'),
+            dateTo: new \DateTimeImmutable('2026-03-03'),
+            campaignIds: ['111'],
+            jobId: null,
+        );
+
+        $foreignCompanyId = '99999999-9999-9999-9999-999999999999';
+
+        $updated = $this->repository->updateState(
+            $foreignCompanyId,
+            'uuid-foreign',
+            'IN_PROGRESS',
+            new \DateTimeImmutable('2026-04-01 10:00:00'),
+            1,
+            new \DateTimeImmutable('2026-04-01 10:00:00'),
+        );
+        self::assertSame(0, $updated, 'updateState не должен трогать строку чужой company');
+
+        $finalized = $this->repository->markFinalized(
+            $foreignCompanyId,
+            'uuid-foreign',
+            OzonAdPendingReportState::ERROR,
+            'foreign write',
+        );
+        self::assertSame(0, $finalized, 'markFinalized не должен трогать строку чужой company');
+
+        $this->em->clear();
+
+        // С корректной company — запись остаётся в REQUESTED, не финализирована.
+        $owned = $this->repository->findByOzonUuid(self::COMPANY_ID, 'uuid-foreign');
+        self::assertNotNull($owned);
+        self::assertSame(OzonAdPendingReportState::REQUESTED, $owned->getState());
+        self::assertNull($owned->getFinalizedAt());
+        self::assertNull($owned->getErrorMessage());
+
+        // С чужой company — findByOzonUuid обязан вернуть null.
+        $foreign = $this->repository->findByOzonUuid($foreignCompanyId, 'uuid-foreign');
+        self::assertNull($foreign, 'findByOzonUuid не должен возвращать строку чужой company');
     }
 
     public function testUniqueConstraintOnOzonUuid(): void

--- a/site/tests/Integration/MarketplaceAds/OzonAdPendingReportRepositoryTest.php
+++ b/site/tests/Integration/MarketplaceAds/OzonAdPendingReportRepositoryTest.php
@@ -1,0 +1,362 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\MarketplaceAds;
+
+use App\Company\Entity\Company;
+use App\MarketplaceAds\Entity\AdLoadJob;
+use App\MarketplaceAds\Entity\OzonAdPendingReport;
+use App\MarketplaceAds\Enum\OzonAdPendingReportState;
+use App\MarketplaceAds\Repository\AdLoadJobRepository;
+use App\MarketplaceAds\Repository\OzonAdPendingReportRepository;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Builders\MarketplaceAds\AdLoadJobBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+
+final class OzonAdPendingReportRepositoryTest extends IntegrationTestCase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-000000000001';
+    private const OWNER_ID = '22222222-2222-2222-2222-000000000001';
+
+    private OzonAdPendingReportRepository $repository;
+    private AdLoadJobRepository $jobRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = self::getContainer()->get(OzonAdPendingReportRepository::class);
+        $this->jobRepository = self::getContainer()->get(AdLoadJobRepository::class);
+    }
+
+    public function testCreatePersistsRecordImmediatelyInRequestedState(): void
+    {
+        $this->seedCompany();
+        $this->em->flush();
+
+        $entity = $this->repository->create(
+            companyId: self::COMPANY_ID,
+            ozonUuid: 'uuid-create-1',
+            dateFrom: new \DateTimeImmutable('2026-03-01'),
+            dateTo: new \DateTimeImmutable('2026-03-03'),
+            campaignIds: ['111', '222'],
+            jobId: null,
+        );
+
+        self::assertSame(OzonAdPendingReportState::REQUESTED, $entity->getState());
+
+        // Сразу читаем из БД без em->flush() — create() обязан flush'ить сам.
+        $this->em->clear();
+        $found = $this->repository->findByOzonUuid('uuid-create-1');
+
+        self::assertInstanceOf(OzonAdPendingReport::class, $found);
+        self::assertSame(self::COMPANY_ID, $found->getCompanyId());
+        self::assertSame('uuid-create-1', $found->getOzonUuid());
+        self::assertSame(['111', '222'], $found->getCampaignIds());
+        self::assertSame(OzonAdPendingReportState::REQUESTED, $found->getState());
+        self::assertSame(0, $found->getPollAttempts());
+        self::assertNull($found->getLastCheckedAt());
+        self::assertNull($found->getFirstNonPendingAt());
+        self::assertNull($found->getFinalizedAt());
+    }
+
+    public function testCreateLinksJobIdWhenProvided(): void
+    {
+        $job = $this->seedJob();
+
+        $entity = $this->repository->create(
+            companyId: self::COMPANY_ID,
+            ozonUuid: 'uuid-with-job',
+            dateFrom: new \DateTimeImmutable('2026-03-01'),
+            dateTo: new \DateTimeImmutable('2026-03-03'),
+            campaignIds: ['111'],
+            jobId: $job->getId(),
+        );
+
+        self::assertSame($job->getId(), $entity->getJobId());
+    }
+
+    public function testUpdateStateAdvancesAttemptAndTimestamps(): void
+    {
+        $this->seedCompany();
+        $this->em->flush();
+
+        $this->repository->create(
+            companyId: self::COMPANY_ID,
+            ozonUuid: 'uuid-upd-1',
+            dateFrom: new \DateTimeImmutable('2026-03-01'),
+            dateTo: new \DateTimeImmutable('2026-03-03'),
+            campaignIds: ['111'],
+            jobId: null,
+        );
+
+        $firstNow = new \DateTimeImmutable('2026-04-01 10:00:00');
+        $rows = $this->repository->updateState('uuid-upd-1', 'NOT_STARTED', $firstNow, 1);
+        self::assertSame(1, $rows);
+
+        $this->em->clear();
+        $afterFirst = $this->repository->findByOzonUuid('uuid-upd-1');
+        self::assertNotNull($afterFirst);
+        self::assertSame('NOT_STARTED', $afterFirst->getState());
+        self::assertSame(1, $afterFirst->getPollAttempts());
+        self::assertNotNull($afterFirst->getLastCheckedAt());
+        self::assertSame($firstNow->format('Y-m-d H:i:s'), $afterFirst->getLastCheckedAt()->format('Y-m-d H:i:s'));
+        self::assertNull($afterFirst->getFirstNonPendingAt());
+
+        // Second iteration — state moves off NOT_STARTED, firstNonPendingAt должен зафиксироваться.
+        $secondNow = new \DateTimeImmutable('2026-04-01 10:00:05');
+        $this->repository->updateState('uuid-upd-1', 'IN_PROGRESS', $secondNow, 2, $secondNow);
+
+        $this->em->clear();
+        $afterSecond = $this->repository->findByOzonUuid('uuid-upd-1');
+        self::assertNotNull($afterSecond);
+        self::assertSame('IN_PROGRESS', $afterSecond->getState());
+        self::assertSame(2, $afterSecond->getPollAttempts());
+        self::assertNotNull($afterSecond->getFirstNonPendingAt());
+        self::assertSame($secondNow->format('Y-m-d H:i:s'), $afterSecond->getFirstNonPendingAt()->format('Y-m-d H:i:s'));
+
+        // Third iteration — firstNonPendingAt уже установлен → COALESCE обязан оставить исходный.
+        $thirdNow = new \DateTimeImmutable('2026-04-01 10:00:10');
+        $this->repository->updateState('uuid-upd-1', 'IN_PROGRESS', $thirdNow, 3, $thirdNow);
+
+        $this->em->clear();
+        $afterThird = $this->repository->findByOzonUuid('uuid-upd-1');
+        self::assertNotNull($afterThird);
+        self::assertSame(3, $afterThird->getPollAttempts());
+        self::assertNotNull($afterThird->getFirstNonPendingAt());
+        self::assertSame(
+            $secondNow->format('Y-m-d H:i:s'),
+            $afterThird->getFirstNonPendingAt()->format('Y-m-d H:i:s'),
+            'COALESCE в updateState() не должен перезаписывать уже зафиксированный firstNonPendingAt',
+        );
+    }
+
+    public function testUpdateStateReturnsZeroForUnknownUuid(): void
+    {
+        $this->seedCompany();
+        $this->em->flush();
+
+        $rows = $this->repository->updateState(
+            'no-such-uuid',
+            'IN_PROGRESS',
+            new \DateTimeImmutable('2026-04-01 10:00:00'),
+            1,
+        );
+
+        self::assertSame(0, $rows);
+    }
+
+    public function testMarkFinalizedSetsTerminalStateAndTimestamp(): void
+    {
+        $this->seedCompany();
+        $this->em->flush();
+
+        $this->repository->create(
+            companyId: self::COMPANY_ID,
+            ozonUuid: 'uuid-fin-ok',
+            dateFrom: new \DateTimeImmutable('2026-03-01'),
+            dateTo: new \DateTimeImmutable('2026-03-03'),
+            campaignIds: ['111'],
+            jobId: null,
+        );
+
+        $rows = $this->repository->markFinalized('uuid-fin-ok', OzonAdPendingReportState::OK);
+        self::assertSame(1, $rows);
+
+        $this->em->clear();
+        $finalized = $this->repository->findByOzonUuid('uuid-fin-ok');
+        self::assertNotNull($finalized);
+        self::assertSame(OzonAdPendingReportState::OK, $finalized->getState());
+        self::assertNotNull($finalized->getFinalizedAt());
+        self::assertNull($finalized->getErrorMessage());
+    }
+
+    public function testMarkFinalizedStoresErrorMessage(): void
+    {
+        $this->seedCompany();
+        $this->em->flush();
+
+        $this->repository->create(
+            companyId: self::COMPANY_ID,
+            ozonUuid: 'uuid-fin-err',
+            dateFrom: new \DateTimeImmutable('2026-03-01'),
+            dateTo: new \DateTimeImmutable('2026-03-03'),
+            campaignIds: ['111'],
+            jobId: null,
+        );
+
+        $this->repository->markFinalized(
+            'uuid-fin-err',
+            OzonAdPendingReportState::ERROR,
+            'Ozon API вернул ERROR: нет прав',
+        );
+
+        $this->em->clear();
+        $finalized = $this->repository->findByOzonUuid('uuid-fin-err');
+        self::assertNotNull($finalized);
+        self::assertSame(OzonAdPendingReportState::ERROR, $finalized->getState());
+        self::assertSame('Ozon API вернул ERROR: нет прав', $finalized->getErrorMessage());
+    }
+
+    public function testMarkFinalizedIsIdempotent(): void
+    {
+        $this->seedCompany();
+        $this->em->flush();
+
+        $this->repository->create(
+            companyId: self::COMPANY_ID,
+            ozonUuid: 'uuid-fin-idem',
+            dateFrom: new \DateTimeImmutable('2026-03-01'),
+            dateTo: new \DateTimeImmutable('2026-03-03'),
+            campaignIds: ['111'],
+            jobId: null,
+        );
+
+        $first = $this->repository->markFinalized('uuid-fin-idem', OzonAdPendingReportState::ERROR, 'boom');
+        $second = $this->repository->markFinalized('uuid-fin-idem', OzonAdPendingReportState::OK, 'should not overwrite');
+
+        self::assertSame(1, $first, 'Первая финализация обязана обновить строку');
+        self::assertSame(0, $second, 'Вторая финализация не должна затронуть ни одну строку');
+
+        $this->em->clear();
+        $finalized = $this->repository->findByOzonUuid('uuid-fin-idem');
+        self::assertNotNull($finalized);
+        self::assertSame(OzonAdPendingReportState::ERROR, $finalized->getState());
+        self::assertSame('boom', $finalized->getErrorMessage());
+    }
+
+    public function testMarkFinalizedRejectsNonTerminalState(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/только терминальные state/');
+
+        $this->repository->markFinalized('any-uuid', OzonAdPendingReportState::IN_PROGRESS);
+    }
+
+    public function testFindInFlightByJobReturnsOnlyInFlightRecords(): void
+    {
+        $job = $this->seedJob();
+        $otherJob = $this->seedJob(index: 2);
+
+        // In-flight на нашем job'е: 2 записи (REQUESTED + IN_PROGRESS).
+        $this->repository->create(
+            companyId: self::COMPANY_ID,
+            ozonUuid: 'uuid-if-1',
+            dateFrom: new \DateTimeImmutable('2026-03-01'),
+            dateTo: new \DateTimeImmutable('2026-03-03'),
+            campaignIds: ['111'],
+            jobId: $job->getId(),
+        );
+        $this->repository->create(
+            companyId: self::COMPANY_ID,
+            ozonUuid: 'uuid-if-2',
+            dateFrom: new \DateTimeImmutable('2026-03-04'),
+            dateTo: new \DateTimeImmutable('2026-03-06'),
+            campaignIds: ['222'],
+            jobId: $job->getId(),
+        );
+        $this->repository->updateState(
+            'uuid-if-2',
+            'IN_PROGRESS',
+            new \DateTimeImmutable('2026-04-01 10:00:00'),
+            1,
+            new \DateTimeImmutable('2026-04-01 10:00:00'),
+        );
+
+        // Финализированная на нашем job'е — не должна попадать в выборку.
+        $this->repository->create(
+            companyId: self::COMPANY_ID,
+            ozonUuid: 'uuid-done',
+            dateFrom: new \DateTimeImmutable('2026-03-07'),
+            dateTo: new \DateTimeImmutable('2026-03-09'),
+            campaignIds: ['333'],
+            jobId: $job->getId(),
+        );
+        $this->repository->markFinalized('uuid-done', OzonAdPendingReportState::OK);
+
+        // На другом job'е — тоже in-flight, но из другого job'а → не должна попасть.
+        $this->repository->create(
+            companyId: self::COMPANY_ID,
+            ozonUuid: 'uuid-other',
+            dateFrom: new \DateTimeImmutable('2026-03-10'),
+            dateTo: new \DateTimeImmutable('2026-03-12'),
+            campaignIds: ['444'],
+            jobId: $otherJob->getId(),
+        );
+
+        $this->em->clear();
+        $inFlight = $this->repository->findInFlightByJob($job->getId());
+
+        self::assertCount(2, $inFlight);
+        $uuids = array_map(static fn (OzonAdPendingReport $r): string => $r->getOzonUuid(), $inFlight);
+        sort($uuids);
+        self::assertSame(['uuid-if-1', 'uuid-if-2'], $uuids);
+    }
+
+    public function testUniqueConstraintOnOzonUuid(): void
+    {
+        $this->seedCompany();
+        $this->em->flush();
+
+        $this->repository->create(
+            companyId: self::COMPANY_ID,
+            ozonUuid: 'uuid-dup',
+            dateFrom: new \DateTimeImmutable('2026-03-01'),
+            dateTo: new \DateTimeImmutable('2026-03-03'),
+            campaignIds: ['111'],
+            jobId: null,
+        );
+
+        $this->expectException(\Doctrine\DBAL\Exception\UniqueConstraintViolationException::class);
+
+        $this->repository->create(
+            companyId: self::COMPANY_ID,
+            ozonUuid: 'uuid-dup',
+            dateFrom: new \DateTimeImmutable('2026-03-01'),
+            dateTo: new \DateTimeImmutable('2026-03-03'),
+            campaignIds: ['222'],
+            jobId: null,
+        );
+    }
+
+    private function seedJob(int $index = 1): AdLoadJob
+    {
+        $this->seedCompany();
+        $this->em->flush();
+
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex($index)
+            ->build();
+
+        $this->jobRepository->save($job);
+        $this->em->flush();
+
+        return $job;
+    }
+
+    private function seedCompany(): Company
+    {
+        $existing = $this->em->getRepository(Company::class)->find(self::COMPANY_ID);
+        if (null !== $existing) {
+            return $existing;
+        }
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('owner@example.test')
+            ->build();
+
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $this->em->persist($owner);
+        $this->em->persist($company);
+
+        return $company;
+    }
+}

--- a/site/tests/Unit/MarketplaceAds/OzonAdClientTest.php
+++ b/site/tests/Unit/MarketplaceAds/OzonAdClientTest.php
@@ -7,8 +7,10 @@ namespace App\Tests\Unit\MarketplaceAds;
 use App\Marketplace\Enum\MarketplaceConnectionType;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Facade\MarketplaceFacade;
+use App\MarketplaceAds\Entity\OzonAdPendingReport;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonAdClient;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonReportDownload;
+use App\MarketplaceAds\Repository\OzonAdPendingReportRepository;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\AbstractLogger;
@@ -26,6 +28,8 @@ final class OzonAdClientTest extends TestCase
 
     private MarketplaceFacade&MockObject $facade;
 
+    private OzonAdPendingReportRepository&MockObject $pendingReportRepo;
+
     /** @var AbstractLogger&object{records: array<int, array{level: string, message: string, context: array<string, mixed>}>} */
     private LoggerInterface $logger;
 
@@ -35,6 +39,15 @@ final class OzonAdClientTest extends TestCase
         $this->facade->method('getConnectionCredentials')
             ->with(self::COMPANY_ID, MarketplaceType::OZON, MarketplaceConnectionType::PERFORMANCE)
             ->willReturn(['api_key' => self::CLIENT_SECRET, 'client_id' => self::CLIENT_ID]);
+
+        // Stub-репозиторий: персистенс pending-отчётов проверяется отдельными integration-тестами.
+        // Для unit-тестов OzonAdClient достаточно no-op mock'а, чтобы методы create/updateState/
+        // markFinalized не падали при реальном flush().
+        $this->pendingReportRepo = $this->createMock(OzonAdPendingReportRepository::class);
+        $this->pendingReportRepo->method('create')->willReturnCallback(
+            static fn (string $companyId, string $ozonUuid, \DateTimeImmutable $from, \DateTimeImmutable $to, array $campaignIds, ?string $jobId): OzonAdPendingReport
+                => new OzonAdPendingReport($companyId, $ozonUuid, $from, $to, $campaignIds, $jobId),
+        );
 
         $this->logger = new class extends AbstractLogger {
             /** @var array<int, array{level: string, message: string, context: array<string, mixed>}> */
@@ -76,7 +89,7 @@ final class OzonAdClientTest extends TestCase
             downloadCsv: $csv,
         );
 
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger, $this->pendingReportRepo);
 
         $result = $client->fetchAdStatisticsRange(
             self::COMPANY_ID,
@@ -122,7 +135,7 @@ final class OzonAdClientTest extends TestCase
             downloadCsv: $this->loadFixture('ozon_range_dmy.csv'),
         );
 
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger, $this->pendingReportRepo);
 
         $resultDmy = $client->fetchAdStatisticsRange(
             self::COMPANY_ID,
@@ -138,7 +151,7 @@ final class OzonAdClientTest extends TestCase
             stateBody: $this->stateReadyBody('/api/client/statistics/report?UUID=uuid-b2'),
             downloadCsv: $this->loadFixture('ozon_range_iso.csv'),
         );
-        $clientIso = new OzonAdClient($httpIso, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+        $clientIso = new OzonAdClient($httpIso, $this->facade, new ArrayAdapter(), $this->logger, $this->logger, $this->pendingReportRepo);
         $resultIso = $clientIso->fetchAdStatisticsRange(
             self::COMPANY_ID,
             new \DateTimeImmutable('2026-03-01'),
@@ -161,7 +174,7 @@ final class OzonAdClientTest extends TestCase
             downloadCsv: $this->loadFixture('ozon_range_invalid_date.csv'),
         );
 
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger, $this->pendingReportRepo);
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessageMatches('/не удалось распарсить дату/u');
@@ -184,6 +197,7 @@ final class OzonAdClientTest extends TestCase
             new ArrayAdapter(),
             $this->logger,
             $this->logger,
+            $this->pendingReportRepo,
         );
 
         $this->expectException(\InvalidArgumentException::class);
@@ -207,6 +221,7 @@ final class OzonAdClientTest extends TestCase
             new ArrayAdapter(),
             $this->logger,
             $this->logger,
+            $this->pendingReportRepo,
         );
 
         $this->expectException(\InvalidArgumentException::class);
@@ -249,7 +264,7 @@ final class OzonAdClientTest extends TestCase
         ]);
 
         $http = new MockHttpClient($responses);
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger, $this->pendingReportRepo);
 
         $result = $client->fetchAdStatisticsRange(
             self::COMPANY_ID,
@@ -291,7 +306,7 @@ final class OzonAdClientTest extends TestCase
             downloadCsv: $this->loadFixture('ozon_range_cyrillic_header.csv'),
         );
 
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger, $this->pendingReportRepo);
 
         $result = $client->fetchAdStatisticsRange(
             self::COMPANY_ID,
@@ -320,7 +335,7 @@ final class OzonAdClientTest extends TestCase
             downloadCsv: $this->loadFixture('ozon_range_iso.csv'),
         );
 
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger, $this->pendingReportRepo);
 
         $client->fetchAdStatisticsRange(
             self::COMPANY_ID,
@@ -358,6 +373,7 @@ final class OzonAdClientTest extends TestCase
             new ArrayAdapter(),
             $this->logger,
             $this->logger,
+            $this->pendingReportRepo,
         );
 
         try {
@@ -401,7 +417,7 @@ final class OzonAdClientTest extends TestCase
             stateBody: json_encode(['state' => 'ERROR', 'error' => 'нет прав'], JSON_THROW_ON_ERROR),
         );
 
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger, $this->pendingReportRepo);
 
         try {
             $client->fetchAdStatisticsRange(
@@ -437,7 +453,7 @@ final class OzonAdClientTest extends TestCase
             stateBody: json_encode(['state' => 'ERROR', 'error' => $errorPayload], JSON_THROW_ON_ERROR),
         );
 
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger, $this->pendingReportRepo);
 
         try {
             $client->fetchAdStatisticsRange(
@@ -473,7 +489,7 @@ final class OzonAdClientTest extends TestCase
             stateBody: json_encode(['state' => 'ERROR', 'error' => $errorPayload], JSON_THROW_ON_ERROR),
         );
 
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger, $this->pendingReportRepo);
 
         try {
             $client->fetchAdStatisticsRange(
@@ -504,7 +520,7 @@ final class OzonAdClientTest extends TestCase
             new MockResponse('{"error":"invalid campaign id"}', ['http_code' => 400]),
         ]);
 
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger, $this->pendingReportRepo);
 
         try {
             $client->fetchAdStatisticsRange(
@@ -541,7 +557,7 @@ final class OzonAdClientTest extends TestCase
             downloadCsv: "date;campaign_id;campaign_name;sku;spend;views;clicks\n",
         );
 
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger, $this->pendingReportRepo);
 
         // Far-past range — guaranteed older than 14 days regardless of run date.
         $dateFrom = (new \DateTimeImmutable('today'))->modify('-60 days');
@@ -581,7 +597,7 @@ final class OzonAdClientTest extends TestCase
         ]);
 
         $http = new MockHttpClient($responses);
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger, $this->pendingReportRepo);
 
         // Recent range — dateTo is within 14-day window from today.
         $dateFrom = (new \DateTimeImmutable('today'))->modify('-5 days');
@@ -623,7 +639,7 @@ final class OzonAdClientTest extends TestCase
             downloadCsv: "date;campaign_id;campaign_name;sku;spend;views;clicks\n",
         );
 
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger, $this->pendingReportRepo);
 
         // dateFrom 30 days ago (< cutoff), dateTo today (>> cutoff).
         // Must behave as backfill: all 3 campaigns kept despite dateTo being recent.
@@ -660,7 +676,7 @@ final class OzonAdClientTest extends TestCase
             downloadCsv: "date;campaign_id;campaign_name;sku;spend;views;clicks\n",
         );
 
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger, $this->pendingReportRepo);
 
         $dateFrom = (new \DateTimeImmutable('today'))->modify('-3 days');
         $dateTo = (new \DateTimeImmutable('today'))->modify('-1 day');
@@ -687,7 +703,7 @@ final class OzonAdClientTest extends TestCase
             downloadCsv: $this->loadFixture('ozon_single_day_legacy.csv'),
         );
 
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger, $this->pendingReportRepo);
 
         $json = $client->fetchAdStatistics(self::COMPANY_ID, new \DateTimeImmutable('2026-03-01'));
 
@@ -727,7 +743,7 @@ final class OzonAdClientTest extends TestCase
             downloadCsv: $zipBytes,
         );
 
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger, $this->pendingReportRepo);
 
         $result = $client->fetchAdStatisticsRange(
             self::COMPANY_ID,
@@ -781,7 +797,7 @@ final class OzonAdClientTest extends TestCase
             downloadCsv: $zipBytes,
         );
 
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger, $this->pendingReportRepo);
 
         $result = $client->fetchAdStatisticsRange(
             self::COMPANY_ID,
@@ -832,7 +848,7 @@ final class OzonAdClientTest extends TestCase
             downloadCsv: $corrupted,
         );
 
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger, $this->pendingReportRepo);
 
         try {
             $client->fetchAdStatisticsRange(
@@ -860,7 +876,7 @@ final class OzonAdClientTest extends TestCase
             downloadCsv: $csv,
         );
 
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger, $this->pendingReportRepo);
 
         $client->fetchAdStatisticsRange(
             self::COMPANY_ID,
@@ -899,7 +915,7 @@ final class OzonAdClientTest extends TestCase
             downloadCsv: $zipBytes,
         );
 
-        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger);
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger, $this->pendingReportRepo);
 
         $client->fetchAdStatisticsRange(
             self::COMPANY_ID,
@@ -925,6 +941,153 @@ final class OzonAdClientTest extends TestCase
         // bronze-хранилище и UI-диагностика работают с исходным файлом.
         self::assertSame(hash('sha256', $zipBytes), $download->sha256);
         self::assertSame(strlen($zipBytes), $download->sizeBytes);
+    }
+
+    // -----------------------------------------------------------------
+    // UUID persistence — create() обязан быть вызван ДО любого pollReport'а
+    // -----------------------------------------------------------------
+    public function testFetchAdStatisticsRangePersistsUuidBeforePolling(): void
+    {
+        $csv = $this->loadFixture('ozon_range_iso.csv');
+        $http = $this->buildHttpClientForRange(
+            tokenBody: $this->tokenBody('TKN-P1'),
+            campaignListBody: $this->campaignListBody(1),
+            statisticsBody: '{"UUID":"uuid-persist-1"}',
+            stateBody: $this->stateReadyBody('/api/client/statistics/report?UUID=uuid-persist-1'),
+            downloadCsv: $csv,
+        );
+
+        $repo = $this->createMock(OzonAdPendingReportRepository::class);
+        $repo->expects(self::once())
+            ->method('create')
+            ->with(
+                self::equalTo(self::COMPANY_ID),
+                self::equalTo('uuid-persist-1'),
+                self::callback(static fn (\DateTimeImmutable $df): bool => '2026-03-01' === $df->format('Y-m-d')),
+                self::callback(static fn (\DateTimeImmutable $dt): bool => '2026-03-05' === $dt->format('Y-m-d')),
+                self::equalTo(['111']),
+                self::equalTo('aaaaaaaa-aaaa-aaaa-aaaa-000000000001'),
+            )
+            ->willReturnCallback(
+                static fn (string $companyId, string $ozonUuid, \DateTimeImmutable $from, \DateTimeImmutable $to, array $campaignIds, ?string $jobId): OzonAdPendingReport
+                    => new OzonAdPendingReport($companyId, $ozonUuid, $from, $to, $campaignIds, $jobId),
+            );
+        // На успешном pollReport() ожидаем markFinalized(OK).
+        $repo->expects(self::once())
+            ->method('markFinalized')
+            ->with('uuid-persist-1', 'OK', null);
+
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger, $repo);
+
+        $client->fetchAdStatisticsRange(
+            self::COMPANY_ID,
+            new \DateTimeImmutable('2026-03-01'),
+            new \DateTimeImmutable('2026-03-05'),
+            'aaaaaaaa-aaaa-aaaa-aaaa-000000000001',
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // pollReport: КАЖДАЯ итерация вызывает updateState + пишет "Ozon poll iteration"
+    // -----------------------------------------------------------------
+    public function testPollReportLogsAndPersistsStateEveryIteration(): void
+    {
+        // Полная hippy-path цепочка, state=OK на первой итерации — одна updateState(..., 'OK', ...).
+        $http = $this->buildHttpClientForRange(
+            tokenBody: $this->tokenBody('TKN-L1'),
+            campaignListBody: $this->campaignListBody(1),
+            statisticsBody: '{"UUID":"uuid-log-1"}',
+            stateBody: $this->stateReadyBody('/api/client/statistics/report?UUID=uuid-log-1'),
+            downloadCsv: "date;campaign_id;campaign_name;sku;spend;views;clicks\n2026-03-01;111;Campaign A;SKU-1;10;1;1\n",
+        );
+
+        $updateStateCalls = [];
+        $repo = $this->createMock(OzonAdPendingReportRepository::class);
+        $repo->method('create')->willReturnCallback(
+            static fn (string $companyId, string $ozonUuid, \DateTimeImmutable $from, \DateTimeImmutable $to, array $campaignIds, ?string $jobId): OzonAdPendingReport
+                => new OzonAdPendingReport($companyId, $ozonUuid, $from, $to, $campaignIds, $jobId),
+        );
+        $repo->expects(self::atLeastOnce())
+            ->method('updateState')
+            ->willReturnCallback(function (string $uuid, string $state, \DateTimeImmutable $now, int $attempt, ?\DateTimeImmutable $firstNonPendingAt = null) use (&$updateStateCalls): int {
+                $updateStateCalls[] = [
+                    'uuid' => $uuid,
+                    'state' => $state,
+                    'attempt' => $attempt,
+                    'firstNonPendingAt' => $firstNonPendingAt,
+                ];
+
+                return 1;
+            });
+        $repo->expects(self::once())->method('markFinalized')->with('uuid-log-1', 'OK', null);
+
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger, $repo);
+
+        $client->fetchAdStatisticsRange(
+            self::COMPANY_ID,
+            new \DateTimeImmutable('2026-03-01'),
+            new \DateTimeImmutable('2026-03-01'),
+            'aaaaaaaa-aaaa-aaaa-aaaa-000000000002',
+        );
+
+        self::assertCount(1, $updateStateCalls, 'OK на первой итерации → ровно один updateState()');
+        self::assertSame('uuid-log-1', $updateStateCalls[0]['uuid']);
+        self::assertSame('OK', $updateStateCalls[0]['state']);
+        self::assertSame(1, $updateStateCalls[0]['attempt']);
+        // state='OK' ≠ 'NOT_STARTED' → firstNonPendingAt должен быть передан (not null).
+        self::assertNotNull($updateStateCalls[0]['firstNonPendingAt']);
+
+        // Проверяем, что "Ozon poll iteration" лог выписан с контекстом.
+        $record = $this->findLogRecord('Ozon poll iteration');
+        self::assertSame('uuid-log-1', $record['context']['reportUuid']);
+        self::assertSame(1, $record['context']['attempt']);
+        self::assertSame('OK', $record['context']['state']);
+    }
+
+    // -----------------------------------------------------------------
+    // pollReport: state=ERROR на первой итерации → markFinalized('ERROR', message)
+    // и UUID УЖЕ был сохранён create()'ом
+    // -----------------------------------------------------------------
+    public function testPollReportFinalizesRecordOnFirstIterationError(): void
+    {
+        $http = $this->buildHttpClientForError(
+            tokenBody: $this->tokenBody('TKN-E1'),
+            campaignListBody: $this->campaignListBody(1),
+            statisticsBody: '{"UUID":"uuid-first-err"}',
+            stateBody: json_encode(['state' => 'ERROR', 'error' => 'квота'], JSON_THROW_ON_ERROR),
+        );
+
+        $repo = $this->createMock(OzonAdPendingReportRepository::class);
+        $repo->expects(self::once())
+            ->method('create')
+            ->with(self::COMPANY_ID, 'uuid-first-err', self::anything(), self::anything(), self::anything(), self::anything())
+            ->willReturnCallback(
+                static fn (string $companyId, string $ozonUuid, \DateTimeImmutable $from, \DateTimeImmutable $to, array $campaignIds, ?string $jobId): OzonAdPendingReport
+                    => new OzonAdPendingReport($companyId, $ozonUuid, $from, $to, $campaignIds, $jobId),
+            );
+        $repo->expects(self::once())
+            ->method('updateState')
+            ->with('uuid-first-err', 'ERROR', self::anything(), 1, self::anything())
+            ->willReturn(1);
+        $repo->expects(self::once())
+            ->method('markFinalized')
+            ->with(
+                'uuid-first-err',
+                'ERROR',
+                self::callback(static fn (?string $msg): bool => null !== $msg && str_contains($msg, 'ERROR') && str_contains($msg, 'квота')),
+            )
+            ->willReturn(1);
+
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger, $repo);
+
+        $this->expectException(\RuntimeException::class);
+
+        $client->fetchAdStatisticsRange(
+            self::COMPANY_ID,
+            new \DateTimeImmutable('2026-03-01'),
+            new \DateTimeImmutable('2026-03-01'),
+            'aaaaaaaa-aaaa-aaaa-aaaa-000000000003',
+        );
     }
 
     // -----------------------------------------------------------------

--- a/site/tests/Unit/MarketplaceAds/OzonAdClientTest.php
+++ b/site/tests/Unit/MarketplaceAds/OzonAdClientTest.php
@@ -48,6 +48,8 @@ final class OzonAdClientTest extends TestCase
             static fn (string $companyId, string $ozonUuid, \DateTimeImmutable $from, \DateTimeImmutable $to, array $campaignIds, ?string $jobId): OzonAdPendingReport
                 => new OzonAdPendingReport($companyId, $ozonUuid, $from, $to, $campaignIds, $jobId),
         );
+        $this->pendingReportRepo->method('updateState')->willReturn(1);
+        $this->pendingReportRepo->method('markFinalized')->willReturn(1);
 
         $this->logger = new class extends AbstractLogger {
             /** @var array<int, array{level: string, message: string, context: array<string, mixed>}> */
@@ -957,6 +959,12 @@ final class OzonAdClientTest extends TestCase
             downloadCsv: $csv,
         );
 
+        // $events фиксирует порядок вызовов create() / updateState() / markFinalized():
+        // create() обязан произойти СТРОГО до первого updateState(). Без этого
+        // invariant'а поллинг мог бы начать писать по несуществующему ozon_uuid.
+        /** @var list<string> $events */
+        $events = [];
+
         $repo = $this->createMock(OzonAdPendingReportRepository::class);
         $repo->expects(self::once())
             ->method('create')
@@ -969,13 +977,26 @@ final class OzonAdClientTest extends TestCase
                 self::equalTo('aaaaaaaa-aaaa-aaaa-aaaa-000000000001'),
             )
             ->willReturnCallback(
-                static fn (string $companyId, string $ozonUuid, \DateTimeImmutable $from, \DateTimeImmutable $to, array $campaignIds, ?string $jobId): OzonAdPendingReport
-                    => new OzonAdPendingReport($companyId, $ozonUuid, $from, $to, $campaignIds, $jobId),
+                static function (string $companyId, string $ozonUuid, \DateTimeImmutable $from, \DateTimeImmutable $to, array $campaignIds, ?string $jobId) use (&$events): OzonAdPendingReport {
+                    $events[] = 'create';
+
+                    return new OzonAdPendingReport($companyId, $ozonUuid, $from, $to, $campaignIds, $jobId);
+                },
             );
+        $repo->method('updateState')->willReturnCallback(static function () use (&$events): int {
+            $events[] = 'updateState';
+
+            return 1;
+        });
         // На успешном pollReport() ожидаем markFinalized(OK).
         $repo->expects(self::once())
             ->method('markFinalized')
-            ->with('uuid-persist-1', 'OK', null);
+            ->with(self::COMPANY_ID, 'uuid-persist-1', 'OK', null)
+            ->willReturnCallback(static function () use (&$events): int {
+                $events[] = 'markFinalized';
+
+                return 1;
+            });
 
         $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger, $repo);
 
@@ -985,6 +1006,15 @@ final class OzonAdClientTest extends TestCase
             new \DateTimeImmutable('2026-03-05'),
             'aaaaaaaa-aaaa-aaaa-aaaa-000000000001',
         );
+
+        // Ordering invariant: первая запись в $events — create; все updateState
+        // идут ПОСЛЕ create; markFinalized — самым последним.
+        self::assertNotEmpty($events);
+        self::assertSame('create', $events[0], 'create() обязан быть вызван до первого updateState()');
+        $firstUpdateIdx = array_search('updateState', $events, true);
+        self::assertIsInt($firstUpdateIdx, 'updateState() должен быть вызван хотя бы раз');
+        self::assertGreaterThan(0, $firstUpdateIdx, 'updateState() не может опережать create()');
+        self::assertSame('markFinalized', end($events), 'markFinalized() обязан быть последним вызовом');
     }
 
     // -----------------------------------------------------------------
@@ -1009,8 +1039,9 @@ final class OzonAdClientTest extends TestCase
         );
         $repo->expects(self::atLeastOnce())
             ->method('updateState')
-            ->willReturnCallback(function (string $uuid, string $state, \DateTimeImmutable $now, int $attempt, ?\DateTimeImmutable $firstNonPendingAt = null) use (&$updateStateCalls): int {
+            ->willReturnCallback(function (string $companyId, string $uuid, string $state, \DateTimeImmutable $now, int $attempt, ?\DateTimeImmutable $firstNonPendingAt = null) use (&$updateStateCalls): int {
                 $updateStateCalls[] = [
+                    'companyId' => $companyId,
                     'uuid' => $uuid,
                     'state' => $state,
                     'attempt' => $attempt,
@@ -1019,7 +1050,7 @@ final class OzonAdClientTest extends TestCase
 
                 return 1;
             });
-        $repo->expects(self::once())->method('markFinalized')->with('uuid-log-1', 'OK', null);
+        $repo->expects(self::once())->method('markFinalized')->with(self::COMPANY_ID, 'uuid-log-1', 'OK', null);
 
         $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger, $repo);
 
@@ -1031,6 +1062,7 @@ final class OzonAdClientTest extends TestCase
         );
 
         self::assertCount(1, $updateStateCalls, 'OK на первой итерации → ровно один updateState()');
+        self::assertSame(self::COMPANY_ID, $updateStateCalls[0]['companyId']);
         self::assertSame('uuid-log-1', $updateStateCalls[0]['uuid']);
         self::assertSame('OK', $updateStateCalls[0]['state']);
         self::assertSame(1, $updateStateCalls[0]['attempt']);
@@ -1042,6 +1074,103 @@ final class OzonAdClientTest extends TestCase
         self::assertSame('uuid-log-1', $record['context']['reportUuid']);
         self::assertSame(1, $record['context']['attempt']);
         self::assertSame('OK', $record['context']['state']);
+    }
+
+    // -----------------------------------------------------------------
+    // pollReport: NOT_STARTED → IN_PROGRESS → OK.
+    // Проверяет:
+    //  • updateState() вызван для каждой из трёх итераций с корректным state/attempt;
+    //  • firstNonPendingAt == null на iter1 (NOT_STARTED), не-null на iter2/iter3;
+    //  • ровно одна finalization (OK) в самом конце.
+    //
+    // pollReport() делает sleep(POLL_INTERVAL_SECONDS=5) между итерациями,
+    // поэтому тест занимает ~10 секунд реального времени. Это сознательный
+    // trade-off: альтернатива — refactor под инжектируемый sleeper, что
+    // ломает сигнатуру и плодит моки.
+    // -----------------------------------------------------------------
+    public function testPollReportCapturesFirstNonPendingAtOnceAcrossIterations(): void
+    {
+        $statePending = json_encode(['state' => 'NOT_STARTED'], JSON_THROW_ON_ERROR);
+        $stateInProgress = json_encode(['state' => 'IN_PROGRESS'], JSON_THROW_ON_ERROR);
+        $stateReady = $this->stateReadyBody('/api/client/statistics/report?UUID=uuid-multi');
+
+        $http = new MockHttpClient([
+            new MockResponse($this->tokenBody('TKN-MULTI')),
+            new MockResponse($this->campaignListBody(1)),
+            new MockResponse('{"UUID":"uuid-multi"}'),
+            // Три последовательных GET /statistics/{uuid}: NOT_STARTED → IN_PROGRESS → OK.
+            new MockResponse($statePending),
+            new MockResponse($stateInProgress),
+            new MockResponse($stateReady),
+            // download — однострочный CSV, чтобы не влиять на парсинг.
+            new MockResponse("date;campaign_id;campaign_name;sku;spend;views;clicks\n2026-03-01;111;Campaign A;SKU-1;1;1;1\n"),
+        ]);
+
+        /** @var list<array{companyId: string, uuid: string, state: string, attempt: int, firstNonPendingAt: ?\DateTimeImmutable}> $calls */
+        $calls = [];
+
+        $repo = $this->createMock(OzonAdPendingReportRepository::class);
+        $repo->method('create')->willReturnCallback(
+            static fn (string $companyId, string $ozonUuid, \DateTimeImmutable $from, \DateTimeImmutable $to, array $campaignIds, ?string $jobId): OzonAdPendingReport
+                => new OzonAdPendingReport($companyId, $ozonUuid, $from, $to, $campaignIds, $jobId),
+        );
+        $repo->expects(self::exactly(3))
+            ->method('updateState')
+            ->willReturnCallback(function (string $companyId, string $uuid, string $state, \DateTimeImmutable $now, int $attempt, ?\DateTimeImmutable $firstNonPendingAt = null) use (&$calls): int {
+                $calls[] = [
+                    'companyId' => $companyId,
+                    'uuid' => $uuid,
+                    'state' => $state,
+                    'attempt' => $attempt,
+                    'firstNonPendingAt' => $firstNonPendingAt,
+                ];
+
+                return 1;
+            });
+        $repo->expects(self::once())
+            ->method('markFinalized')
+            ->with(self::COMPANY_ID, 'uuid-multi', 'OK', null)
+            ->willReturn(1);
+
+        $client = new OzonAdClient($http, $this->facade, new ArrayAdapter(), $this->logger, $this->logger, $repo);
+
+        $client->fetchAdStatisticsRange(
+            self::COMPANY_ID,
+            new \DateTimeImmutable('2026-03-01'),
+            new \DateTimeImmutable('2026-03-01'),
+            'aaaaaaaa-aaaa-aaaa-aaaa-000000000004',
+        );
+
+        self::assertCount(3, $calls);
+
+        self::assertSame(self::COMPANY_ID, $calls[0]['companyId']);
+        self::assertSame('uuid-multi', $calls[0]['uuid']);
+        self::assertSame('NOT_STARTED', $calls[0]['state']);
+        self::assertSame(1, $calls[0]['attempt']);
+        self::assertNull($calls[0]['firstNonPendingAt'], 'NOT_STARTED iteration must not capture firstNonPendingAt');
+
+        self::assertSame('IN_PROGRESS', $calls[1]['state']);
+        self::assertSame(2, $calls[1]['attempt']);
+        self::assertNotNull($calls[1]['firstNonPendingAt'], 'IN_PROGRESS iteration must capture firstNonPendingAt');
+
+        self::assertSame('OK', $calls[2]['state']);
+        self::assertSame(3, $calls[2]['attempt']);
+        // OK-итерация тоже передаёт firstNonPendingAt — COALESCE в Repository
+        // обеспечивает, что SQL-level значение не перезапишется (integration-тест
+        // testUpdateStateAdvancesAttemptAndTimestamps проверяет именно этот
+        // COALESCE-инвариант; здесь мы только фиксируем, что клиент передаёт
+        // не-null, чтобы COALESCE имел шанс сработать).
+        self::assertNotNull($calls[2]['firstNonPendingAt']);
+
+        // Каждая итерация пишет "Ozon poll iteration" в info-канал.
+        $iterationLogs = array_values(array_filter(
+            $this->logger->records,
+            static fn (array $r): bool => 'Ozon poll iteration' === $r['message'],
+        ));
+        self::assertCount(3, $iterationLogs);
+        self::assertSame('NOT_STARTED', $iterationLogs[0]['context']['state']);
+        self::assertSame('IN_PROGRESS', $iterationLogs[1]['context']['state']);
+        self::assertSame('OK', $iterationLogs[2]['context']['state']);
     }
 
     // -----------------------------------------------------------------
@@ -1067,11 +1196,12 @@ final class OzonAdClientTest extends TestCase
             );
         $repo->expects(self::once())
             ->method('updateState')
-            ->with('uuid-first-err', 'ERROR', self::anything(), 1, self::anything())
+            ->with(self::COMPANY_ID, 'uuid-first-err', 'ERROR', self::anything(), 1, self::anything())
             ->willReturn(1);
         $repo->expects(self::once())
             ->method('markFinalized')
             ->with(
+                self::COMPANY_ID,
                 'uuid-first-err',
                 'ERROR',
                 self::callback(static fn (?string $msg): bool => null !== $msg && str_contains($msg, 'ERROR') && str_contains($msg, 'квота')),


### PR DESCRIPTION
## Summary

- **UUID persistence.** `OzonAdClient::requestStatistics()` немедленно сохраняет `ozon_uuid` через `OzonAdPendingReportRepository::create()` (persist + flush) до любого polling'а — сбой handler'а / timeout / рестарт worker'а больше не «теряет» UUID.
- **Structured polling log.** Каждая итерация `pollReport()` пишет info-событие `Ozon poll iteration` (reportUuid / attempt / state / waitedSeconds) и через raw DBAL `updateState()` обновляет state/lastCheckedAt/pollAttempts; `firstNonPendingAt` фиксируется один раз (COALESCE-guard в SQL).
- **Terminal transitions.** `markFinalized()` (raw DBAL, идемпотентно через `finalized_at IS NULL`) вызывается на OK/READY, ERROR/CANCELLED/NOT_FOUND и на исчерпании POLL_MAX_ATTEMPTS (`ABANDONED`).
- **IDOR defense-in-depth.** Все методы репозитория (`updateState`, `markFinalized`, `findByOzonUuid`, `findInFlightByJob`) принимают `string $companyId` и включают его в WHERE-clause; companyId пробрасывается через `pollReport`.
- **Entity / enum / migration.** Новые `OzonAdPendingReport` + `OzonAdPendingReportState` (REQUESTED / NOT_STARTED / IN_PROGRESS / OK / ERROR / ABANDONED), миграция `Version20260420120000` (UNIQUE(ozon_uuid) + индексы по company_id / job_id / state).
- **ARCHITECTURE.md.** Добавлены Entity-поля, Repository-контракт, Enum-константы и строка в migration-status-таблицу.

## Test plan

- [x] Integration: `OzonAdPendingReportRepositoryTest` — create/updateState/markFinalized happy-path, COALESCE для firstNonPendingAt, идемпотентность markFinalized, findInFlightByJob, UNIQUE(ozon_uuid), **negative: updateState/markFinalized с чужой company → 0 строк**.
- [x] Unit: `OzonAdClientTest` — `testFetchAdStatisticsRangePersistsUuidBeforePolling` (ordering: create → updateState → markFinalized), `testPollReportLogsAndPersistsStateEveryIteration`, `testPollReportFinalizesRecordOnFirstIterationError`, `testPollReportCapturesFirstNonPendingAtOnceAcrossIterations` (NOT_STARTED → IN_PROGRESS → OK).
- [ ] Прогнать миграцию `Version20260420120000` на staging и убедиться, что таблица `marketplace_ad_pending_reports` создаётся с нужными индексами.
- [ ] Прогнать один реальный range-fetch Ozon Performance и убедиться, что `state` эволюционирует REQUESTED → NOT_STARTED → IN_PROGRESS → OK, `finalizedAt` выставляется.

https://claude.ai/code/session_01TkDUF6iCThscKCiDngiLug