### PR TITLE
Add async download handler for Ozon Performance reports

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -449,6 +449,10 @@ markFinalized(
 // Загрузка с IDOR-проверкой
 findByOzonUuid(string $companyId, string $ozonUuid): ?OzonAdPendingReport
 
+// IDOR-safe lookup по PK + companyId. Используется async-download handler'ом
+// (step 4 redesign): Messenger-payload несёт pending report ID + companyId.
+findByIdAndCompany(string $id, string $companyId): ?OzonAdPendingReport
+
 // Все in-flight (REQUESTED / NOT_STARTED / IN_PROGRESS) записи конкретного job'а.
 // Для resume-логики (задача 3): Messenger-retry handler получает список UUID,
 // по которым нужно продолжать polling вместо нового POST /statistics.
@@ -528,7 +532,8 @@ Per-company state machine для shared-polling'а. `__invoke(companyId, now): P
    - `UUID` отсутствует в ответе + age ≥ 1h → `markFinalized(ABANDONED)`;
    - отсутствует + age < 1h → `updateSchedule` с backoff `next_poll_at`;
    - raw state ∈ {OK, READY} → `updateStateWithSchedule(OK, nextPollAt=null)`
-     (download + финализацию делает step 4, не этот сервис);
+     + dispatch `DownloadOzonAdReportMessage` в `async_pipeline` (download +
+     финализацию делает `DownloadOzonAdReportHandler`);
    - raw state ∈ {ERROR, CANCELLED, NOT_FOUND} → `markFinalized(ERROR, rawState в message)`;
    - остальное (NOT_STARTED, IN_PROGRESS и пр.) → `updateStateWithSchedule(rawState, next backoff)`.
 
@@ -551,6 +556,75 @@ app:marketplace-ads:ozon-poll-reports [--company-id=UUID] [--dry-run]
 
 **Не подключена к cron** в step 3/5. Step 5 добавит её в `docker/cron/app.cron`.
 До тех пор запуск только ручной: `docker exec site-php-cli php bin/console app:marketplace-ads:ozon-poll-reports`.
+
+### `OzonAdClient::downloadAndConvertReport` (`src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php`)
+```php
+// Скачивает готовый (state=OK/READY) Ozon-отчёт по UUID и конвертирует CSV
+// в структуру date => ['campaigns' => [...]] (совместимо с shape'ом
+// fetchAdStatisticsRange()). НЕ опрашивает state и НЕ спит: предполагается,
+// что caller (poll-cron → DownloadOzonAdReportHandler) уже знает, что отчёт
+// готов. Один GET /statistics/{uuid} за свежей ссылкой + GET report + парсинг.
+// 401 → один refresh-токен retry (withAuthRetry).
+// namesById намеренно пустой: campaign_name приходит отдельной колонкой CSV;
+// листинг кампаний стоит лишнего HTTP и не улучшает качество fallback'а.
+// @param list<string> $campaignIds — только для логирования контекста
+// @return array{downloads: list<OzonReportDownload>, resultByDate: array<string, array{campaigns: list<array{...}>}>}
+// @throws OzonPermanentApiException 403 / missing credentials
+// @throws \RuntimeException         не-готовый state / прочие non-2xx / network / JSON
+downloadAndConvertReport(
+    string $companyId,
+    string $reportUuid,
+    array $campaignIds = [],
+): array
+```
+
+### `DownloadOzonAdReportMessage` (`src/MarketplaceAds/Message/DownloadOzonAdReportMessage.php`)
+
+Scalar-only Messenger-сообщение: `(companyId, pendingReportId)`. Диспатчится
+`OzonAdReportPoller` при переходе pending-отчёта в state=OK/READY.
+Routing: `async_pipeline` (retry 3× 5s/10s/20s).
+
+### `DownloadOzonAdReportHandler` (`src/MarketplaceAds/MessageHandler/DownloadOzonAdReportHandler.php`)
+
+Async-обработчик `DownloadOzonAdReportMessage`. Завершает ингест готового
+отчёта:
+1. `pendingRepo->findByIdAndCompany(pendingReportId, companyId)` — IDOR-safe
+   load; если null или `finalizedAt !== null` → идемпотентный no-op ACK.
+2. `OzonAdClient::downloadAndConvertReport()` — скачивает CSV, конвертирует
+   в date-keyed результат.
+3. За каждый день результата — upsert `AdRawDocument` (новый → `save()`,
+   существующий → `updatePayload()`).
+4. Bronze: `StorageService::storeBytes()` один раз (один UUID = один физический
+   файл), `setFileStorage()` на каждом документе.
+5. `em->flush()` — персист + bronze metadata одним запросом.
+6. `pendingRepo->markFinalized(OK)` — guard `finalized_at IS NULL` делает
+   операцию идемпотентной.
+7. `dispatch(ProcessAdRawDocumentMessage)` за каждый документ — строго ПОСЛЕ
+   `flush()`, иначе per-document handler может не найти документ в БД.
+
+Политика ошибок:
+- `OzonPermanentApiException` (403, missing creds) → `markFinalized(ERROR)`
+  + `UnrecoverableMessageHandlingException` (не ретраит).
+- Прочие `\Throwable` (5xx, сеть) → rethrow, Messenger ретраит по
+  `async_pipeline`-schedule.
+- Not-found / already-finalized — не ошибки, ACK.
+
+Handler НЕ вызывает `AdLoadJobFinalizer::tryFinalize()` — это ответственность
+`ProcessAdRawDocumentHandler` (единственный источник правды по счётчикам job'а).
+
+Поток:
+```
+OzonAdReportPoller (state=OK)
+  └─ dispatch DownloadOzonAdReportMessage ─→ async_pipeline
+       └─ DownloadOzonAdReportHandler
+            ├─ OzonAdClient::downloadAndConvertReport
+            ├─ upsert AdRawDocument per day
+            ├─ StorageService::storeBytes (bronze)
+            ├─ em->flush
+            ├─ pendingRepo->markFinalized(OK)
+            └─ dispatch ProcessAdRawDocumentMessage ─→ async_pipeline
+                 └─ ProcessAdRawDocumentHandler (fan-out per day)
+```
 
 ---
 

--- a/site/config/packages/messenger.yaml
+++ b/site/config/packages/messenger.yaml
@@ -60,6 +60,7 @@ framework:
             'App\Message\EnqueueAutoRulesForRange': async_pipeline
             'App\MarketplaceAnalytics\Message\RecalcSnapshotsMessage': async_pipeline
             'App\MarketplaceAds\Message\ProcessAdRawDocumentMessage': async_pipeline
+            'App\MarketplaceAds\Message\DownloadOzonAdReportMessage': async_pipeline
 
             # --- async_ads: Ozon Performance polling (may block up to 10 min per message) ---
             'App\MarketplaceAds\Message\LoadOzonAdStatisticsRangeMessage': async_ads

--- a/site/src/MarketplaceAds/Application/Service/OzonAdReportPoller.php
+++ b/site/src/MarketplaceAds/Application/Service/OzonAdReportPoller.php
@@ -9,9 +9,11 @@ use App\MarketplaceAds\Entity\OzonAdPendingReport;
 use App\MarketplaceAds\Enum\OzonAdPendingReportState;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonAdClient;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonPermanentApiException;
+use App\MarketplaceAds\Message\DownloadOzonAdReportMessage;
 use App\MarketplaceAds\Repository\OzonAdPendingReportRepository;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
  * Один опрос Ozon Performance /statistics/list на компанию и перевод всех её
@@ -55,6 +57,7 @@ final class OzonAdReportPoller
     public function __construct(
         private readonly OzonAdClient $client,
         private readonly OzonAdPendingReportRepository $repo,
+        private readonly MessageBusInterface $bus,
         #[Autowire(service: 'monolog.logger.marketplace_ads')]
         private readonly LoggerInterface $logger,
     ) {
@@ -171,7 +174,8 @@ final class OzonAdReportPoller
 
         if ($this->isTerminalOk($normalizedUpper)) {
             // OK/READY → фиксируем state=OK, гасим next_poll_at (дальше не
-            // опрашиваем). markFinalized делает step 4 после скачивания CSV.
+            // опрашиваем). markFinalized делает DownloadOzonAdReportHandler
+            // после скачивания CSV.
             $this->repo->updateStateWithSchedule(
                 $companyId,
                 $uuid,
@@ -181,6 +185,14 @@ final class OzonAdReportPoller
                 $nextAttempts,
                 $now,
             );
+
+            // Handoff в async_pipeline: handler сам забирает CSV, upsert'ит
+            // AdRawDocument, финализирует pending-отчёт. Dispatch безопасно
+            // повторный — handler идемпотентен через finalized_at check.
+            $this->bus->dispatch(new DownloadOzonAdReportMessage(
+                companyId: $companyId,
+                pendingReportId: $row->getId(),
+            ));
 
             return [1, 0];
         }

--- a/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
+++ b/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
@@ -474,6 +474,141 @@ class OzonAdClient implements AdPlatformClientInterface
     }
 
     /**
+     * Скачивает готовый отчёт Ozon Performance по UUID и конвертирует CSV в
+     * структуру, сгруппированную по дате (совместимо с shape'ом
+     * {@see fetchAdStatisticsRange()} — date => ['campaigns' => [...]]).
+     *
+     * Используется в async-poll flow (step 4 redesign): poll-cron наблюдает
+     * state=OK на pending-отчёте и хэндит off на DownloadOzonAdReportHandler,
+     * который вызывает этот метод, чтобы завершить ингест без повторного
+     * POST /statistics и без внутреннего polling-цикла.
+     *
+     * НЕ опрашивает state и НЕ спит: вызывающий код уже знает, что state
+     * терминальный OK. Делает один GET /statistics/{uuid} ради свежей
+     * download-ссылки (Ozon link может содержать signed-expiration), затем
+     * GET download + парсинг CSV. 401 на любом шаге — один refresh-токен
+     * retry (withAuthRetry).
+     *
+     * namesById умышленно остаётся пустым: в новом Ozon-формате
+     * campaign_name приходит отдельной колонкой CSV (см. convertCsvToRowsByDate),
+     * а вызывать listSkuCampaigns() стоит одного лишнего HTTP-запроса и
+     * не улучшает качество — если кампания переименована/удалена с момента
+     * запроса, любой fallback всё равно неточен. Parser graceful degrade'ит
+     * до пустого campaign_name.
+     *
+     * НЕ трогает $this->lastChunkDownloads — bronze в async-flow'е пишет
+     * handler сам из возвращаемого `downloads` массива.
+     *
+     * @param list<string> $campaignIds Используются только для логирования контекста.
+     *
+     * @return array{
+     *     downloads: list<OzonReportDownload>,
+     *     resultByDate: array<string, array{campaigns: list<array{
+     *         campaign_id: string,
+     *         campaign_name: string,
+     *         rows: list<array{sku: string, spend: string, views: int, clicks: int}>,
+     *     }>}>,
+     * }
+     *
+     * @throws OzonPermanentApiException 403 / отсутствующие credentials
+     * @throws \RuntimeException         отчёт не в ready-состоянии или прочие non-2xx / network / JSON-ошибки
+     */
+    public function downloadAndConvertReport(
+        string $companyId,
+        string $reportUuid,
+        array $campaignIds = [],
+    ): array {
+        $credentials = $this->resolveCredentials($companyId);
+        $clientId = $credentials['client_id'];
+        $clientSecret = $credentials['client_secret'];
+
+        $startedAt = microtime(true);
+
+        $this->marketplaceAdsLogger->info('Ozon async-download: начало', [
+            'companyId' => $companyId,
+            'reportUuid' => $reportUuid,
+            'campaignCount' => count($campaignIds),
+        ]);
+
+        $link = $this->withAuthRetry(
+            $companyId,
+            $clientId,
+            $clientSecret,
+            fn (string $token): string => $this->fetchReadyReportLink($token, $reportUuid),
+        );
+
+        $download = $this->withAuthRetry(
+            $companyId,
+            $clientId,
+            $clientSecret,
+            fn (string $token): OzonReportDownload => $this->downloadReport($token, $link, $reportUuid),
+        );
+
+        $byDate = $this->convertCsvToRowsByDate($download->csvParts, []);
+
+        // ksort для детерминированного порядка дней в логах и downstream-коде.
+        ksort($byDate);
+
+        $resultByDate = [];
+        foreach ($byDate as $date => $campaignsMap) {
+            $resultByDate[$date] = ['campaigns' => array_values($campaignsMap)];
+        }
+
+        $rowsCount = 0;
+        foreach ($byDate as $campaignsMap) {
+            foreach ($campaignsMap as $campaign) {
+                $rowsCount += count($campaign['rows']);
+            }
+        }
+
+        $this->marketplaceAdsLogger->info('Ozon async-download: завершено', [
+            'companyId' => $companyId,
+            'reportUuid' => $reportUuid,
+            'daysFound' => count($resultByDate),
+            'rowsCount' => $rowsCount,
+            'durationMs' => (int) round((microtime(true) - $startedAt) * 1000),
+        ]);
+
+        return [
+            'downloads' => [$download],
+            'resultByDate' => $resultByDate,
+        ];
+    }
+
+    /**
+     * Возвращает download-link готового отчёта. Если Ozon сообщает
+     * non-ready state, бросает \RuntimeException — caller (poll-cron)
+     * уже видел OK и рассинхрон state'ов = диагностика.
+     */
+    private function fetchReadyReportLink(string $token, string $uuid): string
+    {
+        $response = $this->authorizedRequest(
+            'GET',
+            sprintf(self::STATISTICS_STATE_PATH, rawurlencode($uuid)),
+            $token,
+        );
+        $data = $this->decodeJson($response->getContent(false), 'statistics state (async download)');
+
+        $state = strtoupper($this->stringifyApiField($data['state'] ?? null));
+        if ('OK' !== $state && 'READY' !== $state) {
+            throw new \RuntimeException(sprintf(
+                'Ozon Performance: downloadAndConvertReport вызван для отчёта %s в не-готовом state=%s',
+                $uuid,
+                $state,
+            ));
+        }
+
+        $link = $this->stringifyApiField($data['link'] ?? $data['report']['link'] ?? null);
+        if ('' === $link) {
+            // Старые версии API не отдают link отдельно — отчёт скачивается
+            // по фиксированному /report?UUID=…
+            $link = self::STATISTICS_REPORT_PATH.'?UUID='.rawurlencode($uuid);
+        }
+
+        return $link;
+    }
+
+    /**
      * @return list<array<string, mixed>>
      */
     private function fetchStatisticsListPage(string $token, int $page, int $pageSize): array

--- a/site/src/MarketplaceAds/Message/DownloadOzonAdReportMessage.php
+++ b/site/src/MarketplaceAds/Message/DownloadOzonAdReportMessage.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Message;
+
+/**
+ * Асинхронное сообщение на скачивание готового отчёта Ozon Performance.
+ *
+ * Диспатчится {@see \App\MarketplaceAds\Application\Service\OzonAdReportPoller},
+ * когда poll-cron наблюдает переход pending-отчёта в state=OK. Handler
+ * {@see \App\MarketplaceAds\MessageHandler\DownloadOzonAdReportHandler}
+ * забирает CSV из Ozon, делает upsert AdRawDocument за каждый день,
+ * финализирует pending-отчёт и диспатчит ProcessAdRawDocumentMessage
+ * за каждый созданный/обновлённый документ.
+ *
+ * Scalar-only payload (только companyId + pendingReportId): весь остальной
+ * контекст (ozonUuid, dateFrom/dateTo, campaignIds, jobId) resolve'ится
+ * по pendingReportId в БД. Это Messenger-safe (сериализуемо) и защищает
+ * от расхождения сообщения с entity при retry.
+ *
+ * companyId дублируется в payload'е для IDOR defense-in-depth: handler
+ * ре-проверяет, что загружаемый pending-отчёт действительно принадлежит
+ * переданной компании.
+ */
+final readonly class DownloadOzonAdReportMessage
+{
+    public function __construct(
+        public string $companyId,
+        public string $pendingReportId,
+    ) {
+    }
+}

--- a/site/src/MarketplaceAds/MessageHandler/DownloadOzonAdReportHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/DownloadOzonAdReportHandler.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\MessageHandler;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAds\Entity\AdRawDocument;
+use App\MarketplaceAds\Enum\OzonAdPendingReportState;
+use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonAdClient;
+use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonPermanentApiException;
+use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonReportDownload;
+use App\MarketplaceAds\Message\DownloadOzonAdReportMessage;
+use App\MarketplaceAds\Message\ProcessAdRawDocumentMessage;
+use App\MarketplaceAds\Repository\AdRawDocumentRepository;
+use App\MarketplaceAds\Repository\OzonAdPendingReportRepository;
+use App\Shared\Service\Storage\StorageService;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * Async-обработчик {@see DownloadOzonAdReportMessage}.
+ *
+ * Диспатчится {@see \App\MarketplaceAds\Application\Service\OzonAdReportPoller}
+ * после перехода pending-отчёта в state=OK/READY. Ответственность
+ * handler'а — завершить ингест отчёта:
+ *  1) загрузить pending-отчёт IDOR-safe (findByIdAndCompany);
+ *  2) идемпотентно no-op'нуть, если отчёт уже финализирован (retry / race
+ *     с параллельным воркером);
+ *  3) скачать CSV через {@see OzonAdClient::downloadAndConvertReport()};
+ *  4) upsert AdRawDocument'ов за каждый день из отчёта;
+ *  5) сохранить bronze-файл (один отчёт = один download = одна запись bronze);
+ *  6) flush UoW (persist + bronze-metadata) одним запросом;
+ *  7) markFinalized(OK) на pending-отчёте;
+ *  8) диспатч ProcessAdRawDocumentMessage за каждый созданный/обновлённый
+ *     документ (fan-out строго ПОСЛЕ flush, иначе per-document handler
+ *     может стартовать до появления документа в БД).
+ *
+ * Политика ошибок:
+ *  - OzonPermanentApiException (403, missing credentials): permanent denial →
+ *    markFinalized(ERROR) + UnrecoverableMessageHandlingException (не ретраит).
+ *  - Прочие \Throwable (5xx, сеть, JSON-ошибки): transient → rethrow, Messenger
+ *    ретраит по async_pipeline schedule (3× × 5/10/20s).
+ *  - "Already finalized" / "not found" кейсы — не ошибки, просто no-op ACK.
+ *
+ * Handler НЕ вызывает AdLoadJobFinalizer::tryFinalize(): финализация
+ * привязана к per-document processing (ProcessAdRawDocumentHandler) —
+ * дублировать вызов здесь сломало бы единственный-источник-правды инвариант
+ * про счётчики AdLoadJob.
+ */
+#[AsMessageHandler]
+final class DownloadOzonAdReportHandler
+{
+    public function __construct(
+        private readonly OzonAdPendingReportRepository $pendingRepo,
+        private readonly AdRawDocumentRepository $rawRepo,
+        private readonly OzonAdClient $client,
+        private readonly EntityManagerInterface $em,
+        private readonly MessageBusInterface $bus,
+        private readonly StorageService $storageService,
+        #[Autowire(service: 'monolog.logger.marketplace_ads')]
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(DownloadOzonAdReportMessage $message): void
+    {
+        $now = new \DateTimeImmutable();
+
+        $pending = $this->pendingRepo->findByIdAndCompany(
+            $message->pendingReportId,
+            $message->companyId,
+        );
+
+        if (null === $pending) {
+            // Запись удалена или companyId не совпадает (IDOR-guard). Не ошибка —
+            // ACK и выходим: возможно, оператор вручную удалил pending-отчёт
+            // или мы ловим чужой message из сломанной очереди.
+            $this->logger->warning('DownloadOzonAdReportMessage: pending-отчёт не найден или принадлежит другой company, сообщение проигнорировано', [
+                'pendingReportId' => $message->pendingReportId,
+                'companyId' => $message->companyId,
+            ]);
+
+            return;
+        }
+
+        if (null !== $pending->getFinalizedAt()) {
+            // Уже обработан — идемпотентный no-op. Покрывает две гонки:
+            //  - Messenger retry после успешного прогона (commit прошёл,
+            //    ACK не дошёл до брокера → re-delivery того же message);
+            //  - параллельный worker увидел тот же state=OK и уже всё скачал.
+            $this->logger->info('DownloadOzonAdReportMessage: pending-отчёт уже финализирован, download пропущен', [
+                'pendingReportId' => $pending->getId(),
+                'companyId' => $pending->getCompanyId(),
+                'reportUuid' => $pending->getOzonUuid(),
+                'state' => $pending->getState(),
+            ]);
+
+            return;
+        }
+
+        try {
+            $result = $this->client->downloadAndConvertReport(
+                $pending->getCompanyId(),
+                $pending->getOzonUuid(),
+                $pending->getCampaignIds(),
+            );
+        } catch (OzonPermanentApiException $e) {
+            // 403 / отсутствующие credentials — ретрай не поможет. Финализируем
+            // pending-отчёт как ERROR и бросаем Unrecoverable, чтобы Messenger
+            // не возвращал message в очередь.
+            $this->pendingRepo->markFinalized(
+                $pending->getCompanyId(),
+                $pending->getOzonUuid(),
+                OzonAdPendingReportState::ERROR,
+                'Download permanent failure: '.$e->getMessage(),
+            );
+
+            $this->logger->warning('DownloadOzonAdReportMessage: permanent Ozon API denial', [
+                'pendingReportId' => $pending->getId(),
+                'companyId' => $pending->getCompanyId(),
+                'reportUuid' => $pending->getOzonUuid(),
+                'error' => $e->getMessage(),
+            ]);
+
+            throw new UnrecoverableMessageHandlingException(
+                'DownloadOzonAdReportMessage: Ozon permanent failure — '.$e->getMessage(),
+                0,
+                $e,
+            );
+        }
+
+        /** @var array<string, array{campaigns: list<array{campaign_id: string, campaign_name: string, rows: list<array{sku: string, spend: string, views: int, clicks: int}>}>}> $resultByDate */
+        $resultByDate = $result['resultByDate'];
+        /** @var list<OzonReportDownload> $downloads */
+        $downloads = $result['downloads'];
+
+        /** @var list<AdRawDocument> $documents */
+        $documents = [];
+        $skippedDays = 0;
+
+        foreach ($resultByDate as $dateString => $payload) {
+            $reportDate = \DateTimeImmutable::createFromFormat('!Y-m-d', (string) $dateString);
+            if (false === $reportDate) {
+                ++$skippedDays;
+                $this->logger->error('DownloadOzonAdReportMessage: invalid date key in Ozon result, day skipped', [
+                    'pendingReportId' => $pending->getId(),
+                    'companyId' => $pending->getCompanyId(),
+                    'dateKey' => $dateString,
+                ]);
+                continue;
+            }
+
+            $json = json_encode($payload, \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES);
+            if (false === $json) {
+                ++$skippedDays;
+                $this->logger->error('DownloadOzonAdReportMessage: json_encode failed for day payload, day skipped', [
+                    'pendingReportId' => $pending->getId(),
+                    'companyId' => $pending->getCompanyId(),
+                    'date' => $reportDate->format('Y-m-d'),
+                    'jsonError' => json_last_error_msg(),
+                ]);
+                continue;
+            }
+
+            $existing = $this->rawRepo->findByMarketplaceAndDate(
+                $pending->getCompanyId(),
+                MarketplaceType::OZON->value,
+                $reportDate,
+            );
+
+            if (null === $existing) {
+                $doc = new AdRawDocument(
+                    $pending->getCompanyId(),
+                    MarketplaceType::OZON,
+                    $reportDate,
+                    $json,
+                );
+                $this->rawRepo->save($doc);
+                $documents[] = $doc;
+            } else {
+                // updatePayload() сам сбрасывает status в DRAFT — см. паттерн
+                // в FetchOzonAdStatisticsHandler::__invoke().
+                $existing->updatePayload($json);
+                $documents[] = $existing;
+            }
+        }
+
+        // Bronze-слой: один download = один физический файл, все документы
+        // отчёта ссылаются на него (file_hash / file_size одинаковый).
+        // Для async-poll invariant "один UUID = один download" соблюдается
+        // по построению (poll-cron не батчит, один UUID = один Ozon-отчёт).
+        if (1 === count($downloads) && [] !== $documents) {
+            $firstDownload = $downloads[0];
+            $extension = $firstDownload->wasZip ? 'zip' : 'csv';
+            $relativePath = sprintf(
+                'companies/%s/marketplace-ads/ozon/bronze/%s/%s.%s',
+                $pending->getCompanyId(),
+                $pending->getDateFrom()->format('Y-m-d'),
+                $firstDownload->reportUuid,
+                $extension,
+            );
+
+            $stored = $this->storageService->storeBytes($firstDownload->rawBytes, $relativePath);
+            $size = (int) $stored['sizeBytes'];
+
+            foreach ($documents as $doc) {
+                $doc->setFileStorage($stored['storagePath'], $stored['fileHash'], $size);
+            }
+
+            $this->logger->info('DownloadOzonAdReportMessage: bronze-файл сохранён', [
+                'pendingReportId' => $pending->getId(),
+                'companyId' => $pending->getCompanyId(),
+                'reportUuid' => $firstDownload->reportUuid,
+                'storagePath' => $stored['storagePath'],
+                'sizeBytes' => $size,
+                'wasZip' => $firstDownload->wasZip,
+                'documentsLinked' => count($documents),
+            ]);
+        } elseif (1 !== count($downloads)) {
+            // downloadAndConvertReport гарантирует ровно один download, но
+            // логируем на случай регрессии контракта (например, если в
+            // будущем client начнёт re-batch'ить).
+            $this->logger->warning('DownloadOzonAdReportMessage: unexpected multi-batch download in async flow', [
+                'pendingReportId' => $pending->getId(),
+                'batchCount' => count($downloads),
+            ]);
+        }
+
+        // Единый flush для persist новых AdRawDocument + bronze metadata.
+        // ОБЯЗАН завершиться до dispatch ProcessAdRawDocumentMessage — иначе
+        // per-document handler может не найти документ в БД (race-condition).
+        $this->em->flush();
+
+        // Финализируем pending-отчёт: OK без errorMessage. markFinalized()
+        // идемпотентен (guard `finalized_at IS NULL`), так что при повторном
+        // дисптаче этой цепочки вызов просто вернёт 0 affected rows.
+        $this->pendingRepo->markFinalized(
+            $pending->getCompanyId(),
+            $pending->getOzonUuid(),
+            OzonAdPendingReportState::OK,
+        );
+
+        foreach ($documents as $doc) {
+            $this->bus->dispatch(new ProcessAdRawDocumentMessage(
+                $pending->getCompanyId(),
+                $doc->getId(),
+            ));
+        }
+
+        $this->logger->info('DownloadOzonAdReportMessage: отчёт обработан', [
+            'pendingReportId' => $pending->getId(),
+            'companyId' => $pending->getCompanyId(),
+            'reportUuid' => $pending->getOzonUuid(),
+            'documentsUpserted' => count($documents),
+            'daysSkipped' => $skippedDays,
+            'processedAt' => $now->format('Y-m-d H:i:s'),
+        ]);
+    }
+}

--- a/site/src/MarketplaceAds/Repository/OzonAdPendingReportRepository.php
+++ b/site/src/MarketplaceAds/Repository/OzonAdPendingReportRepository.php
@@ -318,6 +318,23 @@ class OzonAdPendingReportRepository extends ServiceEntityRepository
     }
 
     /**
+     * IDOR-safe lookup по PK + companyId.
+     *
+     * Используется async-download handler'ом (step 4): Messenger-payload
+     * несёт pending report ID и companyId; handler resolve'ит entity по
+     * обоим полям, чтобы чужая company никаким способом (подмена id в
+     * очереди, повтор retry после смены владельца) не получила доступ к
+     * pending-отчёту.
+     */
+    public function findByIdAndCompany(string $id, string $companyId): ?OzonAdPendingReport
+    {
+        Assert::uuid($id);
+        Assert::uuid($companyId);
+
+        return $this->findOneBy(['id' => $id, 'companyId' => $companyId]);
+    }
+
+    /**
      * Все in-flight записи (REQUESTED / NOT_STARTED / IN_PROGRESS) для конкретного job'а.
      * Пригодится для задачи 3 (resume on Messenger retry): handler при повторном
      * запуске получит список UUID, по которым надо продолжать polling вместо

--- a/site/tests/Integration/MarketplaceAds/MessageHandler/DownloadOzonAdReportHandlerTest.php
+++ b/site/tests/Integration/MarketplaceAds/MessageHandler/DownloadOzonAdReportHandlerTest.php
@@ -1,0 +1,284 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\MarketplaceAds\MessageHandler;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAds\Entity\AdRawDocument;
+use App\MarketplaceAds\Entity\OzonAdPendingReport;
+use App\MarketplaceAds\Enum\OzonAdPendingReportState;
+use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonAdClient;
+use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonReportDownload;
+use App\MarketplaceAds\Message\DownloadOzonAdReportMessage;
+use App\MarketplaceAds\Message\ProcessAdRawDocumentMessage;
+use App\MarketplaceAds\MessageHandler\DownloadOzonAdReportHandler;
+use App\MarketplaceAds\Repository\AdRawDocumentRepository;
+use App\MarketplaceAds\Repository\OzonAdPendingReportRepository;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Messenger\Transport\InMemoryTransport;
+
+/**
+ * End-to-end тесты {@see DownloadOzonAdReportHandler}: boot kernel + реальный
+ * Postgres + in-memory Messenger transport + mocked OzonAdClient.
+ *
+ * Покрываются:
+ *  - happy path: pending OK → AdRawDocument upsert, bronze metadata, pending
+ *    финализирован OK, ProcessAdRawDocumentMessage в async_pipeline transport;
+ *  - идемпотентность: повторный запуск на том же pendingReportId — no-op
+ *    (finalized_at guard блокирует повторный download).
+ */
+final class DownloadOzonAdReportHandlerTest extends IntegrationTestCase
+{
+    private OzonAdPendingReportRepository $pendingRepo;
+    private AdRawDocumentRepository $rawRepo;
+    /** @var OzonAdClient&MockObject */
+    private OzonAdClient $clientMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->pendingRepo = self::getContainer()->get(OzonAdPendingReportRepository::class);
+        $this->rawRepo = self::getContainer()->get(AdRawDocumentRepository::class);
+
+        $this->clientMock = $this->createMock(OzonAdClient::class);
+        self::getContainer()->set(OzonAdClient::class, $this->clientMock);
+
+        /** @var InMemoryTransport $transport */
+        $transport = self::getContainer()->get('messenger.transport.async_pipeline');
+        $transport->reset();
+    }
+
+    public function testEndToEndDownloadUpsertsRawDocumentAndDispatchesProcessing(): void
+    {
+        $company = $this->seedCompany();
+        $this->em->flush();
+
+        $pending = $this->seedPendingReport($company->getId(), ozonUuid: 'uuid-happy');
+        $this->em->flush();
+        $pendingId = $pending->getId();
+
+        $download = new OzonReportDownload(
+            rawBytes: 'date;sku;spend;views;clicks',
+            csvContent: 'date;sku;spend;views;clicks',
+            csvParts: ['date;sku;spend;views;clicks'],
+            wasZip: false,
+            sizeBytes: 28,
+            sha256: hash('sha256', 'date;sku;spend;views;clicks'),
+            reportUuid: 'uuid-happy',
+            filesInZip: 0,
+        );
+
+        $this->clientMock
+            ->method('downloadAndConvertReport')
+            ->with($company->getId(), 'uuid-happy', ['CAMP-1'])
+            ->willReturn([
+                'downloads' => [$download],
+                'resultByDate' => [
+                    '2026-04-01' => ['campaigns' => [[
+                        'campaign_id' => 'CAMP-1',
+                        'campaign_name' => 'Camp 1',
+                        'rows' => [['sku' => 'SKU-1', 'spend' => '10.00', 'views' => 5, 'clicks' => 1]],
+                    ]]],
+                    '2026-04-02' => ['campaigns' => [[
+                        'campaign_id' => 'CAMP-1',
+                        'campaign_name' => 'Camp 1',
+                        'rows' => [['sku' => 'SKU-1', 'spend' => '20.00', 'views' => 10, 'clicks' => 2]],
+                    ]]],
+                ],
+            ]);
+
+        $handler = self::getContainer()->get(DownloadOzonAdReportHandler::class);
+
+        $handler(new DownloadOzonAdReportMessage(
+            companyId: $company->getId(),
+            pendingReportId: $pendingId,
+        ));
+
+        $this->em->clear();
+
+        // 1) Pending-отчёт финализирован OK.
+        $finalized = $this->pendingRepo->findByOzonUuid($company->getId(), 'uuid-happy');
+        self::assertNotNull($finalized);
+        self::assertSame(OzonAdPendingReportState::OK, $finalized->getState());
+        self::assertNotNull($finalized->getFinalizedAt(), 'pending-отчёт обязан быть финализирован');
+
+        // 2) За каждый день отчёта создан AdRawDocument + bronze metadata.
+        $docs = $this->rawRepo->findByCompanyMarketplaceAndDateRange(
+            $company->getId(),
+            MarketplaceType::OZON->value,
+            new \DateTimeImmutable('2026-04-01'),
+            new \DateTimeImmutable('2026-04-02'),
+        );
+        self::assertCount(2, $docs);
+        foreach ($docs as $doc) {
+            self::assertSame(MarketplaceType::OZON, $doc->getMarketplace());
+            self::assertNotNull($doc->getStoragePath(), 'bronze storage_path обязан быть заполнен');
+            self::assertNotNull($doc->getFileHash());
+            self::assertNotNull($doc->getFileSizeBytes());
+            self::assertStringContainsString($company->getId(), (string) $doc->getStoragePath());
+            self::assertStringContainsString('uuid-happy', (string) $doc->getStoragePath());
+        }
+
+        // 3) ProcessAdRawDocumentMessage задиспатчен за каждый документ.
+        /** @var InMemoryTransport $transport */
+        $transport = self::getContainer()->get('messenger.transport.async_pipeline');
+        $envelopes = $transport->get();
+        $messages = array_map(static fn ($envelope) => $envelope->getMessage(), iterator_to_array($envelopes));
+        self::assertCount(2, $messages);
+        foreach ($messages as $message) {
+            self::assertInstanceOf(ProcessAdRawDocumentMessage::class, $message);
+            self::assertSame($company->getId(), $message->companyId);
+        }
+
+        $dispatchedDocIds = array_map(static fn (ProcessAdRawDocumentMessage $m) => $m->adRawDocumentId, $messages);
+        $actualDocIds = array_map(static fn (AdRawDocument $d) => $d->getId(), $docs);
+        sort($dispatchedDocIds);
+        sort($actualDocIds);
+        self::assertSame($actualDocIds, $dispatchedDocIds, 'dispatch должен покрывать ровно созданные документы');
+    }
+
+    public function testSecondInvocationIsNoopWhenAlreadyFinalized(): void
+    {
+        $company = $this->seedCompany();
+        $this->em->flush();
+
+        $pending = $this->seedPendingReport($company->getId(), ozonUuid: 'uuid-race');
+        $this->em->flush();
+        $pendingId = $pending->getId();
+
+        $this->clientMock->expects(self::once())
+            ->method('downloadAndConvertReport')
+            ->willReturn([
+                'downloads' => [new OzonReportDownload(
+                    rawBytes: 'b',
+                    csvContent: 'b',
+                    csvParts: ['b'],
+                    wasZip: false,
+                    sizeBytes: 1,
+                    sha256: hash('sha256', 'b'),
+                    reportUuid: 'uuid-race',
+                    filesInZip: 0,
+                )],
+                'resultByDate' => [
+                    '2026-04-01' => ['campaigns' => [[
+                        'campaign_id' => 'CAMP-1',
+                        'campaign_name' => 'N',
+                        'rows' => [['sku' => 'S', 'spend' => '1.00', 'views' => 1, 'clicks' => 1]],
+                    ]]],
+                ],
+            ]);
+
+        $handler = self::getContainer()->get(DownloadOzonAdReportHandler::class);
+
+        $message = new DownloadOzonAdReportMessage(
+            companyId: $company->getId(),
+            pendingReportId: $pendingId,
+        );
+
+        // Первый запуск — полноценный happy path.
+        $handler($message);
+
+        // Перед вторым запуском очищаем UoW, чтобы второй вызов шёл с чистым
+        // Doctrine identity map (реалистичный кейс Messenger retry после
+        // рестарта worker'а).
+        $this->em->clear();
+
+        // Второй запуск: clientMock настроен с expects(self::once()) — если
+        // handler попытается повторно вызвать download, тест упадёт. Проверка
+        // идемпотентности через finalized_at guard.
+        $handler($message);
+
+        $this->em->clear();
+
+        // Pending всё ещё финализирован OK.
+        $finalized = $this->pendingRepo->findByOzonUuid($company->getId(), 'uuid-race');
+        self::assertNotNull($finalized);
+        self::assertSame(OzonAdPendingReportState::OK, $finalized->getState());
+
+        // AdRawDocument остался ровно один (повторный upsert не создавал дубликат).
+        $docs = $this->rawRepo->findByCompanyMarketplaceAndDateRange(
+            $company->getId(),
+            MarketplaceType::OZON->value,
+            new \DateTimeImmutable('2026-04-01'),
+            new \DateTimeImmutable('2026-04-01'),
+        );
+        self::assertCount(1, $docs);
+    }
+
+    public function testForeignCompanyIdIsIgnored(): void
+    {
+        $company = $this->seedCompany();
+        $this->em->flush();
+
+        $pending = $this->seedPendingReport($company->getId(), ozonUuid: 'uuid-foreign');
+        $this->em->flush();
+        $pendingId = $pending->getId();
+
+        $this->clientMock->expects(self::never())->method('downloadAndConvertReport');
+
+        $handler = self::getContainer()->get(DownloadOzonAdReportHandler::class);
+
+        $handler(new DownloadOzonAdReportMessage(
+            companyId: '99999999-9999-9999-9999-999999999999',
+            pendingReportId: $pendingId,
+        ));
+
+        $this->em->clear();
+
+        // Pending-отчёт остался в исходном состоянии (OK, не финализирован).
+        $unchanged = $this->pendingRepo->findByOzonUuid($company->getId(), 'uuid-foreign');
+        self::assertNotNull($unchanged);
+        self::assertNull($unchanged->getFinalizedAt(), 'IDOR-guard: чужая company не должна финализировать pending-отчёт');
+    }
+
+    private function seedCompany(): Company
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $ownerId = Uuid::uuid7()->toString();
+
+        $owner = UserBuilder::aUser()
+            ->withId($ownerId)
+            ->withEmail(sprintf('download-handler+%s@example.test', substr($ownerId, -12)))
+            ->build();
+
+        $company = CompanyBuilder::aCompany()
+            ->withId($companyId)
+            ->withOwner($owner)
+            ->build();
+
+        $this->em->persist($owner);
+        $this->em->persist($company);
+
+        return $company;
+    }
+
+    private function seedPendingReport(
+        string $companyId,
+        string $ozonUuid,
+    ): OzonAdPendingReport {
+        $report = new OzonAdPendingReport(
+            companyId: $companyId,
+            ozonUuid: $ozonUuid,
+            dateFrom: new \DateTimeImmutable('2026-04-01'),
+            dateTo: new \DateTimeImmutable('2026-04-02'),
+            campaignIds: ['CAMP-1'],
+            jobId: null,
+        );
+
+        $ref = new \ReflectionClass($report);
+        $stateProp = $ref->getProperty('state');
+        $stateProp->setAccessible(true);
+        $stateProp->setValue($report, OzonAdPendingReportState::OK);
+
+        $this->em->persist($report);
+
+        return $report;
+    }
+}

