### PR TITLE
Add findInFlightByCompany method to OzonAdPendingReportRepository

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -453,6 +453,15 @@ findByOzonUuid(string $companyId, string $ozonUuid): ?OzonAdPendingReport
 // по которым нужно продолжать polling вместо нового POST /statistics.
 // @return list<OzonAdPendingReport>
 findInFlightByJob(string $companyId, string $jobId): array
+
+// Все in-flight (не финализированные) записи для company, ORDER BY requested_at ASC.
+// "In-flight" = finalized_at IS NULL (единственный источник правды; фильтр по state
+// намеренно не добавлен, чтобы не дублировать логику терминализации).
+// Используется будущей poll-cron (шаг 3 redesign-плана) для bulk-запроса
+// GET /api/client/statistics/list по всем активным UUID одной компании.
+// companyId обязателен и валидируется Assert::uuid().
+// @return list<OzonAdPendingReport>
+findInFlightByCompany(string $companyId): array
 ```
 
 ---

--- a/site/src/MarketplaceAds/Repository/OzonAdPendingReportRepository.php
+++ b/site/src/MarketplaceAds/Repository/OzonAdPendingReportRepository.php
@@ -8,6 +8,7 @@ use App\MarketplaceAds\Entity\OzonAdPendingReport;
 use App\MarketplaceAds\Enum\OzonAdPendingReportState;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Webmozart\Assert\Assert;
 
 /**
  * Репозиторий записей о запрошенных отчётах Ozon Performance.
@@ -213,5 +214,35 @@ class OzonAdPendingReportRepository extends ServiceEntityRepository
             ->getResult();
 
         return $result;
+    }
+
+    /**
+     * Все in-flight (не финализированные) записи для company, отсортированные
+     * по requestedAt ASC — свежие воркеры сначала обрабатывают самые старые.
+     *
+     * "In-flight" определяется строго по `finalized_at IS NULL` — это единственный
+     * источник правды. Фильтр по state умышленно не добавлен: это дублировало бы
+     * логику терминализации и могло бы разъехаться с реальным состоянием записи.
+     *
+     * Используется будущей poll-cron командой (шаг 3 из redesign-плана) для
+     * bulk-запроса `GET /api/client/statistics/list` по всем активным UUID
+     * одной компании за один проход.
+     *
+     * @return list<OzonAdPendingReport>
+     */
+    public function findInFlightByCompany(string $companyId): array
+    {
+        Assert::uuid($companyId);
+
+        /** @var list<OzonAdPendingReport> $rows */
+        $rows = $this->createQueryBuilder('r')
+            ->andWhere('r.companyId = :companyId')
+            ->andWhere('r.finalizedAt IS NULL')
+            ->setParameter('companyId', $companyId)
+            ->orderBy('r.requestedAt', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return $rows;
     }
 }

--- a/site/tests/Integration/MarketplaceAds/OzonAdPendingReportRepositoryTest.php
+++ b/site/tests/Integration/MarketplaceAds/OzonAdPendingReportRepositoryTest.php
@@ -14,6 +14,7 @@ use App\Tests\Builders\Company\CompanyBuilder;
 use App\Tests\Builders\Company\UserBuilder;
 use App\Tests\Builders\MarketplaceAds\AdLoadJobBuilder;
 use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
 
 final class OzonAdPendingReportRepositoryTest extends IntegrationTestCase
 {
@@ -374,6 +375,96 @@ final class OzonAdPendingReportRepositoryTest extends IntegrationTestCase
             campaignIds: ['222'],
             jobId: null,
         );
+    }
+
+    public function testFindInFlightByCompanyReturnsOnlyNonFinalizedRowsForTheCompany(): void
+    {
+        $companyA = Uuid::uuid7()->toString();
+        $companyB = Uuid::uuid7()->toString();
+
+        // A1 — company A, not finalized, requested 10:00
+        // A2 — company A, not finalized, requested 08:00 (older → expect first)
+        // A3 — company A, finalized (should NOT be returned)
+        // B1 — company B, not finalized (wrong company → should NOT be returned)
+        // B2 — company B, finalized
+        $a1 = $this->persistPendingReport($companyA, '2026-04-20 10:00:00', null);
+        $a2 = $this->persistPendingReport($companyA, '2026-04-20 08:00:00', null);
+        $this->persistPendingReport($companyA, '2026-04-20 09:00:00', '2026-04-20 09:05:00');
+        $this->persistPendingReport($companyB, '2026-04-20 07:00:00', null);
+        $this->persistPendingReport($companyB, '2026-04-20 07:30:00', '2026-04-20 07:35:00');
+        $this->em->flush();
+
+        $a1Id = $a1->getId();
+        $a2Id = $a2->getId();
+        $this->em->clear();
+
+        $result = $this->repository->findInFlightByCompany($companyA);
+
+        self::assertCount(2, $result);
+        // Ordered by requestedAt ASC — A2 (08:00) before A1 (10:00).
+        self::assertSame($a2Id, $result[0]->getId());
+        self::assertSame($a1Id, $result[1]->getId());
+    }
+
+    public function testFindInFlightByCompanyReturnsEmptyArrayWhenCompanyHasNoInFlightReports(): void
+    {
+        $companyA = Uuid::uuid7()->toString();
+        $this->persistPendingReport($companyA, '2026-04-20 10:00:00', '2026-04-20 10:05:00');
+        $this->em->flush();
+        $this->em->clear();
+
+        $result = $this->repository->findInFlightByCompany($companyA);
+
+        self::assertSame([], $result);
+    }
+
+    public function testFindInFlightByCompanyRejectsNonUuidCompanyId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->repository->findInFlightByCompany('not-a-uuid');
+    }
+
+    /**
+     * Создаёт OzonAdPendingReport с подменённым requestedAt (для контроля сортировки)
+     * и опциональным finalizedAt (для проверок фильтра "in-flight"). Оба поля
+     * неизменяемы через публичный API и устанавливаются в конструкторе / raw DBAL
+     * соответственно, поэтому в тестовой фикстуре используется reflection.
+     */
+    private function persistPendingReport(
+        string $companyId,
+        string $requestedAt,
+        ?string $finalizedAt,
+        ?string $jobId = null,
+    ): OzonAdPendingReport {
+        $report = new OzonAdPendingReport(
+            companyId: $companyId,
+            ozonUuid: Uuid::uuid7()->toString(),
+            dateFrom: new \DateTimeImmutable('2026-04-01'),
+            dateTo: new \DateTimeImmutable('2026-04-01'),
+            campaignIds: ['12345'],
+            jobId: $jobId,
+        );
+
+        $ref = new \ReflectionClass($report);
+
+        $requestedProp = $ref->getProperty('requestedAt');
+        $requestedProp->setAccessible(true);
+        $requestedProp->setValue($report, new \DateTimeImmutable($requestedAt));
+
+        if (null !== $finalizedAt) {
+            $finalizedProp = $ref->getProperty('finalizedAt');
+            $finalizedProp->setAccessible(true);
+            $finalizedProp->setValue($report, new \DateTimeImmutable($finalizedAt));
+
+            $stateProp = $ref->getProperty('state');
+            $stateProp->setAccessible(true);
+            $stateProp->setValue($report, OzonAdPendingReportState::OK);
+        }
+
+        $this->em->persist($report);
+
+        return $report;
     }
 
     private function seedJob(int $index = 1): AdLoadJob


### PR DESCRIPTION
## Summary
Adds a new repository method `findInFlightByCompany()` to retrieve all non-finalized (in-flight) pending reports for a given company, ordered by request time. This method supports the upcoming poll-cron command for bulk-fetching report statistics.

## Key Changes
- **New Repository Method**: `findInFlightByCompany(string $companyId): array`
  - Filters reports by company ID and `finalized_at IS NULL` condition
  - Orders results by `requestedAt ASC` to process older requests first
  - Validates company ID as UUID using `Assert::uuid()`
  - Intentionally excludes state-based filtering to avoid duplicating termination logic

- **Comprehensive Test Coverage**: Added three test cases
  - `testFindInFlightByCompanyReturnsOnlyNonFinalizedRowsForTheCompany()`: Verifies correct filtering and ordering across multiple companies
  - `testFindInFlightByCompanyReturnsEmptyArrayWhenCompanyHasNoInFlightReports()`: Validates empty result handling
  - `testFindInFlightByCompanyRejectsNonUuidCompanyId()`: Ensures UUID validation

- **Test Helper**: Added `persistPendingReport()` helper method using reflection to set immutable `requestedAt` and `finalizedAt` fields for test fixtures

- **Documentation**: Updated ARCHITECTURE.md with method signature and usage notes

## Implementation Details
- Uses Doctrine QueryBuilder with explicit filtering on `finalized_at IS NULL` as the single source of truth for in-flight status
- Designed for bulk-fetching statistics via `GET /api/client/statistics/list` endpoint (step 3 of redesign plan)
- Follows existing repository patterns and includes detailed docblock explaining design decisions

https://claude.ai/code/session_01P6dp3iuw52mWRaxivfWRFs