### PR TITLE
Open button in cash transaction edit now routes to P&L document edit

### DIFF
--- a/site/templates/transaction/edit.html.twig
+++ b/site/templates/transaction/edit.html.twig
@@ -52,7 +52,7 @@
                                     </td>
                                     <td class="text-end fw-semibold">{{ document.totalAmount|number_format(2, ',', ' ') }}</td>
                                     <td class="text-end">
-                                        <a href="{{ path('document_show', {id: document.id}) }}" class="btn btn-link">Открыть</a>
+                                        <a href="{{ path('document_edit', {id: document.id}) }}" class="btn btn-link">Открыть</a>
                                     </td>
                                 </tr>
                             {% endfor %}


### PR DESCRIPTION
### Motivation
- From the cash transaction edit form the P&L document links should open the document in edit mode so the operation can be modified immediately instead of opening a read-only view.

### Description
- Updated `site/templates/transaction/edit.html.twig` so the "Открыть" button in the "Документы ОПиУ на основании транзакции" block uses `path('document_edit', {id: document.id})` instead of `path('document_show', {id: document.id})`.

### Testing
- No automated tests were run for this small template change, and the template was inspected to confirm it now contains `path('document_edit', {id: document.id})`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15d891bc3883239df3a7432b766bb2)