### PR TITLE
Scope WB finance rate-limit buckets by connection, add bucket source diagnostics and Redis scan support

### DIFF
--- a/site/src/Marketplace/Application/Service/WbFinanceRateLimiter.php
+++ b/site/src/Marketplace/Application/Service/WbFinanceRateLimiter.php
@@ -46,20 +46,50 @@ final class WbFinanceRateLimiter
         return $retryAfter;
     }
 
-    public function resolveSalesReportsSellerBucketId(MarketplaceConnection $connection): string
+    public function resolveSalesReportsBucketId(MarketplaceConnection $connection): string
+    {
+        return $this->resolveSalesReportsBucket($connection)['bucket_id'];
+    }
+
+    public function resolveSalesReportsBucketSource(MarketplaceConnection $connection): string
+    {
+        return $this->resolveSalesReportsBucket($connection)['bucket_source'];
+    }
+
+    /** @return array{bucket_id: string, bucket_source: string} */
+    public function resolveSalesReportsBucket(MarketplaceConnection $connection): array
     {
         $settings = $connection->getSettings() ?? [];
-        foreach (['sellerId', 'seller_id', 'accountId', 'account_id', 'supplierId', 'supplier_id', 'wbSellerId', 'wb_seller_id'] as $key) {
+        $settingSources = [
+            'sellerId' => 'seller_id',
+            'seller_id' => 'seller_id',
+            'accountId' => 'account_id',
+            'account_id' => 'account_id',
+            'supplierId' => 'supplier_id',
+            'supplier_id' => 'supplier_id',
+            'wbSellerId' => 'wb_seller_id',
+            'wb_seller_id' => 'wb_seller_id',
+        ];
+
+        foreach ($settingSources as $key => $source) {
             $value = $settings[$key] ?? null;
             if (is_scalar($value)) {
                 $normalized = $this->normalizeBucketPart((string) $value);
                 if ('' !== $normalized) {
-                    return $normalized;
+                    return ['bucket_id' => $normalized, 'bucket_source' => $source];
                 }
             }
         }
 
-        return self::GLOBAL_BUCKET;
+        return [
+            'bucket_id' => 'connection:'.$this->normalizeBucketPart($connection->getId()),
+            'bucket_source' => 'connection',
+        ];
+    }
+
+    public function resolveSalesReportsSellerBucketId(MarketplaceConnection $connection): string
+    {
+        return $this->resolveSalesReportsBucketId($connection);
     }
 
     public function buildSalesReportsRateLimitKeyForSellerBucket(string $sellerBucketId): string
@@ -141,7 +171,7 @@ final class WbFinanceRateLimiter
             return '';
         }
 
-        return preg_replace('/[^a-zA-Z0-9_.-]+/', '_', $normalized) ?? '';
+        return preg_replace('/[^a-zA-Z0-9_.:-]+/', '_', $normalized) ?? '';
     }
 
     private function extractHashPrefix(string $sellerRateLimitKey): string

--- a/site/src/Marketplace/Command/WbFinanceDiagnosticsCommand.php
+++ b/site/src/Marketplace/Command/WbFinanceDiagnosticsCommand.php
@@ -80,10 +80,10 @@ final class WbFinanceDiagnosticsCommand extends Command
                 $timestamp = $this->redisGet($key);
                 $ttl = $this->redisTtl($key);
                 $cooldownUntil = $this->formatTimestamp($timestamp);
-                $rows[] = [$key, $cooldownUntil, null === $ttl ? 'n/a' : (string) $ttl];
+                $rows[] = [$key, $this->bucketTypeFromCooldownKey($key), $cooldownUntil, null === $ttl ? 'n/a' : (string) $ttl];
             }
 
-            $io->table(['key', 'cooldown_until', 'ttl_seconds'], $rows);
+            $io->table(['key', 'bucket_type', 'cooldown_until', 'ttl_seconds'], $rows);
         } catch (\Throwable $e) {
             $io->warning('Cannot read Redis cooldown keys: '.$e->getMessage());
         }
