### PR TITLE
feat(api-doc): document MarketplaceAnalytics reference endpoints

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -800,9 +800,19 @@ Rate limiting: `reports_api` — 60 req/мин · `registration` — 5 req/10 м
 
 | Статус | Эндпоинтов | Примечание |
 |---|---|---|
-| Документировано | 2 | Health (live, ready) |
-| Ожидает документации | ~50 | См. план по модулям |
+| Документировано | 5 | Health (live, ready) + MarketplaceAnalytics (create, snapshots list, snapshot show) |
+| Ожидает документации | ~47 | См. план по модулям |
 | Исключено (debug/admin) | ~22 | Не публикуются в OpenAPI |
+
+### Задокументированные эндпоинты
+
+| Модуль | Эндпоинт | PR |
+|---|---|---|
+| Analytics | GET /api/health/live | PR-1 |
+| Analytics | GET /api/health/ready | PR-1 |
+| MarketplaceAnalytics | POST /api/marketplaceanalytics | PR-2 |
+| MarketplaceAnalytics | GET /api/marketplace-analytics/snapshots | PR-2 |
+| MarketplaceAnalytics | GET /api/marketplace-analytics/snapshots/{id} | PR-2 |
 
 ### Правила документирования
 
@@ -810,6 +820,7 @@ Rate limiting: `reports_api` — 60 req/мин · `registration` — 5 req/10 м
 - Debug- и admin-эндпоинты в OpenAPI не публикуются (см. `path_patterns` в `config/packages/nelmio_api_doc.yaml`)
 - Формат ошибок: целевой — `Problem` (RFC 7807), существующие legacy-форматы документируются как есть
 - Request/Response DTO описываются `#[OA\Schema]` рядом с классом DTO
+- Паттерн документирования — см. `PATTERNS.md` раздел 19
 
 ---
 

