### PR TITLE
Clarify barcode sync flash message and remove leftover comments/import

### DIFF
--- a/site/src/Marketplace/Controller/Inventory/InventoryController.php
+++ b/site/src/Marketplace/Controller/Inventory/InventoryController.php
@@ -164,7 +164,7 @@ final class InventoryController extends AbstractController
             companyId: $companyId,
         ));
 
-        $this->addFlash('success', 'Синхронизация баркодов Ozon запущена.');
+        $this->addFlash('success', 'Синхронизация баркодов Ozon запущена. Данные обновятся в течение нескольких секунд.');
 
         return $this->redirectToRoute('marketplace_inventory_index');
     }

--- a/site/src/Marketplace/Controller/Inventory/InventoryImportController.php
+++ b/site/src/Marketplace/Controller/Inventory/InventoryImportController.php
@@ -6,7 +6,6 @@ namespace App\Marketplace\Controller\Inventory;
 
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Message\ImportInventoryCostPriceMessage;
-use App\Marketplace\Message\SyncOzonListingBarcodesMessage;
 use App\Shared\Service\ActiveCompanyService;
 use App\Shared\Service\Storage\StorageService;
 use Ramsey\Uuid\Uuid;
@@ -97,29 +96,4 @@ final class InventoryImportController extends AbstractController
         return $this->redirectToRoute('marketplace_inventory_index');
     }
 
-
-// -------------------------------------------------------------------------
-// Добавить в InventoryController:
-// 1. В use-блок:
-//      use App\Marketplace\Message\SyncOzonListingBarcodesMessage;
-//      use Symfony\Component\Messenger\MessageBusInterface;
-// 2. В конструктор добавить:
-//      private readonly MessageBusInterface $messageBus,
-// 3. Метод ниже добавить в тело класса
-// -------------------------------------------------------------------------
-
-    #[Route('/sync-barcodes', name: 'marketplace_inventory_sync_barcodes', methods: ['POST'])]
-    public function syncBarcodes(): Response
-    {
-        $company = $this->companyService->getActiveCompany();
-        $companyId = (string)$company->getId();
-
-        $this->messageBus->dispatch(new SyncOzonListingBarcodesMessage(
-            companyId: $companyId,
-        ));
-
-        $this->addFlash('success', 'Синхронизация баркодов Ozon запущена. Данные обновятся в течение нескольких секунд.');
-
-        return $this->redirectToRoute('marketplace_inventory_index');
-    }
 }


### PR DESCRIPTION
### Motivation
- Remove leftover developer instructions and unused import from the inventory import controller and make the barcode sync feedback clearer to users by indicating data will update shortly.

### Description
- Update the `syncBarcodes` flash message in `InventoryController` to: `Синхронизация баркодов Ozon запущена. Данные обновятся в течение нескольких секунд.`.
- Remove the unused `use App\Marketplace\Message\SyncOzonListingBarcodesMessage;` import from `InventoryImportController`.
- Delete a large commented block of developer instructions that instructed adding the `syncBarcodes` method to `InventoryController` from `InventoryImportController`.

### Testing
- Ran the project's automated test suite via `phpunit` and static analysis via `phpstan`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a056bf8ded88323a73347e6891ff764)