### PR TITLE
Add missing tests for Ozon inventory snapshot pipeline coverage

### DIFF
--- a/site/tests/Integration/Inventory/Application/RequestOzonInventorySnapshotActionTest.php
+++ b/site/tests/Integration/Inventory/Application/RequestOzonInventorySnapshotActionTest.php
@@ -112,6 +112,18 @@ final class RequestOzonInventorySnapshotActionTest extends IntegrationTestCase
         self::assertNull($session, 'Session must not remain active pending/in_progress when all dispatches failed.');
     }
 
+    public function testInvalidConnectionIdScenarioIsNotReachableBecauseMarketplaceConnectionIdMustBeUuid(): void
+    {
+        $company = $this->createCompany(105);
+
+        $this->expectException(\InvalidArgumentException::class);
+        // Intentional invariant check:
+        // MarketplaceConnection validates UUID in constructor (Assert::uuid),
+        // therefore integration scenario with invalid connectionId from MarketplaceFacade
+        // is not reachable without breaking Entity/DB constraints.
+        new MarketplaceConnection('invalid-connection-id', $company, MarketplaceType::OZON, MarketplaceConnectionType::SELLER);
+    }
+
     private function createCompany(int $index): Company
     {
         $user = UserBuilder::aUser()->withIndex($index)->build();

--- a/site/tests/Integration/Inventory/MessageHandler/SyncOzonInventorySnapshotHandlerTest.php
+++ b/site/tests/Integration/Inventory/MessageHandler/SyncOzonInventorySnapshotHandlerTest.php
@@ -75,6 +75,11 @@ final class SyncOzonInventorySnapshotHandlerTest extends IntegrationTestCase
         $raw = $this->findRawBySession($session->getId());
         self::assertCount(1, $raw);
         self::assertSame('77777777-7777-7777-7777-000000000404', $raw[0]->getRequestParams()['connectionId']);
+
+        $columns = $this->em->getConnection()
+            ->createSchemaManager()
+            ->listTableColumns('inventory_raw_snapshots');
+        self::assertArrayNotHasKey('connection_id', $columns);
     }
 
     public function testSuccessSeveralPagesSavesSeveralRawSnapshots(): void

--- a/site/tests/Integration/Inventory/Repository/InventorySnapshotSessionRepositoryTest.php
+++ b/site/tests/Integration/Inventory/Repository/InventorySnapshotSessionRepositoryTest.php
@@ -121,11 +121,60 @@ final class InventorySnapshotSessionRepositoryTest extends IntegrationTestCase
         $count = (int) $this->em->getConnection()->fetchOne('SELECT COUNT(*) FROM inventory_snapshot_sessions');
         self::assertSame(0, $count);
     }
+
+    public function testFindByIdAndCompanyReturnsSessionForMatchingPair(): void
+    {
+        $session = InventorySnapshotSessionBuilder::aSession()
+            ->withCompanyId(self::COMPANY_ID)
+            ->withSource(MarketplaceType::OZON)
+            ->withCorrelationId('33333333-3333-7333-8333-000000000707')
+            ->build();
+
+        $this->em->persist($session);
+        $this->em->flush();
+        $this->em->clear();
+
+        $found = $this->repository->findByIdAndCompany($session->getId(), self::COMPANY_ID);
+
+        self::assertNotNull($found);
+        self::assertSame($session->getId(), $found->getId());
+    }
+
+    public function testFindByIdAndCompanyReturnsNullForForeignCompany(): void
+    {
+        $session = InventorySnapshotSessionBuilder::aSession()
+            ->withCompanyId(self::OTHER_COMPANY_ID)
+            ->withSource(MarketplaceType::OZON)
+            ->withCorrelationId('33333333-3333-7333-8333-000000000708')
+            ->build();
+
+        $this->em->persist($session);
+        $this->em->flush();
+        $this->em->clear();
+
+        $found = $this->repository->findByIdAndCompany($session->getId(), self::COMPANY_ID);
+
+        self::assertNull($found);
+    }
+
+    public function testFindByIdAndCompanyThrowsForInvalidId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->repository->findByIdAndCompany('not-a-uuid', self::COMPANY_ID);
+    }
+
+    public function testFindByIdAndCompanyThrowsForInvalidCompanyId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->repository->findByIdAndCompany('33333333-3333-7333-8333-000000000709', 'not-a-uuid');
+    }
+
     public function testFindLatestActiveByCompanyAndSourceThrowsForInvalidCompanyId(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
         $this->repository->findLatestActiveByCompanyAndSource('not-a-uuid', MarketplaceType::OZON);
     }
-
 }

