### PR TITLE
Make WB sync status finalization context-aware for shared raw documents

### DIFF
--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncStatusUpdater.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncStatusUpdater.php
@@ -145,13 +145,25 @@ final readonly class WbFinancialReportSyncStatusUpdater implements WbFinancialRe
     }
 
 
-    public function syncByRawPipelineResult(MarketplaceRawDocument $rawDocument, ?\Throwable $failure = null): void
+    /** @param array{sync_status_id?: string|null, company_id?: string|null, connection_id?: string|null, marketplace?: string|null, report_type?: string|null, mode?: string|null, business_date?: string|null, raw_document_id?: string|null}|null $context */
+    public function syncByRawPipelineResult(MarketplaceRawDocument $rawDocument, ?\Throwable $failure = null, ?array $context = null): void
     {
         if ($rawDocument->getMarketplace() !== MarketplaceType::WILDBERRIES || $rawDocument->getDocumentType() !== 'sales_report') {
             return;
         }
 
-        $status = $this->statusRepository->findByRawDocumentId((string) $rawDocument->getCompany()->getId(), $rawDocument->getId());
+        $companyId = (string) $rawDocument->getCompany()->getId();
+        $rawDocumentId = $rawDocument->getId();
+        $statuses = $this->statusRepository->findAllByRawDocumentId($companyId, $rawDocumentId);
+        if (count($statuses) > 1) {
+            $this->logger->warning('Multiple WB sync statuses reference one raw document; exact context is required to finalize safely.', [
+                'company_id' => $companyId,
+                'raw_document_id' => $rawDocumentId,
+                'sync_status_ids' => array_map(static fn (MarketplaceFinancialReportSyncStatus $status): string => $status->getId(), $statuses),
+            ]);
+        }
+
+        $status = $this->resolveStatusForRawPipelineResult($rawDocument, $context);
         if ($status === null) {
             return;
         }
@@ -184,6 +196,96 @@ final readonly class WbFinancialReportSyncStatusUpdater implements WbFinancialRe
             'to' => $status->getStatus()->value,
             'pipelineStatus' => $rawDocument->getProcessingStatus()?->value,
         ]);
+    }
+
+    /** @param array{sync_status_id?: string|null, company_id?: string|null, connection_id?: string|null, marketplace?: string|null, report_type?: string|null, mode?: string|null, business_date?: string|null, raw_document_id?: string|null}|null $context */
+    private function resolveStatusForRawPipelineResult(MarketplaceRawDocument $rawDocument, ?array $context): ?MarketplaceFinancialReportSyncStatus
+    {
+        $companyId = (string) $rawDocument->getCompany()->getId();
+        $rawDocumentId = $rawDocument->getId();
+
+        if (null === $context || null === ($context['connection_id'] ?? null)) {
+            $statuses = $this->statusRepository->findAllByRawDocumentId($companyId, $rawDocumentId);
+            if (count($statuses) > 1) {
+                $this->logger->warning('WB sync status finalization skipped because raw document is linked to multiple statuses and no exact context was provided.', [
+                    'company_id' => $companyId,
+                    'raw_document_id' => $rawDocumentId,
+                    'sync_status_ids' => array_map(static fn (MarketplaceFinancialReportSyncStatus $status): string => $status->getId(), $statuses),
+                ]);
+
+                return null;
+            }
+
+            return $statuses[0] ?? null;
+        }
+
+        if (isset($context['company_id']) && $context['company_id'] !== $companyId) {
+            $this->logger->warning('WB sync status finalization skipped because context company does not match raw document company.', [
+                'company_id' => $companyId,
+                'raw_document_id' => $rawDocumentId,
+                'context' => $context,
+            ]);
+
+            return null;
+        }
+
+        $marketplace = MarketplaceType::tryFrom((string) ($context['marketplace'] ?? MarketplaceType::WILDBERRIES->value));
+        $mode = FinancialReportSyncMode::tryFrom((string) ($context['mode'] ?? ''));
+        $businessDate = $this->parseBusinessDate($context['business_date'] ?? null);
+        $reportType = $context['report_type'] ?? null;
+        $contextRawDocumentId = $context['raw_document_id'] ?? $rawDocumentId;
+
+        if ($marketplace === null || $mode === null || $businessDate === null || !is_string($reportType) || $reportType === '' || $contextRawDocumentId !== $rawDocumentId) {
+            $this->logger->warning('WB sync status finalization skipped because exact context is incomplete or mismatched.', [
+                'company_id' => $companyId,
+                'raw_document_id' => $rawDocumentId,
+                'context' => $context,
+            ]);
+
+            return null;
+        }
+
+        $status = $this->statusRepository->findByRawPipelineContext(
+            $context['sync_status_id'] ?? null,
+            $companyId,
+            (string) $context['connection_id'],
+            $marketplace,
+            $reportType,
+            $mode,
+            $businessDate,
+            $rawDocumentId,
+        );
+
+        if ($status === null) {
+            $this->logger->warning('WB sync status finalization skipped: no status matches exact raw pipeline context.', [
+                'company_id' => $companyId,
+                'raw_document_id' => $rawDocumentId,
+                'context' => $context,
+            ]);
+        }
+
+        return $status;
+    }
+
+    private function parseBusinessDate(mixed $value): ?\DateTimeImmutable
+    {
+        if ($value instanceof \DateTimeImmutable) {
+            return $value->setTime(0, 0);
+        }
+
+        if ($value instanceof \DateTimeInterface) {
+            return \DateTimeImmutable::createFromInterface($value)->setTime(0, 0);
+        }
+
+        if (!is_string($value) || '' === $value) {
+            return null;
+        }
+
+        try {
+            return (new \DateTimeImmutable($value))->setTime(0, 0);
+        } catch (\Throwable) {
+            return null;
+        }
     }
 
     /** @param array<string,mixed>|null $requestPayload */

