### PR TITLE
Add Ozon inventory snapshot request action, message, routing and tests

### DIFF
--- a/site/config/packages/messenger.yaml
+++ b/site/config/packages/messenger.yaml
@@ -48,6 +48,7 @@ framework:
             'Symfony\Component\Mailer\Messenger\SendEmailMessage': async_sync
             'Symfony\Component\Notifier\Message\ChatMessage': async_sync
             'Symfony\Component\Notifier\Message\SmsMessage': async_sync
+            'App\Inventory\Message\SyncOzonInventorySnapshotMessage': async_sync
 
             # --- async_pipeline: local CPU/DB processing of already-fetched data ---
             'App\Marketplace\Message\ProcessDayReportMessage': async_pipeline

--- a/site/src/Inventory/Application/DTO/OzonInventorySnapshotRequestResult.php
+++ b/site/src/Inventory/Application/DTO/OzonInventorySnapshotRequestResult.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Inventory\Application\DTO;
+
+final readonly class OzonInventorySnapshotRequestResult
+{
+    /**
+     * @param list<string> $messages
+     */
+    public function __construct(
+        public int $queuedCount,
+        public int $skippedCount,
+        public bool $hasConnections,
+        public bool $hasActiveSession,
+        public array $messages = [],
+    ) {
+    }
+}

