### PR TITLE
Enforce business-key idempotency for WB financial reports and single active exact-day raw documents

### DIFF
--- a/site/migrations/Version20260602120000.php
+++ b/site/migrations/Version20260602120000.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260602120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Enforce WB financial report business idempotency and one active exact-day sales_report raw per company/marketplace/date for all marketplaces';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $platform = $this->connection->getDatabasePlatform()->getName();
+        $this->abortIf(
+            $platform !== 'postgresql',
+            sprintf('Migration %s supports only PostgreSQL; got platform "%s".', self::class, $platform),
+        );
+
+        $duplicateStatusGroups = (int) $this->connection->fetchOne(<<<'SQL'
+            SELECT COUNT(*)
+            FROM (
+                SELECT 1
+                FROM marketplace_financial_report_sync_statuses
+                GROUP BY company_id, marketplace, report_type, business_date
+                HAVING COUNT(*) > 1
+            ) duplicate_groups
+        SQL);
+
+        $this->abortIf(
+            $duplicateStatusGroups > 0,
+            'Cannot create uniq_mfrss_company_marketplace_report_day: duplicate sync statuses exist for company/marketplace/report_type/business_date. Resolve them manually before migration.'
+        );
+
+        // Architecture decision: exact-day sales_report raw idempotency is shared by WB/Ozon
+        // and future marketplaces; marketplace remains part of the unique key.
+        $duplicateRawGroups = (int) $this->connection->fetchOne(<<<'SQL'
+            SELECT COUNT(*)
+            FROM (
+                SELECT 1
+                FROM marketplace_raw_documents
+                WHERE document_type = 'sales_report'
+                  AND period_from = period_to
+                  AND (processing_status IS NULL OR processing_status <> 'failed')
+                GROUP BY company_id, marketplace, document_type, period_from, period_to
+                HAVING COUNT(*) > 1
+            ) duplicate_groups
+        SQL);
+
+        $this->abortIf(
+            $duplicateRawGroups > 0,
+            'Cannot create uniq_mrd_active_sales_report_exact_day: active exact-day sales_report raw duplicates exist for company/marketplace/date. Resolve them manually before migration.'
+        );
+
+        $this->addSql('ALTER TABLE marketplace_financial_report_sync_statuses DROP CONSTRAINT IF EXISTS uniq_mfrss_connection_report_day');
+        $this->addSql('ALTER TABLE marketplace_financial_report_sync_statuses ADD CONSTRAINT uniq_mfrss_company_marketplace_report_day UNIQUE (company_id, marketplace, report_type, business_date)');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_mfrss_company_marketplace_date ON marketplace_financial_report_sync_statuses (company_id, marketplace, business_date)');
+
+        $this->addSql(<<<'SQL'
+            CREATE UNIQUE INDEX IF NOT EXISTS uniq_mrd_active_sales_report_exact_day
+            ON marketplace_raw_documents (company_id, marketplace, document_type, period_from, period_to)
+            WHERE document_type = 'sales_report'
+              AND period_from = period_to
+              AND (processing_status IS NULL OR processing_status <> 'failed')
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $platform = $this->connection->getDatabasePlatform()->getName();
+        $this->abortIf(
+            $platform !== 'postgresql',
+            sprintf('Migration %s supports only PostgreSQL; got platform "%s".', self::class, $platform),
+        );
+
+        $this->addSql('DROP INDEX IF EXISTS uniq_mrd_active_sales_report_exact_day');
+        $this->addSql('DROP INDEX IF EXISTS idx_mfrss_company_marketplace_date');
+        $this->addSql('ALTER TABLE marketplace_financial_report_sync_statuses DROP CONSTRAINT IF EXISTS uniq_mfrss_company_marketplace_report_day');
+        $this->addSql('ALTER TABLE marketplace_financial_report_sync_statuses ADD CONSTRAINT uniq_mfrss_connection_report_day UNIQUE (connection_id, report_type, business_date)');
+    }
+}

--- a/site/src/Marketplace/Application/Service/WbFinancialReportFirstAvailableResolver.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportFirstAvailableResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Marketplace\Application\Service;
 
 use App\Marketplace\Enum\FinancialReportSyncStatus;
+use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Exception\MarketplaceRateLimitException;
 use App\Marketplace\Infrastructure\Api\Wildberries\WbFinanceSalesReportClient;
 use App\Marketplace\Repository\MarketplaceFinancialReportSyncStatusRepository;
