### PR TITLE
Handle Ozon HTTP 429 rate limits with message rescheduling

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -686,6 +686,31 @@ Previously FetchOzonAdStatisticsHandler called requestStatisticsOnly,
 which looped N POSTs back-to-back and reliably hit 429 on the 2nd
 batch for companies with >10 active SKU campaigns.
 
+### Ozon rate limit — «max 1 active /statistics request per account»
+
+FIFO+single-worker (PR #1629) serializes our HTTP calls but does NOT
+satisfy Ozon's "1 active request" constraint — Ozon measures this on
+their backend (UUID-creation occupancy), which outlasts our HTTP
+round-trip by 30–60 seconds. A POST that returns 200 in 150ms on our
+side still occupies a slot on Ozon's side, so the next POST within
+that window is guaranteed to 429.
+
+`OzonAdClient::authorizedRequest` distinguishes HTTP 429 from other
+non-2xx responses and throws `OzonRateLimitException` (extends
+`\RuntimeException`). `RequestOzonAdBatchHandler` catches it and
+reschedules the same message via
+`MessageBusInterface::dispatch(new Envelope($msg), [new DelayStamp(60_000)])`.
+The current message is ACK'd (no Messenger retry consumed, no failure
+transport). The rescheduled message reappears in `async_ads` 60s later,
+by which time Ozon's backend slot has typically freed.
+
+`RequestOzonAdBatchMessage::$rateLimitAttempts` counts reschedules and
+caps them at 10 per batch (10 minutes total per-batch wait). Exceeding
+this marks the job failed via `AdLoadJobRepository::markFailed()` and
+raises `UnrecoverableMessageHandlingException` — functionally equivalent
+to the `OzonPermanentApiException` branch but with a different reason
+string.
+
 Параллельно cron */2 * * * *:
 app:marketplace-ads:ozon-poll-reports → OzonPollReportsCommand → OzonAdReportPoller
   ↓ (GET /statistics/list per active company; reconcile state per UUID)

--- a/site/src/MarketplaceAds/Exception/OzonRateLimitException.php
+++ b/site/src/MarketplaceAds/Exception/OzonRateLimitException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Exception;
+
+/**
+ * Ozon Performance API returned HTTP 429 — "max 1 active request".
+ *
+ * Ozon's backend measures this by UUID-creation occupancy, not by
+ * concurrent HTTP connections. Retrying within seconds is futile.
+ *
+ * The handler catches this and reschedules the message via DelayStamp
+ * so the worker stays free and the message reappears after Ozon's
+ * backend releases the slot (typically 30-60 seconds).
+ */
+final class OzonRateLimitException extends \RuntimeException
+{
+    public function __construct(string $message = 'Ozon Performance: HTTP 429, rate-limited', ?\Throwable $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
+++ b/site/src/MarketplaceAds/Infrastructure/Api/Ozon/OzonAdClient.php
@@ -9,6 +9,7 @@ use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Facade\MarketplaceFacade;
 use App\MarketplaceAds\Entity\OzonAdPendingReport;
 use App\MarketplaceAds\Enum\OzonAdPendingReportState;
+use App\MarketplaceAds\Exception\OzonRateLimitException;
 use App\MarketplaceAds\Exception\OzonStatisticsQueueFullException;
 use App\MarketplaceAds\Infrastructure\Api\Contract\AdPlatformClientInterface;
 use App\MarketplaceAds\Repository\OzonAdPendingReportRepository;
@@ -2064,7 +2065,13 @@ class OzonAdClient implements AdPlatformClientInterface
                 // диагностический статус не был подменён TransportException'ом.
                 $bodyPreview = '<body unavailable>';
             }
-            throw new \RuntimeException(sprintf('Ozon Performance: %s %s вернул HTTP %d, body: %s', $method, $urlOrPath, $statusCode, $bodyPreview));
+            $errorMessage = sprintf('Ozon Performance: %s %s вернул HTTP %d, body: %s', $method, $urlOrPath, $statusCode, $bodyPreview);
+
+            if (429 === $statusCode) {
+                throw new OzonRateLimitException($errorMessage);
+            }
+
+            throw new \RuntimeException($errorMessage);
         }
 
         return $response;

