### PR TITLE
Block SALES_RETURNS close when sales/returns already processed

### DIFF
--- a/site/src/Marketplace/Application/MonthClosePreflightAction.php
+++ b/site/src/Marketplace/Application/MonthClosePreflightAction.php
@@ -113,6 +113,7 @@ final class MonthClosePreflightAction
         $salesStats       = $this->salesReturnsQuery->getSalesStats($command->companyId, $command->marketplace, $periodFrom, $periodTo);
         $salesTotal       = (int) $salesStats['total'];
         $salesWithoutCost = (int) $salesStats['without_cost'];
+        $salesAlreadyProcessed = (int) $salesStats['already_processed'];
 
         if ($salesTotal === 0) {
             $checks[] = PreflightCheck::warning('sales_count', 'Продажи за период', 'Нет продаж за выбранный период', $salesTotal);
@@ -129,9 +130,24 @@ final class MonthClosePreflightAction
             $checks[] = PreflightCheck::ok('sales_without_cost', 'Себестоимость продаж', sprintf('Все продажи имеют себестоимость (%d шт.)', $salesTotal), $salesTotal);
         }
 
+        if ($salesAlreadyProcessed > 0) {
+            $checks[] = PreflightCheck::error(
+                'sales_already_processed',
+                'Уже обработанные продажи',
+                sprintf(
+                    'Найдено %d продаж с document_id IS NOT NULL. Этап был переоткрыт некорректно или данные уже закрывались.',
+                    $salesAlreadyProcessed,
+                ),
+                $salesAlreadyProcessed,
+            );
+        } else {
+            $checks[] = PreflightCheck::ok('sales_already_processed', 'Уже обработанные продажи', 'Продажи готовы к обработке');
+        }
+
         $returnsStats       = $this->salesReturnsQuery->getReturnsStats($command->companyId, $command->marketplace, $periodFrom, $periodTo);
         $returnsTotal       = (int) $returnsStats['total'];
         $returnsWithoutCost = (int) $returnsStats['without_cost'];
+        $returnsAlreadyProcessed = (int) $returnsStats['already_processed'];
 
         if ($returnsTotal === 0) {
             $checks[] = PreflightCheck::ok('returns_without_cost', 'Себестоимость возвратов', 'Нет возвратов за период', 0);
@@ -146,6 +162,20 @@ final class MonthClosePreflightAction
             );
         } else {
             $checks[] = PreflightCheck::ok('returns_without_cost', 'Себестоимость возвратов', sprintf('Все возвраты имеют себестоимость (%d шт.)', $returnsTotal), $returnsTotal);
+        }
+
+        if ($returnsAlreadyProcessed > 0) {
+            $checks[] = PreflightCheck::error(
+                'returns_already_processed',
+                'Уже обработанные возвраты',
+                sprintf(
+                    'Найдено %d возвратов с document_id IS NOT NULL. Этап был переоткрыт некорректно или данные уже закрывались.',
+                    $returnsAlreadyProcessed,
+                ),
+                $returnsAlreadyProcessed,
+            );
+        } else {
+            $checks[] = PreflightCheck::ok('returns_already_processed', 'Уже обработанные возвраты', 'Возвраты готовы к обработке');
         }
 
         if ($command->marketplace === MarketplaceType::OZON->value) {

--- a/site/src/Marketplace/Application/MonthClosePreflightAction.php
+++ b/site/src/Marketplace/Application/MonthClosePreflightAction.php
@@ -135,7 +135,7 @@ final class MonthClosePreflightAction
                 'sales_already_processed',
                 'Уже обработанные продажи',
                 sprintf(
-                    'Найдено %d продаж с document_id IS NOT NULL. Этап был переоткрыт некорректно или данные уже закрывались.',
+                    'Найдено %d записей в sales_report с document_id IS NOT NULL. Этап не был переоткрыт корректно. Переоткройте этап и повторите.',
                     $salesAlreadyProcessed,
                 ),
                 $salesAlreadyProcessed,
@@ -169,7 +169,7 @@ final class MonthClosePreflightAction
                 'returns_already_processed',
                 'Уже обработанные возвраты',
                 sprintf(
-                    'Найдено %d возвратов с document_id IS NOT NULL. Этап был переоткрыт некорректно или данные уже закрывались.',
+                    'Найдено %d записей в sales_report с document_id IS NOT NULL. Этап не был переоткрыт корректно. Переоткройте этап и повторите.',
                     $returnsAlreadyProcessed,
                 ),
                 $returnsAlreadyProcessed,

--- a/site/tests/Integration/Marketplace/PreflightActionDetailsTest.php
+++ b/site/tests/Integration/Marketplace/PreflightActionDetailsTest.php
@@ -190,6 +190,79 @@ final class PreflightActionDetailsTest extends IntegrationTestCase
         self::assertTrue($orphanItems[0]['orphan']);
     }
 
