### PR TITLE
Add limited-range planning for WB financial reports and plan result reporting

### DIFF
--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlanResult.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlanResult.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Application\Service;
+
+final readonly class WbFinancialReportSyncPlanResult
+{
+    public function __construct(
+        public int $candidatesCount,
+        public int $dispatchLimit,
+        public int $attemptedCount,
+        public int $dispatchedCount,
+        public int $skippedByLimitCount,
+    ) {
+    }
+}

--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlanner.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlanner.php
@@ -32,7 +32,7 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
         $day = $this->periodResolver->yesterday();
 
         return $this->planForDays(
-            $this->activeWbConnectionsQuery->execute($companyId, $connectionId),
+            $this->activeConnections($companyId, $connectionId),
             [$day],
             FinancialReportSyncMode::DAILY,
             $force,
@@ -56,7 +56,7 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
         $to = $days[array_key_last($days)];
         $now = $this->clock->now();
 
-        foreach ($this->activeWbConnectionsQuery->execute($companyId, $connectionId) as $connection) {
+        foreach ($this->activeConnections($companyId, $connectionId) as $connection) {
             $statuses = $this->syncStatusRepository->findStatusesForDateRange(
                 $connection['company_id'],
                 $connection['connection_id'],
@@ -161,7 +161,7 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
         $to ??= $this->periodResolver->yesterday();
         $now = $this->clock->now();
 
-        foreach ($this->activeWbConnectionsQuery->execute($companyId, $connectionId) as $connection) {
+        foreach ($this->activeConnections($companyId, $connectionId) as $connection) {
             $retryItems = $this->syncStatusRepository->findRetryDueDays(
                 $connection['company_id'],
                 $connection['connection_id'],
@@ -198,6 +198,9 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
     }
 
 
+    /**
+     * @deprecated Use planRangeLimited() from console commands. planRange() schedules full explicit range without dispatch limit.
+     */
     public function planRange(
         DateTimeImmutable $from,
         DateTimeImmutable $to,
@@ -207,10 +210,59 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
         bool $forceRefresh = false,
     ): int {
         return $this->planForDays(
-            $this->activeWbConnectionsQuery->execute($companyId, $connectionId),
+            $this->activeConnections($companyId, $connectionId),
             $this->periodResolver->daysBetween($from, $to),
             $mode,
             $forceRefresh,
+        );
+    }
+
+    public function planRangeLimited(
+        DateTimeImmutable $from,
+        DateTimeImmutable $to,
+        FinancialReportSyncMode $mode,
+        int $maxDays,
+        ?string $companyId = null,
+        ?string $connectionId = null,
+        bool $forceRefresh = false,
+    ): WbFinancialReportSyncPlanResult {
+        if ($maxDays <= 0) {
+            return new WbFinancialReportSyncPlanResult(0, 0, 0, 0, 0);
+        }
+
+        $candidates = $this->buildRangeCandidates(
+            $this->activeConnections($companyId, $connectionId),
+            $this->periodResolver->daysBetween($from, $to),
+        );
+        $candidatesCount = count($candidates);
+        $attempted = 0;
+        $dispatched = 0;
+
+        foreach ($candidates as $candidate) {
+            ++$attempted;
+
+            if (!$this->claimAndDispatch(
+                $candidate['company_id'],
+                $candidate['connection_id'],
+                $candidate['day'],
+                $mode,
+                $forceRefresh,
+            )) {
+                continue;
+            }
+
+            ++$dispatched;
+            if ($dispatched >= $maxDays) {
+                break;
+            }
+        }
+
+        return new WbFinancialReportSyncPlanResult(
+            $candidatesCount,
+            $maxDays,
+            $attempted,
+            $dispatched,
+            $dispatched >= $maxDays ? max(0, $candidatesCount - $attempted) : 0,
         );
     }
 
@@ -226,7 +278,7 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
         $allDays = $this->periodResolver->daysBetween($from, $to);
         $now = $this->clock->now();
 
-        foreach ($this->activeWbConnectionsQuery->execute($companyId, $connectionId) as $connection) {
+        foreach ($this->activeConnections($companyId, $connectionId) as $connection) {
             $statuses = $this->syncStatusRepository->findStatusesForDateRange(
                 $connection['company_id'],
                 $connection['connection_id'],
@@ -300,12 +352,61 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
         $start = $startFrom ?? $this->periodResolver->currentYearStart();
 
         return $this->planForDays(
-            $this->activeWbConnectionsQuery->execute($companyId, $connectionId),
+            $this->activeConnections($companyId, $connectionId),
             $this->periodResolver->daysBetween($start, $this->periodResolver->yesterday()),
             FinancialReportSyncMode::INITIAL,
             false,
             $maxDays,
         );
+    }
+
+    /**
+     * @return list<array{id: string, company_id: string, connection_id: string}>
+     */
+    private function activeConnections(?string $companyId, ?string $connectionId): array
+    {
+        $connections = $this->activeWbConnectionsQuery->execute($companyId, $connectionId);
+
+        return array_values(array_filter(
+            $connections,
+            static fn (array $connection): bool => (null === $companyId || $connection['company_id'] === $companyId)
+                && (null === $connectionId || $connection['connection_id'] === $connectionId),
+        ));
+    }
+
+    /** @param list<array{id: string, company_id: string, connection_id: string}> $connections
+     * @param list<DateTimeImmutable> $days
+     *
+     * @return list<array{company_id: string, connection_id: string, day: DateTimeImmutable}>
+     */
+    private function buildRangeCandidates(array $connections, array $days): array
+    {
+        $candidates = [];
+        foreach ($days as $day) {
+            foreach ($connections as $connection) {
+                $candidates[] = [
+                    'company_id' => $connection['company_id'],
+                    'connection_id' => $connection['connection_id'],
+                    'day' => $day,
+                ];
+            }
+        }
+
+        usort($candidates, static function (array $a, array $b): int {
+            $dateCompare = $a['day']->getTimestamp() <=> $b['day']->getTimestamp();
+            if (0 !== $dateCompare) {
+                return $dateCompare;
+            }
+
+            $companyCompare = $a['company_id'] <=> $b['company_id'];
+            if (0 !== $companyCompare) {
+                return $companyCompare;
+            }
+
+            return $a['connection_id'] <=> $b['connection_id'];
+        });
+
+        return $candidates;
     }
 
     /** @param list<array{id: string, company_id: string, connection_id: string}> $connections

--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlannerInterface.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlannerInterface.php
@@ -17,6 +17,9 @@ interface WbFinancialReportSyncPlannerInterface
 
     public function planDueRetry(?string $companyId = null, ?string $connectionId = null, int $maxDays = 1, ?DateTimeImmutable $from = null, ?DateTimeImmutable $to = null): int;
 
+    /**
+     * @deprecated Use planRangeLimited() from console commands. planRange() schedules full explicit range without dispatch limit.
+     */
     public function planRange(
         DateTimeImmutable $from,
         DateTimeImmutable $to,
@@ -25,6 +28,16 @@ interface WbFinancialReportSyncPlannerInterface
         ?string $connectionId = null,
         bool $forceRefresh = false,
     ): int;
+
+    public function planRangeLimited(
+        DateTimeImmutable $from,
+        DateTimeImmutable $to,
+        FinancialReportSyncMode $mode,
+        int $maxDays,
+        ?string $companyId = null,
+        ?string $connectionId = null,
+        bool $forceRefresh = false,
+    ): WbFinancialReportSyncPlanResult;
 
     public function planMissing(?string $companyId = null, ?string $connectionId = null, int $maxDays = 14, ?DateTimeImmutable $from = null, ?DateTimeImmutable $to = null): int;
 

--- a/site/src/Marketplace/Command/WbFinancialReportsSyncCommand.php
+++ b/site/src/Marketplace/Command/WbFinancialReportsSyncCommand.php
@@ -6,6 +6,7 @@ namespace App\Marketplace\Command;
 
 use App\Marketplace\Application\Service\WbFinancialReportPeriodResolver;
 use App\Marketplace\Application\Service\WbFinancialReportSyncPlannerInterface;
+use App\Marketplace\Application\Service\WbFinancialReportSyncPlanResult;
 use App\Marketplace\Enum\FinancialReportSyncMode;
 use DateTimeImmutable;
 use DomainException;
@@ -91,9 +92,23 @@ final class WbFinancialReportsSyncCommand extends Command
 
             foreach ($modesToRun as $modeName) {
                 try {
-                    $dispatched = $this->runMode($modeName, $companyId, $connectionId, $force, $maxDays, $daysBack, $windowDays, $from, $to);
+                    $result = $this->runMode($modeName, $companyId, $connectionId, $force, $maxDays, $daysBack, $windowDays, $from, $to);
+                    $dispatched = $result instanceof WbFinancialReportSyncPlanResult ? $result->dispatchedCount : $result;
                     $totalDispatched += $dispatched;
-                    $io->writeln(sprintf('Mode <info>%s</info>: dispatched <comment>%d</comment>', $modeName, $dispatched));
+
+                    if ($result instanceof WbFinancialReportSyncPlanResult) {
+                        $io->writeln(sprintf(
+                            'Mode <info>%s</info>: candidates_count=<comment>%d</comment> dispatch_limit=<comment>%d</comment> attempted_count=<comment>%d</comment> dispatched_count=<comment>%d</comment> skipped_by_limit_count=<comment>%d</comment>',
+                            $modeName,
+                            $result->candidatesCount,
+                            $result->dispatchLimit,
+                            $result->attemptedCount,
+                            $result->dispatchedCount,
+                            $result->skippedByLimitCount,
+                        ));
+                    } else {
+                        $io->writeln(sprintf('Mode <info>%s</info>: dispatched_count=<comment>%d</comment>', $modeName, $dispatched));
+                    }
                 } catch (\Throwable $e) {
                     $criticalErrors[] = sprintf('%s: %s', $modeName, $e->getMessage());
                     $this->logger->error('WB financial report planning mode failed.', [
@@ -127,21 +142,20 @@ final class WbFinancialReportsSyncCommand extends Command
         }
     }
 
-    private function runMode(string $mode, ?string $companyId, ?string $connectionId, bool $force, int $maxDays, int $daysBack, ?int $windowDays, ?DateTimeImmutable $from, ?DateTimeImmutable $to): int
+    private function runMode(string $mode, ?string $companyId, ?string $connectionId, bool $force, int $maxDays, int $daysBack, ?int $windowDays, ?DateTimeImmutable $from, ?DateTimeImmutable $to): int|WbFinancialReportSyncPlanResult
     {
         return match ($mode) {
             'daily' => null !== $from
-                ? $this->planner->planRange($from, $to ?? $from, FinancialReportSyncMode::DAILY, $companyId, $connectionId, $force)
+                ? $this->planner->planRangeLimited($from, $to ?? $from, FinancialReportSyncMode::DAILY, $maxDays, $companyId, $connectionId, $force)
                 : $this->planner->planDaily($companyId, $connectionId, $force),
             'initial' => null !== $from
-                ? $this->planner->planRange($from, $to ?? $from, FinancialReportSyncMode::INITIAL, $companyId, $connectionId, $force)
+                ? $this->planner->planRangeLimited($from, $to ?? $from, FinancialReportSyncMode::INITIAL, $maxDays, $companyId, $connectionId, $force)
                 : $this->planner->planInitial($companyId, $connectionId, null, $maxDays),
             'refresh' => null !== $from
-                ? $this->planner->planRange($from, $to ?? $from, FinancialReportSyncMode::REFRESH_14D, $companyId, $connectionId, true)
+                ? $this->planner->planRangeLimited($from, $to ?? $from, FinancialReportSyncMode::REFRESH_14D, $maxDays, $companyId, $connectionId, true)
                 : $this->planner->planRefreshRecentDays($companyId, $connectionId, $daysBack, $maxDays),
             'refresh14' => null !== $from
-                // Explicit --from/--to is treated as manual force refresh mode; --max-days applies only to automatic refresh planning.
-                ? $this->planner->planRange($from, $to ?? $from, FinancialReportSyncMode::REFRESH_14D, $companyId, $connectionId, true)
+                ? $this->planner->planRangeLimited($from, $to ?? $from, FinancialReportSyncMode::REFRESH_14D, $maxDays, $companyId, $connectionId, true)
                 : (null !== $windowDays
                     ? $this->planner->planRefreshRecentDays($companyId, $connectionId, $windowDays, $maxDays)
                     : $this->planner->planRefresh14Days($companyId, $connectionId, $maxDays)),

--- a/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
@@ -96,7 +96,6 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
         self::assertCount(3, $this->dispatchedMessages);
     }
 
-
     public function testQueuedWithFutureRetryAtIsNotDispatched(): void
     {
         $planner = $this->planner();
@@ -316,6 +315,200 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
         self::assertSame(['2026-05-19'], array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->businessDate, $this->dispatchedMessages));
     }
 
+    public function testPlanRangeLimitedKeepsTryingWhenFirstCandidateIsNotClaimable(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1')]);
+        $this->claimForQueueCallback = function (
+            string $connectionId,
+            string $companyId,
+            MarketplaceType $marketplace,
+            string $reportType,
+            string $apiEndpoint,
+            \DateTimeImmutable $businessDate,
+            FinancialReportSyncMode $mode,
+            bool $forceRefresh,
+            \DateTimeImmutable $now,
+        ): ?MarketplaceFinancialReportSyncStatus {
+            if ('2026-05-18' === $businessDate->format('Y-m-d')) {
+                return null;
+            }
+
+            return $this->statusEntity(
+                $businessDate->format('Y-m-d'),
+                FinancialReportSyncStatus::QUEUED,
+                null,
+                $now->format(DATE_ATOM),
+            );
+        };
+
+        $result = $planner->planRangeLimited(
+            new \DateTimeImmutable('2026-05-18 00:00:00 Europe/Moscow'),
+            new \DateTimeImmutable('2026-05-20 00:00:00 Europe/Moscow'),
+            FinancialReportSyncMode::INITIAL,
+            1,
+        );
+
+        self::assertSame(3, $result->candidatesCount);
+        self::assertSame(2, $result->attemptedCount);
+        self::assertSame(1, $result->dispatchedCount);
+        self::assertSame(1, $result->skippedByLimitCount);
+        self::assertSame(['2026-05-19'], array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->businessDate, $this->dispatchedMessages));
+    }
+
+    public function testPlanRangeLimitedKeepsTryingWhenFirstTwoCandidatesAreNotClaimable(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1')]);
+        $this->claimForQueueCallback = function (
+            string $connectionId,
+            string $companyId,
+            MarketplaceType $marketplace,
+            string $reportType,
+            string $apiEndpoint,
+            \DateTimeImmutable $businessDate,
+            FinancialReportSyncMode $mode,
+            bool $forceRefresh,
+            \DateTimeImmutable $now,
+        ): ?MarketplaceFinancialReportSyncStatus {
+            if (\in_array($businessDate->format('Y-m-d'), ['2026-05-18', '2026-05-19'], true)) {
+                return null;
+            }
+
+            return $this->statusEntity(
+                $businessDate->format('Y-m-d'),
+                FinancialReportSyncStatus::QUEUED,
+                null,
+                $now->format(DATE_ATOM),
+            );
+        };
+
+        $result = $planner->planRangeLimited(
+            new \DateTimeImmutable('2026-05-18 00:00:00 Europe/Moscow'),
+            new \DateTimeImmutable('2026-05-20 00:00:00 Europe/Moscow'),
+            FinancialReportSyncMode::INITIAL,
+            1,
+        );
+
+        self::assertSame(3, $result->candidatesCount);
+        self::assertSame(3, $result->attemptedCount);
+        self::assertSame(1, $result->dispatchedCount);
+        self::assertSame(0, $result->skippedByLimitCount);
+        self::assertSame(['2026-05-20'], array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->businessDate, $this->dispatchedMessages));
+    }
+
+    public function testPlanRangeLimitedInitialFromToDispatchesOneWithConnectionAndCompanyFilter(): void
+    {
+        $planner = $this->planner();
+        $this->connections
+            ->expects(self::once())
+            ->method('execute')
+            ->with('co1', 'c1')
+            ->willReturn([$this->conn('c1', 'co1')]);
+
+        $result = $planner->planRangeLimited(
+            new \DateTimeImmutable('2026-05-18 00:00:00 Europe/Moscow'),
+            new \DateTimeImmutable('2026-05-20 00:00:00 Europe/Moscow'),
+            FinancialReportSyncMode::INITIAL,
+            1,
+            'co1',
+            'c1',
+            true,
+        );
+
+        self::assertSame(3, $result->candidatesCount);
+        self::assertSame(1, $result->dispatchLimit);
+        self::assertSame(1, $result->attemptedCount);
+        self::assertSame(1, $result->dispatchedCount);
+        self::assertSame(2, $result->skippedByLimitCount);
+        self::assertSame(['2026-05-18'], array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->businessDate, $this->dispatchedMessages));
+        self::assertSame(['c1'], array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->connectionId, $this->dispatchedMessages));
+    }
+
+    public function testPlanRangeLimitedInitialFromToDispatchesThreeInAscendingDateOrder(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1')]);
+
+        $result = $planner->planRangeLimited(
+            new \DateTimeImmutable('2026-05-18 00:00:00 Europe/Moscow'),
+            new \DateTimeImmutable('2026-05-20 00:00:00 Europe/Moscow'),
+            FinancialReportSyncMode::INITIAL,
+            3,
+            'co1',
+            'c1',
+            true,
+        );
+
+        self::assertSame(3, $result->candidatesCount);
+        self::assertSame(3, $result->dispatchLimit);
+        self::assertSame(3, $result->attemptedCount);
+        self::assertSame(3, $result->dispatchedCount);
+        self::assertSame(0, $result->skippedByLimitCount);
+        self::assertSame(['2026-05-18', '2026-05-19', '2026-05-20'], array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->businessDate, $this->dispatchedMessages));
+    }
+
+    public function testPlanRangeLimitedInitialDateDispatchesOneGlobally(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1'), $this->conn('c2', 'co2')]);
+
+        $result = $planner->planRangeLimited(
+            new \DateTimeImmutable('2026-05-19 00:00:00 Europe/Moscow'),
+            new \DateTimeImmutable('2026-05-19 00:00:00 Europe/Moscow'),
+            FinancialReportSyncMode::INITIAL,
+            1,
+        );
+
+        self::assertSame(2, $result->candidatesCount);
+        self::assertSame(1, $result->dispatchLimit);
+        self::assertSame(1, $result->attemptedCount);
+        self::assertSame(1, $result->dispatchedCount);
+        self::assertSame(1, $result->skippedByLimitCount);
+        self::assertSame(['c1'], array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->connectionId, $this->dispatchedMessages));
+    }
+
+    public function testPlanRangeLimitedInitialDateWithConnectionIdDispatchesOnlyThatConnection(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1'), $this->conn('c2', 'co2')]);
+
+        $result = $planner->planRangeLimited(
+            new \DateTimeImmutable('2026-05-19 00:00:00 Europe/Moscow'),
+            new \DateTimeImmutable('2026-05-19 00:00:00 Europe/Moscow'),
+            FinancialReportSyncMode::INITIAL,
+            1,
+            null,
+            'c2',
+        );
+
+        self::assertSame(1, $result->candidatesCount);
+        self::assertSame(1, $result->attemptedCount);
+        self::assertSame(1, $result->dispatchedCount);
+        self::assertSame(0, $result->skippedByLimitCount);
+        self::assertSame(['c2'], array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->connectionId, $this->dispatchedMessages));
+    }
+
+    public function testPlanRangeLimitedConnectionIdDoesNotPlanOtherConnections(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1'), $this->conn('c2', 'co1')]);
+
+        $result = $planner->planRangeLimited(
+            new \DateTimeImmutable('2026-05-18 00:00:00 Europe/Moscow'),
+            new \DateTimeImmutable('2026-05-20 00:00:00 Europe/Moscow'),
+            FinancialReportSyncMode::INITIAL,
+            10,
+            'co1',
+            'c1',
+        );
+
+        self::assertSame(3, $result->candidatesCount);
+        self::assertSame(3, $result->attemptedCount);
+        self::assertSame(3, $result->dispatchedCount);
+        self::assertSame(['c1', 'c1', 'c1'], array_map(static fn (SyncWbFinancialReportDayMessage $m): string => $m->connectionId, $this->dispatchedMessages));
+    }
+
     public function testPlanMissingRespectsMaxDays(): void
     {
         $planner = $this->planner();
@@ -325,9 +518,6 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
 
         self::assertSame(2, $planner->planMissing(null, null, 2));
     }
-
-
-
 
     public function testPlanMissingRecoversDueQueuedContinuationWithCursor(): void
     {

--- a/site/tests/Unit/Marketplace/Command/WbFinancialReportsSyncCommandTest.php
+++ b/site/tests/Unit/Marketplace/Command/WbFinancialReportsSyncCommandTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Marketplace\Command;
 
 use App\Marketplace\Application\Service\WbFinancialReportPeriodResolver;
 use App\Marketplace\Application\Service\WbFinancialReportSyncPlannerInterface;
+use App\Marketplace\Application\Service\WbFinancialReportSyncPlanResult;
 use App\Marketplace\Command\WbFinancialReportsSyncCommand;
 use App\Marketplace\Enum\FinancialReportSyncMode;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -76,6 +77,23 @@ final class WbFinancialReportsSyncCommandTest extends TestCase
         $code = $tester->execute([]);
 
         self::assertSame(Command::SUCCESS, $code);
+    }
+
+    public function testAutoDailyOutputDoesNotShowDispatchLimit(): void
+    {
+        $this->planner
+            ->expects(self::once())
+            ->method('planDaily')
+            ->with(null, null, false)
+            ->willReturn(2);
+
+        $tester = $this->tester();
+        $code = $tester->execute(['--mode' => 'daily']);
+
+        self::assertSame(Command::SUCCESS, $code);
+        $output = preg_replace('/\s+/', ' ', $tester->getDisplay());
+        self::assertStringContainsString('Mode daily: dispatched_count=2', $output);
+        self::assertStringNotContainsString('dispatch_limit=1', $output);
     }
 
     public function testAllWithoutAllowAllReturnsFailureAndWarns(): void
@@ -151,16 +169,17 @@ final class WbFinancialReportsSyncCommandTest extends TestCase
     {
         $this->planner
             ->expects(self::once())
-            ->method('planRange')
+            ->method('planRangeLimited')
             ->with(
                 self::callback(static fn (\DateTimeImmutable $d): bool => '2026-05-19' === $d->format('Y-m-d')),
                 self::callback(static fn (\DateTimeImmutable $d): bool => '2026-05-19' === $d->format('Y-m-d')),
                 FinancialReportSyncMode::DAILY,
+                1,
                 null,
                 null,
                 false,
             )
-            ->willReturn(1);
+            ->willReturn(new WbFinancialReportSyncPlanResult(1, 1, 1, 1, 0));
 
         $this->planner->expects(self::never())->method('planDaily');
 
@@ -178,7 +197,7 @@ final class WbFinancialReportsSyncCommandTest extends TestCase
             ->with(null, null, null, 3)
             ->willReturn(3);
 
-        $this->planner->expects(self::never())->method('planRange');
+        $this->planner->expects(self::never())->method('planRangeLimited');
 
         $tester = $this->tester();
         $code = $tester->execute(['--mode' => 'initial', '--max-days' => '3']);
@@ -186,20 +205,21 @@ final class WbFinancialReportsSyncCommandTest extends TestCase
         self::assertSame(Command::SUCCESS, $code);
     }
 
-    public function testInitialExplicitRangeUsesPlanRangeAndIgnoresMaxDaysLimit(): void
+    public function testInitialExplicitRangeUsesPlanRangeLimitedAndHonorsMaxDaysLimit(): void
     {
         $this->planner
             ->expects(self::once())
-            ->method('planRange')
+            ->method('planRangeLimited')
             ->with(
                 self::callback(static fn (\DateTimeImmutable $d): bool => '2026-05-18' === $d->format('Y-m-d')),
                 self::callback(static fn (\DateTimeImmutable $d): bool => '2026-05-20' === $d->format('Y-m-d')),
                 FinancialReportSyncMode::INITIAL,
+                1,
                 null,
                 null,
                 false,
             )
-            ->willReturn(3);
+            ->willReturn(new WbFinancialReportSyncPlanResult(3, 1, 1, 1, 2));
 
         $this->planner->expects(self::never())->method('planInitial');
 
@@ -212,22 +232,25 @@ final class WbFinancialReportsSyncCommandTest extends TestCase
         ]);
 
         self::assertSame(Command::SUCCESS, $code);
+        $output = preg_replace('/\s+/', ' ', $tester->getDisplay());
+        self::assertStringContainsString('candidates_count=3 dispatch_limit=1 attempted_count=1 dispatched_count=1 skipped_by_limit_count=2', $output);
     }
 
-    public function testInitialDateCallsPlanRangeAndNotPlanInitial(): void
+    public function testInitialDateCallsPlanRangeLimitedAndNotPlanInitial(): void
     {
         $this->planner
             ->expects(self::once())
-            ->method('planRange')
+            ->method('planRangeLimited')
             ->with(
                 self::callback(static fn (\DateTimeImmutable $d): bool => '2026-05-19' === $d->format('Y-m-d')),
                 self::callback(static fn (\DateTimeImmutable $d): bool => '2026-05-19' === $d->format('Y-m-d')),
                 FinancialReportSyncMode::INITIAL,
+                1,
                 null,
                 null,
                 false,
             )
-            ->willReturn(1);
+            ->willReturn(new WbFinancialReportSyncPlanResult(1, 1, 1, 1, 0));
 
         $this->planner->expects(self::never())->method('planInitial');
 


### PR DESCRIPTION
### Motivation
- Provide a way to schedule an explicit date range but cap global dispatches (`--max-days`) and report planning metrics back to callers. 
- Improve console output for explicit range runs and preserve backwards-compatible automatic behaviour. 
- Reduce duplicate connection filtering logic by centralizing active connection selection.

### Description
- Introduced a new readonly value object `WbFinancialReportSyncPlanResult` with fields `candidatesCount`, `dispatchLimit`, `attemptedCount`, `dispatchedCount`, and `skippedByLimitCount` to convey detailed planning results. 
- Added `planRangeLimited(...)` to `WbFinancialReportSyncPlanner` and `WbFinancialReportSyncPlannerInterface` to support bounded global dispatching across a range of days, and marked the old `planRange(...)` as deprecated. 
- Implemented `activeConnections(...)` and `buildRangeCandidates(...)` helpers to filter connections and build sorted candidate lists, and replaced direct calls to the connections query with `activeConnections(...)` across planner methods. 
- Updated the CLI `WbFinancialReportsSyncCommand` to call `planRangeLimited(...)` for explicit ranges, accept the new result type from planner methods, and print either summary counts or the simple dispatched count depending on the result. 
- Added and updated unit tests in `WbFinancialReportSyncPlannerTest` and `WbFinancialReportsSyncCommandTest` to cover `planRangeLimited` behaviour, filtering by company/connection, ordering, and console output formatting.

### Testing
- Ran the unit test suite covering planner and command changes, including `tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest` and `tests/Unit/Marketplace/Command/WbFinancialReportsSyncCommandTest`, and all tests passed. 
- Verified the console command output formatting in tests to ensure `dispatch_limit` is only shown for explicit ranged runs using `planRangeLimited`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2166d86f6c83238f069d082b1b1175)