### PR TITLE
Add UI and modal for default Marketplace cost→P&L mapping (preview/apply)

### DIFF
--- a/site/templates/marketplace/cost_pl_mapping/_default_mapping_modal.html.twig
+++ b/site/templates/marketplace/cost_pl_mapping/_default_mapping_modal.html.twig
@@ -1,0 +1,42 @@
+<div class="modal modal-blur fade" id="modal-default-cost-mapping" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-xl modal-dialog-scrollable" role="document">
+        <div class="modal-content"
+             data-default-mapping-modal
+             data-preview-url="{{ path('marketplace_cost_pl_mapping_default_preview') }}"
+             data-apply-url="{{ path('marketplace_cost_pl_mapping_default_apply') }}"
+             data-csrf-token="{{ csrf_token('marketplace_default_cost_mapping') }}">
+            <div class="modal-header">
+                <h5 class="modal-title">Базовый маппинг затрат</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="alert alert-danger d-none" data-default-mapping-blocking>
+                    Есть блокирующие проблемы. Исправьте категории ОПиУ перед применением.
+                </div>
+                <div class="alert alert-warning d-none" data-default-mapping-warning>
+                    В части правил отсутствуют категории затрат маркетплейса. Эти элементы будут пропущены.
+                </div>
+                <div class="alert alert-danger d-none" data-default-mapping-error></div>
+                <div class="alert alert-success d-none" data-default-mapping-success></div>
+
+                <div class="d-flex align-items-center gap-2 text-muted d-none" data-default-mapping-loading>
+                    <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                    Загрузка preview…
+                </div>
+
+                <div class="d-none" data-default-mapping-empty>
+                    <div class="alert alert-info mb-0">Для выбранного маркетплейса нет правил базового маппинга.</div>
+                </div>
+
+                <div data-default-mapping-preview></div>
+            </div>
+            <div class="modal-footer">
+                <small class="text-muted me-auto" data-default-mapping-apply-hint></small>
+                <button type="button" class="btn" data-bs-dismiss="modal">Закрыть</button>
+                <button type="button" class="btn btn-primary" data-default-mapping-apply disabled>
+                    Применить базовый маппинг
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/site/templates/marketplace/cost_pl_mapping/index.html.twig
+++ b/site/templates/marketplace/cost_pl_mapping/index.html.twig
@@ -292,10 +292,21 @@
                     headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
                     body: JSON.stringify(payload)
                 });
-                var data = await res.json();
-                if (!res.ok || data.ok === false) {
-                    throw new Error(data.message || 'Ошибка запроса.');
+
+                var responseText = await res.text();
+                var data = null;
+                if (responseText) {
+                    try {
+                        data = JSON.parse(responseText);
+                    } catch (e) {
+                        throw new Error('Сервер вернул неожиданный ответ. Обновите страницу и повторите попытку.');
+                    }
                 }
+
+                if (!res.ok || !data || data.ok === false) {
+                    throw new Error((data && data.message) ? data.message : 'Ошибка запроса. Попробуйте позже.');
+                }
+
                 return data;
             }
 
@@ -328,8 +339,7 @@
                 }
             }
 
-            document.querySelector('[data-default-mapping-open]').addEventListener('click', function () {
-                modal.show();
+            modalEl.addEventListener('show.bs.modal', function () {
                 loadPreview();
             });
 

--- a/site/templates/marketplace/cost_pl_mapping/index.html.twig
+++ b/site/templates/marketplace/cost_pl_mapping/index.html.twig
@@ -264,7 +264,10 @@
                     return '<div class="col-md-3 col-sm-6"><div class="card card-sm"><div class="card-body"><div class="text-muted small">'+statusLabels[key]+'</div><div class="h2 m-0">'+(summary[key] || 0)+'</div></div></div></div>';
                 }).join('');
 
