### PR TITLE
Add WB financial report first-available-date resolver and local rate limit guard

### DIFF
--- a/site/src/Marketplace/Application/Service/WbFinancialReportFirstAvailableResolver.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportFirstAvailableResolver.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\Service;
+
+use App\Marketplace\Enum\FinancialReportSyncStatus;
+use App\Marketplace\Exception\MarketplaceRateLimitException;
+use App\Marketplace\Infrastructure\Api\Wildberries\WbFinanceSalesReportClient;
+use App\Marketplace\Repository\MarketplaceFinancialReportSyncStatusRepository;
+
+final class WbFinancialReportFirstAvailableResolver
+{
+    public const PHASE_FULL_RANGE = 'full_range';
+    public const PHASE_MONTH_SCAN = 'month_scan';
+    public const PHASE_DAY_SCAN = 'day_scan';
+
+    private const REPORT_TYPE = 'sales_report';
+    private const FLOOR_DATE = '2024-01-29';
+
+    public function __construct(
+        private readonly WbFinancialReportPeriodResolver $periodResolver,
+        private readonly MarketplaceFinancialReportSyncStatusRepository $syncStatusRepository,
+        private readonly WbFinanceSalesReportClient $salesReportClient,
+    ) {}
+
+    public function resolve(
+        string $connectionId,
+        string $companyId,
+        string $apiKey,
+        ?string $phase = null,
+        ?\DateTimeImmutable $probeFrom = null,
+        ?\DateTimeImmutable $probeTo = null,
+    ): WbFinancialReportFirstAvailableResolverResult {
+        $yearStart = $this->periodResolver->currentYearStart();
+        $yesterday = $this->periodResolver->yesterday();
+
+        if ($yearStart > $yesterday) {
+            return WbFinancialReportFirstAvailableResolverResult::noData();
+        }
+
+        if (null === $phase) {
+            $localFirstDate = $this->findLocalFirstKnownDataDateInRange($connectionId, $companyId, $yearStart, $yesterday);
+            if (null !== $localFirstDate) {
+                return WbFinancialReportFirstAvailableResolverResult::withStartDate($localFirstDate);
+            }
+
+            try {
+                if (!$this->salesReportClient->hasAnyDataForConnection($connectionId, $apiKey, $yearStart->format('Y-m-d'), $yesterday->format('Y-m-d'))) {
+                    return WbFinancialReportFirstAvailableResolverResult::noData();
+                }
+            } catch (MarketplaceRateLimitException $e) {
+                return WbFinancialReportFirstAvailableResolverResult::incomplete(self::PHASE_FULL_RANGE, $yearStart, $yesterday, $e->getRetryAfter());
+            }
+
+            return $this->firstMonthIncomplete($yearStart, $yesterday);
+        }
+
+        if (self::PHASE_FULL_RANGE === $phase) {
+            return $this->continueFullRangeProbe($connectionId, $apiKey, $probeFrom, $probeTo, $yearStart, $yesterday);
+        }
+
+        if (self::PHASE_MONTH_SCAN === $phase) {
+            return $this->continueMonthScan($connectionId, $apiKey, $probeFrom, $probeTo, $yesterday);
+        }
+
+        if (self::PHASE_DAY_SCAN === $phase) {
+            return $this->continueDayScan($connectionId, $apiKey, $probeFrom, $probeTo, $yesterday);
+        }
+
+        return WbFinancialReportFirstAvailableResolverResult::noData();
+    }
+
+    private function continueFullRangeProbe(string $connectionId, string $apiKey, ?\DateTimeImmutable $probeFrom, ?\DateTimeImmutable $probeTo, \DateTimeImmutable $yearStart, \DateTimeImmutable $yesterday): WbFinancialReportFirstAvailableResolverResult
+    {
+        if (!$probeFrom instanceof \DateTimeImmutable || !$probeTo instanceof \DateTimeImmutable || $probeFrom > $probeTo || $probeFrom > $yesterday) {
+            return WbFinancialReportFirstAvailableResolverResult::noData();
+        }
+
+        try {
+            $hasAnyData = $this->salesReportClient->hasAnyDataForConnection($connectionId, $apiKey, $probeFrom->format('Y-m-d'), $probeTo->format('Y-m-d'));
+        } catch (MarketplaceRateLimitException $e) {
+            return WbFinancialReportFirstAvailableResolverResult::incomplete(self::PHASE_FULL_RANGE, $probeFrom, $probeTo, $e->getRetryAfter());
+        }
+
+        if (!$hasAnyData) {
+            return WbFinancialReportFirstAvailableResolverResult::noData();
+        }
+
+        return $this->firstMonthIncomplete($probeFrom >= $yearStart ? $probeFrom : $yearStart, $yesterday);
+    }
+
+    private function continueMonthScan(string $connectionId, string $apiKey, ?\DateTimeImmutable $monthFrom, ?\DateTimeImmutable $monthTo, \DateTimeImmutable $yesterday): WbFinancialReportFirstAvailableResolverResult
+    {
+        if (!$monthFrom instanceof \DateTimeImmutable || !$monthTo instanceof \DateTimeImmutable || $monthFrom > $yesterday) {
+            return WbFinancialReportFirstAvailableResolverResult::noData();
+        }
+
+        try {
+            $hasMonthData = $this->salesReportClient->hasAnyDataForConnection($connectionId, $apiKey, $monthFrom->format('Y-m-d'), $monthTo->format('Y-m-d'));
+        } catch (MarketplaceRateLimitException $e) {
+            return WbFinancialReportFirstAvailableResolverResult::incomplete(self::PHASE_MONTH_SCAN, $monthFrom, $monthTo, $e->getRetryAfter());
+        }
+
+        if ($hasMonthData) {
+            return WbFinancialReportFirstAvailableResolverResult::incomplete(self::PHASE_DAY_SCAN, $monthFrom, $monthTo);
+        }
+
+        $nextMonth = $monthFrom->modify('first day of next month')->setTime(0, 0, 0);
+        if ($nextMonth > $yesterday) {
+            return WbFinancialReportFirstAvailableResolverResult::noData();
+        }
+
+        $nextMonthEnd = $nextMonth->modify('last day of this month');
+        if ($nextMonthEnd > $yesterday) {
+            $nextMonthEnd = $yesterday;
+        }
+
+        return WbFinancialReportFirstAvailableResolverResult::incomplete(self::PHASE_MONTH_SCAN, $nextMonth, $nextMonthEnd);
+    }
+
+    private function continueDayScan(string $connectionId, string $apiKey, ?\DateTimeImmutable $dayFrom, ?\DateTimeImmutable $dayTo, \DateTimeImmutable $yesterday): WbFinancialReportFirstAvailableResolverResult
+    {
+        if (!$dayFrom instanceof \DateTimeImmutable || !$dayTo instanceof \DateTimeImmutable || $dayFrom > $dayTo || $dayFrom > $yesterday) {
+            return WbFinancialReportFirstAvailableResolverResult::noData();
+        }
+
+        try {
+            $hasDayData = $this->salesReportClient->hasAnyDataForConnection($connectionId, $apiKey, $dayFrom->format('Y-m-d'), $dayFrom->format('Y-m-d'));
+        } catch (MarketplaceRateLimitException $e) {
+            return WbFinancialReportFirstAvailableResolverResult::incomplete(self::PHASE_DAY_SCAN, $dayFrom, $dayTo, $e->getRetryAfter());
+        }
+
+        if ($hasDayData) {
+            return WbFinancialReportFirstAvailableResolverResult::withStartDate($dayFrom);
+        }
+
+        $nextDay = $dayFrom->modify('+1 day')->setTime(0, 0, 0);
+        if ($nextDay > $dayTo || $nextDay > $yesterday) {
+            return WbFinancialReportFirstAvailableResolverResult::noData();
+        }
+
+        return WbFinancialReportFirstAvailableResolverResult::incomplete(self::PHASE_DAY_SCAN, $nextDay, $dayTo);
+    }
+
+    private function firstMonthIncomplete(\DateTimeImmutable $yearStart, \DateTimeImmutable $yesterday): WbFinancialReportFirstAvailableResolverResult
+    {
+        $floor = new \DateTimeImmutable(self::FLOOR_DATE);
+        $monthFrom = $yearStart >= $floor ? $yearStart : $floor;
+        if ($monthFrom > $yesterday) {
+            return WbFinancialReportFirstAvailableResolverResult::noData();
+        }
+
+        $monthTo = $monthFrom->modify('last day of this month');
+        if ($monthTo > $yesterday) {
+            $monthTo = $yesterday;
+        }
+
+        return WbFinancialReportFirstAvailableResolverResult::incomplete(self::PHASE_MONTH_SCAN, $monthFrom, $monthTo);
+    }
+
+    private function findLocalFirstKnownDataDateInRange(string $connectionId, string $companyId, \DateTimeImmutable $from, \DateTimeImmutable $to): ?\DateTimeImmutable
+    {
+        $positiveStatuses = [FinancialReportSyncStatus::SUCCESS, FinancialReportSyncStatus::RAW_LOADED, FinancialReportSyncStatus::PROCESSING];
+
+        for ($day = $from; $day <= $to; $day = $day->modify('+1 day')->setTime(0, 0, 0)) {
+            $status = $this->syncStatusRepository->findStatusEnumByDay($connectionId, $companyId, $day, self::REPORT_TYPE);
+            if (\in_array($status, $positiveStatuses, true)) {
+                return $day;
+            }
+        }
+
+        return null;
+    }
+}

