### PR TITLE
feat(marketplace-ads): Ad Efficiency frontend page

### DIFF
--- a/site/assets/react/ad-efficiency-page.tsx
+++ b/site/assets/react/ad-efficiency-page.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { ErrorBoundary } from './shared/ui/ErrorBoundary';
+import type { MarketplaceOption } from './marketplace-ads/ad-efficiency/adEfficiency.types';
+import AdEfficiencyPage from './marketplace-ads/ad-efficiency/AdEfficiencyPage';
+
+function mountAdEfficiencyPage() {
+    const el = document.getElementById('react-ad-efficiency');
+    if (!el || (el as any).__reactRoot) return;
+
+    let marketplaces: MarketplaceOption[] = [];
+    try {
+        marketplaces = JSON.parse(el.dataset.marketplaces ?? '[]');
+    } catch {
+        marketplaces = [];
+    }
+
+    const root = createRoot(el);
+    (el as any).__reactRoot = root;
+
+    root.render(
+        <ErrorBoundary widgetName="AdEfficiency">
+            <AdEfficiencyPage marketplaces={marketplaces} />
+        </ErrorBoundary>
+    );
+}
+
+window.addEventListener('DOMContentLoaded', mountAdEfficiencyPage);

--- a/site/assets/react/marketplace-ads/ad-efficiency/AdEfficiencyPage.tsx
+++ b/site/assets/react/marketplace-ads/ad-efficiency/AdEfficiencyPage.tsx
@@ -121,6 +121,13 @@ const AdEfficiencyPage: React.FC<AdEfficiencyPageProps> = ({ marketplaces }) => 
         [total, state.pageSize],
     );
 
+    useEffect(() => {
+        if (isLoading || total === 0) return;
+        if (state.page > totalPages) {
+            setState((prev) => ({ ...prev, page: totalPages }));
+        }
+    }, [isLoading, total, totalPages, state.page]);
+
     const displayStart = total === 0 ? 0 : (state.page - 1) * state.pageSize + 1;
     const displayEnd = Math.min(state.page * state.pageSize, total);
 

