### PR TITLE
Fix WB logistics correction unit test regressions

### DIFF
--- a/site/tests/Unit/Marketplace/Application/Processor/WbCostsRawProcessorTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/WbCostsRawProcessorTest.php
@@ -16,6 +16,7 @@ use App\Marketplace\Enum\MarketplaceCostOperationType;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Enum\StagingRecordType;
 use App\Marketplace\Infrastructure\Query\MarketplaceCostExistingExternalIdsQuery;
+use App\Marketplace\Infrastructure\Query\WbBarcodeUpsertQuery;
 use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
 use App\Marketplace\Repository\MarketplaceBarcodeCatalogRepository;
 use App\Marketplace\Repository\MarketplaceCostCategoryRepository;
@@ -1091,7 +1092,12 @@ final class WbCostsRawProcessorTest extends TestCase
         $costCategoryRepository->method('findBy')->willReturn([]);
         $costCategoryRepository->method('findOneBy')->willReturn(null);
         $categoryResolver = new MarketplaceCostCategoryResolver($costCategoryRepository, $em);
-        $listingResolver = (new \ReflectionClass(WbListingResolverService::class))->newInstanceWithoutConstructor();
+        $listingResolver = new WbListingResolverService(
+            $listingRepository,
+            $barcodeRepository,
+            new WbBarcodeUpsertQuery($connection),
+            $em,
+        );
 
         $calculator = new class implements CostCalculatorInterface {
             public function supports(array $item): bool { return true; }
@@ -1101,7 +1107,7 @@ final class WbCostsRawProcessorTest extends TestCase
                 return [[
                     'external_id' => 'test:wb:cost:1',
                     'cost_date' => new \DateTimeImmutable('2026-01-15 10:00:00'),
-                    'amount' => 80.0,
+                    'amount' => '80',
                     'description' => 'Логистика до покупателя',
                     'category_code' => 'logistics_delivery',
                     'category_name' => 'Логистика до покупателя',
@@ -1253,14 +1259,25 @@ final class WbCostsRawProcessorTest extends TestCase
         $result->method('fetchFirstColumn')->willReturn(['wb:3122030188593:logistics_correction']);
         $connection->method('executeQuery')->willReturn($result);
 
+        $barcodeRepository = $this->createMock(MarketplaceListingBarcodeRepository::class);
+        $barcodeRepository->method('findByBarcodesIndexed')->willReturn([]);
+        $barcodeRepository->method('findByBarcode')->willReturn(null);
+        $listingRepository->method('findByNmIdAndSize')->willReturn(null);
+        $listingResolver = new WbListingResolverService(
+            $listingRepository,
+            $barcodeRepository,
+            new WbBarcodeUpsertQuery($connection),
+            $em,
+        );
+
         $action = new ProcessWbCostsAction(
             $em,
             $listingRepository,
             new MarketplaceCostExistingExternalIdsQuery($connection),
-            (new \ReflectionClass(WbListingResolverService::class))->newInstanceWithoutConstructor(),
+            $listingResolver,
             new MarketplaceCostCategoryResolver($this->createMock(MarketplaceCostCategoryRepository::class), $em),
             new MarketplaceBarcodeCatalogService($this->createMock(MarketplaceBarcodeCatalogRepository::class)),
-            $this->createMock(MarketplaceListingBarcodeRepository::class),
+            $barcodeRepository,
             new WbSalesReportRowNormalizer(),
             new NullLogger(),
             [new WbLogisticsCorrectionCalculator()],


### PR DESCRIPTION
### Motivation
- Fix failing WB costs processor unit tests where an anonymous test calculator returned a numeric `amount` causing `MarketplaceCost::setAmount(string)` to throw a `TypeError`.
- Prevent typed-property initialization failures in `WbListingResolverService` caused by creating the service via `newInstanceWithoutConstructor()` in tests which led to runtime errors during the costs processing flow.

### Description
- Import `WbBarcodeUpsertQuery` and wire it into test resolver construction via `use App\Marketplace\Infrastructure\Query\WbBarcodeUpsertQuery;`.
- Replace `ReflectionClass(...)->newInstanceWithoutConstructor()` with an actual `WbListingResolverService` constructed with mocked dependencies in the affected tests.
- Change the anonymous calculator entry `amount` from `80.0` to the string `'80'` to match the `MarketplaceCost::setAmount(string)` contract.
- Add/adjust mocks for `MarketplaceListingBarcodeRepository::findByBarcodesIndexed`, `findByBarcode` and `MarketplaceListingRepository::findByNmIdAndSize`, and pass the `barcodeRepository` into `ProcessWbCostsAction` where applicable.

### Testing
- Attempted to run focused tests with `docker-compose run --rm site-php-cli php bin/phpunit tests/Unit/Marketplace/Application/Processor/WbCostsRawProcessorTest.php --filter "LogisticsCorrection|BindsListingForBothCamelAndSnakeCaseRows"`, but the environment lacks `docker-compose` so the command failed.
- Attempted to run `php bin/phpunit` directly in `site/`, but execution failed due to missing `vendor/symfony/phpunit-bridge/bin/simple-phpunit.php` so PHPUnit could not run here.
- No automated tests succeeded in this environment; changes were committed to `site/tests/Unit/Marketplace/Application/Processor/WbCostsRawProcessorTest.php` only and do not modify production code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a116535145883239a6fceff253b1744)