### PR TITLE
Fix duplicate Ozon SKU rows in inventory stocks normalization

### DIFF
--- a/site/migrations/Version20260511130000.php
+++ b/site/migrations/Version20260511130000.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260511130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Deduplicate inventory locations and stock snapshots; enforce location uniqueness by company, source, external ID';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS uniq_inventory_locations_external');
+
+        $this->addSql(<<<'SQL'
+            WITH ranked_locations AS (
+                SELECT
+                    id,
+                    company_id,
+                    external_system,
+                    external_id,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY company_id, external_system, external_id
+                        ORDER BY created_at ASC, id ASC
+                    ) AS rn,
+                    FIRST_VALUE(id) OVER (
+                        PARTITION BY company_id, external_system, external_id
+                        ORDER BY created_at ASC, id ASC
+                    ) AS canonical_id
+                FROM inventory_locations
+                WHERE external_id IS NOT NULL
+            )
+            UPDATE inventory_stock_snapshots s
+            SET location_id = rl.canonical_id
+            FROM ranked_locations rl
+            WHERE s.location_id = rl.id
+              AND rl.rn > 1
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            WITH ranked_snapshots AS (
+                SELECT
+                    id,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY company_id, snapshot_session_id, snapshot_date, source, source_sku, fulfillment_type, status
+                        ORDER BY created_at DESC, id DESC
+                    ) AS rn
+                FROM inventory_stock_snapshots
+            )
+            DELETE FROM inventory_stock_snapshots s
+            USING ranked_snapshots rs
+            WHERE s.id = rs.id
+              AND rs.rn > 1
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            WITH ranked_locations AS (
+                SELECT
+                    id,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY company_id, external_system, external_id
+                        ORDER BY created_at ASC, id ASC
+                    ) AS rn
+                FROM inventory_locations
+                WHERE external_id IS NOT NULL
+            )
+            DELETE FROM inventory_locations l
+            USING ranked_locations rl
+            WHERE l.id = rl.id
+              AND rl.rn > 1
+        SQL);
+
+        $this->addSql("CREATE UNIQUE INDEX uniq_inventory_location_company_external ON inventory_locations (company_id, external_system, external_id) WHERE external_id IS NOT NULL");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS uniq_inventory_location_company_external');
+        $this->addSql("CREATE UNIQUE INDEX uniq_inventory_locations_external ON inventory_locations (company_id, external_system, external_id) WHERE external_id IS NOT NULL");
+    }
+}

--- a/site/src/Inventory/Application/NormalizeInventorySnapshotAction.php
+++ b/site/src/Inventory/Application/NormalizeInventorySnapshotAction.php
@@ -98,13 +98,14 @@ final readonly class NormalizeInventorySnapshotAction
         }
 
         $productsByListing = $this->marketplaceFacade->resolveListingsToProducts($companyId, array_values(array_unique($mappedListingIds)));
