### PR TITLE
Use Normalizer for Wildberries fields in sales/returns processors and update tests

### DIFF
--- a/site/src/Marketplace/Application/ProcessWbReturnsAction.php
+++ b/site/src/Marketplace/Application/ProcessWbReturnsAction.php
@@ -63,7 +63,7 @@ final class ProcessWbReturnsAction
             'total_filtered' => count($returnsData),
         ]);
 
-        $allSrids = array_column($returnsData, 'srid');
+        $allSrids = array_values(array_filter(array_map(fn (array $item): ?string => $this->normalizer->srid($item), $returnsData)));
         $existingSridsMap = $this->returnRepository->getExistingExternalIds($companyId, $allSrids);
 
         $allNmIds = array_values(array_unique(array_map(
@@ -88,10 +88,10 @@ final class ProcessWbReturnsAction
             }
 
             $listing = $this->listingResolver->resolve($company, $nmId, $tsName, [
-                'sa_name'      => (string) ($item['sa_name'] ?? ''),
-                'brand_name'   => (string) ($item['brand_name'] ?? ''),
-                'subject_name' => (string) ($item['subject_name'] ?? ''),
-                'retail_price' => (string) ($item['retail_price'] ?? '0'),
+                'sa_name'      => $this->normalizer->vendorCode($item),
+                'brand_name'   => $this->normalizer->brandName($item),
+                'subject_name' => $this->normalizer->subjectName($item),
+                'retail_price' => (string) $this->normalizer->retailPrice($item),
             ]);
 
             $listingsCache[$cacheKey] = $listing;
@@ -107,7 +107,7 @@ final class ProcessWbReturnsAction
 
         foreach ($returnsData as $item) {
             try {
-                $externalReturnId = (string) $item['srid'];
+                $externalReturnId = (string) ($this->normalizer->srid($item) ?? '');
 
                 if (isset($existingSridsMap[$externalReturnId])) {
                     continue;
@@ -172,7 +172,7 @@ final class ProcessWbReturnsAction
                 }
             } catch (\Exception $e) {
                 $this->logger->error('[WB] Failed to process return item', [
-                    'srid' => $item['srid'] ?? 'unknown',
+                    'srid' => $this->normalizer->srid($item) ?? 'unknown',
                     'error' => $e->getMessage(),
                 ]);
                 continue;

--- a/site/src/Marketplace/Application/ProcessWbSalesAction.php
+++ b/site/src/Marketplace/Application/ProcessWbSalesAction.php
@@ -60,7 +60,7 @@ final class ProcessWbSalesAction
             'total_filtered' => count($salesData),
         ]);
 
-        $allSrids = array_column($salesData, 'srid');
+        $allSrids = array_values(array_filter(array_map(fn (array $item): ?string => $this->normalizer->srid($item), $salesData)));
         $existingSridsMap = $this->saleRepository->getExistingExternalIds($companyId, $allSrids);
 
         $allNmIds = array_values(array_unique(array_map(
@@ -83,9 +83,9 @@ final class ProcessWbSalesAction
             if (!isset($listingsCache[$cacheKey])) {
                 $listing = $this->listingResolver->resolve($company, $nmId, $tsName, [
                     'sa_name'      => $this->normalizer->vendorCode($item),
-                    'brand_name'   => (string) ($item['brand_name'] ?? $item['brandName'] ?? ''),
-                    'subject_name' => (string) ($item['subject_name'] ?? $item['subjectName'] ?? ''),
-                    'retail_price' => (string) ($item['retail_price'] ?? $item['retailPrice'] ?? '0'),
+                    'brand_name'   => $this->normalizer->brandName($item),
+                    'subject_name' => $this->normalizer->subjectName($item),
+                    'retail_price' => (string) $this->normalizer->retailPrice($item),
                 ]);
                 $listingsCache[$cacheKey] = $listing;
                 $newListingsCreated++;
@@ -100,7 +100,7 @@ final class ProcessWbSalesAction
         $counter = 0;
         foreach ($salesData as $item) {
             try {
-                $externalOrderId = (string) $item['srid'];
+                $externalOrderId = (string) ($this->normalizer->srid($item) ?? '');
                 if (isset($existingSridsMap[$externalOrderId])) {
                     continue;
                 }
@@ -158,7 +158,7 @@ final class ProcessWbSalesAction
                 }
             } catch (\Throwable $e) {
                 $this->logger->error('[WB] Failed to process sale', [
-                    'srid'  => $item['srid'] ?? 'unknown',
+                    'srid'  => $this->normalizer->srid($item) ?? 'unknown',
                     'error' => $e->getMessage(),
                 ]);
             }

--- a/site/src/Marketplace/Application/Processor/WbReturnsRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/WbReturnsRawProcessor.php
@@ -102,12 +102,12 @@ final class WbReturnsRawProcessor implements MarketplaceRawProcessorInterface
                 continue;
             }
 
-            $barcode = (string) ($item['barcode'] ?? '');
+            $barcode = (string) ($this->normalizer->barcode($item) ?? '');
             $listing = $this->listingResolver->resolve($company, $nmId, $tsName, [
-                'sa_name'      => (string) ($item['sa_name'] ?? ''),
-                'brand_name'   => (string) ($item['brand_name'] ?? ''),
-                'subject_name' => (string) ($item['subject_name'] ?? ''),
-                'retail_price' => (string) ($item['retail_price'] ?? '0'),
+                'sa_name'      => $this->normalizer->vendorCode($item),
+                'brand_name'   => $this->normalizer->brandName($item),
+                'subject_name' => $this->normalizer->subjectName($item),
+                'retail_price' => (string) $this->normalizer->retailPrice($item),
             ], $barcode);
             $listingsCache[$cacheKey] = $listing;
             $newListings++;
@@ -119,11 +119,11 @@ final class WbReturnsRawProcessor implements MarketplaceRawProcessorInterface
             $this->listingResolver->flushBarcodes();
         }
 
-        $allSrids = array_values(array_filter(array_column($returnsData, 'srid')));
+        $allSrids = array_values(array_filter(array_map(fn (array $item): ?string => $this->normalizer->srid($item), $returnsData)));
         $existingMap = $this->returnRepository->getExistingExternalIds($companyId, $allSrids);
 
         foreach ($returnsData as $item) {
-            $srid = (string) ($item['srid'] ?? '');
+            $srid = (string) ($this->normalizer->srid($item) ?? '');
             if ($srid === '' || isset($existingMap[$srid])) {
                 continue;
             }

--- a/site/src/Marketplace/Application/Processor/WbSalesRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/WbSalesRawProcessor.php
@@ -103,9 +103,9 @@ final class WbSalesRawProcessor implements MarketplaceRawProcessorInterface
             $barcode = (string) ($this->normalizer->barcode($item) ?? '');
             $listing = $this->listingResolver->resolve($company, $nmId, $tsName, [
                 'sa_name'      => $this->normalizer->vendorCode($item),
-                'brand_name'   => (string) ($item['brand_name'] ?? $item['brandName'] ?? ''),
-                'subject_name' => (string) ($item['subject_name'] ?? $item['subjectName'] ?? ''),
-                'retail_price' => (string) ($item['retail_price'] ?? $item['retailPrice'] ?? '0'),
+                'brand_name'   => $this->normalizer->brandName($item),
+                'subject_name' => $this->normalizer->subjectName($item),
+                'retail_price' => (string) $this->normalizer->retailPrice($item),
             ], $barcode);
             $listingsCache[$cacheKey] = $listing;
             $newListings++;
@@ -117,11 +117,11 @@ final class WbSalesRawProcessor implements MarketplaceRawProcessorInterface
             $this->listingResolver->flushBarcodes();
         }
 
-        $allSrids = array_values(array_filter(array_column($salesData, 'srid')));
+        $allSrids = array_values(array_filter(array_map(fn (array $item): ?string => $this->normalizer->srid($item), $salesData)));
         $existingMap = $this->saleRepository->getExistingExternalIds($companyId, $allSrids);
 
         foreach ($salesData as $item) {
-            $srid = (string) ($item['srid'] ?? '');
+            $srid = (string) ($this->normalizer->srid($item) ?? '');
             if ($srid === '' || isset($existingMap[$srid])) {
                 continue;
             }

--- a/site/tests/Unit/Marketplace/Application/Processor/WbReturnsRawProcessorRefundAmountTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/WbReturnsRawProcessorRefundAmountTest.php
@@ -8,17 +8,20 @@ use App\Company\Entity\Company;
 use App\Marketplace\Application\ProcessWbReturnsAction;
 use App\Marketplace\Application\Processor\WbReturnsRawProcessor;
 use App\Marketplace\Application\Service\MarketplaceBarcodeCatalogService;
-use App\Marketplace\Repository\MarketplaceBarcodeCatalogRepository;
 use App\Marketplace\Application\Service\MarketplaceCostPriceResolver;
 use App\Marketplace\Application\Service\WbListingResolverService;
 use App\Marketplace\Entity\MarketplaceListing;
 use App\Marketplace\Entity\MarketplaceReturn;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
+use App\Marketplace\Infrastructure\Query\WbBarcodeUpsertQuery;
 use App\Marketplace\Inventory\CostPriceResolverInterface;
+use App\Marketplace\Repository\MarketplaceBarcodeCatalogRepository;
+use App\Marketplace\Repository\MarketplaceListingBarcodeRepository;
 use App\Marketplace\Repository\MarketplaceListingRepository;
 use App\Marketplace\Repository\MarketplaceReturnRepository;
 use App\Marketplace\Repository\MarketplaceSaleRepository;
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -49,51 +52,69 @@ final class WbReturnsRawProcessorRefundAmountTest extends TestCase
         self::assertSame('2026-01-10', $result['returns'][0]->getReturnDate()->format('Y-m-d'));
     }
 
-    public function testUsesRetailPriceWithDiscAsRefundAmountForNewCamelCase(): void
+    public function testCamelCaseReturnCreatesReturnAndListingWithNormalizedMetadata(): void
     {
         $result = $this->runProcessorWithRow([
-            'docTypeName' => 'Return',
-            'retailPriceWithDisc' => 1125,
-            'retailAmount' => 720,
-            'retailPrice' => 1500,
+            'docTypeName' => 'Возврат',
+            'sellerOperName' => 'Возврат',
             'quantity' => 1,
-            'srid' => 'WB-RETURN-1',
-            'nmId' => '123',
-            'techSize' => 'XL',
-            'sellerOperName' => 'Customer return',
-            'rrDate' => '2026-01-10 10:00:00',
-        ]);
+            'retailPriceWithDisc' => 2099,
+            'nmId' => '123456',
+            'techSize' => 'M',
+            'sku' => '200000000001',
+            'vendorCode' => 'ART-001',
+            'brandName' => 'TestBrand',
+            'subjectName' => 'Одежда',
+            'retailPrice' => 2500,
+            'saleDt' => '2026-05-22T10:00:00Z',
+            'rrDate' => '2026-05-22',
+            'srid' => 'test-return-srid-1',
+        ], true);
 
         self::assertCount(1, $result['returns']);
-        self::assertSame([['123']], $result['nmIdsCalls']);
-        self::assertSame('1125', $result['returns'][0]->getRefundAmount());
-        self::assertNotSame('720', $result['returns'][0]->getRefundAmount());
-        self::assertNotSame('1500', $result['returns'][0]->getRefundAmount());
-        self::assertSame('Customer return', $result['returns'][0]->getReturnReason());
-        self::assertSame('2026-01-10', $result['returns'][0]->getReturnDate()->format('Y-m-d'));
+        self::assertSame('test-return-srid-1', $result['returns'][0]->getExternalReturnId());
+        self::assertSame('2099', $result['returns'][0]->getRefundAmount());
+
+        self::assertCount(1, $result['createdListings']);
+        $listing = $result['createdListings'][0];
+        self::assertSame('ART-001', $listing->getSupplierSku());
+        self::assertSame('2500', $listing->getPrice());
+        self::assertSame('M', $listing->getSize());
+        self::assertNotNull($listing->getName());
+        self::assertStringContainsString('TestBrand', (string) $listing->getName());
+        self::assertStringContainsString('Одежда', (string) $listing->getName());
+        self::assertStringContainsString('ART-001', (string) $listing->getName());
+        self::assertStringContainsString('M', (string) $listing->getName());
     }
 
     /**
      * @param array<string, mixed> $row
-     * @return array{returns: list<MarketplaceReturn>, nmIdsCalls: list<list<string>>}
+     * @return array{returns: list<MarketplaceReturn>, createdListings: list<MarketplaceListing>, nmIdsCalls: list<list<string>>}
      */
-    private function runProcessorWithRow(array $row): array
+    private function runProcessorWithRow(array $row, bool $forceResolve = false): array
     {
         $company = $this->createMock(Company::class);
-        $listing = $this->createMock(MarketplaceListing::class);
+        $company->method('getId')->willReturn('company-1');
+        $existingListing = $this->createMock(MarketplaceListing::class);
 
         $persistedReturns = [];
+        $createdListings = [];
         $nmIdsCalls = [];
 
         $em = $this->createMock(EntityManagerInterface::class);
         $em->method('find')->willReturnMap([
             [Company::class, 'company-1', $company],
         ]);
-        $em->method('persist')->willReturnCallback(static function (object $entity) use (&$persistedReturns): void {
-            if ($entity instanceof MarketplaceReturn) {
-                $persistedReturns[] = $entity;
-            }
-        });
+        $em->method('persist')->willReturnCallback(
+            static function (object $entity) use (&$persistedReturns, &$createdListings): void {
+                if ($entity instanceof MarketplaceReturn) {
+                    $persistedReturns[] = $entity;
+                }
+                if ($entity instanceof MarketplaceListing) {
+                    $createdListings[] = $entity;
+                }
+            },
+        );
 
         $returnRepository = $this->createMock(MarketplaceReturnRepository::class);
         $returnRepository->method('getExistingExternalIds')->willReturn([]);
@@ -104,18 +125,32 @@ final class WbReturnsRawProcessorRefundAmountTest extends TestCase
                 Company $companyArg,
                 MarketplaceType $marketplace,
                 array $nmIds,
-            ) use ($listing, &$nmIdsCalls): array {
+            ) use (&$nmIdsCalls, $forceResolve, $existingListing): array {
                 $nmIdsCalls[] = $nmIds;
-                return ['123_XL' => $listing];
+
+                return $forceResolve ? [] : ['123_XL' => $existingListing];
             });
+        $listingRepository->method('findByNmIdAndSize')->willReturn(null);
 
         $saleRepository = $this->createMock(MarketplaceSaleRepository::class);
         $saleRepository->method('findByMarketplaceOrder')->willReturn(null);
+
+        $barcodeRepository = $this->createMock(MarketplaceListingBarcodeRepository::class);
+        $barcodeRepository->method('findByBarcode')->willReturn(null);
+
+        $connection = $this->createMock(Connection::class);
+        $resolver = new WbListingResolverService(
+            $listingRepository,
+            $barcodeRepository,
+            new WbBarcodeUpsertQuery($connection),
+            $em,
+        );
 
         $barcodeCatalogRepository = $this->createMock(MarketplaceBarcodeCatalogRepository::class);
         $barcodeCatalogRepository->method('findByBarcode')->willReturn(null);
         $barcodeCatalogRepository->method('findByBarcodesIndexed')->willReturn([]);
         $barcodeCatalog = new MarketplaceBarcodeCatalogService($barcodeCatalogRepository);
+
         $innerCostPriceResolver = $this->createMock(CostPriceResolverInterface::class);
         $innerCostPriceResolver->method('resolve')->willReturn('0.00');
         $costPriceResolver = new MarketplaceCostPriceResolver($innerCostPriceResolver);
@@ -126,7 +161,7 @@ final class WbReturnsRawProcessorRefundAmountTest extends TestCase
             $returnRepository,
             $saleRepository,
             $listingRepository,
-            $this->makeWbListingResolverServiceStub(),
+            $resolver,
             $barcodeCatalog,
             $costPriceResolver,
             new WbSalesReportRowNormalizer(),
@@ -135,16 +170,15 @@ final class WbReturnsRawProcessorRefundAmountTest extends TestCase
 
         $processor->processBatch('company-1', MarketplaceType::WILDBERRIES, [$row]);
 
-        return ['returns' => $persistedReturns, 'nmIdsCalls' => $nmIdsCalls];
+        return [
+            'returns' => $persistedReturns,
+            'createdListings' => $createdListings,
+            'nmIdsCalls' => $nmIdsCalls,
+        ];
     }
