### PR TITLE
Add inventory snapshots index page, controller, template and tests

### DIFF
--- a/site/config/routes.yaml
+++ b/site/config/routes.yaml
@@ -71,6 +71,13 @@ catalog_controllers:
         namespace: App\Catalog\Controller
     type: attribute
 
+inventory_controllers:
+    resource:
+        path: ../src/Inventory/Controller/
+        namespace: App\Inventory\Controller
+    type: attribute
+
+
 shared_controllers:
     resource:
         path: ../src/Shared/Controller/

--- a/site/src/Inventory/Controller/SnapshotIndexController.php
+++ b/site/src/Inventory/Controller/SnapshotIndexController.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Inventory\Controller;
+
+use App\Inventory\Infrastructure\Query\InventorySnapshotSessionListQuery;
+use App\Shared\Service\ActiveCompanyService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_USER')]
+final class SnapshotIndexController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $activeCompanyService,
+        private readonly InventorySnapshotSessionListQuery $sessionListQuery,
+    ) {
+    }
+
+    #[Route('/inventory/snapshots', name: 'inventory_snapshots_index', methods: ['GET'])]
+    public function __invoke(Request $request): Response
+    {
+        $company = $this->activeCompanyService->getActiveCompany();
+        $companyId = (string) $company->getId();
+
+        $page = max(1, $request->query->getInt('page', 1));
+        $pager = $this->sessionListQuery->getPage($companyId, $page, InventorySnapshotSessionListQuery::PER_PAGE);
+
+        return $this->render('inventory/snapshots/index.html.twig', [
+            'pager' => $pager,
+        ]);
+    }
+}

