### PR TITLE
Add Inventory Location entity, repository, builder and unit tests

### DIFF
--- a/site/config/packages/doctrine.yaml
+++ b/site/config/packages/doctrine.yaml
@@ -90,6 +90,12 @@ doctrine:
                 dir: '%kernel.project_dir%/src/Catalog/Entity'
                 prefix: 'App\Catalog\Entity'
                 alias: Catalog
+            Inventory:
+                type: attribute
+                is_bundle: false
+                dir: '%kernel.project_dir%/src/Inventory/Entity'
+                prefix: 'App\Inventory\Entity'
+                alias: Inventory
             Marketplace:
                 type: attribute
                 is_bundle: false

--- a/site/src/Inventory/Entity/Location.php
+++ b/site/src/Inventory/Entity/Location.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Inventory\Entity;
+
+use App\Inventory\Enum\LocationType;
+use App\Inventory\Repository\LocationRepository;
+use App\Marketplace\Enum\MarketplaceType;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity(repositoryClass: LocationRepository::class)]
+#[ORM\Table(name: 'inventory_locations')]
+#[ORM\Index(columns: ['company_id', 'type', 'is_active'], name: 'idx_inventory_locations_company_type_active')]
+#[ORM\Index(columns: ['company_id', 'external_system'], name: 'idx_inventory_locations_company_external_system')]
+class Location
+{
+    #[ORM\Id]
+    #[ORM\Column(type: Types::GUID, unique: true)]
+    private string $id;
+
+    #[ORM\Column(type: Types::GUID)]
+    private string $companyId;
+
+    #[ORM\Column(type: Types::STRING, length: 50, enumType: LocationType::class)]
+    private LocationType $type;
+
+    #[ORM\Column(type: Types::STRING, length: 50, enumType: MarketplaceType::class)]
+    private MarketplaceType $externalSystem;
+
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
+    private ?string $externalId = null;
+
+    #[ORM\Column(type: Types::STRING, length: 255)]
+    private string $code;
+
+    #[ORM\Column(type: Types::STRING, length: 255)]
+    private string $name;
+
+    #[ORM\Column(type: Types::BOOLEAN)]
+    private bool $isActive = true;
+
+    #[ORM\Column(type: Types::JSON, nullable: true)]
+    private ?array $metadata = null;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $updatedAt;
+
+    public function __construct(
+        string $companyId,
+        LocationType $type,
+        MarketplaceType $externalSystem,
+        string $code,
+        string $name,
+        ?string $externalId = null,
+        ?array $metadata = null,
+    ) {
+        Assert::uuid($companyId);
+
+        $this->id = Uuid::uuid7()->toString();
+        $this->companyId = $companyId;
+        $this->type = $type;
+        $this->externalSystem = $externalSystem;
+        $this->code = $code;
+        $this->name = $name;
+        $this->externalId = $externalId;
+        $this->metadata = $metadata;
+        $this->createdAt = new \DateTimeImmutable();
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getCompanyId(): string
+    {
+        return $this->companyId;
+    }
+
+    public function getType(): LocationType
+    {
+        return $this->type;
+    }
+
+    public function getExternalSystem(): MarketplaceType
+    {
+        return $this->externalSystem;
+    }
+
+    public function getExternalId(): ?string
+    {
+        return $this->externalId;
+    }
+
+    public function setExternalId(?string $externalId): self
+    {
+        $this->externalId = $externalId;
+        $this->touch();
+
+        return $this;
+    }
+
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+
+    public function setCode(string $code): self
+    {
+        $this->code = $code;
+        $this->touch();
+
+        return $this;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+        $this->touch();
+
+        return $this;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->isActive;
+    }
+
+    public function setIsActive(bool $isActive): self
+    {
+        $this->isActive = $isActive;
+        $this->touch();
+
+        return $this;
+    }
+
+    public function getMetadata(): ?array
+    {
+        return $this->metadata;
+    }
+
+    public function setMetadata(?array $metadata): self
+    {
+        $this->metadata = $metadata;
+        $this->touch();
+
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    private function touch(): void
+    {
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+}

--- a/site/src/Inventory/Entity/Location.php
+++ b/site/src/Inventory/Entity/Location.php
@@ -14,6 +14,7 @@ use Webmozart\Assert\Assert;
 
 #[ORM\Entity(repositoryClass: LocationRepository::class)]
 #[ORM\Table(name: 'inventory_locations')]
+#[ORM\UniqueConstraint(columns: ['company_id', 'code'], name: 'uniq_inventory_locations_company_code')]
 #[ORM\Index(columns: ['company_id', 'type', 'is_active'], name: 'idx_inventory_locations_company_type_active')]
 #[ORM\Index(columns: ['company_id', 'external_system'], name: 'idx_inventory_locations_company_external_system')]
 class Location
@@ -61,7 +62,12 @@ class Location
         ?string $externalId = null,
         ?array $metadata = null,
     ) {
+        $code = trim($code);
+        $name = trim($name);
+
         Assert::uuid($companyId);
+        Assert::notEmpty($code);
+        Assert::notEmpty($name);
 
         $this->id = Uuid::uuid7()->toString();
         $this->companyId = $companyId;

--- a/site/src/Inventory/Repository/LocationRepository.php
+++ b/site/src/Inventory/Repository/LocationRepository.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Inventory\Repository;
+
+use App\Inventory\Entity\Location;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+final class LocationRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Location::class);
+    }
+}

