### PR TITLE
Add read-only audit command and query to find duplicate marketplace_raw_documents

### DIFF
--- a/site/src/Marketplace/Command/RawDocumentsDuplicatesAuditCommand.php
+++ b/site/src/Marketplace/Command/RawDocumentsDuplicatesAuditCommand.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Command;
+
+use App\Marketplace\Infrastructure\Query\MarketplaceRawDocumentDuplicateAuditQuery;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:marketplace:raw-documents:duplicates-audit',
+    description: 'Read-only аудит дублей marketplace_raw_documents перед добавлением unique key',
+)]
+final class RawDocumentsDuplicatesAuditCommand extends Command
+{
+    public function __construct(
+        private readonly MarketplaceRawDocumentDuplicateAuditQuery $duplicateAuditQuery,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $rows = $this->duplicateAuditQuery->findDuplicateGroups();
+
+        $io->title('Marketplace raw documents duplicates audit (read-only)');
+
+        if ($rows === []) {
+            $io->success('Конфликтов не найдено: дублей по будущему unique key нет среди активных raw documents.');
+
+            return Command::SUCCESS;
+        }
+
+        $tableRows = array_map(
+            static function (array $row): array {
+                return [
+                    (string) $row['company_id'],
+                    (string) $row['marketplace'],
+                    (string) $row['document_type'],
+                    (string) $row['api_endpoint'],
+                    (string) $row['period_from'],
+                    (string) $row['period_to'],
+                    (string) $row['duplicate_count'],
+                    is_array($row['raw_document_ids']) ? json_encode($row['raw_document_ids'], JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR) : (string) $row['raw_document_ids'],
+                ];
+            },
+            $rows,
+        );
+
+        $io->table(
+            ['company_id', 'marketplace', 'document_type', 'api_endpoint', 'period_from', 'period_to', 'duplicate_count', 'raw_document_ids'],
+            $tableRows,
+        );
+
+        $io->warning(sprintf('Найдено %d конфликтующих групп(ы). Команда не изменяет данные в БД.', count($rows)));
+
+        return Command::SUCCESS;
+    }
+}

--- a/site/src/Marketplace/Infrastructure/Query/MarketplaceRawDocumentDuplicateAuditQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/MarketplaceRawDocumentDuplicateAuditQuery.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Query;
+
+use App\Marketplace\Enum\PipelineStatus;
+use Doctrine\DBAL\Connection;
+
+final class MarketplaceRawDocumentDuplicateAuditQuery
+{
+    public function __construct(
+        private readonly Connection $connection,
+    ) {
+    }
+
+    public function findDuplicateGroups(): array
+    {
+        return $this->connection->fetchAllAssociative(
+            <<<'SQL'
+            SELECT
+                rd.company_id,
+                rd.marketplace,
+                rd.document_type,
+                rd.api_endpoint,
+                rd.period_from,
+                rd.period_to,
+                COUNT(*) AS duplicate_count,
+                ARRAY_AGG(rd.id ORDER BY rd.id) AS raw_document_ids
+            FROM marketplace_raw_documents rd
+            WHERE rd.processing_status IS NULL
+               OR rd.processing_status <> :failedStatus
+            GROUP BY
+                rd.company_id,
+                rd.marketplace,
+                rd.document_type,
+                rd.api_endpoint,
+                rd.period_from,
+                rd.period_to
+            HAVING COUNT(*) > 1
+            ORDER BY duplicate_count DESC, rd.company_id, rd.marketplace, rd.document_type, rd.api_endpoint, rd.period_from, rd.period_to
+            SQL,
+            ['failedStatus' => PipelineStatus::FAILED->value],
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a read-only audit to detect duplicate rows in `marketplace_raw_documents` that would conflict with a planned unique key.
- Avoid modifying database state while surfacing groups of active raw documents that share the same uniqueness dimensions.

### Description
- Add `MarketplaceRawDocumentDuplicateAuditQuery` which executes a SQL query grouping by `company_id, marketplace, document_type, api_endpoint, period_from, period_to` and returns groups with `COUNT(*) > 1`, excluding rows with `processing_status = PipelineStatus::FAILED`.
- Add Symfony console command `app:marketplace:raw-documents:duplicates-audit` (`RawDocumentsDuplicatesAuditCommand`) that calls the query, formats the results into a table, JSON-encodes the `raw_document_ids` column, and prints a warning that the command is read-only.
- Use `ARRAY_AGG` to collect raw document ids and order results by duplicate count and identifying columns.

### Testing
- No automated tests were added for this change.
- Executed the project's existing automated test suite and observed that tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d709e7c3c8323b117ae85614aea99)