### PR TITLE
Add CompanyOwnerAccountCreator service and refactor registration to use it

### DIFF
--- a/site/src/Company/Service/CompanyOwnerAccountCreator.php
+++ b/site/src/Company/Service/CompanyOwnerAccountCreator.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Company\Service;
+
+use App\Company\Entity\Company;
+use App\Company\Entity\User;
+use App\Message\SendRegistrationEmailMessage;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+final readonly class CompanyOwnerAccountCreator
+{
+    public function __construct(
+        private UserPasswordHasherInterface $userPasswordHasher,
+        private EntityManagerInterface $entityManager,
+        private MessageBusInterface $bus,
+    ) {
+    }
+
+    public function create(
+        User $user,
+        string $plainPassword,
+        string $companyName,
+        bool $sendRegistrationEmail = true,
+    ): Company {
+        $user->setPassword($this->userPasswordHasher->hashPassword($user, $plainPassword));
+        $user->setRoles(['ROLE_COMPANY_OWNER']);
+
+        $company = new Company(Uuid::uuid4()->toString(), $user);
+        $company->setName(\trim($companyName));
+        $user->addCompany($company);
+
+        $this->entityManager->persist($user);
+        $this->entityManager->persist($company);
+        $this->entityManager->flush();
+
+        if ($sendRegistrationEmail) {
+            $this->bus->dispatch(new SendRegistrationEmailMessage(
+                userId: (string) $user->getId(),
+                companyId: (string) $company->getId(),
+                createdAt: new \DateTimeImmutable(),
+            ));
+        }
+
+        return $company;
+    }
+}

--- a/site/src/Controller/RegistrationController.php
+++ b/site/src/Controller/RegistrationController.php
@@ -1,14 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Controller;
 
-use App\Company\Entity\Company;
 use App\Company\Entity\User;
 use App\Company\Form\RegistrationFormType;
 use App\Company\Repository\CompanyInviteRepository;
 use App\Company\Service\CompanyInviteManager;
+use App\Company\Service\CompanyOwnerAccountCreator;
 use App\Company\Service\InviteTokenService;
-use App\Message\SendRegistrationEmailMessage;
 use App\Shared\Service\RateLimiter\RegistrationRateLimiter;
 use Doctrine\ORM\EntityManagerInterface;
 use Ramsey\Uuid\Uuid;
@@ -17,11 +18,10 @@ use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Attribute\Route;
 
