### PR TITLE
Add backpressure gate to Ozon batch handler to respect 3-active-reports limit

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 > **Живой документ.** Обновляется после каждого нового модуля или изменения публичного контракта.
 > Читается: Claude Code (через CLAUDE.md) и Claude.ai Projects (через Knowledge).
-> Версия: 1.11 / 2026-04-19
+> Версия: 1.13 / 2026-04-23
 
 ---
 
@@ -467,6 +467,14 @@ findInFlightByJob(string $companyId, string $jobId): array
 // companyId обязателен и валидируется Assert::uuid().
 // @return list<OzonAdPendingReport>
 findInFlightByCompany(string $companyId): array
+
+// Счётчик in-flight pending reports (finalized_at IS NULL) конкретной company.
+// Используется backpressure-гейтом в RequestOzonAdBatchHandler: если >= 3
+// (Ozon жёсткий лимит «активных отчётов» на аккаунт) — POST не делается,
+// сообщение откладывается на 60с. Raw DBAL COUNT, без hydration — вызывается
+// на каждом сообщении и должен быть быстрым.
+// companyId обязателен и валидируется Assert::uuid().
+countInFlightByCompany(string $companyId): int
 
 // Distinct companyIds с хотя бы одной in-flight записью, готовой к опросу:
 // finalized_at IS NULL AND (next_poll_at IS NULL OR next_poll_at <= :now).
@@ -1261,4 +1269,5 @@ paths:
 | 1.9 | 2026-04-15 | MarketplaceAds: команды CLI переименованы в единый паттерн `app:marketplace-ads:*` — `marketplace-ads:load` → `app:marketplace-ads:load`, `marketplace-ads:reprocess` → `app:marketplace-ads:reprocess`. Приводит именование к общему для проекта префиксу `app:` (как у `app:marketplace:wb-daily-sync` и пр.). |
 | 1.10 | 2026-04-15 | Marketplace: UI модалки «Новое подключение» (`templates/marketplace/index.html.twig`) поддерживает два типа подключения — «Основное (Seller API)» и «Реклама (Performance API)». Тип `performance` доступен только при выборе Ozon, иначе опция скрыта и автоматически откатывается на `seller`. Form `action` переключается между `marketplace_connection_create` и `marketplace_connection_performance_create` без перезагрузки страницы; неактивный блок полей `disabled`, чтобы лишние поля не попадали в POST. В списке активных подключений для Performance подключения: суффикс «(Реклама)» к названию маркетплейса, скрыты кнопки «Синхронизировать», «За период», «Реализация», «Переобработать», строка синхронизации — статическая «—» (поллер статуса не запускается). |
 | 1.12 | 2026-04-22 | MarketplaceAds: `OzonAdRawDataParser` теперь принимает обе формы `raw_payload` — legacy flat `{"rows":[…]}` и nested `{"campaigns":[{campaign_id, campaign_name, rows:[…]}]}`, записываемый `DownloadOzonAdReportHandler` (шаг 4 async-poll редизайна). Парсер диспатчится по наличию ключа `campaigns`, пробрасывает `campaign_id` / `campaign_name` из родительского объекта в каждую row и делегирует агрегацию общему пути. Фикс silent no-op: до этого nested-payload уходил в `[]` → `ProcessAdRawDocumentAction` создавал 0 `AdDocument` и помечал `AdRawDocument` как `PROCESSED`, UI «Эффективность рекламы» показывал 0 затрат. Unit-тесты гарантируют идентичность entries для обеих форм. |
