### PR TITLE
Include preliminary-closed periods in month-close history

### DIFF
--- a/site/src/Marketplace/Controller/MonthCloseController.php
+++ b/site/src/Marketplace/Controller/MonthCloseController.php
@@ -56,28 +56,12 @@ final class MonthCloseController extends AbstractController
             $month,
         );
 
-        // История закрытий по маркетплейсу.
-        // Если оба этапа закрыты как «оперативное закрытие» — пока это
-        // не финальное закрытие месяца, и в истории такие записи не показываем.
-        $allHistory = $this->monthCloseRepository->findByCompanyAndMarketplace(
+        // История закрытий по маркетплейсу должна содержать все периоды,
+        // включая полностью оперативно закрытые (оба этапа preliminary).
+        $history = $this->monthCloseRepository->findByCompanyAndMarketplace(
             $companyId,
             $marketplaceType,
         );
-
-        $history = array_values(array_filter(
-            $allHistory,
-            static function ($mc): bool {
-                $bothClosed = $mc->getStageSalesReturnsStatus()->isClosed()
-                    && $mc->getStageCostsStatus()->isClosed();
-                // Скрываем только если ОБА этапа закрыты предварительно —
-                // частично-финальное закрытие (один этап final, другой prelim)
-                // должно остаться видимым в истории.
-                $bothPreliminary = $mc->isStageLastCloseWasPreliminary(CloseStage::SALES_RETURNS)
-                    && $mc->isStageLastCloseWasPreliminary(CloseStage::COSTS);
-
-                return !($bothClosed && $bothPreliminary);
-            },
-        ));
 
         $isCurrentMonth = $year === (int) date('Y') && $month === (int) date('n');
 

--- a/site/tests/Integration/Marketplace/MonthCloseHistoryControllerTest.php
+++ b/site/tests/Integration/Marketplace/MonthCloseHistoryControllerTest.php
@@ -10,6 +10,7 @@ use App\Marketplace\Enum\MarketplaceType;
 use App\Tests\Builders\Company\CompanyBuilder;
 use App\Tests\Builders\Company\UserBuilder;
 use App\Tests\Support\Kernel\WebTestCaseBase;
+use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -38,9 +39,11 @@ final class MonthCloseHistoryControllerTest extends WebTestCaseBase
             costsPreliminary: true,
         );
 
+        $historyYear = $currentYear - 1;
+
         $this->persistMonthClose(
             id: '33333333-3333-3333-3333-c00000000002',
-            year: 2026,
+            year: $historyYear,
             month: 2,
             salesClosed: true,
             costsClosed: true,
@@ -50,10 +53,20 @@ final class MonthCloseHistoryControllerTest extends WebTestCaseBase
 
         $this->persistMonthClose(
             id: '33333333-3333-3333-3333-c00000000003',
-            year: 2026,
+            year: $historyYear,
             month: 3,
             salesClosed: true,
             costsClosed: true,
+            salesPreliminary: true,
+            costsPreliminary: false,
+        );
+
+        $this->persistMonthClose(
+            id: '33333333-3333-3333-3333-c00000000004',
+            year: $historyYear,
+            month: 4,
+            salesClosed: true,
+            costsClosed: false,
             salesPreliminary: true,
             costsPreliminary: false,
         );
@@ -66,16 +79,35 @@ final class MonthCloseHistoryControllerTest extends WebTestCaseBase
 
         self::assertResponseStatusCodeSame(Response::HTTP_OK);
 
-        $html = (string) $client->getResponse()->getContent();
+        $crawler = new Crawler((string) $client->getResponse()->getContent());
 
-        self::assertStringContainsString(
-            sprintf('year=%d&amp;month=%d', $currentYear, $currentMonth),
-            $html,
-            'Текущий fully preliminary период должен оставаться в истории.',
+        $this->assertHistoryRowContains(
+            crawler: $crawler,
+            year: $currentYear,
+            month: $currentMonth,
+            fragments: ['Оперативное закрытие'],
         );
-        self::assertStringContainsString('year=2026&amp;month=2', $html);
-        self::assertStringContainsString('year=2026&amp;month=3', $html);
-        self::assertStringContainsString('Оперативное закрытие', $html);
+
+        $this->assertHistoryRowContains(
+            crawler: $crawler,
+            year: $historyYear,
+            month: 2,
+            fragments: ['Закрыт'],
+        );
+
+        $this->assertHistoryRowContains(
+            crawler: $crawler,
+            year: $historyYear,
+            month: 3,
+            fragments: ['Оперативное закрытие', 'Закрыт'],
+        );
+
+        $this->assertHistoryRowContains(
+            crawler: $crawler,
+            year: $historyYear,
+            month: 4,
+            fragments: ['Оперативное закрытие', 'Не закрыт'],
+        );
     }
 
     private function seedActiveSession(KernelBrowser $client): void
@@ -136,5 +168,32 @@ final class MonthCloseHistoryControllerTest extends WebTestCaseBase
 
         $this->em()->persist($monthClose);
         $this->em()->flush();
+    }
+
+    /**
+     * @param list<string> $fragments
+     */
+    private function assertHistoryRowContains(Crawler $crawler, int $year, int $month, array $fragments): void
+    {
+        $rows = $crawler->filter('table tbody tr')->reduce(
+            static function (Crawler $row) use ($year, $month): bool {
+                $link = $row->filter('a[href*="marketplace/month-close"]');
+                if ($link->count() === 0) {
+                    return false;
+                }
+
+                $href = (string) $link->attr('href');
+
+                return str_contains($href, sprintf('year=%d', $year))
+                    && str_contains($href, sprintf('month=%d', $month));
+            },
+        );
+
+        self::assertSame(1, $rows->count(), sprintf('Период %d-%02d должен присутствовать в истории.', $year, $month));
+
+        $rowText = $rows->text();
+        foreach ($fragments as $fragment) {
+            self::assertStringContainsString($fragment, $rowText);
+        }
     }
 }

