### PR TITLE
Handle Ozon 429 (rate-limit) in planner flow; add reconcile command and repo lookups

### DIFF
--- a/site/src/MarketplaceAds/Application/DispatchOzonAdLoadAction.php
+++ b/site/src/MarketplaceAds/Application/DispatchOzonAdLoadAction.php
@@ -9,8 +9,11 @@ use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Facade\MarketplaceFacade;
 use App\MarketplaceAds\Application\Service\AdBatchPlanner;
 use App\MarketplaceAds\Entity\AdLoadJob;
+use App\MarketplaceAds\Exception\OzonRateLimitException;
 use App\MarketplaceAds\Repository\AdLoadJobRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * Создаёт AdLoadJob и планирует батчи для него в cron-driven pipeline
@@ -46,6 +49,8 @@ final class DispatchOzonAdLoadAction implements DispatchOzonAdLoadActionInterfac
         private readonly AdLoadJobRepository $adLoadJobRepository,
         private readonly EntityManagerInterface $entityManager,
         private readonly AdBatchPlanner $adBatchPlanner,
+        #[Autowire(service: 'monolog.logger.marketplace_ads')]
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -107,6 +112,20 @@ final class DispatchOzonAdLoadAction implements DispatchOzonAdLoadActionInterfac
                 $dateFromNorm,
                 $dateToNorm,
             );
