### PR TITLE
WB finance: connection-first buckets, orchestrator, diagnostics and planner enhancements

### DIFF
--- a/site/src/Marketplace/Application/Service/WbFinanceRateLimiter.php
+++ b/site/src/Marketplace/Application/Service/WbFinanceRateLimiter.php
@@ -59,28 +59,6 @@ final class WbFinanceRateLimiter
     /** @return array{bucket_id: string, bucket_source: string} */
     public function resolveSalesReportsBucket(MarketplaceConnection $connection): array
     {
-        $settings = $connection->getSettings() ?? [];
-        $settingSources = [
-            'sellerId' => 'seller_id',
-            'seller_id' => 'seller_id',
-            'accountId' => 'account_id',
-            'account_id' => 'account_id',
-            'supplierId' => 'supplier_id',
-            'supplier_id' => 'supplier_id',
-            'wbSellerId' => 'wb_seller_id',
-            'wb_seller_id' => 'wb_seller_id',
-        ];
-
-        foreach ($settingSources as $key => $source) {
-            $value = $settings[$key] ?? null;
-            if (is_scalar($value)) {
-                $normalized = $this->normalizeBucketPart((string) $value);
-                if ('' !== $normalized) {
-                    return ['bucket_id' => $normalized, 'bucket_source' => $source];
-                }
-            }
-        }
-
         return [
             'bucket_id' => 'connection:'.$this->normalizeBucketPart($connection->getId()),
             'bucket_source' => 'connection',

--- a/site/src/Marketplace/Application/Service/WbFinancialReportPeriodResolver.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportPeriodResolver.php
@@ -37,8 +37,20 @@ final class WbFinancialReportPeriodResolver
      */
     public function last14Days(): array
     {
+        return $this->lastDays(14);
+    }
+
+    /**
+     * @return list<DateTimeImmutable>
+     */
+    public function lastDays(int $daysBack): array
+    {
+        if ($daysBack <= 0) {
+            throw new DomainException('Days back must be a positive integer.');
+        }
+
         $to = $this->yesterday();
-        $from = $to->modify('-13 days');
+        $from = $to->modify(sprintf('-%d days', $daysBack - 1));
 
         return $this->daysBetween($from, $to);
     }

--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlanner.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlanner.php
@@ -41,12 +41,17 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
 
     public function planRefresh14Days(?string $companyId = null, ?string $connectionId = null, int $maxDays = 1): int
     {
-        if ($maxDays <= 0) {
+        return $this->planRefreshRecentDays($companyId, $connectionId, 14, $maxDays);
+    }
+
+    public function planRefreshRecentDays(?string $companyId = null, ?string $connectionId = null, int $daysBack = 2, int $maxDays = 1): int
+    {
+        if ($maxDays <= 0 || $daysBack <= 0) {
             return 0;
         }
 
         $dispatched = 0;
-        $days = $this->periodResolver->last14Days();
+        $days = $this->periodResolver->lastDays($daysBack);
         $from = $days[0];
         $to = $days[array_key_last($days)];
         $now = $this->clock->now();
@@ -59,51 +64,59 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
                 $from,
                 $to,
             );
-            $statusByDay = [];
+            $statusByDayAndMode = [];
             foreach ($statuses as $statusEntity) {
-                $statusByDay[$statusEntity->getBusinessDate()->format('Y-m-d')] = $statusEntity;
+                $mode = $statusEntity->getMode();
+                if (null === $mode) {
+                    continue;
+                }
+
+                $statusByDayAndMode[$statusEntity->getBusinessDate()->format('Y-m-d')][$mode->value] = $statusEntity;
             }
 
             $retryDue = [];
             $success = [];
-            $unknown = [];
+            $dailyCompletedWithoutRefresh = [];
 
             foreach ($days as $day) {
-                $statusEntity = $statusByDay[$day->format('Y-m-d')] ?? null;
-                $status = $statusEntity?->getStatus();
+                $dayKey = $day->format('Y-m-d');
+                $dailyStatus = ($statusByDayAndMode[$dayKey][FinancialReportSyncMode::DAILY->value] ?? null)?->getStatus();
+                $dailyCompleted = \in_array($dailyStatus, [FinancialReportSyncStatus::SUCCESS, FinancialReportSyncStatus::EMPTY], true);
+                $refreshStatusEntity = $statusByDayAndMode[$dayKey][FinancialReportSyncMode::REFRESH_14D->value] ?? null;
+                $refreshStatus = $refreshStatusEntity?->getStatus();
 
-                if (\in_array($status, [FinancialReportSyncStatus::LOADING, FinancialReportSyncStatus::PROCESSING], true)) {
-                    continue;
-                }
-
-                if (\in_array($status, [FinancialReportSyncStatus::QUEUED, FinancialReportSyncStatus::FAILED], true)) {
-                    if (null !== $statusEntity?->getNextRetryAt() && $statusEntity->getNextRetryAt() > $now) {
+                if (null !== $refreshStatusEntity) {
+                    if (\in_array($refreshStatus, [FinancialReportSyncStatus::LOADING, FinancialReportSyncStatus::PROCESSING], true)) {
                         continue;
                     }
 
-                    if (FinancialReportSyncStatus::QUEUED === $status && null === $statusEntity?->getNextRetryAt()) {
+                    if (\in_array($refreshStatus, [FinancialReportSyncStatus::QUEUED, FinancialReportSyncStatus::FAILED], true)) {
+                        if (null !== $refreshStatusEntity->getNextRetryAt() && $refreshStatusEntity->getNextRetryAt() > $now) {
+                            continue;
+                        }
+
+                        if (FinancialReportSyncStatus::QUEUED === $refreshStatus && null === $refreshStatusEntity->getNextRetryAt()) {
+                            continue;
+                        }
+
+                        $retryDue[] = $day;
                         continue;
                     }
 
-                    $retryDue[] = $day;
-                    continue;
-                }
+                    if (\in_array($refreshStatus, [FinancialReportSyncStatus::SUCCESS, FinancialReportSyncStatus::EMPTY], true)) {
+                        if ($dailyCompleted) {
+                            $success[] = [
+                                'day' => $day,
+                                'updated_at' => $refreshStatusEntity->getUpdatedAt() ?? new DateTimeImmutable('9999-12-31T00:00:00+00:00'),
+                            ];
+                        }
 
-                if (\in_array($status, [FinancialReportSyncStatus::SUCCESS, FinancialReportSyncStatus::EMPTY], true)) {
-                    $updatedAt = $statusEntity?->getUpdatedAt();
-                    if (null === $updatedAt) {
-                        $updatedAt = new DateTimeImmutable('9999-12-31T00:00:00+00:00');
+                        continue;
                     }
-
-                    $success[] = [
-                        'day' => $day,
-                        'updated_at' => $updatedAt,
-                    ];
-                    continue;
                 }
 
-                if (null === $status) {
-                    $unknown[] = $day;
+                if ($dailyCompleted) {
+                    $dailyCompletedWithoutRefresh[] = $day;
                 }
             }
 
@@ -119,12 +132,58 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
             $successDays = array_map(static fn (array $item): DateTimeImmutable => $item['day'], $success);
 
             $scheduledForConnection = 0;
-            foreach (array_merge($retryDue, $successDays, $unknown) as $day) {
+            foreach (array_merge($retryDue, $successDays, $dailyCompletedWithoutRefresh) as $day) {
                 if ($scheduledForConnection >= $maxDays) {
                     break;
                 }
 
                 if (!$this->claimAndDispatch($connection['company_id'], $connection['connection_id'], $day, FinancialReportSyncMode::REFRESH_14D, true)) {
+                    continue;
+                }
+
+                ++$dispatched;
+                ++$scheduledForConnection;
+            }
+        }
+
+        return $dispatched;
+    }
+
+    public function planDueRetry(?string $companyId = null, ?string $connectionId = null, int $maxDays = 1): int
+    {
+        if ($maxDays <= 0) {
+            return 0;
+        }
+
+        $dispatched = 0;
+        $from = $this->periodResolver->currentYearStart();
+        $to = $this->periodResolver->yesterday();
+        $now = $this->clock->now();
+
+        foreach ($this->activeWbConnectionsQuery->execute($companyId, $connectionId) as $connection) {
+            $retryItems = $this->syncStatusRepository->findRetryDueDays(
+                $connection['company_id'],
+                $connection['connection_id'],
+                self::REPORT_TYPE,
+                $from,
+                $to,
+                $now,
+                $maxDays,
+            );
+
+            $scheduledForConnection = 0;
+            foreach ($retryItems as $retryItem) {
+                if ($scheduledForConnection >= $maxDays) {
+                    break;
+                }
+
+                if (!$this->claimAndDispatch(
+                    $connection['company_id'],
+                    $connection['connection_id'],
+                    $retryItem['business_date'],
+                    $retryItem['mode'],
+                    false,
+                )) {
                     continue;
                 }
 
@@ -179,7 +238,7 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
                 $knownDays[$status->getBusinessDate()->format('Y-m-d')] = true;
             }
 
-            $retryDueDays = $this->syncStatusRepository->findRetryDueDays(
+            $retryDueItems = $this->syncStatusRepository->findRetryDueDays(
                 $connection['company_id'],
                 $connection['connection_id'],
                 self::REPORT_TYPE,
@@ -190,8 +249,9 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
             );
 
             $scheduledDays = [];
-            foreach ($retryDueDays as $day) {
-                $scheduledDays[$day->format('Y-m-d')] = $day;
+            foreach ($retryDueItems as $retryItem) {
+                $day = $retryItem['business_date'];
+                $scheduledDays[$day->format('Y-m-d')] = $retryItem;
             }
 
             if (count($scheduledDays) < $maxDays) {
@@ -201,7 +261,7 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
                         continue;
                     }
 
-                    $scheduledDays[$dayKey] = $day;
+                    $scheduledDays[$dayKey] = ['business_date' => $day, 'mode' => FinancialReportSyncMode::MISSING];
                     if (count($scheduledDays) >= $maxDays) {
                         break;
                     }
@@ -209,8 +269,14 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
             }
 
             ksort($scheduledDays);
-            foreach ($scheduledDays as $day) {
-                if (!$this->claimAndDispatch($connection['company_id'], $connection['connection_id'], $day, FinancialReportSyncMode::MISSING, false)) {
+            foreach ($scheduledDays as $retryItem) {
+                if (!$this->claimAndDispatch(
+                    $connection['company_id'],
+                    $connection['connection_id'],
+                    $retryItem['business_date'],
+                    $retryItem['mode'],
+                    false,
+                )) {
                     continue;
                 }
 

--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlannerInterface.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlannerInterface.php
@@ -13,6 +13,10 @@ interface WbFinancialReportSyncPlannerInterface
 
     public function planRefresh14Days(?string $companyId = null, ?string $connectionId = null, int $maxDays = 1): int;
 
+    public function planRefreshRecentDays(?string $companyId = null, ?string $connectionId = null, int $daysBack = 2, int $maxDays = 1): int;
+
+    public function planDueRetry(?string $companyId = null, ?string $connectionId = null, int $maxDays = 1): int;
+
     public function planRange(
         DateTimeImmutable $from,
         DateTimeImmutable $to,

--- a/site/src/Marketplace/Command/WbFinanceDiagnosticsCommand.php
+++ b/site/src/Marketplace/Command/WbFinanceDiagnosticsCommand.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace App\Marketplace\Command;
 
+use App\Marketplace\Application\Service\WbFinanceRateLimiter;
+use App\Marketplace\Application\Service\WbFinancialReportPeriodResolver;
+use App\Marketplace\Exception\MarketplaceRateLimitException;
+use App\Marketplace\Infrastructure\Query\ActiveWbConnectionsQuery;
+use App\Marketplace\Repository\MarketplaceConnectionRepository;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -30,6 +35,10 @@ final class WbFinanceDiagnosticsCommand extends Command
         #[Autowire(service: 'limiter.wb_finance')]
         private readonly object $wbFinanceLimiter,
         private readonly Connection $connection,
+        private readonly ActiveWbConnectionsQuery $activeWbConnectionsQuery,
+        private readonly MarketplaceConnectionRepository $marketplaceConnectionRepository,
+        private readonly WbFinanceRateLimiter $rateLimiter,
+        private readonly WbFinancialReportPeriodResolver $periodResolver,
     ) {
         parent::__construct();
     }
@@ -44,6 +53,8 @@ final class WbFinanceDiagnosticsCommand extends Command
         $this->renderQueueSizes($io);
         $this->renderStatusCounts($io);
         $this->renderRetryAndErrorDiagnostics($io);
+        $this->renderConnectionDiagnostics($io);
+        $this->renderAlertDiagnostics($io);
         $this->renderRawDiagnostics($io);
 
         $io->success('Diagnostics completed. Command is read-only.');
@@ -167,6 +178,241 @@ final class WbFinanceDiagnosticsCommand extends Command
         }
 
         $io->table(['metric', 'value'], $rows);
+    }
+
+
+    private function renderConnectionDiagnostics(SymfonyStyle $io): void
+    {
+        $io->section('Per-connection recovery diagnostics');
+
+        $rows = [];
+        foreach ($this->activeWbConnectionsQuery->execute() as $activeConnection) {
+            $companyId = (string) $activeConnection['company_id'];
+            $connectionId = (string) $activeConnection['connection_id'];
+            $cooldownUntil = null;
+            $marketplaceConnection = $this->marketplaceConnectionRepository->find($connectionId);
+            if (null !== $marketplaceConnection) {
+                $cooldownUntil = $this->rateLimiter->getActiveSalesReportsCooldownUntil(
+                    $this->rateLimiter->resolveSalesReportsBucketId($marketplaceConnection),
+                );
+            }
+
+            $rows[] = [
+                'company_id' => $companyId,
+                'connection_id' => $connectionId,
+                'cooldown_until' => $this->formatDateTime($cooldownUntil),
+                'due_retry_count' => (string) $this->countDueRetry($companyId, $connectionId),
+                'queued_count' => (string) $this->countQueued($companyId, $connectionId),
+                'last_success_date' => $this->formatScalar($this->lastSuccessDate($companyId, $connectionId)),
+                'missing_days_count' => (string) $this->missingDaysCount($companyId, $connectionId),
+                'last_429_time' => $this->formatScalar($this->last429Time($companyId, $connectionId)),
+            ];
+        }
+
+        $this->renderRows($io, [
+            'company_id',
+            'connection_id',
+            'cooldown_until',
+            'due_retry_count',
+            'queued_count',
+            'last_success_date',
+            'missing_days_count',
+            'last_429_time',
+        ], $rows);
+    }
+
+    private function renderAlertDiagnostics(SymfonyStyle $io): void
+    {
+        $io->section('Recovery alerts');
+        $alerts = [];
+        $now = new \DateTimeImmutable();
+        $yesterday = $this->periodResolver->yesterday();
+        $globalCooldownUntil = $this->rateLimiter->getActiveSalesReportsCooldownUntil('global');
+        if (null !== $globalCooldownUntil) {
+            $alerts[] = ['alert' => 'global_cooldown', 'scope' => 'global', 'value' => $globalCooldownUntil->format(\DateTimeInterface::ATOM)];
+        }
+
+        foreach ($this->activeWbConnectionsQuery->execute() as $activeConnection) {
+            $companyId = (string) $activeConnection['company_id'];
+            $connectionId = (string) $activeConnection['connection_id'];
+            $daily = $this->dailyStatusRow($companyId, $connectionId, $yesterday);
+            $dailyStatus = $daily['status'] ?? null;
+            $dailyUpdatedAt = $this->parseNullableDateTime($daily['updated_at'] ?? null);
+            if (!\in_array($dailyStatus, ['success', 'empty'], true)
+                && (null === $dailyUpdatedAt || ($now->getTimestamp() - $dailyUpdatedAt->getTimestamp()) >= 86400)
+            ) {
+                $alerts[] = ['alert' => 'daily_yesterday_late', 'scope' => $connectionId, 'value' => $yesterday->format('Y-m-d').' status='.($dailyStatus ?? 'missing')];
+            }
+
+            $marketplaceConnection = $this->marketplaceConnectionRepository->find($connectionId);
+            if (null !== $marketplaceConnection) {
+                $cooldownUntil = $this->rateLimiter->getActiveSalesReportsCooldownUntil(
+                    $this->rateLimiter->resolveSalesReportsBucketId($marketplaceConnection),
+                );
+                if (null !== $cooldownUntil && ($cooldownUntil->getTimestamp() - $now->getTimestamp()) > 21600) {
+                    $alerts[] = ['alert' => 'cooldown_over_6h', 'scope' => $connectionId, 'value' => $cooldownUntil->format(\DateTimeInterface::ATOM)];
+                }
+            }
+
+            $dueRetryCount = $this->countDueRetry($companyId, $connectionId);
+            if ($dueRetryCount > 0) {
+                $alerts[] = ['alert' => 'due_retry_backlog_present', 'scope' => $connectionId, 'value' => (string) $dueRetryCount];
+            }
+        }
+
+        $this->renderRows($io, ['alert', 'scope', 'value'], $alerts);
+    }
+
+    private function countDueRetry(string $companyId, string $connectionId): int
+    {
+        return (int) $this->connection->fetchOne(
+            "SELECT COUNT(*)
+             FROM marketplace_financial_report_sync_statuses
+             WHERE company_id = :companyId
+               AND connection_id = :connectionId
+               AND marketplace = 'wildberries'
+               AND report_type = 'sales_report'
+               AND business_date BETWEEN :fromDate AND :toDate
+               AND (
+                    (status IN ('queued', 'failed') AND next_retry_at IS NOT NULL AND next_retry_at <= NOW())
+                    OR (status = 'failed' AND next_retry_at IS NULL AND last_error_status_code = 429 AND last_error_class = :rateLimitErrorClass)
+               )",
+            [
+                'companyId' => $companyId,
+                'connectionId' => $connectionId,
+                'fromDate' => $this->periodResolver->currentYearStart()->format('Y-m-d'),
+                'toDate' => $this->periodResolver->yesterday()->format('Y-m-d'),
+                'rateLimitErrorClass' => MarketplaceRateLimitException::class,
+            ],
+        );
+    }
+
+    private function countQueued(string $companyId, string $connectionId): int
+    {
+        return (int) $this->connection->fetchOne(
+            "SELECT COUNT(*)
+             FROM marketplace_financial_report_sync_statuses
+             WHERE company_id = :companyId
+               AND connection_id = :connectionId
+               AND marketplace = 'wildberries'
+               AND report_type = 'sales_report'
+               AND status = 'queued'",
+            ['companyId' => $companyId, 'connectionId' => $connectionId],
+        );
+    }
+
+    private function lastSuccessDate(string $companyId, string $connectionId): ?string
+    {
+        $value = $this->connection->fetchOne(
+            "SELECT MAX(business_date)
+             FROM marketplace_financial_report_sync_statuses
+             WHERE company_id = :companyId
+               AND connection_id = :connectionId
+               AND marketplace = 'wildberries'
+               AND report_type = 'sales_report'
+               AND status IN ('success', 'empty')",
+            ['companyId' => $companyId, 'connectionId' => $connectionId],
+        );
+
+        return false === $value || null === $value ? null : (string) $value;
+    }
+
+    private function last429Time(string $companyId, string $connectionId): ?string
+    {
+        $value = $this->connection->fetchOne(
+            'SELECT MAX(created_at)
+             FROM marketplace_financial_report_sync_errors
+             WHERE company_id = :companyId
+               AND connection_id = :connectionId
+               AND status_code = 429',
+            ['companyId' => $companyId, 'connectionId' => $connectionId],
+        );
+
+        return false === $value || null === $value ? null : (string) $value;
+    }
+
+    private function missingDaysCount(string $companyId, string $connectionId): int
+    {
+        $from = $this->periodResolver->currentYearStart();
+        $to = $this->periodResolver->yesterday();
+        $knownRows = $this->connection->fetchFirstColumn(
+            "SELECT business_date
+             FROM marketplace_financial_report_sync_statuses
+             WHERE company_id = :companyId
+               AND connection_id = :connectionId
+               AND marketplace = 'wildberries'
+               AND report_type = 'sales_report'
+               AND business_date BETWEEN :fromDate AND :toDate",
+            [
+                'companyId' => $companyId,
+                'connectionId' => $connectionId,
+                'fromDate' => $from->format('Y-m-d'),
+                'toDate' => $to->format('Y-m-d'),
+            ],
+        );
+        $known = array_flip(array_map('strval', $knownRows));
+        $missing = 0;
+        foreach ($this->periodResolver->daysBetween($from, $to) as $day) {
+            if (!isset($known[$day->format('Y-m-d')])) {
+                ++$missing;
+            }
+        }
+
+        return $missing;
+    }
+
+    /** @return array<string,mixed> */
+    private function dailyStatusRow(string $companyId, string $connectionId, \DateTimeImmutable $businessDate): array
+    {
+        $row = $this->connection->fetchAssociative(
+            "SELECT status, updated_at
+             FROM marketplace_financial_report_sync_statuses
+             WHERE company_id = :companyId
+               AND connection_id = :connectionId
+               AND marketplace = 'wildberries'
+               AND report_type = 'sales_report'
+               AND business_date = :businessDate
+               AND mode = 'daily'
+             LIMIT 1",
+            [
+                'companyId' => $companyId,
+                'connectionId' => $connectionId,
+                'businessDate' => $businessDate->format('Y-m-d'),
+            ],
+        );
+
+        return false === $row ? [] : $row;
+    }
+
+    private function formatDateTime(?\DateTimeImmutable $dateTime): string
+    {
+        return null === $dateTime ? 'n/a' : $dateTime->format(\DateTimeInterface::ATOM);
+    }
+
+    private function formatScalar(?string $value): string
+    {
+        return null === $value || '' === $value ? 'n/a' : $value;
+    }
+
+    private function parseNullableDateTime(mixed $value): ?\DateTimeImmutable
+    {
+        if (null === $value || '' === $value) {
+            return null;
+        }
+
+        if ($value instanceof \DateTimeImmutable) {
+            return $value;
+        }
+
+        if ($value instanceof \DateTimeInterface) {
+            return \DateTimeImmutable::createFromInterface($value);
+        }
+
+        try {
+            return new \DateTimeImmutable((string) $value);
+        } catch (\Throwable) {
+            return null;
+        }
     }
 
     private function renderRawDiagnostics(SymfonyStyle $io): void

--- a/site/src/Marketplace/Command/WbFinancialReportsOrchestrateCommand.php
+++ b/site/src/Marketplace/Command/WbFinancialReportsOrchestrateCommand.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Command;
+
+use App\Marketplace\Application\Service\WbFinanceRateLimiter;
+use App\Marketplace\Application\Service\WbFinancialReportPeriodResolver;
+use App\Marketplace\Application\Service\WbFinancialReportSyncPlannerInterface;
+use App\Marketplace\Exception\MarketplaceRateLimitException;
+use App\Marketplace\Infrastructure\Query\ActiveWbConnectionsQuery;
+use Doctrine\DBAL\Connection;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\LockableTrait;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:marketplace:wb-financial-reports:orchestrate',
+    description: 'Safe WB finance recovery orchestration with cooldown-aware one-task-per-connection scheduling.',
+)]
+final class WbFinancialReportsOrchestrateCommand extends Command
+{
+    use LockableTrait;
+
+    private const REPORT_TYPE = 'sales_report';
+    private const GLOBAL_BUCKET = 'global';
+
+    public function __construct(
+        private readonly ActiveWbConnectionsQuery $activeWbConnectionsQuery,
+        private readonly WbFinanceRateLimiter $rateLimiter,
+        private readonly WbFinancialReportPeriodResolver $periodResolver,
+        private readonly WbFinancialReportSyncPlannerInterface $planner,
+        private readonly Connection $connection,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('company-id', null, InputOption::VALUE_OPTIONAL)
+            ->addOption('connection-id', null, InputOption::VALUE_OPTIONAL)
+            ->addOption('refresh-days-back', null, InputOption::VALUE_OPTIONAL, 'Refresh only the last N business days before today.', '2');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (!$this->lock()) {
+            return Command::SUCCESS;
+        }
+
+        $io = new SymfonyStyle($input, $output);
+        $rows = [];
+        $totalDispatched = 0;
+
+        try {
+            $companyId = $this->normalizeOptional((string) $input->getOption('company-id'));
+            $connectionId = $this->normalizeOptional((string) $input->getOption('connection-id'));
+            $refreshDaysBack = max(1, (int) $input->getOption('refresh-days-back'));
+            $globalCooldownUntil = $this->rateLimiter->getActiveSalesReportsCooldownUntil(self::GLOBAL_BUCKET);
+            if (null !== $globalCooldownUntil) {
+                $message = 'WB finance global cooldown is active but orchestrator continues connection-scoped planning.';
+                $this->logger->warning($message, ['cooldown_until' => $globalCooldownUntil->format(\DateTimeInterface::ATOM)]);
+                $io->warning($message.' cooldown_until='.$globalCooldownUntil->format(\DateTimeInterface::ATOM));
+            }
+            $yesterday = $this->periodResolver->yesterday();
+
+            foreach ($this->activeWbConnectionsQuery->execute($companyId, $connectionId) as $activeConnection) {
+                $connectionIdValue = (string) $activeConnection['connection_id'];
+                $companyIdValue = (string) $activeConnection['company_id'];
+                $action = 'skipped';
+                $reason = 'no candidate';
+                $dispatched = 0;
+
+                $connectionCooldownUntil = $this->rateLimiter->getActiveSalesReportsCooldownUntil('connection:'.$connectionIdValue);
+
+                $dueRetryCount = $this->countDueRetry($companyIdValue, $connectionIdValue);
+                $futureQueuedCount = $this->countFutureQueued($companyIdValue, $connectionIdValue);
+
+                if (null !== $connectionCooldownUntil) {
+                    $reason = 'connection cooldown until '.$connectionCooldownUntil->format(\DateTimeInterface::ATOM);
+                } elseif ($futureQueuedCount > 0) {
+                    $reason = 'queued future retry exists';
+                } else {
+                    $dailyStatus = $this->findDailyStatus($companyIdValue, $connectionIdValue, $yesterday);
+                    if (!\in_array($dailyStatus, ['success', 'empty'], true)) {
+                        $dispatched = $this->planner->planDaily($companyIdValue, $connectionIdValue, false);
+                        $action = $dispatched > 0 ? 'daily yesterday' : 'daily skipped by claim';
+                        $reason = $dispatched > 0 ? 'planned' : 'status not claimable';
+                    }
+
+                    if (0 === $dispatched && $dueRetryCount > 0) {
+                        $dispatched = $this->planner->planDueRetry($companyIdValue, $connectionIdValue, 1);
+                        $action = $dispatched > 0 ? 'due retry' : 'due retry skipped by claim';
+                        $reason = $dispatched > 0 ? 'planned' : 'status not claimable';
+                    }
+
+                    if (0 === $dispatched && 0 === $dueRetryCount) {
+                        $dispatched = $this->planner->planRefreshRecentDays($companyIdValue, $connectionIdValue, $refreshDaysBack, 1);
+                        if ($dispatched > 0) {
+                            $action = 'refresh last '.$refreshDaysBack.' days';
+                            $reason = 'planned';
+                        }
+                    }
+
+                    if (0 === $dispatched && 0 === $dueRetryCount) {
+                        $dispatched = $this->planner->planMissing($companyIdValue, $connectionIdValue, 1);
+                        if ($dispatched > 0) {
+                            $action = 'historical missing';
+                            $reason = 'planned';
+                        }
+                    }
+                }
+
+                $totalDispatched += $dispatched;
+                $rows[] = [$companyIdValue, $connectionIdValue, $action, (string) $dispatched, $reason];
+            }
+
+            $io->table(['company_id', 'connection_id', 'action', 'dispatched', 'reason'], $rows);
+            $io->success(sprintf('WB finance orchestration completed. Dispatched %d task(s).', $totalDispatched));
+
+            return Command::SUCCESS;
+        } finally {
+            $this->release();
+        }
+    }
+
+    private function countDueRetry(string $companyId, string $connectionId): int
+    {
+        return (int) $this->connection->fetchOne(
+            "SELECT COUNT(*)
+             FROM marketplace_financial_report_sync_statuses
+             WHERE company_id = :companyId
+               AND connection_id = :connectionId
+               AND marketplace = 'wildberries'
+               AND report_type = :reportType
+               AND business_date BETWEEN :fromDate AND :toDate
+               AND (
+                    (status IN ('queued', 'failed') AND next_retry_at IS NOT NULL AND next_retry_at <= NOW())
+                    OR (status = 'failed' AND next_retry_at IS NULL AND last_error_status_code = 429 AND last_error_class = :rateLimitErrorClass)
+               )",
+            [
+                'companyId' => $companyId,
+                'connectionId' => $connectionId,
+                'reportType' => self::REPORT_TYPE,
+                'fromDate' => $this->periodResolver->currentYearStart()->format('Y-m-d'),
+                'toDate' => $this->periodResolver->yesterday()->format('Y-m-d'),
+                'rateLimitErrorClass' => MarketplaceRateLimitException::class,
+            ],
+        );
+    }
+
+    private function countFutureQueued(string $companyId, string $connectionId): int
+    {
+        return (int) $this->connection->fetchOne(
+            "SELECT COUNT(*)
+             FROM marketplace_financial_report_sync_statuses
+             WHERE company_id = :companyId
+               AND connection_id = :connectionId
+               AND marketplace = 'wildberries'
+               AND report_type = :reportType
+               AND status = 'queued'
+               AND next_retry_at IS NOT NULL
+               AND next_retry_at > NOW()",
+            ['companyId' => $companyId, 'connectionId' => $connectionId, 'reportType' => self::REPORT_TYPE],
+        );
+    }
+
+    private function findDailyStatus(string $companyId, string $connectionId, \DateTimeImmutable $businessDate): ?string
+    {
+        $status = $this->connection->fetchOne(
+            "SELECT status
+             FROM marketplace_financial_report_sync_statuses
+             WHERE company_id = :companyId
+               AND connection_id = :connectionId
+               AND marketplace = 'wildberries'
+               AND report_type = :reportType
+               AND business_date = :businessDate
+               AND mode = 'daily'
+             LIMIT 1",
+            [
+                'companyId' => $companyId,
+                'connectionId' => $connectionId,
+                'reportType' => self::REPORT_TYPE,
+                'businessDate' => $businessDate->format('Y-m-d'),
+            ],
+        );
+
+        return false === $status || null === $status ? null : (string) $status;
+    }
+
+    private function normalizeOptional(string $value): ?string
+    {
+        $trimmed = trim($value);
+
+        return '' === $trimmed ? null : $trimmed;
+    }
+}

--- a/site/src/Marketplace/Command/WbFinancialReportsSyncCommand.php
+++ b/site/src/Marketplace/Command/WbFinancialReportsSyncCommand.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
     name: 'app:marketplace:wb-financial-reports:sync',
-    description: 'Планировщик синхронизации финансовых отчётов WB (daily/initial/refresh14/missing)',
+    description: 'Планировщик синхронизации финансовых отчётов WB (daily/initial/refresh/refresh14/missing)',
 )]
 final class WbFinancialReportsSyncCommand extends Command
 {
@@ -37,7 +37,7 @@ final class WbFinancialReportsSyncCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addOption('mode', null, InputOption::VALUE_REQUIRED, 'all|initial|daily|refresh14|missing', 'daily')
+            ->addOption('mode', null, InputOption::VALUE_REQUIRED, 'all|initial|daily|refresh|refresh14|missing', 'daily')
             ->addOption('allow-all', null, InputOption::VALUE_NONE)
             ->addOption('company-id', null, InputOption::VALUE_OPTIONAL)
             ->addOption('connection-id', null, InputOption::VALUE_OPTIONAL)
@@ -45,7 +45,9 @@ final class WbFinancialReportsSyncCommand extends Command
             ->addOption('from', null, InputOption::VALUE_OPTIONAL, 'Начало диапазона (Y-m-d)')
             ->addOption('to', null, InputOption::VALUE_OPTIONAL, 'Конец диапазона (Y-m-d)')
             ->addOption('force', null, InputOption::VALUE_NONE)
-            ->addOption('max-days', null, InputOption::VALUE_OPTIONAL, 'Лимит задач initial/refresh14/missing на connection', '1');
+            ->addOption('max-days', null, InputOption::VALUE_OPTIONAL, 'Лимит задач initial/refresh/refresh14/missing на connection', '1')
+            ->addOption('days-back', null, InputOption::VALUE_OPTIONAL, 'Окно последних N дней для --mode=refresh', '2')
+            ->addOption('window-days', null, InputOption::VALUE_OPTIONAL, 'Окно последних N дней для --mode=refresh14', null);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -68,6 +70,8 @@ final class WbFinancialReportsSyncCommand extends Command
             $connectionId = $this->normalizeOptional((string) $input->getOption('connection-id'));
             $force = (bool) $input->getOption('force');
             $maxDays = $this->parseMaxDays((string) $input->getOption('max-days'));
+            $daysBack = $this->parsePositiveInt((string) $input->getOption('days-back'), '--days-back');
+            $windowDays = null !== $input->getOption('window-days') ? $this->parsePositiveInt((string) $input->getOption('window-days'), '--window-days') : null;
             [$from, $to] = $this->resolveRange($input);
 
             if ('all' === $mode && null !== $from) {
@@ -87,7 +91,7 @@ final class WbFinancialReportsSyncCommand extends Command
 
             foreach ($modesToRun as $modeName) {
                 try {
-                    $dispatched = $this->runMode($modeName, $companyId, $connectionId, $force, $maxDays, $from, $to);
+                    $dispatched = $this->runMode($modeName, $companyId, $connectionId, $force, $maxDays, $daysBack, $windowDays, $from, $to);
                     $totalDispatched += $dispatched;
                     $io->writeln(sprintf('Mode <info>%s</info>: dispatched <comment>%d</comment>', $modeName, $dispatched));
                 } catch (\Throwable $e) {
@@ -123,7 +127,7 @@ final class WbFinancialReportsSyncCommand extends Command
         }
     }
 
-    private function runMode(string $mode, ?string $companyId, ?string $connectionId, bool $force, int $maxDays, ?DateTimeImmutable $from, ?DateTimeImmutable $to): int
+    private function runMode(string $mode, ?string $companyId, ?string $connectionId, bool $force, int $maxDays, int $daysBack, ?int $windowDays, ?DateTimeImmutable $from, ?DateTimeImmutable $to): int
     {
         return match ($mode) {
             'daily' => null !== $from
@@ -132,10 +136,15 @@ final class WbFinancialReportsSyncCommand extends Command
             'initial' => null !== $from
                 ? $this->planner->planRange($from, $to ?? $from, FinancialReportSyncMode::INITIAL, $companyId, $connectionId, $force)
                 : $this->planner->planInitial($companyId, $connectionId, null, $maxDays),
-            'refresh14' => null !== $from
-                // Explicit --from/--to is treated as manual force refresh mode; --max-days applies only to automatic refresh14 planning.
+            'refresh' => null !== $from
                 ? $this->planner->planRange($from, $to ?? $from, FinancialReportSyncMode::REFRESH_14D, $companyId, $connectionId, true)
-                : $this->planner->planRefresh14Days($companyId, $connectionId, $maxDays),
+                : $this->planner->planRefreshRecentDays($companyId, $connectionId, $daysBack, $maxDays),
+            'refresh14' => null !== $from
+                // Explicit --from/--to is treated as manual force refresh mode; --max-days applies only to automatic refresh planning.
+                ? $this->planner->planRange($from, $to ?? $from, FinancialReportSyncMode::REFRESH_14D, $companyId, $connectionId, true)
+                : (null !== $windowDays
+                    ? $this->planner->planRefreshRecentDays($companyId, $connectionId, $windowDays, $maxDays)
+                    : $this->planner->planRefresh14Days($companyId, $connectionId, $maxDays)),
             'missing' => $this->planner->planMissing($companyId, $connectionId, $maxDays),
             default => throw new DomainException(sprintf('Unsupported mode: %s', $mode)),
         };
@@ -144,8 +153,8 @@ final class WbFinancialReportsSyncCommand extends Command
     private function resolveMode(string $mode): string
     {
         $normalized = strtolower(trim($mode));
-        if (!\in_array($normalized, ['all', 'initial', 'daily', 'refresh14', 'missing'], true)) {
-            throw new DomainException('Invalid --mode. Allowed: all|initial|daily|refresh14|missing');
+        if (!\in_array($normalized, ['all', 'initial', 'daily', 'refresh', 'refresh14', 'missing'], true)) {
+            throw new DomainException('Invalid --mode. Allowed: all|initial|daily|refresh|refresh14|missing');
         }
 
         return $normalized;
@@ -153,12 +162,17 @@ final class WbFinancialReportsSyncCommand extends Command
 
     private function parseMaxDays(string $raw): int
     {
-        $maxDays = (int) $raw;
-        if ($maxDays <= 0) {
-            throw new DomainException('Option --max-days must be a positive integer.');
+        return $this->parsePositiveInt($raw, '--max-days');
+    }
+
+    private function parsePositiveInt(string $raw, string $optionName): int
+    {
+        $value = (int) $raw;
+        if ($value <= 0) {
+            throw new DomainException(sprintf('Option %s must be a positive integer.', $optionName));
         }
 
-        return $maxDays;
+        return $value;
     }
 
     private function resolveRange(InputInterface $input): array

--- a/site/src/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClient.php
+++ b/site/src/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClient.php
@@ -404,12 +404,12 @@ final readonly class WbFinanceSalesReportClient
 
     private function normalizeSellerBucketId(?string $sellerBucketId, ?string $connectionId = null): string
     {
-        if (null !== $sellerBucketId && '' !== trim($sellerBucketId)) {
-            return $sellerBucketId;
-        }
-
         if (null !== $connectionId && '' !== trim($connectionId)) {
             return 'connection:'.trim($connectionId);
+        }
+
+        if (null !== $sellerBucketId && '' !== trim($sellerBucketId)) {
+            return $sellerBucketId;
         }
 
         return self::GLOBAL_SELLER_BUCKET;

--- a/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusLookupInterface.php
+++ b/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusLookupInterface.php
@@ -45,7 +45,7 @@ interface MarketplaceFinancialReportSyncStatusLookupInterface
     ): array;
 
     /**
-     * @return list<\DateTimeImmutable>
+     * @return list<array{business_date: \DateTimeImmutable, mode: FinancialReportSyncMode}>
      */
     public function findRetryDueDays(
         string $companyId,

--- a/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepository.php
+++ b/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepository.php
@@ -118,7 +118,7 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
     }
 
     /**
-     * @return list<\DateTimeImmutable>
+     * @return list<array{business_date: \DateTimeImmutable, mode: FinancialReportSyncMode}>
      */
     public function findRetryDueDays(
         string $companyId,
@@ -137,7 +137,7 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
         }
 
         $rows = $this->createQueryBuilder('s')
-            ->select('s.businessDate')
+            ->select('s.businessDate', 's.mode')
             ->where('s.companyId = :companyId')
             ->andWhere('s.connectionId = :connectionId')
             ->andWhere('s.reportType = :reportType')
@@ -162,15 +162,25 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
             ->getQuery()
             ->getArrayResult();
 
-        $days = [];
+        $retryItems = [];
         foreach ($rows as $row) {
             $date = $row['businessDate'] ?? null;
-            if ($date instanceof \DateTimeImmutable) {
-                $days[] = $date;
+            if (!$date instanceof \DateTimeImmutable) {
+                continue;
             }
+
+            $mode = $row['mode'] ?? null;
+            if (!$mode instanceof FinancialReportSyncMode) {
+                $mode = is_string($mode) ? FinancialReportSyncMode::tryFrom($mode) : null;
+            }
+
+            $retryItems[] = [
+                'business_date' => $date,
+                'mode' => $mode ?? FinancialReportSyncMode::MISSING,
+            ];
         }
 
-        return $days;
+        return $retryItems;
     }
 
     public function claimForQueue(

--- a/site/tests/Integration/Marketplace/MessageHandler/SyncWbFinancialReportDayHandlerTest.php
+++ b/site/tests/Integration/Marketplace/MessageHandler/SyncWbFinancialReportDayHandlerTest.php
@@ -122,7 +122,8 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
         $handler(new SyncWbFinancialReportDayMessage($company->getId(), $connection->getId(), '2026-05-20', FinancialReportSyncMode::DAILY->value, false));
 
         self::assertSame(1, $requestCount);
-        self::assertNotNull($storage->getUntilTimestamp('wb_finance:sales_reports:cooldown:seller-9291'));
+        self::assertNotNull($storage->getUntilTimestamp('wb_finance:sales_reports:cooldown:connection:'.$connection->getId()));
+        self::assertNull($storage->getUntilTimestamp('wb_finance:sales_reports:cooldown:seller-9291'));
 
         $firstStatus = $this->findStatus($connection->getId(), $company->getId(), '2026-05-19');
         $secondStatus = $this->findStatus($connection->getId(), $company->getId(), '2026-05-20');

--- a/site/tests/Integration/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepositoryTest.php
+++ b/site/tests/Integration/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepositoryTest.php
@@ -59,7 +59,8 @@ final class MarketplaceFinancialReportSyncStatusRepositoryTest extends Integrati
             2,
         );
 
-        self::assertSame(['2026-01-01', '2026-01-02'], array_map(static fn (\DateTimeImmutable $d): string => $d->format('Y-m-d'), $days));
+        self::assertSame(['2026-01-01', '2026-01-02'], array_map(static fn (array $item): string => $item['business_date']->format('Y-m-d'), $days));
+        self::assertSame([FinancialReportSyncMode::MISSING, FinancialReportSyncMode::MISSING], array_map(static fn (array $item): FinancialReportSyncMode => $item['mode'], $days));
     }
 
 

--- a/site/tests/Unit/Marketplace/Application/Service/WbFinanceRateLimiterTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbFinanceRateLimiterTest.php
@@ -61,7 +61,7 @@ final class WbFinanceRateLimiterTest extends TestCase
         self::assertSame('wb_finance:sales_reports:cooldown:connection:'.$connectionId, $limiter->buildSalesReportsCooldownKey($limiter->resolveSalesReportsBucketId($connection)));
     }
 
-    public function testResolveSalesReportsBucketIdUsesSellerSettingsBeforeConnectionFallback(): void
+    public function testResolveSalesReportsBucketIdUsesConnectionEvenWhenSellerSettingsExist(): void
     {
         $connection = new MarketplaceConnection(
             '6eada2b7-b453-4c33-a92a-e7dce52e291c',
@@ -73,8 +73,8 @@ final class WbFinanceRateLimiterTest extends TestCase
 
         $limiter = $this->createLimiter();
 
-        self::assertSame('account-42', $limiter->resolveSalesReportsBucketId($connection));
-        self::assertSame('account_id', $limiter->resolveSalesReportsBucketSource($connection));
+        self::assertSame('connection:'.$connection->getId(), $limiter->resolveSalesReportsBucketId($connection));
+        self::assertSame('connection', $limiter->resolveSalesReportsBucketSource($connection));
     }
 
     private function createLimiter(?MockClock $clock = null): WbFinanceRateLimiter

--- a/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
@@ -105,8 +105,8 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
             $this->statusEntity('2026-05-20', FinancialReportSyncStatus::QUEUED, '2026-05-21T11:00:00+03:00', '2026-05-20T09:00:00+03:00'),
         ]);
 
-        self::assertSame(1, $planner->planRefresh14Days(null, null, 1));
-        self::assertNotContains('2026-05-20', array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->businessDate, $this->dispatchedMessages));
+        self::assertSame(0, $planner->planRefresh14Days(null, null, 1));
+        self::assertSame([], $this->dispatchedMessages);
     }
 
     public function testQueuedContinuationDueIsDispatchedWithCursor(): void
@@ -148,8 +148,8 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
             $this->statusEntity('2026-05-20', FinancialReportSyncStatus::FAILED, '2026-05-21T11:00:00+03:00', '2026-05-20T09:00:00+03:00'),
         ]);
 
-        self::assertSame(1, $planner->planRefresh14Days(null, null, 1));
-        self::assertNotContains('2026-05-20', array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->businessDate, $this->dispatchedMessages));
+        self::assertSame(0, $planner->planRefresh14Days(null, null, 1));
+        self::assertSame([], $this->dispatchedMessages);
     }
 
     public function testFailedWithRetryDueIsDispatched(): void
@@ -179,7 +179,9 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
         $planner = $this->planner();
         $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1')]);
         $this->statuses->method('findStatusesForDateRange')->willReturn([
+            $this->statusEntity('2026-05-20', FinancialReportSyncStatus::SUCCESS, null, '2026-05-20T08:00:00+03:00', null, null, FinancialReportSyncMode::DAILY),
             $this->statusEntity('2026-05-20', FinancialReportSyncStatus::SUCCESS, null, '2026-05-21T09:00:00+03:00'),
+            $this->statusEntity('2026-05-19', FinancialReportSyncStatus::EMPTY, null, '2026-05-19T08:00:00+03:00', null, null, FinancialReportSyncMode::DAILY),
             $this->statusEntity('2026-05-19', FinancialReportSyncStatus::EMPTY, null, '2026-05-18T09:00:00+03:00'),
         ]);
 
@@ -196,33 +198,65 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
             $this->statusEntity('2026-05-19', FinancialReportSyncStatus::PROCESSING, null, '2026-05-21T09:00:00+03:00'),
         ]);
 
-        self::assertSame(2, $planner->planRefresh14Days(null, null, 2));
-        self::assertNotContains('2026-05-20', array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->businessDate, $this->dispatchedMessages));
-        self::assertNotContains('2026-05-19', array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->businessDate, $this->dispatchedMessages));
+        self::assertSame(0, $planner->planRefresh14Days(null, null, 2));
+        self::assertSame([], $this->dispatchedMessages);
     }
 
