### PR TITLE
Normalize Ozon inventory snapshots and enqueue normalization job

### DIFF
--- a/site/config/packages/messenger.yaml
+++ b/site/config/packages/messenger.yaml
@@ -63,6 +63,7 @@ framework:
             'App\MarketplaceAnalytics\Message\RecalcSnapshotsMessage': async_pipeline
             'App\MarketplaceAds\Message\ProcessAdRawDocumentMessage': async_pipeline
             'App\MarketplaceAds\Message\DownloadOzonAdReportMessage': async_pipeline
+            'App\Inventory\Message\NormalizeInventorySnapshotMessage': async_pipeline
 
             # --- async_ads: Ozon Performance polling (may block up to 10 min per message) ---
             'App\MarketplaceAds\Message\LoadOzonAdStatisticsRangeMessage': async_ads

--- a/site/src/Inventory/Application/NormalizeInventorySnapshotAction.php
+++ b/site/src/Inventory/Application/NormalizeInventorySnapshotAction.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Inventory\Application;
+
+use App\Inventory\Entity\Location;
+use App\Inventory\Entity\StockSnapshot;
+use App\Inventory\Enum\LocationType;
+use App\Inventory\Enum\SnapshotSessionStatus;
+use App\Inventory\Enum\StockSnapshotMappingStatus;
+use App\Inventory\Enum\StockStatus;
+use App\Inventory\Infrastructure\Normalizer\OzonProductStocksRawNormalizer;
+use App\Inventory\Repository\InventoryRawSnapshotRepository;
+use App\Inventory\Repository\InventorySnapshotSessionRepository;
+use App\Inventory\Repository\LocationRepository;
+use App\Inventory\Repository\StockSnapshotRepository;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Facade\MarketplaceFacade;
+use App\Shared\Service\AppLogger;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class NormalizeInventorySnapshotAction
+{
+    public function __construct(
+        private InventorySnapshotSessionRepository $sessionRepository,
+        private InventoryRawSnapshotRepository $rawSnapshotRepository,
+        private OzonProductStocksRawNormalizer $ozonRawNormalizer,
+        private MarketplaceFacade $marketplaceFacade,
+        private LocationRepository $locationRepository,
+        private StockSnapshotRepository $stockSnapshotRepository,
+        private EntityManagerInterface $entityManager,
+        private AppLogger $logger,
+    ) {}
+
+    public function __invoke(string $companyId, string $snapshotSessionId, MarketplaceType $source): void
+    {
+        $session = $this->sessionRepository->findByIdAndCompany($snapshotSessionId, $companyId);
+        if ($session === null) {
+            $this->logger->warning('Normalization skipped: session not found.', compact('companyId', 'snapshotSessionId'));
+            return;
+        }
+
+        if ($session->getStatus() !== SnapshotSessionStatus::Completed) {
+            $this->logger->warning('Normalization skipped: session is not completed.', [
+                'companyId' => $companyId,
+                'snapshotSessionId' => $snapshotSessionId,
+                'status' => $session->getStatus()->value,
+            ]);
+            return;
+        }
+
+        if ($source !== MarketplaceType::OZON) {
+            $this->logger->warning('Normalization skipped: source is not supported.', ['source' => $source->value]);
+            return;
+        }
+
+        $rawSnapshots = $this->rawSnapshotRepository->findBySessionAndCompanyOrdered($snapshotSessionId, $companyId);
+        if ($rawSnapshots === []) {
+            return;
+        }
+
+        $rowsByRaw = [];
+        $sourceSkus = [];
+        foreach ($rawSnapshots as $rawSnapshot) {
+            $rows = $this->ozonRawNormalizer->normalize($rawSnapshot);
+            $rowsByRaw[$rawSnapshot->getId()] = $rows;
+            foreach ($rows as $row) {
+                $sourceSkus[] = $row->sourceSku;
+            }
+        }
+
+        if ($sourceSkus === []) {
+            foreach ($rawSnapshots as $rawSnapshot) {
+                $rawSnapshot->markAsProcessed();
+            }
+
+            $this->entityManager->flush();
+
+            return;
+        }
+
+        $listingsBySku = $this->marketplaceFacade->findListingsByMarketplaceSkus($companyId, MarketplaceType::OZON->value, array_values(array_unique($sourceSkus)));
+
+        $mappedListingIds = [];
+        $mappingBySku = [];
+        foreach (array_unique($sourceSkus) as $sku) {
+            $matches = $listingsBySku[$sku] ?? [];
+            if (count($matches) === 1) {
+                $mappingBySku[$sku] = ['status' => StockSnapshotMappingStatus::Mapped, 'listingId' => $matches[0]['id']];
+                $mappedListingIds[] = $matches[0]['id'];
+                continue;
+            }
+
+            $mappingBySku[$sku] = count($matches) > 1
+                ? ['status' => StockSnapshotMappingStatus::Ambiguous, 'listingId' => null]
+                : ['status' => StockSnapshotMappingStatus::Unmapped, 'listingId' => null];
+        }
+
+        $productsByListing = $this->marketplaceFacade->resolveListingsToProducts($companyId, array_values(array_unique($mappedListingIds)));
+
+        foreach ($rawSnapshots as $rawSnapshot) {
+            foreach ($rowsByRaw[$rawSnapshot->getId()] ?? [] as $row) {
+                $mapping = $mappingBySku[$row->sourceSku] ?? ['status' => StockSnapshotMappingStatus::Unmapped, 'listingId' => null];
+                $listingId = $mapping['listingId'];
+                $productId = $listingId !== null ? ($productsByListing[$listingId] ?? null) : null;
+                $location = $this->findOrCreateLocation($companyId, $source, $row->fulfillmentType);
+
+                $this->stockSnapshotRepository->upsertDaySnapshot(new StockSnapshot(
+                    companyId: $companyId,
+                    snapshotSessionId: $snapshotSessionId,
+                    snapshotDate: $rawSnapshot->getFetchedAt(),
+                    snapshotAt: $rawSnapshot->getFetchedAt(),
+                    locationId: $location->getId(),
+                    status: StockStatus::Available,
+                    quantity: $row->quantity,
+                    reservedQuantity: $row->reservedQuantity,
+                    source: MarketplaceType::OZON,
+                    rawSnapshotId: $rawSnapshot->getId(),
+                    listingId: $listingId,
+                    productId: $productId,
+                    sourceSku: $row->sourceSku,
+                    sourceOfferId: $row->sourceOfferId,
+                    fulfillmentType: $row->fulfillmentType,
+                    mappingStatus: $mapping['status'],
+                ));
+            }
+
+            $rawSnapshot->markAsProcessed();
+        }
+
+        $this->entityManager->flush();
+    }
+
+    private function findOrCreateLocation(string $companyId, MarketplaceType $source, ?string $fulfillmentType): Location
+    {
+        $externalId = $fulfillmentType ?? 'unknown';
+        $location = $this->locationRepository->findOneBy([
+            'companyId' => $companyId,
+            'externalSystem' => $source,
+            'externalId' => $externalId,
+        ]);
+
+        if ($location !== null) {
+            return $location;
+        }
+
+        $location = new Location(
+            companyId: $companyId,
+            type: LocationType::MpWarehouse,
+            externalSystem: $source,
+            code: strtoupper($externalId),
+            name: sprintf('Ozon %s', strtoupper($externalId)),
+            externalId: $externalId,
+        );
+        $this->entityManager->persist($location);
+
+        return $location;
+    }
+}

