### PR TITLE
WB finance: add paginated day sync with durable cursor, local throttling and continuation messages

### DIFF
--- a/site/config/packages/messenger.yaml
+++ b/site/config/packages/messenger.yaml
@@ -21,7 +21,7 @@ framework:
                 dsn: '%env(MESSENGER_TRANSPORT_DSN_WB_FINANCE)%'
                 retry_strategy:
                     max_retries: 20
-                    delay: 61000
+                    delay: '%wb_finance.retry_delay_ms%'
                     multiplier: 1
 
             async_ads:

--- a/site/config/packages/rate_limiter.yaml
+++ b/site/config/packages/rate_limiter.yaml
@@ -15,9 +15,9 @@ framework:
 
         # WB Finance API: POST /api/finance/v1/sales-reports/detailed
         # Official WB limit: 1 request per 5 minutes per seller account.
-        # Use fixed_window with safety margin (we set the interval slightly
-        # higher than 5 min to absorb clock skew between our host and WB).
+        # Use fixed_window with a small safety margin to absorb clock skew
+        # between our host and WB; keep this in sync with services.yaml.
         wb_finance:
             policy: fixed_window
             limit: 1
-            interval: '70 seconds'
+            interval: '%wb_finance.rate_limit_interval%'

--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -8,6 +8,9 @@ parameters:
     app.storage_root: '%kernel.project_dir%/var/storage'
     app.encryption.key_file: '%env(string:APP_ENCRYPTION_KEY_FILE)%'
     app.encryption.current_key_version: '%env(string:APP_ENCRYPTION_CURRENT_KEY_VERSION)%'
+    wb_finance.rate_limit_interval: '310 seconds'
+    wb_finance.rate_limit_interval_seconds: 310
+    wb_finance.retry_delay_ms: 310000
 
 services:
     # default configuration for services in *this* file
@@ -57,6 +60,10 @@ services:
     App\Marketplace\Application\Service\WbFinanceRateLimiter:
         arguments:
             $factory: '@limiter.wb_finance'
+
+    App\Marketplace\MessageHandler\SyncWbFinancialReportDayHandler:
+        arguments:
+            $financeRetryDelaySeconds: '%wb_finance.rate_limit_interval_seconds%'
 
     App\Service\FeatureFlagService:
         arguments:

--- a/site/migrations/Version20260529120000.php
+++ b/site/migrations/Version20260529120000.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260529120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add durable WB finance pagination cursor to sync statuses';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE marketplace_financial_report_sync_statuses ADD staging_raw_document_id UUID DEFAULT NULL');
+        $this->addSql('ALTER TABLE marketplace_financial_report_sync_statuses ADD next_rrd_id INT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE marketplace_financial_report_sync_statuses DROP staging_raw_document_id');
+        $this->addSql('ALTER TABLE marketplace_financial_report_sync_statuses DROP next_rrd_id');
+    }
+}

--- a/site/src/Marketplace/Application/Service/WbFinanceRateLimiter.php
+++ b/site/src/Marketplace/Application/Service/WbFinanceRateLimiter.php
@@ -23,24 +23,22 @@ final class WbFinanceRateLimiter
 
     private LoggerInterface $logger;
 
-    public function wait(string $sellerRateLimitKey, int $tokens = 1): void
+    public function tryConsume(string $sellerRateLimitKey, int $tokens = 1): ?\DateTimeImmutable
     {
-        $limiter = $this->factory->create($sellerRateLimitKey);
-
-        while (true) {
-            $limit = $limiter->consume($tokens);
-            if ($limit->isAccepted()) {
-                return;
-            }
-
-            $retryAfter = $limit->getRetryAfter();
-            $waitSeconds = max(1, $retryAfter->getTimestamp() - $this->clock->now()->getTimestamp());
-            $this->logger->info('WB finance throttle wait.', [
-                'seller_token_hash_prefix' => $this->extractHashPrefix($sellerRateLimitKey),
-                'wait_seconds' => $waitSeconds,
-            ]);
-            $this->clock->sleep($waitSeconds);
+        $limit = $this->factory->create($sellerRateLimitKey)->consume($tokens);
+        if ($limit->isAccepted()) {
+            return null;
         }
+
+        $retryAfter = $limit->getRetryAfter();
+        $waitSeconds = max(1, $retryAfter->getTimestamp() - $this->clock->now()->getTimestamp());
+        $this->logger->info('WB finance throttle bucket busy.', [
+            'seller_token_hash_prefix' => $this->extractHashPrefix($sellerRateLimitKey),
+            'retry_after' => $retryAfter->format(\DateTimeInterface::ATOM),
+            'wait_seconds' => $waitSeconds,
+        ]);
+
+        return $retryAfter;
     }
 
     private function extractHashPrefix(string $sellerRateLimitKey): string

--- a/site/src/Marketplace/Application/Service/WbFinancialReportReconciliationService.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportReconciliationService.php
@@ -103,8 +103,49 @@ final class WbFinancialReportReconciliationService
         return $rawDocument;
     }
 
+    /**
+     * Starts or resumes a staging raw document for page-by-page WB finance loading.
+     * Caller is responsible for persist/flush of returned raw document.
+     *
+     * @param list<array<string,mixed>> $rows
+     */
+    public function appendRawDocumentPage(
+        Company $company,
+        MarketplaceConnection $connection,
+        \DateTimeImmutable $businessDate,
+        array $rows,
+        bool $forceRefresh,
+        ?string $rawDocumentId = null,
+    ): MarketplaceRawDocument {
+        $rawDocument = null !== $rawDocumentId
+            ? $this->rawDocumentRepository->find($rawDocumentId)
+            : null;
+
+        if (null !== $rawDocumentId && !$rawDocument instanceof MarketplaceRawDocument) {
+            throw new \InvalidArgumentException(sprintf('Raw document %s was not found for WB finance day sync continuation.', $rawDocumentId));
+        }
+
+        if ($rawDocument instanceof MarketplaceRawDocument) {
+            if ((string) $rawDocument->getCompany()->getId() !== (string) $company->getId()
+                || $rawDocument->getMarketplace() !== MarketplaceType::WILDBERRIES
+                || $rawDocument->getDocumentType() !== self::DOCUMENT_TYPE
+                || $rawDocument->getApiEndpoint() !== self::API_ENDPOINT
+                || $rawDocument->getPeriodFrom()->format('Y-m-d') !== $businessDate->format('Y-m-d')
+                || $rawDocument->getPeriodTo()->format('Y-m-d') !== $businessDate->format('Y-m-d')
+            ) {
+                throw new \InvalidArgumentException(sprintf('Raw document %s does not match WB finance day sync context.', $rawDocumentId));
+            }
+
+            $rawDocument->appendRawDataRows($rows);
+
+            return $rawDocument;
+        }
+
+        return $this->createOrRefreshRawDocument($company, $connection, $businessDate, $rows, $forceRefresh);
+    }
+
     private function isInFlight(MarketplaceRawDocument $document): bool
     {
-        return in_array($document->getProcessingStatus(), [PipelineStatus::PENDING, PipelineStatus::RUNNING], true);
+        return in_array($document->getProcessingStatus(), [PipelineStatus::LOADING, PipelineStatus::PENDING, PipelineStatus::RUNNING], true);
     }
 }

--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlanner.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlanner.php
@@ -76,8 +76,12 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
                     continue;
                 }
 
-                if (FinancialReportSyncStatus::FAILED === $status) {
+                if (\in_array($status, [FinancialReportSyncStatus::QUEUED, FinancialReportSyncStatus::FAILED], true)) {
                     if (null !== $statusEntity?->getNextRetryAt() && $statusEntity->getNextRetryAt() > $now) {
+                        continue;
+                    }
+
+                    if (FinancialReportSyncStatus::QUEUED === $status && null === $statusEntity?->getNextRetryAt()) {
                         continue;
                     }
 
@@ -285,12 +289,12 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
             return false;
         }
 
-        $this->dispatch($companyId, $connectionId, $day, $mode, $forceRefresh);
+        $this->dispatch($companyId, $connectionId, $day, $mode, $forceRefresh, $status->getNextRrdId() ?? 0, $status->getStagingRawDocumentId());
 
         return true;
     }
 
-    private function dispatch(string $companyId, string $connectionId, DateTimeImmutable $day, FinancialReportSyncMode $mode, bool $forceRefresh): void
+    private function dispatch(string $companyId, string $connectionId, DateTimeImmutable $day, FinancialReportSyncMode $mode, bool $forceRefresh, int $rrdId = 0, ?string $rawDocumentId = null): void
     {
         $this->messageBus->dispatch(new SyncWbFinancialReportDayMessage(
             $companyId,
@@ -298,6 +302,8 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
             $day->format('Y-m-d'),
             $mode->value,
             $forceRefresh,
+            $rrdId,
+            $rawDocumentId,
         ));
     }
 }

--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncStatusUpdater.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncStatusUpdater.php
@@ -7,7 +7,6 @@ namespace App\Marketplace\Application\Service;
 use App\Marketplace\Entity\MarketplaceFinancialReportSyncError;
 use App\Marketplace\Entity\MarketplaceFinancialReportSyncStatus;
 use App\Marketplace\Enum\FinancialReportSyncMode;
-use App\Marketplace\Enum\FinancialReportSyncStatus;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Repository\MarketplaceFinancialReportSyncErrorRepository;
 use App\Marketplace\Repository\MarketplaceFinancialReportSyncStatusRepository;
@@ -23,6 +22,15 @@ final readonly class WbFinancialReportSyncStatusUpdater implements WbFinancialRe
         private MarketplaceFinancialReportSyncErrorRepository $errorRepository,
         private LoggerInterface $logger,
     ) {}
+
+
+    public function findOrCreateForDay(string $connectionId, string $companyId, string $reportType, string $apiEndpoint, \DateTimeImmutable $businessDate): MarketplaceFinancialReportSyncStatus
+    {
+        $status = $this->statusRepository->findOrCreateForDay($connectionId, $companyId, MarketplaceType::WILDBERRIES, $reportType, $apiEndpoint, $businessDate);
+        $this->statusRepository->save($status);
+
+        return $status;
+    }
 
     public function startLoading(string $connectionId, string $companyId, string $reportType, string $apiEndpoint, \DateTimeImmutable $businessDate, FinancialReportSyncMode $mode): MarketplaceFinancialReportSyncStatus
     {
@@ -45,6 +53,27 @@ final readonly class WbFinancialReportSyncStatusUpdater implements WbFinancialRe
         $this->statusRepository->save($status);
     }
 
