### PR TITLE
TASK-022: Перевести WB initial sync на дневное планирование без лимита 60 дней

### DIFF
--- a/site/src/Marketplace/Application/Service/WbInitialSyncStartDateResolver.php
+++ b/site/src/Marketplace/Application/Service/WbInitialSyncStartDateResolver.php
@@ -13,7 +13,6 @@ use Symfony\Component\Clock\ClockInterface;
 class WbInitialSyncStartDateResolver
 {
     private const DOCUMENT_TYPE = 'sales_report';
-    private const DEFAULT_INITIAL_DAYS = 60;
 
     public function __construct(
         private readonly MarketplaceRawDocumentRepository $rawDocumentRepository,
@@ -45,7 +44,7 @@ class WbInitialSyncStartDateResolver
             return $localStartDate->setTime(0, 0, 0);
         }
 
-        return $now->modify(sprintf('-%d days', self::DEFAULT_INITIAL_DAYS));
+        return $yearStart;
     }
 
     private function parseSettingsStartDateOverride(array $settings, \DateTimeImmutable $maxAllowedDate): ?\DateTimeImmutable

--- a/site/src/Marketplace/MessageHandler/TriggerInitialSyncHandler.php
+++ b/site/src/Marketplace/MessageHandler/TriggerInitialSyncHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Marketplace\MessageHandler;
 
 use App\Marketplace\Application\Service\MarketplaceWeekPartitionService;
+use App\Marketplace\Application\Service\WbFinancialReportSyncPlannerInterface;
 use App\Marketplace\Application\Service\WbInitialSyncStartDateResolver;
 use App\Marketplace\Enum\MarketplaceConnectionType;
 use App\Marketplace\Enum\MarketplaceType;
@@ -26,7 +27,6 @@ use Symfony\Component\Messenger\MessageBusInterface;
 #[AsMessageHandler]
 final class TriggerInitialSyncHandler
 {
-    private const MAX_INITIAL_SPAN_DAYS = 60;
     public function __construct(
         private readonly MessageBusInterface $messageBus,
         private readonly LoggerInterface $logger,
@@ -34,6 +34,7 @@ final class TriggerInitialSyncHandler
         private readonly ClockInterface $clock,
         private readonly MarketplaceConnectionRepository $connectionRepository,
         private readonly WbInitialSyncStartDateResolver $wbStartDateResolver,
+        private readonly WbFinancialReportSyncPlannerInterface $wbFinancialReportSyncPlanner,
     ) {
     }
 
@@ -62,15 +63,25 @@ final class TriggerInitialSyncHandler
             $syncStart = $this->wbStartDateResolver->resolve($connection->getCompany(), $connection);
         }
 
-        $endDate = $yesterday;
         if (MarketplaceType::WILDBERRIES === $connection->getMarketplace()) {
-            $wbLimitedEndDate = $syncStart->modify(sprintf('+%d days', self::MAX_INITIAL_SPAN_DAYS));
-            if ($wbLimitedEndDate < $endDate) {
-                $endDate = $wbLimitedEndDate;
-            }
+            $scheduled = $this->wbFinancialReportSyncPlanner->planInitial(
+                companyId: $message->companyId,
+                connectionId: $message->connectionId,
+                startFrom: $syncStart,
+            );
+
+            $this->logger->info('InitialSync WB: planned daily statuses', [
+                'company_id' => $message->companyId,
+                'connection_id' => $message->connectionId,
+                'start_from' => $syncStart->format('Y-m-d H:i:s'),
+                'end_date' => $yesterday->format('Y-m-d H:i:s'),
+                'scheduled_days' => $scheduled,
+            ]);
+
+            return;
         }
 
