### PR TITLE
Add read-only Ozon month raw refresh planner

### DIFF
--- a/site/src/Marketplace/Application/DTO/OzonMonthRawRefreshPlanItem.php
+++ b/site/src/Marketplace/Application/DTO/OzonMonthRawRefreshPlanItem.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\DTO;
+
+final readonly class OzonMonthRawRefreshPlanItem
+{
+    public function __construct(
+        public string $companyId,
+        public string $connectionId,
+        public string $marketplace,
+        public string $date,
+        public string $status,
+        public ?string $skippedReason,
+    ) {
+    }
+}

--- a/site/src/Marketplace/Application/OzonMonthRawRefreshPlanner.php
+++ b/site/src/Marketplace/Application/OzonMonthRawRefreshPlanner.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application;
+
+use App\Marketplace\Application\DTO\OzonMonthRawRefreshPlanItem;
+use App\Marketplace\Infrastructure\Query\ActiveOzonConnectionsQuery;
+
+final readonly class OzonMonthRawRefreshPlanner
+{
+    public function __construct(
+        private ActiveOzonConnectionsQuery $connectionsQuery,
+    ) {
+    }
+
+    /**
+     * @return list<OzonMonthRawRefreshPlanItem>
+     */
+    public function plan(
+        int $year,
+        int $month,
+        ?string $companyId = null,
+        ?\DateTimeImmutable $from = null,
+        ?\DateTimeImmutable $to = null,
+    ): array {
+        $monthStart = new \DateTimeImmutable(sprintf('%04d-%02d-01', $year, $month));
+        $monthEnd = $monthStart->modify('last day of this month');
+
+        $rangeStart = $from ? $this->maxDate($from->setTime(0, 0), $monthStart) : $monthStart;
+        $rangeEnd = $to ? $this->minDate($to->setTime(0, 0), $monthEnd) : $monthEnd;
+
+        $today = new \DateTimeImmutable('today');
+        if ($monthStart->format('Y-m') === $today->format('Y-m')) {
+            $yesterday = $today->modify('-1 day');
+            $rangeEnd = $this->minDate($rangeEnd, $yesterday);
+        }
+
+        if ($rangeStart > $rangeEnd) {
+            return [];
+        }
+
+        $connections = $this->connectionsQuery->execute($companyId);
+        if ([] === $connections) {
+            return [];
+        }
+
+        $plan = [];
+
+        foreach ($connections as $connection) {
+            $lockBefore = isset($connection['finance_lock_before']) && null !== $connection['finance_lock_before']
+                ? new \DateTimeImmutable((string) $connection['finance_lock_before'])
+                : null;
+
+            for ($cursor = $rangeStart; $cursor <= $rangeEnd; $cursor = $cursor->modify('+1 day')) {
+                $status = 'planned';
+                $reason = null;
+
+                if (null !== $lockBefore && $cursor <= $lockBefore) {
+                    $status = 'skipped';
+                    $reason = 'finance_locked';
+                }
+
+                $plan[] = new OzonMonthRawRefreshPlanItem(
+                    companyId: (string) $connection['company_id'],
+                    connectionId: (string) $connection['id'],
+                    marketplace: 'ozon',
+                    date: $cursor->format('Y-m-d'),
+                    status: $status,
+                    skippedReason: $reason,
+                );
+            }
+        }
+
+        return $plan;
+    }
+
+    private function minDate(\DateTimeImmutable $a, \DateTimeImmutable $b): \DateTimeImmutable
+    {
+        return $a <= $b ? $a : $b;
+    }
+
+    private function maxDate(\DateTimeImmutable $a, \DateTimeImmutable $b): \DateTimeImmutable
+    {
+        return $a >= $b ? $a : $b;
+    }
+}

--- a/site/src/Marketplace/Infrastructure/Query/ActiveOzonConnectionsQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/ActiveOzonConnectionsQuery.php
@@ -19,21 +19,29 @@ final class ActiveOzonConnectionsQuery
     }
 
     /**
-     * @return array<int, array{id: string, company_id: string}>
+     * @return array<int, array{id: string, company_id: string, finance_lock_before: null|string}>
      */
