### PR TITLE
Ozon sales: per-run versioning and block artificial _vN creation for existing base keys

### DIFF
--- a/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
@@ -26,6 +26,20 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
      * когда один rawDocument разбит на несколько батчей (>500 строк).
      */
     private ?string $cleanedUpRawDocId = null;
+    /**
+     * Per-run счётчики версий external_order_id.
+     * Позволяют продолжать _vN между batch одного raw-документа внутри одного invocation.
+     *
+     * @var array<string, int>
+     */
+    private array $perRunVersionCounters = [];
+    /**
+     * Base keys, already existing in DB after cleanup, for which _vN generation is forbidden
+     * within current run to avoid artificial duplicate bypass.
+     *
+     * @var array<string, true>
+     */
+    private array $perRunBlockedBaseKeys = [];
 
     public function __construct(
         private readonly ProcessOzonSalesAction $action,
@@ -78,6 +92,8 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
     public function resetPerRunState(): void
     {
         $this->cleanedUpRawDocId = null;
+        $this->perRunVersionCounters = [];
+        $this->perRunBlockedBaseKeys = [];
     }
 
     /**
@@ -161,41 +177,44 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
                 $baseKeysMap[$i] = $baseKey;
             }
 
-            $existingMap = $this->saleRepository->getExistingExternalIds($companyId, array_values(array_unique($baseKeysMap)));
+            $newBaseKeysForDbProbe = [];
+            foreach (array_unique($baseKeysMap) as $baseKey) {
+                if (isset($this->perRunVersionCounters[$baseKey]) || isset($this->perRunBlockedBaseKeys[$baseKey])) {
+                    continue;
+                }
 
-            $counters = [];
+                $newBaseKeysForDbProbe[] = $baseKey;
+            }
+
+            $existingBaseMap = $newBaseKeysForDbProbe === []
+                ? []
+                : $this->saleRepository->getExistingExternalIds($companyId, $newBaseKeysForDbProbe);
+            foreach ($existingBaseMap as $existingBaseKey => $_) {
+                $this->perRunBlockedBaseKeys[$existingBaseKey] = true;
+            }
+
+            // ВАЖНО: версии (_v2/_v3/...) генерируются только в рамках текущего run/invocation.
+            // Не отталкиваемся от уже существующих строк БД, чтобы повторный импорт
+            // не создавал искусственные новые external_order_id.
             $computedIds = [];
             foreach ($salesData as $i => $op) {
                 $baseKey = $baseKeysMap[$i];
-
-                if (!isset($counters[$baseKey])) {
-                    $counters[$baseKey] = isset($existingMap[$baseKey]) ? 1 : 0;
+                if (isset($this->perRunBlockedBaseKeys[$baseKey])) {
+                    $computedIds[$i] = $baseKey;
+                    continue;
                 }
 
-                $counters[$baseKey]++;
-                $computedIds[$i] = $counters[$baseKey] > 1
-                    ? $baseKey . '_v' . $counters[$baseKey]
+                $this->perRunVersionCounters[$baseKey] = ($this->perRunVersionCounters[$baseKey] ?? 0) + 1;
+
+                $computedIds[$i] = $this->perRunVersionCounters[$baseKey] > 1
+                    ? $baseKey . '_v' . $this->perRunVersionCounters[$baseKey]
                     : $baseKey;
             }
 
-            $versionedKeys = array_filter($computedIds, static fn (string $id): bool => (bool) preg_match('/_v\d+$/', $id));
-            if ($versionedKeys !== []) {
-                $versionedExisting = $this->saleRepository->getExistingExternalIds($companyId, array_values(array_unique($versionedKeys)));
-                if ($versionedExisting !== []) {
-                    $existingMap = array_merge($existingMap, $versionedExisting);
-                    foreach ($computedIds as $i => $id) {
-                        if (!isset($versionedExisting[$id])) {
-                            continue;
-                        }
-                        $baseKey = $baseKeysMap[$i];
-                        while (isset($existingMap[$id])) {
-                            $counters[$baseKey]++;
-                            $id = $baseKey . '_v' . $counters[$baseKey];
-                        }
-                        $computedIds[$i] = $id;
-                    }
-                }
-            }
+            // Для idempotency сверяем только уже вычисленные ключи (base + batch versions).
+            // TODO: если Ozon начнёт присылать устойчивые multi-line ключи, перейти на более
+            // строгий natural key (например posting_number + SKU + operation_id) и убрать _vN.
+            $existingMap = $this->saleRepository->getExistingExternalIds($companyId, array_values(array_unique($computedIds)));
 
             foreach ($salesData as $i => $op) {
                 $externalId = $computedIds[$i];

--- a/site/tests/Unit/Marketplace/Application/Processor/OzonSalesRawProcessorVersioningTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/OzonSalesRawProcessorVersioningTest.php
@@ -62,9 +62,9 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
     }
 
     /**
-     * Базовый ключ уже есть в БД → первая regular получает _v2.
+     * Базовый ключ уже есть в БД: не создаём искусственный _v2, строка пропускается.
      */
-    public function testExistingInDbStartsFromV2(): void
+    public function testExistingInDbIsSkippedWithoutArtificialVersioning(): void
     {
         $processor = $this->buildProcessor(existingIds: ['A']);
 
@@ -72,7 +72,7 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
             $this->makeOp('A', +1584, '2026-02-24 14:00:00'),
         ]);
 
