### PR TITLE
Add daily Ozon inventory snapshot command and cron entry with tests

### DIFF
--- a/docker/cron/app.cron
+++ b/docker/cron/app.cron
@@ -10,6 +10,9 @@
 # Ночная синхронизация отчётов Ozon по реализации.
 0 4 * * * php bin/console app:marketplace:ozon-daily-sync --no-interaction
 
+# Inventory Ozon snapshot: запуск в 04:05 MSK, команда только инициирует pipeline; HTTP-загрузка выполняется async worker'ом.
+5 4 * * * cd /app && php bin/console app:inventory:ozon-daily-sync --no-interaction >> /proc/1/fd/1 2>> /proc/1/fd/2
+
 # Daily-sync: создаёт AdLoadJob за вчера для всех компаний с активным Ozon
 # Performance подключением. Дальше работу подхватывают cron-driven worker'ы
 # (scheduler → poller → finalizer → auto-extract), без ручных действий.

--- a/site/src/Inventory/Command/OzonInventoryDailySyncCommand.php
+++ b/site/src/Inventory/Command/OzonInventoryDailySyncCommand.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Inventory\Command;
+
+use App\Inventory\Application\RequestOzonInventorySnapshotAction;
+use App\Inventory\Enum\SnapshotTriggerType;
+use App\Marketplace\Facade\MarketplaceFacade;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\LockableTrait;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'app:inventory:ozon-daily-sync',
+    description: 'Initiates daily Ozon inventory snapshot pipeline for active SELLER connections',
+)]
+final class OzonInventoryDailySyncCommand extends Command
+{
+    use LockableTrait;
+
+    public function __construct(
+        private readonly MarketplaceFacade $marketplaceFacade,
+        private readonly RequestOzonInventorySnapshotAction $requestSnapshotAction,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (!$this->lock()) {
+            $output->writeln('start');
+            $output->writeln('Another inventory daily-sync is running, skipping.');
+            $output->writeln('finish');
+
+            return self::SUCCESS;
+        }
+
+        try {
+            $output->writeln('start');
+
+            $connections = $this->marketplaceFacade->getActiveOzonSellerConnections();
+            $companyIds = array_values(array_unique(array_map(
+                static fn (array $row): string => (string) ($row['companyId'] ?? ''),
+                $connections,
+            )));
+            $companyIds = array_values(array_filter($companyIds, static fn (string $companyId): bool => '' !== $companyId));
+
+            $output->writeln(sprintf('active connections count: %d / queued count: %d', count($connections), 0));
+
+            $queuedCount = 0;
+            $skippedCount = 0;
+            $errorsCount = 0;
+
+            foreach ($companyIds as $companyId) {
+                try {
+                    $result = ($this->requestSnapshotAction)(
+                        $companyId,
+                        SnapshotTriggerType::ScheduledNight,
+                    );
+
+                    $queuedCount += $result->queuedCount;
+                    $skippedCount += $result->skippedCount;
+                } catch (\Throwable $e) {
+                    ++$errorsCount;
+                    $output->writeln(sprintf('company %s error: %s', $companyId, $e->getMessage()));
+                }
+            }
+
+            $output->writeln(sprintf('active connections count: %d / queued count: %d', count($connections), $queuedCount));
+            $output->writeln(sprintf('skipped count: %d', $skippedCount));
+            $output->writeln(sprintf('errors count: %d', $errorsCount));
+            $output->writeln('finish');
+
+            return self::SUCCESS;
+        } catch (\Throwable $e) {
+            $output->writeln(sprintf('errors count: %d', 1));
+            $output->writeln(sprintf('orchestration failure: %s', $e->getMessage()));
+            $output->writeln('finish');
+
+            return self::FAILURE;
+        } finally {
+            $this->release();
+        }
+    }
+}

