### PR TITLE
Add Ozon raw duplicates audit CLI and DB query utilities

### DIFF
--- a/site/src/Marketplace/Command/OzonRawDuplicatesAuditCommand.php
+++ b/site/src/Marketplace/Command/OzonRawDuplicatesAuditCommand.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Command;
+
+use App\Marketplace\Infrastructure\Query\OzonRawDuplicateAuditQuery;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Webmozart\Assert\Assert;
+
+#[AsCommand(
+    name: 'app:marketplace:ozon-raw-duplicates-audit',
+    description: 'Read-only диагностика дублей Ozon raw-документов и обработанных данных',
+)]
+final class OzonRawDuplicatesAuditCommand extends Command
+{
+    public function __construct(
+        private readonly OzonRawDuplicateAuditQuery $auditQuery,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'UUID компании (optional)')
+            ->addOption('from', null, InputOption::VALUE_REQUIRED, 'Начало периода (YYYY-MM-DD)')
+            ->addOption('to', null, InputOption::VALUE_REQUIRED, 'Конец периода (YYYY-MM-DD)')
+            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Формат вывода: table|json', 'table');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $fromOption = $input->getOption('from');
+        $toOption = $input->getOption('to');
+        $companyIdOption = $input->getOption('company-id');
+        $format = (string) $input->getOption('format');
+
+        if (!is_string($fromOption) || $fromOption === '' || !is_string($toOption) || $toOption === '') {
+            $io->error('Опции --from и --to обязательны. Используйте формат YYYY-MM-DD.');
+
+            return Command::FAILURE;
+        }
+
+        $from = $this->parseStrictDate($fromOption);
+        $to = $this->parseStrictDate($toOption);
+
+        if ($from === null || $to === null) {
+            $io->error('Неверный формат дат. Используйте реальные даты в формате YYYY-MM-DD.');
+
+            return Command::FAILURE;
+        }
+
+        if ($from > $to) {
+            $io->error('Опция --from должна быть меньше или равна --to.');
+
+            return Command::FAILURE;
+        }
+
+        if (!in_array($format, ['table', 'json'], true)) {
+            $io->error('Опция --format должна быть table или json.');
+
+            return Command::FAILURE;
+        }
+
+        $companyId = null;
+        if (is_string($companyIdOption) && $companyIdOption !== '') {
+            try {
+                Assert::uuid($companyIdOption);
+            } catch (\InvalidArgumentException) {
+                $io->error('Некорректный формат --company-id, ожидается UUID.');
+
+                return Command::FAILURE;
+            }
+            $companyId = $companyIdOption;
+        }
+
+        $exactDuplicates = $this->auditQuery->findExactRawDocumentDuplicates($companyId, $from, $to);
+        $overlapping = $this->auditQuery->findOverlappingRawDocuments($companyId, $from, $to);
+        $salesDuplicates = $this->auditQuery->findProcessedSalesWithMultipleRawDocuments($companyId, $from, $to);
+        $returnsDuplicates = $this->auditQuery->findProcessedReturnsWithMultipleRawDocuments($companyId, $from, $to);
+        $costsDuplicates = $this->auditQuery->findProcessedCostsWithMultipleRawDocuments($companyId, $from, $to);
+
+        $payload = [
+            'filters' => [
+                'company_id' => $companyId,
+                'from' => $from->format('Y-m-d'),
+                'to' => $to->format('Y-m-d'),
+            ],
+            'exact_raw_duplicates' => $exactDuplicates,
+            'overlapping_raw_documents' => $overlapping,
+            'processed_sales_duplicates' => $salesDuplicates,
+            'processed_returns_duplicates' => $returnsDuplicates,
+            'processed_costs_duplicates' => $costsDuplicates,
+        ];
+
+        if ($format === 'json') {
+            $output->writeln((string) json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR));
+
+            return Command::SUCCESS;
+        }
+
+        $io->title('Ozon raw duplicates audit (read-only)');
+        $io->definitionList(
+            ['Company ID' => $companyId ?? 'ALL'],
+            ['From' => $from->format('Y-m-d')],
+            ['To' => $to->format('Y-m-d')],
+        );
+
+        $this->renderSectionTable($io, '1. Exact raw document duplicates', $exactDuplicates);
+        $this->renderSectionTable($io, '2. Overlapping raw documents', $overlapping);
+        $this->renderSectionTable($io, '3. Processed sales duplicates', $salesDuplicates);
+        $this->renderSectionTable($io, '4. Processed returns duplicates', $returnsDuplicates);
+        $this->renderSectionTable($io, '5. Processed costs duplicates', $costsDuplicates);
+
+        $io->success('Диагностика завершена. Команда выполняет только SELECT-запросы и не изменяет данные.');
+
+        return Command::SUCCESS;
+    }
+
+    private function renderSectionTable(SymfonyStyle $io, string $title, array $rows): void
+    {
+        $io->section($title);
+
+        if ($rows === []) {
+            $io->text('No rows found.');
+
+            return;
+        }
+
+        $headers = array_keys($rows[0]);
+        $tableRows = array_map(
+            static function (array $row): array {
+                return array_map(static fn (mixed $value): string => is_array($value) ? json_encode($value, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR) : (string) $value, $row);
+            },
+            $rows,
+        );
+
+        $io->table($headers, $tableRows);
+    }
+
+    private function parseStrictDate(string $value): ?\DateTimeImmutable
+    {
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
+
+        if ($date === false || $date->format('Y-m-d') !== $value) {
+            return null;
+        }
+
+        return $date;
+    }
+}

