### PR TITLE
Add atomic queue claims for WB financial sync

### DIFF
--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlanner.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlanner.php
@@ -6,6 +6,7 @@ namespace App\Marketplace\Application\Service;
 
 use App\Marketplace\Enum\FinancialReportSyncMode;
 use App\Marketplace\Enum\FinancialReportSyncStatus;
+use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Infrastructure\Query\ActiveWbConnectionsQuery;
 use App\Marketplace\Message\SyncWbFinancialReportDayMessage;
 use App\Marketplace\Repository\MarketplaceFinancialReportSyncStatusLookupInterface;
@@ -16,6 +17,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlannerInterface
 {
     private const REPORT_TYPE = 'sales_report';
+    private const API_ENDPOINT = 'wildberries::finance-sales-reports-detailed';
 
     public function __construct(
         private readonly ActiveWbConnectionsQuery $activeWbConnectionsQuery,
@@ -34,18 +36,6 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
             [$day],
             FinancialReportSyncMode::DAILY,
             $force,
-            static function (?FinancialReportSyncStatus $status) use ($force): bool {
-                if (\in_array($status, [FinancialReportSyncStatus::LOADING, FinancialReportSyncStatus::PROCESSING], true)) {
-                    return false;
-                }
-
-                if ($force) {
-                    return true;
-                }
-
-                return null === $status
-                    || !\in_array($status, [FinancialReportSyncStatus::SUCCESS, FinancialReportSyncStatus::EMPTY], true);
-            },
         );
     }
 
@@ -130,7 +120,10 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
                     break;
                 }
 
-                $this->dispatch($connection['company_id'], $connection['connection_id'], $day, FinancialReportSyncMode::REFRESH_14D, true);
+                if (!$this->claimAndDispatch($connection['company_id'], $connection['connection_id'], $day, FinancialReportSyncMode::REFRESH_14D, true)) {
+                    continue;
+                }
+
                 ++$dispatched;
                 ++$scheduledForConnection;
             }
@@ -153,24 +146,6 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
             $this->periodResolver->daysBetween($from, $to),
             $mode,
             $forceRefresh,
-            function (?FinancialReportSyncStatus $status) use ($forceRefresh, $mode): bool {
-                if (\in_array($status, [FinancialReportSyncStatus::LOADING, FinancialReportSyncStatus::PROCESSING], true)) {
-                    return false;
-                }
-
-                if ($forceRefresh) {
-                    return true;
-                }
-
-                return match ($mode) {
-                    FinancialReportSyncMode::DAILY => null === $status
-                        || !\in_array($status, [FinancialReportSyncStatus::SUCCESS, FinancialReportSyncStatus::EMPTY], true),
-                    FinancialReportSyncMode::INITIAL => null === $status || FinancialReportSyncStatus::FAILED === $status,
-                    FinancialReportSyncMode::REFRESH_14D => true,
-                    FinancialReportSyncMode::MISSING => null === $status || FinancialReportSyncStatus::FAILED === $status,
-                    FinancialReportSyncMode::MANUAL => null === $status || FinancialReportSyncStatus::FAILED === $status,
-                };
-            },
         );
     }
 
@@ -231,7 +206,10 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
 
             ksort($scheduledDays);
             foreach ($scheduledDays as $day) {
-                $this->dispatch($connection['company_id'], $connection['connection_id'], $day, FinancialReportSyncMode::MISSING, false);
+                if (!$this->claimAndDispatch($connection['company_id'], $connection['connection_id'], $day, FinancialReportSyncMode::MISSING, false)) {
+                    continue;
+                }
+
                 ++$dispatched;
             }
         }
@@ -249,38 +227,50 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
             $days,
             FinancialReportSyncMode::INITIAL,
             false,
-            static fn (?FinancialReportSyncStatus $status): bool => null === $status
-                || FinancialReportSyncStatus::FAILED === $status,
         );
     }
 
     /** @param list<array{id: string, company_id: string, connection_id: string}> $connections
      * @param list<DateTimeImmutable> $days
-     * @param callable(?FinancialReportSyncStatus): bool $shouldDispatch
      */