--- a/site/src/Marketplace/Application/Service/WbFinancialReportFirstAvailableResolverResult.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportFirstAvailableResolverResult.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\Service;
+
+final readonly class WbFinancialReportFirstAvailableResolverResult
+{
+    private function __construct(
+        private ?\DateTimeImmutable $startDate,
+        private bool $needsRetry,
+        private ?string $phase,
+        private ?\DateTimeImmutable $nextProbeFrom,
+        private ?\DateTimeImmutable $nextProbeTo,
+        private ?int $retryAfterSeconds,
+    ) {}
+
+    public static function withStartDate(\DateTimeImmutable $startDate): self
+    {
+        return new self($startDate->setTime(0, 0, 0), false, null, null, null, null);
+    }
+
+    public static function noData(): self
+    {
+        return new self(null, false, null, null, null, null);
+    }
+
+    public static function incomplete(string $phase, \DateTimeImmutable $nextProbeFrom, \DateTimeImmutable $nextProbeTo, ?int $retryAfterSeconds = null): self
+    {
+        return new self(null, true, $phase, $nextProbeFrom->setTime(0, 0, 0), $nextProbeTo->setTime(0, 0, 0), $retryAfterSeconds);
+    }
+
+    public function hasData(): bool { return null !== $this->startDate; }
+    public function needsRetry(): bool { return $this->needsRetry; }
+    public function getStartDate(): ?\DateTimeImmutable { return $this->startDate; }
+    public function getPhase(): ?string { return $this->phase; }
+    public function getNextProbeFrom(): ?\DateTimeImmutable { return $this->nextProbeFrom; }
+    public function getNextProbeTo(): ?\DateTimeImmutable { return $this->nextProbeTo; }
+    public function getRetryAfterSeconds(): ?int { return $this->retryAfterSeconds; }
+}

