### PR TITLE
Добавить InventoryRawSnapshot Entity, репозиторий, Builder и unit-тесты

### DIFF
--- a/site/src/Inventory/Entity/InventoryRawSnapshot.php
+++ b/site/src/Inventory/Entity/InventoryRawSnapshot.php
@@ -91,21 +91,10 @@ class InventoryRawSnapshot
         Assert::uuid($snapshotSessionId);
         Assert::uuid($correlationId);
 
-        if ('' === trim($sourceEndpoint)) {
-            throw new \DomainException('sourceEndpoint must not be empty.');
-        }
-
-        if ($responseStatus <= 0) {
-            throw new \DomainException('responseStatus must be greater than 0.');
-        }
-
-        if ($fetchDurationMs < 0) {
-            throw new \DomainException('fetchDurationMs must be greater than or equal to 0.');
-        }
-
-        if ($pageNumber !== null && $pageNumber < 1) {
-            throw new \DomainException('pageNumber must be null or greater than or equal to 1.');
-        }
+        Assert::notEmpty(trim($sourceEndpoint), 'sourceEndpoint must not be empty.');
+        Assert::greaterThan($responseStatus, 0, 'responseStatus must be greater than 0.');
+        Assert::greaterThanEq($fetchDurationMs, 0, 'fetchDurationMs must be greater than or equal to 0.');
+        Assert::nullOrGreaterThanEq($pageNumber, 1, 'pageNumber must be null or greater than or equal to 1.');
 
         $this->id = Uuid::uuid7()->toString();
         $this->companyId = $companyId;
@@ -220,7 +209,7 @@ class InventoryRawSnapshot
         Assert::notEmpty(trim($processingError));
 
         $this->isProcessed = false;
-        $this->processedAt = null;
+        $this->processedAt = new \DateTimeImmutable();
         $this->processingError = $processingError;
     }
 }

