### PR TITLE
Ensure new operation cards are scrolled into view and allow page scrolling for layout-fluid-vertical

### DIFF
--- a/site/assets/styles/app.css
+++ b/site/assets/styles/app.css
@@ -217,3 +217,16 @@ aside.navbar .navbar-brand {
 .vf-sidebar-company-name {
     word-break: break-word;
 }
+
+/* В layout-fluid-vertical основной контент должен расти по высоте и прокручиваться
+   вместе со страницей, иначе динамически добавленные блоки формы могут оказаться
+   ниже viewport без доступной прокрутки. */
+body.layout-fluid-vertical {
+    overflow-y: auto;
+}
+
+body.layout-fluid-vertical .page,
+body.layout-fluid-vertical .page-wrapper {
+    min-height: 100vh;
+    height: auto;
+}

--- a/site/templates/document/edit.html.twig
+++ b/site/templates/document/edit.html.twig
@@ -156,6 +156,7 @@
                 collectionHolder.appendChild(card);
                 prefillOperationCounterparty(card);
                 prefillOperationProject(card);
+                card.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
             });
 
             collectionHolder.addEventListener('click', function(e){

--- a/site/templates/document/new.html.twig
+++ b/site/templates/document/new.html.twig
@@ -123,6 +123,7 @@
                 collectionHolder.appendChild(card);
                 prefillOperationCounterparty(card);
                 prefillOperationProject(card);
+                card.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
             });
 
             collectionHolder.addEventListener('click', function(e){


### PR DESCRIPTION
### Motivation
- Ensure dynamically added operation cards are visible when appended and that pages using the `layout-fluid-vertical` layout can grow and scroll so form blocks never end up below the viewport without scroll access.

### Description
- Add `card.scrollIntoView({ behavior: 'smooth', block: 'nearest' })` to both `site/templates/document/new.html.twig` and `site/templates/document/edit.html.twig` immediately after appending a new operation card.
- Add CSS rules for `body.layout-fluid-vertical` to enable `overflow-y: auto` and set `min-height: 100vh` on `.page` and `.page-wrapper` so the main content can expand and be scrolled.
- The changes affect `site/assets/styles/app.css` and the two document templates to improve UX for dynamically added form items.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26417e41ec8323b1e6cdcecae3e876)