### PR TITLE
fix(api-doc): use Model attribute for nested schema refs

### DIFF
--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -995,6 +995,37 @@ final readonly class SnapshotResponse { /* не трогаем */ }
 
 Если поля в PHP и в JSON совпадают один в один (редкий случай) — можно использовать `#[Model(type: Dto::class)]`.
 
+### Вложенные ссылки между схемами
+
+Строковые ref (`ref: '#/components/schemas/X'`) ВНУТРИ `OA\Schema` НЕ работают — Nelmio не резолвит такой класс и не регистрирует его в `components.schemas`. JSON-фрагмент выглядит корректным, но цепочка вложенных схем обрывается: в спеке появится ссылка на `#/components/schemas/X`, но самого описания `X` в `components.schemas` не будет.
+
+**Правило:** для любой ссылки на другой PHP-класс-схему используй `ref: new Model(type: X::class)`. swagger-php сам отрендерит корректный `#/components/schemas/X` в итоговом JSON, а Nelmio при этом каскадно зарегистрирует всю цепочку вложенных классов.
+
+```php
+use Nelmio\ApiDocBundle\Attribute\Model;
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'SnapshotResponse',
+    properties: [
+        // ❌ НЕ работает — Nelmio не увидит CostBreakdown
+        new OA\Property(property: 'cost_breakdown', ref: '#/components/schemas/CostBreakdown'),
+
+        // ✅ работает — Nelmio резолвит класс и регистрирует схему
+        new OA\Property(property: 'cost_breakdown', ref: new Model(type: CostBreakdown::class)),
+
+        // ✅ для массивов — Model внутри OA\Items
+        new OA\Property(
+            property: 'data',
+            type: 'array',
+            items: new OA\Items(ref: new Model(type: SnapshotResponse::class)),
+        ),
+    ]
+)]
+```
+
+**Исключение:** ссылка на схему, описанную inline в `config/packages/nelmio_api_doc.yaml` (например, `Problem`), — там PHP-класса нет, используется строковый ref. Это работает, потому что схема регистрируется из YAML напрямую.
+
 ### Документирование Request-DTO
 
 Для DTO, которые биндятся через `#[MapRequestPayload]`, описываем схему атрибутом над классом. Валидация (`#[Assert\*]`) Nelmio подхватывает автоматически в части required/min/max/pattern.

--- a/site/src/MarketplaceAnalytics/Api/Response/Schema/AdvertisingDetails.php
+++ b/site/src/MarketplaceAnalytics/Api/Response/Schema/AdvertisingDetails.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\MarketplaceAnalytics\Api\Response\Schema;
 
+use Nelmio\ApiDocBundle\Attribute\Model;
 use OpenApi\Attributes as OA;
 
 #[OA\Schema(
@@ -11,8 +12,8 @@ use OpenApi\Attributes as OA;
     description: 'Рекламные метрики (CPC + прочие расходы)',
     required: ['cpc', 'other'],
     properties: [
-        new OA\Property(property: 'cpc', ref: '#/components/schemas/AdvertisingCpcDetails'),
-        new OA\Property(property: 'other', ref: '#/components/schemas/AdvertisingOtherDetails'),
+        new OA\Property(property: 'cpc', ref: new Model(type: AdvertisingCpcDetails::class)),
+        new OA\Property(property: 'other', ref: new Model(type: AdvertisingOtherDetails::class)),
     ]
 )]
 final class AdvertisingDetails

--- a/site/src/MarketplaceAnalytics/Api/Response/SnapshotListResponse.php
+++ b/site/src/MarketplaceAnalytics/Api/Response/SnapshotListResponse.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\MarketplaceAnalytics\Api\Response;
 
+use App\Shared\OpenApi\Schema\PaginationMeta;
+use Nelmio\ApiDocBundle\Attribute\Model;
 use OpenApi\Attributes as OA;
 
 #[OA\Schema(
