### PR TITLE
Add Ozon raw-duplicates cleanup planner, executor, DTOs and CLI command

### DIFF
--- a/site/src/Marketplace/Application/DTO/OzonRawDuplicatesCleanupDayPlan.php
+++ b/site/src/Marketplace/Application/DTO/OzonRawDuplicatesCleanupDayPlan.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\DTO;
+
+final readonly class OzonRawDuplicatesCleanupDayPlan
+{
+    /**
+     * @param list<string> $duplicateRawDocumentIds
+     * @param list<string> $safeToDeleteRawDocumentIds
+     * @param list<string> $warnings
+     */
+    public function __construct(
+        public \DateTimeImmutable $day,
+        public string $canonicalRawDocumentId,
+        public array $duplicateRawDocumentIds,
+        public int $staleSalesRowsCount,
+        public int $staleReturnsRowsCount,
+        public int $staleCostsRowsCount,
+        public int $closedSalesRowsCount,
+        public int $closedReturnsRowsCount,
+        public int $closedCostsRowsCount,
+        public bool $canAutoCleanup,
+        public array $safeToDeleteRawDocumentIds,
+        public array $warnings,
+    ) {
+    }
+}

--- a/site/src/Marketplace/Application/DTO/OzonRawDuplicatesCleanupExecutionResult.php
+++ b/site/src/Marketplace/Application/DTO/OzonRawDuplicatesCleanupExecutionResult.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\DTO;
+
+final readonly class OzonRawDuplicatesCleanupExecutionResult
+{
+    /** @param list<string> $cleanedCanonicalRawDocumentIds */
+    public function __construct(
+        public int $deletedSalesRows,
+        public int $deletedReturnsRows,
+        public int $deletedCostsRows,
+        public int $cleanedDaysCount,
+        public array $cleanedCanonicalRawDocumentIds,
+    ) {
+    }
+}

--- a/site/src/Marketplace/Application/DTO/OzonRawDuplicatesCleanupPlan.php
+++ b/site/src/Marketplace/Application/DTO/OzonRawDuplicatesCleanupPlan.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\DTO;
+
+final readonly class OzonRawDuplicatesCleanupPlan
+{
+    /** @param list<OzonRawDuplicatesCleanupDayPlan> $affectedDays */
+    public function __construct(
+        public string $companyId,
+        public \DateTimeImmutable $from,
+        public \DateTimeImmutable $to,
+        public array $affectedDays,
+    ) {
+    }
+
+    public function totalStaleSalesRows(): int
+    {
+        return array_sum(array_map(static fn (OzonRawDuplicatesCleanupDayPlan $dayPlan): int => $dayPlan->staleSalesRowsCount, $this->affectedDays));
+    }
+
+    public function totalStaleReturnsRows(): int
+    {
+        return array_sum(array_map(static fn (OzonRawDuplicatesCleanupDayPlan $dayPlan): int => $dayPlan->staleReturnsRowsCount, $this->affectedDays));
+    }
+
+    public function totalStaleCostsRows(): int
+    {
+        return array_sum(array_map(static fn (OzonRawDuplicatesCleanupDayPlan $dayPlan): int => $dayPlan->staleCostsRowsCount, $this->affectedDays));
+    }
+}

