### PR TITLE
Add date-windowed retry/missing planning and historical-recovery mode to WB orchestrator

### DIFF
--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlanner.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlanner.php
@@ -149,15 +149,15 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
         return $dispatched;
     }
 
-    public function planDueRetry(?string $companyId = null, ?string $connectionId = null, int $maxDays = 1): int
+    public function planDueRetry(?string $companyId = null, ?string $connectionId = null, int $maxDays = 1, ?DateTimeImmutable $from = null, ?DateTimeImmutable $to = null): int
     {
         if ($maxDays <= 0) {
             return 0;
         }
 
         $dispatched = 0;
-        $from = $this->periodResolver->currentYearStart();
-        $to = $this->periodResolver->yesterday();
+        $from ??= $this->periodResolver->currentYearStart();
+        $to ??= $this->periodResolver->yesterday();
         $now = $this->clock->now();
 
         foreach ($this->activeWbConnectionsQuery->execute($companyId, $connectionId) as $connection) {
@@ -212,15 +212,15 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
         );
     }
 
-    public function planMissing(?string $companyId = null, ?string $connectionId = null, int $maxDays = 14): int
+    public function planMissing(?string $companyId = null, ?string $connectionId = null, int $maxDays = 14, ?DateTimeImmutable $from = null, ?DateTimeImmutable $to = null): int
     {
         if ($maxDays <= 0) {
             return 0;
         }
 
         $dispatched = 0;
-        $from = $this->periodResolver->currentYearStart();
-        $to = $this->periodResolver->yesterday();
+        $from ??= $this->periodResolver->currentYearStart();
+        $to ??= $this->periodResolver->yesterday();
         $allDays = $this->periodResolver->daysBetween($from, $to);
         $now = $this->clock->now();
 

--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlannerInterface.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlannerInterface.php
@@ -15,7 +15,7 @@ interface WbFinancialReportSyncPlannerInterface
 
     public function planRefreshRecentDays(?string $companyId = null, ?string $connectionId = null, int $daysBack = 2, int $maxDays = 1): int;
 
-    public function planDueRetry(?string $companyId = null, ?string $connectionId = null, int $maxDays = 1): int;
+    public function planDueRetry(?string $companyId = null, ?string $connectionId = null, int $maxDays = 1, ?DateTimeImmutable $from = null, ?DateTimeImmutable $to = null): int;
 
     public function planRange(
         DateTimeImmutable $from,
@@ -26,7 +26,7 @@ interface WbFinancialReportSyncPlannerInterface
         bool $forceRefresh = false,
     ): int;
 
-    public function planMissing(?string $companyId = null, ?string $connectionId = null, int $maxDays = 14): int;
+    public function planMissing(?string $companyId = null, ?string $connectionId = null, int $maxDays = 14, ?DateTimeImmutable $from = null, ?DateTimeImmutable $to = null): int;
 
     public function planInitial(?string $companyId = null, ?string $connectionId = null, ?DateTimeImmutable $startFrom = null, int $maxDays = 1): int;
 }

--- a/site/src/Marketplace/Command/WbFinancialReportsOrchestrateCommand.php
+++ b/site/src/Marketplace/Command/WbFinancialReportsOrchestrateCommand.php
@@ -29,6 +29,8 @@ final class WbFinancialReportsOrchestrateCommand extends Command
 
     private const REPORT_TYPE = 'sales_report';
     private const GLOBAL_BUCKET = 'global';
