### PR TITLE
Telegram: extract cash transaction creation to Action, add external-id generator and tests

### DIFF
--- a/site/src/Telegram/Application/CreateTelegramCashTransactionAction.php
+++ b/site/src/Telegram/Application/CreateTelegramCashTransactionAction.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Telegram\Application;
+
+use App\Cash\Application\DTO\CreateCashTransactionCommand;
+use App\Cash\Enum\Transaction\CashDirection;
+use App\Cash\Facade\CashFacade;
+use App\Telegram\Application\DTO\CreateTelegramCashTransactionActionResult;
+use App\Telegram\Application\DTO\CreateTelegramCashTransactionCommand;
+use App\Telegram\Domain\Service\TelegramCashTransactionExternalIdGenerator;
+
+final readonly class CreateTelegramCashTransactionAction
+{
+    public function __construct(
+        private CashFacade $cashFacade,
+        private TelegramCashTransactionExternalIdGenerator $externalIdGenerator,
+    ) {}
+
+    public function __invoke(CreateTelegramCashTransactionCommand $command): ?CreateTelegramCashTransactionActionResult
+    {
+        $amount = $this->parseAmountFromText($command->text);
+        if (null === $amount) {
+            return null;
+        }
+
+        if (null === $command->chatId || null === $command->messageId) {
+            return CreateTelegramCashTransactionActionResult::skippedDueToMissingMessageIdentity();
+        }
+
+        $direction = $this->detectDirection($command->text);
+        $externalId = $this->externalIdGenerator->generate($command->botId, $command->chatId, $command->messageId);
+
+        $result = $this->cashFacade->createTransaction(new CreateCashTransactionCommand(
+            companyId: $command->companyId,
+            moneyAccountId: $command->moneyAccountId,
+            direction: $direction,
+            amount: $amount,
+            currency: $command->currency,
+            occurredAt: new \DateTimeImmutable(),
+            description: $command->text,
+            importSource: 'telegram',
+            externalId: $externalId,
+            rawData: [
+                'source' => 'telegram',
+                'update_id' => $command->updateId,
+                'message_id' => $command->messageId,
+                'chat_id' => $command->chatId,
+                'from_id' => $command->fromId,
+                'message_date' => $command->messageDate,
+                'text' => $command->text,
+                'bot_id_fallback' => null === $command->botId ? 'default' : null,
+            ],
+        ));
+
+        return CreateTelegramCashTransactionActionResult::created(
+            duplicate: $result->duplicate,
+            amount: $amount,
+            directionLabel: CashDirection::INFLOW === $direction ? 'доход' : 'расход',
+        );
+    }
+
+    private function parseAmountFromText(string $text): ?string
+    {
+        if (!preg_match('/\d[\d\s.,]*/u', $text, $matches)) {
+            return null;
+        }
+
+        $raw = preg_replace('/\s+/u', '', $matches[0]);
+        if (null === $raw || '' === $raw) {
+            return null;
+        }
+
+        $lastDot = strrpos($raw, '.');
+        $lastComma = strrpos($raw, ',');
+        $decimalSeparator = null;
+
+        if (false !== $lastDot && false !== $lastComma) {
+            $decimalSeparator = $lastDot > $lastComma ? '.' : ',';
+        } elseif (false !== $lastDot) {
+            $decimalSeparator = '.';
+        } elseif (false !== $lastComma) {
+            $decimalSeparator = ',';
+        }
+
+        if (',' === $decimalSeparator) {
+            $raw = str_replace('.', '', $raw);
+            $raw = str_replace(',', '.', $raw);
+        } else {
+            $raw = str_replace(',', '', $raw);
+        }
+
+        [$integerPart, $fractionalPart] = array_pad(explode('.', $raw, 2), 2, '');
+        $integerPart = ltrim($integerPart, '0');
+        $integerPart = '' === $integerPart ? '0' : $integerPart;
+        $fractionalPart = substr($fractionalPart, 0, 2);
+        $fractionalPart = str_pad($fractionalPart, 2, '0');
+
+        return sprintf('%s.%s', $integerPart, $fractionalPart);
+    }
+
+    private function detectDirection(string $text): CashDirection
+    {
+        $normalized = mb_strtolower($text);
+
+        if (preg_match('/потрат|расход|купил|оплат/u', $normalized)) {
+            return CashDirection::OUTFLOW;
+        }
+
+        if (preg_match('/пришло|поступ|доход|получил/u', $normalized)) {
+            return CashDirection::INFLOW;
+        }
+
+        return CashDirection::OUTFLOW;
+    }
+}

