### PR TITLE
Add Ozon fines for prohibited products cost category

### DIFF
--- a/site/src/Marketplace/Application/Processor/OzonServiceCategoryMap.php
+++ b/site/src/Marketplace/Application/Processor/OzonServiceCategoryMap.php
@@ -23,7 +23,7 @@ final class OzonServiceCategoryMap
      * Версия словаря — обновлять при любом изменении маппинга.
      * Используется в /marketplace/costs/debug/map-version для проверки деплоя.
      */
-    public const VERSION = '2026-04-21.1';
+    public const VERSION = '2026-04-27.1';
 
     /**
      * Service names из API Ozon, которые являются нулевыми маркерами (price = 0).

--- a/site/src/Marketplace/Domain/OzonCostCategory.php
+++ b/site/src/Marketplace/Domain/OzonCostCategory.php
@@ -542,6 +542,13 @@ final readonly class OzonCostCategory
                 serviceNames: ['MarketplaceSellerCorrectionOperation'],
             ),
             new self(
+                code: 'ozon_fines_prohibited_products',
+                name: 'Штрафы за запрещённые товары Ozon',
+                widgetGroup: 'Другие услуги и штрафы',
+                xlsxGroup: 'Другие услуги и штрафы',
+                serviceNames: ['FinesProhibitedProducts'],
+            ),
+            new self(
                 code: 'ozon_other_service',
                 name: 'Прочие услуги Ozon',
                 widgetGroup: 'Другие услуги и штрафы',


### PR DESCRIPTION
## Summary
Added a new cost category to track fines for prohibited products in Ozon marketplace.

## Changes
- Added new `ozon_fines_prohibited_products` cost category in `OzonCostCategory` with:
  - Display name: "Штрафы за запрещённые товары Ozon" (Ozon fines for prohibited products)
  - Widget group: "Другие услуги и штрафы" (Other services and fines)
  - XLSX export group: "Другие услуги и штрафы" (Other services and fines)
  - Service name mapping: `FinesProhibitedProducts`
- Updated `OzonServiceCategoryMap` version from `2026-04-21.1` to `2026-04-27.1` to reflect the mapping change

## Implementation Details
The new category follows the existing pattern for Ozon service categories and is grouped with other service fees and fines for both UI display and spreadsheet exports.

https://claude.ai/code/session_01YYTdXMhLfiz9V1dkocekFF