### PR TITLE
fix(marketplace): транзакционный rollback закрытия месяца + cleanup висячих document_id

### DIFF
--- a/site/migrations/Version20260420160500.php
+++ b/site/migrations/Version20260420160500.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Data migration: очистка висячих `marketplace_costs.document_id`, которые
+ * ссылаются на уже удалённые строки `documents`.
+ *
+ * Источник мусора — старый код `CloseMonthStageAction::__invoke`, который при
+ * падении контрольной суммы делал «ручной rollback» через
+ * `FinanceFacade::deletePLDocument`, но не откатывал сырой UPDATE
+ * `marketplace_costs.document_id`, выполненный ранее. DELETE и UPDATE
+ * коммитились разными транзакциями, и после падения в `marketplace_costs`
+ * оставались строки со ссылками на уже удалённые документы. Это ломало
+ * preflight (`document_id IS NULL` — необходимое условие для повторного
+ * закрытия месяца).
+ *
+ * Начиная с PR этой задачи handler обёрнут в `EntityManager::wrapInTransaction`
+ * → новый мусор появляться не будет. Миграция чистит только исторический
+ * мусор, оставшийся от инцидентов до фикса.
+ *
+ * См. Sentry issue по неудачным закрытиям месяца + PR с `wrapInTransaction`.
+ */
+final class Version20260420160500 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Marketplace: NULL для висячих marketplace_costs.document_id, ссылающихся на удалённые documents';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $orphanCount = (int) $this->connection->fetchOne(<<<'SQL'
+            SELECT COUNT(*)
+            FROM marketplace_costs c
+            WHERE c.document_id IS NOT NULL
+              AND NOT EXISTS (
+                  SELECT 1 FROM documents d WHERE d.id = c.document_id
+              )
+        SQL);
+
+        $this->write(sprintf(
+            '    <comment>marketplace_costs orphan document_id rows to NULL: %d</comment>',
+            $orphanCount,
+        ));
+
+        if ($orphanCount === 0) {
+            return;
+        }
+
+        $this->addSql(<<<'SQL'
+            UPDATE marketplace_costs c
+            SET document_id = NULL,
+                updated_at = NOW()
+            WHERE c.document_id IS NOT NULL
+              AND NOT EXISTS (
+                  SELECT 1 FROM documents d WHERE d.id = c.document_id
+              )
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Интенционально пусто: восстановить ссылки на уже удалённые документы
+        // невозможно, бизнес-данных миграция не теряет (сами строки затрат
+        // остаются на месте, обнуляется только «висячий» указатель).
+    }
+}

--- a/site/src/Marketplace/Application/CloseMonthStageAction.php
+++ b/site/src/Marketplace/Application/CloseMonthStageAction.php
@@ -18,6 +18,7 @@ use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Infrastructure\Query\UnprocessedCostsQuery;
 use App\Marketplace\Repository\MarketplaceConnectionRepository;
 use App\Marketplace\Repository\MarketplaceMonthCloseRepository;
+use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
 
@@ -43,6 +44,7 @@ final class CloseMonthStageAction
         private readonly MarketplaceConnectionRepository    $connectionRepository,
         private readonly FinanceFacade                      $financeFacade,
         private readonly UnprocessedCostsQuery              $unprocessedCostsQuery,
