### PR TITLE
Add AdminAccountCreateType and use it for admin user creation; update controllers, template and tests

### DIFF
--- a/site/src/Admin/Controller/CreateAccountController.php
+++ b/site/src/Admin/Controller/CreateAccountController.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace App\Admin\Controller;
 
 use App\Admin\Application\CreateAccountAction;
+use App\Admin\Form\AdminAccountCreateType;
 use App\Company\Entity\User;
-use App\Company\Form\RegistrationFormType;
 use App\Repository\UserRepository;
 use Ramsey\Uuid\Uuid;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -21,22 +20,14 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted('ROLE_ADMIN')]
 final class CreateAccountController extends AbstractController
 {
-    private const GENERIC_ACCOUNT_ERROR = 'Не удалось создать аккаунт. Попробуйте позже.';
-
     public function __invoke(
         Request $request,
         UserRepository $userRepository,
         CreateAccountAction $createAccount,
     ): Response {
         $account = new User(id: Uuid::uuid7()->toString());
-        $accountForm = $this->createForm(RegistrationFormType::class, $account, [
-            'is_invite' => false,
-        ]);
+        $accountForm = $this->createForm(AdminAccountCreateType::class, $account);
         $accountForm->handleRequest($request);
-
-        if ($accountForm->isSubmitted() && $accountForm->get('website')->getData()) {
-            $accountForm->addError(new FormError(self::GENERIC_ACCOUNT_ERROR));
-        }
 
         if (!$accountForm->isSubmitted() || !$accountForm->isValid()) {
             return $this->renderUserIndex($request, $userRepository, $accountForm);

--- a/site/src/Admin/Controller/UserController.php
+++ b/site/src/Admin/Controller/UserController.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Admin\Controller;
 
+use App\Admin\Form\AdminAccountCreateType;
 use App\Admin\Service\UserDeletionService;
 use App\Company\Entity\User;
-use App\Company\Form\RegistrationFormType;
 use App\Repository\UserRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Ramsey\Uuid\Uuid;
@@ -43,9 +43,7 @@ final class UserController extends AbstractController
 
     private function createAccountForm(User $account): FormInterface
     {
-        return $this->createForm(RegistrationFormType::class, $account, [
-            'is_invite' => false,
-        ]);
+        return $this->createForm(AdminAccountCreateType::class, $account);
     }
 
     private function renderUserIndex(

--- a/site/src/Admin/Form/AdminAccountCreateType.php
+++ b/site/src/Admin/Form/AdminAccountCreateType.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\Form;
+
+use App\Company\Entity\User;
+use App\Company\Form\RegistrationFormType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class AdminAccountCreateType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('email', EmailType::class)
+            ->add('companyName', TextType::class, [
+                'label' => 'Имя компании',
+                'mapped' => false,
+                'required' => true,
+                'attr' => [
+                    'placeholder' => 'ООО Ромашка',
+                ],
+                'constraints' => RegistrationFormType::companyNameConstraints(),
+            ])
+            ->add('plainPassword', PasswordType::class, [
+                'mapped' => false,
+                'attr' => ['autocomplete' => 'new-password'],
+                'constraints' => RegistrationFormType::plainPasswordConstraints(),
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => User::class,
+        ]);
+    }
+}

--- a/site/src/Company/Form/RegistrationFormType.php
+++ b/site/src/Company/Form/RegistrationFormType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Company\Form;
 
 use App\Company\Entity\User;
@@ -25,11 +27,7 @@ class RegistrationFormType extends AbstractType
                 'attr' => [
                     'placeholder' => 'ООО Ромашка',
                 ],
-                'constraints' => [
-                    new NotBlank([
-                        'message' => 'Введите имя компании',
-                    ]),
-                ],
+                'constraints' => self::companyNameConstraints(),
             ]);
         }
 
@@ -49,17 +47,7 @@ class RegistrationFormType extends AbstractType
                 // this is read and encoded in the controller
                 'mapped' => false,
                 'attr' => ['autocomplete' => 'new-password'],
-                'constraints' => [
-                    new NotBlank([
-                        'message' => 'Please enter a password',
-                    ]),
-                    new Length([
-                        'min' => 6,
-                        'minMessage' => 'Your password should be at least {{ limit }} characters',
-                        // max length allowed by Symfony for security reasons
-                        'max' => 4096,
-                    ]),
-                ],
+                'constraints' => self::plainPasswordConstraints(),
             ])
             ->add('website', TextType::class, [
                 'label' => false,
@@ -72,6 +60,36 @@ class RegistrationFormType extends AbstractType
                 ],
             ])
         ;
