### PR TITLE
Add unit test to verify SyncOzonInventorySnapshotMessage contains only scalar identifiers and no sensitive fields

### DIFF
--- a/site/tests/Unit/Inventory/Message/SyncOzonInventorySnapshotMessageTest.php
+++ b/site/tests/Unit/Inventory/Message/SyncOzonInventorySnapshotMessageTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Inventory\Message;
+
+use App\Inventory\Message\SyncOzonInventorySnapshotMessage;
+use PHPUnit\Framework\TestCase;
+
+final class SyncOzonInventorySnapshotMessageTest extends TestCase
+{
+    public function testMessageContainsOnlyScalarIdentifiersAndTriggerType(): void
+    {
+        $message = new SyncOzonInventorySnapshotMessage(
+            companyId: '11111111-1111-1111-1111-111111111111',
+            connectionId: '22222222-2222-2222-2222-222222222222',
+            snapshotSessionId: '33333333-3333-3333-3333-333333333333',
+            triggerType: 'manual',
+        );
+
+        self::assertSame('11111111-1111-1111-1111-111111111111', $message->companyId);
+        self::assertSame('22222222-2222-2222-2222-222222222222', $message->connectionId);
+        self::assertSame('33333333-3333-3333-3333-333333333333', $message->snapshotSessionId);
+        self::assertSame('manual', $message->triggerType);
+
+        self::assertFalse(property_exists($message, 'apiKey'));
+        self::assertFalse(property_exists($message, 'clientSecret'));
+    }
+}


### PR DESCRIPTION
### Motivation
- Add a focused unit test to ensure `SyncOzonInventorySnapshotMessage` exposes only scalar identifier properties and a `triggerType`, and does not include sensitive fields like API keys or secrets.

### Description
- Introduce the new test file `site/tests/Unit/Inventory/Message/SyncOzonInventorySnapshotMessageTest.php` which instantiates `SyncOzonInventorySnapshotMessage` and asserts the presence of `companyId`, `connectionId`, `snapshotSessionId`, and `triggerType`, and asserts absence of `apiKey` and `clientSecret` properties.

### Testing
- Ran the unit test `SyncOzonInventorySnapshotMessageTest` with `phpunit --filter SyncOzonInventorySnapshotMessageTest` and the test passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a006a1e5530832399e5faf60d66e414)