### PR TITLE
Schedule missing WB report days by combining retryable statuses and missing dates; add range queries and tests

### DIFF
--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlanner.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlanner.php
@@ -103,17 +103,55 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
         }
 
         $dispatched = 0;
-        $days = $this->periodResolver->daysBetween($this->periodResolver->currentYearStart(), $this->periodResolver->yesterday());
+        $from = $this->periodResolver->currentYearStart();
+        $to = $this->periodResolver->yesterday();
+        $allDays = $this->periodResolver->daysBetween($from, $to);
+        $now = new DateTimeImmutable();
 
         foreach ($this->activeWbConnectionsQuery->execute($companyId, $connectionId) as $connection) {
-            $scheduledDays = $this->syncStatusRepository->findMissingOrRetryDueDays(
-                $connection['connection_id'],
+            $statuses = $this->syncStatusRepository->findStatusesForDateRange(
                 $connection['company_id'],
+                $connection['connection_id'],
                 self::REPORT_TYPE,
-                $days,
+                $from,
+                $to,
+            );
+
+            $knownDays = [];
+            foreach ($statuses as $status) {
+                $knownDays[$status->getBusinessDate()->format('Y-m-d')] = true;
+            }
+
+            $retryDueDays = $this->syncStatusRepository->findRetryDueDays(
+                $connection['company_id'],
+                $connection['connection_id'],
+                self::REPORT_TYPE,
+                $from,
+                $to,
+                $now,
                 $maxDays,
             );
 
+            $scheduledDays = [];
+            foreach ($retryDueDays as $day) {
+                $scheduledDays[$day->format('Y-m-d')] = $day;
+            }
+
+            if (count($scheduledDays) < $maxDays) {
+                foreach ($allDays as $day) {
+                    $dayKey = $day->format('Y-m-d');
+                    if (isset($knownDays[$dayKey]) || isset($scheduledDays[$dayKey])) {
+                        continue;
+                    }
+
+                    $scheduledDays[$dayKey] = $day;
+                    if (count($scheduledDays) >= $maxDays) {
+                        break;
+                    }
+                }
+            }
+
+            ksort($scheduledDays);
             foreach ($scheduledDays as $day) {
                 $this->dispatch($connection['company_id'], $connection['connection_id'], $day, FinancialReportSyncMode::MISSING, false);
                 ++$dispatched;

--- a/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepository.php
+++ b/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepository.php
@@ -86,77 +86,81 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
     }
 
     /**
-     * @param list<\DateTimeImmutable> $days
-     *
+     * @return list<MarketplaceFinancialReportSyncStatus>
+     */
+    public function findStatusesForDateRange(
+        string $companyId,
+        string $connectionId,
+        string $reportType,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+    ): array {
+        Assert::uuid($companyId);
+        Assert::uuid($connectionId);
+
+        return $this->createQueryBuilder('s')
+            ->where('s.companyId = :companyId')
+            ->andWhere('s.connectionId = :connectionId')
+            ->andWhere('s.reportType = :reportType')
+            ->andWhere('s.businessDate BETWEEN :from AND :to')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('connectionId', $connectionId)
+            ->setParameter('reportType', $reportType)
+            ->setParameter('from', $from)
+            ->setParameter('to', $to)
+            ->orderBy('s.businessDate', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
      * @return list<\DateTimeImmutable>
      */
-    public function findMissingOrRetryDueDays(
-        string $connectionId,
+    public function findRetryDueDays(
         string $companyId,
+        string $connectionId,
         string $reportType,
-        array $days,
-        int $maxDays,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        \DateTimeImmutable $now,
+        int $limit,
     ): array {
-        Assert::uuid($connectionId);
         Assert::uuid($companyId);
+        Assert::uuid($connectionId);
 
-        if ([] === $days || $maxDays <= 0) {
+        if ($limit <= 0) {
             return [];
         }
 
-        $statuses = $this->createQueryBuilder('s')
-            ->select('s.businessDate, s.status, s.nextRetryAt')
-            ->where('s.connectionId = :connectionId')
-            ->andWhere('s.companyId = :companyId')
+        $rows = $this->createQueryBuilder('s')
+            ->select('s.businessDate')
+            ->where('s.companyId = :companyId')
+            ->andWhere('s.connectionId = :connectionId')
             ->andWhere('s.reportType = :reportType')
-            ->andWhere('s.businessDate IN (:days)')
-            ->setParameter('connectionId', $connectionId)
+            ->andWhere('s.businessDate BETWEEN :from AND :to')
+            ->andWhere('s.status = :failedStatus')
+            ->andWhere('(s.nextRetryAt IS NULL OR s.nextRetryAt <= :now)')
             ->setParameter('companyId', $companyId)
+            ->setParameter('connectionId', $connectionId)
             ->setParameter('reportType', $reportType)
-            ->setParameter('days', $days)
+            ->setParameter('from', $from)
+            ->setParameter('to', $to)
+            ->setParameter('failedStatus', FinancialReportSyncStatus::FAILED)
+            ->setParameter('now', $now)
+            ->orderBy('s.businessDate', 'ASC')
+            ->setMaxResults($limit)
             ->getQuery()
             ->getArrayResult();
 
-        $byDay = [];
-        foreach ($statuses as $row) {
-            $date = $row['businessDate'];
+        $days = [];
+        foreach ($rows as $row) {
+            $date = $row['businessDate'] ?? null;
             if ($date instanceof \DateTimeImmutable) {
-                $byDay[$date->format('Y-m-d')] = [
-                    'status' => $row['status'],
-                    'nextRetryAt' => $row['nextRetryAt'] ?? null,
-                ];
+                $days[] = $date;
             }
         }
 
-        $now = new \DateTimeImmutable();
-        $result = [];
-        foreach ($days as $day) {
-            if (count($result) >= $maxDays) {
-                break;
-            }
-
-            $existing = $byDay[$day->format('Y-m-d')] ?? null;
-            if (null === $existing) {
-                $result[] = $day;
-                continue;
-            }
-
-            $status = $existing['status'];
-            if (is_string($status)) {
-                $status = FinancialReportSyncStatus::from($status);
-            }
-
-            if (FinancialReportSyncStatus::FAILED !== $status) {
-                continue;
-            }
-
-            $nextRetryAt = $existing['nextRetryAt'];
-            if (null === $nextRetryAt || ($nextRetryAt instanceof \DateTimeInterface && $nextRetryAt <= $now)) {
-                $result[] = $day;
-            }
-        }
-
-        return $result;
+        return $days;
     }
 
     public function findOrCreateForDay(

--- a/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
@@ -121,6 +121,8 @@ final class WbFinancialReportSyncPlannerTest extends IntegrationTestCase
         self::assertSame(2, $count);
         self::assertCount(2, $bus->messages);
         self::assertSame(['2026-01-02', '2026-01-04'], array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->businessDate, $bus->messages));
+        self::assertSame(['missing', 'missing'], array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->mode, $bus->messages));
+        self::assertSame([false, false], array_map(static fn (SyncWbFinancialReportDayMessage $m): bool => $m->forceRefresh, $bus->messages));
     }
 
     private function planner(InMemoryMessageBus $bus, \DateTimeImmutable $clockNow): WbFinancialReportSyncPlanner

--- a/site/tests/Unit/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepositoryTest.php
+++ b/site/tests/Unit/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepositoryTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Repository;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Entity\MarketplaceFinancialReportSyncStatus;
+use App\Marketplace\Enum\FinancialReportSyncMode;
+use App\Marketplace\Enum\FinancialReportSyncStatus;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Repository\MarketplaceFinancialReportSyncStatusRepository;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class MarketplaceFinancialReportSyncStatusRepositoryTest extends IntegrationTestCase
+{
+    private const REPORT_TYPE = 'sales_report';
+
+    private MarketplaceFinancialReportSyncStatusRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = self::getContainer()->get(MarketplaceFinancialReportSyncStatusRepository::class);
+    }
+
+    public function testFindRetryDueDaysReturnsOnlyRetryableRowsWithFiltersLimitAndAscOrder(): void
+    {
+        $companyId = '11111111-1111-1111-1111-111111111111';
+        $connectionId = '22222222-2222-4222-8222-222222222222';
+        $this->seedActiveConnection($companyId, $connectionId);
+
+        $now = new \DateTimeImmutable('2026-01-05 12:00:00');
+
+        $this->persistStatus($companyId, $connectionId, '2026-01-01', FinancialReportSyncStatus::FAILED, null);
+        $this->persistStatus($companyId, $connectionId, '2026-01-02', FinancialReportSyncStatus::FAILED, new \DateTimeImmutable('2026-01-05 11:00:00'));
+        $this->persistStatus($companyId, $connectionId, '2026-01-03', FinancialReportSyncStatus::FAILED, new \DateTimeImmutable('2026-01-05 13:00:00'));
+        $this->persistStatus($companyId, $connectionId, '2026-01-04', FinancialReportSyncStatus::SUCCESS);
+        $this->persistStatus($companyId, $connectionId, '2026-01-05', FinancialReportSyncStatus::EMPTY);
+        $this->persistStatus($companyId, $connectionId, '2026-01-06', FinancialReportSyncStatus::LOADING);
+        $this->persistStatus($companyId, $connectionId, '2026-01-07', FinancialReportSyncStatus::PROCESSING);
+
+        $otherCompanyId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+        $otherConnectionId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+        $this->seedActiveConnection($otherCompanyId, $otherConnectionId);
+        $this->persistStatus($otherCompanyId, $connectionId, '2026-01-01', FinancialReportSyncStatus::FAILED, null);
+        $this->persistStatus($companyId, $otherConnectionId, '2026-01-01', FinancialReportSyncStatus::FAILED, null);
+        $this->persistStatus($companyId, $connectionId, '2026-01-08', FinancialReportSyncStatus::FAILED, null, 'another_report');
+
+        $days = $this->repository->findRetryDueDays(
+            $companyId,
+            $connectionId,
+            self::REPORT_TYPE,
+            new \DateTimeImmutable('2026-01-01 00:00:00'),
+            new \DateTimeImmutable('2026-01-10 00:00:00'),
+            $now,
+            2,
+        );
+
+        self::assertSame(['2026-01-01', '2026-01-02'], array_map(static fn (\DateTimeImmutable $d): string => $d->format('Y-m-d'), $days));
+    }
+
+
+    public function testFindStatusesForDateRangeFiltersByScopeRangeAndSortsAsc(): void
+    {
+        $companyId = '11111111-1111-1111-1111-111111111111';
+        $connectionId = '22222222-2222-4222-8222-222222222222';
+        $this->seedActiveConnection($companyId, $connectionId);
+
+        $this->persistStatus($companyId, $connectionId, '2025-12-31', FinancialReportSyncStatus::FAILED);
+        $this->persistStatus($companyId, $connectionId, '2026-01-03', FinancialReportSyncStatus::FAILED);
+        $this->persistStatus($companyId, $connectionId, '2026-01-01', FinancialReportSyncStatus::SUCCESS);
+        $this->persistStatus($companyId, $connectionId, '2026-01-02', FinancialReportSyncStatus::EMPTY);
+        $this->persistStatus($companyId, $connectionId, '2026-01-04', FinancialReportSyncStatus::FAILED, null, 'another_report');
+
+        $otherCompanyId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+        $otherConnectionId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+        $this->seedActiveConnection($otherCompanyId, $otherConnectionId);
+        $this->persistStatus($otherCompanyId, $connectionId, '2026-01-02', FinancialReportSyncStatus::FAILED);
+        $this->persistStatus($companyId, $otherConnectionId, '2026-01-02', FinancialReportSyncStatus::FAILED);
+
+        $statuses = $this->repository->findStatusesForDateRange(
+            $companyId,
+            $connectionId,
+            self::REPORT_TYPE,
+            new \DateTimeImmutable('2026-01-01 00:00:00'),
+            new \DateTimeImmutable('2026-01-03 23:59:59'),
+        );
+
+        self::assertSame(
+            ['2026-01-01', '2026-01-02', '2026-01-03'],
+            array_map(static fn (MarketplaceFinancialReportSyncStatus $status): string => $status->getBusinessDate()->format('Y-m-d'), $statuses),
+        );
+    }
+
+    private function persistStatus(
+        string $companyId,
+        string $connectionId,
+        string $day,
+        FinancialReportSyncStatus $status,
+        ?\DateTimeImmutable $nextRetryAt = null,
+        string $reportType = self::REPORT_TYPE,
+    ): void {
+        $entity = new MarketplaceFinancialReportSyncStatus(
+            Uuid::uuid7()->toString(),
+            $companyId,
+            $connectionId,
+            MarketplaceType::WILDBERRIES,
+            $reportType,
+            'endpoint',
+            new \DateTimeImmutable($day),
+        );
+
+        match ($status) {
+            FinancialReportSyncStatus::SUCCESS => $entity->markSuccess(),
+            FinancialReportSyncStatus::EMPTY => $entity->markEmpty(),
+            FinancialReportSyncStatus::LOADING => $entity->markLoading(FinancialReportSyncMode::DAILY),
+            FinancialReportSyncStatus::PROCESSING => $entity->markProcessing(),
+            FinancialReportSyncStatus::FAILED => $entity->markFailedRetryable('TestException', 'failed', 500, null, $nextRetryAt),
+            default => null,
+        };
+
+        $this->repository->save($entity);
+        $this->em->flush();
+    }
+
+    private function seedActiveConnection(string $companyId, string $connectionId): void
+    {
+        $existing = $this->em->find(Company::class, $companyId);
+        if (!$existing instanceof Company) {
+            $company = CompanyBuilder::aCompany()->withId($companyId)->build();
+            $this->em->persist($company->getOwner());
+            $this->em->persist($company);
+            $this->em->flush();
+        }
+
+        $this->em->getConnection()->insert('marketplace_connections', [
+            'id' => $connectionId,
+            'company_id' => $companyId,
+            'marketplace' => 'wildberries',
+            'connection_type' => 'seller',
+            'api_key' => 'encrypted-key',
+            'is_active' => true,
+            'created_at' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
+            'updated_at' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
+        ]);
+    }
+}


### PR DESCRIPTION
### Motivation

- Ensure `planMissing` schedules both retry-due failed days and previously missing days up to a configurable `maxDays` window and in ascending order.

### Description

- Update `WbFinancialReportSyncPlanner::planMissing` to compute `from`/`to` range, fetch known statuses with `findStatusesForDateRange`, fetch retryable days with `findRetryDueDays`, merge them and fill remaining slots with missing days from the full date range, then `ksort` and dispatch in order.
- Add `findStatusesForDateRange` to `MarketplaceFinancialReportSyncStatusRepository` to return status entities for a date window and `findRetryDueDays` to return failed, retryable business dates within a range while applying `now` and `limit` filters and ordering.
- Adjust repository query parameters, add `Assert::uuid` checks, and change return shapes to use typed entities or date lists as appropriate.
- Update planner test assertions and add `MarketplaceFinancialReportSyncStatusRepositoryTest` covering `findRetryDueDays` filtering/limit/order and `findStatusesForDateRange` scope/sort behavior.

### Testing

- Ran `WbFinancialReportSyncPlannerTest` which was updated to assert dispatched modes and `forceRefresh` and it passed.
- Added and ran `MarketplaceFinancialReportSyncStatusRepositoryTest` validating `findRetryDueDays` and `findStatusesForDateRange`, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0efe852b6c832381f900cad2e52cd2)