### PR TITLE
[codex] Implement ingestion blocks 4-7

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -70,6 +70,12 @@
 | `IngestionTenantProbe` | Ingestion | `string $companyId` + Doctrine `company` filter ✅ |
 | `IngestionCredential` | Ingestion | `string $companyId` + Doctrine `company` filter ✅ |
 | `IngestRawRecord` | Ingestion | `string $companyId` + Doctrine `company` filter ✅ |
+| `IngestCursor` | Ingestion | `string $companyId` + Doctrine `company` filter ✅ |
+| `SyncJob` | Ingestion | `string $companyId` + Doctrine `company` filter ✅ |
+| `FinancialTransaction` | Ingestion | `string $companyId` + Doctrine `company` filter ✅ |
+| `Counterparty` | Ingestion | `string $companyId` + Doctrine `company` filter ✅ |
+| `NormalizationIssue` | Ingestion | `string $companyId` + Doctrine `company` filter ✅ |
+| `PLDirtyPeriod` | Ingestion | `string $companyId` + Doctrine `company` filter ✅ |
 | `ProductImport` | Catalog | `string $companyId` ✅ |
 | `ProductBarcode` | Catalog | `string $companyId` ✅ |
 | `ProductPurchasePrice` | Catalog | `string $companyId` ✅ |
@@ -95,6 +101,43 @@
 - Dedup: перед записью сверяется SHA-256 hash canonical uncompressed NDJSON по `(companyId, source, resourceType, externalId)`. Совпавший hash обновляет `lastSeenAt`; новый object не создаётся.
 - Storage seam общий для проекта: `App\Shared\Service\Storage\ObjectStorageInterface`. Default driver — `local`, он делегирует запись в существующий `StorageService`; S3 driver через Flysystem включается только явным `APP_OBJECT_STORAGE_DRIVER=s3` и `APP_OBJECT_STORAGE_S3_*`.
 - Legacy-модули пока продолжают использовать `StorageService` напрямую. Их переезд на `ObjectStorageInterface` выполняется отдельными задачами, по одному модулю.
+
+### Ingestion: cursor and sync jobs
+
+- `IngestCursor` stores opaque cursor state for `(companyId, connectionRef, resourceType, shopRef)` and advances only through `UpdateCursorAction` / `SyncFacade::updateCursor`.
+- `SyncJob` stores orchestration state for backfill, incremental, and manual sync runs. Parent backfill jobs are split into child chunk jobs; children are dispatched as `RunSyncChunkMessage` through `ingest_fetch`.
+- `SyncJobStatus` owns the explicit state transition matrix. Entity methods reject invalid transitions and terminal jobs cannot be reopened.
+- Repository reads require explicit `companyId`; the Doctrine `company` filter is an additional guard, not the only tenant boundary.
+- `SyncFacade::startBackfill()` creates a parent job, splits it into 7-day chunks by default, and dispatches chunk messages after DB flush.
+- `RunSyncChunkHandler` resolves a `SourceConnectorInterface` through `ConnectorRegistry`, pulls one chunk, stores raw payload through `RawStorageFacade`, dispatches `NormalizeRawRecordMessage`, advances cursor, and finalizes the job.
+- `ingest_fetch` uses the sync transport DSN for external source fetches; `ingest_normalize` uses the pipeline DSN for local normalization work.
+
+### Ingestion: canonical finance layer
+
+- `FinancialTransaction` is the canonical transaction record produced from normalized raw source rows. Natural key: `(companyId, source, externalId, type)`.
+- Amounts are stored in minor units. Shared `Money` is signed and can represent positive, negative, or zero values; `TransactionDirection` (`IN`/`OUT`) remains the normalized flow classification. `Money` enforces one ISO-4217 currency per arithmetic operation.
+- `operationGroupId` groups decomposed transactions from one source operation for audit and sum-control checks.
+- `Counterparty` is a minimal canonical counterparty seam keyed by `(companyId, source, externalKey)`.
+- `NormalizationIssue` is append-only for mapper failures, control-sum mismatches, unknown fields, and currency mismatches; resolving sets `resolvedAt`.
+- Repository reads require explicit `companyId`; period reads use `toIterable()` for future P&L rebuilds over large months.
+- `SourceConnectorInterface` is the per-source boundary for `discoverShops`, `pull`, and future `push`. Production connectors must be registered with `app.ingestion.connector`.
+- `SourceMapperInterface` maps raw rows to `MappedTransaction` DTOs and control sums. Mappers are pure and registered with `app.ingestion.mapper`.
+- `OzonSellerReportConnector` is the first production source connector. It supports `ozon_seller_daily_report` (`/v3/finance/transaction/list`) and `ozon_seller_realization` (`/v2/finance/realization`) through the Ingestion Ozon adapter. Legacy Marketplace Ozon jobs remain enabled until a later shadow/switch task.
+- `OzonSellerReportMapper` and `OzonRealizationMapper` decompose one Ozon operation into multiple canonical transactions with a shared `operationGroupId`. External ids use `ozon:operation:{operation_id}:{component}` so multiple same-type Ozon components can coexist under the current `(companyId, source, externalId, type)` natural key.
+- `NormalizeRawRecordAction` reads NDJSON raw payload, calls the mapper, upserts canonical transactions, records `NormalizationIssue` on mapper/control-sum problems, marks the raw record `DONE`/`FAILED`, and dispatches `NormalizationCompletedEvent` after successful flush.
+- `NormalizationCompletedEvent` carries affected periods for future P&L dirty-period marking. Stage 4 only publishes the event; subscribers for P&L rebuild are added later.
+
+### Finance: P&L dirty-period projection infrastructure
+
+- `PLDirtyPeriod` is the Ingestion-side pipeline marker for month-level P&L projection rebuilds from canonical Ingestion transactions. It uses scalar `companyId`, `periodYear`, `periodMonth`, `shopRef`, `status`, `reason`, attempts, and audit timestamps.
+- Status flow is explicit: `pending -> rebuilding -> done|failed|blocked_by_close`; terminal statuses can be reopened to `pending` when a later import/remap needs another rebuild.
+- `PLDailyTotal` and `PLMonthlySnapshot` now have nullable `rebuiltAt` audit columns. Legacy writers leave them `NULL`; future canonical rebuild code sets them when it owns the recalculation.
+- Existing P&L aggregate tables do not store `shop_ref` and must not receive a source/shop dimension. Repository delete methods support all-shop monthly cleanup (`shopRef = ''`) and reject non-empty `shopRef`; source linkage should be decided later at `Document` / `DocumentOperation` level under `docs/tasks/ingestion/FOLLOWUP-finance-source-linking.md`.
+- `NormalizationCompletedSubscriber` listens to Ingestion normalization events and dispatches `MarkPnlPeriodDirtyMessage`; it does not rebuild P&L inline.
+- `MarkPnlPeriodDirtyAction` is idempotent. Existing `DONE`/`FAILED` periods are reopened to `PENDING`; already pending/rebuilding/blocked periods are left unchanged.
+- `RebuildPnlPeriodAction` owns the Redis/Symfony Lock, close-period guard, delete-then-upsert rebuild, and `rebuiltAt` audit marking. It supports only all-source/all-shop rebuild (`shopRef = ''`) until Finance source-linking is decided.
+- `RebuildDirtyPnlPeriodsCommand` only dispatches `RebuildPnlPeriodMessage` jobs for pending dirty periods. No production cron entry is added by Ingestion Stage 8.
+- `pnl_rebuild` Messenger transport uses `MESSENGER_TRANSPORT_DSN_PIPELINE`. `MarkPnlPeriodDirtyMessage` routes to `ingest_normalize`; `RebuildPnlPeriodMessage` routes to `pnl_rebuild`.
 
 ### Marketplace: WB financial report sync status (дневной статус)
 
@@ -347,6 +390,29 @@ Dead code на Task-11.2: Repository ещё никем не вызывается
 
 > Используй **только** эти методы. Не выдумывай новые без обновления этого файла.
 > Нет нужного метода — спроси, не создавай самостоятельно.
+
+### `IngestionFacade` (`src/Ingestion/Facade/IngestionFacade.php`)
+```php
+// Канонические финансовые транзакции за период для P&L rebuild.
+// @return iterable<FinancialTransaction>
+getTransactions(string $companyId, DateTimeImmutable $from, DateTimeImmutable $to, ?string $shopRef = null): iterable
+
+// Количество открытых normalization issues по компании.
+countOpenIssues(string $companyId): int
+```
+
+### `PnlFacade` (`src/Finance/Facade/PnlFacade.php`)
+```php
+markPeriodDirty(MarkPnlPeriodDirtyCommand $command): void
+rebuildPeriod(RebuildPnlPeriodCommand $command): void
+
+// Dirty-period views for future UI/admin blocks.
+// @return list<PLDirtyPeriodView>
+getDirtyPeriods(string $companyId): array
+
+// Counters by status: pending/rebuilding/done/failed/blocked.
+getProgress(string $companyId): PnlProgressView
+```
 
 ### `CompanyFacade` (`src/Company/Facade/CompanyFacade.php`)
 ```php

--- a/docs/ingestion/ozon-mapping.md
+++ b/docs/ingestion/ozon-mapping.md
@@ -1,0 +1,81 @@
+# Ingestion Ozon Seller Mapping
+
+## Resources
+
+| Resource type | Source API | Mapper |
+|---|---|---|
+| `ozon_seller_daily_report` | `POST /v3/finance/transaction/list` | `OzonSellerReportMapper` |
+| `ozon_seller_realization` | `POST /v2/finance/realization` | `OzonRealizationMapper` |
+
+Legacy Marketplace Ozon pipelines remain unchanged. The Ingestion connector reads Ozon Seller data through `LegacyOzonClientAdapter`, writes raw NDJSON through `RawStorageFacade`, and normalizes rows into `FinancialTransaction`.
+
+## Natural Keys
+
+Base operation id:
+
+| Input | Base id |
+|---|---|
+| `operation_id` present | `ozon:operation:{operation_id}` |
+| `operation_id` missing | `ozon:fallback:{posting_number}:{sku}:{date}` |
+
+Canonical transaction external id:
+
+```text
+{base id}:{component}
+```
+
+The component suffix is intentional. Current canonical uniqueness is `(companyId, source, externalId, type)`, and one Ozon operation can contain several rows with the same `TransactionType` such as multiple logistics or fee components. The suffix keeps daily and realization rows overwrite-compatible while preserving all components.
+
+`operationGroupId` is UUIDv5 over `{companyId}:{base id}`. All components from one Ozon operation share the same group id.
+
+## Daily Report Mapping
+
+| Ozon field | Component | TransactionType | Direction |
+|---|---|---|---|
+| `accruals_for_sale` | `sale` | `SALE` | `IN` for positive, `OUT` for negative |
+| `amount` with `operation_type=ClientReturnAgentOperation` | `refund` | `REFUND` | `OUT` |
+| `sale_commission_amount` / `sale_commission` | `commission` | `COMMISSION` | by amount sign |
+| `deliv_charge_amount` / `delivery_charge` | `logistics_delivery` | `LOGISTICS` | by amount sign |
+| `return_delivery_charge_amount` / `return_delivery_charge` | `logistics_return_delivery` | `LOGISTICS` | by amount sign |
+| `services_amounts.MarketplaceServiceItemReturnAfterDelivToCustomer` | `service_*` | `LOGISTICS` | by amount sign |
+| `services_amounts.MarketplaceServiceItemDelivToCustomer` | `service_*` | `LAST_MILE` | by amount sign |
+| other `services_amounts` / `services[]` | `service_*` | `FEE` | by amount sign |
+| `acquiring` / `acquiring_amount` | `acquiring` | `ACQUIRING` | by amount sign |
+| fallback nonzero `amount` | `other` | `OTHER` | by amount sign |
+
+Amounts are stored as unsigned minor units in `Money`; direction is represented by `TransactionDirection`.
+
+## Realization Mapping
+
+Realization uses the same component rules and external id algorithm as the daily report. It additionally accepts common realization field names:
+
+| Realization field | Canonical meaning |
+|---|---|
+| `seller_price` / `price` | sale amount |
+| `commission_amount` | commission |
+| `delivery_commission` | logistics delivery |
+| `return_delivery_commission` | return logistics |
+| `report_date`, `_header.stop_date` | `externalUpdatedAt` candidates |
+
+Because realization `externalUpdatedAt` is later than the daily operation date, `UpsertFinancialTransactionAction` replaces preliminary daily values instead of creating duplicates.
+
+## Dates And References
+
+| Canon field | Source |
+|---|---|
+| `occurredAt` | `operation_date`, then `sale_date`, then `return_date`, then header dates |
+| daily `externalUpdatedAt` | operation date |
+| realization `externalUpdatedAt` | `realization_report_period_end`, `report_date`, header stop/doc date, then operation/sale/return date |
+| `sourceTz` | `Europe/Moscow` |
+| `orderRef` | `posting.posting_number` or `posting_number` |
+| `payoutRef` | `payout_ref`, `realization_id`, or `_header.doc_number` |
+
+## Control Sum
+
+For each raw row, the mapper produces one control sum:
+
+```text
+sum(abs(mapped component amount minor))
+```
+
+The control sum is compared against all canonical transactions in the same `operationGroupId`. Ozon control sums require the raw record company id, so Ozon mappers implement `RawRecordAwareControlSumMapperInterface`; the base `controlSum()` method remains empty for backward compatibility with the generic mapper contract.

--- a/docs/tasks/ingestion/FOLLOWUP-finance-source-linking.md
+++ b/docs/tasks/ingestion/FOLLOWUP-finance-source-linking.md
@@ -1,0 +1,48 @@
+# FOLLOW-UP — Finance source linking after Ingestion acceptance/deploy
+
+## Status
+
+Decision required after Ingestion acceptance and deployment.
+
+This is not part of Blocks 4-7 implementation and must not block the current Ingestion rollout.
+
+## Context
+
+Stage 7 added P&L dirty-period infrastructure for future canonical rebuilds. During review, the owner clarified an architectural boundary:
+
+- `shop_ref` must not be added to `pl_daily_totals` or `pl_monthly_snapshots`.
+- P&L aggregate tables are calculated result tables and should not carry source/shop linkage.
+- Source linkage belongs closer to the business document layer: `Document.php` and/or `DocumentOperation.php`.
+- The final field name may be not `shop_ref`; it should be a business-level name for preserving links from other modules.
+
+## Decision Question
+
+Where should Finance store links from external/source modules after Ingestion becomes accepted and deployed?
+
+Options to evaluate:
+
+1. Add a source/origin reference to `Document`.
+2. Add a source/origin reference to `DocumentOperation`.
+3. Add both document-level and operation-level references if one external source document can create multiple operations with different source identities.
+4. Use a separate link table if multiple modules may attach several references to the same document/operation.
+
+Naming to decide:
+
+- avoid leaking technical `shop_ref` naming into Finance if it is not the business concept;
+- consider names such as `originRef`, `sourceRef`, `externalContextRef`, or a domain-specific Russian/English business term;
+- preserve the ability to reference Ingestion canonical transactions, marketplace documents, ads reports, and future source modules.
+
+## Explicit Non-Goals
+
+- Do not add `shop_ref` to `pl_daily_totals`.
+- Do not add `shop_ref` to `pl_monthly_snapshots`.
+- Do not change existing P&L formulas or aggregate semantics as part of this decision.
+- Do not implement this before Ingestion is accepted and deployed.
+
+## Acceptance Criteria For The Future Task
+
+- Architecture decision records whether the reference belongs to `Document`, `DocumentOperation`, both, or a dedicated link table.
+- Field/table naming is business-oriented and not tied to Ozon/WB-specific shop terminology.
+- Migration plan is additive and safe for existing Finance data.
+- Existing legacy P&L reports keep working during rollout.
+- Tests cover preserving source links when Finance documents/operations are created from Ingestion.

--- a/docs/tasks/ingestion/INDEX.md
+++ b/docs/tasks/ingestion/INDEX.md
@@ -1,0 +1,187 @@
+# Ingestion Migration — пакет ТЗ для автономной реализации
+
+Это набор технических заданий для миграции загрузки данных в новый модуль `App\Ingestion` платформы VashFinDir. Каждый файл — самодостаточное ТЗ для отдельного блока, исполняемого Claude Code в автономном режиме.
+
+## Карта блоков
+
+```
+БЛОК 1 ─── ✅ ВЫПОЛНЕН (каркас + изоляция через CompanyFilter)
+БЛОК 2 ─── ✅ ВЫПОЛНЕН (credentials через SecretCodec, плейнтекст)
+БЛОК 3 ─── ✅ ВЫПОЛНЕН (единый raw-слой на общем Storage в App\Shared)
+       │
+       ├─── БЛОК 4: Cursor + SyncJob (оркестрация)       → TASK-04-cursor-syncjob.md
+       │           │
+       │           └─── БЛОК 5: Контракт + канон + нормализация → TASK-05-connector-canon.md
+       │                       │
+       │                       └─── БЛОК 6: OzonSellerReportConnector → TASK-06-ozon-connector.md
+       │                                   │
+       │                                   └─── БЛОК 7: Проекция в P&L  → TASK-07-pnl-projection.md
+       │                                               │
+       │                                               └─── БЛОК 8: UI пилота + сверка → TASK-08-ui-verification.md
+       │                                                           │
+       │                                                           └─── БЛОК 9: Shadow + admin → TASK-09-shadow-admin.md
+```
+
+## Файлы пакета
+
+| Файл | Блок | Статус | Что делает |
+|---|---|---|---|
+| `INDEX.md` (этот) | — | — | Обзор пакета и контракты блоков 1-3 |
+| `TASK-04-cursor-syncjob.md` | 4 | DONE | Единый Cursor + SyncJob, state machine, чанкинг, rate limit |
+| `TASK-05-connector-canon.md` | 5 | DONE | SourceConnectorInterface, канон FinancialTransaction, движок нормализации, NormalizationCompletedEvent |
+| `TASK-06-ozon-connector.md` | 6 | DONE | OzonSellerReportConnector + 2 mapper'а (daily report + realization) поверх legacy Ozon API |
+| `TASK-07-pnl-projection.md` | 7 | DONE | PLDirtyPeriod, mark dirty → rebuildPeriod, защита закрытых периодов, Redis Lock |
+| `SUMMARY-blocks-4-7.md` | 4-7 | DONE | Итоговая сводка по выполненным блокам 4-7 |
+| `FOLLOWUP-finance-source-linking.md` | post-deploy | DECISION | Где хранить source/origin-ссылки Finance после приемки и деплоя Ingestion |
+
+
+## Принципы пакета
+
+- **Strangler Fig.** Новый модуль `App\Ingestion` живёт параллельно legacy, ничего не ломая. Legacy продолжает работать всё время пилота. Гашение legacy — отдельная задача после успеха.
+- **Зависимости только вниз по дереву.** Блок N не может стартовать, пока N-1 не в DoD. Внутри одного блока подзадачи имеют свои зависимости (см. таблицу подзадач каждого ТЗ).
+- **Изоляция by default.** `CompanyFilter` (блок 1) автоматически фильтрует все Entity модуля через интерфейс-маркер `TenantOwnedInterface`. Каждый Repository-метод дополнительно принимает `string $companyId` — двойная защита.
+- **Канон — источник истины, P&L — идемпотентная проекция.** Один `rebuildPeriod` обслуживает и реактивный поток (событие из Ingestion), и императивный (пользователь нажал «пересчитать»).
+- **Доверие через сверку.** Пользователь видит не только цифры, но и доказательство их корректности (блок 8). Saapport видит расхождения новой загрузки и старой до того, как клиент переключится (блок 9).
+- **Отказ безопасен.** Feature flag — мгновенный откат пилота без миграций (блок 9).
+
+## Контракты блоков 1-3 (уже выполнено)
+
+Используется блоками 4-9. Полные namespace, сигнатуры, поля Entity.
+
+### Изоляция (блок 1)
+
+```
+App\Ingestion\Domain\TenantOwnedInterface
+    public function getCompanyId(): string
+
+App\Ingestion\Message\CompanyAwareMessage
+    public function getCompanyId(): string
+
+App\Ingestion\Infrastructure\Doctrine\CompanyFilter         (Doctrine SQL filter)
+App\Ingestion\Infrastructure\Messenger\CompanyFilterMiddleware
+App\Ingestion\Infrastructure\Http\CompanyFilterRequestSubscriber
+```
+
+**Правила:**
+- Любая новая Entity модуля Ingestion реализует `TenantOwnedInterface` → автоматически фильтруется по company.
+- Любое новое Message с tenant-нагрузкой реализует `CompanyAwareMessage` → middleware включает фильтр в Messenger-handler.
+- Системные запросы (cron по всем тенантам) явно делают `$em->getFilters()->disable('company')` — это видимый маркер «осознанно по всем компаниям».
+- Двойная защита: фильтр на ORM + явный `companyId` в каждом Repository-методе.
+
+### Credentials (блок 2)
+
+```
+App\Ingestion\Domain\Contract\SecretCodec
+    encode(array): string
+    decode(string, int $keyVersion): array
+
+App\Ingestion\Infrastructure\Security\PlaintextSecretCodec   (keyVersion = 0, плейнтекст)
+App\Ingestion\Infrastructure\Doctrine\EncryptedJsonType      (Doctrine type, использует SecretCodec)
+App\Ingestion\Infrastructure\Security\SecretPayloadMasker    (для логов и API responses)
+App\Ingestion\Infrastructure\Credential\LegacyMarketplaceCredentialReader
+
+App\Ingestion\Entity\IngestionCredential
+    id, companyId, connectionRef, type='api_credentials',
+    payload (зашифровано через EncryptedJsonType), keyVersion, expiresAt,
+    createdAt, updatedAt
+    методы: replacePayload(array, int $keyVersion, ?DateTimeImmutable $expiresAt = null)
+
+App\Ingestion\Facade\CredentialFacade
+    store(string $companyId, string $connectionRef, array $payload): void
+    read(string $companyId, string $connectionRef): array     (throws CredentialNotFoundException)
+    readMasked(string $companyId, string $connectionRef): array
+```
+
+**Шифрование отложено** (`SodiumFieldEncryptionService` не работает). Текущий codec — плейнтекст. Шов готов: позже добавится `SodiumSecretCodec` с `keyVersion >= 1`, без правок бизнес-кода.
+
+### Raw-слой (блок 3)
+
+Storage вынесен в `App\Shared` для переиспользования всем проектом:
+
+```
+App\Shared\Service\Storage\ObjectStorageInterface
+App\Shared\Service\Storage\LocalObjectStorage          (делегирует в существующий StorageService)
+App\Shared\Service\Storage\FlysystemS3ObjectStorage
+App\Shared\Service\Storage\ObjectStorageFactory
+App\Shared\Service\Storage\StoredObject
+App\Shared\Service\Storage\ObjectStorageException
+```
+
+Default driver = `local` через env `APP_OBJECT_STORAGE_DRIVER=local`. S3 включается явно. Legacy продолжает использовать `StorageService` напрямую.
+
+```
+App\Ingestion\Enum\IngestSource: OZON, WILDBERRIES, OZON_PERFORMANCE
+App\Ingestion\Enum\RawNormalizationStatus: PENDING, DONE, FAILED
+
+App\Ingestion\Entity\IngestRawRecord
+    id, companyId, connectionRef, shopRef, source: IngestSource,
+    resourceType, externalId, storagePath, hash, byteSize,
+    fetchedAt, lastSeenAt, syncJobId,
+    normalizationStatus: RawNormalizationStatus = PENDING,
+    createdAt, updatedAt
+    методы: markSeen(?DateTimeImmutable)
+    natural key: (companyId, source, externalId, hash)
+
+App\Ingestion\DTO\RawBatch (final readonly)
+    companyId, connectionRef, shopRef, source: IngestSource,
+    resourceType, externalId, syncJobId,
+    fetchedAt: DateTimeImmutable,
+    rows: iterable<array>
+
+App\Ingestion\Facade\RawStorageFacade
+    store(RawBatch $batch): list<IngestRawRecord>
+    read(string $rawRecordId, string $companyId): iterable<array>
+```
+
+**Путь в S3:** `{companyId}/{source}/{shopRef}/{resourceType}/{yyyy}/{mm}/{dd}/{syncJobId}.ndjson.gz`.
+**Дедуп:** перед записью сверка hash; повтор → новый файл НЕ пишется, `lastSeenAt` обновляется.
+
+## Дополнения к контрактам, которые делают блоки 4-9
+
+Эти небольшие правки уже учтены в соответствующих ТЗ, но фиксирую для прозрачности:
+
+| Где | Что | Откуда |
+|---|---|---|
+| `IngestRawRecord` | Добавить методы `markNormalizationDone()`, `markNormalizationFailed()` | блок 5 (NormalizeRawRecordAction) |
+| `IngestRawRecordRepository` | Добавить методы `findByIdAndCompany`, `findByCompanyAndPeriod` | блоки 5, 8 |
+| `IngestionCredential` | Без изменений | — |
+| `CredentialFacade` | Без изменений | — |
+| `RawStorageFacade` | Без изменений | — |
+
+Изменения в Entity локальные, без миграций (только PHP-методы).
+
+## Как использовать пакет
+
+1. **Сохранить пакет** в `docs/tasks/ingestion-migration/` репозитория (или равнозначное место).
+2. **Для каждого блока:**
+   - Открыть `TASK-0N-...md`.
+   - Передать содержимое Claude Code (или разработчику) как полное самостоятельное задание.
+   - Выполнить, прогнать DoD (раздел §10 каждого ТЗ).
+   - Закрыть PR, обновить `ARCHITECTURE.md` если требуется.
+3. **Параллельность:** блоки 2, 3 уже шли параллельно. Блоки 4-9 строго последовательны.
+4. **Перед каждым блоком:** убедиться, что предыдущий в DoD (включая tenant-leak тесты и обновлённую `ARCHITECTURE.md`).
+
+## Что НЕ входит в этот пакет (отдельные задачи после Ozon-пилота)
+
+- Гашение старого Ozon-пайплайна (после shadow-сверки и переключения).
+- Миграция WB финансов в Ingestion.
+- Миграция Inventory (остатки) в Ingestion.
+- Миграция Ads (схлопывание двух параллельных пайплайнов).
+- Банковские интеграции в Ingestion.
+- МойСклад в Ingestion.
+- Полноценное RBAC поверх admin.
+- Уведомления о расхождениях (email/Telegram).
+- Включение реального шифрования credentials (`SodiumSecretCodec`).
+- Реальное переключение продакшена на S3 (`APP_OBJECT_STORAGE_DRIVER=s3`).
+
+Каждая из этих задач — отдельная итерация после успеха Ozon-пилота. Они переиспользуют те же контракты блока 5 (`SourceConnectorInterface`, канон, normalize-pipeline) — это и есть выигрыш от инвестиции в фундамент.
+
+## Связанная документация
+
+- `ARCHITECTURE.md` — общая архитектура проекта (обновляется по мере закрытия блоков).
+- `PATTERNS.md` — паттерны кодирования (применяются в каждом ТЗ).
+- `CLAUDE.md` — конвенции backend (`src/Ingestion`).
+- `CLAUDE_frontend.md` — конвенции frontend (для блоков 8, 9).
+- `docs/ingestion/ozon-mapping.md` — создаётся в блоке 6.
+- `docs/ingestion/verification-ui.md` — создаётся в блоке 8.
+- `docs/ingestion/runbook.md` — создаётся в блоке 9 (инструкция саппорту).

--- a/docs/tasks/ingestion/SUMMARY-blocks-4-7.md
+++ b/docs/tasks/ingestion/SUMMARY-blocks-4-7.md
@@ -1,0 +1,147 @@
+# Ingestion Blocks 4-7 Summary
+
+## Общий статус
+
+Блоки 4-7 выполнены и доведены до final handoff.
+
+Финальный handoff: `docs/tasks/ingestion/handoff.md`.
+
+Детальные stage reports: `docs/tasks/ingestion/stages/stage-1.md` - `docs/tasks/ingestion/stages/stage-10-correction-money-signed.md`.
+
+`TASK-08` и `TASK-09` не выполнялись: task-файлы отсутствуют, scope был ограничен блоками 4-7.
+
+## Блок 4: Cursor + SyncJob
+
+**Статус:** DONE
+
+Реализована оркестрация загрузок Ingestion:
+
+- `IngestCursor` для хранения состояния курсора по company/connection/resource/shop.
+- `SyncJob` для backfill, incremental и chunk jobs.
+- Enum/state machine для статусов sync jobs.
+- Миграция `Version20260618120000`: таблицы `ingest_cursors`, `ingest_sync_jobs`, индексы.
+- Repository-методы с явным `companyId`.
+- Actions для старта backfill, split на chunks, running/completed/failed, cursor update, финализации parent job.
+- `SyncFacade`.
+- `RunSyncChunkMessage` и handler.
+- `IngestRateLimitGuard`.
+- Messenger routing: `ingest_fetch`, `ingest_normalize`.
+
+**Ключевой результат:** появился управляемый слой синхронизации, который может безопасно запускать загрузку чанками, отслеживать прогресс и не смешивать данные компаний.
+
+## Блок 5: Connector + Canon + Normalization
+
+**Статус:** DONE
+
+Реализован канонический слой финансовых транзакций:
+
+- Shared `Money` вынесен в `site/src/Shared/Domain/ValueObject/Money.php`.
+- Shared `Money` поддерживает positive/negative/zero minor units; проверки неотрицательности должны жить в конкретных бизнес-сценариях.
+- Entity:
+  - `FinancialTransaction`
+  - `Counterparty`
+  - `NormalizationIssue`
+- Миграция `Version20260618130000`: canonical transaction tables.
+- Enums для source capabilities, transaction type/direction, issue kind.
+- Contracts:
+  - `SourceConnectorInterface`
+  - `SourceMapperInterface`
+  - `RawRecordAwareControlSumMapperInterface`
+- Registries для connector/mapper.
+- DTO для mapped transactions/control sums, pull/push requests/results.
+- `NormalizeRawRecordAction`.
+- `UpsertFinancialTransactionAction` с idempotency и stale-update защитой.
+- `RecordNormalizationIssueAction`.
+- `NormalizationCompletedEvent` и `AffectedPeriod`.
+- `IngestionFacade`.
+- `NormalizeRawRecordMessage` и handler.
+- `IngestRawRecord` расширен методами normalization status.
+
+**Ключевой результат:** появился единый canonical pipeline, куда разные маркетплейсы могут приводить данные в общий формат. P&L может строиться от канона, а не от legacy-документов.
+
+## Блок 6: Ozon Connector
+
+**Статус:** DONE
+
+Реализована новая Ozon-загрузка поверх legacy API без изменения legacy flow:
+
+- `LegacyOzonClientAdapter`.
+- Ozon credential provider/adapter interfaces.
+- `OzonSellerReportConnector`.
+- Mappers:
+  - daily seller report mapper
+  - realization report mapper
+  - transaction component mapper
+- Ozon resource/type helpers.
+- Money/parser/operation key helpers.
+- Anonymized fixtures для Ozon.
+- Документация mapping: `docs/ingestion/ozon-mapping.md`.
+- Unit/integration tests на connector, mapper, registry, flow.
+- Live API calls не выполнялись.
+
+**Ключевой результат:** Ozon можно прогонять через новый Ingestion pipeline, при этом старый Marketplace/Ozon pipeline не выключен и не изменен.
+
+## Блок 7: P&L Projection
+
+**Статус:** DONE
+
+Реализована инфраструктура dirty-period и rebuild P&L:
+
+- `PLDirtyPeriod` в `App\Ingestion` для состояния dirty-period pipeline.
+- `PLDirtyPeriodStatus`, `PLDirtyPeriodReason`.
+- `PLDirtyPeriodRepository`.
+- `PLDirtyPeriod` реализует `TenantOwnedInterface`.
+- Миграция `Version20260618140000`:
+  - таблица `pnl_dirty_periods`
+  - nullable `rebuilt_at` в `pl_daily_totals`
+  - nullable `rebuilt_at` в `pl_monthly_snapshots`
+- `MarkPnlPeriodDirtyAction`.
+- `NormalizationCompletedSubscriber`, который отмечает affected periods после normalization.
+- `MaybeBlockByClosePeriodAction`.
+- `RebuildPnlPeriodAction`.
+- `PnlCategoryResolver`, `PnlPeriodResolver`, `PnlProjectDirectionResolver`.
+- `PnlFacade`.
+- `MarkPnlPeriodDirtyMessage`, `RebuildPnlPeriodMessage` и handlers.
+- CLI command: `finance:pnl:rebuild-dirty`.
+- Messenger route: `pnl_rebuild`.
+
+**Важное архитектурное решение:**
+
+- `PLDirtyPeriod*` принадлежит `App\Ingestion`; Finance оставляет только orchestration-классы для mark/rebuild.
+- `shop_ref` не добавлен в `pl_daily_totals` или `pl_monthly_snapshots`.
+- Source-scoped rebuild сейчас блокируется.
+- Отдельный вопрос после приемки сохранен в `docs/tasks/ingestion/FOLLOWUP-finance-source-linking.md`: где правильно хранить source/origin links в Finance, вероятно ближе к `Document` / `DocumentOperation`, и возможно под другим бизнес-названием.
+
+**Ключевой результат:** P&L теперь может пересобираться из canonical Ingestion transactions по dirty periods. Production switch/cron не включались.
+
+## Проверки
+
+Финально пройдено:
+
+- `make site-test-unit` - OK, 1070 tests / 6438 assertions; остались существующие 1 warning и 1 deprecation.
+- Focused integration по Ingestion/P&L - OK, 47 tests / 206 assertions; остались 2 существующих PHPUnit deprecations в Marketplace/MarketplaceAds.
+- `lint:container --env=test` - OK.
+- `doctrine:schema:validate --skip-sync --env=test` - OK по mapping.
+- Scoped `php-cs-fixer` по измененным файлам - OK.
+- `git diff --check` - OK.
+
+Известное ограничение:
+
+- `make site-cs-check` падает на существующем style drift вне scope: 659/1728 файлов. Dry-run ничего не изменил.
+
+## Что не включалось
+
+- Блоки 8 и 9.
+- UI verification page.
+- Shadow/admin workflow.
+- Production cron/worker включение.
+- Production switch с legacy Ozon/P&L на новый Ingestion flow.
+- Live external Ozon API calls.
+
+## Что проверить владельцу
+
+- Миграции перед запуском в shared/prod окружении.
+- Messenger transport/routing и ожидания по workers.
+- P&L rebuild semantics: delete-and-rebuild за company/month, category mapping, close-period guard, retry behavior.
+- Ozon mapper output на representative real reports перед shadow mode.
+- Follow-up по Finance source/origin linking до добавления source reference fields.

--- a/docs/tasks/ingestion/TASK-04-cursor-syncjob.md
+++ b/docs/tasks/ingestion/TASK-04-cursor-syncjob.md
@@ -1,0 +1,551 @@
+# TASK — БЛОК 4: Ingestion · Cursor + SyncJob (оркестрация)
+
+## 0. Сводка
+
+- **Бизнес-цель.** Ввести единый слой курсоров и заданий синхронизации для нового модуля `Ingestion`, чтобы оркестрация бэкфилла/инкрементов перестала дублироваться по источникам (сейчас 5 разных cursor-сущностей в legacy) и стала единообразной для всех будущих коннекторов. Без бизнес-логики конкретного источника.
+- **Модуль.** `App\Ingestion` (новый, продолжение блоков 1-3).
+- **Тип.** feature.
+- **Ветка.** `feature/ingestion-04-cursor-syncjob`.
+- **Подзадачи.** B1 Entity+миграция · B2 Repository · B3 Доменная политика state machine · B4 Action'ы (планирование/чанкинг/завершение) · B5 Facade · B6 Messenger inbound (только контракт сообщения, без handler'ов источника) · B7 Тесты.
+- **Затрагивает другие модули.** Нет.
+- **Требует миграции БД.** Да (две таблицы).
+- **Меняет публичный API.** Нет (HTTP API не вводим, только Facade для будущих коннекторов).
+
+---
+
+## 1. Контекст и границы
+
+### 1.1 Текущее состояние
+
+- Курсоры разрозненны: `BankImportCursor`, `MarketplaceFinancialReportSyncStatus.nextRrdId`, `AdScheduledBatch`, `InventorySnapshotSession`, legacy `ozon_sync_cursor`.
+- Чанкинг бэкфилла реализован по-разному в каждом источнике.
+- В Ingestion готов нижний слой (raw + credentials + изоляция), но нет оркестрации.
+- Существует `CompanyFilter` (блок 1), `RawStorageFacade::store` (блок 3) — новый модуль их использует.
+
+### 1.2 Желаемое состояние
+
+- Один тип Entity `IngestCursor` хранит «где я остановился» для пары (connection, resource, shop).
+- Один тип Entity `SyncJob` описывает выполняемое задание sync — бэкфилл/инкремент/manual; родительский job делится на дочерние чанки.
+- Курсор обновляется ТОЛЬКО после успешной записи raw (не после fetch).
+- State machine `SyncJob` явная, переходы валидируются доменной политикой.
+- Появляется Facade для будущих коннекторов: `startBackfill`, `runIncremental`, `progress`.
+- Rate limit между запросами одного источника — через Redis Lock (`LockFactory` + RedisStore).
+
+### 1.3 In scope
+
+- `IngestCursor`, `SyncJob` (Entity + миграция + индексы).
+- Repository обеих сущностей с обязательным `companyId`.
+- Enum `SyncJobKind`, `SyncJobStatus`.
+- Доменная политика `SyncJobTransitionPolicy` для state machine.
+- Action: `StartBackfillAction`, `SplitJobIntoChunksAction`, `MarkJobRunningAction`, `MarkJobCompletedAction`, `MarkJobFailedAction`, `UpdateCursorAction`.
+- Facade `SyncFacade` как единая точка для будущих коннекторов (блок 6).
+- Сообщения Messenger: `RunSyncChunkMessage` (контракт; **handler в блоке 5/6**, здесь только класс Message и routing в `messenger.yaml`).
+- Транспорт `ingest_fetch` (как алиас к `async_sync`) и `ingest_normalize` (как алиас к `async_pipeline`) — заводим оба, используем в блоках 5-6.
+- Service rate limit `IngestRateLimitGuard` поверх Redis Lock.
+
+### 1.4 Out of scope
+
+- Реальные HTTP-вызовы к источникам (блок 5/6).
+- Handler `RunSyncChunkMessage` (блок 5).
+- Канон `FinancialTransaction` и нормализация (блок 5).
+- Конкретный `OzonSellerReportConnector` (блок 6).
+- HTTP API для управления sync (блок 8).
+- Admin-интерфейс для управления sync-job'ами (блок 9).
+
+### 1.5 Допущения и открытые вопросы
+
+- Допущение: `connectionRef` — строковый идентификатор подключения (UUID или код), формат прозрачен для блока 4, конкретные значения определяет коннектор в блоке 6.
+- Допущение: rate-limit лимиты на источник конфигурируются через параметры сервиса в `services.yaml` (в блоке 6 коннектор задаст реальные значения; здесь — дефолт 60 запросов/мин на ключ).
+
+---
+
+## 2. Доменная модель
+
+### 2.1 Сущности (Entity)
+
+#### `App\Ingestion\Entity\IngestCursor`
+
+Файл: `src/Ingestion/Entity/IngestCursor.php`.
+Таблица: `#[ORM\Table(name: 'ingest_cursors')]`.
+Реализует `TenantOwnedInterface` (для CompanyFilter из блока 1).
+
+| Поле | Тип PHP | Колонка БД | Nullable | Default | Инвариант / правило |
+|---|---|---|---|---|---|
+| `id` | `string` (UUID v7) | `id` GUID | нет | — | PK; `Uuid::uuid7()->toString()` в конструкторе |
+| `companyId` | `string` UUID | `company_id` GUID | нет | — | `Assert::uuid`; неизменяем (нет setter) |
+| `connectionRef` | `string` | `connection_ref` VARCHAR(255) | нет | — | `Assert::notEmpty`; неизменяем |
+| `resourceType` | `string` | `resource_type` VARCHAR(100) | нет | — | `Assert::notEmpty`; неизменяем |
+| `shopRef` | `string` | `shop_ref` VARCHAR(255) | нет | `''` | пустая строка — «нет shop»; неизменяем |
+| `cursorValue` | `string` | `cursor_value` VARCHAR(1024) | нет | `''` | opaque; формат — забота коннектора |
+| `lastFetchedAt` | `?DateTimeImmutable` | `last_fetched_at` TIMESTAMP(6) | да | `null` | время последнего успешного fetch |
+| `lastSyncJobId` | `?string` | `last_sync_job_id` GUID | да | `null` | ссылка на последний SyncJob, обновивший курсор |
+| `createdAt` | `DateTimeImmutable` | `created_at` TIMESTAMP(6) | нет | — | в конструкторе |
+| `updatedAt` | `DateTimeImmutable` | `updated_at` TIMESTAMP(6) | нет | — | обновлять при `advance()` |
+
+Конструктор: `__construct(string $companyId, string $connectionRef, string $resourceType, string $shopRef = '')` — выставляет id, companyId, connectionRef, resourceType, shopRef, createdAt=now, updatedAt=now; `cursorValue=''`, `lastFetchedAt=null`, `lastSyncJobId=null`.
+
+Поведенческий метод (без тела):
+- `advance(string $newCursorValue, string $syncJobId, ?DateTimeImmutable $fetchedAt = null): void` — устанавливает `cursorValue`, `lastSyncJobId`, `lastFetchedAt = $fetchedAt ?? now`, `updatedAt = now`. Инвариант: `$newCursorValue` не пустой.
+
+Геттеры: всех полей.
+
+#### `App\Ingestion\Entity\SyncJob`
+
+Файл: `src/Ingestion/Entity/SyncJob.php`.
+Таблица: `#[ORM\Table(name: 'ingest_sync_jobs')]`.
+Реализует `TenantOwnedInterface`.
+
+| Поле | Тип PHP | Колонка БД | Nullable | Default | Инвариант / правило |
+|---|---|---|---|---|---|
+| `id` | `string` UUID v7 | `id` GUID | нет | — | PK |
+| `companyId` | `string` UUID | `company_id` GUID | нет | — | `Assert::uuid`; неизменяем |
+| `connectionRef` | `string` | `connection_ref` VARCHAR(255) | нет | — | неизменяем |
+| `source` | `IngestSource` enum | `source` VARCHAR(64) | нет | — | enumType=IngestSource (из блока 3); неизменяем |
+| `resourceType` | `string` | `resource_type` VARCHAR(100) | нет | — | неизменяем |
+| `shopRef` | `string` | `shop_ref` VARCHAR(255) | нет | `''` | неизменяем |
+| `kind` | `SyncJobKind` enum | `kind` VARCHAR(32) | нет | — | BACKFILL/INCREMENTAL/MANUAL; неизменяем |
+| `status` | `SyncJobStatus` enum | `status` VARCHAR(32) | нет | `OPEN` | меняется только через transition-методы |
+| `windowFrom` | `?DateTimeImmutable` | `window_from` DATE | да | `null` | для backfill обязателен; неизменяем после конструктора |
+| `windowTo` | `?DateTimeImmutable` | `window_to` DATE | да | `null` | для backfill обязателен; `windowFrom <= windowTo` |
+| `parentJobId` | `?string` UUID | `parent_job_id` GUID | да | `null` | null для родительского job'а; неизменяем |
+| `progressTotal` | `int` | `progress_total` INTEGER | нет | `0` | количество ожидаемых чанков (для родителя) |
+| `progressDone` | `int` | `progress_done` INTEGER | нет | `0` | количество завершённых чанков |
+| `cursorSnapshot` | `?string` | `cursor_snapshot` VARCHAR(1024) | да | `null` | курсор на момент старта (для отката бэкфилла) |
+| `attempts` | `int` | `attempts` INTEGER | нет | `0` | сколько раз входили в `markRunning` |
+| `lastError` | `?string` | `last_error` TEXT | да | `null` | человекочитаемое сообщение последней ошибки |
+| `startedAt` | `?DateTimeImmutable` | `started_at` TIMESTAMP(6) | да | `null` | время первого `markRunning` |
+| `finishedAt` | `?DateTimeImmutable` | `finished_at` TIMESTAMP(6) | да | `null` | время `markCompleted`/`markFailed` |
+| `createdAt` | `DateTimeImmutable` | `created_at` TIMESTAMP(6) | нет | — | |
+| `updatedAt` | `DateTimeImmutable` | `updated_at` TIMESTAMP(6) | нет | — | обновляется на каждом transition |
+
+Конструктор: `__construct(string $companyId, string $connectionRef, IngestSource $source, string $resourceType, SyncJobKind $kind, ?DateTimeImmutable $windowFrom = null, ?DateTimeImmutable $windowTo = null, string $shopRef = '', ?string $parentJobId = null)`. Инварианты: для `kind=BACKFILL` обязательны `windowFrom` и `windowTo`, `windowFrom <= windowTo`; для остальных — допустимо null. Status стартует с `OPEN`. createdAt/updatedAt=now.
+
+Поведенческие методы (без тел):
+- `markRunning(): void` — переход OPEN→RUNNING (см. §2.4); инкрементирует `attempts`, выставляет `startedAt` если null, `updatedAt=now`. Бросает `SyncJobTransitionException` при недопустимом исходном статусе.
+- `markCompleted(?DateTimeImmutable $finishedAt = null): void` — переход RUNNING→COMPLETED; `finishedAt = $finishedAt ?? now`, `updatedAt=now`.
+- `markFailed(string $reason, ?DateTimeImmutable $finishedAt = null): void` — переход RUNNING→FAILED; сохраняет `lastError = $reason`, `finishedAt = $finishedAt ?? now`.
+- `markCancelled(string $reason): void` — переход OPEN→CANCELLED или RUNNING→CANCELLED; сохраняет `lastError = $reason`.
+- `incrementProgress(int $delta = 1): void` — `progressDone += $delta`; `updatedAt=now`. Инвариант: `progressDone <= progressTotal` (если `progressTotal > 0`).
+- `setProgressTotal(int $total): void` — выставляет `progressTotal`; используется при сплите на чанки. Инвариант: вызывается один раз для родителя.
+- `setCursorSnapshot(string $value): void` — сохраняет `cursorSnapshot` (только один раз, до перехода в RUNNING).
+
+Геттеры: всех полей.
+
+### 2.2 Связи
+
+- Внутри модуля: `SyncJob.parentJobId` — ссылка строкой (не ManyToOne, чтобы не создавать каскадные удаления). Иерархия родитель→дочерние ограничена одной нестингом (job либо родитель с детьми, либо дочерний/самостоятельный).
+- Между модулями: нет связей.
+
+### 2.3 Enum
+
+#### `App\Ingestion\Enum\SyncJobKind`
+
+Файл: `src/Ingestion/Enum/SyncJobKind.php`. Backed string.
+
+| Case | value | Когда устанавливается | Метка | Терминальный |
+|---|---|---|---|---|
+| `BACKFILL` | `backfill` | Загрузка исторических данных за период | «Бэкфилл» | нет |
+| `INCREMENTAL` | `incremental` | Регулярный инкремент с курсора | «Инкремент» | нет |
+| `MANUAL` | `manual` | Ручной запуск пользователем/админом | «Ручной» | нет |
+
+Методы:
+- `label(): string` — человекочитаемая метка (русская строка из таблицы выше).
+
+#### `App\Ingestion\Enum\SyncJobStatus`
+
+Файл: `src/Ingestion/Enum/SyncJobStatus.php`. Backed string.
+
+| Case | value | Когда устанавливается | Метка | Терминальный |
+|---|---|---|---|---|
+| `OPEN` | `open` | После создания, ещё не запущен | «Создан» | нет |
+| `RUNNING` | `running` | `markRunning()` | «Выполняется» | нет |
+| `COMPLETED` | `completed` | `markCompleted()` | «Завершён» | да |
+| `FAILED` | `failed` | `markFailed()` | «Ошибка» | да |
+| `CANCELLED` | `cancelled` | `markCancelled()` | «Отменён» | да |
+
+Методы:
+- `label(): string`.
+- `isTerminal(): bool` — true для COMPLETED, FAILED, CANCELLED.
+- `canTransitionTo(SyncJobStatus $next): bool` — реализует матрицу §2.4.
+
+### 2.4 Матрица переходов статусов
+
+| из / в | OPEN | RUNNING | COMPLETED | FAILED | CANCELLED |
+|---|---|---|---|---|---|
+| OPEN | ❌ | ✅ | ❌ | ❌ | ✅ |
+| RUNNING | ❌ | ✅ (retry, инкрементирует attempts) | ✅ | ✅ | ✅ |
+| COMPLETED | ❌ | ❌ | ❌ | ❌ | ❌ |
+| FAILED | ❌ | ❌ | ❌ | ❌ | ❌ |
+| CANCELLED | ❌ | ❌ | ❌ | ❌ | ❌ |
+
+Запрещённый переход → `SyncJobTransitionException` (§6).
+
+---
+
+## 3. Слой доступа к данным
+
+### 3.1 Repository
+
+#### `App\Ingestion\Repository\IngestCursorRepository`
+
+Файл: `src/Ingestion/Repository/IngestCursorRepository.php`. `final class`, extends `ServiceEntityRepository<IngestCursor>`.
+
+| Метод | Что делает | companyId | Возврат |
+|---|---|---|---|
+| `findOne(string $companyId, string $connectionRef, string $resourceType, string $shopRef = ''): ?IngestCursor` | Поиск курсора по ключу. Уникальный, может быть null. | да | `?IngestCursor` |
+| `getOrCreate(string $companyId, string $connectionRef, string $resourceType, string $shopRef = ''): IngestCursor` | Возвращает существующий или создаёт новый (persist, **без flush**). | да | `IngestCursor` |
+
+flush() запрещён внутри методов Repository. find() без companyId запрещён.
+
+#### `App\Ingestion\Repository\SyncJobRepository`
+
+Файл: `src/Ingestion/Repository/SyncJobRepository.php`. `final class`.
+
+| Метод | Что делает | companyId | Возврат |
+|---|---|---|---|
+| `findByIdAndCompany(string $id, string $companyId): ?SyncJob` | Поиск по ID с IDOR-проверкой | да | `?SyncJob` |
+| `findOpenChildrenOf(string $parentJobId, string $companyId): list<SyncJob>` | Все non-terminal дочерние чанки родителя | да | `list<SyncJob>` |
+| `countChildrenByStatus(string $parentJobId, string $companyId, SyncJobStatus $status): int` | Подсчёт детей в статусе (для финализации родителя) | да | `int` |
+| `findLatestForResource(string $companyId, string $connectionRef, string $resourceType, string $shopRef = ''): ?SyncJob` | Последний non-terminal job по ресурсу (для защиты от двойного запуска) | да | `?SyncJob` |
+
+### 3.2 Query
+
+N/A — на этом этапе read-моделей через DBAL не вводим, list-эндпоинтов нет.
+
+### 3.3 Индексы
+
+`ingest_cursors`:
+- UNIQUE `(company_id, connection_ref, resource_type, shop_ref)` → `uniq_ingest_cursor_key`.
+- INDEX `(company_id, connection_ref)` → `idx_ingest_cursor_company_connection`.
+
+`ingest_sync_jobs`:
+- INDEX `(company_id, status)` → `idx_ingest_sync_job_company_status`.
+- INDEX `(company_id, connection_ref, resource_type, status)` → `idx_ingest_sync_job_resource_status`.
+- INDEX `(parent_job_id)` → `idx_ingest_sync_job_parent`.
+- INDEX `(company_id, kind, status)` → `idx_ingest_sync_job_kind_status`.
+
+---
+
+## 4. Слой приложения
+
+### 4.1 Action
+
+Все Action — `final class`, единственный `__invoke`. Вход — Command DTO (§4.3). flush() — здесь.
+
+#### `App\Ingestion\Application\Action\StartBackfillAction`
+
+Вход: `StartBackfillCommand`.
+Шаги:
+1. Получить `SyncJob` родительского запуска для (companyId, connectionRef, resourceType, shopRef) через `SyncJobRepository::findLatestForResource`. Если non-terminal — бросить `ActiveBackfillExistsException` (§6).
+2. Создать новый `SyncJob` родителя с `kind=BACKFILL`, заданным окном, `status=OPEN`, `parentJobId=null`.
+3. persist + flush.
+4. Вернуть id созданного job'а (`string`).
+
+Транзакционность: одна транзакция.
+
+#### `App\Ingestion\Application\Action\SplitJobIntoChunksAction`
+
+Вход: `SplitJobCommand` (`string $parentJobId, string $companyId, int $chunkSizeInDays = 7`).
+Шаги:
+1. Найти родителя через `findByIdAndCompany`. Если нет — `SyncJobNotFoundException`. Если `kind != BACKFILL` или нет окна — `InvalidJobForSplitException`.
+2. Если `progressTotal > 0` — бросить `JobAlreadySplitException` (повторный сплит запрещён).
+3. Разбить окно `[windowFrom, windowTo]` на чанки по `$chunkSizeInDays` дней (последний может быть короче).
+4. Для каждого чанка создать дочерний `SyncJob` (`kind=BACKFILL`, `parentJobId=родитель`, окно чанка, `status=OPEN`). persist.
+5. Вызвать `parent->setProgressTotal($numberOfChunks)`.
+6. flush.
+7. Для каждого дочернего job'а dispatch `RunSyncChunkMessage` (§5) в транспорт `ingest_fetch`.
+8. Вернуть `list<string>` id дочерних job'ов.
+
+Транзакционность: одна транзакция БД; dispatch сообщений — после flush.
+
+#### `App\Ingestion\Application\Action\MarkJobRunningAction`
+
+Вход: `MarkJobRunningCommand` (`string $jobId, string $companyId, ?string $cursorSnapshot = null`).
+Шаги:
+1. `findByIdAndCompany` → `SyncJobNotFoundException`.
+2. Если status не позволяет переход в RUNNING — `SyncJobTransitionException`.
+3. Если передан `$cursorSnapshot` и текущий null — установить через `setCursorSnapshot`.
+4. `job->markRunning()`.
+5. flush.
+
+#### `App\Ingestion\Application\Action\MarkJobCompletedAction`
+
+Вход: `MarkJobCompletedCommand` (`string $jobId, string $companyId`).
+Шаги:
+1. Загрузить + IDOR.
+2. `job->markCompleted()`.
+3. Если у job'а есть `parentJobId` — вызвать `MaybeFinalizeParentAction` (см. ниже).
+4. flush.
+
+#### `App\Ingestion\Application\Action\MarkJobFailedAction`
+
+Вход: `MarkJobFailedCommand` (`string $jobId, string $companyId, string $reason`).
+Шаги:
+1. Загрузить + IDOR.
+2. `job->markFailed($reason)`.
+3. Если есть `parentJobId` — также `MaybeFinalizeParentAction` (родитель завершится, когда все дети терминальны).
+4. flush.
+
+#### `App\Ingestion\Application\Action\MaybeFinalizeParentAction` (internal)
+
+Вход: `string $parentJobId, string $companyId`.
+Шаги:
+1. Загрузить родителя через `findByIdAndCompany`.
+2. Подсчитать через `countChildrenByStatus`: COMPLETED, FAILED, CANCELLED.
+3. Если сумма терминальных = `progressTotal`:
+   - если все COMPLETED → `parent->markCompleted()`;
+   - иначе → `parent->markFailed("partial failure: X failed, Y completed")`.
+4. Иначе ничего не делать.
+5. Без flush (вызывающий Action делает flush).
+
+#### `App\Ingestion\Application\Action\UpdateCursorAction`
+
+Вход: `UpdateCursorCommand` (`string $companyId, string $connectionRef, string $resourceType, string $shopRef, string $newCursorValue, string $syncJobId, ?DateTimeImmutable $fetchedAt = null`).
+Шаги:
+1. Получить курсор через `IngestCursorRepository::getOrCreate`.
+2. `cursor->advance($newCursorValue, $syncJobId, $fetchedAt)`.
+3. flush.
+
+### 4.2 Domain Service / Policy
+
+#### `App\Ingestion\Domain\Service\SyncJobTransitionPolicy`
+
+Файл: `src/Ingestion/Domain/Service/SyncJobTransitionPolicy.php`. `final class`, без зависимостей (чистая логика).
+
+Методы (без тел):
+- `assertCanTransition(SyncJobStatus $from, SyncJobStatus $to): void` — бросает `SyncJobTransitionException` если переход не разрешён матрицей §2.4. Используется методами Entity внутри `markRunning/Completed/Failed/Cancelled`.
+
+### 4.3 DTO
+
+Command (final readonly class):
+
+#### `App\Ingestion\Application\Command\StartBackfillCommand`
+
+| Поле | Тип | Обязательно | Валидация |
+|---|---|---|---|
+| `companyId` | string | да | UUID |
+| `connectionRef` | string | да | not empty |
+| `source` | IngestSource | да | enum |
+| `resourceType` | string | да | not empty |
+| `shopRef` | string | да | может быть '' |
+| `windowFrom` | DateTimeImmutable | да | дата (Y-m-d) |
+| `windowTo` | DateTimeImmutable | да | windowFrom <= windowTo |
+
+#### `App\Ingestion\Application\Command\SplitJobCommand`
+
+Поля: `parentJobId: string` UUID, `companyId: string` UUID, `chunkSizeInDays: int` (default 7, range 1..90).
+
+#### `App\Ingestion\Application\Command\MarkJobRunningCommand`
+
+Поля: `jobId: string` UUID, `companyId: string` UUID, `cursorSnapshot: ?string`.
+
+#### `App\Ingestion\Application\Command\MarkJobCompletedCommand`
+
+Поля: `jobId: string` UUID, `companyId: string` UUID.
+
+#### `App\Ingestion\Application\Command\MarkJobFailedCommand`
+
+Поля: `jobId: string` UUID, `companyId: string` UUID, `reason: string` (not empty, max 2000).
+
+#### `App\Ingestion\Application\Command\UpdateCursorCommand`
+
+Поля: `companyId: string` UUID, `connectionRef: string`, `resourceType: string`, `shopRef: string` (можно ''), `newCursorValue: string` not empty, `syncJobId: string` UUID, `fetchedAt: ?DateTimeImmutable`.
+
+### 4.4 Facade
+
+#### `App\Ingestion\Facade\SyncFacade`
+
+Файл: `src/Ingestion/Facade/SyncFacade.php`. `final readonly class`.
+
+Методы (сигнатура + смысл):
+- `startBackfill(StartBackfillCommand $command): string` — оборачивает `StartBackfillAction` + сразу зовёт `SplitJobIntoChunksAction` для свежесозданного родителя. Возвращает `parentJobId`.
+- `markJobRunning(MarkJobRunningCommand $command): void` — оборачивает `MarkJobRunningAction`.
+- `markJobCompleted(MarkJobCompletedCommand $command): void`.
+- `markJobFailed(MarkJobFailedCommand $command): void`.
+- `updateCursor(UpdateCursorCommand $command): void`.
+- `getProgress(string $jobId, string $companyId): SyncJobProgressView` — DTO с полями `jobId, status, progressDone, progressTotal, attempts, lastError`. Read-only для будущего HTTP API (блок 8).
+
+`SyncJobProgressView` — `App\Ingestion\Application\DTO\SyncJobProgressView`, `final readonly class`.
+
+### 4.5 Rate Limit Service
+
+#### `App\Ingestion\Application\Service\IngestRateLimitGuard`
+
+Файл: `src/Ingestion/Application/Service/IngestRateLimitGuard.php`. `final class`. Использует существующий Redis Lock проекта (`LockFactory` + RedisStore).
+
+Метод:
+- `acquire(string $sourceKey, int $maxLockMs = 60000): \Symfony\Component\Lock\LockInterface` — берёт Lock с ключом `ingest_rate:{$sourceKey}`. Возвращает `LockInterface`, caller обязан вызвать `release()` после окончания работы.
+
+В этом блоке только инфраструктура (класс + интеграция в DI). Использование — в блоках 5-6.
+
+---
+
+## 5. Асинхронность (Messenger)
+
+### 5.1 Сообщения
+
+#### `App\Ingestion\Message\RunSyncChunkMessage`
+
+Файл: `src/Ingestion/Message/RunSyncChunkMessage.php`. `final readonly class`, реализует `CompanyAwareMessage` (из блока 1).
+
+Поля: `companyId: string` UUID, `jobId: string` UUID. Метод `getCompanyId(): string`.
+
+Только scalar ID. Никаких Entity внутри Message.
+
+### 5.2 Handler
+
+В этом блоке handler **не создаём** — Message только определяется и регистрируется в routing. Handler `RunSyncChunkHandler` появится в блоке 5 (он использует контракт `SourceConnectorInterface`, которого здесь ещё нет).
+
+### 5.3 Routing
+
+`config/packages/messenger.yaml` — добавить:
+
+```yaml
+framework:
+  messenger:
+    transports:
+      ingest_fetch:
+        dsn: '%env(MESSENGER_TRANSPORT_DSN_SYNC)%'   # алиас на async_sync DSN
+        retry_strategy:
+          max_retries: 3
+          delay: 10000
+          multiplier: 2
+      ingest_normalize:
+        dsn: '%env(MESSENGER_TRANSPORT_DSN_PIPELINE)%'   # алиас на async_pipeline DSN
+        retry_strategy:
+          max_retries: 3
+          delay: 5000
+          multiplier: 2
+    routing:
+      App\Ingestion\Message\RunSyncChunkMessage: ingest_fetch
+```
+
+`messenger.yaml` в `test` окружении уже маппит async-транспорты в in-memory — `ingest_fetch`/`ingest_normalize` тоже должны попасть в in-memory под test (добавить override).
+
+### 5.4 Идемпотентность
+
+Идемпотентность handler'а — забота блока 5/6 (он использует `IdempotentHandlerTrait` из PATTERNS §22 с natural key `RunSyncChunkMessage` = jobId).
+
+В блоке 4 достаточно гарантии, что родительский job не может быть сплитнут повторно (см. `JobAlreadySplitException` в `SplitJobIntoChunksAction`).
+
+---
+
+## 6. Обработка ошибок
+
+Все исключения — `final class`, extends `\DomainException` (или подкласс), namespace `App\Ingestion\Exception`.
+
+| Класс | Когда | HTTP-статус | error.code | error.message |
+|---|---|---|---|---|
+| `SyncJobNotFoundException` | `findByIdAndCompany` вернул null | 404 | `sync_job_not_found` | «Задание синхронизации не найдено» |
+| `SyncJobTransitionException` | Запрещённый переход статуса | 409 | `sync_job_invalid_transition` | «Недопустимый переход статуса задания» |
+| `ActiveBackfillExistsException` | Попытка запустить второй backfill при non-terminal первом | 409 | `sync_backfill_already_running` | «Бэкфилл по этому ресурсу уже выполняется» |
+| `InvalidJobForSplitException` | Сплит вызван для не-backfill job'а или без окна | 422 | `sync_job_not_splittable` | «Это задание нельзя разбить на чанки» |
+| `JobAlreadySplitException` | Повторный вызов `SplitJobIntoChunksAction` | 409 | `sync_job_already_split` | «Задание уже разбито на чанки» |
+| `CursorNotFoundException` | (зарезервировано на будущее, в блоке 4 не используется) | 404 | `sync_cursor_not_found` | «Курсор не найден» |
+
+HTTP-статусы носят информационный характер на этом этапе (ExceptionListener для Ingestion появится в блоке 8). Здесь — фиксируем коды в исключении (поле/метод `getErrorCode(): string`).
+
+---
+
+## 7. HTTP API (Controller)
+
+N/A — в блоке 4 HTTP-эндпоинты не вводятся. HTTP-управление sync появится в блоке 8.
+
+---
+
+## 8. Разбивка на подзадачи
+
+| Этап | Что входит | Зависит от | Риск | Тесты |
+|---|---|---|---|---|
+| B1 | Enum + Entity `IngestCursor`, `SyncJob` + миграция | — | 🔴 | unit на инварианты конструктора |
+| B2 | Repository обеих сущностей | B1 | 🟡 | integration на каждый метод + tenant-leak |
+| B3 | `SyncJobTransitionPolicy` + transition-методы Entity | B1 | 🟢 | unit на каждый разрешённый/запрещённый переход |
+| B4 | Action'ы (Start/Split/MarkRunning/MarkCompleted/MarkFailed/MaybeFinalize/UpdateCursor) | B2, B3 | 🟡 | integration на каждый Action |
+| B5 | `SyncFacade` + DTO `SyncJobProgressView` | B4 | 🟢 | integration на каждый метод |
+| B6 | Message `RunSyncChunkMessage` + routing | B1 | 🟡 | unit на CompanyAwareMessage |
+| B7 | `IngestRateLimitGuard` + DI | — | 🟢 | integration с in-memory Lock |
+| B8 | Регрессионные тесты + `ARCHITECTURE.md` | все | 🟢 | tenant-leak end-to-end |
+
+Детализация:
+
+**B1**
+- Цель: ввести Entity и enum для cursor/sync job.
+- Создаёт: `src/Ingestion/Entity/{IngestCursor.php,SyncJob.php}`, `src/Ingestion/Enum/{SyncJobKind.php,SyncJobStatus.php}`, `src/Ingestion/Exception/{SyncJobTransitionException.php,SyncJobNotFoundException.php,ActiveBackfillExistsException.php,InvalidJobForSplitException.php,JobAlreadySplitException.php,CursorNotFoundException.php}`, миграция `site/migrations/Version20260616120000.php`.
+- Меняет: ничего legacy.
+- DoD: миграция применяется, schema-validate зелёный, конструкторы валидируют инварианты unit-тестами.
+- Зависимости: блок 1 (`TenantOwnedInterface`), блок 3 (`IngestSource`).
+
+**B2**
+- Цель: Repository с обязательным companyId.
+- Создаёт: `src/Ingestion/Repository/{IngestCursorRepository.php,SyncJobRepository.php}`.
+- DoD: tenant-leak тест на каждый read-метод (компания A не видит B).
+
+**B3**
+- Цель: явная state machine в Entity + Policy.
+- Создаёт: `src/Ingestion/Domain/Service/SyncJobTransitionPolicy.php`.
+- Меняет: `SyncJob` (методы markRunning/Completed/Failed/Cancelled зовут Policy).
+- DoD: unit-таблица переходов: 5×5 кейсов из §2.4.
+
+**B4-B5-B6-B7** — реализация по §4-§5.
+
+**B8** — добавление раздела «Cursor + SyncJob» в `ARCHITECTURE.md` (новые Entity/Enum/Facade-методы).
+
+---
+
+## 9. Ограничения и запреты
+
+- Не ломать: существующие cron-команды legacy-загрузки, `MarketplaceRawDocument`, `BankImportCursor`, `AdScheduledBatch` — они продолжают работать параллельно.
+- Не трогать файлы вне `src/Ingestion/`, `config/packages/messenger.yaml` (только добавление transport+routing), `site/migrations/` (новая миграция).
+- Совместимость API: HTTP API нет.
+- Миграции: zero-downtime, только CREATE TABLE + индексы. Никаких ALTER на существующих таблицах.
+- Performance: пагинации на этом этапе нет (read-методы Repository возвращают одиночные сущности или ограниченный список детей). N+1 защищается тем, что `findOpenChildrenOf` сразу возвращает list, без lazy.
+- Безопасность: companyId обязателен на каждом Repository-методе; `CompanyFilter` из блока 1 покрывает обе Entity автоматически (через `TenantOwnedInterface`).
+
+---
+
+## 10. Критерии приёмки
+
+Функциональные:
+- [ ] `IngestCursor.advance` обновляет cursorValue, lastSyncJobId, lastFetchedAt, updatedAt.
+- [ ] `SyncJob` запрещает переходы, не входящие в матрицу §2.4 (по тестам).
+- [ ] `StartBackfillAction` отказывает повторно при наличии non-terminal job'а на ресурсе.
+- [ ] `SplitJobIntoChunksAction` корректно разбивает 30-дневное окно на 5 семидневных чанков (последний — 2 дня), отказывает при повторном вызове.
+- [ ] При завершении последнего дочернего чанка `MaybeFinalizeParentAction` финализирует родителя (COMPLETED если все ок, FAILED если есть упавшие).
+- [ ] `UpdateCursorAction` создаёт курсор при первом вызове и обновляет при последующих.
+- [ ] `SyncFacade.startBackfill` создаёт родителя и сразу диспатчит N дочерних сообщений в `ingest_fetch`.
+- [ ] `IngestRateLimitGuard.acquire` возвращает удерживаемый Lock; повторный acquire с тем же ключом в пределах TTL — null/throws (в зависимости от реализации Lock).
+
+Технические:
+- [ ] `make site-cs-check` зелёный.
+- [ ] PHPStan уровень проекта зелёный.
+- [ ] `make site-test-unit` + `make site-test-integration` — зелёные.
+- [ ] Миграция применяется и откатывается чисто.
+- [ ] Tenant-leak тест: компания A не видит SyncJob/IngestCursor компании B через ORM (фильтр включён) и через Repository (даже если фильтр выключен — явный companyId в запросе).
+- [ ] Messenger в test окружении использует in-memory transport для `ingest_fetch`/`ingest_normalize`.
+- [ ] `ARCHITECTURE.md` обновлён: добавлены новые Entity, Enum, методы Facade.
+- [ ] OpenAPI не меняется (HTTP-эндпоинтов нет).
+
+---
+
+## 11. План отката
+
+- Откат миграции `Version20260616120000` — DROP двух новых таблиц. Никаких внешних зависимостей не образовано (`RunSyncChunkMessage` handler ещё не существует).
+- Если необходимо отключить feature до удаления кода — выкинуть routing `App\Ingestion\Message\RunSyncChunkMessage` из `messenger.yaml`; Facade останется неиспользованным.
+- Зависимости вниз: блок 5 будет использовать `SyncFacade` и `RunSyncChunkMessage`. До старта блока 5 откат блока 4 безопасен.
+
+---
+
+## 12. Чек-лист качества ТЗ
+
+- [x] Полный namespace и путь файла для каждого нового класса.
+- [x] Полная таблица полей обеих Entity с типами, nullable, default, инвариантами.
+- [x] Каждый enum case описан: value, когда ставится, метка, терминальность.
+- [x] Матрица переходов 5×5 для `SyncJobStatus`.
+- [x] Сигнатура каждого метода Repository/Action/Facade.
+- [x] Каждый Repository/read-метод принимает `string $companyId`.
+- [x] HTTP-контракт — N/A явно отмечен.
+- [x] Каждое исключение замаплено на HTTP-статус и `error.code`.
+- [x] Индексы перечислены явно с именами.
+- [x] Транспорты Messenger (`ingest_fetch`/`ingest_normalize`) указаны.
+- [x] Формат данных: ISO 8601 для дат, UUID для id, snake_case для enum value.
+- [x] Out of scope зафиксирован (раздел 1.4).

--- a/docs/tasks/ingestion/TASK-05-connector-canon.md
+++ b/docs/tasks/ingestion/TASK-05-connector-canon.md
@@ -1,0 +1,614 @@
+# TASK — БЛОК 5: Ingestion · Контракт коннектора + канон + нормализация
+
+## 0. Сводка
+
+- **Бизнес-цель.** Ввести единый контракт `SourceConnectorInterface` и канонический финансовый домен (`FinancialTransaction`), к которому подключаются все будущие источники. Это лекарство от дублирования processors/clients/mappers по источникам в legacy. В блоке 5 — на заглушечном `FakeConnector`, реальный Ozon — в блоке 6.
+- **Модуль.** `App\Ingestion`.
+- **Тип.** feature (центральный блок).
+- **Ветка.** `feature/ingestion-05-connector-canon-normalize`.
+- **Подзадачи.** B1 Domain contracts · B2 Money + канон · B3 Реестр коннекторов · B4 Маппер-контракт · B5 NormalizeRawRecordAction · B6 RunSyncChunkHandler · B7 FakeConnector + FakeMapper · B8 Доменное событие + сверка · B9 Тесты.
+- **Затрагивает другие модули.** Нет.
+- **Требует миграции БД.** Да (3 новые таблицы).
+- **Меняет публичный API.** Нет (HTTP API в блоке 8).
+
+---
+
+## 1. Контекст и границы
+
+### 1.1 Текущее состояние
+
+- Блок 3 готов: `IngestRawRecord` + `RawStorageFacade`.
+- Блок 4 готов: `SyncJob`, `IngestCursor`, `SyncFacade`, `RunSyncChunkMessage` (без handler'а).
+- В Legacy: отдельные processors/actions для Ozon/WB × sales/returns/costs (`Marketplace/Application/Processor/*`), отдельные мапперы на каждом источнике.
+
+### 1.2 Желаемое состояние
+
+- Один `SourceConnectorInterface`: `source/capabilities/discoverShops/pull/push`.
+- Реестр коннекторов через тег `app.ingestion.connector`.
+- Канон `FinancialTransaction` с типизированным enum `TransactionType`; декомпозиция строки отчёта на несколько канонических транзакций с общим `operationGroupId`.
+- `Money` ValueObject (`amountMinor: int` + `currency: string`), запрет смешения валют.
+- `NormalizeRawRecordAction` читает RawRecord, зовёт маппер коннектора (чистая функция), upsert в канон по natural key.
+- `RunSyncChunkHandler` — handler для `RunSyncChunkMessage` (из блока 4): получает коннектор → fetch → store raw → dispatch `NormalizeRawRecordMessage`.
+- Доменное событие `NormalizationCompletedEvent` публикуется после успешной нормализации (для блока 7).
+- После нормализации — сверка суммы канона по `operationGroupId` против контрольной суммы из raw-строки. При расхождении — запись в `NormalizationIssue` и лог.
+- `FakeConnector` + `FakeMapper` для тестирования контракта без реального источника.
+
+### 1.3 In scope
+
+- Domain: `SourceConnectorInterface`, `Capability`, `PullRequest`, `PullResult`, `PushRequest`, `PushResult`, `ShopDescriptor`, `SourceMapperInterface`, `MappedTransaction` DTO.
+- `ConnectorRegistry` (поверх tagged services).
+- `Money` ValueObject + `MoneyMismatchException`.
+- Канон Entity: `FinancialTransaction`, `Counterparty` (минимальный — заглушка), `NormalizationIssue` (для сверки сумм).
+- Enum: `TransactionType`, `TransactionDirection`, `NormalizationIssueKind`.
+- Action: `NormalizeRawRecordAction`, `UpsertFinancialTransactionAction`, `RecordNormalizationIssueAction`.
+- Handler: `RunSyncChunkHandler` (для блока 4 Message), `NormalizeRawRecordHandler`.
+- Message: `NormalizeRawRecordMessage`.
+- Доменное событие: `NormalizationCompletedEvent` + публикация через `EventDispatcher`.
+- Fake: `FakeConnector`, `FakeMapper`, регистрация через тег под `dev`/`test` (но не `prod`).
+- Расширение Facade: `RawStorageFacade` уже есть. Добавляем `IngestionFacade::getTransactions` (используется блоком 7).
+
+### 1.4 Out of scope
+
+- Реальный Ozon — блок 6.
+- Подписка на `NormalizationCompletedEvent` со стороны P&L — блок 7.
+- HTTP API — блок 8.
+- Admin / UI — блок 8-9.
+- `Push`-операции (отчёт комиссионера в МойСклад) — после пилота.
+
+### 1.5 Допущения и открытые вопросы
+
+- Допущение: `Counterparty` в этом блоке — минимальная заглушка (id, companyId, name, externalKey). Полная модель — позже, отдельным блоком при необходимости.
+- Допущение: события публикуются через стандартный `Symfony\Contracts\EventDispatcher\EventDispatcherInterface`; в блоке 5 — только публикация, подписчики нет.
+
+---
+
+## 2. Доменная модель
+
+### 2.1 Сущности (Entity)
+
+#### `App\Ingestion\Entity\FinancialTransaction`
+
+Файл: `src/Ingestion/Entity/FinancialTransaction.php`.
+Таблица: `#[ORM\Table(name: 'ingest_financial_transactions')]`.
+Реализует `TenantOwnedInterface`.
+
+| Поле | Тип PHP | Колонка БД | Nullable | Default | Инвариант |
+|---|---|---|---|---|---|
+| `id` | string UUID v7 | `id` GUID | нет | — | PK |
+| `companyId` | string UUID | `company_id` GUID | нет | — | `Assert::uuid`; неизменяем |
+| `connectionRef` | string | `connection_ref` VARCHAR(255) | нет | — | неизменяем |
+| `shopRef` | string | `shop_ref` VARCHAR(255) | нет | `''` | неизменяем |
+| `source` | IngestSource | `source` VARCHAR(64) | нет | — | enumType=IngestSource; неизменяем |
+| `externalId` | string | `external_id` VARCHAR(255) | нет | — | id операции в источнике; неизменяем |
+| `externalUpdatedAt` | DateTimeImmutable | `external_updated_at` TIMESTAMP(6) | нет | — | для версионирования upsert |
+| `operationGroupId` | string UUID | `operation_group_id` GUID | нет | — | группирует декомпозированные транзакции одной строки отчёта |
+| `type` | TransactionType | `type` VARCHAR(64) | нет | — | enumType=TransactionType |
+| `direction` | TransactionDirection | `direction` VARCHAR(8) | нет | — | enumType=TransactionDirection (`IN`/`OUT`) |
+| `amountMinor` | int | `amount_minor` BIGINT | нет | — | минорные единицы; signed value допускается; `direction` остаётся нормализованной классификацией потока |
+| `currency` | string | `currency` CHAR(3) | нет | — | ISO 4217 (RUB/USD/KZT/...) |
+| `occurredAt` | DateTimeImmutable | `occurred_at` TIMESTAMP(6) | нет | — | UTC; **используется для определения периода в P&L** |
+| `sourceTz` | string | `source_tz` VARCHAR(64) | нет | `'UTC'` | TZ источника для отображения |
+| `orderRef` | ?string | `order_ref` VARCHAR(255) | да | null | id заказа в источнике, если применимо |
+| `payoutRef` | ?string | `payout_ref` VARCHAR(255) | да | null | id выплаты, если транзакция в неё вошла |
+| `counterpartyId` | ?string UUID | `counterparty_id` GUID | да | null | ссылка на Counterparty в каноне |
+| `description` | ?string | `description` TEXT | да | null | человекочитаемое описание |
+| `sourceData` | array | `source_data` JSONB | нет | `[]` | поля источника для UI/аудита |
+| `rawRecordId` | string UUID | `raw_record_id` GUID | нет | — | ссылка на IngestRawRecord |
+| `version` | int | `version` INTEGER | нет | 0 | оптимистичная блокировка (`#[ORM\Version]`) |
+| `createdAt` | DateTimeImmutable | `created_at` TIMESTAMP(6) | нет | — | |
+| `updatedAt` | DateTimeImmutable | `updated_at` TIMESTAMP(6) | нет | — | |
+
+Natural key для upsert: `(company_id, source, external_id, type)`.
+
+Конструктор: `__construct(string $companyId, string $connectionRef, string $shopRef, IngestSource $source, string $externalId, DateTimeImmutable $externalUpdatedAt, string $operationGroupId, TransactionType $type, TransactionDirection $direction, Money $money, DateTimeImmutable $occurredAt, string $rawRecordId, ?string $orderRef = null, ?string $payoutRef = null, ?string $counterpartyId = null, ?string $description = null, array $sourceData = [], string $sourceTz = 'UTC')`.
+
+Инварианты:
+- `Assert::uuid($companyId)`, `Assert::uuid($operationGroupId)`, `Assert::uuid($rawRecordId)`.
+- `$money->amountMinor()` хранится в minor units и может быть положительным, отрицательным или нулевым.
+- `$money->currency()` — 3 буквы, uppercase.
+- `Assert::length($money->currency(), 3)`.
+
+Поведенческие методы:
+- `replaceFromNewerVersion(Money $money, TransactionType $type, TransactionDirection $direction, DateTimeImmutable $occurredAt, DateTimeImmutable $externalUpdatedAt, ?string $orderRef, ?string $payoutRef, ?string $counterpartyId, ?string $description, array $sourceData): void` — обновляет поля, если `$externalUpdatedAt > $this->externalUpdatedAt`; иначе бросает `StaleTransactionUpdateException`.
+- `oldOccurredAt(): DateTimeImmutable` — возвращает `occurredAt` до replace (для детектора смены периода в блоке 7).
+
+#### `App\Ingestion\Entity\Counterparty`
+
+Файл: `src/Ingestion/Entity/Counterparty.php`.
+Таблица: `#[ORM\Table(name: 'ingest_counterparties')]`.
+Реализует `TenantOwnedInterface`.
+
+Минимальная заглушка (полная модель — отдельным блоком):
+
+| Поле | Тип | Колонка | Nullable | Инвариант |
+|---|---|---|---|---|
+| `id` | string UUID v7 | `id` GUID | нет | PK |
+| `companyId` | string UUID | `company_id` GUID | нет | `Assert::uuid`; неизменяем |
+| `source` | IngestSource | `source` VARCHAR(64) | нет | enumType |
+| `externalKey` | string | `external_key` VARCHAR(255) | нет | id контрагента в источнике |
+| `name` | string | `name` VARCHAR(500) | нет | not empty |
+| `createdAt` | DateTimeImmutable | `created_at` TIMESTAMP(6) | нет | |
+| `updatedAt` | DateTimeImmutable | `updated_at` TIMESTAMP(6) | нет | |
+
+Natural key: `(company_id, source, external_key)`.
+
+#### `App\Ingestion\Entity\NormalizationIssue`
+
+Файл: `src/Ingestion/Entity/NormalizationIssue.php`.
+Таблица: `#[ORM\Table(name: 'ingest_normalization_issues')]`.
+Реализует `TenantOwnedInterface`.
+Append-only (никаких setter'ов кроме `markResolved`).
+
+| Поле | Тип | Колонка | Nullable | Инвариант |
+|---|---|---|---|---|
+| `id` | string UUID v7 | `id` GUID | нет | PK |
+| `companyId` | string UUID | `company_id` GUID | нет | `Assert::uuid` |
+| `rawRecordId` | string UUID | `raw_record_id` GUID | нет | |
+| `operationGroupId` | ?string UUID | `operation_group_id` GUID | да | nullable если ошибка не связана с группой |
+| `kind` | NormalizationIssueKind | `kind` VARCHAR(64) | нет | enumType |
+| `details` | array | `details` JSONB | нет | контекст ошибки (что именно не сошлось) |
+| `resolvedAt` | ?DateTimeImmutable | `resolved_at` TIMESTAMP(6) | да | null = открыто |
+| `createdAt` | DateTimeImmutable | `created_at` TIMESTAMP(6) | нет | |
+
+Методы:
+- `markResolved(?DateTimeImmutable $at = null): void` — выставляет `resolvedAt`.
+
+### 2.2 Связи
+
+- `FinancialTransaction.rawRecordId` → `IngestRawRecord.id` (string, без ManyToOne; PATTERNS §11).
+- `FinancialTransaction.counterpartyId` → `Counterparty.id` (string).
+- `NormalizationIssue.rawRecordId` → `IngestRawRecord.id` (string).
+
+### 2.3 Enum
+
+#### `App\Ingestion\Enum\TransactionType`
+
+Backed string. Файл: `src/Ingestion/Enum/TransactionType.php`.
+
+| Case | value | Когда устанавливается | Метка | Терминальный |
+|---|---|---|---|---|
+| `SALE` | `sale` | Продажа товара | «Продажа» | нет |
+| `REFUND` | `refund` | Возврат покупателю | «Возврат» | нет |
+| `COMMISSION` | `commission` | Комиссия маркетплейса | «Комиссия» | нет |
+| `LOGISTICS` | `logistics` | Логистика, FBO, доставка | «Логистика» | нет |
+| `STORAGE` | `storage` | Хранение | «Хранение» | нет |
+| `LAST_MILE` | `last_mile` | Последняя миля | «Последняя миля» | нет |
+| `ACCEPTANCE` | `acceptance` | Приёмка | «Приёмка» | нет |
+| `ADVERTISING` | `advertising` | Реклама (списание МП) | «Реклама» | нет |
+| `PENALTY` | `penalty` | Штраф МП | «Штраф» | нет |
+| `BONUS` | `bonus` | Бонус/компенсация | «Бонус» | нет |
+| `ACQUIRING` | `acquiring` | Эквайринг | «Эквайринг» | нет |
+| `ADJUSTMENT` | `adjustment` | Корректировка | «Корректировка» | нет |
+| `PAYOUT` | `payout` | Выплата от МП | «Выплата» | нет |
+| `DEPOSIT` | `deposit` | Поступление на банковский счёт | «Поступление» | нет |
+| `TRANSFER` | `transfer` | Перевод между счетами | «Перевод» | нет |
+| `TAX` | `tax` | Налог | «Налог» | нет |
+| `FEE` | `fee` | Общий сбор (если не подошёл специфичный тип) | «Сбор» | нет |
+| `OTHER` | `other` | Не классифицировано | «Прочее» | нет |
+
+Метод: `label(): string`.
+
+#### `App\Ingestion\Enum\TransactionDirection`
+
+Backed string.
+
+| Case | value | Когда устанавливается | Метка |
+|---|---|---|---|
+| `IN` | `in` | Деньги пришли тенанту | «Поступление» |
+| `OUT` | `out` | Деньги ушли от тенанта | «Списание» |
+
+#### `App\Ingestion\Enum\NormalizationIssueKind`
+
+Backed string.
+
+| Case | value | Когда | Метка |
+|---|---|---|---|
+| `SUM_MISMATCH` | `sum_mismatch` | Сумма канона ≠ контрольной из raw | «Сумма не сошлась» |
+| `MAPPER_FAILURE` | `mapper_failure` | Маппер бросил исключение | «Ошибка маппинга» |
+| `UNKNOWN_FIELD` | `unknown_field` | В raw появилось неизвестное маппер-полю значение | «Неизвестное поле» |
+| `CURRENCY_MISMATCH` | `currency_mismatch` | В одной строке смешаны валюты | «Несовпадение валют» |
+
+#### `App\Ingestion\Enum\Capability`
+
+Backed string. Файл: `src/Ingestion/Enum/Capability.php`.
+
+| Case | value | Смысл |
+|---|---|---|
+| `CAN_DISCOVER_SHOPS` | `can_discover_shops` | Коннектор умеет перечислять shop'ы аккаунта |
+| `CAN_PULL` | `can_pull` | Коннектор умеет тянуть данные |
+| `CAN_PUSH` | `can_push` | Коннектор умеет отправлять документы наружу |
+
+Метод: `label(): string`.
+
+### 2.4 Матрица переходов статусов
+
+`FinancialTransaction.normalizationStatus` — отсутствует (нормализация — атрибут RawRecord, не транзакции).
+
+`NormalizationIssue`: переход `open → resolved` через `markResolved()`. Обратного перехода нет.
+
+---
+
+## 3. Слой доступа к данным
+
+### 3.1 Repository
+
+#### `App\Ingestion\Repository\FinancialTransactionRepository`
+
+`final class`.
+
+| Метод | Что делает | companyId | Возврат |
+|---|---|---|---|
+| `findByNaturalKey(string $companyId, IngestSource $source, string $externalId, TransactionType $type): ?FinancialTransaction` | Поиск по natural key для upsert | да | `?FinancialTransaction` |
+| `findByOperationGroup(string $companyId, string $operationGroupId): list<FinancialTransaction>` | Все транзакции группы (для сверки сумм) | да | `list<FinancialTransaction>` |
+| `iterateByPeriod(string $companyId, DateTimeImmutable $from, DateTimeImmutable $to, ?string $shopRef = null): iterable<FinancialTransaction>` | Чтение канона за период — для блока 7 (rebuildPeriod) | да | `iterable<FinancialTransaction>` |
+| `findByRawRecordId(string $companyId, string $rawRecordId): list<FinancialTransaction>` | Транзакции, рождённые из конкретного RawRecord | да | `list<FinancialTransaction>` |
+
+`iterateByPeriod` использует QueryBuilder с `iterate()` или `toIterable()` для больших периодов.
+
+#### `App\Ingestion\Repository\CounterpartyRepository`
+
+| Метод | Что делает | companyId | Возврат |
+|---|---|---|---|
+| `findByNaturalKey(string $companyId, IngestSource $source, string $externalKey): ?Counterparty` | Upsert lookup | да | `?Counterparty` |
+| `getOrCreate(string $companyId, IngestSource $source, string $externalKey, string $name): Counterparty` | persist без flush | да | `Counterparty` |
+
+#### `App\Ingestion\Repository\NormalizationIssueRepository`
+
+| Метод | Что делает | companyId | Возврат |
+|---|---|---|---|
+| `findOpenByRawRecord(string $companyId, string $rawRecordId): list<NormalizationIssue>` | Открытые issue по конкретному raw | да | `list<NormalizationIssue>` |
+| `countOpenForCompany(string $companyId): int` | Счётчик для admin (блок 9) | да | `int` |
+
+### 3.2 Query
+
+N/A в этом блоке (read-модели для отчётов — блок 8).
+
+### 3.3 Индексы
+
+`ingest_financial_transactions`:
+- UNIQUE `(company_id, source, external_id, type)` → `uniq_ftx_natural_key`.
+- INDEX `(company_id, occurred_at)` → `idx_ftx_company_occurred`.
+- INDEX `(company_id, shop_ref, occurred_at)` → `idx_ftx_company_shop_occurred`.
+- INDEX `(company_id, operation_group_id)` → `idx_ftx_company_group`.
+- INDEX `(company_id, type, occurred_at)` → `idx_ftx_company_type_occurred`.
+- INDEX `(company_id, raw_record_id)` → `idx_ftx_company_raw`.
+
+`ingest_counterparties`:
+- UNIQUE `(company_id, source, external_key)` → `uniq_counterparty_natural`.
+
+`ingest_normalization_issues`:
+- INDEX `(company_id, kind, resolved_at)` → `idx_norm_issue_company_kind_resolved`.
+- INDEX `(company_id, raw_record_id)` → `idx_norm_issue_company_raw`.
+
+---
+
+## 4. Слой приложения
+
+### 4.1 Domain Contracts
+
+#### `App\Ingestion\Domain\Contract\SourceConnectorInterface`
+
+Файл: `src/Ingestion/Domain/Contract/SourceConnectorInterface.php`.
+
+Методы:
+- `source(): IngestSource` — возвращает источник, который обслуживает коннектор.
+- `capabilities(): list<Capability>` — список флагов capability.
+- `discoverShops(string $companyId, string $connectionRef): list<ShopDescriptor>` — перечислить shop'ы. Может бросить `ConnectorAuthException`, `ConnectorTransientException`.
+- `pull(PullRequest $request): PullResult` — один чанк pull'а. RawBatch внутри PullResult.
+- `push(PushRequest $request): PushResult` — отправка документа наружу. Если `Capability::CAN_PUSH` не заявлена — бросать `UnsupportedCapabilityException`.
+
+#### `App\Ingestion\Domain\Contract\SourceMapperInterface`
+
+Файл: `src/Ingestion/Domain/Contract/SourceMapperInterface.php`.
+
+Чистая функция (без БД/HTTP).
+
+Методы:
+- `source(): IngestSource`.
+- `resourceTypes(): list<string>` — список поддерживаемых resourceType.
+- `map(IngestRawRecord $rawRecord, iterable $rows): list<MappedTransaction>` — для каждой строки raw возвращает список mapped-транзакций (декомпозиция: одна строка отчёта = N канонических транзакций с общим `operationGroupId`).
+- `controlSum(iterable $rows): list<MappedControlSum>` — контрольные суммы по строкам для сверки.
+
+#### DTO
+
+`App\Ingestion\Application\DTO\ShopDescriptor` (final readonly):
+- `externalId: string`, `name: string`, `currency: string`, `metadata: array`.
+
+`App\Ingestion\Application\DTO\PullRequest` (final readonly):
+- `companyId: string`, `connectionRef: string`, `shopRef: string`, `resourceType: string`, `cursorValue: ?string`, `windowFrom: ?DateTimeImmutable`, `windowTo: ?DateTimeImmutable`, `syncJobId: string`.
+
+`App\Ingestion\Application\DTO\PullResult` (final readonly):
+- `rawBatch: RawBatch` (из блока 3), `nextCursorValue: ?string` (null = конец), `hasMore: bool`.
+
+`App\Ingestion\Application\DTO\PushRequest`, `PushResult` — каркас на будущее, минимальные поля (`companyId`, `connectionRef`, `documentType`, `payload`, `idempotencyKey`). В блоке 5 используется только сигнатурой.
+
+`App\Ingestion\Application\DTO\MappedTransaction` (final readonly):
+- `externalId: string`, `externalUpdatedAt: DateTimeImmutable`, `operationGroupId: string`, `type: TransactionType`, `direction: TransactionDirection`, `money: Money`, `occurredAt: DateTimeImmutable`, `sourceTz: string`, `orderRef: ?string`, `payoutRef: ?string`, `counterpartyExternalKey: ?string`, `counterpartyName: ?string`, `description: ?string`, `sourceData: array`.
+
+`App\Ingestion\Application\DTO\MappedControlSum` (final readonly):
+- `operationGroupId: string`, `currency: string`, `amountMinor: int`.
+
+### 4.2 Money Value Object
+
+#### `App\Shared\Domain\ValueObject\Money`
+
+Файл: `src/Shared/Domain/ValueObject/Money.php`. `final readonly class`.
+
+Поля: `amountMinor: int`, `currency: string` (3 буквы uppercase).
+
+Методы:
+- `static fromMinor(int $amountMinor, string $currency): self`.
+- `add(self $other): self` — `MoneyMismatchException` при разных currency.
+- `subtract(self $other): self` — `MoneyMismatchException` при разных currency; результат может быть отрицательным.
+- `negate(): self` — возвращает значение с противоположным знаком.
+- `compareTo(self $other): int` — сравнение только в одной currency, иначе `MoneyMismatchException`.
+- `isZero(): bool`.
+- `amountMinor(): int`, `currency(): string`.
+
+Инвариант: `$amountMinor` — int signed minor units, `$currency` — `Assert::length(3)`, `Assert::regex('/^[A-Z]{3}$/')`. Если конкретный бизнес-сценарий требует неотрицательную сумму, проверка должна жить в этом сценарии, а не в универсальном `Money`.
+
+### 4.3 ConnectorRegistry
+
+#### `App\Ingestion\Domain\Service\ConnectorRegistry`
+
+`final class`. Конструктор принимает `iterable<SourceConnectorInterface>` через `!tagged_iterator app.ingestion.connector`.
+
+Методы:
+- `get(IngestSource $source): SourceConnectorInterface` — `ConnectorNotFoundException` если нет.
+- `has(IngestSource $source): bool`.
+
+#### `App\Ingestion\Domain\Service\MapperRegistry`
+
+`final class`. Конструктор: `iterable<SourceMapperInterface>` через `!tagged_iterator app.ingestion.mapper`.
+
+Метод:
+- `get(IngestSource $source, string $resourceType): SourceMapperInterface` — `MapperNotFoundException`.
+
+### 4.4 Action
+
+#### `App\Ingestion\Application\Action\NormalizeRawRecordAction`
+
+Файл: `src/Ingestion/Application/Action/NormalizeRawRecordAction.php`. `final class`.
+
+Вход: `NormalizeRawRecordCommand` (`string $rawRecordId, string $companyId`).
+Шаги:
+1. Загрузить `IngestRawRecord` через `IngestRawRecordRepository::findByIdAndCompany`. Нет → `RawRecordNotFoundException` (уже есть из блока 3).
+2. Если `normalizationStatus = DONE` — return (идемпотентность).
+3. Получить mapper через `MapperRegistry::get($rawRecord->getSource(), $rawRecord->getResourceType())`.
+4. Прочитать строки из S3 через `RawStorageFacade::read($rawRecordId, $companyId)`.
+5. Вызвать `$mapper->map($rawRecord, $rows)` → `list<MappedTransaction>`. Если бросило — поймать, записать `NormalizationIssue` с `kind=MAPPER_FAILURE`, пометить raw как `FAILED`, return.
+6. Для каждой `MappedTransaction`:
+   - Получить/создать `Counterparty` через `CounterpartyRepository::getOrCreate` если есть `counterpartyExternalKey`.
+   - Вызвать `UpsertFinancialTransactionAction` с переданными полями и `rawRecordId`.
+   - Запомнить старый `occurredAt` и новый — для события (см. шаг 9).
+7. Перечитать строки и вычислить `$mapper->controlSum($rows)`. Для каждой `MappedControlSum`:
+   - Сумма канона по `operationGroupId` (из репо) vs `controlSum.amountMinor` той же валюты.
+   - Если расхождение > 0 минорных единиц → `RecordNormalizationIssueAction` с `kind=SUM_MISMATCH`, details (expected/actual/operationGroupId).
+8. Пометить raw `markNormalizationDone()` (новый метод на `IngestRawRecord` — см. §2.1 ниже).
+9. Собрать `list<AffectedPeriod>` (даты `occurredAt`, старая и новая для каждой обновлённой транзакции) и опубликовать `NormalizationCompletedEvent`.
+10. flush.
+
+Транзакционность: одна транзакция БД. Dispatch события — в `kernel.terminate` или после flush.
+
+**Дополнение к Entity `IngestRawRecord` (блок 3):** добавить методы `markNormalizationDone(): void` (status=DONE, updatedAt=now), `markNormalizationFailed(): void` (status=FAILED). Это правка одной строки в Entity — допустимая в рамках блока 5, поскольку блок 3 ещё не использует эти переходы.
+
+#### `App\Ingestion\Application\Action\UpsertFinancialTransactionAction`
+
+Вход: `UpsertFinancialTransactionCommand` (`string $companyId`, `string $connectionRef`, `string $shopRef`, `IngestSource $source`, `MappedTransaction $mapped`, `string $rawRecordId`, `?string $counterpartyId`).
+
+Шаги:
+1. `findByNaturalKey($companyId, $source, $mapped->externalId, $mapped->type)`.
+2. Если null — создать `FinancialTransaction` через конструктор, persist. Запомнить `null` как `oldOccurredAt`.
+3. Если найден — вызвать `replaceFromNewerVersion(...)`. Запомнить `oldOccurredAt` до replace. Если `replaceFromNewerVersion` бросил `StaleTransactionUpdateException` — skip (старая версия пришла после новой), return null.
+4. Вернуть DTO `UpsertResult { transactionId: string, oldOccurredAt: ?DateTimeImmutable, newOccurredAt: DateTimeImmutable, periodChanged: bool }`.
+
+**Без flush** (NormalizeRawRecordAction делает flush).
+
+#### `App\Ingestion\Application\Action\RecordNormalizationIssueAction`
+
+Вход: `RecordNormalizationIssueCommand` (`string $companyId, string $rawRecordId, ?string $operationGroupId, NormalizationIssueKind $kind, array $details`).
+
+Шаги:
+1. Создать `NormalizationIssue` через конструктор.
+2. persist.
+3. Лог уровня `WARNING` через `LoggerInterface`.
+4. Без flush.
+
+### 4.5 Handler'ы Messenger
+
+#### `App\Ingestion\MessageHandler\RunSyncChunkHandler`
+
+Handler для `RunSyncChunkMessage` (блок 4). `final class` с `#[AsMessageHandler]`. Использует `IdempotentHandlerTrait` (PATTERNS §22) с natural key `jobId`.
+
+Шаги:
+1. `findByIdAndCompany($jobId, $companyId)`. Если status терминальный — return.
+2. `SyncFacade.markJobRunning(...)`.
+3. Достать коннектор: `connectorRegistry->get($job->getSource())`.
+4. Acquire rate-limit guard (`IngestRateLimitGuard::acquire($job->getSource()->value . ':' . $job->getConnectionRef())`).
+5. Собрать `PullRequest` (из полей job'а + текущего курсора через `IngestCursorRepository::findOne`).
+6. `$result = $connector->pull($request)`.
+7. `RawStorageFacade::store($result->rawBatch)` → `list<IngestRawRecord>`.
+8. Для каждого созданного RawRecord — dispatch `NormalizeRawRecordMessage(rawRecordId, companyId)` в `ingest_normalize`.
+9. `SyncFacade.updateCursor(...)` с `$result->nextCursorValue` если не null.
+10. `SyncFacade.markJobCompleted(...)`.
+11. Release lock.
+
+При исключении:
+- `ConnectorAuthException` → `markJobFailed("auth")`, `UnrecoverableMessageHandlingException` (Messenger не ретраит).
+- `ConnectorTransientException` → НЕ `markJobFailed`, бросить наружу (Messenger ретраит).
+- любое другое → `markJobFailed($e->getMessage())`, бросить наружу.
+
+#### `App\Ingestion\Message\NormalizeRawRecordMessage`
+
+`final readonly class`, реализует `CompanyAwareMessage`.
+Поля: `rawRecordId: string` UUID, `companyId: string` UUID. Метод `getCompanyId()`.
+
+#### `App\Ingestion\MessageHandler\NormalizeRawRecordHandler`
+
+`final class`, `#[AsMessageHandler]`, IdempotentHandlerTrait с key `rawRecordId`.
+
+Вызывает `NormalizeRawRecordAction`. Routing: `ingest_normalize`.
+
+### 4.6 Доменное событие
+
+#### `App\Ingestion\Domain\Event\NormalizationCompletedEvent`
+
+`final readonly class`.
+
+Поля: `companyId: string`, `rawRecordId: string`, `affectedPeriods: list<AffectedPeriod>`.
+
+`App\Ingestion\Domain\Event\AffectedPeriod` (final readonly): `shopRef: string`, `oldOccurredAt: ?DateTimeImmutable`, `newOccurredAt: DateTimeImmutable`. Используется блоком 7 для пометки `PLDirtyPeriod`.
+
+Публикация: `EventDispatcherInterface::dispatch($event)` в конце `NormalizeRawRecordAction` после flush.
+
+### 4.7 Facade
+
+#### `App\Ingestion\Facade\IngestionFacade`
+
+`final readonly class`. Используется блоком 7 (P&L).
+
+Методы:
+- `getTransactions(string $companyId, DateTimeImmutable $from, DateTimeImmutable $to, ?string $shopRef = null): iterable<FinancialTransaction>` — делегирует в Repository::iterateByPeriod.
+- `countOpenIssues(string $companyId): int` — для admin.
+
+### 4.8 Fake Connector + Mapper (для тестов)
+
+#### `App\Ingestion\Application\Source\FakeConnector`
+
+`final class`, реализует `SourceConnectorInterface`. Регистрация: тег `app.ingestion.connector` + `autowire: false`, видимый только в `dev`/`test` (`when@dev`, `when@test` в `services.yaml`).
+
+Возвращает захардкоженный `PullResult` с одной строкой raw.
+
+#### `App\Ingestion\Application\Source\FakeMapper`
+
+Реализует `SourceMapperInterface`. Один rows = одна `MappedTransaction` типа `SALE`.
+
+Используется в integration-тестах. Не попадает в prod-сборку (`when@prod` исключает).
+
+---
+
+## 5. Асинхронность (Messenger)
+
+### 5.1 Сообщения
+
+`NormalizeRawRecordMessage` — см. §4.5.
+
+### 5.2 Handler'ы
+
+`RunSyncChunkHandler` (transport `ingest_fetch`), `NormalizeRawRecordHandler` (transport `ingest_normalize`).
+
+### 5.3 Routing
+
+`config/packages/messenger.yaml` — добавить:
+```yaml
+App\Ingestion\Message\NormalizeRawRecordMessage: ingest_normalize
+```
+
+### 5.4 Идемпотентность
+
+Оба handler'а используют `IdempotentHandlerTrait` (§22).
+
+---
+
+## 6. Обработка ошибок
+
+| Класс | Когда | HTTP-статус | error.code | message |
+|---|---|---|---|---|
+| `RawRecordNotFoundException` (из блока 3) | — | 404 | `raw_record_not_found` | «Сырая запись не найдена» |
+| `ConnectorNotFoundException` | `ConnectorRegistry::get` не нашёл | 500 | `connector_not_found` | «Коннектор не найден» |
+| `MapperNotFoundException` | `MapperRegistry::get` не нашёл | 500 | `mapper_not_found` | «Маппер не найден» |
+| `UnsupportedCapabilityException` | push для коннектора без CAN_PUSH | 422 | `connector_capability_unsupported` | «Коннектор не поддерживает эту операцию» |
+| `ConnectorAuthException` | 401/403 от источника | 401 | `connector_auth_failed` | «Ошибка авторизации источника» |
+| `ConnectorTransientException` | 5xx/timeout/429 | 503 | `connector_transient_error` | «Источник временно недоступен» |
+| `MoneyMismatchException` (`App\Shared\Domain\Exception`) | Операция Money с разными currency | 422 | `money_currency_mismatch` | «Несовпадение валют» |
+| `StaleTransactionUpdateException` | externalUpdatedAt старее текущей | 409 | `transaction_stale_update` | «Версия данных устарела» |
+
+Все Ingestion-исключения — namespace `App\Ingestion\Exception`, `final class`. Исключение `MoneyMismatchException` живёт в `App\Shared\Domain\Exception`, потому что `Money` — общий value object.
+
+---
+
+## 7. HTTP API (Controller)
+
+N/A — HTTP API в блоке 8.
+
+---
+
+## 8. Разбивка на подзадачи
+
+| Этап | Что входит | Зависит от | Риск | Тесты |
+|---|---|---|---|---|
+| B1 | Money + ValueObject | — | 🟢 | unit на все операции, MoneyMismatchException |
+| B2 | Enum (TransactionType/Direction/IssueKind/Capability) + Entity (FinancialTransaction/Counterparty/NormalizationIssue) + миграция | блок 3 | 🔴 | unit инвариантов |
+| B3 | Repository (3 шт.) | B2 | 🟡 | tenant-leak на каждый read-метод |
+| B4 | Domain Contracts + DTO (ShopDescriptor/PullRequest/PullResult/MappedTransaction/MappedControlSum) | блок 3 | 🟢 | — |
+| B5 | ConnectorRegistry + MapperRegistry + теги | B4 | 🟡 | unit на get/has |
+| B6 | NormalizeRawRecordAction + UpsertFinancialTransactionAction + RecordNormalizationIssueAction | B2, B3, B4 | 🟡 | integration на happy/mismatch/mapper-failure |
+| B7 | NormalizationCompletedEvent + AffectedPeriod + публикация | B6 | 🟢 | проверить dispatch после flush |
+| B8 | RunSyncChunkMessage handler (использует SyncFacade из блока 4) | блок 4, B6 | 🟡 | integration на coupled flow |
+| B9 | NormalizeRawRecordMessage + Handler + routing | B6 | 🟢 | end-to-end через in-memory transport |
+| B10 | FakeConnector + FakeMapper (dev/test only) | B4, B5 | 🟢 | integration: full pipeline на Fake |
+| B11 | IngestionFacade::getTransactions + countOpenIssues | B3 | 🟢 | integration |
+| B12 | ARCHITECTURE.md обновить | все | 🟢 | — |
+
+---
+
+## 9. Ограничения и запреты
+
+- Не ломать: блоки 1-4 (изменения в `IngestRawRecord` минимальны — только добавление двух методов `markNormalizationDone/Failed`; legacy не трогаем).
+- Не трогать: legacy-зону `src/Entity`, `src/Marketplace`, `src/Inventory`, `src/MarketplaceAds` — новый канон живёт отдельно.
+- Совместимость API: HTTP не вводим.
+- Миграции: zero-downtime, только CREATE TABLE.
+- Performance: `iterateByPeriod` использует `toIterable()` для больших периодов, чтобы не грузить весь канон в память. N+1 защищается batch-fetch'ем counterparty в `NormalizeRawRecordAction` (preload по `externalKey` set'у перед циклом).
+- Безопасность: companyId обязателен в каждом методе Repository; `CompanyFilter` из блока 1 покрывает все новые Entity (они реализуют `TenantOwnedInterface`).
+
+---
+
+## 10. Критерии приёмки
+
+Функциональные:
+- [ ] `Money` допускает положительные, отрицательные и нулевые minor units.
+- [ ] `Money` запрещает арифметику разных валют (`MoneyMismatchException`).
+- [ ] `FakeConnector.pull` → `PullResult` → `RawStorageFacade.store` → `IngestRawRecord` создан.
+- [ ] `NormalizeRawRecordAction` upsert'ит `FinancialTransaction` по natural key (идемпотентность: повтор не плодит дубли).
+- [ ] При повторной нормализации с тем же `externalUpdatedAt` — данные не меняются.
+- [ ] При нормализации с свежим `externalUpdatedAt` — данные обновляются.
+- [ ] При старом `externalUpdatedAt` — обновление пропускается без ошибки.
+- [ ] Сверка сумм: при искусственно расходящейся controlSum создаётся `NormalizationIssue(kind=SUM_MISMATCH)`.
+- [ ] `NormalizationCompletedEvent` публикуется ровно один раз на успешную нормализацию RawRecord.
+- [ ] `AffectedPeriod` содержит и старую, и новую `occurredAt` для каждой обновлённой транзакции.
+- [ ] `RunSyncChunkHandler` отрабатывает Fake-цепочку end-to-end: dispatch RunSyncChunkMessage → пишется raw → диспатчатся NormalizeRawRecordMessage → создаётся канон.
+
+Технические:
+- [ ] `make site-cs-check` + PHPStan зелёные.
+- [ ] `make site-test-unit` + `make site-test-integration` зелёные.
+- [ ] Миграции применяются/откатываются.
+- [ ] Tenant-leak тест на canon (FinancialTransaction компании B не виден из контекста A).
+- [ ] FakeConnector НЕ собирается в `prod`-окружении (тест: `bin/console debug:container --env=prod | grep FakeConnector` ничего не находит).
+- [ ] `ARCHITECTURE.md` обновлён.
+- [ ] OpenAPI — без изменений.
+
+---
+
+## 11. План отката
+
+- DROP трёх новых таблиц + удалить routing `NormalizeRawRecordMessage`.
+- `RunSyncChunkHandler` не зарегистрирован → блок 4 продолжает работать (просто Message в очереди не обрабатывается, можно почистить транспорт).
+- Откат изменений `IngestRawRecord` (два метода `markNormalizationDone/Failed`) — несложный revert.
+- Зависимости вниз: блок 6 (Ozon) использует `SourceConnectorInterface` и `SourceMapperInterface`. До старта блока 6 откат блока 5 безопасен.
+
+---
+
+## 12. Чек-лист качества ТЗ
+
+- [x] Полный namespace и путь для каждого класса.
+- [x] Полная таблица полей трёх новых Entity с типами/nullable/инвариантами.
+- [x] Каждый enum case описан.
+- [x] Сигнатура каждого метода Repository/Action/Facade/Contract.
+- [x] Каждый Repository-метод принимает `string $companyId`.
+- [x] HTTP — N/A явно.
+- [x] Все исключения замаплены на код+статус.
+- [x] Индексы перечислены с именами.
+- [x] Транспорт `ingest_normalize` указан.
+- [x] Формат данных: ISO 8601, UUID, минорные единицы для денег, ISO 4217 для валют.
+- [x] Out of scope зафиксирован.
+- [x] Контракт «push» зарезервирован, но реализация в out-of-scope.

--- a/docs/tasks/ingestion/TASK-06-ozon-connector.md
+++ b/docs/tasks/ingestion/TASK-06-ozon-connector.md
@@ -1,0 +1,387 @@
+# TASK — БЛОК 6: Ingestion · OzonSellerReportConnector (первый реальный источник)
+
+## 0. Сводка
+
+- **Бизнес-цель.** Подключить первый реальный источник — Ozon seller reports (ежедневный отчёт + месячная реализация) — к единому контракту `SourceConnectorInterface` из блока 5. Не переписывать HTTP-клиент с нуля, обернуть существующие Ozon-адаптеры из `Marketplace/Infrastructure/Api`. Первый шаг к гашению дублирующего legacy-пайплайна.
+- **Модуль.** `App\Ingestion` (новый коннектор + маппер) + минимальное использование `App\Marketplace` (только чтение существующих API-клиентов через адаптер, **без модификации**).
+- **Тип.** integration (новый коннектор поверх существующей инфраструктуры).
+- **Ветка.** `feature/ingestion-06-ozon-seller-connector`.
+- **Подзадачи.** B1 Адаптер к существующим Ozon-клиентам · B2 OzonSellerReportConnector · B3 OzonSellerReportMapper (ежедневный отчёт) · B4 OzonRealizationMapper (месячная реализация) · B5 Классификация ошибок · B6 Контрактные фикстуры · B7 Тесты.
+- **Затрагивает другие модули.** Да, читает через адаптер: `App\Marketplace\Infrastructure\Api\Ozon\*` (API-клиенты), `App\Marketplace\Entity\MarketplaceConnection` (credentials через `CredentialFacade` из блока 2 — она уже умеет читать legacy connection).
+- **Требует миграции БД.** Нет.
+- **Меняет публичный API.** Нет.
+
+---
+
+## 1. Контекст и границы
+
+### 1.1 Текущее состояние
+
+- Блоки 1-5 готовы. Есть `SourceConnectorInterface`, `SourceMapperInterface`, канон `FinancialTransaction`, `IngestionFacade::getTransactions`, `RunSyncChunkHandler` запускает `connector->pull()`.
+- В legacy существуют Ozon API-клиенты: `Marketplace/Infrastructure/Api/Ozon/OzonSellerClient` (или эквивалент — точное имя класса уточнить разведкой Marketplace при старте блока), `Marketplace/Service/Integration/...`. Они работают, ходят на `api-seller.ozon.ru`, имеют логику пагинации, ретраев.
+- Credentials лежат в `marketplace_connections.api_key/client_id/settings`; `CredentialFacade::read` уже умеет их вытащить через `LegacyMarketplaceCredentialReader` (блок 2).
+- В Ozon API одни и те же операции приходят дважды: в ежедневном `transaction_list` (предварительные данные) и в месячной реализации (`finance/realization`, финальные данные). Реализация перезаписывает предварительные данные через тот же natural key.
+
+### 1.2 Желаемое состояние
+
+- `OzonSellerReportConnector implements SourceConnectorInterface` с `source() = IngestSource::OZON` и capability'ями `[CAN_DISCOVER_SHOPS, CAN_PULL]`. `CAN_PUSH` — нет.
+- Метод `pull()` обрабатывает два resourceType: `ozon_seller_daily_report` и `ozon_seller_realization`.
+- `OzonSellerReportMapper` маппит строки ежедневного отчёта в `MappedTransaction[]` с декомпозицией: одна строка `accruals_for_sale + sale_commission_amount + deliv_charge_amount + ...` → несколько канонических транзакций с общим `operationGroupId`.
+- `OzonRealizationMapper` маппит строки месячной реализации в тот же канон с тем же natural key (тот же `externalId` и `type`) — что обеспечивает перезапись предварительных данных финальными через механизм upsert (блок 5).
+- Чёткая классификация ошибок: 401/403/missing creds → `ConnectorAuthException`; 5xx/timeout/network → `ConnectorTransientException`; 429 → `ConnectorTransientException` с подсказкой backoff.
+- Параметры коннектора декларативны: размер чанка для бэкфилла = 7 дней; hot rewind window = 14 дней; rate limit = соответствует Ozon (1000 req/min на endpoint, фактически — намного консервативнее: 60/min).
+
+### 1.3 In scope
+
+- Адаптер `LegacyOzonClientAdapter` — обёртка над существующими Ozon API-клиентами. Не модифицирует их. Закрывает Ingestion-модуль от знания о внутренностях `Marketplace/Infrastructure/Api`.
+- `App\Ingestion\Application\Source\Ozon\OzonSellerReportConnector`.
+- `App\Ingestion\Application\Source\Ozon\OzonSellerReportMapper` (resourceType=`ozon_seller_daily_report`).
+- `App\Ingestion\Application\Source\Ozon\OzonRealizationMapper` (resourceType=`ozon_seller_realization`).
+- Маппинг полей Ozon → канон, зафиксированный в коде маппера и в `docs/ingestion/ozon-mapping.md`.
+- Контрактные фикстуры: реальные (анонимизированные) ответы Ozon в `tests/Fixtures/Ingestion/Ozon/*.json`.
+- Регистрация коннектора и обоих мапперов через теги.
+
+### 1.4 Out of scope
+
+- Модификация существующих Ozon API-клиентов в `Marketplace/Infrastructure/Api`.
+- Замена/гашение существующего Ozon-пайплайна — это блок 9 (shadow + переключение).
+- Ozon Performance Ads — отдельный источник, отдельный коннектор позже.
+- Ozon FBO/FBS остатки (Inventory) — отдельный коннектор позже.
+- WB финансы — следующий источник после стабилизации Ozon.
+- Push документов в Ozon — не поддерживается.
+- HTTP API — блок 8.
+
+### 1.5 Допущения и открытые вопросы
+
+- Допущение: имена legacy Ozon-классов и их публичные методы будут уточнены первым шагом блока (разведка `Marketplace/Infrastructure/Api/Ozon/`). На этапе ТЗ называю их по семантике (`OzonSellerClient`, `getTransactionList`, `getRealization`). Адаптер их прячет — даже если имена другие, контракт Ingestion не меняется.
+- Открытый вопрос: ширина hot rewind у Ozon (сколько дней назад данные могут меняться)? Принимаем 14 дней по умолчанию, при необходимости — параметр.
+
+---
+
+## 2. Доменная модель
+
+### 2.1 Сущности
+
+Новых Entity нет.
+
+Используются существующие из блоков 3 и 5: `IngestRawRecord`, `FinancialTransaction`, `Counterparty`, `NormalizationIssue`.
+
+### 2.2 Связи
+
+N/A.
+
+### 2.3 Enum
+
+Используются существующие: `IngestSource::OZON`, `TransactionType`, `TransactionDirection`, `Capability`, `NormalizationIssueKind`.
+
+### 2.4 Матрица переходов статусов
+
+N/A.
+
+### 2.5 Resource types
+
+Строковые константы, объявить в классе-перечислении:
+
+#### `App\Ingestion\Application\Source\Ozon\OzonResourceType`
+
+```php
+final class OzonResourceType
+{
+    public const DAILY_REPORT  = 'ozon_seller_daily_report';
+    public const REALIZATION   = 'ozon_seller_realization';
+}
+```
+
+(Не enum, поскольку resourceType — открытое множество для всех источников; в Ozon-неймспейсе — закрытое.)
+
+### 2.6 Маппинг полей Ozon → канон
+
+#### Ежедневный отчёт (`transaction_list`)
+
+Каждая строка `transaction_list` декомпозируется в N канонических транзакций с одним `operationGroupId = UUID v7 от (companyId, source, externalId)`. `externalId` строки = `operation_id` Ozon.
+
+Маппинг колонок (полный список — в `docs/ingestion/ozon-mapping.md`, здесь — список типов с условием маппинга):
+
+| Поле Ozon (типовое) | TransactionType | Direction | Условие |
+|---|---|---|---|
+| `accruals_for_sale` | `SALE` | `IN` если > 0, `OUT` если < 0 | Всегда создаётся, если ≠ 0 |
+| `sale_commission_amount` | `COMMISSION` | `OUT` | Всегда отрицательная сумма ozon, направление OUT |
+| `deliv_charge_amount` | `LOGISTICS` | `OUT` | Если ≠ 0 |
+| `return_delivery_charge_amount` | `LOGISTICS` | `OUT` | Если ≠ 0 |
+| `services_amounts.MarketplaceServiceItemReturnAfterDelivToCustomer` | `LOGISTICS` | `OUT` | Если ≠ 0 |
+| `services_amounts.MarketplaceServiceItemDelivToCustomer` | `LAST_MILE` | `OUT` | Если ≠ 0 |
+| Все остальные `services_amounts` | `FEE` | `OUT` | Каждый сбор отдельной транзакцией с описанием = ключ сбора |
+| `acquiring` (если присутствует) | `ACQUIRING` | `OUT` | Если ≠ 0 |
+| `amount` (тип операции = `ClientReturnAgentOperation`) | `REFUND` | `OUT` | Если operation_type указывает на возврат |
+
+`occurredAt` = `operation_date` (UTC из ответа Ozon, без конвертации; источник уже даёт UTC).
+`externalUpdatedAt` = `operation_date` для ежедневного отчёта (Ozon в transaction_list не отдаёт явно updated_at, используем operation_date как приближение).
+`sourceTz = 'Europe/Moscow'` (для UI-отображения).
+`orderRef` = `posting_number` если есть.
+`description` = `operation_type_name`.
+`sourceData` = вся исходная строка (для UI/саппорта).
+`counterpartyExternalKey` = `null` для ежедневного отчёта (Ozon как контрагент — не выделяем).
+
+`MappedControlSum` = `(operationGroupId, currency='RUB', amountMinor = ABS(сумма всех начислений и удержаний по строке))` — для сверки.
+
+#### Месячная реализация (`finance/realization`)
+
+Тот же набор типов и natural key, что и для ежедневного. Ключевые отличия:
+- `externalUpdatedAt` = `realization_report_period_end` или `report_date` (точнее в фикстурах).
+- Поскольку `externalUpdatedAt` реализации > `externalUpdatedAt` ежедневного отчёта того же периода — `UpsertFinancialTransactionAction.replaceFromNewerVersion` корректно перезапишет предварительные данные финальными (блок 5).
+- Если в реализации появляется новая операция, которой не было в ежедневном — она создаётся как новая транзакция.
+
+---
+
+## 3. Слой доступа к данным
+
+N/A — новых Repository/Query нет. Используется существующее.
+
+---
+
+## 4. Слой приложения
+
+### 4.1 Адаптер к legacy Ozon-клиентам
+
+#### `App\Ingestion\Infrastructure\Api\Ozon\LegacyOzonClientAdapter`
+
+Файл: `src/Ingestion/Infrastructure/Api/Ozon/LegacyOzonClientAdapter.php`. `final class`.
+
+Назначение: единственный класс в Ingestion, который **знает имена** legacy Ozon-классов. Если завтра legacy переименует/переделает свои клиенты, страдает только этот файл.
+
+Конструктор: принимает существующий Ozon API-клиент через интерфейс или через прямой импорт (определить разведкой первым шагом блока). Принимает также `CredentialFacade` (блок 2) — для получения credentials по `(companyId, connectionRef)`.
+
+Методы:
+- `fetchTransactionList(string $companyId, string $connectionRef, DateTimeImmutable $from, DateTimeImmutable $to, int $page, int $pageSize): OzonRawPage` — обёртка над legacy-методом, возвращает структурированный DTO.
+- `fetchRealization(string $companyId, string $connectionRef, int $year, int $month): OzonRawPage`.
+- `listClusters(string $companyId, string $connectionRef): list<OzonShopDescriptor>` — для `discoverShops`. У Ozon один аккаунт обычно = один shop_id, поэтому возможен один элемент.
+
+`OzonRawPage` (`final readonly class`): `rows: array`, `hasMore: bool`, `nextPageToken: ?string`.
+`OzonShopDescriptor` (`final readonly class`): `externalId: string`, `name: string`.
+
+Адаптер ловит исключения legacy-клиента и **классифицирует**:
+- HTTP 401, 403, отсутствие credentials → `ConnectorAuthException`.
+- HTTP 5xx, timeout, network failure → `ConnectorTransientException`.
+- HTTP 429 → `ConnectorTransientException` (Messenger ретраит).
+- Любое другое → пробрасывает как `\RuntimeException` (handler `RunSyncChunkHandler` пометит job failed).
+
+### 4.2 SourceConnector
+
+#### `App\Ingestion\Application\Source\Ozon\OzonSellerReportConnector`
+
+Файл: `src/Ingestion/Application/Source/Ozon/OzonSellerReportConnector.php`. `final class`, реализует `SourceConnectorInterface` (блок 5). Тег: `app.ingestion.connector`.
+
+Конструктор: `LegacyOzonClientAdapter $client, LoggerInterface $logger`.
+
+Методы:
+
+- `source(): IngestSource` → `IngestSource::OZON`.
+- `capabilities(): list<Capability>` → `[Capability::CAN_DISCOVER_SHOPS, Capability::CAN_PULL]`.
+- `discoverShops(string $companyId, string $connectionRef): list<ShopDescriptor>`:
+  1. `$adapter->listClusters($companyId, $connectionRef)`.
+  2. Маппит `OzonShopDescriptor` → `ShopDescriptor` (currency='RUB' для Ozon RU; для KZ/BY — определяется по дальнейшему сигналу, в MVP только RU).
+  3. Возврат списка.
+- `pull(PullRequest $request): PullResult`:
+  - Если `$request->resourceType === OzonResourceType::DAILY_REPORT`:
+    1. Определить `(from, to)`: из `cursorValue` (если null — `windowFrom`); до `min(windowTo, cursorValue + 7 дней)`.
+    2. Постранично вызвать `$adapter->fetchTransactionList(...)` с пагинацией; собрать строки в `iterable`.
+    3. Сформировать `RawBatch` с `source=OZON, resourceType=DAILY_REPORT, externalId=date_range_token`.
+    4. `nextCursorValue` = ISO дата `to` (следующий чанк стартует от `to+1d`); `hasMore = to < windowTo`.
+  - Если `$request->resourceType === OzonResourceType::REALIZATION`:
+    1. Из `windowFrom/windowTo` определить `(year, month)`. Для каждого месяца отдельный pull (caller — `RunSyncChunkHandler` — может разбить по месяцам через настройку chunkSizeInDays блока 4, либо коннектор сам делит и итерирует).
+    2. `$adapter->fetchRealization($companyId, $connectionRef, $year, $month)`.
+    3. `RawBatch` с `externalId=YYYY-MM`.
+    4. `nextCursorValue` = следующий месяц; `hasMore` определяется по `windowTo`.
+- `push(PushRequest $request): PushResult` → `UnsupportedCapabilityException`.
+
+Параметры коннектора (декларативно, в `services.yaml` через arguments):
+- `chunk_size_days`: 7 (для DAILY_REPORT).
+- `hot_rewind_days`: 14 (используется блоком 4 / future cron).
+- `rate_limit_rpm`: 60 (через `IngestRateLimitGuard`).
+
+### 4.3 Мапперы
+
+#### `App\Ingestion\Application\Source\Ozon\OzonSellerReportMapper`
+
+Файл: `src/Ingestion/Application/Source/Ozon/OzonSellerReportMapper.php`. `final class`, реализует `SourceMapperInterface`. Тег: `app.ingestion.mapper`.
+
+Чистая функция (без БД/HTTP).
+
+Методы:
+- `source(): IngestSource` → `IngestSource::OZON`.
+- `resourceTypes(): list<string>` → `[OzonResourceType::DAILY_REPORT]`.
+- `map(IngestRawRecord $rawRecord, iterable $rows): list<MappedTransaction>` — для каждой строки `transaction_list` создаёт декомпозированный набор `MappedTransaction` по таблице из §2.6.
+- `controlSum(iterable $rows): list<MappedControlSum>` — для каждой строки одна MappedControlSum с суммой `|accruals_for_sale|+|sale_commission_amount|+|deliv_charge_amount|+...`.
+
+Маппер ловит «неизвестное значение operation_type» и возвращает соответствующий `MappedTransaction` с типом `OTHER` + `sourceData` (всё исходное). НЕ бросает — пусть нормализатор сам решит создавать ли issue. (Альтернатива: бросать — но тогда теряется одна строка; лучше fallback в OTHER + лог).
+
+#### `App\Ingestion\Application\Source\Ozon\OzonRealizationMapper`
+
+Файл: `src/Ingestion/Application/Source/Ozon/OzonRealizationMapper.php`. `final class`.
+
+Методы:
+- `source()` → `IngestSource::OZON`.
+- `resourceTypes()` → `[OzonResourceType::REALIZATION]`.
+- `map(...)` — структура реализации отличается (там не `transaction_list`, а агрегированный `report`), но финальный канон тот же. Декомпозиция аналогична: одна строка реализации = N канонических транзакций с тем же `externalId` и `operationGroupId`, что в ежедневке (через тот же алгоритм построения id).
+- `controlSum(...)`.
+
+### 4.4 Алгоритм генерации natural key
+
+Чтобы `OzonRealizationMapper` корректно перезаписал предварительные данные `OzonSellerReportMapper`, оба маппера должны генерировать **одинаковый** `externalId` для одной и той же бизнес-операции.
+
+Правило для Ingestion-Ozon:
+- `externalId` транзакции = строка `ozon:operation:{operation_id}` (Ozon `operation_id` уникален в рамках tenant'а).
+- `operationGroupId` = UUID v5 от строки `{companyId}:{externalId}` (детерминированный, одинаков в обоих мапперах).
+- `type` = строго один из `TransactionType` (один тип = одна строка в каноне).
+
+Это гарантирует, что upsert в `UpsertFinancialTransactionAction` (блок 5) перезапишет ежедневный отчёт реализацией.
+
+Если в реализации `operation_id` отсутствует — fallback: `externalId = ozon:realization:{posting_number}:{type}:{date}`. Документировать в `ozon-mapping.md`.
+
+### 4.5 Action
+
+В блоке 6 новые Action не вводим. Используются `NormalizeRawRecordAction` и `UpsertFinancialTransactionAction` из блока 5.
+
+### 4.6 DTO
+
+Новые: `OzonRawPage`, `OzonShopDescriptor` (см. §4.1).
+
+### 4.7 Регистрация в DI
+
+`config/services.yaml`:
+```yaml
+services:
+  App\Ingestion\Application\Source\Ozon\OzonSellerReportConnector:
+    arguments:
+      $chunkSizeDays: 7
+      $hotRewindDays: 14
+      $rateLimitRpm: 60
+    tags: ['app.ingestion.connector']
+
+  App\Ingestion\Application\Source\Ozon\OzonSellerReportMapper:
+    tags: ['app.ingestion.mapper']
+
+  App\Ingestion\Application\Source\Ozon\OzonRealizationMapper:
+    tags: ['app.ingestion.mapper']
+```
+
+---
+
+## 5. Асинхронность (Messenger)
+
+Новых Message/Handler нет — используется `RunSyncChunkHandler` из блока 5, который вызовет `OzonSellerReportConnector::pull()` через `ConnectorRegistry`.
+
+---
+
+## 6. Обработка ошибок
+
+Все исключения уже определены в блоке 5. Здесь — правила, когда какое:
+
+| Ситуация | Исключение | Действие handler'а |
+|---|---|---|
+| 401/403 от Ozon, отсутствие credentials | `ConnectorAuthException` | `markJobFailed("auth")`, `UnrecoverableMessageHandlingException` |
+| 429 от Ozon | `ConnectorTransientException` | rethrow → Messenger ретраит (10s/20s/40s) |
+| 5xx, timeout, network | `ConnectorTransientException` | rethrow → ретрай |
+| Невалидный ответ Ozon (parse error) | `\RuntimeException` | `markJobFailed(reason)`, rethrow |
+| Запрос > 90 дней (Ozon ограничение) | `\InvalidArgumentException` в `pull()` | `markJobFailed` |
+
+Логирование: каждый внешний вызов Ozon — `INFO` лог с полями `companyId`, `connectionRef`, `endpoint`, `httpStatus`, `durationMs`, **без тела ответа** (CLAUDE.md §«Логирование»).
+
+---
+
+## 7. HTTP API (Controller)
+
+N/A.
+
+---
+
+## 8. Разбивка на подзадачи
+
+| Этап | Что | Зависит от | Риск | Тесты |
+|---|---|---|---|---|
+| B1 | Разведка legacy Ozon-клиентов: имена классов, публичные методы, формат ответов | блоки 1-5 | 🟢 | — |
+| B2 | `LegacyOzonClientAdapter` + классификация ошибок + `OzonRawPage`/`OzonShopDescriptor` | B1 | 🔴 (касается границ legacy) | unit на классификацию ошибок (mock legacy-клиента) |
+| B3 | `OzonResourceType` + `OzonSellerReportConnector` | B2 | 🟡 | unit на `capabilities`, `push throws`; integration на `pull` через `LegacyOzonClientAdapter` mock |
+| B4 | `OzonSellerReportMapper` + фикстуры ежедневного отчёта | B3 | 🟡 | контрактные unit-тесты на фикстурах (10+ кейсов: продажа, возврат, штраф, ...) |
+| B5 | `OzonRealizationMapper` + фикстуры реализации | B4 | 🟡 | контрактные unit-тесты + тест перезаписи ежедневки реализацией через тот же natural key |
+| B6 | Регистрация в DI + tagged services | B3, B4, B5 | 🟢 | integration: `ConnectorRegistry::get(OZON)` возвращает наш коннектор; оба маппера видны через `MapperRegistry` |
+| B7 | end-to-end интеграционный тест: `SyncFacade.startBackfill` → `RunSyncChunkHandler` → `OzonSellerReportConnector` (mock LegacyAdapter) → raw в S3 → `NormalizeRawRecordHandler` → канон | все | 🔴 | один большой test с in-memory transport |
+| B8 | `docs/ingestion/ozon-mapping.md` — таблица маппинга, fallback'и, правила natural key | B4, B5 | 🟢 | — |
+| B9 | `ARCHITECTURE.md` обновить | все | 🟢 | — |
+
+Детализация B1 (разведка legacy):
+
+В рамках первого шага блока — task для Claude Code:
+
+```
+Прочитай site/src/Marketplace/Infrastructure/Api/Ozon/ и site/src/Marketplace/Service/Integration/.
+Выдай отчёт:
+1. Список классов Ozon API-клиентов с public-методами и их сигнатурами.
+2. Какие из них дёргают /v3/finance/transaction/list (или аналог) и /v1/finance/realization.
+3. Какие исключения они бросают.
+4. Где и как они читают credentials (через connection? через service?).
+Код не меняй.
+```
+
+Результат — input для B2.
+
+---
+
+## 9. Ограничения и запреты
+
+- Не модифицировать `Marketplace/Infrastructure/Api/Ozon/*` (legacy-клиенты). `LegacyOzonClientAdapter` — единственный мост.
+- Не вводить ManyToOne связи с `MarketplaceConnection`. Credentials берутся через `CredentialFacade` строкой `connectionRef` (это либо UUID существующего `MarketplaceConnection`, либо собственный id будущего нового подключения).
+- Не трогать существующий cron `app:marketplace:ozon-daily-sync` — он продолжает работать параллельно. Гашение — блок 9.
+- Не вводить HTTP-эндпоинты. Pull инициируется через `SyncFacade.startBackfill` или через будущий cron (блок 9).
+- Performance: для одного pull-чанка (7 дней) не делать > 10 страниц Ozon API; если упёрлись — увеличить `pageSize` или уменьшить `chunkSizeDays`.
+
+---
+
+## 10. Критерии приёмки
+
+Функциональные:
+- [ ] `OzonSellerReportConnector.discoverShops` возвращает список ShopDescriptor.
+- [ ] `OzonSellerReportConnector.pull(DAILY_REPORT)` для 7-дневного окна делает корректный вызов адаптера с правильными датами.
+- [ ] `OzonSellerReportMapper.map` на эталонной фикстуре `transaction_list_with_sale_and_commission.json` производит правильный набор `MappedTransaction` (продажа IN + комиссия OUT + логистика OUT, общий `operationGroupId`, согласованный `externalId`).
+- [ ] `OzonRealizationMapper.map` на эталонной фикстуре `realization_february_2026.json` производит набор с тем же `externalId`, что и ежедневный отчёт за тот же период.
+- [ ] End-to-end тест: запуск backfill на 7 дней → `RunSyncChunkHandler` через mock LegacyAdapter → raw в S3 + IngestRawRecord → `NormalizeRawRecordHandler` → канон в `FinancialTransaction` со всеми правильными суммами.
+- [ ] Перезапись: запуск ежедневки → есть транзакции с `externalUpdatedAt = D1`; запуск реализации с `externalUpdatedAt = D2 > D1` → те же транзакции обновлены, новых дубликатов нет.
+- [ ] 401 от Ozon → `ConnectorAuthException` → job статус FAILED, `lastError = "auth"`, Messenger не ретраит.
+- [ ] 5xx от Ozon → `ConnectorTransientException` → Messenger ретраит.
+- [ ] 429 от Ozon → ретрай с задержкой.
+- [ ] Push операция (любая) → `UnsupportedCapabilityException`.
+- [ ] `controlSum` корректно считается; искусственное расхождение → `NormalizationIssue(SUM_MISMATCH)`.
+
+Технические:
+- [ ] `make site-cs-check` + PHPStan зелёные.
+- [ ] `make site-test-unit` + `make site-test-integration` зелёные.
+- [ ] Tenant-leak: коннектор компании A не возвращает данные B (через mock LegacyAdapter, который возвращает разные ответы по companyId).
+- [ ] Логирование внешних вызовов: запись присутствует, тело ответа НЕ логируется (тест по фильтру в логах).
+- [ ] `docs/ingestion/ozon-mapping.md` существует и содержит таблицу маппинга.
+- [ ] `ARCHITECTURE.md` обновлён: добавлен раздел про OzonSellerReportConnector + два resourceType.
+
+---
+
+## 11. План отката
+
+- Удалить три новых сервиса из DI (`OzonSellerReportConnector`, `OzonSellerReportMapper`, `OzonRealizationMapper`) → `ConnectorRegistry::get(OZON)` бросит `ConnectorNotFoundException`. Любой запущенный `RunSyncChunkMessage` для OZON упадёт, но не приведёт к порче данных (raw не пишется, канон не меняется).
+- Legacy-пайплайн продолжает работать → данные клиента видны.
+- Адаптер `LegacyOzonClientAdapter` после удаления коннектора становится мёртвым кодом, удаляется отдельным коммитом.
+- Зависимости вниз: блок 7 использует канон. Если канон Ozon ещё не наполнен (откатили блок 6) — блок 7 просто работает на пустых данных, без ошибок.
+
+---
+
+## 12. Чек-лист качества ТЗ
+
+- [x] Полный namespace и путь для каждого класса.
+- [x] Маппинг полей Ozon → канон в таблице.
+- [x] Правило natural key зафиксировано (`ozon:operation:{operation_id}`).
+- [x] Classification ошибок в таблице.
+- [x] Параметры коннектора декларативны (через `services.yaml`).
+- [x] DI-конфигурация прописана.
+- [x] HTTP API — N/A.
+- [x] Out of scope зафиксирован (WB, Ads, Inventory, push).
+- [x] Адаптер прячет legacy — единственная точка зависимости.
+- [x] Контрактные фикстуры обязательны для DoD.
+- [x] План отката не порождает потери данных.
+- [x] Разведка legacy указана как B1 — input для B2.

--- a/docs/tasks/ingestion/TASK-07-pnl-projection.md
+++ b/docs/tasks/ingestion/TASK-07-pnl-projection.md
@@ -1,0 +1,498 @@
+# TASK — БЛОК 7: P&L · Проекция канона в витрины + идемпотентная перегенерация
+
+## 0. Сводка
+
+- **Бизнес-цель.** Связать новый канон Ingestion (`FinancialTransaction`) с существующими витринами P&L (`PLDailyTotal`, `PLMonthlySnapshot`). Сделать перегенерацию P&L идемпотентной и автоматически реагирующей на досланные/изменённые данные источников (mark dirty → recompute). Уважать закрытые периоды (`MarketplaceMonthClose`, `financeLockBefore`).
+- **Модуль.** `App\Finance` (существующий модуль витрин). Новый код только в `Finance`, Ingestion не трогается, кроме подписки на её событие.
+- **Тип.** integration (между модулями через события + Facade).
+- **Ветка.** `feature/finance-07-pnl-projection-rebuild`.
+- **Подзадачи.** B1 PLDirtyPeriod Entity · B2 Repository · B3 NormalizationCompletedSubscriber · B4 Action mark dirty · B5 rebuildPeriod (ядро) · B6 защита закрытых периодов · B7 воркер пачкой · B8 Facade · B9 Тесты.
+- **Затрагивает другие модули.** `App\Ingestion` (подписка на событие `NormalizationCompletedEvent`, чтение через `IngestionFacade::getTransactions`).
+- **Требует миграции БД.** Да (1 таблица).
+- **Меняет публичный API.** Нет (HTTP — блок 8).
+
+---
+
+## 1. Контекст и границы
+
+### 1.1 Текущее состояние
+
+- В Finance существуют `PLCategory`, `PLDailyTotal`, `PLMonthlySnapshot`, `Document`, `DocumentOperation`. P&L наполняется legacy-кодом из `Marketplace` и `Cash`.
+- В Ingestion готов канон `FinancialTransaction` (блок 5), есть событие `NormalizationCompletedEvent` с `AffectedPeriod[]`, есть `IngestionFacade::getTransactions(companyId, from, to, shopRef)`.
+- Существует `MarketplaceMonthClose` (закрытый месяц по магазину/маркетплейсу) и `Company.financeLockBefore` (дата, до которой все периоды компании заблокированы).
+- В legacy используется команда `app:marketplace:month-preliminary-rebuild`, но она привязана к конкретному источнику, а не к канону.
+
+### 1.2 Желаемое состояние
+
+- Новая Entity `PLDirtyPeriod`: компания + период (год-месяц) + shop + статус (pending/rebuilding/done) + причина (ingest/manual/remap/month_change).
+- Подписчик `NormalizationCompletedSubscriber` ловит `NormalizationCompletedEvent`, для каждого `AffectedPeriod` определяет (старый, новый) месяц по `occurredAt` и помечает оба `PLDirtyPeriod` со статусом pending.
+- Идемпотентный `PnlFacade::rebuildPeriod(companyId, period, shopRef, source)` читает канон через `IngestionFacade::getTransactions`, **полностью** заменяет P&L-записи периода в одной транзакции БД.
+- Воркер `RebuildDirtyPnlPeriodsCommand` (cron + Messenger): берёт pending → зовёт `rebuildPeriod` для каждого → переводит в done.
+- Защита от конкурентных перегенераций одного периода — Redis Lock с ключом `pnl_rebuild:{companyId}:{period}:{shopRef}`.
+- Закрытые периоды: при попытке `rebuildPeriod` для закрытого периода — НЕ перезаписывать, а создавать `PnlClosedPeriodAlert` (или поднимать флаг в `PLDirtyPeriod` через статус `blocked_by_close`).
+- Версионирование: каждая `PLDailyTotal`/`PLMonthlySnapshot` получает поле `rebuiltAt` (timestamp) — для аудита, когда пересчитано последний раз.
+
+### 1.3 In scope
+
+- Entity `PLDirtyPeriod` (новая, в `Finance`).
+- Enum `PLDirtyPeriodStatus`, `PLDirtyPeriodReason`.
+- Repository `PLDirtyPeriodRepository`.
+- `NormalizationCompletedSubscriber` в Finance (подписан на событие Ingestion).
+- Action `MarkPnlPeriodDirtyAction`, `RebuildPnlPeriodAction`, `MaybeBlockByClosePeriodAction`.
+- Service `PnlPeriodResolver` (вычисление месяца из `occurredAt`).
+- `PnlFacade` расширяется методами `markPeriodDirty`, `rebuildPeriod`, `getDirtyPeriods`.
+- Доменное событие `PnlClosedPeriodTouchedEvent` (для будущих уведомлений в блоке 9).
+- Command `app:finance:rebuild-dirty-pnl-periods` (cron-инициируемый воркер).
+- Расширение существующих `PLDailyTotal`/`PLMonthlySnapshot` полем `rebuiltAt` (через миграцию).
+- Маппинг `TransactionType` (Ingestion) → `PLCategory.flow/code` (Finance) — справочная таблица + резолвер.
+
+### 1.4 Out of scope
+
+- UI для просмотра/запуска перегенерации — блок 8.
+- Admin для управления закрытыми периодами — блок 9.
+- Email/Telegram-уведомления о доехавших данных в закрытый период — блок 9.
+- Существующий legacy-пайплайн P&L (`Marketplace`-источник) НЕ заменяется. Он продолжает писать в те же `PLDailyTotal` — пока Ingestion не покроет тот же набор данных (после блока 6 — только Ozon, остальные — позже).
+- Coexistence Ingestion vs legacy в P&L: в shadow-режиме блока 9; в блоке 7 — только инфраструктура rebuild, реальное переключение источника наполнения — в блоке 9.
+
+### 1.5 Допущения и открытые вопросы
+
+- Допущение: «период» в P&L = месяц (year + month). Это уже в `PLMonthlySnapshot`. `PLDailyTotal` хранится по дням, но dirty-флаг — на уровне месяца (перегенерация одного месяца перезаписывает все дневные записи этого месяца).
+- Допущение: один dirty-period покрывает один shop (для случая «реклама пришла на конкретный магазин — пересчитываем только его»). Для случая «доехала операция без shop» — `shopRef = ''`, перегенерируется P&L всей компании за период.
+- Открытый вопрос: как маппить `TransactionType` Ingestion в существующие `PLCategory` (которые у каждой компании свои)? Решение: сервис `PnlCategoryResolver`, который для пары `(companyId, TransactionType, direction)` отдаёт `PLCategory.id`. Дефолтный маппинг — через `MarketplaceCostPLMapping` (если он применим), fallback — в системную категорию «Прочее». Детализация — отдельной разведкой при старте блока, но контракт сервиса фиксируем сейчас.
+
+---
+
+## 2. Доменная модель
+
+### 2.1 Сущности (Entity)
+
+#### `App\Ingestion\Entity\PLDirtyPeriod`
+
+Файл: `src/Ingestion/Entity/PLDirtyPeriod.php`.
+Таблица: `#[ORM\Table(name: 'pnl_dirty_periods')]`.
+
+Использует scalar `companyId` (как новый стиль). Так как Finance — legacy-модуль на ManyToOne `Company`, для НОВОЙ Entity используем scalar (правило CLAUDE.md для нового кода). Это не нарушает существующих сущностей.
+
+| Поле | Тип | Колонка | Nullable | Default | Инвариант |
+|---|---|---|---|---|---|
+| `id` | string UUID v7 | `id` GUID | нет | — | PK |
+| `companyId` | string UUID | `company_id` GUID | нет | — | `Assert::uuid`, неизменяем |
+| `periodYear` | int | `period_year` SMALLINT | нет | — | 2020..2100 |
+| `periodMonth` | int | `period_month` SMALLINT | нет | — | 1..12 |
+| `shopRef` | string | `shop_ref` VARCHAR(255) | нет | `''` | `''` = всех магазинов; неизменяем |
+| `status` | PLDirtyPeriodStatus | `status` VARCHAR(32) | нет | PENDING | enumType |
+| `reason` | PLDirtyPeriodReason | `reason` VARCHAR(32) | нет | — | enumType |
+| `markedAt` | DateTimeImmutable | `marked_at` TIMESTAMP(6) | нет | — | |
+| `rebuiltAt` | ?DateTimeImmutable | `rebuilt_at` TIMESTAMP(6) | да | null | время фактической перегенерации |
+| `attempts` | int | `attempts` INTEGER | нет | 0 | сколько раз входили в REBUILDING |
+| `lastError` | ?string | `last_error` TEXT | да | null | для статуса BLOCKED_BY_CLOSE или FAILED |
+| `createdAt` | DateTimeImmutable | `created_at` TIMESTAMP(6) | нет | — | |
+| `updatedAt` | DateTimeImmutable | `updated_at` TIMESTAMP(6) | нет | — | |
+
+Конструктор: `__construct(string $companyId, int $periodYear, int $periodMonth, string $shopRef, PLDirtyPeriodReason $reason)`.
+
+Инварианты: `Assert::range($periodYear, 2020, 2100)`, `Assert::range($periodMonth, 1, 12)`.
+
+Поведенческие методы:
+- `markRebuilding(): void` — переход PENDING → REBUILDING, `attempts++`.
+- `markDone(?DateTimeImmutable $at = null): void` — переход REBUILDING → DONE, `rebuiltAt = $at ?? now`.
+- `markFailed(string $reason): void` — переход REBUILDING → FAILED, `lastError = $reason`.
+- `markBlockedByClose(string $reason): void` — переход PENDING/REBUILDING → BLOCKED_BY_CLOSE.
+- `reopen(): void` — переход DONE/FAILED → PENDING (для повторной пометки, если ещё досылка).
+
+#### Изменения в существующих сущностях
+
+`PLDailyTotal` — добавить поле:
+- `rebuiltAt: ?DateTimeImmutable` (nullable), миграция с default null.
+- Сеттер: `setRebuiltAt(DateTimeImmutable $at): void`.
+
+`PLMonthlySnapshot` — добавить поле `rebuiltAt` аналогично.
+
+Это **поля для аудита**, не для бизнес-логики; legacy-код продолжает работать (не заполняет их).
+
+### 2.2 Связи
+
+Внутри модуля: `PLDirtyPeriod` — самостоятельная Entity, без связей с `PLDailyTotal` (один dirty-period покрывает все daily-records месяца).
+
+Между модулями: `PLDirtyPeriod.companyId` — ссылка строкой на Ingestion/Company. `shopRef` — открытая строка (совпадает с тем, что в каноне Ingestion и Marketplace).
+
+### 2.3 Enum
+
+#### `App\Ingestion\Enum\PLDirtyPeriodStatus`
+
+Backed string.
+
+| Case | value | Когда | Метка | Терминальный |
+|---|---|---|---|---|
+| `PENDING` | `pending` | Создан/переоткрыт | «Ожидает перегенерации» | нет |
+| `REBUILDING` | `rebuilding` | `markRebuilding()` | «Перегенерируется» | нет |
+| `DONE` | `done` | `markDone()` | «Готово» | да* |
+| `FAILED` | `failed` | `markFailed()` | «Ошибка» | да* |
+| `BLOCKED_BY_CLOSE` | `blocked_by_close` | Период закрыт | «Заблокировано закрытием» | да* |
+
+*Терминальный условно — `reopen()` возвращает в PENDING при необходимости.
+
+Методы: `label()`, `isTerminal()`, `canTransitionTo()`.
+
+Матрица переходов:
+
+| из/в | PENDING | REBUILDING | DONE | FAILED | BLOCKED_BY_CLOSE |
+|---|---|---|---|---|---|
+| PENDING | ❌ | ✅ | ❌ | ❌ | ✅ |
+| REBUILDING | ❌ | ❌ | ✅ | ✅ | ✅ |
+| DONE | ✅ (reopen) | ❌ | ❌ | ❌ | ❌ |
+| FAILED | ✅ (reopen) | ❌ | ❌ | ❌ | ❌ |
+| BLOCKED_BY_CLOSE | ✅ (reopen после открытия периода) | ❌ | ❌ | ❌ | ❌ |
+
+#### `App\Ingestion\Enum\PLDirtyPeriodReason`
+
+| Case | value | Когда устанавливается | Метка |
+|---|---|---|---|
+| `INGEST` | `ingest` | Подписчик на NormalizationCompletedEvent | «Новые данные источника» |
+| `MANUAL` | `manual` | Пользователь нажал «пересчитать» (в блоке 8) | «Ручной запуск» |
+| `REMAP` | `remap` | Изменился маппинг категорий | «Изменение маппинга» |
+| `MONTH_CHANGE` | `month_change` | Операция перенесена в другой период | «Смена периода операции» |
+
+---
+
+## 3. Слой доступа к данным
+
+### 3.1 Repository
+
+#### `App\Ingestion\Repository\PLDirtyPeriodRepository`
+
+| Метод | Что делает | companyId | Возврат |
+|---|---|---|---|
+| `findOne(string $companyId, int $year, int $month, string $shopRef = ''): ?PLDirtyPeriod` | По уникальному ключу | да | `?PLDirtyPeriod` |
+| `findPending(int $limit = 50): list<PLDirtyPeriod>` | Для воркера: PENDING со всех компаний, ORDER BY markedAt | нет* | `list<PLDirtyPeriod>` |
+| `findPendingForCompany(string $companyId): list<PLDirtyPeriod>` | PENDING конкретной компании | да | `list<PLDirtyPeriod>` |
+| `countByStatus(string $companyId, PLDirtyPeriodStatus $status): int` | Для admin/UI | да | `int` |
+
+*`findPending` — системный запрос воркера (по всем тенантам). В блоке 1 был зафиксирован паттерн: системные методы НЕ принимают companyId. Применяется здесь.
+
+#### `App\Finance\Repository\PLDailyTotalRepository` (правка)
+
+Добавить метод:
+- `deleteByCompanyShopAndMonth(string $companyId, string $shopRef, int $year, int $month): int` — DELETE через DBAL для атомарной очистки месяца перед перезаписью. Возвращает кол-во удалённых строк.
+
+Если `shopRef = ''` — удалить все записи месяца компании независимо от shop'а.
+
+Аналогично `PLMonthlySnapshotRepository::deleteByCompanyShopAndMonth`.
+
+### 3.2 Query
+
+Не вводим в блоке 7. Будет в блоке 8.
+
+### 3.3 Индексы
+
+`pnl_dirty_periods`:
+- UNIQUE `(company_id, period_year, period_month, shop_ref)` → `uniq_pdp_key`.
+- INDEX `(status, marked_at)` → `idx_pdp_status_marked` (для воркера).
+- INDEX `(company_id, status)` → `idx_pdp_company_status`.
+
+`pl_daily_totals` и `pl_monthly_snapshots`:
+- Добавить колонку `rebuilt_at` (TIMESTAMP nullable, без индекса).
+
+---
+
+## 4. Слой приложения
+
+### 4.1 Action
+
+#### `App\Finance\Application\Action\MarkPnlPeriodDirtyAction`
+
+Вход: `MarkPnlPeriodDirtyCommand` (`string $companyId, int $year, int $month, string $shopRef, PLDirtyPeriodReason $reason`).
+
+Шаги:
+1. `findOne($companyId, $year, $month, $shopRef)`.
+2. Если null — создать `PLDirtyPeriod(status=PENDING)`, persist.
+3. Если найден в DONE/FAILED — вызвать `reopen()`.
+4. Если найден в PENDING/REBUILDING/BLOCKED_BY_CLOSE — не трогать (уже помечен).
+5. flush.
+
+Идемпотентно: 5 вызовов подряд → одна строка.
+
+#### `App\Finance\Application\Action\RebuildPnlPeriodAction`
+
+Вход: `RebuildPnlPeriodCommand` (`string $companyId, int $year, int $month, string $shopRef = ''`).
+
+Шаги (в одной транзакции БД, под Redis Lock):
+1. Acquire Lock `pnl_rebuild:{companyId}:{year}-{month}:{shopRef}` с TTL 10 мин.
+2. Проверить, закрыт ли период через `MaybeBlockByClosePeriodAction`:
+   - Прочитать `Company.financeLockBefore` — если `>= last day of (year, month)` → блокирован.
+   - Прочитать `MarketplaceMonthClose` для каждого `marketplace` (или для shop'а, если shopRef задан) — если закрыт → блокирован.
+   - Если блокирован: найти/создать `PLDirtyPeriod`, вызвать `markBlockedByClose($reason)`, опубликовать `PnlClosedPeriodTouchedEvent`, flush, return.
+3. Перевести `PLDirtyPeriod` в REBUILDING (если он есть).
+4. Определить границы периода: `from = first day of month`, `to = last day of month`.
+5. `deleteByCompanyShopAndMonth` для `PLDailyTotal` и `PLMonthlySnapshot`.
+6. Итерировать канон: `IngestionFacade::getTransactions($companyId, $from, $to, $shopRef === '' ? null : $shopRef)`.
+7. Для каждой `FinancialTransaction`:
+   - Резолвить `PLCategory` через `PnlCategoryResolver::resolve($companyId, $type, $direction)`.
+   - Агрегировать сумму по (день, плКатегория, projectDirection=null) в `PLDailyTotal`.
+   - Параллельно агрегировать по (месяц, плКатегория) в `PLMonthlySnapshot`.
+8. persist всех агрегатов + flush.
+9. `PLDirtyPeriod->markDone()`.
+10. flush.
+11. Release Lock.
+
+При исключении в шагах 4-10: rollback транзакции, `markFailed($reason)`, release lock, rethrow.
+
+`PnlCategoryResolver` — сервис в `App\Finance\Application\Service\PnlCategoryResolver`:
+- `resolve(string $companyId, TransactionType $type, TransactionDirection $direction): string` — возвращает `PLCategory.id`. При отсутствии маппинга — фолбэк в системную категорию «Прочее» (создание если нет). Алгоритм маппинга — отдельная разведка legacy `MarketplaceCostPLMapping` при старте блока, но контракт фиксирован.
+
+#### `App\Finance\Application\Action\MaybeBlockByClosePeriodAction` (internal)
+
+Вход: `(string $companyId, int $year, int $month, string $shopRef)`.
+
+Шаги:
+1. Загрузить `Company` (через legacy Facade или Repository — у Finance уже есть доступ).
+2. Если `Company.financeLockBefore !== null` и `financeLockBefore >= lastDayOfMonth` → return `true`.
+3. Если `shopRef !== ''` — найти `MarketplaceMonthClose` по `(companyId, marketplace=derived, year, month)` (marketplace выводится из формата shopRef — обсудить при разведке). Если найден и `stage = CLOSED` → return `true`.
+4. Если `shopRef === ''` — проверить **все** `MarketplaceMonthClose` для компании за этот период; если хотя бы один закрыт → return `true` (консервативно: не пересчитываем затронутый закрытым).
+5. Иначе return `false`.
+
+Возвращает `bool` + (опционально) причину блокировки строкой.
+
+### 4.2 Подписчик на событие Ingestion
+
+#### `App\Finance\EventSubscriber\NormalizationCompletedSubscriber`
+
+Файл: `src/Finance/EventSubscriber/NormalizationCompletedSubscriber.php`. `final class`, имплементит `EventSubscriberInterface`.
+
+Подписка: `NormalizationCompletedEvent::class => 'onNormalizationCompleted'`.
+
+Шаги в `onNormalizationCompleted(NormalizationCompletedEvent $event): void`:
+1. Для каждого `AffectedPeriod $period` из `$event->affectedPeriods`:
+   - Вычислить новый месяц: `(year, month) = PnlPeriodResolver::from($period->newOccurredAt)`.
+   - Если `$period->oldOccurredAt !== null` и `month старого ≠ month нового` → вычислить и старый период.
+   - Для каждого периода: dispatch `MarkPnlPeriodDirtyMessage($companyId, $year, $month, $period->shopRef, INGEST)` в `ingest_normalize` (использовать тот же transport — обработка быстрая).
+
+Подписчик НЕ зовёт `RebuildPnlPeriodAction` напрямую — только маркирует. Сама перегенерация — асинхронная пачка через воркер.
+
+Альтернатива (более простая на старте): подписчик сразу dispatch'ит `RebuildPnlPeriodMessage` для каждого периода. Выбираем **через mark dirty** — это даёт сглаживание нагрузки (досыл за 200 дней не запустит 200 одновременных пересчётов).
+
+### 4.3 PnlPeriodResolver
+
+#### `App\Finance\Application\Service\PnlPeriodResolver`
+
+`final class`. Чистая логика, без зависимостей.
+
+Методы:
+- `from(DateTimeImmutable $at): array{0: int, 1: int}` — `[year, month]` в TZ `Europe/Moscow` (для согласованности с финансовой отчётностью). Конвертация UTC → Europe/Moscow → year/month.
+
+### 4.4 DTO
+
+`MarkPnlPeriodDirtyCommand`:
+| Поле | Тип | Обязательно | Валидация |
+|---|---|---|---|
+| `companyId` | string | да | UUID |
+| `year` | int | да | 2020..2100 |
+| `month` | int | да | 1..12 |
+| `shopRef` | string | да | может быть '' |
+| `reason` | PLDirtyPeriodReason | да | enum |
+
+`RebuildPnlPeriodCommand`:
+| Поле | Тип | Обязательно | Валидация |
+|---|---|---|---|
+| `companyId` | string | да | UUID |
+| `year` | int | да | 2020..2100 |
+| `month` | int | да | 1..12 |
+| `shopRef` | string | нет | '' = все магазины |
+
+### 4.5 Facade
+
+#### `App\Finance\Facade\PnlFacade` (расширение существующего, если есть; иначе новый)
+
+Методы (новые):
+- `markPeriodDirty(MarkPnlPeriodDirtyCommand $command): void`.
+- `rebuildPeriod(RebuildPnlPeriodCommand $command): void`.
+- `getDirtyPeriods(string $companyId): list<PLDirtyPeriodView>` — для UI блока 8.
+- `getProgress(string $companyId): PnlProgressView` — счётчики `pending/rebuilding/done/failed/blocked` для admin (блок 9).
+
+`PLDirtyPeriodView` — `final readonly class` в `App\Ingestion\Application\DTO`; `PnlProgressView` — `final readonly class` в `App\Finance\Application\DTO`.
+
+### 4.6 Доменное событие
+
+#### `App\Finance\Domain\Event\PnlClosedPeriodTouchedEvent`
+
+`final readonly class`.
+
+Поля: `companyId: string`, `year: int`, `month: int`, `shopRef: string`, `reason: string`.
+
+Публикуется в `MaybeBlockByClosePeriodAction` когда период заблокирован. Подписчиков в блоке 7 нет (заглушка для блока 9, где появится уведомление).
+
+---
+
+## 5. Асинхронность (Messenger)
+
+### 5.1 Сообщения
+
+#### `App\Finance\Message\MarkPnlPeriodDirtyMessage`
+
+`final readonly class`, реализует `CompanyAwareMessage` (из блока 1).
+Поля: `companyId, year, month, shopRef, reasonValue`. Метод `getCompanyId()`.
+
+Routing: `ingest_normalize` (быстрая операция, на тех же воркерах что и нормализация — экономим на отдельном пуле).
+
+#### `App\Finance\Message\RebuildPnlPeriodMessage`
+
+`final readonly class`, реализует `CompanyAwareMessage`.
+Поля: `companyId, year, month, shopRef`.
+
+Routing: `pnl_rebuild` — новый transport (см. §5.3).
+
+### 5.2 Handler'ы
+
+`MarkPnlPeriodDirtyHandler` — вызывает `MarkPnlPeriodDirtyAction`. IdempotentHandlerTrait по natural key `(companyId, year, month, shopRef)`.
+
+`RebuildPnlPeriodHandler` — вызывает `RebuildPnlPeriodAction`. IdempotentHandlerTrait по тому же key.
+
+### 5.3 Routing
+
+`config/packages/messenger.yaml`:
+
+```yaml
+framework:
+  messenger:
+    transports:
+      pnl_rebuild:
+        dsn: '%env(MESSENGER_TRANSPORT_DSN_PIPELINE)%'   # тот же DSN что async_pipeline
+        retry_strategy:
+          max_retries: 3
+          delay: 30000
+          multiplier: 2
+    routing:
+      App\Finance\Message\MarkPnlPeriodDirtyMessage: ingest_normalize
+      App\Finance\Message\RebuildPnlPeriodMessage: pnl_rebuild
+```
+
+### 5.4 Воркер пачкой
+
+#### `App\Finance\Command\RebuildDirtyPnlPeriodsCommand`
+
+CLI-команда, регистрируется как cron-задача (`docker/cron/app.cron`):
+
+```
+*/5 * * * * /usr/local/bin/php /app/bin/console app:finance:rebuild-dirty-pnl --max=20 --no-interaction --quiet
+```
+
+Шаги:
+1. `findPending(limit=$max)`.
+2. Для каждого: dispatch `RebuildPnlPeriodMessage(companyId, year, month, shopRef)` в `pnl_rebuild`.
+3. Лог: «Dispatched N rebuild jobs».
+
+Команда сама **не** делает rebuild — только диспатчит сообщения, чтобы рабочая нагрузка размазалась по воркерам и не блокировала cron-тик.
+
+### 5.5 Идемпотентность
+
+`MarkPnlPeriodDirtyAction` идемпотентен по природе (повтор не меняет PENDING).
+
+`RebuildPnlPeriodAction` идемпотентен через:
+- Redis Lock — параллельные rebuild'ы одного периода сериализуются.
+- DELETE-then-INSERT — повторный запуск даёт тот же результат.
+
+Это закрывает оба сценария: «handler упал между DELETE и INSERT» → лок отпустится, новый запуск увидит, что dirty period в REBUILDING и атаmpt'ом > 0, и сделает rebuild заново.
+
+---
+
+## 6. Обработка ошибок
+
+| Класс | Когда | HTTP-статус | error.code | message |
+|---|---|---|---|---|
+| `PLDirtyPeriodNotFoundException` | Action не нашёл dirty-period | 404 | `pnl_dirty_period_not_found` | «Запись о грязном периоде не найдена» |
+| `PnlPeriodClosedException` | Попытка rebuildPeriod закрытого периода (через Facade без воркера) | 409 | `pnl_period_closed` | «Период закрыт, перегенерация невозможна» |
+| `PnlCategoryResolveException` | Не нашли подходящую PLCategory и не смогли создать fallback | 500 | `pnl_category_resolve_failed` | «Не удалось определить категорию P&L» |
+| `PnlRebuildLockTimeoutException` | Не смогли взять Redis Lock за таймаут | 503 | `pnl_rebuild_busy` | «Перегенерация уже выполняется, повторите позже» |
+
+Все исключения — `App\Finance\Exception\*`, `final class`.
+
+---
+
+## 7. HTTP API (Controller)
+
+N/A в блоке 7 (будет в блоке 8: эндпоинты для ручного запуска `rebuildPeriod`, просмотра `getDirtyPeriods`, `getProgress`).
+
+---
+
+## 8. Разбивка на подзадачи
+
+| Этап | Что | Зависит от | Риск | Тесты |
+|---|---|---|---|---|
+| B1 | `PLDirtyPeriod` Entity + enum + миграция + добавление `rebuiltAt` в PLDailyTotal/PLMonthlySnapshot | блок 5 | 🔴 | unit инвариантов |
+| B2 | `PLDirtyPeriodRepository` + `deleteByCompanyShopAndMonth` в PLDailyTotal/Snapshot Repo | B1 | 🟡 | tenant-leak, DELETE-тест |
+| B3 | `PnlPeriodResolver` (TZ Europe/Moscow) | — | 🟢 | unit на edge cases (00:00 моск.т., decembernewyear, leap year) |
+| B4 | `PnlCategoryResolver` + разведка legacy `MarketplaceCostPLMapping` | блок 5 | 🟡 | unit на маппинг каждого `TransactionType` |
+| B5 | `MarkPnlPeriodDirtyAction` + `MarkPnlPeriodDirtyMessage` + Handler | B1, B2 | 🟡 | идемпотентность |
+| B6 | `NormalizationCompletedSubscriber` | блок 5, B5 | 🟡 | подписан, корректно диспатчит при смене периода |
+| B7 | `MaybeBlockByClosePeriodAction` + `PnlClosedPeriodTouchedEvent` | B1 | 🟡 | тест на 4 кейса: financeLockBefore / MarketplaceMonthClose / shop / all-shops |
+| B8 | `RebuildPnlPeriodAction` + Redis Lock + `RebuildPnlPeriodMessage` + Handler | B4, B7 | 🔴 | главное ядро: идемпотентность, перезапись, lock |
+| B9 | `RebuildDirtyPnlPeriodsCommand` + cron | B8 | 🟡 | integration |
+| B10 | `PnlFacade` методы | B5, B8 | 🟢 | integration |
+| B11 | `ARCHITECTURE.md` обновить | все | 🟢 | — |
+
+---
+
+## 9. Ограничения и запреты
+
+- Не модифицировать legacy-наполнение `PLDailyTotal`/`PLMonthlySnapshot` со стороны `Marketplace`. Параллельная coexistence: legacy и Ingestion могут писать в одну таблицу. До блока 9 — это допустимо, поскольку Ingestion ещё не покрывает все источники.
+  - Важный нюанс: при `rebuildPeriod` мы DELETE'им строки месяца **только** по записям с `rebuiltAt IS NOT NULL` (т.е. ранее созданным новым rebuild'ом). Записи legacy остаются. **НЕТ** — это сложно и хрупко. Лучше: в блоке 7 фактическое выполнение `rebuildPeriod` ЗАПРЕЩЕНО, когда есть legacy-источник, который ещё пишет в этот period. Это контролируется через feature flag (см. блок 9).
+  - В блоке 7 `rebuildPeriod` работает, но в production cron `RebuildDirtyPnlPeriodsCommand` отключён (или feature flag), пока не пройдёт shadow в блоке 9. Команда — для тестов и admin.
+- Не трогать `Company.financeLockBefore`, `MarketplaceMonthClose` — только читать.
+- Не трогать существующий cron `app:marketplace:month-preliminary-rebuild`.
+- Не вводить HTTP-эндпоинты.
+- Безопасность: `Repository::findPending` (системный, без companyId) — лимит результата 200, ORDER BY чтобы не было голодания одной компании.
+- Performance: `rebuildPeriod` для одного месяца одной компании должен укладываться в 30 сек (по канону ~100k транзакций). Использовать `iterateByPeriod` + batch flush каждые 1000 строк.
+
+---
+
+## 10. Критерии приёмки
+
+Функциональные:
+- [ ] Создание `PLDirtyPeriod` через `MarkPnlPeriodDirtyAction` идемпотентно.
+- [ ] `NormalizationCompletedSubscriber` правильно вычисляет период (TZ Europe/Moscow) и диспатчит сообщения mark dirty.
+- [ ] При смене периода операции (`oldOccurredAt` ≠ `newOccurredAt` по месяцу) помечаются ОБА периода.
+- [ ] `RebuildPnlPeriodAction` полностью перезаписывает `PLDailyTotal`/`PLMonthlySnapshot` за месяц.
+- [ ] Запуск `rebuildPeriod` 5 раз подряд даёт идентичный результат.
+- [ ] Конкурентные `rebuildPeriod` одного периода сериализуются через Redis Lock.
+- [ ] `financeLockBefore` блокирует rebuild — статус `BLOCKED_BY_CLOSE`, событие `PnlClosedPeriodTouchedEvent` опубликовано.
+- [ ] `MarketplaceMonthClose` блокирует rebuild — то же поведение.
+- [ ] `reopen()` после открытия периода → возможен новый rebuild.
+- [ ] `RebuildDirtyPnlPeriodsCommand` диспатчит до `--max` сообщений, не блокирует cron.
+- [ ] `PnlFacade.getDirtyPeriods` возвращает список с view.
+- [ ] `PnlFacade.getProgress` возвращает корректные счётчики.
+
+Технические:
+- [ ] Миграции применяются/откатываются.
+- [ ] `make site-cs-check` + PHPStan зелёные.
+- [ ] `make site-test-unit` + `make site-test-integration` зелёные.
+- [ ] Tenant-leak на `PLDirtyPeriod`.
+- [ ] `RebuildPnlPeriodAction` для 10k транзакций укладывается в 5 сек (integration-бенчмарк).
+- [ ] Подписчик правильно регистрируется в `event_dispatcher` (тест: dispatch события → handler вызван).
+- [ ] `ARCHITECTURE.md` обновлён.
+
+---
+
+## 11. План отката
+
+- Удалить `NormalizationCompletedSubscriber` → события Ingestion перестают порождать dirty-periods. Канон продолжает писаться, P&L продолжает наполняться legacy.
+- DROP `pnl_dirty_periods`. Откат полей `rebuilt_at` — оставить (nullable, никому не мешает; удалять отдельной миграцией позже).
+- Удалить cron `app:finance:rebuild-dirty-pnl` из расписания.
+- Зависимости вниз: блок 8 (UI) и блок 9 (shadow) используют `PnlFacade.getDirtyPeriods/getProgress`. Их откат — отдельная задача.
+
+---
+
+## 12. Чек-лист качества ТЗ
+
+- [x] Полный namespace и путь.
+- [x] Полная таблица `PLDirtyPeriod` с инвариантами.
+- [x] Изменения существующих сущностей (`PLDailyTotal.rebuiltAt`, `PLMonthlySnapshot.rebuiltAt`) явно указаны.
+- [x] Enum с матрицей переходов.
+- [x] Сигнатуры всех методов Repository/Action/Facade.
+- [x] `findPending` помечен как системный (без companyId) с обоснованием.
+- [x] HTTP — N/A явно.
+- [x] Исключения с кодами.
+- [x] Индексы с именами.
+- [x] Транспорты Messenger.
+- [x] TZ Europe/Moscow зафиксирован для вычисления периода.
+- [x] Out of scope явно (coexistence с legacy остаётся, переключение — в блоке 9).
+- [x] План отката не разрушает данные.

--- a/docs/tasks/ingestion/handoff.md
+++ b/docs/tasks/ingestion/handoff.md
@@ -1,0 +1,146 @@
+# Ingestion Blocks 4-7 Final Handoff
+
+## Status
+
+**Final state:** DONE for `TASK-04` through `TASK-07`.
+
+**Next action:** STOP, owner review and acceptance required.
+
+`TASK-08` and `TASK-09` were not executed because their task files are absent and were explicitly kept out of this implementation scope.
+
+## Stage Summary
+
+- Stage 1 - Block 4 schema/domain: added `IngestCursor`, `SyncJob`, enums, transition exceptions, migration, entity tests.
+- Stage 2 - Block 4 orchestration: added repositories, transition policy, sync actions, `SyncFacade`, fetch messages/handler, rate-limit guard, Messenger routing.
+- Stage 3 - Block 5 canon schema: added shared `Money`, canonical Ingestion transaction/counterparty/issue model, migration, repositories, tenant-leak coverage.
+- Stage 4 - Block 5 normalization pipeline: added connector/mapper contracts, registries, normalization/upsert/issue actions, event, messages/handlers, fake test pipeline, `IngestionFacade`.
+- Stage 5 - Block 6 reconnaissance: inspected legacy Ozon integration and saved findings before implementation.
+- Stage 6 - Block 6 Ozon connector: added legacy adapter, Ozon connector, daily/realization mappers, fixtures, mapping docs, unit/integration tests.
+- Stage 7 - Block 7 P&L dirty-period schema: added `PLDirtyPeriod`, enums, repository, migration, `rebuiltAt` on P&L aggregates, delete helpers, tests.
+- Stage 8 - Block 7 rebuild infrastructure: added P&L dirty marking, event subscriber, close guard, rebuild action/messages/handlers, CLI dispatch command, `PnlFacade`, tests.
+- Stage 8 review fix: renamed `PnlDirtyPeriod*` PHP types to `PLDirtyPeriod*` for consistency with existing `PLDailyTotal` / `PLMonthlySnapshot` naming.
+- Stage 9 correction: moved `PLDirtyPeriod*` ownership from `App\Finance` to `App\Ingestion` and added `TenantOwnedInterface` to the entity.
+- Stage 10 correction: updated shared `Money` to support signed minor units, negative subtraction results, and real sign negation.
+
+Detailed per-stage reports are in `docs/tasks/ingestion/stages/stage-1.md` through `stage-10-correction-money-signed.md`.
+
+## Files Changed
+
+### Documentation
+
+- `ARCHITECTURE.md`
+- `docs/tasks/ingestion/INDEX.md`
+- `docs/tasks/ingestion/TASK-04-cursor-syncjob.md`
+- `docs/tasks/ingestion/TASK-05-connector-canon.md`
+- `docs/tasks/ingestion/TASK-06-ozon-connector.md`
+- `docs/tasks/ingestion/TASK-07-pnl-projection.md`
+- `docs/tasks/ingestion/plan.md`
+- `docs/tasks/ingestion/FOLLOWUP-finance-source-linking.md`
+- `docs/tasks/ingestion/stages/stage-1.md` through `stage-10-correction-money-signed.md`
+- `docs/ingestion/ozon-mapping.md`
+
+### Configuration
+
+- `site/config/packages/messenger.yaml`
+- `site/config/packages/test/messenger.yaml`
+- `site/config/services.yaml`
+- `site/config/services_test.yaml`
+
+### Migrations
+
+- `site/migrations/Version20260618120000.php`
+- `site/migrations/Version20260618130000.php`
+- `site/migrations/Version20260618140000.php`
+
+### Shared
+
+- `site/src/Shared/Domain/ValueObject/Money.php`
+- `site/src/Shared/Domain/Exception/MoneyMismatchException.php`
+
+### Ingestion
+
+- New Ingestion entities, enums, repositories, actions, commands, DTOs, contracts, events, services, facades, messages, and handlers under `site/src/Ingestion/`.
+- Ozon adapter/connector/mapper implementation under `site/src/Ingestion/Application/Source/Ozon/` and `site/src/Ingestion/Infrastructure/Api/Ozon/`.
+- Existing `site/src/Ingestion/Entity/IngestRawRecord.php` and `site/src/Ingestion/Repository/IngestRawRecordRepository.php` were extended with normalization support.
+
+### Finance
+
+- New P&L rebuild orchestration classes under `site/src/Finance/Application/`, `site/src/Finance/Command/`, `site/src/Finance/Domain/`, `site/src/Finance/EventSubscriber/`, `site/src/Finance/Exception/`, `site/src/Finance/Facade/`, `site/src/Finance/Message/`, `site/src/Finance/MessageHandler/`.
+- New dirty-period pipeline state under `site/src/Ingestion/Entity/PLDirtyPeriod.php`, `site/src/Ingestion/Enum/PLDirtyPeriodReason.php`, `site/src/Ingestion/Enum/PLDirtyPeriodStatus.php`, `site/src/Ingestion/Repository/PLDirtyPeriodRepository.php`.
+- Existing `PLDailyTotal`, `PLMonthlySnapshot`, and their repositories were extended with `rebuiltAt` and rebuild delete/upsert support.
+
+### Tests And Fixtures
+
+- New unit/integration coverage under `site/tests/Unit/Ingestion/`, `site/tests/Integration/Ingestion/`, `site/tests/Unit/Finance/`, `site/tests/Integration/Finance/`.
+- New Ozon fixtures under `site/tests/Fixtures/Ingestion/Ozon/`.
+
+## Migrations
+
+- `Version20260618120000`: creates `ingest_cursors` and `ingest_sync_jobs`.
+- `Version20260618130000`: creates `ingest_counterparties`, `ingest_financial_transactions`, and `ingest_normalization_issues`.
+- `Version20260618140000`: creates `pnl_dirty_periods`, adds nullable `rebuilt_at` to `pl_daily_totals` and `pl_monthly_snapshots`.
+
+`up()` migrations are additive. No existing table or column is dropped or renamed in `up()`.
+
+`down()` migrations are destructive by nature: they drop the new Ingestion/P&L tables and remove the new `rebuilt_at` columns.
+
+## Public Contracts
+
+- New internal facades: `SyncFacade`, `IngestionFacade`, `PnlFacade`.
+- New connector contracts: `SourceConnectorInterface`, `SourceMapperInterface`, `RawRecordAwareControlSumMapperInterface`.
+- New Messenger messages: `RunSyncChunkMessage`, `NormalizeRawRecordMessage`, `MarkPnlPeriodDirtyMessage`, `RebuildPnlPeriodMessage`.
+- New Messenger transports/routes: `ingest_fetch`, `ingest_normalize`, `pnl_rebuild`.
+- New CLI command: `finance:pnl:rebuild-dirty`.
+- No HTTP API endpoint was added or changed.
+- No production cron/worker entry was enabled.
+- No live external Ozon API call was made during implementation or verification.
+
+## Checks
+
+- `make site-test-unit` - OK, 1070 tests / 6438 assertions; existing 1 warning and 1 deprecation remain in the project unit suite.
+- `docker compose run --rm -e COMPOSER_PROCESS_TIMEOUT=0 site-php-cli php bin/phpunit --testsuite integration --filter 'Ingestion|PLDirtyPeriod|MarkPnlPeriodDirtyAction|NormalizationCompletedSubscriber|RebuildPnlPeriodAction|RebuildDirtyPnlPeriodsCommand|PLRebuildAuditRepository' --display-phpunit-deprecations` - OK, 47 tests / 206 assertions; existing 2 PHPUnit runner deprecations remain in Marketplace/MarketplaceAds tests.
+- `docker compose run --rm site-php-cli php bin/console lint:container --env=test` - OK.
+- `docker compose run --rm site-php-cli php bin/console doctrine:schema:validate --skip-sync --env=test` - OK for mapping; DB sync check intentionally skipped.
+- Scoped `php-cs-fixer` for changed Ingestion/Finance files - OK, 0 fixable files after local review fix.
+- `git diff --check` - OK.
+- `rg -n "PnlDirtyPeriod" site/src site/tests ARCHITECTURE.md docs/tasks/ingestion/INDEX.md docs/tasks/ingestion/TASK-*.md docs/tasks/ingestion/plan.md` - OK, no active code/task references.
+
+`make site-cs-check` was also run and failed on existing project-wide style drift: 659 of 1728 files are fixable, mostly outside this task scope. This dry-run did not modify files.
+
+No Makefile PHPStan target exists (`make site-phpstan` is unavailable).
+
+## Risks / Reviewer Focus
+
+- Stage 7 and Stage 8 are financial/P&L changes and should be reviewed carefully before deploy.
+- `PLDirtyPeriod` is owned by Ingestion and implements `TenantOwnedInterface`; Finance consumes it only for P&L rebuild orchestration.
+- `RebuildPnlPeriodAction` deletes and rebuilds all-source P&L aggregate rows for a company/month. Source-scoped rebuilds are intentionally blocked until Finance source-linking is decided.
+- `shop_ref` was not added to `pl_daily_totals` or `pl_monthly_snapshots`.
+- `PLDirtyPeriod.shopRef` remains a dirty marker dimension only; the post-deploy decision task asks where source/origin links should live in Finance.
+- `PnlCategoryResolver` creates fallback categories (`INGESTION_OTHER_INCOME`, `INGESTION_OTHER_EXPENSE`) when mapped Finance categories do not exist.
+- Rebuild requires an existing default or first `ProjectDirection`; it does not create one silently.
+- Existing legacy Ozon and P&L flows remain active. This implementation adds the Ingestion path but does not switch production traffic.
+
+## Known Limitations
+
+- Blocks 8 and 9 are not implemented because task specs are absent.
+- No UI verification page, shadow comparison dashboard, admin workflow, or support runbook was added.
+- No real encrypted credential codec was introduced; existing plaintext credential behavior from earlier blocks remains.
+- Full Doctrine DB sync validation was not used for final acceptance because the project has broader schema drift; mapping validation passes.
+- Project-wide CS check is red because of pre-existing style drift outside this change set.
+
+## Follow-Up Tasks
+
+- Decide Finance source/origin linking after Ingestion acceptance/deploy: see `docs/tasks/ingestion/FOLLOWUP-finance-source-linking.md`.
+- Add and execute `TASK-08` UI pilot/verification when its task file is available.
+- Add and execute `TASK-09` shadow/admin when its task file is available.
+- Decide whether `RebuildPnlPeriodAction` should be feature-flagged before real production use.
+- Decide final fallback P&L category names/codes before enabling live rebuilds.
+- Plan legacy Ozon/P&L switch-off only after shadow comparison succeeds.
+
+## Owner Review Checklist
+
+- Review migrations before running them in any shared environment.
+- Review Messenger transport/routing changes and worker deployment expectations.
+- Review P&L rebuild semantics, category mapping, close-period guard, and dirty-period retry behavior.
+- Review Ozon mapper output against representative real reports before shadow mode.
+- Review the source-linking decision task before adding any Finance source reference fields.

--- a/docs/tasks/ingestion/plan.md
+++ b/docs/tasks/ingestion/plan.md
@@ -1,0 +1,44 @@
+# Ingestion Blocks 4-7 Execution Plan
+
+## Summary
+
+- Scope: execute only existing `docs/tasks/ingestion/TASK-04` through `TASK-07`; `TASK-08` and `TASK-09` are out of scope because their task files are absent.
+- Current repo state: `App\Ingestion` contains blocks 1-3 only; `messenger.yaml` has `async_sync` and `async_pipeline`, no ingestion transports yet.
+- Because blocks 4, 5, and 7 require migrations, and block 7 touches P&L semantics, execution must be staged with owner review at every HIGH-risk stage.
+
+## Implementation Stages
+
+- Stage 1 - Block 4 schema/domain: add `IngestCursor`, `SyncJob`, sync enums, transition exceptions, zero-downtime migration for `ingest_cursors` and `ingest_sync_jobs`, plus entity invariant/unit tests. Risk HIGH. STOP after stage report.
+- Stage 2 - Block 4 orchestration: add repositories, transition policy, commands/actions, `SyncFacade`, `RunSyncChunkMessage`, `IngestRateLimitGuard`, messenger transports/routing for `ingest_fetch` and `ingest_normalize`, test overrides, architecture update. Risk HIGH because Messenger config changes. STOP after stage report.
+- Stage 3 - Block 5 canon schema: add `Money`, transaction/capability enums, `FinancialTransaction`, `Counterparty`, `NormalizationIssue`, migration, repositories, tenant-leak tests. Risk HIGH. STOP after stage report.
+- Stage 4 - Block 5 normalization pipeline: add connector/mapper contracts, registries, DTOs, normalize/upsert/issue actions, `NormalizationCompletedEvent`, handlers/messages/routing, fake dev/test connector+mapper, `IngestionFacade`, and update `IngestRawRecord` with normalization state methods. Risk HIGH due Messenger routing and central pipeline. STOP after stage report.
+- Stage 5 - Block 6 reconnaissance: read legacy Ozon API/client code and produce a short report in `docs/tasks/ingestion/stages/stage-5.md`; no code changes. Risk LOW.
+- Stage 6 - Block 6 Ozon connector: add `LegacyOzonClientAdapter`, Ozon DTOs/resource constants, connector, daily/realization mappers, DI tags, anonymized fixtures, `docs/ingestion/ozon-mapping.md`, unit/contract/e2e tests using mocks. Do not modify legacy Marketplace clients or make live API calls. Risk HIGH because it crosses into legacy integration boundaries. STOP after stage report.
+- Stage 7 - Block 7 P&L dirty-period schema: add `PLDirtyPeriod`, Ingestion enums, migration for dirty periods and nullable `rebuiltAt` on P&L aggregates, repository methods and invariant tests. Risk HIGH due Finance/P&L schema. STOP after stage report.
+- Stage 8 - Block 7 rebuild infrastructure: add period resolver, category resolver, mark-dirty action/message/handler, ingestion event subscriber, close-period guard/event, rebuild action/message/handler, `PnlFacade` methods, rebuild dispatch command. Do not enable production cron automatically unless explicitly approved. Risk HIGH due financial semantics and Messenger config. STOP after stage report.
+- Stage Final - Handoff: run full relevant checks, review complete diff, write `docs/tasks/ingestion/handoff.md`, and STOP.
+
+## Public Interfaces And Contracts
+
+- New Ingestion facades/contracts: `SyncFacade`, `IngestionFacade`, `SourceConnectorInterface`, `SourceMapperInterface`.
+- New messages: `RunSyncChunkMessage`, `NormalizeRawRecordMessage`, `MarkPnlPeriodDirtyMessage`, `RebuildPnlPeriodMessage`; all tenant-aware messages implement `CompanyAwareMessage`.
+- New transports/routing: `ingest_fetch`, `ingest_normalize`, and later `pnl_rebuild`, mapped to existing DSNs as specified by task files.
+- No HTTP API changes in blocks 4-7.
+- No live external Ozon calls during tests or implementation verification.
+
+## Test Plan
+
+- Per stage: focused unit/integration tests for entity invariants, repositories with explicit `companyId`, state transitions, actions, handlers, and tenant-leak coverage.
+- Block 4: cursor advance, job transition matrix, split/backfill dispatch, parent finalization, rate-lock behavior.
+- Block 5: money currency guard, canonical upsert idempotency/staleness, mapper failure, sum mismatch issue, event dispatch, fake full pipeline.
+- Block 6: Ozon mapper fixture contracts, error classification, registry tags, mock-adapter end-to-end flow, no response-body logging.
+- Block 7: dirty-period idempotency, Moscow timezone period resolution, old/new period marking, closed-period blocking, rebuild idempotency/lock behavior.
+- Checks before final handoff: `make site-cs-check`, PHPStan command if available, `make site-test-unit`, integration tests if available, `git status --short`, `git diff --stat`.
+
+## Assumptions And Guardrails
+
+- `TASK-08` and `TASK-09` are intentionally excluded until task files are added.
+- Existing uncommitted `docs/tasks/ingestion/*` and `.mimocode/` are treated as user changes and not overwritten.
+- Migrations are create/additive only unless a later approved task explicitly allows destructive changes.
+- Legacy Marketplace/Ozon code remains unmodified; Block 6 adds only a new adapter in Ingestion.
+- Existing legacy P&L and Ozon pipelines remain active; Block 7 infrastructure must not switch production data flow or enable cron without explicit owner approval.

--- a/docs/tasks/ingestion/stages/stage-1.md
+++ b/docs/tasks/ingestion/stages/stage-1.md
@@ -1,0 +1,48 @@
+### Stage 1: Block 4 schema/domain — DONE
+
+**Risk:** HIGH
+**Next action:** STOP, owner review required
+
+#### What was done
+- Added `IngestCursor` and `SyncJob` tenant-owned entities for cursor and sync job state.
+- Added sync job kind/status enums, state-transition guard behavior, and block 4 exception classes.
+- Added additive PostgreSQL migration for `ingest_cursors` and `ingest_sync_jobs`.
+- Added unit tests for cursor behavior, sync job invariants/transitions, and the full status transition matrix.
+- Saved the approved package plan to `docs/tasks/ingestion/plan.md`.
+
+#### Files changed
+- `docs/tasks/ingestion/plan.md` — new Phase 0 plan
+- `site/src/Ingestion/Entity/IngestCursor.php` — new entity
+- `site/src/Ingestion/Entity/SyncJob.php` — new entity
+- `site/src/Ingestion/Enum/SyncJobKind.php` — new enum
+- `site/src/Ingestion/Enum/SyncJobStatus.php` — new enum
+- `site/src/Ingestion/Exception/*.php` — new block 4 exceptions
+- `site/migrations/Version20260618120000.php` — new additive migration
+- `site/tests/Unit/Ingestion/Entity/*` — new entity unit tests
+- `site/tests/Unit/Ingestion/Enum/SyncJobStatusTest.php` — new transition matrix test
+- `docs/tasks/ingestion/stages/stage-1.md` — new stage report
+
+#### Self-review
+- [x] Scope compliance
+- [x] Project patterns followed
+- [x] No forbidden actions
+- [x] Security/company access checked
+- [x] Tests/checks run
+- [x] Documentation updated or N/A
+
+#### Checks
+- `make codex-test-unit-filter FILTER='IngestCursorTest|SyncJobTest|SyncJobStatusTest'` — failed before PHPUnit because host `php` is unavailable in PATH
+- `docker compose run --rm site-php-cli php bin/phpunit --testsuite unit --filter 'IngestCursorTest|SyncJobTest|SyncJobStatusTest'` — OK, 41 tests / 67 assertions
+- `make site-cs-check` — failed on pre-existing style drift across 660 unrelated files
+- scoped `php-cs-fixer --dry-run` on Stage 1 files — OK after one local formatting fix
+- `doctrine:migrations:execute DoctrineMigrations\Version20260618120000 --up --dry-run --env=test` — OK, dry-run only
+- `doctrine:migrations:execute DoctrineMigrations\Version20260618120000 --down --dry-run --env=test` — OK, dry-run only
+- `doctrine:schema:validate --skip-sync --env=test` — OK, mapping valid
+
+#### Risks / reviewer focus
+- Migration creates two new tables and indexes; it was not applied to any database in this stage, only dry-run checked.
+- `SyncJobTransitionPolicy` is not introduced yet; Stage 1 keeps transition rules in `SyncJobStatus::canTransitionTo()` and entity guard methods. Stage 2 may extract the policy if still desired.
+- No repositories, actions, facade, rate-limit guard, or Messenger routing were added in this stage.
+
+#### Open questions
+- none

--- a/docs/tasks/ingestion/stages/stage-10-correction-money-signed.md
+++ b/docs/tasks/ingestion/stages/stage-10-correction-money-signed.md
@@ -1,0 +1,46 @@
+### Stage 10: Signed Money value object correction — DONE
+
+**Risk:** MEDIUM
+**Next action:** STOP, owner review required
+
+#### What was done
+- Updated shared `Money` to represent signed minor-unit values: positive, negative, or zero.
+- Removed the universal `amountMinor >= 0` invariant from `Money`.
+- Allowed `subtract()` to return a negative result.
+- Fixed `negate()` so it returns the opposite sign.
+- Added `compareTo()` and kept same-currency guards for arithmetic/comparison operations through `MoneyMismatchException`.
+- Kept currency validation as uppercase ISO-like 3-letter code.
+- Documented that nonnegative-only money rules must live in concrete business scenarios, not in the base `Money` value object.
+
+#### Files changed
+- `site/src/Shared/Domain/ValueObject/Money.php` — modified
+- `site/tests/Unit/Shared/Domain/ValueObject/MoneyTest.php` — modified
+- `docs/tasks/ingestion/TASK-05-connector-canon.md` — modified
+- `ARCHITECTURE.md` — modified
+- `docs/tasks/ingestion/stages/stage-3.md` — modified
+- `docs/tasks/ingestion/SUMMARY-blocks-4-7.md` — modified
+- `docs/tasks/ingestion/handoff.md` — modified
+
+#### Self-review
+- [x] Scope compliance
+- [x] Project patterns followed
+- [x] No forbidden actions
+- [x] Security/company access checked
+- [x] Tests/checks run
+- [x] Documentation updated
+
+#### Checks
+- `docker compose run --rm site-php-cli php bin/phpunit --testsuite unit --filter 'MoneyTest|FinancialTransactionTest|Ozon|Ingestion'` — OK, 389 tests / 3784 assertions
+- `make site-test-unit` — OK, 1070 tests / 6438 assertions, existing 1 warning and 1 deprecation remain
+- `docker compose run --rm -e COMPOSER_PROCESS_TIMEOUT=0 site-php-cli php bin/phpunit --testsuite integration --filter 'Ingestion|MarkPnlPeriodDirtyAction|RebuildPnlPeriodAction|RebuildDirtyPnlPeriodsCommand' --display-phpunit-deprecations` — OK, 42 tests / 192 assertions, existing 2 PHPUnit runner deprecations remain
+- `docker compose run --rm site-php-cli php bin/console lint:container --env=test` — OK
+- `docker compose run --rm site-php-cli php bin/console doctrine:schema:validate --skip-sync --env=test` — OK, mapping valid; DB sync intentionally skipped
+- `docker compose run --rm site-php-cli vendor/bin/php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.php --cache-file=var/cache/.php-cs-fixer.money-signed.cache --path-mode=intersection ...` — OK
+- `git diff --check` — OK
+
+#### Risks / reviewer focus
+- Existing Ozon mappers still normalize Ozon transaction components with absolute minor amounts and explicit `TransactionDirection`; this correction only makes the base value object capable of signed money.
+- If a specific domain scenario requires nonnegative money, it should add a scenario-level assertion or a dedicated type such as `PositiveMoney` / `NonNegativeMoney`.
+
+#### Open questions
+- none

--- a/docs/tasks/ingestion/stages/stage-2.md
+++ b/docs/tasks/ingestion/stages/stage-2.md
@@ -1,0 +1,53 @@
+### Stage 2: Block 4 orchestration — DONE
+
+**Risk:** HIGH
+**Next action:** STOP, owner review required
+
+#### What was done
+- Added cursor and sync job repositories with explicit `companyId` read methods.
+- Added sync job transition policy, command DTOs, orchestration actions, `SyncFacade`, progress view, and rate-limit guard.
+- Added tenant-aware `RunSyncChunkMessage`.
+- Added `ingest_fetch` and `ingest_normalize` Messenger transports plus test in-memory overrides.
+- Updated architecture notes for cursor/sync jobs and updated `AGENTS.md` with owner stop-notification guidance.
+- Added repository, facade, and message tests for Block 4 orchestration.
+
+#### Files changed
+- `AGENTS.md` — updated autonomous stop/options guidance
+- `ARCHITECTURE.md` — documented Ingestion cursor/sync jobs
+- `site/config/packages/messenger.yaml` — added ingestion transports and `RunSyncChunkMessage` routing
+- `site/config/packages/test/messenger.yaml` — added in-memory ingestion transports
+- `site/config/services.yaml` — made `SyncFacade` public for current/future integration use
+- `site/src/Ingestion/Application/*` — new commands, actions, DTO, rate-limit service
+- `site/src/Ingestion/Domain/Service/SyncJobTransitionPolicy.php` — new transition policy
+- `site/src/Ingestion/Facade/SyncFacade.php` — new facade
+- `site/src/Ingestion/Message/RunSyncChunkMessage.php` — new tenant-aware message
+- `site/src/Ingestion/Repository/*` — new cursor/job repositories
+- `site/tests/Unit/Ingestion/Message/RunSyncChunkMessageTest.php` — new unit test
+- `site/tests/Integration/Ingestion/*` — new repository/facade integration tests
+- `docs/tasks/ingestion/stages/stage-2.md` — new stage report
+
+#### Self-review
+- [x] Scope compliance
+- [x] Project patterns followed
+- [x] No forbidden actions
+- [x] Security/company access checked
+- [x] Tests/checks run
+- [x] Documentation updated or N/A
+
+#### Checks
+- `docker compose run --rm site-php-cli php bin/console doctrine:migrations:migrate --no-interaction --env=test` — OK, test DB migrated to `Version20260618120000`
+- `docker compose run --rm site-php-cli php bin/phpunit --testsuite unit --filter 'RunSyncChunkMessageTest|IngestCursorTest|SyncJobTest|SyncJobStatusTest'` — OK, 42 tests / 71 assertions
+- `docker compose run --rm site-php-cli php bin/phpunit --testsuite integration --filter 'IngestCursorRepositoryTest|SyncJobRepositoryTest|SyncFacadeTest'` — OK, 7 tests / 30 assertions, PHPUnit deprecation notices present
+- scoped `php-cs-fixer --dry-run` on Stage 2 files — OK
+- `docker compose run --rm site-php-cli php bin/console lint:yaml --parse-tags config/packages/messenger.yaml config/packages/test/messenger.yaml config/services.yaml --env=test` — OK
+- `docker compose run --rm site-php-cli php bin/console lint:container --env=test` — OK
+- `docker compose run --rm site-php-cli php bin/console doctrine:schema:validate --skip-sync --env=test` — OK, mapping valid
+
+#### Risks / reviewer focus
+- `messenger.yaml` now defines two new transports and routes `RunSyncChunkMessage` to `ingest_fetch`; this is a mandatory review point.
+- Parent backfill job is marked `RUNNING` immediately after split so child completion can legally finalize the parent under the state machine.
+- `MarkJobCompletedAction` and `MarkJobFailedAction` flush child state before parent aggregate counting; this avoids stale DB counts during parent finalization.
+- `IngestRateLimitGuard` returns an acquired lock and throws when the same key is already locked.
+
+#### Open questions
+- none

--- a/docs/tasks/ingestion/stages/stage-3.md
+++ b/docs/tasks/ingestion/stages/stage-3.md
@@ -1,0 +1,53 @@
+### Stage 3: Block 5 canon schema — DONE
+
+**Risk:** HIGH
+**Next action:** STOP, owner review required
+
+#### What was done
+- Added canonical Ingestion enums: transaction type, direction, normalization issue kind, and connector capability.
+- Added `Money` value object with same-currency guards. After Stage 6 review it was moved from Ingestion to `App\Shared\Domain\ValueObject`; after the signed-money correction it supports positive, negative, and zero minor units.
+- Added tenant-owned canon entities: `FinancialTransaction`, `Counterparty`, and `NormalizationIssue`.
+- Added repositories with explicit `companyId` read methods and iterable period reads for future P&L rebuilds.
+- Added additive PostgreSQL migration for the three canon tables and indexes.
+- Added unit and integration tests for invariants, stale-version protection, repository tenant boundaries, and issue resolution.
+- Updated `ARCHITECTURE.md` with the canonical finance layer.
+
+#### Files changed
+- `ARCHITECTURE.md` — documented canonical Ingestion finance layer
+- `site/src/Shared/Domain/ValueObject/Money.php` — shared value object
+- `site/src/Ingestion/Entity/{FinancialTransaction,Counterparty,NormalizationIssue}.php` — new entities
+- `site/src/Ingestion/Enum/{TransactionType,TransactionDirection,NormalizationIssueKind,Capability}.php` — new enums
+- `site/src/Shared/Domain/Exception/MoneyMismatchException.php` and `site/src/Ingestion/Exception/StaleTransactionUpdateException.php` — new exceptions
+- `site/src/Ingestion/Repository/{FinancialTransactionRepository,CounterpartyRepository,NormalizationIssueRepository}.php` — new repositories
+- `site/migrations/Version20260618130000.php` — new additive migration
+- `site/tests/Unit/Ingestion/*` — new value object/entity tests
+- `site/tests/Integration/Ingestion/Repository/*` — new repository tests
+- `docs/tasks/ingestion/stages/stage-3.md` — new stage report
+
+#### Self-review
+- [x] Scope compliance
+- [x] Project patterns followed
+- [x] No forbidden actions
+- [x] Security/company access checked
+- [x] Tests/checks run
+- [x] Documentation updated or N/A
+
+#### Checks
+- `docker compose run --rm site-php-cli php bin/console doctrine:migrations:migrate --no-interaction --env=test` — OK, test DB migrated to `Version20260618130000`
+- `docker compose run --rm site-php-cli php bin/phpunit --testsuite unit --filter 'MoneyTest|FinancialTransactionTest|NormalizationIssueTest|RunSyncChunkMessageTest|IngestCursorTest|SyncJobTest|SyncJobStatusTest'` — OK, 51 tests / 94 assertions
+- `docker compose run --rm site-php-cli php bin/phpunit --testsuite integration --filter 'FinancialTransactionRepositoryTest|CounterpartyRepositoryTest|NormalizationIssueRepositoryTest|IngestCursorRepositoryTest|SyncJobRepositoryTest|SyncFacadeTest'` — OK, 11 tests / 41 assertions, PHPUnit deprecation notices present
+- scoped `php-cs-fixer --dry-run` on Stage 3 files — OK
+- `doctrine:migrations:execute DoctrineMigrations\Version20260618130000 --down --dry-run --env=test` — OK
+- `doctrine:migrations:execute DoctrineMigrations\Version20260618130000 --up --dry-run --env=test` — OK
+- `doctrine:schema:validate --skip-sync --env=test` — OK, mapping valid
+- `lint:container --env=test` — OK
+- Full `doctrine:schema:validate --env=test` — failed due broader project schema drift; dumped SQL shows many pre-existing diffs plus timestamp precision diffs across existing Ingestion tables
+
+#### Risks / reviewer focus
+- Migration creates three new tables only; no existing tables are altered or dropped.
+- `FinancialTransaction.amountMinor` is stored as string internally because Doctrine hydrates `BIGINT` as string; the public getter remains `int`.
+- `Money` is a signed base value object; any nonnegative-only rule must live in a concrete business scenario. `TransactionDirection` remains the normalized flow classification.
+- Normalization pipeline/actions/handlers are not implemented in this stage.
+
+#### Open questions
+- none

--- a/docs/tasks/ingestion/stages/stage-4.md
+++ b/docs/tasks/ingestion/stages/stage-4.md
@@ -1,0 +1,78 @@
+### Stage 4: Block 5 normalization pipeline — DONE
+
+**Risk:** HIGH
+**Next action:** STOP, owner review required
+
+#### What was done
+- Added `SourceConnectorInterface` / `SourceMapperInterface`, connector and mapper registries, pull/push/shop/mapped DTOs.
+- Added normalization commands/actions for raw normalization, canonical `FinancialTransaction` upsert, and `NormalizationIssue` recording.
+- Added `NormalizeRawRecordMessage`, `RunSyncChunkHandler`, `NormalizeRawRecordHandler`, and routing to `ingest_normalize`.
+- Added `NormalizationCompletedEvent` / `AffectedPeriod` and dispatch after successful raw normalization flush.
+- Added `IngestionFacade::getTransactions()` and `countOpenIssues()` for the next P&L stage.
+- Extended `IngestRawRecord` with `markNormalizationDone()` / `markNormalizationFailed()` and added a task-scope repository lookup.
+- Added test-only `FakeConnector` / `FakeMapper` fixtures tagged only in `services_test.yaml`; prod container does not include them.
+- Updated `ARCHITECTURE.md` with the connector/normalization pipeline and facade contract.
+
+#### Files changed
+- `site/src/Ingestion/Domain/Contract/SourceConnectorInterface.php` — new
+- `site/src/Ingestion/Domain/Contract/SourceMapperInterface.php` — new
+- `site/src/Ingestion/Domain/Service/ConnectorRegistry.php` — new
+- `site/src/Ingestion/Domain/Service/MapperRegistry.php` — new
+- `site/src/Ingestion/Domain/Event/AffectedPeriod.php` — new
+- `site/src/Ingestion/Domain/Event/NormalizationCompletedEvent.php` — new
+- `site/src/Ingestion/Application/DTO/*` — new connector/mapper/upsert DTOs
+- `site/src/Ingestion/Application/Command/NormalizeRawRecordCommand.php` — new
+- `site/src/Ingestion/Application/Command/UpsertFinancialTransactionCommand.php` — new
+- `site/src/Ingestion/Application/Command/RecordNormalizationIssueCommand.php` — new
+- `site/src/Ingestion/Application/Action/NormalizeRawRecordAction.php` — new
+- `site/src/Ingestion/Application/Action/UpsertFinancialTransactionAction.php` — new
+- `site/src/Ingestion/Application/Action/RecordNormalizationIssueAction.php` — new
+- `site/src/Ingestion/Exception/ConnectorAuthException.php` — new
+- `site/src/Ingestion/Exception/ConnectorNotFoundException.php` — new
+- `site/src/Ingestion/Exception/ConnectorTransientException.php` — new
+- `site/src/Ingestion/Exception/MapperNotFoundException.php` — new
+- `site/src/Ingestion/Exception/UnsupportedCapabilityException.php` — new
+- `site/src/Ingestion/Message/NormalizeRawRecordMessage.php` — new
+- `site/src/Ingestion/MessageHandler/RunSyncChunkHandler.php` — new
+- `site/src/Ingestion/MessageHandler/NormalizeRawRecordHandler.php` — new
+- `site/src/Ingestion/Facade/IngestionFacade.php` — new
+- `site/src/Ingestion/Entity/IngestRawRecord.php` — modified
+- `site/src/Ingestion/Repository/IngestRawRecordRepository.php` — modified
+- `site/config/packages/messenger.yaml` — modified
+- `site/config/packages/test/messenger.yaml` — modified
+- `site/config/services.yaml` — modified
+- `site/config/services_test.yaml` — modified
+- `site/tests/Integration/Ingestion/Fixtures/*` — new fake connector/mapper and event recorder
+- `site/tests/Integration/Ingestion/Application/*` — new normalization/upsert tests
+- `site/tests/Integration/Ingestion/MessageHandler/RunSyncChunkHandlerTest.php` — new
+- `site/tests/Unit/Ingestion/Domain/Service/*` — new registry tests
+- `ARCHITECTURE.md` — modified
+
+#### Self-review
+- [x] Scope compliance
+- [x] Project patterns followed
+- [x] No forbidden actions
+- [x] Security/company access checked
+- [x] Tests/checks run
+- [x] Documentation updated or N/A
+
+#### Checks
+- `make codex-test-unit-filter FILTER='Ingestion'` — failed at `codex-prepare`: host `php` not found in Codex PATH; switched to Docker project commands.
+- `docker compose run --rm site-php-cli php bin/phpunit --testsuite unit --filter Ingestion` — OK, 65 tests / 143 assertions.
+- `docker compose run --rm -e COMPOSER_PROCESS_TIMEOUT=0 site-php-cli php bin/phpunit --testsuite integration --filter Ingestion --display-deprecations --display-phpunit-deprecations` — OK, 33 tests / 150 assertions; 2 PHPUnit runner deprecations from existing non-Ingestion doc-comment metadata tests.
+- `make site-test-unit` — OK, 1014 tests / 6289 assertions; 1 existing warning in `StorageServiceTest`, 1 existing deprecation in `XlsxReaderServiceTest`.
+- `make site-cs-check` — failed on 660 pre-existing project-wide style diffs outside this stage.
+- `docker compose run --rm site-php-cli php vendor/bin/php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.php --cache-file=var/cache/.php-cs-fixer.stage4.cache <stage-4-files>` — OK.
+- `docker compose run --rm site-php-cli php bin/console lint:container --env=test` — OK.
+- `docker compose run --rm site-php-cli php bin/console lint:container --env=prod` — OK; existing Symfony/Doctrine deprecation logs printed.
+- `docker compose run --rm site-php-cli php bin/console doctrine:schema:validate --skip-sync --env=test` — OK.
+- `docker compose run --rm site-php-cli sh -lc 'php bin/console debug:container --env=prod --format=json 2>/dev/null | grep -F FakeConnector >/dev/null && exit 1 || exit 0'` — OK, fake connector absent from prod container.
+
+#### Risks / reviewer focus
+- `RunSyncChunkHandler` introduces the central fetch-to-normalize pipeline and new `NormalizeRawRecordMessage` routing; review retry/failure semantics carefully.
+- No new idempotency table was added because the project only documents `IdempotentHandlerTrait` as a pattern and has no implementation. Idempotency relies on sync/raw statuses and canonical natural-key upsert.
+- `FakeConnector` / `FakeMapper` are implemented as test fixtures instead of production `src` classes to keep prod container clean.
+- Stage 4 has no database migration.
+
+#### Open questions
+- none

--- a/docs/tasks/ingestion/stages/stage-5.md
+++ b/docs/tasks/ingestion/stages/stage-5.md
@@ -1,0 +1,55 @@
+### Stage 5: Block 6 legacy Ozon reconnaissance — DONE
+
+**Risk:** LOW
+**Next action:** continue autonomously
+
+#### What was done
+- Read `docs/tasks/ingestion/TASK-06-ozon-connector.md`.
+- Inspected legacy Ozon Seller API clients, handlers, credential readers, and raw processors.
+- Identified which code paths should be wrapped by the new Ingestion adapter and which legacy code must remain untouched.
+
+#### Files changed
+- `docs/tasks/ingestion/stages/stage-5.md` — new reconnaissance report
+
+#### Findings
+- Daily seller report has two legacy entry points:
+  - `App\Marketplace\Infrastructure\Api\Ozon\OzonFetcher::fetch(string $companyId, DateTimeImmutable $dateFrom): Generator` calls `POST /v2/finance/transaction/list`, reads credentials through `MarketplaceCredentialsQuery`, yields decoded pages.
+  - `App\Marketplace\Service\Integration\OzonAdapter::fetchRawReport(Company $company, DateTimeInterface $fromDate, DateTimeInterface $toDate): array` calls `POST /v3/finance/transaction/list`, reads `MarketplaceConnection` through `MarketplaceConnectionRepository`, paginates up to `MAX_PAGES`, returns flattened operations.
+- Monthly realization entry point:
+  - `App\Marketplace\Service\Integration\OzonRealizationFetcher::fetch(MarketplaceConnection $connection, int $year, int $month): array` calls `POST /v2/finance/realization`, validates month is not current/future, returns full Ozon payload.
+- Totals support:
+  - `App\Marketplace\Infrastructure\Api\Ozon\OzonTransactionTotalsClient::fetchTotals(string $companyId, DateTimeImmutable $from, DateTimeImmutable $to): array` calls `POST /v3/finance/transaction/totals`; useful as reference for credential/error behavior, not required for Stage 6 connector pull.
+- Credentials:
+  - Legacy daily flows read from `marketplace_connections` by `(companyId, marketplace=ozon, connectionType=seller)`.
+  - Ingestion already has `App\Ingestion\Infrastructure\Credential\LegacyMarketplaceCredentialReader`, used through `CredentialFacade`, supporting both connection UUID and refs like `marketplace:ozon:seller`.
+- Existing raw processing logic to reuse as mapping reference:
+  - `OzonReportRowClassifier` classifies `orders` as SALE, `ClientReturnAgentOperation` as RETURN, `OperationAgentStornoDeliveredToCustomer` as SALE, other `returns` as COST, and `services/other/compensation` as COST.
+  - `OzonSalesRawProcessor` handles positive sales and storno sales.
+  - `OzonReturnsRawProcessor` handles buyer returns and uses `posting_number` fallback external ids.
+  - `OzonCostsRawProcessor` decomposes `sale_commission`, `delivery_charge`, `return_delivery_charge`, `services[]`, compensation and operation-level amounts; it uses `OzonServiceCategoryMap` / `OzonCostCategory` as the service-name source of truth.
+
+#### Stage 6 implications
+- Prefer a new `LegacyOzonClientAdapter` inside `App\Ingestion` that uses `CredentialFacade` plus `HttpClientInterface` directly. This keeps the adapter independent of legacy `Company` / `MarketplaceConnection` entity loading and preserves the task rule: no legacy client modifications.
+- Use `/v3/finance/transaction/list` for daily reports, because current `OzonAdapter` already uses v3 and returns flattened operations.
+- Use `/v2/finance/realization` for realization, matching the current legacy fetcher.
+- Error classification should be implemented in the Ingestion adapter rather than inherited from legacy clients, because current legacy classes mostly throw generic `RuntimeException`.
+- Tests must mock HTTP/adapter behavior; no live Ozon calls.
+
+#### Self-review
+- [x] Scope compliance
+- [x] Project patterns followed
+- [x] No forbidden actions
+- [x] Security/company access checked
+- [x] Tests/checks run
+- [x] Documentation updated or N/A
+
+#### Checks
+- Read-only reconnaissance plus report creation; no executable code was changed.
+- `git diff --check` will be run with Stage 6 verification.
+
+#### Risks / reviewer focus
+- Legacy has both v2 and v3 transaction-list usage; Stage 6 should standardize the new connector on v3 without changing legacy behavior.
+- Realization payload does not obviously expose the same stable `operation_id` as daily report in all rows; mapper needs a documented fallback natural key.
+
+#### Open questions
+- none

--- a/docs/tasks/ingestion/stages/stage-6.md
+++ b/docs/tasks/ingestion/stages/stage-6.md
@@ -1,0 +1,176 @@
+### Stage 6: Block 6 Ozon connector — DONE
+
+**Risk:** HIGH
+**Next action:** STOP, owner review required
+
+#### What was done
+- Added the Ozon Seller source adapter boundary for Ingestion:
+  - `LegacyOzonClientAdapter`
+  - Ozon credential provider interface/implementation
+  - Ozon raw page and shop descriptor DTOs
+- Added `OzonSellerReportConnector` for:
+  - `ozon_seller_daily_report`
+  - `ozon_seller_realization`
+  - `CAN_DISCOVER_SHOPS`
+  - `CAN_PULL`
+  - no push support
+- Added Ozon mappers:
+  - `OzonSellerReportMapper`
+  - `OzonRealizationMapper`
+  - shared component mapper for sale, refund, commission, logistics, last mile, fee, acquiring, and other fallback rows
+- Added tenant-aware Ozon control sums through `RawRecordAwareControlSumMapperInterface`, because Ozon `operationGroupId` depends on `companyId`.
+- Registered production Ozon connector/mapper services and test-only fake Ozon adapter.
+- Moved the generic Stage 4 fake connector/mapper from `OZON` to `WILDBERRIES` in test scope to avoid duplicate Ozon connector registration.
+- Added anonymized Ozon fixtures and tests for:
+  - adapter error classification
+  - connector pull/discover/push contract
+  - daily report mapping
+  - realization mapping
+  - DI registry tags
+  - local end-to-end sync chunk → raw storage → normalization → canonical transactions
+  - realization overwriting daily preliminary values through matching natural keys
+- Added `docs/ingestion/ozon-mapping.md` and updated `ARCHITECTURE.md`.
+
+#### Files changed
+- `ARCHITECTURE.md` — modified
+- `docs/ingestion/ozon-mapping.md` — new
+- `site/config/services.yaml` — modified
+- `site/config/services_test.yaml` — modified
+- `site/src/Ingestion/Application/Action/NormalizeRawRecordAction.php` — modified
+- `site/src/Ingestion/Domain/Contract/RawRecordAwareControlSumMapperInterface.php` — new
+- `site/src/Ingestion/Application/Source/Ozon/OzonMoneyParser.php` — new
+- `site/src/Ingestion/Application/Source/Ozon/OzonOperationKey.php` — new
+- `site/src/Ingestion/Application/Source/Ozon/OzonRealizationMapper.php` — new
+- `site/src/Ingestion/Application/Source/Ozon/OzonResourceType.php` — new
+- `site/src/Ingestion/Application/Source/Ozon/OzonSellerReportConnector.php` — new
+- `site/src/Ingestion/Application/Source/Ozon/OzonSellerReportMapper.php` — new
+- `site/src/Ingestion/Application/Source/Ozon/OzonTransactionComponentMapper.php` — new
+- `site/src/Ingestion/Infrastructure/Api/Ozon/CredentialFacadeOzonCredentialProvider.php` — new
+- `site/src/Ingestion/Infrastructure/Api/Ozon/LegacyOzonClientAdapter.php` — new
+- `site/src/Ingestion/Infrastructure/Api/Ozon/OzonClientAdapterInterface.php` — new
+- `site/src/Ingestion/Infrastructure/Api/Ozon/OzonCredentialProviderInterface.php` — new
+- `site/src/Ingestion/Infrastructure/Api/Ozon/OzonRawPage.php` — new
+- `site/src/Ingestion/Infrastructure/Api/Ozon/OzonShopDescriptor.php` — new
+- `site/tests/Fixtures/Ingestion/Ozon/transaction_list_with_sale_and_commission.json` — new
+- `site/tests/Fixtures/Ingestion/Ozon/realization_february_2026.json` — new
+- `site/tests/Integration/Ingestion/Application/NormalizeRawRecordActionTest.php` — modified
+- `site/tests/Integration/Ingestion/Application/Source/Ozon/OzonIngestionFlowTest.php` — new
+- `site/tests/Integration/Ingestion/Application/Source/Ozon/OzonIngestionRegistryTest.php` — new
+- `site/tests/Integration/Ingestion/Fixtures/FakeConnector.php` — modified
+- `site/tests/Integration/Ingestion/Fixtures/FakeMapper.php` — modified
+- `site/tests/Integration/Ingestion/Fixtures/FakeOzonClientAdapter.php` — new
+- `site/tests/Integration/Ingestion/MessageHandler/RunSyncChunkHandlerTest.php` — modified
+- `site/tests/Unit/Ingestion/Application/Source/Ozon/OzonSellerReportConnectorTest.php` — new
+- `site/tests/Unit/Ingestion/Application/Source/Ozon/OzonSellerReportMapperTest.php` — new
+- `site/tests/Unit/Ingestion/Infrastructure/Api/Ozon/LegacyOzonClientAdapterTest.php` — new
+
+#### Self-review
+- [x] Scope compliance
+- [x] Project patterns followed
+- [x] No forbidden actions
+- [x] Security/company access checked
+- [x] Tests/checks run
+- [x] Documentation updated or N/A
+
+#### Checks
+- `docker compose run --rm site-php-cli php bin/phpunit --testsuite unit --filter 'Ozon|Ingestion'` — OK, 347 tests / 3688 assertions
+- `docker compose run --rm -e COMPOSER_PROCESS_TIMEOUT=0 site-php-cli php bin/phpunit --testsuite integration --filter 'Ingestion'` — OK, 36 tests / 169 assertions, 2 PHPUnit runner deprecations from existing non-Ingestion-selected test metadata:
+  - `App\Tests\Integration\Marketplace\CloseMonthStageActionPreliminaryTest::testCloseCostsThrowsWhenEntriesAreEmptyEvenIfPreflightAllowsClose`
+  - `App\Tests\Integration\MarketplaceAds\AdLoadJobRepositoryTest::testIncrementRejectsNonPositiveDelta`
+- `make site-test-unit` — OK, 1024 tests / 6336 assertions, existing 1 warning and 1 deprecation remain in the project unit suite
+- `docker compose run --rm site-php-cli vendor/bin/php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.php --cache-file=var/cache/.php-cs-fixer.stage6.cache --path-mode=intersection ...` — OK, 0 fixable Stage 6 files
+- `docker compose run --rm site-php-cli php bin/console lint:container --env=test` — OK
+- `docker compose run --rm site-php-cli php bin/console lint:container --env=prod` — OK, with existing Symfony/Doctrine deprecation logs
+- `docker compose run --rm site-php-cli php bin/console doctrine:schema:validate --skip-sync --env=test` — OK, mapping valid; DB sync intentionally skipped
+- `git diff --check` — OK
+- `make site-cs-check` — FAILED on existing project-wide style drift: 659 of 1691 files fixable, outside Stage 6 scope
+
+#### Risks / reviewer focus
+- `LegacyOzonClientAdapter` performs live Ozon API calls only in production runtime; all tests use `MockHttpClient` or `FakeOzonClientAdapter`. No live external API call was made during this stage.
+- The task specified `externalId = ozon:operation:{operation_id}`. Stage 6 uses `ozon:operation:{operation_id}:{component}` for canonical transaction external ids because current `FinancialTransaction` uniqueness is `(companyId, source, externalId, type)`, and one Ozon operation can contain multiple components with the same `TransactionType`. Daily and realization mappers use the same component ids, so overwrite semantics are preserved.
+- Ozon realization payloads can vary by account/API version. The mapper supports the fields present in the fixture plus common legacy field aliases; reviewer should focus on expanding fixture coverage before enabling shadow production imports.
+- `RawRecordAwareControlSumMapperInterface` is a narrow extension to the mapper contract. It avoids weakening tenant-aware `operationGroupId` generation while keeping existing mappers backward-compatible.
+
+#### Open questions
+- none
+
+---
+
+### Stage 6 Review Fix: Shared Money value object — DONE
+
+**Risk:** LOW
+**Next action:** continue to Stage 7 after owner approval for migration work
+
+#### What was done
+- Moved `Money` from `App\Ingestion\Domain\ValueObject` to `App\Shared\Domain\ValueObject`.
+- Added `App\Shared\Domain\Exception\MoneyMismatchException` so the shared value object does not depend on the Ingestion module.
+- Updated Ingestion DTO/entity/mapper imports and tests to use the shared `Money`.
+- Moved `MoneyTest` to the Shared unit-test namespace.
+- Updated TASK-05 and Stage 3 documentation references.
+
+#### Files changed
+- `site/src/Shared/Domain/ValueObject/Money.php` — moved/modified
+- `site/src/Shared/Domain/Exception/MoneyMismatchException.php` — new
+- `site/src/Ingestion/Application/DTO/MappedTransaction.php` — modified
+- `site/src/Ingestion/Application/Source/Ozon/OzonTransactionComponentMapper.php` — modified
+- `site/src/Ingestion/Entity/FinancialTransaction.php` — modified
+- `site/tests/Unit/Shared/Domain/ValueObject/MoneyTest.php` — moved/modified
+- Ingestion tests using `Money` — imports updated
+- `docs/tasks/ingestion/TASK-05-connector-canon.md` — modified
+- `docs/tasks/ingestion/stages/stage-3.md` — modified
+- `docs/tasks/ingestion/stages/stage-6.md` — modified
+
+#### Checks
+- `docker compose run --rm site-php-cli php bin/phpunit --testsuite unit --filter 'MoneyTest|FinancialTransactionTest|Ozon|Ingestion'` — OK, 351 tests / 3720 assertions
+- `docker compose run --rm -e COMPOSER_PROCESS_TIMEOUT=0 site-php-cli php bin/phpunit --testsuite integration --filter 'Ingestion'` — OK, 36 tests / 169 assertions, existing 2 PHPUnit runner deprecations remain
+- `docker compose run --rm site-php-cli php bin/console lint:container --env=test` — OK
+- `docker compose run --rm site-php-cli vendor/bin/php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.php --cache-file=var/cache/.php-cs-fixer.money-shared.cache --path-mode=intersection ...` — OK, 0 fixable files
+- `git diff --check` — OK
+
+#### Risks / reviewer focus
+- The old `App\Ingestion\Exception\MoneyMismatchException` class is left untouched for now to avoid an extra deletion in this review fix; runtime code now throws the Shared exception.
+
+#### Open questions
+- none
+
+---
+
+### Stage 6 Extension: Ozon fixture coverage — DONE
+
+**Risk:** LOW
+**Next action:** continue to Stage 7 after owner approval for migration work
+
+#### What was done
+- Added anonymized daily Ozon fixture for `ClientReturnAgentOperation` with:
+  - refund amount
+  - returned commission
+  - return delivery
+  - `services[]` logistics and fee components
+- Added anonymized daily Ozon fixture without `operation_id` to lock fallback natural-key behavior.
+- Extended mapper contract tests for:
+  - refund decomposition
+  - positive returned commission direction
+  - `services[]` component ids
+  - fallback `ozon:fallback:{posting}:{sku}:{date}:{component}` external ids
+  - fallback control sum group consistency
+- Extended adapter contract tests for:
+  - realization rows/header metadata
+  - 5xx classification as `ConnectorTransientException`
+  - response body not being logged in adapter log context
+
+#### Files changed
+- `site/tests/Fixtures/Ingestion/Ozon/transaction_list_with_refund_and_services.json` — new
+- `site/tests/Fixtures/Ingestion/Ozon/transaction_list_without_operation_id.json` — new
+- `site/tests/Unit/Ingestion/Application/Source/Ozon/OzonSellerReportMapperTest.php` — modified
+- `site/tests/Unit/Ingestion/Infrastructure/Api/Ozon/LegacyOzonClientAdapterTest.php` — modified
+- `docs/tasks/ingestion/stages/stage-6.md` — modified
+
+#### Checks
+- `docker compose run --rm site-php-cli php bin/phpunit --testsuite unit --filter 'Ozon'` — OK, 286 tests / 3577 assertions
+- `docker compose run --rm site-php-cli vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --cache-file=var/cache/.php-cs-fixer.stage6-expand.cache --path-mode=intersection tests/Unit/Ingestion/Application/Source/Ozon/OzonSellerReportMapperTest.php tests/Unit/Ingestion/Infrastructure/Api/Ozon/LegacyOzonClientAdapterTest.php` — OK, 0 files changed
+
+#### Risks / reviewer focus
+- This extension changes tests/fixtures only. Production Ozon code, DI, database schema, and legacy Marketplace code were not changed.
+
+#### Open questions
+- none

--- a/docs/tasks/ingestion/stages/stage-7.md
+++ b/docs/tasks/ingestion/stages/stage-7.md
@@ -1,0 +1,64 @@
+### Stage 7: Block 7 P&L dirty-period schema — DONE
+
+**Risk:** HIGH
+**Next action:** STOP, owner review required
+
+#### What was done
+- Added Ingestion-side `PLDirtyPeriod` entity for month-level dirty markers keyed by `companyId`, `periodYear`, `periodMonth`, and `shopRef`.
+- Added `PLDirtyPeriodStatus` and `PLDirtyPeriodReason` enums with explicit transition matrix and labels.
+- Added `PLDirtyPeriodRepository` methods for tenant-scoped lookup, pending worker reads, company pending reads, and status counters.
+- Added nullable `rebuiltAt` audit fields to `PLDailyTotal` and `PLMonthlySnapshot`.
+- Added `deleteByCompanyShopAndMonth()` methods to P&L aggregate repositories.
+- Kept delete methods conservative: current P&L aggregate tables do not store `shop_ref` and should not receive it, so `shopRef = ''` deletes only the requested company/month and non-empty `shopRef` is rejected with `LogicException`.
+- Captured the post-deploy Finance source-linking decision as `docs/tasks/ingestion/FOLLOWUP-finance-source-linking.md`.
+- Added additive Doctrine migration `Version20260618140000`.
+- Added unit and integration coverage for entity invariants/transitions, repository tenant scope, pending reads, counters, and safe P&L month deletes.
+- Updated `ARCHITECTURE.md` with the new Finance dirty-period infrastructure and the current `shopRef` limitation.
+
+#### Files changed
+- `ARCHITECTURE.md` — modified
+- `site/migrations/Version20260618140000.php` — new
+- `site/src/Ingestion/Entity/PLDirtyPeriod.php` — new
+- `site/src/Finance/Entity/PLDailyTotal.php` — modified
+- `site/src/Finance/Entity/PLMonthlySnapshot.php` — modified
+- `site/src/Ingestion/Enum/PLDirtyPeriodReason.php` — new
+- `site/src/Ingestion/Enum/PLDirtyPeriodStatus.php` — new
+- `site/src/Ingestion/Repository/PLDirtyPeriodRepository.php` — new
+- `site/src/Finance/Repository/PLDailyTotalRepository.php` — modified
+- `site/src/Finance/Repository/PLMonthlySnapshotRepository.php` — modified
+- `site/tests/Unit/Ingestion/Entity/PLDirtyPeriodTest.php` — new
+- `site/tests/Unit/Ingestion/Enum/PLDirtyPeriodStatusTest.php` — new
+- `site/tests/Integration/Ingestion/Repository/PLDirtyPeriodRepositoryTest.php` — new
+- `site/tests/Integration/Finance/Repository/PLRebuildAuditRepositoryTest.php` — new
+- `docs/tasks/ingestion/FOLLOWUP-finance-source-linking.md` — new
+
+#### Self-review
+- [x] Scope compliance
+- [x] Project patterns followed
+- [x] No forbidden actions
+- [x] Security/company access checked
+- [x] Tests/checks run
+- [x] Documentation updated or N/A
+
+#### Checks
+- `docker compose run --rm site-php-cli php bin/phpunit --testsuite unit --filter 'PLDirtyPeriod'` — OK, 31 tests / 49 assertions
+- `docker compose run --rm site-php-cli php bin/console doctrine:migrations:migrate --no-interaction --env=test` — OK, migrated test DB to `DoctrineMigrations\Version20260618140000`
+- `docker compose run --rm -e COMPOSER_PROCESS_TIMEOUT=0 site-php-cli php bin/phpunit --testsuite integration --filter 'PLDirtyPeriodRepositoryTest|PLRebuildAuditRepositoryTest'` — OK, 6 tests / 17 assertions, existing 2 PHPUnit runner deprecations remain:
+  - `App\Tests\Integration\Marketplace\CloseMonthStageActionPreliminaryTest::testCloseCostsThrowsWhenEntriesAreEmptyEvenIfPreflightAllowsClose`
+  - `App\Tests\Integration\MarketplaceAds\AdLoadJobRepositoryTest::testIncrementRejectsNonPositiveDelta`
+- `docker compose run --rm site-php-cli php bin/console lint:container --env=test` — OK
+- `docker compose run --rm site-php-cli php bin/console doctrine:schema:validate --skip-sync --env=test` — OK, mapping valid; DB sync intentionally skipped
+- `docker compose run --rm site-php-cli vendor/bin/php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.php --cache-file=var/cache/.php-cs-fixer.stage7.cache --path-mode=intersection ...` — OK, 0 fixable Stage 7 files
+- `make site-test-unit` — OK, 1059 tests / 6417 assertions, existing 1 warning and 1 deprecation remain in the project unit suite
+- `docker compose run --rm site-php-cli php bin/console doctrine:schema:validate --env=test` — FAILED on existing project-wide schema drift; mapping is valid. `schema:update --dump-sql` includes many unrelated diffs and Doctrine timestamp precision normalization (`TIMESTAMP(6)` to `TIMESTAMP(0)`) for new and earlier migration-created timestamp columns.
+- `git diff --check` — OK
+
+#### Risks / reviewer focus
+- Migration is additive in `up()`: creates `pnl_dirty_periods` and adds nullable `rebuilt_at` to existing P&L aggregate tables. `down()` drops those additions.
+- Existing P&L aggregate tables must not have a shop/source dimension. The repository methods deliberately reject non-empty `shopRef` to prevent accidental all-shop deletion behind a shop-scoped call.
+- Source linkage should be designed after Ingestion acceptance/deploy at the `Document` / `DocumentOperation` boundary or in a dedicated link table; the exact business field name is still open.
+- This stage does not wire `NormalizationCompletedEvent`, Messenger workers, Redis locks, close-period checks, or canonical rebuild execution. Those remain for later stages.
+- Full Doctrine schema sync is already noisy in this project; reviewer should focus on the new migration SQL and the explicit `TIMESTAMP(6)` precision decision.
+
+#### Open questions
+- What is the correct business name and storage boundary for source/origin links in Finance documents: `Document`, `DocumentOperation`, both, or a dedicated link table?

--- a/docs/tasks/ingestion/stages/stage-8.md
+++ b/docs/tasks/ingestion/stages/stage-8.md
@@ -1,0 +1,144 @@
+### Stage 8: Block 7 P&L rebuild infrastructure — DONE
+
+**Risk:** HIGH
+**Next action:** STOP, owner review required
+
+#### What was done
+- Saved the owner follow-up decision task: `docs/tasks/ingestion/FOLLOWUP-finance-source-linking.md`.
+- Added Finance P&L application commands:
+  - `MarkPnlPeriodDirtyCommand`
+  - `RebuildPnlPeriodCommand`
+- Added `PnlPeriodResolver` with `Europe/Moscow` period boundaries.
+- Added `PnlCategoryResolver` with canonical transaction type/direction mapping and fallback Finance categories:
+  - `INGESTION_OTHER_INCOME`
+  - `INGESTION_OTHER_EXPENSE`
+- Added `PnlProjectDirectionResolver`, using the existing default/first project direction for canonical rebuild rows.
+- Added `MarkPnlPeriodDirtyAction`, idempotent by dirty-period natural key.
+- Added `MaybeBlockByClosePeriodAction` for `Company.financeLockBefore` and `MarketplaceMonthClose` closed-stage checks.
+- Added `RebuildPnlPeriodAction` with Symfony Lock, explicit DB transaction, close guard, delete-then-upsert rebuild, and `rebuiltAt` audit writes.
+- Added `PnlClosedPeriodTouchedEvent`.
+- Added `NormalizationCompletedSubscriber`, which dispatches mark-dirty messages and handles old/new month changes.
+- Added `MarkPnlPeriodDirtyMessage`, `RebuildPnlPeriodMessage`, and handlers.
+- Added `RebuildDirtyPnlPeriodsCommand`; it dispatches rebuild messages only and does not execute rebuild inline.
+- Added `PnlFacade` with `markPeriodDirty`, `rebuildPeriod`, `getDirtyPeriods`, and `getProgress`.
+- Added Messenger routing:
+  - `MarkPnlPeriodDirtyMessage` → `ingest_normalize`
+  - `RebuildPnlPeriodMessage` → `pnl_rebuild`
+- Added test-only in-memory `pnl_rebuild` transport and in-memory lock factory override.
+- Extended `PLDailyTotalRepository::upsert()` and `PLMonthlySnapshotRepository::upsert()` to write `rebuiltAt`; monthly upsert can accumulate for rebuild aggregation.
+- Updated `ARCHITECTURE.md`.
+
+#### Files changed
+- `ARCHITECTURE.md` — modified
+- `docs/tasks/ingestion/FOLLOWUP-finance-source-linking.md` — new
+- `docs/tasks/ingestion/INDEX.md` — modified
+- `site/config/packages/messenger.yaml` — modified
+- `site/config/packages/test/messenger.yaml` — modified
+- `site/config/services.yaml` — modified
+- `site/config/services_test.yaml` — modified
+- `site/src/Finance/Application/Action/MarkPnlPeriodDirtyAction.php` — new
+- `site/src/Finance/Application/Action/MaybeBlockByClosePeriodAction.php` — new
+- `site/src/Finance/Application/Action/RebuildPnlPeriodAction.php` — new
+- `site/src/Finance/Application/Command/MarkPnlPeriodDirtyCommand.php` — new
+- `site/src/Finance/Application/Command/RebuildPnlPeriodCommand.php` — new
+- `site/src/Ingestion/Application/DTO/PLDirtyPeriodView.php` — new
+- `site/src/Finance/Application/DTO/PnlProgressView.php` — new
+- `site/src/Finance/Application/DTO/PnlPeriodBlockResult.php` — new
+- `site/src/Finance/Application/Service/PnlCategoryResolver.php` — new
+- `site/src/Finance/Application/Service/PnlPeriodResolver.php` — new
+- `site/src/Finance/Application/Service/PnlProjectDirectionResolver.php` — new
+- `site/src/Finance/Command/RebuildDirtyPnlPeriodsCommand.php` — new
+- `site/src/Finance/Domain/Event/PnlClosedPeriodTouchedEvent.php` — new
+- `site/src/Finance/EventSubscriber/NormalizationCompletedSubscriber.php` — new
+- `site/src/Finance/Exception/PnlCategoryResolveException.php` — new
+- `site/src/Finance/Exception/PnlProjectDirectionResolveException.php` — new
+- `site/src/Finance/Exception/PnlRebuildLockTimeoutException.php` — new
+- `site/src/Finance/Facade/PnlFacade.php` — new
+- `site/src/Finance/Message/MarkPnlPeriodDirtyMessage.php` — new
+- `site/src/Finance/Message/RebuildPnlPeriodMessage.php` — new
+- `site/src/Finance/MessageHandler/MarkPnlPeriodDirtyHandler.php` — new
+- `site/src/Finance/MessageHandler/RebuildPnlPeriodHandler.php` — new
+- `site/src/Ingestion/Repository/PLDirtyPeriodRepository.php` — modified
+- `site/src/Finance/Repository/PLDailyTotalRepository.php` — modified
+- `site/src/Finance/Repository/PLMonthlySnapshotRepository.php` — modified
+- `site/tests/Unit/Finance/Application/Service/PnlPeriodResolverTest.php` — new
+- `site/tests/Unit/Finance/Message/PnlMessageTest.php` — new
+- `site/tests/Integration/Finance/Application/MarkPnlPeriodDirtyActionTest.php` — new
+- `site/tests/Integration/Finance/Application/RebuildPnlPeriodActionTest.php` — new
+- `site/tests/Integration/Finance/Command/RebuildDirtyPnlPeriodsCommandTest.php` — new
+- `site/tests/Integration/Finance/EventSubscriber/NormalizationCompletedSubscriberTest.php` — new
+
+#### Self-review
+- [x] Scope compliance
+- [x] Project patterns followed
+- [x] No forbidden actions
+- [x] Security/company access checked
+- [x] Tests/checks run
+- [x] Documentation updated or N/A
+
+#### Checks
+- `docker compose run --rm site-php-cli php bin/phpunit --testsuite unit --filter 'PnlPeriodResolverTest|PnlMessageTest|PLDirtyPeriod'` — OK, 35 tests / 55 assertions
+- `docker compose run --rm -e COMPOSER_PROCESS_TIMEOUT=0 site-php-cli php bin/phpunit --testsuite integration --filter 'MarkPnlPeriodDirtyActionTest|NormalizationCompletedSubscriberTest|RebuildPnlPeriodActionTest|RebuildDirtyPnlPeriodsCommandTest|PLDirtyPeriodRepositoryTest|PLRebuildAuditRepositoryTest' --display-phpunit-deprecations` — OK, 11 tests / 37 assertions, existing 2 PHPUnit runner deprecations remain:
+  - `App\Tests\Integration\Marketplace\CloseMonthStageActionPreliminaryTest::testCloseCostsThrowsWhenEntriesAreEmptyEvenIfPreflightAllowsClose`
+  - `App\Tests\Integration\MarketplaceAds\AdLoadJobRepositoryTest::testIncrementRejectsNonPositiveDelta`
+- `docker compose run --rm -e COMPOSER_PROCESS_TIMEOUT=0 site-php-cli php bin/phpunit --testsuite integration --filter 'RebuildPnlPeriodActionTest' --display-phpunit-deprecations` — OK, 2 tests / 8 assertions, same existing PHPUnit runner deprecations
+- `docker compose run --rm site-php-cli php bin/console lint:container --env=test` — OK
+- `docker compose run --rm site-php-cli php bin/console doctrine:schema:validate --skip-sync --env=test` — OK, mapping valid; DB sync intentionally skipped
+- `docker compose run --rm site-php-cli vendor/bin/php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.php --cache-file=var/cache/.php-cs-fixer.stage8.cache --path-mode=intersection ...` — OK, 0 fixable Stage 8 files
+- `make site-test-unit` — OK, 1063 tests / 6423 assertions, existing 1 warning and 1 deprecation remain in the project unit suite
+- `git diff --check` — OK
+
+#### Risks / reviewer focus
+- `RebuildPnlPeriodAction` is intentionally destructive for all-source/all-shop scope: it deletes `PLDailyTotal` and `PLMonthlySnapshot` rows for the company/month before rebuilding from canonical Ingestion transactions.
+- Source-scoped rebuild (`shopRef !== ''`) is not executed. The dirty period is marked `FAILED` with a message pointing to the source-linking decision, because `shop_ref` must not be added to P&L aggregate tables.
+- Canonical rebuild requires an existing default or first `ProjectDirection` for the company. It does not silently create Finance project directions.
+- `PnlCategoryResolver` creates fallback Finance categories if no mapped category exists. Reviewer should confirm the fallback category names/codes before enabling real rebuilds.
+- No production cron entry was added for `RebuildDirtyPnlPeriodsCommand`.
+- Existing legacy P&L writers are still active. This stage adds infrastructure but does not switch production P&L population away from legacy flows.
+
+#### Open questions
+- Owner decision after Ingestion acceptance/deploy: where should Finance store source/origin links: `Document`, `DocumentOperation`, both, or a dedicated link table? See `docs/tasks/ingestion/FOLLOWUP-finance-source-linking.md`.
+- Should `RebuildPnlPeriodAction` remain callable before shadow-mode, or should a feature flag hard-block execution outside test/admin contexts?
+
+### Stage 8 Review Fix: PL dirty-period naming — DONE
+
+**Risk:** LOW
+**Next action:** continue to final handoff
+
+#### What was done
+- Renamed dirty-period PHP types from `PnlDirtyPeriod*` to `PLDirtyPeriod*` for consistency with `PLDailyTotal` and `PLMonthlySnapshot`.
+- Kept the database table name unchanged: `pnl_dirty_periods`.
+- Updated code, tests, task docs, architecture notes, and stage reports to the new naming.
+
+#### Files changed
+- `site/src/Ingestion/Entity/PLDirtyPeriod.php` — renamed
+- `site/src/Ingestion/Enum/PLDirtyPeriodReason.php` — renamed
+- `site/src/Ingestion/Enum/PLDirtyPeriodStatus.php` — renamed
+- `site/src/Ingestion/Repository/PLDirtyPeriodRepository.php` — renamed
+- `site/src/Ingestion/Application/DTO/PLDirtyPeriodView.php` — renamed
+- `site/tests/Unit/Ingestion/Entity/PLDirtyPeriodTest.php` — renamed
+- `site/tests/Unit/Ingestion/Enum/PLDirtyPeriodStatusTest.php` — renamed
+- `site/tests/Integration/Ingestion/Repository/PLDirtyPeriodRepositoryTest.php` — renamed
+
+#### Self-review
+- [x] Scope compliance
+- [x] Project patterns followed
+- [x] No forbidden actions
+- [x] Security/company access checked
+- [x] Tests/checks run
+- [x] Documentation updated
+
+#### Checks
+- `rg -n "PnlDirtyPeriod" site/src site/tests ARCHITECTURE.md docs/tasks/ingestion/INDEX.md docs/tasks/ingestion/TASK-*.md docs/tasks/ingestion/plan.md` — OK, no active code/task references
+- `docker compose run --rm site-php-cli php bin/phpunit --testsuite unit --filter 'PLDirtyPeriod|PnlPeriodResolverTest|PnlMessageTest'` — OK, 35 tests / 55 assertions
+- `docker compose run --rm -e COMPOSER_PROCESS_TIMEOUT=0 site-php-cli php bin/phpunit --testsuite integration --filter 'PLDirtyPeriodRepositoryTest|MarkPnlPeriodDirtyActionTest|RebuildPnlPeriodActionTest|RebuildDirtyPnlPeriodsCommandTest' --display-phpunit-deprecations` — OK, 6 tests / 23 assertions, existing 2 PHPUnit runner deprecations remain
+- `docker compose run --rm site-php-cli php bin/console lint:container --env=test` — OK
+- `docker compose run --rm site-php-cli php bin/console doctrine:schema:validate --skip-sync --env=test` — OK, mapping valid; DB sync intentionally skipped
+- `docker compose run --rm site-php-cli vendor/bin/php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.php --cache-file=var/cache/.php-cs-fixer.rename-pldirty.cache --path-mode=intersection ...` — OK, 0 fixable review-fix files
+- `git diff --check` — OK
+
+#### Risks / reviewer focus
+- This is a PHP/API naming change inside the unmerged Ingestion stage work. The DB table and migration SQL remain unchanged.
+
+#### Open questions
+- none

--- a/docs/tasks/ingestion/stages/stage-9-correction-pldirtyperiod-ownership.md
+++ b/docs/tasks/ingestion/stages/stage-9-correction-pldirtyperiod-ownership.md
@@ -1,0 +1,49 @@
+### Stage 9: PLDirtyPeriod ownership correction — DONE
+
+**Risk:** MEDIUM
+**Next action:** STOP, owner review required
+
+#### What was done
+- Moved dirty-period ownership from `App\Finance` to `App\Ingestion`.
+- Moved `PLDirtyPeriodView` to Ingestion as the read model for the Ingestion-owned dirty-period state.
+- Kept Finance orchestration classes in `App\Finance`: mark-dirty action/message/handler, rebuild action/message/handler, `PnlFacade`, and `NormalizationCompletedSubscriber`.
+- Added `TenantOwnedInterface` to `PLDirtyPeriod`, so the Ingestion company filter can apply to the entity.
+- Kept database table name unchanged: `pnl_dirty_periods`.
+- Confirmed Doctrine already maps `App\Ingestion\Entity`; no `doctrine.yaml` change was required.
+
+#### Files changed
+- `site/src/Ingestion/Entity/PLDirtyPeriod.php` — moved from Finance, implements `TenantOwnedInterface`
+- `site/src/Ingestion/Enum/PLDirtyPeriodReason.php` — moved from Finance
+- `site/src/Ingestion/Enum/PLDirtyPeriodStatus.php` — moved from Finance
+- `site/src/Ingestion/Repository/PLDirtyPeriodRepository.php` — moved from Finance
+- `site/src/Ingestion/Application/DTO/PLDirtyPeriodView.php` — moved from Finance
+- `site/tests/Unit/Ingestion/Entity/PLDirtyPeriodTest.php` — moved from Finance, tenant marker assertion added
+- `site/tests/Unit/Ingestion/Enum/PLDirtyPeriodStatusTest.php` — moved from Finance
+- `site/tests/Integration/Ingestion/Repository/PLDirtyPeriodRepositoryTest.php` — moved from Finance
+- Finance P&L actions, facade, messages, handlers, subscriber, and command — imports updated
+- Documentation and reports — updated to reflect Ingestion ownership
+
+#### Self-review
+- [x] Scope compliance
+- [x] Project patterns followed
+- [x] No forbidden actions
+- [x] Security/company access checked
+- [x] Tests/checks run
+- [x] Documentation updated
+
+#### Checks
+- `grep -rn "Finance\\\\.*PLDirtyPeriod" site/src/` — OK, no matches
+- `rg -n -F 'class PLDirtyPeriod implements TenantOwnedInterface' site/src/Ingestion/Entity/PLDirtyPeriod.php` — OK
+- `docker compose run --rm site-php-cli php bin/console lint:container --env=test` — OK
+- `docker compose run --rm site-php-cli php bin/console doctrine:schema:validate --skip-sync --env=test` — OK
+- `make site-test-unit` — OK, 1063 tests / 6424 assertions, existing 1 warning and 1 deprecation remain
+- `docker compose run --rm -e COMPOSER_PROCESS_TIMEOUT=0 site-php-cli php bin/phpunit --testsuite integration --filter 'Ingestion|PLDirtyPeriod|MarkPnlPeriodDirtyAction|NormalizationCompletedSubscriber|RebuildPnlPeriodAction|RebuildDirtyPnlPeriodsCommand|PLRebuildAuditRepository' --display-phpunit-deprecations` — OK, 47 tests / 206 assertions, existing 2 PHPUnit runner deprecations remain
+- `docker compose run --rm site-php-cli vendor/bin/php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.php --cache-file=var/cache/.php-cs-fixer.pldirty-ingestion.cache --path-mode=intersection ...` — OK, 0 fixable correction files
+- `git diff --check` — OK
+
+#### Risks / reviewer focus
+- This is a namespace and ownership move only; table `pnl_dirty_periods` and entity behavior were intentionally kept unchanged.
+- Review that Finance now imports only Ingestion dirty-period types and does not own the dirty-period state.
+
+#### Open questions
+- none

--- a/site/config/packages/messenger.yaml
+++ b/site/config/packages/messenger.yaml
@@ -17,6 +17,27 @@ framework:
                     delay: 5000
                     multiplier: 2
 
+            ingest_fetch:
+                dsn: '%env(MESSENGER_TRANSPORT_DSN_SYNC)%'
+                retry_strategy:
+                    max_retries: 3
+                    delay: 10000
+                    multiplier: 2
+
+            ingest_normalize:
+                dsn: '%env(MESSENGER_TRANSPORT_DSN_PIPELINE)%'
+                retry_strategy:
+                    max_retries: 3
+                    delay: 5000
+                    multiplier: 2
+
+            pnl_rebuild:
+                dsn: '%env(MESSENGER_TRANSPORT_DSN_PIPELINE)%'
+                retry_strategy:
+                    max_retries: 3
+                    delay: 30000
+                    multiplier: 2
+
             async_wb_finance:
                 dsn: '%env(MESSENGER_TRANSPORT_DSN_WB_FINANCE)%'
                 retry_strategy:
@@ -58,6 +79,7 @@ framework:
             'Symfony\Component\Notifier\Message\ChatMessage': async_sync
             'Symfony\Component\Notifier\Message\SmsMessage': async_sync
             'App\Inventory\Message\SyncOzonInventorySnapshotMessage': async_sync
+            'App\Ingestion\Message\RunSyncChunkMessage': ingest_fetch
 
             # --- async_pipeline: local CPU/DB processing of already-fetched data ---
             'App\Marketplace\Message\ProcessDayReportMessage': async_pipeline
@@ -73,6 +95,9 @@ framework:
             'App\MarketplaceAds\Message\ProcessAdRawDocumentMessage': async_pipeline
             'App\MarketplaceAds\Message\DownloadOzonAdReportMessage': async_pipeline
             'App\Inventory\Message\NormalizeInventorySnapshotMessage': async_pipeline
+            'App\Ingestion\Message\NormalizeRawRecordMessage': ingest_normalize
+            'App\Finance\Message\MarkPnlPeriodDirtyMessage': ingest_normalize
+            'App\Finance\Message\RebuildPnlPeriodMessage': pnl_rebuild
 
             # --- async_ads: Ozon Performance polling (may block up to 10 min per message) ---
             'App\MarketplaceAds\Message\LoadOzonAdStatisticsRangeMessage': async_ads

--- a/site/config/packages/test/messenger.yaml
+++ b/site/config/packages/test/messenger.yaml
@@ -3,7 +3,13 @@ framework:
         transports:
             async_sync: 'in-memory://'
             async_pipeline: 'in-memory://'
+            ingest_fetch: 'in-memory://'
+            ingest_normalize: 'in-memory://'
+            pnl_rebuild: 'in-memory://'
             async_wb_finance: 'in-memory://'
             async_ads: 'in-memory://'
         routing:
             'App\Tests\Integration\Ingestion\Fixtures\TenantVisibilityMessage': async_pipeline
+            'App\Ingestion\Message\NormalizeRawRecordMessage': ingest_normalize
+            'App\Finance\Message\MarkPnlPeriodDirtyMessage': ingest_normalize
+            'App\Finance\Message\RebuildPnlPeriodMessage': pnl_rebuild

--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -125,6 +125,39 @@ services:
     App\Ingestion\Facade\RawStorageFacade:
         public: true
 
+    App\Ingestion\Facade\SyncFacade:
+        public: true
+
+    App\Ingestion\Facade\IngestionFacade:
+        public: true
+
+    App\Finance\Facade\PnlFacade:
+        public: true
+
+    App\Ingestion\Infrastructure\Api\Ozon\OzonCredentialProviderInterface: '@App\Ingestion\Infrastructure\Api\Ozon\CredentialFacadeOzonCredentialProvider'
+    App\Ingestion\Infrastructure\Api\Ozon\OzonClientAdapterInterface: '@App\Ingestion\Infrastructure\Api\Ozon\LegacyOzonClientAdapter'
+
+    App\Ingestion\Application\Source\Ozon\OzonSellerReportConnector:
+        arguments:
+            $chunkSizeDays: 7
+            $hotRewindDays: 14
+            $rateLimitRpm: 60
+        tags: ['app.ingestion.connector']
+
+    App\Ingestion\Application\Source\Ozon\OzonSellerReportMapper:
+        tags: ['app.ingestion.mapper']
+
+    App\Ingestion\Application\Source\Ozon\OzonRealizationMapper:
+        tags: ['app.ingestion.mapper']
+
+    App\Ingestion\Domain\Service\ConnectorRegistry:
+        arguments:
+            $connectors: !tagged_iterator app.ingestion.connector
+
+    App\Ingestion\Domain\Service\MapperRegistry:
+        arguments:
+            $mappers: !tagged_iterator app.ingestion.mapper
+
     App\Marketplace\Application\Service\WbFinancialReportSyncStatusUpdaterInterface: '@App\Marketplace\Application\Service\WbFinancialReportSyncStatusUpdater'
     App\Marketplace\Application\Service\WbGeneratedRowsSafeReplaceServiceInterface: '@App\Marketplace\Application\Service\WbGeneratedRowsSafeReplaceService'
     App\Marketplace\Repository\MarketplaceFinancialReportSyncStatusLookupInterface: '@App\Marketplace\Repository\MarketplaceFinancialReportSyncStatusRepository'

--- a/site/config/services_test.yaml
+++ b/site/config/services_test.yaml
@@ -5,3 +5,27 @@ services:
 
     App\Tests\Integration\Ingestion\Fixtures\:
         resource: '../tests/Integration/Ingestion/Fixtures/'
+
+    App\Tests\Integration\Ingestion\Fixtures\FakeConnector:
+        tags: ['app.ingestion.connector']
+
+    App\Tests\Integration\Ingestion\Fixtures\FakeMapper:
+        tags: ['app.ingestion.mapper']
+
+    App\Ingestion\Infrastructure\Api\Ozon\OzonClientAdapterInterface: '@App\Tests\Integration\Ingestion\Fixtures\FakeOzonClientAdapter'
+
+    test.ingestion_lock_store:
+        class: Symfony\Component\Lock\Store\InMemoryStore
+
+    test.ingestion_lock_factory:
+        class: Symfony\Component\Lock\LockFactory
+        arguments:
+            - '@test.ingestion_lock_store'
+
+    App\Ingestion\Application\Service\IngestRateLimitGuard:
+        arguments:
+            $lockFactory: '@test.ingestion_lock_factory'
+
+    App\Finance\Application\Action\RebuildPnlPeriodAction:
+        arguments:
+            $lockFactory: '@test.ingestion_lock_factory'

--- a/site/migrations/Version20260618120000.php
+++ b/site/migrations/Version20260618120000.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260618120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create Ingestion cursor and sync job tables';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        $this->abortIf(
+            !$platform instanceof PostgreSQLPlatform,
+            sprintf('Migration %s supports only PostgreSQL; got platform "%s".', self::class, $platform::class),
+        );
+
+        $this->addSql("CREATE TABLE ingest_cursors (id UUID NOT NULL, company_id UUID NOT NULL, connection_ref VARCHAR(255) NOT NULL, resource_type VARCHAR(100) NOT NULL, shop_ref VARCHAR(255) DEFAULT '' NOT NULL, cursor_value VARCHAR(1024) DEFAULT '' NOT NULL, last_fetched_at TIMESTAMP(6) WITHOUT TIME ZONE DEFAULT NULL, last_sync_job_id UUID DEFAULT NULL, created_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))");
+        $this->addSql('CREATE UNIQUE INDEX uniq_ingest_cursor_key ON ingest_cursors (company_id, connection_ref, resource_type, shop_ref)');
+        $this->addSql('CREATE INDEX idx_ingest_cursor_company_connection ON ingest_cursors (company_id, connection_ref)');
+
+        $this->addSql("CREATE TABLE ingest_sync_jobs (id UUID NOT NULL, company_id UUID NOT NULL, connection_ref VARCHAR(255) NOT NULL, source VARCHAR(64) NOT NULL, resource_type VARCHAR(100) NOT NULL, shop_ref VARCHAR(255) DEFAULT '' NOT NULL, kind VARCHAR(32) NOT NULL, status VARCHAR(32) DEFAULT 'open' NOT NULL, window_from DATE DEFAULT NULL, window_to DATE DEFAULT NULL, parent_job_id UUID DEFAULT NULL, progress_total INT DEFAULT 0 NOT NULL, progress_done INT DEFAULT 0 NOT NULL, cursor_snapshot VARCHAR(1024) DEFAULT NULL, attempts INT DEFAULT 0 NOT NULL, last_error TEXT DEFAULT NULL, started_at TIMESTAMP(6) WITHOUT TIME ZONE DEFAULT NULL, finished_at TIMESTAMP(6) WITHOUT TIME ZONE DEFAULT NULL, created_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))");
+        $this->addSql('CREATE INDEX idx_ingest_sync_job_company_status ON ingest_sync_jobs (company_id, status)');
+        $this->addSql('CREATE INDEX idx_ingest_sync_job_resource_status ON ingest_sync_jobs (company_id, connection_ref, resource_type, status)');
+        $this->addSql('CREATE INDEX idx_ingest_sync_job_parent ON ingest_sync_jobs (parent_job_id)');
+        $this->addSql('CREATE INDEX idx_ingest_sync_job_kind_status ON ingest_sync_jobs (company_id, kind, status)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        $this->abortIf(
+            !$platform instanceof PostgreSQLPlatform,
+            sprintf('Migration %s supports only PostgreSQL; got platform "%s".', self::class, $platform::class),
+        );
+
+        $this->addSql('DROP TABLE ingest_sync_jobs');
+        $this->addSql('DROP TABLE ingest_cursors');
+    }
+}

--- a/site/migrations/Version20260618130000.php
+++ b/site/migrations/Version20260618130000.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260618130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create Ingestion canonical financial transaction tables';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        $this->abortIf(
+            !$platform instanceof PostgreSQLPlatform,
+            sprintf('Migration %s supports only PostgreSQL; got platform "%s".', self::class, $platform::class),
+        );
+
+        $this->addSql('CREATE TABLE ingest_counterparties (id UUID NOT NULL, company_id UUID NOT NULL, source VARCHAR(64) NOT NULL, external_key VARCHAR(255) NOT NULL, name VARCHAR(500) NOT NULL, created_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE UNIQUE INDEX uniq_counterparty_natural ON ingest_counterparties (company_id, source, external_key)');
+
+        $this->addSql("CREATE TABLE ingest_financial_transactions (id UUID NOT NULL, company_id UUID NOT NULL, connection_ref VARCHAR(255) NOT NULL, shop_ref VARCHAR(255) DEFAULT '' NOT NULL, source VARCHAR(64) NOT NULL, external_id VARCHAR(255) NOT NULL, external_updated_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, operation_group_id UUID NOT NULL, type VARCHAR(64) NOT NULL, direction VARCHAR(8) NOT NULL, amount_minor BIGINT NOT NULL, currency VARCHAR(3) NOT NULL, occurred_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, source_tz VARCHAR(64) DEFAULT 'UTC' NOT NULL, order_ref VARCHAR(255) DEFAULT NULL, payout_ref VARCHAR(255) DEFAULT NULL, counterparty_id UUID DEFAULT NULL, description TEXT DEFAULT NULL, source_data JSONB NOT NULL, raw_record_id UUID NOT NULL, version INT DEFAULT 1 NOT NULL, created_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))");
+        $this->addSql('CREATE UNIQUE INDEX uniq_ftx_natural_key ON ingest_financial_transactions (company_id, source, external_id, type)');
+        $this->addSql('CREATE INDEX idx_ftx_company_occurred ON ingest_financial_transactions (company_id, occurred_at)');
+        $this->addSql('CREATE INDEX idx_ftx_company_shop_occurred ON ingest_financial_transactions (company_id, shop_ref, occurred_at)');
+        $this->addSql('CREATE INDEX idx_ftx_company_group ON ingest_financial_transactions (company_id, operation_group_id)');
+        $this->addSql('CREATE INDEX idx_ftx_company_type_occurred ON ingest_financial_transactions (company_id, type, occurred_at)');
+        $this->addSql('CREATE INDEX idx_ftx_company_raw ON ingest_financial_transactions (company_id, raw_record_id)');
+
+        $this->addSql('CREATE TABLE ingest_normalization_issues (id UUID NOT NULL, company_id UUID NOT NULL, raw_record_id UUID NOT NULL, operation_group_id UUID DEFAULT NULL, kind VARCHAR(64) NOT NULL, details JSONB NOT NULL, resolved_at TIMESTAMP(6) WITHOUT TIME ZONE DEFAULT NULL, created_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX idx_norm_issue_company_kind_resolved ON ingest_normalization_issues (company_id, kind, resolved_at)');
+        $this->addSql('CREATE INDEX idx_norm_issue_company_raw ON ingest_normalization_issues (company_id, raw_record_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        $this->abortIf(
+            !$platform instanceof PostgreSQLPlatform,
+            sprintf('Migration %s supports only PostgreSQL; got platform "%s".', self::class, $platform::class),
+        );
+
+        $this->addSql('DROP TABLE ingest_normalization_issues');
+        $this->addSql('DROP TABLE ingest_financial_transactions');
+        $this->addSql('DROP TABLE ingest_counterparties');
+    }
+}

--- a/site/migrations/Version20260618140000.php
+++ b/site/migrations/Version20260618140000.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260618140000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create P&L dirty period table and add rebuild audit columns';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        $this->abortIf(
+            !$platform instanceof PostgreSQLPlatform,
+            sprintf('Migration %s supports only PostgreSQL; got platform "%s".', self::class, $platform::class),
+        );
+
+        $this->addSql("CREATE TABLE pnl_dirty_periods (id UUID NOT NULL, company_id UUID NOT NULL, period_year SMALLINT NOT NULL, period_month SMALLINT NOT NULL, shop_ref VARCHAR(255) DEFAULT '' NOT NULL, status VARCHAR(32) DEFAULT 'pending' NOT NULL, reason VARCHAR(32) NOT NULL, marked_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, rebuilt_at TIMESTAMP(6) WITHOUT TIME ZONE DEFAULT NULL, attempts INT DEFAULT 0 NOT NULL, last_error TEXT DEFAULT NULL, created_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))");
+        $this->addSql('CREATE UNIQUE INDEX uniq_pdp_key ON pnl_dirty_periods (company_id, period_year, period_month, shop_ref)');
+        $this->addSql('CREATE INDEX idx_pdp_status_marked ON pnl_dirty_periods (status, marked_at)');
+        $this->addSql('CREATE INDEX idx_pdp_company_status ON pnl_dirty_periods (company_id, status)');
+
+        $this->addSql('ALTER TABLE pl_daily_totals ADD rebuilt_at TIMESTAMP(6) WITHOUT TIME ZONE DEFAULT NULL');
+        $this->addSql('ALTER TABLE pl_monthly_snapshots ADD rebuilt_at TIMESTAMP(6) WITHOUT TIME ZONE DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        $this->abortIf(
+            !$platform instanceof PostgreSQLPlatform,
+            sprintf('Migration %s supports only PostgreSQL; got platform "%s".', self::class, $platform::class),
+        );
+
+        $this->addSql('ALTER TABLE pl_monthly_snapshots DROP COLUMN rebuilt_at');
+        $this->addSql('ALTER TABLE pl_daily_totals DROP COLUMN rebuilt_at');
+        $this->addSql('DROP TABLE pnl_dirty_periods');
+    }
+}

--- a/site/src/Finance/Application/Action/MarkPnlPeriodDirtyAction.php
+++ b/site/src/Finance/Application/Action/MarkPnlPeriodDirtyAction.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Finance\Application\Action;
+
+use App\Finance\Application\Command\MarkPnlPeriodDirtyCommand;
+use App\Ingestion\Entity\PLDirtyPeriod;
+use App\Ingestion\Enum\PLDirtyPeriodStatus;
+use App\Ingestion\Repository\PLDirtyPeriodRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class MarkPnlPeriodDirtyAction
+{
+    public function __construct(
+        private PLDirtyPeriodRepository $repository,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function __invoke(MarkPnlPeriodDirtyCommand $command): void
+    {
+        $period = $this->repository->findOne($command->companyId, $command->year, $command->month, $command->shopRef);
+
+        if (!$period instanceof PLDirtyPeriod) {
+            $this->entityManager->persist(new PLDirtyPeriod(
+                companyId: $command->companyId,
+                periodYear: $command->year,
+                periodMonth: $command->month,
+                shopRef: $command->shopRef,
+                reason: $command->reason,
+            ));
+            $this->entityManager->flush();
+
+            return;
+        }
+
+        if (PLDirtyPeriodStatus::DONE === $period->getStatus() || PLDirtyPeriodStatus::FAILED === $period->getStatus()) {
+            $period->reopen();
+            $this->entityManager->flush();
+        }
+    }
+}

--- a/site/src/Finance/Application/Action/MarkPnlPeriodDirtyAction.php
+++ b/site/src/Finance/Application/Action/MarkPnlPeriodDirtyAction.php
@@ -35,7 +35,11 @@ final readonly class MarkPnlPeriodDirtyAction
             return;
         }
 
-        if (PLDirtyPeriodStatus::DONE === $period->getStatus() || PLDirtyPeriodStatus::FAILED === $period->getStatus()) {
+        if (
+            PLDirtyPeriodStatus::DONE === $period->getStatus()
+            || PLDirtyPeriodStatus::FAILED === $period->getStatus()
+            || PLDirtyPeriodStatus::BLOCKED_BY_CLOSE === $period->getStatus()
+        ) {
             $period->reopen();
             $this->entityManager->flush();
         }

--- a/site/src/Finance/Application/Action/MaybeBlockByClosePeriodAction.php
+++ b/site/src/Finance/Application/Action/MaybeBlockByClosePeriodAction.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Finance\Application\Action;
+
+use App\Company\Entity\Company;
+use App\Company\Infrastructure\Repository\CompanyRepository;
+use App\Finance\Application\DTO\PnlPeriodBlockResult;
+use App\Marketplace\Entity\MarketplaceMonthClose;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Repository\MarketplaceMonthCloseRepository;
+
+final readonly class MaybeBlockByClosePeriodAction
+{
+    public function __construct(
+        private CompanyRepository $companyRepository,
+        private MarketplaceMonthCloseRepository $monthCloseRepository,
+    ) {
+    }
+
+    public function __invoke(string $companyId, int $year, int $month, string $shopRef): ?PnlPeriodBlockResult
+    {
+        $company = $this->companyRepository->findById($companyId);
+        if (!$company instanceof Company) {
+            return PnlPeriodBlockResult::blocked(sprintf('Company "%s" was not found.', $companyId));
+        }
+
+        $lastDay = (new \DateTimeImmutable(sprintf('%04d-%02d-01', $year, $month)))->modify('last day of this month')->setTime(0, 0);
+        $financeLockBefore = $company->getFinanceLockBefore();
+        if (null !== $financeLockBefore && $financeLockBefore >= $lastDay) {
+            return PnlPeriodBlockResult::blocked(sprintf('Company finance lock blocks period %04d-%02d.', $year, $month));
+        }
+
+        if ('' !== $shopRef) {
+            $marketplace = $this->deriveMarketplace($shopRef);
+            if (null === $marketplace) {
+                return null;
+            }
+
+            $close = $this->monthCloseRepository->findByPeriod($companyId, $marketplace, $year, $month);
+
+            return $close instanceof MarketplaceMonthClose && $this->hasClosedStage($close)
+                ? PnlPeriodBlockResult::blocked(sprintf('%s month close blocks period %04d-%02d.', $marketplace->value, $year, $month))
+                : null;
+        }
+
+        $closes = $this->monthCloseRepository->createQueryBuilder('close')
+            ->andWhere('close.companyId = :companyId')
+            ->andWhere('close.year = :year')
+            ->andWhere('close.month = :month')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('year', $year)
+            ->setParameter('month', $month)
+            ->getQuery()
+            ->getResult();
+
+        foreach ($closes as $close) {
+            if ($close instanceof MarketplaceMonthClose && $this->hasClosedStage($close)) {
+                return PnlPeriodBlockResult::blocked(sprintf('Marketplace month close blocks period %04d-%02d.', $year, $month));
+            }
+        }
+
+        return null;
+    }
+
+    private function deriveMarketplace(string $shopRef): ?MarketplaceType
+    {
+        $normalized = strtolower($shopRef);
+
+        if (str_starts_with($normalized, 'ozon')) {
+            return MarketplaceType::OZON;
+        }
+
+        if (str_starts_with($normalized, 'wb') || str_starts_with($normalized, 'wildberries')) {
+            return MarketplaceType::WILDBERRIES;
+        }
+
+        return null;
+    }
+
+    private function hasClosedStage(MarketplaceMonthClose $close): bool
+    {
+        return $close->getStageSalesReturnsStatus()->isClosed()
+            || $close->getStageCostsStatus()->isClosed();
+    }
+}

--- a/site/src/Finance/Application/Action/RebuildPnlPeriodAction.php
+++ b/site/src/Finance/Application/Action/RebuildPnlPeriodAction.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Finance\Application\Action;
+
+use App\Company\Entity\Company;
+use App\Company\Infrastructure\Repository\CompanyRepository;
+use App\Finance\Application\Command\RebuildPnlPeriodCommand;
+use App\Finance\Application\Service\PnlCategoryResolver;
+use App\Finance\Application\Service\PnlPeriodResolver;
+use App\Finance\Application\Service\PnlProjectDirectionResolver;
+use App\Finance\Domain\Event\PnlClosedPeriodTouchedEvent;
+use App\Finance\Exception\PnlRebuildLockTimeoutException;
+use App\Finance\Repository\PLDailyTotalRepository;
+use App\Finance\Repository\PLMonthlySnapshotRepository;
+use App\Ingestion\Entity\FinancialTransaction;
+use App\Ingestion\Entity\PLDirtyPeriod;
+use App\Ingestion\Enum\PLDirtyPeriodReason;
+use App\Ingestion\Enum\PLDirtyPeriodStatus;
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Facade\IngestionFacade;
+use App\Ingestion\Repository\PLDirtyPeriodRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Lock\LockFactory;
+
+final readonly class RebuildPnlPeriodAction
+{
+    private const LOCK_TTL_SECONDS = 600.0;
+
+    public function __construct(
+        private PLDirtyPeriodRepository $dirtyPeriodRepository,
+        private CompanyRepository $companyRepository,
+        private PnlPeriodResolver $periodResolver,
+        private PnlCategoryResolver $categoryResolver,
+        private PnlProjectDirectionResolver $projectDirectionResolver,
+        private MaybeBlockByClosePeriodAction $blockByClosePeriodAction,
+        private IngestionFacade $ingestionFacade,
+        private PLDailyTotalRepository $dailyTotalRepository,
+        private PLMonthlySnapshotRepository $monthlySnapshotRepository,
+        private EntityManagerInterface $entityManager,
+        private EventDispatcherInterface $eventDispatcher,
+        private LockFactory $lockFactory,
+    ) {
+    }
+
+    public function __invoke(RebuildPnlPeriodCommand $command): void
+    {
+        $lock = $this->lockFactory->createLock($this->lockKey($command), self::LOCK_TTL_SECONDS, false);
+        if (!$lock->acquire()) {
+            throw new PnlRebuildLockTimeoutException(sprintf('P&L rebuild for company "%s" period %04d-%02d is already running.', $command->companyId, $command->year, $command->month));
+        }
+
+        try {
+            $dirtyPeriod = $this->ensureDirtyPeriod($command);
+
+            if ('' !== $command->shopRef) {
+                $this->markFailed($dirtyPeriod, 'Source-scoped P&L rebuild is not supported until Finance source-linking is decided.');
+
+                return;
+            }
+
+            $block = ($this->blockByClosePeriodAction)($command->companyId, $command->year, $command->month, $command->shopRef);
+            if (null !== $block) {
+                $this->markBlocked($dirtyPeriod, $block->reason, $command);
+
+                return;
+            }
+
+            $this->runRebuild($command, $dirtyPeriod);
+        } catch (\Throwable $exception) {
+            $this->markFailedAfterException($command, $exception);
+
+            throw $exception;
+        } finally {
+            $lock->release();
+        }
+    }
+
+    private function runRebuild(RebuildPnlPeriodCommand $command, PLDirtyPeriod $dirtyPeriod): void
+    {
+        $connection = $this->entityManager->getConnection();
+        $connection->beginTransaction();
+
+        try {
+            if (PLDirtyPeriodStatus::DONE === $dirtyPeriod->getStatus() || PLDirtyPeriodStatus::FAILED === $dirtyPeriod->getStatus()) {
+                $dirtyPeriod->reopen();
+            }
+
+            if (PLDirtyPeriodStatus::PENDING === $dirtyPeriod->getStatus()) {
+                $dirtyPeriod->markRebuilding();
+            }
+
+            $company = $this->companyRepository->findById($command->companyId);
+            if (!$company instanceof Company) {
+                throw new \DomainException(sprintf('Company "%s" was not found.', $command->companyId));
+            }
+
+            $projectDirection = $this->projectDirectionResolver->resolveDefault($company);
+            $projectDirectionId = $projectDirection->getId();
+            if (null === $projectDirectionId) {
+                throw new \LogicException('Resolved project direction does not have an id.');
+            }
+
+            [$from, $to] = $this->periodResolver->bounds($command->year, $command->month);
+            $period = sprintf('%04d-%02d', $command->year, $command->month);
+            $rebuiltAt = new \DateTimeImmutable();
+
+            $this->dailyTotalRepository->deleteByCompanyShopAndMonth($command->companyId, $command->shopRef, $command->year, $command->month);
+            $this->monthlySnapshotRepository->deleteByCompanyShopAndMonth($command->companyId, $command->shopRef, $command->year, $command->month);
+
+            foreach ($this->ingestionFacade->getTransactions($command->companyId, $from, $to, null) as $transaction) {
+                if (!$transaction instanceof FinancialTransaction) {
+                    continue;
+                }
+
+                $categoryId = $this->categoryResolver->resolve($command->companyId, $transaction->getType(), $transaction->getDirection());
+                $amount = $this->formatAmountMinor($transaction->getAmountMinor());
+                $income = TransactionDirection::IN === $transaction->getDirection() ? $amount : '0.00';
+                $expense = TransactionDirection::OUT === $transaction->getDirection() ? $amount : '0.00';
+
+                $this->dailyTotalRepository->upsert(
+                    companyId: $command->companyId,
+                    categoryId: $categoryId,
+                    date: $transaction->getOccurredAt()->setTimezone(new \DateTimeZone('Europe/Moscow'))->setTime(0, 0),
+                    projectDirectionId: $projectDirectionId,
+                    amountIncome: $income,
+                    amountExpense: $expense,
+                    replace: false,
+                    timestamp: $rebuiltAt,
+                    rebuiltAt: $rebuiltAt,
+                );
+
+                $this->monthlySnapshotRepository->upsert(
+                    companyId: $command->companyId,
+                    categoryId: $categoryId,
+                    period: $period,
+                    amountIncome: $income,
+                    amountExpense: $expense,
+                    updatedAt: $rebuiltAt,
+                    rebuiltAt: $rebuiltAt,
+                    accumulate: true,
+                );
+            }
+
+            $dirtyPeriod->markDone($rebuiltAt);
+            $this->entityManager->flush();
+            $connection->commit();
+        } catch (\Throwable $exception) {
+            $connection->rollBack();
+
+            throw $exception;
+        }
+    }
+
+    private function ensureDirtyPeriod(RebuildPnlPeriodCommand $command): PLDirtyPeriod
+    {
+        $dirtyPeriod = $this->dirtyPeriodRepository->findOne($command->companyId, $command->year, $command->month, $command->shopRef);
+        if ($dirtyPeriod instanceof PLDirtyPeriod) {
+            return $dirtyPeriod;
+        }
+
+        $dirtyPeriod = new PLDirtyPeriod(
+            companyId: $command->companyId,
+            periodYear: $command->year,
+            periodMonth: $command->month,
+            shopRef: $command->shopRef,
+            reason: PLDirtyPeriodReason::MANUAL,
+        );
+
+        $this->entityManager->persist($dirtyPeriod);
+        $this->entityManager->flush();
+
+        return $dirtyPeriod;
+    }
+
+    private function markBlocked(PLDirtyPeriod $dirtyPeriod, string $reason, RebuildPnlPeriodCommand $command): void
+    {
+        if (PLDirtyPeriodStatus::PENDING === $dirtyPeriod->getStatus()) {
+            $dirtyPeriod->markBlockedByClose($reason);
+        } elseif (PLDirtyPeriodStatus::REBUILDING === $dirtyPeriod->getStatus()) {
+            $dirtyPeriod->markBlockedByClose($reason);
+        }
+
+        $this->eventDispatcher->dispatch(new PnlClosedPeriodTouchedEvent(
+            companyId: $command->companyId,
+            year: $command->year,
+            month: $command->month,
+            shopRef: $command->shopRef,
+            reason: $reason,
+        ));
+        $this->entityManager->flush();
+    }
+
+    private function markFailed(PLDirtyPeriod $dirtyPeriod, string $reason): void
+    {
+        if (PLDirtyPeriodStatus::PENDING === $dirtyPeriod->getStatus()) {
+            $dirtyPeriod->markRebuilding();
+        }
+
+        if (PLDirtyPeriodStatus::REBUILDING === $dirtyPeriod->getStatus()) {
+            $dirtyPeriod->markFailed($reason);
+            $this->entityManager->flush();
+        }
+    }
+
+    private function markFailedAfterException(RebuildPnlPeriodCommand $command, \Throwable $exception): void
+    {
+        $dirtyPeriod = $this->dirtyPeriodRepository->findOne($command->companyId, $command->year, $command->month, $command->shopRef);
+        if (!$dirtyPeriod instanceof PLDirtyPeriod) {
+            return;
+        }
+
+        $this->markFailed($dirtyPeriod, $exception->getMessage());
+    }
+
+    private function lockKey(RebuildPnlPeriodCommand $command): string
+    {
+        return sprintf('pnl_rebuild:%s:%04d-%02d:%s', $command->companyId, $command->year, $command->month, $command->shopRef);
+    }
+
+    private function formatAmountMinor(int $amountMinor): string
+    {
+        return number_format($amountMinor / 100, 2, '.', '');
+    }
+}

--- a/site/src/Finance/Application/Command/MarkPnlPeriodDirtyCommand.php
+++ b/site/src/Finance/Application/Command/MarkPnlPeriodDirtyCommand.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Finance\Application\Command;
+
+use App\Ingestion\Enum\PLDirtyPeriodReason;
+use Webmozart\Assert\Assert;
+
+final readonly class MarkPnlPeriodDirtyCommand
+{
+    public function __construct(
+        public string $companyId,
+        public int $year,
+        public int $month,
+        public string $shopRef,
+        public PLDirtyPeriodReason $reason,
+    ) {
+        Assert::uuid($this->companyId);
+        Assert::range($this->year, 2020, 2100);
+        Assert::range($this->month, 1, 12);
+    }
+}

--- a/site/src/Finance/Application/Command/RebuildPnlPeriodCommand.php
+++ b/site/src/Finance/Application/Command/RebuildPnlPeriodCommand.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Finance\Application\Command;
+
+use Webmozart\Assert\Assert;
+
+final readonly class RebuildPnlPeriodCommand
+{
+    public function __construct(
+        public string $companyId,
+        public int $year,
+        public int $month,
+        public string $shopRef = '',
+    ) {
+        Assert::uuid($this->companyId);
+        Assert::range($this->year, 2020, 2100);
+        Assert::range($this->month, 1, 12);
+    }
+}

--- a/site/src/Finance/Application/DTO/PnlPeriodBlockResult.php
+++ b/site/src/Finance/Application/DTO/PnlPeriodBlockResult.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Finance\Application\DTO;
+
+final readonly class PnlPeriodBlockResult
+{
+    private function __construct(public string $reason)
+    {
+    }
+
+    public static function blocked(string $reason): self
+    {
+        return new self($reason);
+    }
+}

--- a/site/src/Finance/Application/DTO/PnlProgressView.php
+++ b/site/src/Finance/Application/DTO/PnlProgressView.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Finance\Application\DTO;
+
+final readonly class PnlProgressView
+{
+    public function __construct(
+        public int $pending,
+        public int $rebuilding,
+        public int $done,
+        public int $failed,
+        public int $blockedByClose,
+    ) {
+    }
+}

--- a/site/src/Finance/Application/Service/PnlCategoryResolver.php
+++ b/site/src/Finance/Application/Service/PnlCategoryResolver.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Finance\Application\Service;
+
+use App\Company\Entity\Company;
+use App\Company\Infrastructure\Repository\CompanyRepository;
+use App\Finance\Entity\PLCategory;
+use App\Finance\Enum\PLCategoryType;
+use App\Finance\Enum\PLExpenseType;
+use App\Finance\Enum\PLFlow;
+use App\Finance\Enum\PLValueFormat;
+use App\Finance\Exception\PnlCategoryResolveException;
+use App\Finance\Repository\PLCategoryRepository;
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+
+final readonly class PnlCategoryResolver
+{
+    private const OTHER_INCOME_CODE = 'INGESTION_OTHER_INCOME';
+    private const OTHER_EXPENSE_CODE = 'INGESTION_OTHER_EXPENSE';
+
+    public function __construct(
+        private CompanyRepository $companyRepository,
+        private PLCategoryRepository $categoryRepository,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function resolve(string $companyId, TransactionType $type, TransactionDirection $direction): string
+    {
+        $company = $this->companyRepository->findById($companyId);
+        if (!$company instanceof Company) {
+            throw new PnlCategoryResolveException(sprintf('Company "%s" was not found for P&L category resolution.', $companyId));
+        }
+
+        $category = $this->findByCode($company, $this->codeFor($type, $direction))
+            ?? $this->findByCode($company, $this->fallbackCode($direction))
+            ?? $this->createFallback($company, $direction);
+
+        $categoryId = $category->getId();
+        if (null === $categoryId) {
+            throw new PnlCategoryResolveException('Resolved P&L category does not have an id.');
+        }
+
+        return $categoryId;
+    }
+
+    private function codeFor(TransactionType $type, TransactionDirection $direction): string
+    {
+        if (TransactionDirection::IN === $direction) {
+            return match ($type) {
+                TransactionType::SALE => 'INGESTION_SALE',
+                TransactionType::REFUND => 'INGESTION_REFUND_IN',
+                TransactionType::BONUS => 'INGESTION_BONUS',
+                default => self::OTHER_INCOME_CODE,
+            };
+        }
+
+        return match ($type) {
+            TransactionType::COMMISSION => 'INGESTION_COMMISSION',
+            TransactionType::LOGISTICS => 'INGESTION_LOGISTICS',
+            TransactionType::STORAGE => 'INGESTION_STORAGE',
+            TransactionType::LAST_MILE => 'INGESTION_LAST_MILE',
+            TransactionType::ACCEPTANCE => 'INGESTION_ACCEPTANCE',
+            TransactionType::ADVERTISING => 'INGESTION_ADVERTISING',
+            TransactionType::PENALTY => 'INGESTION_PENALTY',
+            TransactionType::ACQUIRING => 'INGESTION_ACQUIRING',
+            TransactionType::TAX => 'INGESTION_TAX',
+            TransactionType::FEE => 'INGESTION_FEE',
+            default => self::OTHER_EXPENSE_CODE,
+        };
+    }
+
+    private function fallbackCode(TransactionDirection $direction): string
+    {
+        return TransactionDirection::IN === $direction ? self::OTHER_INCOME_CODE : self::OTHER_EXPENSE_CODE;
+    }
+
+    private function findByCode(Company $company, string $code): ?PLCategory
+    {
+        return $this->categoryRepository->findOneBy([
+            'company' => $company,
+            'code' => $code,
+        ]);
+    }
+
+    private function createFallback(Company $company, TransactionDirection $direction): PLCategory
+    {
+        $category = new PLCategory(Uuid::uuid7()->toString(), $company);
+        $category
+            ->setName(TransactionDirection::IN === $direction ? 'Ingestion: прочие доходы' : 'Ingestion: прочие расходы')
+            ->setCode($this->fallbackCode($direction))
+            ->setType(PLCategoryType::LEAF_INPUT)
+            ->setFormat(PLValueFormat::MONEY)
+            ->setFlow(TransactionDirection::IN === $direction ? PLFlow::INCOME : PLFlow::EXPENSE)
+            ->setExpenseType(TransactionDirection::IN === $direction ? PLExpenseType::OTHER : PLExpenseType::VARIABLE)
+            ->setSortOrder($this->categoryRepository->getNextSortOrder($company, null));
+
+        $this->entityManager->persist($category);
+        $this->entityManager->flush();
+
+        return $category;
+    }
+}

--- a/site/src/Finance/Application/Service/PnlPeriodResolver.php
+++ b/site/src/Finance/Application/Service/PnlPeriodResolver.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Finance\Application\Service;
+
+final class PnlPeriodResolver
+{
+    private const REPORT_TIMEZONE = 'Europe/Moscow';
+
+    /**
+     * @return array{0: int, 1: int}
+     */
+    public function from(\DateTimeImmutable $at): array
+    {
+        $local = $at->setTimezone(new \DateTimeZone(self::REPORT_TIMEZONE));
+
+        return [(int) $local->format('Y'), (int) $local->format('n')];
+    }
+
+    /**
+     * @return array{0: \DateTimeImmutable, 1: \DateTimeImmutable}
+     */
+    public function bounds(int $year, int $month): array
+    {
+        $from = new \DateTimeImmutable(
+            sprintf('%04d-%02d-01 00:00:00', $year, $month),
+            new \DateTimeZone(self::REPORT_TIMEZONE),
+        );
+
+        return [$from, $from->modify('last day of this month')->setTime(23, 59, 59)];
+    }
+}

--- a/site/src/Finance/Application/Service/PnlProjectDirectionResolver.php
+++ b/site/src/Finance/Application/Service/PnlProjectDirectionResolver.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Finance\Application\Service;
+
+use App\Company\Entity\Company;
+use App\Company\Entity\ProjectDirection;
+use App\Company\Repository\ProjectDirectionRepository;
+use App\Finance\Exception\PnlProjectDirectionResolveException;
+
+final readonly class PnlProjectDirectionResolver
+{
+    public function __construct(private ProjectDirectionRepository $projectDirectionRepository)
+    {
+    }
+
+    public function resolveDefault(Company $company): ProjectDirection
+    {
+        $default = $this->projectDirectionRepository->findDefaultForCompany($company);
+        if ($default instanceof ProjectDirection) {
+            return $default;
+        }
+
+        $roots = $this->projectDirectionRepository->findRootByCompany($company);
+        if ([] !== $roots) {
+            return $roots[0];
+        }
+
+        throw new PnlProjectDirectionResolveException(sprintf('Default project direction was not found for company "%s".', (string) $company->getId()));
+    }
+}

--- a/site/src/Finance/Command/RebuildDirtyPnlPeriodsCommand.php
+++ b/site/src/Finance/Command/RebuildDirtyPnlPeriodsCommand.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Finance\Command;
+
+use App\Finance\Message\RebuildPnlPeriodMessage;
+use App\Ingestion\Entity\PLDirtyPeriod;
+use App\Ingestion\Repository\PLDirtyPeriodRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[AsCommand(
+    name: 'app:finance:rebuild-dirty-pnl-periods',
+    description: 'Dispatches async rebuild jobs for pending dirty P&L periods.',
+)]
+final class RebuildDirtyPnlPeriodsCommand extends Command
+{
+    public function __construct(
+        private readonly PLDirtyPeriodRepository $dirtyPeriodRepository,
+        private readonly MessageBusInterface $messageBus,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('max', null, InputOption::VALUE_REQUIRED, 'Maximum number of periods to dispatch.', 20);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $max = max(1, min(200, (int) $input->getOption('max')));
+        $periods = $this->dirtyPeriodRepository->findPending($max);
+
+        foreach ($periods as $period) {
+            if (!$period instanceof PLDirtyPeriod) {
+                continue;
+            }
+
+            $this->messageBus->dispatch(new RebuildPnlPeriodMessage(
+                companyId: $period->getCompanyId(),
+                year: $period->getPeriodYear(),
+                month: $period->getPeriodMonth(),
+                shopRef: $period->getShopRef(),
+            ));
+        }
+
+        $io->success(sprintf('Dispatched %d P&L rebuild jobs.', count($periods)));
+
+        return Command::SUCCESS;
+    }
+}

--- a/site/src/Finance/Domain/Event/PnlClosedPeriodTouchedEvent.php
+++ b/site/src/Finance/Domain/Event/PnlClosedPeriodTouchedEvent.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Finance\Domain\Event;
+
+use Webmozart\Assert\Assert;
+
+final readonly class PnlClosedPeriodTouchedEvent
+{
+    public function __construct(
+        public string $companyId,
+        public int $year,
+        public int $month,
+        public string $shopRef,
+        public string $reason,
+    ) {
+        Assert::uuid($this->companyId);
+        Assert::range($this->year, 2020, 2100);
+        Assert::range($this->month, 1, 12);
+        Assert::notEmpty($this->reason);
+    }
+}

--- a/site/src/Finance/Entity/PLDailyTotal.php
+++ b/site/src/Finance/Entity/PLDailyTotal.php
@@ -48,6 +48,9 @@ class PLDailyTotal
     #[ORM\Column(type: 'datetime_immutable')]
     private \DateTimeImmutable $updatedAt;
 
+    #[ORM\Column(type: 'datetime_immutable', precision: 6, nullable: true)]
+    private ?\DateTimeImmutable $rebuiltAt = null;
+
     public function __construct(string $id, Company $company, ProjectDirection $projectDirection, \DateTimeImmutable $date, ?PLCategory $category)
     {
         Assert::uuid($id);
@@ -157,6 +160,18 @@ class PLDailyTotal
     public function setUpdatedAt(\DateTimeImmutable $updatedAt): self
     {
         $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+
+    public function getRebuiltAt(): ?\DateTimeImmutable
+    {
+        return $this->rebuiltAt;
+    }
+
+    public function setRebuiltAt(\DateTimeImmutable $rebuiltAt): self
+    {
+        $this->rebuiltAt = $rebuiltAt;
 
         return $this;
     }

--- a/site/src/Finance/Entity/PLMonthlySnapshot.php
+++ b/site/src/Finance/Entity/PLMonthlySnapshot.php
@@ -39,6 +39,9 @@ class PLMonthlySnapshot
     #[ORM\Column(type: 'datetime_immutable')]
     private \DateTimeImmutable $updatedAt;
 
+    #[ORM\Column(type: 'datetime_immutable', precision: 6, nullable: true)]
+    private ?\DateTimeImmutable $rebuiltAt = null;
+
     public function __construct(string $id, Company $company, string $period, ?PLCategory $category)
     {
         Assert::uuid($id);
@@ -122,6 +125,18 @@ class PLMonthlySnapshot
     public function setUpdatedAt(\DateTimeImmutable $updatedAt): self
     {
         $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+
+    public function getRebuiltAt(): ?\DateTimeImmutable
+    {
+        return $this->rebuiltAt;
+    }
+
+    public function setRebuiltAt(\DateTimeImmutable $rebuiltAt): self
+    {
+        $this->rebuiltAt = $rebuiltAt;
 
         return $this;
     }

--- a/site/src/Finance/EventSubscriber/NormalizationCompletedSubscriber.php
+++ b/site/src/Finance/EventSubscriber/NormalizationCompletedSubscriber.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Finance\EventSubscriber;
+
+use App\Finance\Application\Service\PnlPeriodResolver;
+use App\Finance\Message\MarkPnlPeriodDirtyMessage;
+use App\Ingestion\Domain\Event\AffectedPeriod;
+use App\Ingestion\Domain\Event\NormalizationCompletedEvent;
+use App\Ingestion\Enum\PLDirtyPeriodReason;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final readonly class NormalizationCompletedSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private PnlPeriodResolver $periodResolver,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    /**
+     * @return array<class-string, string>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            NormalizationCompletedEvent::class => 'onNormalizationCompleted',
+        ];
+    }
+
+    public function onNormalizationCompleted(NormalizationCompletedEvent $event): void
+    {
+        $dispatched = [];
+
+        foreach ($event->affectedPeriods as $period) {
+            if (!$period instanceof AffectedPeriod) {
+                continue;
+            }
+
+            [$newYear, $newMonth] = $this->periodResolver->from($period->newOccurredAt);
+            $this->dispatchOnce($dispatched, $event->companyId, $newYear, $newMonth, $period->shopRef, PLDirtyPeriodReason::INGEST);
+
+            if (null === $period->oldOccurredAt) {
+                continue;
+            }
+
+            [$oldYear, $oldMonth] = $this->periodResolver->from($period->oldOccurredAt);
+            if ($oldYear !== $newYear || $oldMonth !== $newMonth) {
+                $this->dispatchOnce($dispatched, $event->companyId, $oldYear, $oldMonth, $period->shopRef, PLDirtyPeriodReason::MONTH_CHANGE);
+            }
+        }
+    }
+
+    /**
+     * @param array<string, true> $dispatched
+     */
+    private function dispatchOnce(
+        array &$dispatched,
+        string $companyId,
+        int $year,
+        int $month,
+        string $shopRef,
+        PLDirtyPeriodReason $reason,
+    ): void {
+        $key = sprintf('%s:%04d-%02d:%s', $companyId, $year, $month, $shopRef);
+        if (isset($dispatched[$key])) {
+            return;
+        }
+
+        $dispatched[$key] = true;
+        $this->messageBus->dispatch(new MarkPnlPeriodDirtyMessage(
+            companyId: $companyId,
+            year: $year,
+            month: $month,
+            shopRef: $shopRef,
+            reasonValue: $reason->value,
+        ));
+    }
+}

--- a/site/src/Finance/Exception/PnlCategoryResolveException.php
+++ b/site/src/Finance/Exception/PnlCategoryResolveException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Finance\Exception;
+
+final class PnlCategoryResolveException extends \RuntimeException
+{
+}

--- a/site/src/Finance/Exception/PnlProjectDirectionResolveException.php
+++ b/site/src/Finance/Exception/PnlProjectDirectionResolveException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Finance\Exception;
+
+final class PnlProjectDirectionResolveException extends \RuntimeException
+{
+}

--- a/site/src/Finance/Exception/PnlRebuildLockTimeoutException.php
+++ b/site/src/Finance/Exception/PnlRebuildLockTimeoutException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Finance\Exception;
+
+final class PnlRebuildLockTimeoutException extends \RuntimeException
+{
+}

--- a/site/src/Finance/Facade/PnlFacade.php
+++ b/site/src/Finance/Facade/PnlFacade.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Finance\Facade;
+
+use App\Finance\Application\Action\MarkPnlPeriodDirtyAction;
+use App\Finance\Application\Action\RebuildPnlPeriodAction;
+use App\Finance\Application\Command\MarkPnlPeriodDirtyCommand;
+use App\Finance\Application\Command\RebuildPnlPeriodCommand;
+use App\Finance\Application\DTO\PnlProgressView;
+use App\Ingestion\Application\DTO\PLDirtyPeriodView;
+use App\Ingestion\Enum\PLDirtyPeriodStatus;
+use App\Ingestion\Repository\PLDirtyPeriodRepository;
+
+final readonly class PnlFacade
+{
+    public function __construct(
+        private MarkPnlPeriodDirtyAction $markDirtyAction,
+        private RebuildPnlPeriodAction $rebuildAction,
+        private PLDirtyPeriodRepository $dirtyPeriodRepository,
+    ) {
+    }
+
+    public function markPeriodDirty(MarkPnlPeriodDirtyCommand $command): void
+    {
+        ($this->markDirtyAction)($command);
+    }
+
+    public function rebuildPeriod(RebuildPnlPeriodCommand $command): void
+    {
+        ($this->rebuildAction)($command);
+    }
+
+    /**
+     * @return list<PLDirtyPeriodView>
+     */
+    public function getDirtyPeriods(string $companyId): array
+    {
+        return array_map(
+            static fn ($period): PLDirtyPeriodView => PLDirtyPeriodView::fromEntity($period),
+            $this->dirtyPeriodRepository->findForCompany($companyId),
+        );
+    }
+
+    public function getProgress(string $companyId): PnlProgressView
+    {
+        return new PnlProgressView(
+            pending: $this->dirtyPeriodRepository->countByStatus($companyId, PLDirtyPeriodStatus::PENDING),
+            rebuilding: $this->dirtyPeriodRepository->countByStatus($companyId, PLDirtyPeriodStatus::REBUILDING),
+            done: $this->dirtyPeriodRepository->countByStatus($companyId, PLDirtyPeriodStatus::DONE),
+            failed: $this->dirtyPeriodRepository->countByStatus($companyId, PLDirtyPeriodStatus::FAILED),
+            blockedByClose: $this->dirtyPeriodRepository->countByStatus($companyId, PLDirtyPeriodStatus::BLOCKED_BY_CLOSE),
+        );
+    }
+}

--- a/site/src/Finance/Message/MarkPnlPeriodDirtyMessage.php
+++ b/site/src/Finance/Message/MarkPnlPeriodDirtyMessage.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Finance\Message;
+
+use App\Ingestion\Enum\PLDirtyPeriodReason;
+use App\Ingestion\Message\CompanyAwareMessage;
+use Webmozart\Assert\Assert;
+
+final readonly class MarkPnlPeriodDirtyMessage implements CompanyAwareMessage
+{
+    public function __construct(
+        public string $companyId,
+        public int $year,
+        public int $month,
+        public string $shopRef,
+        public string $reasonValue,
+    ) {
+        Assert::uuid($this->companyId);
+        Assert::range($this->year, 2020, 2100);
+        Assert::range($this->month, 1, 12);
+        PLDirtyPeriodReason::from($this->reasonValue);
+    }
+
+    public function getCompanyId(): string
+    {
+        return $this->companyId;
+    }
+}

--- a/site/src/Finance/Message/RebuildPnlPeriodMessage.php
+++ b/site/src/Finance/Message/RebuildPnlPeriodMessage.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Finance\Message;
+
+use App\Ingestion\Message\CompanyAwareMessage;
+use Webmozart\Assert\Assert;
+
+final readonly class RebuildPnlPeriodMessage implements CompanyAwareMessage
+{
+    public function __construct(
+        public string $companyId,
+        public int $year,
+        public int $month,
+        public string $shopRef = '',
+    ) {
+        Assert::uuid($this->companyId);
+        Assert::range($this->year, 2020, 2100);
+        Assert::range($this->month, 1, 12);
+    }
+
+    public function getCompanyId(): string
+    {
+        return $this->companyId;
+    }
+}

--- a/site/src/Finance/MessageHandler/MarkPnlPeriodDirtyHandler.php
+++ b/site/src/Finance/MessageHandler/MarkPnlPeriodDirtyHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Finance\MessageHandler;
+
+use App\Finance\Application\Action\MarkPnlPeriodDirtyAction;
+use App\Finance\Application\Command\MarkPnlPeriodDirtyCommand;
+use App\Finance\Message\MarkPnlPeriodDirtyMessage;
+use App\Ingestion\Enum\PLDirtyPeriodReason;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+final readonly class MarkPnlPeriodDirtyHandler
+{
+    public function __construct(private MarkPnlPeriodDirtyAction $action)
+    {
+    }
+
+    public function __invoke(MarkPnlPeriodDirtyMessage $message): void
+    {
+        ($this->action)(new MarkPnlPeriodDirtyCommand(
+            companyId: $message->companyId,
+            year: $message->year,
+            month: $message->month,
+            shopRef: $message->shopRef,
+            reason: PLDirtyPeriodReason::from($message->reasonValue),
+        ));
+    }
+}

--- a/site/src/Finance/MessageHandler/RebuildPnlPeriodHandler.php
+++ b/site/src/Finance/MessageHandler/RebuildPnlPeriodHandler.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Finance\MessageHandler;
+
+use App\Finance\Application\Action\RebuildPnlPeriodAction;
+use App\Finance\Application\Command\RebuildPnlPeriodCommand;
+use App\Finance\Message\RebuildPnlPeriodMessage;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+final readonly class RebuildPnlPeriodHandler
+{
+    public function __construct(private RebuildPnlPeriodAction $action)
+    {
+    }
+
+    public function __invoke(RebuildPnlPeriodMessage $message): void
+    {
+        ($this->action)(new RebuildPnlPeriodCommand(
+            companyId: $message->companyId,
+            year: $message->year,
+            month: $message->month,
+            shopRef: $message->shopRef,
+        ));
+    }
+}

--- a/site/src/Finance/Repository/PLDailyTotalRepository.php
+++ b/site/src/Finance/Repository/PLDailyTotalRepository.php
@@ -10,6 +10,7 @@ use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Persistence\ManagerRegistry;
 use Ramsey\Uuid\Uuid;
+use Webmozart\Assert\Assert;
 
 class PLDailyTotalRepository extends ServiceEntityRepository
 {
@@ -57,6 +58,7 @@ class PLDailyTotalRepository extends ServiceEntityRepository
         string $amountExpense,
         bool $replace,
         ?\DateTimeImmutable $timestamp = null,
+        ?\DateTimeImmutable $rebuiltAt = null,
     ): void {
         $timestamp ??= new \DateTimeImmutable();
 
@@ -64,12 +66,13 @@ class PLDailyTotalRepository extends ServiceEntityRepository
 
         $sql = sprintf(
             <<<'SQL'
-INSERT INTO pl_daily_totals (id, company_id, pl_category_id, date, project_direction_id, amount_income, amount_expense, created_at, updated_at)
-VALUES (:id, :company_id, :category_id, :date, :project_direction_id, :amount_income, :amount_expense, :created_at, :updated_at)
+INSERT INTO pl_daily_totals (id, company_id, pl_category_id, date, project_direction_id, amount_income, amount_expense, created_at, updated_at, rebuilt_at)
+VALUES (:id, :company_id, :category_id, :date, :project_direction_id, :amount_income, :amount_expense, :created_at, :updated_at, :rebuilt_at)
 ON CONFLICT (company_id, pl_category_id, date, project_direction_id) DO UPDATE SET
     amount_income = %s,
     amount_expense = %s,
-    updated_at = EXCLUDED.updated_at
+    updated_at = EXCLUDED.updated_at,
+    rebuilt_at = EXCLUDED.rebuilt_at
 SQL,
             $replace ? 'EXCLUDED.amount_income' : 'pl_daily_totals.amount_income + EXCLUDED.amount_income',
             $replace ? 'EXCLUDED.amount_expense' : 'pl_daily_totals.amount_expense + EXCLUDED.amount_expense',
@@ -87,6 +90,7 @@ SQL,
                 'amount_expense' => $amountExpense,
                 'created_at' => $timestamp,
                 'updated_at' => $timestamp,
+                'rebuilt_at' => $rebuiltAt,
             ],
             [
                 'id' => Types::GUID,
@@ -96,6 +100,40 @@ SQL,
                 'project_direction_id' => Types::GUID,
                 'created_at' => Types::DATETIME_IMMUTABLE,
                 'updated_at' => Types::DATETIME_IMMUTABLE,
+                'rebuilt_at' => Types::DATETIME_IMMUTABLE,
+            ],
+        );
+    }
+
+    public function deleteByCompanyShopAndMonth(string $companyId, string $shopRef, int $year, int $month): int
+    {
+        Assert::uuid($companyId);
+        Assert::range($year, 2020, 2100);
+        Assert::range($month, 1, 12);
+
+        if ('' !== $shopRef) {
+            throw new \LogicException('Shop-scoped P&L daily delete is not available: pl_daily_totals has no shop_ref column.');
+        }
+
+        $from = new \DateTimeImmutable(sprintf('%04d-%02d-01', $year, $month));
+        $toExclusive = $from->modify('first day of next month');
+
+        return $this->getEntityManager()->getConnection()->executeStatement(
+            <<<'SQL'
+DELETE FROM pl_daily_totals
+WHERE company_id = :company_id
+  AND date >= :from
+  AND date < :to_exclusive
+SQL,
+            [
+                'company_id' => $companyId,
+                'from' => $from,
+                'to_exclusive' => $toExclusive,
+            ],
+            [
+                'company_id' => Types::GUID,
+                'from' => Types::DATE_IMMUTABLE,
+                'to_exclusive' => Types::DATE_IMMUTABLE,
             ],
         );
     }

--- a/site/src/Finance/Repository/PLMonthlySnapshotRepository.php
+++ b/site/src/Finance/Repository/PLMonthlySnapshotRepository.php
@@ -9,6 +9,7 @@ use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Persistence\ManagerRegistry;
 use Ramsey\Uuid\Uuid;
+use Webmozart\Assert\Assert;
 
 class PLMonthlySnapshotRepository extends ServiceEntityRepository
 {
@@ -24,19 +25,27 @@ class PLMonthlySnapshotRepository extends ServiceEntityRepository
         string $amountIncome,
         string $amountExpense,
         ?\DateTimeImmutable $updatedAt = null,
+        ?\DateTimeImmutable $rebuiltAt = null,
+        bool $accumulate = false,
     ): void {
         $updatedAt ??= new \DateTimeImmutable();
 
         $connection = $this->getEntityManager()->getConnection();
 
         $sql = <<<'SQL'
-INSERT INTO pl_monthly_snapshots (id, company_id, pl_category_id, period, amount_income, amount_expense, updated_at)
-VALUES (:id, :company_id, :category_id, :period, :amount_income, :amount_expense, :updated_at)
+INSERT INTO pl_monthly_snapshots (id, company_id, pl_category_id, period, amount_income, amount_expense, updated_at, rebuilt_at)
+VALUES (:id, :company_id, :category_id, :period, :amount_income, :amount_expense, :updated_at, :rebuilt_at)
 ON CONFLICT (company_id, pl_category_id, period) DO UPDATE SET
-    amount_income = EXCLUDED.amount_income,
-    amount_expense = EXCLUDED.amount_expense,
-    updated_at = EXCLUDED.updated_at
+    amount_income = %s,
+    amount_expense = %s,
+    updated_at = EXCLUDED.updated_at,
+    rebuilt_at = EXCLUDED.rebuilt_at
 SQL;
+        $sql = sprintf(
+            $sql,
+            $accumulate ? 'pl_monthly_snapshots.amount_income + EXCLUDED.amount_income' : 'EXCLUDED.amount_income',
+            $accumulate ? 'pl_monthly_snapshots.amount_expense + EXCLUDED.amount_expense' : 'EXCLUDED.amount_expense',
+        );
 
         $connection->executeStatement(
             $sql,
@@ -48,6 +57,7 @@ SQL;
                 'amount_income' => $amountIncome,
                 'amount_expense' => $amountExpense,
                 'updated_at' => $updatedAt,
+                'rebuilt_at' => $rebuiltAt,
             ],
             [
                 'id' => Types::GUID,
@@ -55,6 +65,34 @@ SQL;
                 'category_id' => Types::GUID,
                 'period' => Types::STRING,
                 'updated_at' => Types::DATETIME_IMMUTABLE,
+                'rebuilt_at' => Types::DATETIME_IMMUTABLE,
+            ],
+        );
+    }
+
+    public function deleteByCompanyShopAndMonth(string $companyId, string $shopRef, int $year, int $month): int
+    {
+        Assert::uuid($companyId);
+        Assert::range($year, 2020, 2100);
+        Assert::range($month, 1, 12);
+
+        if ('' !== $shopRef) {
+            throw new \LogicException('Shop-scoped P&L monthly delete is not available: pl_monthly_snapshots has no shop_ref column.');
+        }
+
+        return $this->getEntityManager()->getConnection()->executeStatement(
+            <<<'SQL'
+DELETE FROM pl_monthly_snapshots
+WHERE company_id = :company_id
+  AND period = :period
+SQL,
+            [
+                'company_id' => $companyId,
+                'period' => sprintf('%04d-%02d', $year, $month),
+            ],
+            [
+                'company_id' => Types::GUID,
+                'period' => Types::STRING,
             ],
         );
     }

--- a/site/src/Ingestion/Application/Action/MarkJobCompletedAction.php
+++ b/site/src/Ingestion/Application/Action/MarkJobCompletedAction.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Action;
+
+use App\Ingestion\Application\Command\MarkJobCompletedCommand;
+use App\Ingestion\Exception\SyncJobNotFoundException;
+use App\Ingestion\Repository\SyncJobRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class MarkJobCompletedAction
+{
+    public function __construct(
+        private SyncJobRepository $syncJobRepository,
+        private MaybeFinalizeParentAction $maybeFinalizeParentAction,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function __invoke(MarkJobCompletedCommand $command): void
+    {
+        $job = $this->syncJobRepository->findByIdAndCompany($command->jobId, $command->companyId);
+        if (null === $job) {
+            throw new SyncJobNotFoundException('Sync job was not found.');
+        }
+
+        $job->markCompleted();
+        $this->entityManager->flush();
+
+        if (null !== $job->getParentJobId()) {
+            ($this->maybeFinalizeParentAction)($job->getParentJobId(), $command->companyId);
+            $this->entityManager->flush();
+        }
+    }
+}

--- a/site/src/Ingestion/Application/Action/MarkJobFailedAction.php
+++ b/site/src/Ingestion/Application/Action/MarkJobFailedAction.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Action;
+
+use App\Ingestion\Application\Command\MarkJobFailedCommand;
+use App\Ingestion\Exception\SyncJobNotFoundException;
+use App\Ingestion\Repository\SyncJobRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class MarkJobFailedAction
+{
+    public function __construct(
+        private SyncJobRepository $syncJobRepository,
+        private MaybeFinalizeParentAction $maybeFinalizeParentAction,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function __invoke(MarkJobFailedCommand $command): void
+    {
+        $job = $this->syncJobRepository->findByIdAndCompany($command->jobId, $command->companyId);
+        if (null === $job) {
+            throw new SyncJobNotFoundException('Sync job was not found.');
+        }
+
+        $job->markFailed($command->reason);
+        $this->entityManager->flush();
+
+        if (null !== $job->getParentJobId()) {
+            ($this->maybeFinalizeParentAction)($job->getParentJobId(), $command->companyId);
+            $this->entityManager->flush();
+        }
+    }
+}

--- a/site/src/Ingestion/Application/Action/MarkJobRunningAction.php
+++ b/site/src/Ingestion/Application/Action/MarkJobRunningAction.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Action;
+
+use App\Ingestion\Application\Command\MarkJobRunningCommand;
+use App\Ingestion\Exception\SyncJobNotFoundException;
+use App\Ingestion\Repository\SyncJobRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class MarkJobRunningAction
+{
+    public function __construct(
+        private SyncJobRepository $syncJobRepository,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function __invoke(MarkJobRunningCommand $command): void
+    {
+        $job = $this->syncJobRepository->findByIdAndCompany($command->jobId, $command->companyId);
+        if (null === $job) {
+            throw new SyncJobNotFoundException('Sync job was not found.');
+        }
+
+        if (null !== $command->cursorSnapshot && null === $job->getCursorSnapshot()) {
+            $job->setCursorSnapshot($command->cursorSnapshot);
+        }
+
+        $job->markRunning();
+        $this->entityManager->flush();
+    }
+}

--- a/site/src/Ingestion/Application/Action/MaybeFinalizeParentAction.php
+++ b/site/src/Ingestion/Application/Action/MaybeFinalizeParentAction.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Action;
+
+use App\Ingestion\Enum\SyncJobStatus;
+use App\Ingestion\Exception\SyncJobNotFoundException;
+use App\Ingestion\Repository\SyncJobRepository;
+
+final readonly class MaybeFinalizeParentAction
+{
+    public function __construct(private SyncJobRepository $syncJobRepository)
+    {
+    }
+
+    public function __invoke(string $parentJobId, string $companyId): void
+    {
+        $parent = $this->syncJobRepository->findByIdAndCompany($parentJobId, $companyId);
+        if (null === $parent) {
+            throw new SyncJobNotFoundException('Parent sync job was not found.');
+        }
+
+        $completed = $this->syncJobRepository->countChildrenByStatus($parentJobId, $companyId, SyncJobStatus::COMPLETED);
+        $failed = $this->syncJobRepository->countChildrenByStatus($parentJobId, $companyId, SyncJobStatus::FAILED);
+        $cancelled = $this->syncJobRepository->countChildrenByStatus($parentJobId, $companyId, SyncJobStatus::CANCELLED);
+        $terminal = $completed + $failed + $cancelled;
+
+        if ($parent->getProgressTotal() <= 0 || $terminal < $parent->getProgressTotal()) {
+            if ($terminal > $parent->getProgressDone()) {
+                $parent->incrementProgress($terminal - $parent->getProgressDone());
+            }
+
+            return;
+        }
+
+        if ($terminal > $parent->getProgressDone()) {
+            $parent->incrementProgress($terminal - $parent->getProgressDone());
+        }
+
+        if (SyncJobStatus::OPEN === $parent->getStatus()) {
+            $parent->markRunning();
+        }
+
+        if (0 === $failed && 0 === $cancelled) {
+            $parent->markCompleted();
+
+            return;
+        }
+
+        $parent->markFailed(sprintf('partial failure: %d failed, %d cancelled, %d completed', $failed, $cancelled, $completed));
+    }
+}

--- a/site/src/Ingestion/Application/Action/NormalizeRawRecordAction.php
+++ b/site/src/Ingestion/Application/Action/NormalizeRawRecordAction.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Action;
+
+use App\Ingestion\Application\Command\NormalizeRawRecordCommand;
+use App\Ingestion\Application\Command\RecordNormalizationIssueCommand;
+use App\Ingestion\Application\Command\UpsertFinancialTransactionCommand;
+use App\Ingestion\Application\DTO\MappedControlSum;
+use App\Ingestion\Domain\Contract\RawRecordAwareControlSumMapperInterface;
+use App\Ingestion\Domain\Event\AffectedPeriod;
+use App\Ingestion\Domain\Event\NormalizationCompletedEvent;
+use App\Ingestion\Domain\Service\MapperRegistry;
+use App\Ingestion\Enum\NormalizationIssueKind;
+use App\Ingestion\Enum\RawNormalizationStatus;
+use App\Ingestion\Exception\RawRecordNotFoundException;
+use App\Ingestion\Facade\RawStorageFacade;
+use App\Ingestion\Repository\CounterpartyRepository;
+use App\Ingestion\Repository\FinancialTransactionRepository;
+use App\Ingestion\Repository\IngestRawRecordRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+final readonly class NormalizeRawRecordAction
+{
+    public function __construct(
+        private IngestRawRecordRepository $rawRecordRepository,
+        private RawStorageFacade $rawStorageFacade,
+        private MapperRegistry $mapperRegistry,
+        private CounterpartyRepository $counterpartyRepository,
+        private FinancialTransactionRepository $financialTransactionRepository,
+        private UpsertFinancialTransactionAction $upsertFinancialTransactionAction,
+        private RecordNormalizationIssueAction $recordNormalizationIssueAction,
+        private EntityManagerInterface $entityManager,
+        private EventDispatcherInterface $eventDispatcher,
+    ) {
+    }
+
+    public function __invoke(NormalizeRawRecordCommand $command): void
+    {
+        $event = null;
+        $connection = $this->entityManager->getConnection();
+        $connection->beginTransaction();
+
+        try {
+            $rawRecord = $this->rawRecordRepository->findByIdAndCompany($command->rawRecordId, $command->companyId);
+            if (null === $rawRecord) {
+                throw new RawRecordNotFoundException('Raw record not found for requested company.');
+            }
+
+            if (RawNormalizationStatus::DONE === $rawRecord->getNormalizationStatus()) {
+                $connection->commit();
+
+                return;
+            }
+
+            $mapper = $this->mapperRegistry->get($rawRecord->getSource(), $rawRecord->getResourceType());
+            /** @var list<array<string, mixed>> $rows */
+            $rows = array_values(iterator_to_array($this->rawStorageFacade->read($rawRecord->getId(), $command->companyId), false));
+
+            try {
+                $mappedTransactions = $mapper->map($rawRecord, $rows);
+                $controlSums = $mapper instanceof RawRecordAwareControlSumMapperInterface
+                    ? $mapper->controlSumForRawRecord($rawRecord, $rows)
+                    : $mapper->controlSum($rows);
+            } catch (\Throwable $exception) {
+                ($this->recordNormalizationIssueAction)(new RecordNormalizationIssueCommand(
+                    companyId: $command->companyId,
+                    rawRecordId: $rawRecord->getId(),
+                    operationGroupId: null,
+                    kind: NormalizationIssueKind::MAPPER_FAILURE,
+                    details: [
+                        'exceptionClass' => $exception::class,
+                        'message' => $exception->getMessage(),
+                    ],
+                ));
+                $rawRecord->markNormalizationFailed();
+                $this->entityManager->flush();
+                $connection->commit();
+
+                return;
+            }
+
+            $affectedPeriods = [];
+            foreach ($mappedTransactions as $mappedTransaction) {
+                $counterpartyId = null;
+                if (null !== $mappedTransaction->counterpartyExternalKey) {
+                    $counterparty = $this->counterpartyRepository->getOrCreate(
+                        $command->companyId,
+                        $rawRecord->getSource(),
+                        $mappedTransaction->counterpartyExternalKey,
+                        $mappedTransaction->counterpartyName ?? $mappedTransaction->counterpartyExternalKey,
+                    );
+                    $counterpartyId = $counterparty->getId();
+                }
+
+                $result = ($this->upsertFinancialTransactionAction)(new UpsertFinancialTransactionCommand(
+                    companyId: $command->companyId,
+                    connectionRef: $rawRecord->getConnectionRef(),
+                    shopRef: $rawRecord->getShopRef(),
+                    source: $rawRecord->getSource(),
+                    mapped: $mappedTransaction,
+                    rawRecordId: $rawRecord->getId(),
+                    counterpartyId: $counterpartyId,
+                ));
+
+                if (null !== $result) {
+                    $affectedPeriods[] = new AffectedPeriod(
+                        shopRef: $rawRecord->getShopRef(),
+                        oldOccurredAt: $result->oldOccurredAt,
+                        newOccurredAt: $result->newOccurredAt,
+                    );
+                }
+            }
+
+            $this->entityManager->flush();
+            $this->recordControlSumIssues($command->companyId, $rawRecord->getId(), $controlSums);
+            $rawRecord->markNormalizationDone();
+            $this->entityManager->flush();
+            $connection->commit();
+
+            $event = new NormalizationCompletedEvent(
+                companyId: $command->companyId,
+                rawRecordId: $rawRecord->getId(),
+                affectedPeriods: $affectedPeriods,
+            );
+        } catch (\Throwable $exception) {
+            if ($connection->isTransactionActive()) {
+                $connection->rollBack();
+            }
+
+            throw $exception;
+        }
+
+        if (null !== $event) {
+            $this->eventDispatcher->dispatch($event);
+        }
+    }
+
+    /**
+     * @param list<MappedControlSum> $controlSums
+     */
+    private function recordControlSumIssues(string $companyId, string $rawRecordId, array $controlSums): void
+    {
+        foreach ($controlSums as $controlSum) {
+            $transactions = $this->financialTransactionRepository->findByOperationGroup($companyId, $controlSum->operationGroupId);
+            $actualAmountMinor = 0;
+            $hasCurrencyMismatch = false;
+
+            foreach ($transactions as $transaction) {
+                if ($transaction->getCurrency() !== $controlSum->currency) {
+                    $hasCurrencyMismatch = true;
+                    continue;
+                }
+
+                $actualAmountMinor += $transaction->getAmountMinor();
+            }
+
+            if ($hasCurrencyMismatch) {
+                ($this->recordNormalizationIssueAction)(new RecordNormalizationIssueCommand(
+                    companyId: $companyId,
+                    rawRecordId: $rawRecordId,
+                    operationGroupId: $controlSum->operationGroupId,
+                    kind: NormalizationIssueKind::CURRENCY_MISMATCH,
+                    details: [
+                        'expectedCurrency' => $controlSum->currency,
+                        'operationGroupId' => $controlSum->operationGroupId,
+                    ],
+                ));
+            }
+
+            if ($actualAmountMinor !== $controlSum->amountMinor) {
+                ($this->recordNormalizationIssueAction)(new RecordNormalizationIssueCommand(
+                    companyId: $companyId,
+                    rawRecordId: $rawRecordId,
+                    operationGroupId: $controlSum->operationGroupId,
+                    kind: NormalizationIssueKind::SUM_MISMATCH,
+                    details: [
+                        'expectedAmountMinor' => $controlSum->amountMinor,
+                        'actualAmountMinor' => $actualAmountMinor,
+                        'currency' => $controlSum->currency,
+                        'operationGroupId' => $controlSum->operationGroupId,
+                    ],
+                ));
+            }
+        }
+    }
+}

--- a/site/src/Ingestion/Application/Action/RecordNormalizationIssueAction.php
+++ b/site/src/Ingestion/Application/Action/RecordNormalizationIssueAction.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Action;
+
+use App\Ingestion\Application\Command\RecordNormalizationIssueCommand;
+use App\Ingestion\Entity\NormalizationIssue;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+
+final readonly class RecordNormalizationIssueAction
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(RecordNormalizationIssueCommand $command): void
+    {
+        $issue = new NormalizationIssue(
+            companyId: $command->companyId,
+            rawRecordId: $command->rawRecordId,
+            operationGroupId: $command->operationGroupId,
+            kind: $command->kind,
+            details: $command->details,
+        );
+
+        $this->entityManager->persist($issue);
+
+        $this->logger->warning('Ingestion normalization issue recorded.', [
+            'companyId' => $command->companyId,
+            'rawRecordId' => $command->rawRecordId,
+            'operationGroupId' => $command->operationGroupId,
+            'kind' => $command->kind->value,
+        ]);
+    }
+}

--- a/site/src/Ingestion/Application/Action/SplitJobIntoChunksAction.php
+++ b/site/src/Ingestion/Application/Action/SplitJobIntoChunksAction.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Action;
+
+use App\Ingestion\Application\Command\SplitJobCommand;
+use App\Ingestion\Entity\SyncJob;
+use App\Ingestion\Enum\SyncJobKind;
+use App\Ingestion\Exception\InvalidJobForSplitException;
+use App\Ingestion\Exception\JobAlreadySplitException;
+use App\Ingestion\Exception\SyncJobNotFoundException;
+use App\Ingestion\Message\RunSyncChunkMessage;
+use App\Ingestion\Repository\SyncJobRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final readonly class SplitJobIntoChunksAction
+{
+    public function __construct(
+        private SyncJobRepository $syncJobRepository,
+        private EntityManagerInterface $entityManager,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function __invoke(SplitJobCommand $command): array
+    {
+        $parent = $this->syncJobRepository->findByIdAndCompany($command->parentJobId, $command->companyId);
+        if (null === $parent) {
+            throw new SyncJobNotFoundException('Sync job was not found.');
+        }
+
+        if (SyncJobKind::BACKFILL !== $parent->getKind() || null === $parent->getWindowFrom() || null === $parent->getWindowTo()) {
+            throw new InvalidJobForSplitException('Sync job cannot be split into chunks.');
+        }
+
+        if ($parent->getProgressTotal() > 0) {
+            throw new JobAlreadySplitException('Sync job is already split into chunks.');
+        }
+
+        $chunkIds = [];
+        foreach ($this->buildWindows($parent->getWindowFrom(), $parent->getWindowTo(), $command->chunkSizeInDays) as [$from, $to]) {
+            $chunk = new SyncJob(
+                companyId: $parent->getCompanyId(),
+                connectionRef: $parent->getConnectionRef(),
+                source: $parent->getSource(),
+                resourceType: $parent->getResourceType(),
+                kind: SyncJobKind::BACKFILL,
+                windowFrom: $from,
+                windowTo: $to,
+                shopRef: $parent->getShopRef(),
+                parentJobId: $parent->getId(),
+            );
+
+            $this->entityManager->persist($chunk);
+            $chunkIds[] = $chunk->getId();
+        }
+
+        $parent->setProgressTotal(count($chunkIds));
+        $parent->markRunning();
+        $this->entityManager->flush();
+
+        foreach ($chunkIds as $chunkId) {
+            $this->messageBus->dispatch(new RunSyncChunkMessage($command->companyId, $chunkId));
+        }
+
+        return $chunkIds;
+    }
+
+    /**
+     * @return list<array{0: \DateTimeImmutable, 1: \DateTimeImmutable}>
+     */
+    private function buildWindows(\DateTimeImmutable $from, \DateTimeImmutable $to, int $chunkSizeInDays): array
+    {
+        $windows = [];
+        $cursor = $from->setTime(0, 0);
+        $lastDay = $to->setTime(0, 0);
+
+        while ($cursor <= $lastDay) {
+            $chunkTo = $cursor->modify(sprintf('+%d days', $chunkSizeInDays - 1));
+            if ($chunkTo > $lastDay) {
+                $chunkTo = $lastDay;
+            }
+
+            $windows[] = [$cursor, $chunkTo];
+            $cursor = $chunkTo->modify('+1 day');
+        }
+
+        return $windows;
+    }
+}

--- a/site/src/Ingestion/Application/Action/StartBackfillAction.php
+++ b/site/src/Ingestion/Application/Action/StartBackfillAction.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Action;
+
+use App\Ingestion\Application\Command\StartBackfillCommand;
+use App\Ingestion\Entity\SyncJob;
+use App\Ingestion\Enum\SyncJobKind;
+use App\Ingestion\Exception\ActiveBackfillExistsException;
+use App\Ingestion\Repository\SyncJobRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class StartBackfillAction
+{
+    public function __construct(
+        private SyncJobRepository $syncJobRepository,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function __invoke(StartBackfillCommand $command): string
+    {
+        $activeJob = $this->syncJobRepository->findLatestForResource(
+            $command->companyId,
+            $command->connectionRef,
+            $command->resourceType,
+            $command->shopRef,
+        );
+
+        if (null !== $activeJob) {
+            throw new ActiveBackfillExistsException('Backfill for requested resource is already active.');
+        }
+
+        $job = new SyncJob(
+            companyId: $command->companyId,
+            connectionRef: $command->connectionRef,
+            source: $command->source,
+            resourceType: $command->resourceType,
+            kind: SyncJobKind::BACKFILL,
+            windowFrom: $command->windowFrom,
+            windowTo: $command->windowTo,
+            shopRef: $command->shopRef,
+        );
+
+        $this->entityManager->persist($job);
+        $this->entityManager->flush();
+
+        return $job->getId();
+    }
+}

--- a/site/src/Ingestion/Application/Action/UpdateCursorAction.php
+++ b/site/src/Ingestion/Application/Action/UpdateCursorAction.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Action;
+
+use App\Ingestion\Application\Command\UpdateCursorCommand;
+use App\Ingestion\Repository\IngestCursorRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class UpdateCursorAction
+{
+    public function __construct(
+        private IngestCursorRepository $cursorRepository,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function __invoke(UpdateCursorCommand $command): void
+    {
+        $cursor = $this->cursorRepository->getOrCreate(
+            $command->companyId,
+            $command->connectionRef,
+            $command->resourceType,
+            $command->shopRef,
+        );
+
+        $cursor->advance($command->newCursorValue, $command->syncJobId, $command->fetchedAt);
+        $this->entityManager->flush();
+    }
+}

--- a/site/src/Ingestion/Application/Action/UpsertFinancialTransactionAction.php
+++ b/site/src/Ingestion/Application/Action/UpsertFinancialTransactionAction.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Action;
+
+use App\Ingestion\Application\Command\UpsertFinancialTransactionCommand;
+use App\Ingestion\Application\DTO\UpsertResult;
+use App\Ingestion\Entity\FinancialTransaction;
+use App\Ingestion\Exception\StaleTransactionUpdateException;
+use App\Ingestion\Repository\FinancialTransactionRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class UpsertFinancialTransactionAction
+{
+    public function __construct(
+        private FinancialTransactionRepository $financialTransactionRepository,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function __invoke(UpsertFinancialTransactionCommand $command): ?UpsertResult
+    {
+        $mapped = $command->mapped;
+        $transaction = $this->financialTransactionRepository->findByNaturalKey(
+            $command->companyId,
+            $command->source,
+            $mapped->externalId,
+            $mapped->type,
+        );
+
+        if (null === $transaction) {
+            $transaction = new FinancialTransaction(
+                companyId: $command->companyId,
+                connectionRef: $command->connectionRef,
+                shopRef: $command->shopRef,
+                source: $command->source,
+                externalId: $mapped->externalId,
+                externalUpdatedAt: $mapped->externalUpdatedAt,
+                operationGroupId: $mapped->operationGroupId,
+                type: $mapped->type,
+                direction: $mapped->direction,
+                money: $mapped->money,
+                occurredAt: $mapped->occurredAt,
+                rawRecordId: $command->rawRecordId,
+                orderRef: $mapped->orderRef,
+                payoutRef: $mapped->payoutRef,
+                counterpartyId: $command->counterpartyId,
+                description: $mapped->description,
+                sourceData: $mapped->sourceData,
+                sourceTz: $mapped->sourceTz,
+            );
+
+            $this->entityManager->persist($transaction);
+
+            return new UpsertResult(
+                transactionId: $transaction->getId(),
+                oldOccurredAt: null,
+                newOccurredAt: $mapped->occurredAt,
+                periodChanged: false,
+            );
+        }
+
+        $oldOccurredAt = $transaction->getOccurredAt();
+
+        try {
+            $transaction->replaceFromNewerVersion(
+                money: $mapped->money,
+                type: $mapped->type,
+                direction: $mapped->direction,
+                occurredAt: $mapped->occurredAt,
+                externalUpdatedAt: $mapped->externalUpdatedAt,
+                orderRef: $mapped->orderRef,
+                payoutRef: $mapped->payoutRef,
+                counterpartyId: $command->counterpartyId,
+                description: $mapped->description,
+                sourceData: $mapped->sourceData,
+            );
+        } catch (StaleTransactionUpdateException) {
+            return null;
+        }
+
+        return new UpsertResult(
+            transactionId: $transaction->getId(),
+            oldOccurredAt: $oldOccurredAt,
+            newOccurredAt: $mapped->occurredAt,
+            periodChanged: $oldOccurredAt != $mapped->occurredAt,
+        );
+    }
+}

--- a/site/src/Ingestion/Application/Action/UpsertFinancialTransactionAction.php
+++ b/site/src/Ingestion/Application/Action/UpsertFinancialTransactionAction.php
@@ -52,6 +52,7 @@ final readonly class UpsertFinancialTransactionAction
             );
 
             $this->entityManager->persist($transaction);
+            $this->financialTransactionRepository->cache($transaction);
 
             return new UpsertResult(
                 transactionId: $transaction->getId(),

--- a/site/src/Ingestion/Application/Command/MarkJobCompletedCommand.php
+++ b/site/src/Ingestion/Application/Command/MarkJobCompletedCommand.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Command;
+
+use Webmozart\Assert\Assert;
+
+final readonly class MarkJobCompletedCommand
+{
+    public function __construct(
+        public string $jobId,
+        public string $companyId,
+    ) {
+        Assert::uuid($this->jobId);
+        Assert::uuid($this->companyId);
+    }
+}

--- a/site/src/Ingestion/Application/Command/MarkJobFailedCommand.php
+++ b/site/src/Ingestion/Application/Command/MarkJobFailedCommand.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Command;
+
+use Webmozart\Assert\Assert;
+
+final readonly class MarkJobFailedCommand
+{
+    public function __construct(
+        public string $jobId,
+        public string $companyId,
+        public string $reason,
+    ) {
+        Assert::uuid($this->jobId);
+        Assert::uuid($this->companyId);
+        Assert::notEmpty($this->reason);
+        Assert::maxLength($this->reason, 2000);
+    }
+}

--- a/site/src/Ingestion/Application/Command/MarkJobRunningCommand.php
+++ b/site/src/Ingestion/Application/Command/MarkJobRunningCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Command;
+
+use Webmozart\Assert\Assert;
+
+final readonly class MarkJobRunningCommand
+{
+    public function __construct(
+        public string $jobId,
+        public string $companyId,
+        public ?string $cursorSnapshot = null,
+    ) {
+        Assert::uuid($this->jobId);
+        Assert::uuid($this->companyId);
+    }
+}

--- a/site/src/Ingestion/Application/Command/NormalizeRawRecordCommand.php
+++ b/site/src/Ingestion/Application/Command/NormalizeRawRecordCommand.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Command;
+
+use Webmozart\Assert\Assert;
+
+final readonly class NormalizeRawRecordCommand
+{
+    public function __construct(
+        public string $rawRecordId,
+        public string $companyId,
+    ) {
+        Assert::uuid($this->rawRecordId);
+        Assert::uuid($this->companyId);
+    }
+}

--- a/site/src/Ingestion/Application/Command/RecordNormalizationIssueCommand.php
+++ b/site/src/Ingestion/Application/Command/RecordNormalizationIssueCommand.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Command;
+
+use App\Ingestion\Enum\NormalizationIssueKind;
+use Webmozart\Assert\Assert;
+
+final readonly class RecordNormalizationIssueCommand
+{
+    /**
+     * @param array<string, mixed> $details
+     */
+    public function __construct(
+        public string $companyId,
+        public string $rawRecordId,
+        public ?string $operationGroupId,
+        public NormalizationIssueKind $kind,
+        public array $details,
+    ) {
+        Assert::uuid($this->companyId);
+        Assert::uuid($this->rawRecordId);
+
+        if (null !== $this->operationGroupId) {
+            Assert::uuid($this->operationGroupId);
+        }
+    }
+}

--- a/site/src/Ingestion/Application/Command/SplitJobCommand.php
+++ b/site/src/Ingestion/Application/Command/SplitJobCommand.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Command;
+
+use Webmozart\Assert\Assert;
+
+final readonly class SplitJobCommand
+{
+    public function __construct(
+        public string $parentJobId,
+        public string $companyId,
+        public int $chunkSizeInDays = 7,
+    ) {
+        Assert::uuid($this->parentJobId);
+        Assert::uuid($this->companyId);
+        Assert::range($this->chunkSizeInDays, 1, 90);
+    }
+}

--- a/site/src/Ingestion/Application/Command/StartBackfillCommand.php
+++ b/site/src/Ingestion/Application/Command/StartBackfillCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Command;
+
+use App\Ingestion\Enum\IngestSource;
+use Webmozart\Assert\Assert;
+
+final readonly class StartBackfillCommand
+{
+    public function __construct(
+        public string $companyId,
+        public string $connectionRef,
+        public IngestSource $source,
+        public string $resourceType,
+        public string $shopRef,
+        public \DateTimeImmutable $windowFrom,
+        public \DateTimeImmutable $windowTo,
+    ) {
+        Assert::uuid($this->companyId);
+        Assert::notEmpty($this->connectionRef);
+        Assert::notEmpty($this->resourceType);
+        Assert::lessThanEq($this->windowFrom, $this->windowTo);
+    }
+}

--- a/site/src/Ingestion/Application/Command/UpdateCursorCommand.php
+++ b/site/src/Ingestion/Application/Command/UpdateCursorCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Command;
+
+use Webmozart\Assert\Assert;
+
+final readonly class UpdateCursorCommand
+{
+    public function __construct(
+        public string $companyId,
+        public string $connectionRef,
+        public string $resourceType,
+        public string $shopRef,
+        public string $newCursorValue,
+        public string $syncJobId,
+        public ?\DateTimeImmutable $fetchedAt = null,
+    ) {
+        Assert::uuid($this->companyId);
+        Assert::notEmpty($this->connectionRef);
+        Assert::notEmpty($this->resourceType);
+        Assert::notEmpty($this->newCursorValue);
+        Assert::uuid($this->syncJobId);
+    }
+}

--- a/site/src/Ingestion/Application/Command/UpsertFinancialTransactionCommand.php
+++ b/site/src/Ingestion/Application/Command/UpsertFinancialTransactionCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Command;
+
+use App\Ingestion\Application\DTO\MappedTransaction;
+use App\Ingestion\Enum\IngestSource;
+use Webmozart\Assert\Assert;
+
+final readonly class UpsertFinancialTransactionCommand
+{
+    public function __construct(
+        public string $companyId,
+        public string $connectionRef,
+        public string $shopRef,
+        public IngestSource $source,
+        public MappedTransaction $mapped,
+        public string $rawRecordId,
+        public ?string $counterpartyId,
+    ) {
+        Assert::uuid($this->companyId);
+        Assert::notEmpty($this->connectionRef);
+        Assert::uuid($this->rawRecordId);
+
+        if (null !== $this->counterpartyId) {
+            Assert::uuid($this->counterpartyId);
+        }
+    }
+}

--- a/site/src/Ingestion/Application/DTO/MappedControlSum.php
+++ b/site/src/Ingestion/Application/DTO/MappedControlSum.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\DTO;
+
+use Webmozart\Assert\Assert;
+
+final readonly class MappedControlSum
+{
+    public function __construct(
+        public string $operationGroupId,
+        public string $currency,
+        public int $amountMinor,
+    ) {
+        Assert::uuid($this->operationGroupId);
+        Assert::regex($this->currency, '/^[A-Z]{3}$/');
+        Assert::greaterThanEq($this->amountMinor, 0);
+    }
+}

--- a/site/src/Ingestion/Application/DTO/MappedTransaction.php
+++ b/site/src/Ingestion/Application/DTO/MappedTransaction.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\DTO;
+
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+use App\Shared\Domain\ValueObject\Money;
+use Webmozart\Assert\Assert;
+
+final readonly class MappedTransaction
+{
+    /**
+     * @param array<string, mixed> $sourceData
+     */
+    public function __construct(
+        public string $externalId,
+        public \DateTimeImmutable $externalUpdatedAt,
+        public string $operationGroupId,
+        public TransactionType $type,
+        public TransactionDirection $direction,
+        public Money $money,
+        public \DateTimeImmutable $occurredAt,
+        public string $sourceTz = 'UTC',
+        public ?string $orderRef = null,
+        public ?string $payoutRef = null,
+        public ?string $counterpartyExternalKey = null,
+        public ?string $counterpartyName = null,
+        public ?string $description = null,
+        public array $sourceData = [],
+    ) {
+        Assert::notEmpty($this->externalId);
+        Assert::uuid($this->operationGroupId);
+        Assert::notEmpty($this->sourceTz);
+
+        if (null !== $this->counterpartyExternalKey) {
+            Assert::notEmpty($this->counterpartyExternalKey);
+        }
+
+        if (null !== $this->counterpartyName) {
+            Assert::notEmpty($this->counterpartyName);
+        }
+    }
+}

--- a/site/src/Ingestion/Application/DTO/PLDirtyPeriodView.php
+++ b/site/src/Ingestion/Application/DTO/PLDirtyPeriodView.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\DTO;
+
+use App\Ingestion\Entity\PLDirtyPeriod;
+
+final readonly class PLDirtyPeriodView
+{
+    public function __construct(
+        public string $id,
+        public string $companyId,
+        public int $year,
+        public int $month,
+        public string $shopRef,
+        public string $status,
+        public string $reason,
+        public int $attempts,
+        public ?string $lastError,
+        public string $markedAt,
+        public ?string $rebuiltAt,
+    ) {
+    }
+
+    public static function fromEntity(PLDirtyPeriod $period): self
+    {
+        return new self(
+            id: $period->getId(),
+            companyId: $period->getCompanyId(),
+            year: $period->getPeriodYear(),
+            month: $period->getPeriodMonth(),
+            shopRef: $period->getShopRef(),
+            status: $period->getStatus()->value,
+            reason: $period->getReason()->value,
+            attempts: $period->getAttempts(),
+            lastError: $period->getLastError(),
+            markedAt: $period->getMarkedAt()->format(\DateTimeInterface::ATOM),
+            rebuiltAt: $period->getRebuiltAt()?->format(\DateTimeInterface::ATOM),
+        );
+    }
+}

--- a/site/src/Ingestion/Application/DTO/PullRequest.php
+++ b/site/src/Ingestion/Application/DTO/PullRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\DTO;
+
+use Webmozart\Assert\Assert;
+
+final readonly class PullRequest
+{
+    public function __construct(
+        public string $companyId,
+        public string $connectionRef,
+        public string $shopRef,
+        public string $resourceType,
+        public ?string $cursorValue,
+        public ?\DateTimeImmutable $windowFrom,
+        public ?\DateTimeImmutable $windowTo,
+        public string $syncJobId,
+    ) {
+        Assert::uuid($this->companyId);
+        Assert::notEmpty($this->connectionRef);
+        Assert::notEmpty($this->resourceType);
+        Assert::uuid($this->syncJobId);
+    }
+}

--- a/site/src/Ingestion/Application/DTO/PullResult.php
+++ b/site/src/Ingestion/Application/DTO/PullResult.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\DTO;
+
+use App\Ingestion\DTO\RawBatch;
+
+final readonly class PullResult
+{
+    public function __construct(
+        public RawBatch $rawBatch,
+        public ?string $nextCursorValue,
+        public bool $hasMore,
+    ) {
+    }
+}

--- a/site/src/Ingestion/Application/DTO/PushRequest.php
+++ b/site/src/Ingestion/Application/DTO/PushRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\DTO;
+
+use Webmozart\Assert\Assert;
+
+final readonly class PushRequest
+{
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function __construct(
+        public string $companyId,
+        public string $connectionRef,
+        public string $documentType,
+        public array $payload,
+        public string $idempotencyKey,
+    ) {
+        Assert::uuid($this->companyId);
+        Assert::notEmpty($this->connectionRef);
+        Assert::notEmpty($this->documentType);
+        Assert::notEmpty($this->idempotencyKey);
+    }
+}

--- a/site/src/Ingestion/Application/DTO/PushResult.php
+++ b/site/src/Ingestion/Application/DTO/PushResult.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\DTO;
+
+final readonly class PushResult
+{
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function __construct(
+        public bool $accepted,
+        public ?string $externalId = null,
+        public array $metadata = [],
+    ) {
+    }
+}

--- a/site/src/Ingestion/Application/DTO/ShopDescriptor.php
+++ b/site/src/Ingestion/Application/DTO/ShopDescriptor.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\DTO;
+
+use Webmozart\Assert\Assert;
+
+final readonly class ShopDescriptor
+{
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function __construct(
+        public string $externalId,
+        public string $name,
+        public string $currency,
+        public array $metadata = [],
+    ) {
+        Assert::notEmpty($this->externalId);
+        Assert::notEmpty($this->name);
+        Assert::regex($this->currency, '/^[A-Z]{3}$/');
+    }
+}

--- a/site/src/Ingestion/Application/DTO/SyncJobProgressView.php
+++ b/site/src/Ingestion/Application/DTO/SyncJobProgressView.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\DTO;
+
+use App\Ingestion\Enum\SyncJobStatus;
+
+final readonly class SyncJobProgressView
+{
+    public function __construct(
+        public string $jobId,
+        public SyncJobStatus $status,
+        public int $progressDone,
+        public int $progressTotal,
+        public int $attempts,
+        public ?string $lastError,
+    ) {
+    }
+}

--- a/site/src/Ingestion/Application/DTO/UpsertResult.php
+++ b/site/src/Ingestion/Application/DTO/UpsertResult.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\DTO;
+
+use Webmozart\Assert\Assert;
+
+final readonly class UpsertResult
+{
+    public function __construct(
+        public string $transactionId,
+        public ?\DateTimeImmutable $oldOccurredAt,
+        public \DateTimeImmutable $newOccurredAt,
+        public bool $periodChanged,
+    ) {
+        Assert::uuid($this->transactionId);
+    }
+}

--- a/site/src/Ingestion/Application/Service/IngestRateLimitGuard.php
+++ b/site/src/Ingestion/Application/Service/IngestRateLimitGuard.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Service;
+
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\LockInterface;
+use Webmozart\Assert\Assert;
+
+final readonly class IngestRateLimitGuard
+{
+    public function __construct(private LockFactory $lockFactory)
+    {
+    }
+
+    public function acquire(string $sourceKey, int $maxLockMs = 60000): LockInterface
+    {
+        Assert::notEmpty($sourceKey);
+        Assert::greaterThanEq($maxLockMs, 1);
+
+        $lock = $this->lockFactory->createLock(sprintf('ingest_rate:%s', $sourceKey), $maxLockMs / 1000, false);
+        if (!$lock->acquire()) {
+            throw new \RuntimeException(sprintf('Ingestion rate limit lock is already held for key "%s".', $sourceKey));
+        }
+
+        return $lock;
+    }
+}

--- a/site/src/Ingestion/Application/Service/IngestRateLimitGuard.php
+++ b/site/src/Ingestion/Application/Service/IngestRateLimitGuard.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Ingestion\Application\Service;
 
+use App\Ingestion\Exception\ConnectorTransientException;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\LockInterface;
 use Webmozart\Assert\Assert;
@@ -21,7 +22,7 @@ final readonly class IngestRateLimitGuard
 
         $lock = $this->lockFactory->createLock(sprintf('ingest_rate:%s', $sourceKey), $maxLockMs / 1000, false);
         if (!$lock->acquire()) {
-            throw new \RuntimeException(sprintf('Ingestion rate limit lock is already held for key "%s".', $sourceKey));
+            throw new ConnectorTransientException(sprintf('Ingestion rate limit lock is already held for key "%s".', $sourceKey));
         }
 
         return $lock;

--- a/site/src/Ingestion/Application/Source/Ozon/OzonMoneyParser.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonMoneyParser.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Source\Ozon;
+
+final class OzonMoneyParser
+{
+    public function minor(mixed $value): int
+    {
+        $decimal = $this->decimal($value);
+        $negative = str_starts_with($decimal, '-');
+        if ($negative) {
+            $decimal = substr($decimal, 1);
+        }
+
+        [$integer, $fraction] = array_pad(explode('.', $decimal, 2), 2, '');
+        $fraction = str_pad(preg_replace('/\D/', '', $fraction) ?? '', 3, '0');
+        $kopecks = ((int) $integer) * 100 + (int) substr($fraction, 0, 2);
+        if ((int) $fraction[2] >= 5) {
+            ++$kopecks;
+        }
+
+        return $negative ? -$kopecks : $kopecks;
+    }
+
+    private function decimal(mixed $value): string
+    {
+        if (is_int($value)) {
+            return (string) $value;
+        }
+
+        if (is_float($value)) {
+            return sprintf('%.6F', $value);
+        }
+
+        if (is_string($value)) {
+            $normalized = str_replace(',', '.', trim($value));
+            if (preg_match('/^-?\d+(?:\.\d+)?$/', $normalized)) {
+                return $normalized;
+            }
+        }
+
+        return '0';
+    }
+}

--- a/site/src/Ingestion/Application/Source/Ozon/OzonOperationKey.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonOperationKey.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Source\Ozon;
+
+use Ramsey\Uuid\Uuid;
+
+final class OzonOperationKey
+{
+    public function baseExternalId(array $row): string
+    {
+        $operationId = trim((string) ($row['operation_id'] ?? ''));
+        if ('' !== $operationId) {
+            return sprintf('ozon:operation:%s', $operationId);
+        }
+
+        $postingNumber = trim((string) ($row['posting']['posting_number'] ?? $row['posting_number'] ?? ''));
+        $date = trim((string) ($row['operation_date'] ?? $row['sale_date'] ?? $row['return_date'] ?? $row['report_date'] ?? $row['_header']['stop_date'] ?? 'unknown-date'));
+        $sku = trim((string) ($row['item']['sku'] ?? ($row['items'][0]['sku'] ?? $row['sku'] ?? $row['offer_id'] ?? 'unknown-sku')));
+
+        return sprintf('ozon:fallback:%s:%s:%s', $postingNumber ?: 'unknown-posting', $sku, $date);
+    }
+
+    public function transactionExternalId(array $row, string $component): string
+    {
+        return sprintf('%s:%s', $this->baseExternalId($row), $this->normalizeComponent($component));
+    }
+
+    public function operationGroupId(string $companyId, array $row): string
+    {
+        return Uuid::uuid5(Uuid::NAMESPACE_URL, sprintf('%s:%s', $companyId, $this->baseExternalId($row)))->toString();
+    }
+
+    private function normalizeComponent(string $component): string
+    {
+        $normalized = strtolower(trim($component));
+        $normalized = preg_replace('/[^a-z0-9_]+/', '_', $normalized) ?? 'component';
+        $normalized = trim($normalized, '_');
+
+        return '' !== $normalized ? $normalized : 'component';
+    }
+}

--- a/site/src/Ingestion/Application/Source/Ozon/OzonRealizationMapper.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonRealizationMapper.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Source\Ozon;
+
+use App\Ingestion\Application\DTO\MappedControlSum;
+use App\Ingestion\Application\DTO\MappedTransaction;
+use App\Ingestion\Domain\Contract\RawRecordAwareControlSumMapperInterface;
+use App\Ingestion\Domain\Contract\SourceMapperInterface;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\IngestSource;
+
+final readonly class OzonRealizationMapper implements SourceMapperInterface, RawRecordAwareControlSumMapperInterface
+{
+    public function __construct(private OzonTransactionComponentMapper $mapper)
+    {
+    }
+
+    public function source(): IngestSource
+    {
+        return IngestSource::OZON;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function resourceTypes(): array
+    {
+        return [OzonResourceType::REALIZATION];
+    }
+
+    /**
+     * @param iterable<array<string, mixed>> $rows
+     *
+     * @return list<MappedTransaction>
+     */
+    public function map(IngestRawRecord $rawRecord, iterable $rows): array
+    {
+        return $this->mapper->map($rawRecord, $rows, realization: true);
+    }
+
+    /**
+     * @param iterable<array<string, mixed>> $rows
+     *
+     * @return list<MappedControlSum>
+     */
+    public function controlSum(iterable $rows): array
+    {
+        return [];
+    }
+
+    /**
+     * @param iterable<array<string, mixed>> $rows
+     *
+     * @return list<MappedControlSum>
+     */
+    public function controlSumForRawRecord(IngestRawRecord $rawRecord, iterable $rows): array
+    {
+        return $this->mapper->controlSumForRawRecord($rawRecord, $rows);
+    }
+}

--- a/site/src/Ingestion/Application/Source/Ozon/OzonResourceType.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonResourceType.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Source\Ozon;
+
+final class OzonResourceType
+{
+    public const DAILY_REPORT = 'ozon_seller_daily_report';
+    public const REALIZATION = 'ozon_seller_realization';
+}

--- a/site/src/Ingestion/Application/Source/Ozon/OzonSellerReportConnector.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonSellerReportConnector.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Source\Ozon;
+
+use App\Ingestion\Application\DTO\PullRequest;
+use App\Ingestion\Application\DTO\PullResult;
+use App\Ingestion\Application\DTO\PushRequest;
+use App\Ingestion\Application\DTO\PushResult;
+use App\Ingestion\Application\DTO\ShopDescriptor;
+use App\Ingestion\Domain\Contract\SourceConnectorInterface;
+use App\Ingestion\DTO\RawBatch;
+use App\Ingestion\Enum\Capability;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Exception\UnsupportedCapabilityException;
+use App\Ingestion\Infrastructure\Api\Ozon\OzonClientAdapterInterface;
+use Psr\Log\LoggerInterface;
+
+final readonly class OzonSellerReportConnector implements SourceConnectorInterface
+{
+    private const PAGE_SIZE = 1000;
+    private const MAX_PAGES_PER_PULL = 10;
+
+    public function __construct(
+        private OzonClientAdapterInterface $client,
+        private LoggerInterface $logger,
+        private int $chunkSizeDays = 7,
+        private int $hotRewindDays = 14,
+        private int $rateLimitRpm = 60,
+    ) {
+    }
+
+    public function source(): IngestSource
+    {
+        return IngestSource::OZON;
+    }
+
+    /**
+     * @return list<Capability>
+     */
+    public function capabilities(): array
+    {
+        return [Capability::CAN_DISCOVER_SHOPS, Capability::CAN_PULL];
+    }
+
+    /**
+     * @return list<ShopDescriptor>
+     */
+    public function discoverShops(string $companyId, string $connectionRef): array
+    {
+        return array_map(
+            static fn ($shop): ShopDescriptor => new ShopDescriptor(
+                externalId: $shop->externalId,
+                name: $shop->name,
+                currency: $shop->currency,
+                metadata: $shop->metadata,
+            ),
+            $this->client->listClusters($companyId, $connectionRef),
+        );
+    }
+
+    public function pull(PullRequest $request): PullResult
+    {
+        return match ($request->resourceType) {
+            OzonResourceType::DAILY_REPORT => $this->pullDailyReport($request),
+            OzonResourceType::REALIZATION => $this->pullRealization($request),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported Ozon resource type "%s".', $request->resourceType)),
+        };
+    }
+
+    public function push(PushRequest $request): PushResult
+    {
+        throw new UnsupportedCapabilityException('Ozon Seller connector does not support push operations.');
+    }
+
+    private function pullDailyReport(PullRequest $request): PullResult
+    {
+        [$from, $to] = $this->resolveDailyWindow($request);
+        $rows = [];
+        $page = 1;
+        $hasRemoteMore = false;
+
+        do {
+            $pageResult = $this->client->fetchTransactionList(
+                $request->companyId,
+                $request->connectionRef,
+                $from,
+                $to,
+                $page,
+                self::PAGE_SIZE,
+            );
+
+            if ([] !== $pageResult->rows) {
+                array_push($rows, ...$pageResult->rows);
+            }
+
+            $hasRemoteMore = $pageResult->hasMore;
+            ++$page;
+        } while ($hasRemoteMore && $page <= self::MAX_PAGES_PER_PULL);
+
+        if ($hasRemoteMore) {
+            $this->logger->warning('Ozon daily report pagination cap reached.', [
+                'companyId' => $request->companyId,
+                'connectionRef' => $request->connectionRef,
+                'from' => $from->format('Y-m-d'),
+                'to' => $to->format('Y-m-d'),
+                'maxPages' => self::MAX_PAGES_PER_PULL,
+            ]);
+
+            throw new \RuntimeException('Ozon daily report pagination cap reached before all rows were fetched.');
+        }
+
+        $windowHasMore = null !== $request->windowTo && $to < $request->windowTo;
+        $nextCursor = $windowHasMore ? $to->modify('+1 day')->format('Y-m-d') : null;
+
+        return new PullResult(
+            rawBatch: new RawBatch(
+                companyId: $request->companyId,
+                connectionRef: $request->connectionRef,
+                shopRef: $request->shopRef,
+                source: IngestSource::OZON,
+                resourceType: OzonResourceType::DAILY_REPORT,
+                externalId: sprintf('daily:%s:%s', $from->format('Y-m-d'), $to->format('Y-m-d')),
+                syncJobId: $request->syncJobId,
+                fetchedAt: new \DateTimeImmutable(),
+                rows: $rows,
+            ),
+            nextCursorValue: $nextCursor,
+            hasMore: $windowHasMore,
+        );
+    }
+
+    private function pullRealization(PullRequest $request): PullResult
+    {
+        $monthStart = $this->resolveRealizationMonth($request);
+        $page = $this->client->fetchRealization(
+            $request->companyId,
+            $request->connectionRef,
+            (int) $monthStart->format('Y'),
+            (int) $monthStart->format('n'),
+        );
+
+        $rows = array_map(
+            static fn (array $row): array => $row + ['_header' => $page->metadata['header'] ?? [], '_header_additional' => $page->metadata['headerAdditional'] ?? []],
+            $page->rows,
+        );
+
+        $nextMonth = $monthStart->modify('first day of next month');
+        $windowHasMore = null !== $request->windowTo && $nextMonth <= $request->windowTo;
+
+        return new PullResult(
+            rawBatch: new RawBatch(
+                companyId: $request->companyId,
+                connectionRef: $request->connectionRef,
+                shopRef: $request->shopRef,
+                source: IngestSource::OZON,
+                resourceType: OzonResourceType::REALIZATION,
+                externalId: sprintf('realization:%s', $monthStart->format('Y-m')),
+                syncJobId: $request->syncJobId,
+                fetchedAt: new \DateTimeImmutable(),
+                rows: $rows,
+            ),
+            nextCursorValue: $windowHasMore ? $nextMonth->format('Y-m-01') : null,
+            hasMore: $windowHasMore,
+        );
+    }
+
+    /**
+     * @return array{0: \DateTimeImmutable, 1: \DateTimeImmutable}
+     */
+    private function resolveDailyWindow(PullRequest $request): array
+    {
+        $from = null !== $request->cursorValue && '' !== $request->cursorValue
+            ? new \DateTimeImmutable($request->cursorValue)
+            : ($request->windowFrom ?? new \DateTimeImmutable(sprintf('-%d days', $this->hotRewindDays)));
+        $from = $from->setTime(0, 0);
+
+        $maxTo = $from->modify(sprintf('+%d days', max(1, $this->chunkSizeDays) - 1));
+        $to = null !== $request->windowTo && $request->windowTo < $maxTo
+            ? $request->windowTo
+            : $maxTo;
+        $to = $to->setTime(23, 59, 59);
+
+        if ($from > $to) {
+            throw new \InvalidArgumentException('Ozon daily report window is empty.');
+        }
+
+        return [$from, $to];
+    }
+
+    private function resolveRealizationMonth(PullRequest $request): \DateTimeImmutable
+    {
+        $date = null !== $request->cursorValue && '' !== $request->cursorValue
+            ? new \DateTimeImmutable($request->cursorValue)
+            : ($request->windowFrom ?? new \DateTimeImmutable('first day of previous month'));
+
+        return $date->modify('first day of this month')->setTime(0, 0);
+    }
+}

--- a/site/src/Ingestion/Application/Source/Ozon/OzonSellerReportMapper.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonSellerReportMapper.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Source\Ozon;
+
+use App\Ingestion\Application\DTO\MappedControlSum;
+use App\Ingestion\Application\DTO\MappedTransaction;
+use App\Ingestion\Domain\Contract\RawRecordAwareControlSumMapperInterface;
+use App\Ingestion\Domain\Contract\SourceMapperInterface;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\IngestSource;
+
+final readonly class OzonSellerReportMapper implements SourceMapperInterface, RawRecordAwareControlSumMapperInterface
+{
+    public function __construct(private OzonTransactionComponentMapper $mapper)
+    {
+    }
+
+    public function source(): IngestSource
+    {
+        return IngestSource::OZON;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function resourceTypes(): array
+    {
+        return [OzonResourceType::DAILY_REPORT];
+    }
+
+    /**
+     * @param iterable<array<string, mixed>> $rows
+     *
+     * @return list<MappedTransaction>
+     */
+    public function map(IngestRawRecord $rawRecord, iterable $rows): array
+    {
+        return $this->mapper->map($rawRecord, $rows, realization: false);
+    }
+
+    /**
+     * @param iterable<array<string, mixed>> $rows
+     *
+     * @return list<MappedControlSum>
+     */
+    public function controlSum(iterable $rows): array
+    {
+        return [];
+    }
+
+    /**
+     * @param iterable<array<string, mixed>> $rows
+     *
+     * @return list<MappedControlSum>
+     */
+    public function controlSumForRawRecord(IngestRawRecord $rawRecord, iterable $rows): array
+    {
+        return $this->mapper->controlSumForRawRecord($rawRecord, $rows);
+    }
+}

--- a/site/src/Ingestion/Application/Source/Ozon/OzonTransactionComponentMapper.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonTransactionComponentMapper.php
@@ -1,0 +1,341 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Source\Ozon;
+
+use App\Ingestion\Application\DTO\MappedControlSum;
+use App\Ingestion\Application\DTO\MappedTransaction;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+use App\Shared\Domain\ValueObject\Money;
+
+final readonly class OzonTransactionComponentMapper
+{
+    public function __construct(
+        private OzonMoneyParser $moneyParser,
+        private OzonOperationKey $operationKey,
+    ) {
+    }
+
+    /**
+     * @param iterable<array<string, mixed>> $rows
+     *
+     * @return list<MappedTransaction>
+     */
+    public function map(IngestRawRecord $rawRecord, iterable $rows, bool $realization): array
+    {
+        $transactions = [];
+
+        foreach ($rows as $row) {
+            $operationGroupId = $this->operationKey->operationGroupId($rawRecord->getCompanyId(), $row);
+            $currency = $this->currency($row);
+            $occurredAt = $this->occurredAt($row, $realization);
+            $externalUpdatedAt = $this->externalUpdatedAt($row, $realization, $occurredAt);
+            $orderRef = $this->orderRef($row);
+            $description = $this->description($row);
+
+            foreach ($this->components($row) as $component) {
+                $transactions[] = new MappedTransaction(
+                    externalId: $this->operationKey->transactionExternalId($row, $component['externalIdComponent']),
+                    externalUpdatedAt: $externalUpdatedAt,
+                    operationGroupId: $operationGroupId,
+                    type: $component['type'],
+                    direction: $component['direction'],
+                    money: Money::fromMinor(abs($component['amountMinor']), $currency),
+                    occurredAt: $occurredAt,
+                    sourceTz: 'Europe/Moscow',
+                    orderRef: $orderRef,
+                    payoutRef: $this->payoutRef($row),
+                    description: $component['description'] ?? $description,
+                    sourceData: $row + [
+                        '_ingestion_component' => $component['externalIdComponent'],
+                        '_ingestion_resource' => $realization ? OzonResourceType::REALIZATION : OzonResourceType::DAILY_REPORT,
+                    ],
+                );
+            }
+        }
+
+        return $transactions;
+    }
+
+    /**
+     * @param iterable<array<string, mixed>> $rows
+     *
+     * @return list<MappedControlSum>
+     */
+    public function controlSumForRawRecord(IngestRawRecord $rawRecord, iterable $rows): array
+    {
+        $controlSums = [];
+
+        foreach ($rows as $row) {
+            $amountMinor = 0;
+            foreach ($this->components($row) as $component) {
+                $amountMinor += abs($component['amountMinor']);
+            }
+
+            if (0 === $amountMinor) {
+                continue;
+            }
+
+            $controlSums[] = new MappedControlSum(
+                operationGroupId: $this->operationKey->operationGroupId($rawRecord->getCompanyId(), $row),
+                currency: $this->currency($row),
+                amountMinor: $amountMinor,
+            );
+        }
+
+        return $controlSums;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     *
+     * @return list<array{externalIdComponent: string, type: TransactionType, direction: TransactionDirection, amountMinor: int, description?: string}>
+     */
+    private function components(array $row): array
+    {
+        $components = [];
+        $operationType = (string) ($row['operation_type'] ?? '');
+        $isRefund = 'ClientReturnAgentOperation' === $operationType;
+
+        if ($isRefund) {
+            $refundAmount = $this->firstMinor($row, ['amount', 'accruals_for_sale', 'seller_price', 'price']);
+            if (0 !== $refundAmount) {
+                $components[] = $this->component('refund', TransactionType::REFUND, TransactionDirection::OUT, $refundAmount, $this->description($row));
+            }
+        } else {
+            $saleAmount = $this->firstMinor($row, ['accruals_for_sale', 'seller_price', 'price']);
+            if (0 !== $saleAmount) {
+                $components[] = $this->component('sale', TransactionType::SALE, $this->directionFromSigned($saleAmount), $saleAmount, $this->description($row));
+            }
+        }
+
+        $saleCommission = $this->firstMinor($row, ['sale_commission_amount', 'sale_commission', 'commission_amount']);
+        if (0 !== $saleCommission) {
+            $components[] = $this->component('commission', TransactionType::COMMISSION, $this->directionFromSigned($saleCommission), $saleCommission, 'Ozon sale commission');
+        }
+
+        $delivery = $this->firstMinor($row, ['deliv_charge_amount', 'delivery_charge', 'delivery_commission']);
+        if (0 !== $delivery) {
+            $components[] = $this->component('logistics_delivery', TransactionType::LOGISTICS, $this->directionFromSigned($delivery), $delivery, 'Ozon delivery');
+        }
+
+        $returnDelivery = $this->firstMinor($row, ['return_delivery_charge_amount', 'return_delivery_charge', 'return_delivery_commission']);
+        if (0 !== $returnDelivery) {
+            $components[] = $this->component('logistics_return_delivery', TransactionType::LOGISTICS, $this->directionFromSigned($returnDelivery), $returnDelivery, 'Ozon return delivery');
+        }
+
+        foreach ($this->serviceAmounts($row) as $serviceKey => $amountMinor) {
+            if (0 === $amountMinor) {
+                continue;
+            }
+
+            $serviceType = $this->serviceType($serviceKey);
+            $components[] = $this->component(
+                sprintf('service_%s', $serviceKey),
+                $serviceType,
+                $this->directionFromSigned($amountMinor),
+                $amountMinor,
+                sprintf('Ozon service: %s', $serviceKey),
+            );
+        }
+
+        $acquiring = $this->firstMinor($row, ['acquiring', 'acquiring_amount']);
+        if (0 !== $acquiring) {
+            $components[] = $this->component('acquiring', TransactionType::ACQUIRING, $this->directionFromSigned($acquiring), $acquiring, 'Ozon acquiring');
+        }
+
+        if ([] === $components) {
+            $amount = $this->firstMinor($row, ['amount']);
+            if (0 !== $amount) {
+                $components[] = $this->component('other', TransactionType::OTHER, $this->directionFromSigned($amount), $amount, $this->description($row));
+            }
+        }
+
+        return $components;
+    }
+
+    /**
+     * @return array{externalIdComponent: string, type: TransactionType, direction: TransactionDirection, amountMinor: int, description?: string}
+     */
+    private function component(
+        string $externalIdComponent,
+        TransactionType $type,
+        TransactionDirection $direction,
+        int $amountMinor,
+        ?string $description = null,
+    ): array {
+        return [
+            'externalIdComponent' => $externalIdComponent,
+            'type' => $type,
+            'direction' => $direction,
+            'amountMinor' => $amountMinor,
+            'description' => $description,
+        ];
+    }
+
+    private function firstMinor(array $row, array $fields): int
+    {
+        foreach ($fields as $field) {
+            if (array_key_exists($field, $row) && null !== $row[$field] && '' !== $row[$field]) {
+                return $this->moneyParser->minor($row[$field]);
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     *
+     * @return array<string, int>
+     */
+    private function serviceAmounts(array $row): array
+    {
+        $amounts = [];
+        $serviceAmounts = $row['services_amounts'] ?? [];
+
+        if (is_array($serviceAmounts)) {
+            foreach ($serviceAmounts as $serviceName => $amount) {
+                $key = $this->normalizeComponent((string) $serviceName);
+                $amounts[$key] = ($amounts[$key] ?? 0) + $this->moneyParser->minor($amount);
+            }
+        }
+
+        $services = $row['services'] ?? [];
+        if (is_array($services)) {
+            foreach ($services as $index => $service) {
+                if (!is_array($service)) {
+                    continue;
+                }
+
+                $name = (string) ($service['name'] ?? $service['service_name'] ?? $service['type'] ?? 'service_'.$index);
+                $amount = $service['price'] ?? $service['amount'] ?? $service['cost'] ?? null;
+                if (null === $amount || '' === $amount) {
+                    continue;
+                }
+
+                $key = sprintf('%s_%d', $this->normalizeComponent($name), (int) $index);
+                $amounts[$key] = ($amounts[$key] ?? 0) + $this->moneyParser->minor($amount);
+            }
+        }
+
+        return $amounts;
+    }
+
+    private function serviceType(string $serviceKey): TransactionType
+    {
+        return match (true) {
+            str_contains($serviceKey, 'marketplaceserviceitemreturnafterdelivtocustomer') => TransactionType::LOGISTICS,
+            str_contains($serviceKey, 'marketplaceserviceitemdelivtocustomer') => TransactionType::LAST_MILE,
+            default => TransactionType::FEE,
+        };
+    }
+
+    private function directionFromSigned(int $amountMinor): TransactionDirection
+    {
+        return $amountMinor >= 0 ? TransactionDirection::IN : TransactionDirection::OUT;
+    }
+
+    private function currency(array $row): string
+    {
+        $currency = strtoupper((string) ($row['currency'] ?? $row['currency_code'] ?? $row['_header']['currency_code'] ?? 'RUB'));
+
+        return 1 === preg_match('/^[A-Z]{3}$/', $currency) ? $currency : 'RUB';
+    }
+
+    private function occurredAt(array $row, bool $realization): \DateTimeImmutable
+    {
+        $fields = $realization
+            ? ['operation_date', 'sale_date', 'return_date', 'report_date', 'realization_report_period_end']
+            : ['operation_date', 'sale_date', 'return_date'];
+
+        return $this->firstDate($row, $fields)
+            ?? $this->firstDate($row, ['_header.stop_date', '_header.doc_date'])
+            ?? new \DateTimeImmutable('@0');
+    }
+
+    private function externalUpdatedAt(array $row, bool $realization, \DateTimeImmutable $occurredAt): \DateTimeImmutable
+    {
+        if (!$realization) {
+            return $this->firstDate($row, ['operation_date', 'sale_date', 'return_date']) ?? $occurredAt;
+        }
+
+        return $this->firstDate($row, [
+            'realization_report_period_end',
+            'report_date',
+            '_header.stop_date',
+            '_header.doc_date',
+            'operation_date',
+            'sale_date',
+            'return_date',
+        ]) ?? $occurredAt;
+    }
+
+    private function firstDate(array $row, array $fields): ?\DateTimeImmutable
+    {
+        foreach ($fields as $field) {
+            $value = $this->fieldValue($row, $field);
+            if (null === $value || '' === $value) {
+                continue;
+            }
+
+            try {
+                return new \DateTimeImmutable((string) $value);
+            } catch (\Throwable) {
+            }
+        }
+
+        return null;
+    }
+
+    private function fieldValue(array $row, string $field): mixed
+    {
+        if (!str_contains($field, '.')) {
+            return $row[$field] ?? null;
+        }
+
+        $value = $row;
+        foreach (explode('.', $field) as $part) {
+            if (!is_array($value) || !array_key_exists($part, $value)) {
+                return null;
+            }
+
+            $value = $value[$part];
+        }
+
+        return $value;
+    }
+
+    private function orderRef(array $row): ?string
+    {
+        $postingNumber = trim((string) ($row['posting']['posting_number'] ?? $row['posting_number'] ?? ''));
+
+        return '' !== $postingNumber ? $postingNumber : null;
+    }
+
+    private function payoutRef(array $row): ?string
+    {
+        $payoutRef = trim((string) ($row['payout_ref'] ?? $row['realization_id'] ?? $row['_header']['doc_number'] ?? ''));
+
+        return '' !== $payoutRef ? $payoutRef : null;
+    }
+
+    private function description(array $row): ?string
+    {
+        $description = trim((string) ($row['operation_type_name'] ?? $row['operation_type'] ?? $row['row_type'] ?? ''));
+
+        return '' !== $description ? $description : null;
+    }
+
+    private function normalizeComponent(string $component): string
+    {
+        $normalized = strtolower(trim($component));
+        $normalized = preg_replace('/[^a-z0-9_]+/', '_', $normalized) ?? 'service';
+        $normalized = trim($normalized, '_');
+
+        return '' !== $normalized ? $normalized : 'service';
+    }
+}

--- a/site/src/Ingestion/Domain/Contract/RawRecordAwareControlSumMapperInterface.php
+++ b/site/src/Ingestion/Domain/Contract/RawRecordAwareControlSumMapperInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Domain\Contract;
+
+use App\Ingestion\Application\DTO\MappedControlSum;
+use App\Ingestion\Entity\IngestRawRecord;
+
+interface RawRecordAwareControlSumMapperInterface
+{
+    /**
+     * @param iterable<array<string, mixed>> $rows
+     *
+     * @return list<MappedControlSum>
+     */
+    public function controlSumForRawRecord(IngestRawRecord $rawRecord, iterable $rows): array;
+}

--- a/site/src/Ingestion/Domain/Contract/SourceConnectorInterface.php
+++ b/site/src/Ingestion/Domain/Contract/SourceConnectorInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Domain\Contract;
+
+use App\Ingestion\Application\DTO\PullRequest;
+use App\Ingestion\Application\DTO\PullResult;
+use App\Ingestion\Application\DTO\PushRequest;
+use App\Ingestion\Application\DTO\PushResult;
+use App\Ingestion\Application\DTO\ShopDescriptor;
+use App\Ingestion\Enum\Capability;
+use App\Ingestion\Enum\IngestSource;
+
+interface SourceConnectorInterface
+{
+    public function source(): IngestSource;
+
+    /**
+     * @return list<Capability>
+     */
+    public function capabilities(): array;
+
+    /**
+     * @return list<ShopDescriptor>
+     */
+    public function discoverShops(string $companyId, string $connectionRef): array;
+
+    public function pull(PullRequest $request): PullResult;
+
+    public function push(PushRequest $request): PushResult;
+}

--- a/site/src/Ingestion/Domain/Contract/SourceMapperInterface.php
+++ b/site/src/Ingestion/Domain/Contract/SourceMapperInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Domain\Contract;
+
+use App\Ingestion\Application\DTO\MappedControlSum;
+use App\Ingestion\Application\DTO\MappedTransaction;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\IngestSource;
+
+interface SourceMapperInterface
+{
+    public function source(): IngestSource;
+
+    /**
+     * @return list<string>
+     */
+    public function resourceTypes(): array;
+
+    /**
+     * @param iterable<array<string, mixed>> $rows
+     *
+     * @return list<MappedTransaction>
+     */
+    public function map(IngestRawRecord $rawRecord, iterable $rows): array;
+
+    /**
+     * @param iterable<array<string, mixed>> $rows
+     *
+     * @return list<MappedControlSum>
+     */
+    public function controlSum(iterable $rows): array;
+}

--- a/site/src/Ingestion/Domain/Event/AffectedPeriod.php
+++ b/site/src/Ingestion/Domain/Event/AffectedPeriod.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Domain\Event;
+
+final readonly class AffectedPeriod
+{
+    public function __construct(
+        public string $shopRef,
+        public ?\DateTimeImmutable $oldOccurredAt,
+        public \DateTimeImmutable $newOccurredAt,
+    ) {
+    }
+}

--- a/site/src/Ingestion/Domain/Event/NormalizationCompletedEvent.php
+++ b/site/src/Ingestion/Domain/Event/NormalizationCompletedEvent.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Domain\Event;
+
+use Webmozart\Assert\Assert;
+
+final readonly class NormalizationCompletedEvent
+{
+    /**
+     * @param list<AffectedPeriod> $affectedPeriods
+     */
+    public function __construct(
+        public string $companyId,
+        public string $rawRecordId,
+        public array $affectedPeriods,
+    ) {
+        Assert::uuid($this->companyId);
+        Assert::uuid($this->rawRecordId);
+        Assert::allIsInstanceOf($this->affectedPeriods, AffectedPeriod::class);
+    }
+}

--- a/site/src/Ingestion/Domain/Service/ConnectorRegistry.php
+++ b/site/src/Ingestion/Domain/Service/ConnectorRegistry.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Domain\Service;
+
+use App\Ingestion\Domain\Contract\SourceConnectorInterface;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Exception\ConnectorNotFoundException;
+
+final class ConnectorRegistry
+{
+    /**
+     * @var array<string, SourceConnectorInterface>
+     */
+    private array $connectors = [];
+
+    /**
+     * @param iterable<SourceConnectorInterface> $connectors
+     */
+    public function __construct(iterable $connectors)
+    {
+        foreach ($connectors as $connector) {
+            $source = $connector->source()->value;
+            if (isset($this->connectors[$source])) {
+                throw new \InvalidArgumentException(sprintf('Duplicate ingestion connector for source "%s".', $source));
+            }
+
+            $this->connectors[$source] = $connector;
+        }
+    }
+
+    public function get(IngestSource $source): SourceConnectorInterface
+    {
+        return $this->connectors[$source->value]
+            ?? throw new ConnectorNotFoundException(sprintf('Connector for source "%s" was not found.', $source->value));
+    }
+
+    public function has(IngestSource $source): bool
+    {
+        return isset($this->connectors[$source->value]);
+    }
+}

--- a/site/src/Ingestion/Domain/Service/MapperRegistry.php
+++ b/site/src/Ingestion/Domain/Service/MapperRegistry.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Domain\Service;
+
+use App\Ingestion\Domain\Contract\SourceMapperInterface;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Exception\MapperNotFoundException;
+
+final class MapperRegistry
+{
+    /**
+     * @var array<string, array<string, SourceMapperInterface>>
+     */
+    private array $mappers = [];
+
+    /**
+     * @param iterable<SourceMapperInterface> $mappers
+     */
+    public function __construct(iterable $mappers)
+    {
+        foreach ($mappers as $mapper) {
+            $source = $mapper->source()->value;
+            foreach ($mapper->resourceTypes() as $resourceType) {
+                if (isset($this->mappers[$source][$resourceType])) {
+                    throw new \InvalidArgumentException(sprintf('Duplicate ingestion mapper for source "%s" and resource "%s".', $source, $resourceType));
+                }
+
+                $this->mappers[$source][$resourceType] = $mapper;
+            }
+        }
+    }
+
+    public function get(IngestSource $source, string $resourceType): SourceMapperInterface
+    {
+        return $this->mappers[$source->value][$resourceType]
+            ?? throw new MapperNotFoundException(sprintf('Mapper for source "%s" and resource "%s" was not found.', $source->value, $resourceType));
+    }
+}

--- a/site/src/Ingestion/Domain/Service/SyncJobTransitionPolicy.php
+++ b/site/src/Ingestion/Domain/Service/SyncJobTransitionPolicy.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Domain\Service;
+
+use App\Ingestion\Enum\SyncJobStatus;
+use App\Ingestion\Exception\SyncJobTransitionException;
+
+final class SyncJobTransitionPolicy
+{
+    public static function assertCanTransition(SyncJobStatus $from, SyncJobStatus $to): void
+    {
+        if (!$from->canTransitionTo($to)) {
+            throw new SyncJobTransitionException(sprintf('Invalid sync job transition from "%s" to "%s".', $from->value, $to->value));
+        }
+    }
+}

--- a/site/src/Ingestion/Entity/Counterparty.php
+++ b/site/src/Ingestion/Entity/Counterparty.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Entity;
+
+use App\Ingestion\Domain\TenantOwnedInterface;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Repository\CounterpartyRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity(repositoryClass: CounterpartyRepository::class)]
+#[ORM\Table(name: 'ingest_counterparties')]
+#[ORM\UniqueConstraint(name: 'uniq_counterparty_natural', columns: ['company_id', 'source', 'external_key'])]
+class Counterparty implements TenantOwnedInterface
+{
+    #[ORM\Id]
+    #[ORM\Column(type: Types::GUID)]
+    private string $id;
+
+    #[ORM\Column(type: Types::GUID)]
+    private string $companyId;
+
+    #[ORM\Column(type: Types::STRING, length: 64, enumType: IngestSource::class)]
+    private IngestSource $source;
+
+    #[ORM\Column(type: Types::STRING, length: 255)]
+    private string $externalKey;
+
+    #[ORM\Column(type: Types::STRING, length: 500)]
+    private string $name;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6)]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6)]
+    private \DateTimeImmutable $updatedAt;
+
+    public function __construct(string $companyId, IngestSource $source, string $externalKey, string $name)
+    {
+        Assert::uuid($companyId);
+        Assert::notEmpty($externalKey);
+        Assert::notEmpty($name);
+
+        $now = new \DateTimeImmutable();
+
+        $this->id = Uuid::uuid7()->toString();
+        $this->companyId = $companyId;
+        $this->source = $source;
+        $this->externalKey = $externalKey;
+        $this->name = $name;
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+    }
+
+    public function rename(string $name): void
+    {
+        Assert::notEmpty($name);
+
+        if ($this->name === $name) {
+            return;
+        }
+
+        $this->name = $name;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getCompanyId(): string
+    {
+        return $this->companyId;
+    }
+
+    public function getSource(): IngestSource
+    {
+        return $this->source;
+    }
+
+    public function getExternalKey(): string
+    {
+        return $this->externalKey;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+}

--- a/site/src/Ingestion/Entity/FinancialTransaction.php
+++ b/site/src/Ingestion/Entity/FinancialTransaction.php
@@ -1,0 +1,325 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Entity;
+
+use App\Ingestion\Domain\TenantOwnedInterface;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+use App\Ingestion\Exception\StaleTransactionUpdateException;
+use App\Ingestion\Repository\FinancialTransactionRepository;
+use App\Shared\Domain\ValueObject\Money;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity(repositoryClass: FinancialTransactionRepository::class)]
+#[ORM\Table(name: 'ingest_financial_transactions')]
+#[ORM\UniqueConstraint(name: 'uniq_ftx_natural_key', columns: ['company_id', 'source', 'external_id', 'type'])]
+#[ORM\Index(name: 'idx_ftx_company_occurred', columns: ['company_id', 'occurred_at'])]
+#[ORM\Index(name: 'idx_ftx_company_shop_occurred', columns: ['company_id', 'shop_ref', 'occurred_at'])]
+#[ORM\Index(name: 'idx_ftx_company_group', columns: ['company_id', 'operation_group_id'])]
+#[ORM\Index(name: 'idx_ftx_company_type_occurred', columns: ['company_id', 'type', 'occurred_at'])]
+#[ORM\Index(name: 'idx_ftx_company_raw', columns: ['company_id', 'raw_record_id'])]
+class FinancialTransaction implements TenantOwnedInterface
+{
+    #[ORM\Id]
+    #[ORM\Column(type: Types::GUID)]
+    private string $id;
+
+    #[ORM\Column(type: Types::GUID)]
+    private string $companyId;
+
+    #[ORM\Column(type: Types::STRING, length: 255)]
+    private string $connectionRef;
+
+    #[ORM\Column(type: Types::STRING, length: 255, options: ['default' => ''])]
+    private string $shopRef;
+
+    #[ORM\Column(type: Types::STRING, length: 64, enumType: IngestSource::class)]
+    private IngestSource $source;
+
+    #[ORM\Column(type: Types::STRING, length: 255)]
+    private string $externalId;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6)]
+    private \DateTimeImmutable $externalUpdatedAt;
+
+    #[ORM\Column(type: Types::GUID)]
+    private string $operationGroupId;
+
+    #[ORM\Column(type: Types::STRING, length: 64, enumType: TransactionType::class)]
+    private TransactionType $type;
+
+    #[ORM\Column(type: Types::STRING, length: 8, enumType: TransactionDirection::class)]
+    private TransactionDirection $direction;
+
+    #[ORM\Column(type: Types::BIGINT)]
+    private string $amountMinor;
+
+    #[ORM\Column(type: Types::STRING, length: 3)]
+    private string $currency;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6)]
+    private \DateTimeImmutable $occurredAt;
+
+    #[ORM\Column(type: Types::STRING, length: 64, options: ['default' => 'UTC'])]
+    private string $sourceTz = 'UTC';
+
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
+    private ?string $orderRef;
+
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
+    private ?string $payoutRef;
+
+    #[ORM\Column(type: Types::GUID, nullable: true)]
+    private ?string $counterpartyId;
+
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $description;
+
+    /**
+     * @var array<string, mixed>
+     */
+    #[ORM\Column(type: Types::JSON, options: ['jsonb' => true])]
+    private array $sourceData;
+
+    #[ORM\Column(type: Types::GUID)]
+    private string $rawRecordId;
+
+    #[ORM\Version]
+    #[ORM\Column(type: Types::INTEGER, options: ['default' => 1])]
+    private int $version = 1;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6)]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6)]
+    private \DateTimeImmutable $updatedAt;
+
+    private ?\DateTimeImmutable $oldOccurredAt = null;
+
+    /**
+     * @param array<string, mixed> $sourceData
+     */
+    public function __construct(
+        string $companyId,
+        string $connectionRef,
+        string $shopRef,
+        IngestSource $source,
+        string $externalId,
+        \DateTimeImmutable $externalUpdatedAt,
+        string $operationGroupId,
+        TransactionType $type,
+        TransactionDirection $direction,
+        Money $money,
+        \DateTimeImmutable $occurredAt,
+        string $rawRecordId,
+        ?string $orderRef = null,
+        ?string $payoutRef = null,
+        ?string $counterpartyId = null,
+        ?string $description = null,
+        array $sourceData = [],
+        string $sourceTz = 'UTC',
+    ) {
+        Assert::uuid($companyId);
+        Assert::notEmpty($connectionRef);
+        Assert::notEmpty($externalId);
+        Assert::uuid($operationGroupId);
+        Assert::uuid($rawRecordId);
+        Assert::regex($money->currency(), '/^[A-Z]{3}$/');
+
+        if (null !== $counterpartyId) {
+            Assert::uuid($counterpartyId);
+        }
+
+        $now = new \DateTimeImmutable();
+
+        $this->id = Uuid::uuid7()->toString();
+        $this->companyId = $companyId;
+        $this->connectionRef = $connectionRef;
+        $this->shopRef = $shopRef;
+        $this->source = $source;
+        $this->externalId = $externalId;
+        $this->externalUpdatedAt = $externalUpdatedAt;
+        $this->operationGroupId = $operationGroupId;
+        $this->type = $type;
+        $this->direction = $direction;
+        $this->amountMinor = (string) $money->amountMinor();
+        $this->currency = $money->currency();
+        $this->occurredAt = $occurredAt;
+        $this->rawRecordId = $rawRecordId;
+        $this->orderRef = $orderRef;
+        $this->payoutRef = $payoutRef;
+        $this->counterpartyId = $counterpartyId;
+        $this->description = $description;
+        $this->sourceData = $sourceData;
+        $this->sourceTz = $sourceTz;
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+    }
+
+    /**
+     * @param array<string, mixed> $sourceData
+     */
+    public function replaceFromNewerVersion(
+        Money $money,
+        TransactionType $type,
+        TransactionDirection $direction,
+        \DateTimeImmutable $occurredAt,
+        \DateTimeImmutable $externalUpdatedAt,
+        ?string $orderRef,
+        ?string $payoutRef,
+        ?string $counterpartyId,
+        ?string $description,
+        array $sourceData,
+    ): void {
+        if ($externalUpdatedAt <= $this->externalUpdatedAt) {
+            throw new StaleTransactionUpdateException('Incoming transaction version is not newer than existing version.');
+        }
+
+        if (null !== $counterpartyId) {
+            Assert::uuid($counterpartyId);
+        }
+
+        $this->oldOccurredAt = $this->occurredAt;
+        $this->amountMinor = (string) $money->amountMinor();
+        $this->currency = $money->currency();
+        $this->type = $type;
+        $this->direction = $direction;
+        $this->occurredAt = $occurredAt;
+        $this->externalUpdatedAt = $externalUpdatedAt;
+        $this->orderRef = $orderRef;
+        $this->payoutRef = $payoutRef;
+        $this->counterpartyId = $counterpartyId;
+        $this->description = $description;
+        $this->sourceData = $sourceData;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function oldOccurredAt(): \DateTimeImmutable
+    {
+        return $this->oldOccurredAt ?? $this->occurredAt;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getCompanyId(): string
+    {
+        return $this->companyId;
+    }
+
+    public function getConnectionRef(): string
+    {
+        return $this->connectionRef;
+    }
+
+    public function getShopRef(): string
+    {
+        return $this->shopRef;
+    }
+
+    public function getSource(): IngestSource
+    {
+        return $this->source;
+    }
+
+    public function getExternalId(): string
+    {
+        return $this->externalId;
+    }
+
+    public function getExternalUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->externalUpdatedAt;
+    }
+
+    public function getOperationGroupId(): string
+    {
+        return $this->operationGroupId;
+    }
+
+    public function getType(): TransactionType
+    {
+        return $this->type;
+    }
+
+    public function getDirection(): TransactionDirection
+    {
+        return $this->direction;
+    }
+
+    public function getAmountMinor(): int
+    {
+        return (int) $this->amountMinor;
+    }
+
+    public function getCurrency(): string
+    {
+        return $this->currency;
+    }
+
+    public function getOccurredAt(): \DateTimeImmutable
+    {
+        return $this->occurredAt;
+    }
+
+    public function getSourceTz(): string
+    {
+        return $this->sourceTz;
+    }
+
+    public function getOrderRef(): ?string
+    {
+        return $this->orderRef;
+    }
+
+    public function getPayoutRef(): ?string
+    {
+        return $this->payoutRef;
+    }
+
+    public function getCounterpartyId(): ?string
+    {
+        return $this->counterpartyId;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getSourceData(): array
+    {
+        return $this->sourceData;
+    }
+
+    public function getRawRecordId(): string
+    {
+        return $this->rawRecordId;
+    }
+
+    public function getVersion(): int
+    {
+        return $this->version;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+}

--- a/site/src/Ingestion/Entity/IngestCursor.php
+++ b/site/src/Ingestion/Entity/IngestCursor.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Entity;
+
+use App\Ingestion\Domain\TenantOwnedInterface;
+use App\Ingestion\Repository\IngestCursorRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity(repositoryClass: IngestCursorRepository::class)]
+#[ORM\Table(name: 'ingest_cursors')]
+#[ORM\UniqueConstraint(name: 'uniq_ingest_cursor_key', columns: ['company_id', 'connection_ref', 'resource_type', 'shop_ref'])]
+#[ORM\Index(name: 'idx_ingest_cursor_company_connection', columns: ['company_id', 'connection_ref'])]
+class IngestCursor implements TenantOwnedInterface
+{
+    #[ORM\Id]
+    #[ORM\Column(type: Types::GUID)]
+    private string $id;
+
+    #[ORM\Column(type: Types::GUID)]
+    private string $companyId;
+
+    #[ORM\Column(type: Types::STRING, length: 255)]
+    private string $connectionRef;
+
+    #[ORM\Column(type: Types::STRING, length: 100)]
+    private string $resourceType;
+
+    #[ORM\Column(type: Types::STRING, length: 255, options: ['default' => ''])]
+    private string $shopRef;
+
+    #[ORM\Column(type: Types::STRING, length: 1024, options: ['default' => ''])]
+    private string $cursorValue = '';
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6, nullable: true)]
+    private ?\DateTimeImmutable $lastFetchedAt = null;
+
+    #[ORM\Column(type: Types::GUID, nullable: true)]
+    private ?string $lastSyncJobId = null;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6)]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6)]
+    private \DateTimeImmutable $updatedAt;
+
+    public function __construct(
+        string $companyId,
+        string $connectionRef,
+        string $resourceType,
+        string $shopRef = '',
+    ) {
+        Assert::uuid($companyId);
+        Assert::notEmpty($connectionRef);
+        Assert::notEmpty($resourceType);
+
+        $now = new \DateTimeImmutable();
+
+        $this->id = Uuid::uuid7()->toString();
+        $this->companyId = $companyId;
+        $this->connectionRef = $connectionRef;
+        $this->resourceType = $resourceType;
+        $this->shopRef = $shopRef;
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+    }
+
+    public function advance(
+        string $newCursorValue,
+        string $syncJobId,
+        ?\DateTimeImmutable $fetchedAt = null,
+    ): void {
+        Assert::notEmpty($newCursorValue);
+        Assert::uuid($syncJobId);
+
+        $now = new \DateTimeImmutable();
+
+        $this->cursorValue = $newCursorValue;
+        $this->lastSyncJobId = $syncJobId;
+        $this->lastFetchedAt = $fetchedAt ?? $now;
+        $this->updatedAt = $now;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getCompanyId(): string
+    {
+        return $this->companyId;
+    }
+
+    public function getConnectionRef(): string
+    {
+        return $this->connectionRef;
+    }
+
+    public function getResourceType(): string
+    {
+        return $this->resourceType;
+    }
+
+    public function getShopRef(): string
+    {
+        return $this->shopRef;
+    }
+
+    public function getCursorValue(): string
+    {
+        return $this->cursorValue;
+    }
+
+    public function getLastFetchedAt(): ?\DateTimeImmutable
+    {
+        return $this->lastFetchedAt;
+    }
+
+    public function getLastSyncJobId(): ?string
+    {
+        return $this->lastSyncJobId;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+}

--- a/site/src/Ingestion/Entity/IngestRawRecord.php
+++ b/site/src/Ingestion/Entity/IngestRawRecord.php
@@ -195,4 +195,16 @@ class IngestRawRecord implements TenantOwnedInterface
         $this->lastSeenAt = $seenAt ?? new \DateTimeImmutable();
         $this->updatedAt = new \DateTimeImmutable();
     }
+
+    public function markNormalizationDone(): void
+    {
+        $this->normalizationStatus = RawNormalizationStatus::DONE;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function markNormalizationFailed(): void
+    {
+        $this->normalizationStatus = RawNormalizationStatus::FAILED;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
 }

--- a/site/src/Ingestion/Entity/NormalizationIssue.php
+++ b/site/src/Ingestion/Entity/NormalizationIssue.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Entity;
+
+use App\Ingestion\Domain\TenantOwnedInterface;
+use App\Ingestion\Enum\NormalizationIssueKind;
+use App\Ingestion\Repository\NormalizationIssueRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity(repositoryClass: NormalizationIssueRepository::class)]
+#[ORM\Table(name: 'ingest_normalization_issues')]
+#[ORM\Index(name: 'idx_norm_issue_company_kind_resolved', columns: ['company_id', 'kind', 'resolved_at'])]
+#[ORM\Index(name: 'idx_norm_issue_company_raw', columns: ['company_id', 'raw_record_id'])]
+class NormalizationIssue implements TenantOwnedInterface
+{
+    #[ORM\Id]
+    #[ORM\Column(type: Types::GUID)]
+    private string $id;
+
+    #[ORM\Column(type: Types::GUID)]
+    private string $companyId;
+
+    #[ORM\Column(type: Types::GUID)]
+    private string $rawRecordId;
+
+    #[ORM\Column(type: Types::GUID, nullable: true)]
+    private ?string $operationGroupId;
+
+    #[ORM\Column(type: Types::STRING, length: 64, enumType: NormalizationIssueKind::class)]
+    private NormalizationIssueKind $kind;
+
+    /**
+     * @var array<string, mixed>
+     */
+    #[ORM\Column(type: Types::JSON, options: ['jsonb' => true])]
+    private array $details;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6, nullable: true)]
+    private ?\DateTimeImmutable $resolvedAt = null;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6)]
+    private \DateTimeImmutable $createdAt;
+
+    /**
+     * @param array<string, mixed> $details
+     */
+    public function __construct(
+        string $companyId,
+        string $rawRecordId,
+        ?string $operationGroupId,
+        NormalizationIssueKind $kind,
+        array $details,
+    ) {
+        Assert::uuid($companyId);
+        Assert::uuid($rawRecordId);
+
+        if (null !== $operationGroupId) {
+            Assert::uuid($operationGroupId);
+        }
+
+        $this->id = Uuid::uuid7()->toString();
+        $this->companyId = $companyId;
+        $this->rawRecordId = $rawRecordId;
+        $this->operationGroupId = $operationGroupId;
+        $this->kind = $kind;
+        $this->details = $details;
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function markResolved(?\DateTimeImmutable $at = null): void
+    {
+        if (null !== $this->resolvedAt) {
+            return;
+        }
+
+        $this->resolvedAt = $at ?? new \DateTimeImmutable();
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getCompanyId(): string
+    {
+        return $this->companyId;
+    }
+
+    public function getRawRecordId(): string
+    {
+        return $this->rawRecordId;
+    }
+
+    public function getOperationGroupId(): ?string
+    {
+        return $this->operationGroupId;
+    }
+
+    public function getKind(): NormalizationIssueKind
+    {
+        return $this->kind;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getDetails(): array
+    {
+        return $this->details;
+    }
+
+    public function getResolvedAt(): ?\DateTimeImmutable
+    {
+        return $this->resolvedAt;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/site/src/Ingestion/Entity/PLDirtyPeriod.php
+++ b/site/src/Ingestion/Entity/PLDirtyPeriod.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Entity;
+
+use App\Ingestion\Domain\TenantOwnedInterface;
+use App\Ingestion\Enum\PLDirtyPeriodReason;
+use App\Ingestion\Enum\PLDirtyPeriodStatus;
+use App\Ingestion\Repository\PLDirtyPeriodRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity(repositoryClass: PLDirtyPeriodRepository::class)]
+#[ORM\Table(name: 'pnl_dirty_periods')]
+#[ORM\UniqueConstraint(name: 'uniq_pdp_key', columns: ['company_id', 'period_year', 'period_month', 'shop_ref'])]
+#[ORM\Index(name: 'idx_pdp_status_marked', columns: ['status', 'marked_at'])]
+#[ORM\Index(name: 'idx_pdp_company_status', columns: ['company_id', 'status'])]
+class PLDirtyPeriod implements TenantOwnedInterface
+{
+    #[ORM\Id]
+    #[ORM\Column(type: Types::GUID)]
+    private string $id;
+
+    #[ORM\Column(type: Types::GUID)]
+    private string $companyId;
+
+    #[ORM\Column(type: Types::SMALLINT)]
+    private int $periodYear;
+
+    #[ORM\Column(type: Types::SMALLINT)]
+    private int $periodMonth;
+
+    #[ORM\Column(type: Types::STRING, length: 255, options: ['default' => ''])]
+    private string $shopRef;
+
+    #[ORM\Column(type: Types::STRING, length: 32, enumType: PLDirtyPeriodStatus::class, options: ['default' => 'pending'])]
+    private PLDirtyPeriodStatus $status = PLDirtyPeriodStatus::PENDING;
+
+    #[ORM\Column(type: Types::STRING, length: 32, enumType: PLDirtyPeriodReason::class)]
+    private PLDirtyPeriodReason $reason;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6)]
+    private \DateTimeImmutable $markedAt;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6, nullable: true)]
+    private ?\DateTimeImmutable $rebuiltAt = null;
+
+    #[ORM\Column(type: Types::INTEGER, options: ['default' => 0])]
+    private int $attempts = 0;
+
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $lastError = null;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6)]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6)]
+    private \DateTimeImmutable $updatedAt;
+
+    public function __construct(
+        string $companyId,
+        int $periodYear,
+        int $periodMonth,
+        string $shopRef,
+        PLDirtyPeriodReason $reason,
+    ) {
+        Assert::uuid($companyId);
+        Assert::range($periodYear, 2020, 2100);
+        Assert::range($periodMonth, 1, 12);
+
+        $now = new \DateTimeImmutable();
+
+        $this->id = Uuid::uuid7()->toString();
+        $this->companyId = $companyId;
+        $this->periodYear = $periodYear;
+        $this->periodMonth = $periodMonth;
+        $this->shopRef = $shopRef;
+        $this->reason = $reason;
+        $this->markedAt = $now;
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+    }
+
+    public function markRebuilding(): void
+    {
+        $this->transitionTo(PLDirtyPeriodStatus::REBUILDING);
+
+        ++$this->attempts;
+        $this->lastError = null;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function markDone(?\DateTimeImmutable $at = null): void
+    {
+        $this->transitionTo(PLDirtyPeriodStatus::DONE);
+
+        $this->rebuiltAt = $at ?? new \DateTimeImmutable();
+        $this->lastError = null;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function markFailed(string $reason): void
+    {
+        Assert::notEmpty($reason);
+
+        $this->transitionTo(PLDirtyPeriodStatus::FAILED);
+
+        $this->lastError = $reason;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function markBlockedByClose(string $reason): void
+    {
+        Assert::notEmpty($reason);
+
+        $this->transitionTo(PLDirtyPeriodStatus::BLOCKED_BY_CLOSE);
+
+        $this->lastError = $reason;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function reopen(): void
+    {
+        $this->transitionTo(PLDirtyPeriodStatus::PENDING);
+
+        $this->markedAt = new \DateTimeImmutable();
+        $this->lastError = null;
+        $this->updatedAt = $this->markedAt;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getCompanyId(): string
+    {
+        return $this->companyId;
+    }
+
+    public function getPeriodYear(): int
+    {
+        return $this->periodYear;
+    }
+
+    public function getPeriodMonth(): int
+    {
+        return $this->periodMonth;
+    }
+
+    public function getShopRef(): string
+    {
+        return $this->shopRef;
+    }
+
+    public function getStatus(): PLDirtyPeriodStatus
+    {
+        return $this->status;
+    }
+
+    public function getReason(): PLDirtyPeriodReason
+    {
+        return $this->reason;
+    }
+
+    public function getMarkedAt(): \DateTimeImmutable
+    {
+        return $this->markedAt;
+    }
+
+    public function getRebuiltAt(): ?\DateTimeImmutable
+    {
+        return $this->rebuiltAt;
+    }
+
+    public function getAttempts(): int
+    {
+        return $this->attempts;
+    }
+
+    public function getLastError(): ?string
+    {
+        return $this->lastError;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    private function transitionTo(PLDirtyPeriodStatus $next): void
+    {
+        if (!$this->status->canTransitionTo($next)) {
+            throw new \DomainException(sprintf('Cannot transition P&L dirty period from "%s" to "%s".', $this->status->value, $next->value));
+        }
+
+        $this->status = $next;
+    }
+}

--- a/site/src/Ingestion/Entity/SyncJob.php
+++ b/site/src/Ingestion/Entity/SyncJob.php
@@ -1,0 +1,320 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Entity;
+
+use App\Ingestion\Domain\Service\SyncJobTransitionPolicy;
+use App\Ingestion\Domain\TenantOwnedInterface;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\SyncJobKind;
+use App\Ingestion\Enum\SyncJobStatus;
+use App\Ingestion\Repository\SyncJobRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity(repositoryClass: SyncJobRepository::class)]
+#[ORM\Table(name: 'ingest_sync_jobs')]
+#[ORM\Index(name: 'idx_ingest_sync_job_company_status', columns: ['company_id', 'status'])]
+#[ORM\Index(name: 'idx_ingest_sync_job_resource_status', columns: ['company_id', 'connection_ref', 'resource_type', 'status'])]
+#[ORM\Index(name: 'idx_ingest_sync_job_parent', columns: ['parent_job_id'])]
+#[ORM\Index(name: 'idx_ingest_sync_job_kind_status', columns: ['company_id', 'kind', 'status'])]
+class SyncJob implements TenantOwnedInterface
+{
+    #[ORM\Id]
+    #[ORM\Column(type: Types::GUID)]
+    private string $id;
+
+    #[ORM\Column(type: Types::GUID)]
+    private string $companyId;
+
+    #[ORM\Column(type: Types::STRING, length: 255)]
+    private string $connectionRef;
+
+    #[ORM\Column(type: Types::STRING, length: 64, enumType: IngestSource::class)]
+    private IngestSource $source;
+
+    #[ORM\Column(type: Types::STRING, length: 100)]
+    private string $resourceType;
+
+    #[ORM\Column(type: Types::STRING, length: 255, options: ['default' => ''])]
+    private string $shopRef;
+
+    #[ORM\Column(type: Types::STRING, length: 32, enumType: SyncJobKind::class)]
+    private SyncJobKind $kind;
+
+    #[ORM\Column(type: Types::STRING, length: 32, enumType: SyncJobStatus::class, options: ['default' => 'open'])]
+    private SyncJobStatus $status = SyncJobStatus::OPEN;
+
+    #[ORM\Column(type: Types::DATE_IMMUTABLE, nullable: true)]
+    private ?\DateTimeImmutable $windowFrom;
+
+    #[ORM\Column(type: Types::DATE_IMMUTABLE, nullable: true)]
+    private ?\DateTimeImmutable $windowTo;
+
+    #[ORM\Column(type: Types::GUID, nullable: true)]
+    private ?string $parentJobId;
+
+    #[ORM\Column(type: Types::INTEGER, options: ['default' => 0])]
+    private int $progressTotal = 0;
+
+    #[ORM\Column(type: Types::INTEGER, options: ['default' => 0])]
+    private int $progressDone = 0;
+
+    #[ORM\Column(type: Types::STRING, length: 1024, nullable: true)]
+    private ?string $cursorSnapshot = null;
+
+    #[ORM\Column(type: Types::INTEGER, options: ['default' => 0])]
+    private int $attempts = 0;
+
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $lastError = null;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6, nullable: true)]
+    private ?\DateTimeImmutable $startedAt = null;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6, nullable: true)]
+    private ?\DateTimeImmutable $finishedAt = null;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6)]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6)]
+    private \DateTimeImmutable $updatedAt;
+
+    public function __construct(
+        string $companyId,
+        string $connectionRef,
+        IngestSource $source,
+        string $resourceType,
+        SyncJobKind $kind,
+        ?\DateTimeImmutable $windowFrom = null,
+        ?\DateTimeImmutable $windowTo = null,
+        string $shopRef = '',
+        ?string $parentJobId = null,
+    ) {
+        Assert::uuid($companyId);
+        Assert::notEmpty($connectionRef);
+        Assert::notEmpty($resourceType);
+
+        if (null !== $parentJobId) {
+            Assert::uuid($parentJobId);
+        }
+
+        if (SyncJobKind::BACKFILL === $kind && (null === $windowFrom || null === $windowTo)) {
+            throw new \DomainException('Backfill sync job requires a window.');
+        }
+
+        if (null !== $windowFrom && null !== $windowTo && $windowFrom > $windowTo) {
+            throw new \DomainException('windowFrom cannot be later than windowTo.');
+        }
+
+        $now = new \DateTimeImmutable();
+
+        $this->id = Uuid::uuid7()->toString();
+        $this->companyId = $companyId;
+        $this->connectionRef = $connectionRef;
+        $this->source = $source;
+        $this->resourceType = $resourceType;
+        $this->kind = $kind;
+        $this->windowFrom = $windowFrom;
+        $this->windowTo = $windowTo;
+        $this->shopRef = $shopRef;
+        $this->parentJobId = $parentJobId;
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+    }
+
+    public function markRunning(): void
+    {
+        $this->transitionTo(SyncJobStatus::RUNNING);
+
+        ++$this->attempts;
+        $this->startedAt ??= new \DateTimeImmutable();
+        $this->finishedAt = null;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function markCompleted(?\DateTimeImmutable $finishedAt = null): void
+    {
+        $this->transitionTo(SyncJobStatus::COMPLETED);
+
+        $this->finishedAt = $finishedAt ?? new \DateTimeImmutable();
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function markFailed(string $reason, ?\DateTimeImmutable $finishedAt = null): void
+    {
+        Assert::notEmpty($reason);
+
+        $this->transitionTo(SyncJobStatus::FAILED);
+
+        $this->lastError = $reason;
+        $this->finishedAt = $finishedAt ?? new \DateTimeImmutable();
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function markCancelled(string $reason): void
+    {
+        Assert::notEmpty($reason);
+
+        $this->transitionTo(SyncJobStatus::CANCELLED);
+
+        $this->lastError = $reason;
+        $this->finishedAt = new \DateTimeImmutable();
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function incrementProgress(int $delta = 1): void
+    {
+        Assert::greaterThanEq($delta, 1);
+
+        $nextProgress = $this->progressDone + $delta;
+        if ($this->progressTotal > 0 && $nextProgress > $this->progressTotal) {
+            throw new \DomainException('progressDone cannot exceed progressTotal.');
+        }
+
+        $this->progressDone = $nextProgress;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function setProgressTotal(int $total): void
+    {
+        Assert::greaterThanEq($total, 1);
+
+        if ($this->progressTotal > 0) {
+            throw new \DomainException('progressTotal can be set only once.');
+        }
+
+        if ($total < $this->progressDone) {
+            throw new \DomainException('progressTotal cannot be lower than progressDone.');
+        }
+
+        $this->progressTotal = $total;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function setCursorSnapshot(string $value): void
+    {
+        Assert::notEmpty($value);
+
+        if (SyncJobStatus::OPEN !== $this->status) {
+            throw new \DomainException('cursorSnapshot can be set only before the job starts.');
+        }
+
+        if (null !== $this->cursorSnapshot) {
+            throw new \DomainException('cursorSnapshot can be set only once.');
+        }
+
+        $this->cursorSnapshot = $value;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getCompanyId(): string
+    {
+        return $this->companyId;
+    }
+
+    public function getConnectionRef(): string
+    {
+        return $this->connectionRef;
+    }
+
+    public function getSource(): IngestSource
+    {
+        return $this->source;
+    }
+
+    public function getResourceType(): string
+    {
+        return $this->resourceType;
+    }
+
+    public function getShopRef(): string
+    {
+        return $this->shopRef;
+    }
+
+    public function getKind(): SyncJobKind
+    {
+        return $this->kind;
+    }
+
+    public function getStatus(): SyncJobStatus
+    {
+        return $this->status;
+    }
+
+    public function getWindowFrom(): ?\DateTimeImmutable
+    {
+        return $this->windowFrom;
+    }
+
+    public function getWindowTo(): ?\DateTimeImmutable
+    {
+        return $this->windowTo;
+    }
+
+    public function getParentJobId(): ?string
+    {
+        return $this->parentJobId;
+    }
+
+    public function getProgressTotal(): int
+    {
+        return $this->progressTotal;
+    }
+
+    public function getProgressDone(): int
+    {
+        return $this->progressDone;
+    }
+
+    public function getCursorSnapshot(): ?string
+    {
+        return $this->cursorSnapshot;
+    }
+
+    public function getAttempts(): int
+    {
+        return $this->attempts;
+    }
+
+    public function getLastError(): ?string
+    {
+        return $this->lastError;
+    }
+
+    public function getStartedAt(): ?\DateTimeImmutable
+    {
+        return $this->startedAt;
+    }
+
+    public function getFinishedAt(): ?\DateTimeImmutable
+    {
+        return $this->finishedAt;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    private function transitionTo(SyncJobStatus $next): void
+    {
+        SyncJobTransitionPolicy::assertCanTransition($this->status, $next);
+        $this->status = $next;
+    }
+}

--- a/site/src/Ingestion/Enum/Capability.php
+++ b/site/src/Ingestion/Enum/Capability.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Enum;
+
+enum Capability: string
+{
+    case CAN_DISCOVER_SHOPS = 'can_discover_shops';
+    case CAN_PULL = 'can_pull';
+    case CAN_PUSH = 'can_push';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::CAN_DISCOVER_SHOPS => 'Обнаружение магазинов',
+            self::CAN_PULL => 'Загрузка данных',
+            self::CAN_PUSH => 'Отправка данных',
+        };
+    }
+}

--- a/site/src/Ingestion/Enum/NormalizationIssueKind.php
+++ b/site/src/Ingestion/Enum/NormalizationIssueKind.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Enum;
+
+enum NormalizationIssueKind: string
+{
+    case SUM_MISMATCH = 'sum_mismatch';
+    case MAPPER_FAILURE = 'mapper_failure';
+    case UNKNOWN_FIELD = 'unknown_field';
+    case CURRENCY_MISMATCH = 'currency_mismatch';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::SUM_MISMATCH => 'Сумма не сошлась',
+            self::MAPPER_FAILURE => 'Ошибка маппинга',
+            self::UNKNOWN_FIELD => 'Неизвестное поле',
+            self::CURRENCY_MISMATCH => 'Несовпадение валют',
+        };
+    }
+}

--- a/site/src/Ingestion/Enum/PLDirtyPeriodReason.php
+++ b/site/src/Ingestion/Enum/PLDirtyPeriodReason.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Enum;
+
+enum PLDirtyPeriodReason: string
+{
+    case INGEST = 'ingest';
+    case MANUAL = 'manual';
+    case REMAP = 'remap';
+    case MONTH_CHANGE = 'month_change';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::INGEST => 'Новые данные источника',
+            self::MANUAL => 'Ручной запуск',
+            self::REMAP => 'Изменение маппинга',
+            self::MONTH_CHANGE => 'Смена периода операции',
+        };
+    }
+}

--- a/site/src/Ingestion/Enum/PLDirtyPeriodStatus.php
+++ b/site/src/Ingestion/Enum/PLDirtyPeriodStatus.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Enum;
+
+enum PLDirtyPeriodStatus: string
+{
+    case PENDING = 'pending';
+    case REBUILDING = 'rebuilding';
+    case DONE = 'done';
+    case FAILED = 'failed';
+    case BLOCKED_BY_CLOSE = 'blocked_by_close';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::PENDING => 'Ожидает перегенерации',
+            self::REBUILDING => 'Перегенерируется',
+            self::DONE => 'Готово',
+            self::FAILED => 'Ошибка',
+            self::BLOCKED_BY_CLOSE => 'Заблокировано закрытием',
+        };
+    }
+
+    public function isTerminal(): bool
+    {
+        return self::DONE === $this
+            || self::FAILED === $this
+            || self::BLOCKED_BY_CLOSE === $this;
+    }
+
+    public function canTransitionTo(self $next): bool
+    {
+        return match ($this) {
+            self::PENDING => self::REBUILDING === $next || self::BLOCKED_BY_CLOSE === $next,
+            self::REBUILDING => self::DONE === $next
+                || self::FAILED === $next
+                || self::BLOCKED_BY_CLOSE === $next,
+            self::DONE, self::FAILED, self::BLOCKED_BY_CLOSE => self::PENDING === $next,
+        };
+    }
+}

--- a/site/src/Ingestion/Enum/SyncJobKind.php
+++ b/site/src/Ingestion/Enum/SyncJobKind.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Enum;
+
+enum SyncJobKind: string
+{
+    case BACKFILL = 'backfill';
+    case INCREMENTAL = 'incremental';
+    case MANUAL = 'manual';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::BACKFILL => 'Бэкфилл',
+            self::INCREMENTAL => 'Инкремент',
+            self::MANUAL => 'Ручной',
+        };
+    }
+}

--- a/site/src/Ingestion/Enum/SyncJobStatus.php
+++ b/site/src/Ingestion/Enum/SyncJobStatus.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Enum;
+
+enum SyncJobStatus: string
+{
+    case OPEN = 'open';
+    case RUNNING = 'running';
+    case COMPLETED = 'completed';
+    case FAILED = 'failed';
+    case CANCELLED = 'cancelled';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::OPEN => 'Создан',
+            self::RUNNING => 'Выполняется',
+            self::COMPLETED => 'Завершён',
+            self::FAILED => 'Ошибка',
+            self::CANCELLED => 'Отменён',
+        };
+    }
+
+    public function isTerminal(): bool
+    {
+        return self::COMPLETED === $this
+            || self::FAILED === $this
+            || self::CANCELLED === $this;
+    }
+
+    public function canTransitionTo(self $next): bool
+    {
+        return match ($this) {
+            self::OPEN => self::RUNNING === $next || self::CANCELLED === $next,
+            self::RUNNING => self::RUNNING === $next
+                || self::COMPLETED === $next
+                || self::FAILED === $next
+                || self::CANCELLED === $next,
+            self::COMPLETED, self::FAILED, self::CANCELLED => false,
+        };
+    }
+}

--- a/site/src/Ingestion/Enum/TransactionDirection.php
+++ b/site/src/Ingestion/Enum/TransactionDirection.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Enum;
+
+enum TransactionDirection: string
+{
+    case IN = 'in';
+    case OUT = 'out';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::IN => 'Поступление',
+            self::OUT => 'Списание',
+        };
+    }
+}

--- a/site/src/Ingestion/Enum/TransactionType.php
+++ b/site/src/Ingestion/Enum/TransactionType.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Enum;
+
+enum TransactionType: string
+{
+    case SALE = 'sale';
+    case REFUND = 'refund';
+    case COMMISSION = 'commission';
+    case LOGISTICS = 'logistics';
+    case STORAGE = 'storage';
+    case LAST_MILE = 'last_mile';
+    case ACCEPTANCE = 'acceptance';
+    case ADVERTISING = 'advertising';
+    case PENALTY = 'penalty';
+    case BONUS = 'bonus';
+    case ACQUIRING = 'acquiring';
+    case ADJUSTMENT = 'adjustment';
+    case PAYOUT = 'payout';
+    case DEPOSIT = 'deposit';
+    case TRANSFER = 'transfer';
+    case TAX = 'tax';
+    case FEE = 'fee';
+    case OTHER = 'other';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::SALE => 'Продажа',
+            self::REFUND => 'Возврат',
+            self::COMMISSION => 'Комиссия',
+            self::LOGISTICS => 'Логистика',
+            self::STORAGE => 'Хранение',
+            self::LAST_MILE => 'Последняя миля',
+            self::ACCEPTANCE => 'Приёмка',
+            self::ADVERTISING => 'Реклама',
+            self::PENALTY => 'Штраф',
+            self::BONUS => 'Бонус',
+            self::ACQUIRING => 'Эквайринг',
+            self::ADJUSTMENT => 'Корректировка',
+            self::PAYOUT => 'Выплата',
+            self::DEPOSIT => 'Поступление',
+            self::TRANSFER => 'Перевод',
+            self::TAX => 'Налог',
+            self::FEE => 'Сбор',
+            self::OTHER => 'Прочее',
+        };
+    }
+}

--- a/site/src/Ingestion/Exception/ActiveBackfillExistsException.php
+++ b/site/src/Ingestion/Exception/ActiveBackfillExistsException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Exception;
+
+final class ActiveBackfillExistsException extends \DomainException
+{
+    public function getErrorCode(): string
+    {
+        return 'sync_backfill_already_running';
+    }
+}

--- a/site/src/Ingestion/Exception/ConnectorAuthException.php
+++ b/site/src/Ingestion/Exception/ConnectorAuthException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Exception;
+
+final class ConnectorAuthException extends \RuntimeException
+{
+    public function getErrorCode(): string
+    {
+        return 'connector_auth_failed';
+    }
+}

--- a/site/src/Ingestion/Exception/ConnectorNotFoundException.php
+++ b/site/src/Ingestion/Exception/ConnectorNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Exception;
+
+final class ConnectorNotFoundException extends \RuntimeException
+{
+    public function getErrorCode(): string
+    {
+        return 'connector_not_found';
+    }
+}

--- a/site/src/Ingestion/Exception/ConnectorTransientException.php
+++ b/site/src/Ingestion/Exception/ConnectorTransientException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Exception;
+
+final class ConnectorTransientException extends \RuntimeException
+{
+    public function getErrorCode(): string
+    {
+        return 'connector_transient_error';
+    }
+}

--- a/site/src/Ingestion/Exception/CursorNotFoundException.php
+++ b/site/src/Ingestion/Exception/CursorNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Exception;
+
+final class CursorNotFoundException extends \DomainException
+{
+    public function getErrorCode(): string
+    {
+        return 'sync_cursor_not_found';
+    }
+}

--- a/site/src/Ingestion/Exception/InvalidJobForSplitException.php
+++ b/site/src/Ingestion/Exception/InvalidJobForSplitException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Exception;
+
+final class InvalidJobForSplitException extends \DomainException
+{
+    public function getErrorCode(): string
+    {
+        return 'sync_job_not_splittable';
+    }
+}

--- a/site/src/Ingestion/Exception/JobAlreadySplitException.php
+++ b/site/src/Ingestion/Exception/JobAlreadySplitException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Exception;
+
+final class JobAlreadySplitException extends \DomainException
+{
+    public function getErrorCode(): string
+    {
+        return 'sync_job_already_split';
+    }
+}

--- a/site/src/Ingestion/Exception/MapperNotFoundException.php
+++ b/site/src/Ingestion/Exception/MapperNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Exception;
+
+final class MapperNotFoundException extends \RuntimeException
+{
+    public function getErrorCode(): string
+    {
+        return 'mapper_not_found';
+    }
+}

--- a/site/src/Ingestion/Exception/MoneyMismatchException.php
+++ b/site/src/Ingestion/Exception/MoneyMismatchException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Exception;
+
+final class MoneyMismatchException extends \DomainException
+{
+    public function getErrorCode(): string
+    {
+        return 'money_currency_mismatch';
+    }
+}

--- a/site/src/Ingestion/Exception/StaleTransactionUpdateException.php
+++ b/site/src/Ingestion/Exception/StaleTransactionUpdateException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Exception;
+
+final class StaleTransactionUpdateException extends \DomainException
+{
+    public function getErrorCode(): string
+    {
+        return 'transaction_stale_update';
+    }
+}

--- a/site/src/Ingestion/Exception/SyncJobNotFoundException.php
+++ b/site/src/Ingestion/Exception/SyncJobNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Exception;
+
+final class SyncJobNotFoundException extends \DomainException
+{
+    public function getErrorCode(): string
+    {
+        return 'sync_job_not_found';
+    }
+}

--- a/site/src/Ingestion/Exception/SyncJobTransitionException.php
+++ b/site/src/Ingestion/Exception/SyncJobTransitionException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Exception;
+
+final class SyncJobTransitionException extends \DomainException
+{
+    public function getErrorCode(): string
+    {
+        return 'sync_job_invalid_transition';
+    }
+}

--- a/site/src/Ingestion/Exception/UnsupportedCapabilityException.php
+++ b/site/src/Ingestion/Exception/UnsupportedCapabilityException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Exception;
+
+final class UnsupportedCapabilityException extends \DomainException
+{
+    public function getErrorCode(): string
+    {
+        return 'connector_capability_unsupported';
+    }
+}

--- a/site/src/Ingestion/Facade/IngestionFacade.php
+++ b/site/src/Ingestion/Facade/IngestionFacade.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Facade;
+
+use App\Ingestion\Entity\FinancialTransaction;
+use App\Ingestion\Repository\FinancialTransactionRepository;
+use App\Ingestion\Repository\NormalizationIssueRepository;
+
+final readonly class IngestionFacade
+{
+    public function __construct(
+        private FinancialTransactionRepository $financialTransactionRepository,
+        private NormalizationIssueRepository $normalizationIssueRepository,
+    ) {
+    }
+
+    /**
+     * @return iterable<FinancialTransaction>
+     */
+    public function getTransactions(
+        string $companyId,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        ?string $shopRef = null,
+    ): iterable {
+        return $this->financialTransactionRepository->iterateByPeriod($companyId, $from, $to, $shopRef);
+    }
+
+    public function countOpenIssues(string $companyId): int
+    {
+        return $this->normalizationIssueRepository->countOpenForCompany($companyId);
+    }
+}

--- a/site/src/Ingestion/Facade/SyncFacade.php
+++ b/site/src/Ingestion/Facade/SyncFacade.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Facade;
+
+use App\Ingestion\Application\Action\MarkJobCompletedAction;
+use App\Ingestion\Application\Action\MarkJobFailedAction;
+use App\Ingestion\Application\Action\MarkJobRunningAction;
+use App\Ingestion\Application\Action\SplitJobIntoChunksAction;
+use App\Ingestion\Application\Action\StartBackfillAction;
+use App\Ingestion\Application\Action\UpdateCursorAction;
+use App\Ingestion\Application\Command\MarkJobCompletedCommand;
+use App\Ingestion\Application\Command\MarkJobFailedCommand;
+use App\Ingestion\Application\Command\MarkJobRunningCommand;
+use App\Ingestion\Application\Command\SplitJobCommand;
+use App\Ingestion\Application\Command\StartBackfillCommand;
+use App\Ingestion\Application\Command\UpdateCursorCommand;
+use App\Ingestion\Application\DTO\SyncJobProgressView;
+use App\Ingestion\Exception\SyncJobNotFoundException;
+use App\Ingestion\Repository\SyncJobRepository;
+
+final readonly class SyncFacade
+{
+    public function __construct(
+        private StartBackfillAction $startBackfillAction,
+        private SplitJobIntoChunksAction $splitJobIntoChunksAction,
+        private MarkJobRunningAction $markJobRunningAction,
+        private MarkJobCompletedAction $markJobCompletedAction,
+        private MarkJobFailedAction $markJobFailedAction,
+        private UpdateCursorAction $updateCursorAction,
+        private SyncJobRepository $syncJobRepository,
+    ) {
+    }
+
+    public function startBackfill(StartBackfillCommand $command): string
+    {
+        $parentJobId = ($this->startBackfillAction)($command);
+        ($this->splitJobIntoChunksAction)(new SplitJobCommand($parentJobId, $command->companyId));
+
+        return $parentJobId;
+    }
+
+    public function markJobRunning(MarkJobRunningCommand $command): void
+    {
+        ($this->markJobRunningAction)($command);
+    }
+
+    public function markJobCompleted(MarkJobCompletedCommand $command): void
+    {
+        ($this->markJobCompletedAction)($command);
+    }
+
+    public function markJobFailed(MarkJobFailedCommand $command): void
+    {
+        ($this->markJobFailedAction)($command);
+    }
+
+    public function updateCursor(UpdateCursorCommand $command): void
+    {
+        ($this->updateCursorAction)($command);
+    }
+
+    public function getProgress(string $jobId, string $companyId): SyncJobProgressView
+    {
+        $job = $this->syncJobRepository->findByIdAndCompany($jobId, $companyId);
+        if (null === $job) {
+            throw new SyncJobNotFoundException('Sync job was not found.');
+        }
+
+        return new SyncJobProgressView(
+            jobId: $job->getId(),
+            status: $job->getStatus(),
+            progressDone: $job->getProgressDone(),
+            progressTotal: $job->getProgressTotal(),
+            attempts: $job->getAttempts(),
+            lastError: $job->getLastError(),
+        );
+    }
+}

--- a/site/src/Ingestion/Infrastructure/Api/Ozon/CredentialFacadeOzonCredentialProvider.php
+++ b/site/src/Ingestion/Infrastructure/Api/Ozon/CredentialFacadeOzonCredentialProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Api\Ozon;
+
+use App\Ingestion\Facade\CredentialFacade;
+
+final readonly class CredentialFacadeOzonCredentialProvider implements OzonCredentialProviderInterface
+{
+    public function __construct(private CredentialFacade $credentialFacade)
+    {
+    }
+
+    /**
+     * @return array{api_key: string, client_id: ?string}
+     */
+    public function read(string $companyId, string $connectionRef): array
+    {
+        /** @var array{api_key: string, client_id: ?string} $payload */
+        $payload = $this->credentialFacade->read($companyId, $connectionRef);
+
+        return $payload;
+    }
+}

--- a/site/src/Ingestion/Infrastructure/Api/Ozon/LegacyOzonClientAdapter.php
+++ b/site/src/Ingestion/Infrastructure/Api/Ozon/LegacyOzonClientAdapter.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Api\Ozon;
+
+use App\Ingestion\Exception\ConnectorAuthException;
+use App\Ingestion\Exception\ConnectorTransientException;
+use App\Ingestion\Exception\CredentialNotFoundException;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final readonly class LegacyOzonClientAdapter implements OzonClientAdapterInterface
+{
+    private const BASE_URL = 'https://api-seller.ozon.ru';
+    private const TRANSACTION_LIST_ENDPOINT = '/v3/finance/transaction/list';
+    private const REALIZATION_ENDPOINT = '/v2/finance/realization';
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private OzonCredentialProviderInterface $credentialProvider,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function fetchTransactionList(
+        string $companyId,
+        string $connectionRef,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        int $page,
+        int $pageSize,
+    ): OzonRawPage {
+        if ($from > $to) {
+            throw new \InvalidArgumentException('Ozon transaction list dateFrom cannot be later than dateTo.');
+        }
+
+        $payload = $this->requestJson(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            endpoint: self::TRANSACTION_LIST_ENDPOINT,
+            json: [
+                'filter' => [
+                    'date' => [
+                        'from' => $from->format('Y-m-d\T00:00:00.000\Z'),
+                        'to' => $to->format('Y-m-d\T23:59:59.000\Z'),
+                    ],
+                    'transaction_type' => 'all',
+                    'operation_type' => [],
+                    'posting_number' => '',
+                ],
+                'page' => $page,
+                'page_size' => $pageSize,
+            ],
+        );
+
+        $result = $payload['result'] ?? null;
+        if (!is_array($result)) {
+            throw new \RuntimeException('Ozon transaction list returned unexpected payload: result is missing.');
+        }
+
+        $operations = $result['operations'] ?? [];
+        if (!is_array($operations)) {
+            throw new \RuntimeException('Ozon transaction list returned unexpected payload: operations is not an array.');
+        }
+
+        $pageCount = max($page, (int) ($result['page_count'] ?? $page));
+
+        /** @var list<array<string, mixed>> $rows */
+        $rows = array_values(array_filter($operations, static fn (mixed $row): bool => is_array($row)));
+
+        return new OzonRawPage(
+            rows: $rows,
+            hasMore: $page < $pageCount,
+            nextPageToken: $page < $pageCount ? (string) ($page + 1) : null,
+            metadata: ['page' => $page, 'pageCount' => $pageCount],
+        );
+    }
+
+    public function fetchRealization(
+        string $companyId,
+        string $connectionRef,
+        int $year,
+        int $month,
+    ): OzonRawPage {
+        if ($month < 1 || $month > 12) {
+            throw new \InvalidArgumentException(sprintf('Invalid Ozon realization month: %d.', $month));
+        }
+
+        $payload = $this->requestJson(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            endpoint: self::REALIZATION_ENDPOINT,
+            json: [
+                'month' => $month,
+                'year' => $year,
+            ],
+        );
+
+        $result = $payload['result'] ?? null;
+        if (!is_array($result)) {
+            throw new \RuntimeException('Ozon realization returned unexpected payload: result is missing.');
+        }
+
+        $rows = $result['rows'] ?? [];
+        if (!is_array($rows)) {
+            throw new \RuntimeException('Ozon realization returned unexpected payload: rows is not an array.');
+        }
+
+        $header = is_array($result['header'] ?? null) ? $result['header'] : [];
+        $headerAdditional = is_array($result['header_additional'] ?? null) ? $result['header_additional'] : [];
+
+        /** @var list<array<string, mixed>> $rowList */
+        $rowList = array_values(array_filter($rows, static fn (mixed $row): bool => is_array($row)));
+
+        return new OzonRawPage(
+            rows: $rowList,
+            hasMore: false,
+            metadata: [
+                'year' => $year,
+                'month' => $month,
+                'header' => $header,
+                'headerAdditional' => $headerAdditional,
+            ],
+        );
+    }
+
+    /**
+     * @return list<OzonShopDescriptor>
+     */
+    public function listClusters(string $companyId, string $connectionRef): array
+    {
+        $this->credentials($companyId, $connectionRef);
+
+        return [
+            new OzonShopDescriptor(
+                externalId: $connectionRef,
+                name: 'Ozon Seller',
+                currency: 'RUB',
+                metadata: ['connectionRef' => $connectionRef],
+            ),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $json
+     *
+     * @return array<string, mixed>
+     */
+    private function requestJson(
+        string $companyId,
+        string $connectionRef,
+        string $endpoint,
+        array $json,
+    ): array {
+        $credentials = $this->credentials($companyId, $connectionRef);
+        $startedAt = microtime(true);
+        $statusCode = null;
+
+        try {
+            $response = $this->httpClient->request('POST', self::BASE_URL.$endpoint, [
+                'headers' => [
+                    'Client-Id' => $credentials['client_id'],
+                    'Api-Key' => $credentials['api_key'],
+                    'Content-Type' => 'application/json',
+                ],
+                'json' => $json,
+                'timeout' => 120,
+            ]);
+
+            $statusCode = $response->getStatusCode();
+            $this->classifyStatus($statusCode, $endpoint);
+
+            $content = $response->getContent(false);
+        } catch (TransportExceptionInterface $exception) {
+            throw new ConnectorTransientException(sprintf('Ozon transport error for %s.', $endpoint), previous: $exception);
+        } finally {
+            $this->logger->info('Ozon Seller API request finished.', [
+                'companyId' => $companyId,
+                'connectionRef' => $connectionRef,
+                'endpoint' => $endpoint,
+                'httpStatus' => $statusCode,
+                'durationMs' => (int) round((microtime(true) - $startedAt) * 1000),
+            ]);
+        }
+
+        try {
+            $decoded = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $exception) {
+            throw new \RuntimeException(sprintf('Ozon returned invalid JSON for %s.', $endpoint), previous: $exception);
+        }
+
+        if (!is_array($decoded)) {
+            throw new \RuntimeException(sprintf('Ozon returned unexpected non-object payload for %s.', $endpoint));
+        }
+
+        /* @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+
+    /**
+     * @return array{api_key: string, client_id: string}
+     */
+    private function credentials(string $companyId, string $connectionRef): array
+    {
+        try {
+            $payload = $this->credentialProvider->read($companyId, $connectionRef);
+        } catch (CredentialNotFoundException $exception) {
+            throw new ConnectorAuthException('Ozon Seller credentials were not found.', previous: $exception);
+        }
+
+        $apiKey = trim((string) ($payload['api_key'] ?? ''));
+        $clientId = trim((string) ($payload['client_id'] ?? ''));
+
+        if ('' === $apiKey || '' === $clientId) {
+            throw new ConnectorAuthException('Ozon Seller credentials are incomplete.');
+        }
+
+        return ['api_key' => $apiKey, 'client_id' => $clientId];
+    }
+
+    private function classifyStatus(int $statusCode, string $endpoint): void
+    {
+        if (401 === $statusCode || 403 === $statusCode) {
+            throw new ConnectorAuthException(sprintf('Ozon Seller API auth failed for %s.', $endpoint));
+        }
+
+        if (429 === $statusCode) {
+            throw new ConnectorTransientException(sprintf('Ozon Seller API rate limit for %s.', $endpoint));
+        }
+
+        if ($statusCode >= 500) {
+            throw new ConnectorTransientException(sprintf('Ozon Seller API server error %d for %s.', $statusCode, $endpoint));
+        }
+
+        if ($statusCode < 200 || $statusCode >= 300) {
+            throw new \RuntimeException(sprintf('Ozon Seller API returned HTTP %d for %s.', $statusCode, $endpoint));
+        }
+    }
+}

--- a/site/src/Ingestion/Infrastructure/Api/Ozon/OzonClientAdapterInterface.php
+++ b/site/src/Ingestion/Infrastructure/Api/Ozon/OzonClientAdapterInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Api\Ozon;
+
+interface OzonClientAdapterInterface
+{
+    public function fetchTransactionList(
+        string $companyId,
+        string $connectionRef,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        int $page,
+        int $pageSize,
+    ): OzonRawPage;
+
+    public function fetchRealization(
+        string $companyId,
+        string $connectionRef,
+        int $year,
+        int $month,
+    ): OzonRawPage;
+
+    /**
+     * @return list<OzonShopDescriptor>
+     */
+    public function listClusters(string $companyId, string $connectionRef): array;
+}

--- a/site/src/Ingestion/Infrastructure/Api/Ozon/OzonCredentialProviderInterface.php
+++ b/site/src/Ingestion/Infrastructure/Api/Ozon/OzonCredentialProviderInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Api\Ozon;
+
+interface OzonCredentialProviderInterface
+{
+    /**
+     * @return array{api_key: string, client_id: ?string}
+     */
+    public function read(string $companyId, string $connectionRef): array;
+}

--- a/site/src/Ingestion/Infrastructure/Api/Ozon/OzonRawPage.php
+++ b/site/src/Ingestion/Infrastructure/Api/Ozon/OzonRawPage.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Api\Ozon;
+
+final readonly class OzonRawPage
+{
+    /**
+     * @param list<array<string, mixed>> $rows
+     * @param array<string, mixed> $metadata
+     */
+    public function __construct(
+        public array $rows,
+        public bool $hasMore,
+        public ?string $nextPageToken = null,
+        public array $metadata = [],
+    ) {
+    }
+}

--- a/site/src/Ingestion/Infrastructure/Api/Ozon/OzonShopDescriptor.php
+++ b/site/src/Ingestion/Infrastructure/Api/Ozon/OzonShopDescriptor.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Api\Ozon;
+
+use Webmozart\Assert\Assert;
+
+final readonly class OzonShopDescriptor
+{
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function __construct(
+        public string $externalId,
+        public string $name,
+        public string $currency = 'RUB',
+        public array $metadata = [],
+    ) {
+        Assert::notEmpty($this->externalId);
+        Assert::notEmpty($this->name);
+        Assert::regex($this->currency, '/^[A-Z]{3}$/');
+    }
+}

--- a/site/src/Ingestion/Infrastructure/Messenger/SyncJobFailureSubscriber.php
+++ b/site/src/Ingestion/Infrastructure/Messenger/SyncJobFailureSubscriber.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Messenger;
+
+use App\Ingestion\Application\Command\MarkJobFailedCommand;
+use App\Ingestion\Facade\SyncFacade;
+use App\Ingestion\Message\RunSyncChunkMessage;
+use App\Ingestion\Repository\SyncJobRepository;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+
+final readonly class SyncJobFailureSubscriber implements EventSubscriberInterface
+{
+    private const REASON_MAX_LENGTH = 2000;
+
+    public function __construct(
+        private SyncJobRepository $syncJobRepository,
+        private SyncFacade $syncFacade,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            WorkerMessageFailedEvent::class => 'onMessageFailed',
+        ];
+    }
+
+    public function onMessageFailed(WorkerMessageFailedEvent $event): void
+    {
+        if ($event->willRetry()) {
+            return;
+        }
+
+        $message = $event->getEnvelope()->getMessage();
+        if (!$message instanceof RunSyncChunkMessage) {
+            return;
+        }
+
+        $job = $this->syncJobRepository->findByIdAndCompany($message->jobId, $message->companyId);
+        if (null === $job || $job->getStatus()->isTerminal()) {
+            return;
+        }
+
+        $rootCause = $this->rootCause($event->getThrowable());
+        $reason = $this->failureReason($rootCause);
+
+        try {
+            $this->syncFacade->markJobFailed(new MarkJobFailedCommand(
+                jobId: $message->jobId,
+                companyId: $message->companyId,
+                reason: $reason,
+            ));
+        } catch (\Throwable $exception) {
+            $this->logger->error('Ingestion sync job exhausted retries but failure state could not be persisted.', [
+                'companyId' => $message->companyId,
+                'jobId' => $message->jobId,
+                'exceptionClass' => $exception::class,
+                'errorMessage' => $exception->getMessage(),
+            ]);
+
+            return;
+        }
+
+        $this->logger->warning('Ingestion sync job marked as failed after retries exhausted.', [
+            'companyId' => $message->companyId,
+            'jobId' => $message->jobId,
+            'messageType' => $message::class,
+            'errorClass' => $rootCause::class,
+            'errorMessage' => $rootCause->getMessage(),
+        ]);
+    }
+
+    private function rootCause(\Throwable $throwable): \Throwable
+    {
+        if ($throwable instanceof HandlerFailedException && null !== $throwable->getPrevious()) {
+            return $throwable->getPrevious();
+        }
+
+        return $throwable;
+    }
+
+    private function failureReason(\Throwable $throwable): string
+    {
+        $reason = $throwable::class;
+        if ('' !== $throwable->getMessage()) {
+            $reason .= ': '.$throwable->getMessage();
+        }
+
+        if (mb_strlen($reason, 'UTF-8') > self::REASON_MAX_LENGTH) {
+            return mb_substr($reason, 0, self::REASON_MAX_LENGTH, 'UTF-8');
+        }
+
+        return $reason;
+    }
+}

--- a/site/src/Ingestion/Message/NormalizeRawRecordMessage.php
+++ b/site/src/Ingestion/Message/NormalizeRawRecordMessage.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Message;
+
+use Webmozart\Assert\Assert;
+
+final readonly class NormalizeRawRecordMessage implements CompanyAwareMessage
+{
+    public function __construct(
+        public string $rawRecordId,
+        public string $companyId,
+    ) {
+        Assert::uuid($this->rawRecordId);
+        Assert::uuid($this->companyId);
+    }
+
+    public function getCompanyId(): string
+    {
+        return $this->companyId;
+    }
+}

--- a/site/src/Ingestion/Message/RunSyncChunkMessage.php
+++ b/site/src/Ingestion/Message/RunSyncChunkMessage.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Message;
+
+use Webmozart\Assert\Assert;
+
+final readonly class RunSyncChunkMessage implements CompanyAwareMessage
+{
+    public function __construct(
+        public string $companyId,
+        public string $jobId,
+    ) {
+        Assert::uuid($this->companyId);
+        Assert::uuid($this->jobId);
+    }
+
+    public function getCompanyId(): string
+    {
+        return $this->companyId;
+    }
+}

--- a/site/src/Ingestion/MessageHandler/NormalizeRawRecordHandler.php
+++ b/site/src/Ingestion/MessageHandler/NormalizeRawRecordHandler.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\MessageHandler;
+
+use App\Ingestion\Application\Action\NormalizeRawRecordAction;
+use App\Ingestion\Application\Command\NormalizeRawRecordCommand;
+use App\Ingestion\Message\NormalizeRawRecordMessage;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+final readonly class NormalizeRawRecordHandler
+{
+    public function __construct(
+        private NormalizeRawRecordAction $action,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(NormalizeRawRecordMessage $message): void
+    {
+        $this->logger->info('Ingestion raw normalization started.', [
+            'companyId' => $message->companyId,
+            'rawRecordId' => $message->rawRecordId,
+        ]);
+
+        try {
+            ($this->action)(new NormalizeRawRecordCommand($message->rawRecordId, $message->companyId));
+        } catch (\Throwable $exception) {
+            $this->logger->error('Ingestion raw normalization failed.', [
+                'companyId' => $message->companyId,
+                'rawRecordId' => $message->rawRecordId,
+                'exceptionClass' => $exception::class,
+                'errorMessage' => $exception->getMessage(),
+            ]);
+
+            throw $exception;
+        }
+    }
+}

--- a/site/src/Ingestion/MessageHandler/RunSyncChunkHandler.php
+++ b/site/src/Ingestion/MessageHandler/RunSyncChunkHandler.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\MessageHandler;
+
+use App\Ingestion\Application\Command\MarkJobCompletedCommand;
+use App\Ingestion\Application\Command\MarkJobFailedCommand;
+use App\Ingestion\Application\Command\MarkJobRunningCommand;
+use App\Ingestion\Application\Command\UpdateCursorCommand;
+use App\Ingestion\Application\DTO\PullRequest;
+use App\Ingestion\Application\Service\IngestRateLimitGuard;
+use App\Ingestion\Domain\Service\ConnectorRegistry;
+use App\Ingestion\Exception\ConnectorAuthException;
+use App\Ingestion\Exception\ConnectorTransientException;
+use App\Ingestion\Exception\SyncJobNotFoundException;
+use App\Ingestion\Facade\RawStorageFacade;
+use App\Ingestion\Facade\SyncFacade;
+use App\Ingestion\Message\NormalizeRawRecordMessage;
+use App\Ingestion\Message\RunSyncChunkMessage;
+use App\Ingestion\Repository\IngestCursorRepository;
+use App\Ingestion\Repository\SyncJobRepository;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Lock\LockInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[AsMessageHandler]
+final readonly class RunSyncChunkHandler
+{
+    public function __construct(
+        private SyncJobRepository $syncJobRepository,
+        private IngestCursorRepository $cursorRepository,
+        private ConnectorRegistry $connectorRegistry,
+        private RawStorageFacade $rawStorageFacade,
+        private SyncFacade $syncFacade,
+        private IngestRateLimitGuard $rateLimitGuard,
+        private MessageBusInterface $messageBus,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(RunSyncChunkMessage $message): void
+    {
+        $job = $this->syncJobRepository->findByIdAndCompany($message->jobId, $message->companyId);
+        if (null === $job) {
+            throw new SyncJobNotFoundException('Sync job was not found.');
+        }
+
+        if ($job->getStatus()->isTerminal()) {
+            $this->logger->info('Ingestion sync chunk skipped because job is terminal.', [
+                'companyId' => $message->companyId,
+                'jobId' => $message->jobId,
+                'status' => $job->getStatus()->value,
+            ]);
+
+            return;
+        }
+
+        $cursor = $this->cursorRepository->findOne(
+            $job->getCompanyId(),
+            $job->getConnectionRef(),
+            $job->getResourceType(),
+            $job->getShopRef(),
+        );
+        $cursorValue = $cursor?->getCursorValue();
+        $cursorSnapshot = null === $job->getStartedAt() && null !== $cursorValue && '' !== $cursorValue
+            ? $cursorValue
+            : null;
+
+        $this->syncFacade->markJobRunning(new MarkJobRunningCommand(
+            jobId: $job->getId(),
+            companyId: $job->getCompanyId(),
+            cursorSnapshot: $cursorSnapshot,
+        ));
+
+        $lock = null;
+
+        try {
+            $connector = $this->connectorRegistry->get($job->getSource());
+            $lock = $this->rateLimitGuard->acquire(sprintf('%s:%s', $job->getSource()->value, $job->getConnectionRef()));
+            $result = $connector->pull(new PullRequest(
+                companyId: $job->getCompanyId(),
+                connectionRef: $job->getConnectionRef(),
+                shopRef: $job->getShopRef(),
+                resourceType: $job->getResourceType(),
+                cursorValue: $cursorValue,
+                windowFrom: $job->getWindowFrom(),
+                windowTo: $job->getWindowTo(),
+                syncJobId: $job->getId(),
+            ));
+
+            $records = $this->rawStorageFacade->store($result->rawBatch);
+            foreach ($records as $record) {
+                $this->messageBus->dispatch(new NormalizeRawRecordMessage($record->getId(), $record->getCompanyId()));
+            }
+
+            if (null !== $result->nextCursorValue && '' !== $result->nextCursorValue) {
+                $this->syncFacade->updateCursor(new UpdateCursorCommand(
+                    companyId: $job->getCompanyId(),
+                    connectionRef: $job->getConnectionRef(),
+                    resourceType: $job->getResourceType(),
+                    shopRef: $job->getShopRef(),
+                    newCursorValue: $result->nextCursorValue,
+                    syncJobId: $job->getId(),
+                    fetchedAt: new \DateTimeImmutable(),
+                ));
+            }
+
+            $this->syncFacade->markJobCompleted(new MarkJobCompletedCommand($job->getId(), $job->getCompanyId()));
+        } catch (ConnectorAuthException $exception) {
+            $this->markJobFailed($job->getId(), $job->getCompanyId(), 'auth');
+
+            throw new UnrecoverableMessageHandlingException('Ingestion connector authentication failed.', 0, $exception);
+        } catch (ConnectorTransientException $exception) {
+            $this->logger->warning('Ingestion connector transient failure; message will be retried.', [
+                'companyId' => $job->getCompanyId(),
+                'jobId' => $job->getId(),
+                'exceptionClass' => $exception::class,
+                'errorMessage' => $exception->getMessage(),
+            ]);
+
+            throw $exception;
+        } catch (\Throwable $exception) {
+            $this->markJobFailed($job->getId(), $job->getCompanyId(), $this->failureReason($exception));
+
+            throw $exception;
+        } finally {
+            $this->releaseLock($lock);
+        }
+    }
+
+    private function markJobFailed(string $jobId, string $companyId, string $reason): void
+    {
+        try {
+            $this->syncFacade->markJobFailed(new MarkJobFailedCommand($jobId, $companyId, $reason));
+        } catch (\Throwable $exception) {
+            $this->logger->error('Ingestion sync job failed but failure state could not be persisted.', [
+                'companyId' => $companyId,
+                'jobId' => $jobId,
+                'exceptionClass' => $exception::class,
+                'errorMessage' => $exception->getMessage(),
+            ]);
+        }
+    }
+
+    private function failureReason(\Throwable $exception): string
+    {
+        $message = $exception->getMessage();
+        if ('' === $message) {
+            $message = $exception::class;
+        }
+
+        return substr($message, 0, 2000);
+    }
+
+    private function releaseLock(?LockInterface $lock): void
+    {
+        if (null === $lock) {
+            return;
+        }
+
+        try {
+            $lock->release();
+        } catch (\Throwable $exception) {
+            $this->logger->warning('Ingestion rate-limit lock release failed.', [
+                'exceptionClass' => $exception::class,
+                'errorMessage' => $exception->getMessage(),
+            ]);
+        }
+    }
+}

--- a/site/src/Ingestion/MessageHandler/RunSyncChunkHandler.php
+++ b/site/src/Ingestion/MessageHandler/RunSyncChunkHandler.php
@@ -11,6 +11,7 @@ use App\Ingestion\Application\Command\UpdateCursorCommand;
 use App\Ingestion\Application\DTO\PullRequest;
 use App\Ingestion\Application\Service\IngestRateLimitGuard;
 use App\Ingestion\Domain\Service\ConnectorRegistry;
+use App\Ingestion\Entity\SyncJob;
 use App\Ingestion\Exception\ConnectorAuthException;
 use App\Ingestion\Exception\ConnectorTransientException;
 use App\Ingestion\Exception\SyncJobNotFoundException;
@@ -58,14 +59,9 @@ final readonly class RunSyncChunkHandler
             return;
         }
 
-        $cursor = $this->cursorRepository->findOne(
-            $job->getCompanyId(),
-            $job->getConnectionRef(),
-            $job->getResourceType(),
-            $job->getShopRef(),
-        );
-        $cursorValue = $cursor?->getCursorValue();
-        $cursorSnapshot = null === $job->getStartedAt() && null !== $cursorValue && '' !== $cursorValue
+        $isWindowed = $this->isWindowed($job);
+        $cursorValue = $isWindowed ? null : $this->sharedCursorValue($job);
+        $cursorSnapshot = !$isWindowed && null === $job->getStartedAt() && null !== $cursorValue && '' !== $cursorValue
             ? $cursorValue
             : null;
 
@@ -80,33 +76,42 @@ final readonly class RunSyncChunkHandler
         try {
             $connector = $this->connectorRegistry->get($job->getSource());
             $lock = $this->rateLimitGuard->acquire(sprintf('%s:%s', $job->getSource()->value, $job->getConnectionRef()));
-            $result = $connector->pull(new PullRequest(
-                companyId: $job->getCompanyId(),
-                connectionRef: $job->getConnectionRef(),
-                shopRef: $job->getShopRef(),
-                resourceType: $job->getResourceType(),
-                cursorValue: $cursorValue,
-                windowFrom: $job->getWindowFrom(),
-                windowTo: $job->getWindowTo(),
-                syncJobId: $job->getId(),
-            ));
 
-            $records = $this->rawStorageFacade->store($result->rawBatch);
-            foreach ($records as $record) {
-                $this->messageBus->dispatch(new NormalizeRawRecordMessage($record->getId(), $record->getCompanyId()));
-            }
-
-            if (null !== $result->nextCursorValue && '' !== $result->nextCursorValue) {
-                $this->syncFacade->updateCursor(new UpdateCursorCommand(
+            do {
+                $result = $connector->pull(new PullRequest(
                     companyId: $job->getCompanyId(),
                     connectionRef: $job->getConnectionRef(),
-                    resourceType: $job->getResourceType(),
                     shopRef: $job->getShopRef(),
-                    newCursorValue: $result->nextCursorValue,
+                    resourceType: $job->getResourceType(),
+                    cursorValue: $cursorValue,
+                    windowFrom: $job->getWindowFrom(),
+                    windowTo: $job->getWindowTo(),
                     syncJobId: $job->getId(),
-                    fetchedAt: new \DateTimeImmutable(),
                 ));
-            }
+
+                $records = $this->rawStorageFacade->store($result->rawBatch);
+                foreach ($records as $record) {
+                    $this->messageBus->dispatch(new NormalizeRawRecordMessage($record->getId(), $record->getCompanyId()));
+                }
+
+                if (null !== $result->nextCursorValue && '' !== $result->nextCursorValue) {
+                    if (!$isWindowed) {
+                        $this->syncFacade->updateCursor(new UpdateCursorCommand(
+                            companyId: $job->getCompanyId(),
+                            connectionRef: $job->getConnectionRef(),
+                            resourceType: $job->getResourceType(),
+                            shopRef: $job->getShopRef(),
+                            newCursorValue: $result->nextCursorValue,
+                            syncJobId: $job->getId(),
+                            fetchedAt: new \DateTimeImmutable(),
+                        ));
+                    }
+
+                    $cursorValue = $result->nextCursorValue;
+                } elseif ($result->hasMore) {
+                    throw new \RuntimeException('Ingestion connector returned hasMore without next cursor.');
+                }
+            } while ($result->hasMore);
 
             $this->syncFacade->markJobCompleted(new MarkJobCompletedCommand($job->getId(), $job->getCompanyId()));
         } catch (ConnectorAuthException $exception) {
@@ -129,6 +134,23 @@ final readonly class RunSyncChunkHandler
         } finally {
             $this->releaseLock($lock);
         }
+    }
+
+    private function sharedCursorValue(SyncJob $job): ?string
+    {
+        $cursor = $this->cursorRepository->findOne(
+            $job->getCompanyId(),
+            $job->getConnectionRef(),
+            $job->getResourceType(),
+            $job->getShopRef(),
+        );
+
+        return $cursor?->getCursorValue();
+    }
+
+    private function isWindowed(SyncJob $job): bool
+    {
+        return null !== $job->getWindowFrom() || null !== $job->getWindowTo();
     }
 
     private function markJobFailed(string $jobId, string $companyId, string $reason): void

--- a/site/src/Ingestion/Repository/CounterpartyRepository.php
+++ b/site/src/Ingestion/Repository/CounterpartyRepository.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Repository;
+
+use App\Ingestion\Entity\Counterparty;
+use App\Ingestion\Enum\IngestSource;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Counterparty>
+ */
+final class CounterpartyRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Counterparty::class);
+    }
+
+    public function findByNaturalKey(string $companyId, IngestSource $source, string $externalKey): ?Counterparty
+    {
+        return $this->createQueryBuilder('counterparty')
+            ->andWhere('counterparty.companyId = :companyId')
+            ->andWhere('counterparty.source = :source')
+            ->andWhere('counterparty.externalKey = :externalKey')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('source', $source->value)
+            ->setParameter('externalKey', $externalKey)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    public function getOrCreate(
+        string $companyId,
+        IngestSource $source,
+        string $externalKey,
+        string $name,
+    ): Counterparty {
+        $counterparty = $this->findByNaturalKey($companyId, $source, $externalKey);
+        if (null !== $counterparty) {
+            $counterparty->rename($name);
+
+            return $counterparty;
+        }
+
+        $counterparty = new Counterparty($companyId, $source, $externalKey, $name);
+        $this->getEntityManager()->persist($counterparty);
+
+        return $counterparty;
+    }
+}

--- a/site/src/Ingestion/Repository/FinancialTransactionRepository.php
+++ b/site/src/Ingestion/Repository/FinancialTransactionRepository.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Repository;
+
+use App\Ingestion\Entity\FinancialTransaction;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\TransactionType;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<FinancialTransaction>
+ */
+final class FinancialTransactionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, FinancialTransaction::class);
+    }
+
+    public function findByNaturalKey(
+        string $companyId,
+        IngestSource $source,
+        string $externalId,
+        TransactionType $type,
+    ): ?FinancialTransaction {
+        return $this->createQueryBuilder('transaction')
+            ->andWhere('transaction.companyId = :companyId')
+            ->andWhere('transaction.source = :source')
+            ->andWhere('transaction.externalId = :externalId')
+            ->andWhere('transaction.type = :type')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('source', $source->value)
+            ->setParameter('externalId', $externalId)
+            ->setParameter('type', $type->value)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    /**
+     * @return list<FinancialTransaction>
+     */
+    public function findByOperationGroup(string $companyId, string $operationGroupId): array
+    {
+        return $this->createQueryBuilder('transaction')
+            ->andWhere('transaction.companyId = :companyId')
+            ->andWhere('transaction.operationGroupId = :operationGroupId')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('operationGroupId', $operationGroupId)
+            ->orderBy('transaction.occurredAt', 'ASC')
+            ->addOrderBy('transaction.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * @return iterable<FinancialTransaction>
+     */
+    public function iterateByPeriod(
+        string $companyId,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        ?string $shopRef = null,
+    ): iterable {
+        $queryBuilder = $this->createQueryBuilder('transaction')
+            ->andWhere('transaction.companyId = :companyId')
+            ->andWhere('transaction.occurredAt >= :from')
+            ->andWhere('transaction.occurredAt <= :to')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('from', $from)
+            ->setParameter('to', $to)
+            ->orderBy('transaction.occurredAt', 'ASC')
+            ->addOrderBy('transaction.id', 'ASC');
+
+        if (null !== $shopRef) {
+            $queryBuilder
+                ->andWhere('transaction.shopRef = :shopRef')
+                ->setParameter('shopRef', $shopRef);
+        }
+
+        return $queryBuilder->getQuery()->toIterable();
+    }
+
+    /**
+     * @return list<FinancialTransaction>
+     */
+    public function findByRawRecordId(string $companyId, string $rawRecordId): array
+    {
+        return $this->createQueryBuilder('transaction')
+            ->andWhere('transaction.companyId = :companyId')
+            ->andWhere('transaction.rawRecordId = :rawRecordId')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('rawRecordId', $rawRecordId)
+            ->orderBy('transaction.occurredAt', 'ASC')
+            ->addOrderBy('transaction.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/site/src/Ingestion/Repository/FinancialTransactionRepository.php
+++ b/site/src/Ingestion/Repository/FinancialTransactionRepository.php
@@ -9,12 +9,18 @@ use App\Ingestion\Enum\IngestSource;
 use App\Ingestion\Enum\TransactionType;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * @extends ServiceEntityRepository<FinancialTransaction>
  */
-final class FinancialTransactionRepository extends ServiceEntityRepository
+final class FinancialTransactionRepository extends ServiceEntityRepository implements ResetInterface
 {
+    /**
+     * @var array<string, FinancialTransaction>
+     */
+    private array $registryCache = [];
+
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, FinancialTransaction::class);
@@ -26,7 +32,17 @@ final class FinancialTransactionRepository extends ServiceEntityRepository
         string $externalId,
         TransactionType $type,
     ): ?FinancialTransaction {
-        return $this->createQueryBuilder('transaction')
+        $cacheKey = $this->naturalKey($companyId, $source, $externalId, $type);
+        if (isset($this->registryCache[$cacheKey])) {
+            $transaction = $this->registryCache[$cacheKey];
+            if ($this->getEntityManager()->contains($transaction)) {
+                return $transaction;
+            }
+
+            unset($this->registryCache[$cacheKey]);
+        }
+
+        $transaction = $this->createQueryBuilder('transaction')
             ->andWhere('transaction.companyId = :companyId')
             ->andWhere('transaction.source = :source')
             ->andWhere('transaction.externalId = :externalId')
@@ -37,6 +53,27 @@ final class FinancialTransactionRepository extends ServiceEntityRepository
             ->setParameter('type', $type->value)
             ->getQuery()
             ->getOneOrNullResult();
+
+        if ($transaction instanceof FinancialTransaction) {
+            $this->cache($transaction);
+        }
+
+        return $transaction;
+    }
+
+    public function cache(FinancialTransaction $transaction): void
+    {
+        $this->registryCache[$this->naturalKey(
+            $transaction->getCompanyId(),
+            $transaction->getSource(),
+            $transaction->getExternalId(),
+            $transaction->getType(),
+        )] = $transaction;
+    }
+
+    public function reset(): void
+    {
+        $this->registryCache = [];
     }
 
     /**
@@ -97,5 +134,14 @@ final class FinancialTransactionRepository extends ServiceEntityRepository
             ->addOrderBy('transaction.id', 'ASC')
             ->getQuery()
             ->getResult();
+    }
+
+    private function naturalKey(
+        string $companyId,
+        IngestSource $source,
+        string $externalId,
+        TransactionType $type,
+    ): string {
+        return implode(':', [$companyId, $source->value, $externalId, $type->value]);
     }
 }

--- a/site/src/Ingestion/Repository/IngestCursorRepository.php
+++ b/site/src/Ingestion/Repository/IngestCursorRepository.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Repository;
+
+use App\Ingestion\Entity\IngestCursor;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<IngestCursor>
+ */
+final class IngestCursorRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, IngestCursor::class);
+    }
+
+    public function findOne(
+        string $companyId,
+        string $connectionRef,
+        string $resourceType,
+        string $shopRef = '',
+    ): ?IngestCursor {
+        return $this->createQueryBuilder('cursor')
+            ->andWhere('cursor.companyId = :companyId')
+            ->andWhere('cursor.connectionRef = :connectionRef')
+            ->andWhere('cursor.resourceType = :resourceType')
+            ->andWhere('cursor.shopRef = :shopRef')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('connectionRef', $connectionRef)
+            ->setParameter('resourceType', $resourceType)
+            ->setParameter('shopRef', $shopRef)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    public function getOrCreate(
+        string $companyId,
+        string $connectionRef,
+        string $resourceType,
+        string $shopRef = '',
+    ): IngestCursor {
+        $cursor = $this->findOne($companyId, $connectionRef, $resourceType, $shopRef);
+        if (null !== $cursor) {
+            return $cursor;
+        }
+
+        $cursor = new IngestCursor($companyId, $connectionRef, $resourceType, $shopRef);
+        $this->getEntityManager()->persist($cursor);
+
+        return $cursor;
+    }
+}

--- a/site/src/Ingestion/Repository/IngestRawRecordRepository.php
+++ b/site/src/Ingestion/Repository/IngestRawRecordRepository.php
@@ -30,6 +30,11 @@ final class IngestRawRecordRepository extends ServiceEntityRepository
             ->getOneOrNullResult();
     }
 
+    public function findByIdAndCompany(string $rawRecordId, string $companyId): ?IngestRawRecord
+    {
+        return $this->findOneByIdAndCompany($companyId, $rawRecordId);
+    }
+
     public function findLatestByCompanySourceExternalId(
         string $companyId,
         IngestSource $source,

--- a/site/src/Ingestion/Repository/NormalizationIssueRepository.php
+++ b/site/src/Ingestion/Repository/NormalizationIssueRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Repository;
+
+use App\Ingestion\Entity\NormalizationIssue;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<NormalizationIssue>
+ */
+final class NormalizationIssueRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, NormalizationIssue::class);
+    }
+
+    /**
+     * @return list<NormalizationIssue>
+     */
+    public function findOpenByRawRecord(string $companyId, string $rawRecordId): array
+    {
+        return $this->createQueryBuilder('issue')
+            ->andWhere('issue.companyId = :companyId')
+            ->andWhere('issue.rawRecordId = :rawRecordId')
+            ->andWhere('issue.resolvedAt IS NULL')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('rawRecordId', $rawRecordId)
+            ->orderBy('issue.createdAt', 'ASC')
+            ->addOrderBy('issue.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function countOpenForCompany(string $companyId): int
+    {
+        return (int) $this->createQueryBuilder('issue')
+            ->select('COUNT(issue.id)')
+            ->andWhere('issue.companyId = :companyId')
+            ->andWhere('issue.resolvedAt IS NULL')
+            ->setParameter('companyId', $companyId)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+}

--- a/site/src/Ingestion/Repository/PLDirtyPeriodRepository.php
+++ b/site/src/Ingestion/Repository/PLDirtyPeriodRepository.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Repository;
+
+use App\Ingestion\Entity\PLDirtyPeriod;
+use App\Ingestion\Enum\PLDirtyPeriodStatus;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<PLDirtyPeriod>
+ */
+final class PLDirtyPeriodRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, PLDirtyPeriod::class);
+    }
+
+    public function findOne(string $companyId, int $year, int $month, string $shopRef = ''): ?PLDirtyPeriod
+    {
+        return $this->createQueryBuilder('period')
+            ->andWhere('period.companyId = :companyId')
+            ->andWhere('period.periodYear = :year')
+            ->andWhere('period.periodMonth = :month')
+            ->andWhere('period.shopRef = :shopRef')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('year', $year)
+            ->setParameter('month', $month)
+            ->setParameter('shopRef', $shopRef)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    /**
+     * @return list<PLDirtyPeriod>
+     */
+    public function findPending(int $limit = 50): array
+    {
+        $limit = max(1, min(200, $limit));
+
+        return $this->createQueryBuilder('period')
+            ->andWhere('period.status = :status')
+            ->setParameter('status', PLDirtyPeriodStatus::PENDING->value)
+            ->orderBy('period.markedAt', 'ASC')
+            ->addOrderBy('period.createdAt', 'ASC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * @return list<PLDirtyPeriod>
+     */
+    public function findForCompany(string $companyId): array
+    {
+        return $this->createQueryBuilder('period')
+            ->andWhere('period.companyId = :companyId')
+            ->setParameter('companyId', $companyId)
+            ->orderBy('period.markedAt', 'DESC')
+            ->addOrderBy('period.createdAt', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * @return list<PLDirtyPeriod>
+     */
+    public function findPendingForCompany(string $companyId): array
+    {
+        return $this->createQueryBuilder('period')
+            ->andWhere('period.companyId = :companyId')
+            ->andWhere('period.status = :status')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('status', PLDirtyPeriodStatus::PENDING->value)
+            ->orderBy('period.markedAt', 'ASC')
+            ->addOrderBy('period.createdAt', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function countByStatus(string $companyId, PLDirtyPeriodStatus $status): int
+    {
+        return (int) $this->createQueryBuilder('period')
+            ->select('COUNT(period.id)')
+            ->andWhere('period.companyId = :companyId')
+            ->andWhere('period.status = :status')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('status', $status->value)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+}

--- a/site/src/Ingestion/Repository/SyncJobRepository.php
+++ b/site/src/Ingestion/Repository/SyncJobRepository.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Repository;
+
+use App\Ingestion\Entity\SyncJob;
+use App\Ingestion\Enum\SyncJobStatus;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<SyncJob>
+ */
+final class SyncJobRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, SyncJob::class);
+    }
+
+    public function findByIdAndCompany(string $id, string $companyId): ?SyncJob
+    {
+        return $this->createQueryBuilder('job')
+            ->andWhere('job.id = :id')
+            ->andWhere('job.companyId = :companyId')
+            ->setParameter('id', $id)
+            ->setParameter('companyId', $companyId)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    /**
+     * @return list<SyncJob>
+     */
+    public function findOpenChildrenOf(string $parentJobId, string $companyId): array
+    {
+        return $this->createQueryBuilder('job')
+            ->andWhere('job.parentJobId = :parentJobId')
+            ->andWhere('job.companyId = :companyId')
+            ->andWhere('job.status IN (:statuses)')
+            ->setParameter('parentJobId', $parentJobId)
+            ->setParameter('companyId', $companyId)
+            ->setParameter('statuses', [SyncJobStatus::OPEN->value, SyncJobStatus::RUNNING->value])
+            ->orderBy('job.windowFrom', 'ASC')
+            ->addOrderBy('job.createdAt', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function countChildrenByStatus(string $parentJobId, string $companyId, SyncJobStatus $status): int
+    {
+        return (int) $this->createQueryBuilder('job')
+            ->select('COUNT(job.id)')
+            ->andWhere('job.parentJobId = :parentJobId')
+            ->andWhere('job.companyId = :companyId')
+            ->andWhere('job.status = :status')
+            ->setParameter('parentJobId', $parentJobId)
+            ->setParameter('companyId', $companyId)
+            ->setParameter('status', $status->value)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    public function findLatestForResource(
+        string $companyId,
+        string $connectionRef,
+        string $resourceType,
+        string $shopRef = '',
+    ): ?SyncJob {
+        return $this->createQueryBuilder('job')
+            ->andWhere('job.companyId = :companyId')
+            ->andWhere('job.connectionRef = :connectionRef')
+            ->andWhere('job.resourceType = :resourceType')
+            ->andWhere('job.shopRef = :shopRef')
+            ->andWhere('job.status IN (:statuses)')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('connectionRef', $connectionRef)
+            ->setParameter('resourceType', $resourceType)
+            ->setParameter('shopRef', $shopRef)
+            ->setParameter('statuses', [SyncJobStatus::OPEN->value, SyncJobStatus::RUNNING->value])
+            ->orderBy('job.createdAt', 'DESC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+}

--- a/site/src/Shared/Domain/Exception/MoneyMismatchException.php
+++ b/site/src/Shared/Domain/Exception/MoneyMismatchException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Domain\Exception;
+
+final class MoneyMismatchException extends \DomainException
+{
+}

--- a/site/src/Shared/Domain/ValueObject/Money.php
+++ b/site/src/Shared/Domain/ValueObject/Money.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Domain\ValueObject;
+
+use App\Shared\Domain\Exception\MoneyMismatchException;
+use Webmozart\Assert\Assert;
+
+final readonly class Money
+{
+    private function __construct(
+        private int $amountMinor,
+        private string $currency,
+    ) {
+        Assert::regex($this->currency, '/^[A-Z]{3}$/');
+    }
+
+    public static function fromMinor(int $amountMinor, string $currency): self
+    {
+        return new self($amountMinor, strtoupper($currency));
+    }
+
+    public function add(self $other): self
+    {
+        $this->assertSameCurrency($other);
+
+        return new self($this->amountMinor + $other->amountMinor, $this->currency);
+    }
+
+    public function subtract(self $other): self
+    {
+        $this->assertSameCurrency($other);
+
+        return new self($this->amountMinor - $other->amountMinor, $this->currency);
+    }
+
+    public function negate(): self
+    {
+        return new self(-$this->amountMinor, $this->currency);
+    }
+
+    public function compareTo(self $other): int
+    {
+        $this->assertSameCurrency($other);
+
+        return $this->amountMinor <=> $other->amountMinor;
+    }
+
+    public function isZero(): bool
+    {
+        return 0 === $this->amountMinor;
+    }
+
+    public function amountMinor(): int
+    {
+        return $this->amountMinor;
+    }
+
+    public function currency(): string
+    {
+        return $this->currency;
+    }
+
+    private function assertSameCurrency(self $other): void
+    {
+        if ($this->currency !== $other->currency) {
+            throw new MoneyMismatchException(sprintf('Cannot operate on %s and %s money values.', $this->currency, $other->currency));
+        }
+    }
+}

--- a/site/tests/Fixtures/Ingestion/Ozon/realization_february_2026.json
+++ b/site/tests/Fixtures/Ingestion/Ozon/realization_february_2026.json
@@ -1,0 +1,26 @@
+{
+  "rows": [
+    {
+      "operation_id": "1234567890",
+      "operation_type": "OperationAgentDeliveredToCustomer",
+      "operation_type_name": "Финальная реализация",
+      "sale_date": "2026-02-18T09:30:00+00:00",
+      "report_date": "2026-03-05T00:00:00+00:00",
+      "posting_number": "12345-0001-1",
+      "sku": "100200300",
+      "seller_price": "1210.00",
+      "commission_amount": "-121.00",
+      "delivery_commission": "-35.00",
+      "services_amounts": {
+        "MarketplaceServiceItemDelivToCustomer": "-25.00",
+        "MarketplaceServiceItemDropoffPVZ": "-10.00"
+      },
+      "acquiring": "-18.50",
+      "currency": "RUB",
+      "_header": {
+        "doc_number": "OZON-REAL-2026-02",
+        "stop_date": "2026-02-28T23:59:59+00:00"
+      }
+    }
+  ]
+}

--- a/site/tests/Fixtures/Ingestion/Ozon/transaction_list_with_refund_and_services.json
+++ b/site/tests/Fixtures/Ingestion/Ozon/transaction_list_with_refund_and_services.json
@@ -1,0 +1,33 @@
+{
+  "rows": [
+    {
+      "operation_id": "refund-1001",
+      "operation_type": "ClientReturnAgentOperation",
+      "operation_type_name": "Возврат покупателя",
+      "operation_date": "2026-02-19T10:15:00+00:00",
+      "posting": {
+        "posting_number": "12345-0002-1"
+      },
+      "items": [
+        {
+          "sku": "100200301",
+          "name": "Anonymized returned product"
+        }
+      ],
+      "amount": "-550.40",
+      "sale_commission_amount": "55.04",
+      "return_delivery_charge_amount": "-20.00",
+      "services": [
+        {
+          "name": "MarketplaceServiceItemReturnAfterDelivToCustomer",
+          "price": "-15.00"
+        },
+        {
+          "name": "Premium placement",
+          "price": "-7.50"
+        }
+      ],
+      "currency": "RUB"
+    }
+  ]
+}

--- a/site/tests/Fixtures/Ingestion/Ozon/transaction_list_with_sale_and_commission.json
+++ b/site/tests/Fixtures/Ingestion/Ozon/transaction_list_with_sale_and_commission.json
@@ -1,0 +1,28 @@
+{
+  "rows": [
+    {
+      "operation_id": "1234567890",
+      "operation_type": "OperationAgentDeliveredToCustomer",
+      "operation_type_name": "Доставка покупателю",
+      "operation_date": "2026-02-18T09:30:00+00:00",
+      "posting": {
+        "posting_number": "12345-0001-1"
+      },
+      "items": [
+        {
+          "sku": "100200300",
+          "name": "Anonymized product"
+        }
+      ],
+      "accruals_for_sale": "1200.50",
+      "sale_commission_amount": "-120.05",
+      "deliv_charge_amount": "-35.00",
+      "services_amounts": {
+        "MarketplaceServiceItemDelivToCustomer": "-25.00",
+        "MarketplaceServiceItemDropoffPVZ": "-10.00"
+      },
+      "acquiring": "-18.00",
+      "currency": "RUB"
+    }
+  ]
+}

--- a/site/tests/Fixtures/Ingestion/Ozon/transaction_list_without_operation_id.json
+++ b/site/tests/Fixtures/Ingestion/Ozon/transaction_list_without_operation_id.json
@@ -1,0 +1,20 @@
+{
+  "rows": [
+    {
+      "operation_type": "MarketplaceServiceCorrection",
+      "operation_type_name": "Корректировка услуги",
+      "operation_date": "2026-02-20T11:00:00+00:00",
+      "posting": {
+        "posting_number": "fallback-posting-1"
+      },
+      "items": [
+        {
+          "sku": "fallback-sku-1",
+          "name": "Anonymized fallback product"
+        }
+      ],
+      "amount": "42.10",
+      "currency": "RUB"
+    }
+  ]
+}

--- a/site/tests/Integration/Finance/Application/MarkPnlPeriodDirtyActionTest.php
+++ b/site/tests/Integration/Finance/Application/MarkPnlPeriodDirtyActionTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Finance\Application;
+
+use App\Finance\Application\Action\MarkPnlPeriodDirtyAction;
+use App\Finance\Application\Command\MarkPnlPeriodDirtyCommand;
+use App\Ingestion\Enum\PLDirtyPeriodReason;
+use App\Ingestion\Enum\PLDirtyPeriodStatus;
+use App\Ingestion\Repository\PLDirtyPeriodRepository;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class MarkPnlPeriodDirtyActionTest extends IntegrationTestCase
+{
+    public function testMarkDirtyIsIdempotentAndReopensFailedPeriod(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        /** @var MarkPnlPeriodDirtyAction $action */
+        $action = self::getContainer()->get(MarkPnlPeriodDirtyAction::class);
+        /** @var PLDirtyPeriodRepository $repository */
+        $repository = self::getContainer()->get(PLDirtyPeriodRepository::class);
+
+        $command = new MarkPnlPeriodDirtyCommand($companyId, 2026, 2, '', PLDirtyPeriodReason::INGEST);
+        $action($command);
+        $action($command);
+
+        self::assertSame(1, $repository->countByStatus($companyId, PLDirtyPeriodStatus::PENDING));
+
+        $period = $repository->findOne($companyId, 2026, 2, '');
+        self::assertNotNull($period);
+        $period->markRebuilding();
+        $period->markFailed('temporary');
+        $this->em->flush();
+
+        $action($command);
+        $this->em->clear();
+
+        self::assertSame(PLDirtyPeriodStatus::PENDING, $repository->findOne($companyId, 2026, 2, '')?->getStatus());
+    }
+}

--- a/site/tests/Integration/Finance/Application/MarkPnlPeriodDirtyActionTest.php
+++ b/site/tests/Integration/Finance/Application/MarkPnlPeriodDirtyActionTest.php
@@ -14,7 +14,7 @@ use Ramsey\Uuid\Uuid;
 
 final class MarkPnlPeriodDirtyActionTest extends IntegrationTestCase
 {
-    public function testMarkDirtyIsIdempotentAndReopensFailedPeriod(): void
+    public function testMarkDirtyIsIdempotentAndReopensFailedOrBlockedPeriod(): void
     {
         $companyId = Uuid::uuid7()->toString();
         /** @var MarkPnlPeriodDirtyAction $action */
@@ -32,6 +32,16 @@ final class MarkPnlPeriodDirtyActionTest extends IntegrationTestCase
         self::assertNotNull($period);
         $period->markRebuilding();
         $period->markFailed('temporary');
+        $this->em->flush();
+
+        $action($command);
+        $this->em->clear();
+
+        self::assertSame(PLDirtyPeriodStatus::PENDING, $repository->findOne($companyId, 2026, 2, '')?->getStatus());
+
+        $period = $repository->findOne($companyId, 2026, 2, '');
+        self::assertNotNull($period);
+        $period->markBlockedByClose('closed month');
         $this->em->flush();
 
         $action($command);

--- a/site/tests/Integration/Finance/Application/RebuildPnlPeriodActionTest.php
+++ b/site/tests/Integration/Finance/Application/RebuildPnlPeriodActionTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Finance\Application;
+
+use App\Company\Entity\Company;
+use App\Company\Entity\ProjectDirection;
+use App\Company\Entity\User;
+use App\Finance\Application\Action\RebuildPnlPeriodAction;
+use App\Finance\Application\Command\RebuildPnlPeriodCommand;
+use App\Ingestion\Entity\FinancialTransaction;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\PLDirtyPeriodStatus;
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+use App\Ingestion\Repository\PLDirtyPeriodRepository;
+use App\Shared\Domain\ValueObject\Money;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class RebuildPnlPeriodActionTest extends IntegrationTestCase
+{
+    public function testRebuildCreatesCanonicalDailyAndMonthlyTotals(): void
+    {
+        $company = $this->createCompanyWithDefaultProject();
+        $companyId = (string) $company->getId();
+        $this->persistTransaction($companyId, TransactionType::SALE, TransactionDirection::IN, 12345, '2026-02-10 10:00:00 UTC', 'sale-1');
+        $this->persistTransaction($companyId, TransactionType::COMMISSION, TransactionDirection::OUT, 2345, '2026-02-10 12:00:00 UTC', 'commission-1');
+        $this->em->flush();
+
+        /** @var RebuildPnlPeriodAction $action */
+        $action = self::getContainer()->get(RebuildPnlPeriodAction::class);
+        $action(new RebuildPnlPeriodCommand($companyId, 2026, 2));
+
+        /** @var PLDirtyPeriodRepository $dirtyRepository */
+        $dirtyRepository = self::getContainer()->get(PLDirtyPeriodRepository::class);
+        self::assertSame(PLDirtyPeriodStatus::DONE, $dirtyRepository->findOne($companyId, 2026, 2, '')?->getStatus());
+
+        self::assertSame('123.45', $this->sumColumn('pl_daily_totals', $companyId, 'amount_income'));
+        self::assertSame('23.45', $this->sumColumn('pl_daily_totals', $companyId, 'amount_expense'));
+        self::assertSame('123.45', $this->sumColumn('pl_monthly_snapshots', $companyId, 'amount_income'));
+        self::assertSame('23.45', $this->sumColumn('pl_monthly_snapshots', $companyId, 'amount_expense'));
+        self::assertSame(2, (int) $this->connection->fetchOne('SELECT COUNT(*) FROM pl_daily_totals WHERE company_id = :company_id AND rebuilt_at IS NOT NULL', ['company_id' => $companyId]));
+    }
+
+    public function testSourceScopedRebuildIsFailedUntilFinanceSourceLinkingIsDecided(): void
+    {
+        $company = $this->createCompanyWithDefaultProject();
+        $companyId = (string) $company->getId();
+
+        /** @var RebuildPnlPeriodAction $action */
+        $action = self::getContainer()->get(RebuildPnlPeriodAction::class);
+        $action(new RebuildPnlPeriodCommand($companyId, 2026, 2, 'ozon:shop-1'));
+
+        /** @var PLDirtyPeriodRepository $dirtyRepository */
+        $dirtyRepository = self::getContainer()->get(PLDirtyPeriodRepository::class);
+        $period = $dirtyRepository->findOne($companyId, 2026, 2, 'ozon:shop-1');
+
+        self::assertSame(PLDirtyPeriodStatus::FAILED, $period?->getStatus());
+        self::assertStringContainsString('source-linking', (string) $period?->getLastError());
+    }
+
+    private function createCompanyWithDefaultProject(): Company
+    {
+        $user = new User(Uuid::uuid4()->toString());
+        $user->setEmail('pnl-rebuild@example.com');
+        $user->setPassword('password');
+        $company = new Company(Uuid::uuid4()->toString(), $user);
+        $company->setName('P&L rebuild company');
+        $project = new ProjectDirection(Uuid::uuid4()->toString(), $company, 'Основной');
+
+        foreach ([$user, $company, $project] as $entity) {
+            $this->em->persist($entity);
+        }
+        $this->em->flush();
+
+        return $company;
+    }
+
+    private function persistTransaction(
+        string $companyId,
+        TransactionType $type,
+        TransactionDirection $direction,
+        int $amountMinor,
+        string $occurredAt,
+        string $externalId,
+    ): void {
+        $this->em->persist(new FinancialTransaction(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            shopRef: 'ozon:shop-1',
+            source: IngestSource::OZON,
+            externalId: $externalId,
+            externalUpdatedAt: new \DateTimeImmutable($occurredAt),
+            operationGroupId: Uuid::uuid7()->toString(),
+            type: $type,
+            direction: $direction,
+            money: Money::fromMinor($amountMinor, 'RUB'),
+            occurredAt: new \DateTimeImmutable($occurredAt),
+            rawRecordId: Uuid::uuid7()->toString(),
+        ));
+    }
+
+    private function sumColumn(string $table, string $companyId, string $column): string
+    {
+        return (string) $this->connection->fetchOne(
+            sprintf('SELECT COALESCE(SUM(%s), 0)::numeric(18,2)::text FROM %s WHERE company_id = :company_id', $column, $table),
+            ['company_id' => $companyId],
+        );
+    }
+}

--- a/site/tests/Integration/Finance/Command/RebuildDirtyPnlPeriodsCommandTest.php
+++ b/site/tests/Integration/Finance/Command/RebuildDirtyPnlPeriodsCommandTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Finance\Command;
+
+use App\Finance\Message\RebuildPnlPeriodMessage;
+use App\Ingestion\Entity\PLDirtyPeriod;
+use App\Ingestion\Enum\PLDirtyPeriodReason;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+
+final class RebuildDirtyPnlPeriodsCommandTest extends IntegrationTestCase
+{
+    public function testCommandDispatchesPendingPeriodsOnly(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $pending = new PLDirtyPeriod($companyId, 2026, 2, '', PLDirtyPeriodReason::INGEST);
+        $done = new PLDirtyPeriod($companyId, 2026, 3, '', PLDirtyPeriodReason::INGEST);
+        $done->markRebuilding();
+        $done->markDone();
+
+        $this->em->persist($pending);
+        $this->em->persist($done);
+        $this->em->flush();
+
+        /** @var InMemoryTransport $transport */
+        $transport = self::getContainer()->get('messenger.transport.pnl_rebuild');
+        $transport->reset();
+
+        $application = new Application(self::$kernel);
+        $tester = new CommandTester($application->find('app:finance:rebuild-dirty-pnl-periods'));
+
+        self::assertSame(0, $tester->execute(['--max' => 10]));
+
+        $messages = array_map(
+            static fn ($envelope): object => $envelope->getMessage(),
+            $transport->getSent(),
+        );
+
+        self::assertCount(1, $messages);
+        self::assertInstanceOf(RebuildPnlPeriodMessage::class, $messages[0]);
+        self::assertSame(2026, $messages[0]->year);
+        self::assertSame(2, $messages[0]->month);
+    }
+}

--- a/site/tests/Integration/Finance/EventSubscriber/NormalizationCompletedSubscriberTest.php
+++ b/site/tests/Integration/Finance/EventSubscriber/NormalizationCompletedSubscriberTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Finance\EventSubscriber;
+
+use App\Finance\Message\MarkPnlPeriodDirtyMessage;
+use App\Ingestion\Domain\Event\AffectedPeriod;
+use App\Ingestion\Domain\Event\NormalizationCompletedEvent;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+
+final class NormalizationCompletedSubscriberTest extends IntegrationTestCase
+{
+    public function testDispatchesMarkDirtyMessagesForNewAndOldMoscowPeriods(): void
+    {
+        /** @var InMemoryTransport $transport */
+        $transport = self::getContainer()->get('messenger.transport.ingest_normalize');
+        $transport->reset();
+
+        /** @var EventDispatcherInterface $dispatcher */
+        $dispatcher = self::getContainer()->get(EventDispatcherInterface::class);
+        $companyId = Uuid::uuid7()->toString();
+
+        $dispatcher->dispatch(new NormalizationCompletedEvent(
+            companyId: $companyId,
+            rawRecordId: Uuid::uuid7()->toString(),
+            affectedPeriods: [
+                new AffectedPeriod(
+                    shopRef: 'ozon:shop-1',
+                    oldOccurredAt: new \DateTimeImmutable('2026-01-31 20:30:00 UTC'),
+                    newOccurredAt: new \DateTimeImmutable('2026-02-01 00:30:00 UTC'),
+                ),
+            ],
+        ));
+
+        $messages = array_map(
+            static fn ($envelope): object => $envelope->getMessage(),
+            $transport->getSent(),
+        );
+
+        self::assertCount(2, $messages);
+        self::assertContainsOnlyInstancesOf(MarkPnlPeriodDirtyMessage::class, $messages);
+        self::assertSame([2026, 2, 'ingest'], [$messages[0]->year, $messages[0]->month, $messages[0]->reasonValue]);
+        self::assertSame([2026, 1, 'month_change'], [$messages[1]->year, $messages[1]->month, $messages[1]->reasonValue]);
+    }
+}

--- a/site/tests/Integration/Finance/Repository/PLRebuildAuditRepositoryTest.php
+++ b/site/tests/Integration/Finance/Repository/PLRebuildAuditRepositoryTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Finance\Repository;
+
+use App\Company\Entity\Company;
+use App\Company\Entity\ProjectDirection;
+use App\Company\Entity\User;
+use App\Finance\Repository\PLDailyTotalRepository;
+use App\Finance\Repository\PLMonthlySnapshotRepository;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class PLRebuildAuditRepositoryTest extends IntegrationTestCase
+{
+    public function testDailyDeleteByAllShopsDeletesOnlyCompanyMonth(): void
+    {
+        [$companyA, $companyB, $projectA, $projectB] = $this->createCompaniesWithProjects();
+
+        /** @var PLDailyTotalRepository $repository */
+        $repository = self::getContainer()->get(PLDailyTotalRepository::class);
+
+        $repository->upsert($companyA->getId(), null, new \DateTimeImmutable('2026-02-10'), $projectA->getId(), '10.00', '0.00', false);
+        $repository->upsert($companyA->getId(), null, new \DateTimeImmutable('2026-03-01'), $projectA->getId(), '20.00', '0.00', false);
+        $repository->upsert($companyB->getId(), null, new \DateTimeImmutable('2026-02-10'), $projectB->getId(), '30.00', '0.00', false);
+
+        self::assertSame(1, $repository->deleteByCompanyShopAndMonth($companyA->getId(), '', 2026, 2));
+
+        self::assertSame(0, $this->countRows('pl_daily_totals', $companyA->getId(), 'date', '2026-02-10'));
+        self::assertSame(1, $this->countRows('pl_daily_totals', $companyA->getId(), 'date', '2026-03-01'));
+        self::assertSame(1, $this->countRows('pl_daily_totals', $companyB->getId(), 'date', '2026-02-10'));
+    }
+
+    public function testMonthlyDeleteByAllShopsDeletesOnlyCompanyPeriod(): void
+    {
+        [$companyA, $companyB] = $this->createCompaniesWithProjects();
+
+        /** @var PLMonthlySnapshotRepository $repository */
+        $repository = self::getContainer()->get(PLMonthlySnapshotRepository::class);
+
+        $repository->upsert($companyA->getId(), null, '2026-02', '10.00', '0.00');
+        $repository->upsert($companyA->getId(), null, '2026-03', '20.00', '0.00');
+        $repository->upsert($companyB->getId(), null, '2026-02', '30.00', '0.00');
+
+        self::assertSame(1, $repository->deleteByCompanyShopAndMonth($companyA->getId(), '', 2026, 2));
+
+        self::assertSame(0, $this->countRows('pl_monthly_snapshots', $companyA->getId(), 'period', '2026-02'));
+        self::assertSame(1, $this->countRows('pl_monthly_snapshots', $companyA->getId(), 'period', '2026-03'));
+        self::assertSame(1, $this->countRows('pl_monthly_snapshots', $companyB->getId(), 'period', '2026-02'));
+    }
+
+    public function testMonthlyShopScopedDeleteIsRejectedUntilPnlStoresShopRef(): void
+    {
+        [$companyA] = $this->createCompaniesWithProjects();
+
+        /** @var PLMonthlySnapshotRepository $monthlyRepository */
+        $monthlyRepository = self::getContainer()->get(PLMonthlySnapshotRepository::class);
+
+        $this->expectException(\LogicException::class);
+        $monthlyRepository->deleteByCompanyShopAndMonth($companyA->getId(), 'ozon:shop-1', 2026, 2);
+    }
+
+    public function testDailyShopScopedDeleteIsRejectedUntilPnlStoresShopRef(): void
+    {
+        [$companyA] = $this->createCompaniesWithProjects();
+
+        /** @var PLDailyTotalRepository $dailyRepository */
+        $dailyRepository = self::getContainer()->get(PLDailyTotalRepository::class);
+
+        $this->expectException(\LogicException::class);
+        $dailyRepository->deleteByCompanyShopAndMonth($companyA->getId(), 'ozon:shop-1', 2026, 2);
+    }
+
+    /**
+     * @return array{Company, Company, ProjectDirection, ProjectDirection}
+     */
+    private function createCompaniesWithProjects(): array
+    {
+        $userA = new User(Uuid::uuid4()->toString());
+        $userA->setEmail('pnl-a@example.com');
+        $userA->setPassword('password');
+        $companyA = new Company(Uuid::uuid4()->toString(), $userA);
+        $companyA->setName('P&L A');
+        $projectA = new ProjectDirection(Uuid::uuid4()->toString(), $companyA, 'Main A');
+
+        $userB = new User(Uuid::uuid4()->toString());
+        $userB->setEmail('pnl-b@example.com');
+        $userB->setPassword('password');
+        $companyB = new Company(Uuid::uuid4()->toString(), $userB);
+        $companyB->setName('P&L B');
+        $projectB = new ProjectDirection(Uuid::uuid4()->toString(), $companyB, 'Main B');
+
+        foreach ([$userA, $userB, $companyA, $companyB, $projectA, $projectB] as $entity) {
+            $this->em->persist($entity);
+        }
+        $this->em->flush();
+
+        return [$companyA, $companyB, $projectA, $projectB];
+    }
+
+    private function countRows(string $table, string $companyId, string $column, string $value): int
+    {
+        return (int) $this->connection->fetchOne(
+            sprintf('SELECT COUNT(*) FROM %s WHERE company_id = :company_id AND %s = :value', $table, $column),
+            ['company_id' => $companyId, 'value' => $value],
+        );
+    }
+}

--- a/site/tests/Integration/Ingestion/Application/NormalizeRawRecordActionTest.php
+++ b/site/tests/Integration/Ingestion/Application/NormalizeRawRecordActionTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Application;
+
+use App\Ingestion\Application\Action\NormalizeRawRecordAction;
+use App\Ingestion\Application\Command\NormalizeRawRecordCommand;
+use App\Ingestion\DTO\RawBatch;
+use App\Ingestion\Entity\FinancialTransaction;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\NormalizationIssueKind;
+use App\Ingestion\Enum\RawNormalizationStatus;
+use App\Ingestion\Facade\IngestionFacade;
+use App\Ingestion\Facade\RawStorageFacade;
+use App\Ingestion\Repository\FinancialTransactionRepository;
+use App\Ingestion\Repository\IngestRawRecordRepository;
+use App\Ingestion\Repository\NormalizationIssueRepository;
+use App\Tests\Integration\Ingestion\Fixtures\FakeConnector;
+use App\Tests\Integration\Ingestion\Fixtures\NormalizationCompletedRecorder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class NormalizeRawRecordActionTest extends IntegrationTestCase
+{
+    public function testNormalizesRawRecordUpsertsTransactionAndDispatchesEvent(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $operationGroupId = Uuid::uuid7()->toString();
+        $record = $this->storeRawRecord($companyId, [[
+            'externalId' => 'sale-1',
+            'externalUpdatedAt' => '2026-06-18T10:00:00+00:00',
+            'operationGroupId' => $operationGroupId,
+            'amountMinor' => 10000,
+            'controlAmountMinor' => 10000,
+            'currency' => 'RUB',
+            'occurredAt' => '2026-06-18T09:00:00+00:00',
+            'counterpartyExternalKey' => 'buyer-1',
+            'counterpartyName' => 'Buyer One',
+        ]]);
+
+        $recorder = $this->eventRecorder();
+        $recorder->reset();
+
+        $this->normalize($record->getId(), $companyId);
+        $this->em->clear();
+
+        /** @var IngestRawRecordRepository $rawRecordRepository */
+        $rawRecordRepository = self::getContainer()->get(IngestRawRecordRepository::class);
+        $rawRecord = $rawRecordRepository->findByIdAndCompany($record->getId(), $companyId);
+
+        self::assertNotNull($rawRecord);
+        self::assertSame(RawNormalizationStatus::DONE, $rawRecord->getNormalizationStatus());
+
+        /** @var FinancialTransactionRepository $transactionRepository */
+        $transactionRepository = self::getContainer()->get(FinancialTransactionRepository::class);
+        $transactions = $transactionRepository->findByRawRecordId($companyId, $record->getId());
+
+        self::assertCount(1, $transactions);
+        self::assertSame('sale-1', $transactions[0]->getExternalId());
+        self::assertSame(10000, $transactions[0]->getAmountMinor());
+        self::assertSame('RUB', $transactions[0]->getCurrency());
+        self::assertNotNull($transactions[0]->getCounterpartyId());
+
+        /** @var IngestionFacade $facade */
+        $facade = self::getContainer()->get(IngestionFacade::class);
+        self::assertSame(0, $facade->countOpenIssues($companyId));
+        self::assertSame(
+            [$transactions[0]->getId()],
+            array_map(
+                static fn (FinancialTransaction $transaction): string => $transaction->getId(),
+                iterator_to_array($facade->getTransactions(
+                    $companyId,
+                    new \DateTimeImmutable('2026-06-18 00:00:00'),
+                    new \DateTimeImmutable('2026-06-18 23:59:59'),
+                    'shop-1',
+                )),
+            ),
+        );
+
+        $events = $recorder->events();
+        self::assertCount(1, $events);
+        self::assertSame($companyId, $events[0]->companyId);
+        self::assertSame($record->getId(), $events[0]->rawRecordId);
+        self::assertCount(1, $events[0]->affectedPeriods);
+        self::assertNull($events[0]->affectedPeriods[0]->oldOccurredAt);
+        self::assertEquals(new \DateTimeImmutable('2026-06-18T09:00:00+00:00'), $events[0]->affectedPeriods[0]->newOccurredAt);
+    }
+
+    public function testControlSumMismatchRecordsIssueButMarksRawRecordDone(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $operationGroupId = Uuid::uuid7()->toString();
+        $record = $this->storeRawRecord($companyId, [[
+            'externalId' => 'sale-1',
+            'operationGroupId' => $operationGroupId,
+            'amountMinor' => 10000,
+            'controlAmountMinor' => 9000,
+            'currency' => 'RUB',
+        ]]);
+
+        $this->eventRecorder()->reset();
+        $this->normalize($record->getId(), $companyId);
+        $this->em->clear();
+
+        /** @var NormalizationIssueRepository $issueRepository */
+        $issueRepository = self::getContainer()->get(NormalizationIssueRepository::class);
+        $issues = $issueRepository->findOpenByRawRecord($companyId, $record->getId());
+
+        self::assertCount(1, $issues);
+        self::assertSame(NormalizationIssueKind::SUM_MISMATCH, $issues[0]->getKind());
+        self::assertSame($operationGroupId, $issues[0]->getOperationGroupId());
+        self::assertSame(9000, $issues[0]->getDetails()['expectedAmountMinor']);
+        self::assertSame(10000, $issues[0]->getDetails()['actualAmountMinor']);
+
+        /** @var IngestRawRecordRepository $rawRecordRepository */
+        $rawRecordRepository = self::getContainer()->get(IngestRawRecordRepository::class);
+        self::assertSame(
+            RawNormalizationStatus::DONE,
+            $rawRecordRepository->findByIdAndCompany($record->getId(), $companyId)?->getNormalizationStatus(),
+        );
+    }
+
+    public function testMapperFailureRecordsIssueAndMarksRawRecordFailed(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $record = $this->storeRawRecord($companyId, [[
+            'failMapper' => true,
+        ]]);
+
+        $recorder = $this->eventRecorder();
+        $recorder->reset();
+
+        $this->normalize($record->getId(), $companyId);
+        $this->em->clear();
+
+        /** @var NormalizationIssueRepository $issueRepository */
+        $issueRepository = self::getContainer()->get(NormalizationIssueRepository::class);
+        $issues = $issueRepository->findOpenByRawRecord($companyId, $record->getId());
+
+        self::assertCount(1, $issues);
+        self::assertSame(NormalizationIssueKind::MAPPER_FAILURE, $issues[0]->getKind());
+
+        /** @var FinancialTransactionRepository $transactionRepository */
+        $transactionRepository = self::getContainer()->get(FinancialTransactionRepository::class);
+        self::assertSame([], $transactionRepository->findByRawRecordId($companyId, $record->getId()));
+
+        /** @var IngestRawRecordRepository $rawRecordRepository */
+        $rawRecordRepository = self::getContainer()->get(IngestRawRecordRepository::class);
+        self::assertSame(
+            RawNormalizationStatus::FAILED,
+            $rawRecordRepository->findByIdAndCompany($record->getId(), $companyId)?->getNormalizationStatus(),
+        );
+        self::assertSame([], $recorder->events());
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     */
+    private function storeRawRecord(string $companyId, array $rows): IngestRawRecord
+    {
+        /** @var RawStorageFacade $facade */
+        $facade = self::getContainer()->get(RawStorageFacade::class);
+
+        return $facade->store(new RawBatch(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            shopRef: 'shop-1',
+            source: IngestSource::WILDBERRIES,
+            resourceType: FakeConnector::RESOURCE_TYPE,
+            externalId: 'raw-'.Uuid::uuid7()->toString(),
+            syncJobId: 'sync-job-1',
+            fetchedAt: new \DateTimeImmutable('2026-06-18 10:00:00'),
+            rows: $rows,
+        ))[0];
+    }
+
+    private function normalize(string $rawRecordId, string $companyId): void
+    {
+        /** @var NormalizeRawRecordAction $action */
+        $action = self::getContainer()->get(NormalizeRawRecordAction::class);
+        $action(new NormalizeRawRecordCommand($rawRecordId, $companyId));
+    }
+
+    private function eventRecorder(): NormalizationCompletedRecorder
+    {
+        /** @var NormalizationCompletedRecorder $recorder */
+        $recorder = self::getContainer()->get(NormalizationCompletedRecorder::class);
+
+        return $recorder;
+    }
+}

--- a/site/tests/Integration/Ingestion/Application/Source/Ozon/OzonIngestionFlowTest.php
+++ b/site/tests/Integration/Ingestion/Application/Source/Ozon/OzonIngestionFlowTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Application\Source\Ozon;
+
+use App\Ingestion\Application\Action\NormalizeRawRecordAction;
+use App\Ingestion\Application\Command\NormalizeRawRecordCommand;
+use App\Ingestion\Application\Source\Ozon\OzonOperationKey;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\DTO\RawBatch;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Entity\SyncJob;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\SyncJobKind;
+use App\Ingestion\Enum\SyncJobStatus;
+use App\Ingestion\Facade\RawStorageFacade;
+use App\Ingestion\Message\NormalizeRawRecordMessage;
+use App\Ingestion\Message\RunSyncChunkMessage;
+use App\Ingestion\MessageHandler\NormalizeRawRecordHandler;
+use App\Ingestion\MessageHandler\RunSyncChunkHandler;
+use App\Ingestion\Repository\FinancialTransactionRepository;
+use App\Ingestion\Repository\IngestRawRecordRepository;
+use App\Ingestion\Repository\NormalizationIssueRepository;
+use App\Ingestion\Repository\SyncJobRepository;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+
+final class OzonIngestionFlowTest extends IntegrationTestCase
+{
+    public function testRunSyncChunkThroughFakeOzonAdapterStoresRawAndNormalizesCanon(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $job = new SyncJob(
+            companyId: $companyId,
+            connectionRef: 'marketplace:ozon:seller',
+            source: IngestSource::OZON,
+            resourceType: OzonResourceType::DAILY_REPORT,
+            kind: SyncJobKind::BACKFILL,
+            windowFrom: new \DateTimeImmutable('2026-06-18'),
+            windowTo: new \DateTimeImmutable('2026-06-18'),
+            shopRef: 'ozon-shop',
+        );
+
+        $this->em->persist($job);
+        $this->em->flush();
+
+        $normalizeTransport = $this->getNormalizeTransport();
+        $normalizeTransport->reset();
+
+        /** @var RunSyncChunkHandler $handler */
+        $handler = self::getContainer()->get(RunSyncChunkHandler::class);
+        $handler(new RunSyncChunkMessage($companyId, $job->getId()));
+        $this->em->clear();
+
+        /** @var SyncJobRepository $jobRepository */
+        $jobRepository = self::getContainer()->get(SyncJobRepository::class);
+        self::assertSame(SyncJobStatus::COMPLETED, $jobRepository->findByIdAndCompany($job->getId(), $companyId)?->getStatus());
+
+        $envelopes = $normalizeTransport->getSent();
+        self::assertCount(1, $envelopes);
+        self::assertInstanceOf(NormalizeRawRecordMessage::class, $envelopes[0]->getMessage());
+
+        /** @var NormalizeRawRecordMessage $normalizeMessage */
+        $normalizeMessage = $envelopes[0]->getMessage();
+        /** @var IngestRawRecordRepository $rawRecordRepository */
+        $rawRecordRepository = self::getContainer()->get(IngestRawRecordRepository::class);
+        $rawRecord = $rawRecordRepository->findByIdAndCompany($normalizeMessage->rawRecordId, $companyId);
+        self::assertNotNull($rawRecord);
+        self::assertSame(OzonResourceType::DAILY_REPORT, $rawRecord->getResourceType());
+
+        /** @var NormalizeRawRecordHandler $normalizeHandler */
+        $normalizeHandler = self::getContainer()->get(NormalizeRawRecordHandler::class);
+        $normalizeHandler($normalizeMessage);
+        $this->em->clear();
+
+        /** @var FinancialTransactionRepository $transactionRepository */
+        $transactionRepository = self::getContainer()->get(FinancialTransactionRepository::class);
+        $transactions = $transactionRepository->findByRawRecordId($companyId, $normalizeMessage->rawRecordId);
+
+        self::assertCount(4, $transactions);
+        $externalIds = array_map(static fn ($transaction): string => $transaction->getExternalId(), $transactions);
+        sort($externalIds);
+        $expectedExternalIds = [
+            'ozon:operation:fake-ozon-op-1:sale',
+            'ozon:operation:fake-ozon-op-1:commission',
+            'ozon:operation:fake-ozon-op-1:logistics_delivery',
+            'ozon:operation:fake-ozon-op-1:service_marketplaceserviceitemdelivtocustomer',
+        ];
+        sort($expectedExternalIds);
+        self::assertSame(
+            $expectedExternalIds,
+            $externalIds,
+        );
+    }
+
+    public function testRealizationUpdatesDailyTransactionsBySameNaturalKeys(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $dailyRows = $this->fixtureRows('transaction_list_with_sale_and_commission.json');
+        $realizationRows = $this->fixtureRows('realization_february_2026.json');
+        $dailyRecord = $this->storeRawRecord($companyId, OzonResourceType::DAILY_REPORT, 'daily-2026-02', $dailyRows);
+        $realizationRecord = $this->storeRawRecord($companyId, OzonResourceType::REALIZATION, 'realization-2026-02', $realizationRows);
+
+        $this->normalize($dailyRecord->getId(), $companyId);
+        $this->normalize($realizationRecord->getId(), $companyId);
+        $this->em->clear();
+
+        $operationGroupId = (new OzonOperationKey())->operationGroupId($companyId, $dailyRows[0]);
+        /** @var FinancialTransactionRepository $transactionRepository */
+        $transactionRepository = self::getContainer()->get(FinancialTransactionRepository::class);
+        $transactions = $transactionRepository->findByOperationGroup($companyId, $operationGroupId);
+
+        self::assertCount(6, $transactions);
+        $byExternalId = [];
+        foreach ($transactions as $transaction) {
+            $byExternalId[$transaction->getExternalId()] = $transaction;
+        }
+
+        self::assertSame(121000, $byExternalId['ozon:operation:1234567890:sale']->getAmountMinor());
+        self::assertSame(
+            '2026-03-05 00:00:00',
+            $byExternalId['ozon:operation:1234567890:sale']->getExternalUpdatedAt()->format('Y-m-d H:i:s'),
+        );
+
+        /** @var NormalizationIssueRepository $issueRepository */
+        $issueRepository = self::getContainer()->get(NormalizationIssueRepository::class);
+        self::assertSame([], $issueRepository->findOpenByRawRecord($companyId, $dailyRecord->getId()));
+        self::assertSame([], $issueRepository->findOpenByRawRecord($companyId, $realizationRecord->getId()));
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     */
+    private function storeRawRecord(string $companyId, string $resourceType, string $externalId, array $rows): IngestRawRecord
+    {
+        /** @var RawStorageFacade $facade */
+        $facade = self::getContainer()->get(RawStorageFacade::class);
+
+        return $facade->store(new RawBatch(
+            companyId: $companyId,
+            connectionRef: 'marketplace:ozon:seller',
+            shopRef: 'ozon-shop',
+            source: IngestSource::OZON,
+            resourceType: $resourceType,
+            externalId: $externalId,
+            syncJobId: Uuid::uuid7()->toString(),
+            fetchedAt: new \DateTimeImmutable('2026-03-05T00:00:00+00:00'),
+            rows: $rows,
+        ))[0];
+    }
+
+    private function normalize(string $rawRecordId, string $companyId): void
+    {
+        /** @var NormalizeRawRecordAction $action */
+        $action = self::getContainer()->get(NormalizeRawRecordAction::class);
+        $action(new NormalizeRawRecordCommand($rawRecordId, $companyId));
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function fixtureRows(string $fileName): array
+    {
+        $payload = json_decode(
+            (string) file_get_contents(__DIR__.'/../../../../../Fixtures/Ingestion/Ozon/'.$fileName),
+            true,
+            512,
+            \JSON_THROW_ON_ERROR,
+        );
+
+        self::assertIsArray($payload);
+        self::assertIsArray($payload['rows'] ?? null);
+
+        /** @var list<array<string, mixed>> $rows */
+        $rows = $payload['rows'];
+
+        return $rows;
+    }
+
+    private function getNormalizeTransport(): InMemoryTransport
+    {
+        /** @var InMemoryTransport $transport */
+        $transport = self::getContainer()->get('messenger.transport.ingest_normalize');
+
+        return $transport;
+    }
+}

--- a/site/tests/Integration/Ingestion/Application/Source/Ozon/OzonIngestionRegistryTest.php
+++ b/site/tests/Integration/Ingestion/Application/Source/Ozon/OzonIngestionRegistryTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Application\Source\Ozon;
+
+use App\Ingestion\Application\Source\Ozon\OzonRealizationMapper;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Application\Source\Ozon\OzonSellerReportConnector;
+use App\Ingestion\Application\Source\Ozon\OzonSellerReportMapper;
+use App\Ingestion\Domain\Service\ConnectorRegistry;
+use App\Ingestion\Domain\Service\MapperRegistry;
+use App\Ingestion\Enum\IngestSource;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+
+final class OzonIngestionRegistryTest extends IntegrationTestCase
+{
+    public function testOzonConnectorAndMappersAreRegistered(): void
+    {
+        /** @var ConnectorRegistry $connectorRegistry */
+        $connectorRegistry = self::getContainer()->get(ConnectorRegistry::class);
+        /** @var MapperRegistry $mapperRegistry */
+        $mapperRegistry = self::getContainer()->get(MapperRegistry::class);
+
+        self::assertInstanceOf(OzonSellerReportConnector::class, $connectorRegistry->get(IngestSource::OZON));
+        self::assertInstanceOf(
+            OzonSellerReportMapper::class,
+            $mapperRegistry->get(IngestSource::OZON, OzonResourceType::DAILY_REPORT),
+        );
+        self::assertInstanceOf(
+            OzonRealizationMapper::class,
+            $mapperRegistry->get(IngestSource::OZON, OzonResourceType::REALIZATION),
+        );
+    }
+}

--- a/site/tests/Integration/Ingestion/Application/SyncFacadeTest.php
+++ b/site/tests/Integration/Ingestion/Application/SyncFacadeTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Application;
+
+use App\Ingestion\Application\Command\MarkJobCompletedCommand;
+use App\Ingestion\Application\Command\MarkJobRunningCommand;
+use App\Ingestion\Application\Command\StartBackfillCommand;
+use App\Ingestion\Application\Command\UpdateCursorCommand;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\SyncJobStatus;
+use App\Ingestion\Facade\SyncFacade;
+use App\Ingestion\Message\RunSyncChunkMessage;
+use App\Ingestion\Repository\IngestCursorRepository;
+use App\Ingestion\Repository\SyncJobRepository;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+
+final class SyncFacadeTest extends IntegrationTestCase
+{
+    public function testStartBackfillCreatesParentChunksAndDispatchesChunkMessages(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $transport = $this->getIngestFetchTransport();
+        $transport->reset();
+
+        /** @var SyncFacade $facade */
+        $facade = self::getContainer()->get(SyncFacade::class);
+
+        $parentJobId = $facade->startBackfill(new StartBackfillCommand(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            source: IngestSource::OZON,
+            resourceType: 'resource-1',
+            shopRef: 'shop-1',
+            windowFrom: new \DateTimeImmutable('2026-06-01'),
+            windowTo: new \DateTimeImmutable('2026-06-30'),
+        ));
+
+        /** @var SyncJobRepository $jobRepository */
+        $jobRepository = self::getContainer()->get(SyncJobRepository::class);
+        $parent = $jobRepository->findByIdAndCompany($parentJobId, $companyId);
+
+        self::assertNotNull($parent);
+        self::assertSame(SyncJobStatus::RUNNING, $parent->getStatus());
+        self::assertSame(5, $parent->getProgressTotal());
+        self::assertSame(0, $parent->getProgressDone());
+
+        $envelopes = $transport->getSent();
+        self::assertCount(5, $envelopes);
+        foreach ($envelopes as $envelope) {
+            self::assertInstanceOf(RunSyncChunkMessage::class, $envelope->getMessage());
+            self::assertSame($companyId, $envelope->getMessage()->getCompanyId());
+        }
+    }
+
+    public function testCompletingAllChildrenFinalizesParent(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $transport = $this->getIngestFetchTransport();
+        $transport->reset();
+
+        /** @var SyncFacade $facade */
+        $facade = self::getContainer()->get(SyncFacade::class);
+        $parentJobId = $facade->startBackfill(new StartBackfillCommand(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            source: IngestSource::OZON,
+            resourceType: 'resource-1',
+            shopRef: 'shop-1',
+            windowFrom: new \DateTimeImmutable('2026-06-01'),
+            windowTo: new \DateTimeImmutable('2026-06-14'),
+        ));
+
+        foreach ($transport->getSent() as $envelope) {
+            /** @var RunSyncChunkMessage $message */
+            $message = $envelope->getMessage();
+            $facade->markJobRunning(new MarkJobRunningCommand($message->jobId, $companyId));
+            $facade->markJobCompleted(new MarkJobCompletedCommand($message->jobId, $companyId));
+        }
+
+        $progress = $facade->getProgress($parentJobId, $companyId);
+
+        self::assertSame(SyncJobStatus::COMPLETED, $progress->status);
+        self::assertSame(2, $progress->progressTotal);
+        self::assertSame(2, $progress->progressDone);
+    }
+
+    public function testUpdateCursorCreatesAndAdvancesCursor(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $syncJobId = Uuid::uuid7()->toString();
+
+        /** @var SyncFacade $facade */
+        $facade = self::getContainer()->get(SyncFacade::class);
+
+        $facade->updateCursor(new UpdateCursorCommand(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            resourceType: 'resource-1',
+            shopRef: 'shop-1',
+            newCursorValue: 'cursor-2',
+            syncJobId: $syncJobId,
+            fetchedAt: new \DateTimeImmutable('2026-06-18 10:00:00'),
+        ));
+
+        /** @var IngestCursorRepository $cursorRepository */
+        $cursorRepository = self::getContainer()->get(IngestCursorRepository::class);
+        $cursor = $cursorRepository->findOne($companyId, 'connection-1', 'resource-1', 'shop-1');
+
+        self::assertNotNull($cursor);
+        self::assertSame('cursor-2', $cursor->getCursorValue());
+        self::assertSame($syncJobId, $cursor->getLastSyncJobId());
+    }
+
+    private function getIngestFetchTransport(): InMemoryTransport
+    {
+        /** @var InMemoryTransport $transport */
+        $transport = self::getContainer()->get('messenger.transport.ingest_fetch');
+
+        return $transport;
+    }
+}

--- a/site/tests/Integration/Ingestion/Application/UpsertFinancialTransactionActionTest.php
+++ b/site/tests/Integration/Ingestion/Application/UpsertFinancialTransactionActionTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Application;
+
+use App\Ingestion\Application\Action\UpsertFinancialTransactionAction;
+use App\Ingestion\Application\Command\UpsertFinancialTransactionCommand;
+use App\Ingestion\Application\DTO\MappedTransaction;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+use App\Ingestion\Repository\FinancialTransactionRepository;
+use App\Shared\Domain\ValueObject\Money;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class UpsertFinancialTransactionActionTest extends IntegrationTestCase
+{
+    public function testCreatesSkipsStaleAndUpdatesOnlyNewerTransactionVersion(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $rawRecordId = Uuid::uuid7()->toString();
+        $operationGroupId = Uuid::uuid7()->toString();
+
+        /** @var UpsertFinancialTransactionAction $action */
+        $action = self::getContainer()->get(UpsertFinancialTransactionAction::class);
+
+        $created = $action($this->command(
+            companyId: $companyId,
+            rawRecordId: $rawRecordId,
+            mapped: $this->mapped(
+                operationGroupId: $operationGroupId,
+                externalUpdatedAt: new \DateTimeImmutable('2026-06-18 10:00:00'),
+                occurredAt: new \DateTimeImmutable('2026-06-18 09:00:00'),
+                amountMinor: 10000,
+            ),
+        ));
+        $this->em->flush();
+        $this->em->clear();
+
+        self::assertNotNull($created);
+        self::assertNull($created->oldOccurredAt);
+
+        $stale = $action($this->command(
+            companyId: $companyId,
+            rawRecordId: $rawRecordId,
+            mapped: $this->mapped(
+                operationGroupId: $operationGroupId,
+                externalUpdatedAt: new \DateTimeImmutable('2026-06-18 10:00:00'),
+                occurredAt: new \DateTimeImmutable('2026-06-19 09:00:00'),
+                amountMinor: 20000,
+            ),
+        ));
+
+        self::assertNull($stale);
+
+        $updated = $action($this->command(
+            companyId: $companyId,
+            rawRecordId: $rawRecordId,
+            mapped: $this->mapped(
+                operationGroupId: $operationGroupId,
+                externalUpdatedAt: new \DateTimeImmutable('2026-06-18 11:00:00'),
+                occurredAt: new \DateTimeImmutable('2026-06-19 09:00:00'),
+                amountMinor: 20000,
+            ),
+        ));
+        $this->em->flush();
+        $this->em->clear();
+
+        self::assertNotNull($updated);
+        self::assertEquals(new \DateTimeImmutable('2026-06-18 09:00:00'), $updated->oldOccurredAt);
+        self::assertEquals(new \DateTimeImmutable('2026-06-19 09:00:00'), $updated->newOccurredAt);
+        self::assertTrue($updated->periodChanged);
+
+        /** @var FinancialTransactionRepository $repository */
+        $repository = self::getContainer()->get(FinancialTransactionRepository::class);
+        $transaction = $repository->findByNaturalKey($companyId, IngestSource::OZON, 'external-tx-1', TransactionType::SALE);
+
+        self::assertNotNull($transaction);
+        self::assertSame(20000, $transaction->getAmountMinor());
+        self::assertEquals(new \DateTimeImmutable('2026-06-19 09:00:00'), $transaction->getOccurredAt());
+    }
+
+    private function command(
+        string $companyId,
+        string $rawRecordId,
+        MappedTransaction $mapped,
+    ): UpsertFinancialTransactionCommand {
+        return new UpsertFinancialTransactionCommand(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            shopRef: 'shop-1',
+            source: IngestSource::OZON,
+            mapped: $mapped,
+            rawRecordId: $rawRecordId,
+            counterpartyId: null,
+        );
+    }
+
+    private function mapped(
+        string $operationGroupId,
+        \DateTimeImmutable $externalUpdatedAt,
+        \DateTimeImmutable $occurredAt,
+        int $amountMinor,
+    ): MappedTransaction {
+        return new MappedTransaction(
+            externalId: 'external-tx-1',
+            externalUpdatedAt: $externalUpdatedAt,
+            operationGroupId: $operationGroupId,
+            type: TransactionType::SALE,
+            direction: TransactionDirection::IN,
+            money: Money::fromMinor($amountMinor, 'RUB'),
+            occurredAt: $occurredAt,
+        );
+    }
+}

--- a/site/tests/Integration/Ingestion/Application/UpsertFinancialTransactionActionTest.php
+++ b/site/tests/Integration/Ingestion/Application/UpsertFinancialTransactionActionTest.php
@@ -17,6 +17,52 @@ use Ramsey\Uuid\Uuid;
 
 final class UpsertFinancialTransactionActionTest extends IntegrationTestCase
 {
+    public function testReusesPendingTransactionByNaturalKeyBeforeFlush(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $rawRecordId = Uuid::uuid7()->toString();
+        $operationGroupId = Uuid::uuid7()->toString();
+
+        /** @var UpsertFinancialTransactionAction $action */
+        $action = self::getContainer()->get(UpsertFinancialTransactionAction::class);
+
+        $created = $action($this->command(
+            companyId: $companyId,
+            rawRecordId: $rawRecordId,
+            mapped: $this->mapped(
+                operationGroupId: $operationGroupId,
+                externalUpdatedAt: new \DateTimeImmutable('2026-06-18 10:00:00'),
+                occurredAt: new \DateTimeImmutable('2026-06-18 09:00:00'),
+                amountMinor: 10000,
+            ),
+        ));
+        $updated = $action($this->command(
+            companyId: $companyId,
+            rawRecordId: $rawRecordId,
+            mapped: $this->mapped(
+                operationGroupId: $operationGroupId,
+                externalUpdatedAt: new \DateTimeImmutable('2026-06-18 11:00:00'),
+                occurredAt: new \DateTimeImmutable('2026-06-18 09:30:00'),
+                amountMinor: 15000,
+            ),
+        ));
+
+        self::assertNotNull($created);
+        self::assertNotNull($updated);
+        self::assertSame($created->transactionId, $updated->transactionId);
+
+        $this->em->flush();
+        $this->em->clear();
+
+        /** @var FinancialTransactionRepository $repository */
+        $repository = self::getContainer()->get(FinancialTransactionRepository::class);
+        $transactions = $repository->findByRawRecordId($companyId, $rawRecordId);
+
+        self::assertCount(1, $transactions);
+        self::assertSame(15000, $transactions[0]->getAmountMinor());
+        self::assertEquals(new \DateTimeImmutable('2026-06-18 09:30:00'), $transactions[0]->getOccurredAt());
+    }
+
     public function testCreatesSkipsStaleAndUpdatesOnlyNewerTransactionVersion(): void
     {
         $companyId = Uuid::uuid7()->toString();

--- a/site/tests/Integration/Ingestion/Fixtures/FakeConnector.php
+++ b/site/tests/Integration/Ingestion/Fixtures/FakeConnector.php
@@ -20,6 +20,44 @@ final class FakeConnector implements SourceConnectorInterface
 {
     public const RESOURCE_TYPE = 'fake_sales';
 
+    /**
+     * @var list<PullRequest>
+     */
+    private array $pullRequests = [];
+
+    /**
+     * @var list<array{externalId: string, nextCursorValue: ?string, hasMore: bool, rowExternalId: string}>
+     */
+    private array $queuedPullResults = [];
+
+    public function reset(): void
+    {
+        $this->pullRequests = [];
+        $this->queuedPullResults = [];
+    }
+
+    public function enqueuePullResult(
+        string $externalId,
+        ?string $nextCursorValue,
+        bool $hasMore,
+        string $rowExternalId = 'fake-sale-1',
+    ): void {
+        $this->queuedPullResults[] = [
+            'externalId' => $externalId,
+            'nextCursorValue' => $nextCursorValue,
+            'hasMore' => $hasMore,
+            'rowExternalId' => $rowExternalId,
+        ];
+    }
+
+    /**
+     * @return list<PullRequest>
+     */
+    public function pullRequests(): array
+    {
+        return $this->pullRequests;
+    }
+
     public function source(): IngestSource
     {
         return IngestSource::WILDBERRIES;
@@ -50,6 +88,13 @@ final class FakeConnector implements SourceConnectorInterface
 
     public function pull(PullRequest $request): PullResult
     {
+        $this->pullRequests[] = $request;
+        $result = array_shift($this->queuedPullResults) ?? [
+            'externalId' => sprintf('fake-report-%s', $request->syncJobId),
+            'nextCursorValue' => 'cursor-after-fake-sale-1',
+            'hasMore' => false,
+            'rowExternalId' => 'fake-sale-1',
+        ];
         $operationGroupId = Uuid::uuid7()->toString();
 
         return new PullResult(
@@ -59,11 +104,11 @@ final class FakeConnector implements SourceConnectorInterface
                 shopRef: $request->shopRef,
                 source: $this->source(),
                 resourceType: $request->resourceType,
-                externalId: sprintf('fake-report-%s', $request->syncJobId),
+                externalId: $result['externalId'],
                 syncJobId: $request->syncJobId,
                 fetchedAt: new \DateTimeImmutable('2026-06-18 10:00:00'),
                 rows: [[
-                    'externalId' => 'fake-sale-1',
+                    'externalId' => $result['rowExternalId'],
                     'externalUpdatedAt' => '2026-06-18T10:00:00+00:00',
                     'operationGroupId' => $operationGroupId,
                     'amountMinor' => 12345,
@@ -75,8 +120,8 @@ final class FakeConnector implements SourceConnectorInterface
                     'counterpartyName' => 'Fake Buyer',
                 ]],
             ),
-            nextCursorValue: 'cursor-after-fake-sale-1',
-            hasMore: false,
+            nextCursorValue: $result['nextCursorValue'],
+            hasMore: $result['hasMore'],
         );
     }
 

--- a/site/tests/Integration/Ingestion/Fixtures/FakeConnector.php
+++ b/site/tests/Integration/Ingestion/Fixtures/FakeConnector.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Fixtures;
+
+use App\Ingestion\Application\DTO\PullRequest;
+use App\Ingestion\Application\DTO\PullResult;
+use App\Ingestion\Application\DTO\PushRequest;
+use App\Ingestion\Application\DTO\PushResult;
+use App\Ingestion\Application\DTO\ShopDescriptor;
+use App\Ingestion\Domain\Contract\SourceConnectorInterface;
+use App\Ingestion\DTO\RawBatch;
+use App\Ingestion\Enum\Capability;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Exception\UnsupportedCapabilityException;
+use Ramsey\Uuid\Uuid;
+
+final class FakeConnector implements SourceConnectorInterface
+{
+    public const RESOURCE_TYPE = 'fake_sales';
+
+    public function source(): IngestSource
+    {
+        return IngestSource::WILDBERRIES;
+    }
+
+    /**
+     * @return list<Capability>
+     */
+    public function capabilities(): array
+    {
+        return [Capability::CAN_DISCOVER_SHOPS, Capability::CAN_PULL];
+    }
+
+    /**
+     * @return list<ShopDescriptor>
+     */
+    public function discoverShops(string $companyId, string $connectionRef): array
+    {
+        return [
+            new ShopDescriptor(
+                externalId: 'fake-shop',
+                name: 'Fake shop',
+                currency: 'RUB',
+                metadata: ['connectionRef' => $connectionRef],
+            ),
+        ];
+    }
+
+    public function pull(PullRequest $request): PullResult
+    {
+        $operationGroupId = Uuid::uuid7()->toString();
+
+        return new PullResult(
+            rawBatch: new RawBatch(
+                companyId: $request->companyId,
+                connectionRef: $request->connectionRef,
+                shopRef: $request->shopRef,
+                source: $this->source(),
+                resourceType: $request->resourceType,
+                externalId: sprintf('fake-report-%s', $request->syncJobId),
+                syncJobId: $request->syncJobId,
+                fetchedAt: new \DateTimeImmutable('2026-06-18 10:00:00'),
+                rows: [[
+                    'externalId' => 'fake-sale-1',
+                    'externalUpdatedAt' => '2026-06-18T10:00:00+00:00',
+                    'operationGroupId' => $operationGroupId,
+                    'amountMinor' => 12345,
+                    'controlAmountMinor' => 12345,
+                    'currency' => 'RUB',
+                    'occurredAt' => '2026-06-18T09:30:00+00:00',
+                    'orderRef' => 'order-1',
+                    'counterpartyExternalKey' => 'buyer-1',
+                    'counterpartyName' => 'Fake Buyer',
+                ]],
+            ),
+            nextCursorValue: 'cursor-after-fake-sale-1',
+            hasMore: false,
+        );
+    }
+
+    public function push(PushRequest $request): PushResult
+    {
+        throw new UnsupportedCapabilityException('Fake connector does not support push operations.');
+    }
+}

--- a/site/tests/Integration/Ingestion/Fixtures/FakeMapper.php
+++ b/site/tests/Integration/Ingestion/Fixtures/FakeMapper.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Fixtures;
+
+use App\Ingestion\Application\DTO\MappedControlSum;
+use App\Ingestion\Application\DTO\MappedTransaction;
+use App\Ingestion\Domain\Contract\SourceMapperInterface;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+use App\Shared\Domain\ValueObject\Money;
+use Ramsey\Uuid\Uuid;
+
+final class FakeMapper implements SourceMapperInterface
+{
+    public function source(): IngestSource
+    {
+        return IngestSource::WILDBERRIES;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function resourceTypes(): array
+    {
+        return [FakeConnector::RESOURCE_TYPE];
+    }
+
+    /**
+     * @param iterable<array<string, mixed>> $rows
+     *
+     * @return list<MappedTransaction>
+     */
+    public function map(IngestRawRecord $rawRecord, iterable $rows): array
+    {
+        $transactions = [];
+
+        foreach ($rows as $row) {
+            if (($row['failMapper'] ?? false) === true) {
+                throw new \RuntimeException('Fake mapper failure requested by fixture row.');
+            }
+
+            $currency = strtoupper((string) ($row['currency'] ?? 'RUB'));
+            $transactions[] = new MappedTransaction(
+                externalId: (string) ($row['externalId'] ?? $rawRecord->getExternalId()),
+                externalUpdatedAt: new \DateTimeImmutable((string) ($row['externalUpdatedAt'] ?? '2026-06-18T10:00:00+00:00')),
+                operationGroupId: (string) ($row['operationGroupId'] ?? Uuid::uuid7()->toString()),
+                type: TransactionType::from((string) ($row['type'] ?? TransactionType::SALE->value)),
+                direction: TransactionDirection::from((string) ($row['direction'] ?? TransactionDirection::IN->value)),
+                money: Money::fromMinor((int) ($row['amountMinor'] ?? 12345), $currency),
+                occurredAt: new \DateTimeImmutable((string) ($row['occurredAt'] ?? '2026-06-18T09:30:00+00:00')),
+                sourceTz: (string) ($row['sourceTz'] ?? 'UTC'),
+                orderRef: isset($row['orderRef']) ? (string) $row['orderRef'] : null,
+                payoutRef: isset($row['payoutRef']) ? (string) $row['payoutRef'] : null,
+                counterpartyExternalKey: isset($row['counterpartyExternalKey']) ? (string) $row['counterpartyExternalKey'] : null,
+                counterpartyName: isset($row['counterpartyName']) ? (string) $row['counterpartyName'] : null,
+                description: isset($row['description']) ? (string) $row['description'] : null,
+                sourceData: $row,
+            );
+        }
+
+        return $transactions;
+    }
+
+    /**
+     * @param iterable<array<string, mixed>> $rows
+     *
+     * @return list<MappedControlSum>
+     */
+    public function controlSum(iterable $rows): array
+    {
+        $controlSums = [];
+
+        foreach ($rows as $row) {
+            $controlSums[] = new MappedControlSum(
+                operationGroupId: (string) ($row['operationGroupId'] ?? Uuid::uuid7()->toString()),
+                currency: strtoupper((string) ($row['controlCurrency'] ?? $row['currency'] ?? 'RUB')),
+                amountMinor: (int) ($row['controlAmountMinor'] ?? $row['amountMinor'] ?? 12345),
+            );
+        }
+
+        return $controlSums;
+    }
+}

--- a/site/tests/Integration/Ingestion/Fixtures/FakeOzonClientAdapter.php
+++ b/site/tests/Integration/Ingestion/Fixtures/FakeOzonClientAdapter.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Fixtures;
+
+use App\Ingestion\Infrastructure\Api\Ozon\OzonClientAdapterInterface;
+use App\Ingestion\Infrastructure\Api\Ozon\OzonRawPage;
+use App\Ingestion\Infrastructure\Api\Ozon\OzonShopDescriptor;
+
+final class FakeOzonClientAdapter implements OzonClientAdapterInterface
+{
+    public function fetchTransactionList(
+        string $companyId,
+        string $connectionRef,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        int $page,
+        int $pageSize,
+    ): OzonRawPage {
+        if (1 !== $page) {
+            return new OzonRawPage(rows: [], hasMore: false, metadata: ['page' => $page]);
+        }
+
+        return new OzonRawPage(
+            rows: [[
+                'operation_id' => 'fake-ozon-op-1',
+                'operation_type' => 'OperationAgentDeliveredToCustomer',
+                'operation_type_name' => 'Delivery to customer',
+                'operation_date' => '2026-06-18T09:30:00+00:00',
+                'posting' => ['posting_number' => 'posting-1'],
+                'items' => [['sku' => 'sku-1', 'name' => 'Product 1']],
+                'accruals_for_sale' => '120.50',
+                'sale_commission_amount' => '-12.05',
+                'deliv_charge_amount' => '-3.50',
+                'services_amounts' => [
+                    'MarketplaceServiceItemDelivToCustomer' => '-2.50',
+                ],
+                'currency' => 'RUB',
+            ]],
+            hasMore: false,
+            metadata: ['page' => 1],
+        );
+    }
+
+    public function fetchRealization(
+        string $companyId,
+        string $connectionRef,
+        int $year,
+        int $month,
+    ): OzonRawPage {
+        return new OzonRawPage(
+            rows: [[
+                'operation_id' => 'fake-ozon-op-1',
+                'operation_type' => 'OperationAgentDeliveredToCustomer',
+                'operation_type_name' => 'Final delivery to customer',
+                'sale_date' => '2026-06-18T09:30:00+00:00',
+                'report_date' => '2026-07-05T00:00:00+00:00',
+                'posting_number' => 'posting-1',
+                'sku' => 'sku-1',
+                'seller_price' => '121.00',
+                'commission_amount' => '-12.10',
+                'delivery_commission' => '-3.50',
+                'currency' => 'RUB',
+            ]],
+            hasMore: false,
+            metadata: [
+                'year' => $year,
+                'month' => $month,
+                'header' => [
+                    'doc_number' => 'realization-'.$year.'-'.$month,
+                    'stop_date' => sprintf('%04d-%02d-28T00:00:00+00:00', $year, $month),
+                ],
+            ],
+        );
+    }
+
+    /**
+     * @return list<OzonShopDescriptor>
+     */
+    public function listClusters(string $companyId, string $connectionRef): array
+    {
+        return [
+            new OzonShopDescriptor(
+                externalId: $connectionRef,
+                name: 'Fake Ozon Seller',
+                currency: 'RUB',
+                metadata: ['companyId' => $companyId],
+            ),
+        ];
+    }
+}

--- a/site/tests/Integration/Ingestion/Fixtures/NormalizationCompletedRecorder.php
+++ b/site/tests/Integration/Ingestion/Fixtures/NormalizationCompletedRecorder.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Fixtures;
+
+use App\Ingestion\Domain\Event\NormalizationCompletedEvent;
+
+final class NormalizationCompletedRecorder
+{
+    /**
+     * @var list<NormalizationCompletedEvent>
+     */
+    private array $events = [];
+
+    public function record(NormalizationCompletedEvent $event): void
+    {
+        $this->events[] = $event;
+    }
+
+    /**
+     * @return list<NormalizationCompletedEvent>
+     */
+    public function events(): array
+    {
+        return $this->events;
+    }
+
+    public function reset(): void
+    {
+        $this->events = [];
+    }
+}

--- a/site/tests/Integration/Ingestion/Fixtures/NormalizationCompletedSubscriber.php
+++ b/site/tests/Integration/Ingestion/Fixtures/NormalizationCompletedSubscriber.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Fixtures;
+
+use App\Ingestion\Domain\Event\NormalizationCompletedEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final readonly class NormalizationCompletedSubscriber implements EventSubscriberInterface
+{
+    public function __construct(private NormalizationCompletedRecorder $recorder)
+    {
+    }
+
+    /**
+     * @return array<class-string, string>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            NormalizationCompletedEvent::class => 'onCompleted',
+        ];
+    }
+
+    public function onCompleted(NormalizationCompletedEvent $event): void
+    {
+        $this->recorder->record($event);
+    }
+}

--- a/site/tests/Integration/Ingestion/Infrastructure/Messenger/SyncJobFailureSubscriberTest.php
+++ b/site/tests/Integration/Ingestion/Infrastructure/Messenger/SyncJobFailureSubscriberTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Infrastructure\Messenger;
+
+use App\Ingestion\Entity\SyncJob;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\SyncJobKind;
+use App\Ingestion\Enum\SyncJobStatus;
+use App\Ingestion\Exception\ConnectorTransientException;
+use App\Ingestion\Infrastructure\Messenger\SyncJobFailureSubscriber;
+use App\Ingestion\Message\RunSyncChunkMessage;
+use App\Ingestion\Repository\SyncJobRepository;
+use App\Tests\Integration\Ingestion\Fixtures\FakeConnector;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+
+final class SyncJobFailureSubscriberTest extends IntegrationTestCase
+{
+    public function testWillRetryKeepsRunningJobNonTerminal(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $job = $this->newBackfillJob($companyId);
+        $job->markRunning();
+
+        $this->em->persist($job);
+        $this->em->flush();
+
+        $event = new WorkerMessageFailedEvent(
+            new Envelope(new RunSyncChunkMessage($companyId, $job->getId())),
+            'ingest_fetch',
+            new ConnectorTransientException('temporary'),
+        );
+        $event->setForRetry();
+
+        /** @var SyncJobFailureSubscriber $subscriber */
+        $subscriber = self::getContainer()->get(SyncJobFailureSubscriber::class);
+        $subscriber->onMessageFailed($event);
+        $this->em->clear();
+
+        /** @var SyncJobRepository $repository */
+        $repository = self::getContainer()->get(SyncJobRepository::class);
+        $persisted = $repository->findByIdAndCompany($job->getId(), $companyId);
+
+        self::assertNotNull($persisted);
+        self::assertSame(SyncJobStatus::RUNNING, $persisted->getStatus());
+        self::assertNull($persisted->getLastError());
+    }
+
+    public function testExhaustedRetryMarksJobFailedAndFinalizesParent(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $parent = $this->newBackfillJob($companyId);
+        $parent->setProgressTotal(1);
+        $parent->markRunning();
+
+        $child = $this->newBackfillJob($companyId, $parent->getId());
+        $child->markRunning();
+
+        $this->em->persist($parent);
+        $this->em->persist($child);
+        $this->em->flush();
+
+        $envelope = new Envelope(new RunSyncChunkMessage($companyId, $child->getId()));
+        $previous = new ConnectorTransientException('Ozon timeout');
+        $event = new WorkerMessageFailedEvent(
+            $envelope,
+            'ingest_fetch',
+            new HandlerFailedException($envelope, [$previous]),
+        );
+
+        /** @var SyncJobFailureSubscriber $subscriber */
+        $subscriber = self::getContainer()->get(SyncJobFailureSubscriber::class);
+        $subscriber->onMessageFailed($event);
+        $this->em->clear();
+
+        /** @var SyncJobRepository $repository */
+        $repository = self::getContainer()->get(SyncJobRepository::class);
+        $persistedChild = $repository->findByIdAndCompany($child->getId(), $companyId);
+        $persistedParent = $repository->findByIdAndCompany($parent->getId(), $companyId);
+
+        self::assertNotNull($persistedChild);
+        self::assertSame(SyncJobStatus::FAILED, $persistedChild->getStatus());
+        self::assertSame(ConnectorTransientException::class.': Ozon timeout', $persistedChild->getLastError());
+
+        self::assertNotNull($persistedParent);
+        self::assertSame(SyncJobStatus::FAILED, $persistedParent->getStatus());
+        self::assertSame(1, $persistedParent->getProgressDone());
+        self::assertSame('partial failure: 1 failed, 0 cancelled, 0 completed', $persistedParent->getLastError());
+    }
+
+    private function newBackfillJob(string $companyId, ?string $parentJobId = null): SyncJob
+    {
+        return new SyncJob(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            source: IngestSource::WILDBERRIES,
+            resourceType: FakeConnector::RESOURCE_TYPE,
+            kind: SyncJobKind::BACKFILL,
+            windowFrom: new \DateTimeImmutable('2026-06-18'),
+            windowTo: new \DateTimeImmutable('2026-06-18'),
+            shopRef: 'shop-1',
+            parentJobId: $parentJobId,
+        );
+    }
+}

--- a/site/tests/Integration/Ingestion/MessageHandler/RunSyncChunkHandlerTest.php
+++ b/site/tests/Integration/Ingestion/MessageHandler/RunSyncChunkHandlerTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace App\Tests\Integration\Ingestion\MessageHandler;
 
+use App\Ingestion\Application\Service\IngestRateLimitGuard;
 use App\Ingestion\Entity\SyncJob;
 use App\Ingestion\Enum\IngestSource;
 use App\Ingestion\Enum\SyncJobKind;
 use App\Ingestion\Enum\SyncJobStatus;
+use App\Ingestion\Exception\ConnectorTransientException;
 use App\Ingestion\Message\NormalizeRawRecordMessage;
 use App\Ingestion\Message\RunSyncChunkMessage;
 use App\Ingestion\MessageHandler\NormalizeRawRecordHandler;
@@ -25,6 +27,7 @@ final class RunSyncChunkHandlerTest extends IntegrationTestCase
 {
     public function testRunsFakeChunkStoresRawDispatchesNormalizationAndCompletesCanonFlow(): void
     {
+        $this->fakeConnector()->reset();
         $companyId = Uuid::uuid7()->toString();
         $job = new SyncJob(
             companyId: $companyId,
@@ -57,8 +60,11 @@ final class RunSyncChunkHandlerTest extends IntegrationTestCase
         /** @var IngestCursorRepository $cursorRepository */
         $cursorRepository = self::getContainer()->get(IngestCursorRepository::class);
         $cursor = $cursorRepository->findOne($companyId, 'connection-1', FakeConnector::RESOURCE_TYPE, 'shop-1');
-        self::assertNotNull($cursor);
-        self::assertSame('cursor-after-fake-sale-1', $cursor->getCursorValue());
+        self::assertNull($cursor);
+
+        $pullRequests = $this->fakeConnector()->pullRequests();
+        self::assertCount(1, $pullRequests);
+        self::assertNull($pullRequests[0]->cursorValue);
 
         $envelopes = $normalizeTransport->getSent();
         self::assertCount(1, $envelopes);
@@ -85,6 +91,189 @@ final class RunSyncChunkHandlerTest extends IntegrationTestCase
         self::assertCount(1, $transactions);
         self::assertSame('fake-sale-1', $transactions[0]->getExternalId());
         self::assertSame(12345, $transactions[0]->getAmountMinor());
+    }
+
+    public function testIncrementalChunkUsesAndAdvancesSharedCursor(): void
+    {
+        $this->fakeConnector()->reset();
+        $companyId = Uuid::uuid7()->toString();
+        $job = new SyncJob(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            source: IngestSource::WILDBERRIES,
+            resourceType: FakeConnector::RESOURCE_TYPE,
+            kind: SyncJobKind::INCREMENTAL,
+            shopRef: 'shop-1',
+        );
+
+        $this->em->persist($job);
+        $this->em->flush();
+
+        /** @var IngestCursorRepository $cursorRepository */
+        $cursorRepository = self::getContainer()->get(IngestCursorRepository::class);
+        $cursor = $cursorRepository->getOrCreate($companyId, 'connection-1', FakeConnector::RESOURCE_TYPE, 'shop-1');
+        $cursor->advance('cursor-before', $job->getId(), new \DateTimeImmutable('2026-06-18 09:00:00'));
+        $this->em->flush();
+
+        $this->getNormalizeTransport()->reset();
+
+        /** @var RunSyncChunkHandler $handler */
+        $handler = self::getContainer()->get(RunSyncChunkHandler::class);
+        $handler(new RunSyncChunkMessage($companyId, $job->getId()));
+        $this->em->clear();
+
+        $pullRequests = $this->fakeConnector()->pullRequests();
+        self::assertCount(1, $pullRequests);
+        self::assertSame('cursor-before', $pullRequests[0]->cursorValue);
+
+        $cursor = $cursorRepository->findOne($companyId, 'connection-1', FakeConnector::RESOURCE_TYPE, 'shop-1');
+        self::assertNotNull($cursor);
+        self::assertSame('cursor-after-fake-sale-1', $cursor->getCursorValue());
+
+        /** @var SyncJobRepository $jobRepository */
+        $jobRepository = self::getContainer()->get(SyncJobRepository::class);
+        $completedJob = $jobRepository->findByIdAndCompany($job->getId(), $companyId);
+        self::assertSame(SyncJobStatus::COMPLETED, $completedJob?->getStatus());
+        self::assertSame('cursor-before', $completedJob?->getCursorSnapshot());
+    }
+
+    public function testWindowedChunkIgnoresExistingSharedCursor(): void
+    {
+        $this->fakeConnector()->reset();
+        $companyId = Uuid::uuid7()->toString();
+        $job = new SyncJob(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            source: IngestSource::WILDBERRIES,
+            resourceType: FakeConnector::RESOURCE_TYPE,
+            kind: SyncJobKind::BACKFILL,
+            windowFrom: new \DateTimeImmutable('2026-06-08'),
+            windowTo: new \DateTimeImmutable('2026-06-14'),
+            shopRef: 'shop-1',
+        );
+
+        $this->em->persist($job);
+        $this->em->flush();
+
+        /** @var IngestCursorRepository $cursorRepository */
+        $cursorRepository = self::getContainer()->get(IngestCursorRepository::class);
+        $cursor = $cursorRepository->getOrCreate($companyId, 'connection-1', FakeConnector::RESOURCE_TYPE, 'shop-1');
+        $cursor->advance('2099-01-01', $job->getId(), new \DateTimeImmutable('2026-06-18 09:00:00'));
+        $this->em->flush();
+
+        $this->getNormalizeTransport()->reset();
+
+        /** @var RunSyncChunkHandler $handler */
+        $handler = self::getContainer()->get(RunSyncChunkHandler::class);
+        $handler(new RunSyncChunkMessage($companyId, $job->getId()));
+        $this->em->clear();
+
+        $pullRequests = $this->fakeConnector()->pullRequests();
+        self::assertCount(1, $pullRequests);
+        self::assertNull($pullRequests[0]->cursorValue);
+        self::assertEquals(new \DateTimeImmutable('2026-06-08'), $pullRequests[0]->windowFrom);
+        self::assertEquals(new \DateTimeImmutable('2026-06-14'), $pullRequests[0]->windowTo);
+
+        $cursor = $cursorRepository->findOne($companyId, 'connection-1', FakeConnector::RESOURCE_TYPE, 'shop-1');
+        self::assertNotNull($cursor);
+        self::assertSame('2099-01-01', $cursor->getCursorValue());
+    }
+
+    public function testWindowedChunkContinuesPullingUntilConnectorHasNoMoreData(): void
+    {
+        $fakeConnector = $this->fakeConnector();
+        $fakeConnector->reset();
+        $fakeConnector->enqueuePullResult('fake-report-page-1', '2026-06-08', true, 'fake-sale-1');
+        $fakeConnector->enqueuePullResult('fake-report-page-2', null, false, 'fake-sale-2');
+
+        $companyId = Uuid::uuid7()->toString();
+        $job = new SyncJob(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            source: IngestSource::WILDBERRIES,
+            resourceType: FakeConnector::RESOURCE_TYPE,
+            kind: SyncJobKind::BACKFILL,
+            windowFrom: new \DateTimeImmutable('2026-06-01'),
+            windowTo: new \DateTimeImmutable('2026-06-14'),
+            shopRef: 'shop-1',
+        );
+
+        $this->em->persist($job);
+        $this->em->flush();
+
+        $normalizeTransport = $this->getNormalizeTransport();
+        $normalizeTransport->reset();
+
+        /** @var RunSyncChunkHandler $handler */
+        $handler = self::getContainer()->get(RunSyncChunkHandler::class);
+        $handler(new RunSyncChunkMessage($companyId, $job->getId()));
+        $this->em->clear();
+
+        $pullRequests = $fakeConnector->pullRequests();
+        self::assertCount(2, $pullRequests);
+        self::assertNull($pullRequests[0]->cursorValue);
+        self::assertSame('2026-06-08', $pullRequests[1]->cursorValue);
+        self::assertCount(2, $normalizeTransport->getSent());
+
+        /** @var SyncJobRepository $jobRepository */
+        $jobRepository = self::getContainer()->get(SyncJobRepository::class);
+        self::assertSame(SyncJobStatus::COMPLETED, $jobRepository->findByIdAndCompany($job->getId(), $companyId)?->getStatus());
+
+        /** @var IngestCursorRepository $cursorRepository */
+        $cursorRepository = self::getContainer()->get(IngestCursorRepository::class);
+        self::assertNull($cursorRepository->findOne($companyId, 'connection-1', FakeConnector::RESOURCE_TYPE, 'shop-1'));
+    }
+
+    public function testRateLimitLockContentionKeepsJobRetryable(): void
+    {
+        $this->fakeConnector()->reset();
+        $companyId = Uuid::uuid7()->toString();
+        $job = new SyncJob(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            source: IngestSource::WILDBERRIES,
+            resourceType: FakeConnector::RESOURCE_TYPE,
+            kind: SyncJobKind::BACKFILL,
+            windowFrom: new \DateTimeImmutable('2026-06-18'),
+            windowTo: new \DateTimeImmutable('2026-06-18'),
+            shopRef: 'shop-1',
+        );
+
+        $this->em->persist($job);
+        $this->em->flush();
+
+        /** @var IngestRateLimitGuard $rateLimitGuard */
+        $rateLimitGuard = self::getContainer()->get(IngestRateLimitGuard::class);
+        $heldLock = $rateLimitGuard->acquire('wildberries:connection-1');
+
+        try {
+            /** @var RunSyncChunkHandler $handler */
+            $handler = self::getContainer()->get(RunSyncChunkHandler::class);
+            $handler(new RunSyncChunkMessage($companyId, $job->getId()));
+
+            self::fail('Expected rate-limit lock contention to be retryable.');
+        } catch (ConnectorTransientException) {
+        } finally {
+            $heldLock->release();
+        }
+
+        $this->em->clear();
+
+        /** @var SyncJobRepository $jobRepository */
+        $jobRepository = self::getContainer()->get(SyncJobRepository::class);
+        $retryableJob = $jobRepository->findByIdAndCompany($job->getId(), $companyId);
+
+        self::assertNotNull($retryableJob);
+        self::assertSame(SyncJobStatus::RUNNING, $retryableJob->getStatus());
+        self::assertNull($retryableJob->getLastError());
+    }
+
+    private function fakeConnector(): FakeConnector
+    {
+        /** @var FakeConnector $connector */
+        $connector = self::getContainer()->get(FakeConnector::class);
+
+        return $connector;
     }
 
     private function getNormalizeTransport(): InMemoryTransport

--- a/site/tests/Integration/Ingestion/MessageHandler/RunSyncChunkHandlerTest.php
+++ b/site/tests/Integration/Ingestion/MessageHandler/RunSyncChunkHandlerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\MessageHandler;
+
+use App\Ingestion\Entity\SyncJob;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\SyncJobKind;
+use App\Ingestion\Enum\SyncJobStatus;
+use App\Ingestion\Message\NormalizeRawRecordMessage;
+use App\Ingestion\Message\RunSyncChunkMessage;
+use App\Ingestion\MessageHandler\NormalizeRawRecordHandler;
+use App\Ingestion\MessageHandler\RunSyncChunkHandler;
+use App\Ingestion\Repository\FinancialTransactionRepository;
+use App\Ingestion\Repository\IngestCursorRepository;
+use App\Ingestion\Repository\IngestRawRecordRepository;
+use App\Ingestion\Repository\SyncJobRepository;
+use App\Tests\Integration\Ingestion\Fixtures\FakeConnector;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+
+final class RunSyncChunkHandlerTest extends IntegrationTestCase
+{
+    public function testRunsFakeChunkStoresRawDispatchesNormalizationAndCompletesCanonFlow(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $job = new SyncJob(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            source: IngestSource::WILDBERRIES,
+            resourceType: FakeConnector::RESOURCE_TYPE,
+            kind: SyncJobKind::BACKFILL,
+            windowFrom: new \DateTimeImmutable('2026-06-18'),
+            windowTo: new \DateTimeImmutable('2026-06-18'),
+            shopRef: 'shop-1',
+        );
+
+        $this->em->persist($job);
+        $this->em->flush();
+
+        $normalizeTransport = $this->getNormalizeTransport();
+        $normalizeTransport->reset();
+
+        /** @var RunSyncChunkHandler $handler */
+        $handler = self::getContainer()->get(RunSyncChunkHandler::class);
+        $handler(new RunSyncChunkMessage($companyId, $job->getId()));
+        $this->em->clear();
+
+        /** @var SyncJobRepository $jobRepository */
+        $jobRepository = self::getContainer()->get(SyncJobRepository::class);
+        $completedJob = $jobRepository->findByIdAndCompany($job->getId(), $companyId);
+        self::assertNotNull($completedJob);
+        self::assertSame(SyncJobStatus::COMPLETED, $completedJob->getStatus());
+
+        /** @var IngestCursorRepository $cursorRepository */
+        $cursorRepository = self::getContainer()->get(IngestCursorRepository::class);
+        $cursor = $cursorRepository->findOne($companyId, 'connection-1', FakeConnector::RESOURCE_TYPE, 'shop-1');
+        self::assertNotNull($cursor);
+        self::assertSame('cursor-after-fake-sale-1', $cursor->getCursorValue());
+
+        $envelopes = $normalizeTransport->getSent();
+        self::assertCount(1, $envelopes);
+        self::assertInstanceOf(NormalizeRawRecordMessage::class, $envelopes[0]->getMessage());
+
+        /** @var NormalizeRawRecordMessage $normalizeMessage */
+        $normalizeMessage = $envelopes[0]->getMessage();
+        /** @var IngestRawRecordRepository $rawRecordRepository */
+        $rawRecordRepository = self::getContainer()->get(IngestRawRecordRepository::class);
+        $rawRecord = $rawRecordRepository->findByIdAndCompany($normalizeMessage->rawRecordId, $companyId);
+
+        self::assertNotNull($rawRecord);
+        self::assertSame($job->getId(), $rawRecord->getSyncJobId());
+
+        /** @var NormalizeRawRecordHandler $normalizeHandler */
+        $normalizeHandler = self::getContainer()->get(NormalizeRawRecordHandler::class);
+        $normalizeHandler($normalizeMessage);
+        $this->em->clear();
+
+        /** @var FinancialTransactionRepository $transactionRepository */
+        $transactionRepository = self::getContainer()->get(FinancialTransactionRepository::class);
+        $transactions = $transactionRepository->findByRawRecordId($companyId, $normalizeMessage->rawRecordId);
+
+        self::assertCount(1, $transactions);
+        self::assertSame('fake-sale-1', $transactions[0]->getExternalId());
+        self::assertSame(12345, $transactions[0]->getAmountMinor());
+    }
+
+    private function getNormalizeTransport(): InMemoryTransport
+    {
+        /** @var InMemoryTransport $transport */
+        $transport = self::getContainer()->get('messenger.transport.ingest_normalize');
+
+        return $transport;
+    }
+}

--- a/site/tests/Integration/Ingestion/Repository/CounterpartyRepositoryTest.php
+++ b/site/tests/Integration/Ingestion/Repository/CounterpartyRepositoryTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Repository;
+
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Repository\CounterpartyRepository;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class CounterpartyRepositoryTest extends IntegrationTestCase
+{
+    public function testGetOrCreateUsesCompanyIdAndUpdatesNameWithoutFlush(): void
+    {
+        $companyA = Uuid::uuid7()->toString();
+        $companyB = Uuid::uuid7()->toString();
+
+        /** @var CounterpartyRepository $repository */
+        $repository = self::getContainer()->get(CounterpartyRepository::class);
+
+        $counterpartyA = $repository->getOrCreate($companyA, IngestSource::OZON, 'ozon', 'Ozon Old');
+        $counterpartyB = $repository->getOrCreate($companyB, IngestSource::OZON, 'ozon', 'Ozon Company B');
+        $this->em->flush();
+        $this->em->clear();
+
+        $sameA = $repository->getOrCreate($companyA, IngestSource::OZON, 'ozon', 'Ozon New');
+        $this->em->flush();
+
+        self::assertSame($counterpartyA->getId(), $sameA->getId());
+        self::assertSame('Ozon New', $sameA->getName());
+        self::assertSame($counterpartyB->getId(), $repository->findByNaturalKey($companyB, IngestSource::OZON, 'ozon')?->getId());
+    }
+}

--- a/site/tests/Integration/Ingestion/Repository/FinancialTransactionRepositoryTest.php
+++ b/site/tests/Integration/Ingestion/Repository/FinancialTransactionRepositoryTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Repository;
+
+use App\Ingestion\Entity\FinancialTransaction;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+use App\Ingestion\Repository\FinancialTransactionRepository;
+use App\Shared\Domain\ValueObject\Money;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class FinancialTransactionRepositoryTest extends IntegrationTestCase
+{
+    public function testNaturalKeyLookupUsesCompanyId(): void
+    {
+        $companyA = Uuid::uuid7()->toString();
+        $companyB = Uuid::uuid7()->toString();
+        $transactionA = $this->newTransaction($companyA, 'external-1', TransactionType::SALE);
+        $transactionB = $this->newTransaction($companyB, 'external-1', TransactionType::SALE);
+
+        $this->em->persist($transactionA);
+        $this->em->persist($transactionB);
+        $this->em->flush();
+        $this->em->clear();
+
+        /** @var FinancialTransactionRepository $repository */
+        $repository = self::getContainer()->get(FinancialTransactionRepository::class);
+
+        self::assertSame(
+            $transactionA->getId(),
+            $repository->findByNaturalKey($companyA, IngestSource::OZON, 'external-1', TransactionType::SALE)?->getId(),
+        );
+        self::assertSame(
+            $transactionB->getId(),
+            $repository->findByNaturalKey($companyB, IngestSource::OZON, 'external-1', TransactionType::SALE)?->getId(),
+        );
+    }
+
+    public function testPeriodAndRawLookupsUseCompanyAndShop(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $operationGroupId = Uuid::uuid7()->toString();
+        $rawRecordId = Uuid::uuid7()->toString();
+        $shopTransaction = $this->newTransaction($companyId, 'external-1', TransactionType::SALE, 'shop-1', $operationGroupId, $rawRecordId);
+        $otherShopTransaction = $this->newTransaction($companyId, 'external-2', TransactionType::COMMISSION, 'shop-2', $operationGroupId, Uuid::uuid7()->toString());
+
+        $this->em->persist($shopTransaction);
+        $this->em->persist($otherShopTransaction);
+        $this->em->flush();
+        $this->em->clear();
+
+        /** @var FinancialTransactionRepository $repository */
+        $repository = self::getContainer()->get(FinancialTransactionRepository::class);
+
+        self::assertSame(
+            [$shopTransaction->getId(), $otherShopTransaction->getId()],
+            array_map(
+                static fn (FinancialTransaction $transaction): string => $transaction->getId(),
+                $repository->findByOperationGroup($companyId, $operationGroupId),
+            ),
+        );
+        self::assertSame(
+            [$shopTransaction->getId()],
+            array_map(
+                static fn (FinancialTransaction $transaction): string => $transaction->getId(),
+                iterator_to_array($repository->iterateByPeriod(
+                    $companyId,
+                    new \DateTimeImmutable('2026-06-01 00:00:00'),
+                    new \DateTimeImmutable('2026-06-30 23:59:59'),
+                    'shop-1',
+                )),
+            ),
+        );
+        self::assertSame(
+            [$shopTransaction->getId()],
+            array_map(
+                static fn (FinancialTransaction $transaction): string => $transaction->getId(),
+                $repository->findByRawRecordId($companyId, $rawRecordId),
+            ),
+        );
+    }
+
+    private function newTransaction(
+        string $companyId,
+        string $externalId,
+        TransactionType $type,
+        string $shopRef = 'shop-1',
+        ?string $operationGroupId = null,
+        ?string $rawRecordId = null,
+    ): FinancialTransaction {
+        return new FinancialTransaction(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            shopRef: $shopRef,
+            source: IngestSource::OZON,
+            externalId: $externalId,
+            externalUpdatedAt: new \DateTimeImmutable('2026-06-02 00:00:00'),
+            operationGroupId: $operationGroupId ?? Uuid::uuid7()->toString(),
+            type: $type,
+            direction: TransactionType::COMMISSION === $type ? TransactionDirection::OUT : TransactionDirection::IN,
+            money: Money::fromMinor(10000, 'RUB'),
+            occurredAt: new \DateTimeImmutable('2026-06-02 12:00:00'),
+            rawRecordId: $rawRecordId ?? Uuid::uuid7()->toString(),
+        );
+    }
+}

--- a/site/tests/Integration/Ingestion/Repository/IngestCursorRepositoryTest.php
+++ b/site/tests/Integration/Ingestion/Repository/IngestCursorRepositoryTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Repository;
+
+use App\Ingestion\Repository\IngestCursorRepository;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class IngestCursorRepositoryTest extends IntegrationTestCase
+{
+    public function testGetOrCreatePersistsWithoutFlushAndFindOneUsesCompanyId(): void
+    {
+        $companyA = Uuid::uuid7()->toString();
+        $companyB = Uuid::uuid7()->toString();
+
+        /** @var IngestCursorRepository $repository */
+        $repository = self::getContainer()->get(IngestCursorRepository::class);
+
+        $cursorA = $repository->getOrCreate($companyA, 'connection-1', 'resource-1', 'shop-1');
+        $cursorB = $repository->getOrCreate($companyB, 'connection-1', 'resource-1', 'shop-1');
+        $this->em->flush();
+        $this->em->clear();
+
+        self::assertSame($cursorA->getId(), $repository->findOne($companyA, 'connection-1', 'resource-1', 'shop-1')?->getId());
+        self::assertSame($cursorB->getId(), $repository->findOne($companyB, 'connection-1', 'resource-1', 'shop-1')?->getId());
+        self::assertNull($repository->findOne($companyA, 'connection-2', 'resource-1', 'shop-1'));
+    }
+}

--- a/site/tests/Integration/Ingestion/Repository/NormalizationIssueRepositoryTest.php
+++ b/site/tests/Integration/Ingestion/Repository/NormalizationIssueRepositoryTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Repository;
+
+use App\Ingestion\Entity\NormalizationIssue;
+use App\Ingestion\Enum\NormalizationIssueKind;
+use App\Ingestion\Repository\NormalizationIssueRepository;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class NormalizationIssueRepositoryTest extends IntegrationTestCase
+{
+    public function testOpenIssueQueriesUseCompanyIdAndResolvedFilter(): void
+    {
+        $companyA = Uuid::uuid7()->toString();
+        $companyB = Uuid::uuid7()->toString();
+        $rawRecordId = Uuid::uuid7()->toString();
+        $openA = new NormalizationIssue($companyA, $rawRecordId, null, NormalizationIssueKind::SUM_MISMATCH, ['a' => 1]);
+        $resolvedA = new NormalizationIssue($companyA, $rawRecordId, null, NormalizationIssueKind::MAPPER_FAILURE, ['a' => 2]);
+        $resolvedA->markResolved();
+        $openB = new NormalizationIssue($companyB, $rawRecordId, null, NormalizationIssueKind::SUM_MISMATCH, ['b' => 1]);
+
+        foreach ([$openA, $resolvedA, $openB] as $issue) {
+            $this->em->persist($issue);
+        }
+        $this->em->flush();
+        $this->em->clear();
+
+        /** @var NormalizationIssueRepository $repository */
+        $repository = self::getContainer()->get(NormalizationIssueRepository::class);
+
+        self::assertSame([$openA->getId()], array_map(
+            static fn (NormalizationIssue $issue): string => $issue->getId(),
+            $repository->findOpenByRawRecord($companyA, $rawRecordId),
+        ));
+        self::assertSame(1, $repository->countOpenForCompany($companyA));
+        self::assertSame(1, $repository->countOpenForCompany($companyB));
+    }
+}

--- a/site/tests/Integration/Ingestion/Repository/PLDirtyPeriodRepositoryTest.php
+++ b/site/tests/Integration/Ingestion/Repository/PLDirtyPeriodRepositoryTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Repository;
+
+use App\Ingestion\Entity\PLDirtyPeriod;
+use App\Ingestion\Enum\PLDirtyPeriodReason;
+use App\Ingestion\Enum\PLDirtyPeriodStatus;
+use App\Ingestion\Repository\PLDirtyPeriodRepository;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class PLDirtyPeriodRepositoryTest extends IntegrationTestCase
+{
+    public function testFindOneUsesCompanyAndShopScope(): void
+    {
+        $companyA = Uuid::uuid7()->toString();
+        $companyB = Uuid::uuid7()->toString();
+        $periodB = new PLDirtyPeriod($companyB, 2026, 2, 'ozon:shop-1', PLDirtyPeriodReason::INGEST);
+
+        $this->em->persist(new PLDirtyPeriod($companyA, 2026, 2, 'ozon:shop-1', PLDirtyPeriodReason::INGEST));
+        $this->em->persist($periodB);
+        $this->em->flush();
+        $this->em->clear();
+
+        /** @var PLDirtyPeriodRepository $repository */
+        $repository = self::getContainer()->get(PLDirtyPeriodRepository::class);
+
+        self::assertNull($repository->findOne($companyA, 2026, 2, 'missing-shop'));
+        self::assertNull($repository->findOne($companyA, 2026, 2, ''));
+        self::assertSame($periodB->getId(), $repository->findOne($companyB, 2026, 2, 'ozon:shop-1')?->getId());
+    }
+
+    public function testPendingLookupsAndCountersAreScoped(): void
+    {
+        $companyA = Uuid::uuid7()->toString();
+        $companyB = Uuid::uuid7()->toString();
+
+        $pendingA1 = new PLDirtyPeriod($companyA, 2026, 1, '', PLDirtyPeriodReason::INGEST);
+        usleep(1000);
+        $pendingA2 = new PLDirtyPeriod($companyA, 2026, 2, '', PLDirtyPeriodReason::MANUAL);
+        $doneA = new PLDirtyPeriod($companyA, 2026, 3, '', PLDirtyPeriodReason::REMAP);
+        $doneA->markRebuilding();
+        $doneA->markDone();
+        $pendingB = new PLDirtyPeriod($companyB, 2026, 1, '', PLDirtyPeriodReason::INGEST);
+
+        foreach ([$pendingA1, $pendingA2, $doneA, $pendingB] as $period) {
+            $this->em->persist($period);
+        }
+        $this->em->flush();
+        $this->em->clear();
+
+        /** @var PLDirtyPeriodRepository $repository */
+        $repository = self::getContainer()->get(PLDirtyPeriodRepository::class);
+
+        self::assertSame([$pendingA1->getId(), $pendingA2->getId()], array_map(
+            static fn (PLDirtyPeriod $period): string => $period->getId(),
+            $repository->findPendingForCompany($companyA),
+        ));
+        self::assertSame(2, $repository->countByStatus($companyA, PLDirtyPeriodStatus::PENDING));
+        self::assertSame(1, $repository->countByStatus($companyA, PLDirtyPeriodStatus::DONE));
+        self::assertCount(2, $repository->findPending(2));
+    }
+}

--- a/site/tests/Integration/Ingestion/Repository/SyncJobRepositoryTest.php
+++ b/site/tests/Integration/Ingestion/Repository/SyncJobRepositoryTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Repository;
+
+use App\Ingestion\Entity\SyncJob;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\SyncJobKind;
+use App\Ingestion\Enum\SyncJobStatus;
+use App\Ingestion\Repository\SyncJobRepository;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class SyncJobRepositoryTest extends IntegrationTestCase
+{
+    public function testFindByIdAndCompanyPreventsTenantLeak(): void
+    {
+        $companyA = Uuid::uuid7()->toString();
+        $companyB = Uuid::uuid7()->toString();
+        $jobB = $this->newJob($companyB);
+
+        $this->em->persist($this->newJob($companyA));
+        $this->em->persist($jobB);
+        $this->em->flush();
+        $this->em->clear();
+
+        /** @var SyncJobRepository $repository */
+        $repository = self::getContainer()->get(SyncJobRepository::class);
+
+        self::assertNull($repository->findByIdAndCompany($jobB->getId(), $companyA));
+        self::assertSame($jobB->getId(), $repository->findByIdAndCompany($jobB->getId(), $companyB)?->getId());
+    }
+
+    public function testFindLatestForResourceReturnsOnlyNonTerminalJob(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $completed = $this->newJob($companyId);
+        $completed->markRunning();
+        $completed->markCompleted();
+        $active = $this->newJob($companyId);
+
+        $this->em->persist($completed);
+        $this->em->persist($active);
+        $this->em->flush();
+        $this->em->clear();
+
+        /** @var SyncJobRepository $repository */
+        $repository = self::getContainer()->get(SyncJobRepository::class);
+
+        self::assertSame(
+            $active->getId(),
+            $repository->findLatestForResource($companyId, 'connection-1', 'resource-1', 'shop-1')?->getId(),
+        );
+    }
+
+    public function testChildLookupsAndCountersUseCompanyId(): void
+    {
+        $companyA = Uuid::uuid7()->toString();
+        $companyB = Uuid::uuid7()->toString();
+        $parentA = $this->newJob($companyA);
+        $parentB = $this->newJob($companyB);
+        $childA = $this->newJob($companyA, $parentA->getId());
+        $childB = $this->newJob($companyB, $parentB->getId());
+        $childB->markRunning();
+        $childB->markCompleted();
+
+        foreach ([$parentA, $parentB, $childA, $childB] as $job) {
+            $this->em->persist($job);
+        }
+        $this->em->flush();
+        $this->em->clear();
+
+        /** @var SyncJobRepository $repository */
+        $repository = self::getContainer()->get(SyncJobRepository::class);
+
+        self::assertSame([$childA->getId()], array_map(
+            static fn (SyncJob $job): string => $job->getId(),
+            $repository->findOpenChildrenOf($parentA->getId(), $companyA),
+        ));
+        self::assertSame(0, $repository->countChildrenByStatus($parentA->getId(), $companyA, SyncJobStatus::COMPLETED));
+        self::assertSame(1, $repository->countChildrenByStatus($parentB->getId(), $companyB, SyncJobStatus::COMPLETED));
+    }
+
+    private function newJob(string $companyId, ?string $parentJobId = null): SyncJob
+    {
+        return new SyncJob(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            source: IngestSource::OZON,
+            resourceType: 'resource-1',
+            kind: SyncJobKind::BACKFILL,
+            windowFrom: new \DateTimeImmutable('2026-06-01'),
+            windowTo: new \DateTimeImmutable('2026-06-30'),
+            shopRef: 'shop-1',
+            parentJobId: $parentJobId,
+        );
+    }
+}

--- a/site/tests/Unit/Finance/Application/Service/PnlPeriodResolverTest.php
+++ b/site/tests/Unit/Finance/Application/Service/PnlPeriodResolverTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Finance\Application\Service;
+
+use App\Finance\Application\Service\PnlPeriodResolver;
+use PHPUnit\Framework\TestCase;
+
+final class PnlPeriodResolverTest extends TestCase
+{
+    public function testResolvesPeriodInMoscowTimezone(): void
+    {
+        $resolver = new PnlPeriodResolver();
+
+        self::assertSame([2026, 1], $resolver->from(new \DateTimeImmutable('2025-12-31 21:30:00 UTC')));
+        self::assertSame([2026, 2], $resolver->from(new \DateTimeImmutable('2026-02-28 20:30:00 UTC')));
+    }
+
+    public function testBuildsMoscowMonthBounds(): void
+    {
+        $resolver = new PnlPeriodResolver();
+
+        [$from, $to] = $resolver->bounds(2026, 2);
+
+        self::assertSame('2026-02-01 00:00:00 +03:00', $from->format('Y-m-d H:i:s P'));
+        self::assertSame('2026-02-28 23:59:59 +03:00', $to->format('Y-m-d H:i:s P'));
+    }
+}

--- a/site/tests/Unit/Finance/Message/PnlMessageTest.php
+++ b/site/tests/Unit/Finance/Message/PnlMessageTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Finance\Message;
+
+use App\Finance\Message\MarkPnlPeriodDirtyMessage;
+use App\Finance\Message\RebuildPnlPeriodMessage;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+final class PnlMessageTest extends TestCase
+{
+    public function testMarkDirtyMessageExposesCompanyId(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $message = new MarkPnlPeriodDirtyMessage($companyId, 2026, 2, '', 'ingest');
+
+        self::assertSame($companyId, $message->getCompanyId());
+    }
+
+    public function testRebuildMessageExposesCompanyId(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $message = new RebuildPnlPeriodMessage($companyId, 2026, 2);
+
+        self::assertSame($companyId, $message->getCompanyId());
+    }
+}

--- a/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonSellerReportConnectorTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonSellerReportConnectorTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Application\Source\Ozon;
+
+use App\Ingestion\Application\DTO\PullRequest;
+use App\Ingestion\Application\DTO\PushRequest;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Application\Source\Ozon\OzonSellerReportConnector;
+use App\Ingestion\Enum\Capability;
+use App\Ingestion\Exception\UnsupportedCapabilityException;
+use App\Ingestion\Infrastructure\Api\Ozon\OzonClientAdapterInterface;
+use App\Ingestion\Infrastructure\Api\Ozon\OzonRawPage;
+use App\Ingestion\Infrastructure\Api\Ozon\OzonShopDescriptor;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Ramsey\Uuid\Uuid;
+
+final class OzonSellerReportConnectorTest extends TestCase
+{
+    public function testPullDailyReportUsesSevenDayWindowAndReturnsRawBatch(): void
+    {
+        $client = new class implements OzonClientAdapterInterface {
+            public ?\DateTimeImmutable $from = null;
+            public ?\DateTimeImmutable $to = null;
+
+            public function fetchTransactionList(
+                string $companyId,
+                string $connectionRef,
+                \DateTimeImmutable $from,
+                \DateTimeImmutable $to,
+                int $page,
+                int $pageSize,
+            ): OzonRawPage {
+                $this->from = $from;
+                $this->to = $to;
+
+                return new OzonRawPage(rows: [['operation_id' => 'op-1']], hasMore: false);
+            }
+
+            public function fetchRealization(string $companyId, string $connectionRef, int $year, int $month): OzonRawPage
+            {
+                throw new \LogicException('Not used.');
+            }
+
+            public function listClusters(string $companyId, string $connectionRef): array
+            {
+                return [new OzonShopDescriptor('shop-1', 'Shop 1')];
+            }
+        };
+
+        $connector = new OzonSellerReportConnector($client, new NullLogger());
+        $companyId = Uuid::uuid7()->toString();
+        $syncJobId = Uuid::uuid7()->toString();
+
+        $result = $connector->pull(new PullRequest(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            shopRef: 'shop-1',
+            resourceType: OzonResourceType::DAILY_REPORT,
+            cursorValue: null,
+            windowFrom: new \DateTimeImmutable('2026-06-01'),
+            windowTo: new \DateTimeImmutable('2026-06-18'),
+            syncJobId: $syncJobId,
+        ));
+
+        self::assertEquals(new \DateTimeImmutable('2026-06-01 00:00:00'), $client->from);
+        self::assertEquals(new \DateTimeImmutable('2026-06-07 23:59:59'), $client->to);
+        self::assertSame('daily:2026-06-01:2026-06-07', $result->rawBatch->externalId);
+        self::assertSame('2026-06-08', $result->nextCursorValue);
+        self::assertTrue($result->hasMore);
+        self::assertSame([['operation_id' => 'op-1']], $result->rawBatch->rows);
+    }
+
+    public function testCapabilitiesDiscoverAndUnsupportedPush(): void
+    {
+        $client = new class implements OzonClientAdapterInterface {
+            public function fetchTransactionList(
+                string $companyId,
+                string $connectionRef,
+                \DateTimeImmutable $from,
+                \DateTimeImmutable $to,
+                int $page,
+                int $pageSize,
+            ): OzonRawPage {
+                throw new \LogicException('Not used.');
+            }
+
+            public function fetchRealization(string $companyId, string $connectionRef, int $year, int $month): OzonRawPage
+            {
+                throw new \LogicException('Not used.');
+            }
+
+            public function listClusters(string $companyId, string $connectionRef): array
+            {
+                return [new OzonShopDescriptor('shop-1', 'Shop 1')];
+            }
+        };
+
+        $connector = new OzonSellerReportConnector($client, new NullLogger());
+        self::assertSame([Capability::CAN_DISCOVER_SHOPS, Capability::CAN_PULL], $connector->capabilities());
+        self::assertSame('shop-1', $connector->discoverShops(Uuid::uuid7()->toString(), 'connection-1')[0]->externalId);
+
+        $this->expectException(UnsupportedCapabilityException::class);
+        $connector->push(new PushRequest(
+            companyId: Uuid::uuid7()->toString(),
+            connectionRef: 'connection-1',
+            documentType: 'doc',
+            payload: [],
+            idempotencyKey: 'key-1',
+        ));
+    }
+}

--- a/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonSellerReportMapperTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonSellerReportMapperTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Application\Source\Ozon;
+
+use App\Ingestion\Application\Source\Ozon\OzonMoneyParser;
+use App\Ingestion\Application\Source\Ozon\OzonOperationKey;
+use App\Ingestion\Application\Source\Ozon\OzonRealizationMapper;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Application\Source\Ozon\OzonSellerReportMapper;
+use App\Ingestion\Application\Source\Ozon\OzonTransactionComponentMapper;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+final class OzonSellerReportMapperTest extends TestCase
+{
+    public function testDailyReportFixtureIsDecomposedIntoCanonicalTransactions(): void
+    {
+        $rows = $this->fixtureRows('transaction_list_with_sale_and_commission.json');
+        $rawRecord = $this->rawRecord(OzonResourceType::DAILY_REPORT);
+        $mapper = $this->dailyMapper();
+
+        $transactions = $mapper->map($rawRecord, $rows);
+        $controlSums = $mapper->controlSumForRawRecord($rawRecord, $rows);
+
+        self::assertCount(6, $transactions);
+        self::assertCount(1, $controlSums);
+        self::assertSame(140855, $controlSums[0]->amountMinor);
+        self::assertSame('RUB', $controlSums[0]->currency);
+
+        $groupIds = array_unique(array_map(static fn ($transaction): string => $transaction->operationGroupId, $transactions));
+        self::assertCount(1, $groupIds);
+        self::assertSame($controlSums[0]->operationGroupId, $groupIds[0]);
+
+        $byExternalId = [];
+        foreach ($transactions as $transaction) {
+            $byExternalId[$transaction->externalId] = $transaction;
+        }
+
+        self::assertCount(6, $byExternalId);
+        self::assertSame(TransactionType::SALE, $byExternalId['ozon:operation:1234567890:sale']->type);
+        self::assertSame(TransactionDirection::IN, $byExternalId['ozon:operation:1234567890:sale']->direction);
+        self::assertSame(120050, $byExternalId['ozon:operation:1234567890:sale']->money->amountMinor());
+
+        self::assertSame(TransactionType::COMMISSION, $byExternalId['ozon:operation:1234567890:commission']->type);
+        self::assertSame(TransactionDirection::OUT, $byExternalId['ozon:operation:1234567890:commission']->direction);
+        self::assertSame(12005, $byExternalId['ozon:operation:1234567890:commission']->money->amountMinor());
+
+        self::assertSame(TransactionType::LOGISTICS, $byExternalId['ozon:operation:1234567890:logistics_delivery']->type);
+        self::assertSame(TransactionType::LAST_MILE, $byExternalId['ozon:operation:1234567890:service_marketplaceserviceitemdelivtocustomer']->type);
+        self::assertSame(TransactionType::FEE, $byExternalId['ozon:operation:1234567890:service_marketplaceserviceitemdropoffpvz']->type);
+        self::assertSame(TransactionType::ACQUIRING, $byExternalId['ozon:operation:1234567890:acquiring']->type);
+    }
+
+    public function testRealizationFixtureUsesSameExternalIdsAndNewerVersion(): void
+    {
+        $dailyRows = $this->fixtureRows('transaction_list_with_sale_and_commission.json');
+        $realizationRows = $this->fixtureRows('realization_february_2026.json');
+        $daily = $this->dailyMapper()->map($this->rawRecord(OzonResourceType::DAILY_REPORT), $dailyRows);
+        $realization = $this->realizationMapper()->map($this->rawRecord(OzonResourceType::REALIZATION), $realizationRows);
+
+        self::assertSame(
+            array_map(static fn ($transaction): string => $transaction->externalId, $daily),
+            array_map(static fn ($transaction): string => $transaction->externalId, $realization),
+        );
+
+        $sale = $realization[0];
+        self::assertSame('ozon:operation:1234567890:sale', $sale->externalId);
+        self::assertSame(121000, $sale->money->amountMinor());
+        self::assertEquals(new \DateTimeImmutable('2026-03-05T00:00:00+00:00'), $sale->externalUpdatedAt);
+    }
+
+    public function testRefundAndServicesFixtureIsDecomposed(): void
+    {
+        $rows = $this->fixtureRows('transaction_list_with_refund_and_services.json');
+        $rawRecord = $this->rawRecord(OzonResourceType::DAILY_REPORT);
+        $mapper = $this->dailyMapper();
+
+        $transactions = $mapper->map($rawRecord, $rows);
+        $controlSums = $mapper->controlSumForRawRecord($rawRecord, $rows);
+
+        self::assertCount(5, $transactions);
+        self::assertCount(1, $controlSums);
+        self::assertSame(64794, $controlSums[0]->amountMinor);
+
+        $byExternalId = [];
+        foreach ($transactions as $transaction) {
+            $byExternalId[$transaction->externalId] = $transaction;
+        }
+
+        self::assertSame(TransactionType::REFUND, $byExternalId['ozon:operation:refund-1001:refund']->type);
+        self::assertSame(TransactionDirection::OUT, $byExternalId['ozon:operation:refund-1001:refund']->direction);
+        self::assertSame(55040, $byExternalId['ozon:operation:refund-1001:refund']->money->amountMinor());
+
+        self::assertSame(TransactionType::COMMISSION, $byExternalId['ozon:operation:refund-1001:commission']->type);
+        self::assertSame(TransactionDirection::IN, $byExternalId['ozon:operation:refund-1001:commission']->direction);
+        self::assertSame(5504, $byExternalId['ozon:operation:refund-1001:commission']->money->amountMinor());
+
+        self::assertSame(TransactionType::LOGISTICS, $byExternalId['ozon:operation:refund-1001:logistics_return_delivery']->type);
+        self::assertSame(TransactionType::LOGISTICS, $byExternalId['ozon:operation:refund-1001:service_marketplaceserviceitemreturnafterdelivtocustomer_0']->type);
+        self::assertSame(TransactionType::FEE, $byExternalId['ozon:operation:refund-1001:service_premium_placement_1']->type);
+    }
+
+    public function testMissingOperationIdUsesStableFallbackKey(): void
+    {
+        $rows = $this->fixtureRows('transaction_list_without_operation_id.json');
+        $rawRecord = $this->rawRecord(OzonResourceType::DAILY_REPORT);
+        $transactions = $this->dailyMapper()->map($rawRecord, $rows);
+        $controlSums = $this->dailyMapper()->controlSumForRawRecord($rawRecord, $rows);
+
+        self::assertCount(1, $transactions);
+        self::assertSame(
+            'ozon:fallback:fallback-posting-1:fallback-sku-1:2026-02-20T11:00:00+00:00:other',
+            $transactions[0]->externalId,
+        );
+        self::assertSame(TransactionType::OTHER, $transactions[0]->type);
+        self::assertSame(TransactionDirection::IN, $transactions[0]->direction);
+        self::assertSame(4210, $transactions[0]->money->amountMinor());
+        self::assertSame($transactions[0]->operationGroupId, $controlSums[0]->operationGroupId);
+        self::assertSame(4210, $controlSums[0]->amountMinor);
+    }
+
+    private function dailyMapper(): OzonSellerReportMapper
+    {
+        return new OzonSellerReportMapper($this->componentMapper());
+    }
+
+    private function realizationMapper(): OzonRealizationMapper
+    {
+        return new OzonRealizationMapper($this->componentMapper());
+    }
+
+    private function componentMapper(): OzonTransactionComponentMapper
+    {
+        return new OzonTransactionComponentMapper(new OzonMoneyParser(), new OzonOperationKey());
+    }
+
+    private function rawRecord(string $resourceType): IngestRawRecord
+    {
+        return new IngestRawRecord(
+            companyId: '0192f0c2-0000-7000-8000-000000000001',
+            connectionRef: 'marketplace:ozon:seller',
+            shopRef: 'ozon-shop',
+            source: IngestSource::OZON,
+            resourceType: $resourceType,
+            externalId: 'raw-'.$resourceType,
+            storagePath: 'raw.ndjson.gz',
+            hash: str_repeat('a', 64),
+            byteSize: 100,
+            fetchedAt: new \DateTimeImmutable('2026-03-05T00:00:00+00:00'),
+            syncJobId: Uuid::uuid7()->toString(),
+        );
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function fixtureRows(string $fileName): array
+    {
+        $payload = json_decode(
+            (string) file_get_contents(__DIR__.'/../../../../../Fixtures/Ingestion/Ozon/'.$fileName),
+            true,
+            512,
+            \JSON_THROW_ON_ERROR,
+        );
+
+        self::assertIsArray($payload);
+        self::assertIsArray($payload['rows'] ?? null);
+
+        /** @var list<array<string, mixed>> $rows */
+        $rows = $payload['rows'];
+
+        return $rows;
+    }
+}

--- a/site/tests/Unit/Ingestion/Domain/Service/ConnectorRegistryTest.php
+++ b/site/tests/Unit/Ingestion/Domain/Service/ConnectorRegistryTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Domain\Service;
+
+use App\Ingestion\Application\DTO\PullRequest;
+use App\Ingestion\Application\DTO\PullResult;
+use App\Ingestion\Application\DTO\PushRequest;
+use App\Ingestion\Application\DTO\PushResult;
+use App\Ingestion\Application\DTO\ShopDescriptor;
+use App\Ingestion\Domain\Contract\SourceConnectorInterface;
+use App\Ingestion\Domain\Service\ConnectorRegistry;
+use App\Ingestion\Enum\Capability;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Exception\ConnectorNotFoundException;
+use PHPUnit\Framework\TestCase;
+
+final class ConnectorRegistryTest extends TestCase
+{
+    public function testReturnsConnectorBySource(): void
+    {
+        $connector = $this->connector(IngestSource::OZON);
+        $registry = new ConnectorRegistry([$connector]);
+
+        self::assertTrue($registry->has(IngestSource::OZON));
+        self::assertSame($connector, $registry->get(IngestSource::OZON));
+        self::assertFalse($registry->has(IngestSource::WILDBERRIES));
+    }
+
+    public function testMissingConnectorThrowsDomainException(): void
+    {
+        $registry = new ConnectorRegistry([]);
+
+        $this->expectException(ConnectorNotFoundException::class);
+        $registry->get(IngestSource::OZON);
+    }
+
+    public function testDuplicateSourceIsRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new ConnectorRegistry([
+            $this->connector(IngestSource::OZON),
+            $this->connector(IngestSource::OZON),
+        ]);
+    }
+
+    private function connector(IngestSource $source): SourceConnectorInterface
+    {
+        return new class($source) implements SourceConnectorInterface {
+            public function __construct(private readonly IngestSource $source)
+            {
+            }
+
+            public function source(): IngestSource
+            {
+                return $this->source;
+            }
+
+            /**
+             * @return list<Capability>
+             */
+            public function capabilities(): array
+            {
+                return [Capability::CAN_PULL];
+            }
+
+            /**
+             * @return list<ShopDescriptor>
+             */
+            public function discoverShops(string $companyId, string $connectionRef): array
+            {
+                return [];
+            }
+
+            public function pull(PullRequest $request): PullResult
+            {
+                throw new \LogicException('Not used in registry tests.');
+            }
+
+            public function push(PushRequest $request): PushResult
+            {
+                throw new \LogicException('Not used in registry tests.');
+            }
+        };
+    }
+}

--- a/site/tests/Unit/Ingestion/Domain/Service/MapperRegistryTest.php
+++ b/site/tests/Unit/Ingestion/Domain/Service/MapperRegistryTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Domain\Service;
+
+use App\Ingestion\Application\DTO\MappedControlSum;
+use App\Ingestion\Application\DTO\MappedTransaction;
+use App\Ingestion\Domain\Contract\SourceMapperInterface;
+use App\Ingestion\Domain\Service\MapperRegistry;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Exception\MapperNotFoundException;
+use PHPUnit\Framework\TestCase;
+
+final class MapperRegistryTest extends TestCase
+{
+    public function testReturnsMapperBySourceAndResource(): void
+    {
+        $mapper = $this->mapper(IngestSource::OZON, ['sales', 'returns']);
+        $registry = new MapperRegistry([$mapper]);
+
+        self::assertSame($mapper, $registry->get(IngestSource::OZON, 'sales'));
+        self::assertSame($mapper, $registry->get(IngestSource::OZON, 'returns'));
+    }
+
+    public function testMissingMapperThrowsDomainException(): void
+    {
+        $registry = new MapperRegistry([]);
+
+        $this->expectException(MapperNotFoundException::class);
+        $registry->get(IngestSource::OZON, 'sales');
+    }
+
+    public function testDuplicateSourceResourcePairIsRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new MapperRegistry([
+            $this->mapper(IngestSource::OZON, ['sales']),
+            $this->mapper(IngestSource::OZON, ['sales']),
+        ]);
+    }
+
+    /**
+     * @param list<string> $resourceTypes
+     */
+    private function mapper(IngestSource $source, array $resourceTypes): SourceMapperInterface
+    {
+        return new class($source, $resourceTypes) implements SourceMapperInterface {
+            /**
+             * @param list<string> $resourceTypes
+             */
+            public function __construct(
+                private readonly IngestSource $source,
+                private readonly array $resourceTypes,
+            ) {
+            }
+
+            public function source(): IngestSource
+            {
+                return $this->source;
+            }
+
+            /**
+             * @return list<string>
+             */
+            public function resourceTypes(): array
+            {
+                return $this->resourceTypes;
+            }
+
+            /**
+             * @param iterable<array<string, mixed>> $rows
+             *
+             * @return list<MappedTransaction>
+             */
+            public function map(IngestRawRecord $rawRecord, iterable $rows): array
+            {
+                return [];
+            }
+
+            /**
+             * @param iterable<array<string, mixed>> $rows
+             *
+             * @return list<MappedControlSum>
+             */
+            public function controlSum(iterable $rows): array
+            {
+                return [];
+            }
+        };
+    }
+}

--- a/site/tests/Unit/Ingestion/Entity/FinancialTransactionTest.php
+++ b/site/tests/Unit/Ingestion/Entity/FinancialTransactionTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Entity;
+
+use App\Ingestion\Entity\FinancialTransaction;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+use App\Ingestion\Exception\StaleTransactionUpdateException;
+use App\Shared\Domain\ValueObject\Money;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+final class FinancialTransactionTest extends TestCase
+{
+    public function testConstructorStoresCanonicalFields(): void
+    {
+        $transaction = $this->newTransaction();
+
+        self::assertTrue(Uuid::isValid($transaction->getId()));
+        self::assertSame(TransactionType::SALE, $transaction->getType());
+        self::assertSame(TransactionDirection::IN, $transaction->getDirection());
+        self::assertSame(12500, $transaction->getAmountMinor());
+        self::assertSame('RUB', $transaction->getCurrency());
+        self::assertSame('Europe/Moscow', $transaction->getSourceTz());
+        self::assertSame(['row' => 1], $transaction->getSourceData());
+    }
+
+    public function testReplaceFromNewerVersionUpdatesMutableFieldsAndKeepsOldOccurredAt(): void
+    {
+        $transaction = $this->newTransaction();
+        $oldOccurredAt = $transaction->getOccurredAt();
+        $newOccurredAt = new \DateTimeImmutable('2026-06-03 12:00:00');
+
+        $transaction->replaceFromNewerVersion(
+            money: Money::fromMinor(15000, 'RUB'),
+            type: TransactionType::SALE,
+            direction: TransactionDirection::IN,
+            occurredAt: $newOccurredAt,
+            externalUpdatedAt: new \DateTimeImmutable('2026-06-04 00:00:00'),
+            orderRef: 'order-2',
+            payoutRef: 'payout-2',
+            counterpartyId: null,
+            description: 'updated',
+            sourceData: ['row' => 2],
+        );
+
+        self::assertSame(15000, $transaction->getAmountMinor());
+        self::assertSame($newOccurredAt, $transaction->getOccurredAt());
+        self::assertSame($oldOccurredAt, $transaction->oldOccurredAt());
+        self::assertSame('order-2', $transaction->getOrderRef());
+        self::assertSame(['row' => 2], $transaction->getSourceData());
+    }
+
+    public function testReplaceRejectsStaleVersion(): void
+    {
+        $transaction = $this->newTransaction();
+
+        $this->expectException(StaleTransactionUpdateException::class);
+
+        $transaction->replaceFromNewerVersion(
+            money: Money::fromMinor(15000, 'RUB'),
+            type: TransactionType::SALE,
+            direction: TransactionDirection::IN,
+            occurredAt: new \DateTimeImmutable('2026-06-03 12:00:00'),
+            externalUpdatedAt: new \DateTimeImmutable('2026-06-01 00:00:00'),
+            orderRef: null,
+            payoutRef: null,
+            counterpartyId: null,
+            description: null,
+            sourceData: [],
+        );
+    }
+
+    private function newTransaction(): FinancialTransaction
+    {
+        return new FinancialTransaction(
+            companyId: Uuid::uuid7()->toString(),
+            connectionRef: 'connection-1',
+            shopRef: 'shop-1',
+            source: IngestSource::OZON,
+            externalId: 'external-1',
+            externalUpdatedAt: new \DateTimeImmutable('2026-06-02 00:00:00'),
+            operationGroupId: Uuid::uuid7()->toString(),
+            type: TransactionType::SALE,
+            direction: TransactionDirection::IN,
+            money: Money::fromMinor(12500, 'RUB'),
+            occurredAt: new \DateTimeImmutable('2026-06-02 12:00:00'),
+            rawRecordId: Uuid::uuid7()->toString(),
+            orderRef: 'order-1',
+            payoutRef: 'payout-1',
+            counterpartyId: null,
+            description: 'sale',
+            sourceData: ['row' => 1],
+            sourceTz: 'Europe/Moscow',
+        );
+    }
+}

--- a/site/tests/Unit/Ingestion/Entity/IngestCursorTest.php
+++ b/site/tests/Unit/Ingestion/Entity/IngestCursorTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Entity;
+
+use App\Ingestion\Entity\IngestCursor;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+final class IngestCursorTest extends TestCase
+{
+    public function testConstructorSetsDefaults(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+
+        $cursor = new IngestCursor($companyId, 'connection-1', 'ozon_seller_daily_report');
+
+        self::assertTrue(Uuid::isValid($cursor->getId()));
+        self::assertSame($companyId, $cursor->getCompanyId());
+        self::assertSame('connection-1', $cursor->getConnectionRef());
+        self::assertSame('ozon_seller_daily_report', $cursor->getResourceType());
+        self::assertSame('', $cursor->getShopRef());
+        self::assertSame('', $cursor->getCursorValue());
+        self::assertNull($cursor->getLastFetchedAt());
+        self::assertNull($cursor->getLastSyncJobId());
+    }
+
+    public function testAdvanceUpdatesCursorAndTimestamps(): void
+    {
+        $cursor = new IngestCursor(Uuid::uuid7()->toString(), 'connection-1', 'resource-1', 'shop-1');
+        $syncJobId = Uuid::uuid7()->toString();
+        $fetchedAt = new \DateTimeImmutable('2026-06-18 10:15:00');
+        $originalUpdatedAt = $cursor->getUpdatedAt();
+
+        usleep(1000);
+        $cursor->advance('next-page-token', $syncJobId, $fetchedAt);
+
+        self::assertSame('next-page-token', $cursor->getCursorValue());
+        self::assertSame($syncJobId, $cursor->getLastSyncJobId());
+        self::assertSame($fetchedAt, $cursor->getLastFetchedAt());
+        self::assertGreaterThan($originalUpdatedAt, $cursor->getUpdatedAt());
+    }
+
+    public function testAdvanceRejectsEmptyCursorValue(): void
+    {
+        $cursor = new IngestCursor(Uuid::uuid7()->toString(), 'connection-1', 'resource-1');
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $cursor->advance('', Uuid::uuid7()->toString());
+    }
+}

--- a/site/tests/Unit/Ingestion/Entity/NormalizationIssueTest.php
+++ b/site/tests/Unit/Ingestion/Entity/NormalizationIssueTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Entity;
+
+use App\Ingestion\Entity\NormalizationIssue;
+use App\Ingestion\Enum\NormalizationIssueKind;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+final class NormalizationIssueTest extends TestCase
+{
+    public function testMarkResolvedIsIdempotent(): void
+    {
+        $issue = new NormalizationIssue(
+            companyId: Uuid::uuid7()->toString(),
+            rawRecordId: Uuid::uuid7()->toString(),
+            operationGroupId: Uuid::uuid7()->toString(),
+            kind: NormalizationIssueKind::SUM_MISMATCH,
+            details: ['expected' => 100, 'actual' => 99],
+        );
+        $resolvedAt = new \DateTimeImmutable('2026-06-18 12:00:00');
+
+        $issue->markResolved($resolvedAt);
+        $issue->markResolved(new \DateTimeImmutable('2026-06-19 12:00:00'));
+
+        self::assertSame($resolvedAt, $issue->getResolvedAt());
+        self::assertSame(['expected' => 100, 'actual' => 99], $issue->getDetails());
+    }
+}

--- a/site/tests/Unit/Ingestion/Entity/PLDirtyPeriodTest.php
+++ b/site/tests/Unit/Ingestion/Entity/PLDirtyPeriodTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Entity;
+
+use App\Ingestion\Domain\TenantOwnedInterface;
+use App\Ingestion\Entity\PLDirtyPeriod;
+use App\Ingestion\Enum\PLDirtyPeriodReason;
+use App\Ingestion\Enum\PLDirtyPeriodStatus;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+final class PLDirtyPeriodTest extends TestCase
+{
+    public function testConstructorSetsPendingPeriod(): void
+    {
+        $period = $this->newPeriod();
+
+        self::assertTrue(Uuid::isValid($period->getId()));
+        self::assertInstanceOf(TenantOwnedInterface::class, $period);
+        self::assertSame(PLDirtyPeriodStatus::PENDING, $period->getStatus());
+        self::assertSame(PLDirtyPeriodReason::INGEST, $period->getReason());
+        self::assertSame(2026, $period->getPeriodYear());
+        self::assertSame(2, $period->getPeriodMonth());
+        self::assertSame('ozon:shop-1', $period->getShopRef());
+        self::assertSame(0, $period->getAttempts());
+        self::assertNull($period->getRebuiltAt());
+        self::assertNull($period->getLastError());
+    }
+
+    public function testConstructorRejectsInvalidPeriod(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new PLDirtyPeriod(
+            companyId: Uuid::uuid7()->toString(),
+            periodYear: 2019,
+            periodMonth: 13,
+            shopRef: '',
+            reason: PLDirtyPeriodReason::INGEST,
+        );
+    }
+
+    public function testSuccessfulRebuildTransitionSetsAuditFields(): void
+    {
+        $period = $this->newPeriod();
+        $rebuiltAt = new \DateTimeImmutable('2026-06-18 10:00:00');
+
+        $period->markRebuilding();
+        $period->markDone($rebuiltAt);
+
+        self::assertSame(PLDirtyPeriodStatus::DONE, $period->getStatus());
+        self::assertSame(1, $period->getAttempts());
+        self::assertSame($rebuiltAt, $period->getRebuiltAt());
+        self::assertNull($period->getLastError());
+    }
+
+    public function testInvalidTransitionIsRejected(): void
+    {
+        $period = $this->newPeriod();
+
+        $this->expectException(\DomainException::class);
+
+        $period->markDone();
+    }
+
+    public function testFailedAndBlockedPeriodsCanBeReopened(): void
+    {
+        $failed = $this->newPeriod();
+        $failed->markRebuilding();
+        $failed->markFailed('temporary error');
+        $failed->reopen();
+
+        self::assertSame(PLDirtyPeriodStatus::PENDING, $failed->getStatus());
+        self::assertNull($failed->getLastError());
+
+        $blocked = $this->newPeriod();
+        $blocked->markBlockedByClose('closed month');
+        $blocked->reopen();
+
+        self::assertSame(PLDirtyPeriodStatus::PENDING, $blocked->getStatus());
+        self::assertNull($blocked->getLastError());
+    }
+
+    private function newPeriod(): PLDirtyPeriod
+    {
+        return new PLDirtyPeriod(
+            companyId: Uuid::uuid7()->toString(),
+            periodYear: 2026,
+            periodMonth: 2,
+            shopRef: 'ozon:shop-1',
+            reason: PLDirtyPeriodReason::INGEST,
+        );
+    }
+}

--- a/site/tests/Unit/Ingestion/Entity/SyncJobTest.php
+++ b/site/tests/Unit/Ingestion/Entity/SyncJobTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Entity;
+
+use App\Ingestion\Entity\SyncJob;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\SyncJobKind;
+use App\Ingestion\Enum\SyncJobStatus;
+use App\Ingestion\Exception\SyncJobTransitionException;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+final class SyncJobTest extends TestCase
+{
+    public function testBackfillConstructorRequiresWindow(): void
+    {
+        $this->expectException(\DomainException::class);
+
+        $this->createJob(kind: SyncJobKind::BACKFILL, windowFrom: null, windowTo: null);
+    }
+
+    public function testConstructorRejectsInvertedWindow(): void
+    {
+        $this->expectException(\DomainException::class);
+
+        $this->createJob(
+            windowFrom: new \DateTimeImmutable('2026-06-10'),
+            windowTo: new \DateTimeImmutable('2026-06-01'),
+        );
+    }
+
+    public function testIncrementalConstructorAllowsEmptyWindow(): void
+    {
+        $job = $this->createJob(kind: SyncJobKind::INCREMENTAL, windowFrom: null, windowTo: null);
+
+        self::assertSame(SyncJobStatus::OPEN, $job->getStatus());
+        self::assertNull($job->getWindowFrom());
+        self::assertNull($job->getWindowTo());
+    }
+
+    public function testMarkRunningFromOpenStartsJobAndIncrementsAttempts(): void
+    {
+        $job = $this->createJob();
+
+        $job->markRunning();
+
+        self::assertSame(SyncJobStatus::RUNNING, $job->getStatus());
+        self::assertSame(1, $job->getAttempts());
+        self::assertNotNull($job->getStartedAt());
+        self::assertNull($job->getFinishedAt());
+    }
+
+    public function testMarkRunningFromRunningIsRetryAndKeepsStartedAt(): void
+    {
+        $job = $this->createJob();
+        $job->markRunning();
+        $startedAt = $job->getStartedAt();
+
+        usleep(1000);
+        $job->markRunning();
+
+        self::assertSame(SyncJobStatus::RUNNING, $job->getStatus());
+        self::assertSame(2, $job->getAttempts());
+        self::assertSame($startedAt, $job->getStartedAt());
+    }
+
+    public function testMarkCompletedRequiresRunningStatus(): void
+    {
+        $job = $this->createJob();
+
+        $this->expectException(SyncJobTransitionException::class);
+
+        $job->markCompleted();
+    }
+
+    public function testMarkCompletedFromRunningSetsTerminalState(): void
+    {
+        $job = $this->createJob();
+        $finishedAt = new \DateTimeImmutable('2026-06-18 11:00:00');
+
+        $job->markRunning();
+        $job->markCompleted($finishedAt);
+
+        self::assertSame(SyncJobStatus::COMPLETED, $job->getStatus());
+        self::assertSame($finishedAt, $job->getFinishedAt());
+        self::assertTrue($job->getStatus()->isTerminal());
+    }
+
+    public function testMarkFailedStoresReason(): void
+    {
+        $job = $this->createJob();
+        $job->markRunning();
+
+        $job->markFailed('Ozon returned 500');
+
+        self::assertSame(SyncJobStatus::FAILED, $job->getStatus());
+        self::assertSame('Ozon returned 500', $job->getLastError());
+        self::assertNotNull($job->getFinishedAt());
+    }
+
+    public function testMarkCancelledFromOpenStoresReason(): void
+    {
+        $job = $this->createJob();
+
+        $job->markCancelled('manual stop');
+
+        self::assertSame(SyncJobStatus::CANCELLED, $job->getStatus());
+        self::assertSame('manual stop', $job->getLastError());
+        self::assertNotNull($job->getFinishedAt());
+    }
+
+    public function testTerminalStatusCannotTransition(): void
+    {
+        $job = $this->createJob();
+        $job->markRunning();
+        $job->markCompleted();
+
+        $this->expectException(SyncJobTransitionException::class);
+
+        $job->markRunning();
+    }
+
+    public function testProgressTotalCanBeSetOnlyOnce(): void
+    {
+        $job = $this->createJob();
+
+        $job->setProgressTotal(3);
+
+        self::assertSame(3, $job->getProgressTotal());
+
+        $this->expectException(\DomainException::class);
+
+        $job->setProgressTotal(4);
+    }
+
+    public function testIncrementProgressCannotExceedTotal(): void
+    {
+        $job = $this->createJob();
+        $job->setProgressTotal(2);
+        $job->incrementProgress();
+        $job->incrementProgress();
+
+        self::assertSame(2, $job->getProgressDone());
+
+        $this->expectException(\DomainException::class);
+
+        $job->incrementProgress();
+    }
+
+    public function testCursorSnapshotCanBeSetOnlyBeforeRunningAndOnce(): void
+    {
+        $job = $this->createJob();
+
+        $job->setCursorSnapshot('cursor-1');
+
+        self::assertSame('cursor-1', $job->getCursorSnapshot());
+
+        $this->expectException(\DomainException::class);
+
+        $job->setCursorSnapshot('cursor-2');
+    }
+
+    private function createJob(
+        SyncJobKind $kind = SyncJobKind::BACKFILL,
+        ?\DateTimeImmutable $windowFrom = new \DateTimeImmutable('2026-06-01'),
+        ?\DateTimeImmutable $windowTo = new \DateTimeImmutable('2026-06-30'),
+    ): SyncJob {
+        return new SyncJob(
+            companyId: Uuid::uuid7()->toString(),
+            connectionRef: 'connection-1',
+            source: IngestSource::OZON,
+            resourceType: 'ozon_seller_daily_report',
+            kind: $kind,
+            windowFrom: $windowFrom,
+            windowTo: $windowTo,
+            shopRef: 'shop-1',
+        );
+    }
+}

--- a/site/tests/Unit/Ingestion/Enum/PLDirtyPeriodStatusTest.php
+++ b/site/tests/Unit/Ingestion/Enum/PLDirtyPeriodStatusTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Enum;
+
+use App\Ingestion\Enum\PLDirtyPeriodStatus;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class PLDirtyPeriodStatusTest extends TestCase
+{
+    #[DataProvider('transitionProvider')]
+    public function testTransitionMatrix(PLDirtyPeriodStatus $from, PLDirtyPeriodStatus $to, bool $expected): void
+    {
+        self::assertSame($expected, $from->canTransitionTo($to));
+    }
+
+    public function testTerminalStatuses(): void
+    {
+        self::assertFalse(PLDirtyPeriodStatus::PENDING->isTerminal());
+        self::assertFalse(PLDirtyPeriodStatus::REBUILDING->isTerminal());
+        self::assertTrue(PLDirtyPeriodStatus::DONE->isTerminal());
+        self::assertTrue(PLDirtyPeriodStatus::FAILED->isTerminal());
+        self::assertTrue(PLDirtyPeriodStatus::BLOCKED_BY_CLOSE->isTerminal());
+    }
+
+    /**
+     * @return iterable<string, array{PLDirtyPeriodStatus, PLDirtyPeriodStatus, bool}>
+     */
+    public static function transitionProvider(): iterable
+    {
+        $allowed = [
+            PLDirtyPeriodStatus::PENDING->value => [
+                PLDirtyPeriodStatus::REBUILDING->value,
+                PLDirtyPeriodStatus::BLOCKED_BY_CLOSE->value,
+            ],
+            PLDirtyPeriodStatus::REBUILDING->value => [
+                PLDirtyPeriodStatus::DONE->value,
+                PLDirtyPeriodStatus::FAILED->value,
+                PLDirtyPeriodStatus::BLOCKED_BY_CLOSE->value,
+            ],
+            PLDirtyPeriodStatus::DONE->value => [PLDirtyPeriodStatus::PENDING->value],
+            PLDirtyPeriodStatus::FAILED->value => [PLDirtyPeriodStatus::PENDING->value],
+            PLDirtyPeriodStatus::BLOCKED_BY_CLOSE->value => [PLDirtyPeriodStatus::PENDING->value],
+        ];
+
+        foreach (PLDirtyPeriodStatus::cases() as $from) {
+            foreach (PLDirtyPeriodStatus::cases() as $to) {
+                yield sprintf('%s -> %s', $from->value, $to->value) => [
+                    $from,
+                    $to,
+                    in_array($to->value, $allowed[$from->value], true),
+                ];
+            }
+        }
+    }
+}

--- a/site/tests/Unit/Ingestion/Enum/SyncJobStatusTest.php
+++ b/site/tests/Unit/Ingestion/Enum/SyncJobStatusTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Enum;
+
+use App\Ingestion\Enum\SyncJobStatus;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class SyncJobStatusTest extends TestCase
+{
+    #[DataProvider('transitionProvider')]
+    public function testTransitionMatrix(SyncJobStatus $from, SyncJobStatus $to, bool $expected): void
+    {
+        self::assertSame($expected, $from->canTransitionTo($to));
+    }
+
+    /**
+     * @return iterable<string, array{SyncJobStatus, SyncJobStatus, bool}>
+     */
+    public static function transitionProvider(): iterable
+    {
+        $allowed = [
+            SyncJobStatus::OPEN->value => [SyncJobStatus::RUNNING->value, SyncJobStatus::CANCELLED->value],
+            SyncJobStatus::RUNNING->value => [
+                SyncJobStatus::RUNNING->value,
+                SyncJobStatus::COMPLETED->value,
+                SyncJobStatus::FAILED->value,
+                SyncJobStatus::CANCELLED->value,
+            ],
+            SyncJobStatus::COMPLETED->value => [],
+            SyncJobStatus::FAILED->value => [],
+            SyncJobStatus::CANCELLED->value => [],
+        ];
+
+        foreach (SyncJobStatus::cases() as $from) {
+            foreach (SyncJobStatus::cases() as $to) {
+                yield sprintf('%s -> %s', $from->value, $to->value) => [
+                    $from,
+                    $to,
+                    in_array($to->value, $allowed[$from->value], true),
+                ];
+            }
+        }
+    }
+}

--- a/site/tests/Unit/Ingestion/Infrastructure/Api/Ozon/LegacyOzonClientAdapterTest.php
+++ b/site/tests/Unit/Ingestion/Infrastructure/Api/Ozon/LegacyOzonClientAdapterTest.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Infrastructure\Api\Ozon;
+
+use App\Ingestion\Exception\ConnectorAuthException;
+use App\Ingestion\Exception\ConnectorTransientException;
+use App\Ingestion\Exception\CredentialNotFoundException;
+use App\Ingestion\Infrastructure\Api\Ozon\LegacyOzonClientAdapter;
+use App\Ingestion\Infrastructure\Api\Ozon\OzonCredentialProviderInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class LegacyOzonClientAdapterTest extends TestCase
+{
+    public function testFetchTransactionListMapsSuccessfulResponse(): void
+    {
+        $capturedUrl = null;
+        $capturedOptions = null;
+        $http = new MockHttpClient(static function (string $method, string $url, array $options) use (&$capturedUrl, &$capturedOptions): MockResponse {
+            $capturedUrl = $url;
+            $capturedOptions = $options;
+
+            return new MockResponse(
+                '{"result":{"operations":[{"operation_id":"1"}],"page_count":2}}',
+                ['http_code' => 200],
+            );
+        });
+
+        $adapter = new LegacyOzonClientAdapter($http, $this->credentialProvider(), new NullLogger());
+        $page = $adapter->fetchTransactionList(
+            '0192f0c2-0000-7000-8000-000000000001',
+            'marketplace:ozon:seller',
+            new \DateTimeImmutable('2026-02-01'),
+            new \DateTimeImmutable('2026-02-07'),
+            1,
+            1000,
+        );
+
+        self::assertSame('https://api-seller.ozon.ru/v3/finance/transaction/list', $capturedUrl);
+        $requestPayload = $capturedOptions['json'] ?? json_decode((string) ($capturedOptions['body'] ?? ''), true, 512, \JSON_THROW_ON_ERROR);
+        self::assertSame('all', $requestPayload['filter']['transaction_type']);
+        self::assertSame([['operation_id' => '1']], $page->rows);
+        self::assertTrue($page->hasMore);
+        self::assertSame('2', $page->nextPageToken);
+    }
+
+    public function testFetchRealizationMapsRowsAndHeaderMetadata(): void
+    {
+        $capturedUrl = null;
+        $http = new MockHttpClient(static function (string $method, string $url) use (&$capturedUrl): MockResponse {
+            $capturedUrl = $url;
+
+            return new MockResponse(
+                '{"result":{"rows":[{"operation_id":"real-1"}],"header":{"doc_number":"doc-1"},"header_additional":{"currency_code":"RUB"}}}',
+                ['http_code' => 200],
+            );
+        });
+
+        $adapter = new LegacyOzonClientAdapter($http, $this->credentialProvider(), new NullLogger());
+        $page = $adapter->fetchRealization(
+            '0192f0c2-0000-7000-8000-000000000001',
+            'marketplace:ozon:seller',
+            2026,
+            2,
+        );
+
+        self::assertSame('https://api-seller.ozon.ru/v2/finance/realization', $capturedUrl);
+        self::assertSame([['operation_id' => 'real-1']], $page->rows);
+        self::assertFalse($page->hasMore);
+        self::assertSame(['doc_number' => 'doc-1'], $page->metadata['header']);
+        self::assertSame(['currency_code' => 'RUB'], $page->metadata['headerAdditional']);
+    }
+
+    public function testMissingCredentialsBecomeAuthException(): void
+    {
+        $provider = new class implements OzonCredentialProviderInterface {
+            public function read(string $companyId, string $connectionRef): array
+            {
+                throw new CredentialNotFoundException('missing');
+            }
+        };
+
+        $adapter = new LegacyOzonClientAdapter(new MockHttpClient(), $provider, new NullLogger());
+
+        $this->expectException(ConnectorAuthException::class);
+        $adapter->listClusters('0192f0c2-0000-7000-8000-000000000001', 'marketplace:ozon:seller');
+    }
+
+    public function testUnauthorizedStatusBecomesAuthException(): void
+    {
+        $adapter = new LegacyOzonClientAdapter(
+            new MockHttpClient(new MockResponse('{"error":"forbidden"}', ['http_code' => 403])),
+            $this->credentialProvider(),
+            new NullLogger(),
+        );
+
+        $this->expectException(ConnectorAuthException::class);
+        $adapter->fetchTransactionList(
+            '0192f0c2-0000-7000-8000-000000000001',
+            'marketplace:ozon:seller',
+            new \DateTimeImmutable('2026-02-01'),
+            new \DateTimeImmutable('2026-02-07'),
+            1,
+            1000,
+        );
+    }
+
+    public function testRateLimitStatusBecomesTransientException(): void
+    {
+        $adapter = new LegacyOzonClientAdapter(
+            new MockHttpClient(new MockResponse('{"error":"rate"}', ['http_code' => 429])),
+            $this->credentialProvider(),
+            new NullLogger(),
+        );
+
+        $this->expectException(ConnectorTransientException::class);
+        $adapter->fetchTransactionList(
+            '0192f0c2-0000-7000-8000-000000000001',
+            'marketplace:ozon:seller',
+            new \DateTimeImmutable('2026-02-01'),
+            new \DateTimeImmutable('2026-02-07'),
+            1,
+            1000,
+        );
+    }
+
+    public function testServerErrorBecomesTransientExceptionWithoutLoggingResponseBody(): void
+    {
+        $logger = new class extends AbstractLogger {
+            /**
+             * @var list<array{level: mixed, message: string|\Stringable, context: array<string, mixed>}>
+             */
+            public array $records = [];
+
+            public function log($level, string|\Stringable $message, array $context = []): void
+            {
+                $this->records[] = [
+                    'level' => $level,
+                    'message' => $message,
+                    'context' => $context,
+                ];
+            }
+        };
+        $adapter = new LegacyOzonClientAdapter(
+            new MockHttpClient(new MockResponse('{"secret":"response-body"}', ['http_code' => 500])),
+            $this->credentialProvider(),
+            $logger,
+        );
+
+        try {
+            $adapter->fetchTransactionList(
+                '0192f0c2-0000-7000-8000-000000000001',
+                'marketplace:ozon:seller',
+                new \DateTimeImmutable('2026-02-01'),
+                new \DateTimeImmutable('2026-02-07'),
+                1,
+                1000,
+            );
+            self::fail('Expected transient Ozon exception.');
+        } catch (ConnectorTransientException) {
+        }
+
+        self::assertNotSame([], $logger->records);
+        foreach ($logger->records as $record) {
+            self::assertStringNotContainsString('response-body', json_encode($record, \JSON_THROW_ON_ERROR));
+            self::assertArrayNotHasKey('body', $record['context']);
+            self::assertArrayNotHasKey('response', $record['context']);
+        }
+    }
+
+    public function testTransportFailureBecomesTransientException(): void
+    {
+        $http = new MockHttpClient(static function (): never {
+            throw new TransportException('timeout');
+        });
+        $adapter = new LegacyOzonClientAdapter($http, $this->credentialProvider(), new NullLogger());
+
+        $this->expectException(ConnectorTransientException::class);
+        $adapter->fetchTransactionList(
+            '0192f0c2-0000-7000-8000-000000000001',
+            'marketplace:ozon:seller',
+            new \DateTimeImmutable('2026-02-01'),
+            new \DateTimeImmutable('2026-02-07'),
+            1,
+            1000,
+        );
+    }
+
+    public function testInvalidJsonFailsAsRuntimeException(): void
+    {
+        $adapter = new LegacyOzonClientAdapter(
+            new MockHttpClient(new MockResponse('not-json', ['http_code' => 200])),
+            $this->credentialProvider(),
+            new NullLogger(),
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('invalid JSON');
+        $adapter->fetchTransactionList(
+            '0192f0c2-0000-7000-8000-000000000001',
+            'marketplace:ozon:seller',
+            new \DateTimeImmutable('2026-02-01'),
+            new \DateTimeImmutable('2026-02-07'),
+            1,
+            1000,
+        );
+    }
+
+    private function credentialProvider(): OzonCredentialProviderInterface
+    {
+        return new class implements OzonCredentialProviderInterface {
+            public function read(string $companyId, string $connectionRef): array
+            {
+                return ['api_key' => 'api-key', 'client_id' => 'client-id'];
+            }
+        };
+    }
+}

--- a/site/tests/Unit/Ingestion/Message/RunSyncChunkMessageTest.php
+++ b/site/tests/Unit/Ingestion/Message/RunSyncChunkMessageTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Message;
+
+use App\Ingestion\Message\CompanyAwareMessage;
+use App\Ingestion\Message\RunSyncChunkMessage;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+final class RunSyncChunkMessageTest extends TestCase
+{
+    public function testMessageCarriesCompanyContext(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $jobId = Uuid::uuid7()->toString();
+
+        $message = new RunSyncChunkMessage($companyId, $jobId);
+
+        self::assertInstanceOf(CompanyAwareMessage::class, $message);
+        self::assertSame($companyId, $message->companyId);
+        self::assertSame($companyId, $message->getCompanyId());
+        self::assertSame($jobId, $message->jobId);
+    }
+}

--- a/site/tests/Unit/Shared/Domain/ValueObject/MoneyTest.php
+++ b/site/tests/Unit/Shared/Domain/ValueObject/MoneyTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Domain\ValueObject;
+
+use App\Shared\Domain\Exception\MoneyMismatchException;
+use App\Shared\Domain\ValueObject\Money;
+use PHPUnit\Framework\TestCase;
+
+final class MoneyTest extends TestCase
+{
+    public function testCreatesPositiveMinorAmountAndUppercasesCurrency(): void
+    {
+        $money = Money::fromMinor(12345, 'rub');
+
+        self::assertSame(12345, $money->amountMinor());
+        self::assertSame('RUB', $money->currency());
+        self::assertFalse($money->isZero());
+    }
+
+    public function testCreatesZeroMinorAmount(): void
+    {
+        $money = Money::fromMinor(0, 'RUB');
+
+        self::assertSame(0, $money->amountMinor());
+        self::assertSame('RUB', $money->currency());
+        self::assertTrue($money->isZero());
+    }
+
+    public function testCreatesNegativeMinorAmount(): void
+    {
+        $money = Money::fromMinor(-12345, 'RUB');
+
+        self::assertSame(-12345, $money->amountMinor());
+        self::assertSame('RUB', $money->currency());
+        self::assertFalse($money->isZero());
+    }
+
+    public function testRejectsInvalidCurrency(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Money::fromMinor(100, 'RU');
+    }
+
+    public function testAddsSameCurrency(): void
+    {
+        $money = Money::fromMinor(1000, 'RUB');
+
+        self::assertSame(1250, $money->add(Money::fromMinor(250, 'RUB'))->amountMinor());
+    }
+
+    public function testSubtractsSameCurrencyWithPositiveResult(): void
+    {
+        $money = Money::fromMinor(1000, 'RUB');
+
+        self::assertSame(750, $money->subtract(Money::fromMinor(250, 'RUB'))->amountMinor());
+    }
+
+    public function testSubtractsSameCurrencyWithNegativeResult(): void
+    {
+        $money = Money::fromMinor(250, 'RUB');
+
+        self::assertSame(-750, $money->subtract(Money::fromMinor(1000, 'RUB'))->amountMinor());
+    }
+
+    public function testNegatesAmount(): void
+    {
+        self::assertSame(-1000, Money::fromMinor(1000, 'RUB')->negate()->amountMinor());
+        self::assertSame(1000, Money::fromMinor(-1000, 'RUB')->negate()->amountMinor());
+        self::assertSame(0, Money::fromMinor(0, 'RUB')->negate()->amountMinor());
+    }
+
+    public function testComparesSameCurrency(): void
+    {
+        self::assertSame(1, Money::fromMinor(1000, 'RUB')->compareTo(Money::fromMinor(999, 'RUB')));
+        self::assertSame(0, Money::fromMinor(1000, 'RUB')->compareTo(Money::fromMinor(1000, 'RUB')));
+        self::assertSame(-1, Money::fromMinor(999, 'RUB')->compareTo(Money::fromMinor(1000, 'RUB')));
+    }
+
+    public function testRejectsAddCurrencyMismatch(): void
+    {
+        $this->expectException(MoneyMismatchException::class);
+
+        Money::fromMinor(1000, 'RUB')->add(Money::fromMinor(100, 'USD'));
+    }
+
+    public function testRejectsSubtractCurrencyMismatch(): void
+    {
+        $this->expectException(MoneyMismatchException::class);
+
+        Money::fromMinor(1000, 'RUB')->subtract(Money::fromMinor(100, 'USD'));
+    }
+
+    public function testRejectsCompareCurrencyMismatch(): void
+    {
+        $this->expectException(MoneyMismatchException::class);
+
+        Money::fromMinor(1000, 'RUB')->compareTo(Money::fromMinor(100, 'USD'));
+    }
+}


### PR DESCRIPTION
## Summary

Implements the Ingestion migration package for blocks 4-7:

- Block 4: `IngestCursor`, `SyncJob`, orchestration actions, `SyncFacade`, fetch messages/handlers, rate guard, Messenger routing.
- Block 5: canonical Ingestion finance model, shared signed `Money`, normalization pipeline, connector/mapper contracts, `IngestionFacade`.
- Block 6: Ozon seller report connector over the legacy API adapter, mappers, fixtures, mapping docs.
- Block 7: P&L dirty-period/rebuild infrastructure, `PLDirtyPeriod` owned by Ingestion, Finance rebuild orchestration, `pnl_rebuild` routing.

This PR includes the source files and migrations that were missing from the first reviewed patch:

- `site/src/Ingestion/Facade/SyncFacade.php` and the other registered service classes.
- `site/migrations/Version20260618140000.php`, which adds `pnl_dirty_periods` and `rebuilt_at` columns for P&L aggregates.

## Review Fixes Included

- `2da301ae` — fixed pending `FinancialTransaction` upsert lookup by caching unflushed entities in `FinancialTransactionRepository`.
- `e190685c` — closed all 5 ingestion orchestration review comments:
  - rate-limit lock contention is retryable via `ConnectorTransientException`, not terminal `FAILED`;
  - windowed backfill chunks ignore shared resource cursors;
  - windowed chunks do not advance shared cursors;
  - `RunSyncChunkHandler` continues pulls while `hasMore=true`;
  - `BLOCKED_BY_CLOSE` P&L dirty periods reopen on mark-dirty;
  - exhausted Messenger retries are finalized by `SyncJobFailureSubscriber`.

Out of scope and intentionally not included:

- `docs/tasks/s3/*`
- `.mimocode/`
- the local AGENTS commit that remains on local `master`
- blocks 8 and 9

## Checks Run

Local checks:

- `make site-test-unit` — OK, 1070 tests / 6438 assertions; existing 1 warning and 1 deprecation remain.
- `tests/Integration/Ingestion` — OK, 45 tests / 214 assertions.
- Focused Finance P&L tests — OK, 4 tests / 18 assertions.
- `docker compose run --rm site-php-cli php bin/console lint:container --env=test` — OK.
- `docker compose run --rm site-php-cli php bin/console doctrine:schema:validate --skip-sync --env=test` — OK.
- Scoped `php-cs-fixer --dry-run` — OK.
- `git diff --check` / `git diff --cached --check` — OK.

GitHub Actions:

- Latest workflow run `27760017845` for `e190685c` — success.
- Jobs success: unit tests, API types sync, migrations-empty-db, all build-and-push jobs.
- Jobs skipped as expected on draft/non-deploy context: deploy, migrations.

## Reviewer Focus

- Migrations before deploy, especially `Version20260618140000`.
- Messenger routing/transports: `ingest_fetch`, `ingest_normalize`, `pnl_rebuild`.
- Ingestion retry/finalization behavior around `RunSyncChunkMessage` and `SyncJobFailureSubscriber`.
- P&L rebuild semantics: delete-and-rebuild company/month aggregates for all-source scope.
- Ozon mapper output against representative production reports before shadow mode.
- Follow-up source/origin linking decision documented in `docs/tasks/ingestion/FOLLOWUP-finance-source-linking.md`.