### PR TITLE
Introduce `FINANCE_API_ENDPOINT` constant for Wildberries and use it in resolver and tests

### DIFF
--- a/site/src/Marketplace/Application/Service/WbInitialSyncStartDateResolver.php
+++ b/site/src/Marketplace/Application/Service/WbInitialSyncStartDateResolver.php
@@ -7,6 +7,7 @@ namespace App\Marketplace\Application\Service;
 use App\Company\Entity\Company;
 use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
+use App\Marketplace\Service\Integration\WildberriesAdapter;
 use Symfony\Component\Clock\ClockInterface;
 
 class WbInitialSyncStartDateResolver
@@ -35,7 +36,7 @@ class WbInitialSyncStartDateResolver
             company: $company,
             marketplace: $connection->getMarketplace(),
             documentType: self::DOCUMENT_TYPE,
-            apiEndpoint: 'wildberries::reportDetailByPeriod',
+            apiEndpoint: WildberriesAdapter::FINANCE_API_ENDPOINT,
             yearStart: $yearStart,
             yesterday: $yesterday,
         );

--- a/site/src/Marketplace/Service/Integration/WildberriesAdapter.php
+++ b/site/src/Marketplace/Service/Integration/WildberriesAdapter.php
@@ -19,6 +19,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class WildberriesAdapter implements MarketplaceAdapterInterface
 {
+    public const FINANCE_API_ENDPOINT = 'wildberries::finance-sales-reports-detailed';
+
     public function __construct(
         private readonly HttpClientInterface $httpClient,
         private readonly MarketplaceConnectionRepository $connectionRepository,
@@ -313,7 +315,7 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
 
     public function getApiEndpointName(): string
     {
-        return 'wildberries::finance-sales-reports-detailed';
+        return self::FINANCE_API_ENDPOINT;
     }
 
 

--- a/site/tests/Unit/Marketplace/Application/Service/WbInitialSyncStartDateResolverTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbInitialSyncStartDateResolverTest.php
@@ -8,6 +8,7 @@ use App\Marketplace\Application\Service\WbInitialSyncStartDateResolver;
 use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
+use App\Marketplace\Service\Integration\WildberriesAdapter;
 use App\Tests\Builders\Company\CompanyBuilder;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Clock\MockClock;
@@ -38,6 +39,18 @@ final class WbInitialSyncStartDateResolverTest extends TestCase
         $rawRepository = $this->createMock(MarketplaceRawDocumentRepository::class);
         $rawRepository->expects(self::once())
             ->method('findMinPeriodFromForSuccessfulDocuments')
+            ->with(
+                $company,
+                MarketplaceType::WILDBERRIES,
+                'sales_report',
+                WildberriesAdapter::FINANCE_API_ENDPOINT,
+                self::callback(static function (\DateTimeImmutable $date): bool {
+                    return '2026-01-01 00:00:00' === $date->format('Y-m-d H:i:s');
+                }),
+                self::callback(static function (\DateTimeImmutable $date): bool {
+                    return '2026-05-09 00:00:00' === $date->format('Y-m-d H:i:s');
+                }),
+            )
             ->willReturn(new \DateTimeImmutable('2026-04-20 17:10:00'));
 
         $resolver = new WbInitialSyncStartDateResolver($rawRepository, new MockClock('2026-05-10 00:00:00'));


### PR DESCRIPTION
### Motivation
- Replace a hardcoded Wildberries finance API endpoint string with a single source of truth to avoid duplication and typos.
- Ensure the initial-sync start date resolver and its tests use the canonical endpoint identifier.

### Description
- Add `FINANCE_API_ENDPOINT` constant to `WildberriesAdapter` and return it from `getApiEndpointName` via `self::FINANCE_API_ENDPOINT`.
- Update `WbInitialSyncStartDateResolver` to reference `WildberriesAdapter::FINANCE_API_ENDPOINT` when calling `findMinPeriodFromForSuccessfulDocuments`.
- Update `WbInitialSyncStartDateResolverTest` to import `WildberriesAdapter` and assert that `findMinPeriodFromForSuccessfulDocuments` is invoked with the new constant and correct date parameters.

### Testing
- Ran the unit tests for the resolver (updated `WbInitialSyncStartDateResolverTest`) with `phpunit` and the tests passed.
- Ran the project's unit test suite and no regressions were reported by the automated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d4ba0cd50832396fcc1356ea1e698)