### PR TITLE
Add backend preview for default marketplace cost mapping

### DIFF
--- a/site/src/Marketplace/Application/Action/PreviewDefaultCostMappingAction.php
+++ b/site/src/Marketplace/Application/Action/PreviewDefaultCostMappingAction.php
@@ -104,7 +104,7 @@ final readonly class PreviewDefaultCostMappingAction
             plCategoryName: $pl['name'] ?? null,
             existingMappingId: $existing['id'] ?? null,
             existingPlCategoryId: $existing['pl_category_id'] ?? null,
-            existingPlCategoryName: null,
+            existingPlCategoryName: $existing['pl_category_name'] ?? null,
             includeInPl: $rule->isIncludeInPl(),
             isNegative: $rule->isNegative(),
             confidence: $rule->getConfidence(),

--- a/site/src/Marketplace/Application/Action/PreviewDefaultCostMappingAction.php
+++ b/site/src/Marketplace/Application/Action/PreviewDefaultCostMappingAction.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\Action;
+
+use App\Marketplace\Application\Command\PreviewDefaultCostMappingCommand;
+use App\Marketplace\Application\DTO\DefaultCostMappingPreviewItem;
+use App\Marketplace\Application\DTO\DefaultCostMappingPreviewResult;
+use App\Marketplace\Application\DTO\DefaultCostMappingRule;
+use App\Marketplace\Enum\DefaultCostMappingPreviewStatus;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Infrastructure\Provider\DefaultCostMappingYamlProvider;
+use App\Marketplace\Infrastructure\Query\MarketplaceCostCategoriesByCodeQuery;
+use App\Marketplace\Infrastructure\Query\MarketplaceCostPLMappingsByCostCategoryQuery;
+use App\Marketplace\Infrastructure\Query\PLCategoriesByCodeQuery;
+
+final readonly class PreviewDefaultCostMappingAction
+{
+    public function __construct(
+        private DefaultCostMappingYamlProvider $yamlProvider,
+        private MarketplaceCostCategoriesByCodeQuery $costCategoriesByCodeQuery,
+        private PLCategoriesByCodeQuery $plCategoriesByCodeQuery,
+        private MarketplaceCostPLMappingsByCostCategoryQuery $mappingsByCostCategoryQuery,
+    ) {
+    }
+
+    public function __invoke(PreviewDefaultCostMappingCommand $command): DefaultCostMappingPreviewResult
+    {
+        $marketplace = MarketplaceType::tryFrom($command->marketplace);
+        if ($marketplace === null) {
+            throw new \DomainException(sprintf('Unknown marketplace "%s".', $command->marketplace));
+        }
+
+        $rules = $this->yamlProvider->getForMarketplace($marketplace)->getRules();
+        if ($rules === []) {
+            return new DefaultCostMappingPreviewResult($marketplace, []);
+        }
+
+        $costCodes = array_values(array_unique(array_map(static fn(DefaultCostMappingRule $rule): string => $rule->getCostCode(), $rules)));
+        $plCodes = array_values(array_unique(array_map(static fn(DefaultCostMappingRule $rule): string => $rule->getPlCode(), $rules)));
+
+        $costByCode = $this->costCategoriesByCodeQuery->fetchIndexed($command->companyId, $marketplace, $costCodes);
+        $plByCode = $this->plCategoriesByCodeQuery->fetchIndexed($command->companyId, $plCodes);
+
+        $costCategoryIds = array_values(array_map(static fn(array $row): string => $row['id'], $costByCode));
+        $existingMappings = $this->mappingsByCostCategoryQuery->fetchIndexedByCostCategoryId($command->companyId, $costCategoryIds);
+
+        $items = [];
+        foreach ($rules as $rule) {
+            $items[] = $this->buildItem($rule, $costByCode, $plByCode, $existingMappings);
+        }
+
+        return new DefaultCostMappingPreviewResult($marketplace, $items);
+    }
+
+    private function buildItem(DefaultCostMappingRule $rule, array $costByCode, array $plByCode, array $existingMappings): DefaultCostMappingPreviewItem
+    {
+        $cost = $costByCode[$rule->getCostCode()] ?? null;
+        $plCandidates = $plByCode[$rule->getPlCode()] ?? [];
+        $pl = count($plCandidates) === 1 ? $plCandidates[0] : null;
+
+        if ($cost === null) {
+            return $this->item($rule, null, null, null, DefaultCostMappingPreviewStatus::MISSING_COST_CATEGORY, 'Категория затрат не найдена у компании.');
+        }
+
+        if (count($plCandidates) > 1) {
+            return $this->item($rule, $cost, null, null, DefaultCostMappingPreviewStatus::INVALID_TARGET_CATEGORY, 'Найдено несколько категорий ОПиУ с таким code.');
+        }
+
+        if ($pl === null) {
+            return $this->item($rule, $cost, null, $existingMappings[$cost['id']] ?? null, DefaultCostMappingPreviewStatus::MISSING_PL_CATEGORY, 'Категория ОПиУ не найдена у компании.');
+        }
+
+        if ($pl['type'] !== 'LEAF_INPUT') {
+            return $this->item($rule, $cost, $pl, $existingMappings[$cost['id']] ?? null, DefaultCostMappingPreviewStatus::INVALID_TARGET_CATEGORY, 'Целевая категория ОПиУ должна быть LEAF_INPUT.');
+        }
+
+        $existing = $existingMappings[$cost['id']] ?? null;
+        if ($existing === null) {
+            return $this->item($rule, $cost, $pl, null, DefaultCostMappingPreviewStatus::WILL_CREATE, 'Будет создан новый mapping.');
+        }
+
+        if ($existing['include_in_pl'] === false) {
+            return $this->item($rule, $cost, $pl, $existing, DefaultCostMappingPreviewStatus::SKIPPED_DISABLED, 'Пропущено: mapping отключён (include_in_pl=false).');
+        }
+
+        if ($existing['pl_category_id'] === null) {
+            return $this->item($rule, $cost, $pl, $existing, DefaultCostMappingPreviewStatus::WILL_FILL_EMPTY, 'Будет заполнено пустое поле категории ОПиУ.');
+        }
+
+        return $this->item($rule, $cost, $pl, $existing, DefaultCostMappingPreviewStatus::SKIPPED_EXISTING, 'Пропущено: mapping уже настроен вручную.');
+    }
+
+    private function item(DefaultCostMappingRule $rule, ?array $cost, ?array $pl, ?array $existing, DefaultCostMappingPreviewStatus $status, string $message): DefaultCostMappingPreviewItem
+    {
+        return new DefaultCostMappingPreviewItem(
+            marketplace: $rule->getMarketplace(),
+            costCode: $rule->getCostCode(),
+            costCategoryId: $cost['id'] ?? null,
+            costCategoryName: $cost['name'] ?? null,
+            plCode: $rule->getPlCode(),
+            plCategoryId: $pl['id'] ?? null,
+            plCategoryName: $pl['name'] ?? null,
+            existingMappingId: $existing['id'] ?? null,
+            existingPlCategoryId: $existing['pl_category_id'] ?? null,
+            existingPlCategoryName: null,
+            includeInPl: $rule->isIncludeInPl(),
+            isNegative: $rule->isNegative(),
+            confidence: $rule->getConfidence(),
+            note: $rule->getNote(),
+            status: $status,
+            message: $message,
+        );
+    }
+}

