### PR TITLE
Add thin JSON endpoints for default marketplace cost→PL mapping (preview/apply)

### DIFF
--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -271,3 +271,7 @@ services:
     App\MarketplaceAds\Command\LoadAdDataCommand:
         arguments:
             $platformClients: !tagged_iterator marketplace_ads.platform_client
+
+    App\Marketplace\Infrastructure\Provider\DefaultCostMappingYamlProvider:
+        arguments:
+            $configPath: "%kernel.project_dir%/config/marketplace/default_cost_mapping.yaml"

--- a/site/src/Marketplace/Controller/CostPLMappingDefaultSetupController.php
+++ b/site/src/Marketplace/Controller/CostPLMappingDefaultSetupController.php
@@ -32,13 +32,13 @@ final class CostPLMappingDefaultSetupController extends AbstractController
     #[Route('/preview', name: 'marketplace_cost_pl_mapping_default_preview', methods: ['POST'])]
     public function preview(Request $request): JsonResponse
     {
-        if (!$this->isCsrfTokenValid('marketplace_default_cost_mapping', (string) $request->request->get('_token'))) {
+        if (!$this->isCsrfTokenValid('marketplace_default_cost_mapping', $this->extractCsrfToken($request))) {
             return $this->json(['ok' => false, 'message' => 'Некорректный CSRF token.'], JsonResponse::HTTP_FORBIDDEN);
         }
 
         try {
             $companyId = (string) $this->activeCompanyService->getActiveCompany()->getId();
-            $marketplace = (string) $request->request->get('marketplace', '');
+            $marketplace = $this->extractMarketplace($request);
             $result = ($this->previewAction)(new PreviewDefaultCostMappingCommand($companyId, $marketplace));
 
             return $this->json($this->previewResultToArray($result));
@@ -50,7 +50,7 @@ final class CostPLMappingDefaultSetupController extends AbstractController
     #[Route('/apply', name: 'marketplace_cost_pl_mapping_default_apply', methods: ['POST'])]
     public function apply(Request $request): JsonResponse
     {
-        if (!$this->isCsrfTokenValid('marketplace_default_cost_mapping', (string) $request->request->get('_token'))) {
+        if (!$this->isCsrfTokenValid('marketplace_default_cost_mapping', $this->extractCsrfToken($request))) {
             return $this->json(['ok' => false, 'message' => 'Некорректный CSRF token.'], JsonResponse::HTTP_FORBIDDEN);
         }
 
@@ -61,7 +61,7 @@ final class CostPLMappingDefaultSetupController extends AbstractController
 
         try {
             $companyId = (string) $this->activeCompanyService->getActiveCompany()->getId();
-            $marketplace = (string) $request->request->get('marketplace', '');
+            $marketplace = $this->extractMarketplace($request);
             $result = ($this->applyAction)(new ApplyDefaultCostMappingCommand($companyId, $marketplace, (string) $user->getId()));
 
             return $this->json($this->applyResultToArray($result));
@@ -70,6 +70,41 @@ final class CostPLMappingDefaultSetupController extends AbstractController
         }
     }
 
+
+
+    private function extractCsrfToken(Request $request): string
+    {
+        $token = $request->request->getString('_token', '');
+        if ($token !== '') {
+            return $token;
+        }
+
+        $payload = json_decode((string) $request->getContent(), true);
+        if (!is_array($payload)) {
+            return '';
+        }
+
+        $value = $payload['_token'] ?? '';
+
+        return is_string($value) ? $value : '';
+    }
+
+    private function extractMarketplace(Request $request): string
+    {
+        $marketplace = $request->request->getString('marketplace', '');
+        if ($marketplace !== '') {
+            return $marketplace;
+        }
+
+        $payload = json_decode((string) $request->getContent(), true);
+        if (!is_array($payload)) {
+            return '';
+        }
+
+        $value = $payload['marketplace'] ?? '';
+
+        return is_string($value) ? $value : '';
+    }
     private function previewResultToArray(DefaultCostMappingPreviewResult $result): array
     {
         return [

--- a/site/src/Marketplace/Controller/CostPLMappingDefaultSetupController.php
+++ b/site/src/Marketplace/Controller/CostPLMappingDefaultSetupController.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Controller;
+
+use App\Marketplace\Application\Action\ApplyDefaultCostMappingAction;
+use App\Marketplace\Application\Action\PreviewDefaultCostMappingAction;
+use App\Marketplace\Application\Command\ApplyDefaultCostMappingCommand;
+use App\Marketplace\Application\Command\PreviewDefaultCostMappingCommand;
+use App\Marketplace\Application\DTO\DefaultCostMappingApplyResult;
+use App\Marketplace\Application\DTO\DefaultCostMappingPreviewItem;
+use App\Marketplace\Application\DTO\DefaultCostMappingPreviewResult;
+use App\Shared\Service\ActiveCompanyService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route('/marketplace/cost-pl-mapping/default')]
+#[IsGranted('ROLE_USER')]
+final class CostPLMappingDefaultSetupController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $activeCompanyService,
+        private readonly PreviewDefaultCostMappingAction $previewAction,
+        private readonly ApplyDefaultCostMappingAction $applyAction,
+    ) {
+    }
+
+    #[Route('/preview', name: 'marketplace_cost_pl_mapping_default_preview', methods: ['POST'])]
+    public function preview(Request $request): JsonResponse
+    {
+        if (!$this->isCsrfTokenValid('marketplace_default_cost_mapping', (string) $request->request->get('_token'))) {
+            return $this->json(['ok' => false, 'message' => 'Некорректный CSRF token.'], JsonResponse::HTTP_FORBIDDEN);
+        }
+
+        try {
+            $companyId = (string) $this->activeCompanyService->getActiveCompany()->getId();
+            $marketplace = (string) $request->request->get('marketplace', '');
+            $result = ($this->previewAction)(new PreviewDefaultCostMappingCommand($companyId, $marketplace));
+
+            return $this->json($this->previewResultToArray($result));
+        } catch (\DomainException $e) {
+            return $this->json(['ok' => false, 'message' => $e->getMessage()]);
+        }
+    }
+
+    #[Route('/apply', name: 'marketplace_cost_pl_mapping_default_apply', methods: ['POST'])]
+    public function apply(Request $request): JsonResponse
+    {
+        if (!$this->isCsrfTokenValid('marketplace_default_cost_mapping', (string) $request->request->get('_token'))) {
+            return $this->json(['ok' => false, 'message' => 'Некорректный CSRF token.'], JsonResponse::HTTP_FORBIDDEN);
+        }
+
+        $user = $this->getUser();
+        if ($user === null || !method_exists($user, 'getId')) {
+            throw $this->createAccessDeniedException('Пользователь не найден.');
+        }
+
+        try {
+            $companyId = (string) $this->activeCompanyService->getActiveCompany()->getId();
+            $marketplace = (string) $request->request->get('marketplace', '');
+            $result = ($this->applyAction)(new ApplyDefaultCostMappingCommand($companyId, $marketplace, (string) $user->getId()));
+
+            return $this->json($this->applyResultToArray($result));
+        } catch (\DomainException $e) {
+            return $this->json(['ok' => false, 'message' => $e->getMessage()]);
+        }
+    }
+
+    private function previewResultToArray(DefaultCostMappingPreviewResult $result): array
+    {
+        return [
+            'ok' => true,
+            'marketplace' => $result->getMarketplace()->value,
+            'summary' => $result->getSummary(),
+            'hasBlockingIssues' => $result->hasBlockingIssues(),
+            'items' => array_map(fn (DefaultCostMappingPreviewItem $item): array => $this->previewItemToArray($item), $result->getItems()),
+        ];
+    }
+
+    private function previewItemToArray(DefaultCostMappingPreviewItem $item): array
+    {
+        return [
+            'status' => $item->getStatus()->value,
+            'costCode' => $item->getCostCode(),
+            'costCategoryId' => $item->getCostCategoryId(),
+            'costCategoryName' => $item->getCostCategoryName(),
+            'plCode' => $item->getPlCode(),
+            'plCategoryId' => $item->getPlCategoryId(),
+            'plCategoryName' => $item->getPlCategoryName(),
+            'existingMappingId' => $item->getExistingMappingId(),
+            'existingPlCategoryId' => $item->getExistingPlCategoryId(),
+            'existingPlCategoryName' => $item->getExistingPlCategoryName(),
+            'includeInPl' => $item->isIncludeInPl(),
+            'isNegative' => $item->isNegative(),
+            'confidence' => $item->getConfidence()->value,
+            'note' => $item->getNote(),
+            'message' => $item->getMessage(),
+        ];
+    }
+
+    private function applyResultToArray(DefaultCostMappingApplyResult $result): array
+    {
+        return [
+            'ok' => true,
+            'marketplace' => $result->getMarketplace()->value,
+            'summary' => $result->getSummary(),
+            'createdCostCodes' => $result->getCreatedCostCodes(),
+            'updatedCostCodes' => $result->getUpdatedCostCodes(),
+            'skippedCostCodes' => $result->getSkippedCostCodes(),
+        ];
+    }
+}

--- a/site/src/Marketplace/Controller/CostPLMappingDefaultSetupController.php
+++ b/site/src/Marketplace/Controller/CostPLMappingDefaultSetupController.php
@@ -56,7 +56,7 @@ final class CostPLMappingDefaultSetupController extends AbstractController
 
         $user = $this->getUser();
         if ($user === null || !method_exists($user, 'getId')) {
-            throw $this->createAccessDeniedException('Пользователь не найден.');
+            return $this->json(['ok' => false, 'message' => 'Пользователь не найден.'], JsonResponse::HTTP_FORBIDDEN);
         }
 
         try {
@@ -69,9 +69,6 @@ final class CostPLMappingDefaultSetupController extends AbstractController
             return $this->json(['ok' => false, 'message' => $e->getMessage()]);
         }
     }
-
-
-
     private function extractCsrfToken(Request $request): string
     {
         $token = $request->request->getString('_token', '');
@@ -79,10 +76,7 @@ final class CostPLMappingDefaultSetupController extends AbstractController
             return $token;
         }
 
-        $payload = json_decode((string) $request->getContent(), true);
-        if (!is_array($payload)) {
-            return '';
-        }
+        $payload = $this->extractJsonPayload($request);
 
         $value = $payload['_token'] ?? '';
 
@@ -96,15 +90,30 @@ final class CostPLMappingDefaultSetupController extends AbstractController
             return $marketplace;
         }
 
-        $payload = json_decode((string) $request->getContent(), true);
-        if (!is_array($payload)) {
-            return '';
-        }
+        $payload = $this->extractJsonPayload($request);
 
         $value = $payload['marketplace'] ?? '';
 
         return is_string($value) ? $value : '';
     }
