### PR TITLE
Plan Wildberries manual financial sync tasks instead of fetching raw reports

### DIFF
--- a/site/src/Marketplace/Application/SyncConnectionAction.php
+++ b/site/src/Marketplace/Application/SyncConnectionAction.php
@@ -5,27 +5,34 @@ declare(strict_types=1);
 namespace App\Marketplace\Application;
 
 use App\Marketplace\Application\Command\SyncConnectionCommand;
+use App\Marketplace\Application\Service\WbFinancialReportSyncPlannerInterface;
 use App\Marketplace\Entity\MarketplaceRawDocument;
+use App\Marketplace\Enum\FinancialReportSyncMode;
+use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Repository\MarketplaceConnectionRepository;
 use App\Marketplace\Service\Integration\MarketplaceAdapterRegistry;
 use Doctrine\ORM\EntityManagerInterface;
 use Ramsey\Uuid\Uuid;
 
 /**
- * Загружает сырой отчёт с маркетплейса за указанный период и сохраняет его как MarketplaceRawDocument.
+ * Для не-WB загружает сырой отчёт за указанный период и сохраняет его как MarketplaceRawDocument.
+ * Для WB только планирует дневные задачи новой финансовой синхронизации.
  *
  * Используется из:
  *   - MarketplaceController::syncConnection()       — синхронизация за последние 7 дней
  *   - MarketplaceController::syncConnectionPeriod() — синхронизация за произвольный период
  *
- * @return int количество загруженных записей
+ * @return int количество загруженных записей (не-WB) или запланированных задач (WB)
  */
 final class SyncConnectionAction
 {
+    private const WB_MANUAL_RANGE_LIMIT_DAYS = 31;
+
     public function __construct(
         private readonly MarketplaceConnectionRepository $connectionRepository,
         private readonly MarketplaceAdapterRegistry $adapterRegistry,
         private readonly EntityManagerInterface $em,
+        private readonly WbFinancialReportSyncPlannerInterface $wbFinancialReportSyncPlanner,
     ) {
     }
 
@@ -41,6 +48,10 @@ final class SyncConnectionAction
         $this->em->flush();
 
         try {
+            if (MarketplaceType::WILDBERRIES === $connection->getMarketplace()) {
+                return $this->planWbManualSync($command);
+            }
+
             $company  = $connection->getCompany();
             $adapter  = $this->adapterRegistry->get($connection->getMarketplace());
             $response     = $adapter->fetchRawReport($company, $command->fromDate, $command->toDate);
@@ -69,5 +80,42 @@ final class SyncConnectionAction
 
             throw $e;
         }
+    }
+
+    private function planWbManualSync(SyncConnectionCommand $command): int
+    {
+        $from = $this->normalizeWbBusinessDate($command->fromDate);
+        $to = $this->normalizeWbBusinessDate($command->toDate);
+
+        if ($from > $to) {
+            throw new \DomainException('Дата начала должна быть меньше или равна дате окончания');
+        }
+
+        $planResult = $this->wbFinancialReportSyncPlanner->planRangeLimited(
+            $from,
+            $to,
+            FinancialReportSyncMode::MANUAL,
+            self::WB_MANUAL_RANGE_LIMIT_DAYS,
+            $command->companyId,
+            $command->connectionId,
+            true,
+        );
+
+        return $planResult->dispatchedCount;
+    }
+
+    private function normalizeWbBusinessDate(\DateTimeImmutable $date): \DateTimeImmutable
+    {
+        $businessDate = \DateTimeImmutable::createFromFormat(
+            '!Y-m-d',
+            $date->format('Y-m-d'),
+            new \DateTimeZone('Europe/Moscow'),
+        );
+
+        if (!$businessDate instanceof \DateTimeImmutable) {
+            throw new \DomainException('Неверный формат даты WB');
+        }
+
+        return $businessDate;
     }
 }

--- a/site/src/Marketplace/Controller/MarketplaceController.php
+++ b/site/src/Marketplace/Controller/MarketplaceController.php
@@ -200,11 +200,18 @@ class MarketplaceController extends AbstractController
             $count = ($this->syncConnectionAction)($cmd);
 
             $connection = $this->connectionRepository->find($id);
-            $this->addFlash('success', sprintf(
-                'Загружено %d записей от %s.',
-                $count,
-                $connection?->getMarketplace()->getDisplayName() ?? 'маркетплейса',
-            ));
+            if ($connection?->getMarketplace() === MarketplaceType::WILDBERRIES) {
+                $this->addFlash('success', sprintf(
+                    'Запланировано %d задач синхронизации WB.',
+                    $count,
+                ));
+            } else {
+                $this->addFlash('success', sprintf(
+                    'Загружено %d записей от %s.',
+                    $count,
+                    $connection?->getMarketplace()->getDisplayName() ?? 'маркетплейса',
+                ));
+            }
         } catch (\DomainException $e) {
             throw $this->createNotFoundException($e->getMessage());
         } catch (\Exception $e) {
@@ -257,13 +264,22 @@ class MarketplaceController extends AbstractController
             );
             $count = ($this->syncConnectionAction)($cmd);
 
