### PR TITLE
Fix scheduler `waitid: no child processes` noise in cron container

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -351,7 +351,11 @@ services:
         container_name: scheduler
         user: root
         entrypoint: ["/usr/local/bin/supercronic"]
-        command: ["-json", "/etc/crontabs/app.cron"]
+        # supercronic v0.2.31 может логировать "waitid: no child processes"
+        # из-за race между встроенным reaper и основным wait-loop.
+        # Отключаем reaper, т.к. scheduler запускает только короткие php-команды
+        # и не нуждается в отдельной "подборке" orphan-процессов.
+        command: ["-no-reap", "-json", "/etc/crontabs/app.cron"]
         environment:
             TZ: Europe/Moscow
             DATABASE_URL: pgsql://app:${POSTGRES_PASSWORD}@site-postgres:5432/app

--- a/site/docker/production/php-cli/Dockerfile
+++ b/site/docker/production/php-cli/Dockerfile
@@ -61,8 +61,8 @@ COPY ./docker/common/wait-for-it.sh /usr/local/bin/wait-for-it
 RUN chmod 555 /usr/local/bin/wait-for-it
 
 # supercronic — запекаем в образ, чтобы scheduler не скачивал бинарник при каждом старте
-ENV SUPERCRONIC_VERSION="0.2.31" \
-    SUPERCRONIC_SHA1SUM="fb4242e9d28528a76b70d878dbf69fe8d94ba7d2"
+ENV SUPERCRONIC_VERSION="0.2.43" \
+    SUPERCRONIC_SHA1SUM="f97b92132b61a8f827c3faf67106dc0e4467ccf2"
 
 RUN wget -qO /usr/local/bin/supercronic \
         "https://github.com/aptible/supercronic/releases/download/v${SUPERCRONIC_VERSION}/supercronic-linux-amd64" \


### PR DESCRIPTION
### Motivation
- The scheduler container (PID 1) runs `supercronic` and produced noisy logs `error running command: waitid: no child processes` caused by a child-reaping race in `supercronic` v0.2.31. 
- The goal is to eliminate that log noise without changing application code by adjusting how `supercronic` is launched and upgrading the baked binary in the CLI image.

### Description
- Disabled the built-in reaper in the scheduler service by adding `-no-reap` to the `supercronic` command in `docker-compose.prod.yml`. 
- Upgraded the pinned `supercronic` binary in `site/docker/production/php-cli/Dockerfile` from `0.2.31` to `0.2.43` and updated the corresponding SHA1. 
- Changes committed to the repository so the production scheduler will run with the new flag and image after rebuild/deploy.

### Testing
- Attempted to validate the composed production config with `docker compose -f docker-compose.prod.yml config`, but the command could not run in this environment because `docker` is not installed (failed). 
- Local repository checks (`git diff`, file inspection) were performed and the changes were committed successfully; please run CI/build (image rebuild) and deploy to confirm `supercronic` logs no longer show `waitid: no child processes` in the target environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c2098ae883238127b9433dc042b1)