### PR TITLE
Fix cleanup table resolution in Ozon raw reprocess regression test

### DIFF
--- a/site/tests/Integration/MarketplaceAnalytics/UnitExtendedQueryOzonRawReprocessRegressionTest.php
+++ b/site/tests/Integration/MarketplaceAnalytics/UnitExtendedQueryOzonRawReprocessRegressionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Integration\MarketplaceAnalytics;
 
 use App\Company\Entity\Company;
+use App\Company\Entity\User;
 use App\Marketplace\Application\Processor\OzonSalesRawProcessor;
 use App\Marketplace\Entity\MarketplaceRawDocument;
 use App\Marketplace\Enum\MarketplaceType;
@@ -93,6 +94,9 @@ final class UnitExtendedQueryOzonRawReprocessRegressionTest extends IntegrationT
     private function cleanupTestData(): void
     {
         $connection = $this->em->getConnection();
+        $platform = $connection->getDatabasePlatform();
+        $companyTable = $this->em->getClassMetadata(Company::class)->getQuotedTableName($platform);
+        $userTable = $this->em->getClassMetadata(User::class)->getQuotedTableName($platform);
 
         $connection->executeStatement(
             'DELETE FROM marketplace_sales WHERE company_id = :companyId',
@@ -110,14 +114,16 @@ final class UnitExtendedQueryOzonRawReprocessRegressionTest extends IntegrationT
         );
 
         $connection->executeStatement(
-            'DELETE FROM company WHERE id = :companyId',
+            sprintf('DELETE FROM %s WHERE id = :companyId', $companyTable),
             ['companyId' => self::COMPANY_ID],
         );
 
         $connection->executeStatement(
-            'DELETE FROM "user" WHERE id = :ownerId',
+            sprintf('DELETE FROM %s WHERE id = :ownerId', $userTable),
             ['ownerId' => self::OWNER_ID],
         );
+
+        $this->em->clear();
     }
 
     private function seedCompanyAndListing(): void


### PR DESCRIPTION
### Motivation
- The test failed with `relation "company" does not exist` because the cleanup used hardcoded table names (`company` / `"user"`) while Doctrine maps `Company`/`User` to quoted/actual table names (e.g. `companies`), so the cleanup must use metadata to avoid brittle SQL.

### Description
- Use Doctrine metadata to resolve quoted table names via `getClassMetadata(...)->getQuotedTableName($platform)` for `Company::class` and `User::class` and replace hardcoded DELETE SQL with `sprintf('DELETE FROM %s ...', $tableName)`.
- Add `use App\Company\Entity\User;` import required for metadata lookup and call `$this->em->clear();` after executing raw SQL to reset the `EntityManager` state between runs.
- Change is limited to the test file `UnitExtendedQueryOzonRawReprocessRegressionTest.php`; no production code or business logic was modified.

### Testing
- Attempted to run the regression test with `phpunit` via `docker-compose run --rm site-php-cli ...` and `docker compose run ...`, but both runs failed in this environment because `docker-compose` / `docker` is not available, so automated test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd8a2d4554832392e546a79a67962e)