### PR TITLE
Reset per-run processor state to prevent duplicate _v2 sales when reprocessing raw documents

### DIFF
--- a/site/src/Marketplace/Application/ProcessMarketplaceRawDocumentAction.php
+++ b/site/src/Marketplace/Application/ProcessMarketplaceRawDocumentAction.php
@@ -110,6 +110,15 @@ final readonly class ProcessMarketplaceRawDocumentAction
         $classifier = $this->classifierRegistry->get($marketplace);
         $totalProcessed = 0;
 
+
+        // Reset per-run processor state: one raw document can be split into multiple
+        // batches in this invocation, but reprocessing the same rawDocId in another
+        // invocation must run cleanup again (idempotent replace-by-raw-document).
+        $processor = $this->processorRegistry->get(StagingRecordType::from($targetBucketKey), $marketplace);
+        if (method_exists($processor, 'resetPerRunState')) {
+            $processor->resetPerRunState();
+        }
+
         foreach ($rows as $row) {
             if (!is_array($row)) {
                 continue;
@@ -121,7 +130,6 @@ final readonly class ProcessMarketplaceRawDocumentAction
 
             if (count($buckets[$bucketKey]) >= 500) {
                 if ($bucketKey === $targetBucketKey) {
-                    $processor = $this->processorRegistry->get($type, $marketplace);
                     $processor->processBatch(
                         $command->companyId,
                         $marketplace,
@@ -146,8 +154,6 @@ final readonly class ProcessMarketplaceRawDocumentAction
                 continue;
             }
 
-            $type = StagingRecordType::from($bucketKey);
-            $processor = $this->processorRegistry->get($type, $marketplace);
             $processor->processBatch(
                 $command->companyId,
                 $marketplace,

--- a/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
@@ -74,6 +74,12 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
         }
     }
 
+
+    public function resetPerRunState(): void
+    {
+        $this->cleanedUpRawDocId = null;
+    }
+
     /**
      * @param array<int, array<string, mixed>> $rawRows
      */

--- a/site/tests/Unit/Marketplace/Application/Processor/OzonSalesRawProcessorVersioningTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/OzonSalesRawProcessorVersioningTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Marketplace\Application\Processor;
 use App\Company\Entity\Company;
 use App\Marketplace\Application\Processor\OzonSalesRawProcessor;
 use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Entity\MarketplaceRawDocument;
 use App\Marketplace\Entity\MarketplaceSale;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Repository\MarketplaceSaleRepository;
@@ -124,9 +125,9 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
     /**
      * Регрессия: повторная обработка одного raw_document_id не должна создавать _v2 дубли.
      *
-     * Текущая реализация хранит in-memory marker cleanedUpRawDocId и при втором запуске
-     * в рамках того же инстанса процессора cleanup не выполняется, поэтому тест сейчас
-     * воспроизводит баг и может падать (ожидаемо до фикса).
+     * resetPerRunState() моделирует новый invocation ProcessMarketplaceRawDocumentAction.
+     * Внутри одного invocation cleanup должен выполниться только один раз, даже если
+     * документ разбит на несколько batch.
      */
     public function testReprocessingSameRawDocumentIdDoesNotCreateDuplicates(): void
     {
@@ -147,6 +148,7 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
             '11111111-1111-1111-1111-111111111111',
         ], $this->getPersistedRawDocumentIds());
 
+        $processor->resetPerRunState();
         $processor->processBatch('company-1', MarketplaceType::OZON, $ops, '11111111-1111-1111-1111-111111111111');
 
         self::assertCount(2, $this->getPersistedExternalIds(), 'Повторная обработка не должна увеличивать количество продаж.');
@@ -221,8 +223,24 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
         $this->setProperty($listing, 'id', 'listing-1');
         $this->setProperty($listing, 'company', $company);
 
+        $rawDoc = (new \ReflectionClass(MarketplaceRawDocument::class))->newInstanceWithoutConstructor();
+        $this->setProperty($rawDoc, 'id', '11111111-1111-1111-1111-111111111111');
+        $this->setProperty($rawDoc, 'company', $company);
+        $this->setProperty($rawDoc, 'periodFrom', new \DateTimeImmutable('2026-03-01'));
+        $this->setProperty($rawDoc, 'periodTo', new \DateTimeImmutable('2026-03-01'));
+
         $em = $this->createMock(EntityManagerInterface::class);
-        $em->method('find')->willReturn($company);
+        $em->method('find')->willReturnCallback(static function (string $className, mixed $id) use ($company, $rawDoc): object|null {
+            if ($className === Company::class) {
+                return $company;
+            }
+
+            if ($className === MarketplaceRawDocument::class && $id === '11111111-1111-1111-1111-111111111111') {
+                return $rawDoc;
+            }
+
+            return null;
+        });
         $em->method('persist')->willReturnCallback(function (object $entity): void {
             if ($entity instanceof MarketplaceSale) {
                 $this->persistedSales[] = [


### PR DESCRIPTION
### Motivation

- Ensure cleanup that runs once per raw-document invocation is re-applied when a new invocation processes the same raw document ID, avoiding accidental creation of duplicate version-suffixed external IDs.

### Description

- Invoke the per-run reset on the target bucket processor before processing rows by calling `resetPerRunState()` if available and move processor lookup out of the inner batching logic in `ProcessMarketplaceRawDocumentAction`.
- Add `resetPerRunState()` to `OzonSalesRawProcessor` to clear the in-memory `cleanedUpRawDocId` marker so cleanup will run for a new invocation.
- Update `OzonSalesRawProcessorVersioningTest` to construct a `MarketplaceRawDocument`, adjust the `EntityManager` `find` mock to return the document, and call `resetPerRunState()` between `processBatch()` calls to simulate a new invocation.

### Testing

- Updated unit test `OzonSalesRawProcessorVersioningTest` was executed and confirms that reprocessing the same `rawDocId` does not create `_v2` duplicates after calling `resetPerRunState()`; the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa21fe061083239f3dba42cb35c2cb)