### PR TITLE
Add logging, improve Ozon API error messages, and show pages/errors in snapshot UI

### DIFF
--- a/site/src/Inventory/Application/RequestOzonInventorySnapshotAction.php
+++ b/site/src/Inventory/Application/RequestOzonInventorySnapshotAction.php
@@ -11,6 +11,7 @@ use App\Inventory\Message\SyncOzonInventorySnapshotMessage;
 use App\Inventory\Repository\InventorySnapshotSessionRepository;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Facade\MarketplaceFacade;
+use App\Shared\Service\AppLogger;
 use Doctrine\ORM\EntityManagerInterface;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -23,6 +24,7 @@ final readonly class RequestOzonInventorySnapshotAction
         private InventorySnapshotSessionRepository $sessionRepository,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
+        private AppLogger $logger,
     ) {
     }
 
@@ -37,6 +39,10 @@ final readonly class RequestOzonInventorySnapshotAction
         $connections = $this->marketplaceFacade->getActiveOzonSellerConnections($companyId);
 
         if ($connections === []) {
+            $this->logger->info('Inventory snapshot request skipped: no active Ozon SELLER connections.', [
+                'companyId' => $companyId,
+                'triggerType' => $triggerType->value,
+            ]);
             return new OzonInventorySnapshotRequestResult(
                 queuedCount: 0,
                 skippedCount: 0,
@@ -53,6 +59,12 @@ final readonly class RequestOzonInventorySnapshotAction
         foreach ($connections as $connection) {
             $connectionId = (string) ($connection['connectionId'] ?? '');
             if ($connectionId === '') {
+                $this->logger->warning('Inventory snapshot request skipped: empty connectionId.', [
+                    'companyId' => $companyId,
+                    'triggerType' => $triggerType->value,
+                    'queuedCount' => 0,
+                    'skippedCount' => $skippedCount + 1,
+                ]);
                 ++$skippedCount;
                 $messages[] = 'Skipped one connection: empty connectionId.';
 
@@ -60,6 +72,13 @@ final readonly class RequestOzonInventorySnapshotAction
             }
 
             if (!Uuid::isValid($connectionId)) {
+                $this->logger->warning('Inventory snapshot request skipped: invalid connectionId.', [
+                    'companyId' => $companyId,
+                    'connectionId' => $connectionId,
+                    'triggerType' => $triggerType->value,
+                    'queuedCount' => 0,
+                    'skippedCount' => $skippedCount + 1,
+                ]);
                 ++$skippedCount;
                 $messages[] = sprintf('Skipped connection with invalid UUID: %s', $connectionId);
 
@@ -82,6 +101,13 @@ final readonly class RequestOzonInventorySnapshotAction
         $activeSession = $this->sessionRepository->findLatestActiveByCompanyAndSource($companyId, MarketplaceType::OZON);
 
         if ($activeSession !== null) {
+            $this->logger->info('Inventory snapshot request skipped: active session already exists.', [
+                'companyId' => $companyId,
+                'snapshotSessionId' => $activeSession->getId(),
+                'triggerType' => $triggerType->value,
+                'queuedCount' => 0,
+                'skippedCount' => $skippedCount + count($validConnectionIds),
+            ]);
             return new OzonInventorySnapshotRequestResult(
                 queuedCount: 0,
                 skippedCount: $skippedCount + count($validConnectionIds),
@@ -100,6 +126,11 @@ final readonly class RequestOzonInventorySnapshotAction
 
         $this->entityManager->persist($session);
         $this->entityManager->flush();
+        $this->logger->info('Inventory snapshot session created.', [
+            'companyId' => $companyId,
+            'snapshotSessionId' => $session->getId(),
+            'triggerType' => $triggerType->value,
+        ]);
 
         $queuedCount = 0;
 
@@ -113,8 +144,28 @@ final readonly class RequestOzonInventorySnapshotAction
                     triggerType: $triggerType->value,
                 ));
                 ++$queuedCount;
+                $this->logger->info('Inventory snapshot message dispatched.', [
+                    'companyId' => $companyId,
+                    'snapshotSessionId' => $session->getId(),
+                    'connectionId' => $connectionId,
+                    'triggerType' => $triggerType->value,
+                    'queuedCount' => $queuedCount,
+                    'skippedCount' => $skippedCount,
+                ]);
             } catch (\Throwable $e) {
                 ++$skippedCount;
+                $this->logger->error('Inventory snapshot message dispatch failed.', [
+                    'companyId' => $companyId,
+                    'snapshotSessionId' => $session->getId(),
+                    'connectionId' => $connectionId,
+                    'triggerType' => $triggerType->value,
+                    'queuedCount' => $queuedCount,
+                    'skippedCount' => $skippedCount,
+                    'exceptionClass' => $e::class,
+                    'errorMessage' => $e->getMessage(),
+                    'file' => $e->getFile(),
+                    'line' => $e->getLine(),
+                ]);
                 $messages[] = sprintf('Failed to queue connection %s: %s', $connectionId, $e->getMessage());
             }
         }

--- a/site/src/Inventory/Command/OzonInventoryDailySyncCommand.php
+++ b/site/src/Inventory/Command/OzonInventoryDailySyncCommand.php
@@ -49,6 +49,7 @@ final class OzonInventoryDailySyncCommand extends Command
             $companyIds = array_values(array_filter($companyIds, static fn (string $companyId): bool => '' !== $companyId));
 
             $output->writeln(sprintf('active connections count: %d / queued count: %d', count($connections), 0));
+            $output->writeln(sprintf('unique companies count: %d', count($companyIds)));
 
             $queuedCount = 0;
             $skippedCount = 0;
@@ -70,6 +71,7 @@ final class OzonInventoryDailySyncCommand extends Command
             }
 
             $output->writeln(sprintf('active connections count: %d / queued count: %d', count($connections), $queuedCount));
+            $output->writeln(sprintf('unique companies count: %d', count($companyIds)));
             $output->writeln(sprintf('skipped count: %d', $skippedCount));
             $output->writeln(sprintf('errors count: %d', $errorsCount));
             $output->writeln('finish');

--- a/site/src/Inventory/Infrastructure/Api/Ozon/OzonInventoryClient.php
+++ b/site/src/Inventory/Infrastructure/Api/Ozon/OzonInventoryClient.php
@@ -41,18 +41,28 @@ final readonly class OzonInventoryClient
 
         $statusCode = $response->getStatusCode();
         $payload = $response->getContent(false);
+        $payloadFragment = mb_substr(trim($payload), 0, 1000);
+        $message = sprintf(
+            'Ozon Inventory API returned HTTP %d for %s: %s',
+            $statusCode,
+            self::STOCKS_ENDPOINT,
+            $payloadFragment !== '' ? $payloadFragment : '[empty response body]',
+        );
 
         if (429 === $statusCode) {
-            throw new OzonInventoryRateLimitException('Ozon Inventory API returned HTTP 429.');
+            throw new OzonInventoryRateLimitException($message.' Rate limit exceeded, retry later.');
         }
         if (401 === $statusCode || 403 === $statusCode) {
-            throw new OzonInventoryApiException(sprintf('Ozon Inventory API returned HTTP %d.', $statusCode));
+            throw new OzonInventoryApiException($message.' Authentication/authorization failed.');
+        }
+        if (400 === $statusCode) {
+            throw new OzonInventoryApiException($message.' Invalid request payload or parameters.');
         }
         if ($statusCode >= 400 && $statusCode < 500) {
-            throw new OzonInventoryApiException(sprintf('Ozon Inventory API returned HTTP %d.', $statusCode));
+            throw new OzonInventoryApiException($message.' Client-side API error.');
         }
         if ($statusCode >= 500) {
-            throw new \RuntimeException(sprintf('Ozon Inventory API returned HTTP %d.', $statusCode));
+            throw new \RuntimeException($message.' Ozon server-side error.');
         }
 
         try {
@@ -89,4 +99,3 @@ final readonly class OzonInventoryClient
         }
     }
 }