--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncStatusUpdaterInterface.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncStatusUpdaterInterface.php
@@ -9,7 +9,8 @@ use App\Marketplace\Entity\MarketplaceRawDocument;
 
 interface WbFinancialReportSyncStatusUpdaterInterface
 {
-    public function syncByRawPipelineResult(MarketplaceRawDocument $rawDocument, ?\Throwable $failure = null): void;
+    /** @param array{sync_status_id?: string|null, company_id?: string|null, connection_id?: string|null, marketplace?: string|null, report_type?: string|null, mode?: string|null, business_date?: string|null, raw_document_id?: string|null}|null $context */
+    public function syncByRawPipelineResult(MarketplaceRawDocument $rawDocument, ?\Throwable $failure = null, ?array $context = null): void;
 
     public function markConflict(MarketplaceFinancialReportSyncStatus $status, string $errorClass, string $errorMessage, ?int $statusCode = null, ?string $responseExcerpt = null, ?array $requestPayload = null): void;
 }

--- a/site/src/Marketplace/Command/WbFinanceDiagnosticsCommand.php
+++ b/site/src/Marketplace/Command/WbFinanceDiagnosticsCommand.php
@@ -448,14 +448,34 @@ final class WbFinanceDiagnosticsCommand extends Command
                    AND r.marketplace = 'wildberries'
                    AND r.document_type = 'sales_report'
                    AND r.processing_status = 'completed'
-                   AND s.status IN ('failed', 'queued')
+                   AND s.status IN ('failed', 'queued', 'processing')
                  ORDER BY COALESCE(r.processed_at, r.synced_at) DESC
                  LIMIT 50",
             );
