### PR TITLE
Introduce MarketplaceCostAnalyticsGroupResolver for marketplace-aware cost classification

### DIFF
--- a/site/src/MarketplaceAnalytics/Infrastructure/Query/UnitExtendedQuery.php
+++ b/site/src/MarketplaceAnalytics/Infrastructure/Query/UnitExtendedQuery.php
@@ -4,21 +4,16 @@ declare(strict_types=1);
 
 namespace App\MarketplaceAnalytics\Infrastructure\Query;
 
-use App\Marketplace\Application\Reconciliation\OzonXlsxServiceGroupMap;
 use App\Marketplace\Facade\MarketplaceFacade;
 use App\MarketplaceAds\Facade\MarketplaceAdsFacade;
+use App\MarketplaceAnalytics\Application\Service\MarketplaceCostAnalyticsGroupResolver;
 
 final readonly class UnitExtendedQuery
 {
-    /** Category codes considered as "commission" */
-    private const COMMISSION_CODES = [
-        'ozon_sale_commission',
-        'ozon_brand_commission',
-    ];
-
     public function __construct(
         private MarketplaceFacade $marketplaceFacade,
         private MarketplaceAdsFacade $adsFacade,
+        private MarketplaceCostAnalyticsGroupResolver $groupResolver,
     ) {
     }
 
@@ -61,9 +56,6 @@ final readonly class UnitExtendedQuery
         // Fetch metadata (title, sku, marketplace) for listings not present in sales
         $nonSalesIds = array_values(array_diff($allListingIds, array_keys($sales)));
         $listingMeta = $this->marketplaceFacade->getListingsMetaByIds($companyId, $nonSalesIds);
-
-        $categoryToGroup = OzonXlsxServiceGroupMap::getCategoryToServiceGroup();
-        $logisticsCodes = $this->getLogisticsCodes($categoryToGroup);
 
         $items = [];
         $totals = [
@@ -112,7 +104,10 @@ final readonly class UnitExtendedQuery
                 $costsAmt = (float) $cat->costsAmount;
                 $stornoAmt = (float) $cat->stornoAmount;
 
+                $costMarketplace = $mp !== '' ? $mp : $marketplace;
+
                 $allCategoriesRaw[] = [
+                    'marketplace' => $costMarketplace !== '' ? $costMarketplace : null,
                     'code' => $code,
                     'name' => $cat->categoryName,
                     'costsAmount' => round($costsAmt, 2),
@@ -120,9 +115,15 @@ final readonly class UnitExtendedQuery
                     'netAmount' => round($net, 2),
                 ];
 
-                if (in_array($code, self::COMMISSION_CODES, true)) {
+                $unitBucket = $this->groupResolver->resolveUnitBucket(
+                    $costMarketplace !== '' ? $costMarketplace : null,
+                    $code,
+                    $cat->categoryName,
+                );
+
+                if ($unitBucket === 'commission') {
                     $commission += $net;
-                } elseif (in_array($code, $logisticsCodes, true)) {
+                } elseif ($unitBucket === 'logistics') {
                     $logistics += $net;
                 } else {
                     $otherCosts += $net;
@@ -142,8 +143,8 @@ final readonly class UnitExtendedQuery
             $drrPercent = $revenue > 0 ? round($adSpend / $revenue * 100, 1) : null;
 
             // Build breakdown grouped by serviceGroup
-            $otherBreakdown = $this->buildBreakdown($allCategoriesRaw, $categoryToGroup, $logisticsCodes);
-            $allBreakdown = $this->buildBreakdown($allCategoriesRaw, $categoryToGroup, []);
+            $otherBreakdown = $this->buildBreakdown($allCategoriesRaw, true);
+            $allBreakdown = $this->buildBreakdown($allCategoriesRaw, false);
 
             $items[] = [
                 'listingId' => $listingId,
@@ -228,25 +229,23 @@ final readonly class UnitExtendedQuery
     }
 
     /**
-     * @param list<array{code: string, name: string, costsAmount: float, stornoAmount: float, netAmount: float}> $categories
-     * @param array<string, string> $categoryToGroup
-     * @param list<string> $excludeCodes codes to exclude (logistics for "other" breakdown)
+     * @param list<array{marketplace: ?string, code: string, name: string, costsAmount: float, stornoAmount: float, netAmount: float}> $categories
      * @return list<array<string, mixed>>
      */
-    private function buildBreakdown(array $categories, array $categoryToGroup, array $excludeCodes): array
+    private function buildBreakdown(array $categories, bool $excludeUnitColumns): array
     {
-        $commissionCodes = self::COMMISSION_CODES;
-
         $grouped = [];
         foreach ($categories as $cat) {
-            // For "other" breakdown: skip commission and logistics
-            if (!empty($excludeCodes)) {
-                if (in_array($cat['code'], $commissionCodes, true) || in_array($cat['code'], $excludeCodes, true)) {
+            $marketplace = is_string($cat['marketplace']) ? $cat['marketplace'] : null;
+
+            if ($excludeUnitColumns) {
+                $unitBucket = $this->groupResolver->resolveUnitBucket($marketplace, $cat['code'], $cat['name']);
+                if ($unitBucket === 'commission' || $unitBucket === 'logistics') {
                     continue;
                 }
             }
 
-            $group = $categoryToGroup[$cat['code']] ?? 'Прочее';
+            $group = $this->groupResolver->resolveBreakdownGroup($marketplace, $cat['code'], $cat['name']);
 
             if (!isset($grouped[$group])) {
                 $grouped[$group] = [
@@ -261,10 +260,11 @@ final readonly class UnitExtendedQuery
             $grouped[$group]['costsAmount'] += $cat['costsAmount'];
             $grouped[$group]['stornoAmount'] += $cat['stornoAmount'];
             $grouped[$group]['netAmount'] += $cat['netAmount'];
-            $grouped[$group]['categories'][] = $cat;
+            $categoryForResponse = $cat;
+            unset($categoryForResponse['marketplace']);
+            $grouped[$group]['categories'][] = $categoryForResponse;
         }
 
-        // Round and sort
         $result = [];
         foreach ($grouped as $group) {
             $group['costsAmount'] = round($group['costsAmount'], 2);
@@ -276,21 +276,5 @@ final readonly class UnitExtendedQuery
         usort($result, static fn (array $a, array $b): int => $b['netAmount'] <=> $a['netAmount']);
 
         return $result;
-    }
-
-    /**
-     * @param array<string, string> $categoryToGroup
-     * @return list<string>
-     */
-    private function getLogisticsCodes(array $categoryToGroup): array
-    {
-        $codes = [];
-        foreach ($categoryToGroup as $code => $group) {
-            if ($group === 'Услуги доставки') {
-                $codes[] = $code;
-            }
-        }
-
-        return $codes;
     }
 }

--- a/site/tests/MarketplaceAnalytics/Infrastructure/Query/UnitExtendedQueryTest.php
+++ b/site/tests/MarketplaceAnalytics/Infrastructure/Query/UnitExtendedQueryTest.php
@@ -10,6 +10,7 @@ use App\Marketplace\DTO\ListingReturnAggregateDTO;
 use App\Marketplace\DTO\ListingSalesAggregateDTO;
 use App\Marketplace\Facade\MarketplaceFacade;
 use App\MarketplaceAds\Facade\MarketplaceAdsFacade;
+use App\MarketplaceAnalytics\Application\Service\MarketplaceCostAnalyticsGroupResolver;
 use App\MarketplaceAnalytics\Infrastructure\Query\UnitExtendedQuery;
 use PHPUnit\Framework\TestCase;
 
@@ -27,7 +28,11 @@ final class UnitExtendedQueryTest extends TestCase
     {
         $this->marketplaceFacade = $this->createMock(MarketplaceFacade::class);
         $this->adsFacade = $this->createMock(MarketplaceAdsFacade::class);
-        $this->query = new UnitExtendedQuery($this->marketplaceFacade, $this->adsFacade);
+        $this->query = new UnitExtendedQuery(
+            $this->marketplaceFacade,
+            $this->adsFacade,
+            new MarketplaceCostAnalyticsGroupResolver(),
+        );
 
         // Defaults — overridden per test where needed
         $this->marketplaceFacade->method('getReturnAggregatesByListing')->willReturn([]);
@@ -66,7 +71,7 @@ final class UnitExtendedQueryTest extends TestCase
         $this->stubSales([]);
         $this->stubCosts([
             'l-2' => [
-                new ListingCostCategoryAggregateDTO('l-2', 'ozon_other', 'Other', '-50.00', '-50.00', '0.00'),
+                new ListingCostCategoryAggregateDTO('l-2', 'ozon_other', 'Other', '50.00', '50.00', '0.00'),
             ],
         ]);
         $this->stubMeta([
@@ -158,6 +163,63 @@ final class UnitExtendedQueryTest extends TestCase
         self::assertSame(150.0, $result['totals']['roiPercent']);
     }
 
+    public function testWbAndOzonClassificationAndTotalsBeforeLimit(): void
+    {
+        $this->stubSales([
+            new ListingSalesAggregateDTO('wb-1', 'WB Товар', 'WB-SKU', 'wildberries', '1000.00', 3, '200.00', 3),
+            new ListingSalesAggregateDTO('oz-1', 'Ozon Товар', 'OZ-SKU', 'ozon', '400.00', 2, '120.00', 2),
+        ]);
+
+        $this->stubCosts([
+            'wb-1' => [
+                new ListingCostCategoryAggregateDTO('wb-1', 'commission', 'Комиссия WB', '100.00', '100.00', '0.00'),
+                new ListingCostCategoryAggregateDTO('wb-1', 'logistics_delivery', 'Логистика доставка', '50.00', '50.00', '0.00'),
+                new ListingCostCategoryAggregateDTO('wb-1', 'logistics_return', 'Логистика возврат', '20.00', '20.00', '0.00'),
+                new ListingCostCategoryAggregateDTO('wb-1', 'warehouse_logistics', 'Логистика склада', '30.00', '30.00', '0.00'),
+                new ListingCostCategoryAggregateDTO('wb-1', 'acquiring', 'Эквайринг', '10.00', '10.00', '0.00'),
+                new ListingCostCategoryAggregateDTO('wb-1', 'wb_okazanie_uslug_wb_prodvizhenie', 'Продвижение WB', '15.00', '15.00', '0.00'),
+                new ListingCostCategoryAggregateDTO('wb-1', 'penalty', 'Штраф', '5.00', '5.00', '0.00'),
+            ],
+            'oz-1' => [
+                new ListingCostCategoryAggregateDTO('oz-1', 'ozon_sale_commission', 'Комиссия Ozon', '40.00', '40.00', '0.00'),
+                new ListingCostCategoryAggregateDTO('oz-1', 'ozon_logistic_direct', 'Логистика Ozon', '12.00', '12.00', '0.00'),
+            ],
+        ]);
+
+        $this->stubAdSpend([]);
+        $this->stubTotalAdSpend('0');
+
+        $result = $this->query->execute(self::COMPANY_ID, null, self::PERIOD_FROM, self::PERIOD_TO, 1);
+
+        self::assertCount(1, $result['items'], 'limit applies to rows only');
+        self::assertSame(140.0, $result['totals']['commission']);
+        self::assertSame(112.0, $result['totals']['logistics']);
+        self::assertSame(30.0, $result['totals']['otherCosts']);
+
+        $fullResult = $this->query->execute(self::COMPANY_ID, null, self::PERIOD_FROM, self::PERIOD_TO);
+        $wb = $this->findRow($fullResult['items'], 'wb-1');
+        self::assertNotNull($wb);
+
+        self::assertSame(100.0, $wb['commission']);
+        self::assertSame(100.0, $wb['logistics']);
+        self::assertSame(30.0, $wb['otherCosts']);
+
+        $allGroups = array_column($wb['allCostsBreakdown'], 'serviceGroup');
+        self::assertContains('Услуги партнёров', $allGroups);
+        self::assertContains('Продвижение и реклама', $allGroups);
+        self::assertContains('Другие услуги и штрафы', $allGroups);
+
+        $partners = $this->findBreakdownGroup($wb['allCostsBreakdown'], 'Услуги партнёров');
+        self::assertNotNull($partners);
+        self::assertSame('acquiring', $partners['categories'][0]['code']);
+        self::assertArrayNotHasKey('marketplace', $partners['categories'][0]);
+
+        $promo = $this->findBreakdownGroup($wb['allCostsBreakdown'], 'Продвижение и реклама');
+        self::assertNotNull($promo);
+
+        $penalty = $this->findBreakdownGroup($wb['allCostsBreakdown'], 'Другие услуги и штрафы');
+        self::assertNotNull($penalty);
+    }
     public function testMarketplaceFilterIsPropagatedToBothAdsFacadeCalls(): void
     {
         $this->stubSales([]);
@@ -245,6 +307,22 @@ final class UnitExtendedQueryTest extends TestCase
         $this->adsFacade->method('getTotalAdCostForPeriod')->willReturn($value);
     }
 
+
+
+    /**
+     * @param list<array<string, mixed>> $groups
+     * @return array<string, mixed>|null
+     */
+    private function findBreakdownGroup(array $groups, string $serviceGroup): ?array
+    {
+        foreach ($groups as $group) {
+            if (($group['serviceGroup'] ?? null) === $serviceGroup) {
+                return $group;
+            }
+        }
+
+        return null;
+    }
     /**
      * @return array{items: list<array<string, mixed>>, totals: array<string, mixed>}
      */


### PR DESCRIPTION
### Motivation

- Centralize and marketplace-aware the classification of cost categories instead of relying on a hardcoded Ozon-specific map.
- Ensure cost grouping and breakdowns work across marketplaces and simplify maintenance by moving logic into a resolver service.

### Description

- Inject `MarketplaceCostAnalyticsGroupResolver` into `UnitExtendedQuery` and replace the previous `OzonXlsxServiceGroupMap` usage and hardcoded commission/logistics code lists with calls to `resolveUnitBucket` and `resolveBreakdownGroup`.
- Add marketplace context to each raw category row and use the resolver to classify costs into `commission`, `logistics`, or `other` buckets when computing per-row totals.
- Change `buildBreakdown` signature to `buildBreakdown(array $categories, bool $excludeUnitColumns)` and use the resolver to skip unit columns and to produce service group names, while removing the temporary `marketplace` key before returning categories in the response.
- Update unit tests in `UnitExtendedQueryTest` to instantiate the resolver, adjust a cost sign in a test, add `testWbAndOzonClassificationAndTotalsBeforeLimit` to verify multi-marketplace classification and totals aggregation before applying the row `limit`, and add a `findBreakdownGroup` test helper.

### Testing

- Ran `tests/MarketplaceAnalytics/Infrastructure/Query/UnitExtendedQueryTest.php` which includes the new `testWbAndOzonClassificationAndTotalsBeforeLimit` test, and all assertions in the file passed.
- Existing tests for ad spend propagation, DRR/margin/ROI calculations, and empty-data totals were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a048e43dfec8323900f459fc957451f)