### PR TITLE
Add default marketplace cost mapping YAML, provider, DTOs and tests

### DIFF
--- a/site/config/marketplace/default_cost_mapping.yaml
+++ b/site/config/marketplace/default_cost_mapping.yaml
@@ -1,0 +1,72 @@
+version: 1
+marketplaces:
+  ozon:
+    cost_mappings:
+      - cost_code: ozon_sale_commission
+        pl_code: COGS_MP_COMMISSION
+        include_in_pl: true
+        is_negative: true
+        confidence: high
+        note: "Комиссия Ozon за продажу"
+      - cost_code: ozon_logistic_direct
+        pl_code: COGS_DELIVERY
+        include_in_pl: true
+      - cost_code: ozon_logistic_last_mile
+        pl_code: COGS_DELIVERY
+        include_in_pl: true
+      - cost_code: ozon_logistic_return
+        pl_code: COGS_RETURNS_DELIVERY
+        include_in_pl: true
+      - cost_code: ozon_acquiring
+        pl_code: COGS_ACQUIRING
+        include_in_pl: true
+      - cost_code: ozon_return_pvz
+        pl_code: COGS_RETURNS_DELIVERY
+        include_in_pl: true
+      - cost_code: ozon_storage
+        pl_code: OPEX_WH_STORAGE
+        include_in_pl: true
+      - cost_code: ozon_storage_partner
+        pl_code: OPEX_WH_STORAGE
+        include_in_pl: true
+      - cost_code: ozon_logistic_pickup
+        pl_code: COGS_DELIVERY
+        include_in_pl: true
+      - cost_code: ozon_package_labor
+        pl_code: OPEX_WH_MP_DEDUCTIONS
+        include_in_pl: true
+        confidence: medium
+        note: "Маппинг требует бизнес-подтверждения"
+      - cost_code: ozon_package_materials
+        pl_code: OPEX_WH_MP_DEDUCTIONS
+        include_in_pl: true
+        confidence: medium
+        note: "Маппинг требует бизнес-подтверждения"
+      - cost_code: ozon_cpc
+        pl_code: PROMO_INTERNAL
+        include_in_pl: true
+      - cost_code: ozon_delivery_to_handover_place
+        pl_code: COGS_DELIVERY
+        include_in_pl: true
+      - cost_code: ozon_supply_additional
+        pl_code: OPEX_WH_RECEIVING
+        include_in_pl: true
+      - cost_code: ozon_crossdocking
+        pl_code: OPEX_WH_RECEIVING
+        include_in_pl: true
+      - cost_code: ozon_early_payment
+        pl_code: OVERHEAD_ADMIN_BANK
+        include_in_pl: true
+        confidence: low
+        note: "Гипотеза до финальной сверки с фин.методологией"
+      - cost_code: ozon_return_from_stock
+        pl_code: OPEX_WH_MP_DEDUCTIONS
+        include_in_pl: true
+      - cost_code: ozon_supply_shortage
+        pl_code: OPEX_WH_MP_DEDUCTIONS
+        include_in_pl: true
+        confidence: low
+        note: "Гипотеза до финальной сверки с фин.методологией"
+
+  wildberries:
+    cost_mappings: []

--- a/site/src/Marketplace/Application/DTO/DefaultCostMappingRule.php
+++ b/site/src/Marketplace/Application/DTO/DefaultCostMappingRule.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\DTO;
+
+use App\Marketplace\Enum\MarketplaceType;
+
+final readonly class DefaultCostMappingRule
+{
+    public function __construct(
+        private MarketplaceType $marketplace,
+        private string $costCode,
+        private string $plCode,
+        private bool $includeInPl,
+        private bool $isNegative,
+        private string $confidence,
+        private ?string $note,
+    ) {}
+
+    public function getMarketplace(): MarketplaceType
+    {
+        return $this->marketplace;
+    }
+
+    public function getCostCode(): string
+    {
+        return $this->costCode;
+    }
+
+    public function getPlCode(): string
+    {
+        return $this->plCode;
+    }
+
+    public function isIncludeInPl(): bool
+    {
+        return $this->includeInPl;
+    }
+
+    public function isNegative(): bool
+    {
+        return $this->isNegative;
+    }
+
+    public function getConfidence(): string
+    {
+        return $this->confidence;
+    }
+
+    public function getNote(): ?string
+    {
+        return $this->note;
+    }
+}