-        self::assertSame(['A_v2'], $this->getPersistedExternalIds());
+        self::assertSame([], $this->getPersistedExternalIds());
     }
 
     /**
@@ -162,47 +162,63 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
     }
 
     /**
-     * Existing в БД + повтор в батче.
+     * Две разные строки в одном raw-документе с одинаковым base ключом не теряются.
      */
-    public function testExistingPlusRepeatInBatch(): void
+    public function testDuplicateRowsInsideSingleBatchArePreserved(): void
     {
-        $processor = $this->buildProcessor(existingIds: ['A', 'A_storno']);
+        $processor = $this->buildProcessor(existingIds: []);
 
         $processor->processBatch('company-1', MarketplaceType::OZON, [
-            $this->makeOp('A', +1584, '2026-02-25 10:00:00'),
-            $this->makeOp('A', -1584, '2026-02-25 12:00:00'),
-        ]);
+            $this->makeOp('DUP', +1000, '2026-03-02 10:00:00'),
+            $this->makeOp('DUP', +1100, '2026-03-02 10:05:00'),
+        ], '11111111-1111-1111-1111-111111111111');
 
-        self::assertSame(['A_v2', 'A_storno_v2'], $this->getPersistedExternalIds());
+        self::assertSame(['DUP', 'DUP_v2'], $this->getPersistedExternalIds());
+        self::assertSame(2100.0, $this->getSumPersistedAccruals());
     }
 
-    /**
-     * В БД уже есть A и A_v2 → следующая sale должна получить A_v3, не A_v2.
-     */
-    public function testExistingVersionedInDbBumpsToNextFree(): void
+    public function testDuplicateRowsAcrossTwoBatchesInOneRunArePreserved(): void
     {
-        $processor = $this->buildProcessor(existingIds: ['A', 'A_v2']);
+        $processor = $this->buildProcessor(existingIds: []);
 
         $processor->processBatch('company-1', MarketplaceType::OZON, [
-            $this->makeOp('A', +1584, '2026-02-26 10:00:00'),
-        ]);
+            $this->makeOp('DUP', +1000, '2026-03-02 10:00:00'),
+        ], '11111111-1111-1111-1111-111111111111');
 
