### PR TITLE
feat(marketplace-ads): Ad Efficiency read-model backend (Query + API)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -457,6 +457,41 @@ findInFlightByJob(string $companyId, string $jobId): array
 
 ---
 
+## Query — MarketplaceAds
+
+> Read-model агрегаты на DBAL (минуя ORM hydration). Используются напрямую из
+> Controllers и не через Facade — это внутренний read-слой модуля.
+
+### `AdEfficiencyQuery` (`src/MarketplaceAds/Infrastructure/Query/AdEfficiencyQuery.php`)
+```php
+// Страница отчёта «Эффективность рекламы»: SKU × выручка × рекламные затраты × ДРР %.
+// Читает marketplace_sales + marketplace_ad_document_lines/marketplace_ad_documents +
+// marketplace_listings. Валидация входа (page/pageSize/sortBy/sortDir) внутри метода.
+// $sortBy whitelist: 'sku' | 'title' | 'revenue' | 'adSpend' | 'drrPercent' (fallback 'revenue').
+// $sortDir: 'asc' | 'desc' (fallback 'desc').
+// Денежные значения наружу — decimal-строки (bcmath-compatible).
+getPage(
+    string $companyId,
+    \DateTimeImmutable $from,
+    \DateTimeImmutable $to,
+    ?string $marketplace,
+    int $page,
+    int $pageSize,
+    string $sortBy = 'revenue',
+    string $sortDir = 'desc',
+): AdEfficiencyPageDTO
+```
+
+**DTO:**
+- `AdEfficiencyItemDTO` (`src/MarketplaceAds/Application/DTO/AdEfficiencyItemDTO.php`) —
+  строка таблицы: `listingId`, `sku`, `?title`, `marketplace`, `revenue`, `adSpend`, `?drrPercent`.
+  `drrPercent = null`, когда `revenue = 0`.
+- `AdEfficiencyPageDTO` (`src/MarketplaceAds/Application/DTO/AdEfficiencyPageDTO.php`) —
+  `items: list<AdEfficiencyItemDTO>`, `total`, `page`, `pageSize`, `totalRevenue`, `totalAdSpend`,
+  `?totalDrrPercent`. Totals считаются по ВСЕМУ набору листингов, не только по странице.
+
+---
+
 ## Enum — актуальные значения
 
 > Используй **только** эти значения. Не придумывай новые без обновления файла.

--- a/site/src/MarketplaceAds/Application/DTO/AdEfficiencyItemDTO.php
+++ b/site/src/MarketplaceAds/Application/DTO/AdEfficiencyItemDTO.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Application\DTO;
+
+final readonly class AdEfficiencyItemDTO
+{
+    public function __construct(
+        public string $listingId,
+        public string $sku,
+        public ?string $title,
+        public string $marketplace,
+        public string $revenue,
+        public string $adSpend,
+        public ?string $drrPercent,
+    ) {
+    }
+}

--- a/site/src/MarketplaceAds/Application/DTO/AdEfficiencyPageDTO.php
+++ b/site/src/MarketplaceAds/Application/DTO/AdEfficiencyPageDTO.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Application\DTO;
+
+final readonly class AdEfficiencyPageDTO
+{
+    /**
+     * @param list<AdEfficiencyItemDTO> $items
+     */
+    public function __construct(
+        public array $items,
+        public int $total,
+        public int $page,
+        public int $pageSize,
+        public string $totalRevenue,
+        public string $totalAdSpend,
+        public ?string $totalDrrPercent,
+    ) {
+    }
+}

--- a/site/src/MarketplaceAds/Controller/Api/AdEfficiencyController.php
+++ b/site/src/MarketplaceAds/Controller/Api/AdEfficiencyController.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Controller\Api;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAds\Application\DTO\AdEfficiencyItemDTO;
+use App\MarketplaceAds\Infrastructure\Query\AdEfficiencyQuery;
+use App\Shared\Service\ActiveCompanyService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route('/api/marketplace-ads/efficiency', name: 'marketplace_ads_api_efficiency', methods: ['GET'])]
+#[IsGranted('ROLE_COMPANY_USER')]
+final class AdEfficiencyController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $activeCompanyService,
+        private readonly AdEfficiencyQuery $adEfficiencyQuery,
+    ) {
+    }
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        $periodFromStr = (string) $request->query->get('periodFrom', '');
+        $periodToStr = (string) $request->query->get('periodTo', '');
+
+        $from = $this->parseDate($periodFromStr);
+        $to = $this->parseDate($periodToStr);
+
+        if (null === $from || null === $to) {
+            return $this->json(['error' => 'periodFrom and periodTo must be in Y-m-d format'], 400);
+        }
+
+        if ($from > $to) {
+            return $this->json(['error' => 'periodFrom must be <= periodTo'], 400);
+        }
+
+        $marketplaceRaw = $request->query->get('marketplace');
+        $marketplaceValue = null;
+        if (null !== $marketplaceRaw && '' !== $marketplaceRaw) {
+            $marketplace = MarketplaceType::tryFrom((string) $marketplaceRaw);
+            if (null === $marketplace) {
+                return $this->json(['error' => 'invalid marketplace'], 400);
+            }
+            $marketplaceValue = $marketplace->value;
+        }
+
+        $page = $request->query->getInt('page', 1);
+        $pageSize = $request->query->getInt('pageSize', 25);
+        $sortBy = (string) $request->query->get('sortBy', 'revenue');
+        $sortDir = (string) $request->query->get('sortDir', 'desc');
+
+        $company = $this->activeCompanyService->getActiveCompany();
+
+        $pageDto = $this->adEfficiencyQuery->getPage(
+            (string) $company->getId(),
+            $from,
+            $to,
+            $marketplaceValue,
+            $page,
+            $pageSize,
+            $sortBy,
+            $sortDir,
+        );
+
+        return $this->json([
+            'items' => array_map(
+                static fn (AdEfficiencyItemDTO $item): array => [
+                    'listingId' => $item->listingId,
+                    'sku' => $item->sku,
+                    'title' => $item->title,
+                    'marketplace' => $item->marketplace,
+                    'revenue' => $item->revenue,
+                    'adSpend' => $item->adSpend,
+                    'drrPercent' => $item->drrPercent,
+                ],
+                $pageDto->items,
+            ),
+            'total' => $pageDto->total,
+            'page' => $pageDto->page,
+            'pageSize' => $pageDto->pageSize,
+            'totals' => [
+                'revenue' => $pageDto->totalRevenue,
+                'adSpend' => $pageDto->totalAdSpend,
+                'drrPercent' => $pageDto->totalDrrPercent,
+            ],
+        ]);
+    }
+
+    private function parseDate(string $value): ?\DateTimeImmutable
+    {
+        if ('' === $value) {
+            return null;
+        }
+
+        $parsed = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
+
+        if (false === $parsed || $parsed->format('Y-m-d') !== $value) {
+            return null;
+        }
+
+        return $parsed;
+    }
+}

--- a/site/src/MarketplaceAds/Infrastructure/Query/AdEfficiencyQuery.php
+++ b/site/src/MarketplaceAds/Infrastructure/Query/AdEfficiencyQuery.php
@@ -68,35 +68,40 @@ final class AdEfficiencyQuery
 
         $mpSalesFilter = null !== $marketplace ? 'AND s.marketplace = :marketplace' : '';
         $mpAdsFilter = null !== $marketplace ? 'AND ad.marketplace = :marketplace' : '';
-        $mpSalesFilterNoAlias = null !== $marketplace ? 'AND marketplace = :marketplace' : '';
 
