### PR TITLE
Use token_bucket local limiter and blocking wait for WB finance reports

### DIFF
--- a/site/config/packages/rate_limiter.yaml
+++ b/site/config/packages/rate_limiter.yaml
@@ -14,6 +14,6 @@ framework:
             interval: '1 minute'
 
         wb_finance:
-            policy: fixed_window
+            policy: token_bucket
             limit: 1
-            interval: '1 minute'
+            rate: { interval: '61 seconds', amount: 1 }

--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -56,7 +56,7 @@ services:
 
     App\Marketplace\Application\Service\WbFinanceRateLimiter:
         arguments:
-            $factory: '@?limiter.wb_finance'
+            $factory: '@limiter.wb_finance'
 
     App\Service\FeatureFlagService:
         arguments:

--- a/site/src/Marketplace/Application/Service/WbFinanceRateLimiter.php
+++ b/site/src/Marketplace/Application/Service/WbFinanceRateLimiter.php
@@ -5,20 +5,40 @@ declare(strict_types=1);
 namespace App\Marketplace\Application\Service;
 
 use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\Clock\ClockInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 final class WbFinanceRateLimiter
 {
-    public function __construct(private readonly ?RateLimiterFactory $factory = null)
-    {
+    public function __construct(
+        private readonly RateLimiterFactory $factory,
+        private readonly ClockInterface $clock,
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
     }
 
-    public function acquire(string $connectionId, int $tokens = 1): bool
-    {
-        if (null !== $this->factory) {
-            return $this->factory->create($this->buildKey($connectionId))->consume($tokens)->isAccepted();
-        }
+    private LoggerInterface $logger;
 
-        return true;
+    public function wait(string $connectionId, int $tokens = 1): void
+    {
+        $limiter = $this->factory->create($this->buildKey($connectionId));
+
+        while (true) {
+            $limit = $limiter->consume($tokens);
+            if ($limit->isAccepted()) {
+                return;
+            }
+
+            $retryAfter = $limit->getRetryAfter();
+            $waitSeconds = max(1, $retryAfter->getTimestamp() - $this->clock->now()->getTimestamp());
+            $this->logger->info('WB finance throttle wait.', [
+                'connection_id' => $connectionId,
+                'wait_seconds' => $waitSeconds,
+            ]);
+            $this->clock->sleep($waitSeconds);
+        }
     }
 
     private function buildKey(string $connectionId): string

--- a/site/src/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClient.php
+++ b/site/src/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClient.php
@@ -12,7 +12,6 @@ use App\Marketplace\Application\Service\WbFinanceRateLimiter;
 use App\Marketplace\Exception\MarketplaceTemporaryApiException;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Symfony\Component\Clock\ClockInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -22,19 +21,17 @@ final readonly class WbFinanceSalesReportClient
     private const PAGE_SIZE = 100000;
     private const WB_HEADER_RETRY = 'x-ratelimit-retry';
     private const WB_HEADER_RESET = 'x-ratelimit-reset';
-    private const WB_MIN_DELAY_SECONDS = 61;
 
     private LoggerInterface $logger;
     private WbFinanceRateLimiter $rateLimiter;
 
     public function __construct(
         private HttpClientInterface $httpClient,
-        private ClockInterface $clock,
+        WbFinanceRateLimiter $rateLimiter,
         ?LoggerInterface $logger = null,
-        ?WbFinanceRateLimiter $rateLimiter = null,
     ) {
         $this->logger = $logger ?? new NullLogger();
-        $this->rateLimiter = $rateLimiter ?? new WbFinanceRateLimiter();
+        $this->rateLimiter = $rateLimiter;
     }
 
 
@@ -47,6 +44,16 @@ final readonly class WbFinanceSalesReportClient
     }
 
     /** @return list<array<string,mixed>> */
+    public function fetchDetailedForConnection(string $connectionId, string $apiKey, string $dateFrom, string $dateTo): array
+    {
+        return $this->fetchDetailedInternal($apiKey, $dateFrom, $dateTo, $connectionId);
+    }
+
+    /**
+     * @deprecated Use fetchDetailedForConnection() in production flows to ensure local throttling per connection.
+     *
+     * @return list<array<string,mixed>>
+     */
     public function fetchDetailed(string $apiKey, string $dateFrom, string $dateTo): array
     {
         return $this->fetchDetailedInternal($apiKey, $dateFrom, $dateTo);
@@ -59,8 +66,8 @@ final readonly class WbFinanceSalesReportClient
         $rrdId = 0;
 
         while (true) {
-            if (null !== $connectionId && !$this->rateLimiter->acquire($connectionId)) {
-                throw new MarketplaceRateLimitException(429, 'Local WB finance rate limit exceeded.', $dateFrom, $dateTo, self::WB_MIN_DELAY_SECONDS);
+            if (null !== $connectionId) {
+                $this->rateLimiter->wait($connectionId);
             }
             try {
                 $response = $this->httpClient->request('POST', self::BASE_URL.'/api/finance/v1/sales-reports/detailed', [
@@ -143,7 +150,6 @@ final readonly class WbFinanceSalesReportClient
                 return $rows;
             }
 
-            $this->clock->sleep(self::WB_MIN_DELAY_SECONDS);
         }
     }
 
@@ -151,6 +157,8 @@ final readonly class WbFinanceSalesReportClient
 
     public function probeAccess(string $apiKey): bool
     {
+        // Probe is used for explicit credential checks (e.g. verify connection),
+        // not for report sync pipeline, so local report throttling is not applied here.
         try {
             $response = $this->httpClient->request('GET', self::BASE_URL.'/ping', [
                 'headers' => ['Authorization' => $apiKey],
@@ -216,9 +224,7 @@ final readonly class WbFinanceSalesReportClient
 
     public function hasAnyDataForConnection(string $connectionId, string $apiKey, string $dateFrom, string $dateTo): bool
     {
-        if (!$this->rateLimiter->acquire($connectionId)) {
-            throw new MarketplaceRateLimitException(429, 'Local WB finance rate limit exceeded.', $dateFrom, $dateTo, self::WB_MIN_DELAY_SECONDS);
-        }
+        $this->rateLimiter->wait($connectionId);
 
         return $this->hasAnyData($apiKey, $dateFrom, $dateTo);
     }

--- a/site/src/Marketplace/Service/Integration/WildberriesAdapter.php
+++ b/site/src/Marketplace/Service/Integration/WildberriesAdapter.php
@@ -55,7 +55,12 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
         $dateFrom = $fromDate->format('Y-m-d');
         $dateTo = $toDate->format('Y-m-d');
 
-        return $this->salesReportClient->fetchDetailed($connection->getApiKey(), $dateFrom, $dateTo);
+        return $this->salesReportClient->fetchDetailedForConnection(
+            $connection->getId(),
+            $connection->getApiKey(),
+            $dateFrom,
+            $dateTo,
+        );
     }
 
     public function hasRawReportData(
@@ -72,7 +77,12 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
         $dateFrom = $fromDate->format('Y-m-d');
         $dateTo = $toDate->format('Y-m-d');
 
-        return $this->salesReportClient->hasAnyData($connection->getApiKey(), $dateFrom, $dateTo);
+        return $this->salesReportClient->hasAnyDataForConnection(
+            $connection->getId(),
+            $connection->getApiKey(),
+            $dateFrom,
+            $dateTo,
+        );
     }
 
     /**
@@ -328,4 +338,3 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
         );
     }
 }
-

--- a/site/tests/Integration/Marketplace/Application/Service/WbFinancialReportFirstAvailableResolverTest.php
+++ b/site/tests/Integration/Marketplace/Application/Service/WbFinancialReportFirstAvailableResolverTest.php
@@ -108,21 +108,23 @@ final class WbFinancialReportFirstAvailableResolverTest extends IntegrationTestC
         self::assertSame('2026-02-03', $step6->getStartDate()?->format('Y-m-d'));
     }
 
-    public function testRateLimitedStepReturnsIncompleteWithRetryAfter(): void
+    public function testSecondResolveForSameConnectionDoesNotFailOnLocalLimiterAndContinuesFlow(): void
     {
         $resolver = $this->resolverWithResponses([
-            ['http_code' => 200, 'body' => '[{"rrdId":1}]'],
-        ], true);
+            ['http_code' => 200, 'body' => '[{"rrdId":1}]'], // full range true
+            ['http_code' => 204, 'body' => ''],               // month probe after local wait
+        ]);
 
         $step1 = $resolver->resolve(self::CONNECTION_ID, self::COMPANY_ID, 'token');
         self::assertTrue($step1->needsRetry());
 
         $step2 = $resolver->resolve(self::CONNECTION_ID, self::COMPANY_ID, 'token', $step1->getPhase(), $step1->getNextProbeFrom(), $step1->getNextProbeTo());
         self::assertTrue($step2->needsRetry());
-        self::assertSame(61, $step2->getRetryAfterSeconds());
+        self::assertSame(WbFinancialReportFirstAvailableResolver::PHASE_MONTH_SCAN, $step2->getPhase());
+        self::assertNull($step2->getRetryAfterSeconds());
     }
 
-    private function resolverWithResponses(array $responses, bool $withLimiter = false): WbFinancialReportFirstAvailableResolver
+    private function resolverWithResponses(array $responses): WbFinancialReportFirstAvailableResolver
     {
         $idx = 0;
         $http = new MockHttpClient(static function () use (&$idx, $responses): MockResponse {
@@ -132,7 +134,7 @@ final class WbFinancialReportFirstAvailableResolverTest extends IntegrationTestC
             return new MockResponse($response['body'], ['http_code' => $response['http_code']]);
         });
 
-        $client = new WbFinanceSalesReportClient($http, new MockClock('2026-03-15 10:00:00 Europe/Moscow'), null, $withLimiter ? $this->rateLimiter() : null);
+        $client = new WbFinanceSalesReportClient($http, $this->rateLimiter());
 
         return new WbFinancialReportFirstAvailableResolver(new WbFinancialReportPeriodResolver(new MockClock('2026-03-15 10:00:00 Europe/Moscow')), $this->statusRepository, $client);
     }
@@ -147,6 +149,6 @@ final class WbFinancialReportFirstAvailableResolverTest extends IntegrationTestC
 
     private function rateLimiter(): WbFinanceRateLimiter
     {
-        return new WbFinanceRateLimiter(new RateLimiterFactory(['id' => 'wb_finance', 'policy' => 'fixed_window', 'limit' => 1, 'interval' => '1 minute'], new InMemoryStorage()));
+        return new WbFinanceRateLimiter(new RateLimiterFactory(['id' => 'wb_finance', 'policy' => 'token_bucket', 'limit' => 1, 'rate' => ['interval' => '61 seconds', 'amount' => 1]], new InMemoryStorage()), new MockClock('2026-03-15 10:00:00 Europe/Moscow'));
     }
 }

--- a/site/tests/Integration/Marketplace/MessageHandler/SyncWbFinancialReportDayHandlerTest.php
+++ b/site/tests/Integration/Marketplace/MessageHandler/SyncWbFinancialReportDayHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Integration\Marketplace\MessageHandler;
 
+use App\Marketplace\Application\Service\WbFinanceRateLimiter;
 use App\Company\Entity\Company;
 use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Entity\MarketplaceFinancialReportSyncError;
@@ -24,6 +25,8 @@ use App\Tests\Support\Kernel\IntegrationTestCase;
 use Symfony\Component\Clock\MockClock;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
@@ -309,7 +312,7 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
     /** @param list<MockResponse> $responses */
     private function swapWbClient(array $responses): void
     {
-        self::getContainer()->set(WbFinanceSalesReportClient::class, new WbFinanceSalesReportClient(new MockHttpClient($responses), new MockClock('2026-05-20 12:00:00 UTC')));
+        self::getContainer()->set(WbFinanceSalesReportClient::class, new WbFinanceSalesReportClient(new MockHttpClient($responses), $this->createRateLimiter()));
     }
 
     private function swapBusSpy(): object
@@ -381,5 +384,9 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
             'periodFrom' => new \DateTimeImmutable($date),
             'periodTo' => new \DateTimeImmutable($date),
         ]);
+    }
+    private function createRateLimiter(): WbFinanceRateLimiter
+    {
+        return new WbFinanceRateLimiter(new RateLimiterFactory(['id' => 'wb_finance', 'policy' => 'token_bucket', 'limit' => 1, 'rate' => ['interval' => '61 seconds', 'amount' => 1]], new InMemoryStorage()), new MockClock('2026-01-01T00:00:00Z'));
     }
 }

--- a/site/tests/Integration/Marketplace/WbFinancialReportSyncIdempotencyTest.php
+++ b/site/tests/Integration/Marketplace/WbFinancialReportSyncIdempotencyTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Integration\Marketplace;
 
+use App\Marketplace\Application\Service\WbFinanceRateLimiter;
 use App\Company\Entity\Company;
 use App\Marketplace\Application\Service\WbFinancialReportPeriodResolver;
 use App\Marketplace\Application\Service\WbFinancialReportSyncPlanner;
@@ -29,6 +30,8 @@ use Ramsey\Uuid\Uuid;
 use Symfony\Component\Clock\MockClock;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -233,7 +236,7 @@ final class WbFinancialReportSyncIdempotencyTest extends IntegrationTestCase
 
     private function swapWbClient(array $responses): void
     {
-        self::getContainer()->set(WbFinanceSalesReportClient::class, new WbFinanceSalesReportClient(new MockHttpClient($responses), new MockClock('2026-05-21 12:00:00 UTC')));
+        self::getContainer()->set(WbFinanceSalesReportClient::class, new WbFinanceSalesReportClient(new MockHttpClient($responses), $this->createRateLimiter()));
     }
 
     private function countStatuses(string $companyId, string $connectionId, string $day): int
@@ -304,6 +307,10 @@ final class WbFinancialReportSyncIdempotencyTest extends IntegrationTestCase
         $value = $this->connection->fetchOne('SELECT status FROM marketplace_financial_report_sync_statuses WHERE company_id=:c AND connection_id=:n AND business_date=:d', ['c'=>$companyId, 'n'=>$connectionId, 'd'=>$date.' 00:00:00']);
 
         return $value === false ? null : (string) $value;
+    }
+    private function createRateLimiter(): WbFinanceRateLimiter
+    {
+        return new WbFinanceRateLimiter(new RateLimiterFactory(['id' => 'wb_finance', 'policy' => 'token_bucket', 'limit' => 1, 'rate' => ['interval' => '61 seconds', 'amount' => 1]], new InMemoryStorage()), new MockClock('2026-01-01T00:00:00Z'));
     }
 }
 

--- a/site/tests/Unit/Marketplace/Application/Service/WbFinanceRateLimiterTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbFinanceRateLimiterTest.php
@@ -6,40 +6,44 @@ namespace App\Tests\Unit\Marketplace\Application\Service;
 
 use App\Marketplace\Application\Service\WbFinanceRateLimiter;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\MockClock;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 
 final class WbFinanceRateLimiterTest extends TestCase
 {
-    public function testAcquireRejectsSecondRequestForSameConnectionWithinMinute(): void
+    public function testWaitSleepsBeforeSecondRequestForSameConnectionWithinMinute(): void
     {
-        $limiter = $this->createLimiter();
+        $clock = new MockClock('2026-01-01T00:00:00Z');
+        $limiter = $this->createLimiter($clock);
         $connectionId = '6c3a0e9f-1c09-4a2f-a63f-27f3eddd67df';
 
-        self::assertTrue($limiter->acquire($connectionId));
-        self::assertFalse($limiter->acquire($connectionId));
+        $limiter->wait($connectionId);
+        $limiter->wait($connectionId);
+
+        self::assertSame('2026-01-01T00:01:01+00:00', $clock->now()->format(DATE_ATOM));
     }
 
-    public function testAcquireUsesSeparateBucketsForDifferentConnections(): void
+    public function testWaitUsesSeparateBucketsForDifferentConnections(): void
     {
-        $limiter = $this->createLimiter();
+        $clock = new MockClock('2026-01-01T00:00:00Z');
+        $limiter = $this->createLimiter($clock);
 
-        self::assertTrue($limiter->acquire('6c3a0e9f-1c09-4a2f-a63f-27f3eddd67df'));
-        self::assertTrue($limiter->acquire('4d91db78-6c9b-4fb9-8478-24ab4c68253f'));
+        $limiter->wait('6c3a0e9f-1c09-4a2f-a63f-27f3eddd67df');
+        $limiter->wait('4d91db78-6c9b-4fb9-8478-24ab4c68253f');
+
+        self::assertSame('2026-01-01T00:00:00+00:00', $clock->now()->format(DATE_ATOM));
     }
 
-    private function createLimiter(): WbFinanceRateLimiter
+    private function createLimiter(?MockClock $clock = null): WbFinanceRateLimiter
     {
-        $factory = new RateLimiterFactory(
-            [
-                'id' => 'wb_finance',
-                'policy' => 'fixed_window',
-                'limit' => 1,
-                'interval' => '1 minute',
-            ],
-            new InMemoryStorage(),
-        );
+        $factory = new RateLimiterFactory([
+            'id' => 'wb_finance',
+            'policy' => 'token_bucket',
+            'limit' => 1,
+            'rate' => ['interval' => '61 seconds', 'amount' => 1],
+        ], new InMemoryStorage());
 
-        return new WbFinanceRateLimiter($factory);
+        return new WbFinanceRateLimiter($factory, $clock ?? new MockClock());
     }
 }

--- a/site/tests/Unit/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClientTest.php
+++ b/site/tests/Unit/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClientTest.php
@@ -29,8 +29,8 @@ final class WbFinanceSalesReportClientTest extends TestCase
             return new MockResponse('[{"rrdId":10}]', ['http_code' => 200]);
         });
 
