### PR TITLE
Make Ozon processors cleanup idempotent and transactional; remove stale marketplace records

### DIFF
--- a/site/src/Marketplace/Application/Processor/OzonCostsRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonCostsRawProcessor.php
@@ -34,6 +34,11 @@ use Ramsey\Uuid\Uuid;
  */
 final class OzonCostsRawProcessor implements MarketplaceRawProcessorInterface
 {
+    /**
+     * Последний rawDocId, для которого уже выполнена очистка legacy/stale-записей
+     * в рамках текущего жизненного цикла процессора.
+     */
+    private ?string $cleanedUpRawDocId = null;
 
     public function __construct(
         private readonly EntityManagerInterface $em,
@@ -63,19 +68,6 @@ final class OzonCostsRawProcessor implements MarketplaceRawProcessorInterface
 
     public function process(string $companyId, string $rawDocId): int
     {
-        // Удаляем старые затраты по raw_document_id (только незакрытые в ОПиУ)
-        $deleted = $this->connection->executeStatement(
-            'DELETE FROM marketplace_costs WHERE raw_document_id = :rawDocId AND document_id IS NULL',
-            ['rawDocId' => $rawDocId],
-        );
-
-        if ($deleted > 0) {
-            $this->logger->info('[Ozon] Deleted existing costs for reprocessing', [
-                'raw_doc_id' => $rawDocId,
-                'deleted'    => $deleted,
-            ]);
-        }
-
         // Читаем все операции из raw документа включая type=orders.
         // processBatch() получает только COST-bucket (type=services/returns/other),
         // но комиссия и логистика из type=orders тоже являются затратами.
@@ -140,11 +132,23 @@ final class OzonCostsRawProcessor implements MarketplaceRawProcessorInterface
             $listingsIdCache[$sku] = $listing->getId();
         }
 
-        $this->categoryResolver->preload($company, MarketplaceType::OZON);
+        $shouldCleanup = $rawDocId !== null && $this->cleanedUpRawDocId !== $rawDocId;
+        $useTransaction = $rawDocId !== null;
 
-        // Генерируем cost entries
-        $allEntries = [];
-        foreach ($rawRows as $op) {
+        if ($useTransaction) {
+            $this->connection->beginTransaction();
+        }
+
+        try {
+            if ($shouldCleanup) {
+                $this->cleanupLegacyCosts($companyId, $rawDocId);
+            }
+
+            $this->categoryResolver->preload($company, MarketplaceType::OZON);
+
+            // Генерируем cost entries
+            $allEntries = [];
+            foreach ($rawRows as $op) {
             $operationId = (string) ($op['operation_id'] ?? '');
             if ($operationId === '') {
                 continue;
@@ -194,20 +198,26 @@ final class OzonCostsRawProcessor implements MarketplaceRawProcessorInterface
 
                 $allEntries[] = ['entry' => $entry, 'listingId' => $listingId];
             }
-        }
+            }
 
-        if (empty($allEntries)) {
-            return;
-        }
+            if (empty($allEntries)) {
+                if ($useTransaction) {
+                    $this->connection->commit();
+                }
+                if ($shouldCleanup) {
+                    $this->cleanedUpRawDocId = $rawDocId;
+                }
+                return;
+            }
 
-        // Дедупликация
-        $allExternalIds = array_unique(array_map(
-            static fn (array $row): string => $row['entry']['external_id'],
-            $allEntries,
-        ));
-        $existingMap = $this->costExistingIdsQuery->execute($companyId, $allExternalIds);
+            // Дедупликация
+            $allExternalIds = array_unique(array_map(
+                static fn (array $row): string => $row['entry']['external_id'],
+                $allEntries,
+            ));
+            $existingMap = $this->costExistingIdsQuery->execute($companyId, $allExternalIds);
 
-        foreach ($allEntries as $row) {
+            foreach ($allEntries as $row) {
             $entry      = $row['entry'];
             $externalId = $entry['external_id'];
 
@@ -242,12 +252,73 @@ final class OzonCostsRawProcessor implements MarketplaceRawProcessorInterface
                 $cost->setListing($this->em->getReference(MarketplaceListing::class, $row['listingId']));
             }
 
-            $this->em->persist($cost);
-            $existingMap[$externalId] = true;
+                $this->em->persist($cost);
+                $existingMap[$externalId] = true;
+            }
+
+            $this->em->flush();
+            $this->mappingErrorLogger->resetBatch();
+
+            if ($useTransaction) {
+                $this->connection->commit();
+            }
+            if ($shouldCleanup) {
+                $this->cleanedUpRawDocId = $rawDocId;
+            }
+        } catch (\Throwable $e) {
+            if ($useTransaction && $this->connection->isTransactionActive()) {
+                $this->connection->rollBack();
+            }
+            throw $e;
+        }
+    }
+
+    private function cleanupLegacyCosts(string $companyId, string $rawDocId): void
+    {
+        $rawDoc = $this->em->find(MarketplaceRawDocument::class, $rawDocId);
+        if (!$rawDoc instanceof MarketplaceRawDocument) {
+            return;
         }
 
-        $this->em->flush();
-        $this->mappingErrorLogger->resetBatch();
+        $periodFrom = $rawDoc->getPeriodFrom()->format('Y-m-d');
+        $periodTo = $rawDoc->getPeriodTo()->format('Y-m-d');
+
+        $deletedByDoc = (int) $this->connection->executeStatement(
+            'DELETE FROM marketplace_costs
+             WHERE raw_document_id = :rawDocId
+               AND document_id IS NULL',
+            ['rawDocId' => $rawDocId],
+        );
+
+        $deletedStale = (int) $this->connection->executeStatement(
+            'DELETE FROM marketplace_costs
+             WHERE document_id IS NULL
+               AND company_id = :companyId
+               AND marketplace = :marketplace
+               AND cost_date BETWEEN :periodFrom AND :periodTo
+               AND (raw_document_id IS NULL OR raw_document_id != :rawDocId)',
+            [
+                'companyId' => $companyId,
+                'marketplace' => MarketplaceType::OZON->value,
+                'periodFrom' => $periodFrom,
+                'periodTo' => $periodTo,
+                'rawDocId' => $rawDocId,
+            ],
+        );
+
+        if ($deletedByDoc > 0 || $deletedStale > 0) {
+            $this->logger->info(
+                '[Ozon] Deleted costs before reprocessing raw doc',
+                [
+                    'raw_doc_id' => $rawDocId,
+                    'company_id' => $companyId,
+                    'period_from' => $periodFrom,
+                    'period_to' => $periodTo,
+                    'deleted_by_doc' => $deletedByDoc,
+                    'deleted_stale' => $deletedStale,
+                ],
+            );
+        }
     }
 
     /**

--- a/site/src/Marketplace/Application/Processor/OzonReturnsRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonReturnsRawProcessor.php
@@ -218,7 +218,7 @@ final class OzonReturnsRawProcessor implements MarketplaceRawProcessorInterface
 
     /**
      * Удаляет записи текущего raw-документа (идемпотентный повтор обработки)
-     * и legacy-записи без raw_document_id за тот же период.
+     * и открытые stale-записи за период от других raw_document_id.
      *
      * `document_id IS NULL` — не трогаем уже закрытые в ОПиУ записи.
      */
@@ -239,27 +239,28 @@ final class OzonReturnsRawProcessor implements MarketplaceRawProcessorInterface
             ['docId' => $rawDocId],
         );
 
