### PR TITLE
Normalize whitespace in WB financial reports warning unit test

### DIFF
--- a/site/tests/Unit/Marketplace/Command/WbFinancialReportsSyncCommandTest.php
+++ b/site/tests/Unit/Marketplace/Command/WbFinancialReportsSyncCommandTest.php
@@ -90,9 +90,11 @@ final class WbFinancialReportsSyncCommandTest extends TestCase
         $code = $tester->execute(['--mode' => 'all']);
 
         self::assertSame(Command::FAILURE, $code);
+        $output = preg_replace('/\s+/', ' ', $tester->getDisplay());
+
         self::assertStringContainsString(
             'WB financial reports --mode=all is dangerous for cron because it can enqueue many days and hit WB API rate limits.',
-            $tester->getDisplay(),
+            $output,
         );
     }
 


### PR DESCRIPTION
### Motivation
- Stabilize the unit test that asserts the WB `--mode=all` warning because Symfony Console may wrap long messages across lines and break a direct `assertStringContainsString()` on the raw display.

### Description
- In `site/tests/Unit/Marketplace/Command/WbFinancialReportsSyncCommandTest.php` normalize the console output with `preg_replace('/\s+/', ' ', $tester->getDisplay())` and assert the production warning against the normalized `$output`, while keeping the existing `Command::FAILURE` exit-code assertion and not changing the production warning text.

### Testing
- Ran `cd site && php -d memory_limit=512M bin/phpunit --testsuite unit --filter 'WbFinancialReportsSyncCommandTest::testAllWithoutAllowAllReturnsFailureAndWarns'`, which passed (OK).
- Ran `make site-test-unit` in this environment, which failed due to missing `docker-compose` (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ae7e8003083239bbbd57507b4dc33)