### PR TITLE
Force reprocess for Wildberries: remove old sales/returns by raw document and add tests

### DIFF
--- a/site/src/Marketplace/Application/ProcessMarketplaceRawDocumentAction.php
+++ b/site/src/Marketplace/Application/ProcessMarketplaceRawDocumentAction.php
@@ -11,6 +11,8 @@ use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Enum\StagingRecordType;
 use App\Marketplace\Infrastructure\Normalizer\RowClassifierRegistryInterface;
 use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
+use App\Marketplace\Repository\MarketplaceReturnRepository;
+use App\Marketplace\Repository\MarketplaceSaleRepository;
 use App\Shared\Service\AppLogger;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
@@ -31,6 +33,8 @@ final readonly class ProcessMarketplaceRawDocumentAction
         private RowClassifierRegistryInterface $classifierRegistry,
         private MarketplaceRawProcessorRegistryInterface $processorRegistry,
         private MarketplaceRawDocumentRepository $repository,
+        private MarketplaceSaleRepository $saleRepository,
+        private MarketplaceReturnRepository $returnRepository,
         private EntityManagerInterface $entityManager,
         private MarketplaceCostCategoryResolver $costCategoryResolver,
         private Connection $connection,
@@ -61,6 +65,16 @@ final readonly class ProcessMarketplaceRawDocumentAction
         }
 
         $marketplace = $document->getMarketplace();
+
+        if ($command->forceReprocess && $marketplace === MarketplaceType::WILDBERRIES) {
+            $company = $document->getCompany();
+
+            if ($command->kind === 'sales') {
+                $this->saleRepository->deleteByRawDocument($company, $marketplace, $command->rawDocId);
+            } elseif ($command->kind === 'returns') {
+                $this->returnRepository->deleteByRawDocument($company, $marketplace, $command->rawDocId);
+            }
+        }
 
         $this->appLogger->info('ProcessMarketplaceRawDocumentAction called', [
             'rawDocId'       => $command->rawDocId,

--- a/site/src/Marketplace/Repository/MarketplaceReturnRepository.php
+++ b/site/src/Marketplace/Repository/MarketplaceReturnRepository.php
@@ -120,4 +120,22 @@ class MarketplaceReturnRepository extends ServiceEntityRepository
 
         return $qb->getQuery()->getResult();
     }
+
+    public function deleteByRawDocument(
+        Company $company,
+        MarketplaceType $marketplace,
+        string $rawDocumentId,
+    ): int {
+        return (int) $this->createQueryBuilder('r')
+            ->delete()
+            ->where('r.company = :company')
+            ->andWhere('r.marketplace = :marketplace')
+            ->andWhere('r.rawDocumentId = :rawDocumentId')
+            ->andWhere('r.document IS NULL')
+            ->setParameter('company', $company)
+            ->setParameter('marketplace', $marketplace)
+            ->setParameter('rawDocumentId', $rawDocumentId)
+            ->getQuery()
+            ->execute();
+    }
 }

