### PR TITLE
Add Inventory Twig namespace path

### DIFF
--- a/site/config/packages/twig.yaml
+++ b/site/config/packages/twig.yaml
@@ -11,6 +11,7 @@ twig:
         '%kernel.project_dir%/templates/marketplace_ads': MarketplaceAds
         '%kernel.project_dir%/templates/moy_sklad': MoySklad
         '%kernel.project_dir%/templates/finance': Finance
+        '%kernel.project_dir%/templates/inventory': Inventory
         '%kernel.project_dir%/templates/partials': Partials
 
 when@test:


### PR DESCRIPTION
### Motivation
- Follow project rules to wire Inventory UI: ensure Inventory controllers, Twig namespace, and Messenger routing are configured so new Inventory Controller/Twig/Message integrate correctly.

### Description
- Added Twig namespace path `%kernel.project_dir%/templates/inventory`: `Inventory` in `site/config/packages/twig.yaml`, and verified `site/config/routes.yaml` already declares `inventory_controllers` and `site/config/packages/messenger.yaml` already routes `App\Inventory\Message\SyncOzonInventorySnapshotMessage` to `async_sync` without touching Marketplace configs.

### Testing
- Attempted `cd site && bin/console lint:yaml config/routes.yaml config/packages/twig.yaml config/packages/messenger.yaml`, `cd site && bin/console debug:router | grep inventory_snapshots`, and `cd site && bin/console debug:messenger | grep SyncOzonInventorySnapshotMessage`, but the Symfony console cannot boot due to missing PHP dependencies (`LogicException: Dependencies are missing. Try running "composer install".`), so automated checks could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a009113d8248323a1735a42a2245c2d)