+
     private function makeProcessWbReturnsActionStub(): ProcessWbReturnsAction
     {
         return (new \ReflectionClass(ProcessWbReturnsAction::class))->newInstanceWithoutConstructor();
     }
-
-    private function makeWbListingResolverServiceStub(): WbListingResolverService
-    {
-        return (new \ReflectionClass(WbListingResolverService::class))->newInstanceWithoutConstructor();
-    }
-
 }

--- a/site/tests/Unit/Marketplace/Application/Processor/WbSalesRawProcessorRevenueTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/WbSalesRawProcessorRevenueTest.php
@@ -8,16 +8,19 @@ use App\Company\Entity\Company;
 use App\Marketplace\Application\ProcessWbSalesAction;
 use App\Marketplace\Application\Processor\WbSalesRawProcessor;
 use App\Marketplace\Application\Service\MarketplaceBarcodeCatalogService;
-use App\Marketplace\Repository\MarketplaceBarcodeCatalogRepository;
 use App\Marketplace\Application\Service\MarketplaceCostPriceResolver;
 use App\Marketplace\Application\Service\WbListingResolverService;
 use App\Marketplace\Entity\MarketplaceListing;
 use App\Marketplace\Entity\MarketplaceSale;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
+use App\Marketplace\Infrastructure\Query\WbBarcodeUpsertQuery;
 use App\Marketplace\Inventory\CostPriceResolverInterface;
