### PR TITLE
Clear previous raw data and records count on loading/failure in MarketplaceFinancialReportSyncStatus and add unit tests

### DIFF
--- a/site/src/Marketplace/Entity/MarketplaceFinancialReportSyncStatus.php
+++ b/site/src/Marketplace/Entity/MarketplaceFinancialReportSyncStatus.php
@@ -152,6 +152,9 @@ class MarketplaceFinancialReportSyncStatus
         $now = new \DateTimeImmutable();
         $this->status = FinancialReportSyncStatus::LOADING;
         $this->mode = $mode;
+        $this->recordsCount = 0;
+        $this->rawDocumentId = null;
+        $this->rowsHash = null;
         $this->attempts++;
         $this->lastAttemptAt = $now;
         $this->nextRetryAt = null;
@@ -207,6 +210,7 @@ class MarketplaceFinancialReportSyncStatus
     public function markFailedRetryable(string $errorClass, string $errorMessage, ?int $statusCode, ?string $responseExcerpt, ?\DateTimeImmutable $nextRetryAt): void
     {
         $this->status = FinancialReportSyncStatus::FAILED;
+        $this->recordsCount = 0;
         $this->lastErrorClass = $errorClass;
         $this->lastErrorMessage = $errorMessage;
         $this->lastErrorStatusCode = $statusCode;
@@ -235,6 +239,7 @@ class MarketplaceFinancialReportSyncStatus
     {
         $now = new \DateTimeImmutable();
         $this->status = $status;
+        $this->recordsCount = 0;
         $this->lastErrorClass = $errorClass;
         $this->lastErrorMessage = $errorMessage;
         $this->lastErrorStatusCode = $statusCode;

--- a/site/tests/Unit/Marketplace/Entity/MarketplaceFinancialReportSyncStatusTest.php
+++ b/site/tests/Unit/Marketplace/Entity/MarketplaceFinancialReportSyncStatusTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Entity;
+
+use App\Marketplace\Entity\MarketplaceFinancialReportSyncStatus;
+use App\Marketplace\Enum\FinancialReportSyncMode;
+use App\Marketplace\Enum\MarketplaceType;
+use PHPUnit\Framework\TestCase;
+
+final class MarketplaceFinancialReportSyncStatusTest extends TestCase
+{
+    public function testMarkFailedRetryableResetsRecordsCount(): void
+    {
+        $status = $this->statusEntity();
+        $status->markRawLoaded($this->rawId(), 100, 'rows-hash');
+
+        $status->markFailedRetryable('HttpException', 'too many requests', 429, null, null);
+
+        self::assertSame(0, $status->getRecordsCount());
+    }
+
+    public function testMarkLoadingResetsCurrentAttemptResultFields(): void
+    {
+        $status = $this->statusEntity();
+        $status->markRawLoaded($this->rawId(), 100, 'rows-hash');
+
+        $status->markLoading(FinancialReportSyncMode::DAILY);
+
+        self::assertSame(0, $status->getRecordsCount());
+        self::assertNull($status->getRawDocumentId());
+        self::assertNull($status->getRowsHash());
+    }
+
+    public function testMarkRawLoadedSetsProvidedRecordsCount(): void
+    {
+        $status = $this->statusEntity();
+
+        $status->markRawLoaded($this->rawId(), 50, 'rows-hash');
+
+        self::assertSame(50, $status->getRecordsCount());
+    }
+
+    public function testMarkEmptySetsZeroRecordsCount(): void
+    {
+        $status = $this->statusEntity();
+        $status->markRawLoaded($this->rawId(), 100, 'rows-hash');
+
+        $status->markEmpty();
+
+        self::assertSame(0, $status->getRecordsCount());
+    }
+
+    public function testMarkFailedFinalResetsRecordsCount(): void
+    {
+        $status = $this->statusEntity();
+        $status->markRawLoaded($this->rawId(), 100, 'rows-hash');
+
+        $status->markFailedFinal('ValidationException', 'bad payload', 422, null);
+
+        self::assertSame(0, $status->getRecordsCount());
+    }
+
+    public function testMarkAuthFailedResetsRecordsCount(): void
+    {
+        $status = $this->statusEntity();
+        $status->markRawLoaded($this->rawId(), 100, 'rows-hash');
+
+        $status->markAuthFailed('AuthException', 'token expired', 401, null);
+
+        self::assertSame(0, $status->getRecordsCount());
+    }
+
+    public function testMarkConflictResetsRecordsCount(): void
+    {
+        $status = $this->statusEntity();
+        $status->markRawLoaded($this->rawId(), 100, 'rows-hash');
+
+        $status->markConflict('ConflictException', 'conflict detected', 409, null);
+
+        self::assertSame(0, $status->getRecordsCount());
+    }
+
+    private function statusEntity(): MarketplaceFinancialReportSyncStatus
+    {
+        return new MarketplaceFinancialReportSyncStatus(
+            '11111111-1111-4111-8111-111111111111',
+            '22222222-2222-4222-8222-222222222222',
+            '33333333-3333-4333-8333-333333333333',
+            MarketplaceType::WILDBERRIES,
+            'sales_report',
+            '/api/report',
+            new \DateTimeImmutable('2026-05-20'),
+        );
+    }
+
+    private function rawId(): string
+    {
+        return '44444444-4444-4444-8444-444444444444';
+    }
+}


### PR DESCRIPTION
### Motivation

- Prevent stale raw document identifiers, row hashes and record counts from persisting when a new load starts or when a sync ends in a failed state.  
- Ensure downstream logic and metrics don't operate on leftover values after a retry or terminal failure.

### Description

- In `MarketplaceFinancialReportSyncStatus::markLoading` clear previous attempt results by setting `recordsCount = 0`, `rawDocumentId = null`, and `rowsHash = null` in addition to existing state transitions.  
- In `markFailedRetryable` and the `markTerminalFailure` helper set `recordsCount = 0` to avoid retaining prior counts after failures.  
- Added unit tests in `site/tests/Unit/Marketplace/Entity/MarketplaceFinancialReportSyncStatusTest.php` that assert the new clearing behavior for `markLoading`, `markRawLoaded`, `markEmpty`, `markFailedRetryable`, `markFailedFinal`, `markAuthFailed`, and `markConflict`.

### Testing

- Added PHPUnit tests in `MarketplaceFinancialReportSyncStatusTest` covering all changed behaviors and ran them with `vendor/bin/phpunit --filter MarketplaceFinancialReportSyncStatusTest`.  
- The new tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14619e254c8323b49a52e0cca1e5cf)