### PR TITLE
Place "Артикул" column after "Наименование" in unit extended XLSX export and adjust tests

### DIFF
--- a/site/src/MarketplaceAnalytics/Infrastructure/Export/UnitExtendedXlsxExporter.php
+++ b/site/src/MarketplaceAnalytics/Infrastructure/Export/UnitExtendedXlsxExporter.php
@@ -30,8 +30,8 @@ final readonly class UnitExtendedXlsxExporter
     private const COLUMNS = [
         ['label' => 'SKU',             'field' => 'sku',            'type' => 'string'],
         ['label' => 'Наименование',    'field' => 'title',          'type' => 'string'],
-        ['label' => 'Маркетплейс',     'field' => 'marketplace',    'type' => 'string'],
         ['label' => 'Артикул',         'field' => 'sellerArticle',  'type' => 'string'],
+        ['label' => 'Маркетплейс',     'field' => 'marketplace',    'type' => 'string'],
         ['label' => 'Выручка',         'field' => 'revenue',        'type' => 'money'],
         ['label' => 'Кол-во',          'field' => 'quantity',       'type' => 'integer'],
         ['label' => 'Возвраты',        'field' => 'returnsTotal',   'type' => 'money'],

--- a/site/tests/MarketplaceAnalytics/Infrastructure/Query/UnitExtendedQueryTest.php
+++ b/site/tests/MarketplaceAnalytics/Infrastructure/Query/UnitExtendedQueryTest.php
@@ -89,6 +89,9 @@ final class UnitExtendedQueryTest extends TestCase
         $this->stubSales([
             new ListingSalesAggregateDTO('l-3', 'Без РР', 'SKU-3', 'ozon', '500.00', 2, '100.00', 2),
         ]);
+        $this->stubMeta([
+            new ListingMetaDTO('l-3', 'Без РР', 'SKU-3', 'ozon', 'SUP-3'),
+        ]);
         // No ad spend for this listing
         $this->stubAdSpend([]);
         $this->stubTotalAdSpend('0');
@@ -97,9 +100,17 @@ final class UnitExtendedQueryTest extends TestCase
 
         $row = $this->findRow($result['items'], 'l-3');
         self::assertNotNull($row);
+        self::assertArrayHasKey('sellerArticle', $row);
+        self::assertSame('SUP-3', $row['sellerArticle']);
+        self::assertSame('SKU-3', $row['sku']);
         self::assertSame(0.0, $row['adSpend']);
         // revenue > 0, adSpend = 0 → drrPercent = 0.0 (not null)
         self::assertSame(0.0, $row['drrPercent']);
+        self::assertSame(500.0, $row['revenue']);
+        self::assertSame(400.0, $row['profit']);
+        self::assertSame(0.0, $result['totals']['adSpend']);
+        self::assertSame(500.0, $result['totals']['revenue']);
+        self::assertSame(400.0, $result['totals']['profit']);
     }
 
     public function testListingWithAdSpendOnlyDoesNotAppearInRows(): void

--- a/site/tests/Unit/MarketplaceAnalytics/Infrastructure/Export/UnitExtendedXlsxExporterTest.php
+++ b/site/tests/Unit/MarketplaceAnalytics/Infrastructure/Export/UnitExtendedXlsxExporterTest.php
@@ -32,6 +32,7 @@ final class UnitExtendedXlsxExporterTest extends TestCase
                 'listingId' => 'l-1',
                 'title' => 'Товар А',
                 'sku' => 'SKU-A',
+                'sellerArticle' => 'ART-A',
                 'marketplace' => 'ozon',
                 'revenue' => 1000.0,
                 'quantity' => 5,
@@ -52,6 +53,7 @@ final class UnitExtendedXlsxExporterTest extends TestCase
                 'listingId' => 'l-2',
                 'title' => 'Товар Б',
                 'sku' => 'SKU-B',
+                'sellerArticle' => 'ART-B',
                 'marketplace' => 'ozon',
                 'revenue' => 500.0,
                 'quantity' => 2,
@@ -72,6 +74,7 @@ final class UnitExtendedXlsxExporterTest extends TestCase
                 'listingId' => 'l-3',
                 'title' => 'Товар В',
                 'sku' => 'SKU-C',
+                'sellerArticle' => '',
                 'marketplace' => 'wildberries',
                 'revenue' => 0.0,
                 'quantity' => 0,
@@ -140,14 +143,33 @@ final class UnitExtendedXlsxExporterTest extends TestCase
         }
 
         self::assertNotNull($headerRowIndex, 'Header row with "SKU" not found');
-        self::assertContains('Наименование', $rows[$headerRowIndex]);
-        self::assertContains('ROI %', $rows[$headerRowIndex]);
+        $header = $rows[$headerRowIndex];
+        self::assertContains('Наименование', $header);
+        self::assertContains('ROI %', $header);
+
+        $skuColumnIndex = array_search('SKU', $header, true);
+        $titleColumnIndex = array_search('Наименование', $header, true);
+        $articleColumnIndex = array_search('Артикул', $header, true);
+        $marketplaceColumnIndex = array_search('Маркетплейс', $header, true);
+        $revenueColumnIndex = array_search('Выручка', $header, true);
+
+        self::assertNotFalse($skuColumnIndex);
+        self::assertNotFalse($titleColumnIndex);
+        self::assertNotFalse($articleColumnIndex);
+        self::assertNotFalse($marketplaceColumnIndex);
+        self::assertNotFalse($revenueColumnIndex);
+
+        self::assertSame($titleColumnIndex + 1, $articleColumnIndex, '"Артикул" должен быть сразу после "Наименование"');
+        self::assertLessThan($revenueColumnIndex, $articleColumnIndex, '"Артикул" должен быть перед "Выручка"');
 
         $dataRows = array_slice($rows, $headerRowIndex + 1, 3);
         self::assertCount(3, $dataRows, 'Expected exactly 3 data rows');
 
         $skus = array_map(static fn (array $row): string => (string) ($row[0] ?? ''), $dataRows);
         self::assertSame(['SKU-A', 'SKU-B', 'SKU-C'], $skus);
+        self::assertSame('ART-A', (string) ($dataRows[0][$articleColumnIndex] ?? ''));
+        self::assertSame('ART-B', (string) ($dataRows[1][$articleColumnIndex] ?? ''));
+        self::assertSame('', (string) ($dataRows[2][$articleColumnIndex] ?? ''));
 
         $totalsRow = $rows[$headerRowIndex + 4];
         self::assertSame('ИТОГО', (string) $totalsRow[0]);


### PR DESCRIPTION
### Motivation

- Make the seller article (`Артикул`) column appear immediately after the product title (`Наименование`) in the Unit Extended XLSX export to match layout requirements. 

### Description

- Reordered column definitions in `UnitExtendedXlsxExporter` so `sellerArticle` (`Артикул`) comes right after `title` (`Наименование`) and before `marketplace`/`revenue` columns. 
- Updated `UnitExtendedXlsxExporterTest` to include `sellerArticle` values in fixtures and to assert header positions and per-row article values. 
- Updated `UnitExtendedQueryTest` to stub `ListingMetaDTO` with `sellerArticle` for a case without ad spend and to add assertions verifying `sellerArticle`, SKU, revenue, profit and totals. 

### Testing

- Ran the updated unit test classes with `phpunit --filter UnitExtendedXlsxExporterTest` and `phpunit --filter UnitExtendedQueryTest`, and both test classes passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0411488c348323a2b4d4afa97eaa41)