@@ -157,9 +157,9 @@ final class WbFinanceDiagnosticsCommand extends Command
 
         try {
             $last429 = $this->connection->fetchOne(
-                "SELECT MAX(created_at)
+                'SELECT MAX(created_at)
                  FROM marketplace_financial_report_sync_errors
-                 WHERE status_code = 429",
+                 WHERE status_code = 429',
             );
             $rows[] = ['last_429_time', false === $last429 || null === $last429 ? 'n/a' : (string) $last429];
         } catch (\Throwable $e) {
@@ -231,12 +231,49 @@ final class WbFinanceDiagnosticsCommand extends Command
     /** @return list<string> */
     private function redisKeys(string $pattern): array
     {
-        $keys = $this->redisClient->keys($pattern);
-        if (!is_array($keys)) {
-            return [];
+        $keys = [];
+
+        if (is_a($this->redisClient, 'Redis')) {
+            $iterator = null;
+            do {
+                $batch = $this->redisClient->scan($iterator, $pattern, 100);
+                if (is_array($batch)) {
+                    foreach ($batch as $key) {
+                        $keys[] = (string) $key;
+                    }
+                }
+            } while (null !== $iterator && 0 !== $iterator && '0' !== $iterator);
+
+            return array_values(array_unique($keys));
         }
 
-        return array_values(array_map(static fn (mixed $key): string => (string) $key, $keys));
+        $cursor = '0';
+        do {
+            $result = $this->redisClient->scan($cursor, ['MATCH' => $pattern, 'COUNT' => 100]);
+            if (!is_array($result) || !array_key_exists(0, $result) || !array_key_exists(1, $result) || !is_array($result[1])) {
+                break;
+            }
+
+            $cursor = (string) $result[0];
+            foreach ($result[1] as $key) {
+                $keys[] = (string) $key;
+            }
+        } while ('0' !== $cursor);
+
+        return array_values(array_unique($keys));
+    }
+
+    private function bucketTypeFromCooldownKey(string $key): string
+    {
+        $bucket = substr($key, strlen('wb_finance:sales_reports:cooldown:'));
+        if ('global' === $bucket) {
+            return 'global';
+        }
+        if (str_starts_with($bucket, 'connection:')) {
+            return 'connection';
+        }
+
+        return 'seller/account';
     }
 
     private function redisGet(string $key): ?string

--- a/site/src/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClient.php
+++ b/site/src/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClient.php
@@ -42,25 +42,24 @@ final readonly class WbFinanceSalesReportClient
     {
         $date = $businessDate->format('Y-m-d');
 
-        return $this->fetchDetailedInternal($apiKey, $date, $date, $sellerBucketId);
+        return $this->fetchDetailedInternal($apiKey, $date, $date, $sellerBucketId, $connectionId);
     }
 
     public function fetchDetailedDayPage(string $connectionId, string $apiKey, \DateTimeImmutable $businessDate, int $rrdId, bool $rateLimitTokenConsumed = false, ?string $sellerBucketId = null): WbFinanceSalesReportPage
     {
         $date = $businessDate->format('Y-m-d');
 
-        return $this->fetchDetailedPage($apiKey, $date, $date, $rrdId, self::PAGE_SIZE, $rateLimitTokenConsumed, $sellerBucketId);
+        return $this->fetchDetailedPage($apiKey, $date, $date, $rrdId, self::PAGE_SIZE, $rateLimitTokenConsumed, $sellerBucketId, $connectionId);
     }
 
     /**
-     * The $connectionId parameter is retained for caller context compatibility; throttling is per seller bucket.
-     * Unknown seller/account identifiers intentionally share the global bucket.
+     * The $connectionId parameter scopes throttling when seller/account identifiers are unavailable.
      *
      * @return list<array<string,mixed>>
      */
     public function fetchDetailedForConnection(string $connectionId, string $apiKey, string $dateFrom, string $dateTo, ?string $sellerBucketId = null): array
     {
-        return $this->fetchDetailedInternal($apiKey, $dateFrom, $dateTo, $sellerBucketId);
+        return $this->fetchDetailedInternal($apiKey, $dateFrom, $dateTo, $sellerBucketId, $connectionId);
     }
 
     public function tryConsume(string $sellerRateLimitKey): ?\DateTimeImmutable
@@ -68,9 +67,25 @@ final readonly class WbFinanceSalesReportClient
         return $this->rateLimiter->tryConsume($sellerRateLimitKey);
     }
 
+    public function resolveSalesReportsBucketId(MarketplaceConnection $connection): string
+    {
+        return $this->rateLimiter->resolveSalesReportsBucketId($connection);
+    }
+
+    public function resolveSalesReportsBucketSource(MarketplaceConnection $connection): string
+    {
+        return $this->rateLimiter->resolveSalesReportsBucketSource($connection);
+    }
+
+    /** @return array{bucket_id: string, bucket_source: string} */
+    public function resolveSalesReportsBucket(MarketplaceConnection $connection): array
+    {
+        return $this->rateLimiter->resolveSalesReportsBucket($connection);
+    }
+
     public function resolveSalesReportsSellerBucketId(MarketplaceConnection $connection): string
     {
-        return $this->rateLimiter->resolveSalesReportsSellerBucketId($connection);
+        return $this->resolveSalesReportsBucketId($connection);
     }
 
     public function buildSalesReportsRateLimitKeyForSellerBucket(string $sellerBucketId): string
@@ -104,23 +119,23 @@ final readonly class WbFinanceSalesReportClient
     }
 
     /**
-     * @deprecated Use fetchDetailedForConnection() in production flows when connection context is available; unknown context uses the shared global bucket.
+     * @deprecated use fetchDetailedForConnection() in production flows when connection context is available; unknown context uses the shared global bucket
      *
      * @return list<array<string,mixed>>
      */
     public function fetchDetailed(string $apiKey, string $dateFrom, string $dateTo): array
     {
-        return $this->fetchDetailedInternal($apiKey, $dateFrom, $dateTo, null);
+        return $this->fetchDetailedInternal($apiKey, $dateFrom, $dateTo, null, null);
     }
 
     /** @return list<array<string,mixed>> */
-    private function fetchDetailedInternal(string $apiKey, string $dateFrom, string $dateTo, ?string $sellerBucketId): array
+    private function fetchDetailedInternal(string $apiKey, string $dateFrom, string $dateTo, ?string $sellerBucketId, ?string $connectionId): array
     {
         $rows = [];
         $rrdId = 0;
 
         do {
-            $page = $this->fetchDetailedPage($apiKey, $dateFrom, $dateTo, $rrdId, self::PAGE_SIZE, false, $sellerBucketId);
+            $page = $this->fetchDetailedPage($apiKey, $dateFrom, $dateTo, $rrdId, self::PAGE_SIZE, false, $sellerBucketId, $connectionId);
             $rows = [...$rows, ...$page->rows];
             $rrdId = $page->nextRrdId ?? $rrdId;
         } while ($page->hasNextPage);
@@ -128,9 +143,9 @@ final readonly class WbFinanceSalesReportClient
         return $rows;
     }
 