-        $client = new WbFinanceSalesReportClient($http, new MockClock());
-        $rows = $client->fetchDetailed('token', '2026-01-01', '2026-01-01');
+        $client = new WbFinanceSalesReportClient($http, $this->createRateLimiter());
+        $rows = $client->fetchDetailedForConnection('connection-id', 'token', '2026-01-01', '2026-01-01');
 
         self::assertCount(1, $rows);
         self::assertCount(1, $captured);
@@ -51,7 +51,7 @@ final class WbFinanceSalesReportClientTest extends TestCase
             return new MockResponse('[]', ['http_code' => 200]);
         });
 
-        $client = new WbFinanceSalesReportClient($http, new MockClock());
+        $client = new WbFinanceSalesReportClient($http, $this->createRateLimiter());
         $client->fetchDetailedDay('conn-1', 'token', new \DateTimeImmutable('2026-01-15T12:00:00+03:00'));
 
         self::assertSame('2026-01-15', $captured[0]['dateFrom'] ?? null);
@@ -68,20 +68,11 @@ final class WbFinanceSalesReportClientTest extends TestCase
             return new MockResponse('[]', ['http_code' => 200]);
         });
 
-        $client = new WbFinanceSalesReportClient($http, new MockClock(), null, $this->createRateLimiter());
+        $client = new WbFinanceSalesReportClient($http, $this->createRateLimiter());
 
         self::assertSame([], $client->fetchDetailedDay('same-connection', 'token', new \DateTimeImmutable('2026-01-15')));