-
-    public function testUnknownDaysAreDispatchedWhenNoFailedOrSuccessCandidates(): void
+    public function testRefreshDoesNotReplaceMissingWhenDailyIsAbsent(): void
     {
         $planner = $this->planner();
         $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1')]);
         $this->statuses->method('findStatusesForDateRange')->willReturn([]);
 
-        self::assertSame(1, $planner->planRefresh14Days(null, null, 1));
-        self::assertCount(1, $this->dispatchedMessages);
-        self::assertSame('refresh_14d', $this->dispatchedMessages[0]->mode);
-
-        $last14days = (new WbFinancialReportPeriodResolver(new MockClock('2026-05-21 00:00:00 Europe/Moscow')))
-            ->last14Days();
-        $expected = array_map(static fn (\DateTimeImmutable $d): string => $d->format('Y-m-d'), $last14days);
-        self::assertContains($this->dispatchedMessages[0]->businessDate, $expected);
+        self::assertSame(0, $planner->planRefresh14Days(null, null, 1));
+        self::assertSame([], $this->dispatchedMessages);
     }
+
+    public function testRefreshSuccessRequiresDailySuccess(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1')]);
+        $this->statuses->method('findStatusesForDateRange')->willReturn([
+            $this->statusEntity('2026-05-20', FinancialReportSyncStatus::SUCCESS, null, '2026-05-20T09:00:00+03:00', null, null, FinancialReportSyncMode::REFRESH_14D),
+        ]);
+
+        self::assertSame(0, $planner->planRefreshRecentDays(null, null, 1, 1));
+        self::assertSame([], $this->dispatchedMessages);
+    }
+
+    public function testRefreshCanPlanAfterDailySuccessWithoutExistingRefresh(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1')]);
+        $this->statuses->method('findStatusesForDateRange')->willReturn([
+            $this->statusEntity('2026-05-20', FinancialReportSyncStatus::SUCCESS, null, '2026-05-20T09:00:00+03:00', null, null, FinancialReportSyncMode::DAILY),
+        ]);
+
+        self::assertSame(1, $planner->planRefreshRecentDays(null, null, 1, 1));
+        self::assertSame('2026-05-20', $this->dispatchedMessages[0]->businessDate);
+        self::assertSame('refresh_14d', $this->dispatchedMessages[0]->mode);
+    }
+
+    public function testRefreshDoesNotMixModesWhenRefreshFutureRetryExists(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1')]);
+        $this->statuses->method('findStatusesForDateRange')->willReturn([
+            $this->statusEntity('2026-05-20', FinancialReportSyncStatus::SUCCESS, null, '2026-05-20T09:00:00+03:00', null, null, FinancialReportSyncMode::DAILY),
+            $this->statusEntity('2026-05-20', FinancialReportSyncStatus::QUEUED, '2026-05-21T11:00:00+03:00', '2026-05-20T10:00:00+03:00', null, null, FinancialReportSyncMode::REFRESH_14D),
+        ]);
+
+        self::assertSame(0, $planner->planRefreshRecentDays(null, null, 1, 1));
+        self::assertSame([], $this->dispatchedMessages);
+    }
+
     public function testUnknownDaysGoAfterFailedDueAndSuccessEmpty(): void
     {
         $planner = $this->planner();
         $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1')]);
         $this->statuses->method('findStatusesForDateRange')->willReturn([
             $this->statusEntity('2026-05-20', FinancialReportSyncStatus::FAILED, null, '2026-05-21T09:00:00+03:00'),
+            $this->statusEntity('2026-05-19', FinancialReportSyncStatus::SUCCESS, null, '2026-05-17T09:00:00+03:00', null, null, FinancialReportSyncMode::DAILY),
             $this->statusEntity('2026-05-19', FinancialReportSyncStatus::SUCCESS, null, '2026-05-18T09:00:00+03:00'),
         ]);
 
@@ -302,7 +336,7 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
         $this->statuses->method('findStatusesForDateRange')->willReturn([
             $this->statusEntity('2026-01-01', FinancialReportSyncStatus::QUEUED, '2026-05-21T09:59:00+03:00', '2026-05-20T09:00:00+03:00'),
         ]);
-        $this->statuses->method('findRetryDueDays')->willReturn([new \DateTimeImmutable('2026-01-01 00:00:00 Europe/Moscow')]);
+        $this->statuses->method('findRetryDueDays')->willReturn([['business_date' => new \DateTimeImmutable('2026-01-01 00:00:00 Europe/Moscow'), 'mode' => FinancialReportSyncMode::MISSING]]);
         $this->claimForQueueCallback = fn (
             string $connectionId,
             string $companyId,
@@ -333,7 +367,7 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
         $planner = $this->planner();
         $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1'), $this->conn('c2', 'co2')]);
         $this->statuses->method('findStatusesForDateRange')->willReturn([]);
-        $this->statuses->method('findRetryDueDays')->willReturnCallback(static fn (string $companyId): array => [new \DateTimeImmutable('2026-01-01 00:00:00 Europe/Moscow')]);
+        $this->statuses->method('findRetryDueDays')->willReturnCallback(static fn (string $companyId): array => [['business_date' => new \DateTimeImmutable('2026-01-01 00:00:00 Europe/Moscow'), 'mode' => FinancialReportSyncMode::MISSING]]);
 
         self::assertSame(2, $planner->planMissing(null, null, 1));
         self::assertCount(2, $this->dispatchedMessages);
@@ -352,6 +386,31 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
         self::assertSame(10, $planner->planMissing(null, null, 10));
         self::assertSame(['2026-01-03', '2026-01-04'], array_slice(array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->businessDate, $this->dispatchedMessages), 0, 2));
     }
