### PR TITLE
fix(marketplace): учёт operation_type в control sum и preflight net amount

### DIFF
--- a/site/src/Marketplace/Infrastructure/Query/PreflightCostsQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/PreflightCostsQuery.php
@@ -42,7 +42,7 @@ final class PreflightCostsQuery
                     WHERE m.id IS NOT NULL AND m.include_in_pl = false
                 )                                                               AS excluded_from_pl,
                 COALESCE(
-                    SUM(CASE WHEN c.operation_type = 'storno' THEN -c.amount ELSE c.amount END)
+                    SUM(CASE WHEN c.operation_type = 'storno' THEN -ABS(c.amount) ELSE ABS(c.amount) END)
                         FILTER (WHERE m.include_in_pl = true AND m.pl_category_id IS NOT NULL),
                     0
                 )                                                               AS net_amount_for_pl

--- a/site/src/Marketplace/Infrastructure/Query/PreflightCostsQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/PreflightCostsQuery.php
@@ -41,8 +41,11 @@ final class PreflightCostsQuery
                 COUNT(*) FILTER (
                     WHERE m.id IS NOT NULL AND m.include_in_pl = false
                 )                                                               AS excluded_from_pl,
-                COALESCE(SUM(c.amount) FILTER (WHERE m.include_in_pl = true AND m.pl_category_id IS NOT NULL), 0)
-                                                                                AS net_amount_for_pl
+                COALESCE(
+                    SUM(CASE WHEN c.operation_type = 'storno' THEN -c.amount ELSE c.amount END)
+                        FILTER (WHERE m.include_in_pl = true AND m.pl_category_id IS NOT NULL),
+                    0
+                )                                                               AS net_amount_for_pl
             FROM marketplace_costs c
             LEFT JOIN marketplace_cost_pl_mappings m
                 ON m.cost_category_id = c.category_id

