### PR TITLE
feat(marketplace-analytics): add Скачать XLS button to unit-extended report

### DIFF
--- a/site/assets/react/marketplace-analytics/unit-extended/ExportXlsButton.tsx
+++ b/site/assets/react/marketplace-analytics/unit-extended/ExportXlsButton.tsx
@@ -1,0 +1,92 @@
+import React, { useState } from 'react';
+
+interface ExportXlsButtonProps {
+    marketplace: string;
+    periodFrom: string;
+    periodTo: string;
+    disabled?: boolean;
+}
+
+const EXPORT_URL = '/api/marketplace-analytics/unit-extended/export';
+
+function buildExportUrl(marketplace: string, periodFrom: string, periodTo: string): string {
+    const params = new URLSearchParams({ periodFrom, periodTo });
+    if (marketplace) {
+        params.set('marketplace', marketplace);
+    }
+    return `${EXPORT_URL}?${params.toString()}`;
+}
+
+function extractFilename(disposition: string | null, fallback: string): string {
+    if (!disposition) return fallback;
+    const match = disposition.match(/filename="([^"]+)"/);
+    return match?.[1] ?? fallback;
+}
+
+function triggerDownload(blob: Blob, filename: string): void {
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+const ExportXlsButton: React.FC<ExportXlsButtonProps> = ({
+    marketplace,
+    periodFrom,
+    periodTo,
+    disabled = false,
+}) => {
+    const [isLoading, setIsLoading] = useState(false);
+
+    const handleClick = async (): Promise<void> => {
+        if (isLoading) return;
+
+        setIsLoading(true);
+        try {
+            const response = await fetch(buildExportUrl(marketplace, periodFrom, periodTo), {
+                credentials: 'same-origin',
+            });
+
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+            }
+
+            const blob = await response.blob();
+            const fallbackName = `unit_extended_${marketplace || 'all'}_${periodFrom}_${periodTo}.xlsx`;
+            const filename = extractFilename(response.headers.get('Content-Disposition'), fallbackName);
+            triggerDownload(blob, filename);
+        } catch (error) {
+            console.error('Unit-extended export failed', error);
+            window.alert('Не удалось скачать файл');
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    return (
+        <button
+            type="button"
+            className="btn btn-sm btn-ghost-secondary"
+            onClick={handleClick}
+            disabled={disabled || isLoading}
+        >
+            {isLoading ? (
+                <>
+                    <span className="spinner-border spinner-border-sm me-2" role="status" />
+                    Формируем файл…
+                </>
+            ) : (
+                <>
+                    <i className="ti ti-download me-1" />
+                    Скачать XLS
+                </>
+            )}
+        </button>
+    );
+};
+
+export default ExportXlsButton;

--- a/site/assets/react/marketplace-analytics/unit-extended/ExportXlsButton.tsx
+++ b/site/assets/react/marketplace-analytics/unit-extended/ExportXlsButton.tsx
@@ -8,6 +8,7 @@ interface ExportXlsButtonProps {
 }
 
 const EXPORT_URL = '/api/marketplace-analytics/unit-extended/export';
+const XLSX_MIME = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
 
 function buildExportUrl(marketplace: string, periodFrom: string, periodTo: string): string {
     const params = new URLSearchParams({ periodFrom, periodTo });
@@ -53,6 +54,11 @@ const ExportXlsButton: React.FC<ExportXlsButtonProps> = ({
 
             if (!response.ok) {
                 throw new Error(`HTTP ${response.status}`);
+            }
+
+            const contentType = response.headers.get('Content-Type') ?? '';
+            if (response.redirected || !contentType.startsWith(XLSX_MIME)) {
+                throw new Error('Unexpected response (likely auth redirect)');
             }
 
             const blob = await response.blob();

--- a/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedWidget.tsx
+++ b/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedWidget.tsx
@@ -7,6 +7,7 @@ import { getMonthRange } from '../utils/utils';
 import type { MarketplaceOption } from '../types/analytics.types';
 import UnitExtendedFilters from './UnitExtendedFilters';
 import UnitExtendedTable from './UnitExtendedTable';
+import ExportXlsButton from './ExportXlsButton';
 
 interface UnitExtendedWidgetProps {
     marketplaces: MarketplaceOption[];
@@ -113,13 +114,19 @@ const UnitExtendedWidget: React.FC<UnitExtendedWidgetProps> = ({ marketplaces })
             <div className="card">
                 <div className="card-header">
                     <h3 className="card-title">Юнит-экономика по листингам</h3>
-                    {items.length > 0 && (
-                        <div className="card-options">
-                            <span className="text-muted">
+                    <div className="card-options">
+                        <ExportXlsButton
+                            marketplace={filters.marketplace}
+                            periodFrom={filters.dateFrom}
+                            periodTo={filters.dateTo}
+                            disabled={!filters.dateFrom || !filters.dateTo}
+                        />
+                        {items.length > 0 && (
+                            <span className="text-muted ms-3">
                                 Товаров: {items.length.toLocaleString('ru-RU')}
                             </span>
-                        </div>
-                    )}
+                        )}
+                    </div>
                 </div>
 
                 <UnitExtendedTable

--- a/site/src/MarketplaceAnalytics/Controller/Api/UnitExtendedExportController.php
+++ b/site/src/MarketplaceAnalytics/Controller/Api/UnitExtendedExportController.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAnalytics\Controller\Api;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAnalytics\Infrastructure\Export\UnitExtendedExportRequest;
+use App\MarketplaceAnalytics\Infrastructure\Export\UnitExtendedXlsxExporter;
+use App\Shared\Service\ActiveCompanyService;
+use App\Shared\Service\RateLimiter\ReportsApiRateLimiter;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route(
+    '/api/marketplace-analytics/unit-extended/export',
+    name: 'marketplace_analytics_api_unit_extended_export',
+    methods: ['GET'],
+)]
+#[IsGranted('ROLE_COMPANY_USER')]
+final class UnitExtendedExportController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $companyService,
+        private readonly UnitExtendedXlsxExporter $exporter,
+        private readonly ReportsApiRateLimiter $rateLimiter,
+    ) {
+    }
+
+    public function __invoke(Request $request): Response
+    {
+        $company = $this->companyService->getActiveCompany();
+        $companyId = (string) $company->getId();
+
+        if (!$this->rateLimiter->consume($companyId)) {
+            return new JsonResponse(['error' => 'Too many requests'], 429);
+        }
+
+        $marketplace = $request->query->get('marketplace');
+        if (null === $marketplace || '' === $marketplace) {
+            $marketplace = null;
+        } else {
+            $validValues = array_map(
+                static fn (MarketplaceType $t): string => $t->value,
+                MarketplaceType::cases(),
+            );
+            if (!in_array($marketplace, $validValues, true)) {
+                return new JsonResponse([
+                    'error' => 'Invalid marketplace. Allowed: '.implode(', ', $validValues),
+                ], 400);
+            }
+        }
+
+        $periodFrom = (string) $request->query->get('periodFrom', '');
+        $periodTo = (string) $request->query->get('periodTo', '');
+
+        if ('' === $periodFrom || '' === $periodTo) {
+            return new JsonResponse(['error' => 'periodFrom and periodTo are required'], 400);
+        }
+
+        if ($periodFrom > $periodTo) {
+            return new JsonResponse(['error' => 'periodFrom must be <= periodTo'], 400);
+        }
+
+        $exportRequest = new UnitExtendedExportRequest(
+            companyId: $companyId,
+            marketplace: $marketplace,
+            periodFrom: $periodFrom,
+            periodTo: $periodTo,
+        );
+
+        $exporter = $this->exporter;
+        $response = new StreamedResponse(static function () use ($exporter, $exportRequest): void {
+            $tmpFile = tempnam(sys_get_temp_dir(), 'unit_export_');
+            if (false === $tmpFile) {
+                throw new \RuntimeException('Unable to create temporary file for export');
+            }
+
+            try {
+                $exporter->export($exportRequest, $tmpFile);
+                readfile($tmpFile);
+            } finally {
+                if (file_exists($tmpFile)) {
+                    unlink($tmpFile);
+                }
+            }
+        });
+
+        $response->headers->set('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+        $response->headers->set(
+            'Content-Disposition',
+            sprintf('attachment; filename="%s"', $exportRequest->buildFilename()),
+        );
+        $response->headers->set('Cache-Control', 'no-store, no-cache, must-revalidate');
+        $response->headers->set('X-Accel-Buffering', 'no');
+
+        return $response;
+    }
+}

--- a/site/src/MarketplaceAnalytics/Controller/Api/UnitExtendedExportController.php
+++ b/site/src/MarketplaceAnalytics/Controller/Api/UnitExtendedExportController.php
@@ -63,6 +63,10 @@ final class UnitExtendedExportController extends AbstractController
             return new JsonResponse(['error' => 'periodFrom and periodTo are required'], 400);
         }
 
+        if (!$this->isValidIsoDate($periodFrom) || !$this->isValidIsoDate($periodTo)) {
+            return new JsonResponse(['error' => 'periodFrom and periodTo must be in YYYY-MM-DD format'], 400);
+        }
+
         if ($periodFrom > $periodTo) {
             return new JsonResponse(['error' => 'periodFrom must be <= periodTo'], 400);
         }
@@ -100,5 +104,12 @@ final class UnitExtendedExportController extends AbstractController
         $response->headers->set('X-Accel-Buffering', 'no');
 
         return $response;
+    }
+
+    private function isValidIsoDate(string $value): bool
+    {
+        $date = \DateTimeImmutable::createFromFormat('Y-m-d', $value);
+
+        return $date instanceof \DateTimeImmutable && $date->format('Y-m-d') === $value;
     }
 }

