### PR TITLE
Return structured CreateCashTransactionResult and add import-duplicate handling with DBAL lookup

### DIFF
--- a/site/src/Cash/Application/DTO/CreateCashTransactionResult.php
+++ b/site/src/Cash/Application/DTO/CreateCashTransactionResult.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Cash\Application\DTO;
+
+final readonly class CreateCashTransactionResult
+{
+    public function __construct(
+        public string $transactionId,
+        public bool $created,
+        public bool $duplicate,
+    ) {}
+}

--- a/site/src/Cash/Facade/CashFacade.php
+++ b/site/src/Cash/Facade/CashFacade.php
@@ -5,16 +5,20 @@ declare(strict_types=1);
 namespace App\Cash\Facade;
 
 use App\Cash\Application\DTO\CreateCashTransactionCommand;
+use App\Cash\Application\DTO\CreateCashTransactionResult;
 use App\Cash\DTO\CashTransactionDTO;
+use App\Cash\Repository\Transaction\CashTransactionRepository;
 use App\Cash\Service\Transaction\CashTransactionService;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 
 final readonly class CashFacade
 {
     public function __construct(
         private CashTransactionService $cashTransactionService,
+        private CashTransactionRepository $cashTransactionRepository,
     ) {}
 
-    public function createTransaction(CreateCashTransactionCommand $command): string
+    public function createTransaction(CreateCashTransactionCommand $command): CreateCashTransactionResult
     {
         $dto = new CashTransactionDTO();
         $dto->companyId = $command->companyId;
@@ -32,8 +36,45 @@ final readonly class CashFacade
         $dto->dedupeHash = $command->dedupeHash;
         $dto->rawData = $command->rawData;
 
-        $transaction = $this->cashTransactionService->add($dto);
+        $existing = $this->findExistingByImport($command);
+        if (null !== $existing) {
+            return new CreateCashTransactionResult((string) $existing->getId(), false, true);
+        }
 
-        return (string) $transaction->getId();
+        try {
+            $transaction = $this->cashTransactionService->add($dto);
+
+            return new CreateCashTransactionResult((string) $transaction->getId(), true, false);
+        } catch (UniqueConstraintViolationException $e) {
+            if (null === $command->importSource || null === $command->externalId) {
+                throw $e;
+            }
+
+            $existingId = $this->cashTransactionRepository->findIdByCompanyImportSourceExternalIdDbal(
+                $command->companyId,
+                $command->importSource,
+                $command->externalId,
+            );
+
+            if (null !== $existingId) {
+                return new CreateCashTransactionResult($existingId, false, true);
+            }
+
+            throw $e;
+        }
     }
+
+    private function findExistingByImport(CreateCashTransactionCommand $command): ?\App\Cash\Entity\Transaction\CashTransaction
+    {
+        if (null === $command->importSource || null === $command->externalId) {
+            return null;
+        }
+
+        return $this->cashTransactionRepository->findOneByCompanyImportSourceExternalId(
+            $command->companyId,
+            $command->importSource,
+            $command->externalId,
+        );
+    }
+
 }

--- a/site/src/Cash/Repository/Transaction/CashTransactionRepository.php
+++ b/site/src/Cash/Repository/Transaction/CashTransactionRepository.php
@@ -75,19 +75,44 @@ class CashTransactionRepository extends ServiceEntityRepository
             ->getOneOrNullResult();
     }
 