--- a/site/tests/Integration/Marketplace/Application/WbRawForceReprocessRegressionTest.php
+++ b/site/tests/Integration/Marketplace/Application/WbRawForceReprocessRegressionTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Marketplace\Application;
+
+use App\Marketplace\Application\Command\ProcessMarketplaceRawDocumentCommand;
+use App\Marketplace\Application\ProcessMarketplaceRawDocumentAction;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceRawDocumentBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+
+final class WbRawForceReprocessRegressionTest extends IntegrationTestCase
+{
+    public function testForceReprocessReplacesWbSalesAndReturnsByRawDocument(): void
+    {
+        $company = CompanyBuilder::aCompany()->withIndex(401)->build();
+        $this->em->persist($company);
+
+        $rawDocId = '99999999-aaaa-4aaa-8aaa-111111111111';
+        $day = new \DateTimeImmutable('2026-04-20');
+        $rawDoc = MarketplaceRawDocumentBuilder::aDocument()
+            ->withId($rawDocId)
+            ->forCompany($company)
+            ->withMarketplace(MarketplaceType::WILDBERRIES)
+            ->withPeriod($day, $day)
+            ->build();
+        $rawDoc->setRawData([
+            $this->makeWbSaleRow('SRID-SALE-1', 1000.0),
+            $this->makeWbReturnRow('SRID-RETURN-1', 500.0),
+        ]);
+        $this->em->persist($rawDoc);
+        $this->em->flush();
+
+        $action = self::getContainer()->get(ProcessMarketplaceRawDocumentAction::class);
+
+        $action(new ProcessMarketplaceRawDocumentCommand((string) $company->getId(), $rawDocId, 'sales'));
+        $action(new ProcessMarketplaceRawDocumentCommand((string) $company->getId(), $rawDocId, 'returns'));
+
+        self::assertSame(1000.0, $this->saleAmount($company->getId(), $rawDocId, 'SRID-SALE-1'));
+        self::assertSame(500.0, $this->returnAmount($company->getId(), $rawDocId, 'SRID-RETURN-1'));
+
+        $rawDoc->setRawData([
+            $this->makeWbSaleRow('SRID-SALE-1', 1700.0),
+            $this->makeWbReturnRow('SRID-RETURN-1', 900.0),
+        ]);
+        $this->em->flush();
+
+        $action(new ProcessMarketplaceRawDocumentCommand((string) $company->getId(), $rawDocId, 'sales', true));
+        $action(new ProcessMarketplaceRawDocumentCommand((string) $company->getId(), $rawDocId, 'returns', true));
+
+        self::assertSame(1, $this->saleRowsCount($company->getId(), $rawDocId, 'SRID-SALE-1'));
+        self::assertSame(1, $this->returnRowsCount($company->getId(), $rawDocId, 'SRID-RETURN-1'));
+        self::assertSame(1700.0, $this->saleAmount($company->getId(), $rawDocId, 'SRID-SALE-1'));
+        self::assertSame(900.0, $this->returnAmount($company->getId(), $rawDocId, 'SRID-RETURN-1'));
+    }
+
+    private function makeWbSaleRow(string $srid, float $retailPriceWithDisc): array
+    {
+        return [
+            'doc_type_name' => 'Продажа',
+            'supplier_oper_name' => 'Продажа',
+            'srid' => $srid,
+            'nm_id' => '10001',
+            'ts_name' => 'M',
+            'sa_name' => 'ART-1',
+            'barcode' => '1234567890123',
+            'quantity' => 1,
+            'retail_price_withdisc_rub' => $retailPriceWithDisc,
+            'retail_amount' => 700.0,
+            'retail_price' => 1500.0,
+            'sale_dt' => '2026-04-20 12:00:00',
+            'rr_dt' => '2026-04-20 12:00:00',
+        ];
+    }
+
+    private function makeWbReturnRow(string $srid, float $retailPriceWithDisc): array
+    {
+        return [
+            'doc_type_name' => 'Возврат',
+            'supplier_oper_name' => 'Возврат покупателем',
+            'srid' => $srid,
+            'nm_id' => '10001',
+            'ts_name' => 'M',
+            'sa_name' => 'ART-1',
+            'barcode' => '1234567890123',
+            'quantity' => 1,
+            'retail_price_withdisc_rub' => $retailPriceWithDisc,
+            'retail_amount' => 300.0,
+            'retail_price' => 900.0,
+            'sale_dt' => '2026-04-20 12:00:00',
+            'rr_dt' => '2026-04-20 12:00:00',
+        ];
+    }
+
+    private function saleRowsCount(string $companyId, string $rawDocId, string $srid): int
+    {
+        return (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM marketplace_sales WHERE company_id = :companyId AND raw_document_id = :rawDocId AND external_order_id = :srid',
+            ['companyId' => $companyId, 'rawDocId' => $rawDocId, 'srid' => $srid],
+        );
+    }
+
+    private function returnRowsCount(string $companyId, string $rawDocId, string $srid): int
+    {
+        return (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM marketplace_returns WHERE company_id = :companyId AND raw_document_id = :rawDocId AND external_return_id = :srid',
+            ['companyId' => $companyId, 'rawDocId' => $rawDocId, 'srid' => $srid],
+        );
+    }
+
+    private function saleAmount(string $companyId, string $rawDocId, string $srid): float
+    {
+        return (float) $this->connection->fetchOne(
+            'SELECT total_revenue FROM marketplace_sales WHERE company_id = :companyId AND raw_document_id = :rawDocId AND external_order_id = :srid',
+            ['companyId' => $companyId, 'rawDocId' => $rawDocId, 'srid' => $srid],
+        );
+    }
+
+    private function returnAmount(string $companyId, string $rawDocId, string $srid): float
+    {
+        return (float) $this->connection->fetchOne(
+            'SELECT refund_amount FROM marketplace_returns WHERE company_id = :companyId AND raw_document_id = :rawDocId AND external_return_id = :srid',
+            ['companyId' => $companyId, 'rawDocId' => $rawDocId, 'srid' => $srid],
+        );
+    }
+}

