### PR TITLE
Group marketplace cost categories by marketplace and use group resolver

### DIFF
--- a/site/src/MarketplaceAnalytics/Infrastructure/Query/WidgetSummaryQuery.php
+++ b/site/src/MarketplaceAnalytics/Infrastructure/Query/WidgetSummaryQuery.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\MarketplaceAnalytics\Infrastructure\Query;
 
 use App\Marketplace\Facade\MarketplaceFacade;
-use App\MarketplaceAnalytics\Application\Service\WidgetServiceGroupMap;
+use App\MarketplaceAnalytics\Application\Service\MarketplaceCostAnalyticsGroupResolver;
 use Doctrine\DBAL\Connection;
 
 /**
@@ -21,8 +21,6 @@ use Doctrine\DBAL\Connection;
  */
 final readonly class WidgetSummaryQuery
 {
-    private const FALLBACK_GROUP = 'Другие услуги и штрафы';
-
     /** @var list<string> */
     private const WIDGET_GROUPS = [
         'Вознаграждение',
@@ -35,6 +33,7 @@ final readonly class WidgetSummaryQuery
     public function __construct(
         private MarketplaceFacade $marketplaceFacade,
         private Connection $connection,
+        private MarketplaceCostAnalyticsGroupResolver $groupResolver,
     ) {
     }
 
@@ -59,7 +58,6 @@ final readonly class WidgetSummaryQuery
         $returns = $this->marketplaceFacade->getReturnAggregatesByListing($companyId, $marketplace, $dateFrom, $dateTo);
         $costRows = $this->getCostAggregates($companyId, $marketplace, $dateFrom, $dateTo);
 
-        $codeToGroup = WidgetServiceGroupMap::getCategoryToWidgetGroup();
 
         $revenue = 0.0;
         $returnsTotal = 0.0;
@@ -94,7 +92,8 @@ final readonly class WidgetSummaryQuery
             $stornoAmt = (float) $row['storno_amount'];
             $netAmt = (float) $row['net_amount'];
 
-            $group = $codeToGroup[$code] ?? self::FALLBACK_GROUP;
+            $marketplaceFromRow = (string) $row['marketplace'];
+            $group = $this->groupResolver->resolveWidgetGroup($marketplaceFromRow, $code, $name);
 
             $groups[$group]['costsAmount'] += $costsAmt;
             $groups[$group]['stornoAmount'] += $stornoAmt;
@@ -102,8 +101,10 @@ final readonly class WidgetSummaryQuery
 
             // Агрегируем одинаковые categoryCode внутри группы
             // (на всякий случай — SQL уже группирует по cc.code, cc.name)
-            if (!isset($groups[$group]['categories'][$code])) {
-                $groups[$group]['categories'][$code] = [
+            $categoryKey = $marketplaceFromRow . ':' . $code;
+
+            if (!isset($groups[$group]['categories'][$categoryKey])) {
+                $groups[$group]['categories'][$categoryKey] = [
                     'code'         => $code,
                     'name'         => $name,
                     'costsAmount'  => 0.0,
@@ -112,9 +113,9 @@ final readonly class WidgetSummaryQuery
                 ];
             }
 
-            $groups[$group]['categories'][$code]['costsAmount'] += $costsAmt;
-            $groups[$group]['categories'][$code]['stornoAmount'] += $stornoAmt;
-            $groups[$group]['categories'][$code]['netAmount'] += $netAmt;
+            $groups[$group]['categories'][$categoryKey]['costsAmount'] += $costsAmt;
+            $groups[$group]['categories'][$categoryKey]['stornoAmount'] += $stornoAmt;
+            $groups[$group]['categories'][$categoryKey]['netAmount'] += $netAmt;
         }
 
         // Build widgetGroups list with rounding and sorting
@@ -180,6 +181,7 @@ final readonly class WidgetSummaryQuery
      * где бэкфилл-миграция сохранила положительные компенсации как charge.
      *
      * @return list<array{
+     *     marketplace: string,
      *     category_code: string,
      *     category_name: string,
      *     net_amount: string,
@@ -203,6 +205,7 @@ final readonly class WidgetSummaryQuery
         $rows = $this->connection->fetchAllAssociative(
             <<<SQL
             SELECT
+                marketplace,
                 category_code,
                 category_name,
                 SUM(CASE WHEN effective_op = 'storno' THEN  ABS(amount) ELSE -ABS(amount) END) AS net_amount,
@@ -210,6 +213,7 @@ final readonly class WidgetSummaryQuery
                 SUM(CASE WHEN effective_op = 'storno' THEN  ABS(amount) ELSE 0             END) AS storno_amount
             FROM (
                 SELECT
+                    c.marketplace AS marketplace,
                     cc.code  AS category_code,
                     cc.name  AS category_name,
                     c.amount AS amount,
@@ -225,7 +229,7 @@ final readonly class WidgetSummaryQuery
                   AND c.cost_date <= :periodTo
                   {$mpFilter}
             ) AS normalized
-            GROUP BY category_code, category_name
+            GROUP BY marketplace, category_code, category_name
             ORDER BY costs_amount ASC
             SQL,
             array_filter([
@@ -237,6 +241,7 @@ final readonly class WidgetSummaryQuery
         );
 
         /** @var list<array{
+         *     marketplace: string,
          *     category_code: string,
          *     category_name: string,
          *     net_amount: string,

--- a/site/tests/MarketplaceAnalytics/Infrastructure/Query/WidgetSummaryQueryPnlTest.php
+++ b/site/tests/MarketplaceAnalytics/Infrastructure/Query/WidgetSummaryQueryPnlTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\MarketplaceAnalytics\Infrastructure\Query;
 use App\Marketplace\DTO\ListingReturnAggregateDTO;
 use App\Marketplace\DTO\ListingSalesAggregateDTO;
 use App\Marketplace\Facade\MarketplaceFacade;
+use App\MarketplaceAnalytics\Application\Service\MarketplaceCostAnalyticsGroupResolver;
 use App\MarketplaceAnalytics\Infrastructure\Query\WidgetSummaryQuery;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
@@ -17,13 +18,15 @@ final class WidgetSummaryQueryPnlTest extends TestCase
 
     private MarketplaceFacade $facade;
     private Connection $connection;
+    private MarketplaceCostAnalyticsGroupResolver $groupResolver;
     private WidgetSummaryQuery $query;
 
     protected function setUp(): void
     {
         $this->facade = $this->createMock(MarketplaceFacade::class);
         $this->connection = $this->createMock(Connection::class);
-        $this->query = new WidgetSummaryQuery($this->facade, $this->connection);
+        $this->groupResolver = new MarketplaceCostAnalyticsGroupResolver();
+        $this->query = new WidgetSummaryQuery($this->facade, $this->connection, $this->groupResolver);
     }
 
     public function testReturnsNegativeReturnsTotal(): void
@@ -61,7 +64,7 @@ final class WidgetSummaryQueryPnlTest extends TestCase
         $this->stubSales([]);
         $this->stubReturns([]);
         $this->stubCostRows([
-            ['category_code' => 'ozon_sale_commission', 'category_name' => 'Комиссия', 'costs_amount' => '-500.00', 'storno_amount' => '0.00', 'net_amount' => '-500.00'],
+            ['marketplace' => 'ozon', 'category_code' => 'ozon_sale_commission', 'category_name' => 'Комиссия', 'costs_amount' => '-500.00', 'storno_amount' => '0.00', 'net_amount' => '-500.00'],
         ]);
 
         $result = $this->executeSummary();
@@ -78,7 +81,7 @@ final class WidgetSummaryQueryPnlTest extends TestCase
         $this->stubSales([]);
         $this->stubReturns([]);
         $this->stubCostRows([
-            ['category_code' => 'ozon_sale_commission', 'category_name' => 'Комиссия', 'costs_amount' => '-1000.00', 'storno_amount' => '300.00', 'net_amount' => '-700.00'],
+            ['marketplace' => 'ozon', 'category_code' => 'ozon_sale_commission', 'category_name' => 'Комиссия', 'costs_amount' => '-1000.00', 'storno_amount' => '300.00', 'net_amount' => '-700.00'],
         ]);
 
         $result = $this->executeSummary();
@@ -98,8 +101,8 @@ final class WidgetSummaryQueryPnlTest extends TestCase
             new ListingReturnAggregateDTO('l1', '200.00', 1),
         ]);
         $this->stubCostRows([
-            ['category_code' => 'ozon_sale_commission', 'category_name' => 'Комиссия', 'costs_amount' => '-800.00', 'storno_amount' => '0.00', 'net_amount' => '-800.00'],
-            ['category_code' => 'ozon_logistic_direct', 'category_name' => 'FBO', 'costs_amount' => '-500.00', 'storno_amount' => '100.00', 'net_amount' => '-400.00'],
+            ['marketplace' => 'ozon', 'category_code' => 'ozon_sale_commission', 'category_name' => 'Комиссия', 'costs_amount' => '-800.00', 'storno_amount' => '0.00', 'net_amount' => '-800.00'],
+            ['marketplace' => 'ozon', 'category_code' => 'ozon_logistic_direct', 'category_name' => 'FBO', 'costs_amount' => '-500.00', 'storno_amount' => '100.00', 'net_amount' => '-400.00'],
         ]);
 
         $result = $this->executeSummary();
@@ -120,7 +123,7 @@ final class WidgetSummaryQueryPnlTest extends TestCase
         ]);
         $this->stubReturns([]);
         $this->stubCostRows([
-            ['category_code' => 'ozon_sale_commission', 'category_name' => 'K', 'costs_amount' => '-3000.00', 'storno_amount' => '0.00', 'net_amount' => '-3000.00'],
+            ['marketplace' => 'ozon', 'category_code' => 'ozon_sale_commission', 'category_name' => 'K', 'costs_amount' => '-3000.00', 'storno_amount' => '0.00', 'net_amount' => '-3000.00'],
         ]);
 
         $result = $this->executeSummary();
@@ -152,9 +155,9 @@ final class WidgetSummaryQueryPnlTest extends TestCase
         $this->stubSales([]);
         $this->stubReturns([]);
         $this->stubCostRows([
-            ['category_code' => 'ozon_sale_commission', 'category_name' => 'Комиссия', 'costs_amount' => '-300.00', 'storno_amount' => '0.00', 'net_amount' => '-300.00'],
-            ['category_code' => 'ozon_logistic_direct', 'category_name' => 'FBO', 'costs_amount' => '-700.00', 'storno_amount' => '0.00', 'net_amount' => '-700.00'],
-            ['category_code' => 'ozon_cpc', 'category_name' => 'Реклама', 'costs_amount' => '-100.00', 'storno_amount' => '0.00', 'net_amount' => '-100.00'],
+            ['marketplace' => 'ozon', 'category_code' => 'ozon_sale_commission', 'category_name' => 'Комиссия', 'costs_amount' => '-300.00', 'storno_amount' => '0.00', 'net_amount' => '-300.00'],
+            ['marketplace' => 'ozon', 'category_code' => 'ozon_logistic_direct', 'category_name' => 'FBO', 'costs_amount' => '-700.00', 'storno_amount' => '0.00', 'net_amount' => '-700.00'],
+            ['marketplace' => 'ozon', 'category_code' => 'ozon_cpc', 'category_name' => 'Реклама', 'costs_amount' => '-100.00', 'storno_amount' => '0.00', 'net_amount' => '-100.00'],
         ]);
 
         $result = $this->executeSummary();
@@ -175,7 +178,7 @@ final class WidgetSummaryQueryPnlTest extends TestCase
         $this->stubSales([]);
         $this->stubReturns([]);
         $this->stubCostRows([
-            ['category_code' => 'ozon_compensation', 'category_name' => 'Компенсация', 'costs_amount' => '0.00', 'storno_amount' => '1799.00', 'net_amount' => '1799.00'],
+            ['marketplace' => 'ozon', 'category_code' => 'ozon_compensation', 'category_name' => 'Компенсация', 'costs_amount' => '0.00', 'storno_amount' => '1799.00', 'net_amount' => '1799.00'],
         ]);
 
         $result = $this->executeSummary();
@@ -204,7 +207,7 @@ final class WidgetSummaryQueryPnlTest extends TestCase
         $this->stubSales([]);
         $this->stubReturns([]);
         $this->stubCostRows([
-            ['category_code' => 'ozon_compensation', 'category_name' => 'Компенсации и декомпенсации Ozon', 'costs_amount' => '0.00', 'storno_amount' => '5480.00', 'net_amount' => '5480.00'],
+            ['marketplace' => 'ozon', 'category_code' => 'ozon_compensation', 'category_name' => 'Компенсации и декомпенсации Ozon', 'costs_amount' => '0.00', 'storno_amount' => '5480.00', 'net_amount' => '5480.00'],
         ]);
 
         $result = $this->executeSummary();
@@ -227,7 +230,7 @@ final class WidgetSummaryQueryPnlTest extends TestCase
         $this->stubSales([]);
         $this->stubReturns([]);
         $this->stubCostRows([
-            ['category_code' => 'ozon_decompensation', 'category_name' => 'Декомпенсация Ozon', 'costs_amount' => '-1274.00', 'storno_amount' => '0.00', 'net_amount' => '-1274.00'],
+            ['marketplace' => 'ozon', 'category_code' => 'ozon_decompensation', 'category_name' => 'Декомпенсация Ozon', 'costs_amount' => '-1274.00', 'storno_amount' => '0.00', 'net_amount' => '-1274.00'],
         ]);
 
         $result = $this->executeSummary();
@@ -252,8 +255,8 @@ final class WidgetSummaryQueryPnlTest extends TestCase
         $this->stubSales([]);
         $this->stubReturns([]);
         $this->stubCostRows([
-            ['category_code' => 'ozon_compensation', 'category_name' => 'Компенсации и декомпенсации Ozon', 'costs_amount' => '0.00', 'storno_amount' => '5480.00', 'net_amount' => '5480.00'],
-            ['category_code' => 'ozon_decompensation', 'category_name' => 'Декомпенсация Ozon', 'costs_amount' => '-1274.00', 'storno_amount' => '0.00', 'net_amount' => '-1274.00'],
+            ['marketplace' => 'ozon', 'category_code' => 'ozon_compensation', 'category_name' => 'Компенсации и декомпенсации Ozon', 'costs_amount' => '0.00', 'storno_amount' => '5480.00', 'net_amount' => '5480.00'],
+            ['marketplace' => 'ozon', 'category_code' => 'ozon_decompensation', 'category_name' => 'Декомпенсация Ozon', 'costs_amount' => '-1274.00', 'storno_amount' => '0.00', 'net_amount' => '-1274.00'],
         ]);
 
         $result = $this->executeSummary();
@@ -288,6 +291,57 @@ final class WidgetSummaryQueryPnlTest extends TestCase
         self::assertStringContainsString("cc.code = 'ozon_compensation'", $capturedSql);
         self::assertStringContainsString("cc.code = 'ozon_decompensation'", $capturedSql);
         self::assertStringContainsString('effective_op', $capturedSql);
+        self::assertStringContainsString('c.marketplace AS marketplace', $capturedSql);
+        self::assertStringContainsString('GROUP BY marketplace, category_code, category_name', $capturedSql);
+    }
+
+    public function testWbCategoriesAreGroupedByWbMapping(): void
+    {
+        $this->stubSales([]);
+        $this->stubReturns([]);
+        $this->stubCostRows([
+            ['marketplace' => 'wildberries', 'category_code' => 'commission', 'category_name' => 'Комиссия', 'costs_amount' => '-100.00', 'storno_amount' => '0.00', 'net_amount' => '-100.00'],
+            ['marketplace' => 'wildberries', 'category_code' => 'logistics_delivery', 'category_name' => 'Логистика', 'costs_amount' => '-200.00', 'storno_amount' => '0.00', 'net_amount' => '-200.00'],
+            ['marketplace' => 'wildberries', 'category_code' => 'acquiring', 'category_name' => 'Эквайринг', 'costs_amount' => '-300.00', 'storno_amount' => '0.00', 'net_amount' => '-300.00'],
+            ['marketplace' => 'wildberries', 'category_code' => 'wb_okazanie_uslug_wb_prodvizhenie', 'category_name' => 'Продвижение', 'costs_amount' => '-400.00', 'storno_amount' => '0.00', 'net_amount' => '-400.00'],
+            ['marketplace' => 'wildberries', 'category_code' => 'penalty', 'category_name' => 'Штраф', 'costs_amount' => '-500.00', 'storno_amount' => '0.00', 'net_amount' => '-500.00'],
+        ]);
+
+        $result = $this->executeSummaryFor('wildberries');
+
+        self::assertSame('commission', $this->findCategory($result['widgetGroups'], 'Вознаграждение')['code']);
+        self::assertSame('logistics_delivery', $this->findCategory($result['widgetGroups'], 'Услуги доставки и FBO')['code']);
+        self::assertSame('acquiring', $this->findCategory($result['widgetGroups'], 'Услуги партнёров')['code']);
+        self::assertSame('wb_okazanie_uslug_wb_prodvizhenie', $this->findCategory($result['widgetGroups'], 'Продвижение и реклама')['code']);
+        self::assertSame('penalty', $this->findCategory($result['widgetGroups'], 'Другие услуги и штрафы')['code']);
+    }
+
+    public function testUnknownWbCodeFallsBackToOtherServicesAndPenalties(): void
+    {
+        $this->stubSales([]);
+        $this->stubReturns([]);
+        $this->stubCostRows([
+            ['marketplace' => 'wildberries', 'category_code' => 'wb_unknown_code', 'category_name' => 'Неизвестно', 'costs_amount' => '-50.00', 'storno_amount' => '0.00', 'net_amount' => '-50.00'],
+        ]);
+
+        $result = $this->executeSummaryFor('wildberries');
+        self::assertSame('wb_unknown_code', $this->findCategory($result['widgetGroups'], 'Другие услуги и штрафы')['code']);
+    }
+
+    public function testMarketplaceNullDoesNotMergeCategoriesWithSameCode(): void
+    {
+        $this->stubSales([]);
+        $this->stubReturns([]);
+        $this->stubCostRows([
+            ['marketplace' => 'ozon', 'category_code' => 'same_unknown_code', 'category_name' => 'Ozon unknown', 'costs_amount' => '-70.00', 'storno_amount' => '0.00', 'net_amount' => '-70.00'],
+            ['marketplace' => 'wildberries', 'category_code' => 'same_unknown_code', 'category_name' => 'WB unknown', 'costs_amount' => '-30.00', 'storno_amount' => '0.00', 'net_amount' => '-30.00'],
+        ]);
+
+        $result = $this->executeSummaryFor(null);
+
+        $group = $this->findGroup($result['widgetGroups'], 'Другие услуги и штрафы');
+        self::assertNotNull($group);
+        self::assertCount(2, $group['categories']);
     }
 
     /**
@@ -315,10 +369,14 @@ final class WidgetSummaryQueryPnlTest extends TestCase
     }
 
     /**
-     * @param list<array{category_code: string, category_name: string, costs_amount: string, storno_amount: string, net_amount: string}> $rows
+     * @param list<array{marketplace?: string, category_code: string, category_name: string, costs_amount: string, storno_amount: string, net_amount: string}> $rows
      */
     private function stubCostRows(array $rows): void
     {
+        foreach ($rows as &$row) {
+            $row['marketplace'] = $row['marketplace'] ?? 'ozon';
+        }
+        unset($row);
         $this->connection->method('fetchAllAssociative')->willReturn($rows);
     }
 
@@ -327,9 +385,17 @@ final class WidgetSummaryQueryPnlTest extends TestCase
      */
     private function executeSummary(): array
     {
+        return $this->executeSummaryFor('ozon');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function executeSummaryFor(?string $marketplace): array
+    {
         return $this->query->getSummary(
             self::COMPANY_ID,
-            'ozon',
+            $marketplace,
             new \DateTimeImmutable('2026-01-01'),
             new \DateTimeImmutable('2026-01-31'),
         );
@@ -348,5 +414,20 @@ final class WidgetSummaryQueryPnlTest extends TestCase
         }
 
         return null;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $widgetGroups
+     * @return array<string, mixed>
+     */
+    private function findCategory(array $widgetGroups, string $serviceGroup): array
+    {
+        $group = $this->findGroup($widgetGroups, $serviceGroup);
+        self::assertNotNull($group);
+        $category = $group['categories'][0] ?? null;
+        self::assertNotNull($category);
+
+        /** @var array<string, mixed> $category */
+        return $category;
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure cost categories are grouped per market (avoid merging identical category codes across marketplaces) and support marketplace-specific group mapping logic.
- Replace the static widget group map with a resolver service to centralize marketplace-aware grouping decisions.

### Description
- Replaced `WidgetServiceGroupMap` usage with a `MarketplaceCostAnalyticsGroupResolver` injected into `WidgetSummaryQuery` and used to resolve widget group names per row. (file: `WidgetSummaryQuery.php`)
- Included `marketplace` in the SQL select and `GROUP BY` in `getCostAggregates` so cost aggregation is done per marketplace and category. (file: `WidgetSummaryQuery.php`)
- Prevented cross-marketplace category merging by namespacing category keys with `marketplace:code` when building per-group category aggregates. (file: `WidgetSummaryQuery.php`)
- Updated tests in `WidgetSummaryQueryPnlTest` to provide `marketplace` in cost rows, added new tests to validate Wildberries mapping, unknown-code fallback, and that when `marketplace` is null categories with the same code are not merged, plus adjusted helpers (`stubCostRows`, `executeSummaryFor`). (file: `WidgetSummaryQueryPnlTest.php`)

### Testing
- Ran the PHPUnit test class `WidgetSummaryQueryPnlTest`; all existing and newly added unit tests passed. 
- Verified SQL contract assertions in tests that the special-casing for `ozon_compensation` / `ozon_decompensation` and the new `c.marketplace`/`GROUP BY marketplace` appear in generated SQL and those assertions passed. 
- Exercised grouping behavior for `wildberries` mappings and unknown codes via unit tests and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a047a5030048323a304d23c037d9e80)