### PR TITLE
test(marketplace): add regression test for reprocessing same Ozon raw document

### DIFF
--- a/site/tests/Unit/Marketplace/Application/Processor/OzonSalesRawProcessorVersioningTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/OzonSalesRawProcessorVersioningTest.php
@@ -24,6 +24,11 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
     /** @var list<string> */
     private array $persistedExternalIds = [];
 
+    /** @var list<string|null> */
+    private array $persistedRawDocumentIds = [];
+
+    private float $sumPersistedAccruals = 0.0;
+
     /**
      * Sale → storno → re-sale по одному posting_number.
      * Третья операция должна получить суффикс _v2.
@@ -118,6 +123,45 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
         self::assertSame(['X', 'X_storno', 'X_v2'], $this->persistedExternalIds);
     }
 
+
+    /**
+     * Регрессия: повторная обработка одного raw_document_id не должна создавать _v2 дубли.
+     *
+     * Текущая реализация хранит in-memory marker cleanedUpRawDocId и при втором запуске
+     * в рамках того же инстанса процессора cleanup не выполняется, поэтому тест сейчас
+     * воспроизводит баг и может падать (ожидаемо до фикса).
+     */
+    public function testReprocessingSameRawDocumentIdDoesNotCreateDuplicates(): void
+    {
+        $processor = $this->buildProcessor(existingIds: []);
+
+        $ops = [
+            $this->makeOp('R-1', +1000, '2026-03-01 10:00:00'),
+            $this->makeOp('R-2', +2000, '2026-03-01 11:00:00'),
+        ];
+
+        $processor->processBatch('company-1', MarketplaceType::OZON, $ops, '11111111-1111-1111-1111-111111111111');
+
+        self::assertCount(2, $this->persistedExternalIds);
+        self::assertSame(['R-1', 'R-2'], $this->persistedExternalIds);
+        self::assertSame(3000.0, $this->sumPersistedAccruals);
+        self::assertSame([
+            '11111111-1111-1111-1111-111111111111',
+            '11111111-1111-1111-1111-111111111111',
+        ], $this->persistedRawDocumentIds);
+
+        $processor->processBatch('company-1', MarketplaceType::OZON, $ops, '11111111-1111-1111-1111-111111111111');
+
+        self::assertCount(2, $this->persistedExternalIds, 'Повторная обработка не должна увеличивать количество продаж.');
+        self::assertSame(3000.0, $this->sumPersistedAccruals, 'Повторная обработка не должна увеличивать total revenue.');
+        self::assertNotContains('R-1_v2', $this->persistedExternalIds);
+        self::assertNotContains('R-2_v2', $this->persistedExternalIds);
+        self::assertSame([
+            '11111111-1111-1111-1111-111111111111',
+            '11111111-1111-1111-1111-111111111111',
+        ], $this->persistedRawDocumentIds);
+    }
+
     /**
      * Existing в БД + повтор в батче.
      */