--- a/site/src/Marketplace/Application/DTO/DefaultCostMappingRule.php
+++ b/site/src/Marketplace/Application/DTO/DefaultCostMappingRule.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Marketplace\Application\DTO;
 
+use App\Marketplace\Enum\DefaultCostMappingConfidence;
 use App\Marketplace\Enum\MarketplaceType;
 
 final readonly class DefaultCostMappingRule
@@ -14,7 +15,7 @@ final readonly class DefaultCostMappingRule
         private string $plCode,
         private bool $includeInPl,
         private bool $isNegative,
-        private string $confidence,
+        private DefaultCostMappingConfidence $confidence,
         private ?string $note,
     ) {}
 
@@ -43,7 +44,7 @@ final readonly class DefaultCostMappingRule
         return $this->isNegative;
     }
 
-    public function getConfidence(): string
+    public function getConfidence(): DefaultCostMappingConfidence
     {
         return $this->confidence;
     }

--- a/site/src/Marketplace/Application/DTO/DefaultCostMappingRuleSet.php
+++ b/site/src/Marketplace/Application/DTO/DefaultCostMappingRuleSet.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\DTO;
+
+use App\Marketplace\Enum\MarketplaceType;
+
+final readonly class DefaultCostMappingRuleSet
+{
+    /** @var array<string, DefaultCostMappingRule> */
+    private array $rulesByCostCode;
+
+    /** @param DefaultCostMappingRule[] $rules */
+    public function __construct(
+        private MarketplaceType $marketplace,
+        array $rules,
+    ) {
+        $this->rulesByCostCode = [];
+
+        foreach ($rules as $rule) {
+            $this->rulesByCostCode[$rule->getCostCode()] = $rule;
+        }
+    }
+
+    public function getMarketplace(): MarketplaceType
+    {
+        return $this->marketplace;
+    }
+
+    /** @return DefaultCostMappingRule[] */
+    public function getRules(): array
+    {
+        return array_values($this->rulesByCostCode);
+    }
+
+    public function count(): int
+    {
+        return count($this->rulesByCostCode);
+    }
+
+    public function getByCostCode(string $costCode): ?DefaultCostMappingRule
+    {
+        return $this->rulesByCostCode[$costCode] ?? null;
+    }
+}

--- a/site/src/Marketplace/Application/Exception/DefaultCostMappingConfigException.php
+++ b/site/src/Marketplace/Application/Exception/DefaultCostMappingConfigException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\Exception;
+
+final class DefaultCostMappingConfigException extends \RuntimeException
+{
+}

--- a/site/src/Marketplace/Enum/DefaultCostMappingConfidence.php
+++ b/site/src/Marketplace/Enum/DefaultCostMappingConfidence.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Enum;
+
+enum DefaultCostMappingConfidence: string
+{
+    case HIGH = 'high';
+    case MEDIUM = 'medium';
+    case LOW = 'low';
+}

