### PR TITLE
Move Ozon sales DELETE into repository and add tests

### DIFF
--- a/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
@@ -277,12 +277,12 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
 
         $periodFrom = $rawDoc->getPeriodFrom()->format('Y-m-d');
         $periodTo   = $rawDoc->getPeriodTo()->format('Y-m-d');
+        $company = $rawDoc->getCompany();
 
-        $deletedByDoc = (int) $this->connection->executeStatement(
-            'DELETE FROM marketplace_sales
-             WHERE raw_document_id = :docId
-               AND document_id IS NULL',
-            ['docId' => $rawDocId],
+        $deletedByDoc = $this->saleRepository->deleteByRawDocument(
+            company: $company,
+            marketplace: MarketplaceType::OZON,
+            rawDocumentId: $rawDocId,
         );
 
         $deletedLegacy = (int) $this->connection->executeStatement(

--- a/site/src/Marketplace/Repository/MarketplaceSaleRepository.php
+++ b/site/src/Marketplace/Repository/MarketplaceSaleRepository.php
@@ -166,4 +166,22 @@ class MarketplaceSaleRepository extends ServiceEntityRepository
 
         return $qb->getQuery()->getResult();
     }
+
+    public function deleteByRawDocument(
+        Company $company,
+        MarketplaceType $marketplace,
+        string $rawDocumentId,
+    ): int {
+        return (int) $this->createQueryBuilder('s')
+            ->delete()
+            ->where('s.company = :company')
+            ->andWhere('s.marketplace = :marketplace')
+            ->andWhere('s.rawDocumentId = :rawDocumentId')
+            ->andWhere('s.document IS NULL')
+            ->setParameter('company', $company)
+            ->setParameter('marketplace', $marketplace)
+            ->setParameter('rawDocumentId', $rawDocumentId)
+            ->getQuery()
+            ->execute();
+    }
 }

--- a/site/tests/Integration/Marketplace/MarketplaceSaleRepositoryTest.php
+++ b/site/tests/Integration/Marketplace/MarketplaceSaleRepositoryTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Marketplace;
+
+use App\Finance\Entity\Document;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Repository\MarketplaceSaleRepository;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceListingBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceSaleBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class MarketplaceSaleRepositoryTest extends IntegrationTestCase
+{
+    public function testDeleteByRawDocumentDeletesOnlyTargetRows(): void
+    {
+        $company1 = CompanyBuilder::aCompany()->withIndex(1)->build();
+        $company2 = CompanyBuilder::aCompany()->withIndex(2)->build();
+        $this->em->persist($company1);
+        $this->em->persist($company2);
+
+        $listing1Ozon = MarketplaceListingBuilder::aListing()
+            ->forCompany($company1)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withMarketplaceSku('ozon-1')
+            ->build();
+        $listing1Wb = MarketplaceListingBuilder::aListing()
+            ->forCompany($company1)
+            ->withMarketplace(MarketplaceType::WILDBERRIES)
+            ->withMarketplaceSku('wb-1')
+            ->build();
+        $listing2Ozon = MarketplaceListingBuilder::aListing()
+            ->forCompany($company2)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withMarketplaceSku('ozon-2')
+            ->build();
+
+        $this->em->persist($listing1Ozon);
+        $this->em->persist($listing1Wb);
+        $this->em->persist($listing2Ozon);
+
+        $targetRawDocId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+        $otherRawDocId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+        $target1 = MarketplaceSaleBuilder::aSale()
+            ->forCompany($company1)
+            ->forListing($listing1Ozon)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withExternalOrderId('target-1')
+            ->build();
+        $target1->setRawDocumentId($targetRawDocId);
+
+        $target2 = MarketplaceSaleBuilder::aSale()
+            ->forCompany($company1)
+            ->forListing($listing1Ozon)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withExternalOrderId('target-2')
+            ->build();
+        $target2->setRawDocumentId($targetRawDocId);
+
+        $otherDoc = MarketplaceSaleBuilder::aSale()
+            ->forCompany($company1)
+            ->forListing($listing1Ozon)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withExternalOrderId('other-doc')
+            ->build();
+        $otherDoc->setRawDocumentId($otherRawDocId);
+
+        $otherMarketplace = MarketplaceSaleBuilder::aSale()
+            ->forCompany($company1)
+            ->forListing($listing1Wb)
+            ->withMarketplace(MarketplaceType::WILDBERRIES)
+            ->withExternalOrderId('other-marketplace')
+            ->build();
+        $otherMarketplace->setRawDocumentId($targetRawDocId);
+
+        $otherCompany = MarketplaceSaleBuilder::aSale()
+            ->forCompany($company2)
+            ->forListing($listing2Ozon)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withExternalOrderId('other-company')
+            ->build();
+        $otherCompany->setRawDocumentId($targetRawDocId);
+
+        $finalDocument = new Document(Uuid::uuid4()->toString(), $company1);
+        $this->em->persist($finalDocument);
+
+        $lockedByDocument = MarketplaceSaleBuilder::aSale()
+            ->forCompany($company1)
+            ->forListing($listing1Ozon)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withExternalOrderId('locked-by-document')
+            ->build();
+        $lockedByDocument->setRawDocumentId($targetRawDocId);
+        $lockedByDocument->setDocument($finalDocument);
+
+        foreach ([$target1, $target2, $otherDoc, $otherMarketplace, $otherCompany, $lockedByDocument] as $sale) {
+            $this->em->persist($sale);
+        }
+
+        $this->em->flush();
+
+        /** @var MarketplaceSaleRepository $repository */
+        $repository = self::getContainer()->get(MarketplaceSaleRepository::class);
+        $deleted = $repository->deleteByRawDocument($company1, MarketplaceType::OZON, $targetRawDocId);
+        $this->em->flush();
+        $this->em->clear();
+
+        self::assertSame(2, $deleted);
+
+        $remainingRows = (int) $this->connection->fetchOne('SELECT COUNT(*) FROM marketplace_sales');
+        self::assertSame(4, $remainingRows);
+
+        $remainingTargetUnlocked = (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM marketplace_sales WHERE company_id = :company AND marketplace = :marketplace AND raw_document_id = :rawDocId AND document_id IS NULL',
+            [
+                'company' => $company1->getId(),
+                'marketplace' => MarketplaceType::OZON->value,
+                'rawDocId' => $targetRawDocId,
+            ],
+        );
+        self::assertSame(0, $remainingTargetUnlocked);
+
+        $remainingOtherDoc = (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM marketplace_sales WHERE external_order_id = :id',
+            ['id' => 'other-doc'],
+        );
+        self::assertSame(1, $remainingOtherDoc);
+
+        $remainingOtherMarketplace = (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM marketplace_sales WHERE external_order_id = :id',
+            ['id' => 'other-marketplace'],
+        );
+        self::assertSame(1, $remainingOtherMarketplace);
+
+        $remainingOtherCompany = (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM marketplace_sales WHERE external_order_id = :id',
+            ['id' => 'other-company'],
+        );
+        self::assertSame(1, $remainingOtherCompany);
+
+        $remainingLocked = (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM marketplace_sales WHERE external_order_id = :id AND document_id IS NOT NULL',
+            ['id' => 'locked-by-document'],
+        );
+        self::assertSame(1, $remainingLocked);
+
+        $remainingTargetLocked = (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM marketplace_sales WHERE company_id = :company AND marketplace = :marketplace AND raw_document_id = :rawDocId AND document_id IS NOT NULL',
+            [
+                'company' => $company1->getId(),
+                'marketplace' => MarketplaceType::OZON->value,
+                'rawDocId' => $targetRawDocId,
+            ],
+        );
+        self::assertSame(1, $remainingTargetLocked);
+    }
+}

