### PR TITLE
Use rrdId for Wildberries cost external_id (wb:{rrdId}:{categoryCode})

### DIFF
--- a/site/src/Marketplace/Service/CostCalculator/WbAcquiringCalculator.php
+++ b/site/src/Marketplace/Service/CostCalculator/WbAcquiringCalculator.php
@@ -1,18 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Marketplace\Service\CostCalculator;
 
 use App\Marketplace\Entity\MarketplaceListing;
 use App\Marketplace\Enum\MarketplaceCostOperationType;
 use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 class WbAcquiringCalculator implements CostCalculatorInterface
 {
     private WbSalesReportRowNormalizer $normalizer;
+    private WbCostExternalIdBuilder $externalIdBuilder;
 
-    public function __construct(?WbSalesReportRowNormalizer $normalizer = null)
+    public function __construct(?WbSalesReportRowNormalizer $normalizer = null, ?LoggerInterface $logger = null)
     {
         $this->normalizer = $normalizer ?? new WbSalesReportRowNormalizer();
+        $this->externalIdBuilder = new WbCostExternalIdBuilder($this->normalizer, $logger ?? new NullLogger());
     }
 
     public function supports(array $item): bool
@@ -33,7 +39,11 @@ class WbAcquiringCalculator implements CostCalculatorInterface
             return [];
         }
 
-        $srid = (string)$item['srid'];
+        $externalId = $this->externalIdBuilder->build($item, 'acquiring');
+        if ($externalId === null) {
+            return [];
+        }
+
         $saleDate = $this->normalizer->operationDate($item);
         $operationType = $this->normalizer->isReturn($item)
             ? MarketplaceCostOperationType::STORNO
