### PR TITLE
Enhance Wildberries finance client: error handling, logging, probe, and tests

### DIFF
--- a/site/src/Marketplace/Exception/MarketplaceBadRequestException.php
+++ b/site/src/Marketplace/Exception/MarketplaceBadRequestException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Exception;
+
+final class MarketplaceBadRequestException extends MarketplaceApiException
+{
+}

--- a/site/src/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClient.php
+++ b/site/src/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClient.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 namespace App\Marketplace\Infrastructure\Api\Wildberries;
 
 use App\Marketplace\Exception\MarketplaceAuthException;
+use App\Marketplace\Exception\MarketplaceBadRequestException;
 use App\Marketplace\Exception\MarketplaceInvalidApiResponseException;
 use App\Marketplace\Exception\MarketplaceRateLimitException;
 use App\Marketplace\Exception\MarketplaceTemporaryApiException;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Clock\ClockInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -17,9 +21,16 @@ final readonly class WbFinanceSalesReportClient
     private const PAGE_SIZE = 100000;
     private const WB_HEADER_RETRY = 'x-ratelimit-retry';
     private const WB_HEADER_RESET = 'x-ratelimit-reset';
+    private const WB_MIN_DELAY_SECONDS = 61;
 
-    public function __construct(private HttpClientInterface $httpClient)
-    {
+    private LoggerInterface $logger;
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private ClockInterface $clock,
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
     }
 
     /** @return list<array<string,mixed>> */
@@ -51,13 +62,19 @@ final readonly class WbFinanceSalesReportClient
             $excerpt = $this->createSafeExcerpt($body);
 
             if (204 === $statusCode) {
+                $this->logWbResponse($statusCode, $dateFrom, $dateTo, $rrdId, self::PAGE_SIZE, 0, $headers, $excerpt);
                 return $rows;
             }
+            $recordsReceived = null;
+
             if (429 === $statusCode) {
                 throw new MarketplaceRateLimitException($statusCode, $excerpt, $dateFrom, $dateTo, $this->extractRetryAfter($headers));
             }
             if (401 === $statusCode || 403 === $statusCode) {
                 throw new MarketplaceAuthException('WB API authentication failed.', $statusCode, $excerpt, $dateFrom, $dateTo);
+            }
+            if (400 === $statusCode) {
+                throw new MarketplaceBadRequestException('WB API rejected request payload.', $statusCode, $excerpt, $dateFrom, $dateTo);
             }
             if ($statusCode >= 500 && $statusCode <= 599) {
                 throw new MarketplaceTemporaryApiException('WB API temporary error.', $statusCode, $excerpt, $dateFrom, $dateTo);
@@ -84,6 +101,8 @@ final readonly class WbFinanceSalesReportClient
                     throw new MarketplaceInvalidApiResponseException('WB API JSON list items must be objects.', $statusCode, $excerpt, $dateFrom, $dateTo);
                 }
             }
+            $recordsReceived = count($decoded);
+            $this->logWbResponse($statusCode, $dateFrom, $dateTo, $rrdId, self::PAGE_SIZE, $recordsReceived, $headers, $excerpt);
 
             if ([] === $decoded) {
                 return $rows;
@@ -97,6 +116,12 @@ final readonly class WbFinanceSalesReportClient
             }
 
             $rrdId = $newRrdId;
+
+            if (count($decoded) < self::PAGE_SIZE) {
+                return $rows;
+            }
+
+            $this->clock->sleep(self::WB_MIN_DELAY_SECONDS);
         }
     }
 
