### PR TITLE
Safe refresh for WB daily reports: cleanup generated rows, propagate `forceRefresh` and mark conflicts

### DIFF
--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -78,6 +78,8 @@ services:
     App\Marketplace\Application\Service\WbFinancialReportSyncPlannerInterface: '@App\Marketplace\Application\Service\WbFinancialReportSyncPlanner'
 
     App\Marketplace\Application\Service\WbFinancialReportSyncStatusUpdaterInterface: '@App\Marketplace\Application\Service\WbFinancialReportSyncStatusUpdater'
+    App\Marketplace\Application\Service\WbGeneratedRowsSafeReplaceServiceInterface: '@App\Marketplace\Application\Service\WbGeneratedRowsSafeReplaceService'
+    App\Marketplace\Repository\MarketplaceFinancialReportSyncStatusLookupInterface: '@App\Marketplace\Repository\MarketplaceFinancialReportSyncStatusRepository'
     App\Marketplace\Repository\MarketplaceOrderRepositoryInterface: '@App\Marketplace\Repository\MarketplaceOrderRepository'
     App\MarketplaceAnalytics\Repository\UnitEconomyCostMappingRepositoryInterface: '@App\MarketplaceAnalytics\Repository\UnitEconomyCostMappingRepository'
     App\MarketplaceAnalytics\Repository\ListingDailySnapshotRepositoryInterface: '@App\MarketplaceAnalytics\Repository\ListingDailySnapshotRepository'

--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncStatusUpdaterInterface.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncStatusUpdaterInterface.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace App\Marketplace\Application\Service;
 
+use App\Marketplace\Entity\MarketplaceFinancialReportSyncStatus;
 use App\Marketplace\Entity\MarketplaceRawDocument;
 
 interface WbFinancialReportSyncStatusUpdaterInterface
 {
     public function syncByRawPipelineResult(MarketplaceRawDocument $rawDocument, ?\Throwable $failure = null): void;
+
+    public function markConflict(MarketplaceFinancialReportSyncStatus $status, string $errorClass, string $errorMessage, ?int $statusCode = null, ?string $responseExcerpt = null, ?array $requestPayload = null): void;
 }

--- a/site/src/Marketplace/Application/Service/WbGeneratedRowsSafeReplaceService.php
+++ b/site/src/Marketplace/Application/Service/WbGeneratedRowsSafeReplaceService.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\Service;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Exception\WbGeneratedRowsConflictException;
+use App\Marketplace\Repository\MarketplaceCostRepository;
+use App\Marketplace\Repository\MarketplaceReturnRepository;
+use App\Marketplace\Repository\MarketplaceSaleRepository;
+use Psr\Log\LoggerInterface;
+
+final readonly class WbGeneratedRowsSafeReplaceService implements WbGeneratedRowsSafeReplaceServiceInterface
+{
+    public function __construct(
+        private MarketplaceSaleRepository $saleRepository,
+        private MarketplaceReturnRepository $returnRepository,
+        private MarketplaceCostRepository $costRepository,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function cleanupForRawDocument(Company $company, string $rawDocumentId, \DateTimeImmutable $businessDate): void
+    {
+        $lockedSales = $this->saleRepository->countDocumentLinkedByRawDocument($company, MarketplaceType::WILDBERRIES, $rawDocumentId);
+        $lockedReturns = $this->returnRepository->countDocumentLinkedByRawDocument($company, MarketplaceType::WILDBERRIES, $rawDocumentId);
+        $lockedCosts = $this->costRepository->countDocumentLinkedByRawDocument($company, MarketplaceType::WILDBERRIES, $rawDocumentId);
+
+        if (($lockedSales + $lockedReturns + $lockedCosts) > 0) {
+            $this->logger->warning('WB refresh conflict: generated rows are linked to closed documents', [
+                'raw_document_id' => $rawDocumentId,
+                'company_id' => $company->getId(),
+                'business_date' => $businessDate->format('Y-m-d'),
+                'locked_sales' => $lockedSales,
+                'locked_returns' => $lockedReturns,
+                'locked_costs' => $lockedCosts,
+            ]);
+
+            throw new WbGeneratedRowsConflictException(sprintf('Cannot reprocess WB raw document %s: generated rows linked to closed documents.', $rawDocumentId));
+        }
+
+        $this->saleRepository->deleteByRawDocument($company, MarketplaceType::WILDBERRIES, $rawDocumentId);
+        $this->returnRepository->deleteByRawDocument($company, MarketplaceType::WILDBERRIES, $rawDocumentId);
+        $this->costRepository->deleteByRawDocument($company, MarketplaceType::WILDBERRIES, $rawDocumentId);
+    }
+}

--- a/site/src/Marketplace/Application/Service/WbGeneratedRowsSafeReplaceServiceInterface.php
+++ b/site/src/Marketplace/Application/Service/WbGeneratedRowsSafeReplaceServiceInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\Service;
+
+use App\Company\Entity\Company;
+
+interface WbGeneratedRowsSafeReplaceServiceInterface
+{
+    public function cleanupForRawDocument(Company $company, string $rawDocumentId, \DateTimeImmutable $businessDate): void;
+}

--- a/site/src/Marketplace/Exception/WbGeneratedRowsConflictException.php
+++ b/site/src/Marketplace/Exception/WbGeneratedRowsConflictException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Exception;
+
+final class WbGeneratedRowsConflictException extends \LogicException
+{
+}

--- a/site/src/Marketplace/Message/ProcessDayReportMessage.php
+++ b/site/src/Marketplace/Message/ProcessDayReportMessage.php
@@ -16,6 +16,7 @@ final readonly class ProcessDayReportMessage
     public function __construct(
         public string $companyId,
         public string $rawDocumentId,
+        public bool $forceRefresh = false,
     ) {
     }
 }

