### PR TITLE
Treat soft-deleted imported cash transactions as duplicates by adding 'findAny' lookups

### DIFF
--- a/site/src/Cash/Facade/CashFacade.php
+++ b/site/src/Cash/Facade/CashFacade.php
@@ -50,7 +50,7 @@ final readonly class CashFacade
                 throw $e;
             }
 
-            $existingId = $this->cashTransactionRepository->findIdByCompanyImportSourceExternalIdDbal(
+            $existingId = $this->cashTransactionRepository->findAnyIdByCompanyImportSourceExternalIdDbal(
                 $command->companyId,
                 $command->importSource,
                 $command->externalId,
@@ -70,7 +70,7 @@ final readonly class CashFacade
             return null;
         }
 
-        return $this->cashTransactionRepository->findOneByCompanyImportSourceExternalId(
+        return $this->cashTransactionRepository->findAnyByCompanyImportSourceExternalId(
             $command->companyId,
             $command->importSource,
             $command->externalId,

--- a/site/src/Cash/Repository/Transaction/CashTransactionRepository.php
+++ b/site/src/Cash/Repository/Transaction/CashTransactionRepository.php
@@ -95,12 +95,43 @@ class CashTransactionRepository extends ServiceEntityRepository
         return $this->findOneByCompanyImportSourceExternalId($companyId, $source, $externalId);
     }
 
+    public function findAnyByCompanyImportSourceExternalId(string $companyId, string $importSource, string $externalId): ?CashTransaction
+    {
+        return $this->createQueryBuilder('t')
+            ->andWhere('IDENTITY(t.company) = :companyId')
+            ->andWhere('t.importSource = :importSource')
+            ->andWhere('t.externalId = :externalId')
+            ->setMaxResults(1)
+            ->setParameter('companyId', $companyId)
+            ->setParameter('importSource', $importSource)
+            ->setParameter('externalId', $externalId)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
 
 
     public function findIdByCompanyImportSourceExternalIdDbal(string $companyId, string $importSource, string $externalId): ?string
     {
         $id = $this->getEntityManager()->getConnection()->fetchOne(
             'SELECT id FROM cash_transaction WHERE company_id = :companyId AND import_source = :importSource AND external_id = :externalId AND deleted_at IS NULL LIMIT 1',
+            [
+                'companyId' => $companyId,
+                'importSource' => $importSource,
+                'externalId' => $externalId,
+            ],
+        );
+
+        if (false === $id || null === $id) {
+            return null;
+        }
+
+        return (string) $id;
+    }
+
+    public function findAnyIdByCompanyImportSourceExternalIdDbal(string $companyId, string $importSource, string $externalId): ?string
+    {
+        $id = $this->getEntityManager()->getConnection()->fetchOne(
+            'SELECT id FROM cash_transaction WHERE company_id = :companyId AND import_source = :importSource AND external_id = :externalId LIMIT 1',
             [
                 'companyId' => $companyId,
                 'importSource' => $importSource,

--- a/site/tests/Integration/CashFacadeTest.php
+++ b/site/tests/Integration/CashFacadeTest.php
@@ -250,4 +250,60 @@ final class CashFacadeTest extends IntegrationTestCase
         self::assertNotSame($first->transactionId, $second->transactionId);
     }
 
+    public function testCreateTransactionTreatsSoftDeletedImportAsDuplicate(): void
+    {
+        $user = UserBuilder::aUser()->withEmail('facade6@example.com')->withPasswordHash('pass')->build();
+        $company = CompanyBuilder::aCompany()->withOwner($user)->withName('Facade Company 6')->build();
+
+        $account = new MoneyAccount(Uuid::uuid4()->toString(), $company, MoneyAccountType::BANK, 'Main', 'USD');
+        $account->setOpeningBalance('0');
+        $account->setOpeningBalanceDate(new \DateTimeImmutable('2024-01-01'));
+
+        $this->em->persist($user);
+        $this->em->persist($company);
+        $this->em->persist($account);
+        $this->em->flush();
+
+        $first = $this->cashFacade->createTransaction(new CreateCashTransactionCommand(
+            companyId: $company->getId(),
+            moneyAccountId: $account->getId(),
+            direction: CashDirection::OUTFLOW,
+            amount: '100.00',
+            currency: 'USD',
+            occurredAt: new \DateTimeImmutable('2024-03-12'),
+            description: 'Telegram tx initial',
+            importSource: 'telegram',
+            externalId: 'telegram:test',
+        ));
+
+        $stored = $this->cashTransactionRepository->find($first->transactionId);
+        self::assertNotNull($stored);
+        $stored->markDeleted('test-user', 'manual soft delete');
+        $this->em->flush();
+
+        $second = $this->cashFacade->createTransaction(new CreateCashTransactionCommand(
+            companyId: $company->getId(),
+            moneyAccountId: $account->getId(),
+            direction: CashDirection::OUTFLOW,
+            amount: '100.00',
+            currency: 'USD',
+            occurredAt: new \DateTimeImmutable('2024-03-12'),
+            description: 'Telegram tx repeated webhook',
+            importSource: 'telegram',
+            externalId: 'telegram:test',
+        ));
+
+        self::assertFalse($second->created);
+        self::assertTrue($second->duplicate);
+        self::assertSame($first->transactionId, $second->transactionId);
+
+        $rows = $this->cashTransactionRepository->findBy([
+            'company' => $company,
+            'importSource' => 'telegram',
+            'externalId' => 'telegram:test',
+        ]);
+
+        self::assertCount(1, $rows);
+    }
+
 }

--- a/site/tests/Service/Import/CashTransactionRepositoryTest.php
+++ b/site/tests/Service/Import/CashTransactionRepositoryTest.php
@@ -62,4 +62,31 @@ class CashTransactionRepositoryTest extends ClientBank1CImportServiceTestCase
         self::assertSame($transaction->getId(), $foundId);
     }
 
+    public function testFindAnyIdByCompanyImportSourceExternalIdDbalReturnsSoftDeletedTransactionId(): void
+    {
+        $transaction = new CashTransaction(
+            Uuid::uuid4()->toString(),
+            $this->company,
+            $this->account,
+            CashDirection::OUTFLOW,
+            '200.00',
+            'RUB',
+            new \DateTimeImmutable('2024-01-12')
+        );
+        $transaction->setImportSource('telegram');
+        $transaction->setExternalId('ext-dbal-soft-deleted');
+        $transaction->markDeleted('test-user', 'soft delete for idempotency');
+
+        $this->em->persist($transaction);
+        $this->em->flush();
+
+        $foundId = $this->transactionRepository->findAnyIdByCompanyImportSourceExternalIdDbal(
+            $this->company->getId(),
+            'telegram',
+            'ext-dbal-soft-deleted',
+        );
+
+        self::assertSame($transaction->getId(), $foundId);
+    }
+
 }


### PR DESCRIPTION
### Motivation

- Ensure idempotency for imports by treating soft-deleted imported cash transactions as duplicates so repeated imports don't create new rows.
- Provide repository lookups that include soft-deleted rows for use during duplicate detection and error handling.

### Description

- Added `findAnyByCompanyImportSourceExternalId` and `findAnyIdByCompanyImportSourceExternalIdDbal` to `CashTransactionRepository` which omit the `deleted_at IS NULL` filter so soft-deleted records are returned.
- Updated `CashFacade` to use the new `findAny*` repository methods in `findExistingByImport` and in the `UniqueConstraintViolationException` handler so soft-deleted imports are treated as existing duplicates.
- Kept original active-only lookup methods intact (`findOneByCompanyImportSourceExternalId` and `findIdByCompanyImportSourceExternalIdDbal`) for other code paths.

### Testing

- Added integration test `CashFacadeTest::testCreateTransactionTreatsSoftDeletedImportAsDuplicate` which asserts a soft-deleted import is detected as a duplicate and it passed.
- Added repository test `CashTransactionRepositoryTest::testFindAnyIdByCompanyImportSourceExternalIdDbalReturnsSoftDeletedTransactionId` which verifies the DBAL lookup returns soft-deleted IDs and it passed.
- Ran the affected test classes and the updated tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a018a15c7d48323852432643640a0cc)