--- a/site/src/Telegram/Application/DTO/CreateTelegramCashTransactionActionResult.php
+++ b/site/src/Telegram/Application/DTO/CreateTelegramCashTransactionActionResult.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Telegram\Application\DTO;
+
+final readonly class CreateTelegramCashTransactionActionResult
+{
+    private function __construct(
+        public bool $duplicate,
+        public string $amount,
+        public string $directionLabel,
+        public bool $skippedMissingMessageIdentity,
+    ) {}
+
+    public static function created(bool $duplicate, string $amount, string $directionLabel): self
+    {
+        return new self($duplicate, $amount, $directionLabel, false);
+    }
+
+    public static function skippedDueToMissingMessageIdentity(): self
+    {
+        return new self(false, '0.00', '', true);
+    }
+}

--- a/site/src/Telegram/Application/DTO/CreateTelegramCashTransactionCommand.php
+++ b/site/src/Telegram/Application/DTO/CreateTelegramCashTransactionCommand.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Telegram\Application\DTO;
+
+final readonly class CreateTelegramCashTransactionCommand
+{
+    public function __construct(
+        public ?string $botId,
+        public string $companyId,
+        public string $moneyAccountId,
+        public string $currency,
+        public ?string $chatId,
+        public ?string $messageId,
+        public ?string $fromId,
+        public ?int $updateId,
+        public ?int $messageDate,
+        public string $text,
+    ) {}
+}

--- a/site/src/Telegram/Controller/TelegramWebhookController.php
+++ b/site/src/Telegram/Controller/TelegramWebhookController.php
@@ -3,12 +3,12 @@
 namespace App\Telegram\Controller;
 
 use App\Cash\Entity\Accounts\MoneyAccount;
-use App\Cash\Entity\Transaction\CashTransaction;
-use App\Cash\Enum\Transaction\CashDirection;
 use App\Telegram\Entity\ClientBinding;
 use App\Telegram\Entity\ImportJob;
 use App\Telegram\Entity\ReportSubscription;
 use App\Telegram\Entity\TelegramBot;
+use App\Telegram\Application\CreateTelegramCashTransactionAction;
+use App\Telegram\Application\DTO\CreateTelegramCashTransactionCommand;
 use App\Telegram\Entity\TelegramUser;
 use App\Telegram\Repository\BotLinkRepository;
 use App\Telegram\Repository\TelegramBotRepository;
@@ -30,6 +30,7 @@ class TelegramWebhookController extends AbstractController
         private readonly EntityManagerInterface $entityManager,
         private readonly HttpClientInterface $httpClient,
         private readonly LoggerInterface $logger,
+        private readonly CreateTelegramCashTransactionAction $createTelegramCashTransactionAction,
     ) {
     }
 
@@ -101,7 +102,7 @@ class TelegramWebhookController extends AbstractController
                 return $this->handleReports($bot, $message);
             }
 
-            return $this->handleTextMessage($bot, $message, $text);
+            return $this->handleTextMessage($bot, $update, $message, $text);
         } catch (\Throwable $e) {
             error_log('[TELEGRAM_WEBHOOK_EXCEPTION] '.$e->getMessage());
             error_log('[TELEGRAM_WEBHOOK_EXCEPTION] file='.$e->getFile().':'.$e->getLine());
@@ -745,7 +746,7 @@ class TelegramWebhookController extends AbstractController
         return $this->respondWithMessage($bot, $message, $messageText);
     }
 
-    private function handleTextMessage(TelegramBot $bot, array $message, string $text): Response
+    private function handleTextMessage(TelegramBot $bot, array $update, array $message, string $text): Response
     {
         $normalizedText = trim($text);
 
@@ -823,120 +824,50 @@ class TelegramWebhookController extends AbstractController
             return $this->respondWithMessage($bot, $message, 'Сначала выберите кассу: /set_cash');
         }
 