--- a/site/tests/Unit/MarketplaceAds/Application/Service/OzonAdReportPollerTest.php
+++ b/site/tests/Unit/MarketplaceAds/Application/Service/OzonAdReportPollerTest.php
@@ -9,11 +9,14 @@ use App\MarketplaceAds\Entity\OzonAdPendingReport;
 use App\MarketplaceAds\Enum\OzonAdPendingReportState;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonAdClient;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonPermanentApiException;
+use App\MarketplaceAds\Message\DownloadOzonAdReportMessage;
 use App\MarketplaceAds\Repository\OzonAdPendingReportRepository;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Ramsey\Uuid\Uuid;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
  * Unit-тесты {@see OzonAdReportPoller}: per-company state-machine shared-polling'а.
@@ -37,16 +40,20 @@ final class OzonAdReportPollerTest extends TestCase
     private OzonAdClient $client;
     /** @var OzonAdPendingReportRepository&MockObject */
     private OzonAdPendingReportRepository $repo;
+    /** @var MessageBusInterface&MockObject */
+    private MessageBusInterface $bus;
     private OzonAdReportPoller $poller;
 
     protected function setUp(): void
     {
         $this->client = $this->createMock(OzonAdClient::class);
         $this->repo = $this->createMock(OzonAdPendingReportRepository::class);
+        $this->bus = $this->createMock(MessageBusInterface::class);
 
         $this->poller = new OzonAdReportPoller(
             $this->client,
             $this->repo,
+            $this->bus,
             new NullLogger(),
         );
     }