@@ -43,7 +53,7 @@ class WbAcquiringCalculator implements CostCalculatorInterface
             [
                 'category_code' => 'acquiring',
                 'amount' => (string)abs($acquiringFee),
-                'external_id' => $srid . '_acquiring',
+                'external_id' => $externalId,
                 'cost_date' => $saleDate,
                 'description' => 'Эквайринг',
                 'operation_type' => $operationType,

--- a/site/src/Marketplace/Service/CostCalculator/WbCommissionCalculator.php
+++ b/site/src/Marketplace/Service/CostCalculator/WbCommissionCalculator.php
@@ -1,18 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Marketplace\Service\CostCalculator;
 
 use App\Marketplace\Entity\MarketplaceListing;
 use App\Marketplace\Enum\MarketplaceCostOperationType;
 use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 class WbCommissionCalculator implements CostCalculatorInterface
 {
     private WbSalesReportRowNormalizer $normalizer;
+    private WbCostExternalIdBuilder $externalIdBuilder;
 
-    public function __construct(?WbSalesReportRowNormalizer $normalizer = null)
+    public function __construct(?WbSalesReportRowNormalizer $normalizer = null, ?LoggerInterface $logger = null)
     {
         $this->normalizer = $normalizer ?? new WbSalesReportRowNormalizer();
+        $this->externalIdBuilder = new WbCostExternalIdBuilder($this->normalizer, $logger ?? new NullLogger());
     }
 
     public function supports(array $item): bool
@@ -37,7 +43,11 @@ class WbCommissionCalculator implements CostCalculatorInterface
             return [];
         }
 
-        $srid = (string)$item['srid'];
+        $externalId = $this->externalIdBuilder->build($item, 'commission');
+        if ($externalId === null) {
+            return [];
+        }
+
         $saleDate = $this->normalizer->operationDate($item);
         $operationType = $this->normalizer->isReturn($item)
             ? MarketplaceCostOperationType::STORNO
@@ -47,7 +57,7 @@ class WbCommissionCalculator implements CostCalculatorInterface
             [
                 'category_code' => 'commission',
                 'amount' => (string)abs($commission),
-                'external_id' => $srid . '_commission',
+                'external_id' => $externalId,
                 'cost_date' => $saleDate,
                 'description' => 'Комиссия маркетплейса',
                 'operation_type' => $operationType,

--- a/site/src/Marketplace/Service/CostCalculator/WbCostExternalIdBuilder.php
+++ b/site/src/Marketplace/Service/CostCalculator/WbCostExternalIdBuilder.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Service\CostCalculator;
+
+use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
+use Psr\Log\LoggerInterface;
+
+final readonly class WbCostExternalIdBuilder
+{
+    public function __construct(
+        private WbSalesReportRowNormalizer $normalizer,
+        private LoggerInterface $logger,
+    ) {}
+
+    public function build(array $item, string $categoryCode): ?string
+    {
+        $rrdId = $this->normalizer->rrdId($item);
+        if ($rrdId === null) {
+            $this->logger->warning('WB cost row skipped: missing rrdId/rrd_id for external_id generation.', [
+                'category_code' => $categoryCode,
+            ]);
+
+            return null;
+        }
+
+        return sprintf('wb:%s:%s', $rrdId, $categoryCode);
+    }
+}

--- a/site/src/Marketplace/Service/CostCalculator/WbDeductionCalculator.php
+++ b/site/src/Marketplace/Service/CostCalculator/WbDeductionCalculator.php
@@ -1,15 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Marketplace\Service\CostCalculator;
 
 use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use App\Shared\Service\SlugifyService;
 
 class WbDeductionCalculator implements CostCalculatorInterface
 {
+    private WbSalesReportRowNormalizer $normalizer;
+    private WbCostExternalIdBuilder $externalIdBuilder;
     public function __construct(
-        private readonly SlugifyService $slugify
-    ) {}
+        private readonly SlugifyService $slugify,
+        ?WbSalesReportRowNormalizer $normalizer = null,
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->normalizer = $normalizer ?? new WbSalesReportRowNormalizer();
+        $this->externalIdBuilder = new WbCostExternalIdBuilder($this->normalizer, $logger ?? new NullLogger());
+    }
 
     public function supports(array $item): bool
     {
@@ -29,7 +41,7 @@ class WbDeductionCalculator implements CostCalculatorInterface
             return [];
         }
 
-        $srid = (string)$item['srid'];
+
         $saleDate = new \DateTimeImmutable($item['sale_dt'] ?? $item['rr_dt']);
 
         // Обработка bonus_type_name
@@ -83,6 +95,11 @@ class WbDeductionCalculator implements CostCalculatorInterface
             $categoryCode = rtrim($categoryCode, '_'); // Убираем завершающее подчеркивание
         }
 
+        $externalId = $this->externalIdBuilder->build($item, $categoryCode);
+        if ($externalId === null) {
+            return [];
+        }
+
         // Привязываем к товару только если listing найден
         $product = $listing?->getProduct();
 
@@ -91,7 +108,7 @@ class WbDeductionCalculator implements CostCalculatorInterface
                 'category_code' => $categoryCode,
                 'category_name' => $categoryName, // Передаём name для автосоздания
                 'amount' => (string)abs($deduction),
-                'external_id' => $srid . '_deduction',
+                'external_id' => $externalId,
                 'cost_date' => $saleDate,
                 'description' => $categoryName,
                 'product' => $product,

--- a/site/src/Marketplace/Service/CostCalculator/WbLogisticsDeliveryCalculator.php
+++ b/site/src/Marketplace/Service/CostCalculator/WbLogisticsDeliveryCalculator.php
@@ -1,11 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Marketplace\Service\CostCalculator;
 
 use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 class WbLogisticsDeliveryCalculator implements CostCalculatorInterface
 {
+    private WbSalesReportRowNormalizer $normalizer;
+    private WbCostExternalIdBuilder $externalIdBuilder;
+
+    public function __construct(?WbSalesReportRowNormalizer $normalizer = null, ?LoggerInterface $logger = null)
+    {
+        $this->normalizer = $normalizer ?? new WbSalesReportRowNormalizer();
+        $this->externalIdBuilder = new WbCostExternalIdBuilder($this->normalizer, $logger ?? new NullLogger());
+    }
+
     public function supports(array $item): bool
     {
         return ($item['supplier_oper_name'] ?? '') === 'Логистика'
@@ -25,14 +39,18 @@ class WbLogisticsDeliveryCalculator implements CostCalculatorInterface
             return [];
         }
 
-        $srid = (string)$item['srid'];
+        $externalId = $this->externalIdBuilder->build($item, 'logistics_delivery');
+        if ($externalId === null) {
+            return [];
+        }
+
         $saleDate = new \DateTimeImmutable($item['sale_dt'] ?? $item['rr_dt']);
 
         return [
             [
                 'category_code' => 'logistics_delivery',
                 'amount' => (string)abs($deliveryRub),
-                'external_id' => $srid . '_logistics_delivery',
+                'external_id' => $externalId,
                 'cost_date' => $saleDate,
                 'description' => 'Логистика до покупателя',
                 'product' => $listing?->getProduct(),

--- a/site/src/Marketplace/Service/CostCalculator/WbLogisticsReturnCalculator.php
+++ b/site/src/Marketplace/Service/CostCalculator/WbLogisticsReturnCalculator.php
@@ -1,11 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Marketplace\Service\CostCalculator;
 
 use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 class WbLogisticsReturnCalculator implements CostCalculatorInterface
 {
+    private WbSalesReportRowNormalizer $normalizer;
+    private WbCostExternalIdBuilder $externalIdBuilder;
+
+    public function __construct(?WbSalesReportRowNormalizer $normalizer = null, ?LoggerInterface $logger = null)
+    {
+        $this->normalizer = $normalizer ?? new WbSalesReportRowNormalizer();
+        $this->externalIdBuilder = new WbCostExternalIdBuilder($this->normalizer, $logger ?? new NullLogger());
+    }
+
     public function supports(array $item): bool
     {
         return ($item['supplier_oper_name'] ?? '') === 'Логистика'
@@ -25,14 +39,18 @@ class WbLogisticsReturnCalculator implements CostCalculatorInterface
             return [];
         }
 
-        $srid = (string)$item['srid'];
+        $externalId = $this->externalIdBuilder->build($item, 'logistics_return');
+        if ($externalId === null) {
+            return [];
+        }
+
         $saleDate = new \DateTimeImmutable($item['sale_dt'] ?? $item['rr_dt']);
 
         return [
             [
                 'category_code' => 'logistics_return',
                 'amount' => (string)abs($deliveryRub),
-                'external_id' => $srid . '_logistics_return',
+                'external_id' => $externalId,
                 'cost_date' => $saleDate,
                 'description' => 'Логистика возврат',
                 'product' => $listing?->getProduct(),

--- a/site/src/Marketplace/Service/CostCalculator/WbLoyaltyDiscountCalculator.php
+++ b/site/src/Marketplace/Service/CostCalculator/WbLoyaltyDiscountCalculator.php
@@ -1,11 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Marketplace\Service\CostCalculator;
 
 use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 class WbLoyaltyDiscountCalculator implements CostCalculatorInterface
 {
+    private WbSalesReportRowNormalizer $normalizer;
+    private WbCostExternalIdBuilder $externalIdBuilder;
+
+    public function __construct(?WbSalesReportRowNormalizer $normalizer = null, ?LoggerInterface $logger = null)
+    {
+        $this->normalizer = $normalizer ?? new WbSalesReportRowNormalizer();
+        $this->externalIdBuilder = new WbCostExternalIdBuilder($this->normalizer, $logger ?? new NullLogger());
+    }
+
     public function supports(array $item): bool
     {
         return ($item['supplier_oper_name'] ?? '') === 'Компенсация скидки по программе лояльности';
@@ -24,7 +38,11 @@ class WbLoyaltyDiscountCalculator implements CostCalculatorInterface
             return [];
         }
 
-        $srid = (string)$item['srid'];
+        $externalId = $this->externalIdBuilder->build($item, 'wb_loyalty_discount_compensation');
+        if ($externalId === null) {
+            return [];
+        }
+
         $saleDate = new \DateTimeImmutable($item['sale_dt'] ?? $item['rr_dt']);
 
         // Привязываем к товару только если listing найден
@@ -34,7 +52,7 @@ class WbLoyaltyDiscountCalculator implements CostCalculatorInterface
             [
                 'category_code' => 'wb_loyalty_discount_compensation',
                 'amount' => (string)abs($cashbackDiscount),
-                'external_id' => $srid . '_loyalty_discount',
+                'external_id' => $externalId,
                 'cost_date' => $saleDate,
                 'description' => 'Компенсация скидки по программе лояльности WB',
                 'product' => $product,

--- a/site/src/Marketplace/Service/CostCalculator/WbPenaltyCalculator.php
+++ b/site/src/Marketplace/Service/CostCalculator/WbPenaltyCalculator.php
@@ -1,11 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Marketplace\Service\CostCalculator;
 
 use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 class WbPenaltyCalculator implements CostCalculatorInterface
 {
+    private WbSalesReportRowNormalizer $normalizer;
+    private WbCostExternalIdBuilder $externalIdBuilder;
+
+    public function __construct(?WbSalesReportRowNormalizer $normalizer = null, ?LoggerInterface $logger = null)
+    {
+        $this->normalizer = $normalizer ?? new WbSalesReportRowNormalizer();
+        $this->externalIdBuilder = new WbCostExternalIdBuilder($this->normalizer, $logger ?? new NullLogger());
+    }
+
     public function supports(array $item): bool
     {
         return ($item['supplier_oper_name'] ?? '') === 'Штраф';
@@ -23,7 +37,11 @@ class WbPenaltyCalculator implements CostCalculatorInterface
             return [];
         }
 
-        $srid = (string)$item['srid'];
+        $externalId = $this->externalIdBuilder->build($item, 'penalty');
+        if ($externalId === null) {
+            return [];
+        }
+
         $saleDate = new \DateTimeImmutable($item['sale_dt'] ?? $item['rr_dt']);
 
         // Привязываем к товару только если listing найден
@@ -33,7 +51,7 @@ class WbPenaltyCalculator implements CostCalculatorInterface
             [
                 'category_code' => 'penalty',
                 'amount' => (string)abs($penalty),
-                'external_id' => $srid . '_penalty',
+                'external_id' => $externalId,
                 'cost_date' => $saleDate,
                 'description' => 'Штраф WB',
                 'product' => $product,

--- a/site/src/Marketplace/Service/CostCalculator/WbProductProcessingCalculator.php
+++ b/site/src/Marketplace/Service/CostCalculator/WbProductProcessingCalculator.php
@@ -1,14 +1,28 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Marketplace\Service\CostCalculator;
 
 use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 /**
  * Калькулятор для затрат "Обработка товара"
  */
 class WbProductProcessingCalculator implements CostCalculatorInterface
 {
+    private WbSalesReportRowNormalizer $normalizer;
+    private WbCostExternalIdBuilder $externalIdBuilder;
+
+    public function __construct(?WbSalesReportRowNormalizer $normalizer = null, ?LoggerInterface $logger = null)
+    {
+        $this->normalizer = $normalizer ?? new WbSalesReportRowNormalizer();
+        $this->externalIdBuilder = new WbCostExternalIdBuilder($this->normalizer, $logger ?? new NullLogger());
+    }
+
     public function supports(array $item): bool
     {
         return ($item['supplier_oper_name'] ?? '') === 'Обработка товара';
@@ -29,7 +43,11 @@ class WbProductProcessingCalculator implements CostCalculatorInterface
             return [];
         }
 
-        $srid = (string)$item['srid'];
+        $externalId = $this->externalIdBuilder->build($item, 'product_processing');
+        if ($externalId === null) {
+            return [];
+        }
+
         $saleDate = new \DateTimeImmutable($item['sale_dt'] ?? $item['rr_dt']);
 
         // Проверяем есть ли nm_id и ts_name для привязки к товару
@@ -47,7 +65,7 @@ class WbProductProcessingCalculator implements CostCalculatorInterface
                 'category_code' => 'product_processing',
                 'category_name' => 'Обработка товара',
                 'amount' => (string)abs($amount),
-                'external_id' => $srid . '_product_processing',
+                'external_id' => $externalId,
                 'cost_date' => $saleDate,
                 'description' => 'Обработка товара',
                 'product' => $product, // Привязка к товару (если есть nm_id + ts_name)

--- a/site/src/Marketplace/Service/CostCalculator/WbPvzProcessingCalculator.php
+++ b/site/src/Marketplace/Service/CostCalculator/WbPvzProcessingCalculator.php
@@ -1,11 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Marketplace\Service\CostCalculator;
 
 use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 class WbPvzProcessingCalculator implements CostCalculatorInterface
 {
+    private WbSalesReportRowNormalizer $normalizer;
+    private WbCostExternalIdBuilder $externalIdBuilder;
+
+    public function __construct(?WbSalesReportRowNormalizer $normalizer = null, ?LoggerInterface $logger = null)
+    {
+        $this->normalizer = $normalizer ?? new WbSalesReportRowNormalizer();
+        $this->externalIdBuilder = new WbCostExternalIdBuilder($this->normalizer, $logger ?? new NullLogger());
+    }
+
     public function supports(array $item): bool
     {
         return ($item['supplier_oper_name'] ?? '') === 'Возмещение за выдачу и возврат товаров на ПВЗ';
@@ -24,14 +38,18 @@ class WbPvzProcessingCalculator implements CostCalculatorInterface
             return [];
         }
 
-        $srid = (string)$item['srid'];
+        $externalId = $this->externalIdBuilder->build($item, 'pvz_processing');
+        if ($externalId === null) {
+            return [];
+        }
+
         $saleDate = new \DateTimeImmutable($item['sale_dt'] ?? $item['rr_dt']);
 
         return [
             [
                 'category_code' => 'pvz_processing',
                 'amount' => (string)abs($ppvzReward),
-                'external_id' => $srid . '_pvz_processing',
+                'external_id' => $externalId,
                 'cost_date' => $saleDate,
                 'description' => 'Логистика обработка на ПВЗ',
             ],

--- a/site/src/Marketplace/Service/CostCalculator/WbStorageCalculator.php
+++ b/site/src/Marketplace/Service/CostCalculator/WbStorageCalculator.php
@@ -1,11 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Marketplace\Service\CostCalculator;
 
 use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 class WbStorageCalculator implements CostCalculatorInterface
 {
+    private WbSalesReportRowNormalizer $normalizer;
+    private WbCostExternalIdBuilder $externalIdBuilder;
+
+    public function __construct(?WbSalesReportRowNormalizer $normalizer = null, ?LoggerInterface $logger = null)
+    {
+        $this->normalizer = $normalizer ?? new WbSalesReportRowNormalizer();
+        $this->externalIdBuilder = new WbCostExternalIdBuilder($this->normalizer, $logger ?? new NullLogger());
+    }
+
     public function supports(array $item): bool
     {
         return ($item['supplier_oper_name'] ?? '') === 'Хранение';
@@ -24,14 +38,18 @@ class WbStorageCalculator implements CostCalculatorInterface
             return [];
         }
 
-        $srid = (string)$item['srid'];
+        $externalId = $this->externalIdBuilder->build($item, 'storage');
+        if ($externalId === null) {
+            return [];
+        }
+
         $saleDate = new \DateTimeImmutable($item['sale_dt'] ?? $item['rr_dt']);
 
         return [
             [
                 'category_code' => 'storage',
                 'amount' => (string)abs($storageFee),
-                'external_id' => $srid . '_storage',
+                'external_id' => $externalId,
                 'cost_date' => $saleDate,
                 'description' => 'Хранение WB',
                 'product' => null, // Нет привязки к товару

--- a/site/src/Marketplace/Service/CostCalculator/WbWarehouseLogisticsCalculator.php
+++ b/site/src/Marketplace/Service/CostCalculator/WbWarehouseLogisticsCalculator.php
@@ -1,11 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Marketplace\Service\CostCalculator;
 
 use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 class WbWarehouseLogisticsCalculator implements CostCalculatorInterface
 {
+    private WbSalesReportRowNormalizer $normalizer;
+    private WbCostExternalIdBuilder $externalIdBuilder;
+
+    public function __construct(?WbSalesReportRowNormalizer $normalizer = null, ?LoggerInterface $logger = null)
+    {
+        $this->normalizer = $normalizer ?? new WbSalesReportRowNormalizer();
+        $this->externalIdBuilder = new WbCostExternalIdBuilder($this->normalizer, $logger ?? new NullLogger());
+    }
+
     public function supports(array $item): bool
     {
         return ($item['supplier_oper_name'] ?? '') === 'Возмещение издержек по перевозке/по складским операциям с товаром';
@@ -25,7 +39,11 @@ class WbWarehouseLogisticsCalculator implements CostCalculatorInterface
             return [];
         }
 
-        $srid = (string)$item['srid'];
+        $externalId = $this->externalIdBuilder->build($item, 'warehouse_logistics');
+        if ($externalId === null) {
+            return [];
+        }
+
         $saleDate = new \DateTimeImmutable($item['sale_dt'] ?? $item['rr_dt']);
 
         // Привязываем к товару только если listing найден (nm_id + sa_name были заполнены)
@@ -35,7 +53,7 @@ class WbWarehouseLogisticsCalculator implements CostCalculatorInterface
             [
                 'category_code' => 'warehouse_logistics',
                 'amount' => (string)abs($rebillLogisticCost),
-                'external_id' => $srid . '_warehouse_logistics',
+                'external_id' => $externalId,
                 'cost_date' => $saleDate,
                 'description' => 'Логистика складские операции',
                 'product' => $product, // null если нет привязки

--- a/site/tests/Unit/Marketplace/Service/CostCalculator/WbCostExternalIdBuilderTest.php
+++ b/site/tests/Unit/Marketplace/Service/CostCalculator/WbCostExternalIdBuilderTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Service\CostCalculator;
+
+use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
+use App\Marketplace\Service\CostCalculator\WbCommissionCalculator;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+
+final class WbCostExternalIdBuilderTest extends TestCase
+{
+    public function testSameSridDifferentRrdIdProduceDifferentExternalIds(): void
+    {
+        $calculator = new WbCommissionCalculator();
+
+        $first = $calculator->calculate($this->saleItem(['srid' => 'same-srid', 'rrd_id' => '1001']), null);
+        $second = $calculator->calculate($this->saleItem(['srid' => 'same-srid', 'rrd_id' => '1002']), null);
+
+        self::assertSame('wb:1001:commission', $first[0]['external_id']);
+        self::assertSame('wb:1002:commission', $second[0]['external_id']);
+    }
+
+    public function testRowWithoutRrdIdDoesNotCreateCostEntry(): void
+    {
+        $logger = new CollectingLogger();
+        $calculator = new WbCommissionCalculator(new WbSalesReportRowNormalizer(), $logger);
+
+        $entries = $calculator->calculate($this->saleItem(['rrd_id' => null, 'rrdId' => null]), null);
+
+        self::assertSame([], $entries);
+        self::assertCount(1, $logger->warnings);
+    }
+
+    public function testExternalIdFormatIsStrict(): void
+    {
+        $calculator = new WbCommissionCalculator();
+        $entries = $calculator->calculate($this->saleItem(['rrdId' => '777']), null);
+
+        self::assertSame('wb:777:commission', $entries[0]['external_id']);
+    }
+
+    private function saleItem(array $overrides = []): array
+    {
+        return array_merge([
+            'doc_type_name' => 'Продажа',
+            'srid' => 'SRID-1',
+            'rrd_id' => '1001',
+            'sale_dt' => '2026-01-15 10:00:00',
+            'retail_price_withdisc_rub' => 1000.00,
+            'acquiring_fee' => 20.00,
+            'ppvz_for_pay' => 800.00,
+        ], $overrides);
+    }
+}
+
+final class CollectingLogger extends AbstractLogger
+{
+    public array $warnings = [];
+
+    public function log($level, $message, array $context = []): void
+    {
+        if ($level === 'warning') {
+            $this->warnings[] = ['message' => (string) $message, 'context' => $context];
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Wildberries report rows can share the same `srid` while representing different realization rows, which caused cost entries to collide when `external_id` was built from `srid` alone. 
- To guarantee idempotency per report row we must use the unique row id (`rrdId` / `rrd_id`) for cost `external_id` generation for WB only. 

### Description

- Added a centralized `WbCostExternalIdBuilder` that reads `rrdId`/`rrd_id` via `WbSalesReportRowNormalizer`, builds `external_id` in the strict format `wb:{rrdId}:{categoryCode}`, and logs a warning (no personal data) when `rrdId` is missing and returns `null` to skip creating the cost entry.
- Updated all Wildberries cost calculators (`Wb*Calculator`) to use the new builder and to skip creating a cost entry when the builder returns `null`; `WbDeductionCalculator` builds the `external_id` after its dynamic `categoryCode` is computed.
- Kept sale/return external IDs and Ozon logic unchanged as required by the change scope.

### Testing

- Performed PHP syntax checks with `php -l` for the new file and all modified `Wb*Calculator` files and they reported no syntax errors.
- Added unit test `WbCostExternalIdBuilderTest` covering: distinct `rrd_id` → distinct `external_id`, missing `rrdId` → no cost entry and a warning logged, and strict `wb:{rrdId}:{categoryCode}` format; the test file passes `php -l` syntax check.
- Running the full PHPUnit suite was not possible in the environment because `vendor/bin/phpunit` is not available here, so CI should run the unit tests and integration checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05b7f512448323bd5be5483b67cef6)