### PR TITLE
feat(api-doc): setup nelmio/api-doc-bundle infrastructure

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -789,6 +789,30 @@ Rate limiting: `reports_api` — 60 req/мин · `registration` — 5 req/10 м
 
 ---
 
+## API Documentation
+
+**URL:** `https://app.vashfindir.ru/api/doc` (требует авторизации `ROLE_USER`)
+**Spec JSON:** `https://app.vashfindir.ru/api/doc.json`
+
+**Инструмент:** `nelmio/api-doc-bundle` (OpenAPI 3.x)
+
+### Coverage
+
+| Статус | Эндпоинтов | Примечание |
+|---|---|---|
+| Документировано | 2 | Health (live, ready) |
+| Ожидает документации | ~50 | См. план по модулям |
+| Исключено (debug/admin) | ~22 | Не публикуются в OpenAPI |
+
+### Правила документирования
+
+- Атрибуты `#[OA\*]` ставятся над методом контроллера, логика метода не меняется
+- Debug- и admin-эндпоинты в OpenAPI не публикуются (см. `path_patterns` в `config/packages/nelmio_api_doc.yaml`)
+- Формат ошибок: целевой — `Problem` (RFC 7807), существующие legacy-форматы документируются как есть
+- Request/Response DTO описываются `#[OA\Schema]` рядом с классом DTO
+
+---
+
 ## Маршруты — конвенция
 
 ```

--- a/site/composer.json
+++ b/site/composer.json
@@ -13,6 +13,7 @@
         "doctrine/doctrine-bundle": "^2.18.2",
         "doctrine/doctrine-migrations-bundle": "^3.7",
         "doctrine/orm": "^3.6.1",
+        "nelmio/api-doc-bundle": "^5.10",
         "openspout/openspout": "4.28.5",
         "pagerfanta/doctrine-dbal-adapter": "^4.8",
         "pagerfanta/doctrine-orm-adapter": "^4.7.2",

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "277e52bd181824f81e0fa4bf6554f150",
+    "content-hash": "2fac032af8536413eed1bcfb8f15e706",
     "packages": [
         {
             "name": "babdev/pagerfanta-bundle",
@@ -1961,6 +1961,187 @@
             "time": "2026-01-02T08:56:05+00:00"
         },
         {
+            "name": "nelmio/api-doc-bundle",
+            "version": "v5.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nelmio/NelmioApiDocBundle.git",
+                "reference": "212d490a85589ddce0f2dc683bef89bc62485340"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nelmio/NelmioApiDocBundle/zipball/212d490a85589ddce0f2dc683bef89bc62485340",
+                "reference": "212d490a85589ddce0f2dc683bef89bc62485340",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "phpdocumentor/reflection-docblock": "^5.0 || ^6.0",
+                "phpdocumentor/type-resolver": "^1.8.2 || ^2.0",
+                "psr/cache": "^1.0 || ^2.0 || ^3.0",
+                "psr/container": "^1.0 || ^2.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "symfony/config": "^6.4 || ^7.2 || ^8.0",
+                "symfony/console": "^6.4 || ^7.2 || ^8.0",
+                "symfony/dependency-injection": "^6.4 || ^7.2 || ^8.0",
+                "symfony/deprecation-contracts": "^2.1 || ^3",
+                "symfony/framework-bundle": "^6.4 || ^7.2 || ^8.0",
+                "symfony/http-foundation": "^6.4 || ^7.2 || ^8.0",
+                "symfony/http-kernel": "^6.4 || ^7.2 || ^8.0",
+                "symfony/options-resolver": "^6.4 || ^7.2 || ^8.0",
+                "symfony/property-info": "^6.4 || ^7.2 || ^8.0",
+                "symfony/routing": "^6.4 || ^7.2 || ^8.0",
+                "symfony/type-info": "^7.2 || ^8.0",
+                "zircote/swagger-php": "^4.11.1 || ^5.0 || ^6.0"
+            },
+            "conflict": {
+                "symfony/property-info": "6.4.32 || 7.3.10 || 7.4.4 || 8.0.4",
+                "zircote/swagger-php": "4.8.7 || 5.5.0"
+            },
+            "require-dev": {
+                "api-platform/core": "^3.2 || ^4.0",
+                "doctrine/inflector": "^2.0",
+                "friendsofphp/php-cs-fixer": "^3.52",
+                "friendsofsymfony/rest-bundle": "^3.2.0",
+                "jms/serializer": "^3.32",
+                "jms/serializer-bundle": "^5.5",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpstan/phpstan-symfony": "^2.0",
+                "phpunit/phpunit": "^10.5",
+                "symfony/asset": "^6.4 || ^7.2 || ^8.0",
+                "symfony/browser-kit": "^6.4 || ^7.2 || ^8.0",
+                "symfony/cache": "^6.4 || ^7.2 || ^8.0",
+                "symfony/dom-crawler": "^6.4 || ^7.2 || ^8.0",
+                "symfony/expression-language": "^6.4 || ^7.2 || ^8.0",
+                "symfony/finder": "^6.4 || ^7.2 || ^8.0",
+                "symfony/form": "^6.4 || ^7.2 || ^8.0",
+                "symfony/phpunit-bridge": "^6.4 || ^7.2 || ^8.0",
+                "symfony/security-csrf": "^6.4 || ^7.2 || ^8.0",
+                "symfony/security-http": "^6.4 || ^7.2 || ^8.0",
+                "symfony/serializer": "^6.4 || ^7.2 || ^8.0",
+                "symfony/translation": "^6.4 || ^7.2 || ^8.0",
+                "symfony/twig-bundle": "^6.4 || ^7.2 || ^8.0",
+                "symfony/uid": "^6.4 || ^7.2 || ^8.0",
+                "symfony/validator": "^6.4 || ^7.2 || ^8.0",
+                "willdurand/hateoas-bundle": "^2.7 || ^3.0",
+                "willdurand/negotiation": "^3.0"
+            },
+            "suggest": {
+                "api-platform/core": "For using an API oriented framework.",
+                "friendsofsymfony/rest-bundle": "For using the parameters annotations.",
+                "jms/serializer-bundle": "For describing your models.",
+                "symfony/asset": "For using the Swagger UI.",
+                "symfony/cache": "For using a PSR-6 compatible cache implementation with the API doc generator.",
+                "symfony/form": "For describing your form type models.",
+                "symfony/monolog-bundle": "For using a PSR-3 compatible logger implementation with the API PHP describer.",
+                "symfony/security-csrf": "For using csrf protection tokens in forms.",
+                "symfony/serializer": "For describing your models.",
+                "symfony/twig-bundle": "For using the Swagger UI.",
+                "symfony/validator": "For describing the validation constraints in your models.",
+                "willdurand/hateoas-bundle": "For extracting HATEOAS metadata."
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-4.x": "4.x-dev",
+                    "dev-5.x": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Nelmio\\ApiDocBundle\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://github.com/nelmio/NelmioApiDocBundle/contributors"
+                }
+            ],
+            "description": "Generates documentation for your REST API from attributes",
+            "keywords": [
+                "api",
+                "doc",
+                "documentation",
+                "rest"
+            ],
+            "support": {
+                "issues": "https://github.com/nelmio/NelmioApiDocBundle/issues",
+                "source": "https://github.com/nelmio/NelmioApiDocBundle/tree/v5.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/DjordyKoert",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-10T14:26:01+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+            },
+            "time": "2025-12-06T11:56:16+00:00"
+        },
+        {
             "name": "openspout/openspout",
             "version": "v4.28.5",
             "source": {
@@ -3400,6 +3581,68 @@
                 "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
             },
             "time": "2021-10-29T13:26:27+00:00"
+        },
+        {
+            "name": "radebatz/type-info-extras",
+            "version": "1.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DerManoMann/type-info-extras.git",
+                "reference": "95a524a74a61648b44e355cb33d38db4b17ef5ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DerManoMann/type-info-extras/zipball/95a524a74a61648b44e355cb33d38db4b17ef5ce",
+                "reference": "95a524a74a61648b44e355cb33d38db4b17ef5ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "phpstan/phpdoc-parser": "^2.0",
+                "symfony/type-info": "^7.3.8 || ^7.4.1 || ^8.0 || ^8.1-@dev"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.70",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Radebatz\\TypeInfoExtras\\": "src"
+                },
+                "exclude-from-classmap": [
+                    "/tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Martin Rademacher",
+                    "email": "mano@radebatz.org"
+                }
+            ],
+            "description": "Extras for symfony/type-info",
+            "homepage": "http://radebatz.net/mano/",
+            "keywords": [
+                "component",
+                "symfony",
+                "type-info",
+                "types"
+            ],
+            "support": {
+                "issues": "https://github.com/DerManoMann/type-info-extras/issues",
+                "source": "https://github.com/DerManoMann/type-info-extras/tree/1.0.7"
+            },
+            "time": "2026-03-06T22:40:29+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -9993,6 +10236,96 @@
                 "source": "https://github.com/webmozarts/assert/tree/2.1.2"
             },
             "time": "2026-01-13T14:02:24+00:00"
+        },
+        {
+            "name": "zircote/swagger-php",
+            "version": "6.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zircote/swagger-php.git",
+                "reference": "9447c1f45b5ae93185caea9a0c8e298399188a25"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/9447c1f45b5ae93185caea9a0c8e298399188a25",
+                "reference": "9447c1f45b5ae93185caea9a0c8e298399188a25",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "nikic/php-parser": "^4.19 || ^5.0",
+                "php": ">=8.2",
+                "phpstan/phpdoc-parser": "^2.0",
+                "psr/log": "^1.1 || ^2.0 || ^3.0",
+                "radebatz/type-info-extras": "^1.0.2",
+                "symfony/deprecation-contracts": "^2 || ^3",
+                "symfony/finder": "^5.0 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/yaml": "^5.4 || ^6.0 || ^7.0 || ^8.0"
+            },
+            "conflict": {
+                "symfony/process": ">=6, <6.4.14"
+            },
+            "require-dev": {
+                "composer/package-versions-deprecated": "^1.11",
+                "doctrine/annotations": "^2.0",
+                "friendsofphp/php-cs-fixer": "^3.62.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^11.5",
+                "rector/rector": "^2.3.1"
+            },
+            "bin": [
+                "bin/openapi"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "OpenApi\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Allen",
+                    "email": "zircote@gmail.com"
+                },
+                {
+                    "name": "Bob Fanger",
+                    "email": "bfanger@gmail.com",
+                    "homepage": "https://bfanger.nl"
+                },
+                {
+                    "name": "Martin Rademacher",
+                    "email": "mano@radebatz.net",
+                    "homepage": "https://radebatz.net"
+                }
+            ],
+            "description": "Generate interactive documentation for your RESTful API using PHP attributes (preferred) or PHPDoc annotations",
+            "homepage": "https://github.com/zircote/swagger-php",
+            "keywords": [
+                "api",
+                "json",
+                "rest",
+                "service discovery"
+            ],
+            "support": {
+                "issues": "https://github.com/zircote/swagger-php/issues",
+                "source": "https://github.com/zircote/swagger-php/tree/6.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/zircote",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-28T06:42:58+00:00"
         }
     ],
     "packages-dev": [
@@ -10741,64 +11074,6 @@
                 }
             ],
             "time": "2025-08-01T08:46:24+00:00"
-        },
-        {
-            "name": "nikic/php-parser",
-            "version": "v5.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
-                "shasum": ""
-            },
-            "require": {
-                "ext-ctype": "*",
-                "ext-json": "*",
-                "ext-tokenizer": "*",
-                "php": ">=7.4"
-            },
-            "require-dev": {
-                "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^9.0"
-            },
-            "bin": [
-                "bin/php-parse"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PhpParser\\": "lib/PhpParser"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Nikita Popov"
-                }
-            ],
-            "description": "A PHP parser written in PHP",
-            "keywords": [
-                "parser",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
-            },
-            "time": "2025-12-06T11:56:16+00:00"
         },
         {
             "name": "phar-io/manifest",

--- a/site/config/bundles.php
+++ b/site/config/bundles.php
@@ -17,4 +17,5 @@ return [
     BabDev\PagerfantaBundle\BabDevPagerfantaBundle::class => ['all' => true],
     Sentry\SentryBundle\SentryBundle::class => ['all' => true],
     Pentatrion\ViteBundle\PentatrionViteBundle::class => ['all' => true],
+    Nelmio\ApiDocBundle\NelmioApiDocBundle::class => ['all' => true],
 ];

--- a/site/config/packages/nelmio_api_doc.yaml
+++ b/site/config/packages/nelmio_api_doc.yaml
@@ -1,0 +1,64 @@
+nelmio_api_doc:
+    documentation:
+        info:
+            title: 'VashFinDir API'
+            description: |
+                Внутренний API приложения VashFinDir.
+
+                **Аутентификация:** session cookie `PHPSESSID`, устанавливается после логина через `/login`.
+
+                **Контекст компании:** определяется сервером через `ActiveCompanyService` на основе сессии.
+                Параметр `companyId` в запросах НЕ передаётся — он определяется автоматически.
+            version: '1.0.0'
+        servers:
+            - url: 'https://app.vashfindir.ru'
+              description: 'Production'
+            - url: 'http://localhost'
+              description: 'Local development'
+        components:
+            securitySchemes:
+                SessionCookie:
+                    type: apiKey
+                    in: cookie
+                    name: PHPSESSID
+                    description: 'Session cookie, устанавливается после логина через /login'
+            schemas:
+                Problem:
+                    type: object
+                    description: |
+                        RFC 7807 Problem Details.
+                        Целевой формат ошибок для нового API.
+                        Существующие эндпоинты могут возвращать legacy-форматы — см. описание конкретного ответа.
+                    required: [title, status]
+                    properties:
+                        type:
+                            type: string
+                            format: uri
+                            example: 'about:blank'
+                            description: 'URI идентификатор типа ошибки'
+                        title:
+                            type: string
+                            example: 'Validation Failed'
+                            description: 'Краткое человекочитаемое описание ошибки'
+                        status:
+                            type: integer
+                            example: 422
+                            description: 'HTTP status code'
+                        detail:
+                            type: string
+                            example: 'Поле title обязательно'
+                            description: 'Детальное описание конкретного случая'
+                        instance:
+                            type: string
+                            example: '/api/marketplaceanalytics'
+                            description: 'URI запроса, в котором произошла ошибка'
+        security:
+            - SessionCookie: []
+        tags:
+            - name: Health
+              description: 'Проверки жизнеспособности сервиса (liveness/readiness)'
+    areas:
+        default:
+            path_patterns:
+                - ^/api(?!/doc$|/doc\.json$)
+            disable_default_routes: true

--- a/site/config/packages/security.yaml
+++ b/site/config/packages/security.yaml
@@ -70,6 +70,8 @@ security:
         - { path: ^/invite, roles: PUBLIC_ACCESS }
         - { path: ^/admin/login$, roles: PUBLIC_ACCESS }
         - { path: ^/telegram/webhook$, roles: PUBLIC_ACCESS }
+        - { path: ^/api/health, roles: PUBLIC_ACCESS }
+        - { path: ^/api/doc, roles: ROLE_USER }
         - { path: ^/admin, roles: ROLE_ADMIN }
         - { path: ^/, roles: ROLE_USER }
 

--- a/site/config/routes/nelmio_api_doc.yaml
+++ b/site/config/routes/nelmio_api_doc.yaml
@@ -1,0 +1,9 @@
+app.swagger_ui:
+    path: /api/doc
+    methods: GET
+    defaults: { _controller: nelmio_api_doc.controller.swagger_ui }
+
+app.swagger_json:
+    path: /api/doc.json
+    methods: GET
+    defaults: { _controller: nelmio_api_doc.controller.swagger }

--- a/site/src/Analytics/Controller/Api/V1/HealthController.php
+++ b/site/src/Analytics/Controller/Api/V1/HealthController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Analytics\Controller\Api\V1;
 
 use Doctrine\DBAL\Connection;
+use OpenApi\Attributes as OA;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -12,6 +13,7 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 
+#[OA\Tag(name: 'Health')]
 final class HealthController extends AbstractController
 {
     public function __construct(
@@ -21,12 +23,70 @@ final class HealthController extends AbstractController
     ) {
     }
 
+    #[OA\Get(
+        summary: 'Liveness probe',
+        description: 'Всегда возвращает 200 OK пока процесс жив. Не проверяет внешние зависимости.',
+        security: [],
+        tags: ['Health']
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Сервис жив',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'status', type: 'string', example: 'ok'),
+            ],
+            type: 'object'
+        )
+    )]
     #[Route('/api/health/live', name: 'api_health_live', methods: ['GET'])]
     public function live(): JsonResponse
     {
         return $this->json(['status' => 'ok']);
     }
 
+    #[OA\Get(
+        summary: 'Readiness probe',
+        description: 'Проверяет доступность Postgres и Redis. Возвращает 503 при деградации зависимостей.',
+        security: [],
+        tags: ['Health']
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Все зависимости доступны',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'status', type: 'string', example: 'ok'),
+                new OA\Property(
+                    property: 'checks',
+                    type: 'object',
+                    properties: [
+                        new OA\Property(property: 'postgres', type: 'boolean', example: true),
+                        new OA\Property(property: 'redis_cache', type: 'boolean', example: true),
+                    ]
+                ),
+            ],
+            type: 'object'
+        )
+    )]
+    #[OA\Response(
+        response: 503,
+        description: 'Одна или более зависимостей недоступны',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'status', type: 'string', example: 'fail'),
+                new OA\Property(
+                    property: 'checks',
+                    type: 'object',
+                    properties: [
+                        new OA\Property(property: 'postgres', type: 'boolean', example: false),
+                        new OA\Property(property: 'redis_cache', type: 'boolean', example: true),
+                    ]
+                ),
+            ],
+            type: 'object'
+        )
+    )]
     #[Route('/api/health/ready', name: 'api_health_ready', methods: ['GET'])]
     public function ready(): JsonResponse
     {


### PR DESCRIPTION
## Summary

Поднимаем инфраструктуру OpenAPI — рабочий Swagger UI на `/api/doc` с двумя задокументированными health-эндпоинтами как proof-of-concept. Первый из серии PR; остальные модули будем документировать отдельными PR'ами.

**Scope: только инфраструктура, логика приложения не меняется.**

## Что сделано

- **Bundle:** установлен `nelmio/api-doc-bundle ^5.10` (+ транзитивные `zircote/swagger-php`, `radebatz/type-info-extras`). Зарегистрирован в `site/config/bundles.php`.
- **Конфиг** `site/config/packages/nelmio_api_doc.yaml`:
  - Info (title, description, version), servers (prod + local)
  - `SessionCookie` security scheme (apiKey в cookie `PHPSESSID`)
  - Схема `Problem` (RFC 7807) как целевой формат ошибок
  - Тег `Health`
  - `path_patterns: ^/api(?!/doc$|/doc\.json$)` + `disable_default_routes: true` — в OpenAPI попадают только эндпоинты с явными атрибутами
- **Маршруты** `site/config/routes/nelmio_api_doc.yaml`:
  - `GET /api/doc` → Swagger UI
  - `GET /api/doc.json` → OpenAPI JSON spec
- **Security** (`config/packages/security.yaml` → `access_control`):
  - `^/api/health` → `PUBLIC_ACCESS` (Docker healthcheck / Traefik)
  - `^/api/doc` → `ROLE_USER` (не светим структуру API наружу)
- **HealthController** (`src/Analytics/Controller/Api/V1/HealthController.php`):
  - `#[OA\Tag(name: 'Health')]` на классе
  - `#[OA\Get]` + `#[OA\Response]` над `live()` (200) и `ready()` (200 / 503)
  - `security: []` — health в Swagger UI не требует cookie
  - **Логика методов не изменена ни одной строкой**