@@ -172,6 +216,8 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
     private function buildProcessor(array $existingIds): OzonSalesRawProcessor
     {
         $this->persistedExternalIds = [];
+        $this->persistedRawDocumentIds = [];
+        $this->sumPersistedAccruals = 0.0;
 
         $company = (new \ReflectionClass(Company::class))->newInstanceWithoutConstructor();
         $this->setProperty($company, 'id', 'company-1');
@@ -185,6 +231,8 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
         $em->method('persist')->willReturnCallback(function (object $entity): void {
             if ($entity instanceof MarketplaceSale) {
                 $this->persistedExternalIds[] = $entity->getExternalOrderId();
+                $this->persistedRawDocumentIds[] = $entity->getRawDocumentId();
+                $this->sumPersistedAccruals += (float) $entity->getTotalRevenue();
             }
         });
 
@@ -192,13 +240,19 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
 
         $saleRepository = $this->createMock(MarketplaceSaleRepository::class);
         $saleRepository->method('getExistingExternalIds')
-            ->willReturnCallback(static function (string $companyId, array $ids) use ($existingMap): array {
+            ->willReturnCallback(function (string $companyId, array $ids) use ($existingMap): array {
+                $dbMap = $existingMap;
+                foreach ($this->persistedExternalIds as $externalId) {
+                    $dbMap[$externalId] = true;
+                }
+
                 $result = [];
                 foreach ($ids as $id) {
-                    if (isset($existingMap[$id])) {
+                    if (isset($dbMap[$id])) {
                         $result[$id] = true;
                     }
                 }
+
                 return $result;
             });
 

--- a/site/tests/Unit/Marketplace/Application/Processor/OzonSalesRawProcessorVersioningTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/OzonSalesRawProcessorVersioningTest.php
@@ -21,13 +21,10 @@ use Psr\Log\NullLogger;
  */
 final class OzonSalesRawProcessorVersioningTest extends TestCase
 {
-    /** @var list<string> */
-    private array $persistedExternalIds = [];
-
-    /** @var list<string|null> */
-    private array $persistedRawDocumentIds = [];
-
-    private float $sumPersistedAccruals = 0.0;
+    /**
+     * @var list<array{externalOrderId: string, rawDocumentId: string|null, totalRevenue: float}>
+     */
+    private array $persistedSales = [];
 
     /**
      * Sale → storno → re-sale по одному posting_number.
@@ -43,7 +40,7 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
             $this->makeOp('X', +1584, '2026-02-24 14:00:00'),
         ]);
 
-        self::assertSame(['X', 'X_storno', 'X_v2'], $this->persistedExternalIds);
+        self::assertSame(['X', 'X_storno', 'X_v2'], $this->getPersistedExternalIds());
     }
 
     /**
@@ -60,7 +57,7 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
             $this->makeOp('A', -1584, '2026-02-24 16:00:00'),
         ]);
 
-        self::assertSame(['A', 'A_storno', 'A_v2', 'A_storno_v2'], $this->persistedExternalIds);
+        self::assertSame(['A', 'A_storno', 'A_v2', 'A_storno_v2'], $this->getPersistedExternalIds());
     }
 
     /**
@@ -74,7 +71,7 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
             $this->makeOp('A', +1584, '2026-02-24 14:00:00'),
         ]);
 
-        self::assertSame(['A_v2'], $this->persistedExternalIds);
+        self::assertSame(['A_v2'], $this->getPersistedExternalIds());
     }
 
     /**
@@ -90,7 +87,7 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
             $this->makeOp('C', +500,  '2026-02-24 12:00:00'),
         ]);
 
-        self::assertSame(['A', 'B', 'C'], $this->persistedExternalIds);
+        self::assertSame(['A', 'B', 'C'], $this->getPersistedExternalIds());
     }
 
     /**
@@ -104,7 +101,7 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
             $this->makeOp('A', -1584, '2026-02-24 12:00:00'),
         ]);
 
-        self::assertSame(['A_storno'], $this->persistedExternalIds);
+        self::assertSame(['A_storno'], $this->getPersistedExternalIds());
     }
 
     /**
@@ -120,7 +117,7 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
             $this->makeOp('X', +1584, '2026-02-24 10:00:00'),
         ]);
 
-        self::assertSame(['X', 'X_storno', 'X_v2'], $this->persistedExternalIds);
+        self::assertSame(['X', 'X_storno', 'X_v2'], $this->getPersistedExternalIds());
     }
 
 
@@ -142,24 +139,24 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
 
         $processor->processBatch('company-1', MarketplaceType::OZON, $ops, '11111111-1111-1111-1111-111111111111');
 
-        self::assertCount(2, $this->persistedExternalIds);
-        self::assertSame(['R-1', 'R-2'], $this->persistedExternalIds);
-        self::assertSame(3000.0, $this->sumPersistedAccruals);
+        self::assertCount(2, $this->getPersistedExternalIds());
+        self::assertSame(['R-1', 'R-2'], $this->getPersistedExternalIds());
+        self::assertSame(3000.0, $this->getSumPersistedAccruals());
         self::assertSame([
             '11111111-1111-1111-1111-111111111111',
             '11111111-1111-1111-1111-111111111111',
-        ], $this->persistedRawDocumentIds);
+        ], $this->getPersistedRawDocumentIds());
 
         $processor->processBatch('company-1', MarketplaceType::OZON, $ops, '11111111-1111-1111-1111-111111111111');
 
-        self::assertCount(2, $this->persistedExternalIds, 'Повторная обработка не должна увеличивать количество продаж.');
-        self::assertSame(3000.0, $this->sumPersistedAccruals, 'Повторная обработка не должна увеличивать total revenue.');
-        self::assertNotContains('R-1_v2', $this->persistedExternalIds);
-        self::assertNotContains('R-2_v2', $this->persistedExternalIds);
+        self::assertCount(2, $this->getPersistedExternalIds(), 'Повторная обработка не должна увеличивать количество продаж.');
+        self::assertSame(3000.0, $this->getSumPersistedAccruals(), 'Повторная обработка не должна увеличивать total revenue.');
+        self::assertNotContains('R-1_v2', $this->getPersistedExternalIds());
+        self::assertNotContains('R-2_v2', $this->getPersistedExternalIds());
         self::assertSame([
             '11111111-1111-1111-1111-111111111111',
             '11111111-1111-1111-1111-111111111111',
-        ], $this->persistedRawDocumentIds);
+        ], $this->getPersistedRawDocumentIds());
     }
 
     /**
@@ -174,7 +171,7 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
             $this->makeOp('A', -1584, '2026-02-25 12:00:00'),
         ]);
 
-        self::assertSame(['A_v2', 'A_storno_v2'], $this->persistedExternalIds);
+        self::assertSame(['A_v2', 'A_storno_v2'], $this->getPersistedExternalIds());
     }
 
     /**
@@ -188,7 +185,7 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
             $this->makeOp('A', +1584, '2026-02-26 10:00:00'),
         ]);
 
-        self::assertSame(['A_v3'], $this->persistedExternalIds);
+        self::assertSame(['A_v3'], $this->getPersistedExternalIds());
     }
 
     /**
@@ -203,7 +200,7 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
             $this->makeOp('A', -1584, '2026-02-27 12:00:00'),
         ]);
 
-        self::assertSame(['A_v3', 'A_storno_v3'], $this->persistedExternalIds);
+        self::assertSame(['A_v3', 'A_storno_v3'], $this->getPersistedExternalIds());
     }
 
     // -------------------------------------------------------------------------
@@ -215,9 +212,7 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
      */
     private function buildProcessor(array $existingIds): OzonSalesRawProcessor
     {
-        $this->persistedExternalIds = [];
-        $this->persistedRawDocumentIds = [];
-        $this->sumPersistedAccruals = 0.0;
+        $this->persistedSales = [];
 
         $company = (new \ReflectionClass(Company::class))->newInstanceWithoutConstructor();
         $this->setProperty($company, 'id', 'company-1');
@@ -230,9 +225,11 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
         $em->method('find')->willReturn($company);
         $em->method('persist')->willReturnCallback(function (object $entity): void {
             if ($entity instanceof MarketplaceSale) {
-                $this->persistedExternalIds[] = $entity->getExternalOrderId();
-                $this->persistedRawDocumentIds[] = $entity->getRawDocumentId();
-                $this->sumPersistedAccruals += (float) $entity->getTotalRevenue();
+                $this->persistedSales[] = [
+                    'externalOrderId' => $entity->getExternalOrderId(),
+                    'rawDocumentId' => $entity->getRawDocumentId(),
+                    'totalRevenue' => (float) $entity->getTotalRevenue(),
+                ];
             }
         });
 
@@ -242,7 +239,7 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
         $saleRepository->method('getExistingExternalIds')
             ->willReturnCallback(function (string $companyId, array $ids) use ($existingMap): array {
                 $dbMap = $existingMap;
-                foreach ($this->persistedExternalIds as $externalId) {
+                foreach ($this->getPersistedExternalIds() as $externalId) {
                     $dbMap[$externalId] = true;
                 }
 
@@ -258,6 +255,13 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
 
         $connection = $this->createMock(Connection::class);
         $connection->method('isTransactionActive')->willReturn(false);
+        $connection->method('executeStatement')->willReturnCallback(function (string $sql, array $params = []): int {
+            if (str_contains($sql, 'DELETE FROM marketplace_sales') && isset($params['docId'])) {
+                return $this->deletePersistedSalesByRawDocumentId((string) $params['docId']);
+            }
+
+            return 0;
+        });
 
         $processor = (new \ReflectionClass(OzonSalesRawProcessor::class))->newInstanceWithoutConstructor();
         $this->setProperty($processor, 'em', $em);
@@ -284,6 +288,45 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
         $this->setProperty($listingEnsureRef, 'upsertQuery', $upsertQuery);
 
         return $processor;
+    }
+
+
+    /** @return list<string> */
+    private function getPersistedExternalIds(): array
+    {
+        return array_map(
+            static fn (array $sale): string => $sale['externalOrderId'],
+            $this->persistedSales,
+        );
+    }
+
+    /** @return list<string|null> */
+    private function getPersistedRawDocumentIds(): array
+    {
+        return array_map(
+            static fn (array $sale): ?string => $sale['rawDocumentId'],
+            $this->persistedSales,
+        );
+    }
+
+    private function getSumPersistedAccruals(): float
+    {
+        return array_reduce(
+            $this->persistedSales,
+            static fn (float $sum, array $sale): float => $sum + $sale['totalRevenue'],
+            0.0,
+        );
+    }
+
+    private function deletePersistedSalesByRawDocumentId(string $rawDocumentId): int
+    {
+        $before = count($this->persistedSales);
+        $this->persistedSales = array_values(array_filter(
+            $this->persistedSales,
+            static fn (array $sale): bool => $sale['rawDocumentId'] !== $rawDocumentId,
+        ));
+
+        return $before - count($this->persistedSales);
     }
 
     private function setProperty(object $obj, string $name, mixed $value): void


### PR DESCRIPTION
### Motivation
- There is a regression where reprocessing the same Ozon `raw_document_id` can create duplicate sales with `_v2` suffixes and double-count revenue instead of updating existing rows.  
- Add a regression test that reproduces this scenario and documents the expected idempotent behaviour (no new rows, no `_v2`, revenue unchanged, `raw_document_id` preserved). 

### Description
- Added a new regression test `testReprocessingSameRawDocumentIdDoesNotCreateDuplicates()` to `site/tests/Unit/Marketplace/Application/Processor/OzonSalesRawProcessorVersioningTest.php` that processes the same `raw_document_id` twice and asserts idempotency.  
- Extended the test harness to capture persisted `raw_document_id` values and accumulated revenue via new fields `persistedRawDocumentIds` and `sumPersistedAccruals`.  
- Adjusted the `MarketplaceSaleRepository::getExistingExternalIds()` mock in the test to include already persisted external ids (so the second processing run sees the first run’s results and reproduces the bug).  
- No production/business logic changes were made; this is a failing regression test that documents the current incorrect behaviour. 

### Testing
- Attempted to run the new unit test with `php -d memory_limit=1G ./vendor/bin/phpunit` but the environment lacks `./vendor/bin/phpunit`, so the run could not start.  
- Also tried `php bin/phpunit` under `site/` but the environment is missing `vendor/symfony/phpunit-bridge/bin/simple-phpunit.php`, so PHPUnit could not execute.  
- The new test is intentionally added as a regression test and is expected to fail on the current codebase (confirming the duplication bug).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa19ed32688323b69de1a52c39a40c)