### PR TITLE
Task-02: MarketplaceSalesController reads date_from / date_to

### DIFF
--- a/site/src/Marketplace/Controller/MarketplaceSalesController.php
+++ b/site/src/Marketplace/Controller/MarketplaceSalesController.php
@@ -32,9 +32,11 @@ final class MarketplaceSalesController extends AbstractController
         $company      = $this->companyService->getActiveCompany();
         $companyId    = (string) $company->getId();
         $marketplace  = $request->query->get('marketplace') ?: null;
+        $dateFrom     = $this->parseDate($request->query->get('date_from'));
+        $dateTo       = $this->parseDate($request->query->get('date_to'));
         $page         = max(1, $request->query->getInt('page', 1));
 
-        $qb      = $this->salesListQuery->buildQueryBuilder($companyId, $marketplace);
+        $qb      = $this->salesListQuery->buildQueryBuilder($companyId, $marketplace, $dateFrom, $dateTo);
         $adapter = new QueryAdapter($qb, static function (QueryBuilder $qb): void {
             $qb->select('COUNT(s.id)')->resetOrderBy();
         });
@@ -49,6 +51,19 @@ final class MarketplaceSalesController extends AbstractController
             'pager'                  => $pager,
             'available_marketplaces' => MarketplaceType::cases(),
             'selected_marketplace'   => $marketplace,
+            'selected_date_from'     => $dateFrom?->format('Y-m-d'),
+            'selected_date_to'       => $dateTo?->format('Y-m-d'),
         ]);
+    }
+
+    private function parseDate(?string $raw): ?\DateTimeImmutable
+    {
+        if ($raw === null || $raw === '') {
+            return null;
+        }
+
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $raw);
+
+        return $date === false ? null : $date;
     }
 }

--- a/site/src/Marketplace/Controller/MarketplaceSalesController.php
+++ b/site/src/Marketplace/Controller/MarketplaceSalesController.php
@@ -32,8 +32,8 @@ final class MarketplaceSalesController extends AbstractController
         $company      = $this->companyService->getActiveCompany();
         $companyId    = (string) $company->getId();
         $marketplace  = $request->query->get('marketplace') ?: null;
-        $dateFrom     = $this->parseDate($request->query->get('date_from'));
-        $dateTo       = $this->parseDate($request->query->get('date_to'));
+        $dateFrom     = $this->parseDate($request->query->all()['date_from'] ?? null);
+        $dateTo       = $this->parseDate($request->query->all()['date_to'] ?? null);
         $page         = max(1, $request->query->getInt('page', 1));
 
         $qb      = $this->salesListQuery->buildQueryBuilder($companyId, $marketplace, $dateFrom, $dateTo);
@@ -56,14 +56,17 @@ final class MarketplaceSalesController extends AbstractController
         ]);
     }
 
-    private function parseDate(?string $raw): ?\DateTimeImmutable
+    private function parseDate(mixed $raw): ?\DateTimeImmutable
     {
-        if ($raw === null || $raw === '') {
+        if (!is_string($raw) || $raw === '') {
             return null;
         }
 
         $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $raw);
+        if ($date === false || $date->format('Y-m-d') !== $raw) {
+            return null;
+        }
 
-        return $date === false ? null : $date;
+        return $date;
     }
 }

--- a/site/tests/Marketplace/Controller/MarketplaceSalesControllerTest.php
+++ b/site/tests/Marketplace/Controller/MarketplaceSalesControllerTest.php
@@ -88,6 +88,54 @@ final class MarketplaceSalesControllerTest extends WebTestCaseBase
         self::assertStringContainsString('30.04.2026', $body);
     }
 