+| 1.13 | 2026-04-23 | MarketplaceAds: backpressure по in-flight pending_reports. Добавлен `OzonAdPendingReportRepository::countInFlightByCompany`. `RequestOzonAdBatchHandler` перед POST проверяет COUNT in-flight ≥ 3 (Ozon лимит «активных отчётов» на аккаунт) и откладывает сообщение на 60с без инкремента `rateLimitAttempts`. `BATCH_SPACING_MS = 90_000` из `FetchOzonAdStatisticsHandler` удалён — spacing больше не нужен при наличии backpressure. |
 | 1.11 | 2026-04-19 | MarketplaceAds: серия задач по Ozon Ads pipeline. Новые Entity: `AdLoadJob` (пакетная загрузка за период, атомарный счётчик `loadedDays` через raw SQL), `AdChunkProgress` (идемпотентная фиксация успеха чанка через `UniqueConstraint` `(job_id, date_from, date_to)`). Новый Message `LoadOzonAdStatisticsRangeMessage` + handler-оркестратор: PENDING → RUNNING, разбиение диапазона на чанки ≤ 62 дня (лимит Ozon Performance API), dispatch `FetchOzonAdStatisticsMessage` на каждый чанк. `FetchOzonAdStatisticsHandler`: upsert AdRawDocument + идемпотентный `markChunkCompleted` + inc `loadedDays` только при успешной фиксации чанка. Enum `AdRawDocumentStatus` расширен кейсом `FAILED` (+`isTerminal()`); финализация job'а перешла на per-document статус и считает через `countByCompanyMarketplaceAndDateRange`. Удалены мёртвые counter-поля `processedDays` / `failedDays` из `AdLoadJob` (миграция `Version20260419080739`). Новые методы репозиториев: `AdLoadJobRepository::markCompleted` / `markFailed` / `findRecentByCompanyAndMarketplace`; `AdChunkProgressRepository::markChunkCompleted` / `countCompletedChunks`; `AdRawDocumentRepository::markFailedWithReason` / `countByCompanyMarketplaceAndDateRange` / `findByCompanyMarketplaceAndDateRange`. |

--- a/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
@@ -17,10 +17,8 @@ use App\Shared\Service\AppLogger;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
-use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Messenger\Stamp\DelayStamp;
 
 /**
  * Async-обработчик {@see FetchOzonAdStatisticsMessage} — orchestrator'ом one-
@@ -76,23 +74,6 @@ use Symfony\Component\Messenger\Stamp\DelayStamp;
 #[AsMessageHandler]
 final class FetchOzonAdStatisticsHandler
 {
-    /**
-     * Ozon Performance API: "max 1 active /statistics request per account".
-     * Ozon's backend slot occupancy is typically 30-60s. 90s gives us a
-     * safety margin.
-     *
-     * When dispatching N batches for a chunk, we space them:
-     * batch #0 → immediately, batch #i → DelayStamp(i × BATCH_SPACING_MS).
-     *
-     * This prevents the single async_ads worker from issuing N POSTs in
-     * ~Ns wall time (which Ozon rate-limits to 429 on all but the first).
-     *
-     * The 429-reschedule in RequestOzonAdBatchHandler remains as a safety
-     * net for edge cases (Ozon slower than 90s, or concurrent external
-     * activity on the same account).
-     */
-    private const BATCH_SPACING_MS = 90_000;
-
     public function __construct(
         private readonly OzonAdClient $ozonAdClient,
         private readonly AdLoadJobRepository $adLoadJobRepository,
@@ -217,12 +198,13 @@ final class FetchOzonAdStatisticsHandler
         }
 
         // Диспатч по одному сообщению на батч — single async_ads worker
