### PR TITLE
Add import metadata and rawData handling to cash transactions and tests

### DIFF
--- a/site/src/Cash/Application/DTO/CreateCashTransactionCommand.php
+++ b/site/src/Cash/Application/DTO/CreateCashTransactionCommand.php
@@ -8,6 +8,9 @@ use App\Cash\Enum\Transaction\CashDirection;
 
 final readonly class CreateCashTransactionCommand
 {
+    /**
+     * @param array<string, mixed>|null $rawData
+     */
     public function __construct(
         public string $companyId,
         public string $moneyAccountId,

--- a/site/tests/Integration/CashTransactionServiceTest.php
+++ b/site/tests/Integration/CashTransactionServiceTest.php
@@ -77,11 +77,64 @@ final class CashTransactionServiceTest extends IntegrationTestCase
         $dto->description = 'Test tx';
         $dto->cashflowCategoryId = $category->getId();
         $dto->counterpartyId = $counterparty->getId();
+        $dto->importSource = 'telegram';
+        $dto->externalId = 'telegram:service:test';
+        $dto->dedupeHash = 'telegram:dedupe:test';
+        $dto->rawData = ['source' => 'telegram', 'message_id' => 12345];
 
         $tx = $this->txService->add($dto);
 
         $this->assertSame('Test tx', $tx->getDescription());
         $this->assertSame($category->getId(), $tx->getCashflowCategory()->getId());
         $this->assertSame($counterparty->getId(), $tx->getCounterparty()->getId());
+        $this->assertSame('telegram', $tx->getImportSource());
+        $this->assertSame('telegram:service:test', $tx->getExternalId());
+        $this->assertSame('telegram:dedupe:test', $tx->getDedupeHash());
+        $this->assertSame(['source' => 'telegram', 'message_id' => 12345], $tx->getRawData());
+    }
+
+    public function testAddWithoutImportFieldsKeepsBackwardCompatibility(): void
+    {
+        $user = UserBuilder::aUser()
+            ->withEmail('compat@example.com')
+            ->withPasswordHash('pass')
+            ->build();
+
+        $company = CompanyBuilder::aCompany()
+            ->withOwner($user)
+            ->withName('Compat')
+            ->build();
+
+        $account = new MoneyAccount(
+            Uuid::uuid4()->toString(),
+            $company,
+            MoneyAccountType::BANK,
+            'Main',
+            'USD'
+        );
+        $account->setOpeningBalance('0');
+        $account->setOpeningBalanceDate(new \DateTimeImmutable('2024-01-01'));
+
+        $this->em->persist($user);
+        $this->em->persist($company);
+        $this->em->persist($account);
+        $this->em->flush();
+
+        $dto = new CashTransactionDTO();
+        $dto->companyId = $company->getId();
+        $dto->moneyAccountId = $account->getId();
+        $dto->direction = CashDirection::OUTFLOW;
+        $dto->amount = '11.50';
+        $dto->currency = 'USD';
+        $dto->occurredAt = new \DateTimeImmutable('2024-01-11');
+        $dto->description = 'Legacy tx';
+
+        $tx = $this->txService->add($dto);
+
+        $this->assertSame('Legacy tx', $tx->getDescription());
+        $this->assertNull($tx->getImportSource());
+        $this->assertNull($tx->getExternalId());
+        $this->assertNull($tx->getDedupeHash());
+        $this->assertSame([], $tx->getRawData());
     }
 }


### PR DESCRIPTION
### Motivation

- Persist import-related metadata (`importSource`, `externalId`, `dedupeHash`) and arbitrary `rawData` for cash transactions so imported transactions can be tracked and de-duplicated.
- Ensure adding these new fields does not break existing callers that omit import-related fields.

### Description

- Added a PHPDoc type for the `rawData` parameter on `CreateCashTransactionCommand` constructor as `array<string, mixed>|null`.
- Extended `CashTransactionServiceTest` to populate and assert `importSource`, `externalId`, `dedupeHash`, and `rawData` are stored on created transactions.
- Added `testAddWithoutImportFieldsKeepsBackwardCompatibility` to verify that omitting import fields keeps `importSource`, `externalId`, and `dedupeHash` as `null` and returns an empty array for `rawData`.

### Testing

- Ran the integration test file `tests/Integration/CashTransactionServiceTest.php` with `phpunit` and the updated tests `testAdd...` and `testAddWithoutImportFieldsKeepsBackwardCompatibility` passed successfully.
- No other automated test failures were observed when running the updated test suite for this area.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0176a380fc8323b5b7aaeb830ece60)