### PR TITLE
Isolate WB financial sync into dedicated messenger transport and single worker

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,6 +18,7 @@ x-php-env: &php-env
     MESSENGER_TRANSPORT_DSN_SYNC: redis://site-redis:6379/messages_sync
     MESSENGER_TRANSPORT_DSN_PIPELINE: redis://site-redis:6379/messages_pipeline
     MESSENGER_TRANSPORT_DSN_ADS: redis://site-redis:6379/messages_ads
+    MESSENGER_TRANSPORT_DSN_WB_FINANCE: redis://site-redis:6379/messages_wb_finance
     MAILER_DSN: ${SITE_MAILER_DSN}
     SENTRY_DSN: ${SENTRY_DSN}
     HEALTH_CHECK_TOKEN: ${HEALTH_CHECK_TOKEN}
@@ -264,6 +265,38 @@ services:
                 reservations:
                     memory: 192M
 
+    site-messenger-worker-wb-finance:
+        image: ghcr.io/pavelsur07/site-php-cli:latest
+        container_name: site-messenger-worker-wb-finance
+        restart: always
+        command: php bin/console messenger:consume async_wb_finance --time-limit=3600 --memory-limit=256M --sleep=5 --no-interaction
+        environment:
+            <<: *php-env
+        networks:
+            - default
+        depends_on:
+            site-postgres:
+                condition: service_healthy
+            site-redis:
+                condition: service_healthy
+        volumes:
+            - site_storage:/app/var/storage
+            - site_company_storage:/app/var/storage/companies
+            - site_var_log:/app/var/log
+        stop_grace_period: 60s
+        healthcheck:
+            test: ["CMD-SHELL", "ps aux | grep 'messenger:consume async_wb_finance' | grep -v grep"]
+            interval: 30s
+            timeout: 10s
+            retries: 3
+            start_period: 10s
+        deploy:
+            resources:
+                limits:
+                    memory: 256M
+                reservations:
+                    memory: 64M
+
     site-messenger-worker-ads:
         image: ghcr.io/pavelsur07/site-php-cli:latest
         container_name: site-messenger-worker-ads
@@ -367,6 +400,7 @@ services:
             MESSENGER_TRANSPORT_DSN_SYNC: redis://site-redis:6379/messages_sync
             MESSENGER_TRANSPORT_DSN_PIPELINE: redis://site-redis:6379/messages_pipeline
             MESSENGER_TRANSPORT_DSN_ADS: redis://site-redis:6379/messages_ads
+            MESSENGER_TRANSPORT_DSN_WB_FINANCE: redis://site-redis:6379/messages_wb_finance
             MAILER_DSN: ${SITE_MAILER_DSN}
             SENTRY_DSN: ${SENTRY_DSN}
             APP_MAIL_FROM: "Ваш Финдир <support@vashfindir.ru>"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,6 +130,23 @@ services:
             - ./site:/app
         command: php bin/console messenger:consume async_pipeline --time-limit=3600 --memory-limit=500M -vv
 
+    site-php-cli-worker-wb-finance:
+        build:
+            context: site/docker
+            dockerfile: development/php-cli/Dockerfile
+        working_dir: /app
+        restart: unless-stopped
+        environment:
+            <<: *tz-env
+        depends_on:
+            site-postgres:
+                condition: service_healthy
+            site-redis:
+                condition: service_healthy
+        volumes:
+            - ./site:/app
+        command: php bin/console messenger:consume async_wb_finance --time-limit=3600 --memory-limit=256M --sleep=5 --no-interaction
+
     site-php-cli-worker-ads:
         build:
             context: site/docker

--- a/site/.env
+++ b/site/.env
@@ -37,6 +37,7 @@ MESSENGER_TRANSPORT_DSN=redis://site-redis:6379/messages
 MESSENGER_TRANSPORT_DSN_SYNC=redis://site-redis:6379/messages_sync
 MESSENGER_TRANSPORT_DSN_PIPELINE=redis://site-redis:6379/messages_pipeline
 MESSENGER_TRANSPORT_DSN_ADS=redis://site-redis:6379/messages_ads