--- a/site/src/Marketplace/Infrastructure/Provider/DefaultCostMappingYamlProvider.php
+++ b/site/src/Marketplace/Infrastructure/Provider/DefaultCostMappingYamlProvider.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Provider;
+
+use App\Marketplace\Application\DTO\DefaultCostMappingRule;
+use App\Marketplace\Application\DTO\DefaultCostMappingRuleSet;
+use App\Marketplace\Application\Exception\DefaultCostMappingConfigException;
+use App\Marketplace\Enum\MarketplaceType;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+final class DefaultCostMappingYamlProvider
+{
+    private const SUPPORTED_VERSION = 1;
+    private const ALLOWED_CONFIDENCE = ['high', 'medium', 'low'];
+
+    /** @var array<string, DefaultCostMappingRuleSet>|null */
+    private ?array $cachedRuleSets = null;
+
+    public function __construct(private readonly string $configPath)
+    {
+    }
+
+    public function getForMarketplace(MarketplaceType $marketplace): DefaultCostMappingRuleSet
+    {
+        $all = $this->getAll();
+
+        return $all[$marketplace->value] ?? new DefaultCostMappingRuleSet($marketplace, []);
+    }
+
+    /** @return array<string, DefaultCostMappingRuleSet> */
+    public function getAll(): array
+    {
+        if ($this->cachedRuleSets !== null) {
+            return $this->cachedRuleSets;
+        }
+
+        $this->cachedRuleSets = $this->loadRuleSets();
+
+        return $this->cachedRuleSets;
+    }
+
+    /** @return array<string, DefaultCostMappingRuleSet> */
+    private function loadRuleSets(): array
+    {
+        if (!is_file($this->configPath)) {
+            throw new DefaultCostMappingConfigException(sprintf('Default cost mapping config file not found: %s', $this->configPath));
+        }
+
+        try {
+            $data = Yaml::parseFile($this->configPath);
+        } catch (ParseException $exception) {
+            throw new DefaultCostMappingConfigException(
+                sprintf('Failed to parse YAML config: %s', $exception->getMessage()),
+                previous: $exception,
+            );
+        }
+
+        if (!is_array($data)) {
+            throw new DefaultCostMappingConfigException('Default cost mapping YAML root must be an array.');
+        }
+
+        if (($data['version'] ?? null) !== self::SUPPORTED_VERSION) {
+            throw new DefaultCostMappingConfigException('Unsupported default cost mapping version. Expected version: 1.');
+        }
+
+        if (!isset($data['marketplaces']) || !is_array($data['marketplaces'])) {
+            throw new DefaultCostMappingConfigException('Missing or invalid "marketplaces" section in default cost mapping config.');
+        }
+
+        $result = [];
+        foreach ($data['marketplaces'] as $marketplaceKey => $marketplaceConfig) {
+            $marketplace = MarketplaceType::tryFrom((string) $marketplaceKey);
+            if ($marketplace === null) {
+                throw new DefaultCostMappingConfigException(sprintf('Unknown marketplace "%s" in default cost mapping config.', (string) $marketplaceKey));
+            }
+
+            if (!is_array($marketplaceConfig)) {
+                throw new DefaultCostMappingConfigException(sprintf('Marketplace "%s" config must be an array.', $marketplace->value));
+            }
+
+            $costMappings = $marketplaceConfig['cost_mappings'] ?? null;
+            if (!is_array($costMappings)) {
+                throw new DefaultCostMappingConfigException(sprintf('Marketplace "%s" must contain array "cost_mappings".', $marketplace->value));
+            }
+
+            $rules = [];
+            $seenCostCodes = [];
+            foreach ($costMappings as $index => $rawRule) {
+                if (!is_array($rawRule)) {
+                    throw new DefaultCostMappingConfigException(sprintf('Rule #%d in marketplace "%s" must be an array.', $index, $marketplace->value));
+                }
+
+                $costCode = $this->requireNonEmptyString($rawRule, 'cost_code', $marketplace->value, $index);
+                $plCode = $this->requireNonEmptyString($rawRule, 'pl_code', $marketplace->value, $index);
+
+                if (!array_key_exists('include_in_pl', $rawRule) || !is_bool($rawRule['include_in_pl'])) {
+                    throw new DefaultCostMappingConfigException(sprintf('Rule #%d in marketplace "%s" must contain boolean "include_in_pl".', $index, $marketplace->value));
+                }
+
+                if (isset($seenCostCodes[$costCode])) {
+                    throw new DefaultCostMappingConfigException(sprintf('Duplicate cost_code "%s" in marketplace "%s".', $costCode, $marketplace->value));
+                }
+                $seenCostCodes[$costCode] = true;
+
+                $isNegative = $rawRule['is_negative'] ?? true;
+                if (!is_bool($isNegative)) {
+                    throw new DefaultCostMappingConfigException(sprintf('Rule #%d in marketplace "%s" has invalid "is_negative" value.', $index, $marketplace->value));
+                }
+
+                $confidence = $rawRule['confidence'] ?? 'high';
+                if (!is_string($confidence) || !in_array($confidence, self::ALLOWED_CONFIDENCE, true)) {
+                    throw new DefaultCostMappingConfigException(sprintf('Rule #%d in marketplace "%s" has invalid confidence "%s".', $index, $marketplace->value, (string) $confidence));
+                }
+
+                $note = $rawRule['note'] ?? null;
+                if ($note !== null && !is_string($note)) {
+                    throw new DefaultCostMappingConfigException(sprintf('Rule #%d in marketplace "%s" has invalid "note" value.', $index, $marketplace->value));
+                }
+
+                $rules[] = new DefaultCostMappingRule(
+                    marketplace: $marketplace,
+                    costCode: $costCode,
+                    plCode: $plCode,
+                    includeInPl: $rawRule['include_in_pl'],
+                    isNegative: $isNegative,
+                    confidence: $confidence,
+                    note: $note,
+                );
+            }
+
+            $result[$marketplace->value] = new DefaultCostMappingRuleSet($marketplace, $rules);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array<string, mixed> $rawRule
+     */
+    private function requireNonEmptyString(array $rawRule, string $field, string $marketplace, int $index): string
+    {
+        $value = $rawRule[$field] ?? null;
+        if (!is_string($value) || trim($value) === '') {
+            throw new DefaultCostMappingConfigException(sprintf('Rule #%d in marketplace "%s" must contain non-empty string "%s".', $index, $marketplace, $field));
+        }
+
+        return trim($value);
+    }
+}

--- a/site/src/Marketplace/Infrastructure/Provider/DefaultCostMappingYamlProvider.php
+++ b/site/src/Marketplace/Infrastructure/Provider/DefaultCostMappingYamlProvider.php
@@ -7,6 +7,7 @@ namespace App\Marketplace\Infrastructure\Provider;
 use App\Marketplace\Application\DTO\DefaultCostMappingRule;
 use App\Marketplace\Application\DTO\DefaultCostMappingRuleSet;
 use App\Marketplace\Application\Exception\DefaultCostMappingConfigException;
+use App\Marketplace\Enum\DefaultCostMappingConfidence;
 use App\Marketplace\Enum\MarketplaceType;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
@@ -14,8 +15,7 @@ use Symfony\Component\Yaml\Yaml;
 final class DefaultCostMappingYamlProvider
 {
     private const SUPPORTED_VERSION = 1;
-    private const ALLOWED_CONFIDENCE = ['high', 'medium', 'low'];
-
+    
     /** @var array<string, DefaultCostMappingRuleSet>|null */
     private ?array $cachedRuleSets = null;
 
@@ -110,9 +110,10 @@ final class DefaultCostMappingYamlProvider
                     throw new DefaultCostMappingConfigException(sprintf('Rule #%d in marketplace "%s" has invalid "is_negative" value.', $index, $marketplace->value));
                 }
 
-                $confidence = $rawRule['confidence'] ?? 'high';
-                if (!is_string($confidence) || !in_array($confidence, self::ALLOWED_CONFIDENCE, true)) {
-                    throw new DefaultCostMappingConfigException(sprintf('Rule #%d in marketplace "%s" has invalid confidence "%s".', $index, $marketplace->value, (string) $confidence));
+                $rawConfidence = $rawRule['confidence'] ?? DefaultCostMappingConfidence::HIGH->value;
+                $confidence = is_string($rawConfidence) ? DefaultCostMappingConfidence::tryFrom($rawConfidence) : null;
+                if ($confidence === null) {
+                    throw new DefaultCostMappingConfigException(sprintf('Rule #%d in marketplace "%s" has invalid confidence "%s".', $index, $marketplace->value, (string) $rawConfidence));
                 }
 
                 $note = $rawRule['note'] ?? null;

--- a/site/tests/Fixtures/Marketplace/Provider/defaults_optional_fields.yaml
+++ b/site/tests/Fixtures/Marketplace/Provider/defaults_optional_fields.yaml
@@ -1,0 +1,7 @@
+version: 1
+marketplaces:
+  ozon:
+    cost_mappings:
+      - cost_code: ozon_sale_commission
+        pl_code: COGS_MP_COMMISSION
+        include_in_pl: true

--- a/site/tests/Fixtures/Marketplace/Provider/invalid_confidence.yaml
+++ b/site/tests/Fixtures/Marketplace/Provider/invalid_confidence.yaml
@@ -1,0 +1,8 @@
+version: 1
+marketplaces:
+  ozon:
+    cost_mappings:
+      - cost_code: ozon_sale_commission
+        pl_code: COGS_MP_COMMISSION
+        include_in_pl: true
+        confidence: certain

--- a/site/tests/Fixtures/Marketplace/Provider/invalid_duplicate_cost_code.yaml
+++ b/site/tests/Fixtures/Marketplace/Provider/invalid_duplicate_cost_code.yaml
@@ -1,0 +1,10 @@
+version: 1
+marketplaces:
+  ozon:
+    cost_mappings:
+      - cost_code: ozon_sale_commission
+        pl_code: COGS_MP_COMMISSION
+        include_in_pl: true
+      - cost_code: ozon_sale_commission
+        pl_code: COGS_DELIVERY
+        include_in_pl: true

--- a/site/tests/Fixtures/Marketplace/Provider/missing_required_field.yaml
+++ b/site/tests/Fixtures/Marketplace/Provider/missing_required_field.yaml
@@ -1,0 +1,6 @@
+version: 1
+marketplaces:
+  ozon:
+    cost_mappings:
+      - cost_code: ozon_sale_commission
+        include_in_pl: true

--- a/site/tests/Unit/Marketplace/Infrastructure/Provider/DefaultCostMappingYamlProviderTest.php
+++ b/site/tests/Unit/Marketplace/Infrastructure/Provider/DefaultCostMappingYamlProviderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Marketplace\Infrastructure\Provider;
 
 use App\Marketplace\Application\Exception\DefaultCostMappingConfigException;
+use App\Marketplace\Enum\DefaultCostMappingConfidence;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Infrastructure\Provider\DefaultCostMappingYamlProvider;
 use PHPUnit\Framework\TestCase;
@@ -90,6 +91,6 @@ final class DefaultCostMappingYamlProviderTest extends TestCase
 
         self::assertNotNull($rule);
         self::assertTrue($rule->isNegative());
-        self::assertSame('high', $rule->getConfidence());
+        self::assertSame(DefaultCostMappingConfidence::HIGH, $rule->getConfidence());
     }
 }

--- a/site/tests/Unit/Marketplace/Infrastructure/Provider/DefaultCostMappingYamlProviderTest.php
+++ b/site/tests/Unit/Marketplace/Infrastructure/Provider/DefaultCostMappingYamlProviderTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Infrastructure\Provider;
+
+use App\Marketplace\Application\Exception\DefaultCostMappingConfigException;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Infrastructure\Provider\DefaultCostMappingYamlProvider;
+use PHPUnit\Framework\TestCase;
+
+final class DefaultCostMappingYamlProviderTest extends TestCase
+{
+    private const DEFAULT_CONFIG_PATH = __DIR__ . '/../../../../../config/marketplace/default_cost_mapping.yaml';
+    private const FIXTURES_DIR = __DIR__ . '/../../../../Fixtures/Marketplace/Provider';
+
+    public function testItReadsDefaultConfigSuccessfully(): void
+    {
+        $provider = new DefaultCostMappingYamlProvider(self::DEFAULT_CONFIG_PATH);
+
+        $all = $provider->getAll();
+
+        self::assertArrayHasKey(MarketplaceType::OZON->value, $all);
+    }
+
+    public function testItReturnsOzonRules(): void
+    {
+        $provider = new DefaultCostMappingYamlProvider(self::DEFAULT_CONFIG_PATH);
+
+        $ruleSet = $provider->getForMarketplace(MarketplaceType::OZON);
+
+        self::assertGreaterThan(0, $ruleSet->count());
+        self::assertSame(MarketplaceType::OZON, $ruleSet->getMarketplace());
+
+        $commission = $ruleSet->getByCostCode('ozon_sale_commission');
+        self::assertNotNull($commission);
+        self::assertSame('COGS_MP_COMMISSION', $commission->getPlCode());
+
+        $acquiring = $ruleSet->getByCostCode('ozon_acquiring');
+        self::assertNotNull($acquiring);
+        self::assertSame('COGS_ACQUIRING', $acquiring->getPlCode());
+    }
+
+    public function testMarketplaceWithoutRulesReturnsEmptyRuleSet(): void
+    {
+        $provider = new DefaultCostMappingYamlProvider(self::DEFAULT_CONFIG_PATH);
+
+        $ruleSet = $provider->getForMarketplace(MarketplaceType::YANDEX_MARKET);
+
+        self::assertSame(0, $ruleSet->count());
+        self::assertSame(MarketplaceType::YANDEX_MARKET, $ruleSet->getMarketplace());
+    }
+
+    public function testDuplicateCostCodeThrowsException(): void
+    {
+        $provider = new DefaultCostMappingYamlProvider(self::FIXTURES_DIR . '/invalid_duplicate_cost_code.yaml');
+
+        $this->expectException(DefaultCostMappingConfigException::class);
+        $this->expectExceptionMessage('Duplicate cost_code');
+
+        $provider->getAll();
+    }
+
+    public function testInvalidConfidenceThrowsException(): void
+    {
+        $provider = new DefaultCostMappingYamlProvider(self::FIXTURES_DIR . '/invalid_confidence.yaml');
+
+        $this->expectException(DefaultCostMappingConfigException::class);
+        $this->expectExceptionMessage('invalid confidence');
+
+        $provider->getAll();
+    }
+
+    public function testMissingRequiredFieldThrowsException(): void
+    {
+        $provider = new DefaultCostMappingYamlProvider(self::FIXTURES_DIR . '/missing_required_field.yaml');
+
+        $this->expectException(DefaultCostMappingConfigException::class);
+        $this->expectExceptionMessage('pl_code');
+
+        $provider->getAll();
+    }
+
+    public function testDefaultsAreAppliedForOptionalFields(): void
+    {
+        $provider = new DefaultCostMappingYamlProvider(self::FIXTURES_DIR . '/defaults_optional_fields.yaml');
+
+        $ruleSet = $provider->getForMarketplace(MarketplaceType::OZON);
+        $rule = $ruleSet->getByCostCode('ozon_sale_commission');
+
+        self::assertNotNull($rule);
+        self::assertTrue($rule->isNegative());
+        self::assertSame('high', $rule->getConfidence());
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a backend foundation to define and validate default mappings from marketplace cost category codes to P&L category codes via a YAML config for later UI/preview/apply flows. 
- Ensure rules are explicit, typed and validated so future features can safely read and apply them per marketplace without touching the DB. 

### Description
- Add production YAML `site/config/marketplace/default_cost_mapping.yaml` with `version: 1`, an `ozon` ruleset (minimal verified Ozon codes) and an empty `wildberries` section. 
- Introduce immutable DTOs `DefaultCostMappingRule` and `DefaultCostMappingRuleSet` at `site/src/Marketplace/Application/DTO/` to represent a single rule and a marketplace rule collection. 
- Implement `DefaultCostMappingYamlProvider` at `site/src/Marketplace/Infrastructure/Provider/DefaultCostMappingYamlProvider.php` which reads YAML via `Symfony\Component\Yaml\Yaml`, validates the full structure (version, marketplaces, known `MarketplaceType`, `cost_mappings` array, required fields, duplicates, allowed `confidence` values), applies defaults (`is_negative=true`, `confidence=high`) and returns typed `RuleSet`s. 
- Add `DefaultCostMappingConfigException` at `site/src/Marketplace/Application/Exception/DefaultCostMappingConfigException.php` for clear validation errors and unit tests plus fixture YAMLs under `site/tests/Unit/Marketplace/Infrastructure/Provider/` and `site/tests/Fixtures/Marketplace/Provider/` covering success and multiple failure cases. 

### Testing
- Added unit tests `DefaultCostMappingYamlProviderTest` exercising happy path, defaults and invalid fixtures (`invalid_duplicate_cost_code.yaml`, `invalid_confidence.yaml`, `missing_required_field.yaml`), and committed them with fixtures. 
- Attempted to run tests in the current environment (`php bin/phpunit ...` and `./vendor/bin/phpunit ...`) but test execution failed because project dependencies / test bridge are not installed in this environment (missing `vendor/bin` and `symfony/phpunit-bridge`), so tests were not executed here. 
- All changes are unit-testable and should pass once project dependencies are installed and CI runs the test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18e31f0e48323ac3553f53ea9b52e)