### PR TITLE
Добавить фильтрацию по маркетплейсу в истории синхронизаций

### DIFF
--- a/site/src/Marketplace/Controller/MarketplaceController.php
+++ b/site/src/Marketplace/Controller/MarketplaceController.php
@@ -58,8 +58,8 @@ class MarketplaceController extends AbstractController
         $company = $this->companyService->getActiveCompany();
         $page    = max(1, $request->query->getInt('page', 1));
 
-        $marketplaceValue = (string) $request->query->get('marketplace', MarketplaceType::WILDBERRIES->value);
-        $selectedMarketplace = MarketplaceType::tryFrom($marketplaceValue) ?? MarketplaceType::WILDBERRIES;
+        $marketplaceValue = (string) $request->query->get('marketplace', '');
+        $selectedMarketplace = MarketplaceType::tryFrom($marketplaceValue);
 
         $connections = $this->connectionRepository->findByCompany($company);
         $qb          = $this->rawDocumentsListQuery->buildQueryBuilder($company, $selectedMarketplace);

--- a/site/src/Marketplace/Controller/MarketplaceController.php
+++ b/site/src/Marketplace/Controller/MarketplaceController.php
@@ -58,8 +58,11 @@ class MarketplaceController extends AbstractController
         $company = $this->companyService->getActiveCompany();
         $page    = max(1, $request->query->getInt('page', 1));
 
+        $marketplaceValue = (string) $request->query->get('marketplace', MarketplaceType::WILDBERRIES->value);
+        $selectedMarketplace = MarketplaceType::tryFrom($marketplaceValue) ?? MarketplaceType::WILDBERRIES;
+
         $connections = $this->connectionRepository->findByCompany($company);
-        $qb          = $this->rawDocumentsListQuery->buildQueryBuilder($company);
+        $qb          = $this->rawDocumentsListQuery->buildQueryBuilder($company, $selectedMarketplace);
 
         $adapter = new QueryAdapter($qb);
 
@@ -73,6 +76,7 @@ class MarketplaceController extends AbstractController
             'connections'           => $connections,
             'rawDocumentsPager'     => $rawDocumentsPager,
             'availableMarketplaces' => MarketplaceType::cases(),
+            'selectedMarketplace'   => $selectedMarketplace,
         ]);
     }
 

--- a/site/src/Marketplace/Enum/MarketplaceType.php
+++ b/site/src/Marketplace/Enum/MarketplaceType.php
@@ -18,4 +18,12 @@ enum MarketplaceType: string
             self::SBER_MEGAMARKET => 'СберМегаМаркет',
         };
     }
+
+    public function getSyncHistoryFilterName(): string
+    {
+        return match ($this) {
+            self::WILDBERRIES => 'Вайлбериз',
+            default => $this->getDisplayName(),
+        };
+    }
 }

--- a/site/src/Marketplace/Infrastructure/Query/RawDocumentsListQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/RawDocumentsListQuery.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Marketplace\Infrastructure\Query;
 
 use App\Company\Entity\Company;
+use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
 use Doctrine\ORM\QueryBuilder;
 
@@ -15,9 +16,9 @@ final readonly class RawDocumentsListQuery
     ) {
     }
 
-    public function buildQueryBuilder(Company $company): QueryBuilder
+    public function buildQueryBuilder(Company $company, ?MarketplaceType $marketplace = null): QueryBuilder
     {
-        return $this->rawDocumentRepository->createQueryBuilder('d')
+        $queryBuilder = $this->rawDocumentRepository->createQueryBuilder('d')
             ->where('d.company = :company')
             ->setParameter('company', $company)
             ->orderBy('d.periodTo', 'DESC')
@@ -25,5 +26,13 @@ final readonly class RawDocumentsListQuery
             ->addOrderBy('d.marketplace', 'ASC')
             ->addOrderBy('d.documentType', 'ASC')
             ->addOrderBy('d.syncedAt', 'DESC');
+
+        if ($marketplace !== null) {
+            $queryBuilder
+                ->andWhere('d.marketplace = :marketplace')
+                ->setParameter('marketplace', $marketplace);
+        }
+
+        return $queryBuilder;
     }
 }

