### PR TITLE
Add Ozon raw duplicates audit integration tests and builder helpers

### DIFF
--- a/site/tests/Builders/Marketplace/MarketplaceRawDocumentBuilder.php
+++ b/site/tests/Builders/Marketplace/MarketplaceRawDocumentBuilder.php
@@ -40,6 +40,23 @@ final class MarketplaceRawDocumentBuilder
         return $clone;
     }
 
+
+    public function withId(string $id): self
+    {
+        $clone = clone $this;
+        $clone->id = $id;
+
+        return $clone;
+    }
+
+    public function withIndex(int $index): self
+    {
+        $clone = clone $this;
+        $clone->id = sprintf('22222222-2222-2222-2222-%012d', $index);
+
+        return $clone;
+    }
+
     public function withMarketplace(MarketplaceType $marketplace): self
     {
         $clone              = clone $this;

--- a/site/tests/Integration/Marketplace/Command/OzonRawDuplicatesAuditCommandTest.php
+++ b/site/tests/Integration/Marketplace/Command/OzonRawDuplicatesAuditCommandTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Marketplace\Command;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceRawDocumentBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class OzonRawDuplicatesAuditCommandTest extends IntegrationTestCase
+{
+    public function testTableAndJsonAndInvalidDate(): void
+    {
+        $company = CompanyBuilder::aCompany()->withIndex(1)->build();
+        $this->em->persist($company);
+        $this->em->persist(MarketplaceRawDocumentBuilder::aDocument()->withIndex(1)->forCompany($company)->withMarketplace(MarketplaceType::OZON)->withDocumentType('sales_report')->withPeriod(new \DateTimeImmutable('2026-04-01'), new \DateTimeImmutable('2026-04-30'))->build());
+        $this->em->persist(MarketplaceRawDocumentBuilder::aDocument()->withIndex(2)->forCompany($company)->withMarketplace(MarketplaceType::OZON)->withDocumentType('sales_report')->withPeriod(new \DateTimeImmutable('2026-04-01'), new \DateTimeImmutable('2026-04-30'))->build());
+        $this->em->flush();
+
+        $tester = $this->tester();
+        $ok = $tester->execute(['--from' => '2026-04-01', '--to' => '2026-04-30']);
+        self::assertSame(Command::SUCCESS, $ok);
+        $out = $tester->getDisplay();
+        self::assertStringContainsString('Exact raw document duplicates', $out);
+        self::assertStringContainsString('Overlapping raw documents', $out);
+        self::assertStringContainsString('2026-04-01', $out);
+
+        $tester = $this->tester();
+        $okJson = $tester->execute(['--from' => '2026-04-01', '--to' => '2026-04-30', '--format' => 'json']);
+        self::assertSame(Command::SUCCESS, $okJson);
+        $payload = json_decode($tester->getDisplay(), true, 512, JSON_THROW_ON_ERROR);
+        foreach (['exact_raw_duplicates','overlapping_raw_documents','processed_sales_duplicates','processed_returns_duplicates','processed_costs_duplicates'] as $key) {
+            self::assertArrayHasKey($key, $payload);
+        }
+        self::assertGreaterThanOrEqual(1, count($payload['exact_raw_duplicates']));
+        self::assertArrayHasKey('company_id', $payload['exact_raw_duplicates'][0]);
+        self::assertArrayHasKey('period_from', $payload['exact_raw_duplicates'][0]);
+        self::assertArrayHasKey('period_to', $payload['exact_raw_duplicates'][0]);
+        self::assertArrayHasKey('docs_count', $payload['exact_raw_duplicates'][0]);
+
+        $tester = $this->tester();
+        $fail = $tester->execute(['--from' => '2026-05-01', '--to' => '2026-04-01']);
+        self::assertSame(Command::FAILURE, $fail);
+        self::assertStringContainsString('меньше или равна', $tester->getDisplay());
+    }
+
+    private function tester(): CommandTester
+    {
+        $app = new Application(self::$kernel);
+        return new CommandTester($app->find('app:marketplace:ozon-raw-duplicates-audit'));
+    }
+}

--- a/site/tests/Integration/Marketplace/Infrastructure/Query/OzonRawDuplicateAuditQueryTest.php
+++ b/site/tests/Integration/Marketplace/Infrastructure/Query/OzonRawDuplicateAuditQueryTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Marketplace\Infrastructure\Query;
+
+use App\Company\Entity\Company;
+use App\Finance\Entity\Document;
+use App\Marketplace\Entity\MarketplaceCost;
+use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Entity\MarketplaceRawDocument;
+use App\Marketplace\Entity\MarketplaceReturn;
+use App\Marketplace\Entity\MarketplaceSale;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Infrastructure\Query\OzonRawDuplicateAuditQuery;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceRawDocumentBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class OzonRawDuplicateAuditQueryTest extends IntegrationTestCase
+{
+    public function testAuditQueries(): void
+    {
+        $a = CompanyBuilder::aCompany()->withIndex(1)->build();
+        $b = CompanyBuilder::aCompany()->withIndex(2)->build();
+        $this->em->persist($a); $this->em->persist($b);
+
+        $a1 = $this->raw($a, '2026-04-22', '2026-04-22', 1);
+        $a2 = $this->raw($a, '2026-04-20', '2026-04-25', 2);
+        $a3 = $this->raw($a, '2026-04-01', '2026-04-30', 3);
+        $a4 = $this->raw($a, '2026-04-01', '2026-04-30', 4);
+        $b1 = $this->raw($b, '2026-04-01', '2026-04-30', 5);
+        $b2 = $this->raw($b, '2026-04-01', '2026-04-30', 6);
+        foreach ([$a1,$a2,$a3,$a4,$b1,$b2] as $d) { $this->em->persist($d); }
+
+        $listingA = new MarketplaceListing(Uuid::uuid4()->toString(), $a, null, MarketplaceType::OZON);
+        $listingA->setMarketplaceSku('sku-a')->setPrice('100');
+        $listingB = new MarketplaceListing(Uuid::uuid4()->toString(), $b, null, MarketplaceType::OZON);
+        $listingB->setMarketplaceSku('sku-b')->setPrice('100');
+        $this->em->persist($listingA); $this->em->persist($listingB);
+        $doc = new Document(Uuid::uuid4()->toString(), $a); $this->em->persist($doc);
+
+        $s1 = (new MarketplaceSale(Uuid::uuid4()->toString(), $a, $listingA, MarketplaceType::OZON))->setExternalOrderId('a1')->setSaleDate(new \DateTimeImmutable('2026-04-22'))->setQuantity(1)->setPricePerUnit('10')->setTotalRevenue('10')->setRawDocumentId($a1->getId());
+        $s2 = (new MarketplaceSale(Uuid::uuid4()->toString(), $a, $listingA, MarketplaceType::OZON))->setExternalOrderId('a2')->setSaleDate(new \DateTimeImmutable('2026-04-22'))->setQuantity(1)->setPricePerUnit('20')->setTotalRevenue('20')->setRawDocumentId($a2->getId())->setDocument($doc);
+        $s3 = (new MarketplaceSale(Uuid::uuid4()->toString(), $a, $listingA, MarketplaceType::OZON))->setExternalOrderId('a3')->setSaleDate(new \DateTimeImmutable('2026-04-22'))->setQuantity(1)->setPricePerUnit('30')->setTotalRevenue('30');
+        $s4 = (new MarketplaceSale(Uuid::uuid4()->toString(), $b, $listingB, MarketplaceType::OZON))->setExternalOrderId('b1')->setSaleDate(new \DateTimeImmutable('2026-04-22'))->setQuantity(1)->setPricePerUnit('10')->setTotalRevenue('10')->setRawDocumentId($b1->getId());
+        $s5 = (new MarketplaceSale(Uuid::uuid4()->toString(), $b, $listingB, MarketplaceType::OZON))->setExternalOrderId('b2')->setSaleDate(new \DateTimeImmutable('2026-04-22'))->setQuantity(1)->setPricePerUnit('20')->setTotalRevenue('20')->setRawDocumentId($b2->getId());
+
+        $r1 = (new MarketplaceReturn(Uuid::uuid4()->toString(), $a, $listingA, MarketplaceType::OZON))->setReturnDate(new \DateTimeImmutable('2026-04-22'))->setQuantity(1)->setRefundAmount('7')->setRawDocumentId($a1->getId());
+        $r2 = (new MarketplaceReturn(Uuid::uuid4()->toString(), $a, $listingA, MarketplaceType::OZON))->setReturnDate(new \DateTimeImmutable('2026-04-22'))->setQuantity(1)->setRefundAmount('8')->setRawDocumentId($a2->getId())->setDocument($doc);
+
+        $c1 = (new MarketplaceCost(Uuid::uuid4()->toString(), $a, MarketplaceType::OZON))->setCostDate(new \DateTimeImmutable('2026-04-22'))->setAmount('2')->setRawDocumentId($a1->getId());
+        $c2 = (new MarketplaceCost(Uuid::uuid4()->toString(), $a, MarketplaceType::OZON))->setCostDate(new \DateTimeImmutable('2026-04-22'))->setAmount('3')->setRawDocumentId($a2->getId())->setDocument($doc);
+
+        foreach ([$s1,$s2,$s3,$s4,$s5,$r1,$r2,$c1,$c2] as $e) { $this->em->persist($e); }
+        $this->em->flush();
+
+        $q = self::getContainer()->get(OzonRawDuplicateAuditQuery::class);
+        $exact = $q->findExactRawDocumentDuplicates($a->getId(), new \DateTimeImmutable('2026-04-01'), new \DateTimeImmutable('2026-04-30'));
+        self::assertCount(1, $exact); self::assertSame('2', (string) $exact[0]['docs_count']);
+
+        $overlap = $q->findOverlappingRawDocuments($a->getId(), new \DateTimeImmutable('2026-04-01'), new \DateTimeImmutable('2026-04-30'));
+        self::assertNotEmpty($overlap);
+
+        $sales = $q->findProcessedSalesWithMultipleRawDocuments($a->getId(), new \DateTimeImmutable('2026-04-01'), new \DateTimeImmutable('2026-04-30'));
+        self::assertCount(1, $sales); self::assertGreaterThan(1, (int) $sales[0]['raw_docs_count']); self::assertTrue((bool) $sales[0]['has_closed_rows']);
+
+        $returns = $q->findProcessedReturnsWithMultipleRawDocuments($a->getId(), new \DateTimeImmutable('2026-04-01'), new \DateTimeImmutable('2026-04-30'));
+        $costs = $q->findProcessedCostsWithMultipleRawDocuments($a->getId(), new \DateTimeImmutable('2026-04-01'), new \DateTimeImmutable('2026-04-30'));
+        self::assertCount(1, $returns); self::assertTrue((bool) $returns[0]['has_closed_rows']);
+        self::assertCount(1, $costs); self::assertTrue((bool) $costs[0]['has_closed_rows']);
+    }
+
+    public function testExactDailyDuplicatesAreNotReportedAsOverlappingRawDocuments(): void
+    {
+        $company = CompanyBuilder::aCompany()->withIndex(10)->build();
+        $this->em->persist($company);
+        $this->em->persist($this->raw($company, '2026-04-22', '2026-04-22', 10));
+        $this->em->persist($this->raw($company, '2026-04-22', '2026-04-22', 11));
+        $this->em->flush();
+
+        $q = self::getContainer()->get(OzonRawDuplicateAuditQuery::class);
+        $exact = $q->findExactRawDocumentDuplicates($company->getId(), new \DateTimeImmutable('2026-04-22'), new \DateTimeImmutable('2026-04-22'));
+        self::assertCount(1, $exact);
+        self::assertSame('2', (string) $exact[0]['docs_count']);
+
+        $overlap = $q->findOverlappingRawDocuments($company->getId(), new \DateTimeImmutable('2026-04-22'), new \DateTimeImmutable('2026-04-22'));
+        self::assertSame([], $overlap);
+    }
+
+    public function testDailyRawDocumentCoveredByRangeRawDocumentIsReportedAsOverlap(): void
+    {
+        $company = CompanyBuilder::aCompany()->withIndex(11)->build();
+        $this->em->persist($company);
+        $daily = $this->raw($company, '2026-04-22', '2026-04-22', 20);
+        $range = $this->raw($company, '2026-04-20', '2026-04-25', 21);
+        $this->em->persist($daily);
+        $this->em->persist($range);
+        $this->em->flush();
+
+        $q = self::getContainer()->get(OzonRawDuplicateAuditQuery::class);
+        $overlap = $q->findOverlappingRawDocuments($company->getId(), new \DateTimeImmutable('2026-04-20'), new \DateTimeImmutable('2026-04-25'));
+
+        self::assertCount(1, $overlap);
+        self::assertSame($daily->getId(), $overlap[0]['daily_doc_id']);
+        self::assertSame($range->getId(), $overlap[0]['range_doc_id']);
+    }
+
+    private function raw(Company $company, string $from, string $to, int $index): MarketplaceRawDocument
+    {
+        return MarketplaceRawDocumentBuilder::aDocument()->withIndex($index)->forCompany($company)->withMarketplace(MarketplaceType::OZON)->withDocumentType('sales_report')->withPeriod(new \DateTimeImmutable($from), new \DateTimeImmutable($to))->build();
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide coverage for the Ozon raw-duplicates audit logic at both query and CLI command levels to detect exact duplicates, overlapping raw documents, and processed entity correlations.

### Description
- Added `withId` and `withIndex` helper methods to `MarketplaceRawDocumentBuilder` to produce deterministic UUIDs for test documents.
- Added an integration test `OzonRawDuplicateAuditQueryTest` that seeds raw documents, listings, sales, returns and costs and asserts query results for exact duplicates, overlaps, and processed entities linked to multiple raw documents.
- Added an integration command test `OzonRawDuplicatesAuditCommandTest` that exercises the CLI output and JSON format and validates invalid date handling for the `app:marketplace:ozon-raw-duplicates-audit` command.

### Testing
- Executed the new integration tests via PHPUnit using commands such as `vendor/bin/phpunit --filter OzonRawDuplicateAuditQueryTest` and `vendor/bin/phpunit --filter OzonRawDuplicatesAuditCommandTest` and both tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fade54cc048323b614529c7c0a28ae)