+    public function testIgnoresOutOfRangeDateAndShowsAll(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company, $wbListing] = $this->seedCompanyAndListings();
+
+        $this->seedSale($wbListing, '2026-04-01');
+        $this->seedSale($wbListing, '2026-04-15');
+        $this->seedSale($wbListing, '2026-04-30');
+        $this->em()->flush();
+
+        $this->loginWithActiveCompany($client, $owner, $company);
+
+        // April has 30 days; without strict validation PHP rolls 04-31 to 05-01,
+        // which would silently exclude every April sale.
+        $client->request('GET', '/marketplace/sales?date_from=2026-04-31');
+
+        self::assertResponseIsSuccessful();
+        $body = (string) $client->getResponse()->getContent();
+        self::assertStringContainsString('01.04.2026', $body);
+        self::assertStringContainsString('15.04.2026', $body);
+        self::assertStringContainsString('30.04.2026', $body);
+    }
+
+    public function testIgnoresArrayDateAndShowsAll(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company, $wbListing] = $this->seedCompanyAndListings();
+
+        $this->seedSale($wbListing, '2026-04-01');
+        $this->seedSale($wbListing, '2026-04-15');
+        $this->seedSale($wbListing, '2026-04-30');
+        $this->em()->flush();
+
+        $this->loginWithActiveCompany($client, $owner, $company);
+
+        $client->request('GET', '/marketplace/sales?date_from[]=2026-04-15');
+
+        self::assertResponseIsSuccessful();
+        $body = (string) $client->getResponse()->getContent();
+        self::assertStringContainsString('01.04.2026', $body);
+        self::assertStringContainsString('15.04.2026', $body);
+        self::assertStringContainsString('30.04.2026', $body);
+    }
+
     public function testCombinesMarketplaceAndDateFilters(): void
     {
         $client = static::createClient();

--- a/site/tests/Marketplace/Controller/MarketplaceSalesControllerTest.php
+++ b/site/tests/Marketplace/Controller/MarketplaceSalesControllerTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Marketplace\Controller;
+
+use App\Company\Entity\Company;
+use App\Company\Entity\User;
+use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceListingBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceSaleBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+final class MarketplaceSalesControllerTest extends WebTestCaseBase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-000000000088';
+
+    public function testLoadsIndexPageWithoutFilters(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company, $wbListing] = $this->seedCompanyAndListings();
+
+        $this->seedSale($wbListing, '2026-04-01');
+        $this->seedSale($wbListing, '2026-04-15');
+        $this->seedSale($wbListing, '2026-04-30');
+        $this->em()->flush();
+
+        $this->loginWithActiveCompany($client, $owner, $company);
+
+        $client->request('GET', '/marketplace/sales');
+
+        self::assertResponseIsSuccessful();
+        $body = (string) $client->getResponse()->getContent();
+        self::assertStringContainsString('01.04.2026', $body);
+        self::assertStringContainsString('15.04.2026', $body);
+        self::assertStringContainsString('30.04.2026', $body);
+    }
+
+    public function testFiltersByDateFromAndTo(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company, $wbListing] = $this->seedCompanyAndListings();
+
+        $this->seedSale($wbListing, '2026-04-01');
+        $this->seedSale($wbListing, '2026-04-15');
+        $this->seedSale($wbListing, '2026-04-30');
+        $this->em()->flush();
+
+        $this->loginWithActiveCompany($client, $owner, $company);
+
+        $client->request('GET', '/marketplace/sales?date_from=2026-04-10&date_to=2026-04-20');
+
+        self::assertResponseIsSuccessful();
+        $body = (string) $client->getResponse()->getContent();
+        self::assertStringContainsString('15.04.2026', $body);
+        self::assertStringNotContainsString('01.04.2026', $body);
+        self::assertStringNotContainsString('30.04.2026', $body);
+    }
+
+    public function testIgnoresInvalidDateAndShowsAll(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company, $wbListing] = $this->seedCompanyAndListings();
+
+        $this->seedSale($wbListing, '2026-04-01');
+        $this->seedSale($wbListing, '2026-04-15');
+        $this->seedSale($wbListing, '2026-04-30');
+        $this->em()->flush();
+
+        $this->loginWithActiveCompany($client, $owner, $company);
+
+        $client->request('GET', '/marketplace/sales?date_from=not-a-date');
+
+        self::assertResponseIsSuccessful();
+        $body = (string) $client->getResponse()->getContent();
+        self::assertStringContainsString('01.04.2026', $body);
+        self::assertStringContainsString('15.04.2026', $body);
+        self::assertStringContainsString('30.04.2026', $body);
+    }
+
+    public function testCombinesMarketplaceAndDateFilters(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company, $wbListing, $ozonListing] = $this->seedCompanyAndListings();
+
+        $this->seedSale($wbListing, '2026-04-01');
+        $this->seedSale($wbListing, '2026-04-20');
+        $this->seedSale($ozonListing, '2026-04-15');
+        $this->seedSale($ozonListing, '2026-04-25');
+        $this->em()->flush();
+
+        $this->loginWithActiveCompany($client, $owner, $company);
+
+        $client->request('GET', '/marketplace/sales?marketplace=wildberries&date_from=2026-04-10');
+
+        self::assertResponseIsSuccessful();
+        $body = (string) $client->getResponse()->getContent();
+        self::assertStringContainsString('20.04.2026', $body);
+        self::assertStringNotContainsString('01.04.2026', $body);
+        self::assertStringNotContainsString('15.04.2026', $body);
+        self::assertStringNotContainsString('25.04.2026', $body);
+    }
+
+    /**
+     * @return array{0: User, 1: Company, 2: MarketplaceListing, 3: MarketplaceListing}
+     */
+    private function seedCompanyAndListings(): array
+    {
+        $owner = UserBuilder::aUser()
+            ->withEmail('marketplace-sales@example.test')
+            ->build();
+
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->withName('Sales Filter Co')
+            ->build();
+
+        $wbListing = MarketplaceListingBuilder::aListing()
+            ->forCompany($company)
+            ->withMarketplace(MarketplaceType::WILDBERRIES)
+            ->withMarketplaceSku('wb-sku-1')
+            ->build();
+
+        $ozonListing = MarketplaceListingBuilder::aListing()
+            ->forCompany($company)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withMarketplaceSku('ozon-sku-1')
+            ->build();
+
+        $em = $this->em();
+        $em->persist($owner);
+        $em->persist($company);
+        $em->persist($wbListing);
+        $em->persist($ozonListing);
+        $em->flush();
+
+        return [$owner, $company, $wbListing, $ozonListing];
+    }
+
+    private function seedSale(MarketplaceListing $listing, string $date): void
+    {
+        $sale = MarketplaceSaleBuilder::aSale()
+            ->forCompany($listing->getCompany())
+            ->forListing($listing)
+            ->withSaleDate(new \DateTimeImmutable($date))
+            ->build();
+
+        $this->em()->persist($sale);
+    }
+
+    private function loginWithActiveCompany(KernelBrowser $client, User $owner, Company $company): void
+    {
+        $client->loginUser($owner);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', $company->getId());
+        $session->save();
+    }
+}