+use App\Marketplace\Repository\MarketplaceBarcodeCatalogRepository;
+use App\Marketplace\Repository\MarketplaceListingBarcodeRepository;
 use App\Marketplace\Repository\MarketplaceListingRepository;
 use App\Marketplace\Repository\MarketplaceSaleRepository;
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -45,48 +48,71 @@ final class WbSalesRawProcessorRevenueTest extends TestCase
         self::assertSame('2026-01-10', $result['sales'][0]->getSaleDate()->format('Y-m-d'));
     }
 
-    public function testUsesRetailPriceWithDiscAsRevenueForNewCamelCase(): void
+    public function testCamelCaseSaleCreatesSaleAndListingWithNormalizedMetadata(): void
     {
         $result = $this->runProcessorWithRow([
-            'docTypeName' => 'Sale',
-            'retailPriceWithDisc' => 2493,
-            'retailAmount' => 1607,
+            'docTypeName' => 'Продажа',
+            'sellerOperName' => 'Продажа',
             'quantity' => 1,
-            'srid' => 'WB-ORDER-1',
-            'nmId' => '123',
-            'techSize' => 'XL',
-            'saleDt' => '2026-01-10 10:00:00',
-        ]);
+            'retailPriceWithDisc' => 2099,
+            'retailAmount' => 1584,
+            'nmId' => '123456',
+            'techSize' => 'M',
+            'sku' => '200000000001',
+            'vendorCode' => 'ART-001',
+            'brandName' => 'TestBrand',
+            'subjectName' => 'Одежда',
+            'retailPrice' => 2500,
+            'saleDt' => '2026-05-21T10:00:00Z',
+            'rrDate' => '2026-05-21',
+            'srid' => 'test-sale-srid-1',
+        ], true);
 
         self::assertCount(1, $result['sales']);
