### PR TITLE
Split Messenger into three specialized transports

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -127,7 +127,7 @@ jobs:
                     echo "✅ land healthy"
 
                     echo "🐳 [4/5] Обновляем воркеры и CLI"
-                    docker compose -f docker-compose.prod.yml up -d --no-deps site-php-cli site-messenger-worker scheduler
+                    docker compose -f docker-compose.prod.yml up -d --no-deps site-php-cli site-messenger-worker-sync site-messenger-worker-pipeline site-messenger-worker-ads scheduler
 
                     echo "🐳 [5/5] Поднимаем остальные сервисы (если есть новые)"
                     docker compose -f docker-compose.prod.yml up -d --remove-orphans

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,6 +15,9 @@ x-php-env: &php-env
     APP_SECRET: ${APP_SECRET}
     REDIS_DSN: redis://site-redis:6379
     MESSENGER_TRANSPORT_DSN: redis://site-redis:6379/messages
+    MESSENGER_TRANSPORT_DSN_SYNC: redis://site-redis:6379/messages_sync
+    MESSENGER_TRANSPORT_DSN_PIPELINE: redis://site-redis:6379/messages_pipeline
+    MESSENGER_TRANSPORT_DSN_ADS: redis://site-redis:6379/messages_ads
     MAILER_DSN: ${SITE_MAILER_DSN}
     SENTRY_DSN: ${SENTRY_DSN}
     HEALTH_CHECK_TOKEN: ${HEALTH_CHECK_TOKEN}
@@ -176,9 +179,9 @@ services:
         deploy:
             resources:
                 limits:
-                    memory: 1500M
+                    memory: 800M
                 reservations:
-                    memory: 256M
+                    memory: 128M
 
     site-php-cli:
         image: ghcr.io/pavelsur07/site-php-cli:latest
@@ -197,11 +200,11 @@ services:
             - site_company_storage:/app/var/storage/companies
             - site_var_log:/app/var/log
 
-    site-messenger-worker:
+    site-messenger-worker-sync:
         image: ghcr.io/pavelsur07/site-php-cli:latest
-        container_name: site-messenger-worker
+        container_name: site-messenger-worker-sync
         restart: always
-        command: php bin/console messenger:consume async -vv --time-limit=3600
+        command: php bin/console messenger:consume async_sync -vv --time-limit=3600 --memory-limit=160M
         environment:
             <<: *php-env
         networks:
@@ -215,14 +218,86 @@ services:
             - site_storage:/app/var/storage
             - site_company_storage:/app/var/storage/companies
             - site_var_log:/app/var/log
-        # ⬇️ FIX: Даём воркеру завершить текущее сообщение при остановке
         stop_grace_period: 60s
         healthcheck:
-            test: [ "CMD-SHELL", "ps aux | grep 'messenger:consume' | grep -v grep" ]
+            test: ["CMD-SHELL", "ps aux | grep 'messenger:consume async_sync' | grep -v grep"]
             interval: 30s
             timeout: 10s
             retries: 3
             start_period: 10s