-                var tabs = Object.keys(statusLabels).map(function (key, i) {
+                var tabHeaders = [];
+                var tabPanes = [];
+
+                Object.keys(statusLabels).forEach(function (key, i) {
                     var items = (payload.groupedItems && payload.groupedItems[key]) ? payload.groupedItems[key] : [];
                     var active = i === 0 ? 'active' : '';
                     var show = i === 0 ? 'show active' : '';
@@ -273,13 +276,14 @@
                         var confClass = conf === 'high' ? 'bg-green-lt' : (conf === 'medium' ? 'bg-yellow-lt' : 'bg-red-lt');
                         return '<div class="border rounded p-2 mb-2"><div class="d-flex justify-content-between"><span class="badge bg-blue-lt">'+escapeHtml(statusLabels[item.status] || item.status || key)+'</span><span class="badge '+confClass+'">'+escapeHtml(conf)+'</span></div><div class="small mt-2"><strong>Затрата:</strong> '+escapeHtml(item.costCode)+' — '+escapeHtml(item.costCategoryName)+'</div><div class="small"><strong>ОПиУ:</strong> '+escapeHtml(item.plCode)+' — '+escapeHtml(item.plCategoryName)+'</div><div class="small text-muted">'+escapeHtml(item.note || '')+' '+escapeHtml(item.message || '')+'</div></div>';
                     }).join('') : '<div class="text-muted small">Нет элементов.</div>';
-                    return '<li class="nav-item" role="presentation"><button class="nav-link '+active+'" data-bs-toggle="tab" data-bs-target="#map-tab-'+key+'" type="button">'+statusLabels[key]+' <span class="badge bg-secondary-lt">'+items.length+'</span></button></li>' +
-                        '<div class="tab-pane fade '+show+'" id="map-tab-'+key+'" role="tabpanel">'+rows+'</div>';
+
+                    tabHeaders.push('<li class="nav-item" role="presentation"><button class="nav-link '+active+'" data-bs-toggle="tab" data-bs-target="#map-tab-'+key+'" type="button" role="tab">'+statusLabels[key]+' <span class="badge bg-secondary-lt">'+items.length+'</span></button></li>');
+                    tabPanes.push('<div class="tab-pane fade '+show+'" id="map-tab-'+key+'" role="tabpanel">'+rows+'</div>');
                 });
 
                 previewEl.innerHTML = '<div class="row g-2 mb-3">'+cards+'</div>'+
-                    '<ul class="nav nav-tabs mb-2" role="tablist">'+tabs.filter(function(_,i){return i%2===0;}).join('')+'</ul>'+
-                    '<div class="tab-content">'+tabs.filter(function(_,i){return i%2===1;}).join('')+'</div>';
+                    '<ul class="nav nav-tabs mb-2" role="tablist">'+tabHeaders.join('')+'</ul>'+
+                    '<div class="tab-content">'+tabPanes.join('')+'</div>';
             }
 
             async function fetchJson(url, payload) {

--- a/site/templates/marketplace/cost_pl_mapping/index.html.twig
+++ b/site/templates/marketplace/cost_pl_mapping/index.html.twig
@@ -9,7 +9,7 @@
               class="mb-4 d-flex align-items-end gap-3">
             <div>
                 <label class="form-label">Маркетплейс</label>
-                <select name="marketplace" class="form-select w-auto" onchange="this.form.submit()">
+                <select name="marketplace" class="form-select w-auto" onchange="this.form.submit()" data-marketplace-select>
                     <option value="">Все маркетплейсы</option>
                     {% for mp in available_marketplaces %}
                         <option value="{{ mp.value }}"
@@ -19,6 +19,13 @@
                     {% endfor %}
                 </select>
             </div>
+            <button type="button"
+                    class="btn btn-outline-primary"
+                    data-default-mapping-open
+                    data-bs-toggle="modal"
+                    data-bs-target="#modal-default-cost-mapping">
+                Настроить базовый маппинг
+            </button>
         </form>
 
         {% if cost_categories is empty %}
@@ -116,6 +123,8 @@
 
     </div>
 
+    {% include 'marketplace/cost_pl_mapping/_default_mapping_modal.html.twig' %}
+
     {# Modal: Удалить категорию затрат #}
     <div class="modal modal-blur fade" id="modal-delete-cost-category" tabindex="-1" role="dialog" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered" role="document">
@@ -164,5 +173,181 @@
             document.getElementById('delete-modal-token').value = btn.getAttribute('data-token');
             document.getElementById('form-delete-cost-category').action = url;
         });
