### PR TITLE
Support per-connection `--max-days` for initial WB financial report planning

### DIFF
--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlanner.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlanner.php
@@ -217,33 +217,50 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
         return $dispatched;
     }
 
-    public function planInitial(?string $companyId = null, ?string $connectionId = null, ?DateTimeImmutable $startFrom = null): int
+    public function planInitial(?string $companyId = null, ?string $connectionId = null, ?DateTimeImmutable $startFrom = null, int $maxDays = 1): int
     {
+        if ($maxDays <= 0) {
+            return 0;
+        }
+
         $start = $startFrom ?? $this->periodResolver->currentYearStart();
-        $days = $this->periodResolver->daysBetween($start, $this->periodResolver->yesterday());
 
         return $this->planForDays(
             $this->activeWbConnectionsQuery->execute($companyId, $connectionId),
-            $days,
+            $this->periodResolver->daysBetween($start, $this->periodResolver->yesterday()),
             FinancialReportSyncMode::INITIAL,
             false,
+            $maxDays,
         );
     }
 
     /** @param list<array{id: string, company_id: string, connection_id: string}> $connections
      * @param list<DateTimeImmutable> $days
      */
-    private function planForDays(array $connections, array $days, FinancialReportSyncMode $mode, bool $forceRefresh): int
+    private function planForDays(
+        array $connections,
+        array $days,
+        FinancialReportSyncMode $mode,
+        bool $forceRefresh,
+        ?int $maxDaysPerConnection = null,
+    ): int
     {
         $dispatched = 0;
 
         foreach ($connections as $connection) {
+            $scheduledForConnection = 0;
+
             foreach ($days as $day) {
+                if (null !== $maxDaysPerConnection && $scheduledForConnection >= $maxDaysPerConnection) {
+                    break;
+                }
+
                 if (!$this->claimAndDispatch($connection['company_id'], $connection['connection_id'], $day, $mode, $forceRefresh)) {
                     continue;
                 }
 
                 ++$dispatched;
+                ++$scheduledForConnection;
             }
         }
 

--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlannerInterface.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlannerInterface.php
@@ -24,5 +24,5 @@ interface WbFinancialReportSyncPlannerInterface
 
     public function planMissing(?string $companyId = null, ?string $connectionId = null, int $maxDays = 14): int;
 
-    public function planInitial(?string $companyId = null, ?string $connectionId = null, ?DateTimeImmutable $startFrom = null): int;
+    public function planInitial(?string $companyId = null, ?string $connectionId = null, ?DateTimeImmutable $startFrom = null, int $maxDays = 1): int;
 }

--- a/site/src/Marketplace/Command/WbFinancialReportsSyncCommand.php
+++ b/site/src/Marketplace/Command/WbFinancialReportsSyncCommand.php
@@ -45,7 +45,7 @@ final class WbFinancialReportsSyncCommand extends Command
             ->addOption('from', null, InputOption::VALUE_OPTIONAL, 'Начало диапазона (Y-m-d)')
             ->addOption('to', null, InputOption::VALUE_OPTIONAL, 'Конец диапазона (Y-m-d)')
             ->addOption('force', null, InputOption::VALUE_NONE)
-            ->addOption('max-days', null, InputOption::VALUE_OPTIONAL, 'Лимит задач refresh14/missing на connection', '1');
+            ->addOption('max-days', null, InputOption::VALUE_OPTIONAL, 'Лимит задач initial/refresh14/missing на connection', '1');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -131,7 +131,7 @@ final class WbFinancialReportsSyncCommand extends Command
                 : $this->planner->planDaily($companyId, $connectionId, $force),
             'initial' => null !== $from
                 ? $this->planner->planRange($from, $to ?? $from, FinancialReportSyncMode::INITIAL, $companyId, $connectionId, $force)
-                : $this->planner->planInitial($companyId, $connectionId),
+                : $this->planner->planInitial($companyId, $connectionId, null, $maxDays),
             'refresh14' => null !== $from
                 // Explicit --from/--to is treated as manual force refresh mode; --max-days applies only to automatic refresh14 planning.
                 ? $this->planner->planRange($from, $to ?? $from, FinancialReportSyncMode::REFRESH_14D, $companyId, $connectionId, true)

