### PR TITLE
test: protect legit _v2 duplicate behavior in Ozon sales raw processor

### DIFF
--- a/site/tests/Unit/Marketplace/Application/Processor/OzonSalesRawProcessorVersioningTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/OzonSalesRawProcessorVersioningTest.php
@@ -218,17 +218,33 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
     public function testDuplicateRowsAcrossTwoBatchesInOneRunArePreserved(): void
     {
         $processor = $this->buildProcessor(existingIds: []);
+        $rawDocumentId = '11111111-1111-1111-1111-111111111111';
 
         $processor->processBatch('company-1', MarketplaceType::OZON, [
             $this->makeOp('DUP', +1000, '2026-03-02 10:00:00'),
-        ], '11111111-1111-1111-1111-111111111111');
+        ], $rawDocumentId);
 
         $processor->processBatch('company-1', MarketplaceType::OZON, [
             $this->makeOp('DUP', +1100, '2026-03-02 10:05:00'),
-        ], '11111111-1111-1111-1111-111111111111');
+        ], $rawDocumentId);
 
         self::assertSame(['DUP', 'DUP_v2'], $this->getPersistedExternalIds());
         self::assertSame(2100.0, $this->getSumPersistedAccruals());
+
+        $processor->resetPerRunState();
+
+        $processor->processBatch('company-1', MarketplaceType::OZON, [
+            $this->makeOp('DUP', +1000, '2026-03-02 10:00:00'),
+        ], $rawDocumentId);
+
+        $processor->processBatch('company-1', MarketplaceType::OZON, [
+            $this->makeOp('DUP', +1100, '2026-03-02 10:05:00'),
+        ], $rawDocumentId);
+
+        self::assertSame(['DUP', 'DUP_v2'], $this->getPersistedExternalIds());
+        self::assertSame(2100.0, $this->getSumPersistedAccruals());
+        self::assertNotContains('DUP_v3', $this->getPersistedExternalIds());
+        self::assertNotContains('DUP_v4', $this->getPersistedExternalIds());
     }
 
     public function testExistingBaseKeyDoesNotCreateArtificialVersionOnSecondRow(): void


### PR DESCRIPTION
### Motivation
- Ensure that legitimate `_v2` suffixing for duplicate rows is preserved within a single `rawDocumentId`/run while preventing suffix accumulation across invocations (no `_v3`/`_v4`).

### Description
- Extended the unit test `site/tests/Unit/Marketplace/Application/Processor/OzonSalesRawProcessorVersioningTest.php` by updating `testDuplicateRowsAcrossTwoBatchesInOneRunArePreserved` to reuse a local `rawDocumentId`, call `resetPerRunState()`, reprocess the same document and assert that only `DUP` and `DUP_v2` exist and that `DUP_v3`/`DUP_v4` are not produced.

### Testing
- Attempted to run the test with `site/bin/phpunit` but execution failed due to a missing `simple-phpunit.php` from the Symfony PHPUnit bridge in the environment, so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc355e2d48832385f49289b24d3ea9)