### PR TITLE
Handle WB 429 headers and calculate cooldowns with improved parsing and logging

### DIFF
--- a/site/src/Marketplace/Application/Service/WbFinanceRateLimiter.php
+++ b/site/src/Marketplace/Application/Service/WbFinanceRateLimiter.php
@@ -107,13 +107,18 @@ final class WbFinanceRateLimiter
         return max(1, $retryAfter->getTimestamp() - $this->clock->now()->getTimestamp());
     }
 
-    public function cooldownUntilAfterRemote429(?int $retryAfterSeconds, int $defaultSeconds = 900): \DateTimeImmutable
+    public function cooldownUntilAfterRemote429(?int $retryAfterSeconds, int $defaultSeconds = 70): \DateTimeImmutable
     {
         $seconds = null !== $retryAfterSeconds
-            ? max(1, $retryAfterSeconds) + self::REMOTE_429_COOLDOWN_BUFFER_SECONDS
-            : max(1, $defaultSeconds);
+            ? max(1, $retryAfterSeconds)
+            : max(1, $defaultSeconds) + self::REMOTE_429_COOLDOWN_BUFFER_SECONDS;
 
         return $this->clock->now()->modify(sprintf('+%d seconds', $seconds));
+    }
+
+    public function now(): \DateTimeImmutable
+    {
+        return $this->clock->now();
     }
 
     public function getActiveSalesReportsCooldownUntil(string $sellerBucketId): ?\DateTimeImmutable

--- a/site/src/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClient.php
+++ b/site/src/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClient.php
@@ -103,7 +103,7 @@ final readonly class WbFinanceSalesReportClient
         $this->rateLimiter->setSalesReportsCooldownUntil($sellerBucketId, $cooldownUntil);
     }
 
-    public function cooldownUntilAfterRemote429(?int $retryAfterSeconds, int $defaultSeconds = 900): \DateTimeImmutable
+    public function cooldownUntilAfterRemote429(?int $retryAfterSeconds, int $defaultSeconds = 70): \DateTimeImmutable
     {
         return $this->rateLimiter->cooldownUntilAfterRemote429($retryAfterSeconds, $defaultSeconds);
     }
@@ -183,8 +183,7 @@ final readonly class WbFinanceSalesReportClient
         }
 
         if (429 === $statusCode) {
-            $retryAfter = $this->extractRetryAfter($headers);
-            $this->setSalesReportsCooldownUntil($sellerBucketId, $this->cooldownUntilAfterRemote429($retryAfter));
+            $retryAfter = $this->handleRemote429($sellerBucketId, $headers, $statusCode, $dateFrom, $dateTo, $rrdId, $limit, $excerpt, 'wildberries::finance-sales-reports-detailed');
 
             throw new MarketplaceRateLimitException($statusCode, $excerpt, $dateFrom, $dateTo, $retryAfter);
         }
@@ -294,8 +293,7 @@ final readonly class WbFinanceSalesReportClient
             return false;
         }
         if (429 === $statusCode) {
-            $retryAfter = $this->extractRetryAfter($headers);
-            $this->setSalesReportsCooldownUntil($sellerBucketId, $this->cooldownUntilAfterRemote429($retryAfter));
+            $retryAfter = $this->handleRemote429($sellerBucketId, $headers, $statusCode, '', '', null, null, $excerpt, 'wildberries::finance-ping');
 
             throw new MarketplaceRateLimitException($statusCode, $excerpt, '', '', $retryAfter);
         }
@@ -358,8 +356,7 @@ final readonly class WbFinanceSalesReportClient
             return false;
         }
         if (429 === $statusCode) {
-            $retryAfter = $this->extractRetryAfter($headers);
-            $this->setSalesReportsCooldownUntil($sellerBucketId, $this->cooldownUntilAfterRemote429($retryAfter));
+            $retryAfter = $this->handleRemote429($sellerBucketId, $headers, $statusCode, $dateFrom, $dateTo, 0, 1, $excerpt, 'wildberries::finance-sales-reports-detailed');
 
             throw new MarketplaceRateLimitException($statusCode, $excerpt, $dateFrom, $dateTo, $retryAfter);
         }
@@ -433,33 +430,164 @@ final readonly class WbFinanceSalesReportClient
         return mb_substr($trimmed, 0, 500);
     }
 
