### PR TITLE
Align WB initial sync discovery with documented 204/429 behavior

### DIFF
--- a/site/src/Marketplace/MessageHandler/InitialSyncHandler.php
+++ b/site/src/Marketplace/MessageHandler/InitialSyncHandler.php
@@ -34,7 +34,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 final class InitialSyncHandler
 {
     private const LOCK_TTL_SECONDS = 300;
-    private const RATE_LIMIT_FALLBACK_DELAY_SECONDS = 90;
+    private const RATE_LIMIT_FALLBACK_DELAY_SECONDS = 600;
 
     public function __construct(
         private readonly EntityManagerInterface $em,

--- a/site/src/Marketplace/MessageHandler/TriggerInitialSyncHandler.php
+++ b/site/src/Marketplace/MessageHandler/TriggerInitialSyncHandler.php
@@ -29,6 +29,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 #[AsMessageHandler]
 final class TriggerInitialSyncHandler
 {
+    private const WB_RATE_LIMIT_FALLBACK_DELAY_SECONDS = 600;
     public function __construct(
         private readonly MessageBusInterface $messageBus,
         private readonly LoggerInterface $logger,
@@ -65,7 +66,7 @@ final class TriggerInitialSyncHandler
             try {
                 $resolved = $this->wbStartDateResolver->resolve($connection->getCompany(), $connection);
             } catch (MarketplaceRateLimitException $e) {
-                $retrySeconds = max(1, $e->getRetryAfter() ?? 90);
+                $retrySeconds = max(1, $e->getRetryAfter() ?? self::WB_RATE_LIMIT_FALLBACK_DELAY_SECONDS);
                 $this->logger->warning('InitialSync trigger delayed by WB rate limit during discovery', [
                     'company_id' => $message->companyId,
                     'connection_id' => $message->connectionId,

--- a/site/src/Marketplace/Service/Integration/WildberriesAdapter.php
+++ b/site/src/Marketplace/Service/Integration/WildberriesAdapter.php
@@ -23,6 +23,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 class WildberriesAdapter implements MarketplaceAdapterInterface
 {
     private const BASE_URL = 'https://statistics-api.wildberries.ru';
+    private const WB_HEADER_RETRY = 'x-ratelimit-retry';
+    private const WB_HEADER_RESET = 'x-ratelimit-reset';
 
     public function __construct(
         private readonly HttpClientInterface $httpClient,
@@ -93,6 +95,16 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
             throw new MarketplaceTemporaryApiException('WB API transport error.', $statusCode, '', $dateFrom, $dateTo, $e);
         }
         $excerpt = $this->createSafeExcerpt($body);
+
+        if (204 === $statusCode) {
+            $this->logger->info('WB API no data', [
+                'status_code' => $statusCode,
+                'date_from' => $dateFrom,
+                'date_to' => $dateTo,
+            ]);
+
+            return [];
+        }
 
         if (429 === $statusCode) {
             $retryAfter = $this->extractRetryAfter($headers);
@@ -191,6 +203,16 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
             throw new MarketplaceTemporaryApiException('WB API transport error.', $statusCode, '', $dateFrom, $dateTo, $e);
         }
         $excerpt = $this->createSafeExcerpt($body);
+
+        if (204 === $statusCode) {
+            $this->logger->debug('WB API no data', [
+                'status_code' => $statusCode,
+                'date_from' => $dateFrom,
+                'date_to' => $dateTo,
+            ]);
+
+            return false;
+        }
 
         if (429 === $statusCode) {
             $retryAfter = $this->extractRetryAfter($headers);
@@ -445,14 +467,33 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
 
     private function extractRetryAfter(array $headers): ?int
     {
-        $values = $headers['retry-after'] ?? $headers['Retry-After'] ?? null;
-        if (!is_array($values) || [] === $values) {
+        $retryAfter = $this->extractHeaderInt($headers, self::WB_HEADER_RETRY);
+        if ($retryAfter !== null) {
+            return $retryAfter;
+        }
+
+        $reset = $this->extractHeaderInt($headers, self::WB_HEADER_RESET);
+        if ($reset !== null) {
+            return $reset;
+        }
+
+        return $this->extractHeaderInt($headers, 'retry-after');
+    }
+
+    private function extractHeaderInt(array $headers, string $headerName): ?int
+    {
+        if (!isset($headers[$headerName][0])) {
             return null;
         }
 
-        $raw = trim((string) $values[0]);
+        $value = trim((string) $headers[$headerName][0]);
+        if ($value === '' || !is_numeric($value)) {
+            return null;
+        }
 
-        return ctype_digit($raw) ? (int) $raw : null;
+        $seconds = (int) $value;
+
+        return $seconds > 0 ? $seconds : null;
     }
 
     private function createSafeExcerpt(string $body): string

--- a/site/src/Marketplace/Service/Integration/WildberriesAdapter.php
+++ b/site/src/Marketplace/Service/Integration/WildberriesAdapter.php
@@ -474,7 +474,11 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
 
         $reset = $this->extractHeaderInt($headers, self::WB_HEADER_RESET);
         if ($reset !== null) {
-            return $reset;
+            $now = (new \DateTimeImmutable())->getTimestamp();
+
+            return $reset > $now
+                ? max(0, $reset - $now)
+                : $reset;
         }
 
         return $this->extractHeaderInt($headers, 'retry-after');
@@ -487,13 +491,11 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
         }
 
         $value = trim((string) $headers[$headerName][0]);
-        if ($value === '' || !is_numeric($value)) {
+        if ($value === '' || !ctype_digit($value)) {
             return null;
         }
 
-        $seconds = (int) $value;
-
-        return $seconds > 0 ? $seconds : null;
+        return (int) $value;
     }
 
     private function createSafeExcerpt(string $body): string

--- a/site/tests/Unit/Marketplace/MessageHandler/InitialSyncHandlerTest.php
+++ b/site/tests/Unit/Marketplace/MessageHandler/InitialSyncHandlerTest.php
@@ -296,7 +296,7 @@ final class InitialSyncHandlerTest extends TestCase
             ));
             self::fail('Expected RecoverableMessageHandlingException was not thrown.');
         } catch (RecoverableMessageHandlingException $e) {
-            self::assertSame(90_000, $e->getRetryDelay());
+            self::assertSame(600_000, $e->getRetryDelay());
             self::assertNull($captured->message);
         }
     }

--- a/site/tests/Unit/Marketplace/MessageHandler/TriggerInitialSyncHandlerTest.php
+++ b/site/tests/Unit/Marketplace/MessageHandler/TriggerInitialSyncHandlerTest.php
@@ -62,7 +62,7 @@ final class TriggerInitialSyncHandlerTest extends TestCase
             $handler(new TriggerInitialSyncMessage($company->getId(), $connection->getId(), MarketplaceType::WILDBERRIES->value));
             self::fail('Expected RecoverableMessageHandlingException');
         } catch (RecoverableMessageHandlingException $e) {
-            self::assertSame(90_000, $e->getRetryDelay());
+            self::assertSame(600_000, $e->getRetryDelay());
         }
     }
 

--- a/site/tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php
+++ b/site/tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php
@@ -69,6 +69,32 @@ final class WildberriesAdapterTest extends TestCase
         }
     }
 
+    public function testRateLimitUsesResetAsTimestampWhenValueLooksLikeUnixTime(): void
+    {
+        $resetTimestamp = time() + 300;
+        $adapter = $this->createAdapter(new MockResponse('{"error":"too many"}', ['http_code' => 429, 'response_headers' => ['X-Ratelimit-Reset: '.$resetTimestamp]]));
+
+        try {
+            $adapter->fetchRawReport($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-02'));
+            self::fail('Expected MarketplaceRateLimitException was not thrown');
+        } catch (MarketplaceRateLimitException $e) {
+            self::assertGreaterThanOrEqual(299, $e->getRetryAfter());
+            self::assertLessThanOrEqual(300, $e->getRetryAfter());
+        }
+    }
+
+    public function testRateLimitAllowsZeroRetryAfterValue(): void
+    {
+        $adapter = $this->createAdapter(new MockResponse('{"error":"too many"}', ['http_code' => 429, 'response_headers' => ['X-Ratelimit-Retry: 0']]));
+
+        try {
+            $adapter->fetchRawReport($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-02'));
+            self::fail('Expected MarketplaceRateLimitException was not thrown');
+        } catch (MarketplaceRateLimitException $e) {
+            self::assertSame(0, $e->getRetryAfter());
+        }
+    }
+
     public function testThrowsAuthExceptionFor401And403(): void
     {
         $adapter401 = $this->createAdapter(new MockResponse('', ['http_code' => 401]));

--- a/site/tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php
+++ b/site/tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php
@@ -31,14 +31,41 @@ final class WildberriesAdapterTest extends TestCase
 
     public function testThrowsRateLimitExceptionFor429(): void
     {
-        $adapter = $this->createAdapter(new MockResponse('{"error":"too many"}', ['http_code' => 429, 'response_headers' => ['Retry-After: 15']]));
+        $adapter = $this->createAdapter(new MockResponse('{"error":"too many"}', ['http_code' => 429, 'response_headers' => ['X-Ratelimit-Retry: 120', 'Retry-After: 15']]));
 
         try {
             $adapter->fetchRawReport($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-02'));
             self::fail('Expected MarketplaceRateLimitException was not thrown');
         } catch (MarketplaceRateLimitException $e) {
             self::assertSame(429, $e->getStatusCode());
-            self::assertSame(15, $e->getRetryAfter());
+            self::assertSame(120, $e->getRetryAfter());
+        }
+    }
+
+
+    public function testReturnsEmptyArrayFor204NoData(): void
+    {
+        $adapter = $this->createAdapter(new MockResponse('', ['http_code' => 204]));
+
+        self::assertSame([], $adapter->fetchRawReport($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-02')));
+    }
+
+    public function testProbeReturnsFalseFor204NoData(): void
+    {
+        $adapter = $this->createAdapter(new MockResponse('', ['http_code' => 204]));
+
+        self::assertFalse($adapter->hasRawReportData($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-02')));
+    }
+
+    public function testRateLimitUsesXRateLimitResetWhenRetryMissing(): void
+    {
+        $adapter = $this->createAdapter(new MockResponse('{"error":"too many"}', ['http_code' => 429, 'response_headers' => ['X-Ratelimit-Reset: 300']]));
+
+        try {
+            $adapter->fetchRawReport($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-02'));
+            self::fail('Expected MarketplaceRateLimitException was not thrown');
+        } catch (MarketplaceRateLimitException $e) {
+            self::assertSame(300, $e->getRetryAfter());
         }
     }
 


### PR DESCRIPTION
### Motivation
- Wildberries `reportDetailByPeriod` responds with `204 No Content` for empty periods and provides WB-specific rate-limit headers that must be respected to avoid aggressive retries and PROD throttling.
- Current discovery retried every 90s and treated `204` as an error, causing excessive retries against WB and hitting their rate limits.
- The goal is to align initial-sync discovery with Wildberries docs: treat `204` as normal no-data and prioritize WB headers for retry timing, and slow down fallback retries to reduce API pressure.

### Description
- In `WildberriesAdapter::fetchRawReport()` `204` now returns an empty list (`[]`) and logs `WB API no data` at info level, avoiding classification as a temporary error.
- In `WildberriesAdapter::hasRawReportData()` `204` now returns `false` and logs `WB API no data` at debug level, and no longer treats `204` as a temporary error.
- Added WB header parsing priority in `extractRetryAfter()` to prefer `X-Ratelimit-Retry`, then `X-Ratelimit-Reset`, and then `Retry-After`, with a helper `extractHeaderInt()` to parse integer seconds.
- Increased WB discovery/batch fallback retry delay from `90` seconds to `600` seconds in `TriggerInitialSyncHandler` and `InitialSyncHandler`, and updated handlers to use the `MarketplaceRateLimitException`'s retry value when present.
- Updated and added unit tests to cover `204` behavior, `X-Ratelimit-Retry` and `X-Ratelimit-Reset` parsing, and the increased handler fallback delays (tests updated: `WildberriesAdapterTest`, `TriggerInitialSyncHandlerTest`, `InitialSyncHandlerTest`).

### Testing
- Static syntax checks passed with `php -l` for all modified source and test files.
- Unit tests were added/updated to verify `204` handling, WB header priority for `429`, and handler fallback delays, and the test files were lint-checked, but PHPUnit could not be executed in this environment because `./vendor/bin/phpunit` is not available. 
- No changes were made to raw processors, DB unique indexes, idempotency guards, or migrations as requested.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4360ad3c08323923daffe071f1ef1)