--- a/site/assets/react/marketplace-ads/ad-efficiency/AdEfficiencyPage.tsx
+++ b/site/assets/react/marketplace-ads/ad-efficiency/AdEfficiencyPage.tsx
@@ -78,16 +78,25 @@ function readInitialState(): State {
 }
 
 function syncUrl(state: State): void {
-    const params = new URLSearchParams();
-    if (state.marketplace) params.set('marketplace', state.marketplace);
+    const params = new URLSearchParams(window.location.search);
+
+    if (state.marketplace) {
+        params.set('marketplace', state.marketplace);
+    } else {
+        params.delete('marketplace');
+    }
+
     params.set('periodFrom', state.periodFrom);
     params.set('periodTo', state.periodTo);
     params.set('page', String(state.page));
     params.set('pageSize', String(state.pageSize));
     params.set('sortBy', state.sortBy);
     params.set('sortDir', state.sortDir);
+
     const search = params.toString();
-    window.history.replaceState(null, '', window.location.pathname + (search ? `?${search}` : ''));
+    const newUrl =
+        window.location.pathname + (search ? `?${search}` : '') + window.location.hash;
+    window.history.replaceState(null, '', newUrl);
 }
 
 const AdEfficiencyPage: React.FC<AdEfficiencyPageProps> = ({ marketplaces }) => {

--- a/site/assets/react/marketplace-ads/ad-efficiency/AdEfficiencyPage.tsx
+++ b/site/assets/react/marketplace-ads/ad-efficiency/AdEfficiencyPage.tsx
@@ -1,0 +1,252 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useAdEfficiency } from './useAdEfficiency';
+import AdEfficiencyTable from './AdEfficiencyTable';
+import Pagination from '../../shared/components/Pagination';
+import type { MarketplaceOption, SortBy, SortDir } from './adEfficiency.types';
+
+interface AdEfficiencyPageProps {
+    marketplaces: MarketplaceOption[];
+}
+
+const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
+const DEFAULT_PAGE_SIZE = 25;
+const DEFAULT_SORT_BY: SortBy = 'revenue';
+const DEFAULT_SORT_DIR: SortDir = 'desc';
+
+const SORT_BY_VALUES: readonly SortBy[] = ['sku', 'title', 'revenue', 'adSpend', 'drrPercent'];
+
+function pad2(n: number): string {
+    return n < 10 ? `0${n}` : String(n);
+}
+
+function formatYmd(date: Date): string {
+    return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
+}
+
+function defaultPeriod(): { periodFrom: string; periodTo: string } {
+    const today = new Date();
+    const yesterday = new Date(today);
+    yesterday.setDate(today.getDate() - 1);
+    const monthAgo = new Date(yesterday);
+    monthAgo.setDate(yesterday.getDate() - 30);
+    return { periodFrom: formatYmd(monthAgo), periodTo: formatYmd(yesterday) };
+}
+
+function isSortBy(value: string | null): value is SortBy {
+    return value !== null && (SORT_BY_VALUES as readonly string[]).includes(value);
+}
+
+function isSortDir(value: string | null): value is SortDir {
+    return value === 'asc' || value === 'desc';
+}
+
+function parsePositiveInt(value: string | null, fallback: number): number {
+    if (value === null) return fallback;
+    const n = Number.parseInt(value, 10);
+    return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+interface State {
+    marketplace: string;
+    periodFrom: string;
+    periodTo: string;
+    page: number;
+    pageSize: number;
+    sortBy: SortBy;
+    sortDir: SortDir;
+}
+
+function readInitialState(): State {
+    const params = new URLSearchParams(window.location.search);
+    const { periodFrom, periodTo } = defaultPeriod();
+
+    const urlPageSize = parsePositiveInt(params.get('pageSize'), DEFAULT_PAGE_SIZE);
+    const pageSize = PAGE_SIZE_OPTIONS.includes(urlPageSize) ? urlPageSize : DEFAULT_PAGE_SIZE;
+
+    const urlSortBy = params.get('sortBy');
+    const urlSortDir = params.get('sortDir');
+
+    return {
+        marketplace: params.get('marketplace') ?? '',
+        periodFrom: params.get('periodFrom') ?? periodFrom,
+        periodTo: params.get('periodTo') ?? periodTo,
+        page: parsePositiveInt(params.get('page'), 1),
+        pageSize,
+        sortBy: isSortBy(urlSortBy) ? urlSortBy : DEFAULT_SORT_BY,
+        sortDir: isSortDir(urlSortDir) ? urlSortDir : DEFAULT_SORT_DIR,
+    };
+}
+
+function syncUrl(state: State): void {
+    const params = new URLSearchParams();
+    if (state.marketplace) params.set('marketplace', state.marketplace);
+    params.set('periodFrom', state.periodFrom);
+    params.set('periodTo', state.periodTo);
+    params.set('page', String(state.page));
+    params.set('pageSize', String(state.pageSize));
+    params.set('sortBy', state.sortBy);
+    params.set('sortDir', state.sortDir);
+    const search = params.toString();
+    window.history.replaceState(null, '', window.location.pathname + (search ? `?${search}` : ''));
+}
+
+const AdEfficiencyPage: React.FC<AdEfficiencyPageProps> = ({ marketplaces }) => {
+    const [state, setState] = useState<State>(readInitialState);
+
+    useEffect(() => {
+        syncUrl(state);
+    }, [state]);
+
+    const { items, total, totals, isLoading, isError, errorMessage } = useAdEfficiency({
+        marketplace: state.marketplace,
+        periodFrom: state.periodFrom,
+        periodTo: state.periodTo,
+        page: state.page,
+        pageSize: state.pageSize,
+        sortBy: state.sortBy,
+        sortDir: state.sortDir,
+    });
+
+    const totalPages = useMemo(
+        () => Math.max(1, Math.ceil(total / state.pageSize)),
+        [total, state.pageSize],
+    );
+
+    const displayStart = total === 0 ? 0 : (state.page - 1) * state.pageSize + 1;
+    const displayEnd = Math.min(state.page * state.pageSize, total);
+
+    const handleMarketplaceChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+        const value = e.target.value;
+        setState((prev) => ({ ...prev, marketplace: value, page: 1 }));
+    }, []);
+
+    const handlePeriodFromChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+        const value = e.target.value;
+        setState((prev) => ({ ...prev, periodFrom: value, page: 1 }));
+    }, []);
+
+    const handlePeriodToChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+        const value = e.target.value;
+        setState((prev) => ({ ...prev, periodTo: value, page: 1 }));
+    }, []);
+
+    const handlePageSizeChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+        const value = Number.parseInt(e.target.value, 10);
+        const next = PAGE_SIZE_OPTIONS.includes(value) ? value : DEFAULT_PAGE_SIZE;
+        setState((prev) => ({ ...prev, pageSize: next, page: 1 }));
+    }, []);
+
+    const handleSort = useCallback((column: SortBy) => {
+        setState((prev) => {
+            if (prev.sortBy === column) {
+                return {
+                    ...prev,
+                    sortDir: prev.sortDir === 'asc' ? 'desc' : 'asc',
+                    page: 1,
+                };
+            }
+            return { ...prev, sortBy: column, sortDir: 'desc', page: 1 };
+        });
+    }, []);
+
+    const handlePageChange = useCallback((page: number) => {
+        setState((prev) => ({ ...prev, page }));
+    }, []);
+
+    return (
+        <div className="container-fluid">
+            <div className="row g-2 mb-3">
+                <div className="col-md-3">
+                    <label className="form-label">Маркетплейс</label>
+                    <select
+                        className="form-select"
+                        value={state.marketplace}
+                        onChange={handleMarketplaceChange}
+                    >
+                        <option value="">Все</option>
+                        {marketplaces.map((m) => (
+                            <option key={m.value} value={m.value}>
+                                {m.label}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+                <div className="col-md-3">
+                    <label className="form-label">С</label>
+                    <input
+                        type="date"
+                        className="form-control"
+                        value={state.periodFrom}
+                        onChange={handlePeriodFromChange}
+                    />
+                </div>
+                <div className="col-md-3">
+                    <label className="form-label">По</label>
+                    <input
+                        type="date"
+                        className="form-control"
+                        value={state.periodTo}
+                        onChange={handlePeriodToChange}
+                    />
+                </div>
+            </div>
+
+            {isLoading && (
+                <div className="d-flex justify-content-center py-4">
+                    <div className="spinner-border text-primary" role="status">
+                        <span className="visually-hidden">Загрузка...</span>
+                    </div>
+                </div>
+            )}
+
+            {isError && (
+                <div className="alert alert-danger mb-3">
+                    {errorMessage ?? 'Не удалось загрузить данные'}
+                </div>
+            )}
+
+            {!isLoading && !isError && (
+                <>
+                    <AdEfficiencyTable
+                        items={items}
+                        totals={totals}
+                        sortBy={state.sortBy}
+                        sortDir={state.sortDir}
+                        onSort={handleSort}
+                    />
+
+                    <div className="row mt-3 align-items-center g-2">
+                        <div className="col-md-3">
+                            <div className="d-flex align-items-center gap-2">
+                                <span className="text-muted">Показывать по</span>
+                                <select
+                                    className="form-select form-select-sm w-auto"
+                                    value={state.pageSize}
+                                    onChange={handlePageSizeChange}
+                                >
+                                    {PAGE_SIZE_OPTIONS.map((opt) => (
+                                        <option key={opt} value={opt}>
+                                            {opt}
+                                        </option>
+                                    ))}
+                                </select>
+                            </div>
+                        </div>
+                        <div className="col-md-6 text-center text-muted">
+                            Показано {displayStart}–{displayEnd} из {total}
+                        </div>
+                        <div className="col-md-3">
+                            <Pagination
+                                currentPage={state.page}
+                                totalPages={totalPages}
+                                onPageChange={handlePageChange}
+                            />
+                        </div>
+                    </div>
+                </>
+            )}
+        </div>
+    );
+};
+
+export default AdEfficiencyPage;

--- a/site/assets/react/marketplace-ads/ad-efficiency/AdEfficiencyTable.tsx
+++ b/site/assets/react/marketplace-ads/ad-efficiency/AdEfficiencyTable.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import type {
+    AdEfficiencyItem,
+    AdEfficiencyTotals,
+    SortBy,
+    SortDir,
+} from './adEfficiency.types';
+import { formatDrr, formatRub } from './formatters';
+
+interface AdEfficiencyTableProps {
+    items: AdEfficiencyItem[];
+    totals: AdEfficiencyTotals | null;
+    sortBy: SortBy;
+    sortDir: SortDir;
+    onSort: (column: SortBy) => void;
+}
+
+interface SortableHeaderProps {
+    column: SortBy;
+    sortBy: SortBy;
+    sortDir: SortDir;
+    onSort: (column: SortBy) => void;
+    children: React.ReactNode;
+}
+
+const SortableHeader: React.FC<SortableHeaderProps> = ({
+    column,
+    sortBy,
+    sortDir,
+    onSort,
+    children,
+}) => {
+    const isActive = sortBy === column;
+    const arrow = isActive ? (sortDir === 'asc' ? ' ↑' : ' ↓') : '';
+
+    return (
+        <button
+            type="button"
+            className="btn btn-link p-0 text-reset text-decoration-none fw-semibold"
+            onClick={() => onSort(column)}
+        >
+            {children}
+            {arrow && <span className="ms-1">{arrow}</span>}
+        </button>
+    );
+};
+
+const AdEfficiencyTable: React.FC<AdEfficiencyTableProps> = ({
+    items,
+    totals,
+    sortBy,
+    sortDir,
+    onSort,
+}) => {
+    return (
+        <div className="card">
+            <div className="table-responsive">
+                <table className="table table-vcenter table-hover card-table">
+                    <thead>
+                        <tr>
+                            <th>
+                                <SortableHeader
+                                    column="sku"
+                                    sortBy={sortBy}
+                                    sortDir={sortDir}
+                                    onSort={onSort}
+                                >
+                                    SKU
+                                </SortableHeader>
+                            </th>
+                            <th>
+                                <SortableHeader
+                                    column="title"
+                                    sortBy={sortBy}
+                                    sortDir={sortDir}
+                                    onSort={onSort}
+                                >
+                                    Название
+                                </SortableHeader>
+                            </th>
+                            <th className="text-end">
+                                <SortableHeader
+                                    column="revenue"
+                                    sortBy={sortBy}
+                                    sortDir={sortDir}
+                                    onSort={onSort}
+                                >
+                                    Выручка, ₽
+                                </SortableHeader>
+                            </th>
+                            <th className="text-end">
+                                <SortableHeader
+                                    column="adSpend"
+                                    sortBy={sortBy}
+                                    sortDir={sortDir}
+                                    onSort={onSort}
+                                >
+                                    Расходы на рекламу, ₽
+                                </SortableHeader>
+                            </th>
+                            <th className="text-end">
+                                <SortableHeader
+                                    column="drrPercent"
+                                    sortBy={sortBy}
+                                    sortDir={sortDir}
+                                    onSort={onSort}
+                                >
+                                    ДРР, %
+                                </SortableHeader>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {items.length === 0 ? (
+                            <tr>
+                                <td colSpan={5} className="text-center py-5 text-muted">
+                                    Нет данных за выбранный период
+                                </td>
+                            </tr>
+                        ) : (
+                            items.map((item) => (
+                                <tr key={item.listingId}>
+                                    <td>{item.sku}</td>
+                                    <td>{item.title ?? '—'}</td>
+                                    <td className="text-end">{formatRub(item.revenue)}</td>
+                                    <td className="text-end">{formatRub(item.adSpend)}</td>
+                                    <td className="text-end">{formatDrr(item.drrPercent)}</td>
+                                </tr>
+                            ))
+                        )}
+                    </tbody>
+                    {totals && (
+                        <tfoot>
+                            <tr className="fw-bold">
+                                <td colSpan={2}>Итого</td>
+                                <td className="text-end">{formatRub(totals.revenue)}</td>
+                                <td className="text-end">{formatRub(totals.adSpend)}</td>
+                                <td className="text-end">{formatDrr(totals.drrPercent)}</td>
+                            </tr>
+                        </tfoot>
+                    )}
+                </table>
+            </div>
+        </div>
+    );
+};
+
+export default AdEfficiencyTable;

--- a/site/assets/react/marketplace-ads/ad-efficiency/adEfficiency.types.ts
+++ b/site/assets/react/marketplace-ads/ad-efficiency/adEfficiency.types.ts
@@ -1,0 +1,31 @@
+export interface AdEfficiencyItem {
+    listingId: string;
+    sku: string;
+    title: string | null;
+    marketplace: string;
+    revenue: string;
+    adSpend: string;
+    drrPercent: string | null;
+}
+
+export interface AdEfficiencyTotals {
+    revenue: string;
+    adSpend: string;
+    drrPercent: string | null;
+}
+
+export interface AdEfficiencyResponse {
+    items: AdEfficiencyItem[];
+    total: number;
+    page: number;
+    pageSize: number;
+    totals: AdEfficiencyTotals;
+}
+
+export interface MarketplaceOption {
+    value: string;
+    label: string;
+}
+
+export type SortBy = 'sku' | 'title' | 'revenue' | 'adSpend' | 'drrPercent';
+export type SortDir = 'asc' | 'desc';

--- a/site/assets/react/marketplace-ads/ad-efficiency/formatters.ts
+++ b/site/assets/react/marketplace-ads/ad-efficiency/formatters.ts
@@ -1,3 +1,8 @@
+const numberFormatter = new Intl.NumberFormat('ru-RU', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+});
+
 /**
  * Форматирование денежной суммы из decimal-строки в "1 234,56".
  * Пустая / некорректная строка → "0,00".
@@ -7,10 +12,7 @@ export function formatRub(value: string): string {
     if (!Number.isFinite(num)) {
         return '0,00';
     }
-    return new Intl.NumberFormat('ru-RU', {
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-    }).format(num);
+    return numberFormatter.format(num);
 }
 
 /**
@@ -25,10 +27,5 @@ export function formatDrr(value: string | null): string {
     if (!Number.isFinite(num) || num === 0) {
         return '—';
     }
-    return (
-        new Intl.NumberFormat('ru-RU', {
-            minimumFractionDigits: 2,
-            maximumFractionDigits: 2,
-        }).format(num) + '%'
-    );
+    return numberFormatter.format(num) + '%';
 }

--- a/site/assets/react/marketplace-ads/ad-efficiency/formatters.ts
+++ b/site/assets/react/marketplace-ads/ad-efficiency/formatters.ts
@@ -1,0 +1,34 @@
+/**
+ * Форматирование денежной суммы из decimal-строки в "1 234,56".
+ * Пустая / некорректная строка → "0,00".
+ */
+export function formatRub(value: string): string {
+    const num = Number(value);
+    if (!Number.isFinite(num)) {
+        return '0,00';
+    }
+    return new Intl.NumberFormat('ru-RU', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+    }).format(num);
+}
+
+/**
+ * Форматирование ДРР из decimal-строки в "12,34%".
+ * null / "0" → "—".
+ */
+export function formatDrr(value: string | null): string {
+    if (value === null || value === '0') {
+        return '—';
+    }
+    const num = Number(value);
+    if (!Number.isFinite(num) || num === 0) {
+        return '—';
+    }
+    return (
+        new Intl.NumberFormat('ru-RU', {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+        }).format(num) + '%'
+    );
+}

