### PR TITLE
Space Ozon ad batch dispatches to avoid rate limit 429s

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -688,21 +688,31 @@ batch for companies with >10 active SKU campaigns.
 
 ### Ozon rate limit — «max 1 active /statistics request per account»
 
-FIFO+single-worker (PR #1629) serializes our HTTP calls but does NOT
-satisfy Ozon's "1 active request" constraint — Ozon measures this on
-their backend (UUID-creation occupancy), which outlasts our HTTP
-round-trip by 30–60 seconds. A POST that returns 200 in 150ms on our
-side still occupies a slot on Ozon's side, so the next POST within
-that window is guaranteed to 429.
+Ozon measures rate limit by backend UUID-creation slot occupancy
+(30–60s per POST), not by concurrent HTTP connections. A single
+async_ads worker + FIFO Redis transport serializes our POSTs in
+SEQUENCE but not in TIME — worker processes N messages in ~Ns total,
+hitting 429 on batches 2..N.
 
-`OzonAdClient::authorizedRequest` distinguishes HTTP 429 from other
-non-2xx responses and throws `OzonRateLimitException` (extends
-`\RuntimeException`). `RequestOzonAdBatchHandler` catches it and
-reschedules the same message via
-`MessageBusInterface::dispatch(new Envelope($msg), [new DelayStamp(60_000)])`.
+`FetchOzonAdStatisticsHandler` spaces batches at dispatch:
+
+    batch #i → DelayStamp(i × 90_000 ms)
+
+So the worker picks up batch #0 immediately, sits idle, picks up
+batch #1 at t=90s, etc. Ozon's slot is free by the time each POST
+lands. For N batches, wall-time sync duration ≈ N × 90 seconds.
+
+The `OzonRateLimitException` → reschedule path in
+`RequestOzonAdBatchHandler` remains as a safety net: if external
+activity on the same Ozon account coincides with our slot, or if
+Ozon's slot occupancy exceeds 90s, a 429 is caught and the batch
+reschedules with `DelayStamp(60_000)`. `OzonAdClient::authorizedRequest`
+distinguishes HTTP 429 from other non-2xx responses and throws
+`OzonRateLimitException` (extends `\RuntimeException`).
+`RequestOzonAdBatchHandler` catches it and reschedules the same message
+via `MessageBusInterface::dispatch(new Envelope($msg), [new DelayStamp(60_000)])`.
 The current message is ACK'd (no Messenger retry consumed, no failure
-transport). The rescheduled message reappears in `async_ads` 60s later,
-by which time Ozon's backend slot has typically freed.
+transport).
 
 `RequestOzonAdBatchMessage::$rateLimitAttempts` counts reschedules and
 caps them at 10 per batch (10 minutes total per-batch wait). Exceeding