@@ -61,6 +68,7 @@ final class OzonAdReportPollerTest extends TestCase
             ->willReturn([]);
 
         $this->client->expects(self::never())->method('listReportsForCompany');
+        $this->bus->expects(self::never())->method('dispatch');
 
         $result = ($this->poller)(self::COMPANY_ID, $now);
 
@@ -91,6 +99,9 @@ final class OzonAdReportPollerTest extends TestCase
                 return 1;
             });
 
+        // 403 путь никогда не должен диспатчить download — row'ы финализированы ERROR.
+        $this->bus->expects(self::never())->method('dispatch');
+
         $result = ($this->poller)(self::COMPANY_ID, $now);
 
         self::assertSame(2, $result->seen);
@@ -111,6 +122,7 @@ final class OzonAdReportPollerTest extends TestCase
         $this->repo->expects(self::never())->method('markFinalized');
         $this->repo->expects(self::never())->method('updateSchedule');
         $this->repo->expects(self::never())->method('updateStateWithSchedule');
+        $this->bus->expects(self::never())->method('dispatch');
 
         $result = ($this->poller)(self::COMPANY_ID, $now);
 
@@ -143,6 +155,18 @@ final class OzonAdReportPollerTest extends TestCase
             )
             ->willReturn(1);
 
+        // OK путь обязан диспатчить DownloadOzonAdReportMessage c совпадающими
+        // companyId + pendingReportId (step 4 редизайна).
+        $this->bus->expects(self::once())
+            ->method('dispatch')
+            ->willReturnCallback(function (object $message) use ($r1): Envelope {
+                self::assertInstanceOf(DownloadOzonAdReportMessage::class, $message);
+                self::assertSame(self::COMPANY_ID, $message->companyId);
+                self::assertSame($r1->getId(), $message->pendingReportId);
+
+                return new Envelope($message);
+            });
+
         $result = ($this->poller)(self::COMPANY_ID, $now);
 
         self::assertSame(1, $result->seen);
