### PR TITLE
Add DB guard against active duplicate Ozon sales_report raw documents

### DIFF
--- a/site/migrations/Version20260506113000.php
+++ b/site/migrations/Version20260506113000.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260506113000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add partial unique index for active Ozon sales_report raw documents by period with duplicate pre-check';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $duplicatesCount = (int) $this->connection->fetchOne(<<<'SQL'
+            SELECT COUNT(*)
+            FROM (
+                SELECT 1
+                FROM marketplace_raw_documents
+                WHERE marketplace = 'ozon'
+                  AND document_type = 'sales_report'
+                  AND (processing_status IS NULL OR processing_status <> 'failed')
+                GROUP BY company_id, marketplace, document_type, period_from, period_to
+                HAVING COUNT(*) > 1
+            ) duplicate_groups
+        SQL);
+
+        $this->abortIf(
+            $duplicatesCount > 0,
+            'Cannot create uniq_marketplace_raw_documents_active_period: active duplicate raw documents exist. Run app:marketplace:ozon-raw-duplicates-audit and cleanup first.'
+        );
+
+        $this->addSql(<<<'SQL'
+            CREATE UNIQUE INDEX uniq_marketplace_raw_documents_active_period
+            ON marketplace_raw_documents (company_id, marketplace, document_type, period_from, period_to)
+            WHERE marketplace = 'ozon'
+              AND document_type = 'sales_report'
+              AND (processing_status IS NULL OR processing_status <> 'failed')
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS uniq_marketplace_raw_documents_active_period');
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent exact duplicates of active Ozon `sales_report` rows in `marketplace_raw_documents` at the database level after diagnostics and cleanup.
- Minimize blast radius by scoping the protection to `marketplace = 'ozon'` and `document_type = 'sales_report'` so other marketplaces / document types are not affected.

### Description
- Added a new Doctrine migration `Version20260506113000` that creates a partial unique index `uniq_marketplace_raw_documents_active_period` on `(company_id, marketplace, document_type, period_from, period_to)` with the predicate limiting it to Ozon `sales_report` and active rows where `processing_status IS NULL OR processing_status <> 'failed'`.
- The migration performs a pre-check using `GROUP BY company_id, marketplace, document_type, period_from, period_to HAVING COUNT(*) > 1` restricted to the same Ozon + `sales_report` + active predicate and aborts with the clear message `Cannot create uniq_marketplace_raw_documents_active_period: active duplicate raw documents exist. Run app:marketplace:ozon-raw-duplicates-audit and cleanup first.` if duplicates are found.
- The `up()` creates the partial unique index only when the pre-check passes, and the `down()` removes it via `DROP INDEX IF EXISTS uniq_marketplace_raw_documents_active_period`.
- The index is intentionally scoped to Ozon `sales_report` to avoid impacting WB or other document types until their use cases are reviewed.

### Testing
- Ran a syntax check with `php -l site/migrations/Version20260506113000.php`, which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb3e996314832391d1171e3896134b)