-    private function planForDays(array $connections, array $days, FinancialReportSyncMode $mode, bool $forceRefresh, callable $shouldDispatch): int
+    private function planForDays(array $connections, array $days, FinancialReportSyncMode $mode, bool $forceRefresh): int
     {
         $dispatched = 0;
 
         foreach ($connections as $connection) {
             foreach ($days as $day) {
-                $status = $this->syncStatusRepository->findStatusEnumByDay(
-                    $connection['connection_id'],
-                    $connection['company_id'],
-                    $day,
-                    self::REPORT_TYPE,
-                );
-
-                if (!$shouldDispatch($status)) {
+                if (!$this->claimAndDispatch($connection['company_id'], $connection['connection_id'], $day, $mode, $forceRefresh)) {
                     continue;
                 }
 
-                $this->dispatch($connection['company_id'], $connection['connection_id'], $day, $mode, $forceRefresh);
                 ++$dispatched;
             }
         }
 
         return $dispatched;
+    }
+
+    private function claimAndDispatch(string $companyId, string $connectionId, DateTimeImmutable $day, FinancialReportSyncMode $mode, bool $forceRefresh): bool
+    {
+        $status = $this->syncStatusRepository->claimForQueue(
+            $connectionId,
+            $companyId,
+            MarketplaceType::WILDBERRIES,
+            self::REPORT_TYPE,
+            self::API_ENDPOINT,
+            $day,
+            $mode,
+            $forceRefresh,
+            $this->clock->now(),
+        );
+
+        if (null === $status) {
+            return false;
+        }
+
+        $this->dispatch($companyId, $connectionId, $day, $mode, $forceRefresh);
+
+        return true;
     }
 
     private function dispatch(string $companyId, string $connectionId, DateTimeImmutable $day, FinancialReportSyncMode $mode, bool $forceRefresh): void

--- a/site/src/Marketplace/Entity/MarketplaceFinancialReportSyncStatus.php
+++ b/site/src/Marketplace/Entity/MarketplaceFinancialReportSyncStatus.php
@@ -147,6 +147,15 @@ class MarketplaceFinancialReportSyncStatus
     public function getCreatedAt(): \DateTimeImmutable { return $this->createdAt; }
     public function getUpdatedAt(): \DateTimeImmutable { return $this->updatedAt; }
 
+    public function markQueued(FinancialReportSyncMode $mode, bool $forceRefresh): void
+    {
+        $now = new \DateTimeImmutable();
+        $this->status = FinancialReportSyncStatus::QUEUED;
+        $this->mode = $mode;
+        $this->nextRetryAt = null;
+        $this->updatedAt = $now;
+    }
+
     public function markLoading(FinancialReportSyncMode $mode): void
     {
         $now = new \DateTimeImmutable();

--- a/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusLookupInterface.php
+++ b/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusLookupInterface.php
@@ -5,10 +5,25 @@ declare(strict_types=1);
 namespace App\Marketplace\Repository;
 
 use App\Marketplace\Entity\MarketplaceFinancialReportSyncStatus;
+use App\Marketplace\Enum\FinancialReportSyncMode;
 use App\Marketplace\Enum\FinancialReportSyncStatus;
+use App\Marketplace\Enum\MarketplaceType;
 
 interface MarketplaceFinancialReportSyncStatusLookupInterface
 {
+
+    public function claimForQueue(
+        string $connectionId,
+        string $companyId,
+        MarketplaceType $marketplace,
+        string $reportType,
+        string $apiEndpoint,
+        \DateTimeImmutable $businessDate,
+        FinancialReportSyncMode $mode,
+        bool $forceRefresh,
+        \DateTimeImmutable $now,
+    ): ?MarketplaceFinancialReportSyncStatus;
+
     public function findByRawDocumentId(string $companyId, string $rawDocumentId): ?MarketplaceFinancialReportSyncStatus;
 
     public function findStatusEnumByDay(

--- a/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepository.php
+++ b/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepository.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace App\Marketplace\Repository;
 
 use App\Marketplace\Entity\MarketplaceFinancialReportSyncStatus;
+use App\Marketplace\Enum\FinancialReportSyncMode;
 use App\Marketplace\Enum\FinancialReportSyncStatus;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Exception\MarketplaceRateLimitException;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\DBAL\LockMode;
 use Doctrine\Persistence\ManagerRegistry;
 use Ramsey\Uuid\Uuid;
 use Webmozart\Assert\Assert;
@@ -166,6 +169,118 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
         }
 
         return $days;
+    }
+
+    public function claimForQueue(
+        string $connectionId,
+        string $companyId,
+        MarketplaceType $marketplace,
+        string $reportType,
+        string $apiEndpoint,
+        \DateTimeImmutable $businessDate,
+        FinancialReportSyncMode $mode,
+        bool $forceRefresh,
+        \DateTimeImmutable $now,
+    ): ?MarketplaceFinancialReportSyncStatus {
+        Assert::uuid($connectionId);
+        Assert::uuid($companyId);
+
+        $em = $this->getEntityManager();
+
+        try {
+            $em->beginTransaction();
+
+            $syncStatus = $this->createQueryBuilder('s')
+                ->where('s.connectionId = :connectionId')
+                ->andWhere('s.businessDate = :businessDate')
+                ->andWhere('s.reportType = :reportType')
+                ->setParameter('connectionId', $connectionId)
+                ->setParameter('businessDate', $businessDate)
+                ->setParameter('reportType', $reportType)
+                ->setMaxResults(1)
+                ->getQuery()
+                ->setLockMode(LockMode::PESSIMISTIC_WRITE)
+                ->getOneOrNullResult();
+
+            if (!$syncStatus instanceof MarketplaceFinancialReportSyncStatus) {
+                $syncStatus = new MarketplaceFinancialReportSyncStatus(
+                    Uuid::uuid7()->toString(),
+                    $companyId,
+                    $connectionId,
+                    $marketplace,
+                    $reportType,
+                    $apiEndpoint,
+                    $businessDate,
+                );
+
+                $em->persist($syncStatus);
+            } elseif (!$this->canClaimForQueue($syncStatus, $mode, $forceRefresh, $now)) {
+                $em->commit();
+
+                return null;
+            }
+
+            $syncStatus->markQueued($mode, $forceRefresh);
+            $em->persist($syncStatus);
+            $em->flush();
+            $em->commit();
+
+            return $syncStatus;
+        } catch (UniqueConstraintViolationException) {
+            if ($em->getConnection()->isTransactionActive()) {
+                $em->rollback();
+            }
+
+            return null;
+        } catch (\Throwable $e) {
+            if ($em->getConnection()->isTransactionActive()) {
+                $em->rollback();
+            }
+
+            throw $e;
+        }
+    }
+
+    private function canClaimForQueue(
+        MarketplaceFinancialReportSyncStatus $syncStatus,
+        FinancialReportSyncMode $mode,
+        bool $forceRefresh,
+        \DateTimeImmutable $now,
+    ): bool {
+        $status = $syncStatus->getStatus();
+
+        if (\in_array($status, [
+            FinancialReportSyncStatus::QUEUED,
+            FinancialReportSyncStatus::LOADING,
+            FinancialReportSyncStatus::RAW_LOADED,
+            FinancialReportSyncStatus::PROCESSING,
+        ], true)) {
+            return false;
+        }
+
+        if (FinancialReportSyncStatus::FAILED === $status
+            && null !== $syncStatus->getNextRetryAt()
+            && $syncStatus->getNextRetryAt() > $now
+        ) {
+            return false;
+        }
+
+        if (!$forceRefresh
+            && \in_array($mode, [FinancialReportSyncMode::DAILY, FinancialReportSyncMode::MISSING, FinancialReportSyncMode::INITIAL], true)
+            && \in_array($status, [FinancialReportSyncStatus::SUCCESS, FinancialReportSyncStatus::EMPTY], true)
+        ) {
+            return false;
+        }
+
+        if (\in_array($status, [
+            FinancialReportSyncStatus::AUTH_FAILED,
+            FinancialReportSyncStatus::FAILED_FINAL,
+            FinancialReportSyncStatus::CONFLICT,
+        ], true)) {
+            return $forceRefresh && FinancialReportSyncMode::MANUAL === $mode;
+        }
+
+        return true;
     }
 
 

--- a/site/tests/Integration/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepositoryTest.php
+++ b/site/tests/Integration/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepositoryTest.php
@@ -95,6 +95,120 @@ final class MarketplaceFinancialReportSyncStatusRepositoryTest extends Integrati
         );
     }
 
