### PR TITLE
Refactor sidebar: extract styles to CSS and add active company footer

### DIFF
--- a/site/assets/styles/app.css
+++ b/site/assets/styles/app.css
@@ -154,3 +154,66 @@ html {
 .pd-selected { font-weight: 600; }
 
 .pd-children { margin-left: 14px; border-left: 1px dashed rgba(10,21,72,.15); padding-left: 10px; }
+
+:root {
+    --vf-brand: #0A1548;
+    --vf-brand-05: rgba(10, 21, 72, .05);
+}
+
+.nav-item.active > a {
+    background: var(--vf-brand-05);
+    color: var(--vf-brand);
+    border-left: 2px solid var(--vf-brand);
+}
+
+.nav-item a:hover {
+    background: var(--vf-brand-05);
+    color: var(--vf-brand);
+}
+
+.nav-section-title {
+    font-size: .75rem;
+    letter-spacing: .04em;
+    color: #8a94a6;
+    text-transform: uppercase;
+    padding: .5rem 1rem;
+}
+
+.nav-link-icon i {
+    font-size: 1.5em;
+    line-height: 1;
+}
+
+aside.navbar .navbar-brand {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    padding-inline: .75rem;
+    margin-bottom: 0;
+}
+
+.navbar-brand img {
+    height: 40px;
+    width: auto;
+}
+
+.vf-sidebar {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.vf-sidebar-body {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+.vf-sidebar-footer {
+    flex: 0 0 auto;
+}
+
+.vf-sidebar-company-name {
+    word-break: break-word;
+}

--- a/site/templates/partials/_sidebar.html.twig
+++ b/site/templates/partials/_sidebar.html.twig
@@ -3,20 +3,9 @@
 {% if app.user %}
     {% set user_roles = app.user.roles|default([]) %}
 {% endif %}
-<style>
-    :root{
-        --brand:#0A1548; /* основной брендовый */
-        --brand-05: rgba(10,21,72,.05);
-        --sidebar-w: 280px;
-        --sidebar-w-collapsed: 80px;
-    }
-    .nav-item.active > a { background: var(--brand-05); color: var(--brand); border-left: 2px solid var(--brand); }
-    .nav-item a:hover { background: var(--brand-05); color: var(--brand); }
-    .nav-section-title { font-size:.75rem; letter-spacing:.04em; color:#8a94a6; text-transform:uppercase; padding: .5rem 1rem; }
-    .nav-link-icon i { font-size: 1.5em; line-height: 1; }
-    aside.navbar .navbar-brand { display: flex; align-items: center; justify-content: flex-start; padding-inline: .75rem; margin-bottom: 0; }
-    .navbar-brand img { height: 40px; width: auto; }
-</style>
+{% set active_company_id = app.session.get('active_company_id') %}
+{% set active_company = app.user and app.user.companies is defined ? (app.user.companies|filter(c => c.id == active_company_id)|first) : null %}
+{% set active_company_name = active_company ? active_company.name : 'Компания не выбрана' %}
 
 <!-- Sidebar -->
 
@@ -28,8 +17,8 @@
             <img src="{{ asset('static/logo-vf-001.png') }}" alt="Ваш ФинДир" />
         </a>
     </h1>
-    <div class="collapse navbar-collapse" id="sidebar-menu">
-
+    <div class="collapse navbar-collapse d-flex flex-column vf-sidebar" id="sidebar-menu">
+        <div class="vf-sidebar-body">
         <ul class="navbar-nav">
             <!-- Dashboard -->
             {% set dashboard_active = current_route == 'app_home_index' %}
@@ -318,4 +307,11 @@
                 </div>
             </li>
         </ul>
+        </div>
+
+        <div class="vf-sidebar-footer border-top px-3 py-3 mt-auto">
+            <div class="text-muted text-uppercase small">КОМПАНИЯ</div>
+            <div class="fw-bold vf-sidebar-company-name">{{ active_company_name }}</div>
+            <a class="text-muted small" href="{{ path('company_index') }}">Переключить -&gt;</a>
+        </div>
     </div>


### PR DESCRIPTION
### Motivation
- Centralize sidebar styling into the main stylesheet to remove inline styles and make theme variables reusable.
- Improve sidebar layout to support scrollable body and a persistent footer area.
- Surface the currently active company in the sidebar to make switching companies more discoverable.

### Description
- Added new theme variables and sidebar-related rules to `site/assets/styles/app.css`, including `--vf-brand` and `--vf-brand-05` and layout classes such as `vf-sidebar`, `vf-sidebar-body`, and `vf-sidebar-footer`.
- Removed the inline `<style>` block from `site/templates/partials/_sidebar.html.twig` and moved styling into the CSS file.
- Added logic in `_sidebar.html.twig` to read `active_company_id` from session and resolve `active_company` and `active_company_name` for display in the sidebar footer.
- Reworked the sidebar markup by wrapping the nav in `div.collapse.navbar-collapse.d-flex.flex-column.vf-sidebar`, introducing `vf-sidebar-body` around the nav list and adding a `vf-sidebar-footer` that shows the active company and a link to `company_index`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0496bb98fc832380a85d573dfab37c)