### PR TITLE
Adjust Bootstrap column classes for operation form layout

### DIFF
--- a/site/templates/document/_operation_form.html.twig
+++ b/site/templates/document/_operation_form.html.twig
@@ -1,5 +1,5 @@
 <div class="row g-3 align-items-end">
-    <div class="col-md-4 col-xl-5">
+    <div class="col-md-4 col-xl-4">
         {{ form_row(operationForm.category) }}
     </div>
     <div class="col-md-2 col-xl-2">
@@ -8,10 +8,10 @@
     <div class="col-md-3 col-xl-3">
         {{ form_row(operationForm.counterparty) }}
     </div>
-    <div class="col-md-3 col-xl-2">
+    <div class="col-md-2 col-xl-2">
         {{ form_row(operationForm.projectDirection) }}
     </div>
-    <div class="col-auto ms-auto">
+    <div class="col-12 col-md-1 d-flex justify-content-end">
         <button type="button"
                 class="btn btn-sm btn-icon btn-outline-danger remove-item"
                 title="Удалить операцию"


### PR DESCRIPTION
### Motivation
- Improve responsive alignment and spacing of form fields and the remove button in the operation row to better fit different breakpoints.

### Description
- Updated `site/templates/document/_operation_form.html.twig` to tweak Bootstrap column sizes for the operation form row.
- Changed the category column from `col-md-4 col-xl-5` to `col-md-4 col-xl-4` to reduce its width at extra-large breakpoints.
- Adjusted the projectDirection column from `col-md-3 col-xl-2` to `col-md-2 col-xl-2` to re-balance field widths.
- Reworked the remove button container from `col-auto ms-auto` to `col-12 col-md-1 d-flex justify-content-end` to ensure proper alignment and stacking on small screens.

### Testing
- No automated tests were added or run for this UI template change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2636642fdc8323ac1ac3ef17203e14)