### PR TITLE
WB Finance: seller-bucket rate limiting, shared cooldown (Redis) and diagnostics

### DIFF
--- a/site/config/packages/rate_limiter.yaml
+++ b/site/config/packages/rate_limiter.yaml
@@ -20,3 +20,4 @@ framework:
             policy: fixed_window
             limit: 1
             interval: '70 seconds'
+            cache_pool: cache.rate_limiter

--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -56,9 +56,16 @@ services:
             $factory: '@?limiter.registration'
 
 
+    App\Marketplace\Infrastructure\Redis\WbFinanceRedisCooldownStorage:
+        arguments:
+            $redisClient: '@session.redis'
+
+    App\Marketplace\Application\Service\WbFinanceCooldownStorageInterface: '@App\Marketplace\Infrastructure\Redis\WbFinanceRedisCooldownStorage'
+
     App\Marketplace\Application\Service\WbFinanceRateLimiter:
         arguments:
             $factory: '@limiter.wb_finance'
+            $cooldownStorage: '@App\Marketplace\Application\Service\WbFinanceCooldownStorageInterface'
 
     App\Marketplace\MessageHandler\SyncWbFinancialReportDayHandler:
         arguments:

--- a/site/src/Marketplace/Application/Service/WbFinanceCooldownStorageInterface.php
+++ b/site/src/Marketplace/Application/Service/WbFinanceCooldownStorageInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\Service;
+
+interface WbFinanceCooldownStorageInterface
+{
+    public function getUntilTimestamp(string $key): ?int;
+
+    public function setUntilTimestamp(string $key, int $untilTimestamp, int $ttlSeconds): void;
+}

--- a/site/src/Marketplace/Application/Service/WbFinanceRateLimiter.php
+++ b/site/src/Marketplace/Application/Service/WbFinanceRateLimiter.php
@@ -4,19 +4,24 @@ declare(strict_types=1);
 
 namespace App\Marketplace\Application\Service;
 
-use Symfony\Component\RateLimiter\RateLimiterFactory;
-use Symfony\Component\Clock\ClockInterface;
+use App\Marketplace\Entity\MarketplaceConnection;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
 
 final class WbFinanceRateLimiter
 {
     private const HASH_PREFIX_LENGTH = 8;
+    private const COOLDOWN_KEY_PREFIX = 'wb_finance:sales_reports:cooldown';
+    private const GLOBAL_BUCKET = 'global';
+    private const REMOTE_429_COOLDOWN_BUFFER_SECONDS = 15;
 
     public function __construct(
         private readonly RateLimiterFactory $factory,
         private readonly ClockInterface $clock,
         ?LoggerInterface $logger = null,
+        private readonly ?WbFinanceCooldownStorageInterface $cooldownStorage = null,
     ) {
         $this->logger = $logger ?? new NullLogger();
     }
@@ -39,6 +44,104 @@ final class WbFinanceRateLimiter
         ]);
 
         return $retryAfter;
+    }
+
+    public function resolveSalesReportsSellerBucketId(MarketplaceConnection $connection): string
+    {
+        $settings = $connection->getSettings() ?? [];
+        foreach (['sellerId', 'seller_id', 'accountId', 'account_id', 'supplierId', 'supplier_id', 'wbSellerId', 'wb_seller_id'] as $key) {
+            $value = $settings[$key] ?? null;
+            if (is_scalar($value)) {
+                $normalized = $this->normalizeBucketPart((string) $value);
+                if ('' !== $normalized) {
+                    return $normalized;
+                }
+            }
+        }
+
+        return self::GLOBAL_BUCKET;
+    }
+
+    public function buildSalesReportsRateLimitKeyForSellerBucket(string $sellerBucketId): string
+    {
+        $normalized = $this->normalizeBucketPart($sellerBucketId);
+        if ('' === $normalized) {
+            $normalized = self::GLOBAL_BUCKET;
+        }
+
+        return 'wb_finance_sales_reports:'.$normalized;
+    }
+
+    public function secondsUntil(\DateTimeImmutable $retryAfter): int
+    {
+        return max(1, $retryAfter->getTimestamp() - $this->clock->now()->getTimestamp());
+    }
+
+    public function cooldownUntilAfterRemote429(?int $retryAfterSeconds, int $defaultSeconds = 900): \DateTimeImmutable
+    {
+        $seconds = null !== $retryAfterSeconds
+            ? max(1, $retryAfterSeconds) + self::REMOTE_429_COOLDOWN_BUFFER_SECONDS
+            : max(1, $defaultSeconds);
+
+        return $this->clock->now()->modify(sprintf('+%d seconds', $seconds));
+    }
+
+    public function getActiveSalesReportsCooldownUntil(string $sellerBucketId): ?\DateTimeImmutable
+    {
+        if (null === $this->cooldownStorage) {
+            return null;
+        }
+
+        $timestamp = $this->cooldownStorage->getUntilTimestamp($this->buildSalesReportsCooldownKey($sellerBucketId));
+        if (null === $timestamp) {
+            return null;
+        }
+
+        $now = $this->clock->now()->getTimestamp();
+        if ($timestamp <= $now) {
+            return null;
+        }
+
+        return (new \DateTimeImmutable('@'.$timestamp))->setTimezone($this->clock->now()->getTimezone());
+    }
+
+    public function setSalesReportsCooldownUntil(string $sellerBucketId, \DateTimeImmutable $cooldownUntil): void
+    {
+        if (null === $this->cooldownStorage) {
+            return;
+        }
+
+        $now = $this->clock->now()->getTimestamp();
+        $timestamp = $cooldownUntil->getTimestamp();
+        if ($timestamp <= $now) {
+            return;
+        }
+
+        $key = $this->buildSalesReportsCooldownKey($sellerBucketId);
+        $currentTimestamp = $this->cooldownStorage->getUntilTimestamp($key);
+        $effectiveTimestamp = max($timestamp, $currentTimestamp ?? 0);
+        $ttlSeconds = max(1, $effectiveTimestamp - $now);
+        $this->cooldownStorage->setUntilTimestamp($key, $effectiveTimestamp, $ttlSeconds);
+    }
+
+    public function buildSalesReportsCooldownKey(string $sellerBucketId): string
+    {
+        $normalized = $this->normalizeBucketPart($sellerBucketId);
+        if ('' === $normalized || self::GLOBAL_BUCKET === $normalized) {
+            return self::COOLDOWN_KEY_PREFIX.':'.self::GLOBAL_BUCKET;
+        }
+
+        return self::COOLDOWN_KEY_PREFIX.':'.$normalized;
+    }
+
+    private function normalizeBucketPart(string $value): string
+    {
+        $normalized = trim($value);
+        if ('' === $normalized) {
+            return '';
+        }
+
+        return preg_replace('/[^a-zA-Z0-9_.-]+/', '_', $normalized) ?? '';
     }
 
     private function extractHashPrefix(string $sellerRateLimitKey): string

--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncStatusUpdater.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncStatusUpdater.php
@@ -94,6 +94,14 @@ final readonly class WbFinancialReportSyncStatusUpdater implements WbFinancialRe
         $this->saveError($status, $errorClass, $errorMessage, $statusCode, $responseExcerpt, $requestPayload);
     }
 
