### PR TITLE
Изменён заголовок страницы /documents/ на контекст ОПиУ

### DIFF
--- a/site/templates/document/index.html.twig
+++ b/site/templates/document/index.html.twig
@@ -37,7 +37,8 @@
     <div class="page-header d-print-none">
         <div class="row g-2 align-items-center">
             <div class="col">
-                <h2 class="page-title">Документы</h2>
+                <div class="page-pretitle">Отчёт о прибылях и убытках</div>
+                <h2 class="page-title">Операции ОПиУ</h2>
             </div>
             <div class="col-auto ms-auto d-print-none">
                 <a href="{{ path('document_new') }}" class="btn btn-primary">+ Добавить документ</a>


### PR DESCRIPTION
### Motivation
- Привести заголовок страницы документов в соответствие с контекстом отчёта ОПиУ вместо общего «Документы». 

### Description
- В шаблоне `site/templates/document/index.html.twig` добавлен `div.page-pretitle` со значением «Отчёт о прибылях и убытках» и основной заголовок `h2.page-title` изменён на «Операции ОПиУ». 

### Testing
- Автоматический шаг `git commit` прошёл успешно (1 файл изменён), отдельный набор автотестов не запускался.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15e826f98c8323be21e46bac64cbee)