### PR TITLE
Add Task 7 marketplace final verification report

### DIFF
--- a/site/TASK7_FINAL_CHECK_REPORT.md
+++ b/site/TASK7_FINAL_CHECK_REPORT.md
@@ -1,0 +1,37 @@
+# Task 7 — Финальная проверка и регрессия
+
+Дата проверки: 2026-05-04 (UTC)
+
+## Что выполнено
+
+### 1) Проверка синтаксиса PHP-файлов
+- `site/src/Marketplace/Controller/MarketplaceController.php` — OK
+- `site/src/Marketplace/Controller/CostsJsonExportController.php` — OK
+- `site/src/Marketplace/Repository/MarketplaceCostRepository.php` — OK
+
+### 2) Попытка запуска интеграционных тестов Marketplace
+- `php bin/phpunit tests/Integration/Marketplace` — не выполнено: отсутствует `vendor/symfony/phpunit-bridge/bin/simple-phpunit.php`
+- `vendor/bin/phpunit tests/Integration/Marketplace` — не выполнено: отсутствует `vendor/bin/phpunit`
+
+Вывод: в текущем окружении не установлены dev-зависимости (`vendor`) для запуска PHPUnit.
+
+### 3) Проверка phpstan/php-cs-fixer
+В проекте есть скрипты `cs:check`/`cs:fix`, но инструменты также недоступны без установленных зависимостей в `vendor`.
+
+### 4) Ручная браузерная проверка из задания
+Ручная проверка в браузере в этом CI-окружении не выполнена (нет интерактивной браузерной сессии).
+
+Рекомендуется прогон в рабочем/stage окружении по чек-листу:
+1. `/marketplace/costs` — дефолты Ozon + текущий месяц.
+2. Фильтр category + Apply — остальные фильтры сохраняются.
+3. Фильтр marketplace + Apply — остальные фильтры сохраняются.
+4. Фильтр date_from/date_to + Apply — включительные границы.
+5. Tabs (Все / С листингом / Общие) — меняется только `mapped`, прочие фильтры сохраняются.
+6. Пагинация (если >50) — фильтры сохраняются.
+7. `Выгрузить в JSON` — скачивание и валидность (`filters`, `count`, `costs`).
+8. Прямой URL `/marketplace/costs/export.json?...` — `200`, JSON, `Content-Disposition: attachment`.
+9. Невалидные query-параметры — без `500`, fallback на дефолты.
+10. Регрессия страниц: `/marketplace/sales`, `/marketplace/returns`, `/marketplace/cost-categories`, `/marketplace`.
+
+## Изменённые файлы
+- Добавлен отчёт: `site/TASK7_FINAL_CHECK_REPORT.md`.


### PR DESCRIPTION
### Motivation
- Зафиксировать результаты финальной проверки и регрессионного чек-листа для страницы `/marketplace/costs` и сопутствующих страниц, а также задокументировать ограничения окружения, мешающие автоматическому прогону тестов.

### Description
- Добавлен файл `site/TASK7_FINAL_CHECK_REPORT.md`, в котором сохранены результаты синтакс-проверок трёх PHP-файлов, указаны ошибки при попытке запустить PHPUnit в текущем окружении и приведён подробный ручной браузерный чек-лист для валидации фильтров, пагинации и JSON-экспорта; изменения ограничены только добавлением отчёта и не затрагивают код, миграции или frontend-ассеты.

### Testing
- Выполнены автоматические синтакс-проверки: `php -l site/src/Marketplace/Controller/MarketplaceController.php`, `php -l site/src/Marketplace/Controller/CostsJsonExportController.php`, `php -l site/src/Marketplace/Repository/MarketplaceCostRepository.php` — все вернули `No syntax errors detected`.
- Попытки запустить интеграционные тесты `php bin/phpunit tests/Integration/Marketplace` и `vendor/bin/phpunit tests/Integration/Marketplace` не прошли в этой среде из‑за отсутствия dev-зависимостей (`vendor/symfony/phpunit-bridge/bin/simple-phpunit.php` и `vendor/bin/phpunit`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8c19c8470832393068c4033ee96bc)