### PR TITLE
Create CompanyMember for owner on registration and add tests

### DIFF
--- a/site/src/Company/Service/CompanyOwnerAccountCreator.php
+++ b/site/src/Company/Service/CompanyOwnerAccountCreator.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Company\Service;
 
 use App\Company\Entity\Company;
+use App\Company\Entity\CompanyMember;
 use App\Company\Entity\User;
+use App\Company\Repository\CompanyMemberRepository;
 use App\Message\SendRegistrationEmailMessage;
 use Doctrine\ORM\EntityManagerInterface;
 use Ramsey\Uuid\Uuid;
@@ -18,6 +20,7 @@ final readonly class CompanyOwnerAccountCreator
         private UserPasswordHasherInterface $userPasswordHasher,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $bus,
+        private CompanyMemberRepository $companyMemberRepository,
     ) {
     }
 
@@ -36,6 +39,17 @@ final readonly class CompanyOwnerAccountCreator
 
         $this->entityManager->persist($user);
         $this->entityManager->persist($company);
+
+        if (null === $this->companyMemberRepository->findOneByCompanyAndUser($company, $user)) {
+            $companyMember = new CompanyMember(
+                id: Uuid::uuid4()->toString(),
+                company: $company,
+                user: $user,
+                role: CompanyMember::ROLE_OWNER,
+            );
+            $this->entityManager->persist($companyMember);
+        }
+
         $this->entityManager->flush();
 
         if ($sendRegistrationEmail) {

--- a/site/tests/Functional/Company/PublicRegistrationFlowTest.php
+++ b/site/tests/Functional/Company/PublicRegistrationFlowTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Company;
+
+use App\Company\Entity\Company;
+use App\Company\Entity\CompanyMember;
+use App\Company\Entity\User;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+
+final class PublicRegistrationFlowTest extends WebTestCaseBase
+{
+    public function testPublicRegistrationCreatesUserCompanyAndOwnerCompanyMember(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $csrfManager = $client->getContainer()->get('security.csrf.token_manager');
+        $token = $csrfManager->getToken('registration_form')->getValue();
+        $email = 'owner-registration@example.test';
+        $companyName = 'Registration LLC';
+
+        $client->request('POST', '/register', [
+            'registration_form' => [
+                'companyName' => $companyName,
+                'email' => $email,
+                'plainPassword' => 'password123',
+                'agreeTerms' => 1,
+                'website' => '',
+                '_token' => $token,
+            ],
+        ]);
+
+        self::assertTrue($client->getResponse()->isRedirect());
+
+        $em = $this->em();
+        $userRepository = $em->getRepository(User::class);
+        $registeredUser = $userRepository->findOneBy(['email' => $email]);
+
+        self::assertSame(1, $userRepository->count([]));
+        self::assertNotNull($registeredUser);
+
+        $companyRepository = $em->getRepository(Company::class);
+        $company = $companyRepository->findOneBy(['name' => $companyName]);
+
+        self::assertSame(1, $companyRepository->count([]));
+        self::assertNotNull($company);
+        self::assertSame($registeredUser->getId(), $company->getUser()?->getId());
+
+        $memberRepository = $em->getRepository(CompanyMember::class);
+        $member = $memberRepository->findOneByCompanyAndUser($company, $registeredUser);
+
+        self::assertSame(1, $memberRepository->count([]));
+        self::assertNotNull($member);
+        self::assertSame($company->getId(), $member->getCompany()->getId());
+        self::assertSame($registeredUser->getId(), $member->getUser()->getId());
+        self::assertSame(CompanyMember::ROLE_OWNER, $member->getRole());
+        self::assertSame(CompanyMember::STATUS_ACTIVE, $member->getStatus());
+    }
+}

--- a/site/tests/Unit/Company/CompanyOwnerAccountCreatorTest.php
+++ b/site/tests/Unit/Company/CompanyOwnerAccountCreatorTest.php
@@ -5,20 +5,85 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Company;
 
 use App\Company\Entity\Company;
+use App\Company\Entity\CompanyMember;
 use App\Company\Entity\User;
+use App\Company\Repository\CompanyMemberRepository;
 use App\Company\Service\CompanyOwnerAccountCreator;
 use App\Message\SendRegistrationEmailMessage;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 final class CompanyOwnerAccountCreatorTest extends TestCase
 {
-    public function testCreateBuildsOwnerCompanyAndDispatchesRegistrationEmail(): void
+    public function testCreateBuildsOwnerCompanyMemberAndDispatchesRegistrationEmail(): void
     {
         $user = new User('11111111-1111-1111-1111-111111111111');
+
+        $passwordHasher = $this->createMock(UserPasswordHasherInterface::class);
+        $passwordHasher
+            ->expects(self::once())
+            ->method('hashPassword')
+            ->with($user, 'plain-password')
+            ->willReturn('hashed-password');
+
+        $persisted = [];
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager
+            ->expects(self::exactly(3))
+            ->method('persist')
+            ->willReturnCallback(static function (object $entity) use (&$persisted): void {
+                $persisted[] = $entity;
+            });
+        $entityManager
+            ->expects(self::once())
+            ->method('flush');
+
+        $companyMemberRepository = $this->createMock(CompanyMemberRepository::class);
+        $companyMemberRepository
+            ->expects(self::once())
+            ->method('findOneByCompanyAndUser')
+            ->with(self::isInstanceOf(Company::class), $user)
+            ->willReturn(null);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus
+            ->expects(self::once())
+            ->method('dispatch')
+            ->with(self::callback(static function (object $message) use ($user): bool {
+                return $message instanceof SendRegistrationEmailMessage
+                    && $message->userId === $user->getId()
+                    && '' !== $message->companyId;
+            }))
+            ->willReturn(new Envelope(new \stdClass()));
+
+        $creator = new CompanyOwnerAccountCreator($passwordHasher, $entityManager, $bus, $companyMemberRepository);
+
+        $company = $creator->create($user, 'plain-password', '  Acme LLC  ', true);
+
+        self::assertSame('hashed-password', $user->getPassword());
+        self::assertContains('ROLE_COMPANY_OWNER', $user->getRoles());
+        self::assertNotContains('ROLE_ADMIN', $user->getRoles());
+        self::assertSame('Acme LLC', $company->getName());
+        self::assertSame($user, $company->getUser());
+        self::assertTrue($user->getCompanies()->contains($company));
+        self::assertCount(3, $persisted);
+        self::assertSame($user, $persisted[0]);
+        self::assertSame($company, $persisted[1]);
+        self::assertInstanceOf(CompanyMember::class, $persisted[2]);
+        self::assertNotNull($persisted[2]->getId());
+        self::assertTrue(Uuid::isValid($persisted[2]->getId()));
+        self::assertSame($company, $persisted[2]->getCompany());
+        self::assertSame($user, $persisted[2]->getUser());
+        self::assertSame(CompanyMember::ROLE_OWNER, $persisted[2]->getRole());
+    }
+
+    public function testCreateDoesNotPersistDuplicateCompanyMemberWhenRelationAlreadyExists(): void
+    {
+        $user = new User('22222222-2222-2222-2222-222222222222');
 
         $passwordHasher = $this->createMock(UserPasswordHasherInterface::class);
         $passwordHasher
@@ -39,33 +104,36 @@ final class CompanyOwnerAccountCreatorTest extends TestCase
             ->expects(self::once())
             ->method('flush');
 
+        $companyMemberRepository = $this->createMock(CompanyMemberRepository::class);
+        $companyMemberRepository
+            ->expects(self::once())
+            ->method('findOneByCompanyAndUser')
+            ->with(self::isInstanceOf(Company::class), $user)
+            ->willReturnCallback(static function (Company $company, User $user): CompanyMember {
+                return new CompanyMember(
+                    '33333333-3333-3333-3333-333333333333',
+                    $company,
+                    $user,
+                    CompanyMember::ROLE_OWNER,
+                );
+            });
+
         $bus = $this->createMock(MessageBusInterface::class);
         $bus
-            ->expects(self::once())
-            ->method('dispatch')
-            ->with(self::callback(static function (object $message) use ($user): bool {
-                return $message instanceof SendRegistrationEmailMessage
-                    && $message->userId === $user->getId()
-                    && '' !== $message->companyId;
-            }))
-            ->willReturn(new Envelope(new \stdClass()));
+            ->expects(self::never())
+            ->method('dispatch');
 
-        $creator = new CompanyOwnerAccountCreator($passwordHasher, $entityManager, $bus);
+        $creator = new CompanyOwnerAccountCreator($passwordHasher, $entityManager, $bus, $companyMemberRepository);
 
-        $company = $creator->create($user, 'plain-password', '  Acme LLC  ', true);
+        $company = $creator->create($user, 'plain-password', 'Acme LLC', false);
 
-        self::assertSame('hashed-password', $user->getPassword());
-        self::assertContains('ROLE_COMPANY_OWNER', $user->getRoles());
-        self::assertNotContains('ROLE_ADMIN', $user->getRoles());
-        self::assertSame('Acme LLC', $company->getName());
-        self::assertSame($user, $company->getUser());
-        self::assertTrue($user->getCompanies()->contains($company));
+        self::assertInstanceOf(Company::class, $company);
         self::assertSame([$user, $company], $persisted);
     }
 
     public function testCreateCanSkipRegistrationEmailDispatch(): void
     {
-        $user = new User('22222222-2222-2222-2222-222222222222');
+        $user = new User('44444444-4444-4444-4444-444444444444');
 
         $passwordHasher = $this->createMock(UserPasswordHasherInterface::class);
         $passwordHasher
@@ -76,18 +144,25 @@ final class CompanyOwnerAccountCreatorTest extends TestCase
 
         $entityManager = $this->createMock(EntityManagerInterface::class);
         $entityManager
-            ->expects(self::exactly(2))
+            ->expects(self::exactly(3))
             ->method('persist');
         $entityManager
             ->expects(self::once())
             ->method('flush');
+
+        $companyMemberRepository = $this->createMock(CompanyMemberRepository::class);
+        $companyMemberRepository
+            ->expects(self::once())
+            ->method('findOneByCompanyAndUser')
+            ->with(self::isInstanceOf(Company::class), $user)
+            ->willReturn(null);
 
         $bus = $this->createMock(MessageBusInterface::class);
         $bus
             ->expects(self::never())
             ->method('dispatch');
 
-        $creator = new CompanyOwnerAccountCreator($passwordHasher, $entityManager, $bus);
+        $creator = new CompanyOwnerAccountCreator($passwordHasher, $entityManager, $bus, $companyMemberRepository);
 
         $company = $creator->create($user, 'plain-password', 'Acme LLC', false);
 


### PR DESCRIPTION
### Motivation
- Ensure a CompanyMember record is created for a newly registered company owner so the owner relationship is represented in the join table.
- Prevent duplicate CompanyMember creation when the relation already exists.
- Cover the behavior with unit and functional tests to avoid regressions.

### Description
- Added a `CompanyMemberRepository` dependency to `CompanyOwnerAccountCreator` and check `findOneByCompanyAndUser` before creating a `CompanyMember` entity.
- Persist a new `CompanyMember` with `ROLE_OWNER` when no existing relation is found and keep existing behavior for password hashing, company creation, persistence and optional registration email dispatch.
- Updated `CompanyOwnerAccountCreatorTest` to assert the new `CompanyMember` is persisted, to verify no duplicate is created when the relation exists, and to keep the skip-email flow.
- Added a functional test `PublicRegistrationFlowTest` to assert end-to-end that registration creates a `User`, `Company`, and an active owner `CompanyMember`.

### Testing
- Ran unit tests in `CompanyOwnerAccountCreatorTest`, which passed and cover owner member creation, duplicate avoidance, and skip-email behavior.
- Ran the new functional test `PublicRegistrationFlowTest`, which passed and verifies the full registration flow creates the `User`, `Company`, and `CompanyMember` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2aab80143c832392f5d7c4baa4fc2e)