### PR TITLE
Add unified WB financial reports cron jobs and disable legacy wb-daily-sync

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1864,6 +1864,9 @@ paths:
 | `app:marketplace-ads:ozon-poll-reports` | `*/2 * * * *` | Legacy Messenger-pipeline: per-UUID polling (оставлен до Task-11.9b) |
 | `app:marketplace:daily-sync` | `04:30 daily` | Диспатч загрузки данных по активным подключениям |
 | `app:inventory:ozon-daily-sync` | `04:05 daily` | Диспатч загрузки Ozon Inventory snapshot по активным Ozon SELLER подключениям |
+| `app:marketplace:wb-financial-reports:sync --mode=daily` | `03:10 daily` | Ежедневное планирование WB financial sync за рабочий день (новая date-based команда) |
+| `app:marketplace:wb-financial-reports:sync --mode=refresh14` | `04:20 daily` | Планирование пересинхронизации последних 14 дней WB financial reports |
+| `app:marketplace:wb-financial-reports:sync --mode=missing --max-days=10` | `05:30 daily` | Планирование дозагрузки пропущенных дней (до 10 дней на подключение) |
 
 **Правила для новых cron-команд:**
 - Класс в `src/{Module}/Command/`, `final class`, `#[AsCommand]`
@@ -1871,6 +1874,7 @@ paths:
 - Нет `Request`/`Session`/`Security` — CLI-контекст, companyId из аргумента/итерации по БД
 - Per-item try/catch: сбой одной компании / одной записи не прерывает весь запуск
 - Exit code: `Command::SUCCESS` / `Command::FAILURE`
+- Legacy команда `app:marketplace:wb-daily-sync` сохранена для backward compatibility, но её cron отключён после TASK-028-FIX (активный daily cron только `app:marketplace:wb-financial-reports:sync --mode=daily`).
 
 ---
 

--- a/docker/cron/app.cron
+++ b/docker/cron/app.cron
@@ -5,7 +5,13 @@
 #*/5 * * * * php /app/bin/console app:cash:auto-rules:enqueue --no-interaction
 
 # Ночная синхронизация отчётов WB по реализации.
-0 3 * * * php bin/console app:marketplace:wb-daily-sync --no-interaction
+# Legacy WB daily command kept for backward compatibility; cron disabled after TASK-028-FIX.
+# 0 3 * * * php bin/console app:marketplace:wb-daily-sync --no-interaction
+
+# Новый WB financial sync (TASK-028): единая команда-планировщик по режимам.
+10 3 * * * php bin/console app:marketplace:wb-financial-reports:sync --mode=daily --no-interaction --quiet
+20 4 * * * php bin/console app:marketplace:wb-financial-reports:sync --mode=refresh14 --no-interaction --quiet
+30 5 * * * php bin/console app:marketplace:wb-financial-reports:sync --mode=missing --max-days=10 --no-interaction --quiet
 
 # Ночная синхронизация отчётов Ozon по реализации.
 0 4 * * * php bin/console app:marketplace:ozon-daily-sync --no-interaction


### PR DESCRIPTION
### Motivation

- Introduce a single, mode-driven scheduler for WB financial reports to replace the old per-purpose `wb-daily-sync` flow and support daily, refresh and missing-day re-syncs.
- Reflect the operational change in documentation and ensure the old command remains for backward compatibility but is no longer scheduled.

### Description

- Added three new cron entries to `docker/cron/app.cron` to run `app:marketplace:wb-financial-reports:sync` in `--mode=daily`, `--mode=refresh14`, and `--mode=missing --max-days=10` with staggered times and `--quiet` flags.
- Disabled the legacy `app:marketplace:wb-daily-sync` cron line and left the command available for backward compatibility.
- Updated `ARCHITECTURE.md` to document the new cron commands and to note that the legacy `wb-daily-sync` cron is disabled after `TASK-028-FIX`.

### Testing

- Ran the repository automated unit test suite via `phpunit`, and all tests passed.
- Ran the repository CI lint/static checks (`composer test`), and the checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ff2a4a1288323a42c75ea667cacd8)