### PR TITLE
Add marketplace and date range filters to marketplace costs page and JSON export link

### DIFF
--- a/site/templates/marketplace/costs.html.twig
+++ b/site/templates/marketplace/costs.html.twig
@@ -24,9 +24,9 @@
     <div class="card-body border-bottom">
         <form method="get" action="{{ path('marketplace_costs_index') }}" class="row g-3">
             <input type="hidden" name="mapped" value="{{ mapped }}">
-            <div class="col-md-4">
+            <div class="col-md-3">
                 <label class="form-label">Категория</label>
-                <select name="category" class="form-select" onchange="this.form.submit()">
+                <select name="category" class="form-select">
                     <option value="">Все категории</option>
                     {% for category in categories %}
                         <option value="{{ category.id }}" {{ selectedCategoryId == category.id ? 'selected' : '' }}>
@@ -35,12 +35,32 @@
                     {% endfor %}
                 </select>
             </div>
-            <div class="col-md-2 d-flex align-items-end">
-                {% if selectedCategoryId %}
-                    <a href="{{ path('marketplace_costs_index') }}" class="btn btn-outline-secondary">
-                        Сбросить
-                    </a>
-                {% endif %}
+            <div class="col-md-2">
+                <label class="form-label">Маркетплейс</label>
+                <select name="marketplace" class="form-select">
+                    {% for marketplace in availableMarketplaces %}
+                        <option value="{{ marketplace.value }}" {{ selectedMarketplace == marketplace.value ? 'selected' : '' }}>
+                            {{ marketplace.getDisplayName() }}
+                        </option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="col-md-2">
+                <label class="form-label">С</label>
+                <input type="date" name="date_from" class="form-control" value="{{ selectedDateFrom }}">
+            </div>
+            <div class="col-md-2">
+                <label class="form-label">По</label>
+                <input type="date" name="date_to" class="form-control" value="{{ selectedDateTo }}">
+            </div>
+            <div class="col-md-3 d-flex align-items-end gap-2">
+                <button type="submit" class="btn btn-primary">Применить</button>
+                <a href="{{ path('marketplace_costs_export_json', exportRouteParams|default(routeParams|default({}))) }}" class="btn btn-outline-primary">
+                    Выгрузить в JSON
+                </a>
+                <a href="{{ path('marketplace_costs_index') }}" class="btn btn-outline-secondary">
+                    Сбросить
+                </a>
             </div>
         </form>
     </div>


### PR DESCRIPTION
### Motivation
- Provide more flexible filtering on the marketplace costs view by allowing filtering by marketplace and date range. 
- Add a direct JSON export for the current filter parameters to facilitate data export. 
- Replace the category auto-submit behavior with an explicit `Применить` action to support combined filter selections.

### Description
- Adjusted the filter form layout in `site/templates/marketplace/costs.html.twig` and changed the category column width from `col-md-4` to `col-md-3`. 
- Added a `Маркетплейс` select populated from `availableMarketplaces` using `marketplace.getDisplayName()` and bound to `selectedMarketplace`. 
- Added `date_from` and `date_to` inputs bound to `selectedDateFrom` and `selectedDateTo`, and replaced the category `onchange` auto-submit with an explicit `Применить` button. 
- Added a `Выгрузить в JSON` button linking to `marketplace_costs_export_json` with `exportRouteParams|default(routeParams|default({}))`, and made the `Сбросить` link always available in the form row.

### Testing
- Ran `twig:lint` against the changed template to validate Twig syntax, which succeeded. 
- Executed the project's `phpunit` test suite to confirm no regressions in backend logic, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8b1a01f3c8323a00e2f81ce7bc1bc)