### PR TITLE
Map Ozon additional warehouse packaging service

### DIFF
--- a/site/src/Marketplace/Application/Processor/OzonServiceCategoryMap.php
+++ b/site/src/Marketplace/Application/Processor/OzonServiceCategoryMap.php
@@ -23,7 +23,7 @@ final class OzonServiceCategoryMap
      * Версия словаря — обновлять при любом изменении маппинга.
      * Используется в /marketplace/costs/debug/map-version для проверки деплоя.
      */
-    public const VERSION = '2026-05-12.1';
+    public const VERSION = '2026-06-05.1';
 
     /**
      * Service names из API Ozon, которые являются нулевыми маркерами (price = 0).

--- a/site/src/Marketplace/Domain/OzonCostCategory.php
+++ b/site/src/Marketplace/Domain/OzonCostCategory.php
@@ -440,7 +440,10 @@ final readonly class OzonCostCategory
                 name: 'Упаковочные материалы Ozon',
                 widgetGroup: 'Другие услуги и штрафы',
                 xlsxGroup: 'Услуги FBO',
-                serviceNames: ['MarketplaceServiceItemPackageMaterialsProvision'],
+                serviceNames: [
+                    'MarketplaceServiceItemPackageMaterialsProvision',
+                    'OperationMarketplaceItemAdditionalPackagingAtWarehouse',
+                ],
             ),
             new self(
                 code: 'ozon_disposal',

--- a/site/tests/Unit/Marketplace/Application/Processor/OzonServiceCategoryMapTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/OzonServiceCategoryMapTest.php
@@ -173,6 +173,7 @@ final class OzonServiceCategoryMapTest extends TestCase
             'DefectFineShipmentDelayRated' => 'ozon_fines_shipment_delay_rated',
             'DefectFineCancellation' => 'ozon_fines_cancellation',
             'MarketplaceServiceItemServiceFeeRFBS' => 'ozon_service_fee_rfbs',
+            'OperationMarketplaceItemAdditionalPackagingAtWarehouse' => 'ozon_package_materials',
             'DefectFineShipmentDelay' => 'ozon_fines_shipment_delay',
         ];
 

--- a/site/tests/Unit/Marketplace/Domain/OzonCostCategoryTest.php
+++ b/site/tests/Unit/Marketplace/Domain/OzonCostCategoryTest.php
@@ -260,6 +260,10 @@ final class OzonCostCategoryTest extends TestCase
             OzonCostCategory::findByServiceName('MarketplaceServiceItemServiceFeeRFBS')?->code,
         );
         $this->assertSame(
+            'ozon_package_materials',
+            OzonCostCategory::findByServiceName('OperationMarketplaceItemAdditionalPackagingAtWarehouse')?->code,
+        );
+        $this->assertSame(
             'ozon_fines_shipment_delay',
             OzonCostCategory::findByOperationType('DefectFineShipmentDelay')?->code,
         );


### PR DESCRIPTION
### Motivation
- Покрыть новую сервисную строку Ozon `OperationMarketplaceItemAdditionalPackagingAtWarehouse` в справочнике категорий затрат, чтобы она корректно резолвилась как упаковочный материал.
- Обновить версию маппинга, чтобы отражать изменение справочника.
- Добавить юнит-покрытие, которое предотвращает регрессии (fallback в `ozon_other_service` или предупреждения unknown-service).

### Description
- Добавлен `OperationMarketplaceItemAdditionalPackagingAtWarehouse` в `serviceNames` категории `ozon_package_materials` в `site/src/Marketplace/Domain/OzonCostCategory.php`.
- Обновлена константа `OzonServiceCategoryMap::VERSION` на `2026-06-05.1` в `site/src/Marketplace/Application/Processor/OzonServiceCategoryMap.php`.
- Добавлены и/или обновлены проверки в `site/tests/Unit/Marketplace/Domain/OzonCostCategoryTest.php` и `site/tests/Unit/Marketplace/Application/Processor/OzonServiceCategoryMapTest.php`, подтверждающие, что `OperationMarketplaceItemAdditionalPackagingAtWarehouse` резолвится в `ozon_package_materials` без fallback и без warning.

### Testing
- Запущены целевые юнит-тесты: `cd site && APP_ENV=test APP_DEBUG=1 php -d memory_limit=512M bin/phpunit --testsuite unit --filter 'OzonCostCategoryTest|OzonServiceCategoryMapTest'`, результат: OK (19 tests, 1216 assertions).
- Попытка запуска через `make codex-test-unit-filter` на CI-образе первоначально не прошла на шаге `codex-prepare` из-за окружения PATH, но непосредственный запуск `phpunit` подтвердил успешность изменений.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a224d805b0483238afe671206e7a2f5)