### PR TITLE
Add exact-period idempotency lookup (apiEndpoint-aware) to MarketplaceRawDocumentRepository

### DIFF
--- a/site/src/Marketplace/Repository/MarketplaceRawDocumentRepository.php
+++ b/site/src/Marketplace/Repository/MarketplaceRawDocumentRepository.php
@@ -72,6 +72,63 @@ class MarketplaceRawDocumentRepository extends ServiceEntityRepository
         )[0] ?? null;
     }
 
+
+    /**
+     * Deterministic lookup for refresh/idempotency by exact period + api endpoint.
+     * Excludes FAILED documents and returns newest first.
+     *
+     * @return list<MarketplaceRawDocument>
+     */
+    public function findActiveExactPeriodDocuments(
+        Company $company,
+        MarketplaceType $marketplace,
+        string $documentType,
+        string $apiEndpoint,
+        \DateTimeImmutable $periodFrom,
+        \DateTimeImmutable $periodTo,
+    ): array {
+        return $this->createQueryBuilder('d')
+            ->where('d.company = :company')
+            ->andWhere('d.marketplace = :marketplace')
+            ->andWhere('d.documentType = :documentType')
+            ->andWhere('d.apiEndpoint = :apiEndpoint')
+            ->andWhere('d.periodFrom = :periodFrom')
+            ->andWhere('d.periodTo = :periodTo')
+            ->andWhere('(d.processingStatus IS NULL OR d.processingStatus != :failed)')
+            ->setParameter('company', $company)
+            ->setParameter('marketplace', $marketplace)
+            ->setParameter('documentType', $documentType)
+            ->setParameter('apiEndpoint', $apiEndpoint)
+            ->setParameter('periodFrom', $periodFrom)
+            ->setParameter('periodTo', $periodTo)
+            ->setParameter('failed', PipelineStatus::FAILED)
+            ->orderBy('d.syncedAt', 'DESC')
+            ->addOrderBy('d.id', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * Idempotency lookup for refresh/idempotency by exact period + api endpoint.
+     */
+    public function findActiveExactPeriodDocument(
+        Company $company,
+        MarketplaceType $marketplace,
+        string $documentType,
+        string $apiEndpoint,
+        \DateTimeImmutable $periodFrom,
+        \DateTimeImmutable $periodTo,
+    ): ?MarketplaceRawDocument {
+        return $this->findActiveExactPeriodDocuments(
+            $company,
+            $marketplace,
+            $documentType,
+            $apiEndpoint,
+            $periodFrom,
+            $periodTo,
+        )[0] ?? null;
+    }
+
     /**
      * Idempotency lookup for initial sync weekly/month-split batches.
      */

--- a/site/tests/Integration/Marketplace/MarketplaceRawDocumentRepositoryTest.php
+++ b/site/tests/Integration/Marketplace/MarketplaceRawDocumentRepositoryTest.php
@@ -68,5 +68,80 @@ final class MarketplaceRawDocumentRepositoryTest extends IntegrationTestCase
         self::assertNotNull($result);
         self::assertSame('2026-03-01', $result->format('Y-m-d'));
     }
+
+    public function testFindActiveExactPeriodMethodsFilterByEndpointAndExcludeFailed(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+        $this->em->persist($company);
+
+        $activeOlder = MarketplaceRawDocumentBuilder::aDocument()
+            ->forCompany($company)
+            ->withMarketplace(MarketplaceType::WILDBERRIES)
+            ->withPeriod(new \DateTimeImmutable('2026-04-01'), new \DateTimeImmutable('2026-04-01'))
+            ->withIndex(1)
+            ->build();
+        $activeOlder->setApiEndpoint('wildberries::reportDetailByPeriod');
+        $this->em->persist($activeOlder);
+
+        $activeNewest = MarketplaceRawDocumentBuilder::aDocument()
+            ->forCompany($company)
+            ->withMarketplace(MarketplaceType::WILDBERRIES)
+            ->withPeriod(new \DateTimeImmutable('2026-04-01'), new \DateTimeImmutable('2026-04-01'))
+            ->withIndex(2)
+            ->build();
+        $activeNewest->setApiEndpoint('wildberries::reportDetailByPeriod');
+        $activeNewest->markCompleted();
+        $this->em->persist($activeNewest);
+
+        $failed = MarketplaceRawDocumentBuilder::aDocument()
+            ->forCompany($company)
+            ->withMarketplace(MarketplaceType::WILDBERRIES)
+            ->withPeriod(new \DateTimeImmutable('2026-04-01'), new \DateTimeImmutable('2026-04-01'))
+            ->withIndex(3)
+            ->build();
+        $failed->setApiEndpoint('wildberries::reportDetailByPeriod');
+        $failed->markStepFailed(\App\Marketplace\Enum\PipelineStep::SALES);
+        $this->em->persist($failed);
+
+        $otherEndpoint = MarketplaceRawDocumentBuilder::aDocument()
+            ->forCompany($company)
+            ->withMarketplace(MarketplaceType::WILDBERRIES)
+            ->withPeriod(new \DateTimeImmutable('2026-04-01'), new \DateTimeImmutable('2026-04-01'))
+            ->withIndex(4)
+            ->build();
+        $otherEndpoint->setApiEndpoint('wildberries::supplierSales');
+        $this->em->persist($otherEndpoint);
+
+        $this->em->flush();
+
+        /** @var MarketplaceRawDocumentRepository $repository */
+        $repository = self::getContainer()->get(MarketplaceRawDocumentRepository::class);
+
+        $documents = $repository->findActiveExactPeriodDocuments(
+            company: $company,
+            marketplace: MarketplaceType::WILDBERRIES,
+            documentType: 'sales_report',
+            apiEndpoint: 'wildberries::reportDetailByPeriod',
+            periodFrom: new \DateTimeImmutable('2026-04-01'),
+            periodTo: new \DateTimeImmutable('2026-04-01'),
+        );
+
+        self::assertCount(2, $documents);
+        self::assertSame('22222222-2222-2222-2222-000000000002', $documents[0]->getId());
+        self::assertSame('22222222-2222-2222-2222-000000000001', $documents[1]->getId());
+
+        $single = $repository->findActiveExactPeriodDocument(
+            company: $company,
+            marketplace: MarketplaceType::WILDBERRIES,
+            documentType: 'sales_report',
+            apiEndpoint: 'wildberries::reportDetailByPeriod',
+            periodFrom: new \DateTimeImmutable('2026-04-01'),
+            periodTo: new \DateTimeImmutable('2026-04-01'),
+        );
+
+        self::assertNotNull($single);
+        self::assertSame('22222222-2222-2222-2222-000000000002', $single->getId());
+    }
+
 }
 