-        $amount = $this->parseAmountFromText($text);
-        if (null === $amount) {
+        $result = ($this->createTelegramCashTransactionAction)(new CreateTelegramCashTransactionCommand(
+            botId: $bot->getId(),
+            companyId: $clientBinding->getCompany()->getId(),
+            moneyAccountId: $moneyAccount->getId(),
+            currency: $moneyAccount->getCurrency(),
+            chatId: isset($message['chat']['id']) ? (string) $message['chat']['id'] : null,
+            messageId: isset($message['message_id']) ? (string) $message['message_id'] : null,
+            fromId: isset($message['from']['id']) ? (string) $message['from']['id'] : null,
+            updateId: isset($update['update_id']) ? (int) $update['update_id'] : null,
+            messageDate: isset($message['date']) ? (int) $message['date'] : null,
+            text: $text,
+        ));
+
+        if (null === $result) {
             return $this->respondWithMessage($bot, $message, 'Формат: потратил 2500 на рекламу');
         }
 
-        // MVP: определяем направление по ключевым словам, по умолчанию считаем расход
-        $direction = $this->detectDirection($text);
 
-        $now = new \DateTimeImmutable();
+        if ($result->skippedMissingMessageIdentity) {
+            $this->logger->warning('Telegram cash transaction skipped: message identity is incomplete.', [
+                'update_id' => $update['update_id'] ?? null,
+                'chat_id' => $message['chat']['id'] ?? null,
+                'message_id' => $message['message_id'] ?? null,
+            ]);
 
-        if ($this->isRecentDuplicate($moneyAccount, $amount, $text, $now)) {
             return new JsonResponse(['status' => 'ok']);
         }
 
-        $transaction = new CashTransaction(
-            Uuid::uuid4()->toString(),
-            $clientBinding->getCompany(),
-            $moneyAccount,
-            $direction,
-            $amount,
-            $moneyAccount->getCurrency(),
-            $now,
-        );
+        if ($result->duplicate) {
+            $this->logger->info('Telegram duplicate cash transaction skipped.', [
+                'company_id' => $clientBinding->getCompany()->getId(),
+                'money_account_id' => $moneyAccount->getId(),
+            ]);
 
-        $transaction->setDescription($text);
-        $transaction->setImportSource('telegram');
+            return new JsonResponse(['status' => 'ok']);
+        }
 
-        $this->entityManager->persist($transaction);
-        $this->entityManager->flush();
-
-        $directionLabel = CashDirection::INFLOW === $direction ? 'доход' : 'расход';
-        $formattedAmount = $this->formatAmountForMessage($amount, $moneyAccount->getCurrency());
+        $formattedAmount = $this->formatAmountForMessage($result->amount, $moneyAccount->getCurrency());
 
         return $this->respondWithMessage(
             $bot,
             $message,
-            sprintf('Записал %s %s', $directionLabel, $formattedAmount)
+            sprintf('Записал %s %s', $result->directionLabel, $formattedAmount)
         );
-    }
-
-    private function parseAmountFromText(string $text): ?string
-    {
-        if (!preg_match('/\d[\d\s.,]*/u', $text, $matches)) {
-            return null;
-        }
-
-        $raw = preg_replace('/\s+/u', '', $matches[0]);
-        if (null === $raw || '' === $raw) {
-            return null;
-        }
-
-        $lastDot = strrpos($raw, '.');
-        $lastComma = strrpos($raw, ',');
-        $decimalSeparator = null;
-
-        if (false !== $lastDot && false !== $lastComma) {
-            $decimalSeparator = $lastDot > $lastComma ? '.' : ',';
-        } elseif (false !== $lastDot) {
-            $decimalSeparator = '.';
-        } elseif (false !== $lastComma) {
-            $decimalSeparator = ',';
-        }
-
-        if (',' === $decimalSeparator) {
-            $raw = str_replace('.', '', $raw);
-            $raw = str_replace(',', '.', $raw);
-        } else {
-            $raw = str_replace(',', '', $raw);
-        }
-
-        [$integerPart, $fractionalPart] = array_pad(explode('.', $raw, 2), 2, '');
-        $integerPart = ltrim($integerPart, '0');
-        $integerPart = '' === $integerPart ? '0' : $integerPart;
-
-        $fractionalPart = substr($fractionalPart, 0, 2);
-        $fractionalPart = str_pad($fractionalPart, 2, '0');
-
-        return sprintf('%s.%s', $integerPart, $fractionalPart);
-    }
-
-    private function detectDirection(string $text): CashDirection
-    {
-        $normalized = mb_strtolower($text);
-
-        if (preg_match('/потрат|расход|купил|оплат/u', $normalized)) {
-            return CashDirection::OUTFLOW;
-        }
-
-        if (preg_match('/пришло|поступ|доход|получил/u', $normalized)) {
-            return CashDirection::INFLOW;
-        }
-
-        // MVP: по умолчанию считаем расход
-        return CashDirection::OUTFLOW;
-    }
-
-    private function isRecentDuplicate(MoneyAccount $account, string $amount, string $description, \DateTimeImmutable $now): bool
-    {
-        $since = $now->modify('-2 minutes');
-
-        return (bool) $this->entityManager->getRepository(CashTransaction::class)
-            ->createQueryBuilder('t')
-            ->select('1')
-            ->andWhere('t.moneyAccount = :account')
-            ->andWhere('t.amount = :amount')
-            ->andWhere('t.description = :description')
-            ->andWhere('t.createdAt >= :since')
-            ->setParameter('account', $account)
-            ->setParameter('amount', $amount)
-            ->setParameter('description', $description)
-            ->setParameter('since', $since)
-            ->setMaxResults(1)
-            ->getQuery()
-            ->getOneOrNullResult();
     }
 
     private function formatAmountForMessage(string $amount, string $currency): string

--- a/site/src/Telegram/Domain/Service/TelegramCashTransactionExternalIdGenerator.php
+++ b/site/src/Telegram/Domain/Service/TelegramCashTransactionExternalIdGenerator.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Telegram\Domain\Service;
+
+final readonly class TelegramCashTransactionExternalIdGenerator
+{
+    public function generate(?string $botId, string $chatId, string $messageId): string
+    {
+        $stableBotId = $botId ?? 'default';
+
+        return 'telegram:'.hash('sha256', sprintf('%s|%s|%s', $stableBotId, $chatId, $messageId));
+    }
+}

--- a/site/tests/Integration/Telegram/CreateTelegramCashTransactionActionTest.php
+++ b/site/tests/Integration/Telegram/CreateTelegramCashTransactionActionTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Telegram;
+
+use App\Cash\Entity\Transaction\CashTransaction;
+use App\Telegram\Application\CreateTelegramCashTransactionAction;
+use App\Telegram\Application\DTO\CreateTelegramCashTransactionCommand;
+use App\Tests\Builders\Cash\MoneyAccountBuilder;
+use App\Tests\Builders\Company\CompanyBuilder;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class CreateTelegramCashTransactionActionTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private CreateTelegramCashTransactionAction $action;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->em = self::getContainer()->get(EntityManagerInterface::class);
+        $this->action = self::getContainer()->get(CreateTelegramCashTransactionAction::class);
+    }
+
+    public function testDuplicatePayloadCreatesSingleTransaction(): void
+    {
+        [$companyId, $moneyAccountId] = $this->createCompanyAndAccount(101, '33333333-3333-3333-3333-000000000101');
+
+        $command = new CreateTelegramCashTransactionCommand('bot-1', $companyId, $moneyAccountId, 'RUB', '100', '200', '300', 10, 1700000000, 'потратил 2500 на рекламу');
+
+        $first = ($this->action)($command);
+        $second = ($this->action)($command);
+
+        self::assertNotNull($first);
+        self::assertNotNull($second);
+        self::assertFalse($first->duplicate);
+        self::assertTrue($second->duplicate);
+        self::assertSame(1, $this->countTelegramTransactions($companyId, $moneyAccountId));
+    }
+
+    public function testDifferentMessageIdCreatesTwoTransactions(): void
+    {
+        [$companyId, $moneyAccountId] = $this->createCompanyAndAccount(202, '33333333-3333-3333-3333-000000000202');
+
+        ($this->action)(new CreateTelegramCashTransactionCommand('bot-1', $companyId, $moneyAccountId, 'RUB', '100', '200', '300', 10, 1700000000, 'потратил 2500 на рекламу'));
+        ($this->action)(new CreateTelegramCashTransactionCommand('bot-1', $companyId, $moneyAccountId, 'RUB', '100', '201', '300', 11, 1700000001, 'потратил 2500 на рекламу'));
+
+        self::assertSame(2, $this->countTelegramTransactions($companyId, $moneyAccountId));
+    }
+
+    private function createCompanyAndAccount(int $companyIndex, string $moneyAccountId): array
+    {
+        $company = CompanyBuilder::aCompany()->withIndex($companyIndex)->build();
+        $account = MoneyAccountBuilder::aMoneyAccount()->withId($moneyAccountId)->forCompany($company)->build();
+
+        $this->em->persist($company);
+        $this->em->persist($account);
+        $this->em->flush();
+
+        return [$company->getId(), $account->getId()];
+    }
+
+    private function countTelegramTransactions(string $companyId, string $moneyAccountId): int
+    {
+        return (int) $this->em->createQueryBuilder()
+            ->select('COUNT(t.id)')
+            ->from(CashTransaction::class, 't')
+            ->andWhere('t.importSource = :source')
+            ->andWhere('IDENTITY(t.company) = :companyId')
+            ->andWhere('IDENTITY(t.moneyAccount) = :moneyAccountId')
+            ->setParameter('source', 'telegram')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('moneyAccountId', $moneyAccountId)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+}

