### PR TITLE
Add migration to enforce unique active marketplace_raw_documents by company/marketplace/type/endpoint/period

### DIFF
--- a/site/migrations/Version20260520133000.php
+++ b/site/migrations/Version20260520133000.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260520133000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Enforce active raw document idempotency by company/marketplace/type/endpoint/period with duplicate pre-check';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $platform = $this->connection->getDatabasePlatform()->getName();
+        $this->abortIf(
+            $platform !== 'postgresql',
+            sprintf(
+                'Migration %s supports only PostgreSQL; got platform "%s".',
+                self::class,
+                $platform,
+            ),
+        );
+
+        $duplicatesCount = (int) $this->connection->fetchOne(<<<'SQL'
+            SELECT COUNT(*)
+            FROM (
+                SELECT 1
+                FROM marketplace_raw_documents
+                WHERE processing_status IS NULL OR processing_status <> 'failed'
+                GROUP BY company_id, marketplace, document_type, api_endpoint, period_from, period_to
+                HAVING COUNT(*) > 1
+            ) duplicate_groups
+        SQL);
+
+        $this->abortIf(
+            $duplicatesCount > 0,
+            'Cannot create uniq_mrd_active_company_marketplace_type_endpoint_period: active duplicates exist in marketplace_raw_documents. Run TASK-006 audit/cleanup first.'
+        );
+
+        $this->addSql(<<<'SQL'
+            CREATE UNIQUE INDEX uniq_mrd_active_company_marketplace_type_endpoint_period
+            ON marketplace_raw_documents (company_id, marketplace, document_type, api_endpoint, period_from, period_to)
+            WHERE processing_status IS NULL OR processing_status <> 'failed'
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $platform = $this->connection->getDatabasePlatform()->getName();
+        $this->abortIf(
+            $platform !== 'postgresql',
+            sprintf(
+                'Migration %s supports only PostgreSQL; got platform "%s".',
+                self::class,
+                $platform,
+            ),
+        );
+
+        $this->addSql('DROP INDEX IF EXISTS uniq_mrd_active_company_marketplace_type_endpoint_period');
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure idempotency for active raw documents by preventing more than one active `marketplace_raw_documents` row per `company_id, marketplace, document_type, api_endpoint, period_from, period_to` combination.

### Description
- Add new Doctrine migration `Version20260520133000` which only runs on PostgreSQL and performs a duplicate pre-check for active rows (`processing_status IS NULL OR processing_status <> 'failed'`).
- Abort the migration with a clear message if any active duplicates are found, suggesting to run cleanup (`TASK-006`) first.
- Create a partial unique index named `uniq_mrd_active_company_marketplace_type_endpoint_period` on `(company_id, marketplace, document_type, api_endpoint, period_from, period_to)` conditioned on the same active-row predicate, and provide a `down` path that drops the index with `DROP INDEX IF EXISTS`.

### Testing
- No automated tests were run for this migration as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d784dfb048323bd862aa6cfdc8d49)