### PR DESCRIPTION
### Motivation
- Provide idempotent lookup for Marketplace raw documents so daily/refresh handlers can find and update an existing raw document for an exact period and endpoint instead of creating duplicates. 
- The lookup must exclude FAILED processingStatus and respect the `apiEndpoint` to distinguish WB flows from other pipelines. 

### Description
- Added `findActiveExactPeriodDocuments(Company $company, MarketplaceType $marketplace, string $documentType, string $apiEndpoint, DateTimeImmutable $periodFrom, DateTimeImmutable $periodTo): array` to `MarketplaceRawDocumentRepository`, filtering by company, marketplace, documentType, apiEndpoint, periodFrom and periodTo, excluding `PipelineStatus::FAILED` and ordering newest-first (`syncedAt DESC, id DESC`).
- Added `findActiveExactPeriodDocument(...)` helper that returns the first (newest) active exact-period match or `null`.
- Kept existing Ozon/initial-sync repository methods unchanged and did not introduce `flush()` calls or DB index changes. 
- Added an integration test `testFindActiveExactPeriodMethodsFilterByEndpointAndExcludeFailed` verifying endpoint filtering, exclusion of FAILED docs, newest-first ordering, and the single-item helper behavior.

### Testing
- Added an integration test in `tests/Integration/Marketplace/MarketplaceRawDocumentRepositoryTest.php` that asserts the new methods' behavior (test file included in the PR). 
- Attempted to run the repository integration test with `php bin/phpunit tests/Integration/Marketplace/MarketplaceRawDocumentRepositoryTest.php` but it could not run in this environment due to missing `simple-phpunit.php` (project dependencies require `composer install`).
- Attempted `php bin/console lint:container` but it failed in this environment because project PHP dependencies are not installed (`Dependencies are missing. Try running "composer install"`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d75c2c4c8832380aa8780b0b24872)