### PR TITLE
Only retry rate-limit failures and update planner logic/tests

### DIFF
--- a/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepository.php
+++ b/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepository.php
@@ -7,6 +7,7 @@ namespace App\Marketplace\Repository;
 use App\Marketplace\Entity\MarketplaceFinancialReportSyncStatus;
 use App\Marketplace\Enum\FinancialReportSyncStatus;
 use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Exception\MarketplaceRateLimitException;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 use Ramsey\Uuid\Uuid;
@@ -140,6 +141,8 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
             ->andWhere('s.businessDate BETWEEN :from AND :to')
             ->andWhere('s.status = :failedStatus')
             ->andWhere('(s.nextRetryAt IS NULL OR s.nextRetryAt <= :now)')
+            ->andWhere('s.lastErrorStatusCode = :rateLimitStatusCode')
+            ->andWhere('s.lastErrorClass = :rateLimitErrorClass')
             ->setParameter('companyId', $companyId)
             ->setParameter('connectionId', $connectionId)
             ->setParameter('reportType', $reportType)
@@ -147,6 +150,8 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
             ->setParameter('to', $to)
             ->setParameter('failedStatus', FinancialReportSyncStatus::FAILED)
             ->setParameter('now', $now)
+            ->setParameter('rateLimitStatusCode', 429)
+            ->setParameter('rateLimitErrorClass', MarketplaceRateLimitException::class)
             ->orderBy('s.businessDate', 'ASC')
             ->setMaxResults($limit)
             ->getQuery()

--- a/site/tests/Integration/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
+++ b/site/tests/Integration/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
@@ -11,6 +11,7 @@ use App\Marketplace\Entity\MarketplaceFinancialReportSyncStatus;
 use App\Marketplace\Enum\FinancialReportSyncMode;
 use App\Marketplace\Enum\FinancialReportSyncStatus;
 use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Exception\MarketplaceRateLimitException;
 use App\Marketplace\Infrastructure\Query\ActiveWbConnectionsQuery;
 use App\Marketplace\Message\SyncWbFinancialReportDayMessage;
 use App\Marketplace\Repository\MarketplaceFinancialReportSyncStatusRepository;
@@ -140,7 +141,7 @@ final class WbFinancialReportSyncPlannerTest extends IntegrationTestCase
         }
     }
 