+    /** @param array<string,mixed>|null $requestPayload */
+    public function recordRetryableError(MarketplaceFinancialReportSyncStatus $status, string $errorClass, string $errorMessage, ?int $statusCode = null, ?string $responseExcerpt = null, ?array $requestPayload = null): void
+    {
+        $status->recordRetryableError($errorClass, $errorMessage, $statusCode, $responseExcerpt);
+        $this->statusRepository->save($status);
+        $this->saveError($status, $errorClass, $errorMessage, $statusCode, $responseExcerpt, $requestPayload);
+    }
+
 
     /** @param array<string,mixed>|null $requestPayload */
     public function markFailedRetryablePreservingCursor(

--- a/site/src/Marketplace/Command/WbFinanceDiagnosticsCommand.php
+++ b/site/src/Marketplace/Command/WbFinanceDiagnosticsCommand.php
@@ -1,0 +1,290 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Command;
+
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+#[AsCommand(
+    name: 'app:marketplace:wb-finance:diagnostics',
+    description: 'Read-only diagnostics for WB finance limiter, cooldown, queues and sync statuses.',
+)]
+final class WbFinanceDiagnosticsCommand extends Command
+{
+    private const COOLDOWN_PATTERN = 'wb_finance:sales_reports:cooldown:*';
+    private const WB_QUEUE_STREAM = 'messages_wb_finance';
+    private const WB_QUEUE_DELAYED = 'messages_wb_finance__queue';
+
+    public function __construct(
+        #[Autowire(service: 'session.redis')]
+        private readonly object $redisClient,
+        #[Autowire(service: 'cache.rate_limiter')]
+        private readonly object $rateLimiterCachePool,
+        #[Autowire(service: 'limiter.wb_finance')]
+        private readonly object $wbFinanceLimiter,
+        private readonly Connection $connection,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $io->title('WB Finance diagnostics');
+
+        $this->renderRedisAndLimiter($io);
+        $this->renderCooldownKeys($io);
+        $this->renderQueueSizes($io);
+        $this->renderStatusCounts($io);
+        $this->renderRetryAndErrorDiagnostics($io);
+        $this->renderRawDiagnostics($io);
+
+        $io->success('Diagnostics completed. Command is read-only.');
+
+        return Command::SUCCESS;
+    }
+
+    private function renderRedisAndLimiter(SymfonyStyle $io): void
+    {
+        $io->section('Redis / limiter');
+        $io->table(['Check', 'Value'], [
+            ['session.redis class', $this->redisClient::class],
+            ['cache.rate_limiter class', $this->rateLimiterCachePool::class],
+            ['limiter.wb_finance service', 'present: '.$this->wbFinanceLimiter::class],
+        ]);
+    }
+
+    private function renderCooldownKeys(SymfonyStyle $io): void
+    {
+        $io->section('Redis cooldown keys');
+
+        try {
+            $keys = $this->redisKeys(self::COOLDOWN_PATTERN);
+            sort($keys);
+
+            if ([] === $keys) {
+                $io->writeln('No cooldown keys found.');
+
+                return;
+            }
+
+            $rows = [];
+            foreach ($keys as $key) {
+                $timestamp = $this->redisGet($key);
+                $ttl = $this->redisTtl($key);
+                $cooldownUntil = $this->formatTimestamp($timestamp);
+                $rows[] = [$key, $cooldownUntil, null === $ttl ? 'n/a' : (string) $ttl];
+            }
+
+            $io->table(['key', 'cooldown_until', 'ttl_seconds'], $rows);
+        } catch (\Throwable $e) {
+            $io->warning('Cannot read Redis cooldown keys: '.$e->getMessage());
+        }
+    }
+
+    private function renderQueueSizes(SymfonyStyle $io): void
+    {
+        $io->section('Redis queue sizes');
+        $rows = [];
+
+        foreach ([
+            'XLEN '.self::WB_QUEUE_STREAM => static fn (self $command): ?int => $command->redisXLen(self::WB_QUEUE_STREAM),
+            'ZCARD '.self::WB_QUEUE_DELAYED => static fn (self $command): ?int => $command->redisZCard(self::WB_QUEUE_DELAYED),
+        ] as $label => $reader) {
+            try {
+                $value = $reader($this);
+                $rows[] = [$label, null === $value ? 'n/a' : (string) $value];
+            } catch (\Throwable $e) {
+                $rows[] = [$label, 'error: '.$e->getMessage()];
+            }
+        }
+
+        $io->table(['metric', 'value'], $rows);
+    }
+
+    private function renderStatusCounts(SymfonyStyle $io): void
+    {
+        $io->section('WB sales_report sync_status counts');
+
+        try {
+            $rows = $this->connection->fetchAllAssociative(
+                "SELECT status, COUNT(*) AS count
+                 FROM marketplace_financial_report_sync_statuses
+                 WHERE marketplace = 'wildberries' AND report_type = 'sales_report'
+                 GROUP BY status
+                 ORDER BY status",
+            );
+            $countByStatus = [];
+            foreach ($rows as $row) {
+                $countByStatus[(string) $row['status']] = (int) $row['count'];
+            }
+
+            $io->table(['status', 'count'], array_map(
+                static fn (string $status): array => [$status, (string) ($countByStatus[$status] ?? 0)],
+                ['queued', 'failed', 'success', 'loading', 'raw_loaded', 'processing'],
+            ));
+        } catch (\Throwable $e) {
+            $io->warning('Cannot read sync_status counts: '.$e->getMessage());
+        }
+    }
+
+    private function renderRetryAndErrorDiagnostics(SymfonyStyle $io): void
+    {
+        $io->section('Retry / 429 diagnostics');
+
+        $rows = [];
+        try {
+            $dueRetry = $this->connection->fetchOne(
+                "SELECT COUNT(*)
+                 FROM marketplace_financial_report_sync_statuses
+                 WHERE marketplace = 'wildberries'
+                   AND report_type = 'sales_report'
+                   AND status IN ('queued', 'failed')
+                   AND next_retry_at IS NOT NULL
+                   AND next_retry_at <= NOW()",
+            );
+            $rows[] = ['due_retry_count', (string) (int) $dueRetry];
+        } catch (\Throwable $e) {
+            $rows[] = ['due_retry_count', 'error: '.$e->getMessage()];
+        }
+
+        try {
+            $last429 = $this->connection->fetchOne(
+                "SELECT MAX(created_at)
+                 FROM marketplace_financial_report_sync_errors
+                 WHERE status_code = 429",
+            );
+            $rows[] = ['last_429_time', false === $last429 || null === $last429 ? 'n/a' : (string) $last429];
+        } catch (\Throwable $e) {
+            $rows[] = ['last_429_time', 'error: '.$e->getMessage()];
+        }
+
+        $io->table(['metric', 'value'], $rows);
+    }
+
+    private function renderRawDiagnostics(SymfonyStyle $io): void
+    {
+        $io->section('Raw/status consistency');
+
+        try {
+            $rows = $this->connection->fetchAllAssociative(
+                "SELECT s.company_id, s.connection_id, s.business_date, s.raw_document_id, r.processed_at, r.records_count
+                 FROM marketplace_financial_report_sync_statuses s
+                 INNER JOIN marketplace_raw_documents r ON r.id = s.raw_document_id
+                 WHERE s.marketplace = 'wildberries'
+                   AND s.report_type = 'sales_report'
+                   AND r.marketplace = 'wildberries'
+                   AND r.document_type = 'sales_report'
+                   AND r.processing_status = 'completed'
+                 ORDER BY COALESCE(r.processed_at, r.synced_at) DESC
+                 LIMIT 20",
+            );
+            $io->writeln('Last successful raw per connection/date:');
+            $this->renderRows($io, ['company_id', 'connection_id', 'business_date', 'raw_document_id', 'processed_at', 'records_count'], $rows);
+        } catch (\Throwable $e) {
+            $io->warning('Cannot read last successful raw documents: '.$e->getMessage());
+        }
+
+        try {
+            $rows = $this->connection->fetchAllAssociative(
+                "SELECT s.company_id, s.connection_id, s.business_date, s.status, s.raw_document_id, r.processing_status, r.processed_at
+                 FROM marketplace_financial_report_sync_statuses s
+                 INNER JOIN marketplace_raw_documents r ON r.id = s.raw_document_id
+                 WHERE s.marketplace = 'wildberries'
+                   AND s.report_type = 'sales_report'
+                   AND r.marketplace = 'wildberries'
+                   AND r.document_type = 'sales_report'
+                   AND r.processing_status = 'completed'
+                   AND s.status IN ('failed', 'queued')
+                 ORDER BY COALESCE(r.processed_at, r.synced_at) DESC
+                 LIMIT 50",
+            );
+            $io->writeln('Mismatch: raw completed exists, but sync_status failed/queued:');
+            $this->renderRows($io, ['company_id', 'connection_id', 'business_date', 'status', 'raw_document_id', 'processing_status', 'processed_at'], $rows);
+        } catch (\Throwable $e) {
+            $io->warning('Cannot read raw/status mismatches: '.$e->getMessage());
+        }
+    }
+
+    /** @param list<string> $headers @param list<array<string,mixed>> $rows */
+    private function renderRows(SymfonyStyle $io, array $headers, array $rows): void
+    {
+        if ([] === $rows) {
+            $io->writeln('none');
+
+            return;
+        }
+
+        $io->table($headers, array_map(
+            static fn (array $row): array => array_map(static fn (string $header): string => (string) ($row[$header] ?? ''), $headers),
+            $rows,
+        ));
+    }
+
+    /** @return list<string> */
+    private function redisKeys(string $pattern): array
+    {
+        $keys = $this->redisClient->keys($pattern);
+        if (!is_array($keys)) {
+            return [];
+        }
+
+        return array_values(array_map(static fn (mixed $key): string => (string) $key, $keys));
+    }
+
+    private function redisGet(string $key): ?string
+    {
+        $value = $this->redisClient->get($key);
+        if (false === $value || null === $value || '' === $value) {
+            return null;
+        }
+
+        return (string) $value;
+    }
+
+    private function redisTtl(string $key): ?int
+    {
+        $ttl = $this->redisClient->ttl($key);
+        if (false === $ttl || null === $ttl) {
+            return null;
+        }
+
+        return (int) $ttl;
+    }
+
+    private function redisXLen(string $key): ?int
+    {
+        $value = $this->redisClient->xlen($key);
+        if (false === $value || null === $value) {
+            return null;
+        }
+
+        return (int) $value;
+    }
+
+    private function redisZCard(string $key): ?int
+    {
+        $value = $this->redisClient->zcard($key);
+        if (false === $value || null === $value) {
+            return null;
+        }
+
+        return (int) $value;
+    }
+
+    private function formatTimestamp(?string $timestamp): string
+    {
+        if (null === $timestamp || !ctype_digit($timestamp)) {
+            return 'n/a';
+        }
+
+        return (new \DateTimeImmutable('@'.$timestamp))->format(\DateTimeInterface::ATOM);
+    }
+}

