### PR TITLE
fix(marketplace): SALE_GROSS для Ozon завышал выручку на multi-item postings

### DIFF
--- a/site/src/Marketplace/Controller/Debug/SaleGrossDebugController.php
+++ b/site/src/Marketplace/Controller/Debug/SaleGrossDebugController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Marketplace\Controller\Debug;
 
 use App\Marketplace\Enum\MarketplaceType;
+use App\Shared\Service\ActiveCompanyService;
 use Doctrine\DBAL\Connection;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -25,26 +26,34 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted('ROLE_USER')]
 final class SaleGrossDebugController extends AbstractController
 {
-    private const UUID_REGEX = '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i';
     private const DATE_REGEX = '/^\d{4}-\d{2}-\d{2}$/';
     private const TOP_DELTA_LIMIT = 50;
 
     public function __construct(
         private readonly Connection $connection,
+        private readonly ActiveCompanyService $activeCompanyService,
     ) {
     }
 
     #[Route('/sale-gross', name: 'marketplace_debug_sale_gross', methods: ['GET'])]
     public function __invoke(Request $request): JsonResponse
     {
-        $companyId = (string) $request->query->get('company_id', '');
+        // IDOR-protection: company всегда берётся из сессии активной компании
+        // пользователя; query-параметр company_id оставлен для читаемости URL
+        // в спецификации, но игнорируется / валидируется на совпадение.
+        $companyId = (string) $this->activeCompanyService->getActiveCompany()->getId();
+
+        $requestedCompanyId = (string) $request->query->get('company_id', '');
+        if ($requestedCompanyId !== '' && $requestedCompanyId !== $companyId) {
+            return $this->json([
+                'error' => 'company_id в query не совпадает с активной компанией пользователя',
+            ], 403);
+        }
+
         $marketplace = (string) $request->query->get('marketplace', '');
         $from = (string) $request->query->get('from', '');
         $to = (string) $request->query->get('to', '');
 
-        if (!preg_match(self::UUID_REGEX, $companyId)) {
-            return $this->json(['error' => 'company_id must be a UUID'], 400);
-        }
         if (MarketplaceType::tryFrom($marketplace) === null) {
             return $this->json([
                 'error' => 'marketplace must be one of: '

--- a/site/src/Marketplace/Controller/Debug/SaleGrossDebugController.php
+++ b/site/src/Marketplace/Controller/Debug/SaleGrossDebugController.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Controller\Debug;
+
+use App\Marketplace\Enum\MarketplaceType;
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Временный debug-эндпоинт для подтверждения гипотезы о завышении SALE_GROSS
+ * на multi-item posting'ах Ozon. Сравнивает формулу ОПиУ
+ * (price_per_unit × quantity) с формулой Unit-экономики (total_revenue)
+ * на реальных прод-данных.
+ *
+ * @deprecated debug endpoint, remove after 2026-05-04 (2 недели от 2026-04-20).
+ *             Follow-up: удалить файл SaleGrossDebugController.php и его тесты.
+ */
+#[Route('/_debug/marketplace')]
+#[IsGranted('ROLE_USER')]
+final class SaleGrossDebugController extends AbstractController
+{
+    private const UUID_REGEX = '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i';
+    private const DATE_REGEX = '/^\d{4}-\d{2}-\d{2}$/';
+    private const TOP_DELTA_LIMIT = 50;
+
+    public function __construct(
+        private readonly Connection $connection,
+    ) {
+    }
+
+    #[Route('/sale-gross', name: 'marketplace_debug_sale_gross', methods: ['GET'])]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $companyId = (string) $request->query->get('company_id', '');
+        $marketplace = (string) $request->query->get('marketplace', '');
+        $from = (string) $request->query->get('from', '');
+        $to = (string) $request->query->get('to', '');
+
+        if (!preg_match(self::UUID_REGEX, $companyId)) {
+            return $this->json(['error' => 'company_id must be a UUID'], 400);
+        }
+        if (MarketplaceType::tryFrom($marketplace) === null) {
+            return $this->json([
+                'error' => 'marketplace must be one of: '
+                    . implode(', ', array_map(static fn (MarketplaceType $m): string => $m->value, MarketplaceType::cases())),
+            ], 400);
+        }
+        if (!preg_match(self::DATE_REGEX, $from) || !$this->isValidDate($from)) {
+            return $this->json(['error' => 'from must be in Y-m-d format'], 400);
+        }
+        if (!preg_match(self::DATE_REGEX, $to) || !$this->isValidDate($to)) {
+            return $this->json(['error' => 'to must be in Y-m-d format'], 400);
+        }
+
+        $params = [
+            'companyId'  => $companyId,
+            'marketplace' => $marketplace,
+            'periodFrom' => $from,
+            'periodTo'   => $to,
+        ];
+
+        return $this->json([
+            'meta' => [
+                'company_id'   => $companyId,
+                'marketplace'  => $marketplace,
+                'period'       => "{$from} – {$to}",
+                'generated_at' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
+                'hint'         => 'by_quantity: если delta=0 на quantity=1 и delta>0 на quantity≥2 — гипотеза SALE_GROSS inflation подтверждена.',
+            ],
+            'totals'         => $this->totals($params),
+            'by_quantity'    => $this->byQuantity($params),
+            'top_delta_rows' => $this->topDeltaRows($params),
+        ], 200, [], ['json_encode_options' => JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE]);
+    }
+
+    /**
+     * @param array<string, string> $params
+     * @return array<string, mixed>
+     */
+    private function totals(array $params): array
+    {
+        $row = $this->connection->fetchAssociative(
+            <<<'SQL'
+            SELECT
+                COALESCE(SUM(s.total_revenue), 0)                AS unit_revenue,
+                COALESCE(SUM(s.price_per_unit * s.quantity), 0)  AS pnl_gross_revenue,
+                COUNT(*)                                         AS rows_total,
+                COUNT(*) FILTER (WHERE s.document_id IS NULL)    AS rows_open,
+                COUNT(*) FILTER (WHERE s.document_id IS NOT NULL) AS rows_closed
+            FROM marketplace_sales s
+            WHERE s.company_id = :companyId
+              AND s.marketplace = :marketplace
+              AND s.sale_date BETWEEN :periodFrom AND :periodTo
+            SQL,
+            $params,
+        );
+
+        $row = $row ?: [];
+        $unit = (float) ($row['unit_revenue'] ?? 0);
+        $pnl  = (float) ($row['pnl_gross_revenue'] ?? 0);
+
+        return [
+            'unit_revenue'      => round($unit, 2),
+            'pnl_gross_revenue' => round($pnl, 2),
+            'delta'             => round($pnl - $unit, 2),
+            'rows_total'        => (int) ($row['rows_total'] ?? 0),
+            'rows_open'         => (int) ($row['rows_open'] ?? 0),
+            'rows_closed'       => (int) ($row['rows_closed'] ?? 0),
+        ];
+    }
+
+    /**
+     * @param array<string, string> $params
+     * @return list<array<string, mixed>>
+     */
+    private function byQuantity(array $params): array
+    {
+        $rows = $this->connection->fetchAllAssociative(
+            <<<'SQL'
+            SELECT
+                s.quantity                                      AS quantity,
+                COUNT(*)                                        AS rows,
+                COALESCE(SUM(s.total_revenue), 0)               AS unit_revenue,
+                COALESCE(SUM(s.price_per_unit * s.quantity), 0) AS pnl_revenue
+            FROM marketplace_sales s
+            WHERE s.company_id = :companyId
+              AND s.marketplace = :marketplace
+              AND s.sale_date BETWEEN :periodFrom AND :periodTo
+            GROUP BY s.quantity
+            ORDER BY s.quantity
+            SQL,
+            $params,
+        );
+
+        return array_map(static function (array $row): array {
+            $unit = (float) $row['unit_revenue'];
+            $pnl  = (float) $row['pnl_revenue'];
+
+            return [
+                'quantity'     => (int) $row['quantity'],
+                'rows'         => (int) $row['rows'],
+                'unit_revenue' => round($unit, 2),
+                'pnl_revenue'  => round($pnl, 2),
+                'delta'        => round($pnl - $unit, 2),
+            ];
+        }, $rows);
+    }
+
+    /**
+     * @param array<string, string> $params
+     * @return list<array<string, mixed>>
+     */
+    private function topDeltaRows(array $params): array
+    {
+        $limit = self::TOP_DELTA_LIMIT;
+        $rows = $this->connection->fetchAllAssociative(
+            <<<SQL
+            SELECT
+                s.id                                    AS id,
+                s.external_order_id                     AS external_order_id,
+                s.sale_date::text                       AS sale_date,
+                s.quantity                              AS quantity,
+                s.price_per_unit                        AS price_per_unit,
+                s.total_revenue                         AS total_revenue,
+                (s.price_per_unit * s.quantity)         AS pnl_value,
+                (s.price_per_unit * s.quantity - s.total_revenue) AS delta,
+                s.document_id                           AS document_id
+            FROM marketplace_sales s
+            WHERE s.company_id = :companyId
+              AND s.marketplace = :marketplace
+              AND s.sale_date BETWEEN :periodFrom AND :periodTo
+              AND (s.price_per_unit * s.quantity - s.total_revenue) <> 0
+            ORDER BY ABS(s.price_per_unit * s.quantity - s.total_revenue) DESC
+            LIMIT {$limit}
+            SQL,
+            $params,
+        );
+
+        return array_map(static fn (array $row): array => [
+            'id'                => $row['id'],
+            'external_order_id' => $row['external_order_id'],
+            'sale_date'         => $row['sale_date'],
+            'quantity'          => (int) $row['quantity'],
+            'price_per_unit'    => (float) $row['price_per_unit'],
+            'total_revenue'     => (float) $row['total_revenue'],
+            'pnl_value'         => round((float) $row['pnl_value'], 2),
+            'delta'             => round((float) $row['delta'], 2),
+            'document_id'       => $row['document_id'],
+        ], $rows);
+    }
+
+    private function isValidDate(string $date): bool
+    {
+        $dt = \DateTimeImmutable::createFromFormat('Y-m-d', $date);
+
+        return $dt !== null && $dt->format('Y-m-d') === $date;
+    }
+}

--- a/site/src/Marketplace/Enum/AmountSource.php
+++ b/site/src/Marketplace/Enum/AmountSource.php
@@ -9,6 +9,8 @@ namespace App\Marketplace\Enum;
  *
  * Продажи (из marketplace_sales):
  *   SALE_GROSS      → price_per_unit × quantity  (цена продавца × кол-во)
+ *                     ⚠ Для Ozon разворачивается в total_revenue: у Ozon
+ *                       price_per_unit хранит accrual за posting целиком.
  *   SALE_REVENUE    → total_revenue              (accruals_for_sale из финансовых транзакций)
  *   SALE_COST_PRICE → cost_price × quantity      (себестоимость)
  *
@@ -70,10 +72,19 @@ enum AmountSource: string
         };
     }
 
-    public function getSqlExpression(): string
+    /**
+     * Для Ozon SALE_GROSS возвращает s.total_revenue, т.к. price_per_unit
+     * у Ozon хранит accrual за posting целиком (не цену за штуку), а quantity —
+     * число item'ов в posting'е. Формула price_per_unit × quantity умножала бы
+     * accrual на количество товаров в заказе и завышала выручку на
+     * multi-item posting'ах (см. OzonSalesRawProcessor::processBatch:216-229).
+     */
+    public function getSqlExpression(?MarketplaceType $marketplace = null): string
     {
         return match ($this) {
-            self::SALE_GROSS        => 's.price_per_unit * s.quantity',
+            self::SALE_GROSS        => $marketplace === MarketplaceType::OZON
+                ? 's.total_revenue'
+                : 's.price_per_unit * s.quantity',
             self::SALE_REVENUE      => 's.total_revenue',
             self::SALE_COST_PRICE   => 's.cost_price * s.quantity',
             self::SALE_REALIZATION  => 'r.total_amount',        // marketplace_ozon_realizations: price_per_instance × quantity

--- a/site/src/Marketplace/Infrastructure/Query/UnprocessedSalesQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/UnprocessedSalesQuery.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Marketplace\Infrastructure\Query;
 
+use App\Marketplace\Enum\AmountSource;
+use App\Marketplace\Enum\MarketplaceType;
 use Doctrine\DBAL\Connection;
 
 /**
@@ -37,21 +39,26 @@ final class UnprocessedSalesQuery
         string $periodFrom,
         string $periodTo,
     ): array {
-        $sql = <<<'SQL'
+        $marketplaceEnum = MarketplaceType::from($marketplace);
+        $saleGrossExpr = AmountSource::SALE_GROSS->getSqlExpression($marketplaceEnum);
+
+        $amountCase = <<<SQL
+            CASE m.amount_source
+                WHEN 'sale_gross'      THEN $saleGrossExpr
+                WHEN 'sale_revenue'    THEN s.total_revenue
+                WHEN 'sale_cost_price' THEN COALESCE(s.cost_price, 0) * s.quantity
+                ELSE 0
+            END
+        SQL;
+
+        $sql = <<<SQL
             SELECT
                 m.pl_category_id,
                 m.project_direction_id,
                 m.is_negative,
                 m.description_template,
                 m.sort_order,
-                SUM(
-                    CASE m.amount_source
-                        WHEN 'sale_gross'      THEN s.price_per_unit * s.quantity
-                        WHEN 'sale_revenue'    THEN s.total_revenue
-                        WHEN 'sale_cost_price' THEN COALESCE(s.cost_price, 0) * s.quantity
-                        ELSE 0
-                    END
-                ) AS total_amount
+                SUM($amountCase) AS total_amount
             FROM marketplace_sales s
             INNER JOIN marketplace_sale_mappings m
                 ON m.company_id = s.company_id
@@ -69,14 +76,7 @@ final class UnprocessedSalesQuery
                 m.is_negative,
                 m.description_template,
                 m.sort_order
-            HAVING SUM(
-                CASE m.amount_source
-                    WHEN 'sale_gross'      THEN s.price_per_unit * s.quantity
-                    WHEN 'sale_revenue'    THEN s.total_revenue
-                    WHEN 'sale_cost_price' THEN COALESCE(s.cost_price, 0) * s.quantity
-                    ELSE 0
-                END
-            ) != 0
+            HAVING SUM($amountCase) != 0
             ORDER BY m.sort_order ASC
         SQL;
 

--- a/site/tests/Integration/Marketplace/UnprocessedSalesQueryOzonMultiItemTest.php
+++ b/site/tests/Integration/Marketplace/UnprocessedSalesQueryOzonMultiItemTest.php
@@ -1,0 +1,310 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Marketplace;
+
+use App\Company\Entity\Company;
+use App\Finance\Entity\PLCategory;
+use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Entity\MarketplaceSale;
+use App\Marketplace\Entity\MarketplaceSaleMapping;
+use App\Marketplace\Enum\AmountSource;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Facade\MarketplaceFacade;
+use App\Marketplace\Infrastructure\Query\UnprocessedSalesQuery;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Builders\Finance\PLCategoryBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * Регрессия бага SALE_GROSS для Ozon:
+ * price_per_unit у Ozon хранит accrual за posting целиком (не цену за штуку),
+ * а quantity — число item'ов в posting'е. Старая формула
+ * price_per_unit × quantity умножала accrual на количество товаров и
+ * завышала выручку на multi-item posting'ах
+ * (см. OzonSalesRawProcessor::processBatch:216-229).
+ *
+ * Фикс: AmountSource::SALE_GROSS для Ozon разворачивается в s.total_revenue.
+ */
+final class UnprocessedSalesQueryOzonMultiItemTest extends IntegrationTestCase
+{
+    private const PERIOD_FROM = '2026-01-01';
+    private const PERIOD_TO = '2026-01-31';
+
+    private Company $company;
+    private PLCategory $plCategory;
+    private MarketplaceListing $ozonListing;
+    private MarketplaceListing $wbListing;
+
+    private UnprocessedSalesQuery $unprocessedSalesQuery;
+    private MarketplaceFacade $marketplaceFacade;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $owner = UserBuilder::aUser()
+            ->withId('22222222-2222-2222-2222-000000000099')
+            ->withEmail('ozon-sale-gross@example.test')
+            ->build();
+
+        $this->company = CompanyBuilder::aCompany()
+            ->withId('11111111-1111-1111-1111-000000000099')
+            ->withOwner($owner)
+            ->build();
+
+        $this->plCategory = PLCategoryBuilder::aPLCategory()
+            ->forCompany($this->company)
+            ->withName('MP_GROSS_REVENUE')
+            ->build();
+
+        $this->ozonListing = new MarketplaceListing(
+            Uuid::uuid4()->toString(),
+            $this->company,
+            null,
+            MarketplaceType::OZON,
+        );
+        $this->ozonListing->setMarketplaceSku('ozon-sku-1');
+        $this->ozonListing->setPrice('1000.00');
+
+        $this->wbListing = new MarketplaceListing(
+            Uuid::uuid4()->toString(),
+            $this->company,
+            null,
+            MarketplaceType::WILDBERRIES,
+        );
+        $this->wbListing->setMarketplaceSku('wb-sku-1');
+        $this->wbListing->setPrice('400.00');
+
+        $this->em->persist($owner);
+        $this->em->persist($this->company);
+        $this->em->persist($this->plCategory);
+        $this->em->persist($this->ozonListing);
+        $this->em->persist($this->wbListing);
+        $this->em->flush();
+
+        $this->unprocessedSalesQuery = self::getContainer()->get(UnprocessedSalesQuery::class);
+        $this->marketplaceFacade = self::getContainer()->get(MarketplaceFacade::class);
+    }
+
+    /**
+     * Тест 1: multi-item posting Ozon — воспроизводит баг.
+     *
+     * До фикса: 3 × 1000 = 3000 (накрутка ×3).
+     * После фикса: total_revenue = 1000.
+     */
+    public function testOzonMultiItemPostingDoesNotInflateRevenue(): void
+    {
+        $this->createSaleMapping(MarketplaceType::OZON, AmountSource::SALE_GROSS);
+        $this->createOzonSale(quantity: 3, pricePerUnit: '1000.00', totalRevenue: '1000.00');
+        $this->em->flush();
+
+        $total = $this->getSaleGrossTotal('ozon');
+
+        self::assertEqualsWithDelta(
+            1000.0,
+            $total,
+            0.01,
+            'Для multi-item Ozon posting SALE_GROSS должен равняться total_revenue (1000), а не price_per_unit × quantity (3000).',
+        );
+    }
+
+    /**
+     * Тест 2: single-item posting Ozon — фикс не должен сломать норму.
+     */
+    public function testOzonSingleItemPostingUnchanged(): void
+    {
+        $this->createSaleMapping(MarketplaceType::OZON, AmountSource::SALE_GROSS);
+        $this->createOzonSale(quantity: 1, pricePerUnit: '1000.00', totalRevenue: '1000.00');
+        $this->em->flush();
+
+        self::assertEqualsWithDelta(1000.0, $this->getSaleGrossTotal('ozon'), 0.01);
+    }
+
+    /**
+     * Тест 3: Wildberries multi-item — другой маркетплейс не трогаем.
+     *
+     * WB: price_per_unit — реальная цена за штуку, формула ×quantity корректна.
+     */
+    public function testWildberriesMultiItemFormulaUnchanged(): void
+    {
+        $this->createSaleMapping(MarketplaceType::WILDBERRIES, AmountSource::SALE_GROSS);
+        $this->createWbSale(quantity: 3, pricePerUnit: '400.00', totalRevenue: '1200.00');
+        $this->em->flush();
+
+        self::assertEqualsWithDelta(1200.0, $this->getSaleGrossTotal('wildberries'), 0.01);
+    }
+
+    /**
+     * Тест 4: симметрия Unit-экономики и ОПиУ для одного и того же Ozon posting'а.
+     */
+    public function testUnitEconomyAndPnlAreSymmetricForOzonMultiItem(): void
+    {
+        $this->createSaleMapping(MarketplaceType::OZON, AmountSource::SALE_GROSS);
+        $saleDate = new \DateTimeImmutable('2026-01-15');
+        $this->createOzonSale(
+            quantity: 3,
+            pricePerUnit: '1000.00',
+            totalRevenue: '1000.00',
+            saleDate: $saleDate,
+        );
+        $this->em->flush();
+
+        $pnl = $this->getSaleGrossTotal('ozon');
+
+        $sales = $this->marketplaceFacade->getSalesForListingAndDate(
+            $this->company->getId(),
+            $this->ozonListing->getId(),
+            $saleDate,
+        );
+        $unit = 0.0;
+        foreach ($sales as $sale) {
+            $unit += (float) $sale->totalRevenue;
+        }
+
+        self::assertEqualsWithDelta(1000.0, $pnl, 0.01);
+        self::assertEqualsWithDelta(1000.0, $unit, 0.01);
+        self::assertEqualsWithDelta(
+            0.0,
+            abs($pnl - $unit),
+            0.01,
+            'Unit-экономика и ОПиУ SALE_GROSS обязаны давать одинаковую выручку на одном posting\'е Ozon.',
+        );
+    }
+
+    /**
+     * Тест 5: инцидентная фикстура из 3 posting'ов.
+     *
+     * До фикса: SALE_GROSS = 100000 + 50000×2 + 30000×3 = 290 000.
+     * После фикса: SALE_GROSS = 100000 + 50000 + 30000 = 180 000 = Σ total_revenue.
+     */
+    public function testOzonIncidentReproductionThreePostingsSumsToTotalRevenue(): void
+    {
+        $this->createSaleMapping(MarketplaceType::OZON, AmountSource::SALE_GROSS);
+        $this->createOzonSale(quantity: 1, pricePerUnit: '100000.00', totalRevenue: '100000.00', externalOrderId: 'POST-A');
+        $this->createOzonSale(quantity: 2, pricePerUnit: '50000.00',  totalRevenue: '50000.00',  externalOrderId: 'POST-B');
+        $this->createOzonSale(quantity: 3, pricePerUnit: '30000.00',  totalRevenue: '30000.00',  externalOrderId: 'POST-C');
+        $this->em->flush();
+
+        $pnl = $this->getSaleGrossTotal('ozon');
+
+        self::assertEqualsWithDelta(180000.0, $pnl, 0.01);
+
+        $totalRevenueSum = (float) $this->em->getConnection()->fetchOne(
+            'SELECT COALESCE(SUM(total_revenue), 0) FROM marketplace_sales
+             WHERE company_id = :companyId AND marketplace = :marketplace
+             AND sale_date BETWEEN :periodFrom AND :periodTo',
+            [
+                'companyId' => $this->company->getId(),
+                'marketplace' => 'ozon',
+                'periodFrom' => self::PERIOD_FROM,
+                'periodTo' => self::PERIOD_TO,
+            ],
+        );
+
+        self::assertEqualsWithDelta(180000.0, $totalRevenueSum, 0.01);
+        self::assertEqualsWithDelta(
+            0.0,
+            abs($pnl - $totalRevenueSum),
+            0.01,
+            'После фикса SALE_GROSS (ОПиУ) должен совпадать с Σ total_revenue (Unit-экономика).',
+        );
+    }
+
+    // ------------------------- helpers -------------------------
+
+    private function getSaleGrossTotal(string $marketplace): float
+    {
+        $rows = $this->unprocessedSalesQuery->execute(
+            $this->company->getId(),
+            $marketplace,
+            self::PERIOD_FROM,
+            self::PERIOD_TO,
+        );
+
+        $total = 0.0;
+        foreach ($rows as $row) {
+            $total += (float) $row['total_amount'];
+        }
+
+        return $total;
+    }
+
+    private function createSaleMapping(MarketplaceType $marketplace, AmountSource $amountSource): MarketplaceSaleMapping
+    {
+        $mapping = new MarketplaceSaleMapping(
+            Uuid::uuid4()->toString(),
+            $this->company,
+            $marketplace,
+            $amountSource,
+            $this->plCategory,
+        );
+        $this->em->persist($mapping);
+
+        return $mapping;
+    }
+
+    private function createOzonSale(
+        int $quantity,
+        string $pricePerUnit,
+        string $totalRevenue,
+        ?\DateTimeImmutable $saleDate = null,
+        ?string $externalOrderId = null,
+    ): MarketplaceSale {
+        return $this->createSale(
+            MarketplaceType::OZON,
+            $this->ozonListing,
+            $quantity,
+            $pricePerUnit,
+            $totalRevenue,
+            $saleDate,
+            $externalOrderId,
+        );
+    }
+
+    private function createWbSale(
+        int $quantity,
+        string $pricePerUnit,
+        string $totalRevenue,
+        ?\DateTimeImmutable $saleDate = null,
+        ?string $externalOrderId = null,
+    ): MarketplaceSale {
+        return $this->createSale(
+            MarketplaceType::WILDBERRIES,
+            $this->wbListing,
+            $quantity,
+            $pricePerUnit,
+            $totalRevenue,
+            $saleDate,
+            $externalOrderId,
+        );
+    }
+
+    private function createSale(
+        MarketplaceType $marketplace,
+        MarketplaceListing $listing,
+        int $quantity,
+        string $pricePerUnit,
+        string $totalRevenue,
+        ?\DateTimeImmutable $saleDate,
+        ?string $externalOrderId,
+    ): MarketplaceSale {
+        $sale = new MarketplaceSale(
+            Uuid::uuid4()->toString(),
+            $this->company,
+            $listing,
+            $marketplace,
+        );
+        $sale->setExternalOrderId($externalOrderId ?? ('ext-' . Uuid::uuid4()->toString()));
+        $sale->setSaleDate($saleDate ?? new \DateTimeImmutable('2026-01-15'));
+        $sale->setQuantity($quantity);
+        $sale->setPricePerUnit($pricePerUnit);
+        $sale->setTotalRevenue($totalRevenue);
+        $this->em->persist($sale);
+
+        return $sale;
+    }
+}


### PR DESCRIPTION
## Контекст

Два отчёта читают из `marketplace_sales`, но на январь 2026 для
company `b57d7682-505f-4b74-86f8-953d32d59874` / `marketplace=ozon`
дают разные суммы выручки:

- Unit-экономика: **5 298 086** (`SUM(s.total_revenue)`)
- ОПиУ `MP_GROSS_REVENUE`: **5 390 510** (`SUM(s.price_per_unit * s.quantity)`)
- Разница: **+92 424** (~1.7%)

## Причина

У Ozon одна Sale-запись создаётся на posting целиком
(`OzonSalesRawProcessor::processBatch:216-229`):

```php
$sale->setQuantity(count($op['items'] ?? []) ?: 1);
$sale->setPricePerUnit((string) $accrual);   // accrual целиком, не цена за штуку
$sale->setTotalRevenue((string) $accrual);
```

Для Ozon `price_per_unit ≡ total_revenue ≡ accrual` (начисление за posting
целиком), а `quantity` = число item'ов в posting'е. На multi-item posting'ах
формула `price_per_unit × quantity` умножала accrual на количество товаров
и завышала выручку в N раз. `total_revenue` оставался корректным.

## Фикс

`AmountSource::getSqlExpression(?MarketplaceType $marketplace = null)` — для
Ozon `SALE_GROSS` возвращает `s.total_revenue`. Для остальных маркетплейсов
формула не меняется (у WB `price_per_unit` действительно цена за штуку).

`UnprocessedSalesQuery::execute` подставляет marketplace-aware выражение
в CASE через enum-метод. Marketplace уже приходит параметром.

## Что НЕ сделано и почему

- **Семантика `price_per_unit` в `OzonSalesRawProcessor` не исправлена.**
  Правка потребовала бы бэкфилла исторических данных (всех Sale-записей
  Ozon), делается отдельной задачей.
- **Unit-экономика** уже использует правильное поле (`total_revenue`),
  её не трогал.
- **Формулы `SALE_REVENUE`, `SALE_COST_PRICE`** — без изменений.
- **Маппинги в БД** — без изменений.

## Debug-эндпоинт

Добавлен временный read-only контроллер для подтверждения гипотезы на
прод-данных (прод-SQL у команды недоступен):

```
GET /_debug/marketplace/sale-gross?company_id=...&marketplace=ozon&from=2026-01-01&to=2026-01-31
```

Защита: `ROLE_USER`. Возвращает `totals`, `by_quantity`, `top_delta_rows`
(лимит 50). Валидация параметров: company_id — uuid, marketplace — enum,
даты — Y-m-d. Никаких UPDATE/INSERT/DELETE.

**Порядок проверки:**
1. Мёрдж PR в staging/прод (read-only, безопасно).
2. Открыть URL в браузере, сохранить JSON.
3. Если `by_quantity` показывает `delta = 0` на `quantity = 1` и `delta > 0`
   на `quantity ≥ 2`, а сумма дельт ≈ 92 424 — гипотеза подтверждена.
4. Если результат иной — откатить PR или оставить debug, вернуться к
   разведке.

**Жизненный цикл.** Контроллер помечен `@deprecated`. **Удалить файл
`site/src/Marketplace/Controller/Debug/SaleGrossDebugController.php` не
позднее 2026-05-04** (2 недели от 2026-04-20). Отдельный follow-up PR или
issue.

## Чек-лист

- [x] формула `SALE_GROSS` для Ozon возвращает `s.total_revenue`
- [x] формула для других маркетплейсов не изменилась (тест 3 WB)
- [x] Unit и ОПиУ теперь симметричны (тест 4)
- [x] `OzonSalesRawProcessor` не тронут
- [ ] тест 1 красный на `HEAD~1`, зелёный на `HEAD` — **нужно прогнать
  локально**: окружение для `phpunit` здесь не поднимается, проверял только
  `php -l`. Ожидаемый вывод:
  - `HEAD~1`: `Failed asserting that 3000.0 matches expected 1000.0 ±0.01`
  - `HEAD`: зелёный

## Тесты

`site/tests/Integration/Marketplace/UnprocessedSalesQueryOzonMultiItemTest.php`:

1. `testOzonMultiItemPostingDoesNotInflateRevenue` — воспроизводит баг:
   `quantity=3`, `price_per_unit=1000`, `total_revenue=1000`. До фикса:
   3000. После: 1000.
2. `testOzonSingleItemPostingUnchanged` — норма `quantity=1` не ломается.
3. `testWildberriesMultiItemFormulaUnchanged` — WB `quantity=3`,
   `price_per_unit=400`, `total_revenue=1200` → 1200 (формула WB не
   изменилась).
4. `testUnitEconomyAndPnlAreSymmetricForOzonMultiItem` — симметрия:
   `MarketplaceFacade::getSalesForListingAndDate` и `UnprocessedSalesQuery`
   дают одинаковое число.
5. `testOzonIncidentReproductionThreePostingsSumsToTotalRevenue` — 3
   posting'а (1×100000, 2×50000, 3×30000). До фикса: 290 000. После:
   180 000 = Σ total_revenue.

https://claude.ai/code/session_017KRStKpYgeyraurNUqFNsu