### PR TITLE
Task-04: sales header — date filter inputs + "Скачать JSON" button

### DIFF
--- a/site/templates/marketplace/sales.html.twig
+++ b/site/templates/marketplace/sales.html.twig
@@ -3,14 +3,14 @@
 {% set active_tab = 'sales' %}
 
 {% block tab_content %}
-    {# Шапка: заголовок + фильтр + кнопка пересчёта #}
-    <div class="card-header d-flex align-items-center gap-3">
+    {# Шапка: заголовок + фильтры + кнопки пересчёта/экспорта #}
+    <div class="card-header d-flex align-items-center gap-3 flex-wrap">
         <h3 class="card-title me-auto mb-0">Продажи</h3>
 
-        {# Фильтр по маркетплейсу #}
-        <form method="get" action="{{ path('marketplace_sales_index') }}" class="d-flex align-items-center gap-2 mb-0">
-            <select name="marketplace" class="form-select form-select-sm w-auto"
-                    onchange="this.form.submit()">
+        {# Фильтр: маркетплейс + диапазон дат #}
+        <form method="get" action="{{ path('marketplace_sales_index') }}"
+              class="d-flex align-items-center gap-2 mb-0 flex-wrap">
+            <select name="marketplace" class="form-select form-select-sm w-auto">
                 <option value="">Все площадки</option>
                 {% for mp in available_marketplaces %}
                     <option value="{{ mp.value }}"
@@ -19,6 +19,26 @@
                     </option>
                 {% endfor %}
             </select>
+
+            <input type="date"
+                   name="date_from"
+                   class="form-control form-control-sm w-auto"
+                   value="{{ selected_date_from ?? '' }}"
+                   aria-label="Дата с">
+
+            <span class="text-muted">—</span>
+
+            <input type="date"
+                   name="date_to"
+                   class="form-control form-control-sm w-auto"
+                   value="{{ selected_date_to ?? '' }}"
+                   aria-label="Дата по">
+
+            <button type="submit" class="btn btn-sm btn-primary">Применить</button>
+
+            {% if selected_marketplace or selected_date_from or selected_date_to %}
+                <a href="{{ path('marketplace_sales_index') }}" class="btn btn-sm btn-link">Сбросить</a>
+            {% endif %}
         </form>
 
         <button class="btn btn-sm btn-outline-secondary"
@@ -31,6 +51,15 @@
             </svg>
             Пересчитать себестоимость
         </button>
+
+        <a href="{{ path('marketplace_sales_export_json', {
+                marketplace: selected_marketplace,
+                date_from:   selected_date_from,
+                date_to:     selected_date_to,
+           }) }}"
+           class="btn btn-sm btn-outline-primary">
+            Скачать JSON
+        </a>
     </div>
 
     <div class="table-responsive">


### PR DESCRIPTION
## Summary
- Adds two `<input type="date">` filters and an explicit "Применить" submit button to the `/marketplace/sales` header.
- Adds a "Скачать JSON" link wired to `marketplace_sales_export_json` (Task-03), forwarding the currently active filters.
- Drops `onchange="this.form.submit()"` from the marketplace `<select>` so partially-typed dates don't auto-submit on every keystroke.

## Markup changes (only `.card-header`)
- Two `<input type="date" name="date_from|date_to">` with `aria-label`s, prefilled from `selected_date_from` / `selected_date_to` (Task-02 already pushes both to the template).
- `<span class="text-muted">—</span>` between the dates as a visual bridge.
- `<button type="submit" class="btn btn-sm btn-primary">Применить</button>` — the form's only submit trigger now.
- Conditional `<a href="{{ path('marketplace_sales_index') }}">Сбросить</a>` shown only when `selected_marketplace or selected_date_from or selected_date_to`.
- `<a href="{{ path('marketplace_sales_export_json', { marketplace, date_from, date_to }) }}" class="btn btn-sm btn-outline-primary">Скачать JSON</a>` — placed right after "Пересчитать себестоимость". `path()` drops null params, so unfiltered downloads produce a clean URL.
- `flex-wrap` on both the container and the form so the row degrades on narrower viewports.

## Preserved verbatim from the actual file
- Option label `Все площадки` (not "Все маркетплейсы" as in the task's reconstructed example).
- Option text `{{ mp.value|upper }}` (not `getDisplayName()`).
- The "Пересчитать себестоимость" button, SVG, and modal target — untouched.

## Out of scope
The task explicitly limited scope to `.card-header`. The Pagerfanta footer at `templates/marketplace/sales.html.twig:97-105` still passes only `marketplace` in `route_params`, so paginating through filtered results currently drops `date_from` / `date_to`. **Follow-up:** thread the same two params through the `partials/_pagerfanta.html.twig` include — single-line change, separate PR.

## Test plan
- [ ] `/marketplace/sales` renders the new filter row without errors.
- [ ] Selecting a marketplace + filling both dates + clicking "Применить" updates the URL with all three params; inputs stay populated on reload.
- [ ] "Сбросить" appears only with at least one active filter and clears all params on click.
- [ ] "Скачать JSON" with active filters downloads `marketplace-sales-<timestamp>.json` with `filters` populated; without filters it downloads with all-null `filters` and the full company sales set.
- [ ] "Пересчитать себестоимость" modal still opens and submits as before.
- [ ] On `~768px` viewport the row wraps cleanly to a second line, no overflow.

https://claude.ai/code/session_0191NZqhwpeqUzd6FTcKA6TH

---
_Generated by [Claude Code](https://claude.ai/code/session_0191NZqhwpeqUzd6FTcKA6TH)_