### PR TITLE
[codex] Add ingestion verification API

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -131,6 +131,19 @@
 - `NormalizeRawRecordAction` reads NDJSON raw payload, calls the mapper, upserts canonical transactions, records `NormalizationIssue` on mapper/control-sum problems, marks the raw record `DONE`/`FAILED`, and dispatches `NormalizationCompletedEvent` after successful flush.
 - `NormalizationCompletedEvent` carries affected periods for future P&L dirty-period marking. Stage 4 only publishes the event; subscribers for P&L rebuild are added later.
 
+### Ingestion: verification client API
+
+- Client verification API lives under `/api/ingestion/verification/*` and is exposed through `App\Ingestion\Facade\IngestionFacade`.
+- Endpoints:
+  - `GET /api/ingestion/verification/coverage` — raw/canonical/open-issue coverage heatmap plus shop options.
+  - `GET /api/ingestion/verification/reconciliation` — canonical transaction totals by shop vs latest legacy `OzonTransactionTotalsCheck` company-period control total.
+  - `GET /api/ingestion/verification/issues` — unresolved normalization issues with human-readable descriptions only.
+  - `GET /api/ingestion/verification/financial-summary` — rebuilt P&L monthly/category summary from `pl_monthly_snapshots`.
+- All controllers resolve `companyId` from `ActiveCompanyService`; DBAL read queries also include explicit `company_id` predicates and do not rely only on Doctrine filters.
+- API period validation errors use `IngestionExceptionListener` and return `{ "error": { "code": "...", "message": "..." } }` with HTTP 422.
+- Reconciliation reads `OzonTransactionTotalsCheck::getOzonTotals()["total_minor"]`; missing or invalid legacy totals are returned as `null`.
+- `pl_monthly_snapshots` has no shop dimension, so financial summary currently accepts `shop_ref` for API compatibility but returns company-level rebuilt P&L until Finance source/shop linking exists.
+
 ### Finance: P&L dirty-period projection infrastructure
 
 - `PLDirtyPeriod` is the Ingestion-side pipeline marker for month-level P&L projection rebuilds from canonical Ingestion transactions. It uses scalar `companyId`, `periodYear`, `periodMonth`, `shopRef`, `status`, `reason`, attempts, and audit timestamps.

--- a/docs/tasks/ingestion/fix/TASK-UI-CLIENT-BACKEND.md
+++ b/docs/tasks/ingestion/fix/TASK-UI-CLIENT-BACKEND.md
@@ -1,0 +1,470 @@
+# TASK-UI-CLIENT-BACKEND — Клиентский UI Ingestion (Backend часть)
+
+## 0. Сводка
+
+- **Бизнес-цель.** Подготовить REST API для 4 экранов клиентского UI Ingestion: Покрытие, Сверка, Проблемы, Финансовая сводка. Backend полностью самодостаточен — frontend разрабатывается отдельной задачей, опираясь на готовые эндпоинты и `schema.d.ts`.
+- **Модуль.** `App\Ingestion` (существующий).
+- **Тип.** feature (backend).
+- **Ветка.** `feature/ingestion-ui-client-backend`.
+- **Подзадачи.** B1 4 Query · B2 DTO + Facade · B3 4 Controller · B4 OpenAPI · B5 ExceptionListener · B6 Tenant-leak тесты · B7 schema.d.ts.
+- **Затрагивает другие модули.** Читает через Facade: `IngestionFacade` (блок 5), `PnlFacade` (блок 7). Читает legacy `OzonTransactionTotalsCheck` через `OzonTransactionTotalsCheckRepository`.
+- **Требует миграции БД.** Нет.
+- **Меняет публичный API.** Да (4 новых эндпоинта).
+
+---
+
+## 1. Контекст и границы
+
+### 1.1 Текущее состояние
+
+- Канон `FinancialTransaction` наполняется (блоки 5-6).
+- P&L через `rebuildPeriod`, `PLDailyTotal`/`PLMonthlySnapshot` имеют `rebuiltAt` (блок 7).
+- Существует legacy `OzonTransactionTotalsCheck` — контрольная сумма от Ozon.
+- `IngestionFacade` и `PnlFacade` существуют.
+- `make api-types` экспортирует OpenAPI в `schema.d.ts` для frontend.
+
+### 1.2 Желаемое состояние
+
+- 4 REST-эндпоинта под `/api/ingestion/verification/*` с OpenAPI.
+- `schema.d.ts` обновлён и закоммичен.
+- Все эндпоинты под изоляцией `CompanyFilter`, принимают `companyId` из `ActiveCompanyService`.
+- Единый формат ошибок через `IngestionExceptionListener`.
+- Multi-shop поддерживается на уровне API (фильтр `shop_ref`).
+- Reconciliation использует существующий `OzonTransactionTotalsCheck` (без независимого пересчёта).
+
+### 1.3 In scope
+
+- 4 Query (DBAL): coverage, reconciliation, issues, financial-summary.
+- 4 Controller (`__invoke`).
+- DTO View для каждого ответа.
+- OpenAPI-аннотации.
+- `IssueDescriptionFormatter` для человекочитаемых описаний.
+- Расширение `IngestionFacade` 4 методами.
+- `IngestionExceptionListener`.
+- Functional-тесты на каждый эндпоинт (включая tenant-leak).
+
+### 1.4 Out of scope
+
+- Frontend (React, Twig, entry-scripts, PageController) — отдельная задача `TASK-UI-CLIENT-FRONTEND`.
+- Экспорт XLSX — отложен.
+- Независимый пересчёт reconciliation из raw — отдельная задача.
+- Admin-функции — отдельная задача.
+- Грязные периоды P&L клиенту — только admin.
+- Управление подключениями — раздел «Интеграции», отдельная задача.
+
+### 1.5 Допущения
+
+- Допущение: контрольная сумма Ozon берётся из `OzonTransactionTotalsCheck` (заполняется legacy-пайплайном). Если для периода нет записи — `ozon_control_total_minor = null`.
+- Допущение: список shop'ов — `IngestRawRecord.shopRef DISTINCT` за последние 90 дней.
+- Допущение: пагинация Issues — Pagerfanta, max 200 на страницу.
+
+---
+
+## 2. Доменная модель
+
+### 2.1 Сущности
+
+Новых нет.
+
+### 2.2 Связи
+
+N/A.
+
+### 2.3 Enum
+
+Новых нет.
+
+### 2.4 Матрица переходов
+
+N/A.
+
+---
+
+## 3. Слой доступа к данным
+
+### 3.1 Repository
+
+Без новых методов (используются существующие).
+
+### 3.2 Query
+
+Все — `final class`, DBAL. **SELECT * запрещён**. **companyId обязателен**.
+
+#### `App\Ingestion\Infrastructure\Query\CoverageQuery`
+
+Файл: `src/Ingestion/Infrastructure/Query/CoverageQuery.php`.
+
+| Метод | Что делает | companyId | Возврат |
+|---|---|---|---|
+| `heatmap(string $companyId, ?string $shopRef, DateTimeImmutable $from, DateTimeImmutable $to): list<CoverageCellView>` | Группировка по `(date, shop_ref, resource_type)`: rawCount, txCount, issueCount, lastFetchedAt. Источники: `ingest_raw_records`, `ingest_financial_transactions`, `ingest_normalization_issues`. | да | `list<CoverageCellView>` |
+| `shops(string $companyId): list<ShopOptionView>` | Список уникальных shopRef за последние 90 дней. | да | `list<ShopOptionView>` |
+
+#### `App\Ingestion\Infrastructure\Query\ReconciliationQuery`
+
+Файл: `src/Ingestion/Infrastructure/Query/ReconciliationQuery.php`.
+
+| Метод | Что делает | companyId | Возврат |
+|---|---|---|---|
+| `summary(string $companyId, string $shopRef, int $year, int $month): ReconciliationSummaryView` | Канон vs `OzonTransactionTotalsCheck`. Null если контрольной суммы нет. | да | `ReconciliationSummaryView` |
+| `breakdownByType(string $companyId, string $shopRef, int $year, int $month): list<ReconciliationByTypeView>` | По TransactionType: сумма канона, кол-во транзакций. | да | `list<ReconciliationByTypeView>` |
+
+#### `App\Ingestion\Infrastructure\Query\IssuesQuery`
+
+Файл: `src/Ingestion/Infrastructure/Query/IssuesQuery.php`.
+
+| Метод | Что делает | companyId | Возврат |
+|---|---|---|---|
+| `build(string $companyId, ?string $shopRef, ?int $year, ?int $month): QueryBuilder` | DBAL QueryBuilder для Pagerfanta. Только открытые. | да | `QueryBuilder` |
+| `count(string $companyId, ?string $shopRef, ?int $year, ?int $month): int` | Счётчик. | да | `int` |
+
+Колонки QueryBuilder: `id, raw_record_id, operation_group_id, kind, details, created_at`.
+
+#### `App\Ingestion\Infrastructure\Query\FinancialSummaryQuery`
+
+Файл: `src/Ingestion/Infrastructure/Query/FinancialSummaryQuery.php`.
+
+| Метод | Что делает | companyId | Возврат |
+|---|---|---|---|
+| `byMonth(string $companyId, ?string $shopRef, int $yearFrom, int $monthFrom, int $yearTo, int $monthTo): list<FinancialSummaryMonthView>` | Из `pl_monthly_snapshots` где `rebuilt_at IS NOT NULL`. | да | `list<FinancialSummaryMonthView>` |
+| `byCategory(string $companyId, ?string $shopRef, int $year, int $month): list<FinancialSummaryCategoryView>` | По PLCategory за месяц. | да | `list<FinancialSummaryCategoryView>` |
+
+### 3.3 Индексы
+
+Новых не требуется.
+
+---
+
+## 4. Слой приложения
+
+### 4.1 Action
+
+В этом блоке Action не вводятся.
+
+### 4.2 Domain Service
+
+#### `App\Ingestion\Application\Service\IssueDescriptionFormatter`
+
+Файл: `src/Ingestion/Application/Service/IssueDescriptionFormatter.php`. `final class`. Чистая функция.
+
+Методы:
+- `humanize(NormalizationIssueKind $kind, array $details): string` — человекочитаемое описание на русском без технических деталей.
+
+Маппинг:
+- `SUM_MISMATCH` → «Сумма операций не сходится с контрольной суммой источника»
+- `MAPPER_FAILURE` → «Не удалось распознать операцию»
+- `UNKNOWN_FIELD` → «В отчёте появилось неизвестное поле»
+- `CURRENCY_MISMATCH` → «В операции смешаны разные валюты»
+
+### 4.3 DTO
+
+Все View — `App\Ingestion\Application\DTO\*`, `final readonly class`.
+
+#### `CoverageCellView`
+
+| Поле | Тип | Описание |
+|---|---|---|
+| `date` | string | ISO 8601 (YYYY-MM-DD) |
+| `shopRef` | string | |
+| `resourceType` | string | ozon_seller_daily_report / ozon_seller_realization |
+| `rawCount` | int | |
+| `txCount` | int | |
+| `issueCount` | int | |
+| `lastFetchedAt` | ?string | ISO 8601 |
+
+#### `ShopOptionView`
+
+| Поле | Тип |
+|---|---|
+| `shopRef` | string |
+| `label` | string |
+
+#### `ReconciliationSummaryView`
+
+| Поле | Тип | Описание |
+|---|---|---|
+| `period` | string | YYYY-MM |
+| `canonTotalMinor` | int | минорные единицы |
+| `ozonControlTotalMinor` | ?int | null если нет данных |
+| `currency` | string | ISO 4217 |
+| `canonVsOzonDeltaMinor` | ?int | null если нет контрольной |
+| `thresholdMinor` | int | 100 копеек по умолчанию |
+| `recomputedAt` | string | ISO 8601 |
+
+#### `ReconciliationByTypeView`
+
+| Поле | Тип | Описание |
+|---|---|---|
+| `type` | string | enum value |
+| `typeLabel` | string | русская метка |
+| `canonAmountMinor` | int | |
+| `txCount` | int | |
+
+#### `IssueListItemView`
+
+| Поле | Тип | Описание |
+|---|---|---|
+| `id` | string | UUID |
+| `kind` | string | enum value |
+| `humanDescription` | string | через formatter |
+| `createdAt` | string | ISO 8601 |
+
+#### `FinancialSummaryMonthView`
+
+| Поле | Тип |
+|---|---|
+| `year` | int |
+| `month` | int |
+| `incomeMinor` | int |
+| `expenseMinor` | int |
+| `netMinor` | int |
+| `currency` | string |
+
+#### `FinancialSummaryCategoryView`
+
+| Поле | Тип |
+|---|---|
+| `categoryId` | string |
+| `categoryName` | string |
+| `flow` | string |
+| `amountMinor` | int |
+
+#### `PaginationMeta`
+
+| Поле | Тип |
+|---|---|
+| `page` | int |
+| `limit` | int |
+| `total` | int |
+| `totalPages` | int |
+
+### 4.4 Facade
+
+#### `App\Ingestion\Facade\IngestionFacade` (расширение)
+
+Добавить методы:
+- `getCoverage(string $companyId, ?string $shopRef, DateTimeImmutable $from, DateTimeImmutable $to): array{cells: list<CoverageCellView>, shops: list<ShopOptionView>}`.
+- `getReconciliation(string $companyId, string $shopRef, int $year, int $month): array{summary: ReconciliationSummaryView, byType: list<ReconciliationByTypeView>}`.
+- `listIssues(string $companyId, ?string $shopRef, ?int $year, ?int $month, int $page, int $limit): array{items: list<IssueListItemView>, meta: PaginationMeta}`.
+- `getFinancialSummary(string $companyId, ?string $shopRef, int $yearFrom, int $monthFrom, int $yearTo, int $monthTo): array{byMonth: list<FinancialSummaryMonthView>, byCategory: list<FinancialSummaryCategoryView>}`.
+
+---
+
+## 5. Асинхронность (Messenger)
+
+N/A.
+
+---
+
+## 6. Обработка ошибок
+
+| Класс | Когда | HTTP-статус | error.code | error.message |
+|---|---|---|---|---|
+| `InvalidPeriodRangeException` | from > to или yearFrom/monthFrom > yearTo/monthTo | 422 | `invalid_period_range` | «Некорректный диапазон периода» |
+| `InvalidPeriodException` | year < 2020 или > 2100, month < 1 или > 12 | 422 | `invalid_period` | «Некорректный период» |
+
+Namespace: `App\Ingestion\Exception\*`, `final class`.
+
+#### `App\Ingestion\Infrastructure\Http\IngestionExceptionListener`
+
+Файл: `src/Ingestion/Infrastructure/Http/IngestionExceptionListener.php`. `final class`. Подписан на `kernel.exception` с приоритетом 0. Срабатывает только для запросов `/api/ingestion/*`.
+
+Формат ответа:
+```json
+{ "error": { "code": "invalid_period_range", "message": "Некорректный диапазон периода" } }
+```
+
+---
+
+## 7. HTTP API (Controller)
+
+Все: `final class`, `__invoke`, namespace `App\Ingestion\Controller\Api\Verification\`.
+
+Авторизация: зарегистрированный пользователь, активная компания через `ActiveCompanyService`. `companyId` берётся из неё, не из path.
+
+### 7.1 `GET /api/ingestion/verification/coverage`
+
+Controller: `GetCoverageController`.
+
+Query params:
+- `shop_ref` (optional, string)
+- `from` (required, date YYYY-MM-DD)
+- `to` (required, date YYYY-MM-DD)
+
+Response 200:
+```json
+{
+  "cells": [
+    {
+      "date": "2026-06-01",
+      "shop_ref": "ozon-shop-123",
+      "resource_type": "ozon_seller_daily_report",
+      "raw_count": 1,
+      "tx_count": 287,
+      "issue_count": 0,
+      "last_fetched_at": "2026-06-02T03:14:00Z"
+    }
+  ],
+  "shops": [
+    {"shop_ref": "ozon-shop-123", "label": "Ozon магазин 123"}
+  ]
+}
+```
+
+Ошибки: 422 (`invalid_period_range`).
+
+OpenAPI: `#[OA\Tag('Ingestion verification')]`.
+
+### 7.2 `GET /api/ingestion/verification/reconciliation`
+
+Controller: `GetReconciliationController`.
+
+Query params:
+- `shop_ref` (required, string)
+- `year` (required, int)
+- `month` (required, int 1..12)
+
+Response 200:
+```json
+{
+  "summary": {
+    "period": "2026-05",
+    "canon_total_minor": 1234567800,
+    "ozon_control_total_minor": 1234566800,
+    "currency": "RUB",
+    "canon_vs_ozon_delta_minor": 1000,
+    "threshold_minor": 100,
+    "recomputed_at": "2026-06-15T10:00:00Z"
+  },
+  "by_type": [
+    {"type": "sale", "type_label": "Продажа", "canon_amount_minor": 1500000000, "tx_count": 240}
+  ]
+}
+```
+
+Ошибки: 422 (`invalid_period`).
+
+### 7.3 `GET /api/ingestion/verification/issues`
+
+Controller: `GetIssuesController`. Пагинация `?page=1&limit=50`, max 200.
+
+Query params:
+- `shop_ref` (optional)
+- `year` (optional)
+- `month` (optional)
+- `page` (optional, default 1)
+- `limit` (optional, default 50, max 200)
+
+Response 200:
+```json
+{
+  "items": [
+    {
+      "id": "...",
+      "kind": "sum_mismatch",
+      "human_description": "Сумма операций не сходится с контрольной суммой источника",
+      "created_at": "2026-06-15T10:00:00Z"
+    }
+  ],
+  "meta": {"page": 1, "limit": 50, "total": 0, "total_pages": 0}
+}
+```
+
+### 7.4 `GET /api/ingestion/verification/financial-summary`
+
+Controller: `GetFinancialSummaryController`.
+
+Query params:
+- `shop_ref` (optional)
+- `year_from` (required)
+- `month_from` (required, 1..12)
+- `year_to` (required)
+- `month_to` (required, 1..12)
+
+Response 200:
+```json
+{
+  "by_month": [
+    {"year": 2026, "month": 5, "income_minor": 1500000000, "expense_minor": 800000000, "net_minor": 700000000, "currency": "RUB"}
+  ],
+  "by_category": [
+    {"category_id": "...", "category_name": "Продажи", "flow": "income", "amount_minor": 1500000000}
+  ]
+}
+```
+
+Параметр `month` для `by_category` — последний месяц диапазона.
+
+Ошибки: 422 (`invalid_period_range`).
+
+---
+
+## 8. Разбивка на подзадачи
+
+| Этап | Что входит | Зависит от | Риск | Тесты |
+|---|---|---|---|---|
+| B1 | 4 Query + View DTO + `PaginationMeta` | блоки 5, 7 | 🟡 | integration на каждую Query + tenant-leak |
+| B2 | `IssueDescriptionFormatter` + методы Facade | B1 | 🟢 | unit на каждый kind |
+| B3 | 4 Controller + OpenAPI-аннотации | B1, B2 | 🟡 | functional на каждый эндпоинт |
+| B4 | `IngestionExceptionListener` | B3 | 🟢 | unit на формат ответа |
+| B5 | `make api-types` → `schema.d.ts` обновлён и закоммичен | B3 | 🟢 | `api-types-check` зелёный |
+| B6 | Tenant-leak functional тесты на каждый эндпоинт | B3 | 🔴 | компания A не видит данные B |
+| B7 | `ARCHITECTURE.md` + раздел про новые эндпоинты | все | 🟢 | — |
+
+---
+
+## 9. Ограничения и запреты
+
+- Не добавлять новые поля в Entity.
+- Не зависеть от Marketplace модуля напрямую — `OzonTransactionTotalsCheckRepository` инжектируется явно.
+- Не считать reconciliation от raw (отдельная задача).
+- Не возвращать клиенту технические поля (`operationGroupId`, `raw_record_id`, `details JSONB`) — только человекочитаемое.
+- Performance: `getCoverage` и `getReconciliation` — индексирующие запросы; `getFinancialSummary` за > 12 месяцев — пагинированный кейс (вне MVP).
+- Безопасность: каждый эндпоинт через `ActiveCompanyService`, `CompanyFilter` включён.
+- Логирование: каждое обращение к эндпоинту логируется с companyId и временем.
+
+---
+
+## 10. Критерии приёмки
+
+Функциональные:
+- [ ] `GET /coverage` возвращает хитмап и список shop'ов за период.
+- [ ] `GET /reconciliation` отдаёт канон vs Ozon control, null если контрольной суммы нет.
+- [ ] `GET /issues` отдаёт открытые проблемы с человекочитаемым описанием.
+- [ ] `GET /financial-summary` отдаёт P&L по месяцам и категориям из нового канона.
+- [ ] Технические детали (UUID, JSONB) не попадают в ответы API.
+- [ ] Multi-shop: фильтр `shop_ref` работает, отсутствие = все магазины.
+- [ ] Все 422 ошибки в формате `{"error": {"code": ..., "message": ...}}`.
+
+Технические:
+- [ ] `make site-cs-check` + PHPStan зелёные.
+- [ ] `make api-types-check` зелёный.
+- [ ] `schema.d.ts` закоммичен.
+- [ ] `make site-test-unit` + `make site-test-integration` зелёные.
+- [ ] Tenant-leak functional тест на каждый из 4 эндпоинтов.
+- [ ] `make api-doc-lint` зелёный.
+- [ ] `ARCHITECTURE.md` обновлён.
+
+---
+
+## 11. План отката
+
+- Удалить routes `/api/ingestion/verification/*` из `config/routes.yaml`.
+- DROP не требуется (миграций нет).
+- Frontend (отдельная задача) либо ещё не разработан — нечего ломать; либо разработан и обнаружит отсутствие эндпоинтов.
+
+---
+
+## 12. Чек-лист качества ТЗ
+
+- [x] Полный namespace и путь для каждого Controller/Query/Service.
+- [x] HTTP-контракт каждого эндпоинта (метод, путь, params, response JSON).
+- [x] Все Query принимают `companyId`.
+- [x] OpenAPI Tag указан.
+- [x] Пагинация фиксирована для issues.
+- [x] Human-readable issue descriptions через сервис, не технические поля.
+- [x] Out of scope зафиксирован (XLSX, reconciliation от raw, admin, dirty periods, frontend).
+- [x] План отката без потери данных.
+- [x] Tenant-leak обязателен в DoD.
+- [x] Запрет на технические поля в ответах API.
+- [x] schema.d.ts обновляется и коммитится.
+- [x] Frontend явно out of scope.

