### PR TITLE
обновление синхронизации с WB fix/bug

### DIFF
--- a/site/src/Marketplace/Command/WbFinancialReportsOrchestrateCommand.php
+++ b/site/src/Marketplace/Command/WbFinancialReportsOrchestrateCommand.php
@@ -9,6 +9,7 @@ use App\Marketplace\Application\Service\WbFinancialReportPeriodResolver;
 use App\Marketplace\Application\Service\WbFinancialReportSyncPlannerInterface;
 use App\Marketplace\Exception\MarketplaceRateLimitException;
 use App\Marketplace\Infrastructure\Query\ActiveWbConnectionsQuery;
+use App\Marketplace\Repository\MarketplaceFinancialReportSyncStatusRepository;
 use Doctrine\DBAL\Connection;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -207,6 +208,8 @@ final class WbFinancialReportsOrchestrateCommand extends Command
                AND (
                     (status IN ('queued', 'failed') AND next_retry_at IS NOT NULL AND next_retry_at <= NOW())
                     OR (status = 'failed' AND next_retry_at IS NULL AND last_error_status_code = 429 AND last_error_class = :rateLimitErrorClass)
+                    OR (status = 'queued' AND next_retry_at IS NULL AND updated_at <= :stuckBefore)
+                    OR (status = 'loading' AND updated_at <= :stuckBefore)
                )",
             [
                 'companyId' => $companyId,
@@ -215,6 +218,9 @@ final class WbFinancialReportsOrchestrateCommand extends Command
                 'fromDate' => $from->format('Y-m-d'),
                 'toDate' => $to->format('Y-m-d'),
                 'rateLimitErrorClass' => MarketplaceRateLimitException::class,
+                'stuckBefore' => (new \DateTimeImmutable())
+                    ->sub(new \DateInterval(MarketplaceFinancialReportSyncStatusRepository::STUCK_RECLAIM_INTERVAL))
+                    ->format('Y-m-d H:i:s'),
             ],
         );
     }

--- a/site/src/Marketplace/Controller/Api/WbFinanceSyncStatusController.php
+++ b/site/src/Marketplace/Controller/Api/WbFinanceSyncStatusController.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Controller\Api;
+
+use App\Marketplace\Enum\FinancialReportSyncStatus;
+use App\Marketplace\Infrastructure\Query\WbFinanceSyncStatusListQuery;
+use App\Shared\Service\ActiveCompanyService;
+use Pagerfanta\Doctrine\DBAL\QueryAdapter;
+use Pagerfanta\Pagerfanta;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * История загрузки финансовых отчётов WB по дням: статус и причина ошибки.
+ */
+#[IsGranted('ROLE_USER')]
+final class WbFinanceSyncStatusController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $activeCompanyService,
+        private readonly WbFinanceSyncStatusListQuery $listQuery,
+    ) {
+    }
+
+    #[Route('/api/marketplace/wb-finance/sync-statuses', name: 'api_marketplace_wb_finance_sync_statuses', methods: ['GET'])]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $company = $this->activeCompanyService->getActiveCompany();
+
+        $limit = $request->query->getInt('limit', 50);
+        if ($limit < 1 || $limit > 200) {
+            return $this->json([
+                'error' => [
+                    'code' => 'invalid_pagination_limit',
+                    'message' => 'Параметр limit должен быть от 1 до 200',
+                ],
+            ], Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        $days = $request->query->getInt('days', 14);
+        if ($days < 1 || $days > 366) {
+            return $this->json([
+                'error' => [
+                    'code' => 'invalid_days_window',
+                    'message' => 'Параметр days должен быть от 1 до 366',
+                ],
+            ], Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        $from = (new \DateTimeImmutable('today'))->modify(sprintf('-%d days', $days));
+        $qb = $this->listQuery->createByCompanyQueryBuilder((string) $company->getId(), $from);
+
+        $adapter = new QueryAdapter(
+            $qb,
+            static function (\Doctrine\DBAL\Query\QueryBuilder $countQb): void {
+                $countQb->select('COUNT(*)')->resetOrderBy();
+            },
+        );
+        $pagerfanta = new Pagerfanta($adapter);
+        $pagerfanta->setMaxPerPage($limit);
+        $pagerfanta->setCurrentPage(max(1, $request->query->getInt('page', 1)));
+
+        $items = [];
+        foreach ($pagerfanta->getCurrentPageResults() as $row) {
+            $status = FinancialReportSyncStatus::from((string) $row['status']);
+
+            $items[] = [
+                'id' => $row['id'],
+                'connection_id' => $row['connection_id'],
+                'marketplace' => $row['marketplace'],
+                'report_type' => $row['report_type'],
+                'business_date' => substr((string) $row['business_date'], 0, 10),
+                'status' => $status->value,
+                'status_label' => $status->getLabel(),
+                'mode' => $row['mode'],
+                'records_count' => (int) $row['records_count'],
+                'attempts' => (int) $row['attempts'],
+                'next_retry_at' => $row['next_retry_at'],
+                'error_class' => $row['last_error_class'],
+                'error_message' => $row['last_error_message'],
+                'http_status' => null !== $row['last_error_status_code'] ? (int) $row['last_error_status_code'] : null,
+                'started_at' => $row['started_at'],
+                'finished_at' => $row['finished_at'],
+                'updated_at' => $row['updated_at'],
+            ];
+        }
+
+        return $this->json([
+            'items' => $items,
+            'total' => $pagerfanta->getNbResults(),
+            'pages' => $pagerfanta->getNbPages(),
+            'page' => $pagerfanta->getCurrentPage(),
+            'per_page' => $pagerfanta->getMaxPerPage(),
+        ]);
+    }
+}

--- a/site/src/Marketplace/Controller/MarketplaceController.php
+++ b/site/src/Marketplace/Controller/MarketplaceController.php
@@ -14,8 +14,10 @@ use App\Marketplace\Entity\MarketplaceListing;
 use App\Marketplace\Application\Command\SyncConnectionCommand;
 use App\Marketplace\Enum\MarketplaceConnectionType;
 use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Enum\FinancialReportSyncStatus;
 use App\Marketplace\Infrastructure\Query\OzonRealizationStatusQuery;
 use App\Marketplace\Infrastructure\Query\RawDocumentsListQuery;
+use App\Marketplace\Infrastructure\Query\WbFinanceSyncStatusListQuery;
 use App\Marketplace\Message\ReprocessCostsMessage;
 use App\Marketplace\Message\SyncOzonRealizationMessage;
 use App\Marketplace\Message\TriggerInitialSyncMessage;
@@ -54,6 +56,7 @@ class MarketplaceController extends AbstractController
         private readonly SyncConnectionAction             $syncConnectionAction,
         private readonly WbInitialSyncStartDateResolver   $wbInitialSyncStartDateResolver,
         private readonly WbFinancialReportSyncPlannerInterface $wbFinancialReportSyncPlanner,
+        private readonly WbFinanceSyncStatusListQuery     $wbFinanceSyncStatusListQuery,
     ) {
     }
 
@@ -77,11 +80,18 @@ class MarketplaceController extends AbstractController
             50,
         );
 
