### PR TITLE
Add Marketplace FinancialReportSyncStatus and FinancialReportSyncMode enums

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1265,6 +1265,36 @@ enum LocationType: string
 }
 ```
 
+
+### `src/Marketplace/Enum/FinancialReportSyncStatus.php`
+```php
+enum FinancialReportSyncStatus: string
+{
+    case QUEUED = 'queued';
+    case LOADING = 'loading';
+    case RAW_LOADED = 'raw_loaded';
+    case PROCESSING = 'processing';
+    case SUCCESS = 'success';
+    case EMPTY = 'empty';
+    case FAILED = 'failed';
+    case FAILED_FINAL = 'failed_final';
+    case AUTH_FAILED = 'auth_failed';
+    case CONFLICT = 'conflict';
+}
+```
+
+### `src/Marketplace/Enum/FinancialReportSyncMode.php`
+```php
+enum FinancialReportSyncMode: string
+{
+    case INITIAL = 'initial';
+    case DAILY = 'daily';
+    case REFRESH_14D = 'refresh_14d';
+    case MISSING = 'missing';
+    case MANUAL = 'manual';
+}
+```
+
 ### `src/Marketplace/Enum/OrderStatus.php`
 ```php
 enum OrderStatus: string

--- a/site/src/Marketplace/Enum/FinancialReportSyncMode.php
+++ b/site/src/Marketplace/Enum/FinancialReportSyncMode.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Enum;
+
+enum FinancialReportSyncMode: string
+{
+    case INITIAL = 'initial';
+    case DAILY = 'daily';
+    case REFRESH_14D = 'refresh_14d';
+    case MISSING = 'missing';
+    case MANUAL = 'manual';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::INITIAL => 'Первичная загрузка',
+            self::DAILY => 'Ежедневная загрузка',
+            self::REFRESH_14D => 'Обновление за 14 дней',
+            self::MISSING => 'Дозагрузка пропусков',
+            self::MANUAL => 'Ручной запуск',
+        };
+    }
+}

--- a/site/src/Marketplace/Enum/FinancialReportSyncStatus.php
+++ b/site/src/Marketplace/Enum/FinancialReportSyncStatus.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Enum;
+
+enum FinancialReportSyncStatus: string
+{
+    case QUEUED = 'queued';
+    case LOADING = 'loading';
+    case RAW_LOADED = 'raw_loaded';
+    case PROCESSING = 'processing';
+    case SUCCESS = 'success';
+    case EMPTY = 'empty';
+    case FAILED = 'failed';
+    case FAILED_FINAL = 'failed_final';
+    case AUTH_FAILED = 'auth_failed';
+    case CONFLICT = 'conflict';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::QUEUED => 'В очереди',
+            self::LOADING => 'Загрузка',
+            self::RAW_LOADED => 'Raw загружен',
+            self::PROCESSING => 'Обработка',
+            self::SUCCESS => 'Успешно',
+            self::EMPTY => 'Нет данных',
+            self::FAILED => 'Ошибка',
+            self::FAILED_FINAL => 'Финальная ошибка',
+            self::AUTH_FAILED => 'Ошибка авторизации',
+            self::CONFLICT => 'Конфликт',
+        };
+    }
+}


### PR DESCRIPTION
### Motivation
- Replace ad-hoc magic strings for WB financial sync with typed enums to make statuses and modes explicit and discoverable.
- Keep enum style consistent with existing `Marketplace` enums and ensure architecture doc is authoritative about allowed values.

### Description
- Added `App\Marketplace\Enum\FinancialReportSyncStatus` in `site/src/Marketplace/Enum/FinancialReportSyncStatus.php` with cases: `queued`, `loading`, `raw_loaded`, `processing`, `success`, `empty`, `failed`, `failed_final`, `auth_failed`, `conflict` and a `getLabel()` helper following module style.
- Added `App\Marketplace\Enum\FinancialReportSyncMode` in `site/src/Marketplace/Enum/FinancialReportSyncMode.php` with cases: `initial`, `daily`, `refresh_14d`, `missing`, `manual` and a `getLabel()` helper following module style.
- Updated `ARCHITECTURE.md` (Enum — актуальные значения) to include both new enums and their exact values so the contract is recorded.
- Did not add business logic beyond simple label helpers and kept enums non-final per project rules.

### Testing
- Ran `cd site && php bin/console lint:container` which failed due to missing Composer dependencies (`Dependencies are missing. Try running "composer install"`).
- Ran `cd site && php bin/phpunit tests/Unit/Marketplace/Enum` which failed due to missing PHPUnit bridge binaries (`Unable to find the simple-phpunit.php script in vendor/symfony/phpunit-bridge/bin/`).
- No unit tests could be executed in this environment due to missing vendor binaries, but enums are declared in PSR-4 autoloadable paths expected by the project layout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d565975c08323aeb9be82417bc538)