+    public function testSalesAlreadyProcessedBlocksCloseAndCanCloseIsFalse(): void
+    {
+        $listing = $this->createListing('SKU-PROCESSED-SALE');
+        $sale    = $this->createSale($listing, costPrice: '100.00', date: '2026-03-10');
+        $this->em->flush();
+
+        $this->markRowAsProcessed('marketplace_sales', $sale->getId());
+
+        $result = ($this->action)($this->makeSalesCommand());
+        $check  = $this->findCheck($result->checks, 'sales_already_processed');
+
+        self::assertNotNull($check, 'Проверка sales_already_processed должна присутствовать');
+        self::assertFalse($check->passed);
+        self::assertTrue($check->blocking);
+        self::assertSame(1, (int) $check->value);
+        self::assertFalse($result->canClose(), 'canClose() должен быть false при blocking error');
+    }
+
+    public function testReturnsAlreadyProcessedBlocksCloseAndCanCloseIsFalse(): void
+    {
+        $listing = $this->createListing('SKU-PROCESSED-RETURN');
+        $return  = $this->createReturn($listing, costPrice: '120.00', date: '2026-03-10');
+        $this->em->flush();
+
+        $this->markRowAsProcessed('marketplace_returns', $return->getId());
+
+        $result = ($this->action)($this->makeSalesCommand());
+        $check  = $this->findCheck($result->checks, 'returns_already_processed');
+
+        self::assertNotNull($check, 'Проверка returns_already_processed должна присутствовать');
+        self::assertFalse($check->passed);
+        self::assertTrue($check->blocking);
+        self::assertSame(1, (int) $check->value);
+        self::assertFalse($result->canClose(), 'canClose() должен быть false при blocking error');
+    }
+
+    public function testAlreadyProcessedChecksAreOkWhenThereAreNoProcessedRows(): void
+    {
+        $listing = $this->createListing('SKU-NO-PROCESSED');
+        $this->createSale($listing, costPrice: '100.00', date: '2026-03-10');
+        $this->createReturn($listing, costPrice: '100.00', date: '2026-03-12');
+        $this->em->flush();
+
+        $result = ($this->action)($this->makeSalesCommand());
+
+        $salesCheck = $this->findCheck($result->checks, 'sales_already_processed');
+        self::assertNotNull($salesCheck);
+        self::assertTrue($salesCheck->passed);
+        self::assertFalse($salesCheck->blocking);
+
+        $returnsCheck = $this->findCheck($result->checks, 'returns_already_processed');
+        self::assertNotNull($returnsCheck);
+        self::assertTrue($returnsCheck->passed);
+        self::assertFalse($returnsCheck->blocking);
+    }
+
+    public function testWarningsDoNotBlockCanClose(): void
+    {
+        $result = ($this->action)($this->makeSalesCommand());
+
+        $salesCountCheck = $this->findCheck($result->checks, 'sales_count');
+        self::assertNotNull($salesCountCheck, 'Проверка sales_count должна присутствовать');
+        self::assertFalse($salesCountCheck->passed);
+        self::assertFalse($salesCountCheck->blocking);
+
+        $ozonCheck = $this->findCheck($result->checks, 'ozon_realization');
+        self::assertNotNull($ozonCheck, 'Проверка ozon_realization должна присутствовать');
+        self::assertFalse($ozonCheck->passed);
+        self::assertFalse($ozonCheck->blocking);
+
+        self::assertTrue($result->canClose(), 'warnings не должны блокировать canClose()');
+    }
+
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
@@ -315,5 +388,13 @@ final class PreflightActionDetailsTest extends IntegrationTestCase
         }
 
         return null;
+    }
+
+    private function markRowAsProcessed(string $table, string $id): void
+    {
+        $this->em->getConnection()->executeStatement(
+            sprintf('UPDATE %s SET document_id = :documentId WHERE id = :id', $table),
+            ['documentId' => Uuid::uuid4()->toString(), 'id' => $id],
+        );
     }
 }


### PR DESCRIPTION
### Motivation
- Предотвратить некорректное закрытие этапа `SALES_RETURNS`, когда часть продаж или возвратов уже связана с существующим `PLDocument` (имеет `document_id`).
- В предыдущей реализации агрегаты считали `already_processed`, но результат не использовался в `checkSalesReturns()`, что допускало закрытие с частично обработанными данными.

### Description
- В `site/src/Marketplace/Application/MonthClosePreflightAction.php` в методе `checkSalesReturns()` добавлен подсчёт `salesAlreadyProcessed` и `returnsAlreadyProcessed` из результатов `getSalesStats()` / `getReturnsStats()` и соответствующие проверки. 
- Для каждого из них добавлена блокирующая проверка: при значении `> 0` создаётся `PreflightCheck::error()` с ключами `sales_already_processed` и `returns_already_processed`, при `0` возвращается `PreflightCheck::ok()`.
- Логика предупреждений не изменялась: `sales_count` и `ozon_realization` остаются `warning` и не блокируют закрытие, а `PreflightResult::canClose()` не менялся и по-прежнему блокирует только на blocking errors.
- Добавлены интеграционные тесты в `site/tests/Integration/Marketplace/PreflightActionDetailsTest.php`, проверяющие блокировку при уже обработанных строках, успешный `ok` при нулевом счётчике и что ворнинги не блокируют `canClose()`.

### Testing
- Добавлены интеграционные тесты в `site/tests/Integration/Marketplace/PreflightActionDetailsTest.php` covering `sales_already_processed` и `returns_already_processed` scenarios (tests added). 
- Линтинг PHP синтаксиса выполнен с помощью `php -l` для изменённых файлов и завершился успешно. 
- Попытка запустить `phpunit` (`cd site && php -d memory_limit=1G bin/phpunit tests/Integration/Marketplace/PreflightActionDetailsTest.php`) не удалась из-за отсутствия `vendor/symfony/phpunit-bridge/bin/simple-phpunit.php` в окружении, поэтому интеграционные тесты не были выполнены в CI-подобном ранте здесь.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e5b92bfc83238da155a8ec4394f2)