### PR TITLE
Add WbFinancialReportSyncStatusUpdater and state transition methods for marketplace financial report syncs

### DIFF
--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncStatusUpdater.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncStatusUpdater.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\Service;
+
+use App\Marketplace\Entity\MarketplaceFinancialReportSyncError;
+use App\Marketplace\Entity\MarketplaceFinancialReportSyncStatus;
+use App\Marketplace\Enum\FinancialReportSyncMode;
+use App\Marketplace\Enum\FinancialReportSyncStatus;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Repository\MarketplaceFinancialReportSyncErrorRepository;
+use App\Marketplace\Repository\MarketplaceFinancialReportSyncStatusRepository;
+use Ramsey\Uuid\Uuid;
+
+final readonly class WbFinancialReportSyncStatusUpdater
+{
+    public function __construct(
+        private MarketplaceFinancialReportSyncStatusRepository $statusRepository,
+        private MarketplaceFinancialReportSyncErrorRepository $errorRepository,
+    ) {}
+
+    public function startLoading(string $connectionId, string $companyId, string $reportType, string $apiEndpoint, \DateTimeImmutable $businessDate, FinancialReportSyncMode $mode): MarketplaceFinancialReportSyncStatus
+    {
+        $status = $this->statusRepository->findOrCreateForDay($connectionId, $companyId, MarketplaceType::WILDBERRIES, $reportType, $apiEndpoint, $businessDate);
+        $status->markLoading($mode);
+        $this->statusRepository->save($status);
+
+        return $status;
+    }
+
+    public function markEmpty(MarketplaceFinancialReportSyncStatus $status): void
+    {
+        $status->markEmpty();
+        $this->statusRepository->save($status);
+    }
+
+    public function markRawLoaded(MarketplaceFinancialReportSyncStatus $status, string $rawDocumentId, int $recordsCount, ?string $rowsHash): void
+    {
+        $status->markRawLoaded($rawDocumentId, $recordsCount, $rowsHash);
+        $this->statusRepository->save($status);
+    }
+
+    public function markProcessing(MarketplaceFinancialReportSyncStatus $status): void
+    {
+        $status->markProcessing();
+        $this->statusRepository->save($status);
+    }
+
+    public function markSuccess(MarketplaceFinancialReportSyncStatus $status): void
+    {
+        $status->markSuccess();
+        $this->statusRepository->save($status);
+    }
+
+    /** @param array<string,mixed>|null $requestPayload */
+    public function markFailedRetryable(MarketplaceFinancialReportSyncStatus $status, string $errorClass, string $errorMessage, ?int $statusCode = null, ?string $responseExcerpt = null, ?array $requestPayload = null, ?\DateTimeImmutable $nextRetryAt = null): void
+    {
+        $status->markFailedRetryable($errorClass, $errorMessage, $statusCode, $responseExcerpt, $nextRetryAt);
+        $this->statusRepository->save($status);
+        $this->saveError($status, $errorClass, $errorMessage, $statusCode, $responseExcerpt, $requestPayload);
+    }
+
+    /** @param array<string,mixed>|null $requestPayload */
+    public function markFailedFinal(MarketplaceFinancialReportSyncStatus $status, string $errorClass, string $errorMessage, ?int $statusCode = null, ?string $responseExcerpt = null, ?array $requestPayload = null): void
+    {
+        $status->markFailedFinal($errorClass, $errorMessage, $statusCode, $responseExcerpt);
+        $this->statusRepository->save($status);
+        $this->saveError($status, $errorClass, $errorMessage, $statusCode, $responseExcerpt, $requestPayload);
+    }
+
+    /** @param array<string,mixed>|null $requestPayload */
+    public function markAuthFailed(MarketplaceFinancialReportSyncStatus $status, string $errorClass, string $errorMessage, ?int $statusCode = null, ?string $responseExcerpt = null, ?array $requestPayload = null): void
+    {
+        $status->markAuthFailed($errorClass, $errorMessage, $statusCode, $responseExcerpt);
+        $this->statusRepository->save($status);
+        $this->saveError($status, $errorClass, $errorMessage, $statusCode, $responseExcerpt, $requestPayload);
+    }
+
+    /** @param array<string,mixed>|null $requestPayload */
+    public function markConflict(MarketplaceFinancialReportSyncStatus $status, string $errorClass, string $errorMessage, ?int $statusCode = null, ?string $responseExcerpt = null, ?array $requestPayload = null): void
+    {
+        $status->markConflict($errorClass, $errorMessage, $statusCode, $responseExcerpt);
+        $this->statusRepository->save($status);
+        $this->saveError($status, $errorClass, $errorMessage, $statusCode, $responseExcerpt, $requestPayload);
+    }
+
+    /** @param array<string,mixed>|null $requestPayload */
+    private function saveError(MarketplaceFinancialReportSyncStatus $status, string $errorClass, string $errorMessage, ?int $statusCode, ?string $responseExcerpt, ?array $requestPayload): void
+    {
+        $this->errorRepository->save(new MarketplaceFinancialReportSyncError(
+            Uuid::uuid7()->toString(),
+            $status->getId(),
+            $status->getCompanyId(),
+            $status->getConnectionId(),
+            $status->getBusinessDate(),
+            $errorClass,
+            $errorMessage,
+            $statusCode,
+            $responseExcerpt,
+            $requestPayload,
+        ));
+    }
+}