--- a/site/src/Inventory/Application/RequestOzonInventorySnapshotAction.php
+++ b/site/src/Inventory/Application/RequestOzonInventorySnapshotAction.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Inventory\Application;
+
+use App\Inventory\Application\DTO\OzonInventorySnapshotRequestResult;
+use App\Inventory\Entity\InventorySnapshotSession;
+use App\Inventory\Enum\SnapshotTriggerType;
+use App\Inventory\Message\SyncOzonInventorySnapshotMessage;
+use App\Inventory\Repository\InventorySnapshotSessionRepository;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Facade\MarketplaceFacade;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Webmozart\Assert\Assert;
+
+final readonly class RequestOzonInventorySnapshotAction
+{
+    public function __construct(
+        private MarketplaceFacade $marketplaceFacade,
+        private InventorySnapshotSessionRepository $sessionRepository,
+        private EntityManagerInterface $entityManager,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    public function __invoke(string $companyId, SnapshotTriggerType $triggerType, ?string $actorUserId = null): OzonInventorySnapshotRequestResult
+    {
+        Assert::uuid($companyId);
+
+        if ($actorUserId !== null) {
+            Assert::uuid($actorUserId);
+        }
+
+        $connections = $this->marketplaceFacade->getActiveOzonSellerConnections($companyId);
+
+        if ($connections === []) {
+            return new OzonInventorySnapshotRequestResult(
+                queuedCount: 0,
+                skippedCount: 0,
+                hasConnections: false,
+                hasActiveSession: false,
+                messages: ['No active Ozon SELLER connections found.'],
+            );
+        }
+
+        $validConnectionIds = [];
+        $skippedCount = 0;
+        $messages = [];
+
+        foreach ($connections as $connection) {
+            $connectionId = (string) ($connection['connectionId'] ?? '');
+            if ($connectionId === '') {
+                ++$skippedCount;
+                $messages[] = 'Skipped one connection: empty connectionId.';
+
+                continue;
+            }
+
+            if (!Uuid::isValid($connectionId)) {
+                ++$skippedCount;
+                $messages[] = sprintf('Skipped connection with invalid UUID: %s', $connectionId);
+
+                continue;
+            }
+
+            $validConnectionIds[] = $connectionId;
+        }
+
+        if ($validConnectionIds === []) {
+            return new OzonInventorySnapshotRequestResult(
+                queuedCount: 0,
+                skippedCount: $skippedCount,
+                hasConnections: true,
+                hasActiveSession: false,
+                messages: $messages,
+            );
+        }
+
+        $activeSession = $this->sessionRepository->findLatestActiveByCompanyAndSource($companyId, MarketplaceType::OZON);
+
+        if ($activeSession !== null) {
+            return new OzonInventorySnapshotRequestResult(
+                queuedCount: 0,
+                skippedCount: $skippedCount + count($validConnectionIds),
+                hasConnections: true,
+                hasActiveSession: true,
+                messages: array_merge($messages, ['Snapshot request skipped: active session already exists.']),
+            );
+        }
+
+        $session = new InventorySnapshotSession(
+            companyId: $companyId,
+            source: MarketplaceType::OZON,
+            triggerType: $triggerType,
+            triggeredBy: $actorUserId,
+        );
+
+        $this->entityManager->persist($session);
+        $this->entityManager->flush();
+
+        $queuedCount = 0;
+
+        foreach ($validConnectionIds as $connectionId) {
+
+            try {
+                $this->messageBus->dispatch(new SyncOzonInventorySnapshotMessage(
+                    companyId: $companyId,
+                    connectionId: $connectionId,
+                    snapshotSessionId: $session->getId(),
+                    triggerType: $triggerType->value,
+                ));
+                ++$queuedCount;
+            } catch (\Throwable $e) {
+                ++$skippedCount;
+                $messages[] = sprintf('Failed to queue connection %s: %s', $connectionId, $e->getMessage());
+            }
+        }
+
+        if ($queuedCount === 0) {
+            $session->markFailed('Failed to queue all Ozon inventory snapshot messages.');
+            $this->entityManager->flush();
+        }
+
+        return new OzonInventorySnapshotRequestResult(
+            queuedCount: $queuedCount,
+            skippedCount: $skippedCount,
+            hasConnections: true,
+            hasActiveSession: false,
+            messages: $messages,
+        );
+    }
+}

--- a/site/src/Inventory/Message/SyncOzonInventorySnapshotMessage.php
+++ b/site/src/Inventory/Message/SyncOzonInventorySnapshotMessage.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Inventory\Message;
+
+final readonly class SyncOzonInventorySnapshotMessage
+{
+    public function __construct(
+        public string $companyId,
+        public string $connectionId,
+        public string $snapshotSessionId,
+        public string $triggerType,
+    ) {
+    }
+}

--- a/site/tests/Integration/Inventory/Application/RequestOzonInventorySnapshotActionTest.php
+++ b/site/tests/Integration/Inventory/Application/RequestOzonInventorySnapshotActionTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Inventory\Application;
+
+use App\Company\Entity\Company;
+use App\Inventory\Application\RequestOzonInventorySnapshotAction;
+use App\Inventory\Enum\SnapshotTriggerType;
+use App\Inventory\Message\SyncOzonInventorySnapshotMessage;
+use App\Inventory\Repository\InventorySnapshotSessionRepository;
+use App\Marketplace\Facade\MarketplaceFacade;
+use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Enum\MarketplaceConnectionType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class RequestOzonInventorySnapshotActionTest extends IntegrationTestCase
+{
+    private InventorySnapshotSessionRepository $sessionRepository;
+    private MarketplaceFacade $marketplaceFacade;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->sessionRepository = self::getContainer()->get(InventorySnapshotSessionRepository::class);
+        $this->marketplaceFacade = self::getContainer()->get(MarketplaceFacade::class);
+    }
+
+    public function testNoActiveConnectionReturnsHasConnectionsFalse(): void
+    {
+        $company = $this->createCompany(101);
+
+        $action = new RequestOzonInventorySnapshotAction(
+            $this->marketplaceFacade,
+            $this->sessionRepository,
+            $this->em,
+            new InMemoryBus(),
+        );
+
+        $result = $action($company->getId(), SnapshotTriggerType::Manual);
+
+        self::assertFalse($result->hasConnections);
+        self::assertSame(0, $result->queuedCount);
+    }
+
+    public function testActiveConnectionCreatesSessionAndDispatchesMessage(): void
+    {
+        $company = $this->createCompany(102);
+        $this->createSellerConnection($company, '77777777-7777-7777-7777-000000000001');
+
+        $bus = new InMemoryBus();
+        $action = new RequestOzonInventorySnapshotAction(
+            $this->marketplaceFacade,
+            $this->sessionRepository,
+            $this->em,
+            $bus,
+        );
+
+        $result = $action($company->getId(), SnapshotTriggerType::Manual);
+
+        self::assertSame(1, $result->queuedCount);
+        self::assertCount(1, $bus->messages);
+        $message = $bus->messages[0];
+        self::assertInstanceOf(SyncOzonInventorySnapshotMessage::class, $message);
+        self::assertSame(SnapshotTriggerType::Manual->value, $message->triggerType);
+    }
+
+    public function testActiveSessionSkipsDuplicateDispatch(): void
+    {
+        $company = $this->createCompany(103);
+        $this->createSellerConnection($company, '77777777-7777-7777-7777-000000000002');
+
+        $bus = new InMemoryBus();
+        $action = new RequestOzonInventorySnapshotAction(
+            $this->marketplaceFacade,
+            $this->sessionRepository,
+            $this->em,
+            $bus,
+        );
+
+        self::assertSame(1, $action($company->getId(), SnapshotTriggerType::Manual)->queuedCount);
+        $second = $action($company->getId(), SnapshotTriggerType::Manual);
+
+        self::assertTrue($second->hasActiveSession);
+        self::assertSame(0, $second->queuedCount);
+        self::assertCount(1, $bus->messages);
+    }
+
+    public function testAllDispatchFailuresMarkSessionFailed(): void
+    {
+        $company = $this->createCompany(104);
+        $this->createSellerConnection($company, '77777777-7777-7777-7777-000000000003');
+
+        $action = new RequestOzonInventorySnapshotAction(
+            $this->marketplaceFacade,
+            $this->sessionRepository,
+            $this->em,
+            new FailingBus(),
+        );
+
+        $result = $action($company->getId(), SnapshotTriggerType::Manual);
+
+        self::assertSame(0, $result->queuedCount);
+        self::assertSame(1, $result->skippedCount);
+
+        $session = $this->sessionRepository->findLatestActiveByCompanyAndSource($company->getId(), MarketplaceType::OZON);
+        self::assertNull($session, 'Session must not remain active pending/in_progress when all dispatches failed.');
+    }
+
+    private function createCompany(int $index): Company
+    {
+        $user = UserBuilder::aUser()->withIndex($index)->build();
+        $company = CompanyBuilder::aCompany()->withIndex($index)->withOwner($user)->build();
+        $this->em->persist($user);
+        $this->em->persist($company);
+        $this->em->flush();
+
+        return $company;
+    }
+
+    private function createSellerConnection(Company $company, string $connectionId): void
+    {
+        $connection = new MarketplaceConnection($connectionId, $company, MarketplaceType::OZON, MarketplaceConnectionType::SELLER);
+        $connection->setApiKey('test-key')->setClientId('test-client')->setIsActive(true);
+        $this->em->persist($connection);
+        $this->em->flush();
+    }
+}
+
+final class InMemoryBus implements MessageBusInterface
+{
+    /** @var list<object> */
+    public array $messages = [];
+
+    public function dispatch(object $message, array $stamps = []): Envelope
+    {
+        $this->messages[] = $message;
+
+        return new Envelope($message, $stamps);
+    }
+}
+
+final class FailingBus implements MessageBusInterface
+{
+    public function dispatch(object $message, array $stamps = []): Envelope
+    {
+        throw new \RuntimeException('Dispatch failed.');
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a server-side action to request Ozon inventory snapshots per active seller connection and enqueue per-connection snapshot messages.
- Prevent duplicate snapshot requests when an active snapshot session already exists and surface diagnostics for skipped/failed enqueues.

### Description

- Added messenger routing for `App\Inventory\Message\SyncOzonInventorySnapshotMessage` to `async_sync` in `site/config/packages/messenger.yaml`.
- Implemented `RequestOzonInventorySnapshotAction` which validates inputs, queries active Ozon seller connections via `MarketplaceFacade`, creates an `InventorySnapshotSession`, dispatches `SyncOzonInventorySnapshotMessage` per valid connection, skips invalid connections, and marks the session failed if all dispatches fail.
- Introduced DTO `OzonInventorySnapshotRequestResult` to return `queuedCount`, `skippedCount`, `hasConnections`, `hasActiveSession`, and `messages`.
- Added message class `SyncOzonInventorySnapshotMessage` for per-connection snapshot requests.
- Added integration tests `RequestOzonInventorySnapshotActionTest` exercising no-connections, successful dispatch, duplicate-session skipping, and dispatch-failure behavior, with `InMemoryBus` and `FailingBus` test doubles.

### Testing

- Ran the new integration test `site/tests/Integration/Inventory/Application/RequestOzonInventorySnapshotActionTest.php` which covers no active connection, successful dispatch/session creation, duplicate session skipping, and dispatch failure handling; the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a004a59bcc8832380bb55cb7a8da2fe)