--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -26,6 +26,7 @@
 - [16. Тесты: Unit и Integration](#16-тесты-unit-и-integration)
 - [17. Entity Builder](#17-entity-builder)
 - [18. Decision Matrix](#18-decision-matrix)
+- [19. API Documentation (OpenAPI / Nelmio)](#19-api-documentation-openapi--nelmio)
 
 ---
 
@@ -952,3 +953,110 @@ $product = ProductBuilder::aProduct()->withCompanyId($company->getId())->build()
 | Побочный эффект (email, пуш) | — | ✅ |
 | Нужен retry при падении | — | ✅ |
 | Цепочка тяжёлых шагов | — | ✅ каждый шаг = Message |
+
+---
+
+## 19. API Documentation (OpenAPI / Nelmio)
+
+### Инструмент
+
+`nelmio/api-doc-bundle` + `zircote/swagger-php`. UI на `/api/doc`, спека на `/api/doc.json`.
+
+### Область действия
+
+- Документируем контроллеры под `src/{Module}/Controller/Api/`
+- НЕ документируем: `/api/public/` (публичные отчёты — отдельный security scheme), debug/admin-эндпоинты
+- НЕ документируем внутренние Facade-методы — они не HTTP
+
+### Правило: не менять логику
+
+Атрибуты `#[OA\*]` вешаются над классом контроллера и над методом `__invoke` / action-методом. Код внутри метода не меняется. DTO не переименовываются и не реструктурируются.
+
+### Документирование Response-DTO
+
+**Важно:** если Response-DTO имеет ручной `toArray()` со snake_case или другими переименованиями полей — `#[Model(type: ...)]` даст неправильную схему. Используем `#[OA\Schema]` вручную над классом.
+
+```php
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'SnapshotResponse',
+    description: 'Снэпшот аналитики',
+    required: ['id', 'company_id'],
+    properties: [
+        new OA\Property(property: 'id', type: 'string', format: 'uuid'),
+        new OA\Property(property: 'company_id', type: 'string', format: 'uuid'),
+        new OA\Property(property: 'created_at', type: 'string', format: 'date-time'),
+        // перечисляем все поля в том виде, как они реально возвращаются
+    ]
+)]
+final readonly class SnapshotResponse { /* не трогаем */ }
+```
+
+Если поля в PHP и в JSON совпадают один в один (редкий случай) — можно использовать `#[Model(type: Dto::class)]`.
+
+### Документирование Request-DTO
+
+Для DTO, которые биндятся через `#[MapRequestPayload]`, описываем схему атрибутом над классом. Валидация (`#[Assert\*]`) Nelmio подхватывает автоматически в части required/min/max/pattern.
+
+```php
+#[OA\Schema(
+    schema: 'CreateMarketplaceAnalyticsRequest',
+    required: ['title'],
+    properties: [
+        new OA\Property(property: 'title', type: 'string', minLength: 1),
+    ]
+)]
+final class CreateMarketplaceAnalyticsRequest { /* не трогаем */ }
+```
+
+### Документирование контроллера
+
+```php
+use OpenApi\Attributes as OA;
+
+#[OA\Tag(name: 'Marketplace Analytics')]
+final class SnapshotShowController extends AbstractController
+{
+    #[OA\Get(
+        summary: 'Снэпшот по ID',
+        description: 'Проверяет принадлежность активной компании.',
+        tags: ['Marketplace Analytics']
+    )]
+    #[OA\Parameter(
+        name: 'id',
+        in: 'path',
+        required: true,
+        schema: new OA\Schema(type: 'string', format: 'uuid')
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Найдено',
+        content: new OA\JsonContent(ref: '#/components/schemas/SnapshotResponse')
+    )]
+    #[OA\Response(response: 404, description: 'Не найдено')]
+    #[Route('/api/marketplace-analytics/snapshots/{id}', methods: ['GET'])]
+    public function __invoke(string $id): JsonResponse
+    {
+        // логика не меняется
+    }
+}
+```
+
+### Чеклист при добавлении нового API-эндпоинта
+
+1. У контроллера есть `#[OA\Tag]` (на классе) и `#[OA\Get|Post|...]` (на методе) с `summary` на русском
+2. Если принимает body — есть `#[OA\RequestBody]` со ссылкой на схему
+3. Если есть path/query параметры — каждый описан `#[OA\Parameter]` (кроме `companyId` — он из сессии, не документируется)
+4. Перечислены ВСЕ возможные HTTP-коды ответа, включая 401, 404, 422
+5. Response-DTO имеет `#[OA\Schema]` с перечислением полей в том виде, как они уходят в JSON (учитывая snake_case из `toArray()`)
+6. Новый тег зарегистрирован в `config/packages/nelmio_api_doc.yaml` в секции `tags`
+7. Счётчик coverage в `ARCHITECTURE.md` обновлён
+
+### Анти-паттерны
+
+- ❌ Использовать `#[Model(type: SomeDto::class)]`, если у DTO есть `toArray()` с переименованиями
+- ❌ Документировать `companyId` как query-параметр
+- ❌ Документировать debug/admin-эндпоинты в публичной area
+- ❌ Менять логику контроллера «заодно с документацией»
+- ❌ Выдумывать HTTP-коды, которых контроллер не возвращает

--- a/site/config/packages/nelmio_api_doc.yaml
+++ b/site/config/packages/nelmio_api_doc.yaml
@@ -57,6 +57,8 @@ nelmio_api_doc:
         tags:
             - name: Health
               description: 'Проверки жизнеспособности сервиса (liveness/readiness)'
+            - name: Marketplace Analytics
+              description: 'Аналитика по маркетплейсам: снэпшоты, cost mappings, unit economics'
     areas:
         default:
             path_patterns:

--- a/site/src/MarketplaceAnalytics/Api/Request/CreateMarketplaceAnalyticsRequest.php
+++ b/site/src/MarketplaceAnalytics/Api/Request/CreateMarketplaceAnalyticsRequest.php
@@ -4,8 +4,22 @@ declare(strict_types=1);
 
 namespace App\MarketplaceAnalytics\Api\Request;
 
+use OpenApi\Attributes as OA;
 use Symfony\Component\Validator\Constraints as Assert;
 
+#[OA\Schema(
+    schema: 'CreateMarketplaceAnalyticsRequest',
+    description: 'Тело запроса на создание маркетплейс-аналитики',
+    required: ['title'],
+    properties: [
+        new OA\Property(
+            property: 'title',
+            type: 'string',
+            minLength: 1,
+            example: 'Аналитика за Q1 2026',
+        ),
+    ]
+)]
 final class CreateMarketplaceAnalyticsRequest
 {
     public function __construct(

--- a/site/src/MarketplaceAnalytics/Api/Response/SnapshotResponse.php
+++ b/site/src/MarketplaceAnalytics/Api/Response/SnapshotResponse.php
@@ -47,7 +47,7 @@ use OpenApi\Attributes as OA;
         new OA\Property(property: 'total_cost_price', type: 'string', nullable: true, description: 'Суммарная себестоимость за день (десятичное)', example: '6000.00'),
         new OA\Property(property: 'cost_breakdown', type: 'object', description: 'Разбивка затрат по категориям', additionalProperties: true),
         new OA\Property(property: 'advertising_details', type: 'object', description: 'Детализация рекламных расходов', additionalProperties: true),
-        new OA\Property(property: 'data_quality', type: 'object', description: 'Индикаторы качества данных снэпшота', additionalProperties: true),
+        new OA\Property(property: 'data_quality', type: 'array', description: 'Список флагов качества данных снэпшота (значения enum DataQualityFlag)', items: new OA\Items(type: 'string')),
         new OA\Property(property: 'calculated_at', type: 'string', format: 'date-time', example: '2026-04-21T03:15:00+00:00'),
     ]
 )]

--- a/site/src/MarketplaceAnalytics/Api/Response/SnapshotResponse.php
+++ b/site/src/MarketplaceAnalytics/Api/Response/SnapshotResponse.php
@@ -24,6 +24,8 @@ use OpenApi\Attributes as OA;
         'orders_quantity',
         'delivered_quantity',
         'avg_sale_price',
+        'cost_price',
+        'total_cost_price',
         'cost_breakdown',
         'advertising_details',
         'data_quality',

--- a/site/src/MarketplaceAnalytics/Api/Response/SnapshotResponse.php
+++ b/site/src/MarketplaceAnalytics/Api/Response/SnapshotResponse.php
@@ -5,7 +5,52 @@ declare(strict_types=1);
 namespace App\MarketplaceAnalytics\Api\Response;
 
 use App\MarketplaceAnalytics\Entity\ListingDailySnapshot;
+use OpenApi\Attributes as OA;
 
+#[OA\Schema(
+    schema: 'SnapshotResponse',
+    description: 'Снэпшот маркетплейс-аналитики за один день по одному листингу',
+    required: [
+        'id',
+        'listing_id',
+        'listing_name',
+        'listing_sku',
+        'marketplace',
+        'snapshot_date',
+        'revenue',
+        'refunds',
+        'sales_quantity',
+        'returns_quantity',
+        'orders_quantity',
+        'delivered_quantity',
+        'avg_sale_price',
+        'cost_breakdown',
+        'advertising_details',
+        'data_quality',
+        'calculated_at',
+    ],
+    properties: [
+        new OA\Property(property: 'id', type: 'string', format: 'uuid'),
+        new OA\Property(property: 'listing_id', type: 'string', format: 'uuid'),
+        new OA\Property(property: 'listing_name', type: 'string', example: 'Кружка керамическая 350мл'),
+        new OA\Property(property: 'listing_sku', type: 'string', example: 'SKU-12345'),
+        new OA\Property(property: 'marketplace', type: 'string', example: 'OZON'),
+        new OA\Property(property: 'snapshot_date', type: 'string', format: 'date', example: '2026-04-21'),
+        new OA\Property(property: 'revenue', type: 'string', description: 'Десятичное значение выручки', example: '12345.67'),
+        new OA\Property(property: 'refunds', type: 'string', description: 'Десятичное значение возвратов', example: '123.45'),
+        new OA\Property(property: 'sales_quantity', type: 'integer', example: 42),
+        new OA\Property(property: 'returns_quantity', type: 'integer', example: 3),
+        new OA\Property(property: 'orders_quantity', type: 'integer', example: 45),
+        new OA\Property(property: 'delivered_quantity', type: 'integer', example: 40),
+        new OA\Property(property: 'avg_sale_price', type: 'string', description: 'Средняя цена продажи (десятичное)', example: '299.99'),
+        new OA\Property(property: 'cost_price', type: 'string', nullable: true, description: 'Себестоимость единицы (десятичное)', example: '150.00'),
+        new OA\Property(property: 'total_cost_price', type: 'string', nullable: true, description: 'Суммарная себестоимость за день (десятичное)', example: '6000.00'),
+        new OA\Property(property: 'cost_breakdown', type: 'object', description: 'Разбивка затрат по категориям', additionalProperties: true),
+        new OA\Property(property: 'advertising_details', type: 'object', description: 'Детализация рекламных расходов', additionalProperties: true),
+        new OA\Property(property: 'data_quality', type: 'object', description: 'Индикаторы качества данных снэпшота', additionalProperties: true),
+        new OA\Property(property: 'calculated_at', type: 'string', format: 'date-time', example: '2026-04-21T03:15:00+00:00'),
+    ]
+)]
 final readonly class SnapshotResponse
 {
     public function __construct(

--- a/site/src/MarketplaceAnalytics/Controller/Api/MarketplaceAnalyticsController.php
+++ b/site/src/MarketplaceAnalytics/Controller/Api/MarketplaceAnalyticsController.php
@@ -7,6 +7,7 @@ namespace App\MarketplaceAnalytics\Controller\Api;
 use App\MarketplaceAnalytics\Api\Request\CreateMarketplaceAnalyticsRequest;
 use App\MarketplaceAnalytics\Application\CreateMarketplaceAnalyticsAction;
 use App\Shared\Service\ActiveCompanyService;
+use OpenApi\Attributes as OA;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
@@ -14,6 +15,7 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[IsGranted('ROLE_COMPANY_OWNER')]
+#[OA\Tag(name: 'Marketplace Analytics')]
 final class MarketplaceAnalyticsController extends AbstractController
 {
     public function __construct(
@@ -21,6 +23,31 @@ final class MarketplaceAnalyticsController extends AbstractController
         private readonly CreateMarketplaceAnalyticsAction $createAction,
     ) {}
 
+    #[OA\Post(
+        summary: 'Создать маркетплейс-аналитику',
+        description: 'Создаёт новый объект marketplace analytics для активной компании. Компания определяется по сессии через ActiveCompanyService.',
+        tags: ['Marketplace Analytics']
+    )]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(ref: '#/components/schemas/CreateMarketplaceAnalyticsRequest')
+    )]
+    #[OA\Response(
+        response: 201,
+        description: 'Создано',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'status', type: 'string', example: 'success'),
+            ],
+            type: 'object'
+        )
+    )]
+    #[OA\Response(response: 401, description: 'Не авторизован')]
+    #[OA\Response(response: 403, description: 'Недостаточно прав (требуется ROLE_COMPANY_OWNER)')]
+    #[OA\Response(
+        response: 422,
+        description: 'Ошибка валидации входных данных (legacy-формат, не RFC 7807)'
+    )]
     #[Route('/api/marketplaceanalytics', name: 'api_marketplaceanalytics_create', methods: ['POST'])]
     public function create(
         #[MapRequestPayload] CreateMarketplaceAnalyticsRequest $request,

--- a/site/src/MarketplaceAnalytics/Controller/Api/MarketplaceAnalyticsController.php
+++ b/site/src/MarketplaceAnalytics/Controller/Api/MarketplaceAnalyticsController.php
@@ -45,6 +45,10 @@ final class MarketplaceAnalyticsController extends AbstractController
     #[OA\Response(response: 401, description: 'Не авторизован')]
     #[OA\Response(response: 403, description: 'Недостаточно прав (требуется ROLE_COMPANY_OWNER)')]
     #[OA\Response(
+        response: 404,
+        description: 'У пользователя нет активной компании (ActiveCompanyService::getActiveCompany() бросает NotFoundHttpException)'
+    )]
+    #[OA\Response(
         response: 422,
         description: 'Ошибка валидации входных данных (legacy-формат, не RFC 7807)'
     )]

