### PR TITLE
Add SnapshotRequestController and manual snapshot form with tests

### DIFF
--- a/site/src/Inventory/Controller/SnapshotRequestController.php
+++ b/site/src/Inventory/Controller/SnapshotRequestController.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Inventory\Controller;
+
+use App\Inventory\Application\RequestOzonInventorySnapshotAction;
+use App\Inventory\Enum\SnapshotTriggerType;
+use App\Shared\Service\ActiveCompanyService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_COMPANY_OWNER')]
+final class SnapshotRequestController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $activeCompanyService,
+        private readonly RequestOzonInventorySnapshotAction $requestSnapshotAction,
+    ) {
+    }
+
+    #[Route('/inventory/snapshots/request', name: 'inventory_snapshots_request', methods: ['POST'])]
+    public function __invoke(Request $request): RedirectResponse
+    {
+        if (!$this->isCsrfTokenValid('inventory_snapshots_request', (string) $request->request->get('_token'))) {
+            $this->addFlash('danger', 'Неверный CSRF-токен.');
+
+            return $this->redirectToRoute('inventory_snapshots_index');
+        }
+
+        $company = $this->activeCompanyService->getActiveCompany();
+
+        try {
+            $result = ($this->requestSnapshotAction)(
+                companyId: (string) $company->getId(),
+                triggerType: SnapshotTriggerType::Manual,
+                actorUserId: $this->getUser()?->getId(),
+            );
+
+            if (!$result->hasConnections) {
+                $this->addFlash('warning', 'Нет активного Ozon-подключения (SELLER) для запуска синхронизации.');
+            } elseif ($result->hasActiveSession) {
+                $this->addFlash('warning', 'Синхронизация уже выполняется.');
+            } elseif ($result->queuedCount > 0) {
+                $this->addFlash('success', 'Задача синхронизации остатков запущена.');
+            } else {
+                $this->addFlash('danger', 'Не удалось запустить синхронизацию остатков.');
+            }
+        } catch (\Throwable) {
+            $this->addFlash('danger', 'Ошибка запуска синхронизации остатков.');
+        }
+
+        return $this->redirectToRoute('inventory_snapshots_index');
+    }
+}

--- a/site/templates/inventory/snapshots/index.html.twig
+++ b/site/templates/inventory/snapshots/index.html.twig
@@ -17,10 +17,10 @@
                 <div class="fw-medium">Получение актуальных остатков из маркетплейса</div>
                 <div class="text-muted small">Запускает асинхронную загрузку и обновляет историю ниже.</div>
             </div>
-            <div class="d-flex flex-column align-items-end gap-1">
-                <button type="button" class="btn btn-primary" disabled>Получить остатки</button>
-                <span class="text-muted small">Ручной запуск будет подключён отдельной задачей.</span>
-            </div>
+            <form method="post" action="{{ path('inventory_snapshots_request') }}" class="mb-0">
+                <input type="hidden" name="_token" value="{{ csrf_token('inventory_snapshots_request') }}">
+                <button type="submit" class="btn btn-primary">Получить остатки</button>
+            </form>
         </div>
     </div>
 

--- a/site/tests/Functional/Inventory/Controller/SnapshotIndexControllerTest.php
+++ b/site/tests/Functional/Inventory/Controller/SnapshotIndexControllerTest.php
@@ -55,7 +55,9 @@ final class SnapshotIndexControllerTest extends WebTestCaseBase
         self::assertStringContainsString('OZON', (string) $client->getResponse()->getContent());
         self::assertStringNotContainsString('WILDBERRIES', (string) $client->getResponse()->getContent());
         self::assertStringContainsString('Получить остатки', (string) $client->getResponse()->getContent());
-        self::assertGreaterThan(0, $crawler->filter('button[disabled]')->count());
+        self::assertGreaterThan(0, $crawler->filter('form[action="/inventory/snapshots/request"][method="post"]')->count());
+        self::assertGreaterThan(0, $crawler->filter('form[action="/inventory/snapshots/request"] input[type="hidden"][name="_token"]')->count());
+        self::assertSame('Получить остатки', trim((string) $crawler->filter('form[action="/inventory/snapshots/request"] button[type="submit"]')->text()));
 
         $headers = $crawler->filter('table thead th')->each(static fn ($node) => trim((string) $node->text()));
         self::assertSame(['Дата', 'Маркетплейс', 'Статус'], $headers);

