### PR TITLE
Remove manual processing endpoints and UI buttons for marketplace raw docs (sales/returns/costs)

### DIFF
--- a/site/src/Marketplace/Controller/MarketplaceController.php
+++ b/site/src/Marketplace/Controller/MarketplaceController.php
@@ -9,9 +9,7 @@ use App\Marketplace\Application\ReprocessMarketplacePeriodAction;
 use App\Marketplace\Application\SyncConnectionAction;
 use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Entity\MarketplaceListing;
-use App\Marketplace\Application\Command\ProcessMarketplaceRawDocumentCommand;
 use App\Marketplace\Application\Command\SyncConnectionCommand;
-use App\Marketplace\Application\ProcessMarketplaceRawDocumentAction;
 use App\Marketplace\Enum\MarketplaceConnectionType;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Infrastructure\Query\OzonRealizationStatusQuery;
@@ -329,97 +327,6 @@ class MarketplaceController extends AbstractController
         }
 
         return $this->json($rawDoc->getRawData(), 200, [], ['json_encode_options' => JSON_PRETTY_PRINT]);
-    }
-
-    /**
-     * Ручные шаги проведения raw документа.
-     *
-     * В рамках целевого daily pipeline эти кнопки остаются fallback/admin flow
-     * и не удаляются до отдельного решения по миграции UX.
-     */
-    #[Route('/raw/{id}/process-sales', name: 'marketplace_raw_process_sales')]
-    public function processSales(
-        string $id,
-        ProcessMarketplaceRawDocumentAction $action,
-    ): Response {
-        $company = $this->companyService->getActiveCompany();
-
-        $rawDoc = $this->rawDocumentRepository->find($id);
-
-        if (!$rawDoc || $rawDoc->getCompany()->getId() !== $company->getId()) {
-            throw $this->createNotFoundException();
-        }
-
-        try {
-            $cmd   = new ProcessMarketplaceRawDocumentCommand((string) $company->getId(), (string) $rawDoc->getId(), 'sales');
-            $count = ($action)($cmd);
-
-            $this->addFlash('success', sprintf('Обработано продаж: %d', $count));
-        } catch (\Doctrine\DBAL\Exception\UniqueConstraintViolationException $e) {
-            preg_match('/Key \((.*?)\)=\((.*?)\)/', $e->getMessage(), $matches);
-            $keys   = $matches[1] ?? 'unknown';
-            $values = $matches[2] ?? 'unknown';
-
-            $this->addFlash('error', sprintf(
-                'Дубликат товара! Поля: %s | Значения: %s. Очистите БД и попробуйте снова.',
-                $keys,
-                $values
-            ));
-        } catch (\Exception $e) {
-            $this->addFlash('error', 'Ошибка обработки: ' . $e->getMessage());
-        }
-
-        return $this->redirectToRoute('marketplace_index');
-    }
-
-    #[Route('/raw/{id}/process-returns', name: 'marketplace_raw_process_returns')]
-    public function processReturns(
-        string $id,
-        ProcessMarketplaceRawDocumentAction $action,
-    ): Response {
-        $company = $this->companyService->getActiveCompany();
-
-        $rawDoc = $this->rawDocumentRepository->find($id);
-
-        if (!$rawDoc || $rawDoc->getCompany()->getId() !== $company->getId()) {
-            throw $this->createNotFoundException();
-        }
-
-        try {
-            $cmd   = new ProcessMarketplaceRawDocumentCommand((string) $company->getId(), (string) $rawDoc->getId(), 'returns');
-            $count = ($action)($cmd);
-
-            $this->addFlash('success', sprintf('Обработано возвратов: %d', $count));
-        } catch (\Exception $e) {
-            $this->addFlash('error', 'Ошибка обработки возвратов: ' . $e->getMessage());
-        }
-
-        return $this->redirectToRoute('marketplace_index');
-    }
-
-    #[Route('/raw/{id}/process-costs', name: 'marketplace_raw_process_costs')]
-    public function processCosts(
-        string $id,
-        ProcessMarketplaceRawDocumentAction $action,
-    ): Response {
-        $company = $this->companyService->getActiveCompany();
-
-        $rawDoc = $this->rawDocumentRepository->find($id);
-
-        if (!$rawDoc || $rawDoc->getCompany()->getId() !== $company->getId()) {
-            throw $this->createNotFoundException();
-        }
-
-        try {
-            $cmd   = new ProcessMarketplaceRawDocumentCommand((string) $company->getId(), (string) $rawDoc->getId(), 'costs');
-            $count = ($action)($cmd);
-
-            $this->addFlash('success', sprintf('Обработано затрат: %d', $count));
-        } catch (\Exception $e) {
-            $this->addFlash('error', 'Ошибка обработки затрат: ' . $e->getMessage());
-        }
-
-        return $this->redirectToRoute('marketplace_index');
     }
 
     #[Route('/raw/{id}/process-realization', name: 'marketplace_raw_process_realization')]

--- a/site/templates/marketplace/index.html.twig
+++ b/site/templates/marketplace/index.html.twig
@@ -186,11 +186,7 @@
                                 <td class="text-end">
                                     <div class="btn-list">
                                         <a href="{{ path('marketplace_raw_view', {id: doc.id}) }}" class="btn btn-sm btn-ghost-primary" target="_blank">JSON</a>
-                                        {% if doc.documentType == 'sales_report' %}
-                                            <a href="{{ path('marketplace_raw_process_sales', {id: doc.id}) }}" class="btn btn-sm btn-success">Продажи</a>
-                                            <a href="{{ path('marketplace_raw_process_returns', {id: doc.id}) }}" class="btn btn-sm btn-warning">Возвраты</a>
-                                            <a href="{{ path('marketplace_raw_process_costs', {id: doc.id}) }}" class="btn btn-sm btn-purple">Затраты</a>
-                                        {% elseif doc.documentType == 'realization' %}
+                                        {% if doc.documentType == 'realization' %}
                                             <button type="button"
                                                     class="btn btn-sm btn-teal"
                                                     data-bs-toggle="modal"


### PR DESCRIPTION
### Motivation
- Remove legacy/fallback admin flows for manual processing of marketplace raw documents (sales, returns, costs) to simplify controller surface and UI now that automated pipelines handle these cases.
- Keep realization processing intact because it still requires a dedicated action and UI flow.

### Description
- Deleted controller methods `processSales`, `processReturns`, and `processCosts` from `MarketplaceController` and removed their related `use` imports such as `ProcessMarketplaceRawDocumentAction` and `ProcessMarketplaceRawDocumentCommand`.
- Updated template `site/templates/marketplace/index.html.twig` to remove the buttons/links that triggered routes `marketplace_raw_process_sales`, `marketplace_raw_process_returns`, and `marketplace_raw_process_costs` from the raw documents list, leaving only the realization UI control and modal trigger for `marketplace_raw_process_realization`.
- Cleaned up unused imports in `MarketplaceController.php` as a result of removing the methods.

### Testing
- Ran the project's automated test suite with `phpunit` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a151d9e2fb88323800c89a0d3ad9e96)