### PR TITLE
feat(marketplace-ads): add AdSpendByListingQuery + facade aggregator

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -274,6 +274,19 @@ getTotalAdCostForPeriod(
     \DateTimeImmutable $dateTo,
     ?string $marketplace = null,
 ): string
+
+// РР с разрезом по листингам за период.
+// Для построения строк отчётов с колонкой РР по листингу.
+// Возвращает только attributed listingId (те, что есть в marketplace_ad_document_lines).
+// Включает «висячие» listing_id без живого листинга — для согласованности с totals.
+// Для totals (полная сумма за период) использовать getTotalAdCostForPeriod().
+// @return array<string, string>  listingId => decimal-string adSpend
+getAdSpendByListingForPeriod(
+    string $companyId,
+    \DateTimeImmutable $from,
+    \DateTimeImmutable $to,
+    ?string $marketplace = null,
+): array
 ```
 
 ### `MarketplaceAnalyticsFacade` (`src/MarketplaceAnalytics/Facade/MarketplaceAnalyticsFacade.php`)
@@ -857,6 +870,23 @@ getPage(
   `items: list<AdEfficiencyItemDTO>`, `total`, `page`, `pageSize`, `totalRevenue`, `totalAdSpend`,
   `?totalDrrPercent`. Totals считаются по ВСЕМУ набору листингов, не только по странице.
 
+### `AdSpendByListingQuery` (`src/MarketplaceAds/Infrastructure/Query/AdSpendByListingQuery.php`)
+```php
+// РР с разрезом по листингам за период. Используется через MarketplaceAdsFacade
+// (getAdSpendByListingForPeriod) для построения строк отчётов другими модулями.
+// Семантически = CTE ads_agg из AdEfficiencyQuery, вынесенный в отдельный read-only query.
+// В отличие от AdEfficiencyQuery НЕ фильтрует по существованию листинга в marketplace_listings —
+// «висячие» listing_id попадают в выдачу (критично для согласованности totals на потребителях).
+// Денежные значения наружу — decimal-строки (bcmath-compatible).
+// @return array<string, string>  listingId => decimal-string adSpend
+getByListingForPeriod(
+    string $companyId,
+    \DateTimeImmutable $from,
+    \DateTimeImmutable $to,
+    ?string $marketplace = null,
+): array
+```
+
 ---
 
 ## Query — Marketplace
@@ -1355,6 +1385,7 @@ paths:
 
 | Версия | Дата | Что изменилось |
 |---|---|---|
+| 1.36 | 2026-04-25 | MarketplaceAds: новый read-only query `AdSpendByListingQuery` (`src/MarketplaceAds/Infrastructure/Query/AdSpendByListingQuery.php`) — РР с разрезом по листингам за период. Семантически = CTE `ads_agg` из `AdEfficiencyQuery`, вынесен в отдельный класс для переиспользования из других модулей через фасад. SQL = `SELECT adl.listing_id, SUM(adl.cost) FROM marketplace_ad_document_lines adl JOIN marketplace_ad_documents ad ON ad.id = adl.ad_document_id WHERE ad.company_id = :companyId AND ad.report_date BETWEEN :periodFrom AND :periodTo [AND ad.marketplace = :marketplace] GROUP BY adl.listing_id`. В отличие от `AdEfficiencyQuery` НЕ inner-join'ит на `marketplace_listings` — «висячие» listing_id (line.listing_id без живого листинга) попадают в выдачу; это критично для согласованности с `getTotalAdCostForPeriod` на потребителях. Возвращает `array<string, string>` (listingId → decimal-строка), без float — bcmath-совместимость модуля. `MarketplaceAdsFacade` получил конструктор-параметр `AdSpendByListingQuery` рядом с `AdDocumentQuery` и публичный метод `getAdSpendByListingForPeriod(companyId, from, to, ?marketplace=null): array`, делегирующий в новый query. Существующий `getTotalAdCostForPeriod` (полная сумма за период по `marketplace_ad_documents.total_cost`, включая non-attributed) не трогали — его роль totals на потребителях. `AdEfficiencyQuery` и `AdEfficiencyController` не менялись (CTE-дубликат из 6 строк допустим). Тесты: integration `AdSpendByListingQueryTest` (5 кейсов: happy / marketplace-фильтр / пустой период / non-attributed listing_id попадает в выдачу / IDOR другой компании); unit `MarketplaceAdsFacadeTest` (делегация getAdSpendByListingForPeriod через мок + дефолт `marketplace=null`). |
 | 1.35 | 2026-04-25 | Marketplace: рефакторинг UI `/marketplace/sales` — фильтр по диапазону дат и JSON-экспорт. `SalesListQuery::buildQueryBuilder` расширен опциональными `?\DateTimeImmutable $from, ?\DateTimeImmutable $to` (включительные границы `>=`/`<=`, формат `Y-m-d`); возвращает `QueryBuilder`, индексная страница оборачивает его в Pagerfanta-адаптер, экспорт читает напрямую через `fetchAllAssociative()`. Новый `SalesJsonExportController` — `GET /marketplace/sales/export.json` (route `marketplace_sales_export_json`), `JsonResponse` с `Content-Disposition: attachment`, payload `{exported_at, filters, count, sales[]}`, IDOR через `ActiveCompanyService`. Endpoint — page-route, не публичный API (OpenAPI и `schema.d.ts` не затронуты). `MarketplaceSalesController` читает `date_from`/`date_to` + hardened против `?key[]=foo`/массивных входов: невалидные query-параметры через `query->all()` + локальные `stringOrNull`/`parseDate` (с round-trip формата против rollover вроде `2026-04-31` → `2026-05-01`) трактуются как «фильтр не задан», без 4xx. Twig `marketplace/sales.html.twig`: в `.card-header` — два `<input type="date">`, кнопка «Применить», условная «Сбросить» + ссылка «Скачать JSON»; `onchange="this.form.submit()"` со `<select name="marketplace">` снят. Pagerfanta-навигация сохраняет активные фильтры через `routeParams` в include `partials/_pagerfanta.html.twig`. |
 | 1.34 | 2026-04-24 | MarketplaceAds / Task-16: UI рефакторинг после стабилизации cron-pipeline'а. (1) «История загрузок» ограничена top-10 job'ами: `AdLoadJobsListController::LIMIT` 20 → 10, `AdLoadJobRepository::findRecentByCompanyAndMarketplace` переиспользован (limit уже параметризован). (2) «Сырые документы» ограничены top-20 документами: новый метод `AdRawDocumentRepositoryInterface::findRecentByCompanyMarketplaceAndDateRange(companyId, marketplace, from, to, limit=20): list<AdRawDocument>` — фильтр по диапазону дат применяется ДО лимита, сортировка `createdAt DESC`; `AdRawDocumentsListController` переключён на него с `LIMIT=20`. Старый `findByCompanyMarketplaceAndDateRange` (без лимита, `reportDate DESC`) сохранён — им пользуется `DownloadOzonAdReportHandler`-integration-тест и другие non-UI места, где нужен полный список. (3) Кнопки «Открыть batch N (dateFrom—dateTo)» удалены из колонки «Действия» таблицы «История загрузок»: `AdLoadJobsListController` больше не вызывает `collectBatchFiles()`/`collectRawDocumentFiles()` и не возвращает поле `files` в JSON; JS-хелперы `renderJobFiles`, `buildBatchDownloadUrl`, `formatDateRu` удалены из `templates/marketplace_ads/index.html.twig`. Кнопки «Обработать» (для `completed`/`partial_success` jobs с батчами, CSRF `extract-batches-<jobId>`) и «Пометить FAILED» (для `pending`/`running` jobs) **сохранены**. Пустая колонка «Действия» для running-jobs без кнопок рисует плейсхолдер `<span class="text-muted">—</span>`. (4) Endpoint `GET /marketplace-ads/batches/{id}/download` (`AdScheduledBatchDownloadController`) и репозиторный метод `AdScheduledBatchRepository::findDownloadableByJobId` **не удалены** — endpoint остаётся доступен через прямой URL для admin-debug, `findDownloadableByJobId` используется `ExtractBatchesToRawDocumentsAction` (кнопка «Обработать»). DI `AdLoadJobsListController` упрощён: убраны `AdRawDocumentRepository` и `AdScheduledBatchRepository` не нужен для `files` (остаётся для `countStatesForJob` в batchStats). Integration-тесты обновлены: `AdLoadJobsListControllerTest::testLimitsTo10Items` (15 jobs → 10 items), `AdRawDocumentsListControllerTest::testLimitsTo20Items` (30 documents в 30-дневном диапазоне → 20 items). Существующие `testJobWithScheduledBatchesExposes*` и `testJobWithoutScheduledBatchesFallsBackTo*` переписаны: вместо `assertCount(N, $item['files'])` теперь `assertArrayNotHasKey('files', $item)` — поле убрано из контракта. |
 | 1.33 | 2026-04-24 | MarketplaceAds / Task-13b: `AdDailySyncCommand` (`app:marketplace-ads:daily-sync`) — ежедневная автоматическая точка инициации cron-driven pipeline'а. Для каждой компании с активным Ozon Performance подключением (`ActiveOzonPerformanceConnectionsQuery::getCompanyIds()`) создаёт один `AdLoadJob` на `dateFrom=dateTo=вчера в UTC`, синхронно планирует batch'и через `AdBatchPlanner::planBatchesForJob()` и переводит job в RUNNING (без этого Finalizer (v1.27) не подхватил бы его через `findAllRunning()`). Дальше работает автономно: scheduler → poller → finalizer → auto-extract (v1.31) → worker. Cron: `30 4 * * *` в scheduler-контейнере (`TZ=Europe/Moscow` → 04:30 MSK). `LockableTrait` — защита от наложения тиков; per-company isolation: сбой у одной компании (`Throwable`) не блокирует остальных, логируется `error`-уровнем. Идемпотентность: новый метод `AdLoadJobRepositoryInterface::existsByDateRange(companyId, marketplace, dateFrom, dateTo): bool` — повторный запуск в тот же день видит существующий job (любого статуса, включая FAILED/COMPLETED) и skipped'ит компанию; без него второй ручной запуск создавал бы дубликат. При ошибке Planner'а (например, `RuntimeException('No SKU campaigns found')`) job помечается `markFailed('Planning error: …')` — чтобы `existsByDateRange` видел его в следующий запуск и оператор видел причину в «Истории загрузок». Старый cron entry `30 4 * * * app:marketplace-ads:ozon-daily-sync` (Messenger event-driven pipeline) **удалён** из `docker/cron/app.cron`; сам класс `OzonAdDailySyncCommand` оставлен до Task-14, т.к. он диспатчит в Messenger-цепочку, которая ещё обслуживает остатки (выпиливание — отдельная задача). Тесты: unit `AdDailySyncCommandTest` (5 кейсов: happy path 3 компании с yesterday-UTC / empty company list / existsByDateRange → skipped / per-company isolation после Throwable / `existsByDateRange` зовётся с корректной UTC-датой и OZON marketplace.value); integration `Command/AdDailySyncCommandTest` (5 кейсов: 2 компании, только с PERFORMANCE-connection получает RUNNING job + PLANNED batch'и / повторный запуск в тот же день → skipped без дубликата / SELLER-only Ozon не попадает / Planner fail → job в FAILED, сиблинг получает RUNNING / no companies → SUCCESS message); integration `AdLoadJobRepositoryTest::testExistsByDateRange*` (5 кейсов: happy / empty → false / WB-job не матчится OZON-запросом / чужая компания → false / соседний день → false / терминальный FAILED job всё равно матчится — критично для идемпотентности). |

--- a/site/src/MarketplaceAds/Facade/MarketplaceAdsFacade.php
+++ b/site/src/MarketplaceAds/Facade/MarketplaceAdsFacade.php
@@ -6,6 +6,7 @@ namespace App\MarketplaceAds\Facade;
 
 use App\MarketplaceAds\Application\DTO\AdCostForListingDTO;
 use App\MarketplaceAds\Infrastructure\Query\AdDocumentQuery;
+use App\MarketplaceAds\Infrastructure\Query\AdSpendByListingQuery;
 
 /**
  * Публичный API модуля MarketplaceAds для других модулей.
@@ -20,6 +21,7 @@ final readonly class MarketplaceAdsFacade
 {
     public function __construct(
         private AdDocumentQuery $adDocumentQuery,
+        private AdSpendByListingQuery $adSpendByListingQuery,
     ) {
     }
 
@@ -54,5 +56,31 @@ final readonly class MarketplaceAdsFacade
         ?string $marketplace = null,
     ): string {
         return $this->adDocumentQuery->sumTotalCostForPeriod($companyId, $dateFrom, $dateTo, $marketplace);
+    }
+
+    /**
+     * РР с разрезом по листингам за период.
+     *
+     * Для построения строк отчётов с колонкой РР по листингу.
+     * Для totals (полная сумма за период, включая non-attributed) использовать
+     * {@see self::getTotalAdCostForPeriod()}.
+     *
+     * @param string|null $marketplace значение MarketplaceType::value ('wildberries', 'ozon').
+     *                                 Если null — суммируются все площадки.
+     *
+     * @return array<string, string>  listingId => decimal-string adSpend
+     */
+    public function getAdSpendByListingForPeriod(
+        string $companyId,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        ?string $marketplace = null,
+    ): array {
+        return $this->adSpendByListingQuery->getByListingForPeriod(
+            $companyId,
+            $from,
+            $to,
+            $marketplace,
+        );
     }
 }

--- a/site/src/MarketplaceAds/Infrastructure/Query/AdSpendByListingQuery.php
+++ b/site/src/MarketplaceAds/Infrastructure/Query/AdSpendByListingQuery.php
@@ -30,9 +30,15 @@ final readonly class AdSpendByListingQuery
 
     /**
      * РР с разрезом по листингам за период.
-     * Только attributed — listingId, существующие в выдаче (т.е. имеющие живой ad_document_lines).
      *
-     * @return array<string, string>  listingId => decimal-string adSpend ("0" если нет)
+     * Только attributed РР: listingId, упомянутые в marketplace_ad_document_lines
+     * за период. Листинги без записей в результат не попадают — caller сам
+     * решает дефолт ($map[$id] ?? '0').
+     *
+     * Для полной суммы за период (включая non-attributed) использовать
+     * MarketplaceAdsFacade::getTotalAdCostForPeriod().
+     *
+     * @return array<string, string>  listingId => decimal-string adSpend
      */
     public function getByListingForPeriod(
         string $companyId,

--- a/site/src/MarketplaceAds/Infrastructure/Query/AdSpendByListingQuery.php
+++ b/site/src/MarketplaceAds/Infrastructure/Query/AdSpendByListingQuery.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Infrastructure\Query;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * Read-model «РР по листингам за период».
+ *
+ * Возвращает суммарные рекламные затраты с разрезом по `listing_id`, агрегированные
+ * из `marketplace_ad_document_lines` за указанный период. Семантически соответствует
+ * CTE `ads_agg` из {@see AdEfficiencyQuery}, вынесенному в отдельный read-only query
+ * для переиспользования из других модулей через {@see \App\MarketplaceAds\Facade\MarketplaceAdsFacade}.
+ *
+ * В отличие от AdEfficiencyQuery здесь намеренно НЕТ inner-join на `marketplace_listings`:
+ * результат включает «висячие» listing_id (строки в ad_document_lines, у которых нет
+ * живого листинга) — это критично для согласованности с totals на потребителях, где
+ * сумма по разрезу должна сходиться с полной суммой за период.
+ *
+ * DBAL, не ORM. Денежные значения наружу — decimal-строки (bcmath-compatible).
+ */
+final readonly class AdSpendByListingQuery
+{
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    /**
+     * РР с разрезом по листингам за период.
+     * Только attributed — listingId, существующие в выдаче (т.е. имеющие живой ad_document_lines).
+     *
+     * @return array<string, string>  listingId => decimal-string adSpend ("0" если нет)
+     */
+    public function getByListingForPeriod(
+        string $companyId,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        ?string $marketplace = null,
+    ): array {
+        $params = [
+            'companyId' => $companyId,
+            'periodFrom' => $from->format('Y-m-d'),
+            'periodTo' => $to->format('Y-m-d'),
+        ];
+
+        $mpFilter = '';
+        if (null !== $marketplace) {
+            $mpFilter = 'AND ad.marketplace = :marketplace';
+            $params['marketplace'] = $marketplace;
+        }
+
+        $sql = <<<SQL
+            SELECT adl.listing_id, SUM(adl.cost) AS ad_spend
+            FROM marketplace_ad_document_lines adl
+            JOIN marketplace_ad_documents ad ON ad.id = adl.ad_document_id
+            WHERE ad.company_id = :companyId
+              AND ad.report_date BETWEEN :periodFrom AND :periodTo
+              {$mpFilter}
+            GROUP BY adl.listing_id
+            SQL;
+
+        $rows = $this->connection->fetchAllAssociative($sql, $params);
+
+        $result = [];
+        foreach ($rows as $row) {
+            $result[(string) $row['listing_id']] = (string) $row['ad_spend'];
+        }
+
+        return $result;
+    }
+}

--- a/site/tests/Integration/MarketplaceAds/Query/AdSpendByListingQueryTest.php
+++ b/site/tests/Integration/MarketplaceAds/Query/AdSpendByListingQueryTest.php
@@ -1,0 +1,386 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\MarketplaceAds\Query;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAds\Entity\AdDocument;
+use App\MarketplaceAds\Entity\AdDocumentLine;
+use App\MarketplaceAds\Infrastructure\Query\AdSpendByListingQuery;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class AdSpendByListingQueryTest extends IntegrationTestCase
+{
+    private const COMPANY_A_ID = '11111111-1111-1111-1111-000000000001';
+    private const COMPANY_B_ID = '11111111-1111-1111-1111-000000000002';
+    private const OWNER_A_ID   = '22222222-2222-2222-2222-000000000001';
+    private const OWNER_B_ID   = '22222222-2222-2222-2222-000000000002';
+
+    private const LISTING_1_ID = '55555555-5555-5555-5555-000000000001';
+    private const LISTING_2_ID = '55555555-5555-5555-5555-000000000002';
+    private const LISTING_WB_ID = '55555555-5555-5555-5555-000000000003';
+    private const LISTING_B_ID = '55555555-5555-5555-5555-00000000000B';
+
+    private const PERIOD_FROM = '2026-04-01';
+    private const PERIOD_TO   = '2026-04-30';
+
+    private AdSpendByListingQuery $query;
+    private Company $companyA;
+    private Company $companyB;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->query = self::getContainer()->get(AdSpendByListingQuery::class);
+    }
+
+    public function testHappyPathReturnsAdSpendByListing(): void
+    {
+        $this->seedCompanies();
+        $this->seedListings();
+
+        $this->persistAdDocumentWithLine(
+            companyId:   self::COMPANY_A_ID,
+            marketplace: MarketplaceType::OZON,
+            reportDate:  '2026-04-10',
+            campaignId:  'CAMP-L1-A',
+            parentSku:   'SKU-001',
+            totalCost:   '100.00',
+            listingId:   self::LISTING_1_ID,
+            lineCost:    '100.00',
+        );
+        // Второе документ-строка по тому же листингу — суммируется
+        $this->persistAdDocumentWithLine(
+            companyId:   self::COMPANY_A_ID,
+            marketplace: MarketplaceType::OZON,
+            reportDate:  '2026-04-15',
+            campaignId:  'CAMP-L1-B',
+            parentSku:   'SKU-001',
+            totalCost:   '50.00',
+            listingId:   self::LISTING_1_ID,
+            lineCost:    '50.00',
+        );
+        $this->persistAdDocumentWithLine(
+            companyId:   self::COMPANY_A_ID,
+            marketplace: MarketplaceType::OZON,
+            reportDate:  '2026-04-20',
+            campaignId:  'CAMP-L2',
+            parentSku:   'SKU-002',
+            totalCost:   '70.50',
+            listingId:   self::LISTING_2_ID,
+            lineCost:    '70.50',
+        );
+        $this->em->flush();
+        $this->em->clear();
+
+        $result = $this->query->getByListingForPeriod(
+            self::COMPANY_A_ID,
+            new \DateTimeImmutable(self::PERIOD_FROM),
+            new \DateTimeImmutable(self::PERIOD_TO),
+        );
+
+        self::assertCount(2, $result);
+        self::assertArrayHasKey(self::LISTING_1_ID, $result);
+        self::assertArrayHasKey(self::LISTING_2_ID, $result);
+        self::assertEqualsWithDelta(150.0, (float) $result[self::LISTING_1_ID], 0.01);
+        self::assertEqualsWithDelta(70.5, (float) $result[self::LISTING_2_ID], 0.01);
+    }
+
+    public function testMarketplaceFilterReturnsOnlyMatchingMarketplace(): void
+    {
+        $this->seedCompanies();
+        $this->seedListings();
+
+        $this->persistAdDocumentWithLine(
+            companyId:   self::COMPANY_A_ID,
+            marketplace: MarketplaceType::OZON,
+            reportDate:  '2026-04-10',
+            campaignId:  'CAMP-OZON',
+            parentSku:   'SKU-001',
+            totalCost:   '100.00',
+            listingId:   self::LISTING_1_ID,
+            lineCost:    '100.00',
+        );
+        $this->persistAdDocumentWithLine(
+            companyId:   self::COMPANY_A_ID,
+            marketplace: MarketplaceType::WILDBERRIES,
+            reportDate:  '2026-04-12',
+            campaignId:  'CAMP-WB',
+            parentSku:   'WB-001',
+            totalCost:   '40.00',
+            listingId:   self::LISTING_WB_ID,
+            lineCost:    '40.00',
+        );
+        $this->em->flush();
+        $this->em->clear();
+
+        $allMps = $this->query->getByListingForPeriod(
+            self::COMPANY_A_ID,
+            new \DateTimeImmutable(self::PERIOD_FROM),
+            new \DateTimeImmutable(self::PERIOD_TO),
+        );
+        self::assertCount(2, $allMps, 'Без фильтра по marketplace — обе записи');
+
+        $onlyOzon = $this->query->getByListingForPeriod(
+            self::COMPANY_A_ID,
+            new \DateTimeImmutable(self::PERIOD_FROM),
+            new \DateTimeImmutable(self::PERIOD_TO),
+            MarketplaceType::OZON->value,
+        );
+        self::assertCount(1, $onlyOzon);
+        self::assertArrayHasKey(self::LISTING_1_ID, $onlyOzon);
+
+        $onlyWb = $this->query->getByListingForPeriod(
+            self::COMPANY_A_ID,
+            new \DateTimeImmutable(self::PERIOD_FROM),
+            new \DateTimeImmutable(self::PERIOD_TO),
+            MarketplaceType::WILDBERRIES->value,
+        );
+        self::assertCount(1, $onlyWb);
+        self::assertArrayHasKey(self::LISTING_WB_ID, $onlyWb);
+    }
+
+    public function testEmptyPeriodReturnsEmptyArray(): void
+    {
+        $this->seedCompanies();
+        $this->seedListings();
+
+        // Запись ВНЕ периода — не должна попасть в результат
+        $this->persistAdDocumentWithLine(
+            companyId:   self::COMPANY_A_ID,
+            marketplace: MarketplaceType::OZON,
+            reportDate:  '2026-03-15',
+            campaignId:  'CAMP-OUT',
+            parentSku:   'SKU-001',
+            totalCost:   '100.00',
+            listingId:   self::LISTING_1_ID,
+            lineCost:    '100.00',
+        );
+        $this->em->flush();
+        $this->em->clear();
+
+        $result = $this->query->getByListingForPeriod(
+            self::COMPANY_A_ID,
+            new \DateTimeImmutable(self::PERIOD_FROM),
+            new \DateTimeImmutable(self::PERIOD_TO),
+        );
+
+        self::assertSame([], $result);
+    }
+
+    public function testNonAttributedListingIdIsIncludedInResult(): void
+    {
+        // В отличие от AdEfficiencyQuery (который inner-join на marketplace_listings),
+        // AdSpendByListingQuery НЕ фильтрует по существованию листинга — это критично
+        // для согласованности totals на потребителях. Висячий listing_id должен попасть в выдачу.
+        $this->seedCompanies();
+        $this->seedListings();
+
+        $orphanListingId = '99999999-9999-9999-9999-000000000001';
+
+        $this->persistAdDocumentWithLine(
+            companyId:   self::COMPANY_A_ID,
+            marketplace: MarketplaceType::OZON,
+            reportDate:  '2026-04-10',
+            campaignId:  'CAMP-LIVE',
+            parentSku:   'SKU-001',
+            totalCost:   '100.00',
+            listingId:   self::LISTING_1_ID,
+            lineCost:    '100.00',
+        );
+        $this->persistAdDocumentWithLine(
+            companyId:   self::COMPANY_A_ID,
+            marketplace: MarketplaceType::OZON,
+            reportDate:  '2026-04-12',
+            campaignId:  'CAMP-ORPHAN',
+            parentSku:   'SKU-ORPHAN',
+            totalCost:   '42.00',
+            listingId:   $orphanListingId,
+            lineCost:    '42.00',
+        );
+        $this->em->flush();
+        $this->em->clear();
+
+        $result = $this->query->getByListingForPeriod(
+            self::COMPANY_A_ID,
+            new \DateTimeImmutable(self::PERIOD_FROM),
+            new \DateTimeImmutable(self::PERIOD_TO),
+        );
+
+        self::assertCount(2, $result);
+        self::assertArrayHasKey($orphanListingId, $result);
+        self::assertEqualsWithDelta(42.0, (float) $result[$orphanListingId], 0.01);
+        self::assertEqualsWithDelta(100.0, (float) $result[self::LISTING_1_ID], 0.01);
+    }
+
+    public function testIdorOtherCompanyDataIsNotReturned(): void
+    {
+        $this->seedCompanies();
+        $this->seedListings();
+
+        $this->persistAdDocumentWithLine(
+            companyId:   self::COMPANY_A_ID,
+            marketplace: MarketplaceType::OZON,
+            reportDate:  '2026-04-10',
+            campaignId:  'CAMP-A',
+            parentSku:   'SKU-001',
+            totalCost:   '100.00',
+            listingId:   self::LISTING_1_ID,
+            lineCost:    '100.00',
+        );
+        $this->persistAdDocumentWithLine(
+            companyId:   self::COMPANY_B_ID,
+            marketplace: MarketplaceType::OZON,
+            reportDate:  '2026-04-15',
+            campaignId:  'CAMP-B',
+            parentSku:   'SKU-B',
+            totalCost:   '999.00',
+            listingId:   self::LISTING_B_ID,
+            lineCost:    '999.00',
+        );
+        $this->em->flush();
+        $this->em->clear();
+
+        $resultA = $this->query->getByListingForPeriod(
+            self::COMPANY_A_ID,
+            new \DateTimeImmutable(self::PERIOD_FROM),
+            new \DateTimeImmutable(self::PERIOD_TO),
+        );
+        self::assertCount(1, $resultA);
+        self::assertArrayHasKey(self::LISTING_1_ID, $resultA);
+        self::assertArrayNotHasKey(self::LISTING_B_ID, $resultA);
+
+        $resultB = $this->query->getByListingForPeriod(
+            self::COMPANY_B_ID,
+            new \DateTimeImmutable(self::PERIOD_FROM),
+            new \DateTimeImmutable(self::PERIOD_TO),
+        );
+        self::assertCount(1, $resultB);
+        self::assertArrayHasKey(self::LISTING_B_ID, $resultB);
+        self::assertArrayNotHasKey(self::LISTING_1_ID, $resultB);
+    }
+
+    private function seedCompanies(): void
+    {
+        $ownerA = UserBuilder::aUser()
+            ->withId(self::OWNER_A_ID)
+            ->withEmail('ad-spend-a@example.test')
+            ->build();
+        $ownerB = UserBuilder::aUser()
+            ->withId(self::OWNER_B_ID)
+            ->withEmail('ad-spend-b@example.test')
+            ->build();
+
+        $this->companyA = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_A_ID)
+            ->withOwner($ownerA)
+            ->build();
+        $this->companyB = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_B_ID)
+            ->withOwner($ownerB)
+            ->build();
+
+        $this->em->persist($ownerA);
+        $this->em->persist($ownerB);
+        $this->em->persist($this->companyA);
+        $this->em->persist($this->companyB);
+        $this->em->flush();
+    }
+
+    private function seedListings(): void
+    {
+        $listing1 = $this->newListing(
+            self::LISTING_1_ID,
+            $this->companyA,
+            MarketplaceType::OZON,
+            'SKU-001',
+            'Товар 1',
+        );
+        $listing2 = $this->newListing(
+            self::LISTING_2_ID,
+            $this->companyA,
+            MarketplaceType::OZON,
+            'SKU-002',
+            'Товар 2',
+        );
+        $listingWb = $this->newListing(
+            self::LISTING_WB_ID,
+            $this->companyA,
+            MarketplaceType::WILDBERRIES,
+            'WB-001',
+            'WB товар',
+        );
+        $listingB = $this->newListing(
+            self::LISTING_B_ID,
+            $this->companyB,
+            MarketplaceType::OZON,
+            'SKU-B',
+            'Товар компании B',
+        );
+
+        foreach ([$listing1, $listing2, $listingWb, $listingB] as $l) {
+            $this->em->persist($l);
+        }
+        $this->em->flush();
+    }
+
+    private function newListing(
+        string $id,
+        Company $company,
+        MarketplaceType $marketplace,
+        string $sku,
+        string $name,
+    ): MarketplaceListing {
+        $listing = new MarketplaceListing($id, $company, null, $marketplace);
+        $listing->setMarketplaceSku($sku);
+        $listing->setSize('UNKNOWN');
+        $listing->setPrice('0.00');
+        $listing->setName($name);
+
+        return $listing;
+    }
+
+    private function persistAdDocumentWithLine(
+        string $companyId,
+        MarketplaceType $marketplace,
+        string $reportDate,
+        string $campaignId,
+        string $parentSku,
+        string $totalCost,
+        string $listingId,
+        string $lineCost,
+    ): void {
+        $adRawDocumentId = Uuid::uuid4()->toString();
+
+        $adDocument = new AdDocument(
+            companyId: $companyId,
+            marketplace: $marketplace,
+            reportDate: new \DateTimeImmutable($reportDate),
+            campaignId: $campaignId,
+            campaignName: $campaignId,
+            parentSku: $parentSku,
+            totalCost: $totalCost,
+            totalImpressions: 0,
+            totalClicks: 0,
+            adRawDocumentId: $adRawDocumentId,
+        );
+        $this->em->persist($adDocument);
+
+        $line = new AdDocumentLine(
+            adDocument: $adDocument,
+            listingId: $listingId,
+            sharePercent: '100.00',
+            cost: $lineCost,
+            impressions: 0,
+            clicks: 0,
+        );
+        $this->em->persist($line);
+    }
+}

--- a/site/tests/Unit/MarketplaceAds/Facade/MarketplaceAdsFacadeTest.php
+++ b/site/tests/Unit/MarketplaceAds/Facade/MarketplaceAdsFacadeTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MarketplaceAds\Facade;
+
+use App\MarketplaceAds\Facade\MarketplaceAdsFacade;
+use App\MarketplaceAds\Infrastructure\Query\AdDocumentQuery;
+use App\MarketplaceAds\Infrastructure\Query\AdSpendByListingQuery;
+use PHPUnit\Framework\TestCase;
+
+final class MarketplaceAdsFacadeTest extends TestCase
+{
+    public function testGetAdSpendByListingForPeriodDelegatesToQuery(): void
+    {
+        $companyId = '11111111-1111-1111-1111-000000000001';
+        $from = new \DateTimeImmutable('2026-04-01');
+        $to = new \DateTimeImmutable('2026-04-30');
+        $marketplace = 'ozon';
+
+        $expected = [
+            '55555555-5555-5555-5555-000000000001' => '150.00',
+            '55555555-5555-5555-5555-000000000002' => '70.50',
+        ];
+
+        $adSpendByListingQuery = $this->createMock(AdSpendByListingQuery::class);
+        $adSpendByListingQuery
+            ->expects(self::once())
+            ->method('getByListingForPeriod')
+            ->with($companyId, $from, $to, $marketplace)
+            ->willReturn($expected);
+
+        $adDocumentQuery = $this->createMock(AdDocumentQuery::class);
+        $adDocumentQuery->expects(self::never())->method(self::anything());
+
+        $facade = new MarketplaceAdsFacade($adDocumentQuery, $adSpendByListingQuery);
+
+        $result = $facade->getAdSpendByListingForPeriod($companyId, $from, $to, $marketplace);
+
+        self::assertSame($expected, $result);
+    }
+
+    public function testGetAdSpendByListingForPeriodPassesNullMarketplaceByDefault(): void
+    {
+        $companyId = '11111111-1111-1111-1111-000000000001';
+        $from = new \DateTimeImmutable('2026-04-01');
+        $to = new \DateTimeImmutable('2026-04-30');
+
+        $adSpendByListingQuery = $this->createMock(AdSpendByListingQuery::class);
+        $adSpendByListingQuery
+            ->expects(self::once())
+            ->method('getByListingForPeriod')
+            ->with($companyId, $from, $to, null)
+            ->willReturn([]);
+
+        $adDocumentQuery = $this->createMock(AdDocumentQuery::class);
+
+        $facade = new MarketplaceAdsFacade($adDocumentQuery, $adSpendByListingQuery);
+
+        self::assertSame([], $facade->getAdSpendByListingForPeriod($companyId, $from, $to));
+    }
+}


### PR DESCRIPTION
## Summary
- Новый read-only `AdSpendByListingQuery` (`src/MarketplaceAds/Infrastructure/Query/AdSpendByListingQuery.php`) — РР с разрезом по листингам за период. SQL семантически = CTE `ads_agg` из `AdEfficiencyQuery`, но **без** inner-join на `marketplace_listings`: non-attributed `listing_id` попадают в выдачу — это критично для согласованности с `getTotalAdCostForPeriod` на потребителях.
- `MarketplaceAdsFacade` расширен: в конструктор добавлен `AdSpendByListingQuery`, новый публичный метод `getAdSpendByListingForPeriod(companyId, from, to, ?marketplace=null): array<string, string>`. Существующие `getAdCostsForListingAndDate` и `getTotalAdCostForPeriod` не трогали.
- `AdEfficiencyQuery` и `AdEfficiencyController` намеренно **не** менялись — 6-строчный CTE-дубликат допустим.
- `ARCHITECTURE.md`: метод в секции `MarketplaceAdsFacade`, новый блок `AdSpendByListingQuery` в `Query — MarketplaceAds`, запись Changelog v1.36.

## Tests
- Integration `tests/Integration/MarketplaceAds/Query/AdSpendByListingQueryTest.php` (5 кейсов):
  - happy path (2 листинга, повторные документы по одному листингу суммируются)
  - фильтр по `marketplace` (Ozon vs Wildberries)
  - пустой период → пустой массив
  - non-attributed `listing_id` (без живого листинга) попадает в выдачу
  - IDOR: данные другой компании не видны
- Unit `tests/Unit/MarketplaceAds/Facade/MarketplaceAdsFacadeTest.php` (2 кейса):
  - делегация `getAdSpendByListingForPeriod` → `AdSpendByListingQuery::getByListingForPeriod` через мок с явными аргументами
  - дефолт `marketplace=null` пробрасывается в query

## Test plan
- [ ] `vendor/bin/phpstan` — чисто (локально не запускался: в окружении нет `vendor/` и Docker)
- [ ] `vendor/bin/phpunit tests/Integration/MarketplaceAds/Query/AdSpendByListingQueryTest.php` — зелёный
- [ ] `vendor/bin/phpunit tests/Unit/MarketplaceAds/Facade/MarketplaceAdsFacadeTest.php` — зелёный
- [ ] CI на полном `tests/MarketplaceAds/` — без регрессий
- [x] `php -l` на всех изменённых файлах — без ошибок

https://claude.ai/code/session_01UKQoskTgXQpJo7e2UErjSB

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKQoskTgXQpJo7e2UErjSB)_