--- a/site/src/Inventory/Message/NormalizeInventorySnapshotMessage.php
+++ b/site/src/Inventory/Message/NormalizeInventorySnapshotMessage.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Inventory\Message;
+
+final readonly class NormalizeInventorySnapshotMessage
+{
+    public function __construct(
+        public string $companyId,
+        public string $snapshotSessionId,
+        public string $source,
+    ) {
+    }
+}

--- a/site/src/Inventory/MessageHandler/NormalizeInventorySnapshotHandler.php
+++ b/site/src/Inventory/MessageHandler/NormalizeInventorySnapshotHandler.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Inventory\MessageHandler;
+
+use App\Inventory\Application\NormalizeInventorySnapshotAction;
+use App\Inventory\Message\NormalizeInventorySnapshotMessage;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Shared\Service\AppLogger;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+final readonly class NormalizeInventorySnapshotHandler
+{
+    public function __construct(
+        private NormalizeInventorySnapshotAction $action,
+        private AppLogger $logger,
+    ) {}
+
+    public function __invoke(NormalizeInventorySnapshotMessage $message): void
+    {
+        $this->logger->info('Inventory normalization started.', [
+            'companyId' => $message->companyId,
+            'snapshotSessionId' => $message->snapshotSessionId,
+            'source' => $message->source,
+        ]);
+
+        $source = MarketplaceType::tryFrom($message->source);
+        if ($source === null) {
+            $this->logger->warning('Inventory normalization skipped due to unsupported source value.', [
+                'companyId' => $message->companyId,
+                'snapshotSessionId' => $message->snapshotSessionId,
+                'source' => $message->source,
+            ]);
+            return;
+        }
+
+        try {
+            ($this->action)($message->companyId, $message->snapshotSessionId, $source);
+            $this->logger->info('Inventory normalization finished.', [
+                'companyId' => $message->companyId,
+                'snapshotSessionId' => $message->snapshotSessionId,
+                'source' => $message->source,
+            ]);
+        } catch (\Throwable $e) {
+            $this->logger->error('Inventory normalization failed.', [
+                'companyId' => $message->companyId,
+                'snapshotSessionId' => $message->snapshotSessionId,
+                'source' => $message->source,
+                'exceptionClass' => $e::class,
+                'message' => $e->getMessage(),
+            ]);
+
+            throw $e;
+        }
+    }
+}

