### PR TITLE
feat(marketplace-analytics): add UnitExtendedXlsxExporter service

### DIFF
--- a/site/src/MarketplaceAnalytics/Infrastructure/Export/UnitExtendedExportRequest.php
+++ b/site/src/MarketplaceAnalytics/Infrastructure/Export/UnitExtendedExportRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAnalytics\Infrastructure\Export;
+
+final readonly class UnitExtendedExportRequest
+{
+    public function __construct(
+        public string $companyId,
+        public ?string $marketplace,
+        public string $periodFrom,
+        public string $periodTo,
+    ) {
+    }
+
+    public function buildFilename(): string
+    {
+        $marketplace = $this->marketplace ?? 'all';
+
+        return sprintf(
+            'unit_extended_%s_%s_%s.xlsx',
+            $marketplace,
+            $this->periodFrom,
+            $this->periodTo,
+        );
+    }
+}

--- a/site/src/MarketplaceAnalytics/Infrastructure/Export/UnitExtendedXlsxExporter.php
+++ b/site/src/MarketplaceAnalytics/Infrastructure/Export/UnitExtendedXlsxExporter.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAnalytics\Infrastructure\Export;
+
+use App\MarketplaceAnalytics\Infrastructure\Query\UnitExtendedQuery;
+use OpenSpout\Common\Entity\Cell;
+use OpenSpout\Common\Entity\Row;
+use OpenSpout\Common\Entity\Style\CellAlignment;
+use OpenSpout\Common\Entity\Style\CellVerticalAlignment;
+use OpenSpout\Common\Entity\Style\Color;
+use OpenSpout\Common\Entity\Style\Style;
+use OpenSpout\Writer\XLSX\Writer;
+
+final readonly class UnitExtendedXlsxExporter
+{
+    private const FORMAT_MONEY = '#,##0.00 "₽"';
+    private const FORMAT_PERCENT = '0.00"%"';
+    private const FORMAT_INTEGER = '#,##0';
+
+    private const HEADER_BG_COLOR = '2563EB';
+
+    /**
+     * Column definitions: [label, field, type].
+     * Type: string|money|integer|percent.
+     *
+     * @var list<array{label: string, field: string, type: string}>
+     */
+    private const COLUMNS = [
+        ['label' => 'SKU',             'field' => 'sku',            'type' => 'string'],
+        ['label' => 'Наименование',    'field' => 'title',          'type' => 'string'],
+        ['label' => 'Маркетплейс',     'field' => 'marketplace',    'type' => 'string'],
+        ['label' => 'Выручка',         'field' => 'revenue',        'type' => 'money'],
+        ['label' => 'Кол-во',          'field' => 'quantity',       'type' => 'integer'],
+        ['label' => 'Возвраты',        'field' => 'returnsTotal',   'type' => 'money'],
+        ['label' => 'Себестоимость',   'field' => 'costPriceTotal', 'type' => 'money'],
+        ['label' => 'Себест. ед.',     'field' => 'costPriceUnit',  'type' => 'money'],
+        ['label' => 'Комиссия',        'field' => 'commission',     'type' => 'money'],
+        ['label' => 'Логистика',       'field' => 'logistics',      'type' => 'money'],
+        ['label' => 'Прочие затраты',  'field' => 'otherCosts',     'type' => 'money'],
+        ['label' => 'Итого затрат',    'field' => 'totalCosts',     'type' => 'money'],
+        ['label' => 'Прибыль',         'field' => 'profit',         'type' => 'money'],
+        ['label' => 'Маржа %',         'field' => 'marginPercent',  'type' => 'percent'],
+        ['label' => 'ROI %',           'field' => 'roiPercent',     'type' => 'percent'],
+    ];
+
+    public function __construct(
+        private UnitExtendedQuery $unitExtendedQuery,
+    ) {
+    }
+
+    public function export(UnitExtendedExportRequest $request, string $outputPath): void
+    {
+        $result = $this->unitExtendedQuery->execute(
+            $request->companyId,
+            $request->marketplace,
+            $request->periodFrom,
+            $request->periodTo,
+        );
+
+        $writer = new Writer();
+        $writer->openToFile($outputPath);
+
+        $sheet = $writer->getCurrentSheet();
+        $sheet->setName('Unit-экономика');
+
+        $writer->addRow($this->buildMetaRow($request));
+        $writer->addRow(new Row([]));
+        $writer->addRow($this->buildHeaderRow());
+
+        foreach ($result['items'] as $item) {
+            $writer->addRow($this->buildDataRow($item));
+        }
+
+        $writer->addRow($this->buildTotalsRow($result['totals']));
+
+        $writer->close();
+    }
+
+    private function buildMetaRow(UnitExtendedExportRequest $request): Row
+    {
+        $marketplace = $request->marketplace ?? 'все';
+        $generatedAt = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+
+        $text = sprintf(
+            'Период: %s — %s | Маркетплейс: %s | Сформировано: %s',
+            $request->periodFrom,
+            $request->periodTo,
+            $marketplace,
+            $generatedAt,
+        );
+
+        $style = (new Style())->setFontBold();
+
+        return new Row([Cell::fromValue($text, $style)]);
+    }
+
+    private function buildHeaderRow(): Row
+    {
+        $style = (new Style())
+            ->setFontBold()
+            ->setFontColor(Color::WHITE)
+            ->setBackgroundColor(self::HEADER_BG_COLOR)
+            ->setCellAlignment(CellAlignment::CENTER)
+            ->setCellVerticalAlignment(CellVerticalAlignment::CENTER);
+
+        $cells = [];
+        foreach (self::COLUMNS as $column) {
+            $cells[] = Cell::fromValue($column['label'], $style);
+        }
+
+        return new Row($cells);
+    }
+
+    /**
+     * @param array<string, mixed> $item
+     */
+    private function buildDataRow(array $item): Row
+    {
+        $cells = [];
+        foreach (self::COLUMNS as $column) {
+            $value = $item[$column['field']] ?? null;
+            $cells[] = $this->buildValueCell($value, $column['type']);
+        }
+
+        return new Row($cells);
+    }
+
+    /**
+     * @param array<string, mixed> $totals
+     */
+    private function buildTotalsRow(array $totals): Row
+    {
+        $boldStyle = (new Style())->setFontBold();
+        $moneyTotalStyle = (new Style())->setFontBold()->setFormat(self::FORMAT_MONEY);
+        $integerTotalStyle = (new Style())->setFontBold()->setFormat(self::FORMAT_INTEGER);
+        $percentTotalStyle = (new Style())->setFontBold()->setFormat(self::FORMAT_PERCENT);
+
+        $cells = [];
+        foreach (self::COLUMNS as $index => $column) {
+            if (0 === $index) {
+                $cells[] = Cell::fromValue('ИТОГО', $boldStyle);
+
+                continue;
+            }
+
+            if (in_array($column['field'], ['title', 'marketplace', 'costPriceUnit'], true)) {
+                $cells[] = Cell::fromValue('', $boldStyle);
+
+                continue;
+            }
+
+            $value = $totals[$column['field']] ?? null;
+
+            $style = match ($column['type']) {
+                'money' => $moneyTotalStyle,
+                'integer' => $integerTotalStyle,
+                'percent' => $percentTotalStyle,
+                default => $boldStyle,
+            };
+
+            if (null === $value) {
+                $cells[] = Cell::fromValue(null, $style);
+
+                continue;
+            }
+
+            $cells[] = $this->buildTypedCell($value, $column['type'], $style);
+        }
+
+        return new Row($cells);
+    }
+
+    private function buildValueCell(mixed $value, string $type): Cell
+    {
+        if (null === $value) {
+            return Cell::fromValue(null, $this->styleFor($type));
+        }
+
+        return $this->buildTypedCell($value, $type, $this->styleFor($type));
+    }
+
+    private function buildTypedCell(mixed $value, string $type, Style $style): Cell
+    {
+        return match ($type) {
+            'money' => Cell::fromValue((float) $value, $style),
+            'integer' => Cell::fromValue((int) $value, $style),
+            'percent' => Cell::fromValue((float) $value, $style),
+            default => Cell::fromValue((string) $value, $style),
+        };
+    }
+
+    private function styleFor(string $type): Style
+    {
+        return match ($type) {
+            'money' => (new Style())->setFormat(self::FORMAT_MONEY),
+            'integer' => (new Style())->setFormat(self::FORMAT_INTEGER),
+            'percent' => (new Style())->setFormat(self::FORMAT_PERCENT),
+            default => new Style(),
+        };
+    }
+}

