### PR TITLE
[codex] Add transactional test isolation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,14 +48,14 @@ site-test-telegram:
 site-test-unit:
 	docker-compose run --rm site-php-cli composer test:unit
 
-# Интеграционные (готовим среду + БД)
+# Интеграционные (только запуск; подготовка БД отдельно через site-test-prepare)
 site-test-int: site-test-integration
 
-site-test-integration: site-test-init
+site-test-integration: site-test-wait-db
 	docker-compose run --rm site-php-cli composer test:integration
 
 # Все тесты
-site-test: site-test-init
+site-test: site-test-prepare
 	docker-compose run --rm site-php-cli composer test
 
 # ---- подготовка окружения тестов (smoke) ----
@@ -65,11 +65,13 @@ site-test-smoke: site-test-smoke-init
 	docker-compose run --rm -T site-php-cli php bin/phpunit -c phpunit.xml --testsuite=integration --filter SmokePersistenceTest
 
 # Покрытие (нужен xdebug или pcov в CLI-образе)
-site-test-cov: site-test-init
+site-test-cov: site-test-prepare
 	docker-compose run --rm -e XDEBUG_MODE=coverage site-php-cli ./vendor/bin/phpunit -c phpunit.xml --coverage-html var/coverage --coverage-text
 
 # ---- подготовка окружения тестов ----
-site-test-init: site-composer-install site-test-env site-test-wait-db site-test-db site-test-migrations site-test-fixtures
+site-test-init: site-test-prepare
+
+site-test-prepare: site-composer-install site-test-env site-test-wait-db site-test-db site-test-migrations
 
 site-test-env:
 	# .env.test (если нет — скопируем из .env)

--- a/README.md
+++ b/README.md
@@ -11,5 +11,13 @@
 
 * Повысить пользователя до супер-админа: `docker compose exec -T site-php-cli php /app/bin/console security:promote user@example.com --super-admin`
 
+## Тесты
+
+* Подготовка test-БД: `make site-test-prepare`
+* Обычный интеграционный прогон: `make site-test-integration`
+* Полная пересборка test-БД с фикстурами: `make site-test-db-rebuild`
+
+`site-test-integration` не пересоздаёт БД и не загружает application fixtures при каждом запуске. Обычные integration/functional тесты изолируются транзакцией через DAMA Doctrine Test Bundle; PostgreSQL-specific сценарии с реальными commit/lock/schema checks должны наследоваться от `PostgresResetTestCase`.
+
 ## Документация
 - Точка входа: `docs/README.md`

