### PR TITLE
Add InventorySnapshotSessionListQuery with pagination and tests

### DIFF
--- a/site/src/Inventory/Infrastructure/Query/InventorySnapshotSessionListQuery.php
+++ b/site/src/Inventory/Infrastructure/Query/InventorySnapshotSessionListQuery.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Inventory\Infrastructure\Query;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Pagerfanta\Doctrine\DBAL\QueryAdapter;
+use Pagerfanta\Pagerfanta;
+use Webmozart\Assert\Assert;
+
+final class InventorySnapshotSessionListQuery
+{
+    public const PER_PAGE = 30;
+
+    public function __construct(
+        private readonly Connection $connection,
+    ) {
+    }
+
+    public function buildQueryBuilder(string $companyId): QueryBuilder
+    {
+        Assert::uuid($companyId);
+
+        return $this->connection->createQueryBuilder()
+            ->select(
+                's.id',
+                's.company_id',
+                's.source',
+                's.trigger_type',
+                's.status',
+                's.error_message',
+                's.expected_pages',
+                's.received_pages',
+                's.created_at',
+                's.started_at',
+                's.completed_at',
+            )
+            ->from('inventory_snapshot_sessions', 's')
+            ->where('s.company_id = :companyId')
+            ->setParameter('companyId', $companyId)
+            ->orderBy('s.created_at', 'DESC')
+            ->addOrderBy('s.id', 'DESC');
+    }
+
+    public function getPage(string $companyId, int $page, int $perPage = self::PER_PAGE): Pagerfanta
+    {
+        $currentPage = max(1, $page);
+        $currentPerPage = min(100, max(1, $perPage));
+
+        $qb = $this->buildQueryBuilder($companyId);
+
+        return Pagerfanta::createForCurrentPageWithMaxPerPage(
+            new QueryAdapter($qb, static function (QueryBuilder $countQb): void {
+                $countQb
+                    ->select('COUNT(s.id) AS total_results')
+                    ->resetOrderBy()
+                    ->setMaxResults(1);
+            }),
+            $currentPage,
+            $currentPerPage,
+        );
+    }
+}

--- a/site/tests/Integration/Inventory/Infrastructure/Query/InventorySnapshotSessionListQueryTest.php
+++ b/site/tests/Integration/Inventory/Infrastructure/Query/InventorySnapshotSessionListQueryTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Inventory\Infrastructure\Query;
+
+use App\Inventory\Enum\SnapshotTriggerType;
+use App\Inventory\Infrastructure\Query\InventorySnapshotSessionListQuery;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Inventory\InventorySnapshotSessionBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Doctrine\DBAL\Connection;
+
+final class InventorySnapshotSessionListQueryTest extends IntegrationTestCase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-000000000601';
+    private const OTHER_COMPANY_ID = '11111111-1111-1111-1111-000000000602';
+
+    private InventorySnapshotSessionListQuery $query;
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->query = self::getContainer()->get(InventorySnapshotSessionListQuery::class);
+        $this->connection = self::getContainer()->get(Connection::class);
+    }
+
+    public function testReturnsOnlyRecordsForRequestedCompany(): void
+    {
+        $own = InventorySnapshotSessionBuilder::aSession()->withCompanyId(self::COMPANY_ID)->build();
+        $foreign = InventorySnapshotSessionBuilder::aSession()->withCompanyId(self::OTHER_COMPANY_ID)->build();
+
+        $this->em->persist($own);
+        $this->em->persist($foreign);
+        $this->em->flush();
+
+        $rows = $this->query->buildQueryBuilder(self::COMPANY_ID)->executeQuery()->fetchAllAssociative();
+
+        self::assertCount(1, $rows);
+        self::assertSame(self::COMPANY_ID, $rows[0]['company_id']);
+        self::assertSame($own->getId(), $rows[0]['id']);
+    }
+
+    public function testSortsNewestFirst(): void
+    {
+        $old = InventorySnapshotSessionBuilder::aSession()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withSource(MarketplaceType::WILDBERRIES)
+            ->withTriggerType(SnapshotTriggerType::Manual)
+            ->build();
+
+        $new = InventorySnapshotSessionBuilder::aSession()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withSource(MarketplaceType::OZON)
+            ->withTriggerType(SnapshotTriggerType::Retry)
+            ->build();
+
+        $this->em->persist($old);
+        $this->em->persist($new);
+        $this->em->flush();
+
+        $this->connection->update('inventory_snapshot_sessions', ['created_at' => '2026-01-01 10:00:00'], ['id' => $old->getId()]);
+        $this->connection->update('inventory_snapshot_sessions', ['created_at' => '2026-01-02 10:00:00'], ['id' => $new->getId()]);
+
+        $rows = $this->query->buildQueryBuilder(self::COMPANY_ID)->executeQuery()->fetchAllAssociative();
+
+        self::assertCount(2, $rows);
+        self::assertSame($new->getId(), $rows[0]['id']);
+        self::assertSame($old->getId(), $rows[1]['id']);
+    }
+
+    public function testProvidesProductionPaginationWithDefaults(): void
+    {
+        for ($i = 1; $i <= 35; ++$i) {
+            $session = InventorySnapshotSessionBuilder::aSession()
+                ->withCompanyId(self::COMPANY_ID)
+                ->withCorrelationId(sprintf('33333333-3333-7333-8333-%012d', $i))
+                ->build();
+            $this->em->persist($session);
+        }
+        $this->em->flush();
+
+        $pager = $this->query->getPage(self::COMPANY_ID, 1);
+
+        self::assertSame(35, $pager->getNbResults());
+        self::assertSame(InventorySnapshotSessionListQuery::PER_PAGE, $pager->getMaxPerPage());
+        self::assertSame(1, $pager->getCurrentPage());
+        self::assertSame(2, $pager->getNbPages());
+        self::assertCount(30, iterator_to_array($pager->getCurrentPageResults()));
+    }
+
+    public function testDoesNotSelectRawPayloadColumns(): void
+    {
+        $sql = $this->query->buildQueryBuilder(self::COMPANY_ID)->getSQL();
+
+        self::assertStringNotContainsString('*', $sql);
+        self::assertStringNotContainsString('raw_response', $sql);
+        self::assertStringNotContainsString('payload', $sql);
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a reusable DBAL query for listing inventory snapshot sessions scoped to a company with stable ordering and pagination.
- Avoid selecting large raw payload columns in the listing and enforce valid `companyId` format.

### Description

- Added `InventorySnapshotSessionListQuery` which builds a `QueryBuilder` selecting specific session fields and ordering by `created_at` and `id` while asserting `companyId` is a UUID.
- Implemented `getPage` which wraps the query in a `Pagerfanta` pager using `QueryAdapter` and exposes a `PER_PAGE` default with bounds checks.
- Selected explicit columns only (no `*` or raw payload fields) and limited the max `perPage` to 100.
- Added `InventorySnapshotSessionListQueryTest` integration tests covering company scoping, sort order, default pagination behavior, and ensuring raw payload columns are not selected.

### Testing

- Ran the integration test class `InventorySnapshotSessionListQueryTest` including `testReturnsOnlyRecordsForRequestedCompany`, `testSortsNewestFirst`, `testProvidesProductionPaginationWithDefaults`, and `testDoesNotSelectRawPayloadColumns`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0041077a948323ba4251c3ca203519)