### PR TITLE
Task-11.2 fix: align Entity mapping with DB schema

### DIFF
--- a/site/src/MarketplaceAds/Entity/AdScheduledBatch.php
+++ b/site/src/MarketplaceAds/Entity/AdScheduledBatch.php
@@ -67,7 +67,7 @@ class AdScheduledBatch
     #[ORM\Column(type: 'string', length: 32, enumType: AdScheduledBatchState::class, options: ['default' => 'PLANNED'])]
     private AdScheduledBatchState $state;
 
-    #[ORM\Column(type: 'datetime_immutable')]
+    #[ORM\Column(type: 'datetime_immutable', options: ['default' => 'CURRENT_TIMESTAMP'])]
     private \DateTimeImmutable $scheduledAt;
 
     #[ORM\Column(type: 'datetime_immutable', nullable: true)]
@@ -94,10 +94,10 @@ class AdScheduledBatch
     #[ORM\Column(type: 'text', nullable: true)]
     private ?string $lastError = null;
 
-    #[ORM\Column(type: 'datetime_immutable')]
+    #[ORM\Column(type: 'datetime_immutable', options: ['default' => 'CURRENT_TIMESTAMP'])]
     private \DateTimeImmutable $createdAt;
 
-    #[ORM\Column(type: 'datetime_immutable')]
+    #[ORM\Column(type: 'datetime_immutable', options: ['default' => 'CURRENT_TIMESTAMP'])]
     private \DateTimeImmutable $updatedAt;
 
     /**


### PR DESCRIPTION
## Summary

`doctrine:schema:validate` показал расхождение между migration и Entity mapping для `marketplace_ad_scheduled_batches`.

В миграции Task-11.1 (`Version20260423155717`) колонки заявлены как:
```sql
scheduled_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL DEFAULT NOW()
created_at   TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL DEFAULT NOW()
updated_at   TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL DEFAULT NOW()
```

А в Entity mapping (Task-11.2) `options.default` не был указан. Добавил `options: ['default' => 'CURRENT_TIMESTAMP']` на:

- `scheduledAt`
- `createdAt`
- `updatedAt`

`dateFrom` / `dateTo` уже были корректно замаплены на `date_immutable` (соответствует DATE в БД) — менять не пришлось.

## Что НЕ трогал (намеренно)

- **Partial-индексы** `idx_asb_scheduler`, `idx_asb_poller` в Entity не объявлены — ORM-атрибуты не выражают `WHERE`-условие. Задокументировано в docblock Entity.
- **FK `jobId`** остаётся `string` без `ManyToOne` relation — project convention (CLAUDE.md: «Ссылки на Entity других модулей: `string $counterpartyId`, не `#[ManyToOne]`»).

## Test plan

- [x] `php -l` — без ошибок.
- [ ] `doctrine:schema:validate` в CI (`migrations-empty-db`) — должна пройти без расхождений на этих трёх колонках.
- [ ] Интеграционные тесты `AdScheduledBatchRepositoryTest` — не должны сломаться (значения timestamp'ов по-прежнему проставляются в конструкторе Entity, `CURRENT_TIMESTAMP` default работает только если Doctrine не передал поле — для нас это safety net на случай обхода конструктора через raw SQL).


---
_Generated by [Claude Code](https://claude.ai/code/session_01VadXUNC87YXgzEPSG7HV7W)_