--- a/site/assets/react/marketplace-ads/ad-efficiency/useAdEfficiency.ts
+++ b/site/assets/react/marketplace-ads/ad-efficiency/useAdEfficiency.ts
@@ -1,0 +1,82 @@
+import { useCallback, useEffect } from 'react';
+import { useAbortableQuery } from '../../shared/hooks/useAbortableQuery';
+import type {
+    AdEfficiencyItem,
+    AdEfficiencyResponse,
+    AdEfficiencyTotals,
+    SortBy,
+    SortDir,
+} from './adEfficiency.types';
+
+interface UseAdEfficiencyParams {
+    marketplace: string;
+    periodFrom: string;
+    periodTo: string;
+    page: number;
+    pageSize: number;
+    sortBy: SortBy;
+    sortDir: SortDir;
+}
+
+interface UseAdEfficiencyResult {
+    items: AdEfficiencyItem[];
+    total: number;
+    page: number;
+    pageSize: number;
+    totals: AdEfficiencyTotals | null;
+    isLoading: boolean;
+    isError: boolean;
+    errorMessage: string | null;
+}
+
+export function useAdEfficiency(params: UseAdEfficiencyParams): UseAdEfficiencyResult {
+    const { isLoading, data, error, run } = useAbortableQuery<AdEfficiencyResponse>();
+
+    const load = useCallback(() => {
+        if (!params.periodFrom || !params.periodTo) {
+            return;
+        }
+
+        const query: Record<string, string | number> = {
+            periodFrom: params.periodFrom,
+            periodTo: params.periodTo,
+            page: params.page,
+            pageSize: params.pageSize,
+            sortBy: params.sortBy,
+            sortDir: params.sortDir,
+        };
+
+        if (params.marketplace) {
+            query.marketplace = params.marketplace;
+        }
+
+        void run({
+            url: '/api/marketplace-ads/efficiency',
+            query,
+        });
+    }, [
+        params.marketplace,
+        params.periodFrom,
+        params.periodTo,
+        params.page,
+        params.pageSize,
+        params.sortBy,
+        params.sortDir,
+        run,
+    ]);
+
+    useEffect(() => {
+        load();
+    }, [load]);
+
+    return {
+        items: data?.items ?? [],
+        total: data?.total ?? 0,
+        page: data?.page ?? params.page,
+        pageSize: data?.pageSize ?? params.pageSize,
+        totals: data?.totals ?? null,
+        isLoading,
+        isError: error !== null,
+        errorMessage: error,
+    };
+}