--- a/site/src/Marketplace/Entity/MarketplaceFinancialReportSyncStatus.php
+++ b/site/src/Marketplace/Entity/MarketplaceFinancialReportSyncStatus.php
@@ -255,6 +255,15 @@ class MarketplaceFinancialReportSyncStatus
         $this->updatedAt = new \DateTimeImmutable();
     }
 
+    public function recordRetryableError(string $errorClass, string $errorMessage, ?int $statusCode, ?string $responseExcerpt): void
+    {
+        $this->lastErrorClass = $errorClass;
+        $this->lastErrorMessage = $errorMessage;
+        $this->lastErrorStatusCode = $statusCode;
+        $this->lastErrorResponseExcerpt = $responseExcerpt;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
     public function markFailedRetryablePreservingCursor(
         string $errorClass,
         string $errorMessage,

--- a/site/src/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClient.php
+++ b/site/src/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClient.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Marketplace\Infrastructure\Api\Wildberries;
 
 use App\Marketplace\Application\Service\WbFinanceRateLimiter;
+use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Exception\MarketplaceAuthException;
 use App\Marketplace\Exception\MarketplaceBadRequestException;
 use App\Marketplace\Exception\MarketplaceInvalidApiResponseException;
@@ -22,6 +23,7 @@ final readonly class WbFinanceSalesReportClient
     private const WB_HEADER_RETRY = 'x-ratelimit-retry';
     private const WB_HEADER_RESET = 'x-ratelimit-reset';
     private const SALES_REPORTS_RATE_LIMIT_KEY_PREFIX = 'wb_finance_sales_reports';
+    private const GLOBAL_SELLER_BUCKET = 'global';
 
     private LoggerInterface $logger;
     private WbFinanceRateLimiter $rateLimiter;
@@ -35,35 +37,65 @@ final readonly class WbFinanceSalesReportClient
         $this->rateLimiter = $rateLimiter;
     }
 
-
     /** @return list<array<string,mixed>> */
-    public function fetchDetailedDay(string $connectionId, string $apiKey, \DateTimeImmutable $businessDate): array
+    public function fetchDetailedDay(string $connectionId, string $apiKey, \DateTimeImmutable $businessDate, ?string $sellerBucketId = null): array
     {
         $date = $businessDate->format('Y-m-d');
 
-        return $this->fetchDetailedInternal($apiKey, $date, $date);
+        return $this->fetchDetailedInternal($apiKey, $date, $date, $sellerBucketId);
     }
 
-    public function fetchDetailedDayPage(string $connectionId, string $apiKey, \DateTimeImmutable $businessDate, int $rrdId, bool $rateLimitTokenConsumed = false): WbFinanceSalesReportPage
+    public function fetchDetailedDayPage(string $connectionId, string $apiKey, \DateTimeImmutable $businessDate, int $rrdId, bool $rateLimitTokenConsumed = false, ?string $sellerBucketId = null): WbFinanceSalesReportPage
     {
         $date = $businessDate->format('Y-m-d');
 
-        return $this->fetchDetailedPage($apiKey, $date, $date, $rrdId, self::PAGE_SIZE, $rateLimitTokenConsumed);
+        return $this->fetchDetailedPage($apiKey, $date, $date, $rrdId, self::PAGE_SIZE, $rateLimitTokenConsumed, $sellerBucketId);
     }
 
     /**
-     * The $connectionId parameter is retained for caller context compatibility; throttling is per seller WB API token.
+     * The $connectionId parameter is retained for caller context compatibility; throttling is per seller bucket.
+     * Unknown seller/account identifiers intentionally share the global bucket.
      *
      * @return list<array<string,mixed>>
      */
-    public function fetchDetailedForConnection(string $connectionId, string $apiKey, string $dateFrom, string $dateTo): array
+    public function fetchDetailedForConnection(string $connectionId, string $apiKey, string $dateFrom, string $dateTo, ?string $sellerBucketId = null): array
     {
-        return $this->fetchDetailedInternal($apiKey, $dateFrom, $dateTo);
+        return $this->fetchDetailedInternal($apiKey, $dateFrom, $dateTo, $sellerBucketId);
     }
 
     public function tryConsume(string $sellerRateLimitKey): ?\DateTimeImmutable
     {
         return $this->rateLimiter->tryConsume($sellerRateLimitKey);
+    }
+
+    public function resolveSalesReportsSellerBucketId(MarketplaceConnection $connection): string
+    {
+        return $this->rateLimiter->resolveSalesReportsSellerBucketId($connection);
+    }
+
+    public function buildSalesReportsRateLimitKeyForSellerBucket(string $sellerBucketId): string
+    {
+        return $this->rateLimiter->buildSalesReportsRateLimitKeyForSellerBucket($sellerBucketId);
+    }
+
+    public function getActiveSalesReportsCooldownUntil(string $sellerBucketId): ?\DateTimeImmutable
+    {
+        return $this->rateLimiter->getActiveSalesReportsCooldownUntil($sellerBucketId);
+    }
+
+    public function setSalesReportsCooldownUntil(string $sellerBucketId, \DateTimeImmutable $cooldownUntil): void
+    {
+        $this->rateLimiter->setSalesReportsCooldownUntil($sellerBucketId, $cooldownUntil);
+    }
+
+    public function cooldownUntilAfterRemote429(?int $retryAfterSeconds, int $defaultSeconds = 900): \DateTimeImmutable
+    {
+        return $this->rateLimiter->cooldownUntilAfterRemote429($retryAfterSeconds, $defaultSeconds);
+    }
+
+    public function buildSalesReportsCooldownKey(string $sellerBucketId): string
+    {
+        return $this->rateLimiter->buildSalesReportsCooldownKey($sellerBucketId);
     }
 
     public function buildSalesReportsRateLimitKeyForApiKey(string $apiKey): string
@@ -72,23 +104,23 @@ final readonly class WbFinanceSalesReportClient
     }
 
     /**
-     * @deprecated Use fetchDetailedForConnection() in production flows when connection context is available; local throttling is per seller WB API token, not per connection.
+     * @deprecated Use fetchDetailedForConnection() in production flows when connection context is available; unknown context uses the shared global bucket.
      *
      * @return list<array<string,mixed>>
      */
     public function fetchDetailed(string $apiKey, string $dateFrom, string $dateTo): array
     {
-        return $this->fetchDetailedInternal($apiKey, $dateFrom, $dateTo);
+        return $this->fetchDetailedInternal($apiKey, $dateFrom, $dateTo, null);
     }
 
     /** @return list<array<string,mixed>> */
