### PR TITLE
feat(marketplace): search by name/SKU/article on inventory page

### DIFF
--- a/site/src/Marketplace/Controller/Inventory/InventoryController.php
+++ b/site/src/Marketplace/Controller/Inventory/InventoryController.php
@@ -39,10 +39,21 @@ final class InventoryController extends AbstractController
     {
         $company     = $this->companyService->getActiveCompany();
         $companyId   = (string) $company->getId();
-        $marketplace = $request->query->get('marketplace') ?: null;
-        $page        = max(1, (int) $request->query->get('page', 1));
 
-        $qb = $this->query->listingsQueryBuilder($companyId, $marketplace);
+        $rawQuery    = $request->query->all();
+        $marketplace = self::stringOrNull($rawQuery['marketplace'] ?? null);
+        $search      = self::stringOrNull($rawQuery['q'] ?? null);
+        $pageRaw     = self::stringOrNull($rawQuery['page'] ?? null);
+        $page        = max(1, (int) ($pageRaw ?? '1'));
+
+        if ($search !== null) {
+            $search = trim($search);
+            if ($search === '') {
+                $search = null;
+            }
+        }
+
+        $qb = $this->query->listingsQueryBuilder($companyId, $marketplace, $search);
 
         $pager = Pagerfanta::createForCurrentPageWithMaxPerPage(
             new QueryAdapter($qb, static function (QueryBuilder $qb): void {
@@ -63,6 +74,7 @@ final class InventoryController extends AbstractController
             'active_tab'  => 'inventory',
             'pager'       => $pager,
             'marketplace' => $marketplace,
+            'search'      => $search,
             'job_logs'    => $jobLogs,
         ]);
     }
@@ -132,7 +144,7 @@ final class InventoryController extends AbstractController
         $query  = is_string($urlParts['query'] ?? null) ? $urlParts['query'] : '';
         if ($query !== '') {
             parse_str($query, $parsed);
-            foreach (['marketplace', 'page'] as $key) {
+            foreach (['marketplace', 'page', 'q'] as $key) {
                 if (isset($parsed[$key]) && is_string($parsed[$key]) && $parsed[$key] !== '') {
                     $params[$key] = $parsed[$key];
                 }
@@ -155,5 +167,10 @@ final class InventoryController extends AbstractController
         $this->addFlash('success', 'Синхронизация баркодов Ozon запущена.');
 
         return $this->redirectToRoute('marketplace_inventory_index');
+    }
+
+    private static function stringOrNull(mixed $raw): ?string
+    {
+        return is_string($raw) && $raw !== '' ? $raw : null;
     }
 }

--- a/site/src/Marketplace/Inventory/Infrastructure/Query/InventoryCostListingQuery.php
+++ b/site/src/Marketplace/Inventory/Infrastructure/Query/InventoryCostListingQuery.php
@@ -32,8 +32,11 @@ final readonly class InventoryCostListingQuery
      *   product_id (null если не привязан), product_name (null), product_sku (null),
      *   cost_price (null если не задана), cost_currency, cost_from
      */
-    public function listingsQueryBuilder(string $companyId, ?string $marketplace): QueryBuilder
-    {
+    public function listingsQueryBuilder(
+        string $companyId,
+        ?string $marketplace,
+        ?string $search = null,
+    ): QueryBuilder {
         $today = (new \DateTimeImmutable())->format('Y-m-d');
 
         $qb = $this->connection->createQueryBuilder()
@@ -80,7 +83,32 @@ final readonly class InventoryCostListingQuery
                 ->setParameter('marketplace', $marketplace);
         }
 
+        if ($search !== null && $search !== '') {
+            $escaped = $this->escapeLikeOperand($search);
+            $qb->andWhere(
+                '(l.name ILIKE :search '
+                . 'OR l.marketplace_sku ILIKE :search '
+                . 'OR l.supplier_sku ILIKE :search '
+                . 'OR p.name ILIKE :search '
+                . 'OR p.sku ILIKE :search)'
+            )
+                ->setParameter('search', '%' . $escaped . '%');
+        }
+
         return $qb;
+    }
+
+    /**
+     * Экранирует LIKE-метасимволы PostgreSQL: \, %, _.
+     * Порядок важен — backslash первым, иначе уйдём в двойное экранирование.
+     */
+    private function escapeLikeOperand(string $value): string
+    {
+        return str_replace(
+            ['\\', '%', '_'],
+            ['\\\\', '\\%', '\\_'],
+            $value,
+        );
     }
 
     /**

--- a/site/templates/marketplace/inventory/index.html.twig
+++ b/site/templates/marketplace/inventory/index.html.twig
@@ -5,22 +5,39 @@
 {% block tab_content %}
     <div class="p-3">
 
-        <div class="mb-3 d-flex align-items-center gap-2">
-            <select class="form-select w-auto"
-                    onchange="window.location.href = this.value">
-                <option value="{{ path('marketplace_inventory_index') }}"
-                    {{ marketplace is null ? 'selected' : '' }}>
-                    Все маркетплейсы
-                </option>
-                <option value="{{ path('marketplace_inventory_index', {marketplace: 'wildberries'}) }}"
-                    {{ marketplace == 'wildberries' ? 'selected' : '' }}>
-                    Wildberries
-                </option>
-                <option value="{{ path('marketplace_inventory_index', {marketplace: 'ozon'}) }}"
-                    {{ marketplace == 'ozon' ? 'selected' : '' }}>
-                    Ozon
-                </option>
-            </select>
+        <div class="mb-3 d-flex align-items-center gap-2 flex-wrap">
+
+            <form method="get"
+                  action="{{ path('marketplace_inventory_index') }}"
+                  class="d-flex align-items-center gap-2 mb-0 flex-wrap">
+
+                <select name="marketplace" class="form-select form-select-sm w-auto">
+                    <option value="" {{ marketplace is null ? 'selected' : '' }}>
+                        Все маркетплейсы
+                    </option>
+                    <option value="wildberries" {{ marketplace == 'wildberries' ? 'selected' : '' }}>
+                        Wildberries
+                    </option>
+                    <option value="ozon" {{ marketplace == 'ozon' ? 'selected' : '' }}>
+                        Ozon
+                    </option>
+                </select>
+
+                <input type="search"
+                       name="q"
+                       class="form-control form-control-sm"
+                       style="min-width: 280px;"
+                       placeholder="Поиск по названию, SKU или артикулу"
+                       value="{{ search ?? '' }}"
+                       autocomplete="off">
+
+                <button type="submit" class="btn btn-sm btn-primary">Применить</button>
+
+                {% if marketplace or search %}
+                    <a href="{{ path('marketplace_inventory_index') }}"
+                       class="btn btn-sm btn-link">Сбросить</a>
+                {% endif %}
+            </form>
 
             <button type="button"
                     class="btn btn-sm btn-outline-secondary ms-auto"
@@ -37,7 +54,7 @@
                 Загрузить из файла
             </button>
 
-            <form method="post" action="{{ path('marketplace_inventory_sync_barcodes') }}">
+            <form method="post" action="{{ path('marketplace_inventory_sync_barcodes') }}" class="mb-0">
                 <button type="submit" class="btn btn-sm btn-outline-secondary">
                     <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-sm me-1" width="24" height="24"
                          viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"

--- a/site/templates/marketplace/inventory/index.html.twig
+++ b/site/templates/marketplace/inventory/index.html.twig
@@ -244,8 +244,8 @@
                     {% else %}
                         <tr>
                             <td colspan="8" class="text-center text-muted py-4">
-                                {% if marketplace is not null %}
-                                    Нет листингов для выбранного маркетплейса.
+                                {% if marketplace is not null or search is not null %}
+                                    Нет листингов под текущие фильтры.
                                 {% else %}
                                     Нет листингов. Добавьте подключение к маркетплейсу и запустите синхронизацию.
                                 {% endif %}

--- a/site/tests/Functional/Marketplace/Controller/Inventory/InventoryIndexFiltersTest.php
+++ b/site/tests/Functional/Marketplace/Controller/Inventory/InventoryIndexFiltersTest.php
@@ -115,6 +115,21 @@ final class InventoryIndexFiltersTest extends WebTestCaseBase
         self::assertSame(0, $resetLink->count(), 'Empty q should not trigger Reset link');
     }
 
+    public function testEmptySearchResultShowsFilteredEmptyState(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company] = $this->seedCompanyWithListing($client);
+        $this->loginWithActiveCompany($client, $owner, $company);
+
+        $client->request('GET', '/marketplace/inventory?q=zzznomatchzzz');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('table', 'под текущие фильтры');
+        self::assertSelectorTextNotContains('table', 'Добавьте подключение');
+    }
+
     /**
      * @return array{0: User, 1: Company}
      */

--- a/site/tests/Functional/Marketplace/Controller/Inventory/InventoryIndexFiltersTest.php
+++ b/site/tests/Functional/Marketplace/Controller/Inventory/InventoryIndexFiltersTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Marketplace\Controller\Inventory;
+
+use App\Company\Entity\Company;
+use App\Company\Entity\User;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceListingBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+final class InventoryIndexFiltersTest extends WebTestCaseBase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-0000000000fa';
+
+    public function testRendersIndexWithoutFilters(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company] = $this->seedCompanyWithListing($client);
+        $this->loginWithActiveCompany($client, $owner, $company);
+
+        $client->request('GET', '/marketplace/inventory');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testRendersIndexWithMarketplaceFilterSelected(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company] = $this->seedCompanyWithListing($client);
+        $this->loginWithActiveCompany($client, $owner, $company);
+
+        $crawler = $client->request('GET', '/marketplace/inventory?marketplace=ozon');
+
+        self::assertResponseIsSuccessful();
+        $selectedOzon = $crawler->filter('select[name="marketplace"] option[value="ozon"][selected]');
+        self::assertGreaterThan(0, $selectedOzon->count(), 'Expected ozon option to be selected');
+    }
+
+    public function testRendersIndexWithSearchInputValue(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company] = $this->seedCompanyWithListing($client);
+        $this->loginWithActiveCompany($client, $owner, $company);
+
+        $crawler = $client->request('GET', '/marketplace/inventory?q=test');
+
+        self::assertResponseIsSuccessful();
+        $input = $crawler->filter('input[name="q"]');
+        self::assertGreaterThan(0, $input->count(), 'Expected q input on page');
+        self::assertSame('test', $input->attr('value'));
+    }
+
+    public function testGracefulFallbackOnArrayMarketplaceParam(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company] = $this->seedCompanyWithListing($client);
+        $this->loginWithActiveCompany($client, $owner, $company);
+
+        $client->request('GET', '/marketplace/inventory?marketplace[]=foo');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testGracefulFallbackOnArrayQParam(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company] = $this->seedCompanyWithListing($client);
+        $this->loginWithActiveCompany($client, $owner, $company);
+
+        $client->request('GET', '/marketplace/inventory?q[]=foo');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testGracefulFallbackOnArrayPageParam(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company] = $this->seedCompanyWithListing($client);
+        $this->loginWithActiveCompany($client, $owner, $company);
+
+        $client->request('GET', '/marketplace/inventory?page[]=foo');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testEmptyQStringIsIgnored(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company] = $this->seedCompanyWithListing($client);
+        $this->loginWithActiveCompany($client, $owner, $company);
+
+        $crawler = $client->request('GET', '/marketplace/inventory?q=');
+
+        self::assertResponseIsSuccessful();
+        $resetLink = $crawler->filter('a:contains("Сбросить")');
+        self::assertSame(0, $resetLink->count(), 'Empty q should not trigger Reset link');
+    }
+
+    /**
+     * @return array{0: User, 1: Company}
+     */
+    private function seedCompanyWithListing(KernelBrowser $client): array
+    {
+        $owner = UserBuilder::aUser()
+            ->withEmail('inventory-filters@example.test')
+            ->build();
+
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->withName('Inventory Filters Co')
+            ->build();
+
+        $listing = MarketplaceListingBuilder::aListing()
+            ->forCompany($company)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withMarketplaceSku('sku-filters-1')
+            ->build();
+        $listing->setName('Filter test listing');
+
+        $em = $this->em();
+        $em->persist($owner);
+        $em->persist($company);
+        $em->persist($listing);
+        $em->flush();
+
+        return [$owner, $company];
+    }
+
+    private function loginWithActiveCompany(KernelBrowser $client, User $owner, Company $company): void
+    {
+        $client->loginUser($owner);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', $company->getId());
+        $session->save();
+    }
+}

