### PR TITLE
Admin: add account creation modal and CreateAccountAction with unit test

### DIFF
--- a/site/src/Admin/Application/CreateAccountAction.php
+++ b/site/src/Admin/Application/CreateAccountAction.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\Application;
+
+use App\Company\Entity\Company;
+use App\Company\Entity\User;
+use App\Message\SendRegistrationEmailMessage;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+final readonly class CreateAccountAction
+{
+    public function __construct(
+        private UserPasswordHasherInterface $userPasswordHasher,
+        private EntityManagerInterface $entityManager,
+        private MessageBusInterface $bus,
+    ) {
+    }
+
+    public function __invoke(User $account, string $plainPassword, string $companyName): Company
+    {
+        $account->setPassword($this->userPasswordHasher->hashPassword($account, $plainPassword));
+        $account->setRoles(['ROLE_COMPANY_OWNER']);
+
+        $company = new Company(Uuid::uuid7()->toString(), $account);
+        $company->setName(trim($companyName));
+        $account->addCompany($company);
+
+        $this->entityManager->persist($account);
+        $this->entityManager->persist($company);
+        $this->entityManager->flush();
+
+        $this->bus->dispatch(new SendRegistrationEmailMessage(
+            userId: $account->getId(),
+            companyId: $company->getId(),
+            createdAt: new \DateTimeImmutable(),
+        ));
+
+        return $company;
+    }
+}

--- a/site/src/Admin/Controller/UserController.php
+++ b/site/src/Admin/Controller/UserController.php
@@ -1,19 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Admin\Controller;
 
+use App\Admin\Application\CreateAccountAction;
 use App\Admin\Service\UserDeletionService;
 use App\Company\Entity\User;
+use App\Company\Form\RegistrationFormType;
 use App\Repository\UserRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/admin/users', name: 'admin_user_')]
 final class UserController extends AbstractController
 {
+    private const GENERIC_ACCOUNT_ERROR = 'Не удалось создать аккаунт. Попробуйте позже.';
+
     /**
      * @var array<string, string>
      */
@@ -23,9 +31,34 @@ final class UserController extends AbstractController
         'ROLE_COMPANY_USER' => 'Сотрудник компании',
     ];
 
-    #[Route('', name: 'index', methods: ['GET'])]
-    public function index(Request $request, UserRepository $userRepository): Response
-    {
+    #[Route('', name: 'index', methods: ['GET', 'POST'])]
+    public function index(
+        Request $request,
+        UserRepository $userRepository,
+        CreateAccountAction $createAccount,
+    ): Response {
+        $account = new User(id: Uuid::uuid7()->toString());
+        $accountForm = $this->createForm(RegistrationFormType::class, $account, [
+            'is_invite' => false,
+        ]);
+        $accountForm->handleRequest($request);
+
+        if ($accountForm->isSubmitted() && $accountForm->get('website')->getData()) {
+            $accountForm->addError(new FormError(self::GENERIC_ACCOUNT_ERROR));
+        }
+
+        if ($accountForm->isSubmitted() && $accountForm->isValid()) {
+            /** @var string $plainPassword */
+            $plainPassword = (string) $accountForm->get('plainPassword')->getData();
+            $companyName = (string) $accountForm->get('companyName')->getData();
+
+            $createAccount($account, $plainPassword, $companyName);
+
+            $this->addFlash('success', sprintf('Аккаунт %s успешно создан.', $account->getEmail()));
+
+            return $this->redirectToRoute('admin_user_index');
+        }
+
         $lastWeek = new \DateTimeImmutable('-7 days');
         $page = max(1, (int) $request->query->get('page', 1));
         $pager = $userRepository->getRegisteredUsers($page);
@@ -37,6 +70,8 @@ final class UserController extends AbstractController
             'pager' => $pager,
             'totalUsers' => $userRepository->countRegisteredUsers(),
             'recentUsers' => $userRepository->countRegisteredUsersSince($lastWeek),
+            'accountForm' => $accountForm,
+            'showAccountModal' => $accountForm->isSubmitted() && !$accountForm->isValid(),
         ]);
     }
 

--- a/site/templates/admin/users/index.html.twig
+++ b/site/templates/admin/users/index.html.twig
@@ -8,6 +8,17 @@
       <div class="col">
         <h2 class="page-title">{{ title }}</h2>
       </div>
+      <div class="col-auto ms-auto">
+        <button
+          type="button"
+          class="btn btn-primary"
+          data-bs-toggle="modal"
+          data-bs-target="#account-create-modal"
+        >
+          <i class="ti ti-plus me-1"></i>
+          Добавить аккаунт
+        </button>
+      </div>
     </div>
   </div>
 
@@ -90,4 +101,85 @@
       {% include 'partials/_pagerfanta.html.twig' with { pager: pager } %}
     </div>
   </div>