-        $deletedLegacy = (int) $this->connection->executeStatement(
+        $deletedStale = (int) $this->connection->executeStatement(
             'DELETE FROM marketplace_returns
-             WHERE raw_document_id IS NULL
-               AND document_id IS NULL
+             WHERE document_id IS NULL
                AND company_id = :companyId
                AND marketplace = :marketplace
-               AND return_date BETWEEN :periodFrom AND :periodTo',
+               AND return_date BETWEEN :periodFrom AND :periodTo
+               AND (raw_document_id IS NULL OR raw_document_id != :rawDocId)',
             [
                 'companyId'   => $companyId,
                 'marketplace' => MarketplaceType::OZON->value,
                 'periodFrom'  => $periodFrom,
                 'periodTo'    => $periodTo,
+                'rawDocId'    => $rawDocId,
             ],
         );
 
-        if ($deletedByDoc > 0 || $deletedLegacy > 0) {
+        if ($deletedByDoc > 0 || $deletedStale > 0) {
             $this->logger->info(
                 sprintf(
-                    '[Ozon] Очищено %d returns (по raw_document_id) + %d legacy returns за период %s—%s перед обработкой документа %s',
+                    '[Ozon] Очищено %d returns (по raw_document_id) + %d stale returns за период %s—%s перед обработкой документа %s',
                     $deletedByDoc,
-                    $deletedLegacy,
+                    $deletedStale,
                     $periodFrom,
                     $periodTo,
                     $rawDocId,
@@ -268,7 +269,7 @@ final class OzonReturnsRawProcessor implements MarketplaceRawProcessorInterface
                     'raw_doc_id'     => $rawDocId,
                     'company_id'     => $companyId,
                     'deleted_by_doc' => $deletedByDoc,
-                    'deleted_legacy' => $deletedLegacy,
+                    'deleted_stale'  => $deletedStale,
                     'period_from'    => $periodFrom,
                     'period_to'      => $periodTo,
                 ],

--- a/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonSalesRawProcessor.php
@@ -286,7 +286,7 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
 
     /**
      * Удаляет записи текущего raw-документа (идемпотентный повтор обработки)
-     * и legacy-записи без raw_document_id за тот же период.
+     * и открытые stale-записи за период от других raw_document_id.
      *
      * - `document_id IS NULL` — не трогаем уже закрытые в ОПиУ записи.
      * - Перед DELETE применяется guard по Company::financeLockBefore:
@@ -338,12 +338,30 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
             ],
         );
 
-        if ($deletedByDoc > 0 || $deletedLegacy > 0) {
+        $deletedStale = (int) $this->connection->executeStatement(
+            'DELETE FROM marketplace_sales
+             WHERE raw_document_id IS NOT NULL
+               AND raw_document_id != :rawDocId
+               AND document_id IS NULL
+               AND company_id = :companyId
+               AND marketplace = :marketplace
+               AND sale_date BETWEEN :periodFrom AND :periodTo',
+            [
+                'rawDocId'    => $rawDocId,
+                'companyId'   => $companyId,
+                'marketplace' => MarketplaceType::OZON->value,
+                'periodFrom'  => $periodFrom,
+                'periodTo'    => $periodTo,
+            ],
+        );
+
+        if ($deletedByDoc > 0 || $deletedLegacy > 0 || $deletedStale > 0) {
             $this->logger->info(
                 sprintf(
-                    '[Ozon] Очищено %d sales (по raw_document_id) + %d legacy sales за период %s—%s перед обработкой документа %s',
+                    '[Ozon] Очищено %d sales (по raw_document_id) + %d legacy sales + %d stale sales за период %s—%s перед обработкой документа %s',
                     $deletedByDoc,
                     $deletedLegacy,
+                    $deletedStale,
                     $periodFrom,
                     $periodTo,
                     $rawDocId,
@@ -353,6 +371,7 @@ final class OzonSalesRawProcessor implements MarketplaceRawProcessorInterface
                     'company_id'     => $companyId,
                     'deleted_by_doc' => $deletedByDoc,
                     'deleted_legacy' => $deletedLegacy,
+                    'deleted_stale'  => $deletedStale,
                     'period_from'    => $periodFrom,
                     'period_to'      => $periodTo,
                 ],


### PR DESCRIPTION
### Motivation

- Ensure reprocessing a raw document does not leave stale/open marketplace records and avoid double-deletes or race conditions during retries. 
- Perform cleanup only once per processor lifecycle per raw document and ensure cleanup is committed atomically with processing to avoid in-memory marker inconsistencies.

### Description

- Introduced a `cleanedUpRawDocId` marker and conditional transactional flow in `OzonCostsRawProcessor` to perform cleanup only once per raw document and to wrap processing in a DB transaction with proper commit/rollback handling. 
- Moved the initial unconditional DELETE logic into a new `cleanupLegacyCosts` method that deletes by `raw_document_id` and also removes open stale cost rows from other raw documents for the same period, logging deletions. 
- Adjusted processing flow to preload categories, generate entries, deduplicate by `external_id`, persist and `flush()` inside the transaction, and only set the in-memory cleanup marker after successful commit; errors trigger rollback. 
- Aligned `OzonReturnsRawProcessor` and `OzonSalesRawProcessor` cleanup semantics and logging by renaming legacy variables to `deletedStale` and changing SQL to remove open/stale rows from other `raw_document_id`s for the same period, while preserving closed (`document_id IS NOT NULL`) records and finance lock guards in sales cleanup. 

### Testing

- Ran the project's automated test suites including unit and integration tests against the modified processors and observed all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faf6a9a6b883238bbb6b05efe7224a)