### PR TITLE
Fix N+1 query in WB returns batch processing

### DIFF
--- a/site/src/Marketplace/Application/Processor/WbReturnsRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/WbReturnsRawProcessor.php
@@ -39,11 +39,11 @@ final class WbReturnsRawProcessor implements MarketplaceRawProcessorInterface
     public function supports(string|StagingRecordType $type, MarketplaceType $marketplace, string $kind = ''): bool
     {
         if ($type instanceof StagingRecordType) {
-            return $type === StagingRecordType::RETURN
-                && $marketplace === MarketplaceType::WILDBERRIES;
+            return StagingRecordType::RETURN === $type
+                && MarketplaceType::WILDBERRIES === $marketplace;
         }
 
-        return $type === MarketplaceType::WILDBERRIES->value && $kind === 'returns';
+        return $type === MarketplaceType::WILDBERRIES->value && 'returns' === $kind;
     }
 
     public function process(string $companyId, string $rawDocId): int
@@ -66,7 +66,7 @@ final class WbReturnsRawProcessor implements MarketplaceRawProcessorInterface
 
         $company = $this->em->find(Company::class, $companyId);
         if (!$company instanceof Company) {
-            throw new \RuntimeException('Company not found: ' . $companyId);
+            throw new \RuntimeException('Company not found: '.$companyId);
         }
 
         $returnsData = array_filter($rawRows, function (array $item): bool {
@@ -95,8 +95,8 @@ final class WbReturnsRawProcessor implements MarketplaceRawProcessorInterface
         foreach ($returnsData as $item) {
             $nmId = $this->normalizer->nmId($item);
             $tsName = $this->normalizer->techSize($item);
-            $size = trim((string) $tsName) !== '' ? trim((string) $tsName) : 'UNKNOWN';
-            $cacheKey = $nmId . '_' . $size;
+            $size = '' !== trim((string) $tsName) ? trim((string) $tsName) : 'UNKNOWN';
+            $cacheKey = $nmId.'_'.$size;
 
             if (isset($listingsCache[$cacheKey])) {
                 continue;
@@ -104,13 +104,13 @@ final class WbReturnsRawProcessor implements MarketplaceRawProcessorInterface
 
             $barcode = (string) ($this->normalizer->barcode($item) ?? '');
             $listing = $this->listingResolver->resolve($company, $nmId, $tsName, [
-                'sa_name'      => $this->normalizer->vendorCode($item),
-                'brand_name'   => $this->normalizer->brandName($item),
+                'sa_name' => $this->normalizer->vendorCode($item),
+                'brand_name' => $this->normalizer->brandName($item),
                 'subject_name' => $this->normalizer->subjectName($item),
                 'retail_price' => (string) $this->normalizer->retailPrice($item),
             ], $barcode);
             $listingsCache[$cacheKey] = $listing;
-            $newListings++;
+            ++$newListings;
         }
 
         if ($newListings > 0) {
@@ -121,29 +121,30 @@ final class WbReturnsRawProcessor implements MarketplaceRawProcessorInterface
 
         $allSrids = array_values(array_filter(array_map(fn (array $item): ?string => $this->normalizer->srid($item), $returnsData)));
         $existingMap = $this->returnRepository->getExistingExternalIds($companyId, $allSrids);
+        $salesBySrid = $this->saleRepository->findByMarketplaceOrdersIndexed(
+            $company,
+            MarketplaceType::WILDBERRIES,
+            $allSrids,
+        );
 
         foreach ($returnsData as $item) {
             $srid = (string) ($this->normalizer->srid($item) ?? '');
-            if ($srid === '' || isset($existingMap[$srid])) {
+            if ('' === $srid || isset($existingMap[$srid])) {
                 continue;
             }
 
             $nmId = $this->normalizer->nmId($item);
             $tsName = $this->normalizer->techSize($item);
-            $size = trim((string) $tsName) !== '' ? trim((string) $tsName) : 'UNKNOWN';
-            $listing = $listingsCache[$nmId . '_' . $size] ?? null;
+            $size = '' !== trim((string) $tsName) ? trim((string) $tsName) : 'UNKNOWN';
+            $listing = $listingsCache[$nmId.'_'.$size] ?? null;
 
             if (!$listing) {
                 $this->logger->warning('[WB] processBatch returns: listing not found', ['nm_id' => $nmId]);
                 continue;
             }
 
-            // Ищем связанную продажу по srid для получения себестоимости
-            $sale = $this->saleRepository->findByMarketplaceOrder(
-                $company,
-                MarketplaceType::WILDBERRIES,
-                $srid,
-            );
+            // Связанная продажа по srid (предзагружена батчем выше) — для себестоимости
+            $sale = $salesBySrid[$srid] ?? null;
 
             $return = new MarketplaceReturn(
                 Uuid::uuid4()->toString(),
@@ -159,11 +160,11 @@ final class WbReturnsRawProcessor implements MarketplaceRawProcessorInterface
             $return->setReturnReason($this->normalizer->sellerOperName($item));
             $return->setCostPrice($this->costPriceResolver->resolveForReturn($listing, $sale, $item));
             $return->setRawData($item);
-            if ($rawDocId !== null) {
+            if (null !== $rawDocId) {
                 $return->setRawDocumentId($rawDocId);
             }
 
-            if ($sale !== null) {
+            if (null !== $sale) {
                 $return->setSale($sale);
             }
 

--- a/site/src/Marketplace/Repository/MarketplaceSaleRepository.php
+++ b/site/src/Marketplace/Repository/MarketplaceSaleRepository.php
@@ -26,10 +26,10 @@ class MarketplaceSaleRepository extends ServiceEntityRepository
      * SKU хранится в marketplace_listings.marketplace_sku.
      */
     public function findByMarketplaceOrderAndSku(
-        Company         $company,
+        Company $company,
         MarketplaceType $marketplace,
-        string          $externalOrderId,
-        string          $marketplaceSku,
+        string $externalOrderId,
+        string $marketplaceSku,
     ): ?MarketplaceSale {
         return $this->createQueryBuilder('s')
             ->join('s.listing', 'l')
@@ -67,6 +67,40 @@ class MarketplaceSaleRepository extends ServiceEntityRepository
             ->setParameter('orderId', $externalOrderId)
             ->getQuery()
             ->getOneOrNullResult();
+    }
+
+    /**
+     * Массовая загрузка продаж по списку externalOrderId (srid) для bulk-обработки.
+     *
+     * @param string[] $externalOrderIds
+     *
+     * @return array<string, MarketplaceSale> ключ — externalOrderId
+     */
+    public function findByMarketplaceOrdersIndexed(
+        Company $company,
+        MarketplaceType $marketplace,
+        array $externalOrderIds,
+    ): array {
+        if (empty($externalOrderIds)) {
+            return [];
+        }
+
+        $sales = $this->createQueryBuilder('s')
+            ->where('s.company = :company')
+            ->andWhere('s.marketplace = :marketplace')
+            ->andWhere('s.externalOrderId IN (:orderIds)')
+            ->setParameter('company', $company)
+            ->setParameter('marketplace', $marketplace)
+            ->setParameter('orderIds', $externalOrderIds)
+            ->getQuery()
+            ->getResult();
+
+        $map = [];
+        foreach ($sales as $sale) {
+            $map[$sale->getExternalOrderId()] = $sale;
+        }
+
+        return $map;
     }
 
     /**
@@ -113,9 +147,10 @@ class MarketplaceSaleRepository extends ServiceEntityRepository
     }
 
     /**
-     * Массовая проверка существующих SRID (для bulk import)
+     * Массовая проверка существующих SRID (для bulk import).
      *
      * @param string[] $srids
+     *
      * @return array<string, true>
      */
     public function getExistingExternalIds(string $companyId, array $srids): array
@@ -166,7 +201,6 @@ class MarketplaceSaleRepository extends ServiceEntityRepository
 
         return $qb->getQuery()->getResult();
     }
-
 
     public function countDocumentLinkedByRawDocument(
         Company $company,

--- a/site/tests/Unit/Marketplace/Application/Processor/WbReturnsRawProcessorRefundAmountTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/WbReturnsRawProcessorRefundAmountTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Marketplace\Application\Processor;
 
 use App\Company\Entity\Company;
-use App\Marketplace\Application\ProcessWbReturnsAction;
 use App\Marketplace\Application\Processor\WbReturnsRawProcessor;
+use App\Marketplace\Application\ProcessWbReturnsAction;
 use App\Marketplace\Application\Service\MarketplaceBarcodeCatalogService;
 use App\Marketplace\Application\Service\MarketplaceCostPriceResolver;
 use App\Marketplace\Application\Service\WbListingResolverService;
@@ -88,7 +88,92 @@ final class WbReturnsRawProcessorRefundAmountTest extends TestCase
     }
 
     /**
+     * Регрессия H1: связанные продажи должны грузиться одним батч-запросом
+     * (findByMarketplaceOrdersIndexed), а не по строке в цикле (findByMarketplaceOrder).
+     */
+    public function testSalesArePreloadedInSingleBatchQueryNotPerRow(): void
+    {
+        $company = $this->createMock(Company::class);
+        $company->method('getId')->willReturn('company-1');
+        $listing = $this->createMock(MarketplaceListing::class);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('find')->willReturnMap([
+            [Company::class, 'company-1', $company],
+        ]);
+
+        $returnRepository = $this->createMock(MarketplaceReturnRepository::class);
+        $returnRepository->method('getExistingExternalIds')->willReturn([]);
+
+        $listingRepository = $this->createMock(MarketplaceListingRepository::class);
+        $listingRepository->method('findListingsByNmIdsIndexed')->willReturn([
+            '123_XL' => $listing,
+            '456_XL' => $listing,
+        ]);
+        $listingRepository->method('findByNmIdAndSize')->willReturn(null);
+
+        $saleRepository = $this->createMock(MarketplaceSaleRepository::class);
+        $saleRepository->expects(self::once())
+            ->method('findByMarketplaceOrdersIndexed')
+            ->with(
+                $company,
+                MarketplaceType::WILDBERRIES,
+                self::callback(static fn (array $srids): bool => 2 === count($srids)),
+            )
+            ->willReturn([]);
+        $saleRepository->expects(self::never())->method('findByMarketplaceOrder');
+
+        $barcodeRepository = $this->createMock(MarketplaceListingBarcodeRepository::class);
+        $barcodeRepository->method('findByBarcode')->willReturn(null);
+        $connection = $this->createMock(Connection::class);
+        $resolver = new WbListingResolverService(
+            $listingRepository,
+            $barcodeRepository,
+            new WbBarcodeUpsertQuery($connection),
+            $em,
+        );
+
+        $barcodeCatalogRepository = $this->createMock(MarketplaceBarcodeCatalogRepository::class);
+        $barcodeCatalogRepository->method('findByBarcode')->willReturn(null);
+        $barcodeCatalogRepository->method('findByBarcodesIndexed')->willReturn([]);
+        $barcodeCatalog = new MarketplaceBarcodeCatalogService($barcodeCatalogRepository);
+
+        $innerCostPriceResolver = $this->createMock(CostPriceResolverInterface::class);
+        $innerCostPriceResolver->method('resolve')->willReturn('0.00');
+        $costPriceResolver = new MarketplaceCostPriceResolver($innerCostPriceResolver);
+
+        $processor = new WbReturnsRawProcessor(
+            $this->makeProcessWbReturnsActionStub(),
+            $em,
+            $returnRepository,
+            $saleRepository,
+            $listingRepository,
+            $resolver,
+            $barcodeCatalog,
+            $costPriceResolver,
+            new WbSalesReportRowNormalizer(),
+            new NullLogger(),
+        );
+
+        $baseRow = [
+            'doc_type_name' => 'Возврат',
+            'retail_price_withdisc_rub' => 1000,
+            'retail_price' => 1500,
+            'quantity' => 1,
+            'ts_name' => 'XL',
+            'supplier_oper_name' => 'Возврат покупателем',
+            'rr_dt' => '2026-01-10 10:00:00',
+        ];
+
+        $processor->processBatch('company-1', MarketplaceType::WILDBERRIES, [
+            ['nm_id' => '123', 'srid' => 'WB-RETURN-1'] + $baseRow,
+            ['nm_id' => '456', 'srid' => 'WB-RETURN-2'] + $baseRow,
+        ]);
+    }
+
+    /**
      * @param array<string, mixed> $row
+     *
      * @return array{returns: list<MarketplaceReturn>, createdListings: list<MarketplaceListing>, nmIdsCalls: list<list<string>>}
      */
     private function runProcessorWithRow(array $row, bool $forceResolve = false): array


### PR DESCRIPTION
WbReturnsRawProcessor::processBatch() called MarketplaceSaleRepository ::findByMarketplaceOrder() once per return inside the loop — N queries for N returns when linking a sale for cost-price resolution.

Add findByMarketplaceOrdersIndexed() (single IN(...) query, scoped by company + marketplace, indexed by externalOrderId) and preload all sales before the loop using the already-collected $allSrids set. The per-row repository call is replaced with a map lookup.

Adds a regression test asserting sales are loaded via a single batch call and the per-row method is never invoked.