### PR TITLE
Use REDIS_DSN for default provider and add Redis-backed rate limiter cache pool

### DIFF
--- a/site/config/packages/cache.yaml
+++ b/site/config/packages/cache.yaml
@@ -9,11 +9,13 @@ framework:
 
         # Redis
         #app: cache.adapter.redis
-        #default_redis_provider: redis://localhost
+        default_redis_provider: '%env(REDIS_DSN)%'
 
         # APCu (not recommended with heavy random-write workloads as memory fragmentation can cause perf issues)
         #app: cache.adapter.apcu
 
         # Namespaced pools use the above "app" backend by default
-        #pools:
-            #my.dedicated.cache: null
+        pools:
+            # WB finance throttling зависит от общего cache.rate_limiter pool.
+            cache.rate_limiter:
+                adapter: cache.adapter.redis


### PR DESCRIPTION
### Motivation

- Make Redis configuration environment-driven by using the `REDIS_DSN` env var for the default Redis provider. 
- Provide a dedicated Redis-backed cache pool for rate limiting to support WB finance throttling that depends on the shared `cache.rate_limiter` pool.

### Description

- Set `default_redis_provider` to `'%env(REDIS_DSN)%'` in `site/config/packages/cache.yaml` so the Redis DSN is read from the environment. 
- Un-comment and enable the `pools` section and add a `cache.rate_limiter` pool with `adapter: cache.adapter.redis` to use Redis for rate limiting. 
- Cleaned up commented example entries to reflect the active configuration.

### Testing

- Ran `yamllint site/config/packages/cache.yaml` and the linter passed. 
- Ran `php bin/console lint:container` to validate Symfony container config and it passed. 
- CI unit test suite was executed and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a199dbeb5848323bdbb0226ef30abdf)