### PR TITLE
Disable legacy Wildberries sync; add guards and tests

### DIFF
--- a/site/src/Marketplace/Command/MarketplaceSyncCommand.php
+++ b/site/src/Marketplace/Command/MarketplaceSyncCommand.php
@@ -60,6 +60,12 @@ class MarketplaceSyncCommand extends Command
             return Command::FAILURE;
         }
 
+        if (MarketplaceType::WILDBERRIES === $marketplace) {
+            $io->error('Legacy WB sync отключён. Используйте новую команду: app:marketplace:wb-financial-reports:sync');
+
+            return Command::FAILURE;
+        }
+
         $io->title('Синхронизация с '.$marketplace->getDisplayName());
 
         // Получить компании для синхронизации

--- a/site/src/Marketplace/Facade/MarketplaceSyncFacade.php
+++ b/site/src/Marketplace/Facade/MarketplaceSyncFacade.php
@@ -8,6 +8,7 @@ use App\Marketplace\Application\Command\FetchMarketplaceDataCommand;
 use App\Marketplace\Application\Command\ProcessMarketplaceRawDocumentCommand;
 use App\Marketplace\Application\ProcessRawDocumentAction;
 use App\Marketplace\Enum\MarketplaceType;
+use DomainException;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 final readonly class MarketplaceSyncFacade
@@ -24,6 +25,8 @@ final readonly class MarketplaceSyncFacade
         \DateTimeInterface $fromDate,
         \DateTimeInterface $toDate,
     ): int {
+        $this->guardLegacyWbSync($marketplace);
+
         $immutableFrom = $fromDate instanceof \DateTimeImmutable ? $fromDate : \DateTimeImmutable::createFromInterface($fromDate);
         $this->messageBus->dispatch(new FetchMarketplaceDataCommand(
             $companyId,
@@ -42,6 +45,8 @@ final readonly class MarketplaceSyncFacade
         \DateTimeInterface $fromDate,
         \DateTimeInterface $toDate,
     ): int {
+        $this->guardLegacyWbSync($marketplace);
+
         $immutableFrom = $fromDate instanceof \DateTimeImmutable ? $fromDate : \DateTimeImmutable::createFromInterface($fromDate);
         $this->messageBus->dispatch(new FetchMarketplaceDataCommand(
             $companyId,
@@ -60,6 +65,8 @@ final readonly class MarketplaceSyncFacade
         \DateTimeInterface $fromDate,
         \DateTimeInterface $toDate,
     ): int {
+        $this->guardLegacyWbSync($marketplace);
+
         $immutableFrom = $fromDate instanceof \DateTimeImmutable ? $fromDate : \DateTimeImmutable::createFromInterface($fromDate);
         $this->messageBus->dispatch(new FetchMarketplaceDataCommand(
             $companyId,
@@ -70,6 +77,13 @@ final readonly class MarketplaceSyncFacade
         ));
 
         return 0;
+    }
+
+    private function guardLegacyWbSync(MarketplaceType $marketplace): void
+    {
+        if (MarketplaceType::WILDBERRIES === $marketplace) {
+            throw new DomainException('Legacy WB sync отключён. Используйте app:marketplace:wb-financial-reports:sync.');
+        }
     }
 
     /**

--- a/site/src/Marketplace/Infrastructure/Api/Wildberries/WbFetcher.php
+++ b/site/src/Marketplace/Infrastructure/Api/Wildberries/WbFetcher.php
@@ -30,7 +30,7 @@ final readonly class WbFetcher implements MarketplaceFetcherInterface
 
     public function supports(MarketplaceType $type): bool
     {
-        return MarketplaceType::WILDBERRIES === $type;
+        return false;
     }
 
     /**

--- a/site/tests/Unit/Marketplace/LegacyWbSyncDisabledTest.php
+++ b/site/tests/Unit/Marketplace/LegacyWbSyncDisabledTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace;
+
+use App\Company\Facade\CompanyFacade;
+use App\Marketplace\Application\ProcessRawDocumentAction;
+use App\Marketplace\Command\MarketplaceSyncCommand;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Facade\MarketplaceSyncFacade;
+use App\Marketplace\Infrastructure\Api\MarketplaceFetcherRegistry;
+use App\Marketplace\Infrastructure\Api\Wildberries\WbFetcher;
+use App\Marketplace\Repository\MarketplaceConnectionRepository;
+use DomainException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class LegacyWbSyncDisabledTest extends TestCase
+{
+    public function testMarketplaceSyncWildberriesFailsWithNewCommandHint(): void
+    {
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::never())->method('dispatch');
+
+        $command = new MarketplaceSyncCommand(
+            self::uninitialized(MarketplaceConnectionRepository::class),
+            new MarketplaceSyncFacade(self::uninitialized(ProcessRawDocumentAction::class), $bus),
+            self::uninitialized(CompanyFacade::class),
+        );
+        $tester = new CommandTester($command);
+
+        $exitCode = $tester->execute(['marketplace' => MarketplaceType::WILDBERRIES->value]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString('app:marketplace:wb-financial-reports:sync', $tester->getDisplay());
+    }
+
+    #[DataProvider('legacyWbSyncMethodsProvider')]
+    public function testFacadeLegacyWbSyncMethodsDoNotDispatchFetchCommand(string $methodName): void
+    {
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::never())->method('dispatch');
+
+        $facade = new MarketplaceSyncFacade(self::uninitialized(ProcessRawDocumentAction::class), $bus);
+
+        $this->expectException(DomainException::class);
+        $this->expectExceptionMessage('Legacy WB sync отключён');
+
+        $facade->{$methodName}(
+            'company-id',
+            MarketplaceType::WILDBERRIES,
+            new \DateTimeImmutable('2026-01-01'),
+            new \DateTimeImmutable('2026-01-02'),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{methodName: string}>
+     */
+    public static function legacyWbSyncMethodsProvider(): iterable
+    {
+        yield 'sales' => ['methodName' => 'syncSales'];
+        yield 'costs' => ['methodName' => 'syncCosts'];
+        yield 'returns' => ['methodName' => 'syncReturns'];
+    }
+
+    public function testFetcherRegistryDoesNotReturnWbFetcherForWildberries(): void
+    {
+        $wbFetcher = self::uninitialized(WbFetcher::class);
+        $registry = new MarketplaceFetcherRegistry([$wbFetcher]);
+
+        self::assertFalse($wbFetcher->supports(MarketplaceType::WILDBERRIES));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Marketplace fetcher is not configured for type "wildberries".');
+
+        $registry->get(MarketplaceType::WILDBERRIES);
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param class-string<T> $className
+     *
+     * @return T
+     */
+    private static function uninitialized(string $className): object
+    {
+        return (new \ReflectionClass($className))->newInstanceWithoutConstructor();
+    }
+}


### PR DESCRIPTION
### Motivation

- Prevent use of the deprecated Wildberries GET-based sync pipeline and direct callers to the new WB financial-reports flow.
- Ensure the legacy fetcher pipeline remains in the codebase for compatibility while being effectively disabled.

### Description

- Updated `MarketplaceSyncCommand` to fail early with an error and hint `app:marketplace:wb-financial-reports:sync` when `wildberries` is requested.
- Added `guardLegacyWbSync` to `MarketplaceSyncFacade` and invoked it from `syncSales`, `syncCosts`, and `syncReturns` to throw a `DomainException` for `MarketplaceType::WILDBERRIES`.
- Changed `WbFetcher::supports()` to return `false` so the legacy WB fetcher is not selected by the fetcher registry while keeping the class deprecated with its implementation intact.
- Added unit tests in `LegacyWbSyncDisabledTest` to cover the command failure, facade guard behavior for `sync*` methods, and the fetcher registry behavior.

### Testing

- Ran the new unit test `LegacyWbSyncDisabledTest` via `vendor/bin/phpunit --filter LegacyWbSyncDisabledTest` and it passed.
- Verified that the facade methods throw `DomainException` and that `MarketplaceSyncCommand` exits with `Command::FAILURE` when `wildberries` is used, as asserted by the tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23ce1d343483238079bf3cff64fc88)