### PR TITLE
Improve refresh14 planning: per-connection max-days, status lookups, clock injection and tests

### DIFF
--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlanner.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlanner.php
@@ -8,8 +8,9 @@ use App\Marketplace\Enum\FinancialReportSyncMode;
 use App\Marketplace\Enum\FinancialReportSyncStatus;
 use App\Marketplace\Infrastructure\Query\ActiveWbConnectionsQuery;
 use App\Marketplace\Message\SyncWbFinancialReportDayMessage;
-use App\Marketplace\Repository\MarketplaceFinancialReportSyncStatusRepository;
+use App\Marketplace\Repository\MarketplaceFinancialReportSyncStatusLookupInterface;
 use DateTimeImmutable;
+use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlannerInterface
@@ -19,8 +20,9 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
     public function __construct(
         private readonly ActiveWbConnectionsQuery $activeWbConnectionsQuery,
         private readonly WbFinancialReportPeriodResolver $periodResolver,
-        private readonly MarketplaceFinancialReportSyncStatusRepository $syncStatusRepository,
+        private readonly MarketplaceFinancialReportSyncStatusLookupInterface $syncStatusRepository,
         private readonly MessageBusInterface $messageBus,
+        private readonly ClockInterface $clock,
     ) {}
 
     public function planDaily(?string $companyId = null, ?string $connectionId = null, bool $force = false): int
@@ -47,18 +49,94 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
         );
     }
 
-    public function planRefresh14Days(?string $companyId = null, ?string $connectionId = null): int
+    public function planRefresh14Days(?string $companyId = null, ?string $connectionId = null, int $maxDays = 1): int
     {
-        return $this->planForDays(
-            $this->activeWbConnectionsQuery->execute($companyId, $connectionId),
-            $this->periodResolver->last14Days(),
-            FinancialReportSyncMode::REFRESH_14D,
-            true,
-            static fn (?FinancialReportSyncStatus $status): bool => !\in_array($status, [
-                FinancialReportSyncStatus::LOADING,
-                FinancialReportSyncStatus::PROCESSING,
-            ], true),
-        );
+        if ($maxDays <= 0) {
+            return 0;
+        }
+
+        $dispatched = 0;
+        $days = $this->periodResolver->last14Days();
+        $from = $days[0];
+        $to = $days[array_key_last($days)];
+        $now = $this->clock->now();
+
+        foreach ($this->activeWbConnectionsQuery->execute($companyId, $connectionId) as $connection) {
+            $statuses = $this->syncStatusRepository->findStatusesForDateRange(
+                $connection['company_id'],
+                $connection['connection_id'],
+                self::REPORT_TYPE,
+                $from,
+                $to,
+            );
+            $statusByDay = [];
+            foreach ($statuses as $statusEntity) {
+                $statusByDay[$statusEntity->getBusinessDate()->format('Y-m-d')] = $statusEntity;
+            }
+
+            $retryDue = [];
+            $success = [];
+            $unknown = [];
+
+            foreach ($days as $day) {
+                $statusEntity = $statusByDay[$day->format('Y-m-d')] ?? null;
+                $status = $statusEntity?->getStatus();
+
+                if (\in_array($status, [FinancialReportSyncStatus::LOADING, FinancialReportSyncStatus::PROCESSING], true)) {
+                    continue;
+                }
+
+                if (FinancialReportSyncStatus::FAILED === $status) {
+                    if (null !== $statusEntity?->getNextRetryAt() && $statusEntity->getNextRetryAt() > $now) {
+                        continue;
+                    }
+
+                    $retryDue[] = $day;
+                    continue;
+                }
+
+                if (\in_array($status, [FinancialReportSyncStatus::SUCCESS, FinancialReportSyncStatus::EMPTY], true)) {
+                    $updatedAt = $statusEntity?->getUpdatedAt();
+                    if (null === $updatedAt) {
+                        $updatedAt = new DateTimeImmutable('9999-12-31T00:00:00+00:00');
+                    }
+
+                    $success[] = [
+                        'day' => $day,
+                        'updated_at' => $updatedAt,
+                    ];
+                    continue;
+                }
+
+                if (null === $status) {
+                    $unknown[] = $day;
+                }
+            }
+
+            usort($success, static function (array $a, array $b): int {
+                $timestampCompare = $a['updated_at']->getTimestamp() <=> $b['updated_at']->getTimestamp();
+                if (0 !== $timestampCompare) {
+                    return $timestampCompare;
+                }
+
+                return $a['day']->getTimestamp() <=> $b['day']->getTimestamp();
+            });
+
+            $successDays = array_map(static fn (array $item): DateTimeImmutable => $item['day'], $success);
+
+            $scheduledForConnection = 0;
+            foreach (array_merge($retryDue, $successDays, $unknown) as $day) {
+                if ($scheduledForConnection >= $maxDays) {
+                    break;
+                }
+
+                $this->dispatch($connection['company_id'], $connection['connection_id'], $day, FinancialReportSyncMode::REFRESH_14D, true);
+                ++$dispatched;
+                ++$scheduledForConnection;
+            }
+        }
+
+        return $dispatched;
     }
 
 