--- a/site/src/Inventory/MessageHandler/SyncOzonInventorySnapshotHandler.php
+++ b/site/src/Inventory/MessageHandler/SyncOzonInventorySnapshotHandler.php
@@ -9,6 +9,7 @@ use App\Inventory\Enum\SnapshotSessionStatus;
 use App\Inventory\Exception\OzonInventoryRateLimitException;
 use App\Inventory\Infrastructure\Api\Ozon\OzonInventoryClient;
 use App\Inventory\Message\SyncOzonInventorySnapshotMessage;
+use App\Inventory\Message\NormalizeInventorySnapshotMessage;
 use App\Inventory\Repository\InventorySnapshotSessionRepository;
 use App\Marketplace\Enum\MarketplaceConnectionType;
 use App\Marketplace\Enum\MarketplaceType;
@@ -16,6 +17,7 @@ use App\Marketplace\Facade\MarketplaceFacade;
 use App\Shared\Service\AppLogger;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 #[AsMessageHandler]
 final class SyncOzonInventorySnapshotHandler
@@ -28,6 +30,7 @@ final class SyncOzonInventorySnapshotHandler
         private readonly MarketplaceFacade $marketplaceFacade,
         private readonly OzonInventoryClient $ozonInventoryClient,
         private readonly EntityManagerInterface $entityManager,
+        private readonly MessageBusInterface $messageBus,
         private readonly AppLogger $logger,
     ) {
     }
@@ -122,6 +125,11 @@ final class SyncOzonInventorySnapshotHandler
 
             $session->markCompleted();
             $this->entityManager->flush();
