### PR TITLE
Sort /marketplace raw document history by document period

### DIFF
--- a/site/src/Marketplace/Infrastructure/Query/RawDocumentsListQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/RawDocumentsListQuery.php
@@ -20,6 +20,10 @@ final readonly class RawDocumentsListQuery
         return $this->rawDocumentRepository->createQueryBuilder('d')
             ->where('d.company = :company')
             ->setParameter('company', $company)
-            ->orderBy('d.syncedAt', 'DESC');
+            ->orderBy('d.periodTo', 'DESC')
+            ->addOrderBy('d.periodFrom', 'DESC')
+            ->addOrderBy('d.marketplace', 'ASC')
+            ->addOrderBy('d.documentType', 'ASC')
+            ->addOrderBy('d.syncedAt', 'DESC');
     }
 }


### PR DESCRIPTION
### Motivation
- The sync history was ordered by technical sync timestamp (`syncedAt`), causing multiple daily documents reloaded in one run to appear grouped by sync time instead of by calendar period; the list must show documents by their actual data period.

### Description
- Replace the `ORDER BY` in `RawDocumentsListQuery::buildQueryBuilder` to `periodTo DESC, periodFrom DESC, marketplace ASC, documentType ASC, syncedAt DESC`, and do not change any UI, Twig, entity, migration, or processing logic.

### Testing
- Ran `php -l src/Marketplace/Infrastructure/Query/RawDocumentsListQuery.php` which reported no syntax errors (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb511b1c008323a9c253c29c48a83a)