-        self::assertSame([['123']], $result['nmIdsCalls']);
-        self::assertSame('2493', $result['sales'][0]->getTotalRevenue());
-        self::assertSame('2493', $result['sales'][0]->getPricePerUnit());
-        self::assertNotSame('1607', $result['sales'][0]->getTotalRevenue());
-        self::assertSame('2026-01-10', $result['sales'][0]->getSaleDate()->format('Y-m-d'));
+        self::assertSame('test-sale-srid-1', $result['sales'][0]->getExternalOrderId());
+        self::assertSame('2099', $result['sales'][0]->getTotalRevenue());
+        self::assertNotSame('1584', $result['sales'][0]->getTotalRevenue());
+
+        self::assertCount(1, $result['createdListings']);
+        $listing = $result['createdListings'][0];
+        self::assertSame('ART-001', $listing->getSupplierSku());
+        self::assertSame('2500', $listing->getPrice());
+        self::assertSame('M', $listing->getSize());
+        self::assertNotNull($listing->getName());
+        self::assertStringContainsString('TestBrand', (string) $listing->getName());
+        self::assertStringContainsString('Одежда', (string) $listing->getName());
+        self::assertStringContainsString('ART-001', (string) $listing->getName());
+        self::assertStringContainsString('M', (string) $listing->getName());
     }
 
     /**
      * @param array<string, mixed> $row
-     * @return array{sales: list<MarketplaceSale>, nmIdsCalls: list<list<string>>}
+     * @return array{sales: list<MarketplaceSale>, createdListings: list<MarketplaceListing>, nmIdsCalls: list<list<string>>}
      */
