### PR TITLE
Add Wildberries cost categories and analytics group resolver with unit tests

### DIFF
--- a/site/src/Marketplace/Domain/WbCostCategory.php
+++ b/site/src/Marketplace/Domain/WbCostCategory.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Domain;
+
+final readonly class WbCostCategory
+{
+    public function __construct(
+        public string $code,
+        public string $name,
+        public string $widgetGroup,
+        public string $breakdownGroup,
+        public string $unitBucket,
+    ) {}
+
+    /**
+     * @return list<self>
+     */
+    public static function all(): array
+    {
+        /** @var list<self>|null $cache */
+        static $cache = null;
+
+        if ($cache !== null) {
+            return $cache;
+        }
+
+        $cache = [
+            new self('commission', 'Комиссия маркетплейса', 'Вознаграждение', 'Вознаграждение', 'commission'),
+            new self('logistics_delivery', 'Логистика до покупателя', 'Услуги доставки и FBO', 'Услуги доставки', 'logistics'),
+            new self('logistics_return', 'Логистика возврат', 'Услуги доставки и FBO', 'Услуги доставки', 'logistics'),
+            new self('warehouse_logistics', 'Логистика складские операции', 'Услуги доставки и FBO', 'Услуги FBO', 'logistics'),
+            new self('storage', 'Хранение WB', 'Услуги доставки и FBO', 'Услуги FBO', 'other'),
+            new self('pvz_processing', 'Логистика обработка на ПВЗ', 'Услуги партнёров', 'Услуги партнёров', 'other'),
+            new self('acquiring', 'Эквайринг', 'Услуги партнёров', 'Услуги партнёров', 'other'),
+            new self('penalty', 'Штраф WB', 'Другие услуги и штрафы', 'Другие услуги и штрафы', 'other'),
+            new self('wb_okazanie_uslug_wb_prodvizhenie', 'Оказание услуг «WB Продвижение»', 'Продвижение и реклама', 'Продвижение и реклама', 'other'),
+            new self('wb_spisanie_za_otzyv', 'Списание за отзыв', 'Продвижение и реклама', 'Продвижение и реклама', 'other'),
+            new self('wb_vozvrat_neispolzovannogo_ostatka_avansa_za_uslu', 'Возврат неиспользованного остатка аванса за услугу "Баллы за отзывы"', 'Продвижение и реклама', 'Продвижение и реклама', 'other'),
+            new self('wb_loyalty_discount_compensation', 'Компенсация скидки по программе лояльности WB', 'Другие услуги и штрафы', 'Компенсации и декомпенсации', 'other'),
+            new self('product_processing', 'Обработка товара', 'Услуги доставки и FBO', 'Услуги FBO', 'other'),
+        ];
+
+        return $cache;
+    }
+
+    /**
+     * @return array<string, self>
+     */
+    public static function byCode(): array
+    {
+        /** @var array<string, self>|null $cache */
+        static $cache = null;
+
+        if ($cache !== null) {
+            return $cache;
+        }
+
+        $cache = [];
+        foreach (self::all() as $category) {
+            $cache[$category->code] = $category;
+        }
+
+        return $cache;
+    }
+}

