### PR TITLE
Добавить unit-тесты для Ozon rolling sync (D-1..D-14)

### DIFF
--- a/site/tests/Unit/Marketplace/Command/OzonDailySyncCommandTest.php
+++ b/site/tests/Unit/Marketplace/Command/OzonDailySyncCommandTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Command;
+
+use App\Marketplace\Command\OzonDailySyncCommand;
+use App\Marketplace\Infrastructure\Query\ActiveOzonConnectionsQuery;
+use App\Marketplace\Message\SyncOzonReportMessage;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class OzonDailySyncCommandTest extends TestCase
+{
+    private const COMPANY_1 = '11111111-1111-1111-1111-000000000001';
+    private const COMPANY_2 = '11111111-1111-1111-1111-000000000002';
+    private const CONNECTION_1 = '22222222-2222-2222-2222-000000000001';
+    private const CONNECTION_2 = '22222222-2222-2222-2222-000000000002';
+
+    public function testDispatchesFourteenMessagesForSingleConnectionWithExpectedDates(): void
+    {
+        $query = $this->createMock(ActiveOzonConnectionsQuery::class);
+        $query->method('execute')->willReturn([
+            ['id' => self::CONNECTION_1, 'company_id' => self::COMPANY_1],
+        ]);
+
+        $messages = [];
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus
+            ->expects(self::exactly(14))
+            ->method('dispatch')
+            ->willReturnCallback(function (object $message) use (&$messages): Envelope {
+                $messages[] = $message;
+
+                return new Envelope($message);
+            });
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::exactly(14))->method('info');
+
+        $tester = $this->makeTester($query, $bus, $logger);
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertCount(14, $messages);
+
+        foreach ($messages as $message) {
+            self::assertInstanceOf(SyncOzonReportMessage::class, $message);
+            self::assertSame(self::COMPANY_1, $message->companyId);
+            self::assertSame(self::CONNECTION_1, $message->connectionId);
+            self::assertNotNull($message->date);
+        }
+
+        self::assertDatesCoverRollingD1ToD14($messages);
+        self::assertStringContainsString('Отправлено 14 задач', $tester->getDisplay());
+    }
+
+    public function testDispatchesTwentyEightMessagesForTwoConnections(): void
+    {
+        $query = $this->createMock(ActiveOzonConnectionsQuery::class);
+        $query->method('execute')->willReturn([
+            ['id' => self::CONNECTION_1, 'company_id' => self::COMPANY_1],
+            ['id' => self::CONNECTION_2, 'company_id' => self::COMPANY_2],
+        ]);
+
+        $messagesByConnection = [];
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus
+            ->expects(self::exactly(28))
+            ->method('dispatch')
+            ->willReturnCallback(function (object $message) use (&$messagesByConnection): Envelope {
+                self::assertInstanceOf(SyncOzonReportMessage::class, $message);
+                $messagesByConnection[$message->connectionId][] = $message;
+
+                return new Envelope($message);
+            });
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::exactly(28))->method('info');
+
+        $tester = $this->makeTester($query, $bus, $logger);
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertCount(2, $messagesByConnection);
+        self::assertArrayHasKey(self::CONNECTION_1, $messagesByConnection);
+        self::assertArrayHasKey(self::CONNECTION_2, $messagesByConnection);
+
+        self::assertCount(14, $messagesByConnection[self::CONNECTION_1]);
+        self::assertCount(14, $messagesByConnection[self::CONNECTION_2]);
+
+        foreach ($messagesByConnection[self::CONNECTION_1] as $message) {
+            self::assertSame(self::COMPANY_1, $message->companyId);
+            self::assertSame(self::CONNECTION_1, $message->connectionId);
+        }
+
+        foreach ($messagesByConnection[self::CONNECTION_2] as $message) {
+            self::assertSame(self::COMPANY_2, $message->companyId);
+            self::assertSame(self::CONNECTION_2, $message->connectionId);
+        }
+
+        self::assertDatesCoverRollingD1ToD14($messagesByConnection[self::CONNECTION_1]);
+        self::assertDatesCoverRollingD1ToD14($messagesByConnection[self::CONNECTION_2]);
+        self::assertStringContainsString('Отправлено 28 задач', $tester->getDisplay());
+    }
+
+    public function testDoesNotDispatchWhenNoActiveConnections(): void
+    {
+        $query = $this->createMock(ActiveOzonConnectionsQuery::class);
+        $query->method('execute')->willReturn([]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::never())->method('dispatch');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::never())->method('info');
+
+        $tester = $this->makeTester($query, $bus, $logger);
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('Нет активных Ozon-подключений для синхронизации.', $tester->getDisplay());
+    }
+
+    /**
+     * @param list<SyncOzonReportMessage> $messages
+     */
+    private static function assertDatesCoverRollingD1ToD14(array $messages): void
+    {
+        $timezone = new \DateTimeZone('Europe/Moscow');
+        $today = new \DateTimeImmutable('today', $timezone);
+
+        $expectedDates = [];
+        for ($offset = 1; $offset <= 14; $offset++) {
+            $expectedDates[] = $today->modify(sprintf('-%d day', $offset))->format('Y-m-d');
+        }
+
+        $actualDates = array_map(static fn (SyncOzonReportMessage $message): ?string => $message->date, $messages);
+
+        self::assertContains($today->modify('-1 day')->format('Y-m-d'), $actualDates);
+        self::assertEqualsCanonicalizing($expectedDates, $actualDates);
+        self::assertNotContains($today->format('Y-m-d'), $actualDates, 'D-0 must not be dispatched');
+        self::assertNotContains($today->modify('-15 day')->format('Y-m-d'), $actualDates, 'D-15 must not be dispatched');
+    }
+
+    private function makeTester(
+        ActiveOzonConnectionsQuery $query,
+        MessageBusInterface $bus,
+        LoggerInterface $logger,
+    ): CommandTester {
+        $command = new OzonDailySyncCommand($query, $bus, $logger);
+
+        return new CommandTester($command);
+    }
+}

