### PR TITLE
fix(api-doc): register schema-only classes via Nelmio Model attribute

### DIFF
--- a/site/src/MarketplaceAnalytics/Controller/Api/MarketplaceAnalyticsController.php
+++ b/site/src/MarketplaceAnalytics/Controller/Api/MarketplaceAnalyticsController.php
@@ -7,6 +7,7 @@ namespace App\MarketplaceAnalytics\Controller\Api;
 use App\MarketplaceAnalytics\Api\Request\CreateMarketplaceAnalyticsRequest;
 use App\MarketplaceAnalytics\Application\CreateMarketplaceAnalyticsAction;
 use App\Shared\Service\ActiveCompanyService;
+use Nelmio\ApiDocBundle\Attribute\Model;
 use OpenApi\Attributes as OA;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -30,7 +31,7 @@ final class MarketplaceAnalyticsController extends AbstractController
     )]
     #[OA\RequestBody(
         required: true,
-        content: new OA\JsonContent(ref: '#/components/schemas/CreateMarketplaceAnalyticsRequest')
+        content: new Model(type: CreateMarketplaceAnalyticsRequest::class)
     )]
     #[OA\Response(
         response: 201,

--- a/site/src/MarketplaceAnalytics/Controller/Api/SnapshotIndexController.php
+++ b/site/src/MarketplaceAnalytics/Controller/Api/SnapshotIndexController.php
@@ -6,9 +6,11 @@ namespace App\MarketplaceAnalytics\Controller\Api;
 
 use App\Marketplace\Facade\MarketplaceFacade;
 use App\MarketplaceAnalytics\Api\Request\ListSnapshotsRequest;
+use App\MarketplaceAnalytics\Api\Response\SnapshotListResponse;
 use App\MarketplaceAnalytics\Api\Response\SnapshotResponse;
 use App\MarketplaceAnalytics\Repository\ListingDailySnapshotRepositoryInterface;
 use App\Shared\Service\ActiveCompanyService;
+use Nelmio\ApiDocBundle\Attribute\Model;
 use OpenApi\Attributes as OA;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -77,7 +79,7 @@ final class SnapshotIndexController extends AbstractController
     #[OA\Response(
         response: 200,
         description: 'Постраничный список снэпшотов',
-        content: new OA\JsonContent(ref: '#/components/schemas/SnapshotListResponse')
+        content: new Model(type: SnapshotListResponse::class)
     )]
     #[OA\Response(
         response: 400,

--- a/site/src/MarketplaceAnalytics/Controller/Api/SnapshotShowController.php
+++ b/site/src/MarketplaceAnalytics/Controller/Api/SnapshotShowController.php
@@ -8,6 +8,7 @@ use App\Marketplace\Facade\MarketplaceFacade;
 use App\MarketplaceAnalytics\Api\Response\SnapshotResponse;
 use App\MarketplaceAnalytics\Repository\ListingDailySnapshotRepositoryInterface;
 use App\Shared\Service\ActiveCompanyService;
+use Nelmio\ApiDocBundle\Attribute\Model;
 use OpenApi\Attributes as OA;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -40,7 +41,7 @@ final class SnapshotShowController extends AbstractController
     #[OA\Response(
         response: 200,
         description: 'Снэпшот найден',
-        content: new OA\JsonContent(ref: '#/components/schemas/SnapshotResponse')
+        content: new Model(type: SnapshotResponse::class)
     )]
     #[OA\Response(response: 401, description: 'Не авторизован')]
     #[OA\Response(


### PR DESCRIPTION
## Problem

После PR-2.1 `components.schemas` содержал только `CreateMarketplaceAnalyticsRequest` и `Problem`. Schema-only классы (`SnapshotResponse`, `SnapshotListResponse`, `PaginationMeta`, `CostBreakdown`, `AdvertisingDetails`, `AdvertisingCpcDetails`, `AdvertisingOtherDetails`) не попадали в спеку, хотя атрибуты `OA\Schema` на них есть.

Причина: в контроллерах ссылки шли через строковый `ref` (`#/components/schemas/...`). Nelmio сканирует контроллеры и классы, достижимые через `Model` — висящие строковые `ref` не резолвятся.

## Summary

- Заменил строковые `ref` на `new Model(type: ...)` в трёх контроллерах:
  - `SnapshotIndexController` → `SnapshotListResponse`
  - `SnapshotShowController` → `SnapshotResponse` (ответ возвращает тело напрямую, обёртка не нужна)
  - `MarketplaceAnalyticsController::create` → `CreateMarketplaceAnalyticsRequest`
- Внутренние `ref` внутри `OA\Schema` атрибутов не трогал — Nelmio резолвит их каскадно после того как parent-класс зарегистрирован через `Model`.
- Логика не меняется, schema-классы не трогаем.

## Test plan

- [ ] `docker compose exec site-php-cli php bin/console cache:clear`
- [ ] `docker compose exec site-nginx curl -sf http://localhost/api/doc.json | python3 -c "import sys,json; d=json.load(sys.stdin); print('\n'.join(sorted(d['components']['schemas'].keys())))"` содержит минимум: `AdvertisingCpcDetails`, `AdvertisingDetails`, `AdvertisingOtherDetails`, `CostBreakdown`, `CreateMarketplaceAnalyticsRequest`, `PaginationMeta`, `Problem`, `SnapshotListResponse`, `SnapshotResponse`
- [ ] Swagger UI на `/api/doc` отображает все схемы без broken ref