-        // обработает их последовательно, не нарушая Ozon'овский лимит
-        // «1 active /statistics request». matchResumableReport внутри
-        // RequestOzonAdBatchHandler даёт идемпотентность при Messenger-retry.
+        // обработает их последовательно. Ozon лимит «3 активных отчёта/аккаунт»
+        // обеспечивается backpressure-гейтом в RequestOzonAdBatchHandler
+        // (COUNT in-flight pending_reports до POST'а). matchResumableReport
+        // внутри RequestOzonAdBatchHandler даёт идемпотентность при Messenger-retry.
         $batchTotal = count($batches);
         foreach ($batches as $batchIndex => $campaignIds) {
-            $envelope = new Envelope(new RequestOzonAdBatchMessage(
+            $this->messageBus->dispatch(new RequestOzonAdBatchMessage(
                 companyId: $message->companyId,
                 jobId: $message->jobId,
                 dateFrom: $message->dateFrom,
@@ -231,26 +213,6 @@ final class FetchOzonAdStatisticsHandler
                 batchIndex: $batchIndex,
                 batchTotal: $batchTotal,
             ));
-
-            // Space batches in time to avoid Ozon "max 1 active request" 429s.
-            // Batch #0 dispatches immediately; subsequent batches delayed by
-            // BATCH_SPACING_MS per their index.
-            if ($batchIndex > 0) {
-                $envelope = $envelope->with(new DelayStamp($batchIndex * self::BATCH_SPACING_MS));
-            }
-
-            $this->messageBus->dispatch($envelope);
-        }
-
-        if ($batchTotal > 1) {
-            $totalDelaySec = (int) (($batchTotal - 1) * self::BATCH_SPACING_MS / 1000);
-            $this->marketplaceAdsLogger->info('Ozon ad batches dispatched with time spacing', [
-                'jobId' => $message->jobId,
-                'companyId' => $message->companyId,
-                'batchTotal' => $batchTotal,
-                'batchSpacingSeconds' => self::BATCH_SPACING_MS / 1000,
-                'estimatedWallTime' => $totalDelaySec.'s',
-            ]);
         }
 
         // Идемпотентная фиксация чанка — в async-flow означает «запрос отправлен»,

--- a/site/src/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandler.php
@@ -9,6 +9,7 @@ use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonAdClient;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonPermanentApiException;
 use App\MarketplaceAds\Message\RequestOzonAdBatchMessage;
 use App\MarketplaceAds\Repository\AdLoadJobRepository;
+use App\MarketplaceAds\Repository\OzonAdPendingReportRepository;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -71,9 +72,24 @@ final class RequestOzonAdBatchHandler
      */
     private const MAX_RATE_LIMIT_ATTEMPTS = 10;
 
+    /**
+     * Ozon Performance жёсткий лимит: не более 3 активных отчётов в очереди
+     * на один Performance-аккаунт. Превышение → 429 "Превышен лимит активных".
+     * Этот guard делает проверку на СТОРОНЕ КЛИЕНТА, до POST, по БД —
+     * предсказуемее, чем ловить 429 от Ozon.
+     */
+    private const MAX_IN_FLIGHT_PER_COMPANY = 3;
+
+    /**
+     * Backpressure delay: если слотов нет — ждём минуту и возвращаемся.
+     * Тот же порядок, что и RATE_LIMIT_BACKOFF_MS — для консистентности.
+     */
+    private const BACKPRESSURE_BACKOFF_MS = 60_000;
+
     public function __construct(
         private readonly AdLoadJobRepository $jobRepository,
         private readonly OzonAdClient $ozonAdClient,
+        private readonly OzonAdPendingReportRepository $pendingReportRepo,
         private readonly MessageBusInterface $messageBus,
         #[Autowire(service: 'monolog.logger.marketplace_ads')]
         private readonly LoggerInterface $marketplaceAdsLogger,
@@ -94,6 +110,33 @@ final class RequestOzonAdBatchHandler
                 'status' => null === $job ? 'missing' : $job->getStatus()->value,
                 'batchIndex' => $message->batchIndex,
                 'batchTotal' => $message->batchTotal,
+            ]);
+
+            return;
+        }
+
+        // Backpressure: Ozon лимит = 3 активных отчёта/аккаунт. Превышение →
+        // 429 "Превышен лимит активных". Проверяем ДО POST'а через БД — если
+        // у company уже 3+ in-flight, не тратим HTTP и slot Ozon'а, откладываем
+        // message на 60 секунд. rateLimitAttempts НЕ инкрементим — это не 429,
+        // это pre-check, повторяется пока слоты не освободятся (без ограничения
+        // попыток; заблокированный batch в конечном счёте попадёт в общий
+        // failure path через MAX_AGE_BEFORE_ABANDON_SECONDS).
+        $inFlight = $this->pendingReportRepo->countInFlightByCompany($message->companyId);
+        if ($inFlight >= self::MAX_IN_FLIGHT_PER_COMPANY) {
+            $this->messageBus->dispatch(
+                new Envelope($message),
+                [new DelayStamp(self::BACKPRESSURE_BACKOFF_MS)],
+            );
+
+            $this->marketplaceAdsLogger->info('RequestOzonAdBatchMessage: backpressure — slots exhausted, rescheduled', [
+                'jobId' => $message->jobId,
+                'companyId' => $message->companyId,
+                'batchIndex' => $message->batchIndex,
+                'batchTotal' => $message->batchTotal,
+                'inFlight' => $inFlight,
+                'maxInFlight' => self::MAX_IN_FLIGHT_PER_COMPANY,
+                'delayMs' => self::BACKPRESSURE_BACKOFF_MS,
             ]);
 
             return;

--- a/site/src/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandler.php
@@ -77,6 +77,12 @@ final class RequestOzonAdBatchHandler
      * на один Performance-аккаунт. Превышение → 429 "Превышен лимит активных".
      * Этот guard делает проверку на СТОРОНЕ КЛИЕНТА, до POST, по БД —
      * предсказуемее, чем ловить 429 от Ozon.
+     *
+     * ВАЖНО: корректность этого guard'а зависит от того, что транспорт
+     * async_ads остаётся single-worker + FIFO. При >1 worker'е read-modify-write
+     * «COUNT → dispatch POST» становится гонкой: два worker'а могут одновременно
+     * увидеть count=2 и создать 4-й слот. Если будете поднимать параллелизм —
+     * замените на SELECT ... FOR UPDATE или Redis-lock per company_id.
      */
     private const MAX_IN_FLIGHT_PER_COMPANY = 3;
 
@@ -118,10 +124,12 @@ final class RequestOzonAdBatchHandler
         // Backpressure: Ozon лимит = 3 активных отчёта/аккаунт. Превышение →
         // 429 "Превышен лимит активных". Проверяем ДО POST'а через БД — если
         // у company уже 3+ in-flight, не тратим HTTP и slot Ozon'а, откладываем
-        // message на 60 секунд. rateLimitAttempts НЕ инкрементим — это не 429,
-        // это pre-check, повторяется пока слоты не освободятся (без ограничения
-        // попыток; заблокированный batch в конечном счёте попадёт в общий
-        // failure path через MAX_AGE_BEFORE_ABANDON_SECONDS).
+        // message на 60 секунд. rateLimitAttempts НЕ инкрементим — это pre-check,
+        // а не 429. Цикл продолжается пока слоты не освободятся; верхняя граница —
+        // не число попыток, а lifecycle AdLoadJob: когда job помечается FAILED
+        // через другие пути (permanent error / bad date range / таймаут операции),
+        // этот message тоже выйдет из цикла через первую же проверку
+        // `$job->getStatus()->isTerminal()` в начале __invoke.
         $inFlight = $this->pendingReportRepo->countInFlightByCompany($message->companyId);
         if ($inFlight >= self::MAX_IN_FLIGHT_PER_COMPANY) {
             $this->messageBus->dispatch(

--- a/site/src/MarketplaceAds/Repository/OzonAdPendingReportRepository.php
+++ b/site/src/MarketplaceAds/Repository/OzonAdPendingReportRepository.php
@@ -389,4 +389,28 @@ class OzonAdPendingReportRepository extends ServiceEntityRepository
 
         return $rows;
     }
+
+    /**
+     * Счётчик in-flight pending reports конкретной company.
+     * Используется backpressure-гейтом в RequestOzonAdBatchHandler:
+     * если >= 3 (лимит Ozon «активных отчётов» на аккаунт) — не делаем POST,
+     * откладываем Message в очередь.
+     *
+     * Отличие от findInFlightByCompany(): возвращает только COUNT без hydration,
+     * вызывается на каждом сообщении, должен быть быстрым.
+     */
+    public function countInFlightByCompany(string $companyId): int
+    {
+        Assert::uuid($companyId);
+
+        return (int) $this->getEntityManager()->getConnection()->fetchOne(
+            <<<'SQL'
+                SELECT COUNT(*)
+                FROM marketplace_ad_pending_reports
+                WHERE company_id = :company_id
+                  AND finalized_at IS NULL
+                SQL,
+            ['company_id' => $companyId],
+        );
+    }
 }

--- a/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
@@ -24,7 +24,6 @@ use Sentry\State\HubInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Messenger\Stamp\DelayStamp;
 
 // AdLoadJobFinalizer — final readonly, нужен BypassFinals для createMock.
 BypassFinals::allowPaths([
@@ -106,11 +105,10 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $messageBus = $this->createMock(MessageBusInterface::class);
         $messageBus->expects(self::exactly(2))
             ->method('dispatch')
-            ->willReturnCallback(static function (object $envelope) use (&$dispatched): Envelope {
-                self::assertInstanceOf(Envelope::class, $envelope);
-                $dispatched[] = $envelope;
+            ->willReturnCallback(static function (object $message) use (&$dispatched): Envelope {
+                $dispatched[] = $message;
 
-                return $envelope;
+                return new Envelope($message);
             });
 
         $handler = $this->createHandler($ozonClient, $jobRepo, $chunkProgressRepo, $pendingRepo, $finalizer, $messageBus);
@@ -122,8 +120,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         ));
 
         self::assertCount(2, $dispatched);
-        foreach ($dispatched as $i => $envelope) {
-            $m = $envelope->getMessage();
+        foreach ($dispatched as $i => $m) {
             self::assertInstanceOf(RequestOzonAdBatchMessage::class, $m);
             self::assertSame(self::JOB_ID, $m->jobId);
             self::assertSame(self::COMPANY_ID, $m->companyId);
@@ -132,12 +129,17 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             self::assertSame($i, $m->batchIndex);
             self::assertSame(2, $m->batchTotal);
         }
-        self::assertSame(['c1', 'c2'], $dispatched[0]->getMessage()->campaignIds);
-        self::assertSame(['c3'], $dispatched[1]->getMessage()->campaignIds);
+        self::assertSame(['c1', 'c2'], $dispatched[0]->campaignIds);
+        self::assertSame(['c3'], $dispatched[1]->campaignIds);
     }
 
-    public function testDispatchesBatchesWithJitteredDelay(): void
+    public function testDispatchesBatchesWithoutDelayStamp(): void
     {
+        // Backpressure-гейт в RequestOzonAdBatchHandler заменил интра-хандлер
+        // BATCH_SPACING_MS: FetchOzonAdStatisticsHandler больше не навешивает
+        // DelayStamp на диспатчи, отправляет bare-message'и и не оборачивает
+        // их в Envelope вручную. Тест фиксирует отсутствие DelayStamp на
+        // каждом из N батчей.
         $job = AdLoadJobBuilder::aJob()
             ->withCompanyId(self::COMPANY_ID)
             ->withDateRange(new \DateTimeImmutable(self::DATE_FROM), new \DateTimeImmutable(self::DATE_TO))
@@ -167,11 +169,10 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $messageBus = $this->createMock(MessageBusInterface::class);
         $messageBus->expects(self::exactly(3))
             ->method('dispatch')
-            ->willReturnCallback(static function (object $envelope) use (&$dispatched): Envelope {
-                self::assertInstanceOf(Envelope::class, $envelope);
-                $dispatched[] = $envelope;
+            ->willReturnCallback(static function (object $message) use (&$dispatched): Envelope {
+                $dispatched[] = $message;
 
-                return $envelope;
+                return new Envelope($message);
             });
 
         $handler = $this->createHandler($ozonClient, $jobRepo, $chunkProgressRepo, $pendingRepo, $finalizer, $messageBus);
@@ -183,23 +184,21 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         ));
 
         self::assertCount(3, $dispatched);
-
-        $stamps0 = $dispatched[0]->all(DelayStamp::class);
-        self::assertTrue(
-            [] === $stamps0 || 0 === $stamps0[0]->getDelay(),
-            'Batch 0 should dispatch without delay',
-        );
-
-        $stamps1 = $dispatched[1]->all(DelayStamp::class);
-        self::assertCount(1, $stamps1);
-        self::assertSame(90_000, $stamps1[0]->getDelay());
-
-        $stamps2 = $dispatched[2]->all(DelayStamp::class);
-        self::assertCount(1, $stamps2);
-        self::assertSame(180_000, $stamps2[0]->getDelay());
+        foreach ($dispatched as $m) {
+            self::assertInstanceOf(
+                RequestOzonAdBatchMessage::class,
+                $m,
+                'Handler должен диспатчить bare-message без оборачивания в Envelope',
+            );
+            self::assertNotInstanceOf(
+                Envelope::class,
+                $m,
+                'Handler больше не навешивает DelayStamp / не оборачивает в Envelope',
+            );
+        }
     }
 
-    public function testSingleBatchDispatchesWithoutDelay(): void
+    public function testSingleBatchDispatchesBareMessage(): void
     {
         $job = AdLoadJobBuilder::aJob()
             ->withCompanyId(self::COMPANY_ID)
@@ -226,11 +225,10 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $messageBus = $this->createMock(MessageBusInterface::class);
         $messageBus->expects(self::once())
             ->method('dispatch')
-            ->willReturnCallback(static function (object $envelope) use (&$dispatched): Envelope {
-                self::assertInstanceOf(Envelope::class, $envelope);
-                $dispatched = $envelope;
+            ->willReturnCallback(static function (object $message) use (&$dispatched): Envelope {
+                $dispatched = $message;
 
-                return $envelope;
+                return new Envelope($message);
             });
 
         $handler = $this->createHandler($ozonClient, $jobRepo, $chunkProgressRepo, $pendingRepo, $finalizer, $messageBus);
@@ -241,12 +239,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             self::DATE_TO,
         ));
 
-        self::assertNotNull($dispatched);
-        $stamps = $dispatched->all(DelayStamp::class);
-        self::assertTrue(
-            [] === $stamps || 0 === $stamps[0]->getDelay(),
-            'Single batch should dispatch immediately (no DelayStamp)',
-        );
+        self::assertInstanceOf(RequestOzonAdBatchMessage::class, $dispatched);
     }
 
     public function testZeroBatchesStillCallsMarkChunkCompletedAndFinalizer(): void

--- a/site/tests/Unit/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandlerTest.php
@@ -10,6 +10,7 @@ use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonPermanentApiException;
 use App\MarketplaceAds\Message\RequestOzonAdBatchMessage;
 use App\MarketplaceAds\MessageHandler\RequestOzonAdBatchHandler;
 use App\MarketplaceAds\Repository\AdLoadJobRepository;
+use App\MarketplaceAds\Repository\OzonAdPendingReportRepository;
 use App\Tests\Builders\MarketplaceAds\AdLoadJobBuilder;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -21,7 +22,7 @@ use Symfony\Component\Messenger\Stamp\DelayStamp;
 /**
  * Unit-тесты {@see RequestOzonAdBatchHandler}: ровно один POST /statistics
  * на сообщение, с корректной обработкой terminal / missing / permanent /
- * transient / rate-limited сценариев.
+ * transient / rate-limited / backpressure сценариев.
  */
 final class RequestOzonAdBatchHandlerTest extends TestCase
 {
@@ -58,7 +59,7 @@ final class RequestOzonAdBatchHandlerTest extends TestCase
         $bus = $this->createMock(MessageBusInterface::class);
         $bus->expects(self::never())->method('dispatch');
 
-        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, $bus, new NullLogger());
+        $handler = $this->createHandler($jobRepo, $ozonClient, $bus);
         $handler(new RequestOzonAdBatchMessage(
             companyId: self::COMPANY_ID,
             jobId: self::JOB_ID,
@@ -97,7 +98,7 @@ final class RequestOzonAdBatchHandlerTest extends TestCase
             $oversized[] = 'c'.$i;
         }
 
-        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, $bus, new NullLogger());
+        $handler = $this->createHandler($jobRepo, $ozonClient, $bus);
 
         $this->expectException(UnrecoverableMessageHandlingException::class);
         $this->expectExceptionMessage('campaignIds size 11 out of [1..10]');
@@ -136,7 +137,7 @@ final class RequestOzonAdBatchHandlerTest extends TestCase
         $bus = $this->createMock(MessageBusInterface::class);
         $bus->expects(self::never())->method('dispatch');
 
-        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, $bus, new NullLogger());
+        $handler = $this->createHandler($jobRepo, $ozonClient, $bus);
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('HTTP 500');
@@ -196,7 +197,7 @@ final class RequestOzonAdBatchHandlerTest extends TestCase
         $bus = $this->createMock(MessageBusInterface::class);
         $bus->expects(self::never())->method('dispatch');
 
-        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, $bus, new NullLogger());
+        $handler = $this->createHandler($jobRepo, $ozonClient, $bus);
 
         $this->expectException(UnrecoverableMessageHandlingException::class);
         $this->expectExceptionMessage('Ozon permanent failure');
@@ -227,7 +228,11 @@ final class RequestOzonAdBatchHandlerTest extends TestCase
         $bus = $this->createMock(MessageBusInterface::class);
         $bus->expects(self::never())->method('dispatch');
 
-        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, $bus, new NullLogger());
+        $pendingRepo = $this->createMock(OzonAdPendingReportRepository::class);
+        // Если job отсутствует — backpressure-гейт не должен вызываться.
+        $pendingRepo->expects(self::never())->method('countInFlightByCompany');
+
+        $handler = $this->createHandler($jobRepo, $ozonClient, $bus, $pendingRepo);
         $handler(new RequestOzonAdBatchMessage(
             companyId: self::COMPANY_ID,
             jobId: self::JOB_ID,
@@ -259,7 +264,110 @@ final class RequestOzonAdBatchHandlerTest extends TestCase
         $bus = $this->createMock(MessageBusInterface::class);
         $bus->expects(self::never())->method('dispatch');
 
-        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, $bus, new NullLogger());
+        $handler = $this->createHandler($jobRepo, $ozonClient, $bus);
+        $handler(new RequestOzonAdBatchMessage(
+            companyId: self::COMPANY_ID,
+            jobId: self::JOB_ID,
+            dateFrom: self::DATE_FROM,
+            dateTo: self::DATE_TO,
+            campaignIds: ['c1'],
+            batchIndex: 0,
+            batchTotal: 1,
+        ));
+    }
+
+    public function testBackpressureReschedulesWhenSlotsExhausted(): void
+    {
+        // Backpressure-гейт: если у company уже 3 in-flight pending_reports,
+        // handler НЕ делает POST, а дис­патчит сообщение обратно с DelayStamp
+        // 60с. rateLimitAttempts не инкрементируется (это pre-check, не 429),
+        // markFailed не вызывается.
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->asRunning()
+            ->build();
+
+        $jobRepo = $this->createMock(AdLoadJobRepository::class);
+        $jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $jobRepo->expects(self::never())->method('markFailed');
+
+        $ozonClient = $this->createMock(OzonAdClient::class);
+        $ozonClient->expects(self::never())->method('requestOneBatch');
+
+        $pendingRepo = $this->createMock(OzonAdPendingReportRepository::class);
+        $pendingRepo->expects(self::once())
+            ->method('countInFlightByCompany')
+            ->with(self::COMPANY_ID)
+            ->willReturn(3);
+
+        $capturedEnvelope = null;
+        $capturedStamps = null;
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::once())
+            ->method('dispatch')
+            ->willReturnCallback(static function (object $env, array $stamps) use (&$capturedEnvelope, &$capturedStamps): Envelope {
+                $capturedEnvelope = $env;
+                $capturedStamps = $stamps;
+
+                return $env instanceof Envelope ? $env : new Envelope($env);
+            });
+
+        $handler = $this->createHandler($jobRepo, $ozonClient, $bus, $pendingRepo);
+        $handler(new RequestOzonAdBatchMessage(
+            companyId: self::COMPANY_ID,
+            jobId: self::JOB_ID,
+            dateFrom: self::DATE_FROM,
+            dateTo: self::DATE_TO,
+            campaignIds: ['c1', 'c2'],
+            batchIndex: 0,
+            batchTotal: 1,
+            rateLimitAttempts: 2,
+        ));
+
+        self::assertInstanceOf(Envelope::class, $capturedEnvelope);
+        $rescheduled = $capturedEnvelope->getMessage();
+        self::assertInstanceOf(RequestOzonAdBatchMessage::class, $rescheduled);
+        self::assertSame(self::COMPANY_ID, $rescheduled->companyId);
+        self::assertSame(self::JOB_ID, $rescheduled->jobId);
+        self::assertSame(['c1', 'c2'], $rescheduled->campaignIds);
+        self::assertSame(
+            2,
+            $rescheduled->rateLimitAttempts,
+            'backpressure не должен инкрементировать rateLimitAttempts — это не 429',
+        );
+
+        self::assertIsArray($capturedStamps);
+        self::assertCount(1, $capturedStamps);
+        self::assertInstanceOf(DelayStamp::class, $capturedStamps[0]);
+        self::assertSame(60_000, $capturedStamps[0]->getDelay());
+    }
+
+    public function testBackpressureAllowsWhenSlotsAvailable(): void
+    {
+        // countInFlightByCompany < 3 → handler идёт в штатный POST-путь.
+        $job = AdLoadJobBuilder::aJob()
+            ->withCompanyId(self::COMPANY_ID)
+            ->asRunning()
+            ->build();
+
+        $jobRepo = $this->createMock(AdLoadJobRepository::class);
+        $jobRepo->method('findByIdAndCompany')->willReturn($job);
+
+        $pendingRepo = $this->createMock(OzonAdPendingReportRepository::class);
+        $pendingRepo->expects(self::once())
+            ->method('countInFlightByCompany')
+            ->with(self::COMPANY_ID)
+            ->willReturn(2);
+
+        $ozonClient = $this->createMock(OzonAdClient::class);
+        $ozonClient->expects(self::once())
+            ->method('requestOneBatch')
+            ->willReturn('uuid-1');
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::never())->method('dispatch');
+
+        $handler = $this->createHandler($jobRepo, $ozonClient, $bus, $pendingRepo);
         $handler(new RequestOzonAdBatchMessage(
             companyId: self::COMPANY_ID,
             jobId: self::JOB_ID,
@@ -303,7 +411,7 @@ final class RequestOzonAdBatchHandlerTest extends TestCase
                 return $env instanceof Envelope ? $env : new Envelope($env);
             });
 
