### PR TITLE
Add raw snapshot JSON endpoint and UI link, repository query, and tests

### DIFF
--- a/site/src/Inventory/Controller/SnapshotRawJsonController.php
+++ b/site/src/Inventory/Controller/SnapshotRawJsonController.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Inventory\Controller;
+
+use App\Inventory\Entity\InventoryRawSnapshot;
+use App\Inventory\Repository\InventoryRawSnapshotRepository;
+use App\Inventory\Repository\InventorySnapshotSessionRepository;
+use App\Shared\Service\ActiveCompanyService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Webmozart\Assert\Assert;
+
+#[IsGranted('ROLE_USER')]
+final class SnapshotRawJsonController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $activeCompanyService,
+        private readonly InventorySnapshotSessionRepository $sessionRepository,
+        private readonly InventoryRawSnapshotRepository $rawSnapshotRepository,
+    ) {
+    }
+
+    #[Route('/inventory/snapshots/{id}/json', name: 'inventory_snapshots_json', methods: ['GET'])]
+    public function __invoke(string $id): Response
+    {
+        Assert::uuid($id);
+
+        $companyId = (string) $this->activeCompanyService->getActiveCompany()->getId();
+        $session = $this->sessionRepository->findByIdAndCompany($id, $companyId);
+        if ($session === null) {
+            throw $this->createNotFoundException('Inventory snapshot session not found.');
+        }
+
+        $rawSnapshots = $this->rawSnapshotRepository->findBySessionAndCompanyOrdered($session->getId(), $companyId);
+
+        $payload = [
+            'snapshotSession' => [
+                'id' => $session->getId(),
+                'companyId' => $session->getCompanyId(),
+                'source' => $session->getSource()->value,
+                'status' => $session->getStatus()->value,
+                'triggerType' => $session->getTriggerType()->value,
+                'createdAt' => $session->getCreatedAt()->format(DATE_ATOM),
+                'startedAt' => $session->getStartedAt()?->format(DATE_ATOM),
+                'completedAt' => $session->getCompletedAt()?->format(DATE_ATOM),
+                'receivedPages' => $session->getReceivedPages(),
+                'expectedPages' => $session->getExpectedPages(),
+                'errorMessage' => $session->getErrorMessage(),
+                'correlationId' => $session->getCorrelationId(),
+            ],
+            'rawSnapshots' => array_map(static fn (InventoryRawSnapshot $snapshot): array => [
+                'id' => $snapshot->getId(),
+                'pageNumber' => $snapshot->getPageNumber(),
+                'sourceEndpoint' => $snapshot->getSourceEndpoint(),
+                'requestParams' => $snapshot->getRequestParams(),
+                'responseStatus' => $snapshot->getResponseStatus(),
+                'fetchedAt' => $snapshot->getFetchedAt()->format(DATE_ATOM),
+                'fetchDurationMs' => $snapshot->getFetchDurationMs(),
+                'responseBody' => $snapshot->getResponseBody(),
+            ], $rawSnapshots),
+        ];
+
+        if ($rawSnapshots === []) {
+            $payload['message'] = 'No raw snapshots saved for this session.';
+        }
+
+        return new JsonResponse($payload, Response::HTTP_OK);
+    }
+}

--- a/site/src/Inventory/Repository/InventoryRawSnapshotRepository.php
+++ b/site/src/Inventory/Repository/InventoryRawSnapshotRepository.php
@@ -7,11 +7,32 @@ namespace App\Inventory\Repository;
 use App\Inventory\Entity\InventoryRawSnapshot;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Webmozart\Assert\Assert;
 
 final class InventoryRawSnapshotRepository extends ServiceEntityRepository
 {
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, InventoryRawSnapshot::class);
+    }
+
+    /**
+     * @return list<InventoryRawSnapshot>
+     */
+    public function findBySessionAndCompanyOrdered(string $snapshotSessionId, string $companyId): array
+    {
+        Assert::uuid($snapshotSessionId);
+        Assert::uuid($companyId);
+
+        return $this->createQueryBuilder('r')
+            ->andWhere('r.snapshotSessionId = :snapshotSessionId')
+            ->andWhere('r.companyId = :companyId')
+            ->setParameter('snapshotSessionId', $snapshotSessionId)
+            ->setParameter('companyId', $companyId)
+            ->addOrderBy('r.pageNumber', 'ASC')
+            ->addOrderBy('r.fetchedAt', 'ASC')
+            ->addOrderBy('r.id', 'ASC')
+            ->getQuery()
+            ->getResult();
     }
 }

