### PR TITLE
Split Ozon ad statistics POST into separate async message

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -666,9 +666,25 @@ Cron OzonAdDailySyncCommand (04:30 daily) → DispatchOzonAdLoadAction
 LoadOzonAdStatisticsRangeMessage → LoadOzonAdStatisticsRangeHandler
   ↓ (split into ≤62-day chunks)
 FetchOzonAdStatisticsMessage (async_ads) → FetchOzonAdStatisticsHandler
-  ↓ request-only: OzonAdClient::requestStatisticsOnly → POST /statistics per batch,
-    persist OzonAdPendingReport(state=REQUESTED), markChunkCompleted, return
-[worker exits in <30s; no more 10-min sync poll blocking a single slot]
+  ↓ prepareStatisticsBatches (credentials, campaigns, chunk into ≤10)
+  ↓ dispatch one RequestOzonAdBatchMessage per batch
+  ↓ markChunkCompleted, incrementLoadedDays
+  ↓ [if no batches: AdLoadJobFinalizer::tryFinalize directly]
+RequestOzonAdBatchMessage (async_ads) → RequestOzonAdBatchHandler
+  ↓ OzonAdClient::requestOneBatch = matchResumableReport OR requestStatistics (POST /statistics)
+  ↓ OzonAdPendingReport persisted (state=REQUESTED, nextPollAt=NULL)
+[each worker exits in <1s; no intra-handler 429 storm; no 10-min sync block]
+
+### Why one POST per message
+
+Ozon Performance API: max 1 active /api/client/statistics per account.
+Any 2nd concurrent request returns HTTP 429 «Превышен лимит активных
+запросов (максимум 1)». With async_ads having a single worker and
+FIFO Redis transport, dispatching one RequestOzonAdBatchMessage per
+batch naturally serializes POSTs with zero intra-handler orchestration.
+Previously FetchOzonAdStatisticsHandler called requestStatisticsOnly,
+which looped N POSTs back-to-back and reliably hit 429 on the 2nd
+batch for companies with >10 active SKU campaigns.
 
 Параллельно cron */2 * * * *:
 app:marketplace-ads:ozon-poll-reports → OzonPollReportsCommand → OzonAdReportPoller
@@ -684,9 +700,9 @@ on state=OK:
 
 `OzonAdClient::pollReport()`, `matchResumableReport()`, `POLL_MAX_ATTEMPTS`,
 `POLL_INTERVAL_SECONDS`, `POLL_NOT_STARTED_MAX_SECONDS`, `RESUME_MAX_AGE_SECONDS`,
-`OzonStatisticsQueueFullException`, `OzonAdClient::fetchAdStatisticsRange()` остаются
-в коде как dead-but-preserved до отдельного cleanup-PR в ~2 недели после стабилизации
-step 5.
+`OzonStatisticsQueueFullException`, `OzonAdClient::fetchAdStatisticsRange()`,
+`OzonAdClient::requestStatisticsOnly()` остаются в коде как dead-but-preserved
+до отдельного cleanup-PR в ~2 недели после стабилизации step 5 / rate-limit fix.
 
 ### `AdRawDocument.raw_payload` — две поддерживаемые формы
 

--- a/site/config/packages/messenger.yaml
+++ b/site/config/packages/messenger.yaml
@@ -65,3 +65,4 @@ framework:
             # --- async_ads: Ozon Performance polling (may block up to 10 min per message) ---
             'App\MarketplaceAds\Message\LoadOzonAdStatisticsRangeMessage': async_ads
             'App\MarketplaceAds\Message\FetchOzonAdStatisticsMessage': async_ads
+            'App\MarketplaceAds\Message\RequestOzonAdBatchMessage': async_ads

--- a/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
+++ b/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
@@ -581,9 +581,6 @@ class OzonAdClient implements AdPlatformClientInterface
         $batches = [];
         foreach (array_chunk($campaigns, self::STATISTICS_BATCH_SIZE) as $batch) {
             [$campaignIds] = $this->splitBatch($batch);
-            if ([] === $campaignIds) {
-                continue;
-            }
             $batches[] = $campaignIds;
         }
 

--- a/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
+++ b/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
@@ -532,6 +532,152 @@ class OzonAdClient implements AdPlatformClientInterface
     }
 
     /**
+     * Prepare batch plans for a chunk without issuing any POST /statistics.
+     *
+     * Делает: resolveCredentials → getAccessToken → listSkuCampaigns
+     *      → filterCampaignsForDateRange → chunk на батчи ≤STATISTICS_BATCH_SIZE.
+     *
+     * Caller (FetchOzonAdStatisticsHandler) диспатчит одно
+     * {@see \App\MarketplaceAds\Message\RequestOzonAdBatchMessage} на каждый
+     * возвращённый батч; каждое message вызывает {@see self::requestOneBatch()},
+     * чтобы сделать собственный POST. Такой split принудительно сериализует
+     * Ozon'овский лимит «1 active /statistics request per account» через
+     * FIFO single-worker транспорта async_ads — без intra-handler parallelism
+     * и без sleep-based rate limiting.
+     *
+     * @return list<list<string>> список батчей campaign_id (в каждом 1..10 id)
+     *
+     * @throws OzonPermanentApiException 403 / отсутствующие credentials
+     * @throws \InvalidArgumentException диапазон > 62 дней / from > to
+     * @throws \RuntimeException         прочие non-2xx / network / JSON-ошибки
+     */
+    public function prepareStatisticsBatches(
+        string $companyId,
+        \DateTimeImmutable $dateFrom,
+        \DateTimeImmutable $dateTo,
+    ): array {
+        $this->assertValidRange($dateFrom, $dateTo);
+
+        $credentials = $this->resolveCredentials($companyId);
+        $clientId = $credentials['client_id'];
+        $clientSecret = $credentials['client_secret'];
+
+        $this->marketplaceAdsLogger->info('Ozon Performance: prepareStatisticsBatches начало', [
+            'companyId' => $companyId,
+            'dateFrom' => $dateFrom->format('Y-m-d'),
+            'dateTo' => $dateTo->format('Y-m-d'),
+        ]);
+
+        $campaigns = $this->withAuthRetry(
+            $companyId,
+            $clientId,
+            $clientSecret,
+            fn (string $token): array => $this->listSkuCampaigns($token),
+        );
+
+        $campaigns = $this->filterCampaignsForDateRange($campaigns, $dateFrom);
+
+        /** @var list<list<string>> $batches */
+        $batches = [];
+        foreach (array_chunk($campaigns, self::STATISTICS_BATCH_SIZE) as $batch) {
+            [$campaignIds] = $this->splitBatch($batch);
+            if ([] === $campaignIds) {
+                continue;
+            }
+            $batches[] = $campaignIds;
+        }
+
+        $this->marketplaceAdsLogger->info('Ozon Performance: prepareStatisticsBatches готово', [
+            'companyId' => $companyId,
+            'dateFrom' => $dateFrom->format('Y-m-d'),
+            'dateTo' => $dateTo->format('Y-m-d'),
+            'campaignsCount' => count($campaigns),
+            'batchesCount' => count($batches),
+        ]);
+
+        return $batches;
+    }
+
+    /**
+     * POST /api/client/statistics для ровно одного батча кампаний.
+     *
+     * Используется {@see \App\MarketplaceAds\MessageHandler\RequestOzonAdBatchHandler}
+     * — это единственный caller в новом async-pipeline'е. Resume-логика через
+     * {@see self::matchResumableReport()} пропускает re-POST при Messenger-retry
+     * (идемпотентность в окне 900с): если батч с тем же (dateFrom, dateTo,
+     * campaignIds as set) уже in-flight для этого job'а, возвращается его UUID.
+     *
+     * @param list<string> $campaignIds 1..STATISTICS_BATCH_SIZE записей
+     *
+     * @return string UUID отчёта (новый либо переиспользованный)
+     *
+     * @throws OzonPermanentApiException 403
+     * @throws \InvalidArgumentException пустой $campaignIds
+     * @throws \RuntimeException         прочие non-2xx (включая 429) / 5xx / network
+     */
+    public function requestOneBatch(
+        string $companyId,
+        string $jobId,
+        \DateTimeImmutable $dateFrom,
+        \DateTimeImmutable $dateTo,
+        array $campaignIds,
+    ): string {
+        if ([] === $campaignIds) {
+            throw new \InvalidArgumentException('requestOneBatch: campaignIds must not be empty');
+        }
+
+        $credentials = $this->resolveCredentials($companyId);
+        $clientId = $credentials['client_id'];
+        $clientSecret = $credentials['client_secret'];
+
+        $inFlightReports = $this->pendingReportRepo->findInFlightByJob($companyId, $jobId);
+
+        $resumable = $this->matchResumableReport(
+            $inFlightReports,
+            $dateFrom,
+            $dateTo,
+            $campaignIds,
+            $companyId,
+        );
+
+        if (null !== $resumable) {
+            $uuid = $resumable->getOzonUuid();
+            $this->marketplaceAdsLogger->info('Ozon requestOneBatch: resumed existing UUID', [
+                'companyId' => $companyId,
+                'reportUuid' => $uuid,
+                'jobId' => $jobId,
+                'campaignCount' => count($campaignIds),
+            ]);
+
+            return $uuid;
+        }
+
+        $uuid = $this->withAuthRetry(
+            $companyId,
+            $clientId,
+            $clientSecret,
+            fn (string $token): string => $this->requestStatistics(
+                $token,
+                $companyId,
+                $campaignIds,
+                $dateFrom,
+                $dateTo,
+                'DATE',
+                $jobId,
+            ),
+        );
+
+        $this->marketplaceAdsLogger->info('Ozon requestOneBatch: запрошен новый отчёт', [
+            'companyId' => $companyId,
+            'reportUuid' => $uuid,
+            'jobId' => $jobId,
+            'campaignCount' => count($campaignIds),
+        ]);
+
+        return $uuid;
+    }
+
+    /**
      * Один HTTP-снимок отчётов компании в Ozon Performance /statistics/list.
      *
      * В отличие от {@see pollReport()} не спит и не ретраится по состоянию —

--- a/site/src/MarketplaceAds/Message/RequestOzonAdBatchMessage.php
+++ b/site/src/MarketplaceAds/Message/RequestOzonAdBatchMessage.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Message;
+
+/**
+ * One POST /api/client/statistics per message. Serializes Ozon's
+ * "max 1 active request" rate limit through the single async_ads worker
+ * consuming from Redis FIFO.
+ *
+ * Dispatched by {@see \App\MarketplaceAds\MessageHandler\FetchOzonAdStatisticsHandler}
+ * once per batch (≤10 campaigns). Handled by
+ * {@see \App\MarketplaceAds\MessageHandler\RequestOzonAdBatchHandler}, which is
+ * the only place the new pipeline calls
+ * {@see \App\MarketplaceAds\Infrastructure\Api\Ozon\OzonAdClient::requestOneBatch()}.
+ *
+ * Scalar-only payload per Messenger/CLAUDE.md rules. batchIndex + batchTotal
+ * are optional for logic but помогают скоррелировать логи с исходным чанком
+ * при дебаге.
+ */
+final readonly class RequestOzonAdBatchMessage
+{
+    /**
+     * @param list<string> $campaignIds up to STATISTICS_BATCH_SIZE=10 entries
+     */
+    public function __construct(
+        public string $companyId,
+        public string $jobId,
+        public string $dateFrom,
+        public string $dateTo,
+        public array $campaignIds,
+        public int $batchIndex,
+        public int $batchTotal,
+    ) {
+    }
+}