+    public function scheduleQueuedRetry(string $connectionId, string $companyId, string $reportType, string $apiEndpoint, \DateTimeImmutable $businessDate, FinancialReportSyncMode $mode, bool $forceRefresh, \DateTimeImmutable $nextRetryAt, ?string $stagingRawDocumentId = null, ?int $nextRrdId = null): MarketplaceFinancialReportSyncStatus
+    {
+        $status = $this->statusRepository->findOrCreateForDay($connectionId, $companyId, MarketplaceType::WILDBERRIES, $reportType, $apiEndpoint, $businessDate);
+        $this->markPageQueued($status, $mode, $forceRefresh, $nextRetryAt, $stagingRawDocumentId, $nextRrdId);
+
+        return $status;
+    }
+
+    public function markLoading(MarketplaceFinancialReportSyncStatus $status, FinancialReportSyncMode $mode): void
+    {
+        $status->markLoading($mode);
+        $this->statusRepository->save($status);
+    }
+
+    public function markPageQueued(MarketplaceFinancialReportSyncStatus $status, FinancialReportSyncMode $mode, bool $forceRefresh, \DateTimeImmutable $nextRetryAt, ?string $stagingRawDocumentId = null, ?int $nextRrdId = null): void
+    {
+        $status->markQueued($mode, $forceRefresh);
+        $status->scheduleNextRetryAt($nextRetryAt, $stagingRawDocumentId, $nextRrdId);
+        $this->statusRepository->save($status);
+    }
+
     public function markProcessing(MarketplaceFinancialReportSyncStatus $status): void
     {
         $status->markProcessing();
@@ -61,6 +90,24 @@ final readonly class WbFinancialReportSyncStatusUpdater implements WbFinancialRe
     public function markFailedRetryable(MarketplaceFinancialReportSyncStatus $status, string $errorClass, string $errorMessage, ?int $statusCode = null, ?string $responseExcerpt = null, ?array $requestPayload = null, ?\DateTimeImmutable $nextRetryAt = null): void
     {
         $status->markFailedRetryable($errorClass, $errorMessage, $statusCode, $responseExcerpt, $nextRetryAt);
+        $this->statusRepository->save($status);
+        $this->saveError($status, $errorClass, $errorMessage, $statusCode, $responseExcerpt, $requestPayload);
+    }
+
+
+    /** @param array<string,mixed>|null $requestPayload */
+    public function markFailedRetryablePreservingCursor(
+        MarketplaceFinancialReportSyncStatus $status,
+        string $errorClass,
+        string $errorMessage,
+        ?int $statusCode = null,
+        ?string $responseExcerpt = null,
+        ?array $requestPayload = null,
+        ?\DateTimeImmutable $nextRetryAt = null,
+        ?string $stagingRawDocumentId = null,
+        ?int $nextRrdId = null,
+    ): void {
+        $status->markFailedRetryablePreservingCursor($errorClass, $errorMessage, $statusCode, $responseExcerpt, $nextRetryAt, $stagingRawDocumentId, $nextRrdId);
         $this->statusRepository->save($status);
         $this->saveError($status, $errorClass, $errorMessage, $statusCode, $responseExcerpt, $requestPayload);
     }

--- a/site/src/Marketplace/Entity/MarketplaceFinancialReportSyncStatus.php
+++ b/site/src/Marketplace/Entity/MarketplaceFinancialReportSyncStatus.php
@@ -54,6 +54,12 @@ class MarketplaceFinancialReportSyncStatus
     #[ORM\Column(type: 'string', length: 128, nullable: true)]
     private ?string $rowsHash = null;
 
+    #[ORM\Column(type: 'guid', nullable: true)]
+    private ?string $stagingRawDocumentId = null;
+
+    #[ORM\Column(type: 'integer', nullable: true)]
+    private ?int $nextRrdId = null;
+
     #[ORM\Column(type: 'integer', options: ['default' => 0])]
     private int $attempts = 0;
 
@@ -133,6 +139,8 @@ class MarketplaceFinancialReportSyncStatus
     public function getRawDocumentId(): ?string { return $this->rawDocumentId; }
     public function getRecordsCount(): int { return $this->recordsCount; }
     public function getRowsHash(): ?string { return $this->rowsHash; }
+    public function getStagingRawDocumentId(): ?string { return $this->stagingRawDocumentId; }
+    public function getNextRrdId(): ?int { return $this->nextRrdId; }
     public function getAttempts(): int { return $this->attempts; }
     public function getLastAttemptAt(): ?\DateTimeImmutable { return $this->lastAttemptAt; }
     public function getNextRetryAt(): ?\DateTimeImmutable { return $this->nextRetryAt; }
@@ -156,14 +164,24 @@ class MarketplaceFinancialReportSyncStatus
         $this->updatedAt = $now;
     }
 