--- a/site/src/Marketplace/Application/Command/PreviewDefaultCostMappingCommand.php
+++ b/site/src/Marketplace/Application/Command/PreviewDefaultCostMappingCommand.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\Command;
+
+final readonly class PreviewDefaultCostMappingCommand
+{
+    public function __construct(
+        public string $companyId,
+        public string $marketplace,
+    ) {
+    }
+}

--- a/site/src/Marketplace/Application/DTO/DefaultCostMappingPreviewItem.php
+++ b/site/src/Marketplace/Application/DTO/DefaultCostMappingPreviewItem.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\DTO;
+
+use App\Marketplace\Enum\DefaultCostMappingConfidence;
+use App\Marketplace\Enum\DefaultCostMappingPreviewStatus;
+use App\Marketplace\Enum\MarketplaceType;
+
+final readonly class DefaultCostMappingPreviewItem
+{
+    public function __construct(
+        private MarketplaceType $marketplace,
+        private string $costCode,
+        private ?string $costCategoryId,
+        private ?string $costCategoryName,
+        private string $plCode,
+        private ?string $plCategoryId,
+        private ?string $plCategoryName,
+        private ?string $existingMappingId,
+        private ?string $existingPlCategoryId,
+        private ?string $existingPlCategoryName,
+        private bool $includeInPl,
+        private bool $isNegative,
+        private DefaultCostMappingConfidence $confidence,
+        private ?string $note,
+        private DefaultCostMappingPreviewStatus $status,
+        private string $message,
+    ) {
+    }
+
+    public function getStatus(): DefaultCostMappingPreviewStatus { return $this->status; }
+}

