### PR TITLE
Quarantine legacy Wildberries (WB) sync: fail-fast logging, Monolog channel and tests

### DIFF
--- a/docs/marketplace/legacy-wb-sync-quarantine-runbook.md
+++ b/docs/marketplace/legacy-wb-sync-quarantine-runbook.md
@@ -1,0 +1,34 @@
+# Legacy WB sync quarantine runbook
+
+## Alert signal
+
+Legacy WB sync fail-fast paths log ERROR events in Monolog channel `legacy_wb_sync`.
+The production Monolog `sentry` handler accepts this channel and forwards ERROR-level
+events to Sentry/GlitchTip.
+
+Use the stable log/Sentry marker:
+
+```text
+legacy_event=legacy_wb_sync_fail_fast
+```
+
+Each event includes:
+
+- `company_id` when available;
+- `connection_id` when available;
+- `command_class` and/or `message_class`;
+- `recommended_replacement`.
+
+## Quarantine period
+
+Keep the legacy WB entrypoints disabled and monitored for 2–4 weeks. The quarantine
+window can be closed only after there are no `legacy_wb_sync_fail_fast` events for
+the entire selected period.
+
+Recommended checks:
+
+1. Daily: check Sentry/GlitchTip for `legacy_event=legacy_wb_sync_fail_fast`.
+2. Weekly: check container logs for the same marker if Sentry ingestion was degraded.
+3. If any event appears, record its `company_id`, `connection_id`, `command_class` or
+   `message_class`, migrate the caller to `recommended_replacement`, and restart the
+   quarantine window.

--- a/site/config/packages/monolog.yaml
+++ b/site/config/packages/monolog.yaml
@@ -4,6 +4,9 @@ monolog:
         - import.bank1c
         - recalc
         - marketplace_ads
+        # ERROR in this channel is intentionally routed to Sentry by the prod sentry handler.
+        # Use event marker legacy_wb_sync_fail_fast as the alert/query key during quarantine.
+        - legacy_wb_sync
 
 when@dev:
     monolog:

--- a/site/src/Marketplace/Command/MarketplaceSyncCommand.php
+++ b/site/src/Marketplace/Command/MarketplaceSyncCommand.php
@@ -1,13 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Marketplace\Command;
 
 use App\Company\Entity\Company;
-use App\Marketplace\Facade\MarketplaceSyncFacade;
+use App\Company\Facade\CompanyFacade;
 use App\Marketplace\Enum\MarketplaceConnectionType;
 use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Facade\MarketplaceSyncFacade;
 use App\Marketplace\Repository\MarketplaceConnectionRepository;
-use App\Company\Facade\CompanyFacade;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -15,6 +18,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 #[AsCommand(
     name: 'marketplace:sync',
@@ -34,6 +38,8 @@ class MarketplaceSyncCommand extends Command
         private readonly MarketplaceConnectionRepository $connectionRepository,
         private readonly MarketplaceSyncFacade $syncFacade,
         private readonly CompanyFacade $companyFacade,
+        #[Autowire(service: 'monolog.logger.legacy_wb_sync')]
+        private readonly LoggerInterface $logger,
     ) {
         parent::__construct();
     }
