### PR TITLE
Add Ozon transaction totals reconciliation persistence model

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1076,11 +1076,19 @@ enum ReconciliationSessionStatus: string
 ```
 
 ### `src/Marketplace/Enum/OzonTransactionTotalsCheckStatus.php`
+```php
+enum OzonTransactionTotalsCheckStatus: string
+{
+    case OK      = 'ok';
+    case WARNING = 'warning';
+    case FAILED  = 'failed';
+    case SKIPPED = 'skipped';
 
-- `OK` — сверка успешна
-- `WARNING` — сверка с предупреждениями
-- `FAILED` — сверка не пройдена (блокирующая)
-- `SKIPPED` — сверка пропущена
+    public function getLabel(): string;     // Успешно / Предупреждение / Ошибка / Пропущено
+    public function isSuccessful(): bool;   // true только для OK
+    public function isBlocking(): bool;     // true только для FAILED
+}
+```
 
 ### `src/Marketplace/Enum/PipelineStep.php`
 ```php

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -49,6 +49,7 @@
 | `MarketplaceAdvertisingCost` | Marketplace | `string $companyId` ✅ |
 | `MarketplaceOrder` | Marketplace | `string $companyId` ✅ |
 | `ReconciliationSession` | Marketplace | `string $companyId` ✅ |
+| `OzonTransactionTotalsCheck` | Marketplace | `string $companyId` ✅ |
 | `UnitEconomyCostMapping` | MarketplaceAnalytics | `string $companyId` ✅ |
 | `ListingDailySnapshot` | MarketplaceAnalytics | `string $companyId` ✅ |
 | `AdRawDocument` | MarketplaceAds | `string $companyId` ✅ |
@@ -1073,6 +1074,13 @@ enum ReconciliationSessionStatus: string
     public function isTerminal(): bool;    // true для COMPLETED, FAILED
 }
 ```
+
+### `src/Marketplace/Enum/OzonTransactionTotalsCheckStatus.php`
+
+- `OK` — сверка успешна
+- `WARNING` — сверка с предупреждениями
+- `FAILED` — сверка не пройдена (блокирующая)
+- `SKIPPED` — сверка пропущена
 
 ### `src/Marketplace/Enum/PipelineStep.php`
 ```php

--- a/site/migrations/Version20260505110000.php
+++ b/site/migrations/Version20260505110000.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260505110000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add marketplace_ozon_transaction_totals_checks table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE marketplace_ozon_transaction_totals_checks (
+                id UUID NOT NULL,
+                company_id UUID NOT NULL,
+                raw_document_id UUID NOT NULL,
+                period_from DATE NOT NULL,
+                period_to DATE NOT NULL,
+                status VARCHAR(16) NOT NULL,
+                check_type VARCHAR(64) NOT NULL DEFAULT 'transaction_totals',
+                detail_totals JSON NOT NULL,
+                ozon_totals JSON NOT NULL,
+                diffs JSON NOT NULL,
+                tolerance VARCHAR(32) NOT NULL,
+                checked_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                error_message TEXT DEFAULT NULL,
+                created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                PRIMARY KEY(id)
+            )
+            SQL);
+
+        $this->addSql('CREATE INDEX idx_ozon_totals_check_company_period ON marketplace_ozon_transaction_totals_checks (company_id, period_from, period_to)');
+        $this->addSql('CREATE INDEX idx_ozon_totals_check_raw_document ON marketplace_ozon_transaction_totals_checks (company_id, raw_document_id)');
+        $this->addSql('CREATE INDEX idx_ozon_totals_check_status ON marketplace_ozon_transaction_totals_checks (company_id, status)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS marketplace_ozon_transaction_totals_checks');
+    }
+}