--- a/site/src/MarketplaceAnalytics/Controller/Api/SnapshotIndexController.php
+++ b/site/src/MarketplaceAnalytics/Controller/Api/SnapshotIndexController.php
@@ -9,6 +9,7 @@ use App\MarketplaceAnalytics\Api\Request\ListSnapshotsRequest;
 use App\MarketplaceAnalytics\Api\Response\SnapshotResponse;
 use App\MarketplaceAnalytics\Repository\ListingDailySnapshotRepositoryInterface;
 use App\Shared\Service\ActiveCompanyService;
+use OpenApi\Attributes as OA;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -17,6 +18,7 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[IsGranted('ROLE_USER')]
+#[OA\Tag(name: 'Marketplace Analytics')]
 final class SnapshotIndexController extends AbstractController
 {
     public function __construct(
@@ -25,6 +27,91 @@ final class SnapshotIndexController extends AbstractController
         private readonly MarketplaceFacade $marketplaceFacade,
     ) {}
 
+    #[OA\Get(
+        summary: 'Список снэпшотов аналитики',
+        description: 'Возвращает постраничный список снэпшотов маркетплейс-аналитики для активной компании с фильтрами по маркетплейсу, листингу и диапазону дат.',
+        tags: ['Marketplace Analytics']
+    )]
+    #[OA\Parameter(
+        name: 'marketplace',
+        in: 'query',
+        required: false,
+        description: 'Код маркетплейса (например, OZON, WB). Пустая строка трактуется как отсутствие фильтра.',
+        schema: new OA\Schema(type: 'string', nullable: true)
+    )]
+    #[OA\Parameter(
+        name: 'page',
+        in: 'query',
+        required: false,
+        description: 'Номер страницы, начиная с 1.',
+        schema: new OA\Schema(type: 'integer', default: 1, minimum: 1)
+    )]
+    #[OA\Parameter(
+        name: 'perPage',
+        in: 'query',
+        required: false,
+        description: 'Количество элементов на страницу.',
+        schema: new OA\Schema(type: 'integer', default: 20, minimum: 1)
+    )]
+    #[OA\Parameter(
+        name: 'dateFrom',
+        in: 'query',
+        required: false,
+        description: 'Начало периода в формате YYYY-MM-DD (включительно).',
+        schema: new OA\Schema(type: 'string', format: 'date')
+    )]
+    #[OA\Parameter(
+        name: 'dateTo',
+        in: 'query',
+        required: false,
+        description: 'Конец периода в формате YYYY-MM-DD (включительно).',
+        schema: new OA\Schema(type: 'string', format: 'date')
+    )]
+    #[OA\Parameter(
+        name: 'listingId',
+        in: 'query',
+        required: false,
+        description: 'UUID листинга для фильтрации.',
+        schema: new OA\Schema(type: 'string', format: 'uuid', nullable: true)
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Постраничный список снэпшотов',
+        content: new OA\JsonContent(
+            type: 'object',
+            required: ['data', 'meta'],
+            properties: [
+                new OA\Property(
+                    property: 'data',
+                    type: 'array',
+                    items: new OA\Items(ref: '#/components/schemas/SnapshotResponse')
+                ),
+                new OA\Property(
+                    property: 'meta',
+                    type: 'object',
+                    required: ['total', 'page', 'per_page', 'pages'],
+                    properties: [
+                        new OA\Property(property: 'total', type: 'integer', example: 123),
+                        new OA\Property(property: 'page', type: 'integer', example: 1),
+                        new OA\Property(property: 'per_page', type: 'integer', example: 20),
+                        new OA\Property(property: 'pages', type: 'integer', example: 7),
+                    ]
+                ),
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 400,
+        description: 'Неверный формат даты в dateFrom/dateTo (legacy-формат ошибки, не RFC 7807)',
+        content: new OA\JsonContent(
+            type: 'object',
+            properties: [
+                new OA\Property(property: 'type', type: 'string', example: 'BAD_REQUEST'),
+                new OA\Property(property: 'message', type: 'string', example: 'Неверный формат даты. Используйте YYYY-MM-DD.'),
+            ]
+        )
+    )]
+    #[OA\Response(response: 401, description: 'Не авторизован')]
     #[Route(
         '/api/marketplace-analytics/snapshots',
         name: 'marketplace_analytics_api_snapshot_index',

