### PR TITLE
Wildberries row normalizer: skip empty values, add fields and parity tests

### DIFF
--- a/site/src/Marketplace/Infrastructure/Normalizer/Wildberries/WbSalesReportRowNormalizer.php
+++ b/site/src/Marketplace/Infrastructure/Normalizer/Wildberries/WbSalesReportRowNormalizer.php
@@ -26,6 +26,11 @@ final readonly class WbSalesReportRowNormalizer
         return $this->string($row, 'sellerOperName', 'supplier_oper_name');
     }
 
+    public function operationName(array $row): string
+    {
+        return $this->sellerOperName($row);
+    }
+
     public function nmId(array $row): string
     {
         return $this->string($row, 'nmId', 'nm_id');
@@ -34,6 +39,16 @@ final readonly class WbSalesReportRowNormalizer
     public function vendorCode(array $row): string
     {
         return $this->string($row, 'vendorCode', 'sa_name');
+    }
+
+    public function brandName(array $row): string
+    {
+        return $this->string($row, 'brandName', 'brand_name');
+    }
+
+    public function subjectName(array $row): string
+    {
+        return $this->string($row, 'subjectName', 'subject_name');
     }
 
     public function techSize(array $row): ?string
@@ -74,6 +89,51 @@ final readonly class WbSalesReportRowNormalizer
     public function acquiringFee(array $row): float
     {
         return $this->float($row, 'acquiringFee', 'acquiring_fee');
+    }
+
+    public function deliveryAmount(array $row): float
+    {
+        return $this->float($row, 'deliveryAmount', 'delivery_amount');
+    }
+
+    public function returnAmount(array $row): float
+    {
+        return $this->float($row, 'returnAmount', 'return_amount');
+    }
+
+    public function deliveryService(array $row): float
+    {
+        return $this->float($row, 'deliveryService', 'delivery_rub');
+    }
+
+    public function paidStorage(array $row): float
+    {
+        return $this->float($row, 'paidStorage', 'storage_fee');
+    }
+
+    public function paidAcceptance(array $row): float
+    {
+        return $this->float($row, 'paidAcceptance', 'acceptance');
+    }
+
+    public function rebillLogisticCost(array $row): float
+    {
+        return $this->float($row, 'rebillLogisticCost', 'rebill_logistic_cost');
+    }
+
+    public function bonusTypeName(array $row): string
+    {
+        return $this->string($row, 'bonusTypeName', 'bonus_type_name');
+    }
+
+    public function ppvzReward(array $row): float
+    {
+        return $this->float($row, 'ppvzReward', 'ppvz_reward');
+    }
+
+    public function cashbackDiscount(array $row): float
+    {
+        return $this->float($row, 'cashbackDiscount', 'cashback_discount');
     }
 
     public function reportDate(array $row): \DateTimeImmutable
@@ -119,9 +179,20 @@ final readonly class WbSalesReportRowNormalizer
     private function raw(array $row, string ...$keys): mixed
     {
         foreach ($keys as $key) {
-            if (array_key_exists($key, $row)) {
-                return $row[$key];
+            if (!array_key_exists($key, $row)) {
+                continue;
             }
+
+            $value = $row[$key];
+            if ($value === null) {
+                continue;
+            }
+
+            if (is_string($value) && trim($value) === '') {
+                continue;
+            }
+
+            return $value;
         }
 
         return null;
@@ -129,7 +200,9 @@ final readonly class WbSalesReportRowNormalizer
 
     private function string(array $row, string ...$keys): string
     {
-        return trim((string) ($this->raw($row, ...$keys) ?? ''));
+        $value = $this->raw($row, ...$keys);
+
+        return $value === null ? '' : trim((string) $value);
     }
 
     private function nullableString(array $row, string ...$keys): ?string
@@ -141,7 +214,24 @@ final readonly class WbSalesReportRowNormalizer
 
     private function float(array $row, string ...$keys): float
     {
-        return (float) ($this->raw($row, ...$keys) ?? 0);
+        foreach ($keys as $key) {
+            if (!array_key_exists($key, $row)) {
+                continue;
+            }
+
+            $value = $row[$key];
+            if ($value === null) {
+                continue;
+            }
+
+            if (is_string($value) && trim($value) === '') {
+                continue;
+            }
+
+            return (float) $value;
+        }
+
+        return 0.0;
     }
 
     private function normalizeDocTypeName(string $value): ?string
@@ -153,4 +243,3 @@ final readonly class WbSalesReportRowNormalizer
         };
     }
 }
-