-        self::assertSame(1, $requestCount);
-
-        try {
-            $client->fetchDetailedDay('same-connection', 'token', new \DateTimeImmutable('2026-01-15'));
-            self::fail('Expected MarketplaceRateLimitException on second local-limited call');
-        } catch (MarketplaceRateLimitException $e) {
-            self::assertSame(61, $e->getRetryAfter());
-            self::assertStringNotContainsString('token', $e->getMessage());
-        }
-
-        self::assertSame(1, $requestCount);
+        self::assertSame([], $client->fetchDetailedDay('same-connection', 'token', new \DateTimeImmutable('2026-01-15')));
+        self::assertSame(2, $requestCount);
     }
 
     public function testFetchDetailedDayUsesDifferentLimiterBucketsPerConnectionId(): void
@@ -93,7 +84,7 @@ final class WbFinanceSalesReportClientTest extends TestCase
             return new MockResponse('[]', ['http_code' => 200]);
         });
 
-        $client = new WbFinanceSalesReportClient($http, new MockClock(), null, $this->createRateLimiter());
+        $client = new WbFinanceSalesReportClient($http, $this->createRateLimiter());
 
         self::assertSame([], $client->fetchDetailedDay('connection-a', 'token', new \DateTimeImmutable('2026-01-15')));
         self::assertSame([], $client->fetchDetailedDay('connection-b', 'token', new \DateTimeImmutable('2026-01-15')));
