### PR TITLE
Add InventorySnapshotSession entity, repository, builder and unit tests

### DIFF
--- a/site/src/Inventory/Entity/InventorySnapshotSession.php
+++ b/site/src/Inventory/Entity/InventorySnapshotSession.php
@@ -171,6 +171,10 @@ class InventorySnapshotSession
 
     public function markInProgress(): void
     {
+        if ($this->status !== SnapshotSessionStatus::Pending) {
+            throw new \DomainException('Only pending sessions can be moved to in-progress status.');
+        }
+
         $this->status = SnapshotSessionStatus::InProgress;
         $this->touch();
     }

--- a/site/src/Inventory/Entity/InventorySnapshotSession.php
+++ b/site/src/Inventory/Entity/InventorySnapshotSession.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Inventory\Entity;
+
+use App\Inventory\Enum\SnapshotSessionStatus;
+use App\Inventory\Enum\SnapshotTriggerType;
+use App\Inventory\Repository\InventorySnapshotSessionRepository;
+use App\Marketplace\Enum\MarketplaceType;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity(repositoryClass: InventorySnapshotSessionRepository::class)]
+#[ORM\Table(name: 'inventory_snapshot_sessions')]
+#[ORM\Index(columns: ['company_id', 'source', 'status'], name: 'idx_inv_snapshot_sessions_company_source_status')]
+#[ORM\Index(columns: ['correlation_id'], name: 'idx_inv_snapshot_sessions_correlation_id')]
+class InventorySnapshotSession
+{
+    #[ORM\Id]
+    #[ORM\Column(type: Types::GUID, unique: true)]
+    private string $id;
+
+    #[ORM\Column(type: Types::GUID)]
+    private string $companyId;
+
+    #[ORM\Column(type: Types::STRING, length: 50, enumType: MarketplaceType::class)]
+    private MarketplaceType $source;
+
+    #[ORM\Column(type: Types::STRING, length: 50, enumType: SnapshotTriggerType::class)]
+    private SnapshotTriggerType $triggerType;
+
+    #[ORM\Column(type: Types::GUID, nullable: true)]
+    private ?string $triggeredBy;
+
+    #[ORM\Column(type: Types::STRING, length: 50, enumType: SnapshotSessionStatus::class)]
+    private SnapshotSessionStatus $status = SnapshotSessionStatus::Pending;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $startedAt;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    private ?\DateTimeImmutable $completedAt = null;
+
+    #[ORM\Column(type: Types::INTEGER, nullable: true)]
+    private ?int $expectedPages;
+
+    #[ORM\Column(type: Types::INTEGER)]
+    private int $receivedPages = 0;
+
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $errorMessage = null;
+
+    #[ORM\Column(type: Types::GUID)]
+    private string $correlationId;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $updatedAt;
+
+    public function __construct(
+        string $companyId,
+        MarketplaceType $source,
+        SnapshotTriggerType $triggerType,
+        ?string $correlationId = null,
+        ?string $triggeredBy = null,
+        ?int $expectedPages = null,
+    ) {
+        Assert::uuid($companyId);
+
+        if ($triggeredBy !== null) {
+            Assert::uuid($triggeredBy);
+        }
+
+        if ($correlationId !== null) {
+            Assert::uuid($correlationId);
+        }
+
+        if ($expectedPages !== null && $expectedPages < 0) {
+            throw new \DomainException('expectedPages must be greater than or equal to 0.');
+        }
+
+        $now = new \DateTimeImmutable();
+
+        $this->id = Uuid::uuid7()->toString();
+        $this->companyId = $companyId;
+        $this->source = $source;
+        $this->triggerType = $triggerType;
+        $this->triggeredBy = $triggeredBy;
+        $this->status = SnapshotSessionStatus::Pending;
+        $this->startedAt = $now;
+        $this->expectedPages = $expectedPages;
+        $this->correlationId = $correlationId ?? Uuid::uuid7()->toString();
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getCompanyId(): string
+    {
+        return $this->companyId;
+    }
+
+    public function getSource(): MarketplaceType
+    {
+        return $this->source;
+    }
+
+    public function getTriggerType(): SnapshotTriggerType
+    {
+        return $this->triggerType;
+    }
+
+    public function getTriggeredBy(): ?string
+    {
+        return $this->triggeredBy;
+    }
+
+    public function getStatus(): SnapshotSessionStatus
+    {
+        return $this->status;
+    }
+
+    public function getStartedAt(): \DateTimeImmutable
+    {
+        return $this->startedAt;
+    }
+
+    public function getCompletedAt(): ?\DateTimeImmutable
+    {
+        return $this->completedAt;
+    }
+
+    public function getExpectedPages(): ?int
+    {
+        return $this->expectedPages;
+    }
+
+    public function getReceivedPages(): int
+    {
+        return $this->receivedPages;
+    }
+
+    public function getErrorMessage(): ?string
+    {
+        return $this->errorMessage;
+    }
+
+    public function getCorrelationId(): string
+    {
+        return $this->correlationId;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function markInProgress(): void
+    {
+        $this->status = SnapshotSessionStatus::InProgress;
+        $this->touch();
+    }
+
+    public function markCompleted(): void
+    {
+        $this->status = SnapshotSessionStatus::Completed;
+        $this->completedAt = new \DateTimeImmutable();
+        $this->touch();
+    }
+
+    public function markPartial(?string $errorMessage = null): void
+    {
+        $this->status = SnapshotSessionStatus::Partial;
+        $this->errorMessage = $errorMessage;
+        $this->completedAt = new \DateTimeImmutable();
+        $this->touch();
+    }
+
+    public function markFailed(string $errorMessage): void
+    {
+        Assert::notEmpty(trim($errorMessage));
+
+        $this->status = SnapshotSessionStatus::Failed;
+        $this->errorMessage = $errorMessage;
+        $this->completedAt = new \DateTimeImmutable();
+        $this->touch();
+    }
+
+    public function setExpectedPages(?int $expectedPages): void
+    {
+        if ($expectedPages !== null && $expectedPages < 0) {
+            throw new \DomainException('expectedPages must be greater than or equal to 0.');
+        }
+
+        $this->expectedPages = $expectedPages;
+        $this->touch();
+    }
+
+    public function incrementReceivedPages(int $by = 1): void
+    {
+        if ($by < 0) {
+            throw new \DomainException('increment value must be greater than or equal to 0.');
+        }
+
+        $this->receivedPages += $by;
+        $this->touch();
+    }
+
+    public function setReceivedPages(int $receivedPages): void
+    {
+        if ($receivedPages < 0) {
+            throw new \DomainException('receivedPages must be greater than or equal to 0.');
+        }
+
+        $this->receivedPages = $receivedPages;
+        $this->touch();
+    }
+
+    private function touch(): void
+    {
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+}

--- a/site/src/Inventory/Repository/InventorySnapshotSessionRepository.php
+++ b/site/src/Inventory/Repository/InventorySnapshotSessionRepository.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Inventory\Repository;
+
+use App\Inventory\Entity\InventorySnapshotSession;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+final class InventorySnapshotSessionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, InventorySnapshotSession::class);
+    }
+}