--- a/docs/tasks/ingestion/fix/TASK-UI-CLIENT-FRONTEND.md
+++ b/docs/tasks/ingestion/fix/TASK-UI-CLIENT-FRONTEND.md
@@ -1,0 +1,423 @@
+# TASK-UI-CLIENT-FRONTEND — Клиентский UI Ingestion (Frontend часть)
+
+## 0. Сводка
+
+- **Бизнес-цель.** Реализовать 4 React-экрана для клиентского UI Ingestion (Покрытие, Сверка, Проблемы, Финансовая сводка) поверх готового backend API. Дать клиенту визуальный контроль качества новой загрузки Ozon.
+- **Модуль.** Frontend в `assets/react/features/ingestion-verification/` + entrypoints в `assets/react/entrypoints/` + Twig-страницы в `templates/ingestion/verification/`.
+- **Тип.** feature (frontend).
+- **Ветка.** `feature/ingestion-ui-client-frontend`.
+- **Подзадачи.** B1 Shared-компоненты · B2 4 widget feature-slice · B3 4 entry-script + регистрация в Vite · B4 4 Twig-страницы · B5 PageController · B6 Multi-shop с localStorage · B7 Маршруты · B8 E2E проверка.
+- **Зависимость:** требуется завершённая задача `TASK-UI-CLIENT-BACKEND` со зелёным `schema.d.ts`.
+- **Требует миграции БД.** Нет.
+- **Меняет публичный API.** Нет.
+
+---
+
+## 1. Контекст и границы
+
+### 1.1 Текущее состояние
+
+- Backend готов: 4 эндпоинта под `/api/ingestion/verification/*`, OpenAPI, `schema.d.ts` закоммичен.
+- В проекте существует `CLAUDE.frontend.md` с архитектурой feature-slice (Widget/View/hook/types).
+- Используется React + TanStack Query + Vite.
+- Существует страница P&L legacy — не трогаем.
+
+### 1.2 Желаемое состояние
+
+- 4 React-экрана как островки внутри Twig-страниц.
+- Типы из `schema.d.ts` (strict TS, без сырого fetch).
+- Multi-shop фильтр на каждом экране, сохранение выбора в localStorage.
+- Loading / empty / error состояния на каждом widget.
+- 4 новых Twig-маршрута под `/ingestion/verification/*`.
+- Существующая страница P&L legacy не затрагивается.
+
+### 1.3 In scope
+
+- React feature-slice: 4 widget (Widget/View/hook/types).
+- Shared-компоненты: shop-selector, period-picker, money-cell, delta-cell, status-badge, empty-state, loading-state.
+- 4 entry-script в `assets/react/entrypoints/`.
+- Явная регистрация 4 entry-script в `site/vite.config.js` (`build.rollupOptions.input`), чтобы `entrypoints.json` содержал ключи для Twig.
+- 4 Twig-страницы.
+- 4 PageController (`__invoke`, рендер Twig).
+- Маршруты Twig в `config/routes.yaml`.
+- Multi-shop UX с localStorage (`ingestion.selected_shop`).
+- Обработка ошибок: показ `error.message` из ответа API + кнопка «Повторить».
+
+### 1.4 Out of scope
+
+- Backend (контроллеры, Query, эндпоинты) — задача `TASK-UI-CLIENT-BACKEND`.
+- Экспорт XLSX.
+- Admin раздел.
+- Изменение существующей P&L страницы.
+- Графики/чарты — только таблицы и хитмап.
+
+### 1.5 Допущения
+
+- Допущение: `schema.d.ts` корректно отражает API. При несоответствии — фиксится backend.
+- Допущение: TanStack Query уже настроен в проекте (QueryClient, провайдер).
+- Не допущение: новые entry-script'ы нужно явно добавить в `site/vite.config.js` → `build.rollupOptions.input`; проект не подхватывает `assets/react/entrypoints/` автоматически.
+
+---
+
+## 2. Доменная модель
+
+N/A — frontend не имеет своих Entity. Типы данных импортируются из `schema.d.ts`.
+
+---
+
+## 3. Слой доступа к данным
+
+### 3.1 API hooks
+
+Все hooks — `assets/react/features/ingestion-verification/api/`.
+
+#### `ingestion-verification.api.ts`
+
+TanStack Query hooks, типы из `schema.d.ts`.
+
+| Hook | Endpoint | Возврат |
+|---|---|---|
+| `useCoverageData(params)` | `GET /api/ingestion/verification/coverage` | `{cells, shops}` |
+| `useReconciliationData(params)` | `GET /api/ingestion/verification/reconciliation` | `{summary, by_type}` |
+| `useIssuesData(params)` | `GET /api/ingestion/verification/issues` | `{items, meta}` |
+| `useFinancialSummaryData(params)` | `GET /api/ingestion/verification/financial-summary` | `{by_month, by_category}` |
+
+Все hooks:
+- Используют `staleTime: 30000` (30 сек).
+- При ошибке возвращают `error` с `message` из `error.message` ответа API.
+- Запрос автоматически отключается, если обязательные параметры не заданы (`enabled: !!period`).
+
+### 3.2 Query params
+
+N/A.
+
+### 3.3 Индексы
+
+N/A.
+
+---
+
+## 4. Слой приложения (компоненты)
+
+### 4.1 Shared-компоненты
+
+Папка: `assets/react/features/ingestion-verification/components/shared/`.
+
+#### `ShopSelector`
+
+`shop-selector.tsx`. Селектор магазина.
+
+Props:
+- `shops: ShopOption[]` — список магазинов из API.
+- `value: string | null` — текущий shopRef (null = все магазины).
+- `onChange: (shopRef: string | null) => void`.
+
+Поведение:
+- Загружает выбор из `localStorage.getItem('ingestion.selected_shop')` при монтировании.
+- Сохраняет в localStorage при изменении.
+- Опция «Все магазины» (value = null).
+
+#### `PeriodPicker`
+
+`period-picker.tsx`. Выбор периода.
+
+Props:
+- `mode: 'month' | 'range'` — один месяц или диапазон.
+- `value: {year: number, month: number} | {yearFrom, monthFrom, yearTo, monthTo}`.
+- `onChange: (value) => void`.
+
+#### `MoneyCell`
+
+`money-cell.tsx`. Форматирование минорных единиц.
+
+Props:
+- `amountMinor: number`.
+- `currency: string`.
+
+Возврат: «1 234,56 ₽» (форматирование через `Intl.NumberFormat`).
+
+#### `DeltaCell`
+
+`delta-cell.tsx`. Подсветка разницы.
+
+Props:
+- `deltaMinor: number | null`.
+- `thresholdMinor: number`.
+- `currency: string`.
+
+Поведение:
+- Если `delta === null` → «—» серым.
+- Если `|delta| <= threshold` → зелёный.
+- Если `|delta| > threshold` → красный.
+
+#### `StatusBadge`
+
+`status-badge.tsx`. Бейдж статуса.
+
+Props:
+- `status: 'success' | 'warning' | 'error' | 'pending'`.
+- `label: string`.
+
+#### `EmptyState`
+
+`empty-state.tsx`. Пустое состояние.
+
+Props:
+- `message: string` (по умолчанию «Данных нет за выбранный период»).
+
+#### `LoadingState`
+
+`loading-state.tsx`. Состояние загрузки.
+
+Props:
+- `message?: string`.
+
+Скелетон или спиннер.
+
+#### `ErrorState`
+
+`error-state.tsx`. Состояние ошибки.
+
+Props:
+- `error: {code: string, message: string}`.
+- `onRetry: () => void`.
+
+Показывает `error.message`, кнопка «Повторить» зовёт `onRetry`.
+
+### 4.2 Widget'ы
+
+Структура каждого widget по `CLAUDE.frontend.md`:
+- `*.widget.tsx` — data-aware: использует hook, передаёт данные в View.
+- `*.view.tsx` — dumb: только props, без data fetching.
+- `use-*.ts` — TanStack Query hook.
+- `types.ts` — типы из `schema.d.ts`.
+
+#### `coverage-heatmap`
+
+Папка: `widgets/coverage-heatmap/`.
+
+`coverage-heatmap.widget.tsx`:
+- Хранит state: `from`, `to`, `shopRef`.
+- Зовёт `useCoverageData({from, to, shopRef})`.
+- Передаёт данные в `CoverageHeatmapView`.
+- Обрабатывает loading/empty/error.
+
+`coverage-heatmap.view.tsx`:
+- Props: `cells`, `shops`, `selectedShop`, `from`, `to`, `onShopChange`, `onPeriodChange`.
+- Рендерит:
+  - `ShopSelector` сверху.
+  - `PeriodPicker` (mode='range').
+  - Хитмап: ось X — даты, ось Y — resourceType. Ячейка: зелёная если `rawCount > 0 && issueCount === 0`, жёлтая если `issueCount > 0`, серая если нет данных.
+  - При клике на ячейку — tooltip с `rawCount`, `txCount`, `issueCount`, `lastFetchedAt`.
+  - Счётчики вверху: «X дней покрыто», «Y проблем».
+
+#### `reconciliation-summary`
+
+Папка: `widgets/reconciliation-summary/`.
+
+`reconciliation-summary.widget.tsx`:
+- State: `shopRef` (обязательный), `year`, `month`.
+- Зовёт `useReconciliationData({shopRef, year, month})`.
+
+`reconciliation-summary.view.tsx`:
+- Props: `summary`, `by_type`, `selectedShop`, `year`, `month`, `onShopChange`, `onPeriodChange`.
+- Рендерит:
+  - `ShopSelector` (обязательный, без «Все»).
+  - `PeriodPicker` (mode='month').
+  - Главная карточка: «Сходится» / «Расхождение на X руб» — на основе `canon_vs_ozon_delta_minor` и `threshold_minor` через `DeltaCell`.
+  - Таблица по типам: TransactionType label, `canon_amount_minor` через `MoneyCell`, `tx_count`.
+  - Если `ozon_control_total_minor === null` — баннер «Контрольная сумма Ozon недоступна для этого периода».
+  - Дата `recomputed_at`.
+
+#### `issues-list`
+
+Папка: `widgets/issues-list/`.
+
+`issues-list.widget.tsx`:
+- State: `shopRef`, `year`, `month`, `page`, `limit=50`.
+- Зовёт `useIssuesData(params)`.
+
+`issues-list.view.tsx`:
+- Props: `items`, `meta`, `selectedShop`, `year`, `month`, `page`, `onShopChange`, `onPeriodChange`, `onPageChange`.
+- Рендерит:
+  - `ShopSelector`.
+  - `PeriodPicker` (mode='month', optional).
+  - Счётчик: «X открытых проблем».
+  - Таблица: дата, тип (badge), `human_description`. Только человекочитаемые поля.
+  - Пагинация: prev/next, текущая страница из `meta`.
+
+#### `financial-summary`
+
+Папка: `widgets/financial-summary/`.
+
+`financial-summary.widget.tsx`:
+- State: `shopRef`, `yearFrom`, `monthFrom`, `yearTo`, `monthTo`.
+- Зовёт `useFinancialSummaryData(params)`.
+
+`financial-summary.view.tsx`:
+- Props: `by_month`, `by_category`, `selectedShop`, `period`, `onShopChange`, `onPeriodChange`.
+- Рендерит:
+  - `ShopSelector`.
+  - `PeriodPicker` (mode='range').
+  - Таблица «По месяцам»: год-месяц, доход (`MoneyCell`), расход, прибыль.
+  - Таблица «По категориям» за последний месяц диапазона: категория, направление (badge), сумма.
+
+### 4.3 Entry-scripts
+
+Папка: `assets/react/entrypoints/`.
+
+Каждый монтирует один widget в `<div id="root">`:
+- `ingestion-verification-coverage.tsx`
+- `ingestion-verification-reconciliation.tsx`
+- `ingestion-verification-issues.tsx`
+- `ingestion-verification-financial-summary.tsx`
+
+После создания файлов добавить их в `site/vite.config.js`:
+
+```js
+rollupOptions: {
+    input: {
+        ingestion_verification_coverage: "./assets/react/entrypoints/ingestion-verification-coverage.tsx",
+        ingestion_verification_reconciliation: "./assets/react/entrypoints/ingestion-verification-reconciliation.tsx",
+        ingestion_verification_issues: "./assets/react/entrypoints/ingestion-verification-issues.tsx",
+        ingestion_verification_financial_summary: "./assets/react/entrypoints/ingestion-verification-financial-summary.tsx",
+    },
+}
+```
+
+Twig должен использовать те же ключи: `vite_entry_script_tags('ingestion_verification_coverage')`, `vite_entry_script_tags('ingestion_verification_reconciliation')`, `vite_entry_script_tags('ingestion_verification_issues')`, `vite_entry_script_tags('ingestion_verification_financial_summary')`.
+
+### 4.4 Twig-страницы
+
+Папка: `templates/ingestion/verification/`.
+
+Каждая содержит:
+- Заголовок страницы (название экрана).
+- Mount point: `<div id="root"></div>`.
+- Подключение entry-script через `vite_entry_script_tags(...)` с ключами из `site/vite.config.js`.
+
+Файлы:
+- `coverage.html.twig`
+- `reconciliation.html.twig`
+- `issues.html.twig`
+- `financial-summary.html.twig`
+
+### 4.5 PageController
+
+Папка: `src/Ingestion/Controller/Page/`. Все `final class`, `__invoke`, без бизнес-логики.
+
+- `CoveragePageController` → рендер `coverage.html.twig`.
+- `ReconciliationPageController` → `reconciliation.html.twig`.
+- `IssuesPageController` → `issues.html.twig`.
+- `FinancialSummaryPageController` → `financial-summary.html.twig`.
+
+Маршруты (через `#[Route]` атрибут):
+- `GET /ingestion/verification/coverage`
+- `GET /ingestion/verification/reconciliation`
+- `GET /ingestion/verification/issues`
+- `GET /ingestion/verification/financial-summary`
+
+---
+
+## 5. Асинхронность (Messenger)
+
+N/A.
+
+---
+
+## 6. Обработка ошибок
+
+Frontend обрабатывает 422 ошибки от backend:
+
+```json
+{ "error": { "code": "invalid_period_range", "message": "Некорректный диапазон периода" } }
+```
+
+В каждом widget'е при ошибке отображается `ErrorState` с `error.message` и кнопкой «Повторить».
+
+Network ошибки (500, timeout) — отображаются как «Не удалось загрузить данные, попробуйте позже» + кнопка «Повторить».
+
+---
+
+## 7. HTTP API (Controller)
+
+PageController (см. §4.5) — без API логики, только рендер Twig.
+
+---
+
+## 8. Разбивка на подзадачи
+
+| Этап | Что входит | Зависит от | Риск | Тесты |
+|---|---|---|---|---|
+| B1 | Shared-компоненты (`shop-selector`, `period-picker`, `money-cell`, `delta-cell`, `status-badge`, `empty-state`, `loading-state`, `error-state`) | `schema.d.ts` готов | 🟡 | TS strict |
+| B2 | API hooks (`ingestion-verification.api.ts`) | B1 | 🟡 | unit на параметры |
+| B3 | `coverage-heatmap` widget + entry-script | B2 | 🟡 | TS strict |
+| B4 | `reconciliation-summary` widget + entry-script | B2 | 🟡 | TS strict |
+| B5 | `issues-list` widget + entry-script | B2 | 🟡 | TS strict + пагинация |
+| B6 | `financial-summary` widget + entry-script | B2 | 🟡 | TS strict |
+| B7 | 4 Twig-страницы + 4 PageController + маршруты | B3-B6 | 🟢 | functional: страницы открываются |
+| B8 | Multi-shop localStorage интеграция | B1 | 🟢 | E2E если есть |
+| B9 | E2E проверка всех 4 страниц под авторизованным пользователем | B7 | 🟡 | manual или Playwright |
+| B10 | `ARCHITECTURE.md` + раздел про feature-slice | все | 🟢 | — |
+
+---
+
+## 9. Ограничения и запреты
+
+- Не использовать сырой `fetch` — только TanStack Query.
+- Не делать своих типов поверх API — только из `schema.d.ts`.
+- Не показывать клиенту технические поля (`operation_group_id`, `raw_record_id`, `details JSONB`).
+- Не модифицировать существующую страницу P&L legacy.
+- Не добавлять глобальный state — каждый widget управляет своим состоянием.
+- Strict TS: `noImplicitAny`, `strictNullChecks`.
+- Performance: дебаунс при изменении периода (500ms) перед инвалидацией query.
+
+---
+
+## 10. Критерии приёмки
+
+Функциональные:
+- [ ] Все 4 страницы открываются под авторизованным пользователем.
+- [ ] Multi-shop: фильтр работает, выбор сохраняется между сессиями.
+- [ ] Пустые состояния на каждом экране.
+- [ ] Состояния загрузки на каждом экране.
+- [ ] Состояния ошибки с кнопкой «Повторить».
+- [ ] Денежные суммы форматируются корректно (с разделителями, валютой).
+- [ ] DeltaCell подсвечивает расхождения > threshold красным.
+- [ ] Технические UUID и JSONB не отображаются в UI.
+- [ ] Пагинация Issues работает.
+- [ ] При отсутствии `ozon_control_total_minor` показывается соответствующий баннер.
+
+Технические:
+- [ ] TS strict зелёный.
+- [ ] Все типы из `schema.d.ts` (нет ручных интерфейсов поверх API-ответов).
+- [ ] Vite build зелёный.
+- [ ] Functional тест: каждая страница возвращает 200 для авторизованного, 302/401 для неавторизованного.
+- [ ] `make site-cs-check` для PHP-файлов (PageController) зелёный.
+- [ ] `ARCHITECTURE.md` обновлён.
+
+---
+
+## 11. План отката
+
+- Удалить routes `/ingestion/verification/*` из `config/routes.yaml`.
+- Удалить entry-scripts из `site/vite.config.js`.
+- Удалить feature-slice папку.
+- Backend (отдельная задача) продолжит работать — API эндпоинты остаются.
+
+---
+
+## 12. Чек-лист качества ТЗ
+
+- [x] Структура feature-slice по `CLAUDE.frontend.md`.
+- [x] Все hooks через TanStack Query, не fetch.
+- [x] Типы из `schema.d.ts`, не вручную.
+- [x] Multi-shop UX с localStorage явно описан.
+- [x] Состояния: loading, empty, error на каждом widget.
+- [x] Shared-компоненты с props.
+- [x] 4 entry-script с конкретными путями.
+- [x] 4 Twig-страницы + 4 PageController.
+- [x] Маршруты под `/ingestion/verification/*`.
+- [x] Запрет на технические поля в UI.
+- [x] Out of scope (XLSX, admin, legacy P&L).
+- [x] Backend в зависимости — не дублируется здесь.

