### PR TITLE
Add SyncWbFinancialReportDayMessage and register messenger routing

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1729,6 +1729,23 @@ GET /inventory/stocks
 - `SyncOzonInventorySnapshotMessage` выполняет внешний HTTP-запрос к Ozon;
 - `NormalizeInventorySnapshotMessage` выполняет локальную DB-heavy обработку raw JSON.
 
+## Messenger routing — Marketplace (WB financial report day)
+
+- `App\Marketplace\Message\SyncWbFinancialReportDayMessage` → `async_sync`.
+
+Назначение:
+- загрузка WB financial report за один `businessDate` (date-based sync для initial / refresh_14d / missing сценариев).
+
+Payload (только scalar):
+- `companyId` — `string` UUID;
+- `connectionId` — `string` UUID;
+- `businessDate` — `string` в формате `YYYY-MM-DD`;
+- `mode` — `string`, значение `FinancialReportSyncMode`;
+- `forceRefresh` — `bool`.
+
+Ограничения payload:
+- message не содержит `apiKey`, `token`, `connection` entity или любые другие ORM-объекты.
+
 ---
 
 ## Redis — три назначения

--- a/site/config/packages/messenger.yaml
+++ b/site/config/packages/messenger.yaml
@@ -37,6 +37,7 @@ framework:
         routing:
             # --- async_sync: external marketplace/bank HTTP fetches ---
             'App\Marketplace\Message\SyncWbReportMessage': async_sync
+            'App\Marketplace\Message\SyncWbFinancialReportDayMessage': async_sync
             'App\Marketplace\Message\SyncOzonReportMessage': async_sync
             'App\Marketplace\Message\SyncOzonRealizationMessage': async_sync
             'App\Marketplace\Message\InitialSyncMessage': async_sync

--- a/site/src/Marketplace/Message/SyncWbFinancialReportDayMessage.php
+++ b/site/src/Marketplace/Message/SyncWbFinancialReportDayMessage.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Message;
+
+final readonly class SyncWbFinancialReportDayMessage
+{
+    public function __construct(
+        public string $companyId,
+        public string $connectionId,
+        public string $businessDate,
+        public string $mode,
+        public bool $forceRefresh,
+    ) {}
+}

--- a/site/tests/Unit/Marketplace/Message/SyncWbFinancialReportDayMessageTest.php
+++ b/site/tests/Unit/Marketplace/Message/SyncWbFinancialReportDayMessageTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Message;
+
+use App\Marketplace\Message\SyncWbFinancialReportDayMessage;
+use PHPUnit\Framework\TestCase;
+
+final class SyncWbFinancialReportDayMessageTest extends TestCase
+{
+    public function testMessageContainsOnlyScalarFields(): void
+    {
+        $message = new SyncWbFinancialReportDayMessage(
+            companyId: '11111111-1111-1111-1111-111111111111',
+            connectionId: '22222222-2222-2222-2222-222222222222',
+            businessDate: '2026-05-20',
+            mode: 'daily',
+            forceRefresh: true,
+        );
+
+        self::assertSame('11111111-1111-1111-1111-111111111111', $message->companyId);
+        self::assertSame('22222222-2222-2222-2222-222222222222', $message->connectionId);
+        self::assertSame('2026-05-20', $message->businessDate);
+        self::assertSame('daily', $message->mode);
+        self::assertTrue($message->forceRefresh);
+
+        self::assertFalse(property_exists($message, 'apiKey'));
+        self::assertFalse(property_exists($message, 'connection'));
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce a scalar-only message to support day-based WB financial report syncs for `initial`/`refresh_14d`/`missing` scenarios.

### Description
- Add `SyncWbFinancialReportDayMessage` data message in `site/src/Marketplace/Message/SyncWbFinancialReportDayMessage.php` with scalar fields `companyId`, `connectionId`, `businessDate`, `mode`, and `forceRefresh`.
- Register the new message routing to the `async_sync` transport in `site/config/packages/messenger.yaml`.
- Document the new messenger routing and payload shape in `ARCHITECTURE.md` under "Messenger routing — Marketplace (WB financial report day)".
- Add unit test `site/tests/Unit/Marketplace/Message/SyncWbFinancialReportDayMessageTest.php` to assert the message contains only scalar fields and no ORM objects.

### Testing
- Added unit test `SyncWbFinancialReportDayMessageTest` and ran it with PHPUnit using `vendor/bin/phpunit --filter SyncWbFinancialReportDayMessageTest`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0da8ac53fc832395871c1fa33b5b68)