@@ -106,7 +184,7 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
         $from = $this->periodResolver->currentYearStart();
         $to = $this->periodResolver->yesterday();
         $allDays = $this->periodResolver->daysBetween($from, $to);
-        $now = new DateTimeImmutable();
+        $now = $this->clock->now();
 
         foreach ($this->activeWbConnectionsQuery->execute($companyId, $connectionId) as $connection) {
             $statuses = $this->syncStatusRepository->findStatusesForDateRange(

--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlannerInterface.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlannerInterface.php
@@ -11,7 +11,7 @@ interface WbFinancialReportSyncPlannerInterface
 {
     public function planDaily(?string $companyId = null, ?string $connectionId = null, bool $force = false): int;
 
-    public function planRefresh14Days(?string $companyId = null, ?string $connectionId = null): int;
+    public function planRefresh14Days(?string $companyId = null, ?string $connectionId = null, int $maxDays = 1): int;
 
     public function planRange(
         DateTimeImmutable $from,

--- a/site/src/Marketplace/Command/WbFinancialReportsSyncCommand.php
+++ b/site/src/Marketplace/Command/WbFinancialReportsSyncCommand.php
@@ -44,7 +44,7 @@ final class WbFinancialReportsSyncCommand extends Command
             ->addOption('from', null, InputOption::VALUE_OPTIONAL, 'Начало диапазона (Y-m-d)')
             ->addOption('to', null, InputOption::VALUE_OPTIONAL, 'Конец диапазона (Y-m-d)')
             ->addOption('force', null, InputOption::VALUE_NONE)
-            ->addOption('max-days', null, InputOption::VALUE_OPTIONAL, 'Лимит missing-задач на connection', '10');
+            ->addOption('max-days', null, InputOption::VALUE_OPTIONAL, 'Лимит задач refresh14/missing на connection', '1');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -126,8 +126,9 @@ final class WbFinancialReportsSyncCommand extends Command
                 ? $this->planner->planRange($from, $to ?? $from, FinancialReportSyncMode::INITIAL, $companyId, $connectionId, $force)
                 : $this->planner->planInitial($companyId, $connectionId),
             'refresh14' => null !== $from
+                // Explicit --from/--to is treated as manual force refresh mode; --max-days applies only to automatic refresh14 planning.
                 ? $this->planner->planRange($from, $to ?? $from, FinancialReportSyncMode::REFRESH_14D, $companyId, $connectionId, true)
-                : $this->planner->planRefresh14Days($companyId, $connectionId),
+                : $this->planner->planRefresh14Days($companyId, $connectionId, $maxDays),
             'missing' => $this->planner->planMissing($companyId, $connectionId, $maxDays),
             default => throw new DomainException(sprintf('Unsupported mode: %s', $mode)),
         };

--- a/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusLookupInterface.php
+++ b/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusLookupInterface.php
@@ -5,8 +5,40 @@ declare(strict_types=1);
 namespace App\Marketplace\Repository;
 
 use App\Marketplace\Entity\MarketplaceFinancialReportSyncStatus;
+use App\Marketplace\Enum\FinancialReportSyncStatus;
 
 interface MarketplaceFinancialReportSyncStatusLookupInterface
 {
     public function findByRawDocumentId(string $companyId, string $rawDocumentId): ?MarketplaceFinancialReportSyncStatus;
+
+    public function findStatusEnumByDay(
+        string $connectionId,
+        string $companyId,
+        \DateTimeImmutable $businessDate,
+        string $reportType,
+    ): ?FinancialReportSyncStatus;
+
+    /**
+     * @return list<MarketplaceFinancialReportSyncStatus>
+     */
+    public function findStatusesForDateRange(
+        string $companyId,
+        string $connectionId,
+        string $reportType,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+    ): array;
+
+    /**
+     * @return list<\DateTimeImmutable>
+     */
+    public function findRetryDueDays(
+        string $companyId,
+        string $connectionId,
+        string $reportType,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        \DateTimeImmutable $now,
+        int $limit,
+    ): array;
 }

--- a/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Application\Service;
+
+use App\Marketplace\Application\Service\WbFinancialReportPeriodResolver;
+use App\Marketplace\Application\Service\WbFinancialReportSyncPlanner;
+use App\Marketplace\Entity\MarketplaceFinancialReportSyncStatus;
+use App\Marketplace\Enum\FinancialReportSyncStatus;
+use App\Marketplace\Infrastructure\Query\ActiveWbConnectionsQuery;
+use App\Marketplace\Message\SyncWbFinancialReportDayMessage;
+use App\Marketplace\Repository\MarketplaceFinancialReportSyncStatusLookupInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class WbFinancialReportSyncPlannerTest extends TestCase
+{
+    private ActiveWbConnectionsQuery&MockObject $connections;
+    private MarketplaceFinancialReportSyncStatusLookupInterface&MockObject $statuses;
+    private MessageBusInterface&MockObject $bus;
+    private ClockInterface $clock;
+
+    /** @var list<SyncWbFinancialReportDayMessage> */
+    private array $dispatchedMessages = [];
+
+    protected function setUp(): void
+    {
+        $this->connections = $this->createMock(ActiveWbConnectionsQuery::class);
+        $this->statuses = $this->createMock(MarketplaceFinancialReportSyncStatusLookupInterface::class);
+        $this->bus = $this->createMock(MessageBusInterface::class);
+        $this->clock = new MockClock('2026-05-21T10:00:00+03:00');
+        $this->bus->method('dispatch')->willReturnCallback(function (object $message): Envelope {
+            if ($message instanceof SyncWbFinancialReportDayMessage) {
+                $this->dispatchedMessages[] = $message;
+            }
+
+            return new Envelope($message);
+        });
+    }
+
+    public function testPlanRefresh14DaysDispatchesAtMostOnePerConnection(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1')]);
+        $this->statuses->method('findStatusesForDateRange')->willReturn([
+            $this->statusEntity('2026-05-20', FinancialReportSyncStatus::FAILED, null, '2026-05-20T09:00:00+03:00'),
+            $this->statusEntity('2026-05-19', FinancialReportSyncStatus::FAILED, null, '2026-05-20T09:00:00+03:00'),
+        ]);
+
+        self::assertSame(1, $planner->planRefresh14Days(null, null, 1));
+        self::assertCount(1, $this->dispatchedMessages);
+    }
+
+    public function testPlanRefresh14DaysDispatchesAtMostThreePerConnection(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1')]);
+        $this->statuses->method('findStatusesForDateRange')->willReturn([
+            $this->statusEntity('2026-05-20', FinancialReportSyncStatus::FAILED, null, '2026-05-20T09:00:00+03:00'),
+            $this->statusEntity('2026-05-19', FinancialReportSyncStatus::FAILED, null, '2026-05-20T09:00:00+03:00'),
+            $this->statusEntity('2026-05-18', FinancialReportSyncStatus::FAILED, null, '2026-05-20T09:00:00+03:00'),
+            $this->statusEntity('2026-05-17', FinancialReportSyncStatus::FAILED, null, '2026-05-20T09:00:00+03:00'),
+        ]);
+
+        self::assertSame(3, $planner->planRefresh14Days(null, null, 3));
+        self::assertCount(3, $this->dispatchedMessages);
+    }
+
+    public function testFailedWithFutureRetryAtIsNotDispatched(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1')]);
+        $this->statuses->method('findStatusesForDateRange')->willReturn([
+            $this->statusEntity('2026-05-20', FinancialReportSyncStatus::FAILED, '2026-05-21T11:00:00+03:00', '2026-05-20T09:00:00+03:00'),
+        ]);
+
+        self::assertSame(0, $planner->planRefresh14Days(null, null, 1));
+        self::assertCount(0, $this->dispatchedMessages);
+    }
+
+    public function testFailedWithRetryDueIsDispatched(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1')]);
+        $this->statuses->method('findStatusesForDateRange')->willReturn([
+            $this->statusEntity('2026-05-20', FinancialReportSyncStatus::FAILED, '2026-05-21T09:59:00+03:00', '2026-05-20T09:00:00+03:00'),
+        ]);
+
+        self::assertSame(1, $planner->planRefresh14Days(null, null, 1));
+    }
+
+    public function testFailedWithNullRetryAtIsDispatched(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1')]);
+        $this->statuses->method('findStatusesForDateRange')->willReturn([
+            $this->statusEntity('2026-05-20', FinancialReportSyncStatus::FAILED, null, '2026-05-20T09:00:00+03:00'),
+        ]);
+
+        self::assertSame(1, $planner->planRefresh14Days(null, null, 1));
+    }
+
+    public function testSuccessAndEmptyArePrioritizedByOldestUpdatedAt(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1')]);
+        $this->statuses->method('findStatusesForDateRange')->willReturn([
+            $this->statusEntity('2026-05-20', FinancialReportSyncStatus::SUCCESS, null, '2026-05-21T09:00:00+03:00'),
+            $this->statusEntity('2026-05-19', FinancialReportSyncStatus::EMPTY, null, '2026-05-18T09:00:00+03:00'),
+        ]);
+
+        self::assertSame(1, $planner->planRefresh14Days(null, null, 1));
+        self::assertSame('2026-05-19', $this->dispatchedMessages[0]->dateFrom);
+    }
+
+    public function testLoadingAndProcessingAreNotDispatched(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1')]);
+        $this->statuses->method('findStatusesForDateRange')->willReturn([
+            $this->statusEntity('2026-05-20', FinancialReportSyncStatus::LOADING, null, '2026-05-21T09:00:00+03:00'),
+            $this->statusEntity('2026-05-19', FinancialReportSyncStatus::PROCESSING, null, '2026-05-21T09:00:00+03:00'),
+        ]);
+
+        self::assertSame(0, $planner->planRefresh14Days(null, null, 2));
+    }
+
+
+    public function testUnknownDaysAreDispatchedWhenNoFailedOrSuccessCandidates(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1')]);
+        $this->statuses->method('findStatusesForDateRange')->willReturn([]);
+
+        self::assertSame(1, $planner->planRefresh14Days(null, null, 1));
+        self::assertCount(1, $this->dispatchedMessages);
+        self::assertSame('refresh14', $this->dispatchedMessages[0]->mode);
+
+        $last14days = (new WbFinancialReportPeriodResolver(new MockClock('2026-05-21 00:00:00 Europe/Moscow')))
+            ->last14Days();
+        $expected = array_map(static fn (\DateTimeImmutable $d): string => $d->format('Y-m-d'), $last14days);
+        self::assertContains($this->dispatchedMessages[0]->dateFrom, $expected);
+    }
+    public function testUnknownDaysGoAfterFailedDueAndSuccessEmpty(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1')]);
+        $this->statuses->method('findStatusesForDateRange')->willReturn([
+            $this->statusEntity('2026-05-20', FinancialReportSyncStatus::FAILED, null, '2026-05-21T09:00:00+03:00'),
+            $this->statusEntity('2026-05-19', FinancialReportSyncStatus::SUCCESS, null, '2026-05-18T09:00:00+03:00'),
+        ]);
+
+        self::assertSame(2, $planner->planRefresh14Days(null, null, 2));
+        self::assertSame('2026-05-20', $this->dispatchedMessages[0]->dateFrom);
+        self::assertSame('2026-05-19', $this->dispatchedMessages[1]->dateFrom);
+    }
+
+    public function testLimitIsAppliedPerConnection(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1'), $this->conn('c2', 'co2')]);
+        $this->statuses->method('findStatusesForDateRange')->willReturn([
+            $this->statusEntity('2026-05-20', FinancialReportSyncStatus::FAILED, null, '2026-05-21T09:00:00+03:00'),
+        ]);
+
+        self::assertSame(2, $planner->planRefresh14Days(null, null, 1));
+    }
+
+    public function testPlanMissingRespectsMaxDays(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1')]);
+        $this->statuses->method('findStatusesForDateRange')->willReturn([]);
+        $this->statuses->method('findRetryDueDays')->willReturn([]);
+
+        self::assertSame(2, $planner->planMissing(null, null, 2));
+    }
+
+    private function planner(): WbFinancialReportSyncPlanner
+    {
+        return new WbFinancialReportSyncPlanner(
+            $this->connections,
+            new WbFinancialReportPeriodResolver(new MockClock('2026-05-21 00:00:00 Europe/Moscow')),
+            $this->statuses,
+            $this->bus,
+            $this->clock,
+        );
+    }
+
+    private function statusEntity(string $day, FinancialReportSyncStatus $status, ?string $nextRetryAt, string $updatedAt): MarketplaceFinancialReportSyncStatus&MockObject
+    {
+        $entity = $this->createMock(MarketplaceFinancialReportSyncStatus::class);
+        $entity->method('getBusinessDate')->willReturn(new \DateTimeImmutable($day.' 00:00:00 Europe/Moscow'));
+        $entity->method('getStatus')->willReturn($status);
+        $entity->method('getNextRetryAt')->willReturn(null !== $nextRetryAt ? new \DateTimeImmutable($nextRetryAt) : null);
+        $entity->method('getUpdatedAt')->willReturn(new \DateTimeImmutable($updatedAt));
+
+        return $entity;
+    }
+
+    /** @return array{id: string, connection_id: string, company_id: string} */
+    private function conn(string $connectionId, string $companyId): array
+    {
+        return ['id' => $connectionId, 'connection_id' => $connectionId, 'company_id' => $companyId];
+    }
+}


### PR DESCRIPTION
### Motivation
- Make `refresh14` planning more selective and robust by limiting tasks per connection and prioritizing days that need re-syncs or stale successful results. 
- Replace ad-hoc status repository usage with a lookup interface that provides status ranges and retry-due days for better decisioning. 
- Use an injected clock to make time-based logic testable and consistent.

### Description
- Changed `WbFinancialReportSyncPlanner::planRefresh14Days` signature to accept `int $maxDays` and implemented per-connection scheduling that dispatches at most `maxDays` tasks, prioritizing retry-due failed days, then oldest `SUCCESS`/`EMPTY` by `updated_at`, then unknown days; it skips `LOADING`/`PROCESSING` and respects `next_retry_at` compared to the injected clock.
- Injected `ClockInterface $clock` into `WbFinancialReportSyncPlanner` and replaced uses of `new DateTimeImmutable()` with `$this->clock->now()`.
- Introduced `MarketplaceFinancialReportSyncStatusLookupInterface` with methods `findStatusesForDateRange`, `findRetryDueDays`, and `findStatusEnumByDay` and switched the planner to depend on this lookup interface instead of the concrete repository.
- Updated `WbFinancialReportSyncPlannerInterface` to reflect the new `planRefresh14Days(..., int $maxDays = 1)` signature and updated the CLI command `WbFinancialReportsSyncCommand` to parse and forward `--max-days` to `planRefresh14Days` and updated the help text and handling for explicit `--from/--to` in `refresh14` mode.
- Added unit tests `tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php` that cover per-connection limits, retry scheduling, ordering of `SUCCESS`/`EMPTY` by `updated_at`, skipping `LOADING`/`PROCESSING`, unknown-day behavior, and `planMissing` max-days behavior.

### Testing
- Ran the new unit test `WbFinancialReportSyncPlannerTest` under `phpunit`, which executed scenarios for `planRefresh14Days` and `planMissing` and all assertions passed.
- Ran the repository's unit test suite (`phpunit`) to verify no regressions; tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a143f8d3a2c8323b3a594eb2b30ce27)