--- a/site/tests/Builders/Inventory/LocationBuilder.php
+++ b/site/tests/Builders/Inventory/LocationBuilder.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Builders\Inventory;
+
+use App\Inventory\Entity\Location;
+use App\Inventory\Enum\LocationType;
+use App\Marketplace\Enum\MarketplaceType;
+
+final class LocationBuilder
+{
+    public const DEFAULT_COMPANY_ID = '11111111-1111-1111-1111-111111111111';
+
+    private string $companyId = self::DEFAULT_COMPANY_ID;
+    private LocationType $type = LocationType::MpWarehouse;
+    private MarketplaceType $externalSystem = MarketplaceType::WILDBERRIES;
+    private ?string $externalId = 'ext-001';
+    private string $code = 'LOC-001';
+    private string $name = 'Main Warehouse';
+    private bool $isActive = true;
+    private ?array $metadata = ['source' => 'builder'];
+
+    private function __construct()
+    {
+    }
+
+    public static function aLocation(): self
+    {
+        return new self();
+    }
+
+    public function withIndex(int $index): self
+    {
+        $clone = clone $this;
+        $clone->externalId = sprintf('ext-%03d', $index);
+        $clone->code = sprintf('LOC-%03d', $index);
+        $clone->name = sprintf('Location %d', $index);
+
+        return $clone;
+    }
+
+    public function withCompanyId(string $companyId): self
+    {
+        $clone = clone $this;
+        $clone->companyId = $companyId;
+
+        return $clone;
+    }
+
+    public function withExternalId(?string $externalId): self
+    {
+        $clone = clone $this;
+        $clone->externalId = $externalId;
+
+        return $clone;
+    }
+
+    public function withCode(string $code): self
+    {
+        $clone = clone $this;
+        $clone->code = $code;
+
+        return $clone;
+    }
+
+    public function withName(string $name): self
+    {
+        $clone = clone $this;
+        $clone->name = $name;
+
+        return $clone;
+    }
+
+    public function withMetadata(?array $metadata): self
+    {
+        $clone = clone $this;
+        $clone->metadata = $metadata;
+
+        return $clone;
+    }
+
+    public function inactive(): self
+    {
+        $clone = clone $this;
+        $clone->isActive = false;
+
+        return $clone;
+    }
+
+    public function build(): Location
+    {
+        $location = new Location(
+            companyId: $this->companyId,
+            type: $this->type,
+            externalSystem: $this->externalSystem,
+            code: $this->code,
+            name: $this->name,
+            externalId: $this->externalId,
+            metadata: $this->metadata,
+        );
+
+        if (!$this->isActive) {
+            $location->setIsActive(false);
+        }
+
+        return $location;
+    }
+}