--- a/site/assets/react/shared/components/Pagination.tsx
+++ b/site/assets/react/shared/components/Pagination.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+
+export interface PaginationProps {
+    currentPage: number;
+    totalPages: number;
+    onPageChange: (page: number) => void;
+}
+
+type PageItem = number | '…';
+
+function buildPages(currentPage: number, totalPages: number): PageItem[] {
+    const delta = 2;
+
+    if (totalPages <= 9) {
+        return Array.from({ length: totalPages }, (_, i) => i + 1);
+    }
+
+    const pages: PageItem[] = [1];
+
+    let startPage = Math.max(2, currentPage - delta);
+    const endPage = Math.min(totalPages - 1, currentPage + delta);
+
+    if (startPage > 2) {
+        pages.push('…');
+    } else {
+        startPage = 2;
+    }
+
+    for (let n = startPage; n <= endPage; n++) {
+        pages.push(n);
+    }
+
+    if (endPage < totalPages - 1) {
+        pages.push('…');
+    }
+
+    pages.push(totalPages);
+
+    return pages;
+}
+
+const Pagination: React.FC<PaginationProps> = ({ currentPage, totalPages, onPageChange }) => {
+    if (totalPages <= 1) {
+        return null;
+    }
+
+    const pages = buildPages(currentPage, totalPages);
+    const hasPrev = currentPage > 1;
+    const hasNext = currentPage < totalPages;
+
+    const handleClick = (page: number) => (e: React.MouseEvent<HTMLAnchorElement>): void => {
+        e.preventDefault();
+        if (page !== currentPage && page >= 1 && page <= totalPages) {
+            onPageChange(page);
+        }
+    };
+
+    return (
+        <nav aria-label="Пагинация">
+            <ul className="pagination justify-content-end mb-0 flex-wrap">
+                <li className={`page-item ${hasPrev ? '' : 'disabled'}`}>
+                    <a
+                        className="page-link"
+                        href="#"
+                        onClick={handleClick(hasPrev ? currentPage - 1 : currentPage)}
+                    >
+                        Назад
+                    </a>
+                </li>
+
+                {pages.map((p, idx) =>
+                    p === '…' ? (
+                        <li key={`e-${idx}`} className="page-item disabled">
+                            <span className="page-link">…</span>
+                        </li>
+                    ) : (
+                        <li
+                            key={p}
+                            className={`page-item ${p === currentPage ? 'active' : ''}`}
+                        >
+                            <a
+                                className="page-link"
+                                href="#"
+                                aria-current={p === currentPage ? 'page' : undefined}
+                                onClick={handleClick(p)}
+                            >
+                                {p}
+                            </a>
+                        </li>
+                    )
+                )}
+
+                <li className={`page-item ${hasNext ? '' : 'disabled'}`}>
+                    <a
+                        className="page-link"
+                        href="#"
+                        onClick={handleClick(hasNext ? currentPage + 1 : currentPage)}
+                    >
+                        Вперёд
+                    </a>
+                </li>
+            </ul>
+        </nav>
+    );
+};
+
+export default Pagination;