-        $weeks = $this->partitionService->buildPartitions($syncStart, $endDate);
+        $weeks = $this->partitionService->buildPartitions($syncStart, $yesterday);
 
         if (empty($weeks)) {
             $this->logger->warning('InitialSync: no weeks to sync', [

--- a/site/tests/Integration/Marketplace/TriggerInitialSyncHandlerTest.php
+++ b/site/tests/Integration/Marketplace/TriggerInitialSyncHandlerTest.php
@@ -5,16 +5,15 @@ declare(strict_types=1);
 namespace App\Tests\Integration\Marketplace;
 
 use App\Marketplace\Application\Service\MarketplaceWeekPartitionService;
+use App\Marketplace\Application\Service\WbFinancialReportSyncPlannerInterface;
 use App\Marketplace\Application\Service\WbInitialSyncStartDateResolver;
 use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Enum\MarketplaceType;
-use App\Marketplace\Message\InitialSyncMessage;
 use App\Marketplace\Message\TriggerInitialSyncMessage;
 use App\Marketplace\MessageHandler\TriggerInitialSyncHandler;
 use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
 use App\Tests\Builders\Company\CompanyBuilder;
 use App\Tests\Support\Kernel\IntegrationTestCase;
-use PHPUnit\Framework\Assert;
 use Psr\Log\NullLogger;
 use Symfony\Component\Clock\MockClock;
 use Symfony\Component\Messenger\Envelope;
@@ -22,7 +21,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 
 final class TriggerInitialSyncHandlerTest extends IntegrationTestCase
 {
-    public function testWbStartDateFromPastIsCappedToSixtyDaysAndFirstBatchIsDispatched(): void
+    public function testWbStartDateFromPastPlansInitialDailySyncWithoutCap(): void
     {
         $company = CompanyBuilder::aCompany()->build();
         $this->em->persist($company);
@@ -39,19 +38,9 @@ final class TriggerInitialSyncHandlerTest extends IntegrationTestCase
         $this->em->persist($connection);
         $this->em->flush();
 
-        $capturedMessage = null;
-        $bus = new class($capturedMessage) implements MessageBusInterface {
-            public ?object $capturedMessage = null;
-
-            public function __construct(?object &$capturedMessage)
-            {
-                $this->capturedMessage = $capturedMessage;
-            }
-
+        $bus = new class() implements MessageBusInterface {
             public function dispatch(object $message, array $stamps = []): Envelope
             {
-                $this->capturedMessage = $message;
-
                 return new Envelope($message, $stamps);
             }
         };
@@ -61,6 +50,19 @@ final class TriggerInitialSyncHandlerTest extends IntegrationTestCase
             new MockClock('2026-05-10 00:00:00'),
         );
 
+
+        $planner = $this->createMock(WbFinancialReportSyncPlannerInterface::class);
+        $planner->expects(self::once())
+            ->method('planInitial')
+            ->with(
+                $company->getId(),
+                $connection->getId(),
+                self::callback(static function (\DateTimeImmutable $date): bool {
+                    return '2025-05-01 00:00:00' === $date->format('Y-m-d H:i:s');
+                }),
+            )
+            ->willReturn(375);
+
         $handler = new TriggerInitialSyncHandler(
             $bus,
             new NullLogger(),
@@ -68,17 +70,10 @@ final class TriggerInitialSyncHandlerTest extends IntegrationTestCase
             new MockClock('2026-05-10 00:00:00'),
             self::getContainer()->get(\App\Marketplace\Repository\MarketplaceConnectionRepository::class),
             $resolver,
+            $planner,
         );
 
         $handler(new TriggerInitialSyncMessage($company->getId(), $connection->getId(), MarketplaceType::WILDBERRIES->value));
 
-        Assert::assertInstanceOf(InitialSyncMessage::class, $bus->capturedMessage);
-        Assert::assertSame('2025-05-01 00:00:00', $bus->capturedMessage->dateFrom);
-
-        $start = new \DateTimeImmutable($bus->capturedMessage->dateFrom);
-        $allowedMaxEnd = $start->modify('+60 days')->setTime(23, 59, 59);
-        $actualEnd = new \DateTimeImmutable($bus->capturedMessage->nextDateTo ?? $bus->capturedMessage->dateTo);
-
-        Assert::assertLessThanOrEqual($allowedMaxEnd, $actualEnd);
     }
 }

--- a/site/tests/Unit/Marketplace/Application/Service/WbInitialSyncStartDateResolverTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbInitialSyncStartDateResolverTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Clock\MockClock;
 
 final class WbInitialSyncStartDateResolverTest extends TestCase
 {
-    public function testFallbackWhenNoSettingsAndNoRawDocumentsReturnsNowMinusSixtyDays(): void
+    public function testFallbackWhenNoSettingsAndNoRawDocumentsReturnsYearStart(): void
     {
         $company = CompanyBuilder::aCompany()->build();
         $connection = new MarketplaceConnection('22222222-2222-2222-2222-222222222222', $company, MarketplaceType::WILDBERRIES);
@@ -28,7 +28,7 @@ final class WbInitialSyncStartDateResolverTest extends TestCase
 
         $resolver = new WbInitialSyncStartDateResolver($rawRepository, new MockClock('2026-05-10 12:34:56'));
 
-        self::assertSame('2026-03-11', $resolver->resolve($company, $connection)->format('Y-m-d'));
+        self::assertSame('2026-01-01', $resolver->resolve($company, $connection)->format('Y-m-d'));
     }
 
     public function testReturnsMinPeriodFromWhenCompletedRawDocumentsExist(): void
@@ -72,7 +72,7 @@ final class WbInitialSyncStartDateResolverTest extends TestCase
         self::assertSame('2026-05-09', $resolver->resolve($company, $connection)->format('Y-m-d'));
     }
 
-    public function testInvalidSettingsDateFallsBackToDefaultWindow(): void
+    public function testInvalidSettingsDateFallsBackToYearStart(): void
     {
         $company = CompanyBuilder::aCompany()->build();
         $connection = new MarketplaceConnection('22222222-2222-2222-2222-222222222222', $company, MarketplaceType::WILDBERRIES);
@@ -85,7 +85,7 @@ final class WbInitialSyncStartDateResolverTest extends TestCase
 
         $resolver = new WbInitialSyncStartDateResolver($rawRepository, new MockClock('2026-05-10 00:00:00'));
 
-        self::assertSame('2026-03-11', $resolver->resolve($company, $connection)->format('Y-m-d'));
+        self::assertSame('2026-01-01', $resolver->resolve($company, $connection)->format('Y-m-d'));
     }
 
     public function testYesterdayOverrideIsAccepted(): void
@@ -118,7 +118,7 @@ final class WbInitialSyncStartDateResolverTest extends TestCase
         self::assertSame('2026-04-20', $resolver->resolve($company, $connection)->format('Y-m-d'));
     }
 
-    public function testFutureOverrideIsIgnoredAndFallbackIsUsedWhenNoLocalRawDocuments(): void
+    public function testFutureOverrideIsIgnoredAndYearStartIsUsedWhenNoLocalRawDocuments(): void
     {
         $company = CompanyBuilder::aCompany()->build();
         $connection = new MarketplaceConnection('22222222-2222-2222-2222-222222222222', $company, MarketplaceType::WILDBERRIES);
@@ -131,6 +131,6 @@ final class WbInitialSyncStartDateResolverTest extends TestCase
 
         $resolver = new WbInitialSyncStartDateResolver($rawRepository, new MockClock('2026-05-10 00:00:00'));
 
-        self::assertSame('2026-03-11', $resolver->resolve($company, $connection)->format('Y-m-d'));
+        self::assertSame('2026-01-01', $resolver->resolve($company, $connection)->format('Y-m-d'));
     }
 }

--- a/site/tests/Unit/Marketplace/MessageHandler/TriggerInitialSyncHandlerTest.php
+++ b/site/tests/Unit/Marketplace/MessageHandler/TriggerInitialSyncHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Marketplace\MessageHandler;
 
 use App\Marketplace\Application\Service\MarketplaceWeekPartitionService;
+use App\Marketplace\Application\Service\WbFinancialReportSyncPlannerInterface;
 use App\Marketplace\Application\Service\WbInitialSyncStartDateResolver;
 use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Enum\MarketplaceType;
@@ -21,7 +22,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 
 final class TriggerInitialSyncHandlerTest extends TestCase
 {
-    public function testWbBuildsPartitionsFromResolvedDateAndCapsTo60Days(): void
+    public function testWbInitialPlansDailySyncWithoutSixtyDaysCap(): void
     {
         $company = CompanyBuilder::aCompany()->build();
         $connection = new MarketplaceConnection('22222222-2222-2222-2222-222222222222', $company, MarketplaceType::WILDBERRIES);
@@ -34,6 +35,18 @@ final class TriggerInitialSyncHandlerTest extends TestCase
             ->method('resolve')
             ->willReturn(new \DateTimeImmutable('2026-01-10 00:00:00'));
 
+        $planner = $this->createMock(WbFinancialReportSyncPlannerInterface::class);
+        $planner->expects(self::once())
+            ->method('planInitial')
+            ->with(
+                $company->getId(),
+                $connection->getId(),
+                self::callback(static function (\DateTimeImmutable $date): bool {
+                    return '2026-01-10 00:00:00' === $date->format('Y-m-d H:i:s');
+                }),
+            )
+            ->willReturn(120);
+
         $captured = new \stdClass();
         $captured->message = null;
         $bus = $this->createMock(MessageBusInterface::class);
@@ -44,20 +57,7 @@ final class TriggerInitialSyncHandlerTest extends TestCase
         });
 
         $partitionService = $this->createMock(MarketplaceWeekPartitionService::class);
-        $partitionService->expects(self::once())
-            ->method('buildPartitions')
-            ->with(
-                self::callback(static function (\DateTimeImmutable $date): bool {
-                    return '2026-01-10 00:00:00' === $date->format('Y-m-d H:i:s');
-                }),
-                self::callback(static function (\DateTimeImmutable $date): bool {
-                    return '2026-03-11 00:00:00' === $date->format('Y-m-d H:i:s');
-                }),
-            )
-            ->willReturn([
-                ['from' => '2026-01-10 00:00:00', 'to' => '2026-01-19 23:59:59'],
-                ['from' => '2026-01-20 00:00:00', 'to' => '2026-03-11 23:59:59'],
-            ]);
+        $partitionService->expects(self::never())->method('buildPartitions');
 
         $handler = new TriggerInitialSyncHandler(
             $bus,
@@ -66,14 +66,12 @@ final class TriggerInitialSyncHandlerTest extends TestCase
             new MockClock('2026-04-30 00:00:00'),
             $repo,
             $resolver,
+            $planner,
         );
 
         $handler(new TriggerInitialSyncMessage($company->getId(), $connection->getId(), MarketplaceType::WILDBERRIES->value));
 
-        self::assertInstanceOf(InitialSyncMessage::class, $captured->message);
-        self::assertSame('2026-01-10 00:00:00', $captured->message->dateFrom);
-        self::assertSame('2026-01-19 23:59:59', $captured->message->dateTo);
-        self::assertSame('2026-03-11 23:59:59', $captured->message->nextDateTo);
+        self::assertNull($captured->message);
     }
 
     public function testNonWbDoesNotCallResolverAndUsesYearStartUntilYesterday(): void
