### PR TITLE
Add CashFacade and CreateCashTransactionCommand; persist dedupe/rawData; add integration tests

### DIFF
--- a/site/src/Cash/Application/DTO/CreateCashTransactionCommand.php
+++ b/site/src/Cash/Application/DTO/CreateCashTransactionCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Cash\Application\DTO;
+
+use App\Cash\Enum\Transaction\CashDirection;
+
+final readonly class CreateCashTransactionCommand
+{
+    public function __construct(
+        public string $companyId,
+        public string $moneyAccountId,
+        public CashDirection $direction,
+        public string $amount,
+        public string $currency,
+        public \DateTimeImmutable $occurredAt,
+        public ?string $description = null,
+        public ?string $counterpartyId = null,
+        public ?string $cashflowCategoryId = null,
+        public ?string $projectDirectionId = null,
+        public ?string $importSource = null,
+        public ?string $externalId = null,
+        public ?string $dedupeHash = null,
+        public ?array $rawData = null,
+    ) {}
+}

--- a/site/src/Cash/DTO/CashTransactionDTO.php
+++ b/site/src/Cash/DTO/CashTransactionDTO.php
@@ -46,6 +46,14 @@ class CashTransactionDTO
      */
     public ?string $externalId = null;
 
+    /**
+     * Дедупликационный хэш транзакции.
+     */
+    public ?string $dedupeHash = null;
+
+    /** @var array<string, mixed>|null */
+    public ?array $rawData = null;
+
     public ?string $payerInn = null;
     public ?string $payeeInn = null;
     public ?string $counterpartyNameRaw = null;

--- a/site/src/Cash/Facade/CashFacade.php
+++ b/site/src/Cash/Facade/CashFacade.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Cash\Facade;
+
+use App\Cash\Application\DTO\CreateCashTransactionCommand;
+use App\Cash\DTO\CashTransactionDTO;
+use App\Cash\Service\Transaction\CashTransactionService;
+
+final readonly class CashFacade
+{
+    public function __construct(
+        private CashTransactionService $cashTransactionService,
+    ) {}
+
+    public function createTransaction(CreateCashTransactionCommand $command): string
+    {
+        $dto = new CashTransactionDTO();
+        $dto->companyId = $command->companyId;
+        $dto->moneyAccountId = $command->moneyAccountId;
+        $dto->direction = $command->direction;
+        $dto->amount = $command->amount;
+        $dto->currency = $command->currency;
+        $dto->occurredAt = $command->occurredAt;
+        $dto->description = $command->description;
+        $dto->counterpartyId = $command->counterpartyId;
+        $dto->cashflowCategoryId = $command->cashflowCategoryId;
+        $dto->projectDirectionId = $command->projectDirectionId;
+        $dto->importSource = $command->importSource;
+        $dto->externalId = $command->externalId;
+        $dto->dedupeHash = $command->dedupeHash;
+        $dto->rawData = $command->rawData;
+
+        $transaction = $this->cashTransactionService->add($dto);
+
+        return (string) $transaction->getId();
+    }
+}

--- a/site/src/Cash/Service/Transaction/CashTransactionService.php
+++ b/site/src/Cash/Service/Transaction/CashTransactionService.php
@@ -127,6 +127,8 @@ class CashTransactionService
 
         $tx->setImportSource($dto->importSource);
         $tx->setExternalId($dto->externalId);
+        $tx->setDedupeHash($dto->dedupeHash);
+        $tx->setRawData($dto->rawData ?? []);
 
         $this->applyVat($tx, $company, $dto->direction, $dto->amount);
 

