### PR TITLE
Add `Артикул` (sellerArticle) column to Unit Extended XLSX export

### DIFF
--- a/site/src/MarketplaceAnalytics/Infrastructure/Export/UnitExtendedXlsxExporter.php
+++ b/site/src/MarketplaceAnalytics/Infrastructure/Export/UnitExtendedXlsxExporter.php
@@ -31,6 +31,7 @@ final readonly class UnitExtendedXlsxExporter
         ['label' => 'SKU',             'field' => 'sku',            'type' => 'string'],
         ['label' => 'Наименование',    'field' => 'title',          'type' => 'string'],
         ['label' => 'Маркетплейс',     'field' => 'marketplace',    'type' => 'string'],
+        ['label' => 'Артикул',         'field' => 'sellerArticle',  'type' => 'string'],
         ['label' => 'Выручка',         'field' => 'revenue',        'type' => 'money'],
         ['label' => 'Кол-во',          'field' => 'quantity',       'type' => 'integer'],
         ['label' => 'Возвраты',        'field' => 'returnsTotal',   'type' => 'money'],
@@ -152,7 +153,7 @@ final readonly class UnitExtendedXlsxExporter
             }
 
             // Totals are computed per-listing and not aggregated for these fields.
-            if (in_array($column['field'], ['title', 'marketplace', 'costPriceUnit'], true)) {
+            if (in_array($column['field'], ['title', 'marketplace', 'sellerArticle', 'costPriceUnit'], true)) {
                 $cells[] = Cell::fromValue('', $styles['blank']);
 
                 continue;


### PR DESCRIPTION
### Motivation
- Добавить в XLSX-экспорт Unit Extended колонку `Артикул` с данными `sellerArticle` и расположить её строго перед колонкой `Выручка` для корректного отображения артикула поставщика в выгрузке.

### Description
- В `site/src/MarketplaceAnalytics/Infrastructure/Export/UnitExtendedXlsxExporter.php` в `COLUMNS` добавлена колонка `['label' => 'Артикул', 'field' => 'sellerArticle', 'type' => 'string']` перед `Выручка`, и в `buildTotalsRow` добавлен `sellerArticle` в список полей, которые на строке `ИТОГО` заполняются пустой ячейкой; при этом не изменялись `sku`, `UnitExtendedQuery`, контроллер экспорта, название листа, форматы денег/процентов, формулы и расчёты.

### Testing
- Выполнена попытка запустить тест: `php bin/phpunit tests/Unit/MarketplaceAnalytics/Infrastructure/Export/UnitExtendedXlsxExporterTest.php` из каталога `site`, но запуск не прошёл в этом окружении из-за отсутствия скрипта PHPUnit Bridge: `vendor/symfony/phpunit-bridge/bin/simple-phpunit.php`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04100c79908323869de90e36248d6d)