### PR TITLE
Integrate WbSalesReportRowNormalizer into WildberriesAdapter and update legacy DTO mappings

### DIFF
--- a/site/src/Marketplace/Service/Integration/WildberriesAdapter.php
+++ b/site/src/Marketplace/Service/Integration/WildberriesAdapter.php
@@ -260,7 +260,8 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
 
     /**
      * Legacy DTO API. Do not use for WB financial pipeline. Use raw report processors instead.
- * @deprecated
+     *
+     * @deprecated
      */
     public function fetchSales(
         Company $company,
@@ -303,7 +304,8 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
 
     /**
      * Legacy DTO API. Do not use for WB financial pipeline. Use raw report processors instead.
- * @deprecated
+     *
+     * @deprecated
      */
     public function fetchCosts(
         Company $company,
@@ -325,8 +327,11 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
             $tsName = isset($item['ts_name']) ? (string) $item['ts_name'] : null;
             $barcode = isset($item['barcode']) ? (string) $item['barcode'] : null;
 
+            $isReturn = $this->normalizer->isReturn($item);
             $commissionAmount = abs($this->normalizer->fullMarketplaceCommission($item));
-            if ($commissionAmount > 0) {
+            if (!$isReturn && $commissionAmount > 0) {
+                // Legacy CostData does not support operation_type/STORNO.
+                // Return commission/acquiring is handled by WB raw cost processors only.
                 $costs[] = new CostData(
                     marketplace: MarketplaceType::WILDBERRIES,
                     categoryCode: 'wb_commission',
@@ -452,7 +457,8 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
 
     /**
      * Legacy DTO API. Do not use for WB financial pipeline. Use raw report processors instead.
- * @deprecated
+     *
+     * @deprecated
      */
     public function fetchReturns(
         Company $company,

--- a/site/src/Marketplace/Service/Integration/WildberriesAdapter.php
+++ b/site/src/Marketplace/Service/Integration/WildberriesAdapter.php
@@ -15,6 +15,7 @@ use App\Marketplace\Exception\MarketplaceAuthException;
 use App\Marketplace\Exception\MarketplaceInvalidApiResponseException;
 use App\Marketplace\Exception\MarketplaceRateLimitException;
 use App\Marketplace\Exception\MarketplaceTemporaryApiException;
+use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
 use App\Marketplace\Repository\MarketplaceConnectionRepository;
 use Psr\Log\LoggerInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
@@ -30,6 +31,7 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
         private readonly HttpClientInterface $httpClient,
         private readonly MarketplaceConnectionRepository $connectionRepository,
         private readonly LoggerInterface $logger,
+        private readonly WbSalesReportRowNormalizer $normalizer,
     ) {
     }
 
@@ -256,6 +258,10 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
         return [] !== $decoded;
     }
 
+    /**
+     * Legacy DTO API. Do not use for WB financial pipeline. Use raw report processors instead.
+ * @deprecated
+     */
     public function fetchSales(
         Company $company,
         \DateTimeInterface $fromDate,
@@ -265,23 +271,29 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
         $sales = [];
 
         foreach ($data as $item) {
-            if (!isset($item['doc_type_name']) || 'Продажа' !== $item['doc_type_name']) {
+            if (!$this->normalizer->isSale($item)) {
                 continue;
             }
 
-            $retailAmount = (float) ($item['retail_amount'] ?? 0);
-            if ($retailAmount <= 0) {
+            $retailPriceWithDisc = $this->normalizer->retailPriceWithDisc($item);
+            if ($retailPriceWithDisc <= 0) {
+                continue;
+            }
+
+            $quantity = abs($this->normalizer->quantity($item));
+            $externalOrderId = $this->normalizer->rrdId($item) ?? (string) ($item['realizationreport_id'] ?? '');
+            if ($externalOrderId === '') {
                 continue;
             }
 
             $sales[] = new SaleData(
                 marketplace: MarketplaceType::WILDBERRIES,
-                externalOrderId: (string) $item['realizationreport_id'],
-                saleDate: new \DateTimeImmutable($item['rr_dt']),
-                marketplaceSku: $item['sa_name'],
-                quantity: abs((int) $item['quantity']),
-                pricePerUnit: (string) $item['retail_price'],
-                totalRevenue: (string) abs($retailAmount),
+                externalOrderId: $externalOrderId,
+                saleDate: $this->normalizer->operationDate($item),
+                marketplaceSku: $this->normalizer->vendorCode($item),
+                quantity: $quantity,
+                pricePerUnit: (string) ($quantity > 0 ? $retailPriceWithDisc / $quantity : 0.0),
+                totalRevenue: (string) $retailPriceWithDisc,
                 rawData: null
             );
         }
@@ -289,6 +301,10 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
         return $sales;
     }
 
+    /**
+     * Legacy DTO API. Do not use for WB financial pipeline. Use raw report processors instead.
+ * @deprecated
+     */
     public function fetchCosts(
         Company $company,
         \DateTimeInterface $fromDate,
@@ -298,22 +314,27 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
         $costs = [];
 
         foreach ($data as $item) {
-            $realizationId = (string) $item['realizationreport_id'];
-            $saName = $item['sa_name'];
-            $rrDt = new \DateTimeImmutable($item['rr_dt']);
+            $rrdId = $this->normalizer->rrdId($item) ?? (string) ($item['realizationreport_id'] ?? '');
+            if ($rrdId === '') {
+                continue;
+            }
+
+            $saName = $this->normalizer->vendorCode($item);
+            $rrDt = $this->normalizer->reportDate($item);
             $nmId = trim((string) ($item['nm_id'] ?? ''));
             $tsName = isset($item['ts_name']) ? (string) $item['ts_name'] : null;
             $barcode = isset($item['barcode']) ? (string) $item['barcode'] : null;
 
-            if (isset($item['commission_percent']) && abs((float) $item['commission_percent']) > 0) {
+            $commissionAmount = abs($this->normalizer->fullMarketplaceCommission($item));
+            if ($commissionAmount > 0) {
                 $costs[] = new CostData(
                     marketplace: MarketplaceType::WILDBERRIES,
                     categoryCode: 'wb_commission',
-                    amount: (string) abs((float) $item['commission_percent']),
+                    amount: (string) $commissionAmount,
                     costDate: $rrDt,
                     marketplaceSku: $saName,
                     description: 'Комиссия Wildberries',
-                    externalId: $realizationId.'_commission',
+                    externalId: 'wb:'.$rrdId.':wb_commission',
                     nmId: $nmId,
                     tsName: $tsName,
                     barcode: $barcode,
@@ -328,7 +349,7 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
                     costDate: $rrDt,
                     marketplaceSku: $saName,
                     description: 'Логистика WB',
-                    externalId: $realizationId.'_logistics',
+                    externalId: 'wb:'.$rrdId.':wb_logistics',
                     nmId: $nmId,
                     tsName: $tsName,
                     barcode: $barcode,
@@ -343,7 +364,7 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
                     costDate: $rrDt,
                     marketplaceSku: $saName,
                     description: 'Логистика возврата WB',
-                    externalId: $realizationId.'_return_logistics',
+                    externalId: 'wb:'.$rrdId.':wb_return_logistics',
                     nmId: $nmId,
                     tsName: $tsName,
                     barcode: $barcode,
@@ -358,7 +379,7 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
                     costDate: $rrDt,
                     marketplaceSku: $saName,
                     description: 'Хранение на складе WB',
-                    externalId: $realizationId.'_storage',
+                    externalId: 'wb:'.$rrdId.':wb_storage',
                     nmId: $nmId,
                     tsName: $tsName,
                     barcode: $barcode,
@@ -373,7 +394,7 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
                     costDate: $rrDt,
                     marketplaceSku: $saName,
                     description: 'Платная приёмка WB',
-                    externalId: $realizationId.'_acceptance',
+                    externalId: 'wb:'.$rrdId.':wb_acceptance',
                     nmId: $nmId,
                     tsName: $tsName,
                     barcode: $barcode,
@@ -388,7 +409,7 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
                     costDate: $rrDt,
                     marketplaceSku: $saName,
                     description: 'Прочие удержания WB',
-                    externalId: $realizationId.'_deduction',
+                    externalId: 'wb:'.$rrdId.':wb_deduction',
                     nmId: $nmId,
                     tsName: $tsName,
                     barcode: $barcode,
@@ -403,7 +424,7 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
                     costDate: $rrDt,
                     marketplaceSku: $saName,
                     description: 'Штрафы WB',
-                    externalId: $realizationId.'_penalty',
+                    externalId: 'wb:'.$rrdId.':wb_penalty',
                     nmId: $nmId,
                     tsName: $tsName,
                     barcode: $barcode,
@@ -418,7 +439,7 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
                     costDate: $rrDt,
                     marketplaceSku: $saName,
                     description: 'Доплаты WB',
-                    externalId: $realizationId.'_additional_payment',
+                    externalId: 'wb:'.$rrdId.':wb_additional_payment',
                     nmId: $nmId,
                     tsName: $tsName,
                     barcode: $barcode,
@@ -429,6 +450,10 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
         return $costs;
     }
 
+    /**
+     * Legacy DTO API. Do not use for WB financial pipeline. Use raw report processors instead.
+ * @deprecated
+     */
     public function fetchReturns(
         Company $company,
         \DateTimeInterface $fromDate,
@@ -438,19 +463,19 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
         $returns = [];
 
         foreach ($data as $item) {
-            if (!isset($item['doc_type_name']) || 'Возврат' !== $item['doc_type_name']) {
+            if (!$this->normalizer->isReturn($item)) {
                 continue;
             }
 
             $returns[] = new ReturnData(
                 marketplace: MarketplaceType::WILDBERRIES,
-                marketplaceSku: $item['sa_name'],
-                returnDate: new \DateTimeImmutable($item['rr_dt']),
-                quantity: abs((int) $item['quantity']),
-                refundAmount: (string) abs((float) ($item['retail_amount'] ?? 0)),
+                marketplaceSku: $this->normalizer->vendorCode($item),
+                returnDate: $this->normalizer->reportDate($item),
+                quantity: abs($this->normalizer->quantity($item)),
+                refundAmount: (string) abs($this->normalizer->retailPriceWithDisc($item)),
                 returnReason: $item['supplier_oper_name'] ?? null,
                 returnLogisticsCost: isset($item['return_amount']) ? (string) abs((float) $item['return_amount']) : null,
-                externalReturnId: (string) $item['realizationreport_id'],
+                externalReturnId: $this->normalizer->rrdId($item) ?? (string) ($item['realizationreport_id'] ?? ''),
                 nmId: isset($item['nm_id']) ? (string) $item['nm_id'] : null,
                 tsName: isset($item['ts_name']) ? (string) $item['ts_name'] : null,
                 barcode: isset($item['barcode']) ? (string) $item['barcode'] : null,

--- a/site/tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php
+++ b/site/tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php
@@ -10,6 +10,7 @@ use App\Marketplace\Exception\MarketplaceAuthException;
 use App\Marketplace\Exception\MarketplaceInvalidApiResponseException;
 use App\Marketplace\Exception\MarketplaceRateLimitException;
 use App\Marketplace\Exception\MarketplaceTemporaryApiException;
+use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
 use App\Marketplace\Repository\MarketplaceConnectionRepository;
 use App\Marketplace\Service\Integration\WildberriesAdapter;
 use PHPUnit\Framework\TestCase;
@@ -153,7 +154,7 @@ final class WildberriesAdapterTest extends TestCase
         });
         $repo = $this->createMock(MarketplaceConnectionRepository::class);
         $repo->method('findByMarketplace')->willReturn($this->connection());
-        $adapter = new WildberriesAdapter($client, $repo, new NullLogger());
+        $adapter = new WildberriesAdapter($client, $repo, new NullLogger(), new WbSalesReportRowNormalizer());
 
         self::assertFalse($adapter->hasRawReportData($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-02')));
         self::assertSame(1, $captured['limit']);
@@ -180,7 +181,7 @@ final class WildberriesAdapterTest extends TestCase
         $repo = $this->createMock(MarketplaceConnectionRepository::class);
         $repo->method('findByMarketplace')->willReturn($this->connection());
 
-        $adapter = new WildberriesAdapter($client, $repo, new NullLogger());
+        $adapter = new WildberriesAdapter($client, $repo, new NullLogger(), new WbSalesReportRowNormalizer());
 
         $this->expectException(MarketplaceTemporaryApiException::class);
         $adapter->fetchRawReport($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-02'));
@@ -197,7 +198,7 @@ final class WildberriesAdapterTest extends TestCase
         $repo = $this->createMock(MarketplaceConnectionRepository::class);
         $repo->method('findByMarketplace')->willReturn($this->connection());
 
-        $adapter = new WildberriesAdapter(new MockHttpClient(new MockResponse($payload, ['http_code' => 200])), $repo, $logger);
+        $adapter = new WildberriesAdapter(new MockHttpClient(new MockResponse($payload, ['http_code' => 200])), $repo, $logger, new WbSalesReportRowNormalizer());
 
         $decoded = $adapter->fetchRawReport($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-02'));
 
@@ -218,18 +219,59 @@ final class WildberriesAdapterTest extends TestCase
         $repo = $this->createMock(MarketplaceConnectionRepository::class);
         $repo->method('findByMarketplace')->willReturn($this->connection());
 
-        $adapter = new WildberriesAdapter($client, $repo, new NullLogger());
+        $adapter = new WildberriesAdapter($client, $repo, new NullLogger(), new WbSalesReportRowNormalizer());
 
         $this->expectException(MarketplaceTemporaryApiException::class);
         $adapter->hasRawReportData($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-02'));
     }
 
+
+    public function testLegacyFetchSalesUsesRetailPriceWithDiscInsteadOfRetailAmount(): void
+    {
+        $payload = json_encode([[
+            'doc_type_name' => 'Продажа',
+            'rrd_id' => '123',
+            'sale_dt' => '2026-01-10 10:00:00',
+            'sa_name' => 'SKU-1',
+            'quantity' => 2,
+            'retail_amount' => 9999,
+            'retail_price_withdisc_rub' => 1125,
+        ]], JSON_THROW_ON_ERROR);
+
+        $adapter = $this->createAdapter(new MockResponse($payload, ['http_code' => 200]));
+
+        $sales = $adapter->fetchSales($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-31'));
+
+        self::assertCount(1, $sales);
+        self::assertSame('1125', $sales[0]->totalRevenue);
+        self::assertSame('562.5', $sales[0]->pricePerUnit);
+    }
+
+    public function testLegacyFetchReturnsUsesRetailPriceWithDiscInsteadOfRetailAmount(): void
+    {
+        $payload = json_encode([[
+            'doc_type_name' => 'Возврат',
+            'rrd_id' => '124',
+            'rr_dt' => '2026-01-10 10:00:00',
+            'sa_name' => 'SKU-1',
+            'quantity' => 1,
+            'retail_amount' => 9999,
+            'retail_price_withdisc_rub' => 1125,
+        ]], JSON_THROW_ON_ERROR);
+
+        $adapter = $this->createAdapter(new MockResponse($payload, ['http_code' => 200]));
+
+        $returns = $adapter->fetchReturns($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-31'));
+
+        self::assertCount(1, $returns);
+        self::assertSame('1125', $returns[0]->refundAmount);
+    }
     private function createAdapter(MockResponse $response): WildberriesAdapter
     {
         $repo = $this->createMock(MarketplaceConnectionRepository::class);
         $repo->method('findByMarketplace')->willReturn($this->connection());
 
-        return new WildberriesAdapter(new MockHttpClient($response), $repo, new NullLogger());
+        return new WildberriesAdapter(new MockHttpClient($response), $repo, new NullLogger(), new WbSalesReportRowNormalizer());
     }
 
     private function company(): Company

--- a/site/tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php
+++ b/site/tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php
@@ -266,6 +266,52 @@ final class WildberriesAdapterTest extends TestCase
         self::assertCount(1, $returns);
         self::assertSame('1125', $returns[0]->refundAmount);
     }
+
+    public function testLegacyFetchCostsDoesNotCreateCommissionForReturnBecauseCostDataHasNoStorno(): void
+    {
+        $payload = json_encode([[
+            'doc_type_name' => 'Возврат',
+            'supplier_oper_name' => 'Возврат покупателем',
+            'rrd_id' => '125',
+            'rr_dt' => '2026-01-10 10:00:00',
+            'sale_dt' => '2026-01-10 10:00:00',
+            'sa_name' => 'SKU-1',
+            'quantity' => 1,
+            'retail_price_withdisc_rub' => 1125.00,
+            'ppvz_for_pay' => 680.99,
+            'acquiring_fee' => 27.76,
+            'retail_amount' => 720.00,
+            'retail_price' => 1500.00,
+        ]], JSON_THROW_ON_ERROR);
+
+        $adapter = $this->createAdapter(new MockResponse($payload, ['http_code' => 200]));
+        $costs = $adapter->fetchCosts($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-31'));
+
+        self::assertSame([], $costs);
+    }
+
+    public function testLegacyFetchCostsForSaleUsesCommissionFormulaAndExternalIdByRrdId(): void
+    {
+        $payload = json_encode([[
+            'doc_type_name' => 'Продажа',
+            'rrd_id' => '126',
+            'rr_dt' => '2026-01-10 10:00:00',
+            'sale_dt' => '2026-01-10 10:00:00',
+            'sa_name' => 'SKU-1',
+            'quantity' => 1,
+            'retail_price_withdisc_rub' => 1125.00,
+            'ppvz_for_pay' => 680.99,
+            'acquiring_fee' => 27.76,
+        ]], JSON_THROW_ON_ERROR);
+
+        $adapter = $this->createAdapter(new MockResponse($payload, ['http_code' => 200]));
+        $costs = $adapter->fetchCosts($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-31'));
+
+        self::assertCount(1, $costs);
+        self::assertSame('wb_commission', $costs[0]->categoryCode);
+        self::assertSame('416.25', $costs[0]->amount);
+        self::assertSame('wb:126:wb_commission', $costs[0]->externalId);
+    }
     private function createAdapter(MockResponse $response): WildberriesAdapter
     {
         $repo = $this->createMock(MarketplaceConnectionRepository::class);


### PR DESCRIPTION
### Motivation

- Centralize Wildberries report row parsing and business logic by introducing a dedicated normalizer.
- Ensure legacy DTO-producing methods use normalized fields (retail price with discounts, quantity, dates, IDs) for correct financial calculations.
- Mark the legacy DTO API as deprecated and direct new pipelines to use raw report processors.

### Description

- Added a `WbSalesReportRowNormalizer` dependency to `WildberriesAdapter` constructor and imported the class. 
- Updated `fetchSales`, `fetchCosts`, and `fetchReturns` to use normalizer methods such as `isSale`, `isReturn`, `retailPriceWithDisc`, `quantity`, `rrdId`, `operationDate`, `reportDate`, `vendorCode`, and `fullMarketplaceCommission` for field extraction and validation. 
- Calculated `pricePerUnit` from `retailPriceWithDisc / quantity`, and changed cost `externalId` values to the `wb:{rrdId}:{type}` format; handled missing `rrdId` robustly. 
- Added `@deprecated` docblocks to the legacy DTO methods and updated unit tests to instantiate the adapter with the new normalizer dependency.

### Testing

- Ran unit tests in `WildberriesAdapterTest` via PHPUnit, including updated adapter instantiation tests, and they passed. 
- Added `testLegacyFetchSalesUsesRetailPriceWithDiscInsteadOfRetailAmount` which asserts `totalRevenue` and `pricePerUnit` use `retail_price_withdisc_rub`, and it passed. 
- Added `testLegacyFetchReturnsUsesRetailPriceWithDiscInsteadOfRetailAmount` which asserts return refund uses `retail_price_withdisc_rub`, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05c462af80832395c1fd7a35b31fa9)