### PR TITLE
Add company footer section to main left sidebar

### DIFF
--- a/site/assets/styles/app.css
+++ b/site/assets/styles/app.css
@@ -154,3 +154,61 @@ html {
 .pd-selected { font-weight: 600; }
 
 .pd-children { margin-left: 14px; border-left: 1px dashed rgba(10,21,72,.15); padding-left: 10px; }
+
+:root {
+    --vf-brand: #0A1548;
+    --vf-brand-05: rgba(10, 21, 72, .05);
+}
+
+.nav-item.active > a {
+    background: var(--vf-brand-05);
+    color: var(--vf-brand);
+    border-left: 2px solid var(--vf-brand);
+}
+
+.nav-item a:hover {
+    background: var(--vf-brand-05);
+    color: var(--vf-brand);
+}
+
+.nav-section-title {
+    font-size: .75rem;
+    letter-spacing: .04em;
+    color: #8a94a6;
+    text-transform: uppercase;
+    padding: .5rem 1rem;
+}
+
+.nav-link-icon i {
+    font-size: 1.5em;
+    line-height: 1;
+}
+
+aside.navbar .navbar-brand {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    padding-inline: .75rem;
+    margin-bottom: 0;
+}
+
+.navbar-brand img {
+    height: 40px;
+    width: auto;
+}
+
+.vf-sidebar {
+    min-height: 100%;
+}
+
+.vf-sidebar-body {
+    flex: 1 1 auto;
+}
+
+.vf-sidebar-footer {
+    flex-shrink: 0;
+}
+
+.vf-sidebar-company-name {
+    word-break: break-word;
+}

--- a/site/templates/partials/_sidebar.html.twig
+++ b/site/templates/partials/_sidebar.html.twig
@@ -3,20 +3,9 @@
 {% if app.user %}
     {% set user_roles = app.user.roles|default([]) %}
 {% endif %}
-<style>
-    :root{
-        --brand:#0A1548; /* основной брендовый */
-        --brand-05: rgba(10,21,72,.05);
-        --sidebar-w: 280px;
-        --sidebar-w-collapsed: 80px;
-    }
-    .nav-item.active > a { background: var(--brand-05); color: var(--brand); border-left: 2px solid var(--brand); }
-    .nav-item a:hover { background: var(--brand-05); color: var(--brand); }
-    .nav-section-title { font-size:.75rem; letter-spacing:.04em; color:#8a94a6; text-transform:uppercase; padding: .5rem 1rem; }
-    .nav-link-icon i { font-size: 1.5em; line-height: 1; }
-    aside.navbar .navbar-brand { display: flex; align-items: center; justify-content: flex-start; padding-inline: .75rem; margin-bottom: 0; }
-    .navbar-brand img { height: 40px; width: auto; }
-</style>
+{% set active_company_id = app.session.get('active_company_id') %}
+{% set active_company = app.user and app.user.companies is defined ? (app.user.companies|filter(c => c.id == active_company_id)|first) : null %}
+{% set active_company_name = active_company ? active_company.name : 'Компания не выбрана' %}
 
 <!-- Sidebar -->
 
@@ -28,9 +17,9 @@
             <img src="{{ asset('static/logo-vf-001.png') }}" alt="Ваш ФинДир" />
         </a>
     </h1>
-    <div class="collapse navbar-collapse" id="sidebar-menu">
+    <div class="collapse navbar-collapse d-flex flex-column vf-sidebar" id="sidebar-menu">
 
-        <ul class="navbar-nav">
+        <ul class="navbar-nav vf-sidebar-body">
             <!-- Dashboard -->
             {% set dashboard_active = current_route == 'app_home_index' %}
             <li class="nav-item {{ dashboard_active ? 'active' : '' }}">
@@ -318,4 +307,10 @@
                 </div>
             </li>
         </ul>
+
+        <div class="vf-sidebar-footer border-top px-3 py-3 mt-auto">
+            <div class="text-muted text-uppercase small">КОМПАНИЯ</div>
+            <div class="fw-bold vf-sidebar-company-name">{{ active_company_name }}</div>
+            <a class="text-muted small" href="{{ path('company_index') }}">Переключить -&gt;</a>
+        </div>
     </div>


### PR DESCRIPTION
### Motivation
- Provide a persistent footer in the main left `<aside>` menu that shows the current company and a link to switch companies, matching the provided design (divider, uppercase label, bold company name, `Переключить ->`).
- Place the footer visually separated from menu items and pinned to the bottom of the sidebar so it stays there when the viewport is taller than the menu.
- Reuse existing project data and routes for company selection rather than introducing new business logic or routes.

### Description
- Added server-side logic in `site/templates/partials/_sidebar.html.twig` to resolve the active company via `app.session.get('active_company_id')` and `app.user.companies`, with a safe fallback `Компания не выбрана` when nothing is set.
- Inserted the footer block inside the existing collapse container (no new `<aside>`), made the collapse container a column flex (`d-flex flex-column`) and the footer `mt-auto`, and used Tabler utility classes (`border-top`, `text-muted`, `text-uppercase`, `fw-bold`, `small`, `px-3`, `py-3`) where appropriate.
- Moved removed inline styles into `site/assets/styles/app.css` and added minimal namespaced classes prefixed with `vf-` (`vf-sidebar`, `vf-sidebar-body`, `vf-sidebar-footer`, `vf-sidebar-company-name`) to control layout without overriding global Tabler rules.
- The footer link points to the existing `company_index` page because the real `company_set_active` route in the project is POST-only (used by the existing select form), so a direct anchor must reuse the existing companies page instead of inventing a new route.
- Files changed: `site/templates/partials/_sidebar.html.twig`, `site/assets/styles/app.css`.

### Testing
- Attempted to run Twig linter with `php site/bin/console lint:twig site/templates/partials/_sidebar.html.twig`, but the command failed because project PHP dependencies are not installed in the environment (needs `composer install`), so automated Twig linting could not be completed.
- Verified modified files with repository checks (`git status`/`git show`) and committed changes successfully (commit created: `Add company footer block to main sidebar`).
- No automated unit or integration tests were added for this UI change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0496bb98fc832380a85d573dfab37c)