### PR TITLE
Handle unique-constraint races in marketplace initial sync and add partial unique index migration

### DIFF
--- a/site/migrations/Version20260430110000.php
+++ b/site/migrations/Version20260430110000.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260430110000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Marketplace initial sync: preflight duplicate audit + partial unique index for raw document idempotency';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $failedStatus = 'failed';
+
+        $duplicatesCount = (int) $this->connection->fetchOne(
+            <<<'SQL'
+                SELECT COUNT(*)
+                FROM (
+                    SELECT 1
+                    FROM marketplace_raw_documents
+                    WHERE processing_status IS NULL OR processing_status <> :failedStatus
+                    GROUP BY
+                        company_id,
+                        marketplace,
+                        document_type,
+                        period_from,
+                        period_to,
+                        COALESCE(api_endpoint, '')
+                    HAVING COUNT(*) > 1
+                ) duplicate_groups
+            SQL,
+            ['failedStatus' => $failedStatus],
+        );
+
+        if ($duplicatesCount > 0) {
+            $sampleDuplicateGroups = $this->connection->fetchAllAssociative(
+                <<<'SQL'
+                    SELECT
+                        company_id::text AS company_id,
+                        marketplace,
+                        document_type,
+                        period_from::text AS period_from,
+                        period_to::text AS period_to,
+                        COALESCE(api_endpoint, '') AS api_endpoint,
+                        COUNT(*) AS duplicates_count,
+                        STRING_AGG(id::text, ', ' ORDER BY synced_at, id) AS duplicate_ids,
+                        STRING_AGG(synced_at::text, ', ' ORDER BY synced_at, id) AS duplicate_synced_at
+                    FROM marketplace_raw_documents
+                    WHERE processing_status IS NULL OR processing_status <> :failedStatus
+                    GROUP BY
+                        company_id,
+                        marketplace,
+                        document_type,
+                        period_from,
+                        period_to,
+                        COALESCE(api_endpoint, '')
+                    HAVING COUNT(*) > 1
+                    ORDER BY duplicates_count DESC, company_id, marketplace, document_type, period_from, period_to
+                    LIMIT 10
+                SQL,
+                ['failedStatus' => $failedStatus],
+            );
+
+            $groupsPreview = array_map(
+                static fn (array $group): string => sprintf(
+                    '[company=%s marketplace=%s type=%s period=%s..%s endpoint=%s count=%s ids=%s synced_at=%s]',
+                    $group['company_id'],
+                    $group['marketplace'],
+                    $group['document_type'],
+                    $group['period_from'],
+                    $group['period_to'],
+                    $group['api_endpoint'],
+                    $group['duplicates_count'],
+                    $group['duplicate_ids'],
+                    $group['duplicate_synced_at'],
+                ),
+                $sampleDuplicateGroups,
+            );
+
+            $this->abortIf(
+                true,
+                sprintf(
+                    'Found %d duplicate non-failed initial-sync groups in marketplace_raw_documents. Resolve manually before migration. Sample groups: %s',
+                    $duplicatesCount,
+                    implode(' || ', $groupsPreview),
+                ),
+            );
+        }
+
+        $this->addSql(<<<'SQL'
+            CREATE UNIQUE INDEX uniq_mrd_init_sync_period
+            ON marketplace_raw_documents (
+                company_id,
+                marketplace,
+                document_type,
+                period_from,
+                period_to,
+                COALESCE(api_endpoint, '')
+            )
+            WHERE processing_status IS NULL OR processing_status <> 'failed'
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS uniq_mrd_init_sync_period');
+    }
+}

--- a/site/src/Marketplace/MessageHandler/InitialSyncHandler.php
+++ b/site/src/Marketplace/MessageHandler/InitialSyncHandler.php
@@ -15,6 +15,7 @@ use App\Marketplace\Exception\MarketplaceTemporaryApiException;
 use App\Marketplace\Message\InitialSyncMessage;
 use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
 use App\Marketplace\Service\Integration\MarketplaceAdapterRegistry;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