-    public function execute(): array
+    public function execute(?string $companyId = null): array
     {
-        return $this->connection->fetchAllAssociative(
-            'SELECT mc.id, mc.company_id
-             FROM marketplace_connections mc
-             WHERE mc.marketplace = :marketplace
-               AND mc.connection_type = :connection_type
-               AND mc.is_active = true
-             ORDER BY mc.created_at ASC',
-            [
-                'marketplace' => 'ozon',
-                'connection_type' => MarketplaceConnectionType::SELLER->value,
-            ],
-        );
+        $sql = 'SELECT mc.id, mc.company_id, c.finance_lock_before
+                FROM marketplace_connections mc
+                INNER JOIN companies c ON c.id = mc.company_id
+                WHERE mc.marketplace = :marketplace
+                  AND mc.connection_type = :connection_type
+                  AND mc.is_active = true';
+
+        $params = [
+            'marketplace' => 'ozon',
+            'connection_type' => MarketplaceConnectionType::SELLER->value,
+        ];
+
+        if (null !== $companyId) {
+            $sql .= ' AND mc.company_id = :company_id';
+            $params['company_id'] = $companyId;
+        }
+
+        $sql .= ' ORDER BY mc.created_at ASC';
+
+        return $this->connection->fetchAllAssociative($sql, $params);
     }
 }