--- a/site/src/Inventory/Entity/InventoryRawSnapshot.php
+++ b/site/src/Inventory/Entity/InventoryRawSnapshot.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Inventory\Entity;
+
+use App\Inventory\Repository\InventoryRawSnapshotRepository;
+use App\Marketplace\Enum\MarketplaceType;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity(repositoryClass: InventoryRawSnapshotRepository::class)]
+#[ORM\Table(name: 'inventory_raw_snapshots')]
+#[ORM\Index(columns: ['company_id', 'snapshot_session_id'], name: 'idx_inv_raw_snapshots_company_session')]
+#[ORM\Index(columns: ['source', 'fetched_at'], name: 'idx_inv_raw_snapshots_source_fetched_at')]
+#[ORM\Index(columns: ['is_processed'], name: 'idx_inv_raw_snapshots_is_processed')]
+#[ORM\Index(columns: ['correlation_id'], name: 'idx_inv_raw_snapshots_correlation_id')]
+class InventoryRawSnapshot
+{
+    #[ORM\Id]
+    #[ORM\Column(type: Types::GUID, unique: true)]
+    private string $id;
+
+    #[ORM\Column(type: Types::GUID)]
+    private string $companyId;
+
+    #[ORM\Column(type: Types::GUID)]
+    private string $snapshotSessionId;
+
+    #[ORM\Column(type: Types::STRING, length: 50, enumType: MarketplaceType::class)]
+    private MarketplaceType $source;
+
+    #[ORM\Column(type: Types::STRING, length: 500)]
+    private string $sourceEndpoint;
+
+    /** @var array<string, mixed> */
+    #[ORM\Column(type: Types::JSON)]
+    private array $requestParams;
+
+    #[ORM\Column(type: Types::INTEGER)]
+    private int $responseStatus;
+
+    /** @var array<string, mixed> */
+    #[ORM\Column(type: Types::JSON)]
+    private array $responseBody;
+
+    #[ORM\Column(type: Types::INTEGER, nullable: true)]
+    private ?int $pageNumber;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $fetchedAt;
+
+    #[ORM\Column(type: Types::INTEGER)]
+    private int $fetchDurationMs;
+
+    #[ORM\Column(type: Types::BOOLEAN, options: ['default' => false])]
+    private bool $isProcessed = false;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    private ?\DateTimeImmutable $processedAt = null;
+
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $processingError = null;
+
+    #[ORM\Column(type: Types::GUID)]
+    private string $correlationId;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $createdAt;
+
+    /**
+     * @param array<string, mixed> $requestParams
+     * @param array<string, mixed> $responseBody
+     */
+    public function __construct(
+        string $companyId,
+        string $snapshotSessionId,
+        MarketplaceType $source,
+        string $sourceEndpoint,
+        array $requestParams,
+        int $responseStatus,
+        array $responseBody,
+        \DateTimeImmutable $fetchedAt,
+        int $fetchDurationMs,
+        string $correlationId,
+        ?int $pageNumber = null,
+    ) {
+        Assert::uuid($companyId);
+        Assert::uuid($snapshotSessionId);
+        Assert::uuid($correlationId);
+
+        if ('' === trim($sourceEndpoint)) {
+            throw new \DomainException('sourceEndpoint must not be empty.');
+        }
+
+        if ($responseStatus <= 0) {
+            throw new \DomainException('responseStatus must be greater than 0.');
+        }
+
+        if ($fetchDurationMs < 0) {
+            throw new \DomainException('fetchDurationMs must be greater than or equal to 0.');
+        }
+
+        if ($pageNumber !== null && $pageNumber < 1) {
+            throw new \DomainException('pageNumber must be null or greater than or equal to 1.');
+        }
+
+        $this->id = Uuid::uuid7()->toString();
+        $this->companyId = $companyId;
+        $this->snapshotSessionId = $snapshotSessionId;
+        $this->source = $source;
+        $this->sourceEndpoint = $sourceEndpoint;
+        $this->requestParams = $requestParams;
+        $this->responseStatus = $responseStatus;
+        $this->responseBody = $responseBody;
+        $this->fetchedAt = $fetchedAt;
+        $this->fetchDurationMs = $fetchDurationMs;
+        $this->correlationId = $correlationId;
+        $this->pageNumber = $pageNumber;
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getCompanyId(): string
+    {
+        return $this->companyId;
+    }
+
+    public function getSnapshotSessionId(): string
+    {
+        return $this->snapshotSessionId;
+    }
+
+    public function getSource(): MarketplaceType
+    {
+        return $this->source;
+    }
+
+    public function getSourceEndpoint(): string
+    {
+        return $this->sourceEndpoint;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getRequestParams(): array
+    {
+        return $this->requestParams;
+    }
+
+    public function getResponseStatus(): int
+    {
+        return $this->responseStatus;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getResponseBody(): array
+    {
+        return $this->responseBody;
+    }
+
+    public function getPageNumber(): ?int
+    {
+        return $this->pageNumber;
+    }
+
+    public function getFetchedAt(): \DateTimeImmutable
+    {
+        return $this->fetchedAt;
+    }
+
+    public function getFetchDurationMs(): int
+    {
+        return $this->fetchDurationMs;
+    }
+
+    public function isProcessed(): bool
+    {
+        return $this->isProcessed;
+    }
+
+    public function getProcessedAt(): ?\DateTimeImmutable
+    {
+        return $this->processedAt;
+    }
+
+    public function getProcessingError(): ?string
+    {
+        return $this->processingError;
+    }
+
+    public function getCorrelationId(): string
+    {
+        return $this->correlationId;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function markAsProcessed(): void
+    {
+        $this->isProcessed = true;
+        $this->processedAt = new \DateTimeImmutable();
+        $this->processingError = null;
+    }
+
+    public function markAsFailed(string $processingError): void
+    {
+        Assert::notEmpty(trim($processingError));
+
+        $this->isProcessed = false;
+        $this->processedAt = null;
+        $this->processingError = $processingError;
+    }
+}

--- a/site/src/Inventory/Repository/InventoryRawSnapshotRepository.php
+++ b/site/src/Inventory/Repository/InventoryRawSnapshotRepository.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Inventory\Repository;
+
+use App\Inventory\Entity\InventoryRawSnapshot;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+final class InventoryRawSnapshotRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, InventoryRawSnapshot::class);
+    }
+}

--- a/site/tests/Builders/Inventory/InventoryRawSnapshotBuilder.php
+++ b/site/tests/Builders/Inventory/InventoryRawSnapshotBuilder.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Builders\Inventory;
+
+use App\Inventory\Entity\InventoryRawSnapshot;
+use App\Marketplace\Enum\MarketplaceType;
+
+final class InventoryRawSnapshotBuilder
+{
+    public const DEFAULT_COMPANY_ID = '11111111-1111-1111-1111-111111111111';
+    public const DEFAULT_SNAPSHOT_SESSION_ID = '22222222-2222-2222-2222-222222222222';
+    public const DEFAULT_CORRELATION_ID = '33333333-3333-7333-8333-333333333333';
+
+    private string $companyId = self::DEFAULT_COMPANY_ID;
+    private string $snapshotSessionId = self::DEFAULT_SNAPSHOT_SESSION_ID;
+    private MarketplaceType $source = MarketplaceType::WILDBERRIES;
+    private string $endpoint = '/api/v1/stocks';
+
+    /** @var array<string, mixed> */
+    private array $requestParams = ['limit' => 100, 'cursor' => null];
+
+    private int $responseStatus = 200;
+
+    /** @var array<string, mixed> */
+    private array $responseBody = ['items' => [['sku' => 'ABC-123', 'qty' => 10]]];
+
+    private \DateTimeImmutable $fetchedAt;
+    private int $fetchDurationMs = 120;
+    private string $correlationId = self::DEFAULT_CORRELATION_ID;
+    private ?int $pageNumber = 1;
+
+    private function __construct()
+    {
+        $this->fetchedAt = new \DateTimeImmutable('2026-04-20T10:00:00+00:00');
+    }
+
+    public static function aRawSnapshot(): self
+    {
+        return new self();
+    }
+
+    public function withCompanyId(string $companyId): self
+    {
+        $clone = clone $this;
+        $clone->companyId = $companyId;
+
+        return $clone;
+    }
+
+    public function withSnapshotSessionId(string $snapshotSessionId): self
+    {
+        $clone = clone $this;
+        $clone->snapshotSessionId = $snapshotSessionId;
+
+        return $clone;
+    }
+
+    public function withSource(MarketplaceType $source): self
+    {
+        $clone = clone $this;
+        $clone->source = $source;
+
+        return $clone;
+    }
+
+    public function withEndpoint(string $endpoint): self
+    {
+        $clone = clone $this;
+        $clone->endpoint = $endpoint;
+
+        return $clone;
+    }
+
+    /**
+     * @param array<string, mixed> $requestParams
+     */
+    public function withRequestParams(array $requestParams): self
+    {
+        $clone = clone $this;
+        $clone->requestParams = $requestParams;
+
+        return $clone;
+    }
+
+    public function withResponseStatus(int $responseStatus): self
+    {
+        $clone = clone $this;
+        $clone->responseStatus = $responseStatus;
+
+        return $clone;
+    }
+
+    /**
+     * @param array<string, mixed> $responseBody
+     */
+    public function withResponseBody(array $responseBody): self
+    {
+        $clone = clone $this;
+        $clone->responseBody = $responseBody;
+
+        return $clone;
+    }
+
+    public function withFetchedAt(\DateTimeImmutable $fetchedAt): self
+    {
+        $clone = clone $this;
+        $clone->fetchedAt = $fetchedAt;
+
+        return $clone;
+    }
+
+    public function withFetchDurationMs(int $fetchDurationMs): self
+    {
+        $clone = clone $this;
+        $clone->fetchDurationMs = $fetchDurationMs;
+
+        return $clone;
+    }
+
+    public function withCorrelationId(string $correlationId): self
+    {
+        $clone = clone $this;
+        $clone->correlationId = $correlationId;
+
+        return $clone;
+    }
+
+    public function withPageNumber(?int $pageNumber): self
+    {
+        $clone = clone $this;
+        $clone->pageNumber = $pageNumber;
+
+        return $clone;
+    }
+
+    public function build(): InventoryRawSnapshot
+    {
+        return new InventoryRawSnapshot(
+            companyId: $this->companyId,
+            snapshotSessionId: $this->snapshotSessionId,
+            source: $this->source,
+            sourceEndpoint: $this->endpoint,
+            requestParams: $this->requestParams,
+            responseStatus: $this->responseStatus,
+            responseBody: $this->responseBody,
+            fetchedAt: $this->fetchedAt,
+            fetchDurationMs: $this->fetchDurationMs,
+            correlationId: $this->correlationId,
+            pageNumber: $this->pageNumber,
+        );
+    }
+}

--- a/site/tests/Unit/Inventory/Entity/InventoryRawSnapshotTest.php
+++ b/site/tests/Unit/Inventory/Entity/InventoryRawSnapshotTest.php
@@ -82,7 +82,7 @@ final class InventoryRawSnapshotTest extends TestCase
         $snapshot->markAsFailed('Invalid schema in raw response payload');
 
         self::assertFalse($snapshot->isProcessed());
-        self::assertNull($snapshot->getProcessedAt());
+        self::assertInstanceOf(\DateTimeImmutable::class, $snapshot->getProcessedAt());
         self::assertSame('Invalid schema in raw response payload', $snapshot->getProcessingError());
     }
 