+    public function scheduleNextRetryAt(\DateTimeImmutable $nextRetryAt, ?string $stagingRawDocumentId = null, ?int $nextRrdId = null): void
+    {
+        $this->nextRetryAt = $nextRetryAt;
+        $this->stagingRawDocumentId = $stagingRawDocumentId;
+        $this->nextRrdId = $nextRrdId;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
     public function markLoading(FinancialReportSyncMode $mode): void
     {
         $now = new \DateTimeImmutable();
         $this->status = FinancialReportSyncStatus::LOADING;
         $this->mode = $mode;
         $this->recordsCount = 0;
-        $this->rawDocumentId = null;
-        $this->rowsHash = null;
+        if (null === $this->stagingRawDocumentId) {
+            $this->rawDocumentId = null;
+            $this->rowsHash = null;
+        }
         $this->attempts++;
         $this->lastAttemptAt = $now;
         $this->nextRetryAt = null;
@@ -180,6 +198,8 @@ class MarketplaceFinancialReportSyncStatus
         $this->recordsCount = 0;
         $this->lastEmptyAt = $now;
         $this->finishedAt = $now;
+        $this->stagingRawDocumentId = null;
+        $this->nextRrdId = null;
         $this->nextRetryAt = null;
         $this->clearLastError();
         $this->updatedAt = $now;
@@ -193,6 +213,8 @@ class MarketplaceFinancialReportSyncStatus
         $this->rawDocumentId = $rawDocumentId;
         $this->recordsCount = max(0, $recordsCount);
         $this->rowsHash = $rowsHash;
+        $this->stagingRawDocumentId = null;
+        $this->nextRrdId = null;
         $this->nextRetryAt = null;
         $this->clearLastError();
         $this->updatedAt = new \DateTimeImmutable();
@@ -211,6 +233,8 @@ class MarketplaceFinancialReportSyncStatus
         $this->status = FinancialReportSyncStatus::SUCCESS;
         $this->finishedAt = $now;
         $this->lastSuccessAt = $now;
+        $this->stagingRawDocumentId = null;
+        $this->nextRrdId = null;
         $this->nextRetryAt = null;
         $this->clearLastError();
         $this->updatedAt = $now;
@@ -219,6 +243,8 @@ class MarketplaceFinancialReportSyncStatus
     public function markFailedRetryable(string $errorClass, string $errorMessage, ?int $statusCode, ?string $responseExcerpt, ?\DateTimeImmutable $nextRetryAt): void
     {
         $this->status = FinancialReportSyncStatus::FAILED;
+        $this->stagingRawDocumentId = null;
+        $this->nextRrdId = null;
         $this->recordsCount = 0;
         $this->lastErrorClass = $errorClass;
         $this->lastErrorMessage = $errorMessage;
@@ -227,6 +253,20 @@ class MarketplaceFinancialReportSyncStatus
         $this->nextRetryAt = $nextRetryAt ?? new \DateTimeImmutable('+15 minutes');
         $this->finishedAt = null;
         $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function markFailedRetryablePreservingCursor(
+        string $errorClass,
+        string $errorMessage,
+        ?int $statusCode,
+        ?string $responseExcerpt,
+        ?\DateTimeImmutable $nextRetryAt,
+        ?string $stagingRawDocumentId,
+        ?int $nextRrdId,
+    ): void {
+        $this->markFailedRetryable($errorClass, $errorMessage, $statusCode, $responseExcerpt, $nextRetryAt);
+        $this->stagingRawDocumentId = $stagingRawDocumentId;
+        $this->nextRrdId = $nextRrdId;
     }
 
     public function markFailedFinal(string $errorClass, string $errorMessage, ?int $statusCode, ?string $responseExcerpt): void
@@ -248,6 +288,8 @@ class MarketplaceFinancialReportSyncStatus
     {
         $now = new \DateTimeImmutable();
         $this->status = $status;
+        $this->stagingRawDocumentId = null;
+        $this->nextRrdId = null;
         $this->recordsCount = 0;
         $this->lastErrorClass = $errorClass;
         $this->lastErrorMessage = $errorMessage;

--- a/site/src/Marketplace/Entity/MarketplaceRawDocument.php
+++ b/site/src/Marketplace/Entity/MarketplaceRawDocument.php
@@ -204,6 +204,20 @@ class MarketplaceRawDocument
         return $this;
     }
 
+    /** @param list<array<string,mixed>> $rows */
+    public function appendRawDataRows(array $rows): self
+    {
+        if ([] === $rows) {
+            return $this;
+        }
+
+        $this->rawData = [...$this->rawData, ...$rows];
+        $this->recordsCount = count($this->rawData);
+        $this->syncedAt = new \DateTimeImmutable();
+
+        return $this;
+    }
+
     public function getRecordsCreated(): int
     {
         return $this->recordsCreated;
@@ -353,6 +367,22 @@ class MarketplaceRawDocument
     {
         $this->processingStatus = PipelineStatus::COMPLETED;
         $this->processedAt      = new \DateTimeImmutable();
+
+        return $this;
+    }
+
+    public function markLoading(): self
+    {
+        $this->processingStatus = PipelineStatus::LOADING;
+        $this->processedAt = null;
+
+        return $this;
+    }
+
+    public function markFailed(): self
+    {
+        $this->processingStatus = PipelineStatus::FAILED;
+        $this->processedAt = new \DateTimeImmutable();
 
         return $this;
     }

--- a/site/src/Marketplace/Enum/PipelineStatus.php
+++ b/site/src/Marketplace/Enum/PipelineStatus.php
@@ -9,6 +9,7 @@ namespace App\Marketplace\Enum;
  */
 enum PipelineStatus: string
 {
+    case LOADING = 'loading';
     case PENDING = 'pending';
     case RUNNING = 'running';
     case COMPLETED = 'completed';
@@ -17,6 +18,7 @@ enum PipelineStatus: string
     public function getLabel(): string
     {
         return match ($this) {
+            self::LOADING => 'Загружается',
             self::PENDING => 'Ожидает',
             self::RUNNING => 'Выполняется',
             self::COMPLETED => 'Завершён',

--- a/site/src/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClient.php
+++ b/site/src/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClient.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace App\Marketplace\Infrastructure\Api\Wildberries;
 
+use App\Marketplace\Application\Service\WbFinanceRateLimiter;
 use App\Marketplace\Exception\MarketplaceAuthException;
 use App\Marketplace\Exception\MarketplaceBadRequestException;
 use App\Marketplace\Exception\MarketplaceInvalidApiResponseException;
 use App\Marketplace\Exception\MarketplaceRateLimitException;
-use App\Marketplace\Application\Service\WbFinanceRateLimiter;
 use App\Marketplace\Exception\MarketplaceTemporaryApiException;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -18,7 +18,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 final readonly class WbFinanceSalesReportClient
 {
     private const BASE_URL = 'https://finance-api.wildberries.ru';
-    private const PAGE_SIZE = 100000;
+    public const PAGE_SIZE = 100000;
     private const WB_HEADER_RETRY = 'x-ratelimit-retry';
     private const WB_HEADER_RESET = 'x-ratelimit-reset';
     private const SALES_REPORTS_RATE_LIMIT_KEY_PREFIX = 'wb_finance_sales_reports';
@@ -44,6 +44,13 @@ final readonly class WbFinanceSalesReportClient
         return $this->fetchDetailedInternal($apiKey, $date, $date);
     }
 
+    public function fetchDetailedDayPage(string $connectionId, string $apiKey, \DateTimeImmutable $businessDate, int $rrdId, bool $rateLimitTokenConsumed = false): WbFinanceSalesReportPage
+    {
+        $date = $businessDate->format('Y-m-d');
+
+        return $this->fetchDetailedPage($apiKey, $date, $date, $rrdId, self::PAGE_SIZE, $rateLimitTokenConsumed);
+    }
+
     /**
      * The $connectionId parameter is retained for caller context compatibility; throttling is per seller WB API token.
      *
@@ -52,6 +59,16 @@ final readonly class WbFinanceSalesReportClient
     public function fetchDetailedForConnection(string $connectionId, string $apiKey, string $dateFrom, string $dateTo): array
     {
         return $this->fetchDetailedInternal($apiKey, $dateFrom, $dateTo);
+    }
+
+    public function tryConsume(string $sellerRateLimitKey): ?\DateTimeImmutable
+    {
+        return $this->rateLimiter->tryConsume($sellerRateLimitKey);
+    }
+
+    public function buildSalesReportsRateLimitKeyForApiKey(string $apiKey): string
+    {
+        return $this->buildSalesReportsRateLimitKey(hash('sha256', $apiKey));
     }
 
     /**
@@ -69,93 +86,100 @@ final readonly class WbFinanceSalesReportClient
     {
         $rows = [];
         $rrdId = 0;
-        $tokenHash = hash('sha256', $apiKey);
-        $sellerRateLimitKey = $this->buildSalesReportsRateLimitKey($tokenHash);
 
-        while (true) {
-            $this->rateLimiter->wait($sellerRateLimitKey);
-            try {
-                $response = $this->httpClient->request('POST', self::BASE_URL.'/api/finance/v1/sales-reports/detailed', [
-                    'headers' => ['Authorization' => $apiKey],
-                    'json' => [
-                        'dateFrom' => $dateFrom,
-                        'dateTo' => $dateTo,
-                        'limit' => self::PAGE_SIZE,
-                        'rrdId' => $rrdId,
-                        'period' => 'daily',
-                    ],
-                    'timeout' => 120,
-                ]);
-                $statusCode = $response->getStatusCode();
-                $headers = $response->getHeaders(false);
-                $body = $response->getContent(false);
-            } catch (TransportExceptionInterface $e) {
-                throw new MarketplaceTemporaryApiException('WB API transport error.', 0, '', $dateFrom, $dateTo, $e);
-            }
+        do {
+            $page = $this->fetchDetailedPage($apiKey, $dateFrom, $dateTo, $rrdId, self::PAGE_SIZE);
+            $rows = [...$rows, ...$page->rows];
+            $rrdId = $page->nextRrdId ?? $rrdId;
+        } while ($page->hasNextPage);
 
-            $excerpt = $this->createSafeExcerpt($body);
+        return $rows;
+    }
 
-            if (204 === $statusCode) {
-                $this->logWbResponse($statusCode, $dateFrom, $dateTo, $rrdId, self::PAGE_SIZE, 0, $headers, $excerpt);
-                return $rows;
+    private function fetchDetailedPage(string $apiKey, string $dateFrom, string $dateTo, int $rrdId, int $limit, bool $rateLimitTokenConsumed = false): WbFinanceSalesReportPage
+    {
+        if (!$rateLimitTokenConsumed) {
+            $retryAfter = $this->rateLimiter->tryConsume($this->buildSalesReportsRateLimitKeyForApiKey($apiKey));
+            if (null !== $retryAfter) {
+                throw new MarketplaceRateLimitException(429, '', $dateFrom, $dateTo, $this->secondsUntil($retryAfter));
             }
-            $recordsReceived = null;
-
-            if (429 === $statusCode) {
-                throw new MarketplaceRateLimitException($statusCode, $excerpt, $dateFrom, $dateTo, $this->extractRetryAfter($headers));
-            }
-            if (401 === $statusCode || 403 === $statusCode) {
-                throw new MarketplaceAuthException('WB API authentication failed.', $statusCode, $excerpt, $dateFrom, $dateTo);
-            }
-            if (400 === $statusCode) {
-                throw new MarketplaceBadRequestException('WB API rejected request payload.', $statusCode, $excerpt, $dateFrom, $dateTo);
-            }
-            if ($statusCode >= 500 && $statusCode <= 599) {
-                throw new MarketplaceTemporaryApiException('WB API temporary error.', $statusCode, $excerpt, $dateFrom, $dateTo);
-            }
-            if (200 !== $statusCode) {
-                throw new MarketplaceTemporaryApiException('WB API unexpected status.', $statusCode, $excerpt, $dateFrom, $dateTo);
-            }
-            if ('' === trim($body)) {
-                throw new MarketplaceInvalidApiResponseException('WB API JSON must be a list.', $statusCode, $excerpt, $dateFrom, $dateTo);
-            }
-
-            try {
-                $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
-            } catch (\JsonException $e) {
-                throw new MarketplaceInvalidApiResponseException('WB API returned invalid JSON.', $statusCode, $excerpt, $dateFrom, $dateTo, $e);
-            }
-
-            if (!is_array($decoded) || !array_is_list($decoded)) {
-                throw new MarketplaceInvalidApiResponseException('WB API JSON must be a list.', $statusCode, $excerpt, $dateFrom, $dateTo);
-            }
-
-            foreach ($decoded as $row) {
-                if (!is_array($row)) {
-                    throw new MarketplaceInvalidApiResponseException('WB API JSON list items must be objects.', $statusCode, $excerpt, $dateFrom, $dateTo);
-                }
-            }
-            $recordsReceived = count($decoded);
-            $this->logWbResponse($statusCode, $dateFrom, $dateTo, $rrdId, self::PAGE_SIZE, $recordsReceived, $headers, $excerpt);
-
-            if ([] === $decoded) {
-                return $rows;
-            }
-
-            $rows = [...$rows, ...$decoded];
-            $last = end($decoded);
-            $newRrdId = is_array($last) ? (int) ($last['rrdId'] ?? 0) : 0;
-            if ($newRrdId <= $rrdId) {
-                throw new MarketplaceInvalidApiResponseException('WB API pagination rrdId must grow monotonically.', $statusCode, $excerpt, $dateFrom, $dateTo);
-            }
-
-            $rrdId = $newRrdId;
-
-            if (count($decoded) < self::PAGE_SIZE) {
-                return $rows;
-            }
-
         }
+
+        try {
+            $response = $this->httpClient->request('POST', self::BASE_URL.'/api/finance/v1/sales-reports/detailed', [
+                'headers' => ['Authorization' => $apiKey],
+                'json' => [
+                    'dateFrom' => $dateFrom,
+                    'dateTo' => $dateTo,
+                    'limit' => $limit,
+                    'rrdId' => $rrdId,
+                    'period' => 'daily',
+                ],
+                'timeout' => 120,
+            ]);
+            $statusCode = $response->getStatusCode();
+            $headers = $response->getHeaders(false);
+            $body = $response->getContent(false);
+        } catch (TransportExceptionInterface $e) {
+            throw new MarketplaceTemporaryApiException('WB API transport error.', 0, '', $dateFrom, $dateTo, $e);
+        }
+
+        $excerpt = $this->createSafeExcerpt($body);
+
+        if (204 === $statusCode) {
+            $this->logWbResponse($statusCode, $dateFrom, $dateTo, $rrdId, $limit, 0, $headers, $excerpt);
+            return new WbFinanceSalesReportPage([], null, false);
+        }
+
+        if (429 === $statusCode) {
+            throw new MarketplaceRateLimitException($statusCode, $excerpt, $dateFrom, $dateTo, $this->extractRetryAfter($headers));
+        }
+        if (401 === $statusCode || 403 === $statusCode) {
+            throw new MarketplaceAuthException('WB API authentication failed.', $statusCode, $excerpt, $dateFrom, $dateTo);
+        }
+        if (400 === $statusCode) {
+            throw new MarketplaceBadRequestException('WB API rejected request payload.', $statusCode, $excerpt, $dateFrom, $dateTo);
+        }
+        if ($statusCode >= 500 && $statusCode <= 599) {
+            throw new MarketplaceTemporaryApiException('WB API temporary error.', $statusCode, $excerpt, $dateFrom, $dateTo);
+        }
+        if (200 !== $statusCode) {
+            throw new MarketplaceTemporaryApiException('WB API unexpected status.', $statusCode, $excerpt, $dateFrom, $dateTo);
+        }
+        if ('' === trim($body)) {
+            throw new MarketplaceInvalidApiResponseException('WB API JSON must be a list.', $statusCode, $excerpt, $dateFrom, $dateTo);
+        }
+
+        try {
+            $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new MarketplaceInvalidApiResponseException('WB API returned invalid JSON.', $statusCode, $excerpt, $dateFrom, $dateTo, $e);
+        }
+
+        if (!is_array($decoded) || !array_is_list($decoded)) {
+            throw new MarketplaceInvalidApiResponseException('WB API JSON must be a list.', $statusCode, $excerpt, $dateFrom, $dateTo);
+        }
+
+        foreach ($decoded as $row) {
+            if (!is_array($row)) {
+                throw new MarketplaceInvalidApiResponseException('WB API JSON list items must be objects.', $statusCode, $excerpt, $dateFrom, $dateTo);
+            }
+        }
+
+        $recordsReceived = count($decoded);
+        $this->logWbResponse($statusCode, $dateFrom, $dateTo, $rrdId, $limit, $recordsReceived, $headers, $excerpt);
+
+        if ([] === $decoded) {
+            return new WbFinanceSalesReportPage([], null, false);
+        }
+
+        $last = end($decoded);
+        $nextRrdId = is_array($last) ? (int) ($last['rrdId'] ?? 0) : 0;
+        if ($nextRrdId <= $rrdId) {
+            throw new MarketplaceInvalidApiResponseException('WB API pagination rrdId must grow monotonically.', $statusCode, $excerpt, $dateFrom, $dateTo);
+        }
+
+        return new WbFinanceSalesReportPage($decoded, $nextRrdId, $recordsReceived >= $limit);
     }
 
 
@@ -229,8 +253,10 @@ final readonly class WbFinanceSalesReportClient
 
     public function hasAnyDataForConnection(string $connectionId, string $apiKey, string $dateFrom, string $dateTo): bool
     {
-        $tokenHash = hash('sha256', $apiKey);
-        $this->rateLimiter->wait($this->buildSalesReportsRateLimitKey($tokenHash));
+        $retryAfter = $this->rateLimiter->tryConsume($this->buildSalesReportsRateLimitKeyForApiKey($apiKey));
+        if (null !== $retryAfter) {
+            throw new MarketplaceRateLimitException(429, '', $dateFrom, $dateTo, $this->secondsUntil($retryAfter));
+        }
 
         return $this->hasAnyData($apiKey, $dateFrom, $dateTo);
     }
@@ -293,6 +319,11 @@ final readonly class WbFinanceSalesReportClient
         }
 
         return [] !== $decoded;
+    }
+
+    private function secondsUntil(\DateTimeImmutable $retryAfter): int
+    {
+        return max(1, $retryAfter->getTimestamp() - (new \DateTimeImmutable())->getTimestamp());
     }
 
     private function buildSalesReportsRateLimitKey(string $tokenHash): string

--- a/site/src/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportPage.php
+++ b/site/src/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportPage.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Api\Wildberries;
+
+/** @param list<array<string,mixed>> $rows */
+final readonly class WbFinanceSalesReportPage
+{
+    public function __construct(
+        public array $rows,
+        public ?int $nextRrdId,
+        public bool $hasNextPage,
+    ) {}
+}

--- a/site/src/Marketplace/Message/SyncWbFinancialReportDayMessage.php
+++ b/site/src/Marketplace/Message/SyncWbFinancialReportDayMessage.php
@@ -12,5 +12,7 @@ final readonly class SyncWbFinancialReportDayMessage
         public string $businessDate,
         public string $mode,
         public bool $forceRefresh,
+        public int $rrdId = 0,
+        public ?string $rawDocumentId = null,
     ) {}
 }

--- a/site/src/Marketplace/MessageHandler/SyncWbFinancialReportDayHandler.php
+++ b/site/src/Marketplace/MessageHandler/SyncWbFinancialReportDayHandler.php
@@ -9,6 +9,7 @@ use App\Marketplace\Application\Service\WbFinancialReportPeriodResolver;
 use App\Marketplace\Application\Service\WbFinancialReportReconciliationService;
 use App\Marketplace\Application\Service\WbFinancialReportSyncStatusUpdater;
 use App\Marketplace\Enum\FinancialReportSyncMode;
+use App\Marketplace\Enum\FinancialReportSyncStatus;
 use App\Marketplace\Enum\MarketplaceConnectionType;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Exception\MarketplaceAuthException;
@@ -17,17 +18,20 @@ use App\Marketplace\Exception\MarketplaceInvalidApiResponseException;
 use App\Marketplace\Exception\MarketplaceRateLimitException;
 use App\Marketplace\Exception\MarketplaceTemporaryApiException;
 use App\Marketplace\Exception\WbRawDocumentRefreshConflictException;
+use App\Marketplace\Entity\MarketplaceRawDocument;
 use App\Marketplace\Infrastructure\Api\Wildberries\WbFinanceSalesReportClient;
 use App\Marketplace\Message\ProcessDayReportMessage;
 use App\Marketplace\Message\SyncWbFinancialReportDayMessage;
 use App\Marketplace\Repository\MarketplaceConnectionRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
 
 #[AsMessageHandler]
 final class SyncWbFinancialReportDayHandler
@@ -46,6 +50,8 @@ final class SyncWbFinancialReportDayHandler
         private readonly LockFactory $lockFactory,
         private readonly MessageBusInterface $messageBus,
         private readonly LoggerInterface $logger,
+        private readonly ClockInterface $clock,
+        private readonly int $financeRetryDelaySeconds,
     ) {}
 
     public function __invoke(SyncWbFinancialReportDayMessage $message): void
@@ -115,12 +121,92 @@ final class SyncWbFinancialReportDayHandler
             return;
         }
 
-        $status = $this->syncStatusUpdater->startLoading($connection->getId(), $message->companyId, self::REPORT_TYPE, self::API_ENDPOINT, $businessDate, $mode);
+        $status = $this->syncStatusUpdater->findOrCreateForDay($connection->getId(), $message->companyId, self::REPORT_TYPE, self::API_ENDPOINT, $businessDate);
+        if (
+            null !== $message->rawDocumentId
+            && ($status->getStagingRawDocumentId() !== $message->rawDocumentId || $status->getNextRrdId() !== $message->rrdId)
+        ) {
+            $this->logger->info('WB day sync skipped stale continuation message.', [
+                'company_id' => $message->companyId,
+                'connection_id' => $message->connectionId,
+                'business_date' => $businessDate->format('Y-m-d'),
+                'mode' => $mode->value,
+                'message_rrd_id' => $message->rrdId,
+                'message_raw_document_id' => $message->rawDocumentId,
+                'status_rrd_id' => $status->getNextRrdId(),
+                'status_raw_document_id' => $status->getStagingRawDocumentId(),
+                'status' => $status->getStatus()->value,
+            ]);
+
+            return;
+        }
+
+        $effectiveRrdId = $status->getNextRrdId() ?? $message->rrdId;
+        $effectiveRawDocumentId = $status->getStagingRawDocumentId() ?? $message->rawDocumentId;
+
+        if (\in_array($status->getStatus(), [FinancialReportSyncStatus::QUEUED, FinancialReportSyncStatus::FAILED], true)
+            && null !== $status->getNextRetryAt()
+            && $status->getNextRetryAt() > $this->clock->now()
+        ) {
+            $this->dispatchContinuation(new SyncWbFinancialReportDayMessage(
+                $message->companyId,
+                $message->connectionId,
+                $message->businessDate,
+                $message->mode,
+                $message->forceRefresh,
+                $effectiveRrdId,
+                $effectiveRawDocumentId,
+            ), $status->getNextRetryAt());
+
+            $this->logger->info('WB day sync postponed until persisted next retry time.', [
+                'company_id' => $message->companyId,
+                'connection_id' => $message->connectionId,
+                'business_date' => $businessDate->format('Y-m-d'),
+                'mode' => $mode->value,
+                'rrd_id' => $effectiveRrdId,
+                'raw_document_id' => $effectiveRawDocumentId,
+                'next_retry_at' => $status->getNextRetryAt()->format(\DateTimeInterface::ATOM),
+                'status' => $status->getStatus()->value,
+            ]);
+
+            return;
+        }
+
+        $apiKey = $connection->getApiKey();
+        $sellerRateLimitKey = $this->financeSalesReportClient->buildSalesReportsRateLimitKeyForApiKey($apiKey);
+        $retryAfter = $this->financeSalesReportClient->tryConsume($sellerRateLimitKey);
+        if (null !== $retryAfter) {
+            $this->syncStatusUpdater->markPageQueued($status, $mode, $message->forceRefresh, $retryAfter, $effectiveRawDocumentId, $effectiveRrdId);
+            $this->em->flush();
+            $this->dispatchContinuation(new SyncWbFinancialReportDayMessage(
+                $message->companyId,
+                $message->connectionId,
+                $message->businessDate,
+                $message->mode,
+                $message->forceRefresh,
+                $effectiveRrdId,
+                $effectiveRawDocumentId,
+            ), $retryAfter);
+
+            $this->logger->info('WB day sync postponed by local throttle before API request.', [
+                'company_id' => $message->companyId,
+                'connection_id' => $message->connectionId,
+                'business_date' => $businessDate->format('Y-m-d'),
+                'mode' => $mode->value,
+                'rrd_id' => $effectiveRrdId,
+                'raw_document_id' => $effectiveRawDocumentId,
+                'next_retry_at' => $retryAfter->format(\DateTimeInterface::ATOM),
+            ]);
+
+            return;
+        }
+
+        $this->syncStatusUpdater->markLoading($status, $mode);
 
         try {
-            $rows = $this->financeSalesReportClient->fetchDetailedDay($connection->getId(), $connection->getApiKey(), $businessDate);
+            $page = $this->financeSalesReportClient->fetchDetailedDayPage($connection->getId(), $apiKey, $businessDate, $effectiveRrdId, true);
 
-            if ([] === $rows) {
+            if ([] === $page->rows && null === $effectiveRawDocumentId) {
                 $this->syncStatusUpdater->markEmpty($status);
                 $connection->markSyncSuccess();
                 $this->em->flush();
@@ -136,21 +222,54 @@ final class SyncWbFinancialReportDayHandler
                 return;
             }
 
-            $rawDocument = $this->reconciliationService->createOrRefreshRawDocument(
+            $rawDocument = $this->reconciliationService->appendRawDocumentPage(
                 $company,
                 $connection,
                 $businessDate,
-                $rows,
+                $page->rows,
                 $message->forceRefresh,
+                $effectiveRawDocumentId,
             );
 
             $this->em->persist($rawDocument);
-            $this->em->flush();
 
+            if ($page->hasNextPage) {
+                $nextRetryAt = $this->retryAfterFromNow($this->financeRetryDelaySeconds);
+                $nextRrdId = $page->nextRrdId ?? $effectiveRrdId;
+                $rawDocument->markLoading();
+                $this->syncStatusUpdater->markPageQueued($status, $mode, $message->forceRefresh, $nextRetryAt, $rawDocument->getId(), $nextRrdId);
+                $this->em->flush();
+
+                $this->dispatchContinuation(new SyncWbFinancialReportDayMessage(
+                    $message->companyId,
+                    $message->connectionId,
+                    $message->businessDate,
+                    $message->mode,
+                    $message->forceRefresh,
+                    $nextRrdId,
+                    $rawDocument->getId(),
+                ), $nextRetryAt);
+
+                $this->logger->info('WB day sync page loaded, next page scheduled.', [
+                    'company_id' => $message->companyId,
+                    'connection_id' => $message->connectionId,
+                    'business_date' => $businessDate->format('Y-m-d'),
+                    'mode' => $mode->value,
+                    'records_count' => $rawDocument->getRecordsCount(),
+                    'raw_document_id' => $rawDocument->getId(),
+                    'next_rrd_id' => $page->nextRrdId,
+                    'next_retry_at' => $nextRetryAt->format(\DateTimeInterface::ATOM),
+                ]);
+
+                return;
+            }
+
+            $rawDocument->resetProcessingStatus();
+            $rows = $rawDocument->getRawData();
             $this->syncStatusUpdater->markRawLoaded(
                 $status,
                 $rawDocument->getId(),
-                count($rows),
+                $rawDocument->getRecordsCount(),
                 hash('sha256', json_encode($rows, JSON_THROW_ON_ERROR)),
             );
             $this->syncStatusUpdater->markProcessing($status);
@@ -164,29 +283,49 @@ final class SyncWbFinancialReportDayHandler
                 'connection_id' => $message->connectionId,
                 'business_date' => $businessDate->format('Y-m-d'),
                 'mode' => $mode->value,
-                'records_count' => count($rows),
+                'records_count' => $rawDocument->getRecordsCount(),
                 'raw_document_id' => $rawDocument->getId(),
             ]);
         } catch (MarketplaceRateLimitException $e) {
-            $nextRetryAt = null;
-            if (null !== $e->getRetryAfter()) {
-                $nextRetryAt = (new \DateTimeImmutable())->modify(sprintf('+%d seconds', max(1, $e->getRetryAfter())));
-            }
+            $nextRetryAt = null !== $e->getRetryAfter()
+                ? $this->retryAfterFromNow(max(1, $e->getRetryAfter()))
+                : $this->retryAfterFromNow(15 * 60);
 
-            $this->syncStatusUpdater->markFailedRetryable($status, $e::class, $e->getMessage(), $e->getStatusCode(), $e->getResponseExcerpt(), null, $nextRetryAt);
-            $connection->markSyncFailed($e->getMessage());
+            $this->syncStatusUpdater->markFailedRetryablePreservingCursor(
+                $status,
+                $e::class,
+                $e->getMessage(),
+                $e->getStatusCode(),
+                $e->getResponseExcerpt(),
+                null,
+                $nextRetryAt,
+                $effectiveRawDocumentId,
+                $effectiveRrdId,
+            );
             $this->em->flush();
+            $this->dispatchContinuation(new SyncWbFinancialReportDayMessage(
+                $message->companyId,
+                $message->connectionId,
+                $message->businessDate,
+                $message->mode,
+                $message->forceRefresh,
+                $effectiveRrdId,
+                $effectiveRawDocumentId,
+            ), $nextRetryAt);
 
             $this->logger->warning('WB day sync rate-limited, retry scheduled.', [
                 'company_id' => $message->companyId,
                 'connection_id' => $message->connectionId,
                 'business_date' => $businessDate->format('Y-m-d'),
                 'mode' => $mode->value,
+                'rrd_id' => $effectiveRrdId,
+                'raw_document_id' => $effectiveRawDocumentId,
+                'next_retry_at' => $nextRetryAt->format(\DateTimeInterface::ATOM),
             ]);
 
-            // Do not rethrow rate-limit errors: retry is controlled by sync_statuses.next_retry_at and the missing planner.
             return;
         } catch (MarketplaceAuthException $e) {
+            $this->markStagingRawDocumentFailed($status->getStagingRawDocumentId() ?? $effectiveRawDocumentId);
             $this->syncStatusUpdater->markAuthFailed($status, $e::class, $e->getMessage(), $e->getStatusCode(), $e->getResponseExcerpt());
             $connection->markSyncFailed($e->getMessage());
             $this->em->flush();
@@ -200,7 +339,17 @@ final class SyncWbFinancialReportDayHandler
 
             throw new UnrecoverableMessageHandlingException($e->getMessage(), 0, $e);
         } catch (MarketplaceTemporaryApiException $e) {
-            $this->syncStatusUpdater->markFailedRetryable($status, $e::class, $e->getMessage(), $e->getStatusCode(), $e->getResponseExcerpt());
+            $this->syncStatusUpdater->markFailedRetryablePreservingCursor(
+                $status,
+                $e::class,
+                $e->getMessage(),
+                $e->getStatusCode(),
+                $e->getResponseExcerpt(),
+                null,
+                $this->retryAfterFromNow(15 * 60),
+                $effectiveRawDocumentId,
+                $effectiveRrdId,
+            );
             $connection->markSyncFailed($e->getMessage());
             $this->em->flush();
             $this->logger->warning('WB day sync temporary API failure.', [
@@ -211,7 +360,8 @@ final class SyncWbFinancialReportDayHandler
             ]);
 
             throw new RecoverableMessageHandlingException($e->getMessage(), 0, $e);
-        } catch (WbRawDocumentRefreshConflictException $e) {
+        } catch (WbRawDocumentRefreshConflictException|\InvalidArgumentException $e) {
+            $this->markStagingRawDocumentFailed($status->getStagingRawDocumentId() ?? $effectiveRawDocumentId);
             $this->syncStatusUpdater->markConflict($status, $e::class, $e->getMessage(), null, null);
             $connection->markSyncFailed($e->getMessage());
             $this->em->flush();
@@ -224,6 +374,7 @@ final class SyncWbFinancialReportDayHandler
 
             throw new UnrecoverableMessageHandlingException($e->getMessage(), 0, $e);
         } catch (MarketplaceBadRequestException|MarketplaceInvalidApiResponseException $e) {
+            $this->markStagingRawDocumentFailed($status->getStagingRawDocumentId() ?? $effectiveRawDocumentId);
             $this->syncStatusUpdater->markFailedFinal($status, $e::class, $e->getMessage(), $e->getStatusCode(), $e->getResponseExcerpt());
             $connection->markSyncFailed($e->getMessage());
             $this->em->flush();
@@ -236,5 +387,31 @@ final class SyncWbFinancialReportDayHandler
 
             throw new UnrecoverableMessageHandlingException($e->getMessage(), 0, $e);
         }
+    }
+
+    private function dispatchContinuation(SyncWbFinancialReportDayMessage $message, \DateTimeImmutable $retryAfter): void
+    {
+        $delayMs = max(0, ($retryAfter->getTimestamp() - $this->clock->now()->getTimestamp()) * 1000);
+        $this->messageBus->dispatch($message, [new DelayStamp($delayMs)]);
+    }
+
+    private function retryAfterFromNow(int $seconds): \DateTimeImmutable
+    {
+        return $this->clock->now()->modify(sprintf('+%d seconds', max(1, $seconds)));
+    }
+
+    private function markStagingRawDocumentFailed(?string $rawDocumentId): void
+    {
+        if (null === $rawDocumentId) {
+            return;
+        }
+
+        $rawDocument = $this->em->find(MarketplaceRawDocument::class, $rawDocumentId);
+        if (!$rawDocument instanceof MarketplaceRawDocument) {
+            return;
+        }
+
+        $rawDocument->markFailed();
+        $this->em->persist($rawDocument);
     }
 }

--- a/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepository.php
+++ b/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepository.php
@@ -142,15 +142,17 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
             ->andWhere('s.connectionId = :connectionId')
             ->andWhere('s.reportType = :reportType')
             ->andWhere('s.businessDate BETWEEN :from AND :to')
-            ->andWhere('s.status = :failedStatus')
-            ->andWhere('(s.nextRetryAt IS NULL OR s.nextRetryAt <= :now)')
-            ->andWhere('s.lastErrorStatusCode = :rateLimitStatusCode')
-            ->andWhere('s.lastErrorClass = :rateLimitErrorClass')
+            ->andWhere('(
+                (s.status = :queuedStatus AND s.nextRetryAt IS NOT NULL AND s.nextRetryAt <= :now)
+                OR (s.status = :failedStatus AND s.nextRetryAt IS NOT NULL AND s.nextRetryAt <= :now)
+                OR (s.status = :failedStatus AND s.nextRetryAt IS NULL AND s.lastErrorStatusCode = :rateLimitStatusCode AND s.lastErrorClass = :rateLimitErrorClass)
+            )')
             ->setParameter('companyId', $companyId)
             ->setParameter('connectionId', $connectionId)
             ->setParameter('reportType', $reportType)
             ->setParameter('from', $from)
             ->setParameter('to', $to)
+            ->setParameter('queuedStatus', FinancialReportSyncStatus::QUEUED)
             ->setParameter('failedStatus', FinancialReportSyncStatus::FAILED)
             ->setParameter('now', $now)
             ->setParameter('rateLimitStatusCode', 429)
@@ -250,7 +252,6 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
         $status = $syncStatus->getStatus();
 
         if (\in_array($status, [
-            FinancialReportSyncStatus::QUEUED,
             FinancialReportSyncStatus::LOADING,
             FinancialReportSyncStatus::RAW_LOADED,
             FinancialReportSyncStatus::PROCESSING,
@@ -258,11 +259,15 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
             return false;
         }
 
-        if (FinancialReportSyncStatus::FAILED === $status
+        if (\in_array($status, [FinancialReportSyncStatus::QUEUED, FinancialReportSyncStatus::FAILED], true)
             && null !== $syncStatus->getNextRetryAt()
             && $syncStatus->getNextRetryAt() > $now
         ) {
             return false;
+        }
+
+        if (FinancialReportSyncStatus::QUEUED === $status) {
+            return null !== $syncStatus->getNextRetryAt() && $syncStatus->getNextRetryAt() <= $now;
         }
 
         if (!$forceRefresh

--- a/site/src/Marketplace/Repository/MarketplaceRawDocumentRepository.php
+++ b/site/src/Marketplace/Repository/MarketplaceRawDocumentRepository.php
@@ -339,11 +339,13 @@ class MarketplaceRawDocumentRepository extends ServiceEntityRepository
             ->andWhere('d.documentType = :documentType')
             ->andWhere('d.periodFrom >= :firstDay')
             ->andWhere('d.periodTo <= :lastDay')
+            ->andWhere('(d.processingStatus IS NULL OR d.processingStatus != :loading)')
             ->setParameter('companyId', $companyId)
             ->setParameter('marketplace', $marketplace)
             ->setParameter('documentType', 'sales_report')
             ->setParameter('firstDay', $firstDay)
             ->setParameter('lastDay', $lastDay)
+            ->setParameter('loading', PipelineStatus::LOADING)
             ->orderBy('d.periodFrom', 'ASC')
             ->getQuery()
             ->getResult();

--- a/site/tests/Integration/Marketplace/MessageHandler/SyncWbFinancialReportDayHandlerTest.php
+++ b/site/tests/Integration/Marketplace/MessageHandler/SyncWbFinancialReportDayHandlerTest.php
@@ -265,6 +265,168 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
         self::assertNull($this->findStatus($wbPerformance->getId(), $company->getId(), '2026-05-19'));
     }
 
+    public function testLocalRateLimitPostponesWithoutCallingWbApi(): void
+    {
+        $company = $this->createCompany(9214);
+        $connection = $this->createWbSellerConnection($company, 9214);
+        $requestCount = 0;
+        $client = new WbFinanceSalesReportClient(
+            new MockHttpClient(static function () use (&$requestCount): MockResponse {
+                ++$requestCount;
+
+                return new MockResponse('[]', ['http_code' => 200]);
+            }),
+            $this->createRateLimiter(),
+        );
+        self::assertNull($client->tryConsume($client->buildSalesReportsRateLimitKeyForApiKey($connection->getApiKey())));
+        self::getContainer()->set(WbFinanceSalesReportClient::class, $client);
+
+        $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
+        $handler($this->message($company->getId(), $connection->getId(), false));
+
+        self::assertSame(0, $requestCount);
+        $status = $this->findStatus($connection->getId(), $company->getId(), '2026-05-19');
+        self::assertNotNull($status);
+        self::assertSame(FinancialReportSyncStatus::QUEUED, $status->getStatus());
+        self::assertNotNull($status->getNextRetryAt());
+    }
+
+
+    public function testStaleContinuationIsSkippedWithoutCallingWbApi(): void
+    {
+        $company = $this->createCompany(9215);
+        $connection = $this->createWbSellerConnection($company, 9215);
+        $stagingRawDocumentId = 'bbbbbbbb-bbbb-4bbb-8bbb-000000009215';
+        $status = new MarketplaceFinancialReportSyncStatus(
+            'cccccccc-cccc-4ccc-8ccc-000000009215',
+            $company->getId(),
+            $connection->getId(),
+            MarketplaceType::WILDBERRIES,
+            'sales_report',
+            'wildberries::finance-sales-reports-detailed',
+            new \DateTimeImmutable('2026-05-19'),
+        );
+        $status->markQueued(FinancialReportSyncMode::MANUAL, false);
+        $status->scheduleNextRetryAt(new \DateTimeImmutable('2026-05-19T12:00:00Z'), $stagingRawDocumentId, 20);
+        $this->em->persist($status);
+        $this->em->flush();
+
+        $requestCount = 0;
+        self::getContainer()->set(WbFinanceSalesReportClient::class, new WbFinanceSalesReportClient(
+            new MockHttpClient(static function () use (&$requestCount): MockResponse {
+                ++$requestCount;
+
+                return new MockResponse('[]', ['http_code' => 200]);
+            }),
+            $this->createRateLimiter(),
+        ));
+
+        $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
+        $handler(new SyncWbFinancialReportDayMessage($company->getId(), $connection->getId(), '2026-05-19', FinancialReportSyncMode::MANUAL->value, false, 10, $stagingRawDocumentId));
+
+        self::assertSame(0, $requestCount);
+    }
+
+    public function testDuplicateContinuationAfterFinalPageIsSkippedWithoutCallingWbApi(): void
+    {
+        $company = $this->createCompany(9216);
+        $connection = $this->createWbSellerConnection($company, 9216);
+        $bus = $this->swapBusSpy();
+        $firstPageRows = $this->pageRows(1, WbFinanceSalesReportClient::PAGE_SIZE);
+        $this->swapWbClient([new MockResponse(json_encode($firstPageRows, JSON_THROW_ON_ERROR), ['http_code' => 200])]);
+
+        $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
+        $handler($this->message($company->getId(), $connection->getId(), false));
+        $continuation = $this->filterSyncMessages($bus->messages)[0] ?? null;
+        self::assertInstanceOf(SyncWbFinancialReportDayMessage::class, $continuation);
+
+        $this->swapWbClient([new MockResponse('[{"rrdId":100001}]', ['http_code' => 200])]);
+        $handler($continuation);
+
+        $requestCount = 0;
+        self::getContainer()->set(WbFinanceSalesReportClient::class, new WbFinanceSalesReportClient(
+            new MockHttpClient(static function () use (&$requestCount): MockResponse {
+                ++$requestCount;
+
+                return new MockResponse('[]', ['http_code' => 200]);
+            }),
+            $this->createRateLimiter(),
+        ));
+        $handler($continuation);
+
+        self::assertSame(0, $requestCount);
+    }
+
+    public function testTerminalFailureAfterPartialPageMarksStagingRawDocumentFailed(): void
+    {
+        $company = $this->createCompany(9217);
+        $connection = $this->createWbSellerConnection($company, 9217);
+        $bus = $this->swapBusSpy();
+        $firstPageRows = $this->pageRows(1, WbFinanceSalesReportClient::PAGE_SIZE);
+        $this->swapWbClient([new MockResponse(json_encode($firstPageRows, JSON_THROW_ON_ERROR), ['http_code' => 200])]);
+
+        $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
+        $handler($this->message($company->getId(), $connection->getId(), false));
+        $continuation = $this->filterSyncMessages($bus->messages)[0] ?? null;
+        self::assertInstanceOf(SyncWbFinancialReportDayMessage::class, $continuation);
+        $rawDocumentId = $continuation->rawDocumentId;
+        self::assertNotNull($rawDocumentId);
+
+        $this->swapWbClient([new MockResponse('{"error":"bad request"}', ['http_code' => 400])]);
+        $this->expectException(UnrecoverableMessageHandlingException::class);
+
+        try {
+            $handler($continuation);
+        } finally {
+            $raw = $this->em->find(MarketplaceRawDocument::class, $rawDocumentId);
+            self::assertInstanceOf(MarketplaceRawDocument::class, $raw);
+            self::assertSame(PipelineStatus::FAILED, $raw->getProcessingStatus());
+
+            $status = $this->findStatus($connection->getId(), $company->getId(), '2026-05-19');
+            self::assertNotNull($status);
+            self::assertSame(FinancialReportSyncStatus::FAILED_FINAL, $status->getStatus());
+            self::assertNull($status->getStagingRawDocumentId());
+            self::assertNull($status->getNextRrdId());
+        }
+    }
+
+
+    public function testHandlerRespectsPersistedFutureNextRetryAtWithoutCallingWbApi(): void
+    {
+        $company = $this->createCompany(9218);
+        $connection = $this->createWbSellerConnection($company, 9218);
+        $bus = $this->swapBusSpy();
+        $status = new MarketplaceFinancialReportSyncStatus(
+            'cccccccc-cccc-4ccc-8ccc-000000009218',
+            $company->getId(),
+            $connection->getId(),
+            MarketplaceType::WILDBERRIES,
+            'sales_report',
+            'wildberries::finance-sales-reports-detailed',
+            new \DateTimeImmutable('2026-05-19'),
+        );
+        $status->markQueued(FinancialReportSyncMode::MANUAL, false);
+        $status->scheduleNextRetryAt(new \DateTimeImmutable('2099-01-01T00:00:00Z'), null, 0);
+        $this->em->persist($status);
+        $this->em->flush();
+
+        $requestCount = 0;
+        self::getContainer()->set(WbFinanceSalesReportClient::class, new WbFinanceSalesReportClient(
+            new MockHttpClient(static function () use (&$requestCount): MockResponse {
+                ++$requestCount;
+
+                return new MockResponse('[]', ['http_code' => 200]);
+            }),
+            $this->createRateLimiter(),
+        ));
+
+        $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
+        $handler($this->message($company->getId(), $connection->getId(), false));
+
+        self::assertSame(0, $requestCount);
+        self::assertCount(1, $this->filterSyncMessages($bus->messages));
+    }
+
     private function message(string $companyId, string $connectionId, bool $forceRefresh): SyncWbFinancialReportDayMessage
     {
         return new SyncWbFinancialReportDayMessage($companyId, $connectionId, '2026-05-19', FinancialReportSyncMode::MANUAL->value, $forceRefresh);
@@ -335,6 +497,18 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
     private function filterProcessMessages(array $messages): array
     {
         return array_values(array_filter($messages, static fn (object $m): bool => $m instanceof ProcessDayReportMessage));
+    }
+
+    /** @param list<object> $messages */
+    private function filterSyncMessages(array $messages): array
+    {
+        return array_values(array_filter($messages, static fn (object $m): bool => $m instanceof SyncWbFinancialReportDayMessage));
+    }
+
+    /** @return list<array{rrdId:int}> */
+    private function pageRows(int $start, int $count): array
+    {
+        return array_map(static fn (int $rrdId): array => ['rrdId' => $rrdId], range($start, $start + $count - 1));
     }
 
     private function setRawDocumentProcessingStatus(MarketplaceRawDocument $document, PipelineStatus $status): void

--- a/site/tests/Unit/Marketplace/Application/Service/WbFinanceRateLimiterTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbFinanceRateLimiterTest.php
@@ -12,26 +12,27 @@ use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 
 final class WbFinanceRateLimiterTest extends TestCase
 {
-    public function testWaitSleepsBeforeSecondRequestForSameSellerRateLimitKey(): void
+    public function testTryConsumeReturnsNullWhenTokenIsAcceptedAndRetryAfterWhenBucketIsBusy(): void
     {
-        $clock = new MockClock('@'.time());
-        $startTimestamp = $clock->now()->getTimestamp();
+        $clock = new MockClock('2026-01-01T00:00:00Z');
         $limiter = $this->createLimiter($clock);
         $sellerRateLimitKey = 'wb_finance_sales_reports:'.hash('sha256', 'token-a');
 
-        $limiter->wait($sellerRateLimitKey);
-        $limiter->wait($sellerRateLimitKey);
+        self::assertNull($limiter->tryConsume($sellerRateLimitKey));
+        $retryAfter = $limiter->tryConsume($sellerRateLimitKey);
 
-        self::assertGreaterThan(0, $clock->now()->getTimestamp() - $startTimestamp);
+        self::assertNotNull($retryAfter);
+        self::assertGreaterThan($clock->now()->getTimestamp(), $retryAfter->getTimestamp());
+        self::assertSame('2026-01-01T00:00:00+00:00', $clock->now()->format(DATE_ATOM));
     }
 
-    public function testWaitUsesSeparateBucketsForDifferentSellerRateLimitKeys(): void
+    public function testTryConsumeUsesSeparateBucketsForDifferentSellerRateLimitKeys(): void
     {
         $clock = new MockClock('2026-01-01T00:00:00Z');
         $limiter = $this->createLimiter($clock);
 
-        $limiter->wait('wb_finance_sales_reports:'.hash('sha256', 'token-a'));
-        $limiter->wait('wb_finance_sales_reports:'.hash('sha256', 'token-b'));
+        self::assertNull($limiter->tryConsume('wb_finance_sales_reports:'.hash('sha256', 'token-a')));
+        self::assertNull($limiter->tryConsume('wb_finance_sales_reports:'.hash('sha256', 'token-b')));
 
         self::assertSame('2026-01-01T00:00:00+00:00', $clock->now()->format(DATE_ATOM));
     }

--- a/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
@@ -96,6 +96,50 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
         self::assertCount(3, $this->dispatchedMessages);
     }
 
+
+    public function testQueuedWithFutureRetryAtIsNotDispatched(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1')]);
+        $this->statuses->method('findStatusesForDateRange')->willReturn([
+            $this->statusEntity('2026-05-20', FinancialReportSyncStatus::QUEUED, '2026-05-21T11:00:00+03:00', '2026-05-20T09:00:00+03:00'),
+        ]);
+
+        self::assertSame(1, $planner->planRefresh14Days(null, null, 1));
+        self::assertNotContains('2026-05-20', array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->businessDate, $this->dispatchedMessages));
+    }
+
+    public function testQueuedContinuationDueIsDispatchedWithCursor(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1')]);
+        $this->statuses->method('findStatusesForDateRange')->willReturn([
+            $this->statusEntity('2026-05-20', FinancialReportSyncStatus::QUEUED, '2026-05-21T09:59:00+03:00', '2026-05-20T09:00:00+03:00'),
+        ]);
+        $this->claimForQueueCallback = fn (
+            string $connectionId,
+            string $companyId,
+            MarketplaceType $marketplace,
+            string $reportType,
+            string $apiEndpoint,
+            \DateTimeImmutable $businessDate,
+            FinancialReportSyncMode $mode,
+            bool $forceRefresh,
+            \DateTimeImmutable $now,
+        ): MarketplaceFinancialReportSyncStatus => $this->statusEntity(
+            $businessDate->format('Y-m-d'),
+            FinancialReportSyncStatus::QUEUED,
+            null,
+            $now->format(DATE_ATOM),
+            123,
+            'bbbbbbbb-bbbb-4bbb-8bbb-000000009999',
+        );
+
+        self::assertSame(1, $planner->planRefresh14Days(null, null, 1));
+        self::assertSame(123, $this->dispatchedMessages[0]->rrdId);
+        self::assertSame('bbbbbbbb-bbbb-4bbb-8bbb-000000009999', $this->dispatchedMessages[0]->rawDocumentId);
+    }
+
     public function testFailedWithFutureRetryAtIsNotDispatched(): void
     {
         $planner = $this->planner();
@@ -104,8 +148,8 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
             $this->statusEntity('2026-05-20', FinancialReportSyncStatus::FAILED, '2026-05-21T11:00:00+03:00', '2026-05-20T09:00:00+03:00'),
         ]);
 
-        self::assertSame(0, $planner->planRefresh14Days(null, null, 1));
-        self::assertCount(0, $this->dispatchedMessages);
+        self::assertSame(1, $planner->planRefresh14Days(null, null, 1));
+        self::assertNotContains('2026-05-20', array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->businessDate, $this->dispatchedMessages));
     }
 
     public function testFailedWithRetryDueIsDispatched(): void
@@ -140,7 +184,7 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
         ]);
 
         self::assertSame(1, $planner->planRefresh14Days(null, null, 1));
