### PR TITLE
Document messenger transport selection rules for async messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,10 @@ Doctrine генерирует proxy-класс наследованием от E
 ### Message (Messenger)
 - `readonly class` только с scalar ID — не Entity
 - Новый Message → добавить routing в `config/packages/messenger.yaml`
+- **Выбор транспорта обязателен** — ровно один из трёх:
+  - `async_sync` — внешние HTTP-запросы (marketplace/банк API, отправка email)
+  - `async_pipeline` — локальная обработка данных, DB-heavy (процессинг raw-документов, импорты, auto-rules, close-month, analytics recalc)
+  - `async_ads` — Ozon Performance polling (изолирован, т.к. handler может висеть до 10 минут)
 - Handler: нет `Request`/`Session`/`Security` — CLI-контекст
 - Паттерн полностью → `PATTERNS.md` раздел 10
 
@@ -197,7 +201,11 @@ NewModule:
     alias: NewModule
 
 # 3. config/packages/messenger.yaml (если есть async Messages)
-App\NewModule\Message\SomeMessage: async
+#    Выбрать ровно ОДИН транспорт под характер задачи:
+#    - async_sync      — внешние HTTP (marketplace/банк API, email)
+#    - async_pipeline  — локальная обработка (DB/CPU, импорты, analytics)
+#    - async_ads       — Ozon Performance polling (изолирован)
+App\NewModule\Message\SomeMessage: async_pipeline
 
 # 4. config/packages/twig.yaml (если есть шаблоны)
 paths:

--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -419,9 +419,21 @@ final readonly class SyncWbReportMessage
 }
 ```
 
-После создания → добавить в `config/packages/messenger.yaml`:
+После создания → добавить в `config/packages/messenger.yaml` с выбором транспорта:
+
+| Транспорт | Когда использовать | Примеры сообщений |
+|---|---|---|
+| `async_sync` | Внешние HTTP-запросы, отправка email | `SyncWbReportMessage`, `SyncOzonReportMessage`, `BankImportMessage`, `SendEmailMessage` |
+| `async_pipeline` | Локальная обработка, DB/CPU-heavy | `ProcessDayReportMessage`, `ProcessRawDocumentStepMessage`, `ApplyAutoRulesForTransaction`, `RecalcSnapshotsMessage` |
+| `async_ads` | Ozon Performance polling (handler может висеть до 10 минут) | `FetchOzonAdStatisticsMessage`, `LoadOzonAdStatisticsRangeMessage` |
+
+Правило выбора:
+- Handler делает внешний HTTP-запрос к marketplace/банку/email → `async_sync`
+- Handler читает/пишет в БД, парсит локальные файлы, считает агрегаты → `async_pipeline`
+- Handler — часть Ozon Ads pipeline (выделенная очередь из-за долгого polling) → `async_ads`
+
 ```yaml
-App\Marketplace\Message\SyncWbReportMessage: async
+App\Marketplace\Message\SyncWbReportMessage: async_sync
 ```
 
 ### Handler


### PR DESCRIPTION
## Summary
Added comprehensive documentation for choosing the correct messenger transport when creating new async messages. This clarifies the three transport options and provides clear decision criteria based on message handler characteristics.

## Key Changes
- **PATTERNS.md**: 
  - Replaced generic `async` transport reference with three specific transport options (`async_sync`, `async_pipeline`, `async_ads`)
  - Added decision table mapping transports to use cases with concrete message examples
  - Documented selection rules based on handler behavior (external HTTP requests, local data processing, or Ozon Ads polling)

- **CLAUDE.md**:
  - Added transport selection requirement to Message guidelines
  - Documented all three transport options with their purposes
  - Updated code example in module creation checklist to use `async_pipeline` with explanatory comments about transport selection

## Implementation Details
The three transport categories are:
- `async_sync` — for handlers making external HTTP requests (marketplace APIs, bank APIs, email sending)
- `async_pipeline` — for handlers performing local data processing, database operations, or CPU-intensive work
- `async_ads` — for Ozon Performance polling handlers that may run for extended periods (up to 10 minutes)

This ensures proper queue isolation and prevents long-running polling operations from blocking other async tasks.

https://claude.ai/code/session_01TDQTRg3j4daTnwH6batWUb