### PR TITLE
Add MarketplaceFinancialReportSyncError entity and repository and document append-only error history

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -52,6 +52,7 @@
 | `ReconciliationSession` | Marketplace | `string $companyId` ✅ |
 | `OzonTransactionTotalsCheck` | Marketplace | `string $companyId` ✅ |
 | `MarketplaceFinancialReportSyncStatus` | Marketplace | `string $companyId` ✅ |
+| `MarketplaceFinancialReportSyncError` | Marketplace | `string $companyId` ✅ |
 | `UnitEconomyCostMapping` | MarketplaceAnalytics | `string $companyId` ✅ |
 | `ListingDailySnapshot` | MarketplaceAnalytics | `string $companyId` ✅ |
 | `AdRawDocument` | MarketplaceAds | `string $companyId` ✅ |
@@ -82,6 +83,13 @@
 - Бизнес-ключ (idempotency / unique key): `connection_id + report_type + business_date`.
 - `empty day` (статус `EMPTY`) **не равен** `missing day`: пустой день считается обработанным, а не пропущенным.
 - `apiEndpoint` — техническое мета-поле источника/маршрута API, **не часть бизнес-ключа** статуса.
+
+### Marketplace: append-only история ошибок WB financial sync
+
+- Entity: `MarketplaceFinancialReportSyncError`.
+- Назначение: хранит отдельные записи ошибок синхронизации как append-only историю; retry не перезаписывает предыдущую диагностику.
+- Поля: `syncStatusId`, `companyId`, `connectionId`, `businessDate`, `errorClass`, `errorMessage`, `statusCode`, `responseExcerpt`, `requestPayload`, `createdAt`.
+- `requestPayload` хранится в JSON-формате и **не должен** содержать API token, plaintext secret или полный raw response body.
 
 ### `UnitEconomyCostMapping` — поля
 

--- a/site/src/Marketplace/Entity/MarketplaceFinancialReportSyncError.php
+++ b/site/src/Marketplace/Entity/MarketplaceFinancialReportSyncError.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Entity;
+
+use App\Marketplace\Repository\MarketplaceFinancialReportSyncErrorRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity(repositoryClass: MarketplaceFinancialReportSyncErrorRepository::class)]
+#[ORM\Table(name: 'marketplace_financial_report_sync_errors')]
+#[ORM\Index(name: 'idx_mfrse_status_created', columns: ['sync_status_id', 'created_at'])]
+#[ORM\Index(name: 'idx_mfrse_company_date', columns: ['company_id', 'business_date'])]
+#[ORM\Index(name: 'idx_mfrse_connection_date', columns: ['connection_id', 'business_date'])]
+class MarketplaceFinancialReportSyncError
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid')]
+    private string $id;
+
+    #[ORM\Column(type: 'guid')]
+    private string $syncStatusId;
+
+    #[ORM\Column(type: 'guid')]
+    private string $companyId;
+
+    #[ORM\Column(type: 'guid')]
+    private string $connectionId;
+
+    #[ORM\Column(type: 'date_immutable')]
+    private \DateTimeImmutable $businessDate;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private string $errorClass;
+
+    #[ORM\Column(type: 'text')]
+    private string $errorMessage;
+
+    #[ORM\Column(type: 'integer', nullable: true)]
+    private ?int $statusCode;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $responseExcerpt;
+
+    /** @var array<string, mixed>|null */
+    #[ORM\Column(type: 'json', nullable: true)]
+    private ?array $requestPayload;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $createdAt;
+
+    /**
+     * @param array<string, mixed>|null $requestPayload
+     */
+    public function __construct(
+        string $id,
+        string $syncStatusId,
+        string $companyId,
+        string $connectionId,
+        \DateTimeImmutable $businessDate,
+        string $errorClass,
+        string $errorMessage,
+        ?int $statusCode = null,
+        ?string $responseExcerpt = null,
+        ?array $requestPayload = null,
+    ) {
+        Assert::uuid($id);
+        Assert::uuid($syncStatusId);
+        Assert::uuid($companyId);
+        Assert::uuid($connectionId);
+
+        $this->id = $id;
+        $this->syncStatusId = $syncStatusId;
+        $this->companyId = $companyId;
+        $this->connectionId = $connectionId;
+        $this->businessDate = $businessDate;
+        $this->errorClass = $errorClass;
+        $this->errorMessage = $errorMessage;
+        $this->statusCode = $statusCode;
+        $this->responseExcerpt = $responseExcerpt;
+        $this->requestPayload = $requestPayload;
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): string { return $this->id; }
+
+    public function getSyncStatusId(): string { return $this->syncStatusId; }
+
+    public function getCompanyId(): string { return $this->companyId; }
+
+    public function getConnectionId(): string { return $this->connectionId; }
+
+    public function getBusinessDate(): \DateTimeImmutable { return $this->businessDate; }
+
+    public function getErrorClass(): string { return $this->errorClass; }
+
+    public function getErrorMessage(): string { return $this->errorMessage; }
+
+    public function getStatusCode(): ?int { return $this->statusCode; }
+
+    public function getResponseExcerpt(): ?string { return $this->responseExcerpt; }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getRequestPayload(): ?array { return $this->requestPayload; }
+
+    public function getCreatedAt(): \DateTimeImmutable { return $this->createdAt; }
+}

--- a/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncErrorRepository.php
+++ b/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncErrorRepository.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Repository;
+
+use App\Marketplace\Entity\MarketplaceFinancialReportSyncError;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+final class MarketplaceFinancialReportSyncErrorRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, MarketplaceFinancialReportSyncError::class);
+    }
+
+    public function save(MarketplaceFinancialReportSyncError $syncError): void
+    {
+        $this->getEntityManager()->persist($syncError);
+    }
+}


### PR DESCRIPTION
### Motivation

- Introduce an append-only history for WB marketplace financial report sync errors to preserve diagnostics per retry without overwriting previous records. 
- Persist richer error context (HTTP status, excerpts, request payload) alongside links to the related sync status for troubleshooting and auditing. 

### Description

- Added `MarketplaceFinancialReportSyncError` entity (`site/src/Marketplace/Entity/MarketplaceFinancialReportSyncError.php`) with fields `syncStatusId`, `companyId`, `connectionId`, `businessDate`, `errorClass`, `errorMessage`, `statusCode`, `responseExcerpt`, `requestPayload`, and `createdAt`, plus UUID assertions and getter methods. 
- Added Doctrine indexes on `sync_status_id + created_at`, `company_id + business_date`, and `connection_id + business_date`, and the entity is persisted in table `marketplace_financial_report_sync_errors`. 
- Added repository `MarketplaceFinancialReportSyncErrorRepository` (`site/src/Marketplace/Repository/MarketplaceFinancialReportSyncErrorRepository.php`) with a `save()` helper to persist new error records. 
- Updated `ARCHITECTURE.md` to include the new entity in the migration status table and to document the append-only semantics and allowed `requestPayload` content. 

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d5d79c8888323994c9ba7687e0f31)