--- a/site/tests/Unit/Marketplace/ProcessMarketplaceRawDocumentActionTest.php
+++ b/site/tests/Unit/Marketplace/ProcessMarketplaceRawDocumentActionTest.php
@@ -9,6 +9,7 @@ use App\Marketplace\Application\ProcessMarketplaceRawDocumentAction;
 use App\Marketplace\Application\Processor\MarketplaceRawProcessorInterface;
 use App\Marketplace\Application\Processor\MarketplaceRawProcessorRegistryInterface;
 use App\Marketplace\Application\Service\MarketplaceCostCategoryResolver;
+use App\Company\Entity\Company;
 use App\Marketplace\Entity\MarketplaceRawDocument;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Enum\StagingRecordType;
@@ -16,6 +17,8 @@ use App\Marketplace\Infrastructure\Normalizer\Contract\RowClassifierInterface;
 use App\Marketplace\Infrastructure\Normalizer\RowClassifierRegistryInterface;
 use App\Marketplace\Repository\MarketplaceCostCategoryRepository;
 use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
+use App\Marketplace\Repository\MarketplaceReturnRepository;
+use App\Marketplace\Repository\MarketplaceSaleRepository;
 use App\Shared\Service\AppLogger;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
@@ -40,6 +43,8 @@ final class ProcessMarketplaceRawDocumentActionTest extends TestCase
             $this->createMock(RowClassifierRegistryInterface::class),
             $this->createMock(MarketplaceRawProcessorRegistryInterface::class),
             $repository,
+            $this->createMock(\App\Marketplace\Repository\MarketplaceSaleRepository::class),
+            $this->createMock(\App\Marketplace\Repository\MarketplaceReturnRepository::class),
             $this->createMock(EntityManagerInterface::class),
             $this->createCostCategoryResolver(),
             $this->createMock(Connection::class),