+
+    public function testPlanDueRetryPreservesDailyMode(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1')]);
+        $this->statuses->method('findRetryDueDays')->willReturn([
+            ['business_date' => new \DateTimeImmutable('2026-05-20 00:00:00 Europe/Moscow'), 'mode' => FinancialReportSyncMode::DAILY],
+        ]);
+
+        self::assertSame(1, $planner->planDueRetry(null, null, 1));
+        self::assertSame('daily', $this->dispatchedMessages[0]->mode);
+    }
+
+    public function testPlanDueRetryPreservesRefreshMode(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1')]);
+        $this->statuses->method('findRetryDueDays')->willReturn([
+            ['business_date' => new \DateTimeImmutable('2026-05-20 00:00:00 Europe/Moscow'), 'mode' => FinancialReportSyncMode::REFRESH_14D],
+        ]);
+
+        self::assertSame(1, $planner->planDueRetry(null, null, 1));
+        self::assertSame('refresh_14d', $this->dispatchedMessages[0]->mode);
+    }
+
     private function planner(): WbFinancialReportSyncPlanner
     {
         return new WbFinancialReportSyncPlanner(
@@ -370,6 +429,7 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
         string $updatedAt,
         ?int $nextRrdId = null,
         ?string $stagingRawDocumentId = null,
+        ?FinancialReportSyncMode $mode = FinancialReportSyncMode::REFRESH_14D,
     ): MarketplaceFinancialReportSyncStatus&MockObject {
         $entity = $this->createMock(MarketplaceFinancialReportSyncStatus::class);
         $entity->method('getBusinessDate')->willReturn(new \DateTimeImmutable($day.' 00:00:00 Europe/Moscow'));
@@ -378,6 +438,7 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
         $entity->method('getUpdatedAt')->willReturn(new \DateTimeImmutable($updatedAt));
         $entity->method('getNextRrdId')->willReturn($nextRrdId);
         $entity->method('getStagingRawDocumentId')->willReturn($stagingRawDocumentId);
+        $entity->method('getMode')->willReturn($mode);
 
         return $entity;
     }

--- a/site/tests/Unit/Marketplace/Command/WbFinanceDiagnosticsCommandTest.php
+++ b/site/tests/Unit/Marketplace/Command/WbFinanceDiagnosticsCommandTest.php
@@ -4,21 +4,41 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Marketplace\Command;
 
+use App\Marketplace\Application\Service\WbFinanceRateLimiter;
+use App\Marketplace\Application\Service\WbFinancialReportPeriodResolver;
 use App\Marketplace\Command\WbFinanceDiagnosticsCommand;
+use App\Marketplace\Infrastructure\Query\ActiveWbConnectionsQuery;
+use App\Marketplace\Repository\MarketplaceConnectionRepository;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Clock\MockClock;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 
 final class WbFinanceDiagnosticsCommandTest extends TestCase
 {
     public function testDiagnosticsCommandSmoke(): void
     {
-        $connection = $this->createMock(Connection::class);
-        $connection->method('fetchAllAssociative')->willReturn([]);
-        $connection->method('fetchOne')->willReturn(0);
+        $connection = $this->sqliteConnection();
+        $clock = new MockClock('2026-05-21 00:00:00 Europe/Moscow');
+        $rateLimiter = new WbFinanceRateLimiter(
+            new RateLimiterFactory(['id' => 'test', 'policy' => 'fixed_window', 'limit' => 1, 'interval' => '1 minute'], new InMemoryStorage()),
+            $clock,
+        );
 
-        $command = new WbFinanceDiagnosticsCommand(new DiagnosticsRedisFake(), new \stdClass(), new \stdClass(), $connection);
+        $command = new WbFinanceDiagnosticsCommand(
+            new DiagnosticsRedisFake(),
+            new \stdClass(),
+            new \stdClass(),
+            $connection,
+            new ActiveWbConnectionsQuery($connection),
+            $this->createMock(MarketplaceConnectionRepository::class),
+            $rateLimiter,
+            new WbFinancialReportPeriodResolver($clock),
+        );
         $tester = new CommandTester($command);
 
         self::assertSame(Command::SUCCESS, $tester->execute([]));
@@ -30,6 +50,60 @@ final class WbFinanceDiagnosticsCommandTest extends TestCase
         self::assertStringContainsString('bucket_type', $display);
         self::assertStringContainsString('connection', $display);
         self::assertStringContainsString('WB sales_report sync_status counts', $display);
+    }
+
+    private function sqliteConnection(): Connection
+    {
+        $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
+        $connection->executeStatement(
+            'CREATE TABLE marketplace_connections (
+                id VARCHAR(36) PRIMARY KEY,
+                company_id VARCHAR(36) NOT NULL,
+                marketplace VARCHAR(32) NOT NULL,
+                is_active BOOLEAN NOT NULL,
+                connection_type VARCHAR(32) NOT NULL,
+                created_at DATETIME NOT NULL
+            )',
+        );
+        $connection->executeStatement(
+            'CREATE TABLE marketplace_financial_report_sync_statuses (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                company_id VARCHAR(36),
+                connection_id VARCHAR(36),
+                marketplace VARCHAR(32),
+                report_type VARCHAR(32),
+                business_date DATE,
+                mode VARCHAR(32),
+                status VARCHAR(32),
+                next_retry_at DATETIME,
+                last_error_status_code INTEGER,
+                last_error_class VARCHAR(255),
+                updated_at DATETIME,
+                raw_document_id VARCHAR(36)
+            )',
+        );
+        $connection->executeStatement(
+            'CREATE TABLE marketplace_financial_report_sync_errors (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                company_id VARCHAR(36),
+                connection_id VARCHAR(36),
+                status_code INTEGER,
+                created_at DATETIME
+            )',
+        );
+        $connection->executeStatement(
+            'CREATE TABLE marketplace_raw_documents (
+                id VARCHAR(36) PRIMARY KEY,
+                marketplace VARCHAR(32),
+                document_type VARCHAR(32),
+                processing_status VARCHAR(32),
+                processed_at DATETIME,
+                synced_at DATETIME,
+                records_count INTEGER
+            )',
+        );
+
+        return $connection;
     }
 }
 