+            $this->messageBus->dispatch(new NormalizeInventorySnapshotMessage(
+                companyId: $message->companyId,
+                snapshotSessionId: $session->getId(),
+                source: MarketplaceType::OZON->value,
+            ));
         } catch (OzonInventoryRateLimitException $e) {
             $this->logger->warning('Ozon inventory rate limit while fetching raw snapshots.', [
                 'snapshotSessionId' => $session->getId(),

--- a/site/src/Inventory/Repository/StockSnapshotRepository.php
+++ b/site/src/Inventory/Repository/StockSnapshotRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Inventory\Repository;
 
 use App\Inventory\Entity\StockSnapshot;
+use Doctrine\DBAL\Connection;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -13,5 +14,68 @@ final class StockSnapshotRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, StockSnapshot::class);
+    }
+
+    public function upsertDaySnapshot(StockSnapshot $snapshot): void
+    {
+        $this->getEntityManager()->getConnection()->executeStatement(
+            'INSERT INTO inventory_stock_snapshots (
+                id, company_id, snapshot_session_id, snapshot_date, snapshot_at,
+                listing_id, product_id, location_id, status, quantity, reserved_quantity,
+                source, source_sku, source_offer_id, fulfillment_type, mapping_status,
+                raw_snapshot_id, created_at
+             ) VALUES (
+                :id, :companyId, :snapshotSessionId, :snapshotDate, :snapshotAt,
+                :listingId, :productId, :locationId, :status, :quantity, :reservedQuantity,
+                :source, :sourceSku, :sourceOfferId, :fulfillmentType, :mappingStatus,
+                :rawSnapshotId, :createdAt
+             )
+             ON CONFLICT (
+                company_id,
+                snapshot_date,
+                source,
+                source_sku,
+                fulfillment_type,
+                location_id,
+                status
+             )
+             DO UPDATE SET
+                snapshot_session_id = EXCLUDED.snapshot_session_id,
+                snapshot_at = EXCLUDED.snapshot_at,
+                listing_id = EXCLUDED.listing_id,
+                product_id = EXCLUDED.product_id,
+                quantity = EXCLUDED.quantity,
+                reserved_quantity = EXCLUDED.reserved_quantity,
+                source_offer_id = EXCLUDED.source_offer_id,
+                mapping_status = EXCLUDED.mapping_status,
+                raw_snapshot_id = EXCLUDED.raw_snapshot_id',
+            [
+                'id' => $snapshot->getId(),
+                'companyId' => $snapshot->getCompanyId(),
+                'snapshotSessionId' => $snapshot->getSnapshotSessionId(),
+                'snapshotDate' => $snapshot->getSnapshotDate(),
+                'snapshotAt' => $snapshot->getSnapshotAt(),
+                'listingId' => $snapshot->getListingId(),
+                'productId' => $snapshot->getProductId(),
+                'locationId' => $snapshot->getLocationId(),
+                'status' => $snapshot->getStatus()->value,
+                'quantity' => $snapshot->getQuantity(),
+                'reservedQuantity' => $snapshot->getReservedQuantity(),
+                'source' => $snapshot->getSource()->value,
+                'sourceSku' => $snapshot->getSourceSku(),
+                'sourceOfferId' => $snapshot->getSourceOfferId(),
+                'fulfillmentType' => $snapshot->getFulfillmentType(),
+                'mappingStatus' => $snapshot->getMappingStatus()->value,
+                'rawSnapshotId' => $snapshot->getRawSnapshotId(),
+                'createdAt' => $snapshot->getCreatedAt(),
+            ],
+            [
+                'snapshotDate' => 'date_immutable',
+                'snapshotAt' => 'datetime_immutable',
+                'createdAt' => 'datetime_immutable',
+                'listingId' => Connection::PARAM_STR,
+                'productId' => Connection::PARAM_STR,
+            ],
+        );
     }
 }

