### PR TITLE
InitialSyncHandler: add locking and marketplace API error handling and update tests

### DIFF
--- a/site/src/Marketplace/MessageHandler/InitialSyncHandler.php
+++ b/site/src/Marketplace/MessageHandler/InitialSyncHandler.php
@@ -9,13 +9,18 @@ use App\Marketplace\Application\Service\MarketplaceWeekPartitionService;
 use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Entity\MarketplaceRawDocument;
 use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Exception\MarketplaceAuthException;
+use App\Marketplace\Exception\MarketplaceRateLimitException;
+use App\Marketplace\Exception\MarketplaceTemporaryApiException;
 use App\Marketplace\Message\InitialSyncMessage;
 use App\Marketplace\Service\Integration\MarketplaceAdapterRegistry;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
@@ -31,6 +36,7 @@ final class InitialSyncHandler
     public function __construct(
         private readonly EntityManagerInterface $em,
         private readonly MarketplaceAdapterRegistry $adapterRegistry,
+        private readonly LockFactory $lockFactory,
         private readonly MessageBusInterface $messageBus,
         private readonly LoggerInterface $logger,
         private readonly MarketplaceWeekPartitionService $partitionService,
@@ -39,6 +45,32 @@ final class InitialSyncHandler
     }
 
     public function __invoke(InitialSyncMessage $message): void
+    {
+        $lock = $this->lockFactory->createLock(
+            sprintf('marketplace_initial_sync:%s:%s:%s', $message->companyId, $message->connectionId, $message->marketplace),
+            self::LOCK_TTL_SECONDS,
+        );
+
+        if (!$lock->acquire()) {
+            $this->logger->warning('InitialSync: lock not acquired, skipping batch', [
+                'company_id' => $message->companyId,
+                'connection_id' => $message->connectionId,
+                'marketplace' => $message->marketplace,
+                'date_from' => $message->dateFrom,
+                'date_to' => $message->dateTo,
+            ]);
+
+            return;
+        }
+
+        try {
+            $this->process($message);
+        } finally {
+            $lock->release();
+        }
+    }
+
+    private function process(InitialSyncMessage $message): void
     {
         $company = $this->em->find(Company::class, $message->companyId);
         if (!$company) {
@@ -155,6 +187,41 @@ final class InitialSyncHandler
                     'marketplace' => $message->marketplace,
                 ]);
             }
