### PR TITLE
Introduce AdDocumentQueryInterface and update facade/tests to avoid mocking final class

### DIFF
--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -77,6 +77,7 @@ services:
     App\MarketplaceAds\Repository\AdRawDocumentRepositoryInterface: '@App\MarketplaceAds\Repository\AdRawDocumentRepository'
     App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface: '@App\MarketplaceAds\Repository\AdLoadJobRepository'
     App\MarketplaceAds\Application\DispatchOzonAdLoadActionInterface: '@App\MarketplaceAds\Application\DispatchOzonAdLoadAction'
+    App\MarketplaceAds\Infrastructure\Query\AdDocumentQueryInterface: '@App\MarketplaceAds\Infrastructure\Query\AdDocumentQuery'
 
     # ---------- Balance value providers ------------ #
     App\Balance\Provider\:

--- a/site/src/MarketplaceAds/Facade/MarketplaceAdsFacade.php
+++ b/site/src/MarketplaceAds/Facade/MarketplaceAdsFacade.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\MarketplaceAds\Facade;
 
 use App\MarketplaceAds\Application\DTO\AdCostForListingDTO;
-use App\MarketplaceAds\Infrastructure\Query\AdDocumentQuery;
+use App\MarketplaceAds\Infrastructure\Query\AdDocumentQueryInterface;
 use App\MarketplaceAds\Infrastructure\Query\AdSpendByListingQuery;
 
 /**
@@ -20,7 +20,7 @@ use App\MarketplaceAds\Infrastructure\Query\AdSpendByListingQuery;
 final readonly class MarketplaceAdsFacade
 {
     public function __construct(
-        private AdDocumentQuery $adDocumentQuery,
+        private AdDocumentQueryInterface $adDocumentQuery,
         private AdSpendByListingQuery $adSpendByListingQuery,
     ) {
     }

--- a/site/src/MarketplaceAds/Infrastructure/Query/AdDocumentQuery.php
+++ b/site/src/MarketplaceAds/Infrastructure/Query/AdDocumentQuery.php
@@ -14,7 +14,7 @@ use Doctrine\DBAL\Connection;
  * Работает напрямую с DBAL (без ORM hydration) — таблицы только читаются,
  * никаких изменений здесь не происходит.
  */
-final readonly class AdDocumentQuery
+final readonly class AdDocumentQuery implements AdDocumentQueryInterface
 {
     public function __construct(
         private Connection $connection,

--- a/site/src/MarketplaceAds/Infrastructure/Query/AdDocumentQueryInterface.php
+++ b/site/src/MarketplaceAds/Infrastructure/Query/AdDocumentQueryInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Infrastructure\Query;
+
+use App\MarketplaceAds\Application\DTO\AdCostForListingDTO;
+
+interface AdDocumentQueryInterface
+{
+    /**
+     * @return AdCostForListingDTO[]
+     */
+    public function findCostsForListingAndDate(
+        string $companyId,
+        string $listingId,
+        \DateTimeImmutable $date,
+    ): array;
+
+    /**
+     * @return string decimal-строка, например "1234.56"; "0" если данных нет.
+     */
+    public function sumTotalCostForPeriod(
+        string $companyId,
+        \DateTimeImmutable $dateFrom,
+        \DateTimeImmutable $dateTo,
+        ?string $marketplace = null,
+    ): string;
+}

--- a/site/tests/Unit/MarketplaceAds/Facade/MarketplaceAdsFacadeTest.php
+++ b/site/tests/Unit/MarketplaceAds/Facade/MarketplaceAdsFacadeTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\MarketplaceAds\Facade;
 
 use App\MarketplaceAds\Facade\MarketplaceAdsFacade;
-use App\MarketplaceAds\Infrastructure\Query\AdDocumentQuery;
+use App\MarketplaceAds\Infrastructure\Query\AdDocumentQueryInterface;
 use App\MarketplaceAds\Infrastructure\Query\AdSpendByListingQuery;
 use PHPUnit\Framework\TestCase;
 
@@ -30,7 +30,7 @@ final class MarketplaceAdsFacadeTest extends TestCase
             ->with($companyId, $from, $to, $marketplace)
             ->willReturn($expected);
 
-        $adDocumentQuery = $this->createMock(AdDocumentQuery::class);
+        $adDocumentQuery = $this->createMock(AdDocumentQueryInterface::class);
         $adDocumentQuery->expects(self::never())->method(self::anything());
 
         $facade = new MarketplaceAdsFacade($adDocumentQuery, $adSpendByListingQuery);
@@ -53,7 +53,7 @@ final class MarketplaceAdsFacadeTest extends TestCase
             ->with($companyId, $from, $to, null)
             ->willReturn([]);
 
-        $adDocumentQuery = $this->createMock(AdDocumentQuery::class);
+        $adDocumentQuery = $this->createMock(AdDocumentQueryInterface::class);
 
         $facade = new MarketplaceAdsFacade($adDocumentQuery, $adSpendByListingQuery);
 


### PR DESCRIPTION
### Motivation
- Unit tests were failing because `AdDocumentQuery` is declared `final` and PHPUnit cannot create a mock for it, causing `ClassIsFinalException` in `MarketplaceAdsFacadeTest`.
- The facade currently depends on a concrete final query class which prevents stable testing and DI mocking.

### Description
- Added `AdDocumentQueryInterface` with the existing read-contract methods `findCostsForListingAndDate` and `sumTotalCostForPeriod`.
- Made `AdDocumentQuery` implement `AdDocumentQueryInterface` without changing any query logic or behaviour.
- Updated `MarketplaceAdsFacade` to depend on `AdDocumentQueryInterface` instead of the concrete `AdDocumentQuery`.
- Updated `MarketplaceAdsFacadeTest` to mock `AdDocumentQueryInterface` instead of the final class, and added a service alias in `site/config/services.yaml` to wire `AdDocumentQueryInterface` to `AdDocumentQuery` for autowiring (`App\MarketplaceAds\Infrastructure\Query\AdDocumentQueryInterface: '@App\MarketplaceAds\Infrastructure\Query\AdDocumentQuery'`).

### Testing
- Attempted to run `php bin/phpunit tests/Unit/MarketplaceAds/Facade/MarketplaceAdsFacadeTest.php`, but execution failed due to missing `vendor/symfony/phpunit-bridge/bin/simple-phpunit.php` so the test could not be executed in this environment.
- Attempted `php bin/console lint:container`, but it failed because project dependencies are not installed (`composer install` required), so container linting could not complete.
- Attempted `php bin/phpunit --testsuite unit`, but it also failed for the same missing dependencies, therefore automated test-suite run could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcb7ce22308323957ac17721ab2f30)