### PR TITLE
Add PostgreSQL partial unique indexes for marketplace business keys with duplicate guards

### DIFF
--- a/site/migrations/Version20260520143000.php
+++ b/site/migrations/Version20260520143000.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260520143000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Marketplace: add PostgreSQL-only company-aware partial unique business keys for sales/returns/costs with duplicate audit guards';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $platform = $this->connection->getDatabasePlatform()->getName();
+        $this->abortIf($platform !== 'postgresql', 'Migration can only be executed safely on postgresql.');
+
+        $salesDuplicates = (int) $this->connection->fetchOne(<<<'SQL'
+            SELECT COUNT(*)
+            FROM (
+                SELECT s.company_id, s.marketplace, s.external_order_id
+                FROM marketplace_sales s
+                WHERE s.external_order_id IS NOT NULL
+                  AND TRIM(s.external_order_id) <> ''
+                GROUP BY s.company_id, s.marketplace, s.external_order_id
+                HAVING COUNT(*) > 1
+            ) dup
+        SQL);
+
+        $returnsDuplicates = (int) $this->connection->fetchOne(<<<'SQL'
+            SELECT COUNT(*)
+            FROM (
+                SELECT r.company_id, r.marketplace, r.external_return_id
+                FROM marketplace_returns r
+                WHERE r.external_return_id IS NOT NULL
+                  AND TRIM(r.external_return_id) <> ''
+                GROUP BY r.company_id, r.marketplace, r.external_return_id
+                HAVING COUNT(*) > 1
+            ) dup
+        SQL);
+
+        $costsDuplicates = (int) $this->connection->fetchOne(<<<'SQL'
+            SELECT COUNT(*)
+            FROM (
+                SELECT c.company_id, c.marketplace, c.external_id
+                FROM marketplace_costs c
+                WHERE c.external_id IS NOT NULL
+                  AND TRIM(c.external_id) <> ''
+                GROUP BY c.company_id, c.marketplace, c.external_id
+                HAVING COUNT(*) > 1
+            ) dup
+        SQL);
+
+        $this->abortIf(
+            $salesDuplicates > 0,
+            sprintf('Migration aborted: found %d duplicate business keys in marketplace_sales (company_id, marketplace, external_order_id where non-empty). Resolve duplicates and rerun migration.', $salesDuplicates),
+        );
+
+        $this->abortIf(
+            $returnsDuplicates > 0,
+            sprintf('Migration aborted: found %d duplicate business keys in marketplace_returns (company_id, marketplace, external_return_id where non-empty). Resolve duplicates and rerun migration.', $returnsDuplicates),
+        );
+
+        $this->abortIf(
+            $costsDuplicates > 0,
+            sprintf('Migration aborted: found %d duplicate business keys in marketplace_costs (company_id, marketplace, external_id where non-empty). Resolve duplicates and rerun migration.', $costsDuplicates),
+        );
+
+        $this->addSql(<<<'SQL'
+            CREATE UNIQUE INDEX IF NOT EXISTS uniq_marketplace_sales_company_marketplace_external_order
+            ON marketplace_sales (company_id, marketplace, external_order_id)
+            WHERE external_order_id IS NOT NULL AND TRIM(external_order_id) <> ''
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            CREATE UNIQUE INDEX IF NOT EXISTS uniq_marketplace_returns_company_marketplace_external_return
+            ON marketplace_returns (company_id, marketplace, external_return_id)
+            WHERE external_return_id IS NOT NULL AND TRIM(external_return_id) <> ''
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            CREATE UNIQUE INDEX IF NOT EXISTS uniq_marketplace_costs_company_marketplace_external
+            ON marketplace_costs (company_id, marketplace, external_id)
+            WHERE external_id IS NOT NULL AND TRIM(external_id) <> ''
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $platform = $this->connection->getDatabasePlatform()->getName();
+        $this->abortIf($platform !== 'postgresql', 'Migration can only be executed safely on postgresql.');
+
+        $this->addSql('DROP INDEX IF EXISTS uniq_marketplace_sales_company_marketplace_external_order');
+        $this->addSql('DROP INDEX IF EXISTS uniq_marketplace_returns_company_marketplace_external_return');
+        $this->addSql('DROP INDEX IF EXISTS uniq_marketplace_costs_company_marketplace_external');
+    }
+}


### PR DESCRIPTION
### Motivation

- Prevent duplicate business keys across companies for marketplace data by introducing company-aware unique constraints on non-empty external IDs while limiting the change to PostgreSQL only.
- Abort migration on existing duplicates to avoid integrity errors and force manual resolution before enforcing uniqueness.

### Description

- Add a new Doctrine migration `Version20260520143000` that aborts unless the platform is `postgresql` and checks for duplicates in `marketplace_sales`, `marketplace_returns`, and `marketplace_costs` using `SELECT ... GROUP BY ... HAVING COUNT(*) > 1` queries. 
- Create partial unique indexes `uniq_marketplace_sales_company_marketplace_external_order`, `uniq_marketplace_returns_company_marketplace_external_return`, and `uniq_marketplace_costs_company_marketplace_external` that enforce uniqueness on `(company_id, marketplace, external_*)` only when the external id is non-null and not blank. 
- Provide a `down` method that drops the three indexes using `DROP INDEX IF EXISTS` and also guards on the PostgreSQL platform.

### Testing

- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d8e017158832394840e3fe28e770f)