--- a/docs/tasks/ingestion/fix/handoff.md
+++ b/docs/tasks/ingestion/fix/handoff.md
@@ -1,0 +1,90 @@
+# TASK-UI-CLIENT-BACKEND — Final Handoff
+
+## Summary
+
+Implemented backend support for the client Ingestion verification UI:
+
+- Stage 1: DTOs, formatter, period validation, API exceptions.
+- Stage 2: DBAL read queries and `IngestionFacade` methods.
+- Stage 3: 4 public REST endpoints, OpenAPI annotations, request logging, unified exception listener.
+- Stage 4: tenant-leak functional coverage for all endpoints.
+- Stage 5: generated `schema.d.ts`, architecture documentation, API type checks.
+
+## Files changed
+
+- `site/src/Ingestion/Application/DTO/*` — verification response DTOs.
+- `site/src/Ingestion/Application/Service/IssueDescriptionFormatter.php` — human issue descriptions.
+- `site/src/Ingestion/Application/Service/VerificationPeriodValidator.php` — period/date validation.
+- `site/src/Ingestion/Infrastructure/Query/*Query.php` — DBAL read models.
+- `site/src/Ingestion/Controller/Api/Verification/*Controller.php` — new API endpoints.
+- `site/src/Ingestion/Infrastructure/Http/IngestionExceptionListener.php` — unified 422 errors.
+- `site/src/Ingestion/Facade/IngestionFacade.php` — 4 verification methods.
+- `site/src/Marketplace/Repository/OzonTransactionTotalsCheckRepository.php` — latest company-period checksum lookup.
+- `site/assets/api/schema.d.ts` — regenerated API types.
+- `ARCHITECTURE.md` — Ingestion verification API documentation.
+- `site/tests/.../Ingestion/...` — unit, integration, functional, tenant-leak tests.
+- `docs/tasks/ingestion/fix/plan.md`, `docs/tasks/ingestion/fix/stages/*.md` — task documentation.
+
+## Public API changes
+
+Added 4 authenticated endpoints:
+
+- `GET /api/ingestion/verification/coverage`
+- `GET /api/ingestion/verification/reconciliation`
+- `GET /api/ingestion/verification/issues`
+- `GET /api/ingestion/verification/financial-summary`
+
+Errors from Ingestion period validation return HTTP 422:
+
+```json
+{"error":{"code":"invalid_period_range","message":"Некорректный диапазон периода"}}
+```
+
+## Migrations
+
+None. No database schema changes and no destructive migration.
+
+## Checks
+
+- Focused unit:
+  - `docker compose run --rm site-php-cli ./vendor/bin/phpunit -c phpunit.xml --testsuite=unit --filter 'IssueDescriptionFormatterTest|VerificationPeriodValidatorTest|IngestionExceptionListenerTest'` — passed, 12 tests.
+- Focused integration:
+  - `docker compose run --rm -e COMPOSER_PROCESS_TIMEOUT=0 site-php-cli ./vendor/bin/phpunit -c phpunit.xml --filter VerificationQueriesTest` — passed, 4 tests; PHPUnit reported 3 deprecations without detail.
+- Focused functional / tenant-leak:
+  - `docker compose run --rm -e COMPOSER_PROCESS_TIMEOUT=0 site-php-cli ./vendor/bin/phpunit -c phpunit.xml --filter VerificationApiControllerTest` — passed, 3 tests; PHPUnit reported 3 deprecations without detail.
+- Full unit:
+  - `make site-test-unit` — passed, 1082 tests; PHPUnit reported 1 warning and 1 deprecation.
+- Full integration:
+  - `make site-test-integration` — failed in unrelated existing tests: 6 errors, 30 failures across Cash, MarketplaceAds, Telegram, Finance, Inventory, Marketplace.
+- CS:
+  - `make site-cs-check` — failed on 669 pre-existing files outside this task.
+  - Scoped php-cs-fixer dry-run on changed task files — passed.
+- API:
+  - OpenAPI dump with `php -d memory_limit=-1 bin/console nelmio:apidoc:dump --format=json` in container — passed.
+  - `openapi-typescript` generation and `/tmp/schema.check.d.ts` diff — passed.
+  - Spectral lint — not run to completion because no Spectral ruleset exists.
+  - `make api-types` failed in this environment due Makefile `exec` dependency on running `site-php-cli` and exit 137 during dump; equivalent container `run` workflow passed.
+- Diff:
+  - `git diff --check` — passed.
+
+## Risks and limitations
+
+- `financial-summary` accepts `shop_ref`, but current `pl_monthly_snapshots` has no shop dimension; it returns company-level rebuilt P&L and documents this in `ARCHITECTURE.md`.
+- Reconciliation filters canonical transactions by requested `shop_ref`, while legacy `OzonTransactionTotalsCheck` is company-period scoped.
+- Ozon control total is read only from `ozonTotals["total_minor"]`; missing/invalid values return `null`.
+- Full project CS/integration suites are not clean in the current branch/environment independently of this task.
+
+## Follow-ups intentionally left out
+
+- Frontend implementation (`TASK-UI-CLIENT-FRONTEND`).
+- XLSX export.
+- Independent reconciliation recalculation from raw.
+- Admin screens/functions.
+- Shop-level P&L snapshots or Finance source/shop linking.
+
+## Reviewer focus
+
+- Public API response shapes and `schema.d.ts` output.
+- Explicit `company_id` filters in DBAL queries.
+- Tenant-leak functional test coverage.
+- Reconciliation assumptions around legacy checksum scope and JSON shape.

--- a/docs/tasks/ingestion/fix/plan.md
+++ b/docs/tasks/ingestion/fix/plan.md
@@ -1,0 +1,94 @@
+# План TASK-UI-CLIENT-BACKEND
+
+## Summary
+
+Подготовить backend для 4 клиентских Ingestion verification API без миграций и без frontend-работ: DBAL read-model queries, DTO/View слой, расширение `IngestionFacade`, 4 REST-контроллера с OpenAPI, единый listener ошибок, обновление `schema.d.ts`, functional/integration/unit тесты и документация.
+
+Так как добавляются публичные эндпоинты, этапы с API-контрактом классифицируются как HIGH и требуют owner review по правилам репозитория.
+
+## Key Changes
+
+- Добавить read-модели в `App\Ingestion\Application\DTO`: coverage, shops, reconciliation summary/by-type, issues, financial summary, pagination meta.
+- Добавить DBAL queries в `App\Ingestion\Infrastructure\Query`:
+  - `CoverageQuery`: raw/tx/open-issue counts через `ingest_raw_records` как базу, `shop_ref` optional, дата по `fetched_at::date`, tx/issues через `raw_record_id`.
+  - `ReconciliationQuery`: canon sum по `ingest_financial_transactions.occurred_at` за месяц и `shop_ref`; legacy control по latest `marketplace_ozon_transaction_totals_checks` за период компании.
+  - `IssuesQuery`: только unresolved issues, без technical fields в ответе, Pagerfanta limit max 200.
+  - `FinancialSummaryQuery`: `pl_monthly_snapshots` с `rebuilt_at IS NOT NULL`, join `pl_categories`, суммы decimal -> minor units.
+- Расширить `IngestionFacade` 4 методами из ТЗ; контроллеры обращаются только к фасаду и берут `companyId` из `ActiveCompanyService`.
+- Добавить `IssueDescriptionFormatter` и exceptions `InvalidPeriodException`, `InvalidPeriodRangeException`.
+- Добавить `IngestionExceptionListener` на `/api/ingestion/*` с ответом `{"error":{"code": "...", "message": "..."}}`.
+- Добавить 4 контроллера в `App\Ingestion\Controller\Api\Verification`:
+  - `GET /api/ingestion/verification/coverage`
+  - `GET /api/ingestion/verification/reconciliation`
+  - `GET /api/ingestion/verification/issues`
+  - `GET /api/ingestion/verification/financial-summary`
+- Добавить OpenAPI attributes и сгенерировать `site/assets/api/schema.d.ts` через `make api-types`.
+- Логировать каждое обращение через `LoggerInterface` на уровне `info`: endpoint, `companyId`, нормализованные query params, без secrets/PII.
+
+## Stages
+
+1. **Stage 0: Persist plan — LOW**
+   - В execution mode сохранить этот план в `docs/tasks/ingestion/fix/plan.md`.
+   - STOP для owner approval перед кодом.
+
+2. **Stage 1: DTO, formatter, validation exceptions — MEDIUM**
+   - Добавить DTO/View классы, `IssueDescriptionFormatter`, period validation helpers/exceptions.
+   - Unit tests на formatter и validation.
+   - No API routes yet.
+
+3. **Stage 2: DBAL queries and facade — MEDIUM**
+   - Реализовать 4 query-класса и расширить `IngestionFacade`.
+   - Integration tests на aggregation, filters, pagination, empty states.
+   - Reconciliation control parser ожидает `ozonTotals["total_minor"]`; если ключа нет или записи нет, `ozonControlTotalMinor = null`.
+
+4. **Stage 3: Controllers, OpenAPI, exception listener — HIGH**
+   - Добавить 4 public endpoints, OpenAPI annotations, `#[IsGranted('ROLE_USER')]`, `ActiveCompanyService`, logging.
+   - Добавить listener ошибок.
+   - Functional tests на 200/422 responses.
+   - STOP after green self-review because public API is introduced.
+
+5. **Stage 4: Tenant-leak and contract hardening — HIGH**
+   - Functional tenant-leak tests for all 4 endpoints: company A never sees company B data.
+   - Проверить отсутствие `raw_record_id`, `operation_group_id`, `details` в API responses.
+   - STOP after green self-review because this validates public tenant boundary.
+
+6. **Stage 5: API types and docs — LOW**
+   - Run `make api-types`, commit generated `site/assets/api/schema.d.ts`.
+   - Update `ARCHITECTURE.md` with new Ingestion verification endpoints and facade methods.
+   - Run API checks.
+
+7. **Final Handoff — HIGH STOP**
+   - Run relevant full checks, review diff, save `docs/tasks/ingestion/fix/handoff.md`.
+   - STOP for final owner review.
+
+## Test Plan
+
+- Unit:
+  - `IssueDescriptionFormatter` maps all `NormalizationIssueKind` values.
+  - Invalid month/year/range exceptions produce expected codes/messages through listener.
+- Integration:
+  - `CoverageQuery` counts raw records, canonical transactions, unresolved issues, shops distinct last 90 days, and `shop_ref` filtering.
+  - `ReconciliationQuery` sums signed canonical minor amounts by type and month; returns null control when no checksum or no `total_minor`.
+  - `IssuesQuery` returns unresolved issues only, max limit 200, no technical fields.
+  - `FinancialSummaryQuery` includes only rebuilt snapshots and converts decimal money to minor units.
+- Functional:
+  - 4 endpoints return expected JSON shape and snake_case keys.
+  - 422 errors use unified `{error:{code,message}}`.
+  - Tenant-leak test per endpoint with two companies.
+- Commands:
+  - `make site-test-unit`
+  - `make site-test-integration`
+  - `make site-cs-check`
+  - PHPStan command if available in composer/make scripts
+  - `make api-doc-lint`
+  - `make api-types-check`
+
+## Assumptions
+
+- No database migrations, no entity field changes, no new dependencies.
+- `schema.d.ts` is generated, not hand-edited.
+- Reconciliation: canon is filtered by requested `shop_ref`; legacy Ozon control is company-period scoped because current `OzonTransactionTotalsCheck` has no `shop_ref`.
+- `ozon_control_total_minor` is read from `OzonTransactionTotalsCheck::getOzonTotals()["total_minor"]`; missing/invalid value returns `null`.
+- Financial summary remains a DBAL read model in Ingestion and does not extend `PnlFacade`, because current `PnlFacade` has no summary read contract.
+- `financial-summary.by_category` uses the last month of the requested range, as specified.
+- Existing user changes in `docs/tasks/fix/*`, `.mimocode/`, and `docs/tasks/s3/` are unrelated and must not be touched.

--- a/docs/tasks/ingestion/fix/stages/stage-1.md
+++ b/docs/tasks/ingestion/fix/stages/stage-1.md
@@ -1,0 +1,35 @@
+### Stage 1: DTO, formatter, validation exceptions — DONE
+
+**Risk:** MEDIUM
+**Next action:** continue autonomously
+
+#### What was done
+- Added verification response DTOs with explicit snake_case `toArray()` contracts.
+- Added `IssueDescriptionFormatter`.
+- Added period validation service and API exceptions for invalid period/range.
+- Added unit tests for formatter and period validation.
+
+#### Files changed
+- `site/src/Ingestion/Application/DTO/*View.php` — new verification read DTOs
+- `site/src/Ingestion/Application/Service/IssueDescriptionFormatter.php` — new
+- `site/src/Ingestion/Application/Service/VerificationPeriodValidator.php` — new
+- `site/src/Ingestion/Exception/InvalidPeriodException.php` — new
+- `site/src/Ingestion/Exception/InvalidPeriodRangeException.php` — new
+- `site/tests/Unit/Ingestion/Application/Service/*Test.php` — new
+
+#### Self-review
+- [x] Scope compliance
+- [x] Project patterns followed
+- [x] No forbidden actions
+- [x] Security/company access checked: N/A, no data access yet
+- [x] Tests/checks run
+- [x] Documentation updated or N/A
+
+#### Checks
+- `docker compose run --rm site-php-cli ./vendor/bin/phpunit -c phpunit.xml --testsuite=unit --filter 'IssueDescriptionFormatterTest|VerificationPeriodValidatorTest'` — passed, 10 tests
+
+#### Risks / reviewer focus
+- DTO `toArray()` methods define the public snake_case response shape used by upcoming controllers.
+
+#### Open questions
+- none

--- a/docs/tasks/ingestion/fix/stages/stage-2.md
+++ b/docs/tasks/ingestion/fix/stages/stage-2.md
@@ -1,0 +1,35 @@
+### Stage 2: DBAL queries and facade — DONE
+
+**Risk:** MEDIUM
+**Next action:** continue autonomously
+
+#### What was done
+- Added verification DBAL read queries for coverage, reconciliation, issues, and financial summary.
+- Extended `IngestionFacade` with coverage, reconciliation, issues, and financial summary methods.
+- Added a narrow legacy read method to `OzonTransactionTotalsCheckRepository` for latest company-period checksum.
+- Added integration coverage for query aggregation and facade issue pagination.
+
+#### Files changed
+- `site/src/Ingestion/Infrastructure/Query/*Query.php` — new
+- `site/src/Ingestion/Facade/IngestionFacade.php` — modified
+- `site/src/Marketplace/Repository/OzonTransactionTotalsCheckRepository.php` — modified
+- `site/tests/Integration/Ingestion/Infrastructure/Query/VerificationQueriesTest.php` — new
+
+#### Self-review
+- [x] Scope compliance
+- [x] Project patterns followed
+- [x] No forbidden actions
+- [x] Security/company access checked
+- [x] Tests/checks run
+- [x] Documentation updated or N/A
+
+#### Checks
+- `docker compose run --rm -e COMPOSER_PROCESS_TIMEOUT=0 site-php-cli ./vendor/bin/phpunit -c phpunit.xml --filter VerificationQueriesTest` — passed, 4 tests, 20 assertions; PHPUnit reported 3 deprecations without detail.
+
+#### Risks / reviewer focus
+- `financial-summary` reads company-level P&L snapshots; `shop_ref` is accepted but ignored because `pl_monthly_snapshots` has no shop dimension.
+- Reconciliation filters canonical transactions by `shop_ref`, while legacy Ozon control is company-period scoped.
+- Ozon control reads only `ozonTotals["total_minor"]`; missing/invalid value returns null.
+
+#### Open questions
+- none

