### PR TITLE
Guard WB financial reports --mode=all with `--allow-all` flag

### DIFF
--- a/site/src/Marketplace/Command/WbFinancialReportsSyncCommand.php
+++ b/site/src/Marketplace/Command/WbFinancialReportsSyncCommand.php
@@ -37,7 +37,8 @@ final class WbFinancialReportsSyncCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addOption('mode', null, InputOption::VALUE_REQUIRED, 'all|initial|daily|refresh14|missing', 'all')
+            ->addOption('mode', null, InputOption::VALUE_REQUIRED, 'all|initial|daily|refresh14|missing', 'daily')
+            ->addOption('allow-all', null, InputOption::VALUE_NONE)
             ->addOption('company-id', null, InputOption::VALUE_OPTIONAL)
             ->addOption('connection-id', null, InputOption::VALUE_OPTIONAL)
             ->addOption('date', null, InputOption::VALUE_OPTIONAL, 'Дата для single-day запуска (Y-m-d)')
@@ -57,6 +58,12 @@ final class WbFinancialReportsSyncCommand extends Command
 
         try {
             $mode = $this->resolveMode((string) $input->getOption('mode'));
+
+            if ('all' === $mode && !(bool) $input->getOption('allow-all')) {
+                $io->warning('WB financial reports --mode=all is dangerous for cron because it can enqueue many days and hit WB API rate limits.');
+
+                return Command::FAILURE;
+            }
             $companyId = $this->normalizeOptional((string) $input->getOption('company-id'));
             $connectionId = $this->normalizeOptional((string) $input->getOption('connection-id'));
             $force = (bool) $input->getOption('force');

--- a/site/tests/Unit/Marketplace/Command/WbFinancialReportsSyncCommandTest.php
+++ b/site/tests/Unit/Marketplace/Command/WbFinancialReportsSyncCommandTest.php
@@ -60,15 +60,79 @@ final class WbFinancialReportsSyncCommandTest extends TestCase
         self::assertSame(Command::FAILURE, $code);
     }
 
+    public function testDefaultModeRunsDailyOnly(): void
+    {
+        $this->planner
+            ->expects(self::once())
+            ->method('planDaily')
+            ->with(null, null, false)
+            ->willReturn(1);
+
+        $this->planner->expects(self::never())->method('planInitial');
+        $this->planner->expects(self::never())->method('planRefresh14Days');
+        $this->planner->expects(self::never())->method('planMissing');
+
+        $tester = $this->tester();
+        $code = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $code);
+    }
+
+    public function testAllWithoutAllowAllReturnsFailureAndWarns(): void
+    {
+        $this->planner->expects(self::never())->method('planDaily');
+        $this->planner->expects(self::never())->method('planInitial');
+        $this->planner->expects(self::never())->method('planRefresh14Days');
+        $this->planner->expects(self::never())->method('planMissing');
+
+        $tester = $this->tester();
+
+        $code = $tester->execute(['--mode' => 'all']);
+
+        self::assertSame(Command::FAILURE, $code);
+        self::assertStringContainsString(
+            'WB financial reports --mode=all is dangerous for cron because it can enqueue many days and hit WB API rate limits.',
+            $tester->getDisplay(),
+        );
+    }
+
     public function testAllWithDateReturnsFailure(): void
     {
         $tester = $this->tester();
 
-        $code = $tester->execute(['--mode' => 'all', '--date' => '2026-05-19']);
+        $code = $tester->execute(['--mode' => 'all', '--allow-all' => true, '--date' => '2026-05-19']);
 
         self::assertSame(Command::FAILURE, $code);
     }
 
+    public function testAllWithAllowAllRunsAllModes(): void
+    {
+        $this->planner
+            ->expects(self::once())
+            ->method('planInitial')
+            ->with(null, null)
+            ->willReturn(1);
+        $this->planner
+            ->expects(self::once())
+            ->method('planDaily')
+            ->with(null, null, false)
+            ->willReturn(2);
+        $this->planner
+            ->expects(self::once())
+            ->method('planRefresh14Days')
+            ->with(null, null, 1)
+            ->willReturn(3);
+        $this->planner
+            ->expects(self::once())
+            ->method('planMissing')
+            ->with(null, null, 1)
+            ->willReturn(4);
+
+        $tester = $this->tester();
+        $code = $tester->execute(['--mode' => 'all', '--allow-all' => true]);
+
+        self::assertSame(Command::SUCCESS, $code);
+    }
 
     public function testMissingWithDateReturnsFailureAndDoesNotCallPlanMissing(): void
     {


### PR DESCRIPTION
### Motivation
- Prevent accidental cron runs that pass `--mode=all` and can enqueue many days and hit WB API rate limits. 
- Make the safe default for scheduled runs be `daily` instead of `all`.
- Preserve the existing manual behavior for full runs when explicitly allowed.

### Description
- Change default for `--mode` from `all` to `daily` in `WbFinancialReportsSyncCommand::configure()` by setting the default value to `daily`.
- Add an `--allow-all` option (`InputOption::VALUE_NONE`) to the command signature to opt in to running all modes.
- In `execute()` add a guard after resolving `$mode` that returns `Command::FAILURE` and writes a warning when `$mode === 'all'` and `--allow-all` is not provided with the message `WB financial reports --mode=all is dangerous for cron because it can enqueue many days and hit WB API rate limits.`
- Update unit tests in `tests/Unit/Marketplace/Command/WbFinancialReportsSyncCommandTest.php` to cover the new default, blocked `--mode=all` without `--allow-all`, and the preserved `--mode=all --allow-all` behavior.

### Testing
- Ran syntax checks: `php -l src/Marketplace/Command/WbFinancialReportsSyncCommand.php` and `php -l tests/Unit/Marketplace/Command/WbFinancialReportsSyncCommandTest.php`, both succeeded.
- Added unit tests that assert the default runs `daily`, that `--mode=all` without `--allow-all` fails and emits the warning, and that `--mode=all --allow-all` runs all modes; these tests are present in the test suite.
- Attempted to run the unit tests via `php bin/phpunit ...` but execution was blocked in this environment due to missing `vendor/symfony/phpunit-bridge/bin/simple-phpunit.php` (so full automated run could not be completed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a190d3aacd883239abbd72a9002d8fa)