--- a/site/src/Marketplace/MessageHandler/ProcessDayReportHandler.php
+++ b/site/src/Marketplace/MessageHandler/ProcessDayReportHandler.php
@@ -4,9 +4,14 @@ declare(strict_types=1);
 
 namespace App\Marketplace\MessageHandler;
 
+use App\Marketplace\Application\Service\WbFinancialReportSyncStatusUpdaterInterface;
+use App\Marketplace\Application\Service\WbGeneratedRowsSafeReplaceServiceInterface;
+use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Enum\PipelineStep;
 use App\Marketplace\Message\ProcessDayReportMessage;
 use App\Marketplace\Message\ProcessRawDocumentStepMessage;
+use App\Marketplace\Exception\WbGeneratedRowsConflictException;
+use App\Marketplace\Repository\MarketplaceFinancialReportSyncStatusLookupInterface;
 use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -28,6 +33,9 @@ final class ProcessDayReportHandler
         private readonly MessageBusInterface $bus,
         private readonly EntityManagerInterface $entityManager,
         private readonly LoggerInterface $logger,
+        private readonly WbGeneratedRowsSafeReplaceServiceInterface $safeReplaceService,
+        private readonly MarketplaceFinancialReportSyncStatusLookupInterface $syncStatusRepository,
+        private readonly WbFinancialReportSyncStatusUpdaterInterface $syncStatusUpdater,
     ) {
     }
 
@@ -45,6 +53,29 @@ final class ProcessDayReportHandler
             throw new UnrecoverableMessageHandlingException(
                 sprintf('IDOR: document %s does not belong to company %s', $message->rawDocumentId, $message->companyId),
             );
+        }
+
+        if ($message->forceRefresh
+            && $doc->getMarketplace() === MarketplaceType::WILDBERRIES
+            && $doc->getDocumentType() === 'sales_report'
+        ) {
+            try {
+                $this->safeReplaceService->cleanupForRawDocument($doc->getCompany(), $doc->getId(), $doc->getPeriodFrom());
+            } catch (WbGeneratedRowsConflictException $e) {
+                $status = $this->syncStatusRepository->findByRawDocumentId($message->companyId, $message->rawDocumentId);
+                if ($status !== null) {
+                    $this->syncStatusUpdater->markConflict($status, $e::class, $e->getMessage());
+                    $this->entityManager->flush();
+                }
+
+                $this->logger->warning('WB day processing conflict: linked document rows prevent refresh', [
+                    'company_id' => $message->companyId,
+                    'raw_document_id' => $message->rawDocumentId,
+                    'business_date' => $doc->getPeriodFrom()->format('Y-m-d'),
+                ]);
+
+                throw new UnrecoverableMessageHandlingException($e->getMessage(), 0, $e);
+            }
         }
 
         $doc->resetProcessingStatus();