--- a/site/src/MarketplaceAds/Message/RequestOzonAdBatchMessage.php
+++ b/site/src/MarketplaceAds/Message/RequestOzonAdBatchMessage.php
@@ -18,6 +18,11 @@ namespace App\MarketplaceAds\Message;
  * Scalar-only payload per Messenger/CLAUDE.md rules. batchIndex + batchTotal
  * are optional for logic but помогают скоррелировать логи с исходным чанком
  * при дебаге.
+ *
+ * rateLimitAttempts counts how many times this batch has been rescheduled
+ * after an Ozon HTTP 429 (see {@see \App\MarketplaceAds\MessageHandler\RequestOzonAdBatchHandler}).
+ * Defaults to 0 on first dispatch; the handler increments it on each
+ * reschedule and gives up once the cap is exceeded.
  */
 final readonly class RequestOzonAdBatchMessage
 {
@@ -32,6 +37,7 @@ final readonly class RequestOzonAdBatchMessage
         public array $campaignIds,
         public int $batchIndex,
         public int $batchTotal,
+        public int $rateLimitAttempts = 0,
     ) {
     }
 }

--- a/site/src/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\MarketplaceAds\MessageHandler;
 
+use App\MarketplaceAds\Exception\OzonRateLimitException;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonAdClient;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonPermanentApiException;
 use App\MarketplaceAds\Message\RequestOzonAdBatchMessage;
@@ -11,7 +12,10 @@ use App\MarketplaceAds\Repository\AdLoadJobRepository;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
 
 /**
  * Async-обработчик {@see RequestOzonAdBatchMessage}: ровно один POST
@@ -27,10 +31,17 @@ use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
  *  - {@see OzonPermanentApiException} (403 / scope revoked) → markFailed на
  *    job'е + UnrecoverableMessageHandlingException. Оставшиеся батчи тоже
  *    упадут с «job уже терминален» и станут no-op.
- *  - Transient errors (429, 5xx, сеть) — пробрасываются, Messenger ретраит
- *    по расписанию async_ads (2 попытки, 30с базовой задержки, ×2). На
- *    retry matchResumableReport внутри requestOneBatch находит уже
- *    созданный pending-отчёт и пропускает re-POST (окно 900с).
+ *  - {@see OzonRateLimitException} (429) — это НЕ «ретраить через 30с»:
+ *    Ozon меряет «1 active request» на своей стороне через занятость
+ *    UUID-creation slot'а (30–60с), что переживает наш HTTP round-trip.
+ *    Handler диспатчит то же сообщение обратно с {@see DelayStamp} на 60с,
+ *    инкрементит `rateLimitAttempts` и возвращается нормально (ACK — без
+ *    Messenger-ретрая). После {@see self::MAX_RATE_LIMIT_ATTEMPTS} попыток
+ *    батч помечается как failed (same-as-permanent).
+ *  - Остальные transient errors (5xx, сеть) — пробрасываются, Messenger
+ *    ретраит по расписанию async_ads. На retry matchResumableReport внутри
+ *    requestOneBatch находит уже созданный pending-отчёт и пропускает
+ *    re-POST (окно 900с).
  */
 #[AsMessageHandler]
 final class RequestOzonAdBatchHandler
@@ -45,9 +56,25 @@ final class RequestOzonAdBatchHandler
      */
     private const STATISTICS_BATCH_SIZE = 10;
 
+    /**
+     * Ozon "1 active request" backend slot occupancy is 30-60s typically.
+     * 60s gives us a safety margin; jitter is naturally added by the
+     * moment we catch 429 (which is itself time-shifted by HTTP latency).
+     */
+    private const RATE_LIMIT_BACKOFF_MS = 60_000;
+
+    /**
+     * 10 * 60s = 10 min max delay per batch before we give up and mark
+     * the job failed. Беспредельный loop невозможен — Ozon либо отдаст
+     * 200 в пределах этого окна, либо проблема на их стороне затянулась
+     * и инженерам стоит посмотреть руками.
+     */
+    private const MAX_RATE_LIMIT_ATTEMPTS = 10;
+
     public function __construct(
         private readonly AdLoadJobRepository $jobRepository,
         private readonly OzonAdClient $ozonAdClient,
+        private readonly MessageBusInterface $messageBus,
         #[Autowire(service: 'monolog.logger.marketplace_ads')]
         private readonly LoggerInterface $marketplaceAdsLogger,
     ) {
@@ -134,6 +161,65 @@ final class RequestOzonAdBatchHandler
                 0,
                 $e,
             );