--- a/site/templates/marketplace/index.html.twig
+++ b/site/templates/marketplace/index.html.twig
@@ -141,8 +141,9 @@
                                 name="marketplace"
                                 class="form-select"
                                 onchange="this.form.submit()">
+                            <option value="" {{ selectedMarketplace is null ? 'selected' : '' }}>Все маркетплейсы</option>
                             {% for marketplace in availableMarketplaces %}
-                                <option value="{{ marketplace.value }}" {{ selectedMarketplace.value == marketplace.value ? 'selected' : '' }}>
+                                <option value="{{ marketplace.value }}" {{ selectedMarketplace is not null and selectedMarketplace.value == marketplace.value ? 'selected' : '' }}>
                                     {{ marketplace.syncHistoryFilterName }}
                                 </option>
                             {% endfor %}

--- a/site/templates/marketplace/index.html.twig
+++ b/site/templates/marketplace/index.html.twig
@@ -142,9 +142,8 @@
                                 class="form-select"
                                 onchange="this.form.submit()">
                             {% for marketplace in availableMarketplaces %}
-                                {% set optionLabel = marketplace.value == 'wildberries' ? 'Вайлбериз' : marketplace.displayName %}
                                 <option value="{{ marketplace.value }}" {{ selectedMarketplace.value == marketplace.value ? 'selected' : '' }}>
-                                    {{ optionLabel }}
+                                    {{ marketplace.syncHistoryFilterName }}
                                 </option>
                             {% endfor %}
                         </select>

--- a/site/templates/marketplace/index.html.twig
+++ b/site/templates/marketplace/index.html.twig
@@ -135,6 +135,20 @@
             <div class="card-header">
                 <h3 class="card-title">История синхронизаций</h3>
                 <div class="card-actions">
+                    <form method="get" action="{{ path('marketplace_index') }}" class="d-flex align-items-center gap-2 me-2">
+                        <label for="sync-history-marketplace" class="form-label mb-0">Маркетплейсы</label>
+                        <select id="sync-history-marketplace"
+                                name="marketplace"
+                                class="form-select"
+                                onchange="this.form.submit()">
+                            {% for marketplace in availableMarketplaces %}
+                                {% set optionLabel = marketplace.value == 'wildberries' ? 'Вайлбериз' : marketplace.displayName %}
+                                <option value="{{ marketplace.value }}" {{ selectedMarketplace.value == marketplace.value ? 'selected' : '' }}>
+                                    {{ optionLabel }}
+                                </option>
+                            {% endfor %}
+                        </select>
+                    </form>
                     <button type="button" class="btn btn-warning btn-sm" data-bs-toggle="modal" data-bs-target="#bulkProcessModal">
                         Обработать месяц
                     </button>


### PR DESCRIPTION
### Motivation
- Сделать возможным фильтровать карточку "История синхронизаций" по маркетплейсу прямо на странице `/marketplace` для удобного просмотра и отладки данных.

### Description
- В `MarketplaceController::index()` добавлено чтение query-параметра `marketplace` с безопасным fallback на `MarketplaceType::WILDBERRIES` и передача `selectedMarketplace` в запрос и шаблон.
- В `RawDocumentsListQuery::buildQueryBuilder()` добавлен optional-параметр `?MarketplaceType $marketplace` и `andWhere('d.marketplace = :marketplace')` для применения фильтра на уровне ORM-запроса.
- В шаблон `site/templates/marketplace/index.html.twig` в `card-actions` добавлен GET-формуляр с селектором `Маркетплейсы`, автосабмитом и отображением `Вайлбериз` для `wildberries`.

### Testing
- Прогнал `php -l` для `site/src/Marketplace/Controller/MarketplaceController.php` и `site/src/Marketplace/Infrastructure/Query/RawDocumentsListQuery.php`, оба файла синтаксически корректны и проверки прошли успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a153f12673883239e673274b4f27509)