--- a/site/tests/Integration/Inventory/Application/NormalizeInventorySnapshotActionTest.php
+++ b/site/tests/Integration/Inventory/Application/NormalizeInventorySnapshotActionTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Inventory\Application;
+
+use App\Catalog\Entity\Product;
+use App\Company\Entity\Company;
+use App\Inventory\Application\NormalizeInventorySnapshotAction;
+use App\Inventory\Entity\InventoryRawSnapshot;
+use App\Inventory\Entity\InventorySnapshotSession;
+use App\Inventory\Entity\StockSnapshot;
+use App\Inventory\Enum\SnapshotTriggerType;
+use App\Inventory\Enum\StockSnapshotMappingStatus;
+use App\Inventory\Enum\StockStatus;
+use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Builders\Inventory\InventoryRawSnapshotBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+
+final class NormalizeInventorySnapshotActionTest extends IntegrationTestCase
+{
+    public function testIdempotentAndMappingScenarios(): void
+    {
+        $company = $this->createCompany(901);
+        $session = new InventorySnapshotSession($company->getId(), MarketplaceType::OZON, SnapshotTriggerType::Manual);
+        $session->markCompleted();
+        $this->em->persist($session);
+
+        $this->em->persist($this->raw($company->getId(), $session->getId(), 'SKU-U', 10, 2, 'fbo', 'OF-U'));
+        $this->em->persist($this->raw($company->getId(), $session->getId(), 'SKU-M', 20, 3, 'fbs', 'OF-M'));
+        $this->em->persist($this->raw($company->getId(), $session->getId(), 'SKU-A', 30, 4, 'fbo', 'OF-A'));
+        $this->em->persist($this->raw($company->getId(), $session->getId(), 'SKU-O', 40, 5, 'fbs', 'OF-O'));
+
+        $product = new Product('30000000-0000-4000-8000-000000000901', $company);
+        $product->setSku('PRD-901')->setName('P901');
+        $this->em->persist($product);
+
+        $mapped = new MarketplaceListing('50000000-0000-4000-8000-000000000901', $company, $product, MarketplaceType::OZON);
+        $mapped->setMarketplaceSku('SKU-M')->setPrice('100.00');
+        $orphan = new MarketplaceListing('50000000-0000-4000-8000-000000000902', $company, null, MarketplaceType::OZON);
+        $orphan->setMarketplaceSku('SKU-O')->setPrice('100.00');
+        $amb1 = new MarketplaceListing('50000000-0000-4000-8000-000000000903', $company, null, MarketplaceType::OZON);
+        $amb1->setMarketplaceSku('SKU-A')->setSize('L')->setPrice('100.00');
+        $amb2 = new MarketplaceListing('50000000-0000-4000-8000-000000000904', $company, null, MarketplaceType::OZON);
+        $amb2->setMarketplaceSku('SKU-A')->setSize('XL')->setPrice('100.00');
+        $this->em->persist($mapped);$this->em->persist($orphan);$this->em->persist($amb1);$this->em->persist($amb2);
+        $this->em->flush();
+
+        $action = self::getContainer()->get(NormalizeInventorySnapshotAction::class);
+        $action($company->getId(), $session->getId(), MarketplaceType::OZON);
+        $action($company->getId(), $session->getId(), MarketplaceType::OZON);
+
+        $rows = $this->em->getRepository(StockSnapshot::class)->findBy(['companyId' => $company->getId()]);
+        self::assertCount(4, $rows);
+
+        $bySku = [];
+        foreach ($rows as $row) { $bySku[$row->getSourceSku()] = $row; }
+
+        self::assertSame(StockSnapshotMappingStatus::Unmapped, $bySku['SKU-U']->getMappingStatus());
+        self::assertNull($bySku['SKU-U']->getListingId());
+        self::assertNull($bySku['SKU-U']->getProductId());
+
+        self::assertSame(StockSnapshotMappingStatus::Mapped, $bySku['SKU-M']->getMappingStatus());
+        self::assertSame($mapped->getId(), $bySku['SKU-M']->getListingId());
+        self::assertSame($product->getId(), $bySku['SKU-M']->getProductId());
+
+        self::assertSame(StockSnapshotMappingStatus::Ambiguous, $bySku['SKU-A']->getMappingStatus());
+        self::assertNull($bySku['SKU-A']->getListingId());
+        self::assertNull($bySku['SKU-A']->getProductId());
+
+        self::assertSame(StockSnapshotMappingStatus::Mapped, $bySku['SKU-O']->getMappingStatus());
+        self::assertSame($orphan->getId(), $bySku['SKU-O']->getListingId());
+        self::assertNull($bySku['SKU-O']->getProductId());
+
+        self::assertSame(MarketplaceType::OZON, $bySku['SKU-M']->getSource());
+        self::assertSame(StockStatus::Available, $bySku['SKU-M']->getStatus());
+        self::assertSame('20.000', $bySku['SKU-M']->getQuantity());
+        self::assertSame('3.000', $bySku['SKU-M']->getReservedQuantity());
+        self::assertSame('OF-M', $bySku['SKU-M']->getSourceOfferId());
+        self::assertSame('fbs', $bySku['SKU-M']->getFulfillmentType());
+    }
+
+
+
+    public function testCompletedSessionWithEmptyStocksMarksRawProcessedAndCreatesNoSnapshots(): void
+    {
+        $company = $this->createCompany(902);
+        $session = new InventorySnapshotSession($company->getId(), MarketplaceType::OZON, SnapshotTriggerType::Manual);
+        $session->markCompleted();
+        $this->em->persist($session);
+
+        $raw = InventoryRawSnapshotBuilder::aRawSnapshot()
+            ->withCompanyId($company->getId())
+            ->withSnapshotSessionId($session->getId())
+            ->withSource(MarketplaceType::OZON)
+            ->withResponseBody(['result' => ['items' => [['offer_id' => 'OF-EMPTY', 'stocks' => []]]]])
+            ->build();
+        $this->em->persist($raw);
+        $this->em->flush();
+
+        $action = self::getContainer()->get(NormalizeInventorySnapshotAction::class);
+        $action($company->getId(), $session->getId(), MarketplaceType::OZON);
+
+        $this->em->refresh($raw);
+        self::assertTrue($raw->isProcessed());
+        self::assertSame(0, $this->em->getRepository(StockSnapshot::class)->count(['companyId' => $company->getId()]));
+    }
+    private function raw(string $companyId, string $sessionId, string $sku, int $present, int $reserved, string $type, string $offerId): InventoryRawSnapshot
+    {
+        return InventoryRawSnapshotBuilder::aRawSnapshot()
+            ->withCompanyId($companyId)->withSnapshotSessionId($sessionId)->withSource(MarketplaceType::OZON)
+            ->withResponseBody(['result' => ['items' => [['offer_id' => $offerId, 'stocks' => [['sku' => $sku, 'type' => $type, 'present' => $present, 'reserved' => $reserved]]]]]])
+            ->build();
+    }
+
+    private function createCompany(int $index): Company
+    {
+        $user = UserBuilder::aUser()->withIndex($index)->build();
+        $company = CompanyBuilder::aCompany()->withIndex($index)->withOwner($user)->build();
+        $this->em->persist($user); $this->em->persist($company); $this->em->flush();
+        return $company;
+    }
+}

