### PR TITLE
Wildberries adapter: add API exceptions, improved error handling, logging and tests

### DIFF
--- a/site/src/Marketplace/Exception/MarketplaceApiException.php
+++ b/site/src/Marketplace/Exception/MarketplaceApiException.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Exception;
+
+class MarketplaceApiException extends \RuntimeException
+{
+    public function __construct(
+        string $message,
+        private readonly int $statusCode,
+        private readonly string $responseExcerpt,
+        private readonly string $dateFrom,
+        private readonly string $dateTo,
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+
+    public function getResponseExcerpt(): string
+    {
+        return $this->responseExcerpt;
+    }
+
+    public function getDateFrom(): string
+    {
+        return $this->dateFrom;
+    }
+
+    public function getDateTo(): string
+    {
+        return $this->dateTo;
+    }
+}

--- a/site/src/Marketplace/Exception/MarketplaceAuthException.php
+++ b/site/src/Marketplace/Exception/MarketplaceAuthException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Exception;
+
+final class MarketplaceAuthException extends MarketplaceApiException
+{
+}

--- a/site/src/Marketplace/Exception/MarketplaceInvalidApiResponseException.php
+++ b/site/src/Marketplace/Exception/MarketplaceInvalidApiResponseException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Exception;
+
+final class MarketplaceInvalidApiResponseException extends MarketplaceApiException
+{
+}

--- a/site/src/Marketplace/Exception/MarketplaceRateLimitException.php
+++ b/site/src/Marketplace/Exception/MarketplaceRateLimitException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Exception;
+
+final class MarketplaceRateLimitException extends MarketplaceApiException
+{
+    public function __construct(
+        int $statusCode,
+        string $responseExcerpt,
+        string $dateFrom,
+        string $dateTo,
+        private readonly ?int $retryAfter = null,
+    ) {
+        parent::__construct('Marketplace API rate limit exceeded.', $statusCode, $responseExcerpt, $dateFrom, $dateTo);
+    }
+
+    public function getRetryAfter(): ?int
+    {
+        return $this->retryAfter;
+    }
+}

--- a/site/src/Marketplace/Exception/MarketplaceTemporaryApiException.php
+++ b/site/src/Marketplace/Exception/MarketplaceTemporaryApiException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Exception;
+
+final class MarketplaceTemporaryApiException extends MarketplaceApiException
+{
+}

--- a/site/src/Marketplace/Service/Integration/WildberriesAdapter.php
+++ b/site/src/Marketplace/Service/Integration/WildberriesAdapter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Marketplace\Service\Integration;
 
 use App\Company\Entity\Company;
@@ -9,7 +11,12 @@ use App\Marketplace\DTO\SaleData;
 use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Enum\MarketplaceConnectionType;
 use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Exception\MarketplaceAuthException;
+use App\Marketplace\Exception\MarketplaceInvalidApiResponseException;
+use App\Marketplace\Exception\MarketplaceRateLimitException;
+use App\Marketplace\Exception\MarketplaceTemporaryApiException;
 use App\Marketplace\Repository\MarketplaceConnectionRepository;
+use Psr\Log\LoggerInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class WildberriesAdapter implements MarketplaceAdapterInterface
@@ -19,6 +26,7 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
     public function __construct(
         private readonly HttpClientInterface $httpClient,
         private readonly MarketplaceConnectionRepository $connectionRepository,
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -60,20 +68,87 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
             throw new \RuntimeException('Wildberries connection not found');
         }
 
+        $dateFrom = $fromDate->format('Y-m-d');
+        $dateTo = $toDate->format('Y-m-d');
+
         $response = $this->httpClient->request('GET', self::BASE_URL.'/api/v5/supplier/reportDetailByPeriod', [
             'headers' => [
                 'Authorization' => $connection->getApiKey(),
             ],
             'query' => [
-                'dateFrom' => $fromDate->format('Y-m-d'),
-                'dateTo' => $toDate->format('Y-m-d'),
+                'dateFrom' => $dateFrom,
+                'dateTo' => $dateTo,
                 'limit' => 100000,
                 'rrdid' => 0,
-                'period' => 'daily',    // ← добавить
+                'period' => 'daily',
             ],
         ]);
 
-        return $response->toArray();
+        $statusCode = $response->getStatusCode();
+        $headers = $response->getHeaders(false);
+        $body = $response->getContent(false);
+        $excerpt = $this->createSafeExcerpt($body);
+
+        if (429 === $statusCode) {
+            $retryAfter = $this->extractRetryAfter($headers);
+            $this->logger->warning('WB API rate limit', [
+                'status_code' => $statusCode,
+                'retry_after' => $retryAfter,
+                'body_excerpt' => $excerpt,
+                'date_from' => $dateFrom,
+                'date_to' => $dateTo,
+            ]);
+
+            throw new MarketplaceRateLimitException($statusCode, $excerpt, $dateFrom, $dateTo, $retryAfter);
+        }
+
+        if (401 === $statusCode || 403 === $statusCode) {
+            $this->logger->warning('WB API auth error', [
+                'status_code' => $statusCode,
+                'body_excerpt' => $excerpt,
+                'date_from' => $dateFrom,
+                'date_to' => $dateTo,
+            ]);
+
+            throw new MarketplaceAuthException('WB API authentication failed.', $statusCode, $excerpt, $dateFrom, $dateTo);
+        }
+
+        if ($statusCode >= 500 && $statusCode <= 599) {
+            $this->logger->warning('WB API temporary error', [
+                'status_code' => $statusCode,
+                'body_excerpt' => $excerpt,
+                'date_from' => $dateFrom,
+                'date_to' => $dateTo,
+            ]);
+
+            throw new MarketplaceTemporaryApiException('WB API temporary error.', $statusCode, $excerpt, $dateFrom, $dateTo);
+        }
+
+        if (200 !== $statusCode) {
+            throw new MarketplaceTemporaryApiException('WB API unexpected status.', $statusCode, $excerpt, $dateFrom, $dateTo);
+        }
+
+        if ('' === trim($body)) {
+            return [];
+        }
+
+        try {
+            $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new MarketplaceInvalidApiResponseException('WB API returned invalid JSON.', $statusCode, $excerpt, $dateFrom, $dateTo, $e);
+        }
+
+        if (!is_array($decoded) || !array_is_list($decoded)) {
+            throw new MarketplaceInvalidApiResponseException('WB API JSON must be a list.', $statusCode, $excerpt, $dateFrom, $dateTo);
+        }
+
+        foreach ($decoded as $row) {
+            if (!is_array($row)) {
+                throw new MarketplaceInvalidApiResponseException('WB API JSON list items must be objects.', $statusCode, $excerpt, $dateFrom, $dateTo);
+            }
+        }
+
+        return $decoded;
     }
 
     public function fetchSales(
@@ -290,6 +365,25 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
         return 'wildberries::reportDetailByPeriod';
     }
 
