### PR TITLE
Add WB finance rate limiter service, config, and unit tests

### DIFF
--- a/site/config/packages/rate_limiter.yaml
+++ b/site/config/packages/rate_limiter.yaml
@@ -12,3 +12,8 @@ framework:
             policy: fixed_window
             limit: 1
             interval: '1 minute'
+
+        wb_finance:
+            policy: fixed_window
+            limit: 1
+            interval: '1 minute'

--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -53,6 +53,11 @@ services:
         arguments:
             $factory: '@?limiter.registration'
 
+
+    App\Marketplace\Application\Service\WbFinanceRateLimiter:
+        arguments:
+            $factory: '@?limiter.wb_finance'
+
     App\Service\FeatureFlagService:
         arguments:
             $fundsAndWidgetEnabled: '%feature_funds_and_widget%'

--- a/site/src/Marketplace/Application/Service/WbFinanceRateLimiter.php
+++ b/site/src/Marketplace/Application/Service/WbFinanceRateLimiter.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\Service;
+
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+
+final class WbFinanceRateLimiter
+{
+    public function __construct(private readonly ?RateLimiterFactory $factory = null)
+    {
+    }
+
+    public function acquire(string $connectionId, int $tokens = 1): bool
+    {
+        if (null !== $this->factory) {
+            return $this->factory->create($this->buildKey($connectionId))->consume($tokens)->isAccepted();
+        }
+
+        return true;
+    }
+
+    private function buildKey(string $connectionId): string
+    {
+        return sprintf('wb_finance:%s', $connectionId);
+    }
+}

--- a/site/tests/Unit/Marketplace/Application/Service/WbFinanceRateLimiterTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbFinanceRateLimiterTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Application\Service;
+
+use App\Marketplace\Application\Service\WbFinanceRateLimiter;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
+
+final class WbFinanceRateLimiterTest extends TestCase
+{
+    public function testAcquireRejectsSecondRequestForSameConnectionWithinMinute(): void
+    {
+        $limiter = $this->createLimiter();
+        $connectionId = '6c3a0e9f-1c09-4a2f-a63f-27f3eddd67df';
+
+        self::assertTrue($limiter->acquire($connectionId));
+        self::assertFalse($limiter->acquire($connectionId));
+    }
+
+    public function testAcquireUsesSeparateBucketsForDifferentConnections(): void
+    {
+        $limiter = $this->createLimiter();
+
+        self::assertTrue($limiter->acquire('6c3a0e9f-1c09-4a2f-a63f-27f3eddd67df'));
+        self::assertTrue($limiter->acquire('4d91db78-6c9b-4fb9-8478-24ab4c68253f'));
+    }
+
+    private function createLimiter(): WbFinanceRateLimiter
+    {
+        $factory = new RateLimiterFactory(
+            [
+                'id' => 'wb_finance',
+                'policy' => 'fixed_window',
+                'limit' => 1,
+                'interval' => '1 minute',
+            ],
+            new InMemoryStorage(),
+        );
+
+        return new WbFinanceRateLimiter($factory);
+    }
+}


### PR DESCRIPTION
### Motivation

- Introduce a per-connection rate limiter for the WB finance integration to prevent excessive concurrent requests and enforce a 1-per-minute policy.

### Description

- Add a `wb_finance` limiter to `site/config/packages/rate_limiter.yaml` with a `fixed_window` policy, `limit: 1`, and `interval: '1 minute'`.
- Register a new service `App\Marketplace\Application\Service\WbFinanceRateLimiter` in `site/config/services.yaml` wired to `limiter.wb_finance`.
- Implement the `WbFinanceRateLimiter` class with an `acquire(string $connectionId, int $tokens = 1): bool` method that builds a key per connection and consumes tokens via `RateLimiterFactory`.
- Add `WbFinanceRateLimiterTest` unit tests that use `RateLimiterFactory` with `InMemoryStorage` to validate single-request acceptance per connection and separate buckets for different connections.

### Testing

- Ran the unit tests for the limiter via `phpunit --filter WbFinanceRateLimiterTest` and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dad7f5c8c8323b510c37e98692f6c)