--- a/site/src/MarketplaceAnalytics/Application/Service/MarketplaceCostAnalyticsGroupResolver.php
+++ b/site/src/MarketplaceAnalytics/Application/Service/MarketplaceCostAnalyticsGroupResolver.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAnalytics\Application\Service;
+
+use App\Marketplace\Domain\OzonCostCategory;
+use App\Marketplace\Domain\WbCostCategory;
+use App\Marketplace\Enum\MarketplaceType;
+
+final class MarketplaceCostAnalyticsGroupResolver
+{
+    public function resolveWidgetGroup(?string $marketplace, string $code, string $name): string
+    {
+        if ($marketplace === MarketplaceType::WILDBERRIES->value) {
+            return WbCostCategory::byCode()[$code]->widgetGroup ?? 'Другие услуги и штрафы';
+        }
+
+        if ($marketplace === MarketplaceType::OZON->value) {
+            foreach (OzonCostCategory::all() as $c) {
+                if ($c->code === $code) {
+                    return $c->widgetGroup;
+                }
+            }
+
+            return 'Другие услуги и штрафы';
+        }
+
+        foreach (OzonCostCategory::all() as $c) {
+            if ($c->code === $code) {
+                return $c->widgetGroup;
+            }
+        }
+
+        return WbCostCategory::byCode()[$code]->widgetGroup ?? 'Другие услуги и штрафы';
+    }
+
+    public function resolveBreakdownGroup(?string $marketplace, string $code, string $name): string
+    {
+        if ($marketplace === MarketplaceType::WILDBERRIES->value) {
+            return WbCostCategory::byCode()[$code]->breakdownGroup ?? 'Другие услуги и штрафы';
+        }
+
+        if ($marketplace === MarketplaceType::OZON->value) {
+            foreach (OzonCostCategory::all() as $c) {
+                if ($c->code === $code) {
+                    return $c->xlsxGroup;
+                }
+            }
+
+            return 'Другие услуги и штрафы';
+        }
+
+        foreach (OzonCostCategory::all() as $c) {
+            if ($c->code === $code) {
+                return $c->xlsxGroup;
+            }
+        }
+
+        return WbCostCategory::byCode()[$code]->breakdownGroup ?? 'Другие услуги и штрафы';
+    }
+
+    public function resolveUnitBucket(?string $marketplace, string $code, string $name): string
+    {
+        if ($marketplace === MarketplaceType::WILDBERRIES->value) {
+            return WbCostCategory::byCode()[$code]->unitBucket ?? 'other';
+        }
+
+        if ($marketplace === MarketplaceType::OZON->value) {
+            if (in_array($code, ['ozon_sale_commission', 'ozon_brand_commission'], true)) {
+                return 'commission';
+            }
+
+            foreach (OzonCostCategory::all() as $c) {
+                if ($c->code === $code) {
+                    return $c->xlsxGroup === 'Услуги доставки' ? 'logistics' : 'other';
+                }
+            }
+
+            return 'other';
+        }
+
+        foreach (OzonCostCategory::all() as $c) {
+            if ($c->code === $code) {
+                if (in_array($c->code, ['ozon_sale_commission', 'ozon_brand_commission'], true)) {
+                    return 'commission';
+                }
+
+                return $c->xlsxGroup === 'Услуги доставки' ? 'logistics' : 'other';
+            }
+        }
+
+        return WbCostCategory::byCode()[$code]->unitBucket ?? 'other';
+    }
+}

--- a/site/tests/Unit/Marketplace/Domain/WbCostCategoryTest.php
+++ b/site/tests/Unit/Marketplace/Domain/WbCostCategoryTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Domain;
+
+use App\Marketplace\Domain\WbCostCategory;
+use PHPUnit\Framework\TestCase;
+
+final class WbCostCategoryTest extends TestCase
+{
+    public function testByCodeContainsKnownCategories(): void
+    {
+        $byCode = WbCostCategory::byCode();
+
+        $this->assertArrayHasKey('commission', $byCode);
+        $this->assertArrayHasKey('logistics_delivery', $byCode);
+        $this->assertArrayHasKey('warehouse_logistics', $byCode);
+        $this->assertArrayHasKey('wb_loyalty_discount_compensation', $byCode);
+        $this->assertArrayHasKey('product_processing', $byCode);
+    }
+
+    public function testUnitBucketBelongsToKnownSet(): void
+    {
+        $allowed = ['commission', 'logistics', 'other'];
+
+        foreach (WbCostCategory::all() as $category) {
+            $this->assertContains($category->unitBucket, $allowed);
+        }
+    }
+}

