### PR TITLE
Add WbFinancialReportSyncPlanner and supporting query/repository changes for WB sync planning

### DIFF
--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlanner.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlanner.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\Service;
+
+use App\Marketplace\Enum\FinancialReportSyncMode;
+use App\Marketplace\Enum\FinancialReportSyncStatus;
+use App\Marketplace\Infrastructure\Query\ActiveWbConnectionsQuery;
+use App\Marketplace\Message\SyncWbFinancialReportDayMessage;
+use App\Marketplace\Repository\MarketplaceFinancialReportSyncStatusRepository;
+use DateTimeImmutable;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class WbFinancialReportSyncPlanner
+{
+    private const REPORT_TYPE = 'sales_report';
+
+    public function __construct(
+        private readonly ActiveWbConnectionsQuery $activeWbConnectionsQuery,
+        private readonly WbFinancialReportPeriodResolver $periodResolver,
+        private readonly MarketplaceFinancialReportSyncStatusRepository $syncStatusRepository,
+        private readonly MessageBusInterface $messageBus,
+    ) {}
+
+    public function planDaily(?string $companyId = null, ?string $connectionId = null, bool $force = false): int
+    {
+        $day = $this->periodResolver->yesterday();
+
+        return $this->planForDays(
+            $this->activeWbConnectionsQuery->execute($companyId, $connectionId),
+            [$day],
+            FinancialReportSyncMode::DAILY,
+            $force,
+            static function (?FinancialReportSyncStatus $status) use ($force): bool {
+                if (\in_array($status, [FinancialReportSyncStatus::LOADING, FinancialReportSyncStatus::PROCESSING], true)) {
+                    return false;
+                }
+
+                if ($force) {
+                    return true;
+                }
+
+                return null === $status
+                    || !\in_array($status, [FinancialReportSyncStatus::SUCCESS, FinancialReportSyncStatus::EMPTY], true);
+            },
+        );
+    }
+
+    public function planRefresh14Days(?string $companyId = null, ?string $connectionId = null): int
+    {
+        return $this->planForDays(
+            $this->activeWbConnectionsQuery->execute($companyId, $connectionId),
+            $this->periodResolver->last14Days(),
+            FinancialReportSyncMode::REFRESH_14D,
+            true,
+            static fn (?FinancialReportSyncStatus $status): bool => !\in_array($status, [
+                FinancialReportSyncStatus::LOADING,
+                FinancialReportSyncStatus::PROCESSING,
+            ], true),
+        );
+    }
+
+    public function planMissing(?string $companyId = null, ?string $connectionId = null, int $maxDays = 14): int
+    {
+        if ($maxDays <= 0) {
+            return 0;
+        }
+
+        $dispatched = 0;
+        $days = $this->periodResolver->daysBetween($this->periodResolver->currentYearStart(), $this->periodResolver->yesterday());
+
+        foreach ($this->activeWbConnectionsQuery->execute($companyId, $connectionId) as $connection) {
+            $scheduledDays = $this->syncStatusRepository->findMissingOrRetryDueDays(
+                $connection['connection_id'],
+                $connection['company_id'],
+                self::REPORT_TYPE,
+                $days,
+                $maxDays,
+            );
+
+            foreach ($scheduledDays as $day) {
+                $this->dispatch($connection['company_id'], $connection['connection_id'], $day, FinancialReportSyncMode::MISSING, false);
+                ++$dispatched;
+            }
+        }
+
+        return $dispatched;
+    }
+
+    public function planInitial(?string $companyId = null, ?string $connectionId = null, ?DateTimeImmutable $startFrom = null): int
+    {
+        $start = $startFrom ?? $this->periodResolver->currentYearStart();
+        $days = $this->periodResolver->daysBetween($start, $this->periodResolver->yesterday());
+
+        return $this->planForDays(
+            $this->activeWbConnectionsQuery->execute($companyId, $connectionId),
+            $days,
+            FinancialReportSyncMode::INITIAL,
+            false,
+            static fn (?FinancialReportSyncStatus $status): bool => null === $status
+                || FinancialReportSyncStatus::FAILED === $status,
+        );
+    }
+
+    /** @param list<array{id: string, company_id: string, connection_id: string}> $connections
+     * @param list<DateTimeImmutable> $days
+     * @param callable(?FinancialReportSyncStatus): bool $shouldDispatch
+     */
+    private function planForDays(array $connections, array $days, FinancialReportSyncMode $mode, bool $forceRefresh, callable $shouldDispatch): int
+    {
+        $dispatched = 0;
+
+        foreach ($connections as $connection) {
+            foreach ($days as $day) {
+                $status = $this->syncStatusRepository->findStatusEnumByDay(
+                    $connection['connection_id'],
+                    $connection['company_id'],
+                    $day,
+                    self::REPORT_TYPE,
+                );
+
+                if (!$shouldDispatch($status)) {
+                    continue;
+                }
+
+                $this->dispatch($connection['company_id'], $connection['connection_id'], $day, $mode, $forceRefresh);
+                ++$dispatched;
+            }
+        }
+
+        return $dispatched;
+    }
+
+    private function dispatch(string $companyId, string $connectionId, DateTimeImmutable $day, FinancialReportSyncMode $mode, bool $forceRefresh): void
+    {
+        $this->messageBus->dispatch(new SyncWbFinancialReportDayMessage(
+            $companyId,
+            $connectionId,
+            $day->format('Y-m-d'),
+            $mode->value,
+            $forceRefresh,
+        ));
+    }
+}