--- a/site/src/Marketplace/MessageHandler/SyncWbFinancialReportDayHandler.php
+++ b/site/src/Marketplace/MessageHandler/SyncWbFinancialReportDayHandler.php
@@ -157,7 +157,7 @@ final class SyncWbFinancialReportDayHandler
             $connection->markSyncSuccess();
             $this->em->flush();
 
-            $this->messageBus->dispatch(new ProcessDayReportMessage($message->companyId, $rawDocument->getId()));
+            $this->messageBus->dispatch(new ProcessDayReportMessage($message->companyId, $rawDocument->getId(), $message->forceRefresh));
 
             $this->logger->info('WB day sync finished and processing dispatched.', [
                 'company_id' => $message->companyId,

--- a/site/src/Marketplace/Repository/MarketplaceCostRepository.php
+++ b/site/src/Marketplace/Repository/MarketplaceCostRepository.php
@@ -119,6 +119,43 @@ class MarketplaceCostRepository extends ServiceEntityRepository
         return array_fill_keys($result, true);
     }
 
+
+    public function countDocumentLinkedByRawDocument(
+        Company $company,
+        MarketplaceType $marketplace,
+        string $rawDocumentId,
+    ): int {
+        return (int) $this->createQueryBuilder('c')
+            ->select('COUNT(c.id)')
+            ->where('c.company = :company')
+            ->andWhere('c.marketplace = :marketplace')
+            ->andWhere('c.rawDocumentId = :rawDocumentId')
+            ->andWhere('c.document IS NOT NULL')
+            ->setParameter('company', $company)
+            ->setParameter('marketplace', $marketplace)
+            ->setParameter('rawDocumentId', $rawDocumentId)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    public function deleteByRawDocument(
+        Company $company,
+        MarketplaceType $marketplace,
+        string $rawDocumentId,
+    ): int {
+        return (int) $this->createQueryBuilder('c')
+            ->delete()
+            ->where('c.company = :company')
+            ->andWhere('c.marketplace = :marketplace')
+            ->andWhere('c.rawDocumentId = :rawDocumentId')
+            ->andWhere('c.document IS NULL')
+            ->setParameter('company', $company)
+            ->setParameter('marketplace', $marketplace)
+            ->setParameter('rawDocumentId', $rawDocumentId)
+            ->getQuery()
+            ->execute();
+    }
+
     public function findExportRowsByCompanyAndFilters(
         Company $company,
         ?MarketplaceType $marketplace,

--- a/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusLookupInterface.php
+++ b/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusLookupInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Repository;
+
+use App\Marketplace\Entity\MarketplaceFinancialReportSyncStatus;
+
+interface MarketplaceFinancialReportSyncStatusLookupInterface
+{
+    public function findByRawDocumentId(string $companyId, string $rawDocumentId): ?MarketplaceFinancialReportSyncStatus;
+}

--- a/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepository.php
+++ b/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepository.php
@@ -12,7 +12,7 @@ use Doctrine\Persistence\ManagerRegistry;
 use Ramsey\Uuid\Uuid;
 use Webmozart\Assert\Assert;
 
-final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntityRepository
+final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntityRepository implements MarketplaceFinancialReportSyncStatusLookupInterface
 {
     public function __construct(ManagerRegistry $registry)
     {

--- a/site/src/Marketplace/Repository/MarketplaceReturnRepository.php
+++ b/site/src/Marketplace/Repository/MarketplaceReturnRepository.php
@@ -121,6 +121,25 @@ class MarketplaceReturnRepository extends ServiceEntityRepository
         return $qb->getQuery()->getResult();
     }
 
+
+    public function countDocumentLinkedByRawDocument(
+        Company $company,
+        MarketplaceType $marketplace,
+        string $rawDocumentId,
+    ): int {
+        return (int) $this->createQueryBuilder('r')
+            ->select('COUNT(r.id)')
+            ->where('r.company = :company')
+            ->andWhere('r.marketplace = :marketplace')
+            ->andWhere('r.rawDocumentId = :rawDocumentId')
+            ->andWhere('r.document IS NOT NULL')
+            ->setParameter('company', $company)
+            ->setParameter('marketplace', $marketplace)
+            ->setParameter('rawDocumentId', $rawDocumentId)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
     public function deleteByRawDocument(
         Company $company,
         MarketplaceType $marketplace,

--- a/site/src/Marketplace/Repository/MarketplaceSaleRepository.php
+++ b/site/src/Marketplace/Repository/MarketplaceSaleRepository.php
@@ -167,6 +167,25 @@ class MarketplaceSaleRepository extends ServiceEntityRepository
         return $qb->getQuery()->getResult();
     }
 
+
+    public function countDocumentLinkedByRawDocument(
+        Company $company,
+        MarketplaceType $marketplace,
+        string $rawDocumentId,
+    ): int {
+        return (int) $this->createQueryBuilder('s')
+            ->select('COUNT(s.id)')
+            ->where('s.company = :company')
+            ->andWhere('s.marketplace = :marketplace')
+            ->andWhere('s.rawDocumentId = :rawDocumentId')
+            ->andWhere('s.document IS NOT NULL')
+            ->setParameter('company', $company)
+            ->setParameter('marketplace', $marketplace)
+            ->setParameter('rawDocumentId', $rawDocumentId)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
     public function deleteByRawDocument(
         Company $company,
         MarketplaceType $marketplace,

--- a/site/tests/Integration/Marketplace/WbFinancialReportRefreshTest.php
+++ b/site/tests/Integration/Marketplace/WbFinancialReportRefreshTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Marketplace;
+
+use App\Company\Entity\Company;
+use App\Finance\Entity\Document;
+use App\Marketplace\Application\Service\WbGeneratedRowsSafeReplaceService;
+use App\Marketplace\Entity\MarketplaceCost;
+use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Entity\MarketplaceReturn;
+use App\Marketplace\Entity\MarketplaceSale;
+use App\Marketplace\Enum\MarketplaceCostOperationType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Exception\WbGeneratedRowsConflictException;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class WbFinancialReportRefreshTest extends IntegrationTestCase
+{
+    public function testOpenSalesReturnsCostsRowsAreDeleted(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+        $this->em->persist($company);
+        $listing = $this->buildListing($company);
+        $this->em->persist($listing);
+        $rawDocId = '81111111-1111-4111-8111-111111111111';
+        $day = new \DateTimeImmutable('2026-03-12');
+
+        $sale = (new MarketplaceSale(Uuid::uuid4()->toString(), $company, $listing, MarketplaceType::WILDBERRIES))
+            ->setExternalOrderId('sale-1')->setSaleDate($day)->setQuantity(1)->setPricePerUnit('100')->setTotalRevenue('100')->setRawDocumentId($rawDocId);
+        $return = (new MarketplaceReturn(Uuid::uuid4()->toString(), $company, $listing, MarketplaceType::WILDBERRIES))
+            ->setExternalReturnId('ret-1')->setReturnDate($day)->setQuantity(1)->setRefundAmount('50')->setRawDocumentId($rawDocId);
+        $cost = (new MarketplaceCost(Uuid::uuid4()->toString(), $company, MarketplaceType::WILDBERRIES, null))
+            ->setExternalId('cost-1')->setCostDate($day)->setAmount('10')->setOperationType(MarketplaceCostOperationType::CHARGE)->setRawDocumentId($rawDocId);
+        $this->em->persist($sale);$this->em->persist($return);$this->em->persist($cost);$this->em->flush();
+
+        self::getContainer()->get(WbGeneratedRowsSafeReplaceService::class)->cleanupForRawDocument($company, $rawDocId, $day);
+
+        $conn=$this->em->getConnection();
+        self::assertSame(0,(int)$conn->fetchOne('SELECT COUNT(*) FROM marketplace_sales WHERE raw_document_id=:id',['id'=>$rawDocId]));
+        self::assertSame(0,(int)$conn->fetchOne('SELECT COUNT(*) FROM marketplace_returns WHERE raw_document_id=:id',['id'=>$rawDocId]));
+        self::assertSame(0,(int)$conn->fetchOne('SELECT COUNT(*) FROM marketplace_costs WHERE raw_document_id=:id',['id'=>$rawDocId]));
+    }
+
+    public function testLinkedRowsCauseConflictAndNoPartialDeletion(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+        $this->em->persist($company);
+        $listing = $this->buildListing($company);
+        $this->em->persist($listing);
+        $rawDocId = '83333333-3333-4333-8333-333333333333';
+        $day = new \DateTimeImmutable('2026-03-12');
+
+        $document = new Document(Uuid::uuid4()->toString(), $company);
+        $this->em->persist($document);
+
+        $openSale = (new MarketplaceSale(Uuid::uuid4()->toString(), $company, $listing, MarketplaceType::WILDBERRIES))
+            ->setExternalOrderId('open-sale')->setSaleDate($day)->setQuantity(1)->setPricePerUnit('100')->setTotalRevenue('100')->setRawDocumentId($rawDocId);
+        $linkedSale = (new MarketplaceSale(Uuid::uuid4()->toString(), $company, $listing, MarketplaceType::WILDBERRIES))
+            ->setExternalOrderId('linked-sale')->setSaleDate($day)->setQuantity(1)->setPricePerUnit('100')->setTotalRevenue('100')->setRawDocumentId($rawDocId)->setDocument($document);
+        $openReturn = (new MarketplaceReturn(Uuid::uuid4()->toString(), $company, $listing, MarketplaceType::WILDBERRIES))
+            ->setExternalReturnId('open-ret')->setReturnDate($day)->setQuantity(1)->setRefundAmount('50')->setRawDocumentId($rawDocId);
+        $linkedReturn = (new MarketplaceReturn(Uuid::uuid4()->toString(), $company, $listing, MarketplaceType::WILDBERRIES))
+            ->setExternalReturnId('linked-ret')->setReturnDate($day)->setQuantity(1)->setRefundAmount('50')->setRawDocumentId($rawDocId)->setDocument($document);
+        $openCost = (new MarketplaceCost(Uuid::uuid4()->toString(), $company, MarketplaceType::WILDBERRIES, null))
+            ->setExternalId('open-cost')->setCostDate($day)->setAmount('10')->setOperationType(MarketplaceCostOperationType::CHARGE)->setRawDocumentId($rawDocId);
+        $linkedCost = (new MarketplaceCost(Uuid::uuid4()->toString(), $company, MarketplaceType::WILDBERRIES, null))
+            ->setExternalId('linked-cost')->setCostDate($day)->setAmount('11')->setOperationType(MarketplaceCostOperationType::CHARGE)->setRawDocumentId($rawDocId)->setDocument($document);
+        foreach ([$openSale,$linkedSale,$openReturn,$linkedReturn,$openCost,$linkedCost] as $e) {$this->em->persist($e);} $this->em->flush();
+
+        $this->expectException(WbGeneratedRowsConflictException::class);
+        try { self::getContainer()->get(WbGeneratedRowsSafeReplaceService::class)->cleanupForRawDocument($company, $rawDocId, $day);} finally {
+            $conn=$this->em->getConnection();
+            self::assertSame(2,(int)$conn->fetchOne('SELECT COUNT(*) FROM marketplace_sales WHERE raw_document_id=:id',['id'=>$rawDocId]));
+            self::assertSame(2,(int)$conn->fetchOne('SELECT COUNT(*) FROM marketplace_returns WHERE raw_document_id=:id',['id'=>$rawDocId]));
+            self::assertSame(2,(int)$conn->fetchOne('SELECT COUNT(*) FROM marketplace_costs WHERE raw_document_id=:id',['id'=>$rawDocId]));
+        }
+    }
+
+    private function buildListing(Company $company): MarketplaceListing
+    {
+        $listing = new MarketplaceListing(Uuid::uuid4()->toString(), $company, null, MarketplaceType::WILDBERRIES);
+        $listing->setMarketplaceSku('sku-'.substr(Uuid::uuid4()->toString(),0,8));
+        $listing->setPrice('100');
+
+        return $listing;
+    }
+}

--- a/site/tests/Unit/Marketplace/MessageHandler/ProcessDayReportHandlerTest.php
+++ b/site/tests/Unit/Marketplace/MessageHandler/ProcessDayReportHandlerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\MessageHandler;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Application\Service\WbFinancialReportSyncStatusUpdaterInterface;
+use App\Marketplace\Application\Service\WbGeneratedRowsSafeReplaceServiceInterface;
+use App\Marketplace\Entity\MarketplaceFinancialReportSyncStatus;
+use App\Marketplace\Entity\MarketplaceRawDocument;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Exception\WbGeneratedRowsConflictException;
+use App\Marketplace\Message\ProcessDayReportMessage;
+use App\Marketplace\MessageHandler\ProcessDayReportHandler;
+use App\Marketplace\Repository\MarketplaceFinancialReportSyncStatusLookupInterface;
+use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class ProcessDayReportHandlerTest extends TestCase
+{
+    public function testConflictMarksSyncStatusAndThrowsUnrecoverableWithoutDispatch(): void
+    {
+        $company = $this->createMock(Company::class);
+        $company->method('getId')->willReturn('11111111-1111-4111-8111-111111111111');
+        $doc = new MarketplaceRawDocument('22222222-2222-4222-8222-222222222222', $company, MarketplaceType::WILDBERRIES, 'sales_report');
+        $doc->setPeriodFrom(new \DateTimeImmutable('2026-05-10'))->setPeriodTo(new \DateTimeImmutable('2026-05-10'));
+
+        $repo = $this->createMock(MarketplaceRawDocumentRepository::class);
+        $repo->method('find')->willReturn($doc);
+
+        $safe = $this->createMock(WbGeneratedRowsSafeReplaceServiceInterface::class);
+        $safe->expects(self::once())->method('cleanupForRawDocument')->willThrowException(new WbGeneratedRowsConflictException('conflict'));
+
+        $status = $this->createMock(MarketplaceFinancialReportSyncStatus::class);
+        $statusRepo = $this->createMock(MarketplaceFinancialReportSyncStatusLookupInterface::class);
+        $statusRepo->method('findByRawDocumentId')->willReturn($status);
+
+        $updater = $this->createMock(WbFinancialReportSyncStatusUpdaterInterface::class);
+        $updater->expects(self::once())->method('markConflict')->with($status, WbGeneratedRowsConflictException::class, 'conflict');
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::never())->method('dispatch');
+
+        $flushes = 0;
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('flush')->willReturnCallback(static function () use (&$flushes): void { $flushes++; });
+
+        $handler = new ProcessDayReportHandler($repo, $bus, $em, new NullLogger(), $safe, $statusRepo, $updater);
+
+        $this->expectException(UnrecoverableMessageHandlingException::class);
+        try {
+            $handler(new ProcessDayReportMessage((string)$company->getId(), $doc->getId(), true));
+        } finally {
+            self::assertSame(1, $flushes);
+        }
+    }
+
+    public function testNonWbOrNonSalesReportSkipsCleanup(): void
+    {
+        $company = $this->createMock(Company::class);
+        $company->method('getId')->willReturn('11111111-1111-4111-8111-111111111112');
+        $doc = new MarketplaceRawDocument('22222222-2222-4222-8222-222222222223', $company, MarketplaceType::OZON, 'sales_report');
+        $doc->setPeriodFrom(new \DateTimeImmutable('2026-05-10'))->setPeriodTo(new \DateTimeImmutable('2026-05-10'));
+
+        $repo = $this->createMock(MarketplaceRawDocumentRepository::class);
+        $repo->method('find')->willReturn($doc);
+
+        $safe = $this->createMock(WbGeneratedRowsSafeReplaceServiceInterface::class);
+        $safe->expects(self::never())->method('cleanupForRawDocument');
+
+        $statusRepo = $this->createMock(MarketplaceFinancialReportSyncStatusLookupInterface::class);
+        $updater = $this->createMock(WbFinancialReportSyncStatusUpdaterInterface::class);
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::exactly(3))->method('dispatch');
+        $em = $this->createMock(EntityManagerInterface::class);
+
+        $handler = new ProcessDayReportHandler($repo, $bus, $em, new NullLogger(), $safe, $statusRepo, $updater);
+        $handler(new ProcessDayReportMessage((string)$company->getId(), $doc->getId(), true));
+
+        self::assertTrue(true);
+    }
+}

--- a/site/tests/Unit/Marketplace/MessageHandler/SyncWbFinancialReportDayHandlerTest.php
+++ b/site/tests/Unit/Marketplace/MessageHandler/SyncWbFinancialReportDayHandlerTest.php
@@ -15,6 +15,7 @@ use App\Marketplace\Enum\MarketplaceConnectionType;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Enum\PipelineStatus;
 use App\Marketplace\Infrastructure\Api\Wildberries\WbFinanceSalesReportClient;
+use App\Marketplace\Message\ProcessDayReportMessage;
 use App\Marketplace\Message\SyncWbFinancialReportDayMessage;
 use App\Marketplace\MessageHandler\SyncWbFinancialReportDayHandler;
 use App\Tests\Builders\Company\CompanyBuilder;
@@ -24,7 +25,9 @@ use Symfony\Component\Clock\MockClock;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException;
+use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
 {
@@ -107,6 +110,44 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
             self::assertNotNull($error);
             self::assertSame('App\Marketplace\Exception\WbRawDocumentRefreshConflictException', $error->getErrorClass());
         }
+    }
+
+
+    public function testForceRefreshIsPropagatedToProcessDayReportMessage(): void
+    {
+        $company = $this->createCompany(9103);
+        $connection = $this->createWbSellerConnection($company, 9103);
+
+        $this->swapWbClient([new MockResponse('[{"rrdId":2}]', ['http_code' => 200])]);
+
+        $spyBus = new class() implements MessageBusInterface {
+            /** @var list<object> */
+            public array $messages = [];
+            public function dispatch(object $message, array $stamps = []): Envelope
+            {
+                $this->messages[] = $message;
+                return new Envelope($message, $stamps);
+            }
+        };
+
+        self::getContainer()->set(MessageBusInterface::class, $spyBus);
+
+        $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
+        $handler(new SyncWbFinancialReportDayMessage(
+            companyId: $company->getId(),
+            connectionId: $connection->getId(),
+            businessDate: '2026-05-19',
+            mode: FinancialReportSyncMode::MANUAL->value,
+            forceRefresh: true,
+        ));
+
+        $dispatched = array_values(array_filter(
+            $spyBus->messages,
+            static fn (object $m): bool => $m instanceof ProcessDayReportMessage,
+        ));
+
+        self::assertCount(1, $dispatched);
+        self::assertTrue($dispatched[0]->forceRefresh);
     }
 
     private function createCompany(int $index): Company


### PR DESCRIPTION
### Motivation
- Allow forced refresh of Wildberries `sales_report` processing while preventing accidental deletion of rows already linked to closed documents and record conflicts in sync status.

### Description
- Add `WbGeneratedRowsSafeReplaceService` and `WbGeneratedRowsSafeReplaceServiceInterface` to check for linked closed documents and safely delete generated `sales`, `returns`, and `costs`, and introduce `WbGeneratedRowsConflictException` for conflict cases.
- Add `countDocumentLinkedByRawDocument` and `deleteByRawDocument` methods to `MarketplaceSaleRepository`, `MarketplaceReturnRepository`, and `MarketplaceCostRepository`, and add `MarketplaceFinancialReportSyncStatusLookupInterface` implemented by `MarketplaceFinancialReportSyncStatusRepository` for status lookup by raw document id.
- Extend `WbFinancialReportSyncStatusUpdaterInterface` with `markConflict` and wire the new services in `site/config/services.yaml`.
- Propagate `forceRefresh` through `ProcessDayReportMessage` and from `SyncWbFinancialReportDayHandler` into dispatched messages, and update `ProcessDayReportHandler` to run the safe cleanup when `forceRefresh` is set for WB `sales_report`, marking sync status on conflict, logging, flushing and failing the message as unrecoverable.
- Add tests covering the new behavior: integration `WbFinancialReportRefreshTest` and unit tests `ProcessDayReportHandlerTest` and updates to `SyncWbFinancialReportDayHandlerTest` to assert `forceRefresh` propagation.

### Testing
- Ran unit tests including `ProcessDayReportHandlerTest` and `SyncWbFinancialReportDayHandlerTest`, and they passed.
- Ran integration test `WbFinancialReportRefreshTest` which passed and verifies deletion of open rows and that conflicts prevent partial deletion.
- Full automated test suite completed successfully with the new tests included.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fddda35388323b750586a7ac0e980)