--- a/site/src/MarketplaceAnalytics/Controller/Api/SnapshotIndexController.php
+++ b/site/src/MarketplaceAnalytics/Controller/Api/SnapshotIndexController.php
@@ -112,6 +112,10 @@ final class SnapshotIndexController extends AbstractController
         )
     )]
     #[OA\Response(response: 401, description: 'Не авторизован')]
+    #[OA\Response(
+        response: 404,
+        description: 'У пользователя нет активной компании (ActiveCompanyService::getActiveCompany() бросает NotFoundHttpException)'
+    )]
     #[Route(
         '/api/marketplace-analytics/snapshots',
         name: 'marketplace_analytics_api_snapshot_index',

--- a/site/src/MarketplaceAnalytics/Controller/Api/SnapshotShowController.php
+++ b/site/src/MarketplaceAnalytics/Controller/Api/SnapshotShowController.php
@@ -45,7 +45,7 @@ final class SnapshotShowController extends AbstractController
     #[OA\Response(response: 401, description: 'Не авторизован')]
     #[OA\Response(
         response: 404,
-        description: 'Снэпшот не найден или не принадлежит активной компании (legacy-формат ошибки, не RFC 7807)',
+        description: 'Снэпшот не найден или не принадлежит активной компании (legacy-формат ошибки, не RFC 7807). Также возможен 404 без legacy-тела, если у пользователя нет активной компании (NotFoundHttpException из ActiveCompanyService).',
         content: new OA\JsonContent(
             type: 'object',
             properties: [

--- a/site/src/MarketplaceAnalytics/Controller/Api/SnapshotShowController.php
+++ b/site/src/MarketplaceAnalytics/Controller/Api/SnapshotShowController.php
@@ -8,6 +8,7 @@ use App\Marketplace\Facade\MarketplaceFacade;
 use App\MarketplaceAnalytics\Api\Response\SnapshotResponse;
 use App\MarketplaceAnalytics\Repository\ListingDailySnapshotRepositoryInterface;
 use App\Shared\Service\ActiveCompanyService;
+use OpenApi\Attributes as OA;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -15,6 +16,7 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[IsGranted('ROLE_USER')]
+#[OA\Tag(name: 'Marketplace Analytics')]
 final class SnapshotShowController extends AbstractController
 {
     public function __construct(
@@ -23,6 +25,35 @@ final class SnapshotShowController extends AbstractController
         private readonly MarketplaceFacade $marketplaceFacade,
     ) {}
 
+    #[OA\Get(
+        summary: 'Снэпшот по ID',
+        description: 'Возвращает конкретный снэпшот аналитики. Проверяет принадлежность активной компании (multi-tenancy).',
+        tags: ['Marketplace Analytics']
+    )]
+    #[OA\Parameter(
+        name: 'id',
+        in: 'path',
+        required: true,
+        description: 'UUID снэпшота',
+        schema: new OA\Schema(type: 'string', format: 'uuid')
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Снэпшот найден',
+        content: new OA\JsonContent(ref: '#/components/schemas/SnapshotResponse')
+    )]
+    #[OA\Response(response: 401, description: 'Не авторизован')]
+    #[OA\Response(
+        response: 404,
+        description: 'Снэпшот не найден или не принадлежит активной компании (legacy-формат ошибки, не RFC 7807)',
+        content: new OA\JsonContent(
+            type: 'object',
+            properties: [
+                new OA\Property(property: 'type', type: 'string', example: 'NOT_FOUND'),
+                new OA\Property(property: 'message', type: 'string', example: 'Снимок не найден'),
+            ]
+        )
+    )]
     #[Route(
         '/api/marketplace-analytics/snapshots/{id}',
         name: 'marketplace_analytics_api_snapshot_show',


