### PR TITLE
Add StockSnapshot entity, repository, builder and unit tests

### DIFF
--- a/site/src/Inventory/Entity/StockSnapshot.php
+++ b/site/src/Inventory/Entity/StockSnapshot.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Inventory\Entity;
+
+use App\Inventory\Enum\StockStatus;
+use App\Inventory\Repository\StockSnapshotRepository;
+use App\Marketplace\Enum\MarketplaceType;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity(repositoryClass: StockSnapshotRepository::class)]
+#[ORM\Table(name: 'inventory_stock_snapshots')]
+#[ORM\Index(columns: ['company_id', 'snapshot_date'], name: 'idx_inventory_stock_snapshots_company_date')]
+#[ORM\Index(columns: ['company_id', 'snapshot_session_id'], name: 'idx_inventory_stock_snapshots_company_session')]
+#[ORM\Index(columns: ['company_id', 'location_id'], name: 'idx_inventory_stock_snapshots_company_location')]
+class StockSnapshot
+{
+    #[ORM\Id]
+    #[ORM\Column(type: Types::GUID, unique: true)]
+    private string $id;
+
+    #[ORM\Column(type: Types::GUID)]
+    private string $companyId;
+
+    #[ORM\Column(type: Types::GUID)]
+    private string $snapshotSessionId;
+
+    #[ORM\Column(type: Types::DATE_IMMUTABLE)]
+    private \DateTimeImmutable $snapshotDate;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $snapshotAt;
+
+    #[ORM\Column(type: Types::GUID, nullable: true)]
+    private ?string $listingId;
+
+    #[ORM\Column(type: Types::GUID, nullable: true)]
+    private ?string $productId;
+
+    #[ORM\Column(type: Types::GUID)]
+    private string $locationId;
+
+    #[ORM\Column(type: Types::STRING, length: 50, enumType: StockStatus::class)]
+    private StockStatus $status;
+
+    #[ORM\Column(type: Types::DECIMAL, precision: 14, scale: 3)]
+    private string $quantity;
+
+    #[ORM\Column(type: Types::STRING, length: 50, enumType: MarketplaceType::class)]
+    private MarketplaceType $source;
+
+    #[ORM\Column(type: Types::GUID)]
+    private string $rawSnapshotId;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $createdAt;
+
+    public function __construct(
+        string $companyId,
+        string $snapshotSessionId,
+        \DateTimeImmutable $snapshotDate,
+        \DateTimeImmutable $snapshotAt,
+        string $locationId,
+        StockStatus $status,
+        string $quantity,
+        MarketplaceType $source,
+        string $rawSnapshotId,
+        ?string $listingId = null,
+        ?string $productId = null,
+    ) {
+        Assert::uuid($companyId);
+        Assert::uuid($snapshotSessionId);
+        Assert::uuid($locationId);
+        Assert::uuid($rawSnapshotId);
+
+        if ($listingId !== null) {
+            Assert::uuid($listingId);
+        }
+
+        if ($productId !== null) {
+            Assert::uuid($productId);
+        }
+
+        $this->id = Uuid::uuid7()->toString();
+        $this->companyId = $companyId;
+        $this->snapshotSessionId = $snapshotSessionId;
+        $this->snapshotDate = $snapshotDate;
+        $this->snapshotAt = $snapshotAt;
+        $this->listingId = $listingId;
+        $this->productId = $productId;
+        $this->locationId = $locationId;
+        $this->status = $status;
+        $this->quantity = $quantity;
+        $this->source = $source;
+        $this->rawSnapshotId = $rawSnapshotId;
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getCompanyId(): string
+    {
+        return $this->companyId;
+    }
+
+    public function getSnapshotSessionId(): string
+    {
+        return $this->snapshotSessionId;
+    }
+
+    public function getSnapshotDate(): \DateTimeImmutable
+    {
+        return $this->snapshotDate;
+    }
+
+    public function getSnapshotAt(): \DateTimeImmutable
+    {
+        return $this->snapshotAt;
+    }
+
+    public function getListingId(): ?string
+    {
+        return $this->listingId;
+    }
+
+    public function getProductId(): ?string
+    {
+        return $this->productId;
+    }
+
+    public function getLocationId(): string
+    {
+        return $this->locationId;
+    }
+
+    public function getStatus(): StockStatus
+    {
+        return $this->status;
+    }
+
+    public function getQuantity(): string
+    {
+        return $this->quantity;
+    }
+
+    public function getSource(): MarketplaceType
+    {
+        return $this->source;
+    }
+
+    public function getRawSnapshotId(): string
+    {
+        return $this->rawSnapshotId;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/site/src/Inventory/Entity/StockSnapshot.php
+++ b/site/src/Inventory/Entity/StockSnapshot.php
@@ -76,6 +76,7 @@ class StockSnapshot
         Assert::uuid($snapshotSessionId);
         Assert::uuid($locationId);
         Assert::uuid($rawSnapshotId);
+        Assert::numeric($quantity);
 
         if ($listingId !== null) {
             Assert::uuid($listingId);
@@ -88,7 +89,7 @@ class StockSnapshot
         $this->id = Uuid::uuid7()->toString();
         $this->companyId = $companyId;
         $this->snapshotSessionId = $snapshotSessionId;
-        $this->snapshotDate = $snapshotDate;
+        $this->snapshotDate = $snapshotDate->setTime(0, 0, 0);
         $this->snapshotAt = $snapshotAt;
         $this->listingId = $listingId;
         $this->productId = $productId;

--- a/site/src/Inventory/Repository/StockSnapshotRepository.php
+++ b/site/src/Inventory/Repository/StockSnapshotRepository.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Inventory\Repository;
+
+use App\Inventory\Entity\StockSnapshot;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+final class StockSnapshotRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, StockSnapshot::class);
+    }
+}

--- a/site/tests/Builders/Inventory/StockSnapshotBuilder.php
+++ b/site/tests/Builders/Inventory/StockSnapshotBuilder.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Builders\Inventory;
+
+use App\Inventory\Entity\StockSnapshot;
+use App\Inventory\Enum\StockStatus;
+use App\Marketplace\Enum\MarketplaceType;
+
+final class StockSnapshotBuilder
+{
+    public const DEFAULT_COMPANY_ID = '11111111-1111-1111-1111-111111111111';
+    public const DEFAULT_SNAPSHOT_SESSION_ID = '22222222-2222-2222-2222-222222222222';
+    public const DEFAULT_LOCATION_ID = '33333333-3333-3333-3333-333333333333';
+    public const DEFAULT_RAW_SNAPSHOT_ID = '44444444-4444-4444-4444-444444444444';
+    public const DEFAULT_LISTING_ID = '55555555-5555-5555-5555-555555555555';
+    public const DEFAULT_PRODUCT_ID = '66666666-6666-6666-6666-666666666666';
+
+    private string $companyId = self::DEFAULT_COMPANY_ID;
+    private string $snapshotSessionId = self::DEFAULT_SNAPSHOT_SESSION_ID;
+    private \DateTimeImmutable $snapshotDate;
+    private \DateTimeImmutable $snapshotAt;
+    private ?string $listingId = self::DEFAULT_LISTING_ID;
+    private ?string $productId = self::DEFAULT_PRODUCT_ID;
+    private string $locationId = self::DEFAULT_LOCATION_ID;
+    private StockStatus $status = StockStatus::Available;
+    private string $quantity = '12.345';
+    private MarketplaceType $source = MarketplaceType::WILDBERRIES;
+    private string $rawSnapshotId = self::DEFAULT_RAW_SNAPSHOT_ID;
+
+    private function __construct()
+    {
+        $this->snapshotDate = new \DateTimeImmutable('2026-04-20');
+        $this->snapshotAt = new \DateTimeImmutable('2026-04-20T15:30:00+00:00');
+    }
+
+    public static function aStockSnapshot(): self
+    {
+        return new self();
+    }
+
+    public function withCompanyId(string $companyId): self
+    {
+        $clone = clone $this;
+        $clone->companyId = $companyId;
+
+        return $clone;
+    }
+
+    public function withSnapshotSessionId(string $snapshotSessionId): self
+    {
+        $clone = clone $this;
+        $clone->snapshotSessionId = $snapshotSessionId;
+
+        return $clone;
+    }
+
+    public function withSnapshotDate(\DateTimeImmutable $snapshotDate): self
+    {
+        $clone = clone $this;
+        $clone->snapshotDate = $snapshotDate;
+
+        return $clone;
+    }
+
+    public function withSnapshotAt(\DateTimeImmutable $snapshotAt): self
+    {
+        $clone = clone $this;
+        $clone->snapshotAt = $snapshotAt;
+
+        return $clone;
+    }
+
+    public function withListingId(?string $listingId): self
+    {
+        $clone = clone $this;
+        $clone->listingId = $listingId;
+
+        return $clone;
+    }
+
+    public function withProductId(?string $productId): self
+    {
+        $clone = clone $this;
+        $clone->productId = $productId;
+
+        return $clone;
+    }
+
+    public function withLocationId(string $locationId): self
+    {
+        $clone = clone $this;
+        $clone->locationId = $locationId;
+
+        return $clone;
+    }
+
+    public function withStatus(StockStatus $status): self
+    {
+        $clone = clone $this;
+        $clone->status = $status;
+
+        return $clone;
+    }
+
+    public function withQuantity(string $quantity): self
+    {
+        $clone = clone $this;
+        $clone->quantity = $quantity;
+
+        return $clone;
+    }
+
+    public function withSource(MarketplaceType $source): self
+    {
+        $clone = clone $this;
+        $clone->source = $source;
+
+        return $clone;
+    }
+
+    public function withRawSnapshotId(string $rawSnapshotId): self
+    {
+        $clone = clone $this;
+        $clone->rawSnapshotId = $rawSnapshotId;
+
+        return $clone;
+    }
+
+    public function build(): StockSnapshot
+    {
+        return new StockSnapshot(
+            companyId: $this->companyId,
+            snapshotSessionId: $this->snapshotSessionId,
+            snapshotDate: $this->snapshotDate,
+            snapshotAt: $this->snapshotAt,
+            locationId: $this->locationId,
+            status: $this->status,
+            quantity: $this->quantity,
+            source: $this->source,
+            rawSnapshotId: $this->rawSnapshotId,
+            listingId: $this->listingId,
+            productId: $this->productId,
+        );
+    }
+}

--- a/site/tests/Unit/Inventory/Entity/StockSnapshotTest.php
+++ b/site/tests/Unit/Inventory/Entity/StockSnapshotTest.php
@@ -23,7 +23,7 @@ final class StockSnapshotTest extends TestCase
 
     public function testConstructorStoresAllFields(): void
     {
-        $snapshotDate = new \DateTimeImmutable('2026-04-22');
+        $snapshotDate = new \DateTimeImmutable('2026-04-22T21:45:33+00:00');
         $snapshotAt = new \DateTimeImmutable('2026-04-22T12:15:00+00:00');
 
         $snapshot = StockSnapshotBuilder::aStockSnapshot()
@@ -42,7 +42,7 @@ final class StockSnapshotTest extends TestCase
 
         self::assertSame(StockSnapshotBuilder::DEFAULT_COMPANY_ID, $snapshot->getCompanyId());
         self::assertSame(StockSnapshotBuilder::DEFAULT_SNAPSHOT_SESSION_ID, $snapshot->getSnapshotSessionId());
-        self::assertSame($snapshotDate, $snapshot->getSnapshotDate());
+        self::assertSame('2026-04-22 00:00:00', $snapshot->getSnapshotDate()->format('Y-m-d H:i:s'));
         self::assertSame($snapshotAt, $snapshot->getSnapshotAt());
         self::assertSame(StockSnapshotBuilder::DEFAULT_LISTING_ID, $snapshot->getListingId());
         self::assertSame(StockSnapshotBuilder::DEFAULT_PRODUCT_ID, $snapshot->getProductId());
@@ -142,6 +142,15 @@ final class StockSnapshotTest extends TestCase
 
         StockSnapshotBuilder::aStockSnapshot()
             ->withRawSnapshotId('not-a-uuid')
+            ->build();
+    }
+
+    public function testInvalidQuantityThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        StockSnapshotBuilder::aStockSnapshot()
+            ->withQuantity('not-a-number')
             ->build();
     }
 }