--- a/site/src/Marketplace/Application/Service/OzonRawDuplicatesCleanupExecutor.php
+++ b/site/src/Marketplace/Application/Service/OzonRawDuplicatesCleanupExecutor.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\Service;
+
+use App\Marketplace\Application\DTO\OzonRawDuplicatesCleanupExecutionResult;
+use App\Marketplace\Application\DTO\OzonRawDuplicatesCleanupPlan;
+use App\Marketplace\Enum\MarketplaceType;
+use Doctrine\DBAL\Connection;
+use Psr\Log\LoggerInterface;
+
+final readonly class OzonRawDuplicatesCleanupExecutor
+{
+    public function __construct(
+        private Connection $connection,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function execute(OzonRawDuplicatesCleanupPlan $plan): OzonRawDuplicatesCleanupExecutionResult
+    {
+        $deletedSalesRows = 0;
+        $deletedReturnsRows = 0;
+        $deletedCostsRows = 0;
+        $cleanedDays = 0;
+        $canonicalRawDocumentIds = [];
+
+        $this->connection->beginTransaction();
+
+        try {
+            foreach ($plan->affectedDays as $dayPlan) {
+                if (!$dayPlan->canAutoCleanup) {
+                    continue;
+                }
+
+                $deletedSalesForDay = $this->deleteStaleRows('marketplace_sales', 'sale_date', $plan->companyId, $dayPlan->day, $dayPlan->canonicalRawDocumentId);
+                $deletedReturnsForDay = $this->deleteStaleRows('marketplace_returns', 'return_date', $plan->companyId, $dayPlan->day, $dayPlan->canonicalRawDocumentId);
+                $deletedCostsForDay = $this->deleteStaleRows('marketplace_costs', 'cost_date', $plan->companyId, $dayPlan->day, $dayPlan->canonicalRawDocumentId);
+
+                $deletedSalesRows += $deletedSalesForDay;
+                $deletedReturnsRows += $deletedReturnsForDay;
+                $deletedCostsRows += $deletedCostsForDay;
+
+                $deletedForDay = $deletedSalesForDay + $deletedReturnsForDay + $deletedCostsForDay;
+                if ($deletedForDay > 0) {
+                    ++$cleanedDays;
+                    $canonicalRawDocumentIds[] = $dayPlan->canonicalRawDocumentId;
+                }
+            }
+
+            $this->connection->commit();
+        } catch (\Throwable $e) {
+            $this->connection->rollBack();
+
+            $this->logger->error('Ozon raw duplicates cleanup rolled back.', ['exception' => $e]);
+
+            throw $e;
+        }
+
+        $this->logger->info('Ozon raw duplicates cleanup applied.', [
+            'companyId' => $plan->companyId,
+            'from' => $plan->from->format('Y-m-d'),
+            'to' => $plan->to->format('Y-m-d'),
+            'cleanedDays' => $cleanedDays,
+            'deletedSalesRows' => $deletedSalesRows,
+            'deletedReturnsRows' => $deletedReturnsRows,
+            'deletedCostsRows' => $deletedCostsRows,
+        ]);
+
+        return new OzonRawDuplicatesCleanupExecutionResult(
+            deletedSalesRows: $deletedSalesRows,
+            deletedReturnsRows: $deletedReturnsRows,
+            deletedCostsRows: $deletedCostsRows,
+            cleanedDaysCount: $cleanedDays,
+            cleanedCanonicalRawDocumentIds: array_values(array_unique($canonicalRawDocumentIds)),
+        );
+    }
+
+    private function deleteStaleRows(string $table, string $dateField, string $companyId, \DateTimeImmutable $day, string $canonicalRawDocumentId): int
+    {
+        return $this->connection->executeStatement(
+            sprintf(
+                'DELETE FROM %s t WHERE t.company_id = :companyId AND t.marketplace = :marketplace AND t.%s = :day AND t.document_id IS NULL AND (t.raw_document_id IS NULL OR t.raw_document_id <> :canonicalRawDocumentId)',
+                $table,
+                $dateField,
+            ),
+            [
+                'companyId' => $companyId,
+                'marketplace' => MarketplaceType::OZON->value,
+                'day' => $day->format('Y-m-d'),
+                'canonicalRawDocumentId' => $canonicalRawDocumentId,
+            ],
+        );
+    }
+}

--- a/site/src/Marketplace/Application/Service/OzonRawDuplicatesCleanupPlanner.php
+++ b/site/src/Marketplace/Application/Service/OzonRawDuplicatesCleanupPlanner.php
@@ -1,0 +1,353 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\Service;
+
+use App\Marketplace\Application\DTO\OzonRawDuplicatesCleanupDayPlan;
+use App\Marketplace\Application\DTO\OzonRawDuplicatesCleanupPlan;
+use App\Marketplace\Enum\MarketplaceType;
+use Doctrine\DBAL\Connection;
+use Webmozart\Assert\Assert;
+
+final readonly class OzonRawDuplicatesCleanupPlanner
+{
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    public function buildPlan(string $companyId, \DateTimeImmutable $from, \DateTimeImmutable $to): OzonRawDuplicatesCleanupPlan
+    {
+        Assert::uuid($companyId);
+
+        $days = $this->findAffectedDays($companyId, $from, $to);
+        $dayPlans = [];
+
+        foreach ($days as $day) {
+            $rawDocuments = $this->findRawDocumentsForDay($companyId, $day);
+            if ($rawDocuments === []) {
+                continue;
+            }
+
+            $canonical = $this->chooseCanonical($rawDocuments);
+            $duplicateIds = array_values(array_filter(
+                array_map(static fn (array $row): string => (string) $row['id'], $rawDocuments),
+                static fn (string $id): bool => $id !== $canonical,
+            ));
+
+            $staleSales = $this->countStaleRows('marketplace_sales', 'sale_date', $companyId, $day, $canonical, false);
+            $staleReturns = $this->countStaleRows('marketplace_returns', 'return_date', $companyId, $day, $canonical, false);
+            $staleCosts = $this->countStaleRows('marketplace_costs', 'cost_date', $companyId, $day, $canonical, false);
+            $closedSales = $this->countStaleRows('marketplace_sales', 'sale_date', $companyId, $day, $canonical, true);
+            $closedReturns = $this->countStaleRows('marketplace_returns', 'return_date', $companyId, $day, $canonical, true);
+            $closedCosts = $this->countStaleRows('marketplace_costs', 'cost_date', $companyId, $day, $canonical, true);
+
+            $warnings = [];
+            $hasPendingOrRunning = $this->hasPendingOrRunningRawDocument($rawDocuments);
+            $canonicalStatus = $this->findRawDocumentStatusById($rawDocuments, $canonical);
+            $canonicalFailed = $canonicalStatus === 'failed';
+
+            if ($closedSales > 0 || $closedReturns > 0 || $closedCosts > 0) {
+                $warnings[] = 'Найдены closed rows (document_id IS NOT NULL), auto-cleanup отключён для этого дня.';
+            }
+            if ($hasPendingOrRunning) {
+                $warnings[] = 'Есть PENDING/RUNNING rawDoc, auto-cleanup запрещён до завершения pipeline.';
+            }
+            if ($canonicalFailed) {
+                $warnings[] = 'Canonical rawDoc имеет FAILED статус, auto-cleanup запрещён до успешной перезагрузки/пересборки документа.';
+            }
+
+            if ($staleSales + $staleReturns + $staleCosts === 0) {
+                $warnings[] = 'Stale open rows не найдены, очистка processed-таблиц для дня не требуется.';
+            }
+
+            $safeToDeleteRawDocs = $this->findSafeToDeleteRawDocuments($duplicateIds);
+
+            $dayPlans[] = new OzonRawDuplicatesCleanupDayPlan(
+                day: $day,
+                canonicalRawDocumentId: $canonical,
+                duplicateRawDocumentIds: $duplicateIds,
+                staleSalesRowsCount: $staleSales,
+                staleReturnsRowsCount: $staleReturns,
+                staleCostsRowsCount: $staleCosts,
+                closedSalesRowsCount: $closedSales,
+                closedReturnsRowsCount: $closedReturns,
+                closedCostsRowsCount: $closedCosts,
+                canAutoCleanup: !$hasPendingOrRunning && !$canonicalFailed && $closedSales === 0 && $closedReturns === 0 && $closedCosts === 0,
+                safeToDeleteRawDocumentIds: $safeToDeleteRawDocs,
+                warnings: $warnings,
+            );
+        }
+
+        return new OzonRawDuplicatesCleanupPlan($companyId, $from, $to, $dayPlans);
+    }
+
+    /** @return list<\DateTimeImmutable> */
+    private function findAffectedDays(string $companyId, \DateTimeImmutable $from, \DateTimeImmutable $to): array
+    {
+        $rows = $this->connection->fetchFirstColumn(
+            <<<SQL
+            WITH duplicate_processed_days AS (
+                SELECT s.sale_date::date AS day
+                FROM marketplace_sales s
+                WHERE s.company_id = :companyId
+                  AND s.marketplace = :marketplace
+                  AND s.sale_date BETWEEN :fromDate AND :toDate
+                  AND s.raw_document_id IS NOT NULL
+                GROUP BY s.sale_date::date
+                HAVING COUNT(DISTINCT s.raw_document_id) > 1
+                UNION
+                SELECT r.return_date::date AS day
+                FROM marketplace_returns r
+                WHERE r.company_id = :companyId
+                  AND r.marketplace = :marketplace
+                  AND r.return_date BETWEEN :fromDate AND :toDate
+                  AND r.raw_document_id IS NOT NULL
+                GROUP BY r.return_date::date
+                HAVING COUNT(DISTINCT r.raw_document_id) > 1
+                UNION
+                SELECT c.cost_date::date AS day
+                FROM marketplace_costs c
+                WHERE c.company_id = :companyId
+                  AND c.marketplace = :marketplace
+                  AND c.cost_date BETWEEN :fromDate AND :toDate
+                  AND c.raw_document_id IS NOT NULL
+                GROUP BY c.cost_date::date
+                HAVING COUNT(DISTINCT c.raw_document_id) > 1
+            ),
+            duplicate_raw_days AS (
+                SELECT rd.period_from::date AS day
+                FROM marketplace_raw_documents rd
+                WHERE rd.company_id = :companyId
+                  AND rd.marketplace = :marketplace
+                  AND rd.document_type = 'sales_report'
+                  AND rd.period_from BETWEEN :fromDate AND :toDate
+                  AND rd.period_to BETWEEN :fromDate AND :toDate
+                GROUP BY rd.period_from::date, rd.period_to::date
+                HAVING COUNT(*) > 1
+                UNION
+                SELECT daily.period_from::date AS day
+                FROM marketplace_raw_documents daily
+                INNER JOIN marketplace_raw_documents range_doc
+                    ON range_doc.company_id = daily.company_id
+                   AND range_doc.marketplace = daily.marketplace
+                   AND range_doc.document_type = daily.document_type
+                   AND range_doc.id <> daily.id
+                   AND range_doc.period_from <= daily.period_from
+                   AND range_doc.period_to >= daily.period_to
+                   AND range_doc.period_from <> range_doc.period_to
+                WHERE daily.company_id = :companyId
+                  AND daily.marketplace = :marketplace
+                  AND daily.document_type = 'sales_report'
+                  AND daily.period_from = daily.period_to
+                  AND daily.period_from BETWEEN :fromDate AND :toDate
+            ),
+            legacy_processed_days AS (
+                SELECT s.sale_date::date AS day
+                FROM marketplace_sales s
+                WHERE s.company_id = :companyId
+                  AND s.marketplace = :marketplace
+                  AND s.sale_date BETWEEN :fromDate AND :toDate
+                  AND s.document_id IS NULL
+                  AND s.raw_document_id IS NULL
+                  AND EXISTS (
+                      SELECT 1
+                      FROM marketplace_raw_documents rd
+                      WHERE rd.company_id = :companyId
+                        AND rd.marketplace = :marketplace
+                        AND rd.document_type = 'sales_report'
+                        AND rd.period_from <= s.sale_date::date
+                        AND rd.period_to >= s.sale_date::date
+                  )
+                UNION
+                SELECT r.return_date::date AS day
+                FROM marketplace_returns r
+                WHERE r.company_id = :companyId
+                  AND r.marketplace = :marketplace
+                  AND r.return_date BETWEEN :fromDate AND :toDate
+                  AND r.document_id IS NULL
+                  AND r.raw_document_id IS NULL
+                  AND EXISTS (
+                      SELECT 1
+                      FROM marketplace_raw_documents rd
+                      WHERE rd.company_id = :companyId
+                        AND rd.marketplace = :marketplace
+                        AND rd.document_type = 'sales_report'
+                        AND rd.period_from <= r.return_date::date
+                        AND rd.period_to >= r.return_date::date
+                  )
+                UNION
+                SELECT c.cost_date::date AS day
+                FROM marketplace_costs c
+                WHERE c.company_id = :companyId
+                  AND c.marketplace = :marketplace
+                  AND c.cost_date BETWEEN :fromDate AND :toDate
+                  AND c.document_id IS NULL
+                  AND c.raw_document_id IS NULL
+                  AND EXISTS (
+                      SELECT 1
+                      FROM marketplace_raw_documents rd
+                      WHERE rd.company_id = :companyId
+                        AND rd.marketplace = :marketplace
+                        AND rd.document_type = 'sales_report'
+                        AND rd.period_from <= c.cost_date::date
+                        AND rd.period_to >= c.cost_date::date
+                  )
+            )
+            SELECT DISTINCT day
+            FROM (
+                SELECT day FROM duplicate_processed_days
+                UNION
+                SELECT day FROM duplicate_raw_days
+                UNION
+                SELECT day FROM legacy_processed_days
+            ) all_days
+            ORDER BY day ASC
+            SQL,
+            [
+                'companyId' => $companyId,
+                'fromDate' => $from->format('Y-m-d'),
+                'toDate' => $to->format('Y-m-d'),
+                'marketplace' => MarketplaceType::OZON->value,
+            ],
+        );
+
+        return array_map(
+            static fn (string $day): \DateTimeImmutable => new \DateTimeImmutable($day),
+            array_values($rows),
+        );
+    }
+
+    /** @return list<array{id:string, period_from:string, period_to:string, processing_status:?string, synced_at:string, records_count:int}> */
+    private function findRawDocumentsForDay(string $companyId, \DateTimeImmutable $day): array
+    {
+        return $this->connection->fetchAllAssociative(
+            <<<SQL
+            SELECT rd.id, rd.period_from, rd.period_to, rd.processing_status, rd.synced_at, rd.records_count
+            FROM marketplace_raw_documents rd
+            WHERE rd.company_id = :companyId
+              AND rd.marketplace = :marketplace
+              AND rd.document_type = 'sales_report'
+              AND rd.period_from <= :day
+              AND rd.period_to >= :day
+            SQL,
+            [
+                'companyId' => $companyId,
+                'day' => $day->format('Y-m-d'),
+                'marketplace' => MarketplaceType::OZON->value,
+            ],
+        );
+    }
+
+    private function chooseCanonical(array $rawDocuments): string
+    {
+        usort($rawDocuments, static function (array $left, array $right): int {
+            $leftDaily = $left['period_from'] === $left['period_to'];
+            $rightDaily = $right['period_from'] === $right['period_to'];
+            if ($leftDaily !== $rightDaily) {
+                return $leftDaily ? -1 : 1;
+            }
+
+            $statusRank = static function (?string $status): int {
+                return match ($status) {
+                    'completed' => 3,
+                    null => 2,
+                    'failed' => 1,
+                    'pending', 'running' => 0,
+                    default => 1,
+                };
+            };
+
+            $statusCmp = $statusRank($right['processing_status']) <=> $statusRank($left['processing_status']);
+            if ($statusCmp !== 0) {
+                return $statusCmp;
+            }
+
+            $syncedCmp = strtotime((string) $right['synced_at']) <=> strtotime((string) $left['synced_at']);
+            if ($syncedCmp !== 0) {
+                return $syncedCmp;
+            }
+
+            $recordsCmp = ((int) $right['records_count']) <=> ((int) $left['records_count']);
+            if ($recordsCmp !== 0) {
+                return $recordsCmp;
+            }
+
+            return strcmp((string) $left['id'], (string) $right['id']);
+        });
+
+        return (string) $rawDocuments[0]['id'];
+    }
+
+    private function countStaleRows(string $table, string $dateField, string $companyId, \DateTimeImmutable $day, string $canonicalRawDocumentId, bool $closed): int
+    {
+        return (int) $this->connection->fetchOne(
+            sprintf(
+                'SELECT COUNT(*) FROM %s t WHERE t.company_id = :companyId AND t.marketplace = :marketplace AND t.%s = :day AND %s',
+                $table,
+                $dateField,
+                $closed
+                    ? 't.document_id IS NOT NULL AND t.raw_document_id IS NOT NULL AND t.raw_document_id <> :canonicalRawDocumentId'
+                    : 't.document_id IS NULL AND (t.raw_document_id IS NULL OR t.raw_document_id <> :canonicalRawDocumentId)',
+            ),
+            [
+                'companyId' => $companyId,
+                'marketplace' => MarketplaceType::OZON->value,
+                'day' => $day->format('Y-m-d'),
+                'canonicalRawDocumentId' => $canonicalRawDocumentId,
+            ],
+        );
+    }
+
+    private function hasPendingOrRunningRawDocument(array $rawDocuments): bool
+    {
+        foreach ($rawDocuments as $rawDocument) {
+            if (in_array($rawDocument['processing_status'], ['pending', 'running'], true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function findRawDocumentStatusById(array $rawDocuments, string $rawDocumentId): ?string
+    {
+        foreach ($rawDocuments as $rawDocument) {
+            if ((string) $rawDocument['id'] !== $rawDocumentId) {
+                continue;
+            }
+
+            return $rawDocument['processing_status'] === null ? null : (string) $rawDocument['processing_status'];
+        }
+
+        return null;
+    }
+
+    /** @param list<string> $rawDocumentIds */
+    private function findSafeToDeleteRawDocuments(array $rawDocumentIds): array
+    {
+        if ($rawDocumentIds === []) {
+            return [];
+        }
+
+        $safe = [];
+        foreach ($rawDocumentIds as $rawDocumentId) {
+            $references = (int) $this->connection->fetchOne(
+                <<<SQL
+                SELECT
+                    (SELECT COUNT(*) FROM marketplace_sales s WHERE s.raw_document_id = :rawDocumentId)
+                  + (SELECT COUNT(*) FROM marketplace_returns r WHERE r.raw_document_id = :rawDocumentId)
+                  + (SELECT COUNT(*) FROM marketplace_costs c WHERE c.raw_document_id = :rawDocumentId)
+                SQL,
+                ['rawDocumentId' => $rawDocumentId],
+            );
+
+            if ($references === 0) {
+                $safe[] = $rawDocumentId;
+            }
+        }
+
+        return $safe;
+    }
+}

--- a/site/src/Marketplace/Command/OzonRawDuplicatesCleanupCommand.php
+++ b/site/src/Marketplace/Command/OzonRawDuplicatesCleanupCommand.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Command;
+
+use App\Marketplace\Application\Service\OzonRawDuplicatesCleanupExecutor;
+use App\Marketplace\Application\Service\OzonRawDuplicatesCleanupPlanner;
+use App\Marketplace\Message\ProcessDayReportMessage;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Webmozart\Assert\Assert;
+
+#[AsCommand(
+    name: 'app:marketplace:ozon-raw-duplicates-cleanup',
+    description: 'Prod-safe cleanup дублей Ozon raw/processed данных (dry-run by default).',
+)]
+final class OzonRawDuplicatesCleanupCommand extends Command
+{
+    public function __construct(
+        private readonly OzonRawDuplicatesCleanupPlanner $planner,
+        private readonly OzonRawDuplicatesCleanupExecutor $executor,
+        private readonly MessageBusInterface $messageBus,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'UUID компании (required)')
+            ->addOption('from', null, InputOption::VALUE_REQUIRED, 'Начало периода (YYYY-MM-DD, required)')
+            ->addOption('to', null, InputOption::VALUE_REQUIRED, 'Конец периода (YYYY-MM-DD, required)')
+            ->addOption('apply', null, InputOption::VALUE_NONE, 'Применить cleanup (без флага работает только dry-run)')
+            ->addOption('dispatch-reprocess', null, InputOption::VALUE_NONE, 'После apply dispatch ProcessDayReportMessage по canonical rawDoc');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $companyId = (string) $input->getOption('company-id');
+        $fromOption = (string) $input->getOption('from');
+        $toOption = (string) $input->getOption('to');
+        $apply = (bool) $input->getOption('apply');
+        $dispatchReprocess = (bool) $input->getOption('dispatch-reprocess');
+
+        if ($companyId === '' || $fromOption === '' || $toOption === '') {
+            $io->error('Опции --company-id, --from и --to обязательны.');
+
+            return Command::FAILURE;
+        }
+
+        try {
+            Assert::uuid($companyId);
+        } catch (\InvalidArgumentException) {
+            $io->error('Некорректный UUID в --company-id.');
+
+            return Command::FAILURE;
+        }
+
+        $from = $this->parseStrictDate($fromOption);
+        $to = $this->parseStrictDate($toOption);
+
+        if ($from === null || $to === null) {
+            $io->error('Неверный формат дат. Используйте YYYY-MM-DD.');
+
+            return Command::FAILURE;
+        }
+
+        if ($from > $to) {
+            $io->error('Опция --from должна быть меньше или равна --to.');
+
+            return Command::FAILURE;
+        }
+
+        $plan = $this->planner->buildPlan($companyId, $from, $to);
+
+        $io->title('Ozon raw duplicates cleanup plan');
+        $io->definitionList(
+            ['Mode' => $apply ? 'APPLY' : 'DRY-RUN'],
+            ['Company ID' => $companyId],
+            ['From' => $from->format('Y-m-d')],
+            ['To' => $to->format('Y-m-d')],
+            ['Affected days' => (string) count($plan->affectedDays)],
+        );
+
+        foreach ($plan->affectedDays as $dayPlan) {
+            $io->section($dayPlan->day->format('Y-m-d'));
+            $io->listing([
+                sprintf('canonicalRawDocumentId: %s', $dayPlan->canonicalRawDocumentId),
+                sprintf('duplicateRawDocumentIds: %s', $dayPlan->duplicateRawDocumentIds === [] ? '-' : implode(', ', $dayPlan->duplicateRawDocumentIds)),
+                sprintf('stale open rows (sales/returns/costs): %d / %d / %d', $dayPlan->staleSalesRowsCount, $dayPlan->staleReturnsRowsCount, $dayPlan->staleCostsRowsCount),
+                sprintf('closed rows (sales/returns/costs): %d / %d / %d', $dayPlan->closedSalesRowsCount, $dayPlan->closedReturnsRowsCount, $dayPlan->closedCostsRowsCount),
+                sprintf('canAutoCleanup: %s', $dayPlan->canAutoCleanup ? 'true' : 'false'),
+                sprintf('safe_to_delete_raw_docs (info only): %s', $dayPlan->safeToDeleteRawDocumentIds === [] ? '-' : implode(', ', $dayPlan->safeToDeleteRawDocumentIds)),
+            ]);
+
+            foreach ($dayPlan->warnings as $warning) {
+                $io->warning($warning);
+            }
+        }
+
+        $daysBlocked = array_filter($plan->affectedDays, static fn ($dayPlan): bool => !$dayPlan->canAutoCleanup);
+
+        $io->section('Summary');
+        $io->listing([
+            sprintf('days affected: %d', count($plan->affectedDays)),
+            sprintf('open rows to delete (sales/returns/costs): %d / %d / %d', $plan->totalStaleSalesRows(), $plan->totalStaleReturnsRows(), $plan->totalStaleCostsRows()),
+            sprintf('days blocked from auto-cleanup: %d', count($daysBlocked)),
+        ]);
+
+        if (!$apply) {
+            $io->success('Dry-run completed. Изменений в БД не выполнено. Добавьте --apply для применения cleanup.');
+
+            return Command::SUCCESS;
+        }
+
+        $result = $this->executor->execute($plan);
+
+        if ($dispatchReprocess) {
+            foreach ($result->cleanedCanonicalRawDocumentIds as $canonicalRawDocumentId) {
+                $this->messageBus->dispatch(new ProcessDayReportMessage($companyId, $canonicalRawDocumentId));
+            }
+        }
+
+        $io->success('Cleanup applied.');
+        $io->listing([
+            sprintf('deleted rows (sales/returns/costs): %d / %d / %d', $result->deletedSalesRows, $result->deletedReturnsRows, $result->deletedCostsRows),
+            sprintf('cleaned days: %d', $result->cleanedDaysCount),
+            sprintf('reprocess messages dispatched: %d', $dispatchReprocess ? count($result->cleanedCanonicalRawDocumentIds) : 0),
+            sprintf('canonical raw docs: %s', $result->cleanedCanonicalRawDocumentIds === [] ? '-' : implode(', ', $result->cleanedCanonicalRawDocumentIds)),
+        ]);
+
+        if (!$dispatchReprocess && $result->cleanedCanonicalRawDocumentIds !== []) {
+            $io->note('Для ручного reprocess используйте canonical raw docs из списка выше.');
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function parseStrictDate(string $value): ?\DateTimeImmutable
+    {
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
+
+        if ($date === false || $date->format('Y-m-d') !== $value) {
+            return null;
+        }
+
+        return $date;
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a safe, prod-friendly mechanism to detect and remove duplicate marketplace raw documents for Ozon and to clean stale processed rows while allowing a dry-run mode and optional reprocess dispatch.
- Centralize logic to choose canonical raw documents, detect safe-to-delete duplicates, and prevent auto-cleanup when documents are in pending/running/failed states or closed rows exist.

### Description

- Added DTOs `OzonRawDuplicatesCleanupPlan`, `OzonRawDuplicatesCleanupDayPlan`, and `OzonRawDuplicatesCleanupExecutionResult` to represent the plan, per-day details, and execution outcome.
- Implemented `OzonRawDuplicatesCleanupPlanner` with SQL queries to find affected days, list raw documents per day, choose canonical document via status/synced/records heuristics, count stale/closed rows, and detect safe-to-delete raw documents.
- Implemented `OzonRawDuplicatesCleanupExecutor` which performs transactional deletion of stale rows from `marketplace_sales`, `marketplace_returns`, and `marketplace_costs`, logs results, and returns an execution summary.
- Added Symfony console command `app:marketplace:ozon-raw-duplicates-cleanup` to perform dry-run or apply the cleanup and optionally dispatch `ProcessDayReportMessage` for cleaned canonical raw docs.

### Testing

- No automated tests were added for this change and no automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb2bd2388c832395d5fd0851be7534)