### PR TITLE
Add Ozon transaction totals client

### DIFF
--- a/site/src/Marketplace/Infrastructure/Api/Ozon/OzonTransactionTotalsClient.php
+++ b/site/src/Marketplace/Infrastructure/Api/Ozon/OzonTransactionTotalsClient.php
@@ -8,6 +8,7 @@ use App\Marketplace\Enum\MarketplaceConnectionType;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Infrastructure\Query\MarketplaceCredentialsQuery;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Webmozart\Assert\Assert;
 
 final readonly class OzonTransactionTotalsClient
 {
@@ -36,6 +37,12 @@ final readonly class OzonTransactionTotalsClient
         \DateTimeImmutable $from,
         \DateTimeImmutable $to,
     ): array {
+        Assert::uuid($companyId);
+
+        if ($from > $to) {
+            throw new \InvalidArgumentException('Дата начала периода не может быть позже даты окончания.');
+        }
+
         $credentials = $this->credentialsQuery->getCredentials(
             $companyId,
             MarketplaceType::OZON,
@@ -78,23 +85,34 @@ final readonly class OzonTransactionTotalsClient
         }
 
         return [
-            'accruals_for_sale' => $this->decimalString($result['accruals_for_sale'] ?? null),
-            'sale_commission' => $this->decimalString($result['sale_commission'] ?? null),
-            'processing_and_delivery' => $this->decimalString($result['processing_and_delivery'] ?? null),
-            'services_amount' => $this->decimalString($result['services_amount'] ?? null),
-            'refunds_and_cancellations' => $this->decimalString($result['refunds_and_cancellations'] ?? null),
-            'compensation_amount' => $this->decimalString($result['compensation_amount'] ?? null),
-            'money_transfer' => $this->decimalString($result['money_transfer'] ?? null),
-            'others_amount' => $this->decimalString($result['others_amount'] ?? null),
+            'accruals_for_sale' => $this->decimalField($result, 'accruals_for_sale'),
+            'sale_commission' => $this->decimalField($result, 'sale_commission'),
+            'processing_and_delivery' => $this->decimalField($result, 'processing_and_delivery'),
+            'services_amount' => $this->decimalField($result, 'services_amount'),
+            'refunds_and_cancellations' => $this->decimalField($result, 'refunds_and_cancellations'),
+            'compensation_amount' => $this->decimalField($result, 'compensation_amount'),
+            'money_transfer' => $this->decimalField($result, 'money_transfer'),
+            'others_amount' => $this->decimalField($result, 'others_amount'),
         ];
     }
 
-    private function decimalString(mixed $value): string
+    private function decimalField(array $result, string $field): string
     {
+        if (!array_key_exists($field, $result)) {
+            return '0.00';
+        }
+
+        $value = $result[$field];
+
         if (null === $value || '' === $value) {
             return '0.00';
         }
 
+        return $this->decimalString($value, $field);
+    }
+
+    private function decimalString(mixed $value, string $field): string
+    {
         if (is_int($value)) {
             return sprintf('%d.00', $value);
         }
@@ -106,7 +124,10 @@ final readonly class OzonTransactionTotalsClient
         if (is_string($value)) {
             $normalized = str_replace(',', '.', trim($value));
             if (!preg_match('/^-?\d+(?:\.\d+)?$/', $normalized)) {
-                return '0.00';
+                throw new \RuntimeException(sprintf(
+                    'Некорректное числовое значение Ozon transaction totals в поле %s.',
+                    $field,
+                ));
             }
 
             $negative = str_starts_with($normalized, '-');
@@ -136,6 +157,9 @@ final readonly class OzonTransactionTotalsClient
             return $negative && '0.00' !== $result ? '-' . $result : $result;
         }
 
-        return '0.00';
+        throw new \RuntimeException(sprintf(
+            'Некорректное числовое значение Ozon transaction totals в поле %s.',
+            $field,
+        ));
     }
 }

