### PR TITLE
[codex] Validate Ozon keys before initial sync

### DIFF
--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -89,6 +89,7 @@ services:
 
     App\Marketplace\Repository\MarketplaceAdvertisingCostRepositoryInterface: '@App\Marketplace\Repository\MarketplaceAdvertisingCostRepository'
     App\Marketplace\Application\Service\WbFinancialReportSyncPlannerInterface: '@App\Marketplace\Application\Service\WbFinancialReportSyncPlanner'
+    App\Marketplace\Infrastructure\Api\Ozon\OzonSellerCredentialValidatorInterface: '@App\Marketplace\Infrastructure\Api\Ozon\OzonSellerCredentialValidator'
 
     App\Marketplace\Application\Service\WbFinancialReportSyncStatusUpdaterInterface: '@App\Marketplace\Application\Service\WbFinancialReportSyncStatusUpdater'
     App\Marketplace\Application\Service\WbGeneratedRowsSafeReplaceServiceInterface: '@App\Marketplace\Application\Service\WbGeneratedRowsSafeReplaceService'

--- a/site/src/Marketplace/Controller/MarketplaceController.php
+++ b/site/src/Marketplace/Controller/MarketplaceController.php
@@ -15,9 +15,11 @@ use App\Marketplace\Application\Command\SyncConnectionCommand;
 use App\Marketplace\Enum\MarketplaceConnectionType;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Enum\FinancialReportSyncStatus;
+use App\Marketplace\Infrastructure\Api\Ozon\OzonCredentialValidationStatus;
 use App\Marketplace\Infrastructure\Query\OzonRealizationStatusQuery;
 use App\Marketplace\Infrastructure\Query\RawDocumentsListQuery;
 use App\Marketplace\Infrastructure\Query\WbFinanceSyncStatusListQuery;
+use App\Marketplace\Infrastructure\Api\Ozon\OzonSellerCredentialValidatorInterface;
 use App\Marketplace\Message\ReprocessCostsMessage;
 use App\Marketplace\Message\SyncOzonRealizationMessage;
 use App\Marketplace\Message\TriggerInitialSyncMessage;
@@ -57,6 +59,7 @@ class MarketplaceController extends AbstractController
         private readonly WbInitialSyncStartDateResolver   $wbInitialSyncStartDateResolver,
         private readonly WbFinancialReportSyncPlannerInterface $wbFinancialReportSyncPlanner,
         private readonly WbFinanceSyncStatusListQuery     $wbFinanceSyncStatusListQuery,
+        private readonly OzonSellerCredentialValidatorInterface $ozonCredentialValidator,
     ) {
     }
 
@@ -101,8 +104,8 @@ class MarketplaceController extends AbstractController
         $company = $this->companyService->getActiveCompany();
 
         $marketplace = MarketplaceType::from($request->request->get('marketplace'));
-        $apiKey      = $request->request->get('api_key');
-        $clientId    = $request->request->get('client_id');
+        $apiKey      = trim((string) $request->request->get('api_key', ''));
+        $clientId    = trim((string) $request->request->get('client_id', ''));
 
         $existing = $this->connectionRepository->findByMarketplace(
             $company,
@@ -127,6 +130,19 @@ class MarketplaceController extends AbstractController
             $connection->setClientId($clientId);
         }
 
+        $ozonValidation = null;
+        if (MarketplaceType::OZON === $marketplace) {
+            $ozonValidation = $this->ozonCredentialValidator->validate($clientId, $apiKey);
+
+            if ($ozonValidation->isValid()) {
+                $connection->setIsActive(true);
+                $connection->setLastSyncError(null);
+            } else {
+                $connection->setIsActive(false);
+                $connection->setLastSyncError($ozonValidation->message);
+            }
+        }
+
         $this->em->persist($connection);
         $this->em->flush();
 
@@ -136,7 +152,7 @@ class MarketplaceController extends AbstractController
                 connectionId: $connection->getId(),
                 startFrom: $this->wbInitialSyncStartDateResolver->resolve($company, $connection),
             );
-        } else {
+        } elseif (null === $ozonValidation || $ozonValidation->isValid()) {
             $this->messageBus->dispatch(new TriggerInitialSyncMessage(
                 companyId:    (string) $company->getId(),
                 connectionId: $connection->getId(),
@@ -144,7 +160,11 @@ class MarketplaceController extends AbstractController
             ));
         }
 
-        $this->addFlash('success', 'Подключение к ' . $marketplace->getDisplayName() . ' создано');
+        if (null !== $ozonValidation && !$ozonValidation->isValid()) {
+            $this->addFlash('error', 'Подключение к ' . $marketplace->getDisplayName() . ' создано, но ключ не прошёл проверку: ' . $ozonValidation->message);
+        } else {
+            $this->addFlash('success', 'Подключение к ' . $marketplace->getDisplayName() . ' создано');
+        }
 
         return $this->redirectToRoute('marketplace_index');
     }