+MESSENGER_TRANSPORT_DSN_WB_FINANCE=redis://site-redis:6379/messages_wb_finance
 ###< symfony/messenger ###
 
 

--- a/site/config/packages/messenger.yaml
+++ b/site/config/packages/messenger.yaml
@@ -17,6 +17,13 @@ framework:
                     delay: 5000
                     multiplier: 2
 
+            async_wb_finance:
+                dsn: '%env(MESSENGER_TRANSPORT_DSN_WB_FINANCE)%'
+                retry_strategy:
+                    max_retries: 20
+                    delay: 61000
+                    multiplier: 1
+
             async_ads:
                 dsn: '%env(MESSENGER_TRANSPORT_DSN_ADS)%'
                 retry_strategy:
@@ -37,7 +44,7 @@ framework:
         routing:
             # --- async_sync: external marketplace/bank HTTP fetches ---
             'App\Marketplace\Message\SyncWbReportMessage': async_sync
-            'App\Marketplace\Message\SyncWbFinancialReportDayMessage': async_sync
+            'App\Marketplace\Message\SyncWbFinancialReportDayMessage': async_wb_finance
             'App\Marketplace\Message\SyncOzonReportMessage': async_sync
             'App\Marketplace\Message\SyncOzonRealizationMessage': async_sync
             'App\Marketplace\Message\InitialSyncMessage': async_sync

--- a/site/config/packages/test/messenger.yaml
+++ b/site/config/packages/test/messenger.yaml
@@ -3,4 +3,5 @@ framework:
         transports:
             async_sync: 'in-memory://'
             async_pipeline: 'in-memory://'
+            async_wb_finance: 'in-memory://'
             async_ads: 'in-memory://'


### PR DESCRIPTION
### Motivation
- WB financial API has a strict rate limit (~1 request/min) and long waits that must not block the shared `async_sync` transport.
- The change isolates WB finance syncs so throttling and retries won't interfere with other external fetches.

### Description
- Added new Messenger transport `async_wb_finance` in `site/config/packages/messenger.yaml` with `dsn: %env(MESSENGER_TRANSPORT_DSN_WB_FINANCE)%` and retry strategy `max_retries: 20`, `delay: 61000`, `multiplier: 1`.
- Routed `App\Marketplace\Message\SyncWbFinancialReportDayMessage` to `async_wb_finance` and removed it from `async_sync`, while leaving `App\Marketplace\Message\ProcessDayReportMessage` on `async_pipeline` unchanged.
- Added `MESSENGER_TRANSPORT_DSN_WB_FINANCE` to `site/.env` (default Redis stream `redis://site-redis:6379/messages_wb_finance`) and added `async_wb_finance: 'in-memory://'` to `site/config/packages/test/messenger.yaml` for tests.
- Added a single dedicated worker in production `site-messenger-worker-wb-finance` and a dev worker `site-php-cli-worker-wb-finance` that run `php bin/console messenger:consume async_wb_finance --time-limit=3600 --memory-limit=256M --sleep=5 --no-interaction`, and included a healthcheck for the consumer.

### Testing
- Verified presence of new transport, routing change and env variable with `rg`/file inspection which returned the expected entries and worker/service names (success).
- Inspected modified files (`site/config/packages/messenger.yaml`, `site/config/packages/test/messenger.yaml`, `site/.env`, `docker-compose.yml`, `docker-compose.prod.yml`) with `sed`/`nl` to confirm changes (success).
- Attempted `cd site && php bin/console debug:config framework messenger` but it failed with `Dependencies are missing. Try running "composer install"`, so runtime config validation in the app container was not runnable in this environment (failure).
- No additional automated unit/integration test runs were executed in this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13e640536c832395936b9a5b5b225d)