### PR TITLE
Add site_storage volume mount to cron service

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -370,6 +370,7 @@ services:
             FEATURE_FUNDS_AND_WIDGET: ${FEATURE_FUNDS_AND_WIDGET:-1}
         volumes:
             - ./docker/cron/app.cron:/etc/crontabs/app.cron:ro
+            - site_storage:/app/var/storage
         depends_on:
             site-postgres:
                 condition: service_healthy


### PR DESCRIPTION
## Summary
Added a volume mount for `site_storage` to the cron service in the production Docker Compose configuration to ensure the cron container has access to persistent storage.

## Key Changes
- Mounted `site_storage` volume to `/app/var/storage` in the cron service
- This allows cron jobs to read from and write to the shared storage directory alongside other services

## Implementation Details
The volume mount follows the same pattern used by other services in the compose file, ensuring consistency in how persistent storage is accessed across containers. The cron service can now perform storage-related operations that may be required by scheduled tasks.

https://claude.ai/code/session_018h8sQTZMEsNta1q7bvQRx1