### PR TITLE
Sync WB financial-report status from raw pipeline results and wire updater into processor

### DIFF
--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -76,6 +76,8 @@ services:
 
     App\Marketplace\Repository\MarketplaceAdvertisingCostRepositoryInterface: '@App\Marketplace\Repository\MarketplaceAdvertisingCostRepository'
     App\Marketplace\Application\Service\WbFinancialReportSyncPlannerInterface: '@App\Marketplace\Application\Service\WbFinancialReportSyncPlanner'
+
+    App\Marketplace\Application\Service\WbFinancialReportSyncStatusUpdaterInterface: '@App\Marketplace\Application\Service\WbFinancialReportSyncStatusUpdater'
     App\Marketplace\Repository\MarketplaceOrderRepositoryInterface: '@App\Marketplace\Repository\MarketplaceOrderRepository'
     App\MarketplaceAnalytics\Repository\UnitEconomyCostMappingRepositoryInterface: '@App\MarketplaceAnalytics\Repository\UnitEconomyCostMappingRepository'
     App\MarketplaceAnalytics\Repository\ListingDailySnapshotRepositoryInterface: '@App\MarketplaceAnalytics\Repository\ListingDailySnapshotRepository'

--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncStatusUpdater.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncStatusUpdater.php
@@ -11,13 +11,17 @@ use App\Marketplace\Enum\FinancialReportSyncStatus;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Repository\MarketplaceFinancialReportSyncErrorRepository;
 use App\Marketplace\Repository\MarketplaceFinancialReportSyncStatusRepository;
+use App\Marketplace\Entity\MarketplaceRawDocument;
+use App\Marketplace\Enum\PipelineStatus;
+use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
 
-final readonly class WbFinancialReportSyncStatusUpdater
+final readonly class WbFinancialReportSyncStatusUpdater implements WbFinancialReportSyncStatusUpdaterInterface
 {
     public function __construct(
         private MarketplaceFinancialReportSyncStatusRepository $statusRepository,
         private MarketplaceFinancialReportSyncErrorRepository $errorRepository,
+        private LoggerInterface $logger,
     ) {}
 
     public function startLoading(string $connectionId, string $companyId, string $reportType, string $apiEndpoint, \DateTimeImmutable $businessDate, FinancialReportSyncMode $mode): MarketplaceFinancialReportSyncStatus
@@ -83,6 +87,48 @@ final readonly class WbFinancialReportSyncStatusUpdater
         $status->markConflict($errorClass, $errorMessage, $statusCode, $responseExcerpt);
         $this->statusRepository->save($status);
         $this->saveError($status, $errorClass, $errorMessage, $statusCode, $responseExcerpt, $requestPayload);
+    }
+
+
+    public function syncByRawPipelineResult(MarketplaceRawDocument $rawDocument, ?\Throwable $failure = null): void
+    {
+        if ($rawDocument->getMarketplace() !== MarketplaceType::WILDBERRIES || $rawDocument->getDocumentType() !== 'sales_report') {
+            return;
+        }
+
+        $status = $this->statusRepository->findByRawDocumentId((string) $rawDocument->getCompany()->getId(), $rawDocument->getId());
+        if ($status === null) {
+            return;
+        }
+
+        $before = $status->getStatus()->value;
+
+        if ($rawDocument->getProcessingStatus() === PipelineStatus::COMPLETED) {
+            $status->markSuccess();
+        } elseif ($rawDocument->getProcessingStatus() === PipelineStatus::FAILED) {
+            $errorClass = null !== $failure ? $failure::class : 'PipelineFailedException';
+            $errorMessage = $failure?->getMessage() ?? sprintf('Raw pipeline failed for document %s', $rawDocument->getId());
+
+            if ($failure instanceof \LogicException || $failure instanceof \InvalidArgumentException) {
+                $status->markConflict($errorClass, $errorMessage, null, null);
+            } else {
+                $status->markFailedFinal($errorClass, $errorMessage, null, null);
+            }
+
+            $this->saveError($status, $errorClass, $errorMessage, null, null, null);
+        } else {
+            return;
+        }
+
+        $this->statusRepository->save($status);
+
+        $this->logger->info('WB daily sync status changed after raw pipeline result', [
+            'rawDocumentId' => $rawDocument->getId(),
+            'syncStatusId' => $status->getId(),
+            'from' => $before,
+            'to' => $status->getStatus()->value,
+            'pipelineStatus' => $rawDocument->getProcessingStatus()?->value,
+        ]);
     }
 
     /** @param array<string,mixed>|null $requestPayload */