-

--- a/site/src/Inventory/MessageHandler/SyncOzonInventorySnapshotHandler.php
+++ b/site/src/Inventory/MessageHandler/SyncOzonInventorySnapshotHandler.php
@@ -34,6 +34,13 @@ final class SyncOzonInventorySnapshotHandler
 
     public function __invoke(SyncOzonInventorySnapshotMessage $message): void
     {
+        $this->logger->info('Inventory snapshot handler started.', [
+            'companyId' => $message->companyId,
+            'snapshotSessionId' => $message->snapshotSessionId,
+            'connectionId' => $message->connectionId,
+            'triggerType' => $message->triggerType,
+        ]);
+
         $session = $this->sessionRepository->findByIdAndCompany($message->snapshotSessionId, $message->companyId);
         if (null === $session) {
             $this->logger->warning('Inventory snapshot session not found, message acknowledged.', ['snapshotSessionId' => $message->snapshotSessionId, 'companyId' => $message->companyId]);
@@ -45,6 +52,13 @@ final class SyncOzonInventorySnapshotHandler
 
         $credentials = $this->marketplaceFacade->getConnectionCredentials($message->companyId, MarketplaceType::OZON, MarketplaceConnectionType::SELLER);
         if (null === $credentials || '' === trim((string) ($credentials['api_key'] ?? '')) || '' === trim((string) ($credentials['client_id'] ?? ''))) {
+            $this->logger->warning('Inventory snapshot credentials missing for Ozon SELLER connection.', [
+                'companyId' => $message->companyId,
+                'snapshotSessionId' => $message->snapshotSessionId,
+                'connectionId' => $message->connectionId,
+                'marketplace' => MarketplaceType::OZON->value,
+                'connectionType' => MarketplaceConnectionType::SELLER->value,
+            ]);
             $session->markFailed('Ozon SELLER credentials not found for inventory snapshot fetching.');
             $this->entityManager->flush();
             return;
@@ -59,6 +73,12 @@ final class SyncOzonInventorySnapshotHandler
 
         try {
             do {
+                $this->logger->info('Inventory snapshot page fetch started.', [
+                    'snapshotSessionId' => $session->getId(),
+                    'page' => $page,
+                    'hasLastId' => null !== $lastId,
+                    'limit' => self::PAGE_LIMIT,
+                ]);
                 $startedAt = microtime(true);
                 $response = $this->ozonInventoryClient->fetchStocks((string) $credentials['client_id'], (string) $credentials['api_key'], self::PAGE_LIMIT, $lastId);
                 $durationMs = (int) round((microtime(true) - $startedAt) * 1000);
@@ -89,6 +109,12 @@ final class SyncOzonInventorySnapshotHandler
                 ++$savedPages;
                 $session->incrementReceivedPages();
                 $this->entityManager->flush();
+                $this->logger->info('Inventory snapshot page saved.', [
+                    'snapshotSessionId' => $session->getId(),
+                    'page' => $page,
+                    'durationMs' => max(0, $durationMs),
+                    'receivedPages' => $session->getReceivedPages(),
+                ]);
 
                 $lastId = $response->nextLastId;
                 ++$page;
@@ -97,13 +123,28 @@ final class SyncOzonInventorySnapshotHandler
             $session->markCompleted();
             $this->entityManager->flush();
         } catch (OzonInventoryRateLimitException $e) {
-            $this->logger->warning('Ozon inventory rate limit while fetching raw snapshots.', ['snapshotSessionId' => $session->getId(), 'companyId' => $message->companyId, 'savedPages' => $savedPages]);
+            $this->logger->warning('Ozon inventory rate limit while fetching raw snapshots.', [
+                'snapshotSessionId' => $session->getId(),
+                'companyId' => $message->companyId,
+                'savedPages' => $savedPages,
+                'errorMessage' => $e->getMessage(),
+            ]);
             $savedPages > 0
                 ? $session->markPartial('Rate limit exceeded while fetching Ozon inventory snapshots.')
                 : $session->markFailed('Rate limit exceeded before first Ozon inventory page was saved.');
             $this->entityManager->flush();
             return;
         } catch (\Throwable $e) {
+            $this->logger->error('Inventory snapshot fetching failed with unhandled exception.', [
+                'snapshotSessionId' => $session->getId(),
+                'companyId' => $message->companyId,
+                'connectionId' => $message->connectionId,
+                'savedPages' => $savedPages,
+                'exceptionClass' => $e::class,
+                'errorMessage' => $e->getMessage(),
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
+            ]);
             $savedPages > 0
                 ? $session->markPartial('Inventory snapshot fetching failed after partial save: '.$e->getMessage())
                 : $session->markFailed('Inventory snapshot fetching failed before saving pages: '.$e->getMessage());

--- a/site/templates/inventory/snapshots/index.html.twig
+++ b/site/templates/inventory/snapshots/index.html.twig
@@ -35,6 +35,8 @@
                     <th>Дата</th>
                     <th>Маркетплейс</th>
                     <th>Статус</th>
+                    <th>Страницы</th>
+                    <th>Ошибка</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -52,10 +54,24 @@
                             } %}
                             <span class="badge {{ statusClass[row.status]|default('bg-secondary-lt') }}">{{ row.status }}</span>
                         </td>
+                        <td>
+                            {% if row.expected_pages is not null and row.received_pages is not null %}
+                                {{ row.received_pages }} / {{ row.expected_pages }}
+                            {% else %}
+                                —
+                            {% endif %}
+                        </td>
+                        <td class="text-muted small">
+                            {% if row.error_message %}
+                                <div class="text-truncate" style="max-width: 420px;" title="{{ row.error_message }}">{{ row.error_message }}</div>
+                            {% else %}
+                                —
+                            {% endif %}
+                        </td>
                     </tr>
                 {% else %}
                     <tr>
-                        <td colspan="3" class="text-center text-muted py-4">Загрузок пока нет.</td>
+                        <td colspan="5" class="text-center text-muted py-4">Загрузок пока нет.</td>
                     </tr>
                 {% endfor %}
                 </tbody>

--- a/site/tests/Functional/Inventory/Controller/SnapshotIndexControllerTest.php
+++ b/site/tests/Functional/Inventory/Controller/SnapshotIndexControllerTest.php
@@ -30,7 +30,7 @@ final class SnapshotIndexControllerTest extends WebTestCaseBase
             ->withCompanyId($activeCompany->getId())
             ->withSource(MarketplaceType::OZON)
             ->build();
-        $ownSession->markCompleted();
+        $ownSession->markFailed('Ozon Inventory API returned HTTP 403 for /v4/product/info/stocks');
 
         $foreignSession = InventorySnapshotSessionBuilder::aSession()
             ->withCompanyId($otherCompany->getId())
@@ -60,7 +60,9 @@ final class SnapshotIndexControllerTest extends WebTestCaseBase
         self::assertSame('Получить остатки', trim((string) $crawler->filter('form[action="/inventory/snapshots/request"] button[type="submit"]')->text()));
 
         $headers = $crawler->filter('table thead th')->each(static fn ($node) => trim((string) $node->text()));
-        self::assertSame(['Дата', 'Маркетплейс', 'Статус'], $headers);
+        self::assertSame(['Дата', 'Маркетплейс', 'Статус', 'Страницы', 'Ошибка'], $headers);
+        self::assertStringContainsString('Ozon Inventory API returned HTTP 403', (string) $client->getResponse()->getContent());
+        self::assertStringNotContainsString('foreign', (string) $client->getResponse()->getContent());
     }
 
     public function testPaginationWorksWithThirtyItemsPerPage(): void

--- a/site/tests/Integration/Inventory/Application/RequestOzonInventorySnapshotActionTest.php
+++ b/site/tests/Integration/Inventory/Application/RequestOzonInventorySnapshotActionTest.php
@@ -13,6 +13,7 @@ use App\Marketplace\Facade\MarketplaceFacade;
 use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Enum\MarketplaceConnectionType;
 use App\Marketplace\Enum\MarketplaceType;
+use App\Shared\Service\AppLogger;
 use App\Tests\Builders\Company\CompanyBuilder;
 use App\Tests\Builders\Company\UserBuilder;
 use App\Tests\Support\Kernel\IntegrationTestCase;
@@ -40,6 +41,7 @@ final class RequestOzonInventorySnapshotActionTest extends IntegrationTestCase
             $this->sessionRepository,
             $this->em,
             new InMemoryBus(),
+            self::getContainer()->get(AppLogger::class),
         );
 
         $result = $action($company->getId(), SnapshotTriggerType::Manual);
@@ -59,6 +61,7 @@ final class RequestOzonInventorySnapshotActionTest extends IntegrationTestCase
             $this->sessionRepository,
             $this->em,
             $bus,
+            self::getContainer()->get(AppLogger::class),
         );
 
         $result = $action($company->getId(), SnapshotTriggerType::Manual);
