### PR TITLE
Fix Codex PHP path targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,17 +99,24 @@ site-test-db-rebuild: site-test-wait-db
 
 # ===== CODEX TESTS =====
 
+CODEX_SYSTEM_PATH := /usr/bin:/usr/local/bin:/usr/sbin:/bin:/sbin
+
 codex-prepare:
-	cd site && unset COMPOSER_NO_DEV && COMPOSER_ALLOW_SUPERUSER=1 composer install --no-interaction --prefer-dist --no-progress --no-scripts
+	PATH="$(CODEX_SYSTEM_PATH)" which php
+	PATH="$(CODEX_SYSTEM_PATH)" php -v
+	PATH="$(CODEX_SYSTEM_PATH)" php --ini
+	PATH="$(CODEX_SYSTEM_PATH)" php -r 'foreach (["dom","xml","xmlwriter","SimpleXML","mbstring","curl","intl","zip","redis","sodium"] as $$ext) { echo $$ext . ": " . (extension_loaded($$ext) ? "OK" : "MISSING") . PHP_EOL; }'
+	cd site && unset COMPOSER_NO_DEV && PATH="$(CODEX_SYSTEM_PATH)" COMPOSER_ALLOW_SUPERUSER=1 composer install --no-interaction --prefer-dist --no-progress --no-scripts
 	test -f site/vendor/autoload.php
-	test -f site/vendor/symfony/phpunit-bridge/bin/simple-phpunit.php
-	cd site && php -d memory_limit=1G bin/phpunit --version
+	test -f site/bin/phpunit
+	test -f site/vendor/phpunit/phpunit/phpunit
+	cd site && PATH="$(CODEX_SYSTEM_PATH)" php -d memory_limit=1G bin/phpunit --version
 
 codex-test-unit: codex-prepare
-	cd site && APP_ENV=test APP_DEBUG=1 php -d memory_limit=1G bin/phpunit --testsuite unit
+	cd site && APP_ENV=test APP_DEBUG=1 PATH="$(CODEX_SYSTEM_PATH)" php -d memory_limit=1G bin/phpunit --testsuite unit
 
 codex-test-unit-filter: codex-prepare
-	cd site && APP_ENV=test APP_DEBUG=1 php -d memory_limit=512M bin/phpunit --testsuite unit --filter "$(FILTER)"
+	cd site && APP_ENV=test APP_DEBUG=1 PATH="$(CODEX_SYSTEM_PATH)" php -d memory_limit=512M bin/phpunit --testsuite unit --filter "$(FILTER)"
 
 # ===== API TYPES / OPENAPI =====
 #


### PR DESCRIPTION
### Motivation

- Codex Cloud used `/root/.phpenv/shims/php`, which pointed to a PHP without required extensions and caused `composer install` in `make codex-prepare` to fail. 
- The goal is to ensure Codex Makefile targets invoke the system PHP/Composer binaries instead of phpenv shims without touching production code or Docker-based targets.

### Description

- Add `CODEX_SYSTEM_PATH := /usr/bin:/usr/local/bin:/usr/sbin:/bin:/sbin` and run Composer/PHP invocations under that `PATH` so system PHP is used. 
- Update `codex-prepare` to run diagnostics (`which php`, `php -v`, `php --ini`, and an extension check) and to run `composer install` as `cd site && unset COMPOSER_NO_DEV && PATH="$(CODEX_SYSTEM_PATH)" COMPOSER_ALLOW_SUPERUSER=1 composer install --no-interaction --prefer-dist --no-progress --no-scripts`. 
- Ensure all PHP calls in `codex-prepare`, `codex-test-unit` and `codex-test-unit-filter` are executed as `PATH="$(CODEX_SYSTEM_PATH)" php ...` and change file checks to assert `site/bin/phpunit` or `vendor/phpunit/phpunit/phpunit` exist; keep `codex-test-unit*` dependent on `codex-prepare`. 
- Do not modify Docker-based targets; revert accidental `site/yarn.lock`, `site/.yarn/` and `site/.yarnrc.yml` changes and commit only the `Makefile` change.

### Testing

- Ran `make -n codex-prepare` and `make -n codex-test-unit-filter FILTER=ReconcileMarketplaceAdsCommandTest` to verify the generated commands use `PATH="/usr/bin:/usr/local/bin:/usr/sbin:/bin:/sbin"` (succeeded). 
- Ran `make codex-prepare` which performed diagnostics, used system `/usr/bin/php`, showed required extensions including `redis` and `sodium` as `OK`, and completed `composer install` successfully (succeeded after installing missing system PHP packages in the environment). 
- Ran `make codex-test-unit-filter FILTER=ReconcileMarketplaceAdsCommandTest` which executed the filtered unit tests and reported `OK (20 tests, 72 assertions)` (succeeded). 
- Ran `make codex-test-unit` which executed the full unit suite and finished with `OK, but there were issues! ... Warnings: 1` consistent with local expectations (succeeded with warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b0013c6e88323870a962cc1ae96ee)