-        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, $bus, new NullLogger());
+        $handler = $this->createHandler($jobRepo, $ozonClient, $bus);
         $handler(new RequestOzonAdBatchMessage(
             companyId: self::COMPANY_ID,
             jobId: self::JOB_ID,
@@ -353,7 +461,7 @@ final class RequestOzonAdBatchHandlerTest extends TestCase
                 return $env instanceof Envelope ? $env : new Envelope($env);
             });
 
-        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, $bus, new NullLogger());
+        $handler = $this->createHandler($jobRepo, $ozonClient, $bus);
         $handler(new RequestOzonAdBatchMessage(
             companyId: self::COMPANY_ID,
             jobId: self::JOB_ID,
@@ -398,7 +506,7 @@ final class RequestOzonAdBatchHandlerTest extends TestCase
         $bus = $this->createMock(MessageBusInterface::class);
         $bus->expects(self::never())->method('dispatch');
 
-        $handler = new RequestOzonAdBatchHandler($jobRepo, $ozonClient, $bus, new NullLogger());
+        $handler = $this->createHandler($jobRepo, $ozonClient, $bus);
 
         $this->expectException(UnrecoverableMessageHandlingException::class);
         $this->expectExceptionMessage('Ozon rate limit exhausted');
@@ -413,5 +521,28 @@ final class RequestOzonAdBatchHandlerTest extends TestCase
             batchTotal: 1,
             rateLimitAttempts: 10,
         ));
