### PR TITLE
Fix cleanup query in UnitExtendedQuery Ozon raw reprocess regression test

### DIFF
--- a/site/tests/Integration/MarketplaceAnalytics/UnitExtendedQueryOzonRawReprocessRegressionTest.php
+++ b/site/tests/Integration/MarketplaceAnalytics/UnitExtendedQueryOzonRawReprocessRegressionTest.php
@@ -105,8 +105,8 @@ final class UnitExtendedQueryOzonRawReprocessRegressionTest extends IntegrationT
         );
 
         $connection->executeStatement(
-            'DELETE FROM marketplace_listings WHERE company_id = :companyId OR sku = :sku',
-            ['companyId' => self::COMPANY_ID, 'sku' => self::LISTING_SKU],
+            'DELETE FROM marketplace_listings WHERE company_id = :companyId',
+            ['companyId' => self::COMPANY_ID],
         );
 
         $connection->executeStatement(


### PR DESCRIPTION
### Motivation
- An integration test `UnitExtendedQueryOzonRawReprocessRegressionTest::cleanupTestData()` failed with `SQLSTATE[42703]: Undefined column: column "sku" does not exist` because the `marketplace_listings` table has no `sku` column. 
- The goal is to make test cleanup safe and idempotent by deleting only data for the test `companyId` without changing production code or business logic.

### Description
- Updated `site/tests/Integration/MarketplaceAnalytics/UnitExtendedQueryOzonRawReprocessRegressionTest.php` in `cleanupTestData()` to run `DELETE FROM marketplace_listings WHERE company_id = :companyId` and removed the `sku` parameter usage. 
- The change is test-only and does not modify any production code, `OzonSalesRawProcessor`, or `UnitExtendedQuery` logic. 
- The modified function is `cleanupTestData()` and affected file path is `site/tests/Integration/MarketplaceAnalytics/UnitExtendedQueryOzonRawReprocessRegressionTest.php`.

### Testing
- Attempted to run the requested test via Docker: `docker-compose run --rm site-php-cli php -d memory_limit=1G bin/phpunit tests/Integration/MarketplaceAnalytics/UnitExtendedQueryOzonRawReprocessRegressionTest.php`, but `docker-compose` was not available (`command not found`).
- Attempted `docker compose run --rm ...` but `docker` was not available (`command not found`).
- Attempted local PHPUnit run `php -d memory_limit=1G bin/phpunit tests/Integration/MarketplaceAnalytics/UnitExtendedQueryOzonRawReprocessRegressionTest.php`, but the environment is missing the Symfony PHPUnit bridge helper (`vendor/symfony/phpunit-bridge/bin/simple-phpunit.php`), so the test could not be executed.
- No automated test failures were observed in-repo because the containerized or local test execution could not be run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd86f2af208323a1d375a7123c46e8)