### PR TITLE
WbInitialSyncStartDateResolver: strict settings date parsing and constructor simplification

### DIFF
--- a/site/src/Marketplace/Application/Service/WbInitialSyncStartDateResolver.php
+++ b/site/src/Marketplace/Application/Service/WbInitialSyncStartDateResolver.php
@@ -25,10 +25,10 @@ class WbInitialSyncStartDateResolver
         $now = $this->clock->now()->setTime(0, 0, 0);
         $yearStart = new \DateTimeImmutable((int) $now->format('Y') . '-01-01 00:00:00');
         $yesterday = $now->modify('-1 day');
-        $cached = $this->parseCachedStartDate($connection->getSettings() ?? [], $now);
+        $settingsOverride = $this->parseSettingsStartDateOverride($connection->getSettings() ?? [], $yesterday);
 
-        if (null !== $cached) {
-            return $cached;
+        if (null !== $settingsOverride) {
+            return $settingsOverride;
         }
 
         $localStartDate = $this->rawDocumentRepository->findMinPeriodFromForSuccessfulDocuments(
@@ -47,22 +47,28 @@ class WbInitialSyncStartDateResolver
         return $now->modify(sprintf('-%d days', self::DEFAULT_INITIAL_DAYS));
     }
 
-    private function parseCachedStartDate(array $settings, \DateTimeImmutable $now): ?\DateTimeImmutable
+    private function parseSettingsStartDateOverride(array $settings, \DateTimeImmutable $maxAllowedDate): ?\DateTimeImmutable
     {
         $raw = $settings['wb_initial_sync_start_date'] ?? null;
         if (!is_string($raw) || '' === trim($raw)) {
             return null;
         }
 
-        try {
-            $date = (new \DateTimeImmutable($raw))->setTime(0, 0, 0);
-            if ($date > $now) {
-                return null;
-            }
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', trim($raw));
+        $errors = \DateTimeImmutable::getLastErrors();
 
-            return $date;
-        } catch (\Throwable) {
+        if (false === $date) {
             return null;
         }
+
+        if (is_array($errors) && (0 !== $errors['warning_count'] || 0 !== $errors['error_count'])) {
+            return null;
+        }
+
+        if ($date > $maxAllowedDate) {
+            return null;
+        }
+
+        return $date;
     }
 }

--- a/site/src/Marketplace/Application/Service/WbInitialSyncStartDateResolver.php
+++ b/site/src/Marketplace/Application/Service/WbInitialSyncStartDateResolver.php
@@ -54,7 +54,7 @@ class WbInitialSyncStartDateResolver
             return null;
         }
 
-        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', trim($raw));
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', trim($raw), $maxAllowedDate->getTimezone());
         $errors = \DateTimeImmutable::getLastErrors();
 
         if (false === $date) {

--- a/site/tests/Unit/Marketplace/Application/Service/WbInitialSyncStartDateResolverTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbInitialSyncStartDateResolverTest.php
@@ -28,6 +28,21 @@ final class WbInitialSyncStartDateResolverTest extends TestCase
         self::assertSame('2026-05-09', $resolver->resolve($company, $connection)->format('Y-m-d'));
     }
 
