### PR TITLE
Introduce CashflowReportJsonFormatter and wire it into cashflow endpoints

### DIFF
--- a/site/src/Controller/Api/PublicCashflowReportController.php
+++ b/site/src/Controller/Api/PublicCashflowReportController.php
@@ -1,8 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Controller\Api;
 
 use App\Company\Service\ReportApiKeyManager;
+use App\Finance\Infrastructure\Normalizer\CashflowReportJsonFormatter;
 use App\Report\Cashflow\CashflowReportBuilder;
 use App\Report\Cashflow\CashflowReportRequestMapper;
 use App\Shared\Service\RateLimiter\ReportsApiRateLimiter;
@@ -19,6 +22,7 @@ final class PublicCashflowReportController extends AbstractController
         private readonly ReportApiKeyManager $keys,
         private readonly CashflowReportRequestMapper $mapper,
         private readonly CashflowReportBuilder $builder,
+        private readonly CashflowReportJsonFormatter $jsonFormatter,
         private readonly ReportsApiRateLimiter $rateLimiter,
     ) {
     }
@@ -43,28 +47,7 @@ final class PublicCashflowReportController extends AbstractController
         $params = $this->mapper->fromRequest($r, $company);
         $payload = $this->builder->build($params);
 
-        return $this->json([
-            'company' => $payload['company']->getId(),
-            'group' => $payload['group'],
-            'date_from' => $payload['date_from']->format('Y-m-d'),
-            'date_to' => $payload['date_to']->format('Y-m-d'),
-            'periods' => array_map(fn ($p) => [
-                'start' => $p['start']->format('Y-m-d'),
-                'end' => $p['end']->format('Y-m-d'),
-                'label' => $p['label'],
-            ], $payload['periods']),
-            'categories' => array_map(fn ($c) => ['id' => $c->getId(), 'name' => $c->getName()], $payload['categories']),
-            'categoryTotals' => array_map(
-                static fn (array $row): array => [
-                    'totals' => $row['totals'],
-                ],
-                $payload['categoryTotals']
-            ),
-            'openings' => $payload['openings'],
-            'closings' => $payload['closings'],
-            'tree' => $payload['tree'],
-            'categoryTree' => $payload['categoryTree'],
-        ]);
+        return $this->json($this->jsonFormatter->format($payload));
     }
 
     #[Route('/api/public/reports/cashflow.csv', name: 'api_report_cashflow_csv', methods: ['GET'])]
@@ -92,7 +75,7 @@ final class PublicCashflowReportController extends AbstractController
         $openings = $payload['openings'];
         $closings = $payload['closings'];
 
