### PR TITLE
Add integration regression tests for Ozon costs reprocess idempotency

### DIFF
--- a/site/tests/Integration/Marketplace/Application/Processor/OzonCostsRawProcessorTest.php
+++ b/site/tests/Integration/Marketplace/Application/Processor/OzonCostsRawProcessorTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Tests\Integration\Marketplace\Application\Processor;
 
 use App\Finance\Entity\Document;
+use App\Marketplace\Application\Command\ProcessMarketplaceRawDocumentCommand;
+use App\Marketplace\Application\ProcessMarketplaceRawDocumentAction;
 use App\Marketplace\Application\Processor\OzonCostsRawProcessor;
 use App\Marketplace\Entity\MarketplaceCost;
 use App\Marketplace\Enum\MarketplaceCostOperationType;
@@ -131,5 +133,131 @@ final class OzonCostsRawProcessorTest extends IntegrationTestCase
         ]], $rawDocId);
 
         self::assertSame(1, (int) $this->connection->fetchOne("SELECT COUNT(*) FROM marketplace_costs WHERE raw_document_id=:raw", ['raw' => $rawDocId]));
+    }
+
+    public function testCostsReprocessSameRawDocIsIdempotent(): void
+    {
+        $company = CompanyBuilder::aCompany()->withIndex(306)->build();
+        $this->em->persist($company);
+
+        $rawDocId = '11111111-1111-4111-8111-111111111306';
+        $day = new \DateTimeImmutable('2026-03-12');
+
+        $rawDoc = MarketplaceRawDocumentBuilder::aDocument()->withId($rawDocId)->forCompany($company)->withMarketplace(MarketplaceType::OZON)->withPeriod($day, $day)->build();
+        $rawDoc->setRawData(['result' => ['operations' => $this->buildOrderOperations([
+            ['id' => 'A', 'commission' => -100.0],
+            ['id' => 'B', 'commission' => -200.0],
+        ])]]);
+        $this->em->persist($rawDoc);
+        $this->em->flush();
+
+        $action = self::getContainer()->get(ProcessMarketplaceRawDocumentAction::class);
+        $command = new ProcessMarketplaceRawDocumentCommand($company->getId(), $rawDocId, 'costs');
+        $action($command);
+        $action($command);
+
+        self::assertSame(2, (int) $this->connection->fetchOne('SELECT COUNT(*) FROM marketplace_costs WHERE company_id = :companyId', ['companyId' => $company->getId()]));
+        self::assertSame('300.00', (string) $this->connection->fetchOne('SELECT CAST(COALESCE(SUM(amount),0) AS DECIMAL(12,2)) FROM marketplace_costs WHERE company_id = :companyId', ['companyId' => $company->getId()]));
+        self::assertSame(2, (int) $this->connection->fetchOne('SELECT COUNT(DISTINCT external_id) FROM marketplace_costs WHERE company_id = :companyId', ['companyId' => $company->getId()]));
+    }
+
+    public function testCostsReprocessAddsOnlyNewRowsWhenRawDocIsExtended(): void
+    {
+        $company = CompanyBuilder::aCompany()->withIndex(307)->build();
+        $this->em->persist($company);
+
+        $rawDocId = '11111111-1111-4111-8111-111111111307';
+        $day = new \DateTimeImmutable('2026-03-12');
+
+        $rawDoc = MarketplaceRawDocumentBuilder::aDocument()->withId($rawDocId)->forCompany($company)->withMarketplace(MarketplaceType::OZON)->withPeriod($day, $day)->build();
+        $rawDoc->setRawData(['result' => ['operations' => $this->buildOrderOperations([
+            ['id' => 'A', 'commission' => -100.0],
+            ['id' => 'B', 'commission' => -200.0],
+        ])]]);
+        $this->em->persist($rawDoc);
+        $this->em->flush();
+
+        $action = self::getContainer()->get(ProcessMarketplaceRawDocumentAction::class);
+        $command = new ProcessMarketplaceRawDocumentCommand($company->getId(), $rawDocId, 'costs');
+        $action($command);
+
+        $rawDoc->setRawData(['result' => ['operations' => $this->buildOrderOperations([
+            ['id' => 'A', 'commission' => -100.0],
+            ['id' => 'B', 'commission' => -200.0],
+            ['id' => 'C', 'commission' => -300.0],
+        ])]]);
+        $this->em->flush();
+
+        $action($command);
+
+        self::assertSame(3, (int) $this->connection->fetchOne('SELECT COUNT(*) FROM marketplace_costs WHERE company_id = :companyId', ['companyId' => $company->getId()]));
+        self::assertSame(1, (int) $this->connection->fetchOne("SELECT COUNT(*) FROM marketplace_costs WHERE company_id = :companyId AND external_id LIKE 'A_%'", ['companyId' => $company->getId()]));
+        self::assertSame(1, (int) $this->connection->fetchOne("SELECT COUNT(*) FROM marketplace_costs WHERE company_id = :companyId AND external_id LIKE 'B_%'", ['companyId' => $company->getId()]));
+        self::assertSame(1, (int) $this->connection->fetchOne("SELECT COUNT(*) FROM marketplace_costs WHERE company_id = :companyId AND external_id LIKE 'C_%'", ['companyId' => $company->getId()]));
+    }
+
+    public function testCostsReprocessReplacesOpenRowsWithUpdatedAmountsAndKeepsClosedRows(): void
+    {
+        $company = CompanyBuilder::aCompany()->withIndex(308)->build();
+        $this->em->persist($company);
+
+        $rawDocId = '11111111-1111-4111-8111-111111111308';
+        $day = new \DateTimeImmutable('2026-03-12');
+
+        $rawDoc = MarketplaceRawDocumentBuilder::aDocument()->withId($rawDocId)->forCompany($company)->withMarketplace(MarketplaceType::OZON)->withPeriod($day, $day)->build();
+        $rawDoc->setRawData(['result' => ['operations' => $this->buildOrderOperations([
+            ['id' => 'A', 'commission' => -100.0],
+            ['id' => 'B', 'commission' => -200.0],
+        ])]]);
+        $this->em->persist($rawDoc);
+
+        $closedDocument = new Document(Uuid::uuid4()->toString(), $company);
+        $this->em->persist($closedDocument);
+        $closedCost = new MarketplaceCost(Uuid::uuid4()->toString(), $company, MarketplaceType::OZON, null);
+        $closedCost->setExternalId('closed-legacy-row')->setRawDocumentId($rawDocId)->setCostDate($day)->setAmount('999')->setOperationType(MarketplaceCostOperationType::CHARGE)->setDocument($closedDocument);
+        $this->em->persist($closedCost);
+        $this->em->flush();
+
+        $action = self::getContainer()->get(ProcessMarketplaceRawDocumentAction::class);
+        $command = new ProcessMarketplaceRawDocumentCommand($company->getId(), $rawDocId, 'costs');
+        $action($command);
+
+        $rawDoc->setRawData(['result' => ['operations' => $this->buildOrderOperations([
+            ['id' => 'A', 'commission' => -100.0],
+            ['id' => 'B', 'commission' => -250.0],
+        ])]]);
+        $this->em->flush();
+
+        $action($command);
+
+        self::assertSame('350.00', (string) $this->connection->fetchOne("SELECT CAST(COALESCE(SUM(amount),0) AS DECIMAL(12,2)) FROM marketplace_costs WHERE company_id = :companyId AND document_id IS NULL", ['companyId' => $company->getId()]));
+        self::assertSame(1, (int) $this->connection->fetchOne("SELECT COUNT(*) FROM marketplace_costs WHERE company_id = :companyId AND document_id IS NULL AND external_id LIKE 'B_%' AND amount = 250", ['companyId' => $company->getId()]));
+        self::assertSame(1, (int) $this->connection->fetchOne("SELECT COUNT(*) FROM marketplace_costs WHERE company_id = :companyId AND document_id IS NOT NULL AND external_id = 'closed-legacy-row'", ['companyId' => $company->getId()]));
+    }
+
+    /**
+     * @param list<array{id: string, commission: float}> $rows
+     * @return list<array<string, mixed>>
+     */
+    private function buildOrderOperations(array $rows): array
+    {
+        $operations = [];
+        foreach ($rows as $row) {
+            $operations[] = [
+                'operation_id' => $row['id'],
+                'operation_date' => '2026-03-12 10:00:00',
+                'operation_type' => 'MarketplaceSellerCompensationOperation',
+                'operation_type_name' => 'Продажа',
+                'sale_commission' => $row['commission'],
+                'delivery_charge' => 0,
+                'return_delivery_charge' => 0,
+                'amount' => 0,
+                'type' => 'orders',
+                'items' => [['sku' => 'sku-' . $row['id'], 'name' => 'SKU ' . $row['id']]],
+                'services' => [],
+            ];
+        }
+
+        return $operations;
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure monthly/raw reprocess of Ozon `marketplace_costs` is idempotent so repeated processing of the same `raw_document_id` does not create duplicate rows, duplicate `external_id`s or double sums. 
- Cover real-world variations: identical re-run, raw doc extended with a new cost row, and existing open cost amount updated while closed rows remain untouched. 
- Add regression coverage without changing business logic; keep processing code intact and only extend test-suite.

### Description
- Added integration tests in `site/tests/Integration/Marketplace/Application/Processor/OzonCostsRawProcessorTest.php` covering three scenarios: idempotent re-run, adding a new cost row, and updating an existing open cost while preserving closed rows. 
- Tests exercise the real processing entrypoint via `ProcessMarketplaceRawDocumentAction` / `ProcessMarketplaceRawDocumentCommand` to simulate reprocess flows and assert DB state in `marketplace_costs`. 
- Introduced a small test helper `buildOrderOperations()` in the same test file to generate compact Ozon `orders` payloads for assertions. 
- No production/business logic files were modified; changes are limited to test code and fixtures.

### Testing
- Attempted to run the updated integration test file locally with `php -d memory_limit=1G vendor/bin/phpunit tests/Integration/Marketplace/Application/Processor/OzonCostsRawProcessorTest.php`, but the environment failed with `Could not open input file: vendor/bin/phpunit` so tests were not executed here. 
- Also tried `php -d memory_limit=1G bin/phpunit tests/Integration/Marketplace/Application/Processor/OzonCostsRawProcessorTest.php`, which failed due to missing `vendor/symfony/phpunit-bridge/bin/simple-phpunit.php` in this environment, so automated run could not complete. 
- The test file was committed (commit added) and a PR description prepared; CI in the project should run the new integration tests in a properly provisioned environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdbe3be68c8323afd7504246068972)