### PR TITLE
Frontend: add “Артикул” column to Unit Extended table

### DIFF
--- a/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedTable.tsx
+++ b/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedTable.tsx
@@ -8,6 +8,7 @@ import { useFixedHeader } from './useFixedHeader';
 type SortField =
     | 'sku'
     | 'title'
+    | 'sellerArticle'
     | 'revenue'
     | 'quantity'
     | 'returnsTotal'
@@ -92,6 +93,7 @@ interface ExpandedState {
 const HEADERS: { field: SortField; label: string; align?: string; tooltip?: string }[] = [
     { field: 'sku', label: 'SKU' },
     { field: 'title', label: 'Наименование' },
+    { field: 'sellerArticle', label: 'Артикул' },
     { field: 'revenue', label: 'Выручка', align: 'text-end' },
     { field: 'quantity', label: 'Кол-во', align: 'text-end' },
     { field: 'returnsTotal', label: 'Возвраты', align: 'text-end' },
@@ -114,6 +116,9 @@ function comparator(a: UnitExtendedItem, b: UnitExtendedItem, field: SortField):
     }
     if (field === 'sku') {
         return a.sku.localeCompare(b.sku, 'ru');
+    }
+    if (field === 'sellerArticle') {
+        return (a.sellerArticle ?? '').localeCompare(b.sellerArticle ?? '', 'ru');
     }
     const valA = (a[field] as number | null) ?? -Infinity;
     const valB = (b[field] as number | null) ?? -Infinity;
@@ -299,6 +304,9 @@ const UnitExtendedTable: React.FC<UnitExtendedTableProps> = ({ items, totals, is
                                         <td className="ue-ext-frozen ue-ext-frozen-title">
                                             <div className="text-truncate">{row.title || '—'}</div>
                                         </td>
+                                        <td>
+                                            <div className="text-truncate">{row.sellerArticle || '—'}</div>
+                                        </td>
                                         <td className="text-end">{formatMoney(row.revenue)}</td>
                                         <td className="text-end">{row.quantity.toLocaleString('ru-RU')}</td>
                                         <td className="text-end text-red">{formatMoney(row.returnsTotal)}</td>
@@ -371,6 +379,7 @@ const UnitExtendedTable: React.FC<UnitExtendedTableProps> = ({ items, totals, is
                             <tr className="fw-bold">
                                 <td className="ue-ext-frozen ue-ext-frozen-sku"></td>
                                 <td className="ue-ext-frozen ue-ext-frozen-title">Итого</td>
+                                <td></td>
                                 <td className="text-end">{formatMoney(totals.revenue)}</td>
                                 <td className="text-end">{totals.quantity.toLocaleString('ru-RU')}</td>
                                 <td className="text-end text-red">{formatMoney(totals.returnsTotal)}</td>

--- a/site/assets/react/marketplace-analytics/unit-extended/unitExtended.types.ts
+++ b/site/assets/react/marketplace-analytics/unit-extended/unitExtended.types.ts
@@ -18,6 +18,7 @@ export interface UnitExtendedItem {
     listingId: string;
     title: string;
     sku: string;
+    sellerArticle: string;
     marketplace: string;
     revenue: number;
     quantity: number;


### PR DESCRIPTION
### Motivation
- Backend now returns `sellerArticle` in the `/api/marketplace-analytics/unit-extended` rows and the table must display this seller article as a new column immediately before `Выручка` without touching existing `sku` semantics or calculations.

### Description
- Added `sellerArticle: string` to `UnitExtendedItem` in `site/assets/react/marketplace-analytics/unit-extended/unitExtended.types.ts` to type the new API field.
- Inserted a new sortable header `{ field: 'sellerArticle', label: 'Артикул' }` immediately before `Выручка` in `site/assets/react/marketplace-analytics/unit-extended/UnitExtendedTable.tsx` and added `sellerArticle` to the `SortField` union.
- Implemented string comparator handling for `sellerArticle` (empty values treated as `''`), rendered the cell as `{row.sellerArticle || '—'}` placed before the revenue cell, and added an empty `<td>` in the totals row to preserve footer alignment.

### Testing
- Ran `npx tsc --noEmit` (project-wide TypeScript check): it failed due to pre-existing unrelated TypeScript errors outside the modified files; the change itself is type-correct against the local types added.
- Ran `npm run build` from `site` and the Vite production build completed successfully (`vite build` succeeded).
- `npm run typecheck` is not defined in `site/package.json`, so it was not run.

Notes: the new column `Артикул` appears before `Выручка`, `sku` was not renamed or modified, and no calculations/formatting/visual statuses were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a040d29b8848323986e32207bad7a28)