### PR TITLE
Stabilize TriggerInitialSyncHandler timezone-sensitive date assertions

### DIFF
--- a/site/tests/Unit/Marketplace/MessageHandler/TriggerInitialSyncHandlerTest.php
+++ b/site/tests/Unit/Marketplace/MessageHandler/TriggerInitialSyncHandlerTest.php
@@ -47,8 +47,12 @@ final class TriggerInitialSyncHandlerTest extends TestCase
         $partitionService->expects(self::once())
             ->method('buildPartitions')
             ->with(
-                self::equalTo(new \DateTimeImmutable('2026-01-10 00:00:00')),
-                self::equalTo(new \DateTimeImmutable('2026-03-11 00:00:00')),
+                self::callback(static function (\DateTimeImmutable $date): bool {
+                    return '2026-01-10 00:00:00' === $date->format('Y-m-d H:i:s');
+                }),
+                self::callback(static function (\DateTimeImmutable $date): bool {
+                    return '2026-03-11 00:00:00' === $date->format('Y-m-d H:i:s');
+                }),
             )
             ->willReturn([
                 ['from' => '2026-01-10 00:00:00', 'to' => '2026-01-19 23:59:59'],
@@ -95,8 +99,12 @@ final class TriggerInitialSyncHandlerTest extends TestCase
         $partitionService->expects(self::once())
             ->method('buildPartitions')
             ->with(
-                self::equalTo(new \DateTimeImmutable('2026-01-01 00:00:00')),
-                self::equalTo(new \DateTimeImmutable('2026-04-29 00:00:00')),
+                self::callback(static function (\DateTimeImmutable $date): bool {
+                    return '2026-01-01 00:00:00' === $date->format('Y-m-d H:i:s');
+                }),
+                self::callback(static function (\DateTimeImmutable $date): bool {
+                    return '2026-04-29 00:00:00' === $date->format('Y-m-d H:i:s');
+                }),
             )
             ->willReturn([
                 ['from' => '2026-01-01 00:00:00', 'to' => '2026-01-11 23:59:59'],


### PR DESCRIPTION
### Motivation
- The unit test `TriggerInitialSyncHandlerTest::testNonWbDoesNotCallResolverAndUsesYearStartUntilYesterday` was flaky because it compared full `DateTimeImmutable` objects (including timezone), while business intent is to assert calendar dates.

### Description
- Replaced strict `self::equalTo(new \DateTimeImmutable(...))` matchers with `self::callback(...)` matchers that compare the calendar datetime string via `$date->format('Y-m-d H:i:s')` for both `from` and `to` arguments in `buildPartitions()` in `site/tests/Unit/Marketplace/MessageHandler/TriggerInitialSyncHandlerTest.php`, applying the same change to the analogous WB test; this is a test-only change and production code was not modified.

### Testing
- Attempted to run the single failing test with `php bin/phpunit tests/Unit/Marketplace/MessageHandler/TriggerInitialSyncHandlerTest.php --filter testNonWbDoesNotCallResolverAndUsesYearStartUntilYesterday`, but it could not run in this environment due to missing `vendor/symfony/phpunit-bridge/bin/simple-phpunit.php` (failure to execute tests).
- Attempted to run the whole test file with `php bin/phpunit tests/Unit/Marketplace/MessageHandler/TriggerInitialSyncHandlerTest.php`, but it also failed for the same missing bridge script.
- Attempted `make site-test-unit`, but it failed here due to missing `docker-compose`; please run CI or local test suite to confirm green build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd6e4db8a083238afb35dd62259775)