--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncStatusUpdaterInterface.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncStatusUpdaterInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\Service;
+
+use App\Marketplace\Entity\MarketplaceRawDocument;
+
+interface WbFinancialReportSyncStatusUpdaterInterface
+{
+    public function syncByRawPipelineResult(MarketplaceRawDocument $rawDocument, ?\Throwable $failure = null): void;
+}

--- a/site/src/Marketplace/MessageHandler/ProcessRawDocumentStepMessageHandler.php
+++ b/site/src/Marketplace/MessageHandler/ProcessRawDocumentStepMessageHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Marketplace\MessageHandler;
 
 use App\Marketplace\Application\Command\ProcessMarketplaceRawDocumentCommand;
+use App\Marketplace\Application\Service\WbFinancialReportSyncStatusUpdaterInterface;
 use App\Marketplace\Application\ProcessMarketplaceRawDocumentAction;
 use App\Marketplace\Entity\MarketplaceRawDocument;
 use App\Marketplace\Enum\PipelineStep;
@@ -30,6 +31,7 @@ final class ProcessRawDocumentStepMessageHandler
         private readonly EntityManagerInterface $entityManager,
         private readonly ManagerRegistry $managerRegistry,
         private readonly LoggerInterface $logger,
+        private readonly WbFinancialReportSyncStatusUpdaterInterface $statusUpdater,
     ) {
     }
 
@@ -79,6 +81,16 @@ final class ProcessRawDocumentStepMessageHandler
             throw $e;
         }
 
+        try {
+            $this->statusUpdater->syncByRawPipelineResult($doc);
+        } catch (\Throwable $updaterException) {
+            $this->logger->error('Failed to sync WB status after successful pipeline step', [
+                'rawDocumentId' => $message->rawDocumentId,
+                'step' => $step->value,
+                'secondaryException' => $updaterException->getMessage(),
+            ]);
+        }
+
         $this->entityManager->flush();
     }
 
@@ -108,6 +120,18 @@ final class ProcessRawDocumentStepMessageHandler
             }
 
             $doc->markStepFailed($step);
+
+            try {
+                $this->statusUpdater->syncByRawPipelineResult($doc, $originalException);
+            } catch (\Throwable $updaterException) {
+                $this->logger->error('Failed to sync WB status after pipeline failure', [
+                    'rawDocumentId' => $rawDocumentId,
+                    'step' => $step->value,
+                    'originalException' => $originalException->getMessage(),
+                    'secondaryException' => $updaterException->getMessage(),
+                ]);
+            }
+
             $em->flush();
         } catch (\Throwable $secondary) {
             // Не маскируем оригинальное исключение — только логируем secondary.
@@ -117,6 +141,8 @@ final class ProcessRawDocumentStepMessageHandler
                 'originalException' => $originalException->getMessage(),
                 'secondaryException' => $secondary->getMessage(),
             ]);
+
+            return;
         }
     }
 }

--- a/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepository.php
+++ b/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepository.php
@@ -163,6 +163,22 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
         return $days;
     }
 