--- a/site/src/Marketplace/Application/DTO/DefaultCostMappingPreviewItem.php
+++ b/site/src/Marketplace/Application/DTO/DefaultCostMappingPreviewItem.php
@@ -30,5 +30,20 @@ final readonly class DefaultCostMappingPreviewItem
     ) {
     }
 
+    public function getMarketplace(): MarketplaceType { return $this->marketplace; }
+    public function getCostCode(): string { return $this->costCode; }
+    public function getCostCategoryId(): ?string { return $this->costCategoryId; }
+    public function getCostCategoryName(): ?string { return $this->costCategoryName; }
+    public function getPlCode(): string { return $this->plCode; }
+    public function getPlCategoryId(): ?string { return $this->plCategoryId; }
+    public function getPlCategoryName(): ?string { return $this->plCategoryName; }
+    public function getExistingMappingId(): ?string { return $this->existingMappingId; }
+    public function getExistingPlCategoryId(): ?string { return $this->existingPlCategoryId; }
+    public function getExistingPlCategoryName(): ?string { return $this->existingPlCategoryName; }
+    public function isIncludeInPl(): bool { return $this->includeInPl; }
+    public function isNegative(): bool { return $this->isNegative; }
+    public function getConfidence(): DefaultCostMappingConfidence { return $this->confidence; }
+    public function getNote(): ?string { return $this->note; }
     public function getStatus(): DefaultCostMappingPreviewStatus { return $this->status; }
+    public function getMessage(): string { return $this->message; }
 }

--- a/site/src/Marketplace/Application/DTO/DefaultCostMappingPreviewResult.php
+++ b/site/src/Marketplace/Application/DTO/DefaultCostMappingPreviewResult.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\DTO;
+
+use App\Marketplace\Enum\DefaultCostMappingPreviewStatus;
+use App\Marketplace\Enum\MarketplaceType;
+
+final readonly class DefaultCostMappingPreviewResult
+{
+    /** @param list<DefaultCostMappingPreviewItem> $items */
+    public function __construct(
+        private MarketplaceType $marketplace,
+        private array $items,
+    ) {
+    }
+
+    public function getMarketplace(): MarketplaceType { return $this->marketplace; }
+    /** @return list<DefaultCostMappingPreviewItem> */
+    public function getItems(): array { return $this->items; }
+    /** @return list<DefaultCostMappingPreviewItem> */
+    public function getItemsByStatus(DefaultCostMappingPreviewStatus $status): array
+    {
+        return array_values(array_filter($this->items, static fn (DefaultCostMappingPreviewItem $item): bool => $item->getStatus() === $status));
+    }
+
+    public function getTotal(): int { return count($this->items); }
+    public function getCountByStatus(DefaultCostMappingPreviewStatus $status): int { return count($this->getItemsByStatus($status)); }
+
+    /** @return array<string, int> */
+    public function getSummary(): array
+    {
+        $summary = [];
+        foreach (DefaultCostMappingPreviewStatus::cases() as $status) {
+            $summary[$status->value] = $this->getCountByStatus($status);
+        }
+
+        return $summary;
+    }
+
+    public function hasBlockingIssues(): bool
+    {
+        return $this->getCountByStatus(DefaultCostMappingPreviewStatus::MISSING_PL_CATEGORY) > 0
+            || $this->getCountByStatus(DefaultCostMappingPreviewStatus::INVALID_TARGET_CATEGORY) > 0;
+    }
+}

--- a/site/src/Marketplace/Enum/DefaultCostMappingPreviewStatus.php
+++ b/site/src/Marketplace/Enum/DefaultCostMappingPreviewStatus.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Enum;
+
+enum DefaultCostMappingPreviewStatus: string
+{
+    case WILL_CREATE = 'will_create';
+    case WILL_FILL_EMPTY = 'will_fill_empty';
+    case SKIPPED_EXISTING = 'skipped_existing';
+    case SKIPPED_DISABLED = 'skipped_disabled';
+    case MISSING_COST_CATEGORY = 'missing_cost_category';
+    case MISSING_PL_CATEGORY = 'missing_pl_category';
+    case INVALID_TARGET_CATEGORY = 'invalid_target_category';
+}

