### PR TITLE
Use DBAL `ParameterType` and `ArrayParameterType` constants for query parameters

### DIFF
--- a/site/src/Inventory/Repository/StockSnapshotRepository.php
+++ b/site/src/Inventory/Repository/StockSnapshotRepository.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Inventory\Repository;
 
 use App\Inventory\Entity\StockSnapshot;
-use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -73,8 +73,8 @@ final class StockSnapshotRepository extends ServiceEntityRepository
                 'snapshotDate' => 'date_immutable',
                 'snapshotAt' => 'datetime_immutable',
                 'createdAt' => 'datetime_immutable',
-                'listingId' => Connection::PARAM_STR,
-                'productId' => Connection::PARAM_STR,
+                'listingId' => ParameterType::STRING,
+                'productId' => ParameterType::STRING,
             ],
         );
     }

--- a/site/src/Marketplace/Facade/MarketplaceFacade.php
+++ b/site/src/Marketplace/Facade/MarketplaceFacade.php
@@ -23,6 +23,7 @@ use App\Marketplace\Infrastructure\Query\MarketplaceCredentialsQuery;
 use App\Marketplace\Repository\MarketplaceAdvertisingCostRepositoryInterface;
 use App\Marketplace\Repository\MarketplaceListingRepository;
 use App\Marketplace\Repository\MarketplaceOrderRepositoryInterface;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Webmozart\Assert\Assert;
 
@@ -361,7 +362,7 @@ final readonly class MarketplaceFacade
                 'marketplace'     => $marketplace,
                 'marketplaceSkus' => array_values(array_unique($marketplaceSkus)),
             ],
-            ['marketplaceSkus' => Connection::PARAM_STR_ARRAY],
+            ['marketplaceSkus' => ArrayParameterType::STRING],
         );
 
         $result = [];
@@ -403,7 +404,7 @@ final readonly class MarketplaceFacade
                 'listingIds' => $listingIds,
                 'date'       => $date->format('Y-m-d'),
             ],
-            ['listingIds' => Connection::PARAM_STR_ARRAY],
+            ['listingIds' => ArrayParameterType::STRING],
         );
 
         $result = [];

--- a/site/src/Marketplace/Infrastructure/Query/MarketplaceSaleExistingExternalIdsQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/MarketplaceSaleExistingExternalIdsQuery.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Marketplace\Infrastructure\Query;
 
 use App\Marketplace\Enum\MarketplaceType;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 
 final readonly class MarketplaceSaleExistingExternalIdsQuery
@@ -44,7 +45,7 @@ final readonly class MarketplaceSaleExistingExternalIdsQuery
                     'ids' => $externalIds,
                 ],
                 [
-                    'ids' => Connection::PARAM_STR_ARRAY,
+                    'ids' => ArrayParameterType::STRING,
                 ],
             )->fetchFirstColumn(),
         );

--- a/site/tests/Integration/Marketplace/Application/Processor/OzonCostsRawProcessorTest.php
+++ b/site/tests/Integration/Marketplace/Application/Processor/OzonCostsRawProcessorTest.php
@@ -17,6 +17,7 @@ use App\Tests\Builders\Company\CompanyBuilder;
 use App\Tests\Builders\Company\UserBuilder;
 use App\Tests\Builders\Marketplace\MarketplaceRawDocumentBuilder;
 use App\Tests\Support\Kernel\IntegrationTestCase;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Ramsey\Uuid\Uuid;
 
@@ -301,40 +302,40 @@ final class OzonCostsRawProcessorTest extends IntegrationTestCase
             'companyIds' => $companyIds,
             'costRawDocumentIds' => $costRawDocumentIds,
         ], [
-            'companyIds' => Connection::PARAM_STR_ARRAY,
-            'costRawDocumentIds' => Connection::PARAM_STR_ARRAY,
+            'companyIds' => ArrayParameterType::STRING,
+            'costRawDocumentIds' => ArrayParameterType::STRING,
         ]);
 
         $this->connection->executeStatement('DELETE FROM marketplace_raw_documents WHERE company_id IN (:companyIds) OR id IN (:rawDocumentIds)', [
             'companyIds' => $companyIds,
             'rawDocumentIds' => $rawDocumentIds,
         ], [
-            'companyIds' => Connection::PARAM_STR_ARRAY,
-            'rawDocumentIds' => Connection::PARAM_STR_ARRAY,
+            'companyIds' => ArrayParameterType::STRING,
+            'rawDocumentIds' => ArrayParameterType::STRING,
         ]);
 
         $this->connection->executeStatement(sprintf('DELETE FROM %s WHERE company_id IN (:companyIds)', $documentTable), [
             'companyIds' => $companyIds,
         ], [
-            'companyIds' => Connection::PARAM_STR_ARRAY,
+            'companyIds' => ArrayParameterType::STRING,
         ]);
 
         $this->connection->executeStatement('DELETE FROM marketplace_listings WHERE company_id IN (:companyIds)', [
             'companyIds' => $companyIds,
         ], [
-            'companyIds' => Connection::PARAM_STR_ARRAY,
+            'companyIds' => ArrayParameterType::STRING,
         ]);
 
         $this->connection->executeStatement(sprintf('DELETE FROM %s WHERE id IN (:companyIds)', $companyTable), [
             'companyIds' => $companyIds,
         ], [
-            'companyIds' => Connection::PARAM_STR_ARRAY,
+            'companyIds' => ArrayParameterType::STRING,
         ]);
 
         $this->connection->executeStatement(sprintf('DELETE FROM %s WHERE id IN (:userIds)', $userTable), [
             'userIds' => array_values(array_filter($userIds)),
         ], [
-            'userIds' => Connection::PARAM_STR_ARRAY,
+            'userIds' => ArrayParameterType::STRING,
         ]);
     }
 


### PR DESCRIPTION
### Motivation

- Replace deprecated/older `Connection::PARAM_*` constants with the DBAL `ParameterType` and `ArrayParameterType` tokens to align with the newer Doctrine DBAL API and avoid using `Connection` constants for parameter typing.

### Description

- Replace `Connection::PARAM_STR` with `ParameterType::STRING` in `StockSnapshotRepository::upsertDaySnapshot` and add the `use Doctrine\DBAL\ParameterType` import.
- Introduce `use Doctrine\DBAL\ArrayParameterType` and replace `Connection::PARAM_STR_ARRAY` with `ArrayParameterType::STRING` in `MarketplaceFacade`, `MarketplaceSaleExistingExternalIdsQuery`, and the integration test `OzonCostsRawProcessorTest`.
- Update multiple `executeStatement`/`fetchAllAssociative`/`executeQuery` calls to use the new parameter type constants for single and array string parameters.

### Testing

- Ran the modified integration test `OzonCostsRawProcessorTest` via `phpunit --filter OzonCostsRawProcessorTest` and it succeeded.
- Ran the full test suite with `phpunit` and no regressions were observed in automated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01cf8179788323934154b0f9dd3961)