### PR TITLE
Ozon: switch to 14-day rolling sync and per-day messages; restrict to seller connections

### DIFF
--- a/site/src/Marketplace/Command/OzonDailySyncCommand.php
+++ b/site/src/Marketplace/Command/OzonDailySyncCommand.php
@@ -25,10 +25,11 @@ use Symfony\Component\Messenger\MessageBusInterface;
  */
 #[AsCommand(
     name: 'app:marketplace:ozon-daily-sync',
-    description: 'Ежедневная загрузка сырых данных Ozon за последние 3 дня',
+    description: 'Ежедневная загрузка и обновление сырых данных Ozon за последние 14 дней',
 )]
 final class OzonDailySyncCommand extends Command
 {
+    private const LOOKBACK_DAYS = 14;
     public function __construct(
         private readonly ActiveOzonConnectionsQuery $connectionsQuery,
         private readonly MessageBusInterface $messageBus,
@@ -51,23 +52,31 @@ final class OzonDailySyncCommand extends Command
 
         $dispatched = 0;
 
+        $timezone = new \DateTimeZone('Europe/Moscow');
+        $today = new \DateTimeImmutable('today', $timezone);
+
         foreach ($connections as $row) {
             $companyId    = (string) $row['company_id'];
             $connectionId = (string) $row['id'];
 
-            $this->messageBus->dispatch(
-                new SyncOzonReportMessage($companyId, $connectionId),
-            );
+            for ($offset = 1; $offset <= self::LOOKBACK_DAYS; $offset++) {
+                $date = $today->modify(sprintf('-%d day', $offset))->format('Y-m-d');
 
-            $dispatched++;
+                $this->messageBus->dispatch(
+                    new SyncOzonReportMessage($companyId, $connectionId, $date),
+                );
 
-            $this->logger->info('Dispatched Ozon sync message', [
-                'company_id'    => $companyId,
-                'connection_id' => $connectionId,
-            ]);
+                $dispatched++;
+
+                $this->logger->info('Dispatched Ozon rolling sync message', [
+                    'company_id'    => $companyId,
+                    'connection_id' => $connectionId,
+                    'date'          => $date,
+                ]);
+            }
         }
 
-        $io->success(sprintf('Отправлено %d задач на загрузку данных Ozon.', $dispatched));
+        $io->success(sprintf('Отправлено %d задач на rolling-загрузку данных Ozon за последние %d дней.', $dispatched, self::LOOKBACK_DAYS));
 
         return Command::SUCCESS;
     }

--- a/site/src/Marketplace/Infrastructure/Query/ActiveOzonConnectionsQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/ActiveOzonConnectionsQuery.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Marketplace\Infrastructure\Query;
 
+use App\Marketplace\Enum\MarketplaceConnectionType;
 use Doctrine\DBAL\Connection;
 
 /**
@@ -26,9 +27,13 @@ final class ActiveOzonConnectionsQuery
             'SELECT mc.id, mc.company_id
              FROM marketplace_connections mc
              WHERE mc.marketplace = :marketplace
+               AND mc.connection_type = :connection_type
                AND mc.is_active = true
              ORDER BY mc.created_at ASC',
-            ['marketplace' => 'ozon'],
+            [
+                'marketplace' => 'ozon',
+                'connection_type' => MarketplaceConnectionType::SELLER->value,
+            ],
         );
     }
 }

--- a/site/src/Marketplace/MessageHandler/SyncOzonReportHandler.php
+++ b/site/src/Marketplace/MessageHandler/SyncOzonReportHandler.php
@@ -21,13 +21,12 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
- * Загружает сырые данные Ozon за последние 3 дня и сохраняет MarketplaceRawDocument.
+ * Загружает сырые данные Ozon за конкретную дату и сохраняет MarketplaceRawDocument.
  * После успешной загрузки диспатчит ProcessDayReportMessage для автозапуска pipeline.
  */
 #[AsMessageHandler]
 final class SyncOzonReportHandler
 {
-    private const SYNC_PERIOD_DAYS = 3;
     private const LOCK_TTL_SECONDS = 300;
 
     public function __construct(


### PR DESCRIPTION
### Motivation
- Expand daily Ozon synchronization from a narrow recent window to a rolling per-day reload for multiple past days to ensure data completeness and allow idempotent per-day processing.
- Restrict the set of synchronized connections to only seller-type marketplace connections to avoid processing non-seller integration rows.

### Description
- Update `app:marketplace:ozon-daily-sync` command to dispatch one `SyncOzonReportMessage` per company/connection for each of the last 14 days using a new `LOOKBACK_DAYS` constant and `Europe/Moscow` timezone to compute dates.
- Change the message dispatch to include a `date` argument and adjust console success and logger messages to reflect rolling per-day dispatching.
- Add filtering by `MarketplaceConnectionType::SELLER->value` in `ActiveOzonConnectionsQuery` so only seller connections are returned from the DBAL query.
- Adapt `SyncOzonReportHandler` to treat incoming `SyncOzonReportMessage` as a single-date sync (defaulting to yesterday if `date` is not provided), use the date in the locking key, and update handler documentation accordingly.

### Testing
- Ran the project's automated test suite via `vendor/bin/phpunit`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8d8ec96908323a3698dcdbb4c055d)