### PR TITLE
Extend SyncWbFinancialReportDayHandler unit tests and add test helpers

### DIFF
--- a/site/tests/Unit/Marketplace/MessageHandler/SyncWbFinancialReportDayHandlerTest.php
+++ b/site/tests/Unit/Marketplace/MessageHandler/SyncWbFinancialReportDayHandlerTest.php
@@ -24,8 +24,8 @@ use App\Tests\Support\Kernel\IntegrationTestCase;
 use Symfony\Component\Clock\MockClock;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
-use Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -33,29 +33,60 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
 {
     public function testServiceWiring(): void
     {
-        $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
+        self::assertInstanceOf(SyncWbFinancialReportDayHandler::class, self::getContainer()->get(SyncWbFinancialReportDayHandler::class));
+    }
 
-        self::assertInstanceOf(SyncWbFinancialReportDayHandler::class, $handler);
+    public function testEmptyResponseMarksEmptyWithoutRawDocumentAndWithoutDispatch(): void
+    {
+        $company = $this->createCompany(9201);
+        $connection = $this->createWbSellerConnection($company, 9201);
+        $bus = $this->swapBusSpy();
+        $this->swapWbClient([new MockResponse('', ['http_code' => 204])]);
+
+        $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
+        $handler($this->message($company->getId(), $connection->getId(), false));
+
+        $status = $this->findStatus($connection->getId(), $company->getId(), '2026-05-19');
+        self::assertNotNull($status);
+        self::assertSame(FinancialReportSyncStatus::EMPTY, $status->getStatus());
+        self::assertSame(0, $this->countRawDocuments($company->getId(), '2026-05-19'));
+        self::assertCount(0, $this->filterProcessMessages($bus->messages));
+    }
+
+    public function testRowsResponseCreatesRawDocumentMarksProcessingAndDispatches(): void
+    {
+        $company = $this->createCompany(9202);
+        $connection = $this->createWbSellerConnection($company, 9202);
+        $bus = $this->swapBusSpy();
+        $this->swapWbClient([new MockResponse('[{"rrdId":11},{"rrdId":12}]', ['http_code' => 200])]);
+
+        $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
+        $handler($this->message($company->getId(), $connection->getId(), false));
+
+        $status = $this->findStatus($connection->getId(), $company->getId(), '2026-05-19');
+        self::assertNotNull($status);
+        self::assertSame(FinancialReportSyncStatus::PROCESSING, $status->getStatus());
+
+        $raw = $this->findRawDocument($company->getId(), '2026-05-19');
+        self::assertNotNull($raw);
+        self::assertSame(2, $raw->getRecordsCount());
+
+        $messages = $this->filterProcessMessages($bus->messages);
+        self::assertCount(1, $messages);
+        self::assertSame($raw->getId(), $messages[0]->rawDocumentId);
     }
 
     public function testTemporaryApiExceptionMarksRetryableFailedAndStoresError(): void
     {
-        $company = $this->createCompany(9101);
-        $connection = $this->createWbSellerConnection($company, 9101);
-
+        $company = $this->createCompany(9203);
+        $connection = $this->createWbSellerConnection($company, 9203);
         $this->swapWbClient([new MockResponse('{"error":"temporary"}', ['http_code' => 500])]);
 
         $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
-
         $this->expectException(RecoverableMessageHandlingException::class);
+
         try {
-            $handler(new SyncWbFinancialReportDayMessage(
-                companyId: $company->getId(),
-                connectionId: $connection->getId(),
-                businessDate: '2026-05-19',
-                mode: FinancialReportSyncMode::MANUAL->value,
-                forceRefresh: false,
-            ));
+            $handler($this->message($company->getId(), $connection->getId(), false));
         } finally {
             $status = $this->findStatus($connection->getId(), $company->getId(), '2026-05-19');
             self::assertNotNull($status);
@@ -69,38 +100,18 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
 
     public function testConflictMarksConflictAndThrowsUnrecoverable(): void
     {
-        $company = $this->createCompany(9102);
-        $connection = $this->createWbSellerConnection($company, 9102);
+        $company = $this->createCompany(9204);
+        $connection = $this->createWbSellerConnection($company, 9204);
         $businessDate = new \DateTimeImmutable('2026-05-19');
 
-        $existingRaw = new MarketplaceRawDocument(
-            'bbbbbbbb-bbbb-4bbb-8bbb-000000009102',
-            $company,
-            MarketplaceType::WILDBERRIES,
-            'sales_report',
-        );
-        $existingRaw->setPeriodFrom($businessDate);
-        $existingRaw->setPeriodTo($businessDate);
-        $existingRaw->setApiEndpoint('wildberries::finance-sales-reports-detailed');
-        $existingRaw->setRawData([['rrdId' => 1]]);
-        $existingRaw->setRecordsCount(1);
-        $this->setRawDocumentProcessingStatus($existingRaw, PipelineStatus::RUNNING);
-        $this->em->persist($existingRaw);
-        $this->em->flush();
-
+        $existingRaw = $this->createRaw($company, $businessDate, [['rrdId' => 1]], 1, PipelineStatus::RUNNING);
         $this->swapWbClient([new MockResponse('[{"rrdId":2}]', ['http_code' => 200])]);
 
         $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
-
         $this->expectException(UnrecoverableMessageHandlingException::class);
+
         try {
-            $handler(new SyncWbFinancialReportDayMessage(
-                companyId: $company->getId(),
-                connectionId: $connection->getId(),
-                businessDate: '2026-05-19',
-                mode: FinancialReportSyncMode::MANUAL->value,
-                forceRefresh: true,
-            ));
+            $handler($this->message($company->getId(), $connection->getId(), true));
         } finally {
             $status = $this->findStatus($connection->getId(), $company->getId(), '2026-05-19');
             self::assertNotNull($status);
@@ -109,45 +120,154 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
             $error = $this->findLastError($status->getId());
             self::assertNotNull($error);
             self::assertSame('App\Marketplace\Exception\WbRawDocumentRefreshConflictException', $error->getErrorClass());
+            self::assertSame($existingRaw->getId(), $this->findRawDocument($company->getId(), '2026-05-19')?->getId());
         }
     }
 
-
     public function testForceRefreshIsPropagatedToProcessDayReportMessage(): void
     {
-        $company = $this->createCompany(9103);
-        $connection = $this->createWbSellerConnection($company, 9103);
-
+        $company = $this->createCompany(9205);
+        $connection = $this->createWbSellerConnection($company, 9205);
+        $bus = $this->swapBusSpy();
         $this->swapWbClient([new MockResponse('[{"rrdId":2}]', ['http_code' => 200])]);
 
-        $spyBus = new class() implements MessageBusInterface {
-            /** @var list<object> */
-            public array $messages = [];
-            public function dispatch(object $message, array $stamps = []): Envelope
-            {
-                $this->messages[] = $message;
-                return new Envelope($message, $stamps);
-            }
-        };
+        $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
+        $handler($this->message($company->getId(), $connection->getId(), true));
 
-        self::getContainer()->set(MessageBusInterface::class, $spyBus);
+        $messages = $this->filterProcessMessages($bus->messages);
+        self::assertCount(1, $messages);
+        self::assertTrue($messages[0]->forceRefresh);
+    }
+
+    public function testExistingCompletedRawWithForceFalseUsesCanonicalRawDocument(): void
+    {
+        $company = $this->createCompany(9206);
+        $connection = $this->createWbSellerConnection($company, 9206);
+        $existing = $this->createRaw($company, new \DateTimeImmutable('2026-05-19'), [['rrdId' => 100]], 1, PipelineStatus::COMPLETED);
+        $bus = $this->swapBusSpy();
+        $this->swapWbClient([new MockResponse('[{"rrdId":200}]', ['http_code' => 200])]);
 
         $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
-        $handler(new SyncWbFinancialReportDayMessage(
-            companyId: $company->getId(),
-            connectionId: $connection->getId(),
-            businessDate: '2026-05-19',
-            mode: FinancialReportSyncMode::MANUAL->value,
-            forceRefresh: true,
-        ));
+        $handler($this->message($company->getId(), $connection->getId(), false));
 
-        $dispatched = array_values(array_filter(
-            $spyBus->messages,
-            static fn (object $m): bool => $m instanceof ProcessDayReportMessage,
-        ));
+        $raw = $this->findRawDocument($company->getId(), '2026-05-19');
+        self::assertNotNull($raw);
+        self::assertSame($existing->getId(), $raw->getId());
+        self::assertSame([['rrdId' => 200]], $raw->getRawData());
+        self::assertCount(1, $this->filterProcessMessages($bus->messages));
+    }
 
-        self::assertCount(1, $dispatched);
-        self::assertTrue($dispatched[0]->forceRefresh);
+    public function testExistingCompletedRawWithForceTrueRefreshesRawData(): void
+    {
+        $company = $this->createCompany(9207);
+        $connection = $this->createWbSellerConnection($company, 9207);
+        $existing = $this->createRaw($company, new \DateTimeImmutable('2026-05-19'), [['rrdId' => 300]], 1, PipelineStatus::COMPLETED);
+        $this->swapWbClient([new MockResponse('[{"rrdId":301},{"rrdId":302}]', ['http_code' => 200])]);
+
+        $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
+        $handler($this->message($company->getId(), $connection->getId(), true));
+
+        $raw = $this->findRawDocument($company->getId(), '2026-05-19');
+        self::assertNotNull($raw);
+        self::assertSame($existing->getId(), $raw->getId());
+        self::assertSame([['rrdId' => 301], ['rrdId' => 302]], $raw->getRawData());
+        self::assertSame(2, $raw->getRecordsCount());
+    }
+
+    public function testRateLimitMarksFailedAndThrowsRecoverable(): void
+    {
+        $company = $this->createCompany(9208);
+        $connection = $this->createWbSellerConnection($company, 9208);
+        $this->swapWbClient([new MockResponse('{"error":"too many"}', ['http_code' => 429, 'response_headers' => ['x-ratelimit-retry: 120']])]);
+
+        $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
+        $this->expectException(RecoverableMessageHandlingException::class);
+
+        try {
+            $handler($this->message($company->getId(), $connection->getId(), false));
+        } finally {
+            $status = $this->findStatus($connection->getId(), $company->getId(), '2026-05-19');
+            self::assertNotNull($status);
+            self::assertSame(FinancialReportSyncStatus::FAILED, $status->getStatus());
+            self::assertNotNull($status->getNextRetryAt());
+
+            $error = $this->findLastError($status->getId());
+            self::assertNotNull($error);
+            self::assertSame('App\Marketplace\Exception\MarketplaceRateLimitException', $error->getErrorClass());
+        }
+    }
+
+    public function testAuthExceptionMarksAuthFailedAndStoresError(): void
+    {
+        $company = $this->createCompany(9209);
+        $connection = $this->createWbSellerConnection($company, 9209);
+        $this->swapWbClient([new MockResponse('{"error":"auth"}', ['http_code' => 401])]);
+
+        $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
+        $this->expectException(UnrecoverableMessageHandlingException::class);
+
+        try {
+            $handler($this->message($company->getId(), $connection->getId(), false));
+        } finally {
+            $status = $this->findStatus($connection->getId(), $company->getId(), '2026-05-19');
+            self::assertNotNull($status);
+            self::assertSame(FinancialReportSyncStatus::AUTH_FAILED, $status->getStatus());
+            $error = $this->findLastError($status->getId());
+            self::assertNotNull($error);
+            self::assertSame('App\Marketplace\Exception\MarketplaceAuthException', $error->getErrorClass());
+        }
+    }
+
+    public function testInvalidBusinessDateThrowsAndSkipsStatusCreation(): void
+    {
+        $company = $this->createCompany(9210);
+        $connection = $this->createWbSellerConnection($company, 9210);
+        $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
+        $this->expectException(\DomainException::class);
+
+        try {
+            $handler(new SyncWbFinancialReportDayMessage($company->getId(), $connection->getId(), '2026-02-31', FinancialReportSyncMode::MANUAL->value, false));
+        } finally {
+            self::assertNull($this->findStatus($connection->getId(), $company->getId(), '2026-02-28'));
+        }
+    }
+
+    public function testInactiveConnectionSkips(): void
+    {
+        $company = $this->createCompany(9211);
+        $connection = $this->createWbSellerConnection($company, 9211);
+        $connection->setIsActive(false);
+        $this->em->flush();
+
+        $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
+        $handler($this->message($company->getId(), $connection->getId(), false));
+        self::assertNull($this->findStatus($connection->getId(), $company->getId(), '2026-05-19'));
+    }
+
+    public function testWrongMarketplaceOrConnectionTypeSkips(): void
+    {
+        $company = $this->createCompany(9212);
+
+        $ozon = new MarketplaceConnection('aaaaaaaa-aaaa-4aaa-8aaa-000000009212', $company, MarketplaceType::OZON, MarketplaceConnectionType::SELLER);
+        $ozon->setApiKey('oz')->setIsActive(true);
+        $this->em->persist($ozon);
+
+        $wbPerformance = new MarketplaceConnection('aaaaaaaa-aaaa-4aaa-8aaa-000000009213', $company, MarketplaceType::WILDBERRIES, MarketplaceConnectionType::PERFORMANCE);
+        $wbPerformance->setApiKey('wb')->setIsActive(true);
+        $this->em->persist($wbPerformance);
+        $this->em->flush();
+
+        $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
+        $handler($this->message($company->getId(), $ozon->getId(), false));
+        $handler($this->message($company->getId(), $wbPerformance->getId(), false));
+
+        self::assertNull($this->findStatus($ozon->getId(), $company->getId(), '2026-05-19'));
+        self::assertNull($this->findStatus($wbPerformance->getId(), $company->getId(), '2026-05-19'));
+    }
+
+    private function message(string $companyId, string $connectionId, bool $forceRefresh): SyncWbFinancialReportDayMessage
+    {
+        return new SyncWbFinancialReportDayMessage($companyId, $connectionId, '2026-05-19', FinancialReportSyncMode::MANUAL->value, $forceRefresh);
     }
 
     private function createCompany(int $index): Company
@@ -163,31 +283,59 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
 
     private function createWbSellerConnection(Company $company, int $suffix): MarketplaceConnection
     {
-        $connection = new MarketplaceConnection(
-            sprintf('aaaaaaaa-aaaa-4aaa-8aaa-%012d', $suffix),
-            $company,
-            MarketplaceType::WILDBERRIES,
-            MarketplaceConnectionType::SELLER,
-        );
+        $connection = new MarketplaceConnection(sprintf('aaaaaaaa-aaaa-4aaa-8aaa-%012d', $suffix), $company, MarketplaceType::WILDBERRIES, MarketplaceConnectionType::SELLER);
         $connection->setApiKey('wb-test-token')->setIsActive(true);
-
         $this->em->persist($connection);
         $this->em->flush();
 
         return $connection;
     }
 
+    private function createRaw(Company $company, \DateTimeImmutable $date, array $rows, int $count, PipelineStatus $status): MarketplaceRawDocument
+    {
+        $raw = new MarketplaceRawDocument(sprintf('bbbbbbbb-bbbb-4bbb-8bbb-%012d', random_int(1, 999999)), $company, MarketplaceType::WILDBERRIES, 'sales_report');
+        $raw->setPeriodFrom($date);
+        $raw->setPeriodTo($date);
+        $raw->setApiEndpoint('wildberries::finance-sales-reports-detailed');
+        $raw->setRawData($rows);
+        $raw->setRecordsCount($count);
+        $this->setRawDocumentProcessingStatus($raw, $status);
+        $this->em->persist($raw);
+        $this->em->flush();
+
+        return $raw;
+    }
+
     /** @param list<MockResponse> $responses */
     private function swapWbClient(array $responses): void
     {
-        $client = new WbFinanceSalesReportClient(
-            new MockHttpClient($responses),
-            new MockClock('2026-05-20 12:00:00 UTC'),
-        );
-
-        self::getContainer()->set(WbFinanceSalesReportClient::class, $client);
+        self::getContainer()->set(WbFinanceSalesReportClient::class, new WbFinanceSalesReportClient(new MockHttpClient($responses), new MockClock('2026-05-20 12:00:00 UTC')));
     }
 
+    private function swapBusSpy(): object
+    {
+        $spyBus = new class() implements MessageBusInterface {
+            /** @var list<object> */
+            public array $messages = [];
+
+            public function dispatch(object $message, array $stamps = []): Envelope
+            {
+                $this->messages[] = $message;
+
+                return new Envelope($message, $stamps);
+            }
+        };
+
+        self::getContainer()->set(MessageBusInterface::class, $spyBus);
+
+        return $spyBus;
+    }
+
+    /** @param list<object> $messages */
+    private function filterProcessMessages(array $messages): array
+    {
+        return array_values(array_filter($messages, static fn (object $m): bool => $m instanceof ProcessDayReportMessage));
+    }
 
     private function setRawDocumentProcessingStatus(MarketplaceRawDocument $document, PipelineStatus $status): void
     {
@@ -211,5 +359,27 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
         return $this->em->getRepository(MarketplaceFinancialReportSyncError::class)->findOneBy([
             'syncStatusId' => $statusId,
         ], ['createdAt' => 'DESC']);
+    }
+
+    private function findRawDocument(string $companyId, string $date): ?MarketplaceRawDocument
+    {
+        return $this->em->getRepository(MarketplaceRawDocument::class)->findOneBy([
+            'company' => $companyId,
+            'marketplace' => MarketplaceType::WILDBERRIES,
+            'documentType' => 'sales_report',
+            'periodFrom' => new \DateTimeImmutable($date),
+            'periodTo' => new \DateTimeImmutable($date),
+        ]);
+    }
+
+    private function countRawDocuments(string $companyId, string $date): int
+    {
+        return $this->em->getRepository(MarketplaceRawDocument::class)->count([
+            'company' => $companyId,
+            'marketplace' => MarketplaceType::WILDBERRIES,
+            'documentType' => 'sales_report',
+            'periodFrom' => new \DateTimeImmutable($date),
+            'periodTo' => new \DateTimeImmutable($date),
+        ]);
     }
 }


### PR DESCRIPTION
### Motivation

- Improve coverage and robustness of the `SyncWbFinancialReportDayHandler` behaviour by adding tests for multiple HTTP responses and edge cases. 
- Centralize and simplify test setup and assertions via helper methods to reduce duplication and make scenarios clearer.

### Description

- Added many new test cases in `SyncWbFinancialReportDayHandlerTest` covering empty responses, rows responses, temporary API errors, conflict handling, force-refresh propagation, reuse/refresh of completed raw documents, rate limiting, auth failures, invalid business date handling, inactive connections, and wrong marketplace/connection types. 
- Introduced helper methods `message`, `createCompany`, `createWbSellerConnection`, `createRaw`, `swapWbClient`, `swapBusSpy`, `filterProcessMessages`, `findRawDocument`, and `countRawDocuments` to centralize test wiring and assertions. 
- Replaced inline ad-hoc test doubles with a container-injected `WbFinanceSalesReportClient` mocked via `MockHttpClient` and a spy `MessageBusInterface` implementation registered in the container. 
- Small import/order adjustments and added an explicit `testServiceWiring` smoke test to ensure the handler is wired in the container.

### Testing

- Ran the updated unit test file `SyncWbFinancialReportDayHandlerTest` under PHPUnit; all tests passed. 
- Exercised HTTP response scenarios with `MockHttpClient` and verified message dispatching using the spy bus; assertions in tests confirmed expected status and error records were created.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fe7385b9c83239067f396d2c3b436)