### PR TITLE
Fix AppLogger::error() usage in Inventory handlers and add rethrow regression test

### DIFF
--- a/site/src/Inventory/Application/RequestOzonInventorySnapshotAction.php
+++ b/site/src/Inventory/Application/RequestOzonInventorySnapshotAction.php
@@ -154,7 +154,7 @@ final readonly class RequestOzonInventorySnapshotAction
                 ]);
             } catch (\Throwable $e) {
                 ++$skippedCount;
-                $this->logger->error('Inventory snapshot message dispatch failed.', [
+                $this->logger->error('Inventory snapshot message dispatch failed.', $e, [
                     'companyId' => $companyId,
                     'snapshotSessionId' => $session->getId(),
                     'connectionId' => $connectionId,

--- a/site/src/Inventory/MessageHandler/NormalizeInventorySnapshotHandler.php
+++ b/site/src/Inventory/MessageHandler/NormalizeInventorySnapshotHandler.php
@@ -44,12 +44,12 @@ final readonly class NormalizeInventorySnapshotHandler
                 'source' => $message->source,
             ]);
         } catch (\Throwable $e) {
-            $this->logger->error('Inventory normalization failed.', [
+            $this->logger->error('Inventory normalization failed.', $e, [
                 'companyId' => $message->companyId,
                 'snapshotSessionId' => $message->snapshotSessionId,
                 'source' => $message->source,
                 'exceptionClass' => $e::class,
-                'message' => $e->getMessage(),
+                'errorMessage' => $e->getMessage(),
             ]);
 
             throw $e;

--- a/site/src/Inventory/MessageHandler/SyncOzonInventorySnapshotHandler.php
+++ b/site/src/Inventory/MessageHandler/SyncOzonInventorySnapshotHandler.php
@@ -160,7 +160,7 @@ final class SyncOzonInventorySnapshotHandler
 
             return;
         } catch (\Throwable $e) {
-            $this->logger->error('Inventory snapshot fetching failed with unhandled exception.', [
+            $this->logger->error('Inventory snapshot fetching failed with unhandled exception.', $e, [
                 'snapshotSessionId' => $session->getId(),
                 'companyId' => $message->companyId,
                 'connectionId' => $message->connectionId,

--- a/site/tests/Integration/Inventory/MessageHandler/NormalizeInventorySnapshotHandlerTest.php
+++ b/site/tests/Integration/Inventory/MessageHandler/NormalizeInventorySnapshotHandlerTest.php
@@ -78,6 +78,16 @@ final class NormalizeInventorySnapshotHandlerTest extends IntegrationTestCase
         self::assertSame(SnapshotSessionStatus::Completed, $session->getStatus());
     }
 
+
+    public function testTechnicalExceptionIsRethrownForMessengerRetry(): void
+    {
+        $company = $this->createCompany(953);
+
+        $handler = self::getContainer()->get(NormalizeInventorySnapshotHandler::class);
+
+        $this->expectException(\Throwable::class);
+        $handler(new NormalizeInventorySnapshotMessage($company->getId(), 'not-a-uuid', MarketplaceType::OZON->value));
+    }
     private function createCompany(int $index): Company
     {
         $user = UserBuilder::aUser()->withIndex($index)->build();


### PR DESCRIPTION
### Motivation

- Fix a runtime type error where `AppLogger::error()` was called with an `array` as the second argument while its signature expects `(?Throwable $exception, array $context)`. 
- Ensure `NormalizeInventorySnapshotHandler` logs the thrown exception correctly and still rethrows it so Messenger retry semantics are preserved. 
- Align other Inventory `error()` calls with the `AppLogger` signature to prevent similar failures.

### Description

- Updated the catch block in `site/src/Inventory/MessageHandler/NormalizeInventorySnapshotHandler.php` to call `AppLogger::error()` as `->error('...', $e, [...])` and renamed the context key from `message` to `errorMessage`.
- Applied the same signature fix in `site/src/Inventory/MessageHandler/SyncOzonInventorySnapshotHandler.php` and `site/src/Inventory/Application/RequestOzonInventorySnapshotAction.php` so exception is passed as the second argument.
- Added an integration regression test `testTechnicalExceptionIsRethrownForMessengerRetry` to `site/tests/Integration/Inventory/MessageHandler/NormalizeInventorySnapshotHandlerTest.php` that asserts technical exceptions are rethrown for Messenger retry.
- Changes committed (files modified: the three handlers/actions and the integration test).

### Testing

- Added the integration test `NormalizeInventorySnapshotHandlerTest::testTechnicalExceptionIsRethrownForMessengerRetry` to cover the rethrow behavior.
- Attempted to run the Inventory integration tests with `php bin/phpunit tests/Integration/Inventory/MessageHandler/NormalizeInventorySnapshotHandlerTest.php tests/Integration/Inventory/Application/NormalizeInventorySnapshotActionTest.php tests/Integration/Inventory/MessageHandler/SyncOzonInventorySnapshotHandlerTest.php`, but test execution failed due to missing Symfony PHPUnit bridge helper (`Unable to find the simple-phpunit.php script in vendor/symfony/phpunit-bridge/bin/`), so tests were not executed in this environment.
- Static verification performed by running repository search and inspecting modified files to confirm `AppLogger::error()` usages in Inventory now follow the correct signature.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01cc6cda3083239a26f6cd7dba2d64)