--- a/site/tests/InventoryPipelineCoverageReport.md
+++ b/site/tests/InventoryPipelineCoverageReport.md
@@ -1,0 +1,23 @@
+# Inventory Pipeline Coverage Report
+
+## InventorySnapshotSessionRepository
+- `findByIdAndCompany()`
+  - Покрыто: Да
+  - Тесты: `site/tests/Integration/Inventory/Repository/InventorySnapshotSessionRepositoryTest.php`
+
+## OzonInventoryClient
+- `401/403 -> OzonInventoryApiException`
+  - Покрыто: Да
+  - Тесты: `site/tests/Unit/Inventory/Infrastructure/Api/Ozon/OzonInventoryClientTest.php`
+  - Примечание: есть отдельные проверки для 401 и 403.
+
+## RequestOzonInventorySnapshotAction
+- `connectionId` валидируется
+  - Покрыто: Частично
+  - Тесты: `site/tests/Integration/Inventory/Application/RequestOzonInventorySnapshotActionTest.php`
+  - Примечание: сценарий с невалидным `connectionId` через `MarketplaceFacade::getActiveOzonSellerConnections()` недостижим в интеграции, так как `MarketplaceConnection` валидирует UUID в конструкторе (`Assert::uuid`) и поле `id` имеет тип `guid` в БД.
+
+## SyncOzonInventorySnapshotHandler
+- `connectionId` хранится только в `requestParams` (без отдельной колонки `connection_id`)
+  - Покрыто: Да
+  - Тесты: `site/tests/Integration/Inventory/MessageHandler/SyncOzonInventorySnapshotHandlerTest.php`

--- a/site/tests/Unit/Inventory/Infrastructure/Api/Ozon/OzonInventoryClientTest.php
+++ b/site/tests/Unit/Inventory/Infrastructure/Api/Ozon/OzonInventoryClientTest.php
@@ -58,6 +58,14 @@ final class OzonInventoryClientTest extends TestCase
         $client->fetchStocks('cid', 'key');
     }
 
+    public function testUnauthorized401MapsToApiException(): void
+    {
+        $client = new OzonInventoryClient(new MockHttpClient(new MockResponse('{"message":"unauthorized"}', ['http_code' => 401])));
+
+        $this->expectException(OzonInventoryApiException::class);
+        $client->fetchStocks('cid', 'key');
+    }
+
     public function testServerError5xxThrowsRetryableRuntimeException(): void
     {
         $client = new OzonInventoryClient(new MockHttpClient(new MockResponse('{"message":"server"}', ['http_code' => 500])));


### PR DESCRIPTION
### Motivation
- Close several small gaps in test coverage for the Ozon Inventory Snapshot pipeline identified in the coverage report without changing production code.
- Ensure HTTP 401 handling, repository multi-tenant guards and storage of `connectionId` are explicitly covered by automated tests.

### Description
- Added integration tests for `InventorySnapshotSessionRepository::findByIdAndCompany()` covering success, foreign-company null, and invalid `id` / invalid `companyId` validation in `site/tests/Integration/Inventory/Repository/InventorySnapshotSessionRepositoryTest.php`.
- Added unit test `testUnauthorized401MapsToApiException()` to `site/tests/Unit/Inventory/Infrastructure/Api/Ozon/OzonInventoryClientTest.php` that uses `MockResponse` with `http_code => 401` and expects `OzonInventoryApiException`.
- Added an integration assertion in `site/tests/Integration/Inventory/Application/RequestOzonInventorySnapshotActionTest.php` that documents and asserts the invariant that invalid `connectionId` scenarios are unreachable because `MarketplaceConnection` enforces UUIDs (kept as an integration-level note/test without altering production code).
- Extended `site/tests/Integration/Inventory/MessageHandler/SyncOzonInventorySnapshotHandlerTest.php` to assert that `connectionId` is saved inside `requestParams` and that the `inventory_raw_snapshots` table does not have a separate `connection_id` column via Doctrine DBAL `createSchemaManager()`.
- Added `site/tests/InventoryPipelineCoverageReport.md` and updated coverage lines to reflect new tests; no production code changes were made.

### Testing
- Attempted to run the focused PHPUnit set with `php bin/phpunit ...` but the environment is missing `vendor/symfony/phpunit-bridge/bin/simple-phpunit.php` so the run could not be executed here.
- Attempted to run `vendor/bin/phpunit ...` but `vendor/bin/phpunit` is not present in this environment, so automated PHPUnit execution was not possible locally.
- All added tests are unit/integration tests intended to be executed in CI or a full developer environment with project `vendor` dependencies installed; they do not perform real HTTP calls and avoid mocking forbidden final classes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a009b5eb3548323916e03b322627c71)