### PR TITLE
Fix failed-status setup in SyncOzonReportHandlerTest

### DIFF
--- a/site/tests/Unit/Marketplace/MessageHandler/SyncOzonReportHandlerTest.php
+++ b/site/tests/Unit/Marketplace/MessageHandler/SyncOzonReportHandlerTest.php
@@ -9,6 +9,7 @@ use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Entity\MarketplaceRawDocument;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Enum\PipelineStatus;
+use App\Marketplace\Enum\PipelineStep;
 use App\Marketplace\Message\ProcessDayReportMessage;
 use App\Marketplace\Message\SyncOzonReportMessage;
 use App\Marketplace\MessageHandler\SyncOzonReportHandler;
@@ -295,7 +296,7 @@ final class SyncOzonReportHandlerTest extends TestCase
 
         $failedDoc = $this->buildDocForDate($company);
         $failedDoc->setRawData([['failed' => true]])->setRecordsCount(1);
-        $failedDoc->markFailed('boom');
+        $failedDoc->markStepFailed(PipelineStep::DOWNLOAD);
 
         $rawDocRepo = $this->createMock(MarketplaceRawDocumentRepository::class);
         $rawDocRepo->method('findActiveExactDayDocuments')->willReturn([]);


### PR DESCRIPTION
### Motivation
- The unit test called a non-existent `MarketplaceRawDocument::markFailed()` method, while the entity represents failures via per-step methods, so the test must use the real API to model a FAILED raw document.

### Description
- Updated `site/tests/Unit/Marketplace/MessageHandler/SyncOzonReportHandlerTest.php` to import `PipelineStep` and replace the `markFailed('boom')` call with `markStepFailed(PipelineStep::DOWNLOAD)`, keeping production code unchanged.

### Testing
- Attempted to run the targeted test with `docker-compose run --rm site-php-cli php -d memory_limit=1G bin/phpunit tests/Unit/Marketplace/MessageHandler/SyncOzonReportHandlerTest.php` but `docker-compose` was not available, and a local fallback `php -d memory_limit=1G bin/phpunit ...` failed due to missing `vendor/symfony/phpunit-bridge/bin/simple-phpunit.php`, so automated PHPUnit could not be executed in this environment, however the change removes the undefined-method call at source level.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fde41ff14c8323b5ae88d91421dca9)