+    private const MODE_OPERATIONAL = 'operational';
+    private const MODE_HISTORICAL_RECOVERY = 'historical-recovery';
 
     public function __construct(
         private readonly ActiveWbConnectionsQuery $activeWbConnectionsQuery,
@@ -46,7 +48,11 @@ final class WbFinancialReportsOrchestrateCommand extends Command
         $this
             ->addOption('company-id', null, InputOption::VALUE_OPTIONAL)
             ->addOption('connection-id', null, InputOption::VALUE_OPTIONAL)
-            ->addOption('refresh-days-back', null, InputOption::VALUE_OPTIONAL, 'Refresh only the last N business days before today.', '2');
+            ->addOption('refresh-days-back', null, InputOption::VALUE_OPTIONAL, 'Refresh only the last N business days before today.', '2')
+            ->addOption('retry-window-days', null, InputOption::VALUE_OPTIONAL, 'Operational retry/missing window in days before today.', '14')
+            ->addOption('include-historical-retry', null, InputOption::VALUE_NONE, 'Allow due retries and missing days older than retry-window-days.')
+            ->addOption('historical-max-days', null, InputOption::VALUE_OPTIONAL, 'Maximum historical days to schedule per connection when history is explicitly enabled.', '1')
+            ->addOption('mode', null, InputOption::VALUE_OPTIONAL, 'Run mode: operational or historical-recovery.', self::MODE_OPERATIONAL);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -63,6 +69,15 @@ final class WbFinancialReportsOrchestrateCommand extends Command
             $companyId = $this->normalizeOptional((string) $input->getOption('company-id'));
             $connectionId = $this->normalizeOptional((string) $input->getOption('connection-id'));
             $refreshDaysBack = max(1, (int) $input->getOption('refresh-days-back'));
+            $retryWindowDays = max(1, (int) $input->getOption('retry-window-days'));
+            $historicalMaxDays = max(1, (int) $input->getOption('historical-max-days'));
+            $mode = (string) $input->getOption('mode');
+            if (!\in_array($mode, [self::MODE_OPERATIONAL, self::MODE_HISTORICAL_RECOVERY], true)) {
+                $io->error('Invalid mode. Allowed values: operational, historical-recovery.');
+
+                return Command::INVALID;
+            }
+            $includeHistoricalRetry = (bool) $input->getOption('include-historical-retry') || self::MODE_HISTORICAL_RECOVERY === $mode;
             $globalCooldownUntil = $this->rateLimiter->getActiveSalesReportsCooldownUntil(self::GLOBAL_BUCKET);
             if (null !== $globalCooldownUntil) {
                 $message = 'WB finance global cooldown is active but orchestrator continues connection-scoped planning.';
@@ -70,6 +85,12 @@ final class WbFinancialReportsOrchestrateCommand extends Command
                 $io->warning($message.' cooldown_until='.$globalCooldownUntil->format(\DateTimeInterface::ATOM));
             }
             $yesterday = $this->periodResolver->yesterday();
+            $currentYearStart = $this->periodResolver->currentYearStart();
+            $retryWindowStart = $this->periodResolver->lastDays($retryWindowDays)[0];
+            if ($retryWindowStart < $currentYearStart) {
+                $retryWindowStart = $currentYearStart;
+            }
+            $historicalTo = $retryWindowStart->modify('-1 day');
 
             foreach ($this->activeWbConnectionsQuery->execute($companyId, $connectionId) as $activeConnection) {
                 $connectionIdValue = (string) $activeConnection['connection_id'];
@@ -80,37 +101,59 @@ final class WbFinancialReportsOrchestrateCommand extends Command
 
                 $connectionCooldownUntil = $this->rateLimiter->getActiveSalesReportsCooldownUntil('connection:'.$connectionIdValue);
 
-                $dueRetryCount = $this->countDueRetry($companyIdValue, $connectionIdValue);
-                $futureQueuedCount = $this->countFutureQueued($companyIdValue, $connectionIdValue);
+                $recentDueRetryCount = $this->countDueRetry($companyIdValue, $connectionIdValue, $retryWindowStart, $yesterday);
+                $historicalDueRetryCount = $historicalTo >= $currentYearStart
+                    ? $this->countDueRetry($companyIdValue, $connectionIdValue, $currentYearStart, $historicalTo)
+                    : 0;
+                $recentMissingCount = $this->countMissing($companyIdValue, $connectionIdValue, $retryWindowStart, $yesterday);
+                $historicalMissingCount = $historicalTo >= $currentYearStart
+                    ? $this->countMissing($companyIdValue, $connectionIdValue, $currentYearStart, $historicalTo)
+                    : 0;
+                $futureQueuedCount = $this->countFutureQueued($companyIdValue, $connectionIdValue, $retryWindowStart, $yesterday);
 
                 if (null !== $connectionCooldownUntil) {
                     $reason = 'connection cooldown until '.$connectionCooldownUntil->format(\DateTimeInterface::ATOM);
                 } elseif ($futureQueuedCount > 0) {
-                    $reason = 'queued future retry exists';
+                    $reason = 'queued future retry exists in operational window';
                 } else {
-                    $dailyStatus = $this->findDailyStatus($companyIdValue, $connectionIdValue, $yesterday);
-                    if (!\in_array($dailyStatus, ['success', 'empty'], true)) {
-                        $dispatched = $this->planner->planDaily($companyIdValue, $connectionIdValue, false);
-                        $action = $dispatched > 0 ? 'daily yesterday' : 'daily skipped by claim';
-                        $reason = $dispatched > 0 ? 'planned' : 'status not claimable';
-                    }
+                    if (self::MODE_HISTORICAL_RECOVERY !== $mode) {
+                        $dailyStatus = $this->findDailyStatus($companyIdValue, $connectionIdValue, $yesterday);
+                        if (!\in_array($dailyStatus, ['success', 'empty'], true)) {
+                            $dispatched = $this->planner->planDaily($companyIdValue, $connectionIdValue, false);
+                            $action = $dispatched > 0 ? 'daily yesterday' : 'daily skipped by claim';
+                            $reason = $dispatched > 0 ? 'planned' : 'status not claimable';
+                        }
 
-                    if (0 === $dispatched && $dueRetryCount > 0) {
-                        $dispatched = $this->planner->planDueRetry($companyIdValue, $connectionIdValue, 1);
-                        $action = $dispatched > 0 ? 'due retry' : 'due retry skipped by claim';
-                        $reason = $dispatched > 0 ? 'planned' : 'status not claimable';
-                    }
+                        if (0 === $dispatched && $recentDueRetryCount > 0) {
+                            $dispatched = $this->planner->planDueRetry($companyIdValue, $connectionIdValue, 1, $retryWindowStart, $yesterday);
+                            $action = $dispatched > 0 ? 'recent due retry' : 'recent due retry skipped by claim';
+                            $reason = $dispatched > 0 ? 'planned' : 'status not claimable';
+                        }
+                        if (0 === $dispatched && 0 === $recentDueRetryCount) {
+                            $dispatched = $this->planner->planRefreshRecentDays($companyIdValue, $connectionIdValue, $refreshDaysBack, 1);
+                            if ($dispatched > 0) {
+                                $action = 'refresh last '.$refreshDaysBack.' days';
+                                $reason = 'planned';
+                            }
+                        }
 
-                    if (0 === $dispatched && 0 === $dueRetryCount) {
-                        $dispatched = $this->planner->planRefreshRecentDays($companyIdValue, $connectionIdValue, $refreshDaysBack, 1);
-                        if ($dispatched > 0) {
-                            $action = 'refresh last '.$refreshDaysBack.' days';
-                            $reason = 'planned';
+                        if (0 === $dispatched && 0 === $recentDueRetryCount && $recentMissingCount > 0) {
+                            $dispatched = $this->planner->planMissing($companyIdValue, $connectionIdValue, 1, $retryWindowStart, $yesterday);
+                            if ($dispatched > 0) {
+                                $action = 'recent missing';
+                                $reason = 'planned';
+                            }
                         }
                     }
 
-                    if (0 === $dispatched && 0 === $dueRetryCount) {
-                        $dispatched = $this->planner->planMissing($companyIdValue, $connectionIdValue, 1);
+                    if (0 === $dispatched && $includeHistoricalRetry && $historicalDueRetryCount > 0) {
+                        $dispatched = $this->planner->planDueRetry($companyIdValue, $connectionIdValue, $historicalMaxDays, $currentYearStart, $historicalTo);
+                        $action = $dispatched > 0 ? 'historical due retry' : 'historical due retry skipped by claim';
+                        $reason = $dispatched > 0 ? 'planned' : 'status not claimable';
+                    }
+
+                    if (0 === $dispatched && $includeHistoricalRetry && 0 === $historicalDueRetryCount && $historicalMissingCount > 0) {
+                        $dispatched = $this->planner->planMissing($companyIdValue, $connectionIdValue, $historicalMaxDays, $currentYearStart, $historicalTo);
                         if ($dispatched > 0) {
                             $action = 'historical missing';
                             $reason = 'planned';
@@ -119,10 +162,30 @@ final class WbFinancialReportsOrchestrateCommand extends Command
                 }
 
                 $totalDispatched += $dispatched;
-                $rows[] = [$companyIdValue, $connectionIdValue, $action, (string) $dispatched, $reason];
+                $rows[] = [
+                    $companyIdValue,
+                    $connectionIdValue,
+                    $action,
+                    (string) $dispatched,
+                    $reason,
+                    (string) $recentDueRetryCount,
+                    (string) $historicalDueRetryCount,
+                    (string) $recentMissingCount,
+                    (string) $historicalMissingCount,
+                ];
             }
 
-            $io->table(['company_id', 'connection_id', 'action', 'dispatched', 'reason'], $rows);
+            $io->table([
+                'company_id',
+                'connection_id',
+                'action',
+                'dispatched',
+                'reason',
+                'recent_due_retry_count',
+                'historical_due_retry_count',
+                'recent_missing_count',
+                'historical_missing_count',
+            ], $rows);
             $io->success(sprintf('WB finance orchestration completed. Dispatched %d task(s).', $totalDispatched));
 
             return Command::SUCCESS;
@@ -131,7 +194,7 @@ final class WbFinancialReportsOrchestrateCommand extends Command
         }
     }
 
-    private function countDueRetry(string $companyId, string $connectionId): int
+    private function countDueRetry(string $companyId, string $connectionId, \DateTimeImmutable $from, \DateTimeImmutable $to): int
     {
         return (int) $this->connection->fetchOne(
             "SELECT COUNT(*)
@@ -149,14 +212,14 @@ final class WbFinancialReportsOrchestrateCommand extends Command
                 'companyId' => $companyId,
                 'connectionId' => $connectionId,
                 'reportType' => self::REPORT_TYPE,
-                'fromDate' => $this->periodResolver->currentYearStart()->format('Y-m-d'),
-                'toDate' => $this->periodResolver->yesterday()->format('Y-m-d'),
+                'fromDate' => $from->format('Y-m-d'),
+                'toDate' => $to->format('Y-m-d'),
                 'rateLimitErrorClass' => MarketplaceRateLimitException::class,
             ],
         );
     }
 
-    private function countFutureQueued(string $companyId, string $connectionId): int
+    private function countFutureQueued(string $companyId, string $connectionId, \DateTimeImmutable $from, \DateTimeImmutable $to): int
     {
         return (int) $this->connection->fetchOne(
             "SELECT COUNT(*)
@@ -165,11 +228,40 @@ final class WbFinancialReportsOrchestrateCommand extends Command
                AND connection_id = :connectionId
                AND marketplace = 'wildberries'
                AND report_type = :reportType
+               AND business_date BETWEEN :fromDate AND :toDate
                AND status = 'queued'
                AND next_retry_at IS NOT NULL
                AND next_retry_at > NOW()",
-            ['companyId' => $companyId, 'connectionId' => $connectionId, 'reportType' => self::REPORT_TYPE],
+            [
+                'companyId' => $companyId,
+                'connectionId' => $connectionId,
+                'reportType' => self::REPORT_TYPE,
+                'fromDate' => $from->format('Y-m-d'),
+                'toDate' => $to->format('Y-m-d'),
+            ],
         );
+    }
+
+    private function countMissing(string $companyId, string $connectionId, \DateTimeImmutable $from, \DateTimeImmutable $to): int
+    {
+        $knownDays = (int) $this->connection->fetchOne(
+            "SELECT COUNT(DISTINCT business_date)
+             FROM marketplace_financial_report_sync_statuses
+             WHERE company_id = :companyId
+               AND connection_id = :connectionId
+               AND marketplace = 'wildberries'
+               AND report_type = :reportType
+               AND business_date BETWEEN :fromDate AND :toDate",
+            [
+                'companyId' => $companyId,
+                'connectionId' => $connectionId,
+                'reportType' => self::REPORT_TYPE,
+                'fromDate' => $from->format('Y-m-d'),
+                'toDate' => $to->format('Y-m-d'),
+            ],
+        );
+
+        return max(0, count($this->periodResolver->daysBetween($from, $to)) - $knownDays);
     }
 
     private function findDailyStatus(string $companyId, string $connectionId, \DateTimeImmutable $businessDate): ?string

--- a/site/tests/Unit/Marketplace/Command/WbFinancialReportsOrchestrateCommandTest.php
+++ b/site/tests/Unit/Marketplace/Command/WbFinancialReportsOrchestrateCommandTest.php
@@ -94,7 +94,13 @@ final class WbFinancialReportsOrchestrateCommandTest extends TestCase
             ['company-a:conn-a' => 'success'],
             ['company-a:conn-a' => 1],
         ));
-        $this->planner->expects(self::once())->method('planDueRetry')->with('company-a', 'conn-a', 1)->willReturn(1);
+        $this->planner->expects(self::once())->method('planDueRetry')->with(
+            'company-a',
+            'conn-a',
+            1,
+            self::isInstanceOf(\DateTimeImmutable::class),
+            self::isInstanceOf(\DateTimeImmutable::class),
+        )->willReturn(1);
         $this->planner->expects(self::never())->method('planRefreshRecentDays');
         $this->planner->expects(self::never())->method('planMissing');
 
@@ -126,10 +132,144 @@ final class WbFinancialReportsOrchestrateCommandTest extends TestCase
         $this->planner->expects(self::once())->method('planRefreshRecentDays')->with('company-a', 'conn-a', 2, 1)->willReturn(1);
 
         self::assertSame(Command::SUCCESS, $this->execute($this->rateLimiter()));
-        self::assertSame(1, $dueRetrySqlAssertions);
+        self::assertSame(2, $dueRetrySqlAssertions);
     }
 