+        deploy:
+            resources:
+                limits:
+                    memory: 256M
+                reservations:
+                    memory: 64M
+
+    site-messenger-worker-pipeline:
+        image: ghcr.io/pavelsur07/site-php-cli:latest
+        container_name: site-messenger-worker-pipeline
+        restart: always
+        command: php bin/console messenger:consume async_pipeline -vv --time-limit=3600 --memory-limit=500M
+        environment:
+            <<: *php-env
+        networks:
+            - default
+        depends_on:
+            site-postgres:
+                condition: service_healthy
+            site-redis:
+                condition: service_healthy
+        volumes:
+            - site_storage:/app/var/storage
+            - site_company_storage:/app/var/storage/companies
+            - site_var_log:/app/var/log
+        stop_grace_period: 60s
+        healthcheck:
+            test: ["CMD-SHELL", "ps aux | grep 'messenger:consume async_pipeline' | grep -v grep"]
+            interval: 30s
+            timeout: 10s
+            retries: 3
+            start_period: 10s
+        deploy:
+            resources:
+                limits:
+                    memory: 768M
+                reservations:
+                    memory: 192M
+
+    site-messenger-worker-ads:
+        image: ghcr.io/pavelsur07/site-php-cli:latest
+        container_name: site-messenger-worker-ads
+        restart: always
+        # --time-limit=3600 means the worker restarts mid-poll at worst once/hour;
+        # Messenger redelivers the in-flight message automatically.
+        command: php bin/console messenger:consume async_ads -vv --time-limit=3600 --memory-limit=160M
+        environment:
+            <<: *php-env
+        networks:
+            - default
+        depends_on:
+            site-postgres:
+                condition: service_healthy
+            site-redis:
+                condition: service_healthy
+        volumes:
+            - site_storage:/app/var/storage
+            - site_company_storage:/app/var/storage/companies
+            - site_var_log:/app/var/log
+        # Ads handler can poll up to 10 min; give it more time to finish gracefully.
+        stop_grace_period: 120s
+        healthcheck:
+            test: ["CMD-SHELL", "ps aux | grep 'messenger:consume async_ads' | grep -v grep"]
+            interval: 30s
+            timeout: 10s
+            retries: 3
+            start_period: 10s
+        deploy:
+            resources:
+                limits:
+                    memory: 256M
+                reservations:
+                    memory: 64M
 
     site-postgres:
         image: postgres:15-alpine
@@ -285,6 +360,9 @@ services:
             APP_SECRET: ${APP_SECRET}
             REDIS_DSN: redis://site-redis:6379
             MESSENGER_TRANSPORT_DSN: redis://site-redis:6379/messages
+            MESSENGER_TRANSPORT_DSN_SYNC: redis://site-redis:6379/messages_sync
+            MESSENGER_TRANSPORT_DSN_PIPELINE: redis://site-redis:6379/messages_pipeline
+            MESSENGER_TRANSPORT_DSN_ADS: redis://site-redis:6379/messages_ads
             MAILER_DSN: ${SITE_MAILER_DSN}
             SENTRY_DSN: ${SENTRY_DSN}
             APP_MAIL_FROM: "Ваш Финдир <support@vashfindir.ru>"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,7 @@ services:
         ports:
             - "5173:5173" # <-- ДОБАВИТЬ ЭТО (проброс порта Vite)
         command: sh -c "yarn install && yarn dev"
-    site-php-cli-worker:
+    site-php-cli-worker-sync:
         build:
             context: site/docker
             dockerfile: development/php-cli/Dockerfile
@@ -111,7 +111,41 @@ services:
                 condition: service_healthy
         volumes:
             - ./site:/app
-        command: php bin/console messenger:consume async --time-limit=3600 --memory-limit=256M -vv
+        command: php bin/console messenger:consume async_sync --time-limit=3600 --memory-limit=160M -vv
+
+    site-php-cli-worker-pipeline:
+        build:
+            context: site/docker
+            dockerfile: development/php-cli/Dockerfile
+        working_dir: /app
+        restart: unless-stopped
+        environment:
+            <<: *tz-env
+        depends_on:
+            site-postgres:
+                condition: service_healthy
+            site-redis:
+                condition: service_healthy
+        volumes:
+            - ./site:/app
+        command: php bin/console messenger:consume async_pipeline --time-limit=3600 --memory-limit=500M -vv
+
+    site-php-cli-worker-ads:
+        build:
+            context: site/docker
+            dockerfile: development/php-cli/Dockerfile
+        working_dir: /app
+        restart: unless-stopped
+        environment:
+            <<: *tz-env
+        depends_on:
+            site-postgres:
+                condition: service_healthy
+            site-redis:
+                condition: service_healthy
+        volumes:
+            - ./site:/app
+        command: php bin/console messenger:consume async_ads --time-limit=3600 --memory-limit=160M -vv
     site-postgres:
         image: postgres:15-alpine
         container_name: symfony-postgres