- **ARCHITECTURE.md:** добавлена секция «API Documentation» с coverage-таблицей и правилами документирования.

## Что НЕ делаем (вынесено в следующие PR)

- Не документируем остальные контроллеры (PR-4…PR-9 по модулям)
- Не вводим `ExceptionSubscriber` / единый формат ошибок
- Не настраиваем субдомен `api-docs.vashfindir.ru`
- Не ставим `openapi-typescript` (PR-3)
- Не добавляем Spectral в CI (PR-10)
- Не меняем формат ответа health-эндпоинтов

## Test plan

- [ ] `docker compose exec site-php-cli php bin/console cache:clear` проходит без ошибок
- [ ] `docker compose exec site-php-cli php bin/console debug:router | grep api/doc` показывает оба маршрута (`app.swagger_ui`, `app.swagger_json`)
- [ ] `docker compose exec site-nginx curl -sf http://localhost/api/doc.json` отдаёт валидный OpenAPI 3.x JSON с путями `/api/health/live`, `/api/health/ready`, схемой `Problem`, securityScheme `SessionCookie`
- [ ] `docker compose exec site-nginx curl -I http://localhost/api/doc` без cookie возвращает редирект на `/login` (security работает)
- [ ] `docker compose exec site-nginx curl -sf http://localhost/api/health/live` возвращает `{"status":"ok"}` (не сломан)
- [ ] `docker compose exec site-nginx curl -sf http://localhost/api/health/ready` возвращает 200 со списком checks (не сломан)
- [ ] Под авторизованной сессией `/api/doc` открывается и показывает Swagger UI с двумя эндпоинтами Health
- [ ] `php bin/phpunit` — существующие тесты проходят

## Локальная проверка (без docker)

- `php bin/console cache:clear` — OK
- `php bin/console debug:router` — оба маршрута зарегистрированы
- `php bin/console nelmio:apidoc:dump --area=default` — генерит валидный OpenAPI 3.0.0 JSON, `paths` = `["/api/health/live", "/api/health/ready"]`, `components.schemas.Problem` и `components.securitySchemes.SessionCookie` присутствуют

https://claude.ai/code/session_018t6vL5j43Li7CjST43xM7i