@@ -55,13 +60,14 @@ final class ProcessMarketplaceRawDocumentActionTest extends TestCase
     public function testThrowsOnUnknownKind(): void
     {
         $document = $this->createMock(MarketplaceRawDocument::class);
-        $document->method('getRawData')->willReturn([]);
+        $document->method('getRawData')->willReturn([['x' => 1]]);
         $document->method('getMarketplace')->willReturn(MarketplaceType::OZON);
 
         $repository = $this->createMock(MarketplaceRawDocumentRepository::class);
         $repository->method('find')->willReturn($document);
 
         $classifier = $this->createMock(RowClassifierInterface::class);
+        $classifier->method('classify')->willReturn(StagingRecordType::SALE);
         $classifierRegistry = $this->createMock(RowClassifierRegistryInterface::class);
         $classifierRegistry->method('get')->willReturn($classifier);
 
@@ -69,6 +75,8 @@ final class ProcessMarketplaceRawDocumentActionTest extends TestCase
             $classifierRegistry,
             $this->createMock(MarketplaceRawProcessorRegistryInterface::class),
             $repository,
+            $this->createMock(\App\Marketplace\Repository\MarketplaceSaleRepository::class),
+            $this->createMock(\App\Marketplace\Repository\MarketplaceReturnRepository::class),
             $this->createMock(EntityManagerInterface::class),
             $this->createCostCategoryResolver(),
             $this->createMock(Connection::class),
@@ -84,7 +92,7 @@ final class ProcessMarketplaceRawDocumentActionTest extends TestCase
     public function testCostsKindUsesProcessDirectly(): void
     {
         $document = $this->createMock(MarketplaceRawDocument::class);
-        $document->method('getRawData')->willReturn([]);
+        $document->method('getRawData')->willReturn([['x' => 1]]);
         $document->method('getMarketplace')->willReturn(MarketplaceType::OZON);
 
         $repository = $this->createMock(MarketplaceRawDocumentRepository::class);
@@ -111,6 +119,8 @@ final class ProcessMarketplaceRawDocumentActionTest extends TestCase
             $this->createMock(RowClassifierRegistryInterface::class),
             $processorRegistry,
             $repository,
+            $this->createMock(\App\Marketplace\Repository\MarketplaceSaleRepository::class),
+            $this->createMock(\App\Marketplace\Repository\MarketplaceReturnRepository::class),
             $this->createMock(EntityManagerInterface::class),
             $this->createCostCategoryResolver(),
             $this->createMock(Connection::class),
@@ -120,5 +130,129 @@ final class ProcessMarketplaceRawDocumentActionTest extends TestCase
         $result = $action(new ProcessMarketplaceRawDocumentCommand('company-1', 'doc-1', 'costs'));
 
         self::assertSame(42, $result);
+    }
+
+    public function testForceReprocessWbSalesCallsDeleteByRawDocument(): void
+    {
+        $document = $this->createMock(MarketplaceRawDocument::class);
+        $document->method('getRawData')->willReturn([['x' => 1]]);
+        $document->method('getMarketplace')->willReturn(MarketplaceType::WILDBERRIES);
+        $company = $this->createMock(Company::class);
+        $document->method('getCompany')->willReturn($company);
+
+        $repository = $this->createMock(MarketplaceRawDocumentRepository::class);
+        $repository->method('find')->willReturn($document);
+
+        $saleRepository = $this->createMock(MarketplaceSaleRepository::class);
+        $saleRepository->expects(self::once())
+            ->method('deleteByRawDocument')
+            ->with($company, MarketplaceType::WILDBERRIES, 'doc-1');
+
+        $returnRepository = $this->createMock(MarketplaceReturnRepository::class);
+        $returnRepository->expects(self::never())->method('deleteByRawDocument');
+
+        $processor = $this->createMock(MarketplaceRawProcessorInterface::class);
+        $processor->expects(self::once())->method('processBatch');
+        $processorRegistry = $this->createMock(MarketplaceRawProcessorRegistryInterface::class);
+        $processorRegistry->method('get')->willReturn($processor);
+
+        $classifier = $this->createMock(RowClassifierInterface::class);
+        $classifier->method('classify')->willReturn(StagingRecordType::SALE);
+        $classifierRegistry = $this->createMock(RowClassifierRegistryInterface::class);
+        $classifierRegistry->method('get')->willReturn($classifier);
+
+        $action = new ProcessMarketplaceRawDocumentAction(
+            $classifierRegistry,
+            $processorRegistry,
+            $repository,
+            $saleRepository,
+            $returnRepository,
+            $this->createMock(EntityManagerInterface::class),
+            $this->createCostCategoryResolver(),
+            $this->createMock(Connection::class),
+            $this->createMock(AppLogger::class),
+        );
+
+        $action(new ProcessMarketplaceRawDocumentCommand('company-1', 'doc-1', 'sales', true));
+    }
+
+    public function testForceReprocessWbReturnsCallsDeleteByRawDocument(): void
+    {
+        $document = $this->createMock(MarketplaceRawDocument::class);
+        $document->method('getRawData')->willReturn([['x' => 1]]);
+        $document->method('getMarketplace')->willReturn(MarketplaceType::WILDBERRIES);
+        $company = $this->createMock(Company::class);
+        $document->method('getCompany')->willReturn($company);
+
+        $repository = $this->createMock(MarketplaceRawDocumentRepository::class);
+        $repository->method('find')->willReturn($document);
+
+        $saleRepository = $this->createMock(MarketplaceSaleRepository::class);
+        $saleRepository->expects(self::never())->method('deleteByRawDocument');
+
+        $returnRepository = $this->createMock(MarketplaceReturnRepository::class);
+        $returnRepository->expects(self::once())
+            ->method('deleteByRawDocument')
+            ->with($company, MarketplaceType::WILDBERRIES, 'doc-2');
+
+        $processor = $this->createMock(MarketplaceRawProcessorInterface::class);
+        $processor->expects(self::once())->method('processBatch');
+        $processorRegistry = $this->createMock(MarketplaceRawProcessorRegistryInterface::class);
+        $processorRegistry->method('get')->willReturn($processor);
+
+        $classifier = $this->createMock(RowClassifierInterface::class);
+        $classifier->method('classify')->willReturn(StagingRecordType::RETURN);
+        $classifierRegistry = $this->createMock(RowClassifierRegistryInterface::class);
+        $classifierRegistry->method('get')->willReturn($classifier);
+
+        $action = new ProcessMarketplaceRawDocumentAction(
+            $classifierRegistry,
+            $processorRegistry,
+            $repository,
+            $saleRepository,
+            $returnRepository,
+            $this->createMock(EntityManagerInterface::class),
+            $this->createCostCategoryResolver(),
+            $this->createMock(Connection::class),
+            $this->createMock(AppLogger::class),
+        );
+
+        $action(new ProcessMarketplaceRawDocumentCommand('company-1', 'doc-2', 'returns', true));
+    }
+
+    public function testForceReprocessOzonDoesNotCallWbDeleteByRawDocument(): void
+    {
+        $document = $this->createMock(MarketplaceRawDocument::class);
+        $document->method('getRawData')->willReturn([]);
+        $document->method('getMarketplace')->willReturn(MarketplaceType::OZON);
+
+        $repository = $this->createMock(MarketplaceRawDocumentRepository::class);
+        $repository->method('find')->willReturn($document);
+
+        $saleRepository = $this->createMock(MarketplaceSaleRepository::class);
+        $saleRepository->expects(self::never())->method('deleteByRawDocument');
+
+        $returnRepository = $this->createMock(MarketplaceReturnRepository::class);
+        $returnRepository->expects(self::never())->method('deleteByRawDocument');
+
+        $processorRegistry = $this->createMock(MarketplaceRawProcessorRegistryInterface::class);
+        $processorRegistry->expects(self::never())->method('get');
+
+        $classifierRegistry = $this->createMock(RowClassifierRegistryInterface::class);
+        $classifierRegistry->expects(self::never())->method('get');
+
+        $action = new ProcessMarketplaceRawDocumentAction(
+            $classifierRegistry,
+            $processorRegistry,
+            $repository,
+            $saleRepository,
+            $returnRepository,
+            $this->createMock(EntityManagerInterface::class),
+            $this->createCostCategoryResolver(),
+            $this->createMock(Connection::class),
+            $this->createMock(AppLogger::class),
+        );
+
+        $action(new ProcessMarketplaceRawDocumentCommand('company-1', 'doc-3', 'sales', true));
     }
 }


