### PR TITLE
Add feature flag and safety checks to WB legacy reconcile command; update env and tests

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -25,6 +25,7 @@ x-php-env: &php-env
     APP_MAIL_FROM: "Ваш Финдир <support@vashfindir.ru>"
     APP_MAIL_REPLY_TO: "support@vashfindir.ru"
     FEATURE_FUNDS_AND_WIDGET: ${FEATURE_FUNDS_AND_WIDGET:-1}
+    WB_LEGACY_RECONCILE_ENABLED: ${WB_LEGACY_RECONCILE_ENABLED:-0}
     LLM_API_URL: "https://example.com/v1/chat/completions"
     LLM_API_KEY: "change-me"
 
@@ -406,6 +407,7 @@ services:
             APP_MAIL_FROM: "Ваш Финдир <support@vashfindir.ru>"
             APP_MAIL_REPLY_TO: "support@vashfindir.ru"
             FEATURE_FUNDS_AND_WIDGET: ${FEATURE_FUNDS_AND_WIDGET:-1}
+            WB_LEGACY_RECONCILE_ENABLED: ${WB_LEGACY_RECONCILE_ENABLED:-0}
         volumes:
             - ./docker/cron/app.cron:/etc/crontabs/app.cron:ro
             - site_storage:/app/var/storage

--- a/site/.env
+++ b/site/.env
@@ -58,6 +58,7 @@ REDIS_DSN=redis://site-redis:6379
 
 ###> feature flags ###
 FEATURE_FUNDS_AND_WIDGET=false
+WB_LEGACY_RECONCILE_ENABLED=false
 ###< feature flags ###
 
 BANK_PROVIDERS=demo,alfa

--- a/site/.env.test
+++ b/site/.env.test
@@ -6,6 +6,7 @@ APP_DEBUG=1
 DATABASE_URL="postgresql://app:secret@site-postgres:5432/app_test?serverVersion=15&charset=utf8"
 
 FEATURE_FUNDS_AND_WIDGET=false
+WB_LEGACY_RECONCILE_ENABLED=false
 
 LLM_API_URL="https://example.com/v1/chat/completions"
 LLM_API_KEY="test-key"

--- a/site/src/Marketplace/Command/WbFinancialReportsReconcileLegacyCommand.php
+++ b/site/src/Marketplace/Command/WbFinancialReportsReconcileLegacyCommand.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 #[AsCommand(
     name: 'app:marketplace:wb-financial-reports:reconcile-legacy',
@@ -34,12 +35,15 @@ final class WbFinancialReportsReconcileLegacyCommand extends Command
     private const API_ENDPOINT = 'wildberries::finance-sales-reports-detailed';
     private const LEGACY_GENERATED_ENDPOINT = 'legacy_generated_rows';
     private const FLUSH_BATCH_SIZE = 500;
+    private const FEATURE_FLAG_ENV = 'WB_LEGACY_RECONCILE_ENABLED';
 
     public function __construct(
         private readonly Connection $connection,
         private readonly WbFinancialReportPeriodResolver $periodResolver,
         private readonly MarketplaceFinancialReportSyncStatusRepository $syncStatusRepository,
         private readonly EntityManagerInterface $entityManager,
+        #[Autowire('%env(bool:WB_LEGACY_RECONCILE_ENABLED)%')]
+        private readonly bool $legacyReconcileEnabled,
     ) {
         parent::__construct();
     }
@@ -47,17 +51,40 @@ final class WbFinancialReportsReconcileLegacyCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addOption('company-id', null, InputOption::VALUE_OPTIONAL)
-            ->addOption('connection-id', null, InputOption::VALUE_OPTIONAL)
+            ->addOption('company-id', null, InputOption::VALUE_OPTIONAL, 'Target company UUID; required together with enabled '.self::FEATURE_FLAG_ENV.' for writes/diagnostics')
+            ->addOption('connection-id', null, InputOption::VALUE_OPTIONAL, 'Target marketplace connection UUID; required together with enabled '.self::FEATURE_FLAG_ENV.' for writes/diagnostics')
             ->addOption('from', null, InputOption::VALUE_OPTIONAL, 'Y-m-d; default current year start')
             ->addOption('to', null, InputOption::VALUE_OPTIONAL, 'Y-m-d; default yesterday')