@@ -81,6 +84,7 @@ final class RequestOzonInventorySnapshotActionTest extends IntegrationTestCase
             $this->sessionRepository,
             $this->em,
             $bus,
+            self::getContainer()->get(AppLogger::class),
         );
 
         self::assertSame(1, $action($company->getId(), SnapshotTriggerType::Manual)->queuedCount);
@@ -101,6 +105,7 @@ final class RequestOzonInventorySnapshotActionTest extends IntegrationTestCase
             $this->sessionRepository,
             $this->em,
             new FailingBus(),
+            self::getContainer()->get(AppLogger::class),
         );
 
         $result = $action($company->getId(), SnapshotTriggerType::Manual);

--- a/site/tests/Integration/Inventory/MessageHandler/SyncOzonInventorySnapshotHandlerTest.php
+++ b/site/tests/Integration/Inventory/MessageHandler/SyncOzonInventorySnapshotHandlerTest.php
@@ -56,6 +56,7 @@ final class SyncOzonInventorySnapshotHandlerTest extends IntegrationTestCase
 
         $this->em->refresh($session);
         self::assertSame(SnapshotSessionStatus::Failed, $session->getStatus());
+        self::assertStringContainsString('credentials', (string) $session->getErrorMessage());
     }
 
     public function testSuccessOnePageSavesRawAndCompleted(): void
