### PR TITLE
Add Wildberries daily financial report sync handler, repo lookup and unit tests

### DIFF
--- a/site/src/Marketplace/MessageHandler/SyncWbFinancialReportDayHandler.php
+++ b/site/src/Marketplace/MessageHandler/SyncWbFinancialReportDayHandler.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\MessageHandler;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Application\Service\WbFinancialReportPeriodResolver;
+use App\Marketplace\Application\Service\WbFinancialReportReconciliationService;
+use App\Marketplace\Application\Service\WbFinancialReportSyncStatusUpdater;
+use App\Marketplace\Enum\FinancialReportSyncMode;
+use App\Marketplace\Enum\MarketplaceConnectionType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Exception\MarketplaceAuthException;
+use App\Marketplace\Exception\MarketplaceBadRequestException;
+use App\Marketplace\Exception\MarketplaceInvalidApiResponseException;
+use App\Marketplace\Exception\MarketplaceRateLimitException;
+use App\Marketplace\Exception\MarketplaceTemporaryApiException;
+use App\Marketplace\Exception\WbRawDocumentRefreshConflictException;
+use App\Marketplace\Infrastructure\Api\Wildberries\WbFinanceSalesReportClient;
+use App\Marketplace\Message\ProcessDayReportMessage;
+use App\Marketplace\Message\SyncWbFinancialReportDayMessage;
+use App\Marketplace\Repository\MarketplaceConnectionRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[AsMessageHandler]
+final class SyncWbFinancialReportDayHandler
+{
+    private const LOCK_TTL_SECONDS = 600;
+    private const REPORT_TYPE = 'sales_report';
+    private const API_ENDPOINT = 'wildberries::finance-sales-reports-detailed';
+
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly MarketplaceConnectionRepository $connectionRepository,
+        private readonly WbFinancialReportPeriodResolver $periodResolver,
+        private readonly WbFinanceSalesReportClient $financeSalesReportClient,
+        private readonly WbFinancialReportSyncStatusUpdater $syncStatusUpdater,
+        private readonly WbFinancialReportReconciliationService $reconciliationService,
+        private readonly LockFactory $lockFactory,
+        private readonly MessageBusInterface $messageBus,
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    public function __invoke(SyncWbFinancialReportDayMessage $message): void
+    {
+        $businessDate = $this->periodResolver->normalizeBusinessDate($message->businessDate);
+        $mode = FinancialReportSyncMode::from($message->mode);
+
+        $lock = $this->lockFactory->createLock(
+            sprintf('marketplace_wb_day_sync:%s:%s:%s', $message->companyId, $message->connectionId, $businessDate->format('Y-m-d')),
+            self::LOCK_TTL_SECONDS,
+        );
+
+        if (!$lock->acquire()) {
+            $this->logger->warning('WB day sync lock not acquired, skipping.', [
+                'company_id' => $message->companyId,
+                'connection_id' => $message->connectionId,
+                'business_date' => $businessDate->format('Y-m-d'),
+                'mode' => $mode->value,
+            ]);
+
+            return;
+        }
+
+        try {
+            $this->handle($message, $businessDate, $mode);
+        } finally {
+            $lock->release();
+        }
+    }
+
+    private function handle(SyncWbFinancialReportDayMessage $message, \DateTimeImmutable $businessDate, FinancialReportSyncMode $mode): void
+    {
+        $this->logger->info('WB day sync started.', [
+            'company_id' => $message->companyId,
+            'connection_id' => $message->connectionId,
+            'business_date' => $businessDate->format('Y-m-d'),
+            'mode' => $mode->value,
+            'force_refresh' => $message->forceRefresh,
+        ]);
+
+        $company = $this->em->find(Company::class, $message->companyId);
+        if (!$company) {
+            $this->logger->warning('WB day sync skipped: company not found.', ['company_id' => $message->companyId]);
+
+            return;
+        }
+
+        $connection = $this->connectionRepository->findByIdAndCompany($message->connectionId, $company);
+        if (!$connection) {
+            $this->logger->warning('WB day sync skipped: connection not found for company.', [
+                'company_id' => $message->companyId,
+                'connection_id' => $message->connectionId,
+            ]);
+
+            return;
+        }
+
+        if (!$connection->isActive() || MarketplaceType::WILDBERRIES !== $connection->getMarketplace() || MarketplaceConnectionType::SELLER !== $connection->getConnectionType()) {
+            $this->logger->warning('WB day sync skipped: invalid connection state/type.', [
+                'company_id' => $message->companyId,
+                'connection_id' => $message->connectionId,
+                'is_active' => $connection->isActive(),
+                'marketplace' => $connection->getMarketplace()->value,
+                'connection_type' => $connection->getConnectionType()->value,
+            ]);
+
+            return;
+        }
+
+        $status = $this->syncStatusUpdater->startLoading($connection->getId(), $message->companyId, self::REPORT_TYPE, self::API_ENDPOINT, $businessDate, $mode);
+
+        try {
+            $rows = $this->financeSalesReportClient->fetchDetailedDay($connection->getId(), $connection->getApiKey(), $businessDate);
+
+            if ([] === $rows) {
+                $this->syncStatusUpdater->markEmpty($status);
+                $connection->markSyncSuccess();
+                $this->em->flush();
+
+                $this->logger->info('WB day sync finished with empty dataset.', [
+                    'company_id' => $message->companyId,
+                    'connection_id' => $message->connectionId,
+                    'business_date' => $businessDate->format('Y-m-d'),
+                    'mode' => $mode->value,
+                    'records_count' => 0,
+                ]);
+
+                return;
+            }
+
+            $rawDocument = $this->reconciliationService->createOrRefreshRawDocument(
+                $company,
+                $connection,
+                $businessDate,
+                $rows,
+                $message->forceRefresh,
+            );
+
+            $this->em->persist($rawDocument);
+            $this->em->flush();
+
+            $this->syncStatusUpdater->markRawLoaded(
+                $status,
+                $rawDocument->getId(),
+                count($rows),
+                hash('sha256', json_encode($rows, JSON_THROW_ON_ERROR)),
+            );
+            $this->syncStatusUpdater->markProcessing($status);
+            $connection->markSyncSuccess();
+            $this->em->flush();
+
+            $this->messageBus->dispatch(new ProcessDayReportMessage($message->companyId, $rawDocument->getId()));
+
+            $this->logger->info('WB day sync finished and processing dispatched.', [
+                'company_id' => $message->companyId,
+                'connection_id' => $message->connectionId,
+                'business_date' => $businessDate->format('Y-m-d'),
+                'mode' => $mode->value,
+                'records_count' => count($rows),
+                'raw_document_id' => $rawDocument->getId(),
+            ]);
+        } catch (MarketplaceRateLimitException $e) {
+            $nextRetryAt = null;
+            if (null !== $e->getRetryAfter()) {
+                $nextRetryAt = (new \DateTimeImmutable())->modify(sprintf('+%d seconds', max(1, $e->getRetryAfter())));
+            }
+
+            $this->syncStatusUpdater->markFailedRetryable($status, $e::class, $e->getMessage(), $e->getStatusCode(), $e->getResponseExcerpt(), null, $nextRetryAt);
+            $connection->markSyncFailed($e->getMessage());
+            $this->em->flush();
+
+            $this->logger->warning('WB day sync rate-limited, retry scheduled.', [
+                'company_id' => $message->companyId,
+                'connection_id' => $message->connectionId,
+                'business_date' => $businessDate->format('Y-m-d'),
+                'mode' => $mode->value,
+            ]);
+
+            throw new RecoverableMessageHandlingException($e->getMessage(), 0, $e, (($e->getRetryAfter() ?? 61) * 1000));
+        } catch (MarketplaceAuthException $e) {
+            $this->syncStatusUpdater->markAuthFailed($status, $e::class, $e->getMessage(), $e->getStatusCode(), $e->getResponseExcerpt());
+            $connection->markSyncFailed($e->getMessage());
+            $this->em->flush();
+
+            $this->logger->error('WB day sync auth failed.', [
+                'company_id' => $message->companyId,
+                'connection_id' => $message->connectionId,
+                'business_date' => $businessDate->format('Y-m-d'),
+                'mode' => $mode->value,
+            ]);
+
+            throw new UnrecoverableMessageHandlingException($e->getMessage(), 0, $e);
+        } catch (MarketplaceTemporaryApiException $e) {
+            $this->syncStatusUpdater->markFailedRetryable($status, $e::class, $e->getMessage(), $e->getStatusCode(), $e->getResponseExcerpt());
+            $connection->markSyncFailed($e->getMessage());
+            $this->em->flush();
+            $this->logger->warning('WB day sync temporary API failure.', [
+                'company_id' => $message->companyId,
+                'connection_id' => $message->connectionId,
+                'business_date' => $businessDate->format('Y-m-d'),
+                'mode' => $mode->value,
+            ]);
+
+            throw new RecoverableMessageHandlingException($e->getMessage(), 0, $e);
+        } catch (WbRawDocumentRefreshConflictException $e) {
+            $this->syncStatusUpdater->markConflict($status, $e::class, $e->getMessage(), null, null);
+            $connection->markSyncFailed($e->getMessage());
+            $this->em->flush();
+            $this->logger->warning('WB day sync conflict: raw document is in-flight.', [
+                'company_id' => $message->companyId,
+                'connection_id' => $message->connectionId,
+                'business_date' => $businessDate->format('Y-m-d'),
+                'mode' => $mode->value,
+            ]);
+
+            throw new UnrecoverableMessageHandlingException($e->getMessage(), 0, $e);
+        } catch (MarketplaceBadRequestException|MarketplaceInvalidApiResponseException $e) {
+            $this->syncStatusUpdater->markFailedFinal($status, $e::class, $e->getMessage(), $e->getStatusCode(), $e->getResponseExcerpt());
+            $connection->markSyncFailed($e->getMessage());
+            $this->em->flush();
+            $this->logger->error('WB day sync failed with non-retryable payload/response error.', [
+                'company_id' => $message->companyId,
+                'connection_id' => $message->connectionId,
+                'business_date' => $businessDate->format('Y-m-d'),
+                'mode' => $mode->value,
+            ]);
+
+            throw new UnrecoverableMessageHandlingException($e->getMessage(), 0, $e);
+        }
+    }
+}