-            ->addOption('dry-run', null, InputOption::VALUE_NONE)
-            ->addOption('limit', null, InputOption::VALUE_OPTIONAL, 'Limit active connections');
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Diagnostic mode: calculate reconciliation stats without persisting statuses')
+            ->addOption('limit', null, InputOption::VALUE_OPTIONAL, 'Limit active connections after explicit company/connection targeting')
+            ->setHelp(sprintf(
+                'Transition-only command. Set %s=true and pass --company-id or --connection-id explicitly; use --dry-run for diagnostics. After the transition period, remove this command or convert it to read-only diagnostics.',
+                self::FEATURE_FLAG_ENV,
+            ));
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
+
+        $companyId = $this->normalizeOptional((string) $input->getOption('company-id'));
+        $connectionId = $this->normalizeOptional((string) $input->getOption('connection-id'));
+        $fromOption = $this->normalizeOptional((string) $input->getOption('from'));
+        $toOption = $this->normalizeOptional((string) $input->getOption('to'));
+        $dryRun = (bool) $input->getOption('dry-run');
+        $limit = (int) ((string) $input->getOption('limit') ?: '0');
+
+        if (!$this->isLegacyReconcileEnabled()) {
+            $io->error(sprintf('Legacy WB reconciliation is disabled. Set %s=true and pass --company-id or --connection-id to run this transition-only command.', self::FEATURE_FLAG_ENV));
+
+            return Command::FAILURE;
+        }
+
+        if (null === $companyId && null === $connectionId) {
+            $io->error('Legacy WB reconciliation requires explicit targeting via --company-id or --connection-id. Use --dry-run with the same targeting for diagnostics.');
+
+            return Command::FAILURE;
+        }
 
         if (!$this->lock()) {
             $io->note('Command is already running.');
@@ -66,13 +93,6 @@ final class WbFinancialReportsReconcileLegacyCommand extends Command
         }
 
         try {
-            $companyId = $this->normalizeOptional((string) $input->getOption('company-id'));
-            $connectionId = $this->normalizeOptional((string) $input->getOption('connection-id'));
-            $fromOption = $this->normalizeOptional((string) $input->getOption('from'));
-            $toOption = $this->normalizeOptional((string) $input->getOption('to'));
-            $dryRun = (bool) $input->getOption('dry-run');
-            $limit = (int) ((string) $input->getOption('limit') ?: '0');
-
             if ($limit < 0) {
                 $io->error('Option --limit must be greater than or equal to 0.');
 
@@ -265,6 +285,11 @@ final class WbFinancialReportsReconcileLegacyCommand extends Command
         if (0 === $created % self::FLUSH_BATCH_SIZE) {
             $this->entityManager->flush();
         }
+    }
+
+    private function isLegacyReconcileEnabled(): bool
+    {
+        return $this->legacyReconcileEnabled;
     }
 
     private function normalizeOptional(string $value): ?string

--- a/site/tests/Integration/Marketplace/Command/WbFinancialReportsReconcileLegacyCommandTest.php
+++ b/site/tests/Integration/Marketplace/Command/WbFinancialReportsReconcileLegacyCommandTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Tests\Integration\Marketplace\Command;
 
 use App\Company\Entity\Company;
+use App\Marketplace\Application\Service\WbFinancialReportPeriodResolver;
+use App\Marketplace\Command\WbFinancialReportsReconcileLegacyCommand;
 use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Entity\MarketplaceCost;
 use App\Marketplace\Entity\MarketplaceFinancialReportSyncStatus;
@@ -13,22 +15,46 @@ use App\Marketplace\Enum\FinancialReportSyncStatus;
 use App\Marketplace\Enum\MarketplaceConnectionType;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Enum\PipelineStatus;
+use App\Marketplace\Repository\MarketplaceFinancialReportSyncStatusRepository;
 use App\Tests\Builders\Company\CompanyBuilder;
 use App\Tests\Builders\Company\UserBuilder;
 use App\Tests\Support\Kernel\IntegrationTestCase;
+use Doctrine\DBAL\Connection;
 use Ramsey\Uuid\Uuid;
-use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
 final class WbFinancialReportsReconcileLegacyCommandTest extends IntegrationTestCase
 {
+    public function testDisabledByDefaultReturnsFailure(): void
+    {
+        [$company, $connection] = $this->seedWbConnection();
+        $this->seedRaw($company, '2026-01-02', PipelineStatus::COMPLETED, 3, 'legacy::wb-endpoint');
+
+        $exit = $this->tester(false)->execute([
+            '--company-id' => $company->getId(),
+            '--from' => '2026-01-02',
+            '--to' => '2026-01-02',
+            '--dry-run' => true,
+        ]);
+
+        self::assertSame(Command::FAILURE, $exit);
+        self::assertSame(0, $this->countStatuses($company->getId(), $connection->getId()));
+    }
+
+    public function testEnabledCommandRequiresExplicitTarget(): void
+    {
+        $exit = $this->tester()->execute(['--from' => '2026-01-02', '--to' => '2026-01-02', '--dry-run' => true]);
+
+        self::assertSame(Command::FAILURE, $exit);
+    }
+
     public function testDryRunDoesNotPersistStatuses(): void
     {
         [$company, $connection] = $this->seedWbConnection();
         $this->seedRaw($company, '2026-01-02', PipelineStatus::COMPLETED, 3, 'legacy::wb-endpoint');
 
-        $exit = $this->tester()->execute(['--from' => '2026-01-02', '--to' => '2026-01-02', '--dry-run' => true]);
+        $exit = $this->tester()->execute(['--company-id' => $company->getId(), '--from' => '2026-01-02', '--to' => '2026-01-02', '--dry-run' => true]);
 
         self::assertSame(Command::SUCCESS, $exit);
         self::assertSame(0, $this->countStatuses($company->getId(), $connection->getId()));
@@ -39,7 +65,7 @@ final class WbFinancialReportsReconcileLegacyCommandTest extends IntegrationTest
         [$company, $connection] = $this->seedWbConnection();
         $raw = $this->seedRaw($company, '2026-01-03', PipelineStatus::COMPLETED, 2, 'legacy::old-api');
 
-        $exit = $this->tester()->execute(['--from' => '2026-01-03', '--to' => '2026-01-03']);
+        $exit = $this->tester()->execute(['--company-id' => $company->getId(), '--from' => '2026-01-03', '--to' => '2026-01-03']);
 
         self::assertSame(Command::SUCCESS, $exit);
         $status = $this->findStatus($company->getId(), $connection->getId(), '2026-01-03');
@@ -54,7 +80,7 @@ final class WbFinancialReportsReconcileLegacyCommandTest extends IntegrationTest
         [$company, $connection] = $this->seedWbConnection();
         $raw = $this->seedRaw($company, '2026-01-08', PipelineStatus::FAILED, 3, 'legacy::failed-api');
 
-        $exit = $this->tester()->execute(['--from' => '2026-01-08', '--to' => '2026-01-08']);
+        $exit = $this->tester()->execute(['--company-id' => $company->getId(), '--from' => '2026-01-08', '--to' => '2026-01-08']);
 
         self::assertSame(Command::SUCCESS, $exit);
         $status = $this->findStatus($company->getId(), $connection->getId(), '2026-01-08');
@@ -68,7 +94,7 @@ final class WbFinancialReportsReconcileLegacyCommandTest extends IntegrationTest
         [$company, $connection] = $this->seedWbConnection();
         $this->seedRaw($company, '2026-01-04', PipelineStatus::PENDING, 1, 'legacy::old-api');
 
-        $exit = $this->tester()->execute(['--from' => '2026-01-04', '--to' => '2026-01-04']);
+        $exit = $this->tester()->execute(['--company-id' => $company->getId(), '--from' => '2026-01-04', '--to' => '2026-01-04']);
 
         self::assertSame(Command::SUCCESS, $exit);
         $status = $this->findStatus($company->getId(), $connection->getId(), '2026-01-04');
@@ -81,7 +107,7 @@ final class WbFinancialReportsReconcileLegacyCommandTest extends IntegrationTest
         [$company, $connection] = $this->seedWbConnection();
         $this->seedCost($company, new \DateTimeImmutable('2026-01-06 12:34:00'));
 
-        $exit = $this->tester()->execute(['--from' => '2026-01-06', '--to' => '2026-01-06']);
+        $exit = $this->tester()->execute(['--company-id' => $company->getId(), '--from' => '2026-01-06', '--to' => '2026-01-06']);
 
         self::assertSame(Command::SUCCESS, $exit);
         $status = $this->findStatus($company->getId(), $connection->getId(), '2026-01-06');
@@ -94,7 +120,7 @@ final class WbFinancialReportsReconcileLegacyCommandTest extends IntegrationTest
     {
         [$company, $connection] = $this->seedWbConnection();
 
-        $exit = $this->tester()->execute(['--from' => '2026-01-07', '--to' => '2026-01-07']);
+        $exit = $this->tester()->execute(['--company-id' => $company->getId(), '--from' => '2026-01-07', '--to' => '2026-01-07']);
 
         self::assertSame(Command::SUCCESS, $exit);
         self::assertNull($this->findStatus($company->getId(), $connection->getId(), '2026-01-07'));
@@ -102,7 +128,7 @@ final class WbFinancialReportsReconcileLegacyCommandTest extends IntegrationTest
 
     public function testFromGreaterThanToReturnsFailure(): void
     {
-        $exit = $this->tester()->execute(['--from' => '2026-01-10', '--to' => '2026-01-01']);
+        $exit = $this->tester()->execute(['--company-id' => Uuid::uuid7()->toString(), '--from' => '2026-01-10', '--to' => '2026-01-01']);
 
         self::assertSame(Command::FAILURE, $exit);
     }
@@ -123,7 +149,7 @@ final class WbFinancialReportsReconcileLegacyCommandTest extends IntegrationTest
 
     public function testNegativeLimitReturnsFailure(): void
     {
-        $exit = $this->tester()->execute(['--limit' => '-1']);
+        $exit = $this->tester()->execute(['--company-id' => Uuid::uuid7()->toString(), '--limit' => '-1']);
 
         self::assertSame(Command::FAILURE, $exit);
     }
@@ -133,8 +159,8 @@ final class WbFinancialReportsReconcileLegacyCommandTest extends IntegrationTest
         [$company, $connection] = $this->seedWbConnection();
         $this->seedRaw($company, '2026-01-05', PipelineStatus::COMPLETED, 1, 'legacy::old-api');
 
-        $this->tester()->execute(['--from' => '2026-01-05', '--to' => '2026-01-05']);
-        $this->tester()->execute(['--from' => '2026-01-05', '--to' => '2026-01-05']);
+        $this->tester()->execute(['--company-id' => $company->getId(), '--from' => '2026-01-05', '--to' => '2026-01-05']);
+        $this->tester()->execute(['--company-id' => $company->getId(), '--from' => '2026-01-05', '--to' => '2026-01-05']);
 
         self::assertSame(1, $this->countStatuses($company->getId(), $connection->getId()));
     }
@@ -205,10 +231,16 @@ final class WbFinancialReportsReconcileLegacyCommandTest extends IntegrationTest
         ]);
     }
 