--- a/site/templates/inventory/snapshots/index.html.twig
+++ b/site/templates/inventory/snapshots/index.html.twig
@@ -1,0 +1,83 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Загрузка остатков{% endblock %}
+
+{% block content %}
+    <div class="page-header d-print-none mb-3">
+        <div class="row align-items-center">
+            <div class="col">
+                <h2 class="page-title">Загрузка остатков</h2>
+            </div>
+        </div>
+    </div>
+
+    <div class="card mb-3">
+        <div class="card-body d-flex align-items-center justify-content-between gap-3 flex-wrap">
+            <div>
+                <div class="fw-medium">Получение актуальных остатков из маркетплейса</div>
+                <div class="text-muted small">Запускает асинхронную загрузку и обновляет историю ниже.</div>
+            </div>
+            <div class="d-flex flex-column align-items-end gap-1">
+                <button type="button" class="btn btn-primary" disabled>Получить остатки</button>
+                <span class="text-muted small">Ручной запуск будет подключён отдельной задачей.</span>
+            </div>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header">
+            <h3 class="card-title">История загрузок</h3>
+        </div>
+        <div class="table-responsive">
+            <table class="table table-vcenter card-table">
+                <thead>
+                <tr>
+                    <th>Дата</th>
+                    <th>Маркетплейс</th>
+                    <th>Статус</th>
+                </tr>
+                </thead>
+                <tbody>
+                {% for row in pager.currentPageResults %}
+                    <tr>
+                        <td>{{ row.created_at|date('d.m.Y H:i') }}</td>
+                        <td><span class="badge bg-azure-lt">{{ row.source|upper }}</span></td>
+                        <td>
+                            {% set statusClass = {
+                                'pending': 'bg-yellow-lt',
+                                'in_progress': 'bg-blue-lt',
+                                'completed': 'bg-green-lt',
+                                'partial': 'bg-orange-lt',
+                                'failed': 'bg-red-lt'
+                            } %}
+                            <span class="badge {{ statusClass[row.status]|default('bg-secondary-lt') }}">{{ row.status }}</span>
+                        </td>
+                    </tr>
+                {% else %}
+                    <tr>
+                        <td colspan="3" class="text-center text-muted py-4">Загрузок пока нет.</td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+
+        {% if pager.haveToPaginate %}
+            <div class="card-footer d-flex align-items-center">
+                <ul class="pagination m-0 ms-auto">
+                    <li class="page-item {{ pager.currentPage == 1 ? 'disabled' : '' }}">
+                        <a class="page-link" href="{{ path('inventory_snapshots_index', {page: pager.currentPage - 1}) }}">‹</a>
+                    </li>
+                    {% for p in 1..pager.nbPages %}
+                        <li class="page-item {{ p == pager.currentPage ? 'active' : '' }}">
+                            <a class="page-link" href="{{ path('inventory_snapshots_index', {page: p}) }}">{{ p }}</a>
+                        </li>
+                    {% endfor %}
+                    <li class="page-item {{ pager.currentPage == pager.nbPages ? 'disabled' : '' }}">
+                        <a class="page-link" href="{{ path('inventory_snapshots_index', {page: pager.currentPage + 1}) }}">›</a>
+                    </li>
+                </ul>
+            </div>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/site/tests/Functional/Inventory/Controller/SnapshotIndexControllerTest.php
+++ b/site/tests/Functional/Inventory/Controller/SnapshotIndexControllerTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Inventory\Controller;
+
+use App\Company\Entity\Company;
+use App\Company\Entity\User;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Builders\Inventory\InventorySnapshotSessionBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+final class SnapshotIndexControllerTest extends WebTestCaseBase
+{
+    public function testPageIsAvailableForAuthorizedUserAndShowsOnlyOwnCompanyRows(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()->withEmail('inventory-owner@example.test')->build();
+        $activeCompany = CompanyBuilder::aCompany()->withId('11111111-1111-1111-1111-111111111701')->withOwner($owner)->build();
+        $otherCompany = CompanyBuilder::aCompany()->withId('11111111-1111-1111-1111-111111111702')->withOwner($owner)->build();
+
+        $ownSession = InventorySnapshotSessionBuilder::aSession()
+            ->withCompanyId($activeCompany->getId())
+            ->withSource(MarketplaceType::OZON)
+            ->build();
+        $ownSession->markCompleted();
+
+        $foreignSession = InventorySnapshotSessionBuilder::aSession()
+            ->withCompanyId($otherCompany->getId())
+            ->withSource(MarketplaceType::WILDBERRIES)
+            ->build();
+        $foreignSession->markFailed('foreign');
+
+        $em->persist($owner);
+        $em->persist($activeCompany);
+        $em->persist($otherCompany);
+        $em->persist($ownSession);
+        $em->persist($foreignSession);
+        $em->flush();
+
+        $this->loginWithActiveCompany($client, $owner, $activeCompany);
+
+        $crawler = $client->request('GET', '/inventory/snapshots');
+
+        self::assertResponseIsSuccessful();
+        self::assertSame(1, $crawler->filter('table tbody tr')->count());
+        self::assertStringContainsString('История загрузок', (string) $client->getResponse()->getContent());
+        self::assertStringContainsString('OZON', (string) $client->getResponse()->getContent());
+        self::assertStringNotContainsString('WILDBERRIES', (string) $client->getResponse()->getContent());
+        self::assertStringContainsString('Получить остатки', (string) $client->getResponse()->getContent());
+        self::assertGreaterThan(0, $crawler->filter('button[disabled]')->count());
+
+        $headers = $crawler->filter('table thead th')->each(static fn ($node) => trim((string) $node->text()));
+        self::assertSame(['Дата', 'Маркетплейс', 'Статус'], $headers);
+    }
+
+    public function testPaginationWorksWithThirtyItemsPerPage(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $em = $this->em();
+        $owner = UserBuilder::aUser()->withEmail('inventory-pagination@example.test')->build();
+        $company = CompanyBuilder::aCompany()->withId('11111111-1111-1111-1111-111111111703')->withOwner($owner)->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+
+        for ($i = 1; $i <= 31; ++$i) {
+            $session = InventorySnapshotSessionBuilder::aSession()
+                ->withCompanyId($company->getId())
+                ->withCorrelationId(sprintf('33333333-3333-7333-8333-%012d', $i + 3000))
+                ->build();
+            if ($i % 2 === 0) {
+                $session->markCompleted();
+            } elseif ($i % 3 === 0) {
+                $session->markPartial('partial');
+            } else {
+                $session->markFailed('failed');
+            }
+            $em->persist($session);
+        }
+
+        $em->flush();
+        $this->loginWithActiveCompany($client, $owner, $company);
+
+        $crawlerPage1 = $client->request('GET', '/inventory/snapshots?page=1');
+        self::assertResponseIsSuccessful();
+        self::assertSame(30, $crawlerPage1->filter('table tbody tr')->count());
+        self::assertGreaterThan(0, $crawlerPage1->filter('.pagination')->count());
+
+        $crawlerPage2 = $client->request('GET', '/inventory/snapshots?page=2');
+        self::assertResponseIsSuccessful();
+        self::assertSame(1, $crawlerPage2->filter('table tbody tr')->count());
+    }
+
+    public function testEmptyStateIsShownWhenNoSessions(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $em = $this->em();
+        $owner = UserBuilder::aUser()->withEmail('inventory-empty@example.test')->build();
+        $company = CompanyBuilder::aCompany()->withId('11111111-1111-1111-1111-111111111704')->withOwner($owner)->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        $this->loginWithActiveCompany($client, $owner, $company);
+        $client->request('GET', '/inventory/snapshots');
+
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('Загрузок пока нет.', (string) $client->getResponse()->getContent());
+    }
+
+    private function loginWithActiveCompany(KernelBrowser $client, User $user, Company $company): void
+    {
+        $client->loginUser($user);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', $company->getId());
+        $session->save();
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a UI to view history of inventory snapshot sessions and prepare for manual/async snapshot triggers. 
- Support listing and paginating snapshot sessions scoped to the currently active company. 
- Ensure coverage with functional tests for normal, paginated and empty states.

### Description
- Register new `inventory_controllers` routes in `site/config/routes.yaml` to load controllers under `App\Inventory\Controller`.
- Add `SnapshotIndexController` which requires `ROLE_USER`, obtains the active company via `ActiveCompanyService`, queries sessions using `InventorySnapshotSessionListQuery`, and serves the route `GET /inventory/snapshots` named `inventory_snapshots_index`.
- Add Twig template `site/templates/inventory/snapshots/index.html.twig` that renders snapshot rows, status badges, disabled manual trigger button, and page navigation when pagination is required.
- Add functional test `SnapshotIndexControllerTest` with three scenarios covering authorization/ownership filtering, pagination behavior (30 items per page), and empty-state rendering.

### Testing
- Ran the new functional test file `tests/Functional/Inventory/Controller/SnapshotIndexControllerTest.php` using PHPUnit and the three tests `testPageIsAvailableForAuthorizedUserAndShowsOnlyOwnCompanyRows`, `testPaginationWorksWithThirtyItemsPerPage`, and `testEmptyStateIsShownWhenNoSessions` all succeeded.
- Existing functional helpers were used to bootstrap DB state and session context for the tests which passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00826392848323abc7e220c24742c5)