### PR TITLE
Add NormalizeInventorySnapshotHandler tests, tighten inventory schema/enum tests, and update stock report assertions

### DIFF
--- a/site/tests/Functional/Inventory/Controller/StockReportControllerTest.php
+++ b/site/tests/Functional/Inventory/Controller/StockReportControllerTest.php
@@ -144,6 +144,8 @@ final class StockReportControllerTest extends WebTestCaseBase
         $html = (string) $client->getResponse()->getContent();
         self::assertStringContainsString('UNMAPPED-SKU', $html);
         self::assertStringNotContainsString('MAPPED-SKU', $html);
+        self::assertStringContainsString('10.000', $html);
+        self::assertStringContainsString('3.000', $html);
         self::assertStringContainsString('7.000', $html);
 
         $client->request('GET', '/inventory/snapshots');

--- a/site/tests/Integration/Inventory/InventorySchemaTest.php
+++ b/site/tests/Integration/Inventory/InventorySchemaTest.php
@@ -55,8 +55,17 @@ final class InventorySchemaTest extends IntegrationTestCase
         self::assertSame(14, (int) $reservedQuantityDef['numeric_precision']);
         self::assertSame(3, (int) $reservedQuantityDef['numeric_scale']);
 
-        $mappingStatusDefault = $conn->fetchOne("SELECT column_default FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'inventory_stock_snapshots' AND column_name = 'mapping_status'");
-        self::assertStringContainsString('unmapped', (string) $mappingStatusDefault);
+        $mappingStatusDef = $conn->fetchAssociative(<<<'SQL'
+            SELECT data_type, character_maximum_length, column_default
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'inventory_stock_snapshots'
+              AND column_name = 'mapping_status'
+        SQL);
+        self::assertIsArray($mappingStatusDef);
+        self::assertSame('character varying', $mappingStatusDef['data_type']);
+        self::assertSame(50, (int) $mappingStatusDef['character_maximum_length']);
+        self::assertStringContainsString('unmapped', (string) $mappingStatusDef['column_default']);
 
         $companySourceSkuIndex = (string) $conn->fetchOne("SELECT indexdef FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'idx_inventory_stock_company_source_sku'");
         self::assertStringContainsString('(company_id, source_sku)', $companySourceSkuIndex);

--- a/site/tests/Integration/Inventory/MessageHandler/NormalizeInventorySnapshotHandlerTest.php
+++ b/site/tests/Integration/Inventory/MessageHandler/NormalizeInventorySnapshotHandlerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Inventory\MessageHandler;
+
+use App\Company\Entity\Company;
+use App\Inventory\Entity\InventoryRawSnapshot;
+use App\Inventory\Entity\InventorySnapshotSession;
+use App\Inventory\Entity\StockSnapshot;
+use App\Inventory\Enum\SnapshotSessionStatus;
+use App\Inventory\Enum\SnapshotTriggerType;
+use App\Inventory\Message\NormalizeInventorySnapshotMessage;
+use App\Inventory\MessageHandler\NormalizeInventorySnapshotHandler;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Builders\Inventory\InventoryRawSnapshotBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+
+final class NormalizeInventorySnapshotHandlerTest extends IntegrationTestCase
+{
+    public function testOzonSourceRunsNormalizationViaRealAction(): void
+    {
+        $company = $this->createCompany(951);
+        $session = new InventorySnapshotSession($company->getId(), MarketplaceType::OZON, SnapshotTriggerType::Manual);
+        $session->markCompleted();
+        $this->em->persist($session);
+
+        $raw = InventoryRawSnapshotBuilder::aRawSnapshot()
+            ->withCompanyId($company->getId())
+            ->withSnapshotSessionId($session->getId())
+            ->withSource(MarketplaceType::OZON)
+            ->withFetchedAt(new \DateTimeImmutable('2026-05-11T09:00:00+00:00'))
+            ->withResponseBody([
+                'result' => [
+                    'items' => [[
+                        'offer_id' => 'OF-951',
+                        'stocks' => [[
+                            'sku' => 'SKU-951',
+                            'type' => 'fbo',
+                            'present' => 9,
+                            'reserved' => 4,
+                        ]],
+                    ]],
+                ],
+            ])
+            ->build();
+        $this->em->persist($raw);
+        $this->em->flush();
+
+        $handler = self::getContainer()->get(NormalizeInventorySnapshotHandler::class);
+        $handler(new NormalizeInventorySnapshotMessage($company->getId(), $session->getId(), MarketplaceType::OZON->value));
+
+        $this->em->refresh($raw);
+        self::assertTrue($raw->isProcessed());
+
+        $rows = $this->em->getRepository(StockSnapshot::class)->findBy(['companyId' => $company->getId()]);
+        self::assertCount(1, $rows);
+        self::assertSame('SKU-951', $rows[0]->getSourceSku());
+        self::assertSame('9.000', $rows[0]->getQuantity());
+        self::assertSame('4.000', $rows[0]->getReservedQuantity());
+    }
+
+    public function testUnsupportedSourceDoesNothingAndDoesNotFail(): void
+    {
+        $company = $this->createCompany(952);
+        $session = new InventorySnapshotSession($company->getId(), MarketplaceType::OZON, SnapshotTriggerType::Manual);
+        $session->markCompleted();
+        $this->em->persist($session);
+        $this->em->flush();
+
+        $handler = self::getContainer()->get(NormalizeInventorySnapshotHandler::class);
+        $handler(new NormalizeInventorySnapshotMessage($company->getId(), $session->getId(), 'wb'));
+
+        self::assertSame(0, $this->em->getRepository(StockSnapshot::class)->count(['companyId' => $company->getId()]));
+        $this->em->refresh($session);
+        self::assertSame(SnapshotSessionStatus::Completed, $session->getStatus());
+    }
+
+    private function createCompany(int $index): Company
+    {
+        $user = UserBuilder::aUser()->withIndex($index)->build();
+        $company = CompanyBuilder::aCompany()->withIndex($index)->withOwner($user)->build();
+        $this->em->persist($user);
+        $this->em->persist($company);
+        $this->em->flush();
+
+        return $company;
+    }
+}
+

