### PR TITLE
Enable BypassFinals for RebuildPreliminaryForPeriodAction in tests

### DIFF
--- a/site/tests/bootstrap.php
+++ b/site/tests/bootstrap.php
@@ -7,6 +7,7 @@ require dirname(__DIR__).'/vendor/autoload.php';
 DG\BypassFinals::enable();
 DG\BypassFinals::allowPaths([
     '*/src/Marketplace/Facade/MarketplaceFacade.php',
+    '*/src/Marketplace/Application/RebuildPreliminaryForPeriodAction.php',
     '*/src/Marketplace/Infrastructure/Query/UnprocessedCostsQuery.php',
     '*/src/MarketplaceAnalytics/Domain/Service/CostMappingResolver.php',
     '*/src/MarketplaceAnalytics/Domain/Service/DefaultCostMappingSeedPolicy.php',


### PR DESCRIPTION
### Motivation
- Allow unit tests to mock or extend `RebuildPreliminaryForPeriodAction` by permitting the test helper to bypass the `final` modifier for that class.

### Description
- Added `'*/src/Marketplace/Application/RebuildPreliminaryForPeriodAction.php'` to the `DG\BypassFinals::allowPaths` array in `site/tests/bootstrap.php`.

### Testing
- Ran the test suite with `vendor/bin/phpunit` and the automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb12d688e883238b37b7972ffe1b71)