--- a/site/tests/Integration/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
+++ b/site/tests/Integration/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
@@ -247,7 +247,7 @@ final class WbFinancialReportSyncPlannerTest extends IntegrationTestCase
         $bus = new InMemoryMessageBus();
         $planner = $this->planner($bus, new \DateTimeImmutable('2026-01-05 12:00:00 Europe/Moscow'));
 
-        $count = $planner->planInitial($companyId, $connectionId, new \DateTimeImmutable('2026-01-02 00:00:00 Europe/Moscow'));
+        $count = $planner->planInitial($companyId, $connectionId, new \DateTimeImmutable('2026-01-02 00:00:00 Europe/Moscow'), 3);
 
         self::assertSame(3, $count);
         self::assertSame(['2026-01-02', '2026-01-03', '2026-01-04'], array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->businessDate, $bus->messages));

--- a/site/tests/Integration/Marketplace/WbFinancialReportSyncIdempotencyTest.php
+++ b/site/tests/Integration/Marketplace/WbFinancialReportSyncIdempotencyTest.php
@@ -68,8 +68,8 @@ final class WbFinancialReportSyncIdempotencyTest extends IntegrationTestCase
 
         $plannerBus = new InMemoryMessageBus();
         $planner = $this->planner(new \DateTimeImmutable('2026-05-05 12:00:00 Europe/Moscow'), $plannerBus);
-        $planned1 = $planner->planInitial($company->getId(), $connection->getId(), new \DateTimeImmutable('2026-05-02 00:00:00 Europe/Moscow'));
-        $planned2 = $planner->planInitial($company->getId(), $connection->getId(), new \DateTimeImmutable('2026-05-02 00:00:00 Europe/Moscow'));
+        $planned1 = $planner->planInitial($company->getId(), $connection->getId(), new \DateTimeImmutable('2026-05-02 00:00:00 Europe/Moscow'), 3);
+        $planned2 = $planner->planInitial($company->getId(), $connection->getId(), new \DateTimeImmutable('2026-05-02 00:00:00 Europe/Moscow'), 3);
         self::assertSame(3, $planned1);
         self::assertSame(3, $planned2);
 

--- a/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
@@ -30,6 +30,8 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
     /** @var list<SyncWbFinancialReportDayMessage> */
     private array $dispatchedMessages = [];
 
+    private \Closure $claimForQueueCallback;
+
     protected function setUp(): void
     {
         $this->connections = $this->createMock(ActiveWbConnectionsQuery::class);
@@ -43,7 +45,7 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
 
             return new Envelope($message);
         });
-        $this->statuses->method('claimForQueue')->willReturnCallback(function (
+        $this->claimForQueueCallback = function (
             string $connectionId,
             string $companyId,
             MarketplaceType $marketplace,
@@ -60,7 +62,10 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
                 null,
                 $now->format(DATE_ATOM),
             );
-        });
+        };
+        $this->statuses->method('claimForQueue')->willReturnCallback(
+            fn (...$args): ?MarketplaceFinancialReportSyncStatus => ($this->claimForQueueCallback)(...$args),
+        );
     }
 
     public function testPlanRefresh14DaysDispatchesAtMostOnePerConnection(): void
@@ -189,6 +194,46 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
         ]);
 
         self::assertSame(2, $planner->planRefresh14Days(null, null, 1));
+    }
+
+    public function testPlanInitialRespectsMaxDaysPerConnection(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1'), $this->conn('c2', 'co2')]);
+
+        self::assertSame(2, $planner->planInitial(null, null, new \DateTimeImmutable('2026-05-18 00:00:00 Europe/Moscow'), 1));
+        self::assertSame(['2026-05-18', '2026-05-18'], array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->businessDate, $this->dispatchedMessages));
+    }
+
+    public function testPlanInitialUsesClaimForQueueToSkipBlockedDays(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1')]);
+        $this->claimForQueueCallback = function (
+            string $connectionId,
+            string $companyId,
+            MarketplaceType $marketplace,
+            string $reportType,
+            string $apiEndpoint,
+            \DateTimeImmutable $businessDate,
+            FinancialReportSyncMode $mode,
+            bool $forceRefresh,
+            \DateTimeImmutable $now,
+        ): ?MarketplaceFinancialReportSyncStatus {
+            if ('2026-05-18' === $businessDate->format('Y-m-d')) {
+                return null;
+            }
+
+            return $this->statusEntity(
+                $businessDate->format('Y-m-d'),
+                FinancialReportSyncStatus::QUEUED,
+                null,
+                $now->format(DATE_ATOM),
+            );
+        };
+
+        self::assertSame(1, $planner->planInitial(null, null, new \DateTimeImmutable('2026-05-18 00:00:00 Europe/Moscow'), 1));
+        self::assertSame(['2026-05-19'], array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->businessDate, $this->dispatchedMessages));
     }
 
     public function testPlanMissingRespectsMaxDays(): void