-    private function fetchDetailedInternal(string $apiKey, string $dateFrom, string $dateTo): array
+    private function fetchDetailedInternal(string $apiKey, string $dateFrom, string $dateTo, ?string $sellerBucketId): array
     {
         $rows = [];
         $rrdId = 0;
 
         do {
-            $page = $this->fetchDetailedPage($apiKey, $dateFrom, $dateTo, $rrdId, self::PAGE_SIZE);
+            $page = $this->fetchDetailedPage($apiKey, $dateFrom, $dateTo, $rrdId, self::PAGE_SIZE, false, $sellerBucketId);
             $rows = [...$rows, ...$page->rows];
             $rrdId = $page->nextRrdId ?? $rrdId;
         } while ($page->hasNextPage);
@@ -96,12 +128,15 @@ final readonly class WbFinanceSalesReportClient
         return $rows;
     }
 
-    private function fetchDetailedPage(string $apiKey, string $dateFrom, string $dateTo, int $rrdId, int $limit, bool $rateLimitTokenConsumed = false): WbFinanceSalesReportPage
+    private function fetchDetailedPage(string $apiKey, string $dateFrom, string $dateTo, int $rrdId, int $limit, bool $rateLimitTokenConsumed = false, ?string $sellerBucketId = null): WbFinanceSalesReportPage
     {
+        $sellerBucketId = $this->normalizeSellerBucketId($sellerBucketId);
+        $this->guardCooldown($sellerBucketId, $dateFrom, $dateTo);
+
         if (!$rateLimitTokenConsumed) {
-            $retryAfter = $this->rateLimiter->tryConsume($this->buildSalesReportsRateLimitKeyForApiKey($apiKey));
+            $retryAfter = $this->rateLimiter->tryConsume($this->rateLimiter->buildSalesReportsRateLimitKeyForSellerBucket($sellerBucketId));
             if (null !== $retryAfter) {
-                throw new MarketplaceRateLimitException(429, '', $dateFrom, $dateTo, $this->secondsUntil($retryAfter));
+                throw new MarketplaceRateLimitException(429, '', $dateFrom, $dateTo, $this->rateLimiter->secondsUntil($retryAfter));
             }
         }
 
@@ -132,7 +167,10 @@ final readonly class WbFinanceSalesReportClient
         }
 
         if (429 === $statusCode) {
-            throw new MarketplaceRateLimitException($statusCode, $excerpt, $dateFrom, $dateTo, $this->extractRetryAfter($headers));
+            $retryAfter = $this->extractRetryAfter($headers);
+            $this->setSalesReportsCooldownUntil($sellerBucketId, $this->cooldownUntilAfterRemote429($retryAfter));
+
+            throw new MarketplaceRateLimitException($statusCode, $excerpt, $dateFrom, $dateTo, $retryAfter);
         }
         if (401 === $statusCode || 403 === $statusCode) {
             throw new MarketplaceAuthException('WB API authentication failed.', $statusCode, $excerpt, $dateFrom, $dateTo);
@@ -184,10 +222,14 @@ final readonly class WbFinanceSalesReportClient
 
 
 
-    public function probeAccess(string $apiKey): bool
+    public function probeAccess(string $apiKey, ?string $sellerBucketId = null): bool
     {
         // Probe is used for explicit credential checks (e.g. verify connection),
         // not for report sync pipeline, so local report throttling is not applied here.
+        // Shared cooldown still protects the WB Finance API from requests during a remote 429 cooldown.
+        $sellerBucketId = $this->normalizeSellerBucketId($sellerBucketId);
+        $this->guardCooldown($sellerBucketId, '', '');
+
         try {
             $response = $this->httpClient->request('GET', self::BASE_URL.'/ping', [
                 'headers' => ['Authorization' => $apiKey],
@@ -238,7 +280,10 @@ final readonly class WbFinanceSalesReportClient
             return false;
         }
         if (429 === $statusCode) {
-            throw new MarketplaceRateLimitException($statusCode, $excerpt, '', '', $this->extractRetryAfter($headers));
+            $retryAfter = $this->extractRetryAfter($headers);
+            $this->setSalesReportsCooldownUntil($sellerBucketId, $this->cooldownUntilAfterRemote429($retryAfter));
+
+            throw new MarketplaceRateLimitException($statusCode, $excerpt, '', '', $retryAfter);
         }
         if (400 === $statusCode) {
             throw new MarketplaceBadRequestException('WB finance ping rejected request.', $statusCode, $excerpt, '', '');
@@ -251,18 +296,31 @@ final readonly class WbFinanceSalesReportClient
     }
 
 
-    public function hasAnyDataForConnection(string $connectionId, string $apiKey, string $dateFrom, string $dateTo): bool
+    public function hasAnyDataForConnection(string $connectionId, string $apiKey, string $dateFrom, string $dateTo, ?string $sellerBucketId = null): bool
     {
-        $retryAfter = $this->rateLimiter->tryConsume($this->buildSalesReportsRateLimitKeyForApiKey($apiKey));
+        $sellerBucketId = $this->normalizeSellerBucketId($sellerBucketId);
+        $this->guardCooldown($sellerBucketId, $dateFrom, $dateTo);
+
+        $retryAfter = $this->rateLimiter->tryConsume($this->rateLimiter->buildSalesReportsRateLimitKeyForSellerBucket($sellerBucketId));
         if (null !== $retryAfter) {
-            throw new MarketplaceRateLimitException(429, '', $dateFrom, $dateTo, $this->secondsUntil($retryAfter));
+            throw new MarketplaceRateLimitException(429, '', $dateFrom, $dateTo, $this->rateLimiter->secondsUntil($retryAfter));
         }
 
-        return $this->hasAnyData($apiKey, $dateFrom, $dateTo);
+        return $this->hasAnyData($apiKey, $dateFrom, $dateTo, $sellerBucketId, true);
     }
 
-    public function hasAnyData(string $apiKey, string $dateFrom, string $dateTo): bool
+    public function hasAnyData(string $apiKey, string $dateFrom, string $dateTo, ?string $sellerBucketId = null, bool $rateLimitTokenConsumed = false): bool
     {
+        $sellerBucketId = $this->normalizeSellerBucketId($sellerBucketId);
+        $this->guardCooldown($sellerBucketId, $dateFrom, $dateTo);
+
+        if (!$rateLimitTokenConsumed) {
+            $retryAfter = $this->rateLimiter->tryConsume($this->rateLimiter->buildSalesReportsRateLimitKeyForSellerBucket($sellerBucketId));
+            if (null !== $retryAfter) {
+                throw new MarketplaceRateLimitException(429, '', $dateFrom, $dateTo, $this->rateLimiter->secondsUntil($retryAfter));
+            }
+        }
+
         try {
             $response = $this->httpClient->request('POST', self::BASE_URL.'/api/finance/v1/sales-reports/detailed', [
                 'headers' => ['Authorization' => $apiKey],
@@ -287,7 +345,10 @@ final readonly class WbFinanceSalesReportClient
             return false;
         }
         if (429 === $statusCode) {
-            throw new MarketplaceRateLimitException($statusCode, $excerpt, $dateFrom, $dateTo, $this->extractRetryAfter($headers));
+            $retryAfter = $this->extractRetryAfter($headers);
+            $this->setSalesReportsCooldownUntil($sellerBucketId, $this->cooldownUntilAfterRemote429($retryAfter));
+
+            throw new MarketplaceRateLimitException($statusCode, $excerpt, $dateFrom, $dateTo, $retryAfter);
         }
         if (401 === $statusCode || 403 === $statusCode) {
             throw new MarketplaceAuthException('WB API authentication failed.', $statusCode, $excerpt, $dateFrom, $dateTo);
@@ -321,9 +382,23 @@ final readonly class WbFinanceSalesReportClient
         return [] !== $decoded;
     }
 
-    private function secondsUntil(\DateTimeImmutable $retryAfter): int
+    private function guardCooldown(string $sellerBucketId, string $dateFrom, string $dateTo): void
     {
-        return max(1, $retryAfter->getTimestamp() - (new \DateTimeImmutable())->getTimestamp());
+        $cooldownUntil = $this->rateLimiter->getActiveSalesReportsCooldownUntil($sellerBucketId);
+        if (null === $cooldownUntil) {
+            return;
+        }
+
+        throw new MarketplaceRateLimitException(429, '', $dateFrom, $dateTo, $this->rateLimiter->secondsUntil($cooldownUntil));
+    }
+
+    private function normalizeSellerBucketId(?string $sellerBucketId): string
+    {
+        if (null === $sellerBucketId || '' === trim($sellerBucketId)) {
+            return self::GLOBAL_SELLER_BUCKET;
+        }
+
+        return $sellerBucketId;
     }
 
     private function buildSalesReportsRateLimitKey(string $tokenHash): string

--- a/site/src/Marketplace/Infrastructure/Redis/WbFinanceRedisCooldownStorage.php
+++ b/site/src/Marketplace/Infrastructure/Redis/WbFinanceRedisCooldownStorage.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Redis;
+
+use App\Marketplace\Application\Service\WbFinanceCooldownStorageInterface;
+
+final readonly class WbFinanceRedisCooldownStorage implements WbFinanceCooldownStorageInterface
+{
+    public function __construct(private object $redisClient) {}
+
+    public function getUntilTimestamp(string $key): ?int
+    {
+        $value = $this->redisClient->get($key);
+        if (null === $value || false === $value || '' === $value) {
+            return null;
+        }
+
+        $timestamp = (int) $value;
+
+        return $timestamp > 0 ? $timestamp : null;
+    }
+
+    public function setUntilTimestamp(string $key, int $untilTimestamp, int $ttlSeconds): void
+    {
+        $script = <<<'LUA'
+local current = redis.call('GET', KEYS[1])
+if (not current) or (tonumber(current) < tonumber(ARGV[1])) then
+    redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[2])
+    return ARGV[1]
+end
+return current
+LUA;
+
+        if (is_a($this->redisClient, 'Redis')) {
+            $this->redisClient->eval($script, [$key, (string) $untilTimestamp, (string) max(1, $ttlSeconds)], 1);
+
+            return;
+        }
+
+        $this->redisClient->eval($script, 1, $key, (string) $untilTimestamp, (string) max(1, $ttlSeconds));
+    }
+}

--- a/site/src/Marketplace/MessageHandler/SyncWbFinancialReportDayHandler.php
+++ b/site/src/Marketplace/MessageHandler/SyncWbFinancialReportDayHandler.php
@@ -172,8 +172,35 @@ final class SyncWbFinancialReportDayHandler
             return;
         }
 
+        $sellerBucketId = $this->financeSalesReportClient->resolveSalesReportsSellerBucketId($connection);
+        $cooldownUntil = $this->financeSalesReportClient->getActiveSalesReportsCooldownUntil($sellerBucketId);
+        if (null !== $cooldownUntil) {
+            $this->syncStatusUpdater->markPageQueued($status, $mode, $message->forceRefresh, $cooldownUntil, $effectiveRawDocumentId, $effectiveRrdId);
+            $this->em->flush();
+            $this->dispatchContinuation(new SyncWbFinancialReportDayMessage(
+                $message->companyId,
+                $message->connectionId,
+                $message->businessDate,
+                $message->mode,
+                $message->forceRefresh,
+                $effectiveRrdId,
+                $effectiveRawDocumentId,
+            ), $cooldownUntil);
+
+            $this->logger->info('WB finance cooldown active, API request skipped', [
+                'cooldown_until' => $cooldownUntil->format(\DateTimeInterface::ATOM),
+                'company_id' => $message->companyId,
+                'connection_id' => $message->connectionId,
+                'business_date' => $businessDate->format('Y-m-d'),
+                'mode' => $mode->value,
+                'seller_bucket_id' => $sellerBucketId,
+            ]);
+
+            return;
+        }
+
         $apiKey = $connection->getApiKey();
-        $sellerRateLimitKey = $this->financeSalesReportClient->buildSalesReportsRateLimitKeyForApiKey($apiKey);
+        $sellerRateLimitKey = $this->financeSalesReportClient->buildSalesReportsRateLimitKeyForSellerBucket($sellerBucketId);
         $retryAfter = $this->financeSalesReportClient->tryConsume($sellerRateLimitKey);
         if (null !== $retryAfter) {
             $this->syncStatusUpdater->markPageQueued($status, $mode, $message->forceRefresh, $retryAfter, $effectiveRawDocumentId, $effectiveRrdId);
@@ -204,7 +231,7 @@ final class SyncWbFinancialReportDayHandler
         $this->syncStatusUpdater->markLoading($status, $mode);
 
         try {
-            $page = $this->financeSalesReportClient->fetchDetailedDayPage($connection->getId(), $apiKey, $businessDate, $effectiveRrdId, true);
+            $page = $this->financeSalesReportClient->fetchDetailedDayPage($connection->getId(), $apiKey, $businessDate, $effectiveRrdId, true, $sellerBucketId);
 
             if ([] === $page->rows && null === $effectiveRawDocumentId) {
                 $this->syncStatusUpdater->markEmpty($status);
@@ -287,20 +314,23 @@ final class SyncWbFinancialReportDayHandler
                 'raw_document_id' => $rawDocument->getId(),
             ]);
         } catch (MarketplaceRateLimitException $e) {
-            $nextRetryAt = null !== $e->getRetryAfter()
-                ? $this->retryAfterFromNow(max(1, $e->getRetryAfter()))
-                : $this->retryAfterFromNow(15 * 60);
+            $nextRetryAt = $this->financeSalesReportClient->cooldownUntilAfterRemote429($e->getRetryAfter());
+            $this->financeSalesReportClient->setSalesReportsCooldownUntil($sellerBucketId, $nextRetryAt);
 
-            $this->syncStatusUpdater->markFailedRetryablePreservingCursor(
+            $this->syncStatusUpdater->markPageQueued(
+                $status,
+                $mode,
+                $message->forceRefresh,
+                $nextRetryAt,
+                $effectiveRawDocumentId,
+                $effectiveRrdId,
+            );
+            $this->syncStatusUpdater->recordRetryableError(
                 $status,
                 $e::class,
                 $e->getMessage(),
                 $e->getStatusCode(),
                 $e->getResponseExcerpt(),
-                null,
-                $nextRetryAt,
-                $effectiveRawDocumentId,
-                $effectiveRrdId,
             );
             $this->em->flush();
             $this->dispatchContinuation(new SyncWbFinancialReportDayMessage(
@@ -313,7 +343,8 @@ final class SyncWbFinancialReportDayHandler
                 $effectiveRawDocumentId,
             ), $nextRetryAt);
 
-            $this->logger->warning('WB day sync rate-limited, retry scheduled.', [
+            $this->logger->warning('WB finance cooldown set after remote 429', [
+                'cooldown_until' => $nextRetryAt->format(\DateTimeInterface::ATOM),
                 'company_id' => $message->companyId,
                 'connection_id' => $message->connectionId,
                 'business_date' => $businessDate->format('Y-m-d'),

--- a/site/src/Marketplace/Service/Integration/WildberriesAdapter.php
+++ b/site/src/Marketplace/Service/Integration/WildberriesAdapter.php
@@ -38,7 +38,10 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
             return false;
         }
 
-        return $this->salesReportClient->probeAccess($connection->getApiKey());
+        return $this->salesReportClient->probeAccess(
+            $connection->getApiKey(),
+            $this->salesReportClient->resolveSalesReportsSellerBucketId($connection),
+        );
     }
 
     public function fetchRawReport(
@@ -60,6 +63,7 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
             $connection->getApiKey(),
             $dateFrom,
             $dateTo,
+            $this->salesReportClient->resolveSalesReportsSellerBucketId($connection),
         );
     }
 
@@ -82,6 +86,7 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
             $connection->getApiKey(),
             $dateFrom,
             $dateTo,
+            $this->salesReportClient->resolveSalesReportsSellerBucketId($connection),
         );
     }
 

--- a/site/tests/Integration/Marketplace/MessageHandler/SyncWbFinancialReportDayHandlerTest.php
+++ b/site/tests/Integration/Marketplace/MessageHandler/SyncWbFinancialReportDayHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Integration\Marketplace\MessageHandler;
 
+use App\Marketplace\Application\Service\WbFinanceCooldownStorageInterface;
 use App\Marketplace\Application\Service\WbFinanceRateLimiter;
 use App\Company\Entity\Company;
 use App\Marketplace\Entity\MarketplaceConnection;
@@ -98,6 +99,78 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
             self::assertNotNull($error);
             self::assertSame('App\Marketplace\Exception\MarketplaceTemporaryApiException', $error->getErrorClass());
         }
+    }
+
+    public function testRemote429SetsSharedCooldownAndNextDaySkipsHttp(): void
+    {
+        $company = $this->createCompany(9291);
+        $connection = $this->createWbSellerConnection($company, 9291);
+        $connection->setSettings(['seller_id' => 'seller-9291']);
+        $this->em->flush();
+        $bus = $this->swapBusSpy();
+        $storage = new InMemoryWbFinanceCooldownStorage();
+        $requestCount = 0;
+        $http = new MockHttpClient(static function () use (&$requestCount): MockResponse {
+            ++$requestCount;
+
+            return new MockResponse('{"error":"rate"}', ['http_code' => 429, 'response_headers' => ['x-ratelimit-retry: 120']]);
+        });
+        self::getContainer()->set(WbFinanceSalesReportClient::class, new WbFinanceSalesReportClient($http, $this->createRateLimiter($storage)));
+
+        $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
+        $handler($this->message($company->getId(), $connection->getId(), false));
+        $handler(new SyncWbFinancialReportDayMessage($company->getId(), $connection->getId(), '2026-05-20', FinancialReportSyncMode::DAILY->value, false));
+
+        self::assertSame(1, $requestCount);
+        self::assertNotNull($storage->getUntilTimestamp('wb_finance:sales_reports:cooldown:seller-9291'));
+
+        $firstStatus = $this->findStatus($connection->getId(), $company->getId(), '2026-05-19');
+        $secondStatus = $this->findStatus($connection->getId(), $company->getId(), '2026-05-20');
+        self::assertNotNull($firstStatus);
+        self::assertNotNull($secondStatus);
+        self::assertSame(FinancialReportSyncStatus::QUEUED, $firstStatus->getStatus());
+        self::assertSame(FinancialReportSyncStatus::QUEUED, $secondStatus->getStatus());
+        self::assertCount(2, $this->filterSyncMessages($bus->messages));
+    }
+
+    public function testFallbackGlobalBucketPreventsTwoUnknownSellerConnectionsFromCallingApiBackToBack(): void
+    {
+        $companyA = $this->createCompany(9292);
+        $companyB = $this->createCompany(9293);
+        $connectionA = $this->createWbSellerConnection($companyA, 9292);
+        $connectionB = $this->createWbSellerConnection($companyB, 9293);
+        $this->swapBusSpy();
+        $requestCount = 0;
+        $http = new MockHttpClient(static function () use (&$requestCount): MockResponse {
+            ++$requestCount;
+
+            return new MockResponse('', ['http_code' => 204]);
+        });
+        self::getContainer()->set(WbFinanceSalesReportClient::class, new WbFinanceSalesReportClient($http, $this->createRateLimiter(new InMemoryWbFinanceCooldownStorage())));
+
+        $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
+        $handler($this->message($companyA->getId(), $connectionA->getId(), false));
+        $handler($this->message($companyB->getId(), $connectionB->getId(), false));
+
+        self::assertSame(1, $requestCount);
+        $secondStatus = $this->findStatus($connectionB->getId(), $companyB->getId(), '2026-05-19');
+        self::assertNotNull($secondStatus);
+        self::assertSame(FinancialReportSyncStatus::QUEUED, $secondStatus->getStatus());
+    }
+
+    public function testCooldownExpiresAndAllowsApiRequestAgain(): void
+    {
+        $storage = new InMemoryWbFinanceCooldownStorage();
+        $clock = new MockClock('2026-05-19T00:00:00Z');
+        $limiter = $this->createRateLimiter($storage, $clock);
+
+        $limiter->setSalesReportsCooldownUntil('seller-after-cooldown', new \DateTimeImmutable('2026-05-19T00:01:00Z'));
+        self::assertNotNull($limiter->getActiveSalesReportsCooldownUntil('seller-after-cooldown'));
+
+        $clock->modify('+61 seconds');
+
+        self::assertNull($limiter->getActiveSalesReportsCooldownUntil('seller-after-cooldown'));
+        self::assertNull($limiter->tryConsume($limiter->buildSalesReportsRateLimitKeyForSellerBucket('seller-after-cooldown')));
     }
 
     public function testConflictMarksConflictAndThrowsUnrecoverable(): void
@@ -556,8 +629,29 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
             'periodTo' => new \DateTimeImmutable($date),
         ]);
     }
-    private function createRateLimiter(): WbFinanceRateLimiter
+    private function createRateLimiter(?WbFinanceCooldownStorageInterface $storage = null, ?MockClock $clock = null): WbFinanceRateLimiter
     {
-        return new WbFinanceRateLimiter(new RateLimiterFactory(['id' => 'wb_finance', 'policy' => 'token_bucket', 'limit' => 1, 'rate' => ['interval' => '61 seconds', 'amount' => 1]], new InMemoryStorage()), new MockClock('2026-01-01T00:00:00Z'));
+        return new WbFinanceRateLimiter(
+            new RateLimiterFactory(['id' => 'wb_finance', 'policy' => 'token_bucket', 'limit' => 1, 'rate' => ['interval' => '61 seconds', 'amount' => 1]], new InMemoryStorage()),
+            $clock ?? new MockClock('2026-01-01T00:00:00Z'),
+            null,
+            $storage,
+        );
+    }
+}
+
+final class InMemoryWbFinanceCooldownStorage implements WbFinanceCooldownStorageInterface
+{
+    /** @var array<string, int> */
+    private array $values = [];
+
+    public function getUntilTimestamp(string $key): ?int
+    {
+        return $this->values[$key] ?? null;
+    }
+
+    public function setUntilTimestamp(string $key, int $untilTimestamp, int $ttlSeconds): void
+    {
+        $this->values[$key] = $untilTimestamp;
     }
 }