--- a/site/tests/Unit/Marketplace/Application/Processor/OzonSalesRawProcessorVersioningTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/OzonSalesRawProcessorVersioningTest.php
@@ -252,16 +252,14 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
 
                 return $result;
             });
+        $saleRepository->method('deleteByRawDocument')
+            ->willReturnCallback(function (Company $company, MarketplaceType $marketplace, string $rawDocumentId): int {
+                return $this->deletePersistedSalesByRawDocumentId($rawDocumentId);
+            });
 
         $connection = $this->createMock(Connection::class);
         $connection->method('isTransactionActive')->willReturn(false);
-        $connection->method('executeStatement')->willReturnCallback(function (string $sql, array $params = []): int {
-            if (str_contains($sql, 'DELETE FROM marketplace_sales') && isset($params['docId'])) {
-                return $this->deletePersistedSalesByRawDocumentId((string) $params['docId']);
-            }
-
-            return 0;
-        });
+        $connection->method('executeStatement')->willReturn(0);
 
         $processor = (new \ReflectionClass(OzonSalesRawProcessor::class))->newInstanceWithoutConstructor();
         $this->setProperty($processor, 'em', $em);


### PR DESCRIPTION
### Motivation

- Replace raw SQL DELETE usage in Ozon processor with a repository method to encapsulate deletion logic and use entity objects instead of primitive IDs.

### Description

- In `OzonSalesRawProcessor::cleanupLegacySales` retrieve the `Company` from the `MarketplaceRawDocument` and call a new repository method instead of executing raw SQL for deleting sales by `raw_document_id`.
- Add `deleteByRawDocument(Company $company, MarketplaceType $marketplace, string $rawDocumentId): int` to `MarketplaceSaleRepository` to perform the delete via DQL and return the number of deleted rows.
- Update `OzonSalesRawProcessor` unit test `OzonSalesRawProcessorVersioningTest` to mock `deleteByRawDocument` and stop relying on mocking `Connection::executeStatement` for that delete path.
- Add an integration test `MarketplaceSaleRepositoryTest` that verifies `deleteByRawDocument` deletes only unlocked rows for the specified company, marketplace and raw document while preserving other rows.

### Testing

- Ran the unit test `OzonSalesRawProcessorVersioningTest` which was updated to use the repository mock and it passed.
- Ran the new integration test `MarketplaceSaleRepositoryTest` which verifies repository behavior and it passed.
- Ran affected marketplace-related tests locally with `phpunit` filters for the modified tests and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa1d3a10a08323b5b3dfb38a425cbe)