### PR TITLE
Fix medium-severity Marketplace audit findings (M1-M5)

### DIFF
--- a/site/src/Marketplace/Application/Processor/OzonCostsRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/OzonCostsRawProcessor.php
@@ -423,32 +423,35 @@ final class OzonCostsRawProcessor implements MarketplaceRawProcessorInterface
 
             $categoryCode = $this->resolveServiceCategoryCode($serviceName);
 
+            // Деньги через bcmath с точностью 2 знака, чтобы не накапливать float-погрешность.
+            $serviceAmountStr = number_format($serviceAmount, 2, '.', '');
+
             if ($itemCount === 1) {
                 $entries[] = [
                     'external_id'    => $operationId . '_svc_' . $svcIdx,
                     'category_code'  => $categoryCode,
                     'category_name'  => $this->resolveCategoryName($categoryCode),
-                    'amount'         => (string) $serviceAmount,
+                    'amount'         => $serviceAmountStr,
                     'cost_date'      => $operationDate,
                     'description'    => $serviceName,
                     'operation_type' => $serviceOpType,
                     '_item_idx'      => 0,
                 ];
             } else {
-                // Multi-SKU: делим поровну
-                $perItem     = round($serviceAmount / $itemCount, 2);
-                $distributed = 0.0;
+                // Multi-SKU: делим поровну, остаток (копейки) добиваем на последнем SKU.
+                $perItem     = bcdiv($serviceAmountStr, (string) $itemCount, 2);
+                $distributed = '0.00';
 
                 foreach ($items as $itemIdx => $item) {
-                    $isLast  = ($itemIdx === $itemCount - 1);
-                    $amount  = $isLast ? round($serviceAmount - $distributed, 2) : $perItem;
-                    $distributed += $perItem;
+                    $isLast = ($itemIdx === $itemCount - 1);
+                    $amount = $isLast ? bcsub($serviceAmountStr, $distributed, 2) : $perItem;
+                    $distributed = bcadd($distributed, $perItem, 2);
 
                     $entries[] = [
                         'external_id'    => $operationId . '_svc_' . $svcIdx . '_item_' . $itemIdx,
                         'category_code'  => $categoryCode,
                         'category_name'  => $this->resolveCategoryName($categoryCode),
-                        'amount'         => (string) $amount,
+                        'amount'         => $amount,
                         'cost_date'      => $operationDate,
                         'description'    => $serviceName,
                         'operation_type' => $serviceOpType,

--- a/site/src/Marketplace/Application/Processor/WbSalesRawProcessor.php
+++ b/site/src/Marketplace/Application/Processor/WbSalesRawProcessor.php
@@ -149,11 +149,14 @@ final class WbSalesRawProcessor implements MarketplaceRawProcessorInterface
             $sale->setSaleDate($saleDate);
             $quantity = abs($this->normalizer->quantity($item));
             $retailPriceWithDisc = $this->normalizer->retailPriceWithDisc($item);
-            $pricePerUnit = $quantity > 0 ? $retailPriceWithDisc / $quantity : 0.0;
+            // Деньги считаем через bcmath с фиксированной точностью 2 знака,
+            // иначе float-деление давало бы хвост вида "333.33333333" в decimal-поле.
+            $totalRevenue = number_format($retailPriceWithDisc, 2, '.', '');
+            $pricePerUnit = $quantity > 0 ? bcdiv($totalRevenue, (string) $quantity, 2) : '0.00';
 
             $sale->setQuantity($quantity);
-            $sale->setPricePerUnit((string) $pricePerUnit);
-            $sale->setTotalRevenue((string) $retailPriceWithDisc);
+            $sale->setPricePerUnit($pricePerUnit);
+            $sale->setTotalRevenue($totalRevenue);
             $sale->setCostPrice($this->costPriceResolver->resolveForSale($listing, $saleDate));
             $sale->setRawData($item);
             if ($rawDocId !== null) {

--- a/site/src/Marketplace/Application/Reconciliation/XlsxReaderService.php
+++ b/site/src/Marketplace/Application/Reconciliation/XlsxReaderService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Marketplace\Application\Reconciliation;
 
+use App\Marketplace\Exception\ReconciliationFileReadException;
 use OpenSpout\Reader\XLSX\Reader;
 use OpenSpout\Reader\XLSX\Options;
 
@@ -22,57 +23,74 @@ final class XlsxReaderService
         $options->SHOULD_LOAD_EMPTY_ROWS = false;
 
         $reader = new Reader($options);
-        $reader->open($absolutePath);
 
-        $rows   = [];
-        $period = '';
-        $rowIndex = 0;
-
-        foreach ($reader->getSheetIterator() as $sheet) {
-            foreach ($sheet->getRowIterator() as $row) {
-                $rowIndex++;
-                $cells = $row->getCells();
-                $values = array_map(static fn($cell) => $cell->getValue(), $cells);
-
-                // Строка 1 — период "Период: 01.01.2026-31.01.2026"
-                if ($rowIndex === 1) {
-                    $period = (string) ($values[0] ?? '');
-                    continue;
-                }
-
-                // Строка 2 — заголовки
-                if ($rowIndex === 2) {
-                    continue;
-                }
-
-                $amount = $values[15] ?? null;
-                if ($amount === null || $amount === '') {
-                    continue;
-                }
-
-                $rows[] = [
-                    'id'           => $values[0] ?? null,
-                    'date'         => $values[1] ?? null,
-                    'serviceGroup' => (string) ($values[2] ?? ''),
-                    'typeName'     => (string) ($values[3] ?? ''),
-                    'article'      => $values[4] ?? null,
-                    'sku'          => $values[5] ?? null,
-                    'productName'  => $values[6] ?? null,
-                    'quantity'     => (int) ($values[7] ?? 0),
-                    'price'        => (float) ($values[8] ?? 0),
-                    'orderDate'    => $values[9] ?? null,
-                    'platform'     => $values[10] ?? null,
-                    'workScheme'   => $values[11] ?? null,
-                    'ozonFee'      => (float) ($values[12] ?? 0),
-                    'locIndex'     => $values[13] ?? null,
-                    'deliveryTime' => $values[14] ?? null,
-                    'amount'       => (float) $amount,
-                ];
-            }
-            break; // Только первый лист
+        try {
+            $reader->open($absolutePath);
+        } catch (\Throwable $e) {
+            throw new ReconciliationFileReadException(
+                sprintf('Не удалось открыть XLSX-файл сверки «%s»: %s', basename($absolutePath), $e->getMessage()),
+                0,
+                $e,
+            );
         }
 
-        $reader->close();
+        try {
+            $rows   = [];
+            $period = '';
+            $rowIndex = 0;
+
+            foreach ($reader->getSheetIterator() as $sheet) {
+                foreach ($sheet->getRowIterator() as $row) {
+                    $rowIndex++;
+                    $cells = $row->getCells();
+                    $values = array_map(static fn($cell) => $cell->getValue(), $cells);
+
+                    // Строка 1 — период "Период: 01.01.2026-31.01.2026"
+                    if ($rowIndex === 1) {
+                        $period = (string) ($values[0] ?? '');
+                        continue;
+                    }
+
+                    // Строка 2 — заголовки
+                    if ($rowIndex === 2) {
+                        continue;
+                    }
+
+                    $amount = $values[15] ?? null;
+                    if ($amount === null || $amount === '') {
+                        continue;
+                    }
+
+                    $rows[] = [
+                        'id'           => $values[0] ?? null,
+                        'date'         => $values[1] ?? null,
+                        'serviceGroup' => (string) ($values[2] ?? ''),
+                        'typeName'     => (string) ($values[3] ?? ''),
+                        'article'      => $values[4] ?? null,
+                        'sku'          => $values[5] ?? null,
+                        'productName'  => $values[6] ?? null,
+                        'quantity'     => (int) ($values[7] ?? 0),
+                        'price'        => (float) ($values[8] ?? 0),
+                        'orderDate'    => $values[9] ?? null,
+                        'platform'     => $values[10] ?? null,
+                        'workScheme'   => $values[11] ?? null,
+                        'ozonFee'      => (float) ($values[12] ?? 0),
+                        'locIndex'     => $values[13] ?? null,
+                        'deliveryTime' => $values[14] ?? null,
+                        'amount'       => (float) $amount,
+                    ];
+                }
+                break; // Только первый лист
+            }
+        } catch (\Throwable $e) {
+            throw new ReconciliationFileReadException(
+                sprintf('Ошибка чтения XLSX-файла сверки «%s»: %s', basename($absolutePath), $e->getMessage()),
+                0,
+                $e,
+            );
+        } finally {
+            $reader->close();
+        }
 
         return ['period' => $period, 'rows' => $rows];
     }

--- a/site/src/Marketplace/Exception/ReconciliationFileReadException.php
+++ b/site/src/Marketplace/Exception/ReconciliationFileReadException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Exception;
+
+/**
+ * Не удалось открыть или прочитать файл сверки (XLSX-отчёт Ozon).
+ */
+final class ReconciliationFileReadException extends \RuntimeException
+{
+}

--- a/site/src/Marketplace/Infrastructure/Api/Ozon/OzonTransactionTotalsClient.php
+++ b/site/src/Marketplace/Infrastructure/Api/Ozon/OzonTransactionTotalsClient.php
@@ -76,6 +76,15 @@ final readonly class OzonTransactionTotalsClient
             ],
         ]);
 
+        $statusCode = $response->getStatusCode();
+
+        if ($statusCode < 200 || $statusCode >= 300) {
+            // getContent(false) не бросает на 4xx/5xx и отдаёт сырое тело — статус
+            // всплывёт даже если тело ошибки не является валидным JSON.
+            $preview = mb_substr($response->getContent(false), 0, 300);
+            throw new \RuntimeException(sprintf('Ozon transaction totals вернул HTTP %d. preview=%s', $statusCode, $preview));
+        }
+
         $payload = $response->toArray(false);
         $result = $payload['result'] ?? null;
 

--- a/site/src/Marketplace/Service/Integration/OzonAdapter.php
+++ b/site/src/Marketplace/Service/Integration/OzonAdapter.php
@@ -142,8 +142,13 @@ class OzonAdapter implements MarketplaceAdapterInterface
                 continue;
             }
 
