### PR TITLE
[codex] Add shared raw object storage layer

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,7 +26,7 @@
 | `MarketplaceAnalytics` | Аналитика маркетплейсов (витрина) | — |
 | `MarketplaceAds` | Рекламные отчёты WB/Ozon: загрузка raw → распределение затрат | `string $companyId` ✅ |
 | `Inventory` | Загрузка raw-остатков маркетплейсов, нормализация в StockSnapshot, UI-отчёт остатков | `string $companyId` ✅ |
-| `Ingestion` | Каркас для будущих ingestion-пайплайнов и tenant-isolation foundation | `string $companyId` + Doctrine `company` filter ✅ |
+| `Ingestion` | Каркас для будущих ingestion-пайплайнов, credential seam и unified raw-слой | `string $companyId` + Doctrine `company` filter ✅ |
 | `Notification` | Каналы уведомлений (email и др.) | — |
 | `Shared` | Общий код: ActiveCompanyService, аудит, безопасность, storage | — |
 | `Admin` | Административная панель (отдельный firewall) | — |
@@ -68,6 +68,8 @@
 | `Location` | Inventory | `string $companyId` ✅ |
 | `StockSnapshot` | Inventory | `string $companyId` ✅ |
 | `IngestionTenantProbe` | Ingestion | `string $companyId` + Doctrine `company` filter ✅ |
+| `IngestionCredential` | Ingestion | `string $companyId` + Doctrine `company` filter ✅ |
+| `IngestRawRecord` | Ingestion | `string $companyId` + Doctrine `company` filter ✅ |
 | `ProductImport` | Catalog | `string $companyId` ✅ |
 | `ProductBarcode` | Catalog | `string $companyId` ✅ |
 | `ProductPurchasePrice` | Catalog | `string $companyId` ✅ |
@@ -84,6 +86,15 @@
 - HTTP-контекст без активной компании: admin, неавторизованные страницы, страница выбора компании и другие non-workspace запросы не включают filter и не должны падать с 500 из-за отсутствия компании.
 - Messenger-контекст: `CompanyFilterMiddleware` включает filter для сообщений `App\Ingestion\Message\CompanyAwareMessage`, берёт `companyId` из сообщения и восстанавливает прежнее состояние filter после обработки.
 - Системные запросы без tenant-контекста должны осознанно выполнять `$em->getFilters()->disable('company')` или не включать filter. Это допустимо для maintenance/admin/batch операций, где требуется видеть данные всех компаний.
+
+### Ingestion: raw storage
+
+- `RawStorageFacade` — единая точка записи/чтения raw payload для нового Ingestion-модуля. Legacy raw-сущности Marketplace/Inventory/Ads не меняются.
+- `IngestRawRecord` хранит только metadata: company/connection/shop/source/resource/external id, storage path, hash, byte size, fetched/sync timestamps и normalization status. Payload в БД не хранится.
+- Payload записывается как canonical NDJSON, gzip-compressed, один файл на `RawBatch` chunk. Путь: `{company}/{source}/{shop}/{resource}/{yyyy}/{mm}/{dd}/{syncJobId}/{externalId}/{hash}.ndjson.gz`, чтобы несколько batch внутри одного sync job не перезаписывали друг друга.
+- Dedup: перед записью сверяется SHA-256 hash canonical uncompressed NDJSON по `(companyId, source, externalId)`. Совпавший hash обновляет `lastSeenAt`; новый object не создаётся.
+- Storage seam общий для проекта: `App\Shared\Service\Storage\ObjectStorageInterface`. Default driver — `local`, он делегирует запись в существующий `StorageService`; S3 driver через Flysystem включается только явным `APP_OBJECT_STORAGE_DRIVER=s3` и `APP_OBJECT_STORAGE_S3_*`.
+- Legacy-модули пока продолжают использовать `StorageService` напрямую. Их переезд на `ObjectStorageInterface` выполняется отдельными задачами, по одному модулю.
 
 ### Marketplace: WB financial report sync status (дневной статус)
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -92,7 +92,7 @@
 - `RawStorageFacade` — единая точка записи/чтения raw payload для нового Ingestion-модуля. Legacy raw-сущности Marketplace/Inventory/Ads не меняются.
 - `IngestRawRecord` хранит только metadata: company/connection/shop/source/resource/external id, storage path, hash, byte size, fetched/sync timestamps и normalization status. Payload в БД не хранится.
 - Payload записывается как canonical NDJSON, gzip-compressed, один файл на `RawBatch` chunk. Путь: `{company}/{source}/{shop}/{resource}/{yyyy}/{mm}/{dd}/{syncJobId}/{externalId}/{hash}.ndjson.gz`, чтобы несколько batch внутри одного sync job не перезаписывали друг друга.
-- Dedup: перед записью сверяется SHA-256 hash canonical uncompressed NDJSON по `(companyId, source, externalId)`. Совпавший hash обновляет `lastSeenAt`; новый object не создаётся.
+- Dedup: перед записью сверяется SHA-256 hash canonical uncompressed NDJSON по `(companyId, source, resourceType, externalId)`. Совпавший hash обновляет `lastSeenAt`; новый object не создаётся.
 - Storage seam общий для проекта: `App\Shared\Service\Storage\ObjectStorageInterface`. Default driver — `local`, он делегирует запись в существующий `StorageService`; S3 driver через Flysystem включается только явным `APP_OBJECT_STORAGE_DRIVER=s3` и `APP_OBJECT_STORAGE_S3_*`.
 - Legacy-модули пока продолжают использовать `StorageService` напрямую. Их переезд на `ObjectStorageInterface` выполняется отдельными задачами, по одному модулю.
 

--- a/site/composer.json
+++ b/site/composer.json
@@ -13,6 +13,8 @@
         "doctrine/doctrine-bundle": "^2.18.2",
         "doctrine/doctrine-migrations-bundle": "^3.7",
         "doctrine/orm": "^3.6.3",
