### PR TITLE
[codex] Add ingestion credential secret codec

### DIFF
--- a/site/config/packages/doctrine.yaml
+++ b/site/config/packages/doctrine.yaml
@@ -1,6 +1,8 @@
 doctrine:
     dbal:
         url: '%env(resolve:DATABASE_URL)%'
+        types:
+            encrypted_json: App\Ingestion\Infrastructure\Doctrine\EncryptedJsonType
 
         # IMPORTANT: You MUST configure your server version,
         # either here or in the DATABASE_URL env var (see .env file)

--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -90,6 +90,12 @@ services:
     App\Marketplace\Repository\MarketplaceAdvertisingCostRepositoryInterface: '@App\Marketplace\Repository\MarketplaceAdvertisingCostRepository'
     App\Marketplace\Application\Service\WbFinancialReportSyncPlannerInterface: '@App\Marketplace\Application\Service\WbFinancialReportSyncPlanner'
     App\Marketplace\Infrastructure\Api\Ozon\OzonSellerCredentialValidatorInterface: '@App\Marketplace\Infrastructure\Api\Ozon\OzonSellerCredentialValidator'
+    App\Ingestion\Domain\Contract\SecretCodec: '@App\Ingestion\Infrastructure\Security\PlaintextSecretCodec'
+
+    App\Ingestion\Facade\CredentialFacade:
+        public: true
+        arguments:
+            $activeKeyVersion: 0
 
     App\Marketplace\Application\Service\WbFinancialReportSyncStatusUpdaterInterface: '@App\Marketplace\Application\Service\WbFinancialReportSyncStatusUpdater'
     App\Marketplace\Application\Service\WbGeneratedRowsSafeReplaceServiceInterface: '@App\Marketplace\Application\Service\WbGeneratedRowsSafeReplaceService'

--- a/site/migrations/Version20260615143000.php
+++ b/site/migrations/Version20260615143000.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260615143000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create Ingestion credentials storage with SecretCodec-backed payload column';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        $this->abortIf(
+            !$platform instanceof PostgreSQLPlatform,
+            sprintf('Migration %s supports only PostgreSQL; got platform "%s".', self::class, $platform::class),
+        );
+
+        $this->addSql('CREATE TABLE ingestion_credentials (id UUID NOT NULL, company_id UUID NOT NULL, connection_ref VARCHAR(255) NOT NULL, type VARCHAR(100) NOT NULL, payload TEXT NOT NULL, key_version INT DEFAULT 0 NOT NULL, expires_at TIMESTAMP(6) WITHOUT TIME ZONE DEFAULT NULL, created_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX idx_ingestion_credentials_company ON ingestion_credentials (company_id)');
+        $this->addSql('CREATE INDEX idx_ingestion_credentials_connection_ref ON ingestion_credentials (connection_ref)');
+        $this->addSql('CREATE UNIQUE INDEX uniq_ingestion_credentials_company_ref_type ON ingestion_credentials (company_id, connection_ref, type)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        $this->abortIf(
+            !$platform instanceof PostgreSQLPlatform,
+            sprintf('Migration %s supports only PostgreSQL; got platform "%s".', self::class, $platform::class),
+        );
+
+        $this->addSql('DROP TABLE ingestion_credentials');
+    }
+}

--- a/site/src/Ingestion/Domain/Contract/SecretCodec.php
+++ b/site/src/Ingestion/Domain/Contract/SecretCodec.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Domain\Contract;
+
+interface SecretCodec
+{
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function encode(array $payload): string;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function decode(string $stored, int $keyVersion): array;
+}