-        self::assertSame('2026-05-19', $this->dispatchedMessages[0]->dateFrom);
+        self::assertSame('2026-05-19', $this->dispatchedMessages[0]->businessDate);
     }
 
     public function testLoadingAndProcessingAreNotDispatched(): void
@@ -152,7 +196,9 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
             $this->statusEntity('2026-05-19', FinancialReportSyncStatus::PROCESSING, null, '2026-05-21T09:00:00+03:00'),
         ]);
 
-        self::assertSame(0, $planner->planRefresh14Days(null, null, 2));
+        self::assertSame(2, $planner->planRefresh14Days(null, null, 2));
+        self::assertNotContains('2026-05-20', array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->businessDate, $this->dispatchedMessages));
+        self::assertNotContains('2026-05-19', array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->businessDate, $this->dispatchedMessages));
     }
 
 
@@ -164,12 +210,12 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
 
         self::assertSame(1, $planner->planRefresh14Days(null, null, 1));
         self::assertCount(1, $this->dispatchedMessages);
-        self::assertSame('refresh14', $this->dispatchedMessages[0]->mode);
+        self::assertSame('refresh_14d', $this->dispatchedMessages[0]->mode);
 
         $last14days = (new WbFinancialReportPeriodResolver(new MockClock('2026-05-21 00:00:00 Europe/Moscow')))
             ->last14Days();
         $expected = array_map(static fn (\DateTimeImmutable $d): string => $d->format('Y-m-d'), $last14days);
