### PR TITLE
Disable legacy Wildberries sync in MarketplaceSyncFacade

### DIFF
--- a/site/src/Marketplace/Facade/MarketplaceSyncFacade.php
+++ b/site/src/Marketplace/Facade/MarketplaceSyncFacade.php
@@ -13,6 +13,9 @@ use Symfony\Component\Messenger\MessageBusInterface;
 
 final readonly class MarketplaceSyncFacade
 {
+    private const WB_FINANCIAL_REPORTS_SYNC_PLANNER = 'WbFinancialReportSyncPlanner';
+    private const WB_FINANCIAL_REPORTS_SYNC_COMMAND = 'app:marketplace:wb-financial-reports:sync';
+
     public function __construct(
         private ProcessRawDocumentAction $processRawDocumentAction,
         private MessageBusInterface $messageBus,
@@ -82,7 +85,11 @@ final readonly class MarketplaceSyncFacade
     private function guardLegacyWbSync(MarketplaceType $marketplace): void
     {
         if (MarketplaceType::WILDBERRIES === $marketplace) {
-            throw new DomainException('Legacy WB sync отключён. Используйте app:marketplace:wb-financial-reports:sync.');
+            throw new DomainException(sprintf(
+                'Legacy WB sync отключён. Используйте %s или новую команду %s.',
+                self::WB_FINANCIAL_REPORTS_SYNC_PLANNER,
+                self::WB_FINANCIAL_REPORTS_SYNC_COMMAND,
+            ));
         }
     }
 

--- a/site/tests/Unit/Marketplace/LegacyWbSyncDisabledTest.php
+++ b/site/tests/Unit/Marketplace/LegacyWbSyncDisabledTest.php
@@ -22,6 +22,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 final class LegacyWbSyncDisabledTest extends TestCase
@@ -56,6 +57,8 @@ final class LegacyWbSyncDisabledTest extends TestCase
 
         $this->expectException(DomainException::class);
         $this->expectExceptionMessage('Legacy WB sync отключён');
+        $this->expectExceptionMessage('WbFinancialReportSyncPlanner');
+        $this->expectExceptionMessage('app:marketplace:wb-financial-reports:sync');
 
         $facade->{$methodName}(
             'company-id',
@@ -73,6 +76,64 @@ final class LegacyWbSyncDisabledTest extends TestCase
         yield 'sales' => ['methodName' => 'syncSales'];
         yield 'costs' => ['methodName' => 'syncCosts'];
         yield 'returns' => ['methodName' => 'syncReturns'];
+    }
+
+    #[DataProvider('nonWbSyncMethodsProvider')]
+    public function testFacadeNonWbSyncMethodsDispatchFetchCommand(
+        string $methodName,
+        string $expectedProcessKind,
+        MarketplaceType $marketplace,
+    ): void
+    {
+        $fromDate = new \DateTimeImmutable('2026-01-01');
+        $toDate = new \DateTimeImmutable('2026-01-02');
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::once())
+            ->method('dispatch')
+            ->with(self::callback(static function (object $message) use ($expectedProcessKind, $fromDate, $marketplace): bool {
+                self::assertInstanceOf(FetchMarketplaceDataCommand::class, $message);
+                self::assertSame('company-id', $message->companyId);
+                self::assertSame($marketplace, $message->type);
+                self::assertSame($fromDate, $message->dateFrom);
+                self::assertSame('sales_report', $message->documentType);
+                self::assertSame($expectedProcessKind, $message->processKind);
+
+                return true;
+            }))
+            ->willReturnCallback(static fn (object $message): Envelope => new Envelope($message));
+
+        $facade = new MarketplaceSyncFacade(self::uninitialized(ProcessRawDocumentAction::class), $bus);
+
+        self::assertSame(0, $facade->{$methodName}('company-id', $marketplace, $fromDate, $toDate));
+    }
+
+    /**
+     * @return iterable<string, array{methodName: string, expectedProcessKind: string, marketplace: MarketplaceType}>
+     */
+    public static function nonWbSyncMethodsProvider(): iterable
+    {
+        foreach ([
+            'ozon' => MarketplaceType::OZON,
+            'yandex_market' => MarketplaceType::YANDEX_MARKET,
+            'sber_megamarket' => MarketplaceType::SBER_MEGAMARKET,
+        ] as $marketplaceName => $marketplace) {
+            yield $marketplaceName.' sales' => [
+                'methodName' => 'syncSales',
+                'expectedProcessKind' => 'sales',
+                'marketplace' => $marketplace,
+            ];
+            yield $marketplaceName.' costs' => [
+                'methodName' => 'syncCosts',
+                'expectedProcessKind' => 'costs',
+                'marketplace' => $marketplace,
+            ];
+            yield $marketplaceName.' returns' => [
+                'methodName' => 'syncReturns',
+                'expectedProcessKind' => 'returns',
+                'marketplace' => $marketplace,
+            ];
+        }
     }
 
     public function testWbFetcherDoesNotParticipateInMarketplaceFetcherTaggedRegistry(): void


### PR DESCRIPTION
### Motivation
- Prevent legacy Wildberries sync from proceeding via the old `MarketplaceSyncFacade` pipeline and provide a clear migration hint.
- Ensure the guard applies to all legacy sync entry points (`syncSales`, `syncCosts`, `syncReturns`) so WB is blocked before any dispatch. 
- Preserve behavior for other marketplaces (Ozon, Yandex Market, SberMegamarket) so they still dispatch the expected fetch commands.

### Description
- Added constants `WB_FINANCIAL_REPORTS_SYNC_PLANNER` and `WB_FINANCIAL_REPORTS_SYNC_COMMAND` and updated the guard in `MarketplaceSyncFacade::guardLegacyWbSync` to throw a `DomainException` containing both `WbFinancialReportSyncPlanner` and `app:marketplace:wb-financial-reports:sync`.
- Applied the guard call (already present) to `syncSales`, `syncCosts`, and `syncReturns` to block WB before dispatching `FetchMarketplaceDataCommand`.
- Extended `site/tests/Unit/Marketplace/LegacyWbSyncDisabledTest.php` to assert the new exception message contains both hints and added a data-driven test verifying that non-WB marketplaces still dispatch `FetchMarketplaceDataCommand` for `sales`, `costs`, and `returns`.
- Modified files: `site/src/Marketplace/Facade/MarketplaceSyncFacade.php` and `site/tests/Unit/Marketplace/LegacyWbSyncDisabledTest.php`.

### Testing
- Ran the unit test filter: `cd site && APP_ENV=test APP_DEBUG=1 php -d memory_limit=512M bin/phpunit --testsuite unit --filter LegacyWbSyncDisabledTest`, and it passed (`OK`, tests included: 16 tests, 102 assertions).
- `make codex-test-unit-filter FILTER=LegacyWbSyncDisabledTest` failed in this environment due to the Makefile `CODEX_SYSTEM_PATH` not including the phpenv PHP shim, so the `codex-prepare` step could not find the expected `php` shim (environment limitation).
- Performed static checks: `git diff --check` and repository search for `MarketplaceSyncFacade` / `->sync(Sales|Costs|Returns)` to confirm call sites were considered; no unexpected changes to non-WB behavior were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a243c46e6208323b7395969359e89d7)