--- a/site/tests/Unit/Inventory/Entity/StockSnapshotTest.php
+++ b/site/tests/Unit/Inventory/Entity/StockSnapshotTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Inventory\Entity;
+
+use App\Inventory\Entity\StockSnapshot;
+use App\Inventory\Enum\StockStatus;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Inventory\StockSnapshotBuilder;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+final class StockSnapshotTest extends TestCase
+{
+    public function testIdIsGenerated(): void
+    {
+        $snapshot = StockSnapshotBuilder::aStockSnapshot()->build();
+
+        self::assertTrue(Uuid::isValid($snapshot->getId()));
+        self::assertSame(7, Uuid::fromString($snapshot->getId())->getFields()->getVersion());
+    }
+
+    public function testConstructorStoresAllFields(): void
+    {
+        $snapshotDate = new \DateTimeImmutable('2026-04-22');
+        $snapshotAt = new \DateTimeImmutable('2026-04-22T12:15:00+00:00');
+
+        $snapshot = StockSnapshotBuilder::aStockSnapshot()
+            ->withCompanyId(StockSnapshotBuilder::DEFAULT_COMPANY_ID)
+            ->withSnapshotSessionId(StockSnapshotBuilder::DEFAULT_SNAPSHOT_SESSION_ID)
+            ->withSnapshotDate($snapshotDate)
+            ->withSnapshotAt($snapshotAt)
+            ->withListingId(StockSnapshotBuilder::DEFAULT_LISTING_ID)
+            ->withProductId(StockSnapshotBuilder::DEFAULT_PRODUCT_ID)
+            ->withLocationId(StockSnapshotBuilder::DEFAULT_LOCATION_ID)
+            ->withStatus(StockStatus::InTransitToCustomer)
+            ->withQuantity('9999.125')
+            ->withSource(MarketplaceType::OZON)
+            ->withRawSnapshotId(StockSnapshotBuilder::DEFAULT_RAW_SNAPSHOT_ID)
+            ->build();
+
+        self::assertSame(StockSnapshotBuilder::DEFAULT_COMPANY_ID, $snapshot->getCompanyId());
+        self::assertSame(StockSnapshotBuilder::DEFAULT_SNAPSHOT_SESSION_ID, $snapshot->getSnapshotSessionId());
+        self::assertSame($snapshotDate, $snapshot->getSnapshotDate());
+        self::assertSame($snapshotAt, $snapshot->getSnapshotAt());
+        self::assertSame(StockSnapshotBuilder::DEFAULT_LISTING_ID, $snapshot->getListingId());
+        self::assertSame(StockSnapshotBuilder::DEFAULT_PRODUCT_ID, $snapshot->getProductId());
+        self::assertSame(StockSnapshotBuilder::DEFAULT_LOCATION_ID, $snapshot->getLocationId());
+        self::assertSame(StockStatus::InTransitToCustomer, $snapshot->getStatus());
+        self::assertSame('9999.125', $snapshot->getQuantity());
+        self::assertSame(MarketplaceType::OZON, $snapshot->getSource());
+        self::assertSame(StockSnapshotBuilder::DEFAULT_RAW_SNAPSHOT_ID, $snapshot->getRawSnapshotId());
+    }
+
+    public function testListingIdCanBeNull(): void
+    {
+        $snapshot = StockSnapshotBuilder::aStockSnapshot()
+            ->withListingId(null)
+            ->build();
+
+        self::assertNull($snapshot->getListingId());
+    }
+
+    public function testProductIdCanBeNull(): void
+    {
+        $snapshot = StockSnapshotBuilder::aStockSnapshot()
+            ->withProductId(null)
+            ->build();
+
+        self::assertNull($snapshot->getProductId());
+    }
+
+    public function testCreatedAtIsInitialized(): void
+    {
+        $snapshot = StockSnapshotBuilder::aStockSnapshot()->build();
+
+        self::assertInstanceOf(\DateTimeImmutable::class, $snapshot->getCreatedAt());
+    }
+
+    public function testQuantityIsString(): void
+    {
+        $snapshot = StockSnapshotBuilder::aStockSnapshot()
+            ->withQuantity('100.500')
+            ->build();
+
+        self::assertIsString($snapshot->getQuantity());
+        self::assertSame('100.500', $snapshot->getQuantity());
+    }
+
+    public function testEntityHasNoPublicSetters(): void
+    {
+        $publicMethods = array_map(
+            static fn (\ReflectionMethod $method): string => $method->getName(),
+            (new \ReflectionClass(StockSnapshot::class))->getMethods(\ReflectionMethod::IS_PUBLIC),
+        );
+
+        foreach ($publicMethods as $method) {
+            self::assertStringStartsNotWith('set', $method);
+        }
+    }
+
+    public function testInvalidCompanyIdThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        StockSnapshotBuilder::aStockSnapshot()
+            ->withCompanyId('not-a-uuid')
+            ->build();
+    }
+
+    public function testInvalidListingIdThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        StockSnapshotBuilder::aStockSnapshot()
+            ->withListingId('not-a-uuid')
+            ->build();
+    }
+
+    public function testInvalidProductIdThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        StockSnapshotBuilder::aStockSnapshot()
+            ->withProductId('not-a-uuid')
+            ->build();
+    }
+
+    public function testInvalidLocationIdThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        StockSnapshotBuilder::aStockSnapshot()
+            ->withLocationId('not-a-uuid')
+            ->build();
+    }
+
+    public function testInvalidRawSnapshotIdThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        StockSnapshotBuilder::aStockSnapshot()
+            ->withRawSnapshotId('not-a-uuid')
+            ->build();
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce a normalized, immutable inventory snapshot entity to store per-date stock facts for marketplaces.
- Follow project architecture and PATTERNS rules: string UUIDs for cross-module references, `DateTimeImmutable`, no `ManyToOne` to other modules, and entity invariants in the constructor.

