### PR TITLE
Add WbSalesReportRowNormalizer for Wildberries reports with unit tests

### DIFF
--- a/site/src/Marketplace/Infrastructure/Normalizer/Wildberries/WbSalesReportRowNormalizer.php
+++ b/site/src/Marketplace/Infrastructure/Normalizer/Wildberries/WbSalesReportRowNormalizer.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Normalizer\Wildberries;
+
+final readonly class WbSalesReportRowNormalizer
+{
+    public function rrdId(array $row): ?string
+    {
+        return $this->nullableString($row, 'rrdId', 'rrd_id');
+    }
+
+    public function srid(array $row): ?string
+    {
+        return $this->nullableString($row, 'srid');
+    }
+
+    public function docTypeName(array $row): string
+    {
+        return $this->string($row, 'docTypeName', 'doc_type_name');
+    }
+
+    public function sellerOperName(array $row): string
+    {
+        return $this->string($row, 'sellerOperName', 'supplier_oper_name');
+    }
+
+    public function nmId(array $row): string
+    {
+        return $this->string($row, 'nmId', 'nm_id');
+    }
+
+    public function vendorCode(array $row): string
+    {
+        return $this->string($row, 'vendorCode', 'sa_name');
+    }
+
+    public function techSize(array $row): ?string
+    {
+        return $this->nullableString($row, 'techSize', 'ts_name');
+    }
+
+    public function barcode(array $row): ?string
+    {
+        return $this->nullableString($row, 'sku', 'barcode');
+    }
+
+    public function quantity(array $row): int
+    {
+        return (int) ($this->raw($row, 'quantity') ?? 0);
+    }
+
+    public function retailPrice(array $row): float
+    {
+        return $this->float($row, 'retailPrice', 'retail_price');
+    }
+
+    public function retailAmount(array $row): float
+    {
+        return $this->float($row, 'retailAmount', 'retail_amount');
+    }
+
+    public function retailPriceWithDisc(array $row): float
+    {
+        return $this->float($row, 'retailPriceWithDisc', 'retail_price_withdisc_rub');
+    }
+
+    public function forPay(array $row): float
+    {
+        return $this->float($row, 'forPay', 'ppvz_for_pay');
+    }
+
+    public function acquiringFee(array $row): float
+    {
+        return $this->float($row, 'acquiringFee', 'acquiring_fee');
+    }
+
+    public function reportDate(array $row): \DateTimeImmutable
+    {
+        $date = $this->nullableString($row, 'rrDate', 'rr_dt');
+        if ($date === null) {
+            throw new \InvalidArgumentException('WB report row must contain rrDate or rr_dt.');
+        }
+
+        return new \DateTimeImmutable($date);
+    }
+
+    public function operationDate(array $row): \DateTimeImmutable
+    {
+        $date = $this->nullableString($row, 'saleDt', 'sale_dt', 'rrDate', 'rr_dt');
+        if ($date === null) {
+            throw new \InvalidArgumentException('WB report row must contain saleDt/sale_dt or rrDate/rr_dt.');
+        }
+
+        return new \DateTimeImmutable($date);
+    }
+
+    public function isSale(array $row): bool
+    {
+        return $this->normalizeDocTypeName($this->docTypeName($row)) === 'sale';
+    }
+
+    public function isReturn(array $row): bool
+    {
+        return $this->normalizeDocTypeName($this->docTypeName($row)) === 'return';
+    }
+
+    public function isSaleOrReturn(array $row): bool
+    {
+        return $this->isSale($row) || $this->isReturn($row);
+    }
+
+    public function fullMarketplaceCommission(array $row): float
+    {
+        return $this->retailPriceWithDisc($row) - $this->forPay($row) - $this->acquiringFee($row);
+    }
+
+    private function raw(array $row, string ...$keys): mixed
+    {
+        foreach ($keys as $key) {
+            if (array_key_exists($key, $row)) {
+                return $row[$key];
+            }
+        }
+
+        return null;
+    }
+
+    private function string(array $row, string ...$keys): string
+    {
+        return trim((string) ($this->raw($row, ...$keys) ?? ''));
+    }
+
+    private function nullableString(array $row, string ...$keys): ?string
+    {
+        $value = $this->string($row, ...$keys);
+
+        return $value === '' ? null : $value;
+    }
+
+    private function float(array $row, string ...$keys): float
+    {
+        return (float) ($this->raw($row, ...$keys) ?? 0);
+    }
+
+    private function normalizeDocTypeName(string $value): ?string
+    {
+        return match (mb_strtolower(trim($value))) {
+            'продажа', 'sale' => 'sale',
+            'возврат', 'return' => 'return',
+            default => null,
+        };
+    }
+}
+

