### PR TITLE
Prefer local raw documents for WB initial sync and add rate-limit handling

### DIFF
--- a/site/src/Marketplace/Application/Service/WbInitialSyncStartDateResolver.php
+++ b/site/src/Marketplace/Application/Service/WbInitialSyncStartDateResolver.php
@@ -6,6 +6,8 @@ namespace App\Marketplace\Application\Service;
 
 use App\Company\Entity\Company;
 use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Exception\MarketplaceRateLimitException;
+use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
 use App\Marketplace\Service\Integration\WildberriesAdapter;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -14,9 +16,11 @@ use Symfony\Component\Clock\ClockInterface;
 class WbInitialSyncStartDateResolver
 {
     private const DISCOVERY_VERSION = '1';
+    private const DOCUMENT_TYPE = 'sales_report';
 
     public function __construct(
         private WildberriesAdapter $wildberriesAdapter,
+        private MarketplaceRawDocumentRepository $rawDocumentRepository,
         private EntityManagerInterface $entityManager,
         private LoggerInterface $logger,
         private ClockInterface $clock,
@@ -32,6 +36,27 @@ class WbInitialSyncStartDateResolver
 
         if (null !== $cached) {
             return $cached;
+        }
+
+        $localStartDate = $this->rawDocumentRepository->findMinPeriodFromForSuccessfulDocuments(
+            company: $company,
+            marketplace: $connection->getMarketplace(),
+            documentType: self::DOCUMENT_TYPE,
+            apiEndpoint: $this->wildberriesAdapter->getApiEndpointName(),
+            yearStart: $yearStart,
+            yesterday: $yesterday,
+        );
+
+        if (null !== $localStartDate) {
+            $connection->mergeSettings([
+                'wb_initial_sync_start_date' => $localStartDate->format('Y-m-d'),
+                'wb_initial_sync_discovery_at' => $this->clock->now()->format(\DateTimeInterface::ATOM),
+                'wb_initial_sync_discovery_source' => 'local_raw_documents',
+                'wb_initial_sync_discovery_version' => self::DISCOVERY_VERSION,
+            ]);
+            $this->entityManager->flush();
+
+            return $localStartDate;
         }
 
         $startDate = $this->discoverStartDate($company, $connection, $settings, $yearStart, $yesterday);
@@ -95,6 +120,27 @@ class WbInitialSyncStartDateResolver
         \DateTimeImmutable $yesterday,
     ): ?\DateTimeImmutable
     {
+        $retryNotBefore = $settings['wb_initial_sync_discovery_retry_not_before'] ?? null;
+        if (is_string($retryNotBefore) && '' !== trim($retryNotBefore)) {
+            try {
+                $notBefore = new \DateTimeImmutable($retryNotBefore);
+                if ($notBefore > $this->clock->now()) {
+                    $retryAfter = $notBefore->getTimestamp() - $this->clock->now()->getTimestamp();
+
+                    throw new MarketplaceRateLimitException(
+                        429,
+                        'Discovery paused after previous rate limit.',
+                        $yearStart->format('Y-m-d'),
+                        $yesterday->format('Y-m-d'),
+                        $retryAfter,
+                    );
+                }
+            } catch (MarketplaceRateLimitException $e) {
+                throw $e;
+            } catch (\Throwable) {
+            }
+        }
+
         $monthStart = $yearStart;
         $resumeMonth = $settings['wb_initial_sync_discovery_last_probed_month'] ?? null;
         if (is_string($resumeMonth) && '' !== trim($resumeMonth)) {
@@ -113,8 +159,21 @@ class WbInitialSyncStartDateResolver
                 $monthEnd = $yesterday;
             }
 
-            if ($this->wildberriesAdapter->hasRawReportData($company, $monthStart, $monthEnd)) {
-                return $monthStart;
+            try {
+                if ($this->wildberriesAdapter->hasRawReportData($company, $monthStart, $monthEnd)) {
+                    return $monthStart;
+                }
+            } catch (MarketplaceRateLimitException $e) {
+                $retryAfter = $e->getRetryAfter();
+                if (null !== $retryAfter && $retryAfter >= 300) {
+                    $connection->mergeSettings([
+                        'wb_initial_sync_discovery_retry_not_before' => $this->clock->now()->modify(sprintf('+%d seconds', $retryAfter))->format(\DateTimeInterface::ATOM),
+                        'wb_initial_sync_discovery_version' => self::DISCOVERY_VERSION,
+                    ]);
+                    $this->entityManager->flush();
+                }
+
+                throw $e;
             }
 
             $connection->mergeSettings([

--- a/site/src/Marketplace/Repository/MarketplaceRawDocumentRepository.php
+++ b/site/src/Marketplace/Repository/MarketplaceRawDocumentRepository.php
@@ -82,6 +82,40 @@ class MarketplaceRawDocumentRepository extends ServiceEntityRepository
             ->getOneOrNullResult();
     }
 
+    public function findMinPeriodFromForSuccessfulDocuments(
+        Company $company,
+        MarketplaceType $marketplace,
+        string $documentType,
+        string $apiEndpoint,
+        \DateTimeImmutable $yearStart,
+        \DateTimeImmutable $yesterday,
+    ): ?\DateTimeImmutable {
+        $value = $this->createQueryBuilder('d')
+            ->select('MIN(d.periodFrom) AS min_period_from')
+            ->where('d.company = :company')
+            ->andWhere('d.marketplace = :marketplace')
+            ->andWhere('d.documentType = :documentType')
+            ->andWhere('d.apiEndpoint = :apiEndpoint')
+            ->andWhere('d.periodFrom >= :yearStart')
+            ->andWhere('d.periodFrom <= :yesterday')
+            ->andWhere('d.processingStatus = :completed')
+            ->setParameter('company', $company)
+            ->setParameter('marketplace', $marketplace)
+            ->setParameter('documentType', $documentType)
+            ->setParameter('apiEndpoint', $apiEndpoint)
+            ->setParameter('yearStart', $yearStart)
+            ->setParameter('yesterday', $yesterday)
+            ->setParameter('completed', PipelineStatus::COMPLETED)
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        if (!is_string($value) || '' === $value) {
+            return null;
+        }
+
+        return new \DateTimeImmutable($value . ' 00:00:00');
+    }
+
     /**
      * @return MarketplaceRawDocument[]
      */

--- a/site/tests/Integration/Marketplace/MarketplaceRawDocumentRepositoryTest.php
+++ b/site/tests/Integration/Marketplace/MarketplaceRawDocumentRepositoryTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Marketplace;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceRawDocumentBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+
+final class MarketplaceRawDocumentRepositoryTest extends IntegrationTestCase
+{
+    public function testFindMinPeriodFromForSuccessfulDocumentsUsesOnlyCompletedDocuments(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+        $this->em->persist($company);
+
+        $completed = MarketplaceRawDocumentBuilder::aDocument()
+            ->forCompany($company)
+            ->withMarketplace(MarketplaceType::WILDBERRIES)
+            ->withPeriod(new \DateTimeImmutable('2026-03-01'), new \DateTimeImmutable('2026-03-31'))
+            ->build();
+        $completed->setApiEndpoint('wildberries::reportDetailByPeriod');
+        $completed->markCompleted();
+        $this->em->persist($completed);
+
+        $failed = MarketplaceRawDocumentBuilder::aDocument()
+            ->forCompany($company)
+            ->withMarketplace(MarketplaceType::WILDBERRIES)
+            ->withPeriod(new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-31'))
+            ->build();
+        $failed->setApiEndpoint('wildberries::reportDetailByPeriod');
+        $failed->markStepFailed(\App\Marketplace\Enum\PipelineStep::SALES);
+        $this->em->persist($failed);
+
+        $pending = MarketplaceRawDocumentBuilder::aDocument()
+            ->forCompany($company)
+            ->withMarketplace(MarketplaceType::WILDBERRIES)
+            ->withPeriod(new \DateTimeImmutable('2026-02-01'), new \DateTimeImmutable('2026-02-28'))
+            ->build();
+        $pending->setApiEndpoint('wildberries::reportDetailByPeriod');
+        $pending->resetProcessingStatus();
+        $this->em->persist($pending);
+
+        $nullStatus = MarketplaceRawDocumentBuilder::aDocument()
+            ->forCompany($company)
+            ->withMarketplace(MarketplaceType::WILDBERRIES)
+            ->withPeriod(new \DateTimeImmutable('2026-01-15'), new \DateTimeImmutable('2026-01-20'))
+            ->build();
+        $nullStatus->setApiEndpoint('wildberries::reportDetailByPeriod');
+        $this->em->persist($nullStatus);
+
+        $this->em->flush();
+
+        /** @var MarketplaceRawDocumentRepository $repository */
+        $repository = self::getContainer()->get(MarketplaceRawDocumentRepository::class);
+        $result = $repository->findMinPeriodFromForSuccessfulDocuments(
+            company: $company,
+            marketplace: MarketplaceType::WILDBERRIES,
+            documentType: 'sales_report',
+            apiEndpoint: 'wildberries::reportDetailByPeriod',
+            yearStart: new \DateTimeImmutable('2026-01-01'),
+            yesterday: new \DateTimeImmutable('2026-05-01'),
+        );
+
+        self::assertNotNull($result);
+        self::assertSame('2026-03-01', $result->format('Y-m-d'));
+    }
+}
+

--- a/site/tests/Unit/Marketplace/Application/Service/WbInitialSyncStartDateResolverTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbInitialSyncStartDateResolverTest.php
@@ -8,6 +8,7 @@ use App\Marketplace\Application\Service\WbInitialSyncStartDateResolver;
 use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Exception\MarketplaceRateLimitException;
+use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
 use App\Marketplace\Service\Integration\WildberriesAdapter;
 use App\Tests\Builders\Company\CompanyBuilder;
 use Doctrine\ORM\EntityManagerInterface;
@@ -25,11 +26,13 @@ final class WbInitialSyncStartDateResolverTest extends TestCase
 
         $adapter = $this->createMock(WildberriesAdapter::class);
         $adapter->expects(self::never())->method('hasRawReportData');
+        $rawRepository = $this->createMock(MarketplaceRawDocumentRepository::class);
+        $rawRepository->expects(self::never())->method('findMinPeriodFromForSuccessfulDocuments');
 
         $em = $this->createMock(EntityManagerInterface::class);
         $em->expects(self::never())->method('flush');
 
-        $resolver = new WbInitialSyncStartDateResolver($adapter, $em, new NullLogger(), new MockClock('2026-05-10 00:00:00'));
+        $resolver = new WbInitialSyncStartDateResolver($adapter, $rawRepository, $em, new NullLogger(), new MockClock('2026-05-10 00:00:00'));
         $date = $resolver->resolve($company, $connection);
 
         self::assertSame('2026-04-01', $date?->format('Y-m-d'));
@@ -43,11 +46,13 @@ final class WbInitialSyncStartDateResolverTest extends TestCase
 
         $adapter = $this->createMock(WildberriesAdapter::class);
         $adapter->method('hasRawReportData')->willReturnCallback(static fn ($c, $from) => (int) $from->format('n') >= 4);
+        $rawRepository = $this->createMock(MarketplaceRawDocumentRepository::class);
+        $rawRepository->method('findMinPeriodFromForSuccessfulDocuments')->willReturn(null);
 
         $em = $this->createMock(EntityManagerInterface::class);
         $em->expects(self::atLeastOnce())->method('flush');
 
-        $resolver = new WbInitialSyncStartDateResolver($adapter, $em, new NullLogger(), new MockClock('2026-05-10 00:00:00'));
+        $resolver = new WbInitialSyncStartDateResolver($adapter, $rawRepository, $em, new NullLogger(), new MockClock('2026-05-10 00:00:00'));
         $date = $resolver->resolve($company, $connection);
 
         self::assertSame('2026-04-01', $date?->format('Y-m-d'));
@@ -62,8 +67,10 @@ final class WbInitialSyncStartDateResolverTest extends TestCase
 
         $adapter = $this->createMock(WildberriesAdapter::class);
         $adapter->method('hasRawReportData')->willThrowException(new MarketplaceRateLimitException(429, 'rl', '2026-01-01', '2026-01-31', 12));
+        $rawRepository = $this->createMock(MarketplaceRawDocumentRepository::class);
+        $rawRepository->method('findMinPeriodFromForSuccessfulDocuments')->willReturn(null);
 
-        $resolver = new WbInitialSyncStartDateResolver($adapter, $this->createMock(EntityManagerInterface::class), new NullLogger(), new MockClock('2026-05-10 00:00:00'));
+        $resolver = new WbInitialSyncStartDateResolver($adapter, $rawRepository, $this->createMock(EntityManagerInterface::class), new NullLogger(), new MockClock('2026-05-10 00:00:00'));
 
         $this->expectException(MarketplaceRateLimitException::class);
         $resolver->resolve($company, $connection);
@@ -77,11 +84,13 @@ final class WbInitialSyncStartDateResolverTest extends TestCase
 
         $adapter = $this->createMock(WildberriesAdapter::class);
         $adapter->expects(self::once())->method('hasRawReportData')->willReturn(true);
+        $rawRepository = $this->createMock(MarketplaceRawDocumentRepository::class);
+        $rawRepository->method('findMinPeriodFromForSuccessfulDocuments')->willReturn(null);
 
         $em = $this->createMock(EntityManagerInterface::class);
         $em->expects(self::atLeastOnce())->method('flush');
 
-        $resolver = new WbInitialSyncStartDateResolver($adapter, $em, new NullLogger(), new MockClock('2026-05-10 00:00:00'));
+        $resolver = new WbInitialSyncStartDateResolver($adapter, $rawRepository, $em, new NullLogger(), new MockClock('2026-05-10 00:00:00'));
         $date = $resolver->resolve($company, $connection);
 
         self::assertSame('2026-01-01', $date?->format('Y-m-d'));
@@ -95,15 +104,59 @@ final class WbInitialSyncStartDateResolverTest extends TestCase
 
         $adapter = $this->createMock(WildberriesAdapter::class);
         $adapter->method('hasRawReportData')->willReturn(false);
+        $rawRepository = $this->createMock(MarketplaceRawDocumentRepository::class);
+        $rawRepository->method('findMinPeriodFromForSuccessfulDocuments')->willReturn(null);
 
         $em = $this->createMock(EntityManagerInterface::class);
         $em->expects(self::atLeastOnce())->method('flush');
 
-        $resolver = new WbInitialSyncStartDateResolver($adapter, $em, new NullLogger(), new MockClock('2026-05-10 00:00:00'));
+        $resolver = new WbInitialSyncStartDateResolver($adapter, $rawRepository, $em, new NullLogger(), new MockClock('2026-05-10 00:00:00'));
         $date = $resolver->resolve($company, $connection);
 
         self::assertNull($date);
         self::assertSame('me', $connection->getSettings()['keep']);
         self::assertArrayHasKey('wb_initial_sync_no_data_found_at', $connection->getSettings());
+    }
+
+    public function testUsesLocalRawDocumentsAndSkipsDiscoveryProbe(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+        $connection = new MarketplaceConnection('22222222-2222-2222-2222-222222222222', $company, MarketplaceType::WILDBERRIES);
+
+        $adapter = $this->createMock(WildberriesAdapter::class);
+        $adapter->expects(self::never())->method('hasRawReportData');
+        $adapter->method('getApiEndpointName')->willReturn('wildberries::reportDetailByPeriod');
+
+        $rawRepository = $this->createMock(MarketplaceRawDocumentRepository::class);
+        $rawRepository->expects(self::once())
+            ->method('findMinPeriodFromForSuccessfulDocuments')
+            ->willReturn(new \DateTimeImmutable('2026-03-01 00:00:00'));
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::once())->method('flush');
+
+        $resolver = new WbInitialSyncStartDateResolver($adapter, $rawRepository, $em, new NullLogger(), new MockClock('2026-05-10 00:00:00'));
+        $date = $resolver->resolve($company, $connection);
+
+        self::assertSame('2026-03-01', $date?->format('Y-m-d'));
+    }
+
+    public function testNoLocalRawDocumentsTriggersProbe(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+        $connection = new MarketplaceConnection('22222222-2222-2222-2222-222222222222', $company, MarketplaceType::WILDBERRIES);
+
+        $adapter = $this->createMock(WildberriesAdapter::class);
+        $adapter->expects(self::once())->method('hasRawReportData')->willReturn(true);
+        $adapter->method('getApiEndpointName')->willReturn('wildberries::reportDetailByPeriod');
+
+        $rawRepository = $this->createMock(MarketplaceRawDocumentRepository::class);
+        $rawRepository->expects(self::once())->method('findMinPeriodFromForSuccessfulDocuments')->willReturn(null);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::atLeastOnce())->method('flush');
+
+        $resolver = new WbInitialSyncStartDateResolver($adapter, $rawRepository, $em, new NullLogger(), new MockClock('2026-05-10 00:00:00'));
+        $resolver->resolve($company, $connection);
     }
 }


### PR DESCRIPTION
### Motivation

- Reduce unnecessary remote probing by using already-downloaded marketplace raw documents to determine Wildberries initial sync start date.
- Avoid repeated discovery requests after hitting marketplace rate limits by persisting a retry window and surfacing rate-limit errors.

### Description

- Inject `MarketplaceRawDocumentRepository` into `WbInitialSyncStartDateResolver` and add `DOCUMENT_TYPE` constant to prefer local raw documents via a new repository call `findMinPeriodFromForSuccessfulDocuments` before probing the API.
- Add `findMinPeriodFromForSuccessfulDocuments` to `MarketplaceRawDocumentRepository` which returns the minimum `periodFrom` of completed documents in a given range and API endpoint.
- Persist discovery metadata to connection settings when a local start date is found, including `wb_initial_sync_start_date`, `wb_initial_sync_discovery_at`, and `wb_initial_sync_discovery_source`.
- Add handling for `MarketplaceRateLimitException` in discovery: propagate the exception and, when `retryAfter >= 300` seconds, store `wb_initial_sync_discovery_retry_not_before` to pause future discovery until the retry window elapses.
- Minor wiring changes: import `MarketplaceRateLimitException`, call `WildberriesAdapter::getApiEndpointName()` when querying local documents, and update `EntityManagerInterface` flush points.

### Testing

- Added `MarketplaceRawDocumentRepositoryTest::testFindMinPeriodFromForSuccessfulDocumentsUsesOnlyCompletedDocuments` as an integration test, which passed.
- Updated `WbInitialSyncStartDateResolverTest` unit tests to cover cached date usage, discovery probing, rate-limit propagation, local-document short-circuit, and probe fallback, and all unit tests passed.
- Ran the modified test suite (unit + the added integration test) with all tests succeeding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4af48ed088323877edab5a7a39c75)