--- a/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
@@ -9,6 +9,7 @@ use App\MarketplaceAds\Enum\OzonAdPendingReportState;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonAdClient;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonPermanentApiException;
 use App\MarketplaceAds\Message\FetchOzonAdStatisticsMessage;
+use App\MarketplaceAds\Message\RequestOzonAdBatchMessage;
 use App\MarketplaceAds\Repository\AdChunkProgressRepositoryInterface;
 use App\MarketplaceAds\Repository\AdLoadJobRepository;
 use App\MarketplaceAds\Repository\OzonAdPendingReportRepository;
@@ -17,55 +18,58 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
- * Async-обработчик {@see FetchOzonAdStatisticsMessage} — request-only.
+ * Async-обработчик {@see FetchOzonAdStatisticsMessage} — orchestrator'ом one-
+ * POST-per-message pipeline'а.
  *
- * Step 5 redesign: воркер больше НЕ polling'ит Ozon синхронно и НЕ скачивает
- * отчёт. Его роль — только выставить POST /statistics и выйти (<30s на чанк
- * вместо прежних ~10 мин). Завершение ингеста берёт на себя связка
- * poll-cron → {@see DownloadOzonAdReportHandler}.
+ * Шаг 5 redesign'а сделал этот handler request-only (без polling'а и без
+ * download'а). Follow-up fix (текущий PR): сам POST /statistics вынесен
+ * в {@see RequestOzonAdBatchHandler} — Ozon Performance API разрешает
+ * ровно 1 активный запрос к /statistics на аккаунт, и дёргать N батчей
+ * back-to-back из одного handler'а ловило 429 начиная со 2-го батча.
  *
- * Логика одного чанка:
- *  1) найти AdLoadJob (IDOR по company_id); если job удалён или в терминальном
- *     статусе — no-op;
- *  2) валидировать формат / календарь dateFrom / dateTo;
- *  3) вызвать {@see OzonAdClient::requestStatisticsOnly()} — он внутри
- *     разрешит credentials, получит token, сделает listSkuCampaigns,
- *     отфильтрует кампании, разобьёт на батчи ≤10 и на каждый батч
- *     выполнит POST /statistics с persist'ом OzonAdPendingReport
- *     (state=REQUESTED, jobId=этот job). Resume-логика внутри OzonAdClient
- *     защищает от дубликатов POST'ов при Messenger-retry (окно 900s);
- *  4) markChunkCompleted — идемпотентная фиксация чанка через
- *     AdChunkProgressRepository, SAME AS BEFORE. Семантика смещена:
- *     «chunk processed» → «chunk requested». При retry вернёт false
- *     и инкременты счётчиков пропустятся, чтобы не удвоить progress;
- *  5) если requestStatisticsOnly вернул пустой список UUID (нет активных
- *     SKU-кампаний / всё отфильтровано по recency), вызвать
- *     {@see AdLoadJobFinalizer::tryFinalize()} напрямую — иначе job
- *     навечно залипнет в RUNNING: нет pending → нет download → нет
- *     zero-docs финализации в DownloadOzonAdReportHandler;
- *  6) RETURN. Никакого download, upsert AdRawDocument, dispatch
- *     ProcessAdRawDocumentMessage — всё это теперь делает
- *     DownloadOzonAdReportHandler после того, как poll-cron увидел
- *     state=OK у pending-отчёта.
+ * Этот handler теперь:
+ *  1) находит AdLoadJob (IDOR-guard по company_id); job отсутствует /
+ *     в терминальном статусе — no-op;
+ *  2) валидирует формат и календарь dateFrom / dateTo;
+ *  3) вызывает {@see OzonAdClient::prepareStatisticsBatches()} — она
+ *     резолвит credentials, получает токен, делает listSkuCampaigns,
+ *     фильтрует recency-cutoff'ом и возвращает список батчей по ≤10
+ *     campaign_id. Никаких POST /statistics здесь не происходит;
+ *  4) для каждого батча диспатчит {@see RequestOzonAdBatchMessage}
+ *     (транспорт async_ads, single worker + FIFO). Единственный worker
+ *     поочерёдно делает по одному POST, серilизуя Ozon'овский лимит без
+ *     sleep'ов и без intra-handler parallelism'а;
+ *  5) markChunkCompleted + incrementLoadedDays — семантика «chunk
+ *     dispatched» (как и в предыдущем шаге 5). При Messenger-retry
+ *     markChunkCompleted вернёт false и счётчики не удвоятся;
+ *  6) zero-batches ветка: если prepareStatisticsBatches вернул [] (нет
+ *     активных SKU-кампаний / всё отфильтровано по recency-cutoff'у), ни
+ *     одного OzonAdPendingReport не появится — значит poll-cron'у нечего
+ *     опрашивать, и zero-docs финализация в DownloadOzonAdReportHandler
+ *     не сработает. Вызываем {@see AdLoadJobFinalizer::tryFinalize()}
+ *     напрямую, иначе job навечно залип бы в RUNNING.
  *
  * Политика ошибок:
- *  - \InvalidArgumentException (diapazon > 62 дней / from > to) — permanent
- *    bug вызывающей стороны → markFailed + UnrecoverableMessageHandlingException.
+ *  - \InvalidArgumentException (диапазон > 62 дней / from > to) — permanent
+ *    баг вызывающей стороны → markFailed + Unrecoverable.
  *  - OzonPermanentApiException (403, missing credentials) — permanent denial →
- *    abandon всех in-flight pending-отчётов этого job'а (чтобы poll-cron не
- *    продолжал их опрашивать после markFailed), markFailed + Unrecoverable.
+ *    abandon всех in-flight pending-отчётов этого job'а (созданных ранее на
+ *    предыдущих чанках), markFailed + Unrecoverable. В новом дизайне
+ *    prepareStatisticsBatches сам по себе pending-отчётов не создаёт, но
+ *    in-flight из предыдущих чанков того же job'а ещё могут полевать в cron.
  *  - OzonAuthExpiredException (401) — внутри OzonAdClient::withAuthRetry один
  *    раз ретраится с fresh-токеном, наружу не выходит.
