### PR TITLE
Fix readonly mutation bug in DefaultCostMappingRuleSet

### DIFF
--- a/site/src/Marketplace/Application/DTO/DefaultCostMappingRuleSet.php
+++ b/site/src/Marketplace/Application/DTO/DefaultCostMappingRuleSet.php
@@ -16,11 +16,13 @@ final readonly class DefaultCostMappingRuleSet
         private MarketplaceType $marketplace,
         array $rules,
     ) {
-        $this->rulesByCostCode = [];
+        $rulesByCostCode = [];
 
         foreach ($rules as $rule) {
-            $this->rulesByCostCode[$rule->getCostCode()] = $rule;
+            $rulesByCostCode[$rule->getCostCode()] = $rule;
         }
+
+        $this->rulesByCostCode = $rulesByCostCode;
     }
 
     public function getMarketplace(): MarketplaceType


### PR DESCRIPTION
### Motivation
- Исправить падение `Cannot indirectly modify readonly property ...` из-за косвенной модификации readonly-свойства `$rulesByCostCode` в конструкторе DTO.

### Description
- В `DefaultCostMappingRuleSet` конструктор теперь сначала собирает правила в локальный массив `$rulesByCostCode`, а затем единожды присваивает его в ` $this->rulesByCostCode`, при этом публичный контракт DTO и порядок, возвращаемый `getRules()`, сохранены.

### Testing
- Запущены команды `php bin/phpunit tests/Unit/Marketplace/Infrastructure/Provider/DefaultCostMappingYamlProviderTest.php` и `php bin/phpunit --testsuite unit`, но обе завершились ошибкой окружения из-за отсутствия `vendor/symfony/phpunit-bridge/bin/simple-phpunit.php`, поэтому автоматические тесты не выполнились в этом рантайме.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc8b4a07f083239760d001f704bc8c)