+        } catch (OzonRateLimitException $e) {
+            // Ozon backend busy with another /statistics request on this
+            // account. Reschedule THIS message with a 60s delay. This does
+            // NOT consume a Messenger retry attempt — current message is
+            // ACK'd (return normally, not throw), and a fresh copy goes back
+            // to async_ads with a 60-second wait.
+            //
+            // matchResumableReport on the rescheduled attempt still protects
+            // against double-POST if Ozon's slot freed up and we slip through
+            // while a prior attempt also lands.
+            if ($message->rateLimitAttempts >= self::MAX_RATE_LIMIT_ATTEMPTS) {
+                $this->marketplaceAdsLogger->warning('RequestOzonAdBatchMessage: exceeded rate-limit attempt cap — giving up', [
+                    'jobId' => $message->jobId,
+                    'companyId' => $message->companyId,
+                    'batchIndex' => $message->batchIndex,
+                    'batchTotal' => $message->batchTotal,
+                    'attempts' => $message->rateLimitAttempts,
+                ]);
+
+                $this->jobRepository->markFailed(
+                    $message->jobId,
+                    $message->companyId,
+                    sprintf('Ozon Performance: rate-limited >%d attempts — aborting batch', self::MAX_RATE_LIMIT_ATTEMPTS),
+                );
+
+                throw new UnrecoverableMessageHandlingException(
+                    'RequestOzonAdBatchMessage: Ozon rate limit exhausted',
+                    0,
+                    $e,
+                );
+            }
+
+            $next = new RequestOzonAdBatchMessage(
+                companyId: $message->companyId,
+                jobId: $message->jobId,
+                dateFrom: $message->dateFrom,
+                dateTo: $message->dateTo,
+                campaignIds: $message->campaignIds,
+                batchIndex: $message->batchIndex,
+                batchTotal: $message->batchTotal,
+                rateLimitAttempts: $message->rateLimitAttempts + 1,
+            );
+
+            $this->messageBus->dispatch(
+                new Envelope($next),
+                [new DelayStamp(self::RATE_LIMIT_BACKOFF_MS)],
+            );
+
+            $this->marketplaceAdsLogger->info('RequestOzonAdBatchMessage: Ozon 429 — rescheduled with delay', [
+                'jobId' => $message->jobId,
+                'companyId' => $message->companyId,
+                'batchIndex' => $message->batchIndex,
+                'batchTotal' => $message->batchTotal,
+                'attempts' => $next->rateLimitAttempts,
+                'delayMs' => self::RATE_LIMIT_BACKOFF_MS,
+            ]);
+
+            // ACK current message — reschedule is the retry.
+            return;
         }
 
         $this->marketplaceAdsLogger->info('RequestOzonAdBatchMessage: batch requested', [

--- a/site/tests/Unit/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\MarketplaceAds\MessageHandler;
 
+use App\MarketplaceAds\Exception\OzonRateLimitException;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonAdClient;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonPermanentApiException;
 use App\MarketplaceAds\Message\RequestOzonAdBatchMessage;
@@ -12,12 +13,15 @@ use App\MarketplaceAds\Repository\AdLoadJobRepository;
 use App\Tests\Builders\MarketplaceAds\AdLoadJobBuilder;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
 
 /**
  * Unit-тесты {@see RequestOzonAdBatchHandler}: ровно один POST /statistics
  * на сообщение, с корректной обработкой terminal / missing / permanent /
- * transient сценариев.
+ * transient / rate-limited сценариев.
  */
 final class RequestOzonAdBatchHandlerTest extends TestCase
 {
@@ -51,7 +55,10 @@ final class RequestOzonAdBatchHandlerTest extends TestCase
             )
             ->willReturn('uuid-1');
 
-        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, new NullLogger());
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::never())->method('dispatch');
+
+        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, $bus, new NullLogger());
         $handler(new RequestOzonAdBatchMessage(
             companyId: self::COMPANY_ID,
             jobId: self::JOB_ID,
@@ -82,12 +89,15 @@ final class RequestOzonAdBatchHandlerTest extends TestCase
         $ozonClient = $this->createMock(OzonAdClient::class);
         $ozonClient->expects(self::never())->method('requestOneBatch');
 
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::never())->method('dispatch');
+
         $oversized = [];
         for ($i = 1; $i <= 11; ++$i) {
             $oversized[] = 'c'.$i;
         }
 
-        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, new NullLogger());
+        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, $bus, new NullLogger());
 
         $this->expectException(UnrecoverableMessageHandlingException::class);
         $this->expectExceptionMessage('campaignIds size 11 out of [1..10]');