--- a/site/tests/Unit/Marketplace/Command/WbFinanceDiagnosticsCommandTest.php
+++ b/site/tests/Unit/Marketplace/Command/WbFinanceDiagnosticsCommandTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Command;
+
+use App\Marketplace\Command\WbFinanceDiagnosticsCommand;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class WbFinanceDiagnosticsCommandTest extends TestCase
+{
+    public function testDiagnosticsCommandSmoke(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn([]);
+        $connection->method('fetchOne')->willReturn(0);
+
+        $command = new WbFinanceDiagnosticsCommand(new DiagnosticsRedisFake(), new stdClass(), new stdClass(), $connection);
+        $tester = new CommandTester($command);
+
+        self::assertSame(Command::SUCCESS, $tester->execute([]));
+        $display = $tester->getDisplay();
+
+        self::assertStringContainsString('Redis / limiter', $display);
+        self::assertStringContainsString('Redis cooldown keys', $display);
+        self::assertStringContainsString('Redis queue sizes', $display);
+        self::assertStringContainsString('WB sales_report sync_status counts', $display);
+    }
+}
+
+final class DiagnosticsRedisFake
+{
+    /** @return list<string> */
+    public function keys(string $pattern): array
+    {
+        return ['wb_finance:sales_reports:cooldown:seller-1'];
+    }
+
+    public function get(string $key): string
+    {
+        return '1767225600';
+    }
+
+    public function ttl(string $key): int
+    {
+        return 60;
+    }
+
+    public function xlen(string $key): int
+    {
+        return 1;
+    }
+
+    public function zcard(string $key): int
+    {
+        return 2;
+    }
+}