--- a/site/tests/Integration/Inventory/MessageHandler/SyncOzonInventorySnapshotHandlerTest.php
+++ b/site/tests/Integration/Inventory/MessageHandler/SyncOzonInventorySnapshotHandlerTest.php
@@ -81,6 +81,8 @@ final class SyncOzonInventorySnapshotHandlerTest extends IntegrationTestCase
             ->createSchemaManager()
             ->listTableColumns('inventory_raw_snapshots');
         self::assertArrayNotHasKey('connection_id', $columns);
+
+        self::assertGreaterThan(0, $this->countNormalizeMessages($session->getId(), $company->getId()));
     }
 
     public function testSuccessSeveralPagesSavesSeveralRawSnapshots(): void
@@ -114,6 +116,7 @@ final class SyncOzonInventorySnapshotHandlerTest extends IntegrationTestCase
         $this->em->refresh($session);
         self::assertSame(SnapshotSessionStatus::Failed, $session->getStatus());
         self::assertStringContainsString('HTTP 500', (string) $session->getErrorMessage());
+        self::assertSame(0, $this->countNormalizeMessages($session->getId(), $company->getId()));
     }
 
     public function testErrorAfterFirstPageMarksPartialWithoutThrow(): void
@@ -132,6 +135,7 @@ final class SyncOzonInventorySnapshotHandlerTest extends IntegrationTestCase
         $this->em->refresh($session);
         self::assertSame(SnapshotSessionStatus::Partial, $session->getStatus());
         self::assertCount(1, $this->findRawBySession($session->getId()));
