### PR TITLE
Move cash transaction tabs into card header

### DIFF
--- a/site/templates/transaction/index.html.twig
+++ b/site/templates/transaction/index.html.twig
@@ -63,20 +63,6 @@
     </div>
 </div>
 
-<ul class="nav nav-tabs mb-3">
-    <li class="nav-item">
-        <a class="nav-link active" href="{{ path('cash_transaction_index') }}">Все</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="{{ path('cash_transaction_audit_index') }}">История</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="{{ path('cash_transaction_deleted_index') }}">Удалённые</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link" href="{{ path('cash_transaction_auto_rule_apply_page') }}">Авто-правило прим.</a>
-    </li>
-</ul>
 {% if transactions is defined and transactions|length == 0 %}
   <div class="card my-3">
     <div class="card-body text-center">
@@ -93,6 +79,22 @@
     <div class="col-12">
         <div class="card cashflow-ops"
              data-csrf-token="{{ csrf_token('cash_transaction_create_from') }}">
+            <div class="card-header">
+                <ul class="nav nav-tabs card-header-tabs">
+                    <li class="nav-item">
+                        <a class="nav-link active" href="{{ path('cash_transaction_index') }}">Все</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ path('cash_transaction_audit_index') }}">История</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ path('cash_transaction_deleted_index') }}">Удалённые</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ path('cash_transaction_auto_rule_apply_page') }}">Авто-правило прим.</a>
+                    </li>
+                </ul>
+            </div>
             <div class="table-responsive">
                 <table class="table card-table table-vcenter">
                     <thead class="sticky-top">


### PR DESCRIPTION
## Summary
- Move the cash transaction tabs into card headers on the main list, audit, deleted, and auto-rule apply pages
- Add `card-head` alongside the existing `card-header` class
- Keep the full tabs set: `Все`, `История`, `Удалённые`, `Авто-правило прим.`

## Checks
- `docker compose run --rm -T site-php-cli php bin/console lint:twig templates/transaction/index.html.twig templates/transaction/auto_rule_apply.html.twig templates/cash/transaction/deleted_index.html.twig templates/cash/transaction/audit_index.html.twig`
- `git diff --check`