+        $locationByFulfillmentType = $this->resolveLocationsByFulfillmentType($companyId, $source, $rowsByRaw);
 
         foreach ($rawSnapshots as $rawSnapshot) {
             foreach ($rowsByRaw[$rawSnapshot->getId()] ?? [] as $row) {
                 $mapping = $mappingBySku[$row->sourceSku] ?? ['status' => StockSnapshotMappingStatus::Unmapped, 'listingId' => null];
                 $listingId = $mapping['listingId'];
                 $productId = $listingId !== null ? ($productsByListing[$listingId] ?? null) : null;
-                $location = $this->findOrCreateLocation($companyId, $source, $row->fulfillmentType);
+                $location = $locationByFulfillmentType[$this->normalizeFulfillmentType($row->fulfillmentType)];
 
                 $this->stockSnapshotRepository->upsertDaySnapshot(new StockSnapshot(
                     companyId: $companyId,
@@ -132,9 +133,31 @@ final readonly class NormalizeInventorySnapshotAction
         $this->entityManager->flush();
     }
 
+    /**
+     * @param array<string, list<\App\Inventory\Application\DTO\NormalizedStockRow>> $rowsByRaw
+     *
+     * @return array<string, Location>
+     */
+    private function resolveLocationsByFulfillmentType(string $companyId, MarketplaceType $source, array $rowsByRaw): array
+    {
+        $locations = [];
+        foreach ($rowsByRaw as $rows) {
+            foreach ($rows as $row) {
+                $normalizedFulfillmentType = $this->normalizeFulfillmentType($row->fulfillmentType);
+                if (isset($locations[$normalizedFulfillmentType])) {
+                    continue;
+                }
+
+                $locations[$normalizedFulfillmentType] = $this->findOrCreateLocation($companyId, $source, $row->fulfillmentType);
+            }
+        }
+
+        return $locations;
+    }
+
     private function findOrCreateLocation(string $companyId, MarketplaceType $source, ?string $fulfillmentType): Location
     {
-        $externalId = $fulfillmentType ?? 'unknown';
+        $externalId = $this->normalizeFulfillmentType($fulfillmentType);
         $location = $this->locationRepository->findOneBy([
             'companyId' => $companyId,
             'externalSystem' => $source,
@@ -156,5 +179,12 @@ final readonly class NormalizeInventorySnapshotAction
         $this->entityManager->persist($location);
 
         return $location;
+    }
+
+    private function normalizeFulfillmentType(?string $fulfillmentType): string
+    {
+        $normalizedValue = trim((string) $fulfillmentType);
+
+        return $normalizedValue !== '' ? mb_strtolower($normalizedValue) : 'unknown';
     }
 }

--- a/site/src/Inventory/Entity/Location.php
+++ b/site/src/Inventory/Entity/Location.php
@@ -14,7 +14,7 @@ use Webmozart\Assert\Assert;
 
 #[ORM\Entity(repositoryClass: LocationRepository::class)]
 #[ORM\Table(name: 'inventory_locations')]
-#[ORM\UniqueConstraint(name: 'uniq_inventory_locations_external', columns: ['company_id', 'external_system', 'external_id'], options: ['where' => 'external_id IS NOT NULL'])]
+#[ORM\UniqueConstraint(name: 'uniq_inventory_location_company_external', columns: ['company_id', 'external_system', 'external_id'], options: ['where' => 'external_id IS NOT NULL'])]
 #[ORM\Index(columns: ['company_id', 'type', 'is_active'], name: 'idx_inventory_locations_company_type_active')]
 #[ORM\Index(columns: ['company_id', 'external_system'], name: 'idx_inventory_locations_company_external_system')]
 class Location

--- a/site/tests/Integration/Inventory/Application/NormalizeInventorySnapshotActionTest.php
+++ b/site/tests/Integration/Inventory/Application/NormalizeInventorySnapshotActionTest.php
@@ -9,6 +9,7 @@ use App\Company\Entity\Company;
 use App\Inventory\Application\NormalizeInventorySnapshotAction;
 use App\Inventory\Entity\InventoryRawSnapshot;
 use App\Inventory\Entity\InventorySnapshotSession;
+use App\Inventory\Entity\Location;
 use App\Inventory\Entity\StockSnapshot;
 use App\Inventory\Enum\SnapshotTriggerType;
 use App\Inventory\Enum\StockSnapshotMappingStatus;
@@ -55,6 +56,7 @@ final class NormalizeInventorySnapshotActionTest extends IntegrationTestCase
 
         $rows = $this->em->getRepository(StockSnapshot::class)->findBy(['companyId' => $company->getId()]);
         self::assertCount(4, $rows);
+        self::assertSame(2, $this->em->getRepository(Location::class)->count(['companyId' => $company->getId(), 'externalSystem' => MarketplaceType::OZON]));
 
         $bySku = [];
         foreach ($rows as $row) { $bySku[$row->getSourceSku()] = $row; }
@@ -81,6 +83,30 @@ final class NormalizeInventorySnapshotActionTest extends IntegrationTestCase
         self::assertSame('3.000', $bySku['SKU-M']->getReservedQuantity());
         self::assertSame('OF-M', $bySku['SKU-M']->getSourceOfferId());
         self::assertSame('fbs', $bySku['SKU-M']->getFulfillmentType());
+    }
+
+    public function testSingleSkuHasSingleSnapshotRowWithinSession(): void
+    {
+        $company = $this->createCompany(903);
+        $session = new InventorySnapshotSession($company->getId(), MarketplaceType::OZON, SnapshotTriggerType::Manual);
+        $session->markCompleted();
+        $this->em->persist($session);
+
+        $this->em->persist($this->raw($company->getId(), $session->getId(), '220282262', 11, 0, 'fbo', 'OF-220282262'));
+        $this->em->flush();
+
+        $action = self::getContainer()->get(NormalizeInventorySnapshotAction::class);
+        $action($company->getId(), $session->getId(), MarketplaceType::OZON);
+        $action($company->getId(), $session->getId(), MarketplaceType::OZON);
+
+        self::assertSame(1, $this->em->getRepository(StockSnapshot::class)->count([
+            'companyId' => $company->getId(),
+            'snapshotSessionId' => $session->getId(),
+            'source' => MarketplaceType::OZON,
+            'sourceSku' => '220282262',
+            'fulfillmentType' => 'fbo',
+            'status' => StockStatus::Available,
+        ]));
     }
 
 

--- a/site/tests/Integration/Inventory/InventorySchemaTest.php
+++ b/site/tests/Integration/Inventory/InventorySchemaTest.php
@@ -17,8 +17,8 @@ final class InventorySchemaTest extends IntegrationTestCase
         self::assertSame('inventory_raw_snapshots', $conn->fetchOne("SELECT to_regclass('public.inventory_raw_snapshots')"));
         self::assertSame('inventory_stock_snapshots', $conn->fetchOne("SELECT to_regclass('public.inventory_stock_snapshots')"));
 
-        $locationIndex = (string) $conn->fetchOne("SELECT indexdef FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'uniq_inventory_locations_external'");
-        self::assertStringContainsString('UNIQUE INDEX uniq_inventory_locations_external', $locationIndex);
+        $locationIndex = (string) $conn->fetchOne("SELECT indexdef FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'uniq_inventory_location_company_external'");
+        self::assertStringContainsString('UNIQUE INDEX uniq_inventory_location_company_external', $locationIndex);
 
         $rawUnprocessedIndex = (string) $conn->fetchOne("SELECT indexdef FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'idx_inventory_raw_unprocessed'");
         self::assertStringContainsString('WHERE (is_processed = false)', $rawUnprocessedIndex);


### PR DESCRIPTION
### Motivation
- The inventory UI showed the same Ozon SKU multiple times because `StockSnapshot` deduplication included `location_id`, and the normalizer could create multiple technical `Location` rows for the same fulfillment type so UPSERT failed to dedupe. 
- Goal: ensure a single stable `Location` per `company_id + source + fulfillmentType` (external_id), prevent per-row `Location` creation during normalization, and safely clean existing duplicates.

### Description
- `NormalizeInventorySnapshotAction` now pre-resolves a single `Location` per normalized fulfillment type and reuses it for all rows via an in-memory cache, and normalizes fulfillment type values to stable lowercase values with fallback `unknown` (see `resolveLocationsByFulfillmentType` and `normalizeFulfillmentType`).
- `Location` entity unique constraint name changed to `uniq_inventory_location_company_external` to enforce uniqueness on `(company_id, external_system, external_id)` when `external_id` is not null.
- Added migration `Version20260511130000` that repoints `inventory_stock_snapshots.location_id` to canonical locations, deletes duplicate `inventory_stock_snapshots` keeping the latest by `created_at,id`, removes duplicate `inventory_locations`, and creates the unique index `uniq_inventory_location_company_external`.
- Tests updated/added: integration test `NormalizeInventorySnapshotActionTest` now asserts only one `Location` per fulfillment type is created and adds a regression test that SKU `220282262` yields a single snapshot row per session; `InventorySchemaTest` updated to expect the new index name.

### Testing
- Attempted to run integration tests `tests/Integration/Inventory/Application/NormalizeInventorySnapshotActionTest.php` and `tests/Integration/Inventory/InventorySchemaTest.php` via `phpunit`, but execution failed because `vendor/symfony/phpunit-bridge/bin/simple-phpunit.php` is not available in the environment, so tests could not be executed here.
- The changes include new/updated integration tests and a migration; these tests should be run in CI or a full dev environment with Composer dependencies installed to validate behavior and migration safety.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a021b657a888323a254af6176459f9a)