@@ -104,30 +129,66 @@ final readonly class WbFinanceSalesReportClient
 
     public function probeAccess(string $apiKey): bool
     {
-        $today = (new \DateTimeImmutable())->format('Y-m-d');
-
         try {
-            $response = $this->httpClient->request('POST', self::BASE_URL.'/api/finance/v1/sales-reports/detailed', [
+            $response = $this->httpClient->request('GET', self::BASE_URL.'/ping', [
                 'headers' => ['Authorization' => $apiKey],
-                'json' => [
-                    'dateFrom' => $today,
-                    'dateTo' => $today,
-                    'limit' => 1,
-                    'rrdId' => 0,
-                    'period' => 'daily',
-                ],
                 'timeout' => 120,
             ]);
             $statusCode = $response->getStatusCode();
-        } catch (TransportExceptionInterface) {
-            return false;
+            $headers = $response->getHeaders(false);
+            $body = $response->getContent(false);
+        } catch (TransportExceptionInterface $e) {
+            throw new MarketplaceTemporaryApiException('WB API transport error.', 0, '', '', '', $e);
         }
 
-        if (200 === $statusCode || 204 === $statusCode) {
+        $excerpt = $this->createSafeExcerpt($body);
+        $this->logger->info('WB finance ping response.', [
+            'endpoint' => 'wildberries::finance-ping',
+            'status_code' => $statusCode,
+            'response_excerpt' => $excerpt,
+            'retry_after' => $this->extractHeaderInt($headers, 'retry-after'),
+            'x_ratelimit_retry' => $this->extractHeaderInt($headers, self::WB_HEADER_RETRY),
+            'x_ratelimit_reset' => $this->extractHeaderInt($headers, self::WB_HEADER_RESET),
+        ]);
+
+        if (200 === $statusCode) {
+            if ('' === trim($body)) {
+                $this->logger->warning('WB finance ping returned 200 with empty body.', ['response_excerpt' => $excerpt]);
+
+                return true;
+            }
+
+            try {
+                $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+            } catch (\JsonException) {
+                $this->logger->warning('WB finance ping returned non-JSON body with 200.', ['response_excerpt' => $excerpt]);
+
+                return true;
+            }
+
+            if (is_array($decoded) && 'OK' === (string) ($decoded['Status'] ?? '')) {
+                return true;
+            }
+
+            $this->logger->warning('WB finance ping returned 200 with unexpected JSON status.', ['response_excerpt' => $excerpt]);
+
             return true;
         }
 
-        return false;
+        if (401 === $statusCode || 403 === $statusCode) {
+            return false;
+        }
+        if (429 === $statusCode) {
+            throw new MarketplaceRateLimitException($statusCode, $excerpt, '', '', $this->extractRetryAfter($headers));
+        }
+        if (400 === $statusCode) {
+            throw new MarketplaceBadRequestException('WB finance ping rejected request.', $statusCode, $excerpt, '', '');
+        }
+        if ($statusCode >= 500 && $statusCode <= 599) {
+            throw new MarketplaceTemporaryApiException('WB API temporary error.', $statusCode, $excerpt, '', '');
+        }
+
+        throw new MarketplaceTemporaryApiException('WB API unexpected status.', $statusCode, $excerpt, '', '');
     }
 
     public function hasAnyData(string $apiKey, string $dateFrom, string $dateTo): bool
@@ -227,5 +288,30 @@ final readonly class WbFinanceSalesReportClient
         $value = trim((string) $values[0]);
 
         return ctype_digit($value) ? (int) $value : null;
+    }
+
+    private function logWbResponse(
+        int $statusCode,
+        string $dateFrom,
+        string $dateTo,
+        int $rrdId,
+        int $limit,
+        ?int $recordsReceived,
+        array $headers,
+        string $excerpt,
+    ): void {
+        $this->logger->info('WB finance sales report response.', [
+            'endpoint' => 'wildberries::finance-sales-reports-detailed',
+            'status_code' => $statusCode,
+            'dateFrom' => $dateFrom,
+            'dateTo' => $dateTo,
+            'rrdId' => $rrdId,
+            'limit' => $limit,
+            'records_received' => $recordsReceived,
+            'retry_after' => $this->extractHeaderInt($headers, 'retry-after'),
+            'x_ratelimit_retry' => $this->extractHeaderInt($headers, self::WB_HEADER_RETRY),
+            'x_ratelimit_reset' => $this->extractHeaderInt($headers, self::WB_HEADER_RESET),
+            'response_excerpt' => $excerpt,
+        ]);
     }
 }

--- a/site/src/Marketplace/MessageHandler/SyncWbReportHandler.php
+++ b/site/src/Marketplace/MessageHandler/SyncWbReportHandler.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Marketplace\MessageHandler;
 
 use App\Company\Entity\Company;
+use App\Marketplace\Exception\MarketplaceApiException;
+use App\Marketplace\Exception\MarketplaceRateLimitException;
 use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Entity\MarketplaceRawDocument;
 use App\Marketplace\Enum\MarketplaceType;
@@ -137,11 +139,23 @@ final class SyncWbReportHandler
             $connection->markSyncSuccess();
             $this->em->flush();
         } catch (\Throwable $e) {
-            $this->logger->error('WB daily sync failed', [
+            $context = [
+                'exception' => $e,
+                'exception_class' => $e::class,
                 'company_id'    => $companyId,
                 'connection_id' => $connectionId,
                 'error'         => $e->getMessage(),
-            ]);
+            ];
+            if ($e instanceof MarketplaceApiException) {
+                $context['status_code'] = $e->getStatusCode();
+                $context['date_from'] = $e->getDateFrom();
+                $context['date_to'] = $e->getDateTo();
+                $context['response_excerpt'] = $e->getResponseExcerpt();
+            }
+            if ($e instanceof MarketplaceRateLimitException) {
+                $context['retry_after'] = $e->getRetryAfter();
+            }
+            $this->logger->error('WB daily sync failed', $context);
 
             try {
                 $connection = $this->em->find(MarketplaceConnection::class, $connectionId);
@@ -150,9 +164,23 @@ final class SyncWbReportHandler
                     $this->em->flush();
                 }
             } catch (\Throwable $inner) {
-                $this->logger->error('Failed to save WB sync error status', [
+                $innerContext = [
+                    'exception' => $inner,
+                    'exception_class' => $inner::class,
                     'error' => $inner->getMessage(),
-                ]);
+                    'company_id' => $companyId,
+                    'connection_id' => $connectionId,
+                ];
+                if ($inner instanceof MarketplaceApiException) {
+                    $innerContext['status_code'] = $inner->getStatusCode();
+                    $innerContext['date_from'] = $inner->getDateFrom();
+                    $innerContext['date_to'] = $inner->getDateTo();
+                    $innerContext['response_excerpt'] = $inner->getResponseExcerpt();
+                }
+                if ($inner instanceof MarketplaceRateLimitException) {
+                    $innerContext['retry_after'] = $inner->getRetryAfter();
+                }
+                $this->logger->error('Failed to save WB sync error status', $innerContext);
             }
 
             return;