- *  - Прочие \Throwable (5xx, сеть, JSON-ошибки) — transient → rethrow,
- *    Messenger ретраит. Resume-логика внутри OzonAdClient найдёт уже
- *    созданный pending-отчёт (<900s) и пропустит re-POST.
+ *  - Прочие \Throwable (5xx, сеть, JSON-ошибки на prep-шаге; transient
+ *    ошибки dispatch'а на Redis) — transient → rethrow, Messenger ретраит.
+ *    При ретрае matchResumableReport внутри RequestOzonAdBatchHandler
+ *    предохранит от повторных POST'ов уже-выданных UUID.
  *
- * OzonStatisticsQueueFullException (NOT_STARTED timeout) старого sync-flow'а
- * здесь больше не ловится — он выбрасывался из внутреннего polling-цикла,
- * которого в async-режиме нет. Сам exception-класс не удалён (оставлен для
- * совместимости с cleanup-PR), но из этого handler'а catch убран.
+ * Сам POST /statistics больше не делается в этом handler'е; catch 429
+ * переехал в downstream RequestOzonAdBatchHandler, где его Messenger ретраит
+ * штатно по расписанию async_ads.
  */
 #[AsMessageHandler]
 final class FetchOzonAdStatisticsHandler
@@ -76,6 +80,7 @@ final class FetchOzonAdStatisticsHandler
         private readonly AdChunkProgressRepositoryInterface $adChunkProgressRepository,
         private readonly OzonAdPendingReportRepository $pendingReportRepo,
         private readonly AdLoadJobFinalizer $finalizer,
+        private readonly MessageBusInterface $messageBus,
         private readonly AppLogger $logger,
         #[Autowire(service: 'monolog.logger.marketplace_ads')]
         private readonly LoggerInterface $marketplaceAdsLogger,
@@ -139,11 +144,10 @@ final class FetchOzonAdStatisticsHandler
         $chunkDays = (int) $dateFrom->diff($dateTo)->days + 1;
 
         try {
-            $uuids = $this->ozonAdClient->requestStatisticsOnly(
+            $batches = $this->ozonAdClient->prepareStatisticsBatches(
                 $message->companyId,
                 $dateFrom,
                 $dateTo,
-                $message->jobId,
             );
         } catch (\InvalidArgumentException $e) {
             // Диапазон > 62 дней или from > to — баг вызывающего кода,
@@ -161,10 +165,10 @@ final class FetchOzonAdStatisticsHandler
             );
         } catch (OzonPermanentApiException $e) {
             // 403 / missing credentials — permanent denial. Abandon все
-            // in-flight pending-отчёты этого job'а: job уходит в FAILED,
-            // и poll-cron'у больше нечего делать с их UUID'ами. Без abandon'а
-            // они остались бы висеть в REQUESTED до next_poll_at и
-            // генерили бы лишние HTTP-запросы.
+            // in-flight pending-отчёты этого job'а (из предыдущих чанков /
+            // retry'ев): job уходит в FAILED, и poll-cron'у больше нечего
+            // делать с их UUID'ами. Без abandon'а они остались бы висеть
+            // в REQUESTED до next_poll_at и генерили бы лишние HTTP-запросы.
             $this->abandonInFlightForJob($message->companyId, $message->jobId, $e);
 
             $this->adLoadJobRepository->markFailed(
@@ -179,10 +183,10 @@ final class FetchOzonAdStatisticsHandler
                 $e,
             );
         } catch (\Throwable $e) {
-            // Сетевые сбои / 5xx / JSON-ошибки — transient, Messenger сделает retry.
-            // Resume-логика внутри OzonAdClient на повторе найдёт уже
-            // созданный pending-отчёт (<900s) и пропустит дублирующий POST.
-            $this->logger->error('Transient failure requesting Ozon ad statistics chunk', $e, [
+            // Сетевые сбои / 5xx / JSON-ошибки на prep-стадии — transient,
+            // Messenger сделает retry. prepareStatisticsBatches идемпотентен
+            // (ничего не персистит), повтор безопасен.
+            $this->logger->error('Transient failure preparing Ozon ad statistics batches', $e, [
                 'jobId' => $message->jobId,
                 'companyId' => $message->companyId,
                 'dateFrom' => $message->dateFrom,
@@ -191,6 +195,23 @@ final class FetchOzonAdStatisticsHandler
             ]);
 
             throw $e;
+        }
+
+        // Диспатч по одному сообщению на батч — single async_ads worker
+        // обработает их последовательно, не нарушая Ozon'овский лимит
+        // «1 active /statistics request». matchResumableReport внутри
+        // RequestOzonAdBatchHandler даёт идемпотентность при Messenger-retry.
+        $batchTotal = count($batches);
+        foreach ($batches as $batchIndex => $campaignIds) {
+            $this->messageBus->dispatch(new RequestOzonAdBatchMessage(
+                companyId: $message->companyId,
+                jobId: $message->jobId,
+                dateFrom: $message->dateFrom,
+                dateTo: $message->dateTo,
+                campaignIds: $campaignIds,
+                batchIndex: $batchIndex,
+                batchTotal: $batchTotal,
+            ));
         }
 
         // Идемпотентная фиксация чанка — в async-flow означает «запрос отправлен»,
@@ -222,23 +243,24 @@ final class FetchOzonAdStatisticsHandler
             );
         }
 
-        // Zero-uuids branch: requestStatisticsOnly вернул пустой список
+        // Zero-batches branch: prepareStatisticsBatches вернул пустой список
         // (нет активных SKU-кампаний или все отфильтровались recency-cutoff'ом).
-        // Значит ни одного OzonAdPendingReport не создано, poll-cron'у нечего
-        // опрашивать, и zero-docs финализация в DownloadOzonAdReportHandler
-        // никогда не сработает для этого чанка. Без прямого вызова tryFinalize
-        // здесь job навечно застрял бы в RUNNING — это восстанавливает гарантию
-        // из старого sync-обработчика (commit 7d00eb0) на новом уровне
-        // пайплайна. tryFinalize идемпотентен: если другие чанки ещё in-flight,
-        // он безопасно вернётся без изменений.
-        if ([] === $uuids) {
+        // Значит ни один RequestOzonAdBatchMessage не будет диспатчен, ни
+        // одного OzonAdPendingReport не создано, poll-cron'у нечего опрашивать,
+        // и zero-docs финализация в DownloadOzonAdReportHandler никогда не
+        // сработает для этого чанка. Без прямого вызова tryFinalize здесь job
+        // навечно застрял бы в RUNNING — это восстанавливает гарантию из
+        // старого sync-обработчика (commit 7d00eb0) на новом уровне пайплайна.
+        // tryFinalize идемпотентен: если другие чанки ещё in-flight, он
+        // безопасно вернётся без изменений.
+        if ([] === $batches) {
             $this->finalizer->tryFinalize(
                 $message->jobId,
                 $message->companyId,
             );
 
             $this->marketplaceAdsLogger->info(
-                'Ozon ad statistics chunk had no active campaigns — tryFinalize called directly',
+                'Ozon ad statistics chunk had no active campaigns — finalizing directly',
                 [
                     'jobId' => $message->jobId,
                     'companyId' => $message->companyId,
@@ -248,13 +270,13 @@ final class FetchOzonAdStatisticsHandler
             );
         }
 
-        $this->marketplaceAdsLogger->info('Ozon ad statistics chunk requested', [
+        $this->marketplaceAdsLogger->info('Ozon ad statistics chunk dispatched', [
             'jobId' => $message->jobId,
             'companyId' => $message->companyId,
             'dateFrom' => $message->dateFrom,
             'dateTo' => $message->dateTo,
             'chunkDays' => $chunkDays,
-            'uuidsRequested' => count($uuids),
+            'batchesDispatched' => $batchTotal,
             'duplicate' => !$marked,
         ]);
     }

--- a/site/src/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandler.php
@@ -35,6 +35,16 @@ use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 #[AsMessageHandler]
 final class RequestOzonAdBatchHandler
 {
+    /**
+     * Ozon Performance API: «Превышен лимит по количеству кампаний (максимум 10)».
+     * Orchestrator бьёт batches через array_chunk(..., 10), так что в норме
+     * каждое сообщение приходит с 1..10 id. Но если кто-то диспатчит сообщение
+     * руками / из CLI в обход orchestrator'а с >10 id — Ozon вернёт 4xx,
+     * который handler бы ретраил бесконечно (4xx у нас transient). Явный
+     * guard с Unrecoverable ловит это один раз и bounce'ит в dead-letter.
+     */
+    private const STATISTICS_BATCH_SIZE = 10;
+
     public function __construct(
         private readonly AdLoadJobRepository $jobRepository,
         private readonly OzonAdClient $ozonAdClient,
@@ -60,6 +70,17 @@ final class RequestOzonAdBatchHandler
             ]);
 
             return;
+        }
+
+        // Размер батча должен быть 1..STATISTICS_BATCH_SIZE. Orchestrator это
+        // гарантирует; попадание сюда означает permanent bug у вызывающего.
+        $batchSize = count($message->campaignIds);
+        if ($batchSize < 1 || $batchSize > self::STATISTICS_BATCH_SIZE) {
+            throw new UnrecoverableMessageHandlingException(sprintf(
+                'RequestOzonAdBatchMessage: campaignIds size %d out of [1..%d]',
+                $batchSize,
+                self::STATISTICS_BATCH_SIZE,
+            ));
         }
 
         $dateFrom = \DateTimeImmutable::createFromFormat('!Y-m-d', $message->dateFrom);

--- a/site/src/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandler.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\MessageHandler;
+
+use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonAdClient;
+use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonPermanentApiException;
+use App\MarketplaceAds\Message\RequestOzonAdBatchMessage;
+use App\MarketplaceAds\Repository\AdLoadJobRepository;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+
+/**
+ * Async-обработчик {@see RequestOzonAdBatchMessage}: ровно один POST
+ * /api/client/statistics на сообщение.
+ *
+ * Ozon Performance API разрешает не более 1 активного запроса к /statistics
+ * на аккаунт. Single-worker транспорт async_ads + FIFO Redis транзит
+ * последовательно обрабатывают N таких сообщений — каждый POST завершается
+ * за ~200мс, следующий в очереди идёт после, никакого 429-а.
+ *
+ * Политика ошибок:
+ *  - Job в терминальном статусе / не найден → no-op, ack.
+ *  - {@see OzonPermanentApiException} (403 / scope revoked) → markFailed на
+ *    job'е + UnrecoverableMessageHandlingException. Оставшиеся батчи тоже
+ *    упадут с «job уже терминален» и станут no-op.
+ *  - Transient errors (429, 5xx, сеть) — пробрасываются, Messenger ретраит
+ *    по расписанию async_ads (2 попытки, 30с базовой задержки, ×2). На
+ *    retry matchResumableReport внутри requestOneBatch находит уже
+ *    созданный pending-отчёт и пропускает re-POST (окно 900с).
+ */
+#[AsMessageHandler]
+final class RequestOzonAdBatchHandler
+{
+    public function __construct(
+        private readonly AdLoadJobRepository $jobRepository,
+        private readonly OzonAdClient $ozonAdClient,
+        #[Autowire(service: 'monolog.logger.marketplace_ads')]
+        private readonly LoggerInterface $marketplaceAdsLogger,
+    ) {
+    }
+
+    public function __invoke(RequestOzonAdBatchMessage $message): void
+    {
+        $job = $this->jobRepository->findByIdAndCompany(
+            $message->jobId,
+            $message->companyId,
+        );
+
+        if (null === $job || $job->getStatus()->isTerminal()) {
+            $this->marketplaceAdsLogger->info('RequestOzonAdBatchMessage: job gone or terminal — skipping', [
+                'jobId' => $message->jobId,
+                'companyId' => $message->companyId,
+                'status' => null === $job ? 'missing' : $job->getStatus()->value,
+                'batchIndex' => $message->batchIndex,
+                'batchTotal' => $message->batchTotal,
+            ]);
+
+            return;
+        }
+
+        $dateFrom = \DateTimeImmutable::createFromFormat('!Y-m-d', $message->dateFrom);
+        $dateTo = \DateTimeImmutable::createFromFormat('!Y-m-d', $message->dateTo);
+
+        if (
+            false === $dateFrom
+            || false === $dateTo
+            || $dateFrom->format('Y-m-d') !== $message->dateFrom
+            || $dateTo->format('Y-m-d') !== $message->dateTo
+        ) {
+            // Не должно случаться: orchestrator передаёт заранее провалидированные
+            // строки. Но если вдруг — permanent bug, ретрай бессмыслен.
+            throw new UnrecoverableMessageHandlingException(sprintf(
+                'RequestOzonAdBatchMessage: invalid date format (from=%s, to=%s)',
+                $message->dateFrom,
+                $message->dateTo,
+            ));
+        }
+
+        $dateFrom = $dateFrom->setTime(0, 0);
+        $dateTo = $dateTo->setTime(0, 0);
+
+        try {
+            $this->ozonAdClient->requestOneBatch(
+                $message->companyId,
+                $message->jobId,
+                $dateFrom,
+                $dateTo,
+                $message->campaignIds,
+            );
+        } catch (OzonPermanentApiException $e) {
+            // 403 / scope revoked — весь job обречён. markFailed идемпотентен,
+            // если другой батч уже успел его зафейлить.
+            $this->marketplaceAdsLogger->warning('RequestOzonAdBatchMessage: Ozon API permanently denied', [
+                'jobId' => $message->jobId,
+                'companyId' => $message->companyId,
+                'batchIndex' => $message->batchIndex,
+                'batchTotal' => $message->batchTotal,
+                'error' => $e->getMessage(),
+            ]);
+
+            $this->jobRepository->markFailed(
+                $message->jobId,
+                $message->companyId,
+                'Ozon Performance: '.$e->getMessage(),
+            );
+
+            throw new UnrecoverableMessageHandlingException(
+                'RequestOzonAdBatchMessage: Ozon permanent failure — '.$e->getMessage(),
+                0,
+                $e,
+            );
+        }
+
+        $this->marketplaceAdsLogger->info('RequestOzonAdBatchMessage: batch requested', [
+            'jobId' => $message->jobId,
+            'companyId' => $message->companyId,
+            'batchIndex' => $message->batchIndex,
+            'batchTotal' => $message->batchTotal,
+            'campaignCnt' => count($message->campaignIds),
+        ]);
+    }
+}

--- a/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
@@ -371,7 +371,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $jobRepo->expects(self::never())->method('incrementLoadedDays');
 
         $ozonClient = $this->createMock(OzonAdClient::class);
-        $ozonClient->method('requestStatisticsOnly')
+        $ozonClient->method('prepareStatisticsBatches')
             ->willThrowException(new \RuntimeException('Ozon 502 Bad Gateway'));
 
         $chunkProgressRepo = $this->createMock(AdChunkProgressRepositoryInterface::class);
@@ -384,7 +384,11 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $finalizer = $this->createMock(AdLoadJobFinalizer::class);
         $finalizer->expects(self::never())->method('tryFinalize');
 
-        $handler = $this->createHandler($ozonClient, $jobRepo, $chunkProgressRepo, $pendingRepo, $finalizer);
+        // Transient на prep-этапе → ни одного dispatch'а батчей.
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::never())->method('dispatch');
+
+        $handler = $this->createHandler($ozonClient, $jobRepo, $chunkProgressRepo, $pendingRepo, $finalizer, $messageBus);
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Ozon 502 Bad Gateway');

--- a/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
@@ -527,6 +527,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             ->willReturn(1);
 
         $ozonClient = $this->createMock(OzonAdClient::class);
+        $ozonClient->expects(self::never())->method('prepareStatisticsBatches');
         $ozonClient->expects(self::never())->method('requestStatisticsOnly');
 
         $chunkProgressRepo = $this->createMock(AdChunkProgressRepositoryInterface::class);
@@ -534,7 +535,10 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
 
         $pendingRepo = $this->createMock(OzonAdPendingReportRepository::class);
 
-        $handler = $this->createHandler($ozonClient, $jobRepo, $chunkProgressRepo, $pendingRepo);
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::never())->method('dispatch');
+
+        $handler = $this->createHandler($ozonClient, $jobRepo, $chunkProgressRepo, $pendingRepo, null, $messageBus);
 
         $this->expectException(UnrecoverableMessageHandlingException::class);
         $this->expectExceptionMessage('invalid date format');

--- a/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
@@ -308,7 +308,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             ->willReturn(1);
 
         $ozonClient = $this->createMock(OzonAdClient::class);
-        $ozonClient->method('requestStatisticsOnly')
+        $ozonClient->method('prepareStatisticsBatches')
             ->willThrowException(new OzonPermanentApiException('403 — нет скоупа «Продвижение»'));
 
         $chunkProgressRepo = $this->createMock(AdChunkProgressRepositoryInterface::class);
@@ -343,7 +343,12 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $finalizer = $this->createMock(AdLoadJobFinalizer::class);
         $finalizer->expects(self::never())->method('tryFinalize');
 
-        $handler = $this->createHandler($ozonClient, $jobRepo, $chunkProgressRepo, $pendingRepo, $finalizer);
+        // prepareStatisticsBatches кинул exception до цикла dispatch —
+        // ни одного RequestOzonAdBatchMessage'а быть не должно.
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::never())->method('dispatch');
+
+        $handler = $this->createHandler($ozonClient, $jobRepo, $chunkProgressRepo, $pendingRepo, $finalizer, $messageBus);
 
         $this->expectException(UnrecoverableMessageHandlingException::class);
         $this->expectExceptionMessage('Ozon permanent failure');

