### PR TITLE
Add WbFinancialReportReconciliationService, conflict exception, and unit tests

### DIFF
--- a/site/src/Marketplace/Application/Service/WbFinancialReportReconciliationService.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportReconciliationService.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\Service;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Entity\MarketplaceRawDocument;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Enum\PipelineStatus;
+use App\Marketplace\Exception\WbRawDocumentRefreshConflictException;
+use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
+use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\Uuid;
+
+final class WbFinancialReportReconciliationService
+{
+    private const DOCUMENT_TYPE = 'sales_report';
+    private const API_ENDPOINT = 'wildberries::finance-sales-reports-detailed';
+
+    public function __construct(
+        private readonly MarketplaceRawDocumentRepository $rawDocumentRepository,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Caller is responsible for persist/flush of returned raw document.
+     */
+    public function createOrRefreshRawDocument(
+        Company $company,
+        MarketplaceConnection $connection,
+        \DateTimeImmutable $businessDate,
+        array $rows,
+        bool $forceRefresh,
+    ): MarketplaceRawDocument {
+        $existingDocuments = $this->rawDocumentRepository->findActiveExactPeriodDocuments(
+            $company,
+            MarketplaceType::WILDBERRIES,
+            self::DOCUMENT_TYPE,
+            self::API_ENDPOINT,
+            $businessDate,
+            $businessDate,
+        );
+
+        $canonical = $existingDocuments[0] ?? null;
+
+        if (count($existingDocuments) > 1) {
+            $this->logger->warning('Multiple active WB raw documents found for day, using latest as canonical', [
+                'company_id' => $company->getId(),
+                'connection_id' => $connection->getId(),
+                'business_date' => $businessDate->format('Y-m-d'),
+                'raw_document_ids' => array_map(
+                    static fn (MarketplaceRawDocument $document): string => $document->getId(),
+                    $existingDocuments,
+                ),
+            ]);
+        }
+
+        if ($canonical !== null && $this->isInFlight($canonical)) {
+            if ($forceRefresh) {
+                throw new WbRawDocumentRefreshConflictException(
+                    sprintf('Cannot force refresh raw document %s while pipeline is in-flight.', $canonical->getId()),
+                );
+            }
+
+            $this->logger->info('Skipping WB raw document refresh: pipeline is still in progress', [
+                'company_id' => $company->getId(),
+                'connection_id' => $connection->getId(),
+                'raw_document_id' => $canonical->getId(),
+                'status' => $canonical->getProcessingStatus()?->value,
+                'business_date' => $businessDate->format('Y-m-d'),
+            ]);
+
+            return $canonical;
+        }
+
+        if ($canonical !== null) {
+            $canonical->refreshRawData(
+                rawData: $rows,
+                apiEndpoint: self::API_ENDPOINT,
+                recordsCount: count($rows),
+            );
+
+            return $canonical;
+        }
+
+        $rawDocument = new MarketplaceRawDocument(
+            Uuid::uuid4()->toString(),
+            $company,
+            MarketplaceType::WILDBERRIES,
+            self::DOCUMENT_TYPE,
+        );
+
+        $rawDocument->setPeriodFrom($businessDate);
+        $rawDocument->setPeriodTo($businessDate);
+        $rawDocument->setApiEndpoint(self::API_ENDPOINT);
+        $rawDocument->setRawData($rows);
+        $rawDocument->setRecordsCount(count($rows));
+        $rawDocument->resetProcessingStatus();
+
+        return $rawDocument;
+    }
+
+    private function isInFlight(MarketplaceRawDocument $document): bool
+    {
+        return in_array($document->getProcessingStatus(), [PipelineStatus::PENDING, PipelineStatus::RUNNING], true);
+    }
+}

--- a/site/src/Marketplace/Entity/MarketplaceRawDocument.php
+++ b/site/src/Marketplace/Entity/MarketplaceRawDocument.php
@@ -175,7 +175,7 @@ class MarketplaceRawDocument
         $this->syncedAt = $syncedAt ?? new \DateTimeImmutable();
 
         $this->resetProcessingStatus();
-        $this->addSyncNote('Raw document refreshed from Ozon API');
+        $this->addSyncNote('Raw document refreshed from API');
 
         return $this;
     }

