### PR TITLE
Add process-costs action for marketplace raw documents with UI and unit test

### DIFF
--- a/site/src/Marketplace/Controller/MarketplaceController.php
+++ b/site/src/Marketplace/Controller/MarketplaceController.php
@@ -14,6 +14,7 @@ use App\Marketplace\Enum\MarketplaceConnectionType;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Infrastructure\Query\OzonRealizationStatusQuery;
 use App\Marketplace\Infrastructure\Query\RawDocumentsListQuery;
+use App\Marketplace\Message\ReprocessCostsMessage;
 use App\Marketplace\Message\SyncOzonRealizationMessage;
 use App\Marketplace\Message\TriggerInitialSyncMessage;
 use App\Marketplace\Repository\MarketplaceConnectionRepository;
@@ -375,6 +376,54 @@ class MarketplaceController extends AbstractController
         }
 
         return $this->redirectToRoute('marketplace_index');
+    }
+
+    #[Route('/raw/{id}/process-costs', name: 'marketplace_raw_process_costs', methods: ['POST'])]
+    public function processCosts(string $id, Request $request): Response
+    {
+        $company = $this->companyService->getActiveCompany();
+
+        $rawDoc = $this->rawDocumentRepository->find($id);
+
+        if (!$rawDoc || (string) $rawDoc->getCompany()->getId() !== (string) $company->getId()) {
+            throw $this->createNotFoundException();
+        }
+
+        if (!$this->isCsrfTokenValid('marketplace_raw_process_costs' . $id, (string) $request->request->get('_token', ''))) {
+            throw $this->createAccessDeniedException('Недействительный CSRF токен.');
+        }
+
+        if ($rawDoc->getDocumentType() !== 'sales_report') {
+            $this->addFlash('error', 'Документ не является отчетом продаж с затратами.');
+
+            return $this->redirectToMarketplaceIndexFromRequest($request);
+        }
+
+        $this->messageBus->dispatch(new ReprocessCostsMessage(
+            companyId: (string) $company->getId(),
+            rawDocumentId: (string) $rawDoc->getId(),
+        ));
+
+        $this->addFlash('success', 'Повторная обработка затрат поставлена в очередь.');
+
+        return $this->redirectToMarketplaceIndexFromRequest($request);
+    }
+
+    private function redirectToMarketplaceIndexFromRequest(Request $request): Response
+    {
+        $query = [];
+
+        $marketplace = (string) $request->request->get('marketplace', '');
+        if (MarketplaceType::tryFrom($marketplace) !== null) {
+            $query['marketplace'] = $marketplace;
+        }
+
+        $page = max(1, $request->request->getInt('page', 1));
+        if ($page > 1) {
+            $query['page'] = $page;
+        }
+
+        return $this->redirectToRoute('marketplace_index', $query);
     }
 
     #[Route('/reprocess', name: 'marketplace_reprocess', methods: ['POST'])]

--- a/site/templates/marketplace/index.html.twig
+++ b/site/templates/marketplace/index.html.twig
@@ -225,9 +225,16 @@
                                                 </div>
                                             </div>
                                             <div class="ms-auto">
-                                                <a href="{{ path('marketplace_raw_process_costs', {id: doc.id}) }}" class="btn btn-sm btn-warning">
-                                                    Обработать повторно
-                                                </a>
+                                                <form method="post" action="{{ path('marketplace_raw_process_costs', {id: doc.id}) }}" class="m-0">
+                                                    <input type="hidden" name="_token" value="{{ csrf_token('marketplace_raw_process_costs' ~ doc.id) }}">
+                                                    {% if selectedMarketplace is not null %}
+                                                        <input type="hidden" name="marketplace" value="{{ selectedMarketplace.value }}">
+                                                    {% endif %}
+                                                    <input type="hidden" name="page" value="{{ rawDocumentsPager.currentPage }}">
+                                                    <button type="submit" class="btn btn-sm btn-warning">
+                                                        Обработать повторно
+                                                    </button>
+                                                </form>
                                             </div>
                                         </div>
                                     </td>

--- a/site/tests/Unit/Marketplace/Controller/MarketplaceProcessCostsRouteTest.php
+++ b/site/tests/Unit/Marketplace/Controller/MarketplaceProcessCostsRouteTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Controller;
+
+use App\Marketplace\Controller\MarketplaceController;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class MarketplaceProcessCostsRouteTest extends TestCase
+{
+    public function testProcessCostsRouteExistsForRawDocumentsListAction(): void
+    {
+        $method = new \ReflectionMethod(MarketplaceController::class, 'processCosts');
+        $routes = $method->getAttributes(Route::class);
+
+        self::assertCount(1, $routes);
+
+        /** @var Route $route */
+        $route = $routes[0]->newInstance();
+
+        self::assertSame('/raw/{id}/process-costs', $route->getPath());
+        self::assertSame('marketplace_raw_process_costs', $route->getName());
+        self::assertSame(['POST'], $route->getMethods());
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a way to reprocess unrecognized costs from raw marketplace sales reports via the UI and background messaging pipeline.
- Ensure the new endpoint is protected by CSRF and limited to the owning company for safety.
- Keep the marketplace index pagination and marketplace filter when triggering reprocessing from the list.

### Description
- Added `processCosts` action to `MarketplaceController` at route `/marketplace/raw/{id}/process-costs` which validates ownership and CSRF and dispatches `ReprocessCostsMessage` to the message bus.
- Imported `App\Marketplace\Message\ReprocessCostsMessage` and added a helper `redirectToMarketplaceIndexFromRequest` to preserve `marketplace` and `page` parameters when redirecting back to the index.
- Replaced the costs reprocess link in `site/templates/marketplace/index.html.twig` with a POST form that includes a CSRF token and hidden `marketplace` and `page` fields.
- Added unit test `MarketplaceProcessCostsRouteTest` to verify the `processCosts` method has the expected route path, name, and HTTP method attributes.

### Testing
- Ran the new unit test `MarketplaceProcessCostsRouteTest` via `phpunit --filter MarketplaceProcessCostsRouteTest` and it succeeded.
- Ran the unit test suite to ensure no regressions in controller route attributes and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ea15c5b0083238008e268e5cbb093)