### PR TITLE
Mark legacy Wildberries fetcher pipeline and CLI command as deprecated

### DIFF
--- a/site/src/Marketplace/Command/MarketplaceSyncCommand.php
+++ b/site/src/Marketplace/Command/MarketplaceSyncCommand.php
@@ -20,6 +20,12 @@ use Symfony\Component\Console\Style\SymfonyStyle;
     name: 'marketplace:sync',
     description: 'Синхронизация данных с маркетплейсами'
 )]
+/**
+ * @deprecated Legacy CLI sync command.
+ *
+ * Основной WB initial/daily/manual sync использует WildberriesAdapter.
+ * Этот pipeline оставлен только для обратной совместимости; код не удалять.
+ */
 class MarketplaceSyncCommand extends Command
 {
     public function __construct(

--- a/site/src/Marketplace/Infrastructure/Api/Wildberries/WbFetcher.php
+++ b/site/src/Marketplace/Infrastructure/Api/Wildberries/WbFetcher.php
@@ -11,6 +11,12 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 #[AutoconfigureTag('marketplace.fetcher')]
+/**
+ * @deprecated Legacy Wildberries fetcher pipeline.
+ *
+ * Основной WB initial/daily/manual sync использует WildberriesAdapter.
+ * Этот pipeline оставлен только для обратной совместимости; код не удалять.
+ */
 final readonly class WbFetcher implements MarketplaceFetcherInterface
 {
     private const BASE_URL = 'https://statistics-api.wildberries.ru';


### PR DESCRIPTION
### Motivation
- Mark the legacy Wildberries fetcher pipeline as deprecated for clarity while keeping code and runtime behavior unchanged, and explicitly state that the main initial/daily/manual WB flow uses `WildberriesAdapter` and the legacy pipeline is retained for backward compatibility.  

### Description
- Added `@deprecated` PHPDoc with explanatory text to `site/src/Marketplace/Infrastructure/Api/Wildberries/WbFetcher.php` and to `site/src/Marketplace/Command/MarketplaceSyncCommand.php`, leaving all logic, service registration and the `marketplace:sync` command intact.  

### Testing
- Ran syntax checks with `php -l site/src/Marketplace/Infrastructure/Api/Wildberries/WbFetcher.php` and `php -l site/src/Marketplace/Command/MarketplaceSyncCommand.php`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f23af76c248323b33c402696986a50)