-        self::assertContains($this->dispatchedMessages[0]->dateFrom, $expected);
+        self::assertContains($this->dispatchedMessages[0]->businessDate, $expected);
     }
     public function testUnknownDaysGoAfterFailedDueAndSuccessEmpty(): void
     {
@@ -181,8 +227,8 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
         ]);
 
         self::assertSame(2, $planner->planRefresh14Days(null, null, 2));
-        self::assertSame('2026-05-20', $this->dispatchedMessages[0]->dateFrom);
-        self::assertSame('2026-05-19', $this->dispatchedMessages[1]->dateFrom);
+        self::assertSame('2026-05-20', $this->dispatchedMessages[0]->businessDate);
+        self::assertSame('2026-05-19', $this->dispatchedMessages[1]->businessDate);
     }
 
     public function testLimitIsAppliedPerConnection(): void
@@ -248,6 +294,40 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
 
 
 
+
+    public function testPlanMissingRecoversDueQueuedContinuationWithCursor(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1')]);
+        $this->statuses->method('findStatusesForDateRange')->willReturn([
+            $this->statusEntity('2026-01-01', FinancialReportSyncStatus::QUEUED, '2026-05-21T09:59:00+03:00', '2026-05-20T09:00:00+03:00'),
+        ]);
+        $this->statuses->method('findRetryDueDays')->willReturn([new \DateTimeImmutable('2026-01-01 00:00:00 Europe/Moscow')]);
+        $this->claimForQueueCallback = fn (
+            string $connectionId,
+            string $companyId,
+            MarketplaceType $marketplace,
+            string $reportType,
+            string $apiEndpoint,
+            \DateTimeImmutable $businessDate,
+            FinancialReportSyncMode $mode,
+            bool $forceRefresh,
+            \DateTimeImmutable $now,
+        ): MarketplaceFinancialReportSyncStatus => $this->statusEntity(
+            $businessDate->format('Y-m-d'),
+            FinancialReportSyncStatus::QUEUED,
+            null,
+            $now->format(DATE_ATOM),
+            456,
+            'bbbbbbbb-bbbb-4bbb-8bbb-000000008888',
+        );
+
+        self::assertSame(1, $planner->planMissing(null, null, 1));
+        self::assertSame('2026-01-01', $this->dispatchedMessages[0]->businessDate);
+        self::assertSame(456, $this->dispatchedMessages[0]->rrdId);
+        self::assertSame('bbbbbbbb-bbbb-4bbb-8bbb-000000008888', $this->dispatchedMessages[0]->rawDocumentId);
+    }
+
     public function testPlanMissingLimitIsAppliedPerConnection(): void
     {
         $planner = $this->planner();
@@ -269,8 +349,8 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
             $this->statusEntity('2026-01-02', FinancialReportSyncStatus::PROCESSING, null, '2026-01-05T09:00:00+03:00'),
         ]);
 