--- a/docs/tasks/ingestion/fix/stages/stage-3.md
+++ b/docs/tasks/ingestion/fix/stages/stage-3.md
@@ -1,0 +1,36 @@
+### Stage 3: Controllers, OpenAPI, exception listener — DONE
+
+**Risk:** HIGH
+**Next action:** continue autonomously per owner request to implement the approved plan
+
+#### What was done
+- Added 4 public verification endpoints under `/api/ingestion/verification/*`.
+- Added OpenAPI attributes for request parameters and response payloads.
+- Added `IngestionExceptionListener` for unified 422 Ingestion API errors.
+- Added request logging with endpoint, companyId, and request timestamp.
+- Added functional smoke coverage and listener unit tests.
+
+#### Files changed
+- `site/src/Ingestion/Controller/Api/Verification/*Controller.php` — new
+- `site/src/Ingestion/Infrastructure/Http/IngestionExceptionListener.php` — new
+- `site/tests/Functional/Ingestion/Controller/VerificationApiControllerTest.php` — new
+- `site/tests/Unit/Ingestion/Infrastructure/Http/IngestionExceptionListenerTest.php` — new
+
+#### Self-review
+- [x] Scope compliance
+- [x] Project patterns followed
+- [x] No forbidden actions
+- [x] Security/company access checked
+- [x] Tests/checks run
+- [x] Documentation updated or N/A
+
+#### Checks
+- `docker compose run --rm -e COMPOSER_PROCESS_TIMEOUT=0 site-php-cli ./vendor/bin/phpunit -c phpunit.xml --filter VerificationApiControllerTest` — passed, 2 tests, 24 assertions; PHPUnit reported 3 deprecations without detail.
+- `docker compose run --rm site-php-cli ./vendor/bin/phpunit -c phpunit.xml --testsuite=unit --filter IngestionExceptionListenerTest` — passed, 2 tests, 4 assertions.
+
+#### Risks / reviewer focus
+- This stage introduces public API routes and response contracts.
+- Controller validation maps missing/invalid required period params to the planned 422 error format.
+
+#### Open questions
+- none

--- a/docs/tasks/ingestion/fix/stages/stage-4.md
+++ b/docs/tasks/ingestion/fix/stages/stage-4.md
@@ -1,0 +1,29 @@
+### Stage 4: Tenant-leak and contract hardening — DONE
+
+**Risk:** HIGH
+**Next action:** continue autonomously per owner request to implement the approved plan
+
+#### What was done
+- Added functional tenant-leak coverage for all 4 verification endpoints.
+- Verified issue responses do not expose `details`, `raw_record_id`, or `operation_group_id`.
+- Re-ran the verification functional class after adding tenant fixtures.
+
+#### Files changed
+- `site/tests/Functional/Ingestion/Controller/VerificationApiControllerTest.php` — modified
+
+#### Self-review
+- [x] Scope compliance
+- [x] Project patterns followed
+- [x] No forbidden actions
+- [x] Security/company access checked
+- [x] Tests/checks run
+- [x] Documentation updated or N/A
+
+#### Checks
+- `docker compose run --rm -e COMPOSER_PROCESS_TIMEOUT=0 site-php-cli ./vendor/bin/phpunit -c phpunit.xml --filter VerificationApiControllerTest` — passed, 3 tests, 35 assertions; PHPUnit reported 3 deprecations without detail.
+
+#### Risks / reviewer focus
+- Tenant isolation for the new endpoints depends on explicit `company_id` conditions in DBAL queries, not only on Doctrine filters.
+
+#### Open questions
+- none

--- a/docs/tasks/ingestion/fix/stages/stage-5.md
+++ b/docs/tasks/ingestion/fix/stages/stage-5.md
@@ -1,0 +1,35 @@
+### Stage 5: API types and docs — DONE
+
+**Risk:** LOW
+**Next action:** final handoff
+
+#### What was done
+- Regenerated `site/assets/api/schema.d.ts` from the OpenAPI dump.
+- Added 422 error response schemas for the new verification endpoints.
+- Updated `ARCHITECTURE.md` with the new verification API and known shop-scope caveat.
+- Ran focused verification tests and generated API type check.
+
+#### Files changed
+- `site/assets/api/schema.d.ts` — modified/generated
+- `ARCHITECTURE.md` — modified
+- `site/src/Ingestion/Controller/Api/Verification/*Controller.php` — modified OpenAPI annotations
+
+#### Self-review
+- [x] Scope compliance
+- [x] Project patterns followed
+- [x] No forbidden actions
+- [x] Security/company access checked
+- [x] Tests/checks run
+- [x] Documentation updated
+
+#### Checks
+- `docker compose run --rm -e COMPOSER_PROCESS_TIMEOUT=0 site-php-cli sh -lc 'php -d memory_limit=-1 bin/console nelmio:apidoc:dump --format=json > var/openapi.json'` — passed.
+- `docker compose run --rm site-frontend sh -lc 'npx openapi-typescript var/openapi.json -o assets/api/schema.d.ts && npx openapi-typescript var/openapi.json -o /tmp/schema.check.d.ts && diff /tmp/schema.check.d.ts assets/api/schema.d.ts'` — passed.
+- `docker compose run --rm site-frontend sh -lc 'npx -y @stoplight/spectral-cli lint var/openapi.json'` — failed before linting: no Spectral ruleset found.
+- `make api-types` — failed in this environment because `site-php-cli` was not running, then `exec` dump exited 137; equivalent container `run` workflow above passed.
+
+#### Risks / reviewer focus
+- Generated TypeScript marks OpenAPI object properties optional because of current inline OA schemas; endpoint query params and response keys are still documented and generated.
+
+#### Open questions
+- none