--- a/site/tests/Functional/Marketplace/Controller/Inventory/InventorySetCostRedirectTest.php
+++ b/site/tests/Functional/Marketplace/Controller/Inventory/InventorySetCostRedirectTest.php
@@ -63,6 +63,28 @@ final class InventorySetCostRedirectTest extends WebTestCaseBase
         self::assertResponseRedirects('/marketplace/inventory?marketplace=ozon&page=2');
     }
 
+    public function testRedirectsToInventoryIndexPreservesQueryParam(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company, $listing] = $this->seedCompanyAndListing('redirect-q@example.test', 'sku-redirect-q');
+        $this->loginWithActiveCompany($client, $owner, $company);
+
+        $client->request(
+            'POST',
+            sprintf('/marketplace/inventory/%s/set-cost', $listing->getId()),
+            [
+                'price_amount' => '500.00',
+                'effective_from' => '2026-04-19',
+            ],
+            [],
+            ['HTTP_REFERER' => 'http://localhost/marketplace/inventory?marketplace=ozon&q=test&page=2'],
+        );
+
+        self::assertResponseRedirects('/marketplace/inventory?marketplace=ozon&page=2&q=test');
+    }
+
     public function testRedirectsBackToHistoryWhenRefererIsHistory(): void
     {
         $client = static::createClient();

--- a/site/tests/Functional/Marketplace/Controller/Inventory/InventorySetCostRedirectTest.php
+++ b/site/tests/Functional/Marketplace/Controller/Inventory/InventorySetCostRedirectTest.php
@@ -82,6 +82,11 @@ final class InventorySetCostRedirectTest extends WebTestCaseBase
             ['HTTP_REFERER' => 'http://localhost/marketplace/inventory?marketplace=ozon&q=test&page=2'],
         );
 
