### PR TITLE
feat(MarketplaceAnalytics): add ad spend and DRR columns to unit-extended report

### DIFF
--- a/site/src/MarketplaceAnalytics/Infrastructure/Export/UnitExtendedXlsxExporter.php
+++ b/site/src/MarketplaceAnalytics/Infrastructure/Export/UnitExtendedXlsxExporter.php
@@ -37,6 +37,8 @@ final readonly class UnitExtendedXlsxExporter
         ['label' => 'Себестоимость',   'field' => 'costPriceTotal', 'type' => 'money'],
         ['label' => 'Себест. ед.',     'field' => 'costPriceUnit',  'type' => 'money'],
         ['label' => 'Комиссия',        'field' => 'commission',     'type' => 'money'],
+        ['label' => 'РР',              'field' => 'adSpend',        'type' => 'money'],
+        ['label' => 'ДРР(п) %',        'field' => 'drrPercent',     'type' => 'percent'],
         ['label' => 'Логистика',       'field' => 'logistics',      'type' => 'money'],
         ['label' => 'Прочие затраты',  'field' => 'otherCosts',     'type' => 'money'],
         ['label' => 'Итого затрат',    'field' => 'totalCosts',     'type' => 'money'],

--- a/site/src/MarketplaceAnalytics/Infrastructure/Query/UnitExtendedQuery.php
+++ b/site/src/MarketplaceAnalytics/Infrastructure/Query/UnitExtendedQuery.php
@@ -6,6 +6,7 @@ namespace App\MarketplaceAnalytics\Infrastructure\Query;
 
 use App\Marketplace\Application\Reconciliation\OzonXlsxServiceGroupMap;
 use App\Marketplace\Facade\MarketplaceFacade;
+use App\MarketplaceAds\Facade\MarketplaceAdsFacade;
 
 final readonly class UnitExtendedQuery
 {
@@ -17,6 +18,7 @@ final readonly class UnitExtendedQuery
 
     public function __construct(
         private MarketplaceFacade $marketplaceFacade,
+        private MarketplaceAdsFacade $adsFacade,
     ) {
     }
 
@@ -36,6 +38,17 @@ final readonly class UnitExtendedQuery
         $sales = $this->marketplaceFacade->getSalesAggregatesByListing($companyId, $marketplace, $from, $to);
         $returns = $this->marketplaceFacade->getReturnAggregatesByListing($companyId, $marketplace, $from, $to);
         $costs = $this->marketplaceFacade->getCostAggregatesByListing($companyId, $marketplace, $from, $to);
+
+        // Per-listing ad spend (only attributed). Listings present here but absent from
+        // sales/returns/costs are intentionally NOT merged into $allListingIds — the row
+        // would be empty otherwise; their spend is still counted in totals via
+        // getTotalAdCostForPeriod() below (which includes non-attributed too).
+        $adSpendByListing = $this->adsFacade->getAdSpendByListingForPeriod(
+            $companyId,
+            $from,
+            $to,
+            $marketplace,
+        );
 
         // Merge all unique listing IDs from three sources so listings
         // with only returns or costs are not lost
@@ -59,6 +72,7 @@ final readonly class UnitExtendedQuery
             'returnsTotal' => 0.0,
             'costPriceTotal' => 0.0,
             'commission' => 0.0,
+            'adSpend' => 0.0,
             'logistics' => 0.0,
             'otherCosts' => 0.0,
             'totalCosts' => 0.0,
@@ -117,8 +131,14 @@ final readonly class UnitExtendedQuery
             $commission = round($commission, 2);
             $logistics = round($logistics, 2);
             $otherCosts = round($otherCosts, 2);
-            $totalCostsVal = round($commission + $logistics + $otherCosts, 2);
-            $profit = round($revenue - $returnsTotal - $costPriceTotal - $commission - $logistics - $otherCosts, 2);
+            $adSpend = round((float) ($adSpendByListing[$listingId] ?? '0'), 2);
+            $totalCostsVal = round($commission + $logistics + $otherCosts + $adSpend, 2);
+            $profit = round(
+                $revenue - $returnsTotal - $costPriceTotal
+                - $commission - $logistics - $otherCosts - $adSpend,
+                2,
+            );
+            $drrPercent = $revenue > 0 ? round($adSpend / $revenue * 100, 1) : null;
 
             // Build breakdown grouped by serviceGroup
             $otherBreakdown = $this->buildBreakdown($allCategoriesRaw, $categoryToGroup, $logisticsCodes);
@@ -135,6 +155,8 @@ final readonly class UnitExtendedQuery
                 'costPriceTotal' => round($costPriceTotal, 2),
                 'costPriceUnit' => $costPriceUnit,
                 'commission' => $commission,
+                'adSpend' => $adSpend,
+                'drrPercent' => $drrPercent,
                 'logistics' => $logistics,
                 'otherCosts' => $otherCosts,
                 'totalCosts' => $totalCostsVal,
@@ -145,7 +167,11 @@ final readonly class UnitExtendedQuery
                 'allCostsBreakdown' => $allBreakdown,
             ];
 
