### PR TITLE
Add CLI audit command and query to report duplicate generated marketplace rows

### DIFF
--- a/site/src/Marketplace/Command/GeneratedRowsDuplicatesAuditCommand.php
+++ b/site/src/Marketplace/Command/GeneratedRowsDuplicatesAuditCommand.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Command;
+
+use App\Marketplace\Infrastructure\Query\MarketplaceGeneratedRowsDuplicateAuditQuery;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:marketplace:generated-rows:duplicates-audit',
+    description: 'Read-only аудит дублей generated rows перед добавлением unique keys',
+)]
+final class GeneratedRowsDuplicatesAuditCommand extends Command
+{
+    public function __construct(
+        private readonly MarketplaceGeneratedRowsDuplicateAuditQuery $auditQuery,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Количество групп в деталях по каждой таблице', '20');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $limit = (int) $input->getOption('limit');
+        if ($limit <= 0) {
+            $io->error('Опция --limit должна быть положительным целым числом.');
+
+            return Command::FAILURE;
+        }
+
+        $salesCount = $this->auditQuery->countSalesDuplicateGroups();
+        $returnsCount = $this->auditQuery->countReturnsDuplicateGroups();
+        $costsCount = $this->auditQuery->countCostsDuplicateGroups();
+
+        $salesRows = $this->auditQuery->findSalesDuplicateGroups($limit);
+        $returnsRows = $this->auditQuery->findReturnsDuplicateGroups($limit);
+        $costsRows = $this->auditQuery->findCostsDuplicateGroups($limit);
+
+        $io->title('Marketplace generated rows duplicates audit (read-only)');
+        $io->definitionList(
+            ['Detail limit per table' => (string) $limit],
+            ['Sales duplicate groups' => (string) $salesCount],
+            ['Returns duplicate groups' => (string) $returnsCount],
+            ['Costs duplicate groups' => (string) $costsCount],
+        );
+
+        if (($salesCount + $returnsCount + $costsCount) > 0) {
+            $io->warning('Найдены дубли. Перед TASK-010 нужно выполнить отдельный cleanup, иначе unique migration упадёт.');
+        }
+
+        $this->renderSection($io, 'marketplace_sales', $salesRows);
+        $this->renderSection($io, 'marketplace_returns', $returnsRows);
+        $this->renderSection($io, 'marketplace_costs', $costsRows);
+
+        $io->success('Аудит завершён. Команда выполняет только SELECT-запросы и не изменяет данные в БД.');
+
+        return Command::SUCCESS;
+    }
+
+    private function renderSection(SymfonyStyle $io, string $tableName, array $rows): void
+    {
+        $io->section(sprintf('Details: %s', $tableName));
+
+        if ($rows === []) {
+            $io->text('No duplicate groups found.');
+
+            return;
+        }
+
+        $tableRows = array_map(
+            static function (array $row): array {
+                return [
+                    (string) $row['company_id'],
+                    (string) $row['marketplace'],
+                    (string) $row['external_id'],
+                    (string) $row['duplicate_count'],
+                    is_array($row['row_ids']) ? json_encode($row['row_ids'], JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR) : (string) $row['row_ids'],
+                ];
+            },
+            $rows,
+        );
+
+        $io->table(
+            ['company_id', 'marketplace', 'external_id', 'duplicate_count', 'row_ids'],
+            $tableRows,
+        );
+    }
+}

