### PR TITLE
Ensure markProcessed mirrors Unprocessed* filters and honors `preliminary` flag

### DIFF
--- a/site/src/Marketplace/Application/CloseMonthStageAction.php
+++ b/site/src/Marketplace/Application/CloseMonthStageAction.php
@@ -228,6 +228,7 @@ final class CloseMonthStageAction
                     $documentId,
                     $periodFrom,
                     $periodTo,
+                    $command->preliminary,
                 );
             }
 

--- a/site/src/Marketplace/Application/Source/CostsDataSource.php
+++ b/site/src/Marketplace/Application/Source/CostsDataSource.php
@@ -62,9 +62,10 @@ final class CostsDataSource implements MarketplaceDataSourceInterface
         string $documentId,
         string $periodFrom,
         string $periodTo,
+        bool $preliminary = false,
     ): int {
         return $this->markProcessedQuery->markCosts(
-            $companyId, $marketplace, $documentId, $periodFrom, $periodTo,
+            $companyId, $marketplace, $documentId, $periodFrom, $periodTo, $preliminary,
         );
     }
 }

--- a/site/src/Marketplace/Application/Source/MarketplaceDataSourceInterface.php
+++ b/site/src/Marketplace/Application/Source/MarketplaceDataSourceInterface.php
@@ -70,5 +70,6 @@ interface MarketplaceDataSourceInterface
         string $documentId,
         string $periodFrom,
         string $periodTo,
+        bool $preliminary = false,
     ): int;
 }

--- a/site/src/Marketplace/Application/Source/RealizationDataSource.php
+++ b/site/src/Marketplace/Application/Source/RealizationDataSource.php
@@ -66,7 +66,9 @@ final class RealizationDataSource implements MarketplaceDataSourceInterface
         string $documentId,
         string $periodFrom,
         string $periodTo,
