### PR TITLE
Wildberries row classifier: accept camelCase keys and 'приёмка' variant; add unit tests

### DIFF
--- a/site/src/Marketplace/Infrastructure/Normalizer/Wildberries/WbReportRowClassifier.php
+++ b/site/src/Marketplace/Infrastructure/Normalizer/Wildberries/WbReportRowClassifier.php
@@ -19,7 +19,13 @@ final readonly class WbReportRowClassifier implements RowClassifierInterface
 
     public function classify(array $rawRow): StagingRecordType
     {
-        $operation = (string) ($rawRow['supplier_oper_name'] ?? $rawRow['doc_type_name'] ?? '');
+        $operation = $this->firstNonEmptyString(
+            $rawRow,
+            'sellerOperName',
+            'supplier_oper_name',
+            'docTypeName',
+            'doc_type_name',
+        );
         $normalized = mb_strtolower($operation);
 
         if (str_contains($normalized, 'продажа')) {
@@ -30,7 +36,7 @@ final readonly class WbReportRowClassifier implements RowClassifierInterface
             return StagingRecordType::RETURN;
         }
 
-        foreach (['логистика', 'штраф', 'хранение', 'удержание', 'возмещение', 'приемка'] as $keyword) {
+        foreach (['логистика', 'штраф', 'хранение', 'удержание', 'возмещение', 'приемка', 'приёмка'] as $keyword) {
             if (str_contains($normalized, $keyword)) {
                 return StagingRecordType::COST;
             }
@@ -38,4 +44,23 @@ final readonly class WbReportRowClassifier implements RowClassifierInterface
 
         return StagingRecordType::OTHER;
     }
+
+    private function firstNonEmptyString(array $row, string ...$keys): string
+    {
+        foreach ($keys as $key) {
+            if (!array_key_exists($key, $row)) {
+                continue;
+            }
+
+            $value = trim((string) $row[$key]);
+
+            if ($value !== '') {
+                return $value;
+            }
+        }
+
+        return '';
+    }
+
 }
+

--- a/site/tests/Unit/Marketplace/Infrastructure/Normalizer/Wildberries/WbReportRowClassifierTest.php
+++ b/site/tests/Unit/Marketplace/Infrastructure/Normalizer/Wildberries/WbReportRowClassifierTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Infrastructure\Normalizer\Wildberries;
+
+use App\Marketplace\Enum\StagingRecordType;
+use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbReportRowClassifier;
+use PHPUnit\Framework\TestCase;
+
+final class WbReportRowClassifierTest extends TestCase
+{
+    private WbReportRowClassifier $classifier;
+
+    protected function setUp(): void
+    {
+        $this->classifier = new WbReportRowClassifier();
+    }
+
+    public function testCamelCaseSaleClassifiedAsSale(): void
+    {
+        $row = ['sellerOperName' => 'Продажа', 'docTypeName' => 'Продажа'];
+
+        self::assertSame(StagingRecordType::SALE, $this->classifier->classify($row));
+    }
+
+    public function testSnakeCaseSaleClassifiedAsSale(): void
+    {
+        $row = ['supplier_oper_name' => 'Продажа', 'doc_type_name' => 'Продажа'];
+
+        self::assertSame(StagingRecordType::SALE, $this->classifier->classify($row));
+    }
+
+    public function testCamelCaseReturnClassifiedAsReturn(): void
+    {
+        $row = ['sellerOperName' => 'Возврат', 'docTypeName' => 'Возврат'];
+
+        self::assertSame(StagingRecordType::RETURN, $this->classifier->classify($row));
+    }
+
+    public function testSnakeCaseReturnClassifiedAsReturn(): void
+    {
+        $row = ['supplier_oper_name' => 'Возврат', 'doc_type_name' => 'Возврат'];
+
+        self::assertSame(StagingRecordType::RETURN, $this->classifier->classify($row));
+    }
+
+    public function testCamelCaseLogisticsClassifiedAsCost(): void
+    {
+        $row = ['sellerOperName' => 'Логистика', 'docTypeName' => ''];
+
+        self::assertSame(StagingRecordType::COST, $this->classifier->classify($row));
+    }
+
+    public function testSnakeCaseLogisticsClassifiedAsCost(): void
+    {
+        $row = ['supplier_oper_name' => 'Логистика', 'doc_type_name' => ''];
+
+        self::assertSame(StagingRecordType::COST, $this->classifier->classify($row));
+    }
+
+    public function testCamelCaseFallbackToDocTypeWhenSellerOperNameIsEmpty(): void
+    {
+        $row = ['sellerOperName' => '', 'docTypeName' => 'Продажа'];
+
+        self::assertSame(StagingRecordType::SALE, $this->classifier->classify($row));
+    }
+
+    public function testSnakeCaseFallbackToDocTypeWhenSupplierOperNameIsEmpty(): void
+    {
+        $row = ['supplier_oper_name' => '', 'doc_type_name' => 'Возврат'];
+
+        self::assertSame(StagingRecordType::RETURN, $this->classifier->classify($row));
+    }
+
+    public function testEmptyOperationValuesClassifiedAsOther(): void
+    {
+        $row = ['sellerOperName' => '', 'docTypeName' => ''];
+
+        self::assertSame(StagingRecordType::OTHER, $this->classifier->classify($row));
+    }
+
+    public function testPriyomkaWithYoClassifiedAsCost(): void
+    {
+        $row = ['sellerOperName' => 'Приёмка', 'docTypeName' => ''];
+
+        self::assertSame(StagingRecordType::COST, $this->classifier->classify($row));
+    }
+
+}


### PR DESCRIPTION
### Motivation
- Allow classifier to handle Wildberries feed rows that use camelCase field names in addition to existing snake_case keys. 
- Treat the Russian word variant with "ё" (`приёмка`) as a cost-related operation in addition to the existing forms. 
- Improve coverage by adding unit tests that assert classification behavior across key naming variations and empty fallbacks.

### Description
- Added a helper method `firstNonEmptyString` to prefer multiple possible keys (`sellerOperName`, `supplier_oper_name`, `docTypeName`, `doc_type_name`) and return the first non-empty string. 
- Updated `WbReportRowClassifier::classify` to use the new helper so camelCase fields are supported and normalized consistently. 
- Included `приёмка` (with `ё`) in the keywords that map to `StagingRecordType::COST`. 
- Added unit tests in `WbReportRowClassifierTest` to validate camelCase and snake_case handling, fallback behavior when primary keys are empty, and classification of `Приёмка`.

### Testing
- Added PHPUnit test class `WbReportRowClassifierTest` with tests covering sale, return, cost, empty, and fallback cases. 
- Ran the unit test suite for the classifier (`phpunit` for the new test file), and all tests passed. 
- No integration or functional tests were modified or required for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10991578748323956fb8c8acce70cf)