### PR TITLE
Normalize WB sales rows with WbSalesReportRowNormalizer and compute per-unit price; add revenue tests

### DIFF
--- a/site/src/Marketplace/Application/ProcessWbSalesAction.php
+++ b/site/src/Marketplace/Application/ProcessWbSalesAction.php
@@ -10,6 +10,7 @@ use App\Marketplace\Entity\MarketplaceListing;
 use App\Marketplace\Entity\MarketplaceRawDocument;
 use App\Marketplace\Entity\MarketplaceSale;
 use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
 use App\Marketplace\Repository\MarketplaceListingRepository;
 use App\Marketplace\Repository\MarketplaceSaleRepository;
 use Doctrine\ORM\EntityManagerInterface;
@@ -23,6 +24,7 @@ final class ProcessWbSalesAction
         private readonly MarketplaceSaleRepository $saleRepository,
         private readonly MarketplaceListingRepository $listingRepository,
         private readonly WbListingResolverService $listingResolver,
+        private readonly WbSalesReportRowNormalizer $normalizer,
         private readonly LoggerInterface $logger,
     ) {
     }
@@ -43,9 +45,10 @@ final class ProcessWbSalesAction
         $synced = 0;
         $batchSize = 250;
 
-        $salesData = array_filter($rawData, static function (array $item): bool {
-            return ($item['doc_type_name'] ?? '') === 'Продажа'
-                && (float) ($item['retail_amount'] ?? 0) > 0;
+        $salesData = array_filter($rawData, function (array $item): bool {
+            return $this->normalizer->isSale($item)
+                && $this->normalizer->quantity($item) > 0
+                && $this->normalizer->retailPriceWithDisc($item) > 0;
         });
 
         if (empty($salesData)) {
@@ -60,7 +63,10 @@ final class ProcessWbSalesAction
         $allSrids = array_column($salesData, 'srid');
         $existingSridsMap = $this->saleRepository->getExistingExternalIds($companyId, $allSrids);
 
-        $allNmIds = array_values(array_unique(array_column($salesData, 'nm_id')));
+        $allNmIds = array_values(array_unique(array_map(
+            fn (array $item): string => $this->normalizer->nmId($item),
+            $salesData,
+        )));
         $listingsCache = $this->listingRepository->findListingsByNmIdsIndexed(
             $company,
             MarketplaceType::WILDBERRIES,
@@ -69,17 +75,17 @@ final class ProcessWbSalesAction
 
         $newListingsCreated = 0;
         foreach ($salesData as $item) {
-            $nmId = (string) ($item['nm_id'] ?? '');
-            $tsName = $item['ts_name'] ?? null;
+            $nmId = $this->normalizer->nmId($item);
+            $tsName = $this->normalizer->techSize($item);
             $size = (trim((string) $tsName) !== '') ? trim((string) $tsName) : 'UNKNOWN';
             $cacheKey = $nmId . '_' . $size;
 
             if (!isset($listingsCache[$cacheKey])) {
                 $listing = $this->listingResolver->resolve($company, $nmId, $tsName, [
-                    'sa_name'      => $item['sa_name'] ?? '',
-                    'brand_name'   => $item['brand_name'] ?? '',
-                    'subject_name' => $item['subject_name'] ?? '',
-                    'retail_price' => $item['retail_price'] ?? 0,
+                    'sa_name'      => $this->normalizer->vendorCode($item),
+                    'brand_name'   => (string) ($item['brand_name'] ?? $item['brandName'] ?? ''),
+                    'subject_name' => (string) ($item['subject_name'] ?? $item['subjectName'] ?? ''),
+                    'retail_price' => (string) ($item['retail_price'] ?? $item['retailPrice'] ?? '0'),
                 ]);
                 $listingsCache[$cacheKey] = $listing;
                 $newListingsCreated++;
@@ -99,8 +105,8 @@ final class ProcessWbSalesAction
                     continue;
                 }
 
-                $nmId = (string) ($item['nm_id'] ?? '');
-                $tsName = $item['ts_name'] ?? null;
+                $nmId = $this->normalizer->nmId($item);
+                $tsName = $this->normalizer->techSize($item);
                 $size = (trim((string) $tsName) !== '') ? trim((string) $tsName) : 'UNKNOWN';
                 $cacheKey = $nmId . '_' . $size;
                 $listing = $listingsCache[$cacheKey] ?? null;
@@ -118,11 +124,16 @@ final class ProcessWbSalesAction
                 );
 
                 $sale->setExternalOrderId($externalOrderId);
-                $sale->setSaleDate(new \DateTimeImmutable($item['sale_dt'] ?? $item['rr_dt']));
-                $sale->setQuantity(abs((int) $item['quantity']));
-                $sale->setPricePerUnit((string) $item['retail_price']);
-                $sale->setTotalRevenue((string) abs((float) $item['retail_amount']));
+                $sale->setSaleDate($this->normalizer->operationDate($item));
+                $quantity = abs($this->normalizer->quantity($item));
+                $retailPriceWithDisc = $this->normalizer->retailPriceWithDisc($item);
+                $pricePerUnit = $quantity > 0 ? $retailPriceWithDisc / $quantity : 0.0;
+
+                $sale->setQuantity($quantity);
+                $sale->setPricePerUnit((string) $pricePerUnit);
+                $sale->setTotalRevenue((string) $retailPriceWithDisc);
                 $sale->setRawDocumentId($rawDocId);
+                $sale->setRawData($item);
 
                 $this->em->persist($sale);
                 $existingSridsMap[$externalOrderId] = true;

--- a/site/src/Marketplace/Application/Processor/WbSalesRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/WbSalesRawProcessor.php
@@ -12,6 +12,7 @@ use App\Marketplace\Application\Service\WbListingResolverService;
 use App\Marketplace\Entity\MarketplaceSale;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Enum\StagingRecordType;
+use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
 use App\Marketplace\Repository\MarketplaceListingRepository;
 use App\Marketplace\Repository\MarketplaceSaleRepository;
 use Doctrine\ORM\EntityManagerInterface;
@@ -28,6 +29,7 @@ final class WbSalesRawProcessor implements MarketplaceRawProcessorInterface
         private readonly WbListingResolverService $listingResolver,
         private readonly MarketplaceBarcodeCatalogService $barcodeCatalog,
         private readonly MarketplaceCostPriceResolver $costPriceResolver,
+        private readonly WbSalesReportRowNormalizer $normalizer,
         private readonly LoggerInterface $logger,
     ) {
     }
@@ -65,9 +67,10 @@ final class WbSalesRawProcessor implements MarketplaceRawProcessorInterface
             throw new \RuntimeException('Company not found: ' . $companyId);
         }
 
-        $salesData = array_filter($rawRows, static function (array $item): bool {
-            return ($item['doc_type_name'] ?? '') === 'Продажа'
-                && (float) ($item['retail_amount'] ?? 0) > 0;
+        $salesData = array_filter($rawRows, function (array $item): bool {
+            return $this->normalizer->isSale($item)
+                && $this->normalizer->quantity($item) > 0
+                && $this->normalizer->retailPriceWithDisc($item) > 0;
         });
 
         if (empty($salesData)) {
@@ -76,7 +79,10 @@ final class WbSalesRawProcessor implements MarketplaceRawProcessorInterface
 
         $this->barcodeCatalog->fillFromWbRows($companyId, array_values($salesData));
 
-        $allNmIds = array_values(array_unique(array_column($salesData, 'nm_id')));
+        $allNmIds = array_values(array_unique(array_map(
+            fn (array $item): string => $this->normalizer->nmId($item),
+            $salesData,
+        )));
         $listingsCache = $this->listingRepository->findListingsByNmIdsIndexed(
             $company,
             MarketplaceType::WILDBERRIES,
@@ -85,8 +91,8 @@ final class WbSalesRawProcessor implements MarketplaceRawProcessorInterface
 
         $newListings = 0;
         foreach ($salesData as $item) {
-            $nmId = (string) ($item['nm_id'] ?? '');
-            $tsName = $item['ts_name'] ?? null;
+            $nmId = $this->normalizer->nmId($item);
+            $tsName = $this->normalizer->techSize($item);
             $size = trim((string) $tsName) !== '' ? trim((string) $tsName) : 'UNKNOWN';
             $cacheKey = $nmId . '_' . $size;
 
@@ -94,12 +100,12 @@ final class WbSalesRawProcessor implements MarketplaceRawProcessorInterface
                 continue;
             }
 
-            $barcode = (string) ($item['barcode'] ?? '');
+            $barcode = (string) ($this->normalizer->barcode($item) ?? '');
             $listing = $this->listingResolver->resolve($company, $nmId, $tsName, [
-                'sa_name'      => (string) ($item['sa_name'] ?? ''),
-                'brand_name'   => (string) ($item['brand_name'] ?? ''),
-                'subject_name' => (string) ($item['subject_name'] ?? ''),
-                'retail_price' => (string) ($item['retail_price'] ?? '0'),
+                'sa_name'      => $this->normalizer->vendorCode($item),
+                'brand_name'   => (string) ($item['brand_name'] ?? $item['brandName'] ?? ''),
+                'subject_name' => (string) ($item['subject_name'] ?? $item['subjectName'] ?? ''),
+                'retail_price' => (string) ($item['retail_price'] ?? $item['retailPrice'] ?? '0'),
             ], $barcode);
             $listingsCache[$cacheKey] = $listing;
             $newListings++;
@@ -120,8 +126,8 @@ final class WbSalesRawProcessor implements MarketplaceRawProcessorInterface
                 continue;
             }
 
-            $nmId = (string) ($item['nm_id'] ?? '');
-            $tsName = $item['ts_name'] ?? null;
+            $nmId = $this->normalizer->nmId($item);
+            $tsName = $this->normalizer->techSize($item);
             $size = trim((string) $tsName) !== '' ? trim((string) $tsName) : 'UNKNOWN';
             $listing = $listingsCache[$nmId . '_' . $size] ?? null;
 
@@ -130,7 +136,7 @@ final class WbSalesRawProcessor implements MarketplaceRawProcessorInterface
                 continue;
             }
 
-            $saleDate = new \DateTimeImmutable($item['sale_dt'] ?? $item['rr_dt']);
+            $saleDate = $this->normalizer->operationDate($item);
 
             $sale = new MarketplaceSale(
                 Uuid::uuid4()->toString(),
@@ -141,9 +147,13 @@ final class WbSalesRawProcessor implements MarketplaceRawProcessorInterface
 
             $sale->setExternalOrderId($srid);
             $sale->setSaleDate($saleDate);
-            $sale->setQuantity(abs((int) ($item['quantity'] ?? 1)));
-            $sale->setPricePerUnit((string) ($item['retail_price'] ?? '0'));
-            $sale->setTotalRevenue((string) abs((float) ($item['retail_amount'] ?? 0)));
+            $quantity = abs($this->normalizer->quantity($item));
+            $retailPriceWithDisc = $this->normalizer->retailPriceWithDisc($item);
+            $pricePerUnit = $quantity > 0 ? $retailPriceWithDisc / $quantity : 0.0;
+
+            $sale->setQuantity($quantity);
+            $sale->setPricePerUnit((string) $pricePerUnit);
+            $sale->setTotalRevenue((string) $retailPriceWithDisc);
             $sale->setCostPrice($this->costPriceResolver->resolveForSale($listing, $saleDate));
             $sale->setRawData($item);
             if ($rawDocId !== null) {

--- a/site/tests/Unit/Marketplace/Application/Processor/WbSalesRawProcessorRevenueTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/WbSalesRawProcessorRevenueTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Application\Processor;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Application\ProcessWbSalesAction;
+use App\Marketplace\Application\Processor\WbSalesRawProcessor;
+use App\Marketplace\Application\Service\MarketplaceBarcodeCatalogService;
+use App\Marketplace\Application\Service\MarketplaceCostPriceResolver;
+use App\Marketplace\Application\Service\WbListingResolverService;
+use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Entity\MarketplaceSale;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
+use App\Marketplace\Repository\MarketplaceListingRepository;
+use App\Marketplace\Repository\MarketplaceSaleRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+final class WbSalesRawProcessorRevenueTest extends TestCase
+{
+    public function testUsesRetailPriceWithDiscAsRevenueForOldSnakeCase(): void
+    {
+        $result = $this->runProcessorWithRow([
+            'doc_type_name' => 'Продажа',
+            'retail_price_withdisc_rub' => 2493,
+            'retail_amount' => 1607,
+            'quantity' => 1,
+            'srid' => 'WB-ORDER-1',
+            'nm_id' => '123',
+            'ts_name' => 'XL',
+            'sale_dt' => '2026-01-10 10:00:00',
+        ]);
+
+        self::assertCount(1, $result['sales']);
+        self::assertSame([['123']], $result['nmIdsCalls']);
+        self::assertSame('2493', $result['sales'][0]->getTotalRevenue());
+        self::assertSame('2493', $result['sales'][0]->getPricePerUnit());
+        self::assertNotSame('1607', $result['sales'][0]->getTotalRevenue());
+        self::assertSame('2026-01-10', $result['sales'][0]->getSaleDate()->format('Y-m-d'));
+    }
+
+    public function testUsesRetailPriceWithDiscAsRevenueForNewCamelCase(): void
+    {
+        $result = $this->runProcessorWithRow([
+            'docTypeName' => 'Sale',
+            'retailPriceWithDisc' => 2493,
+            'retailAmount' => 1607,
+            'quantity' => 1,
+            'srid' => 'WB-ORDER-1',
+            'nmId' => '123',
+            'techSize' => 'XL',
+            'saleDt' => '2026-01-10 10:00:00',
+        ]);
+
+        self::assertCount(1, $result['sales']);
+        self::assertSame([['123']], $result['nmIdsCalls']);
+        self::assertSame('2493', $result['sales'][0]->getTotalRevenue());
+        self::assertSame('2493', $result['sales'][0]->getPricePerUnit());
+        self::assertNotSame('1607', $result['sales'][0]->getTotalRevenue());
+        self::assertSame('2026-01-10', $result['sales'][0]->getSaleDate()->format('Y-m-d'));
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @return array{sales: list<MarketplaceSale>, nmIdsCalls: list<list<string>>}
+     */
+    private function runProcessorWithRow(array $row): array
+    {
+        $company = $this->createMock(Company::class);
+        $listing = $this->createMock(MarketplaceListing::class);
+
+        $persistedSales = [];
+        $nmIdsCalls = [];
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('find')->willReturnMap([
+            [Company::class, 'company-1', $company],
+        ]);
+        $em->method('persist')->willReturnCallback(static function (object $entity) use (&$persistedSales): void {
+            if ($entity instanceof MarketplaceSale) {
+                $persistedSales[] = $entity;
+            }
+        });
+
+        $saleRepository = $this->createMock(MarketplaceSaleRepository::class);
+        $saleRepository->method('getExistingExternalIds')->willReturn([]);
+
+        $listingRepository = $this->createMock(MarketplaceListingRepository::class);
+        $listingRepository->method('findListingsByNmIdsIndexed')
+            ->willReturnCallback(static function (
+                Company $companyArg,
+                MarketplaceType $marketplace,
+                array $nmIds,
+            ) use ($listing, &$nmIdsCalls): array {
+                $nmIdsCalls[] = $nmIds;
+                return ['123_XL' => $listing];
+            });
+
+        $barcodeCatalog = $this->createMock(MarketplaceBarcodeCatalogService::class);
+        $costPriceResolver = $this->createMock(MarketplaceCostPriceResolver::class);
+        $costPriceResolver->method('resolveForSale')->willReturn(null);
+
+        $processor = new WbSalesRawProcessor(
+            $this->createMock(ProcessWbSalesAction::class),
+            $em,
+            $saleRepository,
+            $listingRepository,
+            $this->createMock(WbListingResolverService::class),
+            $barcodeCatalog,
+            $costPriceResolver,
+            new WbSalesReportRowNormalizer(),
+            new NullLogger(),
+        );
+
+        $processor->processBatch('company-1', MarketplaceType::WILDBERRIES, [$row]);
+
+        return ['sales' => $persistedSales, 'nmIdsCalls' => $nmIdsCalls];
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce a single normalizer to reliably parse Wildberries sales rows that may come in snake_case or camelCase and to centralize revenue/quantity extraction.

### Description
- Inject `WbSalesReportRowNormalizer` into `ProcessWbSalesAction` and `WbSalesRawProcessor` and replace direct array field access with normalizer methods like `isSale`, `nmId`, `techSize`, `quantity`, `retailPriceWithDisc`, `operationDate`, `vendorCode`, and `barcode`.
- Filter sales rows using `isSale` and require positive `quantity` and `retailPriceWithDisc` values before processing.
- Compute `pricePerUnit` as `retailPriceWithDisc / quantity`, set `totalRevenue` to `retailPriceWithDisc`, and persist `rawData` on created `MarketplaceSale` entities.
- Normalize brand/subject/price inputs to handle both snake_case and camelCase fields and keep existing listing resolution/flush logic intact.

### Testing
- Added unit test `WbSalesRawProcessorRevenueTest` that exercises both snake_case and camelCase row formats and asserts `totalRevenue`, `pricePerUnit`, `saleDate`, and `nm_id` lookup behavior. 
- Ran the unit test suite for the new test (`phpunit` run for `WbSalesRawProcessorRevenueTest`) and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05a8e183948323917a56a62696d1eb)