### PR TITLE
fix(inventory): add `filter.visibility=ALL` to Ozon stocks request

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 > **Живой документ.** Обновляется после каждого нового модуля или изменения публичного контракта.
 > Читается: Claude Code (через CLAUDE.md) и Claude.ai Projects (через Knowledge).
-> Версия: 1.45 / 2026-05-10
+> Версия: 1.47 / 2026-05-10
 
 ---
 
@@ -1454,9 +1454,10 @@ paths:
 - HTTP request:
   - Header `Client-Id`
   - Header `Api-Key`
+  - `filter.visibility = ALL`
   - `limit`
-  - `last_id` передаётся только для последующих страниц, когда есть cursor.
-- На первой странице `last_id=null` не отправляется.
+  - `last_id` передаётся только для последующих страниц, когда курсор уже получен из предыдущего ответа.
+- На первой странице `last_id=null` не отправляется (поле отсутствует в JSON body).
 - Ответ возвращается как raw DTO `OzonInventoryResponse`.
 - Клиент не работает с `EntityManager`, не делает retry/sleep.
 - Ошибки:
@@ -1611,6 +1612,7 @@ Cron entry (`docker/cron/app.cron`):
 
 | Версия | Дата | Что изменилось |
 |---|---|---|
+| 1.47 | 2026-05-10 | fix(inventory): для Ozon `POST /v4/product/info/stocks` в request body добавлен `filter.visibility=ALL`; это устраняет `HTTP 400` и `failed`-сессии загрузки остатков при корректных credentials. |
 | 1.46 | 2026-05-10 | docs(inventory): в `ARCHITECTURE.md` задокументирован фактически реализованный Ozon Inventory Snapshot Pipeline: выделенный Inventory UI (GET/POST routes), `RequestOzonInventorySnapshotAction`, async message `SyncOzonInventorySnapshotMessage` (`async_sync`) и handler, `OzonInventoryClient` в модуле Inventory, daily cron `app:inventory:ozon-daily-sync` в 04:05 MSK, хранение `connectionId` в `requestParams` JSON без отдельной колонки, сохранение raw Ozon response в `InventoryRawSnapshot` без нормализации. Зафиксированы границы модулей: Inventory работает с Marketplace только через публичный `MarketplaceFacade`-контракт (без прямых импортов Marketplace Infrastructure/Repository/Query). |
 | 1.45 | 2026-05-10 | feat(marketplace): добавлен публичный контракт `MarketplaceFacade::getActiveOzonSellerConnections(?string $companyId = null): array` для кросс-модульного доступа (в т.ч. Inventory) к активным Ozon SELLER-подключениям **без утечки секретов**. Метод строится на `ActiveOzonConnectionsQuery` и возвращает только безопасные поля: `connectionId`, `companyId`, `marketplace`, `connectionType`, `clientId`. Query минимально расширен полем `client_id` (сохранён `finance_lock_before` для существующих потребителей). Добавлены интеграционные тесты `MarketplaceFacadeTest`: фильтры `is_active=true`, `marketplace=ozon`, `connection_type=seller`, фильтрация по `companyId`, и проверка отсутствия `apiKey/clientSecret/credentials/settings` в результате. |
 | 1.44 | 2026-04-28 | feat(marketplace): новый публичный метод `MarketplaceFacade::resolveListingsToProducts(string $companyId, array $listingIds): array` — пакетный резолв `listingId → productId|null` для будущего парсинга raw snapshot'ов в Inventory модуле. Один DQL-запрос с `IDENTITY(l.product)` и `getArrayResult()` — без N+1 и без загрузки Entity. IDOR через `IDENTITY(l.company) = :companyId`: листинги чужих компаний не появляются в результате (отсутствует ключ, не `null`). `productId = null` только для orphan-листингов (легитимный кейс). Валидация: `Assert::uuid($companyId)`, `Assert::allUuid($listingIds)`, `Assert::maxCount(5000)` — защита от случайного огромного массива; пустой массив возвращается без запроса в БД. Реализация — новый метод `MarketplaceListingRepository::findListingToProductMap(string $companyId, array $listingIds): array` (стиль уже существующего `findMarketplaceNamesByProductIds`). Дедупликация входа через `array_unique` перед `IN (:listingIds)`. **Не тронуто:** Entity `MarketplaceListing`, схема БД, существующие методы фасада. Тесты — `tests/Integration/Marketplace/Facade/MarketplaceFacadeTest.php` (8 кейсов: empty / invalid companyId / invalid listingId / 5001 limit / mapped listing / orphan listing / другая компания / non-existent listing / batch 100 листингов 60 mapped + 40 orphan). |