@@ -102,6 +103,7 @@ final class InitialSyncHandler
         $toDate      = new \DateTimeImmutable($message->dateTo);
 
         try {
+            $entityManagerClosedByUniqueViolation = false;
             $adapter = $this->adapterRegistry->get($marketplace);
             $apiEndpoint = $adapter->getApiEndpointName();
 
@@ -143,15 +145,31 @@ final class InitialSyncHandler
                     $rawDoc->setRecordsCount(count($rawData));
 
                     $this->em->persist($rawDoc);
-                    $this->em->flush();
 
-                    $this->logger->info('InitialSync: batch saved', [
-                        'company_id'    => $message->companyId,
-                        'marketplace'   => $message->marketplace,
-                        'date_from'     => $message->dateFrom,
-                        'date_to'       => $message->dateTo,
-                        'records_count' => count($rawData),
-                    ]);
+                    try {
+                        $this->em->flush();
+
+                        $this->logger->info('InitialSync: batch saved', [
+                            'company_id'    => $message->companyId,
+                            'marketplace'   => $message->marketplace,
+                            'date_from'     => $message->dateFrom,
+                            'date_to'       => $message->dateTo,
+                            'records_count' => count($rawData),
+                        ]);
+                    } catch (UniqueConstraintViolationException $e) {
+                        $entityManagerClosedByUniqueViolation = !$this->em->isOpen();
+
+                        $this->logger->info('InitialSync: idempotent skip after unique violation race', [
+                            'company_id' => $message->companyId,
+                            'connection_id' => $message->connectionId,
+                            'marketplace' => $message->marketplace,
+                            'date_from' => $message->dateFrom,
+                            'date_to' => $message->dateTo,
+                            'api_endpoint' => $apiEndpoint,
+                            'entity_manager_open' => !$entityManagerClosedByUniqueViolation,
+                            'error' => $e->getMessage(),
+                        ]);
+                    }
                 } else {
                     $this->logger->info('InitialSync: empty batch, skipping', [
                         'company_id'  => $message->companyId,
@@ -207,6 +225,18 @@ final class InitialSyncHandler
                     'date_to'     => $nextToStr,
                 ]);
             } else {
+                if ($entityManagerClosedByUniqueViolation) {
+                    $this->logger->warning('InitialSync: cannot mark final batch success because EntityManager is closed after unique violation', [
+                        'company_id' => $message->companyId,
+                        'connection_id' => $message->connectionId,
+                        'marketplace' => $message->marketplace,
+                        'date_from' => $message->dateFrom,
+                        'date_to' => $message->dateTo,
+                    ]);
+
+                    throw new RecoverableMessageHandlingException('EntityManager closed after unique violation on final initial sync batch.');
+                }
+
                 // Последняя партия — обновляем статус подключения
                 $connection = $this->em->find(MarketplaceConnection::class, $message->connectionId);
                 if ($connection) {

--- a/site/tests/Unit/Marketplace/MessageHandler/InitialSyncHandlerTest.php
+++ b/site/tests/Unit/Marketplace/MessageHandler/InitialSyncHandlerTest.php
@@ -17,6 +17,7 @@ use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
 use App\Marketplace\Service\Integration\MarketplaceAdapterInterface;
 use App\Marketplace\Service\Integration\MarketplaceAdapterRegistry;
 use App\Tests\Builders\Company\CompanyBuilder;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -199,6 +200,59 @@ final class InitialSyncHandlerTest extends TestCase
         self::assertInstanceOf(InitialSyncMessage::class, $captured->message);
     }
 
+    public function testUniqueViolationOnFlushIsTreatedAsIdempotentSkipAndDispatchesNextMessage(): void
+    {
+        $uniqueViolation = $this->createMock(UniqueConstraintViolationException::class);
+        [$handler, $captured, $em] = $this->createHandler(
+            new MockClock('2026-04-10 12:00:00'),
+            flushException: $uniqueViolation,
+            entityManagerOpenAfterFlushException: false,
+            expectedFetchCalls: 1,
+        );
+
+        $em->expects(self::once())->method('persist')->with(self::isInstanceOf(MarketplaceRawDocument::class));
+
+        $handler(new InitialSyncMessage(
+            companyId: self::COMPANY_ID,
+            connectionId: self::CONNECTION_ID,
+            marketplace: MarketplaceType::OZON->value,
+            dateFrom: '2026-03-23 00:00:00',
+            dateTo: '2026-03-29 23:59:59',
+            nextDateFrom: '2026-03-30 00:00:00',
+            nextDateTo: '2026-03-31 23:59:59',
+        ));
+
+        self::assertInstanceOf(InitialSyncMessage::class, $captured->message);
+    }
+
+    public function testUniqueViolationOnFinalBatchThrowsRecoverableWhenEntityManagerClosed(): void
+    {
+        $uniqueViolation = $this->createMock(UniqueConstraintViolationException::class);
+        [$handler, $captured] = $this->createHandler(
+            new MockClock('2026-04-10 12:00:00'),
+            flushException: $uniqueViolation,
+            entityManagerOpenAfterFlushException: false,
+            expectedFetchCalls: 1,
+        );
+
+        $this->expectException(RecoverableMessageHandlingException::class);
+        $this->expectExceptionMessage('EntityManager closed after unique violation on final initial sync batch.');
+
+        try {
+            $handler(new InitialSyncMessage(
+                companyId: self::COMPANY_ID,
+                connectionId: self::CONNECTION_ID,
+                marketplace: MarketplaceType::OZON->value,
+                dateFrom: '2026-03-23 00:00:00',
+                dateTo: '2026-03-29 23:59:59',
+                nextDateFrom: null,
+                nextDateTo: null,
+            ));
+        } finally {
+            self::assertNull($captured->message);
+        }
+    }
+
     public function testRateLimitWithRetryAfterDoesNotDispatchNextMessageAndSetsDelay(): void
     {
         [$handler, $captured] = $this->createHandler(
@@ -277,6 +331,8 @@ final class InitialSyncHandlerTest extends TestCase
         bool $emptyRawData = false,
         ?MarketplaceRawDocument $existingRawDocument = null,
         ?int $expectedFetchCalls = null,
+        ?\Throwable $flushException = null,
+        bool $entityManagerOpenAfterFlushException = true,
     ): array
     {
         $company    = CompanyBuilder::aCompany()->withId(self::COMPANY_ID)->build();
@@ -301,6 +357,10 @@ final class InitialSyncHandlerTest extends TestCase
         $rawDocumentRepository = $this->createMock(MarketplaceRawDocumentRepository::class);
         $rawDocumentRepository->method('findExistingInitialSyncDocument')->willReturn($existingRawDocument);
         $em->method('getRepository')->with(MarketplaceRawDocument::class)->willReturn($rawDocumentRepository);
+        if ($flushException !== null) {
+            $em->method('flush')->willThrowException($flushException);
+        }
+        $em->method('isOpen')->willReturn($entityManagerOpenAfterFlushException);
 
         $adapter = $this->createMock(MarketplaceAdapterInterface::class);
         $adapter->method('getMarketplaceType')->willReturn(MarketplaceType::OZON->value);


### PR DESCRIPTION
### Motivation

- Prevent race-condition duplicates during initial marketplace sync by enforcing idempotency at the DB level and treating concurrent insert conflicts as benign for the sync flow.

### Description

- Add a migration `Version20260430110000` that preflights duplicate non-`failed` initial-sync groups in `marketplace_raw_documents` and aborts the migration if any are found, then creates a partial unique index `uniq_mrd_init_sync_period` on `(company_id, marketplace, document_type, period_from, period_to, COALESCE(api_endpoint, ''))` for rows where `processing_status IS NULL OR processing_status <> 'failed'`.
- Update `InitialSyncHandler` to catch `UniqueConstraintViolationException` around the `flush()` that persists `MarketplaceRawDocument`, log it as an idempotent skip, and record whether the `EntityManager` was closed by the exception; if this occurs on the final batch and the `EntityManager` is closed, throw a `RecoverableMessageHandlingException` to allow retrying.
- Add import of `UniqueConstraintViolationException` and adjust handler logic to continue dispatching the next batch when flush fails due to a unique constraint race.
- Extend `InitialSyncHandlerTest` with tests that simulate a `UniqueConstraintViolationException` on `flush()` to assert that a competing insert is treated as idempotent and that a closed `EntityManager` on the final batch leads to a `RecoverableMessageHandlingException`; wire mocks for `flush()` and `isOpen()` to reproduce scenarios.

### Testing

- Ran unit tests for the handler (`tests/Unit/Marketplace/MessageHandler/InitialSyncHandlerTest.php`) which include new tests `testUniqueViolationOnFlushIsTreatedAsIdempotentSkipAndDispatchesNextMessage` and `testUniqueViolationOnFinalBatchThrowsRecoverableWhenEntityManagerClosed` and they passed.
- Existing handler unit tests were executed and continued to pass after changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3103d47e48323ae129c12aeccaf0b)