@@ -164,7 +165,7 @@ final class WbFinancialReportFirstAvailableResolver
         $positiveStatuses = [FinancialReportSyncStatus::SUCCESS, FinancialReportSyncStatus::RAW_LOADED, FinancialReportSyncStatus::PROCESSING];
 
         for ($day = $from; $day <= $to; $day = $day->modify('+1 day')->setTime(0, 0, 0)) {
-            $status = $this->syncStatusRepository->findStatusEnumByDay($connectionId, $companyId, $day, self::REPORT_TYPE);
+            $status = $this->syncStatusRepository->findStatusEnumByDay($connectionId, $companyId, MarketplaceType::WILDBERRIES, $day, self::REPORT_TYPE);
             if (\in_array($status, $positiveStatuses, true)) {
                 return $day;
             }

--- a/site/src/Marketplace/Application/Service/WbFinancialReportReconciliationService.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportReconciliationService.php
@@ -35,12 +35,10 @@ final class WbFinancialReportReconciliationService
         array $rows,
         bool $forceRefresh,
     ): MarketplaceRawDocument {
-        $existingDocuments = $this->rawDocumentRepository->findActiveExactPeriodDocuments(
+        $existingDocuments = $this->rawDocumentRepository->findActiveExactDayDocuments(
             $company,
             MarketplaceType::WILDBERRIES,
             self::DOCUMENT_TYPE,
-            self::API_ENDPOINT,
-            $businessDate,
             $businessDate,
         );
 

--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlanner.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlanner.php
@@ -60,6 +60,7 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
             $statuses = $this->syncStatusRepository->findStatusesForDateRange(
                 $connection['company_id'],
                 $connection['connection_id'],
+                MarketplaceType::WILDBERRIES,
                 self::REPORT_TYPE,
                 $from,
                 $to,
@@ -164,6 +165,7 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
             $retryItems = $this->syncStatusRepository->findRetryDueDays(
                 $connection['company_id'],
                 $connection['connection_id'],
+                MarketplaceType::WILDBERRIES,
                 self::REPORT_TYPE,
                 $from,
                 $to,
@@ -228,6 +230,7 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
             $statuses = $this->syncStatusRepository->findStatusesForDateRange(
                 $connection['company_id'],
                 $connection['connection_id'],
+                MarketplaceType::WILDBERRIES,
                 self::REPORT_TYPE,
                 $from,
                 $to,
@@ -241,6 +244,7 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
             $retryDueItems = $this->syncStatusRepository->findRetryDueDays(
                 $connection['company_id'],
                 $connection['connection_id'],
+                MarketplaceType::WILDBERRIES,
                 self::REPORT_TYPE,
                 $from,
                 $to,

--- a/site/src/Marketplace/Command/WbFinancialReportsReconcileLegacyCommand.php
+++ b/site/src/Marketplace/Command/WbFinancialReportsReconcileLegacyCommand.php
@@ -118,7 +118,7 @@ final class WbFinancialReportsReconcileLegacyCommand extends Command
             $created = 0;
             foreach ($connections as $conn) {
                 foreach ($days as $day) {
-                    $existing = $this->syncStatusRepository->findByConnectionAndDate($conn['connection_id'], $conn['company_id'], $day, self::REPORT_TYPE);
+                    $existing = $this->syncStatusRepository->findByBusinessDay($conn['company_id'], MarketplaceType::WILDBERRIES, self::REPORT_TYPE, $day);
                     if ($existing instanceof MarketplaceFinancialReportSyncStatus) {
                         ++$stats['already_status'];
 

--- a/site/src/Marketplace/Entity/MarketplaceFinancialReportSyncStatus.php
+++ b/site/src/Marketplace/Entity/MarketplaceFinancialReportSyncStatus.php
@@ -13,8 +13,9 @@ use Webmozart\Assert\Assert;
 
 #[ORM\Entity(repositoryClass: MarketplaceFinancialReportSyncStatusRepository::class)]
 #[ORM\Table(name: 'marketplace_financial_report_sync_statuses')]
-#[ORM\UniqueConstraint(name: 'uniq_mfrss_connection_report_day', columns: ['connection_id', 'report_type', 'business_date'])]
+#[ORM\UniqueConstraint(name: 'uniq_mfrss_company_marketplace_report_day', columns: ['company_id', 'marketplace', 'report_type', 'business_date'])]
 #[ORM\Index(name: 'idx_mfrss_company_connection_date', columns: ['company_id', 'connection_id', 'business_date'])]
+#[ORM\Index(name: 'idx_mfrss_company_marketplace_date', columns: ['company_id', 'marketplace', 'business_date'])]
 class MarketplaceFinancialReportSyncStatus
 {
     #[ORM\Id]
@@ -154,6 +155,19 @@ class MarketplaceFinancialReportSyncStatus
     public function getLastErrorResponseExcerpt(): ?string { return $this->lastErrorResponseExcerpt; }
     public function getCreatedAt(): \DateTimeImmutable { return $this->createdAt; }
     public function getUpdatedAt(): \DateTimeImmutable { return $this->updatedAt; }
+
+    public function updateTechnicalContext(string $connectionId, string $apiEndpoint): void
+    {
+        Assert::uuid($connectionId);
+
+        if ($this->connectionId === $connectionId && $this->apiEndpoint === $apiEndpoint) {
+            return;
+        }
+
+        $this->connectionId = $connectionId;
+        $this->apiEndpoint = $apiEndpoint;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
 
     public function markQueued(FinancialReportSyncMode $mode, bool $forceRefresh): void
     {

--- a/site/src/Marketplace/MessageHandler/SyncWbFinancialReportDayHandler.php
+++ b/site/src/Marketplace/MessageHandler/SyncWbFinancialReportDayHandler.php
@@ -61,7 +61,7 @@ final class SyncWbFinancialReportDayHandler
         $mode = FinancialReportSyncMode::from($message->mode);
 
         $lock = $this->lockFactory->createLock(
-            sprintf('marketplace_wb_day_sync:%s:%s:%s', $message->companyId, $message->connectionId, $businessDate->format('Y-m-d')),
+            sprintf('marketplace_financial_report_sync:%s:%s:%s:%s', $message->companyId, MarketplaceType::WILDBERRIES->value, self::REPORT_TYPE, $businessDate->format('Y-m-d')),
             self::LOCK_TTL_SECONDS,
         );
 

--- a/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusLookupInterface.php
+++ b/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusLookupInterface.php
@@ -43,6 +43,7 @@ interface MarketplaceFinancialReportSyncStatusLookupInterface
     public function findStatusEnumByDay(
         string $connectionId,
         string $companyId,
+        MarketplaceType $marketplace,
         \DateTimeImmutable $businessDate,
         string $reportType,
     ): ?FinancialReportSyncStatus;
@@ -53,6 +54,7 @@ interface MarketplaceFinancialReportSyncStatusLookupInterface
     public function findStatusesForDateRange(
         string $companyId,
         string $connectionId,
+        MarketplaceType $marketplace,
         string $reportType,
         \DateTimeImmutable $from,
         \DateTimeImmutable $to,
@@ -64,6 +66,7 @@ interface MarketplaceFinancialReportSyncStatusLookupInterface
     public function findRetryDueDays(
         string $companyId,
         string $connectionId,
+        MarketplaceType $marketplace,
         string $reportType,
         \DateTimeImmutable $from,
         \DateTimeImmutable $to,

--- a/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepository.php
+++ b/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepository.php
@@ -18,6 +18,8 @@ use Webmozart\Assert\Assert;
 
 final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntityRepository implements MarketplaceFinancialReportSyncStatusLookupInterface
 {
+    private const ADVISORY_LOCK_NAMESPACE = 'marketplace_financial_report_sync';
+
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, MarketplaceFinancialReportSyncStatus::class);
@@ -28,22 +30,21 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
         $this->getEntityManager()->persist($syncStatus);
     }
 
-    public function findByConnectionAndDate(
-        string $connectionId,
+    public function findByBusinessDay(
         string $companyId,
-        \DateTimeImmutable $businessDate,
+        MarketplaceType $marketplace,
         string $reportType,
+        \DateTimeImmutable $businessDate,
     ): ?MarketplaceFinancialReportSyncStatus {
-        Assert::uuid($connectionId);
         Assert::uuid($companyId);
 
         return $this->createQueryBuilder('s')
-            ->where('s.connectionId = :connectionId')
-            ->andWhere('s.companyId = :companyId')
+            ->where('s.companyId = :companyId')
+            ->andWhere('s.marketplace = :marketplace')
             ->andWhere('s.businessDate = :businessDate')
             ->andWhere('s.reportType = :reportType')
-            ->setParameter('connectionId', $connectionId)
             ->setParameter('companyId', $companyId)
+            ->setParameter('marketplace', $marketplace)
             ->setParameter('businessDate', $businessDate)
             ->setParameter('reportType', $reportType)
             ->setMaxResults(1)
@@ -54,6 +55,7 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
     public function findStatusEnumByDay(
         string $connectionId,
         string $companyId,
+        MarketplaceType $marketplace,
         \DateTimeImmutable $businessDate,
         string $reportType,
     ): ?FinancialReportSyncStatus {
@@ -62,12 +64,12 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
 
         $status = $this->createQueryBuilder('s')
             ->select('s.status')
-            ->where('s.connectionId = :connectionId')
-            ->andWhere('s.companyId = :companyId')
+            ->where('s.companyId = :companyId')
+            ->andWhere('s.marketplace = :marketplace')
             ->andWhere('s.businessDate = :businessDate')
             ->andWhere('s.reportType = :reportType')
-            ->setParameter('connectionId', $connectionId)
             ->setParameter('companyId', $companyId)
+            ->setParameter('marketplace', $marketplace)
             ->setParameter('businessDate', $businessDate)
             ->setParameter('reportType', $reportType)
             ->setMaxResults(1)
@@ -95,6 +97,7 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
     public function findStatusesForDateRange(
         string $companyId,
         string $connectionId,
+        MarketplaceType $marketplace,
         string $reportType,
         \DateTimeImmutable $from,
         \DateTimeImmutable $to,
@@ -104,11 +107,11 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
 
         return $this->createQueryBuilder('s')
             ->where('s.companyId = :companyId')
-            ->andWhere('s.connectionId = :connectionId')
+            ->andWhere('s.marketplace = :marketplace')
             ->andWhere('s.reportType = :reportType')
             ->andWhere('s.businessDate BETWEEN :from AND :to')
             ->setParameter('companyId', $companyId)
-            ->setParameter('connectionId', $connectionId)
+            ->setParameter('marketplace', $marketplace)
             ->setParameter('reportType', $reportType)
             ->setParameter('from', $from)
             ->setParameter('to', $to)
@@ -123,6 +126,7 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
     public function findRetryDueDays(
         string $companyId,
         string $connectionId,
+        MarketplaceType $marketplace,
         string $reportType,
         \DateTimeImmutable $from,
         \DateTimeImmutable $to,
@@ -139,7 +143,7 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
         $rows = $this->createQueryBuilder('s')
             ->select('s.businessDate', 's.mode')
             ->where('s.companyId = :companyId')
-            ->andWhere('s.connectionId = :connectionId')
+            ->andWhere('s.marketplace = :marketplace')
             ->andWhere('s.reportType = :reportType')
             ->andWhere('s.businessDate BETWEEN :from AND :to')
             ->andWhere('(
@@ -148,7 +152,7 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
                 OR (s.status = :failedStatus AND s.nextRetryAt IS NULL AND s.lastErrorStatusCode = :rateLimitStatusCode AND s.lastErrorClass = :rateLimitErrorClass)
             )')
             ->setParameter('companyId', $companyId)
-            ->setParameter('connectionId', $connectionId)
+            ->setParameter('marketplace', $marketplace)
             ->setParameter('reportType', $reportType)
             ->setParameter('from', $from)
             ->setParameter('to', $to)
@@ -201,12 +205,15 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
 
         try {
             $em->beginTransaction();
+            $this->acquireBusinessDayAdvisoryLock($companyId, $marketplace, $reportType, $businessDate);
 
             $syncStatus = $this->createQueryBuilder('s')
-                ->where('s.connectionId = :connectionId')
+                ->where('s.companyId = :companyId')
+                ->andWhere('s.marketplace = :marketplace')
                 ->andWhere('s.businessDate = :businessDate')
                 ->andWhere('s.reportType = :reportType')
-                ->setParameter('connectionId', $connectionId)
+                ->setParameter('companyId', $companyId)
+                ->setParameter('marketplace', $marketplace)
                 ->setParameter('businessDate', $businessDate)
                 ->setParameter('reportType', $reportType)
                 ->setMaxResults(1)
@@ -226,10 +233,14 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
                 );
 
                 $em->persist($syncStatus);
-            } elseif (!$this->canClaimForQueue($syncStatus, $mode, $forceRefresh, $now)) {
-                $em->commit();
+            } else {
+                if (!$this->canClaimForQueue($syncStatus, $mode, $forceRefresh, $now)) {
+                    $em->commit();
 
-                return null;
+                    return null;
+                }
+
+                $syncStatus->updateTechnicalContext($connectionId, $apiEndpoint);
             }
 
             $syncStatus->markQueued($mode, $forceRefresh);
@@ -352,7 +363,6 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
             return $this->createQueryBuilder('s')
                 ->where('s.id = :syncStatusId')
                 ->andWhere('s.companyId = :companyId')
-                ->andWhere('s.connectionId = :connectionId')
                 ->andWhere('s.marketplace = :marketplace')
                 ->andWhere('s.reportType = :reportType')
                 ->andWhere('s.mode = :mode')
@@ -360,7 +370,6 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
                 ->andWhere('s.rawDocumentId = :rawDocumentId')
                 ->setParameter('syncStatusId', $syncStatusId)
                 ->setParameter('companyId', $companyId)
-                ->setParameter('connectionId', $connectionId)
                 ->setParameter('marketplace', $marketplace)
                 ->setParameter('reportType', $reportType)
                 ->setParameter('mode', $mode)
@@ -373,14 +382,12 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
 
         return $this->createQueryBuilder('s')
             ->where('s.companyId = :companyId')
-            ->andWhere('s.connectionId = :connectionId')
             ->andWhere('s.marketplace = :marketplace')
             ->andWhere('s.reportType = :reportType')
             ->andWhere('s.mode = :mode')
             ->andWhere('s.businessDate = :businessDate')
             ->andWhere('s.rawDocumentId = :rawDocumentId')
             ->setParameter('companyId', $companyId)
-            ->setParameter('connectionId', $connectionId)
             ->setParameter('marketplace', $marketplace)
             ->setParameter('reportType', $reportType)
             ->setParameter('mode', $mode)
@@ -402,35 +409,78 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
         Assert::uuid($connectionId);
         Assert::uuid($companyId);
 
-        $syncStatus = $this->createQueryBuilder('s')
-            ->where('s.connectionId = :connectionId')
-            ->andWhere('s.companyId = :companyId')
-            ->andWhere('s.businessDate = :businessDate')
-            ->andWhere('s.reportType = :reportType')
-            ->setParameter('connectionId', $connectionId)
-            ->setParameter('companyId', $companyId)
-            ->setParameter('businessDate', $businessDate)
-            ->setParameter('reportType', $reportType)
-            ->setMaxResults(1)
-            ->getQuery()
-            ->getOneOrNullResult();
+        $em = $this->getEntityManager();
 
-        if ($syncStatus instanceof MarketplaceFinancialReportSyncStatus) {
+        try {
+            $em->beginTransaction();
+            $this->acquireBusinessDayAdvisoryLock($companyId, $marketplace, $reportType, $businessDate);
+
+            $syncStatus = $this->findByBusinessDay($companyId, $marketplace, $reportType, $businessDate);
+            if ($syncStatus instanceof MarketplaceFinancialReportSyncStatus) {
+                $syncStatus->updateTechnicalContext($connectionId, $apiEndpoint);
+                $em->persist($syncStatus);
+                $em->flush();
+                $em->commit();
+
+                return $syncStatus;
+            }
+
+            $syncStatus = new MarketplaceFinancialReportSyncStatus(
+                Uuid::uuid7()->toString(),
+                $companyId,
+                $connectionId,
+                $marketplace,
+                $reportType,
+                $apiEndpoint,
+                $businessDate,
+            );
+
+            $em->persist($syncStatus);
+            $em->flush();
+            $em->commit();
+
             return $syncStatus;
+        } catch (UniqueConstraintViolationException $e) {
+            if ($em->getConnection()->isTransactionActive()) {
+                $em->rollback();
+            }
+
+            $syncStatus = $this->findByBusinessDay($companyId, $marketplace, $reportType, $businessDate);
+            if ($syncStatus instanceof MarketplaceFinancialReportSyncStatus) {
+                $syncStatus->updateTechnicalContext($connectionId, $apiEndpoint);
+                $this->save($syncStatus);
+
+                return $syncStatus;
+            }
+
+            throw $e;
+        } catch (\Throwable $e) {
+            if ($em->getConnection()->isTransactionActive()) {
+                $em->rollback();
+            }
+
+            throw $e;
         }
+    }
 
-        $syncStatus = new MarketplaceFinancialReportSyncStatus(
-            Uuid::uuid7()->toString(),
-            $companyId,
-            $connectionId,
-            $marketplace,
-            $reportType,
-            $apiEndpoint,
-            $businessDate,
+    private function acquireBusinessDayAdvisoryLock(
+        string $companyId,
+        MarketplaceType $marketplace,
+        string $reportType,
+        \DateTimeImmutable $businessDate,
+    ): void {
+        $this->getEntityManager()->getConnection()->executeStatement(
+            'SELECT pg_advisory_xact_lock(hashtext(:namespace), hashtext(:business_key))',
+            [
+                'namespace' => self::ADVISORY_LOCK_NAMESPACE,
+                'business_key' => sprintf(
+                    '%s:%s:%s:%s',
+                    $companyId,
+                    $marketplace->value,
+                    $reportType,
+                    $businessDate->format('Y-m-d'),
+                ),
+            ],
         );
-
-        $this->save($syncStatus);
-
-        return $syncStatus;
     }
 }

--- a/site/src/Marketplace/Repository/MarketplaceRawDocumentRepository.php
+++ b/site/src/Marketplace/Repository/MarketplaceRawDocumentRepository.php
@@ -21,7 +21,8 @@ class MarketplaceRawDocumentRepository extends ServiceEntityRepository
 
     /**
      * Deterministic lookup for daily sync: returns all exact-day active documents
-     * (processingStatus is null or not FAILED) sorted by newest first.
+     * (processingStatus is null or not FAILED) in canonical order:
+     * completed first, then COALESCE(processedAt, syncedAt) DESC, then id DESC.
      *
      * @return list<MarketplaceRawDocument>
      */
@@ -32,6 +33,8 @@ class MarketplaceRawDocumentRepository extends ServiceEntityRepository
         \DateTimeImmutable $day,
     ): array {
         return $this->createQueryBuilder('d')
+            ->addSelect('CASE WHEN d.processingStatus = :completed THEN 0 ELSE 1 END AS HIDDEN completed_rank')
+            ->addSelect('COALESCE(d.processedAt, d.syncedAt) AS HIDDEN canonical_at')
             ->where('d.company = :company')
             ->andWhere('d.marketplace = :marketplace')
             ->andWhere('d.documentType = :documentType')
@@ -43,7 +46,9 @@ class MarketplaceRawDocumentRepository extends ServiceEntityRepository
             ->setParameter('documentType', $documentType)
             ->setParameter('day', $day)
             ->setParameter('failed', PipelineStatus::FAILED)
-            ->orderBy('d.syncedAt', 'DESC')
+            ->setParameter('completed', PipelineStatus::COMPLETED)
+            ->orderBy('completed_rank', 'ASC')
+            ->addOrderBy('canonical_at', 'DESC')
             ->addOrderBy('d.id', 'DESC')
             ->getQuery()
             ->getResult();

--- a/site/tests/Integration/Marketplace/Application/Service/WbFinancialReportSyncStatusUpdaterTest.php
+++ b/site/tests/Integration/Marketplace/Application/Service/WbFinancialReportSyncStatusUpdaterTest.php
@@ -9,6 +9,7 @@ use App\Marketplace\Entity\MarketplaceFinancialReportSyncError;
 use App\Marketplace\Entity\MarketplaceFinancialReportSyncStatus;
 use App\Marketplace\Enum\FinancialReportSyncMode;
 use App\Marketplace\Enum\FinancialReportSyncStatus;
+use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Repository\MarketplaceFinancialReportSyncErrorRepository;
 use App\Marketplace\Repository\MarketplaceFinancialReportSyncStatusRepository;
 use App\Tests\Support\Kernel\IntegrationTestCase;
@@ -250,33 +251,22 @@ final class WbFinancialReportSyncStatusUpdaterTest extends IntegrationTestCase
     }
 
 
-    public function testSyncByRawPipelineResultUsesExactContextWhenRawDocumentIsSharedByConnections(): void
+    public function testSyncByRawPipelineResultUsesBusinessContextWithoutConnectionIdPredicate(): void
     {
         $rawId = $this->rawId();
-        $otherConnectionId = '00000000-0000-0000-0000-000000000222';
-        $targetConnectionId = '00000000-0000-0000-0000-000000000333';
+        $oldConnectionId = '00000000-0000-0000-0000-000000000222';
+        $newConnectionId = '00000000-0000-0000-0000-000000000333';
 
-        $otherStatus = $this->updater->startLoading(
-            $otherConnectionId,
+        $status = $this->updater->startLoading(
+            $oldConnectionId,
             $this->companyId(),
             'sales_report',
             'wildberries::finance-sales-reports-detailed',
             $this->businessDate(),
             FinancialReportSyncMode::INITIAL,
         );
-        $this->updater->markRawLoaded($otherStatus, $rawId, 10, 'same-raw');
-        $this->updater->markProcessing($otherStatus);
-
-        $targetStatus = $this->updater->startLoading(
-            $targetConnectionId,
-            $this->companyId(),
-            'sales_report',
-            'wildberries::finance-sales-reports-detailed',
-            $this->businessDate(),
-            FinancialReportSyncMode::INITIAL,
-        );
-        $this->updater->markRawLoaded($targetStatus, $rawId, 10, 'same-raw');
-        $this->updater->markProcessing($targetStatus);
+        $this->updater->markRawLoaded($status, $rawId, 10, 'same-raw');
+        $this->updater->markProcessing($status);
         $this->em->flush();
 
         $company = $this->em->getReference(
@@ -292,9 +282,9 @@ final class WbFinancialReportSyncStatusUpdaterTest extends IntegrationTestCase
         $raw->markCompleted();
 
         $this->updater->syncByRawPipelineResult($raw, null, [
-            'sync_status_id' => $targetStatus->getId(),
+            'sync_status_id' => $status->getId(),
             'company_id' => $this->companyId(),
-            'connection_id' => $targetConnectionId,
+            'connection_id' => $newConnectionId,
             'marketplace' => \App\Marketplace\Enum\MarketplaceType::WILDBERRIES->value,
             'report_type' => 'sales_report',
             'mode' => FinancialReportSyncMode::INITIAL->value,
@@ -304,13 +294,12 @@ final class WbFinancialReportSyncStatusUpdaterTest extends IntegrationTestCase
         $this->em->flush();
         $this->em->clear();
 
-        $otherPersisted = $this->statusRepository->findByConnectionAndDate($otherConnectionId, $this->companyId(), $this->businessDate(), 'sales_report');
-        $targetPersisted = $this->statusRepository->findByConnectionAndDate($targetConnectionId, $this->companyId(), $this->businessDate(), 'sales_report');
+        $persisted = $this->statusRepository->findByBusinessDay($this->companyId(), MarketplaceType::WILDBERRIES, 'sales_report', $this->businessDate());
 
-        self::assertNotNull($otherPersisted);
-        self::assertNotNull($targetPersisted);
-        self::assertSame(FinancialReportSyncStatus::PROCESSING, $otherPersisted->getStatus());
-        self::assertSame(FinancialReportSyncStatus::SUCCESS, $targetPersisted->getStatus());
+        self::assertNotNull($persisted);
+        self::assertSame($status->getId(), $persisted->getId());
+        self::assertSame(FinancialReportSyncStatus::SUCCESS, $persisted->getStatus());
+        self::assertSame($oldConnectionId, $persisted->getConnectionId());
     }
 
     private function startLoadingStatus(): MarketplaceFinancialReportSyncStatus
@@ -327,11 +316,11 @@ final class WbFinancialReportSyncStatusUpdaterTest extends IntegrationTestCase
 
     private function findStatus(): ?MarketplaceFinancialReportSyncStatus
     {
-        return $this->statusRepository->findByConnectionAndDate(
-            $this->connectionId(),
+        return $this->statusRepository->findByBusinessDay(
             $this->companyId(),
-            $this->businessDate(),
+            MarketplaceType::WILDBERRIES,
             'sales',
+            $this->businessDate(),
         );
     }
 

--- a/site/tests/Integration/Marketplace/MarketplaceRawDocumentRepositoryTest.php
+++ b/site/tests/Integration/Marketplace/MarketplaceRawDocumentRepositoryTest.php
@@ -143,5 +143,98 @@ final class MarketplaceRawDocumentRepositoryTest extends IntegrationTestCase
         self::assertSame('22222222-2222-2222-2222-000000000002', $single->getId());
     }
 
+    public function testFindActiveExactDayDocumentsIgnoresEndpointAndOrdersCompletedCanonicalFirst(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+        $this->em->persist($company);
+        $day = new \DateTimeImmutable('2026-04-02');
+
+        $pendingNewest = MarketplaceRawDocumentBuilder::aDocument()
+            ->forCompany($company)
+            ->withMarketplace(MarketplaceType::WILDBERRIES)
+            ->withPeriod($day, $day)
+            ->withApiEndpoint('wildberries::new-endpoint')
+            ->withIndex(10)
+            ->build();
+        $pendingNewest->resetProcessingStatus();
+        $this->forceDateTime($pendingNewest, 'syncedAt', new \DateTimeImmutable('2026-04-02 12:00:00'));
+        $this->em->persist($pendingNewest);
+
+        $completedOlder = MarketplaceRawDocumentBuilder::aDocument()
+            ->forCompany($company)
+            ->withMarketplace(MarketplaceType::WILDBERRIES)
+            ->withPeriod($day, $day)
+            ->withApiEndpoint('wildberries::old-endpoint')
+            ->withIndex(11)
+            ->build();
+        $completedOlder->markCompleted();
+        $this->forceDateTime($completedOlder, 'processedAt', new \DateTimeImmutable('2026-04-02 10:00:00'));
+        $this->forceDateTime($completedOlder, 'syncedAt', new \DateTimeImmutable('2026-04-02 10:00:00'));
+        $this->em->persist($completedOlder);
+
+        $failed = MarketplaceRawDocumentBuilder::aDocument()
+            ->forCompany($company)
+            ->withMarketplace(MarketplaceType::WILDBERRIES)
+            ->withPeriod($day, $day)
+            ->withApiEndpoint('wildberries::failed-endpoint')
+            ->withIndex(12)
+            ->build();
+        $failed->markFailed();
+        $this->em->persist($failed);
+
+        $this->em->flush();
+
+        /** @var MarketplaceRawDocumentRepository $repository */
+        $repository = self::getContainer()->get(MarketplaceRawDocumentRepository::class);
+        $documents = $repository->findActiveExactDayDocuments(
+            $company,
+            MarketplaceType::WILDBERRIES,
+            'sales_report',
+            $day,
+        );
+
+        self::assertCount(2, $documents);
+        self::assertSame($completedOlder->getId(), $documents[0]->getId());
+        self::assertSame($pendingNewest->getId(), $documents[1]->getId());
+    }
+
+
+    public function testActiveCompletedExactDaySalesReportRawDuplicatesAreRejectedByDatabase(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+        $this->em->persist($company);
+        $day = new \DateTimeImmutable('2026-04-03');
+
+        $first = MarketplaceRawDocumentBuilder::aDocument()
+            ->forCompany($company)
+            ->withMarketplace(MarketplaceType::WILDBERRIES)
+            ->withPeriod($day, $day)
+            ->withApiEndpoint('wildberries::first')
+            ->withIndex(20)
+            ->build();
+        $first->markCompleted();
+        $this->em->persist($first);
+
+        $second = MarketplaceRawDocumentBuilder::aDocument()
+            ->forCompany($company)
+            ->withMarketplace(MarketplaceType::WILDBERRIES)
+            ->withPeriod($day, $day)
+            ->withApiEndpoint('wildberries::second')
+            ->withIndex(21)
+            ->build();
+        $second->markCompleted();
+        $this->em->persist($second);
+
+        $this->expectException(\Doctrine\DBAL\Exception\UniqueConstraintViolationException::class);
+        $this->em->flush();
+    }
+
+    private function forceDateTime(object $object, string $property, \DateTimeImmutable $value): void
+    {
+        $reflection = new \ReflectionProperty($object, $property);
+        $reflection->setAccessible(true);
+        $reflection->setValue($object, $value);
+    }
+
 }
 

--- a/site/tests/Integration/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepositoryTest.php
+++ b/site/tests/Integration/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepositoryTest.php
@@ -46,12 +46,12 @@ final class MarketplaceFinancialReportSyncStatusRepositoryTest extends Integrati
         $otherConnectionId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
         $this->seedActiveConnection($otherCompanyId, $otherConnectionId);
         $this->persistStatus($otherCompanyId, $connectionId, '2026-01-01', FinancialReportSyncStatus::FAILED, null);
-        $this->persistStatus($companyId, $otherConnectionId, '2026-01-01', FinancialReportSyncStatus::FAILED, null);
         $this->persistStatus($companyId, $connectionId, '2026-01-08', FinancialReportSyncStatus::FAILED, null, 'another_report');
 
         $days = $this->repository->findRetryDueDays(
             $companyId,
             $connectionId,
+            MarketplaceType::WILDBERRIES,
             self::REPORT_TYPE,
             new \DateTimeImmutable('2026-01-01 00:00:00'),
             new \DateTimeImmutable('2026-01-10 00:00:00'),
@@ -80,11 +80,11 @@ final class MarketplaceFinancialReportSyncStatusRepositoryTest extends Integrati
         $otherConnectionId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
         $this->seedActiveConnection($otherCompanyId, $otherConnectionId);
         $this->persistStatus($otherCompanyId, $connectionId, '2026-01-02', FinancialReportSyncStatus::FAILED);
-        $this->persistStatus($companyId, $otherConnectionId, '2026-01-02', FinancialReportSyncStatus::FAILED);
 
         $statuses = $this->repository->findStatusesForDateRange(
             $companyId,
             $connectionId,
+            MarketplaceType::WILDBERRIES,
             self::REPORT_TYPE,
             new \DateTimeImmutable('2026-01-01 00:00:00'),
             new \DateTimeImmutable('2026-01-03 23:59:59'),
@@ -168,7 +168,7 @@ final class MarketplaceFinancialReportSyncStatusRepositoryTest extends Integrati
         $now = new \DateTimeImmutable('2026-01-05 12:00:00');
 
         $this->persistStatus($companyId, $retryConnectionId, '2026-01-01', FinancialReportSyncStatus::FAILED, new \DateTimeImmutable('2026-01-05 13:00:00'));
-        $this->persistStatus($companyId, $terminalConnectionId, '2026-01-01', FinancialReportSyncStatus::AUTH_FAILED);
+        $this->persistStatus($companyId, $terminalConnectionId, '2026-01-02', FinancialReportSyncStatus::AUTH_FAILED);
 
         self::assertNull($this->repository->claimForQueue(
             $retryConnectionId,
@@ -187,7 +187,7 @@ final class MarketplaceFinancialReportSyncStatusRepositoryTest extends Integrati
             MarketplaceType::WILDBERRIES,
             self::REPORT_TYPE,
             'endpoint',
-            new \DateTimeImmutable('2026-01-01 00:00:00'),
+            new \DateTimeImmutable('2026-01-02 00:00:00'),
             FinancialReportSyncMode::DAILY,
             true,
             $now,
@@ -199,7 +199,7 @@ final class MarketplaceFinancialReportSyncStatusRepositoryTest extends Integrati
             MarketplaceType::WILDBERRIES,
             self::REPORT_TYPE,
             'endpoint',
-            new \DateTimeImmutable('2026-01-01 00:00:00'),
+            new \DateTimeImmutable('2026-01-02 00:00:00'),
             FinancialReportSyncMode::MANUAL,
             true,
             $now,
@@ -208,6 +208,134 @@ final class MarketplaceFinancialReportSyncStatusRepositoryTest extends Integrati
         self::assertInstanceOf(MarketplaceFinancialReportSyncStatus::class, $status);
         self::assertSame(FinancialReportSyncStatus::QUEUED, $status->getStatus());
         self::assertSame(FinancialReportSyncMode::MANUAL, $status->getMode());
+    }
+
+
+    public function testFindByBusinessDayIgnoresConnectionAndReturnsCanonicalStatus(): void
+    {
+        $companyId = '11111111-1111-1111-1111-111111111111';
+        $oldConnectionId = '22222222-2222-4222-8222-222222222222';
+        $this->seedActiveConnection($companyId, $oldConnectionId);
+        $this->persistStatus($companyId, $oldConnectionId, '2026-01-09', FinancialReportSyncStatus::SUCCESS);
+
+        $status = $this->repository->findByBusinessDay(
+            $companyId,
+            MarketplaceType::WILDBERRIES,
+            self::REPORT_TYPE,
+            new \DateTimeImmutable('2026-01-09 00:00:00'),
+        );
+
+        self::assertNotNull($status);
+        self::assertSame($oldConnectionId, $status->getConnectionId());
+        self::assertSame('2026-01-09', $status->getBusinessDate()->format('Y-m-d'));
+    }
+
+    public function testRejectedClaimDoesNotMutateConnectionId(): void
+    {
+        $companyId = '11111111-1111-1111-1111-111111111111';
+        $oldConnectionId = '22222222-2222-4222-8222-222222222222';
+        $newConnectionId = '33333333-3333-4333-8333-333333333333';
+        $this->seedActiveConnection($companyId, $oldConnectionId);
+        $this->seedConnectionForExistingCompany($companyId, $newConnectionId);
+        $this->persistStatus($companyId, $oldConnectionId, '2026-01-10', FinancialReportSyncStatus::PROCESSING);
+
+        $claimed = $this->repository->claimForQueue(
+            $newConnectionId,
+            $companyId,
+            MarketplaceType::WILDBERRIES,
+            self::REPORT_TYPE,
+            'new-endpoint',
+            new \DateTimeImmutable('2026-01-10 00:00:00'),
+            FinancialReportSyncMode::REFRESH_14D,
+            true,
+            new \DateTimeImmutable('2026-01-10 12:00:00'),
+        );
+        $this->em->clear();
+
+        $status = $this->repository->findByBusinessDay(
+            $companyId,
+            MarketplaceType::WILDBERRIES,
+            self::REPORT_TYPE,
+            new \DateTimeImmutable('2026-01-10 00:00:00'),
+        );
+
+        self::assertNull($claimed);
+        self::assertNotNull($status);
+        self::assertSame($oldConnectionId, $status->getConnectionId());
+        self::assertSame(FinancialReportSyncStatus::PROCESSING, $status->getStatus());
+    }
+
+    public function testRefreshClaimReusesDailySuccessBusinessStatus(): void
+    {
+        $companyId = '11111111-1111-1111-1111-111111111111';
+        $oldConnectionId = '22222222-2222-4222-8222-222222222222';
+        $newConnectionId = '33333333-3333-4333-8333-333333333333';
+        $this->seedActiveConnection($companyId, $oldConnectionId);
+        $this->seedConnectionForExistingCompany($companyId, $newConnectionId);
+        $this->persistStatus($companyId, $oldConnectionId, '2026-01-11', FinancialReportSyncStatus::SUCCESS);
+
+        $claimed = $this->repository->claimForQueue(
+            $newConnectionId,
+            $companyId,
+            MarketplaceType::WILDBERRIES,
+            self::REPORT_TYPE,
+            'new-endpoint',
+            new \DateTimeImmutable('2026-01-11 00:00:00'),
+            FinancialReportSyncMode::REFRESH_14D,
+            true,
+            new \DateTimeImmutable('2026-01-11 12:00:00'),
+        );
+        $this->em->flush();
+
+        self::assertNotNull($claimed);
+        self::assertSame($newConnectionId, $claimed->getConnectionId());
+        self::assertSame(FinancialReportSyncMode::REFRESH_14D, $claimed->getMode());
+
+        $count = (int) $this->em->getConnection()->fetchOne(
+            'SELECT COUNT(*) FROM marketplace_financial_report_sync_statuses WHERE company_id = :companyId AND marketplace = :marketplace AND report_type = :reportType AND business_date = :businessDate',
+            [
+                'companyId' => $companyId,
+                'marketplace' => MarketplaceType::WILDBERRIES->value,
+                'reportType' => self::REPORT_TYPE,
+                'businessDate' => '2026-01-11',
+            ],
+        );
+        self::assertSame(1, $count);
+    }
+
+
+    public function testFindOrCreateForDayReusesCanonicalBusinessStatusWithNewConnection(): void
+    {
+        $companyId = '11111111-1111-1111-1111-111111111111';
+        $oldConnectionId = '22222222-2222-4222-8222-222222222222';
+        $newConnectionId = '33333333-3333-4333-8333-333333333333';
+        $this->seedActiveConnection($companyId, $oldConnectionId);
+        $this->seedConnectionForExistingCompany($companyId, $newConnectionId);
+        $this->persistStatus($companyId, $oldConnectionId, '2026-01-12', FinancialReportSyncStatus::SUCCESS);
+
+        $status = $this->repository->findOrCreateForDay(
+            $newConnectionId,
+            $companyId,
+            MarketplaceType::WILDBERRIES,
+            self::REPORT_TYPE,
+            'new-endpoint',
+            new \DateTimeImmutable('2026-01-12 00:00:00'),
+        );
+        $this->em->flush();
+
+        self::assertSame($newConnectionId, $status->getConnectionId());
+        self::assertSame('new-endpoint', $status->getApiEndpoint());
+
+        $count = (int) $this->em->getConnection()->fetchOne(
+            'SELECT COUNT(*) FROM marketplace_financial_report_sync_statuses WHERE company_id = :companyId AND marketplace = :marketplace AND report_type = :reportType AND business_date = :businessDate',
+            [
+                'companyId' => $companyId,
+                'marketplace' => MarketplaceType::WILDBERRIES->value,
+                'reportType' => self::REPORT_TYPE,
+                'businessDate' => '2026-01-12',
+            ],
+        );
+        self::assertSame(1, $count);
     }
 
     private function persistStatus(

--- a/site/tests/Integration/Marketplace/WbFinancialReportSyncIdempotencyTest.php
+++ b/site/tests/Integration/Marketplace/WbFinancialReportSyncIdempotencyTest.php
@@ -204,6 +204,90 @@ final class WbFinancialReportSyncIdempotencyTest extends IntegrationTestCase
         self::assertSame('success', $this->statusValue($company->getId(), $connection->getId(), '2026-05-19'));
     }
 
+
+    public function testClaimExistingBusinessDayUpdatesConnectionWithoutCreatingDuplicateStatus(): void
+    {
+        [$company, $oldConnection] = $this->createCompanyAndConnection(309);
+        $newConnectionId = 'bbbbbbbb-bbbb-4bbb-8bbb-000000000310';
+
+        $repo = self::getContainer()->get(MarketplaceFinancialReportSyncStatusRepository::class);
+        $existing = $this->newStatus($company->getId(), $oldConnection->getId(), '2026-05-31');
+        $existing->markSuccess();
+        $repo->save($existing);
+        $this->em->flush();
+
+        $claimed = $repo->claimForQueue(
+            $newConnectionId,
+            $company->getId(),
+            MarketplaceType::WILDBERRIES,
+            'sales_report',
+            'wildberries::finance-sales-reports-detailed',
+            new \DateTimeImmutable('2026-05-31'),
+            FinancialReportSyncMode::REFRESH_14D,
+            true,
+            new \DateTimeImmutable('2026-06-01 12:00:00'),
+        );
+        $this->em->flush();
+
+        self::assertNotNull($claimed);
+        self::assertSame($existing->getId(), $claimed->getId());
+        self::assertSame(1, $this->countStatusesByBusinessDay($company->getId(), '2026-05-31'));
+        self::assertSame($newConnectionId, $claimed->getConnectionId());
+    }
+
+    public function testSequentialClaimsWithDifferentConnectionsReuseCanonicalBusinessStatus(): void
+    {
+        [$company, $firstConnection] = $this->createCompanyAndConnection(311);
+        $secondConnectionId = 'bbbbbbbb-bbbb-4bbb-8bbb-000000000312';
+
+        $repo = self::getContainer()->get(MarketplaceFinancialReportSyncStatusRepository::class);
+        $firstClaim = $repo->claimForQueue(
+            $firstConnection->getId(),
+            $company->getId(),
+            MarketplaceType::WILDBERRIES,
+            'sales_report',
+            'wildberries::finance-sales-reports-detailed',
+            new \DateTimeImmutable('2026-05-30'),
+            FinancialReportSyncMode::REFRESH_14D,
+            true,
+            new \DateTimeImmutable('2026-06-01 12:00:00'),
+        );
+        self::assertNotNull($firstClaim);
+        $firstClaim->markSuccess();
+        $this->em->flush();
+
+        $secondClaim = $repo->claimForQueue(
+            $secondConnectionId,
+            $company->getId(),
+            MarketplaceType::WILDBERRIES,
+            'sales_report',
+            'wildberries::finance-sales-reports-detailed',
+            new \DateTimeImmutable('2026-05-30'),
+            FinancialReportSyncMode::REFRESH_14D,
+            true,
+            new \DateTimeImmutable('2026-06-01 12:01:00'),
+        );
+        $this->em->flush();
+
+        self::assertNotNull($secondClaim);
+        self::assertSame($firstClaim->getId(), $secondClaim->getId());
+        self::assertSame(1, $this->countStatusesByBusinessDay($company->getId(), '2026-05-30'));
+        self::assertSame($secondConnectionId, $secondClaim->getConnectionId());
+    }
+
+    public function testDatabaseRejectsDuplicateSyncStatusByBusinessKeyAcrossConnections(): void
+    {
+        [$company, $firstConnection] = $this->createCompanyAndConnection(313);
+        $secondConnectionId = 'bbbbbbbb-bbbb-4bbb-8bbb-000000000314';
+
+        $repo = self::getContainer()->get(MarketplaceFinancialReportSyncStatusRepository::class);
+        $repo->save($this->newStatus($company->getId(), $firstConnection->getId(), '2026-05-29'));
+        $repo->save($this->newStatus($company->getId(), $secondConnectionId, '2026-05-29'));
+
+        $this->expectException(\Doctrine\DBAL\Exception\UniqueConstraintViolationException::class);
+        $this->em->flush();
+    }
+
     private function planner(\DateTimeImmutable $now, ?MessageBusInterface $bus = null): WbFinancialReportSyncPlanner
     {
         return new WbFinancialReportSyncPlanner(
@@ -241,7 +325,12 @@ final class WbFinancialReportSyncIdempotencyTest extends IntegrationTestCase
 
     private function countStatuses(string $companyId, string $connectionId, string $day): int
     {
-        return (int) $this->connection->fetchOne('SELECT COUNT(*) FROM marketplace_financial_report_sync_statuses WHERE company_id=:c AND connection_id=:n AND business_date=:d', ['c'=>$companyId, 'n'=>$connectionId, 'd'=>$day.' 00:00:00']);
+        return (int) $this->connection->fetchOne('SELECT COUNT(*) FROM marketplace_financial_report_sync_statuses WHERE company_id=:c AND business_date=:d', ['c'=>$companyId, 'd'=>$day.' 00:00:00']);
+    }
+
+    private function countStatusesByBusinessDay(string $companyId, string $day): int
+    {
+        return (int) $this->connection->fetchOne('SELECT COUNT(*) FROM marketplace_financial_report_sync_statuses WHERE company_id=:c AND marketplace=:m AND report_type=:t AND business_date=:d', ['c'=>$companyId, 'm'=>'wildberries', 't'=>'sales_report', 'd'=>$day.' 00:00:00']);
     }
 
     private function countStatusesInRange(string $companyId, string $connectionId, string $from, string $to): int

--- a/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportReconciliationServiceTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportReconciliationServiceTest.php
@@ -26,7 +26,7 @@ final class WbFinancialReportReconciliationServiceTest extends TestCase
 
         $repository = $this->createMock(MarketplaceRawDocumentRepository::class);
         $repository->expects(self::once())
-            ->method('findActiveExactPeriodDocuments')
+            ->method('findActiveExactDayDocuments')
             ->willReturn([]);
 
         $service = new WbFinancialReportReconciliationService($repository, $this->createMock(LoggerInterface::class));
@@ -50,7 +50,7 @@ final class WbFinancialReportReconciliationServiceTest extends TestCase
         $existing = $this->buildRawDocument($company, $businessDate);
         $existing->markCompleted();
         $repository = $this->createMock(MarketplaceRawDocumentRepository::class);
-        $repository->method('findActiveExactPeriodDocuments')->willReturn([$existing]);
+        $repository->method('findActiveExactDayDocuments')->willReturn([$existing]);
 
         $service = new WbFinancialReportReconciliationService($repository, $this->createMock(LoggerInterface::class));
         $rows = [['fresh' => true]];
@@ -73,7 +73,7 @@ final class WbFinancialReportReconciliationServiceTest extends TestCase
         $existing->setRawData([['old' => true]]);
 
         $repository = $this->createMock(MarketplaceRawDocumentRepository::class);
-        $repository->method('findActiveExactPeriodDocuments')->willReturn([$existing]);
+        $repository->method('findActiveExactDayDocuments')->willReturn([$existing]);
 
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects(self::once())->method('info');
@@ -95,7 +95,7 @@ final class WbFinancialReportReconciliationServiceTest extends TestCase
         $this->forceProcessingStatus($existing, PipelineStatus::RUNNING);
 
         $repository = $this->createMock(MarketplaceRawDocumentRepository::class);
-        $repository->method('findActiveExactPeriodDocuments')->willReturn([$existing]);
+        $repository->method('findActiveExactDayDocuments')->willReturn([$existing]);
 
         $service = new WbFinancialReportReconciliationService($repository, $this->createMock(LoggerInterface::class));
 
@@ -114,7 +114,7 @@ final class WbFinancialReportReconciliationServiceTest extends TestCase
         $duplicate->markCompleted();
 
         $repository = $this->createMock(MarketplaceRawDocumentRepository::class);
-        $repository->method('findActiveExactPeriodDocuments')->willReturn([$canonical, $duplicate]);
+        $repository->method('findActiveExactDayDocuments')->willReturn([$canonical, $duplicate]);
 
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects(self::once())->method('warning');

--- a/site/tests/Unit/Marketplace/MessageHandler/SyncWbFinancialReportDayHandlerLockTest.php
+++ b/site/tests/Unit/Marketplace/MessageHandler/SyncWbFinancialReportDayHandlerLockTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\MessageHandler;
+
+use App\Marketplace\Application\Service\WbFinancialReportPeriodResolver;
+use App\Marketplace\Application\Service\WbFinancialReportReconciliationService;
+use App\Marketplace\Application\Service\WbFinancialReportSyncStatusUpdater;
+use App\Marketplace\Infrastructure\Api\Wildberries\WbFinanceSalesReportClient;
+use App\Marketplace\Message\SyncWbFinancialReportDayMessage;
+use App\Marketplace\MessageHandler\SyncWbFinancialReportDayHandler;
+use App\Marketplace\Repository\MarketplaceConnectionRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\Store\InMemoryStore;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class SyncWbFinancialReportDayHandlerLockTest extends TestCase
+{
+    public function testBusinessDayLockIgnoresConnectionIdAndSkipsSecondMessage(): void
+    {
+        $companyId = '11111111-1111-4111-8111-111111111111';
+        $firstConnectionId = '22222222-2222-4222-8222-222222222222';
+        $secondConnectionId = '33333333-3333-4333-8333-333333333333';
+        $businessDate = '2026-05-19';
+
+        $lockFactory = new LockFactory(new InMemoryStore());
+        $heldLock = $lockFactory->createLock(
+            sprintf('marketplace_financial_report_sync:%s:%s:%s:%s', $companyId, 'wildberries', 'sales_report', $businessDate),
+            600,
+        );
+        self::assertTrue($heldLock->acquire());
+
+        $connectionRepository = $this->createMock(MarketplaceConnectionRepository::class);
+        $connectionRepository->expects(self::never())->method('findByIdAndCompany');
+
+        $financeClient = $this->uninitialized(WbFinanceSalesReportClient::class);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with(
+                'WB day sync lock not acquired, skipping.',
+                self::callback(static fn (array $context): bool => $context['connection_id'] === $secondConnectionId),
+            );
+
+        $handler = new SyncWbFinancialReportDayHandler(
+            $this->createMock(EntityManagerInterface::class),
+            $connectionRepository,
+            new WbFinancialReportPeriodResolver(new MockClock('2026-05-20T00:00:00+03:00')),
+            $financeClient,
+            $this->uninitialized(WbFinancialReportSyncStatusUpdater::class),
+            $this->uninitialized(WbFinancialReportReconciliationService::class),
+            $lockFactory,
+            $this->createMock(MessageBusInterface::class),
+            $logger,
+            new MockClock('2026-05-20T00:00:00+03:00'),
+            60,
+        );
+
+        $handler(new SyncWbFinancialReportDayMessage(
+            $companyId,
+            $secondConnectionId,
+            $businessDate,
+            'daily',
+            false,
+        ));
+
+        $heldLock->release();
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @template T of object
+     * @param class-string<T> $className
+     * @return T
+     */
+    private function uninitialized(string $className): object
+    {
+        return (new \ReflectionClass($className))->newInstanceWithoutConstructor();
+    }
+}


### PR DESCRIPTION
### Motivation

- Ensure idempotency and a single canonical sync status per business day by scoping statuses to `company + marketplace + report_type + business_date` instead of `connection_id` to avoid duplicate processing across connections. 
- Prevent multiple active exact-day `sales_report` raw documents per `company/marketplace/date` at the DB level. 
- Allow updating technical context (connection id / api endpoint) on an existing canonical business status without creating duplicates.

### Description

- Add migration `Version20260602120000` that replaces the old unique constraint `uniq_mfrss_connection_report_day` with `uniq_mfrss_company_marketplace_report_day`, creates `idx_mfrss_company_marketplace_date`, and creates a partial unique index `uniq_mrd_active_sales_report_exact_day` on `marketplace_raw_documents` for active exact-day `sales_report` rows. 
- Change `MarketplaceFinancialReportSyncStatus` entity unique constraint and indices to use `company_id + marketplace + report_type + business_date`, add the `marketplace` field usage and add `updateTechnicalContext` to mutate `connectionId`/`apiEndpoint` safely. 
- Update repository API and logic in `MarketplaceFinancialReportSyncStatusRepository`: rename `findByConnectionAndDate` -> `findByBusinessDay`, add `MarketplaceType $marketplace` parameter to query methods, acquire a PostgreSQL transaction-scoped advisory lock (`pg_advisory_xact_lock`) per business key in `acquireBusinessDayAdvisoryLock`, change transactional flows in `claimForQueue` and `findOrCreateForDay` to reuse canonical business statuses and avoid races, and update locking/unique-constraint handling. 
- Update raw document repository to `findActiveExactDayDocuments` with deterministic canonical ordering (completed first, then `COALESCE(processedAt, syncedAt)` DESC, then `id` DESC), and expose `findExistingDayDocument` using that method. 
- Propagate the business-key change across services and handlers: pass `MarketplaceType::WILDBERRIES` where appropriate, change the message lock key to `marketplace_financial_report_sync:company:marketplace:report_type:date`, and adapt logic in reconciliation, planner, sync resolver, and message handler to work with business-key scoped statuses. 
- Update and add tests to reflect new business-key semantics, deterministic raw ordering and DB uniqueness, including `SyncWbFinancialReportDayHandlerLockTest`, multiple integration tests around `MarketplaceFinancialReportSyncStatusRepository` and `MarketplaceRawDocumentRepository`, and updates to unit tests that reference renamed methods.

### Testing

- Ran unit tests in `tests/Unit/Marketplace`, including the new `SyncWbFinancialReportDayHandlerLockTest`, and all assertions passed. 
- Ran integration tests in `tests/Integration/Marketplace`, including updated idempotency and repository tests that validate single-business-day status behaviour and raw-document uniqueness, and they completed successfully. 
- DB migration checks are guarded by pre-migration queries in `Version20260602120000` and the test suite exercised the new constraints and partial unique index through integration tests which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eac8dbfc483238c07ad82eae3dd3d)