### PR TITLE
Run unit tests in CI before building and pushing images

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,10 +17,22 @@ jobs:
               run: docker compose build site-php-cli
 
             - name: 📦 Install PHP dependencies
-              run: docker compose run --rm -T site-php-cli composer install --no-interaction --prefer-dist --no-progress --no-scripts
+              run: |
+                  docker compose run --rm -T \
+                    --user "$(id -u):$(id -g)" \
+                    -e COMPOSER_HOME=/tmp/composer \
+                    site-php-cli composer install --no-interaction --prefer-dist --no-progress --no-scripts
 
             - name: 🧪 Run unit tests
-              run: docker compose run --rm -T -e APP_ENV=test -e APP_DEBUG=0 -e APP_SECRET=test -e DEFAULT_URI=http://localhost site-php-cli composer test:unit
+              run: |
+                  docker compose run --rm -T \
+                    --user "$(id -u):$(id -g)" \
+                    -e COMPOSER_HOME=/tmp/composer \
+                    -e APP_ENV=test \
+                    -e APP_DEBUG=0 \
+                    -e APP_SECRET=test \
+                    -e DEFAULT_URI=http://localhost \
+                    site-php-cli composer test:unit
 
     # 1. ЭТАП СБОРКИ: Запускаем 4 сборки одновременно
     build-and-push:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,8 +6,25 @@ on:
     pull_request:
 
 jobs:
+    unit-tests:
+        name: 🧪 Unit tests
+        runs-on: ubuntu-latest
+        steps:
+            - name: 📦 Checkout repository
+              uses: actions/checkout@v4
+
+            - name: 🐳 Build site-php-cli
+              run: docker compose build site-php-cli
+
+            - name: 📦 Install PHP dependencies
+              run: docker compose run --rm -T site-php-cli composer install --no-interaction --prefer-dist --no-progress --no-scripts
+
+            - name: 🧪 Run unit tests
+              run: docker compose run --rm -T -e APP_ENV=test -e APP_DEBUG=0 -e APP_SECRET=test -e DEFAULT_URI=http://localhost site-php-cli composer test:unit
+
     # 1. ЭТАП СБОРКИ: Запускаем 4 сборки одновременно
     build-and-push:
+        needs: unit-tests
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false


### PR DESCRIPTION
### Motivation

- Ensure unit tests are executed in CI before any build-and-push steps run to catch regressions early.

### Description

- Add a new `unit-tests` job to `.github/workflows/deploy.yml` which checks out the repo, builds the `site-php-cli` service, installs PHP dependencies with `composer install`, and runs unit tests via `composer test:unit` inside the `site-php-cli` container.
- Make the existing `build-and-push` job depend on the new `unit-tests` job by adding `needs: unit-tests` so image builds are blocked until tests complete.
- Use `docker compose` invocations and set test environment variables when running the unit tests.

### Testing

- The CI job added is `unit-tests` and it runs `composer test:unit` inside the `site-php-cli` container as configured in the workflow.
- No automated workflow run results are included in this change, so test run results are not available in this PR.
- CI must be observed after pushing to confirm that the `unit-tests` job passes before `build-and-push` proceeds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b043ff6588323a10a9d7c081c8459)