### PR TITLE
Add reserved quantity, source identifiers and mapping status to StockSnapshot with migration and tests

### DIFF
--- a/site/migrations/Version20260511120000.php
+++ b/site/migrations/Version20260511120000.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260511120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add reserved quantity and enum-based mapping status to inventory stock snapshots';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE inventory_stock_snapshots ADD reserved_quantity NUMERIC(14, 3) DEFAULT 0 NOT NULL");
+        $this->addSql("ALTER TABLE inventory_stock_snapshots ADD source_sku VARCHAR(100) DEFAULT NULL");
+        $this->addSql("ALTER TABLE inventory_stock_snapshots ADD source_offer_id VARCHAR(255) DEFAULT NULL");
+        $this->addSql("ALTER TABLE inventory_stock_snapshots ADD fulfillment_type VARCHAR(50) DEFAULT NULL");
+        $this->addSql("ALTER TABLE inventory_stock_snapshots ADD mapping_status VARCHAR(50) DEFAULT 'unmapped' NOT NULL");
+        $this->addSql('DROP INDEX IF EXISTS uniq_inventory_stock_snapshot_day_item');
+        $this->addSql(<<<'SQL'
+            CREATE UNIQUE INDEX uniq_inventory_stock_snapshot_day_item
+            ON inventory_stock_snapshots (
+                company_id,
+                snapshot_date,
+                source,
+                source_sku,
+                fulfillment_type,
+                location_id,
+                status
+            )
+            NULLS NOT DISTINCT
+        SQL);
+
+        $this->addSql("CREATE INDEX idx_inventory_stock_company_source_snapshot_at ON inventory_stock_snapshots (company_id, source, snapshot_at)");
+        $this->addSql("CREATE INDEX idx_inventory_stock_company_source_sku ON inventory_stock_snapshots (company_id, source_sku)");
+        $this->addSql("CREATE INDEX idx_inventory_stock_company_mapping_status ON inventory_stock_snapshots (company_id, mapping_status)");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS idx_inventory_stock_company_mapping_status');
+        $this->addSql('DROP INDEX IF EXISTS idx_inventory_stock_company_source_sku');
+        $this->addSql('DROP INDEX IF EXISTS idx_inventory_stock_company_source_snapshot_at');
+        $this->addSql('DROP INDEX IF EXISTS uniq_inventory_stock_snapshot_day_item');
+        $this->addSql(<<<'SQL'
+            CREATE UNIQUE INDEX uniq_inventory_stock_snapshot_day_item
+            ON inventory_stock_snapshots (
+                company_id,
+                snapshot_date,
+                listing_id,
+                product_id,
+                location_id,
+                status
+            )
+            NULLS NOT DISTINCT
+        SQL);
+
+        $this->addSql('ALTER TABLE inventory_stock_snapshots DROP mapping_status');
+        $this->addSql('ALTER TABLE inventory_stock_snapshots DROP fulfillment_type');
+        $this->addSql('ALTER TABLE inventory_stock_snapshots DROP source_offer_id');
+        $this->addSql('ALTER TABLE inventory_stock_snapshots DROP source_sku');
+        $this->addSql('ALTER TABLE inventory_stock_snapshots DROP reserved_quantity');
+    }
+}

--- a/site/src/Inventory/Entity/StockSnapshot.php
+++ b/site/src/Inventory/Entity/StockSnapshot.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Inventory\Entity;
 
 use App\Inventory\Enum\StockStatus;
+use App\Inventory\Enum\StockSnapshotMappingStatus;
 use App\Inventory\Repository\StockSnapshotRepository;
 use App\Marketplace\Enum\MarketplaceType;
 use Doctrine\DBAL\Types\Types;
@@ -14,12 +15,15 @@ use Webmozart\Assert\Assert;
 
 #[ORM\Entity(repositoryClass: StockSnapshotRepository::class)]
 #[ORM\Table(name: 'inventory_stock_snapshots')]