--- a/site/tests/Unit/MarketplaceAnalytics/Application/Service/MarketplaceCostAnalyticsGroupResolverTest.php
+++ b/site/tests/Unit/MarketplaceAnalytics/Application/Service/MarketplaceCostAnalyticsGroupResolverTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MarketplaceAnalytics\Application\Service;
+
+use App\MarketplaceAnalytics\Application\Service\MarketplaceCostAnalyticsGroupResolver;
+use PHPUnit\Framework\TestCase;
+
+final class MarketplaceCostAnalyticsGroupResolverTest extends TestCase
+{
+    private MarketplaceCostAnalyticsGroupResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new MarketplaceCostAnalyticsGroupResolver();
+    }
+
+    public function testWbCommissionGroupsAndBucket(): void
+    {
+        $this->assertSame('Вознаграждение', $this->resolver->resolveWidgetGroup('wildberries', 'commission', ''));
+        $this->assertSame('Вознаграждение', $this->resolver->resolveBreakdownGroup('wildberries', 'commission', ''));
+        $this->assertSame('commission', $this->resolver->resolveUnitBucket('wildberries', 'commission', ''));
+    }
+
+    public function testWbLogisticsDeliveryGroupsAndBucket(): void
+    {
+        $this->assertSame('Услуги доставки и FBO', $this->resolver->resolveWidgetGroup('wildberries', 'logistics_delivery', ''));
+        $this->assertSame('Услуги доставки', $this->resolver->resolveBreakdownGroup('wildberries', 'logistics_delivery', ''));
+        $this->assertSame('logistics', $this->resolver->resolveUnitBucket('wildberries', 'logistics_delivery', ''));
+    }
+
+    public function testWbWarehouseLogisticsBreakdownAndBucket(): void
+    {
+        $this->assertSame('Услуги FBO', $this->resolver->resolveBreakdownGroup('wildberries', 'warehouse_logistics', ''));
+        $this->assertSame('logistics', $this->resolver->resolveUnitBucket('wildberries', 'warehouse_logistics', ''));
+    }
+
+    public function testWbAcquiringGroupAndOtherBucket(): void
+    {
+        $this->assertSame('Услуги партнёров', $this->resolver->resolveWidgetGroup('wildberries', 'acquiring', ''));
+        $this->assertSame('other', $this->resolver->resolveUnitBucket('wildberries', 'acquiring', ''));
+    }
+
+    public function testWbPromotionCodesAndOtherBucket(): void
+    {
+        $this->assertSame('Продвижение и реклама', $this->resolver->resolveWidgetGroup('wildberries', 'wb_okazanie_uslug_wb_prodvizhenie', ''));
+        $this->assertSame('other', $this->resolver->resolveUnitBucket('wildberries', 'wb_okazanie_uslug_wb_prodvizhenie', ''));
+
+        $this->assertSame('Продвижение и реклама', $this->resolver->resolveWidgetGroup('wildberries', 'wb_spisanie_za_otzyv', ''));
+        $this->assertSame('other', $this->resolver->resolveUnitBucket('wildberries', 'wb_spisanie_za_otzyv', ''));
+    }
+
+    public function testWbLoyaltyCompensationBreakdownAndBucket(): void
+    {
+        $this->assertSame('Компенсации и декомпенсации', $this->resolver->resolveBreakdownGroup('wildberries', 'wb_loyalty_discount_compensation', ''));
+        $this->assertSame('other', $this->resolver->resolveUnitBucket('wildberries', 'wb_loyalty_discount_compensation', ''));
+    }
+
+    public function testUnknownWbCodeFallsBackToDefault(): void
+    {
+        $this->assertSame('Другие услуги и штрафы', $this->resolver->resolveWidgetGroup('wildberries', 'unknown_code', ''));
+        $this->assertSame('Другие услуги и штрафы', $this->resolver->resolveBreakdownGroup('wildberries', 'unknown_code', ''));
+        $this->assertSame('other', $this->resolver->resolveUnitBucket('wildberries', 'unknown_code', ''));
+    }
+
+    public function testOzonSaleCommissionIsCommissionBucket(): void
+    {
+        $this->assertSame('commission', $this->resolver->resolveUnitBucket('ozon', 'ozon_sale_commission', ''));
+    }
+
+    public function testOzonDeliveryGroupIsLogisticsBucket(): void
+    {
+        $this->assertSame('logistics', $this->resolver->resolveUnitBucket('ozon', 'ozon_logistic_delivery', ''));
+    }
+
+    public function testUnknownMarketplaceAndNullFallbackDoNotFail(): void
+    {
+        $this->assertSame('other', $this->resolver->resolveUnitBucket('unknown', 'unknown_code', ''));
+        $this->assertSame('Другие услуги и штрафы', $this->resolver->resolveWidgetGroup(null, 'unknown_code', ''));
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a canonical set of Wildberries cost categories and a resolver to map marketplace cost codes to analytics groups and unit buckets for reporting.
- Support consistent grouping logic across marketplaces (Wildberries and Ozon) so analytics widgets and breakdowns can be derived deterministically.

### Description

- Add `WbCostCategory` domain class with `all()` and `byCode()` helpers containing known Wildberries cost category definitions and metadata (`code`, `name`, `widgetGroup`, `breakdownGroup`, `unitBucket`).
- Add `MarketplaceCostAnalyticsGroupResolver` service with `resolveWidgetGroup`, `resolveBreakdownGroup`, and `resolveUnitBucket` methods that handle `wildberries`, `ozon`, and fallback/unknown marketplaces and map codes to the appropriate groups and buckets.
- Add unit tests `WbCostCategoryTest` and `MarketplaceCostAnalyticsGroupResolverTest` covering presence of known WB codes, allowed `unitBucket` values, and expected resolver behavior for WB, OZON, unknown, and special-case OZON commission/delivery codes.

### Testing

- Ran unit tests in `tests/Unit/Marketplace/Domain/WbCostCategoryTest.php` and they succeeded verifying known codes and allowed `unitBucket` values.
- Ran unit tests in `tests/Unit/MarketplaceAnalytics/Application/Service/MarketplaceCostAnalyticsGroupResolverTest.php` and they succeeded verifying resolver outputs for WB, OZON, unknown, and special-case codes.
- The new tests exercise `WbCostCategory::all()`, `WbCostCategory::byCode()`, and the resolver methods `resolveWidgetGroup`, `resolveBreakdownGroup`, and `resolveUnitBucket` and all assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0473f33ac08323a10ff55f873ba422)