### PR TITLE
feat(unit-extended): add ad spend and DRR columns to React table

### DIFF
--- a/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedTable.tsx
+++ b/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedTable.tsx
@@ -14,6 +14,8 @@ type SortField =
     | 'costPriceTotal'
     | 'costPriceUnit'
     | 'commission'
+    | 'adSpend'
+    | 'drrPercent'
     | 'logistics'
     | 'otherCosts'
     | 'totalCosts'
@@ -87,7 +89,7 @@ interface ExpandedState {
     type: ExpandedType;
 }
 
-const HEADERS: { field: SortField; label: string; align?: string }[] = [
+const HEADERS: { field: SortField; label: string; align?: string; tooltip?: string }[] = [
     { field: 'sku', label: 'SKU' },
     { field: 'title', label: 'Наименование' },
     { field: 'revenue', label: 'Выручка', align: 'text-end' },
@@ -96,6 +98,8 @@ const HEADERS: { field: SortField; label: string; align?: string }[] = [
     { field: 'costPriceTotal', label: 'Себестоимость', align: 'text-end' },
     { field: 'costPriceUnit', label: 'Себест. ед.', align: 'text-end' },
     { field: 'commission', label: 'Комиссия', align: 'text-end' },
+    { field: 'adSpend', label: 'РР', align: 'text-end', tooltip: 'Рекламные расходы' },
+    { field: 'drrPercent', label: 'ДРР(п) %', align: 'text-end', tooltip: 'Доля рекламных расходов от продаж' },
     { field: 'logistics', label: 'Логистика', align: 'text-end' },
     { field: 'otherCosts', label: 'Прочие затраты', align: 'text-end' },
     { field: 'totalCosts', label: 'Итого затрат', align: 'text-end' },
@@ -204,6 +208,7 @@ const UnitExtendedTable: React.FC<UnitExtendedTableProps> = ({ items, totals, is
                                       }
                                     : {}),
                             }}
+                            title={h.tooltip}
                             onClick={() => handleSort(h.field)}
                         >
                             {h.label}
@@ -300,6 +305,8 @@ const UnitExtendedTable: React.FC<UnitExtendedTableProps> = ({ items, totals, is
                                         <td className="text-end">{formatMoney(row.costPriceTotal)}</td>
                                         <td className="text-end">{formatMoney(row.costPriceUnit)}</td>
                                         <td className="text-end">{formatMoney(row.commission)}</td>
+                                        <td className="text-end">{formatMoney(row.adSpend)}</td>
+                                        <td className="text-end">{formatPercent(row.drrPercent)}</td>
                                         <td className="text-end">{formatMoney(row.logistics)}</td>
                                         <td className="text-end">
                                             <button
@@ -370,6 +377,8 @@ const UnitExtendedTable: React.FC<UnitExtendedTableProps> = ({ items, totals, is
                                 <td className="text-end">{formatMoney(totals.costPriceTotal)}</td>
                                 <td className="text-end">{'—'}</td>
                                 <td className="text-end">{formatMoney(totals.commission)}</td>
+                                <td className="text-end">{formatMoney(totals.adSpend)}</td>
+                                <td className="text-end">{formatPercent(totals.drrPercent)}</td>
                                 <td className="text-end">{formatMoney(totals.logistics)}</td>
                                 <td className="text-end">{formatMoney(totals.otherCosts)}</td>
                                 <td className="text-end">{formatMoney(totals.totalCosts)}</td>

--- a/site/assets/react/marketplace-analytics/unit-extended/unitExtended.types.ts
+++ b/site/assets/react/marketplace-analytics/unit-extended/unitExtended.types.ts
@@ -25,6 +25,8 @@ export interface UnitExtendedItem {
     costPriceTotal: number;
     costPriceUnit: number;
     commission: number;
+    adSpend: number;
+    drrPercent: number | null;
     logistics: number;
     otherCosts: number;
     totalCosts: number;
@@ -41,6 +43,8 @@ export interface UnitExtendedTotals {
     returnsTotal: number;
     costPriceTotal: number;
     commission: number;
+    adSpend: number;
+    drrPercent: number | null;
     logistics: number;
     otherCosts: number;
     totalCosts: number;


### PR DESCRIPTION
## Summary
В таблице `/marketplace-analytics/unit-extended` добавлены две колонки **после «Комиссия»**:
- **РР** — `tooltip="Рекламные расходы"`, формат: денежный
- **ДРР(п) %** — `tooltip="Доля рекламных расходов от продаж"`, формат: процент

Бэкенд (PR #1665, уже в master) отдаёт `adSpend` и `drrPercent` в `items` и `totals`.

## Files changed
- `assets/react/marketplace-analytics/unit-extended/unitExtended.types.ts` — два новых поля в `UnitExtendedItem` и `UnitExtendedTotals` после `commission`.
- `assets/react/marketplace-analytics/unit-extended/UnitExtendedTable.tsx`:
  - `SortField` += `'adSpend' | 'drrPercent'`
  - `HEADERS` — два новых элемента после `commission` + опциональное поле `tooltip?: string` в типе строки массива
  - `<th>` рендерит `title={h.tooltip}` — нативный HTML-tooltip (тот же паттерн уже используется в этой таблице для action-кнопок; на `/marketplace-ads/efficiency` отдельной системы tooltip нет, поэтому используется `title`)
  - В data-row две новые ячейки после Комиссии: `formatMoney(row.adSpend)` и `formatPercent(row.drrPercent)`
  - В tfoot/totals — те же две ячейки

## Что НЕ менялось
- `widgets/` (KPI-плитки), `useUnitExtended.ts`, `UnitExtendedFilters.tsx`, `UnitExtendedWidget.tsx` — `git diff` пустой
- legacy `components/UnitEconomicsTable.tsx`, `widgets/UnitEconomicsWidget.tsx` — `git diff` пустой
- Сортировка по новым полям использует существующий generic `comparator` (`(a[field] as number | null) ?? -Infinity`); `null` идёт в конец при дефолтном `sortDir='desc'` — поведение совпадает с `marginPercent`/`roiPercent`

## Test plan
- [ ] CI: TypeScript-проверка / `vite build` без ошибок
- [ ] Колонки видны после «Комиссия» в порядке: Комиссия → РР → ДРР(п) % → Логистика
- [ ] Hover над `<th>` показывает tooltip
- [ ] Сортировка по `adSpend`/`drrPercent` работает; `drrPercent: null` уходит в конец при desc
- [ ] Footer (totals) показывает РР и ДРР(п) %
- [ ] Регрессии нет: легаси-таблица и виджеты не задеты

## Локально не запускалось
`npm run typecheck` / `npm run lint` — этих скриптов нет в `package.json` (есть только `dev`/`build`/`api:types`), плюс в окружении нет `node_modules`. Проверка типов произойдёт в CI / при `vite build`.

https://claude.ai/code/session_01UKQoskTgXQpJo7e2UErjSB

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKQoskTgXQpJo7e2UErjSB)_