### PR TITLE
Add Ozon default cost mappings and update functional tests

### DIFF
--- a/site/config/marketplace/default_cost_mapping.yaml
+++ b/site/config/marketplace/default_cost_mapping.yaml
@@ -67,6 +67,26 @@ marketplaces:
         include_in_pl: true
         confidence: low
         note: "Гипотеза до финальной сверки с фин.методологией"
+      - cost_code: ozon_fines_shipment_delay_rated
+        pl_code: OPEX_WH_MP_DEDUCTIONS
+        include_in_pl: true
+        confidence: low
+        note: "Гипотеза: штраф Ozon за просрочку отгрузки относится к удержаниям/штрафам маркетплейса до финальной сверки с фин.методологией"
+      - cost_code: ozon_fines_cancellation
+        pl_code: OPEX_WH_MP_DEDUCTIONS
+        include_in_pl: true
+        confidence: low
+        note: "Гипотеза: штраф Ozon за отмену относится к удержаниям/штрафам маркетплейса до финальной сверки с фин.методологией"
+      - cost_code: ozon_service_fee_rfbs
+        pl_code: COGS_DELIVERY
+        include_in_pl: true
+        confidence: medium
+        note: "Гипотеза: RFBS service fee отнесён к доставочным/операционным расходам до финальной сверки с фин.методологией"
+      - cost_code: ozon_fines_shipment_delay
+        pl_code: OPEX_WH_MP_DEDUCTIONS
+        include_in_pl: true
+        confidence: low
+        note: "Гипотеза: штраф Ozon за просрочку отгрузки относится к удержаниям/штрафам маркетплейса до финальной сверки с фин.методологией"
 
   wildberries:
     cost_mappings: []