--- a/site/src/Ingestion/Entity/IngestionCredential.php
+++ b/site/src/Ingestion/Entity/IngestionCredential.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Entity;
+
+use App\Ingestion\Domain\TenantOwnedInterface;
+use App\Ingestion\Infrastructure\Doctrine\EncryptedJsonType;
+use App\Ingestion\Infrastructure\Security\PlaintextSecretCodec;
+use App\Ingestion\Repository\IngestionCredentialRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity(repositoryClass: IngestionCredentialRepository::class)]
+#[ORM\Table(name: 'ingestion_credentials')]
+#[ORM\Index(columns: ['company_id'], name: 'idx_ingestion_credentials_company')]
+#[ORM\Index(columns: ['connection_ref'], name: 'idx_ingestion_credentials_connection_ref')]
+#[ORM\UniqueConstraint(name: 'uniq_ingestion_credentials_company_ref_type', columns: ['company_id', 'connection_ref', 'type'])]
+class IngestionCredential implements TenantOwnedInterface
+{
+    public const TYPE_API_CREDENTIALS = 'api_credentials';
+
+    #[ORM\Id]
+    #[ORM\Column(type: Types::GUID)]
+    private string $id;
+
+    #[ORM\Column(type: Types::GUID)]
+    private string $companyId;
+
+    #[ORM\Column(type: Types::STRING, length: 255)]
+    private string $connectionRef;
+
+    #[ORM\Column(type: Types::STRING, length: 100)]
+    private string $type;
+
+    /**
+     * @var array<string, mixed>
+     */
+    #[ORM\Column(type: EncryptedJsonType::NAME)]
+    private array $payload;
+
+    #[ORM\Column(type: Types::INTEGER, options: ['default' => PlaintextSecretCodec::KEY_VERSION])]
+    private int $keyVersion = PlaintextSecretCodec::KEY_VERSION;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6, nullable: true)]
+    private ?\DateTimeImmutable $expiresAt = null;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6)]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6)]
+    private \DateTimeImmutable $updatedAt;
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function __construct(
+        string $companyId,
+        string $connectionRef,
+        array $payload,
+        string $type = self::TYPE_API_CREDENTIALS,
+        int $keyVersion = PlaintextSecretCodec::KEY_VERSION,
+        ?\DateTimeImmutable $expiresAt = null,
+    ) {
+        Assert::uuid($companyId);
+        Assert::notEmpty($connectionRef);
+        Assert::notEmpty($type);
+
+        $now = new \DateTimeImmutable();
+
+        $this->id = Uuid::uuid7()->toString();
+        $this->companyId = $companyId;
+        $this->connectionRef = $connectionRef;
+        $this->type = $type;
+        $this->payload = $payload;
+        $this->keyVersion = $keyVersion;
+        $this->expiresAt = $expiresAt;
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getCompanyId(): string
+    {
+        return $this->companyId;
+    }
+
+    public function getConnectionRef(): string
+    {
+        return $this->connectionRef;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getPayload(): array
+    {
+        return $this->payload;
+    }
+
+    public function getKeyVersion(): int
+    {
+        return $this->keyVersion;
+    }
+
+    public function getExpiresAt(): ?\DateTimeImmutable
+    {
+        return $this->expiresAt;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function replacePayload(array $payload, int $keyVersion, ?\DateTimeImmutable $expiresAt = null): void
+    {
+        $this->payload = $payload;
+        $this->keyVersion = $keyVersion;
+        $this->expiresAt = $expiresAt;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+}

--- a/site/src/Ingestion/Exception/CredentialNotFoundException.php
+++ b/site/src/Ingestion/Exception/CredentialNotFoundException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Exception;
+
+final class CredentialNotFoundException extends \RuntimeException
+{
+}

--- a/site/src/Ingestion/Facade/CredentialFacade.php
+++ b/site/src/Ingestion/Facade/CredentialFacade.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Facade;
+
+use App\Ingestion\Domain\Contract\SecretCodec;
+use App\Ingestion\Entity\IngestionCredential;
+use App\Ingestion\Exception\CredentialNotFoundException;
+use App\Ingestion\Infrastructure\Credential\LegacyMarketplaceCredentialReader;
+use App\Ingestion\Infrastructure\Doctrine\EncryptedJsonType;
+use App\Ingestion\Infrastructure\Security\SecretPayloadMasker;
+use App\Ingestion\Repository\IngestionCredentialRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Webmozart\Assert\Assert;
+
+final readonly class CredentialFacade
+{
+    public function __construct(
+        private IngestionCredentialRepository $credentialRepository,
+        private LegacyMarketplaceCredentialReader $legacyMarketplaceCredentialReader,
+        private EntityManagerInterface $entityManager,
+        private SecretCodec $secretCodec,
+        private SecretPayloadMasker $masker,
+        private int $activeKeyVersion = 0,
+    ) {
+        EncryptedJsonType::setSecretCodec($this->secretCodec);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function store(string $companyId, string $connectionRef, array $payload): void
+    {
+        Assert::uuid($companyId);
+        Assert::notEmpty($connectionRef);
+
+        $credential = $this->credentialRepository->findOneByCompanyRefAndType(
+            $companyId,
+            $connectionRef,
+            IngestionCredential::TYPE_API_CREDENTIALS,
+        );
+
+        if (null === $credential) {
+            $credential = new IngestionCredential(
+                companyId: $companyId,
+                connectionRef: $connectionRef,
+                payload: $payload,
+                keyVersion: $this->activeKeyVersion,
+            );
+            $this->entityManager->persist($credential);
+        } else {
+            $credential->replacePayload($payload, $this->activeKeyVersion);
+        }
+
+        $this->entityManager->flush();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function read(string $companyId, string $connectionRef): array
+    {
+        Assert::uuid($companyId);
+        Assert::notEmpty($connectionRef);
+
+        $credential = $this->credentialRepository->findOneByCompanyRefAndType(
+            $companyId,
+            $connectionRef,
+            IngestionCredential::TYPE_API_CREDENTIALS,
+        );
+
+        if (null !== $credential) {
+            return $credential->getPayload();
+        }
+
+        $legacyPayload = $this->legacyMarketplaceCredentialReader->read($companyId, $connectionRef);
+        if (null !== $legacyPayload) {
+            return $legacyPayload;
+        }
+
+        throw new CredentialNotFoundException('Credentials not found for requested company and connection reference.');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function readMasked(string $companyId, string $connectionRef): array
+    {
+        return $this->masker->mask($this->read($companyId, $connectionRef));
+    }
+}

--- a/site/src/Ingestion/Infrastructure/Credential/LegacyMarketplaceCredentialReader.php
+++ b/site/src/Ingestion/Infrastructure/Credential/LegacyMarketplaceCredentialReader.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Credential;
+
+use App\Marketplace\Enum\MarketplaceConnectionType;
+use App\Marketplace\Enum\MarketplaceType;
+use Doctrine\DBAL\Connection;
+use Ramsey\Uuid\Uuid;
+use Webmozart\Assert\Assert;
+
+final readonly class LegacyMarketplaceCredentialReader
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    /**
+     * @return array{api_key: string, client_id: ?string}|null
+     */
+    public function read(string $companyId, string $connectionRef): ?array
+    {
+        Assert::uuid($companyId);
+
+        if (Uuid::isValid($connectionRef)) {
+            return $this->readByConnectionId($companyId, $connectionRef);
+        }
+
+        $parsedRef = $this->parseMarketplaceRef($connectionRef);
+        if (null === $parsedRef) {
+            return null;
+        }
+
+        [$marketplace, $connectionType] = $parsedRef;
+
+        return $this->readByMarketplace($companyId, $marketplace, $connectionType);
+    }
+
+    /**
+     * @return array{api_key: string, client_id: ?string}|null
+     */
+    private function readByConnectionId(string $companyId, string $connectionId): ?array
+    {
+        $row = $this->connection->fetchAssociative(
+            <<<'SQL'
+                SELECT api_key, client_id
+                FROM marketplace_connections
+                WHERE id = :connection_id
+                  AND company_id = :company_id
+                  AND is_active = true
+                LIMIT 1
+            SQL,
+            [
+                'connection_id' => $connectionId,
+                'company_id' => $companyId,
+            ],
+        );
+
+        return $this->rowToPayload($row);
+    }
+
+    /**
+     * @return array{api_key: string, client_id: ?string}|null
+     */
+    private function readByMarketplace(
+        string $companyId,
+        MarketplaceType $marketplace,
+        MarketplaceConnectionType $connectionType,
+    ): ?array {
+        $row = $this->connection->fetchAssociative(
+            <<<'SQL'
+                SELECT api_key, client_id
+                FROM marketplace_connections
+                WHERE company_id = :company_id
+                  AND marketplace = :marketplace
+                  AND connection_type = :connection_type
+                  AND is_active = true
+                LIMIT 1
+            SQL,
+            [
+                'company_id' => $companyId,
+                'marketplace' => $marketplace->value,
+                'connection_type' => $connectionType->value,
+            ],
+        );
+
+        return $this->rowToPayload($row);
+    }
+
+    /**
+     * @return array{0: MarketplaceType, 1: MarketplaceConnectionType}|null
+     */
+    private function parseMarketplaceRef(string $connectionRef): ?array
+    {
+        $parts = explode(':', $connectionRef);
+        if (3 === count($parts) && 'marketplace' === $parts[0]) {
+            $parts = [$parts[1], $parts[2]];
+        }
+
+        if (2 !== count($parts)) {
+            return null;
+        }
+
+        $marketplace = MarketplaceType::tryFrom($parts[0]);
+        $connectionType = MarketplaceConnectionType::tryFrom($parts[1]);
+
+        if (null === $marketplace || null === $connectionType) {
+            return null;
+        }
+
+        return [$marketplace, $connectionType];
+    }
+
+    /**
+     * @param array<string, mixed>|false $row
+     *
+     * @return array{api_key: string, client_id: ?string}|null
+     */
+    private function rowToPayload(array|false $row): ?array
+    {
+        if (false === $row) {
+            return null;
+        }
+
+        return [
+            'api_key' => (string) $row['api_key'],
+            'client_id' => null !== $row['client_id'] ? (string) $row['client_id'] : null,
+        ];
+    }
+}

--- a/site/src/Ingestion/Infrastructure/Doctrine/EncryptedJsonType.php
+++ b/site/src/Ingestion/Infrastructure/Doctrine/EncryptedJsonType.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Doctrine;
+
+use App\Ingestion\Domain\Contract\SecretCodec;
+use App\Ingestion\Infrastructure\Security\PlaintextSecretCodec;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+
+final class EncryptedJsonType extends Type
+{
+    public const NAME = 'encrypted_json';
+
+    private static ?SecretCodec $secretCodec = null;
+
+    public static function setSecretCodec(SecretCodec $secretCodec): void
+    {
+        self::$secretCodec = $secretCodec;
+    }
+
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return $platform->getClobTypeDeclarationSQL($column);
+    }
+
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        if (!is_array($value)) {
+            throw ConversionException::conversionFailedInvalidType($value, self::NAME, ['array', 'null']);
+        }
+
+        try {
+            return self::codec()->encode($value);
+        } catch (\Throwable $exception) {
+            throw ConversionException::conversionFailedSerialization($value, self::NAME, $exception->getMessage(), $exception);
+        }
+    }
+
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?array
+    {
+        if (null === $value || '' === $value) {
+            return null;
+        }
+
+        if (is_resource($value)) {
+            $value = stream_get_contents($value);
+        }
+
+        if (!is_string($value)) {
+            throw ConversionException::conversionFailedInvalidType($value, self::NAME, ['string', 'null']);
+        }
+
+        try {
+            return self::codec()->decode($value, PlaintextSecretCodec::KEY_VERSION);
+        } catch (\Throwable $exception) {
+            throw ConversionException::conversionFailed($value, self::NAME, $exception);
+        }
+    }
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+
+    private static function codec(): SecretCodec
+    {
+        return self::$secretCodec ??= new PlaintextSecretCodec();
+    }
+}

--- a/site/src/Ingestion/Infrastructure/Doctrine/EncryptedJsonTypeConfigurator.php
+++ b/site/src/Ingestion/Infrastructure/Doctrine/EncryptedJsonTypeConfigurator.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Doctrine;
+
+use App\Ingestion\Domain\Contract\SecretCodec;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final readonly class EncryptedJsonTypeConfigurator implements EventSubscriberInterface
+{
+    public function __construct(private SecretCodec $secretCodec)
+    {
+        EncryptedJsonType::setSecretCodec($this->secretCodec);
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ConsoleEvents::COMMAND => 'configure',
+            KernelEvents::REQUEST => 'configure',
+        ];
+    }
+
+    public function configure(): void
+    {
+        EncryptedJsonType::setSecretCodec($this->secretCodec);
+    }
+}

--- a/site/src/Ingestion/Infrastructure/Security/PlaintextSecretCodec.php
+++ b/site/src/Ingestion/Infrastructure/Security/PlaintextSecretCodec.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Security;
+
+use App\Ingestion\Domain\Contract\SecretCodec;
+
+final readonly class PlaintextSecretCodec implements SecretCodec
+{
+    public const KEY_VERSION = 0;
+
+    public function encode(array $payload): string
+    {
+        return (string) json_encode(
+            $payload,
+            JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRESERVE_ZERO_FRACTION,
+        );
+    }
+
+    public function decode(string $stored, int $keyVersion): array
+    {
+        return match ($keyVersion) {
+            self::KEY_VERSION => $this->decodePlaintext($stored),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported secret key version "%d".', $keyVersion)),
+        };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodePlaintext(string $stored): array
+    {
+        try {
+            $decoded = json_decode($stored, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $exception) {
+            throw new \InvalidArgumentException('Stored plaintext secret payload is not valid JSON.', 0, $exception);
+        }
+
+        if (!is_array($decoded)) {
+            throw new \InvalidArgumentException('Stored plaintext secret payload must decode to an array.');
+        }
+
+        return $decoded;
+    }
+}

--- a/site/src/Ingestion/Infrastructure/Security/SecretPayloadMasker.php
+++ b/site/src/Ingestion/Infrastructure/Security/SecretPayloadMasker.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Security;
+
+final readonly class SecretPayloadMasker
+{
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, mixed>
+     */
+    public function mask(array $payload): array
+    {
+        $masked = [];
+
+        foreach ($payload as $key => $value) {
+            $masked[$key] = $this->maskValue($value);
+        }
+
+        return $masked;
+    }
+
+    private function maskValue(mixed $value): mixed
+    {
+        if (is_array($value)) {
+            $masked = [];
+            foreach ($value as $key => $nestedValue) {
+                $masked[$key] = $this->maskValue($nestedValue);
+            }
+
+            return $masked;
+        }
+
+        if (null === $value) {
+            return null;
+        }
+
+        return '***';
+    }
+}

--- a/site/src/Ingestion/Repository/IngestionCredentialRepository.php
+++ b/site/src/Ingestion/Repository/IngestionCredentialRepository.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Repository;
+
+use App\Ingestion\Entity\IngestionCredential;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Webmozart\Assert\Assert;
+
+/**
+ * @extends ServiceEntityRepository<IngestionCredential>
+ */
+final class IngestionCredentialRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, IngestionCredential::class);
+    }
+
+    public function findOneByCompanyRefAndType(string $companyId, string $connectionRef, string $type): ?IngestionCredential
+    {
+        Assert::uuid($companyId);
+
+        return $this->createQueryBuilder('credential')
+            ->andWhere('credential.companyId = :companyId')
+            ->andWhere('credential.connectionRef = :connectionRef')
+            ->andWhere('credential.type = :type')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('connectionRef', $connectionRef)
+            ->setParameter('type', $type)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+}

--- a/site/tests/Integration/Ingestion/CredentialFacadeTest.php
+++ b/site/tests/Integration/Ingestion/CredentialFacadeTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion;
+
+use App\Ingestion\Domain\Contract\SecretCodec;
+use App\Ingestion\Entity\IngestionCredential;
+use App\Ingestion\Exception\CredentialNotFoundException;
+use App\Ingestion\Facade\CredentialFacade;
+use App\Ingestion\Infrastructure\Security\PlaintextSecretCodec;
+use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class CredentialFacadeTest extends IntegrationTestCase
+{
+    public function testStoreThenReadReturnsOriginalPayloadAndStoresEncodedPayload(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = 'marketplace:ozon:seller';
+        $payload = [
+            'api_key' => 'ozon-secret-key',
+            'client_id' => 'ozon-client-id',
+        ];
+
+        /** @var CredentialFacade $facade */
+        $facade = self::getContainer()->get(CredentialFacade::class);
+        /** @var SecretCodec $codec */
+        $codec = self::getContainer()->get(SecretCodec::class);
+
+        $facade->store($companyId, $connectionRef, $payload);
+        $this->em->clear();
+
+        self::assertSame($payload, $facade->read($companyId, $connectionRef));
+
+        $row = $this->connection->fetchAssociative(
+            'SELECT payload, key_version FROM ingestion_credentials WHERE company_id = :company_id AND connection_ref = :connection_ref',
+            [
+                'company_id' => $companyId,
+                'connection_ref' => $connectionRef,
+            ],
+        );
+
+        self::assertIsArray($row);
+        self::assertSame($codec->encode($payload), $row['payload']);
+        self::assertSame(PlaintextSecretCodec::KEY_VERSION, (int) $row['key_version']);
+    }
+
+    public function testReadMaskedDoesNotReturnSecretPayloadValues(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = 'marketplace:wildberries:seller';
+        $payload = [
+            'api_key' => 'wb-secret-key',
+            'client_id' => null,
+        ];
+
+        /** @var CredentialFacade $facade */
+        $facade = self::getContainer()->get(CredentialFacade::class);
+        $facade->store($companyId, $connectionRef, $payload);
+
+        $masked = $facade->readMasked($companyId, $connectionRef);
+        $encodedMasked = json_encode($masked, JSON_THROW_ON_ERROR);
+
+        self::assertSame(['api_key' => '***', 'client_id' => null], $masked);
+        self::assertStringNotContainsString('wb-secret-key', $encodedMasked);
+    }
+
+    public function testTenantCannotReadAnotherCompanyCredential(): void
+    {
+        $companyA = Uuid::uuid7()->toString();
+        $companyB = Uuid::uuid7()->toString();
+        $connectionRef = 'marketplace:ozon:seller';
+
+        /** @var CredentialFacade $facade */
+        $facade = self::getContainer()->get(CredentialFacade::class);
+        $facade->store($companyB, $connectionRef, ['api_key' => 'company-b-secret']);
+
+        $this->expectException(CredentialNotFoundException::class);
+        $facade->read($companyA, $connectionRef);
+    }
+
+    public function testReadFallsBackToLegacyMarketplaceConnectionByConnectionId(): void
+    {
+        $user = UserBuilder::aUser()->withIndex(1)->build();
+        $company = CompanyBuilder::aCompany()->withIndex(1)->withOwner($user)->build();
+        $connection = new MarketplaceConnection(
+            Uuid::uuid7()->toString(),
+            $company,
+            MarketplaceType::OZON,
+        );
+        $connection->setClientId('legacy-client-id');
+        $connection->setApiKey('legacy-api-key');
+
+        $this->em->persist($user);
+        $this->em->persist($company);
+        $this->em->persist($connection);
+        $this->em->flush();
+        $this->em->clear();
+
+        /** @var CredentialFacade $facade */
+        $facade = self::getContainer()->get(CredentialFacade::class);
+
+        self::assertSame([
+            'api_key' => 'legacy-api-key',
+            'client_id' => 'legacy-client-id',
+        ], $facade->read((string) $company->getId(), $connection->getId()));
+    }
+
+    public function testCompanyFilterLimitsCredentialOrmReads(): void
+    {
+        $companyA = Uuid::uuid7()->toString();
+        $companyB = Uuid::uuid7()->toString();
+
+        /** @var CredentialFacade $facade */
+        $facade = self::getContainer()->get(CredentialFacade::class);
+        $facade->store($companyA, 'marketplace:ozon:seller', ['api_key' => 'company-a-secret']);
+        $facade->store($companyB, 'marketplace:ozon:seller', ['api_key' => 'company-b-secret']);
+        $this->em->clear();
+
+        $this->em->getFilters()->enable('company')->setParameter('companyId', $companyA);
+
+        $ids = $this->em->createQueryBuilder()
+            ->select('credential.id')
+            ->from(IngestionCredential::class, 'credential')
+            ->getQuery()
+            ->getSingleColumnResult();
+
+        self::assertCount(1, $ids);
+
+        $this->em->getFilters()->disable('company');
+    }
+}

--- a/site/tests/Unit/Ingestion/Infrastructure/Security/PlaintextSecretCodecTest.php
+++ b/site/tests/Unit/Ingestion/Infrastructure/Security/PlaintextSecretCodecTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Infrastructure\Security;
+
+use App\Ingestion\Infrastructure\Security\PlaintextSecretCodec;
+use PHPUnit\Framework\TestCase;
+
+final class PlaintextSecretCodecTest extends TestCase
+{
+    public function testEncodeDecodeVersionZeroReturnsOriginalPayload(): void
+    {
+        $codec = new PlaintextSecretCodec();
+        $payload = [
+            'api_key' => 'secret-api-key',
+            'client_id' => 'client-1',
+            'nested' => ['token' => 'secret-token'],
+        ];
+
+        $stored = $codec->encode($payload);
+
+        self::assertJson($stored);
+        self::assertSame($payload, $codec->decode($stored, PlaintextSecretCodec::KEY_VERSION));
+    }
+
+    public function testDecodeBranchesByKeyVersion(): void
+    {
+        $codec = new PlaintextSecretCodec();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported secret key version "1".');
+
+        $codec->decode('{"api_key":"secret-api-key"}', 1);
+    }
+}

--- a/site/tests/Unit/Ingestion/Infrastructure/Security/SecretPayloadMaskerTest.php
+++ b/site/tests/Unit/Ingestion/Infrastructure/Security/SecretPayloadMaskerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Infrastructure\Security;
+
+use App\Ingestion\Infrastructure\Security\SecretPayloadMasker;
+use PHPUnit\Framework\TestCase;
+
+final class SecretPayloadMaskerTest extends TestCase
+{
+    public function testMaskRemovesPayloadValuesFromOutput(): void
+    {
+        $payload = [
+            'api_key' => 'secret-api-key',
+            'client_id' => 'client-1',
+            'nested' => [
+                'token' => 'secret-token',
+                'nullable' => null,
+            ],
+        ];
+
+        $masked = (new SecretPayloadMasker())->mask($payload);
+
+        self::assertSame([
+            'api_key' => '***',
+            'client_id' => '***',
+            'nested' => [
+                'token' => '***',
+                'nullable' => null,
+            ],
+        ], $masked);
+
+        $encodedMasked = json_encode($masked, JSON_THROW_ON_ERROR);
+        self::assertStringNotContainsString('secret-api-key', $encodedMasked);
+        self::assertStringNotContainsString('client-1', $encodedMasked);
+        self::assertStringNotContainsString('secret-token', $encodedMasked);
+    }
+}


### PR DESCRIPTION
## What changed

- Added the `SecretCodec` contract and `PlaintextSecretCodec` implementation for plaintext JSON credential storage with `keyVersion = 0`.
- Added the `encrypted_json` Doctrine type that routes payload conversion through `SecretCodec` instead of sodium.
- Added `IngestionCredential` as a tenant-owned credential aggregate with `companyId`, `connectionRef`, `type`, `payload`, `keyVersion`, `expiresAt`, and timestamps.
- Added `CredentialFacade` with `store()`, `read()`, and masked read support.
- Added legacy fallback for existing `MarketplaceConnection.api_key/client_id` credentials so future Ozon integration can read through the facade before old data is migrated.
- Added `SecretPayloadMasker` for safe outward representations.
- Added migration for `ingestion_credentials`.

## Why

This creates a single credential storage seam without enabling real encryption yet. Future work can add a Sodium-backed codec for `keyVersion >= 1` and migrate plaintext rows without changing business code.

## Validation

- `docker compose run --rm site-php-cli php bin/phpunit --testsuite unit --filter 'PlaintextSecretCodecTest|SecretPayloadMaskerTest' --display-warnings --display-deprecations`
- `docker compose run --rm site-php-cli php bin/phpunit --testsuite integration --filter 'CredentialFacadeTest' --display-warnings --display-deprecations`
- `docker compose run --rm site-php-cli php bin/console lint:container --env=test`
- `git diff --cached --check`

Note: `make site-test-migrations` was not used for final validation because the existing test DB hits an older unrelated migration conflict on `telegram_bots.updated_at already exists`; the new migration was applied directly during local verification before the focused integration test.