+        "league/flysystem": "^3.30",
+        "league/flysystem-aws-s3-v3": "^3.30",
         "nelmio/api-doc-bundle": "^5.10",
         "openspout/openspout": "4.28.5",
         "pagerfanta/doctrine-dbal-adapter": "^4.8",

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,8 +4,159 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "312fe708fc7205e17c6ade536b9e219f",
+    "content-hash": "93e5f261b5f245a35c3198ae4cff0c9f",
     "packages": [
+        {
+            "name": "aws/aws-crt-php",
+            "version": "v1.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/awslabs/aws-crt-php.git",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/awslabs/aws-crt-php/zipball/d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35||^5.6.3||^9.5",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "suggest": {
+                "ext-awscrt": "Make sure you install awscrt native extension to use any of the functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "AWS SDK Common Runtime Team",
+                    "email": "aws-sdk-common-runtime@amazon.com"
+                }
+            ],
+            "description": "AWS Common Runtime for PHP",
+            "homepage": "https://github.com/awslabs/aws-crt-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "crt",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/awslabs/aws-crt-php/issues",
+                "source": "https://github.com/awslabs/aws-crt-php/tree/v1.2.7"
+            },
+            "time": "2024-10-18T22:15:13+00:00"
+        },
+        {
+            "name": "aws/aws-sdk-php",
+            "version": "3.384.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aws/aws-sdk-php.git",
+                "reference": "71513f9c05ed1fde0fb95e8c7e7d3c88409d7de9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/71513f9c05ed1fde0fb95e8c7e7d3c88409d7de9",
+                "reference": "71513f9c05ed1fde0fb95e8c7e7d3c88409d7de9",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-crt-php": "^1.2.3",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/promises": "^2.0",
+                "guzzlehttp/psr7": "^2.4.5",
+                "mtdowling/jmespath.php": "^2.9.1",
+                "php": ">=8.1",
+                "psr/http-message": "^1.0 || ^2.0",
+                "symfony/filesystem": "^v5.4.45 || ^v6.4.3 || ^v7.1.0 || ^v8.0.0"
+            },
+            "require-dev": {
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "composer/composer": "^2.7.8",
+                "dms/phpunit-arraysubset-asserts": "^v0.5.0",
+                "doctrine/cache": "~1.4",
+                "ext-dom": "*",
+                "ext-openssl": "*",
+                "ext-sockets": "*",
+                "phpunit/phpunit": "^10.0",
+                "psr/cache": "^2.0 || ^3.0",
+                "psr/simple-cache": "^2.0 || ^3.0",
+                "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
+                "yoast/phpunit-polyfills": "^2.0"
+            },
+            "suggest": {
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
+                "ext-curl": "To send requests using cURL",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
+                "ext-pcntl": "To use client-side monitoring",
+                "ext-sockets": "To use client-side monitoring"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Aws\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/data/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Amazon Web Services",
+                    "homepage": "https://aws.amazon.com"
+                }
+            ],
+            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
+            "homepage": "https://aws.amazon.com/sdk-for-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "cloud",
+                "dynamodb",
+                "ec2",
+                "glacier",
+                "s3",
+                "sdk"
+            ],
+            "support": {
+                "forum": "https://github.com/aws/aws-sdk-php/discussions",
+                "issues": "https://github.com/aws/aws-sdk-php/issues",
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.384.9"
+            },
+            "time": "2026-06-12T18:10:49+00:00"
+        },
         {
             "name": "babdev/pagerfanta-bundle",
             "version": "v4.6.0",
@@ -1498,24 +1649,237 @@
             "time": "2025-03-06T22:45:56+00:00"
         },
         {
-            "name": "guzzlehttp/psr7",
-            "version": "2.9.0",
+            "name": "guzzlehttp/guzzle",
+            "version": "7.10.6",
             "source": {
                 "type": "git",
-                "url": "https://github.com/guzzle/psr7.git",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "e7412b3180912c01650cc66647f18c1d1cbe9b94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/e7412b3180912c01650cc66647f18c1d1cbe9b94",
+                "reference": "e7412b3180912c01650cc66647f18c1d1cbe9b94",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^2.3",
+                "guzzlehttp/psr7": "^2.8",
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-client": "^1.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "ext-curl": "*",
+                "guzzle/client-integration-tests": "3.0.2",
+                "guzzlehttp/test-server": "^0.4",
+                "php-http/message-factory": "^1.1",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
+                "psr/log": "^1.1 || ^2.0 || ^3.0"
+            },
+            "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Jeremy Lindblom",
+                    "email": "jeremeamia@gmail.com",
+                    "homepage": "https://github.com/jeremeamia"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "psr-18",
+                "psr-7",
+                "rest",
+                "web service"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/guzzle/issues",
+                "source": "https://github.com/guzzle/guzzle/tree/7.10.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/guzzle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-01T13:06:22+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "2.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/promises/issues",
+                "source": "https://github.com/guzzle/promises/tree/2.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/promises",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-02T12:23:43+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "2.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/bbb5e61349fa5cb822b3e87842b951088b76b81f",
+                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0"
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -1523,9 +1887,9 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "0.9.0",
+                "http-interop/http-factory-tests": "1.1.0",
                 "jshttp/mime-db": "1.54.0.1",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -1596,7 +1960,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.11.0"
             },
             "funding": [
                 {
@@ -1612,7 +1976,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-10T16:41:02+00:00"
+            "time": "2026-06-02T12:30:48+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",
@@ -1673,6 +2037,249 @@
                 "source": "https://github.com/Jean85/pretty-package-versions/tree/2.1.1"
             },
             "time": "2025-03-19T14:43:43+00:00"
+        },
+        {
+            "name": "league/flysystem",
+            "version": "3.34.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem.git",
+                "reference": "2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e",
+                "reference": "2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e",
+                "shasum": ""
+            },
+            "require": {
+                "league/flysystem-local": "^3.0.0",
+                "league/mime-type-detection": "^1.0.0",
+                "php": "^8.0.2"
+            },
+            "conflict": {
+                "async-aws/core": "<1.19.0",
+                "async-aws/s3": "<1.14.0",
+                "aws/aws-sdk-php": "3.209.31 || 3.210.0",
+                "guzzlehttp/guzzle": "<7.0",
+                "guzzlehttp/ringphp": "<1.1.1",
+                "phpseclib/phpseclib": "3.0.15",
+                "symfony/http-client": "<5.2"
+            },
+            "require-dev": {
+                "async-aws/s3": "^1.5 || ^2.0",
+                "async-aws/simple-s3": "^1.1 || ^2.0",
+                "aws/aws-sdk-php": "^3.295.10",
+                "composer/semver": "^3.0",
+                "ext-fileinfo": "*",
+                "ext-ftp": "*",
+                "ext-mongodb": "^1.3|^2",
+                "ext-zip": "*",
+                "friendsofphp/php-cs-fixer": "^3.5",
+                "google/cloud-storage": "^1.23",
+                "guzzlehttp/psr7": "^2.6",
+                "microsoft/azure-storage-blob": "^1.1",
+                "mongodb/mongodb": "^1.2|^2",
+                "phpseclib/phpseclib": "^3.0.36",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^9.5.11|^10.0",
+                "sabre/dav": "^4.6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "File storage abstraction for PHP",
+            "keywords": [
+                "WebDAV",
+                "aws",
+                "cloud",
+                "file",
+                "files",
+                "filesystem",
+                "filesystems",
+                "ftp",
+                "s3",
+                "sftp",
+                "storage"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/flysystem/issues",
+                "source": "https://github.com/thephpleague/flysystem/tree/3.34.0"
+            },
+            "time": "2026-05-14T10:28:08+00:00"
+        },
+        {
+            "name": "league/flysystem-aws-s3-v3",
+            "version": "3.34.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem-aws-s3-v3.git",
+                "reference": "0c62fdac907791d8649ad3c61cb7a77628344fb8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-aws-s3-v3/zipball/0c62fdac907791d8649ad3c61cb7a77628344fb8",
+                "reference": "0c62fdac907791d8649ad3c61cb7a77628344fb8",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-sdk-php": "^3.371.5",
+                "league/flysystem": "^3.10.0",
+                "league/mime-type-detection": "^1.0.0",
+                "php": "^8.0.2"
+            },
+            "conflict": {
+                "guzzlehttp/guzzle": "<7.0",
+                "guzzlehttp/ringphp": "<1.1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\AwsS3V3\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "AWS S3 filesystem adapter for Flysystem.",
+            "keywords": [
+                "Flysystem",
+                "aws",
+                "file",
+                "files",
+                "filesystem",
+                "s3",
+                "storage"
+            ],
+            "support": {
+                "source": "https://github.com/thephpleague/flysystem-aws-s3-v3/tree/3.34.0"
+            },
+            "time": "2026-05-04T08:24:00+00:00"
+        },
+        {
+            "name": "league/flysystem-local",
+            "version": "3.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem-local.git",
+                "reference": "2f669db18a4c20c755c2bb7d3a7b0b2340488079"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-local/zipball/2f669db18a4c20c755c2bb7d3a7b0b2340488079",
+                "reference": "2f669db18a4c20c755c2bb7d3a7b0b2340488079",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "league/flysystem": "^3.0.0",
+                "league/mime-type-detection": "^1.0.0",
+                "php": "^8.0.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\Local\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "Local filesystem adapter for Flysystem.",
+            "keywords": [
+                "Flysystem",
+                "file",
+                "files",
+                "filesystem",
+                "local"
+            ],
+            "support": {
+                "source": "https://github.com/thephpleague/flysystem-local/tree/3.31.0"
+            },
+            "time": "2026-01-23T15:30:45+00:00"
+        },
+        {
+            "name": "league/mime-type-detection",
+            "version": "1.16.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/mime-type-detection.git",
+                "reference": "2d6702ff215bf922936ccc1ad31007edc76451b9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/2d6702ff215bf922936ccc1ad31007edc76451b9",
+                "reference": "2d6702ff215bf922936ccc1ad31007edc76451b9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "phpstan/phpstan": "^0.12.68",
+                "phpunit/phpunit": "^8.5.8 || ^9.3 || ^10.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\MimeTypeDetection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "Mime-type detection for Flysystem",
+            "support": {
+                "issues": "https://github.com/thephpleague/mime-type-detection/issues",
+                "source": "https://github.com/thephpleague/mime-type-detection/tree/1.16.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/frankdejonge",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/league/flysystem",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-21T08:32:55+00:00"
         },
         {
             "name": "maennchen/zipstream-php",
@@ -1961,6 +2568,72 @@
                 }
             ],
             "time": "2026-01-02T08:56:05+00:00"