-    public function findOneByImport(string $companyId, string $source, string $externalId): ?CashTransaction
+    public function findOneByCompanyImportSourceExternalId(string $companyId, string $importSource, string $externalId): ?CashTransaction
     {
         return $this->createQueryBuilder('t')
             ->andWhere('IDENTITY(t.company) = :companyId')
-            ->andWhere('t.importSource = :source')
+            ->andWhere('t.importSource = :importSource')
             ->andWhere('t.externalId = :externalId')
             ->andWhere('t.deletedAt IS NULL')
             ->setMaxResults(1)
             ->setParameter('companyId', $companyId)
-            ->setParameter('source', $source)
+            ->setParameter('importSource', $importSource)
             ->setParameter('externalId', $externalId)
             ->getQuery()
             ->getOneOrNullResult();
+    }
+
+    public function findOneByImport(string $companyId, string $source, string $externalId): ?CashTransaction
+    {
+        return $this->findOneByCompanyImportSourceExternalId($companyId, $source, $externalId);
+    }
+
+
+
+    public function findIdByCompanyImportSourceExternalIdDbal(string $companyId, string $importSource, string $externalId): ?string
+    {
+        $id = $this->getEntityManager()->getConnection()->fetchOne(
+            'SELECT id FROM cash_transaction WHERE company_id = :companyId AND import_source = :importSource AND external_id = :externalId AND deleted_at IS NULL LIMIT 1',
+            [
+                'companyId' => $companyId,
+                'importSource' => $importSource,
+                'externalId' => $externalId,
+            ],
+        );
+
+        if (false === $id || null === $id) {
+            return null;
+        }
+
+        return (string) $id;
     }
 
     public function findActiveByCompanyAccountExternalId(

--- a/site/tests/Integration/CashFacadeTest.php
+++ b/site/tests/Integration/CashFacadeTest.php
@@ -47,7 +47,7 @@ final class CashFacadeTest extends IntegrationTestCase
         $this->em->persist($counterparty);
         $this->em->flush();
 
-        $id = $this->cashFacade->createTransaction(new CreateCashTransactionCommand(
+        $result = $this->cashFacade->createTransaction(new CreateCashTransactionCommand(
             companyId: $company->getId(),
             moneyAccountId: $account->getId(),
             direction: CashDirection::INFLOW,
@@ -58,8 +58,10 @@ final class CashFacadeTest extends IntegrationTestCase
             counterpartyId: $counterparty->getId(),
         ));
 
-        $saved = $this->cashTransactionRepository->find($id);
+        $saved = $this->cashTransactionRepository->find($result->transactionId);
 
+        self::assertTrue($result->created);
+        self::assertFalse($result->duplicate);
         self::assertNotNull($saved);
         self::assertSame('Facade tx', $saved->getDescription());
         self::assertSame($counterparty->getId(), $saved->getCounterparty()?->getId());
@@ -90,7 +92,7 @@ final class CashFacadeTest extends IntegrationTestCase
             'text' => 'расход 100 такси',
         ];
 
-        $id = $this->cashFacade->createTransaction(new CreateCashTransactionCommand(
+        $result = $this->cashFacade->createTransaction(new CreateCashTransactionCommand(
             companyId: $company->getId(),
             moneyAccountId: $account->getId(),
             direction: CashDirection::OUTFLOW,
@@ -104,8 +106,10 @@ final class CashFacadeTest extends IntegrationTestCase
             rawData: $rawData,
         ));
 
-        $saved = $this->cashTransactionRepository->find($id);
+        $saved = $this->cashTransactionRepository->find($result->transactionId);
 
+        self::assertTrue($result->created);
+        self::assertFalse($result->duplicate);
         self::assertNotNull($saved);
         self::assertSame('telegram', $saved->getImportSource());
         self::assertSame('telegram:test', $saved->getExternalId());
@@ -127,7 +131,7 @@ final class CashFacadeTest extends IntegrationTestCase
         $this->em->persist($account);
         $this->em->flush();
 
-        $id = $this->cashFacade->createTransaction(new CreateCashTransactionCommand(
+        $result = $this->cashFacade->createTransaction(new CreateCashTransactionCommand(
             companyId: $company->getId(),
             moneyAccountId: $account->getId(),
             direction: CashDirection::OUTFLOW,
@@ -137,12 +141,113 @@ final class CashFacadeTest extends IntegrationTestCase
             description: 'No import fields',
         ));
 
-        $saved = $this->cashTransactionRepository->find($id);
+        $saved = $this->cashTransactionRepository->find($result->transactionId);
 
+        self::assertTrue($result->created);
+        self::assertFalse($result->duplicate);
         self::assertNotNull($saved);
         self::assertNull($saved->getImportSource());
         self::assertNull($saved->getExternalId());
         self::assertNull($saved->getDedupeHash());
         self::assertSame([], $saved->getRawData());
     }
+
+    public function testCreateTransactionReturnsDuplicateForSameImportSourceAndExternalId(): void
+    {
+        $user = UserBuilder::aUser()->withEmail('facade4@example.com')->withPasswordHash('pass')->build();
+        $company = CompanyBuilder::aCompany()->withOwner($user)->withName('Facade Company 4')->build();
+
+        $account = new MoneyAccount(Uuid::uuid4()->toString(), $company, MoneyAccountType::BANK, 'Main', 'USD');
+        $account->setOpeningBalance('0');
+        $account->setOpeningBalanceDate(new \DateTimeImmutable('2024-01-01'));
+
+        $this->em->persist($user);
+        $this->em->persist($company);
+        $this->em->persist($account);
+        $this->em->flush();
+
+        $first = $this->cashFacade->createTransaction(new CreateCashTransactionCommand(
+            companyId: $company->getId(),
+            moneyAccountId: $account->getId(),
+            direction: CashDirection::OUTFLOW,
+            amount: '100.00',
+            currency: 'USD',
+            occurredAt: new \DateTimeImmutable('2024-03-10'),
+            description: 'Telegram tx',
+            importSource: 'telegram',
+            externalId: 'telegram:dedupe',
+        ));
+
+        $second = $this->cashFacade->createTransaction(new CreateCashTransactionCommand(
+            companyId: $company->getId(),
+            moneyAccountId: $account->getId(),
+            direction: CashDirection::OUTFLOW,
+            amount: '100.00',
+            currency: 'USD',
+            occurredAt: new \DateTimeImmutable('2024-03-10'),
+            description: 'Telegram tx duplicate delivery',
+            importSource: 'telegram',
+            externalId: 'telegram:dedupe',
+        ));
+
+        self::assertTrue($first->created);
+        self::assertFalse($first->duplicate);
+        self::assertFalse($second->created);
+        self::assertTrue($second->duplicate);
+        self::assertSame($first->transactionId, $second->transactionId);
+
+        $rows = $this->cashTransactionRepository->findBy([
+            'company' => $company,
+            'importSource' => 'telegram',
+            'externalId' => 'telegram:dedupe',
+        ]);
+
+        self::assertCount(1, $rows);
+    }
+
+    public function testCreateTransactionDoesNotTreatDifferentExternalIdsAsDuplicate(): void
+    {
+        $user = UserBuilder::aUser()->withEmail('facade5@example.com')->withPasswordHash('pass')->build();
+        $company = CompanyBuilder::aCompany()->withOwner($user)->withName('Facade Company 5')->build();
+
+        $account = new MoneyAccount(Uuid::uuid4()->toString(), $company, MoneyAccountType::BANK, 'Main', 'USD');
+        $account->setOpeningBalance('0');
+        $account->setOpeningBalanceDate(new \DateTimeImmutable('2024-01-01'));
+
+        $this->em->persist($user);
+        $this->em->persist($company);
+        $this->em->persist($account);
+        $this->em->flush();
+
+        $first = $this->cashFacade->createTransaction(new CreateCashTransactionCommand(
+            companyId: $company->getId(),
+            moneyAccountId: $account->getId(),
+            direction: CashDirection::OUTFLOW,
+            amount: '250.00',
+            currency: 'USD',
+            occurredAt: new \DateTimeImmutable('2024-03-11'),
+            description: 'Taxi',
+            importSource: 'telegram',
+            externalId: 'telegram:100',
+        ));
+
+        $second = $this->cashFacade->createTransaction(new CreateCashTransactionCommand(
+            companyId: $company->getId(),
+            moneyAccountId: $account->getId(),
+            direction: CashDirection::OUTFLOW,
+            amount: '250.00',
+            currency: 'USD',
+            occurredAt: new \DateTimeImmutable('2024-03-11'),
+            description: 'Taxi',
+            importSource: 'telegram',
+            externalId: 'telegram:101',
+        ));
+
+        self::assertTrue($first->created);
+        self::assertTrue($second->created);
+        self::assertFalse($first->duplicate);
+        self::assertFalse($second->duplicate);
+        self::assertNotSame($first->transactionId, $second->transactionId);
+    }
+
 }

--- a/site/tests/Service/Import/CashTransactionRepositoryTest.php
+++ b/site/tests/Service/Import/CashTransactionRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\Integration\Import;
 
 use App\Cash\Entity\Transaction\CashTransaction;
@@ -33,4 +35,31 @@ class CashTransactionRepositoryTest extends ClientBank1CImportServiceTestCase
 
         self::assertNull($found);
     }
+
+    public function testFindIdByCompanyImportSourceExternalIdDbalReturnsTransactionId(): void
+    {
+        $transaction = new CashTransaction(
+            Uuid::uuid4()->toString(),
+            $this->company,
+            $this->account,
+            CashDirection::OUTFLOW,
+            '150.00',
+            'RUB',
+            new \DateTimeImmutable('2024-01-11')
+        );
+        $transaction->setImportSource('telegram');
+        $transaction->setExternalId('ext-dbal-lookup');
+
+        $this->em->persist($transaction);
+        $this->em->flush();
+
+        $foundId = $this->transactionRepository->findIdByCompanyImportSourceExternalIdDbal(
+            $this->company->getId(),
+            'telegram',
+            'ext-dbal-lookup',
+        );
+
+        self::assertSame($transaction->getId(), $foundId);
+    }
+
 }


### PR DESCRIPTION
### Motivation

- Represent the outcome of `createTransaction` with structured data indicating transaction id, whether it was created, and whether it was a duplicate.
- Avoid race conditions and surface unique-constraint conflicts for import-based transactions by detecting duplicates and returning the existing id instead of failing.
- Provide a fast DBAL lookup path to resolve an existing transaction id when a unique constraint triggers during insert.

### Description

- Added a new DTO `CreateCashTransactionResult` in `site/src/Cash/Application/DTO/CreateCashTransactionResult.php` to carry `transactionId`, `created`, and `duplicate` flags.
- Updated `CashFacade::createTransaction` to return `CreateCashTransactionResult`, injected `CashTransactionRepository`, perform a pre-check via `findExistingByImport`, call the service to add the transaction, and catch `UniqueConstraintViolationException` to resolve the existing id via a DBAL lookup and return a duplicate result when appropriate.
- Extended `CashTransactionRepository` with a renamed query method `findOneByCompanyImportSourceExternalId`, an alias `findOneByImport`, and a new `findIdByCompanyImportSourceExternalIdDbal` method that performs a direct SQL `SELECT id ...` lookup for faster resolution in exception handling.
- Updated integration tests in `CashFacadeTest` to assert on the new `CreateCashTransactionResult` fields and added tests for duplicate detection and non-duplicates; added `CashTransactionRepositoryTest` to verify the DBAL id lookup.

### Testing

- Ran the updated integration tests `CashFacadeTest` and `CashTransactionRepositoryTest` with PHPUnit; all tests passed.
- Ran the repository-level test that exercises `findIdByCompanyImportSourceExternalIdDbal` and it returned the expected transaction id.
- Verified that the duplicate import scenarios in the `CashFacadeTest` produce `created=false` and `duplicate=true` and that only one row is persisted for the same `importSource`/`externalId` pair.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a017b939054832389311dcb87008c15)