### PR TITLE
feat(marketplace-analytics): add unit-extended XLSX export endpoint

### DIFF
--- a/site/src/MarketplaceAnalytics/Controller/Api/UnitExtendedExportController.php
+++ b/site/src/MarketplaceAnalytics/Controller/Api/UnitExtendedExportController.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAnalytics\Controller\Api;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAnalytics\Infrastructure\Export\UnitExtendedExportRequest;
+use App\MarketplaceAnalytics\Infrastructure\Export\UnitExtendedXlsxExporter;
+use App\Shared\Service\ActiveCompanyService;
+use App\Shared\Service\RateLimiter\ReportsApiRateLimiter;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route(
+    '/api/marketplace-analytics/unit-extended/export',
+    name: 'marketplace_analytics_api_unit_extended_export',
+    methods: ['GET'],
+)]
+#[IsGranted('ROLE_COMPANY_USER')]
+final class UnitExtendedExportController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $companyService,
+        private readonly UnitExtendedXlsxExporter $exporter,
+        private readonly ReportsApiRateLimiter $rateLimiter,
+    ) {
+    }
+
+    public function __invoke(Request $request): Response
+    {
+        $company = $this->companyService->getActiveCompany();
+        $companyId = (string) $company->getId();
+
+        if (!$this->rateLimiter->consume($companyId)) {
+            return new JsonResponse(['error' => 'Too many requests'], 429);
+        }
+
+        $marketplace = $request->query->get('marketplace');
+        if (null === $marketplace || '' === $marketplace) {
+            $marketplace = null;
+        } else {
+            $validValues = array_map(
+                static fn (MarketplaceType $t): string => $t->value,
+                MarketplaceType::cases(),
+            );
+            if (!in_array($marketplace, $validValues, true)) {
+                return new JsonResponse([
+                    'error' => 'Invalid marketplace. Allowed: '.implode(', ', $validValues),
+                ], 400);
+            }
+        }
+
+        $periodFrom = (string) $request->query->get('periodFrom', '');
+        $periodTo = (string) $request->query->get('periodTo', '');
+
+        if ('' === $periodFrom || '' === $periodTo) {
+            return new JsonResponse(['error' => 'periodFrom and periodTo are required'], 400);
+        }
+
+        if ($periodFrom > $periodTo) {
+            return new JsonResponse(['error' => 'periodFrom must be <= periodTo'], 400);
+        }
+
+        $exportRequest = new UnitExtendedExportRequest(
+            companyId: $companyId,
+            marketplace: $marketplace,
+            periodFrom: $periodFrom,
+            periodTo: $periodTo,
+        );
+
+        $exporter = $this->exporter;
+        $response = new StreamedResponse(static function () use ($exporter, $exportRequest): void {
+            $tmpFile = tempnam(sys_get_temp_dir(), 'unit_export_');
+            if (false === $tmpFile) {
+                throw new \RuntimeException('Unable to create temporary file for export');
+            }
+
+            try {
+                $exporter->export($exportRequest, $tmpFile);
+                readfile($tmpFile);
+            } finally {
+                if (file_exists($tmpFile)) {
+                    unlink($tmpFile);
+                }
+            }
+        });
+
+        $response->headers->set('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+        $response->headers->set(
+            'Content-Disposition',
+            sprintf('attachment; filename="%s"', $exportRequest->buildFilename()),
+        );
+        $response->headers->set('Cache-Control', 'no-store, no-cache, must-revalidate');
+        $response->headers->set('X-Accel-Buffering', 'no');
+
+        return $response;
+    }
+}

--- a/site/src/MarketplaceAnalytics/Controller/Api/UnitExtendedExportController.php
+++ b/site/src/MarketplaceAnalytics/Controller/Api/UnitExtendedExportController.php
@@ -63,6 +63,10 @@ final class UnitExtendedExportController extends AbstractController
             return new JsonResponse(['error' => 'periodFrom and periodTo are required'], 400);
         }
 
+        if (!$this->isValidIsoDate($periodFrom) || !$this->isValidIsoDate($periodTo)) {
+            return new JsonResponse(['error' => 'periodFrom and periodTo must be in YYYY-MM-DD format'], 400);
+        }
+
         if ($periodFrom > $periodTo) {
             return new JsonResponse(['error' => 'periodFrom must be <= periodTo'], 400);
         }
@@ -100,5 +104,12 @@ final class UnitExtendedExportController extends AbstractController
         $response->headers->set('X-Accel-Buffering', 'no');
 
         return $response;
+    }
+
+    private function isValidIsoDate(string $value): bool
+    {
+        $date = \DateTimeImmutable::createFromFormat('Y-m-d', $value);
+
+        return $date instanceof \DateTimeImmutable && $date->format('Y-m-d') === $value;
     }
 }

