### PR TITLE
Add WB financial reports sync command, planner interface, planRange and tests

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1743,8 +1743,27 @@ Payload (только scalar):
 - `mode` — `string`, значение `FinancialReportSyncMode`;
 - `forceRefresh` — `bool`.
 
+
 Ограничения payload:
 - message не содержит `apiKey`, `token`, `connection` entity или любые другие ORM-объекты.
+
+### Command: `app:marketplace:wb-financial-reports:sync`
+
+Назначение:
+- единая точка ручного/cron-планирования date-based WB financial report sync;
+- команда только планирует задачи в Messenger и не делает прямых WB HTTP-вызовов.
+
+Режимы:
+- `all`, `initial`, `daily`, `refresh14`, `missing`.
+
+Правила range/date опций:
+- `--date` и `--from/--to` разрешены только для explicit mode (`initial`, `daily`, `refresh14`);
+- `--mode=all` + `--date`/`--from`/`--to` запрещено;
+- `--mode=missing` + `--date`/`--from`/`--to` запрещено, для missing используется `--max-days`.
+
+Message/worker:
+- Message: `App\Marketplace\Message\SyncWbFinancialReportDayMessage`;
+- Worker: `App\Marketplace\MessageHandler\SyncWbFinancialReportDayHandler`.
 
 ---
 

--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -75,6 +75,7 @@ services:
     App\Catalog\Domain\ProductSkuUniquenessChecker: '@App\Catalog\Infrastructure\ProductSkuUniquenessCheckerDoctrine'
 
     App\Marketplace\Repository\MarketplaceAdvertisingCostRepositoryInterface: '@App\Marketplace\Repository\MarketplaceAdvertisingCostRepository'
+    App\Marketplace\Application\Service\WbFinancialReportSyncPlannerInterface: '@App\Marketplace\Application\Service\WbFinancialReportSyncPlanner'
     App\Marketplace\Repository\MarketplaceOrderRepositoryInterface: '@App\Marketplace\Repository\MarketplaceOrderRepository'
     App\MarketplaceAnalytics\Repository\UnitEconomyCostMappingRepositoryInterface: '@App\MarketplaceAnalytics\Repository\UnitEconomyCostMappingRepository'
     App\MarketplaceAnalytics\Repository\ListingDailySnapshotRepositoryInterface: '@App\MarketplaceAnalytics\Repository\ListingDailySnapshotRepository'

--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlanner.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlanner.php
@@ -12,7 +12,7 @@ use App\Marketplace\Repository\MarketplaceFinancialReportSyncStatusRepository;
 use DateTimeImmutable;
 use Symfony\Component\Messenger\MessageBusInterface;
 
-final class WbFinancialReportSyncPlanner
+final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlannerInterface
 {
     private const REPORT_TYPE = 'sales_report';
 
@@ -58,6 +58,41 @@ final class WbFinancialReportSyncPlanner
                 FinancialReportSyncStatus::LOADING,
                 FinancialReportSyncStatus::PROCESSING,
             ], true),
+        );
+    }
+
+
+    public function planRange(
+        DateTimeImmutable $from,
+        DateTimeImmutable $to,
+        FinancialReportSyncMode $mode,
+        ?string $companyId = null,
+        ?string $connectionId = null,
+        bool $forceRefresh = false,
+    ): int {
+        return $this->planForDays(
+            $this->activeWbConnectionsQuery->execute($companyId, $connectionId),
+            $this->periodResolver->daysBetween($from, $to),
+            $mode,
+            $forceRefresh,
+            function (?FinancialReportSyncStatus $status) use ($forceRefresh, $mode): bool {
+                if (\in_array($status, [FinancialReportSyncStatus::LOADING, FinancialReportSyncStatus::PROCESSING], true)) {
+                    return false;
+                }
+
+                if ($forceRefresh) {
+                    return true;
+                }
+
+                return match ($mode) {
+                    FinancialReportSyncMode::DAILY => null === $status
+                        || !\in_array($status, [FinancialReportSyncStatus::SUCCESS, FinancialReportSyncStatus::EMPTY], true),
+                    FinancialReportSyncMode::INITIAL => null === $status || FinancialReportSyncStatus::FAILED === $status,
+                    FinancialReportSyncMode::REFRESH_14D => true,
+                    FinancialReportSyncMode::MISSING => null === $status || FinancialReportSyncStatus::FAILED === $status,
+                    FinancialReportSyncMode::MANUAL => null === $status || FinancialReportSyncStatus::FAILED === $status,
+                };
+            },
         );
     }
 

