### PR TITLE
Add WbFinancialReportPeriodResolver (Moscow business dates) with unit tests

### DIFF
--- a/site/src/Marketplace/Application/Service/WbFinancialReportPeriodResolver.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportPeriodResolver.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\Service;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeZone;
+use DomainException;
+use InvalidArgumentException;
+use Symfony\Component\Clock\ClockInterface;
+
+final class WbFinancialReportPeriodResolver
+{
+    private const BUSINESS_TIMEZONE = 'Europe/Moscow';
+
+    public function __construct(
+        private readonly ClockInterface $clock,
+    ) {
+    }
+
+    public function yesterday(): DateTimeImmutable
+    {
+        return $this->nowInBusinessTimezone()->modify('-1 day');
+    }
+
+    public function currentYearStart(): DateTimeImmutable
+    {
+        $now = $this->nowInBusinessTimezone();
+
+        return $now->setDate((int) $now->format('Y'), 1, 1);
+    }
+
+    /**
+     * @return list<DateTimeImmutable>
+     */
+    public function last14Days(): array
+    {
+        $to = $this->yesterday();
+        $from = $to->modify('-13 days');
+
+        return $this->daysBetween($from, $to);
+    }
+
+    /**
+     * @return list<DateTimeImmutable>
+     */
+    public function daysBetween(DateTimeImmutable $from, DateTimeImmutable $to): array
+    {
+        $normalizedFrom = $this->normalizeToBusinessDayStart($from);
+        $normalizedTo = $this->normalizeToBusinessDayStart($to);
+
+        if ($normalizedFrom > $normalizedTo) {
+            throw new DomainException('From date must be less than or equal to to date.');
+        }
+
+        $days = [];
+        for ($cursor = $normalizedFrom; $cursor <= $normalizedTo; $cursor = $cursor->add(new DateInterval('P1D'))) {
+            $days[] = $cursor;
+        }
+
+        return $days;
+    }
+
+    public function normalizeBusinessDate(string $date): DateTimeImmutable
+    {
+        $trimmed = trim($date);
+        if ('' === $trimmed) {
+            throw new InvalidArgumentException('Business date must not be empty.');
+        }
+
+        $timezone = $this->businessTimezone();
+        $parsed = DateTimeImmutable::createFromFormat('!Y-m-d', $trimmed, $timezone);
+        $errors = DateTimeImmutable::getLastErrors();
+
+        if (false === $parsed || (is_array($errors) && (0 !== $errors['warning_count'] || 0 !== $errors['error_count']))) {
+            throw new DomainException(sprintf('Invalid WB business date: "%s".', $date));
+        }
+
+        return $parsed->setTime(0, 0, 0);
+    }
+
+    private function nowInBusinessTimezone(): DateTimeImmutable
+    {
+        return $this->clock->now()->setTimezone($this->businessTimezone())->setTime(0, 0, 0);
+    }
+
+    private function normalizeToBusinessDayStart(DateTimeImmutable $date): DateTimeImmutable
+    {
+        return $date->setTimezone($this->businessTimezone())->setTime(0, 0, 0);
+    }
+
+    private function businessTimezone(): DateTimeZone
+    {
+        return new DateTimeZone(self::BUSINESS_TIMEZONE);
+    }
+}

