### PR TITLE
[codex] Ignore Symfony config reference file

### DIFF
--- a/site/.gitignore
+++ b/site/.gitignore
@@ -3,6 +3,7 @@
 /.env.local.php
 /.env.*.local
 /config/secrets/prod/prod.decrypt.private.php
+/config/reference.php
 /public/bundles/
 /var/
 /vendor/


### PR DESCRIPTION
## What changed

- Added `site/config/reference.php` to `site/.gitignore`.

## Why

Symfony can generate this local PHP config reference/helper file. It is not application runtime code and should not show up as an untracked file or accidentally be included in unrelated PRs.

## Validation

- Passed: `git check-ignore -v site/config/reference.php`
- Passed: `git diff --check`

## Not included

- The generated local `site/config/reference.php` file itself is not committed.