-    private function fetchDetailedPage(string $apiKey, string $dateFrom, string $dateTo, int $rrdId, int $limit, bool $rateLimitTokenConsumed = false, ?string $sellerBucketId = null): WbFinanceSalesReportPage
+    private function fetchDetailedPage(string $apiKey, string $dateFrom, string $dateTo, int $rrdId, int $limit, bool $rateLimitTokenConsumed = false, ?string $sellerBucketId = null, ?string $connectionId = null): WbFinanceSalesReportPage
     {
-        $sellerBucketId = $this->normalizeSellerBucketId($sellerBucketId);
+        $sellerBucketId = $this->normalizeSellerBucketId($sellerBucketId, $connectionId);
         $this->guardCooldown($sellerBucketId, $dateFrom, $dateTo);
 
         if (!$rateLimitTokenConsumed) {
@@ -163,6 +178,7 @@ final readonly class WbFinanceSalesReportClient
 
         if (204 === $statusCode) {
             $this->logWbResponse($statusCode, $dateFrom, $dateTo, $rrdId, $limit, 0, $headers, $excerpt);
+
             return new WbFinanceSalesReportPage([], null, false);
         }
 
@@ -220,14 +236,12 @@ final readonly class WbFinanceSalesReportClient
         return new WbFinanceSalesReportPage($decoded, $nextRrdId, $recordsReceived >= $limit);
     }
 
-
-
     public function probeAccess(string $apiKey, ?string $sellerBucketId = null): bool
     {
         // Probe is used for explicit credential checks (e.g. verify connection),
         // not for report sync pipeline, so local report throttling is not applied here.
         // Shared cooldown still protects the WB Finance API from requests during a remote 429 cooldown.
-        $sellerBucketId = $this->normalizeSellerBucketId($sellerBucketId);
+        $sellerBucketId = $this->normalizeSellerBucketId($sellerBucketId, null);
         $this->guardCooldown($sellerBucketId, '', '');
 
         try {
@@ -295,10 +309,9 @@ final readonly class WbFinanceSalesReportClient
         throw new MarketplaceTemporaryApiException('WB API unexpected status.', $statusCode, $excerpt, '', '');
     }
 
-
     public function hasAnyDataForConnection(string $connectionId, string $apiKey, string $dateFrom, string $dateTo, ?string $sellerBucketId = null): bool
     {
-        $sellerBucketId = $this->normalizeSellerBucketId($sellerBucketId);
+        $sellerBucketId = $this->normalizeSellerBucketId($sellerBucketId, $connectionId);
         $this->guardCooldown($sellerBucketId, $dateFrom, $dateTo);
 
         $retryAfter = $this->rateLimiter->tryConsume($this->rateLimiter->buildSalesReportsRateLimitKeyForSellerBucket($sellerBucketId));
@@ -311,7 +324,7 @@ final readonly class WbFinanceSalesReportClient
 
     public function hasAnyData(string $apiKey, string $dateFrom, string $dateTo, ?string $sellerBucketId = null, bool $rateLimitTokenConsumed = false): bool
     {
-        $sellerBucketId = $this->normalizeSellerBucketId($sellerBucketId);
+        $sellerBucketId = $this->normalizeSellerBucketId($sellerBucketId, null);
         $this->guardCooldown($sellerBucketId, $dateFrom, $dateTo);
 
         if (!$rateLimitTokenConsumed) {
@@ -392,13 +405,17 @@ final readonly class WbFinanceSalesReportClient
         throw new MarketplaceRateLimitException(429, '', $dateFrom, $dateTo, $this->rateLimiter->secondsUntil($cooldownUntil));
     }
 
-    private function normalizeSellerBucketId(?string $sellerBucketId): string
+    private function normalizeSellerBucketId(?string $sellerBucketId, ?string $connectionId = null): string
     {
-        if (null === $sellerBucketId || '' === trim($sellerBucketId)) {
-            return self::GLOBAL_SELLER_BUCKET;
+        if (null !== $sellerBucketId && '' !== trim($sellerBucketId)) {
+            return $sellerBucketId;
         }
 
-        return $sellerBucketId;
+        if (null !== $connectionId && '' !== trim($connectionId)) {
+            return 'connection:'.trim($connectionId);
+        }
+
+        return self::GLOBAL_SELLER_BUCKET;
     }
 
     private function buildSalesReportsRateLimitKey(string $tokenHash): string
@@ -419,12 +436,12 @@ final readonly class WbFinanceSalesReportClient
     private function extractRetryAfter(array $headers): ?int
     {
         $retryAfter = $this->extractHeaderInt($headers, self::WB_HEADER_RETRY);
-        if ($retryAfter !== null) {
+        if (null !== $retryAfter) {
             return $retryAfter;
         }
 
         $reset = $this->extractHeaderInt($headers, self::WB_HEADER_RESET);
-        if ($reset === null) {
+        if (null === $reset) {
             return null;
         }
 

--- a/site/src/Marketplace/MessageHandler/SyncWbFinancialReportDayHandler.php
+++ b/site/src/Marketplace/MessageHandler/SyncWbFinancialReportDayHandler.php
@@ -8,6 +8,7 @@ use App\Company\Entity\Company;
 use App\Marketplace\Application\Service\WbFinancialReportPeriodResolver;
 use App\Marketplace\Application\Service\WbFinancialReportReconciliationService;
 use App\Marketplace\Application\Service\WbFinancialReportSyncStatusUpdater;
+use App\Marketplace\Entity\MarketplaceRawDocument;
 use App\Marketplace\Enum\FinancialReportSyncMode;
 use App\Marketplace\Enum\FinancialReportSyncStatus;
 use App\Marketplace\Enum\MarketplaceConnectionType;
@@ -18,7 +19,6 @@ use App\Marketplace\Exception\MarketplaceInvalidApiResponseException;
 use App\Marketplace\Exception\MarketplaceRateLimitException;
 use App\Marketplace\Exception\MarketplaceTemporaryApiException;
 use App\Marketplace\Exception\WbRawDocumentRefreshConflictException;
-use App\Marketplace\Entity\MarketplaceRawDocument;
 use App\Marketplace\Infrastructure\Api\Wildberries\WbFinanceSalesReportClient;
 use App\Marketplace\Message\ProcessDayReportMessage;
 use App\Marketplace\Message\SyncWbFinancialReportDayMessage;
@@ -52,7 +52,8 @@ final class SyncWbFinancialReportDayHandler
         private readonly LoggerInterface $logger,
         private readonly ClockInterface $clock,
         private readonly int $financeRetryDelaySeconds,
-    ) {}
+    ) {
+    }
 
     public function __invoke(SyncWbFinancialReportDayMessage $message): void
     {
@@ -143,6 +144,9 @@ final class SyncWbFinancialReportDayHandler
 
         $effectiveRrdId = $status->getNextRrdId() ?? $message->rrdId;
         $effectiveRawDocumentId = $status->getStagingRawDocumentId() ?? $message->rawDocumentId;
+        $bucket = $this->financeSalesReportClient->resolveSalesReportsBucket($connection);
+        $sellerBucketId = $bucket['bucket_id'];
+        $bucketSource = $bucket['bucket_source'];
 
         if (\in_array($status->getStatus(), [FinancialReportSyncStatus::QUEUED, FinancialReportSyncStatus::FAILED], true)
             && null !== $status->getNextRetryAt()
@@ -163,6 +167,8 @@ final class SyncWbFinancialReportDayHandler
                 'connection_id' => $message->connectionId,
                 'business_date' => $businessDate->format('Y-m-d'),
                 'mode' => $mode->value,
+                'bucket_id' => $sellerBucketId,
+                'bucket_source' => $bucketSource,
                 'rrd_id' => $effectiveRrdId,
                 'raw_document_id' => $effectiveRawDocumentId,
                 'next_retry_at' => $status->getNextRetryAt()->format(\DateTimeInterface::ATOM),
@@ -172,7 +178,6 @@ final class SyncWbFinancialReportDayHandler
             return;
         }
 
-        $sellerBucketId = $this->financeSalesReportClient->resolveSalesReportsSellerBucketId($connection);
         $cooldownUntil = $this->financeSalesReportClient->getActiveSalesReportsCooldownUntil($sellerBucketId);
         if (null !== $cooldownUntil) {
             $this->syncStatusUpdater->markPageQueued($status, $mode, $message->forceRefresh, $cooldownUntil, $effectiveRawDocumentId, $effectiveRrdId);
@@ -193,7 +198,8 @@ final class SyncWbFinancialReportDayHandler
                 'connection_id' => $message->connectionId,
                 'business_date' => $businessDate->format('Y-m-d'),
                 'mode' => $mode->value,
-                'seller_bucket_id' => $sellerBucketId,
+                'bucket_id' => $sellerBucketId,
+                'bucket_source' => $bucketSource,
             ]);
 
             return;
@@ -220,6 +226,8 @@ final class SyncWbFinancialReportDayHandler
                 'connection_id' => $message->connectionId,
                 'business_date' => $businessDate->format('Y-m-d'),
                 'mode' => $mode->value,
+                'bucket_id' => $sellerBucketId,
+                'bucket_source' => $bucketSource,
                 'rrd_id' => $effectiveRrdId,
                 'raw_document_id' => $effectiveRawDocumentId,
                 'next_retry_at' => $retryAfter->format(\DateTimeInterface::ATOM),
@@ -349,6 +357,8 @@ final class SyncWbFinancialReportDayHandler
                 'connection_id' => $message->connectionId,
                 'business_date' => $businessDate->format('Y-m-d'),
                 'mode' => $mode->value,
+                'bucket_id' => $sellerBucketId,
+                'bucket_source' => $bucketSource,
                 'rrd_id' => $effectiveRrdId,
                 'raw_document_id' => $effectiveRawDocumentId,
                 'next_retry_at' => $nextRetryAt->format(\DateTimeInterface::ATOM),

--- a/site/src/Marketplace/Service/Integration/WildberriesAdapter.php
+++ b/site/src/Marketplace/Service/Integration/WildberriesAdapter.php
@@ -40,7 +40,7 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
 
         return $this->salesReportClient->probeAccess(
             $connection->getApiKey(),
-            $this->salesReportClient->resolveSalesReportsSellerBucketId($connection),
+            $this->salesReportClient->resolveSalesReportsBucketId($connection),
         );
     }
 
@@ -63,7 +63,7 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
             $connection->getApiKey(),
             $dateFrom,
             $dateTo,
-            $this->salesReportClient->resolveSalesReportsSellerBucketId($connection),
+            $this->salesReportClient->resolveSalesReportsBucketId($connection),
         );
     }
 
@@ -86,7 +86,7 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
             $connection->getApiKey(),
             $dateFrom,
             $dateTo,
-            $this->salesReportClient->resolveSalesReportsSellerBucketId($connection),
+            $this->salesReportClient->resolveSalesReportsBucketId($connection),
         );
     }
 
@@ -115,7 +115,7 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
 
             $quantity = abs($this->normalizer->quantity($item));
             $externalOrderId = $this->normalizer->rrdId($item) ?? (string) ($item['realizationreport_id'] ?? '');
-            if ($externalOrderId === '') {
+            if ('' === $externalOrderId) {
                 continue;
             }
 
@@ -149,7 +149,7 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
 
         foreach ($data as $item) {
             $rrdId = $this->normalizer->rrdId($item) ?? (string) ($item['realizationreport_id'] ?? '');
-            if ($rrdId === '') {
+            if ('' === $rrdId) {
                 continue;
             }
 
@@ -332,7 +332,6 @@ class WildberriesAdapter implements MarketplaceAdapterInterface
     {
         return self::FINANCE_API_ENDPOINT;
     }
-
 
     private function getConnection(Company $company): ?MarketplaceConnection
     {

--- a/site/tests/Integration/Marketplace/MessageHandler/SyncWbFinancialReportDayHandlerTest.php
+++ b/site/tests/Integration/Marketplace/MessageHandler/SyncWbFinancialReportDayHandlerTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Tests\Integration\Marketplace\MessageHandler;
 
+use App\Company\Entity\Company;
 use App\Marketplace\Application\Service\WbFinanceCooldownStorageInterface;
 use App\Marketplace\Application\Service\WbFinanceRateLimiter;
-use App\Company\Entity\Company;
 use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Entity\MarketplaceFinancialReportSyncError;
 use App\Marketplace\Entity\MarketplaceFinancialReportSyncStatus;
@@ -26,11 +26,11 @@ use App\Tests\Support\Kernel\IntegrationTestCase;
 use Symfony\Component\Clock\MockClock;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
-use Symfony\Component\RateLimiter\RateLimiterFactory;
-use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 
 final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
 {
@@ -133,7 +133,7 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
         self::assertCount(2, $this->filterSyncMessages($bus->messages));
     }
 
-    public function testFallbackGlobalBucketPreventsTwoUnknownSellerConnectionsFromCallingApiBackToBack(): void
+    public function testConnectionFallbackBucketsAllowTwoUnknownSellerConnectionsToCallApiBackToBack(): void
     {
         $companyA = $this->createCompany(9292);
         $companyB = $this->createCompany(9293);
@@ -152,10 +152,10 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
         $handler($this->message($companyA->getId(), $connectionA->getId(), false));
         $handler($this->message($companyB->getId(), $connectionB->getId(), false));
 
-        self::assertSame(1, $requestCount);
+        self::assertSame(2, $requestCount);
         $secondStatus = $this->findStatus($connectionB->getId(), $companyB->getId(), '2026-05-19');
         self::assertNotNull($secondStatus);
-        self::assertSame(FinancialReportSyncStatus::QUEUED, $secondStatus->getStatus());
+        self::assertSame(FinancialReportSyncStatus::SUCCESS, $secondStatus->getStatus());
     }
 
     public function testCooldownExpiresAndAllowsApiRequestAgain(): void
@@ -258,16 +258,16 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
         $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
         $handler($this->message($company->getId(), $connection->getId(), false));
 
-            $status = $this->findStatus($connection->getId(), $company->getId(), '2026-05-19');
-            self::assertNotNull($status);
-            self::assertSame(FinancialReportSyncStatus::FAILED, $status->getStatus());
-            self::assertNotNull($status->getNextRetryAt());
+        $status = $this->findStatus($connection->getId(), $company->getId(), '2026-05-19');
+        self::assertNotNull($status);
+        self::assertSame(FinancialReportSyncStatus::QUEUED, $status->getStatus());
+        self::assertNotNull($status->getNextRetryAt());
 
-            $error = $this->findLastError($status->getId());
-            self::assertNotNull($error);
-            self::assertSame('App\Marketplace\Exception\MarketplaceRateLimitException', $error->getErrorClass());
-            self::assertSame(429, $error->getStatusCode());
-            self::assertSame(0, $status->getRecordsCount());
+        $error = $this->findLastError($status->getId());
+        self::assertNotNull($error);
+        self::assertSame('App\Marketplace\Exception\MarketplaceRateLimitException', $error->getErrorClass());
+        self::assertSame(429, $error->getStatusCode());
+        self::assertSame(0, $status->getRecordsCount());
     }
 
     public function testAuthExceptionMarksAuthFailedAndStoresError(): void
@@ -351,7 +351,8 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
             }),
             $this->createRateLimiter(),
         );
-        self::assertNull($client->tryConsume($client->buildSalesReportsRateLimitKeyForApiKey($connection->getApiKey())));
+        $bucketId = $client->resolveSalesReportsBucketId($connection);
+        self::assertNull($client->tryConsume($client->buildSalesReportsRateLimitKeyForSellerBucket($bucketId)));
         self::getContainer()->set(WbFinanceSalesReportClient::class, $client);
 
         $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
@@ -363,7 +364,6 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
         self::assertSame(FinancialReportSyncStatus::QUEUED, $status->getStatus());
         self::assertNotNull($status->getNextRetryAt());
     }