--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlannerInterface.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlannerInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\Service;
+
+use App\Marketplace\Enum\FinancialReportSyncMode;
+use DateTimeImmutable;
+
+interface WbFinancialReportSyncPlannerInterface
+{
+    public function planDaily(?string $companyId = null, ?string $connectionId = null, bool $force = false): int;
+
+    public function planRefresh14Days(?string $companyId = null, ?string $connectionId = null): int;
+
+    public function planRange(
+        DateTimeImmutable $from,
+        DateTimeImmutable $to,
+        FinancialReportSyncMode $mode,
+        ?string $companyId = null,
+        ?string $connectionId = null,
+        bool $forceRefresh = false,
+    ): int;
+
+    public function planMissing(?string $companyId = null, ?string $connectionId = null, int $maxDays = 14): int;
+
+    public function planInitial(?string $companyId = null, ?string $connectionId = null, ?DateTimeImmutable $startFrom = null): int;
+}

--- a/site/src/Marketplace/Command/WbFinancialReportsSyncCommand.php
+++ b/site/src/Marketplace/Command/WbFinancialReportsSyncCommand.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Command;
+
+use App\Marketplace\Application\Service\WbFinancialReportPeriodResolver;
+use App\Marketplace\Application\Service\WbFinancialReportSyncPlannerInterface;
+use App\Marketplace\Enum\FinancialReportSyncMode;
+use DateTimeImmutable;
+use DomainException;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\LockableTrait;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:marketplace:wb-financial-reports:sync',
+    description: 'Планировщик синхронизации финансовых отчётов WB (daily/initial/refresh14/missing)',
+)]
+final class WbFinancialReportsSyncCommand extends Command
+{
+    use LockableTrait;
+
+    public function __construct(
+        private readonly WbFinancialReportSyncPlannerInterface $planner,
+        private readonly WbFinancialReportPeriodResolver $periodResolver,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('mode', null, InputOption::VALUE_REQUIRED, 'all|initial|daily|refresh14|missing', 'all')
+            ->addOption('company-id', null, InputOption::VALUE_OPTIONAL)
+            ->addOption('connection-id', null, InputOption::VALUE_OPTIONAL)
+            ->addOption('date', null, InputOption::VALUE_OPTIONAL, 'Дата для single-day запуска (Y-m-d)')
+            ->addOption('from', null, InputOption::VALUE_OPTIONAL, 'Начало диапазона (Y-m-d)')
+            ->addOption('to', null, InputOption::VALUE_OPTIONAL, 'Конец диапазона (Y-m-d)')
+            ->addOption('force', null, InputOption::VALUE_NONE)
+            ->addOption('max-days', null, InputOption::VALUE_OPTIONAL, 'Лимит missing-задач на connection', '10');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (!$this->lock()) {
+            return Command::SUCCESS;
+        }
+
+        $io = new SymfonyStyle($input, $output);
+
+        try {
+            $mode = $this->resolveMode((string) $input->getOption('mode'));
+            $companyId = $this->normalizeOptional((string) $input->getOption('company-id'));
+            $connectionId = $this->normalizeOptional((string) $input->getOption('connection-id'));
+            $force = (bool) $input->getOption('force');
+            $maxDays = $this->parseMaxDays((string) $input->getOption('max-days'));
+            [$from, $to] = $this->resolveRange($input);
+
+            if ('all' === $mode && null !== $from) {
+                throw new DomainException('Use explicit --mode when --date or --from/--to is provided.');
+            }
+
+            if ('missing' === $mode && null !== $from) {
+                throw new DomainException('Mode missing does not support --date or --from/--to. Use --max-days instead.');
+            }
+
+            $modesToRun = 'all' === $mode
+                ? ['initial', 'daily', 'refresh14', 'missing']
+                : [$mode];
+
+            $totalDispatched = 0;
+            $criticalErrors = [];
+
+            foreach ($modesToRun as $modeName) {
+                try {
+                    $dispatched = $this->runMode($modeName, $companyId, $connectionId, $force, $maxDays, $from, $to);
+                    $totalDispatched += $dispatched;
+                    $io->writeln(sprintf('Mode <info>%s</info>: dispatched <comment>%d</comment>', $modeName, $dispatched));
+                } catch (\Throwable $e) {
+                    $criticalErrors[] = sprintf('%s: %s', $modeName, $e->getMessage());
+                    $this->logger->error('WB financial report planning mode failed.', [
+                        'mode' => $modeName,
+                        'company_id' => $companyId,
+                        'connection_id' => $connectionId,
+                        'exception' => $e,
+                    ]);
+                    $io->warning(sprintf('Mode %s failed: %s', $modeName, $e->getMessage()));
+                }
+            }
+
+            $io->success(sprintf('Планирование завершено. Отправлено задач: %d', $totalDispatched));
+
+            if ([] !== $criticalErrors) {
+                $io->error('Критичные ошибки планирования: '.implode('; ', $criticalErrors));
+
+                return Command::FAILURE;
+            }
+
+            return Command::SUCCESS;
+        } catch (\Throwable $e) {
+            $io->error($e->getMessage());
+            $this->logger->error('WB financial report planner command failed due to configuration error.', [
+                'exception' => $e,
+            ]);
+
+            return Command::FAILURE;
+        } finally {
+            $this->release();
+        }
+    }
+
+    private function runMode(string $mode, ?string $companyId, ?string $connectionId, bool $force, int $maxDays, ?DateTimeImmutable $from, ?DateTimeImmutable $to): int
+    {
+        return match ($mode) {
+            'daily' => null !== $from
+                ? $this->planner->planRange($from, $to ?? $from, FinancialReportSyncMode::DAILY, $companyId, $connectionId, $force)
+                : $this->planner->planDaily($companyId, $connectionId, $force),
+            'initial' => null !== $from
+                ? $this->planner->planRange($from, $to ?? $from, FinancialReportSyncMode::INITIAL, $companyId, $connectionId, $force)
+                : $this->planner->planInitial($companyId, $connectionId),
+            'refresh14' => null !== $from
+                ? $this->planner->planRange($from, $to ?? $from, FinancialReportSyncMode::REFRESH_14D, $companyId, $connectionId, true)
+                : $this->planner->planRefresh14Days($companyId, $connectionId),
+            'missing' => $this->planner->planMissing($companyId, $connectionId, $maxDays),
+            default => throw new DomainException(sprintf('Unsupported mode: %s', $mode)),
+        };
+    }
+
+    private function resolveMode(string $mode): string
+    {
+        $normalized = strtolower(trim($mode));
+        if (!\in_array($normalized, ['all', 'initial', 'daily', 'refresh14', 'missing'], true)) {
+            throw new DomainException('Invalid --mode. Allowed: all|initial|daily|refresh14|missing');
+        }
+
+        return $normalized;
+    }
+
+    private function parseMaxDays(string $raw): int
+    {
+        $maxDays = (int) $raw;
+        if ($maxDays <= 0) {
+            throw new DomainException('Option --max-days must be a positive integer.');
+        }
+
+        return $maxDays;
+    }
+
+    private function resolveRange(InputInterface $input): array
+    {
+        $date = $this->normalizeOptional((string) $input->getOption('date'));
+        $from = $this->normalizeOptional((string) $input->getOption('from'));
+        $to = $this->normalizeOptional((string) $input->getOption('to'));
+
+        if (null !== $date && (null !== $from || null !== $to)) {
+            throw new DomainException('Use either --date or --from/--to, not both.');
+        }
+
+        if (null !== $date) {
+            $day = $this->periodResolver->normalizeBusinessDate($date);
+
+            return [$day, $day];
+        }
+
+        if (null === $from && null === $to) {
+            return [null, null];
+        }
+
+        if (null === $from || null === $to) {
+            throw new DomainException('Both --from and --to are required for range planning.');
+        }
+
+        $fromDate = $this->periodResolver->normalizeBusinessDate($from);
+        $toDate = $this->periodResolver->normalizeBusinessDate($to);
+
+        if ($fromDate > $toDate) {
+            throw new DomainException('Option --from must be less than or equal to --to.');
+        }
+
+        return [$fromDate, $toDate];
+    }
+
+    private function normalizeOptional(string $value): ?string
+    {
+        $trimmed = trim($value);
+
+        return '' === $trimmed ? null : $trimmed;
+    }
+}