+
+    public function testClaimForQueueCreatesQueuedStatusForMissingDay(): void
+    {
+        $companyId = '11111111-1111-1111-1111-111111111111';
+        $connectionId = '22222222-2222-4222-8222-222222222222';
+        $this->seedActiveConnection($companyId, $connectionId);
+        $day = new \DateTimeImmutable('2026-01-01 00:00:00');
+
+        $status = $this->repository->claimForQueue(
+            $connectionId,
+            $companyId,
+            MarketplaceType::WILDBERRIES,
+            self::REPORT_TYPE,
+            'endpoint',
+            $day,
+            FinancialReportSyncMode::DAILY,
+            false,
+            new \DateTimeImmutable('2026-01-05 12:00:00'),
+        );
+
+        self::assertInstanceOf(MarketplaceFinancialReportSyncStatus::class, $status);
+        self::assertSame(FinancialReportSyncStatus::QUEUED, $status->getStatus());
+        self::assertSame(FinancialReportSyncMode::DAILY, $status->getMode());
+        self::assertNull($status->getNextRetryAt());
+    }
+
+    public function testClaimForQueueSkipsSuccessForDailyWithoutForceAndAllowsForce(): void
+    {
+        $companyId = '11111111-1111-1111-1111-111111111111';
+        $connectionId = '22222222-2222-4222-8222-222222222222';
+        $this->seedActiveConnection($companyId, $connectionId);
+        $day = new \DateTimeImmutable('2026-01-01 00:00:00');
+        $this->persistStatus($companyId, $connectionId, '2026-01-01', FinancialReportSyncStatus::SUCCESS);
+
+        self::assertNull($this->repository->claimForQueue(
+            $connectionId,
+            $companyId,
+            MarketplaceType::WILDBERRIES,
+            self::REPORT_TYPE,
+            'endpoint',
+            $day,
+            FinancialReportSyncMode::DAILY,
+            false,
+            new \DateTimeImmutable('2026-01-05 12:00:00'),
+        ));
+
+        $status = $this->repository->claimForQueue(
+            $connectionId,
+            $companyId,
+            MarketplaceType::WILDBERRIES,
+            self::REPORT_TYPE,
+            'endpoint',
+            $day,
+            FinancialReportSyncMode::DAILY,
+            true,
+            new \DateTimeImmutable('2026-01-05 12:00:00'),
+        );
+
+        self::assertInstanceOf(MarketplaceFinancialReportSyncStatus::class, $status);
+        self::assertSame(FinancialReportSyncStatus::QUEUED, $status->getStatus());
+    }
+
+    public function testClaimForQueueSkipsFutureRetryAndTerminalStatusesExceptManualForce(): void
+    {
+        $companyId = '11111111-1111-1111-1111-111111111111';
+        $retryConnectionId = '22222222-2222-4222-8222-222222222222';
+        $terminalConnectionId = '33333333-3333-4333-8333-333333333333';
+        $this->seedActiveConnection($companyId, $retryConnectionId);
+        $this->seedConnectionForExistingCompany($companyId, $terminalConnectionId);
+        $now = new \DateTimeImmutable('2026-01-05 12:00:00');
+
+        $this->persistStatus($companyId, $retryConnectionId, '2026-01-01', FinancialReportSyncStatus::FAILED, new \DateTimeImmutable('2026-01-05 13:00:00'));
+        $this->persistStatus($companyId, $terminalConnectionId, '2026-01-01', FinancialReportSyncStatus::AUTH_FAILED);
+
+        self::assertNull($this->repository->claimForQueue(
+            $retryConnectionId,
+            $companyId,
+            MarketplaceType::WILDBERRIES,
+            self::REPORT_TYPE,
+            'endpoint',
+            new \DateTimeImmutable('2026-01-01 00:00:00'),
+            FinancialReportSyncMode::MISSING,
+            false,
+            $now,
+        ));
+        self::assertNull($this->repository->claimForQueue(
+            $terminalConnectionId,
+            $companyId,
+            MarketplaceType::WILDBERRIES,
+            self::REPORT_TYPE,
+            'endpoint',
+            new \DateTimeImmutable('2026-01-01 00:00:00'),
+            FinancialReportSyncMode::DAILY,
+            true,
+            $now,
+        ));
+
+        $status = $this->repository->claimForQueue(
+            $terminalConnectionId,
+            $companyId,
+            MarketplaceType::WILDBERRIES,
+            self::REPORT_TYPE,
+            'endpoint',
+            new \DateTimeImmutable('2026-01-01 00:00:00'),
+            FinancialReportSyncMode::MANUAL,
+            true,
+            $now,
+        );
+
+        self::assertInstanceOf(MarketplaceFinancialReportSyncStatus::class, $status);
+        self::assertSame(FinancialReportSyncStatus::QUEUED, $status->getStatus());
+        self::assertSame(FinancialReportSyncMode::MANUAL, $status->getMode());
+    }
+
     private function persistStatus(
         string $companyId,
         string $connectionId,
@@ -119,11 +233,29 @@ final class MarketplaceFinancialReportSyncStatusRepositoryTest extends Integrati
             FinancialReportSyncStatus::LOADING => $entity->markLoading(FinancialReportSyncMode::DAILY),
             FinancialReportSyncStatus::PROCESSING => $entity->markProcessing(),
             FinancialReportSyncStatus::FAILED => $entity->markFailedRetryable('TestException', 'failed', 500, null, $nextRetryAt),
+            FinancialReportSyncStatus::AUTH_FAILED => $entity->markAuthFailed('TestException', 'auth failed', 401, null),
+            FinancialReportSyncStatus::FAILED_FINAL => $entity->markFailedFinal('TestException', 'failed final', 500, null),
+            FinancialReportSyncStatus::CONFLICT => $entity->markConflict('TestException', 'conflict', 409, null),
             default => null,
         };
 
         $this->repository->save($entity);
         $this->em->flush();