+        },
+        {
+            "name": "mtdowling/jmespath.php",
+            "version": "2.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jmespath/jmespath.php.git",
+                "reference": "9c208ba27ae7d90853c288b3795d6702eb251d34"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/9c208ba27ae7d90853c288b3795d6702eb251d34",
+                "reference": "9c208ba27ae7d90853c288b3795d6702eb251d34",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.17"
+            },
+            "require-dev": {
+                "composer/xdebug-handler": "^3.0.3",
+                "phpunit/phpunit": "^8.5.52"
+            },
+            "bin": [
+                "bin/jp.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.9-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/JmesPath.php"
+                ],
+                "psr-4": {
+                    "JmesPath\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Declaratively specify how to extract elements from a JSON document",
+            "keywords": [
+                "json",
+                "jsonpath"
+            ],
+            "support": {
+                "issues": "https://github.com/jmespath/jmespath.php/issues",
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.9.1"
+            },
+            "time": "2026-06-11T10:43:56+00:00"
         },
         {
             "name": "nelmio/api-doc-bundle",
@@ -3027,6 +3700,58 @@
                 "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
             },
             "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
         },
         {
             "name": "psr/http-factory",

--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -8,6 +8,13 @@ parameters:
     app.storage_root: '%kernel.project_dir%/var/storage'
     app.encryption.key_file: '%env(string:APP_ENCRYPTION_KEY_FILE)%'
     app.encryption.current_key_version: '%env(string:APP_ENCRYPTION_CURRENT_KEY_VERSION)%'
+    app.object_storage_driver_default: 'local'
+    app.object_storage_s3_bucket_default: ''
+    app.object_storage_s3_region_default: 'us-east-1'
+    app.object_storage_s3_endpoint_default: ''
+    app.object_storage_s3_access_key_default: ''
+    app.object_storage_s3_secret_key_default: ''
+    app.object_storage_s3_path_style_endpoint_default: '0'
     wb_finance.rate_limit_interval_seconds: 70
     wb_finance.retry_delay_ms: 70000
 
@@ -91,11 +98,32 @@ services:
     App\Marketplace\Application\Service\WbFinancialReportSyncPlannerInterface: '@App\Marketplace\Application\Service\WbFinancialReportSyncPlanner'
     App\Marketplace\Infrastructure\Api\Ozon\OzonSellerCredentialValidatorInterface: '@App\Marketplace\Infrastructure\Api\Ozon\OzonSellerCredentialValidator'
     App\Ingestion\Domain\Contract\SecretCodec: '@App\Ingestion\Infrastructure\Security\PlaintextSecretCodec'
+    App\Shared\Service\Storage\ObjectStorageInterface:
+        factory: ['@App\Shared\Service\Storage\ObjectStorageFactory', 'create']
+
+    App\Shared\Service\Storage\ObjectStorageFactory:
+        arguments:
+            $driver: '%env(default:app.object_storage_driver_default:APP_OBJECT_STORAGE_DRIVER)%'
+            $storages: !service_locator
+                local: '@App\Shared\Service\Storage\LocalObjectStorage'
+                s3: '@App\Shared\Service\Storage\FlysystemS3ObjectStorage'
+
+    App\Shared\Service\Storage\FlysystemS3ObjectStorage:
+        arguments:
+            $bucket: '%env(default:app.object_storage_s3_bucket_default:APP_OBJECT_STORAGE_S3_BUCKET)%'
+            $region: '%env(default:app.object_storage_s3_region_default:APP_OBJECT_STORAGE_S3_REGION)%'
+            $endpoint: '%env(default:app.object_storage_s3_endpoint_default:APP_OBJECT_STORAGE_S3_ENDPOINT)%'
+            $accessKey: '%env(default:app.object_storage_s3_access_key_default:APP_OBJECT_STORAGE_S3_ACCESS_KEY)%'
+            $secretKey: '%env(default:app.object_storage_s3_secret_key_default:APP_OBJECT_STORAGE_S3_SECRET_KEY)%'
+            $pathStyleEndpoint: '%env(default:app.object_storage_s3_path_style_endpoint_default:APP_OBJECT_STORAGE_S3_PATH_STYLE_ENDPOINT)%'
 
     App\Ingestion\Facade\CredentialFacade:
         public: true
         arguments:
             $activeKeyVersion: 0
+
+    App\Ingestion\Facade\RawStorageFacade:
+        public: true
 
     App\Marketplace\Application\Service\WbFinancialReportSyncStatusUpdaterInterface: '@App\Marketplace\Application\Service\WbFinancialReportSyncStatusUpdater'
     App\Marketplace\Application\Service\WbGeneratedRowsSafeReplaceServiceInterface: '@App\Marketplace\Application\Service\WbGeneratedRowsSafeReplaceService'

--- a/site/migrations/Version20240619120000.php
+++ b/site/migrations/Version20240619120000.php
@@ -24,7 +24,7 @@ final class Version20240619120000 extends AbstractMigration
         $this->addSql('DROP INDEX IF EXISTS IDX_DACD6ED979B1AD6');
         $this->addSql('ALTER TABLE telegram_bots DROP COLUMN IF EXISTS company_id');
 
-        $this->addSql("ALTER TABLE telegram_bots ADD updated_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NOW()");
+        $this->addSql("ALTER TABLE telegram_bots ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NOW()");
         $this->addSql('UPDATE telegram_bots SET updated_at = created_at WHERE updated_at IS NULL');
         $this->addSql('ALTER TABLE telegram_bots ALTER COLUMN updated_at SET NOT NULL');
         $this->addSql("COMMENT ON COLUMN telegram_bots.updated_at IS '(DC2Type:datetime_immutable)'");

--- a/site/migrations/Version20260615160000.php
+++ b/site/migrations/Version20260615160000.php
@@ -25,7 +25,7 @@ final class Version20260615160000 extends AbstractMigration
 
         $this->addSql('CREATE TABLE ingest_raw_records (id UUID NOT NULL, company_id UUID NOT NULL, connection_ref VARCHAR(255) NOT NULL, shop_ref VARCHAR(255) NOT NULL, source VARCHAR(64) NOT NULL, resource_type VARCHAR(100) NOT NULL, external_id VARCHAR(255) NOT NULL, storage_path VARCHAR(1024) NOT NULL, hash VARCHAR(64) NOT NULL, byte_size INT NOT NULL, fetched_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, last_seen_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, sync_job_id VARCHAR(100) NOT NULL, normalization_status VARCHAR(32) NOT NULL, created_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
         $this->addSql('CREATE INDEX idx_ingest_raw_company_source_resource_fetched ON ingest_raw_records (company_id, source, resource_type, fetched_at)');
-        $this->addSql('CREATE UNIQUE INDEX uniq_ingest_raw_company_source_external_hash ON ingest_raw_records (company_id, source, external_id, hash)');
+        $this->addSql('CREATE UNIQUE INDEX uniq_ingest_raw_company_source_resource_external_hash ON ingest_raw_records (company_id, source, resource_type, external_id, hash)');
     }
 
     public function down(Schema $schema): void

--- a/site/migrations/Version20260615160000.php
+++ b/site/migrations/Version20260615160000.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260615160000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create Ingestion raw record metadata table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        $this->abortIf(
+            !$platform instanceof PostgreSQLPlatform,
+            sprintf('Migration %s supports only PostgreSQL; got platform "%s".', self::class, $platform::class),
+        );
+
+        $this->addSql('CREATE TABLE ingest_raw_records (id UUID NOT NULL, company_id UUID NOT NULL, connection_ref VARCHAR(255) NOT NULL, shop_ref VARCHAR(255) NOT NULL, source VARCHAR(64) NOT NULL, resource_type VARCHAR(100) NOT NULL, external_id VARCHAR(255) NOT NULL, storage_path VARCHAR(1024) NOT NULL, hash VARCHAR(64) NOT NULL, byte_size INT NOT NULL, fetched_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, last_seen_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, sync_job_id VARCHAR(100) NOT NULL, normalization_status VARCHAR(32) NOT NULL, created_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX idx_ingest_raw_company_source_resource_fetched ON ingest_raw_records (company_id, source, resource_type, fetched_at)');
+        $this->addSql('CREATE UNIQUE INDEX uniq_ingest_raw_company_source_external_hash ON ingest_raw_records (company_id, source, external_id, hash)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        $this->abortIf(
+            !$platform instanceof PostgreSQLPlatform,
+            sprintf('Migration %s supports only PostgreSQL; got platform "%s".', self::class, $platform::class),
+        );
+
+        $this->addSql('DROP TABLE ingest_raw_records');
+    }
+}

--- a/site/migrations/Version20260615170000.php
+++ b/site/migrations/Version20260615170000.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260615170000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Ensure Ingestion raw record dedup unique index includes resource type';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        $this->abortIf(
+            !$platform instanceof PostgreSQLPlatform,
+            sprintf('Migration %s supports only PostgreSQL; got platform "%s".', self::class, $platform::class),
+        );
+
+        $this->addSql('DROP INDEX IF EXISTS uniq_ingest_raw_company_source_external_hash');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS uniq_ingest_raw_company_source_resource_external_hash ON ingest_raw_records (company_id, source, resource_type, external_id, hash)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        $this->abortIf(
+            !$platform instanceof PostgreSQLPlatform,
+            sprintf('Migration %s supports only PostgreSQL; got platform "%s".', self::class, $platform::class),
+        );
+
+        $this->addSql('DROP INDEX IF EXISTS uniq_ingest_raw_company_source_resource_external_hash');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS uniq_ingest_raw_company_source_external_hash ON ingest_raw_records (company_id, source, external_id, hash)');
+    }
+}

--- a/site/src/Ingestion/Application/ReadRawRecordAction.php
+++ b/site/src/Ingestion/Application/ReadRawRecordAction.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application;
+
+use App\Ingestion\Exception\RawRecordNotFoundException;
+use App\Ingestion\Infrastructure\Storage\RawNdjsonCodec;
+use App\Ingestion\Repository\IngestRawRecordRepository;
+use App\Shared\Service\Storage\ObjectStorageInterface;
+use Webmozart\Assert\Assert;
+
+final readonly class ReadRawRecordAction
+{
+    public function __construct(
+        private IngestRawRecordRepository $rawRecordRepository,
+        private ObjectStorageInterface $objectStorage,
+        private RawNdjsonCodec $ndjsonCodec,
+    ) {
+    }
+
+    /**
+     * @return iterable<array<string, mixed>>
+     */
+    public function __invoke(string $rawRecordId, string $companyId): iterable
+    {
+        Assert::uuid($rawRecordId);
+        Assert::uuid($companyId);
+
+        $record = $this->rawRecordRepository->findOneByIdAndCompany($companyId, $rawRecordId);
+        if (null === $record) {
+            throw new RawRecordNotFoundException('Raw record not found for requested company.');
+        }
+
+        return $this->ndjsonCodec->decodeCompressedRows($this->objectStorage->read($record->getStoragePath()));
+    }
+}

--- a/site/src/Ingestion/Application/StoreRawBatchAction.php
+++ b/site/src/Ingestion/Application/StoreRawBatchAction.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application;
+
+use App\Ingestion\DTO\RawBatch;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Exception\RawStorageException;
+use App\Ingestion\Infrastructure\Storage\RawNdjsonCodec;
+use App\Ingestion\Infrastructure\Storage\RawStoragePathBuilder;
+use App\Ingestion\Repository\IngestRawRecordRepository;
+use App\Shared\Service\Storage\ObjectStorageInterface;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class StoreRawBatchAction
+{
+    public function __construct(
+        private IngestRawRecordRepository $rawRecordRepository,
+        private ObjectStorageInterface $objectStorage,
+        private RawNdjsonCodec $ndjsonCodec,
+        private RawStoragePathBuilder $pathBuilder,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    /**
+     * @return list<IngestRawRecord>
+     */
+    public function __invoke(RawBatch $batch): array
+    {
+        $ndjson = $this->ndjsonCodec->encodeRows($batch->rows);
+        $hash = hash('sha256', $ndjson);
+
+        $latestRecord = $this->rawRecordRepository->findLatestByCompanySourceExternalId(
+            $batch->companyId,
+            $batch->source,
+            $batch->externalId,
+        );
+
+        if (null !== $latestRecord && $latestRecord->getHash() === $hash) {
+            $latestRecord->markSeen();
+            $this->entityManager->flush();
+
+            return [$latestRecord];
+        }
+
+        $existingRecord = $this->rawRecordRepository->findOneByCompanySourceExternalIdAndHash(
+            $batch->companyId,
+            $batch->source,
+            $batch->externalId,
+            $hash,
+        );
+
+        if (null !== $existingRecord) {
+            $existingRecord->markSeen();
+            $this->entityManager->flush();
+
+            return [$existingRecord];
+        }
+
+        $compressed = gzencode($ndjson, 6);
+        if (false === $compressed) {
+            throw new RawStorageException('Failed to gzip raw payload.');
+        }
+
+        $storagePath = $this->pathBuilder->build($batch, $hash);
+        $storedObject = $this->objectStorage->write($storagePath, $compressed);
+
+        $record = new IngestRawRecord(
+            companyId: $batch->companyId,
+            connectionRef: $batch->connectionRef,
+            shopRef: $batch->shopRef,
+            source: $batch->source,
+            resourceType: $batch->resourceType,
+            externalId: $batch->externalId,
+            storagePath: $storedObject->path,
+            hash: $hash,
+            byteSize: $storedObject->byteSize,
+            fetchedAt: $batch->fetchedAt,
+            syncJobId: $batch->syncJobId,
+        );
+
+        $this->entityManager->persist($record);
+        $this->entityManager->flush();
+
+        return [$record];
+    }
+}

--- a/site/src/Ingestion/Application/StoreRawBatchAction.php
+++ b/site/src/Ingestion/Application/StoreRawBatchAction.php
@@ -11,7 +11,9 @@ use App\Ingestion\Infrastructure\Storage\RawNdjsonCodec;
 use App\Ingestion\Infrastructure\Storage\RawStoragePathBuilder;
 use App\Ingestion\Repository\IngestRawRecordRepository;
 use App\Shared\Service\Storage\ObjectStorageInterface;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 final readonly class StoreRawBatchAction
 {
@@ -21,6 +23,7 @@ final readonly class StoreRawBatchAction
         private RawNdjsonCodec $ndjsonCodec,
         private RawStoragePathBuilder $pathBuilder,
         private EntityManagerInterface $entityManager,
+        private ManagerRegistry $managerRegistry,
     ) {
     }
 
@@ -35,6 +38,7 @@ final readonly class StoreRawBatchAction
         $latestRecord = $this->rawRecordRepository->findLatestByCompanySourceExternalId(
             $batch->companyId,
             $batch->source,
+            $batch->resourceType,
             $batch->externalId,
         );
 
@@ -48,6 +52,7 @@ final readonly class StoreRawBatchAction
         $existingRecord = $this->rawRecordRepository->findOneByCompanySourceExternalIdAndHash(
             $batch->companyId,
             $batch->source,
+            $batch->resourceType,
             $batch->externalId,
             $hash,
         );
@@ -82,8 +87,55 @@ final readonly class StoreRawBatchAction
         );
 
         $this->entityManager->persist($record);