--- a/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
@@ -17,8 +17,10 @@ use App\Shared\Service\AppLogger;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
 
 /**
  * Async-обработчик {@see FetchOzonAdStatisticsMessage} — orchestrator'ом one-
@@ -74,6 +76,23 @@ use Symfony\Component\Messenger\MessageBusInterface;
 #[AsMessageHandler]
 final class FetchOzonAdStatisticsHandler
 {
+    /**
+     * Ozon Performance API: "max 1 active /statistics request per account".
+     * Ozon's backend slot occupancy is typically 30-60s. 90s gives us a
+     * safety margin.
+     *
+     * When dispatching N batches for a chunk, we space them:
+     * batch #0 → immediately, batch #i → DelayStamp(i × BATCH_SPACING_MS).
+     *
+     * This prevents the single async_ads worker from issuing N POSTs in
+     * ~Ns wall time (which Ozon rate-limits to 429 on all but the first).
+     *
+     * The 429-reschedule in RequestOzonAdBatchHandler remains as a safety
+     * net for edge cases (Ozon slower than 90s, or concurrent external
+     * activity on the same account).
+     */
+    private const BATCH_SPACING_MS = 90_000;
+
     public function __construct(
         private readonly OzonAdClient $ozonAdClient,
         private readonly AdLoadJobRepository $adLoadJobRepository,
@@ -203,7 +222,7 @@ final class FetchOzonAdStatisticsHandler
         // RequestOzonAdBatchHandler даёт идемпотентность при Messenger-retry.
         $batchTotal = count($batches);
         foreach ($batches as $batchIndex => $campaignIds) {
-            $this->messageBus->dispatch(new RequestOzonAdBatchMessage(
+            $envelope = new Envelope(new RequestOzonAdBatchMessage(
                 companyId: $message->companyId,
                 jobId: $message->jobId,
                 dateFrom: $message->dateFrom,
@@ -212,6 +231,26 @@ final class FetchOzonAdStatisticsHandler
                 batchIndex: $batchIndex,
                 batchTotal: $batchTotal,
             ));
+
+            // Space batches in time to avoid Ozon "max 1 active request" 429s.
+            // Batch #0 dispatches immediately; subsequent batches delayed by
+            // BATCH_SPACING_MS per their index.
+            if ($batchIndex > 0) {
+                $envelope = $envelope->with(new DelayStamp($batchIndex * self::BATCH_SPACING_MS));
+            }
+
+            $this->messageBus->dispatch($envelope);
+        }
+
+        if ($batchTotal > 1) {
+            $totalDelaySec = (int) (($batchTotal - 1) * self::BATCH_SPACING_MS / 1000);
+            $this->marketplaceAdsLogger->info('Ozon ad batches dispatched with time spacing', [
+                'jobId' => $message->jobId,
+                'companyId' => $message->companyId,
+                'batchTotal' => $batchTotal,
+                'batchSpacingSeconds' => self::BATCH_SPACING_MS / 1000,
+                'estimatedWallTime' => $totalDelaySec.'s',
+            ]);
         }
 
         // Идемпотентная фиксация чанка — в async-flow означает «запрос отправлен»,

--- a/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
@@ -24,6 +24,7 @@ use Sentry\State\HubInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
 
 // AdLoadJobFinalizer — final readonly, нужен BypassFinals для createMock.
 BypassFinals::allowPaths([
@@ -105,10 +106,11 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $messageBus = $this->createMock(MessageBusInterface::class);
         $messageBus->expects(self::exactly(2))
             ->method('dispatch')
-            ->willReturnCallback(static function (object $m) use (&$dispatched): Envelope {
-                $dispatched[] = $m;
+            ->willReturnCallback(static function (object $envelope) use (&$dispatched): Envelope {
+                self::assertInstanceOf(Envelope::class, $envelope);
+                $dispatched[] = $envelope;
 
-                return new Envelope($m);
+                return $envelope;
             });
 
         $handler = $this->createHandler($ozonClient, $jobRepo, $chunkProgressRepo, $pendingRepo, $finalizer, $messageBus);
@@ -120,7 +122,8 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         ));
 
         self::assertCount(2, $dispatched);
-        foreach ($dispatched as $i => $m) {
+        foreach ($dispatched as $i => $envelope) {
+            $m = $envelope->getMessage();
             self::assertInstanceOf(RequestOzonAdBatchMessage::class, $m);
             self::assertSame(self::JOB_ID, $m->jobId);
             self::assertSame(self::COMPANY_ID, $m->companyId);
@@ -129,8 +132,121 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             self::assertSame($i, $m->batchIndex);
             self::assertSame(2, $m->batchTotal);
         }
-        self::assertSame(['c1', 'c2'], $dispatched[0]->campaignIds);
-        self::assertSame(['c3'], $dispatched[1]->campaignIds);
+        self::assertSame(['c1', 'c2'], $dispatched[0]->getMessage()->campaignIds);
+        self::assertSame(['c3'], $dispatched[1]->getMessage()->campaignIds);
+    }
+
+    public function testDispatchesBatchesWithJitteredDelay(): void
+    {
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withDateRange(new \DateTimeImmutable(self::DATE_FROM), new \DateTimeImmutable(self::DATE_TO))
+            ->asRunning()
+            ->build();
+
+        $jobRepo = $this->createMock(AdLoadJobRepository::class);
+        $jobRepo->method('findByIdAndCompany')->willReturn($job);
+
+        $ozonClient = $this->createMock(OzonAdClient::class);
+        $ozonClient->method('prepareStatisticsBatches')
+            ->willReturn([
+                ['c1', 'c2', 'c3'],
+                ['c4', 'c5', 'c6'],
+                ['c7', 'c8', 'c9'],
+            ]);
+
+        $chunkProgressRepo = $this->createMock(AdChunkProgressRepositoryInterface::class);
+        $chunkProgressRepo->method('markChunkCompleted')->willReturn(true);
+
+        $pendingRepo = $this->createMock(OzonAdPendingReportRepository::class);
+
+        $finalizer = $this->createMock(AdLoadJobFinalizer::class);
+        $finalizer->expects(self::never())->method('tryFinalize');
+
+        $dispatched = [];
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::exactly(3))
+            ->method('dispatch')
+            ->willReturnCallback(static function (object $envelope) use (&$dispatched): Envelope {
+                self::assertInstanceOf(Envelope::class, $envelope);
+                $dispatched[] = $envelope;
+
+                return $envelope;
+            });
+
+        $handler = $this->createHandler($ozonClient, $jobRepo, $chunkProgressRepo, $pendingRepo, $finalizer, $messageBus);
+        $handler(new FetchOzonAdStatisticsMessage(
+            self::JOB_ID,
+            self::COMPANY_ID,
+            self::DATE_FROM,
+            self::DATE_TO,
+        ));
+
+        self::assertCount(3, $dispatched);
+
+        $stamps0 = $dispatched[0]->all(DelayStamp::class);
+        self::assertTrue(
+            [] === $stamps0 || 0 === $stamps0[0]->getDelay(),
+            'Batch 0 should dispatch without delay',
+        );
+
+        $stamps1 = $dispatched[1]->all(DelayStamp::class);
+        self::assertCount(1, $stamps1);
+        self::assertSame(90_000, $stamps1[0]->getDelay());
+
+        $stamps2 = $dispatched[2]->all(DelayStamp::class);
+        self::assertCount(1, $stamps2);
+        self::assertSame(180_000, $stamps2[0]->getDelay());
+    }
+
+    public function testSingleBatchDispatchesWithoutDelay(): void
+    {
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withDateRange(new \DateTimeImmutable(self::DATE_FROM), new \DateTimeImmutable(self::DATE_TO))
+            ->asRunning()
+            ->build();
+
+        $jobRepo = $this->createMock(AdLoadJobRepository::class);
+        $jobRepo->method('findByIdAndCompany')->willReturn($job);
+
+        $ozonClient = $this->createMock(OzonAdClient::class);
+        $ozonClient->method('prepareStatisticsBatches')
+            ->willReturn([['c1', 'c2']]);
+
+        $chunkProgressRepo = $this->createMock(AdChunkProgressRepositoryInterface::class);
+        $chunkProgressRepo->method('markChunkCompleted')->willReturn(true);
+
+        $pendingRepo = $this->createMock(OzonAdPendingReportRepository::class);
+
+        $finalizer = $this->createMock(AdLoadJobFinalizer::class);
+        $finalizer->expects(self::never())->method('tryFinalize');
+
+        $dispatched = null;
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::once())
+            ->method('dispatch')
+            ->willReturnCallback(static function (object $envelope) use (&$dispatched): Envelope {
+                self::assertInstanceOf(Envelope::class, $envelope);
+                $dispatched = $envelope;
+
+                return $envelope;
+            });
+
+        $handler = $this->createHandler($ozonClient, $jobRepo, $chunkProgressRepo, $pendingRepo, $finalizer, $messageBus);
+        $handler(new FetchOzonAdStatisticsMessage(
+            self::JOB_ID,
+            self::COMPANY_ID,
+            self::DATE_FROM,
+            self::DATE_TO,
+        ));
+
+        self::assertNotNull($dispatched);
+        $stamps = $dispatched->all(DelayStamp::class);
+        self::assertTrue(
+            [] === $stamps || 0 === $stamps[0]->getDelay(),
+            'Single batch should dispatch immediately (no DelayStamp)',
+        );
     }
 
     public function testZeroBatchesStillCallsMarkChunkCompletedAndFinalizer(): void


### PR DESCRIPTION
## Summary

Implements proactive rate limit handling for Ozon ad statistics requests by spacing batch dispatches in time rather than relying solely on reactive 429 reschedules. This prevents hitting Ozon's "max 1 active /statistics request per account" constraint, which measures backend slot occupancy (30–60s per request) rather than concurrent HTTP connections.

## Key Changes

- **FetchOzonAdStatisticsHandler**: Modified batch dispatch logic to wrap messages in `Envelope` objects with `DelayStamp` for time-spacing:
  - Batch #0 dispatches immediately (no delay)
  - Subsequent batches delayed by `batchIndex × 90_000ms` (90 seconds per batch)
  - Added `BATCH_SPACING_MS` constant with detailed documentation explaining the rate limit strategy
  - Added info-level logging when dispatching multiple batches to track wall-time estimates

- **Test coverage**: Added two new test cases:
  - `testDispatchesBatchesWithJitteredDelay()`: Verifies that 3 batches are dispatched with correct `DelayStamp` values (0ms, 90s, 180s)
  - `testSingleBatchDispatchesWithoutDelay()`: Confirms single-batch jobs dispatch immediately without delay
  - Updated `testHappyPathDispatchesOneBatchMessagePerBatchAndMarkChunkComple()` to work with `Envelope` objects and extract messages for assertions

- **Documentation**: Updated ARCHITECTURE.md to explain the new proactive spacing strategy and how it complements the existing reactive 429-reschedule safety net in `RequestOzonAdBatchHandler`

## Implementation Details

The solution leverages Symfony Messenger's `DelayStamp` to schedule batch processing with 90-second intervals. This allows a single async worker to process batches sequentially in wall-time rather than wall-clock time, ensuring Ozon's backend slot is freed before the next request arrives. The 90-second spacing provides a safety margin over Ozon's typical 30–60s slot occupancy.

The existing `OzonRateLimitException` → reschedule mechanism in `RequestOzonAdBatchHandler` remains as a fallback for edge cases (external concurrent activity on the same account or Ozon slot occupancy exceeding 90s).

https://claude.ai/code/session_013PKT1FUChPoDqS4k8J5ty9