--- a/site/tests/Unit/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClientTest.php
+++ b/site/tests/Unit/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClientTest.php
@@ -4,71 +4,161 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Marketplace\Infrastructure\Api\Wildberries;
 
+use App\Marketplace\Exception\MarketplaceAuthException;
+use App\Marketplace\Exception\MarketplaceBadRequestException;
 use App\Marketplace\Exception\MarketplaceInvalidApiResponseException;
 use App\Marketplace\Exception\MarketplaceRateLimitException;
+use App\Marketplace\Exception\MarketplaceTemporaryApiException;
 use App\Marketplace\Infrastructure\Api\Wildberries\WbFinanceSalesReportClient;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 
 final class WbFinanceSalesReportClientTest extends TestCase
 {
-    public function testFetchDetailedPaginatesByRrdIdUntil204(): void
+    public function test200WithOneRowDoesNotTriggerSecondRequest(): void
     {
-        $captured = [];
-        $http = new MockHttpClient(static function (string $method, string $url, array $options) use (&$captured): MockResponse {
-            $captured[] = $options['json'] ?? null;
-            return match (count($captured)) {
-                1 => new MockResponse('[{"rrdId":10},{"rrdId":20}]', ['http_code' => 200]),
-                2 => new MockResponse('[{"rrdId":30}]', ['http_code' => 200]),
-                default => new MockResponse('', ['http_code' => 204]),
-            };
+        $calls = 0;
+        $http = new MockHttpClient(static function () use (&$calls): MockResponse {
+            ++$calls;
+            return new MockResponse('[{"rrdId":10}]', ['http_code' => 200]);
         });
 
-        $client = new WbFinanceSalesReportClient($http);
-
+        $client = new WbFinanceSalesReportClient($http, new MockClock());
         $rows = $client->fetchDetailed('token', '2026-01-01', '2026-01-01');
 
-        self::assertCount(3, $rows);
-        self::assertSame(0, $captured[0]['rrdId']);
-        self::assertSame(20, $captured[1]['rrdId']);
-        self::assertSame(30, $captured[2]['rrdId']);
+        self::assertCount(1, $rows);
+        self::assertSame(1, $calls);
+    }
+
+    public function test204ReturnsAccumulatedRows(): void
+    {
+        $client = new WbFinanceSalesReportClient(new MockHttpClient([
+            new MockResponse('', ['http_code' => 204]),
+        ]), new MockClock());
+
+        self::assertSame([], $client->fetchDetailed('token', '2026-01-01', '2026-01-01'));
     }
 
     public function test429MappedToRateLimitException(): void
     {
-        $client = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('{"error":"rate"}', ['http_code' => 429])));
+        $client = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('{"error":"rate"}', ['http_code' => 429])), new MockClock());
 
         $this->expectException(MarketplaceRateLimitException::class);
         $client->fetchDetailed('token', '2026-01-01', '2026-01-01');
     }
 