-class RegistrationController extends AbstractController
+final class RegistrationController extends AbstractController
 {
     private const GENERIC_REG_ERROR = 'Не удалось создать аккаунт. Попробуйте позже.';
 
@@ -31,11 +31,11 @@ class RegistrationController extends AbstractController
         UserPasswordHasherInterface $userPasswordHasher,
         Security $security,
         EntityManagerInterface $entityManager,
-        MessageBusInterface $bus,
         RegistrationRateLimiter $registrationRateLimiter,
         CompanyInviteManager $inviteManager,
         CompanyInviteRepository $inviteRepository,
         InviteTokenService $tokenService,
+        CompanyOwnerAccountCreator $companyOwnerAccountCreator,
     ): Response {
         $user = new User(id: Uuid::uuid4()->toString());
         $inviteToken = $request->query->get('invite');
@@ -70,16 +70,11 @@ class RegistrationController extends AbstractController
             /** @var string $plainPassword */
             $plainPassword = (string) $form->get('plainPassword')->getData();
 
-            $user->setPassword($userPasswordHasher->hashPassword($user, $plainPassword));
             if ($isInvite) {
+                $user->setPassword($userPasswordHasher->hashPassword($user, $plainPassword));
                 $user->setRoles(['ROLE_COMPANY_USER']);
-            } else {
-                $user->setRoles(['ROLE_COMPANY_OWNER']);
-            }
+                $entityManager->persist($user);
 
-            $entityManager->persist($user);
-
-            if ($isInvite) {
                 $tokenHash = $tokenService->hashToken($inviteToken);
                 $invite = $inviteRepository->findOneByTokenHash($tokenHash);
                 if (!$invite) {
@@ -90,19 +85,12 @@ class RegistrationController extends AbstractController
                 $inviteManager->acceptInvite($inviteToken, $user);
                 $request->getSession()->set('active_company_id', $companyId);
             } else {
-                $company = new Company(Uuid::uuid4()->toString(), $user);
-                $companyName = trim((string) $form->get('companyName')->getData());
-                $company->setName($companyName);
-                $user->addCompany($company);
-                $entityManager->persist($company);
-
-                $entityManager->flush();
-                $createdAt = new \DateTimeImmutable();
-                $bus->dispatch(new SendRegistrationEmailMessage(
-                    userId: $user->getId(),
-                    companyId: $company->getId(),
-                    createdAt: $createdAt,
-                ));
+                $companyOwnerAccountCreator->create(
+                    user: $user,
+                    plainPassword: $plainPassword,
+                    companyName: (string) $form->get('companyName')->getData(),
+                    sendRegistrationEmail: true,
+                );
             }
 
             // Мгновенный логин

--- a/site/tests/Unit/Company/CompanyOwnerAccountCreatorTest.php
+++ b/site/tests/Unit/Company/CompanyOwnerAccountCreatorTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Company;
+
+use App\Company\Entity\Company;
+use App\Company\Entity\User;
+use App\Company\Service\CompanyOwnerAccountCreator;
+use App\Message\SendRegistrationEmailMessage;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+final class CompanyOwnerAccountCreatorTest extends TestCase
+{
+    public function testCreateBuildsOwnerCompanyAndDispatchesRegistrationEmail(): void
+    {
+        $user = new User('11111111-1111-1111-1111-111111111111');
+
+        $passwordHasher = $this->createMock(UserPasswordHasherInterface::class);
+        $passwordHasher
+            ->expects(self::once())
+            ->method('hashPassword')
+            ->with($user, 'plain-password')
+            ->willReturn('hashed-password');
+
+        $persisted = [];
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager
+            ->expects(self::exactly(2))
+            ->method('persist')
+            ->willReturnCallback(static function (object $entity) use (&$persisted): void {
+                $persisted[] = $entity;
+            });
+        $entityManager
+            ->expects(self::once())
+            ->method('flush');
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus
+            ->expects(self::once())
+            ->method('dispatch')
+            ->with(self::callback(static function (object $message) use ($user): bool {
+                return $message instanceof SendRegistrationEmailMessage
+                    && $message->userId === $user->getId()
+                    && '' !== $message->companyId;
+            }))
+            ->willReturn(new Envelope(new \stdClass()));
+
+        $creator = new CompanyOwnerAccountCreator($passwordHasher, $entityManager, $bus);
+
+        $company = $creator->create($user, 'plain-password', '  Acme LLC  ', true);
+
+        self::assertSame('hashed-password', $user->getPassword());
+        self::assertContains('ROLE_COMPANY_OWNER', $user->getRoles());
+        self::assertNotContains('ROLE_ADMIN', $user->getRoles());
+        self::assertSame('Acme LLC', $company->getName());
+        self::assertSame($user, $company->getUser());
+        self::assertTrue($user->getCompanies()->contains($company));
+        self::assertSame([$user, $company], $persisted);
+    }
+
+    public function testCreateCanSkipRegistrationEmailDispatch(): void
+    {
+        $user = new User('22222222-2222-2222-2222-222222222222');
+
+        $passwordHasher = $this->createMock(UserPasswordHasherInterface::class);
+        $passwordHasher
+            ->expects(self::once())
+            ->method('hashPassword')
+            ->with($user, 'plain-password')
+            ->willReturn('hashed-password');
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager
+            ->expects(self::exactly(2))
+            ->method('persist');
+        $entityManager
+            ->expects(self::once())
+            ->method('flush');
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus
+            ->expects(self::never())
+            ->method('dispatch');
+
+        $creator = new CompanyOwnerAccountCreator($passwordHasher, $entityManager, $bus);
+
+        $company = $creator->create($user, 'plain-password', 'Acme LLC', false);
+
+        self::assertInstanceOf(Company::class, $company);
+    }
+}


### PR DESCRIPTION
### Motivation

- Centralize and encapsulate the logic for creating a company owner account and sending the registration email to improve separation of concerns and testability.
- Reduce controller complexity by moving company creation, role assignment, persistence and message dispatch out of the `RegistrationController`.

### Description

- Add `App\Company\Service\CompanyOwnerAccountCreator` with a `create` method that hashes the password, sets `ROLE_COMPANY_OWNER`, creates a `Company`, persists entities, flushes and optionally dispatches `SendRegistrationEmailMessage`.
- Refactor `RegistrationController` to inject and use `CompanyOwnerAccountCreator` for the non-invite registration path and simplify persistence/role handling for invite and non-invite flows.
- Remove inline company creation and message dispatch from the controller and delegate those responsibilities to the new service.
- Add unit tests `tests/Unit/Company/CompanyOwnerAccountCreatorTest.php` that verify company creation, role assignment, persistence and conditional message dispatch behavior.

### Testing

- Executed unit tests in `tests/Unit/Company/CompanyOwnerAccountCreatorTest.php`, which assert hashing, role assignment, entity persistence, company association and message dispatch behavior; the tests passed.
- No other automated tests were modified or reported failing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2aa468ab0083238c41130251aa6563)