-    private function execute(WbFinanceRateLimiter $rateLimiter): int
+    public function testOldDueRetryOutsideDefaultWindowFallsThroughToRefresh(): void
+    {
+        $this->connections->method('execute')->willReturn([$this->conn('conn-a', 'company-a')]);
+        $this->db->method('fetchOne')->willReturnCallback($this->dbFetchOneCallback(
+            ['company-a:conn-a' => 'success'],
+            ['company-a:conn-a:2026-05-07:2026-05-20' => 0, 'company-a:conn-a:2026-01-01:2026-05-06' => 1],
+        ));
+        $this->planner->expects(self::never())->method('planDueRetry');
+        $this->planner->expects(self::once())->method('planRefreshRecentDays')->with('company-a', 'conn-a', 2, 1)->willReturn(1);
+        $this->planner->expects(self::never())->method('planMissing');
+
+        self::assertSame(Command::SUCCESS, $this->execute($this->rateLimiter()));
+    }
+
+    public function testRecentDueRetryInsideWindowRunsBeforeRefresh(): void
+    {
+        $this->connections->method('execute')->willReturn([$this->conn('conn-a', 'company-a')]);
+        $this->db->method('fetchOne')->willReturnCallback($this->dbFetchOneCallback(
+            ['company-a:conn-a' => 'success'],
+            ['company-a:conn-a:2026-05-07:2026-05-20' => 1],
+        ));
+        $this->planner->expects(self::once())->method('planDueRetry')->with(
+            'company-a',
+            'conn-a',
+            1,
+            self::callback(static fn (\DateTimeImmutable $date): bool => '2026-05-07' === $date->format('Y-m-d')),
+            self::callback(static fn (\DateTimeImmutable $date): bool => '2026-05-20' === $date->format('Y-m-d')),
+        )->willReturn(1);
+        $this->planner->expects(self::never())->method('planRefreshRecentDays');
+        $this->planner->expects(self::never())->method('planMissing');
+
+        self::assertSame(Command::SUCCESS, $this->execute($this->rateLimiter()));
+    }
+
+    public function testIncludeHistoricalRetryAllowsOnlyConfiguredHistoricalBatch(): void
+    {
+        $this->connections->method('execute')->willReturn([$this->conn('conn-a', 'company-a')]);
+        $this->db->method('fetchOne')->willReturnCallback($this->dbFetchOneCallback(
+            ['company-a:conn-a' => 'success'],
+            ['company-a:conn-a:2026-05-07:2026-05-20' => 0, 'company-a:conn-a:2026-01-01:2026-05-06' => 1],
+        ));
+        $this->planner->expects(self::once())->method('planRefreshRecentDays')->with('company-a', 'conn-a', 2, 1)->willReturn(0);
+        $this->planner->expects(self::once())->method('planDueRetry')->with(
+            'company-a',
+            'conn-a',
+            1,
+            self::callback(static fn (\DateTimeImmutable $date): bool => '2026-01-01' === $date->format('Y-m-d')),
+            self::callback(static fn (\DateTimeImmutable $date): bool => '2026-05-06' === $date->format('Y-m-d')),
+        )->willReturn(1);
+        $this->planner->expects(self::never())->method('planMissing');
+
+        self::assertSame(Command::SUCCESS, $this->execute($this->rateLimiter(), ['--include-historical-retry' => true]));
+    }
+
+    public function testRefreshDaysBackDoesNotEnableHistoricalRetry(): void
+    {
+        $this->connections->method('execute')->willReturn([$this->conn('conn-a', 'company-a')]);
+        $this->db->method('fetchOne')->willReturnCallback($this->dbFetchOneCallback(
+            ['company-a:conn-a' => 'success'],
+            ['company-a:conn-a:2026-05-07:2026-05-20' => 0, 'company-a:conn-a:2026-01-01:2026-05-06' => 1],
+        ));
+        $this->planner->expects(self::never())->method('planDueRetry');
+        $this->planner->expects(self::once())->method('planRefreshRecentDays')->with('company-a', 'conn-a', 2, 1)->willReturn(1);
+        $this->planner->expects(self::never())->method('planMissing');
+
+        self::assertSame(Command::SUCCESS, $this->execute($this->rateLimiter(), ['--refresh-days-back' => '2']));
+    }
+
+    public function testRecentMissingIsNotPlannedWhenRecentDueRetryCannotBeClaimed(): void
+    {
+        $tester = null;
+        $this->connections->method('execute')->willReturn([$this->conn('conn-a', 'company-a')]);
+        $this->db->method('fetchOne')->willReturnCallback($this->dbFetchOneCallback(
+            ['company-a:conn-a' => 'success'],
+            ['company-a:conn-a:2026-05-07:2026-05-20' => 1],
+            [],
+            ['company-a:conn-a:2026-05-07:2026-05-20' => 13],
+        ));
+        $this->planner->expects(self::once())->method('planDueRetry')->willReturn(0);
+        $this->planner->expects(self::never())->method('planRefreshRecentDays');
+        $this->planner->expects(self::never())->method('planMissing');
+
+        self::assertSame(Command::SUCCESS, $this->execute($this->rateLimiter(), [], $tester));
+        self::assertStringContainsString('recent due retry skipped by claim', $tester->getDisplay());
+        self::assertStringContainsString('Dispatched 0 task(s).', $tester->getDisplay());
+    }
+
+    public function testHistoricalMissingIsNotPlannedWhenHistoricalDueRetryCannotBeClaimed(): void
+    {
+        $tester = null;
+        $this->connections->method('execute')->willReturn([$this->conn('conn-a', 'company-a')]);
+        $this->db->method('fetchOne')->willReturnCallback($this->dbFetchOneCallback(
+            ['company-a:conn-a' => 'success'],
+            ['company-a:conn-a:2026-05-07:2026-05-20' => 0, 'company-a:conn-a:2026-01-01:2026-05-06' => 1],
+            [],
+            ['company-a:conn-a:2026-01-01:2026-05-06' => 0],
+        ));
+        $this->planner->expects(self::once())->method('planRefreshRecentDays')->with('company-a', 'conn-a', 2, 1)->willReturn(0);
+        $this->planner->expects(self::once())->method('planDueRetry')->with(
+            'company-a',
+            'conn-a',
+            1,
+            self::callback(static fn (\DateTimeImmutable $date): bool => '2026-01-01' === $date->format('Y-m-d')),
+            self::callback(static fn (\DateTimeImmutable $date): bool => '2026-05-06' === $date->format('Y-m-d')),
+        )->willReturn(0);
+        $this->planner->expects(self::never())->method('planMissing');
+
+        self::assertSame(Command::SUCCESS, $this->execute($this->rateLimiter(), ['--include-historical-retry' => true], $tester));
+        self::assertStringContainsString('historical due retry skipped by claim', $tester->getDisplay());
+        self::assertStringContainsString('Dispatched 0 task(s).', $tester->getDisplay());
+    }
+
+    public function testRecentMissingIsPlannedWhenNoRecentDueRetryExists(): void
+    {
+        $this->connections->method('execute')->willReturn([$this->conn('conn-a', 'company-a')]);
+        $this->db->method('fetchOne')->willReturnCallback($this->dbFetchOneCallback(
+            ['company-a:conn-a' => 'success'],
+            ['company-a:conn-a:2026-05-07:2026-05-20' => 0],
+            [],
+            ['company-a:conn-a:2026-05-07:2026-05-20' => 13],
+        ));
+        $this->planner->expects(self::never())->method('planDueRetry');
+        $this->planner->expects(self::once())->method('planRefreshRecentDays')->with('company-a', 'conn-a', 2, 1)->willReturn(0);
+        $this->planner->expects(self::once())->method('planMissing')->with(
+            'company-a',
+            'conn-a',
+            1,
+            self::callback(static fn (\DateTimeImmutable $date): bool => '2026-05-07' === $date->format('Y-m-d')),
+            self::callback(static fn (\DateTimeImmutable $date): bool => '2026-05-20' === $date->format('Y-m-d')),
+        )->willReturn(1);
+
+        self::assertSame(Command::SUCCESS, $this->execute($this->rateLimiter()));
+    }
+
+    private function execute(WbFinanceRateLimiter $rateLimiter, array $input = [], ?CommandTester &$tester = null): int
     {
         $command = new WbFinancialReportsOrchestrateCommand(
             $this->connections,
@@ -140,23 +280,37 @@ final class WbFinancialReportsOrchestrateCommandTest extends TestCase
             $this->logger,
         );
 
-        return (new CommandTester($command))->execute([]);
+        $tester = new CommandTester($command);
+
+        return $tester->execute($input);
     }
 
     /**
      * @param array<string, string|null> $dailyStatuses
-     * @param array<string, int> $dueRetryCounts
+     * @param array<string, int> $dueRetryCounts keyed by company:connection or company:connection:from:to
      * @param array<string, int> $futureQueuedCounts
+     * @param array<string, int> $knownDayCounts keyed by company:connection or company:connection:from:to
      */