+    }
+
+
+    private function seedConnectionForExistingCompany(string $companyId, string $connectionId): void
+    {
+        $this->em->getConnection()->insert('marketplace_connections', [
+            'id' => $connectionId,
+            'company_id' => $companyId,
+            'marketplace' => 'wildberries',
+            'connection_type' => 'seller',
+            'api_key' => 'encrypted-key',
+            'is_active' => true,
+            'created_at' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
+            'updated_at' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
+        ]);
     }
 
     private function seedActiveConnection(string $companyId, string $connectionId): void
@@ -136,15 +268,6 @@ final class MarketplaceFinancialReportSyncStatusRepositoryTest extends Integrati
             $this->em->flush();
         }
 
-        $this->em->getConnection()->insert('marketplace_connections', [
-            'id' => $connectionId,
-            'company_id' => $companyId,
-            'marketplace' => 'wildberries',
-            'connection_type' => 'seller',
-            'api_key' => 'encrypted-key',
-            'is_active' => true,
-            'created_at' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
-            'updated_at' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
-        ]);
+        $this->seedConnectionForExistingCompany($companyId, $connectionId);
     }
 }

--- a/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
@@ -7,7 +7,9 @@ namespace App\Tests\Unit\Marketplace\Application\Service;
 use App\Marketplace\Application\Service\WbFinancialReportPeriodResolver;
 use App\Marketplace\Application\Service\WbFinancialReportSyncPlanner;
 use App\Marketplace\Entity\MarketplaceFinancialReportSyncStatus;
