### PR TITLE
Classify Wildberries "Коррекция логистики" as COST

### DIFF
--- a/site/src/Marketplace/Infrastructure/Normalizer/Wildberries/WbReportRowClassifier.php
+++ b/site/src/Marketplace/Infrastructure/Normalizer/Wildberries/WbReportRowClassifier.php
@@ -36,7 +36,7 @@ final readonly class WbReportRowClassifier implements RowClassifierInterface
             return StagingRecordType::RETURN;
         }
 
-        foreach (['логистика', 'штраф', 'хранение', 'удержание', 'возмещение', 'приемка', 'приёмка'] as $keyword) {
+        foreach (['логистика', 'логистики', 'штраф', 'хранение', 'удержание', 'возмещение', 'приемка', 'приёмка'] as $keyword) {
             if (str_contains($normalized, $keyword)) {
                 return StagingRecordType::COST;
             }

--- a/site/tests/Unit/Marketplace/Infrastructure/Normalizer/Wildberries/WbReportRowClassifierTest.php
+++ b/site/tests/Unit/Marketplace/Infrastructure/Normalizer/Wildberries/WbReportRowClassifierTest.php
@@ -59,6 +59,21 @@ final class WbReportRowClassifierTest extends TestCase
         self::assertSame(StagingRecordType::COST, $this->classifier->classify($row));
     }
 
+
+    public function testSnakeCaseLogisticsCorrectionClassifiedAsCost(): void
+    {
+        $row = ['supplier_oper_name' => 'Коррекция логистики', 'doc_type_name' => ''];
+
+        self::assertSame(StagingRecordType::COST, $this->classifier->classify($row));
+    }
+
+    public function testCamelCaseLogisticsCorrectionClassifiedAsCost(): void
+    {
+        $row = ['sellerOperName' => 'Коррекция логистики', 'docTypeName' => ''];
+
+        self::assertSame(StagingRecordType::COST, $this->classifier->classify($row));
+    }
+
     public function testCamelCaseFallbackToDocTypeWhenSellerOperNameIsEmpty(): void
     {
         $row = ['sellerOperName' => '', 'docTypeName' => 'Продажа'];


### PR DESCRIPTION
### Motivation
- Wildberries reports include new operation text `Коррекция логистики` which must be treated as a cost; current classifier didn't match the inflected form.
- Support both snake_case and camelCase payloads without changing existing sale/return logic.

### Description
- Updated `site/src/Marketplace/Infrastructure/Normalizer/Wildberries/WbReportRowClassifier.php` to include the token `логистики` alongside existing keywords so `Коррекция логистики` is classified as `StagingRecordType::COST`.
- The classifier still prefers `sellerOperName`/`supplier_oper_name` then `docTypeName`/`doc_type_name` and preserves existing precedence for sale and return detection.
- Added two regression tests in `site/tests/Unit/Marketplace/Infrastructure/Normalizer/Wildberries/WbReportRowClassifierTest.php` covering snake_case and camelCase inputs with `Коррекция логистики` expecting `StagingRecordType::COST`.

### Testing
- Added unit tests `testSnakeCaseLogisticsCorrectionClassifiedAsCost` and `testCamelCaseLogisticsCorrectionClassifiedAsCost` in `WbReportRowClassifierTest` and they assert `StagingRecordType::COST` for the new samples.
- Attempted to run PHPUnit with `cd site && php vendor/bin/phpunit tests/Unit/Marketplace/Infrastructure/Normalizer/Wildberries/WbReportRowClassifierTest.php` but it failed due to missing `vendor/bin/phpunit` in the environment.
- Attempted `cd site && php bin/phpunit tests/Unit/Marketplace/Infrastructure/Normalizer/Wildberries/WbReportRowClassifierTest.php` but it failed due to missing Symfony PHPUnit bridge script in `vendor/symfony/phpunit-bridge/bin/simple-phpunit.php`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a114be2865c83239ce1c791cc0cfc11)