+        // base_listings = листинги, у которых были продажи ИЛИ рекламные расходы в периоде,
+        // И которые реально существуют в marketplace_listings текущей компании.
+        // Inner-join на marketplace_listings отсекает «висячие» listing_id в ad_document_lines
+        // (у которых нет FK к marketplace_listings) — чтобы total/totals совпадали с items.
         $baseListingsCte = <<<SQL
             base_listings AS (
-                SELECT s.listing_id
-                FROM marketplace_sales s
-                WHERE s.company_id = :companyId
-                  AND s.sale_date BETWEEN :periodFrom AND :periodTo
-                  {$mpSalesFilter}
-                GROUP BY s.listing_id
-                UNION
-                SELECT adl.listing_id
-                FROM marketplace_ad_document_lines adl
-                JOIN marketplace_ad_documents ad ON ad.id = adl.ad_document_id
-                WHERE ad.company_id = :companyId
-                  AND ad.report_date BETWEEN :periodFrom AND :periodTo
-                  {$mpAdsFilter}
-                GROUP BY adl.listing_id
+                SELECT t.listing_id
+                FROM (
+                    SELECT s.listing_id
+                    FROM marketplace_sales s
+                    WHERE s.company_id = :companyId
+                      AND s.sale_date BETWEEN :periodFrom AND :periodTo
+                      {$mpSalesFilter}
+                    UNION
+                    SELECT adl.listing_id
+                    FROM marketplace_ad_document_lines adl
+                    JOIN marketplace_ad_documents ad ON ad.id = adl.ad_document_id
+                    WHERE ad.company_id = :companyId
+                      AND ad.report_date BETWEEN :periodFrom AND :periodTo
+                      {$mpAdsFilter}
+                ) t
+                JOIN marketplace_listings ml ON ml.id = t.listing_id AND ml.company_id = :companyId
             )
             SQL;
 
         $salesCte = <<<SQL
             sales_agg AS (
-                SELECT listing_id, SUM(total_revenue) AS revenue
-                FROM marketplace_sales
-                WHERE company_id = :companyId
-                  AND sale_date BETWEEN :periodFrom AND :periodTo
-                  {$mpSalesFilterNoAlias}
-                GROUP BY listing_id
+                SELECT s.listing_id, SUM(s.total_revenue) AS revenue
+                FROM marketplace_sales s
+                WHERE s.company_id = :companyId
+                  AND s.sale_date BETWEEN :periodFrom AND :periodTo
+                  {$mpSalesFilter}
+                GROUP BY s.listing_id
             )
             SQL;
 
@@ -112,10 +117,24 @@ final class AdEfficiencyQuery
             )
             SQL;
 
-        $total = (int) $this->connection->fetchOne(
-            "WITH {$baseListingsCte} SELECT COUNT(*) FROM base_listings",
-            $params,
-        );
+        // Count + totals — одним запросом по тому же visible-набору, что и items.
+        // Гарантирует, что total не больше числа реально отдаваемых строк,
+        // а totals.drrPercent согласован с суммой по items.
+        $aggSql = <<<SQL
+            WITH {$baseListingsCte}, {$salesCte}, {$adsCte}
+            SELECT
+                COUNT(*) AS total,
+                COALESCE(SUM(COALESCE(sa.revenue, 0)), 0) AS total_revenue,
+                COALESCE(SUM(COALESCE(aa.ad_spend, 0)), 0) AS total_ad_spend
+            FROM base_listings bl
+            LEFT JOIN sales_agg sa ON sa.listing_id = bl.listing_id
+            LEFT JOIN ads_agg aa ON aa.listing_id = bl.listing_id
+            SQL;
+
+        $aggRow = $this->connection->fetchAssociative($aggSql, $params);
+        $total = (int) $aggRow['total'];
+        $totalRevenue = (string) $aggRow['total_revenue'];
+        $totalAdSpend = (string) $aggRow['total_ad_spend'];
 
         $offset = ($page - 1) * $pageSize;
         $orderColumn = self::SORT_COLUMNS[$sortBy];
@@ -165,31 +184,6 @@ final class AdEfficiencyQuery
                 drrPercent: null !== $row['drr_percent'] ? (string) $row['drr_percent'] : null,
             );
         }