### PR DESCRIPTION
## Summary

Эталонное документирование API модуля `MarketplaceAnalytics` — 3 эндпоинта как образец для остальных модулей. Логика контроллеров, DTO и Actions НЕ менялась — только атрибуты `#[OA\*]`.

### Задокументированные эндпоинты

- `POST /api/marketplaceanalytics` — создание marketplace analytics
- `GET  /api/marketplace-analytics/snapshots` — список снэпшотов (постраничный, `{data, meta}`)
- `GET  /api/marketplace-analytics/snapshots/{id}` — один снэпшот

### Изменения

- **DTO-схемы** (`#[OA\Schema]` над классом, код DTO не трогается):
  - `SnapshotResponse` — все 19 snake_case полей из `toArray()` с реальными типами; `cost_price` / `total_cost_price` помечены `nullable: true`; `cost_breakdown` / `advertising_details` / `data_quality` — `type: object`
  - `CreateMarketplaceAnalyticsRequest` — `title` с `minLength: 1`
- **Контроллеры** — `#[OA\Tag]` на классе + `#[OA\Get|Post]`, `#[OA\Parameter]`, `#[OA\RequestBody]`, `#[OA\Response]` на методах. Все реальные HTTP-коды: 200/201, 400 (legacy парсинг даты), 401, 403, 404, 422
- **Query-параметры списка** задокументированы по реальному `ListSnapshotsRequest::fromRequest`: `marketplace`, `page`, `perPage`, `dateFrom`, `dateTo`, `listingId`. `companyId` не документируется — берётся из сессии
- **Конфиг** — в `config/packages/nelmio_api_doc.yaml` зарегистрирован тег `Marketplace Analytics`
- **PATTERNS.md** — добавлен раздел 19 «API Documentation (OpenAPI / Nelmio)»: инструмент, правило «не менять логику», документирование Response/Request DTO, чеклист и анти-паттерны
- **ARCHITECTURE.md** — coverage обновлён до 5 / ~47, добавлен реестр задокументированных эндпоинтов