--- a/site/src/Marketplace/Entity/OzonTransactionTotalsCheck.php
+++ b/site/src/Marketplace/Entity/OzonTransactionTotalsCheck.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Entity;
+
+use App\Marketplace\Enum\OzonTransactionTotalsCheckStatus;
+use App\Marketplace\Repository\OzonTransactionTotalsCheckRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity(repositoryClass: OzonTransactionTotalsCheckRepository::class)]
+#[ORM\Table(name: 'marketplace_ozon_transaction_totals_checks')]
+#[ORM\Index(columns: ['company_id', 'period_from', 'period_to'], name: 'idx_ozon_totals_check_company_period')]
+#[ORM\Index(columns: ['company_id', 'raw_document_id'], name: 'idx_ozon_totals_check_raw_document')]
+#[ORM\Index(columns: ['company_id', 'status'], name: 'idx_ozon_totals_check_status')]
+class OzonTransactionTotalsCheck
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid', unique: true)]
+    private string $id;
+
+    #[ORM\Column(type: 'guid')]
+    private string $companyId;
+
+    #[ORM\Column(type: 'guid')]
+    private string $rawDocumentId;
+
+    #[ORM\Column(type: 'date_immutable')]
+    private \DateTimeImmutable $periodFrom;
+
+    #[ORM\Column(type: 'date_immutable')]
+    private \DateTimeImmutable $periodTo;
+
+    #[ORM\Column(type: 'string', length: 16, enumType: OzonTransactionTotalsCheckStatus::class)]
+    private OzonTransactionTotalsCheckStatus $status;
+
+    #[ORM\Column(type: 'string', length: 64, options: ['default' => 'transaction_totals'])]
+    private string $checkType;
+
+    #[ORM\Column(type: 'json')]
+    private array $detailTotals = [];
+
+    #[ORM\Column(type: 'json')]
+    private array $ozonTotals = [];
+
+    #[ORM\Column(type: 'json')]
+    private array $diffs = [];
+
+    #[ORM\Column(type: 'string', length: 32)]
+    private string $tolerance;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $checkedAt;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $errorMessage = null;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $updatedAt;
+
+    public function __construct(
+        string $companyId,
+        string $rawDocumentId,
+        \DateTimeImmutable $periodFrom,
+        \DateTimeImmutable $periodTo,
+        string $tolerance = '0.01',
+    ) {
+        Assert::uuid($companyId);
+        Assert::uuid($rawDocumentId);
+
+        $now = new \DateTimeImmutable();
+
+        $this->id = Uuid::uuid7()->toString();
+        $this->companyId = $companyId;
+        $this->rawDocumentId = $rawDocumentId;
+        $this->periodFrom = $periodFrom;
+        $this->periodTo = $periodTo;
+        $this->status = OzonTransactionTotalsCheckStatus::SKIPPED;
+        $this->checkType = 'transaction_totals';
+        $this->tolerance = $tolerance;
+        $this->checkedAt = $now;
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+    }
+
+    public function markOk(array $detailTotals, array $ozonTotals, array $diffs): self
+    {
+        return $this->mark(
+            OzonTransactionTotalsCheckStatus::OK,
+            $detailTotals,
+            $ozonTotals,
+            $diffs,
+        );
+    }
+
+    public function markWarning(array $detailTotals, array $ozonTotals, array $diffs, ?string $message = null): self
+    {
+        return $this->mark(
+            OzonTransactionTotalsCheckStatus::WARNING,
+            $detailTotals,
+            $ozonTotals,
+            $diffs,
+            $message,
+        );
+    }
+
+    public function markFailed(array $detailTotals, array $ozonTotals, array $diffs, ?string $message = null): self
+    {
+        return $this->mark(
+            OzonTransactionTotalsCheckStatus::FAILED,
+            $detailTotals,
+            $ozonTotals,
+            $diffs,
+            $message,
+        );
+    }
+
+    public function markSkipped(?string $message = null): self
+    {
+        return $this->mark(
+            OzonTransactionTotalsCheckStatus::SKIPPED,
+            [],
+            [],
+            [],
+            $message,
+        );
+    }
+
+    public function getId(): string { return $this->id; }
+    public function getCompanyId(): string { return $this->companyId; }
+    public function getRawDocumentId(): string { return $this->rawDocumentId; }
+    public function getPeriodFrom(): \DateTimeImmutable { return $this->periodFrom; }
+    public function getPeriodTo(): \DateTimeImmutable { return $this->periodTo; }
+    public function getStatus(): OzonTransactionTotalsCheckStatus { return $this->status; }
+    public function getCheckType(): string { return $this->checkType; }
+    public function getDetailTotals(): array { return $this->detailTotals; }
+    public function getOzonTotals(): array { return $this->ozonTotals; }
+    public function getDiffs(): array { return $this->diffs; }
+    public function getTolerance(): string { return $this->tolerance; }
+    public function getCheckedAt(): \DateTimeImmutable { return $this->checkedAt; }
+    public function getErrorMessage(): ?string { return $this->errorMessage; }
+    public function getCreatedAt(): \DateTimeImmutable { return $this->createdAt; }
+    public function getUpdatedAt(): \DateTimeImmutable { return $this->updatedAt; }
+
+    private function mark(
+        OzonTransactionTotalsCheckStatus $status,
+        array $detailTotals,
+        array $ozonTotals,
+        array $diffs,
+        ?string $message = null,
+    ): self {
+        $now = new \DateTimeImmutable();
+
+        $this->status = $status;
+        $this->detailTotals = $detailTotals;
+        $this->ozonTotals = $ozonTotals;
+        $this->diffs = $diffs;
+        $this->errorMessage = $message;
+        $this->checkedAt = $now;
+        $this->updatedAt = $now;
+
+        return $this;
+    }
+}

