### PR TITLE
Add findLatestActiveByCompanyAndSource to InventorySnapshotSessionRepository with integration tests

### DIFF
--- a/site/src/Inventory/Repository/InventorySnapshotSessionRepository.php
+++ b/site/src/Inventory/Repository/InventorySnapshotSessionRepository.php
@@ -5,13 +5,37 @@ declare(strict_types=1);
 namespace App\Inventory\Repository;
 
 use App\Inventory\Entity\InventorySnapshotSession;
+use App\Inventory\Enum\SnapshotSessionStatus;
+use App\Marketplace\Enum\MarketplaceType;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Webmozart\Assert\Assert;
 
 final class InventorySnapshotSessionRepository extends ServiceEntityRepository
 {
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, InventorySnapshotSession::class);
+    }
+
+    public function findLatestActiveByCompanyAndSource(string $companyId, MarketplaceType $source): ?InventorySnapshotSession
+    {
+        Assert::uuid($companyId);
+
+        return $this->createQueryBuilder('session')
+            ->andWhere('session.companyId = :companyId')
+            ->andWhere('session.source = :source')
+            ->andWhere('session.status IN (:activeStatuses)')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('source', $source)
+            ->setParameter('activeStatuses', [
+                SnapshotSessionStatus::Pending,
+                SnapshotSessionStatus::InProgress,
+            ])
+            ->orderBy('session.startedAt', 'DESC')
+            ->addOrderBy('session.id', 'DESC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
     }
 }

--- a/site/tests/Integration/Inventory/Repository/InventorySnapshotSessionRepositoryTest.php
+++ b/site/tests/Integration/Inventory/Repository/InventorySnapshotSessionRepositoryTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Inventory\Repository;
+
+use App\Inventory\Enum\SnapshotSessionStatus;
+use App\Inventory\Repository\InventorySnapshotSessionRepository;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Inventory\InventorySnapshotSessionBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+
+final class InventorySnapshotSessionRepositoryTest extends IntegrationTestCase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-000000000701';
+    private const OTHER_COMPANY_ID = '11111111-1111-1111-1111-000000000702';
+
+    private InventorySnapshotSessionRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = self::getContainer()->get(InventorySnapshotSessionRepository::class);
+    }
+
+    public function testFindLatestActiveByCompanyAndSourceReturnsOwnCompanySession(): void
+    {
+        $pending = InventorySnapshotSessionBuilder::aSession()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withSource(MarketplaceType::OZON)
+            ->withCorrelationId('33333333-3333-7333-8333-000000000701')
+            ->build();
+
+        $inProgress = InventorySnapshotSessionBuilder::aSession()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withSource(MarketplaceType::OZON)
+            ->withCorrelationId('33333333-3333-7333-8333-000000000702')
+            ->build();
+        $inProgress->markInProgress();
+
+        $this->em->persist($pending);
+        $this->em->persist($inProgress);
+        $this->em->flush();
+
+        $this->em->getConnection()->update('inventory_snapshot_sessions', ['started_at' => '2026-04-01 10:00:00'], ['id' => $pending->getId()]);
+        $this->em->getConnection()->update('inventory_snapshot_sessions', ['started_at' => '2026-04-02 10:00:00'], ['id' => $inProgress->getId()]);
+
+        $this->em->clear();
+
+        $found = $this->repository->findLatestActiveByCompanyAndSource(self::COMPANY_ID, MarketplaceType::OZON);
+
+        self::assertNotNull($found);
+        self::assertSame($inProgress->getId(), $found->getId());
+        self::assertSame(SnapshotSessionStatus::InProgress, $found->getStatus());
+    }
+
+    public function testTerminalStatusIsNotActive(): void
+    {
+        $completed = InventorySnapshotSessionBuilder::aSession()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withSource(MarketplaceType::OZON)
+            ->withCorrelationId('33333333-3333-7333-8333-000000000703')
+            ->build();
+        $completed->markCompleted();
+
+        $this->em->persist($completed);
+        $this->em->flush();
+        $this->em->clear();
+
+        $found = $this->repository->findLatestActiveByCompanyAndSource(self::COMPANY_ID, MarketplaceType::OZON);
+
+        self::assertNull($found);
+    }
+
+    public function testForeignCompanySessionIsNotVisible(): void
+    {
+        $foreign = InventorySnapshotSessionBuilder::aSession()
+            ->withCompanyId(self::OTHER_COMPANY_ID)
+            ->withSource(MarketplaceType::OZON)
+            ->withCorrelationId('33333333-3333-7333-8333-000000000704')
+            ->build();
+
+        $this->em->persist($foreign);
+        $this->em->flush();
+        $this->em->clear();
+
+        $found = $this->repository->findLatestActiveByCompanyAndSource(self::COMPANY_ID, MarketplaceType::OZON);
+
+        self::assertNull($found);
+    }
+
+    public function testOtherSourceDoesNotBlockRequestedSource(): void
+    {
+        $otherSource = InventorySnapshotSessionBuilder::aSession()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withSource(MarketplaceType::WILDBERRIES)
+            ->withCorrelationId('33333333-3333-7333-8333-000000000705')
+            ->build();
+        $otherSource->markInProgress();
+
+        $this->em->persist($otherSource);
+        $this->em->flush();
+        $this->em->clear();
+
+        $found = $this->repository->findLatestActiveByCompanyAndSource(self::COMPANY_ID, MarketplaceType::OZON);
+
+        self::assertNull($found);
+    }
+
+    public function testRepositoryDoesNotFlushOnPersistWithoutManualFlush(): void
+    {
+        $session = InventorySnapshotSessionBuilder::aSession()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withSource(MarketplaceType::OZON)
+            ->withCorrelationId('33333333-3333-7333-8333-000000000706')
+            ->build();
+
+        $this->em->persist($session);
+
+        $count = (int) $this->em->getConnection()->fetchOne('SELECT COUNT(*) FROM inventory_snapshot_sessions');
+        self::assertSame(0, $count);
+    }
+    public function testFindLatestActiveByCompanyAndSourceThrowsForInvalidCompanyId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->repository->findLatestActiveByCompanyAndSource('not-a-uuid', MarketplaceType::OZON);
+    }
+
+}


### PR DESCRIPTION
### Motivation
- Provide a repository-level query to fetch the latest active inventory snapshot session for a given company and marketplace source while excluding terminal statuses and validating the company id.

### Description
- Added `findLatestActiveByCompanyAndSource(string $companyId, MarketplaceType $source): ?InventorySnapshotSession` to `InventorySnapshotSessionRepository` which validates the `companyId` with `Assert::uuid` and filters by `companyId`, `source` and active statuses (`Pending`, `InProgress`).
- The query orders by `startedAt` then `id` in descending order and returns at most one result.
- Imported `SnapshotSessionStatus`, `MarketplaceType`, and `Webmozart\\Assert::Assert` to support status checks and input validation.
- Added an integration test file `InventorySnapshotSessionRepositoryTest` covering success and edge cases for the new method.

### Testing
- Ran the repository integration tests in `InventorySnapshotSessionRepositoryTest` which include `testFindLatestActiveByCompanyAndSourceReturnsOwnCompanySession`, `testTerminalStatusIsNotActive`, `testForeignCompanySessionIsNotVisible`, `testOtherSourceDoesNotBlockRequestedSource`, `testRepositoryDoesNotFlushOnPersistWithoutManualFlush`, and `testFindLatestActiveByCompanyAndSourceThrowsForInvalidCompanyId` using `phpunit` and the integration test harness; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0045edf2e08323a830b4052364b762)