-            $io->writeln('Mismatch: raw completed exists, but sync_status failed/queued:');
+            $io->writeln('Mismatch: raw completed exists, but sync_status failed/queued/processing:');
             $this->renderRows($io, ['company_id', 'connection_id', 'business_date', 'status', 'raw_document_id', 'processing_status', 'processed_at'], $rows);
         } catch (\Throwable $e) {
             $io->warning('Cannot read raw/status mismatches: '.$e->getMessage());
+        }
+
+        try {
+            $rows = $this->connection->fetchAllAssociative(
+                "SELECT s.id, s.company_id, s.connection_id, s.business_date, s.mode, s.raw_document_id, r.processing_status, r.processed_at, r.records_count
+                 FROM marketplace_financial_report_sync_statuses s
+                 INNER JOIN marketplace_raw_documents r ON r.id = s.raw_document_id
+                 WHERE s.marketplace = 'wildberries'
+                   AND s.report_type = 'sales_report'
+                   AND s.status = 'processing'
+                   AND r.marketplace = 'wildberries'
+                   AND r.document_type = 'sales_report'
+                   AND r.processing_status = 'completed'
+                 ORDER BY COALESCE(r.processed_at, r.synced_at) DESC
+                 LIMIT 200",
+            );
+            $io->writeln('Stale processing statuses with completed raw document:');
+            $this->renderRows($io, ['id', 'company_id', 'connection_id', 'business_date', 'mode', 'raw_document_id', 'processing_status', 'processed_at', 'records_count'], $rows);
+        } catch (\Throwable $e) {
+            $io->warning('Cannot read stale processing statuses: '.$e->getMessage());
         }
     }
 

--- a/site/src/Marketplace/Message/ProcessDayReportMessage.php
+++ b/site/src/Marketplace/Message/ProcessDayReportMessage.php
@@ -17,6 +17,12 @@ final readonly class ProcessDayReportMessage
         public string $companyId,
         public string $rawDocumentId,
         public bool $forceRefresh = false,
+        public ?string $syncStatusId = null,
+        public ?string $connectionId = null,
+        public ?string $marketplace = null,
+        public ?string $reportType = null,
+        public ?string $mode = null,
+        public ?string $businessDate = null,
     ) {
     }
 }

--- a/site/src/Marketplace/Message/ProcessRawDocumentStepMessage.php
+++ b/site/src/Marketplace/Message/ProcessRawDocumentStepMessage.php
@@ -15,6 +15,12 @@ final readonly class ProcessRawDocumentStepMessage
         public string $rawDocumentId,
         public string $step,
         public string $companyId,
+        public ?string $syncStatusId = null,
+        public ?string $connectionId = null,
+        public ?string $marketplace = null,
+        public ?string $reportType = null,
+        public ?string $mode = null,
+        public ?string $businessDate = null,
     ) {
     }
 }

--- a/site/src/Marketplace/MessageHandler/ProcessDayReportHandler.php
+++ b/site/src/Marketplace/MessageHandler/ProcessDayReportHandler.php
@@ -6,6 +6,8 @@ namespace App\Marketplace\MessageHandler;
 
 use App\Marketplace\Application\Service\WbFinancialReportSyncStatusUpdaterInterface;
 use App\Marketplace\Application\Service\WbGeneratedRowsSafeReplaceServiceInterface;
+use App\Marketplace\Entity\MarketplaceFinancialReportSyncStatus;
+use App\Marketplace\Enum\FinancialReportSyncMode;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Enum\PipelineStep;
 use App\Marketplace\Message\ProcessDayReportMessage;
@@ -62,7 +64,7 @@ final class ProcessDayReportHandler
             try {
                 $this->safeReplaceService->cleanupForRawDocument($doc->getCompany(), $doc->getId(), $doc->getPeriodFrom());
             } catch (WbGeneratedRowsConflictException $e) {
-                $status = $this->syncStatusRepository->findByRawDocumentId($message->companyId, $message->rawDocumentId);
+                $status = $this->findExactSyncStatusForMessage($message);
                 if ($status !== null) {
                     $this->syncStatusUpdater->markConflict($status, $e::class, $e->getMessage());
                     $this->entityManager->flush();
@@ -86,6 +88,12 @@ final class ProcessDayReportHandler
                 rawDocumentId: $doc->getId(),
                 step: $step->value,
                 companyId: $message->companyId,
+                syncStatusId: $message->syncStatusId,
+                connectionId: $message->connectionId,
+                marketplace: $message->marketplace,
+                reportType: $message->reportType,
+                mode: $message->mode,
+                businessDate: $message->businessDate,
             ));
         }
 
@@ -94,5 +102,76 @@ final class ProcessDayReportHandler
             'raw_document_id' => $message->rawDocumentId,
             'marketplace'     => $doc->getMarketplace()->value,
         ]);