--- a/site/src/Inventory/Infrastructure/Api/Ozon/OzonInventoryClient.php
+++ b/site/src/Inventory/Infrastructure/Api/Ozon/OzonInventoryClient.php
@@ -24,7 +24,10 @@ final readonly class OzonInventoryClient
     {
         $this->assertInput($clientId, $apiKey, $limit);
 
-        $body = ['limit' => $limit];
+        $body = [
+            'filter' => ['visibility' => 'ALL'],
+            'limit' => $limit,
+        ];
         if (null !== $lastId && '' !== $lastId) {
             $body['last_id'] = $lastId;
         }

--- a/site/tests/Unit/Inventory/Infrastructure/Api/Ozon/OzonInventoryClientTest.php
+++ b/site/tests/Unit/Inventory/Infrastructure/Api/Ozon/OzonInventoryClientTest.php
@@ -15,7 +15,7 @@ final class OzonInventoryClientTest extends TestCase
 {
     /**
      * Contract for Ozon Seller API POST /v4/product/info/stocks:
-     * request uses `limit` + `last_id`, response cursor is `result.last_id`, items are in `result.items`.
+     * request uses `filter.visibility=ALL` + `limit` + optional `last_id`, response cursor is `result.last_id`, items are in `result.items`.
      */
     public function testSuccessReturnsRawResponseWithoutNormalizationForV4ProductInfoStocksContract(): void
     {
@@ -120,7 +120,7 @@ final class OzonInventoryClientTest extends TestCase
         $client = new OzonInventoryClient($http);
         $client->fetchStocks('client-1', 'api-1', 100, null);
 
-        self::assertSame(['limit' => 100], $captured);
+        self::assertSame(['filter' => ['visibility' => 'ALL'], 'limit' => 100], $captured);
         self::assertArrayNotHasKey('last_id', $captured);
     }
 
@@ -140,6 +140,7 @@ final class OzonInventoryClientTest extends TestCase
         self::assertStringEndsWith('/v4/product/info/stocks', $captured['url']);
         self::assertSame('client-1', $captured['options']['headers']['Client-Id']);
         self::assertSame('api-1', $captured['options']['headers']['Api-Key']);
+        self::assertSame(['visibility' => 'ALL'], $captured['options']['json']['filter']);
         self::assertSame(321, $captured['options']['json']['limit']);
         self::assertSame('last-42', $captured['options']['json']['last_id']);
     }


### PR DESCRIPTION
### Motivation
- Ozon Seller API `POST /v4/product/info/stocks` requires `filter.visibility=ALL` for full-stock queries and omission caused `HTTP 400` and failed snapshot sessions. 
- Documentation and tests needed to reflect the actual request contract used by the Inventory pipeline.

### Description
- Updated `App\Inventory\Infrastructure\Api\Ozon\OzonInventoryClient::fetchStocks` to include `'filter' => ['visibility' => 'ALL']` in the JSON request body. 
- Updated unit tests in `site/tests/Unit/Inventory/Infrastructure/Api/Ozon/OzonInventoryClientTest.php` to assert the presence of the `filter.visibility` field and adjusted the contract comment. 
- Bumped `ARCHITECTURE.md` version to `1.47` and added a changelog entry documenting the fix for Ozon inventory requests.

### Testing
- Ran unit tests in `site/tests/Unit/Inventory/Infrastructure/Api/Ozon/OzonInventoryClientTest.php`, including `testRequestBodyDoesNotContainLastIdWhenCursorIsNull` and `testCredentialsAndRequestBodyArePassedCorrectly`, and they passed. 
- No other automated test suites were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00c77b6a748323b5984569f0ee8fd4)