### PR TITLE
Add `app:user:reset-password` console command and unit tests

### DIFF
--- a/site/src/Company/Command/ResetUserPasswordCommand.php
+++ b/site/src/Company/Command/ResetUserPasswordCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Company\Command;
+
+use App\Company\Entity\User;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+#[AsCommand(
+    name: 'app:user:reset-password',
+    description: 'Сбрасывает пароль пользователя по email и выводит новый временный пароль.',
+)]
+final class ResetUserPasswordCommand extends Command
+{
+    public function __construct(
+        private readonly UserRepository $userRepository,
+        private readonly UserPasswordHasherInterface $passwordHasher,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('email', InputArgument::REQUIRED, 'Email пользователя');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $email = User::normalizeEmail((string) $input->getArgument('email'));
+
+        if (false === filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            $output->writeln(sprintf('<error>Некорректный формат email: "%s".</error>', $email));
+
+            return Command::FAILURE;
+        }
+
+        $user = $this->userRepository->findOneBy(['email' => $email]);
+        if (null === $user) {
+            $output->writeln(sprintf('<error>Пользователь с email "%s" не найден.</error>', $email));
+
+            return Command::FAILURE;
+        }
+
+        $plainPassword = $this->generatePassword();
+        $hashedPassword = $this->passwordHasher->hashPassword($user, $plainPassword);
+
+        $user->setPassword($hashedPassword);
+        $this->entityManager->flush();
+
+        $output->writeln(sprintf('<info>Пароль пользователя %s успешно обновлён.</info>', $email));
+        $output->writeln(sprintf('<comment>Новый временный пароль: %s</comment>', $plainPassword));
+
+        return Command::SUCCESS;
+    }
+
+    private function generatePassword(): string
+    {
+        return rtrim(strtr(base64_encode(random_bytes(12)), '+/', '-_'), '=');
+    }
+}

--- a/site/src/Company/Command/ResetUserPasswordCommand.php
+++ b/site/src/Company/Command/ResetUserPasswordCommand.php
@@ -12,11 +12,12 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 #[AsCommand(
     name: 'app:user:reset-password',
-    description: 'Сбрасывает пароль пользователя по email и выводит новый временный пароль.',
+    description: 'Resets a user password by email and displays a new temporary password.',
 )]
 final class ResetUserPasswordCommand extends Command
 {
@@ -30,22 +31,23 @@ final class ResetUserPasswordCommand extends Command
 
     protected function configure(): void
     {
-        $this->addArgument('email', InputArgument::REQUIRED, 'Email пользователя');
+        $this->addArgument('email', InputArgument::REQUIRED, 'User email');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $email = User::normalizeEmail((string) $input->getArgument('email'));
+        $escapedEmail = OutputFormatter::escape($email);
 
         if (false === filter_var($email, FILTER_VALIDATE_EMAIL)) {
-            $output->writeln(sprintf('<error>Некорректный формат email: "%s".</error>', $email));
+            $output->writeln(sprintf('<error>Invalid email format: "%s".</error>', $escapedEmail));
 
             return Command::FAILURE;
         }
 
         $user = $this->userRepository->findOneBy(['email' => $email]);
         if (null === $user) {
-            $output->writeln(sprintf('<error>Пользователь с email "%s" не найден.</error>', $email));
+            $output->writeln(sprintf('<error>User with email "%s" was not found.</error>', $escapedEmail));
 
             return Command::FAILURE;
         }
@@ -56,8 +58,8 @@ final class ResetUserPasswordCommand extends Command
         $user->setPassword($hashedPassword);
         $this->entityManager->flush();
 
-        $output->writeln(sprintf('<info>Пароль пользователя %s успешно обновлён.</info>', $email));
-        $output->writeln(sprintf('<comment>Новый временный пароль: %s</comment>', $plainPassword));
+        $output->writeln(sprintf('<info>Password for user %s has been updated.</info>', $escapedEmail));
+        $output->writeln(sprintf('<comment>New temporary password: %s</comment>', OutputFormatter::escape($plainPassword)));
 
         return Command::SUCCESS;
     }

--- a/site/tests/Unit/Company/Command/ResetUserPasswordCommandTest.php
+++ b/site/tests/Unit/Company/Command/ResetUserPasswordCommandTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Company\Command;
+
+use App\Company\Command\ResetUserPasswordCommand;
+use App\Company\Entity\User;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+final class ResetUserPasswordCommandTest extends TestCase
+{
+    public function testExecuteReturnsFailureWhenEmailFormatIsInvalid(): void
+    {
+        $repository = $this->createMock(UserRepository::class);
+        $hasher = $this->createMock(UserPasswordHasherInterface::class);
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+
+        $repository->expects(self::never())->method('findOneBy');
+        $hasher->expects(self::never())->method('hashPassword');
+        $entityManager->expects(self::never())->method('flush');
+
+        $tester = new CommandTester(new ResetUserPasswordCommand($repository, $hasher, $entityManager));
+        $exitCode = $tester->execute(['email' => 'not-an-email']);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString('Некорректный формат email', $tester->getDisplay());
+    }
+
+    public function testExecuteReturnsFailureWhenUserIsNotFound(): void
+    {
+        $repository = $this->createMock(UserRepository::class);
+        $hasher = $this->createMock(UserPasswordHasherInterface::class);
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+
+        $repository
+            ->expects(self::once())
+            ->method('findOneBy')
+            ->with(['email' => 'missing@example.com'])
+            ->willReturn(null)
+        ;
+
+        $hasher->expects(self::never())->method('hashPassword');
+        $entityManager->expects(self::never())->method('flush');
+
+        $tester = new CommandTester(new ResetUserPasswordCommand($repository, $hasher, $entityManager));
+        $exitCode = $tester->execute(['email' => 'missing@example.com']);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString('не найден', $tester->getDisplay());
+    }
+
+    public function testExecuteResetsPasswordAndFlushesEntityManager(): void
+    {
+        $repository = $this->createMock(UserRepository::class);
+        $hasher = $this->createMock(UserPasswordHasherInterface::class);
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+
+        $user = (new User('11111111-1111-1111-1111-111111111111'))
+            ->setEmail('test@example.com')
+            ->setPassword('old-hash');
+
+        $repository
+            ->expects(self::once())
+            ->method('findOneBy')
+            ->with(['email' => 'test@example.com'])
+            ->willReturn($user)
+        ;
+
+        $hasher
+            ->expects(self::once())
+            ->method('hashPassword')
+            ->with(self::identicalTo($user), self::isType('string'))
+            ->willReturn('new-hash')
+        ;
+
+        $entityManager->expects(self::once())->method('flush');
+
+        $tester = new CommandTester(new ResetUserPasswordCommand($repository, $hasher, $entityManager));
+        $exitCode = $tester->execute(['email' => 'TEST@example.com']);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertSame('new-hash', $user->getPassword());
+        self::assertStringContainsString('успешно обновлён', $tester->getDisplay());
+        self::assertMatchesRegularExpression('/Новый временный пароль:\s*\S+/', $tester->getDisplay());
+    }
+}

--- a/site/tests/Unit/Company/Command/ResetUserPasswordCommandTest.php
+++ b/site/tests/Unit/Company/Command/ResetUserPasswordCommandTest.php
@@ -29,7 +29,7 @@ final class ResetUserPasswordCommandTest extends TestCase
         $exitCode = $tester->execute(['email' => 'not-an-email']);
 
         self::assertSame(Command::FAILURE, $exitCode);
-        self::assertStringContainsString('Некорректный формат email', $tester->getDisplay());
+        self::assertStringContainsString('Invalid email format', $tester->getDisplay());
     }
 
     public function testExecuteReturnsFailureWhenUserIsNotFound(): void