--- a/site/tests/Builders/Inventory/InventorySnapshotSessionBuilder.php
+++ b/site/tests/Builders/Inventory/InventorySnapshotSessionBuilder.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Builders\Inventory;
+
+use App\Inventory\Entity\InventorySnapshotSession;
+use App\Inventory\Enum\SnapshotTriggerType;
+use App\Marketplace\Enum\MarketplaceType;
+
+final class InventorySnapshotSessionBuilder
+{
+    public const DEFAULT_COMPANY_ID = '11111111-1111-1111-1111-111111111111';
+    public const DEFAULT_TRIGGERED_BY = '22222222-2222-2222-2222-222222222222';
+    public const DEFAULT_CORRELATION_ID = '33333333-3333-7333-8333-333333333333';
+
+    private string $companyId = self::DEFAULT_COMPANY_ID;
+    private MarketplaceType $source = MarketplaceType::WILDBERRIES;
+    private SnapshotTriggerType $triggerType = SnapshotTriggerType::Manual;
+    private ?string $triggeredBy = self::DEFAULT_TRIGGERED_BY;
+    private ?int $expectedPages = 10;
+    private ?string $correlationId = self::DEFAULT_CORRELATION_ID;
+
+    private function __construct()
+    {
+    }
+
+    public static function aSession(): self
+    {
+        return new self();
+    }
+
+    public function withCompanyId(string $companyId): self
+    {
+        $clone = clone $this;
+        $clone->companyId = $companyId;
+
+        return $clone;
+    }
+
+    public function withSource(MarketplaceType $source): self
+    {
+        $clone = clone $this;
+        $clone->source = $source;
+
+        return $clone;
+    }
+
+    public function withTriggerType(SnapshotTriggerType $triggerType): self
+    {
+        $clone = clone $this;
+        $clone->triggerType = $triggerType;
+
+        return $clone;
+    }
+
+    public function withTriggeredBy(?string $triggeredBy): self
+    {
+        $clone = clone $this;
+        $clone->triggeredBy = $triggeredBy;
+
+        return $clone;
+    }
+
+    public function withExpectedPages(?int $expectedPages): self
+    {
+        $clone = clone $this;
+        $clone->expectedPages = $expectedPages;
+
+        return $clone;
+    }
+
+    public function withCorrelationId(string $correlationId): self
+    {
+        $clone = clone $this;
+        $clone->correlationId = $correlationId;
+
+        return $clone;
+    }
+
+    public function build(): InventorySnapshotSession
+    {
+        return new InventorySnapshotSession(
+            companyId: $this->companyId,
+            source: $this->source,
+            triggerType: $this->triggerType,
+            correlationId: $this->correlationId,
+            triggeredBy: $this->triggeredBy,
+            expectedPages: $this->expectedPages,
+        );
+    }
+}