--- a/site/src/Marketplace/Infrastructure/Query/UnprocessedCostsQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/UnprocessedCostsQuery.php
@@ -163,7 +163,7 @@ final class UnprocessedCostsQuery
     ): string {
         $result = $this->connection->fetchOne(
             <<<'SQL'
-            SELECT COALESCE(SUM(c.amount), 0)
+            SELECT COALESCE(SUM(CASE WHEN c.operation_type = 'storno' THEN -c.amount ELSE c.amount END), 0)
             FROM marketplace_costs c
             INNER JOIN marketplace_cost_pl_mappings m
                 ON m.cost_category_id = c.category_id

--- a/site/src/Marketplace/Infrastructure/Query/UnprocessedCostsQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/UnprocessedCostsQuery.php
@@ -163,7 +163,7 @@ final class UnprocessedCostsQuery
     ): string {
         $result = $this->connection->fetchOne(
             <<<'SQL'
-            SELECT COALESCE(SUM(CASE WHEN c.operation_type = 'storno' THEN -c.amount ELSE c.amount END), 0)
+            SELECT COALESCE(SUM(CASE WHEN c.operation_type = 'storno' THEN -ABS(c.amount) ELSE ABS(c.amount) END), 0)
             FROM marketplace_costs c
             INNER JOIN marketplace_cost_pl_mappings m
                 ON m.cost_category_id = c.category_id

--- a/site/tests/Integration/Marketplace/UnprocessedCostsQuerySymmetryTest.php
+++ b/site/tests/Integration/Marketplace/UnprocessedCostsQuerySymmetryTest.php
@@ -1,0 +1,339 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Marketplace;
+
+use App\Company\Entity\Company;
+use App\Finance\Entity\Document;
+use App\Marketplace\Entity\MarketplaceCost;
+use App\Marketplace\Entity\MarketplaceCostCategory;
+use App\Marketplace\Entity\MarketplaceCostPLMapping;
+use App\Marketplace\Enum\MarketplaceCostOperationType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Infrastructure\Query\PreflightCostsQuery;
+use App\Marketplace\Infrastructure\Query\UnprocessedCostsQuery;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * Гарантирует симметрию "формулы A" (getControlSum / preflight net_amount_for_pl)
+ * и "формулы B" (execute → PLEntryDTO-like reduce, повторяет логику
+ * CloseMonthStageAction::__invoke строки ~195–205).
+ *
+ * Баг до фикса: getControlSum использовал SUM(c.amount) без учёта operation_type,
+ * тогда как execute вычитает storno через is_storno-флаг. Поскольку после
+ * миграции Version20260413120000 все storno-строки хранятся как amount ≥ 0
+ * с operation_type='storno', расхождение на паре charge+storno равнялось
+ * 2 · Σ storno.amount.
+ */
+final class UnprocessedCostsQuerySymmetryTest extends IntegrationTestCase
+{
+    private const MARKETPLACE = MarketplaceType::OZON;
+    private const MARKETPLACE_VALUE = 'ozon';
+    private const PERIOD_FROM = '2026-01-01';
+    private const PERIOD_TO = '2026-01-31';
+
+    private Company $company;
+
+    private UnprocessedCostsQuery $unprocessedCostsQuery;
+    private PreflightCostsQuery $preflightCostsQuery;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $owner = UserBuilder::aUser()
+            ->withId('22222222-2222-2222-2222-000000000077')
+            ->withEmail('symmetry-owner@example.test')
+            ->build();
+
+        $this->company = CompanyBuilder::aCompany()
+            ->withId('11111111-1111-1111-1111-000000000077')
+            ->withOwner($owner)
+            ->build();
+
+        $this->em->persist($owner);
+        $this->em->persist($this->company);
+        $this->em->flush();
+
+        $this->unprocessedCostsQuery = self::getContainer()->get(UnprocessedCostsQuery::class);
+        $this->preflightCostsQuery = self::getContainer()->get(PreflightCostsQuery::class);
+    }
+
+    public function testOnlyChargeHasDeltaZero(): void
+    {
+        $category = $this->createMappedCategory('only_charge', 'Only charge');
+        $this->createCost($category, '1000.00', MarketplaceCostOperationType::CHARGE, '2026-01-10');
+        $this->em->flush();
+
+        self::assertEqualsWithDelta(1000.0, (float) $this->getControlSum(), 0.01);
+        self::assertEqualsWithDelta(1000.0, $this->handlerPlDocumentSum(), 0.01);
+        self::assertEqualsWithDelta(1000.0, (float) $this->getPreflightNetAmount(), 0.01);
+        $this->assertSymmetry();
+    }
+
+    public function testChargeMinusStornoInSameCategoryHasDeltaZero(): void
+    {
+        $category = $this->createMappedCategory('charge_storno', 'Charge minus storno');
+        $this->createCost($category, '1000.00', MarketplaceCostOperationType::CHARGE, '2026-01-10');
+        $this->createCost($category, '300.00', MarketplaceCostOperationType::STORNO, '2026-01-12');
+        $this->em->flush();
+
+        // controlSum = 1000 − 300 = 700; handler sum = 1000 − 300 = 700.
+        self::assertEqualsWithDelta(700.0, (float) $this->getControlSum(), 0.01);
+        self::assertEqualsWithDelta(700.0, $this->handlerPlDocumentSum(), 0.01);
+        self::assertEqualsWithDelta(700.0, (float) $this->getPreflightNetAmount(), 0.01);
+        $this->assertSymmetry();
+    }
+
+    public function testStandaloneStornoCategoryContributesNegatively(): void
+    {
+        $categoryCharge = $this->createMappedCategory('only_charge_cat', 'Only-charge cat');
+        $categoryStorno = $this->createMappedCategory('only_storno_cat', 'Only-storno cat');
+
+        $this->createCost($categoryCharge, '2000.00', MarketplaceCostOperationType::CHARGE, '2026-01-10');
+        $this->createCost($categoryStorno, '500.00', MarketplaceCostOperationType::STORNO, '2026-01-12');
+        $this->em->flush();
+
+        // A = 2000 − 500 = 1500; B сводит standalone-storno группу в отрицательный вклад.
+        self::assertEqualsWithDelta(1500.0, (float) $this->getControlSum(), 0.01);
+        self::assertEqualsWithDelta(1500.0, $this->handlerPlDocumentSum(), 0.01);
+        $this->assertSymmetry();
+
+        // Одиночная storno-группа даёт отрицательный вклад.
+        $rows = $this->unprocessedCostsQuery->execute(
+            $this->company->getId(),
+            self::MARKETPLACE_VALUE,
+            self::PERIOD_FROM,
+            self::PERIOD_TO,
+        );
+        $stornoOnlyRows = array_values(array_filter(
+            $rows,
+            static fn (array $r): bool => $r['cost_category_code'] === 'only_storno_cat' && $r['is_storno'] === true,
+        ));
+        self::assertCount(1, $stornoOnlyRows);
+        self::assertFalse($stornoOnlyRows[0]['is_negative'], 'Standalone storno row must have is_negative=false to subtract from PL sum.');
+    }
+
+    public function testNetNegativeCategoryStaysNegativeNotAbs(): void
+    {
+        $category = $this->createMappedCategory('net_negative', 'Net negative');
+        $this->createCost($category, '500.00', MarketplaceCostOperationType::CHARGE, '2026-01-10');
+        $this->createCost($category, '800.00', MarketplaceCostOperationType::STORNO, '2026-01-12');
+        $this->em->flush();
+
+        // 500 − 800 = −300; важно что результат отрицательный, не ABS.
+        self::assertEqualsWithDelta(-300.0, (float) $this->getControlSum(), 0.01);
+        self::assertEqualsWithDelta(-300.0, $this->handlerPlDocumentSum(), 0.01);
+        self::assertEqualsWithDelta(-300.0, (float) $this->getPreflightNetAmount(), 0.01);
+        $this->assertSymmetry();
+    }
+
+    public function testIncludeInPlFalseIsIgnoredByBothFormulas(): void
+    {
+        $included = $this->createMappedCategory('included', 'Included', includeInPl: true);
+        $excluded = $this->createMappedCategory('excluded', 'Excluded', includeInPl: false);
+
+        $this->createCost($included, '700.00', MarketplaceCostOperationType::CHARGE, '2026-01-10');
+        $this->createCost($excluded, '999.00', MarketplaceCostOperationType::CHARGE, '2026-01-11');
+        $this->createCost($excluded, '111.00', MarketplaceCostOperationType::STORNO, '2026-01-12');
+        $this->em->flush();
+
+        self::assertEqualsWithDelta(700.0, (float) $this->getControlSum(), 0.01);
+        self::assertEqualsWithDelta(700.0, $this->handlerPlDocumentSum(), 0.01);
+        self::assertEqualsWithDelta(700.0, (float) $this->getPreflightNetAmount(), 0.01);
+        $this->assertSymmetry();
+    }
+
+    public function testAlreadyProcessedRowIsIgnoredByBothFormulas(): void
+    {
+        $category = $this->createMappedCategory('processed_cat', 'Processed cat');
+
+        $processed = $this->createCost($category, '5000.00', MarketplaceCostOperationType::CHARGE, '2026-01-10');
+        $this->createCost($category, '400.00', MarketplaceCostOperationType::CHARGE, '2026-01-12');
+        $this->em->flush();
+
+        $document = new Document(Uuid::uuid4()->toString(), $this->company);
+        $this->em->persist($document);
+        $this->em->flush();
+
+        $processed->setDocument($document);
+        $this->em->flush();
+
+        // Preflight не фильтрует document_id (это отдельная метрика already_processed),
+        // поэтому здесь сравниваем только getControlSum с handler'ом.
+        self::assertEqualsWithDelta(400.0, (float) $this->getControlSum(), 0.01);
+        self::assertEqualsWithDelta(400.0, $this->handlerPlDocumentSum(), 0.01);
+        self::assertEqualsWithDelta(
+            0.0,
+            abs((float) $this->getControlSum() - $this->handlerPlDocumentSum()),
+            0.01,
+        );
+    }
+
+    public function testCostDateOutOfPeriodIsIgnoredByBothFormulas(): void
+    {
+        $category = $this->createMappedCategory('period_cat', 'Period cat');
+        $this->createCost($category, '1200.00', MarketplaceCostOperationType::CHARGE, '2026-01-10');
+        $this->createCost($category, '9999.00', MarketplaceCostOperationType::CHARGE, '2025-12-31'); // до периода
+        $this->createCost($category, '7777.00', MarketplaceCostOperationType::STORNO, '2026-02-01'); // после периода
+        $this->em->flush();
+
+        self::assertEqualsWithDelta(1200.0, (float) $this->getControlSum(), 0.01);
+        self::assertEqualsWithDelta(1200.0, $this->handlerPlDocumentSum(), 0.01);
+        self::assertEqualsWithDelta(1200.0, (float) $this->getPreflightNetAmount(), 0.01);
+        $this->assertSymmetry();
+    }
+
+    /**
+     * Воспроизводит production-инцидент: company b57d7682-...
+     * январь 2026, 1 000 000 начислений + 15 596.06 сторно.
+     *
+     * До фикса: A = 1 015 596.06, B = 984 403.94, delta ≈ 31 192.12 (= 2·Σ storno).
+     * После фикса: delta = 0.
+     */
+    public function testIncidentReproductionHasDeltaZero(): void
+    {
+        $category = $this->createMappedCategory('incident_cat', 'Incident cat');
+        $this->createCost($category, '1000000.00', MarketplaceCostOperationType::CHARGE, '2026-01-10');
+        $this->createCost($category, '15596.06', MarketplaceCostOperationType::STORNO, '2026-01-15');
+        $this->em->flush();
+
+        $controlSum = (float) $this->getControlSum();
+        $handlerSum = $this->handlerPlDocumentSum();
+
+        self::assertEqualsWithDelta(984403.94, $controlSum, 0.01, 'After fix getControlSum == handler plDocumentSum == charge − storno.');
+        self::assertEqualsWithDelta(984403.94, $handlerSum, 0.01);
+        self::assertEqualsWithDelta(0.0, abs($controlSum - $handlerSum), 0.01, 'Control sum and handler sum must match.');
+    }
+
+    // ----------------- helpers -----------------
+
+    private function createMappedCategory(
+        string $code,
+        string $name,
+        bool $includeInPl = true,
+    ): MarketplaceCostCategory {
+        $category = new MarketplaceCostCategory(
+            Uuid::uuid4()->toString(),
+            $this->company,
+            self::MARKETPLACE,
+        );
+        $category->setCode($code);
+        $category->setName($name);
+        $this->em->persist($category);
+
+        $mapping = new MarketplaceCostPLMapping(
+            Uuid::uuid4()->toString(),
+            $this->company->getId(),
+            $category,
+            // plCategoryId: использование FK на реальную PLCategory не требуется —
+            // поле хранит guid и фильтруется через IS NOT NULL.
+            Uuid::uuid4()->toString(),
+            $includeInPl,
+        );
+        $this->em->persist($mapping);
+
+        return $category;
+    }
+
+    private function createCost(
+        MarketplaceCostCategory $category,
+        string $amount,
+        MarketplaceCostOperationType $operationType,
+        string $costDate,
+    ): MarketplaceCost {
+        $cost = new MarketplaceCost(
+            Uuid::uuid4()->toString(),
+            $this->company,
+            self::MARKETPLACE,
+            $category,
+        );
+        $cost->setAmount($amount);
+        $cost->setCostDate(new \DateTimeImmutable($costDate));
+        $cost->setOperationType($operationType);
+        $cost->setExternalId('ext-' . Uuid::uuid4()->toString());
+        $this->em->persist($cost);
+
+        return $cost;
+    }
+
+    private function getControlSum(): string
+    {
+        return $this->unprocessedCostsQuery->getControlSum(
+            $this->company->getId(),
+            self::MARKETPLACE_VALUE,
+            self::PERIOD_FROM,
+            self::PERIOD_TO,
+        );
+    }
+
+    private function getPreflightNetAmount(): string
+    {
+        $stats = $this->preflightCostsQuery->getCostsStats(
+            $this->company->getId(),
+            self::MARKETPLACE_VALUE,
+            self::PERIOD_FROM,
+            self::PERIOD_TO,
+        );
+
+        return (string) $stats['net_amount_for_pl'];
+    }
+
+    /**
+     * Воспроизводит CloseMonthStageAction::__invoke строки ~195–205:
+     *   для каждой entry: isNegative=true → +amount, isNegative=false → -amount.
+     */
+    private function handlerPlDocumentSum(): float
+    {
+        $rows = $this->unprocessedCostsQuery->execute(
+            $this->company->getId(),
+            self::MARKETPLACE_VALUE,
+            self::PERIOD_FROM,
+            self::PERIOD_TO,
+        );
+
+        $sum = '0';
+        foreach ($rows as $row) {
+            $amount = (string) $row['total_amount'];
+            if ((bool) $row['is_negative']) {
+                $sum = bcadd($sum, $amount, 2);
+            } else {
+                $sum = bcsub($sum, $amount, 2);
+            }
+        }
+
+        return (float) $sum;
+    }
+
+    private function assertSymmetry(): void
+    {
+        $controlSum = (float) $this->getControlSum();
+        $handlerSum = $this->handlerPlDocumentSum();
+        $preflight = (float) $this->getPreflightNetAmount();
+
+        self::assertEqualsWithDelta(
+            0.0,
+            abs($controlSum - $handlerSum),
+            0.01,
+            sprintf(
+                'Formula A (getControlSum=%s) must equal Formula B (handler plDocumentSum=%s).',
+                $controlSum,
+                $handlerSum,
+            ),
+        );
+        self::assertEqualsWithDelta(
+            0.0,
+            abs($controlSum - $preflight),
+            0.01,
+            sprintf(
+                'Preflight net_amount_for_pl (%s) must equal getControlSum (%s).',
+                $preflight,
+                $controlSum,
+            ),
+        );
+    }
+}

--- a/site/tests/Integration/Marketplace/UnprocessedCostsQuerySymmetryTest.php
+++ b/site/tests/Integration/Marketplace/UnprocessedCostsQuerySymmetryTest.php
@@ -189,6 +189,29 @@ final class UnprocessedCostsQuerySymmetryTest extends IntegrationTestCase
     }
 
     /**
+     * Защита от регрессии: если кто-то решит убрать ABS внутри CASE как "лишний",
+     * тест остановит. Инвариант amount ≥ 0 enforced только в коде (процессорах
+     * + миграции Version20260413120000), но не в БД — и WB Phase 2B ещё не
+     * полностью выкачена. Формула B использует ABS(SUM(c.amount)) на уровне
+     * группы, поэтому симметричная форма для A — ABS(c.amount) внутри signed-суммы.
+     */
+    public function testSignedAmountSymmetryWhenInvariantBroken(): void
+    {
+        $category = $this->createMappedCategory('broken_invariant_cat', 'Broken invariant cat');
+        // Нарушенный инвариант: storno с отрицательным amount.
+        $this->createCost($category, '500.00', MarketplaceCostOperationType::CHARGE, '2026-01-10');
+        $this->createCost($category, '-200.00', MarketplaceCostOperationType::STORNO, '2026-01-12');
+        $this->em->flush();
+
+        // Formula A: +ABS(500) + (-ABS(-200)) = 500 − 200 = 300.
+        // Formula B: charge_group total=ABS(500)=500 (+500); storno_group total=ABS(-200)=200 (−200) ⇒ 300.
+        self::assertEqualsWithDelta(300.0, (float) $this->getControlSum(), 0.01);
+        self::assertEqualsWithDelta(300.0, $this->handlerPlDocumentSum(), 0.01);
+        self::assertEqualsWithDelta(300.0, (float) $this->getPreflightNetAmount(), 0.01);
+        $this->assertSymmetry();
+    }
+
+    /**
      * Воспроизводит production-инцидент: company b57d7682-...
      * январь 2026, 1 000 000 начислений + 15 596.06 сторно.
      *


### PR DESCRIPTION
## Summary

Hotfix симметрии контрольной суммы на этапе «Затраты» закрытия месяца. Handler падал с `RuntimeException [MonthClose] Контрольная сумма не сошлась`, потому что две формулы считают сумму по-разному:

- **Formula A** (`UnprocessedCostsQuery::getControlSum` + preflight `PreflightCostsQuery::getCostsStats.net_amount_for_pl`) использовала `SUM(c.amount)` без учёта `operation_type`.
- **Formula B** (`UnprocessedCostsQuery::execute` → `PLEntryDTO` → агрегация в `CloseMonthStageAction`) корректно вычитает `storno`.

После миграции `Version20260413120000` все Ozon-строки хранятся как `amount ≥ 0` + `operation_type ∈ {charge, storno}`, поэтому асимметрия равна `2 · Σ storno.amount`.

Добавлен `ABS` внутри CASE: формула B использует `ABS(SUM(c.amount))` на уровне группы, симметричная форма для A — `ABS(c.amount)` внутри signed-суммы. Защищает от регрессии при нарушении инварианта `amount ≥ 0` (WB Phase 2B ещё не полностью выкачена, инвариант enforced в коде, но не в БД).

## Воспроизведение инцидента

- Company `b57d7682-505f-4b74-86f8-953d32d59874`, январь 2026.
- Preflight net (старая формула): **3 766 483.88 ₽**.
- Ожидаемый net (новая формула): **3 735 291.76 ₽**.
- delta ≈ **31 192.12 ₽** = `2 · Σ storno ≈ 2 · 15 596.06`.

## Что изменено

- `site/src/Marketplace/Infrastructure/Query/UnprocessedCostsQuery.php:166` — `SUM(c.amount)` → `SUM(CASE WHEN c.operation_type = 'storno' THEN -ABS(c.amount) ELSE ABS(c.amount) END)`.
- `site/src/Marketplace/Infrastructure/Query/PreflightCostsQuery.php:44` — та же замена только для `net_amount_for_pl`, внутри `FILTER (include_in_pl=true AND pl_category_id IS NOT NULL)`. Сопутствующие агрегаты (`total`, `already_processed`, `without_pl_mapping`, `excluded_from_pl`) **не трогал**.
- `site/tests/Integration/Marketplace/UnprocessedCostsQuerySymmetryTest.php` — новый integration-test, 9 сценариев (only charge, charge+storno same cat, standalone-storno category, net-negative category, `include_in_pl=false`, `document_id IS NOT NULL`, `cost_date` вне периода, **нарушенный инвариант `amount < 0` — защита от регрессии ABS**, воспроизведение production-инцидента).

Литерал `'storno'` тот же, что в `UnprocessedCostsQuery::execute`, `CostReconciliationQuery`, `CostsVerifyQuery` — общего SQL-реестра/константы в кодовой базе пока нет, в этом PR его создавать не стал (roadmap Задача 3). Внешнего `ABS(SUM(...))` нет — `ABS` per-row внутри CASE, симметрично с `costs_amount`/`storno_amount` в `execute()`.

## Чего НЕТ в этом PR (выносится в следующие задачи)

- Транзакция вокруг handler'а закрытия этапа (Задача 2).
- Cleanup висячих `marketplace_costs.document_id` от старых падений (Задача 2).
- Единый SQL-fragment / реестр `OperationType` для consistent signed-amount выражения (возможная Задача 3).
- Никаких refactor/rename/форматирования в правленых файлах — diff минимальный для hotfix.

## Review checklist

- [x] обе правки используют одинаковый литерал `'storno'`, как и соседние queries
- [x] нет внешнего `ABS(SUM(...))` вокруг всего агрегата; `ABS(c.amount)` per-row внутри CASE для симметрии с `execute()`
- [ ] новые тесты падают на `HEAD~1` и проходят на `HEAD` — **требует CI-прогона**: в среде Claude нет docker/vendor, verify'ил логику аналитически (сценарии 2/3/4/8/incident детерминированно валят `assertEqualsWithDelta` на пре-фикс SQL). Рекомендую в CI запустить `composer test:int --filter UnprocessedCostsQuerySymmetryTest` на `HEAD~1` для финального подтверждения.
- [ ] preflight в UI покажет новое нетто (меньше старого на `2 × Σ storno`)

## Test plan

- [ ] Прогнать `composer test:int --filter UnprocessedCostsQuerySymmetryTest` на ветке — должно быть 9 зелёных.
- [ ] Опционально: `git checkout HEAD~2 site/src/Marketplace/Infrastructure/Query/` + прогнать те же тесты — сценарии 2/3/4/8/incident должны стать красными.
- [ ] На staging вручную закрыть январь 2026 для company `b57d7682-…`. Preflight net должен показать ≈ 3 735 291.76 ₽. После «Закрыть этап» — тишина в Sentry, `PLDocument` создан, `marketplace_costs.document_id` заполнен, статус месяца → Закрыт.
- [ ] На проде повторить сначала для одной компании, потом для второй.

https://claude.ai/code/session_01M7AefEDpzUkXzU8FbcRrq8