### PR TITLE
Add WB logistics correction to delivery/FBO grouping

### DIFF
--- a/site/src/Marketplace/Domain/WbCostCategory.php
+++ b/site/src/Marketplace/Domain/WbCostCategory.php
@@ -30,6 +30,7 @@ final readonly class WbCostCategory
             new self('commission', 'Комиссия маркетплейса', 'Вознаграждение', 'Вознаграждение', 'commission'),
             new self('logistics_delivery', 'Логистика до покупателя', 'Услуги доставки и FBO', 'Услуги доставки', 'logistics'),
             new self('logistics_return', 'Логистика возврат', 'Услуги доставки и FBO', 'Услуги доставки', 'logistics'),
+            new self('logistics_correction', 'Коррекция логистики', 'Услуги доставки и FBO', 'Услуги доставки', 'logistics'),
             new self('warehouse_logistics', 'Логистика складские операции', 'Услуги доставки и FBO', 'Услуги FBO', 'logistics'),
             new self('storage', 'Хранение WB', 'Услуги доставки и FBO', 'Услуги FBO', 'other'),
             new self('pvz_processing', 'Логистика обработка на ПВЗ', 'Услуги партнёров', 'Услуги партнёров', 'other'),

--- a/site/tests/Unit/Marketplace/Domain/WbCostCategoryTest.php
+++ b/site/tests/Unit/Marketplace/Domain/WbCostCategoryTest.php
@@ -16,6 +16,7 @@ final class WbCostCategoryTest extends TestCase
         $this->assertArrayHasKey('commission', $byCode);
         $this->assertArrayHasKey('logistics_delivery', $byCode);
         $this->assertArrayHasKey('warehouse_logistics', $byCode);
+        $this->assertArrayHasKey('logistics_correction', $byCode);
         $this->assertArrayHasKey('wb_loyalty_discount_compensation', $byCode);
         $this->assertArrayHasKey('product_processing', $byCode);
     }

--- a/site/tests/Unit/MarketplaceAnalytics/Application/Service/MarketplaceCostAnalyticsGroupResolverTest.php
+++ b/site/tests/Unit/MarketplaceAnalytics/Application/Service/MarketplaceCostAnalyticsGroupResolverTest.php
@@ -30,6 +30,14 @@ final class MarketplaceCostAnalyticsGroupResolverTest extends TestCase
         $this->assertSame('logistics', $this->resolver->resolveUnitBucket('wildberries', 'logistics_delivery', ''));
     }
 
+
+    public function testWbLogisticsCorrectionGroupsAndBucket(): void
+    {
+        $this->assertSame('Услуги доставки и FBO', $this->resolver->resolveWidgetGroup('wildberries', 'logistics_correction', ''));
+        $this->assertSame('Услуги доставки', $this->resolver->resolveBreakdownGroup('wildberries', 'logistics_correction', ''));
+        $this->assertSame('logistics', $this->resolver->resolveUnitBucket('wildberries', 'logistics_correction', ''));
+    }
+
     public function testWbWarehouseLogisticsBreakdownAndBucket(): void
     {
         $this->assertSame('Услуги FBO', $this->resolver->resolveBreakdownGroup('wildberries', 'warehouse_logistics', ''));


### PR DESCRIPTION
### Motivation
- Новый WB `category_code` "Коррекция логистики" должен попадать в логистический блок Unit Extended (блок `Услуги доставки и FBO`) согласно существующей методологии, а не в fallback `Прочее и компенсации`.

### Description
- Добавлен новый WB category: `logistics_correction` в `WbCostCategory::all()` с `widgetGroup` = `Услуги доставки и FBO`, `breakdownGroup` = `Услуги доставки`, `unitBucket` = `logistics` (файл `site/src/Marketplace/Domain/WbCostCategory.php`).
- Обновлены unit-тесты для проверки наличия кода в словаре (файл `site/tests/Unit/Marketplace/Domain/WbCostCategoryTest.php`).
- Добавлен тест в `MarketplaceCostAnalyticsGroupResolverTest` для проверки резолвинга `widgetGroup`, `breakdownGroup` и `unitBucket` для `logistics_correction` (файл `site/tests/Unit/MarketplaceAnalytics/Application/Service/MarketplaceCostAnalyticsGroupResolverTest.php`).
- Никаких изменений в UI и в методологии для существующих категорий не вносилось.

### Testing
- Обновлённые unit-тесты были добавлены, но запуск локально завершился неуспешно из-за отсутствия необходимых тест-дженериков; попытки запустить `php bin/phpunit` и `vendor/bin/phpunit` дали ошибку из-за отсутствия `simple-phpunit.php`/`vendor/bin/phpunit` в окружении, поэтому автоматические тесты не были выполнены локально.
- Статические проверки и краткий grep-проверки по коду подтверждают, что резолвер использует `WbCostCategory::byCode()` для определения групп, поэтому добавление туда регистрирует новый код для Unit Extended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a115d223c788323b407d7bae7c54fcb)