### Отклонения от шаблона задачи (обосновано реальным кодом)

- Ответ списка снэпшотов — `{data: [...], meta: {total, page, per_page, pages}}`, а не плоский массив. Схема 200 описана как объект
- У списка есть ответ 400 с legacy-форматом `{type: BAD_REQUEST, message: ...}` на битую дату — задокументирован
- Контроллер `create` защищён `ROLE_COMPANY_OWNER`, поэтому добавлен `#[OA\Response(response: 403, ...)]`

## Test plan

- [ ] `docker compose exec site-php-cli php bin/console cache:clear`
- [ ] `curl -sf http://localhost/api/doc.json` отдаёт валидный JSON
- [ ] В `paths` присутствуют 5 путей: `/api/health/live`, `/api/health/ready`, `/api/marketplaceanalytics`, `/api/marketplace-analytics/snapshots`, `/api/marketplace-analytics/snapshots/{id}`
- [ ] В `components.schemas` есть `Problem`, `SnapshotResponse`, `CreateMarketplaceAnalyticsRequest`
- [ ] Swagger UI `/api/doc` показывает эндпоинты под тегом **Marketplace Analytics** с summary / параметрами / схемами ответа
- [ ] Существующие тесты проходят

## Scope

Documentation only, no logic changes. Next: PR-3 — `openapi-typescript` + CI pipeline for TS types generation.