### PR TITLE
Respect Company::financeLockBefore when cleaning up legacy Ozon sales

### DIFF
--- a/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
@@ -289,6 +289,8 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
      * и legacy-записи без raw_document_id за тот же период.
      *
      * - `document_id IS NULL` — не трогаем уже закрытые в ОПиУ записи.
+     * - Перед DELETE применяется guard по Company::financeLockBefore:
+     *   reprocess запрещён, если период raw-документа пересекается с закрытым диапазоном.
      * - `price_per_unit > 0` в легаси-DELETE — отсекает storno-записи
      *   (negative accruals_for_sale, суффикс `_storno`, price_per_unit < 0),
      *   которых у старого потока `ProcessOzonSalesAction` не было.
@@ -303,6 +305,16 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
         $periodFrom = $rawDoc->getPeriodFrom()->format('Y-m-d');
         $periodTo   = $rawDoc->getPeriodTo()->format('Y-m-d');
         $company = $rawDoc->getCompany();
+        $lockBefore = $company->getFinanceLockBefore();
+
+        if ($lockBefore !== null && $rawDoc->getPeriodFrom() <= $lockBefore) {
+            throw new \DomainException(sprintf(
+                'Период raw-документа заблокирован для переобработки (financeLockBefore: %s, period: %s—%s).',
+                $lockBefore->format('d.m.Y'),
+                $periodFrom,
+                $periodTo,
+            ));
+        }
 
         $deletedByDoc = $this->saleRepository->deleteByRawDocument(
             company: $company,

--- a/site/tests/Unit/Marketplace/Application/Processor/OzonSalesRawProcessorVersioningTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/OzonSalesRawProcessorVersioningTest.php
@@ -221,6 +221,46 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
         self::assertNotContains('A_storno_v2', $this->getPersistedExternalIds());
     }
 
+    public function testReprocessThrowsWhenFinanceLockCoversRawDocumentPeriod(): void
+    {
+        $deleteByRawDocumentCalls = 0;
+        $processor = $this->buildProcessor(
+            existingIds: [],
+            financeLockBefore: new \DateTimeImmutable('2026-03-15'),
+            deleteByRawDocumentCalls: $deleteByRawDocumentCalls,
+        );
+
+        try {
+            $processor->processBatch('company-1', MarketplaceType::OZON, [
+                $this->makeOp('LOCK-1', +1000, '2026-03-01 10:00:00'),
+            ], '11111111-1111-1111-1111-111111111111');
+
+            self::fail('Expected DomainException for finance lock, but no exception was thrown.');
+        } catch (\DomainException $e) {
+            self::assertStringContainsString('заблокирован для переобработки', $e->getMessage());
+        }
+
+        self::assertSame(0, $deleteByRawDocumentCalls);
+        self::assertSame([], $this->getPersistedExternalIds());
+    }
+
+    public function testReprocessAllowedWhenFinanceLockIsEmptyOrOutsidePeriod(): void
+    {
+        $deleteByRawDocumentCalls = 0;
+        $processor = $this->buildProcessor(
+            existingIds: [],
+            financeLockBefore: new \DateTimeImmutable('2026-02-15'),
+            deleteByRawDocumentCalls: $deleteByRawDocumentCalls,
+        );
+
+        $processor->processBatch('company-1', MarketplaceType::OZON, [
+            $this->makeOp('UNLOCK-1', +1000, '2026-03-01 10:00:00'),
+        ], '11111111-1111-1111-1111-111111111111');
+
+        self::assertSame(1, $deleteByRawDocumentCalls);
+        self::assertSame(['UNLOCK-1'], $this->getPersistedExternalIds());
+    }
+
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
@@ -228,12 +268,17 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
     /**
      * @param list<string> $existingIds
      */
-    private function buildProcessor(array $existingIds): OzonSalesRawProcessor
+    private function buildProcessor(
+        array $existingIds,
+        ?\DateTimeImmutable $financeLockBefore = null,
+        int &$deleteByRawDocumentCalls = 0,
+    ): OzonSalesRawProcessor
     {
         $this->persistedSales = [];
 
         $company = (new \ReflectionClass(Company::class))->newInstanceWithoutConstructor();
         $this->setProperty($company, 'id', 'company-1');
+        $this->setProperty($company, 'financeLockBefore', $financeLockBefore?->setTime(0, 0));
 
         $listing = (new \ReflectionClass(MarketplaceListing::class))->newInstanceWithoutConstructor();
         $this->setProperty($listing, 'id', 'listing-1');
@@ -287,7 +332,8 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
                 return $result;
             });
         $saleRepository->method('deleteByRawDocument')
-            ->willReturnCallback(function (Company $company, MarketplaceType $marketplace, string $rawDocumentId): int {
+            ->willReturnCallback(function (Company $company, MarketplaceType $marketplace, string $rawDocumentId) use (&$deleteByRawDocumentCalls): int {
+                $deleteByRawDocumentCalls++;
                 return $this->deletePersistedSalesByRawDocumentId($rawDocumentId);
             });
 


### PR DESCRIPTION
### Motivation

- Prevent reprocessing/cleanup for raw documents that overlap a company finance lock range so closed periods are not accidentally removed.

### Description

- Add a guard in `cleanupLegacySales` that reads `Company::getFinanceLockBefore()` and throws a `\DomainException` when the raw document period starts on or before the lock (`rawDoc->getPeriodFrom() <= financeLockBefore`).
- Update the method docblock to document the new finance lock guard behavior.
- Extend `OzonSalesRawProcessorVersioningTest` by adding `testReprocessThrowsWhenFinanceLockCoversRawDocumentPeriod` and `testReprocessAllowedWhenFinanceLockIsEmptyOrOutsidePeriod`, and update `buildProcessor` to accept a `financeLockBefore` argument and a reference counter for `deleteByRawDocument` calls.
- Adjust the `deleteByRawDocument` mock to increment the provided call counter so tests can assert whether cleanup was attempted.

### Testing

- Ran the updated unit tests in `site/tests/Unit/Marketplace/Application/Processor/OzonSalesRawProcessorVersioningTest.php`, including the two new tests, and they passed.
- Existing tests covering Ozon processing/versioning were run and remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fab913a6ac83238eacd7a3635dff71)