--- a/site/.env
+++ b/site/.env
@@ -31,11 +31,12 @@ DATABASE_URL=pgsql://app:secret@site-postgres:5432/app
 ###< doctrine/doctrine-bundle ###
 
 ###> symfony/messenger ###
-# Choose one of the transports below
-# MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f/messages
-# MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages
-#MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=0
+# Base DSN retained for backward-compat reads (no transport uses it directly anymore).
 MESSENGER_TRANSPORT_DSN=redis://site-redis:6379/messages
+# Three per-purpose transports — separate Redis streams.
+MESSENGER_TRANSPORT_DSN_SYNC=redis://site-redis:6379/messages_sync
+MESSENGER_TRANSPORT_DSN_PIPELINE=redis://site-redis:6379/messages_pipeline
+MESSENGER_TRANSPORT_DSN_ADS=redis://site-redis:6379/messages_ads
 ###< symfony/messenger ###
 
 

--- a/site/config/packages/messenger.yaml
+++ b/site/config/packages/messenger.yaml
@@ -3,17 +3,28 @@ framework:
         failure_transport: failed
 
         transports:
-            # https://symfony.com/doc/current/messenger.html#transport-configuration
-            async:
-                dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
-                #options:
-                #    use_notify: true
-                #    check_delayed_interval: 60000
+            async_sync:
+                dsn: '%env(MESSENGER_TRANSPORT_DSN_SYNC)%'
                 retry_strategy:
                     max_retries: 3
+                    delay: 10000
                     multiplier: 2
+
+            async_pipeline:
+                dsn: '%env(MESSENGER_TRANSPORT_DSN_PIPELINE)%'
+                retry_strategy:
+                    max_retries: 3
+                    delay: 5000
+                    multiplier: 2
+
+            async_ads:
+                dsn: '%env(MESSENGER_TRANSPORT_DSN_ADS)%'
+                retry_strategy:
+                    max_retries: 2
+                    delay: 30000
+                    multiplier: 2
+
             failed: 'doctrine://default?queue_name=failed'
-            # sync: 'sync://'
 
         default_bus: messenger.bus.default
 
@@ -24,32 +35,32 @@ framework:
                     - doctrine_close_connection
 
         routing:
-            'App\Message\ApplyAutoRulesForTransaction': async
-            'App\Message\EnqueueAutoRulesForRange': async
-            'App\Marketplace\Message\SyncWbReportMessage': async
-            'App\Marketplace\Message\SyncOzonReportMessage': async
-            'App\Marketplace\Message\InitialSyncMessage': async
-            'App\Marketplace\Message\TriggerInitialSyncMessage': async
-            'App\Marketplace\Message\SyncOzonRealizationMessage': async    # ← НОВОЕ
-            'App\Marketplace\Message\ImportInventoryCostPriceMessage': async    # ← НОВОЕ
-            'App\Marketplace\Message\CloseMonthStageMessage': async    # ← НОВОЕ
-            'App\Marketplace\Message\ProcessDayReportMessage': async
-            'App\Marketplace\Message\ProcessRawDocumentStepMessage': async
-            'App\Marketplace\Message\ReprocessCostsMessage': async
-            'App\Marketplace\Application\Command\FetchMarketplaceDataCommand': async
-            'App\Catalog\Message\ImportProductsMessage': async
-            #App\Message\ApplyAutoRulesForTransaction: async
-            #App\Message\EnqueueAutoRulesForRange: async
-            App\Message\SendRegistrationEmailMessage: async
-            App\Cash\Message\Import\BankImportMessage: async
-            App\Cash\Message\Import\CashFileImportMessage: async
-            Symfony\Component\Mailer\Messenger\SendEmailMessage: async
-            Symfony\Component\Notifier\Message\ChatMessage: async
-            Symfony\Component\Notifier\Message\SmsMessage: async
-            App\MarketplaceAnalytics\Message\RecalcSnapshotsMessage: async
-            App\MarketplaceAds\Message\ProcessAdRawDocumentMessage: async
-            App\MarketplaceAds\Message\FetchOzonAdStatisticsMessage: async
-            App\MarketplaceAds\Message\LoadOzonAdStatisticsRangeMessage: async
+            # --- async_sync: external marketplace/bank HTTP fetches ---
+            'App\Marketplace\Message\SyncWbReportMessage': async_sync
+            'App\Marketplace\Message\SyncOzonReportMessage': async_sync
+            'App\Marketplace\Message\SyncOzonRealizationMessage': async_sync
+            'App\Marketplace\Message\InitialSyncMessage': async_sync
+            'App\Marketplace\Message\TriggerInitialSyncMessage': async_sync
+            'App\Marketplace\Application\Command\FetchMarketplaceDataCommand': async_sync
+            'App\Cash\Message\Import\BankImportMessage': async_sync
+            'App\Cash\Message\Import\CashFileImportMessage': async_sync
+            'App\Message\SendRegistrationEmailMessage': async_sync
+            'Symfony\Component\Mailer\Messenger\SendEmailMessage': async_sync
+            'Symfony\Component\Notifier\Message\ChatMessage': async_sync
+            'Symfony\Component\Notifier\Message\SmsMessage': async_sync
 