+    }
+
+    private function findExactSyncStatusForMessage(ProcessDayReportMessage $message): ?MarketplaceFinancialReportSyncStatus
+    {
+        if (null === $message->connectionId) {
+            $this->logger->warning('WB day processing conflict: cannot mark sync status without exact connection context', [
+                'company_id' => $message->companyId,
+                'raw_document_id' => $message->rawDocumentId,
+                'sync_status_id' => $message->syncStatusId,
+            ]);
+
+            return null;
+        }
+
+        $marketplace = MarketplaceType::tryFrom((string) ($message->marketplace ?? MarketplaceType::WILDBERRIES->value));
+        $mode = null === $message->mode ? null : FinancialReportSyncMode::tryFrom($message->mode);
+        $businessDate = $this->parseBusinessDate($message->businessDate);
+
+        if ($marketplace === null || $mode === null || $businessDate === null || null === $message->reportType) {
+            $this->logger->warning('WB day processing conflict: cannot mark sync status because exact context is incomplete', [
+                'company_id' => $message->companyId,
+                'connection_id' => $message->connectionId,
+                'raw_document_id' => $message->rawDocumentId,
+                'sync_status_id' => $message->syncStatusId,
+                'marketplace' => $message->marketplace,
+                'report_type' => $message->reportType,
+                'mode' => $message->mode,
+                'business_date' => $message->businessDate,
+            ]);
+
+            return null;
+        }
+
+        $status = $this->syncStatusRepository->findByRawPipelineContext(
+            $message->syncStatusId,
+            $message->companyId,
+            $message->connectionId,
+            $marketplace,
+            $message->reportType,
+            $mode,
+            $businessDate,
+            $message->rawDocumentId,
+        );
+
+        if ($status === null) {
+            $this->logger->warning('WB day processing conflict: no sync status matches exact raw document context', [
+                'company_id' => $message->companyId,
+                'connection_id' => $message->connectionId,
+                'raw_document_id' => $message->rawDocumentId,
+                'sync_status_id' => $message->syncStatusId,
+                'marketplace' => $marketplace->value,
+                'report_type' => $message->reportType,
+                'mode' => $mode->value,
+                'business_date' => $businessDate->format('Y-m-d'),
+            ]);
+        }
+
+        return $status;
+    }
+
+    private function parseBusinessDate(?string $value): ?\DateTimeImmutable
+    {
+        if (null === $value || '' === $value) {
+            return null;
+        }
+
+        try {
+            return (new \DateTimeImmutable($value))->setTime(0, 0);
+        } catch (\Throwable) {
+            return null;
+        }
     }
 }