--- a/site/tests/Integration/Marketplace/MonthCloseHistoryControllerTest.php
+++ b/site/tests/Integration/Marketplace/MonthCloseHistoryControllerTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Marketplace;
+
+use App\Marketplace\Entity\MarketplaceMonthClose;
+use App\Marketplace\Enum\CloseStage;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\Response;
+
+final class MonthCloseHistoryControllerTest extends WebTestCaseBase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-c00000000001';
+    private const OWNER_ID   = '22222222-2222-2222-2222-c00000000001';
+
+    public function testHistoryKeepsFullyPreliminaryFinalAndMixedPeriodsVisible(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $this->seedActiveSession($client);
+
+        $now = new \DateTimeImmutable('now');
+        $currentYear = (int) $now->format('Y');
+        $currentMonth = (int) $now->format('n');
+
+        $this->persistMonthClose(
+            id: '33333333-3333-3333-3333-c00000000001',
+            year: $currentYear,
+            month: $currentMonth,
+            salesClosed: true,
+            costsClosed: true,
+            salesPreliminary: true,
+            costsPreliminary: true,
+        );
+
+        $this->persistMonthClose(
+            id: '33333333-3333-3333-3333-c00000000002',
+            year: 2026,
+            month: 2,
+            salesClosed: true,
+            costsClosed: true,
+            salesPreliminary: false,
+            costsPreliminary: false,
+        );
+
+        $this->persistMonthClose(
+            id: '33333333-3333-3333-3333-c00000000003',
+            year: 2026,
+            month: 3,
+            salesClosed: true,
+            costsClosed: true,
+            salesPreliminary: true,
+            costsPreliminary: false,
+        );
+
+        $client->request('GET', sprintf(
+            '/marketplace/month-close?marketplace=ozon&year=%d&month=%d',
+            $currentYear,
+            $currentMonth,
+        ));
+
+        self::assertResponseStatusCodeSame(Response::HTTP_OK);
+
+        $html = (string) $client->getResponse()->getContent();
+
+        self::assertStringContainsString(
+            sprintf('year=%d&amp;month=%d', $currentYear, $currentMonth),
+            $html,
+            'Текущий fully preliminary период должен оставаться в истории.',
+        );
+        self::assertStringContainsString('year=2026&amp;month=2', $html);
+        self::assertStringContainsString('year=2026&amp;month=3', $html);
+        self::assertStringContainsString('Оперативное закрытие', $html);
+    }
+
+    private function seedActiveSession(KernelBrowser $client): void
+    {
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('month-close-history-owner@example.test')
+            ->build();
+
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        $client->loginUser($owner);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', self::COMPANY_ID);
+        $session->save();
+    }
+
+    private function persistMonthClose(
+        string $id,
+        int $year,
+        int $month,
+        bool $salesClosed,
+        bool $costsClosed,
+        bool $salesPreliminary,
+        bool $costsPreliminary,
+    ): void {
+        $monthClose = new MarketplaceMonthClose(
+            id: $id,
+            companyId: self::COMPANY_ID,
+            marketplace: MarketplaceType::OZON,
+            year: $year,
+            month: $month,
+        );
+
+        if ($salesClosed) {
+            $monthClose->closeStage(CloseStage::SALES_RETURNS, self::OWNER_ID, [], []);
+        }
+
+        if ($costsClosed) {
+            $monthClose->closeStage(CloseStage::COSTS, self::OWNER_ID, [], []);
+        }
+
+        $monthClose->setSettings([
+            'last_close_was_preliminary' => [
+                CloseStage::SALES_RETURNS->value => $salesPreliminary,
+                CloseStage::COSTS->value => $costsPreliminary,
+            ],
+        ]);
+
+        $this->em()->persist($monthClose);
+        $this->em()->flush();
+    }
+}


### PR DESCRIPTION
### Motivation
- The history view hid periods when both stages were closed as preliminary, causing the current month row to disappear from "История закрытий" despite the underlying `marketplace_month_closes` record and the top cards showing preliminary closure.

### Description
- Remove the filtering logic in `site/src/Marketplace/Controller/MonthCloseController.php::index()` and use the result of `findByCompanyAndMarketplace()` directly so fully preliminary periods remain visible in history.
- Add an integration regression test `site/tests/Integration/Marketplace/MonthCloseHistoryControllerTest.php` that verifies a fully preliminary period, a fully final period, a mixed preliminary/final period, and the currently selected month are present in the history page.
- Do not change any `close`/`reopen`/`preflight` business logic; the Twig template `site/templates/marketplace/month_close/index.html.twig` already displays the `Оперативное закрытие` badge via `isStageLastCloseWasPreliminary()` so no template changes were required.

### Testing
- Ran PHP syntax checks: `php -l site/src/Marketplace/Controller/MonthCloseController.php` and `php -l site/tests/Integration/Marketplace/MonthCloseHistoryControllerTest.php` which passed.
- Attempted to run the new integration test with `php bin/phpunit tests/Integration/Marketplace/MonthCloseHistoryControllerTest.php` but a full test run is blocked in this environment because `vendor/symfony/phpunit-bridge/bin/simple-phpunit.php` is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0ec37dcdc8323a38b6d2cf0072fb3)