### PR TITLE
Support nested campaigns format in OzonAdRawDataParser

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -626,6 +626,25 @@ OzonAdReportPoller (state=OK)
                  └─ ProcessAdRawDocumentHandler (fan-out per day)
 ```
 
+### `AdRawDocument.raw_payload` — две поддерживаемые формы
+
+`OzonAdRawDataParser` принимает обе формы и возвращает одинаковый список `AdRawEntry`:
+
+- **flat** (legacy — `LoadAdDataCommand`, `ReprocessAdDataCommand`,
+  pre-step-4 writers, raw-документы, уже сохранённые в БД до шага 4):
+  ```json
+  {"rows":[{"campaign_id":"…","campaign_name":"…","sku":"…","spend":"…","views":0,"clicks":0}]}
+  ```
+- **nested** (current — `DownloadOzonAdReportHandler` после шага 4 async-poll редизайна):
+  ```json
+  {"campaigns":[{"campaign_id":"…","campaign_name":"…","rows":[{"sku":"…","spend":"…","views":0,"clicks":0}]}]}
+  ```
+
+Парсер диспатчится по наличию ключа `campaigns`; для nested-формы поля
+`campaign_id` / `campaign_name` пробрасываются из родительского объекта
+в каждую row перед общей агрегацией — downstream-код (`ProcessAdRawDocumentAction`)
+не знает, какая форма была на входе.
+
 ---
 
 ## Query — MarketplaceAds
@@ -1128,4 +1147,5 @@ paths:
 | 1.8 | 2026-04-15 | MarketplaceAds: `OzonAdClient` реализован для работы с Ozon Performance API (`https://api-performance.ozon.ru`). Credentials забираются через `MarketplaceFacade::getConnectionCredentials(..., PERFORMANCE)`; OAuth2 access-token кэшируется в Symfony Cache с TTL = `expires_in - 300`. Пайплайн `fetchAdStatistics()`: листинг SKU-кампаний → async `/api/client/statistics` батчами по 100 кампаний → polling состояния (5 сек × 36 попыток = 3 мин) → скачивание CSV → парсинг через `fgetcsv` над `php://memory` (RFC 4180, автодетект `,` или `;`) → JSON `{"rows":[{campaign_id, campaign_name, sku, spend, views, clicks}]}`. `withAuthRetry()` один раз ретраит запрос при 401 (через внутренний `OzonAuthExpiredException`), 403 сигнализируется как permanent failure без ретрая. |
 | 1.9 | 2026-04-15 | MarketplaceAds: команды CLI переименованы в единый паттерн `app:marketplace-ads:*` — `marketplace-ads:load` → `app:marketplace-ads:load`, `marketplace-ads:reprocess` → `app:marketplace-ads:reprocess`. Приводит именование к общему для проекта префиксу `app:` (как у `app:marketplace:wb-daily-sync` и пр.). |
 | 1.10 | 2026-04-15 | Marketplace: UI модалки «Новое подключение» (`templates/marketplace/index.html.twig`) поддерживает два типа подключения — «Основное (Seller API)» и «Реклама (Performance API)». Тип `performance` доступен только при выборе Ozon, иначе опция скрыта и автоматически откатывается на `seller`. Form `action` переключается между `marketplace_connection_create` и `marketplace_connection_performance_create` без перезагрузки страницы; неактивный блок полей `disabled`, чтобы лишние поля не попадали в POST. В списке активных подключений для Performance подключения: суффикс «(Реклама)» к названию маркетплейса, скрыты кнопки «Синхронизировать», «За период», «Реализация», «Переобработать», строка синхронизации — статическая «—» (поллер статуса не запускается). |