+
+    private function extractRetryAfter(array $headers): ?int
+    {
+        $values = $headers['retry-after'] ?? $headers['Retry-After'] ?? null;
+        if (!is_array($values) || [] === $values) {
+            return null;
+        }
+
+        $raw = trim((string) $values[0]);
+
+        return ctype_digit($raw) ? (int) $raw : null;
+    }
+
+    private function createSafeExcerpt(string $body): string
+    {
+        $normalized = preg_replace('/\s+/', ' ', trim($body)) ?? '';
+
+        return mb_substr($normalized, 0, 500);
+    }
     private function getConnection(Company $company): ?MarketplaceConnection
     {
         return $this->connectionRepository->findByMarketplace(

--- a/site/tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php
+++ b/site/tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Service\Integration;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Exception\MarketplaceAuthException;
+use App\Marketplace\Exception\MarketplaceInvalidApiResponseException;
+use App\Marketplace\Exception\MarketplaceRateLimitException;
+use App\Marketplace\Exception\MarketplaceTemporaryApiException;
+use App\Marketplace\Repository\MarketplaceConnectionRepository;
+use App\Marketplace\Service\Integration\WildberriesAdapter;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class WildberriesAdapterTest extends TestCase
+{
+    public function testReturnsEmptyArrayForValidEmptyList(): void
+    {
+        $adapter = $this->createAdapter(new MockResponse('[]', ['http_code' => 200]));
+
+        self::assertSame([], $adapter->fetchRawReport($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-02')));
+    }
+
+    public function testThrowsRateLimitExceptionFor429(): void
+    {
+        $adapter = $this->createAdapter(new MockResponse('{"error":"too many"}', ['http_code' => 429, 'response_headers' => ['Retry-After: 15']]));
+
+        try {
+            $adapter->fetchRawReport($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-02'));
+            self::fail('Expected MarketplaceRateLimitException was not thrown');
+        } catch (MarketplaceRateLimitException $e) {
+            self::assertSame(429, $e->getStatusCode());
+            self::assertSame(15, $e->getRetryAfter());
+        }
+    }
+
+    public function testThrowsAuthExceptionFor401And403(): void
+    {
+        $adapter401 = $this->createAdapter(new MockResponse('', ['http_code' => 401]));
+        $adapter403 = $this->createAdapter(new MockResponse('', ['http_code' => 403]));
+
+        try {
+            $adapter401->fetchRawReport($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-02'));
+            self::fail('Expected MarketplaceAuthException for 401 was not thrown');
+        } catch (MarketplaceAuthException) {
+            self::assertTrue(true);
+        }
+
+        $this->expectException(MarketplaceAuthException::class);
+        $adapter403->fetchRawReport($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-02'));
+    }
+
+    public function testThrowsTemporaryExceptionFor500(): void
+    {
+        $adapter = $this->createAdapter(new MockResponse('{"error":"server"}', ['http_code' => 500]));
+
+        $this->expectException(MarketplaceTemporaryApiException::class);
+        $adapter->fetchRawReport($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-02'));
+    }
+
+    public function testReturnsEmptyArrayForEmptyBodyOn200(): void
+    {
+        $adapter = $this->createAdapter(new MockResponse('', ['http_code' => 200]));
+
+        self::assertSame([], $adapter->fetchRawReport($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-02')));
+    }
+
+
+    public function testThrowsInvalidResponseExceptionForScalarListItems(): void
+    {
+        $adapter = $this->createAdapter(new MockResponse('[1,2,3]', ['http_code' => 200]));
+
+        $this->expectException(MarketplaceInvalidApiResponseException::class);
+        $adapter->fetchRawReport($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-02'));
+    }
+
+    public function testThrowsInvalidResponseExceptionForInvalidJson(): void
+    {
+        $adapter = $this->createAdapter(new MockResponse('{invalid', ['http_code' => 200]));
+
+        $this->expectException(MarketplaceInvalidApiResponseException::class);
+        $adapter->fetchRawReport($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-02'));
+    }
+
+    private function createAdapter(MockResponse $response): WildberriesAdapter
+    {
+        $repo = $this->createMock(MarketplaceConnectionRepository::class);
+        $repo->method('findByMarketplace')->willReturn($this->connection());
+
+        return new WildberriesAdapter(new MockHttpClient($response), $repo, new NullLogger());
+    }
+
+    private function company(): Company
+    {
+        return $this->createMock(Company::class);
+    }
+
+    private function connection(): MarketplaceConnection
+    {
+        $connection = $this->createMock(MarketplaceConnection::class);
+        $connection->method('getApiKey')->willReturn('token');
+
+        return $connection;
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide robust and specific error handling for Wildberries API responses and expose structured information for callers. 
- Surface rate-limit, auth, temporary and invalid-response conditions via dedicated exception types for better upstream handling. 
- Capture safe response excerpts and `Retry-After` metadata to improve diagnostics and observability.

### Description

- Add a base exception `MarketplaceApiException` and specific subclasses `MarketplaceAuthException`, `MarketplaceRateLimitException`, `MarketplaceTemporaryApiException`, and `MarketplaceInvalidApiResponseException` with typed accessors for status, excerpt and date range. 
- Update `WildberriesAdapter` to accept a `LoggerInterface`, normalize `dateFrom`/`dateTo`, request the API and inspect status code and body instead of relying on `toArray()`. 
- Implement status-specific handling: throw `MarketplaceRateLimitException` for 429 (including parsed `Retry-After`), `MarketplaceAuthException` for 401/403, `MarketplaceTemporaryApiException` for 5xx and other unexpected statuses, return `[]` for empty 200 body, and validate JSON structure, throwing `MarketplaceInvalidApiResponseException` on invalid JSON or unexpected shape. 
- Add helper methods `extractRetryAfter()` and `createSafeExcerpt()` and restore the `period => 'daily'` query param.
- Add unit tests in `tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php` covering empty list, 429 rate-limit (with `Retry-After`), 401/403 auth, 500 temporary error, empty 200 body, scalar list items and invalid JSON.

### Testing

- Ran the new unit test class `tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php` under PHPUnit, which covers empty responses, 429, 401/403, 500, empty body, invalid item types and invalid JSON, and all tests passed. 
- Existing code paths for `fetchSales`/`fetchRawReport` retained their behavior where applicable and were exercised by the new tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2df77b9c08323a913ee83ba425faf)