--- a/site/assets/api/schema.d.ts
+++ b/site/assets/api/schema.d.ts
@@ -44,6 +44,74 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/ingestion/verification/coverage": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Ingestion coverage heatmap */
+        get: operations["get_api_ingestion_verification_coverage"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/ingestion/verification/financial-summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Ingestion financial summary */
+        get: operations["get_api_ingestion_verification_financial_summary"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/ingestion/verification/issues": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Open ingestion normalization issues */
+        get: operations["get_api_ingestion_verification_issues"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/ingestion/verification/reconciliation": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Ingestion reconciliation summary */
+        get: operations["get_api_ingestion_verification_reconciliation"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/marketplaceanalytics": {
         parameters: {
             query?: never;
@@ -388,6 +456,268 @@ export interface operations {
                             postgres?: boolean;
                             /** @example true */
                             redis_cache?: boolean;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    get_api_ingestion_verification_coverage: {
+        parameters: {
+            query: {
+                shop_ref?: string;
+                from: string;
+                to: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Coverage heatmap and shop options */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        cells?: {
+                            /**
+                             * Format: date
+                             * @example 2026-06-01
+                             */
+                            date?: string;
+                            /** @example ozon-shop-123 */
+                            shop_ref?: string;
+                            /** @example ozon_seller_daily_report */
+                            resource_type?: string;
+                            /** @example 1 */
+                            raw_count?: number;
+                            /** @example 287 */
+                            tx_count?: number;
+                            /** @example 0 */
+                            issue_count?: number;
+                            /** @example 2026-06-02T03:14:00Z */
+                            last_fetched_at?: string | null;
+                        }[];
+                        shops?: {
+                            /** @example ozon-shop-123 */
+                            shop_ref?: string;
+                            /** @example ozon-shop-123 */
+                            label?: string;
+                        }[];
+                    };
+                };
+            };
+            /** @description Invalid period */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: {
+                            /** @example invalid_period_range */
+                            code?: string;
+                            /** @example Некорректный диапазон периода */
+                            message?: string;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    get_api_ingestion_verification_financial_summary: {
+        parameters: {
+            query: {
+                shop_ref?: string;
+                year_from: number;
+                month_from: number;
+                year_to: number;
+                month_to: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Financial summary */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        by_month?: {
+                            /** @example 2026 */
+                            year?: number;
+                            /** @example 5 */
+                            month?: number;
+                            /** @example 1500000000 */
+                            income_minor?: number;
+                            /** @example 800000000 */
+                            expense_minor?: number;
+                            /** @example 700000000 */
+                            net_minor?: number;
+                            /** @example RUB */
+                            currency?: string;
+                        }[];
+                        by_category?: {
+                            /** Format: uuid */
+                            category_id?: string;
+                            /** @example Продажи */
+                            category_name?: string;
+                            /** @example income */
+                            flow?: string;
+                            /** @example 1500000000 */
+                            amount_minor?: number;
+                        }[];
+                    };
+                };
+            };
+            /** @description Invalid period range */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: {
+                            /** @example invalid_period_range */
+                            code?: string;
+                            /** @example Некорректный диапазон периода */
+                            message?: string;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    get_api_ingestion_verification_issues: {
+        parameters: {
+            query?: {
+                shop_ref?: string;
+                year?: number;
+                month?: number;
+                page?: number;
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Open issues */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        items?: {
+                            /** Format: uuid */
+                            id?: string;
+                            /** @example sum_mismatch */
+                            kind?: string;
+                            human_description?: string;
+                            /** @example 2026-06-15T10:00:00Z */
+                            created_at?: string;
+                        }[];
+                        meta?: {
+                            /** @example 1 */
+                            page?: number;
+                            /** @example 50 */
+                            limit?: number;
+                            /** @example 0 */
+                            total?: number;
+                            /** @example 0 */
+                            total_pages?: number;
+                        };
+                    };
+                };
+            };
+            /** @description Invalid period */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: {
+                            /** @example invalid_period */
+                            code?: string;
+                            /** @example Некорректный период */
+                            message?: string;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    get_api_ingestion_verification_reconciliation: {
+        parameters: {
+            query: {
+                shop_ref: string;
+                year: number;
+                month: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Reconciliation summary */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        summary?: {
+                            /** @example 2026-05 */
+                            period?: string;
+                            /** @example 1234567800 */
+                            canon_total_minor?: number;
+                            /** @example 1234566800 */
+                            ozon_control_total_minor?: number | null;
+                            /** @example RUB */
+                            currency?: string;
+                            /** @example 1000 */
+                            canon_vs_ozon_delta_minor?: number | null;
+                            /** @example 100 */
+                            threshold_minor?: number;
+                            /** @example 2026-06-15T10:00:00Z */
+                            recomputed_at?: string;
+                        };
+                        by_type?: {
+                            /** @example sale */
+                            type?: string;
+                            /** @example Продажа */
+                            type_label?: string;
+                            /** @example 1500000000 */
+                            canon_amount_minor?: number;
+                            /** @example 240 */
+                            tx_count?: number;
+                        }[];
+                    };
+                };
+            };
+            /** @description Invalid period */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: {
+                            /** @example invalid_period */
+                            code?: string;
+                            /** @example Некорректный период */
+                            message?: string;
                         };
                     };
                 };

--- a/site/src/Ingestion/Application/DTO/CoverageCellView.php
+++ b/site/src/Ingestion/Application/DTO/CoverageCellView.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\DTO;
+
+final readonly class CoverageCellView
+{
+    public function __construct(
+        public string $date,
+        public string $shopRef,
+        public string $resourceType,
+        public int $rawCount,
+        public int $txCount,
+        public int $issueCount,
+        public ?string $lastFetchedAt,
+    ) {
+    }
+
+    /**
+     * @return array{date: string, shop_ref: string, resource_type: string, raw_count: int, tx_count: int, issue_count: int, last_fetched_at: string|null}
+     */
+    public function toArray(): array
+    {
+        return [
+            'date' => $this->date,
+            'shop_ref' => $this->shopRef,
+            'resource_type' => $this->resourceType,
+            'raw_count' => $this->rawCount,
+            'tx_count' => $this->txCount,
+            'issue_count' => $this->issueCount,
+            'last_fetched_at' => $this->lastFetchedAt,
+        ];
+    }
+}

--- a/site/src/Ingestion/Application/DTO/FinancialSummaryCategoryView.php
+++ b/site/src/Ingestion/Application/DTO/FinancialSummaryCategoryView.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\DTO;
+
+final readonly class FinancialSummaryCategoryView
+{
+    public function __construct(
+        public string $categoryId,
+        public string $categoryName,
+        public string $flow,
+        public int $amountMinor,
+    ) {
+    }
+
+    /**
+     * @return array{category_id: string, category_name: string, flow: string, amount_minor: int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'category_id' => $this->categoryId,
+            'category_name' => $this->categoryName,
+            'flow' => $this->flow,
+            'amount_minor' => $this->amountMinor,
+        ];
+    }
+}

--- a/site/src/Ingestion/Application/DTO/FinancialSummaryMonthView.php
+++ b/site/src/Ingestion/Application/DTO/FinancialSummaryMonthView.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\DTO;
+
+final readonly class FinancialSummaryMonthView
+{
+    public function __construct(
+        public int $year,
+        public int $month,
+        public int $incomeMinor,
+        public int $expenseMinor,
+        public int $netMinor,
+        public string $currency,
+    ) {
+    }
+
+    /**
+     * @return array{year: int, month: int, income_minor: int, expense_minor: int, net_minor: int, currency: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'year' => $this->year,
+            'month' => $this->month,
+            'income_minor' => $this->incomeMinor,
+            'expense_minor' => $this->expenseMinor,
+            'net_minor' => $this->netMinor,
+            'currency' => $this->currency,
+        ];
+    }
+}

--- a/site/src/Ingestion/Application/DTO/IssueListItemView.php
+++ b/site/src/Ingestion/Application/DTO/IssueListItemView.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\DTO;
+
+final readonly class IssueListItemView
+{
+    public function __construct(
+        public string $id,
+        public string $kind,
+        public string $humanDescription,
+        public string $createdAt,
+    ) {
+    }
+
+    /**
+     * @return array{id: string, kind: string, human_description: string, created_at: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'kind' => $this->kind,
+            'human_description' => $this->humanDescription,
+            'created_at' => $this->createdAt,
+        ];
+    }
+}

--- a/site/src/Ingestion/Application/DTO/PaginationMeta.php
+++ b/site/src/Ingestion/Application/DTO/PaginationMeta.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\DTO;
+
+final readonly class PaginationMeta
+{
+    public function __construct(
+        public int $page,
+        public int $limit,
+        public int $total,
+        public int $totalPages,
+    ) {
+    }
+
+    /**
+     * @return array{page: int, limit: int, total: int, total_pages: int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'page' => $this->page,
+            'limit' => $this->limit,
+            'total' => $this->total,
+            'total_pages' => $this->totalPages,
+        ];
+    }
+}

--- a/site/src/Ingestion/Application/DTO/ReconciliationByTypeView.php
+++ b/site/src/Ingestion/Application/DTO/ReconciliationByTypeView.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\DTO;
+
+final readonly class ReconciliationByTypeView
+{
+    public function __construct(
+        public string $type,
+        public string $typeLabel,
+        public int $canonAmountMinor,
+        public int $txCount,
+    ) {
+    }
+
+    /**
+     * @return array{type: string, type_label: string, canon_amount_minor: int, tx_count: int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'type' => $this->type,
+            'type_label' => $this->typeLabel,
+            'canon_amount_minor' => $this->canonAmountMinor,
+            'tx_count' => $this->txCount,
+        ];
+    }
+}

--- a/site/src/Ingestion/Application/DTO/ReconciliationSummaryView.php
+++ b/site/src/Ingestion/Application/DTO/ReconciliationSummaryView.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\DTO;
+
+final readonly class ReconciliationSummaryView
+{
+    public function __construct(
+        public string $period,
+        public int $canonTotalMinor,
+        public ?int $ozonControlTotalMinor,
+        public string $currency,
+        public ?int $canonVsOzonDeltaMinor,
+        public int $thresholdMinor,
+        public string $recomputedAt,
+    ) {
+    }
+
+    /**
+     * @return array{period: string, canon_total_minor: int, ozon_control_total_minor: int|null, currency: string, canon_vs_ozon_delta_minor: int|null, threshold_minor: int, recomputed_at: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'period' => $this->period,
+            'canon_total_minor' => $this->canonTotalMinor,
+            'ozon_control_total_minor' => $this->ozonControlTotalMinor,
+            'currency' => $this->currency,
+            'canon_vs_ozon_delta_minor' => $this->canonVsOzonDeltaMinor,
+            'threshold_minor' => $this->thresholdMinor,
+            'recomputed_at' => $this->recomputedAt,
+        ];
+    }
+}

--- a/site/src/Ingestion/Application/DTO/ShopOptionView.php
+++ b/site/src/Ingestion/Application/DTO/ShopOptionView.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\DTO;
+
+final readonly class ShopOptionView
+{
+    public function __construct(
+        public string $shopRef,
+        public string $label,
+    ) {
+    }
+
+    /**
+     * @return array{shop_ref: string, label: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'shop_ref' => $this->shopRef,
+            'label' => $this->label,
+        ];
+    }
+}

--- a/site/src/Ingestion/Application/Service/IssueDescriptionFormatter.php
+++ b/site/src/Ingestion/Application/Service/IssueDescriptionFormatter.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Service;
+
+use App\Ingestion\Enum\NormalizationIssueKind;
+
+final class IssueDescriptionFormatter
+{
+    /**
+     * @param array<string, mixed> $details
+     */
+    public function humanize(NormalizationIssueKind $kind, array $details): string
+    {
+        return match ($kind) {
+            NormalizationIssueKind::SUM_MISMATCH => 'Сумма операций не сходится с контрольной суммой источника',
+            NormalizationIssueKind::MAPPER_FAILURE => 'Не удалось распознать операцию',
+            NormalizationIssueKind::UNKNOWN_FIELD => 'В отчёте появилось неизвестное поле',
+            NormalizationIssueKind::CURRENCY_MISMATCH => 'В операции смешаны разные валюты',
+        };
+    }
+}

--- a/site/src/Ingestion/Application/Service/VerificationPeriodValidator.php
+++ b/site/src/Ingestion/Application/Service/VerificationPeriodValidator.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Service;
+
+use App\Ingestion\Exception\InvalidPeriodException;
+use App\Ingestion\Exception\InvalidPeriodRangeException;
+
+final class VerificationPeriodValidator
+{
+    public function parseDate(string $date): \DateTimeImmutable
+    {
+        $parsed = \DateTimeImmutable::createFromFormat('!Y-m-d', $date);
+        $errors = \DateTimeImmutable::getLastErrors();
+
+        if (
+            false === $parsed
+            || false !== $errors && ($errors['warning_count'] > 0 || $errors['error_count'] > 0)
+            || $parsed->format('Y-m-d') !== $date
+        ) {
+            throw new InvalidPeriodException();
+        }
+
+        return $parsed;
+    }
+
+    /**
+     * @return array{0: \DateTimeImmutable, 1: \DateTimeImmutable}
+     */
+    public function parseDateRange(string $from, string $to): array
+    {
+        $fromDate = $this->parseDate($from);
+        $toDate = $this->parseDate($to);
+
+        if ($fromDate > $toDate) {
+            throw new InvalidPeriodRangeException();
+        }
+
+        return [$fromDate, $toDate];
+    }
+
+    public function assertYearMonth(int $year, int $month): void
+    {
+        if ($year < 2020 || $year > 2100 || $month < 1 || $month > 12) {
+            throw new InvalidPeriodException();
+        }
+    }
+
+    public function assertMonthRange(int $yearFrom, int $monthFrom, int $yearTo, int $monthTo): void
+    {
+        $this->assertYearMonth($yearFrom, $monthFrom);
+        $this->assertYearMonth($yearTo, $monthTo);
+
+        if (($yearFrom * 12 + $monthFrom) > ($yearTo * 12 + $monthTo)) {
+            throw new InvalidPeriodRangeException();
+        }
+    }
+}

--- a/site/src/Ingestion/Controller/Api/Verification/GetCoverageController.php
+++ b/site/src/Ingestion/Controller/Api/Verification/GetCoverageController.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Controller\Api\Verification;
+
+use App\Ingestion\Application\Service\VerificationPeriodValidator;
+use App\Ingestion\Facade\IngestionFacade;
+use App\Shared\Service\ActiveCompanyService;
+use OpenApi\Attributes as OA;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_USER')]
+#[OA\Tag(name: 'Ingestion verification')]
+final class GetCoverageController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $activeCompanyService,
+        private readonly IngestionFacade $ingestionFacade,
+        private readonly VerificationPeriodValidator $periodValidator,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    #[OA\Get(summary: 'Ingestion coverage heatmap', tags: ['Ingestion verification'])]
+    #[OA\Parameter(name: 'shop_ref', in: 'query', required: false, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'from', in: 'query', required: true, schema: new OA\Schema(type: 'string', format: 'date'))]
+    #[OA\Parameter(name: 'to', in: 'query', required: true, schema: new OA\Schema(type: 'string', format: 'date'))]
+    #[OA\Response(
+        response: 200,
+        description: 'Coverage heatmap and shop options',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(
+                    property: 'cells',
+                    type: 'array',
+                    items: new OA\Items(
+                        properties: [
+                            new OA\Property(property: 'date', type: 'string', format: 'date', example: '2026-06-01'),
+                            new OA\Property(property: 'shop_ref', type: 'string', example: 'ozon-shop-123'),
+                            new OA\Property(property: 'resource_type', type: 'string', example: 'ozon_seller_daily_report'),
+                            new OA\Property(property: 'raw_count', type: 'integer', example: 1),
+                            new OA\Property(property: 'tx_count', type: 'integer', example: 287),
+                            new OA\Property(property: 'issue_count', type: 'integer', example: 0),
+                            new OA\Property(property: 'last_fetched_at', type: 'string', nullable: true, example: '2026-06-02T03:14:00Z'),
+                        ],
+                        type: 'object',
+                    ),
+                ),
+                new OA\Property(
+                    property: 'shops',
+                    type: 'array',
+                    items: new OA\Items(
+                        properties: [
+                            new OA\Property(property: 'shop_ref', type: 'string', example: 'ozon-shop-123'),
+                            new OA\Property(property: 'label', type: 'string', example: 'ozon-shop-123'),
+                        ],
+                        type: 'object',
+                    ),
+                ),
+            ],
+            type: 'object',
+        ),
+    )]
+    #[OA\Response(
+        response: 422,
+        description: 'Invalid period',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(
+                    property: 'error',
+                    properties: [
+                        new OA\Property(property: 'code', type: 'string', example: 'invalid_period_range'),
+                        new OA\Property(property: 'message', type: 'string', example: 'Некорректный диапазон периода'),
+                    ],
+                    type: 'object',
+                ),
+            ],
+            type: 'object',
+        ),
+    )]
+    #[Route('/api/ingestion/verification/coverage', name: 'api_ingestion_verification_coverage', methods: ['GET'])]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $companyId = (string) $this->activeCompanyService->getActiveCompany()->getId();
+        [$from, $to] = $this->periodValidator->parseDateRange(
+            (string) $request->query->get('from', ''),
+            (string) $request->query->get('to', ''),
+        );
+        $shopRef = $this->nullableString($request->query->get('shop_ref'));
+
+        $this->logRequest($companyId);
+        $coverage = $this->ingestionFacade->getCoverage($companyId, $shopRef, $from, $to);
+
+        return $this->json([
+            'cells' => array_map(static fn ($cell): array => $cell->toArray(), $coverage['cells']),
+            'shops' => array_map(static fn ($shop): array => $shop->toArray(), $coverage['shops']),
+        ]);
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        if (!is_string($value) || '' === trim($value)) {
+            return null;
+        }
+
+        return trim($value);
+    }
+
+    private function logRequest(string $companyId): void
+    {
+        $this->logger->info('Ingestion verification endpoint requested', [
+            'endpoint' => 'coverage',
+            'companyId' => $companyId,
+            'requestedAt' => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+}

--- a/site/src/Ingestion/Controller/Api/Verification/GetFinancialSummaryController.php
+++ b/site/src/Ingestion/Controller/Api/Verification/GetFinancialSummaryController.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Controller\Api\Verification;
+
+use App\Ingestion\Application\Service\VerificationPeriodValidator;
+use App\Ingestion\Facade\IngestionFacade;
+use App\Shared\Service\ActiveCompanyService;
+use OpenApi\Attributes as OA;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_USER')]
+#[OA\Tag(name: 'Ingestion verification')]
+final class GetFinancialSummaryController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $activeCompanyService,
+        private readonly IngestionFacade $ingestionFacade,
+        private readonly VerificationPeriodValidator $periodValidator,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    #[OA\Get(summary: 'Ingestion financial summary', tags: ['Ingestion verification'])]
+    #[OA\Parameter(name: 'shop_ref', in: 'query', required: false, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'year_from', in: 'query', required: true, schema: new OA\Schema(type: 'integer', minimum: 2020, maximum: 2100))]
+    #[OA\Parameter(name: 'month_from', in: 'query', required: true, schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 12))]
+    #[OA\Parameter(name: 'year_to', in: 'query', required: true, schema: new OA\Schema(type: 'integer', minimum: 2020, maximum: 2100))]
+    #[OA\Parameter(name: 'month_to', in: 'query', required: true, schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 12))]
+    #[OA\Response(
+        response: 200,
+        description: 'Financial summary',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(
+                    property: 'by_month',
+                    type: 'array',
+                    items: new OA\Items(
+                        properties: [
+                            new OA\Property(property: 'year', type: 'integer', example: 2026),
+                            new OA\Property(property: 'month', type: 'integer', example: 5),
+                            new OA\Property(property: 'income_minor', type: 'integer', example: 1500000000),
+                            new OA\Property(property: 'expense_minor', type: 'integer', example: 800000000),
+                            new OA\Property(property: 'net_minor', type: 'integer', example: 700000000),
+                            new OA\Property(property: 'currency', type: 'string', example: 'RUB'),
+                        ],
+                        type: 'object',
+                    ),
+                ),
+                new OA\Property(
+                    property: 'by_category',
+                    type: 'array',
+                    items: new OA\Items(
+                        properties: [
+                            new OA\Property(property: 'category_id', type: 'string', format: 'uuid'),
+                            new OA\Property(property: 'category_name', type: 'string', example: 'Продажи'),
+                            new OA\Property(property: 'flow', type: 'string', example: 'income'),
+                            new OA\Property(property: 'amount_minor', type: 'integer', example: 1500000000),
+                        ],
+                        type: 'object',
+                    ),
+                ),
+            ],
+            type: 'object',
+        ),
+    )]
+    #[OA\Response(
+        response: 422,
+        description: 'Invalid period range',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(
+                    property: 'error',
+                    properties: [
+                        new OA\Property(property: 'code', type: 'string', example: 'invalid_period_range'),
+                        new OA\Property(property: 'message', type: 'string', example: 'Некорректный диапазон периода'),
+                    ],
+                    type: 'object',
+                ),
+            ],
+            type: 'object',
+        ),
+    )]
+    #[Route('/api/ingestion/verification/financial-summary', name: 'api_ingestion_verification_financial_summary', methods: ['GET'])]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $companyId = (string) $this->activeCompanyService->getActiveCompany()->getId();
+        $shopRef = $this->nullableString($request->query->get('shop_ref'));
+        $yearFrom = $request->query->getInt('year_from');
+        $monthFrom = $request->query->getInt('month_from');
+        $yearTo = $request->query->getInt('year_to');
+        $monthTo = $request->query->getInt('month_to');
+
+        $this->periodValidator->assertMonthRange($yearFrom, $monthFrom, $yearTo, $monthTo);
+
+        $this->logRequest($companyId);
+        $summary = $this->ingestionFacade->getFinancialSummary(
+            $companyId,
+            $shopRef,
+            $yearFrom,
+            $monthFrom,
+            $yearTo,
+            $monthTo,
+        );
+
+        return $this->json([
+            'by_month' => array_map(static fn ($item): array => $item->toArray(), $summary['byMonth']),
+            'by_category' => array_map(static fn ($item): array => $item->toArray(), $summary['byCategory']),
+        ]);
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        if (!is_string($value) || '' === trim($value)) {
+            return null;
+        }
+
+        return trim($value);
+    }
+
+    private function logRequest(string $companyId): void
+    {
+        $this->logger->info('Ingestion verification endpoint requested', [
+            'endpoint' => 'financial-summary',
+            'companyId' => $companyId,
+            'requestedAt' => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+}

--- a/site/src/Ingestion/Controller/Api/Verification/GetIssuesController.php
+++ b/site/src/Ingestion/Controller/Api/Verification/GetIssuesController.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Controller\Api\Verification;
+
+use App\Ingestion\Application\Service\VerificationPeriodValidator;
+use App\Ingestion\Exception\InvalidPeriodException;
+use App\Ingestion\Facade\IngestionFacade;
+use App\Shared\Service\ActiveCompanyService;
+use OpenApi\Attributes as OA;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_USER')]
+#[OA\Tag(name: 'Ingestion verification')]
+final class GetIssuesController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $activeCompanyService,
+        private readonly IngestionFacade $ingestionFacade,
+        private readonly VerificationPeriodValidator $periodValidator,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    #[OA\Get(summary: 'Open ingestion normalization issues', tags: ['Ingestion verification'])]
+    #[OA\Parameter(name: 'shop_ref', in: 'query', required: false, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'year', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 2020, maximum: 2100))]
+    #[OA\Parameter(name: 'month', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 12))]
+    #[OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer', default: 1, minimum: 1))]
+    #[OA\Parameter(name: 'limit', in: 'query', required: false, schema: new OA\Schema(type: 'integer', default: 50, minimum: 1, maximum: 200))]
+    #[OA\Response(
+        response: 200,
+        description: 'Open issues',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(
+                    property: 'items',
+                    type: 'array',
+                    items: new OA\Items(
+                        properties: [
+                            new OA\Property(property: 'id', type: 'string', format: 'uuid'),
+                            new OA\Property(property: 'kind', type: 'string', example: 'sum_mismatch'),
+                            new OA\Property(property: 'human_description', type: 'string'),
+                            new OA\Property(property: 'created_at', type: 'string', example: '2026-06-15T10:00:00Z'),
+                        ],
+                        type: 'object',
+                    ),
+                ),
+                new OA\Property(
+                    property: 'meta',
+                    properties: [
+                        new OA\Property(property: 'page', type: 'integer', example: 1),
+                        new OA\Property(property: 'limit', type: 'integer', example: 50),
+                        new OA\Property(property: 'total', type: 'integer', example: 0),
+                        new OA\Property(property: 'total_pages', type: 'integer', example: 0),
+                    ],
+                    type: 'object',
+                ),
+            ],
+            type: 'object',
+        ),
+    )]
+    #[OA\Response(
+        response: 422,
+        description: 'Invalid period',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(
+                    property: 'error',
+                    properties: [
+                        new OA\Property(property: 'code', type: 'string', example: 'invalid_period'),
+                        new OA\Property(property: 'message', type: 'string', example: 'Некорректный период'),
+                    ],
+                    type: 'object',
+                ),
+            ],
+            type: 'object',
+        ),
+    )]
+    #[Route('/api/ingestion/verification/issues', name: 'api_ingestion_verification_issues', methods: ['GET'])]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $companyId = (string) $this->activeCompanyService->getActiveCompany()->getId();
+        $shopRef = $this->nullableString($request->query->get('shop_ref'));
+        [$year, $month] = $this->optionalYearMonth($request);
+        $page = $request->query->getInt('page', 1);
+        $limit = $request->query->getInt('limit', 50);
+
+        $this->logRequest($companyId);
+        $issues = $this->ingestionFacade->listIssues($companyId, $shopRef, $year, $month, $page, $limit);
+
+        return $this->json([
+            'items' => array_map(static fn ($item): array => $item->toArray(), $issues['items']),
+            'meta' => $issues['meta']->toArray(),
+        ]);
+    }
+
+    /**
+     * @return array{0: int|null, 1: int|null}
+     */
+    private function optionalYearMonth(Request $request): array
+    {
+        $hasYear = $request->query->has('year');
+        $hasMonth = $request->query->has('month');
+
+        if (!$hasYear && !$hasMonth) {
+            return [null, null];
+        }
+
+        if (!$hasYear || !$hasMonth) {
+            throw new InvalidPeriodException();
+        }
+
+        $year = $request->query->getInt('year');
+        $month = $request->query->getInt('month');
+        $this->periodValidator->assertYearMonth($year, $month);
+
+        return [$year, $month];
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        if (!is_string($value) || '' === trim($value)) {
+            return null;
+        }
+
+        return trim($value);
+    }
+
+    private function logRequest(string $companyId): void
+    {
+        $this->logger->info('Ingestion verification endpoint requested', [
+            'endpoint' => 'issues',
+            'companyId' => $companyId,
+            'requestedAt' => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+}

--- a/site/src/Ingestion/Controller/Api/Verification/GetReconciliationController.php
+++ b/site/src/Ingestion/Controller/Api/Verification/GetReconciliationController.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Controller\Api\Verification;
+
+use App\Ingestion\Application\Service\VerificationPeriodValidator;
+use App\Ingestion\Exception\InvalidPeriodException;
+use App\Ingestion\Facade\IngestionFacade;
+use App\Shared\Service\ActiveCompanyService;
+use OpenApi\Attributes as OA;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_USER')]
+#[OA\Tag(name: 'Ingestion verification')]
+final class GetReconciliationController extends AbstractController
+{
+    public function __construct(
+        private readonly ActiveCompanyService $activeCompanyService,
+        private readonly IngestionFacade $ingestionFacade,
+        private readonly VerificationPeriodValidator $periodValidator,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    #[OA\Get(summary: 'Ingestion reconciliation summary', tags: ['Ingestion verification'])]
+    #[OA\Parameter(name: 'shop_ref', in: 'query', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'year', in: 'query', required: true, schema: new OA\Schema(type: 'integer', minimum: 2020, maximum: 2100))]
+    #[OA\Parameter(name: 'month', in: 'query', required: true, schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 12))]
+    #[OA\Response(
+        response: 200,
+        description: 'Reconciliation summary',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(
+                    property: 'summary',
+                    properties: [
+                        new OA\Property(property: 'period', type: 'string', example: '2026-05'),
+                        new OA\Property(property: 'canon_total_minor', type: 'integer', example: 1234567800),
+                        new OA\Property(property: 'ozon_control_total_minor', type: 'integer', nullable: true, example: 1234566800),
+                        new OA\Property(property: 'currency', type: 'string', example: 'RUB'),
+                        new OA\Property(property: 'canon_vs_ozon_delta_minor', type: 'integer', nullable: true, example: 1000),
+                        new OA\Property(property: 'threshold_minor', type: 'integer', example: 100),
+                        new OA\Property(property: 'recomputed_at', type: 'string', example: '2026-06-15T10:00:00Z'),
+                    ],
+                    type: 'object',
+                ),
+                new OA\Property(
+                    property: 'by_type',
+                    type: 'array',
+                    items: new OA\Items(
+                        properties: [
+                            new OA\Property(property: 'type', type: 'string', example: 'sale'),
+                            new OA\Property(property: 'type_label', type: 'string', example: 'Продажа'),
+                            new OA\Property(property: 'canon_amount_minor', type: 'integer', example: 1500000000),
+                            new OA\Property(property: 'tx_count', type: 'integer', example: 240),
+                        ],
+                        type: 'object',
+                    ),
+                ),
+            ],
+            type: 'object',
+        ),
+    )]
+    #[OA\Response(
+        response: 422,
+        description: 'Invalid period',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(
+                    property: 'error',
+                    properties: [
+                        new OA\Property(property: 'code', type: 'string', example: 'invalid_period'),
+                        new OA\Property(property: 'message', type: 'string', example: 'Некорректный период'),
+                    ],
+                    type: 'object',
+                ),
+            ],
+            type: 'object',
+        ),
+    )]
+    #[Route('/api/ingestion/verification/reconciliation', name: 'api_ingestion_verification_reconciliation', methods: ['GET'])]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $companyId = (string) $this->activeCompanyService->getActiveCompany()->getId();
+        $shopRef = $this->requiredString($request->query->get('shop_ref'));
+        $year = $request->query->getInt('year');
+        $month = $request->query->getInt('month');
+        $this->periodValidator->assertYearMonth($year, $month);
+
+        $this->logRequest($companyId);
+        $reconciliation = $this->ingestionFacade->getReconciliation($companyId, $shopRef, $year, $month);
+
+        return $this->json([
+            'summary' => $reconciliation['summary']->toArray(),
+            'by_type' => array_map(static fn ($item): array => $item->toArray(), $reconciliation['byType']),
+        ]);
+    }
+
+    private function requiredString(mixed $value): string
+    {
+        if (!is_string($value) || '' === trim($value)) {
+            throw new InvalidPeriodException();
+        }
+
+        return trim($value);
+    }
+
+    private function logRequest(string $companyId): void
+    {
+        $this->logger->info('Ingestion verification endpoint requested', [
+            'endpoint' => 'reconciliation',
+            'companyId' => $companyId,
+            'requestedAt' => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+}

--- a/site/src/Ingestion/Exception/IngestionApiExceptionInterface.php
+++ b/site/src/Ingestion/Exception/IngestionApiExceptionInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Exception;
+
+interface IngestionApiExceptionInterface
+{
+    public function errorCode(): string;
+
+    public function publicMessage(): string;
+}

--- a/site/src/Ingestion/Exception/InvalidPeriodException.php
+++ b/site/src/Ingestion/Exception/InvalidPeriodException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Exception;
+
+final class InvalidPeriodException extends \InvalidArgumentException implements IngestionApiExceptionInterface
+{
+    public function __construct()
+    {
+        parent::__construct('Некорректный период');
+    }
+
+    public function errorCode(): string
+    {
+        return 'invalid_period';
+    }
+
+    public function publicMessage(): string
+    {
+        return 'Некорректный период';
+    }
+}

--- a/site/src/Ingestion/Exception/InvalidPeriodRangeException.php
+++ b/site/src/Ingestion/Exception/InvalidPeriodRangeException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Exception;
+
+final class InvalidPeriodRangeException extends \InvalidArgumentException implements IngestionApiExceptionInterface
+{
+    public function __construct()
+    {
+        parent::__construct('Некорректный диапазон периода');
+    }
+
+    public function errorCode(): string
+    {
+        return 'invalid_period_range';
+    }
+
+    public function publicMessage(): string
+    {
+        return 'Некорректный диапазон периода';
+    }
+}

--- a/site/src/Ingestion/Facade/IngestionFacade.php
+++ b/site/src/Ingestion/Facade/IngestionFacade.php
@@ -4,15 +4,37 @@ declare(strict_types=1);
 
 namespace App\Ingestion\Facade;
 
+use App\Ingestion\Application\DTO\CoverageCellView;
+use App\Ingestion\Application\DTO\FinancialSummaryCategoryView;
+use App\Ingestion\Application\DTO\FinancialSummaryMonthView;
+use App\Ingestion\Application\DTO\IssueListItemView;
+use App\Ingestion\Application\DTO\PaginationMeta;
+use App\Ingestion\Application\DTO\ReconciliationByTypeView;
+use App\Ingestion\Application\DTO\ReconciliationSummaryView;
+use App\Ingestion\Application\DTO\ShopOptionView;
+use App\Ingestion\Application\Service\IssueDescriptionFormatter;
 use App\Ingestion\Entity\FinancialTransaction;
+use App\Ingestion\Enum\NormalizationIssueKind;
+use App\Ingestion\Infrastructure\Query\CoverageQuery;
+use App\Ingestion\Infrastructure\Query\FinancialSummaryQuery;
+use App\Ingestion\Infrastructure\Query\IssuesQuery;
+use App\Ingestion\Infrastructure\Query\ReconciliationQuery;
 use App\Ingestion\Repository\FinancialTransactionRepository;
 use App\Ingestion\Repository\NormalizationIssueRepository;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Pagerfanta\Doctrine\DBAL\QueryAdapter;
+use Pagerfanta\Pagerfanta;
 
 final readonly class IngestionFacade
 {
     public function __construct(
         private FinancialTransactionRepository $financialTransactionRepository,
         private NormalizationIssueRepository $normalizationIssueRepository,
+        private CoverageQuery $coverageQuery,
+        private ReconciliationQuery $reconciliationQuery,
+        private IssuesQuery $issuesQuery,
+        private FinancialSummaryQuery $financialSummaryQuery,
+        private IssueDescriptionFormatter $issueDescriptionFormatter,
     ) {
     }
 
@@ -31,5 +53,133 @@ final readonly class IngestionFacade
     public function countOpenIssues(string $companyId): int
     {
         return $this->normalizationIssueRepository->countOpenForCompany($companyId);
+    }
+
+    /**
+     * @return array{cells: list<CoverageCellView>, shops: list<ShopOptionView>}
+     */
+    public function getCoverage(
+        string $companyId,
+        ?string $shopRef,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+    ): array {
+        return [
+            'cells' => $this->coverageQuery->heatmap($companyId, $shopRef, $from, $to),
+            'shops' => $this->coverageQuery->shops($companyId),
+        ];
+    }
+
+    /**
+     * @return array{summary: ReconciliationSummaryView, byType: list<ReconciliationByTypeView>}
+     */
+    public function getReconciliation(string $companyId, string $shopRef, int $year, int $month): array
+    {
+        return [
+            'summary' => $this->reconciliationQuery->summary($companyId, $shopRef, $year, $month),
+            'byType' => $this->reconciliationQuery->breakdownByType($companyId, $shopRef, $year, $month),
+        ];
+    }
+
+    /**
+     * @return array{items: list<IssueListItemView>, meta: PaginationMeta}
+     */
+    public function listIssues(
+        string $companyId,
+        ?string $shopRef,
+        ?int $year,
+        ?int $month,
+        int $page,
+        int $limit,
+    ): array {
+        $page = max(1, $page);
+        $limit = min(200, max(1, $limit));
+        $pager = Pagerfanta::createForCurrentPageWithMaxPerPage(
+            new QueryAdapter(
+                $this->issuesQuery->build($companyId, $shopRef, $year, $month),
+                static function (QueryBuilder $countQb): void {
+                    $countQb
+                        ->select('COUNT(i.id) AS total_results')
+                        ->resetOrderBy();
+                },
+            ),
+            $page,
+            $limit,
+        );
+
+        $items = array_map(
+            fn (array $row): IssueListItemView => $this->mapIssueRow($row),
+            iterator_to_array($pager->getCurrentPageResults()),
+        );
+
+        return [
+            'items' => $items,
+            'meta' => new PaginationMeta(
+                page: $pager->getCurrentPage(),
+                limit: $pager->getMaxPerPage(),
+                total: $pager->getNbResults(),
+                totalPages: $pager->getNbPages(),
+            ),
+        ];
+    }
+
+    /**
+     * @return array{byMonth: list<FinancialSummaryMonthView>, byCategory: list<FinancialSummaryCategoryView>}
+     */
+    public function getFinancialSummary(
+        string $companyId,
+        ?string $shopRef,
+        int $yearFrom,
+        int $monthFrom,
+        int $yearTo,
+        int $monthTo,
+    ): array {
+        return [
+            'byMonth' => $this->financialSummaryQuery->byMonth(
+                $companyId,
+                $shopRef,
+                $yearFrom,
+                $monthFrom,
+                $yearTo,
+                $monthTo,
+            ),
+            'byCategory' => $this->financialSummaryQuery->byCategory($companyId, $shopRef, $yearTo, $monthTo),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function mapIssueRow(array $row): IssueListItemView
+    {
+        $kind = NormalizationIssueKind::from((string) $row['kind']);
+        $details = $this->decodeDetails($row['details'] ?? []);
+
+        return new IssueListItemView(
+            id: (string) $row['id'],
+            kind: $kind->value,
+            humanDescription: $this->issueDescriptionFormatter->humanize($kind, $details),
+            createdAt: (new \DateTimeImmutable((string) $row['created_at']))
+                ->setTimezone(new \DateTimeZone('UTC'))
+                ->format('Y-m-d\TH:i:s\Z'),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeDetails(mixed $details): array
+    {
+        if (is_array($details)) {
+            return $details;
+        }
+
+        if (!is_string($details) || '' === $details) {
+            return [];
+        }
+
+        $decoded = json_decode($details, true);
+
+        return is_array($decoded) ? $decoded : [];
     }
 }

--- a/site/src/Ingestion/Infrastructure/Http/IngestionExceptionListener.php
+++ b/site/src/Ingestion/Infrastructure/Http/IngestionExceptionListener.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Http;
+
+use App\Ingestion\Exception\IngestionApiExceptionInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class IngestionExceptionListener implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::EXCEPTION => ['onKernelException', 0],
+        ];
+    }
+
+    public function onKernelException(ExceptionEvent $event): void
+    {
+        $request = $event->getRequest();
+        if (!str_starts_with($request->getPathInfo(), '/api/ingestion/')) {
+            return;
+        }
+
+        $exception = $event->getThrowable();
+        if (!$exception instanceof IngestionApiExceptionInterface) {
+            return;
+        }
+
+        $event->setResponse(new JsonResponse([
+            'error' => [
+                'code' => $exception->errorCode(),
+                'message' => $exception->publicMessage(),
+            ],
+        ], Response::HTTP_UNPROCESSABLE_ENTITY));
+    }
+}

--- a/site/src/Ingestion/Infrastructure/Query/CoverageQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/CoverageQuery.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Query;
+
+use App\Ingestion\Application\DTO\CoverageCellView;
+use App\Ingestion\Application\DTO\ShopOptionView;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Types\Types;
+use Webmozart\Assert\Assert;
+
+final class CoverageQuery
+{
+    public function __construct(
+        private readonly Connection $connection,
+    ) {
+    }
+
+    /**
+     * @return list<CoverageCellView>
+     */
+    public function heatmap(
+        string $companyId,
+        ?string $shopRef,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+    ): array {
+        Assert::uuid($companyId);
+
+        $qb = $this->connection->createQueryBuilder()
+            ->select(
+                "TO_CHAR(r.fetched_at, 'YYYY-MM-DD') AS record_date",
+                'r.shop_ref',
+                'r.resource_type',
+                'COUNT(DISTINCT r.id) AS raw_count',
+                'COUNT(DISTINCT ft.id) AS tx_count',
+                'COUNT(DISTINCT ni.id) AS issue_count',
+                'MAX(r.fetched_at) AS last_fetched_at',
+            )
+            ->from('ingest_raw_records', 'r')
+            ->leftJoin(
+                'r',
+                'ingest_financial_transactions',
+                'ft',
+                'ft.company_id = r.company_id AND ft.raw_record_id = r.id',
+            )
+            ->leftJoin(
+                'r',
+                'ingest_normalization_issues',
+                'ni',
+                'ni.company_id = r.company_id AND ni.raw_record_id = r.id AND ni.resolved_at IS NULL',
+            )
+            ->where('r.company_id = :companyId')
+            ->andWhere('r.fetched_at >= :from')
+            ->andWhere('r.fetched_at < :toExclusive')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
+            ->setParameter('toExclusive', $to->modify('+1 day'), Types::DATETIME_IMMUTABLE)
+            ->groupBy('record_date', 'r.shop_ref', 'r.resource_type')
+            ->orderBy('record_date', 'ASC')
+            ->addOrderBy('r.shop_ref', 'ASC')
+            ->addOrderBy('r.resource_type', 'ASC');
+
+        if (null !== $shopRef && '' !== $shopRef) {
+            $qb->andWhere('r.shop_ref = :shopRef')
+                ->setParameter('shopRef', $shopRef);
+        }
+
+        $rows = $qb->executeQuery()->fetchAllAssociative();
+
+        return array_map(
+            static fn (array $row): CoverageCellView => new CoverageCellView(
+                date: (string) $row['record_date'],
+                shopRef: (string) $row['shop_ref'],
+                resourceType: (string) $row['resource_type'],
+                rawCount: (int) $row['raw_count'],
+                txCount: (int) $row['tx_count'],
+                issueCount: (int) $row['issue_count'],
+                lastFetchedAt: self::formatDateTime($row['last_fetched_at'] ?? null),
+            ),
+            $rows,
+        );
+    }
+
+    /**
+     * @return list<ShopOptionView>
+     */
+    public function shops(string $companyId): array
+    {
+        Assert::uuid($companyId);
+
+        $rows = $this->connection->createQueryBuilder()
+            ->select('r.shop_ref')
+            ->from('ingest_raw_records', 'r')
+            ->where('r.company_id = :companyId')
+            ->andWhere('r.fetched_at >= :from')
+            ->andWhere("r.shop_ref <> ''")
+            ->setParameter('companyId', $companyId)
+            ->setParameter('from', new \DateTimeImmutable('-90 days'), Types::DATETIME_IMMUTABLE)
+            ->groupBy('r.shop_ref')
+            ->orderBy('r.shop_ref', 'ASC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return array_map(
+            static fn (array $row): ShopOptionView => new ShopOptionView(
+                shopRef: (string) $row['shop_ref'],
+                label: (string) $row['shop_ref'],
+            ),
+            $rows,
+        );
+    }
+
+    private static function formatDateTime(mixed $value): ?string
+    {
+        if (null === $value || '' === $value) {
+            return null;
+        }
+
+        return (new \DateTimeImmutable((string) $value))
+            ->setTimezone(new \DateTimeZone('UTC'))
+            ->format('Y-m-d\TH:i:s\Z');
+    }
+}

--- a/site/src/Ingestion/Infrastructure/Query/FinancialSummaryQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/FinancialSummaryQuery.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Query;
+
+use App\Finance\Enum\PLFlow;
+use App\Ingestion\Application\DTO\FinancialSummaryCategoryView;
+use App\Ingestion\Application\DTO\FinancialSummaryMonthView;
+use Doctrine\DBAL\Connection;
+use Webmozart\Assert\Assert;
+
+final class FinancialSummaryQuery
+{
+    public function __construct(
+        private readonly Connection $connection,
+    ) {
+    }
+
+    /**
+     * @return list<FinancialSummaryMonthView>
+     */
+    public function byMonth(
+        string $companyId,
+        ?string $shopRef,
+        int $yearFrom,
+        int $monthFrom,
+        int $yearTo,
+        int $monthTo,
+    ): array {
+        Assert::uuid($companyId);
+        unset($shopRef);
+
+        $periodFrom = sprintf('%04d-%02d', $yearFrom, $monthFrom);
+        $periodTo = sprintf('%04d-%02d', $yearTo, $monthTo);
+
+        $rows = $this->connection->createQueryBuilder()
+            ->select(
+                's.period',
+                'COALESCE(SUM(s.amount_income), 0) AS income_amount',
+                'COALESCE(SUM(s.amount_expense), 0) AS expense_amount',
+            )
+            ->from('pl_monthly_snapshots', 's')
+            ->where('s.company_id = :companyId')
+            ->andWhere('s.period >= :periodFrom')
+            ->andWhere('s.period <= :periodTo')
+            ->andWhere('s.rebuilt_at IS NOT NULL')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('periodFrom', $periodFrom)
+            ->setParameter('periodTo', $periodTo)
+            ->groupBy('s.period')
+            ->orderBy('s.period', 'ASC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return array_map(
+            static function (array $row): FinancialSummaryMonthView {
+                [$year, $month] = array_map('intval', explode('-', (string) $row['period']));
+                $incomeMinor = self::decimalToMinor((string) $row['income_amount']);
+                $expenseMinor = self::decimalToMinor((string) $row['expense_amount']);
+
+                return new FinancialSummaryMonthView(
+                    year: $year,
+                    month: $month,
+                    incomeMinor: $incomeMinor,
+                    expenseMinor: $expenseMinor,
+                    netMinor: $incomeMinor - $expenseMinor,
+                    currency: 'RUB',
+                );
+            },
+            $rows,
+        );
+    }
+
+    /**
+     * @return list<FinancialSummaryCategoryView>
+     */
+    public function byCategory(string $companyId, ?string $shopRef, int $year, int $month): array
+    {
+        Assert::uuid($companyId);
+        unset($shopRef);
+
+        $period = sprintf('%04d-%02d', $year, $month);
+
+        $rows = $this->connection->createQueryBuilder()
+            ->select(
+                'c.id AS category_id',
+                'c.name AS category_name',
+                'c.flow',
+                'COALESCE(SUM(s.amount_income), 0) AS income_amount',
+                'COALESCE(SUM(s.amount_expense), 0) AS expense_amount',
+            )
+            ->from('pl_monthly_snapshots', 's')
+            ->innerJoin('s', 'pl_categories', 'c', 'c.id = s.pl_category_id')
+            ->where('s.company_id = :companyId')
+            ->andWhere('s.period = :period')
+            ->andWhere('s.rebuilt_at IS NOT NULL')
+            ->andWhere('s.pl_category_id IS NOT NULL')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('period', $period)
+            ->groupBy('c.id', 'c.name', 'c.flow')
+            ->orderBy('c.name', 'ASC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return array_map(
+            static function (array $row): FinancialSummaryCategoryView {
+                $flow = (string) $row['flow'];
+                $incomeMinor = self::decimalToMinor((string) $row['income_amount']);
+                $expenseMinor = self::decimalToMinor((string) $row['expense_amount']);
+                $amountMinor = match ($flow) {
+                    PLFlow::INCOME->value => $incomeMinor,
+                    PLFlow::EXPENSE->value => $expenseMinor,
+                    default => $incomeMinor - $expenseMinor,
+                };
+
+                return new FinancialSummaryCategoryView(
+                    categoryId: (string) $row['category_id'],
+                    categoryName: (string) $row['category_name'],
+                    flow: strtolower($flow),
+                    amountMinor: $amountMinor,
+                );
+            },
+            $rows,
+        );
+    }
+
+    private static function decimalToMinor(string $amount): int
+    {
+        $amount = trim($amount);
+        $negative = str_starts_with($amount, '-');
+        $normalized = $negative ? substr($amount, 1) : $amount;
+        [$whole, $fraction] = array_pad(explode('.', $normalized, 2), 2, '0');
+        $minor = ((int) $whole * 100) + (int) str_pad(substr($fraction, 0, 2), 2, '0');
+
+        return $negative ? -$minor : $minor;
+    }
+}

--- a/site/src/Ingestion/Infrastructure/Query/IssuesQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/IssuesQuery.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Query;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Webmozart\Assert\Assert;
+
+final class IssuesQuery
+{
+    public function __construct(
+        private readonly Connection $connection,
+    ) {
+    }
+
+    public function build(string $companyId, ?string $shopRef, ?int $year, ?int $month): QueryBuilder
+    {
+        Assert::uuid($companyId);
+
+        $qb = $this->connection->createQueryBuilder()
+            ->select(
+                'i.id',
+                'i.kind',
+                'i.details',
+                'i.created_at',
+            )
+            ->from('ingest_normalization_issues', 'i')
+            ->innerJoin(
+                'i',
+                'ingest_raw_records',
+                'r',
+                'r.company_id = i.company_id AND r.id = i.raw_record_id',
+            )
+            ->where('i.company_id = :companyId')
+            ->andWhere('i.resolved_at IS NULL')
+            ->setParameter('companyId', $companyId)
+            ->orderBy('i.created_at', 'DESC')
+            ->addOrderBy('i.id', 'DESC');
+
+        if (null !== $shopRef && '' !== $shopRef) {
+            $qb->andWhere('r.shop_ref = :shopRef')
+                ->setParameter('shopRef', $shopRef);
+        }
+
+        if (null !== $year && null !== $month) {
+            $from = new \DateTimeImmutable(sprintf('%04d-%02d-01 00:00:00', $year, $month));
+            $qb->andWhere('i.created_at >= :from')
+                ->andWhere('i.created_at < :toExclusive')
+                ->setParameter('from', $from, \Doctrine\DBAL\Types\Types::DATETIME_IMMUTABLE)
+                ->setParameter('toExclusive', $from->modify('first day of next month'), \Doctrine\DBAL\Types\Types::DATETIME_IMMUTABLE);
+        }
+
+        return $qb;
+    }
+
+    public function count(string $companyId, ?string $shopRef, ?int $year, ?int $month): int
+    {
+        $qb = $this->build($companyId, $shopRef, $year, $month);
+        $qb->select('COUNT(i.id) AS total_results')
+            ->resetOrderBy();
+
+        return (int) $qb->executeQuery()->fetchOne();
+    }
+}

--- a/site/src/Ingestion/Infrastructure/Query/ReconciliationQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/ReconciliationQuery.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Query;
+
+use App\Ingestion\Application\DTO\ReconciliationByTypeView;
+use App\Ingestion\Application\DTO\ReconciliationSummaryView;
+use App\Ingestion\Enum\TransactionType;
+use App\Marketplace\Repository\OzonTransactionTotalsCheckRepository;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Types\Types;
+use Webmozart\Assert\Assert;
+
+final class ReconciliationQuery
+{
+    private const THRESHOLD_MINOR = 100;
+
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly OzonTransactionTotalsCheckRepository $totalsCheckRepository,
+    ) {
+    }
+
+    public function summary(string $companyId, string $shopRef, int $year, int $month): ReconciliationSummaryView
+    {
+        Assert::uuid($companyId);
+        Assert::notEmpty($shopRef);
+
+        [$from, $toExclusive] = $this->monthBounds($year, $month);
+
+        $row = $this->connection->createQueryBuilder()
+            ->select(
+                'COALESCE(SUM(ft.amount_minor), 0) AS canon_total_minor',
+                "COALESCE(MIN(ft.currency), 'RUB') AS currency",
+                'MAX(ft.updated_at) AS recomputed_at',
+            )
+            ->from('ingest_financial_transactions', 'ft')
+            ->where('ft.company_id = :companyId')
+            ->andWhere('ft.shop_ref = :shopRef')
+            ->andWhere('ft.occurred_at >= :from')
+            ->andWhere('ft.occurred_at < :toExclusive')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('shopRef', $shopRef)
+            ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
+            ->setParameter('toExclusive', $toExclusive, Types::DATETIME_IMMUTABLE)
+            ->executeQuery()
+            ->fetchAssociative();
+
+        $canonTotalMinor = (int) ($row['canon_total_minor'] ?? 0);
+        $currency = (string) ($row['currency'] ?? 'RUB');
+
+        $control = $this->totalsCheckRepository->findLatestByCompanyAndPeriod(
+            $companyId,
+            $from,
+            $toExclusive->modify('-1 day'),
+        );
+        $ozonTotalMinor = $this->extractOzonTotalMinor($control?->getOzonTotals());
+        $delta = null === $ozonTotalMinor ? null : $canonTotalMinor - $ozonTotalMinor;
+
+        return new ReconciliationSummaryView(
+            period: sprintf('%04d-%02d', $year, $month),
+            canonTotalMinor: $canonTotalMinor,
+            ozonControlTotalMinor: $ozonTotalMinor,
+            currency: $currency,
+            canonVsOzonDeltaMinor: $delta,
+            thresholdMinor: self::THRESHOLD_MINOR,
+            recomputedAt: $this->latestDateTime($row['recomputed_at'] ?? null, $control?->getCheckedAt()),
+        );
+    }
+
+    /**
+     * @return list<ReconciliationByTypeView>
+     */
+    public function breakdownByType(string $companyId, string $shopRef, int $year, int $month): array
+    {
+        Assert::uuid($companyId);
+        Assert::notEmpty($shopRef);
+
+        [$from, $toExclusive] = $this->monthBounds($year, $month);
+
+        $rows = $this->connection->createQueryBuilder()
+            ->select(
+                'ft.type',
+                'COALESCE(SUM(ft.amount_minor), 0) AS canon_amount_minor',
+                'COUNT(ft.id) AS tx_count',
+            )
+            ->from('ingest_financial_transactions', 'ft')
+            ->where('ft.company_id = :companyId')
+            ->andWhere('ft.shop_ref = :shopRef')
+            ->andWhere('ft.occurred_at >= :from')
+            ->andWhere('ft.occurred_at < :toExclusive')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('shopRef', $shopRef)
+            ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
+            ->setParameter('toExclusive', $toExclusive, Types::DATETIME_IMMUTABLE)
+            ->groupBy('ft.type')
+            ->orderBy('ft.type', 'ASC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return array_map(
+            static function (array $row): ReconciliationByTypeView {
+                $type = (string) $row['type'];
+                $transactionType = TransactionType::tryFrom($type);
+
+                return new ReconciliationByTypeView(
+                    type: $type,
+                    typeLabel: $transactionType?->label() ?? $type,
+                    canonAmountMinor: (int) $row['canon_amount_minor'],
+                    txCount: (int) $row['tx_count'],
+                );
+            },
+            $rows,
+        );
+    }
+
+    /**
+     * @return array{0: \DateTimeImmutable, 1: \DateTimeImmutable}
+     */
+    private function monthBounds(int $year, int $month): array
+    {
+        $from = new \DateTimeImmutable(sprintf('%04d-%02d-01 00:00:00', $year, $month));
+
+        return [$from, $from->modify('first day of next month')];
+    }
+
+    /**
+     * @param array<string, mixed>|null $totals
+     */
+    private function extractOzonTotalMinor(?array $totals): ?int
+    {
+        if (null === $totals || !array_key_exists('total_minor', $totals)) {
+            return null;
+        }
+
+        $value = $totals['total_minor'];
+
+        if (!is_int($value) && !(is_string($value) && 1 === preg_match('/^-?\d+$/', $value))) {
+            return null;
+        }
+
+        return (int) $value;
+    }
+
+    private function latestDateTime(mixed $canonValue, ?\DateTimeImmutable $controlValue): string
+    {
+        $canonDate = null === $canonValue || '' === $canonValue
+            ? null
+            : new \DateTimeImmutable((string) $canonValue);
+
+        $date = match (true) {
+            null === $canonDate && null === $controlValue => new \DateTimeImmutable(),
+            null === $canonDate => $controlValue,
+            null === $controlValue => $canonDate,
+            default => $canonDate > $controlValue ? $canonDate : $controlValue,
+        };
+
+        return $date
+            ->setTimezone(new \DateTimeZone('UTC'))
+            ->format('Y-m-d\TH:i:s\Z');
+    }
+}

--- a/site/src/Marketplace/Repository/OzonTransactionTotalsCheckRepository.php
+++ b/site/src/Marketplace/Repository/OzonTransactionTotalsCheckRepository.php
@@ -39,6 +39,27 @@ final class OzonTransactionTotalsCheckRepository extends ServiceEntityRepository
             ->getOneOrNullResult();
     }
 
+    public function findLatestByCompanyAndPeriod(
+        string $companyId,
+        \DateTimeImmutable $periodFrom,
+        \DateTimeImmutable $periodTo,
+    ): ?OzonTransactionTotalsCheck {
+        Assert::uuid($companyId);
+
+        return $this->createQueryBuilder('c')
+            ->where('c.companyId = :companyId')
+            ->andWhere('c.periodFrom <= :periodTo')
+            ->andWhere('c.periodTo >= :periodFrom')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('periodFrom', $periodFrom)
+            ->setParameter('periodTo', $periodTo)
+            ->orderBy('c.checkedAt', 'DESC')
+            ->addOrderBy('c.createdAt', 'DESC')
+            ->getQuery()
+            ->setMaxResults(1)
+            ->getOneOrNullResult();
+    }
+
     /**
      * Возвращает только актуальные FAILED-проверки (latest by rawDocumentId).
      *

--- a/site/tests/Functional/Ingestion/Controller/VerificationApiControllerTest.php
+++ b/site/tests/Functional/Ingestion/Controller/VerificationApiControllerTest.php
@@ -1,0 +1,332 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Ingestion\Controller;
+
+use App\Company\Entity\Company;
+use App\Company\Entity\User;
+use App\Finance\Entity\PLMonthlySnapshot;
+use App\Finance\Enum\PLFlow;
+use App\Ingestion\Entity\FinancialTransaction;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Entity\NormalizationIssue;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\NormalizationIssueKind;
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+use App\Marketplace\Entity\OzonTransactionTotalsCheck;
+use App\Shared\Domain\ValueObject\Money;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Builders\Finance\PLCategoryBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+final class VerificationApiControllerTest extends WebTestCaseBase
+{
+    public function testVerificationEndpointsReturnExpectedPayloads(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$owner, $company] = $this->persistVerificationFixture();
+        $this->loginWithActiveCompany($client, $owner, $company);
+
+        $client->request('GET', '/api/ingestion/verification/coverage?from=2026-06-01&to=2026-06-30&shop_ref=shop-1');
+        self::assertResponseIsSuccessful();
+        $coverage = $this->json($client);
+        self::assertSame('shop-1', $coverage['cells'][0]['shop_ref']);
+        self::assertSame(1, $coverage['cells'][0]['raw_count']);
+        self::assertSame(2, $coverage['cells'][0]['tx_count']);
+        self::assertSame(1, $coverage['cells'][0]['issue_count']);
+        self::assertSame('shop-1', $coverage['shops'][0]['shop_ref']);
+
+        $client->request('GET', '/api/ingestion/verification/reconciliation?shop_ref=shop-1&year=2026&month=6');
+        self::assertResponseIsSuccessful();
+        $reconciliation = $this->json($client);
+        self::assertSame(800, $reconciliation['summary']['canon_total_minor']);
+        self::assertSame(750, $reconciliation['summary']['ozon_control_total_minor']);
+        self::assertSame(50, $reconciliation['summary']['canon_vs_ozon_delta_minor']);
+        self::assertSame('sale', $reconciliation['by_type'][1]['type']);
+
+        $client->request('GET', '/api/ingestion/verification/issues?shop_ref=shop-1&page=1&limit=50');
+        self::assertResponseIsSuccessful();
+        $issues = $this->json($client);
+        self::assertSame(1, $issues['meta']['total']);
+        self::assertSame('sum_mismatch', $issues['items'][0]['kind']);
+        self::assertArrayNotHasKey('details', $issues['items'][0]);
+        self::assertArrayNotHasKey('raw_record_id', $issues['items'][0]);
+        self::assertArrayNotHasKey('operation_group_id', $issues['items'][0]);
+
+        $client->request('GET', '/api/ingestion/verification/financial-summary?year_from=2026&month_from=6&year_to=2026&month_to=6');
+        self::assertResponseIsSuccessful();
+        $summary = $this->json($client);
+        self::assertSame(12345, $summary['by_month'][0]['income_minor']);
+        self::assertSame(2345, $summary['by_month'][0]['expense_minor']);
+        self::assertSame(10000, $summary['by_month'][0]['net_minor']);
+        self::assertSame('income', $summary['by_category'][1]['flow']);
+    }
+
+    public function testInvalidPeriodUsesUnifiedErrorFormat(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $owner = UserBuilder::aUser()->withIndex(9101)->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId('11111111-1111-4111-8111-111111119101')
+            ->withOwner($owner)
+            ->build();
+        $em = $this->em();
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        $this->loginWithActiveCompany($client, $owner, $company);
+        $client->request('GET', '/api/ingestion/verification/coverage?from=2026-07-01&to=2026-06-01');
+
+        self::assertResponseStatusCodeSame(422);
+        self::assertSame([
+            'error' => [
+                'code' => 'invalid_period_range',
+                'message' => 'Некорректный диапазон периода',
+            ],
+        ], $this->json($client));
+    }
+
+    public function testVerificationEndpointsDoNotLeakOtherCompanyData(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$ownerA, $companyA] = $this->persistTenantLeakFixture();
+        $this->loginWithActiveCompany($client, $ownerA, $companyA);
+
+        $client->request('GET', '/api/ingestion/verification/coverage?from=2026-06-01&to=2026-06-30');
+        self::assertResponseIsSuccessful();
+        $coverage = $this->json($client);
+        self::assertSame(['shop-a'], array_column($coverage['cells'], 'shop_ref'));
+        self::assertSame(['shop-a'], array_column($coverage['shops'], 'shop_ref'));
+
+        $client->request('GET', '/api/ingestion/verification/reconciliation?shop_ref=shop-a&year=2026&month=6');
+        self::assertResponseIsSuccessful();
+        $reconciliation = $this->json($client);
+        self::assertSame(1000, $reconciliation['summary']['canon_total_minor']);
+        self::assertSame(900, $reconciliation['summary']['ozon_control_total_minor']);
+
+        $client->request('GET', '/api/ingestion/verification/issues?page=1&limit=50');
+        self::assertResponseIsSuccessful();
+        $issues = $this->json($client);
+        self::assertSame(1, $issues['meta']['total']);
+        self::assertSame('sum_mismatch', $issues['items'][0]['kind']);
+
+        $client->request('GET', '/api/ingestion/verification/financial-summary?year_from=2026&month_from=6&year_to=2026&month_to=6');
+        self::assertResponseIsSuccessful();
+        $summary = $this->json($client);
+        self::assertSame(1000, $summary['by_month'][0]['income_minor']);
+    }
+
+    /**
+     * @return array{0: User, 1: Company}
+     */
+    private function persistVerificationFixture(): array
+    {
+        $owner = UserBuilder::aUser()->withIndex(9100)->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId('11111111-1111-4111-8111-111111119100')
+            ->withOwner($owner)
+            ->build();
+        $companyId = $company->getId();
+        $raw = $this->rawRecord($companyId, 'shop-1', 'ozon_seller_daily_report', 'raw-api-1');
+
+        $check = new OzonTransactionTotalsCheck(
+            companyId: $companyId,
+            rawDocumentId: Uuid::uuid7()->toString(),
+            periodFrom: new \DateTimeImmutable('2026-06-01'),
+            periodTo: new \DateTimeImmutable('2026-06-30'),
+        );
+        $check->markOk([], ['total_minor' => 750], []);
+
+        $incomeCategory = PLCategoryBuilder::aPLCategory()
+            ->withId('33333333-3333-4333-8333-333333339100')
+            ->forCompany($company)
+            ->withName('Продажи')
+            ->withFlow(PLFlow::INCOME)
+            ->build();
+        $expenseCategory = PLCategoryBuilder::aPLCategory()
+            ->withId('33333333-3333-4333-8333-333333339101')
+            ->forCompany($company)
+            ->withName('Комиссии')
+            ->withFlow(PLFlow::EXPENSE)
+            ->build();
+        $incomeSnapshot = new PLMonthlySnapshot(Uuid::uuid7()->toString(), $company, '2026-06', $incomeCategory);
+        $incomeSnapshot->setAmountIncome('123.45');
+        $incomeSnapshot->setRebuiltAt(new \DateTimeImmutable('2026-06-20 10:00:00+00:00'));
+        $expenseSnapshot = new PLMonthlySnapshot(Uuid::uuid7()->toString(), $company, '2026-06', $expenseCategory);
+        $expenseSnapshot->setAmountExpense('23.45');
+        $expenseSnapshot->setRebuiltAt(new \DateTimeImmutable('2026-06-20 10:00:00+00:00'));
+
+        $em = $this->em();
+        $em->persist($owner);
+        $em->persist($company);
+        $em->persist($raw);
+        $em->persist($this->transaction($companyId, $raw->getId(), 'api-sale-1', 1000, TransactionType::SALE));
+        $em->persist($this->transaction($companyId, $raw->getId(), 'api-commission-1', -200, TransactionType::COMMISSION));
+        $em->persist(new NormalizationIssue(
+            $companyId,
+            $raw->getId(),
+            Uuid::uuid7()->toString(),
+            NormalizationIssueKind::SUM_MISMATCH,
+            ['raw' => 'hidden'],
+        ));
+        $em->persist($check);
+        $em->persist($incomeCategory);
+        $em->persist($expenseCategory);
+        $em->persist($incomeSnapshot);
+        $em->persist($expenseSnapshot);
+        $em->flush();
+
+        return [$owner, $company];
+    }
+
+    /**
+     * @return array{0: User, 1: Company}
+     */
+    private function persistTenantLeakFixture(): array
+    {
+        $ownerA = UserBuilder::aUser()->withIndex(9200)->build();
+        $ownerB = UserBuilder::aUser()->withIndex(9201)->build();
+        $companyA = CompanyBuilder::aCompany()
+            ->withId('11111111-1111-4111-8111-111111119200')
+            ->withOwner($ownerA)
+            ->build();
+        $companyB = CompanyBuilder::aCompany()
+            ->withId('11111111-1111-4111-8111-111111119201')
+            ->withOwner($ownerB)
+            ->build();
+
+        $rawA = $this->rawRecord($companyA->getId(), 'shop-a', 'ozon_seller_daily_report', 'tenant-raw-a');
+        $rawB = $this->rawRecord($companyB->getId(), 'shop-b', 'ozon_seller_daily_report', 'tenant-raw-b');
+
+        $checkA = new OzonTransactionTotalsCheck(
+            companyId: $companyA->getId(),
+            rawDocumentId: Uuid::uuid7()->toString(),
+            periodFrom: new \DateTimeImmutable('2026-06-01'),
+            periodTo: new \DateTimeImmutable('2026-06-30'),
+        );
+        $checkA->markOk([], ['total_minor' => 900], []);
+        $checkB = new OzonTransactionTotalsCheck(
+            companyId: $companyB->getId(),
+            rawDocumentId: Uuid::uuid7()->toString(),
+            periodFrom: new \DateTimeImmutable('2026-06-01'),
+            periodTo: new \DateTimeImmutable('2026-06-30'),
+        );
+        $checkB->markOk([], ['total_minor' => 99999], []);
+
+        $categoryA = PLCategoryBuilder::aPLCategory()
+            ->withId('33333333-3333-4333-8333-333333339200')
+            ->forCompany($companyA)
+            ->withName('Company A Sales')
+            ->withFlow(PLFlow::INCOME)
+            ->build();
+        $categoryB = PLCategoryBuilder::aPLCategory()
+            ->withId('33333333-3333-4333-8333-333333339201')
+            ->forCompany($companyB)
+            ->withName('Company B Sales')
+            ->withFlow(PLFlow::INCOME)
+            ->build();
+        $snapshotA = new PLMonthlySnapshot(Uuid::uuid7()->toString(), $companyA, '2026-06', $categoryA);
+        $snapshotA->setAmountIncome('10.00');
+        $snapshotA->setRebuiltAt(new \DateTimeImmutable('2026-06-20 10:00:00+00:00'));
+        $snapshotB = new PLMonthlySnapshot(Uuid::uuid7()->toString(), $companyB, '2026-06', $categoryB);
+        $snapshotB->setAmountIncome('999.99');
+        $snapshotB->setRebuiltAt(new \DateTimeImmutable('2026-06-20 10:00:00+00:00'));
+
+        $em = $this->em();
+        foreach ([$ownerA, $ownerB, $companyA, $companyB, $rawA, $rawB] as $entity) {
+            $em->persist($entity);
+        }
+        $em->persist($this->transaction($companyA->getId(), $rawA->getId(), 'tenant-sale-a', 1000, TransactionType::SALE, 'shop-a'));
+        $em->persist($this->transaction($companyB->getId(), $rawB->getId(), 'tenant-sale-b', 99999, TransactionType::SALE, 'shop-b'));
+        $em->persist(new NormalizationIssue(
+            $companyA->getId(),
+            $rawA->getId(),
+            null,
+            NormalizationIssueKind::SUM_MISMATCH,
+            [],
+        ));
+        $em->persist(new NormalizationIssue(
+            $companyB->getId(),
+            $rawB->getId(),
+            null,
+            NormalizationIssueKind::MAPPER_FAILURE,
+            [],
+        ));
+        foreach ([$checkA, $checkB, $categoryA, $categoryB, $snapshotA, $snapshotB] as $entity) {
+            $em->persist($entity);
+        }
+        $em->flush();
+
+        return [$ownerA, $companyA];
+    }
+
+    private function rawRecord(string $companyId, string $shopRef, string $resourceType, string $externalId): IngestRawRecord
+    {
+        return new IngestRawRecord(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            shopRef: $shopRef,
+            source: IngestSource::OZON,
+            resourceType: $resourceType,
+            externalId: $externalId,
+            storagePath: sprintf('%s/%s.ndjson.gz', $companyId, $externalId),
+            hash: hash('sha256', $companyId.$externalId),
+            byteSize: 100,
+            fetchedAt: new \DateTimeImmutable('2026-06-15 10:00:00+00:00'),
+            syncJobId: 'job-'.$externalId,
+        );
+    }
+
+    private function transaction(
+        string $companyId,
+        string $rawRecordId,
+        string $externalId,
+        int $amountMinor,
+        TransactionType $type,
+        string $shopRef = 'shop-1',
+    ): FinancialTransaction {
+        return new FinancialTransaction(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            shopRef: $shopRef,
+            source: IngestSource::OZON,
+            externalId: $externalId,
+            externalUpdatedAt: new \DateTimeImmutable('2026-06-15 10:00:00+00:00'),
+            operationGroupId: Uuid::uuid7()->toString(),
+            type: $type,
+            direction: $amountMinor >= 0 ? TransactionDirection::IN : TransactionDirection::OUT,
+            money: Money::fromMinor($amountMinor, 'RUB'),
+            occurredAt: new \DateTimeImmutable('2026-06-15 10:00:00+00:00'),
+            rawRecordId: $rawRecordId,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function json(KernelBrowser $client): array
+    {
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode((string) $client->getResponse()->getContent(), true, flags: \JSON_THROW_ON_ERROR);
+
+        return $decoded;
+    }
+
+    private function loginWithActiveCompany(KernelBrowser $client, User $user, Company $company): void
+    {
+        $client->loginUser($user);
+        $this->setClientSessionValue($client, 'active_company_id', $company->getId());
+    }
+}

--- a/site/tests/Integration/Ingestion/Infrastructure/Query/VerificationQueriesTest.php
+++ b/site/tests/Integration/Ingestion/Infrastructure/Query/VerificationQueriesTest.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Infrastructure\Query;
+
+use App\Finance\Entity\PLMonthlySnapshot;
+use App\Finance\Enum\PLFlow;
+use App\Ingestion\Entity\FinancialTransaction;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Entity\NormalizationIssue;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\NormalizationIssueKind;
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+use App\Ingestion\Facade\IngestionFacade;
+use App\Ingestion\Infrastructure\Query\CoverageQuery;
+use App\Ingestion\Infrastructure\Query\FinancialSummaryQuery;
+use App\Ingestion\Infrastructure\Query\IssuesQuery;
+use App\Ingestion\Infrastructure\Query\ReconciliationQuery;
+use App\Marketplace\Entity\OzonTransactionTotalsCheck;
+use App\Shared\Domain\ValueObject\Money;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Builders\Finance\PLCategoryBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class VerificationQueriesTest extends IntegrationTestCase
+{
+    public function testCoverageAggregatesRawTransactionsAndOpenIssuesByShopAndResource(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $raw = $this->rawRecord(
+            companyId: $companyId,
+            shopRef: 'shop-1',
+            resourceType: 'ozon_seller_daily_report',
+            fetchedAt: new \DateTimeImmutable('2026-06-15 10:00:00+00:00'),
+            externalId: 'raw-1',
+        );
+        $otherShop = $this->rawRecord(
+            companyId: $companyId,
+            shopRef: 'shop-2',
+            resourceType: 'ozon_seller_daily_report',
+            fetchedAt: new \DateTimeImmutable('2026-06-15 11:00:00+00:00'),
+            externalId: 'raw-2',
+        );
+
+        $this->em->persist($raw);
+        $this->em->persist($otherShop);
+        $this->em->persist($this->transaction($companyId, $raw->getId(), 'tx-1', 1000, TransactionType::SALE));
+        $this->em->persist($this->transaction($companyId, $raw->getId(), 'tx-2', -200, TransactionType::COMMISSION));
+        $this->em->persist(new NormalizationIssue(
+            $companyId,
+            $raw->getId(),
+            null,
+            NormalizationIssueKind::SUM_MISMATCH,
+            ['hidden' => 'details'],
+        ));
+        $this->em->persist(new NormalizationIssue(
+            $companyId,
+            $otherShop->getId(),
+            null,
+            NormalizationIssueKind::MAPPER_FAILURE,
+            [],
+        ));
+        $this->em->flush();
+
+        /** @var CoverageQuery $query */
+        $query = self::getContainer()->get(CoverageQuery::class);
+        $cells = $query->heatmap(
+            $companyId,
+            'shop-1',
+            new \DateTimeImmutable('2026-06-01'),
+            new \DateTimeImmutable('2026-06-30'),
+        );
+
+        self::assertCount(1, $cells);
+        self::assertSame('2026-06-15', $cells[0]->date);
+        self::assertSame('shop-1', $cells[0]->shopRef);
+        self::assertSame(1, $cells[0]->rawCount);
+        self::assertSame(2, $cells[0]->txCount);
+        self::assertSame(1, $cells[0]->issueCount);
+    }
+
+    public function testReconciliationComparesShopCanonWithCompanyPeriodOzonControl(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $rawRecordId = Uuid::uuid7()->toString();
+
+        $this->em->persist($this->transaction($companyId, $rawRecordId, 'sale-1', 1000, TransactionType::SALE));
+        $this->em->persist($this->transaction($companyId, $rawRecordId, 'commission-1', -200, TransactionType::COMMISSION));
+        $this->em->persist($this->transaction($companyId, $rawRecordId, 'other-shop-sale', 999, TransactionType::SALE, 'shop-2'));
+
+        $check = new OzonTransactionTotalsCheck(
+            companyId: $companyId,
+            rawDocumentId: Uuid::uuid7()->toString(),
+            periodFrom: new \DateTimeImmutable('2026-06-01'),
+            periodTo: new \DateTimeImmutable('2026-06-30'),
+        );
+        $check->markOk([], ['total_minor' => 750], []);
+        $this->em->persist($check);
+        $this->em->flush();
+
+        /** @var ReconciliationQuery $query */
+        $query = self::getContainer()->get(ReconciliationQuery::class);
+
+        $summary = $query->summary($companyId, 'shop-1', 2026, 6);
+        $byType = $query->breakdownByType($companyId, 'shop-1', 2026, 6);
+
+        self::assertSame(800, $summary->canonTotalMinor);
+        self::assertSame(750, $summary->ozonControlTotalMinor);
+        self::assertSame(50, $summary->canonVsOzonDeltaMinor);
+        self::assertSame('RUB', $summary->currency);
+        self::assertSame(
+            ['commission' => -200, 'sale' => 1000],
+            array_column($byType, 'canonAmountMinor', 'type'),
+        );
+    }
+
+    public function testIssuesFacadeReturnsOnlyOpenHumanizedItemsWithPagination(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $raw = $this->rawRecord($companyId, 'shop-1', 'ozon_seller_daily_report', new \DateTimeImmutable(), 'issue-raw-1');
+        $otherShop = $this->rawRecord($companyId, 'shop-2', 'ozon_seller_daily_report', new \DateTimeImmutable(), 'issue-raw-2');
+        $resolved = new NormalizationIssue(
+            $companyId,
+            $raw->getId(),
+            Uuid::uuid7()->toString(),
+            NormalizationIssueKind::UNKNOWN_FIELD,
+            ['field' => 'x'],
+        );
+        $resolved->markResolved();
+
+        $this->em->persist($raw);
+        $this->em->persist($otherShop);
+        $this->em->persist(new NormalizationIssue(
+            $companyId,
+            $raw->getId(),
+            Uuid::uuid7()->toString(),
+            NormalizationIssueKind::SUM_MISMATCH,
+            ['raw' => 'must-not-leak'],
+        ));
+        $this->em->persist(new NormalizationIssue(
+            $companyId,
+            $otherShop->getId(),
+            null,
+            NormalizationIssueKind::MAPPER_FAILURE,
+            [],
+        ));
+        $this->em->persist($resolved);
+        $this->em->flush();
+
+        /** @var IssuesQuery $issuesQuery */
+        $issuesQuery = self::getContainer()->get(IssuesQuery::class);
+        self::assertSame(1, $issuesQuery->count($companyId, 'shop-1', null, null));
+
+        /** @var IngestionFacade $facade */
+        $facade = self::getContainer()->get(IngestionFacade::class);
+        $result = $facade->listIssues($companyId, 'shop-1', null, null, 1, 50);
+
+        self::assertSame(1, $result['meta']->total);
+        self::assertSame('sum_mismatch', $result['items'][0]->kind);
+        self::assertSame(
+            'Сумма операций не сходится с контрольной суммой источника',
+            $result['items'][0]->humanDescription,
+        );
+    }
+
+    public function testFinancialSummaryUsesOnlyRebuiltMonthlySnapshots(): void
+    {
+        $owner = UserBuilder::aUser()->withIndex(9001)->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId('11111111-1111-4111-8111-111111119001')
+            ->withOwner($owner)
+            ->build();
+        $incomeCategory = PLCategoryBuilder::aPLCategory()
+            ->withId('33333333-3333-4333-8333-333333339001')
+            ->forCompany($company)
+            ->withName('Продажи')
+            ->withFlow(PLFlow::INCOME)
+            ->build();
+        $expenseCategory = PLCategoryBuilder::aPLCategory()
+            ->withId('33333333-3333-4333-8333-333333339002')
+            ->forCompany($company)
+            ->withName('Комиссии')
+            ->withFlow(PLFlow::EXPENSE)
+            ->build();
+        $legacyCategory = PLCategoryBuilder::aPLCategory()
+            ->withId('33333333-3333-4333-8333-333333339003')
+            ->forCompany($company)
+            ->withName('Legacy')
+            ->withFlow(PLFlow::INCOME)
+            ->build();
+
+        $incomeSnapshot = new PLMonthlySnapshot(Uuid::uuid7()->toString(), $company, '2026-06', $incomeCategory);
+        $incomeSnapshot->setAmountIncome('123.45');
+        $incomeSnapshot->setRebuiltAt(new \DateTimeImmutable('2026-06-20 10:00:00+00:00'));
+
+        $expenseSnapshot = new PLMonthlySnapshot(Uuid::uuid7()->toString(), $company, '2026-06', $expenseCategory);
+        $expenseSnapshot->setAmountExpense('23.45');
+        $expenseSnapshot->setRebuiltAt(new \DateTimeImmutable('2026-06-20 10:00:00+00:00'));
+
+        $legacySnapshot = new PLMonthlySnapshot(Uuid::uuid7()->toString(), $company, '2026-06', $legacyCategory);
+        $legacySnapshot->setAmountIncome('999.99');
+
+        $this->em->persist($owner);
+        $this->em->persist($company);
+        $this->em->persist($incomeCategory);
+        $this->em->persist($expenseCategory);
+        $this->em->persist($legacyCategory);
+        $this->em->persist($incomeSnapshot);
+        $this->em->persist($expenseSnapshot);
+        $this->em->persist($legacySnapshot);
+        $this->em->flush();
+
+        /** @var FinancialSummaryQuery $query */
+        $query = self::getContainer()->get(FinancialSummaryQuery::class);
+
+        $byMonth = $query->byMonth($company->getId(), null, 2026, 6, 2026, 6);
+        $byCategory = $query->byCategory($company->getId(), null, 2026, 6);
+
+        self::assertCount(1, $byMonth);
+        self::assertSame(12345, $byMonth[0]->incomeMinor);
+        self::assertSame(2345, $byMonth[0]->expenseMinor);
+        self::assertSame(10000, $byMonth[0]->netMinor);
+        self::assertSame(
+            ['Комиссии' => 2345, 'Продажи' => 12345],
+            array_column($byCategory, 'amountMinor', 'categoryName'),
+        );
+    }
+
+    private function rawRecord(
+        string $companyId,
+        string $shopRef,
+        string $resourceType,
+        \DateTimeImmutable $fetchedAt,
+        string $externalId,
+    ): IngestRawRecord {
+        return new IngestRawRecord(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            shopRef: $shopRef,
+            source: IngestSource::OZON,
+            resourceType: $resourceType,
+            externalId: $externalId,
+            storagePath: sprintf('%s/%s.ndjson.gz', $companyId, $externalId),
+            hash: hash('sha256', $companyId.$externalId),
+            byteSize: 100,
+            fetchedAt: $fetchedAt,
+            syncJobId: 'job-'.$externalId,
+        );
+    }
+
+    private function transaction(
+        string $companyId,
+        string $rawRecordId,
+        string $externalId,
+        int $amountMinor,
+        TransactionType $type,
+        string $shopRef = 'shop-1',
+    ): FinancialTransaction {
+        return new FinancialTransaction(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            shopRef: $shopRef,
+            source: IngestSource::OZON,
+            externalId: $externalId,
+            externalUpdatedAt: new \DateTimeImmutable('2026-06-15 10:00:00+00:00'),
+            operationGroupId: Uuid::uuid7()->toString(),
+            type: $type,
+            direction: $amountMinor >= 0 ? TransactionDirection::IN : TransactionDirection::OUT,
+            money: Money::fromMinor($amountMinor, 'RUB'),
+            occurredAt: new \DateTimeImmutable('2026-06-15 10:00:00+00:00'),
+            rawRecordId: $rawRecordId,
+        );
+    }
+}

--- a/site/tests/Unit/Ingestion/Application/Service/IssueDescriptionFormatterTest.php
+++ b/site/tests/Unit/Ingestion/Application/Service/IssueDescriptionFormatterTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Application\Service;
+
+use App\Ingestion\Application\Service\IssueDescriptionFormatter;
+use App\Ingestion\Enum\NormalizationIssueKind;
+use PHPUnit\Framework\TestCase;
+
+final class IssueDescriptionFormatterTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{0: NormalizationIssueKind, 1: string}>
+     */
+    public static function issueDescriptions(): iterable
+    {
+        yield 'sum mismatch' => [
+            NormalizationIssueKind::SUM_MISMATCH,
+            'Сумма операций не сходится с контрольной суммой источника',
+        ];
+        yield 'mapper failure' => [
+            NormalizationIssueKind::MAPPER_FAILURE,
+            'Не удалось распознать операцию',
+        ];
+        yield 'unknown field' => [
+            NormalizationIssueKind::UNKNOWN_FIELD,
+            'В отчёте появилось неизвестное поле',
+        ];
+        yield 'currency mismatch' => [
+            NormalizationIssueKind::CURRENCY_MISMATCH,
+            'В операции смешаны разные валюты',
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('issueDescriptions')]
+    public function testHumanizesEveryIssueKind(NormalizationIssueKind $kind, string $expected): void
+    {
+        $formatter = new IssueDescriptionFormatter();
+
+        self::assertSame($expected, $formatter->humanize($kind, ['raw' => 'hidden']));
+    }
+}

--- a/site/tests/Unit/Ingestion/Application/Service/VerificationPeriodValidatorTest.php
+++ b/site/tests/Unit/Ingestion/Application/Service/VerificationPeriodValidatorTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Application\Service;
+
+use App\Ingestion\Application\Service\VerificationPeriodValidator;
+use App\Ingestion\Exception\InvalidPeriodException;
+use App\Ingestion\Exception\InvalidPeriodRangeException;
+use PHPUnit\Framework\TestCase;
+
+final class VerificationPeriodValidatorTest extends TestCase
+{
+    public function testParsesStrictDateRange(): void
+    {
+        $validator = new VerificationPeriodValidator();
+
+        [$from, $to] = $validator->parseDateRange('2026-06-01', '2026-06-30');
+
+        self::assertSame('2026-06-01', $from->format('Y-m-d'));
+        self::assertSame('2026-06-30', $to->format('Y-m-d'));
+    }
+
+    public function testRejectsMalformedDate(): void
+    {
+        $this->expectException(InvalidPeriodException::class);
+
+        (new VerificationPeriodValidator())->parseDate('2026-6-1');
+    }
+
+    public function testRejectsInvertedDateRange(): void
+    {
+        $this->expectException(InvalidPeriodRangeException::class);
+
+        (new VerificationPeriodValidator())->parseDateRange('2026-06-30', '2026-06-01');
+    }
+
+    public function testAcceptsValidYearMonth(): void
+    {
+        (new VerificationPeriodValidator())->assertYearMonth(2026, 6);
+
+        self::addToAssertionCount(1);
+    }
+
+    public function testRejectsInvalidYearMonth(): void
+    {
+        $this->expectException(InvalidPeriodException::class);
+
+        (new VerificationPeriodValidator())->assertYearMonth(2019, 12);
+    }
+
+    public function testRejectsInvertedMonthRange(): void
+    {
+        $this->expectException(InvalidPeriodRangeException::class);
+
+        (new VerificationPeriodValidator())->assertMonthRange(2026, 7, 2026, 6);
+    }
+}

--- a/site/tests/Unit/Ingestion/Infrastructure/Http/IngestionExceptionListenerTest.php
+++ b/site/tests/Unit/Ingestion/Infrastructure/Http/IngestionExceptionListenerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Infrastructure\Http;
+
+use App\Ingestion\Exception\InvalidPeriodRangeException;
+use App\Ingestion\Infrastructure\Http\IngestionExceptionListener;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+final class IngestionExceptionListenerTest extends TestCase
+{
+    public function testFormatsIngestionApiExceptionForIngestionApiPath(): void
+    {
+        $event = new ExceptionEvent(
+            $this->createMock(HttpKernelInterface::class),
+            Request::create('/api/ingestion/verification/coverage'),
+            HttpKernelInterface::MAIN_REQUEST,
+            new InvalidPeriodRangeException(),
+        );
+
+        (new IngestionExceptionListener())->onKernelException($event);
+
+        $response = $event->getResponse();
+        self::assertNotNull($response);
+        self::assertSame(422, $response->getStatusCode());
+        self::assertSame(
+            [
+                'error' => [
+                    'code' => 'invalid_period_range',
+                    'message' => 'Некорректный диапазон периода',
+                ],
+            ],
+            json_decode((string) $response->getContent(), true, flags: \JSON_THROW_ON_ERROR),
+        );
+    }
+
+    public function testIgnoresNonIngestionPath(): void
+    {
+        $event = new ExceptionEvent(
+            $this->createMock(HttpKernelInterface::class),
+            Request::create('/api/marketplace'),
+            HttpKernelInterface::MAIN_REQUEST,
+            new InvalidPeriodRangeException(),
+        );
+
+        (new IngestionExceptionListener())->onKernelException($event);
+
+        self::assertNull($event->getResponse());
+    }
+}


### PR DESCRIPTION
## Summary
- Added backend verification API endpoints for ingestion coverage, reconciliation, issues, and financial summary.
- Added query services, DTOs, period validation, API exception mapping, and issue description formatting.
- Extended ingestion facade and refreshed generated API TypeScript schema.
- Added unit, integration, functional, and tenant-isolation coverage plus task stage/handoff documentation.
- Added frontend implementation task spec and corrected it after review: API response fields match `schema.d.ts`, Vite entrypoints are explicitly registered through `site/vite.config.js`, and unrelated `docs/tasks/fix/*` artifacts are preserved.

## Why
The UI client needs read-only backend endpoints to inspect ingestion verification state without querying internal domain tables directly, plus a frontend task spec that matches the generated API contract and this repository's Vite wiring.

## Review Follow-ups Addressed
- Replaced `byType` / `byMonth` / `byCategory` frontend task references with `by_type` / `by_month` / `by_category`.
- Replaced the automatic Vite entrypoint assumption with explicit `site/vite.config.js` `build.rollupOptions.input` instructions.
- Restored `docs/tasks/fix/*` locally so those unrelated audit/task artifacts are not removed by this PR update.

## Validation
- `make site-test-unit` passed: 1082 tests, with existing warning/deprecation output.
- Focused ingestion unit, integration, and functional tests passed.
- Scoped PHP-CS-Fixer dry-run for changed task files passed.
- `git diff --check` passed.
- Frontend task doc review grep passed: no stale `entries`, camelCase response fields, `vite.config.ts`, or `CLAUDE_frontend.md` references remain.
- OpenAPI dump and `openapi-typescript` generation passed via container run.

## Known Non-Blocking Environment / Existing Issues
- `make site-test-integration` failed in unrelated existing suites outside this task.
- `make site-cs-check` failed on many pre-existing files outside this task.
- `make api-types` could not use `docker compose exec` because the target container was not running/killed; equivalent container-run generation passed.
- `api-doc-lint` could not run because no Spectral ruleset was present.