@@ -163,6 +187,15 @@ final class OzonAdReportPollerTest extends TestCase
         $this->repo->expects(self::once())
             ->method('updateStateWithSchedule')
             ->with(self::COMPANY_ID, 'uuid-ready', OzonAdPendingReportState::OK, $now, null, 1, $now);
+
+        $this->bus->expects(self::once())
+            ->method('dispatch')
+            ->willReturnCallback(function (object $message) use ($r1): Envelope {
+                self::assertInstanceOf(DownloadOzonAdReportMessage::class, $message);
+                self::assertSame($r1->getId(), $message->pendingReportId);
+
+                return new Envelope($message);
+            });
 
         ($this->poller)(self::COMPANY_ID, $now);
     }
@@ -187,6 +220,7 @@ final class OzonAdReportPollerTest extends TestCase
             ->willReturn(1);
         $this->repo->expects(self::never())->method('updateStateWithSchedule');
         $this->repo->expects(self::never())->method('updateSchedule');
+        $this->bus->expects(self::never())->method('dispatch');
 
         $result = ($this->poller)(self::COMPANY_ID, $now);
 
@@ -215,6 +249,7 @@ final class OzonAdReportPollerTest extends TestCase
                 1,
             )
             ->willReturn(1);
+        $this->bus->expects(self::never())->method('dispatch');
 
         $result = ($this->poller)(self::COMPANY_ID, $now);
 
