### PR TITLE
Fix OzonCostsRawProcessorTest fixtures for unique constraint and FK ordering issues

### DIFF
--- a/site/tests/Integration/Marketplace/Application/Processor/OzonCostsRawProcessorTest.php
+++ b/site/tests/Integration/Marketplace/Application/Processor/OzonCostsRawProcessorTest.php
@@ -45,7 +45,7 @@ final class OzonCostsRawProcessorTest extends IntegrationTestCase
         $outside = new \DateTimeImmutable('2026-03-20');
         $rawDocA = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaa12';
         $rawDocB = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbb12';
-        $this->em->persist(MarketplaceRawDocumentBuilder::aDocument()->withId($rawDocA)->forCompany($company)->withMarketplace(MarketplaceType::OZON)->withPeriod($day, $day)->build());
+        $this->em->persist(MarketplaceRawDocumentBuilder::aDocument()->withId($rawDocA)->forCompany($company)->withMarketplace(MarketplaceType::OZON)->withPeriod($day->modify('-1 day'), $day->modify('-1 day'))->build());
 
         $stale = new MarketplaceCost(Uuid::uuid4()->toString(), $company, MarketplaceType::OZON, null);
         $stale->setExternalId('stale-cost')->setCostDate($day)->setAmount('100')->setOperationType(MarketplaceCostOperationType::CHARGE)->setRawDocumentId($rawDocA);
@@ -92,11 +92,13 @@ final class OzonCostsRawProcessorTest extends IntegrationTestCase
         $day = new \DateTimeImmutable('2026-03-12');
         $rawDocId = 'cccccccc-cccc-4ccc-8ccc-cccccccccc12';
 
+        $this->em->persist(MarketplaceRawDocumentBuilder::aDocument()->withId(self::LEGACY_RAW_DOC_ID)->forCompany($company)->withMarketplace(MarketplaceType::OZON)->withPeriod($day->modify('-1 day'), $day->modify('-1 day'))->build());
+        $this->em->persist(MarketplaceRawDocumentBuilder::aDocument()->withId($rawDocId)->forCompany($company)->withMarketplace(MarketplaceType::OZON)->withPeriod($day, $day)->build());
+        $this->em->flush();
+
         $stale = new MarketplaceCost(Uuid::uuid4()->toString(), $company, MarketplaceType::OZON, null);
         $stale->setExternalId('locked-stale-cost')->setCostDate($day)->setAmount('100')->setOperationType(MarketplaceCostOperationType::CHARGE)->setRawDocumentId(self::LEGACY_RAW_DOC_ID);
         $this->em->persist($stale);
-        $this->em->persist(MarketplaceRawDocumentBuilder::aDocument()->withId(self::LEGACY_RAW_DOC_ID)->forCompany($company)->withMarketplace(MarketplaceType::OZON)->withPeriod($day, $day)->build());
-        $this->em->persist(MarketplaceRawDocumentBuilder::aDocument()->withId($rawDocId)->forCompany($company)->withMarketplace(MarketplaceType::OZON)->withPeriod($day, $day)->build());
         $this->em->flush();
 
         try {


### PR DESCRIPTION
### Motivation
- Tests were failing with `uniq_mrd_init_sync_period` duplicate-key and `fk_cost_raw_document` FK errors due to colliding `MarketplaceRawDocument` periods and insertion ordering in the same flush. 
- The change aims to adjust only test fixtures and flush ordering so the integration tests exercise the same production invariants without changing production code or DB constraints.

### Description
- In `tests/Integration/.../OzonCostsRawProcessorTest.php` `testCleanupRemovesOnlyStaleOpenCosts` now creates `rawDocA` with `withPeriod($day->modify('-1 day'), $day->modify('-1 day'))` and leaves `rawDocB` on `$day` to avoid creating two raw documents with identical `(company, marketplace, document_type, period_from, period_to, api_endpoint)`. 
- In `testReprocessFailsWhenFinanceLockCoversRawDocPeriod` the legacy and target raw documents are persisted and flushed first (legacy on `day - 1` and target on `day`), and only after that the stale `MarketplaceCost` referencing the legacy raw document is created and flushed to avoid FK insert-order races; no production code, processor logic, FK definitions, or business assertions were changed.

### Testing
- Attempted to run `docker-compose run --rm site-php-cli php -d memory_limit=1G bin/phpunit tests/Integration/Marketplace/Application/Processor/OzonCostsRawProcessorTest.php` but the environment does not have `docker-compose` installed so the PHPUnit run could not be executed (`/bin/bash: docker-compose: command not found`). 
- No automated test results are available from this environment; the change is limited to test fixtures and intended to make the 7 tests pass on CI or a developer machine where the project test runner is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fddf5533748323908713494f5066db)