+        bool $preliminary = false,
     ): int {
+        // preliminary не влияет на realization: маркировка идёт тем же диапазоном.
         return $this->realizationRepository->markProcessed(
             $companyId,
             $documentId,

--- a/site/src/Marketplace/Application/Source/RealizationReturnDataSource.php
+++ b/site/src/Marketplace/Application/Source/RealizationReturnDataSource.php
@@ -69,10 +69,12 @@ final class RealizationReturnDataSource implements MarketplaceDataSourceInterfac
         string $documentId,
         string $periodFrom,
         string $periodTo,
+        bool $preliminary = false,
     ): int {
         // Используем тот же markProcessed что и RealizationDataSource.
         // Фильтр WHERE pl_document_id IS NULL гарантирует что строки
         // не будут повторно помечены если SALE_REALIZATION отработал первым.
+        // preliminary не влияет на realization: поведение оставлено прежним.
         return $this->realizationRepository->markProcessed(
             $companyId,
             $documentId,

--- a/site/src/Marketplace/Application/Source/SalesReturnsDataSource.php
+++ b/site/src/Marketplace/Application/Source/SalesReturnsDataSource.php
@@ -71,13 +71,14 @@ final class SalesReturnsDataSource implements MarketplaceDataSourceInterface
         string $documentId,
         string $periodFrom,
         string $periodTo,
+        bool $preliminary = false,
     ): int {
         $count = $this->markProcessedQuery->markSales(
-            $companyId, $marketplace, $documentId, $periodFrom, $periodTo,
+            $companyId, $marketplace, $documentId, $periodFrom, $periodTo, $preliminary,
         );
 
         $count += $this->markProcessedQuery->markReturns(
-            $companyId, $marketplace, $documentId, $periodFrom, $periodTo,
+            $companyId, $marketplace, $documentId, $periodFrom, $periodTo, $preliminary,
         );
 
         return $count;

--- a/site/src/Marketplace/Infrastructure/Query/MarkProcessedQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/MarkProcessedQuery.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Marketplace\Infrastructure\Query;
 
+use App\Marketplace\Enum\AmountSource;
+use App\Marketplace\Enum\MarketplaceType;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 
@@ -34,6 +36,17 @@ final class MarkProcessedQuery
         string $periodTo,
         bool $preliminary = false,
     ): int {
+        $marketplaceEnum = MarketplaceType::from($marketplace);
+        $saleGrossExpr = AmountSource::SALE_GROSS->getSqlExpression($marketplaceEnum);
+        $amountCase = <<<SQL
+            CASE m.amount_source
+                WHEN 'sale_gross'      THEN $saleGrossExpr
+                WHEN 'sale_revenue'    THEN s.total_revenue
+                WHEN 'sale_cost_price' THEN COALESCE(s.cost_price, 0) * s.quantity
+                ELSE 0
+            END
+        SQL;
+
         $preliminaryFilter = $preliminary
             ? 'AND s.cost_price IS NOT NULL AND s.cost_price > 0'
             : '';
@@ -58,18 +71,7 @@ final class MarkProcessedQuery
                         AND m.marketplace = s.marketplace
                         AND m.operation_type = \'sale\'
                         AND m.is_active = true
-                        AND CASE m.amount_source
-                            WHEN \'sale_gross\' THEN (
-                                CASE
-                                    WHEN s.marketplace = \'ozon\' THEN COALESCE(s.price_per_unit, 0) * s.quantity
-                                    WHEN s.marketplace = \'wildberries\' THEN COALESCE(s.total_revenue, 0)
-                                    ELSE COALESCE(s.price_per_unit, 0) * s.quantity
-                                END
-                            )
-                            WHEN \'sale_revenue\' THEN COALESCE(s.total_revenue, 0)
-                            WHEN \'sale_cost_price\' THEN COALESCE(s.cost_price, 0) * s.quantity
-                            ELSE 0
-                        END != 0
+                        AND ' . $amountCase . ' != 0
                   )
              )',
             [

--- a/site/src/Marketplace/Infrastructure/Query/MarkProcessedQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/MarkProcessedQuery.php
@@ -32,16 +32,46 @@ final class MarkProcessedQuery
         string $documentId,
         string $periodFrom,
         string $periodTo,
+        bool $preliminary = false,
     ): int {
+        $preliminaryFilter = $preliminary
+            ? 'AND s.cost_price IS NOT NULL AND s.cost_price > 0'
+            : '';
+
         return $this->connection->executeStatement(
             'UPDATE marketplace_sales
              SET document_id = :documentId,
                  updated_at = NOW()
-             WHERE company_id = :companyId
-               AND marketplace = :marketplace
-               AND document_id IS NULL
-               AND sale_date >= :periodFrom
-               AND sale_date <= :periodTo',
+             WHERE id IN (
+                SELECT s.id
+                FROM marketplace_sales s
+                WHERE s.company_id = :companyId
+                  AND s.marketplace = :marketplace
+                  AND s.document_id IS NULL
+                  AND s.sale_date >= :periodFrom
+                  AND s.sale_date <= :periodTo
+                  ' . $preliminaryFilter . '
+                  AND EXISTS (
+                      SELECT 1
+                      FROM marketplace_sale_mappings m
+                      WHERE m.company_id = s.company_id
+                        AND m.marketplace = s.marketplace
+                        AND m.operation_type = \'sale\'
+                        AND m.is_active = true
+                        AND CASE m.amount_source
+                            WHEN \'sale_gross\' THEN (
+                                CASE
+                                    WHEN s.marketplace = \'ozon\' THEN COALESCE(s.price_per_unit, 0) * s.quantity
+                                    WHEN s.marketplace = \'wildberries\' THEN COALESCE(s.total_revenue, 0)
+                                    ELSE COALESCE(s.price_per_unit, 0) * s.quantity
+                                END
+                            )
+                            WHEN \'sale_revenue\' THEN COALESCE(s.total_revenue, 0)
+                            WHEN \'sale_cost_price\' THEN COALESCE(s.cost_price, 0) * s.quantity
+                            ELSE 0
+                        END != 0
+                  )
+             )',
             [
                 'documentId' => $documentId,
                 'companyId' => $companyId,
@@ -63,16 +93,43 @@ final class MarkProcessedQuery
         string $documentId,
         string $periodFrom,
         string $periodTo,
+        bool $preliminary = false,
     ): int {
+        $preliminaryFilter = $preliminary
+            ? 'AND r.cost_price IS NOT NULL AND r.cost_price > 0'
+            : '';
+
         return $this->connection->executeStatement(
             'UPDATE marketplace_returns
              SET document_id = :documentId,
                  updated_at = NOW()
-             WHERE company_id = :companyId
-               AND marketplace = :marketplace
-               AND document_id IS NULL
-               AND return_date >= :periodFrom
-               AND return_date <= :periodTo',
+             WHERE id IN (
+                SELECT r.id
+                FROM marketplace_returns r
+                LEFT JOIN marketplace_sales ms
+                    ON ms.id = r.sale_id
+                WHERE r.company_id = :companyId
+                  AND r.marketplace = :marketplace
+                  AND r.document_id IS NULL
+                  AND r.return_date >= :periodFrom
+                  AND r.return_date <= :periodTo
+                  ' . $preliminaryFilter . '
+                  AND EXISTS (
+                      SELECT 1
+                      FROM marketplace_sale_mappings m
+                      WHERE m.company_id = r.company_id
+                        AND m.marketplace = r.marketplace
+                        AND m.operation_type = \'return\'
+                        AND m.amount_source != \'return_realization\'
+                        AND m.is_active = true
+                        AND CASE m.amount_source
+                            WHEN \'return_refund\' THEN COALESCE(r.refund_amount, 0)
+                            WHEN \'return_gross\' THEN COALESCE(ms.price_per_unit * r.quantity, r.refund_amount, 0)
+                            WHEN \'return_cost_price\' THEN COALESCE(r.cost_price * r.quantity, 0)
+                            ELSE 0
+                        END != 0
+                  )
+             )',
             [
                 'documentId' => $documentId,
                 'companyId' => $companyId,
@@ -94,16 +151,57 @@ final class MarkProcessedQuery
         string $documentId,
         string $periodFrom,
         string $periodTo,
+        bool $preliminary = false,
     ): int {
+        $preliminaryFilter = $preliminary
+            ? "AND mcc2.code != 'ozon_other_service'"
+            : '';
+
         return $this->connection->executeStatement(
             'UPDATE marketplace_costs
              SET document_id = :documentId,
                  updated_at = NOW()
-             WHERE company_id = :companyId
-               AND marketplace = :marketplace
-               AND document_id IS NULL
-               AND cost_date >= :periodFrom
-               AND cost_date <= :periodTo',
+             WHERE id IN (
+                 SELECT c.id
+                 FROM marketplace_costs c
+                 INNER JOIN marketplace_cost_categories mcc
+                     ON mcc.id = c.category_id
+                 INNER JOIN marketplace_cost_pl_mappings m
+                     ON m.cost_category_id = c.category_id
+                     AND m.company_id = c.company_id
+                 WHERE c.company_id = :companyId
+                   AND c.marketplace = :marketplace
+                   AND c.document_id IS NULL
+                   AND c.cost_date >= :periodFrom
+                   AND c.cost_date <= :periodTo
+                   AND m.include_in_pl = true
+                   AND m.pl_category_id IS NOT NULL
+                   AND EXISTS (
+                       SELECT 1
+                       FROM marketplace_costs c2
+                       INNER JOIN marketplace_cost_categories mcc2
+                           ON mcc2.id = c2.category_id
+                       INNER JOIN marketplace_cost_pl_mappings m2
+                           ON m2.cost_category_id = c2.category_id
+                           AND m2.company_id = c2.company_id
+                       WHERE c2.company_id = c.company_id
+                         AND c2.marketplace = c.marketplace
+                         AND c2.document_id IS NULL
+                         AND c2.cost_date >= :periodFrom
+                         AND c2.cost_date <= :periodTo
+                         AND c2.category_id = c.category_id
+                         AND (c2.operation_type = \'storno\') = (c.operation_type = \'storno\')
+                         AND m2.include_in_pl = true
+                         AND m2.pl_category_id IS NOT NULL
+                         ' . $preliminaryFilter . '
+                       GROUP BY
+                           m2.pl_category_id,
+                           m2.sort_order,
+                           m2.is_negative,
+                           (c2.operation_type = \'storno\')
+                       HAVING ABS(SUM(c2.amount)) > 0.001
+                   )
+             )',
             [
                 'documentId' => $documentId,
                 'companyId' => $companyId,

--- a/site/tests/Integration/Marketplace/CloseMonthStageActionMarkProcessedScopeTest.php
+++ b/site/tests/Integration/Marketplace/CloseMonthStageActionMarkProcessedScopeTest.php
@@ -1,0 +1,313 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Marketplace;
+
+use App\Company\Entity\Company;
+use App\Finance\Entity\PLCategory;
+use App\Finance\Enum\PLFlow;
+use App\Marketplace\Application\CloseMonthStageAction;
+use App\Marketplace\Application\Command\CloseMonthStageCommand;
+use App\Marketplace\Entity\MarketplaceCost;
+use App\Marketplace\Entity\MarketplaceCostCategory;
+use App\Marketplace\Entity\MarketplaceCostPLMapping;
+use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Entity\MarketplaceReturn;
+use App\Marketplace\Entity\MarketplaceSale;
+use App\Marketplace\Entity\MarketplaceSaleMapping;
+use App\Marketplace\Enum\AmountSource;
+use App\Marketplace\Enum\CloseStage;
+use App\Marketplace\Enum\MarketplaceCostOperationType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class CloseMonthStageActionMarkProcessedScopeTest extends IntegrationTestCase
+{
+    private const COMPANY_ID = '31111111-1111-1111-1111-000000000123';
+    private const OWNER_ID = '32222222-2222-2222-2222-000000000123';
+    private const MARKETPLACE = MarketplaceType::OZON;
+    private const MARKETPLACE_VALUE = 'ozon';
+    private const YEAR = 2026;
+    private const MONTH = 2;
+
+    private Company $company;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('mark-processed-scope@example.test')
+            ->build();
+
+        $this->company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $this->em->persist($owner);
+        $this->em->persist($this->company);
+        $this->em->flush();
+    }
+
+    public function testCostsCloseMarksOnlyRowsIncludedIntoPlDocument(): void
+    {
+        $plCategory = $this->createPlCategory('Затраты mapped');
+
+        $includedCategory = $this->createCostCategory('cost_included', 'Included');
+        $withoutMappingCategory = $this->createCostCategory('cost_without_mapping', 'Without mapping');
+        $excludedCategory = $this->createCostCategory('cost_excluded', 'Excluded include_in_pl=false');
+
+        $this->createCostMapping($includedCategory, $plCategory->getId(), true);
+        $this->createCostMapping($excludedCategory, $plCategory->getId(), false);
+
+        $includedCost = $this->createCost($includedCategory, '100.00', '2026-02-10');
+        $withoutMappingCost = $this->createCost($withoutMappingCategory, '200.00', '2026-02-11');
+        $excludedCost = $this->createCost($excludedCategory, '300.00', '2026-02-12');
+
+        $this->em->flush();
+
+        $this->closeStage(CloseStage::COSTS, preliminary: false);
+
+        $this->assertMarked($includedCost->getId(), 'marketplace_costs', true);
+        $this->assertMarked($withoutMappingCost->getId(), 'marketplace_costs', false);
+        $this->assertMarked($excludedCost->getId(), 'marketplace_costs', false);
+    }
+
+    public function testCostsPreliminaryUsesSameFilterAsUnprocessedCostsQuery(): void
+    {
+        $plCategory = $this->createPlCategory('Затраты preliminary');
+
+        $includedCategory = $this->createCostCategory('ozon_logistic_direct', 'Logistics');
+        $preliminaryExcludedCategory = $this->createCostCategory('ozon_other_service', 'Other service');
+
+        $this->createCostMapping($includedCategory, $plCategory->getId(), true);
+        $this->createCostMapping($preliminaryExcludedCategory, $plCategory->getId(), true);
+
+        $includedCost = $this->createCost($includedCategory, '150.00', '2026-02-15');
+        $excludedCost = $this->createCost($preliminaryExcludedCategory, '250.00', '2026-02-16');
+
+        $this->em->flush();
+
+        $this->closeStage(CloseStage::COSTS, preliminary: true);
+
+        $this->assertMarked($includedCost->getId(), 'marketplace_costs', true);
+        $this->assertMarked($excludedCost->getId(), 'marketplace_costs', false);
+    }
+
+    public function testSalesPreliminaryDoesNotMarkRowsWithoutCostPrice(): void
+    {
+        $plCategory = $this->createPlCategory('Sale cost price');
+        $this->createSaleMapping($plCategory, AmountSource::SALE_GROSS);
+
+        $listing = $this->createListing('SKU-SALE-1');
+        $saleWithCost = $this->createSale($listing, '120.00', '2026-02-10', '600.00');
+        $saleWithoutCost = $this->createSale($listing, null, '2026-02-11', '700.00');
+
+        $this->em->flush();
+
+        $this->closeStage(CloseStage::SALES_RETURNS, preliminary: true);
+
+        $this->assertMarked($saleWithCost->getId(), 'marketplace_sales', true);
+        $this->assertMarked($saleWithoutCost->getId(), 'marketplace_sales', false);
+    }
+
+    public function testReturnsPreliminaryDoesNotMarkRowsWithoutCostPrice(): void
+    {
+        $plCategory = $this->createPlCategory('Return cost price');
+        $this->createSaleMapping($plCategory, AmountSource::RETURN_COST_PRICE);
+
+        $listing = $this->createListing('SKU-RET-1');
+        $returnWithCost = $this->createReturn($listing, '30.00', '2026-02-20', '100.00');
+        $returnWithoutCost = $this->createReturn($listing, null, '2026-02-21', '120.00');
+
+        $this->em->flush();
+
+        $this->closeStage(CloseStage::SALES_RETURNS, preliminary: true);
+
+        $this->assertMarked($returnWithCost->getId(), 'marketplace_returns', true);
+        $this->assertMarked($returnWithoutCost->getId(), 'marketplace_returns', false);
+    }
+
+    public function testFinalCloseWithValidDataStillMarksRowsAsProcessed(): void
+    {
+        $plCategory = $this->createPlCategory('Final close costs');
+        $category = $this->createCostCategory('final_close_cost', 'Final close cost');
+        $this->createCostMapping($category, $plCategory->getId(), true);
+
+        $costA = $this->createCost($category, '400.00', '2026-02-10');
+        $costB = $this->createCost($category, '600.00', '2026-02-12');
+
+        $this->em->flush();
+
+        $this->closeStage(CloseStage::COSTS, preliminary: false);
+
+        $this->assertMarked($costA->getId(), 'marketplace_costs', true);
+        $this->assertMarked($costB->getId(), 'marketplace_costs', true);
+    }
+
+    private function closeStage(CloseStage $stage, bool $preliminary): void
+    {
+        /** @var CloseMonthStageAction $action */
+        $action = self::getContainer()->get(CloseMonthStageAction::class);
+
+        ($action)(new CloseMonthStageCommand(
+            companyId: self::COMPANY_ID,
+            marketplace: self::MARKETPLACE_VALUE,
+            year: self::YEAR,
+            month: self::MONTH,
+            stage: $stage->value,
+            actorUserId: self::OWNER_ID,
+            preliminary: $preliminary,
+        ));
+
+        $this->em->clear();
+    }
+
+    private function createPlCategory(string $name): PLCategory
+    {
+        $plCategory = new PLCategory(Uuid::uuid4()->toString(), $this->company);
+        $plCategory->setName($name);
+        $plCategory->setFlow(PLFlow::EXPENSE);
+        $this->em->persist($plCategory);
+
+        return $plCategory;
+    }
+
+    private function createListing(string $sku): MarketplaceListing
+    {
+        $listing = new MarketplaceListing(
+            Uuid::uuid4()->toString(),
+            $this->company,
+            null,
+            self::MARKETPLACE,
+        );
+        $listing->setMarketplaceSku($sku);
+        $listing->setPrice('1000.00');
+        $this->em->persist($listing);
+
+        return $listing;
+    }
+
+    private function createSaleMapping(PLCategory $plCategory, AmountSource $amountSource): void
+    {
+        $mapping = new MarketplaceSaleMapping(
+            Uuid::uuid4()->toString(),
+            $this->company,
+            self::MARKETPLACE,
+            $amountSource,
+            $plCategory,
+        );
+        $this->em->persist($mapping);
+    }
+
+    private function createSale(
+        MarketplaceListing $listing,
+        ?string $costPrice,
+        string $saleDate,
+        string $totalRevenue,
+    ): MarketplaceSale {
+        $sale = new MarketplaceSale(
+            Uuid::uuid4()->toString(),
+            $this->company,
+            $listing,
+            self::MARKETPLACE,
+        );
+        $sale->setExternalOrderId('sale-' . Uuid::uuid4()->toString());
+        $sale->setSaleDate(new \DateTimeImmutable($saleDate));
+        $sale->setQuantity(1);
+        $sale->setPricePerUnit($totalRevenue);
+        $sale->setTotalRevenue($totalRevenue);
+        $sale->setCostPrice($costPrice);
+        $this->em->persist($sale);
+
+        return $sale;
+    }
+
+    private function createReturn(
+        MarketplaceListing $listing,
+        ?string $costPrice,
+        string $returnDate,
+        string $refundAmount,
+    ): MarketplaceReturn {
+        $return = new MarketplaceReturn(
+            Uuid::uuid4()->toString(),
+            $this->company,
+            $listing,
+            self::MARKETPLACE,
+        );
+        $return->setExternalReturnId('return-' . Uuid::uuid4()->toString());
+        $return->setReturnDate(new \DateTimeImmutable($returnDate));
+        $return->setQuantity(1);
+        $return->setRefundAmount($refundAmount);
+        $return->setCostPrice($costPrice);
+        $this->em->persist($return);
+
+        return $return;
+    }
+
+    private function createCostCategory(string $code, string $name): MarketplaceCostCategory
+    {
+        $category = new MarketplaceCostCategory(
+            Uuid::uuid4()->toString(),
+            $this->company,
+            self::MARKETPLACE,
+        );
+        $category->setCode($code);
+        $category->setName($name);
+        $this->em->persist($category);
+
+        return $category;
+    }
+
+    private function createCostMapping(MarketplaceCostCategory $category, ?string $plCategoryId, bool $includeInPl): void
+    {
+        $mapping = new MarketplaceCostPLMapping(
+            Uuid::uuid4()->toString(),
+            self::COMPANY_ID,
+            $category,
+            $plCategoryId,
+            $includeInPl,
+        );
+        $this->em->persist($mapping);
+    }
+
+    private function createCost(MarketplaceCostCategory $category, string $amount, string $costDate): MarketplaceCost
+    {
+        $cost = new MarketplaceCost(
+            Uuid::uuid4()->toString(),
+            $this->company,
+            self::MARKETPLACE,
+            $category,
+        );
+        $cost->setAmount($amount);
+        $cost->setCostDate(new \DateTimeImmutable($costDate));
+        $cost->setOperationType(MarketplaceCostOperationType::CHARGE);
+        $cost->setExternalId('cost-' . Uuid::uuid4()->toString());
+        $this->em->persist($cost);
+
+        return $cost;
+    }
+
+    private function assertMarked(string $id, string $table, bool $expectedMarked): void
+    {
+        $documentId = $this->em->getConnection()->fetchOne(
+            sprintf('SELECT document_id FROM %s WHERE id = :id', $table),
+            ['id' => $id],
+        );
+
+        if ($expectedMarked) {
+            self::assertNotFalse($documentId);
+            self::assertNotNull($documentId);
+
+            return;
+        }
+
+        self::assertNull($documentId);
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent marking marketplace rows as processed if they were not included into the PLDocument (due to missing PL-mapping, `include_in_pl = false`, `pl_category_id IS NULL`, `preliminary` filtering, inactive mappings or other Unprocessed*Query filters).

### Description
- Extended `MarketplaceDataSourceInterface::markProcessed(...)` to accept `bool $preliminary = false` so marking can use the same mode-dependent filters as selection.
- Updated all `MarketplaceDataSourceInterface` implementations (`SalesReturnsDataSource`, `CostsDataSource`, `RealizationDataSource`, `RealizationReturnDataSource`) to accept/forward the new argument and documented that `realization` sources are unaffected by `preliminary`.  
- Changed `CloseMonthStageAction` to pass ` $command->preliminary` into each data source `markProcessed(...)` call so marking runs in the same mode as entry collection.  
- Reworked `MarkProcessedQuery` so `markSales(...)`, `markReturns(...)` and `markCosts(...)` mirror the business filters used by `UnprocessedSalesQuery`, `UnprocessedReturnsQuery` and `UnprocessedCostsQuery` respectively: each method now applies company/marketplace/period/document guards, the `preliminary` filters (sales/returns cost_price check, costs `ozon_other_service` exclusion), requires active mappings (and excludes `return_realization`), checks for non-zero mapping contribution (per-amount_source CASE), and for costs uses a correlated `EXISTS/GROUP BY/HAVING ABS(SUM(...)) > 0.001` to preserve group-level symmetry and avoid marking groups that didn't contribute to the PLDocument.  
- Added integration regression tests `tests/Integration/Marketplace/CloseMonthStageActionMarkProcessedScopeTest.php` covering costs/sales/returns scenarios for final and preliminary modes (ensures only entries that would be selected by Unprocessed*Query are marked). 

### Testing
- Ran PHP lint (`php -l`) against modified sources and the new test file: all lint checks passed.  
- Created and executed a local quick syntax check for `MarkProcessedQuery` and the new integration test file: no syntax errors.  
- Tried to run the new integration test with the project test runner, but `simple-phpunit.php` from `vendor/symfony/phpunit-bridge` was not available in the execution environment so full `phpunit` integration run could not be executed here; the test file is added and ready for CI where the full test harness will run it.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f88758b88323b94961ff14ef61ea)