-            # Route your messages to the transports
-            # 'App\Message\YourMessage': async
+            # --- async_pipeline: local CPU/DB processing of already-fetched data ---
+            'App\Marketplace\Message\ProcessDayReportMessage': async_pipeline
+            'App\Marketplace\Message\ProcessRawDocumentStepMessage': async_pipeline
+            'App\Marketplace\Message\ReprocessCostsMessage': async_pipeline
+            'App\Marketplace\Message\CloseMonthStageMessage': async_pipeline
+            'App\Marketplace\Message\ImportInventoryCostPriceMessage': async_pipeline
+            'App\Catalog\Message\ImportProductsMessage': async_pipeline
+            'App\Message\ApplyAutoRulesForTransaction': async_pipeline
+            'App\Message\EnqueueAutoRulesForRange': async_pipeline
+            'App\MarketplaceAnalytics\Message\RecalcSnapshotsMessage': async_pipeline
+            'App\MarketplaceAds\Message\ProcessAdRawDocumentMessage': async_pipeline
+
+            # --- async_ads: Ozon Performance polling (may block up to 10 min per message) ---
+            'App\MarketplaceAds\Message\LoadOzonAdStatisticsRangeMessage': async_ads
+            'App\MarketplaceAds\Message\FetchOzonAdStatisticsMessage': async_ads

--- a/site/config/packages/test/messenger.yaml
+++ b/site/config/packages/test/messenger.yaml
@@ -1,4 +1,6 @@
 framework:
     messenger:
         transports:
-            async: 'in-memory://'
+            async_sync: 'in-memory://'
+            async_pipeline: 'in-memory://'
+            async_ads: 'in-memory://'

--- a/site/tests/Unit/MarketplaceAds/EventSubscriber/AdLoadJobFailureSubscriberTest.php
+++ b/site/tests/Unit/MarketplaceAds/EventSubscriber/AdLoadJobFailureSubscriberTest.php
@@ -43,7 +43,7 @@ final class AdLoadJobFailureSubscriberTest extends TestCase
             '2026-03-01',
             '2026-03-03',
         ));
-        $event = new WorkerMessageFailedEvent($envelope, 'async', new \RuntimeException('transient'));
+        $event = new WorkerMessageFailedEvent($envelope, 'async_ads', new \RuntimeException('transient'));
         $event->setForRetry();
 
         self::assertTrue($event->willRetry(), 'sanity: событие помечено для ретрая');
@@ -63,7 +63,7 @@ final class AdLoadJobFailureSubscriberTest extends TestCase
             self::COMPANY_ID,
             'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
         ));
-        $event = new WorkerMessageFailedEvent($envelope, 'async', new \RuntimeException('boom'));
+        $event = new WorkerMessageFailedEvent($envelope, 'async_ads', new \RuntimeException('boom'));
 
         self::assertFalse($event->willRetry());
 
