### PR TITLE
Introduce DispatchOzonAdLoadActionInterface and use it in OzonAdDailySyncCommand

### DIFF
--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -76,6 +76,7 @@ services:
     App\MarketplaceAds\Repository\AdChunkProgressRepositoryInterface: '@App\MarketplaceAds\Repository\AdChunkProgressRepository'
     App\MarketplaceAds\Repository\AdRawDocumentRepositoryInterface: '@App\MarketplaceAds\Repository\AdRawDocumentRepository'
     App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface: '@App\MarketplaceAds\Repository\AdLoadJobRepository'
+    App\MarketplaceAds\Application\DispatchOzonAdLoadActionInterface: '@App\MarketplaceAds\Application\DispatchOzonAdLoadAction'
 
     # ---------- Balance value providers ------------ #
     App\Balance\Provider\:

--- a/site/src/MarketplaceAds/Application/DispatchOzonAdLoadAction.php
+++ b/site/src/MarketplaceAds/Application/DispatchOzonAdLoadAction.php
@@ -28,7 +28,7 @@ use Doctrine\ORM\EntityManagerInterface;
  * удаляются — они обслуживают job'ы, дошедшие до `AdLoadJob(status=pending)`
  * ДО деплоя. Новые загрузки идут через Planner. Удаление — Task-11.9b.
  */