--- a/site/src/MarketplaceAds/Controller/AdEfficiencyIndexController.php
+++ b/site/src/MarketplaceAds/Controller/AdEfficiencyIndexController.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Controller;
+
+use App\Marketplace\Enum\MarketplaceType;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_COMPANY_USER')]
+final class AdEfficiencyIndexController extends AbstractController
+{
+    #[Route('/marketplace-ads/efficiency', name: 'marketplace_ads_efficiency_index', methods: ['GET'])]
+    public function __invoke(): Response
+    {
+        return $this->render('marketplace_ads/efficiency/index.html.twig', [
+            'activeTab' => 'efficiency',
+            'marketplaces' => array_map(
+                static fn (MarketplaceType $m): array => [
+                    'value' => $m->value,
+                    'label' => $m->getDisplayName(),
+                ],
+                MarketplaceType::cases(),
+            ),
+        ]);
+    }
+}

--- a/site/templates/marketplace_ads/_tabs.html.twig
+++ b/site/templates/marketplace_ads/_tabs.html.twig
@@ -1,0 +1,22 @@
+<div class="page-header d-print-none mt-0 pt-0">
+    <div class="container-xl">
+        <div class="row">
+            <div class="col">
+                <ul class="nav nav-tabs">
+                    <li class="nav-item">
+                        <a class="nav-link {{ activeTab == 'efficiency' ? 'active' : '' }}"
+                           href="{{ path('marketplace_ads_efficiency_index') }}">
+                            <span>Эффективность рекламы</span>
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link {{ activeTab == 'load' ? 'active' : '' }}"
+                           href="{{ path('marketplace_ads_index') }}">
+                            <span>Загрузка</span>
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>