-
-        $totalRevenueRaw = $this->connection->fetchOne(
-            <<<SQL
-            SELECT COALESCE(SUM(total_revenue), 0)
-            FROM marketplace_sales
-            WHERE company_id = :companyId
-              AND sale_date BETWEEN :periodFrom AND :periodTo
-              {$mpSalesFilterNoAlias}
-            SQL,
-            $params,
-        );
-        $totalRevenue = false === $totalRevenueRaw ? '0' : (string) $totalRevenueRaw;
-
-        $totalAdSpendRaw = $this->connection->fetchOne(
-            <<<SQL
-            SELECT COALESCE(SUM(adl.cost), 0)
-            FROM marketplace_ad_document_lines adl
-            JOIN marketplace_ad_documents ad ON ad.id = adl.ad_document_id
-            WHERE ad.company_id = :companyId
-              AND ad.report_date BETWEEN :periodFrom AND :periodTo
-              {$mpAdsFilter}
-            SQL,
-            $params,
-        );
-        $totalAdSpend = false === $totalAdSpendRaw ? '0' : (string) $totalAdSpendRaw;
 
         $totalDrrPercent = null;
         if (1 === bccomp($totalRevenue, '0', 4)) {

--- a/site/src/MarketplaceAds/Infrastructure/Query/AdEfficiencyQuery.php
+++ b/site/src/MarketplaceAds/Infrastructure/Query/AdEfficiencyQuery.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Infrastructure\Query;
+
+use App\MarketplaceAds\Application\DTO\AdEfficiencyItemDTO;
+use App\MarketplaceAds\Application\DTO\AdEfficiencyPageDTO;
+use Doctrine\DBAL\Connection;
+
+/**
+ * Read-model «Эффективность рекламы»: SKU × выручка × рекламные затраты × ДРР %.
+ *
+ * Живёт в MarketplaceAds, но читает напрямую из таблиц Marketplace (marketplace_sales,
+ * marketplace_listings) и собственных (marketplace_ad_documents, marketplace_ad_document_lines).
+ * Для read-only агрегата это приемлемо — см. прецедент ListingSalesAggregateQuery.
+ *
+ * DBAL, не ORM. Денежные значения наружу — decimal-строки (bcmath-compatible).
+ */
+final class AdEfficiencyQuery
+{
+    private const ALLOWED_SORT_BY = ['sku', 'title', 'revenue', 'adSpend', 'drrPercent'];
+    private const ALLOWED_SORT_DIR = ['asc', 'desc'];
+    private const DEFAULT_SORT_BY = 'revenue';
+    private const DEFAULT_SORT_DIR = 'desc';
+
+    private const SORT_COLUMNS = [
+        'sku'        => 'l.marketplace_sku',
+        'title'      => 'l.name',
+        'revenue'    => 'revenue',
+        'adSpend'    => 'ad_spend',
+        'drrPercent' => 'drr_percent',
+    ];
+
+    public function __construct(
+        private readonly Connection $connection,
+    ) {
+    }
+
+    public function getPage(
+        string $companyId,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        ?string $marketplace,
+        int $page,
+        int $pageSize,
+        string $sortBy = self::DEFAULT_SORT_BY,
+        string $sortDir = self::DEFAULT_SORT_DIR,
+    ): AdEfficiencyPageDTO {
+        $page = max(1, $page);
+        $pageSize = max(10, min(100, $pageSize));
+        $sortBy = in_array($sortBy, self::ALLOWED_SORT_BY, true) ? $sortBy : self::DEFAULT_SORT_BY;
+        $sortDir = in_array(strtolower($sortDir), self::ALLOWED_SORT_DIR, true)
+            ? strtolower($sortDir)
+            : self::DEFAULT_SORT_DIR;
+
+        $fromStr = $from->format('Y-m-d');
+        $toStr = $to->format('Y-m-d');
+
+        $params = [
+            'companyId' => $companyId,
+            'periodFrom' => $fromStr,
+            'periodTo' => $toStr,
+        ];
+        if (null !== $marketplace) {
+            $params['marketplace'] = $marketplace;
+        }
+
+        $mpSalesFilter = null !== $marketplace ? 'AND s.marketplace = :marketplace' : '';
+        $mpAdsFilter = null !== $marketplace ? 'AND ad.marketplace = :marketplace' : '';
+        $mpSalesFilterNoAlias = null !== $marketplace ? 'AND marketplace = :marketplace' : '';
+
+        $baseListingsCte = <<<SQL
+            base_listings AS (
+                SELECT s.listing_id
+                FROM marketplace_sales s
+                WHERE s.company_id = :companyId
+                  AND s.sale_date BETWEEN :periodFrom AND :periodTo
+                  {$mpSalesFilter}
+                GROUP BY s.listing_id
+                UNION
+                SELECT adl.listing_id
+                FROM marketplace_ad_document_lines adl
+                JOIN marketplace_ad_documents ad ON ad.id = adl.ad_document_id
+                WHERE ad.company_id = :companyId
+                  AND ad.report_date BETWEEN :periodFrom AND :periodTo
+                  {$mpAdsFilter}
+                GROUP BY adl.listing_id
+            )
+            SQL;
+
+        $salesCte = <<<SQL
+            sales_agg AS (
+                SELECT listing_id, SUM(total_revenue) AS revenue
+                FROM marketplace_sales
+                WHERE company_id = :companyId
+                  AND sale_date BETWEEN :periodFrom AND :periodTo
+                  {$mpSalesFilterNoAlias}
+                GROUP BY listing_id
+            )
+            SQL;
+
+        $adsCte = <<<SQL
+            ads_agg AS (
+                SELECT adl.listing_id, SUM(adl.cost) AS ad_spend
+                FROM marketplace_ad_document_lines adl
+                JOIN marketplace_ad_documents ad ON ad.id = adl.ad_document_id
+                WHERE ad.company_id = :companyId
+                  AND ad.report_date BETWEEN :periodFrom AND :periodTo
+                  {$mpAdsFilter}
+                GROUP BY adl.listing_id
+            )
+            SQL;
+
+        $total = (int) $this->connection->fetchOne(
+            "WITH {$baseListingsCte} SELECT COUNT(*) FROM base_listings",
+            $params,
+        );
+
+        $offset = ($page - 1) * $pageSize;
+        $orderColumn = self::SORT_COLUMNS[$sortBy];
+        $orderDirUpper = strtoupper($sortDir);
+        $nullsPosition = 'ASC' === $orderDirUpper ? 'NULLS FIRST' : 'NULLS LAST';
+
+        $pageSql = <<<SQL
+            WITH
+            {$baseListingsCte},
+            {$salesCte},
+            {$adsCte}
+            SELECT
+                l.id AS listing_id,
+                l.marketplace_sku AS sku,
+                l.name AS title,
+                l.marketplace AS marketplace,
+                COALESCE(sales_agg.revenue, 0) AS revenue,
+                COALESCE(ads_agg.ad_spend, 0) AS ad_spend,
+                CASE WHEN COALESCE(sales_agg.revenue, 0) > 0
+                     THEN COALESCE(ads_agg.ad_spend, 0) / sales_agg.revenue * 100
+                     ELSE NULL
+                END AS drr_percent
+            FROM base_listings bl
+            JOIN marketplace_listings l ON l.id = bl.listing_id
+            LEFT JOIN sales_agg ON sales_agg.listing_id = l.id
+            LEFT JOIN ads_agg ON ads_agg.listing_id = l.id
+            ORDER BY {$orderColumn} {$orderDirUpper} {$nullsPosition}, l.id ASC
+            LIMIT :pageSize OFFSET :offset
+            SQL;
+
+        $pageParams = $params + [
+            'pageSize' => $pageSize,
+            'offset' => $offset,
+        ];
+
+        $rows = $this->connection->fetchAllAssociative($pageSql, $pageParams);
+
+        $items = [];
+        foreach ($rows as $row) {
+            $items[] = new AdEfficiencyItemDTO(
+                listingId: (string) $row['listing_id'],
+                sku: (string) $row['sku'],
+                title: null !== $row['title'] ? (string) $row['title'] : null,
+                marketplace: (string) $row['marketplace'],
+                revenue: (string) $row['revenue'],
+                adSpend: (string) $row['ad_spend'],
+                drrPercent: null !== $row['drr_percent'] ? (string) $row['drr_percent'] : null,
+            );
+        }
+
+        $totalRevenueRaw = $this->connection->fetchOne(
+            <<<SQL
+            SELECT COALESCE(SUM(total_revenue), 0)
+            FROM marketplace_sales
+            WHERE company_id = :companyId
+              AND sale_date BETWEEN :periodFrom AND :periodTo
+              {$mpSalesFilterNoAlias}
+            SQL,
+            $params,
+        );
+        $totalRevenue = false === $totalRevenueRaw ? '0' : (string) $totalRevenueRaw;
+
+        $totalAdSpendRaw = $this->connection->fetchOne(
+            <<<SQL
+            SELECT COALESCE(SUM(adl.cost), 0)
+            FROM marketplace_ad_document_lines adl
+            JOIN marketplace_ad_documents ad ON ad.id = adl.ad_document_id
+            WHERE ad.company_id = :companyId
+              AND ad.report_date BETWEEN :periodFrom AND :periodTo
+              {$mpAdsFilter}
+            SQL,
+            $params,
+        );
+        $totalAdSpend = false === $totalAdSpendRaw ? '0' : (string) $totalAdSpendRaw;
+
+        $totalDrrPercent = null;
+        if (1 === bccomp($totalRevenue, '0', 4)) {
+            // (totalAdSpend / totalRevenue) * 100, с запасом знаков для bcdiv
+            $totalDrrPercent = bcmul(bcdiv($totalAdSpend, $totalRevenue, 8), '100', 4);
+        }
+
+        return new AdEfficiencyPageDTO(
+            items: $items,
+            total: $total,
+            page: $page,
+            pageSize: $pageSize,
+            totalRevenue: $totalRevenue,
+            totalAdSpend: $totalAdSpend,
+            totalDrrPercent: $totalDrrPercent,
+        );
+    }
+}

--- a/site/tests/Integration/MarketplaceAds/Controller/Api/AdEfficiencyControllerTest.php
+++ b/site/tests/Integration/MarketplaceAds/Controller/Api/AdEfficiencyControllerTest.php
@@ -1,0 +1,358 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\MarketplaceAds\Controller\Api;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Entity\MarketplaceSale;
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAds\Entity\AdDocument;
+use App\MarketplaceAds\Entity\AdDocumentLine;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+final class AdEfficiencyControllerTest extends WebTestCaseBase
+{
+    private const COMPANY_A_ID = '11111111-1111-1111-1111-a00000000001';
+    private const COMPANY_B_ID = '11111111-1111-1111-1111-a00000000002';
+    private const OWNER_A_ID = '22222222-2222-2222-2222-a00000000001';
+    private const OWNER_B_ID = '22222222-2222-2222-2222-a00000000002';
+
+    private const LISTING_A_ID = '55555555-5555-5555-5555-a00000000001';
+    private const LISTING_B_ID = '55555555-5555-5555-5555-a00000000002';
+
+    private const URL = '/api/marketplace-ads/efficiency';
+
+    public function testUnauthenticatedAccessIsDenied(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $client->request('GET', self::URL.'?periodFrom=2026-04-01&periodTo=2026-04-30');
+
+        $response = $client->getResponse();
+        self::assertTrue(
+            $response->isRedirect() || 401 === $response->getStatusCode() || 403 === $response->getStatusCode(),
+            'Unauthenticated access must be redirected or denied, got '.$response->getStatusCode(),
+        );
+    }
+
+    public function testReturns400WhenPeriodFromIsAfterPeriodTo(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $this->seedCompanyA($this->em());
+        $this->loginAsCompanyA($client);
+
+        $client->request('GET', self::URL.'?periodFrom=2026-04-30&periodTo=2026-04-01');
+
+        self::assertResponseStatusCodeSame(400);
+        $data = json_decode((string) $client->getResponse()->getContent(), true);
+        self::assertSame('periodFrom must be <= periodTo', $data['error']);
+    }
+
+    public function testReturns400WhenPeriodFromIsNotInYmdFormat(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $this->seedCompanyA($this->em());
+        $this->loginAsCompanyA($client);
+
+        $client->request('GET', self::URL.'?periodFrom=01-04-2026&periodTo=2026-04-30');
+
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    public function testReturns400WhenMarketplaceIsInvalid(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $this->seedCompanyA($this->em());
+        $this->loginAsCompanyA($client);
+
+        $client->request(
+            'GET',
+            self::URL.'?periodFrom=2026-04-01&periodTo=2026-04-30&marketplace=not_a_marketplace',
+        );
+
+        self::assertResponseStatusCodeSame(400);
+        $data = json_decode((string) $client->getResponse()->getContent(), true);
+        self::assertSame('invalid marketplace', $data['error']);
+    }
+
+    public function testInvalidSortBySilentlyFallsBackToDefaultAndReturns200(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+        $this->seedCompanyA($em);
+        $this->seedCompanyAData($em);
+        $this->loginAsCompanyA($client);
+
+        $client->request(
+            'GET',
+            self::URL.'?periodFrom=2026-04-01&periodTo=2026-04-30&sortBy=evil_column&sortDir=desc',
+        );
+
+        self::assertResponseIsSuccessful();
+        $data = json_decode((string) $client->getResponse()->getContent(), true);
+        self::assertArrayHasKey('items', $data);
+        self::assertArrayHasKey('total', $data);
+    }
+
+    public function testHappyPathReturnsExpectedStructure(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+        $this->seedCompanyA($em);
+        $this->seedCompanyAData($em);
+        $this->loginAsCompanyA($client);
+
+        $client->request(
+            'GET',
+            self::URL.'?periodFrom=2026-04-01&periodTo=2026-04-30&page=1&pageSize=25',
+        );
+
+        self::assertResponseIsSuccessful();
+        $data = json_decode((string) $client->getResponse()->getContent(), true);
+
+        self::assertArrayHasKey('items', $data);
+        self::assertArrayHasKey('total', $data);
+        self::assertArrayHasKey('page', $data);
+        self::assertArrayHasKey('pageSize', $data);
+        self::assertArrayHasKey('totals', $data);
+
+        self::assertSame(1, $data['total']);
+        self::assertSame(1, $data['page']);
+        self::assertSame(25, $data['pageSize']);
+        self::assertCount(1, $data['items']);
+
+        $item = $data['items'][0];
+        self::assertSame(self::LISTING_A_ID, $item['listingId']);
+        self::assertSame('SKU-A', $item['sku']);
+        self::assertSame('Товар A', $item['title']);
+        self::assertSame('ozon', $item['marketplace']);
+        self::assertEqualsWithDelta(1000.0, (float) $item['revenue'], 0.01);
+        self::assertEqualsWithDelta(100.0, (float) $item['adSpend'], 0.01);
+        self::assertNotNull($item['drrPercent']);
+        self::assertEqualsWithDelta(10.0, (float) $item['drrPercent'], 0.01);
+
+        self::assertArrayHasKey('revenue', $data['totals']);
+        self::assertArrayHasKey('adSpend', $data['totals']);
+        self::assertArrayHasKey('drrPercent', $data['totals']);
+        self::assertEqualsWithDelta(1000.0, (float) $data['totals']['revenue'], 0.01);
+        self::assertEqualsWithDelta(100.0, (float) $data['totals']['adSpend'], 0.01);
+        self::assertEqualsWithDelta(10.0, (float) $data['totals']['drrPercent'], 0.01);
+    }
+
+    public function testIdorReturnsEmptyItemsWhenActiveCompanyDoesNotOwnData(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $em = $this->em();
+
+        $this->seedCompanyA($em);
+        $this->seedCompanyB($em);
+        $this->seedCompanyAData($em);
+        $this->seedCompanyBData($em);
+
+        // Залогинены как owner Company B → активная компания — B; данные A не должны быть видны.
+        $ownerB = $em->getRepository(\App\Company\Entity\User::class)->find(self::OWNER_B_ID);
+        self::assertNotNull($ownerB);
+        $client->loginUser($ownerB);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', self::COMPANY_B_ID);
+        $session->save();
+
+        $client->request(
+            'GET',
+            self::URL.'?periodFrom=2026-04-01&periodTo=2026-04-30',
+        );
+
+        self::assertResponseIsSuccessful();
+        $data = json_decode((string) $client->getResponse()->getContent(), true);
+
+        self::assertSame(1, $data['total']);
+        self::assertCount(1, $data['items']);
+        $ids = array_column($data['items'], 'listingId');
+        self::assertContains(self::LISTING_B_ID, $ids);
+        self::assertNotContains(self::LISTING_A_ID, $ids);
+    }
+
+    private function loginAsCompanyA(KernelBrowser $client): void
+    {
+        $em = $this->em();
+        $owner = $em->getRepository(\App\Company\Entity\User::class)->find(self::OWNER_A_ID);
+        self::assertNotNull($owner);
+        $client->loginUser($owner);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', self::COMPANY_A_ID);
+        $session->save();
+    }
+
+    private function seedCompanyA(EntityManagerInterface $em): void
+    {
+        $ownerA = UserBuilder::aUser()
+            ->withId(self::OWNER_A_ID)
+            ->withEmail('ad-eff-ctrl-a@example.test')
+            ->build();
+        $companyA = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_A_ID)
+            ->withOwner($ownerA)
+            ->build();
+
+        $em->persist($ownerA);
+        $em->persist($companyA);
+        $em->flush();
+    }
+
+    private function seedCompanyB(EntityManagerInterface $em): void
+    {
+        $ownerB = UserBuilder::aUser()
+            ->withId(self::OWNER_B_ID)
+            ->withEmail('ad-eff-ctrl-b@example.test')
+            ->build();
+        $companyB = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_B_ID)
+            ->withOwner($ownerB)
+            ->build();
+
+        $em->persist($ownerB);
+        $em->persist($companyB);
+        $em->flush();
+    }
+
+    private function seedCompanyAData(EntityManagerInterface $em): void
+    {
+        $companyA = $em->getRepository(Company::class)->find(self::COMPANY_A_ID);
+        self::assertNotNull($companyA);
+
+        $listing = $this->newListing(
+            self::LISTING_A_ID,
+            $companyA,
+            MarketplaceType::OZON,
+            'SKU-A',
+            'Товар A',
+        );
+        $em->persist($listing);
+
+        $this->persistSale($em, $companyA, $listing, MarketplaceType::OZON, '2026-04-10', '1000.00', 'ORD-A-1');
+        $em->flush();
+
+        $this->persistAdDocumentWithLine(
+            $em,
+            companyId: self::COMPANY_A_ID,
+            marketplace: MarketplaceType::OZON,
+            reportDate: '2026-04-10',
+            campaignId: 'CAMP-A',
+            parentSku: 'SKU-A',
+            totalCost: '100.00',
+            listingId: self::LISTING_A_ID,
+            lineCost: '100.00',
+        );
+        $em->flush();
+        $em->clear();
+    }
+
+    private function seedCompanyBData(EntityManagerInterface $em): void
+    {
+        $companyB = $em->getRepository(Company::class)->find(self::COMPANY_B_ID);
+        self::assertNotNull($companyB);
+
+        $listing = $this->newListing(
+            self::LISTING_B_ID,
+            $companyB,
+            MarketplaceType::OZON,
+            'SKU-B',
+            'Товар B',
+        );
+        $em->persist($listing);
+
+        $this->persistSale($em, $companyB, $listing, MarketplaceType::OZON, '2026-04-15', '200.00', 'ORD-B-1');
+        $em->flush();
+        $em->clear();
+    }
+
+    private function newListing(
+        string $id,
+        Company $company,
+        MarketplaceType $marketplace,
+        string $sku,
+        string $name,
+    ): MarketplaceListing {
+        $listing = new MarketplaceListing($id, $company, null, $marketplace);
+        $listing->setMarketplaceSku($sku);
+        $listing->setSize('UNKNOWN');
+        $listing->setPrice('0.00');
+        $listing->setName($name);
+
+        return $listing;
+    }
+
+    private function persistSale(
+        EntityManagerInterface $em,
+        Company $company,
+        MarketplaceListing $listing,
+        MarketplaceType $marketplace,
+        string $dateYmd,
+        string $totalRevenue,
+        string $externalOrderId,
+    ): void {
+        $sale = new MarketplaceSale(
+            Uuid::uuid4()->toString(),
+            $company,
+            $listing,
+            $marketplace,
+        );
+        $sale->setExternalOrderId($externalOrderId);
+        $sale->setSaleDate(new \DateTimeImmutable($dateYmd));
+        $sale->setQuantity(1);
+        $sale->setPricePerUnit($totalRevenue);
+        $sale->setTotalRevenue($totalRevenue);
+
+        $em->persist($sale);
+    }
+
+    private function persistAdDocumentWithLine(
+        EntityManagerInterface $em,
+        string $companyId,
+        MarketplaceType $marketplace,
+        string $reportDate,
+        string $campaignId,
+        string $parentSku,
+        string $totalCost,
+        string $listingId,
+        string $lineCost,
+    ): void {
+        $adDocument = new AdDocument(
+            companyId: $companyId,
+            marketplace: $marketplace,
+            reportDate: new \DateTimeImmutable($reportDate),
+            campaignId: $campaignId,
+            campaignName: $campaignId,
+            parentSku: $parentSku,
+            totalCost: $totalCost,
+            totalImpressions: 0,
+            totalClicks: 0,
+            adRawDocumentId: Uuid::uuid4()->toString(),
+        );
+        $em->persist($adDocument);
+
+        $line = new AdDocumentLine(
+            adDocument: $adDocument,
+            listingId: $listingId,
+            sharePercent: '100.00',
+            cost: $lineCost,
+            impressions: 0,
+            clicks: 0,
+        );
+        $em->persist($line);
+    }
+}

