### PR TITLE
Add integration regression test: prevent doubled revenue after reprocessing Ozon raw sales

### DIFF
--- a/site/tests/Integration/MarketplaceAnalytics/UnitExtendedQueryOzonRawReprocessRegressionTest.php
+++ b/site/tests/Integration/MarketplaceAnalytics/UnitExtendedQueryOzonRawReprocessRegressionTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\MarketplaceAnalytics;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Application\Processor\OzonSalesRawProcessor;
+use App\Marketplace\Entity\MarketplaceRawDocument;
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAnalytics\Infrastructure\Query\UnitExtendedQuery;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceListingBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceRawDocumentBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+
+final class UnitExtendedQueryOzonRawReprocessRegressionTest extends IntegrationTestCase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-000000000111';
+    private const OWNER_ID = '22222222-2222-2222-2222-000000000111';
+    private const PERIOD_FROM = '2026-02-01';
+    private const PERIOD_TO = '2026-02-28';
+    private const LISTING_SKU = 'OZON-REGRESSION-1';
+
+    private UnitExtendedQuery $unitExtendedQuery;
+    private OzonSalesRawProcessor $rawProcessor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->unitExtendedQuery = self::getContainer()->get(UnitExtendedQuery::class);
+        $this->rawProcessor = self::getContainer()->get(OzonSalesRawProcessor::class);
+
+        $this->seedCompanyAndListing();
+    }
+
+    public function test_reprocessing_same_raw_document_does_not_double_revenue_or_sales_rows(): void
+    {
+        $rawDocument = $this->createRawDocument();
+        $rawRows = $this->buildRawSalesRows();
+
+        $this->rawProcessor->resetPerRunState();
+        $this->rawProcessor->processBatch(self::COMPANY_ID, MarketplaceType::OZON, $rawRows, $rawDocument->getId());
+
+        $firstImportRevenue = $this->getTotalRevenueFromSalesTable();
+        $firstImportRows = $this->countRawSalesRows($rawDocument->getId());
+
+        self::assertSame(15488951.02, $firstImportRevenue, 'Санити-чек: первая обработка должна записать ожидаемую выручку.');
+        self::assertSame(1, $firstImportRows, 'Санити-чек: первая обработка должна записать одну строку продажи.');
+
+        $this->rawProcessor->resetPerRunState();
+        $this->rawProcessor->processBatch(self::COMPANY_ID, MarketplaceType::OZON, $rawRows, $rawDocument->getId());
+
+        $queryResult = $this->unitExtendedQuery->execute(
+            self::COMPANY_ID,
+            MarketplaceType::OZON->value,
+            self::PERIOD_FROM,
+            self::PERIOD_TO,
+            limit: 100,
+        );
+
+        self::assertSame(
+            15488951.02,
+            (float) $queryResult['totals']['revenue'],
+            'Регрессия: Unit Extended не должен показывать удвоенную выручку после повторной обработки того же raw-документа.',
+        );
+
+        self::assertSame(
+            1,
+            $this->countRawSalesRows($rawDocument->getId()),
+            'Регрессия: количество строк marketplace_sales по raw_document_id не должно удваиваться при повторной обработке.',
+        );
+    }
+
+    private function seedCompanyAndListing(): void
+    {
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('unit-extended-raw-regression@example.test')
+            ->build();
+
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $listing = MarketplaceListingBuilder::aListing()
+            ->forCompany($company)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withMarketplaceSku(self::LISTING_SKU)
+            ->build();
+
+        $this->em->persist($owner);
+        $this->em->persist($company);
+        $this->em->persist($listing);
+        $this->em->flush();
+    }
+
+    private function createRawDocument(): MarketplaceRawDocument
+    {
+        /** @var Company $company */
+        $company = $this->em->find(Company::class, self::COMPANY_ID);
+
+        $rawDocument = MarketplaceRawDocumentBuilder::aDocument()
+            ->forCompany($company)
+            ->withMarketplace(MarketplaceType::OZON)
+            ->withDocumentType('sales')
+            ->withPeriod(new \DateTimeImmutable(self::PERIOD_FROM), new \DateTimeImmutable(self::PERIOD_TO))
+            ->build();
+
+        $this->em->persist($rawDocument);
+        $this->em->flush();
+
+        return $rawDocument;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function buildRawSalesRows(): array
+    {
+        return [[
+            'operation_id' => 7000001,
+            'operation_date' => '2026-02-14T10:00:00+00:00',
+            'type' => 'orders',
+            'operation_type' => 'OperationAgentDeliveredToCustomer',
+            'accruals_for_sale' => 15488951.02,
+            'posting' => [
+                'posting_number' => 'OZON-POSTING-REG-1',
+            ],
+            'items' => [[
+                'sku' => self::LISTING_SKU,
+                'name' => 'Regression SKU',
+            ]],
+        ]];
+    }
+
+    private function countRawSalesRows(string $rawDocId): int
+    {
+        return (int) $this->em->getConnection()->fetchOne(
+            'SELECT COUNT(*) FROM marketplace_sales WHERE company_id = :companyId AND raw_document_id = :rawDocId',
+            ['companyId' => self::COMPANY_ID, 'rawDocId' => $rawDocId],
+        );
+    }
+
+    private function getTotalRevenueFromSalesTable(): float
+    {
+        return (float) $this->em->getConnection()->fetchOne(
+            'SELECT COALESCE(SUM(total_revenue), 0) FROM marketplace_sales WHERE company_id = :companyId',
+            ['companyId' => self::COMPANY_ID],
+        );
+    }
+}