@@ -106,24 +97,27 @@ final class WbFinanceSalesReportClientTest extends TestCase
         $rows = array_fill(0, 100000, ['rrdId' => 10]);
         $rows[99999] = ['rrdId' => 20];
 
+        $captured = [];
         $requestCount = 0;
-        $http = new MockHttpClient(static function () use (&$requestCount, $rows): MockResponse {
+        $http = new MockHttpClient(static function (string $method, string $url, array $options) use (&$requestCount, &$captured, $rows): MockResponse {
             ++$requestCount;
+            $captured[] = $options['json'];
 
-            return new MockResponse((string) json_encode($rows, JSON_THROW_ON_ERROR), ['http_code' => 200]);
+            return match ($requestCount) {
+                1 => new MockResponse((string) json_encode($rows, JSON_THROW_ON_ERROR), ['http_code' => 200]),
+                default => new MockResponse('', ['http_code' => 204]),
+            };
         });
 
-        $client = new WbFinanceSalesReportClient($http, new MockClock(), null, $this->createRateLimiter());
+        $clock = new MockClock('2026-01-01T00:00:00Z');
+        $client = new WbFinanceSalesReportClient($http, $this->createRateLimiter($clock));
 
-        try {
-            $client->fetchDetailedDay('00000000-0000-0000-0000-000000000001', 'token', new \DateTimeImmutable('2026-01-15'));
-            self::fail('Expected MarketplaceRateLimitException before second paginated HTTP request');
-        } catch (MarketplaceRateLimitException $e) {
-            self::assertSame(61, $e->getRetryAfter());
-            self::assertStringNotContainsString('token', $e->getMessage());
-        }
-
-        self::assertSame(1, $requestCount);
+        $data = $client->fetchDetailedDay('00000000-0000-0000-0000-000000000001', 'token', new \DateTimeImmutable('2026-01-15'));
+        self::assertCount(100000, $data);
+        self::assertSame(2, $requestCount);
+        self::assertSame(0, $captured[0]['rrdId']);
+        self::assertSame(20, $captured[1]['rrdId']);
+        self::assertSame('2026-01-01T00:01:01+00:00', $clock->now()->format(DATE_ATOM));
     }
 
 
@@ -135,19 +129,11 @@ final class WbFinanceSalesReportClientTest extends TestCase
             return new MockResponse('[{"rrdId":1}]', ['http_code' => 200]);
         });
 