--- a/site/src/Marketplace/Infrastructure/Api/Ozon/OzonTransactionTotalsClient.php
+++ b/site/src/Marketplace/Infrastructure/Api/Ozon/OzonTransactionTotalsClient.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Api\Ozon;
+
+use App\Marketplace\Enum\MarketplaceConnectionType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Infrastructure\Query\MarketplaceCredentialsQuery;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final readonly class OzonTransactionTotalsClient
+{
+    private const URL = 'https://api-seller.ozon.ru/v3/finance/transaction/totals';
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private MarketplaceCredentialsQuery $credentialsQuery,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     accruals_for_sale: string,
+     *     sale_commission: string,
+     *     processing_and_delivery: string,
+     *     services_amount: string,
+     *     refunds_and_cancellations: string,
+     *     compensation_amount: string,
+     *     money_transfer: string,
+     *     others_amount: string,
+     * }
+     */
+    public function fetchTotals(
+        string $companyId,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+    ): array {
+        $credentials = $this->credentialsQuery->getCredentials(
+            $companyId,
+            MarketplaceType::OZON,
+            MarketplaceConnectionType::SELLER,
+        );
+
+        if (null === $credentials) {
+            throw new \RuntimeException('Ozon Seller credentials не найдены для компании.');
+        }
+
+        $apiKey = $credentials['api_key'];
+        $clientId = $credentials['client_id'] ?? null;
+
+        if ('' === $apiKey || null === $clientId || '' === $clientId) {
+            throw new \RuntimeException('Ozon Seller credentials неполные: отсутствует api_key или client_id.');
+        }
+
+        $response = $this->httpClient->request('POST', self::URL, [
+            'headers' => [
+                'Client-Id' => $clientId,
+                'Api-Key' => $apiKey,
+                'Content-Type' => 'application/json',
+            ],
+            'json' => [
+                'date' => [
+                    'from' => $from->format('Y-m-d\T00:00:00.000\Z'),
+                    'to' => $to->format('Y-m-d\T23:59:59.000\Z'),
+                ],
+                'transaction_type' => 'all',
+                'posting_number' => '',
+            ],
+        ]);
+
+        $payload = $response->toArray(false);
+        $result = $payload['result'] ?? null;
+
+        if (!is_array($result)) {
+            $preview = mb_substr(json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: 'invalid_response', 0, 300);
+            throw new \RuntimeException(sprintf('Некорректный ответ Ozon transaction totals: result отсутствует или не является массивом. preview=%s', $preview));
+        }
+
+        return [
+            'accruals_for_sale' => $this->decimalString($result['accruals_for_sale'] ?? null),
+            'sale_commission' => $this->decimalString($result['sale_commission'] ?? null),
+            'processing_and_delivery' => $this->decimalString($result['processing_and_delivery'] ?? null),
+            'services_amount' => $this->decimalString($result['services_amount'] ?? null),
+            'refunds_and_cancellations' => $this->decimalString($result['refunds_and_cancellations'] ?? null),
+            'compensation_amount' => $this->decimalString($result['compensation_amount'] ?? null),
+            'money_transfer' => $this->decimalString($result['money_transfer'] ?? null),
+            'others_amount' => $this->decimalString($result['others_amount'] ?? null),
+        ];
+    }
+
+    private function decimalString(mixed $value): string
+    {
+        if (null === $value || '' === $value) {
+            return '0.00';
+        }
+
+        if (is_int($value)) {
+            return sprintf('%d.00', $value);
+        }
+
+        if (is_float($value)) {
+            $value = sprintf('%.6F', $value);
+        }
+
+        if (is_string($value)) {
+            $normalized = str_replace(',', '.', trim($value));
+            if (!preg_match('/^-?\d+(?:\.\d+)?$/', $normalized)) {
+                return '0.00';
+            }
+
+            $negative = str_starts_with($normalized, '-');
+            if ($negative) {
+                $normalized = substr($normalized, 1);
+            }
+
+            [$intPart, $fractionPart] = array_pad(explode('.', $normalized, 2), 2, '');
+            $fractionPart = preg_replace('/\D/', '', $fractionPart) ?? '';
+            $fractionPart = str_pad($fractionPart, 3, '0');
+
+            $hundredths = (int) substr($fractionPart, 0, 2);
+            $thousandth = (int) $fractionPart[2];
+
+            if ($thousandth >= 5) {
+                ++$hundredths;
+            }
+
+            $intValue = (int) $intPart;
+            if ($hundredths >= 100) {
+                ++$intValue;
+                $hundredths = 0;
+            }
+
+            $result = sprintf('%d.%02d', $intValue, $hundredths);
+
+            return $negative && '0.00' !== $result ? '-' . $result : $result;
+        }
+
+        return '0.00';
+    }
+}


### PR DESCRIPTION
### Motivation

- Добавить отдельный клиент для вызова Seller API Ozon `POST /v3/finance/transaction/totals` и получить контрольные итоги за период в виде нормализованных decimal-строк.
- Избежать изменений в существующем `OzonAdapter` и не добавлять persist/diff/retry-логику в этом задании.

### Description

- Добавлен `final readonly class OzonTransactionTotalsClient` в `site/src/Marketplace/Infrastructure/Api/Ozon/OzonTransactionTotalsClient.php` с зависимостями `HttpClientInterface` и `MarketplaceCredentialsQuery`.
- Реализован публичный метод `fetchTotals(string $companyId, \DateTimeImmutable $from, \DateTimeImmutable $to): array`, который получает credentials через `MarketplaceCredentialsQuery::getCredentials(..., MarketplaceType::OZON, MarketplaceConnectionType::SELLER)` и бросает `RuntimeException` если учётные данные отсутствуют или неполные.
- Выполняется `POST` в `https://api-seller.ozon.ru/v3/finance/transaction/totals` с заголовками `Client-Id`, `Api-Key`, `Content-Type: application/json` и телом с датами в формате `Y-m-d\T00:00:00.000\Z`/`Y-m-d\T23:59:59.000\Z`.
- Валидируется наличие `response['result']` как массива и при некорректном ответе выбрасывается `RuntimeException` с безопасным превью полезной нагрузки (обрезано до 300 символов), и возвращается массив из 8 ключей с decimal-строками (2 знака) через вспомогательный `decimalString(mixed $value): string` без использования float-арифметики для финансовых расчётов.

### Testing

- Выполнена синтаксическая проверка файла командой `php -l site/src/Marketplace/Infrastructure/Api/Ozon/OzonTransactionTotalsClient.php` и проверка прошла успешно.
- Нет добавленных unit/integration тестов в этом PR; поведение клиента покрывается будущими модульными тестами при необходимости.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f96bde66288323beb726b7f80147cf)