--- a/site/tests/Unit/Marketplace/Application/OzonMonthRawRefreshPlannerTest.php
+++ b/site/tests/Unit/Marketplace/Application/OzonMonthRawRefreshPlannerTest.php
@@ -35,6 +35,7 @@ final class OzonMonthRawRefreshPlannerTest extends TestCase
     public function testCurrentMonthExcludesTodayAndFutureDates(): void
     {
         $today = new \DateTimeImmutable('today');
+        $dayOfMonth = (int) $today->format('j');
 
         $query = $this->createMock(ActiveOzonConnectionsQuery::class);
         $query->method('execute')->willReturn([
@@ -46,9 +47,14 @@ final class OzonMonthRawRefreshPlannerTest extends TestCase
 
         $dates = array_map(static fn ($item) => $item->date, $plan);
 
-        self::assertContains($today->modify('-1 day')->format('Y-m-d'), $dates);
         self::assertNotContains($today->format('Y-m-d'), $dates);
         self::assertNotContains($today->modify('+1 day')->format('Y-m-d'), $dates);
+
+        if ($dayOfMonth > 1) {
+            self::assertContains($today->modify('-1 day')->format('Y-m-d'), $dates);
+        } else {
+            self::assertSame([], $dates);
+        }
     }
 
     public function testFiltersByCompanyId(): void

--- a/site/tests/Unit/Marketplace/Application/OzonMonthRawRefreshPlannerTest.php
+++ b/site/tests/Unit/Marketplace/Application/OzonMonthRawRefreshPlannerTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Application;
+
+use App\Marketplace\Application\OzonMonthRawRefreshPlanner;
+use App\Marketplace\Infrastructure\Query\ActiveOzonConnectionsQuery;
+use PHPUnit\Framework\TestCase;
+
+final class OzonMonthRawRefreshPlannerTest extends TestCase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-000000000001';
+    private const CONNECTION_ID = '22222222-2222-2222-2222-000000000001';
+
+    public function testBuildsFullPlanForPreviousMonth(): void
+    {
+        $today = new \DateTimeImmutable('today');
+        $previousMonth = $today->modify('first day of previous month');
+
+        $query = $this->createMock(ActiveOzonConnectionsQuery::class);
+        $query->expects(self::once())->method('execute')->with(null)->willReturn([
+            ['id' => self::CONNECTION_ID, 'company_id' => self::COMPANY_ID, 'finance_lock_before' => null],
+        ]);
+
+        $planner = new OzonMonthRawRefreshPlanner($query);
+        $plan = $planner->plan((int) $previousMonth->format('Y'), (int) $previousMonth->format('m'));
+
+        $expectedDays = (int) $previousMonth->format('t');
+        self::assertCount($expectedDays, $plan);
+        self::assertSame($previousMonth->format('Y-m-01'), $plan[0]->date);
+        self::assertSame($previousMonth->format('Y-m-t'), $plan[$expectedDays - 1]->date);
+    }
+
+    public function testCurrentMonthExcludesTodayAndFutureDates(): void
+    {
+        $today = new \DateTimeImmutable('today');
+
+        $query = $this->createMock(ActiveOzonConnectionsQuery::class);
+        $query->method('execute')->willReturn([
+            ['id' => self::CONNECTION_ID, 'company_id' => self::COMPANY_ID, 'finance_lock_before' => null],
+        ]);
+
+        $planner = new OzonMonthRawRefreshPlanner($query);
+        $plan = $planner->plan((int) $today->format('Y'), (int) $today->format('m'));
+
+        $dates = array_map(static fn ($item) => $item->date, $plan);
+
+        self::assertContains($today->modify('-1 day')->format('Y-m-d'), $dates);
+        self::assertNotContains($today->format('Y-m-d'), $dates);
+        self::assertNotContains($today->modify('+1 day')->format('Y-m-d'), $dates);
+    }
+
+    public function testFiltersByCompanyId(): void
+    {
+        $month = new \DateTimeImmutable('2026-04-01');
+
+        $query = $this->createMock(ActiveOzonConnectionsQuery::class);
+        $query->expects(self::once())->method('execute')->with(self::COMPANY_ID)->willReturn([
+            ['id' => self::CONNECTION_ID, 'company_id' => self::COMPANY_ID, 'finance_lock_before' => null],
+        ]);
+
+        $planner = new OzonMonthRawRefreshPlanner($query);
+        $plan = $planner->plan((int) $month->format('Y'), (int) $month->format('m'), self::COMPANY_ID);
+
+        self::assertNotEmpty($plan);
+        self::assertSame(self::COMPANY_ID, $plan[0]->companyId);
+    }
+
+    public function testMarksFinanceLockedDatesAsSkipped(): void
+    {
+        $month = new \DateTimeImmutable('2026-04-01');
+
+        $query = $this->createMock(ActiveOzonConnectionsQuery::class);
+        $query->method('execute')->willReturn([
+            ['id' => self::CONNECTION_ID, 'company_id' => self::COMPANY_ID, 'finance_lock_before' => '2026-04-10'],
+        ]);
+
+        $planner = new OzonMonthRawRefreshPlanner($query);
+        $plan = $planner->plan(2026, 4, null, $month, $month->modify('+14 day'));
+
+        $byDate = [];
+        foreach ($plan as $item) {
+            $byDate[$item->date] = $item;
+        }
+
+        self::assertSame('skipped', $byDate['2026-04-01']->status);
+        self::assertSame('finance_locked', $byDate['2026-04-01']->skippedReason);
+        self::assertSame('skipped', $byDate['2026-04-10']->status);
+        self::assertSame('planned', $byDate['2026-04-11']->status);
+    }
+
+    public function testReturnsEmptyPlanWhenNoActiveConnections(): void
+    {
+        $query = $this->createMock(ActiveOzonConnectionsQuery::class);
+        $query->method('execute')->willReturn([]);
+
+        $planner = new OzonMonthRawRefreshPlanner($query);
+        $plan = $planner->plan(2026, 4);
+
+        self::assertSame([], $plan);
+    }
+
+    public function testIsReadOnlyAndUsesOnlyConnectionsQuery(): void
+    {
+        $query = $this->createMock(ActiveOzonConnectionsQuery::class);
+        $query->expects(self::once())->method('execute')->willReturn([
+            ['id' => self::CONNECTION_ID, 'company_id' => self::COMPANY_ID, 'finance_lock_before' => null],
+        ]);
+
+        $planner = new OzonMonthRawRefreshPlanner($query);
+        $plan = $planner->plan(2026, 4, null, new \DateTimeImmutable('2026-04-10'), new \DateTimeImmutable('2026-04-12'));
+
+        self::assertCount(3, $plan);
+    }
+}


### PR DESCRIPTION
### Motivation
- Daily rolling refresh only updates the last 14 days which causes month-end discrepancies in Ozon costs, so a safe full-month refresh plan is required before closing the month. 
- The planner must be read-only: it must build a plan of dates to refresh without dispatching messages or writing anything to the DB.

### Description
- Added `OzonMonthRawRefreshPlanner` (`src/Marketplace/Application/OzonMonthRawRefreshPlanner.php`) that builds a per-company/per-connection per-day plan for a given year/month and optional `from`/`to` range and `companyId` filter. 
- Added DTO `OzonMonthRawRefreshPlanItem` (`src/Marketplace/Application/DTO/OzonMonthRawRefreshPlanItem.php`) with `companyId`, `connectionId`, `marketplace`, `date`, `status` (`planned`/`skipped`) and nullable `skippedReason`. 
- Extended existing `ActiveOzonConnectionsQuery::execute` to accept optional `companyId` and to include `finance_lock_before` (via join on `companies`) so the planner can be lock-aware while reusing the same query used by daily sync. 
- Planner behavior: normalizes month bounds, excludes today/future for current month, respects optional `from`/`to` inside the month, marks dates as `skipped` with reason `finance_locked` when `date <= financeLockBefore`, and never calls the Ozon API, messenger, or performs DB writes.

### Testing
- Added unit tests `tests/Unit/Marketplace/Application/OzonMonthRawRefreshPlannerTest.php` covering: full previous-month plan, current month excluding today/future, `companyId` filtering, `financeLockBefore` skipped dates, empty connections → empty plan, and read-only (query-only) behavior. 
- Performed PHP syntax checks (`php -l`) on the new and modified files and they passed. 
- Attempted to run PHPUnit in this environment (`php bin/phpunit ...`) but execution failed due to a missing Symfony phpunit-bridge script (`vendor/symfony/phpunit-bridge/bin/simple-phpunit.php`), so tests were added but not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdeadfc1808323a7d7eed1ef696b32)