+        // NOTE: exact-string assertion is intentional. Whitelist order in
+        // InventoryController::setCost (['marketplace', 'page', 'q']) is
+        // part of the user-visible redirect URL contract — reorder the
+        // whitelist and this test will fail loudly. Do not weaken to a
+        // parse-and-compare assertion without architect sign-off.
         self::assertResponseRedirects('/marketplace/inventory?marketplace=ozon&page=2&q=test');
     }
 

--- a/site/tests/Integration/Marketplace/Inventory/Infrastructure/Query/InventoryCostListingQueryTest.php
+++ b/site/tests/Integration/Marketplace/Inventory/Infrastructure/Query/InventoryCostListingQueryTest.php
@@ -1,0 +1,289 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Marketplace\Inventory\Infrastructure\Query;
+
+use App\Catalog\Entity\Product;
+use App\Company\Entity\Company;
+use App\Company\Entity\User;
+use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Inventory\Infrastructure\Query\InventoryCostListingQuery;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceListingBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+
+final class InventoryCostListingQueryTest extends IntegrationTestCase
+{
+    private const COMPANY_A_ID = '11111111-1111-1111-1111-00000000000a';
+    private const COMPANY_B_ID = '11111111-1111-1111-1111-00000000000b';
+    private const OWNER_A_ID   = '22222222-2222-2222-2222-00000000000a';
+    private const OWNER_B_ID   = '22222222-2222-2222-2222-00000000000b';
+
+    private InventoryCostListingQuery $query;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->query = self::getContainer()->get(InventoryCostListingQuery::class);
+    }
+
+    public function testReturnsAllListingsOfCompanyWhenSearchIsNull(): void
+    {
+        $companyA = $this->seedCompany(self::COMPANY_A_ID, self::OWNER_A_ID, 'a@example.test');
+
+        $this->seedListing($companyA, 'sku-001', 'Foo Bar', null, MarketplaceType::OZON);
+        $this->seedListing($companyA, 'sku-002', 'Baz Qux', null, MarketplaceType::WILDBERRIES);
+        $this->seedListing($companyA, 'sku-003', 'Quux',    null, MarketplaceType::OZON);
+
+        $this->em->flush();
+
+        $rows = $this->fetch(self::COMPANY_A_ID, null, null);
+
+        self::assertCount(3, $rows);
+    }
+
+    public function testSearchMatchesByListingName(): void
+    {
+        $companyA = $this->seedCompany(self::COMPANY_A_ID, self::OWNER_A_ID, 'a@example.test');
+
+        $this->seedListing($companyA, 'sku-001', 'Кружка зелёная', null, MarketplaceType::OZON);
+        $this->seedListing($companyA, 'sku-002', 'Тарелка синяя',  null, MarketplaceType::OZON);
+
+        $this->em->flush();
+
+        $rows = $this->fetch(self::COMPANY_A_ID, null, 'кружка');
+
+        self::assertCount(1, $rows);
+        self::assertSame('sku-001', $rows[0]['marketplace_sku']);
+    }
+
+    public function testSearchMatchesByMarketplaceSku(): void
+    {
+        $companyA = $this->seedCompany(self::COMPANY_A_ID, self::OWNER_A_ID, 'a@example.test');
+
+        $this->seedListing($companyA, 'WB-12345', 'Listing One', null, MarketplaceType::WILDBERRIES);
+        $this->seedListing($companyA, 'WB-67890', 'Listing Two', null, MarketplaceType::WILDBERRIES);
+
+        $this->em->flush();
+
+        $rows = $this->fetch(self::COMPANY_A_ID, null, '12345');
+
+        self::assertCount(1, $rows);
+        self::assertSame('WB-12345', $rows[0]['marketplace_sku']);
+    }
+
+    public function testSearchMatchesBySupplierSku(): void
+    {
+        $companyA = $this->seedCompany(self::COMPANY_A_ID, self::OWNER_A_ID, 'a@example.test');
+
+        $this->seedListing($companyA, 'sku-A', 'Listing A', 'VENDOR-AAA', MarketplaceType::OZON);
+        $this->seedListing($companyA, 'sku-B', 'Listing B', 'VENDOR-BBB', MarketplaceType::OZON);
+
+        $this->em->flush();
+
+        $rows = $this->fetch(self::COMPANY_A_ID, null, 'AAA');
+
+        self::assertCount(1, $rows);
+        self::assertSame('sku-A', $rows[0]['marketplace_sku']);
+    }
+
+    public function testSearchMatchesByProductName(): void
+    {
+        $companyA = $this->seedCompany(self::COMPANY_A_ID, self::OWNER_A_ID, 'a@example.test');
+
+        $product = $this->seedProduct($companyA, 'PRD-001', 'Карандаш красный');
+        $this->seedListing($companyA, 'sku-mp-1', 'Listing Title', null, MarketplaceType::OZON, $product);
+        $this->seedListing($companyA, 'sku-mp-2', 'Other Title',   null, MarketplaceType::OZON);
+
+        $this->em->flush();
+
+        $rows = $this->fetch(self::COMPANY_A_ID, null, 'карандаш');
+
+        self::assertCount(1, $rows);
+        self::assertSame('sku-mp-1', $rows[0]['marketplace_sku']);
+    }
+
+    public function testSearchMatchesByProductSku(): void
+    {
+        $companyA = $this->seedCompany(self::COMPANY_A_ID, self::OWNER_A_ID, 'a@example.test');
+
+        $product = $this->seedProduct($companyA, 'PRD-99-XYZ', 'Some product');
+        $this->seedListing($companyA, 'sku-with-prd', 'L1', null, MarketplaceType::OZON, $product);
+        $this->seedListing($companyA, 'sku-without',  'L2', null, MarketplaceType::OZON);
+
+        $this->em->flush();
+
+        $rows = $this->fetch(self::COMPANY_A_ID, null, 'XYZ');
+
+        self::assertCount(1, $rows);
+        self::assertSame('sku-with-prd', $rows[0]['marketplace_sku']);
+    }
+
+    public function testSearchIsCaseInsensitive(): void
+    {
+        $companyA = $this->seedCompany(self::COMPANY_A_ID, self::OWNER_A_ID, 'a@example.test');
+
+        $this->seedListing($companyA, 'sku-1', 'lower-case-name', null, MarketplaceType::OZON);
+        $this->seedListing($companyA, 'sku-2', 'Other',           null, MarketplaceType::OZON);
+
+        $this->em->flush();
+
+        $rows = $this->fetch(self::COMPANY_A_ID, null, 'LOWER');
+
+        self::assertCount(1, $rows);
+        self::assertSame('sku-1', $rows[0]['marketplace_sku']);
+    }
+
+    public function testUnderscoreInSearchIsTreatedAsLiteralNotWildcard(): void
+    {
+        $companyA = $this->seedCompany(self::COMPANY_A_ID, self::OWNER_A_ID, 'a@example.test');
+
+        $this->seedListing($companyA, 'sku-l1', 'ABC_X', null, MarketplaceType::OZON);
+        $this->seedListing($companyA, 'sku-l2', 'ABC1X', null, MarketplaceType::OZON);
+
+        $this->em->flush();
+
+        $rows = $this->fetch(self::COMPANY_A_ID, null, '_X');
+
+        self::assertCount(1, $rows);
+        self::assertSame('sku-l1', $rows[0]['marketplace_sku']);
+    }
+
+    public function testPercentInSearchIsTreatedAsLiteralNotWildcard(): void
+    {
+        $companyA = $this->seedCompany(self::COMPANY_A_ID, self::OWNER_A_ID, 'a@example.test');
+
+        $this->seedListing($companyA, 'sku-l1', 'foo%bar', null, MarketplaceType::OZON);
+        $this->seedListing($companyA, 'sku-l2', 'fooXbar', null, MarketplaceType::OZON);
+
+        $this->em->flush();
+
+        $rows = $this->fetch(self::COMPANY_A_ID, null, '%');
+
+        self::assertCount(1, $rows);
+        self::assertSame('sku-l1', $rows[0]['marketplace_sku']);
+    }
+
+    public function testIDORListingFromOtherCompanyNotReturned(): void
+    {
+        $companyA = $this->seedCompany(self::COMPANY_A_ID, self::OWNER_A_ID, 'a@example.test');
+        $companyB = $this->seedCompany(self::COMPANY_B_ID, self::OWNER_B_ID, 'b@example.test');
+
+        $this->seedListing($companyA, 'sku-A1', 'Shared name', null, MarketplaceType::OZON);
+        $this->seedListing($companyB, 'sku-B1', 'Shared name', null, MarketplaceType::OZON);
+
+        $this->em->flush();
+
+        $rowsA = $this->fetch(self::COMPANY_A_ID, null, 'shared');
+        $rowsB = $this->fetch(self::COMPANY_B_ID, null, 'shared');
+
+        self::assertCount(1, $rowsA);
+        self::assertSame('sku-A1', $rowsA[0]['marketplace_sku']);
+
+        self::assertCount(1, $rowsB);
+        self::assertSame('sku-B1', $rowsB[0]['marketplace_sku']);
+    }
+
+    public function testSearchAndMarketplaceFiltersCombineWithAnd(): void
+    {
+        $companyA = $this->seedCompany(self::COMPANY_A_ID, self::OWNER_A_ID, 'a@example.test');
+
+        $this->seedListing($companyA, 'sku-1', 'Match Word', null, MarketplaceType::OZON);
+        $this->seedListing($companyA, 'sku-2', 'Match Word', null, MarketplaceType::WILDBERRIES);
+        $this->seedListing($companyA, 'sku-3', 'Other',      null, MarketplaceType::OZON);
+
+        $this->em->flush();
+
+        $rows = $this->fetch(self::COMPANY_A_ID, MarketplaceType::OZON->value, 'match');
+
+        self::assertCount(1, $rows);
+        self::assertSame('sku-1', $rows[0]['marketplace_sku']);
+    }
+
+    public function testEmptyAndNullSearchAreEquivalent(): void
+    {
+        $companyA = $this->seedCompany(self::COMPANY_A_ID, self::OWNER_A_ID, 'a@example.test');
+
+        $this->seedListing($companyA, 'sku-1', 'Alpha', null, MarketplaceType::OZON);
+        $this->seedListing($companyA, 'sku-2', 'Beta',  null, MarketplaceType::OZON);
+
+        $this->em->flush();
+
+        $rowsNull  = $this->fetch(self::COMPANY_A_ID, null, null);
+        $rowsEmpty = $this->fetch(self::COMPANY_A_ID, null, '');
+
+        self::assertCount(2, $rowsNull);
+        self::assertCount(2, $rowsEmpty);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function fetch(string $companyId, ?string $marketplace, ?string $search): array
+    {
+        $qb = $this->query->listingsQueryBuilder($companyId, $marketplace, $search);
+
+        return $qb->executeQuery()->fetchAllAssociative();
+    }
+
+    private function seedCompany(string $companyId, string $ownerId, string $email): Company
+    {
+        $owner = UserBuilder::aUser()
+            ->withId($ownerId)
+            ->withEmail($email)
+            ->build();
+
+        $company = CompanyBuilder::aCompany()
+            ->withId($companyId)
+            ->withOwner($owner)
+            ->build();
+
+        $this->em->persist($owner);
+        $this->em->persist($company);
+
+        return $company;
+    }
+
+    private function seedProduct(Company $company, string $sku, string $name): Product
+    {
+        $product = new Product(
+            \Ramsey\Uuid\Uuid::uuid4()->toString(),
+            $company,
+        );
+        $product->setSku($sku);
+        $product->setName($name);
+
+        $this->em->persist($product);
+
+        return $product;
+    }
+
+    private function seedListing(
+        Company $company,
+        string $marketplaceSku,
+        string $name,
+        ?string $supplierSku,
+        MarketplaceType $marketplace,
+        ?Product $product = null,
+    ): MarketplaceListing {
+        $listing = MarketplaceListingBuilder::aListing()
+            ->forCompany($company)
+            ->withMarketplace($marketplace)
+            ->withMarketplaceSku($marketplaceSku)
+            ->build();
+
+        $listing->setName($name);
+        $listing->setSupplierSku($supplierSku);
+        if ($product !== null) {
+            $listing->setProduct($product);
+        }
+
+        $this->em->persist($listing);
+
+        return $listing;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a single-input search next to the existing marketplace filter on `/marketplace/inventory`. Matches against listing `name`, `marketplace_sku`, `supplier_sku` and the linked product's `name`/`sku` via case-insensitive `ILIKE`. LIKE-metacharacters (`\`, `%`, `_`) are escaped, so user input is treated as a literal substring, not a wildcard pattern.
- Hardens query-string parsing in `InventoryController::index`: `marketplace`, `q` and `page` are read via `query->all()` + local `stringOrNull` helper (mirroring `MarketplaceSalesController`). Array-shaped values (`?key[]=foo`) no longer raise `BadRequestException` — they fall back gracefully to "no filter".
- The `setCost` redirect whitelist is extended to `['marketplace', 'page', 'q']` so editing cost from a filtered list keeps the search context.

## Changes

- `src/Marketplace/Inventory/Infrastructure/Query/InventoryCostListingQuery.php` — third optional `?string $search` param; OR over 5 columns; private `escapeLikeOperand()`.
- `src/Marketplace/Controller/Inventory/InventoryController.php` — graceful-fallback parsing, pass `search` to template, expand whitelist, private `stringOrNull()` helper.
- `templates/marketplace/inventory/index.html.twig` — wrap marketplace `<select>` + new `<input type="search" name="q">` in `<form method="get">` with «Применить» / «Сбросить»; move other action buttons out of the search form so their clicks don't submit it; drop the `onchange="window.location.href"` JS hack.
- `_pagerfanta.html.twig` not touched — pagination links pick up `q` automatically via `app.request.query.all`.

## Test plan

- [ ] `phpunit tests/Integration/Marketplace/Inventory/Infrastructure/Query/InventoryCostListingQueryTest.php` — happy-path; matches by `l.name`, `l.marketplace_sku`, `l.supplier_sku`, `p.name`, `p.sku`; case-insensitive; `_` and `%` treated as literals; cross-company IDOR; AND with marketplace filter; empty/null search equivalence.
- [ ] `phpunit tests/Functional/Marketplace/Controller/Inventory/InventoryIndexFiltersTest.php` — renders with no filters / `marketplace=ozon` / `q=test`; graceful-fallback on `?marketplace[]=foo`, `?q[]=foo`, `?page[]=foo`; empty `?q=` ignored (no «Сбросить» link).
- [ ] `phpunit tests/Functional/Marketplace/Controller/Inventory/InventorySetCostRedirectTest.php` — existing redirect cases stay green; new `testRedirectsToInventoryIndexPreservesQueryParam` keeps `marketplace=ozon&page=2&q=test`.
- [ ] Manual: open `/marketplace/inventory`, type a substring of a listing name, hit Enter / click «Применить» — expect filtered list; «Сбросить» clears both filters; pagination links retain `q` and `marketplace`.
- [ ] Manual: «Загрузить из файла» modal opens and «Синхронизировать баркоды Ozon» still POSTs — neither submits the search form.

https://claude.ai/code/session_018yf67b1CKtJueDBbtVrtwr

---
_Generated by [Claude Code](https://claude.ai/code/session_018yf67b1CKtJueDBbtVrtwr)_