-    private function runProcessorWithRow(array $row): array
+    private function runProcessorWithRow(array $row, bool $forceResolve = false): array
     {
         $company = $this->createMock(Company::class);
-        $listing = $this->createMock(MarketplaceListing::class);
+        $company->method('getId')->willReturn('company-1');
+        $existingListing = $this->createMock(MarketplaceListing::class);
 
         $persistedSales = [];
+        $createdListings = [];
         $nmIdsCalls = [];
 
         $em = $this->createMock(EntityManagerInterface::class);
         $em->method('find')->willReturnMap([
             [Company::class, 'company-1', $company],
         ]);
-        $em->method('persist')->willReturnCallback(static function (object $entity) use (&$persistedSales): void {
-            if ($entity instanceof MarketplaceSale) {
-                $persistedSales[] = $entity;
-            }
-        });
+        $em->method('persist')->willReturnCallback(
+            static function (object $entity) use (&$persistedSales, &$createdListings): void {
+                if ($entity instanceof MarketplaceSale) {
+                    $persistedSales[] = $entity;
+                }
+                if ($entity instanceof MarketplaceListing) {
+                    $createdListings[] = $entity;
+                }
+            },
+        );
 
         $saleRepository = $this->createMock(MarketplaceSaleRepository::class);
         $saleRepository->method('getExistingExternalIds')->willReturn([]);
@@ -97,15 +123,29 @@ final class WbSalesRawProcessorRevenueTest extends TestCase
                 Company $companyArg,
                 MarketplaceType $marketplace,
                 array $nmIds,
-            ) use ($listing, &$nmIdsCalls): array {
+            ) use (&$nmIdsCalls, $forceResolve, $existingListing): array {
                 $nmIdsCalls[] = $nmIds;
-                return ['123_XL' => $listing];
+
+                return $forceResolve ? [] : ['123_XL' => $existingListing];
             });