--- a/site/tests/Integration/MarketplaceAds/Query/AdEfficiencyQueryTest.php
+++ b/site/tests/Integration/MarketplaceAds/Query/AdEfficiencyQueryTest.php
@@ -1,0 +1,569 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\MarketplaceAds\Query;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Entity\MarketplaceSale;
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAds\Entity\AdDocument;
+use App\MarketplaceAds\Entity\AdDocumentLine;
+use App\MarketplaceAds\Infrastructure\Query\AdEfficiencyQuery;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class AdEfficiencyQueryTest extends IntegrationTestCase
+{
+    private const COMPANY_A_ID = '11111111-1111-1111-1111-000000000001';
+    private const COMPANY_B_ID = '11111111-1111-1111-1111-000000000002';
+    private const OWNER_A_ID   = '22222222-2222-2222-2222-000000000001';
+    private const OWNER_B_ID   = '22222222-2222-2222-2222-000000000002';
+
+    private const LISTING_1_ID = '55555555-5555-5555-5555-000000000001';
+    private const LISTING_2_ID = '55555555-5555-5555-5555-000000000002';
+    private const LISTING_3_ID = '55555555-5555-5555-5555-000000000003';
+    private const LISTING_4_ID = '55555555-5555-5555-5555-000000000004';
+    private const LISTING_B_ID = '55555555-5555-5555-5555-00000000000B';
+
+    private const PERIOD_FROM = '2026-04-01';
+    private const PERIOD_TO   = '2026-04-30';
+
+    private AdEfficiencyQuery $query;
+    private Company $companyA;
+    private Company $companyB;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->query = self::getContainer()->get(AdEfficiencyQuery::class);
+
+        $this->seedFixtures();
+    }
+
+    public function testHappyPathReturnsListingsFromBothSalesAndAds(): void
+    {
+        $dto = $this->query->getPage(
+            self::COMPANY_A_ID,
+            new \DateTimeImmutable(self::PERIOD_FROM),
+            new \DateTimeImmutable(self::PERIOD_TO),
+            null,
+            page: 1,
+            pageSize: 25,
+        );
+
+        self::assertSame(3, $dto->total);
+        self::assertCount(3, $dto->items);
+
+        $ids = array_map(static fn ($i) => $i->listingId, $dto->items);
+        self::assertContains(self::LISTING_1_ID, $ids);
+        self::assertContains(self::LISTING_2_ID, $ids);
+        self::assertContains(self::LISTING_3_ID, $ids);
+        self::assertNotContains(self::LISTING_4_ID, $ids, 'listing4 — вне периода, должен быть исключён');
+        self::assertNotContains(self::LISTING_B_ID, $ids, 'IDOR: листинг Company B не должен попасть');
+
+        // totals — по всему набору (1000 + 500 + 0) = 1500 revenue; (100 + 0 + 50) = 150 ad_spend
+        self::assertEqualsWithDelta(1500.0, (float) $dto->totalRevenue, 0.01);
+        self::assertEqualsWithDelta(150.0, (float) $dto->totalAdSpend, 0.01);
+        self::assertNotNull($dto->totalDrrPercent);
+        // DRR = 150 / 1500 * 100 = 10
+        self::assertEqualsWithDelta(10.0, (float) $dto->totalDrrPercent, 0.01);
+    }
+
+    public function testListing1HasBothRevenueAndAdSpendAndDrrComputed(): void
+    {
+        $dto = $this->query->getPage(
+            self::COMPANY_A_ID,
+            new \DateTimeImmutable(self::PERIOD_FROM),
+            new \DateTimeImmutable(self::PERIOD_TO),
+            null,
+            page: 1,
+            pageSize: 25,
+        );
+
+        $listing1 = $this->findItem($dto->items, self::LISTING_1_ID);
+        self::assertNotNull($listing1);
+        self::assertEqualsWithDelta(1000.0, (float) $listing1->revenue, 0.01);
+        self::assertEqualsWithDelta(100.0, (float) $listing1->adSpend, 0.01);
+        self::assertNotNull($listing1->drrPercent);
+        // DRR = 100 / 1000 * 100 = 10
+        self::assertEqualsWithDelta(10.0, (float) $listing1->drrPercent, 0.01);
+    }
+
+    public function testListing2HasZeroAdSpendAndDrrIsZero(): void
+    {
+        $dto = $this->query->getPage(
+            self::COMPANY_A_ID,
+            new \DateTimeImmutable(self::PERIOD_FROM),
+            new \DateTimeImmutable(self::PERIOD_TO),
+            null,
+            page: 1,
+            pageSize: 25,
+        );
+
+        $listing2 = $this->findItem($dto->items, self::LISTING_2_ID);
+        self::assertNotNull($listing2);
+        self::assertEqualsWithDelta(500.0, (float) $listing2->revenue, 0.01);
+        self::assertEqualsWithDelta(0.0, (float) $listing2->adSpend, 0.01);
+        // revenue > 0, adSpend = 0 → drrPercent = 0 (не null)
+        self::assertNotNull($listing2->drrPercent);
+        self::assertEqualsWithDelta(0.0, (float) $listing2->drrPercent, 0.01);
+    }
+
+    public function testListing3HasZeroRevenueAndDrrIsNull(): void
+    {
+        $dto = $this->query->getPage(
+            self::COMPANY_A_ID,
+            new \DateTimeImmutable(self::PERIOD_FROM),
+            new \DateTimeImmutable(self::PERIOD_TO),
+            null,
+            page: 1,
+            pageSize: 25,
+        );
+
+        $listing3 = $this->findItem($dto->items, self::LISTING_3_ID);
+        self::assertNotNull($listing3);
+        self::assertEqualsWithDelta(0.0, (float) $listing3->revenue, 0.01);
+        self::assertEqualsWithDelta(50.0, (float) $listing3->adSpend, 0.01);
+        self::assertNull($listing3->drrPercent, 'revenue = 0 → drrPercent обязан быть null');
+    }
+
+    public function testMarketplaceFilterIncludesOnlyMatchingListings(): void
+    {
+        $this->seedWildberriesListingWithSales();
+
+        $dtoAll = $this->query->getPage(
+            self::COMPANY_A_ID,
+            new \DateTimeImmutable(self::PERIOD_FROM),
+            new \DateTimeImmutable(self::PERIOD_TO),
+            null,
+            page: 1,
+            pageSize: 25,
+        );
+        self::assertSame(4, $dtoAll->total, 'Без фильтра должны попасть Ozon + WB листинги');
+
+        $dtoOzon = $this->query->getPage(
+            self::COMPANY_A_ID,
+            new \DateTimeImmutable(self::PERIOD_FROM),
+            new \DateTimeImmutable(self::PERIOD_TO),
+            MarketplaceType::OZON->value,
+            page: 1,
+            pageSize: 25,
+        );
+        self::assertSame(3, $dtoOzon->total);
+        foreach ($dtoOzon->items as $item) {
+            self::assertSame('ozon', $item->marketplace);
+        }
+
+        $dtoWb = $this->query->getPage(
+            self::COMPANY_A_ID,
+            new \DateTimeImmutable(self::PERIOD_FROM),
+            new \DateTimeImmutable(self::PERIOD_TO),
+            MarketplaceType::WILDBERRIES->value,
+            page: 1,
+            pageSize: 25,
+        );
+        self::assertSame(1, $dtoWb->total);
+        self::assertSame('wildberries', $dtoWb->items[0]->marketplace);
+    }
+
+    public function testPagination(): void
+    {
+        // Страница 1 — 2 записи
+        $page1 = $this->query->getPage(
+            self::COMPANY_A_ID,
+            new \DateTimeImmutable(self::PERIOD_FROM),
+            new \DateTimeImmutable(self::PERIOD_TO),
+            null,
+            page: 1,
+            pageSize: 2,
+        );
+        self::assertSame(3, $page1->total);
+        self::assertCount(2, $page1->items);
+
+        // Страница 2 — 1 запись
+        $page2 = $this->query->getPage(
+            self::COMPANY_A_ID,
+            new \DateTimeImmutable(self::PERIOD_FROM),
+            new \DateTimeImmutable(self::PERIOD_TO),
+            null,
+            page: 2,
+            pageSize: 2,
+        );
+        self::assertSame(3, $page2->total);
+        self::assertCount(1, $page2->items);
+
+        // Страница 3 — пусто
+        $page3 = $this->query->getPage(
+            self::COMPANY_A_ID,
+            new \DateTimeImmutable(self::PERIOD_FROM),
+            new \DateTimeImmutable(self::PERIOD_TO),
+            null,
+            page: 3,
+            pageSize: 2,
+        );
+        self::assertSame(3, $page3->total);
+        self::assertCount(0, $page3->items);
+
+        // Records across pages — нет дубликатов
+        $idsPage1 = array_map(static fn ($i) => $i->listingId, $page1->items);
+        $idsPage2 = array_map(static fn ($i) => $i->listingId, $page2->items);
+        self::assertEmpty(array_intersect($idsPage1, $idsPage2));
+    }
+
+    public function testSortByRevenueDescendingOrdersListings(): void
+    {
+        $dto = $this->query->getPage(
+            self::COMPANY_A_ID,
+            new \DateTimeImmutable(self::PERIOD_FROM),
+            new \DateTimeImmutable(self::PERIOD_TO),
+            null,
+            page: 1,
+            pageSize: 25,
+            sortBy: 'revenue',
+            sortDir: 'desc',
+        );
+
+        $ids = array_map(static fn ($i) => $i->listingId, $dto->items);
+        self::assertSame(
+            [self::LISTING_1_ID, self::LISTING_2_ID, self::LISTING_3_ID],
+            $ids,
+            'revenue DESC: 1000 > 500 > 0',
+        );
+    }
+
+    public function testSortByAdSpendAscendingOrdersListings(): void
+    {
+        $dto = $this->query->getPage(
+            self::COMPANY_A_ID,
+            new \DateTimeImmutable(self::PERIOD_FROM),
+            new \DateTimeImmutable(self::PERIOD_TO),
+            null,
+            page: 1,
+            pageSize: 25,
+            sortBy: 'adSpend',
+            sortDir: 'asc',
+        );
+
+        $ids = array_map(static fn ($i) => $i->listingId, $dto->items);
+        self::assertSame(
+            [self::LISTING_2_ID, self::LISTING_3_ID, self::LISTING_1_ID],
+            $ids,
+            'adSpend ASC: 0 < 50 < 100',
+        );
+    }
+
+    public function testIdorCompanyBDataIsNotReturnedForCompanyA(): void
+    {
+        $dto = $this->query->getPage(
+            self::COMPANY_A_ID,
+            new \DateTimeImmutable(self::PERIOD_FROM),
+            new \DateTimeImmutable(self::PERIOD_TO),
+            null,
+            page: 1,
+            pageSize: 25,
+        );
+
+        $ids = array_map(static fn ($i) => $i->listingId, $dto->items);
+        self::assertNotContains(self::LISTING_B_ID, $ids);
+
+        // А обратно — Company B видит свои
+        $dtoB = $this->query->getPage(
+            self::COMPANY_B_ID,
+            new \DateTimeImmutable(self::PERIOD_FROM),
+            new \DateTimeImmutable(self::PERIOD_TO),
+            null,
+            page: 1,
+            pageSize: 25,
+        );
+        self::assertSame(1, $dtoB->total);
+        self::assertSame(self::LISTING_B_ID, $dtoB->items[0]->listingId);
+    }
+
+    public function testTotalsAreComputedOverFullSetNotJustThePage(): void
+    {
+        $dto = $this->query->getPage(
+            self::COMPANY_A_ID,
+            new \DateTimeImmutable(self::PERIOD_FROM),
+            new \DateTimeImmutable(self::PERIOD_TO),
+            null,
+            page: 1,
+            pageSize: 1, // на страницу — только 1 запись
+        );
+
+        self::assertCount(1, $dto->items);
+        self::assertSame(3, $dto->total);
+        // totals не должны зависеть от pageSize
+        self::assertEqualsWithDelta(1500.0, (float) $dto->totalRevenue, 0.01);
+        self::assertEqualsWithDelta(150.0, (float) $dto->totalAdSpend, 0.01);
+    }
+
+    /**
+     * @param list<\App\MarketplaceAds\Application\DTO\AdEfficiencyItemDTO> $items
+     */
+    private function findItem(array $items, string $listingId): ?\App\MarketplaceAds\Application\DTO\AdEfficiencyItemDTO
+    {
+        foreach ($items as $item) {
+            if ($item->listingId === $listingId) {
+                return $item;
+            }
+        }
+
+        return null;
+    }
+
+    private function seedFixtures(): void
+    {
+        // --- Companies & owners ---
+        $ownerA = UserBuilder::aUser()
+            ->withId(self::OWNER_A_ID)
+            ->withEmail('ad-eff-a@example.test')
+            ->build();
+        $ownerB = UserBuilder::aUser()
+            ->withId(self::OWNER_B_ID)
+            ->withEmail('ad-eff-b@example.test')
+            ->build();
+
+        $this->companyA = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_A_ID)
+            ->withOwner($ownerA)
+            ->build();
+        $this->companyB = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_B_ID)
+            ->withOwner($ownerB)
+            ->build();
+
+        $this->em->persist($ownerA);
+        $this->em->persist($ownerB);
+        $this->em->persist($this->companyA);
+        $this->em->persist($this->companyB);
+
+        // --- Listings (Company A, OZON) ---
+        $listing1 = $this->newListing(
+            self::LISTING_1_ID,
+            $this->companyA,
+            MarketplaceType::OZON,
+            'SKU-001',
+            'Товар 1',
+        );
+        $listing2 = $this->newListing(
+            self::LISTING_2_ID,
+            $this->companyA,
+            MarketplaceType::OZON,
+            'SKU-002',
+            'Товар 2',
+        );
+        $listing3 = $this->newListing(
+            self::LISTING_3_ID,
+            $this->companyA,
+            MarketplaceType::OZON,
+            'SKU-003',
+            'Товар 3',
+        );
+        $listing4 = $this->newListing(
+            self::LISTING_4_ID,
+            $this->companyA,
+            MarketplaceType::OZON,
+            'SKU-004',
+            'Товар 4 (out of period)',
+        );
+
+        // --- Listing Company B (IDOR) ---
+        $listingB = $this->newListing(
+            self::LISTING_B_ID,
+            $this->companyB,
+            MarketplaceType::OZON,
+            'SKU-B',
+            'Товар компании B',
+        );
+
+        foreach ([$listing1, $listing2, $listing3, $listing4, $listingB] as $l) {
+            $this->em->persist($l);
+        }
+
+        // --- Sales in period (Company A) ---
+        // listing1: revenue = 1000, listing2: revenue = 500.
+        $this->persistSale($this->companyA, $listing1, MarketplaceType::OZON, '2026-04-10', '1000.00', 1, 'ORD-A-1');
+        $this->persistSale($this->companyA, $listing2, MarketplaceType::OZON, '2026-04-12', '500.00',  1, 'ORD-A-2');
+
+        // listing4: продажи ВНЕ периода → должен быть исключён
+        $this->persistSale($this->companyA, $listing4, MarketplaceType::OZON, '2026-03-15', '999.00', 1, 'ORD-A-4-before');
+
+        // Sales Company B (IDOR)
+        $this->persistSale($this->companyB, $listingB, MarketplaceType::OZON, '2026-04-15', '200.00', 1, 'ORD-B-1');
+
+        $this->em->flush();
+
+        // --- Ad documents in period ---
+        // listing1: adSpend = 100, listing3: adSpend = 50
+        $this->persistAdDocumentWithLine(
+            companyId:     self::COMPANY_A_ID,
+            marketplace:   MarketplaceType::OZON,
+            reportDate:    '2026-04-10',
+            campaignId:    'CAMP-L1',
+            parentSku:     'SKU-001',
+            totalCost:     '100.00',
+            listingId:     self::LISTING_1_ID,
+            lineCost:      '100.00',
+        );
+        $this->persistAdDocumentWithLine(
+            companyId:     self::COMPANY_A_ID,
+            marketplace:   MarketplaceType::OZON,
+            reportDate:    '2026-04-12',
+            campaignId:    'CAMP-L3',
+            parentSku:     'SKU-003',
+            totalCost:     '50.00',
+            listingId:     self::LISTING_3_ID,
+            lineCost:      '50.00',
+        );
+
+        // listing4: реклама ВНЕ периода → должен быть исключён
+        $this->persistAdDocumentWithLine(
+            companyId:     self::COMPANY_A_ID,
+            marketplace:   MarketplaceType::OZON,
+            reportDate:    '2026-03-20',
+            campaignId:    'CAMP-L4-before',
+            parentSku:     'SKU-004',
+            totalCost:     '77.00',
+            listingId:     self::LISTING_4_ID,
+            lineCost:      '77.00',
+        );
+
+        // listingB (IDOR)
+        $this->persistAdDocumentWithLine(
+            companyId:     self::COMPANY_B_ID,
+            marketplace:   MarketplaceType::OZON,
+            reportDate:    '2026-04-15',
+            campaignId:    'CAMP-B',
+            parentSku:     'SKU-B',
+            totalCost:     '33.00',
+            listingId:     self::LISTING_B_ID,
+            lineCost:      '33.00',
+        );
+
+        $this->em->flush();
+        $this->em->clear();
+    }
+
+    private function seedWildberriesListingWithSales(): void
+    {
+        $companyA = $this->em->getRepository(Company::class)->find(self::COMPANY_A_ID);
+
+        $wbListingId = '55555555-5555-5555-5555-000000000005';
+        $wbListing = $this->newListing(
+            $wbListingId,
+            $companyA,
+            MarketplaceType::WILDBERRIES,
+            'WB-001',
+            'WB товар',
+        );
+        $this->em->persist($wbListing);
+
+        $this->persistSale(
+            $companyA,
+            $wbListing,
+            MarketplaceType::WILDBERRIES,
+            '2026-04-14',
+            '700.00',
+            1,
+            'ORD-WB-1',
+        );
+
+        $this->persistAdDocumentWithLine(
+            companyId:     self::COMPANY_A_ID,
+            marketplace:   MarketplaceType::WILDBERRIES,
+            reportDate:    '2026-04-14',
+            campaignId:    'CAMP-WB',
+            parentSku:     'WB-001',
+            totalCost:     '70.00',
+            listingId:     $wbListingId,
+            lineCost:      '70.00',
+        );
+
+        $this->em->flush();
+        $this->em->clear();
+    }
+
+    private function newListing(
+        string $id,
+        Company $company,
+        MarketplaceType $marketplace,
+        string $sku,
+        string $name,
+    ): MarketplaceListing {
+        $listing = new MarketplaceListing($id, $company, null, $marketplace);
+        $listing->setMarketplaceSku($sku);
+        $listing->setSize('UNKNOWN');
+        $listing->setPrice('0.00');
+        $listing->setName($name);
+
+        return $listing;
+    }
+
+    private function persistSale(
+        Company $company,
+        MarketplaceListing $listing,
+        MarketplaceType $marketplace,
+        string $dateYmd,
+        string $totalRevenue,
+        int $quantity,
+        string $externalOrderId,
+    ): void {
+        $sale = new MarketplaceSale(
+            Uuid::uuid4()->toString(),
+            $company,
+            $listing,
+            $marketplace,
+        );
+        $sale->setExternalOrderId($externalOrderId);
+        $sale->setSaleDate(new \DateTimeImmutable($dateYmd));
+        $sale->setQuantity($quantity);
+        $sale->setPricePerUnit($totalRevenue);
+        $sale->setTotalRevenue($totalRevenue);
+
+        $this->em->persist($sale);
+    }
+
+    private function persistAdDocumentWithLine(
+        string $companyId,
+        MarketplaceType $marketplace,
+        string $reportDate,
+        string $campaignId,
+        string $parentSku,
+        string $totalCost,
+        string $listingId,
+        string $lineCost,
+    ): void {
+        // AdDocument.adRawDocumentId — колонка типа guid (Assert::uuid в конструкторе), но без FK.
+        // Для read-only агрегата раскопка raw-доков не нужна — достаточно валидного uuid.
+        $adRawDocumentId = Uuid::uuid4()->toString();
+
+        $adDocument = new AdDocument(
+            companyId: $companyId,
+            marketplace: $marketplace,
+            reportDate: new \DateTimeImmutable($reportDate),
+            campaignId: $campaignId,
+            campaignName: $campaignId,
+            parentSku: $parentSku,
+            totalCost: $totalCost,
+            totalImpressions: 0,
+            totalClicks: 0,
+            adRawDocumentId: $adRawDocumentId,
+        );
+        $this->em->persist($adDocument);
+
+        $line = new AdDocumentLine(
+            adDocument: $adDocument,
+            listingId: $listingId,
+            sharePercent: '100.00',
+            cost: $lineCost,
+            impressions: 0,
+            clicks: 0,
+        );
+        $this->em->persist($line);
+    }
+}

