### PR TITLE
Reconcile Ozon ads: all-active mode, days-back option, active-job guard and cron entry

### DIFF
--- a/docker/cron/app.cron
+++ b/docker/cron/app.cron
@@ -25,6 +25,11 @@
 # Scheduler-контейнер запущен с TZ=Europe/Moscow → 30 4 = 04:30 MSK.
 30 4 * * * php bin/console app:marketplace-ads:daily-sync --no-interaction --quiet
 
+# Reconcile missed Ozon Performance ad spend days.
+# Runs after daily ads sync window. Creates at most one recovery job per company per run.
+# Covers transient 429/API failures and restores missing/failed days safely.
+10,40 6-23 * * * php bin/console app:marketplace-ads:reconcile --marketplace=ozon --all-active --days-back=14 --include-failed --include-rate-limited --no-interaction --quiet
+
 # Poll Ozon Performance reports (async-poll redesign, step 5)
 # Picks up pending reports in REQUESTED state, transitions state via
 # GET /statistics/list (one call per company), dispatches download

--- a/site/src/MarketplaceAds/Command/ReconcileMarketplaceAdsCommand.php
+++ b/site/src/MarketplaceAds/Command/ReconcileMarketplaceAdsCommand.php
@@ -8,6 +8,7 @@ use App\Marketplace\Enum\MarketplaceType;
 use App\MarketplaceAds\Application\DispatchOzonAdLoadActionInterface;
 use App\MarketplaceAds\Enum\AdLoadJobStatus;
 use App\MarketplaceAds\Exception\OzonRateLimitException;
