### PR TITLE
Make UnitExtendedQuery Ozon reprocess regression test idempotent

### DIFF
--- a/site/tests/Integration/MarketplaceAnalytics/UnitExtendedQueryOzonRawReprocessRegressionTest.php
+++ b/site/tests/Integration/MarketplaceAnalytics/UnitExtendedQueryOzonRawReprocessRegressionTest.php
@@ -33,6 +33,7 @@ final class UnitExtendedQueryOzonRawReprocessRegressionTest extends IntegrationT
         $this->unitExtendedQuery = self::getContainer()->get(UnitExtendedQuery::class);
         $this->rawProcessor = self::getContainer()->get(OzonSalesRawProcessor::class);
 
+        $this->cleanupTestData();
         $this->seedCompanyAndListing();
     }
 
@@ -85,6 +86,37 @@ final class UnitExtendedQueryOzonRawReprocessRegressionTest extends IntegrationT
             ['OZON-POSTING-REG-1'],
             $this->getExternalOrderIds($rawDocument->getId()),
             'Регрессия: после повторной обработки должен остаться только базовый external_order_id без _v2.',
+        );
+    }
+
+
+    private function cleanupTestData(): void
+    {
+        $connection = $this->em->getConnection();
+
+        $connection->executeStatement(
+            'DELETE FROM marketplace_sales WHERE company_id = :companyId',
+            ['companyId' => self::COMPANY_ID],
+        );
+
+        $connection->executeStatement(
+            'DELETE FROM marketplace_raw_documents WHERE company_id = :companyId',
+            ['companyId' => self::COMPANY_ID],
+        );
+
+        $connection->executeStatement(
+            'DELETE FROM marketplace_listings WHERE company_id = :companyId OR sku = :sku',
+            ['companyId' => self::COMPANY_ID, 'sku' => self::LISTING_SKU],
+        );
+
+        $connection->executeStatement(
+            'DELETE FROM company WHERE id = :companyId',
+            ['companyId' => self::COMPANY_ID],
+        );
+
+        $connection->executeStatement(
+            'DELETE FROM "user" WHERE id = :ownerId',
+            ['ownerId' => self::OWNER_ID],
         );
     }
 


### PR DESCRIPTION
### Motivation
- The integration test `UnitExtendedQueryOzonRawReprocessRegressionTest` used fixed IDs/SKU and failed on repeated runs with a `duplicate key value violates unique constraint "user_pkey"` error because seed data was re-inserted into a persistent test DB.
- The intent is to make this test isolated and repeatable without touching production code or business logic.

### Description
- Added a call to `cleanupTestData()` in `setUp()` before `seedCompanyAndListing()` in `tests/Integration/MarketplaceAnalytics/UnitExtendedQueryOzonRawReprocessRegressionTest.php`.
- Implemented `private function cleanupTestData(): void` which executes targeted `DELETE` statements against the test fixtures only, in an FK-safe order: `marketplace_sales` → `marketplace_raw_documents` → `marketplace_listings` → `company` → `"user"` (filters use `COMPANY_ID`, `OWNER_ID` and `LISTING_SKU`).
- Kept all production code unchanged and limited the fix to the integration test file only.

### Testing
- Attempted to run the requested integration test via `docker-compose run --rm site-php-cli php -d memory_limit=1G bin/phpunit tests/Integration/MarketplaceAnalytics/UnitExtendedQueryOzonRawReprocessRegressionTest.php`, but the environment lacks `docker`/`docker-compose` so PHPUnit could not be executed.
- Also attempted the unit test `tests/Unit/Marketplace/Application/Processor/OzonSalesRawProcessorVersioningTest.php` via the same Docker command and it could not be run for the same reason.
- The change was committed locally (`Make Ozon raw reprocess regression test re-runnable`) and the diff touches only the single integration test file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd7b225328832396c25ccd84db1add)