### PR TITLE
Add WB logistics correction cost calculator

### DIFF
--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -131,33 +131,38 @@ services:
         tags:
             - { name: 'app.marketplace.cost_calculator', priority: 107 }
 
-    App\Marketplace\Service\CostCalculator\WbStorageCalculator:
+
+    App\Marketplace\Service\CostCalculator\WbLogisticsCorrectionCalculator:
         tags:
             - { name: 'app.marketplace.cost_calculator', priority: 106 }
 
-    App\Marketplace\Service\CostCalculator\WbPvzProcessingCalculator:
+    App\Marketplace\Service\CostCalculator\WbStorageCalculator:
         tags:
             - { name: 'app.marketplace.cost_calculator', priority: 105 }
 
-    App\Marketplace\Service\CostCalculator\WbWarehouseLogisticsCalculator:
+    App\Marketplace\Service\CostCalculator\WbPvzProcessingCalculator:
         tags:
             - { name: 'app.marketplace.cost_calculator', priority: 104 }
 
-    App\Marketplace\Service\CostCalculator\WbPenaltyCalculator:
+    App\Marketplace\Service\CostCalculator\WbWarehouseLogisticsCalculator:
         tags:
             - { name: 'app.marketplace.cost_calculator', priority: 103 }
 
-    App\Marketplace\Service\CostCalculator\WbProductProcessingCalculator:
+    App\Marketplace\Service\CostCalculator\WbPenaltyCalculator:
         tags:
             - { name: 'app.marketplace.cost_calculator', priority: 102 }
 
-    App\Marketplace\Service\CostCalculator\WbDeductionCalculator:
+    App\Marketplace\Service\CostCalculator\WbProductProcessingCalculator:
         tags:
             - { name: 'app.marketplace.cost_calculator', priority: 101 }
 
-    App\Marketplace\Service\CostCalculator\WbLoyaltyDiscountCalculator:
+    App\Marketplace\Service\CostCalculator\WbDeductionCalculator:
         tags:
             - { name: 'app.marketplace.cost_calculator', priority: 100 }
+
+    App\Marketplace\Service\CostCalculator\WbLoyaltyDiscountCalculator:
+        tags:
+            - { name: 'app.marketplace.cost_calculator', priority: 99 }
 
     App\Marketplace\Application\ProcessWbCostsAction:
         arguments:

--- a/site/src/Marketplace/Service/CostCalculator/WbLogisticsCorrectionCalculator.php
+++ b/site/src/Marketplace/Service/CostCalculator/WbLogisticsCorrectionCalculator.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Service\CostCalculator;
+
+use App\Marketplace\Entity\MarketplaceListing;
+use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+class WbLogisticsCorrectionCalculator implements CostCalculatorInterface
+{
+    private WbSalesReportRowNormalizer $normalizer;
+    private WbCostExternalIdBuilder $externalIdBuilder;
+
+    public function __construct(?WbSalesReportRowNormalizer $normalizer = null, ?LoggerInterface $logger = null)
+    {
+        $this->normalizer = $normalizer ?? new WbSalesReportRowNormalizer();
+        $this->externalIdBuilder = new WbCostExternalIdBuilder($this->normalizer, $logger ?? new NullLogger());
+    }
+
+    public function supports(array $item): bool
+    {
+        return $this->normalizer->sellerOperName($item) === 'Коррекция логистики';
+    }
+
+    public function requiresListing(): bool
+    {
+        return true;
+    }
+
+    public function calculate(array $item, ?MarketplaceListing $listing): array
+    {
+        $deliveryRub = $this->normalizer->deliveryService($item);
+
+        if (abs($deliveryRub) < 0.01) {
+            return [];
+        }
+
+        $externalId = $this->externalIdBuilder->build($item, 'logistics_correction');
+        if ($externalId === null) {
+            return [];
+        }
+
+        return [[
+            'category_code' => 'logistics_correction',
+            'category_name' => 'Коррекция логистики',
+            'amount' => (string) abs($deliveryRub),
+            'external_id' => $externalId,
+            'cost_date' => $this->normalizer->operationDate($item),
+            'description' => 'Коррекция логистики WB',
+            'product' => $listing?->getProduct(),
+        ]];
+    }
+}

--- a/site/tests/Unit/Marketplace/Application/Processor/WbCostsRawProcessorTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/WbCostsRawProcessorTest.php
@@ -26,6 +26,7 @@ use App\Marketplace\Service\CostCalculator\WbAcquiringCalculator;
 use App\Marketplace\Service\CostCalculator\WbCommissionCalculator;
 use App\Marketplace\Service\CostCalculator\WbDeductionCalculator;
 use App\Marketplace\Service\CostCalculator\WbLogisticsDeliveryCalculator;
+use App\Marketplace\Service\CostCalculator\WbLogisticsCorrectionCalculator;
 use App\Marketplace\Service\CostCalculator\WbLogisticsReturnCalculator;
 use App\Marketplace\Service\CostCalculator\WbLoyaltyDiscountCalculator;
 use App\Marketplace\Service\CostCalculator\WbPenaltyCalculator;
