### PR TITLE
Add Ozon product stocks normalizer and NormalizedStockRow DTO with unit tests

### DIFF
--- a/site/src/Inventory/Application/DTO/NormalizedStockRow.php
+++ b/site/src/Inventory/Application/DTO/NormalizedStockRow.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Inventory\Application\DTO;
+
+use App\Inventory\Enum\StockStatus;
+use App\Marketplace\Enum\MarketplaceType;
+
+final readonly class NormalizedStockRow
+{
+    public function __construct(
+        public MarketplaceType $source,
+        public string $sourceSku,
+        public ?string $sourceOfferId,
+        public ?string $fulfillmentType,
+        public StockStatus $status,
+        public string $quantity,
+        public string $reservedQuantity,
+        public string $rawSnapshotId,
+    ) {
+    }
+}

--- a/site/src/Inventory/Infrastructure/Normalizer/OzonProductStocksRawNormalizer.php
+++ b/site/src/Inventory/Infrastructure/Normalizer/OzonProductStocksRawNormalizer.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Inventory\Infrastructure\Normalizer;
+
+use App\Inventory\Application\DTO\NormalizedStockRow;
+use App\Inventory\Entity\InventoryRawSnapshot;
+use App\Inventory\Enum\StockStatus;
+use App\Marketplace\Enum\MarketplaceType;
+
+final class OzonProductStocksRawNormalizer
+{
+    /**
+     * @param array<string, mixed>|InventoryRawSnapshot $raw
+     *
+     * @return list<NormalizedStockRow>
+     */
+    public function normalize(array|InventoryRawSnapshot $raw): array
+    {
+        $payload = $raw instanceof InventoryRawSnapshot ? $raw->getResponseBody() : $raw;
+        $rawSnapshotId = $raw instanceof InventoryRawSnapshot ? $raw->getId() : '';
+
+        $items = $this->extractItems($payload);
+        if ($items === []) {
+            return [];
+        }
+
+        $rows = [];
+
+        foreach ($items as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+
+            $stocks = $item['stocks'] ?? null;
+            if (!is_array($stocks) || $stocks === []) {
+                continue;
+            }
+
+            $offerId = isset($item['offer_id']) ? (string) $item['offer_id'] : null;
+
+            foreach ($stocks as $stock) {
+                if (!is_array($stock) || !array_key_exists('sku', $stock)) {
+                    continue;
+                }
+
+                $sourceSku = trim((string) $stock['sku']);
+                if ($sourceSku === '') {
+                    continue;
+                }
+
+                $rows[] = new NormalizedStockRow(
+                    source: MarketplaceType::OZON,
+                    sourceSku: $sourceSku,
+                    sourceOfferId: $offerId,
+                    fulfillmentType: isset($stock['type']) ? (string) $stock['type'] : null,
+                    status: StockStatus::Available,
+                    quantity: $this->toDecimalString($stock['present'] ?? 0),
+                    reservedQuantity: $this->toDecimalString($stock['reserved'] ?? 0),
+                    rawSnapshotId: $rawSnapshotId,
+                );
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return list<mixed>
+     */
+    private function extractItems(array $payload): array
+    {
+        $topLevelItems = $payload['items'] ?? null;
+        if (is_array($topLevelItems)) {
+            return array_values($topLevelItems);
+        }
+
+        $result = $payload['result'] ?? null;
+        if (!is_array($result)) {
+            return [];
+        }
+
+        $resultItems = $result['items'] ?? null;
+        if (!is_array($resultItems)) {
+            return [];
+        }
+
+        return array_values($resultItems);
+    }
+
+    private function toDecimalString(mixed $value): string
+    {
+        if (is_int($value) || is_float($value) || is_string($value)) {
+            return number_format((float) $value, 3, '.', '');
+        }
+
+        return '0.000';
+    }
+}

--- a/site/tests/Unit/Inventory/Infrastructure/Normalizer/OzonProductStocksRawNormalizerTest.php
+++ b/site/tests/Unit/Inventory/Infrastructure/Normalizer/OzonProductStocksRawNormalizerTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Inventory\Infrastructure\Normalizer;
+
+use App\Inventory\Entity\InventoryRawSnapshot;
+use App\Inventory\Enum\StockStatus;
+use App\Inventory\Infrastructure\Normalizer\OzonProductStocksRawNormalizer;
+use App\Marketplace\Enum\MarketplaceType;
+use PHPUnit\Framework\TestCase;
+
+final class OzonProductStocksRawNormalizerTest extends TestCase
+{
+    private OzonProductStocksRawNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = new OzonProductStocksRawNormalizer();
+    }
+
+    public function testNormalizesSingleItemSingleStockFromTopLevelItems(): void
+    {
+        $rows = $this->normalizer->normalize([
+            'items' => [[
+                'offer_id' => 'offer-1',
+                'stocks' => [[
+                    'sku' => 12345,
+                    'type' => 'fbo',
+                    'present' => 7,
+                    'reserved' => 2,
+                ]],
+            ]],
+        ]);
+
+        self::assertCount(1, $rows);
+        self::assertSame(MarketplaceType::OZON, $rows[0]->source);
+        self::assertSame('12345', $rows[0]->sourceSku);
+        self::assertSame('offer-1', $rows[0]->sourceOfferId);
+        self::assertSame('fbo', $rows[0]->fulfillmentType);
+        self::assertSame(StockStatus::Available, $rows[0]->status);
+        self::assertSame('7.000', $rows[0]->quantity);
+        self::assertSame('2.000', $rows[0]->reservedQuantity);
+        self::assertSame('', $rows[0]->rawSnapshotId);
+    }
+
+    public function testNormalizesMultipleStocksFromResultItems(): void
+    {
+        $rows = $this->normalizer->normalize([
+            'result' => [
+                'items' => [[
+                    'offer_id' => 'offer-2',
+                    'stocks' => [
+                        ['sku' => 'sku-fbo', 'type' => 'fbo', 'present' => 10, 'reserved' => 1],
+                        ['sku' => 'sku-rfbs', 'type' => 'rfbs', 'present' => 4, 'reserved' => 0],
+                    ],
+                ]],
+            ],
+        ]);
+
+        self::assertCount(2, $rows);
+        self::assertSame('sku-fbo', $rows[0]->sourceSku);
+        self::assertSame('fbo', $rows[0]->fulfillmentType);
+        self::assertSame('sku-rfbs', $rows[1]->sourceSku);
+        self::assertSame('rfbs', $rows[1]->fulfillmentType);
+    }
+
+    public function testSkipsItemWithEmptyStocks(): void
+    {
+        $rows = $this->normalizer->normalize([
+            'items' => [[
+                'offer_id' => 'offer-3',
+                'stocks' => [],
+            ]],
+        ]);
+
+        self::assertSame([], $rows);
+    }
+
+    public function testSupportsReservedGreaterThanZero(): void
+    {
+        $rows = $this->normalizer->normalize([
+            'items' => [[
+                'offer_id' => 'offer-4',
+                'stocks' => [[
+                    'sku' => 'sku-1',
+                    'type' => 'fbo',
+                    'present' => 3,
+                    'reserved' => 9,
+                ]],
+            ]],
+        ]);
+
+        self::assertCount(1, $rows);
+        self::assertSame('3.000', $rows[0]->quantity);
+        self::assertSame('9.000', $rows[0]->reservedQuantity);
+    }
+
+    public function testMissingOptionalFieldsAreHandled(): void
+    {
+        $rows = $this->normalizer->normalize([
+            'items' => [[
+                'stocks' => [[
+                    'sku' => 'sku-2',
+                    'present' => '11',
+                ]],
+            ]],
+        ]);
+
+        self::assertCount(1, $rows);
+        self::assertNull($rows[0]->sourceOfferId);
+        self::assertNull($rows[0]->fulfillmentType);
+        self::assertSame('11.000', $rows[0]->quantity);
+        self::assertSame('0.000', $rows[0]->reservedQuantity);
+    }
+
+
+    public function testSkipsEmptySkuValuesAndKeepsValidSku(): void
+    {
+        $rows = $this->normalizer->normalize([
+            'items' => [[
+                'offer_id' => 'offer-6',
+                'stocks' => [
+                    ['sku' => null, 'type' => 'fbo', 'present' => 1, 'reserved' => 0],
+                    ['sku' => '', 'type' => 'fbo', 'present' => 2, 'reserved' => 0],
+                    ['sku' => '   ', 'type' => 'fbo', 'present' => 3, 'reserved' => 1],
+                    ['sku' => '220279573', 'type' => 'fbo', 'present' => 4, 'reserved' => 2],
+                ],
+            ]],
+        ]);
+
+        self::assertCount(1, $rows);
+        self::assertSame('220279573', $rows[0]->sourceSku);
+        self::assertSame('4.000', $rows[0]->quantity);
+        self::assertSame('2.000', $rows[0]->reservedQuantity);
+    }
+
+    public function testInvalidPayloadStructureReturnsEmptyList(): void
+    {
+        self::assertSame([], $this->normalizer->normalize(['result' => ['items' => 'invalid']]));
+        self::assertSame([], $this->normalizer->normalize(['items' => 'invalid']));
+        self::assertSame([], $this->normalizer->normalize(['foo' => 'bar']));
+    }
+
+    public function testCanNormalizeFromInventoryRawSnapshotEntity(): void
+    {
+        $snapshot = new InventoryRawSnapshot(
+            companyId: '11111111-1111-1111-1111-111111111111',
+            snapshotSessionId: '22222222-2222-2222-2222-222222222222',
+            source: MarketplaceType::OZON,
+            sourceEndpoint: '/v4/product/info/stocks',
+            requestParams: ['limit' => 100],
+            responseStatus: 200,
+            responseBody: [
+                'result' => [
+                    'items' => [[
+                        'offer_id' => 'offer-5',
+                        'stocks' => [[
+                            'sku' => 'sku-5',
+                            'type' => 'fbo',
+                            'present' => 1,
+                            'reserved' => 0,
+                        ]],
+                    ]],
+                ],
+            ],
+            fetchedAt: new \DateTimeImmutable(),
+            fetchDurationMs: 120,
+            correlationId: '33333333-3333-3333-3333-333333333333',
+            pageNumber: 1,
+        );
+
+        $rows = $this->normalizer->normalize($snapshot);
+
+        self::assertCount(1, $rows);
+        self::assertSame($snapshot->getId(), $rows[0]->rawSnapshotId);
+    }
+}


### PR DESCRIPTION
### Motivation

- Introduce a dedicated normalizer to convert raw Ozon product stocks payloads into a consistent internal representation for inventory processing.
- Support multiple raw payload shapes and the `InventoryRawSnapshot` entity while sanitizing and formatting quantity fields.

### Description

- Add `NormalizedStockRow` DTO to represent normalized stock rows with source metadata and decimal-formatted quantities.
- Implement `OzonProductStocksRawNormalizer` with `normalize`, `extractItems`, and `toDecimalString` methods that handle both top-level `items` and nested `result.items`, skip invalid entries, and set `MarketplaceType::OZON` and `StockStatus::Available`.
- Ensure SKU trimming and validation, optional `offer_id` and `type` handling, and quantity/reserved formatting to three decimal places using `number_format`.
- Add comprehensive unit tests in `OzonProductStocksRawNormalizerTest` covering different payload shapes, edge cases, and normalization from an `InventoryRawSnapshot` entity.

### Testing

- Ran the normalizer unit tests in `OzonProductStocksRawNormalizerTest` via PHPUnit, exercising top-level `items` and nested `result.items` scenarios, and all assertions passed.
- Tests verified handling of empty stocks, missing optional fields, reserved quantities greater than present, and skipping empty SKUs, and they all succeeded.
- The `InventoryRawSnapshot` integration test verifies `rawSnapshotId` propagation and passed.
- No failing automated tests were observed for the added test class.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b94e25b0832387c34dc7865e98be)