--- a/site/src/Marketplace/Exception/WbRawDocumentRefreshConflictException.php
+++ b/site/src/Marketplace/Exception/WbRawDocumentRefreshConflictException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Exception;
+
+final class WbRawDocumentRefreshConflictException extends \RuntimeException
+{
+}

--- a/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportReconciliationServiceTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportReconciliationServiceTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Application\Service;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Application\Service\WbFinancialReportReconciliationService;
+use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Entity\MarketplaceRawDocument;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Enum\PipelineStatus;
+use App\Marketplace\Exception\WbRawDocumentRefreshConflictException;
+use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Marketplace\MarketplaceRawDocumentBuilder;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+final class WbFinancialReportReconciliationServiceTest extends TestCase
+{
+    public function testCreatesRawDocumentWhenNoExistingDocument(): void
+    {
+        [$company, $connection] = $this->buildCompanyAndConnection();
+        $businessDate = new \DateTimeImmutable('2026-04-17');
+
+        $repository = $this->createMock(MarketplaceRawDocumentRepository::class);
+        $repository->expects(self::once())
+            ->method('findActiveExactPeriodDocuments')
+            ->willReturn([]);
+
+        $service = new WbFinancialReportReconciliationService($repository, $this->createMock(LoggerInterface::class));
+        $rows = [['id' => 1], ['id' => 2]];
+
+        $document = $service->createOrRefreshRawDocument($company, $connection, $businessDate, $rows, false);
+
+        self::assertSame($rows, $document->getRawData());
+        self::assertSame('sales_report', $document->getDocumentType());
+        self::assertSame('wildberries::finance-sales-reports-detailed', $document->getApiEndpoint());
+        self::assertSame($businessDate, $document->getPeriodFrom());
+        self::assertSame($businessDate, $document->getPeriodTo());
+        self::assertSame(PipelineStatus::PENDING, $document->getProcessingStatus());
+    }
+
+    public function testRefreshesExistingCompletedDocument(): void
+    {
+        [$company, $connection] = $this->buildCompanyAndConnection();
+        $businessDate = new \DateTimeImmutable('2026-04-17');
+
+        $existing = $this->buildRawDocument($company, $businessDate);
+        $existing->markCompleted();
+        $repository = $this->createMock(MarketplaceRawDocumentRepository::class);
+        $repository->method('findActiveExactPeriodDocuments')->willReturn([$existing]);
+
+        $service = new WbFinancialReportReconciliationService($repository, $this->createMock(LoggerInterface::class));
+        $rows = [['fresh' => true]];
+
+        $result = $service->createOrRefreshRawDocument($company, $connection, $businessDate, $rows, false);
+
+        self::assertSame($existing->getId(), $result->getId());
+        self::assertSame($rows, $result->getRawData());
+        self::assertSame(PipelineStatus::PENDING, $result->getProcessingStatus());
+        self::assertStringNotContainsString('Ozon', (string) $result->getSyncNotes());
+    }
+
+    public function testSkipsRefreshForInFlightDocumentWhenForceRefreshIsFalse(): void
+    {
+        [$company, $connection] = $this->buildCompanyAndConnection();
+        $businessDate = new \DateTimeImmutable('2026-04-17');
+
+        $existing = $this->buildRawDocument($company, $businessDate);
+        $existing->resetProcessingStatus();
+        $existing->setRawData([['old' => true]]);
+
+        $repository = $this->createMock(MarketplaceRawDocumentRepository::class);
+        $repository->method('findActiveExactPeriodDocuments')->willReturn([$existing]);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('info');
+
+        $service = new WbFinancialReportReconciliationService($repository, $logger);
+
+        $result = $service->createOrRefreshRawDocument($company, $connection, $businessDate, [['fresh' => true]], false);
+
+        self::assertSame($existing->getId(), $result->getId());
+        self::assertSame([['old' => true]], $result->getRawData());
+    }
+
+    public function testThrowsConflictWhenForceRefreshOnInFlightDocument(): void
+    {
+        [$company, $connection] = $this->buildCompanyAndConnection();
+        $businessDate = new \DateTimeImmutable('2026-04-17');
+
+        $existing = $this->buildRawDocument($company, $businessDate);
+        $this->forceProcessingStatus($existing, PipelineStatus::RUNNING);
+
+        $repository = $this->createMock(MarketplaceRawDocumentRepository::class);
+        $repository->method('findActiveExactPeriodDocuments')->willReturn([$existing]);
+
+        $service = new WbFinancialReportReconciliationService($repository, $this->createMock(LoggerInterface::class));
+
+        $this->expectException(WbRawDocumentRefreshConflictException::class);
+        $service->createOrRefreshRawDocument($company, $connection, $businessDate, [['fresh' => true]], true);
+    }
+
+    public function testLogsWarningWhenMultipleActiveDocumentsFound(): void
+    {
+        [$company, $connection] = $this->buildCompanyAndConnection();
+        $businessDate = new \DateTimeImmutable('2026-04-17');
+
+        $canonical = $this->buildRawDocument($company, $businessDate);
+        $duplicate = $this->buildRawDocument($company, $businessDate);
+        $canonical->markCompleted();
+        $duplicate->markCompleted();
+
+        $repository = $this->createMock(MarketplaceRawDocumentRepository::class);
+        $repository->method('findActiveExactPeriodDocuments')->willReturn([$canonical, $duplicate]);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('warning');
+
+        $service = new WbFinancialReportReconciliationService($repository, $logger);
+        $service->createOrRefreshRawDocument($company, $connection, $businessDate, [['fresh' => true]], false);
+    }
+
+    private function buildCompanyAndConnection(): array
+    {
+        $company = CompanyBuilder::aCompany()->build();
+        $connection = new MarketplaceConnection('22222222-2222-2222-2222-222222222222', $company, MarketplaceType::WILDBERRIES);
+
+        return [$company, $connection];
+    }
+
+    private function buildRawDocument(Company $company, \DateTimeImmutable $day): MarketplaceRawDocument
+    {
+        return MarketplaceRawDocumentBuilder::aDocument()
+            ->forCompany($company)
+            ->withMarketplace(MarketplaceType::WILDBERRIES)
+            ->withDocumentType('sales_report')
+            ->withApiEndpoint('wildberries::finance-sales-reports-detailed')
+            ->withPeriod($day, $day)
+            ->build();
+    }
+
+    private function forceProcessingStatus(MarketplaceRawDocument $doc, PipelineStatus $status): void
+    {
+        $reflection = new \ReflectionProperty($doc, 'processingStatus');
+        $reflection->setAccessible(true);
+        $reflection->setValue($doc, $status);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a dedicated service to create or refresh Wildberries financial raw documents and centralize refresh/conflict logic for daily sales reports.
- Ensure safe handling when a previous raw document pipeline is in-flight and surface a clear conflict error for forced refresh attempts.

### Description
- Adds `WbFinancialReportReconciliationService` with `createOrRefreshRawDocument` which queries `MarketplaceRawDocumentRepository::findActiveExactPeriodDocuments`, reuses or refreshes an existing document, skips refresh if the pipeline is in-flight, and throws `WbRawDocumentRefreshConflictException` when a forced refresh conflicts with an in-flight document; the method leaves persistence to the caller.
- Introduces `WbRawDocumentRefreshConflictException` as a specific runtime exception for refresh conflicts.
- Updates `MarketplaceRawDocument::refreshRawData` to change the sync note message from `Raw document refreshed from Ozon API` to `Raw document refreshed from API`.
- Adds unit tests in `WbFinancialReportReconciliationServiceTest` covering creation of new documents, refresh of completed documents, skipping refresh for in-flight documents, conflict on forced refresh, and logging when multiple active documents are found.

### Testing
- Added PHPUnit unit tests in `site/tests/Unit/Marketplace/Application/Service/WbFinancialReportReconciliationServiceTest.php` which exercise all main scenarios of the reconciliation flow and were executed as part of the test run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e913179048323bfb247d8d3276daa)