### PR TITLE
fix(marketplace): inventory set-cost returns to referer, not history

### DIFF
--- a/site/src/Marketplace/Controller/Inventory/InventoryController.php
+++ b/site/src/Marketplace/Controller/Inventory/InventoryController.php
@@ -116,21 +116,21 @@ final class InventoryController extends AbstractController
             $this->addFlash('error', 'Ошибка сохранения: ' . $e->getMessage());
         }
 
-        $referer = (string) $request->headers->get('referer', '');
+        $referer  = (string) $request->headers->get('referer', '');
+        $urlParts = $referer !== '' ? (parse_url($referer) ?: []) : [];
+        $path     = is_string($urlParts['path'] ?? null) ? $urlParts['path'] : '';
 
-        if ($referer !== '' && str_contains($referer, '/marketplace/inventory/' . $id . '/history')) {
+        if (str_contains($path, '/marketplace/inventory/' . $id . '/history')) {
             return $this->redirectToRoute('marketplace_inventory_history', ['id' => $id]);
         }
 
         $params = [];
-        if ($referer !== '') {
-            $query = parse_url($referer, PHP_URL_QUERY);
-            if (is_string($query) && $query !== '') {
-                parse_str($query, $parsed);
-                foreach (['marketplace', 'page'] as $key) {
-                    if (isset($parsed[$key]) && is_string($parsed[$key]) && $parsed[$key] !== '') {
-                        $params[$key] = $parsed[$key];
-                    }
+        $query  = is_string($urlParts['query'] ?? null) ? $urlParts['query'] : '';
+        if ($query !== '') {
+            parse_str($query, $parsed);
+            foreach (['marketplace', 'page'] as $key) {
+                if (isset($parsed[$key]) && is_string($parsed[$key]) && $parsed[$key] !== '') {
+                    $params[$key] = $parsed[$key];
                 }
             }
         }

--- a/site/src/Marketplace/Controller/Inventory/InventoryController.php
+++ b/site/src/Marketplace/Controller/Inventory/InventoryController.php
@@ -116,7 +116,26 @@ final class InventoryController extends AbstractController
             $this->addFlash('error', 'Ошибка сохранения: ' . $e->getMessage());
         }
 
-        return $this->redirectToRoute('marketplace_inventory_history', ['id' => $id]);
+        $referer = (string) $request->headers->get('referer', '');
+
+        if ($referer !== '' && str_contains($referer, '/marketplace/inventory/' . $id . '/history')) {
+            return $this->redirectToRoute('marketplace_inventory_history', ['id' => $id]);
+        }
+
+        $params = [];
+        if ($referer !== '') {
+            $query = parse_url($referer, PHP_URL_QUERY);
+            if (is_string($query) && $query !== '') {
+                parse_str($query, $parsed);
+                foreach (['marketplace', 'page'] as $key) {
+                    if (isset($parsed[$key]) && is_string($parsed[$key]) && $parsed[$key] !== '') {
+                        $params[$key] = $parsed[$key];
+                    }
+                }
+            }
+        }
+
+        return $this->redirectToRoute('marketplace_inventory_index', $params);
     }
 
     #[Route('/sync-barcodes', name: 'marketplace_inventory_sync_barcodes', methods: ['POST'])]

--- a/site/src/Marketplace/Controller/Inventory/InventoryController.php
+++ b/site/src/Marketplace/Controller/Inventory/InventoryController.php
@@ -116,6 +116,10 @@ final class InventoryController extends AbstractController
             $this->addFlash('error', 'Ошибка сохранения: ' . $e->getMessage());
         }
 
+        if ($request->request->get('return_to') === 'history') {
+            return $this->redirectToRoute('marketplace_inventory_history', ['id' => $id]);
+        }
+
         $referer  = (string) $request->headers->get('referer', '');
         $urlParts = $referer !== '' ? (parse_url($referer) ?: []) : [];
         $path     = is_string($urlParts['path'] ?? null) ? $urlParts['path'] : '';

--- a/site/templates/marketplace/inventory/history.html.twig
+++ b/site/templates/marketplace/inventory/history.html.twig
@@ -97,6 +97,7 @@
             <div class="modal-content">
                 <form method="post"
                       action="{{ path('marketplace_inventory_set_cost', {id: listing.listing_id}) }}">
+                    <input type="hidden" name="return_to" value="history">
                     <div class="modal-header">
                         <h5 class="modal-title">Новая себестоимость</h5>
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>

--- a/site/tests/Functional/Marketplace/Controller/Inventory/InventorySetCostRedirectTest.php
+++ b/site/tests/Functional/Marketplace/Controller/Inventory/InventorySetCostRedirectTest.php
@@ -87,6 +87,29 @@ final class InventorySetCostRedirectTest extends WebTestCaseBase
         self::assertResponseRedirects(sprintf('/marketplace/inventory/%s/history', $listingId));
     }
 
+    public function testRedirectsToHistoryWhenReturnToFieldIsPresentWithoutReferer(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company, $listing] = $this->seedCompanyAndListing('redirect-return-to@example.test', 'sku-redirect-4');
+        $this->loginWithActiveCompany($client, $owner, $company);
+
+        $listingId = (string) $listing->getId();
+
+        $client->request(
+            'POST',
+            sprintf('/marketplace/inventory/%s/set-cost', $listingId),
+            [
+                'price_amount' => '777.00',
+                'effective_from' => '2026-04-18',
+                'return_to' => 'history',
+            ],
+        );
+
+        self::assertResponseRedirects(sprintf('/marketplace/inventory/%s/history', $listingId));
+    }
+
     /**
      * @return array{0: User, 1: Company, 2: MarketplaceListing}
      */

