### PR TITLE
Task-10: DelayStamp between Ozon batches to avoid throttling

### DIFF
--- a/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
@@ -19,6 +19,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
 
 /**
  * Async-обработчик {@see FetchOzonAdStatisticsMessage} — orchestrator'ом one-
@@ -204,15 +205,27 @@ final class FetchOzonAdStatisticsHandler
         // внутри RequestOzonAdBatchHandler даёт идемпотентность при Messenger-retry.
         $batchTotal = count($batches);
         foreach ($batches as $batchIndex => $campaignIds) {
-            $this->messageBus->dispatch(new RequestOzonAdBatchMessage(
-                companyId: $message->companyId,
-                jobId: $message->jobId,
-                dateFrom: $message->dateFrom,
-                dateTo: $message->dateTo,
-                campaignIds: $campaignIds,
-                batchIndex: $batchIndex,
-                batchTotal: $batchTotal,
-            ));
+            // Ozon /statistics жёстко троттлит при back-to-back POST'ах на аккаунт
+            // (25 подряд → устойчивые 429, которые не пробить даже 10 ретраями).
+            // Разносим batch'и на 90 секунд — Ozon'у хватает обработать предыдущий
+            // запрос до того, как прилетит следующий. batchIndex=0 идёт без задержки.
+            $stamps = [];
+            if ($batchIndex > 0) {
+                $stamps[] = new DelayStamp($batchIndex * 90_000);
+            }
+
+            $this->messageBus->dispatch(
+                new RequestOzonAdBatchMessage(
+                    companyId: $message->companyId,
+                    jobId: $message->jobId,
+                    dateFrom: $message->dateFrom,
+                    dateTo: $message->dateTo,
+                    campaignIds: $campaignIds,
+                    batchIndex: $batchIndex,
+                    batchTotal: $batchTotal,
+                ),
+                $stamps,
+            );
         }
 
         // Идемпотентная фиксация чанка — в async-flow означает «запрос отправлен»,

--- a/site/src/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandler.php
@@ -68,13 +68,14 @@ final class RequestOzonAdBatchHandler
      * 3 × 60с = 3 минуты максимум на rate-limit backoff одного batch'а.
      * Если Ozon троттлит устойчиво — markFailed, инженер смотрит руками.
      *
-     * Снижено с 10 до 3 после внедрения backpressure (v1.13): 429 по лимиту
-     * активных отчётов теперь физически невозможен — client-side gate блокирует
-     * POST до превышения порога MAX_IN_FLIGHT_PER_COMPANY=3. Остаются только
-     * редкие глобальные throttle'ы Ozon — 3 попыток (3 минуты) хватает
-     * отличить transient от устойчивой проблемы.
+     * Снижено с 10 до 3 после внедрения 90-секундного DelayStamp между batch'ами
+     * в FetchOzonAdStatisticsHandler: batch'и больше не идут back-to-back, и
+     * 429 от глобального троттлинга Ozon'а стал редким остаточным явлением.
+     * 3 попыток (3 минуты) хватает отличить transient от устойчивой проблемы;
+     * оставлять 10 попыток при уже разнесённых batch'ах — маскировать более
+     * серьёзную проблему на стороне Ozon'а лишним ретрай-шумом.
      */
-    private const MAX_RATE_LIMIT_ATTEMPTS = 10;
+    private const MAX_RATE_LIMIT_ATTEMPTS = 3;
 
     /**
      * Ozon Performance жёсткий лимит: не более 3 активных отчётов в очереди


### PR DESCRIPTION
## Summary

- В `FetchOzonAdStatisticsHandler` при dispatch'е `RequestOzonAdBatchMessage` добавлен `DelayStamp` со смещением `batchIndex * 90_000` мс. Первый batch (index 0) идёт без задержки, каждый следующий — на 90 секунд позже. Ozon `/statistics` жёстко троттлит на back-to-back POST'ах (25 подряд ловят устойчивые 429, не пробиваемые даже 10 ретраями) — 90 сек между batch'ами дают Ozon'у время обработать предыдущий запрос до прилёта следующего.
- В `RequestOzonAdBatchHandler` возвращён `MAX_RATE_LIMIT_ATTEMPTS` с 10 на 3. После разнесения batch'ей 90-секундным DelayStamp'ом частые 429 становятся невозможны; 3 попыток (3 минуты backoff'а) хватает как защита от редких глобальных throttle'ов Ozon. 10 попыток при уже разнесённых batch'ах только маскировали бы более серьёзную проблему лишним ретрай-шумом.

## Test plan

- [ ] Запустить `AdLoadJob` с диапазоном, порождающим >1 batch'а (>10 активных SKU-кампаний) и убедиться, что второй+ `RequestOzonAdBatchMessage` появляются в очереди `async_ads` с `available_at` через 90/180/… секунд после первого
- [ ] Проверить, что single batch (batchIndex=0) по-прежнему диспатчится без задержки
- [ ] Проверить лог `RequestOzonAdBatchMessage: batch requested` — batch'и должны обрабатываться с реальным ~90-секундным разрывом, без 429
- [ ] Спровоцировать искусственный 429 (мок) и убедиться, что после 3-й попытки batch помечается FAILED с сообщением `rate-limited >3 attempts`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gay9FUW1SW4ZwHYPysJKGQ)_