+        private readonly EntityManagerInterface             $entityManager,
         private readonly LoggerInterface                    $logger,
         private readonly iterable                           $dataSources,
     ) {
@@ -53,6 +55,21 @@ final class CloseMonthStageAction
      * @throws \DomainException если preflight не пройден
      */
     public function __invoke(CloseMonthStageCommand $command): array
+    {
+        // Оборачиваем весь pipeline в одну Doctrine-транзакцию:
+        // save PLDocument (ORM), PLRegister-пересчёт (тот же EM),
+        // MarkProcessedQuery::markCosts (DBAL Connection того же EM).
+        // При любом throw — автоматический rollback, ничего не коммитится,
+        // ретраи Messenger стартуют с чистого состояния БД.
+        return $this->entityManager->wrapInTransaction(function () use ($command): array {
+            return $this->doInvoke($command);
+        });
+    }
+
+    /**
+     * @return array{monthCloseId: string, plDocumentIds: string[], preflightResult: PreflightResult}
+     */
+    private function doInvoke(CloseMonthStageCommand $command): array
     {
         $stage       = CloseStage::from($command->stage);
         $marketplace = MarketplaceType::from($command->marketplace);
@@ -207,9 +224,11 @@ final class CloseMonthStageAction
                 $delta = abs((float) $controlSumBefore - (float) $plDocumentSum);
 
                 if ($delta > 0.01) {
-                    // Критическая ошибка — откатываем через удаление документа
-                    $this->financeFacade->deletePLDocument($command->companyId, $documentId);
-
+                    // Контрольная сумма не сошлась — бросаем исключение, внешний
+                    // wrapInTransaction откатит создание PLDocument и UPDATE
+                    // marketplace_costs.document_id (ручной deletePLDocument
+                    // больше не нужен — раньше он оставлял висящий document_id,
+                    // т.к. DELETE коммитился отдельно от UPDATE).
                     throw new \RuntimeException(sprintf(
                         '[MonthClose] Контрольная сумма не сошлась: marketplace_costs=%s, PLDocument=%s, delta=%s. Документ удалён, закрытие отменено.',
                         $controlSumBefore,

--- a/site/src/Marketplace/Controller/Debug/OrphanDocumentIdDebugController.php
+++ b/site/src/Marketplace/Controller/Debug/OrphanDocumentIdDebugController.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Controller\Debug;
+
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Pre-flight проверка для data-migration очистки `marketplace_costs.document_id`,
+ * ссылающихся на уже удалённые `documents`. Возвращает totals + breakdown'ы,
+ * чтобы до применения миграции Version20260420160500 оценить blast radius и
+ * исключить посторонние сценарии появления orphan-строк.
+ *
+ * Только SELECT, никаких мутаций.
+ *
+ * @deprecated debug endpoint, remove after 2026-05-04 (2 недели от 2026-04-20).
+ *             Follow-up: удалить файл OrphanDocumentIdDebugController.php
+ *             и связанный route.
+ */
+#[Route('/_debug/marketplace')]
+#[IsGranted('ROLE_USER')]
+final class OrphanDocumentIdDebugController extends AbstractController
+{
+    private const SAMPLE_LIMIT = 50;
+
+    public function __construct(
+        private readonly Connection $connection,
+    ) {
+    }
+
+    #[Route('/orphan-document-ids', name: 'marketplace_debug_orphan_document_ids', methods: ['GET'])]
+    public function __invoke(): JsonResponse
+    {
+        return $this->json([
+            'meta' => [
+                'generated_at' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
+                'hint'         => 'Ожидание: десятки–сотни строк в январе–апреле 2026. Иное — стоп-сигнал, не применять миграцию.',
+                'note'         => 'Endpoint scoped to marketplace_costs rows where document_id references a documents.id that no longer exists.',
+            ],
+            'totals'         => $this->totals(),
+            'by_company'     => $this->byCompany(),
+            'by_period_month'=> $this->byPeriodMonth(),
+            'sample_rows'    => $this->sampleRows(),
+        ], 200, [], ['json_encode_options' => JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function totals(): array
+    {
+        $row = $this->connection->fetchAssociative(<<<'SQL'
+            SELECT
+                COUNT(*)                                            AS orphan_rows,
+                COUNT(DISTINCT c.company_id)                        AS affected_companies,
+                COUNT(DISTINCT c.marketplace)                       AS affected_marketplaces,
+                MIN(c.cost_date)::text                              AS earliest_cost_date,
+                MAX(c.cost_date)::text                              AS latest_cost_date,
+                MIN(c.updated_at)::text                             AS earliest_updated_at,
+                MAX(c.updated_at)::text                             AS latest_updated_at
+            FROM marketplace_costs c
+            LEFT JOIN documents d ON d.id = c.document_id
+            WHERE c.document_id IS NOT NULL
+              AND d.id IS NULL
+        SQL);
+
+        $row = $row ?: [];
+
+        return [
+            'orphan_rows'           => (int) ($row['orphan_rows'] ?? 0),
+            'affected_companies'    => (int) ($row['affected_companies'] ?? 0),
+            'affected_marketplaces' => (int) ($row['affected_marketplaces'] ?? 0),
+            'earliest_cost_date'    => $row['earliest_cost_date'] ?? null,
+            'latest_cost_date'      => $row['latest_cost_date'] ?? null,
+            'earliest_updated_at'   => $row['earliest_updated_at'] ?? null,
+            'latest_updated_at'     => $row['latest_updated_at'] ?? null,
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function byCompany(): array
+    {
+        $rows = $this->connection->fetchAllAssociative(<<<'SQL'
+            SELECT
+                c.company_id                 AS company_id,
+                COUNT(*)                     AS orphan_rows,
+                MIN(c.cost_date)::text       AS min_date,
+                MAX(c.cost_date)::text       AS max_date
+            FROM marketplace_costs c
+            LEFT JOIN documents d ON d.id = c.document_id
+            WHERE c.document_id IS NOT NULL
+              AND d.id IS NULL
+            GROUP BY c.company_id
+            ORDER BY COUNT(*) DESC
+        SQL);
+
+        return array_map(static fn (array $row): array => [
+            'company_id'  => $row['company_id'],
+            'orphan_rows' => (int) $row['orphan_rows'],
+            'min_date'    => $row['min_date'],
+            'max_date'    => $row['max_date'],
+        ], $rows);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function byPeriodMonth(): array
+    {
+        $rows = $this->connection->fetchAllAssociative(<<<'SQL'
+            SELECT
+                to_char(c.cost_date, 'YYYY-MM') AS month,
+                COUNT(*)                        AS rows
+            FROM marketplace_costs c
+            LEFT JOIN documents d ON d.id = c.document_id
+            WHERE c.document_id IS NOT NULL
+              AND d.id IS NULL
+            GROUP BY to_char(c.cost_date, 'YYYY-MM')
+            ORDER BY month ASC
+        SQL);
+
+        return array_map(static fn (array $row): array => [
+            'month' => $row['month'],
+            'rows'  => (int) $row['rows'],
+        ], $rows);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function sampleRows(): array
+    {
+        $limit = self::SAMPLE_LIMIT;
+        $rows = $this->connection->fetchAllAssociative(<<<SQL
+            SELECT
+                c.id                     AS id,
+                c.company_id             AS company_id,
+                c.marketplace            AS marketplace,
+                c.cost_date::text        AS cost_date,
+                c.document_id            AS document_id,
+                c.updated_at::text       AS updated_at
+            FROM marketplace_costs c
+            LEFT JOIN documents d ON d.id = c.document_id
+            WHERE c.document_id IS NOT NULL
+              AND d.id IS NULL
+            ORDER BY c.updated_at DESC, c.id ASC
+            LIMIT {$limit}
+        SQL);
+
+        return array_map(static fn (array $row): array => [
+            'id'          => $row['id'],
+            'company_id'  => $row['company_id'],
+            'marketplace' => $row['marketplace'],
+            'cost_date'   => $row['cost_date'],
+            'document_id' => $row['document_id'],
+            'updated_at'  => $row['updated_at'],
+        ], $rows);
+    }
+}

--- a/site/src/Marketplace/Controller/Debug/OrphanDocumentIdDebugController.php
+++ b/site/src/Marketplace/Controller/Debug/OrphanDocumentIdDebugController.php
@@ -23,7 +23,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
  *             и связанный route.
  */
 #[Route('/_debug/marketplace')]
-#[IsGranted('ROLE_USER')]
+#[IsGranted('ROLE_SUPER_ADMIN')]
 final class OrphanDocumentIdDebugController extends AbstractController
 {
     private const SAMPLE_LIMIT = 50;

--- a/site/tests/Integration/Marketplace/CloseMonthStageActionRollbackTest.php
+++ b/site/tests/Integration/Marketplace/CloseMonthStageActionRollbackTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Marketplace;
+
+use App\Company\Entity\Company;
+use App\Finance\Entity\PLCategory;
+use App\Finance\Enum\PLFlow;
+use App\Marketplace\Application\CloseMonthStageAction;
+use App\Marketplace\Application\Command\CloseMonthStageCommand;
+use App\Marketplace\Entity\MarketplaceCost;
+use App\Marketplace\Entity\MarketplaceCostCategory;
+use App\Marketplace\Entity\MarketplaceCostPLMapping;
+use App\Marketplace\Enum\CloseStage;
+use App\Marketplace\Enum\MarketplaceCostOperationType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Infrastructure\Query\UnprocessedCostsQuery;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+// UnprocessedCostsQuery — final, но для теста нужно подменить getControlSum,
+// оставив execute() реальным. Разрешение final-обхода вынесено в
+// tests/bootstrap.php (allowPaths), чтобы стрим-декор BypassFinals отработал
+// до первого autoload класса.
+
+/**
+ * Guarantees that CloseMonthStageAction откатывает ВСЮ свою запись при падении
+ * контрольной суммы: созданный PLDocument не виден, marketplace_costs.document_id
+ * остался NULL у всех строк периода, MarketplaceMonthClose не создан.
+ *
+ * До обёртки в wrapInTransaction этот тест не проходил — PLDocument и
+ * UPDATE document_id коммитились отдельно, а «ручной rollback» чистил только
+ * документ, оставляя висящий document_id в marketplace_costs.
+ */
+final class CloseMonthStageActionRollbackTest extends IntegrationTestCase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-000000000088';
+    private const OWNER_ID   = '22222222-2222-2222-2222-000000000088';
+    private const MARKETPLACE = MarketplaceType::OZON;
+    private const MARKETPLACE_VALUE = 'ozon';
+    private const YEAR  = 2026;
+    private const MONTH = 1;
+    private const PERIOD_FROM = '2026-01-01';
+    private const PERIOD_TO   = '2026-01-31';
+
+    private Company $company;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('rollback-owner@example.test')
+            ->build();
+
+        $this->company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $this->em->persist($owner);
+        $this->em->persist($this->company);
+        $this->em->flush();
+    }
+
+    public function testControlSumMismatchRollsBackEverything(): void
+    {
+        $plCategory = new PLCategory(Uuid::uuid4()->toString(), $this->company);
+        $plCategory->setName('Логистика Ozon');
+        $plCategory->setFlow(PLFlow::EXPENSE);
+        $this->em->persist($plCategory);
+
+        $costCategory = new MarketplaceCostCategory(
+            Uuid::uuid4()->toString(),
+            $this->company,
+            self::MARKETPLACE,
+        );
+        $costCategory->setCode('ozon_logistic_direct');
+        $costCategory->setName('Логистика до покупателя');
+        $this->em->persist($costCategory);
+
+        $mapping = new MarketplaceCostPLMapping(
+            Uuid::uuid4()->toString(),
+            self::COMPANY_ID,
+            $costCategory,
+            $plCategory->getId(),
+            true,
+        );
+        $this->em->persist($mapping);
+
+        // Два charge-строки; они замаппены, в периоде, document_id IS NULL.
+        $this->createCost($costCategory, '1000.00', MarketplaceCostOperationType::CHARGE, '2026-01-10');
+        $this->createCost($costCategory, '500.00',  MarketplaceCostOperationType::CHARGE, '2026-01-20');
+        $this->em->flush();
+        $this->em->clear();
+
+        // Override UnprocessedCostsQuery so getControlSum намеренно расходится с
+        // handler-ом (он агрегирует execute()). Формула А = реальная + 9999,
+        // формула В (handler) считается из execute() как есть → delta ≈ 9999.
+        $real = self::getContainer()->get(UnprocessedCostsQuery::class);
+        $stub = new class($real) extends UnprocessedCostsQuery {
+            public function __construct(private readonly UnprocessedCostsQuery $real)
+            {
+                // intentionally skip parent ctor: we delegate all work to $real
+            }
+
+            public function execute(string $companyId, string $marketplace, string $periodFrom, string $periodTo): array
+            {
+                return $this->real->execute($companyId, $marketplace, $periodFrom, $periodTo);
+            }
+
+            public function getControlSum(string $companyId, string $marketplace, string $periodFrom, string $periodTo): string
+            {
+                return bcadd(
+                    $this->real->getControlSum($companyId, $marketplace, $periodFrom, $periodTo),
+                    '9999.00',
+                    2,
+                );
+            }
+        };
+        self::getContainer()->set(UnprocessedCostsQuery::class, $stub);
+
+        /** @var CloseMonthStageAction $action */
+        $action = self::getContainer()->get(CloseMonthStageAction::class);
+
+        $command = new CloseMonthStageCommand(
+            companyId:   self::COMPANY_ID,
+            marketplace: self::MARKETPLACE_VALUE,
+            year:        self::YEAR,
+            month:       self::MONTH,
+            stage:       CloseStage::COSTS->value,
+            actorUserId: self::OWNER_ID,
+        );
+
+        $caught = null;
+        try {
+            ($action)($command);
+        } catch (\RuntimeException $e) {
+            $caught = $e;
+        }
+
+        self::assertNotNull($caught, 'CloseMonthStageAction должен был бросить RuntimeException на контрольной сумме.');
+        self::assertStringContainsString('Контрольная сумма не сошлась', $caught->getMessage());
+
+        $conn = $this->em->getConnection();
+
+        $documentRows = (int) $conn->fetchOne(
+            'SELECT COUNT(*) FROM documents WHERE company_id = :c',
+            ['c' => self::COMPANY_ID],
+        );
+        self::assertSame(0, $documentRows, 'PLDocument должен быть откачен — в documents ничего нет.');
+
+        $withDocId = (int) $conn->fetchOne(
+            'SELECT COUNT(*) FROM marketplace_costs WHERE company_id = :c AND document_id IS NOT NULL',
+            ['c' => self::COMPANY_ID],
+        );
+        self::assertSame(0, $withDocId, 'marketplace_costs.document_id должен остаться NULL после rollback.');
+
+        $costsPresent = (int) $conn->fetchOne(
+            'SELECT COUNT(*) FROM marketplace_costs WHERE company_id = :c',
+            ['c' => self::COMPANY_ID],
+        );
+        self::assertSame(2, $costsPresent, 'Исходные строки затрат не должны быть удалены rollback-ом.');
+
+        $monthCloseRows = (int) $conn->fetchOne(
+            'SELECT COUNT(*) FROM marketplace_month_closes WHERE company_id = :c',
+            ['c' => self::COMPANY_ID],
+        );
+        self::assertSame(0, $monthCloseRows, 'MarketplaceMonthClose не должен был сохраниться при rollback.');
+    }
+
+    private function createCost(
+        MarketplaceCostCategory $category,
+        string $amount,
+        MarketplaceCostOperationType $operationType,
+        string $costDate,
+    ): MarketplaceCost {
+        $cost = new MarketplaceCost(
+            Uuid::uuid4()->toString(),
+            $this->company,
+            self::MARKETPLACE,
+            $category,
+        );
+        $cost->setAmount($amount);
+        $cost->setCostDate(new \DateTimeImmutable($costDate));
+        $cost->setOperationType($operationType);
+        $cost->setExternalId('ext-' . Uuid::uuid4()->toString());
+        $this->em->persist($cost);
+
+        return $cost;
+    }
+}

--- a/site/tests/bootstrap.php
+++ b/site/tests/bootstrap.php
@@ -7,6 +7,7 @@ require dirname(__DIR__).'/vendor/autoload.php';
 DG\BypassFinals::enable();
 DG\BypassFinals::allowPaths([
     '*/src/Marketplace/Facade/MarketplaceFacade.php',
+    '*/src/Marketplace/Infrastructure/Query/UnprocessedCostsQuery.php',
     '*/src/MarketplaceAnalytics/Domain/Service/CostMappingResolver.php',
     '*/src/MarketplaceAnalytics/Domain/Service/DefaultCostMappingSeedPolicy.php',
 ]);


### PR DESCRIPTION
## Контекст

В Sentry регулярно падает `CloseMonthStageAction` на контрольной сумме после закрытия `COSTS`-этапа. Ретраи Messenger не помогают: preflight видит `marketplace_costs.document_id IS NOT NULL` и отказывает в повторном закрытии.

Корень: старый «ручной rollback» делал `FinanceFacade::deletePLDocument(...)`, но не откатывал сырой `UPDATE marketplace_costs.document_id`, выполненный в `MarkProcessedQuery::markCosts` ранее. `DELETE` и `UPDATE` уходили в БД разными транзакциями → после падения в `marketplace_costs` оставался `document_id`, ссылающийся на уже удалённый `documents.id`.

## Что сделано

### A. Транзакционный handler
`site/src/Marketplace/Application/CloseMonthStageAction.php`
- Тело `__invoke` обёрнуто в `EntityManager::wrapInTransaction(...)`.
  Покрывает `save PLDocument` (ORM) + `PLRegister`-пересчёт (тот же EM) + `MarkProcessedQuery::markCosts` (DBAL того же default-connection). Все три пишут в одну транзакцию — коммит/откат атомарно.
- В ветке `delta > 0.01` убран `FinanceFacade::deletePLDocument(...)`. Сохранён `throw new \RuntimeException(...)` с прежним текстом "Контрольная сумма не сошлась" — чтобы Sentry-issue схлопнулся с историей.
- Поведение на happy-path не меняется.

### B. Data migration — cleanup исторического мусора
`site/migrations/Version20260420160500.php`
- `UPDATE marketplace_costs SET document_id = NULL` для строк, где `document_id` ссылается на отсутствующий `documents.id`.
- Перед UPDATE считает и логирует `$this->write(...)` число затрагиваемых строк.
- `down()` интенционально пуст — восстановить ссылки на удалённые документы невозможно, бизнес-данные не теряются.
- FK не добавляется (вне scope).

### C. Preflight debug endpoint
`site/src/Marketplace/Controller/Debug/OrphanDocumentIdDebugController.php`
- `GET /_debug/marketplace/orphan-document-ids`, `ROLE_USER`, только SELECT-запросы.
- Возвращает JSON: `totals` (orphan_rows, affected_companies, earliest/latest cost_date & updated_at), `by_company`, `by_period_month`, `sample_rows` (LIMIT 50).
- `@deprecated` c датой удаления 2026-05-04 — снимаем сразу после применения миграции на prod.

### D. Integration-тест rollback
`site/tests/Integration/Marketplace/CloseMonthStageActionRollbackTest.php`
- Стабом `UnprocessedCostsQuery::getControlSum` смещает контрольную сумму на +9999, `execute()` делегирует в реальный сервис.
- Действует `$action($command)`, ловит `RuntimeException`.
- Утверждает: `documents=0`, `marketplace_costs.document_id IS NOT NULL = 0`, исходные 2 затраты на месте, `marketplace_month_closes=0`.
- `UnprocessedCostsQuery` — `final class`; добавил его путь в `DG\BypassFinals::allowPaths` в `site/tests/bootstrap.php` (pattern уже используется для `MarketplaceFacade` и других в этом же bootstrap).

## План выката

1. Deploy кода (handler c `wrapInTransaction`) — новый мусор появляться перестаёт.
2. Открыть `GET /_debug/marketplace/orphan-document-ids` на prod — сверить totals. Ожидание: десятки–сотни строк в январе–апреле 2026. Иное — стоп-сигнал, не применять миграцию.
3. Применить `Version20260420160500` — число orphan-строк появится в логе миграции (`$this->write(...)`).
4. Повторно открыть endpoint — `orphan_rows=0`.
5. После 2026-05-04 — удалить debug-controller и этот PR-комментарий.

## Review checklist

- [x] `wrapInTransaction` покрывает все три writes (EM ORM + DBAL того же default-connection).
- [x] Удалён `deletePLDocument` из ветки контрольной суммы, но `throw` остался с прежним текстом.
- [x] Миграция только SELECT-count + один UPDATE, `down()` пуст.
- [x] Debug-endpoint под `ROLE_USER` и помечен `@deprecated`.
- [x] Тест падает на старом коде (оставался висячий `document_id`) и зелёный на новом.

https://claude.ai/code/session_01U2TDSK2Mi6f4CKK4oriqsA