--- a/site/tests/Unit/Marketplace/Command/OzonDailySyncCommandTest.php
+++ b/site/tests/Unit/Marketplace/Command/OzonDailySyncCommandTest.php
@@ -23,6 +23,8 @@ final class OzonDailySyncCommandTest extends TestCase
 
     public function testDispatchesFourteenMessagesForSingleConnectionWithExpectedDates(): void
     {
+        $referenceToday = new \DateTimeImmutable('today', new \DateTimeZone('Europe/Moscow'));
+
         $query = $this->createMock(ActiveOzonConnectionsQuery::class);
         $query->method('execute')->willReturn([
             ['id' => self::CONNECTION_1, 'company_id' => self::COMPANY_1],
@@ -55,12 +57,14 @@ final class OzonDailySyncCommandTest extends TestCase
             self::assertNotNull($message->date);
         }
 
-        self::assertDatesCoverRollingD1ToD14($messages);
+        self::assertDatesCoverRollingD1ToD14($messages, $referenceToday);
         self::assertStringContainsString('Отправлено 14 задач', $tester->getDisplay());
     }
 
     public function testDispatchesTwentyEightMessagesForTwoConnections(): void
     {
+        $referenceToday = new \DateTimeImmutable('today', new \DateTimeZone('Europe/Moscow'));
+
         $query = $this->createMock(ActiveOzonConnectionsQuery::class);
         $query->method('execute')->willReturn([
             ['id' => self::CONNECTION_1, 'company_id' => self::COMPANY_1],
@@ -103,8 +107,8 @@ final class OzonDailySyncCommandTest extends TestCase
             self::assertSame(self::CONNECTION_2, $message->connectionId);
         }
 
-        self::assertDatesCoverRollingD1ToD14($messagesByConnection[self::CONNECTION_1]);
-        self::assertDatesCoverRollingD1ToD14($messagesByConnection[self::CONNECTION_2]);
+        self::assertDatesCoverRollingD1ToD14($messagesByConnection[self::CONNECTION_1], $referenceToday);
+        self::assertDatesCoverRollingD1ToD14($messagesByConnection[self::CONNECTION_2], $referenceToday);
         self::assertStringContainsString('Отправлено 28 задач', $tester->getDisplay());
     }
 
@@ -129,22 +133,19 @@ final class OzonDailySyncCommandTest extends TestCase
     /**
      * @param list<SyncOzonReportMessage> $messages
      */
-    private static function assertDatesCoverRollingD1ToD14(array $messages): void
+    private static function assertDatesCoverRollingD1ToD14(array $messages, \DateTimeImmutable $referenceToday): void
     {
-        $timezone = new \DateTimeZone('Europe/Moscow');
-        $today = new \DateTimeImmutable('today', $timezone);
-
         $expectedDates = [];
         for ($offset = 1; $offset <= 14; $offset++) {
-            $expectedDates[] = $today->modify(sprintf('-%d day', $offset))->format('Y-m-d');
+            $expectedDates[] = $referenceToday->modify(sprintf('-%d day', $offset))->format('Y-m-d');
         }
 
         $actualDates = array_map(static fn (SyncOzonReportMessage $message): ?string => $message->date, $messages);
 
-        self::assertContains($today->modify('-1 day')->format('Y-m-d'), $actualDates);
+        self::assertContains($referenceToday->modify('-1 day')->format('Y-m-d'), $actualDates);
         self::assertEqualsCanonicalizing($expectedDates, $actualDates);
-        self::assertNotContains($today->format('Y-m-d'), $actualDates, 'D-0 must not be dispatched');
-        self::assertNotContains($today->modify('-15 day')->format('Y-m-d'), $actualDates, 'D-15 must not be dispatched');
+        self::assertNotContains($referenceToday->format('Y-m-d'), $actualDates, 'D-0 must not be dispatched');
+        self::assertNotContains($referenceToday->modify('-15 day')->format('Y-m-d'), $actualDates, 'D-15 must not be dispatched');
     }
 
     private function makeTester(


### PR DESCRIPTION
### Motivation
- Покрыть поведением команду `OzonDailySyncCommand` тестами чтобы гарантировать ежедневный rolling reload за последние 14 дней (D-1…D-14) и корректное поведение при 0/1/2 активных подключениях.

### Description
- Добавлен тест `site/tests/Unit/Marketplace/Command/OzonDailySyncCommandTest.php` с тремя сценариями: одно подключение (14 сообщений), два подключения (28 сообщений) и отсутствие подключений (0 сообщений).
- Тесты assert'ят, что все отправленные объекты — `SyncOzonReportMessage`, что `companyId` и `connectionId` соответствуют подключению и что `date` задан (не null).
- Добавлена вспомогательная проверка `assertDatesCoverRollingD1ToD14()` которая валидирует полный набор дат D-1…D-14 в таймзоне `Europe/Moscow` и проверяет отсутствие D-0 и D-15.
- Производственный код не изменялся.

### Testing
- Попытка запустить добавленные unit-тесты через `bin/phpunit` в контейнере завершилась неудачей из-за отсутствия скрипта `vendor/symfony/phpunit-bridge/bin/simple-phpunit.php`, поэтому автоматическое выполнение тестов в этом окружении не прошло.
- Коммит тестов был создан успешно и PR-метаданные сформированы (см. добавленный файл `site/tests/Unit/Marketplace/Command/OzonDailySyncCommandTest.php`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9621816d08323bc53fbc8f6548b21)