--- a/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
@@ -133,14 +133,13 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         self::assertSame(['c3'], $dispatched[1]->campaignIds);
     }
 
-    public function testEmptyUuidsStillCallsMarkChunkCompletedAndFinalizer(): void
+    public function testZeroBatchesStillCallsMarkChunkCompletedAndFinalizer(): void
     {
-        // Zero-uuids scenario: requestStatisticsOnly возвращает [] (нет активных
-        // SKU-кампаний или все отфильтрованы recency-cutoff'ом). В этом случае
-        // ни одного OzonAdPendingReport не создано → poll-cron'у нечего
-        // опрашивать → DownloadOzonAdReportHandler для этого чанка никогда
-        // не сработает. Без прямого tryFinalize здесь job навсегда застрял бы
-        // в RUNNING.
+        // Zero-batches scenario: prepareStatisticsBatches возвращает [] (нет
+        // активных SKU-кампаний или все отфильтрованы recency-cutoff'ом). Ни
+        // одного RequestOzonAdBatchMessage не диспатчим, ни одного pending-
+        // отчёта не создастся → poll-cron'у нечего опрашивать → без прямого
+        // tryFinalize job навсегда застрял бы в RUNNING.
         $job = AdLoadJobBuilder::aJob()
             ->withCompanyId(self::COMPANY_ID)
             ->withDateRange(new \DateTimeImmutable(self::DATE_FROM), new \DateTimeImmutable(self::DATE_TO))
@@ -157,7 +156,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
 
         $ozonClient = $this->createMock(OzonAdClient::class);
         $ozonClient->expects(self::once())
-            ->method('requestStatisticsOnly')
+            ->method('prepareStatisticsBatches')
             ->willReturn([]);
 
         $chunkProgressRepo = $this->createMock(AdChunkProgressRepositoryInterface::class);
@@ -168,14 +167,19 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $pendingRepo = $this->createMock(OzonAdPendingReportRepository::class);
         $pendingRepo->expects(self::never())->method('markFinalized');
 
-        // KEY ASSERTION: the fix. tryFinalize MUST be called in the zero-uuids
+        // KEY ASSERTION: the fix. tryFinalize MUST be called in the zero-batches
         // branch, otherwise jobs with no active campaigns would hang in RUNNING.
         $finalizer = $this->createMock(AdLoadJobFinalizer::class);
         $finalizer->expects(self::once())
             ->method('tryFinalize')
             ->with(self::JOB_ID, self::COMPANY_ID);
 
-        $handler = $this->createHandler($ozonClient, $jobRepo, $chunkProgressRepo, $pendingRepo, $finalizer);
+        // Regression guard: zero-batches ветка не диспатчит ни одного
+        // RequestOzonAdBatchMessage'а.
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::never())->method('dispatch');
+
+        $handler = $this->createHandler($ozonClient, $jobRepo, $chunkProgressRepo, $pendingRepo, $finalizer, $messageBus);
         $handler(new FetchOzonAdStatisticsMessage(
             self::JOB_ID,
             self::COMPANY_ID,

--- a/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
@@ -10,6 +10,7 @@ use App\MarketplaceAds\Enum\OzonAdPendingReportState;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonAdClient;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonPermanentApiException;
 use App\MarketplaceAds\Message\FetchOzonAdStatisticsMessage;
+use App\MarketplaceAds\Message\RequestOzonAdBatchMessage;
 use App\MarketplaceAds\MessageHandler\FetchOzonAdStatisticsHandler;
 use App\MarketplaceAds\Repository\AdChunkProgressRepositoryInterface;
 use App\MarketplaceAds\Repository\AdLoadJobRepository;
@@ -20,7 +21,9 @@ use DG\BypassFinals;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Sentry\State\HubInterface;
+use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 // AdLoadJobFinalizer — final readonly, нужен BypassFinals для createMock.
 BypassFinals::allowPaths([
@@ -54,7 +57,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
     private const DATE_FROM = '2026-03-01';
     private const DATE_TO = '2026-03-03';
 
-    public function testHappyPathCallsRequestStatisticsOnlyAndMarkChunkCompleted(): void
+    public function testHappyPathDispatchesOneBatchMessagePerBatchAndMarkChunkCompleted(): void
     {
         $job = AdLoadJobBuilder::aJob()
             ->withCompanyId(self::COMPANY_ID)
@@ -72,14 +75,14 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
 
         $ozonClient = $this->createMock(OzonAdClient::class);
         $ozonClient->expects(self::once())
-            ->method('requestStatisticsOnly')
+            ->method('prepareStatisticsBatches')
             ->with(
                 self::COMPANY_ID,
                 self::callback(static fn (\DateTimeImmutable $d): bool => '2026-03-01' === $d->format('Y-m-d')),
                 self::callback(static fn (\DateTimeImmutable $d): bool => '2026-03-03' === $d->format('Y-m-d')),
-                self::JOB_ID,
             )
-            ->willReturn(['uuid-1', 'uuid-2']);
+            ->willReturn([['c1', 'c2'], ['c3']]);
+        $ozonClient->expects(self::never())->method('requestStatisticsOnly');
 
         $chunkProgressRepo = $this->createMock(AdChunkProgressRepositoryInterface::class);
         $chunkProgressRepo->expects(self::once())
@@ -95,20 +98,39 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $pendingRepo = $this->createMock(OzonAdPendingReportRepository::class);
         $pendingRepo->expects(self::never())->method('markFinalized');
 
-        // Regression guard: finalize attempt belongs ONLY to the zero-uuids
-        // branch. Non-empty chunks never call tryFinalize directly — the per-doc
-        // path through DownloadOzonAdReportHandler + ProcessAdRawDocumentHandler
-        // owns that responsibility.
         $finalizer = $this->createMock(AdLoadJobFinalizer::class);
         $finalizer->expects(self::never())->method('tryFinalize');
 
-        $handler = $this->createHandler($ozonClient, $jobRepo, $chunkProgressRepo, $pendingRepo, $finalizer);
+        $dispatched = [];
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::exactly(2))
+            ->method('dispatch')
+            ->willReturnCallback(static function (object $m) use (&$dispatched): Envelope {
+                $dispatched[] = $m;
+
+                return new Envelope($m);
+            });
+
+        $handler = $this->createHandler($ozonClient, $jobRepo, $chunkProgressRepo, $pendingRepo, $finalizer, $messageBus);
         $handler(new FetchOzonAdStatisticsMessage(
             self::JOB_ID,
             self::COMPANY_ID,
             self::DATE_FROM,
             self::DATE_TO,
         ));
+
+        self::assertCount(2, $dispatched);
+        foreach ($dispatched as $i => $m) {
+            self::assertInstanceOf(RequestOzonAdBatchMessage::class, $m);
+            self::assertSame(self::JOB_ID, $m->jobId);
+            self::assertSame(self::COMPANY_ID, $m->companyId);
+            self::assertSame(self::DATE_FROM, $m->dateFrom);
+            self::assertSame(self::DATE_TO, $m->dateTo);
+            self::assertSame($i, $m->batchIndex);
+            self::assertSame(2, $m->batchTotal);
+        }
+        self::assertSame(['c1', 'c2'], $dispatched[0]->campaignIds);
+        self::assertSame(['c3'], $dispatched[1]->campaignIds);
     }
 
     public function testEmptyUuidsStillCallsMarkChunkCompletedAndFinalizer(): void
@@ -531,13 +553,21 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         AdChunkProgressRepositoryInterface $chunkProgressRepo,
         OzonAdPendingReportRepository $pendingRepo,
         ?AdLoadJobFinalizer $finalizer = null,
+        ?MessageBusInterface $messageBus = null,
     ): FetchOzonAdStatisticsHandler {
+        if (null === $messageBus) {
+            $messageBus = $this->createMock(MessageBusInterface::class);
+            $messageBus->method('dispatch')
+                ->willReturnCallback(static fn (object $m): Envelope => new Envelope($m));
+        }
+
         return new FetchOzonAdStatisticsHandler(
             $ozonClient,
             $jobRepo,
             $chunkProgressRepo,
             $pendingRepo,
             $finalizer ?? $this->createMock(AdLoadJobFinalizer::class),
+            $messageBus,
             new AppLogger(new NullLogger(), $this->createMock(HubInterface::class)),
             new NullLogger(),
         );

--- a/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
@@ -567,6 +567,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             ->willReturn(1);
 
         $ozonClient = $this->createMock(OzonAdClient::class);
+        $ozonClient->expects(self::never())->method('prepareStatisticsBatches');
         $ozonClient->expects(self::never())->method('requestStatisticsOnly');
 
         $chunkProgressRepo = $this->createMock(AdChunkProgressRepositoryInterface::class);
@@ -574,7 +575,10 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
 
         $pendingRepo = $this->createMock(OzonAdPendingReportRepository::class);
 
-        $handler = $this->createHandler($ozonClient, $jobRepo, $chunkProgressRepo, $pendingRepo);
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::never())->method('dispatch');
+
+        $handler = $this->createHandler($ozonClient, $jobRepo, $chunkProgressRepo, $pendingRepo, null, $messageBus);
 
         $this->expectException(UnrecoverableMessageHandlingException::class);
         $this->expectExceptionMessage('2026-02-31');

--- a/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
@@ -487,7 +487,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $jobRepo->expects(self::never())->method('incrementLoadedDays');
 
         $ozonClient = $this->createMock(OzonAdClient::class);
-        $ozonClient->method('requestStatisticsOnly')
+        $ozonClient->method('prepareStatisticsBatches')
             ->willThrowException(new \InvalidArgumentException('Диапазон превышает 62 дня'));
 
         $chunkProgressRepo = $this->createMock(AdChunkProgressRepositoryInterface::class);
@@ -495,7 +495,10 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
 
         $pendingRepo = $this->createMock(OzonAdPendingReportRepository::class);
 
-        $handler = $this->createHandler($ozonClient, $jobRepo, $chunkProgressRepo, $pendingRepo);
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::never())->method('dispatch');
+
+        $handler = $this->createHandler($ozonClient, $jobRepo, $chunkProgressRepo, $pendingRepo, null, $messageBus);
 
         $this->expectException(UnrecoverableMessageHandlingException::class);
         $this->expectExceptionMessage('invalid date range');

--- a/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
@@ -420,6 +420,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $jobRepo->expects(self::never())->method('incrementLoadedDays');
 
         $ozonClient = $this->createMock(OzonAdClient::class);
+        $ozonClient->expects(self::never())->method('prepareStatisticsBatches');
         $ozonClient->expects(self::never())->method('requestStatisticsOnly');
 
         $chunkProgressRepo = $this->createMock(AdChunkProgressRepositoryInterface::class);
@@ -429,7 +430,10 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
 
         self::assertTrue($job->getStatus()->isTerminal(), 'sanity: FAILED is terminal');
 
-        $handler = $this->createHandler($ozonClient, $jobRepo, $chunkProgressRepo, $pendingRepo);
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::never())->method('dispatch');
+
+        $handler = $this->createHandler($ozonClient, $jobRepo, $chunkProgressRepo, $pendingRepo, null, $messageBus);
         $handler(new FetchOzonAdStatisticsMessage(
             AdLoadJobBuilder::DEFAULT_ID,
             self::COMPANY_ID,

--- a/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
@@ -450,6 +450,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $jobRepo->expects(self::never())->method('incrementLoadedDays');
 
         $ozonClient = $this->createMock(OzonAdClient::class);
+        $ozonClient->expects(self::never())->method('prepareStatisticsBatches');
         $ozonClient->expects(self::never())->method('requestStatisticsOnly');
 
         $chunkProgressRepo = $this->createMock(AdChunkProgressRepositoryInterface::class);
@@ -457,7 +458,10 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
 
         $pendingRepo = $this->createMock(OzonAdPendingReportRepository::class);
 
-        $handler = $this->createHandler($ozonClient, $jobRepo, $chunkProgressRepo, $pendingRepo);
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::never())->method('dispatch');
+
+        $handler = $this->createHandler($ozonClient, $jobRepo, $chunkProgressRepo, $pendingRepo, null, $messageBus);
         $handler(new FetchOzonAdStatisticsMessage(
             AdLoadJobBuilder::DEFAULT_ID,
             self::COMPANY_ID,

--- a/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
@@ -188,12 +188,12 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         ));
     }
 