-        $client = new WbFinanceSalesReportClient($http, new MockClock(), null, $this->createRateLimiter());
+        $client = new WbFinanceSalesReportClient($http, $this->createRateLimiter());
 
         self::assertTrue($client->hasAnyDataForConnection('same-connection', 'token', '2026-01-01', '2026-01-31'));
-
-        try {
-            $client->hasAnyDataForConnection('same-connection', 'token', '2026-01-01', '2026-01-31');
-            self::fail('Expected MarketplaceRateLimitException before HTTP request');
-        } catch (MarketplaceRateLimitException $e) {
-            self::assertSame(61, $e->getRetryAfter());
-            self::assertStringNotContainsString('token', $e->getMessage());
-        }
-
-        self::assertSame(1, $requestCount);
+        self::assertTrue($client->hasAnyDataForConnection('same-connection', 'token', '2026-01-01', '2026-01-31'));
+        self::assertSame(2, $requestCount);
     }
 
     public function testHasAnyDataForConnectionDelegatesToHasAnyDataLogic(): void
@@ -163,7 +149,7 @@ final class WbFinanceSalesReportClientTest extends TestCase
             return new MockResponse('[{"rrdId":77}]', ['http_code' => 200]);
         });
 
-        $client = new WbFinanceSalesReportClient($http, new MockClock());
+        $client = new WbFinanceSalesReportClient($http, $this->createRateLimiter());
 
         self::assertTrue($client->hasAnyDataForConnection('connection-id', 'token', '2026-02-01', '2026-02-03'));
         self::assertSame('POST', $captured[0]);
