### PR TITLE
Use real OzonMonthRawRefreshPlanner in tests and add DB-backed test helper

### DIFF
--- a/site/tests/Unit/Marketplace/Command/OzonMonthRawRefreshCommandTest.php
+++ b/site/tests/Unit/Marketplace/Command/OzonMonthRawRefreshCommandTest.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Marketplace\Command;
 
-use App\Marketplace\Application\DTO\OzonMonthRawRefreshPlanItem;
 use App\Marketplace\Application\OzonMonthRawRefreshPlanner;
 use App\Marketplace\Command\OzonMonthRawRefreshCommand;
+use App\Marketplace\Infrastructure\Query\ActiveOzonConnectionsQuery;
 use App\Marketplace\Message\SyncOzonReportMessage;
+use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Clock\MockClock;
 use Symfony\Component\Console\Command\Command;
@@ -19,19 +20,17 @@ final class OzonMonthRawRefreshCommandTest extends TestCase
 {
     public function testDryRunPrintsPlanAndDoesNotDispatch(): void
     {
-        $planner = $this->createMock(OzonMonthRawRefreshPlanner::class);
-        $planner->expects(self::once())
-            ->method('plan')
-            ->with(2026, 4, null)
-            ->willReturn([
-                $this->planItem('planned', null, '2026-04-01'),
-                $this->planItem('skipped', 'finance_locked', '2026-04-02'),
-            ]);
-
         $bus = $this->createMock(MessageBusInterface::class);
         $bus->expects(self::never())->method('dispatch');
 
-        $tester = $this->makeTester($planner, $bus);
+        $tester = $this->makeTesterWithConnectionRows([
+            [
+                'id' => '22222222-2222-2222-2222-222222222222',
+                'company_id' => '11111111-1111-1111-1111-111111111111',
+                'finance_lock_before' => null,
+            ],
+        ], $bus);
+
         $exitCode = $tester->execute(['--year' => '2026', '--month' => '4', '--dry-run' => true]);
 
         self::assertSame(Command::SUCCESS, $exitCode);
@@ -42,13 +41,6 @@ final class OzonMonthRawRefreshCommandTest extends TestCase
 
     public function testDispatchesOnlyPlannedItems(): void
     {
-        $planner = $this->createMock(OzonMonthRawRefreshPlanner::class);
-        $planner->method('plan')->willReturn([
-            $this->planItem('planned', null, '2026-04-01', 'c1', 'k1'),
-            $this->planItem('skipped', 'finance_locked', '2026-04-02', 'c1', 'k1'),
-            $this->planItem('planned', null, '2026-04-03', 'c2', 'k2'),
-        ]);
-
         $messages = [];
         $bus = $this->createMock(MessageBusInterface::class);
         $bus->expects(self::exactly(2))->method('dispatch')->willReturnCallback(function (object $message) use (&$messages): Envelope {
@@ -57,34 +49,49 @@ final class OzonMonthRawRefreshCommandTest extends TestCase
             return new Envelope($message);
         });
 
-        $tester = $this->makeTester($planner, $bus);
+        $tester = $this->makeTesterWithConnectionRows([
+            [
+                'id' => '22222222-2222-2222-2222-222222222222',
+                'company_id' => '11111111-1111-1111-1111-111111111111',
+                'finance_lock_before' => '2026-04-28',
+            ],
+        ], $bus);
+
         $exitCode = $tester->execute(['--year' => '2026', '--month' => '4']);
 
         self::assertSame(Command::SUCCESS, $exitCode);
         self::assertCount(2, $messages);
-        self::assertSame('2026-04-01', $messages[0]->date);
-        self::assertSame('2026-04-03', $messages[1]->date);
+        self::assertInstanceOf(SyncOzonReportMessage::class, $messages[0]);
+        self::assertInstanceOf(SyncOzonReportMessage::class, $messages[1]);
+        self::assertSame('2026-04-29', $messages[0]->date);
+        self::assertSame('2026-04-30', $messages[1]->date);
         self::assertStringContainsString('planned dispatched: 2', $tester->getDisplay());
-        self::assertStringContainsString('skipped: 1', $tester->getDisplay());
-        self::assertStringContainsString('skipped by finance_locked: 1', $tester->getDisplay());
+        self::assertStringContainsString('skipped: 28', $tester->getDisplay());
+        self::assertStringContainsString('skipped by finance_locked: 28', $tester->getDisplay());
     }
 
     public function testCompanyIdPassedToPlanner(): void
     {
-        $planner = $this->createMock(OzonMonthRawRefreshPlanner::class);
-        $planner->expects(self::once())
-            ->method('plan')
-            ->with(2026, 4, '11111111-1111-1111-1111-111111111111')
-            ->willReturn([]);
-
         $bus = $this->createMock(MessageBusInterface::class);
         $bus->expects(self::never())->method('dispatch');
 
-        $tester = $this->makeTester($planner, $bus);
+        $tester = $this->makeTesterWithConnectionRows([
+            [
+                'id' => '22222222-2222-2222-2222-222222222222',
+                'company_id' => '11111111-1111-1111-1111-111111111111',
+                'finance_lock_before' => null,
+            ],
+        ], $bus, null, static function (string $sql, array $params): void {
+            self::assertStringContainsString('mc.company_id = :company_id', $sql);
+            self::assertArrayHasKey('company_id', $params);
+            self::assertSame('11111111-1111-1111-1111-111111111111', $params['company_id']);
+        });
+
         $exitCode = $tester->execute([
             '--year' => '2026',
             '--month' => '4',
             '--company-id' => '11111111-1111-1111-1111-111111111111',
+            '--dry-run' => true,
         ]);
 
         self::assertSame(Command::SUCCESS, $exitCode);
@@ -92,47 +99,55 @@ final class OzonMonthRawRefreshCommandTest extends TestCase
 
     public function testPreviousMonthUsesClock(): void
     {
-        $planner = $this->createMock(OzonMonthRawRefreshPlanner::class);
-        $planner->expects(self::once())
-            ->method('plan')
-            ->with(2026, 4, null)
-            ->willReturn([]);
-
         $bus = $this->createMock(MessageBusInterface::class);
         $bus->expects(self::never())->method('dispatch');
 
-        $tester = $this->makeTester($planner, $bus, new MockClock('2026-05-08 12:00:00'));
-        $exitCode = $tester->execute(['--previous-month' => true]);
+        $tester = $this->makeTesterWithConnectionRows([
+            [
+                'id' => '22222222-2222-2222-2222-222222222222',
+                'company_id' => '11111111-1111-1111-1111-111111111111',
+                'finance_lock_before' => null,
+            ],
+        ], $bus, new MockClock('2026-05-08 12:00:00'));
+
+        $exitCode = $tester->execute(['--previous-month' => true, '--dry-run' => true]);
 
         self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('2026-04-01', $tester->getDisplay());
+        self::assertStringContainsString('2026-04-30', $tester->getDisplay());
     }
 
     public function testPreviousMonthUsesMoscowTimezoneBoundary(): void
     {
-        $planner = $this->createMock(OzonMonthRawRefreshPlanner::class);
-        $planner->expects(self::once())
-            ->method('plan')
-            ->with(2026, 3, null)
-            ->willReturn([]);
-
         $bus = $this->createMock(MessageBusInterface::class);
         $bus->expects(self::never())->method('dispatch');
 
-        $tester = $this->makeTester($planner, $bus, new MockClock('2026-03-31 22:30:00+00:00'));
-        $exitCode = $tester->execute(['--previous-month' => true]);
+        $tester = $this->makeTesterWithConnectionRows([
+            [
+                'id' => '22222222-2222-2222-2222-222222222222',
+                'company_id' => '11111111-1111-1111-1111-111111111111',
+                'finance_lock_before' => null,
+            ],
+        ], $bus, new MockClock('2026-03-31 22:30:00+00:00'));
+
+        $exitCode = $tester->execute(['--previous-month' => true, '--dry-run' => true]);
 
         self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('2026-03-01', $tester->getDisplay());
+        self::assertStringContainsString('2026-03-31', $tester->getDisplay());
     }
 
     public function testInvalidInputReturnsFailure(): void
     {
-        $planner = $this->createMock(OzonMonthRawRefreshPlanner::class);
-        $planner->expects(self::never())->method('plan');
-
         $bus = $this->createMock(MessageBusInterface::class);
         $bus->expects(self::never())->method('dispatch');
 
-        $tester = $this->makeTester($planner, $bus);
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::never())->method('fetchAllAssociative');
+
+        $query = new ActiveOzonConnectionsQuery($connection);
+        $planner = new OzonMonthRawRefreshPlanner($query);
+        $tester = new CommandTester(new OzonMonthRawRefreshCommand($planner, $bus, new MockClock('2026-05-08 12:00:00')));
 
         self::assertSame(Command::FAILURE, $tester->execute(['--previous-month' => true, '--year' => '2026', '--month' => '4']));
         self::assertSame(Command::FAILURE, $tester->execute([]));
@@ -145,43 +160,41 @@ final class OzonMonthRawRefreshCommandTest extends TestCase
 
     public function testEmptyPlanReturnsSuccessWithoutDispatch(): void
     {
-        $planner = $this->createMock(OzonMonthRawRefreshPlanner::class);
-        $planner->method('plan')->willReturn([]);
-
         $bus = $this->createMock(MessageBusInterface::class);
         $bus->expects(self::never())->method('dispatch');
 
-        $tester = $this->makeTester($planner, $bus);
+        $tester = $this->makeTesterWithConnectionRows([], $bus);
         $exitCode = $tester->execute(['--year' => '2026', '--month' => '4']);
 
         self::assertSame(Command::SUCCESS, $exitCode);
         self::assertStringContainsString('План пуст', $tester->getDisplay());
     }
 
-    private function makeTester(
-        OzonMonthRawRefreshPlanner $planner,
+    private function makeTesterWithConnectionRows(
+        array $connectionRows,
         MessageBusInterface $bus,
         ?MockClock $clock = null,
+        ?callable $connectionAssert = null,
     ): CommandTester {
-        $command = new OzonMonthRawRefreshCommand($planner, $bus, $clock ?? new MockClock('2026-05-08 12:00:00'));
+        $dbal = $this->createMock(Connection::class);
+        $dbal->method('fetchAllAssociative')
+            ->willReturnCallback(function (string $sql, array $params = []) use ($connectionRows, $connectionAssert): array {
+                if ($connectionAssert !== null) {
+                    $connectionAssert($sql, $params);
+                }
+
+                return $connectionRows;
+            });
+
+        $query = new ActiveOzonConnectionsQuery($dbal);
+        $planner = new OzonMonthRawRefreshPlanner($query);
+
+        $command = new OzonMonthRawRefreshCommand(
+            $planner,
+            $bus,
+            $clock ?? new MockClock('2026-05-08 12:00:00'),
+        );
 
         return new CommandTester($command);
-    }
-
-    private function planItem(
-        string $status,
-        ?string $reason,
-        string $date,
-        string $companyId = '11111111-1111-1111-1111-111111111111',
-        string $connectionId = '22222222-2222-2222-2222-222222222222',
-    ): OzonMonthRawRefreshPlanItem {
-        return new OzonMonthRawRefreshPlanItem(
-            companyId: $companyId,
-            connectionId: $connectionId,
-            marketplace: 'ozon',
-            date: $date,
-            status: $status,
-            skippedReason: $reason,
-        );
     }
 }


### PR DESCRIPTION
### Motivation
- PHPUnit cannot double the `final` class `OzonMonthRawRefreshPlanner`, causing `ClassIsFinalException` in the command tests.
- Tests should exercise the real planner behavior while leaving production classes `final` and unchanged.

### Description
- Replace planner mocks with a real `OzonMonthRawRefreshPlanner` constructed from `ActiveOzonConnectionsQuery` backed by a mocked `Doctrine\DBAL\Connection` via a new helper `makeTesterWithConnectionRows` in `site/tests/Unit/Marketplace/Command/OzonMonthRawRefreshCommandTest.php`.
- Update tests to drive planning via provided DB rows and assert produced `SyncOzonReportMessage` instances, expected dispatched dates, `--company-id` SQL parameter assertion, `--previous-month` outcomes, invalid input failure cases, and empty-plan behavior.
- Remove the old `makeTester`/`planItem` mocking approach and keep production classes `OzonMonthRawRefreshCommand`, `OzonMonthRawRefreshPlanner`, and `ActiveOzonConnectionsQuery` unchanged.
- Apply a small helper cleanup to use an explicit `!== null` guard for the optional connection-assert callback.

### Testing
- Ran PHP syntax check with `php -l site/tests/Unit/Marketplace/Command/OzonMonthRawRefreshCommandTest.php` which passed.
- Attempted to run the full unit test suite with `vendor/bin/phpunit` / `bin/phpunit` but the test runner is not available in this environment so a full PHPUnit run was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdfbfd6e34832395b4a5008480387d)