### PR TITLE
Add app:marketplace:ozon-month-raw-refresh command

### DIFF
--- a/site/src/Marketplace/Command/OzonMonthRawRefreshCommand.php
+++ b/site/src/Marketplace/Command/OzonMonthRawRefreshCommand.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Command;
+
+use App\Marketplace\Application\OzonMonthRawRefreshPlanner;
+use App\Marketplace\Message\SyncOzonReportMessage;
+use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[AsCommand(
+    name: 'app:marketplace:ozon-month-raw-refresh',
+    description: 'Месячный raw-refresh Ozon по дням месяца',
+)]
+final class OzonMonthRawRefreshCommand extends Command
+{
+    public function __construct(
+        private readonly OzonMonthRawRefreshPlanner $planner,
+        private readonly MessageBusInterface $messageBus,
+        private readonly ClockInterface $clock,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('year', null, InputOption::VALUE_REQUIRED, 'Год периода (YYYY)')
+            ->addOption('month', null, InputOption::VALUE_REQUIRED, 'Месяц периода (1..12)')
+            ->addOption('previous-month', null, InputOption::VALUE_NONE, 'Использовать предыдущий календарный месяц')
+            ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Ограничить план по company UUID')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Показать план без dispatch в очередь');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $period = $this->resolvePeriod($input, $io);
+        if (null === $period) {
+            return Command::FAILURE;
+        }
+
+        $companyId = $input->getOption('company-id');
+        $plan = $this->planner->plan($period['year'], $period['month'], is_string($companyId) ? $companyId : null);
+
+        if ([] === $plan) {
+            $io->success('План пуст: нет элементов для выбранного периода и фильтра компании.');
+
+            return Command::SUCCESS;
+        }
+
+        if (true === $input->getOption('dry-run')) {
+            $this->renderPlanTable($output, $plan);
+            $io->success('Dry-run завершен: сообщения не отправлялись.');
+
+            return Command::SUCCESS;
+        }
+
+        $total = \count($plan);
+        $plannedDispatched = 0;
+        $skipped = 0;
+        $skippedFinanceLocked = 0;
+
+        foreach ($plan as $item) {
+            if ('planned' !== $item->status) {
+                $skipped++;
+                if ('finance_locked' === $item->skippedReason) {
+                    $skippedFinanceLocked++;
+                }
+
+                continue;
+            }
+
+            $this->messageBus->dispatch(new SyncOzonReportMessage(
+                companyId: $item->companyId,
+                connectionId: $item->connectionId,
+                date: $item->date,
+            ));
+
+            $plannedDispatched++;
+        }
+
+        if (0 === $plannedDispatched) {
+            $io->success('Нет planned-дат для dispatch: все элементы пропущены.');
+        }
+
+        $io->section('Summary');
+        $io->writeln(sprintf('total items: %d', $total));
+        $io->writeln(sprintf('planned dispatched: %d', $plannedDispatched));
+        $io->writeln(sprintf('skipped: %d', $skipped));
+        $io->writeln(sprintf('skipped by finance_locked: %d', $skippedFinanceLocked));
+
+        return Command::SUCCESS;
+    }
+
+    private function resolvePeriod(InputInterface $input, SymfonyStyle $io): ?array
+    {
+        $previousMonth = true === $input->getOption('previous-month');
+        $yearRaw = $input->getOption('year');
+        $monthRaw = $input->getOption('month');
+
+        $yearProvided = is_string($yearRaw) && '' !== trim($yearRaw);
+        $monthProvided = is_string($monthRaw) && '' !== trim($monthRaw);
+
+        if ($previousMonth && ($yearProvided || $monthProvided)) {
+            $io->error('Нельзя использовать --previous-month одновременно с --year/--month.');
+
+            return null;
+        }
+
+        if ($previousMonth) {
+            $periodDate = $this->clock->now()->setTimezone(new \DateTimeZone('UTC'))->modify('first day of previous month');
+
+            return [
+                'year' => (int) $periodDate->format('Y'),
+                'month' => (int) $periodDate->format('n'),
+            ];
+        }
+
+        if ($yearProvided xor $monthProvided) {
+            $io->error('Параметры --year и --month должны быть указаны вместе.');
+
+            return null;
+        }
+
+        if (!$yearProvided && !$monthProvided) {
+            $io->error('Укажите период: либо --previous-month, либо пару --year и --month.');
+
+            return null;
+        }
+
+        $year = (int) $yearRaw;
+        $month = (int) $monthRaw;
+
+        if ($year < 2000) {
+            $io->error('Некорректный --year: укажите год >= 2000.');
+
+            return null;
+        }
+
+        if ($month < 1 || $month > 12) {
+            $io->error('Некорректный --month: допустимые значения 1..12.');
+
+            return null;
+        }
+
+        return ['year' => $year, 'month' => $month];
+    }
+
+    private function renderPlanTable(OutputInterface $output, array $plan): void
+    {
+        $table = new Table($output);
+        $table->setHeaders(['company_id', 'connection_id', 'date', 'status', 'skipped_reason']);
+
+        foreach ($plan as $item) {
+            $table->addRow([
+                $item->companyId,
+                $item->connectionId,
+                $item->date,
+                $item->status,
+                $item->skippedReason,
+            ]);
+        }
+
+        $table->render();
+    }
+}