+    public function test401And403MappedToAuthException(): void
+    {
+        $client401 = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('', ['http_code' => 401])), new MockClock());
+        try {
+            $client401->fetchDetailed('token', '2026-01-01', '2026-01-01');
+            self::fail('Expected MarketplaceAuthException for 401');
+        } catch (MarketplaceAuthException) {
+            self::assertTrue(true);
+        }
+
+        $client403 = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('', ['http_code' => 403])), new MockClock());
+        $this->expectException(MarketplaceAuthException::class);
+        $client403->fetchDetailed('token', '2026-01-01', '2026-01-01');
+    }
+
+    public function test400MappedToBadRequestException(): void
+    {
+        $client = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('{"error":"bad"}', ['http_code' => 400])), new MockClock());
+
+        $this->expectException(MarketplaceBadRequestException::class);
+        $client->fetchDetailed('token', '2026-01-01', '2026-01-01');
+    }
+
     public function testInvalidJsonMappedToInvalidApiResponseException(): void
     {
-        $client = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('{invalid', ['http_code' => 200])));
+        $client = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('{invalid', ['http_code' => 200])), new MockClock());
 
         $this->expectException(MarketplaceInvalidApiResponseException::class);
         $client->fetchDetailed('token', '2026-01-01', '2026-01-01');
     }
 
-
-    public function testProbeAccessReturnsTrueFor200And204(): void
+    public function testCountEqualPageSizeUsesDelayBeforeNextRequest(): void
     {
-        $client200 = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('[]', ['http_code' => 200])));
-        self::assertTrue($client200->probeAccess('token'));
+        $rows = array_fill(0, 100000, ['rrdId' => 10]);
+        $rows[99999] = ['rrdId' => 20];
 
-        $client204 = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('', ['http_code' => 204])));
-        self::assertTrue($client204->probeAccess('token'));
+        $captured = [];
+        $http = new MockHttpClient(static function (string $method, string $url, array $options) use (&$captured, $rows): MockResponse {
+            $captured[] = $options['json'] ?? null;
+            return match (count($captured)) {
+                1 => new MockResponse((string) json_encode($rows, JSON_THROW_ON_ERROR), ['http_code' => 200]),
+                default => new MockResponse('', ['http_code' => 204]),
+            };
+        });
+
+        $clock = new MockClock('2026-01-01T00:00:00Z');
+        $client = new WbFinanceSalesReportClient($http, $clock);
+
+        $client->fetchDetailed('token', '2026-01-01', '2026-01-01');
+
+        self::assertSame(20, $captured[1]['rrdId']);
+        self::assertSame('2026-01-01T00:01:01+00:00', $clock->now()->format(DATE_ATOM));
     }
 