+
+        (function () {
+            var modalRoot = document.querySelector('[data-default-mapping-modal]');
+            if (!modalRoot) {
+                return;
+            }
+
+            var modalEl = document.getElementById('modal-default-cost-mapping');
+            var modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+            var previewUrl = modalRoot.getAttribute('data-preview-url');
+            var applyUrl = modalRoot.getAttribute('data-apply-url');
+            var token = modalRoot.getAttribute('data-csrf-token');
+            var selectEl = document.querySelector('[data-marketplace-select]');
+
+            var loadingEl = modalRoot.querySelector('[data-default-mapping-loading]');
+            var previewEl = modalRoot.querySelector('[data-default-mapping-preview]');
+            var emptyEl = modalRoot.querySelector('[data-default-mapping-empty]');
+            var errorEl = modalRoot.querySelector('[data-default-mapping-error]');
+            var successEl = modalRoot.querySelector('[data-default-mapping-success]');
+            var blockingEl = modalRoot.querySelector('[data-default-mapping-blocking]');
+            var warningEl = modalRoot.querySelector('[data-default-mapping-warning]');
+            var hintEl = modalRoot.querySelector('[data-default-mapping-apply-hint]');
+            var applyBtn = modalRoot.querySelector('[data-default-mapping-apply]');
+
+            var state = {preview: null, loading: false, applying: false};
+            var statusLabels = {
+                will_create: 'Будет создано',
+                will_fill_empty: 'Будет дополнено',
+                skipped_existing: 'Уже настроено',
+                skipped_disabled: 'Отключено вручную',
+                missing_cost_category: 'Нет категории МП',
+                missing_pl_category: 'Нет статьи ОПиУ',
+                invalid_target_category: 'Невалидная статья ОПиУ'
+            };
+
+            function escapeHtml(text) {
+                return String(text ?? '').replace(/[&<>"']/g, function (char) {
+                    return ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#039;'})[char];
+                });
+            }
+
+            function currentMarketplace() {
+                return selectEl ? selectEl.value : '';
+            }
+
+            function showError(message) {
+                errorEl.textContent = message;
+                errorEl.classList.remove('d-none');
+            }
+
+            function hideAlerts() {
+                [errorEl, successEl, blockingEl, warningEl].forEach(function (el) {
+                    el.classList.add('d-none');
+                });
+            }
+
+            function updateApplyState() {
+                var summary = state.preview ? state.preview.summary || {} : {};
+                var actionable = (summary.will_create || 0) + (summary.will_fill_empty || 0);
+                var hasBlocking = Boolean(state.preview && state.preview.hasBlockingIssues);
+                var disabled = !state.preview || state.loading || state.applying || hasBlocking || actionable === 0;
+                applyBtn.disabled = disabled;
+
+                if (!state.preview) {
+                    hintEl.textContent = 'Сначала загрузите preview.';
+                } else if (hasBlocking) {
+                    hintEl.textContent = 'Применение недоступно из-за блокирующих проблем.';
+                } else if (actionable === 0) {
+                    hintEl.textContent = 'Нет новых маппингов для применения.';
+                } else {
+                    hintEl.textContent = '';
+                }
+            }
+
+            function renderPreview(payload) {
+                previewEl.innerHTML = '';
+                emptyEl.classList.add('d-none');
+
+                var summary = payload.summary || {};
+                if ((payload.total || 0) === 0) {
+                    emptyEl.classList.remove('d-none');
+                    return;
+                }
+
+                if (payload.hasBlockingIssues) blockingEl.classList.remove('d-none');
+                if ((summary.missing_cost_category || 0) > 0) warningEl.classList.remove('d-none');
+
+                var cards = Object.keys(statusLabels).map(function (key) {
+                    return '<div class="col-md-3 col-sm-6"><div class="card card-sm"><div class="card-body"><div class="text-muted small">'+statusLabels[key]+'</div><div class="h2 m-0">'+(summary[key] || 0)+'</div></div></div></div>';
+                }).join('');
+
+                var tabs = Object.keys(statusLabels).map(function (key, i) {
+                    var items = (payload.groupedItems && payload.groupedItems[key]) ? payload.groupedItems[key] : [];
+                    var active = i === 0 ? 'active' : '';
+                    var show = i === 0 ? 'show active' : '';
+                    var rows = items.length ? items.map(function (item) {
+                        var conf = item.confidence || 'n/a';
+                        var confClass = conf === 'high' ? 'bg-green-lt' : (conf === 'medium' ? 'bg-yellow-lt' : 'bg-red-lt');
+                        return '<div class="border rounded p-2 mb-2"><div class="d-flex justify-content-between"><span class="badge bg-blue-lt">'+escapeHtml(statusLabels[item.status] || item.status || key)+'</span><span class="badge '+confClass+'">'+escapeHtml(conf)+'</span></div><div class="small mt-2"><strong>Затрата:</strong> '+escapeHtml(item.costCode)+' — '+escapeHtml(item.costCategoryName)+'</div><div class="small"><strong>ОПиУ:</strong> '+escapeHtml(item.plCode)+' — '+escapeHtml(item.plCategoryName)+'</div><div class="small text-muted">'+escapeHtml(item.note || '')+' '+escapeHtml(item.message || '')+'</div></div>';
+                    }).join('') : '<div class="text-muted small">Нет элементов.</div>';
+                    return '<li class="nav-item" role="presentation"><button class="nav-link '+active+'" data-bs-toggle="tab" data-bs-target="#map-tab-'+key+'" type="button">'+statusLabels[key]+' <span class="badge bg-secondary-lt">'+items.length+'</span></button></li>' +
+                        '<div class="tab-pane fade '+show+'" id="map-tab-'+key+'" role="tabpanel">'+rows+'</div>';
+                });
+
+                previewEl.innerHTML = '<div class="row g-2 mb-3">'+cards+'</div>'+
+                    '<ul class="nav nav-tabs mb-2" role="tablist">'+tabs.filter(function(_,i){return i%2===0;}).join('')+'</ul>'+
+                    '<div class="tab-content">'+tabs.filter(function(_,i){return i%2===1;}).join('')+'</div>';
+            }
+
+            async function fetchJson(url, payload) {
+                var res = await fetch(url, {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
+                    body: JSON.stringify(payload)
+                });
+                var data = await res.json();
+                if (!res.ok || data.ok === false) {
+                    throw new Error(data.message || 'Ошибка запроса.');
+                }
+                return data;
+            }
+
+            async function loadPreview() {
+                hideAlerts();
+                previewEl.innerHTML = '';
+                emptyEl.classList.add('d-none');
+                var marketplace = currentMarketplace();
+                if (!marketplace) {
+                    showError('Выберите маркетплейс перед настройкой базового маппинга.');
+                    state.preview = null;
+                    updateApplyState();
+                    return;
+                }
+
+                state.loading = true;
+                updateApplyState();
+                loadingEl.classList.remove('d-none');
+                try {
+                    var payload = await fetchJson(previewUrl, {marketplace: marketplace, _token: token});
+                    state.preview = payload;
+                    renderPreview(payload);
+                } catch (e) {
+                    state.preview = null;
+                    showError(e.message);
+                } finally {
+                    state.loading = false;
+                    loadingEl.classList.add('d-none');
+                    updateApplyState();
+                }
+            }
+
+            document.querySelector('[data-default-mapping-open]').addEventListener('click', function () {
+                modal.show();
+                loadPreview();
+            });
+
+            applyBtn.addEventListener('click', async function () {
+                if (applyBtn.disabled) return;
+                state.applying = true;
+                hideAlerts();
+                applyBtn.textContent = 'Применяем...';
+                updateApplyState();
+                try {
+                    var data = await fetchJson(applyUrl, {marketplace: currentMarketplace(), _token: token});
+                    successEl.textContent = 'Базовый маппинг применён. Создано: ' + (data.summary.created || 0) + ', дополнено: ' + (data.summary.updated || 0) + ', пропущено: ' + (data.summary.skipped || 0);
+                    successEl.classList.remove('d-none');
+                    setTimeout(function () { window.location.reload(); }, 1000);
+                } catch (e) {
+                    showError(e.message);
+                } finally {
+                    state.applying = false;
+                    applyBtn.textContent = 'Применить базовый маппинг';
+                    updateApplyState();
+                }
+            });
+        })();
     </script>
 {% endblock %}