--- a/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportPeriodResolverTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportPeriodResolverTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Application\Service;
+
+use App\Marketplace\Application\Service\WbFinancialReportPeriodResolver;
+use DomainException;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\MockClock;
+
+final class WbFinancialReportPeriodResolverTest extends TestCase
+{
+    public function testYesterdayUsesMoscowBusinessDate(): void
+    {
+        $resolver = new WbFinancialReportPeriodResolver(new MockClock('2026-05-10 00:30:00 UTC'));
+
+        self::assertSame('2026-05-09 00:00:00 Europe/Moscow', $resolver->yesterday()->format('Y-m-d H:i:s e'));
+    }
+
+    public function testCurrentYearStartUsesCurrentBusinessYear(): void
+    {
+        $resolver = new WbFinancialReportPeriodResolver(new MockClock('2026-01-01 00:30:00 UTC'));
+
+        self::assertSame('2026-01-01 00:00:00 Europe/Moscow', $resolver->currentYearStart()->format('Y-m-d H:i:s e'));
+    }
+
+    public function testCurrentYearStartUsesCurrentBusinessYearForRegularDate(): void
+    {
+        $resolver = new WbFinancialReportPeriodResolver(new MockClock('2026-05-20 12:00:00 Europe/Moscow'));
+
+        self::assertSame('2026-01-01 00:00:00 Europe/Moscow', $resolver->currentYearStart()->format('Y-m-d H:i:s e'));
+    }
+
+    public function testLast14DaysReturnsFourteenDatesIncludingYesterday(): void
+    {
+        $resolver = new WbFinancialReportPeriodResolver(new MockClock('2026-05-20 12:00:00 Europe/Moscow'));
+
+        $days = $resolver->last14Days();
+
+        self::assertCount(14, $days);
+        self::assertSame('2026-05-06', $days[0]->format('Y-m-d'));
+        self::assertSame('2026-05-19', $days[13]->format('Y-m-d'));
+    }
+
+    public function testDaysBetweenReturnsInclusiveNormalizedDayRange(): void
+    {
+        $resolver = new WbFinancialReportPeriodResolver(new MockClock('2026-05-20 12:00:00 UTC'));
+
+        $days = $resolver->daysBetween(
+            new \DateTimeImmutable('2026-05-03 23:59:59 UTC'),
+            new \DateTimeImmutable('2026-05-05 01:00:00 Europe/Moscow'),
+        );
+
+        self::assertSame(['2026-05-04', '2026-05-05'], array_map(
+            static fn (\DateTimeImmutable $day): string => $day->format('Y-m-d'),
+            $days,
+        ));
+    }
+
+    public function testDaysBetweenThrowsWhenFromGreaterThanTo(): void
+    {
+        $resolver = new WbFinancialReportPeriodResolver(new MockClock('2026-05-20 12:00:00 UTC'));
+
+        $this->expectException(DomainException::class);
+        $resolver->daysBetween(
+            new \DateTimeImmutable('2026-05-10 00:00:00 Europe/Moscow'),
+            new \DateTimeImmutable('2026-05-09 00:00:00 Europe/Moscow'),
+        );
+    }
+
+    public function testNormalizeBusinessDateParsesValidDate(): void
+    {
+        $resolver = new WbFinancialReportPeriodResolver(new MockClock('2026-05-20 12:00:00 UTC'));
+
+        $date = $resolver->normalizeBusinessDate(' 2026-02-03 ');
+
+        self::assertSame('2026-02-03 00:00:00 Europe/Moscow', $date->format('Y-m-d H:i:s e'));
+    }
+
+    public function testNormalizeBusinessDateThrowsForEmptyDate(): void
+    {
+        $resolver = new WbFinancialReportPeriodResolver(new MockClock('2026-05-20 12:00:00 UTC'));
+
+        $this->expectException(InvalidArgumentException::class);
+        $resolver->normalizeBusinessDate('   ');
+    }
+
+    public function testNormalizeBusinessDateThrowsForInvalidDate(): void
+    {
+        $resolver = new WbFinancialReportPeriodResolver(new MockClock('2026-05-20 12:00:00 UTC'));
+
+        $this->expectException(DomainException::class);
+        $resolver->normalizeBusinessDate('2026-02-30');
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a centralized utility to resolve WB (Wildberries) financial reporting periods and normalize dates according to the Moscow business day boundary.

### Description

- Introduce `WbFinancialReportPeriodResolver` which uses a `ClockInterface` and the `Europe/Moscow` timezone to compute business-local dates and ranges.
- Implement methods `yesterday()`, `currentYearStart()`, `last14Days()`, `daysBetween()`, and `normalizeBusinessDate()` with normalization to business day starts and validation.
- Add private helpers `nowInBusinessTimezone()`, `normalizeToBusinessDayStart()`, and `businessTimezone()` to centralize timezone handling.
- Add comprehensive unit tests in `tests/Unit/Marketplace/Application/Service/WbFinancialReportPeriodResolverTest.php` covering typical and edge cases including parsing, inclusive ranges, and error conditions.

### Testing

- Added PHPUnit tests located at `tests/Unit/Marketplace/Application/Service/WbFinancialReportPeriodResolverTest.php` that exercise all public methods and error paths. 
- Ran the unit test suite for the resolver with `phpunit` and all new tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d93c9a244832399d9f8fd592daf9b)