-    private function tester(): CommandTester
+    private function tester(bool $legacyEnabled = true): CommandTester
     {
-        $app = new Application(self::bootKernel());
+        $command = new WbFinancialReportsReconcileLegacyCommand(
+            self::getContainer()->get(Connection::class),
+            self::getContainer()->get(WbFinancialReportPeriodResolver::class),
+            self::getContainer()->get(MarketplaceFinancialReportSyncStatusRepository::class),
+            $this->em,
+            $legacyEnabled,
+        );
 
-        return new CommandTester($app->find('app:marketplace:wb-financial-reports:reconcile-legacy'));
+        return new CommandTester($command);
     }
 }


### PR DESCRIPTION
### Motivation
- Introduce an opt-in feature flag to gate a transition-only legacy Wildberries reconcile command to prevent accidental mass writes. 
- Require explicit targeting for writes and provide a diagnostic `--dry-run` mode to inspect results without persisting.

### Description
- Add `WB_LEGACY_RECONCILE_ENABLED` environment variable to `docker-compose.prod.yml`, `site/.env` and `site/.env.test` with default `false`. 
- Wire a new constructor boolean `legacyReconcileEnabled` into `WbFinancialReportsReconcileLegacyCommand` using `#[Autowire('%env(bool:WB_LEGACY_RECONCILE_ENABLED)%')]` and add `isLegacyReconcileEnabled()` helper. 
- Enforce the feature flag and explicit targeting by failing early with a clear message when `WB_LEGACY_RECONCILE_ENABLED` is not enabled or neither `--company-id` nor `--connection-id` is provided; update command options/help and require `--company-id`/`--connection-id` for non-diagnostic runs. 
- Keep `--dry-run` diagnostic mode; adjust option handling/validation order and small refactors (`normalizeOptional` usage). 
- Update integration tests to instantiate the command directly (allowing toggling the flag in tests), add tests `testDisabledByDefaultReturnsFailure` and `testEnabledCommandRequiresExplicitTarget`, and change existing tests to pass `--company-id` where explicit targeting is required.

### Testing
- Ran the updated integration tests for `WbFinancialReportsReconcileLegacyCommand` (PHPUnit) covering dry-run behavior, success/failure cases, validation of UUIDs, limit handling and idempotency, and the new gating behavior; tests passed. 
- Verified new tests `testDisabledByDefaultReturnsFailure` and `testEnabledCommandRequiresExplicitTarget` execute and assert expected `Command::FAILURE` conditions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24fbfb208c8323a635faf7b258a87b)