### PR TITLE
docs(architecture): document CashFacade contract and Telegram dedup flow

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 > **Живой документ.** Обновляется после каждого нового модуля или изменения публичного контракта.
 > Читается: Claude Code (через CLAUDE.md) и Claude.ai Projects (через Knowledge).
-> Версия: 1.45 / 2026-05-10
+> Версия: 1.46 / 2026-05-11
 
 ---
 
@@ -266,6 +266,63 @@ updatePLRegisterForDocument(string $documentId): void
 ```
 
 > **Остальные Facade** добавлять сюда по мере реализации модулей.
+
+### `CashFacade` (`src/Cash/Facade/CashFacade.php`)
+```php
+// Создать ДДС-транзакцию из внешнего модуля (идемпотентно для внешних источников)
+createTransaction(CreateCashTransactionCommand $command): CreateCashTransactionResult
+```
+
+**Назначение:** `CashFacade` — единственный публичный контракт Cash-модуля для создания ДДС-транзакций из других модулей.
+
+Другие модули не должны:
+- создавать `CashTransaction` напрямую;
+- вызывать `CashTransactionService` напрямую;
+- делать `persist/flush` `CashTransaction` самостоятельно.
+
+**DTO команды:** `CreateCashTransactionCommand` (`src/Cash/Application/DTO/CreateCashTransactionCommand.php`)
+- `companyId`
+- `moneyAccountId`
+- `direction`
+- `amount`
+- `currency`
+- `occurredAt`
+- `description` (`nullable`)
+- `counterpartyId` (`nullable`)
+- `cashflowCategoryId` (`nullable`)
+- `projectDirectionId` (`nullable`)
+- `importSource` (`nullable`)
+- `externalId` (`nullable`)
+- `dedupeHash` (`nullable`)
+- `rawData` (`nullable`)
+
+**DTO результата:** `CreateCashTransactionResult` (`src/Cash/Application/DTO/CreateCashTransactionResult.php`)
+- `transactionId: string`
+- `created: bool`
+- `duplicate: bool`
+
+**Side effects:** создание через `CashFacade::createTransaction()` сохраняет все side effects `CashTransactionService::add()`:
+- VAT logic;
+- `PaymentPlanMatcher`;
+- `ApplyAutoRulesForTransaction`;
+- `DailyBalanceRecalculator`;
+- `SnapshotCacheInvalidator`.
+
+**Идемпотентность внешних источников:**
+- Для внешних источников нужно заполнять `importSource` и `externalId`.
+- Идемпотентность обеспечивается unique constraint `uniq_cashflow_import(company_id, import_source, external_id)`.
+- Если запись с тем же `companyId + importSource + externalId` уже существует, `CashFacade` возвращает:
+  - `created=false`
+  - `duplicate=true`
+
+Важно: одинаковые `amount`/`description`/`occurredAt` **не** являются жёстким ключом дедубликации. Две реальные одинаковые операции разрешены, если `externalId` разный.
+
+**Race-safe поведение:**
+- При `UniqueConstraintViolationException` `CashFacade` делает DBAL lookup по:
+  - `company_id`
+  - `import_source`
+  - `external_id`
+- Если запись найдена, возвращается duplicate-result (без HTTP 500).
 
 ### `MarketplaceAdsFacade` (`src/MarketplaceAds/Facade/MarketplaceAdsFacade.php`)
 ```php
