### PR TITLE
Add handler to sync Ozon inventory snapshots with repository helper and integration tests

### DIFF
--- a/site/src/Inventory/Exception/OzonInventoryApiException.php
+++ b/site/src/Inventory/Exception/OzonInventoryApiException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace App\Inventory\Exception;
 
-final class OzonInventoryApiException extends \RuntimeException
+class OzonInventoryApiException extends \RuntimeException
 {
 }

--- a/site/src/Inventory/MessageHandler/SyncOzonInventorySnapshotHandler.php
+++ b/site/src/Inventory/MessageHandler/SyncOzonInventorySnapshotHandler.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Inventory\MessageHandler;
+
+use App\Inventory\Entity\InventoryRawSnapshot;
+use App\Inventory\Enum\SnapshotSessionStatus;
+use App\Inventory\Exception\OzonInventoryRateLimitException;
+use App\Inventory\Infrastructure\Api\Ozon\OzonInventoryClient;
+use App\Inventory\Message\SyncOzonInventorySnapshotMessage;
+use App\Inventory\Repository\InventorySnapshotSessionRepository;
+use App\Marketplace\Enum\MarketplaceConnectionType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Facade\MarketplaceFacade;
+use App\Shared\Service\AppLogger;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+final class SyncOzonInventorySnapshotHandler
+{
+    private const ENDPOINT = '/v4/product/info/stocks';
+    private const PAGE_LIMIT = 1000;
+
+    public function __construct(
+        private readonly InventorySnapshotSessionRepository $sessionRepository,
+        private readonly MarketplaceFacade $marketplaceFacade,
+        private readonly OzonInventoryClient $ozonInventoryClient,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly AppLogger $logger,
+    ) {
+    }
+
+    public function __invoke(SyncOzonInventorySnapshotMessage $message): void
+    {
+        $session = $this->sessionRepository->findByIdAndCompany($message->snapshotSessionId, $message->companyId);
+        if (null === $session) {
+            $this->logger->warning('Inventory snapshot session not found, message acknowledged.', ['snapshotSessionId' => $message->snapshotSessionId, 'companyId' => $message->companyId]);
+            return;
+        }
+        if (in_array($session->getStatus(), [SnapshotSessionStatus::Completed, SnapshotSessionStatus::Partial, SnapshotSessionStatus::Failed], true)) {
+            return;
+        }
+
+        $credentials = $this->marketplaceFacade->getConnectionCredentials($message->companyId, MarketplaceType::OZON, MarketplaceConnectionType::SELLER);
+        if (null === $credentials || '' === trim((string) ($credentials['api_key'] ?? '')) || '' === trim((string) ($credentials['client_id'] ?? ''))) {
+            $session->markFailed('Ozon SELLER credentials not found for inventory snapshot fetching.');
+            $this->entityManager->flush();
+            return;
+        }
+
+        $session->markInProgress();
+        $this->entityManager->flush();
+
+        $savedPages = 0;
+        $lastId = null;
+        $page = 1;
+
+        try {
+            do {
+                $startedAt = microtime(true);
+                $response = $this->ozonInventoryClient->fetchStocks((string) $credentials['client_id'], (string) $credentials['api_key'], self::PAGE_LIMIT, $lastId);
+                $durationMs = (int) round((microtime(true) - $startedAt) * 1000);
+
+                $rawSnapshot = new InventoryRawSnapshot(
+                    companyId: $message->companyId,
+                    snapshotSessionId: $session->getId(),
+                    source: MarketplaceType::OZON,
+                    sourceEndpoint: self::ENDPOINT,
+                    requestParams: array_filter([
+                        'connectionId' => $message->connectionId,
+                        'marketplace' => MarketplaceType::OZON->value,
+                        'page' => $page,
+                        'last_id' => $lastId,
+                        'limit' => self::PAGE_LIMIT,
+                        'requestedAt' => $session->getStartedAt()->format(DATE_ATOM),
+                        'correlationId' => $session->getCorrelationId(),
+                    ], static fn (mixed $value): bool => null !== $value),
+                    responseStatus: 200,
+                    responseBody: $response->raw,
+                    fetchedAt: new \DateTimeImmutable(),
+                    fetchDurationMs: max(0, $durationMs),
+                    correlationId: $session->getCorrelationId(),
+                    pageNumber: $page,
+                );
+
+                $this->entityManager->persist($rawSnapshot);
+                ++$savedPages;
+                $session->incrementReceivedPages();
+                $this->entityManager->flush();
+
+                $lastId = $response->nextLastId;
+                ++$page;
+            } while (null !== $lastId);
+
+            $session->markCompleted();
+            $this->entityManager->flush();
+        } catch (OzonInventoryRateLimitException $e) {
+            $this->logger->warning('Ozon inventory rate limit while fetching raw snapshots.', ['snapshotSessionId' => $session->getId(), 'companyId' => $message->companyId, 'savedPages' => $savedPages]);
+            $savedPages > 0
+                ? $session->markPartial('Rate limit exceeded while fetching Ozon inventory snapshots.')
+                : $session->markFailed('Rate limit exceeded before first Ozon inventory page was saved.');
+            $this->entityManager->flush();
+            return;
+        } catch (\Throwable $e) {
+            $savedPages > 0
+                ? $session->markPartial('Inventory snapshot fetching failed after partial save: '.$e->getMessage())
+                : $session->markFailed('Inventory snapshot fetching failed before saving pages: '.$e->getMessage());
+            $this->entityManager->flush();
+            return;
+        }
+    }
+}