--- a/site/tests/Unit/Inventory/Enum/InventoryEnumsTest.php
+++ b/site/tests/Unit/Inventory/Enum/InventoryEnumsTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\Inventory\Enum;
 use App\Inventory\Enum\LocationType;
 use App\Inventory\Enum\SnapshotSessionStatus;
 use App\Inventory\Enum\SnapshotTriggerType;
+use App\Inventory\Enum\StockSnapshotMappingStatus;
 use App\Inventory\Enum\StockStatus;
 use PHPUnit\Framework\TestCase;
 
@@ -64,6 +65,18 @@ final class InventoryEnumsTest extends TestCase
                 'retry',
             ],
             array_map(static fn (SnapshotTriggerType $case): string => $case->value, SnapshotTriggerType::cases()),
+        );
+    }
+
+    public function testStockSnapshotMappingStatusHasExpectedValuesCount(): void
+    {
+        $this->assertSame(
+            [
+                'unmapped',
+                'mapped',
+                'ambiguous',
+            ],
+            array_map(static fn (StockSnapshotMappingStatus $case): string => $case->value, StockSnapshotMappingStatus::cases()),
         );
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure inventory normalization behavior is covered by integration tests and that unsupported sources do not break processing.
- Verify database schema for `mapping_status` and numeric precision for snapshot quantities matches expectations.
- Confirm the `StockSnapshotMappingStatus` enum contains the expected values and that UI shows formatted quantities.

### Description
- Added `NormalizeInventorySnapshotHandlerTest` integration test which validates Ozon normalization creates `StockSnapshot` rows with correct `quantity` and `reserved_quantity` formatting and that unsupported sources leave the session completed without creating rows.
- Updated `InventorySchemaTest` to assert `mapping_status` column is `character varying(50)` and that its default contains `'unmapped'` instead of only checking the default string, and retained numeric precision/scale checks for `quantity` and `reserved_quantity`.
- Updated `StockReportControllerTest` functional test to assert formatted quantity strings (e.g. `10.000`, `3.000`, `7.000`) are present in the rendered report.
- Added `InventoryEnumsTest` unit test for `StockSnapshotMappingStatus` to assert the enum values `unmapped`, `mapped`, and `ambiguous` are present.

### Testing
- Ran unit tests including `InventoryEnumsTest`, which passed successfully.
- Ran integration tests including `NormalizeInventorySnapshotHandlerTest` and `InventorySchemaTest`, which passed successfully.
- Ran functional tests including `StockReportControllerTest`, which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01c6de8e008323906a7f2c950f0b81)