+use App\Marketplace\Enum\FinancialReportSyncMode;
 use App\Marketplace\Enum\FinancialReportSyncStatus;
+use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Infrastructure\Query\ActiveWbConnectionsQuery;
 use App\Marketplace\Message\SyncWbFinancialReportDayMessage;
 use App\Marketplace\Repository\MarketplaceFinancialReportSyncStatusLookupInterface;
@@ -40,6 +42,24 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
             }
 
             return new Envelope($message);
+        });
+        $this->statuses->method('claimForQueue')->willReturnCallback(function (
+            string $connectionId,
+            string $companyId,
+            MarketplaceType $marketplace,
+            string $reportType,
+            string $apiEndpoint,
+            \DateTimeImmutable $businessDate,
+            FinancialReportSyncMode $mode,
+            bool $forceRefresh,
+            \DateTimeImmutable $now,
+        ): MarketplaceFinancialReportSyncStatus {
+            return $this->statusEntity(
+                $businessDate->format('Y-m-d'),
+                FinancialReportSyncStatus::QUEUED,
+                null,
+                $now->format(DATE_ATOM),
+            );
         });
     }
 


### PR DESCRIPTION
### Motivation
- Сделать планирование и отправку задач синха WB атомарными, чтобы избежать гонок и дублирующих dispatch-ов при конкурентных планировщиках. 
- Вынести логику проверки текущего статуса и правил пропуска в единый claim-метод, чтобы упростить `WbFinancialReportSyncPlanner` и обеспечить корректный инкремент счётчика только для реально заявленных задач.

