### PR TITLE
Add date range filtering to SalesListQuery

### DIFF
--- a/site/src/Marketplace/Infrastructure/Query/SalesListQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/SalesListQuery.php
@@ -14,8 +14,12 @@ final class SalesListQuery
     ) {
     }
 
-    public function buildQueryBuilder(string $companyId, ?string $marketplace): QueryBuilder
-    {
+    public function buildQueryBuilder(
+        string $companyId,
+        ?string $marketplace,
+        ?\DateTimeImmutable $from = null,
+        ?\DateTimeImmutable $to = null,
+    ): QueryBuilder {
         $qb = $this->connection->createQueryBuilder()
             ->select(
                 's.id',
@@ -38,6 +42,16 @@ final class SalesListQuery
         if ($marketplace !== null) {
             $qb->andWhere('s.marketplace = :marketplace')
                 ->setParameter('marketplace', $marketplace);
+        }
+
+        if ($from !== null) {
+            $qb->andWhere('s.sale_date >= :saleDateFrom')
+                ->setParameter('saleDateFrom', $from->format('Y-m-d'));
+        }
+
+        if ($to !== null) {
+            $qb->andWhere('s.sale_date <= :saleDateTo')
+                ->setParameter('saleDateTo', $to->format('Y-m-d'));
         }
 
         return $qb;

--- a/site/tests/Builders/Marketplace/MarketplaceListingBuilder.php
+++ b/site/tests/Builders/Marketplace/MarketplaceListingBuilder.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Builders\Marketplace;
+
+use App\Catalog\Entity\Product;
+use App\Company\Entity\Company;
+use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Enum\MarketplaceType;
+use Ramsey\Uuid\Uuid;
+
+final class MarketplaceListingBuilder
+{
+    private string $id;
+    private ?Company $company = null;
+    private ?Product $product = null;
+    private MarketplaceType $marketplace = MarketplaceType::WILDBERRIES;
+    private string $marketplaceSku = 'sku-test-1';
+    private string $price = '1000.00';
+
+    private function __construct()
+    {
+        $this->id = Uuid::uuid4()->toString();
+    }
+
+    public static function aListing(): self
+    {
+        return new self();
+    }
+
+    public function forCompany(Company $company): self
+    {
+        $clone = clone $this;
+        $clone->company = $company;
+
+        return $clone;
+    }
+
+    public function withMarketplace(MarketplaceType $marketplace): self
+    {
+        $clone = clone $this;
+        $clone->marketplace = $marketplace;
+
+        return $clone;
+    }
+
+    public function withMarketplaceSku(string $marketplaceSku): self
+    {
+        $clone = clone $this;
+        $clone->marketplaceSku = $marketplaceSku;
+
+        return $clone;
+    }
+
+    public function withPrice(string $price): self
+    {
+        $clone = clone $this;
+        $clone->price = $price;
+
+        return $clone;
+    }
+
+    public function build(): MarketplaceListing
+    {
+        if ($this->company === null) {
+            throw new \LogicException('Company is required. Call forCompany().');
+        }
+
+        $listing = new MarketplaceListing(
+            $this->id,
+            $this->company,
+            $this->product,
+            $this->marketplace,
+        );
+        $listing->setMarketplaceSku($this->marketplaceSku);
+        $listing->setPrice($this->price);
+
+        return $listing;
+    }
+}

--- a/site/tests/Builders/Marketplace/MarketplaceSaleBuilder.php
+++ b/site/tests/Builders/Marketplace/MarketplaceSaleBuilder.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Builders\Marketplace;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Entity\MarketplaceSale;
+use App\Marketplace\Enum\MarketplaceType;
+use Ramsey\Uuid\Uuid;
+
+final class MarketplaceSaleBuilder
+{
+    private string $id;
+    private ?Company $company = null;
+    private ?MarketplaceListing $listing = null;
+    private MarketplaceType $marketplace = MarketplaceType::WILDBERRIES;
+    private string $externalOrderId;
+    private \DateTimeImmutable $saleDate;
+    private int $quantity = 1;
+    private string $pricePerUnit = '1000.00';
+    private string $totalRevenue = '1000.00';
+    private ?string $costPrice = null;
+
+    private function __construct()
+    {
+        $this->id = Uuid::uuid4()->toString();
+        $this->externalOrderId = 'ext-' . Uuid::uuid4()->toString();
+        $this->saleDate = new \DateTimeImmutable('2026-04-15');
+    }
+
+    public static function aSale(): self
+    {
+        return new self();
+    }
+
+    public function forCompany(Company $company): self
+    {
+        $clone = clone $this;
+        $clone->company = $company;
+
+        return $clone;
+    }
+
+    public function forListing(MarketplaceListing $listing): self
+    {
+        $clone = clone $this;
+        $clone->listing = $listing;
+        $clone->marketplace = $listing->getMarketplace();
+
+        return $clone;
+    }
+
+    public function withMarketplace(MarketplaceType $marketplace): self
+    {
+        $clone = clone $this;
+        $clone->marketplace = $marketplace;
+
+        return $clone;
+    }
+
+    public function withExternalOrderId(string $externalOrderId): self
+    {
+        $clone = clone $this;
+        $clone->externalOrderId = $externalOrderId;
+
+        return $clone;
+    }
+
+    public function withSaleDate(\DateTimeImmutable $saleDate): self
+    {
+        $clone = clone $this;
+        $clone->saleDate = $saleDate;
+
+        return $clone;
+    }
+
+    public function withQuantity(int $quantity): self
+    {
+        $clone = clone $this;
+        $clone->quantity = $quantity;
+
+        return $clone;
+    }
+
+    public function withPricePerUnit(string $pricePerUnit): self
+    {
+        $clone = clone $this;
+        $clone->pricePerUnit = $pricePerUnit;
+
+        return $clone;
+    }
+
+    public function withTotalRevenue(string $totalRevenue): self
+    {
+        $clone = clone $this;
+        $clone->totalRevenue = $totalRevenue;
+
+        return $clone;
+    }
+
+    public function build(): MarketplaceSale
+    {
+        if ($this->company === null) {
+            throw new \LogicException('Company is required. Call forCompany().');
+        }
+        if ($this->listing === null) {
+            throw new \LogicException('Listing is required. Call forListing().');
+        }
+
+        $sale = new MarketplaceSale(
+            $this->id,
+            $this->company,
+            $this->listing,
+            $this->marketplace,
+        );
+        $sale->setExternalOrderId($this->externalOrderId);
+        $sale->setSaleDate($this->saleDate);
+        $sale->setQuantity($this->quantity);
+        $sale->setPricePerUnit($this->pricePerUnit);
+        $sale->setTotalRevenue($this->totalRevenue);
+        if ($this->costPrice !== null) {
+            $sale->setCostPrice($this->costPrice);
+        }
+
+        return $sale;
+    }
+}

--- a/site/tests/Marketplace/Infrastructure/Query/SalesListQueryTest.php
+++ b/site/tests/Marketplace/Infrastructure/Query/SalesListQueryTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Marketplace\Infrastructure\Query;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Entity\MarketplaceSale;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Infrastructure\Query\SalesListQuery;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class SalesListQueryTest extends IntegrationTestCase
+{
+    private Company $company;
+    private MarketplaceListing $wbListing;
+    private MarketplaceListing $ozonListing;
+    private SalesListQuery $salesListQuery;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $owner = UserBuilder::aUser()
+            ->withId('22222222-2222-2222-2222-000000000077')
+            ->withEmail('sales-list-query@example.test')
+            ->build();
+
+        $this->company = CompanyBuilder::aCompany()
+            ->withId('11111111-1111-1111-1111-000000000077')
+            ->withOwner($owner)
+            ->build();
+
+        $this->wbListing = new MarketplaceListing(
+            Uuid::uuid4()->toString(),
+            $this->company,
+            null,
+            MarketplaceType::WILDBERRIES,
+        );
+        $this->wbListing->setMarketplaceSku('wb-sku-1');
+        $this->wbListing->setPrice('1000.00');
+
+        $this->ozonListing = new MarketplaceListing(
+            Uuid::uuid4()->toString(),
+            $this->company,
+            null,
+            MarketplaceType::OZON,
+        );
+        $this->ozonListing->setMarketplaceSku('ozon-sku-1');
+        $this->ozonListing->setPrice('1000.00');
+
+        $this->em->persist($owner);
+        $this->em->persist($this->company);
+        $this->em->persist($this->wbListing);
+        $this->em->persist($this->ozonListing);
+        $this->em->flush();
+
+        $this->salesListQuery = self::getContainer()->get(SalesListQuery::class);
+    }
+
+    public function testDoesNotFilterWhenDatesAreNull(): void
+    {
+        $this->createSale($this->wbListing, MarketplaceType::WILDBERRIES, new \DateTimeImmutable('2026-04-01'));
+        $this->createSale($this->wbListing, MarketplaceType::WILDBERRIES, new \DateTimeImmutable('2026-04-15'));
+        $this->createSale($this->wbListing, MarketplaceType::WILDBERRIES, new \DateTimeImmutable('2026-04-30'));
+        $this->em->flush();
+
+        $qb = $this->salesListQuery->buildQueryBuilder(
+            companyId: $this->company->getId(),
+            marketplace: null,
+        );
+
+        $rows = $qb->executeQuery()->fetchAllAssociative();
+
+        self::assertCount(3, $rows);
+    }
+
+    public function testFiltersByDateFromInclusive(): void
+    {
+        $this->createSale($this->wbListing, MarketplaceType::WILDBERRIES, new \DateTimeImmutable('2026-04-01'));
+        $this->createSale($this->wbListing, MarketplaceType::WILDBERRIES, new \DateTimeImmutable('2026-04-15'));
+        $this->createSale($this->wbListing, MarketplaceType::WILDBERRIES, new \DateTimeImmutable('2026-04-30'));
+        $this->em->flush();
+
+        $qb = $this->salesListQuery->buildQueryBuilder(
+            companyId: $this->company->getId(),
+            marketplace: null,
+            from: new \DateTimeImmutable('2026-04-15'),
+        );
+
+        $rows = $qb->executeQuery()->fetchAllAssociative();
+
+        self::assertCount(2, $rows);
+        $dates = array_map(static fn (array $row): string => self::normalizeDate($row['sale_date']), $rows);
+        sort($dates);
+        self::assertSame(['2026-04-15', '2026-04-30'], $dates);
+    }
+
+    public function testFiltersByDateToInclusive(): void
+    {
+        $this->createSale($this->wbListing, MarketplaceType::WILDBERRIES, new \DateTimeImmutable('2026-04-01'));
+        $this->createSale($this->wbListing, MarketplaceType::WILDBERRIES, new \DateTimeImmutable('2026-04-15'));
+        $this->createSale($this->wbListing, MarketplaceType::WILDBERRIES, new \DateTimeImmutable('2026-04-30'));
+        $this->em->flush();
+
+        $qb = $this->salesListQuery->buildQueryBuilder(
+            companyId: $this->company->getId(),
+            marketplace: null,
+            to: new \DateTimeImmutable('2026-04-15'),
+        );
+
+        $rows = $qb->executeQuery()->fetchAllAssociative();
+
+        self::assertCount(2, $rows);
+        $dates = array_map(static fn (array $row): string => self::normalizeDate($row['sale_date']), $rows);
+        sort($dates);
+        self::assertSame(['2026-04-01', '2026-04-15'], $dates);
+    }
+
+    public function testFiltersByDateRangeAndMarketplaceCombined(): void
+    {
+        $this->createSale($this->wbListing, MarketplaceType::WILDBERRIES, new \DateTimeImmutable('2026-04-01'));
+        $this->createSale($this->wbListing, MarketplaceType::WILDBERRIES, new \DateTimeImmutable('2026-04-20'));
+        $this->createSale($this->ozonListing, MarketplaceType::OZON, new \DateTimeImmutable('2026-04-10'));
+        $this->createSale($this->ozonListing, MarketplaceType::OZON, new \DateTimeImmutable('2026-04-25'));
+        $this->em->flush();
+
+        $qb = $this->salesListQuery->buildQueryBuilder(
+            companyId: $this->company->getId(),
+            marketplace: MarketplaceType::WILDBERRIES->value,
+            from: new \DateTimeImmutable('2026-04-10'),
+            to: new \DateTimeImmutable('2026-04-20'),
+        );
+
+        $rows = $qb->executeQuery()->fetchAllAssociative();
+
+        self::assertCount(1, $rows);
+        self::assertSame('2026-04-20', self::normalizeDate($rows[0]['sale_date']));
+        self::assertSame(MarketplaceType::WILDBERRIES->value, $rows[0]['marketplace']);
+    }
+
+    private function createSale(
+        MarketplaceListing $listing,
+        MarketplaceType $marketplace,
+        \DateTimeImmutable $saleDate,
+    ): MarketplaceSale {
+        $sale = new MarketplaceSale(
+            Uuid::uuid4()->toString(),
+            $this->company,
+            $listing,
+            $marketplace,
+        );
+        $sale->setExternalOrderId('ext-' . Uuid::uuid4()->toString());
+        $sale->setSaleDate($saleDate);
+        $sale->setQuantity(1);
+        $sale->setPricePerUnit('1000.00');
+        $sale->setTotalRevenue('1000.00');
+        $this->em->persist($sale);
+
+        return $sale;
+    }
+
+    private static function normalizeDate(string $dbValue): string
+    {
+        return (new \DateTimeImmutable($dbValue))->format('Y-m-d');
+    }
+}

--- a/site/tests/Marketplace/Infrastructure/Query/SalesListQueryTest.php
+++ b/site/tests/Marketplace/Infrastructure/Query/SalesListQueryTest.php
@@ -11,11 +11,15 @@ use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Infrastructure\Query\SalesListQuery;
 use App\Tests\Builders\Company\CompanyBuilder;
 use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceListingBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceSaleBuilder;
 use App\Tests\Support\Kernel\IntegrationTestCase;
-use Ramsey\Uuid\Uuid;
 
 final class SalesListQueryTest extends IntegrationTestCase
 {
+    private const COMPANY_ID = '11111111-1111-1111-1111-000000000077';
+    private const OWNER_ID = '22222222-2222-2222-2222-000000000077';
+
     private Company $company;
     private MarketplaceListing $wbListing;
     private MarketplaceListing $ozonListing;
@@ -26,32 +30,26 @@ final class SalesListQueryTest extends IntegrationTestCase
         parent::setUp();
 
         $owner = UserBuilder::aUser()
-            ->withId('22222222-2222-2222-2222-000000000077')
+            ->withId(self::OWNER_ID)
             ->withEmail('sales-list-query@example.test')
             ->build();
 
         $this->company = CompanyBuilder::aCompany()
-            ->withId('11111111-1111-1111-1111-000000000077')
+            ->withId(self::COMPANY_ID)
             ->withOwner($owner)
             ->build();
 
-        $this->wbListing = new MarketplaceListing(
-            Uuid::uuid4()->toString(),
-            $this->company,
-            null,
-            MarketplaceType::WILDBERRIES,
-        );
-        $this->wbListing->setMarketplaceSku('wb-sku-1');
-        $this->wbListing->setPrice('1000.00');
+        $this->wbListing = MarketplaceListingBuilder::aListing()
+            ->forCompany($this->company)
+            ->withMarketplace(MarketplaceType::WILDBERRIES)
+            ->withMarketplaceSku('wb-sku-1')
+            ->build();
 
-        $this->ozonListing = new MarketplaceListing(
-            Uuid::uuid4()->toString(),
-            $this->company,
-            null,
-            MarketplaceType::OZON,
-        );
-        $this->ozonListing->setMarketplaceSku('ozon-sku-1');
-        $this->ozonListing->setPrice('1000.00');
+        $this->ozonListing = MarketplaceListingBuilder::aListing()
+            ->forCompany($this->company)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withMarketplaceSku('ozon-sku-1')
+            ->build();
 
         $this->em->persist($owner);
         $this->em->persist($this->company);
@@ -64,9 +62,9 @@ final class SalesListQueryTest extends IntegrationTestCase
 
     public function testDoesNotFilterWhenDatesAreNull(): void
     {
-        $this->createSale($this->wbListing, MarketplaceType::WILDBERRIES, new \DateTimeImmutable('2026-04-01'));
-        $this->createSale($this->wbListing, MarketplaceType::WILDBERRIES, new \DateTimeImmutable('2026-04-15'));
-        $this->createSale($this->wbListing, MarketplaceType::WILDBERRIES, new \DateTimeImmutable('2026-04-30'));
+        foreach (['2026-04-01', '2026-04-15', '2026-04-30'] as $date) {
+            $this->createSale($this->wbListing, new \DateTimeImmutable($date));
+        }
         $this->em->flush();
 
         $qb = $this->salesListQuery->buildQueryBuilder(
@@ -81,9 +79,9 @@ final class SalesListQueryTest extends IntegrationTestCase
 
     public function testFiltersByDateFromInclusive(): void
     {
-        $this->createSale($this->wbListing, MarketplaceType::WILDBERRIES, new \DateTimeImmutable('2026-04-01'));
-        $this->createSale($this->wbListing, MarketplaceType::WILDBERRIES, new \DateTimeImmutable('2026-04-15'));
-        $this->createSale($this->wbListing, MarketplaceType::WILDBERRIES, new \DateTimeImmutable('2026-04-30'));
+        foreach (['2026-04-01', '2026-04-15', '2026-04-30'] as $date) {
+            $this->createSale($this->wbListing, new \DateTimeImmutable($date));
+        }
         $this->em->flush();
 
         $qb = $this->salesListQuery->buildQueryBuilder(
@@ -102,9 +100,9 @@ final class SalesListQueryTest extends IntegrationTestCase
 
     public function testFiltersByDateToInclusive(): void
     {
-        $this->createSale($this->wbListing, MarketplaceType::WILDBERRIES, new \DateTimeImmutable('2026-04-01'));
-        $this->createSale($this->wbListing, MarketplaceType::WILDBERRIES, new \DateTimeImmutable('2026-04-15'));
-        $this->createSale($this->wbListing, MarketplaceType::WILDBERRIES, new \DateTimeImmutable('2026-04-30'));
+        foreach (['2026-04-01', '2026-04-15', '2026-04-30'] as $date) {
+            $this->createSale($this->wbListing, new \DateTimeImmutable($date));
+        }
         $this->em->flush();
 
         $qb = $this->salesListQuery->buildQueryBuilder(
@@ -123,10 +121,10 @@ final class SalesListQueryTest extends IntegrationTestCase
 
     public function testFiltersByDateRangeAndMarketplaceCombined(): void
     {
-        $this->createSale($this->wbListing, MarketplaceType::WILDBERRIES, new \DateTimeImmutable('2026-04-01'));
-        $this->createSale($this->wbListing, MarketplaceType::WILDBERRIES, new \DateTimeImmutable('2026-04-20'));
-        $this->createSale($this->ozonListing, MarketplaceType::OZON, new \DateTimeImmutable('2026-04-10'));
-        $this->createSale($this->ozonListing, MarketplaceType::OZON, new \DateTimeImmutable('2026-04-25'));
+        $this->createSale($this->wbListing, new \DateTimeImmutable('2026-04-01'));
+        $this->createSale($this->wbListing, new \DateTimeImmutable('2026-04-20'));
+        $this->createSale($this->ozonListing, new \DateTimeImmutable('2026-04-10'));
+        $this->createSale($this->ozonListing, new \DateTimeImmutable('2026-04-25'));
         $this->em->flush();
 
         $qb = $this->salesListQuery->buildQueryBuilder(
@@ -145,20 +143,13 @@ final class SalesListQueryTest extends IntegrationTestCase
 
     private function createSale(
         MarketplaceListing $listing,
-        MarketplaceType $marketplace,
         \DateTimeImmutable $saleDate,
     ): MarketplaceSale {
-        $sale = new MarketplaceSale(
-            Uuid::uuid4()->toString(),
-            $this->company,
-            $listing,
-            $marketplace,
-        );
-        $sale->setExternalOrderId('ext-' . Uuid::uuid4()->toString());
-        $sale->setSaleDate($saleDate);
-        $sale->setQuantity(1);
-        $sale->setPricePerUnit('1000.00');
-        $sale->setTotalRevenue('1000.00');
+        $sale = MarketplaceSaleBuilder::aSale()
+            ->forCompany($this->company)
+            ->forListing($listing)
+            ->withSaleDate($saleDate)
+            ->build();
         $this->em->persist($sale);
 
         return $sale;


### PR DESCRIPTION
## Summary
Added date range filtering capabilities to the `SalesListQuery` class to allow filtering marketplace sales by `from` and `to` dates, with inclusive boundaries on both ends.

## Key Changes
- Extended `SalesListQuery::buildQueryBuilder()` method signature with two optional parameters:
  - `$from`: Filter sales on or after this date (inclusive)
  - `$to`: Filter sales on or before this date (inclusive)
- Implemented date range filtering logic using SQL `>=` and `<=` operators
- Dates are formatted as `Y-m-d` strings for database comparison
- Added comprehensive test coverage in `SalesListQueryTest` with four test cases:
  - Verifies no filtering occurs when dates are null
  - Tests inclusive lower bound filtering
  - Tests inclusive upper bound filtering
  - Tests combined date range and marketplace filtering

## Implementation Details
- Date parameters are optional and default to `null` for backward compatibility
- Filters are applied conditionally only when date parameters are provided
- Date formatting uses immutable `DateTimeImmutable` objects converted to `Y-m-d` format for database queries
- Tests use realistic future dates (April 2026) and verify correct row counts and date values

https://claude.ai/code/session_0191NZqhwpeqUzd6FTcKA6TH