--- a/site/tests/Integration/CashFacadeTest.php
+++ b/site/tests/Integration/CashFacadeTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration;
+
+use App\Cash\Application\DTO\CreateCashTransactionCommand;
+use App\Cash\Entity\Accounts\MoneyAccount;
+use App\Cash\Enum\Accounts\MoneyAccountType;
+use App\Cash\Enum\Transaction\CashDirection;
+use App\Cash\Facade\CashFacade;
+use App\Cash\Repository\Transaction\CashTransactionRepository;
+use App\Company\Entity\Counterparty;
+use App\Company\Enum\CounterpartyType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class CashFacadeTest extends IntegrationTestCase
+{
+    private CashFacade $cashFacade;
+    private CashTransactionRepository $cashTransactionRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->cashFacade = self::getContainer()->get(CashFacade::class);
+        $this->cashTransactionRepository = self::getContainer()->get(CashTransactionRepository::class);
+    }
+
+    public function testCreateTransactionPersistsTransactionViaPublicFacade(): void
+    {
+        $user = UserBuilder::aUser()->withEmail('facade@example.com')->withPasswordHash('pass')->build();
+        $company = CompanyBuilder::aCompany()->withOwner($user)->withName('Facade Company')->build();
+
+        $account = new MoneyAccount(Uuid::uuid4()->toString(), $company, MoneyAccountType::BANK, 'Main', 'USD');
+        $account->setOpeningBalance('0');
+        $account->setOpeningBalanceDate(new \DateTimeImmutable('2024-01-01'));
+
+        $counterparty = new Counterparty(Uuid::uuid4()->toString(), $company, 'Client', CounterpartyType::LEGAL_ENTITY);
+
+        $this->em->persist($user);
+        $this->em->persist($company);
+        $this->em->persist($account);
+        $this->em->persist($counterparty);
+        $this->em->flush();
+
+        $id = $this->cashFacade->createTransaction(new CreateCashTransactionCommand(
+            companyId: $company->getId(),
+            moneyAccountId: $account->getId(),
+            direction: CashDirection::INFLOW,
+            amount: '123.45',
+            currency: 'USD',
+            occurredAt: new \DateTimeImmutable('2024-02-10'),
+            description: 'Facade tx',
+            counterpartyId: $counterparty->getId(),
+        ));
+
+        $saved = $this->cashTransactionRepository->find($id);
+
+        self::assertNotNull($saved);
+        self::assertSame('Facade tx', $saved->getDescription());
+        self::assertSame($counterparty->getId(), $saved->getCounterparty()?->getId());
+    }
+
+
+    public function testCreateTransactionPersistsImportAndTelegramDedupFields(): void
+    {
+        $user = UserBuilder::aUser()->withEmail('facade3@example.com')->withPasswordHash('pass')->build();
+        $company = CompanyBuilder::aCompany()->withOwner($user)->withName('Facade Company 3')->build();
+
+        $account = new MoneyAccount(Uuid::uuid4()->toString(), $company, MoneyAccountType::BANK, 'Main', 'USD');
+        $account->setOpeningBalance('0');
+        $account->setOpeningBalanceDate(new \DateTimeImmutable('2024-01-01'));
+
+        $this->em->persist($user);
+        $this->em->persist($company);
+        $this->em->persist($account);
+        $this->em->flush();
+
+        $rawData = [
+            'source' => 'telegram',
+            'update_id' => 123,
+            'message_id' => 456,
+            'chat_id' => 789,
+            'from_id' => 111,
+            'message_date' => 1710000000,
+            'text' => 'расход 100 такси',
+        ];
+
+        $id = $this->cashFacade->createTransaction(new CreateCashTransactionCommand(
+            companyId: $company->getId(),
+            moneyAccountId: $account->getId(),
+            direction: CashDirection::OUTFLOW,
+            amount: '100.00',
+            currency: 'USD',
+            occurredAt: new \DateTimeImmutable('2024-03-10'),
+            description: 'Telegram tx',
+            importSource: 'telegram',
+            externalId: 'telegram:test',
+            dedupeHash: 'telegram:hash:test',
+            rawData: $rawData,
+        ));
+
+        $saved = $this->cashTransactionRepository->find($id);
+
+        self::assertNotNull($saved);
+        self::assertSame('telegram', $saved->getImportSource());
+        self::assertSame('telegram:test', $saved->getExternalId());
+        self::assertSame('telegram:hash:test', $saved->getDedupeHash());
+        self::assertSame($rawData, $saved->getRawData());
+    }
+
+    public function testCreateTransactionWithoutImportFieldsWorks(): void
+    {
+        $user = UserBuilder::aUser()->withEmail('facade2@example.com')->withPasswordHash('pass')->build();
+        $company = CompanyBuilder::aCompany()->withOwner($user)->withName('Facade Company 2')->build();
+
+        $account = new MoneyAccount(Uuid::uuid4()->toString(), $company, MoneyAccountType::BANK, 'Main', 'USD');
+        $account->setOpeningBalance('0');
+        $account->setOpeningBalanceDate(new \DateTimeImmutable('2024-01-01'));
+
+        $this->em->persist($user);
+        $this->em->persist($company);
+        $this->em->persist($account);
+        $this->em->flush();
+
+        $id = $this->cashFacade->createTransaction(new CreateCashTransactionCommand(
+            companyId: $company->getId(),
+            moneyAccountId: $account->getId(),
+            direction: CashDirection::OUTFLOW,
+            amount: '77.00',
+            currency: 'USD',
+            occurredAt: new \DateTimeImmutable('2024-03-01'),
+            description: 'No import fields',
+        ));
+
+        $saved = $this->cashTransactionRepository->find($id);
+
+        self::assertNotNull($saved);
+        self::assertNull($saved->getImportSource());
+        self::assertNull($saved->getExternalId());
+        self::assertNull($saved->getDedupeHash());
+        self::assertSame([], $saved->getRawData());
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a public facade to create cash transactions from application code and external callers. 
- Support import-related fields such as `dedupeHash` and arbitrary `rawData` for Telegram/imported transactions and ensure they are persisted.

### Description

- Add `App\Cash\Application\DTO\CreateCashTransactionCommand` to represent facade input parameters. 
- Add `App\Cash\Facade\CashFacade` with `createTransaction` that maps the command to `CashTransactionDTO` and returns the created transaction id. 
- Extend `CashTransactionDTO` with `dedupeHash` and `rawData` fields. 
- Update `CashTransactionService` to persist `dedupeHash` and `rawData` on new transactions and to default `rawData` to an empty array when null. 
- Add integration tests in `tests/Integration/CashFacadeTest.php` that verify basic creation, import/dedup/rawData persistence, and behavior when import fields are omitted.

### Testing

- Ran the new integration tests in `tests/Integration/CashFacadeTest.php` via `phpunit` and all assertions passed. 
- The tests verify that `createTransaction` persists transactions, sets `importSource`, `externalId`, `dedupeHash`, and `rawData` when provided, and leaves them null or empty as expected when omitted.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0171935d6c8323a7bf2c4df797413a)