### Description
- Добавлен метод `markQueued(FinancialReportSyncMode $mode, bool $forceRefresh): void` в `MarketplaceFinancialReportSyncStatus` для установки `status = FinancialReportSyncStatus::QUEUED`, установки `mode`, сброса `nextRetryAt` и обновления `updatedAt` (поле для явного сохранения `forceRefresh` в сущности не добавлялось, поэтому флаг не сохраняется). 
- Добавлено определение `claimForQueue(...)` в `MarketplaceFinancialReportSyncStatusLookupInterface` и реализация в `MarketplaceFinancialReportSyncStatusRepository`, которая внутри транзакции выполняет поиск (с `PESSIMISTIC_WRITE`) или создание записи по уникальному ключу `connection_id + report_type + business_date`, применяет правила допуска и вызывает `markQueued(...)`, а при конфликте уникального индекса возвращает `null`. 
- Правила пропуска в `claimForQueue` включают пропуск свежих in-flight статусов (`QUEUED`, `LOADING`, `RAW_LOADED`, `PROCESSING`), пропуск `FAILED` с `nextRetryAt > now`, пропуск `SUCCESS`/`EMPTY` для режимов `daily`/`missing`/`initial` без `force`, и блокировку `AUTH_FAILED`/`FAILED_FINAL`/`CONFLICT`, кроме ручного `MANUAL`+`force`. 
- `WbFinancialReportSyncPlanner` заменён на «claim-before-dispatch»: `planForDays()`, `planRefresh14Days()` и `planMissing()` теперь вызывают `claimForQueue(...)` через `claimAndDispatch(...)` и выполняют `dispatch()` только при успешном `claim`, при этом счётчики `dispatched` увеличиваются только для реально claim-нутых записей. 
- Обновлены/добавлены тесты: unit-тест `WbFinancialReportSyncPlannerTest` подменяет `claimForQueue` в моках, а integration-тесты для `MarketplaceFinancialReportSyncStatusRepository` добавлены для проверки создания queued-статуса, поведения force и правил пропуска.

### Testing
- Запущены синтаксические проверки `php -l` для всех изменённых PHP-файлов и тестов (`site/src/...` и соответствующие тест-файлы), и они прошли без ошибок. 
- Добавлены интеграционные тесты в `site/tests/Integration/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepositoryTest.php` и обновлён unit-тест `site/tests/Unit/.../WbFinancialReportSyncPlannerTest.php`, при этом изменения прошли статическую проверку синтаксиса (`php -l`). 
- Попытка запуска `phpunit` на CI рабочем окружении была заблокирована из-за отсутствия скрипта `simple-phpunit.php` (Symfony PHPUnit Bridge), поэтому полное выполнение тестов не было выполнено in-repo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a190ec14568832391e3b779353f7391)