--- a/site/src/Marketplace/Entity/MarketplaceFinancialReportSyncStatus.php
+++ b/site/src/Marketplace/Entity/MarketplaceFinancialReportSyncStatus.php
@@ -146,4 +146,109 @@ class MarketplaceFinancialReportSyncStatus
     public function getLastErrorResponseExcerpt(): ?string { return $this->lastErrorResponseExcerpt; }
     public function getCreatedAt(): \DateTimeImmutable { return $this->createdAt; }
     public function getUpdatedAt(): \DateTimeImmutable { return $this->updatedAt; }
+
+    public function markLoading(FinancialReportSyncMode $mode): void
+    {
+        $now = new \DateTimeImmutable();
+        $this->status = FinancialReportSyncStatus::LOADING;
+        $this->mode = $mode;
+        $this->attempts++;
+        $this->lastAttemptAt = $now;
+        $this->nextRetryAt = null;
+        $this->startedAt ??= $now;
+        $this->finishedAt = null;
+        $this->clearLastError();
+        $this->updatedAt = $now;
+    }
+
+    public function markEmpty(): void
+    {
+        $now = new \DateTimeImmutable();
+        $this->status = FinancialReportSyncStatus::EMPTY;
+        $this->recordsCount = 0;
+        $this->lastEmptyAt = $now;
+        $this->finishedAt = $now;
+        $this->nextRetryAt = null;
+        $this->clearLastError();
+        $this->updatedAt = $now;
+    }
+
+    public function markRawLoaded(string $rawDocumentId, int $recordsCount, ?string $rowsHash): void
+    {
+        Assert::uuid($rawDocumentId);
+
+        $this->status = FinancialReportSyncStatus::RAW_LOADED;
+        $this->rawDocumentId = $rawDocumentId;
+        $this->recordsCount = max(0, $recordsCount);
+        $this->rowsHash = $rowsHash;
+        $this->nextRetryAt = null;
+        $this->clearLastError();
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function markProcessing(): void
+    {
+        $this->status = FinancialReportSyncStatus::PROCESSING;
+        $this->nextRetryAt = null;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function markSuccess(): void
+    {
+        $now = new \DateTimeImmutable();
+        $this->status = FinancialReportSyncStatus::SUCCESS;
+        $this->finishedAt = $now;
+        $this->lastSuccessAt = $now;
+        $this->nextRetryAt = null;
+        $this->clearLastError();
+        $this->updatedAt = $now;
+    }
+
+    public function markFailedRetryable(string $errorClass, string $errorMessage, ?int $statusCode, ?string $responseExcerpt, ?\DateTimeImmutable $nextRetryAt): void
+    {
+        $this->status = FinancialReportSyncStatus::FAILED;
+        $this->lastErrorClass = $errorClass;
+        $this->lastErrorMessage = $errorMessage;
+        $this->lastErrorStatusCode = $statusCode;
+        $this->lastErrorResponseExcerpt = $responseExcerpt;
+        $this->nextRetryAt = $nextRetryAt ?? new \DateTimeImmutable('+15 minutes');
+        $this->finishedAt = null;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function markFailedFinal(string $errorClass, string $errorMessage, ?int $statusCode, ?string $responseExcerpt): void
+    {
+        $this->markTerminalFailure(FinancialReportSyncStatus::FAILED_FINAL, $errorClass, $errorMessage, $statusCode, $responseExcerpt);
+    }
+
+    public function markAuthFailed(string $errorClass, string $errorMessage, ?int $statusCode, ?string $responseExcerpt): void
+    {
+        $this->markTerminalFailure(FinancialReportSyncStatus::AUTH_FAILED, $errorClass, $errorMessage, $statusCode, $responseExcerpt);
+    }
+
+    public function markConflict(string $errorClass, string $errorMessage, ?int $statusCode, ?string $responseExcerpt): void
+    {
+        $this->markTerminalFailure(FinancialReportSyncStatus::CONFLICT, $errorClass, $errorMessage, $statusCode, $responseExcerpt);
+    }
+
+    private function markTerminalFailure(FinancialReportSyncStatus $status, string $errorClass, string $errorMessage, ?int $statusCode, ?string $responseExcerpt): void
+    {
+        $now = new \DateTimeImmutable();
+        $this->status = $status;
+        $this->lastErrorClass = $errorClass;
+        $this->lastErrorMessage = $errorMessage;
+        $this->lastErrorStatusCode = $statusCode;
+        $this->lastErrorResponseExcerpt = $responseExcerpt;
+        $this->nextRetryAt = null;
+        $this->finishedAt = $now;
+        $this->updatedAt = $now;
+    }
+
+    private function clearLastError(): void
+    {
+        $this->lastErrorClass = null;
+        $this->lastErrorMessage = null;
+        $this->lastErrorStatusCode = null;
+        $this->lastErrorResponseExcerpt = null;
+    }
 }

--- a/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncStatusUpdaterTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncStatusUpdaterTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Application\Service;
+
+use App\Marketplace\Application\Service\WbFinancialReportSyncStatusUpdater;
+use App\Marketplace\Entity\MarketplaceFinancialReportSyncError;
+use App\Marketplace\Entity\MarketplaceFinancialReportSyncStatus;
+use App\Marketplace\Enum\FinancialReportSyncMode;
+use App\Marketplace\Enum\FinancialReportSyncStatus;
+use App\Marketplace\Repository\MarketplaceFinancialReportSyncErrorRepository;
+use App\Marketplace\Repository\MarketplaceFinancialReportSyncStatusRepository;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+
+final class WbFinancialReportSyncStatusUpdaterTest extends IntegrationTestCase
+{
+    private WbFinancialReportSyncStatusUpdater $updater;
+    private MarketplaceFinancialReportSyncStatusRepository $statusRepository;
+    private MarketplaceFinancialReportSyncErrorRepository $errorRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->updater = self::getContainer()->get(WbFinancialReportSyncStatusUpdater::class);
+        $this->statusRepository = self::getContainer()->get(MarketplaceFinancialReportSyncStatusRepository::class);
+        $this->errorRepository = self::getContainer()->get(MarketplaceFinancialReportSyncErrorRepository::class);
+    }
+
+    public function testStartLoadingCreatesStatusAndIncrementsAttempts(): void
+    {
+        $status = $this->updater->startLoading(
+            $this->connectionId(),
+            $this->companyId(),
+            'sales',
+            '/api/v1/report',
+            $this->businessDate(),
+            FinancialReportSyncMode::DAILY,
+        );
+
+        $this->em->flush();
+        $this->em->clear();
+
+        $persisted = $this->findStatus();
+
+        self::assertNotNull($persisted);
+        self::assertSame($status->getId(), $persisted->getId());
+        self::assertSame(FinancialReportSyncStatus::LOADING, $persisted->getStatus());
+        self::assertSame(1, $persisted->getAttempts());
+    }
+
+    public function testMarkRawLoadedPersistsRawFields(): void
+    {
+        $status = $this->startLoadingStatus();
+
+        $this->updater->markRawLoaded($status, $this->rawId(), 55, 'hash-1');
+        $this->em->flush();
+        $this->em->clear();
+
+        $persisted = $this->findStatus();
+        self::assertNotNull($persisted);
+        self::assertSame(FinancialReportSyncStatus::RAW_LOADED, $persisted->getStatus());
+        self::assertSame($this->rawId(), $persisted->getRawDocumentId());
+        self::assertSame(55, $persisted->getRecordsCount());
+        self::assertSame('hash-1', $persisted->getRowsHash());
+    }
+
+    public function testMarkSuccessPersistsSuccessState(): void
+    {
+        $status = $this->startLoadingStatus();
+        $this->updater->markSuccess($status);
+        $this->em->flush();
+        $this->em->clear();
+
+        $persisted = $this->findStatus();
+        self::assertNotNull($persisted);
+        self::assertSame(FinancialReportSyncStatus::SUCCESS, $persisted->getStatus());
+        self::assertNotNull($persisted->getLastSuccessAt());
+    }
+
+    public function testMarkProcessingPersistsProcessingState(): void
+    {
+        $status = $this->startLoadingStatus();
+        $this->updater->markProcessing($status);
+        $this->em->flush();
+        $this->em->clear();
+
+        $persisted = $this->findStatus();
+        self::assertNotNull($persisted);
+        self::assertSame(FinancialReportSyncStatus::PROCESSING, $persisted->getStatus());
+    }
+
+    public function testMarkEmptyPersistsEmptyStateAndZeroRecords(): void
+    {
+        $status = $this->startLoadingStatus();
+        $this->updater->markEmpty($status);
+        $this->em->flush();
+        $this->em->clear();
+
+        $persisted = $this->findStatus();
+        self::assertNotNull($persisted);
+        self::assertSame(FinancialReportSyncStatus::EMPTY, $persisted->getStatus());
+        self::assertSame(0, $persisted->getRecordsCount());
+    }
+
+    public function testMarkFailedRetryablePersistsFailedStateNextRetryAndError(): void
+    {
+        $status = $this->startLoadingStatus();
+        $nextRetryAt = new \DateTimeImmutable('2026-05-01 10:30:00');
+
+        $this->updater->markFailedRetryable($status, 'HttpException', 'temporary failure', 503, 'timeout', ['period' => '2026-05'], $nextRetryAt);
+        $this->em->flush();
+        $this->em->clear();
+
+        $persisted = $this->findStatus();
+        self::assertNotNull($persisted);
+        self::assertSame(FinancialReportSyncStatus::FAILED, $persisted->getStatus());
+        self::assertSame($nextRetryAt->format(DATE_ATOM), $persisted->getNextRetryAt()?->format(DATE_ATOM));
+
+        $errors = $this->errorRepository->findBy(['syncStatusId' => $persisted->getId()]);
+        self::assertCount(1, $errors);
+    }
+
+    public function testMarkFailedFinalPersistsStatusAndCreatesError(): void
+    {
+        $status = $this->startLoadingStatus();
+        $this->updater->markFailedFinal($status, 'ValidationException', 'bad payload', 422);
+        $this->em->flush();
+        $this->em->clear();
+
+        $persisted = $this->findStatus();
+        self::assertNotNull($persisted);
+        self::assertSame(FinancialReportSyncStatus::FAILED_FINAL, $persisted->getStatus());
+
+        $errors = $this->errorRepository->findBy(['syncStatusId' => $persisted->getId()]);
+        self::assertCount(1, $errors);
+        self::assertContainsOnlyInstancesOf(MarketplaceFinancialReportSyncError::class, $errors);
+    }
+
+    public function testMarkAuthFailedPersistsStatusAndCreatesError(): void
+    {
+        $status = $this->startLoadingStatus();
+        $this->updater->markAuthFailed($status, 'AuthException', 'token expired', 401);
+        $this->em->flush();
+        $this->em->clear();
+
+        $persisted = $this->findStatus();
+        self::assertNotNull($persisted);
+        self::assertSame(FinancialReportSyncStatus::AUTH_FAILED, $persisted->getStatus());
+
+        $errors = $this->errorRepository->findBy(['syncStatusId' => $persisted->getId()]);
+        self::assertCount(1, $errors);
+        self::assertContainsOnlyInstancesOf(MarketplaceFinancialReportSyncError::class, $errors);
+    }
+
+    public function testMarkConflictPersistsStatusAndCreatesError(): void
+    {
+        $status = $this->startLoadingStatus();
+        $this->updater->markConflict($status, 'ConflictException', 'conflict', 409);
+        $this->em->flush();
+        $this->em->clear();
+
+        $persisted = $this->findStatus();
+        self::assertNotNull($persisted);
+        self::assertSame(FinancialReportSyncStatus::CONFLICT, $persisted->getStatus());
+
+        $errors = $this->errorRepository->findBy(['syncStatusId' => $persisted->getId()]);
+        self::assertCount(1, $errors);
+        self::assertContainsOnlyInstancesOf(MarketplaceFinancialReportSyncError::class, $errors);
+    }
+
+    private function startLoadingStatus(): MarketplaceFinancialReportSyncStatus
+    {
+        return $this->updater->startLoading(
+            $this->connectionId(),
+            $this->companyId(),
+            'sales',
+            '/api/v1/report',
+            $this->businessDate(),
+            FinancialReportSyncMode::INITIAL,
+        );
+    }
+
+    private function findStatus(): ?MarketplaceFinancialReportSyncStatus
+    {
+        return $this->statusRepository->findByConnectionAndDate(
+            $this->connectionId(),
+            $this->companyId(),
+            $this->businessDate(),
+            'sales',
+        );
+    }
+
+    private function companyId(): string { return '00000000-0000-0000-0000-000000000001'; }
+    private function connectionId(): string { return '00000000-0000-0000-0000-000000000002'; }
+    private function rawId(): string { return '00000000-0000-0000-0000-000000000099'; }
+    private function businessDate(): \DateTimeImmutable { return new \DateTimeImmutable('2026-05-01'); }
+}


### PR DESCRIPTION
### Motivation

- Centralize and standardize lifecycle transitions for Wildberries financial report synchronization records and ensure consistent persistence of state changes. 
- Persist detailed error records when sync operations fail to support diagnostics and retry logic.
- Provide automated tests to validate status transitions and error creation flows.

### Description

- Added `WbFinancialReportSyncStatusUpdater` service with methods to start loading and transition statuses (`startLoading`, `markEmpty`, `markRawLoaded`, `markProcessing`, `markSuccess`, `markFailedRetryable`, `markFailedFinal`, `markAuthFailed`, `markConflict`) and to persist related `MarketplaceFinancialReportSyncError` entries. 
- Extended `MarketplaceFinancialReportSyncStatus` entity with explicit state transition methods (`markLoading`, `markEmpty`, `markRawLoaded`, `markProcessing`, `markSuccess`, `markFailedRetryable`, `markFailedFinal`, `markAuthFailed`, `markConflict`) plus helpers `markTerminalFailure` and `clearLastError` to update timestamps, attempts, retry scheduling and last-error fields consistently. 
- Added unit test `WbFinancialReportSyncStatusUpdaterTest` that covers creating/loading a status, raw load, processing, success, empty state, and each error path verifying both status changes and error persistence.

### Testing

- Added PHPUnit test `WbFinancialReportSyncStatusUpdaterTest` covering all updater methods and repository persistence checks. 
- Ran the new test suite for the updater via PHPUnit and the tests completed successfully. 
- Tests assert persistence of status fields, retry scheduling, and creation of `MarketplaceFinancialReportSyncError` records for failing transitions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d97dc6c4c8323a43a11422ac28351)