--- a/site/tests/Unit/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClientTest.php
+++ b/site/tests/Unit/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClientTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Marketplace\Infrastructure\Api\Wildberries;
 
+use App\Marketplace\Application\Service\WbFinanceCooldownStorageInterface;
 use App\Marketplace\Application\Service\WbFinanceRateLimiter;
 use App\Marketplace\Exception\MarketplaceAuthException;
 use App\Marketplace\Exception\MarketplaceBadRequestException;
@@ -104,7 +105,7 @@ final class WbFinanceSalesReportClientTest extends TestCase
         }
     }
 
-    public function testFetchDetailedDayUsesDifferentLimiterBucketsForDifferentTokens(): void
+    public function testFetchDetailedDayUsesDifferentLimiterBucketsForDifferentSellerBuckets(): void
     {
         $requestCount = 0;
         $http = new MockHttpClient(static function () use (&$requestCount): MockResponse {
@@ -117,8 +118,8 @@ final class WbFinanceSalesReportClientTest extends TestCase
         $startTimestamp = $clock->now()->getTimestamp();
         $client = new WbFinanceSalesReportClient($http, $this->createRateLimiter($clock));
 
-        self::assertSame([], $client->fetchDetailedDay('connection-a', 'token-a', new \DateTimeImmutable('2026-01-15')));
-        self::assertSame([], $client->fetchDetailedDay('connection-b', 'token-b', new \DateTimeImmutable('2026-01-15')));
+        self::assertSame([], $client->fetchDetailedDay('connection-a', 'token-a', new \DateTimeImmutable('2026-01-15'), 'seller-a'));
+        self::assertSame([], $client->fetchDetailedDay('connection-b', 'token-b', new \DateTimeImmutable('2026-01-15'), 'seller-b'));
         self::assertSame(2, $requestCount);
         self::assertSame($startTimestamp, $clock->now()->getTimestamp());
     }
@@ -201,6 +202,33 @@ final class WbFinanceSalesReportClientTest extends TestCase
         self::assertSame(1, $captured[2]['limit'] ?? null);
         self::assertSame('2026-02-01', $captured[2]['dateFrom'] ?? null);
         self::assertSame('2026-02-03', $captured[2]['dateTo'] ?? null);
+    }
+
+    public function testHasAnyDataForConnectionStoresCooldownAfterRemote429AndSkipsNextHttpRequest(): void
+    {
+        $storage = new InMemoryWbFinanceCooldownStorage();
+        $requestCount = 0;
+        $http = new MockHttpClient(static function () use (&$requestCount): MockResponse {
+            ++$requestCount;
+
+            return new MockResponse('{"error":"rate"}', ['http_code' => 429, 'response_headers' => ['x-ratelimit-retry: 17']]);
+        });
+        $client = new WbFinanceSalesReportClient($http, $this->createRateLimiter(null, $storage));
+
+        try {
+            $client->hasAnyDataForConnection('connection-id', 'token', '2026-02-01', '2026-02-03', 'seller-has-any');
+            self::fail('Expected MarketplaceRateLimitException');
+        } catch (MarketplaceRateLimitException $e) {
+            self::assertSame(17, $e->getRetryAfter());
+        }
+
+        $this->expectException(MarketplaceRateLimitException::class);
+        try {
+            $client->hasAnyDataForConnection('connection-id', 'token', '2026-02-01', '2026-02-03', 'seller-has-any');
+        } finally {
+            self::assertSame(1, $requestCount);
+            self::assertNotNull($storage->getUntilTimestamp('wb_finance:sales_reports:cooldown:seller-has-any'));
+        }
     }
     public function test204ReturnsAccumulatedRows(): void
     {
@@ -343,6 +371,70 @@ final class WbFinanceSalesReportClientTest extends TestCase
         $client->probeAccess('token');
     }
 
+    public function testProbeAccessRespectsSellerCooldownWithoutHttpRequest(): void
+    {
+        $storage = new InMemoryWbFinanceCooldownStorage();
+        $clock = new MockClock('2026-01-01T00:00:00Z');
+        $storage->setUntilTimestamp('wb_finance:sales_reports:cooldown:seller-1', $clock->now()->modify('+60 seconds')->getTimestamp(), 60);
+        $requestCount = 0;
+        $http = new MockHttpClient(static function () use (&$requestCount): MockResponse {
+            ++$requestCount;
+
+            return new MockResponse('{"Status":"OK"}', ['http_code' => 200]);
+        });
+        $client = new WbFinanceSalesReportClient($http, $this->createRateLimiter($clock, $storage));
+
+        $this->expectException(MarketplaceRateLimitException::class);
+        try {
+            $client->probeAccess('token', 'seller-1');
+        } finally {
+            self::assertSame(0, $requestCount);
+        }
+    }
+
+    public function testProbeAccessRemote429SetsSellerCooldownAndNextProbeSkipsHttp(): void
+    {
+        $storage = new InMemoryWbFinanceCooldownStorage();
+        $requestCount = 0;
+        $http = new MockHttpClient(static function () use (&$requestCount): MockResponse {
+            ++$requestCount;
+
+            return new MockResponse('{"error":"rate"}', ['http_code' => 429, 'response_headers' => ['x-ratelimit-retry: 17']]);
+        });
+        $client = new WbFinanceSalesReportClient($http, $this->createRateLimiter(new MockClock('2026-01-01T00:00:00Z'), $storage));
+
+        try {
+            $client->probeAccess('token', 'seller-1');
+            self::fail('Expected MarketplaceRateLimitException');
+        } catch (MarketplaceRateLimitException $e) {
+            self::assertSame(17, $e->getRetryAfter());
+        }
+
+        $this->expectException(MarketplaceRateLimitException::class);
+        try {
+            $client->probeAccess('token', 'seller-1');
+        } finally {
+            self::assertSame(1, $requestCount);
+            self::assertNotNull($storage->getUntilTimestamp('wb_finance:sales_reports:cooldown:seller-1'));
+        }
+    }
+
+    public function testProbeAccessRemote429UsesGlobalCooldownFallback(): void
+    {
+        $storage = new InMemoryWbFinanceCooldownStorage();
+        $client = new WbFinanceSalesReportClient(
+            new MockHttpClient(new MockResponse('{"error":"rate"}', ['http_code' => 429, 'response_headers' => ['x-ratelimit-retry: 17']])),
+            $this->createRateLimiter(new MockClock('2026-01-01T00:00:00Z'), $storage),
+        );
+
+        $this->expectException(MarketplaceRateLimitException::class);
+        try {
+            $client->probeAccess('token', null);
+        } finally {
+            self::assertNotNull($storage->getUntilTimestamp('wb_finance:sales_reports:cooldown:global'));
+        }
+    }
+
     public function testProbeAccess5xxThrowsTemporaryApiException(): void
     {
         $client = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('{"error":"server"}', ['http_code' => 500])), $this->createRateLimiter());
