### PR TITLE
Expose supplier SKU through DTOs and queries and surface in analytics

### DIFF
--- a/site/src/Marketplace/DTO/ListingMetaDTO.php
+++ b/site/src/Marketplace/DTO/ListingMetaDTO.php
@@ -11,5 +11,6 @@ final readonly class ListingMetaDTO
         public ?string $title,
         public string $sku,
         public string $marketplace,
+        public ?string $supplierSku = null,
     ) {}
 }

--- a/site/src/Marketplace/DTO/ListingSalesAggregateDTO.php
+++ b/site/src/Marketplace/DTO/ListingSalesAggregateDTO.php
@@ -15,5 +15,6 @@ final readonly class ListingSalesAggregateDTO
         public int $quantity,
         public string $costPriceTotal,
         public int $costPriceQuantity,
+        public ?string $supplierSku = null,
     ) {}
 }

--- a/site/src/Marketplace/Infrastructure/Query/ListingMetaQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/ListingMetaQuery.php
@@ -31,7 +31,8 @@ final readonly class ListingMetaQuery
                 l.id,
                 l.name            AS listing_title,
                 l.marketplace_sku AS listing_sku,
-                l.marketplace     AS listing_marketplace
+                l.marketplace     AS listing_marketplace,
+                l.supplier_sku    AS supplier_sku
             FROM marketplace_listings l
             WHERE l.id IN (:ids)
               AND l.company_id = :companyId
@@ -50,6 +51,7 @@ final readonly class ListingMetaQuery
                 title:       $row['listing_title'],
                 sku:         $row['listing_sku'],
                 marketplace: $row['listing_marketplace'],
+                supplierSku: $row['supplier_sku'] !== null ? (string) $row['supplier_sku'] : null,
             );
         }
 

--- a/site/src/Marketplace/Infrastructure/Query/ListingSalesAggregateQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/ListingSalesAggregateQuery.php
@@ -33,17 +33,20 @@ final readonly class ListingSalesAggregateQuery
                 l.name                AS listing_title,
                 l.marketplace_sku     AS listing_sku,
                 l.marketplace         AS listing_marketplace,
+                l.supplier_sku        AS supplier_sku,
                 SUM(s.total_revenue)  AS revenue,
                 SUM(s.quantity)       AS quantity,
                 SUM(CASE WHEN s.cost_price IS NOT NULL THEN s.cost_price * s.quantity ELSE 0 END) AS cost_price_total,
                 SUM(CASE WHEN s.cost_price IS NOT NULL THEN s.quantity ELSE 0 END) AS cost_price_quantity
             FROM marketplace_sales s
-            JOIN marketplace_listings l ON l.id = s.listing_id
+            JOIN marketplace_listings l
+              ON l.id = s.listing_id
+             AND l.company_id = s.company_id
             WHERE s.company_id = :companyId
               AND s.sale_date >= :periodFrom
               AND s.sale_date <= :periodTo
               {$mpFilter}
-            GROUP BY s.listing_id, l.name, l.marketplace_sku, l.marketplace
+            GROUP BY s.listing_id, l.name, l.marketplace_sku, l.marketplace, l.supplier_sku
             SQL,
             array_filter([
                 'companyId'   => $companyId,
@@ -64,6 +67,7 @@ final readonly class ListingSalesAggregateQuery
                 quantity:          (int) $row['quantity'],
                 costPriceTotal:    (string) $row['cost_price_total'],
                 costPriceQuantity: (int) $row['cost_price_quantity'],
+                supplierSku:       $row['supplier_sku'] !== null ? (string) $row['supplier_sku'] : null,
             );
         }
 

--- a/site/src/MarketplaceAnalytics/Infrastructure/Query/UnitExtendedQuery.php
+++ b/site/src/MarketplaceAnalytics/Infrastructure/Query/UnitExtendedQuery.php
@@ -98,6 +98,7 @@ final readonly class UnitExtendedQuery
             $title = $sale?->title ?? $meta?->title ?? '';
             $sku = $sale?->sku ?? $meta?->sku ?? '';
             $mp = $sale?->marketplace ?? $meta?->marketplace ?? '';
+            $sellerArticle = $sale?->supplierSku ?? $meta?->supplierSku ?? '';
 
             // Classify costs
             $commission = 0.0;
@@ -148,6 +149,7 @@ final readonly class UnitExtendedQuery
                 'listingId' => $listingId,
                 'title' => $title,
                 'sku' => $sku,
+                'sellerArticle' => $sellerArticle,
                 'marketplace' => $mp,
                 'revenue' => round($revenue, 2),
                 'quantity' => $quantity,


### PR DESCRIPTION
### Motivation
- Surface the supplier (seller) SKU alongside listing metadata and sales aggregates so analytics can display the seller article identifier.
- Ensure the sales aggregation query joins listings by company and groups on the new `supplier_sku` to avoid incorrect aggregation across companies.

### Description
- Added a nullable `supplierSku` property (default `null`) to `ListingMetaDTO` and `ListingSalesAggregateDTO`.
- Selected `supplier_sku` in `ListingMetaQuery` and `ListingSalesAggregateQuery` and mapped it into the new DTO fields with null coercion.
- Tightened the join in `ListingSalesAggregateQuery` to `ON l.id = s.listing_id AND l.company_id = s.company_id` and added `l.supplier_sku` to the `GROUP BY` clause.
- Propagated the supplier SKU into the analytics output in `UnitExtendedQuery` as `sellerArticle`, preferring the sales source and falling back to listing metadata.

### Testing
- Ran the PHP unit test suite with `vendor/bin/phpunit` and all tests passed.
- Ran static analysis with `vendor/bin/phpstan` and no new errors were reported.
- Ran the project linter/formatter and there were no reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04082479cc83239a65f265fd673714)