--- a/site/src/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClient.php
+++ b/site/src/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClient.php
@@ -213,6 +213,16 @@ final readonly class WbFinanceSalesReportClient
         throw new MarketplaceTemporaryApiException('WB API unexpected status.', $statusCode, $excerpt, '', '');
     }
 
+
+    public function hasAnyDataForConnection(string $connectionId, string $apiKey, string $dateFrom, string $dateTo): bool
+    {
+        if (!$this->rateLimiter->acquire($connectionId)) {
+            throw new MarketplaceRateLimitException(429, 'Local WB finance rate limit exceeded.', $dateFrom, $dateTo, self::WB_MIN_DELAY_SECONDS);
+        }
+
+        return $this->hasAnyData($apiKey, $dateFrom, $dateTo);
+    }
+
     public function hasAnyData(string $apiKey, string $dateFrom, string $dateTo): bool
     {
         try {

--- a/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportFirstAvailableResolverTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportFirstAvailableResolverTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Application\Service;
+
+use App\Marketplace\Application\Service\WbFinanceRateLimiter;
+use App\Marketplace\Application\Service\WbFinancialReportFirstAvailableResolver;
+use App\Marketplace\Application\Service\WbFinancialReportPeriodResolver;
+use App\Marketplace\Entity\MarketplaceFinancialReportSyncStatus;
+use App\Marketplace\Enum\FinancialReportSyncMode;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Infrastructure\Api\Wildberries\WbFinanceSalesReportClient;
+use App\Marketplace\Repository\MarketplaceFinancialReportSyncStatusRepository;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
+
+final class WbFinancialReportFirstAvailableResolverTest extends IntegrationTestCase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-111111111111';
+    private const CONNECTION_ID = '22222222-2222-2222-2222-222222222222';
+
+    private MarketplaceFinancialReportSyncStatusRepository $statusRepository;
+
+    protected function setUp(): void { parent::setUp(); $this->statusRepository = self::getContainer()->get(MarketplaceFinancialReportSyncStatusRepository::class); }
+
+    public function testLocalKnownDataReturnsFirstDateAndIgnoresLoading(): void
+    {
+        $this->persistStatus('2026-01-02', static function (MarketplaceFinancialReportSyncStatus $s): void { $s->markLoading(FinancialReportSyncMode::INITIAL); });
+        $this->persistStatus('2026-01-03', static function (MarketplaceFinancialReportSyncStatus $s): void { $s->markRawLoaded('raw-id', 10, 'hash'); });
+
+        $resolver = $this->resolverWithResponses([]);
+        $result = $resolver->resolve(self::CONNECTION_ID, self::COMPANY_ID, 'token');
+
+        self::assertTrue($result->hasData());
+        self::assertSame('2026-01-03', $result->getStartDate()?->format('Y-m-d'));
+    }
+
+    public function testFullRangeFalseReturnsNoDataImmediately(): void
+    {
+        $resolver = $this->resolverWithResponses([['http_code' => 204, 'body' => '']]);
+        $result = $resolver->resolve(self::CONNECTION_ID, self::COMPANY_ID, 'token');
+
+        self::assertFalse($result->hasData());
+        self::assertFalse($result->needsRetry());
+    }
+
+
+    public function testFullRangeContinuationAfterRateLimitGoesToMonthScan(): void
+    {
+        $resolver = $this->resolverWithResponses([
+            ['http_code' => 429, 'body' => '{"error":"rate"}'],
+            ['http_code' => 200, 'body' => '[{"rrdId":1}]'],
+        ]);
+
+        $step1 = $resolver->resolve(self::CONNECTION_ID, self::COMPANY_ID, 'token');
+        self::assertTrue($step1->needsRetry());
+        self::assertSame(WbFinancialReportFirstAvailableResolver::PHASE_FULL_RANGE, $step1->getPhase());
+
+        $step2 = $resolver->resolve(
+            self::CONNECTION_ID,
+            self::COMPANY_ID,
+            'token',
+            $step1->getPhase(),
+            $step1->getNextProbeFrom(),
+            $step1->getNextProbeTo(),
+        );
+
+        self::assertTrue($step2->needsRetry());
+        self::assertSame(WbFinancialReportFirstAvailableResolver::PHASE_MONTH_SCAN, $step2->getPhase());
+    }
+
+    public function testProgressIsStatefulAndDoesNotRestartFromFullRange(): void
+    {
+        $resolver = $this->resolverWithResponses([
+            ['http_code' => 200, 'body' => '[{"rrdId":1}]'], // full range true
+            ['http_code' => 204, 'body' => ''], // jan false
+            ['http_code' => 200, 'body' => '[{"rrdId":2}]'], // feb true
+            ['http_code' => 204, 'body' => ''], // feb-01 false
+            ['http_code' => 204, 'body' => ''], // feb-02 false
+            ['http_code' => 200, 'body' => '[{"rrdId":3}]'], // feb-03 true
+        ]);
+
+        $step1 = $resolver->resolve(self::CONNECTION_ID, self::COMPANY_ID, 'token');
+        self::assertTrue($step1->needsRetry());
+        self::assertSame(WbFinancialReportFirstAvailableResolver::PHASE_MONTH_SCAN, $step1->getPhase());
+
+        $step2 = $resolver->resolve(self::CONNECTION_ID, self::COMPANY_ID, 'token', $step1->getPhase(), $step1->getNextProbeFrom(), $step1->getNextProbeTo());
+        self::assertTrue($step2->needsRetry());
+        self::assertSame(WbFinancialReportFirstAvailableResolver::PHASE_MONTH_SCAN, $step2->getPhase());
+
+        $step3 = $resolver->resolve(self::CONNECTION_ID, self::COMPANY_ID, 'token', $step2->getPhase(), $step2->getNextProbeFrom(), $step2->getNextProbeTo());
+        self::assertTrue($step3->needsRetry());
+        self::assertSame(WbFinancialReportFirstAvailableResolver::PHASE_DAY_SCAN, $step3->getPhase());
+
+        $step4 = $resolver->resolve(self::CONNECTION_ID, self::COMPANY_ID, 'token', $step3->getPhase(), $step3->getNextProbeFrom(), $step3->getNextProbeTo());
+        self::assertTrue($step4->needsRetry());
+        $step5 = $resolver->resolve(self::CONNECTION_ID, self::COMPANY_ID, 'token', $step4->getPhase(), $step4->getNextProbeFrom(), $step4->getNextProbeTo());
+        self::assertTrue($step5->needsRetry());
+
+        $step6 = $resolver->resolve(self::CONNECTION_ID, self::COMPANY_ID, 'token', $step5->getPhase(), $step5->getNextProbeFrom(), $step5->getNextProbeTo());
+        self::assertTrue($step6->hasData());
+        self::assertSame('2026-02-03', $step6->getStartDate()?->format('Y-m-d'));
+    }
+
+    public function testRateLimitedStepReturnsIncompleteWithRetryAfter(): void
+    {
+        $resolver = $this->resolverWithResponses([
+            ['http_code' => 200, 'body' => '[{"rrdId":1}]'],
+        ], true);
+
+        $step1 = $resolver->resolve(self::CONNECTION_ID, self::COMPANY_ID, 'token');
+        self::assertTrue($step1->needsRetry());
+
+        $step2 = $resolver->resolve(self::CONNECTION_ID, self::COMPANY_ID, 'token', $step1->getPhase(), $step1->getNextProbeFrom(), $step1->getNextProbeTo());
+        self::assertTrue($step2->needsRetry());
+        self::assertSame(61, $step2->getRetryAfterSeconds());
+    }
+
+    private function resolverWithResponses(array $responses, bool $withLimiter = false): WbFinancialReportFirstAvailableResolver
+    {
+        $idx = 0;
+        $http = new MockHttpClient(static function () use (&$idx, $responses): MockResponse {
+            $response = $responses[$idx] ?? ['http_code' => 500, 'body' => '{"error":"unexpected"}'];
+            ++$idx;
+
+            return new MockResponse($response['body'], ['http_code' => $response['http_code']]);
+        });
+
+        $client = new WbFinanceSalesReportClient($http, new MockClock('2026-03-15 10:00:00 Europe/Moscow'), null, $withLimiter ? $this->rateLimiter() : null);
+
+        return new WbFinancialReportFirstAvailableResolver(new WbFinancialReportPeriodResolver(new MockClock('2026-03-15 10:00:00 Europe/Moscow')), $this->statusRepository, $client);
+    }
+
+    private function persistStatus(string $day, callable $marker): void
+    {
+        $status = new MarketplaceFinancialReportSyncStatus(Uuid::uuid7()->toString(), self::COMPANY_ID, self::CONNECTION_ID, MarketplaceType::WILDBERRIES, 'sales_report', 'endpoint', new \DateTimeImmutable($day));
+        $marker($status);
+        $this->statusRepository->save($status);
+        $this->em->flush();
+    }
+
+    private function rateLimiter(): WbFinanceRateLimiter
+    {
+        return new WbFinanceRateLimiter(new RateLimiterFactory(['id' => 'wb_finance', 'policy' => 'fixed_window', 'limit' => 1, 'interval' => '1 minute'], new InMemoryStorage()));
+    }
+}

--- a/site/tests/Unit/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClientTest.php
+++ b/site/tests/Unit/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClientTest.php
@@ -122,6 +122,48 @@ final class WbFinanceSalesReportClientTest extends TestCase
         self::assertSame(1, $requestCount);
     }
 
