### PR TITLE
Add PeriodKey-based presets and normalize period handling in Unit Extended widgets

### DIFF
--- a/site/assets/react/marketplace-analytics/components/PeriodPresets.tsx
+++ b/site/assets/react/marketplace-analytics/components/PeriodPresets.tsx
@@ -1,12 +1,26 @@
 import React from 'react';
 
+export type PeriodKey =
+    | 'custom'
+    | 'today'
+    | 'yesterday'
+    | 'current_week'
+    | 'previous_week'
+    | 'current_month'
+    | 'previous_month'
+    | 'current_quarter'
+    | 'current_year'
+    | `month_${number}_${number}`;
+
 interface PeriodPresetsProps {
-    onSelect: (from: string, to: string) => void;
-    currentFrom: string;
-    currentTo: string;
+    onSelect: (from: string, to: string, period: PeriodKey) => void;
+    currentPeriod?: PeriodKey;
+    currentFrom?: string;
+    currentTo?: string;
 }
 
 interface Preset {
+    key: PeriodKey;
     label: string;
     from: string;
     to: string;
@@ -19,38 +33,231 @@ function toDateStr(d: Date): string {
     return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
 }
 
-function buildPreset(offset: number, base: Date): Preset {
+function buildMonthPreset(offset: number, base: Date): Preset {
     const first = new Date(base.getFullYear(), base.getMonth() + offset, 1);
     const last = new Date(base.getFullYear(), base.getMonth() + offset + 1, 0);
     const label = offset === 0
         ? 'Текущий месяц'
         : `${MONTHS[first.getMonth()] ?? ''} ${first.getFullYear()}`;
-    return { label, from: toDateStr(first), to: toDateStr(last) };
+
+    return {
+        key: getMonthPeriodKey(first),
+        label,
+        from: toDateStr(first),
+        to: toDateStr(last),
+    };
+}
+
+export function getMonthPeriodKey(date: Date): PeriodKey {
+    return `month_${date.getFullYear()}_${date.getMonth() + 1}`;
+}
+
+function buildOperationalPresets(base: Date): Preset[] {
+    const today = new Date(base.getFullYear(), base.getMonth(), base.getDate());
+    const yesterday = new Date(today);
+    yesterday.setDate(today.getDate() - 1);
+
+    const currentWeekStart = new Date(today);
+    const day = currentWeekStart.getDay();
+    const daysFromMonday = day === 0 ? 6 : day - 1;
+    currentWeekStart.setDate(today.getDate() - daysFromMonday);
+
+    const previousWeekStart = new Date(currentWeekStart);
+    previousWeekStart.setDate(currentWeekStart.getDate() - 7);
+    const previousWeekEnd = new Date(currentWeekStart);
+    previousWeekEnd.setDate(currentWeekStart.getDate() - 1);
+
+    const currentMonthStart = new Date(today.getFullYear(), today.getMonth(), 1);
+    const previousMonthStart = new Date(today.getFullYear(), today.getMonth() - 1, 1);
+    const previousMonthEnd = new Date(today.getFullYear(), today.getMonth(), 0);
+
+    const quarterStartMonth = Math.floor(today.getMonth() / 3) * 3;
+    const currentQuarterStart = new Date(today.getFullYear(), quarterStartMonth, 1);
+    const currentYearStart = new Date(today.getFullYear(), 0, 1);
+
+    return [
+        { key: 'today', label: 'Сегодня', from: toDateStr(today), to: toDateStr(today) },
+        { key: 'yesterday', label: 'Вчера', from: toDateStr(yesterday), to: toDateStr(yesterday) },
+        { key: 'current_week', label: 'Эта неделя', from: toDateStr(currentWeekStart), to: toDateStr(today) },
+        { key: 'previous_week', label: 'Прошлая неделя', from: toDateStr(previousWeekStart), to: toDateStr(previousWeekEnd) },
+        { key: 'current_month', label: 'Этот месяц', from: toDateStr(currentMonthStart), to: toDateStr(today) },
+        { key: 'previous_month', label: 'Прошлый месяц', from: toDateStr(previousMonthStart), to: toDateStr(previousMonthEnd) },
+        { key: 'current_quarter', label: 'Квартал', from: toDateStr(currentQuarterStart), to: toDateStr(today) },
+        { key: 'current_year', label: 'Год', from: toDateStr(currentYearStart), to: toDateStr(today) },
+    ];
+}
+
+export function getPeriodRange(period: PeriodKey, base = new Date()): { from: string; to: string } | null {
+    if (period === 'custom') {
+        return null;
+    }
+
+    const monthMatch = period.match(/^month_(\d{4})_(\d{1,2})$/);
+    if (monthMatch) {
+        const year = Number(monthMatch[1]);
+        const month = Number(monthMatch[2]);
+        if (month < 1 || month > 12) {
+            return null;
+        }
+
+        const monthIndex = month - 1;
+        const first = new Date(year, monthIndex, 1);
+        const last = new Date(year, monthIndex + 1, 0);
+
+        return { from: toDateStr(first), to: toDateStr(last) };
+    }
+
+    const presets = [
+        ...[-4, -3, -2, -1, 0].map((offset) => buildMonthPreset(offset, base)),
+        ...buildOperationalPresets(base),
+    ];
+    const preset = presets.find((item) => item.key === period);
+
+    return preset ? { from: preset.from, to: preset.to } : null;
+}
+
+
+function parseDateStr(date: string): Date | null {
+    const match = date.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (!match) {
+        return null;
+    }
+
+    const year = Number(match[1]);
+    const monthIndex = Number(match[2]) - 1;
+    const day = Number(match[3]);
+    const parsed = new Date(year, monthIndex, day);
+    if (
+        parsed.getFullYear() !== year
+        || parsed.getMonth() !== monthIndex
+        || parsed.getDate() !== day
+    ) {
+        return null;
+    }
+
+    return parsed;
+}
+
+export function getPeriodKeyForRange(from: string, to: string, base = new Date()): PeriodKey {
+    const fromDate = parseDateStr(from);
+    const toDate = parseDateStr(to);
+    if (!fromDate || !toDate) {
+        return 'custom';
+    }
+
+    const fullMonthEnd = new Date(fromDate.getFullYear(), fromDate.getMonth() + 1, 0);
+    if (
+        fromDate.getDate() === 1
+        && toDate.getFullYear() === fromDate.getFullYear()
+        && toDate.getMonth() === fromDate.getMonth()
+        && toDate.getDate() === fullMonthEnd.getDate()
+    ) {
+        return getMonthPeriodKey(fromDate);
+    }
+
+    const preset = buildOperationalPresets(base).find((item) => item.from === from && item.to === to);
+
+    return preset?.key ?? 'custom';
+}
+
+function isKnownPeriod(period: string | null): period is PeriodKey {
+    if (period === null) {
+        return false;
+    }
+
+    return period === 'custom'
+        || period === 'today'
+        || period === 'yesterday'
+        || period === 'current_week'
+        || period === 'previous_week'
+        || period === 'current_month'
+        || period === 'previous_month'
+        || period === 'current_quarter'
+        || period === 'current_year'
+        || /^month_\d{4}_(?:[1-9]|1[0-2])$/.test(period);
+}
+
+export function normalizePeriod(period: string | null): PeriodKey {
+    return isKnownPeriod(period) ? period : 'custom';
 }
 
 // Вычисляется один раз при загрузке модуля — не пересчитывается на каждый рендер
 const TODAY = new Date();
-const PRESETS: readonly Preset[] = [-4, -3, -2, -1, 0].map((offset) =>
-    buildPreset(offset, TODAY),
+const MONTH_PRESETS: readonly Preset[] = [-4, -3, -2, -1, 0].map((offset) =>
+    buildMonthPreset(offset, TODAY),
+);
+const OPERATIONAL_PRESETS: readonly Preset[] = buildOperationalPresets(TODAY);
+
+const PeriodButton: React.FC<{
+    preset: Preset;
+    isActive: boolean;
+    onSelect: (from: string, to: string, period: PeriodKey) => void;
+}> = ({ preset, isActive, onSelect }) => (
+    <button
+        type="button"
+        aria-pressed={isActive}
+        className={`btn btn-sm rounded-pill ${isActive ? 'btn-primary' : 'btn-outline-secondary'}`}
+        onClick={() => onSelect(preset.from, preset.to, preset.key)}
+    >
+        {preset.label}
+    </button>
 );
 
-const PeriodPresets: React.FC<PeriodPresetsProps> = ({ onSelect, currentFrom, currentTo }) => (
-    <div className="d-flex gap-1 flex-wrap mb-2">
-        {PRESETS.map((preset) => {
-            const isActive = preset.from === currentFrom && preset.to === currentTo;
-            return (
-                <button
-                    key={preset.label}
-                    type="button"
-                    aria-pressed={isActive}
-                    className={`btn btn-sm ${isActive ? 'btn-primary' : 'btn-outline-secondary'}`}
-                    onClick={() => onSelect(preset.from, preset.to)}
-                >
-                    {preset.label}
-                </button>
-            );
-        })}
-    </div>
-);
+const PeriodPresets: React.FC<PeriodPresetsProps> = ({
+    onSelect,
+    currentPeriod,
+    currentFrom,
+    currentTo,
+}) => {
+    const activePeriod = currentPeriod ?? (currentFrom && currentTo
+        ? getPeriodKeyForRange(currentFrom, currentTo, TODAY)
+        : 'custom');
+
+    return (
+        <div className="card mb-3">
+            <div className="card-body py-3">
+                <div className="text-muted text-uppercase small fw-semibold mb-2">Период</div>
+
+                <div className="mb-3">
+                    <div className="small text-muted mb-1">Месяцы:</div>
+                    <div className="d-flex gap-1 flex-wrap">
+                        {MONTH_PRESETS.map((preset) => (
+                            <PeriodButton
+                                key={preset.key}
+                                preset={preset}
+                                isActive={preset.key === activePeriod}
+                                onSelect={onSelect}
+                            />
+                        ))}
+                    </div>
+                </div>
+
+                <div>
+                    <div className="small text-muted mb-1">Быстрый выбор:</div>
+                    <div className="d-flex gap-1 flex-wrap">
+                        {OPERATIONAL_PRESETS.map((preset) => (
+                            <PeriodButton
+                                key={preset.key}
+                                preset={preset}
+                                isActive={preset.key === activePeriod}
+                                onSelect={onSelect}
+                            />
+                        ))}
+                        {activePeriod === 'custom' && (
+                            <button
+                                type="button"
+                                aria-pressed="true"
+                                className="btn btn-sm rounded-pill btn-primary"
+                                disabled
+                            >
+                                Произвольный
+                            </button>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
 
 export default PeriodPresets;

--- a/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedFilters.tsx
+++ b/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedFilters.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PeriodPresets from '../components/PeriodPresets';
+import type { PeriodKey } from '../components/PeriodPresets';
 import type { MarketplaceOption } from '../types/analytics.types';
 
 interface UnitExtendedFiltersProps {
@@ -7,10 +8,11 @@ interface UnitExtendedFiltersProps {
     marketplace: string;
     dateFrom: string;
     dateTo: string;
+    period: PeriodKey;
     onMarketplaceChange: (mp: string) => void;
     onDateFromChange: (date: string) => void;
     onDateToChange: (date: string) => void;
-    onDateRangeChange: (from: string, to: string) => void;
+    onDateRangeChange: (from: string, to: string, period: PeriodKey) => void;
 }
 
 const UnitExtendedFilters: React.FC<UnitExtendedFiltersProps> = ({
@@ -18,6 +20,7 @@ const UnitExtendedFilters: React.FC<UnitExtendedFiltersProps> = ({
     marketplace,
     dateFrom,
     dateTo,
+    period,
     onMarketplaceChange,
     onDateFromChange,
     onDateToChange,
@@ -26,8 +29,7 @@ const UnitExtendedFilters: React.FC<UnitExtendedFiltersProps> = ({
     <>
         <PeriodPresets
             onSelect={onDateRangeChange}
-            currentFrom={dateFrom}
-            currentTo={dateTo}
+            currentPeriod={period}
         />
 
         <div className="row g-2 mb-3">
@@ -49,6 +51,7 @@ const UnitExtendedFilters: React.FC<UnitExtendedFiltersProps> = ({
                     type="date"
                     className="form-control"
                     value={dateFrom}
+                    aria-label="Дата с"
                     onChange={(e) => onDateFromChange(e.target.value)}
                 />
             </div>
@@ -57,6 +60,7 @@ const UnitExtendedFilters: React.FC<UnitExtendedFiltersProps> = ({
                     type="date"
                     className="form-control"
                     value={dateTo}
+                    aria-label="Дата по"
                     onChange={(e) => onDateToChange(e.target.value)}
                 />
             </div>

--- a/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedWidget.tsx
+++ b/site/assets/react/marketplace-analytics/unit-extended/UnitExtendedWidget.tsx
@@ -4,6 +4,8 @@ import { useWidgets } from './widgets/useWidgets';
 import WidgetsGrid from './widgets/WidgetsGrid';
 import { ErrorBoundary } from '../../shared/ui/ErrorBoundary';
 import { getMonthRange } from '../utils/utils';
+import { getMonthPeriodKey, getPeriodKeyForRange, getPeriodRange, normalizePeriod } from '../components/PeriodPresets';
+import type { PeriodKey } from '../components/PeriodPresets';
 import type { MarketplaceOption } from '../types/analytics.types';
 import UnitExtendedFilters from './UnitExtendedFilters';
 import UnitExtendedTable from './UnitExtendedTable';
@@ -17,23 +19,52 @@ interface Filters {
     marketplace: string;
     dateFrom: string;
     dateTo: string;
+    period: PeriodKey;
 }
 
 function getFiltersFromUrl(): Filters {
     const params = new URLSearchParams(window.location.search);
     const currentMonth = getMonthRange(0);
+    const currentMonthPeriod = getMonthPeriodKey(new Date());
+    const urlDateFrom = params.get('dateFrom') ?? params.get('from');
+    const urlDateTo = params.get('dateTo') ?? params.get('to');
+
+    if (params.has('period')) {
+        const requestedPeriod = normalizePeriod(params.get('period'));
+        const requestedRange = getPeriodRange(requestedPeriod);
+
+        return {
+            marketplace: params.get('marketplace') ?? 'ozon',
+            dateFrom: requestedPeriod === 'custom'
+                ? (urlDateFrom ?? currentMonth.from)
+                : (requestedRange?.from ?? currentMonth.from),
+            dateTo: requestedPeriod === 'custom'
+                ? (urlDateTo ?? currentMonth.to)
+                : (requestedRange?.to ?? currentMonth.to),
+            period: requestedRange === null && requestedPeriod !== 'custom' ? 'custom' : requestedPeriod,
+        };
+    }
+
+    const hasAnyDateParam = Boolean(urlDateFrom || urlDateTo);
+    const inferredPeriod = urlDateFrom && urlDateTo
+        ? getPeriodKeyForRange(urlDateFrom, urlDateTo)
+        : (hasAnyDateParam ? 'custom' : currentMonthPeriod);
+    const inferredRange = getPeriodRange(inferredPeriod);
+
     return {
         marketplace: params.get('marketplace') ?? 'ozon',
-        dateFrom: params.get('from') ?? currentMonth.from,
-        dateTo: params.get('to') ?? currentMonth.to,
+        dateFrom: urlDateFrom ?? inferredRange?.from ?? currentMonth.from,
+        dateTo: urlDateTo ?? inferredRange?.to ?? currentMonth.to,
+        period: inferredPeriod,
     };
 }
 
 function setFiltersToUrl(filters: Filters): void {
     const params = new URLSearchParams();
     if (filters.marketplace) params.set('marketplace', filters.marketplace);
-    if (filters.dateFrom) params.set('from', filters.dateFrom);
-    if (filters.dateTo) params.set('to', filters.dateTo);
+    if (filters.dateFrom) params.set('dateFrom', filters.dateFrom);
+    if (filters.dateTo) params.set('dateTo', filters.dateTo);
+    params.set('period', filters.period);
     const search = params.toString();
     window.history.replaceState(null, '', window.location.pathname + (search ? `?${search}` : ''));
 }
@@ -62,15 +93,15 @@ const UnitExtendedWidget: React.FC<UnitExtendedWidgetProps> = ({ marketplaces })
     }, []);
 
     const handleDateFromChange = useCallback((date: string) => {
-        setFilters((prev) => ({ ...prev, dateFrom: date }));
+        setFilters((prev) => ({ ...prev, dateFrom: date, period: 'custom' }));
     }, []);
 
     const handleDateToChange = useCallback((date: string) => {
-        setFilters((prev) => ({ ...prev, dateTo: date }));
+        setFilters((prev) => ({ ...prev, dateTo: date, period: 'custom' }));
     }, []);
 
-    const handleDateRangeChange = useCallback((from: string, to: string) => {
-        setFilters((prev) => ({ ...prev, dateFrom: from, dateTo: to }));
+    const handleDateRangeChange = useCallback((from: string, to: string, period: PeriodKey) => {
+        setFilters((prev) => ({ ...prev, dateFrom: from, dateTo: to, period }));
     }, []);
 
     return (
@@ -88,6 +119,7 @@ const UnitExtendedWidget: React.FC<UnitExtendedWidgetProps> = ({ marketplaces })
                 marketplace={filters.marketplace}
                 dateFrom={filters.dateFrom}
                 dateTo={filters.dateTo}
+                period={filters.period}
                 onMarketplaceChange={handleMarketplaceChange}
                 onDateFromChange={handleDateFromChange}
                 onDateToChange={handleDateToChange}


### PR DESCRIPTION
### Motivation
- Provide a canonical representation for selectable date presets and unify month/operational presets behind `PeriodKey` values.
- Make URL state and widget filters aware of semantic periods (months, today/this week/etc.) to simplify inference and synchronization of the date range.

### Description
- Introduce `PeriodKey` type and helper functions `getMonthPeriodKey`, `getPeriodRange`, `getPeriodKeyForRange`, `normalizePeriod`, and `parseDateStr` to map between semantic period keys and concrete `from`/`to` ranges.
- Replace the old simple month presets with `MONTH_PRESETS` and `OPERATIONAL_PRESETS`, add `PeriodButton` component, and update `PeriodPresets` to accept/emit `currentPeriod` and call `onSelect(from, to, period)`.
- Update `UnitExtendedFilters` to accept `period` and propagate the new `onDateRangeChange` signature, and add `aria-label` attributes to the date inputs.
- Update `UnitExtendedWidget` URL handling and state: parse `period` URL param, infer period when only date params are present, store `period` in URL via `setFiltersToUrl`, and mark manual date edits as `period: 'custom'`.

### Testing
- Ran TypeScript type-check/build to validate new types and component signatures and the build completed successfully.
- Ran existing automated unit tests for the analytics frontend and they passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a73e8374c8323a6e031b78212b5a0)