@@ -359,7 +451,7 @@ final class WbFinanceSalesReportClientTest extends TestCase
         $this->expectException(MarketplaceTemporaryApiException::class);
         $client->probeAccess('token');
     }
-    private function createRateLimiter(?MockClock $clock = null): WbFinanceRateLimiter
+    private function createRateLimiter(?MockClock $clock = null, ?WbFinanceCooldownStorageInterface $storage = null): WbFinanceRateLimiter
     {
         $factory = new RateLimiterFactory(
             [
@@ -371,6 +463,22 @@ final class WbFinanceSalesReportClientTest extends TestCase
             new InMemoryStorage(),
         );
 
-        return new WbFinanceRateLimiter($factory, $clock ?? new MockClock());
+        return new WbFinanceRateLimiter($factory, $clock ?? new MockClock(), null, $storage);
+    }
+}
+
+final class InMemoryWbFinanceCooldownStorage implements WbFinanceCooldownStorageInterface
+{
+    /** @var array<string, int> */
+    private array $values = [];
+
+    public function getUntilTimestamp(string $key): ?int
+    {
+        return $this->values[$key] ?? null;
+    }
+
+    public function setUntilTimestamp(string $key, int $untilTimestamp, int $ttlSeconds): void
+    {
+        $this->values[$key] = max($this->values[$key] ?? 0, $untilTimestamp);
     }
 }