+
+    public function testHasAnyDataForConnectionAppliesLocalRateLimitBeforeHttpRequest(): void
+    {
+        $requestCount = 0;
+        $http = new MockHttpClient(static function () use (&$requestCount): MockResponse {
+            ++$requestCount;
+            return new MockResponse('[{"rrdId":1}]', ['http_code' => 200]);
+        });
+
+        $client = new WbFinanceSalesReportClient($http, new MockClock(), null, $this->createRateLimiter());
+
+        self::assertTrue($client->hasAnyDataForConnection('same-connection', 'token', '2026-01-01', '2026-01-31'));
+
+        try {
+            $client->hasAnyDataForConnection('same-connection', 'token', '2026-01-01', '2026-01-31');
+            self::fail('Expected MarketplaceRateLimitException before HTTP request');
+        } catch (MarketplaceRateLimitException $e) {
+            self::assertSame(61, $e->getRetryAfter());
+            self::assertStringNotContainsString('token', $e->getMessage());
+        }
+
+        self::assertSame(1, $requestCount);
+    }
+
+    public function testHasAnyDataForConnectionDelegatesToHasAnyDataLogic(): void
+    {
+        $captured = [];
+        $http = new MockHttpClient(static function (string $method, string $url, array $options) use (&$captured): MockResponse {
+            $captured = [$method, $url, $options];
+
+            return new MockResponse('[{"rrdId":77}]', ['http_code' => 200]);
+        });
+
+        $client = new WbFinanceSalesReportClient($http, new MockClock());
+
+        self::assertTrue($client->hasAnyDataForConnection('connection-id', 'token', '2026-02-01', '2026-02-03'));
+        self::assertSame('POST', $captured[0]);
+        self::assertStringEndsWith('/api/finance/v1/sales-reports/detailed', $captured[1]);
+        self::assertSame(1, $captured[2]['json']['limit'] ?? null);
+        self::assertSame('2026-02-01', $captured[2]['json']['dateFrom'] ?? null);
+        self::assertSame('2026-02-03', $captured[2]['json']['dateTo'] ?? null);
+    }
     public function test204ReturnsAccumulatedRows(): void
     {
         $client = new WbFinanceSalesReportClient(new MockHttpClient([


### PR DESCRIPTION
### Motivation

- Provide a deterministic way to discover the first available sales-report date for a Wildberries connection while respecting local and remote rate limits.
- Avoid unnecessary full-range probing when local sync status already contains known data and make the probe process resumable across phases.
- Apply a local rate limiter to client entry points to prevent excessive HTTP calls and surface retry-after information to callers.

### Description

- Introduces `WbFinancialReportFirstAvailableResolver` to locate the first available `sales_report` date using a phased probe workflow (`full_range`, `month_scan`, `day_scan`) and a floor date of `2024-01-29`.
- Adds immutable result type `WbFinancialReportFirstAvailableResolverResult` to represent found start dates, incomplete probe phases with next probe ranges, and optional retry-after seconds.
- Adds `WbFinanceSalesReportClient::hasAnyDataForConnection` which enforces a local rate limit before delegating to `hasAnyData`, and throws `MarketplaceRateLimitException` with retry-after when the local limit is exceeded.
- Extends `WbFinanceSalesReportClient` tests to validate local rate limiting behavior and that `hasAnyDataForConnection` forwards correct request parameters.
- Adds comprehensive unit tests for the resolver in `WbFinancialReportFirstAvailableResolverTest` covering local-known data detection, phased probing flow, rate-limit handling, and end-to-end progression from full-range to day scan.

### Testing

- Ran `WbFinancialReportFirstAvailableResolverTest` unit tests which exercise the phased probe flow, local status detection, and rate-limit scenarios; tests passed.
- Ran updated `WbFinanceSalesReportClientTest` unit tests validating local rate limiting on pagination and `hasAnyDataForConnection` behavior; tests passed.
- All new unit tests executed successfully in the test suite (no failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ee613dc008323b678f32dd044bb0c)