+
+    public function findByRawDocumentId(string $companyId, string $rawDocumentId): ?MarketplaceFinancialReportSyncStatus
+    {
+        Assert::uuid($companyId);
+        Assert::uuid($rawDocumentId);
+
+        return $this->createQueryBuilder('s')
+            ->where('s.companyId = :companyId')
+            ->andWhere('s.rawDocumentId = :rawDocumentId')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('rawDocumentId', $rawDocumentId)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
     public function findOrCreateForDay(
         string $connectionId,
         string $companyId,

--- a/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncStatusUpdaterTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncStatusUpdaterTest.php
@@ -170,6 +170,85 @@ final class WbFinancialReportSyncStatusUpdaterTest extends IntegrationTestCase
         self::assertContainsOnlyInstancesOf(MarketplaceFinancialReportSyncError::class, $errors);
     }
 
+
+    public function testSyncByRawPipelineResultMarksSuccessForCompletedWbSalesReport(): void
+    {
+        $status = $this->startLoadingStatus();
+        $this->updater->markRawLoaded($status, $this->rawId(), 1, 'h');
+        $this->updater->markProcessing($status);
+
+        $company = $this->em->getReference(\App\Company\Entity\Company::class, $this->companyId());
+        $raw = new \App\Marketplace\Entity\MarketplaceRawDocument(
+            $this->rawId(),
+            $company,
+            \App\Marketplace\Enum\MarketplaceType::WILDBERRIES,
+            'sales_report',
+        );
+        $raw->markCompleted();
+
+        $this->updater->syncByRawPipelineResult($raw);
+        $this->em->flush();
+        $this->em->clear();
+
+        $persisted = $this->findStatus();
+        self::assertNotNull($persisted);
+        self::assertSame(FinancialReportSyncStatus::SUCCESS, $persisted->getStatus());
+        self::assertNotNull($persisted->getFinishedAt());
+        self::assertNotNull($persisted->getLastSuccessAt());
+    }
+
+
+    public function testSyncByRawPipelineResultMarksFailedFinalAndSavesError(): void
+    {
+        $status = $this->startLoadingStatus();
+        $this->updater->markRawLoaded($status, $this->rawId(), 1, 'h');
+        $this->updater->markProcessing($status);
+
+        $company = $this->em->getReference(\App\Company\Entity\Company::class, $this->companyId());
+        $raw = new \App\Marketplace\Entity\MarketplaceRawDocument(
+            $this->rawId(),
+            $company,
+            \App\Marketplace\Enum\MarketplaceType::WILDBERRIES,
+            'sales_report',
+        );
+        $raw->markStepFailed(\App\Marketplace\Enum\PipelineStep::SALES);
+
+        $this->updater->syncByRawPipelineResult($raw, new \RuntimeException('pipeline exploded'));
+        $this->em->flush();
+        $this->em->clear();
+
+        $persisted = $this->findStatus();
+        self::assertNotNull($persisted);
+        self::assertSame(FinancialReportSyncStatus::FAILED_FINAL, $persisted->getStatus());
+
+        $errors = $this->errorRepository->findBy(['syncStatusId' => $persisted->getId()]);
+        self::assertNotEmpty($errors);
+    }
+
+    public function testSyncByRawPipelineResultSkipsNonWbOrNonSalesReport(): void
+    {
+        $status = $this->startLoadingStatus();
+        $this->updater->markRawLoaded($status, $this->rawId(), 1, 'h');
+        $this->updater->markProcessing($status);
+
+        $company = $this->em->getReference(\App\Company\Entity\Company::class, $this->companyId());
+        $raw = new \App\Marketplace\Entity\MarketplaceRawDocument(
+            '00000000-0000-0000-0000-000000000100',
+            $company,
+            \App\Marketplace\Enum\MarketplaceType::OZON,
+            'sales_report',
+        );
+        $raw->markCompleted();
+
+        $this->updater->syncByRawPipelineResult($raw);
+        $this->em->flush();
+        $this->em->clear();
+
+        $persisted = $this->findStatus();
+        self::assertNotNull($persisted);
+        self::assertSame(FinancialReportSyncStatus::PROCESSING, $persisted->getStatus());
+    }
+
     private function startLoadingStatus(): MarketplaceFinancialReportSyncStatus
     {
         return $this->updater->startLoading(

--- a/site/tests/Unit/Marketplace/MessageHandler/ProcessRawDocumentStepMessageHandlerTest.php
+++ b/site/tests/Unit/Marketplace/MessageHandler/ProcessRawDocumentStepMessageHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Marketplace\MessageHandler;
 
 use App\Marketplace\Application\ProcessMarketplaceRawDocumentAction;
+use App\Marketplace\Application\Service\WbFinancialReportSyncStatusUpdaterInterface;
 use App\Marketplace\Entity\MarketplaceRawDocument;
 use App\Marketplace\Enum\PipelineStep;
 use App\Marketplace\Message\ProcessRawDocumentStepMessage;
@@ -83,6 +84,7 @@ final class ProcessRawDocumentStepMessageHandlerTest extends TestCase
             $closedEm,
             $registry,
             new NullLogger(),
+            $this->createMock(WbFinancialReportSyncStatusUpdaterInterface::class),
         );
 
         $message = new ProcessRawDocumentStepMessage(
@@ -151,6 +153,7 @@ final class ProcessRawDocumentStepMessageHandlerTest extends TestCase
             $em,
             $registry,
             new NullLogger(),
+            $this->createMock(WbFinancialReportSyncStatusUpdaterInterface::class),
         );
 
         $message = new ProcessRawDocumentStepMessage(
@@ -162,4 +165,77 @@ final class ProcessRawDocumentStepMessageHandlerTest extends TestCase
         $this->expectExceptionObject($primaryException);
         $handler($message);
     }
+
+    public function testHandlerSyncsWbStatusOnSuccessfulPipelineCompletion(): void
+    {
+        $user    = UserBuilder::aUser()->withIndex(3)->build();
+        $company = CompanyBuilder::aCompany()->withIndex(3)->withOwner($user)->build();
+        $doc     = MarketplaceRawDocumentBuilder::aDocument()->forCompany($company)->build();
+
+        $repo = $this->createMock(MarketplaceRawDocumentRepository::class);
+        $repo->method('find')->with($doc->getId())->willReturn($doc);
+
+        $processAction = $this->createMock(ProcessMarketplaceRawDocumentAction::class);
+        $processAction->method('__invoke')->willReturn(10);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::exactly(count(PipelineStep::cases())))->method('flush');
+
+        $registry = $this->createMock(ManagerRegistry::class);
+
+        $updater = $this->createMock(WbFinancialReportSyncStatusUpdaterInterface::class);
+        $updater->expects(self::exactly(count(PipelineStep::cases())))
+            ->method('syncByRawPipelineResult')
+            ->with($doc, null);
+
+        $handler = new ProcessRawDocumentStepMessageHandler(
+            $repo,
+            $processAction,
+            $em,
+            $registry,
+            new NullLogger(),
+            $updater,
+        );
+
+        foreach (PipelineStep::cases() as $step) {
+            $handler(new ProcessRawDocumentStepMessage($doc->getId(), $step->value, $company->getId()));
+        }
+    }
+
+
+    public function testHandlerIgnoresUpdaterExceptionOnSuccessPath(): void
+    {
+        $user    = UserBuilder::aUser()->withIndex(4)->build();
+        $company = CompanyBuilder::aCompany()->withIndex(4)->withOwner($user)->build();
+        $doc     = MarketplaceRawDocumentBuilder::aDocument()->forCompany($company)->build();
+
+        $repo = $this->createMock(MarketplaceRawDocumentRepository::class);
+        $repo->method('find')->with($doc->getId())->willReturn($doc);
+
+        $processAction = $this->createMock(ProcessMarketplaceRawDocumentAction::class);
+        $processAction->method('__invoke')->willReturn(1);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::once())->method('flush');
+
+        $registry = $this->createMock(ManagerRegistry::class);
+
+        $updater = $this->createMock(WbFinancialReportSyncStatusUpdaterInterface::class);
+        $updater->method('syncByRawPipelineResult')->willThrowException(new \RuntimeException('updater failed'));
+
+        $handler = new ProcessRawDocumentStepMessageHandler(
+            $repo,
+            $processAction,
+            $em,
+            $registry,
+            new NullLogger(),
+            $updater,
+        );
+
+        $handler(new ProcessRawDocumentStepMessage($doc->getId(), PipelineStep::SALES->value, $company->getId()));
+
+        self::assertContains(PipelineStep::SALES->value, $doc->getSucceededSteps());
+        self::assertNotContains(PipelineStep::SALES->value, $doc->getFailedSteps());
+    }
+
 }


