### PR TITLE
Support camelCase + snake_case fields in WB cost calculators

### DIFF
--- a/site/src/Marketplace/Service/CostCalculator/WbDeductionCalculator.php
+++ b/site/src/Marketplace/Service/CostCalculator/WbDeductionCalculator.php
@@ -25,7 +25,7 @@ class WbDeductionCalculator implements CostCalculatorInterface
 
     public function supports(array $item): bool
     {
-        return ($item['supplier_oper_name'] ?? '') === 'Удержание';
+        return $this->normalizer->sellerOperName($item) === 'Удержание';
     }
 
     public function requiresListing(): bool
@@ -42,10 +42,10 @@ class WbDeductionCalculator implements CostCalculatorInterface
         }
 
 
-        $saleDate = new \DateTimeImmutable($item['sale_dt'] ?? $item['rr_dt']);
+        $saleDate = $this->normalizer->operationDate($item);
 
         // Обработка bonus_type_name
-        $bonusTypeName = (string)($item['bonus_type_name'] ?? '');
+        $bonusTypeName = $this->normalizer->bonusTypeName($item);
 
         // Шаг 1: Удаляем ID-паттерн
         // Паттерн: "Списание за отзыв 1xTgKBfVf6AAWKuVZ1ql: акция №1392833"

--- a/site/src/Marketplace/Service/CostCalculator/WbLogisticsDeliveryCalculator.php
+++ b/site/src/Marketplace/Service/CostCalculator/WbLogisticsDeliveryCalculator.php
@@ -22,8 +22,8 @@ class WbLogisticsDeliveryCalculator implements CostCalculatorInterface
 
     public function supports(array $item): bool
     {
-        return ($item['supplier_oper_name'] ?? '') === 'Логистика'
-            && (int)($item['delivery_amount'] ?? 0) === 1;
+        return $this->normalizer->sellerOperName($item) === 'Логистика'
+            && (int) $this->normalizer->deliveryAmount($item) === 1;
     }
 
     public function requiresListing(): bool