@@ -112,6 +113,7 @@ final class SyncOzonInventorySnapshotHandlerTest extends IntegrationTestCase
 
         $this->em->refresh($session);
         self::assertSame(SnapshotSessionStatus::Failed, $session->getStatus());
+        self::assertStringContainsString('HTTP 500', (string) $session->getErrorMessage());
     }
 
     public function testErrorAfterFirstPageMarksPartialWithoutThrow(): void
@@ -144,6 +146,7 @@ final class SyncOzonInventorySnapshotHandlerTest extends IntegrationTestCase
 
         $this->em->refresh($session);
         self::assertSame(SnapshotSessionStatus::Failed, $session->getStatus());
+        self::assertStringContainsString('Rate limit', (string) $session->getErrorMessage());
     }
 
     private function createCompany(int $index): Company


### PR DESCRIPTION
### Motivation

- Improve observability of Ozon inventory snapshot orchestration by adding structured logs for key events and failures. 
- Make Ozon API client errors more informative by including HTTP status and response fragment to aid debugging. 
- Surface page counts and error messages in the snapshots UI so operators can quickly see progress and failures.

### Description

- Inject `AppLogger` and add informational, warning and error logs in `RequestOzonInventorySnapshotAction` for skipped connections, existing active sessions, session creation and message dispatch outcomes. 
- Add structured logging to `SyncOzonInventorySnapshotHandler` for handler start, per-page fetch start, saved pages and failure cases (rate limit and unexpected exceptions). 
- Improve `OzonInventoryClient::fetchStocks` error messages to include HTTP status, endpoint and a clipped response body fragment, and refine message text per status range. 
- Update the snapshots index template to display `Страницы` (received/expected) and `Ошибка` columns, including truncation for long messages. 
- Update the cron command output in `OzonInventoryDailySyncCommand` to print unique companies count. 
- Update tests to accommodate logging changes and UI columns, and inject `AppLogger` into integration test cases where `RequestOzonInventorySnapshotAction` is constructed.

### Testing

- Ran modified functional test `SnapshotIndexControllerTest` which asserts new table headers and error message visibility; test passed. 
- Ran integration tests `RequestOzonInventorySnapshotActionTest` and `SyncOzonInventorySnapshotHandlerTest` which cover session creation, dispatch behavior and error/rate-limit handling; tests passed. 
- Ran overall test suite for the inventory snapshot flow (unit/functional/integration slices) and no automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00c263e4d08323ab5022e8d30630a2)