### PR TITLE
Перестроить header блока истории синхронизаций на /marketplace

### DIFF
--- a/site/templates/marketplace/index.html.twig
+++ b/site/templates/marketplace/index.html.twig
@@ -132,10 +132,10 @@
 
         {# История синхронизаций #}
         <div class="card">
-            <div class="card-header">
-                <h3 class="card-title">История синхронизаций</h3>
-                <div class="card-actions">
-                    <form method="get" action="{{ path('marketplace_index') }}" class="d-flex align-items-center gap-2 me-2">
+            <div class="card-header d-flex align-items-center justify-content-between gap-3">
+                <div class="d-flex align-items-center gap-3">
+                    <h3 class="card-title mb-0">История синхронизаций</h3>
+                    <form method="get" action="{{ path('marketplace_index') }}" class="d-flex align-items-center gap-2 mb-0">
                         <label for="sync-history-marketplace" class="form-label mb-0">Маркетплейсы</label>
                         <select id="sync-history-marketplace"
                                 name="marketplace"
@@ -149,10 +149,10 @@
                             {% endfor %}
                         </select>
                     </form>
-                    <button type="button" class="btn btn-warning btn-sm" data-bs-toggle="modal" data-bs-target="#bulkProcessModal">
-                        Обработать месяц
-                    </button>
                 </div>
+                <button type="button" class="btn btn-warning btn-sm ms-auto" data-bs-toggle="modal" data-bs-target="#bulkProcessModal">
+                    Обработать месяц
+                </button>
             </div>
             <div class="table-responsive">
                 <table class="table card-table table-vcenter">


### PR DESCRIPTION
### Motivation
- Улучшить расположение элементов header карточки «История синхронизаций»: заголовок и селектор должны быть слева в одной строке, кнопка — прижата к правому краю.

### Description
- Обновлён шаблон `site/templates/marketplace/index.html.twig` для блока «История синхронизаций»: заголовок и селектор вынесены в общий левый flex-контейнер, `card-header` получил утилитарные классы выравнивания, а кнопке добавлен `ms-auto` для прижатия вправо.
- Визуальные стили кнопки и селектора не изменялись — использованы только Bootstrap-утилиты и небольшие правки классов разметки.

### Testing
- Выполнен автоматический скрипт обновления (встроенный `python`-заменитель) и проверен результат содержимого файла методом просмотра строк (`nl`), изменения соответствуют требованиям, проверка успешна.
- Просмотрен diff шаблона, подтверждающий что изменился только markup header-а, проверка успешна.
- Юнит/интеграционные тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15d0044dfc832394b2c4fe320009e5)