--- a/site/src/MarketplaceAnalytics/Infrastructure/Export/UnitExtendedXlsxExporter.php
+++ b/site/src/MarketplaceAnalytics/Infrastructure/Export/UnitExtendedXlsxExporter.php
@@ -52,30 +52,37 @@ final readonly class UnitExtendedXlsxExporter
 
     public function export(UnitExtendedExportRequest $request, string $outputPath): void
     {
+        // Export should always contain full dataset; override the query's default UI limit.
         $result = $this->unitExtendedQuery->execute(
             $request->companyId,
             $request->marketplace,
             $request->periodFrom,
             $request->periodTo,
+            \PHP_INT_MAX,
         );
+
+        $dataStyles = $this->buildDataStyles();
+        $totalsStyles = $this->buildTotalsStyles();
 
         $writer = new Writer();
         $writer->openToFile($outputPath);
 
-        $sheet = $writer->getCurrentSheet();
-        $sheet->setName('Unit-экономика');
+        try {
+            $sheet = $writer->getCurrentSheet();
+            $sheet->setName('Unit-экономика');
 
-        $writer->addRow($this->buildMetaRow($request));
-        $writer->addRow(new Row([]));
-        $writer->addRow($this->buildHeaderRow());
+            $writer->addRow($this->buildMetaRow($request));
+            $writer->addRow(new Row([]));
+            $writer->addRow($this->buildHeaderRow());
 
-        foreach ($result['items'] as $item) {
-            $writer->addRow($this->buildDataRow($item));
+            foreach ($result['items'] as $item) {
+                $writer->addRow($this->buildDataRow($item, $dataStyles));
+            }
+
+            $writer->addRow($this->buildTotalsRow($result['totals'], $totalsStyles));
+        } finally {
+            $writer->close();
         }
-
-        $writer->addRow($this->buildTotalsRow($result['totals']));
-
-        $writer->close();
     }
 
     private function buildMetaRow(UnitExtendedExportRequest $request): Row
@@ -115,13 +122,14 @@ final readonly class UnitExtendedXlsxExporter
 
     /**
      * @param array<string, mixed> $item
+     * @param array<string, Style> $styles keyed by column type
      */
-    private function buildDataRow(array $item): Row
+    private function buildDataRow(array $item, array $styles): Row
     {
         $cells = [];
         foreach (self::COLUMNS as $column) {
             $value = $item[$column['field']] ?? null;
-            $cells[] = $this->buildValueCell($value, $column['type']);
+            $cells[] = $this->buildTypedCell($value, $column['type'], $styles[$column['type']]);
         }
 
         return new Row($cells);
@@ -129,75 +137,69 @@ final readonly class UnitExtendedXlsxExporter
 
     /**
      * @param array<string, mixed> $totals
+     * @param array<string, Style> $styles keyed by column type, plus 'blank' for filler cells
      */
-    private function buildTotalsRow(array $totals): Row
+    private function buildTotalsRow(array $totals, array $styles): Row
     {
-        $boldStyle = (new Style())->setFontBold();
-        $moneyTotalStyle = (new Style())->setFontBold()->setFormat(self::FORMAT_MONEY);
-        $integerTotalStyle = (new Style())->setFontBold()->setFormat(self::FORMAT_INTEGER);
-        $percentTotalStyle = (new Style())->setFontBold()->setFormat(self::FORMAT_PERCENT);
-
         $cells = [];
         foreach (self::COLUMNS as $index => $column) {
             if (0 === $index) {
-                $cells[] = Cell::fromValue('ИТОГО', $boldStyle);
+                $cells[] = Cell::fromValue('ИТОГО', $styles['blank']);
 
                 continue;
             }
 
+            // Totals are computed per-listing and not aggregated for these fields.
             if (in_array($column['field'], ['title', 'marketplace', 'costPriceUnit'], true)) {
-                $cells[] = Cell::fromValue('', $boldStyle);
+                $cells[] = Cell::fromValue('', $styles['blank']);
 
                 continue;
             }
 
             $value = $totals[$column['field']] ?? null;
-
-            $style = match ($column['type']) {
-                'money' => $moneyTotalStyle,
-                'integer' => $integerTotalStyle,
-                'percent' => $percentTotalStyle,
-                default => $boldStyle,
-            };
-
-            if (null === $value) {
-                $cells[] = Cell::fromValue(null, $style);
-
-                continue;
-            }
-
-            $cells[] = $this->buildTypedCell($value, $column['type'], $style);
+            $cells[] = $this->buildTypedCell($value, $column['type'], $styles[$column['type']]);
         }
 
         return new Row($cells);
     }
 
-    private function buildValueCell(mixed $value, string $type): Cell
-    {
-        if (null === $value) {
-            return Cell::fromValue(null, $this->styleFor($type));
-        }
-
-        return $this->buildTypedCell($value, $type, $this->styleFor($type));
-    }
-
     private function buildTypedCell(mixed $value, string $type, Style $style): Cell
     {
+        if (null === $value) {
+            return Cell::fromValue(null, $style);
+        }
+
         return match ($type) {
-            'money' => Cell::fromValue((float) $value, $style),
+            'money', 'percent' => Cell::fromValue((float) $value, $style),
             'integer' => Cell::fromValue((int) $value, $style),
-            'percent' => Cell::fromValue((float) $value, $style),
             default => Cell::fromValue((string) $value, $style),
         };
     }
 
-    private function styleFor(string $type): Style
+    /**
+     * @return array<string, Style>
+     */
+    private function buildDataStyles(): array
     {
-        return match ($type) {
+        return [
+            'string' => new Style(),
             'money' => (new Style())->setFormat(self::FORMAT_MONEY),
             'integer' => (new Style())->setFormat(self::FORMAT_INTEGER),
             'percent' => (new Style())->setFormat(self::FORMAT_PERCENT),
-            default => new Style(),
-        };
+        ];
+    }
+
+    /**
+     * @return array<string, Style>
+     */
+    private function buildTotalsStyles(): array
+    {
+        return [
+            'blank' => (new Style())->setFontBold(),
+            'string' => (new Style())->setFontBold(),
+            'money' => (new Style())->setFontBold()->setFormat(self::FORMAT_MONEY),
+            'integer' => (new Style())->setFontBold()->setFormat(self::FORMAT_INTEGER),
+            'percent' => (new Style())->setFontBold()->setFormat(self::FORMAT_PERCENT),
+        ];
     }
 }

--- a/site/tests/Unit/MarketplaceAnalytics/Infrastructure/Export/UnitExtendedXlsxExporterTest.php
+++ b/site/tests/Unit/MarketplaceAnalytics/Infrastructure/Export/UnitExtendedXlsxExporterTest.php
@@ -108,7 +108,7 @@ final class UnitExtendedXlsxExporterTest extends TestCase
         $query
             ->expects(self::once())
             ->method('execute')
-            ->with(self::COMPANY_ID, 'ozon', '2026-01-01', '2026-01-31')
+            ->with(self::COMPANY_ID, 'ozon', '2026-01-01', '2026-01-31', PHP_INT_MAX)
             ->willReturn(['items' => $items, 'totals' => $totals]);
 
         $exporter = new UnitExtendedXlsxExporter($query);

--- a/site/tests/Unit/MarketplaceAnalytics/Infrastructure/Export/UnitExtendedXlsxExporterTest.php
+++ b/site/tests/Unit/MarketplaceAnalytics/Infrastructure/Export/UnitExtendedXlsxExporterTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MarketplaceAnalytics\Infrastructure\Export;
+
+use App\MarketplaceAnalytics\Infrastructure\Export\UnitExtendedExportRequest;
+use App\MarketplaceAnalytics\Infrastructure\Export\UnitExtendedXlsxExporter;
+use App\MarketplaceAnalytics\Infrastructure\Query\UnitExtendedQuery;
+use OpenSpout\Reader\XLSX\Reader;
+use PHPUnit\Framework\TestCase;
+
+final class UnitExtendedXlsxExporterTest extends TestCase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-111111111111';
+
+    private ?string $tempFile = null;
+
+    protected function tearDown(): void
+    {
+        if (null !== $this->tempFile && file_exists($this->tempFile)) {
+            unlink($this->tempFile);
+        }
+
+        $this->tempFile = null;
+    }
+
+    public function testExportWritesAllRowsAndTotals(): void
+    {
+        $items = [
+            [
+                'listingId' => 'l-1',
+                'title' => 'Товар А',
+                'sku' => 'SKU-A',
+                'marketplace' => 'ozon',
+                'revenue' => 1000.0,
+                'quantity' => 5,
+                'returnsTotal' => 50.0,
+                'costPriceTotal' => 400.0,
+                'costPriceUnit' => 80.0,
+                'commission' => 100.0,
+                'logistics' => 50.0,
+                'otherCosts' => 20.0,
+                'totalCosts' => 170.0,
+                'profit' => 380.0,
+                'marginPercent' => 38.0,
+                'roiPercent' => 95.0,
+                'otherCostsBreakdown' => [],
+                'allCostsBreakdown' => [],
+            ],
+            [
+                'listingId' => 'l-2',
+                'title' => 'Товар Б',
+                'sku' => 'SKU-B',
+                'marketplace' => 'ozon',
+                'revenue' => 500.0,
+                'quantity' => 2,
+                'returnsTotal' => 0.0,
+                'costPriceTotal' => 200.0,
+                'costPriceUnit' => 100.0,
+                'commission' => 60.0,
+                'logistics' => 30.0,
+                'otherCosts' => 10.0,
+                'totalCosts' => 100.0,
+                'profit' => 200.0,
+                'marginPercent' => 40.0,
+                'roiPercent' => 100.0,
+                'otherCostsBreakdown' => [],
+                'allCostsBreakdown' => [],
+            ],
+            [
+                'listingId' => 'l-3',
+                'title' => 'Товар В',
+                'sku' => 'SKU-C',
+                'marketplace' => 'wildberries',
+                'revenue' => 0.0,
+                'quantity' => 0,
+                'returnsTotal' => 0.0,
+                'costPriceTotal' => 0.0,
+                'costPriceUnit' => 0.0,
+                'commission' => 0.0,
+                'logistics' => 0.0,
+                'otherCosts' => 0.0,
+                'totalCosts' => 0.0,
+                'profit' => 0.0,
+                'marginPercent' => null,
+                'roiPercent' => null,
+                'otherCostsBreakdown' => [],
+                'allCostsBreakdown' => [],
+            ],
+        ];
+
+        $totals = [
+            'revenue' => 1500.0,
+            'quantity' => 7,
+            'returnsTotal' => 50.0,
+            'costPriceTotal' => 600.0,
+            'commission' => 160.0,
+            'logistics' => 80.0,
+            'otherCosts' => 30.0,
+            'totalCosts' => 270.0,
+            'profit' => 580.0,
+            'marginPercent' => 38.7,
+            'roiPercent' => 96.7,
+        ];
+
+        $query = $this->createMock(UnitExtendedQuery::class);
+        $query
+            ->expects(self::once())
+            ->method('execute')
+            ->with(self::COMPANY_ID, 'ozon', '2026-01-01', '2026-01-31')
+            ->willReturn(['items' => $items, 'totals' => $totals]);
+
+        $exporter = new UnitExtendedXlsxExporter($query);
+        $request = new UnitExtendedExportRequest(
+            companyId: self::COMPANY_ID,
+            marketplace: 'ozon',
+            periodFrom: '2026-01-01',
+            periodTo: '2026-01-31',
+        );
+
+        $this->tempFile = tempnam(sys_get_temp_dir(), 'unit_extended_').'.xlsx';
+
+        $exporter->export($request, $this->tempFile);
+
+        self::assertFileExists($this->tempFile);
+        self::assertGreaterThan(0, filesize($this->tempFile));
+
+        $rows = $this->readXlsxRows($this->tempFile);
+
+        self::assertGreaterThanOrEqual(6, count($rows), 'Expected meta + empty + header + 3 data + totals');
+
+        $headerRowIndex = null;
+        foreach ($rows as $index => $row) {
+            if (in_array('SKU', $row, true)) {
+                $headerRowIndex = $index;
+
+                break;
+            }
+        }
+
+        self::assertNotNull($headerRowIndex, 'Header row with "SKU" not found');
+        self::assertContains('Наименование', $rows[$headerRowIndex]);
+        self::assertContains('ROI %', $rows[$headerRowIndex]);
+
+        $dataRows = array_slice($rows, $headerRowIndex + 1, 3);
+        self::assertCount(3, $dataRows, 'Expected exactly 3 data rows');
+
+        $skus = array_map(static fn (array $row): string => (string) ($row[0] ?? ''), $dataRows);
+        self::assertSame(['SKU-A', 'SKU-B', 'SKU-C'], $skus);
+
+        $totalsRow = $rows[$headerRowIndex + 4];
+        self::assertSame('ИТОГО', (string) $totalsRow[0]);
+    }
+
+    /**
+     * @return list<list<string>>
+     */
+    private function readXlsxRows(string $path): array
+    {
+        $reader = new Reader();
+        $reader->open($path);
+
+        $rows = [];
+        foreach ($reader->getSheetIterator() as $sheet) {
+            foreach ($sheet->getRowIterator() as $row) {
+                $cells = array_map(
+                    static fn ($cell): string => (string) $cell->getValue(),
+                    $row->getCells(),
+                );
+                $rows[] = $cells;
+            }
+
+            break;
+        }
+
+        $reader->close();
+
+        return $rows;
+    }
+}

