### PR TITLE
Tune WB financial sync cron cadence

### DIFF
--- a/docker/cron/app.cron
+++ b/docker/cron/app.cron
@@ -9,13 +9,13 @@
 # 0 3 * * * php bin/console app:marketplace:wb-daily-sync --no-interaction
 
 # Новый WB financial sync (TASK-028): единая команда-планировщик по режимам.
-10 3 * * * php bin/console app:marketplace:wb-financial-reports:sync --mode=daily --no-interaction --quiet
+10 3 * * * php bin/console app:marketplace:wb-financial-reports:sync --mode=daily --max-days=1 --no-interaction --quiet
 
-# Временно отключено до внедрения промышленного WB throttling-а (иначе flood задач и 429 Too Many Requests).
-# 20 4 * * * php bin/console app:marketplace:wb-financial-reports:sync --mode=refresh14 --no-interaction --quiet
+# Постепенное обновление последних 14 дней: не более 1 дня на connection за запуск.
+*/20 6-23 * * * php bin/console app:marketplace:wb-financial-reports:sync --mode=refresh14 --max-days=1 --no-interaction --quiet
 
-# Временно ограничено: не более 1 missing-дня на connection за запуск.
-30 5 * * * php bin/console app:marketplace:wb-financial-reports:sync --mode=missing --max-days=1 --no-interaction --quiet
+# Постепенное восстановление пропущенных дней: не более 1 missing-дня на connection за запуск.
+*/15 6-23 * * * php bin/console app:marketplace:wb-financial-reports:sync --mode=missing --max-days=1 --no-interaction --quiet
 
 # Ночная синхронизация отчётов Ozon по реализации.
 0 4 * * * php bin/console app:marketplace:ozon-daily-sync --no-interaction


### PR DESCRIPTION
### Motivation
- Prevent flood and duplicated work when moving to the new WB financial sync scheduler by running daily and recovery modes in small, rate-limited increments and keeping the daily run bounded to one day of work; do not enable these cron ticks in production until atomic `QUEUED` claim (and seller-token limiter / `cache.rate_limiter`) are in place to avoid duplicates.

### Description
- Add explicit `--max-days=1` to the daily WB financial reports sync cron (`app:marketplace:wb-financial-reports:sync --mode=daily`).
- Replace the single nightly `missing` run with gradual ticks every 15 minutes during `06:00-23:00` using `--mode=missing --max-days=1`.
- Uncomment/add gradual `refresh14` ticks every 20 minutes during `06:00-23:00` with `--mode=refresh14 --max-days=1`.

### Testing
- Ran `git diff --check -- docker/cron/app.cron` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19c09ba8808323bcec4e7c9a5d8b5c)