### PR TITLE
Allow DG\BypassFinals for additional Marketplace and MarketplaceAds classes in tests bootstrap

### DIFF
--- a/site/tests/bootstrap.php
+++ b/site/tests/bootstrap.php
@@ -7,7 +7,15 @@ require dirname(__DIR__).'/vendor/autoload.php';
 DG\BypassFinals::enable();
 DG\BypassFinals::allowPaths([
     '*/src/Marketplace/Facade/MarketplaceFacade.php',
+    '*/src/Marketplace/Application/RebuildPreliminaryForPeriodAction.php',
     '*/src/Marketplace/Infrastructure/Query/UnprocessedCostsQuery.php',
+    '*/src/MarketplaceAds/Infrastructure/Query/AdSpendByListingQuery.php',
+    '*/src/MarketplaceAds/Infrastructure/Query/ActiveOzonPerformanceConnectionsQuery.php',
+    '*/src/MarketplaceAds/Application/ExtractBatchesToRawDocumentsAction.php',
+    '*/src/MarketplaceAds/Application/Service/AdBatchPlanner.php',
+    '*/src/Marketplace/Application/Service/MarketplaceWeekPartitionService.php',
+    '*/src/Marketplace/Infrastructure/Query/ActiveOzonConnectionsQuery.php',
+    '*/src/Marketplace/Infrastructure/Query/ActiveSellerConnectionsQuery.php',
     '*/src/MarketplaceAnalytics/Domain/Service/CostMappingResolver.php',
     '*/src/MarketplaceAnalytics/Domain/Service/DefaultCostMappingSeedPolicy.php',
     '*/src/MarketplaceAnalytics/Infrastructure/Query/UnitExtendedQuery.php',


### PR DESCRIPTION
### Motivation

- Enable unit and integration tests to mock or override final classes used by Marketplace and MarketplaceAds code by expanding the `DG\BypassFinals::allowPaths` list in the test bootstrap.

### Description

- Updated `site/tests/bootstrap.php` to extend the `DG\BypassFinals::allowPaths` array with additional paths for Marketplace and MarketplaceAds classes.
- Added the following allow patterns: `*/src/Marketplace/Application/RebuildPreliminaryForPeriodAction.php`, `*/src/MarketplaceAds/Infrastructure/Query/AdSpendByListingQuery.php`, `*/src/MarketplaceAds/Infrastructure/Query/ActiveOzonPerformanceConnectionsQuery.php`, `*/src/MarketplaceAds/Application/ExtractBatchesToRawDocumentsAction.php`, `*/src/MarketplaceAds/Application/Service/AdBatchPlanner.php`, `*/src/Marketplace/Application/Service/MarketplaceWeekPartitionService.php`, `*/src/Marketplace/Infrastructure/Query/ActiveOzonConnectionsQuery.php`, and `*/src/Marketplace/Infrastructure/Query/ActiveSellerConnectionsQuery.php`.

### Testing

- Ran the test suite with `vendor/bin/phpunit` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb12d688e883238b37b7972ffe1b71)