@@ -105,10 +115,10 @@ final class RequestOzonAdBatchHandlerTest extends TestCase
 
     public function testTransientRuntimeExceptionPropagatesWithoutMarkingFailed(): void
     {
-        // Ozon 429 «Превышен лимит активных запросов» и прочие transient
-        // (5xx, сеть, JSON) проходят наружу как \RuntimeException —
+        // Generic \RuntimeException (5xx, сеть, JSON) проходит наружу —
         // Messenger ретраит по расписанию async_ads, markFailed не
-        // вызывается, Unrecoverable тоже.
+        // вызывается, Unrecoverable тоже, и reschedule через bus не
+        // диспатчится (это только для 429-веточки).
         $job = AdLoadJobBuilder::aJob()
             ->withCompanyId(self::COMPANY_ID)
             ->asRunning()
@@ -121,12 +131,15 @@ final class RequestOzonAdBatchHandlerTest extends TestCase
         $ozonClient = $this->createMock(OzonAdClient::class);
         $ozonClient->expects(self::once())
             ->method('requestOneBatch')
-            ->willThrowException(new \RuntimeException('Ozon Performance: HTTP 429 Превышен лимит активных запросов'));
+            ->willThrowException(new \RuntimeException('Ozon Performance: HTTP 500 internal'));
 
-        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, new NullLogger());
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::never())->method('dispatch');
+
+        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, $bus, new NullLogger());
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('HTTP 429');
+        $this->expectExceptionMessage('HTTP 500');
 
         try {
             $handler(new RequestOzonAdBatchMessage(
@@ -143,6 +156,11 @@ final class RequestOzonAdBatchHandlerTest extends TestCase
                 UnrecoverableMessageHandlingException::class,
                 $e,
                 'transient-ошибки не должны заворачиваться в Unrecoverable',
+            );
+            self::assertNotInstanceOf(
+                OzonRateLimitException::class,
+                $e,
+                'generic RuntimeException не должен интерпретироваться как 429',
             );
             throw $e;
         }
@@ -175,7 +193,10 @@ final class RequestOzonAdBatchHandlerTest extends TestCase
             ->method('requestOneBatch')
             ->willThrowException(new OzonPermanentApiException('403 — нет скоупа «Продвижение»'));
 
-        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, new NullLogger());
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::never())->method('dispatch');
+
+        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, $bus, new NullLogger());
 
         $this->expectException(UnrecoverableMessageHandlingException::class);
         $this->expectExceptionMessage('Ozon permanent failure');
@@ -203,7 +224,10 @@ final class RequestOzonAdBatchHandlerTest extends TestCase
         $ozonClient = $this->createMock(OzonAdClient::class);
         $ozonClient->expects(self::never())->method('requestOneBatch');
 