+
+    /** @return array<string, mixed> */
+    private function extractJsonPayload(Request $request): array
+    {
+        $content = (string) $request->getContent();
+        if ($content === '') {
+            return [];
+        }
+
+        try {
+            $payload = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return [];
+        }
+
+        return is_array($payload) ? $payload : [];
+    }
+
     private function previewResultToArray(DefaultCostMappingPreviewResult $result): array
     {
         return [

--- a/site/tests/Functional/Marketplace/Controller/CostPLMappingDefaultSetupControllerTest.php
+++ b/site/tests/Functional/Marketplace/Controller/CostPLMappingDefaultSetupControllerTest.php
@@ -105,6 +105,7 @@ final class CostPLMappingDefaultSetupControllerTest extends WebTestCaseBase
         ]);
         $payload = json_decode((string) $client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         self::assertFalse($payload['ok']);
+        self::assertArrayHasKey('message', $payload);
 
         $client->request('POST', '/marketplace/cost-pl-mapping/default/preview', [
             'marketplace' => 'unknown',

--- a/site/tests/Functional/Marketplace/Controller/CostPLMappingDefaultSetupControllerTest.php
+++ b/site/tests/Functional/Marketplace/Controller/CostPLMappingDefaultSetupControllerTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Marketplace\Controller;
+
+use App\Company\Entity\Company;
+use App\Company\Entity\User;
+use App\Finance\Enum\PLCategoryType;
+use App\Marketplace\Entity\MarketplaceCostCategory;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Builders\Finance\PLCategoryBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+final class CostPLMappingDefaultSetupControllerTest extends WebTestCaseBase
+{
+    public function testPreviewReturnsOkAndIsReadOnly(): void
+    {
+        $this->resetDb();
+        $client = static::createClient();
+        [$user, $company] = $this->seedBaseData();
+        $this->loginWithActiveCompany($client, $user, $company);
+
+        $before = $this->countMappings();
+        $client->request('POST', '/marketplace/cost-pl-mapping/default/preview', [
+            'marketplace' => 'ozon',
+            '_token' => $this->csrf($client),
+        ]);
+
+        self::assertResponseIsSuccessful();
+        $payload = json_decode((string) $client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        self::assertTrue($payload['ok']);
+        self::assertArrayHasKey('summary', $payload);
+        self::assertSame($before, $this->countMappings());
+    }
+
+    public function testApplyIsIdempotentAndUsesActiveCompany(): void
+    {
+        $this->resetDb();
+        $client = static::createClient();
+        [$user, $company] = $this->seedBaseData();
+        $this->loginWithActiveCompany($client, $user, $company);
+
+        $client->request('POST', '/marketplace/cost-pl-mapping/default/apply', [
+            'marketplace' => 'ozon',
+            'companyId' => Uuid::uuid4()->toString(),
+            '_token' => $this->csrf($client),
+        ]);
+        self::assertResponseIsSuccessful();
+        $first = json_decode((string) $client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        self::assertTrue($first['ok']);
+
+        $createdAfterFirst = $this->countMappings();
+        self::assertGreaterThan(0, $createdAfterFirst);
+
+        $client->request('POST', '/marketplace/cost-pl-mapping/default/apply', [
+            'marketplace' => 'ozon',
+            '_token' => $this->csrf($client),
+        ]);
+        self::assertResponseIsSuccessful();
+        $second = json_decode((string) $client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        self::assertTrue($second['ok']);
+        self::assertSame($createdAfterFirst, $this->countMappings());
+    }
+
+    public function testApplyReturnsErrorForBlockingIssuesAndInvalidMarketplace(): void
+    {
+        $this->resetDb();
+        $client = static::createClient();
+        [$user, $company] = $this->seedBaseData(false);
+        $this->loginWithActiveCompany($client, $user, $company);
+
+        $client->request('POST', '/marketplace/cost-pl-mapping/default/apply', [
+            'marketplace' => 'ozon',
+            '_token' => $this->csrf($client),
+        ]);
+        $payload = json_decode((string) $client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        self::assertFalse($payload['ok']);
+
+        $client->request('POST', '/marketplace/cost-pl-mapping/default/preview', [
+            'marketplace' => 'unknown',
+            '_token' => $this->csrf($client),
+        ]);
+        $payload = json_decode((string) $client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        self::assertFalse($payload['ok']);
+    }
+
+    public function testInvalidCsrfReturnsError(): void
+    {
+        $this->resetDb();
+        $client = static::createClient();
+        [$user, $company] = $this->seedBaseData();
+        $this->loginWithActiveCompany($client, $user, $company);
+
+        $client->request('POST', '/marketplace/cost-pl-mapping/default/apply', [
+            'marketplace' => 'ozon',
+            '_token' => 'invalid',
+        ]);
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    private function csrf(KernelBrowser $client): string
+    {
+        return $client->getContainer()->get('security.csrf.token_manager')->getToken('marketplace_default_cost_mapping')->getValue();
+    }
+
+    private function countMappings(): int
+    {
+        return (int) $this->em()->getConnection()->fetchOne('SELECT COUNT(*) FROM marketplace_cost_pl_mappings');
+    }
+
+    private function loginWithActiveCompany(KernelBrowser $client, User $user, Company $company): void
+    {
+        $client->loginUser($user);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', $company->getId());
+        $session->save();
+    }
+
+    private function seedBaseData(bool $withAllPlCodes = true): array
+    {
+        $user = UserBuilder::aUser()->withEmail('default-mapping@test.local')->build();
+        $company = CompanyBuilder::aCompany()->withOwner($user)->build();
+        $em = $this->em();
+        $em->persist($user);
+        $em->persist($company);
+
+        $codes = ['ozon_sale_commission', 'ozon_logistic_direct'];
+        foreach ($codes as $i => $code) {
+            $cost = new MarketplaceCostCategory(Uuid::uuid4()->toString(), $company, MarketplaceType::OZON);
+            $cost->setName('Cost '.$i)->setCode($code);
+            $em->persist($cost);
+        }
+
+        $plCodes = $withAllPlCodes ? ['COGS_MP_COMMISSION', 'COGS_DELIVERY'] : ['COGS_MP_COMMISSION'];
+        foreach ($plCodes as $code) {
+            $pl = PLCategoryBuilder::aPLCategory()->forCompany($company)->withName($code)->build();
+            $pl->setCode($code);
+            $pl->setType(PLCategoryType::LEAF_INPUT);
+            $em->persist($pl);
+        }
+
+        $em->flush();
+
+        return [$user, $company];
+    }
+}

--- a/site/tests/Functional/Marketplace/Controller/CostPLMappingDefaultSetupControllerTest.php
+++ b/site/tests/Functional/Marketplace/Controller/CostPLMappingDefaultSetupControllerTest.php
@@ -38,6 +38,31 @@ final class CostPLMappingDefaultSetupControllerTest extends WebTestCaseBase
         self::assertSame($before, $this->countMappings());
     }
 
+
+
+    public function testPreviewAcceptsJsonBody(): void
+    {
+        $this->resetDb();
+        $client = static::createClient();
+        [$user, $company] = $this->seedBaseData();
+        $this->loginWithActiveCompany($client, $user, $company);
+
+        $client->request(
+            'POST',
+            '/marketplace/cost-pl-mapping/default/preview',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode([
+                'marketplace' => 'ozon',
+                '_token' => $this->csrf($client),
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        self::assertResponseIsSuccessful();
+        $payload = json_decode((string) $client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        self::assertTrue($payload['ok']);
+        self::assertSame('ozon', $payload['marketplace']);
+    }
+
     public function testApplyIsIdempotentAndUsesActiveCompany(): void
     {
         $this->resetDb();


### PR DESCRIPTION
### Motivation
- Provide AJAX-ready endpoints for previewing and applying the default Marketplace→P&L cost mapping so a future modal UI can consume them.
- Controller must be thin, use `ActiveCompanyService` for the active company, and delegate to existing actions/commands without embedding business logic.

### Description
- Added `CostPLMappingDefaultSetupController` with two POST routes: `marketplace_cost_pl_mapping_default_preview` (`/marketplace/cost-pl-mapping/default/preview`) and `marketplace_cost_pl_mapping_default_apply` (`/marketplace/cost-pl-mapping/default/apply`).
- Controller performs CSRF checks using token id `marketplace_default_cost_mapping`, uses `ActiveCompanyService` to resolve the company, extracts actor user id from the current user, delegates work to `PreviewDefaultCostMappingAction` and `ApplyDefaultCostMappingAction`, and catches `DomainException` to return `{ ok: false, message }` JSON.
- Maps preview/apply DTOs to JSON via private mappers (`previewResultToArray`, `previewItemToArray`, `applyResultToArray`) returning the formats required by the spec; does not perform redirects or flash messages and does not run month-close/recalculate logic.
- Added DI binding for `App\Marketplace\Infrastructure\Provider\DefaultCostMappingYamlProvider` in `site/config/services.yaml` with `$configPath: "%kernel.project_dir%/config/marketplace/default_cost_mapping.yaml"`.
- Added functional test `site/tests/Functional/Marketplace/Controller/CostPLMappingDefaultSetupControllerTest.php` covering preview/read-only behavior, apply idempotency, blocking/invalid marketplace responses, CSRF handling, and use of active company.

### Testing
- Functional tests were added: `site/tests/Functional/Marketplace/Controller/CostPLMappingDefaultSetupControllerTest.php` (not executed in CI here, included in PR).
- Attempted to run `vendor/bin/phpunit` for the new functional test, but test run could not be executed because project dependencies are not installed (`vendor/bin/phpunit` missing).
- Ran `php bin/console lint:container` but it failed with `Dependencies are missing. Try running "composer install".` so container/schema validation could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1f12d3f24832399c999c695c1ffbb)