--- a/site/src/Marketplace/Repository/MarketplaceConnectionRepository.php
+++ b/site/src/Marketplace/Repository/MarketplaceConnectionRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Marketplace\Repository;
 
 use App\Company\Entity\Company;
@@ -76,6 +78,18 @@ class MarketplaceConnectionRepository extends ServiceEntityRepository
             ->getOneOrNullResult();
     }
 
+
+
+    public function findByIdAndCompany(string $connectionId, Company $company): ?MarketplaceConnection
+    {
+        return $this->createQueryBuilder('c')
+            ->where('c.id = :connectionId')
+            ->andWhere('c.company = :company')
+            ->setParameter('connectionId', $connectionId)
+            ->setParameter('company', $company)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
     /**
      * @return MarketplaceConnection[]
      */

--- a/site/tests/Unit/Marketplace/MessageHandler/SyncWbFinancialReportDayHandlerTest.php
+++ b/site/tests/Unit/Marketplace/MessageHandler/SyncWbFinancialReportDayHandlerTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\MessageHandler;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Entity\MarketplaceFinancialReportSyncError;
+use App\Marketplace\Entity\MarketplaceFinancialReportSyncStatus;
+use App\Marketplace\Entity\MarketplaceRawDocument;
+use App\Marketplace\Enum\FinancialReportSyncMode;
+use App\Marketplace\Enum\FinancialReportSyncStatus;
+use App\Marketplace\Enum\MarketplaceConnectionType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Enum\PipelineStatus;
+use App\Marketplace\Infrastructure\Api\Wildberries\WbFinanceSalesReportClient;
+use App\Marketplace\Message\SyncWbFinancialReportDayMessage;
+use App\Marketplace\MessageHandler\SyncWbFinancialReportDayHandler;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+
+final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
+{
+    public function testServiceWiring(): void
+    {
+        $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
+
+        self::assertInstanceOf(SyncWbFinancialReportDayHandler::class, $handler);
+    }
+
+    public function testTemporaryApiExceptionMarksRetryableFailedAndStoresError(): void
+    {
+        $company = $this->createCompany(9101);
+        $connection = $this->createWbSellerConnection($company, 9101);
+
+        $this->swapWbClient([new MockResponse('{"error":"temporary"}', ['http_code' => 500])]);
+
+        $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
+
+        $this->expectException(RecoverableMessageHandlingException::class);
+        try {
+            $handler(new SyncWbFinancialReportDayMessage(
+                companyId: $company->getId(),
+                connectionId: $connection->getId(),
+                businessDate: '2026-05-19',
+                mode: FinancialReportSyncMode::MANUAL->value,
+                forceRefresh: false,
+            ));
+        } finally {
+            $status = $this->findStatus($connection->getId(), $company->getId(), '2026-05-19');
+            self::assertNotNull($status);
+            self::assertSame(FinancialReportSyncStatus::FAILED, $status->getStatus());
+
+            $error = $this->findLastError($status->getId());
+            self::assertNotNull($error);
+            self::assertSame('App\Marketplace\Exception\MarketplaceTemporaryApiException', $error->getErrorClass());
+        }
+    }
+
+    public function testConflictMarksConflictAndThrowsUnrecoverable(): void
+    {
+        $company = $this->createCompany(9102);
+        $connection = $this->createWbSellerConnection($company, 9102);
+        $businessDate = new \DateTimeImmutable('2026-05-19');
+
+        $existingRaw = new MarketplaceRawDocument(
+            'bbbbbbbb-bbbb-4bbb-8bbb-000000009102',
+            $company,
+            MarketplaceType::WILDBERRIES,
+            'sales_report',
+        );
+        $existingRaw->setPeriodFrom($businessDate);
+        $existingRaw->setPeriodTo($businessDate);
+        $existingRaw->setApiEndpoint('wildberries::finance-sales-reports-detailed');
+        $existingRaw->setRawData([['rrdId' => 1]]);
+        $existingRaw->setRecordsCount(1);
+        $this->setRawDocumentProcessingStatus($existingRaw, PipelineStatus::RUNNING);
+        $this->em->persist($existingRaw);
+        $this->em->flush();
+
+        $this->swapWbClient([new MockResponse('[{"rrdId":2}]', ['http_code' => 200])]);
+
+        $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
+
+        $this->expectException(UnrecoverableMessageHandlingException::class);
+        try {
+            $handler(new SyncWbFinancialReportDayMessage(
+                companyId: $company->getId(),
+                connectionId: $connection->getId(),
+                businessDate: '2026-05-19',
+                mode: FinancialReportSyncMode::MANUAL->value,
+                forceRefresh: true,
+            ));
+        } finally {
+            $status = $this->findStatus($connection->getId(), $company->getId(), '2026-05-19');
+            self::assertNotNull($status);
+            self::assertSame(FinancialReportSyncStatus::CONFLICT, $status->getStatus());
+
+            $error = $this->findLastError($status->getId());
+            self::assertNotNull($error);
+            self::assertSame('App\Marketplace\Exception\WbRawDocumentRefreshConflictException', $error->getErrorClass());
+        }
+    }
+
+    private function createCompany(int $index): Company
+    {
+        $user = UserBuilder::aUser()->withIndex($index)->build();
+        $company = CompanyBuilder::aCompany()->withIndex($index)->withOwner($user)->build();
+        $this->em->persist($user);
+        $this->em->persist($company);
+        $this->em->flush();
+
+        return $company;
+    }
+
+    private function createWbSellerConnection(Company $company, int $suffix): MarketplaceConnection
+    {
+        $connection = new MarketplaceConnection(
+            sprintf('aaaaaaaa-aaaa-4aaa-8aaa-%012d', $suffix),
+            $company,
+            MarketplaceType::WILDBERRIES,
+            MarketplaceConnectionType::SELLER,
+        );
+        $connection->setApiKey('wb-test-token')->setIsActive(true);
+
+        $this->em->persist($connection);
+        $this->em->flush();
+
+        return $connection;
+    }
+
+    /** @param list<MockResponse> $responses */
+    private function swapWbClient(array $responses): void
+    {
+        $client = new WbFinanceSalesReportClient(
+            new MockHttpClient($responses),
+            new MockClock('2026-05-20 12:00:00 UTC'),
+        );
+
+        self::getContainer()->set(WbFinanceSalesReportClient::class, $client);
+    }
+
+
+    private function setRawDocumentProcessingStatus(MarketplaceRawDocument $document, PipelineStatus $status): void
+    {
+        $reflection = new \ReflectionProperty($document, 'processingStatus');
+        $reflection->setAccessible(true);
+        $reflection->setValue($document, $status);
+    }
+
+    private function findStatus(string $connectionId, string $companyId, string $date): ?MarketplaceFinancialReportSyncStatus
+    {
+        return $this->em->getRepository(MarketplaceFinancialReportSyncStatus::class)->findOneBy([
+            'connectionId' => $connectionId,
+            'companyId' => $companyId,
+            'businessDate' => new \DateTimeImmutable($date),
+            'reportType' => 'sales_report',
+        ]);
+    }
+
+    private function findLastError(string $statusId): ?MarketplaceFinancialReportSyncError
+    {
+        return $this->em->getRepository(MarketplaceFinancialReportSyncError::class)->findOneBy([
+            'syncStatusId' => $statusId,
+        ], ['createdAt' => 'DESC']);
+    }
+}


### PR DESCRIPTION
### Motivation

- Implement a dedicated message handler to fetch and process Wildberries daily financial reports with proper locking and status tracking.
- Provide a repository helper to look up marketplace connections by id and company for worker/handler usage.
- Add unit tests to cover success/error wiring and critical failure/retry flows for the new handler.

### Description

- Adds `SyncWbFinancialReportDayHandler` which acquires a lock, validates the `MarketplaceConnection`, fetches day report rows via `WbFinanceSalesReportClient`, persists raw documents via `WbFinancialReportReconciliationService`, updates sync statuses via `WbFinancialReportSyncStatusUpdater`, and dispatches `ProcessDayReportMessage` for processing. 
- Implements detailed error handling mapping marketplace exceptions to status updates and Messenger semantics, including rate-limiting retries, auth failures, temporary API errors, raw-document refresh conflicts and non-retryable payload/response errors. 
- Introduces constants `REPORT_TYPE` and `API_ENDPOINT` and uses a 10-minute lock TTL to avoid concurrent processing of the same day. 
- Updates `MarketplaceConnectionRepository` to add `declare(strict_types=1)` and a new `findByIdAndCompany(string $connectionId, Company $company): ?MarketplaceConnection` method used by the handler. 
- Adds `SyncWbFinancialReportDayHandlerTest` unit tests which mock the Wildberries client to assert service wiring, retryable temporary API errors, and raw-document refresh conflict handling.

### Testing

- Ran the new unit test class with `vendor/bin/phpunit --filter SyncWbFinancialReportDayHandlerTest` and the tests passed. 
- Exercised `testTemporaryApiExceptionMarksRetryableFailedAndStoresError` which verifies retryable error status recording and raised `RecoverableMessageHandlingException`. 
- Exercised `testConflictMarksConflictAndThrowsUnrecoverable` which verifies conflict status recording and raised `UnrecoverableMessageHandlingException`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e9a6bffc883239210d518f3f9eb94)