-        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, new NullLogger());
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::never())->method('dispatch');
+
+        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, $bus, new NullLogger());
         $handler(new RequestOzonAdBatchMessage(
             companyId: self::COMPANY_ID,
             jobId: self::JOB_ID,
@@ -232,7 +256,10 @@ final class RequestOzonAdBatchHandlerTest extends TestCase
         $ozonClient = $this->createMock(OzonAdClient::class);
         $ozonClient->expects(self::never())->method('requestOneBatch');
 
-        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, new NullLogger());
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::never())->method('dispatch');
+
+        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, $bus, new NullLogger());
         $handler(new RequestOzonAdBatchMessage(
             companyId: self::COMPANY_ID,
             jobId: self::JOB_ID,
@@ -241,6 +268,150 @@ final class RequestOzonAdBatchHandlerTest extends TestCase
             campaignIds: ['c1'],
             batchIndex: 0,
             batchTotal: 1,
+        ));
+    }
+
+    public function testRateLimitExceptionReschedulesWithDelay(): void
+    {
+        // 429 от Ozon → handler диспатчит копию сообщения с DelayStamp(60_000)
+        // и возвращается нормально (ACK). markFailed НЕ вызывается, никаких
+        // исключений наружу — иначе Messenger посчитал бы это за retry и
+        // в конце концов отправил бы сообщение в failure transport.
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->asRunning()
+            ->build();
+
+        $jobRepo = $this->createMock(AdLoadJobRepository::class);
+        $jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $jobRepo->expects(self::never())->method('markFailed');
+
+        $ozonClient = $this->createMock(OzonAdClient::class);
+        $ozonClient->expects(self::once())
+            ->method('requestOneBatch')
+            ->willThrowException(new OzonRateLimitException('Ozon Performance: HTTP 429 Превышен лимит активных запросов'));
+
+        $capturedEnvelope = null;
+        $capturedStamps = null;
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::once())
+            ->method('dispatch')
+            ->willReturnCallback(static function (object $env, array $stamps) use (&$capturedEnvelope, &$capturedStamps): Envelope {
+                $capturedEnvelope = $env;
+                $capturedStamps = $stamps;
+
+                return $env instanceof Envelope ? $env : new Envelope($env);
+            });
+
+        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, $bus, new NullLogger());
+        $handler(new RequestOzonAdBatchMessage(
+            companyId: self::COMPANY_ID,
+            jobId: self::JOB_ID,
+            dateFrom: self::DATE_FROM,
+            dateTo: self::DATE_TO,
+            campaignIds: ['c1', 'c2'],
+            batchIndex: 0,
+            batchTotal: 1,
+        ));
+
+        self::assertInstanceOf(Envelope::class, $capturedEnvelope);
+        $rescheduled = $capturedEnvelope->getMessage();
+        self::assertInstanceOf(RequestOzonAdBatchMessage::class, $rescheduled);
+        self::assertSame(self::COMPANY_ID, $rescheduled->companyId);
+        self::assertSame(self::JOB_ID, $rescheduled->jobId);
+        self::assertSame(['c1', 'c2'], $rescheduled->campaignIds);
+
+        self::assertIsArray($capturedStamps);
+        self::assertCount(1, $capturedStamps);
+        self::assertInstanceOf(DelayStamp::class, $capturedStamps[0]);
+        self::assertSame(60_000, $capturedStamps[0]->getDelay());
+    }
+
+    public function testRateLimitIncrementsAttemptsOnReschedule(): void
+    {
+        // rateLimitAttempts: 0 → 1 на первом 429, 3 → 4 на четвёртом и т.д.
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->asRunning()
+            ->build();
+
+        $jobRepo = $this->createMock(AdLoadJobRepository::class);
+        $jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $jobRepo->expects(self::never())->method('markFailed');
+
+        $ozonClient = $this->createMock(OzonAdClient::class);
+        $ozonClient->method('requestOneBatch')
+            ->willThrowException(new OzonRateLimitException());
+
+        $captured = null;
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::once())
+            ->method('dispatch')
+            ->willReturnCallback(static function (object $env) use (&$captured): Envelope {
+                $captured = $env;
+
+                return $env instanceof Envelope ? $env : new Envelope($env);
+            });
+
+        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, $bus, new NullLogger());
+        $handler(new RequestOzonAdBatchMessage(
+            companyId: self::COMPANY_ID,
+            jobId: self::JOB_ID,
+            dateFrom: self::DATE_FROM,
+            dateTo: self::DATE_TO,
+            campaignIds: ['c1'],
+            batchIndex: 0,
+            batchTotal: 1,
+            rateLimitAttempts: 3,
+        ));
+
+        self::assertInstanceOf(Envelope::class, $captured);
+        $rescheduled = $captured->getMessage();
+        self::assertInstanceOf(RequestOzonAdBatchMessage::class, $rescheduled);
+        self::assertSame(4, $rescheduled->rateLimitAttempts);
+    }
+
+    public function testRateLimitMaxAttemptsMarksFailedAndUnrecoverable(): void
+    {
+        // После MAX_RATE_LIMIT_ATTEMPTS (10) reschedules handler сдаётся:
+        // markFailed на job, Unrecoverable наружу, новых сообщений в bus нет.
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->asRunning()
+            ->build();
+
+        $jobRepo = $this->createMock(AdLoadJobRepository::class);
+        $jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $jobRepo->expects(self::once())
+            ->method('markFailed')
+            ->with(
+                self::JOB_ID,
+                self::COMPANY_ID,
+                self::stringContains('rate-limited'),
+            )
+            ->willReturn(1);
+
+        $ozonClient = $this->createMock(OzonAdClient::class);
+        $ozonClient->method('requestOneBatch')
+            ->willThrowException(new OzonRateLimitException());
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::never())->method('dispatch');
+
+        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, $bus, new NullLogger());
+
+        $this->expectException(UnrecoverableMessageHandlingException::class);
+        $this->expectExceptionMessage('Ozon rate limit exhausted');
+
+        $handler(new RequestOzonAdBatchMessage(
+            companyId: self::COMPANY_ID,
+            jobId: self::JOB_ID,
+            dateFrom: self::DATE_FROM,
+            dateTo: self::DATE_TO,
+            campaignIds: ['c1'],
+            batchIndex: 0,
+            batchTotal: 1,
+            rateLimitAttempts: 10,
         ));
     }
 }