+        $wbFinanceSyncDays = array_map(static function (array $row): array {
+            $row['status_enum'] = FinancialReportSyncStatus::from((string) $row['status']);
+
+            return $row;
+        }, $this->wbFinanceSyncStatusListQuery->findRecentDays((string) $company->getId(), 14));
+
         return $this->render('marketplace/index.html.twig', [
             'connections'           => $connections,
             'rawDocumentsPager'     => $rawDocumentsPager,
             'availableMarketplaces' => MarketplaceType::cases(),
             'selectedMarketplace'   => $selectedMarketplace,
+            'wbFinanceSyncDays'     => $wbFinanceSyncDays,
         ]);
     }
 

--- a/site/src/Marketplace/Infrastructure/Query/WbFinanceSyncStatusListQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/WbFinanceSyncStatusListQuery.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Query;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+
+/**
+ * DBAL Query: статусы загрузки финансовых отчётов WB по дням для компании.
+ * Источник для UI-таблицы статусов синхронизации и API endpoint'а.
+ */
+final class WbFinanceSyncStatusListQuery
+{
+    public function __construct(
+        private readonly Connection $connection,
+    ) {}
+
+    public function createByCompanyQueryBuilder(string $companyId, ?\DateTimeImmutable $from = null): QueryBuilder
+    {
+        $qb = $this->connection->createQueryBuilder()
+            ->select(
+                's.id',
+                's.connection_id',
+                's.marketplace',
+                's.report_type',
+                's.business_date',
+                's.status',
+                's.mode',
+                's.records_count',
+                's.attempts',
+                's.next_retry_at',
+                's.last_error_class',
+                's.last_error_message',
+                's.last_error_status_code',
+                's.started_at',
+                's.finished_at',
+                's.updated_at',
+            )
+            ->from('marketplace_financial_report_sync_statuses', 's')
+            ->where('s.company_id = :companyId')
+            ->andWhere('s.marketplace = :marketplace')
+            ->andWhere('s.report_type = :reportType')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('marketplace', 'wildberries')
+            ->setParameter('reportType', 'sales_report')
+            ->orderBy('s.business_date', 'DESC');
+
+        if (null !== $from) {
+            $qb->andWhere('s.business_date >= :fromDate')
+                ->setParameter('fromDate', $from->format('Y-m-d'));
+        }
+
+        return $qb;
+    }
+
+    /**
+     * Последние N дней для server-side рендера карточки на странице маркетплейсов.
+     * Окно ограничено днями (одна строка на день/report_type) — выборка bounded.
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function findRecentDays(string $companyId, int $days = 14): array
+    {
+        $from = (new \DateTimeImmutable('today'))->modify(sprintf('-%d days', max(1, $days)));
+
+        return $this->createByCompanyQueryBuilder($companyId, $from)
+            ->executeQuery()
+            ->fetchAllAssociative();
+    }
+}

--- a/site/src/Marketplace/MessageHandler/SyncWbFinancialReportDayHandler.php
+++ b/site/src/Marketplace/MessageHandler/SyncWbFinancialReportDayHandler.php
@@ -8,6 +8,8 @@ use App\Company\Entity\Company;
 use App\Marketplace\Application\Service\WbFinancialReportPeriodResolver;
 use App\Marketplace\Application\Service\WbFinancialReportReconciliationService;
 use App\Marketplace\Application\Service\WbFinancialReportSyncStatusUpdater;
+use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Entity\MarketplaceFinancialReportSyncStatus;
 use App\Marketplace\Entity\MarketplaceRawDocument;
 use App\Marketplace\Enum\FinancialReportSyncMode;
 use App\Marketplace\Enum\FinancialReportSyncStatus;
@@ -386,6 +388,8 @@ final class SyncWbFinancialReportDayHandler
                 'connection_id' => $message->connectionId,
                 'business_date' => $businessDate->format('Y-m-d'),
                 'mode' => $mode->value,
+                'http_status' => $e->getStatusCode(),
+                'error_message' => $e->getMessage(),
             ]);
 
             throw new UnrecoverableMessageHandlingException($e->getMessage(), 0, $e);
@@ -408,6 +412,8 @@ final class SyncWbFinancialReportDayHandler
                 'connection_id' => $message->connectionId,
                 'business_date' => $businessDate->format('Y-m-d'),
                 'mode' => $mode->value,
+                'http_status' => $e->getStatusCode(),
+                'error_message' => $e->getMessage(),
             ]);
 
             throw new RecoverableMessageHandlingException($e->getMessage(), 0, $e);
@@ -434,9 +440,56 @@ final class SyncWbFinancialReportDayHandler
                 'connection_id' => $message->connectionId,
                 'business_date' => $businessDate->format('Y-m-d'),
                 'mode' => $mode->value,
+                'http_status' => $e->getStatusCode(),
+                'error_message' => $e->getMessage(),
             ]);
 
             throw new UnrecoverableMessageHandlingException($e->getMessage(), 0, $e);
+        } catch (\Throwable $e) {
+            // Без этого блока неожиданное исключение оставляет статус в LOADING навсегда:
+            // такой день не попадает ни в retry-выборку, ни в missing (строка уже существует).
+            $this->recordUnexpectedFailure($status, $connection, $e, $effectiveRawDocumentId, $effectiveRrdId);
+
+            $this->logger->error('WB day sync failed with unexpected error.', [
+                'company_id' => $message->companyId,
+                'connection_id' => $message->connectionId,
+                'business_date' => $businessDate->format('Y-m-d'),
+                'mode' => $mode->value,
+                'error_class' => $e::class,
+                'error_message' => $e->getMessage(),
+            ]);
+
+            throw $e;
+        }
+    }
+
+    private function recordUnexpectedFailure(
+        MarketplaceFinancialReportSyncStatus $status,
+        MarketplaceConnection $connection,
+        \Throwable $e,
+        ?string $effectiveRawDocumentId,
+        ?int $effectiveRrdId,
+    ): void {
+        try {
+            $this->syncStatusUpdater->markFailedRetryablePreservingCursor(
+                $status,
+                $e::class,
+                $e->getMessage(),
+                null,
+                null,
+                null,
+                $this->retryAfterFromNow(15 * 60),
+                $effectiveRawDocumentId,
+                $effectiveRrdId,
+            );
+            $connection->markSyncFailed($e->getMessage());
+            $this->em->flush();
+        } catch (\Throwable $persistError) {
+            $this->logger->error('WB day sync could not persist failure status, status may stay stale until stuck-reclaim.', [
+                'company_id' => $status->getCompanyId(),
+                'business_date' => $status->getBusinessDate()->format('Y-m-d'),
+                'persist_error' => $persistError->getMessage(),
+            ]);
         }
     }
 

--- a/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepository.php
+++ b/site/src/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepository.php
@@ -20,6 +20,14 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
 {
     private const ADVISORY_LOCK_NAMESPACE = 'marketplace_financial_report_sync';
 
+    /**
+     * Статусы QUEUED (без next_retry_at — сообщение потеряно после claim) и LOADING
+     * (worker убит после markLoading) без этого порога зависают навсегда: они не
+     * переоткрываются claim'ом, не попадают в retry-выборку и не считаются missing.
+     * Порог должен быть заметно больше lock TTL handler'а (600 c) и окна redelivery Messenger.
+     */
+    public const STUCK_RECLAIM_INTERVAL = 'PT2H';
+
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, MarketplaceFinancialReportSyncStatus::class);
@@ -150,6 +158,8 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
                 (s.status = :queuedStatus AND s.nextRetryAt IS NOT NULL AND s.nextRetryAt <= :now)
                 OR (s.status = :failedStatus AND s.nextRetryAt IS NOT NULL AND s.nextRetryAt <= :now)
                 OR (s.status = :failedStatus AND s.nextRetryAt IS NULL AND s.lastErrorStatusCode = :rateLimitStatusCode AND s.lastErrorClass = :rateLimitErrorClass)