@@ -176,17 +162,17 @@ final class WbFinanceSalesReportClientTest extends TestCase
     {
         $client = new WbFinanceSalesReportClient(new MockHttpClient([
             new MockResponse('', ['http_code' => 204]),
-        ]), new MockClock());
+        ]), $this->createRateLimiter());
 
         self::assertSame([], $client->fetchDetailed('token', '2026-01-01', '2026-01-01'));
     }
 
     public function test429MappedToRateLimitException(): void
     {
-        $client = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('{"error":"rate"}', ['http_code' => 429])), new MockClock());
+        $client = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('{"error":"rate"}', ['http_code' => 429])), $this->createRateLimiter());
 
         $this->expectException(MarketplaceRateLimitException::class);
-        $client->fetchDetailed('token', '2026-01-01', '2026-01-01');
+        $client->fetchDetailedForConnection('connection-id', 'token', '2026-01-01', '2026-01-01');
     }
 
 
@@ -197,10 +183,10 @@ final class WbFinanceSalesReportClientTest extends TestCase
             'response_headers' => [
                 'x-ratelimit-retry: 17',
             ],
-        ])), new MockClock());
+        ])), $this->createRateLimiter());
 
         try {
-            $client->fetchDetailed('token', '2026-01-01', '2026-01-01');
+            $client->fetchDetailedForConnection('connection-id', 'token', '2026-01-01', '2026-01-01');
             self::fail('Expected MarketplaceRateLimitException');
         } catch (MarketplaceRateLimitException $e) {
             self::assertSame(17, $e->getRetryAfter());
@@ -209,7 +195,7 @@ final class WbFinanceSalesReportClientTest extends TestCase
 
     public function test401And403MappedToAuthException(): void
     {
-        $client401 = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('', ['http_code' => 401])), new MockClock());
+        $client401 = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('', ['http_code' => 401])), $this->createRateLimiter());
         try {
             $client401->fetchDetailed('token', '2026-01-01', '2026-01-01');
             self::fail('Expected MarketplaceAuthException for 401');
@@ -217,25 +203,25 @@ final class WbFinanceSalesReportClientTest extends TestCase
             self::assertTrue(true);
         }
 
-        $client403 = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('', ['http_code' => 403])), new MockClock());
+        $client403 = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('', ['http_code' => 403])), $this->createRateLimiter());
         $this->expectException(MarketplaceAuthException::class);
         $client403->fetchDetailed('token', '2026-01-01', '2026-01-01');
     }
 
     public function test400MappedToBadRequestException(): void
     {
-        $client = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('{"error":"bad"}', ['http_code' => 400])), new MockClock());
+        $client = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('{"error":"bad"}', ['http_code' => 400])), $this->createRateLimiter());
 
         $this->expectException(MarketplaceBadRequestException::class);
-        $client->fetchDetailed('token', '2026-01-01', '2026-01-01');
+        $client->fetchDetailedForConnection('connection-id', 'token', '2026-01-01', '2026-01-01');
     }
 
     public function testInvalidJsonMappedToInvalidApiResponseException(): void
     {
-        $client = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('{invalid', ['http_code' => 200])), new MockClock());
+        $client = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('{invalid', ['http_code' => 200])), $this->createRateLimiter());
 
         $this->expectException(MarketplaceInvalidApiResponseException::class);
-        $client->fetchDetailed('token', '2026-01-01', '2026-01-01');
+        $client->fetchDetailedForConnection('connection-id', 'token', '2026-01-01', '2026-01-01');
     }
 
     public function testCountEqualPageSizeUsesDelayBeforeNextRequest(): void
@@ -259,9 +245,9 @@ final class WbFinanceSalesReportClientTest extends TestCase
         });
 
         $clock = new MockClock('2026-01-01T00:00:00Z');
-        $client = new WbFinanceSalesReportClient($http, $clock);
+        $client = new WbFinanceSalesReportClient($http, $this->createRateLimiter($clock));
 