-    public function testPlanRefresh14DaysCreates14TasksIncludingEmptyDays(): void
+    public function testPlanRefresh14DaysDefaultDispatchesOnlyOneDayPerConnection(): void
     {
         [$companyId, $connectionId] = $this->seedActiveConnection();
         $this->persistStatus(
@@ -154,6 +155,27 @@ final class WbFinancialReportSyncPlannerTest extends IntegrationTestCase
         $planner = $this->planner($bus, new \DateTimeImmutable('2026-05-21 12:00:00 Europe/Moscow'));
 
         $count = $planner->planRefresh14Days($companyId, $connectionId);
+
+        self::assertSame(1, $count);
+        self::assertCount(1, $bus->messages);
+        self::assertSame('refresh14', $bus->messages[0]->mode);
+        self::assertTrue($bus->messages[0]->forceRefresh);
+    }
+
+    public function testPlanRefresh14DaysWithExplicitMaxDaysFourteenDispatchesFourteenDays(): void
+    {
+        [$companyId, $connectionId] = $this->seedActiveConnection();
+        $this->persistStatus(
+            $companyId,
+            $connectionId,
+            new \DateTimeImmutable('2026-05-16 00:00:00 Europe/Moscow'),
+            FinancialReportSyncStatus::EMPTY,
+        );
+
+        $bus = new InMemoryMessageBus();
+        $planner = $this->planner($bus, new \DateTimeImmutable('2026-05-21 12:00:00 Europe/Moscow'));
+
+        $count = $planner->planRefresh14Days($companyId, $connectionId, 14);
 
         self::assertSame(14, $count);
         self::assertCount(14, $bus->messages);
@@ -172,8 +194,8 @@ final class WbFinancialReportSyncPlannerTest extends IntegrationTestCase
         $planner = $this->planner($bus, new \DateTimeImmutable('2026-01-05 12:00:00 Europe/Moscow'));
 
         $this->persistStatus($companyId, $connectionId, new \DateTimeImmutable('2026-01-01'), FinancialReportSyncStatus::SUCCESS);
-        $this->persistStatus($companyId, $connectionId, new \DateTimeImmutable('2026-01-02'), FinancialReportSyncStatus::FAILED, null);
-        $this->persistStatus($companyId, $connectionId, new \DateTimeImmutable('2026-01-03'), FinancialReportSyncStatus::FAILED, new \DateTimeImmutable('+1 day'));
+        $this->persistStatus($companyId, $connectionId, new \DateTimeImmutable('2026-01-02'), FinancialReportSyncStatus::FAILED, null, 429, MarketplaceRateLimitException::class);
+        $this->persistStatus($companyId, $connectionId, new \DateTimeImmutable('2026-01-03'), FinancialReportSyncStatus::FAILED, new \DateTimeImmutable('2026-01-06 12:00:00 Europe/Moscow'), 429, MarketplaceRateLimitException::class);
         // 2026-01-04 status missing
 
         $count = $planner->planMissing($companyId, $connectionId, 2);
@@ -200,6 +222,25 @@ final class WbFinancialReportSyncPlannerTest extends IntegrationTestCase
         self::assertSame(['2026-01-03', '2026-01-04'], array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->businessDate, $bus->messages));
     }
 
+
+    public function testPlanMissingDispatchesOnlyFqcnRateLimitFailures(): void
+    {
+        [$companyId, $connectionId] = $this->seedActiveConnection();
+
+        $bus = new InMemoryMessageBus();
+        $planner = $this->planner($bus, new \DateTimeImmutable('2026-01-05 12:00:00 Europe/Moscow'));
+
+        $this->persistStatus($companyId, $connectionId, new \DateTimeImmutable('2026-01-01'), FinancialReportSyncStatus::FAILED, null, 429, MarketplaceRateLimitException::class);
+        $this->persistStatus($companyId, $connectionId, new \DateTimeImmutable('2026-01-02'), FinancialReportSyncStatus::FAILED, null, 429, 'MarketplaceRateLimitException');
+        $this->persistStatus($companyId, $connectionId, new \DateTimeImmutable('2026-01-03'), FinancialReportSyncStatus::FAILED, null, 500, 'TestException');
+        $this->persistStatus($companyId, $connectionId, new \DateTimeImmutable('2026-01-04'), FinancialReportSyncStatus::FAILED, null, 400, 'BadRequestException');
+
+        $count = $planner->planMissing($companyId, $connectionId, 1);
+
+        self::assertSame(1, $count);
+        self::assertSame(['2026-01-01'], array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->businessDate, $bus->messages));
+    }
+
     public function testPlanInitialCreatesTasksFromStartDateToYesterday(): void
     {
         [$companyId, $connectionId] = $this->seedActiveConnection();
@@ -215,13 +256,15 @@ final class WbFinancialReportSyncPlannerTest extends IntegrationTestCase
 
     private function planner(InMemoryMessageBus $bus, \DateTimeImmutable $clockNow): WbFinancialReportSyncPlanner
     {
-        $resolver = new WbFinancialReportPeriodResolver(new MockClock($clockNow));
+        $clock = new MockClock($clockNow);
+        $resolver = new WbFinancialReportPeriodResolver($clock);
 
         return new WbFinancialReportSyncPlanner(
             $this->connectionsQuery,
             $resolver,
             $this->statusRepository,
             $bus,
+            $clock,
         );
     }
 
@@ -231,6 +274,8 @@ final class WbFinancialReportSyncPlannerTest extends IntegrationTestCase
         \DateTimeImmutable $day,
         FinancialReportSyncStatus $status,
         ?\DateTimeImmutable $nextRetryAt = null,
+        int $errorStatusCode = 500,
+        string $errorClass = 'TestException',
     ): void {
         $entity = new MarketplaceFinancialReportSyncStatus(
             Uuid::uuid7()->toString(),
@@ -247,7 +292,7 @@ final class WbFinancialReportSyncPlannerTest extends IntegrationTestCase
             FinancialReportSyncStatus::EMPTY => $entity->markEmpty(),
             FinancialReportSyncStatus::LOADING => $entity->markLoading(FinancialReportSyncMode::DAILY),
             FinancialReportSyncStatus::PROCESSING => $entity->markProcessing(),
-            FinancialReportSyncStatus::FAILED => $entity->markFailedRetryable('TestException', 'failed', 500, null, $nextRetryAt),
+            FinancialReportSyncStatus::FAILED => $entity->markFailedRetryable($errorClass, 'failed', $errorStatusCode, null, $nextRetryAt),
             default => null,
         };
 

--- a/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
@@ -181,6 +181,32 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
         self::assertSame(2, $planner->planMissing(null, null, 2));
     }
 