### PR DESCRIPTION
## Summary
Implements proper handling of Ozon Performance API's HTTP 429 "max 1 active request" constraint by rescheduling messages with a 60-second delay instead of relying on Messenger's retry mechanism, which is ineffective against Ozon's backend slot occupancy (30–60s).

## Key Changes

- **New exception class** `OzonRateLimitException`: Distinguishes HTTP 429 responses from other transient errors in `OzonAdClient::authorizedRequest()`

- **Message rescheduling logic** in `RequestOzonAdBatchHandler`:
  - Catches `OzonRateLimitException` and dispatches a fresh copy of the message via `MessageBusInterface` with a `DelayStamp(60_000)`
  - Increments `rateLimitAttempts` counter on each reschedule
  - Caps reschedules at 10 attempts (10 minutes total per batch)
  - Exceeding the cap marks the job as failed and throws `UnrecoverableMessageHandlingException`
  - Current message is ACK'd (returns normally) — no Messenger retry consumed

- **Updated `RequestOzonAdBatchMessage`**: Added optional `rateLimitAttempts` field (defaults to 0) to track reschedule count across message dispatches

- **Updated `RequestOzonAdBatchHandler` constructor**: Now accepts `MessageBusInterface` for rescheduling capability

- **Comprehensive test coverage**: Added three new test cases covering rate-limit reschedule behavior, attempt counter increment, and max-attempts exhaustion

## Implementation Details

The key insight is that Ozon's "1 active request" constraint is measured by UUID-creation slot occupancy on their backend, not by concurrent HTTP connections. A request that completes in 150ms still occupies a slot for 30–60 seconds, making immediate Messenger retries (with 30s base delay) ineffective.

The solution uses `MessageBusInterface::dispatch()` with `DelayStamp` to return the message to the queue after 60 seconds, allowing the worker to process other messages in the meantime. The current message is ACK'd without consuming a Messenger retry attempt, preventing eventual routing to the failure transport.

The `rateLimitAttempts` counter ensures we don't loop indefinitely; 10 attempts (10 minutes) is a reasonable cap before treating it as a permanent failure.

https://claude.ai/code/session_01Xvj5s6bu6Kdfb1vrE5FDrr