--- a/site/tests/Integration/MarketplaceAnalytics/UnitExtendedQueryOzonRawReprocessRegressionTest.php
+++ b/site/tests/Integration/MarketplaceAnalytics/UnitExtendedQueryOzonRawReprocessRegressionTest.php
@@ -47,7 +47,7 @@ final class UnitExtendedQueryOzonRawReprocessRegressionTest extends IntegrationT
         $firstImportRevenue = $this->getTotalRevenueFromSalesTable();
         $firstImportRows = $this->countRawSalesRows($rawDocument->getId());
 
-        self::assertSame(15488951.02, $firstImportRevenue, 'Санити-чек: первая обработка должна записать ожидаемую выручку.');
+        self::assertEqualsWithDelta(15488951.02, $firstImportRevenue, 0.01, 'Санити-чек: первая обработка должна записать ожидаемую выручку.');
         self::assertSame(1, $firstImportRows, 'Санити-чек: первая обработка должна записать одну строку продажи.');
 
         $this->rawProcessor->resetPerRunState();
@@ -61,9 +61,10 @@ final class UnitExtendedQueryOzonRawReprocessRegressionTest extends IntegrationT
             limit: 100,
         );
 
-        self::assertSame(
+        self::assertEqualsWithDelta(
             15488951.02,
             (float) $queryResult['totals']['revenue'],
+            0.01,
             'Регрессия: Unit Extended не должен показывать удвоенную выручку после повторной обработки того же raw-документа.',
         );
 
@@ -71,6 +72,12 @@ final class UnitExtendedQueryOzonRawReprocessRegressionTest extends IntegrationT
             1,
             $this->countRawSalesRows($rawDocument->getId()),
             'Регрессия: количество строк marketplace_sales по raw_document_id не должно удваиваться при повторной обработке.',
+        );
+
+        self::assertSame(
+            ['OZON-POSTING-REG-1'],
+            $this->getExternalOrderIds($rawDocument->getId()),
+            'Регрессия: после повторной обработки должен остаться только базовый external_order_id без _v2.',
         );
     }
 
@@ -151,5 +158,19 @@ final class UnitExtendedQueryOzonRawReprocessRegressionTest extends IntegrationT
             'SELECT COALESCE(SUM(total_revenue), 0) FROM marketplace_sales WHERE company_id = :companyId',
             ['companyId' => self::COMPANY_ID],
         );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getExternalOrderIds(string $rawDocId): array
+    {
+        /** @var list<string> $ids */
+        $ids = $this->em->getConnection()->fetchFirstColumn(
+            'SELECT external_order_id FROM marketplace_sales WHERE company_id = :companyId AND raw_document_id = :rawDocId ORDER BY external_order_id ASC',
+            ['companyId' => self::COMPANY_ID, 'rawDocId' => $rawDocId],
+        );
+
+        return $ids;
     }
 }


### PR DESCRIPTION
### Motivation
- A real bug manifested in `UnitExtendedQuery` where reprocessing the same Ozon sales raw-document produced doubled revenue (observed 30,977,902.04 vs expected 15,488,951.02), so a regression test is needed to lock the behaviour. 
- The goal is to verify idempotency of source sales ingestion (via `OzonSalesRawProcessor`) and ensure the `UnitExtendedQuery` report shows revenue for a single import without adding anti-duplicate logic to the query itself.

### Description
- Added an integration test `UnitExtendedQueryOzonRawReprocessRegressionTest` at `site/tests/Integration/MarketplaceAnalytics/UnitExtendedQueryOzonRawReprocessRegressionTest.php` that seeds company/listing and creates a `MarketplaceRawDocument` for the period. 
- The test builds a single Ozon sales payload, calls `OzonSalesRawProcessor::processBatch` twice for the same raw document (with `resetPerRunState()` between runs), then executes `UnitExtendedQuery` for the period. 
- Assertions verify that `totals.revenue` equals the single-import value `15,488,951.02` and that the number of rows in `marketplace_sales` for the `raw_document_id` did not increase. 
- No changes were made to `UnitExtendedQuery` logic and no anti-duplicate filter (e.g. `external_order_id_vN`) was added; the test asserts correct idempotent behaviour of the ingestion path.

### Testing
- The new test file was committed (`site/tests/Integration/MarketplaceAnalytics/UnitExtendedQueryOzonRawReprocessRegressionTest.php`) and a PR message was prepared. 
- Attempted to run the new integration test with `php bin/phpunit ...`, but execution failed due to missing local dependencies: `vendor/symfony/phpunit-bridge/bin/simple-phpunit.php` was not found. 
- Because of the missing test runner dependencies the test execution result is Unknown and must be run in CI or a developer environment with project dependencies installed, where it is expected to pass if ingestion idempotency remains correct.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69face87853083238b105e24f05f5e74)