### PR TITLE
Nightly WB sync: dispatch financial report day messages and filter active seller connections

### DIFF
--- a/site/src/Marketplace/Command/MarketplaceNightlySyncCommand.php
+++ b/site/src/Marketplace/Command/MarketplaceNightlySyncCommand.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Marketplace\Command;
 
+use App\Marketplace\Application\Service\WbFinancialReportPeriodResolver;
+use App\Marketplace\Enum\FinancialReportSyncMode;
 use App\Marketplace\Infrastructure\Query\ActiveWbConnectionsQuery;
-use App\Marketplace\Message\SyncWbReportMessage;
+use App\Marketplace\Message\SyncWbFinancialReportDayMessage;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -21,8 +23,8 @@ use Symfony\Component\Messenger\MessageBusInterface;
  *
  * Команда тонкая: получает список активных WB-подключений через DBAL Query,
  * для каждого отправляет Message в шину Messenger.
- * Вся логика загрузки — в SyncWbReportHandler (Worker).
- * Обработка данных — вручную через UI или отдельной командой.
+ * Вся логика загрузки — в SyncWbFinancialReportDayHandler (Worker).
+ * Загрузка выполняется в SyncWbFinancialReportDayHandler; после успешной загрузки raw document handler отправляет ProcessDayReportMessage в async_pipeline.
  */
 #[AsCommand(
     name: 'app:marketplace:wb-daily-sync',
@@ -32,6 +34,7 @@ final class MarketplaceNightlySyncCommand extends Command
 {
     public function __construct(
         private readonly ActiveWbConnectionsQuery $connectionsQuery,
+        private readonly WbFinancialReportPeriodResolver $periodResolver,
         private readonly MessageBusInterface $messageBus,
         private readonly LoggerInterface $logger,
     ) {
@@ -50,6 +53,7 @@ final class MarketplaceNightlySyncCommand extends Command
             return Command::SUCCESS;
         }
 
+        $businessDate = $this->periodResolver->yesterday()->format('Y-m-d');
         $dispatched = 0;
 
         foreach ($connections as $row) {
@@ -57,7 +61,13 @@ final class MarketplaceNightlySyncCommand extends Command
             $connectionId = (string) $row['id'];
 
             $this->messageBus->dispatch(
-                new SyncWbReportMessage($companyId, $connectionId),
+                new SyncWbFinancialReportDayMessage(
+                    $companyId,
+                    $connectionId,
+                    $businessDate,
+                    FinancialReportSyncMode::DAILY->value,
+                    false,
+                ),
             );
 
             $dispatched++;
@@ -65,6 +75,8 @@ final class MarketplaceNightlySyncCommand extends Command
             $this->logger->info('Dispatched WB sync message', [
                 'company_id'    => $companyId,
                 'connection_id' => $connectionId,
+                'business_date' => $businessDate,
+                'mode'          => FinancialReportSyncMode::DAILY->value,
             ]);
         }
 

--- a/site/src/Marketplace/Infrastructure/Query/ActiveWbConnectionsQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/ActiveWbConnectionsQuery.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Marketplace\Infrastructure\Query;
 
 use Doctrine\DBAL\Connection;
@@ -24,8 +26,12 @@ final class ActiveWbConnectionsQuery
              FROM marketplace_connections mc
              WHERE mc.marketplace = :marketplace
                AND mc.is_active = true
+               AND mc.connection_type = :connectionType
              ORDER BY mc.created_at ASC',
-            ['marketplace' => 'wildberries']
+            [
+                'marketplace' => 'wildberries',
+                'connectionType' => 'seller',
+            ]
         );
     }
 }


### PR DESCRIPTION
### Motivation
- Switch the nightly WB ingestion to the new financial-report pipeline that requires a business date and sync mode.
- Avoid dispatching tasks for non-seller connections by tightening the DB query for active WB connections.

### Description
- Replaced `SyncWbReportMessage` with `SyncWbFinancialReportDayMessage` and added `WbFinancialReportPeriodResolver` to compute `businessDate` (yesterday) and pass `FinancialReportSyncMode::DAILY` and the `false` flag when dispatching messages.
- Updated logging to include `business_date` and `mode` for dispatched messages.
- Added `declare(strict_types=1)` to `ActiveWbConnectionsQuery` and restricted the query to `connection_type = 'seller'` while returning associative arrays of `id` and `company_id`.
- Adjusted imports and command PHPDoc to reference the new handler and async pipeline flow.

### Testing
- Ran the project's automated test suite and static checks; all tests and linters passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ea770c8288323a36f7442866e730b)