### PR TITLE
Update test to use PipelineStep enum and markStepFailed

### DIFF
--- a/site/tests/Unit/Marketplace/MessageHandler/SyncOzonReportHandlerTest.php
+++ b/site/tests/Unit/Marketplace/MessageHandler/SyncOzonReportHandlerTest.php
@@ -9,6 +9,7 @@ use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Entity\MarketplaceRawDocument;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Enum\PipelineStatus;
+use App\Marketplace\Enum\PipelineStep;
 use App\Marketplace\Message\ProcessDayReportMessage;
 use App\Marketplace\Message\SyncOzonReportMessage;
 use App\Marketplace\MessageHandler\SyncOzonReportHandler;
@@ -295,7 +296,7 @@ final class SyncOzonReportHandlerTest extends TestCase
 
         $failedDoc = $this->buildDocForDate($company);
         $failedDoc->setRawData([['failed' => true]])->setRecordsCount(1);
-        $failedDoc->markFailed('boom');
+        $failedDoc->markStepFailed(PipelineStep::SALES);
 
         $rawDocRepo = $this->createMock(MarketplaceRawDocumentRepository::class);
         $rawDocRepo->method('findActiveExactDayDocuments')->willReturn([]);


### PR DESCRIPTION
### Motivation
- The marketplace pipeline failure API was changed to record a failed pipeline step via `markStepFailed` using the `PipelineStep` enum instead of the old `markFailed` message API, so the test must be updated to match the new contract.

### Description
- Added `use App\Marketplace\Enum\PipelineStep;` and replaced the call to `markFailed('boom')` with `markStepFailed(PipelineStep::SALES)` in `SyncOzonReportHandlerTest`.

### Testing
- Ran the unit test `SyncOzonReportHandlerTest` with `phpunit --filter SyncOzonReportHandlerTest` and the test completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fde41ff14c8323b5ae88d91421dca9)