### PR TITLE
Add idempotency check for initial sync batches; repository and tests updates

### DIFF
--- a/site/src/Marketplace/MessageHandler/InitialSyncHandler.php
+++ b/site/src/Marketplace/MessageHandler/InitialSyncHandler.php
@@ -13,6 +13,7 @@ use App\Marketplace\Exception\MarketplaceAuthException;
 use App\Marketplace\Exception\MarketplaceRateLimitException;
 use App\Marketplace\Exception\MarketplaceTemporaryApiException;
 use App\Marketplace\Message\InitialSyncMessage;
+use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
 use App\Marketplace\Service\Integration\MarketplaceAdapterRegistry;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -102,38 +103,63 @@ final class InitialSyncHandler
 
         try {
             $adapter = $this->adapterRegistry->get($marketplace);
-            $rawData = $adapter->fetchRawReport($company, $fromDate, $toDate);
+            $apiEndpoint = $adapter->getApiEndpointName();
 
-            if (!empty($rawData)) {
-                $rawDoc = new MarketplaceRawDocument(
-                    Uuid::uuid4()->toString(),
-                    $company,
-                    $marketplace,
-                    'sales_report',
-                );
-                $rawDoc->setPeriodFrom($fromDate);
-                $rawDoc->setPeriodTo($toDate);
-                $rawDoc->setApiEndpoint($adapter->getApiEndpointName());
-                $rawDoc->setRawData($rawData);
-                $rawDoc->setRecordsCount(count($rawData));
+            /** @var MarketplaceRawDocumentRepository $rawRepository */
+            $rawRepository = $this->em->getRepository(MarketplaceRawDocument::class);
+            $existingRawDocument = $rawRepository->findExistingInitialSyncDocument(
+                $company,
+                $marketplace,
+                'sales_report',
+                $fromDate,
+                $toDate,
+                $apiEndpoint,
+            );
 
-                $this->em->persist($rawDoc);
-                $this->em->flush();
-
-                $this->logger->info('InitialSync: batch saved', [
-                    'company_id'    => $message->companyId,
-                    'marketplace'   => $message->marketplace,
-                    'date_from'     => $message->dateFrom,
-                    'date_to'       => $message->dateTo,
-                    'records_count' => count($rawData),
+            if ($existingRawDocument !== null) {
+                $this->logger->info('InitialSync: idempotent skip, raw document already exists', [
+                    'company_id' => $message->companyId,
+                    'connection_id' => $message->connectionId,
+                    'marketplace' => $message->marketplace,
+                    'date_from' => $message->dateFrom,
+                    'date_to' => $message->dateTo,
+                    'raw_document_id' => $existingRawDocument->getId(),
+                    'api_endpoint' => $apiEndpoint,
                 ]);
             } else {
-                $this->logger->info('InitialSync: empty batch, skipping', [
-                    'company_id'  => $message->companyId,
-                    'marketplace' => $message->marketplace,
-                    'date_from'   => $message->dateFrom,
-                    'date_to'     => $message->dateTo,
-                ]);
+                $rawData = $adapter->fetchRawReport($company, $fromDate, $toDate);
+
+                if (!empty($rawData)) {
+                    $rawDoc = new MarketplaceRawDocument(
+                        Uuid::uuid4()->toString(),
+                        $company,
+                        $marketplace,
+                        'sales_report',
+                    );
+                    $rawDoc->setPeriodFrom($fromDate);
+                    $rawDoc->setPeriodTo($toDate);
+                    $rawDoc->setApiEndpoint($apiEndpoint);
+                    $rawDoc->setRawData($rawData);
+                    $rawDoc->setRecordsCount(count($rawData));
+
+                    $this->em->persist($rawDoc);
+                    $this->em->flush();
+
+                    $this->logger->info('InitialSync: batch saved', [
+                        'company_id'    => $message->companyId,
+                        'marketplace'   => $message->marketplace,
+                        'date_from'     => $message->dateFrom,
+                        'date_to'       => $message->dateTo,
+                        'records_count' => count($rawData),
+                    ]);
+                } else {
+                    $this->logger->info('InitialSync: empty batch, skipping', [
+                        'company_id'  => $message->companyId,
+                        'marketplace' => $message->marketplace,
+                        'date_from'   => $message->dateFrom,
+                        'date_to'     => $message->dateTo,
+                    ]);
+                }
             }
 
             // Диспатчим следующую партию если она есть

--- a/site/src/Marketplace/Repository/MarketplaceRawDocumentRepository.php
+++ b/site/src/Marketplace/Repository/MarketplaceRawDocumentRepository.php
@@ -52,6 +52,37 @@ class MarketplaceRawDocumentRepository extends ServiceEntityRepository
     }
 
     /**
+     * Idempotency lookup for initial sync weekly/month-split batches.
+     */
+    public function findExistingInitialSyncDocument(
+        Company $company,
+        MarketplaceType $marketplace,
+        string $documentType,
+        \DateTimeImmutable $periodFrom,
+        \DateTimeImmutable $periodTo,
+        string $apiEndpoint,
+    ): ?MarketplaceRawDocument {
+        return $this->createQueryBuilder('d')
+            ->where('d.company = :company')
+            ->andWhere('d.marketplace = :marketplace')
+            ->andWhere('d.documentType = :documentType')
+            ->andWhere('d.periodFrom = :periodFrom')
+            ->andWhere('d.periodTo = :periodTo')
+            ->andWhere('d.apiEndpoint = :apiEndpoint')
+            ->andWhere('d.processingStatus IS NULL OR d.processingStatus != :failed')
+            ->setParameter('company', $company)
+            ->setParameter('marketplace', $marketplace)
+            ->setParameter('documentType', $documentType)
+            ->setParameter('periodFrom', $periodFrom)
+            ->setParameter('periodTo', $periodTo)
+            ->setParameter('apiEndpoint', $apiEndpoint)
+            ->setParameter('failed', PipelineStatus::FAILED)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    /**
      * @return MarketplaceRawDocument[]
      */
     public function findByCompany(Company $company, int $limit = 20): array

--- a/site/tests/Unit/Marketplace/MessageHandler/InitialSyncHandlerTest.php
+++ b/site/tests/Unit/Marketplace/MessageHandler/InitialSyncHandlerTest.php
@@ -7,11 +7,13 @@ namespace App\Tests\Unit\Marketplace\MessageHandler;
 use App\Company\Entity\Company;
 use App\Marketplace\Application\Service\MarketplaceWeekPartitionService;
 use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Entity\MarketplaceRawDocument;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Exception\MarketplaceAuthException;
 use App\Marketplace\Exception\MarketplaceRateLimitException;
 use App\Marketplace\Message\InitialSyncMessage;
 use App\Marketplace\MessageHandler\InitialSyncHandler;
+use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
 use App\Marketplace\Service\Integration\MarketplaceAdapterInterface;
 use App\Marketplace\Service\Integration\MarketplaceAdapterRegistry;
 use App\Tests\Builders\Company\CompanyBuilder;
@@ -132,7 +134,57 @@ final class InitialSyncHandlerTest extends TestCase
 
     public function testEmptyBatchStillDispatchesNextMessage(): void
     {
-        [$handler, $captured] = $this->createHandler(new MockClock('2026-04-10 12:00:00'), emptyRawData: true);
+        [$handler, $captured, $em] = $this->createHandler(new MockClock('2026-04-10 12:00:00'), emptyRawData: true, expectedFetchCalls: 1);
+
+        $em->expects(self::never())->method('persist');
+
+        $handler(new InitialSyncMessage(
+            companyId: self::COMPANY_ID,
+            connectionId: self::CONNECTION_ID,
+            marketplace: MarketplaceType::OZON->value,
+            dateFrom: '2026-03-23 00:00:00',
+            dateTo: '2026-03-29 23:59:59',
+            nextDateFrom: '2026-03-30 00:00:00',
+            nextDateTo: '2026-03-31 23:59:59',
+        ));
+
+        self::assertInstanceOf(InitialSyncMessage::class, $captured->message);
+    }
+
+    public function testFirstRunPersistsRawDocumentAndDispatchesNextMessage(): void
+    {
+        [$handler, $captured, $em] = $this->createHandler(new MockClock('2026-04-10 12:00:00'), expectedFetchCalls: 1);
+
+        $em->expects(self::once())->method('persist')->with(self::isInstanceOf(MarketplaceRawDocument::class));
+
+        $handler(new InitialSyncMessage(
+            companyId: self::COMPANY_ID,
+            connectionId: self::CONNECTION_ID,
+            marketplace: MarketplaceType::OZON->value,
+            dateFrom: '2026-03-23 00:00:00',
+            dateTo: '2026-03-29 23:59:59',
+            nextDateFrom: '2026-03-30 00:00:00',
+            nextDateTo: '2026-03-31 23:59:59',
+        ));
+
+        self::assertInstanceOf(InitialSyncMessage::class, $captured->message);
+    }
+
+    public function testSameBatchIdempotentSkipDispatchesNextMessageWithoutPersist(): void
+    {
+        $existingRawDoc = new MarketplaceRawDocument(
+            '33333333-3333-4333-8333-333333333333',
+            CompanyBuilder::aCompany()->withId(self::COMPANY_ID)->build(),
+            MarketplaceType::OZON,
+            'sales_report',
+        );
+        [$handler, $captured, $em] = $this->createHandler(
+            new MockClock('2026-04-10 12:00:00'),
+            existingRawDocument: $existingRawDoc,
+            expectedFetchCalls: 0,
+        );
+
+        $em->expects(self::never())->method('persist');
 
         $handler(new InitialSyncMessage(
             companyId: self::COMPANY_ID,
@@ -216,13 +268,15 @@ final class InitialSyncHandlerTest extends TestCase
     }
 
     /**
-     * @return array{0: InitialSyncHandler, 1: \stdClass} captured->message хранит последнее задиспатченное сообщение
+     * @return array{0: InitialSyncHandler, 1: \stdClass, 2: EntityManagerInterface, 3: MarketplaceAdapterInterface} captured->message хранит последнее задиспатченное сообщение
      */
     private function createHandler(
         MockClock $clock,
         ?\Throwable $fetchException = null,
         bool $lockAcquired = true,
         bool $emptyRawData = false,
+        ?MarketplaceRawDocument $existingRawDocument = null,
+        ?int $expectedFetchCalls = null,
     ): array
     {
         $company    = CompanyBuilder::aCompany()->withId(self::COMPANY_ID)->build();
@@ -244,16 +298,24 @@ final class InitialSyncHandlerTest extends TestCase
             return null;
         });
 
+        $rawDocumentRepository = $this->createMock(MarketplaceRawDocumentRepository::class);
+        $rawDocumentRepository->method('findExistingInitialSyncDocument')->willReturn($existingRawDocument);
+        $em->method('getRepository')->with(MarketplaceRawDocument::class)->willReturn($rawDocumentRepository);
+
         $adapter = $this->createMock(MarketplaceAdapterInterface::class);
         $adapter->method('getMarketplaceType')->willReturn(MarketplaceType::OZON->value);
         $adapter->method('getApiEndpointName')->willReturn('test/endpoint');
         // Непустой raw → handler сохранит MarketplaceRawDocument и дойдёт до dispatch.
+        $fetchRawReportExpectation = $expectedFetchCalls !== null
+            ? $adapter->expects(self::exactly($expectedFetchCalls))
+            : $adapter->expects(self::any());
+
         if ($fetchException !== null) {
-            $adapter->method('fetchRawReport')->willThrowException($fetchException);
+            $fetchRawReportExpectation->method('fetchRawReport')->willThrowException($fetchException);
         } elseif ($emptyRawData) {
-            $adapter->method('fetchRawReport')->willReturn([]);
+            $fetchRawReportExpectation->method('fetchRawReport')->willReturn([]);
         } else {
-            $adapter->method('fetchRawReport')->willReturn([['ok' => 1]]);
+            $fetchRawReportExpectation->method('fetchRawReport')->willReturn([['ok' => 1]]);
         }
 
         $registry = new MarketplaceAdapterRegistry([$adapter]);
@@ -287,6 +349,6 @@ final class InitialSyncHandlerTest extends TestCase
             $clock,
         );
 
-        return [$handler, $captured];
+        return [$handler, $captured, $em, $adapter];
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent duplicate saving of the same initial-sync weekly/month-split raw document by checking for an existing non-failed document with the same period and API endpoint.
- Make `InitialSyncHandler` idempotent so retries or duplicate dispatches do not create duplicate `MarketplaceRawDocument` records.

### Description
- Added `findExistingInitialSyncDocument` to `MarketplaceRawDocumentRepository` to locate an existing non-failed document by `company`, `marketplace`, `documentType`, `periodFrom`, `periodTo`, and `apiEndpoint`.
- Updated `InitialSyncHandler` to call the repository lookup (via `EntityManager::getRepository`) and skip fetching/persisting when an existing raw document is found, logging an idempotent skip with `raw_document_id` and `api_endpoint` details.
- Extracted `apiEndpoint` from the adapter earlier and only call `fetchRawReport` when no existing document is found; preserved previous behavior to persist non-empty raw data and dispatch the next message in the chain.
- Updated `InitialSyncHandlerTest` to mock the new repository method, assert `persist` is called or not as appropriate, and added/adjusted tests: `testEmptyBatchStillDispatchesNextMessage`, `testFirstRunPersistsRawDocumentAndDispatchesNextMessage`, and `testSameBatchIdempotentSkipDispatchesNextMessageWithoutPersist` among other expectations and mocks.

### Testing
- Ran unit tests for the handler (`site/tests/Unit/Marketplace/MessageHandler/InitialSyncHandlerTest`) under `phpunit`; all modified tests passed successfully.
- Verified expectations for `EntityManager::persist` and adapter `fetchRawReport` call counts in the updated unit tests, and confirmed dispatch behavior via the mocked `MessageBus`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f306adc9dc8323ae4db413b37185c7)