@@ -102,7 +102,7 @@ final class AdLoadJobFailureSubscriberTest extends TestCase
         ));
         $event = new WorkerMessageFailedEvent(
             $envelope,
-            'async',
+            'async_ads',
             new \RuntimeException('Ozon 502 Bad Gateway'),
         );
 
@@ -146,7 +146,7 @@ final class AdLoadJobFailureSubscriberTest extends TestCase
                 }),
             );
 
-        $event = new WorkerMessageFailedEvent($envelope, 'async', $wrapper);
+        $event = new WorkerMessageFailedEvent($envelope, 'async_ads', $wrapper);
 
         (new AdLoadJobFailureSubscriber($repo, $logger))->onMessageFailed($event);
     }
@@ -178,7 +178,7 @@ final class AdLoadJobFailureSubscriberTest extends TestCase
             '2026-03-01',
             '2026-03-03',
         ));
-        $event = new WorkerMessageFailedEvent($envelope, 'async', new \RuntimeException($longMessage));
+        $event = new WorkerMessageFailedEvent($envelope, 'async_ads', new \RuntimeException($longMessage));
 
         (new AdLoadJobFailureSubscriber($repo, $logger))->onMessageFailed($event);
     }
@@ -207,7 +207,7 @@ final class AdLoadJobFailureSubscriberTest extends TestCase
             '2026-03-01',
             '2026-03-03',
         ));
-        $event = new WorkerMessageFailedEvent($envelope, 'async', new \RuntimeException($longMessage));
+        $event = new WorkerMessageFailedEvent($envelope, 'async_ads', new \RuntimeException($longMessage));
 
         (new AdLoadJobFailureSubscriber($repo, $logger))->onMessageFailed($event);
     }


### PR DESCRIPTION
## Summary
Refactored the Symfony Messenger configuration to use three separate, purpose-built transports instead of a single generic async queue. This allows for independent scaling, retry strategies, and resource allocation based on message type characteristics.

## Key Changes

- **Three new transports** in `messenger.yaml`:
  - `async_sync`: External HTTP fetches (marketplace/bank APIs) — 3 retries, 10s delay
  - `async_pipeline`: Local CPU/DB processing — 3 retries, 5s delay  
  - `async_ads`: Ozon Performance polling (long-running, up to 10 min) — 2 retries, 30s delay

- **Message routing** reorganized by workload type:
  - Sync transport: marketplace syncs, bank imports, email/notification sends
  - Pipeline transport: report processing, cost recalculation, product imports, transaction rules
  - Ads transport: Ozon ad statistics fetching and processing

- **Three dedicated worker containers** in both dev and prod:
  - `site-messenger-worker-sync`: 160M memory limit
  - `site-messenger-worker-pipeline`: 500M memory limit (CPU-intensive)
  - `site-messenger-worker-ads`: 160M memory limit, 120s grace period (long polls)

- **Resource optimization**:
  - Reduced FPM memory limits (1500M → 800M) to accommodate separate workers
  - Each worker sized appropriately for its workload
  - Pipeline worker gets more resources for heavy processing

- **Improved observability**:
  - Healthchecks now transport-specific (grep for exact queue name)
  - Explicit retry strategies per transport type
  - Comments documenting long-poll behavior for ads worker

- **Environment configuration**:
  - Added `MESSENGER_TRANSPORT_DSN_SYNC`, `MESSENGER_TRANSPORT_DSN_PIPELINE`, `MESSENGER_TRANSPORT_DSN_ADS` to `.env` and compose files
  - Separate Redis streams for each transport type

- **Test configuration** updated to use in-memory transports for all three queues

## Implementation Details

The refactoring maintains backward compatibility by keeping the base `MESSENGER_TRANSPORT_DSN` variable, though no transport directly uses it anymore. Each message class is explicitly routed to its appropriate transport based on whether it performs I/O (sync), local processing (pipeline), or long-running external polling (ads).

https://claude.ai/code/session_01G1mPfMbQTgWzKC6WDAvgF7