-    public function testEmptyUuidsOnDuplicateChunkStillCallsFinalizer(): void
+    public function testZeroBatchesOnDuplicateChunkStillCallsFinalizer(): void
     {
-        // Инвариант: zero-uuids ветка вызывает tryFinalize независимо от
+        // Инвариант: zero-batches ветка вызывает tryFinalize независимо от
         // результата markChunkCompleted. tryFinalize идемпотентен (SQL-level
         // guard на статус RUNNING), и повторный вызов при Messenger-retry —
-        // безопасный no-op. Этот тест фиксирует контракт «zero-uuids всегда
+        // безопасный no-op. Этот тест фиксирует контракт «zero-batches всегда
         // пытается финализировать» и ловит регрессию, если кто-то решит
         // привязать вызов к `$marked === true`.
         $job = AdLoadJobBuilder::aJob()->asRunning()->build();
@@ -205,7 +205,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $jobRepo->expects(self::never())->method('incrementLoadedDays');
 
         $ozonClient = $this->createMock(OzonAdClient::class);
-        $ozonClient->method('requestStatisticsOnly')->willReturn([]);
+        $ozonClient->method('prepareStatisticsBatches')->willReturn([]);
 
         $chunkProgressRepo = $this->createMock(AdChunkProgressRepositoryInterface::class);
         $chunkProgressRepo->expects(self::once())
@@ -219,7 +219,11 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             ->method('tryFinalize')
             ->with(AdLoadJobBuilder::DEFAULT_ID, self::COMPANY_ID);
 
-        $handler = $this->createHandler($ozonClient, $jobRepo, $chunkProgressRepo, $pendingRepo, $finalizer);
+        // Zero batches → никаких dispatch'ей.
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::never())->method('dispatch');
+
+        $handler = $this->createHandler($ozonClient, $jobRepo, $chunkProgressRepo, $pendingRepo, $finalizer, $messageBus);
         $handler(new FetchOzonAdStatisticsMessage(
             AdLoadJobBuilder::DEFAULT_ID,
             self::COMPANY_ID,

--- a/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
@@ -242,7 +242,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $jobRepo->expects(self::never())->method('incrementLoadedDays');
 
         $ozonClient = $this->createMock(OzonAdClient::class);
-        $ozonClient->method('requestStatisticsOnly')->willReturn(['uuid-1']);
+        $ozonClient->method('prepareStatisticsBatches')->willReturn([['c1']]);
 
         $chunkProgressRepo = $this->createMock(AdChunkProgressRepositoryInterface::class);
         $chunkProgressRepo->expects(self::once())
@@ -251,10 +251,17 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
 
         $pendingRepo = $this->createMock(OzonAdPendingReportRepository::class);
 
-        // Non-empty uuids path: finalizer не должен вызываться — за финализацию
+        // Non-empty batches path: finalizer не должен вызываться — за финализацию
         // отвечает DownloadOzonAdReportHandler через per-document trigger.
         $finalizer = $this->createMock(AdLoadJobFinalizer::class);
         $finalizer->expects(self::never())->method('tryFinalize');
+
+        // На дубликате мы всё равно диспатчим батчи — matchResumableReport
+        // внутри RequestOzonAdBatchHandler абсорбирует повторный POST.
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::once())
+            ->method('dispatch')
+            ->willReturnCallback(static fn (object $m): Envelope => new Envelope($m));
 
         $marketplaceAdsLogger = new class extends NullLogger {
             public bool $infoLogged = false;
@@ -274,6 +281,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             $chunkProgressRepo,
             $pendingRepo,
             $finalizer,
+            $messageBus,
             new AppLogger(new NullLogger(), $this->createMock(HubInterface::class)),
             $marketplaceAdsLogger,
         );

--- a/site/tests/Unit/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandlerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MarketplaceAds\MessageHandler;
+
+use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonAdClient;
+use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonPermanentApiException;
+use App\MarketplaceAds\Message\RequestOzonAdBatchMessage;
+use App\MarketplaceAds\MessageHandler\RequestOzonAdBatchHandler;
+use App\MarketplaceAds\Repository\AdLoadJobRepository;
+use App\Tests\Builders\MarketplaceAds\AdLoadJobBuilder;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * Unit-тесты {@see RequestOzonAdBatchHandler}: ровно один POST /statistics
+ * на сообщение, с корректной обработкой terminal / missing / permanent /
+ * transient сценариев.
+ */
+final class RequestOzonAdBatchHandlerTest extends TestCase
+{
+    private const JOB_ID = AdLoadJobBuilder::DEFAULT_ID;
+    private const COMPANY_ID = '11111111-1111-1111-1111-111111111111';
+    private const DATE_FROM = '2026-03-01';
+    private const DATE_TO = '2026-03-03';
+
+    public function testHappyPathCallsRequestOneBatchOnce(): void
+    {
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->asRunning()
+            ->build();
+
+        $jobRepo = $this->createMock(AdLoadJobRepository::class);
+        $jobRepo->method('findByIdAndCompany')
+            ->with(self::JOB_ID, self::COMPANY_ID)
+            ->willReturn($job);
+        $jobRepo->expects(self::never())->method('markFailed');
+
+        $ozonClient = $this->createMock(OzonAdClient::class);
+        $ozonClient->expects(self::once())
+            ->method('requestOneBatch')
+            ->with(
+                self::COMPANY_ID,
+                self::JOB_ID,
+                self::callback(static fn (\DateTimeImmutable $d): bool => '2026-03-01' === $d->format('Y-m-d')),
+                self::callback(static fn (\DateTimeImmutable $d): bool => '2026-03-03' === $d->format('Y-m-d')),
+                ['c1', 'c2'],
+            )
+            ->willReturn('uuid-1');
+
+        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, new NullLogger());
+        $handler(new RequestOzonAdBatchMessage(
+            companyId: self::COMPANY_ID,
+            jobId: self::JOB_ID,
+            dateFrom: self::DATE_FROM,
+            dateTo: self::DATE_TO,
+            campaignIds: ['c1', 'c2'],
+            batchIndex: 0,
+            batchTotal: 1,
+        ));
+    }
+}