--- a/site/templates/inventory/snapshots/index.html.twig
+++ b/site/templates/inventory/snapshots/index.html.twig
@@ -36,6 +36,7 @@
                     <th>Маркетплейс</th>
                     <th>Статус</th>
                     <th>Страницы</th>
+                    <th>JSON</th>
                     <th>Ошибка</th>
                 </tr>
                 </thead>
@@ -61,6 +62,11 @@
                                 —
                             {% endif %}
                         </td>
+                        <td>
+                            <a class="btn btn-sm btn-outline-secondary" href="{{ path('inventory_snapshots_json', {id: row.id}) }}" target="_blank" rel="noopener noreferrer">
+                                JSON
+                            </a>
+                        </td>
                         <td class="text-muted small">
                             {% if row.error_message %}
                                 <div class="text-truncate" style="max-width: 420px;" title="{{ row.error_message }}">{{ row.error_message }}</div>
@@ -71,7 +77,7 @@
                     </tr>
                 {% else %}
                     <tr>
-                        <td colspan="5" class="text-center text-muted py-4">Загрузок пока нет.</td>
+                        <td colspan="6" class="text-center text-muted py-4">Загрузок пока нет.</td>
                     </tr>
                 {% endfor %}
                 </tbody>

--- a/site/tests/Functional/Inventory/Controller/SnapshotIndexControllerTest.php
+++ b/site/tests/Functional/Inventory/Controller/SnapshotIndexControllerTest.php
@@ -60,7 +60,13 @@ final class SnapshotIndexControllerTest extends WebTestCaseBase
         self::assertSame('Получить остатки', trim((string) $crawler->filter('form[action="/inventory/snapshots/request"] button[type="submit"]')->text()));
 
         $headers = $crawler->filter('table thead th')->each(static fn ($node) => trim((string) $node->text()));
-        self::assertSame(['Дата', 'Маркетплейс', 'Статус', 'Страницы', 'Ошибка'], $headers);
+        self::assertSame(['Дата', 'Маркетплейс', 'Статус', 'Страницы', 'JSON', 'Ошибка'], $headers);
+
+        $jsonLink = $crawler->filter(sprintf('a[href="/inventory/snapshots/%s/json"]', $ownSession->getId()));
+        self::assertSame(1, $jsonLink->count());
+        self::assertSame('JSON', trim((string) $jsonLink->text()));
+        self::assertSame('_blank', $jsonLink->attr('target'));
+        self::assertStringContainsString('noopener', (string) $jsonLink->attr('rel'));
         self::assertStringContainsString('Ozon Inventory API returned HTTP 403', (string) $client->getResponse()->getContent());
         self::assertStringNotContainsString('foreign', (string) $client->getResponse()->getContent());
     }