--- a/site/src/Marketplace/Infrastructure/Query/MarketplaceCostCategoriesByCodeQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/MarketplaceCostCategoriesByCodeQuery.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Query;
+
+use App\Marketplace\Enum\MarketplaceType;
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+
+final readonly class MarketplaceCostCategoriesByCodeQuery
+{
+    public function __construct(private Connection $connection) {}
+
+    /** @param list<string> $codes @return array<string, array{id: string, code: string, name: string}> */
+    public function fetchIndexed(string $companyId, MarketplaceType $marketplace, array $codes): array
+    {
+        if ($codes === []) {
+            return [];
+        }
+
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT id, code, name FROM marketplace_cost_categories WHERE company_id = :companyId AND marketplace = :marketplace AND code IN (:codes)',
+            ['companyId' => $companyId, 'marketplace' => $marketplace->value, 'codes' => array_values(array_unique($codes))],
+            ['codes' => ArrayParameterType::STRING],
+        );
+
+        $result = [];
+        foreach ($rows as $row) {
+            $result[(string) $row['code']] = ['id' => (string) $row['id'], 'code' => (string) $row['code'], 'name' => (string) $row['name']];
+        }
+
+        return $result;
+    }
+}

--- a/site/src/Marketplace/Infrastructure/Query/MarketplaceCostPLMappingsByCostCategoryQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/MarketplaceCostPLMappingsByCostCategoryQuery.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Query;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+
+final readonly class MarketplaceCostPLMappingsByCostCategoryQuery
+{
+    public function __construct(private Connection $connection) {}
+
+    /** @param list<string> $costCategoryIds @return array<string, array{id: string, cost_category_id: string, pl_category_id: ?string, include_in_pl: bool, is_negative: bool, sort_order: ?int}> */
+    public function fetchIndexedByCostCategoryId(string $companyId, array $costCategoryIds): array
+    {
+        if ($costCategoryIds === []) {
+            return [];
+        }
+
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT id, cost_category_id, pl_category_id, include_in_pl, is_negative, sort_order FROM marketplace_cost_pl_mappings WHERE company_id = :companyId AND cost_category_id IN (:ids)',
+            ['companyId' => $companyId, 'ids' => array_values(array_unique($costCategoryIds))],
+            ['ids' => ArrayParameterType::STRING],
+        );
+
+        $result = [];
+        foreach ($rows as $row) {
+            $result[(string) $row['cost_category_id']] = [
+                'id' => (string) $row['id'],
+                'cost_category_id' => (string) $row['cost_category_id'],
+                'pl_category_id' => $row['pl_category_id'] !== null ? (string) $row['pl_category_id'] : null,
+                'include_in_pl' => (bool) $row['include_in_pl'],
+                'is_negative' => (bool) $row['is_negative'],
+                'sort_order' => $row['sort_order'] !== null ? (int) $row['sort_order'] : null,
+            ];
+        }
+
+        return $result;
+    }
+}