+use App\MarketplaceAds\Infrastructure\Query\ActiveOzonPerformanceConnectionsQuery;
 use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -23,6 +24,7 @@ final class ReconcileMarketplaceAdsCommand extends Command
     public function __construct(
         private readonly AdLoadJobRepositoryInterface $jobRepository,
         private readonly DispatchOzonAdLoadActionInterface $dispatchOzonAdLoadAction,
+        private readonly ActiveOzonPerformanceConnectionsQuery $activeConnectionsQuery,
         #[Autowire(service: 'monolog.logger.marketplace_ads')]
         private readonly LoggerInterface $logger,
     ) {
@@ -36,6 +38,8 @@ final class ReconcileMarketplaceAdsCommand extends Command
             ->addOption('company', null, InputOption::VALUE_REQUIRED)
             ->addOption('from', null, InputOption::VALUE_REQUIRED)
             ->addOption('to', null, InputOption::VALUE_REQUIRED)
+            ->addOption('all-active', null, InputOption::VALUE_NONE)
+            ->addOption('days-back', null, InputOption::VALUE_REQUIRED)
             ->addOption('dry-run', null, InputOption::VALUE_NONE)
             ->addOption('include-failed', null, InputOption::VALUE_NONE)
             ->addOption('include-rate-limited', null, InputOption::VALUE_NONE);
@@ -46,19 +50,40 @@ final class ReconcileMarketplaceAdsCommand extends Command
         $marketplace = (string) $input->getOption('marketplace');
         if ('ozon' !== strtolower($marketplace)) {
             $output->writeln('<error>Only --marketplace=ozon is supported.</error>');
+
             return self::INVALID;
         }
 
-        $companyId = (string) $input->getOption('company');
-        if ('' === trim($companyId)) {
+        $allActive = (bool) $input->getOption('all-active');
+        $companyIds = $allActive
+            ? $this->activeConnectionsQuery->getCompanyIds()
+            : [(string) $input->getOption('company')];
+
+        if (!$allActive && '' === trim($companyIds[0])) {
             $output->writeln('<error>Option --company is required.</error>');
+
             return self::INVALID;
         }
-        $from = \DateTimeImmutable::createFromFormat('!Y-m-d', (string) $input->getOption('from'));
-        $to = \DateTimeImmutable::createFromFormat('!Y-m-d', (string) $input->getOption('to'));
-        if (false === $from || false === $to || $from > $to) {
-            $output->writeln('<error>Invalid --from/--to range.</error>');
-            return self::INVALID;
+
+        $daysBackOption = $input->getOption('days-back');
+        if (null !== $daysBackOption && '' !== trim((string) $daysBackOption)) {
+            if (!is_numeric($daysBackOption) || (int) $daysBackOption < 1) {
+                $output->writeln('<error>Option --days-back must be a positive integer.</error>');
+
+                return self::INVALID;
+            }
+
+            $todayUtc = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->setTime(0, 0);
+            $from = $todayUtc->modify(sprintf('-%d days', (int) $daysBackOption));
+            $to = $todayUtc->modify('-1 day');
+        } else {
+            $from = \DateTimeImmutable::createFromFormat('!Y-m-d', (string) $input->getOption('from'));
+            $to = \DateTimeImmutable::createFromFormat('!Y-m-d', (string) $input->getOption('to'));
+            if (false === $from || false === $to || $from > $to) {
+                $output->writeln('<error>Invalid --from/--to range.</error>');
+
+                return self::INVALID;
+            }
         }
 
         $dryRun = (bool) $input->getOption('dry-run');
@@ -70,98 +95,105 @@ final class ReconcileMarketplaceAdsCommand extends Command
         $skipped = 0;
         $deferred = 0;
         $failed = 0;
-        $createdInThisRun = false;
-        $stopDispatchInThisRun = false;
-        for ($day = $from; $day <= $to; $day = $day->modify('+1 day')) {
-            try {
-                $active = $this->jobRepository->findActiveJobCoveringDate($companyId, MarketplaceType::OZON, $day);
-                if (null !== $active) {
-                    ++$deferred;
-                    $output->writeln(sprintf('%s deferred: active pipeline already running for this date', $day->format('Y-m-d')));
-                    continue;
-                }
 
-                $completed = $this->jobRepository->findCompletedJobCoveringDate($companyId, MarketplaceType::OZON, $day);
-                if (null !== $completed) {
-                    ++$skipped;
-                    $output->writeln(sprintf('%s skip: completed', $day->format('Y-m-d')));
-                    continue;
-                }
+        foreach ($companyIds as $companyId) {
+            $createdInThisRun = false;
+            $stopDispatchInThisRun = false;
+            $hasActiveCompanyJob = null !== $this->jobRepository->findLatestActiveJobByCompanyAndMarketplace(
+                $companyId,
+                MarketplaceType::OZON,
+            );
 
-                $latest = $this->jobRepository->findLatestJobCoveringDate($companyId, MarketplaceType::OZON, $day);
-                $shouldReload = false;
-                $reason = 'missing';
-                if (null === $latest) {
-                    $shouldReload = true;
-                } elseif (AdLoadJobStatus::COMPLETED === $latest->getStatus()) {
-                    $reason = 'completed';
-                } elseif (AdLoadJobStatus::PARTIAL_SUCCESS === $latest->getStatus()) {
-                    $reason = 'partial_success';
-                    $shouldReload = $includeFailed;
-                } elseif (AdLoadJobStatus::FAILED === $latest->getStatus()) {
-                    $failure = (string) $latest->getFailureReason();
-                    if (self::isRateLimitedFailure($failure)) {
-                        $reason = 'rate_limited';
-                        $shouldReload = $includeRateLimited || $includeFailed;
-                        $this->logger->warning('Reconcile: rate-limited day detected', [
+            for ($day = $from; $day <= $to; $day = $day->modify('+1 day')) {
+                try {
+                    $completed = $this->jobRepository->findCompletedJobCoveringDate($companyId, MarketplaceType::OZON, $day);
+                    if (null !== $completed) {
+                        ++$skipped;
+                        $output->writeln(sprintf('[%s] %s skip: completed', $companyId, $day->format('Y-m-d')));
+                        continue;
+                    }
+
+                    $latest = $this->jobRepository->findLatestJobCoveringDate($companyId, MarketplaceType::OZON, $day);
+                    $shouldReload = false;
+                    $reason = 'missing';
+                    if (null === $latest) {
+                        $shouldReload = true;
+                    } elseif (AdLoadJobStatus::COMPLETED === $latest->getStatus()) {
+                        $reason = 'completed';
+                    } elseif (AdLoadJobStatus::PARTIAL_SUCCESS === $latest->getStatus()) {
+                        $reason = 'partial_success';
+                        $shouldReload = $includeFailed;
+                    } elseif (AdLoadJobStatus::FAILED === $latest->getStatus()) {
+                        $failure = (string) $latest->getFailureReason();
+                        if (self::isRateLimitedFailure($failure)) {
+                            $reason = 'rate_limited';
+                            $shouldReload = $includeRateLimited || $includeFailed;
+                            $this->logger->warning('Reconcile: rate-limited day detected', [
+                                'companyId' => $companyId,
+                                'jobId' => $latest->getId(),
+                                'dateFrom' => $day->format('Y-m-d'),
+                                'dateTo' => $day->format('Y-m-d'),
+                            ]);
+                        } elseif (self::isPermanentFailure($failure)) {
+                            $reason = 'failed_permanent';
+                        } else {
+                            $reason = 'failed_transient';
+                            $shouldReload = $includeFailed;
+                        }
+                    } else {
+                        $reason = $latest->getStatus()->value;
+                    }
+
+                    $output->writeln(sprintf('[%s] %s %s: %s', $companyId, $day->format('Y-m-d'), $shouldReload ? 'reload' : 'skip', $reason));
+                    if ($shouldReload) {
+                        ++$wouldCreate;
+                        if ($hasActiveCompanyJob) {
+                            ++$deferred;
+                            $output->writeln(sprintf('[%s] %s deferred: active pipeline already running for company', $companyId, $day->format('Y-m-d')));
+
+                            continue;
+                        }
+                        if ($createdInThisRun || $stopDispatchInThisRun) {
+                            ++$deferred;
+                            $output->writeln(sprintf('[%s] %s deferred: active job was created in this run; will retry on next reconcile run', $companyId, $day->format('Y-m-d')));
+
+                            continue;
+                        }
+                        if ($dryRun) {
+                            continue;
+                        }
+                        ($this->dispatchOzonAdLoadAction)($companyId, $day, $day);
+                        $createdInThisRun = true;
+                        ++$created;
+                    } else {
+                        ++$skipped;
+                    }
+                } catch (\Throwable $e) {
+                    if ($this->isFreshRateLimitedDispatchError($e)) {
+                        $stopDispatchInThisRun = true;
+                        ++$deferred;
+                        $this->logger->warning('Reconcile: deferred due to fresh rate limit', [
                             'companyId' => $companyId,
-                            'jobId' => $latest->getId(),
                             'dateFrom' => $day->format('Y-m-d'),
                             'dateTo' => $day->format('Y-m-d'),
+                            'error' => $e->getMessage(),
+                            'exception' => $e::class,
                         ]);
-                    } elseif (self::isPermanentFailure($failure)) {
-                        $reason = 'failed_permanent';
-                    } else {
-                        $reason = 'failed_transient';
-                        $shouldReload = $includeFailed;
-                    }
-                } else {
-                    $reason = $latest->getStatus()->value;
-                }
-
-                $output->writeln(sprintf('%s %s: %s', $day->format('Y-m-d'), $shouldReload ? 'reload' : 'skip', $reason));
-                if ($shouldReload) {
-                    ++$wouldCreate;
-                    if ($createdInThisRun || $stopDispatchInThisRun) {
-                        ++$deferred;
-                        $output->writeln(sprintf('%s deferred: active job was created in this run; will retry on next reconcile run', $day->format('Y-m-d')));
+                        $output->writeln(sprintf('[%s] %s deferred: rate_limited', $companyId, $day->format('Y-m-d')));
 
                         continue;
                     }
-                    if ($dryRun) {
-                        continue;
-                    }
-                    ($this->dispatchOzonAdLoadAction)($companyId, $day, $day);
-                    $createdInThisRun = true;
-                    ++$created;
-                } else {
-                    ++$skipped;
-                }
-            } catch (\Throwable $e) {
-                if ($this->isFreshRateLimitedDispatchError($e)) {
-                    $stopDispatchInThisRun = true;
-                    ++$deferred;
-                    $this->logger->warning('Reconcile: deferred due to fresh rate limit', [
+
+                    ++$failed;
+                    $this->logger->error('Reconcile: failed to process day', [
                         'companyId' => $companyId,
                         'dateFrom' => $day->format('Y-m-d'),
                         'dateTo' => $day->format('Y-m-d'),
                         'error' => $e->getMessage(),
                         'exception' => $e::class,
                     ]);
-                    $output->writeln(sprintf('%s deferred: rate_limited', $day->format('Y-m-d')));
-
-                    continue;
+                    $output->writeln(sprintf('[%s] %s error: %s', $companyId, $day->format('Y-m-d'), $e->getMessage()));
                 }
-
-                ++$failed;
-                $this->logger->error('Reconcile: failed to process day', [
-                    'companyId' => $companyId,
-                    'dateFrom' => $day->format('Y-m-d'),
-                    'dateTo' => $day->format('Y-m-d'),
-                    'error' => $e->getMessage(),
-                    'exception' => $e::class,
-                ]);
-                $output->writeln(sprintf('%s error: %s', $day->format('Y-m-d'), $e->getMessage()));
             }
         }
 

--- a/site/src/MarketplaceAds/Repository/AdLoadJobRepositoryInterface.php
+++ b/site/src/MarketplaceAds/Repository/AdLoadJobRepositoryInterface.php
@@ -27,10 +27,18 @@ interface AdLoadJobRepositoryInterface
     ): array;
 
     /**
-     * Возвращает активный (PENDING/RUNNING) job, чей диапазон [dateFrom, dateTo]
-     * включает $date. Используется для маппинга обработанного документа на
-     * job, которому он принадлежит.
+     * Возвращает последний активный (PENDING/RUNNING) job компании по маркетплейсу
+     * независимо от диапазона дат job'а.
+     *
+     * Используется reconcile-командой для предотвращения конфликта с
+     * DispatchOzonAdLoadAction: для Ozon Ads одновременно допускается только
+     * один active job на компанию.
      */
+    public function findLatestActiveJobByCompanyAndMarketplace(
+        string $companyId,
+        MarketplaceType $marketplace,
+    ): ?AdLoadJob;
+
     public function findActiveJobCoveringDate(
         string $companyId,
         MarketplaceType $marketplace,

--- a/site/tests/Unit/MarketplaceAds/Command/ReconcileMarketplaceAdsCommandTest.php
+++ b/site/tests/Unit/MarketplaceAds/Command/ReconcileMarketplaceAdsCommandTest.php
@@ -10,6 +10,7 @@ use App\MarketplaceAds\Command\ReconcileMarketplaceAdsCommand;
 use App\MarketplaceAds\Entity\AdLoadJob;
 use App\MarketplaceAds\Enum\AdLoadJobStatus;
 use App\MarketplaceAds\Exception\OzonRateLimitException;
+use App\MarketplaceAds\Infrastructure\Query\ActiveOzonPerformanceConnectionsQuery;
 use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -23,7 +24,7 @@ final class ReconcileMarketplaceAdsCommandTest extends TestCase
     public function testDryRunCreatesNothing(): void
     {
         $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
-        $repo->method('findActiveJobCoveringDate')->willReturn(null);
+        $repo->method('findLatestActiveJobByCompanyAndMarketplace')->willReturn(null);
         $repo->method('findLatestJobCoveringDate')->willReturn(null);
 
         $dispatch = $this->createMock(DispatchOzonAdLoadActionInterface::class);
@@ -44,7 +45,7 @@ final class ReconcileMarketplaceAdsCommandTest extends TestCase
     public function testCompletedJobIsNotReloaded(): void
     {
         $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
-        $repo->method('findActiveJobCoveringDate')->willReturn(null);
+        $repo->method('findLatestActiveJobByCompanyAndMarketplace')->willReturn(null);
         $repo->method('findCompletedJobCoveringDate')->willReturn($this->job(AdLoadJobStatus::COMPLETED));
 
         $dispatch = $this->createMock(DispatchOzonAdLoadActionInterface::class);
@@ -64,7 +65,7 @@ final class ReconcileMarketplaceAdsCommandTest extends TestCase
     public function testFailedJobDoesNotBlockReconcile(): void
     {
         $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
-        $repo->method('findActiveJobCoveringDate')->willReturn(null);
+        $repo->method('findLatestActiveJobByCompanyAndMarketplace')->willReturn(null);
         $repo->method('findCompletedJobCoveringDate')->willReturn(null);
         $repo->method('findLatestJobCoveringDate')->willReturn($this->job(AdLoadJobStatus::FAILED, 'HTTP 500'));
 
@@ -86,7 +87,7 @@ final class ReconcileMarketplaceAdsCommandTest extends TestCase
     public function testRecognizes429AsRateLimited(): void
     {
         $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
-        $repo->method('findActiveJobCoveringDate')->willReturn(null);
+        $repo->method('findLatestActiveJobByCompanyAndMarketplace')->willReturn(null);
         $repo->method('findCompletedJobCoveringDate')->willReturn(null);
         $repo->method('findLatestJobCoveringDate')->willReturn($this->job(AdLoadJobStatus::FAILED, 'Marketplace API rate limit exceeded'));        
 
@@ -96,7 +97,7 @@ final class ReconcileMarketplaceAdsCommandTest extends TestCase
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects(self::once())->method('warning');
 
-        $command = new ReconcileMarketplaceAdsCommand($repo, $dispatch, $logger);
+        $command = new ReconcileMarketplaceAdsCommand($repo, $dispatch, $this->emptyConnectionsQuery(), $logger);
         $tester = new CommandTester($command);
         $code = $tester->execute([
             '--company' => self::COMPANY_ID,
@@ -111,7 +112,7 @@ final class ReconcileMarketplaceAdsCommandTest extends TestCase
     public function testContinuesIfOneDayFails(): void
     {
         $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
-        $repo->method('findActiveJobCoveringDate')->willReturn(null);
+        $repo->method('findLatestActiveJobByCompanyAndMarketplace')->willReturn(null);
         $repo->method('findCompletedJobCoveringDate')->willReturn(null);
         $repo->method('findLatestJobCoveringDate')->willReturn(null);
 
@@ -138,7 +139,7 @@ final class ReconcileMarketplaceAdsCommandTest extends TestCase
     public function testRealRunCreatesOnlyOneJobAndDefersRemainingDays(): void
     {
         $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
-        $repo->method('findActiveJobCoveringDate')->willReturn(null);
+        $repo->method('findLatestActiveJobByCompanyAndMarketplace')->willReturn(null);
         $repo->method('findCompletedJobCoveringDate')->willReturn(null);
         $repo->method('findLatestJobCoveringDate')->willReturn(null);
         $dispatch = $this->createMock(DispatchOzonAdLoadActionInterface::class);
@@ -156,7 +157,7 @@ final class ReconcileMarketplaceAdsCommandTest extends TestCase
     public function testRealRunMissingCompletedMissingShowsSkipAndDeferredAndRemainingOne(): void
     {
         $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
-        $repo->method('findActiveJobCoveringDate')->willReturn(null);
+        $repo->method('findLatestActiveJobByCompanyAndMarketplace')->willReturn(null);
         $repo->method('findCompletedJobCoveringDate')->willReturnCallback(
             fn (string $companyId, MarketplaceType $marketplace, \DateTimeImmutable $date): ?AdLoadJob => '2026-04-02' === $date->format('Y-m-d')
                 ? $this->job(AdLoadJobStatus::COMPLETED)
@@ -182,7 +183,7 @@ final class ReconcileMarketplaceAdsCommandTest extends TestCase
     public function testCompletedJobWinsOverLatestFailedJob(): void
     {
         $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
-        $repo->method('findActiveJobCoveringDate')->willReturn(null);
+        $repo->method('findLatestActiveJobByCompanyAndMarketplace')->willReturn(null);
         $repo->method('findCompletedJobCoveringDate')->willReturn($this->job(AdLoadJobStatus::COMPLETED));
         $repo->method('findLatestJobCoveringDate')->willReturn($this->job(AdLoadJobStatus::FAILED, 'HTTP 500'));
         $dispatch = $this->createMock(DispatchOzonAdLoadActionInterface::class);
@@ -210,7 +211,7 @@ final class ReconcileMarketplaceAdsCommandTest extends TestCase
     public function testExistingActiveJobIsDeferredWithoutDispatch(): void
     {
         $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
-        $repo->method('findActiveJobCoveringDate')->willReturn($this->job(AdLoadJobStatus::RUNNING));
+        $repo->method('findLatestActiveJobByCompanyAndMarketplace')->willReturn($this->job(AdLoadJobStatus::RUNNING));
         $dispatch = $this->createMock(DispatchOzonAdLoadActionInterface::class);
         $dispatch->expects(self::never())->method('__invoke');
         $tester = $this->tester($repo, $dispatch);
@@ -221,7 +222,7 @@ final class ReconcileMarketplaceAdsCommandTest extends TestCase
     public function testFreshRateLimitDuringDispatchIsDeferredWithWarningNotError(): void
     {
         $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
-        $repo->method('findActiveJobCoveringDate')->willReturn(null);
+        $repo->method('findLatestActiveJobByCompanyAndMarketplace')->willReturn(null);
         $repo->method('findCompletedJobCoveringDate')->willReturn(null);
         $repo->method('findLatestJobCoveringDate')->willReturn(null);
 
@@ -234,7 +235,7 @@ final class ReconcileMarketplaceAdsCommandTest extends TestCase
         $logger->expects(self::once())->method('warning');
         $logger->expects(self::never())->method('error');
 
-        $command = new ReconcileMarketplaceAdsCommand($repo, $dispatch, $logger);
+        $command = new ReconcileMarketplaceAdsCommand($repo, $dispatch, $this->emptyConnectionsQuery(), $logger);
         $tester = new CommandTester($command);
         $code = $tester->execute([
             '--company' => self::COMPANY_ID,
@@ -252,7 +253,7 @@ final class ReconcileMarketplaceAdsCommandTest extends TestCase
     public function testFreshRateLimitStopsFurtherDispatchAttemptsInSameRun(): void
     {
         $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
-        $repo->method('findActiveJobCoveringDate')->willReturn(null);
+        $repo->method('findLatestActiveJobByCompanyAndMarketplace')->willReturn(null);
         $repo->method('findCompletedJobCoveringDate')->willReturn(null);
         $repo->method('findLatestJobCoveringDate')->willReturn(null);
 
@@ -268,7 +269,7 @@ final class ReconcileMarketplaceAdsCommandTest extends TestCase
         $logger->expects(self::atLeastOnce())->method('warning');
         $logger->expects(self::never())->method('error');
 
-        $command = new ReconcileMarketplaceAdsCommand($repo, $dispatch, $logger);
+        $command = new ReconcileMarketplaceAdsCommand($repo, $dispatch, $this->emptyConnectionsQuery(), $logger);
         $tester = new CommandTester($command);
         $code = $tester->execute([
             '--company' => self::COMPANY_ID,
@@ -282,12 +283,126 @@ final class ReconcileMarketplaceAdsCommandTest extends TestCase
         self::assertStringContainsString('deferred=3', $tester->getDisplay());
     }
 
-    private function tester(AdLoadJobRepositoryInterface $repo, DispatchOzonAdLoadActionInterface $dispatch): CommandTester
+
+    public function testAllActiveUsesConnectionsQueryAndProcessesEachCompany(): void
+    {
+        $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $repo->method('findLatestActiveJobByCompanyAndMarketplace')->willReturn(null);
+        $repo->method('findCompletedJobCoveringDate')->willReturn(null);
+        $repo->method('findLatestJobCoveringDate')->willReturn(null);
+
+        $dispatch = $this->createMock(DispatchOzonAdLoadActionInterface::class);
+        $dispatch->expects(self::exactly(2))->method('__invoke');
+
+        $query = $this->createMock(ActiveOzonPerformanceConnectionsQuery::class);
+        $query->expects(self::once())->method('getCompanyIds')->willReturn(['c1', 'c2']);
+
+        $tester = $this->tester($repo, $dispatch, $query);
+        $code = $tester->execute(['--all-active' => true, '--from' => '2026-04-01', '--to' => '2026-04-01']);
+
+        self::assertSame(Command::SUCCESS, $code);
+    }
+
+    public function testAllActiveDoesNotRequireCompany(): void
+    {
+        $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $repo->method('findLatestActiveJobByCompanyAndMarketplace')->willReturn(null);
+        $repo->method('findCompletedJobCoveringDate')->willReturn(null);
+        $repo->method('findLatestJobCoveringDate')->willReturn(null);
+        $dispatch = $this->createMock(DispatchOzonAdLoadActionInterface::class);
+        $dispatch->expects(self::never())->method('__invoke');
+
+        $query = $this->createMock(ActiveOzonPerformanceConnectionsQuery::class);
+        $query->method('getCompanyIds')->willReturn([]);
+
+        $tester = $this->tester($repo, $dispatch, $query);
+        $code = $tester->execute(['--all-active' => true, '--from' => '2026-04-01', '--to' => '2026-04-01']);
+        self::assertSame(Command::SUCCESS, $code);
+    }
+
+    public function testDaysBackBuildsUtcRangeUntilYesterday(): void
+    {
+        $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $repo->method('findLatestActiveJobByCompanyAndMarketplace')->willReturn(null);
+        $repo->method('findCompletedJobCoveringDate')->willReturn(null);
+        $repo->method('findLatestJobCoveringDate')->willReturn(null);
+
+        $todayUtc = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->setTime(0, 0);
+        $expectedFrom = $todayUtc->modify('-14 days')->format('Y-m-d');
+        $expectedTo = $todayUtc->modify('-1 day')->format('Y-m-d');
+
+        $dispatch = $this->createMock(DispatchOzonAdLoadActionInterface::class);
+        $dispatch->expects(self::once())->method('__invoke')
+            ->with(self::COMPANY_ID, self::callback(fn (\DateTimeImmutable $d): bool => $expectedFrom === $d->format('Y-m-d')), self::anything());
+
+        $tester = $this->tester($repo, $dispatch);
+        $code = $tester->execute(['--company' => self::COMPANY_ID, '--days-back' => '14']);
+        self::assertSame(Command::SUCCESS, $code);
+        self::assertStringContainsString($expectedTo, $tester->getDisplay());
+    }
+
+    public function testRateLimitInOneCompanyDoesNotBlockAnotherInAllActiveMode(): void
+    {
+        $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $repo->method('findLatestActiveJobByCompanyAndMarketplace')->willReturn(null);
+        $repo->method('findCompletedJobCoveringDate')->willReturn(null);
+        $repo->method('findLatestJobCoveringDate')->willReturn(null);
+
+        $dispatch = $this->createMock(DispatchOzonAdLoadActionInterface::class);
+        $dispatch->expects(self::exactly(2))->method('__invoke')
+            ->willReturnCallback(function (string $companyId): void {
+                if ('c1' === $companyId) {
+                    throw new \RuntimeException('rate_limited', 0, new OzonRateLimitException('429'));
+                }
+            });
+
+        $query = $this->createMock(ActiveOzonPerformanceConnectionsQuery::class);
+        $query->method('getCompanyIds')->willReturn(['c1', 'c2']);
+
+        $tester = $this->tester($repo, $dispatch, $query);
+        $code = $tester->execute(['--all-active' => true, '--from' => '2026-04-01', '--to' => '2026-04-01']);
+
+        self::assertSame(Command::SUCCESS, $code);
+        self::assertStringContainsString('[c2]', $tester->getDisplay());
+    }
+
+
+    public function testActiveCompanyJobForAnotherDateDefersMissingDayWithoutDispatchAndWithoutErrorLog(): void
+    {
+        $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $repo->method('findLatestActiveJobByCompanyAndMarketplace')->willReturn($this->job(AdLoadJobStatus::RUNNING));
+        $repo->method('findCompletedJobCoveringDate')->willReturn(null);
+        $repo->method('findLatestJobCoveringDate')->willReturn(null);
+
+        $dispatch = $this->createMock(DispatchOzonAdLoadActionInterface::class);
+        $dispatch->expects(self::never())->method('__invoke');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::never())->method('error');
+
+        $command = new ReconcileMarketplaceAdsCommand($repo, $dispatch, $this->emptyConnectionsQuery(), $logger);
+        $tester = new CommandTester($command);
+        $code = $tester->execute(['--company' => self::COMPANY_ID, '--from' => '2026-04-01', '--to' => '2026-04-01']);
+
+        self::assertSame(Command::SUCCESS, $code);
+        self::assertStringContainsString('deferred: active pipeline already running for company', $tester->getDisplay());
+    }
+
+    private function tester(AdLoadJobRepositoryInterface $repo, DispatchOzonAdLoadActionInterface $dispatch, ?ActiveOzonPerformanceConnectionsQuery $query = null): CommandTester
     {
         $logger = $this->createMock(LoggerInterface::class);
-        $command = new ReconcileMarketplaceAdsCommand($repo, $dispatch, $logger);
+        $command = new ReconcileMarketplaceAdsCommand($repo, $dispatch, $query ?? $this->emptyConnectionsQuery(), $logger);
 
         return new CommandTester($command);
+    }
+
+
+    private function emptyConnectionsQuery(): ActiveOzonPerformanceConnectionsQuery
+    {
+        $query = $this->createMock(ActiveOzonPerformanceConnectionsQuery::class);
+        $query->method('getCompanyIds')->willReturn([]);
+
+        return $query;
     }
 
     private function job(AdLoadJobStatus $status, ?string $reason = null): AdLoadJob


### PR DESCRIPTION
### Motivation
- Provide a safe, scheduled recovery mechanism for missed Ozon Performance ad-spend days that can operate across many companies. 
- Avoid conflicting or duplicate planning by ensuring only one active Ozon ads job exists per company at a time. 
- Make the reconcile command more convenient for bulk runs by allowing UTC `days-back` ranges and a cluster-wide `--all-active` mode.

### Description
- Added a cron entry in `docker/cron/app.cron` to run the new reconcile workflow periodically for Ozon Performance: `app:marketplace-ads:reconcile`.
- Extended `ReconcileMarketplaceAdsCommand` to support `--all-active` (uses `ActiveOzonPerformanceConnectionsQuery::getCompanyIds()`), `--days-back` (builds UTC range until yesterday) and per-company processing with improved logging and rate-limit handling.
- Replaced the per-date active-job lookup with `AdLoadJobRepositoryInterface::findLatestActiveJobByCompanyAndMarketplace()` and added this method to the repository interface to prevent dispatching when a company already has any active job.
- Updated reconcile logic to defer creation when an active job exists, when a job was already created earlier in the same run, or when a fresh rate-limit dispatch error occurs, and to selectively reload `failed`/`rate_limited` days per flags.

### Testing
- Updated and expanded unit tests in `site/tests/Unit/MarketplaceAds/Command/ReconcileMarketplaceAdsCommandTest.php` to cover `--all-active`, `--days-back`, active-job deferral, rate-limit behavior, and multi-company interactions.
- Ran the PHPUnit unit test suite for the modified command class and related tests; all tests in the changed test file passed.
- Existing command behavior tests (dry-run, completed/failed handling, single-job creation) were retained and verified as passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11d3cd4e9c832381e7765cc3a74873)