### PR TITLE
Add timeout and bound pagination in OzonAdapter

### DIFF
--- a/site/src/Marketplace/Service/Integration/OzonAdapter.php
+++ b/site/src/Marketplace/Service/Integration/OzonAdapter.php
@@ -18,6 +18,13 @@ class OzonAdapter implements MarketplaceAdapterInterface
     private const BASE_URL = 'https://api-seller.ozon.ru';
     private const TRANSACTION_ENDPOINT = '/v3/finance/transaction/list';
     private const PAGE_SIZE = 1000;
+    private const REQUEST_TIMEOUT = 120;
+
+    /**
+     * Защитный предел числа страниц пагинации: backstop против runaway-цикла,
+     * если API вернёт некорректный page_count. В штатной работе не достигается.
+     */
+    private const MAX_PAGES = 1000;
 
     public function __construct(
         private readonly HttpClientInterface $httpClient,
@@ -50,6 +57,7 @@ class OzonAdapter implements MarketplaceAdapterInterface
                     'page' => 1,
                     'page_size' => 1,
                 ],
+                'timeout' => self::REQUEST_TIMEOUT,
             ]);
 
             return 200 === $response->getStatusCode();
@@ -88,6 +96,7 @@ class OzonAdapter implements MarketplaceAdapterInterface
 
         $allOperations = [];
         $page = 1;
+        $pageCount = 1;
 
         do {
             $response = $this->httpClient->request('POST', self::BASE_URL . self::TRANSACTION_ENDPOINT, [
@@ -105,13 +114,17 @@ class OzonAdapter implements MarketplaceAdapterInterface
                     'page' => $page,
                     'page_size' => self::PAGE_SIZE,
                 ],
+                'timeout' => self::REQUEST_TIMEOUT,
             ]);
 
             $data = $response->toArray();
             $operations = $data['result']['operations'] ?? [];
-            $pageCount = $data['result']['page_count'] ?? 1;
+            $pageCount = (int) ($data['result']['page_count'] ?? 1);
 
-            $allOperations = array_merge($allOperations, $operations);
+            // In-place append: array_merge в цикле переписывал бы весь аккумулятор каждую итерацию.
+            if ($operations !== []) {
+                array_push($allOperations, ...$operations);
+            }
 
             $this->logger->info('Ozon transactions fetched', [
                 'page' => $page,
@@ -119,7 +132,16 @@ class OzonAdapter implements MarketplaceAdapterInterface
                 'operations_on_page' => count($operations),
             ]);
 
-            $page++;
+            ++$page;
+
+            if ($page > self::MAX_PAGES && $page <= $pageCount) {
+                $this->logger->warning('Ozon transaction pagination cap reached; remaining pages skipped', [
+                    'company_id' => (string) $company->getId(),
+                    'fetched_pages' => self::MAX_PAGES,
+                    'reported_page_count' => $pageCount,
+                ]);
+                break;
+            }
         } while ($page <= $pageCount);
 
         return $allOperations;

--- a/site/tests/Unit/Marketplace/Service/Integration/OzonAdapterTest.php
+++ b/site/tests/Unit/Marketplace/Service/Integration/OzonAdapterTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Service\Integration;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Repository\MarketplaceConnectionRepository;
+use App\Marketplace\Service\Integration\OzonAdapter;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class OzonAdapterTest extends TestCase
+{
+    /**
+     * H2: операции со всех страниц должны накапливаться корректно
+     * (after array_merge → array_push refactor).
+     * H3: каждый HTTP-запрос должен нести явный timeout.
+     */
+    public function testFetchRawReportAccumulatesAllPagesAndPassesTimeout(): void
+    {
+        $capturedTimeouts = [];
+        $responses = [
+            json_encode(['result' => ['operations' => [['operation_id' => 1], ['operation_id' => 2]], 'page_count' => 2]], \JSON_THROW_ON_ERROR),
+            json_encode(['result' => ['operations' => [['operation_id' => 3]], 'page_count' => 2]], \JSON_THROW_ON_ERROR),
+        ];
+        $index = 0;
+
+        $http = new MockHttpClient(static function (string $method, string $url, array $options) use (&$capturedTimeouts, &$index, $responses): MockResponse {
+            $capturedTimeouts[] = $options['timeout'] ?? null;
+
+            return new MockResponse($responses[$index++], ['http_code' => 200]);
+        });
+
+        $adapter = $this->createAdapter($http);
+        $operations = $adapter->fetchRawReport(
+            $this->company(),
+            new \DateTimeImmutable('2026-01-01'),
+            new \DateTimeImmutable('2026-01-31'),
+        );
+
+        self::assertCount(3, $operations);
+        self::assertSame([1, 2, 3], array_column($operations, 'operation_id'));
+
+        self::assertCount(2, $capturedTimeouts);
+        foreach ($capturedTimeouts as $timeout) {
+            self::assertEqualsWithDelta(120, $timeout, 0.0001);
+        }
+    }
+
+    private function createAdapter(MockHttpClient $http): OzonAdapter
+    {
+        $repo = $this->createMock(MarketplaceConnectionRepository::class);
+        $repo->method('findByMarketplace')->willReturn($this->connection());
+
+        return new OzonAdapter($http, $repo, new NullLogger());
+    }
+
+    private function company(): Company
+    {
+        return $this->createMock(Company::class);
+    }
+
+    private function connection(): MarketplaceConnection
+    {
+        $connection = $this->createMock(MarketplaceConnection::class);
+        $connection->method('getId')->willReturn('connection-id');
+        $connection->method('getClientId')->willReturn('client-id');
+        $connection->method('getApiKey')->willReturn('api-key');
+
+        return $connection;
+    }
+}


### PR DESCRIPTION
OzonAdapter::fetchRawTransactions() (Ozon sync path via fetchRawReport) had two issues found in the Marketplace audit:

H3 — no timeout on the Ozon HTTP requests: a hung Ozon API or flaky network could block the worker for the default (effectively unbounded) timeout. Add an explicit 120s timeout (mirrors OzonFetcher) to both the authenticate() probe and the transaction-list requests.

H2 — unbounded page accumulation: the loop re-built the whole operations array with array_merge() each iteration and had no upper bound on the page count. Append in place with array_push(...$operations) and add a defensive MAX_PAGES backstop that logs a warning instead of looping forever if the API returns an incorrect page_count. Full materialization is kept because fetchRawReport() must return the whole payload to store it as a RawDocument.

Adds OzonAdapterTest covering multi-page accumulation and the per-request timeout.