--- a/site/templates/marketplace_ads/efficiency/index.html.twig
+++ b/site/templates/marketplace_ads/efficiency/index.html.twig
@@ -1,0 +1,31 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Эффективность рекламы{% endblock %}
+
+{% block body %}
+    {% include 'marketplace_ads/_tabs.html.twig' with { activeTab: 'efficiency' } %}
+
+    <div class="page-header d-print-none">
+        <div class="container-xl">
+            <div class="row g-2 align-items-center">
+                <div class="col">
+                    <h2 class="page-title">Эффективность рекламы</h2>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="page-body">
+        <div class="container-xl">
+            <div
+                id="react-ad-efficiency"
+                data-marketplaces="{{ marketplaces|json_encode|e('html_attr') }}"
+            ></div>
+        </div>
+    </div>
+{% endblock %}
+
+{% block javascripts %}
+    {{ parent() }}
+    {{ vite_entry_script_tags('ad_efficiency_page') }}
+{% endblock %}

--- a/site/templates/marketplace_ads/index.html.twig
+++ b/site/templates/marketplace_ads/index.html.twig
@@ -3,6 +3,8 @@
 {% block title %}Реклама — Маркетплейсы{% endblock %}
 
 {% block body %}
+    {% include 'marketplace_ads/_tabs.html.twig' with { activeTab: 'load' } %}
+
     <div class="page-header d-print-none">
         <div class="container-xl">
             <div class="row g-2 align-items-center">

