### PR TITLE
Перевести PHPUnit docblock metadata на PHPUnit 11 attributes в unit-тестах

### DIFF
--- a/site/tests/Unit/Cash/Service/Import/File/CashFileRowNormalizerTest.php
+++ b/site/tests/Unit/Cash/Service/Import/File/CashFileRowNormalizerTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Cash\Service\Import\File;
 
 use App\Cash\Enum\Transaction\CashDirection;
 use App\Cash\Service\Import\File\CashFileRowNormalizer;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class CashFileRowNormalizerTest extends TestCase
@@ -34,9 +35,7 @@ final class CashFileRowNormalizerTest extends TestCase
         self::assertSame($expected, $result['externalId']);
     }
 
-    /**
-     * @dataProvider inflowOutflowProvider
-     */
+    #[DataProvider('inflowOutflowProvider')]
     public function testInflowOutflowModeDetectsDirection(array $row, CashDirection $direction, string $amount): void
     {
         $normalizer = new CashFileRowNormalizer();

--- a/site/tests/Unit/Marketplace/Application/Processor/WbCostsRawProcessorTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/WbCostsRawProcessorTest.php
@@ -22,6 +22,7 @@ use App\Marketplace\Service\CostCalculator\WbPvzProcessingCalculator;
 use App\Marketplace\Service\CostCalculator\WbStorageCalculator;
 use App\Marketplace\Service\CostCalculator\WbWarehouseLogisticsCalculator;
 use App\Shared\Service\SlugifyService;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -88,7 +89,7 @@ final class WbCostsRawProcessorTest extends TestCase
     // ProcessWbCostsAction::__invoke() — отдельные тесты ниже.
     // -------------------------------------------------------------------------
 
-    /** @dataProvider commissionScenarios */
+    #[DataProvider('commissionScenarios')]
     public function testWbCommissionCalculatorEmitsPositiveAmount(
         float $retailPrice,
         float $acquiringFee,

--- a/site/tests/Unit/MarketplaceAds/AdLoadJobTest.php
+++ b/site/tests/Unit/MarketplaceAds/AdLoadJobTest.php
@@ -8,6 +8,7 @@ use App\Marketplace\Enum\MarketplaceType;
 use App\MarketplaceAds\Entity\AdLoadJob;
 use App\MarketplaceAds\Enum\AdLoadJobStatus;
 use App\Tests\Builders\MarketplaceAds\AdLoadJobBuilder;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class AdLoadJobTest extends TestCase
@@ -243,9 +244,7 @@ final class AdLoadJobTest extends TestCase
         $job->setChunksTotal(5);
     }
 
-    /**
-     * @dataProvider invalidChunksTotalProvider
-     */
+    #[DataProvider('invalidChunksTotalProvider')]
     public function testSetChunksTotalRejectsZeroOrNegative(int $total): void
     {
         $job = AdLoadJobBuilder::aJob()->build();


### PR DESCRIPTION
### Motivation
- Устранить PHPUnit Deprecations, вызванные устаревшими doc-comment metadata (`@dataProvider`) и привести тесты в соответствие с PHPUnit 11.

### Description
- Заменил `@dataProvider` в тестах на атрибуты `#[DataProvider('...')]` в трёх файлах: `site/tests/Unit/Cash/Service/Import/File/CashFileRowNormalizerTest.php::testInflowOutflowModeDetectsDirection`, `site/tests/Unit/Marketplace/Application/Processor/WbCostsRawProcessorTest.php::testWbCommissionCalculatorEmitsPositiveAmount`, и `site/tests/Unit/MarketplaceAds/AdLoadJobTest.php::testSetChunksTotalRejectsZeroOrNegative`.
- Добавил `use PHPUnit\Framework\Attributes\DataProvider;` импорт в изменённых файлах.
- Никакая логика тестов, production-код или код vendor не изменялись.

### Testing
- Изменения закоммичены локально (`Fix PHPUnit 11 metadata deprecations in unit tests`).
- Попытки запустить целевые тесты через `docker-compose run --rm site-php-cli php -d memory_limit=1G bin/phpunit <test-file>` не были выполнены, потому что в окружении отсутствует `docker-compose` (ошибка: `bash: command not found: docker-compose`).
- Никакие автоматические unit-тесты не были исполнены в этом окружении; CI/локальная среда с доступом к `docker-compose` или соответствующим рантаймом должна подтвердить, что депрекации исчезли и тесты проходят чисто.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe03b8f8188323ab909cd5f1795968)