### PR TITLE
Fix FK fixtures in OzonCostsRawProcessorTest

### DIFF
--- a/site/tests/Integration/Marketplace/Application/Processor/OzonCostsRawProcessorTest.php
+++ b/site/tests/Integration/Marketplace/Application/Processor/OzonCostsRawProcessorTest.php
@@ -45,6 +45,7 @@ final class OzonCostsRawProcessorTest extends IntegrationTestCase
         $outside = new \DateTimeImmutable('2026-03-20');
         $rawDocA = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaa12';
         $rawDocB = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbb12';
+        $this->em->persist(MarketplaceRawDocumentBuilder::aDocument()->withId($rawDocA)->forCompany($company)->withMarketplace(MarketplaceType::OZON)->withPeriod($day, $day)->build());
 
         $stale = new MarketplaceCost(Uuid::uuid4()->toString(), $company, MarketplaceType::OZON, null);
         $stale->setExternalId('stale-cost')->setCostDate($day)->setAmount('100')->setOperationType(MarketplaceCostOperationType::CHARGE)->setRawDocumentId($rawDocA);
@@ -94,6 +95,7 @@ final class OzonCostsRawProcessorTest extends IntegrationTestCase
         $stale = new MarketplaceCost(Uuid::uuid4()->toString(), $company, MarketplaceType::OZON, null);
         $stale->setExternalId('locked-stale-cost')->setCostDate($day)->setAmount('100')->setOperationType(MarketplaceCostOperationType::CHARGE)->setRawDocumentId(self::LEGACY_RAW_DOC_ID);
         $this->em->persist($stale);
+        $this->em->persist(MarketplaceRawDocumentBuilder::aDocument()->withId(self::LEGACY_RAW_DOC_ID)->forCompany($company)->withMarketplace(MarketplaceType::OZON)->withPeriod($day, $day)->build());
         $this->em->persist(MarketplaceRawDocumentBuilder::aDocument()->withId($rawDocId)->forCompany($company)->withMarketplace(MarketplaceType::OZON)->withPeriod($day, $day)->build());
         $this->em->flush();
 


### PR DESCRIPTION
### Motivation
- Two integration tests failed with FK `fk_cost_raw_document` because `MarketplaceCost` rows referenced `raw_document_id` values that had no corresponding `marketplace_raw_documents` fixtures, so tests must persist matching `MarketplaceRawDocument` entities.

### Description
- Added `MarketplaceRawDocument` persist for `$rawDocA` in `testCleanupRemovesOnlyStaleOpenCosts()` and for `self::LEGACY_RAW_DOC_ID` in `testReprocessFailsWhenFinanceLockCoversRawDocPeriod()` in `site/tests/Integration/Marketplace/Application/Processor/OzonCostsRawProcessorTest.php`, leaving production code unchanged.

### Testing
- Attempted to run the targeted test file with `php -d memory_limit=1G bin/phpunit tests/Integration/Marketplace/Application/Processor/OzonCostsRawProcessorTest.php` via `docker-compose` / `docker`, but automated test execution could not be performed here because the environment reported `docker-compose: command not found` and `docker: command not found`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fddd754d7483238d60383c9d6f95ec)