### PR TITLE
Fix floating horizontal scrollbar visibility in UnitExtendedTable

### DIFF
--- a/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedTable.tsx
+++ b/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedTable.tsx
@@ -190,9 +190,8 @@ const UnitExtendedTable: React.FC<UnitExtendedTableProps> = ({ items, totals, is
 
         const hasHorizontalOverflow = wrapper.scrollWidth > wrapper.clientWidth;
         const rect = wrapper.getBoundingClientRect();
-        const tableStarted = rect.top < window.innerHeight;
-        const tableBottomBelowViewport = rect.bottom > window.innerHeight;
-        const shouldShow = hasHorizontalOverflow && tableStarted && tableBottomBelowViewport;
+        const isTableVisible = rect.top < window.innerHeight && rect.bottom > 0;
+        const shouldShow = hasHorizontalOverflow && isTableVisible;
 
         setShowFloatingScrollbar(shouldShow);
         setFloatingScrollbarStyle({


### PR DESCRIPTION
### Motivation
- The previous visibility check required the table bottom to be below the viewport, which hid the floating horizontal scrollbar when the table bottom was near or inside the viewport bottom despite horizontal overflow.
- The goal is to show the floating scrollbar whenever the table has horizontal overflow and the table intersects the viewport so the user can access horizontal scrolling reliably.

### Description
- Replaced the strict `tableStarted / tableBottomBelowViewport` logic with `isTableVisible = rect.top < window.innerHeight && rect.bottom > 0` in `syncFloatingState`.
- Changed `shouldShow` to `hasHorizontalOverflow && isTableVisible` so the floating bar appears when the table intersects the viewport and has horizontal overflow.
- Kept floating scrollbar alignment unchanged by continuing to set `left: \`${rect.left}px\`` and `width: \`${rect.width}px\`` and preserved scroll synchronization behavior.

### Testing
- Ran local verification commands `sed -n '183,212p' site/assets/react/marketplace-analytics/unit-extended/UnitExtendedTable.tsx`, `git diff` and committed the change, and these steps succeeded.
- No automated unit or CI tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1727aaac308323a204c7ac23197d34)