+
+  <div class="modal modal-blur fade" id="account-create-modal" tabindex="-1" aria-labelledby="account-create-modal-title" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
+      <div class="modal-content">
+        {{ form_start(accountForm, { action: path('admin_user_index'), method: 'POST' }) }}
+          <div class="modal-header">
+            <h5 class="modal-title" id="account-create-modal-title">Добавить аккаунт</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Закрыть"></button>
+          </div>
+          <div class="modal-body">
+            {% if accountForm.vars.errors|length > 0 %}
+              <div class="alert alert-danger" role="alert">
+                {{ form_errors(accountForm) }}
+              </div>
+            {% endif %}
+
+            <div class="row g-3">
+              <div class="col-12">
+                {{ form_label(accountForm.email, 'Email', { label_attr: { class: 'form-label' } }) }}
+                {{ form_widget(accountForm.email, {
+                  attr: { class: 'form-control', placeholder: 'user@example.com', autocomplete: 'email' }
+                }) }}
+                {{ form_errors(accountForm.email) }}
+              </div>
+
+              <div class="col-12">
+                {{ form_label(accountForm.plainPassword, 'Пароль', { label_attr: { class: 'form-label' } }) }}
+                {{ form_widget(accountForm.plainPassword, {
+                  attr: { class: 'form-control', placeholder: '••••••••', autocomplete: 'new-password' }
+                }) }}
+                {{ form_errors(accountForm.plainPassword) }}
+              </div>
+
+              <div class="col-12">
+                {{ form_label(accountForm.companyName, 'Название компании', { label_attr: { class: 'form-label' } }) }}
+                {{ form_widget(accountForm.companyName, {
+                  attr: { class: 'form-control', placeholder: 'ООО Ромашка' }
+                }) }}
+                {{ form_errors(accountForm.companyName) }}
+              </div>
+
+              <div class="col-12">
+                <label class="form-check">
+                  {{ form_widget(accountForm.agreeTerms, { attr: { class: 'form-check-input' } }) }}
+                  <span class="form-check-label">{{ accountForm.agreeTerms.vars.label }}</span>
+                </label>
+                {{ form_errors(accountForm.agreeTerms) }}
+              </div>
+
+              <div class="d-none" aria-hidden="true">
+                {{ form_widget(accountForm.website) }}
+                {{ form_errors(accountForm.website) }}
+              </div>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-link link-secondary" data-bs-dismiss="modal">Отмена</button>
+            <button type="submit" class="btn btn-primary ms-auto">
+              <i class="ti ti-plus me-1"></i>
+              Создать аккаунт
+            </button>
+          </div>
+        {{ form_end(accountForm) }}
+      </div>
+    </div>
+  </div>
+
+{% endblock %}
+
+{% block admin_scripts %}
+  {{ parent() }}
+  {% if showAccountModal %}
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const modalElement = document.getElementById('account-create-modal');
+        if (modalElement && window.bootstrap) {
+          window.bootstrap.Modal.getOrCreateInstance(modalElement).show();
+        }
+      });
+    </script>
+  {% endif %}
 {% endblock %}

--- a/site/tests/Unit/Admin/Application/CreateAccountActionTest.php
+++ b/site/tests/Unit/Admin/Application/CreateAccountActionTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Admin\Application;
+
+use App\Admin\Application\CreateAccountAction;
+use App\Company\Entity\Company;
+use App\Company\Entity\User;
+use App\Message\SendRegistrationEmailMessage;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+#[CoversClass(CreateAccountAction::class)]
+final class CreateAccountActionTest extends TestCase
+{
+    public function testCreatesOwnerAccountWithCompanyAndDispatchesRegistrationEmail(): void
+    {
+        $account = new User('22222222-2222-4222-8222-222222222222');
+        $account->setEmail('new-owner@example.test');
+
+        $passwordHasher = $this->createMock(UserPasswordHasherInterface::class);
+        $passwordHasher
+            ->expects(self::once())
+            ->method('hashPassword')
+            ->with($account, 'plain-password')
+            ->willReturn('hashed-password');
+
+        $persisted = [];
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager
+            ->expects(self::exactly(2))
+            ->method('persist')
+            ->willReturnCallback(static function (object $entity) use (&$persisted): void {
+                $persisted[] = $entity;
+            });
+        $entityManager
+            ->expects(self::once())
+            ->method('flush');
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus
+            ->expects(self::once())
+            ->method('dispatch')
+            ->with(self::isInstanceOf(SendRegistrationEmailMessage::class))
+            ->willReturnCallback(static fn (object $message): Envelope => new Envelope($message));
+
+        $action = new CreateAccountAction($passwordHasher, $entityManager, $bus);
+        $company = $action($account, 'plain-password', '  ООО Ромашка  ');
+
+        self::assertSame('hashed-password', $account->getPassword());
+        self::assertContains('ROLE_COMPANY_OWNER', $account->getRoles());
+        self::assertSame('ООО Ромашка', $company->getName());
+        self::assertSame($account, $company->getUser());
+        self::assertContains($account, $persisted);
+        self::assertContains($company, $persisted);
+        self::assertInstanceOf(Company::class, $company);
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide an in-admin flow to create new company owner accounts and their companies without going through the public registration flow.
- Centralize account creation logic (password hashing, role assignment, company creation, persistence, and email dispatch) into an application service.
- Add a UI dialog to create accounts from the users index and preserve form state when validation fails.

### Description

- Added `App\Admin\Application\CreateAccountAction` which hashes the password, assigns `ROLE_COMPANY_OWNER`, creates a `Company` with `Uuid::uuid7()`, persists both entities, flushes, and dispatches `SendRegistrationEmailMessage`.
- Updated `App\Admin\Controller\UserController::index` to handle `GET` and `POST`, build and validate the registration form, enforce a honeypot `website` check, call `CreateAccountAction`, add a success flash and redirect on success, and pass `accountForm` and `showAccountModal` to the template.
- Extended the users index template `templates/admin/users/index.html.twig` with an "Add account" button, a modal containing the registration form, server-side error display, a hidden honeypot field, and JS to reopen the modal when the submitted form is invalid.
- Added unit test `tests/Unit/Admin/Application/CreateAccountActionTest.php` which mocks the password hasher, entity manager and message bus to assert password hashing, role assignment, trimming of company name, persistence of both entities, flush call, and dispatch of the registration message.
- Minor code-style updates: added `declare(strict_types=1)` and switched to PHP attribute `Route` usage in the controller.

### Testing

- Ran the new unit test with `vendor/bin/phpunit tests/Unit/Admin/Application/CreateAccountActionTest.php` and it passed (asserted hashing, persistence, company creation, and message dispatch).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a90c2c13483238ecb9488390fcd94)