--- a/site/tests/Functional/Marketplace/Controller/Inventory/InventorySetCostRedirectTest.php
+++ b/site/tests/Functional/Marketplace/Controller/Inventory/InventorySetCostRedirectTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Marketplace\Controller\Inventory;
+
+use App\Company\Entity\Company;
+use App\Company\Entity\User;
+use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceListingBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+final class InventorySetCostRedirectTest extends WebTestCaseBase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-000000000099';
+
+    public function testRedirectsToInventoryIndexWhenRefererIsIndex(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company, $listing] = $this->seedCompanyAndListing('redirect-index@example.test', 'sku-redirect-1');
+        $this->loginWithActiveCompany($client, $owner, $company);
+
+        $client->request(
+            'POST',
+            sprintf('/marketplace/inventory/%s/set-cost', $listing->getId()),
+            [
+                'price_amount' => '850.00',
+                'effective_from' => '2026-04-15',
+                'note' => 'unit test',
+            ],
+            [],
+            ['HTTP_REFERER' => 'http://localhost/marketplace/inventory'],
+        );
+
+        self::assertResponseRedirects('/marketplace/inventory');
+    }
+
+    public function testRedirectsToInventoryIndexWithQueryWhenRefererHasFilter(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company, $listing] = $this->seedCompanyAndListing('redirect-filter@example.test', 'sku-redirect-2');
+        $this->loginWithActiveCompany($client, $owner, $company);
+
+        $client->request(
+            'POST',
+            sprintf('/marketplace/inventory/%s/set-cost', $listing->getId()),
+            [
+                'price_amount' => '999.50',
+                'effective_from' => '2026-04-16',
+            ],
+            [],
+            ['HTTP_REFERER' => 'http://localhost/marketplace/inventory?marketplace=ozon&page=2'],
+        );
+
+        self::assertResponseRedirects('/marketplace/inventory?marketplace=ozon&page=2');
+    }
+
+    public function testRedirectsBackToHistoryWhenRefererIsHistory(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company, $listing] = $this->seedCompanyAndListing('redirect-history@example.test', 'sku-redirect-3');
+        $this->loginWithActiveCompany($client, $owner, $company);
+
+        $listingId = (string) $listing->getId();
+
+        $client->request(
+            'POST',
+            sprintf('/marketplace/inventory/%s/set-cost', $listingId),
+            [
+                'price_amount' => '1234.56',
+                'effective_from' => '2026-04-17',
+            ],
+            [],
+            ['HTTP_REFERER' => sprintf('http://localhost/marketplace/inventory/%s/history', $listingId)],
+        );
+
+        self::assertResponseRedirects(sprintf('/marketplace/inventory/%s/history', $listingId));
+    }
+
+    /**
+     * @return array{0: User, 1: Company, 2: MarketplaceListing}
+     */
+    private function seedCompanyAndListing(string $email, string $sku): array
+    {
+        $owner = UserBuilder::aUser()
+            ->withEmail($email)
+            ->build();
+
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->withName('Inventory Redirect Co')
+            ->build();
+
+        $listing = MarketplaceListingBuilder::aListing()
+            ->forCompany($company)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withMarketplaceSku($sku)
+            ->build();
+
+        $em = $this->em();
+        $em->persist($owner);
+        $em->persist($company);
+        $em->persist($listing);
+        $em->flush();
+
+        return [$owner, $company, $listing];
+    }
+
+    private function loginWithActiveCompany(KernelBrowser $client, User $owner, Company $company): void
+    {
+        $client->loginUser($owner);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', $company->getId());
+        $session->save();
+    }
+}


### PR DESCRIPTION
## Summary
- `InventoryController::setCost` no longer force-redirects to the listing's history page after saving cost. It now honors `Referer`: stays on `/marketplace/inventory/{id}/history` when submitted from there, otherwise returns to `/marketplace/inventory` preserving `marketplace` and `page` query parameters.
- Same modal `#modal-set-cost` is rendered from `index.html.twig` and `history.html.twig`; user now lands back on the page they submitted from.
- Adds functional regression test `InventorySetCostRedirectTest` with three scenarios (index referer, index referer with filter+page, history referer).

## Test plan
- [ ] `docker-compose run --rm site-php-cli vendor/bin/phpunit --filter InventorySetCostRedirect` — all 3 tests pass
- [ ] Manual: open `/marketplace/inventory?marketplace=ozon&page=2`, set cost via modal → стаём на той же странице с фильтром, видим flash "Себестоимость сохранена."
- [ ] Manual: open `/marketplace/inventory/{id}/history`, set cost via modal → остаёмся на странице истории, видим обновлённую запись
- [ ] Manual: error path (overlapping date) — flash error отображается на той же странице, без редиректа на history

## Out of scope (still open)
- Duplicate `syncBarcodes` method in `InventoryImportController.php` (lines ~100–125) is dead code — header comment marks it as draft to be moved into `InventoryController`. Left untouched pending owner confirmation.

https://claude.ai/code/session_01JBArkNeoXQb6zvBmHXGYyE

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBArkNeoXQb6zvBmHXGYyE)_