@@ -270,6 +271,40 @@ final class WbCostsRawProcessorTest extends TestCase
         self::assertSame('logistics_return', $entries[0]['category_code']);
         self::assertGreaterThan(0, (float) $entries[0]['amount']);
         self::assertEqualsWithDelta(33.00, (float) $entries[0]['amount'], 0.001);
+    }
+
+    public function testWbLogisticsCorrectionCalculatorSupportsAndEmitsPositiveAmount(): void
+    {
+        $calculator = new WbLogisticsCorrectionCalculator();
+
+        $snakeRow = $this->supplierOpItem('Коррекция логистики', [
+            'delivery_amount' => 0,
+            'return_amount' => 0,
+            'delivery_rub' => -21.22,
+            'rrd_id' => '3101',
+        ]);
+        $camelRow = [
+            'sellerOperName' => 'Коррекция логистики',
+            'deliveryAmount' => 0,
+            'returnAmount' => 0,
+            'deliveryService' => 21.22,
+            'saleDt' => '2026-01-15 10:00:00',
+            'rrdId' => '3102',
+        ];
+
+        self::assertTrue($calculator->supports($snakeRow));
+        self::assertTrue($calculator->supports($camelRow));
+
+        $snakeEntries = $calculator->calculate($snakeRow, null);
+        $camelEntries = $calculator->calculate($camelRow, null);
+
+        self::assertCount(1, $snakeEntries);
+        self::assertCount(1, $camelEntries);
+        self::assertSame('logistics_correction', $snakeEntries[0]['category_code']);
+        self::assertSame('Коррекция логистики', $snakeEntries[0]['category_name']);
+        self::assertSame('Коррекция логистики WB', $snakeEntries[0]['description']);
+        self::assertEqualsWithDelta(21.22, (float) $snakeEntries[0]['amount'], 0.001);
+        self::assertEqualsWithDelta(21.22, (float) $camelEntries[0]['amount'], 0.001);
     }
 
     public function testWbStorageCalculatorEmitsPositiveAmount(): void
@@ -898,16 +933,17 @@ final class WbCostsRawProcessorTest extends TestCase
     }
 
     /**
-     * Контрактная проверка: все 11 калькуляторов реализуют CostCalculatorInterface.
+     * Контрактная проверка: все 12 калькуляторов реализуют CostCalculatorInterface.
      * На случай если кто-то добавит calculator без implements — поймаем здесь.
      */
-    public function testAllElevenWbCalculatorsImplementInterface(): void
+    public function testAllTwelveWbCalculatorsImplementInterface(): void
     {
         $calculators = [
             new WbCommissionCalculator(),
             new WbAcquiringCalculator(),
             new WbLogisticsDeliveryCalculator(),
             new WbLogisticsReturnCalculator(),
+            new WbLogisticsCorrectionCalculator(),
             new WbStorageCalculator(),
             new WbPvzProcessingCalculator(),
             new WbWarehouseLogisticsCalculator(),
@@ -917,7 +953,7 @@ final class WbCostsRawProcessorTest extends TestCase
             new WbLoyaltyDiscountCalculator(),
         ];
 
-        self::assertCount(11, $calculators, '11 WB-калькуляторов согласно services.yaml');
+        self::assertCount(12, $calculators, '12 WB-калькуляторов согласно services.yaml');
 
         foreach ($calculators as $calc) {
             self::assertInstanceOf(CostCalculatorInterface::class, $calc);


### PR DESCRIPTION
### Motivation
- Wildberries rows with `supplier_oper_name` / `sellerOperName = "Коррекция логистики"` must be represented as a separate cost type instead of being mixed with existing logistics calculators that rely on `deliveryAmount`/`returnAmount` flags.

### Description
- Added `WbLogisticsCorrectionCalculator` at `site/src/Marketplace/Service/CostCalculator/WbLogisticsCorrectionCalculator.php` which implements `CostCalculatorInterface`, uses `WbSalesReportRowNormalizer` and `WbCostExternalIdBuilder`, and supports both snake_case and camelCase input.
- The calculator reads amount from `delivery_rub` / `deliveryService`, returns `[]` when `abs(amount) < 0.01`, generates external IDs with suffix `logistics_correction`, and emits a cost with `category_code = logistics_correction`, `category_name = "Коррекция логистики"`, and `description = "Коррекция логистики WB"`, attaching `product` when `listing` is available.
- Registered the new calculator in `site/config/services.yaml` under the `app.marketplace.cost_calculator` tag and adjusted priorities in the WB calculators block to keep ordering consistent.
- Updated unit tests in `site/tests/Unit/Marketplace/Application/Processor/WbCostsRawProcessorTest.php` with a new test for the correction calculator and bumped the contract test from 11 to 12 calculators.

### Testing
- Ran PHP syntax checks with `php -l` on `WbLogisticsCorrectionCalculator.php`, the modified test file, and `site/config/services.yaml`, all reporting no syntax errors.
- Attempted to run the specific unit test file with PHPUnit (`php bin/phpunit tests/Unit/Marketplace/Application/Processor/WbCostsRawProcessorTest.php`), but the environment lacks Symfony Bridge's `simple-phpunit.php` so the full PHPUnit run could not be executed.
- Unit test file changes are present and ready to run in a CI environment with PHPUnit available and will validate the new calculator once the test runner is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a114dc35e808323b839c24adc353c83)