### PR TITLE
Extract account creation into dedicated CreateAccountController and add functional tests

### DIFF
--- a/site/src/Admin/Controller/CreateAccountController.php
+++ b/site/src/Admin/Controller/CreateAccountController.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\Controller;
+
+use App\Admin\Application\CreateAccountAction;
+use App\Company\Entity\User;
+use App\Company\Form\RegistrationFormType;
+use App\Repository\UserRepository;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route('/admin/users/new-account', name: 'admin_user_create_account', methods: ['POST'])]
+#[IsGranted('ROLE_ADMIN')]
+final class CreateAccountController extends AbstractController
+{
+    private const GENERIC_ACCOUNT_ERROR = 'Не удалось создать аккаунт. Попробуйте позже.';
+
+    public function __invoke(
+        Request $request,
+        UserRepository $userRepository,
+        CreateAccountAction $createAccount,
+    ): Response {
+        $account = new User(id: Uuid::uuid7()->toString());
+        $accountForm = $this->createForm(RegistrationFormType::class, $account, [
+            'is_invite' => false,
+        ]);
+        $accountForm->handleRequest($request);
+
+        if ($accountForm->isSubmitted() && $accountForm->get('website')->getData()) {
+            $accountForm->addError(new FormError(self::GENERIC_ACCOUNT_ERROR));
+        }
+
+        if (!$accountForm->isSubmitted() || !$accountForm->isValid()) {
+            return $this->renderUserIndex($request, $userRepository, $accountForm);
+        }
+
+        /** @var string $plainPassword */
+        $plainPassword = (string) $accountForm->get('plainPassword')->getData();
+        $companyName = (string) $accountForm->get('companyName')->getData();
+
+        $createAccount($account, $plainPassword, $companyName);
+
+        $this->addFlash('success', 'Аккаунт и компания успешно созданы.');
+
+        return $this->redirectToRoute('admin_user_index');
+    }
+
+    private function renderUserIndex(
+        Request $request,
+        UserRepository $userRepository,
+        FormInterface $accountForm,
+    ): Response {
+        $lastWeek = new \DateTimeImmutable('-7 days');
+        $page = max(1, (int) $request->query->get('page', 1));
+        $pager = $userRepository->getRegisteredUsers($page);
+        $users = iterator_to_array($pager->getCurrentPageResults());
+
+        return $this->render('admin/users/index.html.twig', [
+            'title' => 'Зарегистрированные пользователи',
+            'users' => $users,
+            'pager' => $pager,
+            'totalUsers' => $userRepository->countRegisteredUsers(),
+            'recentUsers' => $userRepository->countRegisteredUsersSince($lastWeek),
+            'accountForm' => $accountForm,
+            'showAccountModal' => true,
+        ], new Response(status: Response::HTTP_UNPROCESSABLE_ENTITY));
+    }
+}

--- a/site/src/Admin/Controller/UserController.php
+++ b/site/src/Admin/Controller/UserController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Admin\Controller;
 
-use App\Admin\Application\CreateAccountAction;
 use App\Admin\Service\UserDeletionService;
 use App\Company\Entity\User;
 use App\Company\Form\RegistrationFormType;
@@ -12,16 +11,16 @@ use App\Repository\UserRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Ramsey\Uuid\Uuid;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[Route('/admin/users', name: 'admin_user_')]
+#[IsGranted('ROLE_ADMIN')]
 final class UserController extends AbstractController
 {
-    private const GENERIC_ACCOUNT_ERROR = 'Не удалось создать аккаунт. Попробуйте позже.';
-
     /**
      * @var array<string, string>
      */
@@ -31,34 +30,30 @@ final class UserController extends AbstractController
         'ROLE_COMPANY_USER' => 'Сотрудник компании',
     ];
 
-    #[Route('', name: 'index', methods: ['GET', 'POST'])]
+    #[Route('', name: 'index', methods: ['GET'])]
     public function index(
         Request $request,
         UserRepository $userRepository,
-        CreateAccountAction $createAccount,
     ): Response {
         $account = new User(id: Uuid::uuid7()->toString());
-        $accountForm = $this->createForm(RegistrationFormType::class, $account, [
+        $accountForm = $this->createAccountForm($account);
+
+        return $this->renderUserIndex($request, $userRepository, $accountForm, false);
+    }
+
+    private function createAccountForm(User $account): FormInterface
+    {
+        return $this->createForm(RegistrationFormType::class, $account, [
             'is_invite' => false,
         ]);
-        $accountForm->handleRequest($request);
+    }
 
-        if ($accountForm->isSubmitted() && $accountForm->get('website')->getData()) {
-            $accountForm->addError(new FormError(self::GENERIC_ACCOUNT_ERROR));
-        }
-
-        if ($accountForm->isSubmitted() && $accountForm->isValid()) {
-            /** @var string $plainPassword */
-            $plainPassword = (string) $accountForm->get('plainPassword')->getData();
-            $companyName = (string) $accountForm->get('companyName')->getData();
-
-            $createAccount($account, $plainPassword, $companyName);
-
-            $this->addFlash('success', sprintf('Аккаунт %s успешно создан.', $account->getEmail()));
-
-            return $this->redirectToRoute('admin_user_index');
-        }
-
+    private function renderUserIndex(
+        Request $request,
+        UserRepository $userRepository,
+        FormInterface $accountForm,
+        bool $showAccountModal,
+    ): Response {
         $lastWeek = new \DateTimeImmutable('-7 days');
         $page = max(1, (int) $request->query->get('page', 1));
         $pager = $userRepository->getRegisteredUsers($page);
@@ -71,7 +66,7 @@ final class UserController extends AbstractController
             'totalUsers' => $userRepository->countRegisteredUsers(),
             'recentUsers' => $userRepository->countRegisteredUsersSince($lastWeek),
             'accountForm' => $accountForm,
-            'showAccountModal' => $accountForm->isSubmitted() && !$accountForm->isValid(),
+            'showAccountModal' => $showAccountModal,
         ]);
     }
 