--- a/site/tests/Unit/Marketplace/Command/WbFinancialReportsOrchestrateCommandTest.php
+++ b/site/tests/Unit/Marketplace/Command/WbFinancialReportsOrchestrateCommandTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Command;
+
+use App\Marketplace\Application\Service\WbFinanceCooldownStorageInterface;
+use App\Marketplace\Application\Service\WbFinanceRateLimiter;
+use App\Marketplace\Application\Service\WbFinancialReportPeriodResolver;
+use App\Marketplace\Application\Service\WbFinancialReportSyncPlannerInterface;
+use App\Marketplace\Command\WbFinancialReportsOrchestrateCommand;
+use App\Marketplace\Infrastructure\Query\ActiveWbConnectionsQuery;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
+
+final class WbFinancialReportsOrchestrateCommandTest extends TestCase
+{
+    private ActiveWbConnectionsQuery&MockObject $connections;
+    private WbFinancialReportSyncPlannerInterface&MockObject $planner;
+    private Connection&MockObject $db;
+    private LoggerInterface&MockObject $logger;
+    private InMemoryCooldownStorage $cooldownStorage;
+
+    protected function setUp(): void
+    {
+        $this->connections = $this->createMock(ActiveWbConnectionsQuery::class);
+        $this->planner = $this->createMock(WbFinancialReportSyncPlannerInterface::class);
+        $this->db = $this->createMock(Connection::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->cooldownStorage = new InMemoryCooldownStorage();
+    }
+
+    public function testGlobalCooldownDoesNotBlockConnectionPlanning(): void
+    {
+        $this->connections->method('execute')->willReturn([$this->conn('conn-a', 'company-a')]);
+        $rateLimiter = $this->rateLimiter();
+        $rateLimiter->setSalesReportsCooldownUntil('global', new \DateTimeImmutable('2026-05-21T18:00:00+03:00'));
+        $this->db->method('fetchOne')->willReturnCallback($this->dbFetchOneCallback(['company-a:conn-a' => null]));
+        $this->logger->expects(self::once())->method('warning');
+        $this->planner->expects(self::once())->method('planDaily')->with('company-a', 'conn-a', false)->willReturn(1);
+
+        self::assertSame(Command::SUCCESS, $this->execute($rateLimiter));
+    }
+
+    public function testConnectionCooldownBlocksOnlyThatConnection(): void
+    {
+        $this->connections->method('execute')->willReturn([
+            $this->conn('conn-a', 'company-a'),
+            $this->conn('conn-b', 'company-b'),
+        ]);
+        $rateLimiter = $this->rateLimiter();
+        $rateLimiter->setSalesReportsCooldownUntil('connection:conn-a', new \DateTimeImmutable('2026-05-21T18:00:00+03:00'));
+        $this->db->method('fetchOne')->willReturnCallback($this->dbFetchOneCallback([
+            'company-a:conn-a' => null,
+            'company-b:conn-b' => null,
+        ]));
+        $this->planner->expects(self::once())->method('planDaily')->with('company-b', 'conn-b', false)->willReturn(1);
+
+        self::assertSame(Command::SUCCESS, $this->execute($rateLimiter));
+    }
+
+    public function testDailyStatusIsReadOnlyForDailyMode(): void
+    {
+        $this->connections->method('execute')->willReturn([$this->conn('conn-a', 'company-a')]);
+        $dailySqlAssertions = 0;
+        $this->db->method('fetchOne')->willReturnCallback(function (string $sql, array $params = []) use (&$dailySqlAssertions): mixed {
+            if (str_contains($sql, 'AND business_date = :businessDate')) {
+                ++$dailySqlAssertions;
+                self::assertStringContainsString("AND mode = 'daily'", $sql);
+
+                return 'success';
+            }
+
+            return 0;
+        });
+        $this->planner->expects(self::never())->method('planDaily');
+        $this->planner->expects(self::once())->method('planRefreshRecentDays')->with('company-a', 'conn-a', 2, 1)->willReturn(1);
+
+        self::assertSame(Command::SUCCESS, $this->execute($this->rateLimiter()));
+        self::assertSame(1, $dailySqlAssertions);
+    }
+
+    public function testOneTaskPerConnectionKeepsDueRetryAheadOfRefresh(): void
+    {
+        $this->connections->method('execute')->willReturn([$this->conn('conn-a', 'company-a')]);
+        $this->db->method('fetchOne')->willReturnCallback($this->dbFetchOneCallback(
+            ['company-a:conn-a' => 'success'],
+            ['company-a:conn-a' => 1],
+        ));
+        $this->planner->expects(self::once())->method('planDueRetry')->with('company-a', 'conn-a', 1)->willReturn(1);
+        $this->planner->expects(self::never())->method('planRefreshRecentDays');
+        $this->planner->expects(self::never())->method('planMissing');
+
+        self::assertSame(Command::SUCCESS, $this->execute($this->rateLimiter()));
+    }
+
+    public function testDueRetryCountRequiresRateLimitErrorClassAndFallsThroughToRefresh(): void
+    {
+        $this->connections->method('execute')->willReturn([$this->conn('conn-a', 'company-a')]);
+        $dueRetrySqlAssertions = 0;
+        $this->db->method('fetchOne')->willReturnCallback(function (string $sql, array $params = []) use (&$dueRetrySqlAssertions): mixed {
+            if (str_contains($sql, 'AND business_date = :businessDate')) {
+                return 'success';
+            }
+            if (str_contains($sql, "status = 'queued'") && str_contains($sql, 'next_retry_at > NOW()')) {
+                return 0;
+            }
+            if (str_contains($sql, "status IN ('queued', 'failed')")) {
+                ++$dueRetrySqlAssertions;
+                self::assertStringContainsString('last_error_class = :rateLimitErrorClass', $sql);
+                self::assertSame('App\Marketplace\Exception\MarketplaceRateLimitException', $params['rateLimitErrorClass'] ?? null);
+
+                return 0;
+            }
+
+            return 0;
+        });
+        $this->planner->expects(self::never())->method('planDueRetry');
+        $this->planner->expects(self::once())->method('planRefreshRecentDays')->with('company-a', 'conn-a', 2, 1)->willReturn(1);
+
+        self::assertSame(Command::SUCCESS, $this->execute($this->rateLimiter()));
+        self::assertSame(1, $dueRetrySqlAssertions);
+    }
+
+    private function execute(WbFinanceRateLimiter $rateLimiter): int
+    {
+        $command = new WbFinancialReportsOrchestrateCommand(
+            $this->connections,
+            $rateLimiter,
+            new WbFinancialReportPeriodResolver(new MockClock('2026-05-21 00:00:00 Europe/Moscow')),
+            $this->planner,
+            $this->db,
+            $this->logger,
+        );
+
+        return (new CommandTester($command))->execute([]);
+    }
+
+    /**
+     * @param array<string, string|null> $dailyStatuses
+     * @param array<string, int> $dueRetryCounts
+     * @param array<string, int> $futureQueuedCounts
+     */
+    private function dbFetchOneCallback(array $dailyStatuses, array $dueRetryCounts = [], array $futureQueuedCounts = []): \Closure
+    {
+        return static function (string $sql, array $params = []) use ($dailyStatuses, $dueRetryCounts, $futureQueuedCounts): mixed {
+            $key = ($params['companyId'] ?? '').':'.($params['connectionId'] ?? '');
+            if (str_contains($sql, "status = 'queued'") && str_contains($sql, 'next_retry_at > NOW()')) {
+                return $futureQueuedCounts[$key] ?? 0;
+            }
+            if (str_contains($sql, "status IN ('queued', 'failed')")) {
+                return $dueRetryCounts[$key] ?? 0;
+            }
+            if (str_contains($sql, 'AND business_date = :businessDate')) {
+                return $dailyStatuses[$key] ?? null;
+            }
+
+            return 0;
+        };
+    }
+
+    private function rateLimiter(): WbFinanceRateLimiter
+    {
+        return new WbFinanceRateLimiter(
+            new RateLimiterFactory([
+                'id' => 'wb_finance_orchestrator_test',
+                'policy' => 'fixed_window',
+                'limit' => 1,
+                'interval' => '1 second',
+            ], new InMemoryStorage()),
+            new MockClock('2026-05-21T10:00:00+03:00'),
+            null,
+            $this->cooldownStorage,
+        );
+    }
+
+    /** @return array{id: string, connection_id: string, company_id: string} */
+    private function conn(string $connectionId, string $companyId): array
+    {
+        return ['id' => $connectionId, 'connection_id' => $connectionId, 'company_id' => $companyId];
+    }
+}
+
+final class InMemoryCooldownStorage implements WbFinanceCooldownStorageInterface
+{
+    /** @var array<string, int> */
+    private array $timestamps = [];
+
+    public function getUntilTimestamp(string $key): ?int
+    {
+        return $this->timestamps[$key] ?? null;
+    }
+
+    public function setUntilTimestamp(string $key, int $untilTimestamp, int $ttlSeconds): void
+    {
+        $this->timestamps[$key] = $untilTimestamp;
+    }
+}

--- a/site/tests/Unit/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClientTest.php
+++ b/site/tests/Unit/Marketplace/Infrastructure/Api/Wildberries/WbFinanceSalesReportClientTest.php
@@ -101,7 +101,7 @@ final class WbFinanceSalesReportClientTest extends TestCase
         self::assertSame($startTimestamp, $clock->now()->getTimestamp());
     }
 