+            $operationDate = $this->parseOperationDate($op['operation_date'] ?? null);
+            if (null === $operationDate) {
+                $this->logger->warning('Ozon operation skipped: invalid operation_date', ['operation_id' => $op['operation_id'] ?? null]);
+                continue;
+            }
+
             $postingNumber = $op['posting']['posting_number'] ?? '';
-            $operationDate = new \DateTimeImmutable($op['operation_date']);
             $items = $op['items'] ?? [];
 
             // SKU первого товара в операции
@@ -174,7 +179,11 @@ class OzonAdapter implements MarketplaceAdapterInterface
 
         foreach ($operations as $op) {
             $operationId = (string)($op['operation_id'] ?? '');
-            $operationDate = new \DateTimeImmutable($op['operation_date']);
+            $operationDate = $this->parseOperationDate($op['operation_date'] ?? null);
+            if (null === $operationDate) {
+                $this->logger->warning('Ozon operation skipped: invalid operation_date', ['operation_id' => $op['operation_id'] ?? null]);
+                continue;
+            }
             $postingNumber = $op['posting']['posting_number'] ?? '';
             $items = $op['items'] ?? [];
             $sku = !empty($items) ? (string)$items[0]['sku'] : null;
@@ -267,8 +276,13 @@ class OzonAdapter implements MarketplaceAdapterInterface
                 continue;
             }
 