--- a/site/tests/Unit/Marketplace/Command/WbFinancialReportsSyncCommandTest.php
+++ b/site/tests/Unit/Marketplace/Command/WbFinancialReportsSyncCommandTest.php
@@ -110,7 +110,7 @@ final class WbFinancialReportsSyncCommandTest extends TestCase
         $this->planner
             ->expects(self::once())
             ->method('planInitial')
-            ->with(null, null)
+            ->with(null, null, null, 1)
             ->willReturn(1);
         $this->planner
             ->expects(self::once())
@@ -164,6 +164,50 @@ final class WbFinancialReportsSyncCommandTest extends TestCase
 
         $tester = $this->tester();
         $code = $tester->execute(['--mode' => 'daily', '--date' => '2026-05-19']);
+
+        self::assertSame(Command::SUCCESS, $code);
+    }
+
+    public function testInitialAutomaticPassesMaxDays(): void
+    {
+        $this->planner
+            ->expects(self::once())
+            ->method('planInitial')
+            ->with(null, null, null, 3)
+            ->willReturn(3);
+
+        $this->planner->expects(self::never())->method('planRange');
+
+        $tester = $this->tester();
+        $code = $tester->execute(['--mode' => 'initial', '--max-days' => '3']);
+
+        self::assertSame(Command::SUCCESS, $code);
+    }
+
+    public function testInitialExplicitRangeUsesPlanRangeAndIgnoresMaxDaysLimit(): void
+    {
+        $this->planner
+            ->expects(self::once())
+            ->method('planRange')
+            ->with(
+                self::callback(static fn (\DateTimeImmutable $d): bool => '2026-05-18' === $d->format('Y-m-d')),
+                self::callback(static fn (\DateTimeImmutable $d): bool => '2026-05-20' === $d->format('Y-m-d')),
+                FinancialReportSyncMode::INITIAL,
+                null,
+                null,
+                false,
+            )
+            ->willReturn(3);
+
+        $this->planner->expects(self::never())->method('planInitial');
+
+        $tester = $this->tester();
+        $code = $tester->execute([
+            '--mode' => 'initial',
+            '--from' => '2026-05-18',
+            '--to' => '2026-05-20',
+            '--max-days' => '1',
+        ]);
 
         self::assertSame(Command::SUCCESS, $code);
     }


### PR DESCRIPTION
### Motivation

- Allow limiting the number of days scheduled per connection during the `initial` planning run to avoid enqueuing too many jobs at once and to reuse existing `--max-days` semantics used for other modes.

### Description

- Added a `maxDays` parameter to `planInitial` and propagated a `?int $maxDaysPerConnection` parameter to the internal `planForDays` to enforce a per-connection scheduling limit, and early-return when `maxDays <= 0` in `planInitial`.
- Adjusted `claimAndDispatch` usage so `planInitial` respects claim failures (skipped days) while still counting scheduled days toward the per-connection limit.
- Updated the `WbFinancialReportSyncPlannerInterface` signature and the CLI `WbFinancialReportsSyncCommand` to pass `--max-days` to `planInitial` for automatic runs and clarified the option help text to include `initial` in the description.
- Updated unit and integration tests to reflect the new parameter and behaviors, and refactored a test helper callback to allow conditional `claimForQueue` responses.

### Testing

- Ran unit tests, including new/updated tests `testPlanInitialRespectsMaxDaysPerConnection`, `testPlanInitialUsesClaimForQueueToSkipBlockedDays`, `testInitialAutomaticPassesMaxDays`, and `testInitialExplicitRangeUsesPlanRangeAndIgnoresMaxDaysLimit`, and they passed.
- Ran integration tests that reference `planInitial` behavior and idempotency and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a191174050883239eb8e705a6a5b7f7)