### PR TITLE
Abandon non-terminal AdScheduledBatch on terminal job, add repository interface, and tighten reconcile/load logic

### DIFF
--- a/docker/cron/app.cron
+++ b/docker/cron/app.cron
@@ -28,7 +28,7 @@
 # Reconcile missed Ozon Performance ad spend days.
 # Runs after daily ads sync window. Creates at most one recovery job per company per run.
 # Covers transient 429/API failures and restores missing/failed days safely.
-10,40 6-23 * * * php bin/console app:marketplace-ads:reconcile --marketplace=ozon --all-active --days-back=14 --include-failed --include-rate-limited --no-interaction --quiet
+10,40 6-23 * * * php bin/console app:marketplace-ads:reconcile --marketplace=ozon --all-active --days-back=14 --include-rate-limited --no-interaction --quiet
 
 # Poll Ozon Performance reports (async-poll redesign, step 5)
 # Picks up pending reports in REQUESTED state, transitions state via
@@ -77,5 +77,4 @@
 
 # Ежедневно в 03:00: чистка логов/временных таблиц
 #0 3 * * * php /app/bin/console app:maintenance:cleanup --env=prod
-
 

--- a/site/src/MarketplaceAds/Application/DispatchOzonAdLoadAction.php
+++ b/site/src/MarketplaceAds/Application/DispatchOzonAdLoadAction.php
@@ -33,17 +33,6 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
  */
 final class DispatchOzonAdLoadAction implements DispatchOzonAdLoadActionInterface
 {
-    /**
-     * Ozon Performance API лимит — максимум 62 дня в POST `/statistics`
-     * (см. {@see \App\MarketplaceAds\Infrastructure\Api\Ozon\OzonAdClient::assertValidRange()}).
-     *
-     * Planner не разбивает период на чанки по датам (в отличие от старого
-     * `LoadOzonAdStatisticsRangeHandler`), поэтому reject'им период >62 дней
-     * сразу с понятной ошибкой. Multi-chunk поддержка — отдельная follow-up
-     * задача; пока пользователь обязан разбить вручную.
-     */
-    private const MAX_DAYS_PER_LOAD = 62;
-
     public function __construct(
         private readonly MarketplaceFacade $marketplaceFacade,
         private readonly AdLoadJobRepository $adLoadJobRepository,
@@ -81,13 +70,8 @@ final class DispatchOzonAdLoadAction implements DispatchOzonAdLoadActionInterfac
             throw new \DomainException('Нельзя загружать данные за будущие даты. Дата окончания должна быть не позже вчерашнего дня.');
         }
 
-        $days = (int) $dateFromNorm->diff($dateToNorm)->days + 1;
-        if ($days > self::MAX_DAYS_PER_LOAD) {
-            throw new \DomainException(sprintf(
-                'Период %d дней превышает лимит Ozon Performance API (%d дней). Разбейте период на несколько загрузок.',
-                $days,
-                self::MAX_DAYS_PER_LOAD,
-            ));
+        if ($dateFromNorm != $dateToNorm) {
+            throw new \DomainException('Загрузка рекламных расходов Ozon сейчас поддерживает только один день. Для периода используйте восстановление пропусков.');
         }
 
         $activeJob = $this->adLoadJobRepository->findLatestActiveJobByCompanyAndMarketplace(

--- a/site/src/MarketplaceAds/Application/Service/AdLoadJobFinalizer.php
+++ b/site/src/MarketplaceAds/Application/Service/AdLoadJobFinalizer.php
@@ -9,6 +9,7 @@ use App\MarketplaceAds\Enum\AdRawDocumentStatus;
 use App\MarketplaceAds\Repository\AdChunkProgressRepositoryInterface;
 use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
 use App\MarketplaceAds\Repository\AdRawDocumentRepositoryInterface;
+use App\MarketplaceAds\Repository\AdScheduledBatchRepositoryInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
@@ -32,6 +33,7 @@ final readonly class AdLoadJobFinalizer
         private AdLoadJobRepositoryInterface $jobRepository,
         private AdRawDocumentRepositoryInterface $documentRepository,
         private AdChunkProgressRepositoryInterface $chunkProgressRepository,
+        private AdScheduledBatchRepositoryInterface $batchRepository,
         #[Autowire(service: 'monolog.logger.marketplace_ads')]
         private LoggerInterface $marketplaceAdsLogger,
     ) {
@@ -87,6 +89,10 @@ final readonly class AdLoadJobFinalizer
         if (0 === $failedDocs) {
             $affected = $this->jobRepository->markCompleted($jobId, $companyId);
             if ($affected > 0) {
+                $this->batchRepository->abandonNonTerminalBatchesForTerminalJob(
+                    $jobId,
+                    'Abandoned because parent job became terminal: completed',
+                );
                 $this->marketplaceAdsLogger->info('AdLoadJob completed', [
                     'jobId' => $jobId,
                     'companyId' => $companyId,
@@ -100,6 +106,10 @@ final readonly class AdLoadJobFinalizer
         $reason = sprintf('Partial failure: %d of %d documents failed', $failedDocs, $totalDocs);
         $affected = $this->jobRepository->markFailed($jobId, $companyId, $reason);
         if ($affected > 0) {
+            $this->batchRepository->abandonNonTerminalBatchesForTerminalJob(
+                $jobId,
+                'Abandoned because parent job became terminal: failed',
+            );
             $this->marketplaceAdsLogger->warning('AdLoadJob finalized with failures', [
                 'jobId' => $jobId,
                 'companyId' => $companyId,

--- a/site/src/MarketplaceAds/Command/AdJobFinalizerCommand.php
+++ b/site/src/MarketplaceAds/Command/AdJobFinalizerCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\MarketplaceAds\Command;
 
 use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
-use App\MarketplaceAds\Repository\AdScheduledBatchRepository;
+use App\MarketplaceAds\Repository\AdScheduledBatchRepositoryInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -51,7 +51,7 @@ final class AdJobFinalizerCommand extends Command
 
     public function __construct(
         private readonly AdLoadJobRepositoryInterface $jobRepository,
-        private readonly AdScheduledBatchRepository $batchRepository,
+        private readonly AdScheduledBatchRepositoryInterface $batchRepository,
         #[Autowire(service: 'monolog.logger.marketplace_ads')]
         private readonly LoggerInterface $logger,
     ) {
@@ -145,18 +145,25 @@ final class AdJobFinalizerCommand extends Command
 
         if ($ok === $total) {
             // Все batch'и OK — full success.
-            $this->jobRepository->markCompleted($jobId, $companyId);
+            $affected = $this->jobRepository->markCompleted($jobId, $companyId);
             $resolvedStatus = 'completed';
         } elseif (0 === $ok) {
             // Ни одного OK — full failure.
             $reason = sprintf('All %d batches failed', $failedTotal);
-            $this->jobRepository->markFailed($jobId, $companyId, $reason);
+            $affected = $this->jobRepository->markFailed($jobId, $companyId, $reason);
             $resolvedStatus = 'failed';
         } else {
             // Микс — partial success.
             $reason = sprintf('%d of %d batches failed', $failedTotal, $total);
-            $this->jobRepository->markPartialSuccess($jobId, $companyId, $reason);
+            $affected = $this->jobRepository->markPartialSuccess($jobId, $companyId, $reason);
             $resolvedStatus = 'partial_success';
+        }
+
+        if (($affected ?? 0) > 0) {
+            $this->batchRepository->abandonNonTerminalBatchesForTerminalJob(
+                $jobId,
+                sprintf('Abandoned because parent job became terminal: %s', $resolvedStatus),
+            );
         }
 
         $this->logger->info('Finalizer: job finalized', [

--- a/site/src/MarketplaceAds/Command/ReconcileMarketplaceAdsCommand.php
+++ b/site/src/MarketplaceAds/Command/ReconcileMarketplaceAdsCommand.php
@@ -7,9 +7,13 @@ namespace App\MarketplaceAds\Command;
 use App\Marketplace\Enum\MarketplaceType;
 use App\MarketplaceAds\Application\DispatchOzonAdLoadActionInterface;
 use App\MarketplaceAds\Enum\AdLoadJobStatus;
+use App\MarketplaceAds\Enum\AdRawDocumentStatus;
 use App\MarketplaceAds\Exception\OzonRateLimitException;
 use App\MarketplaceAds\Infrastructure\Query\ActiveOzonPerformanceConnectionsQuery;
+use App\MarketplaceAds\Infrastructure\Query\AdDocumentQueryInterface;
 use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
+use App\MarketplaceAds\Repository\AdRawDocumentRepositoryInterface;
+use Doctrine\DBAL\Connection;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -23,6 +27,9 @@ final class ReconcileMarketplaceAdsCommand extends Command
 {
     public function __construct(
         private readonly AdLoadJobRepositoryInterface $jobRepository,
+        private readonly AdRawDocumentRepositoryInterface $rawDocumentRepository,
+        private readonly AdDocumentQueryInterface $adDocumentQuery,
+        private readonly Connection $connection,
         private readonly DispatchOzonAdLoadActionInterface $dispatchOzonAdLoadAction,
         private readonly ActiveOzonPerformanceConnectionsQuery $activeConnectionsQuery,
         #[Autowire(service: 'monolog.logger.marketplace_ads')]
@@ -42,7 +49,8 @@ final class ReconcileMarketplaceAdsCommand extends Command
             ->addOption('days-back', null, InputOption::VALUE_REQUIRED)
             ->addOption('dry-run', null, InputOption::VALUE_NONE)
             ->addOption('include-failed', null, InputOption::VALUE_NONE)
-            ->addOption('include-rate-limited', null, InputOption::VALUE_NONE);
+            ->addOption('include-rate-limited', null, InputOption::VALUE_NONE)
+            ->addOption('force-reload-existing-data', null, InputOption::VALUE_NONE);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -89,6 +97,7 @@ final class ReconcileMarketplaceAdsCommand extends Command
         $dryRun = (bool) $input->getOption('dry-run');
         $includeFailed = (bool) $input->getOption('include-failed');
         $includeRateLimited = (bool) $input->getOption('include-rate-limited');
+        $forceReloadExistingData = (bool) $input->getOption('force-reload-existing-data');
 
         $created = 0;
         $wouldCreate = 0;
@@ -114,6 +123,35 @@ final class ReconcileMarketplaceAdsCommand extends Command
                     }
 
                     $latest = $this->jobRepository->findLatestJobCoveringDate($companyId, MarketplaceType::OZON, $day);
+                    $rawCount = $this->rawDocumentRepository->countByCompanyMarketplaceAndDateRange(
+                        $companyId,
+                        MarketplaceType::OZON->value,
+                        $day,
+                        $day,
+                    );
+                    $failedRawCount = $this->rawDocumentRepository->countByCompanyMarketplaceAndDateRange(
+                        $companyId,
+                        MarketplaceType::OZON->value,
+                        $day,
+                        $day,
+                        AdRawDocumentStatus::FAILED,
+                    );
+                    $draftRawCount = $this->rawDocumentRepository->countByCompanyMarketplaceAndDateRange(
+                        $companyId,
+                        MarketplaceType::OZON->value,
+                        $day,
+                        $day,
+                        AdRawDocumentStatus::DRAFT,
+                    );
+                    $adDocumentsCount = (int) $this->connection->fetchOne(
+                        'SELECT COUNT(*) FROM marketplace_ad_documents WHERE company_id = :company_id AND marketplace = :marketplace AND report_date = :report_date',
+                        [
+                            'company_id' => $companyId,
+                            'marketplace' => MarketplaceType::OZON->value,
+                            'report_date' => $day->format('Y-m-d'),
+                        ],
+                    );
+                    $adSpend = $this->adDocumentQuery->sumTotalCostForPeriod($companyId, $day, $day, MarketplaceType::OZON->value);
                     $shouldReload = false;
                     $reason = 'missing';
                     if (null === $latest) {
@@ -144,7 +182,28 @@ final class ReconcileMarketplaceAdsCommand extends Command
                         $reason = $latest->getStatus()->value;
                     }
 
-                    $output->writeln(sprintf('[%s] %s %s: %s', $companyId, $day->format('Y-m-d'), $shouldReload ? 'reload' : 'skip', $reason));
+                    if ($shouldReload && !$forceReloadExistingData && ($rawCount > 0 || $adDocumentsCount > 0)) {
+                        $shouldReload = false;
+                        if ($failedRawCount > 0) {
+                            $reason = 'raw_failed_needs_attention';
+                        } elseif ($draftRawCount > 0) {
+                            $reason = 'raw_draft_needs_attention';
+                        } else {
+                            $reason = 'needs_attention_data_exists';
+                        }
+                    }
+                    $output->writeln(sprintf(
+                        '[%s] %s %s: %s raw_count=%d failed_raw_count=%d draft_raw_count=%d ad_documents_count=%d ad_spend=%s',
+                        $companyId,
+                        $day->format('Y-m-d'),
+                        $shouldReload ? 'reload' : 'skip',
+                        $reason,
+                        $rawCount,
+                        $failedRawCount,
+                        $draftRawCount,
+                        $adDocumentsCount,
+                        $adSpend,
+                    ));
                     if ($shouldReload) {
                         ++$wouldCreate;
                         if ($hasActiveCompanyJob) {

--- a/site/src/MarketplaceAds/Controller/Api/Admin/MarkAdLoadJobFailedController.php
+++ b/site/src/MarketplaceAds/Controller/Api/Admin/MarkAdLoadJobFailedController.php
@@ -6,6 +6,7 @@ namespace App\MarketplaceAds\Controller\Api\Admin;
 
 use App\Company\Entity\User;
 use App\MarketplaceAds\Repository\AdLoadJobRepository;
+use App\MarketplaceAds\Repository\AdScheduledBatchRepository;
 use App\Shared\Service\ActiveCompanyService;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -29,6 +30,7 @@ final class MarkAdLoadJobFailedController extends AbstractController
     public function __construct(
         private readonly ActiveCompanyService $activeCompanyService,
         private readonly AdLoadJobRepository $adLoadJobRepository,
+        private readonly AdScheduledBatchRepository $adScheduledBatchRepository,
         private readonly Security $security,
         private readonly LoggerInterface $logger,
     ) {}
@@ -53,6 +55,11 @@ final class MarkAdLoadJobFailedController extends AbstractController
         if (0 === $affected) {
             return $this->json(['error' => 'Job not found or already finalized'], 404);
         }
+
+        $this->adScheduledBatchRepository->abandonNonTerminalBatchesForTerminalJob(
+            $jobId,
+            'Abandoned because parent job became terminal: failed',
+        );
 
         $user = $this->security->getUser();
         $this->logger->warning('AdLoadJob manually marked as failed', [

--- a/site/src/MarketplaceAds/EventSubscriber/AdLoadJobFailureSubscriber.php
+++ b/site/src/MarketplaceAds/EventSubscriber/AdLoadJobFailureSubscriber.php
@@ -6,6 +6,7 @@ namespace App\MarketplaceAds\EventSubscriber;
 
 use App\MarketplaceAds\Message\FetchOzonAdStatisticsMessage;
 use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
+use App\MarketplaceAds\Repository\AdScheduledBatchRepositoryInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -30,6 +31,7 @@ final class AdLoadJobFailureSubscriber implements EventSubscriberInterface
 
     public function __construct(
         private readonly AdLoadJobRepositoryInterface $adLoadJobRepository,
+        private readonly AdScheduledBatchRepositoryInterface $adScheduledBatchRepository,
         #[Autowire(service: 'monolog.logger.marketplace_ads')]
         private readonly LoggerInterface $marketplaceAdsLogger,
     ) {
@@ -63,7 +65,13 @@ final class AdLoadJobFailureSubscriber implements EventSubscriberInterface
             $reason = mb_substr($reason, 0, self::REASON_MAX_LENGTH, 'UTF-8');
         }
 
-        $this->adLoadJobRepository->markFailed($message->jobId, $message->companyId, $reason);
+        $affected = $this->adLoadJobRepository->markFailed($message->jobId, $message->companyId, $reason);
+        if ($affected > 0) {
+            $this->adScheduledBatchRepository->abandonNonTerminalBatchesForTerminalJob(
+                $message->jobId,
+                'Abandoned because parent job became terminal: failed',
+            );
+        }
 
         $this->marketplaceAdsLogger->warning('AdLoadJob marked as failed after retries exhausted', [
             'job_id' => $message->jobId,

--- a/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
@@ -12,6 +12,7 @@ use App\MarketplaceAds\Message\FetchOzonAdStatisticsMessage;
 use App\MarketplaceAds\Message\RequestOzonAdBatchMessage;
 use App\MarketplaceAds\Repository\AdChunkProgressRepositoryInterface;
 use App\MarketplaceAds\Repository\AdLoadJobRepository;
+use App\MarketplaceAds\Repository\AdScheduledBatchRepositoryInterface;
 use App\MarketplaceAds\Repository\OzonAdPendingReportRepository;
 use App\Shared\Service\AppLogger;
 use Psr\Log\LoggerInterface;
@@ -78,6 +79,7 @@ final class FetchOzonAdStatisticsHandler
     public function __construct(
         private readonly OzonAdClient $ozonAdClient,
         private readonly AdLoadJobRepository $adLoadJobRepository,
+        private readonly AdScheduledBatchRepositoryInterface $adScheduledBatchRepository,
         private readonly AdChunkProgressRepositoryInterface $adChunkProgressRepository,
         private readonly OzonAdPendingReportRepository $pendingReportRepo,
         private readonly AdLoadJobFinalizer $finalizer,
@@ -127,11 +129,17 @@ final class FetchOzonAdStatisticsHandler
             || $dateFrom->format('Y-m-d') !== $message->dateFrom
             || $dateTo->format('Y-m-d') !== $message->dateTo
         ) {
-            $this->adLoadJobRepository->markFailed(
+            $affected = $this->adLoadJobRepository->markFailed(
                 $message->jobId,
                 $message->companyId,
                 sprintf('Invalid date format in message: from=%s, to=%s', $message->dateFrom, $message->dateTo),
             );
+            if ($affected > 0) {
+                $this->adScheduledBatchRepository->abandonNonTerminalBatchesForTerminalJob(
+                    $message->jobId,
+                    'Abandoned because parent job became terminal: failed',
+                );
+            }
 
             throw new UnrecoverableMessageHandlingException(sprintf(
                 'FetchOzonAdStatisticsMessage: invalid date format (from=%s, to=%s)',
@@ -153,11 +161,17 @@ final class FetchOzonAdStatisticsHandler
         } catch (\InvalidArgumentException $e) {
             // Диапазон > 62 дней или from > to — баг вызывающего кода,
             // ретраить бессмысленно.
-            $this->adLoadJobRepository->markFailed(
+            $affected = $this->adLoadJobRepository->markFailed(
                 $message->jobId,
                 $message->companyId,
                 'Invalid date range: '.$e->getMessage(),
             );
+            if ($affected > 0) {
+                $this->adScheduledBatchRepository->abandonNonTerminalBatchesForTerminalJob(
+                    $message->jobId,
+                    'Abandoned because parent job became terminal: failed',
+                );
+            }
 
             throw new UnrecoverableMessageHandlingException(
                 'FetchOzonAdStatisticsMessage: invalid date range — '.$e->getMessage(),
@@ -172,11 +186,17 @@ final class FetchOzonAdStatisticsHandler
             // в REQUESTED до next_poll_at и генерили бы лишние HTTP-запросы.
             $this->abandonInFlightForJob($message->companyId, $message->jobId, $e);
 
-            $this->adLoadJobRepository->markFailed(
+            $affected = $this->adLoadJobRepository->markFailed(
                 $message->jobId,
                 $message->companyId,
                 'Ozon API permanent failure: '.$e->getMessage(),
             );
+            if ($affected > 0) {
+                $this->adScheduledBatchRepository->abandonNonTerminalBatchesForTerminalJob(
+                    $message->jobId,
+                    'Abandoned because parent job became terminal: failed',
+                );
+            }
 
             throw new UnrecoverableMessageHandlingException(
                 'FetchOzonAdStatisticsMessage: Ozon permanent failure — '.$e->getMessage(),

--- a/site/src/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandler.php
@@ -9,6 +9,7 @@ use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonAdClient;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonPermanentApiException;
 use App\MarketplaceAds\Message\RequestOzonAdBatchMessage;
 use App\MarketplaceAds\Repository\AdLoadJobRepository;
+use App\MarketplaceAds\Repository\AdScheduledBatchRepositoryInterface;
 use App\MarketplaceAds\Repository\OzonAdPendingReportRepository;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -99,6 +100,7 @@ final class RequestOzonAdBatchHandler
 
     public function __construct(
         private readonly AdLoadJobRepository $jobRepository,
+        private readonly AdScheduledBatchRepositoryInterface $adScheduledBatchRepository,
         private readonly OzonAdClient $ozonAdClient,
         private readonly OzonAdPendingReportRepository $pendingReportRepo,
         private readonly MessageBusInterface $messageBus,
@@ -206,11 +208,17 @@ final class RequestOzonAdBatchHandler
                 'error' => $e->getMessage(),
             ]);
 
-            $this->jobRepository->markFailed(
+            $affected = $this->jobRepository->markFailed(
                 $message->jobId,
                 $message->companyId,
                 'Ozon Performance: '.$e->getMessage(),
             );
+            if ($affected > 0) {
+                $this->adScheduledBatchRepository->abandonNonTerminalBatchesForTerminalJob(
+                    $message->jobId,
+                    'Abandoned because parent job became terminal: failed',
+                );
+            }
 
             throw new UnrecoverableMessageHandlingException(
                 'RequestOzonAdBatchMessage: Ozon permanent failure — '.$e->getMessage(),
@@ -236,11 +244,17 @@ final class RequestOzonAdBatchHandler
                     'attempts' => $message->rateLimitAttempts,
                 ]);
 
-                $this->jobRepository->markFailed(
+                $affected = $this->jobRepository->markFailed(
                     $message->jobId,
                     $message->companyId,
                     sprintf('Ozon Performance: rate-limited >%d attempts — aborting batch', self::MAX_RATE_LIMIT_ATTEMPTS),
                 );
+                if ($affected > 0) {
+                    $this->adScheduledBatchRepository->abandonNonTerminalBatchesForTerminalJob(
+                        $message->jobId,
+                        'Abandoned because parent job became terminal: failed',
+                    );
+                }
 
                 throw new UnrecoverableMessageHandlingException(
                     'RequestOzonAdBatchMessage: Ozon rate limit exhausted',

--- a/site/src/MarketplaceAds/Repository/AdScheduledBatchRepository.php
+++ b/site/src/MarketplaceAds/Repository/AdScheduledBatchRepository.php
@@ -22,7 +22,7 @@ use Webmozart\Assert\Assert;
  * не мешают друг другу (скипают уже захваченные строки), один тик гарантированно
  * обслуживает не более одного батча на worker'а.
  */
-final class AdScheduledBatchRepository extends ServiceEntityRepository
+final class AdScheduledBatchRepository extends ServiceEntityRepository implements AdScheduledBatchRepositoryInterface
 {
     public function __construct(ManagerRegistry $registry)
     {
@@ -61,6 +61,7 @@ final class AdScheduledBatchRepository extends ServiceEntityRepository
         $sql = sprintf(
             'SELECT %s FROM marketplace_ad_scheduled_batches b '
             . 'WHERE b.state = :state '
+            . "  AND EXISTS (SELECT 1 FROM marketplace_ad_load_jobs j WHERE j.id = b.job_id AND j.status IN ('pending','running')) "
             . '  AND b.scheduled_at <= NOW() '
             . 'ORDER BY b.scheduled_at ASC, b.batch_index ASC '
             . 'LIMIT 1 FOR UPDATE SKIP LOCKED',
@@ -88,13 +89,22 @@ final class AdScheduledBatchRepository extends ServiceEntityRepository
      */
     public function findAllInFlight(): array
     {
+        $rsm = new ResultSetMappingBuilder($this->getEntityManager());
+        $rsm->addRootEntityFromClassMetadata(AdScheduledBatch::class, 'b');
+
+        $sql = sprintf(
+            'SELECT %s FROM marketplace_ad_scheduled_batches b '
+            . 'WHERE b.state = :state '
+            . "  AND EXISTS (SELECT 1 FROM marketplace_ad_load_jobs j WHERE j.id = b.job_id AND j.status IN ('pending','running')) "
+            . 'ORDER BY b.started_at ASC NULLS LAST',
+            $rsm->generateSelectClause(['b' => 'b']),
+        );
+
+        $query = $this->getEntityManager()->createNativeQuery($sql, $rsm);
+        $query->setParameter('state', AdScheduledBatchState::IN_FLIGHT->value);
+
         /** @var list<AdScheduledBatch> $result */
-        $result = $this->createQueryBuilder('b')
-            ->where('b.state = :state')
-            ->setParameter('state', AdScheduledBatchState::IN_FLIGHT)
-            ->orderBy('b.startedAt', 'ASC')
-            ->getQuery()
-            ->getResult();
+        $result = $query->getResult();
 
         return $result;
     }
@@ -230,5 +240,35 @@ final class AdScheduledBatchRepository extends ServiceEntityRepository
             ->getResult();
 
         return $result;
+    }
+
+    /**
+     * Переводит все non-terminal батчи job'а (PLANNED / IN_FLIGHT / REQUESTED)
+     * в ABANDONED после терминализации parent job.
+     *
+     * Идемпотентно: повторный вызов не трогает уже терминальные записи.
+     *
+     * @return int число обновлённых батчей
+     */
+    public function abandonNonTerminalBatchesForTerminalJob(string $jobId, string $reason): int
+    {
+        Assert::uuid($jobId);
+        Assert::notEmpty($reason);
+
+        return (int) $this->getEntityManager()->getConnection()->executeStatement(
+            <<<'SQL'
+                UPDATE marketplace_ad_scheduled_batches
+                SET state = 'ABANDONED',
+                    last_error = :reason,
+                    finished_at = NOW(),
+                    updated_at = NOW()
+                WHERE job_id = :job_id
+                  AND state IN ('PLANNED', 'IN_FLIGHT', 'REQUESTED')
+                SQL,
+            [
+                'job_id' => $jobId,
+                'reason' => $reason,
+            ],
+        );
     }
 }

--- a/site/src/MarketplaceAds/Repository/AdScheduledBatchRepositoryInterface.php
+++ b/site/src/MarketplaceAds/Repository/AdScheduledBatchRepositoryInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MarketplaceAds\Repository;
+
+use App\MarketplaceAds\Entity\AdScheduledBatch;
+
+interface AdScheduledBatchRepositoryInterface
+{
+    public function findNextPlanned(): ?AdScheduledBatch;
+
+    /**
+     * @return list<AdScheduledBatch>
+     */
+    public function findAllInFlight(): array;
+
+    /**
+     * @return array<string, int>
+     */
+    public function countStatesForJob(string $jobId, string $companyId): array;
+
+    public function abandonNonTerminalBatchesForTerminalJob(string $jobId, string $reason): int;
+}
+

--- a/site/tests/Integration/MarketplaceAds/AdScheduledBatchRepositoryTest.php
+++ b/site/tests/Integration/MarketplaceAds/AdScheduledBatchRepositoryTest.php
@@ -274,6 +274,94 @@ final class AdScheduledBatchRepositoryTest extends IntegrationTestCase
         self::assertNull($picked, 'Батч со scheduled_at в будущем не должен выбираться (retry/backoff).');
     }
 
+    public function testAbandonNonTerminalBatchesForTerminalJobMarksPlannedAndInFlight(): void
+    {
+        $job = $this->seedJob();
+
+        $planned = AdScheduledBatchBuilder::aBatch()
+            ->withJobId($job->getId())
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(1)
+            ->withState(AdScheduledBatchState::PLANNED)
+            ->build();
+        $inFlight = AdScheduledBatchBuilder::aBatch()
+            ->withJobId($job->getId())
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(2)
+            ->withState(AdScheduledBatchState::IN_FLIGHT)
+            ->build();
+        $ok = AdScheduledBatchBuilder::aBatch()
+            ->withJobId($job->getId())
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(3)
+            ->withState(AdScheduledBatchState::OK)
+            ->build();
+
+        $this->repository->save($planned);
+        $this->repository->save($inFlight);
+        $this->repository->save($ok);
+        $this->em->flush();
+        $this->em->clear();
+
+        $affected = $this->repository->abandonNonTerminalBatchesForTerminalJob(
+            $job->getId(),
+            'Abandoned because parent job became terminal: failed',
+        );
+        self::assertSame(2, $affected);
+
+        $rows = $this->em->getConnection()->fetchAllAssociative(
+            'SELECT state, last_error FROM marketplace_ad_scheduled_batches WHERE job_id = :job ORDER BY batch_index ASC',
+            ['job' => $job->getId()],
+        );
+        self::assertSame('ABANDONED', $rows[0]['state']);
+        self::assertSame('ABANDONED', $rows[1]['state']);
+        self::assertSame('OK', $rows[2]['state']);
+        self::assertStringContainsString('parent job became terminal: failed', (string) $rows[0]['last_error']);
+        self::assertStringContainsString('parent job became terminal: failed', (string) $rows[1]['last_error']);
+    }
+
+    public function testFindAllInFlightSkipsTerminalParentJob(): void
+    {
+        $terminalJob = $this->seedJob();
+        $terminalJob->markRunning();
+        $terminalJob->markFailed('x');
+        $this->em->flush();
+
+        $batch = AdScheduledBatchBuilder::aBatch()
+            ->withJobId($terminalJob->getId())
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(1)
+            ->withState(AdScheduledBatchState::IN_FLIGHT)
+            ->build();
+        $this->repository->save($batch);
+        $this->em->flush();
+        $this->em->clear();
+
+        $result = $this->repository->findAllInFlight();
+        self::assertSame([], $result);
+    }
+
+    public function testFindAllInFlightReturnsBatchesForActiveParentJob(): void
+    {
+        $activeJob = $this->seedJob();
+        $activeJob->markRunning();
+        $this->em->flush();
+
+        $batch = AdScheduledBatchBuilder::aBatch()
+            ->withJobId($activeJob->getId())
+            ->withCompanyId(self::COMPANY_ID)
+            ->withIndex(1)
+            ->withState(AdScheduledBatchState::IN_FLIGHT)
+            ->build();
+        $this->repository->save($batch);
+        $this->em->flush();
+        $this->em->clear();
+
+        $result = $this->repository->findAllInFlight();
+        self::assertCount(1, $result);
+        self::assertSame($batch->getId(), $result[0]->getId());
+    }
+
     public function testFindNextPlannedPicksDueBatchEvenIfAnotherIsFurtherInFuture(): void
     {
         $job = $this->seedJob();

--- a/site/tests/Unit/MarketplaceAds/Application/DispatchOzonAdLoadActionTest.php
+++ b/site/tests/Unit/MarketplaceAds/Application/DispatchOzonAdLoadActionTest.php
@@ -77,7 +77,7 @@ final class DispatchOzonAdLoadActionTest extends TestCase
             ->willReturn(3);
 
         $dateFrom = new \DateTimeImmutable('2026-03-01');
-        $dateTo = new \DateTimeImmutable('2026-03-10');
+        $dateTo = new \DateTimeImmutable('2026-03-01');
 
         $job = ($this->action)(self::COMPANY_ID, $dateFrom, $dateTo);
 
@@ -101,7 +101,7 @@ final class DispatchOzonAdLoadActionTest extends TestCase
         ($this->action)(
             self::COMPANY_ID,
             new \DateTimeImmutable('2026-03-01'),
-            new \DateTimeImmutable('2026-03-10'),
+            new \DateTimeImmutable('2026-03-01'),
         );
     }
 
@@ -123,6 +123,24 @@ final class DispatchOzonAdLoadActionTest extends TestCase
         );
     }
 
+    public function testThrowsWhenMultiDayRangeRequested(): void
+    {
+        $this->marketplaceFacade
+            ->method('getConnectionCredentials')
+            ->willReturn(['api_key' => 'key', 'client_id' => null]);
+
+        $this->adBatchPlanner->expects(self::never())->method('planBatchesForJob');
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('Загрузка рекламных расходов Ozon сейчас поддерживает только один день. Для периода используйте восстановление пропусков.');
+
+        ($this->action)(
+            self::COMPANY_ID,
+            new \DateTimeImmutable('2026-03-01'),
+            new \DateTimeImmutable('2026-03-02'),
+        );
+    }
+
     public function testThrowsWhenDateToIsInFuture(): void
     {
         $this->marketplaceFacade
@@ -138,26 +156,6 @@ final class DispatchOzonAdLoadActionTest extends TestCase
             self::COMPANY_ID,
             new \DateTimeImmutable('2026-01-01'),
             new \DateTimeImmutable('+7 days'),
-        );
-    }
-
-    public function testThrowsWhenPeriodExceeds62Days(): void
-    {
-        $this->marketplaceFacade
-            ->method('getConnectionCredentials')
-            ->willReturn(['api_key' => 'key', 'client_id' => null]);
-
-        $this->adBatchPlanner->expects(self::never())->method('planBatchesForJob');
-
-        $this->expectException(\DomainException::class);
-        $this->expectExceptionMessageMatches('/превышает лимит Ozon.*62 дней/');
-
-        // 63 дня включительно (дата окончания заведомо в прошлом, чтобы не споткнуться
-        // о «future»-guard).
-        ($this->action)(
-            self::COMPANY_ID,
-            new \DateTimeImmutable('2026-01-01'),
-            new \DateTimeImmutable('2026-03-04'),
         );
     }
 
@@ -186,7 +184,7 @@ final class DispatchOzonAdLoadActionTest extends TestCase
         ($this->action)(
             self::COMPANY_ID,
             new \DateTimeImmutable('2026-03-01'),
-            new \DateTimeImmutable('2026-03-10'),
+            new \DateTimeImmutable('2026-03-01'),
         );
     }
 
@@ -215,7 +213,7 @@ final class DispatchOzonAdLoadActionTest extends TestCase
         ($this->action)(
             self::COMPANY_ID,
             new \DateTimeImmutable('2026-03-01'),
-            new \DateTimeImmutable('2026-03-10'),
+            new \DateTimeImmutable('2026-03-01'),
         );
     }
 
@@ -237,7 +235,7 @@ final class DispatchOzonAdLoadActionTest extends TestCase
         ($this->action)(
             self::COMPANY_ID,
             new \DateTimeImmutable('2026-03-01'),
-            new \DateTimeImmutable('2026-03-10'),
+            new \DateTimeImmutable('2026-03-01'),
         );
     }
 }

--- a/site/tests/Unit/MarketplaceAds/Application/Service/AdLoadJobFinalizerTest.php
+++ b/site/tests/Unit/MarketplaceAds/Application/Service/AdLoadJobFinalizerTest.php
@@ -10,6 +10,7 @@ use App\MarketplaceAds\Enum\AdRawDocumentStatus;
 use App\MarketplaceAds\Repository\AdChunkProgressRepositoryInterface;
 use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
 use App\MarketplaceAds\Repository\AdRawDocumentRepositoryInterface;
+use App\MarketplaceAds\Repository\AdScheduledBatchRepositoryInterface;
 use App\Tests\Builders\MarketplaceAds\AdLoadJobBuilder;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -38,6 +39,8 @@ final class AdLoadJobFinalizerTest extends TestCase
     private AdRawDocumentRepositoryInterface $rawDocRepo;
     /** @var AdChunkProgressRepositoryInterface&MockObject */
     private AdChunkProgressRepositoryInterface $chunkRepo;
+    /** @var AdScheduledBatchRepositoryInterface&MockObject */
+    private AdScheduledBatchRepositoryInterface $batchRepo;
     private AdLoadJobFinalizer $finalizer;
 
     protected function setUp(): void
@@ -45,11 +48,13 @@ final class AdLoadJobFinalizerTest extends TestCase
         $this->jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
         $this->rawDocRepo = $this->createMock(AdRawDocumentRepositoryInterface::class);
         $this->chunkRepo = $this->createMock(AdChunkProgressRepositoryInterface::class);
+        $this->batchRepo = $this->createMock(AdScheduledBatchRepositoryInterface::class);
 
         $this->finalizer = new AdLoadJobFinalizer(
             $this->jobRepo,
             $this->rawDocRepo,
             $this->chunkRepo,
+            $this->batchRepo,
             new NullLogger(),
         );
     }

--- a/site/tests/Unit/MarketplaceAds/Command/AdJobFinalizerCommandTest.php
+++ b/site/tests/Unit/MarketplaceAds/Command/AdJobFinalizerCommandTest.php
@@ -7,7 +7,7 @@ namespace App\Tests\Unit\MarketplaceAds\Command;
 use App\MarketplaceAds\Command\AdJobFinalizerCommand;
 use App\MarketplaceAds\Entity\AdLoadJob;
 use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
-use App\MarketplaceAds\Repository\AdScheduledBatchRepository;
+use App\MarketplaceAds\Repository\AdScheduledBatchRepositoryInterface;
 use App\Tests\Builders\MarketplaceAds\AdLoadJobBuilder;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -35,15 +35,15 @@ final class AdJobFinalizerCommandTest extends TestCase
 
     /** @var AdLoadJobRepositoryInterface&MockObject */
     private AdLoadJobRepositoryInterface $jobRepo;
-    /** @var AdScheduledBatchRepository&MockObject */
-    private AdScheduledBatchRepository $batchRepo;
+    /** @var AdScheduledBatchRepositoryInterface&MockObject */
+    private AdScheduledBatchRepositoryInterface $batchRepo;
 
     private AdJobFinalizerCommand $command;
 
     protected function setUp(): void
     {
         $this->jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
-        $this->batchRepo = $this->createMock(AdScheduledBatchRepository::class);
+        $this->batchRepo = $this->createMock(AdScheduledBatchRepositoryInterface::class);
 
         $this->command = new AdJobFinalizerCommand(
             $this->jobRepo,
@@ -121,6 +121,10 @@ final class AdJobFinalizerCommandTest extends TestCase
             ->method('markCompleted')
             ->with(self::JOB_ID, self::COMPANY_ID)
             ->willReturn(1);
+        $this->batchRepo->expects(self::once())
+            ->method('abandonNonTerminalBatchesForTerminalJob')
+            ->with(self::JOB_ID, 'Abandoned because parent job became terminal: completed')
+            ->willReturn(0);
         $this->jobRepo->expects(self::never())->method('markFailed');
         $this->jobRepo->expects(self::never())->method('markPartialSuccess');
 
@@ -138,6 +142,10 @@ final class AdJobFinalizerCommandTest extends TestCase
             ->method('markFailed')
             ->with(self::JOB_ID, self::COMPANY_ID, 'All 3 batches failed')
             ->willReturn(1);
+        $this->batchRepo->expects(self::once())
+            ->method('abandonNonTerminalBatchesForTerminalJob')
+            ->with(self::JOB_ID, 'Abandoned because parent job became terminal: failed')
+            ->willReturn(0);
         $this->jobRepo->expects(self::never())->method('markCompleted');
         $this->jobRepo->expects(self::never())->method('markPartialSuccess');
 
@@ -157,6 +165,10 @@ final class AdJobFinalizerCommandTest extends TestCase
             ->method('markFailed')
             ->with(self::JOB_ID, self::COMPANY_ID, 'All 3 batches failed')
             ->willReturn(1);
+        $this->batchRepo->expects(self::once())
+            ->method('abandonNonTerminalBatchesForTerminalJob')
+            ->with(self::JOB_ID, 'Abandoned because parent job became terminal: failed')
+            ->willReturn(0);
         $this->jobRepo->expects(self::never())->method('markPartialSuccess');
 
         $tester = new CommandTester($this->command);
@@ -176,6 +188,10 @@ final class AdJobFinalizerCommandTest extends TestCase
             ->method('markPartialSuccess')
             ->with(self::JOB_ID, self::COMPANY_ID, '3 of 8 batches failed')
             ->willReturn(1);
+        $this->batchRepo->expects(self::once())
+            ->method('abandonNonTerminalBatchesForTerminalJob')
+            ->with(self::JOB_ID, 'Abandoned because parent job became terminal: partial_success')
+            ->willReturn(0);
         $this->jobRepo->expects(self::never())->method('markCompleted');
         $this->jobRepo->expects(self::never())->method('markFailed');
 

--- a/site/tests/Unit/MarketplaceAds/Command/ReconcileMarketplaceAdsCommandTest.php
+++ b/site/tests/Unit/MarketplaceAds/Command/ReconcileMarketplaceAdsCommandTest.php
@@ -11,7 +11,10 @@ use App\MarketplaceAds\Entity\AdLoadJob;
 use App\MarketplaceAds\Enum\AdLoadJobStatus;
 use App\MarketplaceAds\Exception\OzonRateLimitException;
 use App\MarketplaceAds\Infrastructure\Query\ActiveOzonPerformanceConnectionsQuery;
+use App\MarketplaceAds\Infrastructure\Query\AdDocumentQueryInterface;
 use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
+use App\MarketplaceAds\Repository\AdRawDocumentRepositoryInterface;
+use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
@@ -84,6 +87,84 @@ final class ReconcileMarketplaceAdsCommandTest extends TestCase
         self::assertStringContainsString('reload: failed_transient', $tester->getDisplay());
     }
 
+    public function testFailedJobWithExistingRawDataNeedsAttentionAndNoDispatch(): void
+    {
+        $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $repo->method('findLatestActiveJobByCompanyAndMarketplace')->willReturn(null);
+        $repo->method('findCompletedJobCoveringDate')->willReturn(null);
+        $repo->method('findLatestJobCoveringDate')->willReturn($this->job(AdLoadJobStatus::FAILED, 'HTTP 500'));
+
+        $dispatch = $this->createMock(DispatchOzonAdLoadActionInterface::class);
+        $dispatch->expects(self::never())->method('__invoke');
+
+        $rawRepo = $this->createMock(AdRawDocumentRepositoryInterface::class);
+        $rawRepo->method('countByCompanyMarketplaceAndDateRange')->willReturnCallback(
+            static fn (string $companyId, string $marketplace, \DateTimeImmutable $from, \DateTimeImmutable $to, ?\App\MarketplaceAds\Enum\AdRawDocumentStatus $statusFilter = null): int => match ($statusFilter) {
+                \App\MarketplaceAds\Enum\AdRawDocumentStatus::FAILED => 1,
+                \App\MarketplaceAds\Enum\AdRawDocumentStatus::DRAFT => 0,
+                default => 1,
+            }
+        );
+        $adQuery = $this->createMock(AdDocumentQueryInterface::class);
+        $adQuery->method('sumTotalCostForPeriod')->willReturn('0');
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchOne')->willReturn(0);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $command = $this->createCommand($repo, $dispatch, $logger, $this->emptyConnectionsQuery(), $rawRepo, $adQuery, $connection);
+        $tester = new CommandTester($command);
+        $tester->execute(['--company' => self::COMPANY_ID, '--from' => '2026-04-01', '--to' => '2026-04-01', '--include-failed' => true]);
+
+        self::assertStringContainsString('raw_failed_needs_attention', $tester->getDisplay());
+    }
+
+    public function testFailedJobWithExistingAdDocumentsNeedsAttentionAndNoDispatch(): void
+    {
+        $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $repo->method('findLatestActiveJobByCompanyAndMarketplace')->willReturn(null);
+        $repo->method('findCompletedJobCoveringDate')->willReturn(null);
+        $repo->method('findLatestJobCoveringDate')->willReturn($this->job(AdLoadJobStatus::FAILED, 'HTTP 500'));
+        $dispatch = $this->createMock(DispatchOzonAdLoadActionInterface::class);
+        $dispatch->expects(self::never())->method('__invoke');
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchOne')->willReturn(3);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $command = $this->createCommand($repo, $dispatch, $logger, $this->emptyConnectionsQuery(), connection: $connection);
+        $tester = new CommandTester($command);
+        $tester->execute(['--company' => self::COMPANY_ID, '--from' => '2026-04-01', '--to' => '2026-04-01', '--include-failed' => true]);
+
+        self::assertStringContainsString('needs_attention_data_exists', $tester->getDisplay());
+    }
+
+    public function testForceReloadExistingDataAllowsDispatch(): void
+    {
+        $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
+        $repo->method('findLatestActiveJobByCompanyAndMarketplace')->willReturn(null);
+        $repo->method('findCompletedJobCoveringDate')->willReturn(null);
+        $repo->method('findLatestJobCoveringDate')->willReturn($this->job(AdLoadJobStatus::FAILED, 'HTTP 500'));
+        $dispatch = $this->createMock(DispatchOzonAdLoadActionInterface::class);
+        $dispatch->expects(self::once())->method('__invoke');
+
+        $rawRepo = $this->createMock(AdRawDocumentRepositoryInterface::class);
+        $rawRepo->method('countByCompanyMarketplaceAndDateRange')->willReturn(2);
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchOne')->willReturn(2);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $command = $this->createCommand($repo, $dispatch, $logger, $this->emptyConnectionsQuery(), $rawRepo, connection: $connection);
+        $tester = new CommandTester($command);
+        $tester->execute([
+            '--company' => self::COMPANY_ID,
+            '--from' => '2026-04-01',
+            '--to' => '2026-04-01',
+            '--include-failed' => true,
+            '--force-reload-existing-data' => true,
+        ]);
+        self::assertStringContainsString('reload: failed_transient', $tester->getDisplay());
+    }
+
     public function testRecognizes429AsRateLimited(): void
     {
         $repo = $this->createMock(AdLoadJobRepositoryInterface::class);
@@ -97,7 +178,7 @@ final class ReconcileMarketplaceAdsCommandTest extends TestCase
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects(self::once())->method('warning');
 
-        $command = new ReconcileMarketplaceAdsCommand($repo, $dispatch, $this->emptyConnectionsQuery(), $logger);
+        $command = $this->createCommand($repo, $dispatch, $logger, $this->emptyConnectionsQuery());
         $tester = new CommandTester($command);
         $code = $tester->execute([
             '--company' => self::COMPANY_ID,
@@ -235,7 +316,7 @@ final class ReconcileMarketplaceAdsCommandTest extends TestCase
         $logger->expects(self::once())->method('warning');
         $logger->expects(self::never())->method('error');
 
-        $command = new ReconcileMarketplaceAdsCommand($repo, $dispatch, $this->emptyConnectionsQuery(), $logger);
+        $command = $this->createCommand($repo, $dispatch, $logger, $this->emptyConnectionsQuery());
         $tester = new CommandTester($command);
         $code = $tester->execute([
             '--company' => self::COMPANY_ID,
@@ -269,7 +350,7 @@ final class ReconcileMarketplaceAdsCommandTest extends TestCase
         $logger->expects(self::atLeastOnce())->method('warning');
         $logger->expects(self::never())->method('error');
 
-        $command = new ReconcileMarketplaceAdsCommand($repo, $dispatch, $this->emptyConnectionsQuery(), $logger);
+        $command = $this->createCommand($repo, $dispatch, $logger, $this->emptyConnectionsQuery());
         $tester = new CommandTester($command);
         $code = $tester->execute([
             '--company' => self::COMPANY_ID,
@@ -380,7 +461,7 @@ final class ReconcileMarketplaceAdsCommandTest extends TestCase
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects(self::never())->method('error');
 
-        $command = new ReconcileMarketplaceAdsCommand($repo, $dispatch, $this->emptyConnectionsQuery(), $logger);
+        $command = $this->createCommand($repo, $dispatch, $logger, $this->emptyConnectionsQuery());
         $tester = new CommandTester($command);
         $code = $tester->execute(['--company' => self::COMPANY_ID, '--from' => '2026-04-01', '--to' => '2026-04-01']);
 
@@ -391,9 +472,46 @@ final class ReconcileMarketplaceAdsCommandTest extends TestCase
     private function tester(AdLoadJobRepositoryInterface $repo, DispatchOzonAdLoadActionInterface $dispatch, ?ActiveOzonPerformanceConnectionsQuery $query = null): CommandTester
     {
         $logger = $this->createMock(LoggerInterface::class);
-        $command = new ReconcileMarketplaceAdsCommand($repo, $dispatch, $query ?? $this->emptyConnectionsQuery(), $logger);
+        $command = $this->createCommand($repo, $dispatch, $logger, $query ?? $this->emptyConnectionsQuery());
 
         return new CommandTester($command);
+    }
+
+    private function createCommand(
+        AdLoadJobRepositoryInterface $repo,
+        DispatchOzonAdLoadActionInterface $dispatch,
+        LoggerInterface $logger,
+        ActiveOzonPerformanceConnectionsQuery $query,
+        ?AdRawDocumentRepositoryInterface $rawRepo = null,
+        ?AdDocumentQueryInterface $adDocumentQuery = null,
+        ?Connection $connection = null,
+    ): ReconcileMarketplaceAdsCommand {
+        if (null === $rawRepo) {
+            $rawRepo = $this->createMock(AdRawDocumentRepositoryInterface::class);
+            $rawRepo->method('countByCompanyMarketplaceAndDateRange')->willReturnCallback(
+                static fn (string $companyId, string $marketplace, \DateTimeImmutable $from, \DateTimeImmutable $to, ?\App\MarketplaceAds\Enum\AdRawDocumentStatus $statusFilter = null): int => 0
+            );
+        }
+
+        if (null === $adDocumentQuery) {
+            $adDocumentQuery = $this->createMock(AdDocumentQueryInterface::class);
+            $adDocumentQuery->method('sumTotalCostForPeriod')->willReturn('0');
+        }
+
+        if (null === $connection) {
+            $connection = $this->createMock(Connection::class);
+            $connection->method('fetchOne')->willReturn(0);
+        }
+
+        return new ReconcileMarketplaceAdsCommand(
+            $repo,
+            $rawRepo,
+            $adDocumentQuery,
+            $connection,
+            $dispatch,
+            $query,
+            $logger,
+        );
     }
 
 

--- a/site/tests/Unit/MarketplaceAds/EventSubscriber/AdLoadJobFailureSubscriberTest.php
+++ b/site/tests/Unit/MarketplaceAds/EventSubscriber/AdLoadJobFailureSubscriberTest.php
@@ -8,6 +8,7 @@ use App\MarketplaceAds\EventSubscriber\AdLoadJobFailureSubscriber;
 use App\MarketplaceAds\Message\FetchOzonAdStatisticsMessage;
 use App\MarketplaceAds\Message\ProcessAdRawDocumentMessage;
 use App\MarketplaceAds\Repository\AdLoadJobRepositoryInterface;
+use App\MarketplaceAds\Repository\AdScheduledBatchRepositoryInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Envelope;
@@ -48,7 +49,8 @@ final class AdLoadJobFailureSubscriberTest extends TestCase
 
         self::assertTrue($event->willRetry(), 'sanity: событие помечено для ретрая');
 
-        (new AdLoadJobFailureSubscriber($repo, $logger))->onMessageFailed($event);
+        $batchRepo = $this->createMock(AdScheduledBatchRepositoryInterface::class);
+        (new AdLoadJobFailureSubscriber($repo, $batchRepo, $logger))->onMessageFailed($event);
     }
 
     public function testNonFetchMessageIsIgnored(): void
@@ -67,7 +69,8 @@ final class AdLoadJobFailureSubscriberTest extends TestCase
 
         self::assertFalse($event->willRetry());
 
-        (new AdLoadJobFailureSubscriber($repo, $logger))->onMessageFailed($event);
+        $batchRepo = $this->createMock(AdScheduledBatchRepositoryInterface::class);
+        (new AdLoadJobFailureSubscriber($repo, $batchRepo, $logger))->onMessageFailed($event);
     }
 
     public function testExhaustedRetriesMarkJobAsFailed(): void
@@ -108,7 +111,9 @@ final class AdLoadJobFailureSubscriberTest extends TestCase
 
         self::assertFalse($event->willRetry());
 
-        (new AdLoadJobFailureSubscriber($repo, $logger))->onMessageFailed($event);
+        $batchRepo = $this->createMock(AdScheduledBatchRepositoryInterface::class);
+        $batchRepo->expects(self::once())->method('abandonNonTerminalBatchesForTerminalJob');
+        (new AdLoadJobFailureSubscriber($repo, $batchRepo, $logger))->onMessageFailed($event);
     }
 
     public function testHandlerFailedExceptionUnwrapsToPrevious(): void
@@ -148,7 +153,9 @@ final class AdLoadJobFailureSubscriberTest extends TestCase
 
         $event = new WorkerMessageFailedEvent($envelope, 'async_ads', $wrapper);
 
-        (new AdLoadJobFailureSubscriber($repo, $logger))->onMessageFailed($event);
+        $batchRepo = $this->createMock(AdScheduledBatchRepositoryInterface::class);
+        $batchRepo->expects(self::once())->method('abandonNonTerminalBatchesForTerminalJob');
+        (new AdLoadJobFailureSubscriber($repo, $batchRepo, $logger))->onMessageFailed($event);
     }
 
     public function testReasonTruncationKeepsUtf8Valid(): void
@@ -180,7 +187,9 @@ final class AdLoadJobFailureSubscriberTest extends TestCase
         ));
         $event = new WorkerMessageFailedEvent($envelope, 'async_ads', new \RuntimeException($longMessage));
 
-        (new AdLoadJobFailureSubscriber($repo, $logger))->onMessageFailed($event);
+        $batchRepo = $this->createMock(AdScheduledBatchRepositoryInterface::class);
+        $batchRepo->expects(self::once())->method('abandonNonTerminalBatchesForTerminalJob');
+        (new AdLoadJobFailureSubscriber($repo, $batchRepo, $logger))->onMessageFailed($event);
     }
 
     public function testReasonIsTruncatedTo1000Chars(): void
@@ -209,6 +218,8 @@ final class AdLoadJobFailureSubscriberTest extends TestCase
         ));
         $event = new WorkerMessageFailedEvent($envelope, 'async_ads', new \RuntimeException($longMessage));
 
-        (new AdLoadJobFailureSubscriber($repo, $logger))->onMessageFailed($event);
+        $batchRepo = $this->createMock(AdScheduledBatchRepositoryInterface::class);
+        $batchRepo->expects(self::once())->method('abandonNonTerminalBatchesForTerminalJob');
+        (new AdLoadJobFailureSubscriber($repo, $batchRepo, $logger))->onMessageFailed($event);
     }
 }

--- a/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
@@ -14,6 +14,7 @@ use App\MarketplaceAds\Message\RequestOzonAdBatchMessage;
 use App\MarketplaceAds\MessageHandler\FetchOzonAdStatisticsHandler;
 use App\MarketplaceAds\Repository\AdChunkProgressRepositoryInterface;
 use App\MarketplaceAds\Repository\AdLoadJobRepository;
+use App\MarketplaceAds\Repository\AdScheduledBatchRepositoryInterface;
 use App\MarketplaceAds\Repository\OzonAdPendingReportRepository;
 use App\Shared\Service\AppLogger;
 use App\Tests\Builders\MarketplaceAds\AdLoadJobBuilder;
@@ -387,6 +388,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         $handler = new FetchOzonAdStatisticsHandler(
             $ozonClient,
             $jobRepo,
+            $this->createMock(AdScheduledBatchRepositoryInterface::class),
             $chunkProgressRepo,
             $pendingRepo,
             $finalizer,
@@ -717,6 +719,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         return new FetchOzonAdStatisticsHandler(
             $ozonClient,
             $jobRepo,
+            $this->createMock(AdScheduledBatchRepositoryInterface::class),
             $chunkProgressRepo,
             $pendingRepo,
             $finalizer ?? $this->createMock(AdLoadJobFinalizer::class),

--- a/site/tests/Unit/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandlerTest.php
@@ -10,6 +10,7 @@ use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonPermanentApiException;
 use App\MarketplaceAds\Message\RequestOzonAdBatchMessage;
 use App\MarketplaceAds\MessageHandler\RequestOzonAdBatchHandler;
 use App\MarketplaceAds\Repository\AdLoadJobRepository;
+use App\MarketplaceAds\Repository\AdScheduledBatchRepositoryInterface;
 use App\MarketplaceAds\Repository\OzonAdPendingReportRepository;
 use App\Tests\Builders\MarketplaceAds\AdLoadJobBuilder;
 use PHPUnit\Framework\TestCase;
@@ -539,6 +540,7 @@ final class RequestOzonAdBatchHandlerTest extends TestCase
 
         return new RequestOzonAdBatchHandler(
             $jobRepo,
+            $this->createMock(AdScheduledBatchRepositoryInterface::class),
             $ozonClient,
             $pendingRepo,
             $bus,


### PR DESCRIPTION
### Motivation

- Prevent orphaned/in-flight Ozon scheduled batches from remaining active after their parent `AdLoadJob` becomes terminal to avoid stray API activity and inconsistent pipeline state. 
- Decouple services from the concrete repository and make batch-abandon semantics reusable via an interface. 
- Harden user-facing load/reconcile flows to avoid accidental multi-day loads and to skip reloading days when raw/ad data already exists unless explicitly forced.

### Description

- Add `AdScheduledBatchRepositoryInterface` and make `AdScheduledBatchRepository` implement it, exposing `findNextPlanned`, `findAllInFlight`, `countStatesForJob` and new `abandonNonTerminalBatchesForTerminalJob` which atomically updates non-terminal batches to `ABANDONED` with reason. 
- Update repository SQL in `findNextPlanned` and `findAllInFlight` to skip batches whose parent job is terminal. 
- Propagate the interface injection across consumers and replace concrete-type dependencies with `AdScheduledBatchRepositoryInterface` in `AdLoadJobFinalizer`, `AdJobFinalizerCommand`, `MarkAdLoadJobFailedController`, `AdLoadJobFailureSubscriber`, `FetchOzonAdStatisticsHandler`, `RequestOzonAdBatchHandler` and tests. 
- Ensure any code path that terminalizes a job (`markCompleted`, `markFailed`, `markPartialSuccess`) calls `abandonNonTerminalBatchesForTerminalJob` (guarded on affected rows) to abandon remaining `PLANNED/IN_FLIGHT/REQUESTED` batches. 
- Restrict manual dispatch behavior in `DispatchOzonAdLoadAction` to single-day loads and update related tests to reflect the new validation. 
- Enhance `ReconcileMarketplaceAdsCommand` with checks for existing raw documents and already-upserted ad documents (via `AdRawDocumentRepository`, `AdDocumentQueryInterface` and DB `fetchOne`), add `--force-reload-existing-data` option, and skip reloads when data exists unless forced; add richer logging with counts and reasons. 
- Add unit/integration tests and update many existing tests to reflect the new behavior and DI changes, including `AdScheduledBatchRepositoryTest`, `DispatchOzonAdLoadActionTest`, `AdLoadJobFinalizerTest`, `AdJobFinalizerCommandTest`, `ReconcileMarketplaceAdsCommandTest`, `AdLoadJobFailureSubscriberTest`, `FetchOzonAdStatisticsHandlerTest`, and `RequestOzonAdBatchHandlerTest`.

### Testing

- Ran the MarketplaceAds unit test suite including `DispatchOzonAdLoadActionTest`, `AdLoadJobFinalizerTest`, `AdJobFinalizerCommandTest`, `ReconcileMarketplaceAdsCommandTest`, `AdLoadJobFailureSubscriberTest`, `FetchOzonAdStatisticsHandlerTest`, and `RequestOzonAdBatchHandlerTest`, and they passed. 
- Ran the integration test `AdScheduledBatchRepositoryTest` covering `findNextPlanned`, `findAllInFlight` and `abandonNonTerminalBatchesForTerminalJob`, and it passed. 
- Executed the full PHPUnit MarketplaceAds test group after changes; all modified and existing tests in that group succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a129decfb9c8323b7071d0ad2ba4725)