### PR TITLE
Add Wildberries initial-sync discovery and probe; integrate into TriggerInitialSyncHandler

### DIFF
--- a/site/src/Marketplace/Application/Service/WbInitialSyncStartDateResolver.php
+++ b/site/src/Marketplace/Application/Service/WbInitialSyncStartDateResolver.php
@@ -27,14 +27,14 @@ final readonly class WbInitialSyncStartDateResolver
     {
         $yesterday = $this->clock->now()->modify('-1 day')->setTime(0, 0, 0);
         $settings = $connection->getSettings() ?? [];
-        $cached = $this->parseCachedStartDate($settings, $yesterday);
+        $yearStart = new \DateTimeImmutable((int) $yesterday->format('Y') . '-01-01 00:00:00');
+        $cached = $this->parseCachedStartDate($settings, $yearStart, $yesterday);
 
         if (null !== $cached) {
             return $cached;
         }
 
-        $yearStart = new \DateTimeImmutable((int) $yesterday->format('Y') . '-01-01 00:00:00');
-        $startDate = $this->discoverStartDate($company, $yearStart, $yesterday);
+        $startDate = $this->discoverStartDate($company, $connection, $settings, $yearStart, $yesterday);
 
         if (null === $startDate) {
             $connection->mergeSettings([
@@ -57,8 +57,12 @@ final readonly class WbInitialSyncStartDateResolver
         return $startDate;
     }
 
-    private function parseCachedStartDate(array $settings, \DateTimeImmutable $yesterday): ?\DateTimeImmutable
+    private function parseCachedStartDate(array $settings, \DateTimeImmutable $yearStart, \DateTimeImmutable $yesterday): ?\DateTimeImmutable
     {
+        if (($settings['wb_initial_sync_discovery_version'] ?? null) !== self::DISCOVERY_VERSION) {
+            return null;
+        }
+
         $raw = $settings['wb_initial_sync_start_date'] ?? null;
         if (!is_string($raw) || '' === trim($raw)) {
             return null;
@@ -74,9 +78,10 @@ final readonly class WbInitialSyncStartDateResolver
             return null;
         }
 
-        if ($date > $yesterday) {
+        if ($date > $yesterday || $date < $yearStart) {
             $this->logger->warning('WB initial sync start date in settings is in future; discovery will be repeated.', [
                 'wb_initial_sync_start_date' => $raw,
+                'year_start' => $yearStart->format('Y-m-d'),
                 'yesterday' => $yesterday->format('Y-m-d'),
             ]);
 
@@ -86,9 +91,26 @@ final readonly class WbInitialSyncStartDateResolver
         return $date;
     }
 
-    private function discoverStartDate(Company $company, \DateTimeImmutable $yearStart, \DateTimeImmutable $yesterday): ?\DateTimeImmutable
+    private function discoverStartDate(
+        Company $company,
+        MarketplaceConnection $connection,
+        array $settings,
+        \DateTimeImmutable $yearStart,
+        \DateTimeImmutable $yesterday,
+    ): ?\DateTimeImmutable
     {
         $monthStart = $yearStart;
+        $resumeMonth = $settings['wb_initial_sync_discovery_last_probed_month'] ?? null;
+        if (is_string($resumeMonth) && '' !== trim($resumeMonth)) {
+            try {
+                $resumeDate = new \DateTimeImmutable($resumeMonth . '-01 00:00:00');
+                if ($resumeDate >= $yearStart && $resumeDate <= $yesterday) {
+                    $monthStart = $resumeDate;
+                }
+            } catch (\Throwable) {
+            }
+        }
+
         while ($monthStart <= $yesterday) {
             $monthEnd = $monthStart->modify('last day of this month')->setTime(0, 0, 0);
             if ($monthEnd > $yesterday) {
@@ -99,10 +121,15 @@ final readonly class WbInitialSyncStartDateResolver
                 return $monthStart;
             }
 
+            $connection->mergeSettings([
+                'wb_initial_sync_discovery_last_probed_month' => $monthStart->format('Y-m'),
+                'wb_initial_sync_discovery_version' => self::DISCOVERY_VERSION,
+            ]);
+            $this->entityManager->flush();
+
             $monthStart = $monthStart->modify('first day of next month')->setTime(0, 0, 0);
         }
 
         return null;
     }
 }
-

--- a/site/src/Marketplace/Application/Service/WbInitialSyncStartDateResolver.php
+++ b/site/src/Marketplace/Application/Service/WbInitialSyncStartDateResolver.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\Service;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Service\Integration\WildberriesAdapter;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Clock\ClockInterface;
+
+final readonly class WbInitialSyncStartDateResolver
+{
+    private const DISCOVERY_VERSION = '1';
+
+    public function __construct(
+        private WildberriesAdapter $wildberriesAdapter,
+        private EntityManagerInterface $entityManager,
+        private LoggerInterface $logger,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function resolve(Company $company, MarketplaceConnection $connection): ?\DateTimeImmutable
+    {
+        $yesterday = $this->clock->now()->modify('-1 day')->setTime(0, 0, 0);
+        $settings = $connection->getSettings() ?? [];
+        $cached = $this->parseCachedStartDate($settings, $yesterday);
+
+        if (null !== $cached) {
+            return $cached;
+        }
+
+        $yearStart = new \DateTimeImmutable((int) $yesterday->format('Y') . '-01-01 00:00:00');
+        $startDate = $this->discoverStartDate($company, $yearStart, $yesterday);
+
+        if (null === $startDate) {
+            $connection->mergeSettings([
+                'wb_initial_sync_no_data_found_at' => $this->clock->now()->format(\DateTimeInterface::ATOM),
+                'wb_initial_sync_discovery_at' => $this->clock->now()->format(\DateTimeInterface::ATOM),
+                'wb_initial_sync_discovery_version' => self::DISCOVERY_VERSION,
+            ]);
+            $this->entityManager->flush();
+
+            return null;
+        }
+
+        $connection->mergeSettings([
+            'wb_initial_sync_start_date' => $startDate->format('Y-m-d'),
+            'wb_initial_sync_discovery_at' => $this->clock->now()->format(\DateTimeInterface::ATOM),
+            'wb_initial_sync_discovery_version' => self::DISCOVERY_VERSION,
+        ]);
+        $this->entityManager->flush();
+
+        return $startDate;
+    }
+
+    private function parseCachedStartDate(array $settings, \DateTimeImmutable $yesterday): ?\DateTimeImmutable
+    {
+        $raw = $settings['wb_initial_sync_start_date'] ?? null;
+        if (!is_string($raw) || '' === trim($raw)) {
+            return null;
+        }
+
+        try {
+            $date = new \DateTimeImmutable($raw . ' 00:00:00');
+        } catch (\Throwable) {
+            $this->logger->warning('WB initial sync start date in settings is invalid; discovery will be repeated.', [
+                'wb_initial_sync_start_date' => $raw,
+            ]);
+
+            return null;
+        }
+
+        if ($date > $yesterday) {
+            $this->logger->warning('WB initial sync start date in settings is in future; discovery will be repeated.', [
+                'wb_initial_sync_start_date' => $raw,
+                'yesterday' => $yesterday->format('Y-m-d'),
+            ]);
+
+            return null;
+        }
+
+        return $date;
+    }
+
+    private function discoverStartDate(Company $company, \DateTimeImmutable $yearStart, \DateTimeImmutable $yesterday): ?\DateTimeImmutable
+    {
+        $monthStart = $yearStart;
+        while ($monthStart <= $yesterday) {
+            $monthEnd = $monthStart->modify('last day of this month')->setTime(0, 0, 0);
+            if ($monthEnd > $yesterday) {
+                $monthEnd = $yesterday;
+            }
+
+            if ($this->wildberriesAdapter->hasRawReportData($company, $monthStart, $monthEnd)) {
+                return $monthStart;
+            }
+
+            $monthStart = $monthStart->modify('first day of next month')->setTime(0, 0, 0);
+        }
+
+        return null;
+    }
+}
+

--- a/site/src/Marketplace/Application/Service/WbInitialSyncStartDateResolver.php
+++ b/site/src/Marketplace/Application/Service/WbInitialSyncStartDateResolver.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Clock\ClockInterface;
 
-final readonly class WbInitialSyncStartDateResolver
+class WbInitialSyncStartDateResolver
 {
     private const DISCOVERY_VERSION = '1';
 
@@ -59,10 +59,6 @@ final readonly class WbInitialSyncStartDateResolver
 
     private function parseCachedStartDate(array $settings, \DateTimeImmutable $yearStart, \DateTimeImmutable $yesterday): ?\DateTimeImmutable
     {
-        if (($settings['wb_initial_sync_discovery_version'] ?? null) !== self::DISCOVERY_VERSION) {
-            return null;
-        }
-
         $raw = $settings['wb_initial_sync_start_date'] ?? null;
         if (!is_string($raw) || '' === trim($raw)) {
             return null;

--- a/site/src/Marketplace/Entity/MarketplaceConnection.php
+++ b/site/src/Marketplace/Entity/MarketplaceConnection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Marketplace\Entity;
 
 use App\Company\Entity\Company;
@@ -201,6 +203,14 @@ class MarketplaceConnection
     public function setSettings(?array $settings): self
     {
         $this->settings = $settings;
+        $this->updatedAt = new \DateTimeImmutable();
+
+        return $this;
+    }
+
+    public function mergeSettings(array $settings): self
+    {
+        $this->settings = array_merge($this->settings ?? [], $settings);
         $this->updatedAt = new \DateTimeImmutable();
 
         return $this;

--- a/site/src/Marketplace/MessageHandler/TriggerInitialSyncHandler.php
+++ b/site/src/Marketplace/MessageHandler/TriggerInitialSyncHandler.php
@@ -5,13 +5,18 @@ declare(strict_types=1);
 namespace App\Marketplace\MessageHandler;
 
 use App\Marketplace\Application\Service\MarketplaceWeekPartitionService;
+use App\Marketplace\Application\Service\WbInitialSyncStartDateResolver;
 use App\Marketplace\Enum\MarketplaceConnectionType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Exception\MarketplaceRateLimitException;
 use App\Marketplace\Message\InitialSyncMessage;
 use App\Marketplace\Message\TriggerInitialSyncMessage;
 use App\Marketplace\Repository\MarketplaceConnectionRepository;
+use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
@@ -30,6 +35,8 @@ final class TriggerInitialSyncHandler
         private readonly MarketplaceWeekPartitionService $partitionService,
         private readonly ClockInterface $clock,
         private readonly MarketplaceConnectionRepository $connectionRepository,
+        private readonly WbInitialSyncStartDateResolver $wbStartDateResolver,
+        private readonly EntityManagerInterface $entityManager,
     ) {
     }
 
@@ -52,7 +59,45 @@ final class TriggerInitialSyncHandler
 
         $yesterday = $this->clock->now()->modify('-1 day')->setTime(0, 0, 0);
         $yearStart = new \DateTimeImmutable((int) $yesterday->format('Y') . '-01-01 00:00:00');
-        $weeks = $this->partitionService->buildPartitions($yearStart, $yesterday);
+        $syncStart = $yearStart;
+
+        if (MarketplaceType::WILDBERRIES === $connection->getMarketplace()) {
+            try {
+                $resolved = $this->wbStartDateResolver->resolve($connection->getCompany(), $connection);
+            } catch (MarketplaceRateLimitException $e) {
+                $retrySeconds = max(1, $e->getRetryAfter() ?? 90);
+                $this->logger->warning('InitialSync trigger delayed by WB rate limit during discovery', [
+                    'company_id' => $message->companyId,
+                    'connection_id' => $message->connectionId,
+                    'marketplace' => $message->marketplace,
+                    'date_from' => $e->getDateFrom(),
+                    'date_to' => $e->getDateTo(),
+                    'retry_after' => $e->getRetryAfter(),
+                ]);
+
+                throw new RecoverableMessageHandlingException(
+                    'InitialSync trigger rate limited by Wildberries discovery.',
+                    retryDelay: $retrySeconds * 1000,
+                    previous: $e,
+                );
+            }
+
+            if (null === $resolved) {
+                $connection->markSyncSuccess();
+                $this->entityManager->flush();
+                $this->logger->info('InitialSync: WB no data found for current year, sync completed without batches.', [
+                    'company_id' => $message->companyId,
+                    'connection_id' => $message->connectionId,
+                    'marketplace' => $message->marketplace,
+                ]);
+
+                return;
+            }
+
+            $syncStart = $resolved;
+        }
+
+        $weeks = $this->partitionService->buildPartitions($syncStart, $yesterday);
 
         if (empty($weeks)) {
             $this->logger->warning('InitialSync: no weeks to sync', [

--- a/site/src/Marketplace/Service/Integration/WildberriesAdapter.php
+++ b/site/src/Marketplace/Service/Integration/WildberriesAdapter.php
@@ -89,8 +89,8 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
         $headers = $response->getHeaders(false);
         try {
             $body = $response->getContent(false);
-        } catch (TransportExceptionInterface) {
-            $body = '';
+        } catch (TransportExceptionInterface $e) {
+            throw new MarketplaceTemporaryApiException('WB API transport error.', $statusCode, '', $dateFrom, $dateTo, $e);
         }
         $excerpt = $this->createSafeExcerpt($body);
 
@@ -187,8 +187,8 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
         $headers = $response->getHeaders(false);
         try {
             $body = $response->getContent(false);
-        } catch (TransportExceptionInterface) {
-            $body = '';
+        } catch (TransportExceptionInterface $e) {
+            throw new MarketplaceTemporaryApiException('WB API transport error.', $statusCode, '', $dateFrom, $dateTo, $e);
         }
         $excerpt = $this->createSafeExcerpt($body);
 

--- a/site/src/Marketplace/Service/Integration/WildberriesAdapter.php
+++ b/site/src/Marketplace/Service/Integration/WildberriesAdapter.php
@@ -17,6 +17,7 @@ use App\Marketplace\Exception\MarketplaceRateLimitException;
 use App\Marketplace\Exception\MarketplaceTemporaryApiException;
 use App\Marketplace\Repository\MarketplaceConnectionRepository;
 use Psr\Log\LoggerInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class WildberriesAdapter implements MarketplaceAdapterInterface
@@ -86,7 +87,11 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
 
         $statusCode = $response->getStatusCode();
         $headers = $response->getHeaders(false);
-        $body = $response->getContent(false);
+        try {
+            $body = $response->getContent(false);
+        } catch (TransportExceptionInterface) {
+            $body = '';
+        }
         $excerpt = $this->createSafeExcerpt($body);
 
         if (429 === $statusCode) {
@@ -180,7 +185,11 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
 
         $statusCode = $response->getStatusCode();
         $headers = $response->getHeaders(false);
-        $body = $response->getContent(false);
+        try {
+            $body = $response->getContent(false);
+        } catch (TransportExceptionInterface) {
+            $body = '';
+        }
         $excerpt = $this->createSafeExcerpt($body);
 
         if (429 === $statusCode) {
@@ -208,6 +217,12 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
 
         if (!is_array($decoded) || !array_is_list($decoded)) {
             throw new MarketplaceInvalidApiResponseException('WB API JSON must be a list.', $statusCode, $excerpt, $dateFrom, $dateTo);
+        }
+
+        foreach ($decoded as $row) {
+            if (!is_array($row)) {
+                throw new MarketplaceInvalidApiResponseException('WB API JSON list items must be objects.', $statusCode, $excerpt, $dateFrom, $dateTo);
+            }
         }
 
         return [] !== $decoded;

--- a/site/src/Marketplace/Service/Integration/WildberriesAdapter.php
+++ b/site/src/Marketplace/Service/Integration/WildberriesAdapter.php
@@ -151,6 +151,68 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
         return $decoded;
     }
 
+    public function hasRawReportData(
+        Company $company,
+        \DateTimeInterface $fromDate,
+        \DateTimeInterface $toDate,
+    ): bool {
+        $connection = $this->getConnection($company);
+
+        if (!$connection) {
+            throw new \RuntimeException('Wildberries connection not found');
+        }
+
+        $dateFrom = $fromDate->format('Y-m-d');
+        $dateTo = $toDate->format('Y-m-d');
+
+        $response = $this->httpClient->request('GET', self::BASE_URL.'/api/v5/supplier/reportDetailByPeriod', [
+            'headers' => [
+                'Authorization' => $connection->getApiKey(),
+            ],
+            'query' => [
+                'dateFrom' => $dateFrom,
+                'dateTo' => $dateTo,
+                'limit' => 1,
+                'rrdid' => 0,
+                'period' => 'daily',
+            ],
+        ]);
+
+        $statusCode = $response->getStatusCode();
+        $headers = $response->getHeaders(false);
+        $body = $response->getContent(false);
+        $excerpt = $this->createSafeExcerpt($body);
+
+        if (429 === $statusCode) {
+            $retryAfter = $this->extractRetryAfter($headers);
+            throw new MarketplaceRateLimitException($statusCode, $excerpt, $dateFrom, $dateTo, $retryAfter);
+        }
+        if (401 === $statusCode || 403 === $statusCode) {
+            throw new MarketplaceAuthException('WB API authentication failed.', $statusCode, $excerpt, $dateFrom, $dateTo);
+        }
+        if ($statusCode >= 500 && $statusCode <= 599) {
+            throw new MarketplaceTemporaryApiException('WB API temporary error.', $statusCode, $excerpt, $dateFrom, $dateTo);
+        }
+        if (200 !== $statusCode) {
+            throw new MarketplaceTemporaryApiException('WB API unexpected status.', $statusCode, $excerpt, $dateFrom, $dateTo);
+        }
+        if ('' === trim($body)) {
+            return false;
+        }
+
+        try {
+            $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new MarketplaceInvalidApiResponseException('WB API returned invalid JSON.', $statusCode, $excerpt, $dateFrom, $dateTo, $e);
+        }
+
+        if (!is_array($decoded) || !array_is_list($decoded)) {
+            throw new MarketplaceInvalidApiResponseException('WB API JSON must be a list.', $statusCode, $excerpt, $dateFrom, $dateTo);
+        }
+
+        return [] !== $decoded;
+    }
+
     public function fetchSales(
         Company $company,
         \DateTimeInterface $fromDate,

--- a/site/tests/Unit/Marketplace/Application/Service/WbInitialSyncStartDateResolverTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbInitialSyncStartDateResolverTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Application\Service;
+
+use App\Marketplace\Application\Service\WbInitialSyncStartDateResolver;
+use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Exception\MarketplaceRateLimitException;
+use App\Marketplace\Service\Integration\WildberriesAdapter;
+use App\Tests\Builders\Company\CompanyBuilder;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Clock\MockClock;
+
+final class WbInitialSyncStartDateResolverTest extends TestCase
+{
+    public function testUsesValidCachedStartDateWithoutDiscovery(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+        $connection = new MarketplaceConnection('22222222-2222-2222-2222-222222222222', $company, MarketplaceType::WILDBERRIES);
+        $connection->setSettings(['wb_initial_sync_start_date' => '2026-04-01', 'keep' => 'me']);
+
+        $adapter = $this->createMock(WildberriesAdapter::class);
+        $adapter->expects(self::never())->method('hasRawReportData');
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::never())->method('flush');
+
+        $resolver = new WbInitialSyncStartDateResolver($adapter, $em, new NullLogger(), new MockClock('2026-05-10 00:00:00'));
+        $date = $resolver->resolve($company, $connection);
+
+        self::assertSame('2026-04-01', $date?->format('Y-m-d'));
+    }
+
+    public function testDiscoversFromAprilWhenJanToMarchEmpty(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+        $connection = new MarketplaceConnection('22222222-2222-2222-2222-222222222222', $company, MarketplaceType::WILDBERRIES);
+        $connection->setSettings(['keep' => 'me']);
+
+        $adapter = $this->createMock(WildberriesAdapter::class);
+        $adapter->method('hasRawReportData')->willReturnCallback(static fn ($c, $from) => (int) $from->format('n') >= 4);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::once())->method('flush');
+
+        $resolver = new WbInitialSyncStartDateResolver($adapter, $em, new NullLogger(), new MockClock('2026-05-10 00:00:00'));
+        $date = $resolver->resolve($company, $connection);
+
+        self::assertSame('2026-04-01', $date?->format('Y-m-d'));
+        self::assertSame('me', $connection->getSettings()['keep']);
+        self::assertSame('2026-04-01', $connection->getSettings()['wb_initial_sync_start_date']);
+    }
+
+    public function testPropagatesRateLimitException(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+        $connection = new MarketplaceConnection('22222222-2222-2222-2222-222222222222', $company, MarketplaceType::WILDBERRIES);
+
+        $adapter = $this->createMock(WildberriesAdapter::class);
+        $adapter->method('hasRawReportData')->willThrowException(new MarketplaceRateLimitException(429, 'rl', '2026-01-01', '2026-01-31', 12));
+
+        $resolver = new WbInitialSyncStartDateResolver($adapter, $this->createMock(EntityManagerInterface::class), new NullLogger(), new MockClock('2026-05-10 00:00:00'));
+
+        $this->expectException(MarketplaceRateLimitException::class);
+        $resolver->resolve($company, $connection);
+    }
+
+    public function testInvalidCachedStartDateTriggersDiscovery(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+        $connection = new MarketplaceConnection('22222222-2222-2222-2222-222222222222', $company, MarketplaceType::WILDBERRIES);
+        $connection->setSettings(['wb_initial_sync_start_date' => 'invalid-date']);
+
+        $adapter = $this->createMock(WildberriesAdapter::class);
+        $adapter->expects(self::once())->method('hasRawReportData')->willReturn(true);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::once())->method('flush');
+
+        $resolver = new WbInitialSyncStartDateResolver($adapter, $em, new NullLogger(), new MockClock('2026-05-10 00:00:00'));
+        $date = $resolver->resolve($company, $connection);
+
+        self::assertSame('2026-01-01', $date?->format('Y-m-d'));
+    }
+
+    public function testReturnsNullAndStoresNoDataMetadataWhenAllMonthsEmpty(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+        $connection = new MarketplaceConnection('22222222-2222-2222-2222-222222222222', $company, MarketplaceType::WILDBERRIES);
+        $connection->setSettings(['keep' => 'me']);
+
+        $adapter = $this->createMock(WildberriesAdapter::class);
+        $adapter->method('hasRawReportData')->willReturn(false);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::once())->method('flush');
+
+        $resolver = new WbInitialSyncStartDateResolver($adapter, $em, new NullLogger(), new MockClock('2026-05-10 00:00:00'));
+        $date = $resolver->resolve($company, $connection);
+
+        self::assertNull($date);
+        self::assertSame('me', $connection->getSettings()['keep']);
+        self::assertArrayHasKey('wb_initial_sync_no_data_found_at', $connection->getSettings());
+    }
+}

--- a/site/tests/Unit/Marketplace/Application/Service/WbInitialSyncStartDateResolverTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbInitialSyncStartDateResolverTest.php
@@ -45,7 +45,7 @@ final class WbInitialSyncStartDateResolverTest extends TestCase
         $adapter->method('hasRawReportData')->willReturnCallback(static fn ($c, $from) => (int) $from->format('n') >= 4);
 
         $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects(self::once())->method('flush');
+        $em->expects(self::atLeastOnce())->method('flush');
 
         $resolver = new WbInitialSyncStartDateResolver($adapter, $em, new NullLogger(), new MockClock('2026-05-10 00:00:00'));
         $date = $resolver->resolve($company, $connection);
@@ -79,7 +79,7 @@ final class WbInitialSyncStartDateResolverTest extends TestCase
         $adapter->expects(self::once())->method('hasRawReportData')->willReturn(true);
 
         $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects(self::once())->method('flush');
+        $em->expects(self::atLeastOnce())->method('flush');
 
         $resolver = new WbInitialSyncStartDateResolver($adapter, $em, new NullLogger(), new MockClock('2026-05-10 00:00:00'));
         $date = $resolver->resolve($company, $connection);
@@ -97,7 +97,7 @@ final class WbInitialSyncStartDateResolverTest extends TestCase
         $adapter->method('hasRawReportData')->willReturn(false);
 
         $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects(self::once())->method('flush');
+        $em->expects(self::atLeastOnce())->method('flush');
 
         $resolver = new WbInitialSyncStartDateResolver($adapter, $em, new NullLogger(), new MockClock('2026-05-10 00:00:00'));
         $date = $resolver->resolve($company, $connection);

--- a/site/tests/Unit/Marketplace/MessageHandler/TriggerInitialSyncHandlerTest.php
+++ b/site/tests/Unit/Marketplace/MessageHandler/TriggerInitialSyncHandlerTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\MessageHandler;
+
+use App\Marketplace\Application\Service\MarketplaceWeekPartitionService;
+use App\Marketplace\Application\Service\WbInitialSyncStartDateResolver;
+use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Exception\MarketplaceRateLimitException;
+use App\Marketplace\Message\InitialSyncMessage;
+use App\Marketplace\Message\TriggerInitialSyncMessage;
+use App\Marketplace\MessageHandler\TriggerInitialSyncHandler;
+use App\Marketplace\Repository\MarketplaceConnectionRepository;
+use App\Tests\Builders\Company\CompanyBuilder;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class TriggerInitialSyncHandlerTest extends TestCase
+{
+    public function testWbBuildsPartitionsFromResolvedDate(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+        $connection = new MarketplaceConnection('22222222-2222-2222-2222-222222222222', $company, MarketplaceType::WILDBERRIES);
+
+        $repo = $this->createMock(MarketplaceConnectionRepository::class);
+        $repo->method('find')->willReturn($connection);
+
+        $resolver = $this->createMock(WbInitialSyncStartDateResolver::class);
+        $resolver->method('resolve')->willReturn(new \DateTimeImmutable('2026-04-01 00:00:00'));
+
+        $captured = new \stdClass(); $captured->message = null;
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->method('dispatch')->willReturnCallback(static function ($m) use ($captured) { $captured->message = $m; return new Envelope($m); });
+
+        $handler = new TriggerInitialSyncHandler($bus, new NullLogger(), new MarketplaceWeekPartitionService(), new MockClock('2026-04-30 00:00:00'), $repo, $resolver, $this->createMock(EntityManagerInterface::class));
+        $handler(new TriggerInitialSyncMessage($company->getId(), $connection->getId(), MarketplaceType::WILDBERRIES->value));
+
+        self::assertInstanceOf(InitialSyncMessage::class, $captured->message);
+        self::assertStringStartsWith('2026-04', $captured->message->dateFrom);
+    }
+
+    public function testRateLimitConvertsToRecoverableExceptionWithDelay(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+        $connection = new MarketplaceConnection('22222222-2222-2222-2222-222222222222', $company, MarketplaceType::WILDBERRIES);
+        $repo = $this->createMock(MarketplaceConnectionRepository::class);
+        $repo->method('find')->willReturn($connection);
+
+        $resolver = $this->createMock(WbInitialSyncStartDateResolver::class);
+        $resolver->method('resolve')->willThrowException(new MarketplaceRateLimitException(429, 'rl', '2026-01-01', '2026-01-31', null));
+
+        $handler = new TriggerInitialSyncHandler($this->createMock(MessageBusInterface::class), new NullLogger(), new MarketplaceWeekPartitionService(), new MockClock('2026-04-30 00:00:00'), $repo, $resolver, $this->createMock(EntityManagerInterface::class));
+
+        try {
+            $handler(new TriggerInitialSyncMessage($company->getId(), $connection->getId(), MarketplaceType::WILDBERRIES->value));
+            self::fail('Expected RecoverableMessageHandlingException');
+        } catch (RecoverableMessageHandlingException $e) {
+            self::assertSame(90_000, $e->getRetryDelay());
+        }
+    }
+
+    public function testRateLimitRetryAfterDelayAndNoDispatch(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+        $connection = new MarketplaceConnection('22222222-2222-2222-2222-222222222222', $company, MarketplaceType::WILDBERRIES);
+        $repo = $this->createMock(MarketplaceConnectionRepository::class);
+        $repo->method('find')->willReturn($connection);
+
+        $resolver = $this->createMock(WbInitialSyncStartDateResolver::class);
+        $resolver->method('resolve')->willThrowException(new MarketplaceRateLimitException(429, 'rl', '2026-01-01', '2026-01-31', 2));
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::never())->method('dispatch');
+
+        $handler = new TriggerInitialSyncHandler($bus, new NullLogger(), new MarketplaceWeekPartitionService(), new MockClock('2026-04-30 00:00:00'), $repo, $resolver, $this->createMock(EntityManagerInterface::class));
+
+        try {
+            $handler(new TriggerInitialSyncMessage($company->getId(), $connection->getId(), MarketplaceType::WILDBERRIES->value));
+            self::fail('Expected RecoverableMessageHandlingException');
+        } catch (RecoverableMessageHandlingException $e) {
+            self::assertSame(2_000, $e->getRetryDelay());
+        }
+    }
+
+    public function testWbNoDataMarksSyncSuccessAndSkipsDispatch(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+        $connection = $this->getMockBuilder(MarketplaceConnection::class)
+            ->setConstructorArgs(['22222222-2222-2222-2222-222222222222', $company, MarketplaceType::WILDBERRIES])
+            ->onlyMethods(['markSyncSuccess'])
+            ->getMock();
+        $connection->expects(self::once())->method('markSyncSuccess')->willReturnSelf();
+
+        $repo = $this->createMock(MarketplaceConnectionRepository::class);
+        $repo->method('find')->willReturn($connection);
+
+        $resolver = $this->createMock(WbInitialSyncStartDateResolver::class);
+        $resolver->method('resolve')->willReturn(null);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::never())->method('dispatch');
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::once())->method('flush');
+
+        $handler = new TriggerInitialSyncHandler($bus, new NullLogger(), new MarketplaceWeekPartitionService(), new MockClock('2026-04-30 00:00:00'), $repo, $resolver, $em);
+        $handler(new TriggerInitialSyncMessage($company->getId(), $connection->getId(), MarketplaceType::WILDBERRIES->value));
+    }
+
+    public function testNonWbDoesNotCallResolverAndUsesYearStart(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+        $connection = new MarketplaceConnection('22222222-2222-2222-2222-222222222222', $company, MarketplaceType::OZON);
+        $repo = $this->createMock(MarketplaceConnectionRepository::class);
+        $repo->method('find')->willReturn($connection);
+
+        $resolver = $this->createMock(WbInitialSyncStartDateResolver::class);
+        $resolver->expects(self::never())->method('resolve');
+
+        $captured = new \stdClass();
+        $captured->message = null;
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->method('dispatch')->willReturnCallback(static function ($m) use ($captured) { $captured->message = $m; return new Envelope($m); });
+
+        $handler = new TriggerInitialSyncHandler($bus, new NullLogger(), new MarketplaceWeekPartitionService(), new MockClock('2026-04-30 00:00:00'), $repo, $resolver, $this->createMock(EntityManagerInterface::class));
+        $handler(new TriggerInitialSyncMessage($company->getId(), $connection->getId(), MarketplaceType::OZON->value));
+
+        self::assertInstanceOf(InitialSyncMessage::class, $captured->message);
+        self::assertSame('2026-01-01 00:00:00', $captured->message->dateFrom);
+    }
+}

--- a/site/tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php
+++ b/site/tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php
@@ -87,6 +87,29 @@ final class WildberriesAdapterTest extends TestCase
         $adapter->fetchRawReport($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-02'));
     }
 
+    public function testProbeReturnsFalseForEmptyListAndUsesLightweightQuery(): void
+    {
+        $captured = [];
+        $client = new MockHttpClient(static function (string $method, string $url, array $options) use (&$captured): MockResponse {
+            $captured = $options['query'];
+            return new MockResponse('[]', ['http_code' => 200]);
+        });
+        $repo = $this->createMock(MarketplaceConnectionRepository::class);
+        $repo->method('findByMarketplace')->willReturn($this->connection());
+        $adapter = new WildberriesAdapter($client, $repo, new NullLogger());
+
+        self::assertFalse($adapter->hasRawReportData($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-02')));
+        self::assertSame(1, $captured['limit']);
+        self::assertSame('daily', $captured['period']);
+        self::assertSame(0, $captured['rrdid']);
+    }
+
+    public function testProbeReturnsTrueForNonEmptyList(): void
+    {
+        $adapter = $this->createAdapter(new MockResponse('[{"id":1}]', ['http_code' => 200]));
+        self::assertTrue($adapter->hasRawReportData($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-02')));
+    }
+
     private function createAdapter(MockResponse $response): WildberriesAdapter
     {
         $repo = $this->createMock(MarketplaceConnectionRepository::class);

--- a/site/tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php
+++ b/site/tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php
@@ -16,6 +16,9 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 
 final class WildberriesAdapterTest extends TestCase
 {
@@ -108,6 +111,44 @@ final class WildberriesAdapterTest extends TestCase
     {
         $adapter = $this->createAdapter(new MockResponse('[{"id":1}]', ['http_code' => 200]));
         self::assertTrue($adapter->hasRawReportData($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-02')));
+    }
+
+    public function testFetchRawReportThrowsTemporaryExceptionOnTransportErrorWhileReadingBody(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('getHeaders')->willReturn([]);
+        $response->method('getContent')->willThrowException($this->createMock(TransportExceptionInterface::class));
+
+        $client = $this->createMock(HttpClientInterface::class);
+        $client->method('request')->willReturn($response);
+
+        $repo = $this->createMock(MarketplaceConnectionRepository::class);
+        $repo->method('findByMarketplace')->willReturn($this->connection());
+
+        $adapter = new WildberriesAdapter($client, $repo, new NullLogger());
+
+        $this->expectException(MarketplaceTemporaryApiException::class);
+        $adapter->fetchRawReport($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-02'));
+    }
+
+    public function testHasRawReportDataThrowsTemporaryExceptionOnTransportErrorWhileReadingBody(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('getHeaders')->willReturn([]);
+        $response->method('getContent')->willThrowException($this->createMock(TransportExceptionInterface::class));
+
+        $client = $this->createMock(HttpClientInterface::class);
+        $client->method('request')->willReturn($response);
+
+        $repo = $this->createMock(MarketplaceConnectionRepository::class);
+        $repo->method('findByMarketplace')->willReturn($this->connection());
+
+        $adapter = new WildberriesAdapter($client, $repo, new NullLogger());
+
+        $this->expectException(MarketplaceTemporaryApiException::class);
+        $adapter->hasRawReportData($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-02'));
     }
 
     private function createAdapter(MockResponse $response): WildberriesAdapter


### PR DESCRIPTION
### Motivation

- Avoid full-year backfill for Wildberries by discovering the earliest month that actually has raw report data and start initial sync from there.
- Provide a lightweight probe to check presence of data and propagate WB API rate limits to message handling so retries are scheduled correctly.

### Description

- Introduces `WbInitialSyncStartDateResolver` which inspects cached settings or probes Wildberries month-by-month from year start to `yesterday` and persists discovery metadata into connection settings.
- Adds `hasRawReportData` to `WildberriesAdapter` performing a lightweight `GET /api/v5/supplier/reportDetailByPeriod` probe, handling HTTP errors, JSON validation, and throwing `MarketplaceRateLimitException` on `429` responses.
- Updates `TriggerInitialSyncHandler` to use the resolver for `MarketplaceType::WILDBERRIES`, convert `MarketplaceRateLimitException` into `RecoverableMessageHandlingException` with computed retry delay, and mark connection as synced when no data is found; non-WB flows remain unchanged.
- Adds `mergeSettings` to `MarketplaceConnection` for safe settings merging and updates several unit tests and adds new tests: `WbInitialSyncStartDateResolverTest`, `TriggerInitialSyncHandlerTest`, and new probe assertions in `WildberriesAdapterTest`.

### Testing

- Ran unit tests covering the new resolver via `WbInitialSyncStartDateResolverTest` which verifies cached usage, discovery, rate-limit propagation, invalid-cache handling, and no-data metadata; tests passed.
- Ran handler tests in `TriggerInitialSyncHandlerTest` which verify resolver integration, recoverable exception conversion and delays, no-dispatch when no data, and non-WB behaviour; tests passed.
- Ran adapter tests in `WildberriesAdapterTest` which verify the lightweight probe query parameters and truthiness for empty/non-empty responses; tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2f31f861c8323890f17c1b06f7ff9)