--- a/site/tests/Functional/Marketplace/Controller/CostPLMappingControllerTest.php
+++ b/site/tests/Functional/Marketplace/Controller/CostPLMappingControllerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Marketplace\Controller;
+
+use App\Company\Entity\Company;
+use App\Company\Entity\User;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+final class CostPLMappingControllerTest extends WebTestCaseBase
+{
+    public function testIndexRendersDefaultMappingUiElements(): void
+    {
+        $this->resetDb();
+        $client = static::createClient();
+        [$user, $company] = $this->seedBaseData();
+        $this->loginWithActiveCompany($client, $user, $company);
+
+        $client->request('GET', '/marketplace/cost-pl-mapping');
+
+        self::assertResponseIsSuccessful();
+        $html = (string) $client->getResponse()->getContent();
+
+        self::assertStringContainsString('Настроить базовый маппинг', $html);
+        self::assertStringContainsString('modal-default-cost-mapping', $html);
+        self::assertStringContainsString('/marketplace/cost-pl-mapping/default/preview', $html);
+        self::assertStringContainsString('/marketplace/cost-pl-mapping/default/apply', $html);
+
+        $csrf = $client->getContainer()->get('security.csrf.token_manager')
+            ->getToken('marketplace_default_cost_mapping')
+            ->getValue();
+        self::assertStringContainsString($csrf, $html);
+    }
+
+    private function loginWithActiveCompany(KernelBrowser $client, User $user, Company $company): void
+    {
+        $client->loginUser($user);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', $company->getId());
+        $session->save();
+    }
+
+    private function seedBaseData(): array
+    {
+        $user = UserBuilder::aUser()->withEmail('cost-pl-mapping@test.local')->build();
+        $company = CompanyBuilder::aCompany()->withOwner($user)->build();
+
+        $em = $this->em();
+        $em->persist($user);
+        $em->persist($company);
+        $em->flush();
+
+        return [$user, $company];
+    }
+}

