### PR TITLE
fix: sticky table header via portal-cloned thead (UnitExtendedTable)

### DIFF
--- a/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedTable.tsx
+++ b/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedTable.tsx
@@ -1,7 +1,9 @@
 import React, { useState, useMemo } from 'react';
+import { createPortal } from 'react-dom';
 import type { UnitExtendedItem, UnitExtendedTotals } from './unitExtended.types';
 import CostsBreakdown from './CostsBreakdown';
 import { formatMoney } from '../utils/utils';
+import { useFixedHeader } from './useFixedHeader';
 
 type SortField =
     | 'title'
@@ -26,16 +28,9 @@ interface UnitExtendedTableProps {
     isLoading: boolean;
 }
 
-// Inline-CSS для sticky шапки + frozen первой колонки.
-// scroll-контейнер .ue-ext-scroll лежит внутри .card — тот уже имеет overflow:hidden
-// и border-radius, которые клипуют внутренний скроллбар, поэтому отдельного wrapper'а нет.
-// max-height рассчитан под текущий layout страницы (topbar + два page-header + табы +
-// фильтры + card-header ≈ 380px).
 const TABLE_STYLES = `
 .ue-ext-scroll {
-    max-height: calc(100vh - 380px);
-    min-height: 240px;
-    overflow: auto;
+    overflow-x: auto;
 }
 .ue-ext-table {
     border-collapse: separate;
@@ -43,13 +38,6 @@ const TABLE_STYLES = `
     width: max-content;
     min-width: 100%;
     margin: 0;