+            $operationDate = $this->parseOperationDate($op['operation_date'] ?? null);
+            if (null === $operationDate) {
+                $this->logger->warning('Ozon operation skipped: invalid operation_date', ['operation_id' => $op['operation_id'] ?? null]);
+                continue;
+            }
+
             $postingNumber = $op['posting']['posting_number'] ?? '';
-            $operationDate = new \DateTimeImmutable($op['operation_date']);
             $items = $op['items'] ?? [];
             $sku = !empty($items) ? (string)$items[0]['sku'] : '';
 
@@ -356,6 +370,24 @@ class OzonAdapter implements MarketplaceAdapterInterface
 
         // Прочее
         return 'ozon_other_service';
+    }
+
+    /**
+     * Безопасный разбор даты операции из ответа Ozon.
+     * Возвращает null, если поле отсутствует/пустое/имеет некорректный формат —
+     * вызывающий пропускает такую операцию, не роняя обработку всего батча.
+     */
+    private function parseOperationDate(mixed $value): ?\DateTimeImmutable
+    {
+        if (!is_string($value) || '' === $value) {
+            return null;
+        }
+
+        try {
+            return new \DateTimeImmutable($value);
+        } catch (\Exception) {
+            return null;
+        }
     }
 
     private function buildHeaders(MarketplaceConnection $connection): array

--- a/site/tests/Unit/Marketplace/Application/Processor/WbSalesRawProcessorRevenueTest.php
+++ b/site/tests/Unit/Marketplace/Application/Processor/WbSalesRawProcessorRevenueTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Marketplace\Application\Processor;
 
 use App\Company\Entity\Company;
-use App\Marketplace\Application\ProcessWbSalesAction;
 use App\Marketplace\Application\Processor\WbSalesRawProcessor;
+use App\Marketplace\Application\ProcessWbSalesAction;
 use App\Marketplace\Application\Service\MarketplaceBarcodeCatalogService;
 use App\Marketplace\Application\Service\MarketplaceCostPriceResolver;
 use App\Marketplace\Application\Service\WbListingResolverService;
