### PR TITLE
Task 3.2: keep InitialSync lock-miss as skip and document idempotency risk

### DIFF
--- a/site/src/Marketplace/MessageHandler/InitialSyncHandler.php
+++ b/site/src/Marketplace/MessageHandler/InitialSyncHandler.php
@@ -61,6 +61,11 @@ final class InitialSyncHandler
                 'date_to' => $message->dateTo,
             ]);
 
+            // В текущей модели initial sync повторная обработка одного и того же batch
+            // не защищена от дублей MarketplaceRawDocument (нет уникального ключа/guard'а
+            // по company+marketplace+document_type+period). Поэтому lock-miss завершаем
+            // как "skip + ack", а не retry: это осознанная защита от потенциального
+            // повторного сохранения raw-документов до внедрения idempotency guard.
             return;
         }
 


### PR DESCRIPTION
### Motivation
- Investigation showed that `InitialSyncHandler` creates a new `MarketplaceRawDocument` (new UUID + `persist`/`flush`) without a uniqueness guard for `(company, marketplace, document_type, period)`, so retrying a lock-missed message can create duplicate raw documents; therefore we must keep `lock not acquired -> return` until idempotency is implemented.

### Description
- Added an explicit comment in `src/Marketplace/MessageHandler/InitialSyncHandler.php` explaining that a lock miss is intentionally acknowledged (skip + ack) because the current model is not protected from duplicate `MarketplaceRawDocument` creation, and left runtime behavior unchanged.

### Testing
- Ran `php -l src/Marketplace/MessageHandler/InitialSyncHandler.php` and `php -l src/Marketplace/Entity/MarketplaceRawDocument.php` (both reported no syntax errors); `php bin/console cache:clear` and `php bin/phpunit ...` could not run in this environment because Composer dependencies are not installed (`vendor` missing), so full Symfony/test suite could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f304315c808323a150086e717bda22)