--- a/site/tests/Unit/Inventory/Entity/InventorySnapshotSessionTest.php
+++ b/site/tests/Unit/Inventory/Entity/InventorySnapshotSessionTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Inventory\Entity;
+
+use App\Inventory\Entity\InventorySnapshotSession;
+use App\Inventory\Enum\SnapshotSessionStatus;
+use App\Inventory\Enum\SnapshotTriggerType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Inventory\InventorySnapshotSessionBuilder;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+final class InventorySnapshotSessionTest extends TestCase
+{
+    public function testConstructorGeneratesUuidV7Id(): void
+    {
+        $session = InventorySnapshotSessionBuilder::aSession()->build();
+
+        self::assertTrue(Uuid::isValid($session->getId()));
+        self::assertSame(7, Uuid::fromString($session->getId())->getFields()->getVersion());
+    }
+
+    public function testCorrelationIdIsGeneratedWhenNotProvided(): void
+    {
+        $session = new InventorySnapshotSession(
+            companyId: InventorySnapshotSessionBuilder::DEFAULT_COMPANY_ID,
+            source: MarketplaceType::OZON,
+            triggerType: SnapshotTriggerType::ScheduledNight,
+            correlationId: null,
+            triggeredBy: null,
+            expectedPages: null,
+        );
+
+        self::assertTrue(Uuid::isValid($session->getCorrelationId()));
+        self::assertSame(7, Uuid::fromString($session->getCorrelationId())->getFields()->getVersion());
+    }
+
+    public function testCorrelationIdIsStoredWhenProvided(): void
+    {
+        $session = InventorySnapshotSessionBuilder::aSession()
+            ->withCorrelationId(InventorySnapshotSessionBuilder::DEFAULT_CORRELATION_ID)
+            ->build();
+
+        self::assertSame(InventorySnapshotSessionBuilder::DEFAULT_CORRELATION_ID, $session->getCorrelationId());
+    }
+
+    public function testDefaultsAreInitialized(): void
+    {
+        $session = new InventorySnapshotSession(
+            companyId: InventorySnapshotSessionBuilder::DEFAULT_COMPANY_ID,
+            source: MarketplaceType::WILDBERRIES,
+            triggerType: SnapshotTriggerType::Manual,
+            correlationId: null,
+            triggeredBy: null,
+            expectedPages: null,
+        );
+
+        self::assertSame(SnapshotSessionStatus::Pending, $session->getStatus());
+        self::assertSame(0, $session->getReceivedPages());
+        self::assertInstanceOf(\DateTimeImmutable::class, $session->getStartedAt());
+        self::assertInstanceOf(\DateTimeImmutable::class, $session->getCreatedAt());
+        self::assertInstanceOf(\DateTimeImmutable::class, $session->getUpdatedAt());
+        self::assertNull($session->getTriggeredBy());
+        self::assertNull($session->getExpectedPages());
+    }
+
+    public function testMarkInProgressChangesStatus(): void
+    {
+        $session = InventorySnapshotSessionBuilder::aSession()->build();
+
+        $session->markInProgress();
+
+        self::assertSame(SnapshotSessionStatus::InProgress, $session->getStatus());
+    }
+
+    public function testIncrementReceivedPagesIncreasesCounter(): void
+    {
+        $session = InventorySnapshotSessionBuilder::aSession()->build();
+
+        $session->incrementReceivedPages();
+        $session->incrementReceivedPages(2);
+
+        self::assertSame(3, $session->getReceivedPages());
+    }
+
+    public function testSetReceivedPagesSetsCounter(): void
+    {
+        $session = InventorySnapshotSessionBuilder::aSession()->build();
+
+        $session->setReceivedPages(7);
+
+        self::assertSame(7, $session->getReceivedPages());
+    }
+
+    public function testSetExpectedPagesSetsExpectedPages(): void
+    {
+        $session = InventorySnapshotSessionBuilder::aSession()->withExpectedPages(null)->build();
+
+        $session->setExpectedPages(15);
+
+        self::assertSame(15, $session->getExpectedPages());
+    }
+
+    public function testMarkCompletedSetsStatusAndCompletedAt(): void
+    {
+        $session = InventorySnapshotSessionBuilder::aSession()->build();
+
+        $session->markCompleted();
+
+        self::assertSame(SnapshotSessionStatus::Completed, $session->getStatus());
+        self::assertInstanceOf(\DateTimeImmutable::class, $session->getCompletedAt());
+    }
+
+    public function testMarkPartialSetsStatusErrorMessageAndCompletedAt(): void
+    {
+        $session = InventorySnapshotSessionBuilder::aSession()->build();
+
+        $session->markPartial('Some pages are missing');
+
+        self::assertSame(SnapshotSessionStatus::Partial, $session->getStatus());
+        self::assertSame('Some pages are missing', $session->getErrorMessage());
+        self::assertInstanceOf(\DateTimeImmutable::class, $session->getCompletedAt());
+    }
+
+    public function testMarkFailedSetsStatusErrorMessageAndCompletedAt(): void
+    {
+        $session = InventorySnapshotSessionBuilder::aSession()->build();
+
+        $session->markFailed('Fatal API error');
+
+        self::assertSame(SnapshotSessionStatus::Failed, $session->getStatus());
+        self::assertSame('Fatal API error', $session->getErrorMessage());
+        self::assertInstanceOf(\DateTimeImmutable::class, $session->getCompletedAt());
+    }
+
+    public function testEntityHasNoPublicSettersForImmutableFields(): void
+    {
+        self::assertFalse(method_exists(InventorySnapshotSession::class, 'setCompanyId'));
+        self::assertFalse(method_exists(InventorySnapshotSession::class, 'setSource'));
+        self::assertFalse(method_exists(InventorySnapshotSession::class, 'setTriggerType'));
+    }
+
+    public function testConstructorThrowsWhenExpectedPagesIsNegative(): void
+    {
+        $this->expectException(\DomainException::class);
+
+        new InventorySnapshotSession(
+            companyId: InventorySnapshotSessionBuilder::DEFAULT_COMPANY_ID,
+            source: MarketplaceType::OZON,
+            triggerType: SnapshotTriggerType::Manual,
+            expectedPages: -1,
+        );
+    }
+
+    public function testIncrementReceivedPagesThrowsWhenByIsNegative(): void
+    {
+        $session = InventorySnapshotSessionBuilder::aSession()->build();
+
+        $this->expectException(\DomainException::class);
+
+        $session->incrementReceivedPages(-1);
+    }
+
+    public function testSetReceivedPagesThrowsWhenNegative(): void
+    {
+        $session = InventorySnapshotSessionBuilder::aSession()->build();
+
+        $this->expectException(\DomainException::class);
+
+        $session->setReceivedPages(-1);
+    }
+
+    public function testSetExpectedPagesThrowsWhenNegative(): void
+    {
+        $session = InventorySnapshotSessionBuilder::aSession()->build();
+
+        $this->expectException(\DomainException::class);
+
+        $session->setExpectedPages(-5);
+    }
+}