@@ -187,13 +207,35 @@ class MarketplaceController extends AbstractController
             throw $this->createNotFoundException('Подключение не найдено');
         }
 
-        $success = false;
-        $error   = null;
+        if ($connection->getMarketplace() === MarketplaceType::OZON
+            && $connection->getConnectionType() === MarketplaceConnectionType::SELLER
+        ) {
+            $result = $this->ozonCredentialValidator->validate($connection->getClientId(), $connection->getApiKey());
+
+            if ($result->isValid()) {
+                $connection->setIsActive(true);
+                $connection->setLastSyncError(null);
+                $this->em->flush();
+
+                $this->addFlash('success', 'Подключение работает корректно');
+            } else {
+                if (OzonCredentialValidationStatus::INVALID_CREDENTIALS === $result->status) {
+                    $connection->setIsActive(false);
+                }
+                $connection->setLastSyncError($result->message);
+                $this->em->flush();
+
+                $this->addFlash('error', 'Ошибка подключения: ' . $result->message);
+            }
+
+            return $this->redirectToRoute('marketplace_index');
+        }
 
         try {
             $adapter = $this->adapterRegistry->get($connection->getMarketplace());
             $success = $adapter->authenticate($company);
         } catch (\Exception $e) {
+            $success = false;
             $error = $e->getMessage();
         }
 