--- a/site/tests/Functional/MarketplaceAnalytics/UnitExtendedExportControllerTest.php
+++ b/site/tests/Functional/MarketplaceAnalytics/UnitExtendedExportControllerTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\MarketplaceAnalytics;
+
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+final class UnitExtendedExportControllerTest extends WebTestCaseBase
+{
+    private const EXPORT_URL = '/api/marketplace-analytics/unit-extended/export';
+
+    public function testHappyPathReturnsXlsxAttachment(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $owner = UserBuilder::aUser()
+            ->withEmail('owner-export@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId('11111111-1111-1111-1111-111111111111')
+            ->withOwner($owner)
+            ->withName('Export Company')
+            ->build();
+
+        $em = $this->em();
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        $this->loginAsOwner($client, $owner, (string) $company->getId());
+
+        $client->request('GET', self::EXPORT_URL, [
+            'marketplace' => 'ozon',
+            'periodFrom' => '2026-04-01',
+            'periodTo' => '2026-04-30',
+        ]);
+
+        self::assertResponseStatusCodeSame(200);
+
+        $response = $client->getResponse();
+        self::assertSame(
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            $response->headers->get('Content-Type'),
+        );
+
+        $disposition = (string) $response->headers->get('Content-Disposition');
+        self::assertStringContainsString('attachment', $disposition);
+        self::assertStringContainsString('.xlsx', $disposition);
+
+        $content = $client->getInternalResponse()->getContent();
+        self::assertNotSame('', $content);
+    }
+
+    public function testReturnsErrorWhenNotAuthenticated(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $client->request('GET', self::EXPORT_URL, [
+            'marketplace' => 'ozon',
+            'periodFrom' => '2026-04-01',
+            'periodTo' => '2026-04-30',
+        ]);
+
+        $status = $client->getResponse()->getStatusCode();
+        self::assertContains($status, [302, 401, 403], sprintf('Unexpected status for anonymous request: %d', $status));
+    }
+
+    public function testReturns400WhenPeriodFromMissing(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $owner = UserBuilder::aUser()
+            ->withEmail('owner-export-missing@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId('22222222-2222-2222-2222-222222222222')
+            ->withOwner($owner)
+            ->withName('Export Company Missing')
+            ->build();
+
+        $em = $this->em();
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        $this->loginAsOwner($client, $owner, (string) $company->getId());
+
+        $client->request('GET', self::EXPORT_URL, [
+            'marketplace' => 'ozon',
+            'periodTo' => '2026-04-30',
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    private function loginAsOwner(KernelBrowser $client, object $owner, string $companyId): void
+    {
+        $client->loginUser($owner);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', $companyId);
+        $session->save();
+    }
+}

--- a/site/tests/Functional/MarketplaceAnalytics/UnitExtendedExportControllerTest.php
+++ b/site/tests/Functional/MarketplaceAnalytics/UnitExtendedExportControllerTest.php
@@ -71,6 +71,36 @@ final class UnitExtendedExportControllerTest extends WebTestCaseBase
         self::assertContains($status, [302, 401, 403], sprintf('Unexpected status for anonymous request: %d', $status));
     }
 
+    public function testReturns400WhenPeriodFormatIsInvalid(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $owner = UserBuilder::aUser()
+            ->withEmail('owner-export-bad-date@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId('33333333-3333-3333-3333-333333333333')
+            ->withOwner($owner)
+            ->withName('Export Company Bad Date')
+            ->build();
+
+        $em = $this->em();
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        $this->loginAsOwner($client, $owner, (string) $company->getId());
+
+        $client->request('GET', self::EXPORT_URL, [
+            'marketplace' => 'ozon',
+            'periodFrom' => '2026/04/01',
+            'periodTo' => '2026-04-30',
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
+    }
+
     public function testReturns400WhenPeriodFromMissing(): void
     {
         $client = static::createClient();


### PR DESCRIPTION
## Summary

- Новый API-эндпоинт `GET /api/marketplace-analytics/unit-extended/export` для скачивания Unit-extended отчёта в формате XLSX
- Rate limiter `reports_api` (60 req/min) по `companyId` с ответом 429
- Функциональные тесты на happy path, анонимный доступ и отсутствие обязательных параметров

## Details

**Controller** — `src/MarketplaceAnalytics/Controller/Api/UnitExtendedExportController.php`:
- `#[IsGranted('ROLE_COMPANY_USER')]`, только `GET`
- DI: `ActiveCompanyService`, `UnitExtendedXlsxExporter`, `ReportsApiRateLimiter`
- Валидация `marketplace` через `MarketplaceType::cases()` → 400 на неверном значении; пустое значение = все маркетплейсы
- Обязательные `periodFrom`/`periodTo` → 400 при отсутствии; `periodFrom > periodTo` → 400
- `StreamedResponse` с `tempnam` → `exporter->export()` → `readfile()` → `unlink()` в `finally`
- Заголовки: `Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`, `Content-Disposition: attachment; filename="..."`, `Cache-Control: no-store, no-cache, must-revalidate`, `X-Accel-Buffering: no`

**Functional test** — `tests/Functional/MarketplaceAnalytics/UnitExtendedExportControllerTest.php`:
- Happy path: 200, корректный `Content-Type`, `Content-Disposition` с `attachment` и `.xlsx`, непустое тело
- Анонимный запрос: 302/401/403
- Отсутствие `periodFrom`: 400

## Test plan

- [ ] `vendor/bin/phpunit --testsuite functional --filter UnitExtendedExportControllerTest`
- [ ] Ручная проверка скачивания XLSX из UI
- [ ] Убедиться, что 429 срабатывает после 60 запросов в минуту от одной компании
- [ ] Проверить, что файл корректно открывается в Excel / LibreOffice

https://claude.ai/code/session_018B8ZnEcqLBEJ5cjEpypSuB