### PR TITLE
Add Unit Extended regression test for Ozon raw-doc reprocess idempotency

### DIFF
--- a/site/tests/Integration/MarketplaceAnalytics/UnitExtendedQueryOzonRawReprocessRegressionTest.php
+++ b/site/tests/Integration/MarketplaceAnalytics/UnitExtendedQueryOzonRawReprocessRegressionTest.php
@@ -44,16 +44,23 @@ final class UnitExtendedQueryOzonRawReprocessRegressionTest extends IntegrationT
         $this->rawProcessor->resetPerRunState();
         $this->rawProcessor->processBatch(self::COMPANY_ID, MarketplaceType::OZON, $rawRows, $rawDocument->getId());
 
-        $firstImportRevenue = $this->getTotalRevenueFromSalesTable();
-        $firstImportRows = $this->countRawSalesRows($rawDocument->getId());
+        $firstQueryResult = $this->unitExtendedQuery->execute(
+            self::COMPANY_ID,
+            MarketplaceType::OZON->value,
+            self::PERIOD_FROM,
+            self::PERIOD_TO,
+            limit: 100,
+        );
 
-        self::assertEqualsWithDelta(15488951.02, $firstImportRevenue, 0.01, 'Санити-чек: первая обработка должна записать ожидаемую выручку.');
-        self::assertSame(1, $firstImportRows, 'Санити-чек: первая обработка должна записать одну строку продажи.');
+        $firstRevenue = (float) $firstQueryResult['totals']['revenue'];
+
+        self::assertEqualsWithDelta(15488951.02, $firstRevenue, 0.01, 'Санити-чек: первая обработка должна дать ожидаемую выручку в Unit Extended.');
+        self::assertSame(1, $this->countRawSalesRows($rawDocument->getId()), 'Санити-чек: первая обработка должна записать одну строку продажи.');
 
         $this->rawProcessor->resetPerRunState();
         $this->rawProcessor->processBatch(self::COMPANY_ID, MarketplaceType::OZON, $rawRows, $rawDocument->getId());
 
-        $queryResult = $this->unitExtendedQuery->execute(
+        $secondQueryResult = $this->unitExtendedQuery->execute(
             self::COMPANY_ID,
             MarketplaceType::OZON->value,
             self::PERIOD_FROM,
@@ -62,8 +69,8 @@ final class UnitExtendedQueryOzonRawReprocessRegressionTest extends IntegrationT
         );
 
         self::assertEqualsWithDelta(
-            15488951.02,
-            (float) $queryResult['totals']['revenue'],
+            $firstRevenue,
+            (float) $secondQueryResult['totals']['revenue'],
             0.01,
             'Регрессия: Unit Extended не должен показывать удвоенную выручку после повторной обработки того же raw-документа.',
         );
@@ -152,13 +159,6 @@ final class UnitExtendedQueryOzonRawReprocessRegressionTest extends IntegrationT
         );
     }
 
-    private function getTotalRevenueFromSalesTable(): float
-    {
-        return (float) $this->em->getConnection()->fetchOne(
-            'SELECT COALESCE(SUM(total_revenue), 0) FROM marketplace_sales WHERE company_id = :companyId',
-            ['companyId' => self::COMPANY_ID],
-        );
-    }
 
     /**
      * @return list<string>


### PR DESCRIPTION
### Motivation
- Защитить Unit Extended отчёт от регрессии, когда повторная обработка того же Ozon raw-документа могла удваивать выручку и порождать искусственные external_order_id с суффиксом `_v2`.

### Description
- Обновлён тест `site/tests/Integration/MarketplaceAnalytics/UnitExtendedQueryOzonRawReprocessRegressionTest.php`: после первой обработки теперь берётся `revenue` из `UnitExtendedQuery::execute`, сохраняется в `$firstRevenue`, затем вызывается `resetPerRunState()` и повторная обработка того же `raw_document_id`, после чего делается повторный `UnitExtendedQuery` и сравнение с `assertEqualsWithDelta(..., 0.01)`.
- Сохранены проверки идемпотентности данных: число строк в `marketplace_sales` по `raw_document_id` остаётся `1` и список `external_order_id` содержит только `OZON-POSTING-REG-1` без `_v2`.
- Убран вспомогательный метод, который суммировал выручку напрямую из таблицы (`getTotalRevenueFromSalesTable()`), чтобы фокус теста был на поведении бизнес-отчёта.

### Testing
- Попытка запустить тест через `php -d memory_limit=1G vendor/bin/phpunit site/tests/Integration/MarketplaceAnalytics/UnitExtendedQueryOzonRawReprocessRegressionTest.php` завершилась неудачей, так как `vendor/bin/phpunit` отсутствует в окружении.
- Попытка запустить тест из `site/` через `php -d memory_limit=1G bin/phpunit tests/Integration/MarketplaceAnalytics/UnitExtendedQueryOzonRawReprocessRegressionTest.php` завершилась неудачей из-за отсутствия `vendor/symfony/phpunit-bridge/bin/simple-phpunit.php` в этом окружении.
- В этом CI/локальном окружении автоматические интеграционные тесты не были успешно выполнены; изменения закоммичены в репозиторий и готовы к запуску в стандартном тестовом окружении.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc7ce345d88323995677b0856ee824)