-final class DispatchOzonAdLoadAction
+final class DispatchOzonAdLoadAction implements DispatchOzonAdLoadActionInterface
 {
     /**
      * Ozon Performance API лимит — максимум 62 дня в POST `/statistics`

--- a/site/src/MarketplaceAds/Application/DispatchOzonAdLoadActionInterface.php
+++ b/site/src/MarketplaceAds/Application/DispatchOzonAdLoadActionInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Application;
+
+use App\MarketplaceAds\Entity\AdLoadJob;
+
+interface DispatchOzonAdLoadActionInterface
+{
+    public function __invoke(
+        string $companyId,
+        \DateTimeImmutable $dateFrom,
+        \DateTimeImmutable $dateTo,
+    ): AdLoadJob;
+}

--- a/site/src/MarketplaceAds/Command/OzonAdDailySyncCommand.php
+++ b/site/src/MarketplaceAds/Command/OzonAdDailySyncCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\MarketplaceAds\Command;
 
-use App\MarketplaceAds\Application\DispatchOzonAdLoadAction;
+use App\MarketplaceAds\Application\DispatchOzonAdLoadActionInterface;
 use App\MarketplaceAds\Infrastructure\Query\ActiveOzonPerformanceConnectionsQuery;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Cron: 30 4 * * * php bin/console app:marketplace-ads:ozon-daily-sync
  *
  * Команда тонкая: получает список активных Ozon Performance подключений через DBAL Query,
- * для каждой компании вызывает {@see DispatchOzonAdLoadAction} с датой = «вчера».
+ * для каждой компании вызывает {@see DispatchOzonAdLoadActionInterface} с датой = «вчера».
  * Ошибки отдельной компании не должны прерывать обработку остальных.
  */
 #[AsCommand(
@@ -30,7 +30,7 @@ final class OzonAdDailySyncCommand extends Command
 {
     public function __construct(
         private readonly ActiveOzonPerformanceConnectionsQuery $connectionsQuery,
-        private readonly DispatchOzonAdLoadAction $dispatchAction,
+        private readonly DispatchOzonAdLoadActionInterface $dispatchAction,
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct();

--- a/site/tests/Unit/MarketplaceAds/Command/OzonAdDailySyncCommandTest.php
+++ b/site/tests/Unit/MarketplaceAds/Command/OzonAdDailySyncCommandTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\MarketplaceAds\Command;
 
 use App\Marketplace\Enum\MarketplaceType;
-use App\MarketplaceAds\Application\DispatchOzonAdLoadAction;
+use App\MarketplaceAds\Application\DispatchOzonAdLoadActionInterface;
 use App\MarketplaceAds\Command\OzonAdDailySyncCommand;
 use App\MarketplaceAds\Entity\AdLoadJob;
 use App\MarketplaceAds\Infrastructure\Query\ActiveOzonPerformanceConnectionsQuery;
@@ -28,7 +28,7 @@ final class OzonAdDailySyncCommandTest extends TestCase
         $query = $this->createMock(ActiveOzonPerformanceConnectionsQuery::class);
         $query->method('getCompanyIds')->willReturn($companyIds);
 
-        $action = $this->createMock(DispatchOzonAdLoadAction::class);
+        $action = $this->createMock(DispatchOzonAdLoadActionInterface::class);
 
         $receivedCompanies = [];
         $action
@@ -63,7 +63,7 @@ final class OzonAdDailySyncCommandTest extends TestCase
         $query = $this->createMock(ActiveOzonPerformanceConnectionsQuery::class);
         $query->method('getCompanyIds')->willReturn([]);
 
-        $action = $this->createMock(DispatchOzonAdLoadAction::class);
+        $action = $this->createMock(DispatchOzonAdLoadActionInterface::class);
         $action->expects(self::never())->method('__invoke');
 
         $logger = $this->createMock(LoggerInterface::class);
@@ -82,7 +82,7 @@ final class OzonAdDailySyncCommandTest extends TestCase
         $query = $this->createMock(ActiveOzonPerformanceConnectionsQuery::class);
         $query->method('getCompanyIds')->willReturn($companyIds);
 
-        $action = $this->createMock(DispatchOzonAdLoadAction::class);
+        $action = $this->createMock(DispatchOzonAdLoadActionInterface::class);
         $received = [];
         $action
             ->expects(self::exactly(3))
@@ -115,7 +115,7 @@ final class OzonAdDailySyncCommandTest extends TestCase
         $query = $this->createMock(ActiveOzonPerformanceConnectionsQuery::class);
         $query->method('getCompanyIds')->willReturn($companyIds);
 
-        $action = $this->createMock(DispatchOzonAdLoadAction::class);
+        $action = $this->createMock(DispatchOzonAdLoadActionInterface::class);
         $received = [];
         $action
             ->expects(self::exactly(3))
@@ -143,7 +143,7 @@ final class OzonAdDailySyncCommandTest extends TestCase
 
     private function makeTester(
         ActiveOzonPerformanceConnectionsQuery $query,
-        DispatchOzonAdLoadAction $action,
+        DispatchOzonAdLoadActionInterface $action,
         LoggerInterface $logger,
     ): CommandTester {
         $command = new OzonAdDailySyncCommand($query, $action, $logger);


### PR DESCRIPTION
### Motivation
- PHPUnit tests attempted to `createMock()` a `final` action (`DispatchOzonAdLoadAction`) which causes `ClassIsFinalException` and breaks `OzonAdDailySyncCommandTest` runs. 
- Provide a stable, testable contract so tests can mock the action while keeping the production action class `final` and preserving business logic.

### Description
- Added `DispatchOzonAdLoadActionInterface` with `__invoke(string, \DateTimeImmutable, \DateTimeImmutable): AdLoadJob` as the action contract (`site/src/MarketplaceAds/Application/DispatchOzonAdLoadActionInterface.php`).
- Updated `DispatchOzonAdLoadAction` to `implement DispatchOzonAdLoadActionInterface` without changing its business logic (`site/src/MarketplaceAds/Application/DispatchOzonAdLoadAction.php`).
- Switched `OzonAdDailySyncCommand` to depend on the interface instead of the concrete class and updated its phpdoc reference to the interface (`site/src/MarketplaceAds/Command/OzonAdDailySyncCommand.php`).
- Updated `OzonAdDailySyncCommandTest` to mock `DispatchOzonAdLoadActionInterface` instead of the final class and adjusted type hints/imports accordingly (`site/tests/Unit/MarketplaceAds/Command/OzonAdDailySyncCommandTest.php`).
- Added a DI alias in `site/config/services.yaml` to bind the interface to the implementation so the container resolves the service (`App\MarketplaceAds\Application\DispatchOzonAdLoadActionInterface: '@App\MarketplaceAds\Application\DispatchOzonAdLoadAction'`).

### Testing
- Ran the targeted unit test command `php bin/phpunit tests/Unit/MarketplaceAds/Command/OzonAdDailySyncCommandTest.php`, which failed to execute in this environment due to a missing `vendor/symfony/phpunit-bridge/bin/simple-phpunit.php` (environment dependency issue).
- Ran `php bin/console lint:container`, which could not run because project dependencies are not installed (`composer install` required), so container validation was not performed here.
- Ran `php bin/phpunit --testsuite unit`, which also could not run for the same missing `simple-phpunit.php` dependency; the test updates are designed to remove the `final`-mocking error and should allow the four previously failing tests to pass when run in a fully provisioned environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc8f121d408323b3eeb5277ed5a225)