--- a/site/composer.json
+++ b/site/composer.json
@@ -125,6 +125,7 @@
         }
     },
     "require-dev": {
+        "dama/doctrine-test-bundle": "^8.6",
         "dg/bypass-finals": ">=1.9",
         "doctrine/doctrine-fixtures-bundle": "^4.3.1",
         "friendsofphp/php-cs-fixer": "^3.95.1",

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e3dcb494e9e3c335d0a985bb6f8a1c5",
+    "content-hash": "312fe708fc7205e17c6ade536b9e219f",
     "packages": [
         {
             "name": "babdev/pagerfanta-bundle",
@@ -10318,6 +10318,75 @@
                 }
             ],
             "time": "2024-05-06T16:37:16+00:00"
+        },
+        {
+            "name": "dama/doctrine-test-bundle",
+            "version": "v8.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dmaicher/doctrine-test-bundle.git",
+                "reference": "f7e3487643e685432f7e27c50cac64e9f8c515a4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dmaicher/doctrine-test-bundle/zipball/f7e3487643e685432f7e27c50cac64e9f8c515a4",
+                "reference": "f7e3487643e685432f7e27c50cac64e9f8c515a4",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": "^3.3 || ^4.0",
+                "doctrine/doctrine-bundle": "^2.11.0 || ^3.0",
+                "php": ">= 8.2",
+                "psr/cache": "^2.0 || ^3.0",
+                "symfony/cache": "^6.4 || ^7.3 || ^8.0",
+                "symfony/framework-bundle": "^6.4 || ^7.3 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<11.0"
+            },
+            "require-dev": {
+                "behat/behat": "^3.0",
+                "friendsofphp/php-cs-fixer": "^3.27",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^11.5.41|| ^12.3.14",
+                "symfony/dotenv": "^6.4 || ^7.3 || ^8.0",
+                "symfony/process": "^6.4 || ^7.3 || ^8.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DAMA\\DoctrineTestBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David Maicher",
+                    "email": "mail@dmaicher.de"
+                }
+            ],
+            "description": "Symfony bundle to isolate doctrine database tests and improve test performance",
+            "keywords": [
+                "doctrine",
+                "isolation",
+                "performance",
+                "symfony",
+                "testing",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dmaicher/doctrine-test-bundle/issues",
+                "source": "https://github.com/dmaicher/doctrine-test-bundle/tree/v8.6.0"
+            },
+            "time": "2026-01-21T07:39:44+00:00"
         },
         {
             "name": "dg/bypass-finals",

--- a/site/config/bundles.php
+++ b/site/config/bundles.php
@@ -18,4 +18,5 @@ return [
     Sentry\SentryBundle\SentryBundle::class => ['all' => true],
     Pentatrion\ViteBundle\PentatrionViteBundle::class => ['all' => true],
     Nelmio\ApiDocBundle\NelmioApiDocBundle::class => ['all' => true],
+    DAMA\DoctrineTestBundle\DAMADoctrineTestBundle::class => ['test' => true],
 ];

--- a/site/config/packages/dama_doctrine_test_bundle.yaml
+++ b/site/config/packages/dama_doctrine_test_bundle.yaml
@@ -1,0 +1,5 @@
+when@test:
+    dama_doctrine_test:
+        enable_static_connection: true
+        enable_static_meta_data_cache: true
+        enable_static_query_cache: true

--- a/site/phpunit.xml
+++ b/site/phpunit.xml
@@ -47,4 +47,8 @@
             <directory>src</directory>
         </include>
     </source>
+
+    <extensions>
+        <bootstrap class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension"/>
+    </extensions>
 </phpunit>

--- a/site/symfony.lock
+++ b/site/symfony.lock
@@ -2,6 +2,18 @@
     "babdev/pagerfanta-bundle": {
         "version": "v4.5.0"
     },
+    "dama/doctrine-test-bundle": {
+        "version": "8.6",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "8.3",
+            "ref": "dfc51177476fb39d014ed89944cde53dc3326d23"
+        },
+        "files": [
+            "config/packages/dama_doctrine_test_bundle.yaml"
+        ]
+    },
     "doctrine/deprecations": {
         "version": "1.1",
         "recipe": {

--- a/site/tests/Integration/Catalog/ProductPurchasePricePersistenceTest.php
+++ b/site/tests/Integration/Catalog/ProductPurchasePricePersistenceTest.php
@@ -16,7 +16,7 @@ final class ProductPurchasePricePersistenceTest extends IntegrationTestCase
     {
         $this->resetDb();
 
-        $em = $this->em();
+        $em = $this->em;
         $owner = UserBuilder::aUser()->withEmail('owner-product-purchase-price@example.test')->build();
         $company = CompanyBuilder::aCompany()
             ->withId('11111111-1111-1111-1111-111111111190')
@@ -46,7 +46,7 @@ final class ProductPurchasePricePersistenceTest extends IntegrationTestCase
         $em->flush();
         $em->clear();
 
-        $loaded = $this->em()->getRepository(ProductPurchasePrice::class)->find('44444444-4444-4444-4444-444444444490');
+        $loaded = $this->em->getRepository(ProductPurchasePrice::class)->find('44444444-4444-4444-4444-444444444490');
 
         self::assertInstanceOf(ProductPurchasePrice::class, $loaded);
         self::assertSame('11111111-1111-1111-1111-111111111190', $loaded->getCompany()->getId());

--- a/site/tests/Integration/Catalog/SetPurchasePriceActionTest.php
+++ b/site/tests/Integration/Catalog/SetPurchasePriceActionTest.php
@@ -25,7 +25,7 @@ final class SetPurchasePriceActionTest extends IntegrationTestCase
         $command = $this->makeCommand($companyId, $productId, '2026-04-01', 10000, 'Первая цена');
         $priceId = $this->action()($command);
 
-        $loaded = $this->em()->getRepository(ProductPurchasePrice::class)->find($priceId);
+        $loaded = $this->em->getRepository(ProductPurchasePrice::class)->find($priceId);
         self::assertInstanceOf(ProductPurchasePrice::class, $loaded);
         self::assertSame('2026-04-01', $loaded->getEffectiveFrom()->format('Y-m-d'));
         self::assertNull($loaded->getEffectiveTo());
@@ -42,7 +42,7 @@ final class SetPurchasePriceActionTest extends IntegrationTestCase
         $this->action()($this->makeCommand($companyId, $productId, '2026-04-01', 10000, 'Начальная цена'));
         $this->action()($this->makeCommand($companyId, $productId, '2026-04-15', 12000, 'Новая цена'));
 
-        $prices = $this->em()->getRepository(ProductPurchasePrice::class)->findBy([], ['effectiveFrom' => 'ASC']);
+        $prices = $this->em->getRepository(ProductPurchasePrice::class)->findBy([], ['effectiveFrom' => 'ASC']);
         self::assertCount(2, $prices);
         self::assertSame('2026-04-14', $prices[0]->getEffectiveTo()?->format('Y-m-d'));
         self::assertNull($prices[1]->getEffectiveTo());
@@ -91,10 +91,10 @@ final class SetPurchasePriceActionTest extends IntegrationTestCase
             ->setSku('SKU-'.$productId)
             ->setPurchasePrice('100.00');
 
-        $this->em()->persist($owner);
-        $this->em()->persist($company);
-        $this->em()->persist($product);
-        $this->em()->flush();
+        $this->em->persist($owner);
+        $this->em->persist($company);
+        $this->em->persist($product);
+        $this->em->flush();
 
         return [$companyId, $productId];
     }

--- a/site/tests/Integration/Inventory/InventorySchemaTest.php
+++ b/site/tests/Integration/Inventory/InventorySchemaTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Tests\Integration\Inventory;
 
-use App\Tests\Support\Kernel\IntegrationTestCase;
+use App\Tests\Support\Kernel\PostgresResetTestCase;
 
-final class InventorySchemaTest extends IntegrationTestCase
+final class InventorySchemaTest extends PostgresResetTestCase
 {
     public function testInventoryTablesColumnsAndIndexesExistWithExpectedDefinitions(): void
     {

--- a/site/tests/Integration/MarketplaceAds/AdScheduledBatchRepositoryTest.php
+++ b/site/tests/Integration/MarketplaceAds/AdScheduledBatchRepositoryTest.php
@@ -14,10 +14,10 @@ use App\Tests\Builders\Company\CompanyBuilder;
 use App\Tests\Builders\Company\UserBuilder;
 use App\Tests\Builders\MarketplaceAds\AdLoadJobBuilder;
 use App\Tests\Builders\MarketplaceAds\AdScheduledBatchBuilder;
-use App\Tests\Support\Kernel\IntegrationTestCase;
+use App\Tests\Support\Kernel\PostgresResetTestCase;
 use Doctrine\DBAL\DriverManager;
 
-final class AdScheduledBatchRepositoryTest extends IntegrationTestCase
+final class AdScheduledBatchRepositoryTest extends PostgresResetTestCase
 {
     private const COMPANY_ID = '11111111-1111-1111-1111-000000000001';
     private const OWNER_ID = '22222222-2222-2222-2222-000000000001';

--- a/site/tests/Integration/MarketplaceAds/Command/AdBatchSchedulerCommandTest.php
+++ b/site/tests/Integration/MarketplaceAds/Command/AdBatchSchedulerCommandTest.php
@@ -17,7 +17,7 @@ use App\Tests\Builders\Company\CompanyBuilder;
 use App\Tests\Builders\Company\UserBuilder;
 use App\Tests\Builders\MarketplaceAds\AdLoadJobBuilder;
 use App\Tests\Builders\MarketplaceAds\AdScheduledBatchBuilder;
-use App\Tests\Support\Kernel\IntegrationTestCase;
+use App\Tests\Support\Kernel\PostgresResetTestCase;
 use Doctrine\DBAL\DriverManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -37,7 +37,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  *  - FOR UPDATE SKIP LOCKED → параллельный worker при заблокированном row
  *    видит null и не перехватывает тот же батч.
  */
-final class AdBatchSchedulerCommandTest extends IntegrationTestCase
+final class AdBatchSchedulerCommandTest extends PostgresResetTestCase
 {
     private const COMPANY_ID = '11111111-1111-1111-1111-000000000001';
     private const OWNER_ID = '22222222-2222-2222-2222-000000000001';

--- a/site/tests/Support/Kernel/IntegrationTestCase.php
+++ b/site/tests/Support/Kernel/IntegrationTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Support\Kernel;
 
+use App\Tests\Support\Db\DbReset;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
@@ -16,9 +17,6 @@ abstract class IntegrationTestCase extends KernelTestCase
         self::bootKernel();
 
         $this->em = self::getContainer()->get(EntityManagerInterface::class);
-
-        // Единая “чистка” перед каждым тестом: по реальным таблицам ORM (без хардкода).
-        $this->truncateAllMappedTables();
     }
 
     protected function tearDown(): void
@@ -32,54 +30,14 @@ abstract class IntegrationTestCase extends KernelTestCase
         self::ensureKernelShutdown();
     }
 
-    protected function truncateAllMappedTables(): void
+    protected function resetDb(): void
     {
-        $conn = $this->em->getConnection();
-        $platform = $conn->getDatabasePlatform();
-        $schemaManager = $conn->createSchemaManager();
-
-        $metadata = $this->em->getMetadataFactory()->getAllMetadata();
-
-        $tables = [];
-        foreach ($metadata as $m) {
-            $tableName = $m->getTableName();
-            if (!is_string($tableName) || '' === $tableName) {
-                continue;
-            }
-            // В маппинге зарезервированные имена обёрнуты в backticks (`user`) —
-            // снимаем их, иначе имя не совпадёт со списком таблиц БД и таблица не очистится.
-            $tables[] = trim($tableName, '`');
-        }
-
-        $tables = array_values(array_unique($tables));
-        if ([] === $tables) {
+        if (class_exists(\DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension::class)
+            && \DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension::$transactionStarted
+        ) {
             return;
         }
 
-        // listTableNames() возвращает зарезервированные имена в кавычках ("user") —
-        // нормализуем, иначе такие таблицы не пройдут фильтр и не будут очищены.
-        $existingTables = array_map(
-            static fn (string $t): string => strtolower(trim($t, '"')),
-            $schemaManager->listTableNames(),
-        );
-        $existingLookup = array_fill_keys($existingTables, true);
-
-        $tables = array_values(array_filter(
-            $tables,
-            static fn (string $table): bool => isset($existingLookup[strtolower($table)])
-        ));
-
-        if ([] === $tables) {
-            return;
-        }
-
-        // Postgres-friendly: временно отключаем триггеры/проверки FK.
-        $conn->executeStatement('SET session_replication_role = replica');
-
-        $quoted = array_map(static fn (string $t) => $platform->quoteIdentifier($t), $tables);
-        $sql = sprintf('TRUNCATE TABLE %s CASCADE', implode(', ', $quoted));
-        $conn->executeStatement($sql);
-
-        $conn->executeStatement('SET session_replication_role = origin');
+        (new DbReset())->reset($this->em);
     }
 }

--- a/site/tests/Support/Kernel/KernelTestCaseBase.php
+++ b/site/tests/Support/Kernel/KernelTestCaseBase.php
@@ -21,6 +21,12 @@ abstract class KernelTestCaseBase extends KernelTestCase
 
     protected function resetDb(): void
     {
+        if (class_exists(\DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension::class)
+            && \DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension::$transactionStarted
+        ) {
+            return;
+        }
+
         (new DbReset())->reset($this->em());
     }
 }

--- a/site/tests/Support/Kernel/PostgresResetTestCase.php
+++ b/site/tests/Support/Kernel/PostgresResetTestCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Support\Kernel;
+
+use App\Tests\Support\Db\DbReset;
+use DAMA\DoctrineTestBundle\PHPUnit\SkipDatabaseRollback;
+
+#[SkipDatabaseRollback]
+abstract class PostgresResetTestCase extends IntegrationTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->resetDb();
+    }
+
+    protected function resetDb(): void
+    {
+        (new DbReset())->reset($this->em);
+    }
+}

--- a/site/tests/Support/Kernel/WebTestCaseBase.php
+++ b/site/tests/Support/Kernel/WebTestCaseBase.php
@@ -21,6 +21,12 @@ abstract class WebTestCaseBase extends WebTestCase
 
     protected function resetDb(): void
     {
+        if (class_exists(\DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension::class)
+            && \DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension::$transactionStarted
+        ) {
+            return;
+        }
+
         (new DbReset())->reset($this->em());
     }
 }