--- a/site/src/Marketplace/MessageHandler/ProcessRawDocumentStepMessageHandler.php
+++ b/site/src/Marketplace/MessageHandler/ProcessRawDocumentStepMessageHandler.php
@@ -77,12 +77,17 @@ final class ProcessRawDocumentStepMessageHandler
             }
             $doc->markStepSucceeded($step);
         } catch (\Throwable $e) {
-            $this->recordStepFailure($message->rawDocumentId, $step, $e);
+            $this->recordStepFailure($message->rawDocumentId, $step, $e, $this->buildSyncStatusContext($message));
             throw $e;
         }
 
         try {
-            $this->statusUpdater->syncByRawPipelineResult($doc);
+            $context = $this->buildSyncStatusContext($message);
+            if ($context === null) {
+                $this->statusUpdater->syncByRawPipelineResult($doc);
+            } else {
+                $this->statusUpdater->syncByRawPipelineResult($doc, null, $context);
+            }
         } catch (\Throwable $updaterException) {
             $this->logger->error('Failed to sync WB status after successful pipeline step', [
                 'rawDocumentId' => $message->rawDocumentId,
@@ -94,10 +99,30 @@ final class ProcessRawDocumentStepMessageHandler
         $this->entityManager->flush();
     }
 
+    /** @return array{sync_status_id?: string|null, company_id: string, connection_id?: string|null, marketplace?: string|null, report_type?: string|null, mode?: string|null, business_date?: string|null, raw_document_id: string}|null */
+    private function buildSyncStatusContext(ProcessRawDocumentStepMessage $message): ?array
+    {
+        if (null === $message->syncStatusId && null === $message->connectionId) {
+            return null;
+        }
+
+        return [
+            'sync_status_id' => $message->syncStatusId,
+            'company_id' => $message->companyId,
+            'connection_id' => $message->connectionId,
+            'marketplace' => $message->marketplace,
+            'report_type' => $message->reportType,
+            'mode' => $message->mode,
+            'business_date' => $message->businessDate,
+            'raw_document_id' => $message->rawDocumentId,
+        ];
+    }
+
     private function recordStepFailure(
         string $rawDocumentId,
         PipelineStep $step,
         \Throwable $originalException,
+        ?array $context = null,
     ): void {
         try {
             $em = $this->entityManager;
@@ -122,7 +147,13 @@ final class ProcessRawDocumentStepMessageHandler
             $doc->markStepFailed($step);
 
             try {
-                $this->statusUpdater->syncByRawPipelineResult($doc, $originalException);
+                // Failure recording may run after the original EntityManager was reset; keep this
+                // path backward-compatible for legacy messages that do not carry exact status context.
+                if ($context === null) {
+                    $this->statusUpdater->syncByRawPipelineResult($doc, $originalException);
+                } else {
+                    $this->statusUpdater->syncByRawPipelineResult($doc, $originalException, $context);
+                }
             } catch (\Throwable $updaterException) {
                 $this->logger->error('Failed to sync WB status after pipeline failure', [
                     'rawDocumentId' => $rawDocumentId,

--- a/site/src/Marketplace/MessageHandler/SyncWbFinancialReportDayHandler.php
+++ b/site/src/Marketplace/MessageHandler/SyncWbFinancialReportDayHandler.php
@@ -311,7 +311,17 @@ final class SyncWbFinancialReportDayHandler
             $connection->markSyncSuccess();
             $this->em->flush();
 
-            $this->messageBus->dispatch(new ProcessDayReportMessage($message->companyId, $rawDocument->getId(), $message->forceRefresh));
+            $this->messageBus->dispatch(new ProcessDayReportMessage(
+                companyId: $message->companyId,
+                rawDocumentId: $rawDocument->getId(),
+                forceRefresh: $message->forceRefresh,
+                syncStatusId: $status->getId(),
+                connectionId: $message->connectionId,
+                marketplace: MarketplaceType::WILDBERRIES->value,
+                reportType: self::REPORT_TYPE,
+                mode: $mode->value,
+                businessDate: $businessDate->format('Y-m-d'),
+            ));
 
             $this->logger->info('WB day sync finished and processing dispatched.', [
                 'company_id' => $message->companyId,

--- a/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusLookupInterface.php
+++ b/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusLookupInterface.php
@@ -26,6 +26,20 @@ interface MarketplaceFinancialReportSyncStatusLookupInterface
 
     public function findByRawDocumentId(string $companyId, string $rawDocumentId): ?MarketplaceFinancialReportSyncStatus;
 
+    /** @return list<MarketplaceFinancialReportSyncStatus> */
+    public function findAllByRawDocumentId(string $companyId, string $rawDocumentId): array;
+
+    public function findByRawPipelineContext(
+        ?string $syncStatusId,
+        string $companyId,
+        string $connectionId,
+        MarketplaceType $marketplace,
+        string $reportType,
+        FinancialReportSyncMode $mode,
+        \DateTimeImmutable $businessDate,
+        string $rawDocumentId,
+    ): ?MarketplaceFinancialReportSyncStatus;
+
     public function findStatusEnumByDay(
         string $connectionId,
         string $companyId,

--- a/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepository.php
+++ b/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepository.php
@@ -314,6 +314,83 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
             ->getOneOrNullResult();
     }
 
+    /**
+     * @return list<MarketplaceFinancialReportSyncStatus>
+     */
+    public function findAllByRawDocumentId(string $companyId, string $rawDocumentId): array
+    {
+        Assert::uuid($companyId);
+        Assert::uuid($rawDocumentId);
+
+        return $this->createQueryBuilder('s')
+            ->where('s.companyId = :companyId')
+            ->andWhere('s.rawDocumentId = :rawDocumentId')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('rawDocumentId', $rawDocumentId)
+            ->orderBy('s.updatedAt', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function findByRawPipelineContext(
+        ?string $syncStatusId,
+        string $companyId,
+        string $connectionId,
+        MarketplaceType $marketplace,
+        string $reportType,
+        FinancialReportSyncMode $mode,
+        \DateTimeImmutable $businessDate,
+        string $rawDocumentId,
+    ): ?MarketplaceFinancialReportSyncStatus {
+        Assert::uuid($companyId);
+        Assert::uuid($connectionId);
+        Assert::uuid($rawDocumentId);
+
+        if (null !== $syncStatusId) {
+            Assert::uuid($syncStatusId);
+
+            return $this->createQueryBuilder('s')
+                ->where('s.id = :syncStatusId')
+                ->andWhere('s.companyId = :companyId')
+                ->andWhere('s.connectionId = :connectionId')
+                ->andWhere('s.marketplace = :marketplace')
+                ->andWhere('s.reportType = :reportType')
+                ->andWhere('s.mode = :mode')
+                ->andWhere('s.businessDate = :businessDate')
+                ->andWhere('s.rawDocumentId = :rawDocumentId')
+                ->setParameter('syncStatusId', $syncStatusId)
+                ->setParameter('companyId', $companyId)
+                ->setParameter('connectionId', $connectionId)
+                ->setParameter('marketplace', $marketplace)
+                ->setParameter('reportType', $reportType)
+                ->setParameter('mode', $mode)
+                ->setParameter('businessDate', $businessDate)
+                ->setParameter('rawDocumentId', $rawDocumentId)
+                ->setMaxResults(1)
+                ->getQuery()
+                ->getOneOrNullResult();
+        }
+
+        return $this->createQueryBuilder('s')
+            ->where('s.companyId = :companyId')
+            ->andWhere('s.connectionId = :connectionId')
+            ->andWhere('s.marketplace = :marketplace')
+            ->andWhere('s.reportType = :reportType')
+            ->andWhere('s.mode = :mode')
+            ->andWhere('s.businessDate = :businessDate')
+            ->andWhere('s.rawDocumentId = :rawDocumentId')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('connectionId', $connectionId)
+            ->setParameter('marketplace', $marketplace)
+            ->setParameter('reportType', $reportType)
+            ->setParameter('mode', $mode)
+            ->setParameter('businessDate', $businessDate)
+            ->setParameter('rawDocumentId', $rawDocumentId)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
     public function findOrCreateForDay(
         string $connectionId,
         string $companyId,

--- a/site/tests/Integration/Marketplace/Application/Service/WbFinancialReportSyncStatusUpdaterTest.php
+++ b/site/tests/Integration/Marketplace/Application/Service/WbFinancialReportSyncStatusUpdaterTest.php
@@ -249,6 +249,70 @@ final class WbFinancialReportSyncStatusUpdaterTest extends IntegrationTestCase
         self::assertSame(FinancialReportSyncStatus::PROCESSING, $persisted->getStatus());
     }
 
+
+    public function testSyncByRawPipelineResultUsesExactContextWhenRawDocumentIsSharedByConnections(): void
+    {
+        $rawId = $this->rawId();
+        $otherConnectionId = '00000000-0000-0000-0000-000000000222';
+        $targetConnectionId = '00000000-0000-0000-0000-000000000333';
+
+        $otherStatus = $this->updater->startLoading(
+            $otherConnectionId,
+            $this->companyId(),
+            'sales_report',
+            'wildberries::finance-sales-reports-detailed',
+            $this->businessDate(),
+            FinancialReportSyncMode::INITIAL,
+        );
+        $this->updater->markRawLoaded($otherStatus, $rawId, 10, 'same-raw');
+        $this->updater->markProcessing($otherStatus);
+
+        $targetStatus = $this->updater->startLoading(
+            $targetConnectionId,
+            $this->companyId(),
+            'sales_report',
+            'wildberries::finance-sales-reports-detailed',
+            $this->businessDate(),
+            FinancialReportSyncMode::INITIAL,
+        );
+        $this->updater->markRawLoaded($targetStatus, $rawId, 10, 'same-raw');
+        $this->updater->markProcessing($targetStatus);
+        $this->em->flush();
+
+        $company = $this->em->getReference(
+            \App\Company\Entity\Company::class,
+            $this->companyId(),
+        );
+        $raw = new \App\Marketplace\Entity\MarketplaceRawDocument(
+            $rawId,
+            $company,
+            \App\Marketplace\Enum\MarketplaceType::WILDBERRIES,
+            'sales_report',
+        );
+        $raw->markCompleted();
+
+        $this->updater->syncByRawPipelineResult($raw, null, [
+            'sync_status_id' => $targetStatus->getId(),
+            'company_id' => $this->companyId(),
+            'connection_id' => $targetConnectionId,
+            'marketplace' => \App\Marketplace\Enum\MarketplaceType::WILDBERRIES->value,
+            'report_type' => 'sales_report',
+            'mode' => FinancialReportSyncMode::INITIAL->value,
+            'business_date' => $this->businessDate()->format('Y-m-d'),
+            'raw_document_id' => $rawId,
+        ]);
+        $this->em->flush();
+        $this->em->clear();
+
+        $otherPersisted = $this->statusRepository->findByConnectionAndDate($otherConnectionId, $this->companyId(), $this->businessDate(), 'sales_report');
+        $targetPersisted = $this->statusRepository->findByConnectionAndDate($targetConnectionId, $this->companyId(), $this->businessDate(), 'sales_report');
+
+        self::assertNotNull($otherPersisted);
+        self::assertNotNull($targetPersisted);
+        self::assertSame(FinancialReportSyncStatus::PROCESSING, $otherPersisted->getStatus());
+        self::assertSame(FinancialReportSyncStatus::SUCCESS, $targetPersisted->getStatus());
+    }
+
     private function startLoadingStatus(): MarketplaceFinancialReportSyncStatus
     {
         return $this->updater->startLoading(

--- a/site/tests/Unit/Marketplace/MessageHandler/ProcessDayReportHandlerTest.php
+++ b/site/tests/Unit/Marketplace/MessageHandler/ProcessDayReportHandlerTest.php
@@ -9,6 +9,7 @@ use App\Marketplace\Application\Service\WbFinancialReportSyncStatusUpdaterInterf
 use App\Marketplace\Application\Service\WbGeneratedRowsSafeReplaceServiceInterface;
 use App\Marketplace\Entity\MarketplaceFinancialReportSyncStatus;
 use App\Marketplace\Entity\MarketplaceRawDocument;
+use App\Marketplace\Enum\FinancialReportSyncMode;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Exception\WbGeneratedRowsConflictException;
 use App\Marketplace\Message\ProcessDayReportMessage;
@@ -37,9 +38,23 @@ final class ProcessDayReportHandlerTest extends TestCase
         $safe = $this->createMock(WbGeneratedRowsSafeReplaceServiceInterface::class);
         $safe->expects(self::once())->method('cleanupForRawDocument')->willThrowException(new WbGeneratedRowsConflictException('conflict'));
 
+        $syncStatusId = '33333333-3333-4333-8333-333333333333';
+        $connectionId = '44444444-4444-4444-8444-444444444444';
         $status = $this->createMock(MarketplaceFinancialReportSyncStatus::class);
         $statusRepo = $this->createMock(MarketplaceFinancialReportSyncStatusLookupInterface::class);
-        $statusRepo->method('findByRawDocumentId')->willReturn($status);
+        $statusRepo->expects(self::once())
+            ->method('findByRawPipelineContext')
+            ->with(
+                $syncStatusId,
+                (string) $company->getId(),
+                $connectionId,
+                MarketplaceType::WILDBERRIES,
+                'sales_report',
+                FinancialReportSyncMode::INITIAL,
+                self::callback(static fn (\DateTimeImmutable $date): bool => '2026-05-10' === $date->format('Y-m-d')),
+                $doc->getId(),
+            )
+            ->willReturn($status);
 
         $updater = $this->createMock(WbFinancialReportSyncStatusUpdaterInterface::class);
         $updater->expects(self::once())->method('markConflict')->with($status, WbGeneratedRowsConflictException::class, 'conflict');
@@ -55,7 +70,17 @@ final class ProcessDayReportHandlerTest extends TestCase
 
         $this->expectException(UnrecoverableMessageHandlingException::class);
         try {
-            $handler(new ProcessDayReportMessage((string)$company->getId(), $doc->getId(), true));
+            $handler(new ProcessDayReportMessage(
+                companyId: (string) $company->getId(),
+                rawDocumentId: $doc->getId(),
+                forceRefresh: true,
+                syncStatusId: $syncStatusId,
+                connectionId: $connectionId,
+                marketplace: MarketplaceType::WILDBERRIES->value,
+                reportType: 'sales_report',
+                mode: FinancialReportSyncMode::INITIAL->value,
+                businessDate: '2026-05-10',
+            ));
         } finally {
             self::assertSame(1, $flushes);
         }

--- a/site/tests/Unit/Marketplace/MessageHandler/ProcessRawDocumentStepMessageHandlerTest.php
+++ b/site/tests/Unit/Marketplace/MessageHandler/ProcessRawDocumentStepMessageHandlerTest.php
@@ -186,7 +186,7 @@ final class ProcessRawDocumentStepMessageHandlerTest extends TestCase
         $updater = $this->createMock(WbFinancialReportSyncStatusUpdaterInterface::class);
         $updater->expects(self::exactly(count(PipelineStep::cases())))
             ->method('syncByRawPipelineResult')
-            ->with($doc, null);
+            ->with($doc);
 
         $handler = new ProcessRawDocumentStepMessageHandler(
             $repo,


### PR DESCRIPTION
### Motivation

- Prevent incorrect finalization of Wildberries financial sync statuses when a single `MarketplaceRawDocument` is referenced by multiple sync statuses or connections by requiring exact pipeline context to resolve the target status. 
- Provide backward-compatible behavior for legacy messages while improving diagnostics and logging when context is missing or ambiguous.

### Description

- Add an optional `?array $context` parameter to `WbFinancialReportSyncStatusUpdater::syncByRawPipelineResult` and its interface to carry exact pipeline context (sync status id, connection id, marketplace, report type, mode, business date, raw document id). 
- Implement `resolveStatusForRawPipelineResult` and `parseBusinessDate` in the updater to safely select the appropriate `MarketplaceFinancialReportSyncStatus`, log ambiguity, and skip finalization when context is incomplete or mismatched. 
- Extend repository lookup API with `findAllByRawDocumentId` and `findByRawPipelineContext` to support context-aware resolution and add corresponding query implementations in `MarketplaceFinancialReportSyncStatusRepository`. 
- Propagate context through messaging by adding context fields to `ProcessDayReportMessage` and `ProcessRawDocumentStepMessage`, and update `ProcessDayReportHandler` and `ProcessRawDocumentStepMessageHandler` to build, validate, and pass the context when dispatching or calling the updater; keep legacy path when context is absent. 
- Improve diagnostics in `WbFinanceDiagnosticsCommand` to report `processing` statuses and stale `processing` statuses with completed raw documents, and add warnings/logging where finalization is skipped. 
- Update tests to assert new context-aware behavior and to exercise the new lookup and handler flows.

### Testing

- Ran integration test `WbFinancialReportSyncStatusUpdaterTest` which includes a new test `testSyncByRawPipelineResultUsesExactContextWhenRawDocumentIsSharedByConnections` and it succeeded. 
- Ran unit tests `ProcessDayReportHandlerTest` changes that assert `findByRawPipelineContext` usage and `ProcessRawDocumentStepMessageHandlerTest` adjustments for context propagation, and they succeeded. 
- Existing CI unit and integration suites were exercised for the changed handlers and repository lookups and no failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1da5bb3dac83239b9c894f940d27fd)