### PR TITLE
Task-9: raise MAX_RATE_LIMIT_ATTEMPTS from 3 to 10

### DIFF
--- a/site/src/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandler.php
@@ -74,7 +74,7 @@ final class RequestOzonAdBatchHandler
      * редкие глобальные throttle'ы Ozon — 3 попыток (3 минуты) хватает
      * отличить transient от устойчивой проблемы.
      */
-    private const MAX_RATE_LIMIT_ATTEMPTS = 3;
+    private const MAX_RATE_LIMIT_ATTEMPTS = 10;
 
     /**
      * Ozon Performance жёсткий лимит: не более 3 активных отчётов в очереди


### PR DESCRIPTION
## Summary

Поднимаем `MAX_RATE_LIMIT_ATTEMPTS` с 3 до 10 в `RequestOzonAdBatchHandler`.

## Причина

При загрузке периода с 246 кампаниями разбивка идёт на 25 batch'ей. На 2-3 batch'е Ozon отдаёт 429, handler ретраит 3 раза и сдаётся — остальные 22 batch'а не обрабатываются.

10 попыток × 60 сек = 10 минут на batch — достаточно чтобы Ozon отпустил throttle, и хватает защиты от infinite-retry, ради которой в Task-2 понижали с 10 до 3.

## Changes

- `site/src/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandler.php`: `MAX_RATE_LIMIT_ATTEMPTS` 3 → 10

## Test plan

- [ ] Запустить загрузку периода с большим числом кампаний (≥200), убедиться что все batch'и пройдут через throttle Ozon
- [ ] Проверить логи что при 429 происходит до 10 попыток, а не 3

https://claude.ai/code/session_015vE754uVtDYdoW6ep2peqA

---
_Generated by [Claude Code](https://claude.ai/code/session_015vE754uVtDYdoW6ep2peqA)_