-        $resp = new StreamedResponse(function () use ($periods, $categoryTotals, $openings, $closings) {
+        $resp = new StreamedResponse(static function () use ($periods, $categoryTotals, $openings, $closings) {
             $out = fopen('php://output', 'w');
             fputcsv($out, ['Период', 'КатегорияID', 'Валюта', 'Сальдо нач.', 'Нетто', 'Сальдо кон.']);
             foreach ($periods as $i => $p) {

--- a/site/src/Controller/Finance/ReportCashflowController.php
+++ b/site/src/Controller/Finance/ReportCashflowController.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Controller\Finance;
 
+use App\Finance\Infrastructure\Normalizer\CashflowReportJsonFormatter;
 use App\Report\Cashflow\CashflowReportBuilder;
 use App\Report\Cashflow\CashflowReportParams;
 use App\Report\Cashflow\CashflowReportRequestMapper;
@@ -20,6 +23,7 @@ class ReportCashflowController extends AbstractController
         private ActiveCompanyService $activeCompanyService,
         private CashflowReportRequestMapper $mapper,
         private CashflowReportBuilder $builder,
+        private CashflowReportJsonFormatter $jsonFormatter,
     ) {
     }
 
@@ -31,40 +35,15 @@ class ReportCashflowController extends AbstractController
         $params = $this->mapper->fromRequest($request, $company);
         $payload = $this->builder->build($params);
 
-        $dateFrom = $payload['date_from']->format('Y-m-d');
-        $dateTo = $payload['date_to']->format('Y-m-d');
-
-        $response = new JsonResponse([
-            'exported_at' => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
-            'filters' => [
-                'group' => $payload['group'],
-                'date_from' => $dateFrom,
-                'date_to' => $dateTo,
-            ],
-            'company' => $payload['company']->getId(),
-            'group' => $payload['group'],
-            'date_from' => $dateFrom,
-            'date_to' => $dateTo,
-            'periods' => array_map(static fn (array $period): array => [
-                'start' => $period['start']->format('Y-m-d'),
-                'end' => $period['end']->format('Y-m-d'),
-                'label' => $period['label'],
-            ], $payload['periods']),
-            'categories' => array_map(static fn ($category): array => [
-                'id' => $category->getId(),
-                'name' => $category->getName(),
-            ], $payload['categories']),
-            'openings' => $payload['openings'],
-            'closings' => $payload['closings'],
-            'tree' => $payload['tree'],
-            'categoryTree' => $payload['categoryTree'],
-            'categoryTotals' => array_map(
-                static fn (array $row): array => [
-                    'totals' => $row['totals'],
-                ],
-                $payload['categoryTotals']
-            ),
+        $formatted = $this->jsonFormatter->format($payload, [
+            'include_exported_at' => true,
+            'dataset' => 'cashflow',
+            'include_filters' => true,
         ]);
+        $dateFrom = $formatted['date_from'];
+        $dateTo = $formatted['date_to'];
+
+        $response = new JsonResponse($formatted);
         $response->setEncodingOptions(\JSON_PRETTY_PRINT | \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES);
         $response->headers->set(
             'Content-Disposition',

--- a/site/src/Finance/Infrastructure/Normalizer/CashflowReportJsonFormatter.php
+++ b/site/src/Finance/Infrastructure/Normalizer/CashflowReportJsonFormatter.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Finance\Infrastructure\Normalizer;
+
+final readonly class CashflowReportJsonFormatter
+{
+    /**
+     * @param array<string,mixed> $payload Payload from CashflowReportBuilder::build()
+     * @param array{
+     *     include_exported_at?: bool,
+     *     exported_at?: \DateTimeInterface,
+     *     dataset?: string,
+     *     include_filters?: bool,
+     * } $options
+     *
+     * @return array<string,mixed>
+     */
+    public function format(array $payload, array $options = []): array
+    {
+        $dateFrom = $this->formatDate($payload['date_from']);
+        $dateTo = $this->formatDate($payload['date_to']);
+
+        $result = [];
+        if (($options['include_exported_at'] ?? false) || isset($options['exported_at'])) {
+            $exportedAt = $options['exported_at'] ?? new \DateTimeImmutable();
+            $result['exported_at'] = $exportedAt->format(\DateTimeInterface::ATOM);
+        }
+        if (isset($options['dataset'])) {
+            $result['dataset'] = $options['dataset'];
+        }
+        if ($options['include_filters'] ?? false) {
+            $result['filters'] = [
+                'group' => $payload['group'],
+                'date_from' => $dateFrom,
+                'date_to' => $dateTo,
+            ];
+        }
+
+        return $result + [
+            'company' => $payload['company']->getId(),
+            'group' => $payload['group'],
+            'date_from' => $dateFrom,
+            'date_to' => $dateTo,
+            'periods' => array_map(fn (array $period): array => [
+                'start' => $this->formatDate($period['start']),
+                'end' => $this->formatDate($period['end']),
+                'label' => $period['label'],
+            ], $payload['periods']),
+            'categories' => array_map(static fn ($category): array => [
+                'id' => $category->getId(),
+                'name' => $category->getName(),
+            ], $payload['categories']),
+            'categoryTotals' => $this->formatCategoryTotals($payload['categoryTotals']),
+            'openings' => $payload['openings'],
+            'closings' => $payload['closings'],
+            'tree' => $payload['tree'],
+            'categoryTree' => $payload['categoryTree'],
+        ];
+    }
+
+    private function formatDate(\DateTimeInterface $date): string
+    {
+        return $date->format('Y-m-d');
+    }
+
+    /**
+     * @param array<string,array<string,mixed>> $categoryTotals
+     *
+     * @return array<string,array{totals:mixed}>
+     */
+    private function formatCategoryTotals(array $categoryTotals): array
+    {
+        $formatted = [];
+        foreach ($categoryTotals as $categoryId => $row) {
+            $formatted[$categoryId] = [
+                'totals' => $row['totals'],
+            ];
+        }
+
+        return $formatted;
+    }
+}

--- a/site/tests/Unit/Finance/Infrastructure/Normalizer/CashflowReportJsonFormatterTest.php
+++ b/site/tests/Unit/Finance/Infrastructure/Normalizer/CashflowReportJsonFormatterTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Finance\Infrastructure\Normalizer;
+
+use App\Cash\Entity\Transaction\CashflowCategory;
+use App\Company\Entity\Company;
+use App\Company\Entity\User;
+use App\Finance\Infrastructure\Normalizer\CashflowReportJsonFormatter;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+final class CashflowReportJsonFormatterTest extends TestCase
+{
+    public function testFormatKeepsPublicJsonContractSerializable(): void
+    {
+        $formatter = new CashflowReportJsonFormatter();
+        $user = $this->createUser();
+        $company = new Company('11111111-1111-4111-8111-111111111111', $user);
+        $company->setName('Cashflow Co');
+        $category = new CashflowCategory('22222222-2222-4222-8222-222222222222', $company);
+        $category->setName('Operations');
+
+        $tree = [[
+            'id' => $category->getId(),
+            'name' => $category->getName(),
+            'level' => 0,
+            'totals' => ['USD' => [123.45]],
+            'children' => [],
+        ]];
+        $categoryTree = [[
+            'id' => $category->getId(),
+            'name' => $category->getName(),
+            'parentId' => null,
+            'level' => 0,
+            'order' => 0,
+        ]];
+
+        $formatted = $formatter->format([
+            'company' => $company,
+            'group' => 'month',
+            'date_from' => new \DateTimeImmutable('2026-01-01'),
+            'date_to' => new \DateTimeImmutable('2026-01-31'),
+            'periods' => [[
+                'start' => new \DateTimeImmutable('2026-01-01'),
+                'end' => new \DateTimeImmutable('2026-01-31'),
+                'label' => 'Jan 2026',
+            ]],
+            'categories' => [$category],
+            'categoryTotals' => [
+                $category->getId() => [
+                    'entity' => $category,
+                    'totals' => ['USD' => [123.45]],
+                ],
+            ],
+            'openings' => ['USD' => [10.0]],
+            'closings' => ['USD' => [133.45]],
+            'tree' => $tree,
+            'categoryTree' => $categoryTree,
+        ]);
+
+        self::assertSame([
+            'company' => $company->getId(),
+            'group' => 'month',
+            'date_from' => '2026-01-01',
+            'date_to' => '2026-01-31',
+            'periods' => [[
+                'start' => '2026-01-01',
+                'end' => '2026-01-31',
+                'label' => 'Jan 2026',
+            ]],
+            'categories' => [[
+                'id' => $category->getId(),
+                'name' => 'Operations',
+            ]],
+            'categoryTotals' => [
+                $category->getId() => [
+                    'totals' => ['USD' => [123.45]],
+                ],
+            ],
+            'openings' => ['USD' => [10.0]],
+            'closings' => ['USD' => [133.45]],
+            'tree' => $tree,
+            'categoryTree' => $categoryTree,
+        ], $formatted);
+    }
+
+    public function testFormatCanAddExportMetadataAndFilters(): void
+    {
+        $formatter = new CashflowReportJsonFormatter();
+        $user = $this->createUser();
+        $company = new Company('33333333-3333-4333-8333-333333333333', $user);
+
+        $formatted = $formatter->format([
+            'company' => $company,
+            'group' => 'day',
+            'date_from' => new \DateTimeImmutable('2026-02-01'),
+            'date_to' => new \DateTimeImmutable('2026-02-02'),
+            'periods' => [],
+            'categories' => [],
+            'categoryTotals' => [],
+            'openings' => [],
+            'closings' => [],
+            'tree' => [],
+            'categoryTree' => [],
+        ], [
+            'include_exported_at' => true,
+            'exported_at' => new \DateTimeImmutable('2026-02-03T04:05:06+00:00'),
+            'dataset' => 'cashflow',
+            'include_filters' => true,
+        ]);
+
+        self::assertSame('2026-02-03T04:05:06+00:00', $formatted['exported_at']);
+        self::assertSame('cashflow', $formatted['dataset']);
+        self::assertSame([
+            'group' => 'day',
+            'date_from' => '2026-02-01',
+            'date_to' => '2026-02-02',
+        ], $formatted['filters']);
+    }
+
+    private function createUser(): User
+    {
+        $user = new User(Uuid::uuid4()->toString());
+        $user->setEmail('cashflow-json-formatter@example.com');
+        $user->setPassword('pass');
+
+        return $user;
+    }
+}


### PR DESCRIPTION
### Motivation

- Centralize JSON formatting for cashflow reports to keep controllers thin and ensure a stable public JSON contract.
- Provide an option to include export metadata and filters in exported report JSON.

### Description

- Add `App\Finance\Infrastructure\Normalizer\CashflowReportJsonFormatter` that transforms `CashflowReportBuilder::build()` payloads into a serializable array and supports export metadata via options.
- Update `PublicCashflowReportController::jsonReport` and `ReportCashflowController::exportJson` to use the new `CashflowReportJsonFormatter` and add `declare(strict_types=1)` and necessary imports.
- Use the formatter output for filename generation in `exportJson` and simplify JSON assembly in controllers, and make the CSV `StreamedResponse` closure `static`.
- Add unit tests in `tests/Unit/Finance/Infrastructure/Normalizer/CashflowReportJsonFormatterTest.php` that verify the public JSON contract and export metadata behavior.

### Testing

- Added `CashflowReportJsonFormatter` unit tests in `tests/Unit/Finance/Infrastructure/Normalizer/CashflowReportJsonFormatterTest.php` and ran them with `phpunit --filter CashflowReportJsonFormatterTest`, which passed.
- No integration or functional failures were observed when running the focused unit test suite for the new formatter.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1884e133148323abe9af81aba3b8ec)