-            // Totals accumulate across ALL listings (not limited)
+            // Totals accumulate across ALL listings (not limited).
+            // adSpend/totalCosts/profit will be recomputed below from getTotalAdCostForPeriod()
+            // — sum of per-row adSpend may be < totals.adSpend by design (rows show only
+            // attributed ad spend; totals include non-attributed for parity with
+            // /marketplace-ads/efficiency).
             $totals['revenue'] += $revenue;
             $totals['quantity'] += $quantity;
             $totals['returnsTotal'] += $returnsTotal;
@@ -153,8 +179,6 @@ final readonly class UnitExtendedQuery
             $totals['commission'] += $commission;
             $totals['logistics'] += $logistics;
             $totals['otherCosts'] += $otherCosts;
-            $totals['totalCosts'] += $totalCostsVal;
-            $totals['profit'] += $profit;
         }
 
         // Sort by revenue DESC
@@ -165,6 +189,29 @@ final readonly class UnitExtendedQuery
             $totals[$key] = is_float($val) ? round($val, 2) : $val;
         }
 
+        // totals.adSpend — full ad cost for the period (including non-attributed),
+        // for parity with /marketplace-ads/efficiency. Recompute totalCosts/profit
+        // accordingly. Sum of per-row adSpend may be smaller — that is OK.
+        $totalAdSpend = round((float) $this->adsFacade->getTotalAdCostForPeriod(
+            $companyId,
+            $from,
+            $to,
+            $marketplace,
+        ), 2);
+
+        $totals['adSpend'] = $totalAdSpend;
+        $totals['drrPercent'] = $totals['revenue'] > 0
+            ? round($totalAdSpend / $totals['revenue'] * 100, 1)
+            : null;
+        $totals['totalCosts'] = round(
+            $totals['commission'] + $totals['logistics'] + $totals['otherCosts'] + $totalAdSpend,
+            2,
+        );
+        $totals['profit'] = round(
+            $totals['revenue'] - $totals['returnsTotal'] - $totals['costPriceTotal']
+            - $totals['commission'] - $totals['logistics'] - $totals['otherCosts'] - $totalAdSpend,
+            2,
+        );
         $totals['marginPercent'] = $totals['revenue'] > 0
             ? round($totals['profit'] / $totals['revenue'] * 100, 1)
             : null;