-        self::assertSame(2, $planner->planMissing(null, null, 10));
-        self::assertSame(['2026-01-03', '2026-01-04'], array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->businessDate, $this->dispatchedMessages));
+        self::assertSame(10, $planner->planMissing(null, null, 10));
+        self::assertSame(['2026-01-03', '2026-01-04'], array_slice(array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->businessDate, $this->dispatchedMessages), 0, 2));
     }
     private function planner(): WbFinancialReportSyncPlanner
     {
@@ -283,13 +363,21 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
         );
     }
 
-    private function statusEntity(string $day, FinancialReportSyncStatus $status, ?string $nextRetryAt, string $updatedAt): MarketplaceFinancialReportSyncStatus&MockObject
-    {
+    private function statusEntity(
+        string $day,
+        FinancialReportSyncStatus $status,
+        ?string $nextRetryAt,
+        string $updatedAt,
+        ?int $nextRrdId = null,
+        ?string $stagingRawDocumentId = null,
+    ): MarketplaceFinancialReportSyncStatus&MockObject {
         $entity = $this->createMock(MarketplaceFinancialReportSyncStatus::class);
         $entity->method('getBusinessDate')->willReturn(new \DateTimeImmutable($day.' 00:00:00 Europe/Moscow'));
         $entity->method('getStatus')->willReturn($status);
         $entity->method('getNextRetryAt')->willReturn(null !== $nextRetryAt ? new \DateTimeImmutable($nextRetryAt) : null);
         $entity->method('getUpdatedAt')->willReturn(new \DateTimeImmutable($updatedAt));
+        $entity->method('getNextRrdId')->willReturn($nextRrdId);
+        $entity->method('getStagingRawDocumentId')->willReturn($stagingRawDocumentId);
 
         return $entity;
     }

--- a/site/tests/Unit/Marketplace/Entity/MarketplaceFinancialReportSyncStatusTest.php
+++ b/site/tests/Unit/Marketplace/Entity/MarketplaceFinancialReportSyncStatusTest.php
@@ -82,6 +82,30 @@ final class MarketplaceFinancialReportSyncStatusTest extends TestCase
         self::assertSame(0, $status->getRecordsCount());
     }
 