-            $this->addFlash('success', sprintf(
-                'Загружено %d записей от %s за период %s — %s.',
-                $count,
-                $connection->getMarketplace()->getDisplayName(),
-                $fromDate->format('d.m.Y'),
-                $toDate->format('d.m.Y'),
-            ));
+            if ($connection->getMarketplace() === MarketplaceType::WILDBERRIES) {
+                $this->addFlash('success', sprintf(
+                    'Запланировано %d задач синхронизации WB за период %s — %s.',
+                    $count,
+                    $fromDate->format('d.m.Y'),
+                    $toDate->format('d.m.Y'),
+                ));
+            } else {
+                $this->addFlash('success', sprintf(
+                    'Загружено %d записей от %s за период %s — %s.',
+                    $count,
+                    $connection->getMarketplace()->getDisplayName(),
+                    $fromDate->format('d.m.Y'),
+                    $toDate->format('d.m.Y'),
+                ));
+            }
         } catch (\Exception $e) {
             $this->addFlash('error', 'Ошибка загрузки: ' . $e->getMessage());
         }

--- a/site/tests/Unit/Marketplace/SyncConnectionActionTest.php
+++ b/site/tests/Unit/Marketplace/SyncConnectionActionTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace;
+
+use App\Company\Entity\Company;
+use App\Company\Entity\User;
+use App\Marketplace\Application\Command\SyncConnectionCommand;
+use App\Marketplace\Application\Service\WbFinancialReportSyncPlannerInterface;
+use App\Marketplace\Application\Service\WbFinancialReportSyncPlanResult;
+use App\Marketplace\Application\SyncConnectionAction;
+use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Enum\FinancialReportSyncMode;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Repository\MarketplaceConnectionRepository;
+use App\Marketplace\Service\Integration\MarketplaceAdapterRegistry;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+final class SyncConnectionActionTest extends TestCase
+{
+    public function testWildberriesManualSyncSchedulesPlannerTasksInsteadOfFetchingRawReport(): void
+    {
+        $companyId = '11111111-1111-4111-8111-111111111111';
+        $connectionId = '22222222-2222-4222-8222-222222222222';
+        $company = new Company($companyId, self::uninitialized(User::class));
+        $connection = new MarketplaceConnection($connectionId, $company, MarketplaceType::WILDBERRIES);
+
+        $repository = $this->createMock(MarketplaceConnectionRepository::class);
+        $repository->expects(self::once())
+            ->method('find')
+            ->with($connectionId)
+            ->willReturn($connection);
+
+        $adapterRegistry = $this->createMock(MarketplaceAdapterRegistry::class);
+        $adapterRegistry->expects(self::never())->method('get');
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::never())->method('persist');
+        $entityManager->expects(self::once())->method('flush');
+
+        $planner = $this->createMock(WbFinancialReportSyncPlannerInterface::class);
+        $planner->expects(self::once())
+            ->method('planRangeLimited')
+            ->with(
+                self::callback(
+                    static fn (\DateTimeImmutable $date): bool => '2026-02-10 00:00:00 Europe/Moscow'
+                        === $date->format('Y-m-d H:i:s e'),
+                ),
+                self::callback(
+                    static fn (\DateTimeImmutable $date): bool => '2026-02-10 00:00:00 Europe/Moscow'
+                        === $date->format('Y-m-d H:i:s e'),
+                ),
+                FinancialReportSyncMode::MANUAL,
+                31,
+                $companyId,
+                $connectionId,
+                true,
+            )
+            ->willReturn(new WbFinancialReportSyncPlanResult(
+                candidatesCount: 1,
+                dispatchLimit: 31,
+                attemptedCount: 1,
+                dispatchedCount: 1,
+                skippedByLimitCount: 0,
+            ));
+
+        $action = new SyncConnectionAction($repository, $adapterRegistry, $entityManager, $planner);
+
+        $scheduledCount = $action(new SyncConnectionCommand(
+            companyId: $companyId,
+            connectionId: $connectionId,
+            fromDate: new \DateTimeImmutable('2026-02-10 12:30:00 UTC'),
+            toDate: new \DateTimeImmutable('2026-02-10 23:59:59 UTC'),
+        ));
+
+        self::assertSame(1, $scheduledCount);
+        self::assertNull($connection->getLastSuccessfulSyncAt());
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param class-string<T> $className
+     *
+     * @return T
+     */
+    private static function uninitialized(string $className): object
+    {
+        return (new \ReflectionClass($className))->newInstanceWithoutConstructor();
+    }
+}


### PR DESCRIPTION
### Motivation

- Introduce special handling for Wildberries (WB) connections so manual syncs schedule per-day financial sync tasks rather than fetching a single raw report.
- Enforce WB-specific date normalization to business dates in `Europe/Moscow` and limit manual ranges to 31 days.

### Description

- Add branching in `SyncConnectionAction` to route WB connections to a new `planWbManualSync` flow and inject `WbFinancialReportSyncPlannerInterface` for planning tasks. 
- Implement `planWbManualSync`, `normalizeWbBusinessDate` and `WB_MANUAL_RANGE_LIMIT_DAYS` constant, and return the planner result's `dispatchedCount` instead of raw-record counts for WB. 
- Update `MarketplaceController` sync endpoints to show different success messages for WB (scheduled tasks) versus other marketplaces (loaded records). 
- Add unit test `SyncConnectionActionTest` that verifies WB scheduling is invoked, the adapter is not called, and the planner result is returned correctly. 

### Testing

- Ran the new unit test `SyncConnectionActionTest` via PHPUnit which exercises WB manual scheduling, and it passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a244bc17b34832397d1c95f9e8dfb87)