### PR TITLE
Provide MockClock to WbFinanceSalesReportClient in WildberriesAdapterTest

### DIFF
--- a/site/tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php
+++ b/site/tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php
@@ -12,6 +12,7 @@ use App\Marketplace\Repository\MarketplaceConnectionRepository;
 use App\Marketplace\Service\Integration\WildberriesAdapter;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use Symfony\Component\Clock\MockClock;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 
@@ -111,7 +112,7 @@ final class WildberriesAdapterTest extends TestCase
         $repo = $this->createMock(MarketplaceConnectionRepository::class);
         $repo->method('findByMarketplace')->willReturn($this->connection());
 
-        return new WildberriesAdapter($http, $repo, new NullLogger(), new WbSalesReportRowNormalizer(), new WbFinanceSalesReportClient($http));
+        return new WildberriesAdapter($http, $repo, new NullLogger(), new WbSalesReportRowNormalizer(), new WbFinanceSalesReportClient($http, new MockClock()));
     }
 
     private function company(): Company { return $this->createMock(Company::class); }


### PR DESCRIPTION
### Motivation
- The `WbFinanceSalesReportClient` gained a `Clock` dependency and the test must supply a deterministic clock to avoid time-dependent behavior.

### Description
- Added `use Symfony\Component\Clock\MockClock;` and passed `new MockClock()` when constructing `WbFinanceSalesReportClient` in `createAdapter` of `site/tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php`.

### Testing
- Ran `phpunit --filter WildberriesAdapterTest` for `site/tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0824b45e9083238638b9b36b558353)