### PR TITLE
Add cashflow JSON export route

### DIFF
--- a/site/src/Controller/Finance/ReportCashflowController.php
+++ b/site/src/Controller/Finance/ReportCashflowController.php
@@ -7,6 +7,7 @@ use App\Report\Cashflow\CashflowReportParams;
 use App\Report\Cashflow\CashflowReportRequestMapper;
 use App\Shared\Service\ActiveCompanyService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -20,6 +21,57 @@ class ReportCashflowController extends AbstractController
         private CashflowReportRequestMapper $mapper,
         private CashflowReportBuilder $builder,
     ) {
+    }
+
+    #[Route('/finance/reports/cashflow/export.json', name: 'report_cashflow_export_json', methods: ['GET'])]
+    public function exportJson(Request $request): JsonResponse
+    {
+        $company = $this->activeCompanyService->getActiveCompany();
+        /** @var CashflowReportParams $params */
+        $params = $this->mapper->fromRequest($request, $company);
+        $payload = $this->builder->build($params);
+
+        $dateFrom = $payload['date_from']->format('Y-m-d');
+        $dateTo = $payload['date_to']->format('Y-m-d');
+
+        $response = new JsonResponse([
+            'exported_at' => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
+            'filters' => [
+                'group' => $payload['group'],
+                'date_from' => $dateFrom,
+                'date_to' => $dateTo,
+            ],
+            'company' => $payload['company']->getId(),
+            'group' => $payload['group'],
+            'date_from' => $dateFrom,
+            'date_to' => $dateTo,
+            'periods' => array_map(static fn (array $period): array => [
+                'start' => $period['start']->format('Y-m-d'),
+                'end' => $period['end']->format('Y-m-d'),
+                'label' => $period['label'],
+            ], $payload['periods']),
+            'categories' => array_map(static fn ($category): array => [
+                'id' => $category->getId(),
+                'name' => $category->getName(),
+            ], $payload['categories']),
+            'openings' => $payload['openings'],
+            'closings' => $payload['closings'],
+            'tree' => $payload['tree'],
+            'categoryTree' => $payload['categoryTree'],
+            'categoryTotals' => array_map(
+                static fn (array $row): array => [
+                    'totals' => $row['totals'],
+                ],
+                $payload['categoryTotals']
+            ),
+        ]);
+        $response->setEncodingOptions(\JSON_PRETTY_PRINT | \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES);
+        $response->headers->set(
+            'Content-Disposition',
+            \sprintf('attachment; filename="cashflow-report-%s_%s.json"', $dateFrom, $dateTo),
+        );
+
+        return $response;
     }
 
     #[Route('/finance/reports/cashflow', name: 'report_cashflow_index', methods: ['GET'])]


### PR DESCRIPTION
### Motivation
- Provide a downloadable JSON export for the cashflow report so company users can export current filters and full report data in a machine-readable format. 
- Match existing export style used elsewhere while adding export metadata and a stable attachment filename for the selected period.

### Description
- Added a new authenticated GET route `#[Route('/finance/reports/cashflow/export.json', name: 'report_cashflow_export_json', methods: ['GET'])]` in `ReportCashflowController` with handler `exportJson`.
- The handler obtains the active company via `ActiveCompanyService::getActiveCompany()`, maps request filters with `CashflowReportRequestMapper::fromRequest()`, and builds the report using `CashflowReportBuilder::build()`.
- The JSON payload mirrors the public report shape (periods, categories, `openings`, `closings`, `tree`, `categoryTree`, `categoryTotals`) and adds `exported_at`, `filters`, and `company` id, with period/date values formatted as `Y-m-d`.
- The response uses `JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES` encoding and sets `Content-Disposition` to `attachment; filename="cashflow-report-<from>_<to>.json"`, and the route remains protected by the class-level `#[IsGranted('ROLE_USER')]`.

### Testing
- `php -l site/src/Controller/Finance/ReportCashflowController.php` executed and reported no syntax errors (passed).
- `php -d memory_limit=512M bin/console lint:container --no-debug` executed and linted the container successfully (passed).
- Unit test `tests/Unit/Report/Cashflow/CashflowReportBuilderTest.php` run via `php -d memory_limit=512M bin/phpunit` and passed (OK).
- `php -d memory_limit=512M bin/console debug:router report_cashflow_export_json --no-debug` verified the new route is registered (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1873a13e748323a478017466c8ab07)