@@ -210,6 +252,17 @@ class MarketplaceController extends AbstractController
     public function syncConnection(string $id): Response
     {
         $company = $this->companyService->getActiveCompany();
+        $connection = $this->connectionRepository->find($id);
+
+        if (!$connection || (string) $connection->getCompany()->getId() !== (string) $company->getId()) {
+            throw $this->createNotFoundException('Подключение не найдено');
+        }
+
+        if (!$this->canRunManualSync($connection)) {
+            $this->addFlash('error', $this->manualSyncBlockedMessage($connection));
+
+            return $this->redirectToRoute('marketplace_index');
+        }
 
         try {
             $cmd   = new SyncConnectionCommand(
@@ -220,7 +273,6 @@ class MarketplaceController extends AbstractController
             );
             $count = ($this->syncConnectionAction)($cmd);
 
-            $connection = $this->connectionRepository->find($id);
             if ($connection?->getMarketplace() === MarketplaceType::WILDBERRIES) {
                 $this->addFlash('success', sprintf(
                     'Запланировано %d задач синхронизации WB.',
@@ -250,6 +302,12 @@ class MarketplaceController extends AbstractController
 
         if (!$connection || (string) $connection->getCompany()->getId() !== (string) $company->getId()) {
             throw $this->createNotFoundException('Подключение не найдено');
+        }
+
+        if (!$this->canRunManualSync($connection)) {
+            $this->addFlash('error', $this->manualSyncBlockedMessage($connection));
+
+            return $this->redirectToRoute('marketplace_index');
         }
 
         $dateFromStr = $request->query->get('date_from');
@@ -322,6 +380,12 @@ class MarketplaceController extends AbstractController
 
         if ($connection->getMarketplace() !== MarketplaceType::OZON) {
             $this->addFlash('warning', 'Загрузка реализации доступна только для Ozon.');
+
+            return $this->redirectToRoute('marketplace_index');
+        }
+
+        if (!$this->canRunManualSync($connection)) {
+            $this->addFlash('error', $this->manualSyncBlockedMessage($connection));
 
             return $this->redirectToRoute('marketplace_index');
         }
@@ -609,11 +673,37 @@ class MarketplaceController extends AbstractController
             throw $this->createAccessDeniedException('Invalid CSRF token.');
         }
 
-        $connection->setIsActive(!$connection->isActive());
+        if ($connection->isActive()) {
+            $connection->setIsActive(false);
+            $this->em->flush();
+
+            $this->addFlash('success', 'Подключение деактивировано');
+
+            return $this->redirectToRoute('marketplace_index');
+        }
+
+        if ($connection->getMarketplace() === MarketplaceType::OZON
+            && $connection->getConnectionType() === MarketplaceConnectionType::SELLER
+        ) {
+            $result = $this->ozonCredentialValidator->validate($connection->getClientId(), $connection->getApiKey());
+
+            if (!$result->isValid()) {
+                $connection->setIsActive(false);
+                $connection->setLastSyncError($result->message);
+                $this->em->flush();
+
+                $this->addFlash('error', 'Подключение не активировано: ' . $result->message);
+
+                return $this->redirectToRoute('marketplace_index');
+            }
+
+            $connection->setLastSyncError(null);
+        }
+
+        $connection->setIsActive(true);
         $this->em->flush();
 
-        $status = $connection->isActive() ? 'активировано' : 'деактивировано';
-        $this->addFlash('success', 'Подключение ' . $status);
+        $this->addFlash('success', 'Подключение активировано');
 
         return $this->redirectToRoute('marketplace_index');
     }
@@ -737,6 +827,20 @@ class MarketplaceController extends AbstractController
         }
 
         return $date;
+    }
+
+    private function canRunManualSync(MarketplaceConnection $connection): bool
+    {
+        return $connection->isActive();
+    }
+
+    private function manualSyncBlockedMessage(MarketplaceConnection $connection): string
+    {
+        if (!$connection->isActive()) {
+            return 'Синхронизация недоступна: подключение неактивно.';
+        }
+
+        return 'Синхронизация недоступна.';
     }
 
     /**

--- a/site/src/Marketplace/Infrastructure/Api/Ozon/OzonCredentialValidationResult.php
+++ b/site/src/Marketplace/Infrastructure/Api/Ozon/OzonCredentialValidationResult.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Api\Ozon;
+
+final readonly class OzonCredentialValidationResult
+{
+    public function __construct(
+        public OzonCredentialValidationStatus $status,
+        public string $message,
+        public ?int $statusCode = null,
+    ) {
+    }
+
+    public static function valid(): self
+    {
+        return new self(
+            OzonCredentialValidationStatus::VALID,
+            'Ключ Ozon Seller API успешно проверен.',
+        );
+    }
+
+    public function isValid(): bool
+    {
+        return OzonCredentialValidationStatus::VALID === $this->status;
+    }
+}

--- a/site/src/Marketplace/Infrastructure/Api/Ozon/OzonCredentialValidationStatus.php
+++ b/site/src/Marketplace/Infrastructure/Api/Ozon/OzonCredentialValidationStatus.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Api\Ozon;
+
+enum OzonCredentialValidationStatus: string
+{
+    case VALID = 'valid';
+    case INVALID_CREDENTIALS = 'invalid_credentials';
+    case TEMPORARY_ERROR = 'temporary_error';
+    case RATE_LIMITED = 'rate_limited';
+    case UNEXPECTED_ERROR = 'unexpected_error';
+}

--- a/site/src/Marketplace/Infrastructure/Api/Ozon/OzonSellerCredentialValidator.php
+++ b/site/src/Marketplace/Infrastructure/Api/Ozon/OzonSellerCredentialValidator.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Api\Ozon;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final readonly class OzonSellerCredentialValidator implements OzonSellerCredentialValidatorInterface
+{
+    private const URL = 'https://api-seller.ozon.ru/v4/product/info/limit';
+    private const REQUEST_TIMEOUT = 15;
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function validate(?string $clientId, string $apiKey): OzonCredentialValidationResult
+    {
+        $clientId = trim((string) $clientId);
+        $apiKey = trim($apiKey);
+
+        if ('' === $clientId || '' === $apiKey) {
+            return new OzonCredentialValidationResult(
+                OzonCredentialValidationStatus::INVALID_CREDENTIALS,
+                'Укажите Client-Id и Api-Key Ozon Seller API.',
+            );
+        }
+
+        try {
+            $response = $this->httpClient->request('POST', self::URL, [
+                'headers' => [
+                    'Client-Id' => $clientId,
+                    'Api-Key' => $apiKey,
+                    'Content-Type' => 'application/json',
+                ],
+                'json' => new \stdClass(),
+                'timeout' => self::REQUEST_TIMEOUT,
+            ]);
+
+            $statusCode = $response->getStatusCode();
+            $body = $response->getContent(false);
+        } catch (TransportExceptionInterface $e) {
+            $this->logger->warning('Ozon Seller credential validation transport error.', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return new OzonCredentialValidationResult(
+                OzonCredentialValidationStatus::TEMPORARY_ERROR,
+                'Ozon Seller API временно недоступен. Повторите проверку позже.',
+            );
+        }
+
+        if ($statusCode >= 200 && $statusCode < 300) {
+            return OzonCredentialValidationResult::valid();
+        }
+
+        $bodyExcerpt = mb_substr(trim($body), 0, 300);
+
+        return match (true) {
+            401 === $statusCode || 403 === $statusCode => new OzonCredentialValidationResult(
+                OzonCredentialValidationStatus::INVALID_CREDENTIALS,
+                'Ozon отклонил Client-Id или Api-Key. Проверьте ключ Seller API.',
+                $statusCode,
+            ),
+            404 === $statusCode && $this->looksLikeInvalidCredentialResponse($body) => new OzonCredentialValidationResult(
+                OzonCredentialValidationStatus::INVALID_CREDENTIALS,
+                'Ozon не нашёл активный Seller API ключ для указанных данных.',
+                $statusCode,
+            ),
+            429 === $statusCode => new OzonCredentialValidationResult(
+                OzonCredentialValidationStatus::RATE_LIMITED,
+                'Ozon временно ограничил количество запросов. Повторите проверку позже.',
+                $statusCode,
+            ),
+            $statusCode >= 500 => new OzonCredentialValidationResult(
+                OzonCredentialValidationStatus::TEMPORARY_ERROR,
+                'Ozon Seller API вернул временную ошибку. Повторите проверку позже.',
+                $statusCode,
+            ),
+            default => new OzonCredentialValidationResult(
+                OzonCredentialValidationStatus::UNEXPECTED_ERROR,
+                sprintf(
+                    'Неожиданный ответ Ozon Seller API при проверке ключа: HTTP %d%s',
+                    $statusCode,
+                    '' !== $bodyExcerpt ? ', '.$bodyExcerpt : '',
+                ),
+                $statusCode,
+            ),
+        };
+    }
+
+    private function looksLikeInvalidCredentialResponse(string $body): bool
+    {
+        $normalized = mb_strtolower($body);
+
+        return str_contains($normalized, 'api')
+            || str_contains($normalized, 'key')
+            || str_contains($normalized, 'client')
+            || str_contains($normalized, 'credential')
+            || str_contains($normalized, 'invalid')
+            || str_contains($normalized, 'unauthorized')
+            || str_contains($normalized, 'forbidden');
+    }
+}

--- a/site/src/Marketplace/Infrastructure/Api/Ozon/OzonSellerCredentialValidatorInterface.php
+++ b/site/src/Marketplace/Infrastructure/Api/Ozon/OzonSellerCredentialValidatorInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Api\Ozon;
+
+interface OzonSellerCredentialValidatorInterface
+{
+    public function validate(?string $clientId, string $apiKey): OzonCredentialValidationResult;
+}

--- a/site/templates/marketplace/index.html.twig
+++ b/site/templates/marketplace/index.html.twig
@@ -29,6 +29,8 @@
                     <div class="list-group list-group-flush">
                         {% for connection in connections %}
                             {% set isSeller = connection.connectionType.value == 'seller' %}
+                            {% set hasConnectionError = connection.lastSyncError is not empty and not connection.isActive %}
+                            {% set canManualSync = isSeller and connection.isActive %}
                             <div class="list-group-item">
                                 <div class="row align-items-center">
                                     <div class="col-auto">
@@ -50,9 +52,13 @@
                                             <div class="d-block text-muted mt-1"
                                                  data-connection-id="{{ connection.id }}"
                                                  data-status-url="{{ path('marketplace_connection_status', {id: connection.id}) }}"
-                                                 data-synced="{{ connection.lastSyncAt ? '1' : '0' }}"
+                                                 data-synced="{{ connection.lastSyncAt or hasConnectionError or not connection.isActive ? '1' : '0' }}"
                                                  id="connection-status-{{ connection.id }}">
-                                                {% if connection.lastSyncAt %}
+                                                {% if hasConnectionError %}
+                                                    <small class="text-danger">Ошибка: {{ connection.lastSyncError|slice(0, 100) }}</small>
+                                                {% elseif not connection.isActive %}
+                                                    <small>Последняя синхронизация: —</small>
+                                                {% elseif connection.lastSyncAt %}
                                                     <small>Последняя синхронизация: {{ connection.lastSyncAt|date('d.m.Y H:i') }}</small>
                                                 {% else %}
                                                     <small class="text-warning">
@@ -66,15 +72,10 @@
                                                 <small>Последняя синхронизация: —</small>
                                             </div>
                                         {% endif %}
-                                        {% if connection.lastSyncError %}
-                                            <div class="text-danger mt-1">
-                                                <small>Ошибка: {{ connection.lastSyncError|slice(0, 100) }}</small>
-                                            </div>
-                                        {% endif %}
                                     </div>
                                     <div class="col-auto">
-                                        <span class="badge bg-{{ connection.isActive ? 'success' : 'secondary' }}">
-                                            {{ connection.isActive ? 'Активно' : 'Неактивно' }}
+                                        <span class="badge bg-{{ hasConnectionError ? 'danger' : (connection.isActive ? 'success' : 'secondary') }}">
+                                            {{ hasConnectionError ? 'Ошибка подключения' : (connection.isActive ? 'Активно' : 'Неактивно') }}
                                         </span>
                                     </div>
                                     <div class="col-auto">
@@ -82,20 +83,29 @@
                                             <a href="{{ path('marketplace_connection_edit', {id: connection.id}) }}" class="btn btn-sm btn-outline-secondary">Настройки</a>
                                             <a href="{{ path('marketplace_connection_test', {id: connection.id}) }}" class="btn btn-sm btn-outline-info">Проверить</a>
                                             {% if isSeller %}
-                                                <a href="{{ path('marketplace_connection_sync', {id: connection.id}) }}" class="btn btn-sm btn-primary">Синхронизировать</a>
-                                                <a href="#" class="btn btn-sm btn-outline-primary"
-                                                   data-bs-toggle="modal"
-                                                   data-bs-target="#modal-sync-period"
-                                                   data-connection-id="{{ connection.id }}">За период</a>
+                                                {% if canManualSync %}
+                                                    <a href="{{ path('marketplace_connection_sync', {id: connection.id}) }}" class="btn btn-sm btn-primary">Синхронизировать</a>
+                                                    <a href="#" class="btn btn-sm btn-outline-primary"
+                                                       data-bs-toggle="modal"
+                                                       data-bs-target="#modal-sync-period"
+                                                       data-connection-id="{{ connection.id }}">За период</a>
+                                                {% else %}
+                                                    <button type="button" class="btn btn-sm btn-primary" disabled>Синхронизировать</button>
+                                                    <button type="button" class="btn btn-sm btn-outline-primary" disabled>За период</button>
+                                                {% endif %}
                                                 {% if connection.marketplace.value == 'ozon' %}
-                                                    <button type="button"
-                                                            class="btn btn-sm btn-outline-teal"
-                                                            data-bs-toggle="modal"
-                                                            data-bs-target="#modal-sync-realization"
-                                                            data-connection-id="{{ connection.id }}"
-                                                            data-action="{{ path('marketplace_connection_sync_realization', {id: connection.id}) }}">
-                                                        Реализация
-                                                    </button>
+                                                    {% if canManualSync %}
+                                                        <button type="button"
+                                                                class="btn btn-sm btn-outline-teal"
+                                                                data-bs-toggle="modal"
+                                                                data-bs-target="#modal-sync-realization"
+                                                                data-connection-id="{{ connection.id }}"
+                                                                data-action="{{ path('marketplace_connection_sync_realization', {id: connection.id}) }}">
+                                                            Реализация
+                                                        </button>
+                                                    {% else %}
+                                                        <button type="button" class="btn btn-sm btn-outline-teal" disabled>Реализация</button>
+                                                    {% endif %}
                                                 {% endif %}
                                                 <button type="button"
                                                         class="btn btn-sm btn-outline-warning"

--- a/site/tests/Unit/Marketplace/Controller/MarketplaceControllerCreateConnectionTest.php
+++ b/site/tests/Unit/Marketplace/Controller/MarketplaceControllerCreateConnectionTest.php
@@ -12,6 +12,9 @@ use App\Marketplace\Controller\MarketplaceController;
 use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Enum\MarketplaceConnectionType;
 use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Infrastructure\Api\Ozon\OzonCredentialValidationResult;
+use App\Marketplace\Infrastructure\Api\Ozon\OzonCredentialValidationStatus;
+use App\Marketplace\Infrastructure\Api\Ozon\OzonSellerCredentialValidatorInterface;
 use App\Marketplace\Infrastructure\Query\OzonRealizationStatusQuery;
 use App\Marketplace\Infrastructure\Query\RawDocumentsListQuery;
 use App\Marketplace\Infrastructure\Query\WbFinanceSyncStatusListQuery;
@@ -129,7 +132,7 @@ final class MarketplaceControllerCreateConnectionTest extends TestCase
         self::assertSame($createdConnection->getId(), $plannedConnectionId);
     }
 
-    public function testCreateNonWbConnectionStillDispatchesLegacyInitialTrigger(): void
+    public function testCreateValidOzonConnectionStoresActiveConnectionAndDispatchesInitialTrigger(): void
     {
         $company = CompanyBuilder::aCompany()->build();
         $createdConnection = null;
@@ -168,8 +171,217 @@ final class MarketplaceControllerCreateConnectionTest extends TestCase
         $planner = $this->createMock(WbFinancialReportSyncPlannerInterface::class);
         $planner->expects(self::never())->method('planInitial');
 
-        $this->controller($companyService, $connectionRepository, $em, $messageBus, $startDateResolver, $planner)
+        $validator = $this->createMock(OzonSellerCredentialValidatorInterface::class);
+        $validator->expects(self::once())
+            ->method('validate')
+            ->with('client-id', 'api-key')
+            ->willReturn(OzonCredentialValidationResult::valid());
+
+        $this->controller($companyService, $connectionRepository, $em, $messageBus, $startDateResolver, $planner, $validator)
             ->createConnection($this->request(MarketplaceType::OZON, 'client-id'));
+
+        self::assertInstanceOf(MarketplaceConnection::class, $createdConnection);
+        self::assertTrue($createdConnection->isActive());
+        self::assertNull($createdConnection->getLastSyncError());
+    }
+
+    public function testCreateInvalidOzonConnectionStoresInactiveConnectionWithErrorAndDoesNotDispatchInitialTrigger(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+        $createdConnection = null;
+
+        $companyService = $this->createMock(ActiveCompanyService::class);
+        $companyService->method('getActiveCompany')->willReturn($company);
+
+        $connectionRepository = $this->createMock(MarketplaceConnectionRepository::class);
+        $connectionRepository->method('findByMarketplace')->willReturn(null);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('persist')
+            ->with(self::callback(static function (MarketplaceConnection $connection) use (&$createdConnection): bool {
+                $createdConnection = $connection;
+
+                return true;
+            }));
+        $em->expects(self::once())->method('flush');
+
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::never())->method('dispatch');
+
+        $startDateResolver = $this->createMock(WbInitialSyncStartDateResolver::class);
+        $startDateResolver->expects(self::never())->method('resolve');
+
+        $planner = $this->createMock(WbFinancialReportSyncPlannerInterface::class);
+        $planner->expects(self::never())->method('planInitial');
+
+        $validator = $this->createMock(OzonSellerCredentialValidatorInterface::class);
+        $validator->expects(self::once())
+            ->method('validate')
+            ->with('client-id', 'api-key')
+            ->willReturn(new OzonCredentialValidationResult(
+                OzonCredentialValidationStatus::INVALID_CREDENTIALS,
+                'Ozon отклонил Client-Id или Api-Key. Проверьте ключ Seller API.',
+                403,
+            ));
+
+        $this->controller($companyService, $connectionRepository, $em, $messageBus, $startDateResolver, $planner, $validator)
+            ->createConnection($this->request(MarketplaceType::OZON, 'client-id'));
+
+        self::assertInstanceOf(MarketplaceConnection::class, $createdConnection);
+        self::assertFalse($createdConnection->isActive());
+        self::assertSame('Ozon отклонил Client-Id или Api-Key. Проверьте ключ Seller API.', $createdConnection->getLastSyncError());
+    }
+
+    public function testManualSyncDoesNotStartForInactiveConnectionWithStoredError(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+        $connection = new MarketplaceConnection('11111111-1111-4111-8111-111111111111', $company, MarketplaceType::OZON);
+        $connection->setApiKey('api-key');
+        $connection->setClientId('client-id');
+        $connection->setIsActive(false);
+        $connection->setLastSyncError('Ozon отклонил ключ.');
+
+        $companyService = $this->createMock(ActiveCompanyService::class);
+        $companyService->method('getActiveCompany')->willReturn($company);
+
+        $connectionRepository = $this->createMock(MarketplaceConnectionRepository::class);
+        $connectionRepository->method('find')->with($connection->getId())->willReturn($connection);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $messageBus = $this->createMock(MessageBusInterface::class);
+
+        $response = $this->controller(
+            $companyService,
+            $connectionRepository,
+            $em,
+            $messageBus,
+            $this->createMock(WbInitialSyncStartDateResolver::class),
+            $this->createMock(WbFinancialReportSyncPlannerInterface::class),
+        )->syncConnection($connection->getId());
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+    }
+
+    public function testTestConnectionActivatesValidOzonConnectionAndClearsError(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+        $connection = new MarketplaceConnection('22222222-2222-4222-8222-222222222222', $company, MarketplaceType::OZON);
+        $connection->setApiKey('api-key');
+        $connection->setClientId('client-id');
+        $connection->setIsActive(false);
+        $connection->setLastSyncError('old error');
+
+        $companyService = $this->createMock(ActiveCompanyService::class);
+        $companyService->method('getActiveCompany')->willReturn($company);
+
+        $connectionRepository = $this->createMock(MarketplaceConnectionRepository::class);
+        $connectionRepository->method('find')->with($connection->getId())->willReturn($connection);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::once())->method('flush');
+
+        $validator = $this->createMock(OzonSellerCredentialValidatorInterface::class);
+        $validator->expects(self::once())
+            ->method('validate')
+            ->with('client-id', 'api-key')
+            ->willReturn(OzonCredentialValidationResult::valid());
+
+        $response = $this->controller(
+            $companyService,
+            $connectionRepository,
+            $em,
+            $this->createMock(MessageBusInterface::class),
+            $this->createMock(WbInitialSyncStartDateResolver::class),
+            $this->createMock(WbFinancialReportSyncPlannerInterface::class),
+            $validator,
+        )->testConnection($connection->getId());
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertTrue($connection->isActive());
+        self::assertNull($connection->getLastSyncError());
+    }
+
+    public function testTestConnectionDeactivatesInvalidOzonConnectionAndStoresError(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+        $connection = new MarketplaceConnection('33333333-3333-4333-8333-333333333333', $company, MarketplaceType::OZON);
+        $connection->setApiKey('api-key');
+        $connection->setClientId('client-id');
+
+        $companyService = $this->createMock(ActiveCompanyService::class);
+        $companyService->method('getActiveCompany')->willReturn($company);
+
+        $connectionRepository = $this->createMock(MarketplaceConnectionRepository::class);
+        $connectionRepository->method('find')->with($connection->getId())->willReturn($connection);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::once())->method('flush');
+
+        $validator = $this->createMock(OzonSellerCredentialValidatorInterface::class);
+        $validator->expects(self::once())
+            ->method('validate')
+            ->with('client-id', 'api-key')
+            ->willReturn(new OzonCredentialValidationResult(
+                OzonCredentialValidationStatus::INVALID_CREDENTIALS,
+                'Ozon отклонил Client-Id или Api-Key. Проверьте ключ Seller API.',
+                403,
+            ));
+
+        $response = $this->controller(
+            $companyService,
+            $connectionRepository,
+            $em,
+            $this->createMock(MessageBusInterface::class),
+            $this->createMock(WbInitialSyncStartDateResolver::class),
+            $this->createMock(WbFinancialReportSyncPlannerInterface::class),
+            $validator,
+        )->testConnection($connection->getId());
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertFalse($connection->isActive());
+        self::assertSame('Ozon отклонил Client-Id или Api-Key. Проверьте ключ Seller API.', $connection->getLastSyncError());
+    }
+
+    public function testTestConnectionPreservesActiveOzonConnectionOnTemporaryValidationError(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+        $connection = new MarketplaceConnection('44444444-4444-4444-8444-444444444444', $company, MarketplaceType::OZON);
+        $connection->setApiKey('api-key');
+        $connection->setClientId('client-id');
+        $connection->setIsActive(true);
+
+        $companyService = $this->createMock(ActiveCompanyService::class);
+        $companyService->method('getActiveCompany')->willReturn($company);
+
+        $connectionRepository = $this->createMock(MarketplaceConnectionRepository::class);
+        $connectionRepository->method('find')->with($connection->getId())->willReturn($connection);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::once())->method('flush');
+
+        $validator = $this->createMock(OzonSellerCredentialValidatorInterface::class);
+        $validator->expects(self::once())
+            ->method('validate')
+            ->with('client-id', 'api-key')
+            ->willReturn(new OzonCredentialValidationResult(
+                OzonCredentialValidationStatus::TEMPORARY_ERROR,
+                'Ozon Seller API временно недоступен. Повторите проверку позже.',
+                500,
+            ));
+
+        $response = $this->controller(
+            $companyService,
+            $connectionRepository,
+            $em,
+            $this->createMock(MessageBusInterface::class),
+            $this->createMock(WbInitialSyncStartDateResolver::class),
+            $this->createMock(WbFinancialReportSyncPlannerInterface::class),
+            $validator,
+        )->testConnection($connection->getId());
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertTrue($connection->isActive());
+        self::assertSame('Ozon Seller API временно недоступен. Повторите проверку позже.', $connection->getLastSyncError());
     }
 
     private function request(MarketplaceType $marketplace, ?string $clientId = null): Request
@@ -188,7 +400,10 @@ final class MarketplaceControllerCreateConnectionTest extends TestCase
         MessageBusInterface $messageBus,
         WbInitialSyncStartDateResolver $startDateResolver,
         WbFinancialReportSyncPlannerInterface $planner,
+        ?OzonSellerCredentialValidatorInterface $ozonCredentialValidator = null,
     ): MarketplaceController {
+        $ozonCredentialValidator ??= $this->createMock(OzonSellerCredentialValidatorInterface::class);
+
         return new class(
             $companyService,
             $connectionRepository,
@@ -204,6 +419,7 @@ final class MarketplaceControllerCreateConnectionTest extends TestCase
             $startDateResolver,
             $planner,
             self::uninitialized(WbFinanceSyncStatusListQuery::class),
+            $ozonCredentialValidator,
         ) extends MarketplaceController {
             protected function addFlash(string $type, mixed $message): void
             {

--- a/site/tests/Unit/Marketplace/Infrastructure/Api/Ozon/OzonSellerCredentialValidatorTest.php
+++ b/site/tests/Unit/Marketplace/Infrastructure/Api/Ozon/OzonSellerCredentialValidatorTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Infrastructure\Api\Ozon;
+
+use App\Marketplace\Infrastructure\Api\Ozon\OzonCredentialValidationStatus;
+use App\Marketplace\Infrastructure\Api\Ozon\OzonSellerCredentialValidator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+final class OzonSellerCredentialValidatorTest extends TestCase
+{
+    public function testSuccessMapsToValidAndUsesProductLimitProbe(): void
+    {
+        $captured = [];
+        $http = new MockHttpClient(static function (string $method, string $url, array $options) use (&$captured): MockResponse {
+            $captured = ['method' => $method, 'url' => $url, 'options' => $options];
+
+            return new MockResponse('{"result":{"total":{"limit":1000,"usage":0}}}', ['http_code' => 200]);
+        });
+
+        $result = $this->validator($http)->validate('client-1', 'api-1');
+
+        self::assertTrue($result->isValid());
+        self::assertSame(OzonCredentialValidationStatus::VALID, $result->status);
+        self::assertSame('POST', $captured['method']);
+        self::assertStringEndsWith('/v4/product/info/limit', $captured['url']);
+        self::assertHeaderValue('client-1', $captured['options'], 'client-id');
+        self::assertHeaderValue('api-1', $captured['options'], 'api-key');
+    }
+
+    #[DataProvider('invalidCredentialsResponses')]
+    public function testInvalidCredentialResponsesMapToInvalidCredentials(int $statusCode, string $body): void
+    {
+        $result = $this->validator(new MockHttpClient(new MockResponse($body, ['http_code' => $statusCode])))
+            ->validate('client-1', 'api-1');
+
+        self::assertSame(OzonCredentialValidationStatus::INVALID_CREDENTIALS, $result->status);
+        self::assertFalse($result->isValid());
+        self::assertSame($statusCode, $result->statusCode);
+    }
+
+    public function testRateLimitMapsToRateLimited(): void
+    {
+        $result = $this->validator(new MockHttpClient(new MockResponse('{"message":"rate"}', ['http_code' => 429])))
+            ->validate('client-1', 'api-1');
+
+        self::assertSame(OzonCredentialValidationStatus::RATE_LIMITED, $result->status);
+        self::assertFalse($result->isValid());
+    }
+
+    public function testServerErrorMapsToTemporaryError(): void
+    {
+        $result = $this->validator(new MockHttpClient(new MockResponse('{"message":"server"}', ['http_code' => 500])))
+            ->validate('client-1', 'api-1');
+
+        self::assertSame(OzonCredentialValidationStatus::TEMPORARY_ERROR, $result->status);
+        self::assertFalse($result->isValid());
+    }
+
+    public function testNetworkErrorMapsToTemporaryError(): void
+    {
+        $http = new MockHttpClient(static function (): never {
+            throw new class('network down') extends \RuntimeException implements TransportExceptionInterface {
+            };
+        });
+
+        $result = $this->validator($http)->validate('client-1', 'api-1');
+
+        self::assertSame(OzonCredentialValidationStatus::TEMPORARY_ERROR, $result->status);
+        self::assertFalse($result->isValid());
+    }
+
+    public function testUnexpectedClientResponseMapsToUnexpectedError(): void
+    {
+        $result = $this->validator(new MockHttpClient(new MockResponse('{"message":"bad request"}', ['http_code' => 400])))
+            ->validate('client-1', 'api-1');
+
+        self::assertSame(OzonCredentialValidationStatus::UNEXPECTED_ERROR, $result->status);
+        self::assertFalse($result->isValid());
+    }
+
+    public function testMissingCredentialsMapToInvalidCredentialsWithoutHttpRequest(): void
+    {
+        $http = new MockHttpClient(static function (): never {
+            self::fail('HTTP request must not be sent for incomplete credentials.');
+        });
+
+        $result = $this->validator($http)->validate('', 'api-1');
+
+        self::assertSame(OzonCredentialValidationStatus::INVALID_CREDENTIALS, $result->status);
+        self::assertFalse($result->isValid());
+    }
+
+    /**
+     * @return iterable<string, array{0: int, 1: string}>
+     */
+    public static function invalidCredentialsResponses(): iterable
+    {
+        yield 'unauthorized' => [401, '{"message":"unauthorized"}'];
+        yield 'forbidden' => [403, '{"message":"forbidden"}'];
+        yield 'not found invalid api key' => [404, '{"message":"invalid api key"}'];
+    }
+
+    private function validator(MockHttpClient $http): OzonSellerCredentialValidator
+    {
+        return new OzonSellerCredentialValidator($http, new NullLogger());
+    }
+
+    private static function assertHeaderValue(string $expected, array $options, string $normalizedName): void
+    {
+        $normalized = $options['normalized_headers'][$normalizedName][0] ?? null;
+        self::assertIsString($normalized);
+        self::assertSame($expected, trim((string) preg_replace('/^[^:]+:/', '', $normalized)));
+    }
+}


