### PR TITLE
Preserve costs filters in tabs and pager params

### DIFF
--- a/site/templates/marketplace/costs.html.twig
+++ b/site/templates/marketplace/costs.html.twig
@@ -6,15 +6,15 @@
     <ul class="nav nav-tabs mb-3">
         <li class="nav-item">
             <a class="nav-link {{ mapped == 'all' ? 'active' : '' }}"
-               href="{{ path('marketplace_costs_index', {'category': selectedCategoryId, 'mapped': 'all'}) }}">Все</a>
+               href="{{ path('marketplace_costs_index', routeParams|default({'category': selectedCategoryId, 'mapped': mapped, 'marketplace': selectedMarketplace, 'date_from': selectedDateFrom, 'date_to': selectedDateTo})|merge({'mapped': 'all'})) }}">Все</a>
         </li>
         <li class="nav-item">
             <a class="nav-link {{ mapped == 'linked' ? 'active' : '' }}"
-               href="{{ path('marketplace_costs_index', {'category': selectedCategoryId, 'mapped': 'linked'}) }}">С листингом</a>
+               href="{{ path('marketplace_costs_index', routeParams|default({'category': selectedCategoryId, 'mapped': mapped, 'marketplace': selectedMarketplace, 'date_from': selectedDateFrom, 'date_to': selectedDateTo})|merge({'mapped': 'linked'})) }}">С листингом</a>
         </li>
         <li class="nav-item">
             <a class="nav-link {{ mapped == 'general' ? 'active' : '' }}"
-               href="{{ path('marketplace_costs_index', {'category': selectedCategoryId, 'mapped': 'general'}) }}">Общие</a>
+               href="{{ path('marketplace_costs_index', routeParams|default({'category': selectedCategoryId, 'mapped': mapped, 'marketplace': selectedMarketplace, 'date_from': selectedDateFrom, 'date_to': selectedDateTo})|merge({'mapped': 'general'})) }}">Общие</a>
         </li>
     </ul>
 
@@ -152,10 +152,13 @@
             {% include 'partials/_pagerfanta.html.twig' with {
                 'pager': pager,
                 'route': 'marketplace_costs_index',
-                'params': {
+                'params': routeParams|default({
                     'category': selectedCategoryId,
-                    'mapped': mapped
-                }
+                    'mapped': mapped,
+                    'marketplace': selectedMarketplace,
+                    'date_from': selectedDateFrom,
+                    'date_to': selectedDateTo
+                })
             } %}
         </div>
     {% endif %}


### PR DESCRIPTION
### Motivation
- Switching tabs or pages should not drop newly added query filters `marketplace`, `date_from`, `date_to` or existing `category` and `mapped` parameters on the costs page.
- Use existing `routeParams` when building tab URLs and pager params so only `mapped` is overridden per-tab and all other filters are preserved.

### Description
- Replaced manual query construction in tabs with `routeParams|default({...})|merge({'mapped': '...'})` for the three tabs (`all`, `linked`, `general`) in `site/templates/marketplace/costs.html.twig` so only `mapped` is changed on tab switch.
- Replaced the `pagerfanta` include `params` with `routeParams|default({...})` containing `category`, `mapped`, `marketplace`, `date_from`, and `date_to` so pagination preserves all filters.
- Did not change the route name `marketplace_costs_index`, the visual tab markup/classes, or the pager partial `site/templates/partials/_pagerfanta.html.twig`.

### Testing
- No automated tests were executed for this template-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8b49ed0b883238cb8d30da400f8e4)