-    private function extractRetryAfter(array $headers): ?int
+    private function handleRemote429(
+        string $sellerBucketId,
+        array $headers,
+        int $statusCode,
+        string $dateFrom,
+        string $dateTo,
+        ?int $rrdId,
+        ?int $limit,
+        string $excerpt,
+        string $endpoint,
+    ): ?int {
+        $cooldown = $this->calculateRemote429Cooldown($headers);
+        $this->setSalesReportsCooldownUntil($sellerBucketId, $cooldown['cooldown_until']);
+
+        $this->logger->warning('WB finance remote rate limit response.', [
+            'endpoint' => $endpoint,
+            'status_code' => $statusCode,
+            'dateFrom' => $dateFrom,
+            'dateTo' => $dateTo,
+            'rrdId' => $rrdId,
+            'limit' => $limit,
+            'seller_bucket_id' => $sellerBucketId,
+            'server_time' => $cooldown['server_time']->format(\DateTimeInterface::ATOM),
+            'calculated_cooldown_until' => $cooldown['cooldown_until']->format(\DateTimeInterface::ATOM),
+            'calculated_retry_after_seconds' => $cooldown['retry_after_seconds'],
+            'cooldown_source_header' => $cooldown['source_header'],
+            'cooldown_source_value' => $cooldown['source_value'],
+            'retry_after' => $this->extractHeaderFirstValue($headers, 'retry-after'),
+            'x_ratelimit_retry' => $this->extractHeaderFirstValue($headers, self::WB_HEADER_RETRY),
+            'x_ratelimit_reset' => $this->extractHeaderFirstValue($headers, self::WB_HEADER_RESET),
+            'x_ratelimit_limit' => $this->extractHeaderFirstValue($headers, 'x-ratelimit-limit'),
+            'x_ratelimit_remaining' => $this->extractHeaderFirstValue($headers, 'x-ratelimit-remaining'),
+            'response_headers_json' => $this->encodeSafeHeadersJson($headers),
+            'response_excerpt' => $excerpt,
+        ]);
+
+        return $cooldown['retry_after_seconds'];
+    }
+
+    /**
+     * @return array{cooldown_until: \DateTimeImmutable, retry_after_seconds: ?int, server_time: \DateTimeImmutable, source_header: ?string, source_value: ?string}
+     */
+    private function calculateRemote429Cooldown(array $headers): array
     {
-        $retryAfter = $this->extractHeaderInt($headers, self::WB_HEADER_RETRY);
-        if (null !== $retryAfter) {
-            return $retryAfter;
+        $now = $this->rateLimiter->now();
+        $candidates = [
+            'retry-after' => true,
+            self::WB_HEADER_RETRY => true,
+            self::WB_HEADER_RESET => false,
+        ];
+
+        foreach ($candidates as $headerName => $allowRelativeSeconds) {
+            $value = $this->extractHeaderFirstValue($headers, $headerName);
+            if (null === $value) {
+                continue;
+            }
+
+            $cooldownUntil = $this->parseRetryCooldownHeader($value, $now, $allowRelativeSeconds);
+
+            if (null === $cooldownUntil) {
+                continue;
+            }
+
+            return [
+                'cooldown_until' => $cooldownUntil,
+                'retry_after_seconds' => max(1, $cooldownUntil->getTimestamp() - $now->getTimestamp()),
+                'server_time' => $now,
+                'source_header' => $headerName,
+                'source_value' => $value,
+            ];
         }
 
-        $reset = $this->extractHeaderInt($headers, self::WB_HEADER_RESET);
-        if (null === $reset) {
+        $fallbackUntil = $this->cooldownUntilAfterRemote429(null);
+
+        return [
+            'cooldown_until' => $fallbackUntil,
+            'retry_after_seconds' => null,
+            'server_time' => $now,
+            'source_header' => null,
+            'source_value' => null,
+        ];
+    }
+
+    private function parseRetryCooldownHeader(string $value, \DateTimeImmutable $now, bool $allowRelativeSeconds): ?\DateTimeImmutable
+    {
+        $trimmed = trim($value);
+        if ('' === $trimmed) {
             return null;
         }
 
-        $now = (new \DateTimeImmutable())->getTimestamp();
+        if (ctype_digit($trimmed)) {
+            $numericValue = (int) $trimmed;
+            if ($allowRelativeSeconds && $numericValue <= 86400) {
+                return $now->modify(sprintf('+%d seconds', max(1, $numericValue)));
+            }
 
-        return $reset > $now ? max(0, $reset - $now) : $reset;
+            if ($numericValue > $now->getTimestamp()) {
+                return (new \DateTimeImmutable('@'.$numericValue))->setTimezone($now->getTimezone());
+            }
+
+            return null;
+        }
+
+        return $this->parseDateTimeHeader($trimmed, $now);
+    }
+
+    private function parseDateTimeHeader(string $value, \DateTimeImmutable $now): ?\DateTimeImmutable
+    {
+        if ('' === $value) {
+            return null;
+        }
+
+        try {
+            $parsed = new \DateTimeImmutable($value, $now->getTimezone());
+        } catch (\Exception) {
+            return null;
+        }
+
+        if ($parsed->getTimestamp() <= $now->getTimestamp()) {
+            return null;
+        }
+
+        return $parsed->setTimezone($now->getTimezone());
+    }
+
+    private function extractRetryAfter(array $headers): ?int
+    {
+        return $this->calculateRemote429Cooldown($headers)['retry_after_seconds'];
     }
 
     private function extractHeaderInt(array $headers, string $name): ?int
+    {
+        $value = $this->extractHeaderFirstValue($headers, $name);
+
+        return null !== $value && ctype_digit(trim($value)) ? (int) trim($value) : null;
+    }
+
+    private function extractHeaderFirstValue(array $headers, string $name): ?string
     {
         $values = $headers[$name] ?? $headers[strtolower($name)] ?? null;
         if (!is_array($values) || [] === $values) {
             return null;
         }
 
-        $value = trim((string) $values[0]);
+        return trim((string) $values[0]);
+    }
 
-        return ctype_digit($value) ? (int) $value : null;
+    private function encodeSafeHeadersJson(array $headers): string
+    {
+        $normalized = [];
+        foreach ($headers as $name => $values) {
+            $normalized[(string) $name] = array_map(
+                static fn (mixed $value): string => mb_substr((string) $value, 0, 1000),
+                is_array($values) ? $values : [$values],
+            );
+        }
+
+        return json_encode($normalized, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE) ?: '{}';
     }
 
     private function logWbResponse(

--- a/site/tests/Unit/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClientTest.php
+++ b/site/tests/Unit/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClientTest.php
@@ -13,6 +13,7 @@ use App\Marketplace\Exception\MarketplaceRateLimitException;
 use App\Marketplace\Exception\MarketplaceTemporaryApiException;
 use App\Marketplace\Infrastructure\Api\Wildberries\WbFinanceSalesReportClient;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
 use Symfony\Component\Clock\MockClock;
 use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -205,7 +206,7 @@ final class WbFinanceSalesReportClientTest extends TestCase
         $http = new MockHttpClient(static function () use (&$requestCount): MockResponse {
             ++$requestCount;
 
-            return new MockResponse('{"error":"rate"}', ['http_code' => 429, 'response_headers' => ['x-ratelimit-retry: 17']]);
+            return new MockResponse('{"error":"rate"}', ['http_code' => 429, 'response_headers' => ['retry-after: 17']]);
         });
         $client = new WbFinanceSalesReportClient($http, $this->createRateLimiter(null, $storage));
 
@@ -230,7 +231,7 @@ final class WbFinanceSalesReportClientTest extends TestCase
         $storage = new InMemoryWbFinanceCooldownStorage();
         $connectionId = '6eada2b7-b453-4c33-a92a-e7dce52e291c';
         $client = new WbFinanceSalesReportClient(
-            new MockHttpClient(new MockResponse('{"error":"rate"}', ['http_code' => 429, 'response_headers' => ['x-ratelimit-retry: 17']])),
+            new MockHttpClient(new MockResponse('{"error":"rate"}', ['http_code' => 429, 'response_headers' => ['retry-after: 17']])),
             $this->createRateLimiter(new MockClock('2026-01-01T00:00:00Z'), $storage),
         );
 
@@ -252,7 +253,7 @@ final class WbFinanceSalesReportClientTest extends TestCase
         $http = new MockHttpClient(static function () use (&$requestCount): MockResponse {
             ++$requestCount;
 
-            return new MockResponse('{"error":"rate"}', ['http_code' => 429, 'response_headers' => ['x-ratelimit-retry: 17']]);
+            return new MockResponse('{"error":"rate"}', ['http_code' => 429, 'response_headers' => ['retry-after: 17']]);
         });
         $client = new WbFinanceSalesReportClient($http, $this->createRateLimiter(new MockClock('2026-01-01T00:00:00Z'), $storage));
 
@@ -277,7 +278,7 @@ final class WbFinanceSalesReportClientTest extends TestCase
     {
         $storage = new InMemoryWbFinanceCooldownStorage();
         $client = new WbFinanceSalesReportClient(
-            new MockHttpClient(new MockResponse('{"error":"rate"}', ['http_code' => 429, 'response_headers' => ['x-ratelimit-retry: 17']])),
+            new MockHttpClient(new MockResponse('{"error":"rate"}', ['http_code' => 429, 'response_headers' => ['retry-after: 17']])),
             $this->createRateLimiter(new MockClock('2026-01-01T00:00:00Z'), $storage),
         );
 
@@ -293,7 +294,7 @@ final class WbFinanceSalesReportClientTest extends TestCase
     {
         $storage = new InMemoryWbFinanceCooldownStorage();
         $client = new WbFinanceSalesReportClient(
-            new MockHttpClient(new MockResponse('{"error":"rate"}', ['http_code' => 429, 'response_headers' => ['x-ratelimit-retry: 17']])),
+            new MockHttpClient(new MockResponse('{"error":"rate"}', ['http_code' => 429, 'response_headers' => ['retry-after: 17']])),
             $this->createRateLimiter(new MockClock('2026-01-01T00:00:00Z'), $storage),
         );
 
@@ -327,7 +328,7 @@ final class WbFinanceSalesReportClientTest extends TestCase
         $client = new WbFinanceSalesReportClient(new MockHttpClient(new MockResponse('{"error":"rate"}', [
             'http_code' => 429,
             'response_headers' => [
-                'x-ratelimit-retry: 17',
+                'retry-after: 17',
             ],
         ])), $this->createRateLimiter());
 
@@ -337,6 +338,169 @@ final class WbFinanceSalesReportClientTest extends TestCase
         } catch (MarketplaceRateLimitException $e) {
             self::assertSame(17, $e->getRetryAfter());
         }
+    }
+
+
+    public function testRemote429RetryAfterSecondsSetsCooldownFromNow(): void
+    {
+        $storage = new InMemoryWbFinanceCooldownStorage();
+        $clock = new MockClock('2026-01-01T12:00:00Z');
+        $client = new WbFinanceSalesReportClient(
+            new MockHttpClient(new MockResponse('{"error":"rate"}', [
+                'http_code' => 429,
+                'response_headers' => ['retry-after: 60'],
+            ])),
+            $this->createRateLimiter($clock, $storage),
+        );
+
+        try {
+            $client->fetchDetailedForConnection('connection-id', 'token', '2026-01-01', '2026-01-01');
+            self::fail('Expected MarketplaceRateLimitException');
+        } catch (MarketplaceRateLimitException $e) {
+            self::assertSame(60, $e->getRetryAfter());
+        }
+
+        self::assertSame(
+            $clock->now()->modify('+60 seconds')->getTimestamp(),
+            $storage->getUntilTimestamp('wb_finance:sales_reports:cooldown:connection:connection-id'),
+        );
+    }
+
+    public function testRemote429XRateLimitRetryRelativeSecondsSetsCooldownFromNow(): void
+    {
+        $storage = new InMemoryWbFinanceCooldownStorage();
+        $clock = new MockClock('2026-01-01T12:00:00Z');
+        $client = new WbFinanceSalesReportClient(
+            new MockHttpClient(new MockResponse('{"error":"rate"}', [
+                'http_code' => 429,
+                'response_headers' => ['x-ratelimit-retry: 60'],
+            ])),
+            $this->createRateLimiter($clock, $storage),
+        );
+
+        try {
+            $client->fetchDetailedForConnection('connection-id', 'token', '2026-01-01', '2026-01-01');
+            self::fail('Expected MarketplaceRateLimitException');
+        } catch (MarketplaceRateLimitException $e) {
+            self::assertSame(60, $e->getRetryAfter());
+        }
+
+        self::assertSame(
+            $clock->now()->modify('+60 seconds')->getTimestamp(),
+            $storage->getUntilTimestamp('wb_finance:sales_reports:cooldown:connection:connection-id'),
+        );
+    }
+
+    public function testRemote429XRateLimitRetryUnixTimestampSetsCooldownToTimestamp(): void
+    {
+        $storage = new InMemoryWbFinanceCooldownStorage();
+        $clock = new MockClock('2026-01-01T12:00:00Z');
+        $retryAt = $clock->now()->modify('+75 seconds')->getTimestamp();
+        $client = new WbFinanceSalesReportClient(
+            new MockHttpClient(new MockResponse('{"error":"rate"}', [
+                'http_code' => 429,
+                'response_headers' => ['x-ratelimit-retry: '.$retryAt],
+            ])),
+            $this->createRateLimiter($clock, $storage),
+        );
+
+        try {
+            $client->fetchDetailedForConnection('connection-id', 'token', '2026-01-01', '2026-01-01');
+            self::fail('Expected MarketplaceRateLimitException');
+        } catch (MarketplaceRateLimitException $e) {
+            self::assertSame(75, $e->getRetryAfter());
+        }
+
+        self::assertSame($retryAt, $storage->getUntilTimestamp('wb_finance:sales_reports:cooldown:connection:connection-id'));
+    }
+
+    public function testRemote429InvalidRateLimitHeaderUsesShortFallback(): void
+    {
+        $storage = new InMemoryWbFinanceCooldownStorage();
+        $clock = new MockClock('2026-01-01T12:00:00Z');
+        $client = new WbFinanceSalesReportClient(
+            new MockHttpClient(new MockResponse('{"error":"rate"}', [
+                'http_code' => 429,
+                'response_headers' => ['x-ratelimit-retry: not-a-date'],
+            ])),
+            $this->createRateLimiter($clock, $storage),
+        );
+
+        try {
+            $client->fetchDetailedForConnection('connection-id', 'token', '2026-01-01', '2026-01-01');
+            self::fail('Expected MarketplaceRateLimitException');
+        } catch (MarketplaceRateLimitException $e) {
+            self::assertNull($e->getRetryAfter());
+        }
+
+        self::assertSame(
+            $clock->now()->modify('+85 seconds')->getTimestamp(),
+            $storage->getUntilTimestamp('wb_finance:sales_reports:cooldown:connection:connection-id'),
+        );
+    }
+
+
+    public function testRemote429RetryAfterTakesPriorityOverLongResetTimestamp(): void
+    {
+        $storage = new InMemoryWbFinanceCooldownStorage();
+        $clock = new MockClock('2026-01-01T12:00:00Z');
+        $longResetAt = $clock->now()->setTime(21, 15)->getTimestamp();
+        $client = new WbFinanceSalesReportClient(
+            new MockHttpClient(new MockResponse('{"error":"rate"}', [
+                'http_code' => 429,
+                'response_headers' => [
+                    'retry-after: 60',
+                    'x-ratelimit-reset: '.$longResetAt,
+                ],
+            ])),
+            $this->createRateLimiter($clock, $storage),
+        );
+
+        try {
+            $client->fetchDetailedForConnection('connection-id', 'token', '2026-01-01', '2026-01-01');
+            self::fail('Expected MarketplaceRateLimitException');
+        } catch (MarketplaceRateLimitException $e) {
+            self::assertSame(60, $e->getRetryAfter());
+        }
+
+        self::assertSame(
+            $clock->now()->modify('+60 seconds')->getTimestamp(),
+            $storage->getUntilTimestamp('wb_finance:sales_reports:cooldown:connection:connection-id'),
+        );
+    }
+
+    public function testRemote429LogsRawRateLimitHeadersAndCalculatedCooldown(): void
+    {
+        $storage = new InMemoryWbFinanceCooldownStorage();
+        $clock = new MockClock('2026-01-01T12:00:00Z');
+        $logger = new InMemoryLogger();
+        $client = new WbFinanceSalesReportClient(
+            new MockHttpClient(new MockResponse('{"error":"rate"}', [
+                'http_code' => 429,
+                'response_headers' => [
+                    'retry-after: 60',
+                    'x-ratelimit-limit: 1',
+                    'x-ratelimit-remaining: 0',
+                ],
+            ])),
+            $this->createRateLimiter($clock, $storage),
+            $logger,
+        );
+
+        try {
+            $client->fetchDetailedForConnection('connection-id', 'token', '2026-01-01', '2026-01-01');
+            self::fail('Expected MarketplaceRateLimitException');
+        } catch (MarketplaceRateLimitException) {
+        }
+
+        $record = $logger->firstRecordByMessage('WB finance remote rate limit response.');
+        self::assertNotNull($record);
+        self::assertSame('60', $record['context']['retry_after'] ?? null);
+        self::assertSame('1', $record['context']['x_ratelimit_limit'] ?? null);
+        self::assertSame('0', $record['context']['x_ratelimit_remaining'] ?? null);
+        self::assertSame('2026-01-01T12:00:00+00:00', $record['context']['server_time'] ?? null);
+        self::assertSame('2026-01-01T12:01:00+00:00', $record['context']['calculated_cooldown_until'] ?? null);
+        self::assertJson((string) ($record['context']['response_headers_json'] ?? ''));
     }
 
     public function test401And403MappedToAuthException(): void
@@ -475,7 +639,7 @@ final class WbFinanceSalesReportClientTest extends TestCase
         $http = new MockHttpClient(static function () use (&$requestCount): MockResponse {
             ++$requestCount;
 
-            return new MockResponse('{"error":"rate"}', ['http_code' => 429, 'response_headers' => ['x-ratelimit-retry: 17']]);
+            return new MockResponse('{"error":"rate"}', ['http_code' => 429, 'response_headers' => ['retry-after: 17']]);
         });
         $client = new WbFinanceSalesReportClient($http, $this->createRateLimiter(new MockClock('2026-01-01T00:00:00Z'), $storage));
 
@@ -499,7 +663,7 @@ final class WbFinanceSalesReportClientTest extends TestCase
     {
         $storage = new InMemoryWbFinanceCooldownStorage();
         $client = new WbFinanceSalesReportClient(
-            new MockHttpClient(new MockResponse('{"error":"rate"}', ['http_code' => 429, 'response_headers' => ['x-ratelimit-retry: 17']])),
+            new MockHttpClient(new MockResponse('{"error":"rate"}', ['http_code' => 429, 'response_headers' => ['retry-after: 17']])),
             $this->createRateLimiter(new MockClock('2026-01-01T00:00:00Z'), $storage),
         );
 
@@ -541,6 +705,31 @@ final class WbFinanceSalesReportClientTest extends TestCase
         );
 
         return new WbFinanceRateLimiter($factory, $clock ?? new MockClock(), null, $storage);
+    }
+}
+
+
+final class InMemoryLogger extends AbstractLogger
+{
+    /** @var list<array{level: mixed, message: string, context: array<string, mixed>}> */
+    private array $records = [];
+
+    /** @param array<string, mixed> $context */
+    public function log($level, string|\Stringable $message, array $context = []): void
+    {
+        $this->records[] = ['level' => $level, 'message' => (string) $message, 'context' => $context];
+    }
+
+    /** @return array{level: mixed, message: string, context: array<string, mixed>}|null */
+    public function firstRecordByMessage(string $message): ?array
+    {
+        foreach ($this->records as $record) {
+            if ($message === $record['message']) {
+                return $record;
+            }
+        }
+
+        return null;
     }
 }
 


### PR DESCRIPTION
### Motivation
- Make cooldown calculation for remote 429 responses more robust by parsing standard and vendor headers and preferring `Retry-After` values when present.  
- Ensure cooldowns are stored and logged with consistent timezone-aware timestamps and provide better observability of raw rate-limit headers.  
- Add targeted unit tests to cover multiple header formats and fallback behaviors.

### Description
- Changed default short fallback cooldown from `900` to `70` seconds in `WbFinanceRateLimiter::cooldownUntilAfterRemote429` and adjusted buffer application order.  
- Added `WbFinanceRateLimiter::now()` helper to expose clock time for callers.  
- Replaced ad-hoc `extractRetryAfter` usage in `WbFinanceSalesReportClient` with `handleRemote429`, which centralizes: header parsing, cooldown calculation, storage update via `setSalesReportsCooldownUntil`, and structured logging.  
- Implemented header parsing helpers: `calculateRemote429Cooldown`, `parseRetryCooldownHeader`, `parseDateTimeHeader`, `extractHeaderInt`, `extractHeaderFirstValue`, and `encodeSafeHeadersJson` to handle `Retry-After`, `x-ratelimit-retry`, and `x-ratelimit-reset` semantics (relative seconds or absolute timestamps).  
- Updated `logWbResponse` to use the integer header extractor for consistent logged values.  
- Updated unit tests in `WbFinanceSalesReportClientTest` to use `retry-after` headers and added new tests covering relative-second and unix-timestamp parsing, invalid headers fallback, `Retry-After` priority over long `x-ratelimit-reset`, and logging of calculated cooldowns; also added an `InMemoryLogger` test helper and imported `Psr\Log\AbstractLogger`.

### Testing
- Ran the PHPUnit unit test file `site/tests/Unit/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClientTest.php`, which includes new tests for multiple 429 header scenarios and logging, and all tests completed successfully.  
- Existing tests covering status-code mappings (`204`, `401`, `403`, `400`, `5xx`, transport errors) were exercised and passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bf2a86a9083238a7eac87f95b6f67)