--- a/site/tests/Functional/Inventory/Controller/SnapshotRawJsonControllerTest.php
+++ b/site/tests/Functional/Inventory/Controller/SnapshotRawJsonControllerTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Inventory\Controller;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Builders\Inventory\InventoryRawSnapshotBuilder;
+use App\Tests\Builders\Inventory\InventorySnapshotSessionBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+
+final class SnapshotRawJsonControllerTest extends WebTestCaseBase
+{
+    public function testOwnCompanySessionWithRawSnapshotsReturns200AndPayload(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $em = $this->em();
+        $owner = UserBuilder::aUser()->withEmail('inventory-json-own@example.test')->build();
+        $company = CompanyBuilder::aCompany()->withId('11111111-1111-1111-1111-111111111801')->withOwner($owner)->build();
+
+        $session = InventorySnapshotSessionBuilder::aSession()
+            ->withCompanyId($company->getId())
+            ->withSource(MarketplaceType::OZON)
+            ->build();
+        $session->markCompleted();
+
+        $raw = InventoryRawSnapshotBuilder::aRawSnapshot()
+            ->withCompanyId($company->getId())
+            ->withSnapshotSessionId($session->getId())
+            ->withSource(MarketplaceType::OZON)
+            ->withEndpoint('/v4/product/info/stocks')
+            ->withResponseBody(['result' => ['items' => [['sku' => 'A1']]]])
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->persist($session);
+        $em->persist($raw);
+        $em->flush();
+
+        $this->loginWithActiveCompany($client, $owner, $company);
+        $client->request('GET', sprintf('/inventory/snapshots/%s/json', $session->getId()));
+
+        self::assertResponseIsSuccessful();
+        $json = json_decode((string) $client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame($session->getId(), $json['snapshotSession']['id']);
+        self::assertSame('ozon', $json['snapshotSession']['source']);
+        self::assertSame(1, count($json['rawSnapshots']));
+        self::assertSame('/v4/product/info/stocks', $json['rawSnapshots'][0]['sourceEndpoint']);
+        self::assertSame('A1', $json['rawSnapshots'][0]['responseBody']['result']['items'][0]['sku']);
+        self::assertArrayNotHasKey('apiKey', $json);
+        self::assertArrayNotHasKey('clientSecret', $json);
+        self::assertArrayNotHasKey('credentials', $json);
+    }
+
+    public function testForeignCompanySessionReturns404(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $em = $this->em();
+        $owner = UserBuilder::aUser()->withEmail('inventory-json-foreign@example.test')->build();
+        $companyA = CompanyBuilder::aCompany()->withId('11111111-1111-1111-1111-111111111802')->withOwner($owner)->build();
+        $companyB = CompanyBuilder::aCompany()->withId('11111111-1111-1111-1111-111111111803')->withOwner($owner)->build();
+
+        $foreignSession = InventorySnapshotSessionBuilder::aSession()
+            ->withCompanyId($companyB->getId())
+            ->build();
+        $foreignSession->markCompleted();
+
+        $em->persist($owner);
+        $em->persist($companyA);
+        $em->persist($companyB);
+        $em->persist($foreignSession);
+        $em->flush();
+
+        $this->loginWithActiveCompany($client, $owner, $companyA);
+        $client->request('GET', sprintf('/inventory/snapshots/%s/json', $foreignSession->getId()));
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    public function testNotExistingSessionReturns404(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $em = $this->em();
+        $owner = UserBuilder::aUser()->withEmail('inventory-json-missing@example.test')->build();
+        $company = CompanyBuilder::aCompany()->withId('11111111-1111-1111-1111-111111111804')->withOwner($owner)->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        $this->loginWithActiveCompany($client, $owner, $company);
+        $client->request('GET', '/inventory/snapshots/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/json');
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    public function testFailedSessionWithoutRawSnapshotsReturns200WithMessage(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $em = $this->em();
+        $owner = UserBuilder::aUser()->withEmail('inventory-json-empty@example.test')->build();
+        $company = CompanyBuilder::aCompany()->withId('11111111-1111-1111-1111-111111111805')->withOwner($owner)->build();
+
+        $session = InventorySnapshotSessionBuilder::aSession()
+            ->withCompanyId($company->getId())
+            ->withSource(MarketplaceType::OZON)
+            ->build();
+        $session->markFailed('fetch error');
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->persist($session);
+        $em->flush();
+
+        $this->loginWithActiveCompany($client, $owner, $company);
+        $client->request('GET', sprintf('/inventory/snapshots/%s/json', $session->getId()));
+
+        self::assertResponseIsSuccessful();
+        $json = json_decode((string) $client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame($session->getId(), $json['snapshotSession']['id']);
+        self::assertSame([], $json['rawSnapshots']);
+        self::assertSame('No raw snapshots saved for this session.', $json['message']);
+    }
+
+    public function testUnauthenticatedUserIsRedirectedToLogin(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $client->request('GET', '/inventory/snapshots/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/json');
+
+        self::assertTrue($client->getResponse()->isRedirect() || $client->getResponse()->getStatusCode() === 403);
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a machine-readable dump of raw inventory snapshot data for a given snapshot session and expose it from the UI. 
- Ensure raw snapshots are queried in a stable order and only for the active company. 
- Add automated tests to cover the new endpoint and the UI link.

### Description

- Introduces a new controller `SnapshotRawJsonController` with route `/inventory/snapshots/{id}/json` that returns JSON payloads for a snapshot session and its raw snapshots and requires `ROLE_USER`.
- Adds `findBySessionAndCompanyOrdered` to `InventoryRawSnapshotRepository` with UUID assertions and ordered results by `pageNumber`, `fetchedAt`, and `id`.
- Updates the snapshots list template to show a `JSON` column with a link that opens the raw JSON in a new tab.
- Updates `SnapshotIndexControllerTest` expectations for the new table header and link attributes and adds a new `SnapshotRawJsonControllerTest` that verifies success, 404 cases, empty results message, and authentication behavior.

### Testing

- Ran the functional test suite covering the inventory snapshot pages and endpoint, specifically `SnapshotIndexControllerTest` and `SnapshotRawJsonControllerTest`, and they succeeded. 
- Verified the new endpoint returns expected JSON structure for sessions with raw snapshots and returns `404` for missing or foreign sessions. 
- Verified the snapshots index page contains the `JSON` column and the action link opens in a new tab with `rel="noopener"`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0167e49a608323bc24592227a691fb)