### PR TITLE
Task-02b: harden MarketplaceSalesController query parsing against array inputs

### DIFF
--- a/site/src/Marketplace/Controller/MarketplaceSalesController.php
+++ b/site/src/Marketplace/Controller/MarketplaceSalesController.php
@@ -31,7 +31,7 @@ final class MarketplaceSalesController extends AbstractController
     {
         $company      = $this->companyService->getActiveCompany();
         $companyId    = (string) $company->getId();
-        $marketplace  = $request->query->get('marketplace') ?: null;
+        $marketplace  = $this->stringOrNull($request->query->all()['marketplace'] ?? null);
         $dateFrom     = $this->parseDate($request->query->all()['date_from'] ?? null);
         $dateTo       = $this->parseDate($request->query->all()['date_to'] ?? null);
         $page         = max(1, $request->query->getInt('page', 1));
@@ -68,5 +68,10 @@ final class MarketplaceSalesController extends AbstractController
         }
 
         return $date;
+    }
+
+    private function stringOrNull(mixed $raw): ?string
+    {
+        return is_string($raw) && $raw !== '' ? $raw : null;
     }
 }

--- a/site/tests/Marketplace/Controller/MarketplaceSalesControllerTest.php
+++ b/site/tests/Marketplace/Controller/MarketplaceSalesControllerTest.php
@@ -136,6 +136,32 @@ final class MarketplaceSalesControllerTest extends WebTestCaseBase
         self::assertStringContainsString('30.04.2026', $body);
     }
 
+    public function testIgnoresArrayQueryParamsAndShowsAll(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company, $wbListing] = $this->seedCompanyAndListings();
+
+        $this->seedSale($wbListing, '2026-04-01');
+        $this->seedSale($wbListing, '2026-04-15');
+        $this->seedSale($wbListing, '2026-04-30');
+        $this->em()->flush();
+
+        $this->loginWithActiveCompany($client, $owner, $company);
+
+        $client->request(
+            'GET',
+            '/marketplace/sales?marketplace[]=foo&date_from[]=bar&date_to[]=baz',
+        );
+
+        self::assertResponseIsSuccessful();
+        $body = (string) $client->getResponse()->getContent();
+        self::assertStringContainsString('01.04.2026', $body);
+        self::assertStringContainsString('15.04.2026', $body);
+        self::assertStringContainsString('30.04.2026', $body);
+    }
+
     public function testCombinesMarketplaceAndDateFilters(): void
     {
         $client = static::createClient();


### PR DESCRIPTION
## Summary
- Ports the `query->all()['key'] ?? null` + `stringOrNull()` pattern from `SalesJsonExportController` (PR #1660) into `MarketplaceSalesController`.
- `?marketplace[]=foo` no longer triggers Symfony's `BadRequestException` (HTTP 400) from `InputBag::get()` — array inputs are gracefully ignored, page renders with the filter unset.
- Both controllers in the module now read query params identically.

## Why
Pre-existing gap surfaced during the PR #1660 review: only the export controller had the hardened pattern, while the index controller still used `$request->query->get('marketplace') ?: null`. With Task-04 about to add `<a href="{{ path('marketplace_sales_export_json', {marketplace: …, …}) }}">` links from the index page, asymmetric handling could mean one URL returns 200 while the other returns 400 for the same query string.

## Diff scope
- `MarketplaceSalesController::__invoke` — one line changed for `marketplace` (dates were already on `query->all()` from PR #1659).
- New private `stringOrNull(mixed): ?string` (1-for-1 copy from `SalesJsonExportController:75-78`).
- `parseDate`, `page`, route, DI, render — untouched.

## Not scoped here
- No extraction of `parseDate` / `stringOrNull` into a shared trait — only two callers, rule-of-three. Lifts naturally when a third caller appears.
- No `getInt('page', …)` change — `InputBag::getInt` coerces array input to `0`, doesn't throw.
- No fixes in unrelated controllers (`RecalculateSalesCostPriceController`, `MarketplaceAnalytics*Controller`, etc.) — out of scope; this PR is strictly about `/marketplace/sales` UX.

## Test plan
- [x] `php -l` passes on both files.
- [ ] CI runs `tests/Marketplace/Controller/MarketplaceSalesControllerTest.php`:
  - 4 pre-existing tests untouched (load, filter-by-date, invalid-date, combined).
  - Pre-existing `testIgnoresArrayDateAndShowsAll` (date-only) untouched.
  - **New** `testIgnoresArrayQueryParamsAndShowsAll` — `?marketplace[]=foo&date_from[]=bar&date_to[]=baz` → 200, all sales visible. Name matches `SalesJsonExportControllerTest::testIgnoresArrayQueryParamsAndShowsAll` for symmetry.
- [ ] Manual: `curl "/marketplace/sales?marketplace[]=foo"` returns 200 (was 400 pre-fix).

https://claude.ai/code/session_0191NZqhwpeqUzd6FTcKA6TH

---
_Generated by [Claude Code](https://claude.ai/code/session_0191NZqhwpeqUzd6FTcKA6TH)_