--- a/site/src/Marketplace/Infrastructure/Query/MarketplaceGeneratedRowsDuplicateAuditQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/MarketplaceGeneratedRowsDuplicateAuditQuery.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Query;
+
+use Doctrine\DBAL\Connection;
+
+final class MarketplaceGeneratedRowsDuplicateAuditQuery
+{
+    private const DUPLICATE_TARGETS = [
+        'sales' => [
+            'table' => 'marketplace_sales',
+            'external_id_column' => 'external_order_id',
+        ],
+        'returns' => [
+            'table' => 'marketplace_returns',
+            'external_id_column' => 'external_return_id',
+        ],
+        'costs' => [
+            'table' => 'marketplace_costs',
+            'external_id_column' => 'external_id',
+        ],
+    ];
+
+    public function __construct(
+        private readonly Connection $connection,
+    ) {
+    }
+
+    public function countSalesDuplicateGroups(): int
+    {
+        return $this->countDuplicateGroups('sales');
+    }
+
+    public function countReturnsDuplicateGroups(): int
+    {
+        return $this->countDuplicateGroups('returns');
+    }
+
+    public function countCostsDuplicateGroups(): int
+    {
+        return $this->countDuplicateGroups('costs');
+    }
+
+    public function findSalesDuplicateGroups(int $limit): array
+    {
+        return $this->findDuplicateGroups('sales', $limit);
+    }
+
+    public function findReturnsDuplicateGroups(int $limit): array
+    {
+        return $this->findDuplicateGroups('returns', $limit);
+    }
+
+    public function findCostsDuplicateGroups(int $limit): array
+    {
+        return $this->findDuplicateGroups('costs', $limit);
+    }
+
+    private function countDuplicateGroups(string $kind): int
+    {
+        ['table' => $tableName, 'external_id_column' => $externalIdColumn] = $this->resolveKindConfig($kind);
+
+        $sql = sprintf(
+            <<<'SQL'
+            SELECT COUNT(*)
+            FROM (
+                SELECT 1
+                FROM %s t
+                WHERE t.%s IS NOT NULL
+                  AND TRIM(t.%s) <> ''
+                GROUP BY t.company_id, t.marketplace, t.%s
+                HAVING COUNT(*) > 1
+            ) duplicated_groups
+            SQL,
+            $tableName,
+            $externalIdColumn,
+            $externalIdColumn,
+            $externalIdColumn,
+        );
+
+        return (int) $this->connection->fetchOne($sql);
+    }
+
+    private function findDuplicateGroups(string $kind, int $limit): array
+    {
+        ['table' => $tableName, 'external_id_column' => $externalIdColumn] = $this->resolveKindConfig($kind);
+
+        $sql = sprintf(
+            <<<'SQL'
+            SELECT
+                t.company_id,
+                t.marketplace,
+                t.%s AS external_id,
+                COUNT(*) AS duplicate_count,
+                ARRAY_AGG(t.id ORDER BY t.created_at ASC, t.id ASC) AS row_ids
+            FROM %s t
+            WHERE t.%s IS NOT NULL
+              AND TRIM(t.%s) <> ''
+            GROUP BY t.company_id, t.marketplace, t.%s
+            HAVING COUNT(*) > 1
+            ORDER BY duplicate_count DESC, t.company_id ASC, t.marketplace ASC, external_id ASC
+            LIMIT :limit
+            SQL,
+            $externalIdColumn,
+            $tableName,
+            $externalIdColumn,
+            $externalIdColumn,
+            $externalIdColumn,
+        );
+
+        // ARRAY_AGG использован осознанно: запрос рассчитан на PostgreSQL, как и миграция unique index для raw documents.
+        return $this->connection->fetchAllAssociative($sql, ['limit' => $limit], ['limit' => \PDO::PARAM_INT]);
+    }
+
+    private function resolveKindConfig(string $kind): array
+    {
+        $config = self::DUPLICATE_TARGETS[$kind] ?? null;
+        if ($config === null) {
+            throw new \InvalidArgumentException(sprintf('Unknown duplicate audit kind: %s', $kind));
+        }
+
+        return $config;
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a read-only CLI tool to detect duplicate generated rows in marketplace tables before adding unique keys to avoid migration failures.
- Centralize duplicate-detection logic for `sales`, `returns`, and `costs` tables with reusable query code.

### Description

- Add `GeneratedRowsDuplicatesAuditCommand` (`app:marketplace:generated-rows:duplicates-audit`) which validates `--limit`, queries duplicate counts and details, and renders results in tables with user-facing messages (Russian texts and a safety warning).
- Add `MarketplaceGeneratedRowsDuplicateAuditQuery` which implements duplicate counting and lookup for three targets via `count*` and `find*` methods and a `DUPLICATE_TARGETS` mapping for table/column config.
- Queries use PostgreSQL-specific `ARRAY_AGG` for `row_ids` and perform filtering on non-null/non-empty external id columns; `find*` uses a `:limit` parameter passed to DBAL's `fetchAllAssociative`.
- Command output is read-only and explicitly states it only runs `SELECT` queries; duplicate rows are rendered with `row_ids` JSON-encoded when needed.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d8b1716008323b7f36cf8127957e9)