### PR TITLE
WB: fix commission and acquiring calculation for returns

### DIFF
--- a/site/src/Marketplace/Service/CostCalculator/WbAcquiringCalculator.php
+++ b/site/src/Marketplace/Service/CostCalculator/WbAcquiringCalculator.php
@@ -3,12 +3,21 @@
 namespace App\Marketplace\Service\CostCalculator;
 
 use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Enum\MarketplaceCostOperationType;
+use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
 
 class WbAcquiringCalculator implements CostCalculatorInterface
 {
+    private WbSalesReportRowNormalizer $normalizer;
+
+    public function __construct(?WbSalesReportRowNormalizer $normalizer = null)
+    {
+        $this->normalizer = $normalizer ?? new WbSalesReportRowNormalizer();
+    }
+
     public function supports(array $item): bool
     {
-        return ($item['doc_type_name'] ?? '') === 'Продажа';
+        return $this->normalizer->isSaleOrReturn($item);
     }
 
     public function requiresListing(): bool
@@ -18,14 +27,17 @@ class WbAcquiringCalculator implements CostCalculatorInterface
 
     public function calculate(array $item, ?MarketplaceListing $listing): array
     {
-        $acquiringFee = (float)($item['acquiring_fee'] ?? 0);
+        $acquiringFee = $this->normalizer->acquiringFee($item);
 
         if (abs($acquiringFee) < 0.01) {
             return [];
         }
 
         $srid = (string)$item['srid'];
-        $saleDate = new \DateTimeImmutable($item['sale_dt'] ?? $item['rr_dt']);
+        $saleDate = $this->normalizer->operationDate($item);
+        $operationType = $this->normalizer->isReturn($item)
+            ? MarketplaceCostOperationType::STORNO
+            : MarketplaceCostOperationType::CHARGE;
 
         return [
             [
@@ -34,6 +46,7 @@ class WbAcquiringCalculator implements CostCalculatorInterface
                 'external_id' => $srid . '_acquiring',
                 'cost_date' => $saleDate,
                 'description' => 'Эквайринг',
+                'operation_type' => $operationType,
                 'product' => $listing?->getProduct(),
             ],
         ];

--- a/site/src/Marketplace/Service/CostCalculator/WbCommissionCalculator.php
+++ b/site/src/Marketplace/Service/CostCalculator/WbCommissionCalculator.php
@@ -3,12 +3,21 @@
 namespace App\Marketplace\Service\CostCalculator;
 
 use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Enum\MarketplaceCostOperationType;
+use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
 
 class WbCommissionCalculator implements CostCalculatorInterface
 {
+    private WbSalesReportRowNormalizer $normalizer;
+
+    public function __construct(?WbSalesReportRowNormalizer $normalizer = null)
+    {
+        $this->normalizer = $normalizer ?? new WbSalesReportRowNormalizer();
+    }
+
     public function supports(array $item): bool
     {
-        return ($item['doc_type_name'] ?? '') === 'Продажа';
+        return $this->normalizer->isSaleOrReturn($item);
     }
 
     public function requiresListing(): bool
@@ -18,10 +27,10 @@ class WbCommissionCalculator implements CostCalculatorInterface
 
     public function calculate(array $item, ?MarketplaceListing $listing): array
     {
-        $retailPrice = (float)($item['retail_price'] ?? 0);
-        $acquiringFee = (float)($item['acquiring_fee'] ?? 0);
-        $ppvzForPay = (float)($item['ppvz_for_pay'] ?? 0);
-        $commission = $retailPrice - $acquiringFee - $ppvzForPay;
+        $retailPriceWithDisc = $this->normalizer->retailPriceWithDisc($item);
+        $acquiringFee = $this->normalizer->acquiringFee($item);
+        $forPay = $this->normalizer->forPay($item);
+        $commission = $retailPriceWithDisc - $forPay - $acquiringFee;
 
         // Пропускаем нулевые комиссии
         if (abs($commission) < 0.01) {
@@ -29,7 +38,10 @@ class WbCommissionCalculator implements CostCalculatorInterface
         }
 
         $srid = (string)$item['srid'];
-        $saleDate = new \DateTimeImmutable($item['sale_dt'] ?? $item['rr_dt']);
+        $saleDate = $this->normalizer->operationDate($item);
+        $operationType = $this->normalizer->isReturn($item)
+            ? MarketplaceCostOperationType::STORNO
+            : MarketplaceCostOperationType::CHARGE;
 
         return [
             [
@@ -38,6 +50,7 @@ class WbCommissionCalculator implements CostCalculatorInterface
                 'external_id' => $srid . '_commission',
                 'cost_date' => $saleDate,
                 'description' => 'Комиссия маркетплейса',
+                'operation_type' => $operationType,
                 'product' => $listing?->getProduct(),
             ],
         ];

--- a/site/tests/Unit/Marketplace/Application/Processor/WbCostsRawProcessorTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/WbCostsRawProcessorTest.php
@@ -100,14 +100,14 @@ final class WbCostsRawProcessorTest extends TestCase
 
     #[DataProvider('commissionScenarios')]
     public function testWbCommissionCalculatorEmitsPositiveAmount(
-        float $retailPrice,
+        float $retailPriceWithDisc,
         float $acquiringFee,
         float $ppvzForPay,
         float $expectedAbs,
     ): void {
         $entries = (new WbCommissionCalculator())->calculate(
             $this->saleItem([
-                'retail_price'  => $retailPrice,
+                'retail_price_withdisc_rub'  => $retailPriceWithDisc,
                 'acquiring_fee' => $acquiringFee,
                 'ppvz_for_pay'  => $ppvzForPay,
             ]),
@@ -123,7 +123,7 @@ final class WbCostsRawProcessorTest extends TestCase
     /** @return iterable<string, array{0:float,1:float,2:float,3:float}> */
     public static function commissionScenarios(): iterable
     {
-        // commission = retail - acquiring - ppvzForPay
+        // commission = retailPriceWithDisc - acquiring - forPay
         yield 'positive commission'  => [1000.0,  20.0, 800.0, 180.0];
         yield 'negative commission'  => [1000.0,  20.0, 1100.0,  120.0]; // commission = -120 → abs
     }
@@ -139,6 +139,67 @@ final class WbCostsRawProcessorTest extends TestCase
         self::assertSame('acquiring', $entries[0]['category_code']);
         self::assertGreaterThan(0, (float) $entries[0]['amount']);
         self::assertEqualsWithDelta(55.50, (float) $entries[0]['amount'], 0.001);
+    }
+
+
+    public function testWbCommissionCalculatorSaleFormulaAndOperationTypeCharge(): void
+    {
+        $entries = (new WbCommissionCalculator())->calculate(
+            $this->saleItem([
+                'retail_price_withdisc_rub' => 2493.00,
+                'ppvz_for_pay' => 1581.10,
+                'acquiring_fee' => 64.28,
+            ]),
+            null,
+        );
+
+        self::assertCount(1, $entries);
+        self::assertEqualsWithDelta(847.62, (float) $entries[0]['amount'], 0.001);
+        self::assertSame(MarketplaceCostOperationType::CHARGE, $entries[0]['operation_type']);
+    }
+
+    public function testWbCommissionCalculatorReturnFormulaAndOperationTypeStorno(): void
+    {
+        $entries = (new WbCommissionCalculator())->calculate(
+            $this->saleItem([
+                'doc_type_name' => 'Возврат',
+                'retail_price_withdisc_rub' => 1125.00,
+                'ppvz_for_pay' => 680.99,
+                'acquiring_fee' => 27.76,
+            ]),
+            null,
+        );
+
+        self::assertCount(1, $entries);
+        self::assertEqualsWithDelta(416.25, (float) $entries[0]['amount'], 0.001);
+        self::assertSame(MarketplaceCostOperationType::STORNO, $entries[0]['operation_type']);
+    }
+
+    public function testWbAcquiringCalculatorSaleOperationTypeCharge(): void
+    {
+        $entries = (new WbAcquiringCalculator())->calculate(
+            $this->saleItem(['acquiring_fee' => 64.28]),
+            null,
+        );
+
+        self::assertCount(1, $entries);
+        self::assertEqualsWithDelta(64.28, (float) $entries[0]['amount'], 0.001);
+        self::assertSame(MarketplaceCostOperationType::CHARGE, $entries[0]['operation_type']);
+    }
+
+    public function testWbAcquiringCalculatorReturnOperationTypeStorno(): void
+    {
+        $entries = (new WbAcquiringCalculator())->calculate(
+            $this->saleItem([
+                'doc_type_name' => 'Возврат',
+                'acquiring_fee' => 27.76,
+            ]),
+            null,
+        );
+
+        self::assertCount(1, $entries);
+        self::assertEqualsWithDelta(27.76, (float) $entries[0]['amount'], 0.001);
+        self::assertSame(MarketplaceCostOperationType::STORNO, $entries[0]['operation_type']);
     }
 
     public function testWbLogisticsDeliveryCalculatorEmitsPositiveAmount(): void


### PR DESCRIPTION
### Motivation
- Исправить расчёт комиссии и эквайринга для Wildberries так, чтобы возвраты учитывались как сторно и комиссия считалась по корректной формуле.
- Устранить завышение расходов при возвратах и сохранить контракт: `amount` — всегда по модулю, `operation_type` определяет смысл операции.

### Description
- `WbCommissionCalculator`: `supports()` теперь принимает строки «Продажа» и «Возврат» через `WbSalesReportRowNormalizer::isSaleOrReturn()`, формула комиссии заменена на `retailPriceWithDisc - forPay - acquiringFee`, добавлено поле `operation_type` (`CHARGE` для продажи, `STORNO` для возврата), `amount` возвращается как `abs(commission)`, и при `abs(commission) < 0.01` результат пустой; дата берётся через `operationDate()`; `external_id` оставлен без изменений.
- `WbAcquiringCalculator`: `supports()` теперь принимает продажу и возврат через нормалайзер, сумма эквайринга берётся из нормалайзера, `amount` = `abs(acquiringFee)`, добавлено `operation_type` с теми же CHARGE/STORNO правилами, дата через `operationDate()`; порог `abs < 0.01` сохранён.
- Обновлены/добавлены unit-тесты в `WbCostsRawProcessorTest.php` для сценариев: комиссия (продажа), комиссия (возврат), эквайринг (продажа), эквайринг (возврат), и скорректирован data-provider для использования поля `retail_price_withdisc_rub`.
- Не использованы поля `commission_percent` или `ppvz_vw` как суммарная комиссия, и `external_id` поведение не менялось в рамках этой задачи.

### Testing
- Добавлены автоматические unit-тесты для четырёх сценариев: комиссия продажа (2493, 1581.10, 64.28 → 847.62, `CHARGE`), комиссия возврат (1125, 680.99, 27.76 → 416.25, `STORNO`), эквайринг продажа (64.28 → `CHARGE`), эквайринг возврат (27.76 → `STORNO`).
- Существующие тесты по комиссии адаптированы к использованию `retail_price_withdisc_rub` в provider'е.
- Попытка запустить тесты локально завершилась неудачей из‑за отсутствующих тест-бриджей в окружении (`vendor/bin/phpunit` и `vendor/symfony/phpunit-bridge/bin/simple-phpunit.php` не найдены), поэтому прогон тестов в CI обязателен при мерже.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05b311d2288323972b7627877a7920)