--- a/site/tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php
+++ b/site/tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php
@@ -51,6 +51,10 @@ final class WildberriesAdapterTest extends TestCase
         $http = new MockHttpClient(static function (string $method, string $url, array $options) use (&$capturedUrl, &$capturedPayload): MockResponse {
             $capturedUrl = $url;
             $capturedPayload = $options['json'] ?? [];
+            if ([] === $capturedPayload && isset($options['body']) && is_string($options['body']) && '' !== $options['body']) {
+                $capturedPayload = json_decode($options['body'], true, 512, JSON_THROW_ON_ERROR);
+            }
+
             return new MockResponse('[{"rrdId":10}]', ['http_code' => 200]);
         });
 


### PR DESCRIPTION
### Motivation

- Prevent back-to-back WB Finance API requests across different connections that belong to the same seller/account and protect the API after remote 429 responses by applying a shared cooldown.
- Allow grouping of connections into seller buckets (with safe normalization and a global fallback) so local throttling is applied per seller bucket instead of per-API-key or per-connection.
- Provide operational visibility via a read-only diagnostics command and persist cooldown state in Redis.

### Description

- Introduced `WbFinanceCooldownStorageInterface` and `WbFinanceRedisCooldownStorage` to persist cooldown-until timestamps in Redis with atomic set-if-greater semantics using a Lua script.
- Enhanced `WbFinanceRateLimiter` with seller-bucket helpers, cooldown management (`getActiveSalesReportsCooldownUntil`, `setSalesReportsCooldownUntil`, `cooldownUntilAfterRemote429`, `resolveSalesReportsSellerBucketId`, normalization utilities) and logging helpers.
- Modified `WbFinanceSalesReportClient` to accept and use seller-bucket ids, guard shared cooldowns before HTTP calls, store seller cooldown after remote `429`, and expose convenience methods delegating to the rate limiter.
- Updated message handler `SyncWbFinancialReportDayHandler` to resolve seller buckets, skip requests while cooldown is active (marking status queued and dispatching continuation), and to set shared cooldowns upon remote `429` responses.
- Added `WbFinanceDiagnosticsCommand` to inspect limiter/Redis state, queue sizes and sync status counts for diagnostics; registered new services and wired `WbFinanceRedisCooldownStorage` into DI and rate limiter wiring (added `cache_pool` for rate limiter in config).
- Added `recordRetryableError` to the sync status entity and corresponding updater method to persist retryable error metadata without changing retry cursor state.
- Updated unit and integration tests to cover seller-bucket behaviour, shared cooldown storage, probe/cooldown interactions, diagnostics command and handler flows; added in-memory test doubles for cooldown storage.

### Testing

- Ran unit tests including `WbFinanceSalesReportClientTest`, `WbFinanceDiagnosticsCommandTest` and `WildberriesAdapterTest`; they verify cooldown storage behavior, probe and fetch flows, and diagnostics output, and passed.
- Ran integration tests for `SyncWbFinancialReportDayHandlerTest` which include new scenarios `testRemote429SetsSharedCooldownAndNextDaySkipsHttp`, `testFallbackGlobalBucketPreventsTwoUnknownSellerConnectionsFromCallingApiBackToBack`, and `testCooldownExpiresAndAllowsApiRequestAgain`, and they passed.
- No automated test failures were observed when exercising the updated rate limiter, client and Redis cooldown interactions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a8d06a4b08323b06abba39882c810)