### PR TITLE
Move marketplace tests from Unit to Integration and update Makefile test targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,10 @@ site-test-unit:
 	docker-compose run --rm site-php-cli composer test:unit
 
 # Интеграционные (готовим среду + БД)
-site-test-int: site-test-init
-	docker-compose run --rm site-php-cli composer test:int
+site-test-int: site-test-integration
+
+site-test-integration: site-test-init
+	docker-compose run --rm site-php-cli composer test:integration
 
 # Все тесты
 site-test: site-test-init

--- a/site/tests/Integration/Marketplace/Application/Service/WbFinancialReportFirstAvailableResolverTest.php
+++ b/site/tests/Integration/Marketplace/Application/Service/WbFinancialReportFirstAvailableResolverTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Unit\Marketplace\Application\Service;
+namespace App\Tests\Integration\Marketplace\Application\Service;
 
 use App\Marketplace\Application\Service\WbFinanceRateLimiter;
 use App\Marketplace\Application\Service\WbFinancialReportFirstAvailableResolver;

--- a/site/tests/Integration/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
+++ b/site/tests/Integration/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Unit\Marketplace\Application\Service;
+namespace App\Tests\Integration\Marketplace\Application\Service;
 
 use App\Company\Entity\Company;
 use App\Marketplace\Application\Service\WbFinancialReportPeriodResolver;

--- a/site/tests/Integration/Marketplace/Application/Service/WbFinancialReportSyncStatusUpdaterTest.php
+++ b/site/tests/Integration/Marketplace/Application/Service/WbFinancialReportSyncStatusUpdaterTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Unit\Marketplace\Application\Service;
+namespace App\Tests\Integration\Marketplace\Application\Service;
 
 use App\Marketplace\Application\Service\WbFinancialReportSyncStatusUpdater;
 use App\Marketplace\Entity\MarketplaceFinancialReportSyncError;

--- a/site/tests/Integration/Marketplace/MessageHandler/SyncWbFinancialReportDayHandlerTest.php
+++ b/site/tests/Integration/Marketplace/MessageHandler/SyncWbFinancialReportDayHandlerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Unit\Marketplace\MessageHandler;
+namespace App\Tests\Integration\Marketplace\MessageHandler;
 
 use App\Company\Entity\Company;
 use App\Marketplace\Entity\MarketplaceConnection;

--- a/site/tests/Integration/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepositoryTest.php
+++ b/site/tests/Integration/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepositoryTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Unit\Marketplace\Repository;
+namespace App\Tests\Integration\Marketplace\Repository;
 
 use App\Company\Entity\Company;
 use App\Marketplace\Entity\MarketplaceFinancialReportSyncStatus;


### PR DESCRIPTION
### Motivation

- Consolidate test classification by moving several marketplace tests from the `Unit` test suite into the `Integration` suite to reflect their dependency on application state and container resources.
- Align Makefile targets with the renamed integration test suite so CI and local invocations use consistent target names.

### Description

- Renamed and moved multiple test files from `site/tests/Unit/...` to `site/tests/Integration/...` and updated their PHP namespaces from `App\Tests\Unit\...` to `App\Tests\Integration\...`.
- Updated the Makefile test targets by replacing `site-test-int` with `site-test-integration` and adjusted the dependent commands to call `composer test:integration` instead of `composer test:int`.
- Kept existing test setup targets (like `site-test-init`) and preserved test-related targets such as `site-test-smoke` and `site-test-cov` without behavioral changes.

### Testing

- No automated test run was included in this change; consumers should run the integration suite using `make site-test-integration` or `make site-test` to validate the moved tests locally or in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a116b99ed7c8323ab09be73865e8c2b)