### PR TITLE
Disable legacy Wildberries sync and show new WB command hint

### DIFF
--- a/site/src/Marketplace/Command/MarketplaceSyncCommand.php
+++ b/site/src/Marketplace/Command/MarketplaceSyncCommand.php
@@ -28,6 +28,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 class MarketplaceSyncCommand extends Command
 {
+    private const WB_FINANCIAL_REPORTS_SYNC_COMMAND = 'app:marketplace:wb-financial-reports:sync';
+
     public function __construct(
         private readonly MarketplaceConnectionRepository $connectionRepository,
         private readonly MarketplaceSyncFacade $syncFacade,
@@ -61,7 +63,10 @@ class MarketplaceSyncCommand extends Command
         }
 
         if (MarketplaceType::WILDBERRIES === $marketplace) {
-            $io->error('Legacy WB sync отключён. Используйте новую команду: app:marketplace:wb-financial-reports:sync');
+            $io->error(sprintf(
+                'Legacy WB sync отключён. Используйте новую команду: %s',
+                self::WB_FINANCIAL_REPORTS_SYNC_COMMAND,
+            ));
 
             return Command::FAILURE;
         }

--- a/site/tests/Unit/Marketplace/LegacyWbSyncDisabledTest.php
+++ b/site/tests/Unit/Marketplace/LegacyWbSyncDisabledTest.php
@@ -31,6 +31,8 @@ final class LegacyWbSyncDisabledTest extends TestCase
             new MarketplaceSyncFacade(self::uninitialized(ProcessRawDocumentAction::class), $bus),
             self::uninitialized(CompanyFacade::class),
         );
+        self::assertSame('marketplace:sync', $command->getName());
+
         $tester = new CommandTester($command);
 
         $exitCode = $tester->execute(['marketplace' => MarketplaceType::WILDBERRIES->value]);


### PR DESCRIPTION
### Motivation
- Prevent accidental use of the legacy Wildberries path in the `marketplace:sync` command and surface the new command to users as a hint instead of silently performing legacy work. 
- Keep the legacy command present (do not remove it) so hidden/manual runs become visible through an explicit failure.

### Description
- Added a `WB_FINANCIAL_REPORTS_SYNC_COMMAND` constant to `site/src/Marketplace/Command/MarketplaceSyncCommand.php` and changed the Wildberries branch to print a formatted hint using that constant and exit with `Command::FAILURE` after parsing `MarketplaceType`.
- Strengthened `site/tests/Unit/Marketplace/LegacyWbSyncDisabledTest.php` by asserting the legacy command name is `marketplace:sync` and keeping the expectation that no `MessageBus` dispatch occurs when `wildberries` is requested.

### Testing
- Ran the unit test suite filter: `cd site && APP_ENV=test APP_DEBUG=1 php -d memory_limit=512M bin/phpunit --testsuite unit --filter LegacyWbSyncDisabledTest`, which completed successfully (`OK (5 tests, 16 assertions)`).
- Attempted `make codex-test-unit-filter FILTER=LegacyWbSyncDisabledTest`, which failed in this environment due to the Makefile restricting `PATH` where `php` was unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23e55fa5e08323a1b957779d7bc716)