--- a/site/src/Inventory/Repository/InventorySnapshotSessionRepository.php
+++ b/site/src/Inventory/Repository/InventorySnapshotSessionRepository.php
@@ -18,6 +18,15 @@ final class InventorySnapshotSessionRepository extends ServiceEntityRepository
         parent::__construct($registry, InventorySnapshotSession::class);
     }
 
+
+    public function findByIdAndCompany(string $id, string $companyId): ?InventorySnapshotSession
+    {
+        Assert::uuid($id);
+        Assert::uuid($companyId);
+
+        return $this->findOneBy(['id' => $id, 'companyId' => $companyId]);
+    }
+
     public function findLatestActiveByCompanyAndSource(string $companyId, MarketplaceType $source): ?InventorySnapshotSession
     {
         Assert::uuid($companyId);

--- a/site/tests/Integration/Inventory/MessageHandler/SyncOzonInventorySnapshotHandlerTest.php
+++ b/site/tests/Integration/Inventory/MessageHandler/SyncOzonInventorySnapshotHandlerTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Inventory\MessageHandler;
+
+use App\Company\Entity\Company;
+use App\Inventory\Entity\InventoryRawSnapshot;
+use App\Inventory\Entity\InventorySnapshotSession;
+use App\Inventory\Enum\SnapshotSessionStatus;
+use App\Inventory\Enum\SnapshotTriggerType;
+use App\Inventory\Message\SyncOzonInventorySnapshotMessage;
+use App\Inventory\MessageHandler\SyncOzonInventorySnapshotHandler;
+use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Enum\MarketplaceConnectionType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class SyncOzonInventorySnapshotHandlerTest extends IntegrationTestCase
+{
+    public function testSessionNotFoundNoOp(): void
+    {
+        $company = $this->createCompany(401);
+        $handler = self::getContainer()->get(SyncOzonInventorySnapshotHandler::class);
+
+        $handler(new SyncOzonInventorySnapshotMessage($company->getId(), '77777777-7777-7777-7777-000000000401', '88888888-8888-8888-8888-000000000401', 'manual'));
+
+        self::assertSame(0, $this->countRawSnapshots());
+    }
+
+    public function testTerminalSessionNoOp(): void
+    {
+        $company = $this->createCompany(402);
+        $session = $this->createSession($company);
+        $session->markInProgress();
+        $session->markCompleted();
+        $this->em->flush();
+
+        $handler = self::getContainer()->get(SyncOzonInventorySnapshotHandler::class);
+        $handler(new SyncOzonInventorySnapshotMessage($company->getId(), '77777777-7777-7777-7777-000000000402', $session->getId(), 'manual'));
+
+        self::assertSame(0, $this->countRawSnapshots());
+    }
+
+    public function testNoCredentialsMarksFailed(): void
+    {
+        $company = $this->createCompany(403);
+        $session = $this->createSession($company);
+
+        $handler = self::getContainer()->get(SyncOzonInventorySnapshotHandler::class);
+        $handler(new SyncOzonInventorySnapshotMessage($company->getId(), '77777777-7777-7777-7777-000000000403', $session->getId(), 'manual'));
+
+        $this->em->refresh($session);
+        self::assertSame(SnapshotSessionStatus::Failed, $session->getStatus());
+    }
+
+    public function testSuccessOnePageSavesRawAndCompleted(): void
+    {
+        $company = $this->createCompany(404);
+        $session = $this->createSession($company);
+        $this->createSellerConnection($company, 404);
+        $this->swapHttpClient([new MockResponse('{"result":{"items":[{"sku":"1"}]}}', ['http_code' => 200])]);
+
+        $handler = self::getContainer()->get(SyncOzonInventorySnapshotHandler::class);
+        $handler(new SyncOzonInventorySnapshotMessage($company->getId(), '77777777-7777-7777-7777-000000000404', $session->getId(), 'manual'));
+
+        $this->em->refresh($session);
+        self::assertSame(SnapshotSessionStatus::Completed, $session->getStatus());
+        self::assertSame(1, $session->getReceivedPages());
+
+        $raw = $this->findRawBySession($session->getId());
+        self::assertCount(1, $raw);
+        self::assertSame('77777777-7777-7777-7777-000000000404', $raw[0]->getRequestParams()['connectionId']);
+    }
+
+    public function testSuccessSeveralPagesSavesSeveralRawSnapshots(): void
+    {
+        $company = $this->createCompany(405);
+        $session = $this->createSession($company);
+        $this->createSellerConnection($company, 405);
+        $this->swapHttpClient([
+            new MockResponse('{"result":{"items":[{"sku":"1"}],"last_id":"next-1"}}', ['http_code' => 200]),
+            new MockResponse('{"result":{"items":[{"sku":"2"}]}}', ['http_code' => 200]),
+        ]);
+
+        $handler = self::getContainer()->get(SyncOzonInventorySnapshotHandler::class);
+        $handler(new SyncOzonInventorySnapshotMessage($company->getId(), '77777777-7777-7777-7777-000000000405', $session->getId(), 'manual'));
+
+        $this->em->refresh($session);
+        self::assertSame(SnapshotSessionStatus::Completed, $session->getStatus());
+        self::assertCount(2, $this->findRawBySession($session->getId()));
+    }
+
+    public function testErrorBeforeFirstPageMarksFailedWithoutThrow(): void
+    {
+        $company = $this->createCompany(406);
+        $session = $this->createSession($company);
+        $this->createSellerConnection($company, 406);
+        $this->swapHttpClient([new MockResponse('{"error":"server"}', ['http_code' => 500])]);
+
+        $handler = self::getContainer()->get(SyncOzonInventorySnapshotHandler::class);
+        $handler(new SyncOzonInventorySnapshotMessage($company->getId(), '77777777-7777-7777-7777-000000000406', $session->getId(), 'manual'));
+
+        $this->em->refresh($session);
+        self::assertSame(SnapshotSessionStatus::Failed, $session->getStatus());
+    }
+
+    public function testErrorAfterFirstPageMarksPartialWithoutThrow(): void
+    {
+        $company = $this->createCompany(407);
+        $session = $this->createSession($company);
+        $this->createSellerConnection($company, 407);
+        $this->swapHttpClient([
+            new MockResponse('{"result":{"items":[{"sku":"1"}],"last_id":"next-1"}}', ['http_code' => 200]),
+            new MockResponse('{"error":"server"}', ['http_code' => 500]),
+        ]);
+
+        $handler = self::getContainer()->get(SyncOzonInventorySnapshotHandler::class);
+        $handler(new SyncOzonInventorySnapshotMessage($company->getId(), '77777777-7777-7777-7777-000000000407', $session->getId(), 'manual'));
+
+        $this->em->refresh($session);
+        self::assertSame(SnapshotSessionStatus::Partial, $session->getStatus());
+        self::assertCount(1, $this->findRawBySession($session->getId()));
+    }
+
+    public function testRateLimitBeforeFirstPageMarksFailedWithoutThrow(): void
+    {
+        $company = $this->createCompany(408);
+        $session = $this->createSession($company);
+        $this->createSellerConnection($company, 408);
+        $this->swapHttpClient([new MockResponse('{"error":"rate"}', ['http_code' => 429])]);
+
+        $handler = self::getContainer()->get(SyncOzonInventorySnapshotHandler::class);
+        $handler(new SyncOzonInventorySnapshotMessage($company->getId(), '77777777-7777-7777-7777-000000000408', $session->getId(), 'manual'));
+
+        $this->em->refresh($session);
+        self::assertSame(SnapshotSessionStatus::Failed, $session->getStatus());
+    }
+
+    private function createCompany(int $index): Company
+    {
+        $user = UserBuilder::aUser()->withIndex($index)->build();
+        $company = CompanyBuilder::aCompany()->withIndex($index)->withOwner($user)->build();
+        $this->em->persist($user);
+        $this->em->persist($company);
+        $this->em->flush();
+
+        return $company;
+    }
+
+    private function createSession(Company $company): InventorySnapshotSession
+    {
+        $session = new InventorySnapshotSession($company->getId(), MarketplaceType::OZON, SnapshotTriggerType::Manual);
+        $this->em->persist($session);
+        $this->em->flush();
+
+        return $session;
+    }
+
+    private function createSellerConnection(Company $company, int $suffix): void
+    {
+        $connection = new MarketplaceConnection(sprintf('77777777-7777-7777-7777-%012d', $suffix), $company, MarketplaceType::OZON, MarketplaceConnectionType::SELLER);
+        $connection->setApiKey('test-key')->setClientId('test-client')->setIsActive(true);
+        $this->em->persist($connection);
+        $this->em->flush();
+    }
+
+    /** @param list<MockResponse> $responses */
+    private function swapHttpClient(array $responses): void
+    {
+        self::getContainer()->set('http_client', new MockHttpClient($responses));
+    }
+
+    /** @return list<InventoryRawSnapshot> */
+    private function findRawBySession(string $sessionId): array
+    {
+        return $this->em->getRepository(InventoryRawSnapshot::class)->findBy(['snapshotSessionId' => $sessionId], ['pageNumber' => 'ASC']);
+    }
+
+    private function countRawSnapshots(): int
+    {
+        return $this->em->getRepository(InventoryRawSnapshot::class)->count([]);
+    }
+}


### PR DESCRIPTION
### Motivation

- Implement server-side logic to fetch raw inventory pages from Ozon, persist them and track snapshot session progress and terminal states.
- Ensure robust handling of missing credentials, API errors and rate limits while keeping snapshot session state consistent.

### Description

- Added `SyncOzonInventorySnapshotHandler` which paginates through Ozon stock endpoint using `OzonInventoryClient::fetchStocks`, persists `InventoryRawSnapshot` entities, and updates `InventorySnapshotSession` statuses (`InProgress`, `Completed`, `Partial`, `Failed`).
- The handler validates seller credentials via `MarketplaceFacade`, records request/response metadata including `fetchDurationMs`, `correlationId` and `pageNumber`, and treats `OzonInventoryRateLimitException` specially to mark sessions as partial or failed.
- Added `findByIdAndCompany` to `InventorySnapshotSessionRepository` to safely load sessions scoped to a company.
- Added comprehensive integration tests `SyncOzonInventorySnapshotHandlerTest` covering session-not-found, terminal sessions, missing credentials, single/multi-page success flows, server errors before/after first page, and rate-limit scenarios.

### Testing

- Ran the integration test class `SyncOzonInventorySnapshotHandlerTest` which includes tests: `testSessionNotFoundNoOp`, `testTerminalSessionNoOp`, `testNoCredentialsMarksFailed`, `testSuccessOnePageSavesRawAndCompleted`, `testSuccessSeveralPagesSavesSeveralRawSnapshots`, `testErrorBeforeFirstPageMarksFailedWithoutThrow`, `testErrorAfterFirstPageMarksPartialWithoutThrow`, and `testRateLimitBeforeFirstPageMarksFailedWithoutThrow`.
- All executed integration tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00799125488323895dc925041a4d0f)