### PR TITLE
Use WbSalesReportRowNormalizer for Wildberries returns and add refund-amount test

### DIFF
--- a/site/src/Marketplace/Application/ProcessWbReturnsAction.php
+++ b/site/src/Marketplace/Application/ProcessWbReturnsAction.php
@@ -10,6 +10,7 @@ use App\Marketplace\Entity\MarketplaceListing;
 use App\Marketplace\Entity\MarketplaceRawDocument;
 use App\Marketplace\Entity\MarketplaceReturn;
 use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
 use App\Marketplace\Repository\MarketplaceListingRepository;
 use App\Marketplace\Repository\MarketplaceReturnRepository;
 use Doctrine\ORM\EntityManagerInterface;
@@ -23,6 +24,7 @@ final class ProcessWbReturnsAction
         private readonly MarketplaceReturnRepository $returnRepository,
         private readonly MarketplaceListingRepository $listingRepository,
         private readonly WbListingResolverService $listingResolver,
+        private readonly WbSalesReportRowNormalizer $normalizer,
         private readonly LoggerInterface $logger,
     ) {
     }
@@ -45,11 +47,10 @@ final class ProcessWbReturnsAction
         $synced = 0;
         $batchSize = 250;
 
-        $returnsData = array_filter($rawData, static function (array $item): bool {
-            $docType = $item['doc_type_name'] ?? '';
-
-            return in_array($docType, ['Возврат', 'возврат', 'Return'], true)
-                && (float) ($item['retail_price'] ?? 0) > 0;
+        $returnsData = array_filter($rawData, function (array $item): bool {
+            return $this->normalizer->isReturn($item)
+                && $this->normalizer->quantity($item) > 0
+                && $this->normalizer->retailPriceWithDisc($item) > 0;
         });
 
         if (empty($returnsData)) {
@@ -65,7 +66,10 @@ final class ProcessWbReturnsAction
         $allSrids = array_column($returnsData, 'srid');
         $existingSridsMap = $this->returnRepository->getExistingExternalIds($companyId, $allSrids);
 
-        $allNmIds = array_values(array_unique(array_column($returnsData, 'nm_id')));
+        $allNmIds = array_values(array_unique(array_map(
+            fn (array $item): string => $this->normalizer->nmId($item),
+            $returnsData,
+        )));
         $listingsCache = $this->listingRepository->findListingsByNmIdsIndexed(
             $company,
             MarketplaceType::WILDBERRIES,
@@ -74,8 +78,8 @@ final class ProcessWbReturnsAction
 
         $newListingsCreated = 0;
         foreach ($returnsData as $item) {
-            $nmId = (string) ($item['nm_id'] ?? '');
-            $tsName = $item['ts_name'] ?? null;
+            $nmId = $this->normalizer->nmId($item);
+            $tsName = $this->normalizer->techSize($item);
             $size = trim((string) $tsName) !== '' ? trim((string) $tsName) : 'UNKNOWN';
             $cacheKey = $nmId . '_' . $size;
 
@@ -109,8 +113,8 @@ final class ProcessWbReturnsAction
                     continue;
                 }
 
-                $nmId = (string) ($item['nm_id'] ?? '');
-                $tsName = $item['ts_name'] ?? null;
+                $nmId = $this->normalizer->nmId($item);
+                $tsName = $this->normalizer->techSize($item);
                 $size = trim((string) $tsName) !== '' ? trim((string) $tsName) : 'UNKNOWN';
                 $cacheKey = $nmId . '_' . $size;
 
@@ -132,11 +136,12 @@ final class ProcessWbReturnsAction
                 );
 
                 $return->setExternalReturnId($externalReturnId);
-                $return->setReturnDate(new \DateTimeImmutable($item['rr_dt']));
-                $return->setQuantity(abs((int) $item['quantity']));
-                $return->setRefundAmount((string) $item['retail_price']);
-                $return->setReturnReason($item['supplier_oper_name'] ?? '');
+                $return->setReturnDate($this->normalizer->reportDate($item));
+                $return->setQuantity(abs($this->normalizer->quantity($item)));
+                $return->setRefundAmount((string) $this->normalizer->retailPriceWithDisc($item));
+                $return->setReturnReason($this->normalizer->sellerOperName($item));
                 $return->setRawDocumentId($rawDocId);
+                $return->setRawData($item);
 
                 $this->em->persist($return);
                 $existingSridsMap[$externalReturnId] = true;

--- a/site/src/Marketplace/Application/Processor/WbReturnsRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/WbReturnsRawProcessor.php
@@ -12,6 +12,7 @@ use App\Marketplace\Application\Service\WbListingResolverService;
 use App\Marketplace\Entity\MarketplaceReturn;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Enum\StagingRecordType;
+use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
 use App\Marketplace\Repository\MarketplaceListingRepository;
 use App\Marketplace\Repository\MarketplaceReturnRepository;
 use App\Marketplace\Repository\MarketplaceSaleRepository;
@@ -30,6 +31,7 @@ final class WbReturnsRawProcessor implements MarketplaceRawProcessorInterface
         private readonly WbListingResolverService $listingResolver,
         private readonly MarketplaceBarcodeCatalogService $barcodeCatalog,
         private readonly MarketplaceCostPriceResolver $costPriceResolver,
+        private readonly WbSalesReportRowNormalizer $normalizer,
         private readonly LoggerInterface $logger,
     ) {
     }
@@ -67,9 +69,10 @@ final class WbReturnsRawProcessor implements MarketplaceRawProcessorInterface
             throw new \RuntimeException('Company not found: ' . $companyId);
         }
 
-        $returnsData = array_filter($rawRows, static function (array $item): bool {
-            return in_array($item['doc_type_name'] ?? '', ['Возврат', 'возврат', 'Return'], true)
-                && (float) ($item['retail_price'] ?? 0) > 0;
+        $returnsData = array_filter($rawRows, function (array $item): bool {
+            return $this->normalizer->isReturn($item)
+                && $this->normalizer->quantity($item) > 0
+                && $this->normalizer->retailPriceWithDisc($item) > 0;
         });
 
         if (empty($returnsData)) {
@@ -78,7 +81,10 @@ final class WbReturnsRawProcessor implements MarketplaceRawProcessorInterface
 
         $this->barcodeCatalog->fillFromWbRows($companyId, array_values($returnsData));
 
-        $allNmIds = array_values(array_unique(array_column($returnsData, 'nm_id')));
+        $allNmIds = array_values(array_unique(array_map(
+            fn (array $item): string => $this->normalizer->nmId($item),
+            $returnsData,
+        )));
         $listingsCache = $this->listingRepository->findListingsByNmIdsIndexed(
             $company,
             MarketplaceType::WILDBERRIES,
@@ -87,8 +93,8 @@ final class WbReturnsRawProcessor implements MarketplaceRawProcessorInterface
 
         $newListings = 0;
         foreach ($returnsData as $item) {
-            $nmId = (string) ($item['nm_id'] ?? '');
-            $tsName = $item['ts_name'] ?? null;
+            $nmId = $this->normalizer->nmId($item);
+            $tsName = $this->normalizer->techSize($item);
             $size = trim((string) $tsName) !== '' ? trim((string) $tsName) : 'UNKNOWN';
             $cacheKey = $nmId . '_' . $size;
 
@@ -122,8 +128,8 @@ final class WbReturnsRawProcessor implements MarketplaceRawProcessorInterface
                 continue;
             }
 
-            $nmId = (string) ($item['nm_id'] ?? '');
-            $tsName = $item['ts_name'] ?? null;
+            $nmId = $this->normalizer->nmId($item);
+            $tsName = $this->normalizer->techSize($item);
             $size = trim((string) $tsName) !== '' ? trim((string) $tsName) : 'UNKNOWN';
             $listing = $listingsCache[$nmId . '_' . $size] ?? null;
 
@@ -147,10 +153,10 @@ final class WbReturnsRawProcessor implements MarketplaceRawProcessorInterface
             );
 
             $return->setExternalReturnId($srid);
-            $return->setReturnDate(new \DateTimeImmutable($item['rr_dt']));
-            $return->setQuantity(abs((int) ($item['quantity'] ?? 1)));
-            $return->setRefundAmount((string) ($item['retail_price'] ?? '0'));
-            $return->setReturnReason($item['supplier_oper_name'] ?? '');
+            $return->setReturnDate($this->normalizer->reportDate($item));
+            $return->setQuantity(abs($this->normalizer->quantity($item)));
+            $return->setRefundAmount((string) $this->normalizer->retailPriceWithDisc($item));
+            $return->setReturnReason($this->normalizer->sellerOperName($item));
             $return->setCostPrice($this->costPriceResolver->resolveForReturn($listing, $sale, $item));
             $return->setRawData($item);
             if ($rawDocId !== null) {

--- a/site/tests/Unit/Marketplace/Application/Processor/WbReturnsRawProcessorRefundAmountTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/WbReturnsRawProcessorRefundAmountTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Application\Processor;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Application\ProcessWbReturnsAction;
+use App\Marketplace\Application\Processor\WbReturnsRawProcessor;
+use App\Marketplace\Application\Service\MarketplaceBarcodeCatalogService;
+use App\Marketplace\Application\Service\MarketplaceCostPriceResolver;
+use App\Marketplace\Application\Service\WbListingResolverService;
+use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Entity\MarketplaceReturn;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
+use App\Marketplace\Repository\MarketplaceListingRepository;
+use App\Marketplace\Repository\MarketplaceReturnRepository;
+use App\Marketplace\Repository\MarketplaceSaleRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+final class WbReturnsRawProcessorRefundAmountTest extends TestCase
+{
+    public function testUsesRetailPriceWithDiscAsRefundAmountForOldSnakeCase(): void
+    {
+        $result = $this->runProcessorWithRow([
+            'doc_type_name' => 'Возврат',
+            'retail_price_withdisc_rub' => 1125,
+            'retail_amount' => 720,
+            'retail_price' => 1500,
+            'quantity' => 1,
+            'srid' => 'WB-RETURN-1',
+            'nm_id' => '123',
+            'ts_name' => 'XL',
+            'supplier_oper_name' => 'Возврат покупателем',
+            'rr_dt' => '2026-01-10 10:00:00',
+        ]);
+
+        self::assertCount(1, $result['returns']);
+        self::assertSame([['123']], $result['nmIdsCalls']);
+        self::assertSame('1125', $result['returns'][0]->getRefundAmount());
+        self::assertNotSame('720', $result['returns'][0]->getRefundAmount());
+        self::assertNotSame('1500', $result['returns'][0]->getRefundAmount());
+        self::assertSame('Возврат покупателем', $result['returns'][0]->getReturnReason());
+        self::assertSame('2026-01-10', $result['returns'][0]->getReturnDate()->format('Y-m-d'));
+    }
+
+    public function testUsesRetailPriceWithDiscAsRefundAmountForNewCamelCase(): void
+    {
+        $result = $this->runProcessorWithRow([
+            'docTypeName' => 'Return',
+            'retailPriceWithDisc' => 1125,
+            'retailAmount' => 720,
+            'retailPrice' => 1500,
+            'quantity' => 1,
+            'srid' => 'WB-RETURN-1',
+            'nmId' => '123',
+            'techSize' => 'XL',
+            'sellerOperName' => 'Customer return',
+            'rrDate' => '2026-01-10 10:00:00',
+        ]);
+
+        self::assertCount(1, $result['returns']);
+        self::assertSame([['123']], $result['nmIdsCalls']);
+        self::assertSame('1125', $result['returns'][0]->getRefundAmount());
+        self::assertNotSame('720', $result['returns'][0]->getRefundAmount());
+        self::assertNotSame('1500', $result['returns'][0]->getRefundAmount());
+        self::assertSame('Customer return', $result['returns'][0]->getReturnReason());
+        self::assertSame('2026-01-10', $result['returns'][0]->getReturnDate()->format('Y-m-d'));
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @return array{returns: list<MarketplaceReturn>, nmIdsCalls: list<list<string>>}
+     */
+    private function runProcessorWithRow(array $row): array
+    {
+        $company = $this->createMock(Company::class);
+        $listing = $this->createMock(MarketplaceListing::class);
+
+        $persistedReturns = [];
+        $nmIdsCalls = [];
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('find')->willReturnMap([
+            [Company::class, 'company-1', $company],
+        ]);
+        $em->method('persist')->willReturnCallback(static function (object $entity) use (&$persistedReturns): void {
+            if ($entity instanceof MarketplaceReturn) {
+                $persistedReturns[] = $entity;
+            }
+        });
+
+        $returnRepository = $this->createMock(MarketplaceReturnRepository::class);
+        $returnRepository->method('getExistingExternalIds')->willReturn([]);
+
+        $listingRepository = $this->createMock(MarketplaceListingRepository::class);
+        $listingRepository->method('findListingsByNmIdsIndexed')
+            ->willReturnCallback(static function (
+                Company $companyArg,
+                MarketplaceType $marketplace,
+                array $nmIds,
+            ) use ($listing, &$nmIdsCalls): array {
+                $nmIdsCalls[] = $nmIds;
+                return ['123_XL' => $listing];
+            });
+
+        $saleRepository = $this->createMock(MarketplaceSaleRepository::class);
+        $saleRepository->method('findByMarketplaceOrder')->willReturn(null);
+
+        $barcodeCatalog = $this->createMock(MarketplaceBarcodeCatalogService::class);
+        $costPriceResolver = $this->createMock(MarketplaceCostPriceResolver::class);
+        $costPriceResolver->method('resolveForReturn')->willReturn(null);
+
+        $processor = new WbReturnsRawProcessor(
+            $this->createMock(ProcessWbReturnsAction::class),
+            $em,
+            $returnRepository,
+            $saleRepository,
+            $listingRepository,
+            $this->createMock(WbListingResolverService::class),
+            $barcodeCatalog,
+            $costPriceResolver,
+            new WbSalesReportRowNormalizer(),
+            new NullLogger(),
+        );
+
+        $processor->processBatch('company-1', MarketplaceType::WILDBERRIES, [$row]);
+
+        return ['returns' => $persistedReturns, 'nmIdsCalls' => $nmIdsCalls];
+    }
+}


### PR DESCRIPTION
### Motivation

- Centralize and standardize parsing of Wildberries returns rows to support both snake_case and camelCase report formats. 
- Ensure the refund amount is taken from `retailPriceWithDisc` (normalized) rather than relying on fragile direct array keys.

### Description

- Inject `WbSalesReportRowNormalizer` into `ProcessWbReturnsAction` and `WbReturnsRawProcessor` and add the corresponding `use` imports. 
- Replace ad-hoc array key reads/filters with normalizer calls like `isReturn`, `quantity`, `retailPriceWithDisc`, `nmId`, `techSize`, `reportDate`, and `sellerOperName`. 
- Build the list of NM ids using `array_map` with the normalizer and set `rawData` on new `MarketplaceReturn` entities created in `ProcessWbReturnsAction`. 
- Add unit test `WbReturnsRawProcessorRefundAmountTest` that verifies `retailPriceWithDisc` is used as the refund amount for both snake_case and camelCase row variants.

### Testing

- Ran the new unit test `WbReturnsRawProcessorRefundAmountTest` (`phpunit` targeted) and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05ad08d04c83238f51de993411d7db)