--- a/site/tests/Integration/Inventory/Command/OzonInventoryDailySyncCommandTest.php
+++ b/site/tests/Integration/Inventory/Command/OzonInventoryDailySyncCommandTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Inventory\Command;
+
+use App\Company\Entity\Company;
+use App\Inventory\Entity\InventorySnapshotSession;
+use App\Inventory\Enum\SnapshotTriggerType;
+use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Enum\MarketplaceConnectionType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class OzonInventoryDailySyncCommandTest extends IntegrationTestCase
+{
+    public function testNoConnectionsReturnsSuccess(): void
+    {
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertStringContainsString('start', $tester->getDisplay());
+        self::assertStringContainsString('active connections count: 0 / queued count: 0', $tester->getDisplay());
+        self::assertStringContainsString('skipped count: 0', $tester->getDisplay());
+        self::assertStringContainsString('errors count: 0', $tester->getDisplay());
+        self::assertStringContainsString('finish', $tester->getDisplay());
+    }
+
+    public function testCreatesScheduledNightSessionForActiveSellerConnection(): void
+    {
+        $company = $this->seedCompany('owner-inv@example.test');
+        $connection = new MarketplaceConnection(
+            id: '77777777-7777-7777-7777-000000000010',
+            company: $company,
+            marketplace: MarketplaceType::OZON,
+            connectionType: MarketplaceConnectionType::SELLER,
+        );
+        $connection->setApiKey('test-key');
+        $connection->setClientId('test-client-id');
+        $connection->setIsActive(true);
+
+        $this->em->persist($connection);
+        $this->em->flush();
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertStringContainsString('active connections count: 1 / queued count: 1', $tester->getDisplay());
+
+        $session = $this->em->getRepository(InventorySnapshotSession::class)->findOneBy([
+            'companyId' => $company->getId(),
+        ]);
+
+        self::assertInstanceOf(InventorySnapshotSession::class, $session);
+        self::assertSame(SnapshotTriggerType::ScheduledNight, $session->getTriggerType());
+    }
+
+    private function seedCompany(string $email): Company
+    {
+        $owner = UserBuilder::aUser()->withEmail($email)->build();
+        $company = CompanyBuilder::aCompany()->withOwner($owner)->build();
+
+        $this->em->persist($owner);
+        $this->em->persist($company);
+        $this->em->flush();
+
+        return $company;
+    }
+
+    private function makeTester(): CommandTester
+    {
+        $app = new Application(self::bootKernel());
+        $command = $app->find('app:inventory:ozon-daily-sync');
+
+        return new CommandTester($command);
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce a scheduled task to initiate daily Ozon inventory snapshots for active SELLER connections so the async worker can fetch inventory data during the night window. 
- Prevent concurrent runs of the orchestration and provide observability about queued/skipped/error counts when the job runs. 

### Description
- Add a new Symfony console command `app:inventory:ozon-daily-sync` (`OzonInventoryDailySyncCommand`) that locks execution, fetches active Ozon SELLER connections via `MarketplaceFacade`, deduplicates `companyId`s and invokes `RequestOzonInventorySnapshotAction` with `SnapshotTriggerType::ScheduledNight` for each company while aggregating queued/skipped/error counts. 
- Emit start/finish and per-company error messages to the console and return appropriate exit codes on failure or success, and release the lock in `finally`. 
- Update `docker/cron/app.cron` to schedule the command at `04:05` MSK using `cd /app && php bin/console app:inventory:ozon-daily-sync --no-interaction >> /proc/1/fd/1 2>> /proc/1/fd/2`. 
- Add integration tests `OzonInventoryDailySyncCommandTest` covering the no-connections case and the creation of a scheduled-night `InventorySnapshotSession` for an active SELLER connection. 

### Testing
- Ran the new integration tests in `site/tests/Integration/Inventory/Command/OzonInventoryDailySyncCommandTest.php` which include a zero-connections scenario and a scenario that seeds a company and active Ozon SELLER connection; both tests passed. 
- No additional automated test failures were reported when running the integration test suite for the modified code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a008b8e57548323a88f083c44b74d6b)