--- a/site/tests/Unit/Inventory/Entity/LocationTest.php
+++ b/site/tests/Unit/Inventory/Entity/LocationTest.php
@@ -99,4 +99,30 @@ final class LocationTest extends TestCase
         self::assertFalse(method_exists(Location::class, 'setType'));
         self::assertFalse(method_exists(Location::class, 'setExternalSystem'));
     }
+
+    public function testConstructorThrowsWhenCodeIsEmpty(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new Location(
+            companyId: LocationBuilder::DEFAULT_COMPANY_ID,
+            type: LocationType::MpWarehouse,
+            externalSystem: MarketplaceType::WILDBERRIES,
+            code: '  ',
+            name: 'Valid name',
+        );
+    }
+
+    public function testConstructorThrowsWhenNameIsEmpty(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new Location(
+            companyId: LocationBuilder::DEFAULT_COMPANY_ID,
+            type: LocationType::MpWarehouse,
+            externalSystem: MarketplaceType::WILDBERRIES,
+            code: 'VALID',
+            name: '   ',
+        );
+    }
 }

--- a/site/tests/Unit/Inventory/Entity/LocationTest.php
+++ b/site/tests/Unit/Inventory/Entity/LocationTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Inventory\Entity;
+
+use App\Inventory\Entity\Location;
+use App\Inventory\Enum\LocationType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Inventory\LocationBuilder;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+final class LocationTest extends TestCase
+{
+    public function testLocationCreationSetsExpectedFields(): void
+    {
+        $location = new Location(
+            companyId: LocationBuilder::DEFAULT_COMPANY_ID,
+            type: LocationType::MpWarehouse,
+            externalSystem: MarketplaceType::OZON,
+            code: 'MSK-01',
+            name: 'Москва склад',
+            externalId: 'oz-warehouse-001',
+            metadata: ['city' => 'Moscow'],
+        );
+
+        self::assertTrue(Uuid::isValid($location->getId()));
+        self::assertSame(LocationBuilder::DEFAULT_COMPANY_ID, $location->getCompanyId());
+        self::assertSame(LocationType::MpWarehouse, $location->getType());
+        self::assertSame(MarketplaceType::OZON, $location->getExternalSystem());
+        self::assertSame('oz-warehouse-001', $location->getExternalId());
+        self::assertSame('MSK-01', $location->getCode());
+        self::assertSame('Москва склад', $location->getName());
+        self::assertTrue($location->isActive());
+        self::assertSame(['city' => 'Moscow'], $location->getMetadata());
+        self::assertInstanceOf(\DateTimeImmutable::class, $location->getCreatedAt());
+        self::assertInstanceOf(\DateTimeImmutable::class, $location->getUpdatedAt());
+    }
+
+    public function testSetNameUpdatesNameAndUpdatedAt(): void
+    {
+        $location = LocationBuilder::aLocation()->build();
+        $before = $location->getUpdatedAt();
+
+        $location->setName('Новый склад');
+
+        self::assertSame('Новый склад', $location->getName());
+        self::assertGreaterThanOrEqual($before, $location->getUpdatedAt());
+    }
+
+    public function testSetIsActiveUpdatesFlagAndUpdatedAt(): void
+    {
+        $location = LocationBuilder::aLocation()->build();
+        $before = $location->getUpdatedAt();
+
+        $location->setIsActive(false);
+
+        self::assertFalse($location->isActive());
+        self::assertGreaterThanOrEqual($before, $location->getUpdatedAt());
+    }
+
+    public function testSetMetadataUpdatesMetadataAndUpdatedAt(): void
+    {
+        $location = LocationBuilder::aLocation()->build();
+        $before = $location->getUpdatedAt();
+
+        $location->setMetadata(['zone' => 'A1']);
+
+        self::assertSame(['zone' => 'A1'], $location->getMetadata());
+        self::assertGreaterThanOrEqual($before, $location->getUpdatedAt());
+    }
+
+    public function testSetCodeUpdatesCodeAndUpdatedAt(): void
+    {
+        $location = LocationBuilder::aLocation()->build();
+        $before = $location->getUpdatedAt();
+
+        $location->setCode('NEW-CODE');
+
+        self::assertSame('NEW-CODE', $location->getCode());
+        self::assertGreaterThanOrEqual($before, $location->getUpdatedAt());
+    }
+
+    public function testSetExternalIdUpdatesExternalIdAndUpdatedAt(): void
+    {
+        $location = LocationBuilder::aLocation()->build();
+        $before = $location->getUpdatedAt();
+
+        $location->setExternalId('new-external-id');
+
+        self::assertSame('new-external-id', $location->getExternalId());
+        self::assertGreaterThanOrEqual($before, $location->getUpdatedAt());
+    }
+
+    public function testLocationHasNoPublicMutableSettersForImmutableFields(): void
+    {
+        self::assertFalse(method_exists(Location::class, 'setCompanyId'));
+        self::assertFalse(method_exists(Location::class, 'setType'));
+        self::assertFalse(method_exists(Location::class, 'setExternalSystem'));
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce the first Entity of the new `Inventory` module: a marketplace locations directory to store marketplace warehouses/acceptances and support later features. 
- Provide a testable domain model and Builder to follow existing project patterns for new Entities and to enable safe future development and migrations.

### Description
- Added `App\Inventory\Entity\Location` mapped to table `inventory_locations` with UUIDv7 `id` (generated in constructor), immutable `companyId` (validated with `Assert::uuid()`), enum `type` (`LocationType`) and enum `externalSystem` (`App\Marketplace\Enum\MarketplaceType`), nullable JSON `metadata`, `code`, `name`, `isActive`, and `createdAt`/`updatedAt` timestamps; mutable setters `setName`, `setIsActive`, `setMetadata`, `setCode`, `setExternalId` update `updatedAt`, and the class is not `final`. 
- Added `App\Inventory\Repository\LocationRepository` as a `final` `ServiceEntityRepository` with only a constructor and no `flush()` or extra find methods. 
- Added `tests/Builders/Inventory/LocationBuilder` implementing `aLocation()`, `withIndex()`, `withCompanyId()`, `withExternalId()`, `withCode()`, `withName()`, `withMetadata()`, `inactive()`, and `build()` where the Builder does not set `id`. 
- Added unit test `tests/Unit/Inventory/Entity/LocationTest.php` that verifies construction (UUID generation and field preservation), default `isActive`, metadata, timestamps, all mutable setters update `updatedAt` (checked by `>=`), and absence of public setters for immutable fields. 
- Registered Doctrine mapping for the new module in `site/config/packages/doctrine.yaml` by adding an `Inventory` mapping pointing to `src/Inventory/Entity` and did not add any `routes.yaml`, `messenger.yaml` or `twig.yaml` changes.

### Testing
- Ran the unit test command `cd site && vendor/bin/phpunit tests/Unit/Inventory/Entity/LocationTest.php` but it could not run because Composer dependencies are not installed in the environment (vendor binaries missing). 
- Ran Doctrine checks `cd site && php bin/console doctrine:mapping:info` and `cd site && php bin/console doctrine:schema:validate --skip-sync` which failed with `LogicException: Dependencies are missing. Try running "composer install".` in the current environment. 
- Verified repository state with `cd site && git status --short` to confirm the expected files are present in the working tree.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f065dac5408323a58facbbfc5ca122)