-        $this->entityManager->flush();
+        try {
+            $this->entityManager->flush();
+        } catch (UniqueConstraintViolationException $exception) {
+            return [$this->recoverConcurrentDuplicate($batch, $hash, $exception)];
+        }
 
         return [$record];
+    }
+
+    private function recoverConcurrentDuplicate(
+        RawBatch $batch,
+        string $hash,
+        UniqueConstraintViolationException $exception,
+    ): IngestRawRecord {
+        $entityManager = $this->entityManager;
+        $repository = $this->rawRecordRepository;
+
+        if ($entityManager->isOpen()) {
+            $entityManager->clear();
+        } else {
+            $resetManager = $this->managerRegistry->resetManager();
+            if (!$resetManager instanceof EntityManagerInterface) {
+                throw $exception;
+            }
+
+            $entityManager = $resetManager;
+            $resetRepository = $entityManager->getRepository(IngestRawRecord::class);
+            if (!$resetRepository instanceof IngestRawRecordRepository) {
+                throw $exception;
+            }
+
+            $repository = $resetRepository;
+        }
+
+        $existingRecord = $repository->findOneByCompanySourceExternalIdAndHash(
+            $batch->companyId,
+            $batch->source,
+            $batch->resourceType,
+            $batch->externalId,
+            $hash,
+        );
+
+        if (null === $existingRecord) {
+            throw $exception;
+        }
+
+        $existingRecord->markSeen();
+        $entityManager->flush();
+
+        return $existingRecord;
     }
 }

--- a/site/src/Ingestion/DTO/RawBatch.php
+++ b/site/src/Ingestion/DTO/RawBatch.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\DTO;
+
+use App\Ingestion\Enum\IngestSource;
+use Webmozart\Assert\Assert;
+
+final readonly class RawBatch
+{
+    /**
+     * @param iterable<array<string, mixed>> $rows
+     */
+    public function __construct(
+        public string $companyId,
+        public string $connectionRef,
+        public string $shopRef,
+        public IngestSource $source,
+        public string $resourceType,
+        public string $externalId,
+        public string $syncJobId,
+        public \DateTimeImmutable $fetchedAt,
+        public iterable $rows,
+    ) {
+        Assert::uuid($this->companyId);
+        Assert::notEmpty($this->connectionRef);
+        Assert::notEmpty($this->shopRef);
+        Assert::notEmpty($this->resourceType);
+        Assert::notEmpty($this->externalId);
+        Assert::notEmpty($this->syncJobId);
+    }
+}

