### PR TITLE
test: prevent artificial versioning when base key exists in Ozon sales processor

### DIFF
--- a/site/tests/Unit/Marketplace/Application/Processor/OzonSalesRawProcessorVersioningTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/OzonSalesRawProcessorVersioningTest.php
@@ -73,6 +73,7 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
         ]);
 
         self::assertSame([], $this->getPersistedExternalIds());
+        self::assertNotContains('A_v2', $this->getPersistedExternalIds());
     }
 
     /**
@@ -259,6 +260,7 @@ final class OzonSalesRawProcessorVersioningTest extends TestCase
         self::assertSame([], $this->getPersistedExternalIds());
         self::assertSame(0.0, $this->getSumPersistedAccruals());
         self::assertNotContains('A_v2', $this->getPersistedExternalIds());
+        self::assertNotContains('A_v3', $this->getPersistedExternalIds());
     }
 
     public function testExistingStornoBaseKeyDoesNotCreateArtificialVersionOnSecondRow(): void


### PR DESCRIPTION
### Motivation
- Зафиксировать правило, что наличие базового external key в БД блокирует создание искусственного суффикса `_v2`/`_v3` и не используется процессором как обход уже существующей строки.

### Description
- В `site/tests/Unit/Marketplace/Application/Processor/OzonSalesRawProcessorVersioningTest.php` добавлена явная проверка в `testExistingInDbIsSkippedWithoutArtificialVersioning()` что `A_v2` не создаётся при `existingIds: ['A']`.
- В том же файле добавлена проверка в `testExistingBaseKeyDoesNotCreateArtificialVersionOnSecondRow()` что при двух входных строках и `existingIds: ['A']` ни `A_v2`, ни `A_v3` не появляются.

### Testing
- Попытки запустить таргетный тест через `php -d memory_limit=1G vendor/bin/phpunit site/tests/Unit/Marketplace/Application/Processor/OzonSalesRawProcessorVersioningTest.php` и через проектный wrapper `php -d memory_limit=1G site/bin/phpunit site/tests/Unit/Marketplace/Application/Processor/OzonSalesRawProcessorVersioningTest.php` завершились неудачей из-за отсутствия bootstrap для PHPUnit (`vendor/symfony/phpunit-bridge/bin/simple-phpunit.php` отсутствует), поэтому автоматические тесты не были выполнены.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc54c274648323aea2263b52a6f514)