### PR TITLE
Add cashflow JSON export button

### DIFF
--- a/site/templates/report/cashflow.html.twig
+++ b/site/templates/report/cashflow.html.twig
@@ -34,6 +34,7 @@
     </div>
     <div class="col-auto">
         <button type="submit" class="btn btn-primary">Показать</button>
+        <a href="{{ path('report_cashflow_export_json', app.request.query.all) }}" class="btn btn-outline-secondary">JSON</a>
     </div>
 </form>
 


### PR DESCRIPTION
### Motivation
- Provide a quick way to download the currently-filtered cashflow report as JSON while preserving the active filters.

### Description
- Inserted a link-styled button next to the filter `Показать` submit that points to `report_cashflow_export_json` with `app.request.query.all`, renders as `JSON`, uses `btn btn-outline-secondary`, and omits `target` so the response can be served with `Content-Disposition: attachment`.

### Testing
- Ran `php -d memory_limit=-1 bin/console lint:twig templates/report/cashflow.html.twig` and the Twig syntax check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1883355a50832385b885c2cb096b37)