-        $client->fetchDetailed('token', '2026-01-01', '2026-01-01');
+        $client->fetchDetailedForConnection('connection-id', 'token', '2026-01-01', '2026-01-01');
 
         self::assertIsArray($captured[1]);
         self::assertSame(20, $captured[1]['rrdId'] ?? null);
@@ -276,7 +262,7 @@ final class WbFinanceSalesReportClientTest extends TestCase
             return new MockResponse('', ['http_code' => 200]);
         });
 
-        $client = new WbFinanceSalesReportClient($http, new MockClock());
+        $client = new WbFinanceSalesReportClient($http, $this->createRateLimiter());
         self::assertTrue($client->probeAccess('token'));
         self::assertSame('GET', $captured[0]);
         self::assertStringEndsWith('/ping', $captured[1]);
@@ -286,32 +272,32 @@ final class WbFinanceSalesReportClientTest extends TestCase
 
     public function testProbeAccessReturnsTrueFor200StatusOk(): void
     {
-        $client = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('{"TS":"2024-08-16T11:19:05+03:00","Status":"OK"}', ['http_code' => 200])), new MockClock());
+        $client = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('{"TS":"2024-08-16T11:19:05+03:00","Status":"OK"}', ['http_code' => 200])), $this->createRateLimiter());
         self::assertTrue($client->probeAccess('token'));
     }
 
     public function testProbeAccessReturnsFalseFor401(): void
     {
-        $client = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('', ['http_code' => 401])), new MockClock());
+        $client = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('', ['http_code' => 401])), $this->createRateLimiter());
         self::assertFalse($client->probeAccess('token'));
     }
 
     public function testProbeAccessReturnsFalseFor403(): void
     {
-        $client = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('', ['http_code' => 403])), new MockClock());
+        $client = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('', ['http_code' => 403])), $this->createRateLimiter());
         self::assertFalse($client->probeAccess('token'));
     }
 
     public function testProbeAccess429ThrowsRateLimitException(): void
     {
-        $client = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('{"error":"rate"}', ['http_code' => 429])), new MockClock());
+        $client = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('{"error":"rate"}', ['http_code' => 429])), $this->createRateLimiter());
         $this->expectException(MarketplaceRateLimitException::class);
         $client->probeAccess('token');
     }
 
     public function testProbeAccess5xxThrowsTemporaryApiException(): void
     {
-        $client = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('{"error":"server"}', ['http_code' => 500])), new MockClock());
+        $client = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('{"error":"server"}', ['http_code' => 500])), $this->createRateLimiter());
         $this->expectException(MarketplaceTemporaryApiException::class);
         $client->probeAccess('token');
     }
@@ -321,22 +307,22 @@ final class WbFinanceSalesReportClientTest extends TestCase
         $http = new MockHttpClient(static function (): never {
             throw new TransportException('network');
         });
-        $client = new WbFinanceSalesReportClient($http, new MockClock());
+        $client = new WbFinanceSalesReportClient($http, $this->createRateLimiter());
         $this->expectException(MarketplaceTemporaryApiException::class);
         $client->probeAccess('token');
     }
-    private function createRateLimiter(): WbFinanceRateLimiter
+    private function createRateLimiter(?MockClock $clock = null): WbFinanceRateLimiter
     {
         $factory = new RateLimiterFactory(
             [
                 'id' => 'wb_finance',
-                'policy' => 'fixed_window',
+                'policy' => 'token_bucket',
                 'limit' => 1,
-                'interval' => '1 minute',
+                'rate' => ['interval' => '61 seconds', 'amount' => 1],
             ],
             new InMemoryStorage(),
         );
 
-        return new WbFinanceRateLimiter($factory);
+        return new WbFinanceRateLimiter($factory, $clock ?? new MockClock());
     }
 }

--- a/site/tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php
+++ b/site/tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Marketplace\Service\Integration;
 
+use App\Marketplace\Application\Service\WbFinanceRateLimiter;
 use App\Company\Entity\Company;
 use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Infrastructure\Api\Wildberries\WbFinanceSalesReportClient;