--- a/site/src/Marketplace/Entity/OzonTransactionTotalsCheck.php
+++ b/site/src/Marketplace/Entity/OzonTransactionTotalsCheck.php
@@ -18,7 +18,7 @@ use Webmozart\Assert\Assert;
 class OzonTransactionTotalsCheck
 {
     #[ORM\Id]
-    #[ORM\Column(type: 'guid', unique: true)]
+    #[ORM\Column(type: 'guid')]
     private string $id;
 
     #[ORM\Column(type: 'guid')]

--- a/site/src/Marketplace/Enum/OzonTransactionTotalsCheckStatus.php
+++ b/site/src/Marketplace/Enum/OzonTransactionTotalsCheckStatus.php
@@ -14,10 +14,10 @@ enum OzonTransactionTotalsCheckStatus: string
     public function getLabel(): string
     {
         return match ($this) {
-            self::OK => 'OK',
-            self::WARNING => 'Warning',
-            self::FAILED => 'Failed',
-            self::SKIPPED => 'Skipped',
+            self::OK => 'Успешно',
+            self::WARNING => 'Предупреждение',
+            self::FAILED => 'Ошибка',
+            self::SKIPPED => 'Пропущено',
         };
     }
 

--- a/site/src/Marketplace/Enum/OzonTransactionTotalsCheckStatus.php
+++ b/site/src/Marketplace/Enum/OzonTransactionTotalsCheckStatus.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Enum;
+
+enum OzonTransactionTotalsCheckStatus: string
+{
+    case OK = 'ok';
+    case WARNING = 'warning';
+    case FAILED = 'failed';
+    case SKIPPED = 'skipped';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::OK => 'OK',
+            self::WARNING => 'Warning',
+            self::FAILED => 'Failed',
+            self::SKIPPED => 'Skipped',
+        };
+    }
+
+    public function isSuccessful(): bool
+    {
+        return $this === self::OK;
+    }
+
+    public function isBlocking(): bool
+    {
+        return $this === self::FAILED;
+    }
+}

--- a/site/src/Marketplace/Repository/OzonTransactionTotalsCheckRepository.php
+++ b/site/src/Marketplace/Repository/OzonTransactionTotalsCheckRepository.php
@@ -40,22 +40,37 @@ final class OzonTransactionTotalsCheckRepository extends ServiceEntityRepository
     }
 
     /**
+     * Возвращает только актуальные FAILED-проверки (latest by rawDocumentId).
+     *
+     * Исторический FAILED не возвращается, если по тому же rawDocumentId
+     * существует более свежая проверка в любом другом статусе.
+     *
      * @return list<OzonTransactionTotalsCheck>
      */
     public function findFailedByCompanyAndPeriod(string $companyId, \DateTimeImmutable $from, \DateTimeImmutable $to): array
     {
         Assert::uuid($companyId);
 
-        return $this->createQueryBuilder('c')
+        $qb = $this->createQueryBuilder('c');
+
+        $subQb = $this->createQueryBuilder('newer')
+            ->select('1')
+            ->where('newer.companyId = c.companyId')
+            ->andWhere('newer.rawDocumentId = c.rawDocumentId')
+            ->andWhere('(newer.checkedAt > c.checkedAt OR (newer.checkedAt = c.checkedAt AND newer.createdAt > c.createdAt))');
+
+        return $qb
             ->where('c.companyId = :companyId')
             ->andWhere('c.status = :status')
             ->andWhere('c.periodFrom <= :to')
             ->andWhere('c.periodTo >= :from')
+            ->andWhere($qb->expr()->not($qb->expr()->exists($subQb->getDQL())))
             ->setParameter('companyId', $companyId)
             ->setParameter('status', OzonTransactionTotalsCheckStatus::FAILED)
             ->setParameter('from', $from)
             ->setParameter('to', $to)
             ->orderBy('c.checkedAt', 'DESC')
+            ->addOrderBy('c.createdAt', 'DESC')
             ->getQuery()
             ->getResult();
     }

