### PR TITLE
Make Ozon daily raw-doc lookup deterministic and duplicate-aware

### DIFF
--- a/site/src/Marketplace/MessageHandler/SyncOzonReportHandler.php
+++ b/site/src/Marketplace/MessageHandler/SyncOzonReportHandler.php
@@ -113,13 +113,25 @@ final class SyncOzonReportHandler
         // 2) skip refresh для in-flight pipeline (pending/running), чтобы не обновлять
         //    payload во время обработки и не получить смешанное состояние шагов.
         // FAILED-документы в выборку не попадают — для них retry создаёт новый.
-        $existingDoc = $this->rawDocumentRepository->findExistingDayDocument(
+        $existingDocs = $this->rawDocumentRepository->findActiveExactDayDocuments(
             $company,
             MarketplaceType::OZON,
             'sales_report',
             $fromDate,
         );
+        $existingDoc = $existingDocs[0] ?? null;
 
+        if (count($existingDocs) > 1) {
+            $this->logger->warning('Multiple active Ozon raw documents found for day, using latest as canonical', [
+                'company_id' => $companyId,
+                'connection_id' => $connectionId,
+                'date' => $fromDate->format('Y-m-d'),
+                'raw_document_ids' => array_map(
+                    static fn (MarketplaceRawDocument $rawDocument): string => $rawDocument->getId(),
+                    $existingDocs,
+                ),
+            ]);
+        }
 
         if (
             $existingDoc !== null

--- a/site/src/Marketplace/Repository/MarketplaceRawDocumentRepository.php
+++ b/site/src/Marketplace/Repository/MarketplaceRawDocumentRepository.php
@@ -19,6 +19,37 @@ class MarketplaceRawDocumentRepository extends ServiceEntityRepository
         parent::__construct($registry, MarketplaceRawDocument::class);
     }
 
+
+    /**
+     * Deterministic lookup for daily sync: returns all exact-day active documents
+     * (processingStatus is null or not FAILED) sorted by newest first.
+     *
+     * @return list<MarketplaceRawDocument>
+     */
+    public function findActiveExactDayDocuments(
+        Company $company,
+        MarketplaceType $marketplace,
+        string $documentType,
+        \DateTimeImmutable $day,
+    ): array {
+        return $this->createQueryBuilder('d')
+            ->where('d.company = :company')
+            ->andWhere('d.marketplace = :marketplace')
+            ->andWhere('d.documentType = :documentType')
+            ->andWhere('d.periodFrom = :day')
+            ->andWhere('d.periodTo = :day')
+            ->andWhere('d.processingStatus IS NULL OR d.processingStatus != :failed')
+            ->setParameter('company', $company)
+            ->setParameter('marketplace', $marketplace)
+            ->setParameter('documentType', $documentType)
+            ->setParameter('day', $day)
+            ->setParameter('failed', PipelineStatus::FAILED)
+            ->orderBy('d.syncedAt', 'DESC')
+            ->addOrderBy('d.id', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
+
     /**
      * Idempotency lookup for daily sync: возвращает существующий raw_document
      * за конкретный день (periodFrom=periodTo), у которого processingStatus
@@ -34,21 +65,12 @@ class MarketplaceRawDocumentRepository extends ServiceEntityRepository
         string $documentType,
         \DateTimeImmutable $day,
     ): ?MarketplaceRawDocument {
-        return $this->createQueryBuilder('d')
-            ->where('d.company = :company')
-            ->andWhere('d.marketplace = :marketplace')
-            ->andWhere('d.documentType = :documentType')
-            ->andWhere('d.periodFrom = :day')
-            ->andWhere('d.periodTo = :day')
-            ->andWhere('d.processingStatus IS NULL OR d.processingStatus != :failed')
-            ->setParameter('company', $company)
-            ->setParameter('marketplace', $marketplace)
-            ->setParameter('documentType', $documentType)
-            ->setParameter('day', $day)
-            ->setParameter('failed', PipelineStatus::FAILED)
-            ->setMaxResults(1)
-            ->getQuery()
-            ->getOneOrNullResult();
+        return $this->findActiveExactDayDocuments(
+            $company,
+            $marketplace,
+            $documentType,
+            $day,
+        )[0] ?? null;
     }
 
     /**

--- a/site/src/Marketplace/Repository/MarketplaceRawDocumentRepository.php
+++ b/site/src/Marketplace/Repository/MarketplaceRawDocumentRepository.php
@@ -19,7 +19,6 @@ class MarketplaceRawDocumentRepository extends ServiceEntityRepository
         parent::__construct($registry, MarketplaceRawDocument::class);
     }
 
-
     /**
      * Deterministic lookup for daily sync: returns all exact-day active documents
      * (processingStatus is null or not FAILED) sorted by newest first.
@@ -38,7 +37,7 @@ class MarketplaceRawDocumentRepository extends ServiceEntityRepository
             ->andWhere('d.documentType = :documentType')
             ->andWhere('d.periodFrom = :day')
             ->andWhere('d.periodTo = :day')
-            ->andWhere('d.processingStatus IS NULL OR d.processingStatus != :failed')
+            ->andWhere('(d.processingStatus IS NULL OR d.processingStatus != :failed)')
             ->setParameter('company', $company)
             ->setParameter('marketplace', $marketplace)
             ->setParameter('documentType', $documentType)
@@ -91,7 +90,7 @@ class MarketplaceRawDocumentRepository extends ServiceEntityRepository
             ->andWhere('d.periodFrom = :periodFrom')
             ->andWhere('d.periodTo = :periodTo')
             ->andWhere('d.apiEndpoint = :apiEndpoint')
-            ->andWhere('d.processingStatus IS NULL OR d.processingStatus != :failed')
+            ->andWhere('(d.processingStatus IS NULL OR d.processingStatus != :failed)')
             ->setParameter('company', $company)
             ->setParameter('marketplace', $marketplace)
             ->setParameter('documentType', $documentType)


### PR DESCRIPTION
### Motivation
- Prevent nondeterministic selection of an existing Ozon-day raw document when exact active duplicates exist for the same day. 
- Ensure handler deterministically picks a canonical document to avoid refreshing the wrong raw doc and breaking processed-lines linkage.

### Description
- Added `MarketplaceRawDocumentRepository::findActiveExactDayDocuments(...)` to return all exact-day active documents (`periodFrom = day` and `periodTo = day`, excluding `FAILED`) ordered deterministically by `syncedAt DESC` and `id DESC` as a fallback. 
- Kept `findExistingDayDocument(...)` backward-compatible and made it delegate to the new `findActiveExactDayDocuments(...)` returning the first (canonical) element. 
- Updated `SyncOzonReportHandler` to use `findActiveExactDayDocuments(...)`, choose the canonical document as the first element, and log a `warning` with `company_id`, `connection_id`, `date`, and `raw_document_ids` when multiple active exact-day duplicates are found. 
- Preserved existing behavior for canonical statuses: `PENDING`/`RUNNING` → skip refresh, `COMPLETED`/`null` → refresh, and `null` → create new raw document; no changes to processors, overlap lookup, duplicate deletion, DB indexes, or commands were made.

### Testing
- Ran syntax checks via `php -l site/src/Marketplace/Repository/MarketplaceRawDocumentRepository.php && php -l site/src/Marketplace/MessageHandler/SyncOzonReportHandler.php` which reported no syntax errors. 
- Verified diffs and changes with `git diff` and committed the update. 
- No automated unit/integration tests were added in this task by design; existing behavior paths for canonical statuses are preserved by code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fae9a5eecc8323a268843c4dbd13fb)