--- a/site/src/Marketplace/Infrastructure/Query/OzonRawDuplicateAuditQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/OzonRawDuplicateAuditQuery.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Query;
+
+use Doctrine\DBAL\Connection;
+use Webmozart\Assert\Assert;
+
+final class OzonRawDuplicateAuditQuery
+{
+    public function __construct(
+        private readonly Connection $connection,
+    ) {
+    }
+
+    public function findExactRawDocumentDuplicates(?string $companyId, \DateTimeImmutable $from, \DateTimeImmutable $to): array
+    {
+        $params = $this->buildBaseParams($companyId, $from, $to);
+        $companyFilter = $companyId !== null ? ' AND rd.company_id = :companyId' : '';
+
+        return $this->connection->fetchAllAssociative(
+            <<<SQL
+            SELECT
+                rd.company_id,
+                rd.marketplace,
+                rd.document_type,
+                rd.period_from,
+                rd.period_to,
+                COUNT(*) AS docs_count,
+                ARRAY_AGG(rd.id ORDER BY rd.synced_at DESC, rd.id DESC) AS doc_ids,
+                ARRAY_AGG(COALESCE(rd.processing_status, 'null') ORDER BY rd.synced_at DESC, rd.id DESC) AS statuses,
+                ARRAY_AGG(rd.records_count ORDER BY rd.synced_at DESC, rd.id DESC) AS records_counts,
+                ARRAY_AGG(rd.synced_at ORDER BY rd.synced_at DESC, rd.id DESC) AS synced_ats
+            FROM marketplace_raw_documents rd
+            WHERE rd.marketplace = 'ozon'
+              AND rd.document_type = 'sales_report'
+              AND rd.period_from BETWEEN :fromDate AND :toDate
+              AND rd.period_to BETWEEN :fromDate AND :toDate
+              {$companyFilter}
+            GROUP BY rd.company_id, rd.marketplace, rd.document_type, rd.period_from, rd.period_to
+            HAVING COUNT(*) > 1
+            ORDER BY rd.company_id, rd.period_from, rd.period_to
+            SQL,
+            $params,
+        );
+    }
+
+    public function findOverlappingRawDocuments(?string $companyId, \DateTimeImmutable $from, \DateTimeImmutable $to): array
+    {
+        $params = $this->buildBaseParams($companyId, $from, $to);
+        $companyFilter = $companyId !== null ? ' AND daily.company_id = :companyId' : '';
+
+        return $this->connection->fetchAllAssociative(
+            <<<SQL
+            SELECT
+                daily.company_id,
+                daily.period_from AS day,
+                daily.id AS daily_doc_id,
+                daily.records_count AS daily_records_count,
+                range_doc.id AS range_doc_id,
+                range_doc.period_from AS range_from,
+                range_doc.period_to AS range_to,
+                range_doc.records_count AS range_records_count,
+                daily.processing_status AS daily_status,
+                range_doc.processing_status AS range_status
+            FROM marketplace_raw_documents daily
+            INNER JOIN marketplace_raw_documents range_doc
+                ON range_doc.company_id = daily.company_id
+               AND range_doc.marketplace = daily.marketplace
+               AND range_doc.document_type = daily.document_type
+               AND range_doc.id <> daily.id
+               AND range_doc.period_from <= daily.period_from
+               AND range_doc.period_to >= daily.period_to
+               AND range_doc.period_from <> range_doc.period_to
+            WHERE daily.marketplace = 'ozon'
+              AND daily.document_type = 'sales_report'
+              AND daily.period_from = daily.period_to
+              AND daily.period_from BETWEEN :fromDate AND :toDate
+              {$companyFilter}
+            ORDER BY daily.company_id, daily.period_from, daily.id, range_doc.id
+            SQL,
+            $params,
+        );
+    }
+
+    public function findProcessedSalesWithMultipleRawDocuments(?string $companyId, \DateTimeImmutable $from, \DateTimeImmutable $to): array
+    {
+        return $this->findProcessedRowsWithMultipleRawDocuments(
+            table: 'marketplace_sales',
+            dateField: 'sale_date',
+            amountField: 'total_revenue',
+            alias: 's',
+            companyId: $companyId,
+            from: $from,
+            to: $to,
+        );
+    }
+
+    public function findProcessedReturnsWithMultipleRawDocuments(?string $companyId, \DateTimeImmutable $from, \DateTimeImmutable $to): array
+    {
+        return $this->findProcessedRowsWithMultipleRawDocuments(
+            table: 'marketplace_returns',
+            dateField: 'return_date',
+            amountField: 'refund_amount',
+            alias: 'r',
+            companyId: $companyId,
+            from: $from,
+            to: $to,
+        );
+    }
+
+    public function findProcessedCostsWithMultipleRawDocuments(?string $companyId, \DateTimeImmutable $from, \DateTimeImmutable $to): array
+    {
+        return $this->findProcessedRowsWithMultipleRawDocuments(
+            table: 'marketplace_costs',
+            dateField: 'cost_date',
+            amountField: 'amount',
+            alias: 'c',
+            companyId: $companyId,
+            from: $from,
+            to: $to,
+        );
+    }
+
+    private function findProcessedRowsWithMultipleRawDocuments(
+        string $table,
+        string $dateField,
+        string $amountField,
+        string $alias,
+        ?string $companyId,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+    ): array {
+        $params = $this->buildBaseParams($companyId, $from, $to);
+        $companyFilter = $companyId !== null ? sprintf(' AND %s.company_id = :companyId', $alias) : '';
+
+        return $this->connection->fetchAllAssociative(
+            sprintf(
+                <<<SQL
+                SELECT
+                    %1$s.company_id,
+                    %1$s.%2$s,
+                    COUNT(DISTINCT %1$s.raw_document_id) AS raw_docs_count,
+                    COUNT(*) AS row_count,
+                    COALESCE(SUM(%1$s.%3$s), 0) AS amount_sum,
+                    ARRAY_AGG(DISTINCT %1$s.raw_document_id) AS raw_document_ids,
+                    BOOL_OR(%1$s.document_id IS NOT NULL) AS has_closed_rows
+                FROM %4$s %1$s
+                WHERE %1$s.marketplace = 'ozon'
+                  AND %1$s.%2$s BETWEEN :fromDate AND :toDate
+                  AND %1$s.raw_document_id IS NOT NULL
+                  %5$s
+                GROUP BY %1$s.company_id, %1$s.%2$s
+                HAVING COUNT(DISTINCT %1$s.raw_document_id) > 1
+                ORDER BY %1$s.company_id, %1$s.%2$s
+                SQL,
+                $alias,
+                $dateField,
+                $amountField,
+                $table,
+                $companyFilter,
+            ),
+            $params,
+        );
+    }
+
+    private function buildBaseParams(?string $companyId, \DateTimeImmutable $from, \DateTimeImmutable $to): array
+    {
+        if ($companyId !== null) {
+            Assert::uuid($companyId);
+        }
+
+        $params = [
+            'fromDate' => $from->format('Y-m-d'),
+            'toDate' => $to->format('Y-m-d'),
+        ];
+
+        if ($companyId !== null) {
+            $params['companyId'] = $companyId;
+        }
+
+        return $params;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a read-only diagnostic tool to detect duplicate and overlapping Ozon marketplace raw documents and identify processed rows linked to multiple raw documents for easier investigation.

### Description
- Add a new Symfony Console command `app:marketplace:ozon-raw-duplicates-audit` with options `--company-id`, `--from`, `--to`, and `--format` to output results as `table` or `json` and validate inputs.
- Implement `OzonRawDuplicateAuditQuery` which performs read-only DB inspections via `Doctrine\DBAL\Connection` and includes methods `findExactRawDocumentDuplicates`, `findOverlappingRawDocuments`, `findProcessedSalesWithMultipleRawDocuments`, `findProcessedReturnsWithMultipleRawDocuments`, and `findProcessedCostsWithMultipleRawDocuments`.
- Add helper logic in the command to format results, render tables (`renderSectionTable`), and strictly parse dates (`parseStrictDate`), and add query helpers `findProcessedRowsWithMultipleRawDocuments` and `buildBaseParams` with UUID validation via `Webmozart\Assert`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad8d81c9c8323abea1758001a9fc9)