### PR TITLE
Task-03: SalesJsonExportController — GET /marketplace/sales/export.json

### DIFF
--- a/site/src/Marketplace/Controller/SalesJsonExportController.php
+++ b/site/src/Marketplace/Controller/SalesJsonExportController.php
@@ -28,7 +28,7 @@ final class SalesJsonExportController extends AbstractController
     {
         $company     = $this->companyService->getActiveCompany();
         $companyId   = (string) $company->getId();
-        $marketplace = $request->query->get('marketplace') ?: null;
+        $marketplace = $this->stringOrNull($request->query->all()['marketplace'] ?? null);
         $dateFrom    = $this->parseDate($request->query->all()['date_from'] ?? null);
         $dateTo      = $this->parseDate($request->query->all()['date_to'] ?? null);
 
@@ -70,5 +70,10 @@ final class SalesJsonExportController extends AbstractController
         }
 
         return $date;
+    }
+
+    private function stringOrNull(mixed $raw): ?string
+    {
+        return is_string($raw) && $raw !== '' ? $raw : null;
     }
 }

--- a/site/src/Marketplace/Controller/SalesJsonExportController.php
+++ b/site/src/Marketplace/Controller/SalesJsonExportController.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Controller;
+
+use App\Marketplace\Infrastructure\Query\SalesListQuery;
+use App\Shared\Service\ActiveCompanyService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route('/marketplace')]
+#[IsGranted('ROLE_USER')]
+final class SalesJsonExportController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $companyService,
+        private readonly SalesListQuery       $salesListQuery,
+    ) {
+    }
+
+    #[Route('/sales/export.json', name: 'marketplace_sales_export_json', methods: ['GET'])]
+    public function __invoke(Request $request): Response
+    {
+        $company     = $this->companyService->getActiveCompany();
+        $companyId   = (string) $company->getId();
+        $marketplace = $request->query->get('marketplace') ?: null;
+        $dateFrom    = $this->parseDate($request->query->all()['date_from'] ?? null);
+        $dateTo      = $this->parseDate($request->query->all()['date_to'] ?? null);
+
+        $qb   = $this->salesListQuery->buildQueryBuilder($companyId, $marketplace, $dateFrom, $dateTo);
+        $rows = $qb->executeQuery()->fetchAllAssociative();
+
+        $payload = [
+            'exported_at' => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
+            'filters'     => [
+                'marketplace' => $marketplace,
+                'date_from'   => $dateFrom?->format('Y-m-d'),
+                'date_to'     => $dateTo?->format('Y-m-d'),
+            ],
+            'count'       => \count($rows),
+            'sales'       => $rows,
+        ];
+
+        $response = new JsonResponse($payload);
+        $response->setEncodingOptions(\JSON_PRETTY_PRINT | \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES);
+
+        $filename = \sprintf('marketplace-sales-%s.json', (new \DateTimeImmutable())->format('Ymd-His'));
+        $response->headers->set(
+            'Content-Disposition',
+            \sprintf('attachment; filename="%s"', $filename),
+        );
+
+        return $response;
+    }
+
+    private function parseDate(mixed $raw): ?\DateTimeImmutable
+    {
+        if (!is_string($raw) || $raw === '') {
+            return null;
+        }
+
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $raw);
+        if ($date === false || $date->format('Y-m-d') !== $raw) {
+            return null;
+        }
+
+        return $date;
+    }
+}

--- a/site/tests/Marketplace/Controller/SalesJsonExportControllerTest.php
+++ b/site/tests/Marketplace/Controller/SalesJsonExportControllerTest.php
@@ -101,6 +101,29 @@ final class SalesJsonExportControllerTest extends WebTestCaseBase
         self::assertSame('2026-04-20', $payload['filters']['date_to']);
     }
 