@@ -15,6 +16,8 @@ use Psr\Log\NullLogger;
 use Symfony\Component\Clock\MockClock;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 
 final class WildberriesAdapterTest extends TestCase
 {
@@ -44,17 +47,22 @@ final class WildberriesAdapterTest extends TestCase
     public function testHasRawReportDataUsesFinanceEndpointNotLegacyV5(): void
     {
         $capturedUrl = '';
-        $http = new MockHttpClient(static function (string $method, string $url): MockResponse {
-            return new MockResponse('[{"rrdId":10}]', ['http_code' => 200]);
-        });
-        $http = new MockHttpClient(static function (string $method, string $url) use (&$capturedUrl): MockResponse {
+        $capturedPayload = [];
+        $http = new MockHttpClient(static function (string $method, string $url, array $options) use (&$capturedUrl, &$capturedPayload): MockResponse {
             $capturedUrl = $url;
+            $capturedPayload = $options['json'] ?? [];
             return new MockResponse('[{"rrdId":10}]', ['http_code' => 200]);
         });
 
         $adapter = $this->createAdapter($http);
         self::assertTrue($adapter->hasRawReportData($this->company(), new \DateTimeImmutable('2026-01-01'), new \DateTimeImmutable('2026-01-02')));
+        self::assertSame('https://finance-api.wildberries.ru/api/finance/v1/sales-reports/detailed', $capturedUrl);
         self::assertStringNotContainsString('/api/v5/supplier/reportDetailByPeriod', $capturedUrl);
+        self::assertSame(1, $capturedPayload['limit'] ?? null);
+        self::assertSame(0, $capturedPayload['rrdId'] ?? null);
+        self::assertSame('daily', $capturedPayload['period'] ?? null);
+        self::assertSame('2026-01-01', $capturedPayload['dateFrom'] ?? null);
+        self::assertSame('2026-01-02', $capturedPayload['dateTo'] ?? null);
     }
 
     public function testAuthenticateUsesProbeAccess(): void
@@ -112,14 +120,19 @@ final class WildberriesAdapterTest extends TestCase
         $repo = $this->createMock(MarketplaceConnectionRepository::class);
         $repo->method('findByMarketplace')->willReturn($this->connection());
 
-        return new WildberriesAdapter($http, $repo, new NullLogger(), new WbSalesReportRowNormalizer(), new WbFinanceSalesReportClient($http, new MockClock()));
+        return new WildberriesAdapter($http, $repo, new NullLogger(), new WbSalesReportRowNormalizer(), new WbFinanceSalesReportClient($http, $this->createRateLimiter()));
     }
 
     private function company(): Company { return $this->createMock(Company::class); }
     private function connection(): MarketplaceConnection
     {
         $connection = $this->createMock(MarketplaceConnection::class);
+        $connection->method('getId')->willReturn('connection-id');
         $connection->method('getApiKey')->willReturn('token');
         return $connection;
+    }
+    private function createRateLimiter(): WbFinanceRateLimiter
+    {
+        return new WbFinanceRateLimiter(new RateLimiterFactory(['id' => 'wb_finance', 'policy' => 'token_bucket', 'limit' => 1, 'rate' => ['interval' => '61 seconds', 'amount' => 1]], new InMemoryStorage()), new MockClock('2026-01-01T00:00:00Z'));
     }
 }


### PR DESCRIPTION
### Motivation

- Replace the previous `fixed_window` local limiter with a `token_bucket` policy using a 61s refill to better model WB finance rate behavior and avoid spiky rejections. 
- Make local throttling block-and-wait per connection instead of throwing rate-limit exceptions that may leak API tokens and complicate pipelines. 
- Exempt explicit credential `probeAccess` calls from local throttling so auth checks remain immediate.

### Description

- Updated rate limiter configuration in `rate_limiter.yaml` to use `policy: token_bucket` and `rate: { interval: '61 seconds', amount: 1 }` for `wb_finance` and changed service wiring in `services.yaml` to require the `@limiter.wb_finance` factory. 
- Reworked `App\\Marketplace\Application\Service\WbFinanceRateLimiter` to require a `RateLimiterFactory` and `ClockInterface`, add a `LoggerInterface`, remove `acquire()` and introduce a blocking `wait()` that consumes tokens in a loop and sleeps via the injected clock. 
- `WbFinanceSalesReportClient` now uses per-connection local throttling by calling `rateLimiter->wait()` before requests, introduces `fetchDetailedForConnection()` (and deprecates the old `fetchDetailed()` for production flows), and leaves `probeAccess()` unaffected by local throttling. 
- Call sites updated to pass `connectionId` (e.g. `WildberriesAdapter`) and service usages adjusted to the new constructor signature and method name. 
- Tests updated to reflect token-bucket semantics and blocking behavior, injecting `MockClock` where needed and asserting clock advances and request counts accordingly.

### Testing

- Ran unit tests including `WbFinanceRateLimiterTest`, `WbFinanceSalesReportClientTest`, and `WildberriesAdapterTest`, which were updated to use the new limiter and `MockClock`, and they passed. 
- Ran integration tests including `SyncWbFinancialReportDayHandlerTest`, `WbFinancialReportFirstAvailableResolverTest`, and `WbFinancialReportSyncIdempotencyTest`, which were updated to create the `WbFinanceRateLimiter` with `MockClock`, and they passed. 
- Verified modified service wiring and configuration (`services.yaml`, `rate_limiter.yaml`) by executing the automated test suite that covers the changed code paths and confirmed all related tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14365a39bc8323bf8c1b52dab567c5)