### Description
- Added `App\Inventory\Entity\StockSnapshot` mapped to table `inventory_stock_snapshots` with fields and types as specified, including `snapshotDate` as `Types::DATE_IMMUTABLE`, `snapshotAt` as `Types::DATETIME_IMMUTABLE`, and `quantity` as `DECIMAL(14,3)` stored in PHP as `string`.
- Validates UUIDs in constructor for `companyId`, `snapshotSessionId`, `locationId`, `rawSnapshotId`, and nullable `listingId` / `productId` via `Assert::uuid()` and generates `id` with `Uuid::uuid7()`; no setters are provided (entity is immutable).
- Added `App\Inventory\Repository\StockSnapshotRepository` as a final `ServiceEntityRepository` with only the constructor.
- Added `App\Tests\Builders\Inventory\StockSnapshotBuilder` and `App\Tests\Unit\Inventory\Entity\StockSnapshotTest` covering id generation, field storage, nullability, string quantity semantics, `createdAt`, absence of public setters, and UUID validation errors.

### Testing
- Attempted `vendor/bin/phpunit tests/Unit/Inventory/Entity/StockSnapshotTest.php`, but execution failed in the environment because dependencies are not installed (`vendor/bin/phpunit` not found); running the tests locally requires `composer install` first.
- Attempted `php bin/console doctrine:mapping:info` and `php bin/console doctrine:schema:validate --skip-sync`, both failed due to missing Composer dependencies (`composer install` required).
- Performed static checks (search/reflection) for forbidden patterns and setters and found no `ManyToOne` relations or public `set*` methods in the new `StockSnapshot` entity.
- Unit test file with assertions was added and is ready to run in a properly bootstrapped environment (run `cd site && composer install && vendor/bin/phpunit tests/Unit/Inventory/Entity/StockSnapshotTest.php`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f07e37411c832390ed2a200f0705c8)