--- a/site/tests/Unit/Telegram/TelegramCashTransactionExternalIdGeneratorTest.php
+++ b/site/tests/Unit/Telegram/TelegramCashTransactionExternalIdGeneratorTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Telegram;
+
+use App\Telegram\Domain\Service\TelegramCashTransactionExternalIdGenerator;
+use PHPUnit\Framework\TestCase;
+
+final class TelegramCashTransactionExternalIdGeneratorTest extends TestCase
+{
+    public function testSameIdentityProducesSameExternalId(): void
+    {
+        $generator = new TelegramCashTransactionExternalIdGenerator();
+
+        self::assertSame(
+            $generator->generate('bot-1', 'chat-1', 'msg-1'),
+            $generator->generate('bot-1', 'chat-1', 'msg-1'),
+        );
+    }
+
+    public function testDifferentMessageIdProducesDifferentExternalId(): void
+    {
+        $generator = new TelegramCashTransactionExternalIdGenerator();
+
+        self::assertNotSame(
+            $generator->generate('bot-1', 'chat-1', 'msg-1'),
+            $generator->generate('bot-1', 'chat-1', 'msg-2'),
+        );
+    }
+
+    public function testExternalIdLengthDoesNotExceed128(): void
+    {
+        $generator = new TelegramCashTransactionExternalIdGenerator();
+
+        self::assertLessThanOrEqual(128, mb_strlen($generator->generate('bot-1', 'chat-1', 'msg-1')));
+    }
+
+    public function testFallbackBotIdDefaultIsUsedWhenBotIdIsNull(): void
+    {
+        $generator = new TelegramCashTransactionExternalIdGenerator();
+
+        self::assertSame(
+            'telegram:'.hash('sha256', 'default|chat-1|msg-1'),
+            $generator->generate(null, 'chat-1', 'msg-1'),
+        );
+    }
+}