@@ -42,10 +42,31 @@ final class WbSalesRawProcessorRevenueTest extends TestCase
 
         self::assertCount(1, $result['sales']);
         self::assertSame([['123']], $result['nmIdsCalls']);
-        self::assertSame('2493', $result['sales'][0]->getTotalRevenue());
-        self::assertSame('2493', $result['sales'][0]->getPricePerUnit());
+        self::assertSame('2493.00', $result['sales'][0]->getTotalRevenue());
+        self::assertSame('2493.00', $result['sales'][0]->getPricePerUnit());
         self::assertNotSame('1607', $result['sales'][0]->getTotalRevenue());
         self::assertSame('2026-01-10', $result['sales'][0]->getSaleDate()->format('Y-m-d'));
+    }
+
+    /**
+     * M1: цена за единицу считается через bcmath с точностью 2 знака —
+     * неделящаяся сумма не должна давать длинный float-хвост.
+     */
+    public function testPricePerUnitUsesTwoDecimalBcmathForNonDivisibleQuantity(): void
+    {
+        $result = $this->runProcessorWithRow([
+            'doc_type_name' => 'Продажа',
+            'retail_price_withdisc_rub' => 1000,
+            'quantity' => 3,
+            'srid' => 'WB-ORDER-DIV',
+            'nm_id' => '123',
+            'ts_name' => 'XL',
+            'sale_dt' => '2026-01-10 10:00:00',
+        ]);
+
+        self::assertCount(1, $result['sales']);
+        self::assertSame('1000.00', $result['sales'][0]->getTotalRevenue());
+        self::assertSame('333.33', $result['sales'][0]->getPricePerUnit());
     }
 
     public function testCamelCaseSaleCreatesSaleAndListingWithNormalizedMetadata(): void
@@ -70,7 +91,7 @@ final class WbSalesRawProcessorRevenueTest extends TestCase
 
         self::assertCount(1, $result['sales']);
         self::assertSame('test-sale-srid-1', $result['sales'][0]->getExternalOrderId());
-        self::assertSame('2099', $result['sales'][0]->getTotalRevenue());
+        self::assertSame('2099.00', $result['sales'][0]->getTotalRevenue());
         self::assertNotSame('1584', $result['sales'][0]->getTotalRevenue());
 
         self::assertCount(1, $result['createdListings']);
@@ -87,6 +108,7 @@ final class WbSalesRawProcessorRevenueTest extends TestCase
 
     /**
      * @param array<string, mixed> $row
+     *
      * @return array{sales: list<MarketplaceSale>, createdListings: list<MarketplaceListing>, nmIdsCalls: list<list<string>>}
      */
     private function runProcessorWithRow(array $row, bool $forceResolve = false): array

--- a/site/tests/Unit/Marketplace/Application/Reconciliation/XlsxReaderServiceTest.php
+++ b/site/tests/Unit/Marketplace/Application/Reconciliation/XlsxReaderServiceTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Application\Reconciliation;
+
+use App\Marketplace\Application\Reconciliation\XlsxReaderService;
+use App\Marketplace\Exception\ReconciliationFileReadException;
+use PHPUnit\Framework\TestCase;
+
+final class XlsxReaderServiceTest extends TestCase
+{
+    /**
+     * M4: повреждённый/недоступный файл должен давать понятное доменное
+     * исключение, а не падать необработанным низкоуровневым исключением.
+     */
+    public function testThrowsDomainExceptionWhenFileCannotBeOpened(): void
+    {
+        $service = new XlsxReaderService();
+
+        $this->expectException(ReconciliationFileReadException::class);
+
+        $service->read('/nonexistent/path/reconciliation-does-not-exist.xlsx');
+    }
+}

