### PR TITLE
Удалить вкладку «Юнит-экономика» из меню аналитики маркетплейсов

### DIFF
--- a/site/templates/marketplace_analytics/_tabs.html.twig
+++ b/site/templates/marketplace_analytics/_tabs.html.twig
@@ -14,19 +14,6 @@
             <div class="col">
                 <ul class="nav nav-tabs">
                     <li class="nav-item">
-                        <a href="{{ path('marketplace_analytics_unit_economics_index') }}"
-                           class="nav-link {{ activeTab == 'analytics' ? 'active' : '' }}">
-                            <svg xmlns="http://www.w3.org/2000/svg"
-                                 class="icon me-2" width="24" height="24"
-                                 viewBox="0 0 24 24" stroke-width="2"
-                                 stroke="currentColor" fill="none">
-                                <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-                                <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/>
-                            </svg>
-                            Юнит-экономика
-                        </a>
-                    </li>
-                    <li class="nav-item">
                         <a href="{{ path('marketplace_analytics_unit_extended_index') }}"
                            class="nav-link {{ activeTab == 'unit_extended' ? 'active' : '' }}">
                             <svg xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
### Motivation
- Убрать пункт навигации «Юнит-экономика» из вкладок раздела аналитики маркетплейсов, поскольку он больше не должен отображаться в меню.

### Description
- Удалён `<li>` элемент с ссылкой на `marketplace_analytics_unit_economics_index` из шаблона `site/templates/marketplace_analytics/_tabs.html.twig` (исключена разметка вкладки «Юнит-экономика»). 

### Testing
- Выполнены проверочные команды `git diff -- site/templates/marketplace_analytics/_tabs.html.twig` и `nl -ba site/templates/marketplace_analytics/_tabs.html.twig | sed -n '1,120p'`, которые подтвердили удаление и показали обновленный файл (успешно).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0aa85ac8e083238664749c95846d46)