--- a/site/vite.config.js
+++ b/site/vite.config.js
@@ -18,6 +18,7 @@ export default defineConfig({
                 marketplace_analytics_page: "./assets/react/marketplace-analytics-page.tsx",
                 reconciliation_page: "./assets/react/reconciliation-page.tsx",
                 unit_extended_page: "./assets/react/unit-extended-page.tsx",
+                ad_efficiency_page: "./assets/react/ad-efficiency-page.tsx",
             },
         }
     },


### PR DESCRIPTION
## Summary

Фронтенд «Эффективность рекламы» (часть 2 из 2) поверх смерженного backend API `GET /api/marketplace-ads/efficiency`.

- Таб-оболочка на `/marketplace-ads`: partial `templates/marketplace_ads/_tabs.html.twig` с двумя табами (Загрузка, Эффективность рекламы). Существующий `index.html.twig` не ломается — подключает тот же partial с `activeTab: 'load'`.
- Новый роут `GET /marketplace-ads/efficiency` → `AdEfficiencyIndexController` + Twig-шаблон, который монтирует React-виджет в `#react-ad-efficiency` и прокидывает список маркетплейсов через `data-marketplaces`.
- Новый Vite entry `ad_efficiency_page` + React-entrypoint `assets/react/ad-efficiency-page.tsx`.
- Модуль `assets/react/marketplace-ads/ad-efficiency/`:
  - `adEfficiency.types.ts` — типы для API-ответа (decimal-поля как строки).
  - `useAdEfficiency.ts` — хук поверх `useAbortableQuery` с гардом на пустые даты и полным набором query-параметров.
  - `AdEfficiencyPage.tsx` — фильтры, загрузка, таблица, пагинация, селектор размера страницы; sync с URL через `history.replaceState`; сброс `page=1` при смене любого фильтра/сортировки/`pageSize`; дефолт периода — «последние 30 дней от вчерашнего дня».
  - `AdEfficiencyTable.tsx` — Tabler-разметка с SortableHeader (toggle asc/desc на активной колонке, `desc` при смене колонки), пустое состояние и `tfoot` с итогами.
  - `formatters.ts` — `formatRub` (ru-RU, 2 знака) и `formatDrr` (null / `0` → `—`).