+| 1.12 | 2026-04-22 | MarketplaceAds: `OzonAdRawDataParser` теперь принимает обе формы `raw_payload` — legacy flat `{"rows":[…]}` и nested `{"campaigns":[{campaign_id, campaign_name, rows:[…]}]}`, записываемый `DownloadOzonAdReportHandler` (шаг 4 async-poll редизайна). Парсер диспатчится по наличию ключа `campaigns`, пробрасывает `campaign_id` / `campaign_name` из родительского объекта в каждую row и делегирует агрегацию общему пути. Фикс silent no-op: до этого nested-payload уходил в `[]` → `ProcessAdRawDocumentAction` создавал 0 `AdDocument` и помечал `AdRawDocument` как `PROCESSED`, UI «Эффективность рекламы» показывал 0 затрат. Unit-тесты гарантируют идентичность entries для обеих форм. |
 | 1.11 | 2026-04-19 | MarketplaceAds: серия задач по Ozon Ads pipeline. Новые Entity: `AdLoadJob` (пакетная загрузка за период, атомарный счётчик `loadedDays` через raw SQL), `AdChunkProgress` (идемпотентная фиксация успеха чанка через `UniqueConstraint` `(job_id, date_from, date_to)`). Новый Message `LoadOzonAdStatisticsRangeMessage` + handler-оркестратор: PENDING → RUNNING, разбиение диапазона на чанки ≤ 62 дня (лимит Ozon Performance API), dispatch `FetchOzonAdStatisticsMessage` на каждый чанк. `FetchOzonAdStatisticsHandler`: upsert AdRawDocument + идемпотентный `markChunkCompleted` + inc `loadedDays` только при успешной фиксации чанка. Enum `AdRawDocumentStatus` расширен кейсом `FAILED` (+`isTerminal()`); финализация job'а перешла на per-document статус и считает через `countByCompanyMarketplaceAndDateRange`. Удалены мёртвые counter-поля `processedDays` / `failedDays` из `AdLoadJob` (миграция `Version20260419080739`). Новые методы репозиториев: `AdLoadJobRepository::markCompleted` / `markFailed` / `findRecentByCompanyAndMarketplace`; `AdChunkProgressRepository::markChunkCompleted` / `countCompletedChunks`; `AdRawDocumentRepository::markFailedWithReason` / `countByCompanyMarketplaceAndDateRange` / `findByCompanyMarketplaceAndDateRange`. |