--- a/site/tests/Unit/Marketplace/Infrastructure/Normalizer/Wildberries/WbSalesReportRowNormalizerTest.php
+++ b/site/tests/Unit/Marketplace/Infrastructure/Normalizer/Wildberries/WbSalesReportRowNormalizerTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Infrastructure\Normalizer\Wildberries;
+
+use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
+use PHPUnit\Framework\TestCase;
+
+final class WbSalesReportRowNormalizerTest extends TestCase
+{
+    public function testSnakeCaseAndCamelCaseRowsAreNormalizedEqually(): void
+    {
+        $normalizer = new WbSalesReportRowNormalizer();
+
+        $snakeCase = [
+            'supplier_oper_name' => 'Логистика продажа',
+            'doc_type_name' => 'Продажа',
+            'nm_id' => '12345',
+            'ts_name' => 'M',
+            'barcode' => '4600000000001',
+            'sa_name' => 'ART-1',
+            'brand_name' => 'Brand X',
+            'subject_name' => 'T-Shirt',
+            'retail_price' => '1500.50',
+            'retail_price_withdisc_rub' => '1300.40',
+            'ppvz_for_pay' => '1200.30',
+            'acquiring_fee' => '20.10',
+            'delivery_amount' => '2',
+            'return_amount' => '0',
+            'delivery_rub' => '15.5',
+            'storage_fee' => '',
+            'acceptance' => null,
+            'rebill_logistic_cost' => '3.2',
+            'bonus_type_name' => 'Скидка WB',
+            'ppvz_reward' => '1.5',
+            'cashback_discount' => '0.7',
+            'sale_dt' => '2026-05-01 11:00:00',
+            'rr_dt' => '2026-05-01 12:00:00',
+        ];
+
+        $camelCase = [
+            'sellerOperName' => 'Логистика продажа',
+            'docTypeName' => 'Продажа',
+            'nmId' => '12345',
+            'techSize' => 'M',
+            'sku' => '4600000000001',
+            'vendorCode' => 'ART-1',
+            'brandName' => 'Brand X',
+            'subjectName' => 'T-Shirt',
+            'retailPrice' => '1500.50',
+            'retailPriceWithDisc' => '1300.40',
+            'forPay' => '1200.30',
+            'acquiringFee' => '20.10',
+            'deliveryAmount' => '2',
+            'returnAmount' => '0',
+            'deliveryService' => '15.5',
+            'paidStorage' => '',
+            'paidAcceptance' => null,
+            'rebillLogisticCost' => '3.2',
+            'bonusTypeName' => 'Скидка WB',
+            'ppvzReward' => '1.5',
+            'cashbackDiscount' => '0.7',
+            'saleDt' => '2026-05-01 11:00:00',
+            'rrDate' => '2026-05-01 12:00:00',
+        ];
+
+        self::assertSame($normalizer->operationName($snakeCase), $normalizer->operationName($camelCase));
+        self::assertSame($normalizer->docTypeName($snakeCase), $normalizer->docTypeName($camelCase));
+        self::assertSame($normalizer->nmId($snakeCase), $normalizer->nmId($camelCase));
+        self::assertSame($normalizer->techSize($snakeCase), $normalizer->techSize($camelCase));
+        self::assertSame($normalizer->barcode($snakeCase), $normalizer->barcode($camelCase));
+        self::assertSame($normalizer->vendorCode($snakeCase), $normalizer->vendorCode($camelCase));
+        self::assertSame($normalizer->brandName($snakeCase), $normalizer->brandName($camelCase));
+        self::assertSame($normalizer->subjectName($snakeCase), $normalizer->subjectName($camelCase));
+        self::assertSame($normalizer->retailPrice($snakeCase), $normalizer->retailPrice($camelCase));
+        self::assertSame($normalizer->retailPriceWithDisc($snakeCase), $normalizer->retailPriceWithDisc($camelCase));
+        self::assertSame($normalizer->forPay($snakeCase), $normalizer->forPay($camelCase));
+        self::assertSame($normalizer->acquiringFee($snakeCase), $normalizer->acquiringFee($camelCase));
+        self::assertSame($normalizer->deliveryAmount($snakeCase), $normalizer->deliveryAmount($camelCase));
+        self::assertSame($normalizer->returnAmount($snakeCase), $normalizer->returnAmount($camelCase));
+        self::assertSame($normalizer->deliveryService($snakeCase), $normalizer->deliveryService($camelCase));
+        self::assertSame($normalizer->paidStorage($snakeCase), $normalizer->paidStorage($camelCase));
+        self::assertSame($normalizer->paidAcceptance($snakeCase), $normalizer->paidAcceptance($camelCase));
+        self::assertSame($normalizer->rebillLogisticCost($snakeCase), $normalizer->rebillLogisticCost($camelCase));
+        self::assertSame($normalizer->bonusTypeName($snakeCase), $normalizer->bonusTypeName($camelCase));
+        self::assertSame($normalizer->ppvzReward($snakeCase), $normalizer->ppvzReward($camelCase));
+        self::assertSame($normalizer->cashbackDiscount($snakeCase), $normalizer->cashbackDiscount($camelCase));
+        self::assertSame(
+            $normalizer->operationDate($snakeCase)->format('Y-m-d H:i:s'),
+            $normalizer->operationDate($camelCase)->format('Y-m-d H:i:s'),
+        );
+        self::assertSame(
+            $normalizer->reportDate($snakeCase)->format('Y-m-d H:i:s'),
+            $normalizer->reportDate($camelCase)->format('Y-m-d H:i:s'),
+        );
+    }
+
+    public function testStringFallbackSkipsEmptyCamelCaseAndUsesSnakeCase(): void
+    {
+        $normalizer = new WbSalesReportRowNormalizer();
+
+        $row = [
+            'sellerOperName' => '',
+            'supplier_oper_name' => 'Продажа',
+        ];
+
+        self::assertSame('Продажа', $normalizer->sellerOperName($row));
+    }
+
+    public function testNullableStringFallbackSkipsEmptyCamelCaseAndUsesSnakeCase(): void
+    {
+        $normalizer = new WbSalesReportRowNormalizer();
+
+        $row = [
+            'techSize' => '',
+            'ts_name' => 'M',
+        ];
+
+        self::assertSame('M', $normalizer->techSize($row));
+    }
+
+    public function testFloatFallbackSkipsEmptyCamelCaseAndUsesSnakeCase(): void
+    {
+        $normalizer = new WbSalesReportRowNormalizer();
+
+        $row = [
+            'retailPriceWithDisc' => '',
+            'retail_price_withdisc_rub' => '1300.40',
+        ];
+
+        self::assertSame(1300.40, $normalizer->retailPriceWithDisc($row));
+    }
+
+    public function testFloatReturnsZeroWhenAllFallbackValuesAreEmpty(): void
+    {
+        $normalizer = new WbSalesReportRowNormalizer();
+
+        $row = [
+            'paidStorage' => '',
+            'storage_fee' => null,
+        ];
+
+        self::assertSame(0.0, $normalizer->paidStorage($row));
+    }
+
+    public function testOperationDateFallbackSkipsEmptySaleDtAndUsesRrDate(): void
+    {
+        $normalizer = new WbSalesReportRowNormalizer();
+
+        $row = [
+            'saleDt' => '',
+            'rrDate' => '2026-05-01',
+        ];
+
+        self::assertSame('2026-05-01', $normalizer->operationDate($row)->format('Y-m-d'));
+    }
+}