--- a/site/tests/Unit/Marketplace/Infrastructure/Wildberries/WbSalesReportRowNormalizerTest.php
+++ b/site/tests/Unit/Marketplace/Infrastructure/Wildberries/WbSalesReportRowNormalizerTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Infrastructure\Wildberries;
+
+use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
+use PHPUnit\Framework\TestCase;
+
+final class WbSalesReportRowNormalizerTest extends TestCase
+{
+    private WbSalesReportRowNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = new WbSalesReportRowNormalizer();
+    }
+
+    public function testNormalizesOldSnakeCaseSaleRow(): void
+    {
+        $row = $this->oldSaleRow();
+
+        self::assertSame('1001', $this->normalizer->rrdId($row));
+        self::assertSame('srid-1', $this->normalizer->srid($row));
+        self::assertSame('Продажа', $this->normalizer->docTypeName($row));
+        self::assertSame('Логистика продажа', $this->normalizer->sellerOperName($row));
+        self::assertSame('12345', $this->normalizer->nmId($row));
+        self::assertSame('ART-1', $this->normalizer->vendorCode($row));
+        self::assertSame('M', $this->normalizer->techSize($row));
+        self::assertSame('4600000000001', $this->normalizer->barcode($row));
+        self::assertSame(2, $this->normalizer->quantity($row));
+        self::assertSame(1300.0, $this->normalizer->retailPriceWithDisc($row));
+        self::assertSame(80.0, $this->normalizer->fullMarketplaceCommission($row));
+        self::assertTrue($this->normalizer->isSale($row));
+        self::assertFalse($this->normalizer->isReturn($row));
+    }
+
+    public function testNormalizesOldSnakeCaseReturnRow(): void
+    {
+        $row = $this->oldReturnRow();
+
+        self::assertTrue($this->normalizer->isReturn($row));
+        self::assertFalse($this->normalizer->isSale($row));
+        self::assertTrue($this->normalizer->isSaleOrReturn($row));
+    }
+
+    public function testNormalizesNewCamelCaseSaleRow(): void
+    {
+        $row = $this->newSaleRow();
+
+        self::assertSame('1001', $this->normalizer->rrdId($row));
+        self::assertSame('srid-1', $this->normalizer->srid($row));
+        self::assertSame('12345', $this->normalizer->nmId($row));
+        self::assertSame('ART-1', $this->normalizer->vendorCode($row));
+        self::assertSame('M', $this->normalizer->techSize($row));
+        self::assertSame('4600000000001', $this->normalizer->barcode($row));
+        self::assertSame(1500.0, $this->normalizer->retailPrice($row));
+        self::assertSame(1500.0, $this->normalizer->retailAmount($row));
+        self::assertSame(1300.0, $this->normalizer->retailPriceWithDisc($row));
+        self::assertSame(1200.0, $this->normalizer->forPay($row));
+        self::assertSame(20.0, $this->normalizer->acquiringFee($row));
+        self::assertSame(80.0, $this->normalizer->fullMarketplaceCommission($row));
+        self::assertTrue($this->normalizer->isSale($row));
+    }
+
+    public function testNormalizesNewCamelCaseReturnRow(): void
+    {
+        $row = $this->newReturnRow();
+
+        self::assertTrue($this->normalizer->isReturn($row));
+        self::assertFalse($this->normalizer->isSale($row));
+        self::assertTrue($this->normalizer->isSaleOrReturn($row));
+    }
+
+
+    public function testPvzCompensationWithReturnWordIsStillSaleByDocTypeOnly(): void
+    {
+        $row = [
+            'doc_type_name' => 'Продажа',
+            'supplier_oper_name' => 'Возмещение за выдачу и возврат товаров на ПВЗ',
+        ];
+
+        self::assertTrue($this->normalizer->isSale($row));
+        self::assertFalse($this->normalizer->isReturn($row));
+        self::assertTrue($this->normalizer->isSaleOrReturn($row));
+    }
+
+    public function testRowWithoutDocTypeButWithReturnWordInOperationIsNotReturn(): void
+    {
+        $row = [
+            'doc_type_name' => '',
+            'supplier_oper_name' => 'Возмещение за выдачу и возврат товаров на ПВЗ',
+        ];
+
+        self::assertFalse($this->normalizer->isSale($row));
+        self::assertFalse($this->normalizer->isReturn($row));
+        self::assertFalse($this->normalizer->isSaleOrReturn($row));
+    }
+
+    public function testUnknownDocTypeNameIsNotSaleOrReturn(): void
+    {
+        $row = [
+            'docTypeName' => 'Correction',
+            'sellerOperName' => 'Return operation',
+        ];
+
+        self::assertFalse($this->normalizer->isSale($row));
+        self::assertFalse($this->normalizer->isReturn($row));
+        self::assertFalse($this->normalizer->isSaleOrReturn($row));
+    }
+
+    public function testReportDateThrowsWhenDateFieldsAreMissing(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('WB report row must contain rrDate or rr_dt.');
+
+        $this->normalizer->reportDate([]);
+    }
+
+    public function testOperationDateThrowsWhenDateFieldsAreMissing(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('WB report row must contain saleDt/sale_dt or rrDate/rr_dt.');
+
+        $this->normalizer->operationDate([]);
+    }
+
+    public function testRrdIdReturnsNullWhenMissing(): void
+    {
+        self::assertNull($this->normalizer->rrdId(['srid' => 'srid-2']));
+    }
+
+    private function oldSaleRow(): array
+    {
+        return [
+            'rrd_id' => '1001',
+            'doc_type_name' => 'Продажа',
+            'supplier_oper_name' => 'Логистика продажа',
+            'nm_id' => '12345',
+            'sa_name' => 'ART-1',
+            'ts_name' => 'M',
+            'barcode' => '4600000000001',
+            'retail_price' => '1500',
+            'retail_amount' => '1500',
+            'retail_price_withdisc_rub' => '1300',
+            'ppvz_for_pay' => '1200',
+            'acquiring_fee' => '20',
+            'quantity' => 2,
+            'srid' => 'srid-1',
+            'rr_dt' => '2026-05-01 12:00:00',
+            'sale_dt' => '2026-05-01 11:00:00',
+        ];
+    }
+
+    private function oldReturnRow(): array
+    {
+        $row = $this->oldSaleRow();
+        $row['doc_type_name'] = 'Возврат';
+        $row['supplier_oper_name'] = 'Возврат покупателем';
+
+        return $row;
+    }
+
+    private function newSaleRow(): array
+    {
+        return [
+            'rrdId' => '1001',
+            'docTypeName' => 'Sale',
+            'sellerOperName' => 'Sale operation',
+            'nmId' => '12345',
+            'vendorCode' => 'ART-1',
+            'techSize' => 'M',
+            'sku' => '4600000000001',
+            'retailPrice' => '1500',
+            'retailAmount' => '1500',
+            'retailPriceWithDisc' => '1300',
+            'forPay' => '1200',
+            'acquiringFee' => '20',
+            'quantity' => 2,
+            'srid' => 'srid-1',
+            'rrDate' => '2026-05-01 12:00:00',
+            'saleDt' => '2026-05-01 11:00:00',
+        ];
+    }
+
+    private function newReturnRow(): array
+    {
+        $row = $this->newSaleRow();
+        $row['docTypeName'] = 'Return';
+        $row['sellerOperName'] = 'Return operation';
+
+        return $row;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a single normalizer that understands both old snake_case and new camelCase Wildberries sales report rows and centralizes parsing/normalization logic.
- Ensure correct type conversions, date parsing and consistent identification of sale vs return rows for downstream processing.

### Description
- Add `WbSalesReportRowNormalizer` implementing helpers `raw`, `string`, `nullableString`, `float` and specific accessors like `rrdId`, `srid`, `nmId`, `vendorCode`, `barcode`, `quantity`, `retailPrice`, `retailAmount`, `retailPriceWithDisc`, `forPay`, `acquiringFee`, `reportDate`, `operationDate`, `isSale`, `isReturn`, `isSaleOrReturn`, and `fullMarketplaceCommission` in `site/src/Marketplace/Infrastructure/Normalizer/Wildberries/WbSalesReportRowNormalizer.php`.
- Support both snake_case and camelCase keys, trim and nullable handling, numeric casting, date parsing with explicit exceptions when required date fields are missing, and normalize `docTypeName` values (`"продажа"/"sale"` => `sale`, `"возврат"/"return"` => `return`).
- Add comprehensive unit tests in `site/tests/Unit/Marketplace/Infrastructure/Wildberries/WbSalesReportRowNormalizerTest.php` covering old/new formats, sale/return detection, commission calculation, date error cases and edge cases around doc type and operation names.

### Testing
- Ran the new unit test class with `phpunit` targeting `WbSalesReportRowNormalizerTest`, and all assertions passed. 
- New tests cover positive cases for old/new rows and negative cases for missing dates and unknown doc types, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05a61151888323b7c04cfe8086eec4)