### PR TITLE
Add builder id/index helpers and integration tests for Ozon raw processors

### DIFF
--- a/site/tests/Builders/Marketplace/MarketplaceListingBuilder.php
+++ b/site/tests/Builders/Marketplace/MarketplaceListingBuilder.php
@@ -53,6 +53,22 @@ final class MarketplaceListingBuilder
         return $clone;
     }
 
+    public function withId(string $id): self
+    {
+        $clone = clone $this;
+        $clone->id = $id;
+
+        return $clone;
+    }
+
+    public function withIndex(int $index): self
+    {
+        $clone = clone $this;
+        $clone->id = sprintf('33333333-3333-4333-8333-%012d', $index);
+
+        return $clone;
+    }
+
     public function withPrice(string $price): self
     {
         $clone = clone $this;

--- a/site/tests/Builders/Marketplace/MarketplaceSaleBuilder.php
+++ b/site/tests/Builders/Marketplace/MarketplaceSaleBuilder.php
@@ -60,6 +60,22 @@ final class MarketplaceSaleBuilder
         return $clone;
     }
 
+    public function withId(string $id): self
+    {
+        $clone = clone $this;
+        $clone->id = $id;
+
+        return $clone;
+    }
+
+    public function withIndex(int $index): self
+    {
+        $clone = clone $this;
+        $clone->id = sprintf('44444444-4444-4444-8444-%012d', $index);
+
+        return $clone;
+    }
+
     public function withExternalOrderId(string $externalOrderId): self
     {
         $clone = clone $this;

--- a/site/tests/Integration/Marketplace/Application/Processor/OzonCostsRawProcessorTest.php
+++ b/site/tests/Integration/Marketplace/Application/Processor/OzonCostsRawProcessorTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Marketplace\Application\Processor;
+
+use App\Finance\Entity\Document;
+use App\Marketplace\Application\Processor\OzonCostsRawProcessor;
+use App\Marketplace\Entity\MarketplaceCost;
+use App\Marketplace\Enum\MarketplaceCostOperationType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceRawDocumentBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class OzonCostsRawProcessorTest extends IntegrationTestCase
+{
+    public function testCleanupRemovesOnlyStaleOpenCosts(): void
+    {
+        $company = CompanyBuilder::aCompany()->withIndex(301)->build();
+        $foreignCompany = CompanyBuilder::aCompany()->withIndex(302)->build();
+        $this->em->persist($company);
+        $this->em->persist($foreignCompany);
+        $day = new \DateTimeImmutable('2026-03-12');
+        $outside = new \DateTimeImmutable('2026-03-20');
+        $rawDocA = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaa12';
+        $rawDocB = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbb12';
+
+        $stale = new MarketplaceCost(Uuid::uuid4()->toString(), $company, MarketplaceType::OZON, null);
+        $stale->setExternalId('stale-cost')->setCostDate($day)->setAmount('100')->setOperationType(MarketplaceCostOperationType::CHARGE)->setRawDocumentId($rawDocA);
+
+        $doc = new Document(Uuid::uuid4()->toString(), $company);
+        $this->em->persist($doc);
+        $closed = new MarketplaceCost(Uuid::uuid4()->toString(), $company, MarketplaceType::OZON, null);
+        $closed->setExternalId('closed-cost')->setCostDate($day)->setAmount('100')->setOperationType(MarketplaceCostOperationType::CHARGE)->setRawDocumentId($rawDocA)->setDocument($doc);
+        $foreignStale = new MarketplaceCost(Uuid::uuid4()->toString(), $foreignCompany, MarketplaceType::OZON, null);
+        $foreignStale->setExternalId('foreign-cost')->setCostDate($day)->setAmount('100')->setOperationType(MarketplaceCostOperationType::CHARGE)->setRawDocumentId($rawDocA);
+        $outsidePeriod = new MarketplaceCost(Uuid::uuid4()->toString(), $company, MarketplaceType::OZON, null);
+        $outsidePeriod->setExternalId('outside-cost')->setCostDate($outside)->setAmount('100')->setOperationType(MarketplaceCostOperationType::CHARGE)->setRawDocumentId($rawDocA);
+        $wbCost = new MarketplaceCost(Uuid::uuid4()->toString(), $company, MarketplaceType::WILDBERRIES, null);
+        $wbCost->setExternalId('wb-cost')->setCostDate($day)->setAmount('100')->setOperationType(MarketplaceCostOperationType::CHARGE)->setRawDocumentId($rawDocA);
+
+        $this->em->persist($stale);
+        $this->em->persist($closed);
+        $this->em->persist($foreignStale);
+        $this->em->persist($outsidePeriod);
+        $this->em->persist($wbCost);
+        $this->em->persist(MarketplaceRawDocumentBuilder::aDocument()->withId($rawDocB)->forCompany($company)->withMarketplace(MarketplaceType::OZON)->withPeriod($day, $day)->build());
+        $this->em->flush();
+
+        self::getContainer()->get(OzonCostsRawProcessor::class)->processBatch($company->getId(), MarketplaceType::OZON, [[
+            'operation_id' => 'cost-1', 'operation_date' => '2026-03-12 10:00:00', 'operation_type' => 'MarketplaceSellerCompensationOperation',
+            'operation_type_name' => 'Продажа', 'sale_commission' => -10, 'delivery_charge' => 0, 'return_delivery_charge' => 0,
+            'amount' => 0, 'type' => 'orders', 'items' => [['sku' => 'sku-1', 'name' => 'N']], 'services' => [],
+        ]], $rawDocB);
+
+        self::assertSame(0, (int) $this->connection->fetchOne("SELECT COUNT(*) FROM marketplace_costs WHERE external_id='stale-cost'"));
+        self::assertSame(1, (int) $this->connection->fetchOne("SELECT COUNT(*) FROM marketplace_costs WHERE external_id='closed-cost' AND document_id IS NOT NULL"));
+        self::assertSame(1, (int) $this->connection->fetchOne("SELECT COUNT(*) FROM marketplace_costs WHERE raw_document_id=:raw", ['raw' => $rawDocB]));
+        self::assertSame(1, (int) $this->connection->fetchOne("SELECT COUNT(*) FROM marketplace_costs WHERE external_id='foreign-cost'"));
+        self::assertSame(1, (int) $this->connection->fetchOne("SELECT COUNT(*) FROM marketplace_costs WHERE external_id='outside-cost'"));
+        self::assertSame(1, (int) $this->connection->fetchOne("SELECT COUNT(*) FROM marketplace_costs WHERE external_id='wb-cost'"));
+    }
+}

--- a/site/tests/Integration/Marketplace/Application/Processor/OzonReturnsRawProcessorTest.php
+++ b/site/tests/Integration/Marketplace/Application/Processor/OzonReturnsRawProcessorTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Marketplace\Application\Processor;
+
+use App\Finance\Entity\Document;
+use App\Marketplace\Application\Processor\OzonReturnsRawProcessor;
+use App\Marketplace\Entity\MarketplaceReturn;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceListingBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceRawDocumentBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class OzonReturnsRawProcessorTest extends IntegrationTestCase
+{
+    public function testCleanupRemovesOnlyStaleOpenReturns(): void
+    {
+        $company = CompanyBuilder::aCompany()->withIndex(201)->build();
+        $foreignCompany = CompanyBuilder::aCompany()->withIndex(202)->build();
+        $this->em->persist($company);
+        $this->em->persist($foreignCompany);
+        $listing = MarketplaceListingBuilder::aListing()->forCompany($company)->withMarketplace(MarketplaceType::OZON)->withMarketplaceSku('oz-ret')->build();
+        $foreignListing = MarketplaceListingBuilder::aListing()->forCompany($foreignCompany)->withMarketplace(MarketplaceType::OZON)->withMarketplaceSku('oz-ret-foreign')->build();
+        $this->em->persist($listing);
+        $this->em->persist($foreignListing);
+
+        $day = new \DateTimeImmutable('2026-03-11');
+        $outside = new \DateTimeImmutable('2026-03-18');
+        $rawDocA = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaa11';
+        $rawDocB = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbb11';
+
+        $stale = new MarketplaceReturn(Uuid::uuid4()->toString(), $company, $listing, MarketplaceType::OZON);
+        $stale->setExternalReturnId('stale-ret')->setReturnDate($day)->setQuantity(1)->setRefundAmount('10')->setRawDocumentId($rawDocA);
+
+        $doc = new Document(Uuid::uuid4()->toString(), $company);
+        $this->em->persist($doc);
+        $closed = new MarketplaceReturn(Uuid::uuid4()->toString(), $company, $listing, MarketplaceType::OZON);
+        $closed->setExternalReturnId('closed-ret')->setReturnDate($day)->setQuantity(1)->setRefundAmount('10')->setRawDocumentId($rawDocA)->setDocument($doc);
+        $foreignStale = new MarketplaceReturn(Uuid::uuid4()->toString(), $foreignCompany, $foreignListing, MarketplaceType::OZON);
+        $foreignStale->setExternalReturnId('foreign-ret')->setReturnDate($day)->setQuantity(1)->setRefundAmount('10')->setRawDocumentId($rawDocA);
+        $outsidePeriod = new MarketplaceReturn(Uuid::uuid4()->toString(), $company, $listing, MarketplaceType::OZON);
+        $outsidePeriod->setExternalReturnId('outside-ret')->setReturnDate($outside)->setQuantity(1)->setRefundAmount('10')->setRawDocumentId($rawDocA);
+
+        $this->em->persist($stale);
+        $this->em->persist($closed);
+        $this->em->persist($foreignStale);
+        $this->em->persist($outsidePeriod);
+        $this->em->persist(MarketplaceRawDocumentBuilder::aDocument()->withId($rawDocB)->forCompany($company)->withMarketplace(MarketplaceType::OZON)->withPeriod($day, $day)->build());
+        $this->em->flush();
+
+        self::getContainer()->get(OzonReturnsRawProcessor::class)->processBatch($company->getId(), MarketplaceType::OZON, [[
+            'operation_id' => 'ret-1', 'operation_date' => '2026-03-11 10:00:00', 'posting' => ['posting_number' => 'ret-b'],
+            'accruals_for_sale' => -10, 'amount' => -10, 'operation_type_name' => 'Возврат', 'items' => [['sku' => 'oz-ret', 'name' => 'N']],
+        ]], $rawDocB);
+
+        self::assertSame(0, (int) $this->connection->fetchOne("SELECT COUNT(*) FROM marketplace_returns WHERE external_return_id='stale-ret'"));
+        self::assertSame(1, (int) $this->connection->fetchOne("SELECT COUNT(*) FROM marketplace_returns WHERE external_return_id='closed-ret' AND document_id IS NOT NULL"));
+        self::assertSame(1, (int) $this->connection->fetchOne("SELECT COUNT(*) FROM marketplace_returns WHERE external_return_id='ret-b' AND raw_document_id=:raw", ['raw' => $rawDocB]));
+        self::assertSame(1, (int) $this->connection->fetchOne("SELECT COUNT(*) FROM marketplace_returns WHERE external_return_id='foreign-ret'"));
+        self::assertSame(1, (int) $this->connection->fetchOne("SELECT COUNT(*) FROM marketplace_returns WHERE external_return_id='outside-ret'"));
+    }
+}

--- a/site/tests/Integration/Marketplace/Application/Processor/OzonSalesRawProcessorTest.php
+++ b/site/tests/Integration/Marketplace/Application/Processor/OzonSalesRawProcessorTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Marketplace\Application\Processor;
+
+use App\Finance\Entity\Document;
+use App\Marketplace\Application\Processor\OzonSalesRawProcessor;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceListingBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceRawDocumentBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceSaleBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class OzonSalesRawProcessorTest extends IntegrationTestCase
+{
+    public function testCleanupDeletesOnlyStaleOpenRowsWithinSameCompanyMarketplaceAndPeriod(): void
+    {
+        $companyA = CompanyBuilder::aCompany()->withIndex(101)->build();
+        $companyB = CompanyBuilder::aCompany()->withIndex(102)->build();
+        $this->em->persist($companyA);
+        $this->em->persist($companyB);
+
+        $listingA = MarketplaceListingBuilder::aListing()->withIndex(1)->forCompany($companyA)->withMarketplace(MarketplaceType::OZON)->withMarketplaceSku('oz-a')->build();
+        $listingB = MarketplaceListingBuilder::aListing()->withIndex(2)->forCompany($companyB)->withMarketplace(MarketplaceType::OZON)->withMarketplaceSku('oz-b')->build();
+        $listingWb = MarketplaceListingBuilder::aListing()->withIndex(3)->forCompany($companyA)->withMarketplace(MarketplaceType::WILDBERRIES)->withMarketplaceSku('wb-a')->build();
+        $this->em->persist($listingA); $this->em->persist($listingB); $this->em->persist($listingWb);
+
+        $day = new \DateTimeImmutable('2026-03-10');
+        $outside = new \DateTimeImmutable('2026-03-15');
+        $rawDocA = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+        $rawDocB = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+        $stale = MarketplaceSaleBuilder::aSale()->withIndex(1)->forCompany($companyA)->forListing($listingA)->withMarketplace(MarketplaceType::OZON)->withExternalOrderId('stale')->withSaleDate($day)->build();
+        $stale->setRawDocumentId($rawDocA);
+        $staleStorno = MarketplaceSaleBuilder::aSale()->withIndex(2)->forCompany($companyA)->forListing($listingA)->withMarketplace(MarketplaceType::OZON)->withExternalOrderId('stale-storno')->withSaleDate($day)->withPricePerUnit('-200.00')->withTotalRevenue('-200.00')->build();
+        $staleStorno->setRawDocumentId($rawDocA);
+        $foreignCompany = MarketplaceSaleBuilder::aSale()->withIndex(3)->forCompany($companyB)->forListing($listingB)->withMarketplace(MarketplaceType::OZON)->withExternalOrderId('foreign-company')->withSaleDate($day)->build();
+        $foreignCompany->setRawDocumentId($rawDocA);
+        $foreignMarketplace = MarketplaceSaleBuilder::aSale()->withIndex(4)->forCompany($companyA)->forListing($listingWb)->withMarketplace(MarketplaceType::WILDBERRIES)->withExternalOrderId('foreign-marketplace')->withSaleDate($day)->build();
+        $foreignMarketplace->setRawDocumentId($rawDocA);
+        $outsidePeriod = MarketplaceSaleBuilder::aSale()->withIndex(5)->forCompany($companyA)->forListing($listingA)->withMarketplace(MarketplaceType::OZON)->withExternalOrderId('outside-period')->withSaleDate($outside)->build();
+        $outsidePeriod->setRawDocumentId($rawDocA);
+
+        $doc = new Document(Uuid::uuid4()->toString(), $companyA);
+        $this->em->persist($doc);
+        $closed = MarketplaceSaleBuilder::aSale()->withIndex(6)->forCompany($companyA)->forListing($listingA)->withMarketplace(MarketplaceType::OZON)->withExternalOrderId('closed')->withSaleDate($day)->build();
+        $closed->setRawDocumentId($rawDocA);
+        $closed->setDocument($doc);
+
+        foreach ([$stale, $staleStorno, $foreignCompany, $foreignMarketplace, $outsidePeriod, $closed] as $sale) {
+            $this->em->persist($sale);
+        }
+
+        $rawDoc = MarketplaceRawDocumentBuilder::aDocument()->withId($rawDocB)->forCompany($companyA)->withMarketplace(MarketplaceType::OZON)->withPeriod($day, $day)->build();
+        $this->em->persist($rawDoc);
+        $this->em->flush();
+
+        self::getContainer()->get(OzonSalesRawProcessor::class)->processBatch($companyA->getId(), MarketplaceType::OZON, [[
+            'operation_id' => '2001',
+            'operation_date' => '2026-03-10 12:00:00',
+            'accruals_for_sale' => 100,
+            'type' => 'orders',
+            'posting' => ['posting_number' => 'posting-b'],
+            'items' => [['sku' => 'oz-a', 'name' => 'SKU A']],
+        ]], $rawDocB);
+
+        self::assertSame(0, (int) $this->connection->fetchOne("SELECT COUNT(*) FROM marketplace_sales WHERE external_order_id='stale'"));
+        self::assertSame(0, (int) $this->connection->fetchOne("SELECT COUNT(*) FROM marketplace_sales WHERE external_order_id='stale-storno'"));
+        self::assertSame(1, (int) $this->connection->fetchOne("SELECT COUNT(*) FROM marketplace_sales WHERE external_order_id='posting-b' AND raw_document_id=:raw", ['raw' => $rawDocB]));
+        self::assertSame(1, (int) $this->connection->fetchOne("SELECT COUNT(*) FROM marketplace_sales WHERE external_order_id='closed' AND document_id IS NOT NULL"));
+        self::assertSame(1, (int) $this->connection->fetchOne("SELECT COUNT(*) FROM marketplace_sales WHERE external_order_id='foreign-company'"));
+        self::assertSame(1, (int) $this->connection->fetchOne("SELECT COUNT(*) FROM marketplace_sales WHERE external_order_id='foreign-marketplace'"));
+        self::assertSame(1, (int) $this->connection->fetchOne("SELECT COUNT(*) FROM marketplace_sales WHERE external_order_id='outside-period'"));
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a simple way to set deterministic IDs for marketplace test entities to simplify test setup and allow indexed, predictable UUIDs for assertions. 
- Add integration tests that exercise cleanup logic in Ozon raw processors to ensure stale open rows are removed only within the same company/marketplace/period.

### Description

- Added `withId(string $id)` and `withIndex(int $index)` to `MarketplaceListingBuilder` to allow explicit or indexed UUID assignment, with `withIndex` using the format `'33333333-3333-4333-8333-%012d'`.
- Added `withId(string $id)` and `withIndex(int $index)` to `MarketplaceSaleBuilder` to allow explicit or indexed UUID assignment, with `withIndex` using the format `'44444444-4444-4444-8444-%012d'`.
- Added integration tests `OzonSalesRawProcessorTest`, `OzonReturnsRawProcessorTest`, and `OzonCostsRawProcessorTest` under `site/tests/Integration/Marketplace/Application/Processor/` which create entities using builders, invoke the corresponding `processBatch` methods, and assert DB state to validate stale-row cleanup behavior.

### Testing

- Ran the new integration tests `OzonSalesRawProcessorTest`, `OzonReturnsRawProcessorTest`, and `OzonCostsRawProcessorTest` via PHPUnit and they passed. 
- Each test asserts expected row counts in the database after calling the processor `processBatch` methods and succeeded. 
- Test setup uses `CompanyBuilder`, `MarketplaceListingBuilder`, `MarketplaceSaleBuilder`, and `MarketplaceRawDocumentBuilder` to create deterministic test data.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fafd22fe188323b026820c757ea5f7)