### PR TITLE
Добавить cron-задачу оркестрации загрузки WB financial reports

### DIFF
--- a/docker/cron/app.cron
+++ b/docker/cron/app.cron
@@ -17,6 +17,11 @@
 # Временно отключено: восстановление пропущенных дней
 #10 * * * * cd /app && php bin/console app:marketplace:wb-financial-reports:sync --mode=missing --max-days=1 --no-interaction --quiet >> /proc/1/fd/1 2>> /proc/1/fd/2
 
+# Оркестрация WB financial reports: каждый час проверяет последние 7 дней.
+# Команда сама учитывает cooldown/LockableTrait и ставит не больше одной задачи на подключение;
+# при отсутствии sync-status за день планирует загрузку как recent missing.
+20 * * * * cd /app && php bin/console app:marketplace:wb-financial-reports:orchestrate --retry-window-days=7 --refresh-days-back=2 --no-interaction --quiet >> /proc/1/fd/1 2>> /proc/1/fd/2
+
 # Ночная синхронизация отчётов Ozon по реализации.
 0 4 * * * php bin/console app:marketplace:ozon-daily-sync --no-interaction
 


### PR DESCRIPTION
### Motivation
- Добавить в планировщик hourly задачу, которая будет запускать оркестрацию загрузки финансовых отчётов Wildberries и проверять последние 7 дней на предмет пропущенных загрузок, чтобы автоматически запланировать загрузку недостающих дней.

### Description
- Добавлена запись в `docker/cron/app.cron` для ежечасного запуска команды `app:marketplace:wb-financial-reports:orchestrate` с опциями `--retry-window-days=7 --refresh-days-back=2`, при этом команда сама учитывает cooldown/LockableTrait и ставит не больше одной задачи на подключение при планировании пропущенных дней.

### Testing
- Выполнена простая валидация cron-строк (скрипт на `python3`, проверяющий наличие 5 полей расписания + команду) и она прошла успешно; попытка запустить `make sched-test` не удалась из-за отсутствия Docker в окружении (`docker: No such file or directory`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2992dd5a4c8323a2c13393116cbc1f)