--- a/site/tests/Unit/Inventory/Entity/InventorySnapshotSessionTest.php
+++ b/site/tests/Unit/Inventory/Entity/InventorySnapshotSessionTest.php
@@ -75,6 +75,17 @@ final class InventorySnapshotSessionTest extends TestCase
         self::assertSame(SnapshotSessionStatus::InProgress, $session->getStatus());
     }
 
+
+    public function testMarkInProgressThrowsForTerminalStatus(): void
+    {
+        $session = InventorySnapshotSessionBuilder::aSession()->build();
+        $session->markCompleted();
+
+        $this->expectException(\DomainException::class);
+
+        $session->markInProgress();
+    }
+
     public function testIncrementReceivedPagesIncreasesCounter(): void
     {
         $session = InventorySnapshotSessionBuilder::aSession()->build();


### PR DESCRIPTION
### Motivation
- Ввести сущность сессии загрузки snapshot-остатков для фиксации процесса загрузки страниц остатков и корреляции запросов. 
- Обеспечить явные state-transition методы и инварианты (immutable companyId/source/triggerType/correlationId, валидации UUID, запрет отрицательных счётчиков). 
- Подготовить тестовую инфраструктуру (Builder + unit-test) для гарантии корректного поведения Entity без добавления оркестрации/Message/Handler.

### Description
- Добавлена Entity `App\Inventory\Entity\InventorySnapshotSession` (таблица `inventory_snapshot_sessions`) с полями `id` (UUID v7), `companyId`, `source: MarketplaceType`, `triggerType: SnapshotTriggerType`, `triggeredBy`, `status: SnapshotSessionStatus` (по умолчанию `Pending`), `startedAt`, `completedAt`, `expectedPages`, `receivedPages` (по умолчанию 0), `errorMessage`, `correlationId` (UUID v7 если не передан), `createdAt`, `updatedAt` и индексами `company_id, source, status` и `correlation_id`.
- Конструктор валидирует `companyId`, `triggeredBy` и `correlationId` (если переданы), генерирует `id` и `correlationId` через `Uuid::uuid7()->toString()` при отсутствии входного значения, и инициализирует временные метки и значения по умолчанию; запрещает negative `expectedPages`.
- Добавлены state/guard-методы: `markInProgress()`, `markCompleted()`, `markPartial(?string $errorMessage = null)`, `markFailed(string $errorMessage)`, `setExpectedPages(?int)`, `incrementReceivedPages(int $by = 1)` и `setReceivedPages(int)` с обновлением `updatedAt` и проверками на отрицательные значения.
- Добавлен репозиторий `App\Inventory\Repository\InventorySnapshotSessionRepository` как `ServiceEntityRepository` с конструктором только (без кастомных методов в этой задаче).
- Добавлен тестовый билдeр `App\Tests\Builders\Inventory\InventorySnapshotSessionBuilder` с `aSession()` и методами `withCompanyId()`, `withSource()`, `withTriggerType()`, `withTriggeredBy()`, `withExpectedPages()`, `withCorrelationId()` и `build()`.
- Добавлен unit-тест `App\Tests\Unit\Inventory\Entity\InventorySnapshotSessionTest` покрывающий генерацию UUID v7 для `id` и `correlationId`, поведение по умолчанию, state-трансформации, счётчики, nullable-поля, отсутствие публичных сеттеров для immutable полей и отрицательные-значения guards.

### Testing
- Прогон синтаксиса: `php -l` пройден для файлов `site/src/Inventory/Entity/InventorySnapshotSession.php`, `site/src/Inventory/Repository/InventorySnapshotSessionRepository.php`, `site/tests/Builders/Inventory/InventorySnapshotSessionBuilder.php` и `site/tests/Unit/Inventory/Entity/InventorySnapshotSessionTest.php` (успешно). 
- Попытка запустить unit-тесты с `vendor/bin/phpunit tests/Unit/Inventory/Entity/InventorySnapshotSessionTest.php` не выполнена из-за отсутствующих зависимостей (`vendor`), требуется `composer install` в окружении для запуска; результат — не запущено. 
- Попытки выполнить `php bin/console doctrine:mapping:info` и `php bin/console doctrine:schema:validate --skip-sync` не выполнены из-за тех же отсутствующих зависимостей (`composer install`), поэтому маппинг/схема не были проверены в этом окружении.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f07035897c832382bc496671137aa0)