### PR DESCRIPTION
### Motivation

- Treat empty strings and explicit nulls as absent values when normalizing Wildberries report rows to ensure correct fallback between camelCase and snake_case keys.
- Expose additional report columns via dedicated accessors to support more fields returned by Wildberries reports.
- Add unit tests to guarantee parity between snake_case and camelCase inputs and correct fallback behavior.

### Description

- Update `raw()` to skip missing keys, `null` values and empty strings and return the first non-empty value found across provided keys. 
- Make `string()` return empty string only when no value is found and adjust `nullableString()` to convert empty string to `null` accordingly. 
- Update `float()` to iterate keys and skip missing/null/empty-string values, returning `0.0` when no numeric value is present. 
- Add new accessor methods: `operationName()`, `brandName()`, `subjectName()`, `deliveryAmount()`, `returnAmount()`, `deliveryService()`, `paidStorage()`, `paidAcceptance()`, `rebillLogisticCost()`, `bonusTypeName()`, `ppvzReward()`, and `cashbackDiscount()`. 
- Add unit tests in `tests/Unit/Marketplace/Infrastructure/Normalizer/Wildberries/WbSalesReportRowNormalizerTest.php` covering snake_case vs camelCase parity and fallback behaviors for `string`, `nullableString`, `float` and date fallbacks. 

### Testing

- Ran the new unit tests with `phpunit tests/Unit/Marketplace/Infrastructure/Normalizer/Wildberries/WbSalesReportRowNormalizerTest.php`. 
- All tests in the added test file passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a109bd7270883238809a3a60a8b4408)