+
+    public function testMarkFailedRetryableClearsPaginationCursorByDefault(): void
+    {
+        $status = $this->statusEntity();
+        $status->scheduleNextRetryAt(new \DateTimeImmutable('2026-05-20T12:00:00Z'), $this->rawId(), 123);
+
+        $status->markFailedRetryable('HttpException', 'temporary', 500, null, new \DateTimeImmutable('2026-05-20T12:15:00Z'));
+
+        self::assertNull($status->getStagingRawDocumentId());
+        self::assertNull($status->getNextRrdId());
+    }
+
+    public function testMarkFailedRetryablePreservingCursorKeepsPaginationCursor(): void
+    {
+        $status = $this->statusEntity();
+        $nextRetryAt = new \DateTimeImmutable('2026-05-20T12:15:00Z');
+
+        $status->markFailedRetryablePreservingCursor('HttpException', 'temporary', 500, null, $nextRetryAt, $this->rawId(), 123);
+
+        self::assertSame($this->rawId(), $status->getStagingRawDocumentId());
+        self::assertSame(123, $status->getNextRrdId());
+        self::assertSame($nextRetryAt, $status->getNextRetryAt());
+    }
+
     private function statusEntity(): MarketplaceFinancialReportSyncStatus
     {
         return new MarketplaceFinancialReportSyncStatus(

--- a/site/tests/Unit/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClientTest.php
+++ b/site/tests/Unit/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClientTest.php
@@ -59,7 +59,7 @@ final class WbFinanceSalesReportClientTest extends TestCase
     }
 
 
-    public function testFetchDetailedDayAppliesLocalRateLimitBeforeHttpRequest(): void
+    public function testFetchDetailedDayThrowsBeforeHttpRequestWhenLocalBucketIsBusy(): void
     {
         $requestCount = 0;
         $http = new MockHttpClient(static function () use (&$requestCount): MockResponse {
@@ -71,11 +71,16 @@ final class WbFinanceSalesReportClientTest extends TestCase
         $client = new WbFinanceSalesReportClient($http, $this->createRateLimiter());
 
         self::assertSame([], $client->fetchDetailedDay('same-connection', 'token', new \DateTimeImmutable('2026-01-15')));
-        self::assertSame([], $client->fetchDetailedDay('same-connection', 'token', new \DateTimeImmutable('2026-01-15')));
-        self::assertSame(2, $requestCount);
+
+        $this->expectException(MarketplaceRateLimitException::class);
+        try {
+            $client->fetchDetailedDay('same-connection', 'token', new \DateTimeImmutable('2026-01-15'));
+        } finally {
+            self::assertSame(1, $requestCount);
+        }
     }
 
-    public function testFetchDetailedDayUsesSameLimiterBucketForSameTokenAcrossDifferentConnectionIds(): void
+    public function testFetchDetailedDayReturnsRateLimitForSameTokenAcrossDifferentConnectionIds(): void
     {
         $requestCount = 0;
         $http = new MockHttpClient(static function () use (&$requestCount): MockResponse {
@@ -89,9 +94,14 @@ final class WbFinanceSalesReportClientTest extends TestCase
         $client = new WbFinanceSalesReportClient($http, $this->createRateLimiter($clock));
 
         self::assertSame([], $client->fetchDetailedDay('connection-a', 'same-token', new \DateTimeImmutable('2026-01-15')));
-        self::assertSame([], $client->fetchDetailedDay('connection-b', 'same-token', new \DateTimeImmutable('2026-01-15')));
-        self::assertSame(2, $requestCount);
-        self::assertGreaterThan(0, $clock->now()->getTimestamp() - $startTimestamp);
+
+        $this->expectException(MarketplaceRateLimitException::class);
+        try {
+            $client->fetchDetailedDay('connection-b', 'same-token', new \DateTimeImmutable('2026-01-15'));
+        } finally {
+            self::assertSame(1, $requestCount);
+            self::assertSame($startTimestamp, $clock->now()->getTimestamp());
+        }
     }
 
     public function testFetchDetailedDayUsesDifferentLimiterBucketsForDifferentTokens(): void
@@ -114,7 +124,7 @@ final class WbFinanceSalesReportClientTest extends TestCase
     }
 
 
-    public function testFetchDetailedDayAppliesLocalRateLimitOnPaginationRequest(): void
+    public function testFetchDetailedDayPageReturnsContinuationCursorForFullPage(): void
     {
         $rows = array_fill(0, 100000, ['rrdId' => 10]);
         $rows[99999] = ['rrdId' => 20];
@@ -139,16 +149,18 @@ final class WbFinanceSalesReportClientTest extends TestCase
         $startTimestamp = $clock->now()->getTimestamp();
         $client = new WbFinanceSalesReportClient($http, $this->createRateLimiter($clock));
 
-        $data = $client->fetchDetailedDay('00000000-0000-0000-0000-000000000001', 'token', new \DateTimeImmutable('2026-01-15'));
-        self::assertCount(100000, $data);
-        self::assertSame(2, $requestCount);
+        $page = $client->fetchDetailedDayPage('00000000-0000-0000-0000-000000000001', 'token', new \DateTimeImmutable('2026-01-15'), 0);
+
+        self::assertCount(100000, $page->rows);
+        self::assertTrue($page->hasNextPage);
+        self::assertSame(20, $page->nextRrdId);
+        self::assertSame(1, $requestCount);
         self::assertSame(0, $captured[0]['rrdId']);
-        self::assertSame(20, $captured[1]['rrdId']);
-        self::assertGreaterThan(0, $clock->now()->getTimestamp() - $startTimestamp);
+        self::assertSame($startTimestamp, $clock->now()->getTimestamp());
     }
 
 
-    public function testHasAnyDataForConnectionAppliesLocalRateLimitBeforeHttpRequest(): void
+    public function testHasAnyDataForConnectionThrowsBeforeHttpRequestWhenLocalBucketIsBusy(): void
     {
         $requestCount = 0;
         $http = new MockHttpClient(static function () use (&$requestCount): MockResponse {
@@ -159,8 +171,13 @@ final class WbFinanceSalesReportClientTest extends TestCase
         $client = new WbFinanceSalesReportClient($http, $this->createRateLimiter());
 
         self::assertTrue($client->hasAnyDataForConnection('same-connection', 'token', '2026-01-01', '2026-01-31'));
-        self::assertTrue($client->hasAnyDataForConnection('same-connection', 'token', '2026-01-01', '2026-01-31'));
-        self::assertSame(2, $requestCount);
+
+        $this->expectException(MarketplaceRateLimitException::class);
+        try {
+            $client->hasAnyDataForConnection('same-connection', 'token', '2026-01-01', '2026-01-31');
+        } finally {
+            self::assertSame(1, $requestCount);
+        }
     }
 
     public function testHasAnyDataForConnectionDelegatesToHasAnyDataLogic(): void
@@ -251,7 +268,7 @@ final class WbFinanceSalesReportClientTest extends TestCase
         $client->fetchDetailedForConnection('connection-id', 'token', '2026-01-01', '2026-01-01');
     }
 
-    public function testCountEqualPageSizeUsesDelayBeforeNextRequest(): void
+    public function testCountEqualPageSizeThrowsBeforeNextRequestWhenBucketIsBusy(): void
     {
         $rows = array_fill(0, 100000, ['rrdId' => 10]);
         $rows[99999] = ['rrdId' => 20];
@@ -275,11 +292,14 @@ final class WbFinanceSalesReportClientTest extends TestCase
         $startTimestamp = $clock->now()->getTimestamp();
         $client = new WbFinanceSalesReportClient($http, $this->createRateLimiter($clock));
 
-        $client->fetchDetailedForConnection('connection-id', 'token', '2026-01-01', '2026-01-01');
-
-        self::assertIsArray($captured[1]);
-        self::assertSame(20, $captured[1]['rrdId'] ?? null);
-        self::assertGreaterThan(0, $clock->now()->getTimestamp() - $startTimestamp);
+        $this->expectException(MarketplaceRateLimitException::class);
+        try {
+            $client->fetchDetailedForConnection('connection-id', 'token', '2026-01-01', '2026-01-01');
+        } finally {
+            self::assertCount(1, $captured);
+            self::assertSame(0, $captured[0]['rrdId'] ?? null);
+            self::assertSame($startTimestamp, $clock->now()->getTimestamp());
+        }
     }
 
     public function testProbeAccessUsesFinancePingEndpoint(): void

--- a/site/tests/bootstrap.php
+++ b/site/tests/bootstrap.php
@@ -15,6 +15,7 @@ DG\BypassFinals::allowPaths([
     '*/src/MarketplaceAds/Application/Service/AdBatchPlanner.php',
     '*/src/Marketplace/Application/Service/MarketplaceWeekPartitionService.php',
     '*/src/Marketplace/Infrastructure/Query/ActiveOzonConnectionsQuery.php',
+    '*/src/Marketplace/Infrastructure/Query/ActiveWbConnectionsQuery.php',
     '*/src/Marketplace/Infrastructure/Query/ActiveSellerConnectionsQuery.php',
     '*/src/MarketplaceAnalytics/Domain/Service/CostMappingResolver.php',
     '*/src/MarketplaceAnalytics/Domain/Service/DefaultCostMappingSeedPolicy.php',


### PR DESCRIPTION
### Motivation

- Implement reliable page-by-page loading for Wildberries finance reports to handle very large responses and allow resuming after rate-limited failures. 
- Make local throttling observable and non-blocking so continuation scheduling can be coordinated with persisted sync status. 
- Preserve a durable pagination cursor and staging raw document across retries to avoid refetching already downloaded pages. 
- Surface progress in the raw-document pipeline so partially loaded documents can be marked and resumed or failed deterministically.

### Description

- Added persisted cursor fields to `MarketplaceFinancialReportSyncStatus` (`stagingRawDocumentId`, `nextRrdId`) and a migration `Version20260529120000` to add the columns. 
- Implemented paginated fetch API: new `WbFinanceSalesReportPage` type, `WbFinanceSalesReportClient::fetchDetailedDayPage`, cursor handling, local pre-request rate-limit check and helper `tryConsume`, and exposed `buildSalesReportsRateLimitKeyForApiKey`. 
- Made sync flow resumable by extending `SyncWbFinancialReportDayMessage` with `rrdId` and `rawDocumentId`, updating `SyncWbFinancialReportDayHandler` to schedule continuations with `DelayStamp`, persist staging cursor, append pages via `WbFinancialReportReconciliationService::appendRawDocumentPage`, and mark staging raw documents loading/failed. 
- Introduced `WbFinanceRateLimiter::tryConsume` (non-blocking) and tests/consumers updated accordingly, plus `MarketplaceRawDocument::appendRawDataRows`, new `PipelineStatus::LOADING`, status updater methods to preserve or clear cursor state, and repository/query guards to avoid loading documents in `LOADING` state.

### Testing

- Ran unit tests `WbFinanceRateLimiterTest`, `WbFinanceSalesReportClientTest`, `WbFinancialReportSyncPlannerTest`, and `MarketplaceFinancialReportSyncStatusTest` which were updated to cover `tryConsume`, pagination, queued continuations and cursor preservation; these tests passed. 
- Ran integration tests in `SyncWbFinancialReportDayHandlerTest` covering local throttling, stale/duplicate continuation skipping, page continuation scheduling and terminal failure handling of staging documents; these integration tests passed. 
- Updated test bootstrap and service wiring to inject new parameters (`wb_finance.rate_limit_interval`, `wb_finance.retry_delay_ms`) used by the new behavior and all modified tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a194db40f7c8323b2fe767773f7558c)