### PR DESCRIPTION
### Motivation

- Centralize Telegram-to-cash-transaction logic to a reusable service and keep the controller thin.
- Ensure stable deduplication by generating a deterministic external id for Telegram messages.
- Add coverage for the generator and the new action to prevent regressions.

### Description

- Introduce `CreateTelegramCashTransactionAction` which parses amount, detects direction, generates stable external id, and delegates creation to `CashFacade`; it returns a `CreateTelegramCashTransactionActionResult` DTO.
- Add DTOs `CreateTelegramCashTransactionCommand` and `CreateTelegramCashTransactionActionResult` to represent input and result states, including a flag for skipped creation when message identity is incomplete and duplicate detection.
- Add `TelegramCashTransactionExternalIdGenerator` service which produces a stable SHA256-based external id with a `default` fallback for missing bot id.
- Integrate the action into `TelegramWebhookController`, removing inline parsing/creation/duplication logic and adding logging for skipped or duplicate cases; keep message formatting behavior intact.

### Testing

- Added unit test `TelegramCashTransactionExternalIdGeneratorTest` which verifies determinism, uniqueness, length limit, and bot-id fallback, and it passed.
- Added integration test `CreateTelegramCashTransactionActionTest` which verifies duplicate suppression and distinct message handling, and it passed.
- Ran the project automated test suite including the new tests and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0181bbc24883238c6544293fa1facb)