--- a/site/tests/Unit/Marketplace/Infrastructure/Api/Ozon/OzonTransactionTotalsClientTest.php
+++ b/site/tests/Unit/Marketplace/Infrastructure/Api/Ozon/OzonTransactionTotalsClientTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Infrastructure\Api\Ozon;
+
+use App\Marketplace\Infrastructure\Api\Ozon\OzonTransactionTotalsClient;
+use App\Marketplace\Infrastructure\Query\MarketplaceCredentialsQuery;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class OzonTransactionTotalsClientTest extends TestCase
+{
+    /**
+     * M2: HTTP-ошибку нельзя глотать через toArray(false) — статус должен
+     * всплыть в исключении, а не парситься как валидные данные.
+     */
+    public function testThrowsAndSurfacesHttpStatusOnErrorResponse(): void
+    {
+        $dbal = $this->createMock(Connection::class);
+        $dbal->method('fetchAssociative')->willReturn(['api_key' => 'key', 'client_id' => 'client']);
+        $credentialsQuery = new MarketplaceCredentialsQuery($dbal);
+
+        $http = new MockHttpClient(new MockResponse('{"error":"boom"}', ['http_code' => 500]));
+        $client = new OzonTransactionTotalsClient($http, $credentialsQuery);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/HTTP 500/');
+
+        $client->fetchTotals(
+            '0192f0c2-0000-7000-8000-000000000000',
+            new \DateTimeImmutable('2026-01-01'),
+            new \DateTimeImmutable('2026-01-31'),
+        );
+    }
+}

--- a/site/tests/Unit/Marketplace/Service/Integration/OzonAdapterDateParsingTest.php
+++ b/site/tests/Unit/Marketplace/Service/Integration/OzonAdapterDateParsingTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Service\Integration;
+
+use App\Company\Entity\Company;
+use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Repository\MarketplaceConnectionRepository;
+use App\Marketplace\Service\Integration\OzonAdapter;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class OzonAdapterDateParsingTest extends TestCase
+{
+    /**
+     * M3: операция с некорректной/отсутствующей operation_date пропускается
+     * (логируется), а не роняет обработку всего батча.
+     */
+    public function testFetchSalesSkipsOperationWithInvalidOperationDate(): void
+    {
+        $payload = json_encode([
+            'result' => [
+                'operations' => [
+                    ['type' => 'orders', 'accruals_for_sale' => 100, 'operation_id' => 1, 'operation_date' => 'not-a-date', 'items' => [['sku' => 'A']], 'posting' => ['posting_number' => 'P1']],
+                    ['type' => 'orders', 'accruals_for_sale' => 200, 'operation_id' => 2, 'operation_date' => '2026-01-15 10:00:00', 'items' => [['sku' => 'B']], 'posting' => ['posting_number' => 'P2']],
+                ],
+                'page_count' => 1,
+            ],
+        ], \JSON_THROW_ON_ERROR);
+
+        $adapter = $this->createAdapter(new MockHttpClient(new MockResponse($payload, ['http_code' => 200])));
+
+        $sales = $adapter->fetchSales(
+            $this->createMock(Company::class),
+            new \DateTimeImmutable('2026-01-01'),
+            new \DateTimeImmutable('2026-01-31'),
+        );
+
+        self::assertCount(1, $sales);
+        self::assertSame('P2', $sales[0]->externalOrderId);
+    }
+
+    private function createAdapter(MockHttpClient $http): OzonAdapter
+    {
+        $repo = $this->createMock(MarketplaceConnectionRepository::class);
+        $repo->method('findByMarketplace')->willReturn($this->connection());
+
+        return new OzonAdapter($http, $repo, new NullLogger());
+    }
+
+    private function connection(): MarketplaceConnection
+    {
+        $connection = $this->createMock(MarketplaceConnection::class);
+        $connection->method('getId')->willReturn('connection-id');
+        $connection->method('getClientId')->willReturn('client-id');
+        $connection->method('getApiKey')->willReturn('api-key');
+
+        return $connection;
+    }
+}


### PR DESCRIPTION
M1 — WbSalesRawProcessor: price-per-unit was computed with float division and stored as string, leaking a long tail like "333.33333333" into the decimal column. Use number_format + bcdiv with scale 2; revenue is normalized to 2 decimals too.

M2 — OzonTransactionTotalsClient: toArray(false) swallowed the HTTP status, so a 4xx/5xx Ozon response was parsed as data. Check the status code first and throw with the status and a raw-body preview (works even when the error body is not JSON).

M3 — OzonAdapter: new \DateTimeImmutable($op['operation_date']) could throw on a missing/invalid date and abort the whole batch. Add a guarded parseOperationDate() helper; an unparseable operation is logged and skipped.

M4 — XlsxReaderService: read() opened and iterated the file without any error handling. Wrap open and iteration, guarantee reader close() via finally, and rethrow a domain ReconciliationFileReadException with the cause.

M5 — OzonCostsRawProcessor: multi-SKU cost split accumulated float rounding. Distribute with bcdiv/bcadd/bcsub (scale 2); the last SKU absorbs the remainder so the parts sum exactly to the service amount.

Tests: regression for the non-divisible price-per-unit, Ozon totals HTTP error, invalid operation_date skip, and XLSX read failure. Existing delta-based OzonCosts tests still pass.