@@ -14,9 +16,9 @@ use OpenApi\Attributes as OA;
         new OA\Property(
             property: 'data',
             type: 'array',
-            items: new OA\Items(ref: '#/components/schemas/SnapshotResponse')
+            items: new OA\Items(ref: new Model(type: SnapshotResponse::class))
         ),
-        new OA\Property(property: 'meta', ref: '#/components/schemas/PaginationMeta'),
+        new OA\Property(property: 'meta', ref: new Model(type: PaginationMeta::class)),
     ]
 )]
 final class SnapshotListResponse

--- a/site/src/MarketplaceAnalytics/Api/Response/SnapshotResponse.php
+++ b/site/src/MarketplaceAnalytics/Api/Response/SnapshotResponse.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace App\MarketplaceAnalytics\Api\Response;
 
+use App\MarketplaceAnalytics\Api\Response\Schema\AdvertisingDetails;
+use App\MarketplaceAnalytics\Api\Response\Schema\CostBreakdown;
 use App\MarketplaceAnalytics\Entity\ListingDailySnapshot;
+use Nelmio\ApiDocBundle\Attribute\Model;
 use OpenApi\Attributes as OA;
 
 #[OA\Schema(
@@ -70,8 +73,8 @@ use OpenApi\Attributes as OA;
             example: ['cost_price_missing', 'api_advertising_missing'],
             description: 'Флаги проблем с качеством данных (значения enum DataQualityFlag)',
         ),
-        new OA\Property(property: 'cost_breakdown', ref: '#/components/schemas/CostBreakdown'),
-        new OA\Property(property: 'advertising_details', ref: '#/components/schemas/AdvertisingDetails'),
+        new OA\Property(property: 'cost_breakdown', ref: new Model(type: CostBreakdown::class)),
+        new OA\Property(property: 'advertising_details', ref: new Model(type: AdvertisingDetails::class)),
     ]
 )]
 final readonly class SnapshotResponse


### PR DESCRIPTION
## Summary

- Replace string refs (`#/components/schemas/X`) inside `OA\Schema` attributes with `ref: new Model(type: X::class)` so Nelmio can cascade-register nested schema classes.
- Affected files: `SnapshotResponse`, `SnapshotListResponse`, `AdvertisingDetails`.
- Document the pattern in `PATTERNS.md` section 19 under a new subsection "Вложенные ссылки между схемами".

## Root cause

Nelmio resolves PHP classes only when it encounters `Nelmio\ApiDocBundle\Attribute\Model`. String refs are treated as opaque — the target class is never auto-registered in `components.schemas`, so after PR-2.2 only 4 schemas were present and `PaginationMeta`, `CostBreakdown`, `AdvertisingDetails`, `AdvertisingCpcDetails`, `AdvertisingOtherDetails` were missing even though the JSON fragment referenced them.

## What changed

- `site/src/MarketplaceAnalytics/Api/Response/SnapshotResponse.php` — `cost_breakdown`, `advertising_details` now use `Model(type: ...)`.
- `site/src/MarketplaceAnalytics/Api/Response/SnapshotListResponse.php` — `data` (via `OA\Items`) and `meta` now use `Model(type: ...)`.
- `site/src/MarketplaceAnalytics/Api/Response/Schema/AdvertisingDetails.php` — `cpc`, `other` now use `Model(type: ...)`.
- `PATTERNS.md` — new subsection documenting the rule, with examples and the YAML-inline exception (e.g. `Problem`).

No logic changes.

## Test plan

- [ ] `docker compose exec site-php-cli php bin/console cache:clear`
- [ ] `docker compose exec site-nginx curl -sf http://localhost/api/doc.json | python3 -c "import sys,json; d=json.load(sys.stdin); print('\n'.join(sorted(d['components']['schemas'].keys())))"` returns the expected 9 schemas:
  - AdvertisingCpcDetails
  - AdvertisingDetails
  - AdvertisingOtherDetails
  - CostBreakdown
  - CreateMarketplaceAnalyticsRequest
  - PaginationMeta
  - Problem
  - SnapshotListResponse
  - SnapshotResponse
- [ ] `/api/doc` UI renders all nested schemas correctly.