### PR DESCRIPTION
## What changed

- Added an Ozon Seller credential validator that probes `POST /v4/product/info/limit` instead of the legacy finance transaction endpoint.
- Ozon Seller connection creation now validates credentials before initial sync dispatch.
- Invalid Ozon credentials are saved as inactive with a readable `lastSyncError`; valid credentials are active and initial sync is dispatched.
- The “Проверить” action uses the new validator. Confirmed invalid credentials deactivate the connection, while temporary/rate-limit errors preserve an already active connection.
- Manual sync is gated by `isActive` server-side, while active connections can still retry after ordinary transient sync failures.
- Marketplace UI now distinguishes inactive credential errors from active connections with previous sync errors and disables sync buttons only when the connection is inactive.

## Why

Ozon keys were previously accepted without validation and initial sync could start with bad credentials. The existing “Проверить” path also used a finance endpoint, which is too heavy and can fail for reasons unrelated to credential validity.

## Validation

- `docker compose run --rm site-php-cli php bin/phpunit --testsuite unit --filter 'OzonSellerCredentialValidatorTest|MarketplaceControllerCreateConnectionTest' --display-warnings --display-deprecations`
- `make site-test-unit`
- `git diff --check`

Full unit suite passes. Existing unrelated PHPUnit warning/deprecation remain in `StorageServiceTest` and `XlsxReaderServiceTest`.