### PR TITLE
Add CompanyFacade::createOwnerAccount and refactor admin account creation to use facade

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -326,6 +326,25 @@ Dead code на Task-11.2: Repository ещё никем не вызывается
 > Используй **только** эти методы. Не выдумывай новые без обновления этого файла.
 > Нет нужного метода — спроси, не создавай самостоятельно.
 
+### `CompanyFacade` (`src/Company/Facade/CompanyFacade.php`)
+```php
+// Создать пользователя-владельца, компанию и активного CompanyMember OWNER.
+// Используется внешними модулями, включая Admin, вместо прямого вызова Company Service/Application.
+createOwnerAccount(string $email, string $plainPassword, string $companyName): Company
+
+// Найти компанию по ID
+findById(string $companyId): ?Company
+
+// ID всех активных компаний
+// @return list<string>
+getAllActiveCompanyIds(): array
+
+// Компании по списку ID как простые DTO-массивы
+// @param list<string> $companyIds
+// @return list<array{id: string, name: string}>
+getCompaniesByIds(array $companyIds): array
+```
+
 ### `CounterpartyFacade` (`src/Company/Facade/CounterpartyFacade.php`)
 ```php
 // Список контрагентов для ChoiceType в формах
@@ -1973,6 +1992,7 @@ $apiKey = $this->encryption->decrypt($connection->getApiKey());
 
 | Версия | Дата | Что изменилось |
 |---|---|---|
+| 1.49 | 2026-06-12 | Company: добавлен публичный контракт `CompanyFacade::createOwnerAccount()` для создания owner-аккаунта через фасад из Admin |
 | 1.48 | 2026-05-22 | Marketplace: зафиксирован контракт WB financial sync (entities статуса/ошибок, enum mode/status, message `SyncWbFinancialReportDayMessage` на `async_sync`, команда `app:marketplace:wb-financial-reports:sync`, pipeline, TZ `Europe/Moscow`, правило empty day и rate limit 1 request/min) |
 | 1.47 | 2026-05-11 | Inventory: задокументирован первый этап Ozon stock normalization — raw `/v4/product/info/stocks` → `StockSnapshot`, `reservedQuantity`, `StockSnapshotMappingStatus`, async normalization и UI `/inventory/stocks` |
 | 1.46 | 2026-05-11 | Cash/Telegram: добавлен публичный контракт `CashFacade::createTransaction()` и зафиксировано идемпотентное создание Telegram-транзакций через `importSource`/`externalId` |

--- a/site/src/Admin/Application/CreateAccountAction.php
+++ b/site/src/Admin/Application/CreateAccountAction.php
@@ -6,40 +6,17 @@ namespace App\Admin\Application;
 
 use App\Company\Entity\Company;
 use App\Company\Entity\User;
-use App\Message\SendRegistrationEmailMessage;
-use Doctrine\ORM\EntityManagerInterface;
-use Ramsey\Uuid\Uuid;
-use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use App\Company\Facade\CompanyFacade;
 
 final readonly class CreateAccountAction
 {
     public function __construct(
-        private UserPasswordHasherInterface $userPasswordHasher,
-        private EntityManagerInterface $entityManager,
-        private MessageBusInterface $bus,
+        private CompanyFacade $companyFacade,
     ) {
     }
 
     public function __invoke(User $account, string $plainPassword, string $companyName): Company
     {
-        $account->setPassword($this->userPasswordHasher->hashPassword($account, $plainPassword));
-        $account->setRoles(['ROLE_COMPANY_OWNER']);
-
-        $company = new Company(Uuid::uuid7()->toString(), $account);
-        $company->setName(trim($companyName));
-        $account->addCompany($company);
-
-        $this->entityManager->persist($account);
-        $this->entityManager->persist($company);
-        $this->entityManager->flush();
-
-        $this->bus->dispatch(new SendRegistrationEmailMessage(
-            userId: $account->getId(),
-            companyId: $company->getId(),
-            createdAt: new \DateTimeImmutable(),
-        ));
-
-        return $company;
+        return $this->companyFacade->createOwnerAccount((string) $account->getEmail(), $plainPassword, $companyName);
     }
 }

--- a/site/src/Company/Facade/CompanyFacade.php
+++ b/site/src/Company/Facade/CompanyFacade.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace App\Company\Facade;
 
 use App\Company\Entity\Company;
+use App\Company\Entity\User;
 use App\Company\Infrastructure\Repository\CompanyRepository;
-use Doctrine\DBAL\Connection;
+use App\Company\Service\CompanyOwnerAccountCreator;
+use Ramsey\Uuid\Uuid;
 
 /**
  * Публичный контракт модуля Company для других модулей.
@@ -14,13 +16,25 @@ use Doctrine\DBAL\Connection;
 final class CompanyFacade
 {
     public function __construct(
-        private CompanyRepository $repository
-    ) {}
-
+        private readonly CompanyRepository $repository,
+        private readonly CompanyOwnerAccountCreator $accountCreator,
+    ) {
+    }
 
     public function findById(string $companyId): ?Company
     {
         return $this->repository->findById($companyId);
+    }
+
+    /**
+     * Создаёт пользователя-владельца, компанию и активного CompanyMember OWNER.
+     */
+    public function createOwnerAccount(string $email, string $plainPassword, string $companyName): Company
+    {
+        $user = new User(Uuid::uuid7()->toString());
+        $user->setEmail($email);
+
+        return $this->accountCreator->create($user, $plainPassword, $companyName);
     }
 
     /**

--- a/site/tests/Functional/Admin/AdminUserCreateAccountTest.php
+++ b/site/tests/Functional/Admin/AdminUserCreateAccountTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Admin;
+
+use App\Company\Entity\Company;
+use App\Company\Entity\CompanyMember;
+use App\Company\Entity\User;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\Response;
+
+final class AdminUserCreateAccountTest extends WebTestCaseBase
+{
+    public function testNonAdminCannotCreateAccount(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $nonAdmin = UserBuilder::aUser()
+            ->withEmail('owner@example.test')
+            ->asCompanyOwner()
+            ->build();
+
+        $em = $this->em();
+        $em->persist($nonAdmin);
+        $em->flush();
+
+        $client->loginUser($nonAdmin, 'admin');
+        $client->request('POST', '/admin/users/new-account', [
+            'admin_account_create' => [
+                'email' => 'created-by-non-admin@example.test',
+                'plainPassword' => 'secret-password',
+                'companyName' => 'Forbidden Company',
+            ],
+        ]);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        self::assertSame(1, $em->getRepository(User::class)->count([]));
+        self::assertSame(0, $em->getRepository(Company::class)->count([]));
+        self::assertSame(0, $em->getRepository(CompanyMember::class)->count([]));
+    }
+
+    public function testAdminSeesAddAccountButton(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $admin = $this->persistAdmin();
+
+        $client->loginUser($admin, 'admin');
+        $client->request('GET', '/admin/users');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('button[data-bs-target="#account-create-modal"]', 'Добавить аккаунт');
+    }
+
+    public function testValidPostCreatesUserCompanyAndOwnerCompanyMemberWithoutAdminRole(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $admin = $this->persistAdmin();
+        $client->loginUser($admin, 'admin');
+        $crawler = $client->request('GET', '/admin/users');
+
+        $form = $crawler->selectButton('Создать аккаунт')->form([
+            'admin_account_create[email]' => '  Owner.Account@Example.Test  ',
+            'admin_account_create[plainPassword]' => 'secret-password',
+            'admin_account_create[companyName]' => '  ООО Новая компания  ',
+        ]);
+
+        $client->submit($form);
+
+        self::assertResponseRedirects('/admin/users');
+
+        $em = $this->em();
+        $userRepository = $em->getRepository(User::class);
+        $createdUser = $userRepository->findOneBy(['email' => 'owner.account@example.test']);
+
+        self::assertSame(2, $userRepository->count([]));
+        self::assertNotNull($createdUser);
+        self::assertSame('owner.account@example.test', $createdUser->getEmail());
+        self::assertContains('ROLE_COMPANY_OWNER', $createdUser->getRoles());
+        self::assertNotContains('ROLE_ADMIN', $createdUser->getRoles());
+
+        $companyRepository = $em->getRepository(Company::class);
+        $company = $companyRepository->findOneBy(['user' => $createdUser]);
+
+        self::assertSame(1, $companyRepository->count([]));
+        self::assertNotNull($company);
+        self::assertSame('ООО Новая компания', $company->getName());
+        self::assertSame($createdUser->getId(), $company->getUser()?->getId());
+
+        $memberRepository = $em->getRepository(CompanyMember::class);
+        $member = $memberRepository->findOneByCompanyAndUser($company, $createdUser);
+
+        self::assertSame(1, $memberRepository->count([]));
+        self::assertNotNull($member);
+        self::assertSame($company->getId(), $member->getCompany()->getId());
+        self::assertSame($createdUser->getId(), $member->getUser()->getId());
+        self::assertSame(CompanyMember::ROLE_OWNER, $member->getRole());
+        self::assertSame(CompanyMember::STATUS_ACTIVE, $member->getStatus());
+    }
+
+    public function testDuplicateNormalizedEmailReturnsFormErrorAndDoesNotCreateSecondCompany(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $admin = $this->persistAdmin();
+        $client->loginUser($admin, 'admin');
+
+        $this->submitAccountCreateForm($client, 'Unique.Owner@Example.Test', 'ООО Первая компания');
+        self::assertResponseRedirects('/admin/users');
+
+        $crawler = $client->request('GET', '/admin/users');
+        $form = $crawler->selectButton('Создать аккаунт')->form([
+            'admin_account_create[email]' => '  unique.owner@example.test  ',
+            'admin_account_create[plainPassword]' => 'secret-password',
+            'admin_account_create[companyName]' => 'ООО Вторая компания',
+        ]);
+
+        $client->submit($form);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        self::assertSelectorTextContains('.invalid-feedback', 'There is already an account with this email');
+        self::assertStringContainsString(
+            'window.bootstrap.Modal.getOrCreateInstance(modalElement).show();',
+            $client->getResponse()->getContent(),
+        );
+
+        $em = $this->em();
+        self::assertSame(2, $em->getRepository(User::class)->count([]));
+        self::assertSame(1, $em->getRepository(User::class)->count(['email' => 'unique.owner@example.test']));
+        self::assertSame(1, $em->getRepository(Company::class)->count([]));
+        self::assertNull($em->getRepository(Company::class)->findOneBy(['name' => 'ООО Вторая компания']));
+        self::assertSame(1, $em->getRepository(CompanyMember::class)->count([]));
+    }
+
+    private function persistAdmin(): User
+    {
+        $admin = UserBuilder::aUser()
+            ->withEmail('admin@example.test')
+            ->withRoles(['ROLE_ADMIN'])
+            ->build();
+
+        $em = $this->em();
+        $em->persist($admin);
+        $em->flush();
+
+        return $admin;
+    }
+
+    private function submitAccountCreateForm(KernelBrowser $client, string $email, string $companyName): void
+    {
+        $crawler = $client->request('GET', '/admin/users');
+        $form = $crawler->selectButton('Создать аккаунт')->form([
+            'admin_account_create[email]' => $email,
+            'admin_account_create[plainPassword]' => 'secret-password',
+            'admin_account_create[companyName]' => $companyName,
+        ]);
+
+        $client->submit($form);
+    }
+}

--- a/site/tests/Unit/Admin/Application/CreateAccountActionTest.php
+++ b/site/tests/Unit/Admin/Application/CreateAccountActionTest.php
@@ -6,7 +6,12 @@ namespace App\Tests\Unit\Admin\Application;
 
 use App\Admin\Application\CreateAccountAction;
 use App\Company\Entity\Company;
+use App\Company\Entity\CompanyMember;
 use App\Company\Entity\User;
+use App\Company\Facade\CompanyFacade;
+use App\Company\Infrastructure\Repository\CompanyRepository;
+use App\Company\Repository\CompanyMemberRepository;
+use App\Company\Service\CompanyOwnerAccountCreator;
 use App\Message\SendRegistrationEmailMessage;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -18,7 +23,7 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 #[CoversClass(CreateAccountAction::class)]
 final class CreateAccountActionTest extends TestCase
 {
-    public function testCreatesOwnerAccountWithCompanyAndDispatchesRegistrationEmail(): void
+    public function testCreatesOwnerAccountWithCompanyMemberViaCompanyFacade(): void
     {
         $account = new User('22222222-2222-4222-8222-222222222222');
         $account->setEmail('new-owner@example.test');
@@ -27,13 +32,16 @@ final class CreateAccountActionTest extends TestCase
         $passwordHasher
             ->expects(self::once())
             ->method('hashPassword')
-            ->with($account, 'plain-password')
+            ->with(
+                self::callback(static fn (User $user): bool => 'new-owner@example.test' === $user->getEmail()),
+                'plain-password',
+            )
             ->willReturn('hashed-password');
 
         $persisted = [];
         $entityManager = $this->createMock(EntityManagerInterface::class);
         $entityManager
-            ->expects(self::exactly(2))
+            ->expects(self::exactly(3))
             ->method('persist')
             ->willReturnCallback(static function (object $entity) use (&$persisted): void {
                 $persisted[] = $entity;
@@ -42,6 +50,16 @@ final class CreateAccountActionTest extends TestCase
             ->expects(self::once())
             ->method('flush');
 
+        $companyMemberRepository = $this->createMock(CompanyMemberRepository::class);
+        $companyMemberRepository
+            ->expects(self::once())
+            ->method('findOneByCompanyAndUser')
+            ->with(
+                self::isInstanceOf(Company::class),
+                self::callback(static fn (User $user): bool => 'new-owner@example.test' === $user->getEmail()),
+            )
+            ->willReturn(null);
+
         $bus = $this->createMock(MessageBusInterface::class);
         $bus
             ->expects(self::once())
@@ -49,15 +67,29 @@ final class CreateAccountActionTest extends TestCase
             ->with(self::isInstanceOf(SendRegistrationEmailMessage::class))
             ->willReturnCallback(static fn (object $message): Envelope => new Envelope($message));
 
-        $action = new CreateAccountAction($passwordHasher, $entityManager, $bus);
+        $accountCreator = new CompanyOwnerAccountCreator(
+            $passwordHasher,
+            $entityManager,
+            $bus,
+            $companyMemberRepository,
+        );
+        $companyFacade = new CompanyFacade($this->createMock(CompanyRepository::class), $accountCreator);
+        $action = new CreateAccountAction($companyFacade);
+
         $company = $action($account, 'plain-password', '  ООО Ромашка  ');
 
-        self::assertSame('hashed-password', $account->getPassword());
-        self::assertContains('ROLE_COMPANY_OWNER', $account->getRoles());
+        self::assertInstanceOf(User::class, $persisted[0]);
+        self::assertNotSame($account, $persisted[0]);
+        self::assertSame('new-owner@example.test', $persisted[0]->getEmail());
+        self::assertSame('hashed-password', $persisted[0]->getPassword());
+        self::assertContains('ROLE_COMPANY_OWNER', $persisted[0]->getRoles());
+        self::assertNotContains('ROLE_ADMIN', $persisted[0]->getRoles());
         self::assertSame('ООО Ромашка', $company->getName());
-        self::assertSame($account, $company->getUser());
-        self::assertContains($account, $persisted);
+        self::assertSame($persisted[0], $company->getUser());
         self::assertContains($company, $persisted);
         self::assertInstanceOf(Company::class, $company);
+        self::assertInstanceOf(CompanyMember::class, $persisted[2]);
+        self::assertSame($persisted[0], $persisted[2]->getUser());
+        self::assertSame(CompanyMember::ROLE_OWNER, $persisted[2]->getRole());
     }
 }


### PR DESCRIPTION
### Motivation

- Centralize owner-account creation behind the public `CompanyFacade` contract so other modules (Admin and CLI) use a single service for creating owner users, companies and company members.
- Remove direct entity construction and messaging from the Admin action to keep cross-module behavior inside Company domain services.

### Description

- Added `CompanyFacade::createOwnerAccount(string $email, string $plainPassword, string $companyName): Company` and wired it to use `CompanyOwnerAccountCreator` in `site/src/Company/Facade/CompanyFacade.php`.
- Refactored `CreateAccountAction` to depend on `CompanyFacade` and delegate account creation via `createOwnerAccount()` instead of manually creating `User`, `Company`, persisting entities and dispatching `SendRegistrationEmailMessage` in `site/src/Admin/Application/CreateAccountAction.php`.
- Updated `ARCHITECTURE.md` to document the new facade method and added a changelog entry for the change.
- Added/updated tests: new functional test `AdminUserCreateAccountTest` and updated unit test `CreateAccountActionTest` to assert behavior via the facade and `CompanyOwnerAccountCreator`.

### Testing

- Ran unit tests for `CreateAccountActionTest` which passed successfully.
- Executed the new functional test suite including `AdminUserCreateAccountTest` which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b8d6539ac8323b28aba374bd6a3cd)