+    public function testIgnoresArrayQueryParamsAndShowsAll(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company, $wbListing] = $this->seedCompanyA();
+        $this->seedSale($wbListing, '2026-04-15');
+        $this->em()->flush();
+
+        $this->loginWithActiveCompany($client, $owner, $company);
+
+        $client->request(
+            'GET',
+            '/marketplace/sales/export.json?marketplace[]=wildberries&date_from[]=2026-04-15',
+        );
+
+        self::assertResponseIsSuccessful();
+        $payload = $this->decodeJson($client);
+        self::assertSame(1, $payload['count']);
+        self::assertNull($payload['filters']['marketplace']);
+        self::assertNull($payload['filters']['date_from']);
+    }
+
     public function testReturnsEmptyArrayWhenNoMatches(): void
     {
         $client = static::createClient();

--- a/site/tests/Marketplace/Controller/SalesJsonExportControllerTest.php
+++ b/site/tests/Marketplace/Controller/SalesJsonExportControllerTest.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Marketplace\Controller;
+
+use App\Company\Entity\Company;
+use App\Company\Entity\User;
+use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceListingBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceSaleBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+final class SalesJsonExportControllerTest extends WebTestCaseBase
+{
+    private const COMPANY_A_ID = '11111111-1111-1111-1111-0000000000a1';
+    private const COMPANY_B_ID = '11111111-1111-1111-1111-0000000000b2';
+
+    public function testReturnsJsonWithAttachmentHeader(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company, $wbListing] = $this->seedCompanyA();
+        $this->seedSale($wbListing, '2026-04-15');
+        $this->em()->flush();
+
+        $this->loginWithActiveCompany($client, $owner, $company);
+
+        $client->request('GET', '/marketplace/sales/export.json');
+
+        self::assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertStringContainsString('application/json', (string) $response->headers->get('Content-Type'));
+        self::assertMatchesRegularExpression(
+            '/^attachment; filename="marketplace-sales-\d{8}-\d{6}\.json"$/',
+            (string) $response->headers->get('Content-Disposition'),
+        );
+    }
+
+    public function testIncludesAllSalesForCompanyWhenNoFilters(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$ownerA, $companyA, $wbListingA] = $this->seedCompanyA();
+        [$ownerB, $companyB, $wbListingB] = $this->seedCompanyB();
+
+        $this->seedSale($wbListingA, '2026-04-01');
+        $this->seedSale($wbListingA, '2026-04-15');
+        $this->seedSale($wbListingA, '2026-04-30');
+        $this->seedSale($wbListingB, '2026-04-10');
+        $this->seedSale($wbListingB, '2026-04-20');
+        $this->em()->flush();
+
+        $this->loginWithActiveCompany($client, $ownerA, $companyA);
+
+        $client->request('GET', '/marketplace/sales/export.json');
+
+        self::assertResponseIsSuccessful();
+        $payload = $this->decodeJson($client);
+
+        self::assertSame(3, $payload['count']);
+        self::assertCount(3, $payload['sales']);
+
+        $listingIds = array_unique(array_column($payload['sales'], 'marketplace_sku'));
+        self::assertSame(['wb-sku-A'], array_values($listingIds));
+    }
+
+    public function testFiltersByMarketplaceAndDates(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company, $wbListing, $ozonListing] = $this->seedCompanyA();
+
+        $this->seedSale($wbListing, '2026-04-01');
+        $this->seedSale($wbListing, '2026-04-15');
+        $this->seedSale($wbListing, '2026-04-25');
+        $this->seedSale($ozonListing, '2026-04-15');
+        $this->em()->flush();
+
+        $this->loginWithActiveCompany($client, $owner, $company);
+
+        $client->request('GET', '/marketplace/sales/export.json?marketplace=wildberries&date_from=2026-04-10&date_to=2026-04-20');
+
+        self::assertResponseIsSuccessful();
+        $payload = $this->decodeJson($client);
+
+        self::assertSame(1, $payload['count']);
+        self::assertCount(1, $payload['sales']);
+        self::assertSame('wildberries', $payload['sales'][0]['marketplace']);
+        self::assertSame('2026-04-15', substr((string) $payload['sales'][0]['sale_date'], 0, 10));
+
+        self::assertSame('wildberries', $payload['filters']['marketplace']);
+        self::assertSame('2026-04-10', $payload['filters']['date_from']);
+        self::assertSame('2026-04-20', $payload['filters']['date_to']);
+    }
+
+    public function testReturnsEmptyArrayWhenNoMatches(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company, $wbListing] = $this->seedCompanyA();
+        $this->seedSale($wbListing, '2026-04-15');
+        $this->em()->flush();
+
+        $this->loginWithActiveCompany($client, $owner, $company);
+
+        $client->request('GET', '/marketplace/sales/export.json?date_from=2099-01-01');
+
+        self::assertResponseIsSuccessful();
+        $payload = $this->decodeJson($client);
+
+        self::assertSame(0, $payload['count']);
+        self::assertSame([], $payload['sales']);
+    }
+
+    public function testPayloadStructureContainsRequiredFields(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company, $wbListing] = $this->seedCompanyA();
+        $this->seedSale($wbListing, '2026-04-15');
+        $this->em()->flush();
+
+        $this->loginWithActiveCompany($client, $owner, $company);
+
+        $client->request('GET', '/marketplace/sales/export.json');
+
+        self::assertResponseIsSuccessful();
+        $payload = $this->decodeJson($client);
+
+        self::assertArrayHasKey('exported_at', $payload);
+        self::assertArrayHasKey('filters', $payload);
+        self::assertArrayHasKey('count', $payload);
+        self::assertArrayHasKey('sales', $payload);
+
+        self::assertSame(['marketplace', 'date_from', 'date_to'], array_keys($payload['filters']));
+        self::assertNull($payload['filters']['marketplace']);
+        self::assertNull($payload['filters']['date_from']);
+        self::assertNull($payload['filters']['date_to']);
+
+        self::assertNotEmpty($payload['sales']);
+        $sale = $payload['sales'][0];
+        foreach ([
+            'id', 'sale_date', 'marketplace', 'external_order_id',
+            'quantity', 'price_per_unit', 'total_revenue', 'cost_price',
+            'marketplace_sku', 'listing_name',
+        ] as $field) {
+            self::assertArrayHasKey($field, $sale);
+        }
+    }
+
+    /**
+     * @return array{0: User, 1: Company, 2: MarketplaceListing, 3: MarketplaceListing}
+     */
+    private function seedCompanyA(): array
+    {
+        $owner = UserBuilder::aUser()
+            ->withId('22222222-2222-2222-2222-0000000000a1')
+            ->withEmail('export-owner-a@example.test')
+            ->build();
+
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_A_ID)
+            ->withOwner($owner)
+            ->withName('Export Company A')
+            ->build();
+
+        $wbListing = MarketplaceListingBuilder::aListing()
+            ->forCompany($company)
+            ->withMarketplace(MarketplaceType::WILDBERRIES)
+            ->withMarketplaceSku('wb-sku-A')
+            ->build();
+
+        $ozonListing = MarketplaceListingBuilder::aListing()
+            ->forCompany($company)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withMarketplaceSku('ozon-sku-A')
+            ->build();
+
+        $em = $this->em();
+        $em->persist($owner);
+        $em->persist($company);
+        $em->persist($wbListing);
+        $em->persist($ozonListing);
+        $em->flush();
+
+        return [$owner, $company, $wbListing, $ozonListing];
+    }
+
+    /**
+     * @return array{0: User, 1: Company, 2: MarketplaceListing}
+     */
+    private function seedCompanyB(): array
+    {
+        $owner = UserBuilder::aUser()
+            ->withId('22222222-2222-2222-2222-0000000000b2')
+            ->withEmail('export-owner-b@example.test')
+            ->build();
+
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_B_ID)
+            ->withOwner($owner)
+            ->withName('Export Company B')
+            ->build();
+
+        $wbListing = MarketplaceListingBuilder::aListing()
+            ->forCompany($company)
+            ->withMarketplace(MarketplaceType::WILDBERRIES)
+            ->withMarketplaceSku('wb-sku-B')
+            ->build();
+
+        $em = $this->em();
+        $em->persist($owner);
+        $em->persist($company);
+        $em->persist($wbListing);
+        $em->flush();
+
+        return [$owner, $company, $wbListing];
+    }
+
+    private function seedSale(MarketplaceListing $listing, string $date): void
+    {
+        $sale = MarketplaceSaleBuilder::aSale()
+            ->forCompany($listing->getCompany())
+            ->forListing($listing)
+            ->withSaleDate(new \DateTimeImmutable($date))
+            ->build();
+
+        $this->em()->persist($sale);
+    }
+
+    private function loginWithActiveCompany(KernelBrowser $client, User $owner, Company $company): void
+    {
+        $client->loginUser($owner);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', $company->getId());
+        $session->save();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(KernelBrowser $client): array
+    {
+        $body = (string) $client->getResponse()->getContent();
+        $decoded = json_decode($body, true);
+        self::assertIsArray($decoded);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## Summary
- New `final class SalesJsonExportController` with a single `__invoke` route at `GET /marketplace/sales/export.json`.
- Reuses the shared `SalesListQuery` (Task-01) — same `marketplace` / `date_from` / `date_to` filters as the index page, same row shape.
- Returns a `JsonResponse` with `JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES` and `Content-Disposition: attachment; filename="marketplace-sales-<Ymd-His>.json"` for a plain `<a href="...">` download.
- IDOR-safe: `IsGranted('ROLE_USER')` at route level + `ActiveCompanyService::getActiveCompany()` at data level.

## Payload shape

```json
{
  "exported_at": "2026-04-25T...+00:00",
  "filters": { "marketplace": "wildberries", "date_from": "2026-04-01", "date_to": "2026-04-30" },
  "count": 142,
  "sales": [{ "id": "...", "sale_date": "...", ... }]
}
```

`filters` echoes the inputs (with `null` for unset filters) so the user can see what produced the file.

## Notes
- **`parseDate` matches the hardened Task-02 version** (`mixed` input, `!Y-m-d` + format round-trip), not the simpler form shown in the task spec — reproducing the simpler one would silently re-introduce both the rollover issue (`2026-04-31` → `2026-05-01`) and the array-input crash (`?date_from[]=…`) that PR #1659 fixed.
- **No `Api/`, no OpenAPI annotations, no `schema.d.ts` regeneration** — endpoint is consumed by a plain `<a href>`, so the API-types CI gate doesn't apply.
- **No pagination, no `StreamedResponse`** — the date filter is the volume cap; we don't need streaming for a few thousand rows.
- **No `MarketplaceFacade`** — same module, our own Query.
- `parseDate` is duplicated locally (8 lines) with the index controller — extracted only when a third caller appears.

## Test plan
- [x] `php -l` passes on both files.
- [ ] CI runs `tests/Marketplace/Controller/SalesJsonExportControllerTest.php`:
  - [ ] `testReturnsJsonWithAttachmentHeader` — Content-Type + Content-Disposition pattern.
  - [ ] `testIncludesAllSalesForCompanyWhenNoFilters` — **IDOR isolation** between two seeded companies.
  - [ ] `testFiltersByMarketplaceAndDates` — combined `marketplace` + `date_from` + `date_to` narrows correctly; `filters` is echoed back.
  - [ ] `testReturnsEmptyArrayWhenNoMatches` — `count: 0`, `sales: []`.
  - [ ] `testPayloadStructureContainsRequiredFields` — top-level keys + all 10 sale-row fields.

https://claude.ai/code/session_0191NZqhwpeqUzd6FTcKA6TH

---
_Generated by [Claude Code](https://claude.ai/code/session_0191NZqhwpeqUzd6FTcKA6TH)_