+    }
+
+    /**
+     * @return list<NotBlank>
+     */
+    public static function companyNameConstraints(): array
+    {
+        return [
+            new NotBlank([
+                'message' => 'Введите имя компании',
+            ]),
+        ];
+    }
+
+    /**
+     * @return list<NotBlank|Length>
+     */
+    public static function plainPasswordConstraints(): array
+    {
+        return [
+            new NotBlank([
+                'message' => 'Please enter a password',
+            ]),
+            new Length([
+                'min' => 6,
+                'minMessage' => 'Your password should be at least {{ limit }} characters',
+                // max length allowed by Symfony for security reasons
+                'max' => 4096,
+            ]),
+        ];
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/site/templates/admin/users/index.html.twig
+++ b/site/templates/admin/users/index.html.twig
@@ -141,19 +141,6 @@
                 }) }}
                 {{ form_errors(accountForm.companyName) }}
               </div>
-
-              <div class="col-12">
-                <label class="form-check">
-                  {{ form_widget(accountForm.agreeTerms, { attr: { class: 'form-check-input' } }) }}
-                  <span class="form-check-label">{{ accountForm.agreeTerms.vars.label }}</span>
-                </label>
-                {{ form_errors(accountForm.agreeTerms) }}
-              </div>
-
-              <div class="d-none" aria-hidden="true">
-                {{ form_widget(accountForm.website) }}
-                {{ form_errors(accountForm.website) }}
-              </div>
             </div>
           </div>
           <div class="modal-footer">

--- a/site/tests/Functional/Admin/UserCreateAccountControllerTest.php
+++ b/site/tests/Functional/Admin/UserCreateAccountControllerTest.php
@@ -30,10 +30,9 @@ final class UserCreateAccountControllerTest extends WebTestCaseBase
         $crawler = $client->request('GET', '/admin/users');
 
         $form = $crawler->selectButton('Создать аккаунт')->form([
-            'registration_form[email]' => 'owner@example.test',
-            'registration_form[plainPassword]' => 'secret-password',
-            'registration_form[companyName]' => 'ООО Новая компания',
-            'registration_form[agreeTerms]' => '1',
+            'admin_account_create[email]' => 'owner@example.test',
+            'admin_account_create[plainPassword]' => 'secret-password',
+            'admin_account_create[companyName]' => 'ООО Новая компания',
         ]);
 
         $client->submit($form);
@@ -80,11 +79,9 @@ final class UserCreateAccountControllerTest extends WebTestCaseBase
         $crawler = $client->request('GET', '/admin/users');
 
         $form = $crawler->selectButton('Создать аккаунт')->form([
-            'registration_form[email]' => 'owner@example.test',
-            'registration_form[plainPassword]' => 'secret-password',
-            'registration_form[companyName]' => 'ООО Новая компания',
-            'registration_form[agreeTerms]' => '1',
-            'registration_form[website]' => 'spam.example',
+            'admin_account_create[email]' => 'existing@example.test',
+            'admin_account_create[plainPassword]' => 'secret-password',
+            'admin_account_create[companyName]' => 'ООО Новая компания',
         ]);
 
         $client->submit($form);
@@ -92,7 +89,7 @@ final class UserCreateAccountControllerTest extends WebTestCaseBase
         self::assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         self::assertSelectorTextContains('h2.page-title', 'Зарегистрированные пользователи');
         self::assertStringContainsString('existing@example.test', $client->getResponse()->getContent());
-        self::assertSelectorTextContains('.alert-danger', 'Не удалось создать аккаунт. Попробуйте позже.');
+        self::assertSelectorTextContains('.invalid-feedback', 'There is already an account with this email');
         self::assertStringContainsString(
             'window.bootstrap.Modal.getOrCreateInstance(modalElement).show();',
             $client->getResponse()->getContent()


### PR DESCRIPTION
### Motivation
- Provide a simplified form type for admins to create user accounts without invite-only fields and terms checkbox. 
- Reuse validation constraints from the existing registration form to avoid duplication.
- Remove honeypot/website spam handling and the agree-to-terms input from the admin creation flow and template.

### Description
- Added `App\Admin\Form\AdminAccountCreateType` which exposes `email`, `companyName` and `plainPassword` and uses constraint helpers from `RegistrationFormType`.
- Replaced usage of `RegistrationFormType` with `AdminAccountCreateType` in `CreateAccountController` and `UserController` via `createForm()` calls and removed related unused constants/imports.
- Extracted `companyNameConstraints()` and `plainPasswordConstraints()` static helpers in `App\Company\Form\RegistrationFormType` and kept the `is_invite` option behavior intact.
- Updated `site/templates/admin/users/index.html.twig` to remove the `agreeTerms` checkbox and the hidden `website` honeypot widget from the admin modal.
- Updated functional test `UserCreateAccountControllerTest` to submit `admin_account_create[...]` form fields and to assert the adjusted validation error message.

### Testing
- Ran the functional test `site/tests/Functional/Admin/UserCreateAccountControllerTest.php` which exercises both successful and invalid admin account creation scenarios, and the tests passed.
- Executed the test suite with `phpunit` for the modified tests to verify integration with controllers and templates, and no regressions were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ab81c6f9883239bad17b086c21c4f)