### PR TITLE
Add requiresListing() to anonymous CostCalculator stub in WbCostsRawProcessorTest

### DIFF
--- a/site/tests/Unit/Marketplace/Application/Processor/WbCostsRawProcessorTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/WbCostsRawProcessorTest.php
@@ -1095,6 +1095,7 @@ final class WbCostsRawProcessorTest extends TestCase
 
         $calculator = new class implements CostCalculatorInterface {
             public function supports(array $item): bool { return true; }
+            public function requiresListing(): bool { return true; }
             public function calculate(array $item, ?MarketplaceListing $listing = null): array
             {
                 return [[


### PR DESCRIPTION
### Motivation
- Fix a fatal error caused by an anonymous class implementing `CostCalculatorInterface` that did not implement the newly required `requiresListing(): bool`, which prevented the unit test from running.

### Description
- Add `public function requiresListing(): bool { return true; }` to the anonymous `CostCalculatorInterface` implementation in `site/tests/Unit/Marketplace/Application/Processor/WbCostsRawProcessorTest.php` (around line 1096) so the test stub satisfies the interface contract and reflects the scenario where the cost must be linked to a listing.

### Testing
- Searched the test file for other `new class implements CostCalculatorInterface` occurrences and updated the single occurrence, and attempted to run `docker-compose run --rm site-php-cli php bin/phpunit tests/Unit/Marketplace/Application/Processor/WbCostsRawProcessorTest.php` and `make site-test-unit`, but test execution could not be completed here because `docker-compose` is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11629798388323b0faa4f71c17c689)