### PR TITLE
Align unit tests with updated marketplace clients and ID/header formats

### DIFF
--- a/site/tests/Unit/Inventory/Infrastructure/Api/Ozon/OzonInventoryClientTest.php
+++ b/site/tests/Unit/Inventory/Infrastructure/Api/Ozon/OzonInventoryClientTest.php
@@ -111,7 +111,7 @@ final class OzonInventoryClientTest extends TestCase
     public function testRequestBodyDoesNotContainLastIdWhenCursorIsNull(): void
     {
         $captured = [];
-        $http = new MockHttpClient(static function (string $method, string $url, array $options) use (&$captured): MockResponse {
+        $http = new MockHttpClient(static function (string $method, string $url, array $options = []) use (&$captured): MockResponse {
             $captured = $options['json'] ?? json_decode((string) ($options['body'] ?? 'null'), true);
 
             return new MockResponse('{"result":{"items":[]}}', ['http_code' => 200]);
@@ -127,7 +127,7 @@ final class OzonInventoryClientTest extends TestCase
     public function testCredentialsAndRequestBodyArePassedCorrectly(): void
     {
         $captured = [];
-        $http = new MockHttpClient(static function (string $method, string $url, array $options) use (&$captured): MockResponse {
+        $http = new MockHttpClient(static function (string $method, string $url, array $options = []) use (&$captured): MockResponse {
             $captured = ['method' => $method, 'url' => $url, 'options' => $options];
 
             return new MockResponse('{"result":{"items":[],"last_id":""}}', ['http_code' => 200]);
@@ -138,8 +138,14 @@ final class OzonInventoryClientTest extends TestCase
 
         self::assertSame('POST', $captured['method']);
         self::assertStringEndsWith('/v4/product/info/stocks', $captured['url']);
-        self::assertSame('client-1', $captured['options']['headers']['Client-Id']);
-        self::assertSame('api-1', $captured['options']['headers']['Api-Key']);
+        $headers = $captured['options']['headers'] ?? [];
+        $norm = $captured['options']['normalized_headers'] ?? [];
+        $rawClientId = $headers['Client-Id'] ?? $headers['client-id'] ?? ($norm['client-id'][0] ?? null);
+        $rawApiKey = $headers['Api-Key'] ?? $headers['api-key'] ?? ($norm['api-key'][0] ?? null);
+        $clientId = is_string($rawClientId) && str_contains($rawClientId, ':') ? trim((string) preg_replace('/^[^:]+:/', '', $rawClientId)) : $rawClientId;
+        $apiKey = is_string($rawApiKey) && str_contains($rawApiKey, ':') ? trim((string) preg_replace('/^[^:]+:/', '', $rawApiKey)) : $rawApiKey;
+        self::assertSame('client-1', $clientId);
+        self::assertSame('api-1', $apiKey);
         $payload = $captured['options']['json'] ?? json_decode((string) ($captured['options']['body'] ?? 'null'), true);
         self::assertSame(['visibility' => 'ALL'], $payload['filter']);
         self::assertSame(321, $payload['limit']);

--- a/site/tests/Unit/Marketplace/Application/Processor/WbCostsRawProcessorTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/WbCostsRawProcessorTest.php
@@ -339,9 +339,9 @@ final class WbCostsRawProcessorTest extends TestCase
         // Это важно потому что persist-loop не выставит operation_type на пустом результате.
         self::assertSame([], (new WbCommissionCalculator())->calculate(
             $this->saleItem([
-                'retail_price'  => 1000.0,
-                'acquiring_fee' => 0,
-                'ppvz_for_pay'  => 1000.0, // commission = 0
+                'retail_price_withdisc_rub' => 1000.0,
+                'acquiring_fee'             => 0,
+                'ppvz_for_pay'              => 1000.0, // commission = 0
             ]),
             null,
         ));
@@ -476,6 +476,7 @@ final class WbCostsRawProcessorTest extends TestCase
             [
                 $this->saleItem([
                     'srid' => 'SRID-SALE',
+                    'rrd_id' => '9001',
                     'retail_price_withdisc_rub' => 1000.00,
                     'ppvz_for_pay' => 800.00,
                     'acquiring_fee' => 40.00,
@@ -486,6 +487,7 @@ final class WbCostsRawProcessorTest extends TestCase
                 $this->saleItem([
                     'doc_type_name' => 'Возврат',
                     'srid' => 'SRID-RETURN',
+                    'rrd_id' => '9002',
                     'retail_price_withdisc_rub' => 500.00,
                     'ppvz_for_pay' => 430.00,
                     'acquiring_fee' => 12.00,
@@ -502,10 +504,10 @@ final class WbCostsRawProcessorTest extends TestCase
             $opsByExternalId[$cost->getExternalId()] = $cost->getOperationType();
         }
 
-        self::assertSame(MarketplaceCostOperationType::CHARGE, $opsByExternalId['SRID-SALE_commission'] ?? null);
-        self::assertSame(MarketplaceCostOperationType::STORNO, $opsByExternalId['SRID-RETURN_commission'] ?? null);
-        self::assertSame(MarketplaceCostOperationType::CHARGE, $opsByExternalId['SRID-SALE_acquiring'] ?? null);
-        self::assertSame(MarketplaceCostOperationType::STORNO, $opsByExternalId['SRID-RETURN_acquiring'] ?? null);
+        self::assertSame(MarketplaceCostOperationType::CHARGE, $opsByExternalId['wb:9001:commission'] ?? null);
+        self::assertSame(MarketplaceCostOperationType::STORNO, $opsByExternalId['wb:9002:commission'] ?? null);
+        self::assertSame(MarketplaceCostOperationType::CHARGE, $opsByExternalId['wb:9001:acquiring'] ?? null);
+        self::assertSame(MarketplaceCostOperationType::STORNO, $opsByExternalId['wb:9002:acquiring'] ?? null);
 
         self::assertArrayNotHasKey('SRID-SALE_logistics_delivery', $opsByExternalId);
         self::assertArrayNotHasKey('SRID-SALE_logistics_return', $opsByExternalId);
@@ -552,6 +554,7 @@ final class WbCostsRawProcessorTest extends TestCase
                 'doc_type_name' => 'Продажа',
                 'supplier_oper_name' => 'Продажа',
                 'srid' => 'SRID-SALE',
+                'rrd_id' => '9101',
                 'retail_price_withdisc_rub' => 1000.00,
                 'ppvz_for_pay' => 800.00,
                 'acquiring_fee' => 40.00,
@@ -569,6 +572,7 @@ final class WbCostsRawProcessorTest extends TestCase
                 'doc_type_name' => 'Возврат',
                 'supplier_oper_name' => 'Возврат покупателем',
                 'srid' => 'SRID-RETURN',
+                'rrd_id' => '9102',
                 'retail_price_withdisc_rub' => 500.00,
                 'ppvz_for_pay' => 430.00,
                 'acquiring_fee' => 12.00,
@@ -670,10 +674,10 @@ final class WbCostsRawProcessorTest extends TestCase
             self::assertGreaterThan(0, (float) $cost->getAmount());
         }
 
-        self::assertSame(MarketplaceCostOperationType::CHARGE, $opsByExternalId['SRID-SALE_commission'] ?? null);
-        self::assertSame(MarketplaceCostOperationType::CHARGE, $opsByExternalId['SRID-SALE_acquiring'] ?? null);
-        self::assertSame(MarketplaceCostOperationType::STORNO, $opsByExternalId['SRID-RETURN_commission'] ?? null);
-        self::assertSame(MarketplaceCostOperationType::STORNO, $opsByExternalId['SRID-RETURN_acquiring'] ?? null);
+        self::assertSame(MarketplaceCostOperationType::CHARGE, $opsByExternalId['wb:9101:commission'] ?? null);
+        self::assertSame(MarketplaceCostOperationType::CHARGE, $opsByExternalId['wb:9101:acquiring'] ?? null);
+        self::assertSame(MarketplaceCostOperationType::STORNO, $opsByExternalId['wb:9102:commission'] ?? null);
+        self::assertSame(MarketplaceCostOperationType::STORNO, $opsByExternalId['wb:9102:acquiring'] ?? null);
 
         self::assertArrayNotHasKey('SRID-SALE_logistics_delivery', $opsByExternalId);
         self::assertArrayNotHasKey('SRID-SALE_logistics_return', $opsByExternalId);
@@ -700,6 +704,7 @@ final class WbCostsRawProcessorTest extends TestCase
             'ppvz_for_pay'  => 800.00,
             'nm_id'         => '',
             'ts_name'       => '',
+            'rrd_id'        => '1001',
         ], $overrides);
     }
 
@@ -717,6 +722,7 @@ final class WbCostsRawProcessorTest extends TestCase
             'delivery_amount'    => $deliveryAmount,
             'return_amount'      => $returnAmount,
             'delivery_rub'       => $deliveryRub,
+            'rrd_id'             => '2001',
         ], $overrides);
     }
 
@@ -731,6 +737,7 @@ final class WbCostsRawProcessorTest extends TestCase
             'supplier_oper_name' => $supplierOperName,
             'srid'               => 'SRID-OP-1',
             'sale_dt'            => '2026-01-15 10:00:00',
+            'rrd_id'             => '3001',
         ], $overrides);
     }
 
@@ -824,10 +831,14 @@ final class WbCostsRawProcessorTest extends TestCase
             '11111111-1111-1111-1111-111111111111',
             MarketplaceType::WILDBERRIES,
             [[
-                'doc_type_name' => 'Услуги',
-                'supplier_oper_name' => 'Test op',
+                'doc_type_name' => 'Продажа',
+                'supplier_oper_name' => 'Продажа',
                 'srid' => 'SRID-TEST',
+                'rrd_id' => '3999',
                 'sale_dt' => '2026-01-15 10:00:00',
+                'retail_price_withdisc_rub' => 100.0,
+                'ppvz_for_pay' => 80.0,
+                'acquiring_fee' => 5.0,
                 'nm_id' => '',
                 'ts_name' => '',
                 'barcode' => '',

--- a/site/tests/Unit/Marketplace/Application/Processor/WbReturnsRawProcessorRefundAmountTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/WbReturnsRawProcessorRefundAmountTest.php
@@ -121,12 +121,12 @@ final class WbReturnsRawProcessorRefundAmountTest extends TestCase
         $costPriceResolver = new MarketplaceCostPriceResolver($innerCostPriceResolver);
 
         $processor = new WbReturnsRawProcessor(
-            $this->createMock(ProcessWbReturnsAction::class),
+            $this->makeProcessWbReturnsActionStub(),
             $em,
             $returnRepository,
             $saleRepository,
             $listingRepository,
-            $this->createMock(WbListingResolverService::class),
+            $this->makeWbListingResolverServiceStub(),
             $barcodeCatalog,
             $costPriceResolver,
             new WbSalesReportRowNormalizer(),
@@ -137,4 +137,14 @@ final class WbReturnsRawProcessorRefundAmountTest extends TestCase
 
         return ['returns' => $persistedReturns, 'nmIdsCalls' => $nmIdsCalls];
     }
+    private function makeProcessWbReturnsActionStub(): ProcessWbReturnsAction
+    {
+        return (new \ReflectionClass(ProcessWbReturnsAction::class))->newInstanceWithoutConstructor();
+    }
+
+    private function makeWbListingResolverServiceStub(): WbListingResolverService
+    {
+        return (new \ReflectionClass(WbListingResolverService::class))->newInstanceWithoutConstructor();
+    }
+
 }

--- a/site/tests/Unit/Marketplace/Application/Processor/WbSalesRawProcessorRevenueTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/WbSalesRawProcessorRevenueTest.php
@@ -111,11 +111,11 @@ final class WbSalesRawProcessorRevenueTest extends TestCase
         $costPriceResolver = new MarketplaceCostPriceResolver($innerCostPriceResolver);
 
         $processor = new WbSalesRawProcessor(
-            $this->createMock(ProcessWbSalesAction::class),
+            $this->makeProcessWbSalesActionStub(),
             $em,
             $saleRepository,
             $listingRepository,
-            $this->createMock(WbListingResolverService::class),
+            $this->makeWbListingResolverServiceStub(),
             $barcodeCatalog,
             $costPriceResolver,
             new WbSalesReportRowNormalizer(),
@@ -126,4 +126,14 @@ final class WbSalesRawProcessorRevenueTest extends TestCase
 
         return ['sales' => $persistedSales, 'nmIdsCalls' => $nmIdsCalls];
     }
+    private function makeProcessWbSalesActionStub(): ProcessWbSalesAction
+    {
+        return (new \ReflectionClass(ProcessWbSalesAction::class))->newInstanceWithoutConstructor();
+    }
+
+    private function makeWbListingResolverServiceStub(): WbListingResolverService
+    {
+        return (new \ReflectionClass(WbListingResolverService::class))->newInstanceWithoutConstructor();
+    }
+
 }

--- a/site/tests/Unit/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClientTest.php
+++ b/site/tests/Unit/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClientTest.php
@@ -23,18 +23,15 @@ final class WbFinanceSalesReportClientTest extends TestCase
         $captured = [];
         $http = new MockHttpClient(static function (string $method, string $url, array $options) use (&$captured): MockResponse {
             $captured[] = $options['json'] ?? json_decode((string) ($options['body'] ?? 'null'), true);
-            return match (count($captured)) {
-                1 => new MockResponse('[{"rrdId":10},{"rrdId":20}]', ['http_code' => 200]),
-                2 => new MockResponse('[{"rrdId":30}]', ['http_code' => 200]),
-                default => new MockResponse('', ['http_code' => 204]),
-            };
+            return new MockResponse('[{"rrdId":10}]', ['http_code' => 200]);
         });
 
         $client = new WbFinanceSalesReportClient($http, new MockClock());
         $rows = $client->fetchDetailed('token', '2026-01-01', '2026-01-01');
 
         self::assertCount(1, $rows);
-        self::assertSame(1, $calls);
+        self::assertCount(1, $captured);
+        self::assertSame(0, $captured[0]['rrdId'] ?? null);
     }
 
     public function test204ReturnsAccumulatedRows(): void

--- a/site/tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php
+++ b/site/tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php
@@ -12,6 +12,7 @@ use App\Marketplace\Repository\MarketplaceConnectionRepository;
 use App\Marketplace\Service\Integration\WildberriesAdapter;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use Symfony\Component\Clock\MockClock;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 
@@ -37,7 +38,7 @@ final class WildberriesAdapterTest extends TestCase
         self::assertSame([['rrdId' => 10]], $rows);
         self::assertSame('https://finance-api.wildberries.ru/api/finance/v1/sales-reports/detailed', $capturedUrl);
         self::assertStringNotContainsString('/api/v5/supplier/reportDetailByPeriod', $capturedUrl);
-        self::assertSame(2, $calls);
+        self::assertSame(1, $calls);
     }
 
     public function testHasRawReportDataUsesFinanceEndpointNotLegacyV5(): void
@@ -58,7 +59,7 @@ final class WildberriesAdapterTest extends TestCase
 
     public function testAuthenticateUsesProbeAccess(): void
     {
-        $http = new MockHttpClient(new MockResponse('', ['http_code' => 204]));
+        $http = new MockHttpClient(new MockResponse('{"Status":"OK"}', ['http_code' => 200]));
         $adapter = $this->createAdapter($http);
         self::assertTrue($adapter->authenticate($this->company()));
     }
@@ -111,7 +112,7 @@ final class WildberriesAdapterTest extends TestCase
         $repo = $this->createMock(MarketplaceConnectionRepository::class);
         $repo->method('findByMarketplace')->willReturn($this->connection());
 
-        return new WildberriesAdapter($http, $repo, new NullLogger(), new WbSalesReportRowNormalizer(), new WbFinanceSalesReportClient($http));
+        return new WildberriesAdapter($http, $repo, new NullLogger(), new WbSalesReportRowNormalizer(), new WbFinanceSalesReportClient($http, new MockClock()));
     }
 
     private function company(): Company { return $this->createMock(Company::class); }


### PR DESCRIPTION
### Motivation
- Adjust tests to match updated HTTP client behavior, header normalization, and finance API contract changes.
- Ensure marketplace processors and adapters use `rrd_id`-based external IDs and avoid mocking final classes.

### Description
- Relaxed MockHttpClient callback signatures to accept optional `options` and updated header assertions to read either raw or normalized headers and strip possible prefixes when extracting `Client-Id` and `Api-Key` values in `OzonInventoryClientTest`.
- Switched tests to expect `rrd_id`-based external IDs and updated helpers to provide default `rrd_id` values, plus replaced legacy `retail_price` usages with `retail_price_withdisc_rub` in `WbCostsRawProcessorTest` and related expectations for externalId formats (now `wb:{rrd_id}:...`).
- Replaced PHPUnit `createMock` usages for final classes by creating stubs with `ReflectionClass::newInstanceWithoutConstructor()` for `ProcessWbReturnsAction`, `ProcessWbSalesAction`, and `WbListingResolverService` in relevant tests to avoid mocking finals.
- Updated Wildberries finance client tests and adapter expectations to use a single-page finance endpoint behavior, use `MockClock` when constructing `WbFinanceSalesReportClient`, and adapt `authenticate` probe to expect a `{"Status":"OK"}` 200 response.

### Testing
- Ran unit tests touching `site/tests/Unit/Inventory/Infrastructure/Api/Ozon/OzonInventoryClientTest.php`, `site/tests/Unit/Marketplace/Application/Processor/WbCostsRawProcessorTest.php`, `site/tests/Unit/Marketplace/Application/Processor/WbReturnsRawProcessorRefundAmountTest.php`, `site/tests/Unit/Marketplace/Application/Processor/WbSalesRawProcessorRevenueTest.php`, `site/tests/Unit/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClientTest.php`, and `site/tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php` with PHPUnit; all modified tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0824b45e9083238638b9b36b558353)