+    }
+
+    private function createHandler(
+        AdLoadJobRepository $jobRepo,
+        OzonAdClient $ozonClient,
+        MessageBusInterface $bus,
+        ?OzonAdPendingReportRepository $pendingRepo = null,
+    ): RequestOzonAdBatchHandler {
+        if (null === $pendingRepo) {
+            // Дефолт: 0 in-flight reports — backpressure не срабатывает,
+            // handler идёт в штатный путь. Тесты со specific backpressure
+            // semantics подают явный mock.
+            $pendingRepo = $this->createMock(OzonAdPendingReportRepository::class);
+            $pendingRepo->method('countInFlightByCompany')->willReturn(0);
+        }
+
+        return new RequestOzonAdBatchHandler(
+            $jobRepo,
+            $ozonClient,
+            $pendingRepo,
+            $bus,
+            new NullLogger(),
+        );
     }
 }


### PR DESCRIPTION
## Summary
Implements client-side backpressure control in `RequestOzonAdBatchHandler` to respect Ozon's hard limit of 3 concurrent active reports per Performance account. Instead of waiting for Ozon to reject requests with 429 errors, the handler now checks in-flight report count before making POST requests and reschedules messages when the limit is reached.

## Key Changes

- **Backpressure gate in RequestOzonAdBatchHandler**: Added pre-flight check via `OzonAdPendingReportRepository::countInFlightByCompany()` before issuing POST requests. If ≥3 in-flight reports exist for a company, the message is rescheduled with a 60-second delay instead of attempting the request.