-        self::assertSame(['A_v3'], $this->getPersistedExternalIds());
+        $processor->processBatch('company-1', MarketplaceType::OZON, [
+            $this->makeOp('DUP', +1100, '2026-03-02 10:05:00'),
+        ], '11111111-1111-1111-1111-111111111111');
+
+        self::assertSame(['DUP', 'DUP_v2'], $this->getPersistedExternalIds());
+        self::assertSame(2100.0, $this->getSumPersistedAccruals());
     }
 
-    /**
-     * В БД A, A_storno, A_v2, A_storno_v2 → следующая пара получает _v3.
-     */
-    public function testFullCycleExistingBumpsToV3(): void
+    public function testExistingBaseKeyDoesNotCreateArtificialVersionOnSecondRow(): void
     {
-        $processor = $this->buildProcessor(existingIds: ['A', 'A_storno', 'A_v2', 'A_storno_v2']);
+        $processor = $this->buildProcessor(existingIds: ['A']);
 
         $processor->processBatch('company-1', MarketplaceType::OZON, [
-            $this->makeOp('A', +1584, '2026-02-27 10:00:00'),
-            $this->makeOp('A', -1584, '2026-02-27 12:00:00'),
+            $this->makeOp('A', +1000, '2026-03-03 10:00:00'),
+            $this->makeOp('A', +1100, '2026-03-03 10:05:00'),
         ]);
 
-        self::assertSame(['A_v3', 'A_storno_v3'], $this->getPersistedExternalIds());
+        self::assertSame([], $this->getPersistedExternalIds());
+        self::assertSame(0.0, $this->getSumPersistedAccruals());
+        self::assertNotContains('A_v2', $this->getPersistedExternalIds());
+    }
+
+    public function testExistingStornoBaseKeyDoesNotCreateArtificialVersionOnSecondRow(): void
+    {
+        $processor = $this->buildProcessor(existingIds: ['A_storno']);
+
+        $processor->processBatch('company-1', MarketplaceType::OZON, [
+            $this->makeOp('A', -1000, '2026-03-03 10:00:00'),
+            $this->makeOp('A', -1100, '2026-03-03 10:05:00'),
+        ]);
+
+        self::assertSame([], $this->getPersistedExternalIds());
+        self::assertSame(0.0, $this->getSumPersistedAccruals());
+        self::assertNotContains('A_storno_v2', $this->getPersistedExternalIds());
     }
 
     // -------------------------------------------------------------------------
@@ -285,6 +301,8 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
         $this->setProperty($processor, 'saleRepository', $saleRepository);
         $this->setProperty($processor, 'logger', new NullLogger());
         $this->setProperty($processor, 'cleanedUpRawDocId', null);
+        $this->setProperty($processor, 'perRunVersionCounters', []);
+        $this->setProperty($processor, 'perRunBlockedBaseKeys', []);
 
         // OzonListingEnsureService — final class, create via reflection
         $listingEnsureRef = (new \ReflectionClass(\App\Marketplace\Application\Service\OzonListingEnsureService::class))->newInstanceWithoutConstructor();


### PR DESCRIPTION
### Motivation
- Prevent creating artificial `_vN` suffixes for base external IDs that already exist in the DB during import runs, while still allowing versioning for true duplicates inside a single run.

### Description
- Added per-run state to `OzonSalesRawProcessor`: `perRunVersionCounters` and `perRunBlockedBaseKeys`, and reset them in `resetPerRunState`.
- Changed `processBatch` flow to avoid probing DB for base keys that are already tracked in the current run, to mark base keys found in DB as blocked for artificial `_vN` generation, and to compute versioned IDs only based on per-run counters; existing DB checks are performed against the final `computedIds` set.
- Updated unit tests in `OzonSalesRawProcessorVersioningTest` to reflect the new semantics and added/renamed tests for duplicates inside a single batch and across multiple batches inside one run.

### Testing
- Updated and ran unit tests covering `OzonSalesRawProcessor` versioning behavior (`site/tests/Unit/Marketplace/Application/Processor/OzonSalesRawProcessorVersioningTest.php`), and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa25a512ac8323a7d87dde79bae9a0)