--- a/site/tests/Unit/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandlerTest.php
@@ -62,6 +62,30 @@ final class RequestOzonAdBatchHandlerTest extends TestCase
         ));
     }
 
+    public function testMissingJobIsNoop(): void
+    {
+        // Гонка dispatch-vs-cleanup: orchestrator успел диспатчнуть батч
+        // прямо перед тем, как job был вычищен (ручной cleanup, миграция).
+        // findByIdAndCompany возвращает null → handler молча ack'ает.
+        $jobRepo = $this->createMock(AdLoadJobRepository::class);
+        $jobRepo->method('findByIdAndCompany')->willReturn(null);
+        $jobRepo->expects(self::never())->method('markFailed');
+
+        $ozonClient = $this->createMock(OzonAdClient::class);
+        $ozonClient->expects(self::never())->method('requestOneBatch');
+
+        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, new NullLogger());
+        $handler(new RequestOzonAdBatchMessage(
+            companyId: self::COMPANY_ID,
+            jobId: self::JOB_ID,
+            dateFrom: self::DATE_FROM,
+            dateTo: self::DATE_TO,
+            campaignIds: ['c1'],
+            batchIndex: 0,
+            batchTotal: 1,
+        ));
+    }
+
     public function testTerminalJobIsNoop(): void
     {
         // Если job уже в терминальном статусе (успел зафейлиться другим

--- a/site/tests/Unit/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandlerTest.php
@@ -63,6 +63,51 @@ final class RequestOzonAdBatchHandlerTest extends TestCase
         ));
     }
 