@@ -962,6 +1019,32 @@ buildQueryBuilder(
 
 ---
 
+## Telegram → Cash: контракт интеграции
+
+Telegram создаёт ДДС-транзакции только через цепочку:
+
+`TelegramWebhookController` → `CreateTelegramCashTransactionAction` → `CashFacade::createTransaction()`.
+
+**Telegram externalId:**
+- `telegram:{sha256(botId|chatId|messageId)}`
+- Технически: `externalId = 'telegram:' . hash('sha256', botId . '|' . chatId . '|' . messageId)`
+
+**Telegram rawData:**
+- `source = telegram`
+- `update_id`
+- `message_id`
+- `chat_id`
+- `from_id`
+- `message_date`
+- `text`
+- `bot_id_fallback`
+
+Если `chatId`/`messageId` отсутствуют:
+- `CashTransaction` не создаётся;
+- webhook отвечает `ok`;
+- пишется warning.
+
+
 ## Enum — актуальные значения
 
 > Используй **только** эти значения. Не придумывай новые без обновления файла.
@@ -1478,6 +1561,7 @@ $apiKey = $this->encryption->decrypt($connection->getApiKey());
 
 | Версия | Дата | Что изменилось |
 |---|---|---|
+| 1.46 | 2026-05-11 | Cash/Telegram: добавлен публичный контракт `CashFacade::createTransaction()` и зафиксировано идемпотентное создание Telegram-транзакций через `importSource`/`externalId` |
 | 1.45 | 2026-05-10 | `MarketplaceFacade::getActiveOzonSellerConnections()` — безопасный публичный контракт без секретов |
 | 1.44 | 2026-04-28 | `MarketplaceFacade::resolveListingsToProducts()` — batch резолв listingId→productId для Inventory |
 | 1.43 | 2026-04-27 | revert: откат soft-mode в `CloseMonthStageAction`, preflight снова строгий |


### PR DESCRIPTION
### Motivation
- Обновить «живоe» руководство архитектуры, зафиксировав новый публичный контракт Cash-модуля и правило дедубликации Telegram→Cash после завершения реализации технической части. 
- Зафиксировать ожидания для внешних модулей о том, как создавать ДДС-транзакции (единственная публичная точка входа) и как обеспечивается идемпотентность для импортов. 
- Обеспечить явную документацию для команды и Projects-чатов, чтобы дальнейший код использовал только описанный интерфейс и поведение при race-условиях.

### Description
- Обновлён `ARCHITECTURE.md` версия до `1.46 / 2026-05-11` и в раздел публичных Facade добавлен `CashFacade` с методом `createTransaction(CreateCashTransactionCommand $command): CreateCashTransactionResult` и подробным описанием полей команды и результата. 
- Задокументировано назначение `CashFacade` как единственной публичной точки входа для создания ДДС-транзакций и запрет на прямое создание `CashTransaction`, вызов `CashTransactionService` или самостоятельный `persist/flush`. 
- Описаны side effects, сохраняемые при создании (`VAT logic`, `PaymentPlanMatcher`, `ApplyAutoRulesForTransaction`, `DailyBalanceRecalculator`, `SnapshotCacheInvalidator`) и поведение по идемпотентности через `importSource + externalId` (ссылкой на `uniq_cashflow_import(company_id, import_source, external_id)`). 
- Добавлен раздел `Telegram → Cash` с описанием потока `TelegramWebhookController → CreateTelegramCashTransactionAction → CashFacade::createTransaction()`, формулой стабильного `externalId = telegram:{sha256(botId|chatId|messageId)}`, перечислением полей `rawData` и правилом: при отсутствии `chatId`/`messageId` транзакция не создаётся, пишется warning и webhook возвращает `ok`. 

### Testing
- Прочитал исходные документы перед правкой с помощью `cat CLAUDE.md`, `cat PATTERNS.md`, `cat ARCHITECTURE.md`, и проверил наличие файлов с `rg --files`; все команды выполнились успешно. 
- Просмотрел и зафиксировал diff изменения через `git diff -- ARCHITECTURE.md` и убедился в добавленных блоках; проверка выполнена успешно. 
- Зафиксировал изменения в репозитории (документация только) и создал PR-манифест через `make_pr`; операции прошли успешно. 
- В PR зафиксировано, что не вносились изменения в код, тесты или схему БД.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0186f67eb48323b60d678fb255fcf0)