--- a/site/src/Marketplace/Repository/OzonTransactionTotalsCheckRepository.php
+++ b/site/src/Marketplace/Repository/OzonTransactionTotalsCheckRepository.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Repository;
+
+use App\Marketplace\Entity\OzonTransactionTotalsCheck;
+use App\Marketplace\Enum\OzonTransactionTotalsCheckStatus;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Webmozart\Assert\Assert;
+
+final class OzonTransactionTotalsCheckRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, OzonTransactionTotalsCheck::class);
+    }
+
+    public function save(OzonTransactionTotalsCheck $check): void
+    {
+        $this->getEntityManager()->persist($check);
+    }
+
+    public function findLatestByRawDocumentIdAndCompany(string $companyId, string $rawDocumentId): ?OzonTransactionTotalsCheck
+    {
+        Assert::uuid($companyId);
+        Assert::uuid($rawDocumentId);
+
+        return $this->createQueryBuilder('c')
+            ->where('c.companyId = :companyId')
+            ->andWhere('c.rawDocumentId = :rawDocumentId')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('rawDocumentId', $rawDocumentId)
+            ->orderBy('c.checkedAt', 'DESC')
+            ->addOrderBy('c.createdAt', 'DESC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    /**
+     * @return list<OzonTransactionTotalsCheck>
+     */
+    public function findFailedByCompanyAndPeriod(string $companyId, \DateTimeImmutable $from, \DateTimeImmutable $to): array
+    {
+        Assert::uuid($companyId);
+
+        return $this->createQueryBuilder('c')
+            ->where('c.companyId = :companyId')
+            ->andWhere('c.status = :status')
+            ->andWhere('c.periodFrom <= :to')
+            ->andWhere('c.periodTo >= :from')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('status', OzonTransactionTotalsCheckStatus::FAILED)
+            ->setParameter('from', $from)
+            ->setParameter('to', $to)
+            ->orderBy('c.checkedAt', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
+}


### PR DESCRIPTION
### Motivation
- Persist results of reconciling Ozon `transaction/list` detail with `transaction/totals` instead of keeping them only in logs. 
- Provide an auditable, queryable model per company/raw-document to support warnings, failures and retries without changing existing sync pipeline.

### Description
- Added enum `App\Marketplace\Enum\OzonTransactionTotalsCheckStatus` with values `ok`, `warning`, `failed`, `skipped` and helper methods `getLabel()`, `isSuccessful()` and `isBlocking()`.
- Added entity `App\Marketplace\Entity\OzonTransactionTotalsCheck` with UUID v7 PK, immutable `companyId` and `rawDocumentId` (validated via `Assert::uuid()`), period fields, `status`, `checkType`, JSON columns `detailTotals`, `ozonTotals`, `diffs`, `tolerance`, `checkedAt`, `errorMessage`, `createdAt` and `updatedAt`, plus business methods `markOk`, `markWarning`, `markFailed`, `markSkipped` that update `checkedAt` and `updatedAt`.
- Added repository `App\Marketplace\Repository\OzonTransactionTotalsCheckRepository` with IDOR-safe methods `save()` (persist without flush), `findLatestByRawDocumentIdAndCompany()` and `findFailedByCompanyAndPeriod()`.
- Added Doctrine migration `Version20260505110000` creating table `marketplace_ozon_transaction_totals_checks` with indexes `idx_ozon_totals_check_company_period`, `idx_ozon_totals_check_raw_document` and `idx_ozon_totals_check_status` and updated `ARCHITECTURE.md` to register the new Entity/Enum.

### Testing
- Ran `php -l` syntax checks for `site/src/Marketplace/Enum/OzonTransactionTotalsCheckStatus.php` which succeeded.
- Ran `php -l` syntax checks for `site/src/Marketplace/Entity/OzonTransactionTotalsCheck.php` which succeeded.
- Ran `php -l` syntax checks for `site/src/Marketplace/Repository/OzonTransactionTotalsCheckRepository.php` and `site/migrations/Version20260505110000.php` which both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f967c1b25c83239087ee77a650d22b)