@@ -85,6 +83,9 @@ final class TriggerInitialSyncHandlerTest extends TestCase
 
         $resolver = $this->createMock(WbInitialSyncStartDateResolver::class);
         $resolver->expects(self::never())->method('resolve');
+
+        $planner = $this->createMock(WbFinancialReportSyncPlannerInterface::class);
+        $planner->expects(self::never())->method('planInitial');
 
         $captured = new \stdClass();
         $captured->message = null;
@@ -118,6 +119,7 @@ final class TriggerInitialSyncHandlerTest extends TestCase
             new MockClock('2026-04-30 00:00:00'),
             $repo,
             $resolver,
+            $planner,
         );
 
         $handler(new TriggerInitialSyncMessage($company->getId(), $connection->getId(), MarketplaceType::OZON->value));


### PR DESCRIPTION
### Motivation
- Убрать искусственное ограничение в 60 дней для первичной синхронизации Wildberries и перейти на дневные статусы для WB initial чтобы обеспечить полную загрузку с начала года или с первой доступной даты.
- Сохранить прежнюю weekly-цепочку для Ozon и других маркетплейсов без изменений.

### Description
- Для `MarketplaceType::WILDBERRIES` в `TriggerInitialSyncHandler` убран `MAX_INITIAL_SPAN_DAYS` и вместо формирования weekly-партий теперь вызывается `WbFinancialReportSyncPlannerInterface::planInitial(...)` с `startFrom` из резолвера, после чего handler завершает работу (WB initial планируется как дневные статусы).
- Логика для Ozon/прочих маркетплейсов оставлена: weekly-партии строятся через `MarketplaceWeekPartitionService` и диспатчится первый `InitialSyncMessage` как раньше.
- В `WbInitialSyncStartDateResolver` удалён fallback `-60 days`: теперь fallback по умолчанию — `01-01` текущего года; при этом остаются настройки override и использование минимальной локальной даты из `MarketplaceRawDocumentRepository` если есть.
- Обновлены тесты: unit-тесты для `TriggerInitialSyncHandler` и `WbInitialSyncStartDateResolver` адаптированы под новую WB-ветку (проверка вызова `planInitial` и проверка fallback → начало года); integration-test обновлён для проверки планирования WB через planner.
- Изменённые файлы: `site/src/Marketplace/MessageHandler/TriggerInitialSyncHandler.php`, `site/src/Marketplace/Application/Service/WbInitialSyncStartDateResolver.php`, `site/tests/Unit/Marketplace/MessageHandler/TriggerInitialSyncHandlerTest.php`, `site/tests/Unit/Marketplace/Application/Service/WbInitialSyncStartDateResolverTest.php`, `site/tests/Integration/Marketplace/TriggerInitialSyncHandlerTest.php`.

### Testing
- Синтаксический PHP-линт выполнен с `php -l` для изменённых файлов и тестов — все проверенные файлы без синтаксических ошибок (успех).
- Попытки запустить unit-тесты через `php bin/phpunit` в `site` упали из-за отсутствующих зависимостей/`simple-phpunit` (требуется `composer install`), поэтому PHPUnit-run не выполнен в этом окружении (неуспех).
- `php bin/console lint:container` не выполнен из-за отсутствия установленных зависимостей (требуется `composer install`).
- Обновлённые unit/integration тесты проверяют: WB initial больше не обрезается до 60 дней и планируется через `planInitial`, а fallback start date для WB — начало года (тесты добавлены/адаптированы, ожидают прохождения в CI после установки зависимостей).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0efa298b288323860ea35f08c5e7b6)