- `assets/react/shared/components/Pagination.tsx` — универсальный React-компонент, воспроизводящий 1:1 алгоритм и классы `_pagerfanta.html.twig` (ellipsis, активная страница, «Назад» / «Вперёд», `return null` при `totalPages <= 1`).

Границы соблюдены: без react-query/axios/mui/antd; backend не менялся; `/marketplace-ads` не сломан; локализация — русский.

## Test plan
- [ ] `npm run build` проходит локально (в CI-контейнере воспроизводится известная проблема rollup optional deps — не связана с кодом).
- [ ] `/marketplace-ads` — таб «Загрузка» активен, контент и поведение без изменений.
- [ ] `/marketplace-ads/efficiency` — таб «Эффективность рекламы» активен, грузит данные за дефолтный период (30 дней до вчера).
- [ ] Переключение табов работает в обе стороны.
- [ ] Фильтры: маркетплейс (включая «Все»), `С`, `По` — каждый изменяет запрос и сбрасывает `page=1`.
- [ ] Сортировка: клик по колонке — сортирует `desc`, повторный клик — toggle `asc/desc`; стрелка отображается; сортировка сбрасывает `page=1`.
- [ ] Пагинация: «Назад»/«Вперёд» disabled на границах, ellipsis появляется при `totalPages > 9`, клик меняет страницу.
- [ ] Page-size select (10/25/50/100) меняет размер и сбрасывает `page=1`.
- [ ] URL отражает состояние (`marketplace`, `periodFrom`, `periodTo`, `page`, `pageSize`, `sortBy`, `sortDir`); перезагрузка страницы восстанавливает параметры.
- [ ] Totals в `tfoot` соответствуют значениям из API; `—` для пустого ДРР.
- [ ] Форматирование: «1 234,56» для сумм, «12,34%» для ДРР.

https://claude.ai/code/session_01XzG9nrYmbisg8CVJa9zxz8