### PR TITLE
Add Inventory enums and contract unit tests

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,7 +25,6 @@
 | `Analytics` | Аналитические запросы и дашборды | — |
 | `MarketplaceAnalytics` | Аналитика маркетплейсов (витрина) | — |
 | `MarketplaceAds` | Рекламные отчёты WB/Ozon: загрузка raw → распределение затрат | `string $companyId` ✅ |
-| `Inventory` | Snapshot-based хранение остатков WB/Ozon | в разработке |
 | `Notification` | Каналы уведомлений (email и др.) | — |
 | `Shared` | Общий код: ActiveCompanyService, аудит, безопасность, storage | — |
 | `Admin` | Административная панель (отдельный firewall) | — |
@@ -194,18 +193,6 @@ pipeline'а (timeout, рестарт worker'а, exception) видимым для
 - `save(AdScheduledBatch $batch): void` — persist без flush (консистентно с `AdLoadJobRepository::save()`), вызывающий сам flush'ит в конце транзакции
 
 Dead code на Task-11.2: Repository ещё никем не вызывается, будет использован в Task-11.3+ (planner / poster / poller / finalizer).
-
----
-
-## Inventory — Enum контракт (task 1)
-
-Namespace: `App\Inventory\Enum`
-
-- `ExternalSystemType`: `wildberries`, `ozon`
-- `LocationType`: `mp_warehouse`, `mp_acceptance`, `mp_in_transit_to_customer`, `mp_in_transit_from_customer`
-- `StockStatus`: `available`, `in_transit_to_customer`, `in_transit_from_customer`, `on_acceptance`, `defect`, `blocked`
-- `SnapshotSessionStatus`: `pending`, `in_progress`, `completed`, `partial`, `failed`
-- `SnapshotTriggerType`: `scheduled_night`, `scheduled_day`, `manual`, `retry`
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,6 +25,7 @@
 | `Analytics` | Аналитические запросы и дашборды | — |
 | `MarketplaceAnalytics` | Аналитика маркетплейсов (витрина) | — |
 | `MarketplaceAds` | Рекламные отчёты WB/Ozon: загрузка raw → распределение затрат | `string $companyId` ✅ |
+| `Inventory` | Snapshot-based хранение остатков WB/Ozon | в разработке |
 | `Notification` | Каналы уведомлений (email и др.) | — |
 | `Shared` | Общий код: ActiveCompanyService, аудит, безопасность, storage | — |
 | `Admin` | Административная панель (отдельный firewall) | — |
@@ -193,6 +194,18 @@ pipeline'а (timeout, рестарт worker'а, exception) видимым для
 - `save(AdScheduledBatch $batch): void` — persist без flush (консистентно с `AdLoadJobRepository::save()`), вызывающий сам flush'ит в конце транзакции
 
 Dead code на Task-11.2: Repository ещё никем не вызывается, будет использован в Task-11.3+ (planner / poster / poller / finalizer).
+
+---
+
+## Inventory — Enum контракт (task 1)
+
+Namespace: `App\Inventory\Enum`
+
+- `ExternalSystemType`: `wildberries`, `ozon`
+- `LocationType`: `mp_warehouse`, `mp_acceptance`, `mp_in_transit_to_customer`, `mp_in_transit_from_customer`
+- `StockStatus`: `available`, `in_transit_to_customer`, `in_transit_from_customer`, `on_acceptance`, `defect`, `blocked`
+- `SnapshotSessionStatus`: `pending`, `in_progress`, `completed`, `partial`, `failed`
+- `SnapshotTriggerType`: `scheduled_night`, `scheduled_day`, `manual`, `retry`
 
 ---
 

--- a/site/src/Inventory/Enum/ExternalSystemType.php
+++ b/site/src/Inventory/Enum/ExternalSystemType.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Inventory\Enum;
+
+enum ExternalSystemType: string
+{
+    case Wildberries = 'wildberries';
+    case Ozon = 'ozon';
+}

--- a/site/src/Inventory/Enum/LocationType.php
+++ b/site/src/Inventory/Enum/LocationType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Inventory\Enum;
+
+enum LocationType: string
+{
+    case MpWarehouse = 'mp_warehouse';
+    case MpAcceptance = 'mp_acceptance';
+    case MpInTransitToCustomer = 'mp_in_transit_to_customer';
+    case MpInTransitFromCustomer = 'mp_in_transit_from_customer';
+}

--- a/site/src/Inventory/Enum/SnapshotSessionStatus.php
+++ b/site/src/Inventory/Enum/SnapshotSessionStatus.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Inventory\Enum;
+
+enum SnapshotSessionStatus: string
+{
+    case Pending = 'pending';
+    case InProgress = 'in_progress';
+    case Completed = 'completed';
+    case Partial = 'partial';
+    case Failed = 'failed';
+}

--- a/site/src/Inventory/Enum/SnapshotTriggerType.php
+++ b/site/src/Inventory/Enum/SnapshotTriggerType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Inventory\Enum;
+
+enum SnapshotTriggerType: string
+{
+    case ScheduledNight = 'scheduled_night';
+    case ScheduledDay = 'scheduled_day';
+    case Manual = 'manual';
+    case Retry = 'retry';
+}

--- a/site/src/Inventory/Enum/StockStatus.php
+++ b/site/src/Inventory/Enum/StockStatus.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Inventory\Enum;
+
+enum StockStatus: string
+{
+    case Available = 'available';
+    case InTransitToCustomer = 'in_transit_to_customer';
+    case InTransitFromCustomer = 'in_transit_from_customer';
+    case OnAcceptance = 'on_acceptance';
+    case Defect = 'defect';
+    case Blocked = 'blocked';
+}