@@ -242,6 +277,7 @@ final class OzonAdReportPollerTest extends TestCase
                 self::stringContains('Missing from /statistics/list'),
             )
             ->willReturn(1);
+        $this->bus->expects(self::never())->method('dispatch');
 
         $result = ($this->poller)(self::COMPANY_ID, $now);
 
@@ -272,6 +308,7 @@ final class OzonAdReportPollerTest extends TestCase
                 null, // NOT_STARTED → не фиксируем firstNonPendingAt
             )
             ->willReturn(1);
+        $this->bus->expects(self::never())->method('dispatch');
 
         $result = ($this->poller)(self::COMPANY_ID, $now);
 
@@ -300,6 +337,7 @@ final class OzonAdReportPollerTest extends TestCase
                 $now, // state ≠ NOT_STARTED → фиксируем
             )
             ->willReturn(1);
+        $this->bus->expects(self::never())->method('dispatch');
 
         ($this->poller)(self::COMPANY_ID, $now);
     }

--- a/site/tests/Unit/MarketplaceAds/MessageHandler/DownloadOzonAdReportHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/MessageHandler/DownloadOzonAdReportHandlerTest.php
@@ -1,0 +1,389 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MarketplaceAds\MessageHandler;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAds\Entity\AdRawDocument;
+use App\MarketplaceAds\Entity\OzonAdPendingReport;
+use App\MarketplaceAds\Enum\OzonAdPendingReportState;
+use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonAdClient;
+use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonPermanentApiException;
+use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonReportDownload;
+use App\MarketplaceAds\Message\DownloadOzonAdReportMessage;
+use App\MarketplaceAds\Message\ProcessAdRawDocumentMessage;
+use App\MarketplaceAds\MessageHandler\DownloadOzonAdReportHandler;
+use App\MarketplaceAds\Repository\AdRawDocumentRepository;
+use App\MarketplaceAds\Repository\OzonAdPendingReportRepository;
+use App\Shared\Service\Storage\StorageService;
+use DG\BypassFinals;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+// StorageService — final class, нужен BypassFinals для createMock.
+BypassFinals::allowPaths([
+    '*/src/Shared/Service/Storage/StorageService.php',
+]);
+
+/**
+ * Unit-тесты {@see DownloadOzonAdReportHandler}: async-download pending-отчёта.
+ *
+ * Покрываемые инварианты:
+ *  1. findByIdAndCompany вернул null → warning + no-op ACK, никаких side-effects.
+ *  2. pending-отчёт уже финализирован → info + no-op ACK, download не вызывается.
+ *  3. OzonPermanentApiException → markFinalized(ERROR) + Unrecoverable.
+ *  4. Generic \Throwable → markFinalized НЕ вызывается, exception propagate
+ *     (Messenger ретраит).
+ *  5. Happy-path 2 дня → 2 dispatch(ProcessAdRawDocumentMessage).
+ *  6. Happy-path bronze — один download → setFileStorage на каждом документе.
+ *  7. Порядок side-effects: flush → markFinalized(OK) → dispatch.
+ */
+final class DownloadOzonAdReportHandlerTest extends TestCase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-111111111111';
+    private const PENDING_ID = '22222222-2222-2222-2222-222222222222';
+    private const OZON_UUID = 'ozon-report-uuid-xyz';
+
+    /** @var OzonAdPendingReportRepository&MockObject */
+    private OzonAdPendingReportRepository $pendingRepo;
+    /** @var AdRawDocumentRepository&MockObject */
+    private AdRawDocumentRepository $rawRepo;
+    /** @var OzonAdClient&MockObject */
+    private OzonAdClient $client;
+    /** @var EntityManagerInterface&MockObject */
+    private EntityManagerInterface $em;
+    /** @var MessageBusInterface&MockObject */
+    private MessageBusInterface $bus;
+    /** @var StorageService&MockObject */
+    private StorageService $storage;
+
+    protected function setUp(): void
+    {
+        $this->pendingRepo = $this->createMock(OzonAdPendingReportRepository::class);
+        $this->rawRepo = $this->createMock(AdRawDocumentRepository::class);
+        $this->client = $this->createMock(OzonAdClient::class);
+        $this->em = $this->createMock(EntityManagerInterface::class);
+        $this->bus = $this->createMock(MessageBusInterface::class);
+        $this->storage = $this->createMock(StorageService::class);
+    }
+
+    public function testPendingReportNotFoundIsNoop(): void
+    {
+        $this->pendingRepo->expects(self::once())
+            ->method('findByIdAndCompany')
+            ->with(self::PENDING_ID, self::COMPANY_ID)
+            ->willReturn(null);
+
+        $this->client->expects(self::never())->method('downloadAndConvertReport');
+        $this->pendingRepo->expects(self::never())->method('markFinalized');
+        $this->em->expects(self::never())->method('flush');
+        $this->bus->expects(self::never())->method('dispatch');
+
+        $this->makeHandler()(new DownloadOzonAdReportMessage(
+            companyId: self::COMPANY_ID,
+            pendingReportId: self::PENDING_ID,
+        ));
+    }
+
+    public function testAlreadyFinalizedIsNoop(): void
+    {
+        $pending = $this->makePendingReport(finalizedAt: new \DateTimeImmutable('-1 minute'));
+
+        $this->pendingRepo->method('findByIdAndCompany')->willReturn($pending);
+
+        $this->client->expects(self::never())->method('downloadAndConvertReport');
+        $this->pendingRepo->expects(self::never())->method('markFinalized');
+        $this->em->expects(self::never())->method('flush');
+        $this->bus->expects(self::never())->method('dispatch');
+
+        $this->makeHandler()(new DownloadOzonAdReportMessage(
+            companyId: self::COMPANY_ID,
+            pendingReportId: self::PENDING_ID,
+        ));
+    }
+
+    public function testPermanentApiExceptionFinalizesErrorAndThrowsUnrecoverable(): void
+    {
+        $pending = $this->makePendingReport();
+
+        $this->pendingRepo->method('findByIdAndCompany')->willReturn($pending);
+
+        $this->client->method('downloadAndConvertReport')
+            ->willThrowException(new OzonPermanentApiException('403 forbidden'));
+
+        $this->pendingRepo->expects(self::once())
+            ->method('markFinalized')
+            ->with(
+                self::COMPANY_ID,
+                self::OZON_UUID,
+                OzonAdPendingReportState::ERROR,
+                self::stringContains('Download permanent failure'),
+            )
+            ->willReturn(1);
+
+        $this->em->expects(self::never())->method('flush');
+        $this->bus->expects(self::never())->method('dispatch');
+
+        $this->expectException(UnrecoverableMessageHandlingException::class);
+        $this->expectExceptionMessage('Ozon permanent failure');
+
+        $this->makeHandler()(new DownloadOzonAdReportMessage(
+            companyId: self::COMPANY_ID,
+            pendingReportId: self::PENDING_ID,
+        ));
+    }
+
+    public function testGenericThrowableDoesNotFinalizeAndPropagates(): void
+    {
+        $pending = $this->makePendingReport();
+
+        $this->pendingRepo->method('findByIdAndCompany')->willReturn($pending);
+        $this->client->method('downloadAndConvertReport')
+            ->willThrowException(new \RuntimeException('network timeout'));
+
+        $this->pendingRepo->expects(self::never())->method('markFinalized');
+        $this->em->expects(self::never())->method('flush');
+        $this->bus->expects(self::never())->method('dispatch');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('network timeout');
+
+        $this->makeHandler()(new DownloadOzonAdReportMessage(
+            companyId: self::COMPANY_ID,
+            pendingReportId: self::PENDING_ID,
+        ));
+    }
+
+    public function testHappyPathUpsertsDocumentsAndDispatchesProcessingAfterFlush(): void
+    {
+        $pending = $this->makePendingReport();
+
+        $this->pendingRepo->method('findByIdAndCompany')->willReturn($pending);
+
+        $download = $this->makeDownload('raw-bytes-1');
+        $this->client->method('downloadAndConvertReport')
+            ->willReturn([
+                'downloads' => [$download],
+                'resultByDate' => [
+                    '2026-04-01' => ['campaigns' => [[
+                        'campaign_id' => 'c1',
+                        'campaign_name' => 'Camp 1',
+                        'rows' => [['sku' => 's1', 'spend' => '10.00', 'views' => 5, 'clicks' => 1]],
+                    ]]],
+                    '2026-04-02' => ['campaigns' => [[
+                        'campaign_id' => 'c1',
+                        'campaign_name' => 'Camp 1',
+                        'rows' => [['sku' => 's1', 'spend' => '20.00', 'views' => 10, 'clicks' => 2]],
+                    ]]],
+                ],
+            ]);
+
+        // Оба дня новые — findByMarketplaceAndDate возвращает null.
+        $this->rawRepo->method('findByMarketplaceAndDate')->willReturn(null);
+        /** @var list<AdRawDocument> $saved */
+        $saved = [];
+        $this->rawRepo->expects(self::exactly(2))
+            ->method('save')
+            ->willReturnCallback(function (AdRawDocument $doc) use (&$saved): void {
+                $saved[] = $doc;
+            });
+
+        $this->storage->expects(self::once())
+            ->method('storeBytes')
+            ->willReturn([
+                'storagePath' => 'companies/xxx/marketplace-ads/ozon/bronze/2026-04-01/ozon-report-uuid-xyz.csv',
+                'fileHash' => 'sha256:deadbeef',
+                'sizeBytes' => 11,
+                'mimeType' => 'text/csv',
+            ]);
+
+        // Строгий порядок вызовов: flush → markFinalized → dispatch. Assertим через
+        // шаг-трекер, потому что PHPUnit InSequence не работает для разных моков.
+        $trace = [];
+        $this->em->expects(self::once())
+            ->method('flush')
+            ->willReturnCallback(function () use (&$trace): void {
+                $trace[] = 'flush';
+            });
+        $this->pendingRepo->expects(self::once())
+            ->method('markFinalized')
+            ->with(self::COMPANY_ID, self::OZON_UUID, OzonAdPendingReportState::OK, null)
+            ->willReturnCallback(function () use (&$trace): int {
+                $trace[] = 'markFinalized';
+
+                return 1;
+            });
+
+        $dispatched = [];
+        $this->bus->expects(self::exactly(2))
+            ->method('dispatch')
+            ->willReturnCallback(function (object $message) use (&$dispatched, &$trace): Envelope {
+                self::assertInstanceOf(ProcessAdRawDocumentMessage::class, $message);
+                self::assertSame(self::COMPANY_ID, $message->companyId);
+                $dispatched[] = $message;
+                $trace[] = 'dispatch';
+
+                return new Envelope($message);
+            });
+
+        $this->makeHandler()(new DownloadOzonAdReportMessage(
+            companyId: self::COMPANY_ID,
+            pendingReportId: self::PENDING_ID,
+        ));
+
+        self::assertCount(2, $saved, '2 новых AdRawDocument должны быть сохранены');
+        foreach ($saved as $doc) {
+            self::assertSame(MarketplaceType::OZON, $doc->getMarketplace());
+            self::assertSame(self::COMPANY_ID, $doc->getCompanyId());
+            self::assertSame('companies/xxx/marketplace-ads/ozon/bronze/2026-04-01/ozon-report-uuid-xyz.csv', $doc->getStoragePath());
+            self::assertSame('sha256:deadbeef', $doc->getFileHash());
+            self::assertSame(11, $doc->getFileSizeBytes());
+        }
+
+        self::assertCount(2, $dispatched, 'dispatch должен быть вызван по разу на документ');
+        self::assertSame(['flush', 'markFinalized', 'dispatch', 'dispatch'], $trace, 'flush → markFinalized → dispatch — порядок критичен');
+    }
+
+    public function testHappyPathExistingDocumentUpdatesPayload(): void
+    {
+        $pending = $this->makePendingReport();
+        $this->pendingRepo->method('findByIdAndCompany')->willReturn($pending);
+
+        $existing = new AdRawDocument(
+            self::COMPANY_ID,
+            MarketplaceType::OZON,
+            new \DateTimeImmutable('2026-04-01'),
+            '{"old":"payload"}',
+        );
+
+        // Существующий документ — save не вызывается, updatePayload внутри entity.
+        $this->rawRepo->method('findByMarketplaceAndDate')->willReturn($existing);
+        $this->rawRepo->expects(self::never())->method('save');
+
+        $download = $this->makeDownload('raw-bytes-2');
+        $this->client->method('downloadAndConvertReport')
+            ->willReturn([
+                'downloads' => [$download],
+                'resultByDate' => [
+                    '2026-04-01' => ['campaigns' => [['campaign_id' => 'c1', 'campaign_name' => 'N', 'rows' => []]]],
+                ],
+            ]);
+
+        $this->storage->method('storeBytes')->willReturn([
+            'storagePath' => 'p',
+            'fileHash' => 'h',
+            'sizeBytes' => 11,
+            'mimeType' => 'text/csv',
+        ]);
+
+        $this->em->expects(self::once())->method('flush');
+        $this->pendingRepo->expects(self::once())->method('markFinalized');
+        $this->bus->expects(self::once())
+            ->method('dispatch')
+            ->willReturnCallback(static fn (object $m): Envelope => new Envelope($m));
+
+        $this->makeHandler()(new DownloadOzonAdReportMessage(
+            companyId: self::COMPANY_ID,
+            pendingReportId: self::PENDING_ID,
+        ));
+
+        self::assertStringContainsString('"campaigns"', $existing->getRawPayload(), 'updatePayload должен переписать payload');
+    }
+
+    public function testEmptyResultByDateSkipsBronzeAndDispatch(): void
+    {
+        $pending = $this->makePendingReport();
+        $this->pendingRepo->method('findByIdAndCompany')->willReturn($pending);
+
+        $download = $this->makeDownload('raw-bytes-empty');
+        $this->client->method('downloadAndConvertReport')->willReturn([
+            'downloads' => [$download],
+            'resultByDate' => [],
+        ]);
+
+        $this->rawRepo->expects(self::never())->method('save');
+        $this->storage->expects(self::never())->method('storeBytes');
+        $this->em->expects(self::once())->method('flush');
+
+        // markFinalized всё равно вызывается — пустой отчёт это валидный "обработан".
+        $this->pendingRepo->expects(self::once())
+            ->method('markFinalized')
+            ->with(self::COMPANY_ID, self::OZON_UUID, OzonAdPendingReportState::OK, null)
+            ->willReturn(1);
+
+        $this->bus->expects(self::never())->method('dispatch');
+
+        $this->makeHandler()(new DownloadOzonAdReportMessage(
+            companyId: self::COMPANY_ID,
+            pendingReportId: self::PENDING_ID,
+        ));
+    }
+
+    private function makeHandler(): DownloadOzonAdReportHandler
+    {
+        return new DownloadOzonAdReportHandler(
+            $this->pendingRepo,
+            $this->rawRepo,
+            $this->client,
+            $this->em,
+            $this->bus,
+            $this->storage,
+            new NullLogger(),
+        );
+    }
+
+    private function makePendingReport(?\DateTimeImmutable $finalizedAt = null): OzonAdPendingReport
+    {
+        $pending = new OzonAdPendingReport(
+            companyId: self::COMPANY_ID,
+            ozonUuid: self::OZON_UUID,
+            dateFrom: new \DateTimeImmutable('2026-04-01'),
+            dateTo: new \DateTimeImmutable('2026-04-02'),
+            campaignIds: ['c1', 'c2'],
+            jobId: Uuid::uuid7()->toString(),
+        );
+
+        $ref = new \ReflectionClass($pending);
+
+        $idProp = $ref->getProperty('id');
+        $idProp->setAccessible(true);
+        $idProp->setValue($pending, self::PENDING_ID);
+
+        if (null !== $finalizedAt) {
+            $finalizedProp = $ref->getProperty('finalizedAt');
+            $finalizedProp->setAccessible(true);
+            $finalizedProp->setValue($pending, $finalizedAt);
+
+            $stateProp = $ref->getProperty('state');
+            $stateProp->setAccessible(true);
+            $stateProp->setValue($pending, OzonAdPendingReportState::OK);
+        } else {
+            $stateProp = $ref->getProperty('state');
+            $stateProp->setAccessible(true);
+            $stateProp->setValue($pending, OzonAdPendingReportState::OK);
+        }
+
+        return $pending;
+    }
+
+    private function makeDownload(string $rawBytes): OzonReportDownload
+    {
+        return new OzonReportDownload(
+            rawBytes: $rawBytes,
+            csvContent: 'date;sku;spend;views;clicks',
+            csvParts: ['date;sku;spend;views;clicks'],
+            wasZip: false,
+            sizeBytes: strlen($rawBytes),
+            sha256: hash('sha256', $rawBytes),
+            reportUuid: self::OZON_UUID,
+            filesInZip: 0,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Implements step 4 of the Ozon async-polling redesign: adds `DownloadOzonAdReportHandler` to asynchronously download and ingest ready Ozon Performance reports. When the poll-cron observes a pending report transitioning to `state=OK`, it now dispatches a `DownloadOzonAdReportMessage` to an async worker, which downloads the CSV, upserts `AdRawDocument` entities per day, stores bronze metadata, and fans out `ProcessAdRawDocumentMessage` for downstream processing.

## Key Changes

- **New message class** `DownloadOzonAdReportMessage`: scalar-only payload carrying `companyId` and `pendingReportId` for IDOR-safe async dispatch
- **New handler** `DownloadOzonAdReportHandler`: orchestrates the complete download-to-dispatch flow with strict ordering guarantees (flush → markFinalized → dispatch) and comprehensive error handling
  - Idempotent no-op on already-finalized reports (guards against Messenger retries and race conditions)
  - Permanent API failures (403, missing credentials) → `markFinalized(ERROR)` + `UnrecoverableMessageHandlingException`
  - Transient failures (5xx, network, JSON errors) → rethrow for Messenger retry
  - Upserts `AdRawDocument` per day with payload merge for existing records
  - Stores bronze file once per report and links all documents to it
- **New API method** `OzonAdClient::downloadAndConvertReport()`: fetches ready report by UUID, downloads CSV, and converts to date-grouped structure compatible with existing `fetchAdStatisticsRange()` shape
- **Repository method** `OzonAdPendingReportRepository::findByIdAndCompany()`: IDOR-safe lookup by PK + companyId for handler's entity resolution
- **Updated poller** `OzonAdReportPoller`: now dispatches `DownloadOzonAdReportMessage` when observing `state=OK` transition
- **Messenger routing**: registered `DownloadOzonAdReportMessage` in `async_pipeline` transport
- **Comprehensive test coverage**:
  - 389-line unit test suite covering all invariants (not found, already finalized, permanent/transient errors, happy paths with new/existing documents, empty results, side-effect ordering)
  - 284-line integration test suite with real Postgres, in-memory Messenger transport, and mocked Ozon client (end-to-end flow, idempotency, IDOR guard)

## Notable Implementation Details

- Handler enforces strict side-effect ordering: persist documents → flush → markFinalized → dispatch messages. This ensures downstream handlers see documents in DB before processing.
- Bronze storage is unified: one report UUID = one download = one physical file, all documents reference it via file_hash/file_size.
- Campaign names are resolved from CSV columns rather than separate API calls, reducing HTTP overhead and avoiding stale fallback data.
- Comprehensive logging at info/warning/error levels for observability of async download lifecycle.
- IDOR defense-in-depth: both message payload and repository lookup verify companyId ownership.

https://claude.ai/code/session_015Xr6Xcnz1KBs5qXmzqtQPu