-}
-.ue-ext-table thead th {
-    position: sticky;
-    top: 0;
-    z-index: 2;
-    background: var(--tblr-bg-surface);
-    border-bottom: 2px solid var(--tblr-border-color);
 }
 .ue-ext-table td.ue-ext-frozen,
 .ue-ext-table th.ue-ext-frozen {
@@ -125,7 +113,7 @@ function roiColor(v: number | null): string {
 }
 
 function formatPercent(v: number | null): React.ReactNode {
-    if (v === null) return '\u2014';
+    if (v === null) return '—';
     return `${v.toFixed(1)}%`;
 }
 
@@ -133,6 +121,7 @@ const UnitExtendedTable: React.FC<UnitExtendedTableProps> = ({ items, totals, is
     const [sortField, setSortField] = useState<SortField>('revenue');
     const [sortDir, setSortDir] = useState<SortDir>('desc');
     const [expanded, setExpanded] = useState<ExpandedState | null>(null);
+    const { tableWrapperRef, theadRef, showFixed, columnWidths, scrollLeft } = useFixedHeader();
 
     const sorted = useMemo(() => {
         const copy = [...items];
@@ -161,6 +150,40 @@ const UnitExtendedTable: React.FC<UnitExtendedTableProps> = ({ items, totals, is
         });
     };
 
+    const renderHeaderCells = (widths?: number[]) => {
+        const getWidthStyle = (i: number): React.CSSProperties => {
+            const w = widths?.[i];
+            return w !== undefined ? { width: w, minWidth: w, maxWidth: w } : {};
+        };
+
+        return (
+            <tr>
+                {HEADERS.map((h, i) => (
+                    <th
+                        key={h.field}
+                        className={`${h.align ?? ''} ${h.field === 'title' ? 'ue-ext-frozen' : ''}`}
+                        style={{
+                            cursor: 'pointer',
+                            ...getWidthStyle(i),
+                            ...(widths !== undefined && h.field === 'title'
+                                ? { position: 'sticky' as const, left: 0, zIndex: 1, background: 'var(--tblr-bg-surface)' }
+                                : {}),
+                        }}
+                        onClick={() => handleSort(h.field)}
+                    >
+                        {h.label}
+                        {sortField === h.field && (
+                            <i className={`ti ti-chevron-${sortDir === 'asc' ? 'up' : 'down'} ms-1`} />
+                        )}
+                    </th>
+                ))}
+                <th className="text-end" style={getWidthStyle(HEADERS.length)}>
+                    Все затраты
+                </th>
+            </tr>
+        );
+    };
+
     if (isLoading) {
         return (
             <div className="d-flex justify-content-center py-4">
@@ -182,136 +205,151 @@ const UnitExtendedTable: React.FC<UnitExtendedTableProps> = ({ items, totals, is
         );
     }
 
-    const colCount = HEADERS.length + 1; // +1 for "Все затраты" button column
+    const colCount = HEADERS.length + 1;
+    const wrapperRect = tableWrapperRef.current?.getBoundingClientRect();
 
     return (
         <>
             <style>{TABLE_STYLES}</style>
-            <div className="ue-ext-scroll">
-                <table className="table table-vcenter card-table ue-ext-table">
-                    <thead>
-                        <tr>
-                            {HEADERS.map((h) => (
-                                <th
-                                    key={h.field}
-                                    className={`${h.align ?? ''} ${h.field === 'title' ? 'ue-ext-frozen' : ''}`}
-                                    style={{ cursor: 'pointer' }}
-                                    onClick={() => handleSort(h.field)}
-                                >
-                                    {h.label}
-                                    {sortField === h.field && (
-                                        <i className={`ti ti-chevron-${sortDir === 'asc' ? 'up' : 'down'} ms-1`} />
-                                    )}
-                                </th>
-                            ))}
-                            <th className="text-end">Все затраты</th>
-                        </tr>
-                    </thead>
-                <tbody>
-                    {sorted.map((row) => {
-                        const isOtherExpanded = expanded?.listingId === row.listingId && expanded?.type === 'other';
-                        const isAllExpanded = expanded?.listingId === row.listingId && expanded?.type === 'all';
 
-                        return (
-                            <React.Fragment key={row.listingId}>
-                                <tr>
-                                    <td className="ue-ext-frozen">
-                                        <div className="text-truncate">{row.title || '\u2014'}</div>
-                                        <div className="text-muted small text-truncate">{row.sku}</div>
-                                    </td>
-                                    <td className="text-end">{formatMoney(row.revenue)}</td>
-                                    <td className="text-end">{row.quantity.toLocaleString('ru-RU')}</td>
-                                    <td className="text-end text-red">{formatMoney(row.returnsTotal)}</td>
-                                    <td className="text-end">{formatMoney(row.costPriceTotal)}</td>
-                                    <td className="text-end">{formatMoney(row.costPriceUnit)}</td>
-                                    <td className="text-end">{formatMoney(row.commission)}</td>
-                                    <td className="text-end">{formatMoney(row.logistics)}</td>
-                                    <td className="text-end">
-                                        <button
-                                            type="button"
-                                            className={`btn btn-sm ${isOtherExpanded ? 'btn-primary' : 'btn-ghost-primary'} p-1`}
-                                            onClick={() => handleExpandToggle(row.listingId, 'other')}
-                                            title="Показать детали прочих затрат"
-                                        >
-                                            {formatMoney(row.otherCosts)}
-                                            <i className={`ti ti-chevron-${isOtherExpanded ? 'up' : 'down'} ms-1`} />
-                                        </button>
-                                    </td>
-                                    <td className="text-end">{formatMoney(row.totalCosts)}</td>
-                                    <td className="text-end">
-                                        <span className={row.profit >= 0 ? 'text-green' : 'text-red'}>
-                                            {formatMoney(row.profit)}
-                                        </span>
-                                    </td>
-                                    <td className={`text-end ${marginColor(row.marginPercent)}`}>
-                                        {formatPercent(row.marginPercent)}
-                                    </td>
-                                    <td className={`text-end ${roiColor(row.roiPercent)}`}>
-                                        {formatPercent(row.roiPercent)}
-                                    </td>
-                                    <td className="text-end">
-                                        <button
-                                            type="button"
-                                            className={`btn btn-sm ${isAllExpanded ? 'btn-primary' : 'btn-ghost-secondary'} p-1`}
-                                            onClick={() => handleExpandToggle(row.listingId, 'all')}
-                                            title="Показать все затраты"
-                                        >
-                                            <i className={`ti ti-list-details`} />
-                                        </button>
-                                    </td>
-                                </tr>
-                                {isOtherExpanded && (
+            {showFixed && createPortal(
+                <div style={{
+                    position: 'fixed',
+                    top: 0,
+                    left: wrapperRect?.left ?? 0,
+                    width: wrapperRect?.width ?? 'auto',
+                    zIndex: 1050,
+                    overflow: 'hidden',
+                    background: 'var(--tblr-bg-surface)',
+                    borderBottom: '2px solid var(--tblr-border-color)',
+                    boxShadow: '0 2px 4px rgba(0,0,0,0.08)',
+                }}>
+                    <table style={{
+                        borderCollapse: 'separate',
+                        borderSpacing: 0,
+                        width: 'max-content',
+                        minWidth: '100%',
+                        margin: 0,
+                        transform: `translateX(-${scrollLeft}px)`,
+                    }}>
+                        <thead>
+                            {renderHeaderCells(columnWidths)}
+                        </thead>
+                    </table>
+                </div>,
+                document.body
+            )}
+
+            <div ref={tableWrapperRef} className="ue-ext-scroll">
+                <table className="table table-vcenter card-table ue-ext-table">
+                    <thead ref={theadRef}>
+                        {renderHeaderCells()}
+                    </thead>
+                    <tbody>
+                        {sorted.map((row) => {
+                            const isOtherExpanded = expanded?.listingId === row.listingId && expanded?.type === 'other';
+                            const isAllExpanded = expanded?.listingId === row.listingId && expanded?.type === 'all';
+
+                            return (
+                                <React.Fragment key={row.listingId}>
                                     <tr>
-                                        <td colSpan={colCount} className="p-0 bg-light">
-                                            <CostsBreakdown
-                                                groups={row.otherCostsBreakdown}
-                                                title="Прочие затраты (без комиссии и логистики)"
-                                            />
+                                        <td className="ue-ext-frozen">
+                                            <div className="text-truncate">{row.title || '—'}</div>
+                                            <div className="text-muted small text-truncate">{row.sku}</div>
+                                        </td>
+                                        <td className="text-end">{formatMoney(row.revenue)}</td>
+                                        <td className="text-end">{row.quantity.toLocaleString('ru-RU')}</td>
+                                        <td className="text-end text-red">{formatMoney(row.returnsTotal)}</td>
+                                        <td className="text-end">{formatMoney(row.costPriceTotal)}</td>
+                                        <td className="text-end">{formatMoney(row.costPriceUnit)}</td>
+                                        <td className="text-end">{formatMoney(row.commission)}</td>
+                                        <td className="text-end">{formatMoney(row.logistics)}</td>
+                                        <td className="text-end">
+                                            <button
+                                                type="button"
+                                                className={`btn btn-sm ${isOtherExpanded ? 'btn-primary' : 'btn-ghost-primary'} p-1`}
+                                                onClick={() => handleExpandToggle(row.listingId, 'other')}
+                                                title="Показать детали прочих затрат"
+                                            >
+                                                {formatMoney(row.otherCosts)}
+                                                <i className={`ti ti-chevron-${isOtherExpanded ? 'up' : 'down'} ms-1`} />
+                                            </button>
+                                        </td>
+                                        <td className="text-end">{formatMoney(row.totalCosts)}</td>
+                                        <td className="text-end">
+                                            <span className={row.profit >= 0 ? 'text-green' : 'text-red'}>
+                                                {formatMoney(row.profit)}
+                                            </span>
+                                        </td>
+                                        <td className={`text-end ${marginColor(row.marginPercent)}`}>
+                                            {formatPercent(row.marginPercent)}
+                                        </td>
+                                        <td className={`text-end ${roiColor(row.roiPercent)}`}>
+                                            {formatPercent(row.roiPercent)}
+                                        </td>
+                                        <td className="text-end">
+                                            <button
+                                                type="button"
+                                                className={`btn btn-sm ${isAllExpanded ? 'btn-primary' : 'btn-ghost-secondary'} p-1`}
+                                                onClick={() => handleExpandToggle(row.listingId, 'all')}
+                                                title="Показать все затраты"
+                                            >
+                                                <i className={`ti ti-list-details`} />
+                                            </button>
                                         </td>
                                     </tr>
-                                )}
-                                {isAllExpanded && (
-                                    <tr>
-                                        <td colSpan={colCount} className="p-0 bg-light">
-                                            <CostsBreakdown
-                                                groups={row.allCostsBreakdown}
-                                                title="Все затраты по категориям"
-                                            />
-                                        </td>
-                                    </tr>
-                                )}
-                            </React.Fragment>
-                        );
-                    })}
-                </tbody>
-                {totals && (
-                    <tfoot>
-                        <tr className="fw-bold">
-                            <td className="ue-ext-frozen">Итого</td>
-                            <td className="text-end">{formatMoney(totals.revenue)}</td>
-                            <td className="text-end">{totals.quantity.toLocaleString('ru-RU')}</td>
-                            <td className="text-end text-red">{formatMoney(totals.returnsTotal)}</td>
-                            <td className="text-end">{formatMoney(totals.costPriceTotal)}</td>
-                            <td className="text-end">{'\u2014'}</td>
-                            <td className="text-end">{formatMoney(totals.commission)}</td>
-                            <td className="text-end">{formatMoney(totals.logistics)}</td>
-                            <td className="text-end">{formatMoney(totals.otherCosts)}</td>
-                            <td className="text-end">{formatMoney(totals.totalCosts)}</td>
-                            <td className="text-end">
-                                <span className={totals.profit >= 0 ? 'text-green' : 'text-red'}>
-                                    {formatMoney(totals.profit)}
-                                </span>
-                            </td>
-                            <td className={`text-end ${marginColor(totals.marginPercent)}`}>
-                                {formatPercent(totals.marginPercent)}
-                            </td>
-                            <td className={`text-end ${roiColor(totals.roiPercent)}`}>
-                                {formatPercent(totals.roiPercent)}
-                            </td>
-                            <td></td>
-                        </tr>
-                    </tfoot>
-                )}
+                                    {isOtherExpanded && (
+                                        <tr>
+                                            <td colSpan={colCount} className="p-0 bg-light">
+                                                <CostsBreakdown
+                                                    groups={row.otherCostsBreakdown}
+                                                    title="Прочие затраты (без комиссии и логистики)"
+                                                />
+                                            </td>
+                                        </tr>
+                                    )}
+                                    {isAllExpanded && (
+                                        <tr>
+                                            <td colSpan={colCount} className="p-0 bg-light">
+                                                <CostsBreakdown
+                                                    groups={row.allCostsBreakdown}
+                                                    title="Все затраты по категориям"
+                                                />
+                                            </td>
+                                        </tr>
+                                    )}
+                                </React.Fragment>
+                            );
+                        })}
+                    </tbody>
+                    {totals && (
+                        <tfoot>
+                            <tr className="fw-bold">
+                                <td className="ue-ext-frozen">Итого</td>
+                                <td className="text-end">{formatMoney(totals.revenue)}</td>
+                                <td className="text-end">{totals.quantity.toLocaleString('ru-RU')}</td>
+                                <td className="text-end text-red">{formatMoney(totals.returnsTotal)}</td>
+                                <td className="text-end">{formatMoney(totals.costPriceTotal)}</td>
+                                <td className="text-end">{'—'}</td>
+                                <td className="text-end">{formatMoney(totals.commission)}</td>
+                                <td className="text-end">{formatMoney(totals.logistics)}</td>
+                                <td className="text-end">{formatMoney(totals.otherCosts)}</td>
+                                <td className="text-end">{formatMoney(totals.totalCosts)}</td>
+                                <td className="text-end">
+                                    <span className={totals.profit >= 0 ? 'text-green' : 'text-red'}>
+                                        {formatMoney(totals.profit)}
+                                    </span>
+                                </td>
+                                <td className={`text-end ${marginColor(totals.marginPercent)}`}>
+                                    {formatPercent(totals.marginPercent)}
+                                </td>
+                                <td className={`text-end ${roiColor(totals.roiPercent)}`}>
+                                    {formatPercent(totals.roiPercent)}
+                                </td>
+                                <td></td>
+                            </tr>
+                        </tfoot>
+                    )}
                 </table>
             </div>
         </>

--- a/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedTable.tsx
+++ b/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedTable.tsx
@@ -121,7 +121,7 @@ const UnitExtendedTable: React.FC<UnitExtendedTableProps> = ({ items, totals, is
     const [sortField, setSortField] = useState<SortField>('revenue');
     const [sortDir, setSortDir] = useState<SortDir>('desc');
     const [expanded, setExpanded] = useState<ExpandedState | null>(null);
-    const { tableWrapperRef, theadRef, showFixed, columnWidths, scrollLeft } = useFixedHeader();
+    const { tableWrapperRef, theadRef, showFixed, columnWidths, scrollLeft, wrapperRect } = useFixedHeader();
 
     const sorted = useMemo(() => {
         const copy = [...items];
@@ -150,6 +150,10 @@ const UnitExtendedTable: React.FC<UnitExtendedTableProps> = ({ items, totals, is
         });
     };
 
+    // Renders header row for both the real thead and the portal clone.
+    // When `widths` are provided (clone mode), each th gets a fixed pixel width.
+    // The frozen first column uses a counter-transform to stay visible despite the
+    // table's translateX(-scrollLeft) shift.
     const renderHeaderCells = (widths?: number[]) => {
         const getWidthStyle = (i: number): React.CSSProperties => {
             const w = widths?.[i];
@@ -166,7 +170,14 @@ const UnitExtendedTable: React.FC<UnitExtendedTableProps> = ({ items, totals, is
                             cursor: 'pointer',
                             ...getWidthStyle(i),
                             ...(widths !== undefined && h.field === 'title'
-                                ? { position: 'sticky' as const, left: 0, zIndex: 1, background: 'var(--tblr-bg-surface)' }
+                                ? {
+                                    position: 'relative' as const,
+                                    zIndex: 10,
+                                    background: 'var(--tblr-bg-surface)',
+                                    // Counter-act the table's translateX(-scrollLeft) so the
+                                    // frozen column stays anchored at the left edge of the clone.
+                                    transform: `translateX(${scrollLeft}px)`,
+                                  }
                                 : {}),
                         }}
                         onClick={() => handleSort(h.field)}
@@ -206,25 +217,24 @@ const UnitExtendedTable: React.FC<UnitExtendedTableProps> = ({ items, totals, is
     }
 
     const colCount = HEADERS.length + 1;
-    const wrapperRect = tableWrapperRef.current?.getBoundingClientRect();
 
     return (
         <>
             <style>{TABLE_STYLES}</style>
 
-            {showFixed && createPortal(
+            {showFixed && wrapperRect && createPortal(
                 <div style={{
                     position: 'fixed',
                     top: 0,
-                    left: wrapperRect?.left ?? 0,
-                    width: wrapperRect?.width ?? 'auto',
+                    left: wrapperRect.left,
+                    width: wrapperRect.width,
                     zIndex: 1050,
                     overflow: 'hidden',
                     background: 'var(--tblr-bg-surface)',
                     borderBottom: '2px solid var(--tblr-border-color)',
                     boxShadow: '0 2px 4px rgba(0,0,0,0.08)',
                 }}>
-                    <table style={{
+                    <table className="table table-vcenter card-table" style={{
                         borderCollapse: 'separate',
                         borderSpacing: 0,
                         width: 'max-content',

--- a/site/assets/react/marketplace-analytics/unit-extended/useFixedHeader.ts
+++ b/site/assets/react/marketplace-analytics/unit-extended/useFixedHeader.ts
@@ -1,0 +1,62 @@
+import { useEffect, useRef, useState } from 'react';
+import type { RefObject } from 'react';
+
+interface UseFixedHeaderResult {
+    tableWrapperRef: RefObject<HTMLDivElement>;
+    theadRef: RefObject<HTMLTableSectionElement>;
+    showFixed: boolean;
+    columnWidths: number[];
+    scrollLeft: number;
+}
+
+export function useFixedHeader(): UseFixedHeaderResult {
+    const tableWrapperRef = useRef<HTMLDivElement>(null);
+    const theadRef = useRef<HTMLTableSectionElement>(null);
+    const [showFixed, setShowFixed] = useState(false);
+    const [columnWidths, setColumnWidths] = useState<number[]>([]);
+    const [scrollLeft, setScrollLeft] = useState(0);
+
+    useEffect(() => {
+        const thead = theadRef.current;
+        if (!thead) return;
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                const entry = entries[0];
+                if (!entry) return;
+                setShowFixed(!entry.isIntersecting);
+                if (!entry.isIntersecting) {
+                    const ths = thead.querySelectorAll('th');
+                    setColumnWidths(Array.from(ths).map((th) => th.getBoundingClientRect().width));
+                }
+            },
+            { threshold: 0, rootMargin: '0px' }
+        );
+
+        observer.observe(thead);
+        return () => observer.disconnect();
+    }, []);
+
+    useEffect(() => {
+        const wrapper = tableWrapperRef.current;
+        if (!wrapper) return;
+
+        const handleScroll = () => setScrollLeft(wrapper.scrollLeft);
+        wrapper.addEventListener('scroll', handleScroll, { passive: true });
+        return () => wrapper.removeEventListener('scroll', handleScroll);
+    }, []);
+
+    useEffect(() => {
+        const updateWidths = () => {
+            const thead = theadRef.current;
+            if (thead && showFixed) {
+                const ths = thead.querySelectorAll('th');
+                setColumnWidths(Array.from(ths).map((th) => th.getBoundingClientRect().width));
+            }
+        };
+        window.addEventListener('resize', updateWidths);
+        return () => window.removeEventListener('resize', updateWidths);
+    }, [showFixed]);
+
+    return { tableWrapperRef, theadRef, showFixed, columnWidths, scrollLeft };
+}

--- a/site/assets/react/marketplace-analytics/unit-extended/useFixedHeader.ts
+++ b/site/assets/react/marketplace-analytics/unit-extended/useFixedHeader.ts
@@ -1,62 +1,119 @@
-import { useEffect, useRef, useState } from 'react';
-import type { RefObject } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { RefCallback, RefObject } from 'react';
+
+interface WrapperRect {
+    left: number;
+    width: number;
+}
 
 interface UseFixedHeaderResult {
-    tableWrapperRef: RefObject<HTMLDivElement>;
-    theadRef: RefObject<HTMLTableSectionElement>;
+    tableWrapperRef: RefCallback<HTMLDivElement>;
+    theadRef: RefCallback<HTMLTableSectionElement>;
     showFixed: boolean;
     columnWidths: number[];
     scrollLeft: number;
+    wrapperRect: WrapperRect | undefined;
 }
 
 export function useFixedHeader(): UseFixedHeaderResult {
-    const tableWrapperRef = useRef<HTMLDivElement>(null);
-    const theadRef = useRef<HTMLTableSectionElement>(null);
-    const [showFixed, setShowFixed] = useState(false);
+    const [theadNode, setTheadNode] = useState<HTMLTableSectionElement | null>(null);
+    const [wrapperNode, setWrapperNode] = useState<HTMLDivElement | null>(null);
+    // Keep a sync ref for use inside event handlers (getBoundingClientRect, scrollLeft)
+    const wrapperNodeRef = useRef<HTMLDivElement | null>(null);
+
+    const [theadAbove, setTheadAbove] = useState(false);
+    const [tableInView, setTableInView] = useState(true);
     const [columnWidths, setColumnWidths] = useState<number[]>([]);
     const [scrollLeft, setScrollLeft] = useState(0);
+    const [wrapperRect, setWrapperRect] = useState<WrapperRect | undefined>(undefined);
 
+    const theadRef = useCallback((node: HTMLTableSectionElement | null) => {
+        setTheadNode(node);
+    }, []);
+
+    const tableWrapperRef = useCallback((node: HTMLDivElement | null) => {
+        wrapperNodeRef.current = node;
+        setWrapperNode(node);
+    }, []);
+
+    const captureWidthsAndRect = useCallback((thead: HTMLTableSectionElement) => {
+        const ths = thead.querySelectorAll('th');
+        setColumnWidths(Array.from(ths).map((th) => th.getBoundingClientRect().width));
+        const wrapper = wrapperNodeRef.current;
+        if (wrapper) {
+            const rect = wrapper.getBoundingClientRect();
+            setWrapperRect({ left: rect.left, width: rect.width });
+        }
+    }, []);
+
+    // Watch thead: detect when it scrolls above the viewport top
     useEffect(() => {
-        const thead = theadRef.current;
-        if (!thead) return;
+        if (!theadNode) {
+            setTheadAbove(false);
+            setWrapperRect(undefined);
+            return;
+        }
 
         const observer = new IntersectionObserver(
             (entries) => {
                 const entry = entries[0];
                 if (!entry) return;
-                setShowFixed(!entry.isIntersecting);
-                if (!entry.isIntersecting) {
-                    const ths = thead.querySelectorAll('th');
-                    setColumnWidths(Array.from(ths).map((th) => th.getBoundingClientRect().width));
+                const above = !entry.isIntersecting;
+                setTheadAbove(above);
+                if (above) {
+                    captureWidthsAndRect(theadNode);
+                } else {
+                    setWrapperRect(undefined);
                 }
             },
             { threshold: 0, rootMargin: '0px' }
         );
 
-        observer.observe(thead);
+        observer.observe(theadNode);
         return () => observer.disconnect();
-    }, []);
+    }, [theadNode, captureWidthsAndRect]);
 
+    // Watch table wrapper: hide fixed header when entire table scrolls past viewport
     useEffect(() => {
-        const wrapper = tableWrapperRef.current;
-        if (!wrapper) return;
+        if (!wrapperNode) return;
 
-        const handleScroll = () => setScrollLeft(wrapper.scrollLeft);
-        wrapper.addEventListener('scroll', handleScroll, { passive: true });
-        return () => wrapper.removeEventListener('scroll', handleScroll);
-    }, []);
+        const observer = new IntersectionObserver(
+            (entries) => {
+                const entry = entries[0];
+                if (!entry) return;
+                setTableInView(entry.isIntersecting);
+            },
+            { threshold: 0 }
+        );
 
+        observer.observe(wrapperNode);
+        return () => observer.disconnect();
+    }, [wrapperNode]);
+
+    // Horizontal scroll sync
     useEffect(() => {
-        const updateWidths = () => {
-            const thead = theadRef.current;
-            if (thead && showFixed) {
-                const ths = thead.querySelectorAll('th');
-                setColumnWidths(Array.from(ths).map((th) => th.getBoundingClientRect().width));
-            }
-        };
-        window.addEventListener('resize', updateWidths);
-        return () => window.removeEventListener('resize', updateWidths);
-    }, [showFixed]);
+        if (!wrapperNode) return;
 
-    return { tableWrapperRef, theadRef, showFixed, columnWidths, scrollLeft };
+        const handleScroll = () => setScrollLeft(wrapperNode.scrollLeft);
+        wrapperNode.addEventListener('scroll', handleScroll, { passive: true });
+        return () => wrapperNode.removeEventListener('scroll', handleScroll);
+    }, [wrapperNode]);
+
+    // Resize: recalculate column widths and wrapper rect
+    useEffect(() => {
+        if (!theadNode || !theadAbove) return;
+
+        const updateOnResize = () => captureWidthsAndRect(theadNode);
+        window.addEventListener('resize', updateOnResize);
+        return () => window.removeEventListener('resize', updateOnResize);
+    }, [theadNode, theadAbove, captureWidthsAndRect]);
+
+    return {
+        tableWrapperRef,
+        theadRef,
+        showFixed: theadAbove && tableInView,
+        columnWidths,
+        scrollLeft,
+        wrapperRect,
+    };
 }


### PR DESCRIPTION
## Проблема

`position: sticky` на `thead th` не работал в Tabler layout-fluid-vertical — родительские контейнеры Tabler имеют `overflow: hidden/auto`, которые обрывают sticky-контекст. Четыре предыдущих CSS-only подхода не дали результата.

## Решение

Вместо CSS sticky — клонированный `thead` через `createPortal` в `document.body`.

### Как работает

1. `useFixedHeader` хук отслеживает оригинальный `<thead>` через `IntersectionObserver`
2. Когда thead уходит за верх viewport → снимаются ширины колонок через `getBoundingClientRect()` и выставляется `showFixed = true`
3. Portal рендерит `position: fixed; top: 0` div прямо в `document.body` — минует все overflow-предки Tabler
4. Клон синхронизирует горизонтальный скролл через `transform: translateX(-scrollLeft)`
5. При resize ширины пересчитываются

### Изменённые файлы

- **`useFixedHeader.ts`** — новый хук (IntersectionObserver + scroll sync + resize handler)
- **`UnitExtendedTable.tsx`** — подключён хук, добавлен portal-клон, убраны все предыдущие sticky-попытки

### Что убрано

- `position: sticky; top: 0` с `thead th`
- `max-height: calc(100vh - 380px)` и `overflow: auto` с `.ue-ext-scroll`

## Чеклист

- [x] Скролл вниз → шапка прилипает к `top: 0` viewport
- [x] Скролл вверх → шапка отлипает, оригинальный thead виден
- [x] Горизонтальный скролл → клон скроллится синхронно
- [x] Ширина колонок клона = ширина колонок оригинала (pixel-perfect)
- [x] Resize окна → ширины пересчитываются
- [x] Клон содержит только строку заголовков (без KPI, без секций)
- [x] Сортировка работает через клон (те же обработчики)
- [x] `z-index: 1050` — выше Tabler dropdowns (1030), ниже модалов (1055)
- [x] Frozen первая колонка сохранена в клоне
- [x] Другие страницы не затронуты

https://claude.ai/code/session_01JujaRCwMSwWsmirEqUpUsk