@@ -52,7 +52,7 @@ final class ResetUserPasswordCommandTest extends TestCase
         $exitCode = $tester->execute(['email' => 'missing@example.com']);
 
         self::assertSame(Command::FAILURE, $exitCode);
-        self::assertStringContainsString('не найден', $tester->getDisplay());
+        self::assertStringContainsString('was not found', $tester->getDisplay());
     }
 
     public function testExecuteResetsPasswordAndFlushesEntityManager(): void
@@ -86,7 +86,7 @@ final class ResetUserPasswordCommandTest extends TestCase
 
         self::assertSame(Command::SUCCESS, $exitCode);
         self::assertSame('new-hash', $user->getPassword());
-        self::assertStringContainsString('успешно обновлён', $tester->getDisplay());
-        self::assertMatchesRegularExpression('/Новый временный пароль:\s*\S+/', $tester->getDisplay());
+        self::assertStringContainsString('has been updated', $tester->getDisplay());
+        self::assertMatchesRegularExpression('/New temporary password:\s*\S+/', $tester->getDisplay());
     }
 }


### PR DESCRIPTION
### Motivation

- Provide an administrator CLI tool to reset a user's password by email and emit a new temporary password for onboarding or recovery.
- Ensure the operation validates input, normalizes email addresses, and updates the persisted user password securely using the configured password hasher.
- Add automated coverage for the command to prevent regressions and verify behavior in invalid and success scenarios.

### Description

- Introduce `ResetUserPasswordCommand` in `site/src/Company/Command/ResetUserPasswordCommand.php` that registers the `app:user:reset-password` command, validates and normalizes the email with `User::normalizeEmail`, looks up the user via `UserRepository`, generates a random temporary password, hashes it with `UserPasswordHasherInterface`, updates the `User` entity, and flushes via `EntityManagerInterface` while printing results to stdout.
- Implement `generatePassword()` which produces a URL-safe base64 string from `random_bytes(12)` for the temporary password.
- Add unit tests in `site/tests/Unit/Company/Command/ResetUserPasswordCommandTest.php` covering invalid email format, user-not-found, and successful reset behavior including invocation of `hashPassword`, `flush`, and output assertions.

### Testing

- Added PHPUnit unit tests located at `site/tests/Unit/Company/Command/ResetUserPasswordCommandTest.php` that exercise invalid input, missing user, and successful reset flows.
- Ran the command tests with PHPUnit (targeting the `ResetUserPasswordCommandTest`) and they passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02a9ecd7c08323b9ed5a6b88df3a50)