--- a/site/tests/Functional/Marketplace/Controller/CostPLMappingDefaultSetupControllerTest.php
+++ b/site/tests/Functional/Marketplace/Controller/CostPLMappingDefaultSetupControllerTest.php
@@ -18,6 +18,13 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 final class CostPLMappingDefaultSetupControllerTest extends WebTestCaseBase
 {
+    private const NEW_OZON_COST_MAPPINGS = [
+        'ozon_fines_shipment_delay_rated' => 'OPEX_WH_MP_DEDUCTIONS',
+        'ozon_fines_cancellation' => 'OPEX_WH_MP_DEDUCTIONS',
+        'ozon_service_fee_rfbs' => 'COGS_DELIVERY',
+        'ozon_fines_shipment_delay' => 'OPEX_WH_MP_DEDUCTIONS',
+    ];
+
     public function testPreviewReturnsOkAndIsReadOnly(): void
     {
         $this->resetDb();
@@ -36,9 +43,8 @@ final class CostPLMappingDefaultSetupControllerTest extends WebTestCaseBase
         self::assertTrue($payload['ok']);
         self::assertArrayHasKey('summary', $payload);
         self::assertSame($before, $this->countMappings());
+        $this->assertNewOzonCostMappingsArePreviewedForCreation($payload);
     }
-
-
 
     public function testPreviewAcceptsJsonBody(): void
     {
@@ -78,6 +84,9 @@ final class CostPLMappingDefaultSetupControllerTest extends WebTestCaseBase
         self::assertResponseIsSuccessful();
         $first = json_decode((string) $client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         self::assertTrue($first['ok']);
+        foreach (array_keys(self::NEW_OZON_COST_MAPPINGS) as $costCode) {
+            self::assertContains($costCode, $first['createdCostCodes']);
+        }
 
         $createdAfterFirst = $this->countMappings();
         self::assertGreaterThan(0, $createdAfterFirst);
@@ -129,6 +138,26 @@ final class CostPLMappingDefaultSetupControllerTest extends WebTestCaseBase
         self::assertResponseStatusCodeSame(403);
     }
 
+    /** @param array<string, mixed> $payload */
+    private function assertNewOzonCostMappingsArePreviewedForCreation(array $payload): void
+    {
+        self::assertArrayHasKey('items', $payload);
+        self::assertIsArray($payload['items']);
+
+        $itemsByCostCode = [];
+        foreach ($payload['items'] as $item) {
+            self::assertIsArray($item);
+            $itemsByCostCode[$item['costCode']] = $item;
+        }
+
+        foreach (self::NEW_OZON_COST_MAPPINGS as $costCode => $plCode) {
+            self::assertArrayHasKey($costCode, $itemsByCostCode);
+            self::assertSame('will_create', $itemsByCostCode[$costCode]['status']);
+            self::assertSame($plCode, $itemsByCostCode[$costCode]['plCode']);
+            self::assertNotNull($itemsByCostCode[$costCode]['plCategoryId']);
+        }
+    }
+
     private function csrf(KernelBrowser $client): string
     {
         return $client->getContainer()->get('security.csrf.token_manager')->getToken('marketplace_default_cost_mapping')->getValue();
@@ -155,14 +184,14 @@ final class CostPLMappingDefaultSetupControllerTest extends WebTestCaseBase
         $em->persist($user);
         $em->persist($company);
 
-        $codes = ['ozon_sale_commission', 'ozon_logistic_direct'];
+        $codes = ['ozon_sale_commission', 'ozon_logistic_direct', ...array_keys(self::NEW_OZON_COST_MAPPINGS)];
         foreach ($codes as $i => $code) {
             $cost = new MarketplaceCostCategory(Uuid::uuid4()->toString(), $company, MarketplaceType::OZON);
             $cost->setName('Cost '.$i)->setCode($code);
             $em->persist($cost);
         }
 
-        $plCodes = $withAllPlCodes ? ['COGS_MP_COMMISSION', 'COGS_DELIVERY'] : ['COGS_MP_COMMISSION'];
+        $plCodes = $withAllPlCodes ? ['COGS_MP_COMMISSION', 'COGS_DELIVERY', 'OPEX_WH_MP_DEDUCTIONS'] : ['COGS_MP_COMMISSION'];
         foreach ($plCodes as $code) {
             $pl = PLCategoryBuilder::aPLCategory()->forCompany($company)->withName($code)->build();
             $pl->setCode($code);


### PR DESCRIPTION
### Motivation

- Add missing default cost mappings for several Ozon cost codes (shipment-delay fines, cancellation fines, RFBS service fee) so they are included in the initial P&L mapping and reviewable in the preview UI.
- Surface confidence and explanatory notes where the exact `pl_code` is provisional to reflect finance methodology uncertainty.
- Ensure the default mapping preview/apply flow and test seed data cover the new cost codes so they are not dropped from the baseline mapping.

### Description

- Added four entries to `site/config/marketplace/default_cost_mapping.yaml` for `ozon_fines_shipment_delay_rated`, `ozon_fines_cancellation`, `ozon_service_fee_rfbs`, and `ozon_fines_shipment_delay` with appropriate `pl_code`, `include_in_pl`, `confidence` and `note` fields.
- Extended `site/tests/Functional/Marketplace/Controller/CostPLMappingDefaultSetupControllerTest.php` by adding `NEW_OZON_COST_MAPPINGS`, assertions in the preview to check `will_create` items and `plCode`/`plCategoryId`, assertions in the apply response to ensure new cost codes are reported as created, and updated test seed data to include the new cost categories and `OPEX_WH_MP_DEDUCTIONS` PL code.
- No production code paths were changed; this is a configuration and test update to verify default mapping behaviour.

### Testing

- Ran PHP syntax check on the modified test file with `php -l site/tests/Functional/Marketplace/Controller/CostPLMappingDefaultSetupControllerTest.php` which passed.
- Validated the YAML entries with a Ruby YAML script that ensured the four new `cost_code` entries exist and reported their `pl_code` and `confidence`, which succeeded.
- Attempts to run `make codex-test-unit-filter FILTER=CostPLMappingDefaultSetupControllerTest` and `phpunit` were blocked by the environment: the Makefile forces a restricted `PATH` and the test environment lacks required vendor binaries and PHP extensions (`sodium`, `redis`), so full PHPUnit runs could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22548f8f0c8323aceb703035734e45)