+        } catch (MarketplaceRateLimitException $e) {
+            $this->logger->warning('InitialSync: rate limit, batch retry scheduled', [
+                'company_id' => $message->companyId,
+                'connection_id' => $message->connectionId,
+                'marketplace' => $message->marketplace,
+                'date_from' => $message->dateFrom,
+                'date_to' => $message->dateTo,
+                'retry_after' => $e->getRetryAfter(),
+                'error' => $e->getMessage(),
+            ]);
+
+            throw new RecoverableMessageHandlingException($e->getMessage(), 0, $e);
+        } catch (MarketplaceAuthException $e) {
+            $this->logger->error('InitialSync: auth error, stopping sync chain', [
+                'company_id' => $message->companyId,
+                'connection_id' => $message->connectionId,
+                'marketplace' => $message->marketplace,
+                'date_from' => $message->dateFrom,
+                'date_to' => $message->dateTo,
+                'error' => $e->getMessage(),
+            ]);
+
+            $connection->markSyncFailed($e->getMessage());
+            $this->em->flush();
+        } catch (MarketplaceTemporaryApiException $e) {
+            $this->logger->warning('InitialSync: temporary API error, retry scheduled', [
+                'company_id' => $message->companyId,
+                'connection_id' => $message->connectionId,
+                'marketplace' => $message->marketplace,
+                'date_from' => $message->dateFrom,
+                'date_to' => $message->dateTo,
+                'error' => $e->getMessage(),
+            ]);
+
+            throw new RecoverableMessageHandlingException($e->getMessage(), 0, $e);
         } catch (\Throwable $e) {
             $this->logger->error('InitialSync: batch failed', [
                 'company_id'  => $message->companyId,

--- a/site/tests/Unit/Marketplace/MessageHandler/InitialSyncHandlerTest.php
+++ b/site/tests/Unit/Marketplace/MessageHandler/InitialSyncHandlerTest.php
@@ -8,6 +8,8 @@ use App\Company\Entity\Company;
 use App\Marketplace\Application\Service\MarketplaceWeekPartitionService;
 use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Exception\MarketplaceAuthException;
+use App\Marketplace\Exception\MarketplaceRateLimitException;
 use App\Marketplace\Message\InitialSyncMessage;
 use App\Marketplace\MessageHandler\InitialSyncHandler;
 use App\Marketplace\Service\Integration\MarketplaceAdapterInterface;
@@ -17,7 +19,10 @@ use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\LockInterface;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 final class InitialSyncHandlerTest extends TestCase
@@ -108,10 +113,92 @@ final class InitialSyncHandlerTest extends TestCase
         self::assertNull($dispatched->nextDateTo);
     }
 
+    public function testLockNotAcquiredSkipsBatch(): void
+    {
+        [$handler, $captured] = $this->createHandler(new MockClock('2026-04-10 12:00:00'), null, lockAcquired: false);
+
+        $handler(new InitialSyncMessage(
+            companyId: self::COMPANY_ID,
+            connectionId: self::CONNECTION_ID,
+            marketplace: MarketplaceType::OZON->value,
+            dateFrom: '2026-03-23 00:00:00',
+            dateTo: '2026-03-29 23:59:59',
+            nextDateFrom: '2026-03-30 00:00:00',
+            nextDateTo: '2026-03-31 23:59:59',
+        ));
+
+        self::assertNull($captured->message);
+    }
+
+    public function testEmptyBatchStillDispatchesNextMessage(): void
+    {
+        [$handler, $captured] = $this->createHandler(new MockClock('2026-04-10 12:00:00'), emptyRawData: true);
+
+        $handler(new InitialSyncMessage(
+            companyId: self::COMPANY_ID,
+            connectionId: self::CONNECTION_ID,
+            marketplace: MarketplaceType::OZON->value,
+            dateFrom: '2026-03-23 00:00:00',
+            dateTo: '2026-03-29 23:59:59',
+            nextDateFrom: '2026-03-30 00:00:00',
+            nextDateTo: '2026-03-31 23:59:59',
+        ));
+
+        self::assertInstanceOf(InitialSyncMessage::class, $captured->message);
+    }
+
+    public function testRateLimitDoesNotDispatchNextMessage(): void
+    {
+        [$handler, $captured] = $this->createHandler(
+            new MockClock('2026-04-10 12:00:00'),
+            new MarketplaceRateLimitException(429, 'rate-limit', '2026-03-23', '2026-03-29', 60),
+        );
+
+        try {
+            $handler(new InitialSyncMessage(
+                companyId: self::COMPANY_ID,
+                connectionId: self::CONNECTION_ID,
+                marketplace: MarketplaceType::OZON->value,
+                dateFrom: '2026-03-23 00:00:00',
+                dateTo: '2026-03-29 23:59:59',
+                nextDateFrom: '2026-03-30 00:00:00',
+                nextDateTo: '2026-03-31 23:59:59',
+            ));
+            self::fail('Expected RecoverableMessageHandlingException was not thrown.');
+        } catch (RecoverableMessageHandlingException) {
+            self::assertNull($captured->message);
+        }
+    }
+
+    public function testAuthErrorDoesNotDispatchNextMessage(): void
+    {
+        [$handler, $captured] = $this->createHandler(
+            new MockClock('2026-04-10 12:00:00'),
+            new MarketplaceAuthException('auth', 401, 'denied', '2026-03-23', '2026-03-29'),
+        );
+
+        $handler(new InitialSyncMessage(
+            companyId: self::COMPANY_ID,
+            connectionId: self::CONNECTION_ID,
+            marketplace: MarketplaceType::OZON->value,
+            dateFrom: '2026-03-23 00:00:00',
+            dateTo: '2026-03-29 23:59:59',
+            nextDateFrom: '2026-03-30 00:00:00',
+            nextDateTo: '2026-03-31 23:59:59',
+        ));
+
+        self::assertNull($captured->message);
+    }
+
     /**
      * @return array{0: InitialSyncHandler, 1: \stdClass} captured->message хранит последнее задиспатченное сообщение
      */
-    private function createHandler(MockClock $clock): array
+    private function createHandler(
+        MockClock $clock,
+        ?\Throwable $fetchException = null,
+        bool $lockAcquired = true,
+        bool $emptyRawData = false,
+    ): array
     {
         $company    = CompanyBuilder::aCompany()->withId(self::COMPANY_ID)->build();
         $connection = new MarketplaceConnection(
@@ -136,7 +223,13 @@ final class InitialSyncHandlerTest extends TestCase
         $adapter->method('getMarketplaceType')->willReturn(MarketplaceType::OZON->value);
         $adapter->method('getApiEndpointName')->willReturn('test/endpoint');
         // Непустой raw → handler сохранит MarketplaceRawDocument и дойдёт до dispatch.
-        $adapter->method('fetchRawReport')->willReturn([['ok' => 1]]);
+        if ($fetchException !== null) {
+            $adapter->method('fetchRawReport')->willThrowException($fetchException);
+        } elseif ($emptyRawData) {
+            $adapter->method('fetchRawReport')->willReturn([]);
+        } else {
+            $adapter->method('fetchRawReport')->willReturn([['ok' => 1]]);
+        }
 
         $registry = new MarketplaceAdapterRegistry([$adapter]);
 
@@ -146,18 +239,23 @@ final class InitialSyncHandlerTest extends TestCase
         $captured->message = null;
 
         $messageBus = $this->createMock(MessageBusInterface::class);
-        $messageBus
-            ->expects(self::once())
-            ->method('dispatch')
-            ->willReturnCallback(static function (object $message) use ($captured): Envelope {
-                $captured->message = $message;
+        $messageBus->method('dispatch')->willReturnCallback(static function (object $message) use ($captured): Envelope {
+            $captured->message = $message;
 
-                return new Envelope($message);
-            });
+            return new Envelope($message);
+        });
+
+        $lock = $this->createMock(LockInterface::class);
+        $lock->method('acquire')->willReturn($lockAcquired);
+        $lock->method('release');
+
+        $lockFactory = $this->createMock(LockFactory::class);
+        $lockFactory->method('createLock')->willReturn($lock);
 
         $handler = new InitialSyncHandler(
             $em,
             $registry,
+            $lockFactory,
             $messageBus,
             new NullLogger(),
             new MarketplaceWeekPartitionService(),


### PR DESCRIPTION
### Motivation

- Prevent concurrent processing of the same company/connection/marketplace batch to avoid duplicate sync work and race conditions.
- Handle marketplace API failure modes (rate limits, temporary errors, auth failures) so the sync chain reacts appropriately instead of blindly continuing.
- Make handler behavior more testable and explicit by separating lock management from processing.

### Description

- Add a lock via `LockFactory` with a TTL to `InitialSyncHandler` and skip processing when the lock cannot be acquired, with logging of the skip reason.
- Extract the core logic into a private `process()` method and wrap the public `__invoke()` with lock acquire/release to ensure single-run semantics per batch key.
- Catch `MarketplaceRateLimitException` and `MarketplaceTemporaryApiException` and rethrow them as `RecoverableMessageHandlingException` so Messenger will retry, and catch `MarketplaceAuthException` to log and mark the connection as failed without dispatching the next batch.
- Update imports and unit tests: adjust mocks to provide `LockFactory`/`LockInterface`, allow injecting fetch exceptions or empty data, and capture dispatched messages in `InitialSyncHandlerTest`.

### Testing

- Ran unit tests in `InitialSyncHandlerTest` which now include `testNextBatchPreservesMonthBoundarySplit`, `testLockNotAcquiredSkipsBatch`, `testEmptyBatchStillDispatchesNextMessage`, `testRateLimitDoesNotDispatchNextMessage`, and `testAuthErrorDoesNotDispatchNextMessage` under `phpunit` and they all passed.
- The tests exercise lock acquisition behavior, empty/raw fetch paths, handling of rate-limit and auth exceptions, and the expected dispatch/no-dispatch outcomes for each scenario.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2e7037abc832380b44a6dcb721716)