### PR DESCRIPTION
### Motivation

- Ensure Wildberries daily financial report sync statuses are updated based on raw document pipeline results so the sync state reflects pipeline success/failure.

### Description

- Add `WbFinancialReportSyncStatusUpdaterInterface` and implement `syncByRawPipelineResult` in `WbFinancialReportSyncStatusUpdater` to mark statuses `SUCCESS`, `FAILED_FINAL` or `CONFLICT` based on `MarketplaceRawDocument` pipeline outcome and optional throwable, and persist corresponding `MarketplaceFinancialReportSyncError` entries via `saveError`.
- Add `findByRawDocumentId` to `MarketplaceFinancialReportSyncStatusRepository` to look up sync status by `rawDocumentId` and `companyId`.
- Call the updater from `ProcessRawDocumentStepMessageHandler` on both successful step completion and when recording a step failure, and log any secondary exceptions so they don't mask primary failures.
- Wire the new updater interface into the service container in `site/config/services.yaml`.
- Add and update unit tests: `WbFinancialReportSyncStatusUpdaterTest` to cover success, failure and non-WB/non-sales skipping, and `ProcessRawDocumentStepMessageHandlerTest` to assert the handler invokes the updater and ignores updater exceptions on the success path.

### Testing

- Ran unit tests including `WbFinancialReportSyncStatusUpdaterTest` and `ProcessRawDocumentStepMessageHandlerTest` which exercise the new `syncByRawPipelineResult` behavior and handler invocations; all unit tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f059821d88323a37e68c95275f16f)