### PR TITLE
Fix default cost mapping modal JS bindings and preview loading

### DIFF
--- a/site/templates/marketplace/cost_pl_mapping/index.html.twig
+++ b/site/templates/marketplace/cost_pl_mapping/index.html.twig
@@ -197,7 +197,7 @@
             var hintEl = modalRoot.querySelector('[data-default-mapping-apply-hint]');
             var applyBtn = modalRoot.querySelector('[data-default-mapping-apply]');
 
-            var state = {preview: null, loading: false, applying: false};
+            var state = {preview: null, loading: false, applying: false, previewRequested: false};
             var statusLabels = {
                 will_create: 'Будет создано',
                 will_fill_empty: 'Будет дополнено',
@@ -314,6 +314,7 @@
                 if (state.loading) {
                     return;
                 }
+                state.previewRequested = true;
                 hideAlerts();
                 previewEl.innerHTML = '';
                 emptyEl.classList.add('d-none');
@@ -345,13 +346,21 @@
 
             if (openBtn) {
                 openBtn.addEventListener('click', function () {
-                    loadPreview();
+                    if (modalEl && modalEl.classList.contains('show')) {
+                        loadPreview();
+                    }
                 });
             }
 
             if (modalEl) {
                 modalEl.addEventListener('shown.bs.modal', function () {
+                    if (state.previewRequested) {
+                        return;
+                    }
                     loadPreview();
+                });
+                modalEl.addEventListener('hidden.bs.modal', function () {
+                    state.previewRequested = false;
                 });
             }
 

--- a/site/templates/marketplace/cost_pl_mapping/index.html.twig
+++ b/site/templates/marketplace/cost_pl_mapping/index.html.twig
@@ -180,8 +180,8 @@
                 return;
             }
 
-            var modalEl = document.getElementById('modal-default-cost-mapping');
-            var modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+            var modalEl = document.querySelector('#modal-default-cost-mapping');
+            var openBtn = document.querySelector('[data-default-mapping-open]');
             var previewUrl = modalRoot.getAttribute('data-preview-url');
             var applyUrl = modalRoot.getAttribute('data-apply-url');
             var token = modalRoot.getAttribute('data-csrf-token');
@@ -311,9 +311,13 @@
             }
 
             async function loadPreview() {
+                if (state.loading) {
+                    return;
+                }
                 hideAlerts();
                 previewEl.innerHTML = '';
                 emptyEl.classList.add('d-none');
+                applyBtn.disabled = true;
                 var marketplace = currentMarketplace();
                 if (!marketplace) {
                     showError('Выберите маркетплейс перед настройкой базового маппинга.');
@@ -339,9 +343,17 @@
                 }
             }
 
-            modalEl.addEventListener('show.bs.modal', function () {
-                loadPreview();
-            });
+            if (openBtn) {
+                openBtn.addEventListener('click', function () {
+                    loadPreview();
+                });
+            }
+
+            if (modalEl) {
+                modalEl.addEventListener('shown.bs.modal', function () {
+                    loadPreview();
+                });
+            }
 
             applyBtn.addEventListener('click', async function () {
                 if (applyBtn.disabled) return;


### PR DESCRIPTION
### Motivation
- The default mapping modal opened but did not trigger preview POST to `marketplace_cost_pl_mapping_default_preview` because JS was bound to incorrect selectors in the template `site/templates/marketplace/cost_pl_mapping/index.html.twig`.
- The intent is to attach the preview/apply flow to the real DOM controls and avoid duplicate or missing preview requests without touching backend endpoints or action logic.

### Description
- Updated JS in `site/templates/marketplace/cost_pl_mapping/index.html.twig` to use real selectors: modal `#modal-default-cost-mapping`, open button `[data-default-mapping-open]`, and apply button `[data-default-mapping-apply]`.
- Wired preview loading to both the open button `click` and modal `shown.bs.modal` events and preserved existing apply flow using `data-apply-url` (route `marketplace_cost_pl_mapping_default_apply`).
- Added a guard to prevent concurrent preview requests (`if (state.loading) return`) and force-disabled the apply button before each preview fetch starts.
- Kept all backend routes and preview/apply logic unchanged and did not modify YAML, month-close, or manual bulk-save behavior.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f23343e5108323b01117e34eb43d51)