--- a/site/tests/Integration/Inventory/Controller/SnapshotRequestControllerTest.php
+++ b/site/tests/Integration/Inventory/Controller/SnapshotRequestControllerTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Inventory\Controller;
+
+use App\Company\Entity\User;
+use App\Inventory\Entity\InventorySnapshotSession;
+use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Enum\MarketplaceConnectionType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\Transport\InMemoryTransport;
+
+final class SnapshotRequestControllerTest extends WebTestCaseBase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-a90000000001';
+    private const OWNER_ID = '22222222-2222-2222-2222-a90000000001';
+
+    public function testValidCsrfRequestsSnapshotAndRedirectsWithSuccessFlash(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company] = $this->seedOwnerAndCompany('inventory-request-ok@example.test');
+        $this->persistActiveOzonConnection($company->getId(), $company);
+        $this->login($client, $owner, self::COMPANY_ID);
+
+        $transport = $this->getSyncTransport($client);
+        $token = static::getContainer()->get('security.csrf.token_manager')->getToken('inventory_snapshots_request')->getValue();
+
+        $client->request('POST', '/inventory/snapshots/request', ['_token' => $token]);
+
+        self::assertResponseRedirects('/inventory/snapshots');
+        self::assertCount(1, $transport->getSent());
+
+        $sessionRepo = static::getContainer()->get('doctrine')->getRepository(InventorySnapshotSession::class);
+        self::assertCount(1, $sessionRepo->findBy(['companyId' => self::COMPANY_ID]));
+
+        $client->followRedirect();
+        self::assertSelectorTextContains('.alert-success', 'Задача синхронизации остатков запущена.');
+    }
+
+    public function testInvalidCsrfRedirectsWithDangerFlashAndDoesNotDispatch(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company] = $this->seedOwnerAndCompany('inventory-request-csrf@example.test');
+        $this->persistActiveOzonConnection($company->getId(), $company);
+        $this->login($client, $owner, self::COMPANY_ID);
+
+        $transport = $this->getSyncTransport($client);
+
+        $client->request('POST', '/inventory/snapshots/request', ['_token' => 'invalid-token']);
+
+        self::assertResponseRedirects('/inventory/snapshots');
+        self::assertCount(0, $transport->getSent());
+
+        $client->followRedirect();
+        self::assertSelectorTextContains('.alert-danger', 'Неверный CSRF-токен.');
+    }
+
+    public function testNoActiveConnectionShowsWarningFlash(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner] = $this->seedOwnerAndCompany('inventory-request-no-connection@example.test');
+        $this->login($client, $owner, self::COMPANY_ID);
+
+        $token = static::getContainer()->get('security.csrf.token_manager')->getToken('inventory_snapshots_request')->getValue();
+        $transport = $this->getSyncTransport($client);
+
+        $client->request('POST', '/inventory/snapshots/request', ['_token' => $token]);
+
+        self::assertResponseRedirects('/inventory/snapshots');
+        self::assertCount(0, $transport->getSent());
+
+        $client->followRedirect();
+        self::assertSelectorTextContains('.alert-warning', 'Нет активного Ozon-подключения');
+    }
+
+    public function testActiveSessionExistsShowsAlreadyRunningWarning(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company] = $this->seedOwnerAndCompany('inventory-request-already-running@example.test');
+        $this->persistActiveOzonConnection($company->getId(), $company);
+        $this->persistActiveSession();
+        $this->login($client, $owner, self::COMPANY_ID);
+
+        $token = static::getContainer()->get('security.csrf.token_manager')->getToken('inventory_snapshots_request')->getValue();
+
+        $client->request('POST', '/inventory/snapshots/request', ['_token' => $token]);
+
+        self::assertResponseRedirects('/inventory/snapshots');
+
+        $client->followRedirect();
+        self::assertSelectorTextContains('.alert-warning', 'Синхронизация уже выполняется.');
+    }
+
+    public function testRouteRequiresAuthenticatedOwnerWithActiveCompany(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $client->request('POST', '/inventory/snapshots/request', ['_token' => 'noop']);
+        self::assertResponseStatusCodeSame(Response::HTTP_FOUND);
+        self::assertStringContainsString('/login', (string) $client->getResponse()->headers->get('Location'));
+
+        $user = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail('inventory-request-not-owner@example.test')
+            ->withRoles(['ROLE_COMPANY_USER'])
+            ->build();
+        $this->em()->persist($user);
+        $this->em()->flush();
+
+        $client->loginUser($user);
+        $client->request('POST', '/inventory/snapshots/request', ['_token' => 'noop']);
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    private function seedOwnerAndCompany(string $email): array
+    {
+        $owner = UserBuilder::aUser()
+            ->withId(self::OWNER_ID)
+            ->withEmail($email)
+            ->asCompanyOwner()
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId(self::COMPANY_ID)
+            ->withOwner($owner)
+            ->build();
+
+        $this->em()->persist($owner);
+        $this->em()->persist($company);
+        $this->em()->flush();
+
+        return [$owner, $company];
+    }
+
+    private function login(KernelBrowser $client, User $user, string $companyId): void
+    {
+        $client->loginUser($user);
+        $session = $client->getContainer()->get('session');
+        $session->set('active_company_id', $companyId);
+        $session->save();
+    }
+
+    private function persistActiveOzonConnection(string $connectionId, \App\Company\Entity\Company $company): void
+    {
+        $connection = new MarketplaceConnection(
+            id: $connectionId,
+            company: $company,
+            marketplace: MarketplaceType::OZON,
+            connectionType: MarketplaceConnectionType::SELLER,
+        );
+        $connection->setApiKey('test-api-key');
+        $connection->setClientId('1000');
+        $connection->setIsActive(true);
+
+        $this->em()->persist($connection);
+        $this->em()->flush();
+    }
+
+    private function persistActiveSession(): void
+    {
+        $session = new InventorySnapshotSession(
+            companyId: self::COMPANY_ID,
+            source: MarketplaceType::OZON,
+            triggerType: \App\Inventory\Enum\SnapshotTriggerType::Manual,
+            triggeredBy: self::OWNER_ID,
+        );
+
+        $this->em()->persist($session);
+        $this->em()->flush();
+    }
+
+    private function getSyncTransport(KernelBrowser $client): InMemoryTransport
+    {
+        /** @var InMemoryTransport $transport */
+        $transport = $client->getContainer()->get('messenger.transport.async_sync');
+
+        return $transport;
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a way for company owners to manually request inventory snapshot synchronization from marketplace (Ozon) via the UI with CSRF protection.
- Replace the disabled placeholder button in the snapshots index with a working form that triggers the request flow.
- Ensure behavior is covered by functional and integration tests for various scenarios (CSRF, no connection, already running session, permissions).

### Description

- Added `SnapshotRequestController` which requires `ROLE_COMPANY_OWNER`, validates CSRF token, obtains the active company, invokes `RequestOzonInventorySnapshotAction` with `SnapshotTriggerType::Manual`, and sets user-facing flash messages based on the action result or exceptions.
- Replaced the disabled button in `site/templates/inventory/snapshots/index.html.twig` with a POST form that includes a CSRF token and submits to the new route `inventory_snapshots_request`.
- Updated `SnapshotIndexControllerTest` to assert presence of the new form, its CSRF hidden input, and the submit button text instead of the previous disabled button assertion.
- Added `SnapshotRequestControllerTest` integration test covering successful dispatch, invalid CSRF handling, missing active connection, already-running session, and access control for non-owner or unauthenticated users.

### Testing

- Ran the functional test `SnapshotIndexControllerTest` which now asserts the new form elements and passed.
- Ran the integration test suite including `SnapshotRequestControllerTest` that validates CSRF, dispatch behavior, flash messages, and permission checks and passed.
- Verified message dispatch to the `async_sync` transport and persistence of `InventorySnapshotSession` in the successful case during integration tests, and those checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0085cb91788323b175b26f46ad49c2)