+                OR (s.status = :queuedStatus AND s.nextRetryAt IS NULL AND s.updatedAt <= :stuckBefore)
+                OR (s.status = :loadingStatus AND s.updatedAt <= :stuckBefore)
             )')
             ->setParameter('companyId', $companyId)
             ->setParameter('marketplace', $marketplace)
@@ -158,7 +168,9 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
             ->setParameter('to', $to)
             ->setParameter('queuedStatus', FinancialReportSyncStatus::QUEUED)
             ->setParameter('failedStatus', FinancialReportSyncStatus::FAILED)
+            ->setParameter('loadingStatus', FinancialReportSyncStatus::LOADING)
             ->setParameter('now', $now)
+            ->setParameter('stuckBefore', $now->sub(new \DateInterval(self::STUCK_RECLAIM_INTERVAL)))
             ->setParameter('rateLimitStatusCode', 429)
             ->setParameter('rateLimitErrorClass', MarketplaceRateLimitException::class)
             ->orderBy('s.businessDate', 'ASC')
@@ -271,9 +283,13 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
         \DateTimeImmutable $now,
     ): bool {
         $status = $syncStatus->getStatus();
+        $stuckBefore = $now->sub(new \DateInterval(self::STUCK_RECLAIM_INTERVAL));
+
+        if (FinancialReportSyncStatus::LOADING === $status) {
+            return $syncStatus->getUpdatedAt() <= $stuckBefore;
+        }
 
         if (\in_array($status, [
-            FinancialReportSyncStatus::LOADING,
             FinancialReportSyncStatus::RAW_LOADED,
             FinancialReportSyncStatus::PROCESSING,
         ], true)) {
@@ -288,7 +304,11 @@ final class MarketplaceFinancialReportSyncStatusRepository extends ServiceEntity
         }
 
         if (FinancialReportSyncStatus::QUEUED === $status) {
-            return null !== $syncStatus->getNextRetryAt() && $syncStatus->getNextRetryAt() <= $now;
+            if (null === $syncStatus->getNextRetryAt()) {
+                return $syncStatus->getUpdatedAt() <= $stuckBefore;
+            }
+
+            return $syncStatus->getNextRetryAt() <= $now;
         }
 
         if (!$forceRefresh

--- a/site/templates/marketplace/index.html.twig
+++ b/site/templates/marketplace/index.html.twig
@@ -130,6 +130,75 @@
             </div>
         </div>
 
+        {# Статус загрузки финансовых отчётов WB по дням #}
+        {% if wbFinanceSyncDays is not empty %}
+            {% set wbSyncBadgeClass = {
+                'success': 'bg-success',
+                'empty': 'bg-secondary',
+                'queued': 'bg-secondary',
+                'loading': 'bg-info',
+                'raw_loaded': 'bg-info',
+                'processing': 'bg-info',
+                'failed': 'bg-danger',
+                'failed_final': 'bg-danger',
+                'auth_failed': 'bg-danger',
+                'conflict': 'bg-warning',
+            } %}
+            <div class="card mb-3">
+                <div class="card-header">
+                    <h3 class="card-title mb-0">Загрузка отчётов WB (последние 14 дней)</h3>
+                </div>
+                <div class="table-responsive">
+                    <table class="table card-table table-vcenter">
+                        <thead>
+                        <tr>
+                            <th>Дата</th>
+                            <th>Режим</th>
+                            <th>Статус</th>
+                            <th>Записей</th>
+                            <th>Попыток</th>
+                            <th>Обновлено</th>
+                            <th>Ошибка</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {% for day in wbFinanceSyncDays %}
+                            <tr>
+                                <td>{{ day.business_date|date('d.m.Y') }}</td>
+                                <td><small class="text-muted">{{ day.mode ?? '—' }}</small></td>
+                                <td>
+                                    <span class="badge {{ wbSyncBadgeClass[day.status] ?? 'bg-secondary' }}"
+                                          {% if day.last_error_message %}title="{{ day.last_error_message }}"{% endif %}>
+                                        {{ day.status_enum.label }}
+                                    </span>
+                                </td>
+                                <td>{{ day.records_count }}</td>
+                                <td>{{ day.attempts }}</td>
+                                <td><small>{{ day.updated_at|date('d.m.Y H:i') }}</small></td>
+                                <td>
+                                    {% if day.last_error_message %}
+                                        <details>
+                                            <summary class="text-danger small" title="{{ day.last_error_message }}">
+                                                {{ day.last_error_message|length > 60 ? day.last_error_message|slice(0, 60) ~ '…' : day.last_error_message }}
+                                            </summary>
+                                            <div class="small text-muted mt-1">
+                                                {% if day.last_error_status_code %}HTTP {{ day.last_error_status_code }} · {% endif %}
+                                                {{ day.last_error_class }}<br>
+                                                {{ day.last_error_message }}
+                                            </div>
+                                        </details>
+                                    {% else %}
+                                        <span class="text-muted">—</span>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        {% endif %}
+
         {# История синхронизаций #}
         <div class="card">
             <div class="card-header d-flex align-items-center justify-content-between gap-3">

--- a/site/tests/Functional/Marketplace/Controller/WbFinanceSyncStatusControllerTest.php
+++ b/site/tests/Functional/Marketplace/Controller/WbFinanceSyncStatusControllerTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Marketplace\Controller;
+
+use App\Company\Entity\Company;
+use App\Company\Entity\User;
+use App\Marketplace\Entity\MarketplaceFinancialReportSyncStatus;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+final class WbFinanceSyncStatusControllerTest extends WebTestCaseBase
+{
+    public function testReturnsFailedDayWithErrorMessage(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        [$user, $company] = $this->seedBaseData();
+        $this->loginWithActiveCompany($client, $user, $company);
+
+        $businessDate = (new \DateTimeImmutable('today'))->modify('-2 days');
+        $this->seedAuthFailedStatus((string) $company->getId(), $businessDate);
+
+        $client->request('GET', '/api/marketplace/wb-finance/sync-statuses');
+
+        self::assertResponseIsSuccessful();
+        $payload = json_decode((string) $client->getResponse()->getContent(), true);
+
+        self::assertSame(1, $payload['total']);
+        $item = $payload['items'][0];
+        self::assertSame($businessDate->format('Y-m-d'), $item['business_date']);
+        self::assertSame('auth_failed', $item['status']);
+        self::assertSame('Ошибка авторизации', $item['status_label']);
+        self::assertSame('Invalid API token', $item['error_message']);
+        self::assertSame(401, $item['http_status']);
+    }
+
+    public function testRejectsLimitOverMaximumWith422(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        [$user, $company] = $this->seedBaseData();
+        $this->loginWithActiveCompany($client, $user, $company);
+
+        $client->request('GET', '/api/marketplace/wb-finance/sync-statuses?limit=500');
+
+        self::assertResponseStatusCodeSame(422);
+        $payload = json_decode((string) $client->getResponse()->getContent(), true);
+        self::assertSame('invalid_pagination_limit', $payload['error']['code']);
+    }
+
+    public function testDoesNotLeakStatusesOfOtherCompany(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        [$user, $company] = $this->seedBaseData();
+        $this->loginWithActiveCompany($client, $user, $company);
+
+        $otherUser = UserBuilder::aUser()
+            ->withId('33333333-3333-4333-8333-333333333333')
+            ->withEmail('other-wb-sync@test.local')
+            ->build();
+        $otherCompany = CompanyBuilder::aCompany()
+            ->withId('44444444-4444-4444-4444-444444444444')
+            ->withOwner($otherUser)
+            ->build();
+        $em = $this->em();
+        $em->persist($otherUser);
+        $em->persist($otherCompany);
+        $em->flush();
+
+        $this->seedAuthFailedStatus((string) $otherCompany->getId(), (new \DateTimeImmutable('today'))->modify('-1 day'));
+
+        $client->request('GET', '/api/marketplace/wb-finance/sync-statuses');
+
+        self::assertResponseIsSuccessful();
+        $payload = json_decode((string) $client->getResponse()->getContent(), true);
+        self::assertSame(0, $payload['total']);
+        self::assertSame([], $payload['items']);
+    }
+
+    public function testDoesNotLeakOtherMarketplaceOrReportTypeStatuses(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        [$user, $company] = $this->seedBaseData();
+        $this->loginWithActiveCompany($client, $user, $company);
+
+        $businessDate = (new \DateTimeImmutable('today'))->modify('-1 day');
+        $this->seedAuthFailedStatus((string) $company->getId(), $businessDate);
+        $this->seedStatus((string) $company->getId(), $businessDate, MarketplaceType::OZON, 'sales_report');
+        $this->seedStatus((string) $company->getId(), $businessDate, MarketplaceType::WILDBERRIES, 'ads_report');
+
+        $client->request('GET', '/api/marketplace/wb-finance/sync-statuses');
+
+        self::assertResponseIsSuccessful();
+        $payload = json_decode((string) $client->getResponse()->getContent(), true);
+
+        self::assertSame(1, $payload['total']);
+        self::assertSame('wildberries', $payload['items'][0]['marketplace']);
+        self::assertSame('sales_report', $payload['items'][0]['report_type']);
+    }
+
+    private function seedAuthFailedStatus(string $companyId, \DateTimeImmutable $businessDate): void
+    {
+        $status = $this->seedStatus($companyId, $businessDate, MarketplaceType::WILDBERRIES, 'sales_report');
+        $status->markAuthFailed('App\Marketplace\Exception\MarketplaceAuthException', 'Invalid API token', 401, null);
+
+        $this->em()->flush();
+    }
+
+    private function seedStatus(
+        string $companyId,
+        \DateTimeImmutable $businessDate,
+        MarketplaceType $marketplace,
+        string $reportType,
+    ): MarketplaceFinancialReportSyncStatus
+    {
+        $status = new MarketplaceFinancialReportSyncStatus(
+            Uuid::uuid7()->toString(),
+            $companyId,
+            Uuid::uuid7()->toString(),
+            $marketplace,
+            $reportType,
+            sprintf('%s::%s', $marketplace->value, $reportType),
+            $businessDate,
+        );
+
+        $em = $this->em();
+        $em->persist($status);
+        $em->flush();
+
+        return $status;
+    }
+
+    private function loginWithActiveCompany(KernelBrowser $client, User $user, Company $company): void
+    {
+        // active_company_id в сессии не нужен: ActiveCompanyService сам
+        // выбирает первую компанию пользователя при пустой сессии.
+        $client->loginUser($user);
+    }
+
+    /**
+     * @return array{0: User, 1: Company}
+     */
+    private function seedBaseData(): array
+    {
+        $user = UserBuilder::aUser()->withEmail('wb-sync-status@test.local')->build();
+        $company = CompanyBuilder::aCompany()->withOwner($user)->build();
+
+        $em = $this->em();
+        $em->persist($user);
+        $em->persist($company);
+        $em->flush();
+
+        return [$user, $company];
+    }
+}

--- a/site/tests/Integration/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
+++ b/site/tests/Integration/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
@@ -16,6 +16,7 @@ use App\Marketplace\Infrastructure\Query\ActiveWbConnectionsQuery;
 use App\Marketplace\Message\SyncWbFinancialReportDayMessage;
 use App\Marketplace\Repository\MarketplaceFinancialReportSyncStatusRepository;
 use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
 use App\Tests\Support\Kernel\IntegrationTestCase;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\Clock\MockClock;
@@ -308,8 +309,13 @@ final class WbFinancialReportSyncPlannerTest extends IntegrationTestCase
 
         $existing = $this->em->find(Company::class, $cid);
         if (!$existing instanceof Company) {
-            $company = CompanyBuilder::aCompany()->withId($cid)->build();
-            $this->em->persist($company->getOwner());
+            $ownerId = Uuid::uuid7()->toString();
+            $owner = UserBuilder::aUser()
+                ->withId($ownerId)
+                ->withEmail(sprintf('owner+%s@example.test', $ownerId))
+                ->build();
+            $company = CompanyBuilder::aCompany()->withId($cid)->withOwner($owner)->build();
+            $this->em->persist($owner);
             $this->em->persist($company);
             $this->em->flush();
         }

--- a/site/tests/Integration/Marketplace/MessageHandler/SyncWbFinancialReportDayHandlerTest.php
+++ b/site/tests/Integration/Marketplace/MessageHandler/SyncWbFinancialReportDayHandlerTest.php
@@ -41,9 +41,9 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
 
     public function testEmptyResponseMarksEmptyWithoutRawDocumentAndWithoutDispatch(): void
     {
+        $bus = $this->swapBusSpy();
         $company = $this->createCompany(9201);
         $connection = $this->createWbSellerConnection($company, 9201);
-        $bus = $this->swapBusSpy();
         $this->swapWbClient([new MockResponse('', ['http_code' => 204])]);
 
         $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
@@ -58,9 +58,9 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
 
     public function testRowsResponseCreatesRawDocumentMarksProcessingAndDispatches(): void
     {
+        $bus = $this->swapBusSpy();
         $company = $this->createCompany(9202);
         $connection = $this->createWbSellerConnection($company, 9202);
-        $bus = $this->swapBusSpy();
         $this->swapWbClient([new MockResponse('[{"rrdId":11},{"rrdId":12}]', ['http_code' => 200])]);
 
         $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
@@ -101,13 +101,37 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
         }
     }
 
+    public function testTrulyUnexpectedExceptionMarksFailedRetryableAndRethrows(): void
+    {
+        $company = $this->createCompany(9305);
+        $connection = $this->createWbSellerConnection($company, 9305);
+        $http = new MockHttpClient(static function (): MockResponse {
+            throw new \RuntimeException('boom: unexpected infrastructure error');
+        });
+        self::getContainer()->set(WbFinanceSalesReportClient::class, new WbFinanceSalesReportClient($http, $this->createRateLimiter()));
+
+        $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
+        $this->expectException(\RuntimeException::class);
+
+        try {
+            $handler($this->message($company->getId(), $connection->getId(), false));
+        } finally {
+            $status = $this->findStatus($connection->getId(), $company->getId(), '2026-05-19');
+            self::assertNotNull($status);
+            self::assertSame(FinancialReportSyncStatus::FAILED, $status->getStatus());
+            self::assertNotNull($status->getNextRetryAt(), 'Статус должен остаться видимым для retry-планировщика.');
+            self::assertSame(\RuntimeException::class, $status->getLastErrorClass());
+            self::assertSame('boom: unexpected infrastructure error', $status->getLastErrorMessage());
+        }
+    }
+
     public function testRemote429SetsSharedCooldownAndNextDaySkipsHttp(): void
     {
+        $bus = $this->swapBusSpy();
         $company = $this->createCompany(9291);
         $connection = $this->createWbSellerConnection($company, 9291);
         $connection->setSettings(['seller_id' => 'seller-9291']);
         $this->em->flush();
-        $bus = $this->swapBusSpy();
         $storage = new InMemoryWbFinanceCooldownStorage();
         $requestCount = 0;
         $http = new MockHttpClient(static function () use (&$requestCount): MockResponse {
@@ -136,11 +160,11 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
 
     public function testConnectionFallbackBucketsAllowTwoUnknownSellerConnectionsToCallApiBackToBack(): void
     {
+        $this->swapBusSpy();
         $companyA = $this->createCompany(9292);
         $companyB = $this->createCompany(9293);
         $connectionA = $this->createWbSellerConnection($companyA, 9292);
         $connectionB = $this->createWbSellerConnection($companyB, 9293);
-        $this->swapBusSpy();
         $requestCount = 0;
         $http = new MockHttpClient(static function () use (&$requestCount): MockResponse {
             ++$requestCount;
@@ -156,7 +180,7 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
         self::assertSame(2, $requestCount);
         $secondStatus = $this->findStatus($connectionB->getId(), $companyB->getId(), '2026-05-19');
         self::assertNotNull($secondStatus);
-        self::assertSame(FinancialReportSyncStatus::SUCCESS, $secondStatus->getStatus());
+        self::assertSame(FinancialReportSyncStatus::EMPTY, $secondStatus->getStatus());
     }
 
     public function testCooldownExpiresAndAllowsApiRequestAgain(): void
@@ -202,9 +226,9 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
 
     public function testForceRefreshIsPropagatedToProcessDayReportMessage(): void
     {
+        $bus = $this->swapBusSpy();
         $company = $this->createCompany(9205);
         $connection = $this->createWbSellerConnection($company, 9205);
-        $bus = $this->swapBusSpy();
         $this->swapWbClient([new MockResponse('[{"rrdId":2}]', ['http_code' => 200])]);
 
         $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
@@ -217,10 +241,10 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
 
     public function testExistingCompletedRawWithForceFalseUsesCanonicalRawDocument(): void
     {
+        $bus = $this->swapBusSpy();
         $company = $this->createCompany(9206);
         $connection = $this->createWbSellerConnection($company, 9206);
         $existing = $this->createRaw($company, new \DateTimeImmutable('2026-05-19'), [['rrdId' => 100]], 1, PipelineStatus::COMPLETED);
-        $bus = $this->swapBusSpy();
         $this->swapWbClient([new MockResponse('[{"rrdId":200}]', ['http_code' => 200])]);
 
         $handler = self::getContainer()->get(SyncWbFinancialReportDayHandler::class);
@@ -403,9 +427,9 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
 
     public function testDuplicateContinuationAfterFinalPageIsSkippedWithoutCallingWbApi(): void
     {
+        $bus = $this->swapBusSpy();
         $company = $this->createCompany(9216);
         $connection = $this->createWbSellerConnection($company, 9216);
-        $bus = $this->swapBusSpy();
         $firstPageRows = $this->pageRows(1, WbFinanceSalesReportClient::PAGE_SIZE);
         $this->swapWbClient([new MockResponse(json_encode($firstPageRows, JSON_THROW_ON_ERROR), ['http_code' => 200])]);
 
@@ -414,18 +438,16 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
         $continuation = $this->filterSyncMessages($bus->messages)[0] ?? null;
         self::assertInstanceOf(SyncWbFinancialReportDayMessage::class, $continuation);
 
+        $this->makeStatusRetryDue($company->getId(), '2026-05-19');
         $this->swapWbClient([new MockResponse('[{"rrdId":100001}]', ['http_code' => 200])]);
         $handler($continuation);
 
         $requestCount = 0;
-        self::getContainer()->set(WbFinanceSalesReportClient::class, new WbFinanceSalesReportClient(
-            new MockHttpClient(static function () use (&$requestCount): MockResponse {
-                ++$requestCount;
+        $this->swapWbClient(static function () use (&$requestCount): MockResponse {
+            ++$requestCount;
 
-                return new MockResponse('[]', ['http_code' => 200]);
-            }),
-            $this->createRateLimiter(),
-        ));
+            return new MockResponse('[]', ['http_code' => 200]);
+        });
         $handler($continuation);
 
         self::assertSame(0, $requestCount);
@@ -433,9 +455,9 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
 
     public function testTerminalFailureAfterPartialPageMarksStagingRawDocumentFailed(): void
     {
+        $bus = $this->swapBusSpy();
         $company = $this->createCompany(9217);
         $connection = $this->createWbSellerConnection($company, 9217);
-        $bus = $this->swapBusSpy();
         $firstPageRows = $this->pageRows(1, WbFinanceSalesReportClient::PAGE_SIZE);
         $this->swapWbClient([new MockResponse(json_encode($firstPageRows, JSON_THROW_ON_ERROR), ['http_code' => 200])]);
 
@@ -446,6 +468,7 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
         $rawDocumentId = $continuation->rawDocumentId;
         self::assertNotNull($rawDocumentId);
 
+        $this->makeStatusRetryDue($company->getId(), '2026-05-19');
         $this->swapWbClient([new MockResponse('{"error":"bad request"}', ['http_code' => 400])]);
         $this->expectException(UnrecoverableMessageHandlingException::class);
 
@@ -466,9 +489,9 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
 
     public function testHandlerRespectsPersistedFutureNextRetryAtWithoutCallingWbApi(): void
     {
+        $bus = $this->swapBusSpy();
         $company = $this->createCompany(9218);
         $connection = $this->createWbSellerConnection($company, 9218);
-        $bus = $this->swapBusSpy();
         $status = new MarketplaceFinancialReportSyncStatus(
             'cccccccc-cccc-4ccc-8ccc-000000009218',
             $company->getId(),
@@ -541,10 +564,76 @@ final class SyncWbFinancialReportDayHandlerTest extends IntegrationTestCase
         return $raw;
     }
 
-    /** @param list<MockResponse> $responses */
-    private function swapWbClient(array $responses): void
+    /** @var list<MockResponse> */
+    private array $wbMockResponses = [];
+
+    private ?\Closure $wbMockResponseFactory = null;
+
+    private bool $wbClientSwapped = false;
+
+    /**
+     * Подменяет WB-клиент один раз за тест; повторные вызовы лишь заменяют очередь
+     * mock-ответов — TestContainer не позволяет заменить уже инициализированный сервис.
+     *
+     * @param list<MockResponse>|\Closure $responses
+     */
+    private function swapWbClient(array|\Closure $responses): void
     {
-        self::getContainer()->set(WbFinanceSalesReportClient::class, new WbFinanceSalesReportClient(new MockHttpClient($responses), $this->createRateLimiter()));
+        if ($responses instanceof \Closure) {
+            $this->wbMockResponseFactory = $responses;
+            $this->wbMockResponses = [];
+        } else {
+            $this->wbMockResponseFactory = null;
+            $this->wbMockResponses = $responses;
+        }
+
+        if ($this->wbClientSwapped) {
+            return;
+        }
+
+        $http = new MockHttpClient(function (): MockResponse {
+            if (null !== $this->wbMockResponseFactory) {
+                return ($this->wbMockResponseFactory)();
+            }
+
+            $response = array_shift($this->wbMockResponses);
+            if (!$response instanceof MockResponse) {
+                throw new \LogicException('No queued WB mock response left.');
+            }
+
+            return $response;
+        });
+
+        // Щедрый лимит: до редизайна каждый swap создавал свежий limiter с полным
+        // бюджетом; теперь клиент один на тест, и локальный троттлинг не должен
+        // мешать сценариям с несколькими вызовами handler'а. Поведение троттлинга
+        // проверяют отдельные тесты со своими клиентами.
+        $limiter = new WbFinanceRateLimiter(
+            new RateLimiterFactory(['id' => 'wb_finance', 'policy' => 'token_bucket', 'limit' => 1000, 'rate' => ['interval' => '61 seconds', 'amount' => 1000]], new InMemoryStorage()),
+            new MockClock('2026-01-01T00:00:00Z'),
+            null,
+            null,
+        );
+        self::getContainer()->set(WbFinanceSalesReportClient::class, new WbFinanceSalesReportClient($http, $limiter));
+        $this->wbClientSwapped = true;
+    }
+
+    /**
+     * Continuation в проде приходит после задержки (financeRetryDelaySeconds = 70 с),
+     * поэтому next_retry_at сдвигается в прошлое — иначе handler уйдёт в постпон-ветку
+     * и не дойдёт до API-запроса.
+     */
+    private function makeStatusRetryDue(string $companyId, string $day): void
+    {
+        $this->em->getConnection()->executeStatement(
+            'UPDATE marketplace_financial_report_sync_statuses SET next_retry_at = :ts WHERE company_id = :companyId AND business_date = :day',
+            [
+                'ts' => (new \DateTimeImmutable('-5 minutes'))->format('Y-m-d H:i:s'),
+                'companyId' => $companyId,
+                'day' => $day,
+            ],
+        );
+        $this->em->clear();
     }
 
     private function swapBusSpy(): object

--- a/site/tests/Integration/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepositoryTest.php
+++ b/site/tests/Integration/Marketplace/Repository/MarketplaceFinancialReportSyncStatusRepositoryTest.php
@@ -11,6 +11,7 @@ use App\Marketplace\Enum\FinancialReportSyncStatus;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Repository\MarketplaceFinancialReportSyncStatusRepository;
 use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
 use App\Tests\Support\Kernel\IntegrationTestCase;
 use Ramsey\Uuid\Uuid;
 
@@ -34,7 +35,7 @@ final class MarketplaceFinancialReportSyncStatusRepositoryTest extends Integrati
 
         $now = new \DateTimeImmutable('2026-01-05 12:00:00');
 
-        $this->persistStatus($companyId, $connectionId, '2026-01-01', FinancialReportSyncStatus::FAILED, null);
+        $this->persistStatus($companyId, $connectionId, '2026-01-01', FinancialReportSyncStatus::FAILED, new \DateTimeImmutable('2026-01-05 10:00:00'));
         $this->persistStatus($companyId, $connectionId, '2026-01-02', FinancialReportSyncStatus::FAILED, new \DateTimeImmutable('2026-01-05 11:00:00'));
         $this->persistStatus($companyId, $connectionId, '2026-01-03', FinancialReportSyncStatus::FAILED, new \DateTimeImmutable('2026-01-05 13:00:00'));
         $this->persistStatus($companyId, $connectionId, '2026-01-04', FinancialReportSyncStatus::SUCCESS);
@@ -63,6 +64,84 @@ final class MarketplaceFinancialReportSyncStatusRepositoryTest extends Integrati
         self::assertSame([FinancialReportSyncMode::MISSING, FinancialReportSyncMode::MISSING], array_map(static fn (array $item): FinancialReportSyncMode => $item['mode'], $days));
     }
 
+
+    public function testFindRetryDueDaysReturnsStuckQueuedAndLoadingOlderThanReclaimInterval(): void
+    {
+        $companyId = '11111111-1111-1111-1111-111111111111';
+        $connectionId = '22222222-2222-4222-8222-222222222222';
+        $this->seedActiveConnection($companyId, $connectionId);
+
+        $this->persistStatus($companyId, $connectionId, '2026-01-01', FinancialReportSyncStatus::QUEUED);
+        $this->persistStatus($companyId, $connectionId, '2026-01-02', FinancialReportSyncStatus::QUEUED);
+        $this->persistStatus($companyId, $connectionId, '2026-01-03', FinancialReportSyncStatus::LOADING);
+        $this->persistStatus($companyId, $connectionId, '2026-01-04', FinancialReportSyncStatus::LOADING);
+
+        $this->backdateStatusUpdatedAt($companyId, '2026-01-01');
+        $this->backdateStatusUpdatedAt($companyId, '2026-01-03');
+        $this->em->clear();
+
+        $days = $this->repository->findRetryDueDays(
+            $companyId,
+            $connectionId,
+            MarketplaceType::WILDBERRIES,
+            self::REPORT_TYPE,
+            new \DateTimeImmutable('2026-01-01 00:00:00'),
+            new \DateTimeImmutable('2026-01-10 00:00:00'),
+            new \DateTimeImmutable(),
+            10,
+        );
+
+        self::assertSame(
+            ['2026-01-01', '2026-01-03'],
+            array_map(static fn (array $item): string => $item['business_date']->format('Y-m-d'), $days),
+        );
+        self::assertSame(
+            [FinancialReportSyncMode::MISSING, FinancialReportSyncMode::DAILY],
+            array_map(static fn (array $item): FinancialReportSyncMode => $item['mode'], $days),
+        );
+    }
+
+    public function testClaimForQueueReclaimsOnlyStuckQueuedAndLoading(): void
+    {
+        $companyId = '11111111-1111-1111-1111-111111111111';
+        $connectionId = '22222222-2222-4222-8222-222222222222';
+        $this->seedActiveConnection($companyId, $connectionId);
+
+        $this->persistStatus($companyId, $connectionId, '2026-01-01', FinancialReportSyncStatus::QUEUED);
+        $this->persistStatus($companyId, $connectionId, '2026-01-02', FinancialReportSyncStatus::QUEUED);
+        $this->persistStatus($companyId, $connectionId, '2026-01-03', FinancialReportSyncStatus::LOADING);
+        $this->persistStatus($companyId, $connectionId, '2026-01-04', FinancialReportSyncStatus::LOADING);
+
+        $this->backdateStatusUpdatedAt($companyId, '2026-01-01');
+        $this->backdateStatusUpdatedAt($companyId, '2026-01-03');
+        $this->em->clear();
+
+        $now = new \DateTimeImmutable();
+        $claim = fn (string $day) => $this->repository->claimForQueue(
+            $connectionId,
+            $companyId,
+            MarketplaceType::WILDBERRIES,
+            self::REPORT_TYPE,
+            'endpoint',
+            new \DateTimeImmutable($day),
+            FinancialReportSyncMode::MISSING,
+            false,
+            $now,
+        );
+
+        $stuckQueued = $claim('2026-01-01 00:00:00');
+        self::assertInstanceOf(MarketplaceFinancialReportSyncStatus::class, $stuckQueued);
+        self::assertSame(FinancialReportSyncStatus::QUEUED, $stuckQueued->getStatus());
+        self::assertSame(FinancialReportSyncMode::MISSING, $stuckQueued->getMode());
+
+        self::assertNull($claim('2026-01-02 00:00:00'), 'Свежий QUEUED без next_retry_at ждёт своё сообщение и не переоткрывается.');
+
+        $stuckLoading = $claim('2026-01-03 00:00:00');
+        self::assertInstanceOf(MarketplaceFinancialReportSyncStatus::class, $stuckLoading);
+        self::assertSame(FinancialReportSyncStatus::QUEUED, $stuckLoading->getStatus());
+
+        self::assertNull($claim('2026-01-04 00:00:00'), 'Свежий LOADING — handler ещё работает, переоткрывать нельзя.');
+    }
 
     public function testFindStatusesForDateRangeFiltersByScopeRangeAndSortsAsc(): void
     {
@@ -373,8 +452,27 @@ final class MarketplaceFinancialReportSyncStatusRepositoryTest extends Integrati
     }
 
 
+    private function backdateStatusUpdatedAt(string $companyId, string $day, string $modify = '-3 hours'): void
+    {
+        $this->em->getConnection()->executeStatement(
+            'UPDATE marketplace_financial_report_sync_statuses SET updated_at = :ts WHERE company_id = :companyId AND business_date = :day',
+            [
+                'ts' => (new \DateTimeImmutable($modify))->format('Y-m-d H:i:s'),
+                'companyId' => $companyId,
+                'day' => $day,
+            ],
+        );
+    }
+
     private function seedConnectionForExistingCompany(string $companyId, string $connectionId): void
     {
+        // uniq_company_marketplace_type допускает один WB seller-кабинет на компанию:
+        // тесты «нового подключения» моделируют замену кабинета, поэтому старую строку убираем.
+        $this->em->getConnection()->executeStatement(
+            "DELETE FROM marketplace_connections WHERE company_id = :companyId AND marketplace = 'wildberries' AND connection_type = 'seller'",
+            ['companyId' => $companyId],
+        );
+
         $this->em->getConnection()->insert('marketplace_connections', [
             'id' => $connectionId,
             'company_id' => $companyId,
@@ -391,8 +489,13 @@ final class MarketplaceFinancialReportSyncStatusRepositoryTest extends Integrati
     {
         $existing = $this->em->find(Company::class, $companyId);
         if (!$existing instanceof Company) {
-            $company = CompanyBuilder::aCompany()->withId($companyId)->build();
-            $this->em->persist($company->getOwner());
+            $ownerId = Uuid::uuid7()->toString();
+            $owner = UserBuilder::aUser()
+                ->withId($ownerId)
+                ->withEmail(sprintf('owner+%s@example.test', $ownerId))
+                ->build();
+            $company = CompanyBuilder::aCompany()->withId($companyId)->withOwner($owner)->build();
+            $this->em->persist($owner);
             $this->em->persist($company);
             $this->em->flush();
         }

--- a/site/tests/Support/Db/DbReset.php
+++ b/site/tests/Support/Db/DbReset.php
@@ -22,7 +22,12 @@ final class DbReset
             return;
         }
 
-        $quotedTables = array_map([$connection, 'quoteIdentifier'], $tableNames);
+        // listTableNames() возвращает зарезервированные имена уже в кавычках ("user") —
+        // снимаем их перед повторным квотированием, иначе получится ""user"".
+        $quotedTables = array_map(
+            static fn (string $t): string => $connection->quoteIdentifier(trim($t, '"')),
+            $tableNames,
+        );
         $tableList = implode(', ', $quotedTables);
 
         $connection->executeStatement("SET session_replication_role = 'replica'");

--- a/site/tests/Support/Kernel/IntegrationTestCase.php
+++ b/site/tests/Support/Kernel/IntegrationTestCase.php
@@ -46,7 +46,9 @@ abstract class IntegrationTestCase extends KernelTestCase
             if (!is_string($tableName) || '' === $tableName) {
                 continue;
             }
-            $tables[] = $tableName;
+            // В маппинге зарезервированные имена обёрнуты в backticks (`user`) —
+            // снимаем их, иначе имя не совпадёт со списком таблиц БД и таблица не очистится.
+            $tables[] = trim($tableName, '`');
         }
 
         $tables = array_values(array_unique($tables));
@@ -54,7 +56,12 @@ abstract class IntegrationTestCase extends KernelTestCase
             return;
         }
 
-        $existingTables = array_map('strtolower', $schemaManager->listTableNames());
+        // listTableNames() возвращает зарезервированные имена в кавычках ("user") —
+        // нормализуем, иначе такие таблицы не пройдут фильтр и не будут очищены.
+        $existingTables = array_map(
+            static fn (string $t): string => strtolower(trim($t, '"')),
+            $schemaManager->listTableNames(),
+        );
         $existingLookup = array_fill_keys($existingTables, true);
 
         $tables = array_values(array_filter(

--- a/site/tests/Unit/Marketplace/Controller/MarketplaceControllerCreateConnectionTest.php
+++ b/site/tests/Unit/Marketplace/Controller/MarketplaceControllerCreateConnectionTest.php
@@ -14,6 +14,7 @@ use App\Marketplace\Enum\MarketplaceConnectionType;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Infrastructure\Query\OzonRealizationStatusQuery;
 use App\Marketplace\Infrastructure\Query\RawDocumentsListQuery;
+use App\Marketplace\Infrastructure\Query\WbFinanceSyncStatusListQuery;
 use App\Marketplace\Message\TriggerInitialSyncMessage;
 use App\Marketplace\Repository\MarketplaceConnectionRepository;
 use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
@@ -202,6 +203,7 @@ final class MarketplaceControllerCreateConnectionTest extends TestCase
             self::uninitialized(SyncConnectionAction::class),
             $startDateResolver,
             $planner,
+            self::uninitialized(WbFinanceSyncStatusListQuery::class),
         ) extends MarketplaceController {
             protected function addFlash(string $type, mixed $message): void
             {


### PR DESCRIPTION
## What changed

- Added/updated WB financial report sync recovery/status handling on the existing WB sync branch.
- Added an API endpoint for WB finance sync status history with pagination and day-window validation.
- Added a DBAL query for `marketplace_financial_report_sync_statuses` scoped to active company, `wildberries`, and `sales_report`.
- Added functional coverage for failed status rendering, pagination validation, company isolation, and marketplace/report-type isolation.
- Fixed `MarketplaceControllerCreateConnectionTest` to pass the new `WbFinanceSyncStatusListQuery` constructor dependency.

## Reviewer fix

- Addressed the P2 review comment: the WB status list now filters by `marketplace = 'wildberries'` and `report_type = 'sales_report'`, so unrelated marketplace/report rows are not shown in the WB finance API/UI.

## Validation

- Passed: `docker compose run --rm site-php-cli php bin/phpunit tests/Functional/Marketplace/Controller/WbFinanceSyncStatusControllerTest.php` — 4 tests, 16 assertions.
- Passed: `docker compose run --rm site-php-cli php bin/phpunit tests/Unit/Marketplace/Controller/MarketplaceControllerCreateConnectionTest.php` — 3 tests, 32 assertions.
- Passed: `docker compose run --rm site-php-cli composer test:unit` — 927 tests, 5548 assertions, 1 warning.

## Notes

- DAMA/test-isolation changes were moved out of this PR into separate PR #1977.