--- a/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdRawDataParser.php
+++ b/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdRawDataParser.php
@@ -13,14 +13,12 @@ use Psr\Log\NullLogger;
 /**
  * Парсер rawPayload рекламной статистики Ozon.
  *
- * TODO: уточнить реальный формат ответа Performance API Ozon.
- * Ожидаемая структура:
- * {
- *   "rows": [
- *     {"campaign_id": "123", "campaign_name": "...", "sku": "456",
- *      "spend": 150.50, "views": 1000, "clicks": 50}
- *   ]
- * }
+ * Поддерживаются две формы payload (см. ARCHITECTURE §AdRawDocument):
+ *  - legacy flat: {"rows":[{campaign_id, campaign_name, sku, spend, views, clicks}]}
+ *    (LoadAdDataCommand / ReprocessAdDataCommand / pre-step-4 writers)
+ *  - nested:      {"campaigns":[{campaign_id, campaign_name, rows:[{sku, spend, views, clicks}]}]}
+ *    (DownloadOzonAdReportHandler, шаг 4 async-poll редизайна)
+ * Обе формы после парсинга дают идентичные AdRawEntry.
  */
 final class OzonAdRawDataParser implements AdRawDataParserInterface
 {
@@ -46,8 +44,72 @@ final class OzonAdRawDataParser implements AdRawDataParserInterface
     {
         $data = json_decode($rawPayload, true, flags: \JSON_THROW_ON_ERROR);
 
+        // Nested form пишется DownloadOzonAdReportHandler (async-poll, шаг 4);
+        // flat form остаётся для legacy-loader'ов и старых raw-документов в БД.
+        if (isset($data['campaigns']) && is_array($data['campaigns'])) {
+            return $this->parseFlat($this->flattenCampaigns($data['campaigns']));
+        }
+
         $rows = $data['rows'] ?? [];
         if (!is_array($rows) || [] === $rows) {
+            return [];
+        }
+
+        return $this->parseFlat($rows);
+    }
+
+    /**
+     * Разворачивает nested-payload в плоский список rows, пробрасывая
+     * campaign_id / campaign_name из родительского объекта внутрь каждой строки,
+     * так что parseFlat() видит те же ключи, что и в legacy-формате.
+     *
+     * @param list<mixed> $campaigns
+     * @return list<mixed>
+     */
+    private function flattenCampaigns(array $campaigns): array
+    {
+        $flattened = [];
+
+        foreach ($campaigns as $campaign) {
+            if (!is_array($campaign)) {
+                continue;
+            }
+
+            $campaignId = isset($campaign['campaign_id']) ? (string) $campaign['campaign_id'] : '';
+            $campaignName = isset($campaign['campaign_name']) ? (string) $campaign['campaign_name'] : '';
+            $rows = $campaign['rows'] ?? [];
+
+            if (!is_array($rows) || [] === $rows) {
+                continue;
+            }
+
+            foreach ($rows as $row) {
+                if (!is_array($row)) {
+                    // Сохраняем non-array элементы, чтобы parseFlat учёл их в
+                    // счётчике skipped_non_array (единообразная диагностика).
+                    $flattened[] = $row;
+                    continue;
+                }
+
+                // Не перезаписываем поля, если строка уже несёт свой
+                // campaign_id/campaign_name — defensive для будущих вариаций payload.
+                $row['campaign_id'] = $row['campaign_id'] ?? $campaignId;
+                $row['campaign_name'] = $row['campaign_name'] ?? $campaignName;
+
+                $flattened[] = $row;
+            }
+        }
+
+        return $flattened;
+    }
+
+    /**
+     * @param list<mixed> $rows
+     * @return list<AdRawEntry>
+     */
+    private function parseFlat(array $rows): array
+    {
+        if ([] === $rows) {
             return [];
         }
 

--- a/site/tests/Integration/MarketplaceAds/ProcessAdRawDocumentActionTest.php
+++ b/site/tests/Integration/MarketplaceAds/ProcessAdRawDocumentActionTest.php
@@ -187,6 +187,42 @@ final class ProcessAdRawDocumentActionTest extends IntegrationTestCase
         ($this->action())(self::COMPANY_ID, '99999999-9999-9999-9999-999999999999');
     }
 
+    public function testProcessesNestedCampaignsPayload(): void
+    {
+        $company = $this->seedCompany();
+        $this->seedListing($company, 'SKU-PARENT-1', 'L', '55555555-5555-5555-5555-000000000101');
+        $this->seedListing($company, 'SKU-PARENT-1', 'XL', '55555555-5555-5555-5555-000000000102');
+        $this->em->flush();
+
+        $rawDocumentId = $this->seedOzonRawDocumentWithNestedPayload([
+            [
+                'campaign_id' => 'CAMP-N',
+                'campaign_name' => 'Nested',
+                'rows' => [
+                    ['sku' => 'SKU-PARENT-1', 'spend' => '100.00', 'views' => 1000, 'clicks' => 40],
+                ],
+            ],
+        ]);
+
+        ($this->action())(self::COMPANY_ID, $rawDocumentId);
+
+        $this->em->clear();
+
+        $adDocuments = $this->em->getRepository(AdDocument::class)->findBy(['adRawDocumentId' => $rawDocumentId]);
+        self::assertCount(1, $adDocuments);
+
+        $adDocument = $adDocuments[0];
+        self::assertSame('CAMP-N', $adDocument->getCampaignId());
+        self::assertSame('Nested', $adDocument->getCampaignName());
+        self::assertSame('SKU-PARENT-1', $adDocument->getParentSku());
+        self::assertSame('100.00', $adDocument->getTotalCost());
+        self::assertSame(1000, $adDocument->getTotalImpressions());
+        self::assertSame(40, $adDocument->getTotalClicks());
+
+        $lines = $this->em->getRepository(AdDocumentLine::class)->findBy(['adDocument' => $adDocument->getId()]);
+        self::assertCount(2, $lines);
+    }
+
     private function action(): ProcessAdRawDocumentAction
     {
         return self::getContainer()->get(ProcessAdRawDocumentAction::class);
@@ -233,6 +269,26 @@ final class ProcessAdRawDocumentActionTest extends IntegrationTestCase
             companyId:   self::COMPANY_ID,
             marketplace: MarketplaceType::OZON,
             reportDate:  new \DateTimeImmutable('2026-04-10'),
+            rawPayload:  $payload,
+        );
+
+        $this->em->persist($rawDocument);
+        $this->em->flush();
+
+        return $rawDocument->getId();
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $campaigns
+     */
+    private function seedOzonRawDocumentWithNestedPayload(array $campaigns): string
+    {
+        $payload = json_encode(['campaigns' => $campaigns], JSON_THROW_ON_ERROR);
+
+        $rawDocument = new AdRawDocument(
+            companyId:   self::COMPANY_ID,
+            marketplace: MarketplaceType::OZON,
+            reportDate:  new \DateTimeImmutable('2026-04-11'),
             rawPayload:  $payload,
         );
 

--- a/site/tests/Unit/MarketplaceAds/OzonAdRawDataParserTest.php
+++ b/site/tests/Unit/MarketplaceAds/OzonAdRawDataParserTest.php
@@ -229,4 +229,159 @@ final class OzonAdRawDataParserTest extends TestCase
 
         self::assertSame([], $logger->records);
     }
+
+    public function testParsesNestedCampaignsFormat(): void
+    {
+        $json = json_encode([
+            'campaigns' => [
+                [
+                    'campaign_id' => '24449058',
+                    'campaign_name' => '07.04 Ловушка для мух желтая',
+                    'rows' => [
+                        ['sku' => '3765141162', 'spend' => '17.87', 'views' => 219, 'clicks' => 1],
+                    ],
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR);
+
+        $result = $this->parser->parse($json);
+
+        self::assertCount(1, $result);
+        self::assertInstanceOf(AdRawEntry::class, $result[0]);
+        self::assertSame('24449058', $result[0]->campaignId);
+        self::assertSame('07.04 Ловушка для мух желтая', $result[0]->campaignName);
+        self::assertSame('3765141162', $result[0]->parentSku);
+        self::assertSame('17.87', $result[0]->cost);
+        self::assertSame(219, $result[0]->impressions);
+        self::assertSame(1, $result[0]->clicks);
+    }
+
+    /**
+     * Регрессионный guard: одни и те же данные в обоих форматах должны
+     * давать идентичные AdRawEntry — это инвариант, на который опирается
+     * ProcessAdRawDocumentAction при обработке legacy + новых raw-документов.
+     */
+    public function testFlatAndNestedProduceIdenticalEntries(): void
+    {
+        $flatJson = json_encode([
+            'rows' => [
+                ['campaign_id' => '111', 'campaign_name' => 'C1', 'sku' => 'A',
+                 'spend' => 12.34, 'views' => 100, 'clicks' => 3],
+                ['campaign_id' => '111', 'campaign_name' => 'C1', 'sku' => 'B',
+                 'spend' => 5.00, 'views' => 50, 'clicks' => 1],
+            ],
+        ], JSON_THROW_ON_ERROR);
+
+        $nestedJson = json_encode([
+            'campaigns' => [
+                [
+                    'campaign_id' => '111',
+                    'campaign_name' => 'C1',
+                    'rows' => [
+                        ['sku' => 'A', 'spend' => 12.34, 'views' => 100, 'clicks' => 3],
+                        ['sku' => 'B', 'spend' => 5.00, 'views' => 50, 'clicks' => 1],
+                    ],
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR);
+
+        self::assertEquals($this->parser->parse($flatJson), $this->parser->parse($nestedJson));
+    }
+
+    public function testNestedMultipleCampaignsMultipleRows(): void
+    {
+        $json = json_encode([
+            'campaigns' => [
+                [
+                    'campaign_id' => '111',
+                    'campaign_name' => 'Alpha',
+                    'rows' => [
+                        ['sku' => 'A', 'spend' => 1.00, 'views' => 10, 'clicks' => 1],
+                        ['sku' => 'B', 'spend' => 2.00, 'views' => 20, 'clicks' => 2],
+                    ],
+                ],
+                [
+                    'campaign_id' => '222',
+                    'campaign_name' => 'Beta',
+                    'rows' => [
+                        ['sku' => 'A', 'spend' => 3.00, 'views' => 30, 'clicks' => 3],
+                        ['sku' => 'C', 'spend' => 4.00, 'views' => 40, 'clicks' => 4],
+                    ],
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR);
+
+        $result = $this->parser->parse($json);
+
+        self::assertCount(4, $result);
+
+        $byKey = [];
+        foreach ($result as $entry) {
+            $byKey[$entry->campaignId.'|'.$entry->parentSku] = $entry;
+        }
+
+        self::assertArrayHasKey('111|A', $byKey);
+        self::assertSame('Alpha', $byKey['111|A']->campaignName);
+        self::assertSame('1.00', $byKey['111|A']->cost);
+
+        self::assertArrayHasKey('111|B', $byKey);
+        self::assertSame('222', $byKey['222|A']->campaignId);
+        self::assertSame('Beta', $byKey['222|A']->campaignName);
+        self::assertSame('3.00', $byKey['222|A']->cost);
+
+        self::assertArrayHasKey('222|C', $byKey);
+    }
+
+    public function testNestedEmptyCampaignsReturnsEmpty(): void
+    {
+        self::assertSame([], $this->parser->parse('{"campaigns": []}'));
+    }
+
+    public function testNestedCampaignWithoutRowsIsSkipped(): void
+    {
+        $json = json_encode([
+            'campaigns' => [
+                ['campaign_id' => '111', 'campaign_name' => 'NoRows'],
+                [
+                    'campaign_id' => '222',
+                    'campaign_name' => 'WithRows',
+                    'rows' => [
+                        ['sku' => 'X', 'spend' => 9.99, 'views' => 10, 'clicks' => 1],
+                    ],
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR);
+
+        $result = $this->parser->parse($json);
+
+        self::assertCount(1, $result);
+        self::assertSame('222', $result[0]->campaignId);
+        self::assertSame('X', $result[0]->parentSku);
+    }
+
+    /**
+     * Defensive для будущих вариаций payload: если nested row уже несёт
+     * свой campaign_id — НЕ перезатираем его родительским.
+     */
+    public function testNestedRowOwnCampaignIdNotOverwritten(): void
+    {
+        $json = json_encode([
+            'campaigns' => [
+                [
+                    'campaign_id' => 'PARENT',
+                    'campaign_name' => 'ParentName',
+                    'rows' => [
+                        ['campaign_id' => 'ROW', 'campaign_name' => 'RowName',
+                         'sku' => 'X', 'spend' => 1.00, 'views' => 1, 'clicks' => 0],
+                    ],
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR);
+
+        $result = $this->parser->parse($json);
+
+        self::assertCount(1, $result);
+        self::assertSame('ROW', $result[0]->campaignId);
+        self::assertSame('RowName', $result[0]->campaignName);
+    }
 }


### PR DESCRIPTION
## Summary
Extended `OzonAdRawDataParser` to support both legacy flat and new nested payload formats from Ozon Performance API, ensuring backward compatibility while enabling the new async-poll workflow (step 4 of the redesign).

## Key Changes

- **Parser dual-format support**: `OzonAdRawDataParser.parse()` now detects and handles both:
  - Legacy flat format: `{"rows":[{campaign_id, campaign_name, sku, spend, views, clicks}]}`
  - New nested format: `{"campaigns":[{campaign_id, campaign_name, rows:[{sku, spend, views, clicks}]}]}`

- **Payload flattening logic**: Added `flattenCampaigns()` method that:
  - Unpacks nested campaign structures into flat rows
  - Propagates `campaign_id` and `campaign_name` from parent campaign to each row
  - Preserves row-level campaign fields if already present (defensive for future payload variations)
  - Maintains consistent error handling and diagnostics across both formats

- **Extracted common parsing**: Refactored aggregation logic into `parseFlat()` method to eliminate duplication and ensure both formats produce identical `AdRawEntry` results

- **Comprehensive test coverage**:
  - Unit tests for nested single/multiple campaigns with multiple rows
  - Regression test (`testFlatAndNestedProduceIdenticalEntries`) ensuring both formats yield identical entries
  - Edge cases: empty campaigns, missing rows, row-level campaign ID preservation
  - Integration test verifying end-to-end processing of nested payloads through `ProcessAdRawDocumentAction`

## Implementation Details

- Format detection uses presence of `campaigns` key; if absent, falls back to legacy `rows` key
- Both formats are normalized to the same internal representation before aggregation
- Downstream code (`ProcessAdRawDocumentAction`, etc.) remains unchanged—format conversion is transparent
- Documented in ARCHITECTURE.md with examples of both payload structures

https://claude.ai/code/session_01TJyxuMcg8T4x8zv87qdxuR