### PR TITLE
Fix cleanup in Ozon raw reprocess regression test to avoid manual Company/User SQL

### DIFF
--- a/site/tests/Integration/MarketplaceAnalytics/UnitExtendedQueryOzonRawReprocessRegressionTest.php
+++ b/site/tests/Integration/MarketplaceAnalytics/UnitExtendedQueryOzonRawReprocessRegressionTest.php
@@ -94,9 +94,6 @@ final class UnitExtendedQueryOzonRawReprocessRegressionTest extends IntegrationT
     private function cleanupTestData(): void
     {
         $connection = $this->em->getConnection();
-        $platform = $connection->getDatabasePlatform();
-        $companyTable = $this->em->getClassMetadata(Company::class)->getQuotedTableName($platform);
-        $userTable = $this->em->getClassMetadata(User::class)->getQuotedTableName($platform);
 
         $connection->executeStatement(
             'DELETE FROM marketplace_sales WHERE company_id = :companyId',
@@ -113,15 +110,17 @@ final class UnitExtendedQueryOzonRawReprocessRegressionTest extends IntegrationT
             ['companyId' => self::COMPANY_ID],
         );
 
-        $connection->executeStatement(
-            sprintf('DELETE FROM %s WHERE id = :companyId', $companyTable),
-            ['companyId' => self::COMPANY_ID],
-        );
+        $company = $this->em->find(Company::class, self::COMPANY_ID);
+        if ($company !== null) {
+            $this->em->remove($company);
+            $this->em->flush();
+        }
 
-        $connection->executeStatement(
-            sprintf('DELETE FROM %s WHERE id = :ownerId', $userTable),
-            ['ownerId' => self::OWNER_ID],
-        );
+        $owner = $this->em->find(User::class, self::OWNER_ID);
+        if ($owner !== null) {
+            $this->em->remove($owner);
+            $this->em->flush();
+        }
 
         $this->em->clear();
     }


### PR DESCRIPTION
### Motivation
- Исправить некорректную очистку тестовых данных, которая вызывала ошибки в `setUp()` при повторном запуске теста (duplicate user_pkey, обращения к несуществующим таблицам/колонкам и к отсутствующему `getQuotedTableName()`).

### Description
- В `cleanupTestData()` оставил сырой SQL только для marketplace-таблиц (`marketplace_sales`, `marketplace_raw_documents`, `marketplace_listings`), убрал динамическую резолюцию имён таблиц и ручные `DELETE` для `Company`/`User`, и удаляю `Company` и `User` через `EntityManager` (`find` → `remove` → `flush`), затем вызываю `$this->em->clear()`; изменение в `site/tests/Integration/MarketplaceAnalytics/UnitExtendedQueryOzonRawReprocessRegressionTest.php`.

### Testing
- Попытки запустить тесты дважды через `docker-compose run --rm site-php-cli php -d memory_limit=1G bin/phpunit tests/Integration/MarketplaceAnalytics/UnitExtendedQueryOzonRawReprocessRegressionTest.php` и `docker compose run --rm site-php-cli php -d memory_limit=1G bin/phpunit tests/Integration/MarketplaceAnalytics/UnitExtendedQueryOzonRawReprocessRegressionTest.php` не выполнились из-за отсутствия `docker`/`docker-compose` в среде (`command not found`), поэтому PHPUnit не запускался здесь.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd946e57648323b4abb72603040b9e)