### PR TITLE
Update WB finance rate limiter window

### DIFF
--- a/site/config/packages/rate_limiter.yaml
+++ b/site/config/packages/rate_limiter.yaml
@@ -14,10 +14,9 @@ framework:
             interval: '1 minute'
 
         # WB Finance API: POST /api/finance/v1/sales-reports/detailed
-        # Official WB limit: 1 request per 5 minutes per seller account.
-        # Use fixed_window with a small safety margin to absorb clock skew
-        # between our host and WB; keep this in sync with services.yaml.
+        # Official WB limit: 1 request per 1 minute per seller account.
+        # Use 70 seconds as safety margin.
         wb_finance:
             policy: fixed_window
             limit: 1
-            interval: '%wb_finance.rate_limit_interval%'
+            interval: '70 seconds'

--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -8,9 +8,8 @@ parameters:
     app.storage_root: '%kernel.project_dir%/var/storage'
     app.encryption.key_file: '%env(string:APP_ENCRYPTION_KEY_FILE)%'
     app.encryption.current_key_version: '%env(string:APP_ENCRYPTION_CURRENT_KEY_VERSION)%'
-    wb_finance.rate_limit_interval: '310 seconds'
-    wb_finance.rate_limit_interval_seconds: 310
-    wb_finance.retry_delay_ms: 310000
+    wb_finance.rate_limit_interval_seconds: 70
+    wb_finance.retry_delay_ms: 70000
 
 services:
     # default configuration for services in *this* file


### PR DESCRIPTION
### Motivation
- Align the WB Finance rate limiter docs and settings with the official limit of 1 request per minute and use a 70‑second safety margin.
- Ensure the runtime retry/delay parameters are consistent with the chosen window so message retry delays match the rate limiter.

### Description
- Updated the comment and interval for the `wb_finance` limiter in `site/config/packages/rate_limiter.yaml` to document the official limit and set `interval: '70 seconds'` while keeping `policy: fixed_window` and `limit: 1`.
- Replaced the previous 310s parameters with `wb_finance.rate_limit_interval_seconds: 70` and `wb_finance.retry_delay_ms: 70000` in `site/config/services.yaml` to match the 70‑second window.
- Confirmed the service binding uses `@limiter.wb_finance` so the limiter name matches the service configuration.

### Testing
- Parsed YAML files with `ruby -e "require 'yaml'; ARGV.each { |f| YAML.load_file(f); puts \"parsed #{f}\" }" site/config/packages/rate_limiter.yaml site/config/services.yaml` and it succeeded.
- Searched and validated settings with `rg -n "wb_finance:|limiter\.wb_finance|interval: '70 seconds'|rate_limit_interval_seconds|retry_delay_ms"` and found the updated entries.
- Ran `git diff --check` to ensure no whitespace/diff issues and it returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19bd0343e48323ac796ee128e70a91)