### PR TITLE
Align DefaultCostMappingSeedPolicyTest with repository contract

### DIFF
--- a/site/tests/Unit/MarketplaceAnalytics/Domain/Service/DefaultCostMappingSeedPolicyTest.php
+++ b/site/tests/Unit/MarketplaceAnalytics/Domain/Service/DefaultCostMappingSeedPolicyTest.php
@@ -21,9 +21,9 @@ final class DefaultCostMappingSeedPolicyTest extends TestCase
         $saved = [];
 
         $repo = $this->createMock(UnitEconomyCostMappingRepositoryInterface::class);
-        $repo->method('hasCompanyMappings')
-            ->with(self::COMPANY_ID, MarketplaceType::WILDBERRIES)
-            ->willReturn(false);
+        $repo->method('findByCompanyAndMarketplace')
+            ->with(self::COMPANY_ID, MarketplaceType::WILDBERRIES->value)
+            ->willReturn([]);
         $repo->method('save')
             ->willReturnCallback(static function (UnitEconomyCostMapping $mapping) use (&$saved): void {
                 $saved[] = $mapping;
@@ -35,16 +35,19 @@ final class DefaultCostMappingSeedPolicyTest extends TestCase
         self::assertCount(6, $saved);
 
         foreach ($saved as $mapping) {
-            self::assertTrue($mapping->isSystem());
+            self::assertSame(self::COMPANY_ID, $mapping->getCompanyId());
+            self::assertSame(MarketplaceType::WILDBERRIES, $mapping->getMarketplace());
         }
     }
 
     public function testSeedIsIdempotent(): void
     {
         $repo = $this->createMock(UnitEconomyCostMappingRepositoryInterface::class);
-        $repo->method('hasCompanyMappings')
-            ->with(self::COMPANY_ID, MarketplaceType::WILDBERRIES)
-            ->willReturn(true);
+        $repo->method('findByCompanyAndMarketplace')
+            ->with(self::COMPANY_ID, MarketplaceType::WILDBERRIES->value)
+            ->willReturn([
+                $this->createMock(UnitEconomyCostMapping::class),
+            ]);
         $repo->expects(self::never())->method('save');
 
         $policy = new DefaultCostMappingSeedPolicy($repo);
@@ -56,7 +59,7 @@ final class DefaultCostMappingSeedPolicyTest extends TestCase
         $saved = [];
 
         $repo = $this->createMock(UnitEconomyCostMappingRepositoryInterface::class);
-        $repo->method('hasCompanyMappings')->willReturn(false);
+        $repo->method('findByCompanyAndMarketplace')->willReturn([]);
         $repo->method('save')
             ->willReturnCallback(static function (UnitEconomyCostMapping $mapping) use (&$saved): void {
                 $saved[] = $mapping;
@@ -65,16 +68,16 @@ final class DefaultCostMappingSeedPolicyTest extends TestCase
         $policy = new DefaultCostMappingSeedPolicy($repo);
         $policy->seedForCompanyAndMarketplace(self::COMPANY_ID, self::MARKETPLACE);
 
-        $typesByCode = [];
+        $typesByCategoryName = [];
         foreach ($saved as $mapping) {
-            $typesByCode[$mapping->getCostCategoryCode()] = $mapping->getUnitEconomyCostType();
+            $typesByCategoryName[$mapping->getCostCategoryName()] = $mapping->getUnitEconomyCostType();
         }
 
-        self::assertSame(UnitEconomyCostType::ADVERTISING_CPC, $typesByCode['advertising_cpc']);
-        self::assertSame(UnitEconomyCostType::ADVERTISING_OTHER, $typesByCode['advertising_other']);
-        self::assertSame(UnitEconomyCostType::LOGISTICS_TO, $typesByCode['logistics_delivery']);
-        self::assertSame(UnitEconomyCostType::LOGISTICS_BACK, $typesByCode['logistics_return']);
-        self::assertSame(UnitEconomyCostType::STORAGE, $typesByCode['storage']);
-        self::assertSame(UnitEconomyCostType::COMMISSION, $typesByCode['commission']);
+        self::assertSame(UnitEconomyCostType::ADVERTISING_CPC, $typesByCategoryName['Реклама (CPC)']);
+        self::assertSame(UnitEconomyCostType::ADVERTISING_OTHER, $typesByCategoryName['Реклама (прочая)']);
+        self::assertSame(UnitEconomyCostType::LOGISTICS_TO, $typesByCategoryName['Логистика (доставка)']);
+        self::assertSame(UnitEconomyCostType::LOGISTICS_BACK, $typesByCategoryName['Логистика (возврат)']);
+        self::assertSame(UnitEconomyCostType::STORAGE, $typesByCategoryName['Хранение']);
+        self::assertSame(UnitEconomyCostType::COMMISSION, $typesByCategoryName['Комиссия']);
     }
 }


### PR DESCRIPTION
### Motivation
- Tests were failing because they tried to mock a non-existent `hasCompanyMappings()` method while production code uses `findByCompanyAndMarketplace()` to check existing mappings. 
- The goal is to keep the original business intent (seed when no mappings, idempotency, and correct mapping types) while matching the actual repository contract used by `DefaultCostMappingSeedPolicy`.

### Description
- Replaced all uses of the removed `hasCompanyMappings()` mock with `findByCompanyAndMarketplace()` and matched the production-call signature (`companyId` and `MarketplaceType::...->value`).
- Kept the idempotency scenario by returning a non-empty array from `findByCompanyAndMarketplace()` and asserting that `save()` is never called.
- Updated creation assertions to inspect the real `UnitEconomyCostMapping` fields by asserting `getCompanyId()` and `getMarketplace()` on created entities and to validate types via `costCategoryName -> unitEconomyCostType` mappings instead of legacy `costCategoryCode`/`isSystem()` checks.
- No production code was changed and no compatibility shims (like re-adding `hasCompanyMappings()`) were introduced.

### Testing
- Attempted to run the focused test with `php bin/phpunit tests/Unit/MarketplaceAnalytics/Domain/Service/DefaultCostMappingSeedPolicyTest.php`, but it failed to run in this environment because the Symfony PHPUnit Bridge bootstrap `vendor/symfony/phpunit-bridge/bin/simple-phpunit.php` is missing.
- Attempted to run the full unit suite with `php bin/phpunit --testsuite unit`, and it failed for the same missing bootstrap script.
- The change is limited to unit tests and should pass in a normal developer environment where `simple-phpunit.php` (Symfony PHPUnit Bridge) is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcbbf850408323b7365fbad97c90da)