--- a/site/tests/Functional/MarketplaceAnalytics/UnitExtendedExportControllerTest.php
+++ b/site/tests/Functional/MarketplaceAnalytics/UnitExtendedExportControllerTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\MarketplaceAnalytics;
+
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+final class UnitExtendedExportControllerTest extends WebTestCaseBase
+{
+    private const EXPORT_URL = '/api/marketplace-analytics/unit-extended/export';
+
+    public function testHappyPathReturnsXlsxAttachment(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $owner = UserBuilder::aUser()
+            ->withEmail('owner-export@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId('11111111-1111-1111-1111-111111111111')
+            ->withOwner($owner)
+            ->withName('Export Company')
+            ->build();
+
+        $em = $this->em();
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        $this->loginAsOwner($client, $owner, (string) $company->getId());
+
+        $client->request('GET', self::EXPORT_URL, [
+            'marketplace' => 'ozon',
+            'periodFrom' => '2026-04-01',
+            'periodTo' => '2026-04-30',
+        ]);
+
+        self::assertResponseStatusCodeSame(200);
+
+        $response = $client->getResponse();
+        self::assertSame(
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            $response->headers->get('Content-Type'),
+        );
+
+        $disposition = (string) $response->headers->get('Content-Disposition');
+        self::assertStringContainsString('attachment', $disposition);
+        self::assertStringContainsString('.xlsx', $disposition);
+
+        $content = $client->getInternalResponse()->getContent();
+        self::assertNotSame('', $content);
+    }
+
+    public function testReturnsErrorWhenNotAuthenticated(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $client->request('GET', self::EXPORT_URL, [
+            'marketplace' => 'ozon',
+            'periodFrom' => '2026-04-01',
+            'periodTo' => '2026-04-30',
+        ]);
+
+        $status = $client->getResponse()->getStatusCode();
+        self::assertContains($status, [302, 401, 403], sprintf('Unexpected status for anonymous request: %d', $status));
+    }
+
+    public function testReturns400WhenPeriodFromMissing(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $owner = UserBuilder::aUser()
+            ->withEmail('owner-export-missing@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId('22222222-2222-2222-2222-222222222222')
+            ->withOwner($owner)
+            ->withName('Export Company Missing')
+            ->build();
+
+        $em = $this->em();
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        $this->loginAsOwner($client, $owner, (string) $company->getId());
+
+        $client->request('GET', self::EXPORT_URL, [
+            'marketplace' => 'ozon',
+            'periodTo' => '2026-04-30',
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    private function loginAsOwner(KernelBrowser $client, object $owner, string $companyId): void
+    {
+        $client->loginUser($owner);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', $companyId);
+        $session->save();
+    }
+}

--- a/site/tests/Functional/MarketplaceAnalytics/UnitExtendedExportControllerTest.php
+++ b/site/tests/Functional/MarketplaceAnalytics/UnitExtendedExportControllerTest.php
@@ -71,6 +71,36 @@ final class UnitExtendedExportControllerTest extends WebTestCaseBase
         self::assertContains($status, [302, 401, 403], sprintf('Unexpected status for anonymous request: %d', $status));
     }
 
+    public function testReturns400WhenPeriodFormatIsInvalid(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $owner = UserBuilder::aUser()
+            ->withEmail('owner-export-bad-date@example.test')
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId('33333333-3333-3333-3333-333333333333')
+            ->withOwner($owner)
+            ->withName('Export Company Bad Date')
+            ->build();
+
+        $em = $this->em();
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        $this->loginAsOwner($client, $owner, (string) $company->getId());
+
+        $client->request('GET', self::EXPORT_URL, [
+            'marketplace' => 'ozon',
+            'periodFrom' => '2026/04/01',
+            'periodTo' => '2026-04-30',
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
+    }
+
     public function testReturns400WhenPeriodFromMissing(): void
     {
         $client = static::createClient();


### PR DESCRIPTION
## Summary

- Новый компонент `ExportXlsButton` с loading-состоянием и blob-скачиванием
- Встроен в `card-options` виджета Unit-extended над счётчиком товаров
- Имя файла извлекается из `Content-Disposition`, есть fallback

## Details

**`ExportXlsButton.tsx`** — новый компонент в `assets/react/marketplace-analytics/unit-extended/`:
- Props: `marketplace: string`, `periodFrom: string`, `periodTo: string`, `disabled?: boolean`
- Пустой `marketplace` → параметр не добавляется в URL (значит «все маркетплейсы»)
- `fetch(url, { credentials: 'same-origin' })` → `response.blob()` → `<a download>` → `URL.revokeObjectURL` через `setTimeout`
- Loading: спиннер + «Формируем файл…»; disabled во время запроса или пока не заполнены даты
- Ошибка → `console.error` + `alert('Не удалось скачать файл')`

**`UnitExtendedWidget.tsx`** — встраивание:
- Импорт `ExportXlsButton`
- `card-options` теперь рендерится всегда (раньше только при `items.length > 0`) — чтобы кнопка была доступна до первой загрузки
- Счётчик товаров остался условным, с отступом `ms-3` от кнопки

## Отклонения от ТЗ

- Файл лежит в `unit-extended/` (рядом с `UnitExtendedWidget.tsx`), а не в `components/` — там и так нет подпапки `components/`
- Тип `marketplace: string` (а не `string | null`) — соответствует state виджета
- Иконка через webfont `ti ti-download` — в проекте стоит `@tabler/icons-webfont`

## Test plan

- [ ] Открыть `/marketplace-analytics/unit-extended?marketplace=ozon&from=2026-04-01&to=2026-04-30`
- [ ] Кнопка отображается в правом верхнем углу карточки «Юнит-экономика по листингам»
- [ ] Клик → файл `unit_extended_ozon_2026-04-01_2026-04-30.xlsx` скачивается
- [ ] Файл открывается в Excel/LibreOffice, содержит заголовки, данные и строку ИТОГО
- [ ] Во время загрузки кнопка показывает спиннер и недоступна
- [ ] При очистке даты кнопка становится disabled
- [ ] Проверить `npm run build` без ошибок

https://claude.ai/code/session_018B8ZnEcqLBEJ5cjEpypSuB