- **New repository method**: `OzonAdPendingReportRepository::countInFlightByCompany()` — lightweight COUNT query (no hydration) to check in-flight pending reports by company, called on every message dispatch.

- **Removed inter-batch spacing logic**: Deleted `BATCH_SPACING_MS` (90s) and DelayStamp injection from `FetchOzonAdStatisticsHandler`. Batches now dispatch immediately as bare messages; backpressure in the downstream handler replaces this timing-based approach with demand-driven flow control.

- **Updated handler constructor**: `RequestOzonAdBatchHandler` now accepts `OzonAdPendingReportRepository` as a required dependency (inserted before `MessageBusInterface`).

- **Test coverage**: Added two new test cases:
  - `testBackpressureReschedulesWhenSlotsExhausted()` — verifies message rescheduling with 60s delay when limit is hit
  - `testBackpressureAllowsWhenSlotsAvailable()` — verifies normal POST flow when slots are available
  - Refactored existing tests to use new `createHandler()` helper that defaults to 0 in-flight (backpressure disabled) for backward compatibility

- **Documentation**: Updated ARCHITECTURE.md with new method signature and backpressure semantics.

## Implementation Details

- Backpressure is a **pre-check** (not a 429 response), so `rateLimitAttempts` is not incremented
- Messages blocked by backpressure are rescheduled indefinitely until slots free up (no attempt limit)
- The check happens after job existence/terminal state validation but before any API call
- Logging includes in-flight count and max limit for observability

https://claude.ai/code/session_01JYjj6TLMVbD4gXQLbGw9Hq