-    public function testFetchDetailedDayUsesDifferentLimiterBucketsForDifferentSellerBuckets(): void
+    public function testFetchDetailedDayUsesConnectionBucketsEvenWhenSellerBucketsAreProvided(): void
     {
         $requestCount = 0;
         $http = new MockHttpClient(static function () use (&$requestCount): MockResponse {
@@ -222,7 +222,8 @@ final class WbFinanceSalesReportClientTest extends TestCase
             $client->hasAnyDataForConnection('connection-id', 'token', '2026-02-01', '2026-02-03', 'seller-has-any');
         } finally {
             self::assertSame(1, $requestCount);
-            self::assertNotNull($storage->getUntilTimestamp('wb_finance:sales_reports:cooldown:seller-has-any'));
+            self::assertNotNull($storage->getUntilTimestamp('wb_finance:sales_reports:cooldown:connection:connection-id'));
+            self::assertNull($storage->getUntilTimestamp('wb_finance:sales_reports:cooldown:seller-has-any'));
         }
     }
 


### PR DESCRIPTION
### Motivation

- Prefer connection-scoped rate-limit buckets and simplify bucket resolution to avoid using ambiguous seller settings when scheduling/guarding WB finance requests.
- Provide a safe, cooldown-aware orchestration command that schedules at most one recovery task per connection and prioritizes due retries over refreshes.
- Improve diagnostics to surface per-connection recovery state and alerts to aid troubleshooting of throttling and backlogs.
- Make the planner and repository return and preserve per-day `mode` information so refresh/daily semantics are respected when choosing candidates.

### Description

- Updated `WbFinanceRateLimiter` to always fall back to connection-based bucket ids and added helper `secondsUntil`; removed the previous multi-key settings lookup logic.
- Added a new orchestrator command `WbFinancialReportsOrchestrateCommand` that schedules a single task per active connection, respects per-connection cooldowns, and prioritizes `planDaily`, `planDueRetry`, `planRefreshRecentDays`, then `planMissing` for each connection.
- Extended planning API: introduced `planRefreshRecentDays` and `planDueRetry` in `WbFinancialReportSyncPlanner` and `WbFinancialReportSyncPlannerInterface`, and updated `WbFinancialReportsSyncCommand` to support `refresh` mode and additional options (`--days-back`, `--window-days`).
- Made planner logic stricter about modes: `findRetryDueDays` now returns items with both `business_date` and `mode`, repository returns `mode`, and planner preserves the `mode` when dispatching retry tasks so `daily`/`refresh_14d` are not mixed improperly.
- Improved `WbFinanceSalesReportClient` behavior to prefer `connection:` buckets when building cooldown keys and moved seller fallback after connection check; added `guardCooldown` usage and `normalizeSellerBucketId` ordering change.
- Enhanced diagnostics command `WbFinanceDiagnosticsCommand` to include per-connection recovery diagnostics and alerts (`renderConnectionDiagnostics`, `renderAlertDiagnostics`) and to depend on `ActiveWbConnectionsQuery`, `MarketplaceConnectionRepository`, `WbFinanceRateLimiter`, and `WbFinancialReportPeriodResolver`.
- Adjusted multiple unit and integration tests to match new behaviors and added new tests for the orchestrator and diagnostics; updated expectations to assert connection-scoped cooldown keys and mode-preserving planner behavior.

### Testing

- Ran unit tests for planner and rate limiter including `WbFinancialReportSyncPlannerTest`, `WbFinanceRateLimiterTest`, `WbFinanceSalesReportClientTest`, and `WbFinancialReportsOrchestrateCommandTest`, and they all passed.
- Ran updated diagnostics unit test `WbFinanceDiagnosticsCommandTest` which passed with an in-memory SQLite fixture.
- Ran integration tests that exercise end-to-end scheduling and cooldown behavior such as `SyncWbFinancialReportDayHandlerTest` and `MarketplaceFinancialReportSyncStatusRepositoryTest`, and they passed.
- Adjusted and executed related test suites that rely on `findRetryDueDays` and mode semantics; assertions were updated and test runs succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d00eac934832384ac412dcbdae012)