### PR DESCRIPTION
## Summary
- `MarketplaceSalesController` reads optional `date_from` / `date_to` from the query string and forwards them to `SalesListQuery::buildQueryBuilder` (extended in Task-01).
- Date parsing uses `!Y-m-d` — strict and anchored. Invalid or empty values fall back to `null` rather than throwing, so a bad query param can't 5xx the page.
- Render context now exposes `selected_date_from` / `selected_date_to` as `Y-m-d` strings ready for `<input type="date">` prefill (no `|date` filter required in Twig).

## Notes
- No DTO / Form class — two scalars + a small private helper, per task spec.
- No `from <= to` validation — empty result is acceptable UX.
- Route name `marketplace_sales_index` unchanged (referenced by the "Recalculate cost" modal).
- IDOR guard via `getActiveCompany()` unchanged.
- Twig template not modified (frontend scope was not invoked in this task).

## Test plan
- [x] `php -l` passes on both files.
- [ ] CI runs `tests/Marketplace/Controller/MarketplaceSalesControllerTest.php` covering:
  - happy path render without filters,
  - inclusive `date_from` + `date_to` range,
  - invalid date string → graceful fallback (all sales visible),
  - combined `marketplace=wildberries` + `date_from`.

https://claude.ai/code/session_0191NZqhwpeqUzd6FTcKA6TH

---
_Generated by [Claude Code](https://claude.ai/code/session_0191NZqhwpeqUzd6FTcKA6TH)_