--- a/site/src/Marketplace/Command/MarketplaceNightlySyncCommand.php
+++ b/site/src/Marketplace/Command/MarketplaceNightlySyncCommand.php
@@ -58,7 +58,7 @@ final class MarketplaceNightlySyncCommand extends Command
 
         foreach ($connections as $row) {
             $companyId    = (string) $row['company_id'];
-            $connectionId = (string) $row['id'];
+            $connectionId = (string) ($row['connection_id'] ?? $row['id']);
 
             $this->messageBus->dispatch(
                 new SyncWbFinancialReportDayMessage(

--- a/site/src/Marketplace/Infrastructure/Query/ActiveWbConnectionsQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/ActiveWbConnectionsQuery.php
@@ -17,21 +17,31 @@ final class ActiveWbConnectionsQuery
     ) {}
 
     /**
-     * @return array<int, array{id: string, company_id: string}>
+     * @return list<array{id: string, connection_id: string, company_id: string}>
      */
-    public function execute(): array
+    public function execute(?string $companyId = null, ?string $connectionId = null): array
     {
-        return $this->connection->fetchAllAssociative(
-            'SELECT mc.id, mc.company_id
-             FROM marketplace_connections mc
-             WHERE mc.marketplace = :marketplace
-               AND mc.is_active = true
-               AND mc.connection_type = :connectionType
-             ORDER BY mc.created_at ASC',
-            [
-                'marketplace' => 'wildberries',
-                'connectionType' => 'seller',
-            ]
-        );
+        $qb = $this->connection->createQueryBuilder()
+            ->select('mc.id', 'mc.id AS connection_id', 'mc.company_id')
+            ->from('marketplace_connections', 'mc')
+            ->where('mc.marketplace = :marketplace')
+            ->andWhere('mc.is_active = true')
+            ->andWhere('mc.connection_type = :connectionType')
+            ->setParameter('marketplace', 'wildberries')
+            ->setParameter('connectionType', 'seller')
+            ->orderBy('mc.created_at', 'ASC');
+
+        if (null !== $companyId) {
+            $qb->andWhere('mc.company_id = :companyId')->setParameter('companyId', $companyId);
+        }
+
+        if (null !== $connectionId) {
+            $qb->andWhere('mc.id = :connectionId')->setParameter('connectionId', $connectionId);
+        }
+
+        /** @var list<array{id: string, connection_id: string, company_id: string}> $result */
+        $result = $qb->executeQuery()->fetchAllAssociative();
+
+        return $result;
     }
 }

--- a/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepository.php
+++ b/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Marketplace\Repository;
 
 use App\Marketplace\Entity\MarketplaceFinancialReportSyncStatus;
+use App\Marketplace\Enum\FinancialReportSyncStatus;
 use App\Marketplace\Enum\MarketplaceType;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -28,8 +29,7 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
         string $companyId,
         \DateTimeImmutable $businessDate,
         string $reportType,
-    ): ?MarketplaceFinancialReportSyncStatus
-    {
+    ): ?MarketplaceFinancialReportSyncStatus {
         Assert::uuid($connectionId);
         Assert::uuid($companyId);
 
@@ -45,6 +45,118 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
             ->setMaxResults(1)
             ->getQuery()
             ->getOneOrNullResult();
+    }
+
+    public function findStatusEnumByDay(
+        string $connectionId,
+        string $companyId,
+        \DateTimeImmutable $businessDate,
+        string $reportType,
+    ): ?FinancialReportSyncStatus {
+        Assert::uuid($connectionId);
+        Assert::uuid($companyId);
+
+        $status = $this->createQueryBuilder('s')
+            ->select('s.status')
+            ->where('s.connectionId = :connectionId')
+            ->andWhere('s.companyId = :companyId')
+            ->andWhere('s.businessDate = :businessDate')
+            ->andWhere('s.reportType = :reportType')
+            ->setParameter('connectionId', $connectionId)
+            ->setParameter('companyId', $companyId)
+            ->setParameter('businessDate', $businessDate)
+            ->setParameter('reportType', $reportType)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        if (null === $status) {
+            return null;
+        }
+
+        if (is_array($status)) {
+            $status = $status['status'] ?? null;
+        }
+
+        if ($status instanceof FinancialReportSyncStatus) {
+            return $status;
+        }
+
+        return is_string($status) ? FinancialReportSyncStatus::from($status) : null;
+    }
+
+    /**
+     * @param list<\DateTimeImmutable> $days
+     *
+     * @return list<\DateTimeImmutable>
+     */
+    public function findMissingOrRetryDueDays(
+        string $connectionId,
+        string $companyId,
+        string $reportType,
+        array $days,
+        int $maxDays,
+    ): array {
+        Assert::uuid($connectionId);
+        Assert::uuid($companyId);
+
+        if ([] === $days || $maxDays <= 0) {
+            return [];
+        }
+
+        $statuses = $this->createQueryBuilder('s')
+            ->select('s.businessDate, s.status, s.nextRetryAt')
+            ->where('s.connectionId = :connectionId')
+            ->andWhere('s.companyId = :companyId')
+            ->andWhere('s.reportType = :reportType')
+            ->andWhere('s.businessDate IN (:days)')
+            ->setParameter('connectionId', $connectionId)
+            ->setParameter('companyId', $companyId)
+            ->setParameter('reportType', $reportType)
+            ->setParameter('days', $days)
+            ->getQuery()
+            ->getArrayResult();
+
+        $byDay = [];
+        foreach ($statuses as $row) {
+            $date = $row['businessDate'];
+            if ($date instanceof \DateTimeImmutable) {
+                $byDay[$date->format('Y-m-d')] = [
+                    'status' => $row['status'],
+                    'nextRetryAt' => $row['nextRetryAt'] ?? null,
+                ];
+            }
+        }
+
+        $now = new \DateTimeImmutable();
+        $result = [];
+        foreach ($days as $day) {
+            if (count($result) >= $maxDays) {
+                break;
+            }
+
+            $existing = $byDay[$day->format('Y-m-d')] ?? null;
+            if (null === $existing) {
+                $result[] = $day;
+                continue;
+            }
+
+            $status = $existing['status'];
+            if (is_string($status)) {
+                $status = FinancialReportSyncStatus::from($status);
+            }
+
+            if (FinancialReportSyncStatus::FAILED !== $status) {
+                continue;
+            }
+
+            $nextRetryAt = $existing['nextRetryAt'];
+            if (null === $nextRetryAt || ($nextRetryAt instanceof \DateTimeInterface && $nextRetryAt <= $now)) {
+                $result[] = $day;
+            }
+        }
+
+        return $result;
     }
 
     public function findOrCreateForDay(

--- a/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Application\Service;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Application\Service\WbFinancialReportPeriodResolver;
+use App\Marketplace\Application\Service\WbFinancialReportSyncPlanner;
+use App\Marketplace\Entity\MarketplaceFinancialReportSyncStatus;
+use App\Marketplace\Enum\FinancialReportSyncMode;
+use App\Marketplace\Enum\FinancialReportSyncStatus;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Infrastructure\Query\ActiveWbConnectionsQuery;
+use App\Marketplace\Message\SyncWbFinancialReportDayMessage;
+use App\Marketplace\Repository\MarketplaceFinancialReportSyncStatusRepository;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class WbFinancialReportSyncPlannerTest extends IntegrationTestCase
+{
+    private const REPORT_TYPE = 'sales_report';
+
+    private ActiveWbConnectionsQuery $connectionsQuery;
+    private MarketplaceFinancialReportSyncStatusRepository $statusRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->connectionsQuery = self::getContainer()->get(ActiveWbConnectionsQuery::class);
+        $this->statusRepository = self::getContainer()->get(MarketplaceFinancialReportSyncStatusRepository::class);
+    }
+
+    public function testActiveWbConnectionsQueryReturnsLegacyAndNewConnectionKeys(): void
+    {
+        [$companyId, $connectionId] = $this->seedActiveConnection();
+
+        $rows = $this->connectionsQuery->execute($companyId, $connectionId);
+
+        self::assertCount(1, $rows);
+        self::assertSame($connectionId, $rows[0]['id']);
+        self::assertSame($connectionId, $rows[0]['connection_id']);
+        self::assertSame($companyId, $rows[0]['company_id']);
+    }
+
+    public function testPlanDailyWithoutForceSkipsSuccessAndDispatchesMissing(): void
+    {
+        [$companyId, $connectionId] = $this->seedActiveConnection();
+        $day = new \DateTimeImmutable('2026-05-20 00:00:00 Europe/Moscow');
+        $this->persistStatus($companyId, $connectionId, $day, FinancialReportSyncStatus::SUCCESS);
+
+        $bus = new InMemoryMessageBus();
+        $planner = $this->planner($bus, new \DateTimeImmutable('2026-05-21 00:00:00 Europe/Moscow'));
+
+        self::assertSame(0, $planner->planDaily($companyId, $connectionId, false));
+
+        $otherConnectionId = '44444444-4444-4444-4444-444444444444';
+        $this->seedConnectionForExistingCompany($companyId, $otherConnectionId);
+
+        self::assertSame(1, $planner->planDaily($companyId, $otherConnectionId, false));
+    }
+
+    public function testPlanDailyWithForceDispatchesSuccessEmptyButNotInFlight(): void
+    {
+        [$companyIdA, $connectionIdA] = $this->seedActiveConnection('11111111-1111-1111-1111-111111111111', 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa');
+        [$companyIdB, $connectionIdB] = $this->seedActiveConnection('22222222-2222-2222-2222-222222222222', 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb');
+        [$companyIdC, $connectionIdC] = $this->seedActiveConnection('33333333-3333-3333-3333-333333333333', 'cccccccc-cccc-4ccc-8ccc-cccccccccccc');
+
+        $day = new \DateTimeImmutable('2026-05-20 00:00:00 Europe/Moscow');
+        $this->persistStatus($companyIdA, $connectionIdA, $day, FinancialReportSyncStatus::SUCCESS);
+        $this->persistStatus($companyIdB, $connectionIdB, $day, FinancialReportSyncStatus::EMPTY);
+        $this->persistStatus($companyIdC, $connectionIdC, $day, FinancialReportSyncStatus::LOADING);
+
+        $bus = new InMemoryMessageBus();
+        $planner = $this->planner($bus, new \DateTimeImmutable('2026-05-21 00:00:00 Europe/Moscow'));
+
+        $count = $planner->planDaily(force: true);
+
+        self::assertSame(2, $count);
+        self::assertCount(2, $bus->messages);
+        self::assertTrue($bus->messages[0]->forceRefresh);
+        self::assertTrue($bus->messages[1]->forceRefresh);
+    }
+
+    public function testPlanRefresh14DaysSkipsInFlightAndUsesForceRefresh(): void
+    {
+        [$companyId, $connectionId] = $this->seedActiveConnection();
+        $dayInFlight = new \DateTimeImmutable('2026-05-19');
+        $this->persistStatus($companyId, $connectionId, $dayInFlight, FinancialReportSyncStatus::LOADING);
+
+        $bus = new InMemoryMessageBus();
+        $planner = $this->planner($bus, new \DateTimeImmutable('2026-05-21 12:00:00 Europe/Moscow'));
+
+        $count = $planner->planRefresh14Days($companyId, $connectionId);
+        self::assertGreaterThan(0, $count);
+
+        foreach ($bus->messages as $message) {
+            self::assertTrue($message->forceRefresh);
+            self::assertNotSame('2026-05-19', $message->businessDate);
+        }
+    }
+
+    public function testPlanMissingDispatchesRetryDueAndMissingWithMaxDaysLimit(): void
+    {
+        [$companyId, $connectionId] = $this->seedActiveConnection();
+
+        $bus = new InMemoryMessageBus();
+        $planner = $this->planner($bus, new \DateTimeImmutable('2026-01-05 12:00:00 Europe/Moscow'));
+
+        $this->persistStatus($companyId, $connectionId, new \DateTimeImmutable('2026-01-01'), FinancialReportSyncStatus::SUCCESS);
+        $this->persistStatus($companyId, $connectionId, new \DateTimeImmutable('2026-01-02'), FinancialReportSyncStatus::FAILED, null);
+        $this->persistStatus($companyId, $connectionId, new \DateTimeImmutable('2026-01-03'), FinancialReportSyncStatus::FAILED, new \DateTimeImmutable('+1 day'));
+        // 2026-01-04 status missing
+
+        $count = $planner->planMissing($companyId, $connectionId, 2);
+
+        self::assertSame(2, $count);
+        self::assertCount(2, $bus->messages);
+        self::assertSame(['2026-01-02', '2026-01-04'], array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->businessDate, $bus->messages));
+    }
+
+    private function planner(InMemoryMessageBus $bus, \DateTimeImmutable $clockNow): WbFinancialReportSyncPlanner
+    {
+        $resolver = new WbFinancialReportPeriodResolver(new MockClock($clockNow));
+
+        return new WbFinancialReportSyncPlanner(
+            $this->connectionsQuery,
+            $resolver,
+            $this->statusRepository,
+            $bus,
+        );
+    }
+
+    private function persistStatus(
+        string $companyId,
+        string $connectionId,
+        \DateTimeImmutable $day,
+        FinancialReportSyncStatus $status,
+        ?\DateTimeImmutable $nextRetryAt = null,
+    ): void {
+        $entity = new MarketplaceFinancialReportSyncStatus(
+            Uuid::uuid7()->toString(),
+            $companyId,
+            $connectionId,
+            MarketplaceType::WILDBERRIES,
+            self::REPORT_TYPE,
+            'endpoint',
+            $day,
+        );
+
+        match ($status) {
+            FinancialReportSyncStatus::SUCCESS => $entity->markSuccess(),
+            FinancialReportSyncStatus::EMPTY => $entity->markEmpty(),
+            FinancialReportSyncStatus::LOADING => $entity->markLoading(FinancialReportSyncMode::DAILY),
+            FinancialReportSyncStatus::PROCESSING => $entity->markProcessing(),
+            FinancialReportSyncStatus::FAILED => $entity->markFailedRetryable('TestException', 'failed', 500, null, $nextRetryAt),
+            default => null,
+        };
+
+        $this->statusRepository->save($entity);
+        $this->em->flush();
+    }
+
+    /** @return array{0:string,1:string} */
+    private function seedActiveConnection(?string $companyId = null, ?string $connectionId = null): array
+    {
+        $cid = $companyId ?? '11111111-1111-1111-1111-111111111111';
+        $connection = $connectionId ?? '22222222-2222-4222-8222-222222222222';
+
+        $existing = $this->em->find(Company::class, $cid);
+        if (!$existing instanceof Company) {
+            $company = CompanyBuilder::aCompany()->withId($cid)->build();
+            $this->em->persist($company->getOwner());
+            $this->em->persist($company);
+            $this->em->flush();
+        }
+
+        $this->seedConnectionForExistingCompany($cid, $connection);
+
+        return [$cid, $connection];
+    }
+
+    private function seedConnectionForExistingCompany(string $companyId, string $connectionId): void
+    {
+        $this->em->getConnection()->insert('marketplace_connections', [
+            'id' => $connectionId,
+            'company_id' => $companyId,
+            'marketplace' => 'wildberries',
+            'connection_type' => 'seller',
+            'api_key' => 'encrypted-key',
+            'is_active' => true,
+            'created_at' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
+            'updated_at' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
+        ]);
+    }
+}
+
+final class InMemoryMessageBus implements MessageBusInterface
+{
+    /** @var list<SyncWbFinancialReportDayMessage> */
+    public array $messages = [];
+
+    public function dispatch(object $message, array $stamps = []): Envelope
+    {
+        if ($message instanceof SyncWbFinancialReportDayMessage) {
+            $this->messages[] = $message;
+        }
+
+        return new Envelope($message, $stamps);
+    }
+}


### PR DESCRIPTION
### Motivation

- Centralize and improve planning of Wildberries financial report syncs (daily, initial, 14-day refresh, and missing days) and enable filtering by company/connection and retry logic.

### Description

- Add `WbFinancialReportSyncPlanner` with `planDaily`, `planRefresh14Days`, `planMissing`, `planInitial` and internal `planForDays`/`dispatch`, which dispatches `SyncWbFinancialReportDayMessage` with appropriate `FinancialReportSyncMode` and `forceRefresh` behavior.
- Update `ActiveWbConnectionsQuery::execute` to return `connection_id` (legacy compatibility with `id`) and accept optional `companyId` and `connectionId` filters while keeping ordering by `created_at`.
- Adjust `MarketplaceNightlySyncCommand` to read the new/legacy connection key via `($row['connection_id'] ?? $row['id'])` to remain compatible with the query change.
- Extend `MarketplaceFinancialReportSyncStatusRepository` with `findStatusEnumByDay` (returns `FinancialReportSyncStatus` enum or `null`) and `findMissingOrRetryDueDays` (computes missing days and retry-due failed days up to a `maxDays` limit) and add related type handling.
- Add `WbFinancialReportSyncPlannerTest` unit test covering connection query shape, `planDaily` (with and without `force`), `planRefresh14Days`, and `planMissing`, and include an `InMemoryMessageBus` test helper.

### Testing

- Added and executed unit test `WbFinancialReportSyncPlannerTest`, which verifies planning behavior and message dispatching, and it passed.
- Repository and query changes are covered by the new tests and they passed in the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ec00bfb5083239640649a35a21148)