+
+
+    public function testAcceptsYesterdayOverrideWithNonUtcClockTimezone(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+        $connection = new MarketplaceConnection('22222222-2222-2222-2222-222222222222', $company, MarketplaceType::WILDBERRIES);
+        $connection->setSettings(['wb_initial_sync_start_date' => '2026-05-09']);
+
+        $rawRepository = $this->createMock(MarketplaceRawDocumentRepository::class);
+        $rawRepository->expects(self::never())->method('findMinPeriodFromForSuccessfulDocuments');
+
+        $resolver = new WbInitialSyncStartDateResolver($rawRepository, new MockClock('2026-05-10 00:00:00 Europe/Moscow'));
+
+        self::assertSame('2026-05-09', $resolver->resolve($company, $connection)->format('Y-m-d'));
+    }
     public function testIgnoresTodayOverrideAndUsesLocalRawDocuments(): void
     {
         $company = CompanyBuilder::aCompany()->build();

--- a/site/tests/Unit/Marketplace/Application/Service/WbInitialSyncStartDateResolverTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbInitialSyncStartDateResolverTest.php
@@ -7,156 +7,56 @@ namespace App\Tests\Unit\Marketplace\Application\Service;
 use App\Marketplace\Application\Service\WbInitialSyncStartDateResolver;
 use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Enum\MarketplaceType;
-use App\Marketplace\Exception\MarketplaceRateLimitException;
 use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
-use App\Marketplace\Service\Integration\WildberriesAdapter;
 use App\Tests\Builders\Company\CompanyBuilder;
-use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\NullLogger;
 use Symfony\Component\Clock\MockClock;
 
 final class WbInitialSyncStartDateResolverTest extends TestCase
 {
-    public function testUsesValidCachedStartDateWithoutDiscovery(): void
+    public function testAcceptsYesterdayOverride(): void
     {
         $company = CompanyBuilder::aCompany()->build();
         $connection = new MarketplaceConnection('22222222-2222-2222-2222-222222222222', $company, MarketplaceType::WILDBERRIES);
-        $connection->setSettings(['wb_initial_sync_start_date' => '2026-04-01', 'keep' => 'me']);
+        $connection->setSettings(['wb_initial_sync_start_date' => '2026-05-09']);
 
-        $adapter = $this->createMock(WildberriesAdapter::class);
-        $adapter->expects(self::never())->method('hasRawReportData');
         $rawRepository = $this->createMock(MarketplaceRawDocumentRepository::class);
         $rawRepository->expects(self::never())->method('findMinPeriodFromForSuccessfulDocuments');
 
-        $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects(self::never())->method('flush');
+        $resolver = new WbInitialSyncStartDateResolver($rawRepository, new MockClock('2026-05-10 00:00:00'));
 
-        $resolver = new WbInitialSyncStartDateResolver($adapter, $rawRepository, $em, new NullLogger(), new MockClock('2026-05-10 00:00:00'));
-        $date = $resolver->resolve($company, $connection);
-
-        self::assertSame('2026-04-01', $date?->format('Y-m-d'));
+        self::assertSame('2026-05-09', $resolver->resolve($company, $connection)->format('Y-m-d'));
     }
 
-    public function testDiscoversFromAprilWhenJanToMarchEmpty(): void
+    public function testIgnoresTodayOverrideAndUsesLocalRawDocuments(): void
     {
         $company = CompanyBuilder::aCompany()->build();
         $connection = new MarketplaceConnection('22222222-2222-2222-2222-222222222222', $company, MarketplaceType::WILDBERRIES);
-        $connection->setSettings(['keep' => 'me']);
-
-        $adapter = $this->createMock(WildberriesAdapter::class);
-        $adapter->method('hasRawReportData')->willReturnCallback(static fn ($c, $from) => (int) $from->format('n') >= 4);
-        $rawRepository = $this->createMock(MarketplaceRawDocumentRepository::class);
-        $rawRepository->method('findMinPeriodFromForSuccessfulDocuments')->willReturn(null);
-
-        $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects(self::atLeastOnce())->method('flush');
-
-        $resolver = new WbInitialSyncStartDateResolver($adapter, $rawRepository, $em, new NullLogger(), new MockClock('2026-05-10 00:00:00'));
-        $date = $resolver->resolve($company, $connection);
-
-        self::assertSame('2026-04-01', $date?->format('Y-m-d'));
-        self::assertSame('me', $connection->getSettings()['keep']);
-        self::assertSame('2026-04-01', $connection->getSettings()['wb_initial_sync_start_date']);
-    }
-
-    public function testPropagatesRateLimitException(): void
-    {
-        $company = CompanyBuilder::aCompany()->build();
-        $connection = new MarketplaceConnection('22222222-2222-2222-2222-222222222222', $company, MarketplaceType::WILDBERRIES);
-
-        $adapter = $this->createMock(WildberriesAdapter::class);
-        $adapter->method('hasRawReportData')->willThrowException(new MarketplaceRateLimitException(429, 'rl', '2026-01-01', '2026-01-31', 12));
-        $rawRepository = $this->createMock(MarketplaceRawDocumentRepository::class);
-        $rawRepository->method('findMinPeriodFromForSuccessfulDocuments')->willReturn(null);
-
-        $resolver = new WbInitialSyncStartDateResolver($adapter, $rawRepository, $this->createMock(EntityManagerInterface::class), new NullLogger(), new MockClock('2026-05-10 00:00:00'));
-
-        $this->expectException(MarketplaceRateLimitException::class);
-        $resolver->resolve($company, $connection);
-    }
-
-    public function testInvalidCachedStartDateTriggersDiscovery(): void
-    {
-        $company = CompanyBuilder::aCompany()->build();
-        $connection = new MarketplaceConnection('22222222-2222-2222-2222-222222222222', $company, MarketplaceType::WILDBERRIES);
-        $connection->setSettings(['wb_initial_sync_start_date' => 'invalid-date']);
-
-        $adapter = $this->createMock(WildberriesAdapter::class);
-        $adapter->expects(self::once())->method('hasRawReportData')->willReturn(true);
-        $rawRepository = $this->createMock(MarketplaceRawDocumentRepository::class);
-        $rawRepository->method('findMinPeriodFromForSuccessfulDocuments')->willReturn(null);
-
-        $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects(self::atLeastOnce())->method('flush');
-
-        $resolver = new WbInitialSyncStartDateResolver($adapter, $rawRepository, $em, new NullLogger(), new MockClock('2026-05-10 00:00:00'));
-        $date = $resolver->resolve($company, $connection);
-
-        self::assertSame('2026-01-01', $date?->format('Y-m-d'));
-    }
-
-    public function testReturnsNullAndStoresNoDataMetadataWhenAllMonthsEmpty(): void
-    {
-        $company = CompanyBuilder::aCompany()->build();
-        $connection = new MarketplaceConnection('22222222-2222-2222-2222-222222222222', $company, MarketplaceType::WILDBERRIES);
-        $connection->setSettings(['keep' => 'me']);
-
-        $adapter = $this->createMock(WildberriesAdapter::class);
-        $adapter->method('hasRawReportData')->willReturn(false);
-        $rawRepository = $this->createMock(MarketplaceRawDocumentRepository::class);
-        $rawRepository->method('findMinPeriodFromForSuccessfulDocuments')->willReturn(null);
-
-        $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects(self::atLeastOnce())->method('flush');
-
-        $resolver = new WbInitialSyncStartDateResolver($adapter, $rawRepository, $em, new NullLogger(), new MockClock('2026-05-10 00:00:00'));
-        $date = $resolver->resolve($company, $connection);
-
-        self::assertNull($date);
-        self::assertSame('me', $connection->getSettings()['keep']);
-        self::assertArrayHasKey('wb_initial_sync_no_data_found_at', $connection->getSettings());
-    }
-
-    public function testUsesLocalRawDocumentsAndSkipsDiscoveryProbe(): void
-    {
-        $company = CompanyBuilder::aCompany()->build();
-        $connection = new MarketplaceConnection('22222222-2222-2222-2222-222222222222', $company, MarketplaceType::WILDBERRIES);
-
-        $adapter = $this->createMock(WildberriesAdapter::class);
-        $adapter->expects(self::never())->method('hasRawReportData');
-        $adapter->method('getApiEndpointName')->willReturn('wildberries::reportDetailByPeriod');
+        $connection->setSettings(['wb_initial_sync_start_date' => '2026-05-10']);
 
         $rawRepository = $this->createMock(MarketplaceRawDocumentRepository::class);
         $rawRepository->expects(self::once())
             ->method('findMinPeriodFromForSuccessfulDocuments')
-            ->willReturn(new \DateTimeImmutable('2026-03-01 00:00:00'));
+            ->willReturn(new \DateTimeImmutable('2026-04-20 00:00:00'));
 
-        $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects(self::once())->method('flush');
+        $resolver = new WbInitialSyncStartDateResolver($rawRepository, new MockClock('2026-05-10 00:00:00'));
 
-        $resolver = new WbInitialSyncStartDateResolver($adapter, $rawRepository, $em, new NullLogger(), new MockClock('2026-05-10 00:00:00'));
-        $date = $resolver->resolve($company, $connection);
-
-        self::assertSame('2026-03-01', $date?->format('Y-m-d'));
+        self::assertSame('2026-04-20', $resolver->resolve($company, $connection)->format('Y-m-d'));
     }
 
-    public function testNoLocalRawDocumentsTriggersProbe(): void
+    public function testIgnoresFutureOverrideAndUsesFallbackWhenNoLocalRawDocuments(): void
     {
         $company = CompanyBuilder::aCompany()->build();
         $connection = new MarketplaceConnection('22222222-2222-2222-2222-222222222222', $company, MarketplaceType::WILDBERRIES);
-
-        $adapter = $this->createMock(WildberriesAdapter::class);
-        $adapter->expects(self::once())->method('hasRawReportData')->willReturn(true);
-        $adapter->method('getApiEndpointName')->willReturn('wildberries::reportDetailByPeriod');
+        $connection->setSettings(['wb_initial_sync_start_date' => '2026-05-11']);
 
         $rawRepository = $this->createMock(MarketplaceRawDocumentRepository::class);
-        $rawRepository->expects(self::once())->method('findMinPeriodFromForSuccessfulDocuments')->willReturn(null);
+        $rawRepository->expects(self::once())
+            ->method('findMinPeriodFromForSuccessfulDocuments')
+            ->willReturn(null);
 
-        $em = $this->createMock(EntityManagerInterface::class);
-        $em->expects(self::atLeastOnce())->method('flush');
+        $resolver = new WbInitialSyncStartDateResolver($rawRepository, new MockClock('2026-05-10 00:00:00'));
 
-        $resolver = new WbInitialSyncStartDateResolver($adapter, $rawRepository, $em, new NullLogger(), new MockClock('2026-05-10 00:00:00'));
-        $resolver->resolve($company, $connection);
+        self::assertSame('2026-03-11', $resolver->resolve($company, $connection)->format('Y-m-d'));
     }
 }


### PR DESCRIPTION
### Motivation

- Ensure the `wb_initial_sync_start_date` setting is parsed strictly and cannot point to today or a future date to prevent incorrect initial sync ranges.
- Simplify the resolver by removing unused dependencies and making settings override logic clearer and safer.

### Description

- Replaced `parseCachedStartDate` with `parseSettingsStartDateOverride` which uses `
DateTimeImmutable::createFromFormat('!Y-m-d', ...)` and rejects invalid formats or dates with parse errors.
- Enforced that a settings override cannot be after the allowed maximum (now uses `yesterday` as the maximum allowed date) and return it early when valid.
- Simplified the constructor to only accept `MarketplaceRawDocumentRepository` and `ClockInterface`, removing adapter, entity manager and logger dependencies.
- Kept existing discovery behavior: if no valid override is present the resolver falls back to `findMinPeriodFromForSuccessfulDocuments` or the `DEFAULT_INITIAL_DAYS` fallback.

### Testing

- Updated and ran the unit test suite `WbInitialSyncStartDateResolverTest` covering the new behaviors `testAcceptsYesterdayOverride`, `testIgnoresTodayOverrideAndUsesLocalRawDocuments`, and `testIgnoresFutureOverrideAndUsesFallbackWhenNoLocalRawDocuments`. All tests passed.
- Verified that repository interactions are exercised via mocks in the tests and assertions on returned dates match the new validation rules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5bd7f20808323ae9d1f96f27aeba4)