### PR TITLE
Skip cron-driven jobs in AdLoadJobFinalizer and avoid abandoning batches on successful completion

### DIFF
--- a/site/src/MarketplaceAds/Application/Service/AdLoadJobFinalizer.php
+++ b/site/src/MarketplaceAds/Application/Service/AdLoadJobFinalizer.php
@@ -50,6 +50,12 @@ final readonly class AdLoadJobFinalizer
             return;
         }
 
+        $scheduledBatchStats = $this->batchRepository->countStatesForJob($jobId, $companyId);
+        if ([] !== $scheduledBatchStats) {
+            // cron-driven pipeline: финализацию выполняет только AdJobFinalizerCommand
+            return;
+        }
+
         $completedChunks = $this->chunkProgressRepository->countCompletedChunks($jobId, $companyId);
         if ($completedChunks < $job->getChunksTotal()) {
             return;
@@ -89,10 +95,6 @@ final readonly class AdLoadJobFinalizer
         if (0 === $failedDocs) {
             $affected = $this->jobRepository->markCompleted($jobId, $companyId);
             if ($affected > 0) {
-                $this->batchRepository->abandonNonTerminalBatchesForTerminalJob(
-                    $jobId,
-                    'Abandoned because parent job became terminal: completed',
-                );
                 $this->marketplaceAdsLogger->info('AdLoadJob completed', [
                     'jobId' => $jobId,
                     'companyId' => $companyId,

--- a/site/tests/Unit/MarketplaceAds/Application/Service/AdLoadJobFinalizerTest.php
+++ b/site/tests/Unit/MarketplaceAds/Application/Service/AdLoadJobFinalizerTest.php
@@ -93,6 +93,7 @@ final class AdLoadJobFinalizerTest extends TestCase
         $job = $this->buildJob()->withChunksTotal(3)->asRunning()->build();
 
         $this->jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $this->batchRepo->method('countStatesForJob')->willReturn([]);
         $this->chunkRepo->expects(self::once())
             ->method('countCompletedChunks')
             ->willReturn(2);
@@ -109,6 +110,7 @@ final class AdLoadJobFinalizerTest extends TestCase
         $job = $this->buildJob()->withChunksTotal(1)->asRunning()->build();
 
         $this->jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $this->batchRepo->method('countStatesForJob')->willReturn([]);
         $this->chunkRepo->method('countCompletedChunks')->willReturn(1);
         // 5 total, 3 processed + 1 failed = 4 терминальных, остался 1 DRAFT.
         $this->mockDocCounts(total: 5, processed: 3, failed: 1);
@@ -124,6 +126,7 @@ final class AdLoadJobFinalizerTest extends TestCase
         $job = $this->buildJob()->withChunksTotal(2)->asRunning()->build();
 
         $this->jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $this->batchRepo->method('countStatesForJob')->willReturn([]);
         $this->chunkRepo->method('countCompletedChunks')->willReturn(2);
         $this->mockDocCounts(total: 5, processed: 5, failed: 0);
 
@@ -131,6 +134,7 @@ final class AdLoadJobFinalizerTest extends TestCase
             ->method('markCompleted')
             ->with(self::JOB_ID, self::COMPANY_ID)
             ->willReturn(1);
+        $this->batchRepo->expects(self::never())->method('abandonNonTerminalBatchesForTerminalJob');
         $this->jobRepo->expects(self::never())->method('markFailed');
 
         $this->finalizer->tryFinalize(self::JOB_ID, self::COMPANY_ID);
@@ -141,6 +145,7 @@ final class AdLoadJobFinalizerTest extends TestCase
         $job = $this->buildJob()->withChunksTotal(2)->asRunning()->build();
 
         $this->jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $this->batchRepo->method('countStatesForJob')->willReturn([]);
         $this->chunkRepo->method('countCompletedChunks')->willReturn(2);
         $this->mockDocCounts(total: 5, processed: 3, failed: 2);
 
@@ -153,6 +158,9 @@ final class AdLoadJobFinalizerTest extends TestCase
                 'Partial failure: 2 of 5 documents failed',
             )
             ->willReturn(1);
+        $this->batchRepo->expects(self::once())
+            ->method('abandonNonTerminalBatchesForTerminalJob')
+            ->with(self::JOB_ID, 'Abandoned because parent job became terminal: failed');
 
         $this->finalizer->tryFinalize(self::JOB_ID, self::COMPANY_ID);
     }
@@ -164,12 +172,14 @@ final class AdLoadJobFinalizerTest extends TestCase
         $job = $this->buildJob()->withChunksTotal(1)->asRunning()->build();
 
         $this->jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $this->batchRepo->method('countStatesForJob')->willReturn([]);
         $this->chunkRepo->method('countCompletedChunks')->willReturn(1);
         $this->mockDocCounts(total: 1, processed: 1, failed: 0);
 
         $this->jobRepo->expects(self::once())
             ->method('markCompleted')
             ->willReturn(0);
+        $this->batchRepo->expects(self::never())->method('abandonNonTerminalBatchesForTerminalJob');
         $this->jobRepo->expects(self::never())->method('markFailed');
 
         $this->finalizer->tryFinalize(self::JOB_ID, self::COMPANY_ID);
@@ -183,6 +193,7 @@ final class AdLoadJobFinalizerTest extends TestCase
         $job = $this->buildJob()->withChunksTotal(1)->asRunning()->build();
 
         $this->jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $this->batchRepo->method('countStatesForJob')->willReturn([]);
         $this->chunkRepo->method('countCompletedChunks')->willReturn(1);
         $this->mockDocCounts(total: 0, processed: 0, failed: 0);
 
@@ -190,7 +201,27 @@ final class AdLoadJobFinalizerTest extends TestCase
             ->method('markCompleted')
             ->with(self::JOB_ID, self::COMPANY_ID)
             ->willReturn(1);
+        $this->batchRepo->expects(self::never())->method('abandonNonTerminalBatchesForTerminalJob');
         $this->jobRepo->expects(self::never())->method('markFailed');
+
+        $this->finalizer->tryFinalize(self::JOB_ID, self::COMPANY_ID);
+    }
+
+    public function testCronDrivenJobIsSkippedByRawFinalizer(): void
+    {
+        $job = $this->buildJob()->withChunksTotal(6)->asRunning()->build();
+
+        $this->jobRepo->method('findByIdAndCompany')->willReturn($job);
+        $this->batchRepo->expects(self::once())
+            ->method('countStatesForJob')
+            ->with(self::JOB_ID, self::COMPANY_ID)
+            ->willReturn(['OK' => 1, 'PLANNED' => 5]);
+
+        $this->chunkRepo->expects(self::never())->method('countCompletedChunks');
+        $this->rawDocRepo->expects(self::never())->method('countByCompanyMarketplaceAndDateRange');
+        $this->jobRepo->expects(self::never())->method('markCompleted');
+        $this->jobRepo->expects(self::never())->method('markFailed');
+        $this->batchRepo->expects(self::never())->method('abandonNonTerminalBatchesForTerminalJob');
 
         $this->finalizer->tryFinalize(self::JOB_ID, self::COMPANY_ID);
     }


### PR DESCRIPTION
### Motivation
- Fix premature finalization of cron-driven Ozon pipeline where `AdLoadJobFinalizer` marked jobs completed and abandoned remaining scheduled batches while cron-driven finalization must be handled by `AdJobFinalizerCommand`.
- Prevent successful `markCompleted` from converting remaining non-terminal batches to `ABANDONED` which caused the production symptom `completed + 1 OK + many ABANDONED`.
- Preserve abandon behavior for genuine failure terminal paths so only error/failure scenarios will abandon remaining tails.

### Description
- In `AdLoadJobFinalizer::tryFinalize()` added a call to `AdScheduledBatchRepositoryInterface::countStatesForJob($jobId, $companyId)` and early-return when the result is non-empty so cron-driven jobs are skipped by the raw-document finalizer.
- Removed the `abandonNonTerminalBatchesForTerminalJob(...)` call from the successful `markCompleted` path so completed jobs no longer abandon remaining non-terminal batches.
- Kept `abandonNonTerminalBatchesForTerminalJob(...)` only in failed terminal paths (`markFailed`) so abandonment still occurs for manual/permanent failures and retry/rate-limit exhaustion.
- Updated `tests/Unit/MarketplaceAds/Application/Service/AdLoadJobFinalizerTest.php` to assert the new behavior including a new test where a cron-driven job with `OK=1, PLANNED=5` is skipped by the raw finalizer, and to assert that completed paths do not call `abandonNonTerminalBatchesForTerminalJob` while failed paths still do.

### Testing
- Updated unit tests: `tests/Unit/MarketplaceAds/Application/Service/AdLoadJobFinalizerTest.php` was extended to cover the cron-driven skip and abandonment behavior, and existing legacy/no-batches tests were preserved and adjusted to set `countStatesForJob => []` for non-cron scenarios.
- Attempted to run the requested PHPUnit suites with `php bin/phpunit` for the following files but execution failed due to missing Symfony PHPUnit Bridge script:
  - `php bin/phpunit tests/Unit/MarketplaceAds/Application/Service/AdLoadJobFinalizerTest.php`
  - `php bin/phpunit tests/Unit/MarketplaceAds/Command/AdJobFinalizerCommandTest.php`
  - `php bin/phpunit tests/Unit/MarketplaceAds/EventSubscriber/AdLoadJobFailureSubscriberTest.php`
  - `php bin/phpunit tests/Unit/MarketplaceAds/MessageHandler/RequestOzonAdBatchHandlerTest.php`
  - `php bin/phpunit tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php`
- Each test run failed with `Unable to find the simple-phpunit.php script in vendor/symfony/phpunit-bridge/bin/.` so automated execution could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1667d24c5483239250876c56fd99d5)