--- a/site/src/Marketplace/Infrastructure/Query/MarketplaceCostPLMappingsByCostCategoryQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/MarketplaceCostPLMappingsByCostCategoryQuery.php
@@ -11,7 +11,7 @@ final readonly class MarketplaceCostPLMappingsByCostCategoryQuery
 {
     public function __construct(private Connection $connection) {}
 
-    /** @param list<string> $costCategoryIds @return array<string, array{id: string, cost_category_id: string, pl_category_id: ?string, include_in_pl: bool, is_negative: bool, sort_order: ?int}> */
+    /** @param list<string> $costCategoryIds @return array<string, array{id: string, cost_category_id: string, pl_category_id: ?string, pl_category_name: ?string, include_in_pl: bool, is_negative: bool, sort_order: ?int}> */
     public function fetchIndexedByCostCategoryId(string $companyId, array $costCategoryIds): array
     {
         if ($costCategoryIds === []) {
@@ -19,7 +19,7 @@ final readonly class MarketplaceCostPLMappingsByCostCategoryQuery
         }
 
         $rows = $this->connection->fetchAllAssociative(
-            'SELECT id, cost_category_id, pl_category_id, include_in_pl, is_negative, sort_order FROM marketplace_cost_pl_mappings WHERE company_id = :companyId AND cost_category_id IN (:ids)',
+            'SELECT m.id, m.cost_category_id, m.pl_category_id, pl.name AS pl_category_name, m.include_in_pl, m.is_negative, m.sort_order FROM marketplace_cost_pl_mappings m LEFT JOIN pl_categories pl ON pl.id = m.pl_category_id WHERE m.company_id = :companyId AND m.cost_category_id IN (:ids)',
             ['companyId' => $companyId, 'ids' => array_values(array_unique($costCategoryIds))],
             ['ids' => ArrayParameterType::STRING],
         );
@@ -30,6 +30,7 @@ final readonly class MarketplaceCostPLMappingsByCostCategoryQuery
                 'id' => (string) $row['id'],
                 'cost_category_id' => (string) $row['cost_category_id'],
                 'pl_category_id' => $row['pl_category_id'] !== null ? (string) $row['pl_category_id'] : null,
+                'pl_category_name' => $row['pl_category_name'] !== null ? (string) $row['pl_category_name'] : null,
                 'include_in_pl' => (bool) $row['include_in_pl'],
                 'is_negative' => (bool) $row['is_negative'],
                 'sort_order' => $row['sort_order'] !== null ? (int) $row['sort_order'] : null,

--- a/site/src/Marketplace/Infrastructure/Query/PLCategoriesByCodeQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/PLCategoriesByCodeQuery.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Query;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+
+final readonly class PLCategoriesByCodeQuery
+{
+    public function __construct(private Connection $connection) {}
+
+    /** @param list<string> $codes @return array<string, list<array{id: string, code: string, name: string, type: string, flow: string, is_visible: bool}>> */
+    public function fetchIndexed(string $companyId, array $codes): array
+    {
+        if ($codes === []) {
+            return [];
+        }
+
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT c.id, c.code, c.name, c.type, c.flow, c.is_visible FROM pl_categories c INNER JOIN company co ON c.company_id = co.id WHERE co.id = :companyId AND c.code IN (:codes)',
+            ['companyId' => $companyId, 'codes' => array_values(array_unique($codes))],
+            ['codes' => ArrayParameterType::STRING],
+        );
+
+        $result = [];
+        foreach ($rows as $row) {
+            $code = (string) $row['code'];
+            $result[$code] ??= [];
+            $result[$code][] = [
+                'id' => (string) $row['id'],
+                'code' => $code,
+                'name' => (string) $row['name'],
+                'type' => (string) $row['type'],
+                'flow' => (string) $row['flow'],
+                'is_visible' => (bool) $row['is_visible'],
+            ];
+        }
+
+        return $result;
+    }
+}

--- a/site/src/Marketplace/Infrastructure/Query/PLCategoriesByCodeQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/PLCategoriesByCodeQuery.php
@@ -19,7 +19,7 @@ final readonly class PLCategoriesByCodeQuery
         }
 
         $rows = $this->connection->fetchAllAssociative(
-            'SELECT c.id, c.code, c.name, c.type, c.flow, c.is_visible FROM pl_categories c INNER JOIN company co ON c.company_id = co.id WHERE co.id = :companyId AND c.code IN (:codes)',
+            'SELECT c.id, c.code, c.name, c.type, c.flow, c.is_visible FROM pl_categories c WHERE c.company_id = :companyId AND c.code IN (:codes)',
             ['companyId' => $companyId, 'codes' => array_values(array_unique($codes))],
             ['codes' => ArrayParameterType::STRING],
         );

--- a/site/tests/Fixtures/Marketplace/default_cost_mapping_preview.yaml
+++ b/site/tests/Fixtures/Marketplace/default_cost_mapping_preview.yaml
@@ -1,0 +1,25 @@
+version: 1
+marketplaces:
+  ozon:
+    cost_mappings:
+      - cost_code: cost_create
+        pl_code: PL_LEAF
+        include_in_pl: true
+      - cost_code: cost_fill
+        pl_code: PL_LEAF
+        include_in_pl: true
+      - cost_code: cost_existing
+        pl_code: PL_LEAF
+        include_in_pl: true
+      - cost_code: cost_disabled
+        pl_code: PL_LEAF
+        include_in_pl: true
+      - cost_code: cost_missing
+        pl_code: PL_LEAF
+        include_in_pl: true
+      - cost_code: cost_missing_pl
+        pl_code: PL_MISSING
+        include_in_pl: true
+      - cost_code: cost_invalid_pl
+        pl_code: PL_SUBTOTAL
+        include_in_pl: true

--- a/site/tests/Fixtures/Marketplace/empty_default_cost_mapping.yaml
+++ b/site/tests/Fixtures/Marketplace/empty_default_cost_mapping.yaml
@@ -1,0 +1,4 @@
+version: 1
+marketplaces:
+  wildberries:
+    cost_mappings: []