--- a/site/tests/MarketplaceAnalytics/Infrastructure/Query/UnitExtendedQueryTest.php
+++ b/site/tests/MarketplaceAnalytics/Infrastructure/Query/UnitExtendedQueryTest.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\MarketplaceAnalytics\Infrastructure\Query;
+
+use App\Marketplace\DTO\ListingCostCategoryAggregateDTO;
+use App\Marketplace\DTO\ListingMetaDTO;
+use App\Marketplace\DTO\ListingReturnAggregateDTO;
+use App\Marketplace\DTO\ListingSalesAggregateDTO;
+use App\Marketplace\Facade\MarketplaceFacade;
+use App\MarketplaceAds\Facade\MarketplaceAdsFacade;
+use App\MarketplaceAnalytics\Infrastructure\Query\UnitExtendedQuery;
+use PHPUnit\Framework\TestCase;
+
+final class UnitExtendedQueryTest extends TestCase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-111111111111';
+    private const PERIOD_FROM = '2026-04-01';
+    private const PERIOD_TO = '2026-04-30';
+
+    private MarketplaceFacade $marketplaceFacade;
+    private MarketplaceAdsFacade $adsFacade;
+    private UnitExtendedQuery $query;
+
+    protected function setUp(): void
+    {
+        $this->marketplaceFacade = $this->createMock(MarketplaceFacade::class);
+        $this->adsFacade = $this->createMock(MarketplaceAdsFacade::class);
+        $this->query = new UnitExtendedQuery($this->marketplaceFacade, $this->adsFacade);
+
+        // Defaults — overridden per test where needed
+        $this->marketplaceFacade->method('getReturnAggregatesByListing')->willReturn([]);
+        $this->marketplaceFacade->method('getCostAggregatesByListing')->willReturn([]);
+        $this->marketplaceFacade->method('getListingsMetaByIds')->willReturn([]);
+    }
+
+    public function testRowFormulaWithAdSpend(): void
+    {
+        $this->stubSales([
+            new ListingSalesAggregateDTO('l-1', 'Товар', 'SKU-1', 'ozon', '1000.00', 5, '300.00', 5),
+        ]);
+        $this->stubAdSpend(['l-1' => '150.00']);
+        $this->stubTotalAdSpend('150.00');
+
+        $result = $this->execute();
+
+        $row = $this->findRow($result['items'], 'l-1');
+        self::assertNotNull($row);
+        self::assertSame(150.0, $row['adSpend']);
+        // totalCosts = commission(0) + logistics(0) + otherCosts(0) + adSpend(150) = 150
+        self::assertSame(150.0, $row['totalCosts']);
+        // profit = revenue(1000) - returns(0) - costPrice(300) - 0 - 0 - 0 - adSpend(150) = 550
+        self::assertSame(550.0, $row['profit']);
+        // drrPercent = 150 / 1000 * 100 = 15.0
+        self::assertSame(15.0, $row['drrPercent']);
+        // marginPercent = 550 / 1000 * 100 = 55.0
+        self::assertSame(55.0, $row['marginPercent']);
+        // roiPercent = 550 / 300 * 100 = 183.3
+        self::assertSame(183.3, $row['roiPercent']);
+    }
+
+    public function testRowDrrPercentIsNullWhenRevenueIsZero(): void
+    {
+        // Listing with cost row but no sales → revenue = 0; adSpend may exist
+        $this->stubSales([]);
+        $this->stubCosts([
+            'l-2' => [
+                new ListingCostCategoryAggregateDTO('l-2', 'ozon_other', 'Other', '-50.00', '-50.00', '0.00'),
+            ],
+        ]);
+        $this->stubMeta([
+            new ListingMetaDTO('l-2', 'Без выручки', 'SKU-2', 'ozon'),
+        ]);
+        $this->stubAdSpend(['l-2' => '40.00']);
+        $this->stubTotalAdSpend('40.00');
+
+        $result = $this->execute();
+
+        $row = $this->findRow($result['items'], 'l-2');
+        self::assertNotNull($row);
+        self::assertSame(0.0, $row['revenue']);
+        self::assertSame(40.0, $row['adSpend']);
+        self::assertNull($row['drrPercent'], 'revenue = 0 → drrPercent must be null');
+    }
+
+    public function testRowWithoutAdSpendHasZeroAdSpendAndZeroDrr(): void
+    {
+        $this->stubSales([
+            new ListingSalesAggregateDTO('l-3', 'Без РР', 'SKU-3', 'ozon', '500.00', 2, '100.00', 2),
+        ]);
+        // No ad spend for this listing
+        $this->stubAdSpend([]);
+        $this->stubTotalAdSpend('0');
+
+        $result = $this->execute();
+
+        $row = $this->findRow($result['items'], 'l-3');
+        self::assertNotNull($row);
+        self::assertSame(0.0, $row['adSpend']);
+        // revenue > 0, adSpend = 0 → drrPercent = 0.0 (not null)
+        self::assertSame(0.0, $row['drrPercent']);
+    }
+
+    public function testListingWithAdSpendOnlyDoesNotAppearInRows(): void
+    {
+        // Sales on l-A, ad spend on l-A AND on l-B (without sales/costs/returns)
+        $this->stubSales([
+            new ListingSalesAggregateDTO('l-A', 'Товар А', 'SKU-A', 'ozon', '1000.00', 5, '200.00', 5),
+        ]);
+        $this->stubAdSpend([
+            'l-A' => '100.00',
+            'l-B' => '777.77', // listing not present in sales/returns/costs
+        ]);
+        $this->stubTotalAdSpend('877.77');
+
+        $result = $this->execute();
+
+        $ids = array_map(static fn (array $r): string => (string) $r['listingId'], $result['items']);
+        self::assertContains('l-A', $ids);
+        self::assertNotContains('l-B', $ids, 'Листинг с РР, но без sales/returns/costs не должен попасть в строки');
+    }
+
+    public function testTotalsAdSpendComesFromGetTotalAdCostForPeriodNotFromRowsSum(): void
+    {
+        // Sum of per-row adSpend = 100, but totals.adSpend must equal facade's full value (250)
+        // — that's the design decision (parity with /marketplace-ads/efficiency totals).
+        $this->stubSales([
+            new ListingSalesAggregateDTO('l-1', 'Товар', 'SKU-1', 'ozon', '1000.00', 5, '300.00', 5),
+        ]);
+        $this->stubAdSpend(['l-1' => '100.00']);
+        $this->stubTotalAdSpend('250.00');
+
+        $result = $this->execute();
+
+        self::assertSame(100.0, $result['items'][0]['adSpend']);
+        self::assertSame(250.0, $result['totals']['adSpend']);
+        // totals.totalCosts = commission(0) + logistics(0) + otherCosts(0) + 250 = 250
+        self::assertSame(250.0, $result['totals']['totalCosts']);
+        // totals.profit = revenue(1000) - returns(0) - costPrice(300) - 0 - 0 - 0 - 250 = 450
+        self::assertSame(450.0, $result['totals']['profit']);
+        // totals.drrPercent = 250 / 1000 * 100 = 25.0
+        self::assertSame(25.0, $result['totals']['drrPercent']);
+        // marginPercent = 450 / 1000 * 100 = 45.0
+        self::assertSame(45.0, $result['totals']['marginPercent']);
+        // roiPercent = 450 / 300 * 100 = 150.0
+        self::assertSame(150.0, $result['totals']['roiPercent']);
+    }
+
+    public function testMarketplaceFilterIsPropagatedToBothAdsFacadeCalls(): void
+    {
+        $this->stubSales([]);
+        $this->stubAdSpend([]);
+
+        $marketplaceArg = 'ozon';
+        $from = new \DateTimeImmutable(self::PERIOD_FROM);
+        $to = new \DateTimeImmutable(self::PERIOD_TO);
+
+        $this->adsFacade
+            ->expects(self::once())
+            ->method('getAdSpendByListingForPeriod')
+            ->with(self::COMPANY_ID, $from, $to, $marketplaceArg)
+            ->willReturn([]);
+
+        $this->adsFacade
+            ->expects(self::once())
+            ->method('getTotalAdCostForPeriod')
+            ->with(self::COMPANY_ID, $from, $to, $marketplaceArg)
+            ->willReturn('0');
+
+        $this->query->execute(self::COMPANY_ID, $marketplaceArg, self::PERIOD_FROM, self::PERIOD_TO);
+    }
+
+    public function testEmptyEverythingProducesZeroTotals(): void
+    {
+        $this->stubSales([]);
+        $this->stubAdSpend([]);
+        $this->stubTotalAdSpend('0');
+
+        $result = $this->execute();
+
+        self::assertSame([], $result['items']);
+        self::assertSame(0.0, $result['totals']['revenue']);
+        self::assertSame(0.0, $result['totals']['adSpend']);
+        self::assertSame(0.0, $result['totals']['totalCosts']);
+        self::assertSame(0.0, $result['totals']['profit']);
+        self::assertNull($result['totals']['drrPercent']);
+        self::assertNull($result['totals']['marginPercent']);
+        self::assertNull($result['totals']['roiPercent']);
+    }
+
+    /**
+     * @param list<ListingSalesAggregateDTO> $sales
+     */
+    private function stubSales(array $sales): void
+    {
+        $keyed = [];
+        foreach ($sales as $s) {
+            $keyed[$s->listingId] = $s;
+        }
+        $this->marketplaceFacade->method('getSalesAggregatesByListing')->willReturn($keyed);
+    }
+
+    /**
+     * @param array<string, list<ListingCostCategoryAggregateDTO>> $costs
+     */
+    private function stubCosts(array $costs): void
+    {
+        $this->marketplaceFacade->method('getCostAggregatesByListing')->willReturn($costs);
+    }
+
+    /**
+     * @param list<ListingMetaDTO> $meta
+     */
+    private function stubMeta(array $meta): void
+    {
+        $keyed = [];
+        foreach ($meta as $m) {
+            $keyed[$m->id] = $m;
+        }
+        $this->marketplaceFacade->method('getListingsMetaByIds')->willReturn($keyed);
+    }
+
+    /**
+     * @param array<string, string> $byListing
+     */
+    private function stubAdSpend(array $byListing): void
+    {
+        $this->adsFacade->method('getAdSpendByListingForPeriod')->willReturn($byListing);
+    }
+
+    private function stubTotalAdSpend(string $value): void
+    {
+        $this->adsFacade->method('getTotalAdCostForPeriod')->willReturn($value);
+    }
+
+    /**
+     * @return array{items: list<array<string, mixed>>, totals: array<string, mixed>}
+     */
+    private function execute(): array
+    {
+        return $this->query->execute(
+            self::COMPANY_ID,
+            'ozon',
+            self::PERIOD_FROM,
+            self::PERIOD_TO,
+        );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $items
+     * @return array<string, mixed>|null
+     */
+    private function findRow(array $items, string $listingId): ?array
+    {
+        foreach ($items as $item) {
+            if ($item['listingId'] === $listingId) {
+                return $item;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
В отчёте `/marketplace-analytics/unit-extended` добавлены колонки **РР** (adSpend) и **ДРР(п) %** (drrPercent) — в строки и в totals. Пересчитаны `totalCosts`, `profit`, `marginPercent`, `roiPercent` с учётом РР. Все обращения к данным рекламы — через `MarketplaceAdsFacade` (без прямого импорта Repository/Query/Service модуля MarketplaceAds).

## Ключевое решение по семантике totals
- **Строки** (`items[].adSpend`) — только attributed РР: значения из `MarketplaceAdsFacade::getAdSpendByListingForPeriod()`.
- **Totals** (`totals.adSpend`) — **полная** сумма за период (включая non-attributed) из `MarketplaceAdsFacade::getTotalAdCostForPeriod()`.
- Согласованность с `/marketplace-ads/efficiency` за тот же период — главное требование заказчика.
- Расхождение «сумма строк РР < totals.adSpend» — **допустимо и ожидаемо**, зафиксировано комментариями в коде.

## Files changed
- `src/MarketplaceAnalytics/Infrastructure/Query/UnitExtendedQuery.php` — `MarketplaceAdsFacade` в конструктор, два вызова фасада в `execute()`, пересчёт `totalCosts`/`profit`/`marginPercent`/`roiPercent` с учётом РР, новые ключи `adSpend`/`drrPercent` в `$items[]` и `$totals`.
- `src/MarketplaceAnalytics/Infrastructure/Export/UnitExtendedXlsxExporter.php` — две новых колонки `РР`/`ДРР(п) %` после Комиссии в `COLUMNS`.
- `tests/MarketplaceAnalytics/Infrastructure/Query/UnitExtendedQueryTest.php` — новый unit-тест, 7 кейсов.

## Что НЕ менялось
- Виджеты: `WidgetSummaryQuery`, `UnitEconomicsQuery`, `UnitEconomicsAggregationPolicy`, `PortfolioSummaryPolicy`, `UnitExtendedExportRequest` — `git diff` пустой.
- Контроллеры `UnitExtendedController`, `UnitExtendedExportController` — без изменений.
- Snapshot-фикстуры виджетов — без обновлений.

## Tests
Unit `UnitExtendedQueryTest` (7 кейсов через моки `MarketplaceFacade` + `MarketplaceAdsFacade`):
- happy path: формула строки с adSpend > 0 (totalCosts / profit / drrPercent / marginPercent / roiPercent)
- `drrPercent = null` при `revenue = 0`
- листинг без РР: `adSpend = 0.0`, `drrPercent = 0.0` (revenue > 0)
- листинг с РР, но без sales/returns/costs — НЕ появляется в `items` (учтётся только в totals)
- `totals.adSpend` равен значению `getTotalAdCostForPeriod()` (250.00), даже когда сумма adSpend по строкам = 100.00; зависимые поля (`totalCosts/profit/drrPercent/marginPercent/roiPercent`) посчитаны от 250.00
- `marketplace`-фильтр пробрасывается в **оба** вызова фасада с правильными аргументами
- empty everything → пустые items, нулевые totals, `null` для всех процентов

## Test plan
- [ ] `vendor/bin/phpstan` — чисто (локально не запускался: нет vendor/Docker)
- [ ] `vendor/bin/phpunit tests/MarketplaceAnalytics/Infrastructure/Query/UnitExtendedQueryTest.php` — зелёный
- [ ] `vendor/bin/phpunit tests/MarketplaceAnalytics/` — зелёный (snapshot-тесты виджетов БЕЗ обновления фикстур)
- [ ] `tests/Unit/MarketplaceAnalytics/Infrastructure/Export/UnitExtendedXlsxExporterTest.php` — зелёный (мок query возвращает items без `adSpend`/`drrPercent`; экспортёр пишет `null`-ячейки, существующие assertions не задеты)
- [x] `php -l` на всех изменённых файлах — без ошибок
- [x] `grep 'App\MarketplaceAds\(Service|Repository|Application|Infrastructure)' src/MarketplaceAnalytics/` — пусто

https://claude.ai/code/session_01UKQoskTgXQpJo7e2UErjSB

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKQoskTgXQpJo7e2UErjSB)_