### PR TITLE
Fix UnitExtended floating scrollbar overflow detection

### DIFF
--- a/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedTable.tsx
+++ b/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedTable.tsx
@@ -188,8 +188,14 @@ const UnitExtendedTable: React.FC<UnitExtendedTableProps> = ({ items, totals, is
             return;
         }
 
-        const hasHorizontalOverflow = wrapper.scrollWidth > wrapper.clientWidth;
+        const table = wrapper.querySelector('.ue-ext-table') as HTMLTableElement | null;
+        const contentScrollWidth = table?.scrollWidth ?? wrapper.scrollWidth;
         const rect = wrapper.getBoundingClientRect();
+        if (wrapper.clientWidth === 0 || rect.width === 0) {
+            setShowFloatingScrollbar(false);
+            return;
+        }
+        const hasHorizontalOverflow = contentScrollWidth > wrapper.clientWidth + 1;
         const isTableVisible = rect.top < window.innerHeight && rect.bottom > 0;
         const shouldShow = hasHorizontalOverflow && isTableVisible;
 
@@ -239,7 +245,9 @@ const UnitExtendedTable: React.FC<UnitExtendedTableProps> = ({ items, totals, is
         const syncWidths = () => {
             const inner = floating.firstElementChild as HTMLDivElement | null;
             if (!inner) return;
-            inner.style.width = `${wrapper.scrollWidth}px`;
+            const table = wrapper.querySelector('.ue-ext-table') as HTMLTableElement | null;
+            const contentScrollWidth = table?.scrollWidth ?? wrapper.scrollWidth;
+            inner.style.width = `${contentScrollWidth}px`;
             syncFloatingState();
         };
 


### PR DESCRIPTION
### Motivation
- The floating horizontal scrollbar did not appear when the visible table was wider than the wrapper because overflow was measured from the wrapper instead of the real table element. 
- Ensure the floating scrollbar appears only when the real table content overflows the visible wrapper while keeping existing sticky header, frozen columns and visual layout unchanged.

### Description
- In `UnitExtendedTable.tsx` updated `syncFloatingState` to find the real table via `wrapper.querySelector('.ue-ext-table')` and compute `contentScrollWidth = table?.scrollWidth ?? wrapper.scrollWidth`.
- Added a guard to hide the floating scrollbar when `wrapper.clientWidth === 0` or the wrapper `rect.width === 0` to avoid showing the control for degenerate sizes.
- Check overflow using `contentScrollWidth > wrapper.clientWidth + 1` and keep floating scrollbar alignment from `wrapper.getBoundingClientRect()` (`left` and `width`) unchanged.
- Use `contentScrollWidth` when setting the inner floating scrollbar width (`inner.style.width = `${contentScrollWidth}px``) so the thumb matches the real table width.

### Testing
- Ran `git diff --check` on the modified file (`site/assets/react/marketplace-analytics/unit-extended/UnitExtendedTable.tsx`) and it passed without warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a172c520b488323b2aa2317d9c8924e)