### PR TITLE
Исправить невалидный raw_document_id в OzonCostsRawProcessorTest

### DIFF
--- a/site/tests/Integration/Marketplace/Application/Processor/OzonCostsRawProcessorTest.php
+++ b/site/tests/Integration/Marketplace/Application/Processor/OzonCostsRawProcessorTest.php
@@ -22,6 +22,8 @@ use Ramsey\Uuid\Uuid;
 
 final class OzonCostsRawProcessorTest extends IntegrationTestCase
 {
+    private const LEGACY_RAW_DOC_ID = '99999999-9999-4999-8999-999999999999';
+
     private Connection $connection;
 
     protected function setUp(): void
@@ -90,7 +92,7 @@ final class OzonCostsRawProcessorTest extends IntegrationTestCase
         $rawDocId = 'cccccccc-cccc-4ccc-8ccc-cccccccccc12';
 
         $stale = new MarketplaceCost(Uuid::uuid4()->toString(), $company, MarketplaceType::OZON, null);
-        $stale->setExternalId('locked-stale-cost')->setCostDate($day)->setAmount('100')->setOperationType(MarketplaceCostOperationType::CHARGE)->setRawDocumentId('legacy-raw-doc');
+        $stale->setExternalId('locked-stale-cost')->setCostDate($day)->setAmount('100')->setOperationType(MarketplaceCostOperationType::CHARGE)->setRawDocumentId(self::LEGACY_RAW_DOC_ID);
         $this->em->persist($stale);
         $this->em->persist(MarketplaceRawDocumentBuilder::aDocument()->withId($rawDocId)->forCompany($company)->withMarketplace(MarketplaceType::OZON)->withPeriod($day, $day)->build());
         $this->em->flush();
@@ -284,7 +286,7 @@ final class OzonCostsRawProcessorTest extends IntegrationTestCase
             '11111111-1111-4111-8111-111111111307',
             '11111111-1111-4111-8111-111111111308',
         ];
-        $costRawDocumentIds = [...$rawDocumentIds, 'legacy-raw-doc'];
+        $costRawDocumentIds = [...$rawDocumentIds, self::LEGACY_RAW_DOC_ID];
 
         $platform = $this->connection->getDatabasePlatform();
         $companyTable = $platform->quoteIdentifier($this->em->getClassMetadata(Company::class)->getTableName());


### PR DESCRIPTION
### Motivation

- Тесты падали на стадии очистки данных с ошибкой `invalid input syntax for type uuid` из-за использования строки `legacy-raw-doc` в колонке `marketplace_costs.raw_document_id`, которая имеет тип UUID.  
- Необходимо заменить не-UUID значение в тесте/cleanup на корректный UUID без изменения production-кода и бизнес-assertions.  

### Description

- Добавлена константа `private const LEGACY_RAW_DOC_ID = '99999999-9999-4999-8999-999999999999';` в `OzonCostsRawProcessorTest`.  
- В `testReprocessFailsWhenFinanceLockCoversRawDocPeriod()` заменено `setRawDocumentId('legacy-raw-doc')` на `setRawDocumentId(self::LEGACY_RAW_DOC_ID)`.  
- В `cleanupTestData()` заменён элемент массива `['legacy-raw-doc']` на `self::LEGACY_RAW_DOC_ID` чтобы передаваемые значения в SQL соответствовали UUID-типу.  
- Не изменялся production-код и не менялся `OzonCostsRawProcessor`, изменился только тестовый файл `site/tests/Integration/Marketplace/Application/Processor/OzonCostsRawProcessorTest.php`.  

### Testing

- Попытка запустить интеграционный тест через Docker: `docker-compose run --rm site-php-cli php -d memory_limit=1G bin/phpunit tests/Integration/Marketplace/Application/Processor/OzonCostsRawProcessorTest.php` завершилась неудачей из-за отсутствия `docker-compose` в окружении (`command not found`).  
- Локальная попытка запуска `php -d memory_limit=1G bin/phpunit tests/Integration/Marketplace/Application/Processor/OzonCostsRawProcessorTest.php` не выполнилась из-за отсутствия `bin/phpunit` в этом раннере (`Could not open input file: bin/phpunit`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fddb0882d083238d0ac31881a74212)