+        $listingRepository->method('findByNmIdAndSize')->willReturn(null);
+
+        $barcodeRepository = $this->createMock(MarketplaceListingBarcodeRepository::class);
+        $barcodeRepository->method('findByBarcode')->willReturn(null);
+
+        $connection = $this->createMock(Connection::class);
+        $resolver = new WbListingResolverService(
+            $listingRepository,
+            $barcodeRepository,
+            new WbBarcodeUpsertQuery($connection),
+            $em,
+        );
 
         $barcodeCatalogRepository = $this->createMock(MarketplaceBarcodeCatalogRepository::class);
         $barcodeCatalogRepository->method('findByBarcode')->willReturn(null);
         $barcodeCatalogRepository->method('findByBarcodesIndexed')->willReturn([]);
         $barcodeCatalog = new MarketplaceBarcodeCatalogService($barcodeCatalogRepository);
+
         $innerCostPriceResolver = $this->createMock(CostPriceResolverInterface::class);
         $innerCostPriceResolver->method('resolve')->willReturn('0.00');
         $costPriceResolver = new MarketplaceCostPriceResolver($innerCostPriceResolver);
@@ -115,7 +155,7 @@ final class WbSalesRawProcessorRevenueTest extends TestCase
             $em,
             $saleRepository,
             $listingRepository,