--- a/site/src/Ingestion/Entity/IngestRawRecord.php
+++ b/site/src/Ingestion/Entity/IngestRawRecord.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Entity;
+
+use App\Ingestion\Domain\TenantOwnedInterface;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\RawNormalizationStatus;
+use App\Ingestion\Repository\IngestRawRecordRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity(repositoryClass: IngestRawRecordRepository::class)]
+#[ORM\Table(name: 'ingest_raw_records')]
+#[ORM\Index(columns: ['company_id', 'source', 'resource_type', 'fetched_at'], name: 'idx_ingest_raw_company_source_resource_fetched')]
+#[ORM\UniqueConstraint(name: 'uniq_ingest_raw_company_source_external_hash', columns: ['company_id', 'source', 'external_id', 'hash'])]
+class IngestRawRecord implements TenantOwnedInterface
+{
+    #[ORM\Id]
+    #[ORM\Column(type: Types::GUID)]
+    private string $id;
+
+    #[ORM\Column(type: Types::GUID)]
+    private string $companyId;
+
+    #[ORM\Column(type: Types::STRING, length: 255)]
+    private string $connectionRef;
+
+    #[ORM\Column(type: Types::STRING, length: 255)]
+    private string $shopRef;
+
+    #[ORM\Column(type: Types::STRING, length: 64, enumType: IngestSource::class)]
+    private IngestSource $source;
+
+    #[ORM\Column(type: Types::STRING, length: 100)]
+    private string $resourceType;
+
+    #[ORM\Column(type: Types::STRING, length: 255)]
+    private string $externalId;
+
+    #[ORM\Column(type: Types::STRING, length: 1024)]
+    private string $storagePath;
+
+    #[ORM\Column(type: Types::STRING, length: 64)]
+    private string $hash;
+
+    #[ORM\Column(type: Types::INTEGER)]
+    private int $byteSize;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6)]
+    private \DateTimeImmutable $fetchedAt;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6)]
+    private \DateTimeImmutable $lastSeenAt;
+
+    #[ORM\Column(type: Types::STRING, length: 100)]
+    private string $syncJobId;
+
+    #[ORM\Column(type: Types::STRING, length: 32, enumType: RawNormalizationStatus::class)]
+    private RawNormalizationStatus $normalizationStatus = RawNormalizationStatus::PENDING;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6)]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6)]
+    private \DateTimeImmutable $updatedAt;
+
+    public function __construct(
+        string $companyId,
+        string $connectionRef,
+        string $shopRef,
+        IngestSource $source,
+        string $resourceType,
+        string $externalId,
+        string $storagePath,
+        string $hash,
+        int $byteSize,
+        \DateTimeImmutable $fetchedAt,
+        string $syncJobId,
+    ) {
+        Assert::uuid($companyId);
+        Assert::notEmpty($connectionRef);
+        Assert::notEmpty($shopRef);
+        Assert::notEmpty($resourceType);
+        Assert::notEmpty($externalId);
+        Assert::notEmpty($storagePath);
+        Assert::length($hash, 64);
+        Assert::natural($byteSize);
+        Assert::notEmpty($syncJobId);
+
+        $now = new \DateTimeImmutable();
+
+        $this->id = Uuid::uuid7()->toString();
+        $this->companyId = $companyId;
+        $this->connectionRef = $connectionRef;
+        $this->shopRef = $shopRef;
+        $this->source = $source;
+        $this->resourceType = $resourceType;
+        $this->externalId = $externalId;
+        $this->storagePath = $storagePath;
+        $this->hash = $hash;
+        $this->byteSize = $byteSize;
+        $this->fetchedAt = $fetchedAt;
+        $this->lastSeenAt = $now;
+        $this->syncJobId = $syncJobId;
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getCompanyId(): string
+    {
+        return $this->companyId;
+    }
+
+    public function getConnectionRef(): string
+    {
+        return $this->connectionRef;
+    }
+
+    public function getShopRef(): string
+    {
+        return $this->shopRef;
+    }
+
+    public function getSource(): IngestSource
+    {
+        return $this->source;
+    }
+
+    public function getResourceType(): string
+    {
+        return $this->resourceType;
+    }
+
+    public function getExternalId(): string
+    {
+        return $this->externalId;
+    }
+
+    public function getStoragePath(): string
+    {
+        return $this->storagePath;
+    }
+
+    public function getHash(): string
+    {
+        return $this->hash;
+    }
+
+    public function getByteSize(): int
+    {
+        return $this->byteSize;
+    }
+
+    public function getFetchedAt(): \DateTimeImmutable
+    {
+        return $this->fetchedAt;
+    }
+
+    public function getLastSeenAt(): \DateTimeImmutable
+    {
+        return $this->lastSeenAt;
+    }
+
+    public function getSyncJobId(): string
+    {
+        return $this->syncJobId;
+    }
+
+    public function getNormalizationStatus(): RawNormalizationStatus
+    {
+        return $this->normalizationStatus;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function markSeen(?\DateTimeImmutable $seenAt = null): void
+    {
+        $this->lastSeenAt = $seenAt ?? new \DateTimeImmutable();
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+}

--- a/site/src/Ingestion/Entity/IngestRawRecord.php
+++ b/site/src/Ingestion/Entity/IngestRawRecord.php
@@ -16,7 +16,7 @@ use Webmozart\Assert\Assert;
 #[ORM\Entity(repositoryClass: IngestRawRecordRepository::class)]
 #[ORM\Table(name: 'ingest_raw_records')]
 #[ORM\Index(columns: ['company_id', 'source', 'resource_type', 'fetched_at'], name: 'idx_ingest_raw_company_source_resource_fetched')]
-#[ORM\UniqueConstraint(name: 'uniq_ingest_raw_company_source_external_hash', columns: ['company_id', 'source', 'external_id', 'hash'])]
+#[ORM\UniqueConstraint(name: 'uniq_ingest_raw_company_source_resource_external_hash', columns: ['company_id', 'source', 'resource_type', 'external_id', 'hash'])]
 class IngestRawRecord implements TenantOwnedInterface
 {
     #[ORM\Id]

--- a/site/src/Ingestion/Enum/IngestSource.php
+++ b/site/src/Ingestion/Enum/IngestSource.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Enum;
+
+enum IngestSource: string
+{
+    case OZON = 'ozon';
+    case WILDBERRIES = 'wildberries';
+    case OZON_PERFORMANCE = 'ozon_performance';
+}

--- a/site/src/Ingestion/Enum/RawNormalizationStatus.php
+++ b/site/src/Ingestion/Enum/RawNormalizationStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Enum;
+
+enum RawNormalizationStatus: string
+{
+    case PENDING = 'pending';
+    case DONE = 'done';
+    case FAILED = 'failed';
+}

--- a/site/src/Ingestion/Exception/RawRecordNotFoundException.php
+++ b/site/src/Ingestion/Exception/RawRecordNotFoundException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Exception;
+
+final class RawRecordNotFoundException extends \RuntimeException
+{
+}

--- a/site/src/Ingestion/Exception/RawStorageException.php
+++ b/site/src/Ingestion/Exception/RawStorageException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Exception;
+
+final class RawStorageException extends \RuntimeException
+{
+}

--- a/site/src/Ingestion/Facade/RawStorageFacade.php
+++ b/site/src/Ingestion/Facade/RawStorageFacade.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Facade;
+
+use App\Ingestion\Application\ReadRawRecordAction;
+use App\Ingestion\Application\StoreRawBatchAction;
+use App\Ingestion\DTO\RawBatch;
+use App\Ingestion\Entity\IngestRawRecord;
+
+final readonly class RawStorageFacade
+{
+    public function __construct(
+        private StoreRawBatchAction $storeRawBatchAction,
+        private ReadRawRecordAction $readRawRecordAction,
+    ) {
+    }
+
+    /**
+     * @return list<IngestRawRecord>
+     */
+    public function store(RawBatch $batch): array
+    {
+        return ($this->storeRawBatchAction)($batch);
+    }
+
+    /**
+     * @return iterable<array<string, mixed>>
+     */
+    public function read(string $rawRecordId, string $companyId): iterable
+    {
+        return ($this->readRawRecordAction)($rawRecordId, $companyId);
+    }
+}

--- a/site/src/Ingestion/Infrastructure/Storage/PathSegmentNormalizer.php
+++ b/site/src/Ingestion/Infrastructure/Storage/PathSegmentNormalizer.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Storage;
+
+use Webmozart\Assert\Assert;
+
+final class PathSegmentNormalizer
+{
+    public function normalize(string $segment): string
+    {
+        $segment = trim($segment);
+        Assert::notEmpty($segment);
+
+        $normalized = preg_replace('/[^A-Za-z0-9._=-]+/', '-', $segment);
+        if (null === $normalized) {
+            throw new \InvalidArgumentException('Failed to normalize storage path segment.');
+        }
+
+        $normalized = trim($normalized, '-.');
+        Assert::notEmpty($normalized);
+
+        return $normalized;
+    }
+}

--- a/site/src/Ingestion/Infrastructure/Storage/RawNdjsonCodec.php
+++ b/site/src/Ingestion/Infrastructure/Storage/RawNdjsonCodec.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Storage;
+
+use App\Ingestion\Exception\RawStorageException;
+
+final class RawNdjsonCodec
+{
+    /**
+     * @param iterable<array<string, mixed>> $rows
+     */
+    public function encodeRows(iterable $rows): string
+    {
+        $lines = [];
+
+        foreach ($rows as $row) {
+            $lines[] = json_encode(
+                $this->normalizeValue($row),
+                \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES | \JSON_PRESERVE_ZERO_FRACTION,
+            );
+        }
+
+        if ([] === $lines) {
+            throw new RawStorageException('Raw batch must contain at least one row.');
+        }
+
+        return implode("\n", $lines)."\n";
+    }
+
+    /**
+     * @return iterable<array<string, mixed>>
+     */
+    public function decodeCompressedRows(string $compressedPayload): iterable
+    {
+        $payload = gzdecode($compressedPayload);
+        if (false === $payload) {
+            throw new RawStorageException('Failed to decode gzip raw payload.');
+        }
+
+        foreach (explode("\n", $payload) as $line) {
+            if ('' === $line) {
+                continue;
+            }
+
+            $row = json_decode($line, true, 512, \JSON_THROW_ON_ERROR);
+            if (!is_array($row)) {
+                throw new RawStorageException('Decoded raw payload row is not an object.');
+            }
+
+            yield $row;
+        }
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    private function normalizeValue(mixed $value): mixed
+    {
+        if (!is_array($value)) {
+            return $value;
+        }
+
+        if (array_is_list($value)) {
+            return array_map($this->normalizeValue(...), $value);
+        }
+
+        ksort($value);
+
+        foreach ($value as $key => $nestedValue) {
+            $value[$key] = $this->normalizeValue($nestedValue);
+        }
+
+        return $value;
+    }
+}

--- a/site/src/Ingestion/Infrastructure/Storage/RawStoragePathBuilder.php
+++ b/site/src/Ingestion/Infrastructure/Storage/RawStoragePathBuilder.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Storage;
+
+use App\Ingestion\DTO\RawBatch;
+
+final readonly class RawStoragePathBuilder
+{
+    public function __construct(private PathSegmentNormalizer $pathSegmentNormalizer)
+    {
+    }
+
+    public function build(RawBatch $batch, string $hash): string
+    {
+        return sprintf(
+            '%s/%s/%s/%s/%s/%s/%s/%s/%s/%s.ndjson.gz',
+            $this->pathSegmentNormalizer->normalize($batch->companyId),
+            $this->pathSegmentNormalizer->normalize($batch->source->value),
+            $this->pathSegmentNormalizer->normalize($batch->shopRef),
+            $this->pathSegmentNormalizer->normalize($batch->resourceType),
+            $batch->fetchedAt->format('Y'),
+            $batch->fetchedAt->format('m'),
+            $batch->fetchedAt->format('d'),
+            $this->pathSegmentNormalizer->normalize($batch->syncJobId),
+            $this->pathSegmentNormalizer->normalize($batch->externalId),
+            $this->pathSegmentNormalizer->normalize($hash),
+        );
+    }
+}

--- a/site/src/Ingestion/Repository/IngestRawRecordRepository.php
+++ b/site/src/Ingestion/Repository/IngestRawRecordRepository.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Repository;
+
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\IngestSource;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<IngestRawRecord>
+ */
+final class IngestRawRecordRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, IngestRawRecord::class);
+    }
+
+    public function findOneByIdAndCompany(string $companyId, string $rawRecordId): ?IngestRawRecord
+    {
+        return $this->createQueryBuilder('record')
+            ->andWhere('record.companyId = :companyId')
+            ->andWhere('record.id = :rawRecordId')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('rawRecordId', $rawRecordId)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    public function findLatestByCompanySourceExternalId(
+        string $companyId,
+        IngestSource $source,
+        string $externalId,
+    ): ?IngestRawRecord {
+        return $this->createQueryBuilder('record')
+            ->andWhere('record.companyId = :companyId')
+            ->andWhere('record.source = :source')
+            ->andWhere('record.externalId = :externalId')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('source', $source)
+            ->setParameter('externalId', $externalId)
+            ->orderBy('record.fetchedAt', 'DESC')
+            ->addOrderBy('record.createdAt', 'DESC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    public function findOneByCompanySourceExternalIdAndHash(
+        string $companyId,
+        IngestSource $source,
+        string $externalId,
+        string $hash,
+    ): ?IngestRawRecord {
+        return $this->createQueryBuilder('record')
+            ->andWhere('record.companyId = :companyId')
+            ->andWhere('record.source = :source')
+            ->andWhere('record.externalId = :externalId')
+            ->andWhere('record.hash = :hash')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('source', $source)
+            ->setParameter('externalId', $externalId)
+            ->setParameter('hash', $hash)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+}

--- a/site/src/Ingestion/Repository/IngestRawRecordRepository.php
+++ b/site/src/Ingestion/Repository/IngestRawRecordRepository.php
@@ -33,14 +33,17 @@ final class IngestRawRecordRepository extends ServiceEntityRepository
     public function findLatestByCompanySourceExternalId(
         string $companyId,
         IngestSource $source,
+        string $resourceType,
         string $externalId,
     ): ?IngestRawRecord {
         return $this->createQueryBuilder('record')
             ->andWhere('record.companyId = :companyId')
             ->andWhere('record.source = :source')
+            ->andWhere('record.resourceType = :resourceType')
             ->andWhere('record.externalId = :externalId')
             ->setParameter('companyId', $companyId)
             ->setParameter('source', $source)
+            ->setParameter('resourceType', $resourceType)
             ->setParameter('externalId', $externalId)
             ->orderBy('record.fetchedAt', 'DESC')
             ->addOrderBy('record.createdAt', 'DESC')
@@ -52,16 +55,19 @@ final class IngestRawRecordRepository extends ServiceEntityRepository
     public function findOneByCompanySourceExternalIdAndHash(
         string $companyId,
         IngestSource $source,
+        string $resourceType,
         string $externalId,
         string $hash,
     ): ?IngestRawRecord {
         return $this->createQueryBuilder('record')
             ->andWhere('record.companyId = :companyId')
             ->andWhere('record.source = :source')
+            ->andWhere('record.resourceType = :resourceType')
             ->andWhere('record.externalId = :externalId')
             ->andWhere('record.hash = :hash')
             ->setParameter('companyId', $companyId)
             ->setParameter('source', $source)
+            ->setParameter('resourceType', $resourceType)
             ->setParameter('externalId', $externalId)
             ->setParameter('hash', $hash)
             ->getQuery()

--- a/site/src/Shared/Service/Storage/FlysystemS3ObjectStorage.php
+++ b/site/src/Shared/Service/Storage/FlysystemS3ObjectStorage.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Service\Storage;
+
+use Aws\S3\S3Client;
+use League\Flysystem\AwsS3V3\AwsS3V3Adapter;
+use League\Flysystem\Filesystem;
+use League\Flysystem\FilesystemException;
+use Webmozart\Assert\Assert;
+
+final class FlysystemS3ObjectStorage implements ObjectStorageInterface
+{
+    private Filesystem $filesystem;
+
+    public function __construct(
+        string $bucket,
+        string $region,
+        string $endpoint = '',
+        string $accessKey = '',
+        string $secretKey = '',
+        string $pathStyleEndpoint = '0',
+    ) {
+        Assert::notEmpty($bucket);
+        Assert::notEmpty($region);
+
+        $clientConfig = [
+            'version' => 'latest',
+            'region' => $region,
+        ];
+
+        if ('' !== $endpoint) {
+            $clientConfig['endpoint'] = $endpoint;
+        }
+
+        if ('' !== $accessKey || '' !== $secretKey) {
+            $clientConfig['credentials'] = [
+                'key' => $accessKey,
+                'secret' => $secretKey,
+            ];
+        }
+
+        if (in_array(strtolower($pathStyleEndpoint), ['1', 'true', 'yes'], true)) {
+            $clientConfig['use_path_style_endpoint'] = true;
+        }
+
+        $this->filesystem = new Filesystem(new AwsS3V3Adapter(new S3Client($clientConfig), $bucket));
+    }
+
+    public function write(string $path, string $contents): StoredObject
+    {
+        try {
+            $this->filesystem->write($path, $contents);
+        } catch (FilesystemException $exception) {
+            throw new ObjectStorageException(sprintf('Failed to write object "%s".', $path), 0, $exception);
+        }
+
+        return new StoredObject($path, strlen($contents));
+    }
+
+    public function read(string $path): string
+    {
+        try {
+            return $this->filesystem->read($path);
+        } catch (FilesystemException $exception) {
+            throw new ObjectStorageException(sprintf('Failed to read object "%s".', $path), 0, $exception);
+        }
+    }
+
+    public function exists(string $path): bool
+    {
+        try {
+            return $this->filesystem->fileExists($path);
+        } catch (FilesystemException $exception) {
+            throw new ObjectStorageException(sprintf('Failed to check object "%s".', $path), 0, $exception);
+        }
+    }
+}

--- a/site/src/Shared/Service/Storage/LocalObjectStorage.php
+++ b/site/src/Shared/Service/Storage/LocalObjectStorage.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Service\Storage;
+
+final readonly class LocalObjectStorage implements ObjectStorageInterface
+{
+    public function __construct(private StorageService $storageService)
+    {
+    }
+
+    public function write(string $path, string $contents): StoredObject
+    {
+        $stored = $this->storageService->storeBytes($contents, $path);
+
+        return new StoredObject($stored['storagePath'], $stored['sizeBytes']);
+    }
+
+    public function read(string $path): string
+    {
+        $contents = file_get_contents($this->storageService->getAbsolutePath($path));
+        if (false === $contents) {
+            throw new ObjectStorageException(sprintf('Failed to read object "%s".', $path));
+        }
+
+        return $contents;
+    }
+
+    public function exists(string $path): bool
+    {
+        return is_file($this->storageService->getAbsolutePath($path));
+    }
+}

--- a/site/src/Shared/Service/Storage/ObjectStorageException.php
+++ b/site/src/Shared/Service/Storage/ObjectStorageException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Service\Storage;
+
+final class ObjectStorageException extends \RuntimeException
+{
+}

--- a/site/src/Shared/Service/Storage/ObjectStorageFactory.php
+++ b/site/src/Shared/Service/Storage/ObjectStorageFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Service\Storage;
+
+use Psr\Container\ContainerInterface;
+use Webmozart\Assert\Assert;
+
+final readonly class ObjectStorageFactory
+{
+    public function __construct(
+        private ContainerInterface $storages,
+        private string $driver,
+    ) {
+    }
+
+    public function create(): ObjectStorageInterface
+    {
+        $driver = '' === trim($this->driver) ? 'local' : trim($this->driver);
+        Assert::oneOf($driver, ['local', 's3']);
+
+        /** @var ObjectStorageInterface $storage */
+        $storage = $this->storages->get($driver);
+
+        return $storage;
+    }
+}

--- a/site/src/Shared/Service/Storage/ObjectStorageInterface.php
+++ b/site/src/Shared/Service/Storage/ObjectStorageInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Service\Storage;
+
+interface ObjectStorageInterface
+{
+    public function write(string $path, string $contents): StoredObject;
+
+    public function read(string $path): string;
+
+    public function exists(string $path): bool;
+}

--- a/site/src/Shared/Service/Storage/StoredObject.php
+++ b/site/src/Shared/Service/Storage/StoredObject.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Service\Storage;
+
+use Webmozart\Assert\Assert;
+
+final readonly class StoredObject
+{
+    public function __construct(
+        public string $path,
+        public int $byteSize,
+    ) {
+        Assert::notEmpty($this->path);
+        Assert::natural($this->byteSize);
+    }
+}

--- a/site/tests/Builders/Ingestion/IngestRawRecordBuilder.php
+++ b/site/tests/Builders/Ingestion/IngestRawRecordBuilder.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Builders\Ingestion;
+
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\IngestSource;
+use Ramsey\Uuid\Uuid;
+
+final class IngestRawRecordBuilder
+{
+    private string $companyId;
+    private string $connectionRef = 'connection-1';
+    private string $shopRef = 'shop-1';
+    private IngestSource $source = IngestSource::OZON;
+    private string $resourceType = 'seller-report';
+    private string $externalId = 'external-1';
+    private string $storagePath = 'company/ozon/shop/seller-report/2026/06/15/job-1.ndjson.gz';
+    private string $hash = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    private int $byteSize = 100;
+    private \DateTimeImmutable $fetchedAt;
+    private string $syncJobId = 'job-1';
+
+    public function __construct()
+    {
+        $this->companyId = Uuid::uuid7()->toString();
+        $this->fetchedAt = new \DateTimeImmutable('2026-06-15 12:00:00');
+    }
+
+    public static function aRawRecord(): self
+    {
+        return new self();
+    }
+
+    public function withCompanyId(string $companyId): self
+    {
+        $this->companyId = $companyId;
+
+        return $this;
+    }
+
+    public function withStoragePath(string $storagePath): self
+    {
+        $this->storagePath = $storagePath;
+
+        return $this;
+    }
+
+    public function build(): IngestRawRecord
+    {
+        return new IngestRawRecord(
+            companyId: $this->companyId,
+            connectionRef: $this->connectionRef,
+            shopRef: $this->shopRef,
+            source: $this->source,
+            resourceType: $this->resourceType,
+            externalId: $this->externalId,
+            storagePath: $this->storagePath,
+            hash: $this->hash,
+            byteSize: $this->byteSize,
+            fetchedAt: $this->fetchedAt,
+            syncJobId: $this->syncJobId,
+        );
+    }
+}

--- a/site/tests/Integration/Ingestion/RawStorageFacadeTest.php
+++ b/site/tests/Integration/Ingestion/RawStorageFacadeTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion;
+
+use App\Ingestion\DTO\RawBatch;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Exception\RawRecordNotFoundException;
+use App\Ingestion\Facade\RawStorageFacade;
+use App\Shared\Service\Storage\ObjectStorageInterface;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class RawStorageFacadeTest extends IntegrationTestCase
+{
+    public function testStoreWritesObjectAndMetadataThenReadReturnsRows(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $rows = [
+            ['sku' => 'SKU-1', 'qty' => 2],
+            ['sku' => 'SKU-2', 'qty' => 0],
+        ];
+
+        /** @var RawStorageFacade $facade */
+        $facade = self::getContainer()->get(RawStorageFacade::class);
+        /** @var ObjectStorageInterface $storage */
+        $storage = self::getContainer()->get(ObjectStorageInterface::class);
+
+        $records = $facade->store($this->batch($companyId, rows: $rows));
+
+        self::assertCount(1, $records);
+        $record = $records[0];
+        self::assertSame($companyId, $record->getCompanyId());
+        self::assertSame('shop-main', $record->getShopRef());
+        self::assertTrue($storage->exists($record->getStoragePath()));
+
+        $row = $this->connection->fetchAssociative(
+            'SELECT company_id, storage_path, hash, byte_size, normalization_status FROM ingest_raw_records WHERE id = :id',
+            ['id' => $record->getId()],
+        );
+
+        self::assertIsArray($row);
+        self::assertSame($companyId, $row['company_id']);
+        self::assertSame($record->getStoragePath(), $row['storage_path']);
+        self::assertSame($record->getHash(), $row['hash']);
+        self::assertSame($record->getByteSize(), (int) $row['byte_size']);
+        self::assertSame('pending', $row['normalization_status']);
+        self::assertEquals($rows, iterator_to_array($facade->read($record->getId(), $companyId)));
+    }
+
+    public function testStoreDuplicateHashDoesNotCreateNewObjectAndUpdatesLastSeenAt(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $rows = [['sku' => 'SKU-1', 'qty' => 2]];
+
+        /** @var RawStorageFacade $facade */
+        $facade = self::getContainer()->get(RawStorageFacade::class);
+        /** @var ObjectStorageInterface $storage */
+        $storage = self::getContainer()->get(ObjectStorageInterface::class);
+
+        $first = $facade->store($this->batch($companyId, syncJobId: 'sync-job-first', rows: $rows))[0];
+        $firstPath = $first->getStoragePath();
+        $firstLastSeenAt = $first->getLastSeenAt();
+
+        usleep(1000);
+
+        $second = $facade->store($this->batch($companyId, syncJobId: 'sync-job-second', rows: $rows))[0];
+
+        self::assertSame($first->getId(), $second->getId());
+        self::assertSame($firstPath, $second->getStoragePath());
+        self::assertGreaterThan($firstLastSeenAt, $second->getLastSeenAt());
+        self::assertTrue($storage->exists($firstPath));
+        self::assertFalse($storage->exists(sprintf(
+            '%s/ozon/shop-main/seller-report/2026/06/15/sync-job-second/external-report-1/%s.ndjson.gz',
+            $companyId,
+            $first->getHash(),
+        )));
+
+        self::assertSame(1, (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM ingest_raw_records WHERE company_id = :company_id AND external_id = :external_id',
+            ['company_id' => $companyId, 'external_id' => 'external-report-1'],
+        ));
+    }
+
+    public function testTenantCannotReadAnotherCompanyRawRecord(): void
+    {
+        $companyA = Uuid::uuid7()->toString();
+        $companyB = Uuid::uuid7()->toString();
+
+        /** @var RawStorageFacade $facade */
+        $facade = self::getContainer()->get(RawStorageFacade::class);
+
+        $record = $facade->store($this->batch($companyB))[0];
+
+        $this->expectException(RawRecordNotFoundException::class);
+        iterator_to_array($facade->read($record->getId(), $companyA));
+    }
+
+    public function testLargePayloadIsStoredOnlyInObjectStorage(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $largeValue = str_repeat('x', 1024 * 1024);
+
+        /** @var RawStorageFacade $facade */
+        $facade = self::getContainer()->get(RawStorageFacade::class);
+        /** @var ObjectStorageInterface $storage */
+        $storage = self::getContainer()->get(ObjectStorageInterface::class);
+
+        $record = $facade->store($this->batch(
+            companyId: $companyId,
+            rows: [['sku' => 'SKU-LARGE', 'payload' => $largeValue]],
+        ))[0];
+
+        $row = $this->connection->fetchAssociative(
+            'SELECT * FROM ingest_raw_records WHERE id = :id',
+            ['id' => $record->getId()],
+        );
+
+        self::assertIsArray($row);
+        self::assertArrayNotHasKey('payload', $row);
+        self::assertStringNotContainsString('SKU-LARGE', json_encode($row, JSON_THROW_ON_ERROR));
+        self::assertTrue($storage->exists($record->getStoragePath()));
+        self::assertGreaterThan(0, $record->getByteSize());
+    }
+
+    public function testMultipleBatchesInSameSyncJobUseDistinctObjectPaths(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+
+        /** @var RawStorageFacade $facade */
+        $facade = self::getContainer()->get(RawStorageFacade::class);
+
+        $firstRows = [['sku' => 'SKU-1', 'qty' => 1]];
+        $secondRows = [['sku' => 'SKU-2', 'qty' => 2]];
+
+        $first = $facade->store($this->batch(
+            companyId: $companyId,
+            syncJobId: 'sync-job-shared',
+            externalId: 'external-report-1',
+            rows: $firstRows,
+        ))[0];
+        $second = $facade->store($this->batch(
+            companyId: $companyId,
+            syncJobId: 'sync-job-shared',
+            externalId: 'external-report-2',
+            rows: $secondRows,
+        ))[0];
+
+        self::assertNotSame($first->getStoragePath(), $second->getStoragePath());
+        self::assertStringContainsString('/external-report-1/', $first->getStoragePath());
+        self::assertStringContainsString('/external-report-2/', $second->getStoragePath());
+        self::assertStringContainsString($first->getHash(), $first->getStoragePath());
+        self::assertStringContainsString($second->getHash(), $second->getStoragePath());
+        self::assertEquals($firstRows, iterator_to_array($facade->read($first->getId(), $companyId)));
+        self::assertEquals($secondRows, iterator_to_array($facade->read($second->getId(), $companyId)));
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     */
+    private function batch(
+        string $companyId,
+        string $syncJobId = 'sync-job-1',
+        string $externalId = 'external-report-1',
+        array $rows = [['sku' => 'SKU-1']],
+    ): RawBatch {
+        return new RawBatch(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            shopRef: 'shop-main',
+            source: IngestSource::OZON,
+            resourceType: 'seller-report',
+            externalId: $externalId,
+            syncJobId: $syncJobId,
+            fetchedAt: new \DateTimeImmutable('2026-06-15 10:20:30'),
+            rows: $rows,
+        );
+    }
+}

--- a/site/tests/Integration/Ingestion/RawStorageFacadeTest.php
+++ b/site/tests/Integration/Ingestion/RawStorageFacadeTest.php
@@ -157,6 +157,39 @@ final class RawStorageFacadeTest extends IntegrationTestCase
         self::assertEquals($secondRows, iterator_to_array($facade->read($second->getId(), $companyId)));
     }
 
+    public function testSameExternalIdAndHashAcrossResourceTypesCreatesSeparateRecords(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $rows = [['sku' => 'SKU-SHARED', 'qty' => 1]];
+
+        /** @var RawStorageFacade $facade */
+        $facade = self::getContainer()->get(RawStorageFacade::class);
+
+        $sellerReport = $facade->store($this->batch(
+            companyId: $companyId,
+            syncJobId: 'sync-job-seller',
+            externalId: 'external-shared',
+            resourceType: 'seller-report',
+            rows: $rows,
+        ))[0];
+        $analyticsReport = $facade->store($this->batch(
+            companyId: $companyId,
+            syncJobId: 'sync-job-analytics',
+            externalId: 'external-shared',
+            resourceType: 'analytics-report',
+            rows: $rows,
+        ))[0];
+
+        self::assertNotSame($sellerReport->getId(), $analyticsReport->getId());
+        self::assertSame($sellerReport->getHash(), $analyticsReport->getHash());
+        self::assertStringContainsString('/seller-report/', $sellerReport->getStoragePath());
+        self::assertStringContainsString('/analytics-report/', $analyticsReport->getStoragePath());
+        self::assertSame(2, (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM ingest_raw_records WHERE company_id = :company_id AND external_id = :external_id',
+            ['company_id' => $companyId, 'external_id' => 'external-shared'],
+        ));
+    }
+
     /**
      * @param list<array<string, mixed>> $rows
      */
@@ -164,6 +197,7 @@ final class RawStorageFacadeTest extends IntegrationTestCase
         string $companyId,
         string $syncJobId = 'sync-job-1',
         string $externalId = 'external-report-1',
+        string $resourceType = 'seller-report',
         array $rows = [['sku' => 'SKU-1']],
     ): RawBatch {
         return new RawBatch(
@@ -171,7 +205,7 @@ final class RawStorageFacadeTest extends IntegrationTestCase
             connectionRef: 'connection-1',
             shopRef: 'shop-main',
             source: IngestSource::OZON,
-            resourceType: 'seller-report',
+            resourceType: $resourceType,
             externalId: $externalId,
             syncJobId: $syncJobId,
             fetchedAt: new \DateTimeImmutable('2026-06-15 10:20:30'),

--- a/site/tests/Integration/Shared/Storage/ObjectStorageIntegrationTest.php
+++ b/site/tests/Integration/Shared/Storage/ObjectStorageIntegrationTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Shared\Storage;
+
+use App\Shared\Service\Storage\ObjectStorageInterface;
+use App\Shared\Service\Storage\StorageService;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class ObjectStorageIntegrationTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        self::ensureKernelShutdown();
+        $_ENV['APP_OBJECT_STORAGE_DRIVER'] = 'local';
+        $_SERVER['APP_OBJECT_STORAGE_DRIVER'] = 'local';
+
+        self::bootKernel();
+    }
+
+    protected function tearDown(): void
+    {
+        self::ensureKernelShutdown();
+        unset($_ENV['APP_OBJECT_STORAGE_DRIVER'], $_SERVER['APP_OBJECT_STORAGE_DRIVER']);
+
+        parent::tearDown();
+    }
+
+    public function testLocalDriverWritesThroughStorageServicePath(): void
+    {
+        /** @var ObjectStorageInterface $objectStorage */
+        $objectStorage = self::getContainer()->get(ObjectStorageInterface::class);
+        /** @var StorageService $storageService */
+        $storageService = self::getContainer()->get(StorageService::class);
+
+        $relativePath = sprintf('object-storage-test/%s/payload.ndjson.gz', bin2hex(random_bytes(6)));
+        $payload = gzencode("{\"id\":1}\n");
+        self::assertIsString($payload);
+
+        $stored = $objectStorage->write($relativePath, $payload);
+        $absolutePath = $storageService->getAbsolutePath($stored->path);
+
+        self::assertSame($relativePath, $stored->path);
+        self::assertFileExists($absolutePath);
+        self::assertSame($payload, file_get_contents($absolutePath));
+        self::assertTrue($objectStorage->exists($relativePath));
+    }
+}

--- a/site/tests/Unit/Ingestion/Application/StoreRawBatchActionTest.php
+++ b/site/tests/Unit/Ingestion/Application/StoreRawBatchActionTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Application;
+
+use App\Ingestion\Application\StoreRawBatchAction;
+use App\Ingestion\DTO\RawBatch;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Infrastructure\Storage\PathSegmentNormalizer;
+use App\Ingestion\Infrastructure\Storage\RawNdjsonCodec;
+use App\Ingestion\Infrastructure\Storage\RawStoragePathBuilder;
+use App\Ingestion\Repository\IngestRawRecordRepository;
+use App\Shared\Service\Storage\ObjectStorageInterface;
+use App\Shared\Service\Storage\StoredObject;
+use Doctrine\DBAL\Driver\Exception as DriverException;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\TestCase;
+
+final class StoreRawBatchActionTest extends TestCase
+{
+    public function testConcurrentDuplicateInsertReturnsExistingRecordAfterUniqueViolation(): void
+    {
+        $companyId = '11111111-1111-7111-8111-111111111111';
+        $resourceType = 'seller-report';
+        $externalId = 'external-report-1';
+        $rows = [['sku' => 'SKU-1', 'qty' => 1]];
+        $batch = new RawBatch(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            shopRef: 'shop-main',
+            source: IngestSource::OZON,
+            resourceType: $resourceType,
+            externalId: $externalId,
+            syncJobId: 'sync-job-1',
+            fetchedAt: new \DateTimeImmutable('2026-06-15 10:20:30'),
+            rows: $rows,
+        );
+        $codec = new RawNdjsonCodec();
+        $hash = hash('sha256', $codec->encodeRows($rows));
+        $existingRecord = new IngestRawRecord(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            shopRef: 'shop-main',
+            source: IngestSource::OZON,
+            resourceType: $resourceType,
+            externalId: $externalId,
+            storagePath: 'existing-path.ndjson.gz',
+            hash: $hash,
+            byteSize: 42,
+            fetchedAt: new \DateTimeImmutable('2026-06-15 10:20:30'),
+            syncJobId: 'sync-job-previous',
+        );
+        $originalLastSeenAt = $existingRecord->getLastSeenAt();
+
+        $repository = $this->createMock(IngestRawRecordRepository::class);
+        $repository->expects(self::once())
+            ->method('findLatestByCompanySourceExternalId')
+            ->with($companyId, IngestSource::OZON, $resourceType, $externalId)
+            ->willReturn(null);
+
+        $duplicateLookupCalls = 0;
+        $repository->expects(self::exactly(2))
+            ->method('findOneByCompanySourceExternalIdAndHash')
+            ->willReturnCallback(
+                function (
+                    string $actualCompanyId,
+                    IngestSource $actualSource,
+                    string $actualResourceType,
+                    string $actualExternalId,
+                    string $actualHash,
+                ) use (
+                    &$duplicateLookupCalls,
+                    $companyId,
+                    $resourceType,
+                    $externalId,
+                    $hash,
+                    $existingRecord,
+                ): ?IngestRawRecord {
+                    ++$duplicateLookupCalls;
+
+                    self::assertSame($companyId, $actualCompanyId);
+                    self::assertSame(IngestSource::OZON, $actualSource);
+                    self::assertSame($resourceType, $actualResourceType);
+                    self::assertSame($externalId, $actualExternalId);
+                    self::assertSame($hash, $actualHash);
+
+                    return 1 === $duplicateLookupCalls ? null : $existingRecord;
+                },
+            );
+
+        $objectStorage = $this->createMock(ObjectStorageInterface::class);
+        $objectStorage->expects(self::once())
+            ->method('write')
+            ->with(
+                self::callback(static fn (string $path): bool => str_contains($path, '/seller-report/')
+                    && str_contains($path, '/external-report-1/')),
+                self::callback(static fn (string $payload): bool => $rows == array_map(
+                    static fn (string $line): array => json_decode($line, true, 512, JSON_THROW_ON_ERROR),
+                    array_filter(explode("\n", trim((string) gzdecode($payload)))),
+                )),
+            )
+            ->willReturnCallback(static fn (string $path, string $payload): StoredObject => new StoredObject($path, strlen($payload)));
+
+        $uniqueViolation = new UniqueConstraintViolationException(
+            new class('Duplicate raw record') extends \Exception implements DriverException {
+                public function getSQLState()
+                {
+                    return '23505';
+                }
+            },
+            null,
+        );
+
+        $flushCalls = 0;
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::once())->method('persist')->with(self::isInstanceOf(IngestRawRecord::class));
+        $entityManager->expects(self::never())->method('clear');
+        $entityManager->expects(self::once())
+            ->method('flush')
+            ->willReturnCallback(static function () use (&$flushCalls, $uniqueViolation): void {
+                ++$flushCalls;
+
+                if (1 === $flushCalls) {
+                    throw $uniqueViolation;
+                }
+            });
+        $entityManager->expects(self::once())->method('isOpen')->willReturn(false);
+
+        $recoveredEntityManager = $this->createMock(EntityManagerInterface::class);
+        $recoveredEntityManager->expects(self::once())
+            ->method('getRepository')
+            ->with(IngestRawRecord::class)
+            ->willReturn($repository);
+        $recoveredEntityManager->expects(self::once())->method('flush');
+
+        $managerRegistry = $this->createMock(ManagerRegistry::class);
+        $managerRegistry->expects(self::once())
+            ->method('resetManager')
+            ->willReturn($recoveredEntityManager);
+
+        $action = new StoreRawBatchAction(
+            $repository,
+            $objectStorage,
+            $codec,
+            new RawStoragePathBuilder(new PathSegmentNormalizer()),
+            $entityManager,
+            $managerRegistry,
+        );
+
+        $records = $action($batch);
+
+        self::assertSame([$existingRecord], $records);
+        self::assertGreaterThan($originalLastSeenAt, $existingRecord->getLastSeenAt());
+    }
+}

--- a/site/tests/Unit/Ingestion/Infrastructure/Storage/RawNdjsonCodecTest.php
+++ b/site/tests/Unit/Ingestion/Infrastructure/Storage/RawNdjsonCodecTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Infrastructure\Storage;
+
+use App\Ingestion\Exception\RawStorageException;
+use App\Ingestion\Infrastructure\Storage\RawNdjsonCodec;
+use PHPUnit\Framework\TestCase;
+
+final class RawNdjsonCodecTest extends TestCase
+{
+    public function testEncodeRowsIsCanonicalForAssociativeKeyOrder(): void
+    {
+        $codec = new RawNdjsonCodec();
+
+        $first = $codec->encodeRows([
+            ['b' => 2, 'a' => ['z' => 1, 'm' => 2]],
+        ]);
+        $second = $codec->encodeRows([
+            ['a' => ['m' => 2, 'z' => 1], 'b' => 2],
+        ]);
+
+        self::assertSame($first, $second);
+        self::assertSame(hash('sha256', $first), hash('sha256', $second));
+    }
+
+    public function testDecodeCompressedRowsReturnsOriginalRows(): void
+    {
+        $codec = new RawNdjsonCodec();
+        $rows = [
+            ['sku' => 'A-1', 'qty' => 3],
+            ['sku' => 'B-2', 'qty' => 0, 'price' => 10.5],
+        ];
+
+        $compressed = gzencode($codec->encodeRows($rows));
+
+        self::assertIsString($compressed);
+        self::assertEquals($rows, iterator_to_array($codec->decodeCompressedRows($compressed)));
+    }
+
+    public function testEncodeRowsRejectsEmptyBatch(): void
+    {
+        $codec = new RawNdjsonCodec();
+
+        $this->expectException(RawStorageException::class);
+        $this->expectExceptionMessage('Raw batch must contain at least one row.');
+
+        $codec->encodeRows([]);
+    }
+}

--- a/site/tests/Unit/Ingestion/Infrastructure/Storage/RawStoragePathBuilderTest.php
+++ b/site/tests/Unit/Ingestion/Infrastructure/Storage/RawStoragePathBuilderTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Infrastructure\Storage;
+
+use App\Ingestion\DTO\RawBatch;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Infrastructure\Storage\PathSegmentNormalizer;
+use App\Ingestion\Infrastructure\Storage\RawStoragePathBuilder;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+final class RawStoragePathBuilderTest extends TestCase
+{
+    public function testBuildsDeterministicGzipNdjsonPath(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $builder = new RawStoragePathBuilder(new PathSegmentNormalizer());
+        $batch = new RawBatch(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            shopRef: 'Main Shop #1',
+            source: IngestSource::OZON,
+            resourceType: 'seller/report',
+            externalId: 'external-1',
+            syncJobId: 'sync job 42',
+            fetchedAt: new \DateTimeImmutable('2026-06-15 10:20:30'),
+            rows: [['id' => 1]],
+        );
+
+        self::assertSame(
+            sprintf('%s/ozon/Main-Shop-1/seller-report/2026/06/15/sync-job-42/external-1/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.ndjson.gz', $companyId),
+            $builder->build($batch, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+        );
+    }
+}

--- a/site/tests/Unit/Shared/Service/Storage/LocalObjectStorageTest.php
+++ b/site/tests/Unit/Shared/Service/Storage/LocalObjectStorageTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Service\Storage;
+
+use App\Shared\Service\Storage\LocalObjectStorage;
+use App\Shared\Service\Storage\StorageService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class LocalObjectStorageTest extends TestCase
+{
+    public function testWriteDelegatesToStorageService(): void
+    {
+        /** @var StorageService&MockObject $storageService */
+        $storageService = $this->createMock(StorageService::class);
+        $storageService
+            ->expects(self::once())
+            ->method('storeBytes')
+            ->with('payload-bytes', 'company/source/file.ndjson.gz')
+            ->willReturn([
+                'storagePath' => 'company/source/file.ndjson.gz',
+                'fileHash' => hash('sha256', 'payload-bytes'),
+                'sizeBytes' => strlen('payload-bytes'),
+                'mimeType' => 'application/gzip',
+            ]);
+
+        $stored = (new LocalObjectStorage($storageService))->write(
+            'company/source/file.ndjson.gz',
+            'payload-bytes',
+        );
+
+        self::assertSame('company/source/file.ndjson.gz', $stored->path);
+        self::assertSame(strlen('payload-bytes'), $stored->byteSize);
+    }
+}

--- a/site/tests/bootstrap.php
+++ b/site/tests/bootstrap.php
@@ -23,6 +23,7 @@ DG\BypassFinals::allowPaths([
     '*/src/MarketplaceAds/Repository/AdScheduledBatchRepository.php',
     '*/src/MarketplaceAds/Repository/AdRawDocumentRepository.php',
     '*/src/Shared/Service/Storage/StorageService.php',
+    '*/src/Ingestion/Repository/IngestRawRecordRepository.php',
 ]);
 
 if (method_exists(Dotenv::class, 'bootEnv')) {


### PR DESCRIPTION
## Summary

Adds Block 3 raw ingestion storage with metadata in Postgres and payloads in object storage. The generic object storage seam lives in `App\Shared\Service\Storage`, while Ingestion keeps only raw-specific NDJSON/path logic.

## What changed

- Added shared `ObjectStorageInterface` with local `StorageService` delegation and Flysystem S3 implementation.
- Added `IngestRawRecord`, `RawStorageFacade`, raw store/read actions, DTOs, enums, repository, and migration.
- Stores raw payload as canonical gzip NDJSON outside the DB.
- Deduplicates repeated payload hash and updates `lastSeenAt` instead of writing another object.
- Makes raw object paths unique per batch using `syncJobId/externalId/hash` to avoid overwrites inside one sync job.
- Keeps legacy code on `StorageService`; S3 is enabled only explicitly through `APP_OBJECT_STORAGE_DRIVER=s3` and `APP_OBJECT_STORAGE_S3_*`.
- Fixed old `telegram_bots.updated_at` migration idempotency with `ADD COLUMN IF NOT EXISTS`.

## Validation

- `make site-test-unit`
- `php bin/phpunit --testsuite integration --filter 'RawStorageFacadeTest|ObjectStorageIntegrationTest'`
- `php bin/console lint:container --env=test`
- `make try-build`

Notes: unit/integration suites pass with existing warning/deprecation output.