--- a/site/tests/Unit/Inventory/Enum/InventoryEnumsTest.php
+++ b/site/tests/Unit/Inventory/Enum/InventoryEnumsTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Inventory\Enum;
+
+use App\Inventory\Enum\ExternalSystemType;
+use App\Inventory\Enum\LocationType;
+use App\Inventory\Enum\SnapshotSessionStatus;
+use App\Inventory\Enum\SnapshotTriggerType;
+use App\Inventory\Enum\StockStatus;
+use PHPUnit\Framework\TestCase;
+
+final class InventoryEnumsTest extends TestCase
+{
+    public function testExternalSystemTypeHasOnlyExpectedValues(): void
+    {
+        $this->assertSame(
+            ['wildberries', 'ozon'],
+            array_map(static fn (ExternalSystemType $case): string => $case->value, ExternalSystemType::cases()),
+        );
+    }
+
+    public function testLocationTypeHasExpectedValuesCount(): void
+    {
+        $this->assertCount(
+            4,
+            array_map(static fn (LocationType $case): string => $case->value, LocationType::cases()),
+        );
+    }
+
+    public function testStockStatusHasExpectedValuesCount(): void
+    {
+        $this->assertCount(
+            6,
+            array_map(static fn (StockStatus $case): string => $case->value, StockStatus::cases()),
+        );
+    }
+
+    public function testSnapshotSessionStatusHasExpectedValuesCount(): void
+    {
+        $this->assertCount(
+            5,
+            array_map(static fn (SnapshotSessionStatus $case): string => $case->value, SnapshotSessionStatus::cases()),
+        );
+    }
+
+    public function testSnapshotTriggerTypeHasExpectedValuesCount(): void
+    {
+        $this->assertCount(
+            4,
+            array_map(static fn (SnapshotTriggerType $case): string => $case->value, SnapshotTriggerType::cases()),
+        );
+    }
+}

--- a/site/tests/Unit/Inventory/Enum/InventoryEnumsTest.php
+++ b/site/tests/Unit/Inventory/Enum/InventoryEnumsTest.php
@@ -23,32 +23,55 @@ final class InventoryEnumsTest extends TestCase
 
     public function testLocationTypeHasExpectedValuesCount(): void
     {
-        $this->assertCount(
-            4,
+        $this->assertSame(
+            [
+                'mp_warehouse',
+                'mp_acceptance',
+                'mp_in_transit_to_customer',
+                'mp_in_transit_from_customer',
+            ],
             array_map(static fn (LocationType $case): string => $case->value, LocationType::cases()),
         );
     }
 
     public function testStockStatusHasExpectedValuesCount(): void
     {
-        $this->assertCount(
-            6,
+        $this->assertSame(
+            [
+                'available',
+                'in_transit_to_customer',
+                'in_transit_from_customer',
+                'on_acceptance',
+                'defect',
+                'blocked',
+            ],
             array_map(static fn (StockStatus $case): string => $case->value, StockStatus::cases()),
         );
     }
 
     public function testSnapshotSessionStatusHasExpectedValuesCount(): void
     {
-        $this->assertCount(
-            5,
+        $this->assertSame(
+            [
+                'pending',
+                'in_progress',
+                'completed',
+                'partial',
+                'failed',
+            ],
             array_map(static fn (SnapshotSessionStatus $case): string => $case->value, SnapshotSessionStatus::cases()),
         );
     }
 
     public function testSnapshotTriggerTypeHasExpectedValuesCount(): void
     {
-        $this->assertCount(
-            4,
+        $this->assertSame(
+            [
+                'scheduled_night',
+                'scheduled_day',
+                'manual',
+                'retry',
+            ],
             array_map(static fn (SnapshotTriggerType $case): string => $case->value, SnapshotTriggerType::cases()),
         );
     }


### PR DESCRIPTION
### Motivation
- Implement the enum layer for the new Inventory module to fix the public contract for snapshot-based marketplace stocks without adding business logic or future enum values.
- Follow project rules from `CLAUDE.md` / `ARCHITECTURE.md` / `PATTERNS.md` (namespace, `declare(strict_types=1)`, no `final`, no extra methods). 

### Description
- Added new enums under `App\Inventory\Enum`: `ExternalSystemType`, `LocationType`, `StockStatus`, `SnapshotSessionStatus`, `SnapshotTriggerType`, each with the exact string values from the task spec and `declare(strict_types=1)` at file top. 
- Added unit test `site/tests/Unit/Inventory/Enum/InventoryEnumsTest.php` that asserts enum contracts by checking `->value` for each enum (exact values/counts as required). 
- Updated `ARCHITECTURE.md` to include the Inventory module row and an explicit "Inventory — Enum контракт (task 1)" section documenting the enum values. 
- Did not add any entities, repositories, facades, methods like `getLabel()`, or any future enum values, and kept enums non-final per spec. 

### Testing
- Attempted to run the targeted PHPUnit test via `cd site && vendor/bin/phpunit tests/Unit/Inventory/Enum/InventoryEnumsTest.php`, but the test runner is not available in the environment (`vendor/bin/phpunit` missing). 
- Per-file PHP syntax checks `php -l` were executed for all new enum files and reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f059749e78832392c732546c55f97c)