+        } catch (OzonRateLimitException $e) {
+            $reason = 'Planning rate_limited: '.$e->getMessage();
+            $job->markFailed($reason);
+            $this->entityManager->flush();
+            $this->logger->warning('DispatchOzonAdLoadAction: planner rate-limited', [
+                'companyId' => $companyId,
+                'jobId' => $job->getId(),
+                'dateFrom' => $dateFromNorm->format('Y-m-d'),
+                'dateTo' => $dateToNorm->format('Y-m-d'),
+                'endpoint' => '/api/client/campaign',
+                'httpStatus' => 429,
+            ]);
+
+            throw new \RuntimeException('Failed to plan ad load job: '.$reason, 0, $e);
         } catch (\Throwable $e) {
             // Ошибка планирования (например, Ozon вернул пустой список кампаний —
             // `RuntimeException('No SKU campaigns found…')`) — фиксируем job как

--- a/site/src/MarketplaceAds/Command/AdDailySyncCommand.php
+++ b/site/src/MarketplaceAds/Command/AdDailySyncCommand.php
@@ -7,6 +7,7 @@ namespace App\MarketplaceAds\Command;
 use App\Marketplace\Enum\MarketplaceType;
 use App\MarketplaceAds\Application\Service\AdBatchPlanner;
 use App\MarketplaceAds\Entity\AdLoadJob;
+use App\MarketplaceAds\Exception\OzonRateLimitException;
 use App\MarketplaceAds\Infrastructure\Query\ActiveOzonPerformanceConnectionsQuery;
 use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
@@ -97,9 +98,9 @@ final class AdDailySyncCommand extends Command
 
             foreach ($companyIds as $companyId) {
                 try {
-                    // Идемпотентность: повторный запуск в тот же день не
-                    // создаёт второй job за вчера (по (company, marketplace,
-                    // dateFrom, dateTo)), даже если первый оказался FAILED.
+                    // Идемпотентность daily-sync: если job за вчера уже
+                    // создавался (любой статус), второй не создаём. Восстановление
+                    // failed/partial делается отдельной reconcile-командой.
                     if ($this->jobRepo->existsByDateRange(
                         $companyId,
                         MarketplaceType::OZON->value,
@@ -133,6 +134,21 @@ final class AdDailySyncCommand extends Command
                             $yesterday,
                             $yesterday,
                         );
+                    } catch (OzonRateLimitException $e) {
+                        $reason = 'Planning rate_limited: '.$e->getMessage();
+                        $job->markFailed($reason);
+                        $this->em->flush();
+                        $this->logger->warning('Daily sync: planner rate-limited', [
+                            'companyId' => $companyId,
+                            'jobId' => $job->getId(),
+                            'date' => $yesterday->format('Y-m-d'),
+                            'endpoint' => '/api/client/campaign',
+                            'httpStatus' => 429,
+                            'error' => $e->getMessage(),
+                            'exception' => $e::class,
+                        ]);
+
+                        throw $e;
                     } catch (\Throwable $e) {
                         // Планировщик бросает, например, при пустом списке
                         // SKU-кампаний в Ozon. Фиксируем job как FAILED,
@@ -158,6 +174,12 @@ final class AdDailySyncCommand extends Command
                         'date' => $yesterday->format('Y-m-d'),
                     ]);
                 } catch (\Throwable $e) {
+                    if ($e instanceof OzonRateLimitException) {
+                        ++$failed;
+
+                        continue;
+                    }
+
                     // Per-company isolation: сбой у одной компании
                     // (например, Ozon вернул пустой список кампаний или
                     // упал transient) не прерывает обработку остальных.

--- a/site/src/MarketplaceAds/Command/ReconcileMarketplaceAdsCommand.php
+++ b/site/src/MarketplaceAds/Command/ReconcileMarketplaceAdsCommand.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Command;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAds\Application\DispatchOzonAdLoadActionInterface;
+use App\MarketplaceAds\Enum\AdLoadJobStatus;
+use App\MarketplaceAds\Exception\OzonRateLimitException;
+use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+#[AsCommand(name: 'app:marketplace-ads:reconcile', description: 'Reconcile missed Ozon ad spend load dates')]
+final class ReconcileMarketplaceAdsCommand extends Command
+{
+    public function __construct(
+        private readonly AdLoadJobRepositoryInterface $jobRepository,
+        private readonly DispatchOzonAdLoadActionInterface $dispatchOzonAdLoadAction,
+        #[Autowire(service: 'monolog.logger.marketplace_ads')]
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('marketplace', null, InputOption::VALUE_REQUIRED, 'Marketplace', 'ozon')
+            ->addOption('company', null, InputOption::VALUE_REQUIRED)
+            ->addOption('from', null, InputOption::VALUE_REQUIRED)
+            ->addOption('to', null, InputOption::VALUE_REQUIRED)
+            ->addOption('dry-run', null, InputOption::VALUE_NONE)
+            ->addOption('include-failed', null, InputOption::VALUE_NONE)
+            ->addOption('include-rate-limited', null, InputOption::VALUE_NONE);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $marketplace = (string) $input->getOption('marketplace');
+        if ('ozon' !== strtolower($marketplace)) {
+            $output->writeln('<error>Only --marketplace=ozon is supported.</error>');
+            return self::INVALID;
+        }
+
+        $companyId = (string) $input->getOption('company');
+        if ('' === trim($companyId)) {
+            $output->writeln('<error>Option --company is required.</error>');
+            return self::INVALID;
+        }
+        $from = \DateTimeImmutable::createFromFormat('!Y-m-d', (string) $input->getOption('from'));
+        $to = \DateTimeImmutable::createFromFormat('!Y-m-d', (string) $input->getOption('to'));
+        if (false === $from || false === $to || $from > $to) {
+            $output->writeln('<error>Invalid --from/--to range.</error>');
+            return self::INVALID;
+        }
+
+        $dryRun = (bool) $input->getOption('dry-run');
+        $includeFailed = (bool) $input->getOption('include-failed');
+        $includeRateLimited = (bool) $input->getOption('include-rate-limited');
+
+        $created = 0;
+        $wouldCreate = 0;
+        $skipped = 0;
+        $deferred = 0;
+        $failed = 0;
+        $createdInThisRun = false;
+        $stopDispatchInThisRun = false;
+        for ($day = $from; $day <= $to; $day = $day->modify('+1 day')) {
+            try {
+                $active = $this->jobRepository->findActiveJobCoveringDate($companyId, MarketplaceType::OZON, $day);
+                if (null !== $active) {
+                    ++$deferred;
+                    $output->writeln(sprintf('%s deferred: active pipeline already running for this date', $day->format('Y-m-d')));
+                    continue;
+                }
+
+                $completed = $this->jobRepository->findCompletedJobCoveringDate($companyId, MarketplaceType::OZON, $day);
+                if (null !== $completed) {
+                    ++$skipped;
+                    $output->writeln(sprintf('%s skip: completed', $day->format('Y-m-d')));
+                    continue;
+                }
+
+                $latest = $this->jobRepository->findLatestJobCoveringDate($companyId, MarketplaceType::OZON, $day);
+                $shouldReload = false;
+                $reason = 'missing';
+                if (null === $latest) {
+                    $shouldReload = true;
+                } elseif (AdLoadJobStatus::COMPLETED === $latest->getStatus()) {
+                    $reason = 'completed';
+                } elseif (AdLoadJobStatus::PARTIAL_SUCCESS === $latest->getStatus()) {
+                    $reason = 'partial_success';
+                    $shouldReload = $includeFailed;
+                } elseif (AdLoadJobStatus::FAILED === $latest->getStatus()) {
+                    $failure = (string) $latest->getFailureReason();
+                    if (self::isRateLimitedFailure($failure)) {
+                        $reason = 'rate_limited';
+                        $shouldReload = $includeRateLimited || $includeFailed;
+                        $this->logger->warning('Reconcile: rate-limited day detected', [
+                            'companyId' => $companyId,
+                            'jobId' => $latest->getId(),
+                            'dateFrom' => $day->format('Y-m-d'),
+                            'dateTo' => $day->format('Y-m-d'),
+                        ]);
+                    } elseif (self::isPermanentFailure($failure)) {
+                        $reason = 'failed_permanent';
+                    } else {
+                        $reason = 'failed_transient';
+                        $shouldReload = $includeFailed;
+                    }
+                } else {
+                    $reason = $latest->getStatus()->value;
+                }
+
+                $output->writeln(sprintf('%s %s: %s', $day->format('Y-m-d'), $shouldReload ? 'reload' : 'skip', $reason));
+                if ($shouldReload) {
+                    ++$wouldCreate;
+                    if ($createdInThisRun || $stopDispatchInThisRun) {
+                        ++$deferred;
+                        $output->writeln(sprintf('%s deferred: active job was created in this run; will retry on next reconcile run', $day->format('Y-m-d')));
+
+                        continue;
+                    }
+                    if ($dryRun) {
+                        continue;
+                    }
+                    ($this->dispatchOzonAdLoadAction)($companyId, $day, $day);
+                    $createdInThisRun = true;
+                    ++$created;
+                } else {
+                    ++$skipped;
+                }
+            } catch (\Throwable $e) {
+                if ($this->isFreshRateLimitedDispatchError($e)) {
+                    $stopDispatchInThisRun = true;
+                    ++$deferred;
+                    $this->logger->warning('Reconcile: deferred due to fresh rate limit', [
+                        'companyId' => $companyId,
+                        'dateFrom' => $day->format('Y-m-d'),
+                        'dateTo' => $day->format('Y-m-d'),
+                        'error' => $e->getMessage(),
+                        'exception' => $e::class,
+                    ]);
+                    $output->writeln(sprintf('%s deferred: rate_limited', $day->format('Y-m-d')));
+
+                    continue;
+                }
+
+                ++$failed;
+                $this->logger->error('Reconcile: failed to process day', [
+                    'companyId' => $companyId,
+                    'dateFrom' => $day->format('Y-m-d'),
+                    'dateTo' => $day->format('Y-m-d'),
+                    'error' => $e->getMessage(),
+                    'exception' => $e::class,
+                ]);
+                $output->writeln(sprintf('%s error: %s', $day->format('Y-m-d'), $e->getMessage()));
+            }
+        }
+
+        $output->writeln(sprintf(
+            'done: would_create=%d created=%d skipped=%d deferred=%d failed=%d remaining=%d dry_run=%s',
+            $wouldCreate,
+            $created,
+            $skipped,
+            $deferred,
+            $failed,
+            max(0, $wouldCreate - $created),
+            $dryRun ? 'yes' : 'no',
+        ));
+
+        return $failed > 0 ? self::FAILURE : self::SUCCESS;
+    }
+
+    private static function isPermanentFailure(string $failure): bool
+    {
+        $failure = mb_strtolower($failure);
+
+        return str_contains($failure, '403')
+            || str_contains($failure, '401')
+            || str_contains($failure, 'invalid credentials');
+    }
+
+    private static function isRateLimitedFailure(string $failure): bool
+    {
+        $failure = mb_strtolower($failure);
+
+        return str_contains($failure, '429')
+            || str_contains($failure, 'ozonratelimitexception')
+            || str_contains($failure, 'rate limit')
+            || str_contains($failure, 'rate-limit')
+            || str_contains($failure, 'marketplace api rate limit exceeded')
+            || str_contains($failure, 'превышен лимит активных запросов')
+            || str_contains($failure, 'лимит активных запросов');
+    }
+
+    private function isFreshRateLimitedDispatchError(\Throwable $e): bool
+    {
+        if ($e->getPrevious() instanceof OzonRateLimitException) {
+            return true;
+        }
+
+        return self::isRateLimitedFailure($e->getMessage());
+    }
+}

--- a/site/src/MarketplaceAds/Repository/AdLoadJobRepository.php
+++ b/site/src/MarketplaceAds/Repository/AdLoadJobRepository.php
@@ -254,6 +254,46 @@ class AdLoadJobRepository extends ServiceEntityRepository implements AdLoadJobRe
         return $count > 0;
     }
 
+    public function findLatestJobCoveringDate(
+        string $companyId,
+        MarketplaceType $marketplace,
+        \DateTimeImmutable $date,
+    ): ?AdLoadJob {
+        return $this->createQueryBuilder('j')
+            ->where('j.companyId = :companyId')
+            ->andWhere('j.marketplace = :marketplace')
+            ->andWhere('j.dateFrom <= :date')
+            ->andWhere('j.dateTo >= :date')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('marketplace', $marketplace)
+            ->setParameter('date', $date->setTime(0, 0), 'date_immutable')
+            ->orderBy('j.createdAt', 'DESC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    public function findCompletedJobCoveringDate(
+        string $companyId,
+        MarketplaceType $marketplace,
+        \DateTimeImmutable $date,
+    ): ?AdLoadJob {
+        return $this->createQueryBuilder('j')
+            ->where('j.companyId = :companyId')
+            ->andWhere('j.marketplace = :marketplace')
+            ->andWhere('j.status = :status')
+            ->andWhere('j.dateFrom <= :date')
+            ->andWhere('j.dateTo >= :date')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('marketplace', $marketplace)
+            ->setParameter('status', AdLoadJobStatus::COMPLETED)
+            ->setParameter('date', $date->setTime(0, 0), 'date_immutable')
+            ->orderBy('j.createdAt', 'DESC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
     private function atomicIncrement(string $column, string $jobId, string $companyId, int $delta): int
     {
         // Whitelist — защита от SQL-injection через имя колонки (параметризовать имя

--- a/site/src/MarketplaceAds/Repository/AdLoadJobRepositoryInterface.php
+++ b/site/src/MarketplaceAds/Repository/AdLoadJobRepositoryInterface.php
@@ -97,4 +97,16 @@ interface AdLoadJobRepositoryInterface
         \DateTimeImmutable $dateFrom,
         \DateTimeImmutable $dateTo,
     ): bool;
+
+    public function findLatestJobCoveringDate(
+        string $companyId,
+        MarketplaceType $marketplace,
+        \DateTimeImmutable $date,
+    ): ?AdLoadJob;
+
+    public function findCompletedJobCoveringDate(
+        string $companyId,
+        MarketplaceType $marketplace,
+        \DateTimeImmutable $date,
+    ): ?AdLoadJob;
 }

--- a/site/tests/Unit/MarketplaceAds/Application/DispatchOzonAdLoadActionTest.php
+++ b/site/tests/Unit/MarketplaceAds/Application/DispatchOzonAdLoadActionTest.php
@@ -11,9 +11,11 @@ use App\MarketplaceAds\Application\DispatchOzonAdLoadAction;
 use App\MarketplaceAds\Application\Service\AdBatchPlanner;
 use App\MarketplaceAds\Entity\AdLoadJob;
 use App\MarketplaceAds\Enum\AdLoadJobStatus;
+use App\MarketplaceAds\Exception\OzonRateLimitException;
 use App\MarketplaceAds\Repository\AdLoadJobRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 /**
  * Unit-тесты {@see DispatchOzonAdLoadAction} после переключения с
@@ -27,6 +29,7 @@ final class DispatchOzonAdLoadActionTest extends TestCase
     private AdLoadJobRepository $adLoadJobRepository;
     private EntityManagerInterface $entityManager;
     private AdBatchPlanner $adBatchPlanner;
+    private LoggerInterface $logger;
     private DispatchOzonAdLoadAction $action;
 
     protected function setUp(): void
@@ -35,12 +38,14 @@ final class DispatchOzonAdLoadActionTest extends TestCase
         $this->adLoadJobRepository = $this->createMock(AdLoadJobRepository::class);
         $this->entityManager = $this->createMock(EntityManagerInterface::class);
         $this->adBatchPlanner = $this->createMock(AdBatchPlanner::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
 
         $this->action = new DispatchOzonAdLoadAction(
             $this->marketplaceFacade,
             $this->adLoadJobRepository,
             $this->entityManager,
             $this->adBatchPlanner,
+            $this->logger,
         );
     }
 
@@ -206,6 +211,28 @@ final class DispatchOzonAdLoadActionTest extends TestCase
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessageMatches('/Failed to plan ad load job/');
+
+        ($this->action)(
+            self::COMPANY_ID,
+            new \DateTimeImmutable('2026-03-01'),
+            new \DateTimeImmutable('2026-03-10'),
+        );
+    }
+
+    public function testPlanner429IsClassifiedAsRateLimitedAndLoggedAsWarning(): void
+    {
+        $this->marketplaceFacade
+            ->method('getConnectionCredentials')
+            ->willReturn(['api_key' => 'secret', 'client_id' => 'client-abc']);
+        $this->adLoadJobRepository->method('findLatestActiveJobByCompanyAndMarketplace')->willReturn(null);
+        $this->adLoadJobRepository->expects(self::once())->method('save');
+        $this->adBatchPlanner->method('planBatchesForJob')
+            ->willThrowException(new OzonRateLimitException('HTTP 429 Превышен лимит активных запросов'));
+        $this->entityManager->expects(self::exactly(2))->method('flush');
+        $this->logger->expects(self::once())->method('warning');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('rate_limited');
 
         ($this->action)(
             self::COMPANY_ID,

--- a/site/tests/Unit/MarketplaceAds/Command/AdDailySyncCommandTest.php
+++ b/site/tests/Unit/MarketplaceAds/Command/AdDailySyncCommandTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\MarketplaceAds\Command;
 use App\Marketplace\Enum\MarketplaceType;
 use App\MarketplaceAds\Application\Service\AdBatchPlanner;
 use App\MarketplaceAds\Command\AdDailySyncCommand;
+use App\MarketplaceAds\Exception\OzonRateLimitException;
 use App\MarketplaceAds\Infrastructure\Query\ActiveOzonPerformanceConnectionsQuery;
 use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
@@ -202,6 +203,34 @@ final class AdDailySyncCommandTest extends TestCase
         $exitCode = $tester->execute([]);
 
         self::assertSame(Command::SUCCESS, $exitCode);
+    }
+
+    public function testPlannerRateLimitLogsWarningAndNotError(): void
+    {
+        $query = $this->createMock(ActiveOzonPerformanceConnectionsQuery::class);
+        $query->method('getCompanyIds')->willReturn([self::COMPANY_1]);
+
+        $jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $jobRepo->method('existsByDateRange')->willReturn(false);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::once())->method('persist');
+        // persist + markFailed
+        $em->expects(self::exactly(2))->method('flush');
+
+        $planner = $this->createMock(AdBatchPlanner::class);
+        $planner->method('planBatchesForJob')
+            ->willThrowException(new OzonRateLimitException('HTTP 429 Превышен лимит активных запросов'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('warning');
+        $logger->expects(self::never())->method('error');
+
+        $tester = $this->makeTester($query, $planner, $jobRepo, $em, $logger);
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('created=0 skipped=0 failed=1', $tester->getDisplay());
     }
 
     private function makeTester(

--- a/site/tests/Unit/MarketplaceAds/Command/ReconcileMarketplaceAdsCommandTest.php
+++ b/site/tests/Unit/MarketplaceAds/Command/ReconcileMarketplaceAdsCommandTest.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\MarketplaceAds\Command;
+
+use App\Marketplace\Enum\MarketplaceType;
+use App\MarketplaceAds\Application\DispatchOzonAdLoadActionInterface;
+use App\MarketplaceAds\Command\ReconcileMarketplaceAdsCommand;
+use App\MarketplaceAds\Entity\AdLoadJob;
+use App\MarketplaceAds\Enum\AdLoadJobStatus;
+use App\MarketplaceAds\Exception\OzonRateLimitException;
+use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class ReconcileMarketplaceAdsCommandTest extends TestCase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-000000000001';
+
+    public function testDryRunCreatesNothing(): void
+    {
+        $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $repo->method('findActiveJobCoveringDate')->willReturn(null);
+        $repo->method('findLatestJobCoveringDate')->willReturn(null);
+
+        $dispatch = $this->createMock(DispatchOzonAdLoadActionInterface::class);
+        $dispatch->expects(self::never())->method('__invoke');
+
+        $tester = $this->tester($repo, $dispatch);
+        $code = $tester->execute([
+            '--company' => self::COMPANY_ID,
+            '--from' => '2026-04-01',
+            '--to' => '2026-04-02',
+            '--dry-run' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $code);
+        self::assertStringContainsString('would_create=2 created=0', $tester->getDisplay());
+    }
+
+    public function testCompletedJobIsNotReloaded(): void
+    {
+        $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $repo->method('findActiveJobCoveringDate')->willReturn(null);
+        $repo->method('findCompletedJobCoveringDate')->willReturn($this->job(AdLoadJobStatus::COMPLETED));
+
+        $dispatch = $this->createMock(DispatchOzonAdLoadActionInterface::class);
+        $dispatch->expects(self::never())->method('__invoke');
+
+        $tester = $this->tester($repo, $dispatch);
+        $code = $tester->execute([
+            '--company' => self::COMPANY_ID,
+            '--from' => '2026-04-01',
+            '--to' => '2026-04-01',
+        ]);
+
+        self::assertSame(Command::SUCCESS, $code);
+        self::assertStringContainsString('skip: completed', $tester->getDisplay());
+    }
+
+    public function testFailedJobDoesNotBlockReconcile(): void
+    {
+        $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $repo->method('findActiveJobCoveringDate')->willReturn(null);
+        $repo->method('findCompletedJobCoveringDate')->willReturn(null);
+        $repo->method('findLatestJobCoveringDate')->willReturn($this->job(AdLoadJobStatus::FAILED, 'HTTP 500'));
+
+        $dispatch = $this->createMock(DispatchOzonAdLoadActionInterface::class);
+        $dispatch->expects(self::once())->method('__invoke');
+
+        $tester = $this->tester($repo, $dispatch);
+        $code = $tester->execute([
+            '--company' => self::COMPANY_ID,
+            '--from' => '2026-04-01',
+            '--to' => '2026-04-01',
+            '--include-failed' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $code);
+        self::assertStringContainsString('reload: failed_transient', $tester->getDisplay());
+    }
+
+    public function testRecognizes429AsRateLimited(): void
+    {
+        $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $repo->method('findActiveJobCoveringDate')->willReturn(null);
+        $repo->method('findCompletedJobCoveringDate')->willReturn(null);
+        $repo->method('findLatestJobCoveringDate')->willReturn($this->job(AdLoadJobStatus::FAILED, 'Marketplace API rate limit exceeded'));        
+
+        $dispatch = $this->createMock(DispatchOzonAdLoadActionInterface::class);
+        $dispatch->expects(self::never())->method('__invoke');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('warning');
+
+        $command = new ReconcileMarketplaceAdsCommand($repo, $dispatch, $logger);
+        $tester = new CommandTester($command);
+        $code = $tester->execute([
+            '--company' => self::COMPANY_ID,
+            '--from' => '2026-04-01',
+            '--to' => '2026-04-01',
+        ]);
+
+        self::assertSame(Command::SUCCESS, $code);
+        self::assertStringContainsString('skip: rate_limited', $tester->getDisplay());
+    }
+
+    public function testContinuesIfOneDayFails(): void
+    {
+        $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $repo->method('findActiveJobCoveringDate')->willReturn(null);
+        $repo->method('findCompletedJobCoveringDate')->willReturn(null);
+        $repo->method('findLatestJobCoveringDate')->willReturn(null);
+
+        $dispatch = $this->createMock(DispatchOzonAdLoadActionInterface::class);
+        $calls = 0;
+        $dispatch->method('__invoke')->willReturnCallback(function () use (&$calls): void {
+            ++$calls;
+            if (1 === $calls) {
+                throw new \RuntimeException('boom');
+            }
+        });
+
+        $tester = $this->tester($repo, $dispatch);
+        $code = $tester->execute([
+            '--company' => self::COMPANY_ID,
+            '--from' => '2026-04-01',
+            '--to' => '2026-04-02',
+        ]);
+
+        self::assertSame(Command::FAILURE, $code);
+        self::assertStringContainsString('failed=1', $tester->getDisplay());
+    }
+
+    public function testRealRunCreatesOnlyOneJobAndDefersRemainingDays(): void
+    {
+        $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $repo->method('findActiveJobCoveringDate')->willReturn(null);
+        $repo->method('findCompletedJobCoveringDate')->willReturn(null);
+        $repo->method('findLatestJobCoveringDate')->willReturn(null);
+        $dispatch = $this->createMock(DispatchOzonAdLoadActionInterface::class);
+        $dispatch->expects(self::once())->method('__invoke');
+        $tester = $this->tester($repo, $dispatch);
+        $code = $tester->execute([
+            '--company' => self::COMPANY_ID,
+            '--from' => '2026-04-01',
+            '--to' => '2026-04-03',
+        ]);
+        self::assertSame(Command::SUCCESS, $code);
+        self::assertStringContainsString('remaining=2', $tester->getDisplay());
+    }
+
+    public function testRealRunMissingCompletedMissingShowsSkipAndDeferredAndRemainingOne(): void
+    {
+        $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $repo->method('findActiveJobCoveringDate')->willReturn(null);
+        $repo->method('findCompletedJobCoveringDate')->willReturnCallback(
+            fn (string $companyId, MarketplaceType $marketplace, \DateTimeImmutable $date): ?AdLoadJob => '2026-04-02' === $date->format('Y-m-d')
+                ? $this->job(AdLoadJobStatus::COMPLETED)
+                : null
+        );
+        $repo->method('findLatestJobCoveringDate')->willReturn(null);
+
+        $dispatch = $this->createMock(DispatchOzonAdLoadActionInterface::class);
+        $dispatch->expects(self::once())->method('__invoke');
+
+        $tester = $this->tester($repo, $dispatch);
+        $code = $tester->execute([
+            '--company' => self::COMPANY_ID,
+            '--from' => '2026-04-01',
+            '--to' => '2026-04-03',
+        ]);
+
+        self::assertSame(Command::SUCCESS, $code);
+        self::assertStringContainsString('2026-04-02 skip: completed', $tester->getDisplay());
+        self::assertStringContainsString('remaining=1', $tester->getDisplay());
+    }
+
+    public function testCompletedJobWinsOverLatestFailedJob(): void
+    {
+        $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $repo->method('findActiveJobCoveringDate')->willReturn(null);
+        $repo->method('findCompletedJobCoveringDate')->willReturn($this->job(AdLoadJobStatus::COMPLETED));
+        $repo->method('findLatestJobCoveringDate')->willReturn($this->job(AdLoadJobStatus::FAILED, 'HTTP 500'));
+        $dispatch = $this->createMock(DispatchOzonAdLoadActionInterface::class);
+        $dispatch->expects(self::never())->method('__invoke');
+        $tester = $this->tester($repo, $dispatch);
+        $tester->execute([
+            '--company' => self::COMPANY_ID,
+            '--from' => '2026-04-01',
+            '--to' => '2026-04-01',
+            '--include-failed' => true,
+        ]);
+        self::assertStringContainsString('skip: completed', $tester->getDisplay());
+    }
+
+    public function testEmptyCompanyOptionReturnsInvalid(): void
+    {
+        $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $dispatch = $this->createMock(DispatchOzonAdLoadActionInterface::class);
+        $dispatch->expects(self::never())->method('__invoke');
+        $tester = $this->tester($repo, $dispatch);
+        $code = $tester->execute(['--company' => '', '--from' => '2026-04-01', '--to' => '2026-04-01']);
+        self::assertSame(Command::INVALID, $code);
+    }
+
+    public function testExistingActiveJobIsDeferredWithoutDispatch(): void
+    {
+        $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $repo->method('findActiveJobCoveringDate')->willReturn($this->job(AdLoadJobStatus::RUNNING));
+        $dispatch = $this->createMock(DispatchOzonAdLoadActionInterface::class);
+        $dispatch->expects(self::never())->method('__invoke');
+        $tester = $this->tester($repo, $dispatch);
+        $tester->execute(['--company' => self::COMPANY_ID, '--from' => '2026-04-01', '--to' => '2026-04-01']);
+        self::assertStringContainsString('deferred', $tester->getDisplay());
+    }
+
+    public function testFreshRateLimitDuringDispatchIsDeferredWithWarningNotError(): void
+    {
+        $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $repo->method('findActiveJobCoveringDate')->willReturn(null);
+        $repo->method('findCompletedJobCoveringDate')->willReturn(null);
+        $repo->method('findLatestJobCoveringDate')->willReturn(null);
+
+        $dispatch = $this->createMock(DispatchOzonAdLoadActionInterface::class);
+        $dispatch->method('__invoke')->willThrowException(
+            new \RuntimeException('Failed to plan ad load job: rate_limited', 0, new OzonRateLimitException('429'))
+        );
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('warning');
+        $logger->expects(self::never())->method('error');
+
+        $command = new ReconcileMarketplaceAdsCommand($repo, $dispatch, $logger);
+        $tester = new CommandTester($command);
+        $code = $tester->execute([
+            '--company' => self::COMPANY_ID,
+            '--from' => '2026-04-01',
+            '--to' => '2026-04-01',
+            '--include-rate-limited' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $code);
+        self::assertStringContainsString('deferred: rate_limited', $tester->getDisplay());
+        self::assertStringContainsString('failed=0', $tester->getDisplay());
+        self::assertStringContainsString('deferred=1', $tester->getDisplay());
+    }
+
+    public function testFreshRateLimitStopsFurtherDispatchAttemptsInSameRun(): void
+    {
+        $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $repo->method('findActiveJobCoveringDate')->willReturn(null);
+        $repo->method('findCompletedJobCoveringDate')->willReturn(null);
+        $repo->method('findLatestJobCoveringDate')->willReturn(null);
+
+        $dispatch = $this->createMock(DispatchOzonAdLoadActionInterface::class);
+        $dispatch->expects(self::once())->method('__invoke')
+            ->willThrowException(new \RuntimeException(
+                'Failed to plan ad load job: rate_limited',
+                0,
+                new OzonRateLimitException('429'),
+            ));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::atLeastOnce())->method('warning');
+        $logger->expects(self::never())->method('error');
+
+        $command = new ReconcileMarketplaceAdsCommand($repo, $dispatch, $logger);
+        $tester = new CommandTester($command);
+        $code = $tester->execute([
+            '--company' => self::COMPANY_ID,
+            '--from' => '2026-04-01',
+            '--to' => '2026-04-03',
+            '--include-rate-limited' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $code);
+        self::assertStringContainsString('failed=0', $tester->getDisplay());
+        self::assertStringContainsString('deferred=3', $tester->getDisplay());
+    }
+
+    private function tester(AdLoadJobRepositoryInterface $repo, DispatchOzonAdLoadActionInterface $dispatch): CommandTester
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $command = new ReconcileMarketplaceAdsCommand($repo, $dispatch, $logger);
+
+        return new CommandTester($command);
+    }
+
+    private function job(AdLoadJobStatus $status, ?string $reason = null): AdLoadJob
+    {
+        $job = new AdLoadJob(self::COMPANY_ID, MarketplaceType::OZON, new \DateTimeImmutable('2026-04-01'), new \DateTimeImmutable('2026-04-01'));
+
+        if (AdLoadJobStatus::COMPLETED === $status) {
+            $job->markRunning();
+            $job->markCompleted();
+        }
+        if (AdLoadJobStatus::FAILED === $status) {
+            $job->markRunning();
+            $job->markFailed($reason ?? 'failed');
+        }
+        if (AdLoadJobStatus::RUNNING === $status) {
+            $job->markRunning();
+        }
+
+        return $job;
+    }
+}


### PR DESCRIPTION
### Motivation

- Make planner failures caused by Ozon rate limits (HTTP 429) explicit and recoverable by classifying them, logging them as warnings and marking related jobs as FAILED so operators see clear reasons in the UI. 
- Provide an offline reconciliation tool to detect and (optionally) re-dispatch missed or transiently-failed Ozon ad-load dates across date ranges. 
- Add repository helpers to query jobs that cover a calendar date to power the reconcile logic.

### Description

- Add explicit handling of `OzonRateLimitException` in `DispatchOzonAdLoadAction`: mark the `AdLoadJob` as FAILED with a `rate_limited`-style reason, flush changes, log a warning (autowired `monolog.logger.marketplace_ads`), and rethrow a `RuntimeException` wrapping the cause. 
- Update `AdDailySyncCommand` to treat planner `OzonRateLimitException` specially: mark job failed, log a warning (not an error), increment failure counts appropriately, and avoid treating rate-limit as a hard crash for the whole run. 
- Introduce `ReconcileMarketplaceAdsCommand` CLI command to scan a date range for a company and decide per-day whether to skip, reload (dispatch), defer (active/rate-limited), or mark as would-create in dry-run mode; includes flags `--dry-run`, `--include-failed`, and `--include-rate-limited` and logic to avoid creating multiple active jobs in one run. 
- Add repository APIs `findLatestJobCoveringDate()` and `findCompletedJobCoveringDate()` plus corresponding interface declarations to support date-based reconciliation. 
- Add and update unit tests: new `ReconcileMarketplaceAdsCommandTest`, extend `DispatchOzonAdLoadActionTest` with a rate-limit test, and extend `AdDailySyncCommandTest` to assert rate-limit handling and logging behavior. 

### Testing

- Ran PHPUnit unit test suite focused on changed areas: `DispatchOzonAdLoadActionTest`, `AdDailySyncCommandTest`, and new `ReconcileMarketplaceAdsCommandTest`, and all tests passed. 
- New unit tests cover planner 429 handling, daily-sync behavior on rate limits, and multiple reconcile scenarios including dry-run, completed/failed detection, deferral on active pipeline, and halting further dispatches in the same run after a fresh rate limit; these tests succeeded. 
- Repository-level changes were exercised by unit tests that mock DB interactions and validate query-based decision logic, and those tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11afd884108323bb0acfc362b508c4)