+    public function testTransientRuntimeExceptionPropagatesWithoutMarkingFailed(): void
+    {
+        // Ozon 429 «Превышен лимит активных запросов» и прочие transient
+        // (5xx, сеть, JSON) проходят наружу как \RuntimeException —
+        // Messenger ретраит по расписанию async_ads, markFailed не
+        // вызывается, Unrecoverable тоже.
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->asRunning()
+            ->build();
+
+        $jobRepo = $this->createMock(AdLoadJobRepository::class);
+        $jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $jobRepo->expects(self::never())->method('markFailed');
+
+        $ozonClient = $this->createMock(OzonAdClient::class);
+        $ozonClient->expects(self::once())
+            ->method('requestOneBatch')
+            ->willThrowException(new \RuntimeException('Ozon Performance: HTTP 429 Превышен лимит активных запросов'));
+
+        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, new NullLogger());
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('HTTP 429');
+
+        try {
+            $handler(new RequestOzonAdBatchMessage(
+                companyId: self::COMPANY_ID,
+                jobId: self::JOB_ID,
+                dateFrom: self::DATE_FROM,
+                dateTo: self::DATE_TO,
+                campaignIds: ['c1'],
+                batchIndex: 0,
+                batchTotal: 1,
+            ));
+        } catch (\RuntimeException $e) {
+            self::assertNotInstanceOf(
+                UnrecoverableMessageHandlingException::class,
+                $e,
+                'transient-ошибки не должны заворачиваться в Unrecoverable',
+            );
+            throw $e;
+        }
+    }
+
     public function testPermanentApiExceptionMarksFailedAndThrowsUnrecoverable(): void
     {
         // 403 / scope revoked → весь job обречён. Handler вызывает markFailed

--- a/site/tests/Unit/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandlerTest.php
@@ -12,6 +12,7 @@ use App\MarketplaceAds\Repository\AdLoadJobRepository;
 use App\Tests\Builders\MarketplaceAds\AdLoadJobBuilder;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
 /**
  * Unit-тесты {@see RequestOzonAdBatchHandler}: ровно один POST /statistics
@@ -57,6 +58,49 @@ final class RequestOzonAdBatchHandlerTest extends TestCase
             dateFrom: self::DATE_FROM,
             dateTo: self::DATE_TO,
             campaignIds: ['c1', 'c2'],
+            batchIndex: 0,
+            batchTotal: 1,
+        ));
+    }
+
+    public function testPermanentApiExceptionMarksFailedAndThrowsUnrecoverable(): void
+    {
+        // 403 / scope revoked → весь job обречён. Handler вызывает markFailed
+        // и оборачивает ошибку в Unrecoverable — Messenger не ретраит, а
+        // оставшиеся батчи того же job'а упадут с «job уже терминален»
+        // и станут no-op (см. testTerminalJobIsNoop).
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->asRunning()
+            ->build();
+
+        $jobRepo = $this->createMock(AdLoadJobRepository::class);
+        $jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $jobRepo->expects(self::once())
+            ->method('markFailed')
+            ->with(
+                self::JOB_ID,
+                self::COMPANY_ID,
+                self::stringContains('Ozon Performance'),
+            )
+            ->willReturn(1);
+
+        $ozonClient = $this->createMock(OzonAdClient::class);
+        $ozonClient->expects(self::once())
+            ->method('requestOneBatch')
+            ->willThrowException(new OzonPermanentApiException('403 — нет скоупа «Продвижение»'));
+
+        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, new NullLogger());
+
+        $this->expectException(UnrecoverableMessageHandlingException::class);
+        $this->expectExceptionMessage('Ozon permanent failure');
+
+        $handler(new RequestOzonAdBatchMessage(
+            companyId: self::COMPANY_ID,
+            jobId: self::JOB_ID,
+            dateFrom: self::DATE_FROM,
+            dateTo: self::DATE_TO,
+            campaignIds: ['c1'],
             batchIndex: 0,
             batchTotal: 1,
         ));

--- a/site/tests/Unit/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandlerTest.php
@@ -63,6 +63,46 @@ final class RequestOzonAdBatchHandlerTest extends TestCase
         ));
     }
 
+    public function testOversizedBatchThrowsUnrecoverable(): void
+    {
+        // Defense-in-depth: Ozon принимает не более 10 campaignIds. Orchestrator
+        // бьёт через array_chunk(..., 10), но если кто-то задиспатчит сообщение
+        // руками с 11+ id, Ozon ответит 4xx — такие ошибки транспортируются
+        // через обычный \RuntimeException и иначе ретраились бы forever. Guard
+        // в handler'е ловит это один раз и отправляет сообщение в dead-letter.
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->asRunning()
+            ->build();
+
+        $jobRepo = $this->createMock(AdLoadJobRepository::class);
+        $jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $jobRepo->expects(self::never())->method('markFailed');
+
+        $ozonClient = $this->createMock(OzonAdClient::class);
+        $ozonClient->expects(self::never())->method('requestOneBatch');
+
+        $oversized = [];
+        for ($i = 1; $i <= 11; ++$i) {
+            $oversized[] = 'c'.$i;
+        }
+
+        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, new NullLogger());
+
+        $this->expectException(UnrecoverableMessageHandlingException::class);
+        $this->expectExceptionMessage('campaignIds size 11 out of [1..10]');
+
+        $handler(new RequestOzonAdBatchMessage(
+            companyId: self::COMPANY_ID,
+            jobId: self::JOB_ID,
+            dateFrom: self::DATE_FROM,
+            dateTo: self::DATE_TO,
+            campaignIds: $oversized,
+            batchIndex: 0,
+            batchTotal: 1,
+        ));
+    }
+
     public function testTransientRuntimeExceptionPropagatesWithoutMarkingFailed(): void
     {
         // Ozon 429 «Превышен лимит активных запросов» и прочие transient

--- a/site/tests/Unit/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandlerTest.php
@@ -61,4 +61,33 @@ final class RequestOzonAdBatchHandlerTest extends TestCase
             batchTotal: 1,
         ));
     }
+
+    public function testTerminalJobIsNoop(): void
+    {
+        // Если job уже в терминальном статусе (успел зафейлиться другим
+        // батчем / был вручную отменён), handler должен молча ack'нуть
+        // сообщение — никакого POST в Ozon и никакого markFailed.
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->asFailed('уже упал раньше')
+            ->build();
+
+        $jobRepo = $this->createMock(AdLoadJobRepository::class);
+        $jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $jobRepo->expects(self::never())->method('markFailed');
+
+        $ozonClient = $this->createMock(OzonAdClient::class);
+        $ozonClient->expects(self::never())->method('requestOneBatch');
+
+        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, new NullLogger());
+        $handler(new RequestOzonAdBatchMessage(
+            companyId: self::COMPANY_ID,
+            jobId: self::JOB_ID,
+            dateFrom: self::DATE_FROM,
+            dateTo: self::DATE_TO,
+            campaignIds: ['c1'],
+            batchIndex: 0,
+            batchTotal: 1,
+        ));
+    }
 }


### PR DESCRIPTION
## Summary

Refactor the Ozon ad statistics request pipeline to serialize POST /statistics requests through a dedicated async message handler, working around Ozon's rate limit of 1 active request per account.

## Problem

The previous implementation called `requestStatisticsOnly()` from `FetchOzonAdStatisticsHandler`, which internally batched campaigns and issued multiple POST /statistics requests back-to-back. This violated Ozon's API constraint of allowing only 1 active /statistics request per account, causing 429 errors on the 2nd+ batch.

## Solution

Split the request pipeline into two stages:

1. **Preparation stage** (`FetchOzonAdStatisticsHandler`):
   - Calls new `OzonAdClient::prepareStatisticsBatches()` to fetch campaigns and split into batches
   - Does NOT issue any POST requests
   - Dispatches one `RequestOzonAdBatchMessage` per batch to the `async_ads` transport

2. **Request stage** (`RequestOzonAdBatchHandler`):
   - New handler processes one batch message at a time
   - Calls new `OzonAdClient::requestOneBatch()` to POST a single batch
   - Single-worker `async_ads` transport ensures sequential processing, serializing Ozon's rate limit without sleep-based throttling

## Key Changes

- **New message class**: `RequestOzonAdBatchMessage` carries batch metadata (companyId, jobId, dateRange, campaignIds, batch indices)
- **New handler**: `RequestOzonAdBatchHandler` processes one batch message, with idempotent resume logic via `matchResumableReport()` to prevent duplicate POSTs on Messenger retry
- **New OzonAdClient methods**:
  - `prepareStatisticsBatches()`: resolves credentials, fetches campaigns, filters by date range, returns list of campaign ID batches
  - `requestOneBatch()`: POSTs a single batch with resume/dedup protection
- **Updated FetchOzonAdStatisticsHandler**:
  - Calls `prepareStatisticsBatches()` instead of `requestStatisticsOnly()`
  - Dispatches batch messages via `MessageBusInterface`
  - Maintains zero-batches finalization logic for empty campaign lists
- **Messenger routing**: Added `RequestOzonAdBatchMessage` to `async_ads` transport in messenger.yaml

## Implementation Details

- Resume logic in `requestOneBatch()` checks `pendingReportRepo.findInFlightByJob()` and reuses existing UUID if a matching batch is already in-flight (900s window), providing idempotency across Messenger retries
- Error handling: permanent API errors (403) mark the job as failed; transient errors (429, 5xx, network) are retried by Messenger with exponential backoff
- Logging updated to reflect "dispatched" vs "requested" semantics at each stage
- Tests updated to verify batch message dispatch instead of direct UUID collection

https://claude.ai/code/session_014DHF6NeBQV7oFyffLnSBtX