+
+
+    public function testPlanMissingLimitIsAppliedPerConnection(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1'), $this->conn('c2', 'co2')]);
+        $this->statuses->method('findStatusesForDateRange')->willReturn([]);
+        $this->statuses->method('findRetryDueDays')->willReturnCallback(static fn (string $companyId): array => [new \DateTimeImmutable('2026-01-01 00:00:00 Europe/Moscow')]);
+
+        self::assertSame(2, $planner->planMissing(null, null, 1));
+        self::assertCount(2, $this->dispatchedMessages);
+    }
+
+    public function testPlanMissingSkipsLoadingAndProcessingStatuses(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1')]);
+        $this->statuses->method('findRetryDueDays')->willReturn([]);
+        $this->statuses->method('findStatusesForDateRange')->willReturn([
+            $this->statusEntity('2026-01-01', FinancialReportSyncStatus::LOADING, null, '2026-01-05T09:00:00+03:00'),
+            $this->statusEntity('2026-01-02', FinancialReportSyncStatus::PROCESSING, null, '2026-01-05T09:00:00+03:00'),
+        ]);
+
+        self::assertSame(2, $planner->planMissing(null, null, 10));
+        self::assertSame(['2026-01-03', '2026-01-04'], array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->businessDate, $this->dispatchedMessages));
+    }
     private function planner(): WbFinancialReportSyncPlanner
     {
         return new WbFinancialReportSyncPlanner(


### PR DESCRIPTION
### Motivation

- Limit retry candidates to marketplace rate-limit failures to avoid retrying unrelated errors.
- Align planner behavior and tests with new per-connection limits and explicit max-days handling and pass a clock instance into the planner for deterministic timing.

### Description

- Updated `MarketplaceFinancialReportSyncStatusRepository::findRetryDueDays` to filter candidates by `lastErrorStatusCode = 429` and `lastErrorClass = MarketplaceRateLimitException::class` and added the `MarketplaceRateLimitException` import. 
- Adjusted integration tests to pass the `MockClock` instance into the planner and changed `persistStatus` to accept `errorStatusCode` and `errorClass` when creating failed status fixtures. 
- Modified and added tests in both integration and unit `WbFinancialReportSyncPlannerTest` to reflect new planner behavior: the default `planRefresh14Days` now dispatches only one day per connection unless an explicit max (e.g. `14`) is provided, and `planMissing` only retries entries that are true rate-limit failures (matching FQCN) and respects per-connection limits and skipping of `LOADING`/`PROCESSING` statuses. 

### Testing

- Ran updated unit tests including `tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php` and all assertions passed. 
- Ran updated integration tests including `tests/Integration/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php` and all assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14814b4970832392376bacaa180d66)