--- a/site/tests/Integration/Marketplace/Application/Action/PreviewDefaultCostMappingActionTest.php
+++ b/site/tests/Integration/Marketplace/Application/Action/PreviewDefaultCostMappingActionTest.php
@@ -11,6 +11,7 @@ use App\Marketplace\Application\Action\PreviewDefaultCostMappingAction;
 use App\Marketplace\Application\Command\PreviewDefaultCostMappingCommand;
 use App\Marketplace\Entity\MarketplaceCostCategory;
 use App\Marketplace\Entity\MarketplaceCostPLMapping;
+use App\Marketplace\Enum\DefaultCostMappingConfidence;
 use App\Marketplace\Enum\DefaultCostMappingPreviewStatus;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Infrastructure\Provider\DefaultCostMappingYamlProvider;
@@ -67,6 +68,24 @@ final class PreviewDefaultCostMappingActionTest extends IntegrationTestCase
         self::assertTrue($result->hasBlockingIssues());
         self::assertSame(1, $result->getSummary()[DefaultCostMappingPreviewStatus::WILL_CREATE->value]);
 
+        $createItem = $this->findByCostCode($result, 'cost_create');
+        self::assertSame(DefaultCostMappingPreviewStatus::WILL_CREATE, $createItem->getStatus());
+        self::assertSame('PL_LEAF', $createItem->getPlCode());
+        self::assertSame('PL_LEAF', $createItem->getPlCategoryName());
+        self::assertTrue($createItem->isIncludeInPl());
+        self::assertTrue($createItem->isNegative());
+        self::assertSame(DefaultCostMappingConfidence::HIGH, $createItem->getConfidence());
+
+        $existingItem = $this->findByCostCode($result, 'cost_existing');
+        self::assertSame(DefaultCostMappingPreviewStatus::SKIPPED_EXISTING, $existingItem->getStatus());
+        self::assertNotNull($existingItem->getExistingMappingId());
+        self::assertSame('PL_LEAF', $existingItem->getExistingPlCategoryName());
+
+        $missingPlItem = $this->findByCostCode($result, 'cost_missing_pl');
+        self::assertSame(DefaultCostMappingPreviewStatus::MISSING_PL_CATEGORY, $missingPlItem->getStatus());
+        self::assertSame('Категория ОПиУ не найдена у компании.', $missingPlItem->getMessage());
+
+
         $afterCount = (int) $this->em->getConnection()->fetchOne('SELECT COUNT(*) FROM marketplace_cost_pl_mappings WHERE company_id = :companyId', ['companyId' => $companyId]);
         self::assertSame($beforeCount, $afterCount);
         self::assertNotNull($create);
@@ -89,6 +108,37 @@ final class PreviewDefaultCostMappingActionTest extends IntegrationTestCase
 
         $result = $action(new PreviewDefaultCostMappingCommand($companyId, MarketplaceType::OZON->value));
         self::assertSame(0, $result->getTotal());
+    }
+
+
+    public function testInvalidMarketplaceThrows(): void
+    {
+        $companyId = '11111111-1111-1111-1111-111111111113';
+        $this->createCompany($companyId);
+
+        $action = new PreviewDefaultCostMappingAction(
+            new DefaultCostMappingYamlProvider(__DIR__ . '/../../../../Fixtures/Marketplace/default_cost_mapping_preview.yaml'),
+            new MarketplaceCostCategoriesByCodeQuery($this->em->getConnection()),
+            new PLCategoriesByCodeQuery($this->em->getConnection()),
+            new MarketplaceCostPLMappingsByCostCategoryQuery($this->em->getConnection()),
+        );
+
+        $this->expectException(\DomainException::class);
+        $action(new PreviewDefaultCostMappingCommand($companyId, 'invalid_marketplace'));
+    }
+
+
+    private function findByCostCode(
+        \App\Marketplace\Application\DTO\DefaultCostMappingPreviewResult $result,
+        string $costCode,
+    ): \App\Marketplace\Application\DTO\DefaultCostMappingPreviewItem {
+        foreach ($result->getItems() as $item) {
+            if ($item->getCostCode() === $costCode) {
+                return $item;
+            }
+        }
+
+        self::fail(sprintf('Preview item for cost code "%s" not found.', $costCode));
     }
 
     private function createCompany(string $companyId): Company