-            $this->makeWbListingResolverServiceStub(),
+            $resolver,
             $barcodeCatalog,
             $costPriceResolver,
             new WbSalesReportRowNormalizer(),
@@ -124,16 +164,15 @@ final class WbSalesRawProcessorRevenueTest extends TestCase
 
         $processor->processBatch('company-1', MarketplaceType::WILDBERRIES, [$row]);
 
-        return ['sales' => $persistedSales, 'nmIdsCalls' => $nmIdsCalls];
+        return [
+            'sales' => $persistedSales,
+            'createdListings' => $createdListings,
+            'nmIdsCalls' => $nmIdsCalls,
+        ];
     }
+
     private function makeProcessWbSalesActionStub(): ProcessWbSalesAction
     {
         return (new \ReflectionClass(ProcessWbSalesAction::class))->newInstanceWithoutConstructor();
     }
-
-    private function makeWbListingResolverServiceStub(): WbListingResolverService
-    {
-        return (new \ReflectionClass(WbListingResolverService::class))->newInstanceWithoutConstructor();
-    }
-
 }


### PR DESCRIPTION
### Motivation
- Ensure robust and uniform parsing of Wildberries report rows by using the row normalizer instead of ad-hoc array access to handle both snake_case and camelCase fields and avoid undefined index issues.
- Centralize normalization for identifiers, prices, barcodes and metadata so listing resolution and persistence receive consistent values.

### Description
- Replaced direct array access of fields such as `srid`, `brand_name`/`brandName`, `subject_name`/`subjectName`, `retail_price`/`retailPrice`, `sa_name`/`vendorCode`, and `barcode` with calls to the normalizer methods (`srid`, `brandName`, `subjectName`, `retailPrice`, `vendorCode`, `barcode`) in `ProcessWbSalesAction`, `ProcessWbReturnsAction`, `WbSalesRawProcessor` and `WbReturnsRawProcessor`.
- Made srid extraction more robust by collecting srids with `array_map` + `array_filter` and using the normalizer when logging or checking existing external ids.
- Pass normalized metadata and barcode into the listing resolver and keep barcode flush behavior after creating listings.
- Updated unit tests (`WbReturnsRawProcessorRefundAmountTest` and `WbSalesRawProcessorRevenueTest`) to validate camelCase handling, assert created listings and normalized metadata, collect created listings from `EntityManager::persist`, and instantiate a `WbListingResolverService` with a `WbBarcodeUpsertQuery` stub to exercise listing resolution.
- Minor logging adjustments to include normalized `srid` values.

### Testing
- Ran the modified unit tests in `site/tests/Unit/Marketplace/Application/Processor`, specifically `WbReturnsRawProcessorRefundAmountTest` and `WbSalesRawProcessorRevenueTest`, via `phpunit`; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a109ec6416c83238823bf8d92b97d85)