### PR TITLE
Fix InitialSyncHandlerTest lock mock to SharedLockInterface

### DIFF
--- a/site/tests/Unit/Marketplace/MessageHandler/InitialSyncHandlerTest.php
+++ b/site/tests/Unit/Marketplace/MessageHandler/InitialSyncHandlerTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\Clock\MockClock;
 use Symfony\Component\Lock\LockFactory;
-use Symfony\Component\Lock\LockInterface;
+use Symfony\Component\Lock\SharedLockInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -392,7 +392,7 @@ final class InitialSyncHandlerTest extends TestCase
             return new Envelope($message);
         });
 
-        $lock = $this->createMock(LockInterface::class);
+        $lock = $this->createMock(SharedLockInterface::class);
         $lock->method('acquire')->willReturn($lockAcquired);
         $lock->method('release');
 


### PR DESCRIPTION
### Motivation
- Tests were failing with `IncompatibleReturnValueException` because the test mock returned `LockInterface` while `LockFactory::createLock()` expects `SharedLockInterface`, so the test helper needed to match the current Symfony contract.

### Description
- Replaced the import and mock creation in `site/tests/Unit/Marketplace/MessageHandler/InitialSyncHandlerTest.php` to use `SharedLockInterface` instead of `LockInterface` and kept the mock configured only for the methods the handler uses (`acquire()` and `release()`), leaving production code unchanged.

### Testing
- Attempted to run `php bin/phpunit tests/Unit/Marketplace/MessageHandler/InitialSyncHandlerTest.php` and `php bin/phpunit --testsuite unit`, but both commands could not run in this environment due to missing `vendor/symfony/phpunit-bridge/bin/simple-phpunit.php`, so automated tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc8d33d28883239dde3f217c25d348)