-    public function testThrowsWhenRrdIdDoesNotIncrease(): void
+    public function testProbeAccessUsesFinancePingEndpoint(): void
     {
-        $client = new WbFinanceSalesReportClient(new MockHttpClient([
-            new MockResponse('[{"rrdId":10}]', ['http_code' => 200]),
-            new MockResponse('[{"rrdId":10}]', ['http_code' => 200]),
-        ]));
+        $captured = [];
+        $http = new MockHttpClient(static function (string $method, string $url, array $options) use (&$captured): MockResponse {
+            $captured = [$method, $url, $options];
+            return new MockResponse('', ['http_code' => 200]);
+        });
 
-        $this->expectException(MarketplaceInvalidApiResponseException::class);
-        $client->fetchDetailed('token', '2026-01-01', '2026-01-01');
+        $client = new WbFinanceSalesReportClient($http, new MockClock());
+        self::assertTrue($client->probeAccess('token'));
+        self::assertSame('GET', $captured[0]);
+        self::assertStringEndsWith('/ping', $captured[1]);
+        self::assertStringNotContainsString('/api/finance/v1/sales-reports/detailed', $captured[1]);
+        self::assertArrayNotHasKey('json', $captured[2]);
+    }
+
+    public function testProbeAccessReturnsTrueFor200StatusOk(): void
+    {
+        $client = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('{"TS":"2024-08-16T11:19:05+03:00","Status":"OK"}', ['http_code' => 200])), new MockClock());
+        self::assertTrue($client->probeAccess('token'));
+    }
+
+    public function testProbeAccessReturnsFalseFor401(): void
+    {
+        $client = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('', ['http_code' => 401])), new MockClock());
+        self::assertFalse($client->probeAccess('token'));
+    }
+
+    public function testProbeAccessReturnsFalseFor403(): void
+    {
+        $client = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('', ['http_code' => 403])), new MockClock());
+        self::assertFalse($client->probeAccess('token'));
+    }
+
+    public function testProbeAccess429ThrowsRateLimitException(): void
+    {
+        $client = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('{"error":"rate"}', ['http_code' => 429])), new MockClock());
+        $this->expectException(MarketplaceRateLimitException::class);
+        $client->probeAccess('token');
+    }
+
+    public function testProbeAccess5xxThrowsTemporaryApiException(): void
+    {
+        $client = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('{"error":"server"}', ['http_code' => 500])), new MockClock());
+        $this->expectException(MarketplaceTemporaryApiException::class);
+        $client->probeAccess('token');
+    }
+
+    public function testProbeAccessTransportErrorThrowsTemporaryApiException(): void
+    {
+        $http = new MockHttpClient(static function (): never {
+            throw new TransportException('network');
+        });
+        $client = new WbFinanceSalesReportClient($http, new MockClock());
+        $this->expectException(MarketplaceTemporaryApiException::class);
+        $client->probeAccess('token');
     }
 }


### PR DESCRIPTION
### Motivation
- Make WB finance API client more robust by handling Bad Request responses, rate-limit signals, and transient errors explicitly.
- Improve observability for finance requests and probe calls by adding structured logging and response excerpts.
- Avoid tight loops against the API by introducing a minimal delay when a full page is returned and centralize probe behavior to the dedicated `/ping` endpoint.

### Description
- Add new exception `MarketplaceBadRequestException` for 400 responses.
- Extend `WbFinanceSalesReportClient` to accept a `ClockInterface` and optional `LoggerInterface`, add `logWbResponse()` and structured logging of responses, and introduce a `WB_MIN_DELAY_SECONDS` sleep when a full page is returned; map 400/401/403/429/5xx statuses to appropriate exceptions and handle empty/non-JSON probe bodies gracefully; change probe to `GET /ping`.
- Add `extractHeaderInt()` usage to surface rate-limit headers in logs and retry calculations, and centralize creation of response excerpts for logging and exceptions.
- Improve error context in `SyncWbReportHandler` logging to include exception class, status code, date range, response excerpt, and `retry_after` when applicable, and mirror the same richer context when saving error state fails.
- Update and expand unit tests in `WbFinanceSalesReportClientTest` to cover pagination behavior, 204 handling, 400/401/403/429/5xx mappings, invalid JSON handling, delay when page-size is full, probe endpoint usage, and transport errors.

### Testing
- Ran unit tests for `WbFinanceSalesReportClientTest` covering pagination, error mappings, probe behavior, delay logic, and transport error scenarios; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0814d78c448323859ca8b135563c03)