--- a/site/tests/bootstrap.php
+++ b/site/tests/bootstrap.php
@@ -10,6 +10,7 @@ DG\BypassFinals::allowPaths([
     '*/src/Marketplace/Infrastructure/Query/UnprocessedCostsQuery.php',
     '*/src/MarketplaceAnalytics/Domain/Service/CostMappingResolver.php',
     '*/src/MarketplaceAnalytics/Domain/Service/DefaultCostMappingSeedPolicy.php',
+    '*/src/MarketplaceAnalytics/Infrastructure/Query/UnitExtendedQuery.php',
 ]);
 
 if (method_exists(Dotenv::class, 'bootEnv')) {


### PR DESCRIPTION
## Summary

- Добавлен `UnitExtendedXlsxExporter` (`src/MarketplaceAnalytics/Infrastructure/Export/`) — экспорт Unit-extended отчёта в XLSX через `openspout/openspout`. Лист «Unit-экономика», 15 колонок (SKU → ROI %), meta-строка, заголовки на синем фоне (#2563EB, белый жирный текст, центр), строки данных и ИТОГО, форматы money/integer/percent, `null` → пустая ячейка.
- Добавлен DTO `UnitExtendedExportRequest` с `buildFilename()` для удобного именования файла (`unit_extended_{mp}_{from}_{to}.xlsx`).
- Unit-тест `tests/Unit/MarketplaceAnalytics/Infrastructure/Export/UnitExtendedXlsxExporterTest.php` — мокает `UnitExtendedQuery::execute()` (3 строки + totals), читает результат через `OpenSpout\Reader\XLSX\Reader`, проверяет структуру (заголовок `SKU`, SKU тестовых данных, 3 строки данных, строка `ИТОГО`, размер файла > 0).
- `tests/bootstrap.php` — добавил `UnitExtendedQuery.php` в `BypassFinals::allowPaths`, чтобы можно было мокать `final readonly` класс.

Существующий `UnitExtendedQuery` не трогался, контроллер не добавлялся (задача 2).

## Test plan

- [x] `vendor/bin/phpunit --testsuite unit --filter UnitExtendedXlsxExporterTest` — зелёный (1 тест, 15 ассертов)
- [x] `vendor/bin/php-cs-fixer fix` прогнан по новым файлам
- [ ] `vendor/bin/phpstan` — пропущено, в проекте не установлен (`vendor/bin/phpstan` отсутствует, есть только `phpstan/phpdoc-parser`)
- [ ] Ручная проверка: открыть сгенерированный XLSX в Excel/Numbers, убедиться в корректности форматирования и локали

https://claude.ai/code/session_018B8ZnEcqLBEJ5cjEpypSuB