@@ -63,6 +69,15 @@ class MarketplaceSyncCommand extends Command
         }
 
         if (MarketplaceType::WILDBERRIES === $marketplace) {
+            $this->logger->error('Legacy WB sync fail-fast triggered.', [
+                'legacy_event' => 'legacy_wb_sync_fail_fast',
+                'company_id' => is_string($companyId) && '' !== $companyId ? $companyId : null,
+                'connection_id' => null,
+                'command_class' => self::class,
+                'message_class' => null,
+                'recommended_replacement' => sprintf('%s (%s)', WbFinancialReportsSyncCommand::class, self::WB_FINANCIAL_REPORTS_SYNC_COMMAND),
+            ]);
+
             $io->error(sprintf(
                 'Legacy WB sync отключён. Используйте новую команду: %s',
                 self::WB_FINANCIAL_REPORTS_SYNC_COMMAND,

--- a/site/src/Marketplace/Facade/MarketplaceSyncFacade.php
+++ b/site/src/Marketplace/Facade/MarketplaceSyncFacade.php
@@ -7,8 +7,11 @@ namespace App\Marketplace\Facade;
 use App\Marketplace\Application\Command\FetchMarketplaceDataCommand;
 use App\Marketplace\Application\Command\ProcessMarketplaceRawDocumentCommand;
 use App\Marketplace\Application\ProcessRawDocumentAction;
+use App\Marketplace\Application\Service\WbFinancialReportSyncPlanner;
+use App\Marketplace\Command\WbFinancialReportsSyncCommand;
 use App\Marketplace\Enum\MarketplaceType;
-use DomainException;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 final readonly class MarketplaceSyncFacade
@@ -19,6 +22,8 @@ final readonly class MarketplaceSyncFacade
     public function __construct(
         private ProcessRawDocumentAction $processRawDocumentAction,
         private MessageBusInterface $messageBus,
+        #[Autowire(service: 'monolog.logger.legacy_wb_sync')]
+        private LoggerInterface $logger,
     ) {
     }
 
@@ -28,7 +33,7 @@ final readonly class MarketplaceSyncFacade
         \DateTimeInterface $fromDate,
         \DateTimeInterface $toDate,
     ): int {
-        $this->guardLegacyWbSync($marketplace);
+        $this->guardLegacyWbSync($marketplace, $companyId, __METHOD__);
 
         $immutableFrom = $fromDate instanceof \DateTimeImmutable ? $fromDate : \DateTimeImmutable::createFromInterface($fromDate);
         $this->messageBus->dispatch(new FetchMarketplaceDataCommand(
@@ -48,7 +53,7 @@ final readonly class MarketplaceSyncFacade
         \DateTimeInterface $fromDate,
         \DateTimeInterface $toDate,
     ): int {
-        $this->guardLegacyWbSync($marketplace);
+        $this->guardLegacyWbSync($marketplace, $companyId, __METHOD__);
 
         $immutableFrom = $fromDate instanceof \DateTimeImmutable ? $fromDate : \DateTimeImmutable::createFromInterface($fromDate);
         $this->messageBus->dispatch(new FetchMarketplaceDataCommand(
@@ -68,7 +73,7 @@ final readonly class MarketplaceSyncFacade
         \DateTimeInterface $fromDate,
         \DateTimeInterface $toDate,
     ): int {
-        $this->guardLegacyWbSync($marketplace);
+        $this->guardLegacyWbSync($marketplace, $companyId, __METHOD__);
 
         $immutableFrom = $fromDate instanceof \DateTimeImmutable ? $fromDate : \DateTimeImmutable::createFromInterface($fromDate);
         $this->messageBus->dispatch(new FetchMarketplaceDataCommand(
@@ -82,14 +87,21 @@ final readonly class MarketplaceSyncFacade
         return 0;
     }
 
-    private function guardLegacyWbSync(MarketplaceType $marketplace): void
+    private function guardLegacyWbSync(MarketplaceType $marketplace, string $companyId, string $entrypoint): void
     {
         if (MarketplaceType::WILDBERRIES === $marketplace) {
-            throw new DomainException(sprintf(
-                'Legacy WB sync отключён. Используйте %s или новую команду %s.',
-                self::WB_FINANCIAL_REPORTS_SYNC_PLANNER,
-                self::WB_FINANCIAL_REPORTS_SYNC_COMMAND,
-            ));
+            $this->logger->error('Legacy WB sync facade fail-fast triggered.', [
+                'legacy_event' => 'legacy_wb_sync_fail_fast',
+                'company_id' => $companyId,
+                'connection_id' => null,
+                'command_class' => null,
+                'entrypoint_class' => self::class,
+                'entrypoint_method' => $entrypoint,
+                'message_class' => null,
+                'recommended_replacement' => sprintf('%s / %s (%s)', WbFinancialReportSyncPlanner::class, WbFinancialReportsSyncCommand::class, self::WB_FINANCIAL_REPORTS_SYNC_COMMAND),
+            ]);
+
+            throw new \DomainException(sprintf('Legacy WB sync отключён. Используйте %s или новую команду %s.', self::WB_FINANCIAL_REPORTS_SYNC_PLANNER, self::WB_FINANCIAL_REPORTS_SYNC_COMMAND));
         }
     }
 
@@ -113,5 +125,4 @@ final readonly class MarketplaceSyncFacade
     {
         return ($this->processRawDocumentAction)(new ProcessMarketplaceRawDocumentCommand($companyId, $rawDocId, 'costs'));
     }
-
 }

--- a/site/src/Marketplace/MessageHandler/SyncWbReportHandler.php
+++ b/site/src/Marketplace/MessageHandler/SyncWbReportHandler.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace App\Marketplace\MessageHandler;
 
+use App\Marketplace\Message\SyncWbFinancialReportDayMessage;
 use App\Marketplace\Message\SyncWbReportMessage;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
@@ -18,8 +21,23 @@ final class SyncWbReportHandler
 {
     private const ERROR_MESSAGE = 'Legacy SyncWbReportMessage is disabled. Use the new pipeline SyncWbFinancialReportDayMessage.';
 
+    public function __construct(
+        #[Autowire(service: 'monolog.logger.legacy_wb_sync')]
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
     public function __invoke(SyncWbReportMessage $message): void
     {
+        $this->logger->error('Legacy WB report message fail-fast triggered.', [
+            'legacy_event' => 'legacy_wb_sync_fail_fast',
+            'company_id' => $message->companyId,
+            'connection_id' => $message->connectionId,
+            'command_class' => null,
+            'message_class' => $message::class,
+            'recommended_replacement' => SyncWbFinancialReportDayMessage::class,
+        ]);
+
         throw new UnrecoverableMessageHandlingException(self::ERROR_MESSAGE);
     }
 }

--- a/site/tests/Unit/Marketplace/LegacyWbSyncDisabledTest.php
+++ b/site/tests/Unit/Marketplace/LegacyWbSyncDisabledTest.php
@@ -8,7 +8,9 @@ use App\Company\Facade\CompanyFacade;
 use App\Marketplace\Application\Command\FetchMarketplaceDataCommand;
 use App\Marketplace\Application\FetchMarketplaceDataAction;
 use App\Marketplace\Application\ProcessRawDocumentAction;
+use App\Marketplace\Application\Service\WbFinancialReportSyncPlanner;
 use App\Marketplace\Command\MarketplaceSyncCommand;
+use App\Marketplace\Command\WbFinancialReportsSyncCommand;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Facade\MarketplaceSyncFacade;
 use App\Marketplace\Infrastructure\Api\MarketplaceFetcherRegistry;
@@ -16,9 +18,9 @@ use App\Marketplace\Infrastructure\Api\Wildberries\WbFetcher;
 use App\Marketplace\Repository\MarketplaceConnectionRepository;
 use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
 use Doctrine\ORM\EntityManagerInterface;
-use DomainException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -32,10 +34,32 @@ final class LegacyWbSyncDisabledTest extends TestCase
         $bus = $this->createMock(MessageBusInterface::class);
         $bus->expects(self::never())->method('dispatch');
 
+        $facadeLogger = $this->createMock(LoggerInterface::class);
+        $facadeLogger->expects(self::never())->method('error');
+
+        $commandLogger = $this->createMock(LoggerInterface::class);
+        $commandLogger->expects(self::once())
+            ->method('error')
+            ->with(
+                'Legacy WB sync fail-fast triggered.',
+                self::callback(static function (array $context): bool {
+                    self::assertSame('legacy_wb_sync_fail_fast', $context['legacy_event']);
+                    self::assertNull($context['company_id']);
+                    self::assertNull($context['connection_id']);
+                    self::assertSame(MarketplaceSyncCommand::class, $context['command_class']);
+                    self::assertNull($context['message_class']);
+                    self::assertStringContainsString(WbFinancialReportsSyncCommand::class, $context['recommended_replacement']);
+                    self::assertStringContainsString('app:marketplace:wb-financial-reports:sync', $context['recommended_replacement']);
+
+                    return true;
+                }),
+            );
+
         $command = new MarketplaceSyncCommand(
             self::uninitialized(MarketplaceConnectionRepository::class),
-            new MarketplaceSyncFacade(self::uninitialized(ProcessRawDocumentAction::class), $bus),
+            new MarketplaceSyncFacade(self::uninitialized(ProcessRawDocumentAction::class), $bus, $facadeLogger),
             self::uninitialized(CompanyFacade::class),
+            $commandLogger,
         );
         self::assertSame('marketplace:sync', $command->getName());
 
@@ -53,9 +77,29 @@ final class LegacyWbSyncDisabledTest extends TestCase
         $bus = $this->createMock(MessageBusInterface::class);
         $bus->expects(self::never())->method('dispatch');
 
-        $facade = new MarketplaceSyncFacade(self::uninitialized(ProcessRawDocumentAction::class), $bus);
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('error')
+            ->with(
+                'Legacy WB sync facade fail-fast triggered.',
+                self::callback(static function (array $context): bool {
+                    self::assertSame('legacy_wb_sync_fail_fast', $context['legacy_event']);
+                    self::assertSame('company-id', $context['company_id']);
+                    self::assertNull($context['connection_id']);
+                    self::assertNull($context['command_class']);
+                    self::assertSame(MarketplaceSyncFacade::class, $context['entrypoint_class']);
+                    self::assertIsString($context['entrypoint_method']);
+                    self::assertNull($context['message_class']);
+                    self::assertStringContainsString(WbFinancialReportSyncPlanner::class, $context['recommended_replacement']);
+                    self::assertStringContainsString('app:marketplace:wb-financial-reports:sync', $context['recommended_replacement']);
 
-        $this->expectException(DomainException::class);
+                    return true;
+                }),
+            );
+
+        $facade = new MarketplaceSyncFacade(self::uninitialized(ProcessRawDocumentAction::class), $bus, $logger);
+
+        $this->expectException(\DomainException::class);
         $this->expectExceptionMessage('Legacy WB sync отключён');
         $this->expectExceptionMessage('WbFinancialReportSyncPlanner');
         $this->expectExceptionMessage('app:marketplace:wb-financial-reports:sync');
@@ -83,8 +127,7 @@ final class LegacyWbSyncDisabledTest extends TestCase
         string $methodName,
         string $expectedProcessKind,
         MarketplaceType $marketplace,
-    ): void
-    {
+    ): void {
         $fromDate = new \DateTimeImmutable('2026-01-01');
         $toDate = new \DateTimeImmutable('2026-01-02');
 
@@ -103,7 +146,10 @@ final class LegacyWbSyncDisabledTest extends TestCase
             }))
             ->willReturnCallback(static fn (object $message): Envelope => new Envelope($message));
 
-        $facade = new MarketplaceSyncFacade(self::uninitialized(ProcessRawDocumentAction::class), $bus);
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::never())->method('error');
+
+        $facade = new MarketplaceSyncFacade(self::uninitialized(ProcessRawDocumentAction::class), $bus, $logger);
 
         self::assertSame(0, $facade->{$methodName}('company-id', $marketplace, $fromDate, $toDate));
     }

--- a/site/tests/Unit/Marketplace/MessageHandler/SyncWbReportHandlerTest.php
+++ b/site/tests/Unit/Marketplace/MessageHandler/SyncWbReportHandlerTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Marketplace\MessageHandler;
 
+use App\Marketplace\Message\SyncWbFinancialReportDayMessage;
 use App\Marketplace\Message\SyncWbReportMessage;
 use App\Marketplace\MessageHandler\SyncWbReportHandler;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 
 final class SyncWbReportHandlerTest extends TestCase
@@ -14,9 +16,28 @@ final class SyncWbReportHandlerTest extends TestCase
     public function testLegacyMessageFailsFastWithoutWbApiLoading(): void
     {
         $reflection = new \ReflectionClass(SyncWbReportHandler::class);
-        self::assertNull($reflection->getConstructor(), 'The legacy handler must not keep WB API/loading dependencies.');
+        $constructor = $reflection->getConstructor();
+        self::assertNotNull($constructor);
+        self::assertCount(1, $constructor->getParameters(), 'The legacy handler must keep only LoggerInterface dependency.');
 
-        $handler = new SyncWbReportHandler();
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('error')
+            ->with(
+                'Legacy WB report message fail-fast triggered.',
+                self::callback(static function (array $context): bool {
+                    self::assertSame('legacy_wb_sync_fail_fast', $context['legacy_event']);
+                    self::assertSame('11111111-1111-1111-1111-111111111111', $context['company_id']);
+                    self::assertSame('22222222-2222-2222-2222-222222222222', $context['connection_id']);
+                    self::assertNull($context['command_class']);
+                    self::assertSame(SyncWbReportMessage::class, $context['message_class']);
+                    self::assertSame(SyncWbFinancialReportDayMessage::class, $context['recommended_replacement']);
+
+                    return true;
+                }),
+            );
+
+        $handler = new SyncWbReportHandler($logger);
 
         $this->expectException(UnrecoverableMessageHandlingException::class);
         $this->expectExceptionMessage('SyncWbFinancialReportDayMessage');


### PR DESCRIPTION
### Motivation

- Disable legacy Wildberries sync entrypoints and surface clear fail-fast alerts to Sentry/logs during a quarantine window. 
- Provide an operational runbook and observable marker for incident tracking and migration guidance.

### Description

- Add a quarantine runbook `docs/marketplace/legacy-wb-sync-quarantine-runbook.md` describing alert marker `legacy_wb_sync_fail_fast` and monitoring steps. 
- Register a `legacy_wb_sync` Monolog channel in `site/config/packages/monolog.yaml` and document that ERRORs are routed to Sentry for quarantine alerts. 
- Update `MarketplaceSyncCommand` to inject the `monolog.logger.legacy_wb_sync` logger and log a fail-fast error with context and `recommended_replacement` before failing when `MarketplaceType::WILDBERRIES` is requested. 
- Update `MarketplaceSyncFacade` to inject the same logger, change `guardLegacyWbSync` to accept `companyId` and `entrypoint`, emit a structured error log and then throw a `DomainException` for WB sync attempts. 
- Update `SyncWbReportHandler` to inject the legacy logger, log a structured fail-fast event when the legacy message is handled, and then throw an `UnrecoverableMessageHandlingException`. 
- Add and update unit tests to assert the new logging and fail-fast behavior in `LegacyWbSyncDisabledTest` and `SyncWbReportHandlerTest`, and adjust facade/command/test wiring accordingly.

### Testing

- Updated unit tests `site/tests/Unit/Marketplace/LegacyWbSyncDisabledTest.php` and `site/tests/Unit/Marketplace/MessageHandler/SyncWbReportHandlerTest.php` were added/modified to assert logger calls and exceptions, and were executed via PHPUnit; they passed. 
- Existing tests that exercise non-WB sync paths remain unchanged and were executed as part of the suite; they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2506f1fcac832393165e9a49c07282)