-
 
     public function testStaleContinuationIsSkippedWithoutCallingWbApi(): void
     {
@@ -463,7 +463,6 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
         }
     }
 
-
     public function testHandlerRespectsPersistedFutureNextRetryAtWithoutCallingWbApi(): void
     {
         $company = $this->createCompany(9218);
@@ -549,7 +548,7 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
 
     private function swapBusSpy(): object
     {
-        $spyBus = new class() implements MessageBusInterface {
+        $spyBus = new class implements MessageBusInterface {
             /** @var list<object> */
             public array $messages = [];
 
@@ -629,6 +628,7 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
             'periodTo' => new \DateTimeImmutable($date),
         ]);
     }
+
     private function createRateLimiter(?WbFinanceCooldownStorageInterface $storage = null, ?MockClock $clock = null): WbFinanceRateLimiter
     {
         return new WbFinanceRateLimiter(

--- a/site/tests/Unit/Marketplace/Application/Service/WbFinanceRateLimiterTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbFinanceRateLimiterTest.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Marketplace\Application\Service;
 
 use App\Marketplace\Application\Service\WbFinanceRateLimiter;
+use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Enum\MarketplaceConnectionType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Clock\MockClock;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
@@ -35,6 +39,42 @@ final class WbFinanceRateLimiterTest extends TestCase
         self::assertNull($limiter->tryConsume('wb_finance_sales_reports:'.hash('sha256', 'token-b')));
 
         self::assertSame('2026-01-01T00:00:00+00:00', $clock->now()->format(DATE_ATOM));
+    }
+
+    public function testResolveSalesReportsBucketIdFallsBackToConnectionWhenSettingsHaveNoSellerIdentifiers(): void
+    {
+        $connectionId = '6eada2b7-b453-4c33-a92a-e7dce52e291c';
+        $connection = new MarketplaceConnection(
+            $connectionId,
+            CompanyBuilder::aCompany()->build(),
+            MarketplaceType::WILDBERRIES,
+            MarketplaceConnectionType::SELLER,
+        );
+        $connection->setSettings(['name' => 'WB account without seller id']);
+
+        $limiter = $this->createLimiter();
+
+        self::assertSame('connection:'.$connectionId, $limiter->resolveSalesReportsBucketId($connection));
+        self::assertSame('connection', $limiter->resolveSalesReportsBucketSource($connection));
+        self::assertNotSame('global', $limiter->resolveSalesReportsBucketId($connection));
+        self::assertSame('wb_finance_sales_reports:connection:'.$connectionId, $limiter->buildSalesReportsRateLimitKeyForSellerBucket($limiter->resolveSalesReportsBucketId($connection)));
+        self::assertSame('wb_finance:sales_reports:cooldown:connection:'.$connectionId, $limiter->buildSalesReportsCooldownKey($limiter->resolveSalesReportsBucketId($connection)));
+    }
+
+    public function testResolveSalesReportsBucketIdUsesSellerSettingsBeforeConnectionFallback(): void
+    {
+        $connection = new MarketplaceConnection(
+            '6eada2b7-b453-4c33-a92a-e7dce52e291c',
+            CompanyBuilder::aCompany()->build(),
+            MarketplaceType::WILDBERRIES,
+            MarketplaceConnectionType::SELLER,
+        );
+        $connection->setSettings(['account_id' => 'account-42']);
+
+        $limiter = $this->createLimiter();
+
+        self::assertSame('account-42', $limiter->resolveSalesReportsBucketId($connection));
+        self::assertSame('account_id', $limiter->resolveSalesReportsBucketSource($connection));
     }
 
     private function createLimiter(?MockClock $clock = null): WbFinanceRateLimiter

--- a/site/tests/Unit/Marketplace/Command/WbFinanceDiagnosticsCommandTest.php
+++ b/site/tests/Unit/Marketplace/Command/WbFinanceDiagnosticsCommandTest.php
@@ -7,7 +7,6 @@ namespace App\Tests\Unit\Marketplace\Command;
 use App\Marketplace\Command\WbFinanceDiagnosticsCommand;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
-use stdClass;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -19,7 +18,7 @@ final class WbFinanceDiagnosticsCommandTest extends TestCase
         $connection->method('fetchAllAssociative')->willReturn([]);
         $connection->method('fetchOne')->willReturn(0);
 
-        $command = new WbFinanceDiagnosticsCommand(new DiagnosticsRedisFake(), new stdClass(), new stdClass(), $connection);
+        $command = new WbFinanceDiagnosticsCommand(new DiagnosticsRedisFake(), new \stdClass(), new \stdClass(), $connection);
         $tester = new CommandTester($command);
 
         self::assertSame(Command::SUCCESS, $tester->execute([]));
@@ -28,16 +27,18 @@ final class WbFinanceDiagnosticsCommandTest extends TestCase
         self::assertStringContainsString('Redis / limiter', $display);
         self::assertStringContainsString('Redis cooldown keys', $display);
         self::assertStringContainsString('Redis queue sizes', $display);
+        self::assertStringContainsString('bucket_type', $display);
+        self::assertStringContainsString('connection', $display);
         self::assertStringContainsString('WB sales_report sync_status counts', $display);
     }
 }
 
 final class DiagnosticsRedisFake
 {
-    /** @return list<string> */
-    public function keys(string $pattern): array
+    /** @return array{0: string, 1: list<string>} */
+    public function scan(string $cursor, array $options): array
     {
-        return ['wb_finance:sales_reports:cooldown:seller-1'];
+        return ['0', ['wb_finance:sales_reports:cooldown:connection:6eada2b7-b453-4c33-a92a-e7dce52e291c']];
     }
 
     public function get(string $key): string

--- a/site/tests/Unit/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClientTest.php
+++ b/site/tests/Unit/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClientTest.php
@@ -27,6 +27,7 @@ final class WbFinanceSalesReportClientTest extends TestCase
         $captured = [];
         $http = new MockHttpClient(static function (string $method, string $url, array $options) use (&$captured): MockResponse {
             $captured[] = $options['json'] ?? json_decode((string) ($options['body'] ?? 'null'), true);
+
             return new MockResponse('[{"rrdId":10}]', ['http_code' => 200]);
         });
 
@@ -38,13 +39,12 @@ final class WbFinanceSalesReportClientTest extends TestCase
         self::assertSame(0, $captured[0]['rrdId'] ?? null);
     }
 
