### PR TITLE
Honor WB Retry-After for InitialSync retries

### DIFF
--- a/site/src/Marketplace/MessageHandler/InitialSyncHandler.php
+++ b/site/src/Marketplace/MessageHandler/InitialSyncHandler.php
@@ -32,6 +32,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 final class InitialSyncHandler
 {
     private const LOCK_TTL_SECONDS = 300;
+    private const RATE_LIMIT_FALLBACK_DELAY_SECONDS = 90;
 
     public function __construct(
         private readonly EntityManagerInterface $em,
@@ -188,6 +189,9 @@ final class InitialSyncHandler
                 ]);
             }
         } catch (MarketplaceRateLimitException $e) {
+            $retryAfterSeconds = $e->getRetryAfter() ?? self::RATE_LIMIT_FALLBACK_DELAY_SECONDS;
+            $retryAfterMs = max(1, $retryAfterSeconds) * 1000;
+
             $this->logger->warning('InitialSync: rate limit, batch retry scheduled', [
                 'company_id' => $message->companyId,
                 'connection_id' => $message->connectionId,
@@ -195,10 +199,12 @@ final class InitialSyncHandler
                 'date_from' => $message->dateFrom,
                 'date_to' => $message->dateTo,
                 'retry_after' => $e->getRetryAfter(),
+                'retry_after_fallback' => $e->getRetryAfter() === null,
+                'retry_delay_ms' => $retryAfterMs,
                 'error' => $e->getMessage(),
             ]);
 
-            throw new RecoverableMessageHandlingException($e->getMessage(), 0, $e);
+            throw new RecoverableMessageHandlingException($e->getMessage(), 0, $e, $retryAfterMs);
         } catch (MarketplaceAuthException $e) {
             $this->logger->error('InitialSync: auth error, stopping sync chain', [
                 'company_id' => $message->companyId,

--- a/site/tests/Unit/Marketplace/MessageHandler/InitialSyncHandlerTest.php
+++ b/site/tests/Unit/Marketplace/MessageHandler/InitialSyncHandlerTest.php
@@ -147,7 +147,7 @@ final class InitialSyncHandlerTest extends TestCase
         self::assertInstanceOf(InitialSyncMessage::class, $captured->message);
     }
 
-    public function testRateLimitDoesNotDispatchNextMessage(): void
+    public function testRateLimitWithRetryAfterDoesNotDispatchNextMessageAndSetsDelay(): void
     {
         [$handler, $captured] = $this->createHandler(
             new MockClock('2026-04-10 12:00:00'),
@@ -165,7 +165,32 @@ final class InitialSyncHandlerTest extends TestCase
                 nextDateTo: '2026-03-31 23:59:59',
             ));
             self::fail('Expected RecoverableMessageHandlingException was not thrown.');
-        } catch (RecoverableMessageHandlingException) {
+        } catch (RecoverableMessageHandlingException $e) {
+            self::assertSame(60_000, $e->getRetryDelay());
+            self::assertNull($captured->message);
+        }
+    }
+
+    public function testRateLimitWithoutRetryAfterUsesFallbackDelay(): void
+    {
+        [$handler, $captured] = $this->createHandler(
+            new MockClock('2026-04-10 12:00:00'),
+            new MarketplaceRateLimitException(429, 'rate-limit', '2026-03-23', '2026-03-29', null),
+        );
+
+        try {
+            $handler(new InitialSyncMessage(
+                companyId: self::COMPANY_ID,
+                connectionId: self::CONNECTION_ID,
+                marketplace: MarketplaceType::OZON->value,
+                dateFrom: '2026-03-23 00:00:00',
+                dateTo: '2026-03-29 23:59:59',
+                nextDateFrom: '2026-03-30 00:00:00',
+                nextDateTo: '2026-03-31 23:59:59',
+            ));
+            self::fail('Expected RecoverableMessageHandlingException was not thrown.');
+        } catch (RecoverableMessageHandlingException $e) {
+            self::assertSame(90_000, $e->getRetryDelay());
             self::assertNull($captured->message);
         }
     }


### PR DESCRIPTION
### Motivation
- Ensure 429 responses from Wildberries cause a delayed retry that respects the `Retry-After` header instead of immediate/unchanged retry behavior.
- Use marketplace-provided delay when available and a safe fallback when it is not, while preventing dispatch of the next batch on 429.
- Keep existing chain/dispatch semantics: do not dispatch the following `InitialSyncMessage` on rate limit and do not change `WildberriesAdapter` or `TriggerInitialSyncHandler`.

### Description
- Added a fallback constant `RATE_LIMIT_FALLBACK_DELAY_SECONDS = 90` to `src/Marketplace/MessageHandler/InitialSyncHandler.php` and compute `retryDelayMs` from `MarketplaceRateLimitException::getRetryAfter()` or the fallback.
- Log additional diagnostics (`retry_after_fallback`, `retry_delay_ms`) and throw `RecoverableMessageHandlingException` with explicit delay (ms) so Symfony Messenger will schedule delayed retry instead of immediate requeueing.
- Updated tests in `tests/Unit/Marketplace/MessageHandler/InitialSyncHandlerTest.php` to assert that `RecoverableMessageHandlingException` carries the expected retry delay for both `Retry-After=60` and `Retry-After=null` (fallback) and that no next message is dispatched on 429.
- Verified project uses `symfony/messenger v7.3.9` (supports delay parameter on `RecoverableMessageHandlingException`) and made no changes to `WildberriesAdapter`, `TriggerInitialSyncHandler`, or messenger routing.

### Testing
- Ran PHP syntax checks with `php -l` for the modified files (`src/Marketplace/MessageHandler/InitialSyncHandler.php` and `tests/Unit/Marketplace/MessageHandler/InitialSyncHandlerTest.php`) and they passed.
- Attempted to run unit tests with `phpunit`, but automated test execution failed because `composer install` could not complete due to missing PHP extensions (`ext-sodium` and `ext-redis`) in the environment, so `vendor/bin/phpunit` was not available and tests could not be executed here.
- Unit tests were updated to cover both `Retry-After` and fallback behavior; these tests are included in the PR and are expected to pass when dependencies are installed in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2ebe211d08323915d8fa65c2aa2df)