### PR TITLE
Add integration tests for Ozon raw-duplicates cleanup (planner, executor, command)

### DIFF
--- a/site/tests/Integration/Marketplace/Application/Service/OzonRawDuplicatesCleanupExecutorTest.php
+++ b/site/tests/Integration/Marketplace/Application/Service/OzonRawDuplicatesCleanupExecutorTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Marketplace\Application\Service;
+
+use App\Marketplace\Application\Service\OzonRawDuplicatesCleanupExecutor;
+use App\Marketplace\Application\Service\OzonRawDuplicatesCleanupPlanner;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceListingBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceRawDocumentBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceSaleBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+
+final class OzonRawDuplicatesCleanupExecutorTest extends IntegrationTestCase
+{
+    public function testRollbackOnFailureKeepsDataUnchanged(): void
+    {
+        $company = CompanyBuilder::aCompany()->withIndex(1200)->build();
+        $this->em->persist($company);
+        $listing = MarketplaceListingBuilder::aListing()->withIndex(1200)->forCompany($company)->withMarketplace(MarketplaceType::OZON)->build();
+        $this->em->persist($listing);
+        $day = new \DateTimeImmutable('2026-04-15');
+
+        $rawA = MarketplaceRawDocumentBuilder::aDocument()->withIndex(1201)->forCompany($company)->withMarketplace(MarketplaceType::OZON)->withDocumentType('sales_report')->withPeriod($day, $day)->withProcessingStatus('completed')->build();
+        $rawB = MarketplaceRawDocumentBuilder::aDocument()->withIndex(1202)->forCompany($company)->withMarketplace(MarketplaceType::OZON)->withDocumentType('sales_report')->withPeriod($day, $day)->withProcessingStatus('completed')->withSyncedAt($day->modify('+1 day'))->build();
+        $this->em->persist($rawA); $this->em->persist($rawB);
+
+        $saleA = MarketplaceSaleBuilder::aSale()->withIndex(1203)->forCompany($company)->forListing($listing)->withMarketplace(MarketplaceType::OZON)->withSaleDate($day)->build();
+        $saleA->setRawDocumentId($rawA->getId());
+        $saleB = MarketplaceSaleBuilder::aSale()->withIndex(1204)->forCompany($company)->forListing($listing)->withMarketplace(MarketplaceType::OZON)->withSaleDate($day)->build();
+        $saleB->setRawDocumentId($rawB->getId());
+        $this->em->persist($saleA); $this->em->persist($saleB);
+        $this->em->flush();
+
+        $this->em->getConnection()->insert('marketplace_returns', [
+            'id' => 'aaaaaaaa-aaaa-4aaa-8aaa-000000001200', 'company_id' => $company->getId(), 'listing_id' => $listing->getId(), 'marketplace' => MarketplaceType::OZON->value,
+            'return_date' => $day->format('Y-m-d'), 'quantity' => 1, 'refund_amount' => '1.00', 'raw_document_id' => $rawA->getId(), 'created_at' => '2026-04-15 00:00:00', 'updated_at' => '2026-04-15 00:00:00',
+        ]);
+        $this->em->getConnection()->insert('marketplace_costs', [
+            'id' => 'bbbbbbbb-bbbb-4bbb-8bbb-000000001200', 'company_id' => $company->getId(), 'marketplace' => MarketplaceType::OZON->value,
+            'amount' => '1.00', 'cost_date' => $day->format('Y-m-d'), 'raw_document_id' => $rawA->getId(), 'created_at' => '2026-04-15 00:00:00', 'updated_at' => '2026-04-15 00:00:00',
+        ]);
+
+        $conn = $this->em->getConnection();
+        $before = $this->counts($company->getId(), $day);
+        $conn->executeStatement('CREATE OR REPLACE FUNCTION test_fail_delete_returns() RETURNS trigger AS $$ BEGIN RAISE EXCEPTION \'forced failure\'; END; $$ LANGUAGE plpgsql');
+        $conn->executeStatement('CREATE TRIGGER trg_test_fail_delete_returns BEFORE DELETE ON marketplace_returns FOR EACH ROW EXECUTE FUNCTION test_fail_delete_returns()');
+
+        $planner = self::getContainer()->get(OzonRawDuplicatesCleanupPlanner::class);
+        $executor = self::getContainer()->get(OzonRawDuplicatesCleanupExecutor::class);
+        $plan = $planner->buildPlan($company->getId(), $day, $day);
+
+        $caught = null;
+
+        try {
+            $executor->execute($plan);
+        } catch (\Throwable $e) {
+            $caught = $e;
+        } finally {
+            $conn->executeStatement('DROP TRIGGER IF EXISTS trg_test_fail_delete_returns ON marketplace_returns');
+            $conn->executeStatement('DROP FUNCTION IF EXISTS test_fail_delete_returns()');
+        }
+
+        self::assertInstanceOf(\Throwable::class, $caught);
+        self::assertSame($before, $this->counts($company->getId(), $day));
+    }
+
+    private function counts(string $companyId, \DateTimeImmutable $day): array
+    {
+        $conn = $this->em->getConnection();
+
+        return [
+            'sales' => (int) $conn->fetchOne('SELECT COUNT(*) FROM marketplace_sales WHERE company_id=:c AND sale_date=:d', ['c' => $companyId, 'd' => $day->format('Y-m-d')]),
+            'returns' => (int) $conn->fetchOne('SELECT COUNT(*) FROM marketplace_returns WHERE company_id=:c AND return_date=:d', ['c' => $companyId, 'd' => $day->format('Y-m-d')]),
+            'costs' => (int) $conn->fetchOne('SELECT COUNT(*) FROM marketplace_costs WHERE company_id=:c AND cost_date=:d', ['c' => $companyId, 'd' => $day->format('Y-m-d')]),
+        ];
+    }
+}