--- a/site/tests/Integration/MarketplaceAds/Query/AdEfficiencyQueryTest.php
+++ b/site/tests/Integration/MarketplaceAds/Query/AdEfficiencyQueryTest.php
@@ -284,6 +284,44 @@ final class AdEfficiencyQueryTest extends IntegrationTestCase
         self::assertSame(self::LISTING_B_ID, $dtoB->items[0]->listingId);
     }
 
+    public function testOrphanedAdLineListingIdIsExcludedFromCountAndTotals(): void
+    {
+        // marketplace_ad_document_lines.listing_id не имеет FK на marketplace_listings:
+        // возможна ситуация, когда ad-строка ссылается на несуществующий листинг.
+        // Такие «висячие» id не должны попадать ни в total, ни в totalAdSpend,
+        // иначе API будет отдавать числа, несовместимые с отрисованной таблицей.
+        $orphanListingId = '99999999-9999-9999-9999-000000000001';
+        $this->persistAdDocumentWithLine(
+            companyId:   self::COMPANY_A_ID,
+            marketplace: MarketplaceType::OZON,
+            reportDate:  '2026-04-20',
+            campaignId:  'CAMP-ORPHAN',
+            parentSku:   'SKU-ORPHAN',
+            totalCost:   '42.00',
+            listingId:   $orphanListingId,
+            lineCost:    '42.00',
+        );
+        $this->em->flush();
+        $this->em->clear();
+
+        $dto = $this->query->getPage(
+            self::COMPANY_A_ID,
+            new \DateTimeImmutable(self::PERIOD_FROM),
+            new \DateTimeImmutable(self::PERIOD_TO),
+            null,
+            page: 1,
+            pageSize: 25,
+        );
+
+        self::assertSame(3, $dto->total, 'Висячий listing_id не должен увеличивать total');
+        $ids = array_map(static fn ($i) => $i->listingId, $dto->items);
+        self::assertNotContains($orphanListingId, $ids);
+
+        // totalAdSpend = 100 + 50 = 150 (висячие 42.00 не учтены)
+        self::assertEqualsWithDelta(150.0, (float) $dto->totalAdSpend, 0.01);
+        self::assertEqualsWithDelta(1500.0, (float) $dto->totalRevenue, 0.01);
+    }
+
     public function testTotalsAreComputedOverFullSetNotJustThePage(): void
     {
         $dto = $this->query->getPage(


### PR DESCRIPTION
## Summary

Backend (часть 1 из 2) для будущей страницы `/marketplace-ads/efficiency`
«Эффективность рекламы»: таблица `SKU | Название | Выручка | Рекламные
расходы | ДРР %` с пагинацией и фильтром по маркетплейсу. **Только
backend — фронтенд отдельной задачей.**

### Что добавлено

**DTO** (`App\MarketplaceAds\Application\DTO`):
- `AdEfficiencyItemDTO` — строка таблицы: `listingId`, `sku`, `?title`,
  `marketplace`, `revenue`, `adSpend`, `?drrPercent`.
  `drrPercent = null`, когда `revenue = 0`.
- `AdEfficiencyPageDTO` — `items`, `total`, `page`, `pageSize`,
  `totalRevenue`, `totalAdSpend`, `?totalDrrPercent`. Totals считаются по
  **всему набору** листингов, не только по странице.

**Query** (`App\MarketplaceAds\Infrastructure\Query\AdEfficiencyQuery`, DBAL):
- `getPage(companyId, from, to, ?marketplace, page, pageSize, sortBy, sortDir): AdEfficiencyPageDTO`.
- SQL-паттерн: CTE `base_listings` (UNION листингов, у которых были продажи
  **или** рекламные расходы в периоде) + отдельные CTE `sales_agg` и
  `ads_agg` — избегаем картезиана между продажами и рекламой.
- Входные параметры валидируются внутри метода: `page ≥ 1`,
  `10 ≤ pageSize ≤ 100`, `sortBy ∈ {sku,title,revenue,adSpend,drrPercent}`
  (fallback `revenue`), `sortDir ∈ {asc,desc}` (fallback `desc`).
- `NULLS LAST`/`NULLS FIRST` + вторичный `l.id ASC` для детерминированной
  пагинации при одинаковых значениях сортировки.
- Денежные значения наружу — **decimal-строки** (bcmath-compatible).
  `totalDrrPercent` считается через `bcdiv` + `bcmul`, null при нулевой
  выручке.

**Controller** (`GET /api/marketplace-ads/efficiency`):
- `#[IsGranted('ROLE_COMPANY_USER')]`, активная компания — из
  `ActiveCompanyService`.
- Валидация `periodFrom`/`periodTo` в формате `Y-m-d` → 400.
- `periodFrom > periodTo` → 400.
- `marketplace` через `MarketplaceType::tryFrom`; невалидное значение → 400.
- **Невалидный `sortBy` молча падает в default** — protection-in-depth,
  не 400.
- Response: `{items, total, page, pageSize, totals: {revenue, adSpend, drrPercent}}`.

**Безопасность / границы модулей:**
- Каждый SQL-путь ограничен `company_id = :companyId` — IDOR-safe.
- Нет изменений в `MarketplaceAdsFacade` / `MarketplaceFacade`. Query —
  внутренний read-слой модуля MarketplaceAds, используется контроллером
  напрямую (прецедент: `ListingSalesAggregateQuery`).
- Нет фронтенда, нет twig-шаблонов.

**ARCHITECTURE.md:** добавлена секция «Query — MarketplaceAds».

## Test plan

Интеграционные тесты покрывают все сценарии из ТЗ:

**`AdEfficiencyQueryTest`** (extends `IntegrationTestCase`):
- [x] Happy path: листинги попадают и через продажи, и через рекламу
- [x] `listing1` (sales+ads) → `revenue=1000`, `adSpend=100`, `drr=10%`
- [x] `listing2` (только sales) → `adSpend=0`, `drr=0`
- [x] `listing3` (только ads) → `revenue=0`, `drr=null`
- [x] `listing4` вне периода — исключён
- [x] Фильтр по `marketplace` (Ozon vs Wildberries)
- [x] Пагинация: `page=1/2/3 × pageSize=2`, без дубликатов между страницами
- [x] Сортировка `revenue DESC`, `adSpend ASC`
- [x] IDOR: данные Company B не видны Company A и наоборот
- [x] Totals считаются по всему набору при `pageSize=1`

**`AdEfficiencyControllerTest`** (extends `WebTestCaseBase`):
- [x] Неавторизованный доступ → redirect / 401 / 403
- [x] `periodFrom > periodTo` → 400
- [x] Невалидный формат даты → 400
- [x] Невалидный `marketplace` → 400
- [x] Невалидный `sortBy` → 200 (silent fallback), ответ валиден
- [x] Happy path: корректная структура response, значения из Query
- [x] IDOR: активная компания B видит только свои данные

> ⚠️ В sandbox-окружении ассистента Docker недоступен, так что тесты
> прогоняются в CI. Файлы прошли `php -l` syntax-check локально;
> builders/конструкторы/setter'ы сверены с существующими тестами
> (`AdsIndexControllerTest`, `ReprocessAdRawDocumentControllerTest`,
> `ActiveOzonPerformanceConnectionsQueryTest`).

https://claude.ai/code/session_01VcpUfrbP65PFUdwMhf8vct