+        self::assertSame(0, $this->countNormalizeMessages($session->getId(), $company->getId()));
     }
 
     public function testRateLimitBeforeFirstPageMarksFailedWithoutThrow(): void
@@ -193,4 +197,30 @@ final class SyncOzonInventorySnapshotHandlerTest extends IntegrationTestCase
     {
         return $this->em->getRepository(InventoryRawSnapshot::class)->count([]);
     }
+
+
+    private function countNormalizeMessages(string $sessionId, string $companyId): int
+    {
+        $cnt = (int) $this->em->getConnection()->fetchOne(
+            "SELECT COUNT(*) FROM messenger_messages WHERE body LIKE :needle1 AND body LIKE :needle2 AND body LIKE :needle3",
+            [
+                'needle1' => '%NormalizeInventorySnapshotMessage%',
+                'needle2' => '%"snapshotSessionId":"'.$sessionId.'"%',
+                'needle3' => '%"companyId":"'.$companyId.'"%',
+            ],
+        );
+
+        $body = (string) $this->em->getConnection()->fetchOne(
+            "SELECT body FROM messenger_messages WHERE body LIKE :needle ORDER BY available_at DESC LIMIT 1",
+            ['needle' => '%NormalizeInventorySnapshotMessage%'],
+        );
+        if ($body !== '') {
+            self::assertStringContainsString('"source":"ozon"', $body);
+            self::assertStringNotContainsString('api_key', $body);
+            self::assertStringNotContainsString('client_id', $body);
+        }
+
+        return $cnt;
+    }
+
 }


### PR DESCRIPTION
### Motivation

- Ensure raw Ozon inventory pages fetched by the snapshot sync are converted into normalized `StockSnapshot` rows, mapped to marketplace listings/products and locations, and upserted per day to avoid duplicates.

### Description

- Added `NormalizeInventorySnapshotAction` which normalizes raw Ozon snapshots, resolves marketplace listings/products, creates missing `Location` entities and writes normalized `StockSnapshot` records using an `upsertDaySnapshot` path.
- Added `NormalizeInventorySnapshotMessage` and `NormalizeInventorySnapshotHandler` and registered the message in `site/config/packages/messenger.yaml` so normalization runs asynchronously after successful fetch.
- Updated `SyncOzonInventorySnapshotHandler` to dispatch `NormalizeInventorySnapshotMessage` when a session completes.
- Implemented `StockSnapshotRepository::upsertDaySnapshot` performing a PostgreSQL `ON CONFLICT` upsert to update existing daily snapshots atomically.
- Added integration tests `NormalizeInventorySnapshotActionTest` and extended `SyncOzonInventorySnapshotHandlerTest` to assert message dispatching and normalization behavior.

### Testing

- Ran `tests/Integration/Inventory/Application/NormalizeInventorySnapshotActionTest.php` which verifies idempotency, mapping statuses (`Mapped`/`Ambiguous`/`Unmapped`), created snapshots, and processed-empty-raw behavior; the test passed.
- Ran updated `tests/Integration/Inventory/MessageHandler/SyncOzonInventorySnapshotHandlerTest.php` which verifies the handler marks sessions `Completed`/`Partial`/`Failed` appropriately and that the normalization message is enqueued only on full success; the test assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01bce488208323aaffb224df7b08d7)