--- a/site/tests/Integration/Marketplace/Application/Service/OzonRawDuplicatesCleanupPlannerTest.php
+++ b/site/tests/Integration/Marketplace/Application/Service/OzonRawDuplicatesCleanupPlannerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Marketplace\Application\Service;
+
+use App\Marketplace\Application\Service\OzonRawDuplicatesCleanupPlanner;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceRawDocumentBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+
+final class OzonRawDuplicatesCleanupPlannerTest extends IntegrationTestCase
+{
+    public function testCanonicalSelectionPrefersFreshCompletedDaily(): void
+    {
+        $company = CompanyBuilder::aCompany()->withIndex(401)->build();
+        $this->em->persist($company);
+
+        $day = new \DateTimeImmutable('2026-04-10');
+        $dailyOld = MarketplaceRawDocumentBuilder::aDocument()->withIndex(401)->forCompany($company)->withMarketplace(MarketplaceType::OZON)->withDocumentType('sales_report')->withPeriod($day, $day)->withProcessingStatus('completed')->withSyncedAt(new \DateTimeImmutable('2026-04-10 09:00:00'))->build();
+        $range = MarketplaceRawDocumentBuilder::aDocument()->withIndex(402)->forCompany($company)->withMarketplace(MarketplaceType::OZON)->withDocumentType('sales_report')->withPeriod(new \DateTimeImmutable('2026-04-01'), new \DateTimeImmutable('2026-04-30'))->withProcessingStatus('completed')->withSyncedAt(new \DateTimeImmutable('2026-04-11 10:00:00'))->build();
+        $dailyFresh = MarketplaceRawDocumentBuilder::aDocument()->withIndex(403)->forCompany($company)->withMarketplace(MarketplaceType::OZON)->withDocumentType('sales_report')->withPeriod($day, $day)->withProcessingStatus('completed')->withSyncedAt(new \DateTimeImmutable('2026-04-12 11:00:00'))->build();
+        $this->em->persist($dailyOld); $this->em->persist($range); $this->em->persist($dailyFresh);
+        $this->em->flush();
+
+        $planner = self::getContainer()->get(OzonRawDuplicatesCleanupPlanner::class);
+        $plan = $planner->buildPlan($company->getId(), new \DateTimeImmutable('2026-04-01'), new \DateTimeImmutable('2026-04-30'));
+
+        self::assertNotEmpty($plan->affectedDays);
+        $dayPlan = $plan->affectedDays[0];
+        self::assertSame($dailyFresh->getId(), $dayPlan->canonicalRawDocumentId);
+    }
+}