@@ -115,7 +115,7 @@ final class InventoryRawSnapshotTest extends TestCase
 
     public function testNegativeFetchDurationThrows(): void
     {
-        $this->expectException(\DomainException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         InventoryRawSnapshotBuilder::aRawSnapshot()
             ->withFetchDurationMs(-1)
@@ -124,7 +124,7 @@ final class InventoryRawSnapshotTest extends TestCase
 
     public function testPageNumberZeroThrows(): void
     {
-        $this->expectException(\DomainException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         InventoryRawSnapshotBuilder::aRawSnapshot()
             ->withPageNumber(0)

--- a/site/tests/Unit/Inventory/Entity/InventoryRawSnapshotTest.php
+++ b/site/tests/Unit/Inventory/Entity/InventoryRawSnapshotTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Inventory\Entity;
+
+use App\Inventory\Entity\InventoryRawSnapshot;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Inventory\InventoryRawSnapshotBuilder;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+final class InventoryRawSnapshotTest extends TestCase
+{
+    public function testIdIsGenerated(): void
+    {
+        $snapshot = InventoryRawSnapshotBuilder::aRawSnapshot()->build();
+
+        self::assertTrue(Uuid::isValid($snapshot->getId()));
+        self::assertSame(7, Uuid::fromString($snapshot->getId())->getFields()->getVersion());
+    }
+
+    public function testConstructorStoresAllRawFields(): void
+    {
+        $fetchedAt = new \DateTimeImmutable('2026-04-21T12:00:00+00:00');
+        $requestParams = ['cursor' => 'next-token', 'limit' => 500];
+        $responseBody = ['result' => [['sku' => 'SKU-001', 'quantity' => 15]]];
+
+        $snapshot = InventoryRawSnapshotBuilder::aRawSnapshot()
+            ->withCompanyId(InventoryRawSnapshotBuilder::DEFAULT_COMPANY_ID)
+            ->withSnapshotSessionId(InventoryRawSnapshotBuilder::DEFAULT_SNAPSHOT_SESSION_ID)
+            ->withSource(MarketplaceType::OZON)
+            ->withEndpoint('/v4/product/info/stocks')
+            ->withRequestParams($requestParams)
+            ->withResponseStatus(207)
+            ->withResponseBody($responseBody)
+            ->withPageNumber(3)
+            ->withFetchedAt($fetchedAt)
+            ->withFetchDurationMs(999)
+            ->withCorrelationId(InventoryRawSnapshotBuilder::DEFAULT_CORRELATION_ID)
+            ->build();
+
+        self::assertSame(InventoryRawSnapshotBuilder::DEFAULT_COMPANY_ID, $snapshot->getCompanyId());
+        self::assertSame(InventoryRawSnapshotBuilder::DEFAULT_SNAPSHOT_SESSION_ID, $snapshot->getSnapshotSessionId());
+        self::assertSame(MarketplaceType::OZON, $snapshot->getSource());
+        self::assertSame('/v4/product/info/stocks', $snapshot->getSourceEndpoint());
+        self::assertSame($requestParams, $snapshot->getRequestParams());
+        self::assertSame(207, $snapshot->getResponseStatus());
+        self::assertSame($responseBody, $snapshot->getResponseBody());
+        self::assertSame(3, $snapshot->getPageNumber());
+        self::assertSame($fetchedAt, $snapshot->getFetchedAt());
+        self::assertSame(999, $snapshot->getFetchDurationMs());
+        self::assertSame(InventoryRawSnapshotBuilder::DEFAULT_CORRELATION_ID, $snapshot->getCorrelationId());
+    }
+
+    public function testDefaultsAreInitialized(): void
+    {
+        $snapshot = InventoryRawSnapshotBuilder::aRawSnapshot()->build();
+
+        self::assertFalse($snapshot->isProcessed());
+        self::assertNull($snapshot->getProcessedAt());
+        self::assertNull($snapshot->getProcessingError());
+        self::assertInstanceOf(\DateTimeImmutable::class, $snapshot->getCreatedAt());
+    }
+
+    public function testMarkAsProcessedSetsFlagsAndTimestamp(): void
+    {
+        $snapshot = InventoryRawSnapshotBuilder::aRawSnapshot()->build();
+
+        $snapshot->markAsProcessed();
+
+        self::assertTrue($snapshot->isProcessed());
+        self::assertInstanceOf(\DateTimeImmutable::class, $snapshot->getProcessedAt());
+        self::assertNull($snapshot->getProcessingError());
+    }
+
+    public function testMarkAsFailedStoresProcessingError(): void
+    {
+        $snapshot = InventoryRawSnapshotBuilder::aRawSnapshot()->build();
+        $snapshot->markAsProcessed();
+
+        $snapshot->markAsFailed('Invalid schema in raw response payload');
+
+        self::assertFalse($snapshot->isProcessed());
+        self::assertNull($snapshot->getProcessedAt());
+        self::assertSame('Invalid schema in raw response payload', $snapshot->getProcessingError());
+    }
+
+    public function testInvalidCompanyIdThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        InventoryRawSnapshotBuilder::aRawSnapshot()
+            ->withCompanyId('not-a-uuid')
+            ->build();
+    }
+
+    public function testInvalidSnapshotSessionIdThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        InventoryRawSnapshotBuilder::aRawSnapshot()
+            ->withSnapshotSessionId('not-a-uuid')
+            ->build();
+    }
+
+    public function testInvalidCorrelationIdThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        InventoryRawSnapshotBuilder::aRawSnapshot()
+            ->withCorrelationId('not-a-uuid')
+            ->build();
+    }
+
+    public function testNegativeFetchDurationThrows(): void
+    {
+        $this->expectException(\DomainException::class);
+
+        InventoryRawSnapshotBuilder::aRawSnapshot()
+            ->withFetchDurationMs(-1)
+            ->build();
+    }
+
+    public function testPageNumberZeroThrows(): void
+    {
+        $this->expectException(\DomainException::class);
+
+        InventoryRawSnapshotBuilder::aRawSnapshot()
+            ->withPageNumber(0)
+            ->build();
+    }
+
+    public function testEntityHasNoPublicSettersForRawFields(): void
+    {
+        self::assertFalse(method_exists(InventoryRawSnapshot::class, 'setCompanyId'));
+        self::assertFalse(method_exists(InventoryRawSnapshot::class, 'setSnapshotSessionId'));
+        self::assertFalse(method_exists(InventoryRawSnapshot::class, 'setSource'));
+        self::assertFalse(method_exists(InventoryRawSnapshot::class, 'setSourceEndpoint'));
+        self::assertFalse(method_exists(InventoryRawSnapshot::class, 'setRequestParams'));
+        self::assertFalse(method_exists(InventoryRawSnapshot::class, 'setResponseStatus'));
+        self::assertFalse(method_exists(InventoryRawSnapshot::class, 'setResponseBody'));
+        self::assertFalse(method_exists(InventoryRawSnapshot::class, 'setFetchedAt'));
+        self::assertFalse(method_exists(InventoryRawSnapshot::class, 'setFetchDurationMs'));
+        self::assertFalse(method_exists(InventoryRawSnapshot::class, 'setCorrelationId'));
+        self::assertFalse(method_exists(InventoryRawSnapshot::class, 'setPageNumber'));
+    }
+}


### PR DESCRIPTION
### Motivation
- Нужна сущность для хранения «raw-first» ответов API маркетплейсов в слое Inventory как audit-log единиц данных. 
- Требуется обеспечить валидацию UUID и инварианты конструктора, а также ограничить изменяемость полей только guard-методами для корректного аудита.

### Description
- Добавлена Entity `App\Inventory\Entity\InventoryRawSnapshot` с таблицей `inventory_raw_snapshots`, UUID v7 `id`, полями `companyId`, `snapshotSessionId`, `source` (`MarketplaceType`), `sourceEndpoint`, `requestParams` (JSON), `responseStatus`, `responseBody` (JSON), `pageNumber`, `fetchedAt`, `fetchDurationMs`, `isProcessed`, `processedAt`, `processingError`, `correlationId`, `createdAt`, и с валидацией инвариантов в конструкторе (`sourceEndpoint` не пустой, `responseStatus > 0`, `fetchDurationMs >= 0`, `pageNumber null или >=1`).
- Добавлен репозиторий `App\Inventory\Repository\InventoryRawSnapshotRepository` как `ServiceEntityRepository` с конструктором и без кастомных методов.
- Добавлен тестовый билдер `App\Tests\Builders\Inventory\InventoryRawSnapshotBuilder` с `aRawSnapshot()` и набором `with*` методов для детерминированного создания сущностей в тестах.
- Добавлен unit-тест `App\Tests\Unit\Inventory\Entity\InventoryRawSnapshotTest`, покрывающий генерацию id, хранение полей, дефолты, `markAsProcessed()`, `markAsFailed()`, проверки на невалидные UUID, отрицательную длительность и `pageNumber=0`, а также отсутствие публичных сеттеров для raw-полей; поля `requestParams` и `responseBody` хранится как Doctrine JSON (без ручной сериализации).

### Testing
- Запуск `vendor/bin/phpunit tests/Unit/Inventory/Entity/InventoryRawSnapshotTest.php` был выполнен в окружении и не прошёл из-за отсутствия установленных зависимостей (`vendor`), поэтому тесты фактически не запущены.  
- Команды `php bin/console doctrine:mapping:info` и `php bin/console doctrine:schema:validate --skip-sync` были вызваны и не выполнились по той же причине (зависимости не установлены).  
- Локальные unit-файлы тестов добавлены и готовы к запуску в CI/локальном окружении при наличии `composer install` и установленного `phpunit`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f07596bc888323a98723fcc19fd42a)