### PR DESCRIPTION
### Motivation

- Ensure that a forced reprocess of Wildberries raw documents replaces previously staged sales and returns originating from the same raw document to avoid duplicates and stale rows.
- Provide repository support and automated coverage so the daily pipeline `forceReprocess` behavior is explicit and tested.

### Description

- Inject `MarketplaceSaleRepository` and `MarketplaceReturnRepository` into `ProcessMarketplaceRawDocumentAction` and delete existing staging rows for `sales` or `returns` when `forceReprocess` is true and the marketplace is `WILDBERRIES`.
- Add `deleteByRawDocument` method to `MarketplaceReturnRepository` (deletes rows where `document IS NULL` and matches company, marketplace and `rawDocumentId`).
- Update `ProcessMarketplaceRawDocumentAction` logging and keep existing behavior for `costs` unchanged (existing cost deletion for unfiled costs remains).
- Add/modify tests: extend `ProcessMarketplaceRawDocumentActionTest` with unit tests validating WB-specific deletion behavior and add `WbRawForceReprocessRegressionTest` integration test that verifies reprocessing replaces sale/return amounts and row counts.

### Testing

- Ran unit tests for `ProcessMarketplaceRawDocumentActionTest` including new cases covering WB `forceReprocess`, all assertions passed.
- Ran the new integration test `WbRawForceReprocessRegressionTest` which simulates reprocessing of WB sales and returns and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05be4cdc40832383be902cf9f102d0)