### PR TITLE
Fix marketplace ads reconcile unit mocks

### DIFF
--- a/site/tests/Unit/MarketplaceAds/Command/ReconcileMarketplaceAdsCommandTest.php
+++ b/site/tests/Unit/MarketplaceAds/Command/ReconcileMarketplaceAdsCommandTest.php
@@ -199,12 +199,15 @@ final class ReconcileMarketplaceAdsCommandTest extends TestCase
 
         $dispatch = $this->createMock(DispatchOzonAdLoadActionInterface::class);
         $calls = 0;
-        $dispatch->method('__invoke')->willReturnCallback(function () use (&$calls): void {
-            ++$calls;
-            if (1 === $calls) {
-                throw new \RuntimeException('boom');
-            }
-        });
+        $dispatch->expects(self::exactly(2))->method('__invoke')
+            ->willReturnCallback(function (string $companyId, \DateTimeImmutable $dateFrom, \DateTimeImmutable $dateTo) use (&$calls): AdLoadJob {
+                ++$calls;
+                if (1 === $calls) {
+                    throw new \RuntimeException('boom');
+                }
+
+                return new AdLoadJob($companyId, MarketplaceType::OZON, $dateFrom, $dateTo);
+            });
 
         $tester = $this->tester($repo, $dispatch);
         $code = $tester->execute([
@@ -213,8 +216,13 @@ final class ReconcileMarketplaceAdsCommandTest extends TestCase
             '--to' => '2026-04-02',
         ]);
 
+        $display = $tester->getDisplay();
         self::assertSame(Command::FAILURE, $code);
-        self::assertStringContainsString('failed=1', $tester->getDisplay());
+        self::assertStringContainsString('2026-04-01 error: boom', $display);
+        self::assertStringContainsString('2026-04-02 reload: missing', $display);
+        self::assertStringContainsString('created=1', $display);
+        self::assertStringContainsString('failed=1', $display);
+        self::assertStringNotContainsString('Return value must be of type', $display);
     }
 
     public function testRealRunCreatesOnlyOneJobAndDefersRemainingDays(): void
@@ -429,22 +437,33 @@ final class ReconcileMarketplaceAdsCommandTest extends TestCase
         $repo->method('findCompletedJobCoveringDate')->willReturn(null);
         $repo->method('findLatestJobCoveringDate')->willReturn(null);
 
+        $rateLimitedCompanyId = '11111111-1111-1111-1111-000000000101';
+        $healthyCompanyId = '11111111-1111-1111-1111-000000000202';
+
         $dispatch = $this->createMock(DispatchOzonAdLoadActionInterface::class);
         $dispatch->expects(self::exactly(2))->method('__invoke')
-            ->willReturnCallback(function (string $companyId): void {
-                if ('c1' === $companyId) {
+            ->willReturnCallback(function (string $companyId, \DateTimeImmutable $dateFrom, \DateTimeImmutable $dateTo) use ($rateLimitedCompanyId): AdLoadJob {
+                if ($rateLimitedCompanyId === $companyId) {
                     throw new \RuntimeException('rate_limited', 0, new OzonRateLimitException('429'));
                 }
+
+                return new AdLoadJob($companyId, MarketplaceType::OZON, $dateFrom, $dateTo);
             });
 
         $query = $this->createMock(ActiveOzonPerformanceConnectionsQuery::class);
-        $query->method('getCompanyIds')->willReturn(['c1', 'c2']);
+        $query->method('getCompanyIds')->willReturn([$rateLimitedCompanyId, $healthyCompanyId]);
 
         $tester = $this->tester($repo, $dispatch, $query);
         $code = $tester->execute(['--all-active' => true, '--from' => '2026-04-01', '--to' => '2026-04-01']);
 
+        $display = $tester->getDisplay();
         self::assertSame(Command::SUCCESS, $code);
-        self::assertStringContainsString('[c2]', $tester->getDisplay());
+        self::assertStringContainsString(sprintf('[%s] 2026-04-01 deferred: rate_limited', $rateLimitedCompanyId), $display);
+        self::assertStringContainsString(sprintf('[%s] 2026-04-01 reload: missing', $healthyCompanyId), $display);
+        self::assertStringContainsString('created=1', $display);
+        self::assertStringContainsString('deferred=1', $display);
+        self::assertStringContainsString('failed=0', $display);
+        self::assertStringNotContainsString('Return value must be of type', $display);
     }
 
 


### PR DESCRIPTION
### Motivation
- Two unit tests for the MarketplaceAds reconcile command were failing due to incorrect mock behavior and overly-weak test setup: one test produced a null return from the dispatch mock (triggering a return-type error) and the all-active rate-limit test used non-UUID company ids and did not assert that a rate-limit in one company does not stop work for another.

### Description
- Updated `testContinuesIfOneDayFails` to make the `DispatchOzonAdLoadActionInterface` mock throw `RuntimeException('boom')` on the first call and return a valid `AdLoadJob` on the second call, and added assertions that the second day is processed and no return-type error is produced.
- Strengthened `testRateLimitInOneCompanyDoesNotBlockAnotherInAllActiveMode` to use concrete company UUIDs, have the dispatch mock return a valid `AdLoadJob` for the healthy company while throwing an `OzonRateLimitException`-wrapped `RuntimeException` for the rate-limited company, and added assertions for deferred/created/failed counters and relevant per-company output.
- Changes are limited to test fixtures and assertions in `site/tests/Unit/MarketplaceAds/Command/ReconcileMarketplaceAdsCommandTest.php` to ensure the tests verify the intended business logic without weakening expectations.

### Testing
- Linted the modified test file with `php -l` and it reported no syntax errors.
- Ran the focused test with `cd site && php -d memory_limit=512M bin/phpunit --testsuite unit --filter ReconcileMarketplaceAdsCommandTest` and it passed (20 tests, 72 assertions).
- Ran the entire unit test suite `cd site && php -d memory_limit=512M bin/phpunit --testsuite unit` and it completed successfully (868 tests; 1 warning, 2 deprecations, 4 skipped) indicating no regressions in other tests.
- `make site-test-unit` was attempted but fails in this environment because `docker-compose` is not available, which does not affect the unit-level verification performed above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1aea819d608323b9d71296aa2c3b86)