--- a/site/tests/Integration/Marketplace/Command/OzonRawDuplicatesCleanupCommandTest.php
+++ b/site/tests/Integration/Marketplace/Command/OzonRawDuplicatesCleanupCommandTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Marketplace\Command;
+
+use App\Company\Entity\Company;
+use App\Finance\Entity\Document;
+use App\Marketplace\Entity\MarketplaceCost;
+use App\Marketplace\Entity\MarketplaceReturn;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceListingBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceRawDocumentBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceSaleBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class OzonRawDuplicatesCleanupCommandTest extends IntegrationTestCase
+{
+    public function testDryRunDoesNotChangeData(): void
+    {
+        [$company, $day] = $this->seedDuplicateDay(true, 600);
+        $before = $this->counts($company->getId(), $day);
+
+        $tester = $this->tester();
+        $exit = $tester->execute(['--company-id' => $company->getId(), '--from' => '2026-04-15', '--to' => '2026-04-15']);
+        self::assertSame(Command::SUCCESS, $exit);
+
+        self::assertSame($before, $this->counts($company->getId(), $day));
+        self::assertStringContainsString('DRY-RUN', $tester->getDisplay());
+    }
+
+    public function testApplyDeletesOnlyOpenRowsAndCanDispatch(): void
+    {
+        [$company, $day, $canonicalRawId] = $this->seedDuplicateDay(true, 700);
+
+        $tester = $this->tester();
+        $exit = $tester->execute(['--company-id' => $company->getId(), '--from' => '2026-04-15', '--to' => '2026-04-15', '--apply' => true, '--dispatch-reprocess' => true]);
+        self::assertSame(Command::SUCCESS, $exit);
+
+        $counts = $this->counts($company->getId(), $day);
+        self::assertSame(1, $counts['sales']);
+        self::assertSame(0, $counts['returns']);
+        self::assertSame(0, $counts['costs']);
+
+        $conn = $this->em->getConnection();
+        self::assertSame($canonicalRawId, (string) $conn->fetchOne('SELECT raw_document_id FROM marketplace_sales WHERE company_id=:c AND sale_date=:d LIMIT 1', ['c' => $company->getId(), 'd' => $day->format('Y-m-d')]));
+
+        $out = $tester->getDisplay();
+        self::assertStringContainsString('deleted rows', $out);
+        self::assertStringContainsString('cleaned days: 1', $out);
+        self::assertStringContainsString('reprocess messages dispatched: 1', $out);
+        self::assertStringContainsString($canonicalRawId, $out);
+    }
+
+    public function testApplyDoesNotDeleteClosedRows(): void
+    {
+        [$company, $day] = $this->seedDuplicateDay(false, 800);
+
+        $before = $this->counts($company->getId(), $day);
+        $tester = $this->tester();
+        $exit = $tester->execute(['--company-id' => $company->getId(), '--from' => '2026-04-15', '--to' => '2026-04-15', '--apply' => true]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertSame($before, $this->counts($company->getId(), $day));
+        self::assertStringContainsString('canAutoCleanup: false', $tester->getDisplay());
+    }
+
+    public function testApplyDoesNotTouchAnotherCompany(): void
+    {
+        [$companyA, $day] = $this->seedDuplicateDay(true, 900);
+        [$companyB] = $this->seedDuplicateDay(true, 1000);
+
+        $beforeB = $this->counts($companyB->getId(), $day);
+        $tester = $this->tester();
+        $exit = $tester->execute(['--company-id' => $companyA->getId(), '--from' => '2026-04-15', '--to' => '2026-04-15', '--apply' => true]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertSame(['sales' => 1, 'returns' => 0, 'costs' => 0], $this->counts($companyA->getId(), $day));
+        self::assertSame($beforeB, $this->counts($companyB->getId(), $day));
+    }
+
+    public function testApplyDoesNotTouchRowsOutsideDateRange(): void
+    {
+        $company = CompanyBuilder::aCompany()->withIndex(1100)->build();
+        $this->em->persist($company);
+        $this->seedDuplicateDay(true, 1110, $company, new \DateTimeImmutable('2026-04-15'));
+        $this->seedDuplicateDay(true, 1120, $company, new \DateTimeImmutable('2026-04-20'));
+
+        $beforeOutside = $this->counts($company->getId(), new \DateTimeImmutable('2026-04-20'));
+        $tester = $this->tester();
+        $exit = $tester->execute(['--company-id' => $company->getId(), '--from' => '2026-04-15', '--to' => '2026-04-15', '--apply' => true]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertSame(['sales' => 1, 'returns' => 0, 'costs' => 0], $this->counts($company->getId(), new \DateTimeImmutable('2026-04-15')));
+        self::assertSame($beforeOutside, $this->counts($company->getId(), new \DateTimeImmutable('2026-04-20')));
+    }
+
+    private function seedDuplicateDay(bool $open, int $baseIndex = 600, ?Company $company = null, ?\DateTimeImmutable $day = null): array
+    {
+        $company ??= CompanyBuilder::aCompany()->withIndex($baseIndex)->build();
+        $this->em->persist($company);
+        $day ??= new \DateTimeImmutable('2026-04-15');
+
+        $listing = MarketplaceListingBuilder::aListing()->withIndex($baseIndex)->forCompany($company)->withMarketplace(MarketplaceType::OZON)->withMarketplaceSku(sprintf('oz-cleanup-%d', $baseIndex))->build();
+        $this->em->persist($listing);
+
+        $staleRaw = MarketplaceRawDocumentBuilder::aDocument()->withIndex($baseIndex + 1)->forCompany($company)->withMarketplace(MarketplaceType::OZON)->withDocumentType('sales_report')->withPeriod($day, $day)->withProcessingStatus('completed')->build();
+        $canonicalRaw = MarketplaceRawDocumentBuilder::aDocument()->withIndex($baseIndex + 2)->forCompany($company)->withMarketplace(MarketplaceType::OZON)->withDocumentType('sales_report')->withPeriod($day, $day)->withProcessingStatus('completed')->withSyncedAt($day->modify('+1 day'))->build();
+        $this->em->persist($staleRaw);
+        $this->em->persist($canonicalRaw);
+
+        $doc = null;
+        if (!$open) {
+            $doc = new Document(sprintf('77777777-7777-4777-8777-%012d', $baseIndex), $company);
+            $this->em->persist($doc);
+        }
+
+        $sale1 = MarketplaceSaleBuilder::aSale()->withIndex($baseIndex + 3)->forCompany($company)->forListing($listing)->withMarketplace(MarketplaceType::OZON)->withSaleDate($day)->withExternalOrderId(sprintf('cleanup-stale-%d', $baseIndex))->build();
+        $sale1->setRawDocumentId($staleRaw->getId());
+        if ($doc !== null) { $sale1->setDocument($doc); }
+
+        $sale2 = MarketplaceSaleBuilder::aSale()->withIndex($baseIndex + 4)->forCompany($company)->forListing($listing)->withMarketplace(MarketplaceType::OZON)->withSaleDate($day)->withExternalOrderId(sprintf('cleanup-canonical-%d', $baseIndex))->build();
+        $sale2->setRawDocumentId($canonicalRaw->getId());
+        $this->em->persist($sale1);
+        $this->em->persist($sale2);
+
+        $return = new MarketplaceReturn(sprintf('66666666-6666-4666-8666-%012d', $baseIndex), $company, $listing, MarketplaceType::OZON);
+        $return->setExternalReturnId(sprintf('cleanup-return-%d', $baseIndex))->setReturnDate($day)->setQuantity(1)->setRefundAmount('1.00')->setRawDocumentId($staleRaw->getId());
+        if ($doc !== null) { $return->setDocument($doc); }
+        $this->em->persist($return);
+
+        $cost = new MarketplaceCost(sprintf('55555555-5555-4555-8555-%012d', $baseIndex), $company, MarketplaceType::OZON);
+        $cost->setExternalId(sprintf('cleanup-cost-%d', $baseIndex))->setCostDate($day)->setAmount('1.00')->setRawDocumentId($staleRaw->getId());
+        if ($doc !== null) { $cost->setDocument($doc); }
+        $this->em->persist($cost);
+
+        $this->em->flush();
+
+        return [$company, $day, $canonicalRaw->getId()];
+    }
+
+    private function counts(string $companyId, \DateTimeImmutable $day): array
+    {
+        $conn = $this->em->getConnection();
+
+        return [
+            'sales' => (int) $conn->fetchOne('SELECT COUNT(*) FROM marketplace_sales WHERE company_id=:c AND sale_date=:d', ['c' => $companyId, 'd' => $day->format('Y-m-d')]),
+            'returns' => (int) $conn->fetchOne('SELECT COUNT(*) FROM marketplace_returns WHERE company_id=:c AND return_date=:d', ['c' => $companyId, 'd' => $day->format('Y-m-d')]),
+            'costs' => (int) $conn->fetchOne('SELECT COUNT(*) FROM marketplace_costs WHERE company_id=:c AND cost_date=:d', ['c' => $companyId, 'd' => $day->format('Y-m-d')]),
+        ];
+    }
+
+    private function tester(): CommandTester
+    {
+        $app = new Application(self::$kernel);
+
+        return new CommandTester($app->find('app:marketplace:ozon-raw-duplicates-cleanup'));
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure the Ozon raw-duplicates cleanup logic picks the correct canonical raw document for a day and cleans stale rows safely.
- Validate that the executor runs inside a transaction and fully rolls back on failure to keep data consistent.
- Verify the console command supports dry-run, applying changes, dispatching reprocess messages, and respects closed rows, company boundaries, and date ranges.

### Description
- Added `site/tests/Integration/Marketplace/Application/Service/OzonRawDuplicatesCleanupPlannerTest.php` to assert canonical selection prefers the freshest completed daily document.
- Added `site/tests/Integration/Marketplace/Application/Service/OzonRawDuplicatesCleanupExecutorTest.php` which seeds sales/returns/costs, installs a failing DB trigger to force an exception, runs the executor, and asserts a rollback left data unchanged.
- Added `site/tests/Integration/Marketplace/Command/OzonRawDuplicatesCleanupCommandTest.php` covering dry-run behavior, apply with reprocess dispatch, protection of closed rows, company isolation, and date-range scoping, and introduced `seedDuplicateDay`, `counts`, and `tester` helpers.
- Tests use existing builders and direct DB inserts and execute planner/executor services and the console command via the container and `CommandTester`.

### Testing
- Ran the new integration tests `OzonRawDuplicatesCleanupPlannerTest`, `OzonRawDuplicatesCleanupExecutorTest`, and `OzonRawDuplicatesCleanupCommandTest` using `php bin/phpunit`.
- All added tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb37787a0c8323be447c6bbca3444d)