-    private function dbFetchOneCallback(array $dailyStatuses, array $dueRetryCounts = [], array $futureQueuedCounts = []): \Closure
+    private function dbFetchOneCallback(array $dailyStatuses, array $dueRetryCounts = [], array $futureQueuedCounts = [], array $knownDayCounts = []): \Closure
     {
-        return static function (string $sql, array $params = []) use ($dailyStatuses, $dueRetryCounts, $futureQueuedCounts): mixed {
+        return static function (string $sql, array $params = []) use ($dailyStatuses, $dueRetryCounts, $futureQueuedCounts, $knownDayCounts): mixed {
             $key = ($params['companyId'] ?? '').':'.($params['connectionId'] ?? '');
+            $rangeKey = $key.':'.($params['fromDate'] ?? '').':'.($params['toDate'] ?? '');
+            if (str_contains($sql, 'COUNT(DISTINCT business_date)')) {
+                if (array_key_exists($rangeKey, $knownDayCounts) || array_key_exists($key, $knownDayCounts)) {
+                    return $knownDayCounts[$rangeKey] ?? $knownDayCounts[$key];
+                }
+
+                $from = new \DateTimeImmutable((string) $params['fromDate']);
+                $to = new \DateTimeImmutable((string) $params['toDate']);
+
+                return $from->diff($to)->days + 1;
+            }
             if (str_contains($sql, "status = 'queued'") && str_contains($sql, 'next_retry_at > NOW()')) {
-                return $futureQueuedCounts[$key] ?? 0;
+                return $futureQueuedCounts[$rangeKey] ?? $futureQueuedCounts[$key] ?? 0;
             }
             if (str_contains($sql, "status IN ('queued', 'failed')")) {
-                return $dueRetryCounts[$key] ?? 0;
+                return $dueRetryCounts[$rangeKey] ?? $dueRetryCounts[$key] ?? 0;
             }
             if (str_contains($sql, 'AND business_date = :businessDate')) {
                 return $dailyStatuses[$key] ?? null;


### PR DESCRIPTION
### Motivation
- Allow the orchestrator and planner to operate on bounded date windows so recent operational retries and older historical retries/missing days can be handled separately.
- Make it possible to explicitly enable a historical-recovery mode that schedules controlled historical batches without interfering with the operational scheduling flow.

### Description
- Extended `WbFinancialReportSyncPlannerInterface` and `WbFinancialReportSyncPlanner` by adding optional `from`/`to` parameters to `planDueRetry` and `planMissing` so planning can be restricted to date ranges and default to current year start / yesterday when omitted.
- Added new CLI options to `WbFinancialReportsOrchestrateCommand`: `--retry-window-days`, `--include-historical-retry`, `--historical-max-days` and `--mode` (supports `operational` and `historical-recovery`), and implemented logic to compute `retryWindowStart` and separate recent vs historical ranges.
- Modified counting helpers to accept ranges and updated SQL queries in `countDueRetry` and `countFutureQueued`, and added `countMissing` to compute known days vs expected days in a range.
- Changed orchestration decision flow to prefer recent due retries inside the operational window, fall through to recent refresh or recent missing, and only run historical batches when `--include-historical-retry` or `historical-recovery` mode is enabled; added more columns to the command table output for visibility.
- Updated unit tests in `WbFinancialReportsOrchestrateCommandTest` to cover the new date-window behaviour, operational vs historical scenarios, and updated planner method expectations to include the new date-range parameters.

### Testing
- Updated and executed unit tests in `site/tests/Unit/Marketplace/Command/WbFinancialReportsOrchestrateCommandTest.php` which cover recent vs historical retry/missing flows, claim skipping behavior, and CLI option interactions, and they passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d5ca7b93483238b4bbc1c3bfc6350)