--- a/site/templates/admin/users/index.html.twig
+++ b/site/templates/admin/users/index.html.twig
@@ -105,7 +105,7 @@
   <div class="modal modal-blur fade" id="account-create-modal" tabindex="-1" aria-labelledby="account-create-modal-title" aria-hidden="true">
     <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
       <div class="modal-content">
-        {{ form_start(accountForm, { action: path('admin_user_index'), method: 'POST' }) }}
+        {{ form_start(accountForm, { action: path('admin_user_create_account'), method: 'POST' }) }}
           <div class="modal-header">
             <h5 class="modal-title" id="account-create-modal-title">Добавить аккаунт</h5>
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Закрыть"></button>

--- a/site/tests/Functional/Admin/UserCreateAccountControllerTest.php
+++ b/site/tests/Functional/Admin/UserCreateAccountControllerTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Admin;
+
+use App\Company\Entity\Company;
+use App\Repository\UserRepository;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class UserCreateAccountControllerTest extends WebTestCaseBase
+{
+    public function testCreateAccountRedirectsAndCreatesOwnerCompany(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $admin = UserBuilder::aUser()
+            ->withEmail('admin@example.test')
+            ->withRoles(['ROLE_ADMIN'])
+            ->build();
+
+        $em = $this->em();
+        $em->persist($admin);
+        $em->flush();
+
+        $client->loginUser($admin, 'admin');
+        $crawler = $client->request('GET', '/admin/users');
+
+        $form = $crawler->selectButton('Создать аккаунт')->form([
+            'registration_form[email]' => 'owner@example.test',
+            'registration_form[plainPassword]' => 'secret-password',
+            'registration_form[companyName]' => 'ООО Новая компания',
+            'registration_form[agreeTerms]' => '1',
+        ]);
+
+        $client->submit($form);
+
+        self::assertResponseRedirects('/admin/users');
+
+        /** @var UserRepository $userRepository */
+        $userRepository = static::getContainer()->get(UserRepository::class);
+        $createdUser = $userRepository->findOneBy(['email' => 'owner@example.test']);
+
+        self::assertNotNull($createdUser);
+        self::assertContains('ROLE_COMPANY_OWNER', $createdUser->getRoles());
+
+        $company = $this->em()->getRepository(Company::class)->findOneBy(['user' => $createdUser]);
+
+        self::assertNotNull($company);
+        self::assertSame('ООО Новая компания', $company->getName());
+        self::assertSame(
+            ['Аккаунт и компания успешно созданы.'],
+            $client->getRequest()->getSession()->getFlashBag()->peek('success')
+        );
+    }
+
+    public function testInvalidCreateAccountRendersUsersIndexWithModalOpen(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $admin = UserBuilder::aUser()
+            ->withEmail('admin@example.test')
+            ->withRoles(['ROLE_ADMIN'])
+            ->build();
+        $existingUser = UserBuilder::aUser()
+            ->withIndex(2)
+            ->withEmail('existing@example.test')
+            ->build();
+
+        $em = $this->em();
+        $em->persist($admin);
+        $em->persist($existingUser);
+        $em->flush();
+
+        $client->loginUser($admin, 'admin');
+        $crawler = $client->request('GET', '/admin/users');
+
+        $form = $crawler->selectButton('Создать аккаунт')->form([
+            'registration_form[email]' => 'owner@example.test',
+            'registration_form[plainPassword]' => 'secret-password',
+            'registration_form[companyName]' => 'ООО Новая компания',
+            'registration_form[agreeTerms]' => '1',
+            'registration_form[website]' => 'spam.example',
+        ]);
+
+        $client->submit($form);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        self::assertSelectorTextContains('h2.page-title', 'Зарегистрированные пользователи');
+        self::assertStringContainsString('existing@example.test', $client->getResponse()->getContent());
+        self::assertSelectorTextContains('.alert-danger', 'Не удалось создать аккаунт. Попробуйте позже.');
+        self::assertStringContainsString(
+            'window.bootstrap.Modal.getOrCreateInstance(modalElement).show();',
+            $client->getResponse()->getContent()
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Separate the account creation POST flow from the users listing to simplify the `UserController` and make the handler single-purpose.
- Prevent spam/bot submissions using the existing `website` honeypot check on a dedicated endpoint and return a proper unprocessable response when creation fails.
- Ensure admin-only access is consistently enforced for user management endpoints.

### Description
- Added `CreateAccountController` with route `POST /admin/users/new-account` that handles the registration form, performs the `website` honeypot check, invokes `CreateAccountAction`, flashes success and redirects to the users index, or renders the users index with status `422` when invalid.
- Updated `UserController` to `GET`-only for the index, removed account creation handling and `CreateAccountAction` dependency, and extracted `createAccountForm` and `renderUserIndex` helpers while applying `#[IsGranted('ROLE_ADMIN')]`.
- Changed the users index template form action to `path('admin_user_create_account')` so the modal posts to the new controller.
- Added functional test `UserCreateAccountControllerTest` covering successful account/company creation and the invalid (honeypot) case, asserting redirects, created entities, flashes, and that the modal remains open on error.

### Testing
- Added and ran the new functional tests in `site/tests/Functional/Admin/UserCreateAccountControllerTest.php` via PHPUnit, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a98300a848323bf9e8cb26fe40daa)