--- a/site/tests/Integration/Marketplace/Application/Action/PreviewDefaultCostMappingActionTest.php
+++ b/site/tests/Integration/Marketplace/Application/Action/PreviewDefaultCostMappingActionTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Marketplace\Application\Action;
+
+use App\Company\Entity\Company;
+use App\Finance\Entity\PLCategory;
+use App\Finance\Enum\PLCategoryType;
+use App\Marketplace\Application\Action\PreviewDefaultCostMappingAction;
+use App\Marketplace\Application\Command\PreviewDefaultCostMappingCommand;
+use App\Marketplace\Entity\MarketplaceCostCategory;
+use App\Marketplace\Entity\MarketplaceCostPLMapping;
+use App\Marketplace\Enum\DefaultCostMappingPreviewStatus;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Infrastructure\Provider\DefaultCostMappingYamlProvider;
+use App\Marketplace\Infrastructure\Query\MarketplaceCostCategoriesByCodeQuery;
+use App\Marketplace\Infrastructure\Query\MarketplaceCostPLMappingsByCostCategoryQuery;
+use App\Marketplace\Infrastructure\Query\PLCategoriesByCodeQuery;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class PreviewDefaultCostMappingActionTest extends IntegrationTestCase
+{
+    public function testPreviewStatusesSummaryAndReadonly(): void
+    {
+        $companyId = '11111111-1111-1111-1111-111111111111';
+        $company = $this->createCompany($companyId);
+
+        $leaf = $this->createPl($company, 'PL_LEAF', PLCategoryType::LEAF_INPUT);
+        $subtotal = $this->createPl($company, 'PL_SUBTOTAL', PLCategoryType::SUBTOTAL);
+
+        $create = $this->createCost($company, 'cost_create');
+        $fill = $this->createCost($company, 'cost_fill');
+        $existing = $this->createCost($company, 'cost_existing');
+        $disabled = $this->createCost($company, 'cost_disabled');
+        $missingPl = $this->createCost($company, 'cost_missing_pl');
+        $invalidPl = $this->createCost($company, 'cost_invalid_pl');
+
+        $this->em->persist(new MarketplaceCostPLMapping(Uuid::uuid7()->toString(), $companyId, $fill, null, true));
+        $this->em->persist(new MarketplaceCostPLMapping(Uuid::uuid7()->toString(), $companyId, $existing, (string) $leaf->getId(), true));
+        $this->em->persist(new MarketplaceCostPLMapping(Uuid::uuid7()->toString(), $companyId, $disabled, (string) $leaf->getId(), false));
+
+        $this->em->flush();
+
+        $beforeCount = (int) $this->em->getConnection()->fetchOne('SELECT COUNT(*) FROM marketplace_cost_pl_mappings WHERE company_id = :companyId', ['companyId' => $companyId]);
+
+        $action = new PreviewDefaultCostMappingAction(
+            new DefaultCostMappingYamlProvider(__DIR__ . '/../../../../Fixtures/Marketplace/default_cost_mapping_preview.yaml'),
+            new MarketplaceCostCategoriesByCodeQuery($this->em->getConnection()),
+            new PLCategoriesByCodeQuery($this->em->getConnection()),
+            new MarketplaceCostPLMappingsByCostCategoryQuery($this->em->getConnection()),
+        );
+
+        $result = $action(new PreviewDefaultCostMappingCommand($companyId, MarketplaceType::OZON->value));
+
+        self::assertSame(7, $result->getTotal());
+        self::assertSame(1, $result->getCountByStatus(DefaultCostMappingPreviewStatus::WILL_CREATE));
+        self::assertSame(1, $result->getCountByStatus(DefaultCostMappingPreviewStatus::WILL_FILL_EMPTY));
+        self::assertSame(1, $result->getCountByStatus(DefaultCostMappingPreviewStatus::SKIPPED_EXISTING));
+        self::assertSame(1, $result->getCountByStatus(DefaultCostMappingPreviewStatus::SKIPPED_DISABLED));
+        self::assertSame(1, $result->getCountByStatus(DefaultCostMappingPreviewStatus::MISSING_COST_CATEGORY));
+        self::assertSame(1, $result->getCountByStatus(DefaultCostMappingPreviewStatus::MISSING_PL_CATEGORY));
+        self::assertSame(1, $result->getCountByStatus(DefaultCostMappingPreviewStatus::INVALID_TARGET_CATEGORY));
+        self::assertTrue($result->hasBlockingIssues());
+        self::assertSame(1, $result->getSummary()[DefaultCostMappingPreviewStatus::WILL_CREATE->value]);
+
+        $afterCount = (int) $this->em->getConnection()->fetchOne('SELECT COUNT(*) FROM marketplace_cost_pl_mappings WHERE company_id = :companyId', ['companyId' => $companyId]);
+        self::assertSame($beforeCount, $afterCount);
+        self::assertNotNull($create);
+        self::assertNotNull($missingPl);
+        self::assertNotNull($invalidPl);
+        self::assertNotNull($subtotal);
+    }
+
+    public function testEmptyRuleSet(): void
+    {
+        $companyId = '11111111-1111-1111-1111-111111111112';
+        $this->createCompany($companyId);
+
+        $action = new PreviewDefaultCostMappingAction(
+            new DefaultCostMappingYamlProvider(__DIR__ . '/../../../../Fixtures/Marketplace/empty_default_cost_mapping.yaml'),
+            new MarketplaceCostCategoriesByCodeQuery($this->em->getConnection()),
+            new PLCategoriesByCodeQuery($this->em->getConnection()),
+            new MarketplaceCostPLMappingsByCostCategoryQuery($this->em->getConnection()),
+        );
+
+        $result = $action(new PreviewDefaultCostMappingCommand($companyId, MarketplaceType::OZON->value));
+        self::assertSame(0, $result->getTotal());
+    }
+
+    private function createCompany(string $companyId): Company
+    {
+        $owner = UserBuilder::aUser()->withId(Uuid::uuid7()->toString())->withEmail(sprintf('%s@example.test', $companyId))->build();
+        $company = CompanyBuilder::aCompany()->withId($companyId)->withOwner($owner)->build();
+        $this->em->persist($owner);
+        $this->em->persist($company);
+
+        return $company;
+    }
+
+    private function createPl(Company $company, string $code, PLCategoryType $type): PLCategory
+    {
+        $pl = new PLCategory(Uuid::uuid7()->toString(), $company);
+        $pl->setName($code)->setCode($code)->setType($type);
+        $this->em->persist($pl);
+
+        return $pl;
+    }
+
+    private function createCost(Company $company, string $code): MarketplaceCostCategory
+    {
+        $cost = new MarketplaceCostCategory(Uuid::uuid7()->toString(), $company, MarketplaceType::OZON);
+        $cost->setCode($code);
+        $cost->setName($code);
+        $this->em->persist($cost);
+
+        return $cost;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a read-only backend preview that shows what would happen when applying YAML-based default Marketplace→P&L mapping for a given `companyId` + `marketplace` without mutating DB state. 
- Surface all classification outcomes required by business rules (will_create, will_fill_empty, skipped_existing, skipped_disabled, missing_cost_category, missing_pl_category, invalid_target_category) so UI can present a safe preview before apply. 

### Description
- Added `PreviewDefaultCostMappingCommand` (`site/src/Marketplace/Application/Command/PreviewDefaultCostMappingCommand.php`) and read-only action `PreviewDefaultCostMappingAction` (`site/src/Marketplace/Application/Action/PreviewDefaultCostMappingAction.php`) which validates `marketplace` via `MarketplaceType::tryFrom`, loads rules from `DefaultCostMappingYamlProvider` and returns a `DefaultCostMappingPreviewResult` without any DB writes. 
- Introduced DTOs and enum: `DefaultCostMappingPreviewItem` and `DefaultCostMappingPreviewResult` (`site/src/Marketplace/Application/DTO/`) and `DefaultCostMappingPreviewStatus` enum (`site/src/Marketplace/Enum/DefaultCostMappingPreviewStatus.php`) implementing required summary / filtering / blocking-issues semantics. 
- Implemented DBAL read queries to build the read-paths: `MarketplaceCostCategoriesByCodeQuery`, `MarketplaceCostPLMappingsByCostCategoryQuery`, `PLCategoriesByCodeQuery` under `site/src/Marketplace/Infrastructure/Query/` and wired them into the action; PL query returns all matches per code so duplicates are reported as `invalid_target_category`. 
- Added YAML test fixtures and an integration test `PreviewDefaultCostMappingActionTest` (`site/tests/Integration/Marketplace/Application/Action/PreviewDefaultCostMappingActionTest.php`) exercising the full status matrix and verifying preview is read-only and that empty ruleset returns empty result. 

### Testing
- Ran PHP syntax checks (`php -l`) for the new action, result DTO and integration test files and they passed with no syntax errors. 
- Attempted to run PHPUnit in this environment but `vendor` / PHPUnit bridge is not installed so `phpunit` runs failed (missing `vendor/bin/phpunit` and `simple-phpunit.php`). 
- Attempted `php bin/console lint:container` but it failed due to missing project dependencies and requires `composer install` in this environment; integration test file is present but automated execution was not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f19811c198832380349afcf3b30d4f)