-#[ORM\UniqueConstraint(name: 'uniq_inventory_stock_snapshot_day_item', columns: ['company_id', 'snapshot_date', 'listing_id', 'product_id', 'location_id', 'status'])]
+#[ORM\UniqueConstraint(name: 'uniq_inventory_stock_snapshot_day_item', columns: ['company_id', 'snapshot_date', 'source', 'source_sku', 'fulfillment_type', 'location_id', 'status'])]
 #[ORM\Index(columns: ['company_id', 'snapshot_date'], name: 'idx_inventory_stock_company_date')]
+#[ORM\Index(columns: ['company_id', 'source', 'snapshot_at'], name: 'idx_inventory_stock_company_source_snapshot_at')]
 #[ORM\Index(columns: ['company_id', 'product_id', 'snapshot_date'], name: 'idx_inventory_stock_company_product_date')]
 #[ORM\Index(columns: ['company_id', 'listing_id', 'snapshot_date'], name: 'idx_inventory_stock_company_listing_date')]
 #[ORM\Index(columns: ['company_id', 'location_id', 'snapshot_date'], name: 'idx_inventory_stock_company_location_date')]
 #[ORM\Index(columns: ['snapshot_session_id'], name: 'idx_inventory_stock_session')]
+#[ORM\Index(columns: ['company_id', 'source_sku'], name: 'idx_inventory_stock_company_source_sku')]
+#[ORM\Index(columns: ['company_id', 'mapping_status'], name: 'idx_inventory_stock_company_mapping_status')]
 class StockSnapshot
 {
     #[ORM\Id]
@@ -53,8 +57,23 @@ class StockSnapshot
     #[ORM\Column(type: Types::DECIMAL, precision: 14, scale: 3)]
     private string $quantity;
 
+    #[ORM\Column(type: Types::DECIMAL, precision: 14, scale: 3, options: ['default' => '0'])]
+    private string $reservedQuantity = '0';
+
     #[ORM\Column(type: Types::STRING, length: 50, enumType: MarketplaceType::class)]
     private MarketplaceType $source;
+
+    #[ORM\Column(type: Types::STRING, length: 100, nullable: true)]
+    private ?string $sourceSku;
+
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
+    private ?string $sourceOfferId;
+
+    #[ORM\Column(type: Types::STRING, length: 50, nullable: true)]
+    private ?string $fulfillmentType;
+
+    #[ORM\Column(type: Types::STRING, length: 50, enumType: StockSnapshotMappingStatus::class, options: ['default' => StockSnapshotMappingStatus::Unmapped->value])]
+    private StockSnapshotMappingStatus $mappingStatus;
 
     /**
      * Указывает на InventoryRawSnapshot, из которого получены ТЕКУЩИЕ значения
@@ -82,10 +101,15 @@ class StockSnapshot
         string $locationId,
         StockStatus $status,
         string $quantity,
+        string $reservedQuantity,
         MarketplaceType $source,
         string $rawSnapshotId,
         ?string $listingId = null,
         ?string $productId = null,
+        ?string $sourceSku = null,
+        ?string $sourceOfferId = null,
+        ?string $fulfillmentType = null,
+        StockSnapshotMappingStatus $mappingStatus = StockSnapshotMappingStatus::Unmapped,
     ) {
         Assert::uuid($companyId);
         Assert::uuid($snapshotSessionId);
@@ -95,6 +119,11 @@ class StockSnapshot
         Assert::true(
             bccomp($quantity, '0', 3) >= 0,
             sprintf('Quantity must be non-negative, got: %s', $quantity),
+        );
+        Assert::numeric($reservedQuantity);
+        Assert::true(
+            bccomp($reservedQuantity, '0', 3) >= 0,
+            sprintf('Reserved quantity must be non-negative, got: %s', $reservedQuantity),
         );
 
         if ($listingId !== null) {
@@ -119,7 +148,12 @@ class StockSnapshot
         $this->locationId = $locationId;
         $this->status = $status;
         $this->quantity = $quantity;
+        $this->reservedQuantity = $reservedQuantity;
         $this->source = $source;
+        $this->sourceSku = $sourceSku;
+        $this->sourceOfferId = $sourceOfferId;
+        $this->fulfillmentType = $fulfillmentType;
+        $this->mappingStatus = $mappingStatus;
         $this->rawSnapshotId = $rawSnapshotId;
         $this->createdAt = new \DateTimeImmutable();
     }
@@ -174,9 +208,34 @@ class StockSnapshot
         return $this->quantity;
     }
 
+    public function getReservedQuantity(): string
+    {
+        return $this->reservedQuantity;
+    }
+
     public function getSource(): MarketplaceType
     {
         return $this->source;
+    }
+
+    public function getSourceSku(): ?string
+    {
+        return $this->sourceSku;
+    }
+
+    public function getSourceOfferId(): ?string
+    {
+        return $this->sourceOfferId;
+    }
+
+    public function getFulfillmentType(): ?string
+    {
+        return $this->fulfillmentType;
+    }
+
+    public function getMappingStatus(): StockSnapshotMappingStatus
+    {
+        return $this->mappingStatus;
     }
 
     public function getRawSnapshotId(): string

--- a/site/src/Inventory/Enum/StockSnapshotMappingStatus.php
+++ b/site/src/Inventory/Enum/StockSnapshotMappingStatus.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Inventory\Enum;
+
+enum StockSnapshotMappingStatus: string
+{
+    case Mapped = 'mapped';
+    case Unmapped = 'unmapped';
+    case Ambiguous = 'ambiguous';
+}
+

--- a/site/tests/Builders/Inventory/StockSnapshotBuilder.php
+++ b/site/tests/Builders/Inventory/StockSnapshotBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Builders\Inventory;
 
 use App\Inventory\Entity\StockSnapshot;
+use App\Inventory\Enum\StockSnapshotMappingStatus;
 use App\Inventory\Enum\StockStatus;
 use App\Marketplace\Enum\MarketplaceType;
 
@@ -26,7 +27,12 @@ final class StockSnapshotBuilder
     private string $locationId = self::DEFAULT_LOCATION_ID;
     private StockStatus $status = StockStatus::Available;
     private string $quantity = '12.345';
+    private string $reservedQuantity = '0.000';
     private MarketplaceType $source = MarketplaceType::WILDBERRIES;
+    private ?string $sourceSku = null;
+    private ?string $sourceOfferId = null;
+    private ?string $fulfillmentType = null;
+    private StockSnapshotMappingStatus $mappingStatus = StockSnapshotMappingStatus::Unmapped;
     private string $rawSnapshotId = self::DEFAULT_RAW_SNAPSHOT_ID;
 
     private function __construct()
@@ -120,6 +126,46 @@ final class StockSnapshotBuilder
         return $clone;
     }
 
+    public function withReservedQuantity(string $reservedQuantity): self
+    {
+        $clone = clone $this;
+        $clone->reservedQuantity = $reservedQuantity;
+
+        return $clone;
+    }
+
+    public function withSourceSku(?string $sourceSku): self
+    {
+        $clone = clone $this;
+        $clone->sourceSku = $sourceSku;
+
+        return $clone;
+    }
+
+    public function withSourceOfferId(?string $sourceOfferId): self
+    {
+        $clone = clone $this;
+        $clone->sourceOfferId = $sourceOfferId;
+
+        return $clone;
+    }
+
+    public function withFulfillmentType(?string $fulfillmentType): self
+    {
+        $clone = clone $this;
+        $clone->fulfillmentType = $fulfillmentType;
+
+        return $clone;
+    }
+
+    public function withMappingStatus(StockSnapshotMappingStatus $mappingStatus): self
+    {
+        $clone = clone $this;
+        $clone->mappingStatus = $mappingStatus;
+
+        return $clone;
+    }
+
     public function withRawSnapshotId(string $rawSnapshotId): self
     {
         $clone = clone $this;
@@ -138,10 +184,15 @@ final class StockSnapshotBuilder
             locationId: $this->locationId,
             status: $this->status,
             quantity: $this->quantity,
+            reservedQuantity: $this->reservedQuantity,
             source: $this->source,
             rawSnapshotId: $this->rawSnapshotId,
             listingId: $this->listingId,
             productId: $this->productId,
+            sourceSku: $this->sourceSku,
+            sourceOfferId: $this->sourceOfferId,
+            fulfillmentType: $this->fulfillmentType,
+            mappingStatus: $this->mappingStatus,
         );
     }
 }

--- a/site/tests/Integration/Inventory/InventoryPersistenceTest.php
+++ b/site/tests/Integration/Inventory/InventoryPersistenceTest.php
@@ -8,6 +8,8 @@ use App\Inventory\Entity\InventoryRawSnapshot;
 use App\Inventory\Entity\InventorySnapshotSession;
 use App\Inventory\Entity\Location;
 use App\Inventory\Entity\StockSnapshot;
+use App\Inventory\Enum\StockSnapshotMappingStatus;
+use App\Marketplace\Enum\MarketplaceType;
 use App\Tests\Builders\Inventory\InventoryRawSnapshotBuilder;
 use App\Tests\Builders\Inventory\InventorySnapshotSessionBuilder;
 use App\Tests\Builders\Inventory\LocationBuilder;
@@ -43,6 +45,11 @@ final class InventoryPersistenceTest extends IntegrationTestCase
             ->withListingId(null)
             ->withProductId(null)
             ->withQuantity('42.125')
+            ->withReservedQuantity('5.000')
+            ->withSourceSku('SKU-42')
+            ->withSourceOfferId('OFFER-42')
+            ->withFulfillmentType('fbs')
+            ->withMappingStatus(StockSnapshotMappingStatus::Unmapped)
             ->build();
 
         $this->em->persist($location);
@@ -67,7 +74,65 @@ final class InventoryPersistenceTest extends IntegrationTestCase
         self::assertSame(['rows' => [['sku' => 'SKU-42', 'qty' => 12.345]]], $loadedRaw->getResponseBody());
 
         self::assertSame('42.125', $loadedStock->getQuantity());
+        self::assertSame('5.000', $loadedStock->getReservedQuantity());
+        self::assertSame('SKU-42', $loadedStock->getSourceSku());
+        self::assertSame('OFFER-42', $loadedStock->getSourceOfferId());
+        self::assertSame('fbs', $loadedStock->getFulfillmentType());
+        self::assertSame(StockSnapshotMappingStatus::Unmapped, $loadedStock->getMappingStatus());
         self::assertNull($loadedStock->getListingId());
         self::assertNull($loadedStock->getProductId());
+    }
+
+    public function testUnmappedSnapshotsWithDifferentSourceSkuDoNotConflictWithinSameDay(): void
+    {
+        $location = LocationBuilder::aLocation()
+            ->withCompanyId('11111111-1111-1111-1111-111111111111')
+            ->build();
+
+        $session = InventorySnapshotSessionBuilder::aSession()
+            ->withCompanyId('11111111-1111-1111-1111-111111111111')
+            ->build();
+
+        $rawSnapshot = InventoryRawSnapshotBuilder::aRawSnapshot()
+            ->withCompanyId('11111111-1111-1111-1111-111111111111')
+            ->withSnapshotSessionId($session->getId())
+            ->build();
+
+        $first = StockSnapshotBuilder::aStockSnapshot()
+            ->withCompanyId('11111111-1111-1111-1111-111111111111')
+            ->withSnapshotSessionId($session->getId())
+            ->withSnapshotDate(new \DateTimeImmutable('2026-05-11T00:00:00+00:00'))
+            ->withLocationId($location->getId())
+            ->withRawSnapshotId($rawSnapshot->getId())
+            ->withSource(MarketplaceType::OZON)
+            ->withListingId(null)
+            ->withProductId(null)
+            ->withFulfillmentType('fbo')
+            ->withSourceSku('SKU-111')
+            ->withMappingStatus(StockSnapshotMappingStatus::Unmapped)
+            ->build();
+
+        $second = StockSnapshotBuilder::aStockSnapshot()
+            ->withCompanyId('11111111-1111-1111-1111-111111111111')
+            ->withSnapshotSessionId($session->getId())
+            ->withSnapshotDate(new \DateTimeImmutable('2026-05-11T00:00:00+00:00'))
+            ->withLocationId($location->getId())
+            ->withRawSnapshotId($rawSnapshot->getId())
+            ->withSource(MarketplaceType::OZON)
+            ->withListingId(null)
+            ->withProductId(null)
+            ->withFulfillmentType('fbo')
+            ->withSourceSku('SKU-222')
+            ->withMappingStatus(StockSnapshotMappingStatus::Unmapped)
+            ->build();
+
+        $this->em->persist($location);
+        $this->em->persist($session);
+        $this->em->persist($rawSnapshot);
+        $this->em->persist($first);
+        $this->em->persist($second);
+        $this->em->flush();
+
+        self::assertNotSame($first->getId(), $second->getId());
     }
 }

--- a/site/tests/Integration/Inventory/InventorySchemaTest.php
+++ b/site/tests/Integration/Inventory/InventorySchemaTest.php
@@ -30,6 +30,7 @@ final class InventorySchemaTest extends IntegrationTestCase
 
         $stockUniqueIndex = (string) $conn->fetchOne("SELECT indexdef FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'uniq_inventory_stock_snapshot_day_item'");
         self::assertStringContainsString('NULLS NOT DISTINCT', $stockUniqueIndex);
+        self::assertStringContainsString('(company_id, snapshot_date, source, source_sku, fulfillment_type, location_id, status)', $stockUniqueIndex);
 
         $quantityDef = $conn->fetchAssociative(<<<'SQL'
             SELECT data_type, numeric_precision, numeric_scale
@@ -42,6 +43,26 @@ final class InventorySchemaTest extends IntegrationTestCase
         self::assertSame('numeric', $quantityDef['data_type']);
         self::assertSame(14, (int) $quantityDef['numeric_precision']);
         self::assertSame(3, (int) $quantityDef['numeric_scale']);
+        $reservedQuantityDef = $conn->fetchAssociative(<<<'SQL'
+            SELECT data_type, numeric_precision, numeric_scale
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'inventory_stock_snapshots'
+              AND column_name = 'reserved_quantity'
+        SQL);
+        self::assertIsArray($reservedQuantityDef);
+        self::assertSame('numeric', $reservedQuantityDef['data_type']);
+        self::assertSame(14, (int) $reservedQuantityDef['numeric_precision']);
+        self::assertSame(3, (int) $reservedQuantityDef['numeric_scale']);
+
+        $mappingStatusDefault = $conn->fetchOne("SELECT column_default FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'inventory_stock_snapshots' AND column_name = 'mapping_status'");
+        self::assertStringContainsString('unmapped', (string) $mappingStatusDefault);
+
+        $companySourceSkuIndex = (string) $conn->fetchOne("SELECT indexdef FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'idx_inventory_stock_company_source_sku'");
+        self::assertStringContainsString('(company_id, source_sku)', $companySourceSkuIndex);
+
+        $companyMappingStatusIndex = (string) $conn->fetchOne("SELECT indexdef FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'idx_inventory_stock_company_mapping_status'");
+        self::assertStringContainsString('(company_id, mapping_status)', $companyMappingStatusIndex);
 
         $requestParamsType = $conn->fetchOne("SELECT udt_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'inventory_raw_snapshots' AND column_name = 'request_params'");
         $responseBodyType = $conn->fetchOne("SELECT udt_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'inventory_raw_snapshots' AND column_name = 'response_body'");

--- a/site/tests/Unit/Inventory/Entity/StockSnapshotTest.php
+++ b/site/tests/Unit/Inventory/Entity/StockSnapshotTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Inventory\Entity;
 
 use App\Inventory\Entity\StockSnapshot;
+use App\Inventory\Enum\StockSnapshotMappingStatus;
 use App\Inventory\Enum\StockStatus;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Tests\Builders\Inventory\StockSnapshotBuilder;
@@ -36,7 +37,12 @@ final class StockSnapshotTest extends TestCase
             ->withLocationId(StockSnapshotBuilder::DEFAULT_LOCATION_ID)
             ->withStatus(StockStatus::InTransitToCustomer)
             ->withQuantity('9999.125')
+            ->withReservedQuantity('120.500')
             ->withSource(MarketplaceType::OZON)
+            ->withSourceSku('SKU-123')
+            ->withSourceOfferId('OFFER-123')
+            ->withFulfillmentType('fbo')
+            ->withMappingStatus(StockSnapshotMappingStatus::Mapped)
             ->withRawSnapshotId(StockSnapshotBuilder::DEFAULT_RAW_SNAPSHOT_ID)
             ->build();
 
@@ -49,7 +55,12 @@ final class StockSnapshotTest extends TestCase
         self::assertSame(StockSnapshotBuilder::DEFAULT_LOCATION_ID, $snapshot->getLocationId());
         self::assertSame(StockStatus::InTransitToCustomer, $snapshot->getStatus());
         self::assertSame('9999.125', $snapshot->getQuantity());
+        self::assertSame('120.500', $snapshot->getReservedQuantity());
         self::assertSame(MarketplaceType::OZON, $snapshot->getSource());
+        self::assertSame('SKU-123', $snapshot->getSourceSku());
+        self::assertSame('OFFER-123', $snapshot->getSourceOfferId());
+        self::assertSame('fbo', $snapshot->getFulfillmentType());
+        self::assertSame(StockSnapshotMappingStatus::Mapped, $snapshot->getMappingStatus());
         self::assertSame(StockSnapshotBuilder::DEFAULT_RAW_SNAPSHOT_ID, $snapshot->getRawSnapshotId());
     }
 
@@ -210,5 +221,15 @@ final class StockSnapshotTest extends TestCase
             ->build();
 
         self::assertSame('100.500', $snapshot->getQuantity());
+    }
+
+    public function testReservedQuantityCannotBeNegative(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/reserved quantity must be non-negative/i');
+
+        StockSnapshotBuilder::aStockSnapshot()
+            ->withReservedQuantity('-1.000')
+            ->build();
     }
 }


### PR DESCRIPTION
### Motivation

- Introduce `reserved_quantity` to capture reserved amounts separately from available `quantity` for more accurate inventory accounting.
- Track marketplace-level identifiers (`source_sku`, `source_offer_id`, `fulfillment_type`) on daily snapshots to support mapping and deduplication per source.
- Add an enum-based `mapping_status` to represent mapping state (`mapped`, `unmapped`, `ambiguous`) and update the unique constraint to use source-based columns to avoid false conflicts.

### Description

- Added a migration `site/migrations/Version20260511120000.php` that creates columns `reserved_quantity`, `source_sku`, `source_offer_id`, `fulfillment_type`, `mapping_status`, replaces the unique index `uniq_inventory_stock_snapshot_day_item` to include `(company_id, snapshot_date, source, source_sku, fulfillment_type, location_id, status)`, and adds indexes `idx_inventory_stock_company_source_snapshot_at`, `idx_inventory_stock_company_source_sku`, and `idx_inventory_stock_company_mapping_status`.
- Added enum `App\Inventory\Enum\StockSnapshotMappingStatus` with values `mapped`, `unmapped`, and `ambiguous`.
- Updated entity `StockSnapshot` to include new fields (`reservedQuantity`, `sourceSku`, `sourceOfferId`, `fulfillmentType`, `mappingStatus`), ORM mappings and indexes, constructor assertions for non-negative `reservedQuantity`, and new getters.
- Updated test builders and test cases: modified `StockSnapshotBuilder` to set new fields, extended `StockSnapshotTest`, `InventoryPersistenceTest`, and `InventorySchemaTest` to cover storage, schema defaults, indexes and the uniqueness behavior for unmapped snapshots.

### Testing

- Ran unit tests with `phpunit` including `App\Tests\Unit\Inventory\Entity\StockSnapshotTest` and related builder tests, and they passed.
- Ran integration tests `App\Tests\Integration\Inventory\InventoryPersistenceTest` and `InventorySchemaTest` that validate persistence, schema columns/defaults and indexes, and they passed.
- Executed the full test suite via `phpunit` and all automated tests related to inventory changes succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b4bccf9c8323b098c1ccbdc7e3d3)