### PR DESCRIPTION
## What changed

- Added `dama/doctrine-test-bundle` for transactional test isolation in the test environment.
- Enabled the DAMA PHPUnit extension and test bundle config.
- Removed per-test truncation from the default `IntegrationTestCase` path.
- Added `PostgresResetTestCase` for PostgreSQL-specific tests that need real commits, schema inspection, locks, or second DB connections.
- Moved schema/`SKIP LOCKED` tests to the reset-based base class.
- Split Makefile test preparation from normal integration execution so `site-test-integration` no longer rebuilds DB/fixtures every run.
- Documented the new test workflow in `README.md`.

## Why

The integration suite was doing a full database truncate before normal tests and the Makefile also rebuilt/loaded fixtures before each integration run. Transactional rollback makes the common path faster while preserving explicit reset coverage for PostgreSQL-specific behavior.

## Validation

- Passed: syntax checks for changed test base/catalog files with `php -l`.
- Passed: `docker compose run --rm site-php-cli composer test:unit` — 933 tests, 5574 assertions, 1 warning, 1 deprecation.
- Passed: `InventorySchemaTest` — 1 test, 29 assertions.
- Passed: `AdScheduledBatchRepositoryTest --filter testFindNextPlannedSkipsLockedRowConcurrently` — 1 test, 2 assertions.
- Passed: `AdBatchSchedulerCommandTest --filter testParallelWorkerSkipsLockedRow` — 1 test, 5 assertions.

## Known local limitation

- `SmokePersistenceTest` failed locally before a DB rebuild because the existing local `app_test` database already contained rows with fixed test UUIDs. This is expected for the new transactional model when running against a dirty local DB; use `site-test-db-rebuild` / clean test DB preparation before a full integration suite run.

## Not included

- `site/config/reference.php` was generated locally and intentionally left out of the PR.