--- a/site/src/Marketplace/Command/OzonMonthRawRefreshCommand.php
+++ b/site/src/Marketplace/Command/OzonMonthRawRefreshCommand.php
@@ -118,7 +118,7 @@ final class OzonMonthRawRefreshCommand extends Command
         }
 
         if ($previousMonth) {
-            $periodDate = $this->clock->now()->setTimezone(new \DateTimeZone('UTC'))->modify('first day of previous month');
+            $periodDate = $this->clock->now()->setTimezone(new \DateTimeZone('Europe/Moscow'))->modify('first day of previous month');
 
             return [
                 'year' => (int) $periodDate->format('Y'),
@@ -134,6 +134,12 @@ final class OzonMonthRawRefreshCommand extends Command
 
         if (!$yearProvided && !$monthProvided) {
             $io->error('Укажите период: либо --previous-month, либо пару --year и --month.');
+
+            return null;
+        }
+
+        if (!is_string($yearRaw) || !is_string($monthRaw) || !ctype_digit($yearRaw) || !ctype_digit($monthRaw)) {
+            $io->error('Параметры --year и --month должны быть целыми числовыми значениями.');
 
             return null;
         }

--- a/site/tests/Unit/Marketplace/Command/OzonMonthRawRefreshCommandTest.php
+++ b/site/tests/Unit/Marketplace/Command/OzonMonthRawRefreshCommandTest.php
@@ -107,6 +107,23 @@ final class OzonMonthRawRefreshCommandTest extends TestCase
         self::assertSame(Command::SUCCESS, $exitCode);
     }
 
+    public function testPreviousMonthUsesMoscowTimezoneBoundary(): void
+    {
+        $planner = $this->createMock(OzonMonthRawRefreshPlanner::class);
+        $planner->expects(self::once())
+            ->method('plan')
+            ->with(2026, 3, null)
+            ->willReturn([]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::never())->method('dispatch');
+
+        $tester = $this->makeTester($planner, $bus, new MockClock('2026-03-31 22:30:00+00:00'));
+        $exitCode = $tester->execute(['--previous-month' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+    }
+
     public function testInvalidInputReturnsFailure(): void
     {
         $planner = $this->createMock(OzonMonthRawRefreshPlanner::class);
@@ -122,6 +139,8 @@ final class OzonMonthRawRefreshCommandTest extends TestCase
         self::assertSame(Command::FAILURE, $tester->execute(['--year' => '2026']));
         self::assertSame(Command::FAILURE, $tester->execute(['--month' => '4']));
         self::assertSame(Command::FAILURE, $tester->execute(['--year' => '2026', '--month' => '13']));
+        self::assertSame(Command::FAILURE, $tester->execute(['--year' => '2026foo', '--month' => '4']));
+        self::assertSame(Command::FAILURE, $tester->execute(['--year' => '2026', '--month' => '4bar']));
     }
 
     public function testEmptyPlanReturnsSuccessWithoutDispatch(): void

--- a/site/tests/Unit/Marketplace/Command/OzonMonthRawRefreshCommandTest.php
+++ b/site/tests/Unit/Marketplace/Command/OzonMonthRawRefreshCommandTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Command;
+
+use App\Marketplace\Application\DTO\OzonMonthRawRefreshPlanItem;
+use App\Marketplace\Application\OzonMonthRawRefreshPlanner;
+use App\Marketplace\Command\OzonMonthRawRefreshCommand;
+use App\Marketplace\Message\SyncOzonReportMessage;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class OzonMonthRawRefreshCommandTest extends TestCase
+{
+    public function testDryRunPrintsPlanAndDoesNotDispatch(): void
+    {
+        $planner = $this->createMock(OzonMonthRawRefreshPlanner::class);
+        $planner->expects(self::once())
+            ->method('plan')
+            ->with(2026, 4, null)
+            ->willReturn([
+                $this->planItem('planned', null, '2026-04-01'),
+                $this->planItem('skipped', 'finance_locked', '2026-04-02'),
+            ]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::never())->method('dispatch');
+
+        $tester = $this->makeTester($planner, $bus);
+        $exitCode = $tester->execute(['--year' => '2026', '--month' => '4', '--dry-run' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('company_id', $tester->getDisplay());
+        self::assertStringContainsString('2026-04-01', $tester->getDisplay());
+        self::assertStringContainsString('Dry-run завершен', $tester->getDisplay());
+    }
+
+    public function testDispatchesOnlyPlannedItems(): void
+    {
+        $planner = $this->createMock(OzonMonthRawRefreshPlanner::class);
+        $planner->method('plan')->willReturn([
+            $this->planItem('planned', null, '2026-04-01', 'c1', 'k1'),
+            $this->planItem('skipped', 'finance_locked', '2026-04-02', 'c1', 'k1'),
+            $this->planItem('planned', null, '2026-04-03', 'c2', 'k2'),
+        ]);
+
+        $messages = [];
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::exactly(2))->method('dispatch')->willReturnCallback(function (object $message) use (&$messages): Envelope {
+            $messages[] = $message;
+
+            return new Envelope($message);
+        });
+
+        $tester = $this->makeTester($planner, $bus);
+        $exitCode = $tester->execute(['--year' => '2026', '--month' => '4']);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertCount(2, $messages);
+        self::assertSame('2026-04-01', $messages[0]->date);
+        self::assertSame('2026-04-03', $messages[1]->date);
+        self::assertStringContainsString('planned dispatched: 2', $tester->getDisplay());
+        self::assertStringContainsString('skipped: 1', $tester->getDisplay());
+        self::assertStringContainsString('skipped by finance_locked: 1', $tester->getDisplay());
+    }
+
+    public function testCompanyIdPassedToPlanner(): void
+    {
+        $planner = $this->createMock(OzonMonthRawRefreshPlanner::class);
+        $planner->expects(self::once())
+            ->method('plan')
+            ->with(2026, 4, '11111111-1111-1111-1111-111111111111')
+            ->willReturn([]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::never())->method('dispatch');
+
+        $tester = $this->makeTester($planner, $bus);
+        $exitCode = $tester->execute([
+            '--year' => '2026',
+            '--month' => '4',
+            '--company-id' => '11111111-1111-1111-1111-111111111111',
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+    }
+
+    public function testPreviousMonthUsesClock(): void
+    {
+        $planner = $this->createMock(OzonMonthRawRefreshPlanner::class);
+        $planner->expects(self::once())
+            ->method('plan')
+            ->with(2026, 4, null)
+            ->willReturn([]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::never())->method('dispatch');
+
+        $tester = $this->makeTester($planner, $bus, new MockClock('2026-05-08 12:00:00'));
+        $exitCode = $tester->execute(['--previous-month' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+    }
+
+    public function testInvalidInputReturnsFailure(): void
+    {
+        $planner = $this->createMock(OzonMonthRawRefreshPlanner::class);
+        $planner->expects(self::never())->method('plan');
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::never())->method('dispatch');
+
+        $tester = $this->makeTester($planner, $bus);
+
+        self::assertSame(Command::FAILURE, $tester->execute(['--previous-month' => true, '--year' => '2026', '--month' => '4']));
+        self::assertSame(Command::FAILURE, $tester->execute([]));
+        self::assertSame(Command::FAILURE, $tester->execute(['--year' => '2026']));
+        self::assertSame(Command::FAILURE, $tester->execute(['--month' => '4']));
+        self::assertSame(Command::FAILURE, $tester->execute(['--year' => '2026', '--month' => '13']));
+    }
+
+    public function testEmptyPlanReturnsSuccessWithoutDispatch(): void
+    {
+        $planner = $this->createMock(OzonMonthRawRefreshPlanner::class);
+        $planner->method('plan')->willReturn([]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::never())->method('dispatch');
+
+        $tester = $this->makeTester($planner, $bus);
+        $exitCode = $tester->execute(['--year' => '2026', '--month' => '4']);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('План пуст', $tester->getDisplay());
+    }
+
+    private function makeTester(
+        OzonMonthRawRefreshPlanner $planner,
+        MessageBusInterface $bus,
+        ?MockClock $clock = null,
+    ): CommandTester {
+        $command = new OzonMonthRawRefreshCommand($planner, $bus, $clock ?? new MockClock('2026-05-08 12:00:00'));
+
+        return new CommandTester($command);
+    }
+
+    private function planItem(
+        string $status,
+        ?string $reason,
+        string $date,
+        string $companyId = '11111111-1111-1111-1111-111111111111',
+        string $connectionId = '22222222-2222-2222-2222-222222222222',
+    ): OzonMonthRawRefreshPlanItem {
+        return new OzonMonthRawRefreshPlanItem(
+            companyId: $companyId,
+            connectionId: $connectionId,
+            marketplace: 'ozon',
+            date: $date,
+            status: $status,
+            skippedReason: $reason,
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a safe, read-only CLI entrypoint to trigger monthly pre-close Ozon raw-data refresh planning without calling Ozon API or writing raw docs, so monthly reconciliation can be run for past month days.
- Reuse the existing `OzonMonthRawRefreshPlanner` to build the plan and ensure finance-locked / skipped dates are not dispatched.

### Description
- Added new Symfony console command `app:marketplace:ozon-month-raw-refresh` at `site/src/Marketplace/Command/OzonMonthRawRefreshCommand.php` which accepts `--year`, `--month`, `--previous-month`, `--company-id`, and `--dry-run` options and injects `OzonMonthRawRefreshPlanner`, `MessageBusInterface` and `ClockInterface`.
- Implemented strict period resolution and validation according to the rules: mutually exclusive `--previous-month` vs `--year/--month`, require both `--year` and `--month` together, validate `month` range and `year >= 2000`, and compute previous month using `ClockInterface`.
- Command is read-only with planner: in `--dry-run` it renders a table with columns `company_id`, `connection_id`, `date`, `status`, `skipped_reason` and does not dispatch or write anything; in normal mode it dispatches `SyncOzonReportMessage` only for items with `status = planned` and skips `skipped`/`finance_locked` items, then prints a summary (`total items`, `planned dispatched`, `skipped`, `skipped by finance_locked`).
- Added unit tests at `site/tests/Unit/Marketplace/Command/OzonMonthRawRefreshCommandTest.php` covering dry-run output/no-dispatch, dispatch-only-for-planned, `--company-id` propagation, `--previous-month` calculation via `MockClock`, invalid input matrix, and empty-plan success path.
- Followed repository rules from `CLAUDE.md` / `ARCHITECTURE.md`: used planner Facade, scalar message DTO `SyncOzonReportMessage`, no direct API/raw-doc writes, constructor injection, and proper use of `ClockInterface`.

### Testing
- Added unit tests: `tests/Unit/Marketplace/Command/OzonMonthRawRefreshCommandTest.php` covering the scenarios required by the task and exercising the command logic.
- Attempted to run the PHPUnit checks via the project commands but automated runs failed in the current environment due to missing Docker tooling: the `docker-compose`/`docker compose` calls to run `phpunit` returned `/bin/bash: docker-compose: command not found` and `/bin/bash: docker: command not found`, so tests were not executed here.
- No changes to existing planner/handler/processor code or their tests were made; existing unit/integration tests for those components remain unchanged and should be run in CI with Docker available (suggested commands: `php -d memory_limit=1G bin/phpunit tests/Unit/Marketplace/Command/OzonMonthRawRefreshCommandTest.php` via the project Docker runner).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf31033bc832397eab632ebdc744f)