### PR TITLE
Makefile: remove mandatory FILTER check from `codex-test-unit-filter` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,6 @@ codex-test-unit: codex-prepare
 	cd site && APP_ENV=test APP_DEBUG=1 php -d memory_limit=1G bin/phpunit --testsuite unit
 
 codex-test-unit-filter: codex-prepare
-	test -n "$(FILTER)"
 	cd site && APP_ENV=test APP_DEBUG=1 php -d memory_limit=512M bin/phpunit --testsuite unit --filter "$(FILTER)"
 
 # ===== API TYPES / OPENAPI =====


### PR DESCRIPTION
### Motivation
- Allow `codex-test-unit-filter` to run without failing when the `FILTER` make variable is not set by removing the explicit `test -n "$(FILTER)"` guard.

### Description
- Deleted the `test -n "$(FILTER)"` line from the `codex-test-unit-filter` Makefile target so the target no longer requires `FILTER` to be non-empty and simply invokes PHPUnit with `--filter "$(FILTER)"`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1af272376c83238f026e7add6a85e7)