--- a/site/tests/Unit/Marketplace/Command/WbFinancialReportsSyncCommandTest.php
+++ b/site/tests/Unit/Marketplace/Command/WbFinancialReportsSyncCommandTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Command;
+
+use App\Marketplace\Application\Service\WbFinancialReportPeriodResolver;
+use App\Marketplace\Application\Service\WbFinancialReportSyncPlannerInterface;
+use App\Marketplace\Command\WbFinancialReportsSyncCommand;
+use App\Marketplace\Enum\FinancialReportSyncMode;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class WbFinancialReportsSyncCommandTest extends TestCase
+{
+    private WbFinancialReportSyncPlannerInterface&MockObject $planner;
+
+    protected function setUp(): void
+    {
+        $this->planner = $this->createMock(WbFinancialReportSyncPlannerInterface::class);
+    }
+
+    public function testInvalidModeReturnsFailure(): void
+    {
+        $tester = $this->tester();
+
+        $code = $tester->execute(['--mode' => 'bad']);
+
+        self::assertSame(Command::FAILURE, $code);
+    }
+
+    public function testFromWithoutToReturnsFailure(): void
+    {
+        $tester = $this->tester();
+
+        $code = $tester->execute(['--mode' => 'daily', '--from' => '2026-05-19']);
+
+        self::assertSame(Command::FAILURE, $code);
+    }
+
+    public function testToWithoutFromReturnsFailure(): void
+    {
+        $tester = $this->tester();
+
+        $code = $tester->execute(['--mode' => 'daily', '--to' => '2026-05-19']);
+
+        self::assertSame(Command::FAILURE, $code);
+    }
+
+    public function testFromGreaterThanToReturnsFailure(): void
+    {
+        $tester = $this->tester();
+
+        $code = $tester->execute(['--mode' => 'daily', '--from' => '2026-05-20', '--to' => '2026-05-19']);
+
+        self::assertSame(Command::FAILURE, $code);
+    }
+
+    public function testAllWithDateReturnsFailure(): void
+    {
+        $tester = $this->tester();
+
+        $code = $tester->execute(['--mode' => 'all', '--date' => '2026-05-19']);
+
+        self::assertSame(Command::FAILURE, $code);
+    }
+
+
+    public function testMissingWithDateReturnsFailureAndDoesNotCallPlanMissing(): void
+    {
+        $this->planner->expects(self::never())->method('planMissing');
+
+        $tester = $this->tester();
+
+        $code = $tester->execute(['--mode' => 'missing', '--date' => '2026-05-19']);
+
+        self::assertSame(Command::FAILURE, $code);
+    }
+
+    public function testDailyDateCallsPlanRangeForOneDay(): void
+    {
+        $this->planner
+            ->expects(self::once())
+            ->method('planRange')
+            ->with(
+                self::callback(static fn (\DateTimeImmutable $d): bool => '2026-05-19' === $d->format('Y-m-d')),
+                self::callback(static fn (\DateTimeImmutable $d): bool => '2026-05-19' === $d->format('Y-m-d')),
+                FinancialReportSyncMode::DAILY,
+                null,
+                null,
+                false,
+            )
+            ->willReturn(1);
+
+        $this->planner->expects(self::never())->method('planDaily');
+
+        $tester = $this->tester();
+        $code = $tester->execute(['--mode' => 'daily', '--date' => '2026-05-19']);
+
+        self::assertSame(Command::SUCCESS, $code);
+    }
+
+    public function testInitialDateCallsPlanRangeAndNotPlanInitial(): void
+    {
+        $this->planner
+            ->expects(self::once())
+            ->method('planRange')
+            ->with(
+                self::callback(static fn (\DateTimeImmutable $d): bool => '2026-05-19' === $d->format('Y-m-d')),
+                self::callback(static fn (\DateTimeImmutable $d): bool => '2026-05-19' === $d->format('Y-m-d')),
+                FinancialReportSyncMode::INITIAL,
+                null,
+                null,
+                false,
+            )
+            ->willReturn(1);
+
+        $this->planner->expects(self::never())->method('planInitial');
+
+        $tester = $this->tester();
+        $code = $tester->execute(['--mode' => 'initial', '--date' => '2026-05-19']);
+
+        self::assertSame(Command::SUCCESS, $code);
+    }
+
+    private function tester(): CommandTester
+    {
+        $resolver = new WbFinancialReportPeriodResolver(new MockClock('2026-05-21 00:00:00 Europe/Moscow'));
+        $command = new WbFinancialReportsSyncCommand($this->planner, $resolver, new NullLogger());
+
+        return new CommandTester($command);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a single CLI entrypoint to schedule WB financial report sync jobs (date/range-based and various modes) without making HTTP calls directly. 
- Expose a planner interface so scheduling logic can be depended on by the command and other callers. 

### Description
- Add `WbFinancialReportsSyncCommand` which implements `app:marketplace:wb-financial-reports:sync` and supports modes `all|initial|daily|refresh14|missing` and options `--date`, `--from/--to`, `--force` and `--max-days`. 
- Introduce `WbFinancialReportSyncPlannerInterface` and update `WbFinancialReportSyncPlanner` to implement it and add `planRange(...)` logic with mode-specific dispatch rules. 
- Register the planner interface wiring in `site/config/services.yaml` and document the command and rules in `ARCHITECTURE.md`. 
- Add unit tests `WbFinancialReportsSyncCommandTest` covering argument validation and that the planner methods (`planRange`, `planDaily`, `planInitial`, `planMissing`) are invoked as expected. 

### Testing
- Added PHPUnit unit tests in `site/tests/Unit/Marketplace/Command/WbFinancialReportsSyncCommandTest.php` which exercise invalid mode handling and date/range interactions. 
- Ran the new command unit tests (`WbFinancialReportsSyncCommandTest`) with `phpunit` and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ef2596ccc8323a86af60553672204)