@@ -33,7 +33,7 @@ class WbLogisticsDeliveryCalculator implements CostCalculatorInterface
 
     public function calculate(array $item, ?MarketplaceListing $listing): array
     {
-        $deliveryRub = (float)($item['delivery_rub'] ?? 0);
+        $deliveryRub = $this->normalizer->deliveryService($item);
 
         if (abs($deliveryRub) < 0.01) {
             return [];
@@ -44,7 +44,7 @@ class WbLogisticsDeliveryCalculator implements CostCalculatorInterface
             return [];
         }
 
-        $saleDate = new \DateTimeImmutable($item['sale_dt'] ?? $item['rr_dt']);
+        $saleDate = $this->normalizer->operationDate($item);
 
         return [
             [

--- a/site/src/Marketplace/Service/CostCalculator/WbLogisticsReturnCalculator.php
+++ b/site/src/Marketplace/Service/CostCalculator/WbLogisticsReturnCalculator.php
@@ -22,8 +22,8 @@ class WbLogisticsReturnCalculator implements CostCalculatorInterface
 
     public function supports(array $item): bool
     {
-        return ($item['supplier_oper_name'] ?? '') === 'Логистика'
-            && (int)($item['return_amount'] ?? 0) === 1;
+        return $this->normalizer->sellerOperName($item) === 'Логистика'
+            && (int) $this->normalizer->returnAmount($item) === 1;
     }
 
     public function requiresListing(): bool
@@ -33,7 +33,7 @@ class WbLogisticsReturnCalculator implements CostCalculatorInterface
 
     public function calculate(array $item, ?MarketplaceListing $listing): array
     {
-        $deliveryRub = (float)($item['delivery_rub'] ?? 0);
+        $deliveryRub = $this->normalizer->deliveryService($item);
 
         if (abs($deliveryRub) < 0.01) {
             return [];
@@ -44,7 +44,7 @@ class WbLogisticsReturnCalculator implements CostCalculatorInterface
             return [];
         }
 
-        $saleDate = new \DateTimeImmutable($item['sale_dt'] ?? $item['rr_dt']);
+        $saleDate = $this->normalizer->operationDate($item);
 
         return [
             [

--- a/site/src/Marketplace/Service/CostCalculator/WbLoyaltyDiscountCalculator.php
+++ b/site/src/Marketplace/Service/CostCalculator/WbLoyaltyDiscountCalculator.php
@@ -22,7 +22,7 @@ class WbLoyaltyDiscountCalculator implements CostCalculatorInterface
 
     public function supports(array $item): bool
     {
-        return ($item['supplier_oper_name'] ?? '') === 'Компенсация скидки по программе лояльности';
+        return $this->normalizer->sellerOperName($item) === 'Компенсация скидки по программе лояльности';
     }
 
     public function requiresListing(): bool
@@ -32,7 +32,7 @@ class WbLoyaltyDiscountCalculator implements CostCalculatorInterface
 
     public function calculate(array $item, ?MarketplaceListing $listing): array
     {
-        $cashbackDiscount = (float)($item['cashback_discount'] ?? 0);
+        $cashbackDiscount = $this->normalizer->cashbackDiscount($item);
 
         if (abs($cashbackDiscount) < 0.01) {
             return [];
@@ -43,7 +43,7 @@ class WbLoyaltyDiscountCalculator implements CostCalculatorInterface
             return [];
         }
 
-        $saleDate = new \DateTimeImmutable($item['sale_dt'] ?? $item['rr_dt']);
+        $saleDate = $this->normalizer->operationDate($item);
 
         // Привязываем к товару только если listing найден
         $product = $listing?->getProduct();

--- a/site/src/Marketplace/Service/CostCalculator/WbPenaltyCalculator.php
+++ b/site/src/Marketplace/Service/CostCalculator/WbPenaltyCalculator.php
@@ -22,7 +22,7 @@ class WbPenaltyCalculator implements CostCalculatorInterface
 
     public function supports(array $item): bool
     {
-        return ($item['supplier_oper_name'] ?? '') === 'Штраф';
+        return $this->normalizer->sellerOperName($item) === 'Штраф';
     }
 
     public function requiresListing(): bool
@@ -42,7 +42,7 @@ class WbPenaltyCalculator implements CostCalculatorInterface
             return [];
         }
 
-        $saleDate = new \DateTimeImmutable($item['sale_dt'] ?? $item['rr_dt']);
+        $saleDate = $this->normalizer->operationDate($item);
 
         // Привязываем к товару только если listing найден
         $product = $listing?->getProduct();

--- a/site/src/Marketplace/Service/CostCalculator/WbProductProcessingCalculator.php
+++ b/site/src/Marketplace/Service/CostCalculator/WbProductProcessingCalculator.php
@@ -25,7 +25,7 @@ class WbProductProcessingCalculator implements CostCalculatorInterface
 
     public function supports(array $item): bool
     {
-        return ($item['supplier_oper_name'] ?? '') === 'Обработка товара';
+        return $this->normalizer->sellerOperName($item) === 'Обработка товара';
     }
 
     public function requiresListing(): bool
@@ -37,7 +37,7 @@ class WbProductProcessingCalculator implements CostCalculatorInterface
     public function calculate(array $item, ?MarketplaceListing $listing): array
     {
         // Сумма затраты - приёмка товара
-        $amount = (float)($item['acceptance'] ?? 0);
+        $amount = $this->normalizer->paidAcceptance($item);
 
         if (abs($amount) < 0.01) {
             return [];
@@ -48,11 +48,11 @@ class WbProductProcessingCalculator implements CostCalculatorInterface
             return [];
         }
 
-        $saleDate = new \DateTimeImmutable($item['sale_dt'] ?? $item['rr_dt']);
+        $saleDate = $this->normalizer->operationDate($item);
 
         // Проверяем есть ли nm_id и ts_name для привязки к товару
-        $nmId = (string)($item['nm_id'] ?? '');
-        $tsName = trim($item['ts_name'] ?? '');
+        $nmId = $this->normalizer->nmId($item);
+        $tsName = trim($this->normalizer->techSize($item) ?? '');
         $product = null;
 
         // Если есть И nm_id И ts_name - привязываем к товару

--- a/site/src/Marketplace/Service/CostCalculator/WbPvzProcessingCalculator.php
+++ b/site/src/Marketplace/Service/CostCalculator/WbPvzProcessingCalculator.php
@@ -22,7 +22,7 @@ class WbPvzProcessingCalculator implements CostCalculatorInterface
 
     public function supports(array $item): bool
     {
-        return ($item['supplier_oper_name'] ?? '') === 'Возмещение за выдачу и возврат товаров на ПВЗ';
+        return $this->normalizer->sellerOperName($item) === 'Возмещение за выдачу и возврат товаров на ПВЗ';
     }
 
     public function requiresListing(): bool
@@ -32,7 +32,7 @@ class WbPvzProcessingCalculator implements CostCalculatorInterface
 
     public function calculate(array $item, ?MarketplaceListing $listing): array
     {
-        $ppvzReward = (float)($item['ppvz_reward'] ?? 0);
+        $ppvzReward = $this->normalizer->ppvzReward($item);
 
         if (abs($ppvzReward) < 0.01) {
             return [];
@@ -43,7 +43,7 @@ class WbPvzProcessingCalculator implements CostCalculatorInterface
             return [];
         }
 
-        $saleDate = new \DateTimeImmutable($item['sale_dt'] ?? $item['rr_dt']);
+        $saleDate = $this->normalizer->operationDate($item);
 
         return [
             [

--- a/site/src/Marketplace/Service/CostCalculator/WbStorageCalculator.php
+++ b/site/src/Marketplace/Service/CostCalculator/WbStorageCalculator.php
@@ -22,7 +22,7 @@ class WbStorageCalculator implements CostCalculatorInterface
 
     public function supports(array $item): bool
     {
-        return ($item['supplier_oper_name'] ?? '') === 'Хранение';
+        return $this->normalizer->sellerOperName($item) === 'Хранение';
     }
 
     public function requiresListing(): bool
@@ -32,7 +32,7 @@ class WbStorageCalculator implements CostCalculatorInterface
 
     public function calculate(array $item, ?MarketplaceListing $listing): array
     {
-        $storageFee = (float)($item['storage_fee'] ?? 0);
+        $storageFee = $this->normalizer->paidStorage($item);
 
         if (abs($storageFee) < 0.01) {
             return [];
@@ -43,7 +43,7 @@ class WbStorageCalculator implements CostCalculatorInterface
             return [];
         }
 
-        $saleDate = new \DateTimeImmutable($item['sale_dt'] ?? $item['rr_dt']);
+        $saleDate = $this->normalizer->operationDate($item);
 
         return [
             [

--- a/site/src/Marketplace/Service/CostCalculator/WbWarehouseLogisticsCalculator.php
+++ b/site/src/Marketplace/Service/CostCalculator/WbWarehouseLogisticsCalculator.php
@@ -22,7 +22,7 @@ class WbWarehouseLogisticsCalculator implements CostCalculatorInterface
 
     public function supports(array $item): bool
     {
-        return ($item['supplier_oper_name'] ?? '') === 'Возмещение издержек по перевозке/по складским операциям с товаром';
+        return $this->normalizer->sellerOperName($item) === 'Возмещение издержек по перевозке/по складским операциям с товаром';
     }
 
     public function requiresListing(): bool
@@ -33,7 +33,7 @@ class WbWarehouseLogisticsCalculator implements CostCalculatorInterface
 
     public function calculate(array $item, ?MarketplaceListing $listing): array
     {
-        $rebillLogisticCost = (float)($item['rebill_logistic_cost'] ?? 0);
+        $rebillLogisticCost = $this->normalizer->rebillLogisticCost($item);
 
         if (abs($rebillLogisticCost) < 0.01) {
             return [];
@@ -44,7 +44,7 @@ class WbWarehouseLogisticsCalculator implements CostCalculatorInterface
             return [];
         }
 
-        $saleDate = new \DateTimeImmutable($item['sale_dt'] ?? $item['rr_dt']);
+        $saleDate = $this->normalizer->operationDate($item);
 
         // Привязываем к товару только если listing найден (nm_id + sa_name были заполнены)
         $product = $listing?->getProduct();

--- a/site/tests/Unit/Marketplace/Application/Processor/WbCostsRawProcessorTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/WbCostsRawProcessorTest.php
@@ -206,6 +206,46 @@ final class WbCostsRawProcessorTest extends TestCase
         self::assertSame(MarketplaceCostOperationType::STORNO, $entries[0]['operation_type']);
     }
 
+    public function testWbLogisticsDeliveryCalculatorCamelCaseMatchesSnakeCase(): void
+    {
+        $calculator = new WbLogisticsDeliveryCalculator();
+        $snakeEntries = $calculator->calculate($this->logisticsItem(1, 0, -42.00), null);
+        $camelEntries = $calculator->calculate([
+            'docTypeName' => 'Услуги',
+            'sellerOperName' => 'Логистика',
+            'srid' => 'SRID-LOG-1',
+            'saleDt' => '2026-01-15 10:00:00',
+            'rrdId' => '2001',
+            'deliveryAmount' => 1,
+            'returnAmount' => 0,
+            'deliveryService' => -42.00,
+        ], null);
+
+        self::assertCount(1, $snakeEntries);
+        self::assertCount(1, $camelEntries);
+        self::assertSame((string) $snakeEntries[0]['amount'], (string) $camelEntries[0]['amount']);
+    }
+
+    public function testWbLogisticsReturnCalculatorCamelCaseMatchesSnakeCase(): void
+    {
+        $calculator = new WbLogisticsReturnCalculator();
+        $snakeEntries = $calculator->calculate($this->logisticsItem(0, 1, 33.00), null);
+        $camelEntries = $calculator->calculate([
+            'docTypeName' => 'Услуги',
+            'sellerOperName' => 'Логистика',
+            'srid' => 'SRID-LOG-2',
+            'saleDt' => '2026-01-15 10:00:00',
+            'rrdId' => '2002',
+            'deliveryAmount' => 0,
+            'returnAmount' => 1,
+            'deliveryService' => 33.00,
+        ], null);
+
+        self::assertCount(1, $snakeEntries);
+        self::assertCount(1, $camelEntries);
+        self::assertSame((string) $snakeEntries[0]['amount'], (string) $camelEntries[0]['amount']);
+    }
+
     public function testWbLogisticsDeliveryCalculatorEmitsPositiveAmount(): void
     {
         $entries = (new WbLogisticsDeliveryCalculator())->calculate(
@@ -243,6 +283,64 @@ final class WbCostsRawProcessorTest extends TestCase
         self::assertSame('storage', $entries[0]['category_code']);
         self::assertGreaterThan(0, (float) $entries[0]['amount']);
         self::assertEqualsWithDelta(125.75, (float) $entries[0]['amount'], 0.001);
+    }
+
+    public function testWbStorageCalculatorCamelCaseMatchesSnakeCase(): void
+    {
+        $calculator = new WbStorageCalculator();
+        $snakeEntries = $calculator->calculate($this->supplierOpItem('Хранение', ['storage_fee' => -125.75]), null);
+        $camelEntries = $calculator->calculate([
+            'docTypeName' => 'Услуги',
+            'sellerOperName' => 'Хранение',
+            'srid' => 'SRID-OP-1',
+            'saleDt' => '2026-01-15 10:00:00',
+            'rrdId' => '3001',
+            'paidStorage' => -125.75,
+        ], null);
+
+        self::assertCount(1, $snakeEntries);
+        self::assertCount(1, $camelEntries);
+        self::assertSame((string) $snakeEntries[0]['amount'], (string) $camelEntries[0]['amount']);
+    }
+
+    public function testWbCommissionCalculatorCamelCaseMatchesSnakeCase(): void
+    {
+        $calculator = new WbCommissionCalculator();
+        $snakeEntries = $calculator->calculate($this->saleItem([
+            'retail_price_withdisc_rub' => 2493.00,
+            'ppvz_for_pay' => 1581.10,
+            'acquiring_fee' => 64.28,
+        ]), null);
+        $camelEntries = $calculator->calculate([
+            'docTypeName' => 'Продажа',
+            'srid' => 'SRID-1',
+            'saleDt' => '2026-01-15 10:00:00',
+            'rrdId' => '1001',
+            'retailPriceWithDisc' => 2493.00,
+            'forPay' => 1581.10,
+            'acquiringFee' => 64.28,
+        ], null);
+
+        self::assertCount(1, $snakeEntries);
+        self::assertCount(1, $camelEntries);
+        self::assertSame((string) $snakeEntries[0]['amount'], (string) $camelEntries[0]['amount']);
+    }
+
+    public function testWbAcquiringCalculatorCamelCaseMatchesSnakeCase(): void
+    {
+        $calculator = new WbAcquiringCalculator();
+        $snakeEntries = $calculator->calculate($this->saleItem(['acquiring_fee' => 64.28]), null);
+        $camelEntries = $calculator->calculate([
+            'docTypeName' => 'Продажа',
+            'srid' => 'SRID-1',
+            'saleDt' => '2026-01-15 10:00:00',
+            'rrdId' => '1001',
+            'acquiringFee' => 64.28,
+        ], null);
+
+        self::assertCount(1, $snakeEntries);
+        self::assertCount(1, $camelEntries);
+        self::assertSame((string) $snakeEntries[0]['amount'], (string) $camelEntries[0]['amount']);
     }
 
     public function testWbPvzProcessingCalculatorEmitsPositiveAmount(): void


### PR DESCRIPTION
### Motivation

- Wildberries introduced a camelCase report format while existing calculators read old snake_case fields; calculators must accept both formats without changing formulas, categories or signs.

### Description

- Replaced direct snake_case array reads in WB cost calculators with `WbSalesReportRowNormalizer` accessors so each calculator accepts both camelCase and snake_case input.
- Updated the following calculators to use the normalizer and `operationDate` where appropriate: `WbLogisticsDeliveryCalculator`, `WbLogisticsReturnCalculator`, `WbStorageCalculator`, `WbDeductionCalculator`, `WbPenaltyCalculator`, `WbProductProcessingCalculator`, `WbPvzProcessingCalculator`, `WbWarehouseLogisticsCalculator`, `WbLoyaltyDiscountCalculator`.
- Added regression unit tests in `WbCostsRawProcessorTest` asserting parity between camelCase and snake_case for logistics delivery, logistics return, storage, commission and acquiring calculations.
- Kept all existing formulas and semantics unchanged (notably commission formula `retailPriceWithDisc - forPay - acquiringFee`, acquiring logic, cost categories and charge/storno signs).

### Testing

- Added PHPUnit tests: new test cases in `site/tests/Unit/Marketplace/Application/Processor/WbCostsRawProcessorTest.php` validate camelCase vs snake_case parity and existing behavior.
- Attempted to run unit tests with `php -d memory_limit=1G bin/phpunit tests/Unit/Marketplace/Service/CostCalculator` and `vendor/bin/phpunit tests/Unit/Marketplace/Application/Processor/WbCostsRawProcessorTest.php`, but test binaries are not available in this environment so automated runs failed due to missing vendor/phpunit bridge (`vendor/bin/phpunit` / `simple-phpunit.php` not found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a112fdf10848323bcb760d25fea76a0)