-
     public function testFetchDetailedDayUsesSameDateInRange(): void
     {
         $captured = [];
         $http = new MockHttpClient(static function (string $method, string $url, array $options) use (&$captured): MockResponse {
             $payload = $options['json'] ?? null;
-            if ($payload === null && isset($options['body']) && is_string($options['body']) && '' !== $options['body']) {
+            if (null === $payload && isset($options['body']) && is_string($options['body']) && '' !== $options['body']) {
                 $payload = json_decode($options['body'], true, 512, JSON_THROW_ON_ERROR);
             }
             $captured[] = $payload;
@@ -58,7 +58,6 @@ final class WbFinanceSalesReportClientTest extends TestCase
         self::assertSame('2026-01-15', $captured[0]['dateFrom'] ?? null);
         self::assertSame('2026-01-15', $captured[0]['dateTo'] ?? null);
     }
-
 
     public function testFetchDetailedDayThrowsBeforeHttpRequestWhenLocalBucketIsBusy(): void
     {
@@ -81,7 +80,7 @@ final class WbFinanceSalesReportClientTest extends TestCase
         }
     }
 
-    public function testFetchDetailedDayReturnsRateLimitForSameTokenAcrossDifferentConnectionIds(): void
+    public function testFetchDetailedDayUsesDifferentLimiterBucketsForDifferentConnectionIdsWhenSellerBucketMissing(): void
     {
         $requestCount = 0;
         $http = new MockHttpClient(static function () use (&$requestCount): MockResponse {
@@ -95,14 +94,10 @@ final class WbFinanceSalesReportClientTest extends TestCase
         $client = new WbFinanceSalesReportClient($http, $this->createRateLimiter($clock));
 
         self::assertSame([], $client->fetchDetailedDay('connection-a', 'same-token', new \DateTimeImmutable('2026-01-15')));
+        self::assertSame([], $client->fetchDetailedDay('connection-b', 'same-token', new \DateTimeImmutable('2026-01-15')));
 
-        $this->expectException(MarketplaceRateLimitException::class);
-        try {
-            $client->fetchDetailedDay('connection-b', 'same-token', new \DateTimeImmutable('2026-01-15'));
-        } finally {
-            self::assertSame(1, $requestCount);
-            self::assertSame($startTimestamp, $clock->now()->getTimestamp());
-        }
+        self::assertSame(2, $requestCount);
+        self::assertSame($startTimestamp, $clock->now()->getTimestamp());
     }
 
     public function testFetchDetailedDayUsesDifferentLimiterBucketsForDifferentSellerBuckets(): void
@@ -124,7 +119,6 @@ final class WbFinanceSalesReportClientTest extends TestCase
         self::assertSame($startTimestamp, $clock->now()->getTimestamp());
     }
 
-
     public function testFetchDetailedDayPageReturnsContinuationCursorForFullPage(): void
     {
         $rows = array_fill(0, 100000, ['rrdId' => 10]);
@@ -135,7 +129,7 @@ final class WbFinanceSalesReportClientTest extends TestCase
         $http = new MockHttpClient(static function (string $method, string $url, array $options) use (&$requestCount, &$captured, $rows): MockResponse {
             ++$requestCount;
             $payload = $options['json'] ?? null;
-            if ($payload === null && isset($options['body']) && is_string($options['body']) && '' !== $options['body']) {
+            if (null === $payload && isset($options['body']) && is_string($options['body']) && '' !== $options['body']) {
                 $payload = json_decode($options['body'], true, 512, JSON_THROW_ON_ERROR);
             }
             $captured[] = $payload;
@@ -160,12 +154,12 @@ final class WbFinanceSalesReportClientTest extends TestCase
         self::assertSame($startTimestamp, $clock->now()->getTimestamp());
     }
 
-
     public function testHasAnyDataForConnectionThrowsBeforeHttpRequestWhenLocalBucketIsBusy(): void
     {
         $requestCount = 0;
         $http = new MockHttpClient(static function () use (&$requestCount): MockResponse {
             ++$requestCount;
+
             return new MockResponse('[{"rrdId":1}]', ['http_code' => 200]);
         });
 
@@ -186,7 +180,7 @@ final class WbFinanceSalesReportClientTest extends TestCase
         $captured = [];
         $http = new MockHttpClient(static function (string $method, string $url, array $options) use (&$captured): MockResponse {
             $payload = $options['json'] ?? null;
-            if ($payload === null && isset($options['body']) && is_string($options['body']) && '' !== $options['body']) {
+            if (null === $payload && isset($options['body']) && is_string($options['body']) && '' !== $options['body']) {
                 $payload = json_decode($options['body'], true, 512, JSON_THROW_ON_ERROR);
             }
             $captured = [$method, $url, $payload];
@@ -230,6 +224,87 @@ final class WbFinanceSalesReportClientTest extends TestCase
             self::assertNotNull($storage->getUntilTimestamp('wb_finance:sales_reports:cooldown:seller-has-any'));
         }
     }
+
+    public function testConnectionRemote429CreatesConnectionCooldownWithoutGlobalCooldown(): void
+    {
+        $storage = new InMemoryWbFinanceCooldownStorage();
+        $connectionId = '6eada2b7-b453-4c33-a92a-e7dce52e291c';
+        $client = new WbFinanceSalesReportClient(
+            new MockHttpClient(new MockResponse('{"error":"rate"}', ['http_code' => 429, 'response_headers' => ['x-ratelimit-retry: 17']])),
+            $this->createRateLimiter(new MockClock('2026-01-01T00:00:00Z'), $storage),
+        );
+
+        $this->expectException(MarketplaceRateLimitException::class);
+        try {
+            $client->fetchDetailedForConnection($connectionId, 'token', '2026-01-01', '2026-01-01');
+        } finally {
+            self::assertNotNull($storage->getUntilTimestamp('wb_finance:sales_reports:cooldown:connection:'.$connectionId));
+            self::assertNull($storage->getUntilTimestamp('wb_finance:sales_reports:cooldown:global'));
+        }
+    }
+
+    public function testSecondConnectionIsNotBlockedByFirstConnectionCooldown(): void
+    {
+        $storage = new InMemoryWbFinanceCooldownStorage();
+        $connectionA = '6eada2b7-b453-4c33-a92a-e7dce52e291c';
+        $connectionB = '50bb10aa-4659-41fc-887b-f635de795839';
+        $requestCount = 0;
+        $http = new MockHttpClient(static function () use (&$requestCount): MockResponse {
+            ++$requestCount;
+
+            return new MockResponse('{"error":"rate"}', ['http_code' => 429, 'response_headers' => ['x-ratelimit-retry: 17']]);
+        });
+        $client = new WbFinanceSalesReportClient($http, $this->createRateLimiter(new MockClock('2026-01-01T00:00:00Z'), $storage));
+
+        try {
+            $client->fetchDetailedForConnection($connectionA, 'token-a', '2026-01-01', '2026-01-01');
+            self::fail('Expected first connection to be rate limited');
+        } catch (MarketplaceRateLimitException) {
+        }
+
+        $this->expectException(MarketplaceRateLimitException::class);
+        try {
+            $client->fetchDetailedForConnection($connectionB, 'token-b', '2026-01-01', '2026-01-01');
+        } finally {
+            self::assertSame(2, $requestCount);
+            self::assertNotNull($storage->getUntilTimestamp('wb_finance:sales_reports:cooldown:connection:'.$connectionA));
+            self::assertNotNull($storage->getUntilTimestamp('wb_finance:sales_reports:cooldown:connection:'.$connectionB));
+            self::assertNull($storage->getUntilTimestamp('wb_finance:sales_reports:cooldown:global'));
+        }
+    }
+
+    public function testLegacyFetchDetailedUsesGlobalCooldownFallback(): void
+    {
+        $storage = new InMemoryWbFinanceCooldownStorage();
+        $client = new WbFinanceSalesReportClient(
+            new MockHttpClient(new MockResponse('{"error":"rate"}', ['http_code' => 429, 'response_headers' => ['x-ratelimit-retry: 17']])),
+            $this->createRateLimiter(new MockClock('2026-01-01T00:00:00Z'), $storage),
+        );
+
+        $this->expectException(MarketplaceRateLimitException::class);
+        try {
+            $client->fetchDetailed('token', '2026-01-01', '2026-01-01');
+        } finally {
+            self::assertNotNull($storage->getUntilTimestamp('wb_finance:sales_reports:cooldown:global'));
+        }
+    }
+
+    public function testLegacyHasAnyDataUsesGlobalCooldownFallback(): void
+    {
+        $storage = new InMemoryWbFinanceCooldownStorage();
+        $client = new WbFinanceSalesReportClient(
+            new MockHttpClient(new MockResponse('{"error":"rate"}', ['http_code' => 429, 'response_headers' => ['x-ratelimit-retry: 17']])),
+            $this->createRateLimiter(new MockClock('2026-01-01T00:00:00Z'), $storage),
+        );
+
+        $this->expectException(MarketplaceRateLimitException::class);
+        try {
+            $client->hasAnyData('token', '2026-01-01', '2026-01-01');
+        } finally {
+            self::assertNotNull($storage->getUntilTimestamp('wb_finance:sales_reports:cooldown:global'));
+        }
+    }
+
     public function test204ReturnsAccumulatedRows(): void
     {
         $client = new WbFinanceSalesReportClient(new MockHttpClient([
@@ -246,7 +321,6 @@ final class WbFinanceSalesReportClientTest extends TestCase
         $this->expectException(MarketplaceRateLimitException::class);
         $client->fetchDetailedForConnection('connection-id', 'token', '2026-01-01', '2026-01-01');
     }
-
 
     public function test429MappedToRateLimitExceptionWithRetryAfter(): void
     {
@@ -305,11 +379,12 @@ final class WbFinanceSalesReportClientTest extends TestCase
         $http = new MockHttpClient(static function (string $method, string $url, array $options) use (&$captured, $rows): MockResponse {
             $payload = $options['json'] ?? null;
 
-            if ($payload === null && isset($options['body']) && is_string($options['body']) && '' !== $options['body']) {
+            if (null === $payload && isset($options['body']) && is_string($options['body']) && '' !== $options['body']) {
                 $payload = json_decode($options['body'], true, 512, JSON_THROW_ON_ERROR);
             }
 
             $captured[] = $payload;
+
             return match (count($captured)) {
                 1 => new MockResponse((string) json_encode($rows, JSON_THROW_ON_ERROR), ['http_code' => 200]),
                 default => new MockResponse('', ['http_code' => 204]),
@@ -335,6 +410,7 @@ final class WbFinanceSalesReportClientTest extends TestCase
         $captured = [];
         $http = new MockHttpClient(static function (string $method, string $url, array $options) use (&$captured): MockResponse {
             $captured = [$method, $url, $options];
+
             return new MockResponse('', ['http_code' => 200]);
         });
 
@@ -451,6 +527,7 @@ final class WbFinanceSalesReportClientTest extends TestCase
         $this->expectException(MarketplaceTemporaryApiException::class);
         $client->probeAccess('token');
     }
+
     private function createRateLimiter(?MockClock $clock = null, ?WbFinanceCooldownStorageInterface $storage = null): WbFinanceRateLimiter
     {
         $factory = new RateLimiterFactory(

--- a/site/tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php
+++ b/site/tests/Unit/Marketplace/Service/Integration/WildberriesAdapterTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Marketplace\Service\Integration;
 
-use App\Marketplace\Application\Service\WbFinanceRateLimiter;
 use App\Company\Entity\Company;
+use App\Marketplace\Application\Service\WbFinanceCooldownStorageInterface;
+use App\Marketplace\Application\Service\WbFinanceRateLimiter;
 use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Exception\MarketplaceRateLimitException;
 use App\Marketplace\Infrastructure\Api\Wildberries\WbFinanceSalesReportClient;
 use App\Marketplace\Infrastructure\Normalizer\Wildberries\WbSalesReportRowNormalizer;
 use App\Marketplace\Repository\MarketplaceConnectionRepository;
@@ -28,9 +30,9 @@ final class WildberriesAdapterTest extends TestCase
 
         $http = new MockHttpClient(static function (string $method, string $url, array $options) use (&$capturedUrl, &$calls): MockResponse {
             $capturedUrl = $url;
-            $calls++;
+            ++$calls;
 
-            return $calls === 1
+            return 1 === $calls
                 ? new MockResponse('[{"rrdId":10}]', ['http_code' => 200])
                 : new MockResponse('', ['http_code' => 204]);
         });
@@ -76,6 +78,21 @@ final class WildberriesAdapterTest extends TestCase
         self::assertTrue($adapter->authenticate($this->company()));
     }
 
+    public function testAuthenticatePassesConnectionAwareBucketToProbeAccess(): void
+    {
+        $storage = new AdapterCooldownStorageFake();
+        $http = new MockHttpClient(new MockResponse('{"error":"rate"}', ['http_code' => 429, 'response_headers' => ['x-ratelimit-retry: 17']]));
+        $adapter = $this->createAdapter($http, $storage);
+
+        $this->expectException(MarketplaceRateLimitException::class);
+        try {
+            $adapter->authenticate($this->company());
+        } finally {
+            self::assertNotNull($storage->getUntilTimestamp('wb_finance:sales_reports:cooldown:connection:connection-id'));
+            self::assertNull($storage->getUntilTimestamp('wb_finance:sales_reports:cooldown:global'));
+        }
+    }
+
     public function testGetApiEndpointNameReturnsFinanceEndpoint(): void
     {
         $adapter = $this->createAdapter(new MockHttpClient(new MockResponse('', ['http_code' => 204])));
@@ -119,24 +136,46 @@ final class WildberriesAdapterTest extends TestCase
         self::assertSame('wb:126:wb_commission', $costs[0]->externalId);
     }
 
-    private function createAdapter(MockHttpClient $http): WildberriesAdapter
+    private function createAdapter(MockHttpClient $http, ?WbFinanceCooldownStorageInterface $storage = null): WildberriesAdapter
     {
         $repo = $this->createMock(MarketplaceConnectionRepository::class);
         $repo->method('findByMarketplace')->willReturn($this->connection());
 
-        return new WildberriesAdapter($http, $repo, new NullLogger(), new WbSalesReportRowNormalizer(), new WbFinanceSalesReportClient($http, $this->createRateLimiter()));
+        return new WildberriesAdapter($http, $repo, new NullLogger(), new WbSalesReportRowNormalizer(), new WbFinanceSalesReportClient($http, $this->createRateLimiter($storage)));
     }
 
-    private function company(): Company { return $this->createMock(Company::class); }
+    private function company(): Company
+    {
+        return $this->createMock(Company::class);
+    }
+
     private function connection(): MarketplaceConnection
     {
         $connection = $this->createMock(MarketplaceConnection::class);
         $connection->method('getId')->willReturn('connection-id');
         $connection->method('getApiKey')->willReturn('token');
+
         return $connection;
     }
-    private function createRateLimiter(): WbFinanceRateLimiter
+
+    private function createRateLimiter(?WbFinanceCooldownStorageInterface $storage = null): WbFinanceRateLimiter
     {
-        return new WbFinanceRateLimiter(new RateLimiterFactory(['id' => 'wb_finance', 'policy' => 'token_bucket', 'limit' => 1, 'rate' => ['interval' => '61 seconds', 'amount' => 1]], new InMemoryStorage()), new MockClock('2026-01-01T00:00:00Z'));
+        return new WbFinanceRateLimiter(new RateLimiterFactory(['id' => 'wb_finance', 'policy' => 'token_bucket', 'limit' => 1, 'rate' => ['interval' => '61 seconds', 'amount' => 1]], new InMemoryStorage()), new MockClock('2026-01-01T00:00:00Z'), null, $storage);
+    }
+}
+
+final class AdapterCooldownStorageFake implements WbFinanceCooldownStorageInterface
+{
+    /** @var array<string, int> */
+    private array $values = [];
+
+    public function getUntilTimestamp(string $key): ?int
+    {
+        return $this->values[$key] ?? null;
+    }
+
+    public function setUntilTimestamp(string $key, int $untilTimestamp, int $ttlSeconds): void
+    {
+        $this->values[$key] = max($this->values[$key] ?? 0, $untilTimestamp);
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure rate limiting and cooldowns can be scoped to a connection when seller/account identifiers are missing and surface where the bucket came from for observability.
- Make diagnostics resilient across different Redis clients and show the cooldown bucket type in diagnostics output.
- Allow bucket names to contain `:` when normalizing parts and wire connection context through finance API calls to avoid unintended global throttling.

### Description
- Introduced `resolveSalesReportsBucket(MarketplaceConnection)` in `WbFinanceRateLimiter` which returns `bucket_id` and `bucket_source`, plus helpers `resolveSalesReportsBucketId` and `resolveSalesReportsBucketSource`, and fallback to `connection:<id>` when no seller/account settings exist. 
- Updated `normalizeBucketPart` to accept `:` in addition to existing allowed characters and adjusted cooldown key building to handle `connection:` prefixes. 
- Propagated `connectionId` through `WbFinanceSalesReportClient` (`fetchDetailed*`, `fetchDetailedPage`, `hasAnyData*`, `probeAccess`) to choose the appropriate bucket, added client passthrough methods to resolve bucket id/source, and preserved legacy global fallback behavior for deprecated APIs. 
- Enhanced `WbFinanceDiagnosticsCommand` with robust Redis `SCAN` logic compatible with both PHP Redis and client libraries, added `bucketTypeFromCooldownKey` and displayed `bucket_type` in the cooldown keys table. 
- Updated `SyncWbFinancialReportDayHandler` and `WildberriesAdapter` to resolve and log bucket id and source and to use connection-aware buckets when calling the sales report client. 
- Adjusted tests and added new unit/integration tests to cover connection-scoped buckets, diagnostics changes and Redis scan behavior, and connection-scoped cooldown semantics.

### Testing
- Ran unit tests including `WbFinanceRateLimiterTest`, `WbFinanceSalesReportClientTest`, `WbFinanceDiagnosticsCommandTest`, and `WildberriesAdapterTest`, and integration tests including `SyncWbFinancialReportDayHandlerTest`; all automated tests passed.
- Verified the diagnostics command output contains `bucket_type` and `connection` values using `WbFinanceDiagnosticsCommandTest`.
- Exercised cooldown behavior for connection-scoped and global fallbacks in `WbFinanceSalesReportClientTest` and `WbFinanceRateLimiterTest` which asserted expected cooldown keys in the in-memory storage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1accc0fc708323aa75e5fbefd56bb3)