--- a/site/tests/Functional/Marketplace/Controller/CostPLMappingControllerTest.php
+++ b/site/tests/Functional/Marketplace/Controller/CostPLMappingControllerTest.php
@@ -26,14 +26,16 @@ final class CostPLMappingControllerTest extends WebTestCaseBase
         $html = (string) $client->getResponse()->getContent();
 
         self::assertStringContainsString('Настроить базовый маппинг', $html);
-        self::assertStringContainsString('modal-default-cost-mapping', $html);
-        self::assertStringContainsString('/marketplace/cost-pl-mapping/default/preview', $html);
-        self::assertStringContainsString('/marketplace/cost-pl-mapping/default/apply', $html);
+        self::assertSelectorExists('#modal-default-cost-mapping [data-default-mapping-modal]');
+        self::assertSelectorExists('#modal-default-cost-mapping [data-default-mapping-apply]');
+
+        self::assertSelectorExists('[data-preview-url="/marketplace/cost-pl-mapping/default/preview"]');
+        self::assertSelectorExists('[data-apply-url="/marketplace/cost-pl-mapping/default/apply"]');
 
         $csrf = $client->getContainer()->get('security.csrf.token_manager')
             ->getToken('marketplace_default_cost_mapping')
             ->getValue();
-        self::assertStringContainsString($csrf, $html);
+        self::assertSelectorExists(sprintf('[data-csrf-token="%s"]', $csrf));
     }
 
     private function loginWithActiveCompany(KernelBrowser $client, User $user, Company $company): void


### PR DESCRIPTION
### Motivation
- Упростить и обезопасить массовое применение базового маппинга категорий затрат маркетплейса к статьям ОПиУ, предоставив preview и явный apply, чтобы не перезаписывать ручные настройки и не применять изменения молча.
- Сохранить существующий workflow ручного сохранения и удаления категорий, добавив независимый page-local UI для безопасного просмотра/применения default-правил.

### Description
- Добавлен partial-модал `site/templates/marketplace/cost_pl_mapping/_default_mapping_modal.html.twig` с состояниями `loading`, `error`, `empty`, `blocking` и data-атрибутами для `preview`/`apply` URL и CSRF токена (`marketplace_default_cost_mapping`).
- В шаблон `site/templates/marketplace/cost_pl_mapping/index.html.twig` добавлена кнопка `Настроить базовый маппинг`, подключение modal и атрибут `data-marketplace-select` на select, при этом существующая форма `bulk-save` и её поведение не изменены.
- Реализован page-local JavaScript (inline в том же Twig) который открывает modal, делает `POST` fetch на маршруты `marketplace_cost_pl_mapping_default_preview` и `marketplace_cost_pl_mapping_default_apply` с CSRF, рендерит summary cards и сгруппированные табы, и управляет состоянием кнопки `Применить базовый маппинг` согласно правилам (loading, applying, blocking issues, отсутствие actionable-элементов).
- Добавлен функциональный smoke-тест `site/tests/Functional/Marketplace/Controller/CostPLMappingControllerTest.php`, который проверяет рендер кнопки, наличие модала/ID, наличия путей preview/apply в HTML и присутствие CSRF токена.

### Testing
- Добавлен и запущен локально smoke-functional тест на рендер страницы, но полноценный запуск `phpunit` и Symfony линтеров не выполнился из-за отсутствия установленных зависимостей в окружении (`composer install` не выполнен), поэтому автоматические тесты завершились с ошибкой окружения; файл теста добавлен и готов к выполнению в CI.
- Попытки запустить `php bin/phpunit` и `php bin/console lint:*` вернули ошибки о недостающих зависимостях (`vendor/symfony/phpunit-bridge/bin/simple-phpunit.php` и сообщение `Try running "composer install"`).
- Вручную в проекте проверена интеграция шаблонов и inclusion-механизм (инъекция partial и скрипта), и UI поведение реализовано локальным, небиблиотечным JS без изменения backend-логики и существующего bulk-save pipeline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20ad83aa083238f93d5bc4ec50a72)