### PR TITLE
[codex] add ingestion backfill CLI commands

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -110,6 +110,7 @@
 - `SyncJobStatus` owns the explicit state transition matrix. Entity methods reject invalid transitions and terminal jobs cannot be reopened.
 - Repository reads require explicit `companyId`; the Doctrine `company` filter is an additional guard, not the only tenant boundary.
 - `SyncFacade::startBackfill()` creates a parent job, splits it into 7-day chunks by default, and dispatches chunk messages after DB flush.
+- `SyncFacade::startIncremental()` creates one non-windowed incremental job and dispatches one `RunSyncChunkMessage` after DB flush; the worker reads the shared cursor for that `(companyId, connectionRef, resourceType, shopRef)`.
 - `RunSyncChunkHandler` resolves a `SourceConnectorInterface` through `ConnectorRegistry`, pulls one chunk, stores raw payload through `RawStorageFacade`, dispatches `NormalizeRawRecordMessage`, advances cursor, and finalizes the job.
 - `ingest_fetch` uses the sync transport DSN for external source fetches; `ingest_normalize` uses the pipeline DSN for local normalization work.
 

--- a/docker/cron/app.cron
+++ b/docker/cron/app.cron
@@ -84,6 +84,9 @@
 # Страховка для зависших PENDING raw-records: повторно ставит нормализацию в очередь.
 */10 * * * * cd /app && php bin/console app:ingestion:normalize-pending --limit=50 --no-interaction --quiet >> /proc/1/fd/1 2>> /proc/1/fd/2
 
+# Ежедневный инкрементальный запуск нового Ingestion pipeline.
+0 3 * * * cd /app && php bin/console app:ingestion:run-incremental --no-interaction --quiet
+
 # Ежедневно в 02:10: снапшоты остатков по счетам
 #10 2 * * * php /app/bin/console app:money-account:snapshot --no-interaction
 

--- a/docs/tasks/TASK-FIX-05/plan.md
+++ b/docs/tasks/TASK-FIX-05/plan.md
@@ -1,0 +1,53 @@
+# TASK-FIX-05 — Ingestion backfill/incremental CLI plan
+
+## Summary
+
+Add CLI entrypoints for the existing Ingestion pipeline:
+
+- `app:ingestion:start-backfill` starts Ozon backfill jobs for one company connection.
+- `app:ingestion:run-incremental` starts incremental jobs only for active Ozon seller connections that already have cursors.
+- Cron is a separate high-risk stage because it changes production scheduling.
+
+## Stages
+
+### Stage 1: Backfill CLI
+
+Risk: MEDIUM.
+
+- Add `App\Ingestion\Command\StartBackfillCommand`.
+- Resolve Ozon resource types and shop reference.
+- Support `--dry-run`, UUID validation, `days-back` bounds, and active-backfill warnings.
+
+### Stage 2: Incremental CLI
+
+Risk: MEDIUM.
+
+- Add incremental application DTO/action and `SyncFacade::startIncremental()`.
+- Add cursor repository lookup by resource.
+- Add `App\Ingestion\Command\RunIncrementalCommand`.
+- Default to Ozon only; skip Wildberries as out of scope.
+
+### Stage 3: Cron
+
+Risk: HIGH.
+
+- Add the daily `app:ingestion:run-incremental` cron entry after owner review.
+
+### Stage 4: Tests and handoff
+
+Risk: LOW.
+
+- Add command integration tests for dry-run, dispatch, duplicate active jobs, cursor skipping, and company filtering.
+- Run focused tests, unit tests, CS check, and final diff review.
+
+## Checks
+
+- Targeted Ingestion command integration tests.
+- `make site-test-unit`
+- `make site-cs-check`
+- `lint:container --env=prod` if available in the project.
+
+## Assumptions
+
+- No DB migration, public HTTP API change, Messenger routing change, dependency install, or live external API call is part of this task.
+- Wildberries incremental is out of scope for TASK-FIX-05.

--- a/docs/tasks/TASK-FIX-05/stages/stage-1.md
+++ b/docs/tasks/TASK-FIX-05/stages/stage-1.md
@@ -1,0 +1,31 @@
+### Stage 1: Backfill CLI — DONE
+
+**Risk:** MEDIUM
+**Next action:** continue to Stage 2
+
+#### What was done
+- Added `app:ingestion:start-backfill`.
+- Added UUID/source/resource validation, `--days-back` bounds, `--dry-run`, Ozon shop discovery, and active-backfill warning behavior.
+- Wired the command to existing `SyncFacade::startBackfill()`.
+
+#### Files changed
+- `site/src/Ingestion/Command/StartBackfillCommand.php` — new
+- `site/tests/Integration/Ingestion/Command/StartBackfillCommandTest.php` — new
+
+#### Self-review
+- [x] Scope compliance
+- [x] Project patterns followed
+- [x] No forbidden actions
+- [x] Security/company access checked
+- [x] Tests/checks run
+- [x] Documentation updated or N/A
+
+#### Checks
+- `docker compose run --rm -e APP_ENV=test -e APP_DEBUG=1 site-php-cli php -d memory_limit=1G bin/phpunit --testsuite integration --filter 'StartBackfillCommandTest|RunIncrementalCommandTest'` — passed
+- `docker compose run --rm site-php-cli ./vendor/bin/php-cs-fixer fix --dry-run --diff --using-cache=no --config=.php-cs-fixer.php <touched-files>` — passed
+
+#### Risks / reviewer focus
+- The command supports Ozon resources only because no production WB ingestion connector/resource list exists in this task.
+
+#### Open questions
+- none

--- a/docs/tasks/TASK-FIX-05/stages/stage-2-review-fixes.md
+++ b/docs/tasks/TASK-FIX-05/stages/stage-2-review-fixes.md
@@ -1,0 +1,36 @@
+### Stage 2 Review Fixes: Ingestion CLI correctness — DONE
+
+**Risk:** MEDIUM
+**Next action:** STOP before Stage 3 cron, owner review required
+
+#### What was done
+- Fixed Ozon non-windowed incremental pulls so daily report and realization return the next cursor after fetched work.
+- Changed incremental company limiting to collect eligible cursor work first and select oldest cursor groups, avoiding deterministic starvation of later companies.
+- Removed `ozon_seller_realization` from default/manual backfill support until month-aligned chunking is implemented separately.
+
+#### Files changed
+- `site/src/Ingestion/Application/Source/Ozon/OzonSellerReportConnector.php` — modified
+- `site/src/Ingestion/Command/RunIncrementalCommand.php` — modified
+- `site/src/Ingestion/Command/StartBackfillCommand.php` — modified
+- `site/tests/Integration/Ingestion/Command/*CommandTest.php` — modified
+- `site/tests/Unit/Ingestion/Application/Source/Ozon/OzonSellerReportConnectorTest.php` — modified
+
+#### Self-review
+- [x] Scope compliance
+- [x] Project patterns followed
+- [x] No forbidden actions
+- [x] Security/company access checked
+- [x] Tests/checks run
+- [x] Documentation updated or N/A
+
+#### Checks
+- `docker compose run --rm -e APP_ENV=test -e APP_DEBUG=1 site-php-cli php -d memory_limit=1G bin/phpunit --testsuite integration --filter 'StartBackfillCommandTest|RunIncrementalCommandTest'` — passed, 10 tests / 47 assertions
+- `docker compose run --rm site-php-cli php -d memory_limit=1G bin/phpunit --testsuite unit --filter OzonSellerReportConnectorTest` — passed, 4 tests / 17 assertions
+- `docker compose run --rm site-php-cli ./vendor/bin/php-cs-fixer fix --dry-run --diff --using-cache=no --config=.php-cs-fixer.php <touched-files>` — passed
+
+#### Risks / reviewer focus
+- Daily incremental cursor is capped at yesterday; repeated same-day cron runs skip daily work that is not due yet.
+- Realization backfill is intentionally disabled in this PR until monthly chunking is designed.
+
+#### Open questions
+- Stage 3 cron entry still needs owner approval before implementation.

--- a/docs/tasks/TASK-FIX-05/stages/stage-2.md
+++ b/docs/tasks/TASK-FIX-05/stages/stage-2.md
@@ -1,0 +1,44 @@
+### Stage 2: Incremental CLI — DONE
+
+**Risk:** MEDIUM
+**Next action:** STOP before Stage 3 cron, owner review required
+
+#### What was done
+- Added incremental application DTO/action and `SyncFacade::startIncremental()`.
+- Added cursor lookup by `(companyId, connectionRef, resourceType)`.
+- Added `app:ingestion:run-incremental` for active Ozon seller connections with existing non-empty cursors.
+- Skips Wildberries incremental as out of scope.
+- Updated `ARCHITECTURE.md` for the new `SyncFacade` method.
+
+#### Files changed
+- `site/src/Ingestion/Application/Action/StartIncrementalAction.php` — new
+- `site/src/Ingestion/Application/Command/StartIncrementalCommand.php` — new
+- `site/src/Ingestion/Command/RunIncrementalCommand.php` — new
+- `site/src/Ingestion/Facade/SyncFacade.php` — modified
+- `site/src/Ingestion/Repository/IngestCursorRepository.php` — modified
+- `site/tests/Integration/Ingestion/Command/RunIncrementalCommandTest.php` — new
+- `ARCHITECTURE.md` — modified
+
+#### Self-review
+- [x] Scope compliance
+- [x] Project patterns followed
+- [x] No forbidden actions
+- [x] Security/company access checked
+- [x] Tests/checks run
+- [x] Documentation updated or N/A
+
+#### Checks
+- `make site-test-prepare` — failed on pre-existing dirty test DB migration state (`bot_links.updated_at` already existed)
+- `make site-test-db-rebuild` — passed
+- `docker compose run --rm -e APP_ENV=test -e APP_DEBUG=1 site-php-cli php -d memory_limit=1G bin/phpunit --testsuite integration --filter 'StartBackfillCommandTest|RunIncrementalCommandTest'` — passed, 8 tests / 49 assertions
+- `make site-test-unit` — passed, PHPUnit reported 1 warning and 1 deprecation
+- `make site-cs-check` — failed on pre-existing project-wide CS drift outside this task
+- `docker compose run --rm site-php-cli ./vendor/bin/php-cs-fixer fix --dry-run --diff --using-cache=no --config=.php-cs-fixer.php <touched-files>` — passed
+- `docker compose run --rm site-php-cli php bin/console lint:container --env=prod` — passed with existing deprecation notices
+
+#### Risks / reviewer focus
+- Incremental dispatch starts only when a cursor row exists and `cursorValue` is non-empty; this avoids accidental hot-rewind pulls.
+- `ActiveBackfillExistsException` is reused as the existing active resource guard exception, including for incremental jobs.
+
+#### Open questions
+- Stage 3 cron entry needs owner approval before implementation.

--- a/docs/tasks/TASK-FIX-05/stages/stage-3-cron.md
+++ b/docs/tasks/TASK-FIX-05/stages/stage-3-cron.md
@@ -1,0 +1,31 @@
+### Stage 3: Ingestion incremental cron — DONE
+
+**Risk:** HIGH
+**Next action:** STOP, owner review required
+
+#### What was done
+- Added the daily cron entry for `app:ingestion:run-incremental` at 03:00.
+
+#### Files changed
+- `docker/cron/app.cron` — modified
+- `docs/tasks/TASK-FIX-05/stages/stage-3-cron.md` — new
+
+#### Self-review
+- [x] Scope compliance
+- [x] Project patterns followed
+- [x] No forbidden actions
+- [x] Security/company access checked
+- [x] Tests/checks run
+- [x] Documentation updated or N/A
+
+#### Checks
+- `git diff --check` — passed
+- `docker compose run --rm site-php-cli php bin/console cache:clear --env=prod` — passed, with existing deprecation notices
+- `docker compose run --rm site-php-cli php bin/console list app:ingestion --env=prod | rg 'run-incremental'` — passed
+- `docker compose run --rm site-php-cli php bin/console app:ingestion:run-incremental --help --env=prod` — passed
+
+#### Risks / reviewer focus
+- This is a production scheduler change. Confirm the 03:00 runtime is still the desired window relative to legacy sync jobs.
+
+#### Open questions
+- none

--- a/site/src/Ingestion/Application/Action/StartIncrementalAction.php
+++ b/site/src/Ingestion/Application/Action/StartIncrementalAction.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Action;
+
+use App\Ingestion\Application\Command\StartIncrementalCommand;
+use App\Ingestion\Entity\SyncJob;
+use App\Ingestion\Enum\SyncJobKind;
+use App\Ingestion\Exception\ActiveBackfillExistsException;
+use App\Ingestion\Message\RunSyncChunkMessage;
+use App\Ingestion\Repository\SyncJobRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final readonly class StartIncrementalAction
+{
+    public function __construct(
+        private SyncJobRepository $syncJobRepository,
+        private EntityManagerInterface $entityManager,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    public function __invoke(StartIncrementalCommand $command): string
+    {
+        $activeJob = $this->syncJobRepository->findLatestForResource(
+            $command->companyId,
+            $command->connectionRef,
+            $command->resourceType,
+            $command->shopRef,
+        );
+
+        if (null !== $activeJob) {
+            throw new ActiveBackfillExistsException('Sync job for requested resource is already active.');
+        }
+
+        $job = new SyncJob(
+            companyId: $command->companyId,
+            connectionRef: $command->connectionRef,
+            source: $command->source,
+            resourceType: $command->resourceType,
+            kind: SyncJobKind::INCREMENTAL,
+            shopRef: $command->shopRef,
+        );
+
+        $this->entityManager->persist($job);
+        $this->entityManager->flush();
+
+        $this->messageBus->dispatch(new RunSyncChunkMessage($command->companyId, $job->getId()));
+
+        return $job->getId();
+    }
+}

--- a/site/src/Ingestion/Application/Command/StartIncrementalCommand.php
+++ b/site/src/Ingestion/Application/Command/StartIncrementalCommand.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Command;
+
+use App\Ingestion\Enum\IngestSource;
+use Webmozart\Assert\Assert;
+
+final readonly class StartIncrementalCommand
+{
+    public function __construct(
+        public string $companyId,
+        public string $connectionRef,
+        public IngestSource $source,
+        public string $resourceType,
+        public string $shopRef,
+    ) {
+        Assert::uuid($this->companyId);
+        Assert::notEmpty($this->connectionRef);
+        Assert::notEmpty($this->resourceType);
+    }
+}

--- a/site/src/Ingestion/Application/Source/Ozon/OzonSellerReportConnector.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonSellerReportConnector.php
@@ -112,7 +112,7 @@ final readonly class OzonSellerReportConnector implements SourceConnectorInterfa
         }
 
         $windowHasMore = null !== $request->windowTo && $to < $request->windowTo;
-        $nextCursor = $windowHasMore ? $to->modify('+1 day')->format('Y-m-d') : null;
+        $nextCursor = $windowHasMore || $this->isIncremental($request) ? $to->modify('+1 day')->format('Y-m-d') : null;
 
         return new PullResult(
             rawBatch: new RawBatch(
@@ -161,7 +161,7 @@ final readonly class OzonSellerReportConnector implements SourceConnectorInterfa
                 fetchedAt: new \DateTimeImmutable(),
                 rows: $rows,
             ),
-            nextCursorValue: $windowHasMore ? $nextMonth->format('Y-m-01') : null,
+            nextCursorValue: $windowHasMore || $this->isIncremental($request) ? $nextMonth->format('Y-m-01') : null,
             hasMore: $windowHasMore,
         );
     }
@@ -180,6 +180,14 @@ final readonly class OzonSellerReportConnector implements SourceConnectorInterfa
         $to = null !== $request->windowTo && $request->windowTo < $maxTo
             ? $request->windowTo
             : $maxTo;
+
+        if (null === $request->windowTo && null !== $request->cursorValue && '' !== $request->cursorValue) {
+            $yesterday = (new \DateTimeImmutable('today'))->modify('-1 day')->setTime(23, 59, 59);
+            if ($yesterday < $to) {
+                $to = $yesterday;
+            }
+        }
+
         $to = $to->setTime(23, 59, 59);
 
         if ($from > $to) {
@@ -196,5 +204,13 @@ final readonly class OzonSellerReportConnector implements SourceConnectorInterfa
             : ($request->windowFrom ?? new \DateTimeImmutable('first day of previous month'));
 
         return $date->modify('first day of this month')->setTime(0, 0);
+    }
+
+    private function isIncremental(PullRequest $request): bool
+    {
+        return null !== $request->cursorValue
+            && '' !== $request->cursorValue
+            && null === $request->windowFrom
+            && null === $request->windowTo;
     }
 }

--- a/site/src/Ingestion/Command/RunIncrementalCommand.php
+++ b/site/src/Ingestion/Command/RunIncrementalCommand.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Command;
+
+use App\Ingestion\Application\Command\StartIncrementalCommand as StartIncrementalApplicationCommand;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Exception\ActiveBackfillExistsException;
+use App\Ingestion\Facade\SyncFacade;
+use App\Ingestion\Repository\IngestCursorRepository;
+use App\Marketplace\Infrastructure\Query\ActiveSellerConnectionsQuery;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\LockableTrait;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Webmozart\Assert\Assert;
+
+#[AsCommand(
+    name: 'app:ingestion:run-incremental',
+    description: 'Dispatches ingestion incremental jobs for active seller connections with cursors.',
+)]
+final class RunIncrementalCommand extends Command
+{
+    use LockableTrait;
+
+    /**
+     * @var list<string>
+     */
+    private const OZON_RESOURCE_TYPES = [
+        OzonResourceType::DAILY_REPORT,
+        OzonResourceType::REALIZATION,
+    ];
+
+    public function __construct(
+        private readonly ActiveSellerConnectionsQuery $connectionsQuery,
+        private readonly IngestCursorRepository $cursorRepository,
+        private readonly SyncFacade $syncFacade,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('source', null, InputOption::VALUE_REQUIRED, 'Optional source filter. Only "ozon" is supported now.')
+            ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Optional company UUID filter.')
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Maximum companies per tick.', 50);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        if (!$this->lock()) {
+            $io->warning('Command is already running in another process.');
+
+            return Command::SUCCESS;
+        }
+
+        try {
+            return $this->runIncremental($input, $io);
+        } finally {
+            $this->release();
+        }
+    }
+
+    private function runIncremental(InputInterface $input, SymfonyStyle $io): int
+    {
+        try {
+            $source = $this->source($input);
+            $companyId = $this->companyId($input);
+            $limit = $this->limit($input);
+        } catch (\Throwable $exception) {
+            $io->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        if (IngestSource::OZON !== $source) {
+            $io->warning(sprintf('Incremental ingestion for "%s" is not supported yet.', $source->value));
+            $this->logger->info('Ingestion incremental skipped because source is not supported yet.', [
+                'source' => $source->value,
+                'companyId' => $companyId,
+            ]);
+
+            return Command::SUCCESS;
+        }
+
+        $connections = $this->connectionsQuery->execute();
+        $processedCompanies = [];
+        $dispatched = 0;
+        $skippedWithoutCursor = 0;
+        $skippedActive = 0;
+        $failed = 0;
+
+        foreach ($connections as $connection) {
+            if (IngestSource::OZON->value !== (string) $connection['marketplace']) {
+                continue;
+            }
+
+            $connectionCompanyId = (string) $connection['company_id'];
+            if (null !== $companyId && $connectionCompanyId !== $companyId) {
+                continue;
+            }
+
+            if (!isset($processedCompanies[$connectionCompanyId])) {
+                if (count($processedCompanies) >= $limit) {
+                    break;
+                }
+
+                $processedCompanies[$connectionCompanyId] = true;
+            }
+
+            $connectionRef = (string) $connection['id'];
+
+            foreach (self::OZON_RESOURCE_TYPES as $resourceType) {
+                $cursors = $this->cursorRepository->findByResource($connectionCompanyId, $connectionRef, $resourceType);
+                if ([] === $cursors) {
+                    ++$skippedWithoutCursor;
+                    continue;
+                }
+
+                foreach ($cursors as $cursor) {
+                    if ('' === $cursor->getCursorValue()) {
+                        ++$skippedWithoutCursor;
+                        continue;
+                    }
+
+                    try {
+                        $this->syncFacade->startIncremental(new StartIncrementalApplicationCommand(
+                            companyId: $connectionCompanyId,
+                            connectionRef: $connectionRef,
+                            source: IngestSource::OZON,
+                            resourceType: $resourceType,
+                            shopRef: $cursor->getShopRef(),
+                        ));
+
+                        ++$dispatched;
+                    } catch (ActiveBackfillExistsException) {
+                        ++$skippedActive;
+                        $io->warning(sprintf(
+                            'Incremental already running for companyId=%s resourceType=%s shopRef=%s.',
+                            $connectionCompanyId,
+                            $resourceType,
+                            $cursor->getShopRef(),
+                        ));
+                    } catch (\Throwable $exception) {
+                        ++$failed;
+                        $this->logger->warning('Failed to dispatch ingestion incremental job.', [
+                            'companyId' => $connectionCompanyId,
+                            'connectionRef' => $connectionRef,
+                            'source' => IngestSource::OZON->value,
+                            'resourceType' => $resourceType,
+                            'shopRef' => $cursor->getShopRef(),
+                            'exceptionClass' => $exception::class,
+                            'errorMessage' => $exception->getMessage(),
+                        ]);
+                    }
+                }
+            }
+        }
+
+        $this->logger->info('Dispatched ingestion incremental jobs.', [
+            'dispatched' => $dispatched,
+            'failed' => $failed,
+            'skippedWithoutCursor' => $skippedWithoutCursor,
+            'skippedActive' => $skippedActive,
+            'companyLimit' => $limit,
+            'companyId' => $companyId,
+            'source' => $source->value,
+        ]);
+
+        $io->success(sprintf(
+            'Dispatched %d incremental jobs (skipped without cursor: %d, active: %d, failed: %d).',
+            $dispatched,
+            $skippedWithoutCursor,
+            $skippedActive,
+            $failed,
+        ));
+
+        return 0 === $dispatched && $failed > 0 ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    private function source(InputInterface $input): IngestSource
+    {
+        $value = trim((string) $input->getOption('source'));
+        if ('' === $value) {
+            return IngestSource::OZON;
+        }
+
+        $source = IngestSource::tryFrom($value);
+        if (null === $source) {
+            throw new \InvalidArgumentException(sprintf('Unsupported ingestion source "%s".', $value));
+        }
+
+        return $source;
+    }
+
+    private function companyId(InputInterface $input): ?string
+    {
+        $value = trim((string) $input->getOption('company-id'));
+        if ('' === $value) {
+            return null;
+        }
+
+        Assert::uuid($value, 'Invalid --company-id UUID.');
+
+        return $value;
+    }
+
+    private function limit(InputInterface $input): int
+    {
+        $value = (string) $input->getOption('limit');
+        if (!ctype_digit($value)) {
+            throw new \InvalidArgumentException('The --limit option must be an integer from 1 to 500.');
+        }
+
+        $limit = (int) $value;
+        if ($limit < 1 || $limit > 500) {
+            throw new \InvalidArgumentException('The --limit option must be an integer from 1 to 500.');
+        }
+
+        return $limit;
+    }
+}

--- a/site/src/Ingestion/Command/RunIncrementalCommand.php
+++ b/site/src/Ingestion/Command/RunIncrementalCommand.php
@@ -94,9 +94,10 @@ final class RunIncrementalCommand extends Command
         }
 
         $connections = $this->connectionsQuery->execute();
-        $processedCompanies = [];
+        $eligibleWork = [];
         $dispatched = 0;
         $skippedWithoutCursor = 0;
+        $skippedNotDue = 0;
         $skippedActive = 0;
         $failed = 0;
 
@@ -108,14 +109,6 @@ final class RunIncrementalCommand extends Command
             $connectionCompanyId = (string) $connection['company_id'];
             if (null !== $companyId && $connectionCompanyId !== $companyId) {
                 continue;
-            }
-
-            if (!isset($processedCompanies[$connectionCompanyId])) {
-                if (count($processedCompanies) >= $limit) {
-                    break;
-                }
-
-                $processedCompanies[$connectionCompanyId] = true;
             }
 
             $connectionRef = (string) $connection['id'];
@@ -133,36 +126,69 @@ final class RunIncrementalCommand extends Command
                         continue;
                     }
 
-                    try {
-                        $this->syncFacade->startIncremental(new StartIncrementalApplicationCommand(
-                            companyId: $connectionCompanyId,
-                            connectionRef: $connectionRef,
-                            source: IngestSource::OZON,
-                            resourceType: $resourceType,
-                            shopRef: $cursor->getShopRef(),
-                        ));
-
-                        ++$dispatched;
-                    } catch (ActiveBackfillExistsException) {
-                        ++$skippedActive;
-                        $io->warning(sprintf(
-                            'Incremental already running for companyId=%s resourceType=%s shopRef=%s.',
-                            $connectionCompanyId,
-                            $resourceType,
-                            $cursor->getShopRef(),
-                        ));
-                    } catch (\Throwable $exception) {
-                        ++$failed;
-                        $this->logger->warning('Failed to dispatch ingestion incremental job.', [
-                            'companyId' => $connectionCompanyId,
-                            'connectionRef' => $connectionRef,
-                            'source' => IngestSource::OZON->value,
-                            'resourceType' => $resourceType,
-                            'shopRef' => $cursor->getShopRef(),
-                            'exceptionClass' => $exception::class,
-                            'errorMessage' => $exception->getMessage(),
-                        ]);
+                    if (!$this->cursorHasDueWork($resourceType, $cursor->getCursorValue())) {
+                        ++$skippedNotDue;
+                        continue;
                     }
+
+                    $sortAt = $cursor->getLastFetchedAt() ?? $cursor->getUpdatedAt();
+                    $eligibleWork[$connectionCompanyId] ??= [
+                        'companyId' => $connectionCompanyId,
+                        'sortAt' => $sortAt,
+                        'jobs' => [],
+                    ];
+                    if ($sortAt < $eligibleWork[$connectionCompanyId]['sortAt']) {
+                        $eligibleWork[$connectionCompanyId]['sortAt'] = $sortAt;
+                    }
+                    $eligibleWork[$connectionCompanyId]['jobs'][] = [
+                        'connectionRef' => $connectionRef,
+                        'resourceType' => $resourceType,
+                        'shopRef' => $cursor->getShopRef(),
+                    ];
+                }
+            }
+        }
+
+        $eligibleWork = array_values($eligibleWork);
+        usort(
+            $eligibleWork,
+            static fn (array $left, array $right): int => $left['sortAt'] <=> $right['sortAt']
+                ?: $left['companyId'] <=> $right['companyId'],
+        );
+
+        foreach (array_slice($eligibleWork, 0, $limit) as $companyWork) {
+            $connectionCompanyId = $companyWork['companyId'];
+
+            foreach ($companyWork['jobs'] as $job) {
+                try {
+                    $this->syncFacade->startIncremental(new StartIncrementalApplicationCommand(
+                        companyId: $connectionCompanyId,
+                        connectionRef: $job['connectionRef'],
+                        source: IngestSource::OZON,
+                        resourceType: $job['resourceType'],
+                        shopRef: $job['shopRef'],
+                    ));
+
+                    ++$dispatched;
+                } catch (ActiveBackfillExistsException) {
+                    ++$skippedActive;
+                    $io->warning(sprintf(
+                        'Incremental already running for companyId=%s resourceType=%s shopRef=%s.',
+                        $connectionCompanyId,
+                        $job['resourceType'],
+                        $job['shopRef'],
+                    ));
+                } catch (\Throwable $exception) {
+                    ++$failed;
+                    $this->logger->warning('Failed to dispatch ingestion incremental job.', [
+                        'companyId' => $connectionCompanyId,
+                        'connectionRef' => $job['connectionRef'],
+                        'source' => IngestSource::OZON->value,
+                        'resourceType' => $job['resourceType'],
+                        'shopRef' => $job['shopRef'],
+                        'exceptionClass' => $exception::class,
+                        'errorMessage' => $exception->getMessage(),
+                    ]);
                 }
             }
         }
@@ -171,6 +197,7 @@ final class RunIncrementalCommand extends Command
             'dispatched' => $dispatched,
             'failed' => $failed,
             'skippedWithoutCursor' => $skippedWithoutCursor,
+            'skippedNotDue' => $skippedNotDue,
             'skippedActive' => $skippedActive,
             'companyLimit' => $limit,
             'companyId' => $companyId,
@@ -178,9 +205,10 @@ final class RunIncrementalCommand extends Command
         ]);
 
         $io->success(sprintf(
-            'Dispatched %d incremental jobs (skipped without cursor: %d, active: %d, failed: %d).',
+            'Dispatched %d incremental jobs (skipped without cursor: %d, not due: %d, active: %d, failed: %d).',
             $dispatched,
             $skippedWithoutCursor,
+            $skippedNotDue,
             $skippedActive,
             $failed,
         ));
@@ -228,5 +256,22 @@ final class RunIncrementalCommand extends Command
         }
 
         return $limit;
+    }
+
+    private function cursorHasDueWork(string $resourceType, string $cursorValue): bool
+    {
+        if (OzonResourceType::DAILY_REPORT !== $resourceType) {
+            return true;
+        }
+
+        try {
+            $cursorDate = (new \DateTimeImmutable($cursorValue))->setTime(0, 0);
+        } catch (\Throwable) {
+            return true;
+        }
+
+        $yesterday = (new \DateTimeImmutable('today'))->modify('-1 day')->setTime(0, 0);
+
+        return $cursorDate <= $yesterday;
     }
 }

--- a/site/src/Ingestion/Command/StartBackfillCommand.php
+++ b/site/src/Ingestion/Command/StartBackfillCommand.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Command;
+
+use App\Ingestion\Application\Command\StartBackfillCommand as StartBackfillApplicationCommand;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Domain\Service\ConnectorRegistry;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Exception\ActiveBackfillExistsException;
+use App\Ingestion\Exception\ConnectorAuthException;
+use App\Ingestion\Facade\SyncFacade;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Webmozart\Assert\Assert;
+
+#[AsCommand(
+    name: 'app:ingestion:start-backfill',
+    description: 'Starts ingestion backfill jobs for one company connection.',
+)]
+final class StartBackfillCommand extends Command
+{
+    /**
+     * @var array<string, list<string>>
+     */
+    private const RESOURCE_TYPES_BY_SOURCE = [
+        'ozon' => [
+            OzonResourceType::DAILY_REPORT,
+            OzonResourceType::REALIZATION,
+        ],
+    ];
+
+    public function __construct(
+        private readonly SyncFacade $syncFacade,
+        private readonly ConnectorRegistry $connectorRegistry,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Company UUID.')
+            ->addOption('connection-ref', null, InputOption::VALUE_REQUIRED, 'Marketplace connection UUID.')
+            ->addOption('source', null, InputOption::VALUE_REQUIRED, 'Ingestion source, for example "ozon".')
+            ->addOption('days-back', null, InputOption::VALUE_REQUIRED, 'Backfill depth in days, 1..365.', 30)
+            ->addOption('shop-ref', null, InputOption::VALUE_REQUIRED, 'Optional concrete shop reference.')
+            ->addOption('resource-type', null, InputOption::VALUE_REQUIRED, 'Optional concrete resource type.')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Print planned jobs without starting them.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        try {
+            $companyId = $this->requiredUuidOption($input, 'company-id');
+            $connectionRef = $this->requiredUuidOption($input, 'connection-ref');
+            $source = $this->source($input);
+            $daysBack = $this->daysBack($input);
+            $resourceTypes = $this->resourceTypes($source, $input);
+            $shopRef = $this->shopRef($source, $companyId, $connectionRef, $input);
+        } catch (ConnectorAuthException) {
+            $io->error('Auth failed: check credentials for connection.');
+
+            return Command::FAILURE;
+        } catch (\Throwable $exception) {
+            $io->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $windowTo = (new \DateTimeImmutable('today'))->modify('-1 day');
+        $windowFrom = (new \DateTimeImmutable('today'))->modify(sprintf('-%d days', $daysBack));
+
+        if ((bool) $input->getOption('dry-run')) {
+            $this->printDryRun($io, $companyId, $connectionRef, $source, $shopRef, $resourceTypes, $windowFrom, $windowTo);
+
+            return Command::SUCCESS;
+        }
+
+        $started = 0;
+        $failed = 0;
+
+        foreach ($resourceTypes as $resourceType) {
+            try {
+                $jobId = $this->syncFacade->startBackfill(new StartBackfillApplicationCommand(
+                    companyId: $companyId,
+                    connectionRef: $connectionRef,
+                    source: $source,
+                    resourceType: $resourceType,
+                    shopRef: $shopRef,
+                    windowFrom: $windowFrom,
+                    windowTo: $windowTo,
+                ));
+
+                ++$started;
+
+                $io->writeln(sprintf(
+                    'Started backfill: jobId=%s, resourceType=%s, window=%s->%s',
+                    $jobId,
+                    $resourceType,
+                    $windowFrom->format('Y-m-d'),
+                    $windowTo->format('Y-m-d'),
+                ));
+                $this->logger->info('Ingestion backfill started.', [
+                    'companyId' => $companyId,
+                    'connectionRef' => $connectionRef,
+                    'source' => $source->value,
+                    'resourceType' => $resourceType,
+                    'shopRef' => $shopRef,
+                    'windowFrom' => $windowFrom->format('Y-m-d'),
+                    'windowTo' => $windowTo->format('Y-m-d'),
+                    'jobId' => $jobId,
+                ]);
+            } catch (ActiveBackfillExistsException) {
+                $io->warning(sprintf('Backfill already running for %s.', $resourceType));
+                $this->logger->info('Ingestion backfill skipped because an active job already exists.', [
+                    'companyId' => $companyId,
+                    'connectionRef' => $connectionRef,
+                    'source' => $source->value,
+                    'resourceType' => $resourceType,
+                    'shopRef' => $shopRef,
+                ]);
+            } catch (\Throwable $exception) {
+                ++$failed;
+
+                $io->warning(sprintf('Failed to start backfill for %s.', $resourceType));
+                $this->logger->warning('Failed to start ingestion backfill.', [
+                    'companyId' => $companyId,
+                    'connectionRef' => $connectionRef,
+                    'source' => $source->value,
+                    'resourceType' => $resourceType,
+                    'shopRef' => $shopRef,
+                    'exceptionClass' => $exception::class,
+                    'errorMessage' => $exception->getMessage(),
+                ]);
+            }
+        }
+
+        return 0 === $started && $failed > 0 ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    private function requiredUuidOption(InputInterface $input, string $name): string
+    {
+        $value = trim((string) $input->getOption($name));
+        Assert::uuid($value, sprintf('Invalid --%s UUID.', $name));
+
+        return $value;
+    }
+
+    private function source(InputInterface $input): IngestSource
+    {
+        $value = trim((string) $input->getOption('source'));
+        Assert::notEmpty($value, 'The --source option is required.');
+
+        $source = IngestSource::tryFrom($value);
+        if (null === $source || !isset(self::RESOURCE_TYPES_BY_SOURCE[$source->value])) {
+            throw new \InvalidArgumentException(sprintf('Unsupported ingestion source "%s".', $value));
+        }
+
+        return $source;
+    }
+
+    private function daysBack(InputInterface $input): int
+    {
+        $value = (string) $input->getOption('days-back');
+        if (!ctype_digit($value)) {
+            throw new \InvalidArgumentException('The --days-back option must be an integer from 1 to 365.');
+        }
+
+        $daysBack = (int) $value;
+        if ($daysBack < 1 || $daysBack > 365) {
+            throw new \InvalidArgumentException('The --days-back option must be an integer from 1 to 365.');
+        }
+
+        return $daysBack;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function resourceTypes(IngestSource $source, InputInterface $input): array
+    {
+        $resourceTypes = self::RESOURCE_TYPES_BY_SOURCE[$source->value];
+        $requested = trim((string) $input->getOption('resource-type'));
+
+        if ('' === $requested) {
+            return $resourceTypes;
+        }
+
+        if (!in_array($requested, $resourceTypes, true)) {
+            throw new \InvalidArgumentException(sprintf('Unsupported resource type "%s" for source "%s".', $requested, $source->value));
+        }
+
+        return [$requested];
+    }
+
+    private function shopRef(IngestSource $source, string $companyId, string $connectionRef, InputInterface $input): string
+    {
+        $shopRef = trim((string) $input->getOption('shop-ref'));
+        if ('' !== $shopRef) {
+            return $shopRef;
+        }
+
+        $shops = $this->connectorRegistry->get($source)->discoverShops($companyId, $connectionRef);
+        if ([] === $shops) {
+            throw new \RuntimeException('No shops found for connection.');
+        }
+
+        return $shops[0]->externalId;
+    }
+
+    /**
+     * @param list<string> $resourceTypes
+     */
+    private function printDryRun(
+        SymfonyStyle $io,
+        string $companyId,
+        string $connectionRef,
+        IngestSource $source,
+        string $shopRef,
+        array $resourceTypes,
+        \DateTimeImmutable $windowFrom,
+        \DateTimeImmutable $windowTo,
+    ): void {
+        $rows = [];
+        foreach ($resourceTypes as $resourceType) {
+            $rows[] = [
+                $companyId,
+                $connectionRef,
+                $source->value,
+                $resourceType,
+                $shopRef,
+                $windowFrom->format('Y-m-d'),
+                $windowTo->format('Y-m-d'),
+            ];
+        }
+
+        $io->title('DRY-RUN ingestion backfill');
+        $io->table(
+            ['companyId', 'connectionRef', 'source', 'resourceType', 'shopRef', 'windowFrom', 'windowTo'],
+            $rows,
+        );
+    }
+}

--- a/site/src/Ingestion/Command/StartBackfillCommand.php
+++ b/site/src/Ingestion/Command/StartBackfillCommand.php
@@ -32,7 +32,6 @@ final class StartBackfillCommand extends Command
     private const RESOURCE_TYPES_BY_SOURCE = [
         'ozon' => [
             OzonResourceType::DAILY_REPORT,
-            OzonResourceType::REALIZATION,
         ],
     ];
 

--- a/site/src/Ingestion/Facade/SyncFacade.php
+++ b/site/src/Ingestion/Facade/SyncFacade.php
@@ -9,12 +9,14 @@ use App\Ingestion\Application\Action\MarkJobFailedAction;
 use App\Ingestion\Application\Action\MarkJobRunningAction;
 use App\Ingestion\Application\Action\SplitJobIntoChunksAction;
 use App\Ingestion\Application\Action\StartBackfillAction;
+use App\Ingestion\Application\Action\StartIncrementalAction;
 use App\Ingestion\Application\Action\UpdateCursorAction;
 use App\Ingestion\Application\Command\MarkJobCompletedCommand;
 use App\Ingestion\Application\Command\MarkJobFailedCommand;
 use App\Ingestion\Application\Command\MarkJobRunningCommand;
 use App\Ingestion\Application\Command\SplitJobCommand;
 use App\Ingestion\Application\Command\StartBackfillCommand;
+use App\Ingestion\Application\Command\StartIncrementalCommand;
 use App\Ingestion\Application\Command\UpdateCursorCommand;
 use App\Ingestion\Application\DTO\SyncJobProgressView;
 use App\Ingestion\Exception\SyncJobNotFoundException;
@@ -24,6 +26,7 @@ final readonly class SyncFacade
 {
     public function __construct(
         private StartBackfillAction $startBackfillAction,
+        private StartIncrementalAction $startIncrementalAction,
         private SplitJobIntoChunksAction $splitJobIntoChunksAction,
         private MarkJobRunningAction $markJobRunningAction,
         private MarkJobCompletedAction $markJobCompletedAction,
@@ -39,6 +42,11 @@ final readonly class SyncFacade
         ($this->splitJobIntoChunksAction)(new SplitJobCommand($parentJobId, $command->companyId));
 
         return $parentJobId;
+    }
+
+    public function startIncremental(StartIncrementalCommand $command): string
+    {
+        return ($this->startIncrementalAction)($command);
     }
 
     public function markJobRunning(MarkJobRunningCommand $command): void

--- a/site/src/Ingestion/Repository/IngestCursorRepository.php
+++ b/site/src/Ingestion/Repository/IngestCursorRepository.php
@@ -37,6 +37,26 @@ final class IngestCursorRepository extends ServiceEntityRepository
             ->getOneOrNullResult();
     }
 
+    /**
+     * @return list<IngestCursor>
+     */
+    public function findByResource(
+        string $companyId,
+        string $connectionRef,
+        string $resourceType,
+    ): array {
+        return $this->createQueryBuilder('cursor')
+            ->andWhere('cursor.companyId = :companyId')
+            ->andWhere('cursor.connectionRef = :connectionRef')
+            ->andWhere('cursor.resourceType = :resourceType')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('connectionRef', $connectionRef)
+            ->setParameter('resourceType', $resourceType)
+            ->orderBy('cursor.shopRef', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
     public function getOrCreate(
         string $companyId,
         string $connectionRef,

--- a/site/tests/Integration/Ingestion/Command/RunIncrementalCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/RunIncrementalCommandTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Command;
+
+use App\Company\Entity\Company;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Enum\SyncJobKind;
+use App\Ingestion\Message\RunSyncChunkMessage;
+use App\Ingestion\Repository\IngestCursorRepository;
+use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Enum\MarketplaceConnectionType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+
+final class RunIncrementalCommandTest extends IntegrationTestCase
+{
+    public function testSkipsConnectionsWithoutCursor(): void
+    {
+        $company = $this->seedCompany(1001);
+        $this->seedConnection($company, '77777777-7777-7777-7777-000000001001');
+
+        $transport = $this->getIngestFetchTransport();
+        $transport->reset();
+
+        $tester = $this->tester('app:ingestion:run-incremental');
+        $exit = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertStringContainsString('Dispatched 0 incremental jobs', $tester->getDisplay());
+        self::assertSame(0, $this->incrementalJobCount($company->getId()));
+        self::assertCount(0, $transport->getSent());
+    }
+
+    public function testDispatchesOneIncrementalJobPerExistingCursor(): void
+    {
+        $company = $this->seedCompany(1002);
+        $connection = $this->seedConnection($company, '77777777-7777-7777-7777-000000001002');
+        $this->seedCursor($company->getId(), $connection->getId(), OzonResourceType::DAILY_REPORT, 'shop-a', '2026-06-18');
+        $this->seedCursor($company->getId(), $connection->getId(), OzonResourceType::REALIZATION, 'shop-a', '2026-06-01');
+
+        $transport = $this->getIngestFetchTransport();
+        $transport->reset();
+
+        $tester = $this->tester('app:ingestion:run-incremental');
+        $exit = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertStringContainsString('Dispatched 2 incremental jobs', $tester->getDisplay());
+        self::assertSame(2, $this->incrementalJobCount($company->getId()));
+
+        $envelopes = $transport->getSent();
+        self::assertCount(2, $envelopes);
+        foreach ($envelopes as $envelope) {
+            self::assertInstanceOf(RunSyncChunkMessage::class, $envelope->getMessage());
+        }
+    }
+
+    public function testCompanyFilterDispatchesOnlyRequestedCompany(): void
+    {
+        $companyA = $this->seedCompany(1003);
+        $connectionA = $this->seedConnection($companyA, '77777777-7777-7777-7777-000000001003');
+        $this->seedCursor($companyA->getId(), $connectionA->getId(), OzonResourceType::DAILY_REPORT, 'shop-a', '2026-06-18');
+
+        $companyB = $this->seedCompany(1004);
+        $connectionB = $this->seedConnection($companyB, '77777777-7777-7777-7777-000000001004');
+        $this->seedCursor($companyB->getId(), $connectionB->getId(), OzonResourceType::DAILY_REPORT, 'shop-b', '2026-06-18');
+
+        $transport = $this->getIngestFetchTransport();
+        $transport->reset();
+
+        $tester = $this->tester('app:ingestion:run-incremental');
+        $exit = $tester->execute(['--company-id' => $companyB->getId()]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertSame(0, $this->incrementalJobCount($companyA->getId()));
+        self::assertSame(1, $this->incrementalJobCount($companyB->getId()));
+        self::assertCount(1, $transport->getSent());
+    }
+
+    public function testWildberriesSourceIsSkipped(): void
+    {
+        $tester = $this->tester('app:ingestion:run-incremental');
+        $exit = $tester->execute(['--source' => 'wildberries']);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertStringContainsString('not supported yet', $tester->getDisplay());
+    }
+
+    private function seedCompany(int $index): Company
+    {
+        $owner = UserBuilder::aUser()->withIndex($index)->build();
+        $company = CompanyBuilder::aCompany()->withIndex($index)->withOwner($owner)->build();
+
+        $this->em->persist($owner);
+        $this->em->persist($company);
+        $this->em->flush();
+
+        return $company;
+    }
+
+    private function seedConnection(Company $company, string $id): MarketplaceConnection
+    {
+        $connection = new MarketplaceConnection(
+            id: $id,
+            company: $company,
+            marketplace: MarketplaceType::OZON,
+            connectionType: MarketplaceConnectionType::SELLER,
+        );
+        $connection->setApiKey('test-key');
+        $connection->setClientId('test-client-id');
+        $connection->setIsActive(true);
+
+        $this->em->persist($connection);
+        $this->em->flush();
+
+        return $connection;
+    }
+
+    private function seedCursor(
+        string $companyId,
+        string $connectionRef,
+        string $resourceType,
+        string $shopRef,
+        string $cursorValue,
+    ): void {
+        /** @var IngestCursorRepository $cursorRepository */
+        $cursorRepository = self::getContainer()->get(IngestCursorRepository::class);
+        $cursor = $cursorRepository->getOrCreate($companyId, $connectionRef, $resourceType, $shopRef);
+        $cursor->advance($cursorValue, Uuid::uuid7()->toString(), new \DateTimeImmutable('2026-06-18 10:00:00'));
+        $this->em->flush();
+    }
+
+    private function incrementalJobCount(string $companyId): int
+    {
+        return (int) $this->connection->fetchOne(
+            'SELECT COUNT(*)
+             FROM ingest_sync_jobs
+             WHERE company_id = :companyId AND kind = :kind',
+            [
+                'companyId' => $companyId,
+                'kind' => SyncJobKind::INCREMENTAL->value,
+            ],
+        );
+    }
+
+    private function tester(string $commandName): CommandTester
+    {
+        $app = new Application(self::$kernel);
+
+        return new CommandTester($app->find($commandName));
+    }
+
+    private function getIngestFetchTransport(): InMemoryTransport
+    {
+        /** @var InMemoryTransport $transport */
+        $transport = self::getContainer()->get('messenger.transport.ingest_fetch');
+
+        return $transport;
+    }
+}

--- a/site/tests/Integration/Ingestion/Command/RunIncrementalCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/RunIncrementalCommandTest.php
@@ -86,6 +86,42 @@ final class RunIncrementalCommandTest extends IntegrationTestCase
         self::assertCount(1, $transport->getSent());
     }
 
+    public function testLimitSelectsOldestEligibleCursorWorkInsteadOfFirstActiveCompanies(): void
+    {
+        $newerCompany = $this->seedCompany(1005);
+        $newerConnection = $this->seedConnection($newerCompany, '77777777-7777-7777-7777-000000001005');
+        $this->seedCursor(
+            $newerCompany->getId(),
+            $newerConnection->getId(),
+            OzonResourceType::DAILY_REPORT,
+            'shop-newer',
+            '2026-06-18',
+            new \DateTimeImmutable('2026-06-18 10:00:00'),
+        );
+
+        $olderCompany = $this->seedCompany(1006);
+        $olderConnection = $this->seedConnection($olderCompany, '77777777-7777-7777-7777-000000001006');
+        $this->seedCursor(
+            $olderCompany->getId(),
+            $olderConnection->getId(),
+            OzonResourceType::DAILY_REPORT,
+            'shop-older',
+            '2026-06-18',
+            new \DateTimeImmutable('2026-06-01 10:00:00'),
+        );
+
+        $transport = $this->getIngestFetchTransport();
+        $transport->reset();
+
+        $tester = $this->tester('app:ingestion:run-incremental');
+        $exit = $tester->execute(['--limit' => '1']);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertSame(0, $this->incrementalJobCount($newerCompany->getId()));
+        self::assertSame(1, $this->incrementalJobCount($olderCompany->getId()));
+        self::assertCount(1, $transport->getSent());
+    }
+
     public function testWildberriesSourceIsSkipped(): void
     {
         $tester = $this->tester('app:ingestion:run-incremental');
@@ -131,11 +167,12 @@ final class RunIncrementalCommandTest extends IntegrationTestCase
         string $resourceType,
         string $shopRef,
         string $cursorValue,
+        ?\DateTimeImmutable $lastFetchedAt = null,
     ): void {
         /** @var IngestCursorRepository $cursorRepository */
         $cursorRepository = self::getContainer()->get(IngestCursorRepository::class);
         $cursor = $cursorRepository->getOrCreate($companyId, $connectionRef, $resourceType, $shopRef);
-        $cursor->advance($cursorValue, Uuid::uuid7()->toString(), new \DateTimeImmutable('2026-06-18 10:00:00'));
+        $cursor->advance($cursorValue, Uuid::uuid7()->toString(), $lastFetchedAt ?? new \DateTimeImmutable('2026-06-18 10:00:00'));
         $this->em->flush();
     }
 

--- a/site/tests/Integration/Ingestion/Command/StartBackfillCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/StartBackfillCommandTest.php
@@ -37,12 +37,12 @@ final class StartBackfillCommandTest extends IntegrationTestCase
         self::assertSame(Command::SUCCESS, $exit);
         self::assertStringContainsString('DRY-RUN ingestion backfill', $tester->getDisplay());
         self::assertStringContainsString(OzonResourceType::DAILY_REPORT, $tester->getDisplay());
-        self::assertStringContainsString(OzonResourceType::REALIZATION, $tester->getDisplay());
+        self::assertStringNotContainsString(OzonResourceType::REALIZATION, $tester->getDisplay());
         self::assertSame(0, $this->syncJobCount($companyId));
         self::assertCount(0, $transport->getSent());
     }
 
-    public function testStartsBackfillForAllOzonResourceTypes(): void
+    public function testStartsBackfillForDefaultOzonResourceType(): void
     {
         $companyId = Uuid::uuid7()->toString();
         $connectionRef = Uuid::uuid7()->toString();
@@ -59,7 +59,7 @@ final class StartBackfillCommandTest extends IntegrationTestCase
 
         self::assertSame(Command::SUCCESS, $exit);
         self::assertStringContainsString(OzonResourceType::DAILY_REPORT, $tester->getDisplay());
-        self::assertStringContainsString(OzonResourceType::REALIZATION, $tester->getDisplay());
+        self::assertStringNotContainsString(OzonResourceType::REALIZATION, $tester->getDisplay());
 
         $parentJobs = $this->connection->fetchAllAssociative(
             'SELECT resource_type, shop_ref, progress_total
@@ -69,21 +69,19 @@ final class StartBackfillCommandTest extends IntegrationTestCase
             ['companyId' => $companyId],
         );
 
-        self::assertCount(2, $parentJobs);
-        self::assertSame([OzonResourceType::DAILY_REPORT, OzonResourceType::REALIZATION], array_column($parentJobs, 'resource_type'));
+        self::assertCount(1, $parentJobs);
+        self::assertSame([OzonResourceType::DAILY_REPORT], array_column($parentJobs, 'resource_type'));
         self::assertSame($connectionRef, $parentJobs[0]['shop_ref']);
-        self::assertSame($connectionRef, $parentJobs[1]['shop_ref']);
         self::assertSame(5, (int) $parentJobs[0]['progress_total']);
-        self::assertSame(5, (int) $parentJobs[1]['progress_total']);
 
         $envelopes = $transport->getSent();
-        self::assertCount(10, $envelopes);
+        self::assertCount(5, $envelopes);
         foreach ($envelopes as $envelope) {
             self::assertInstanceOf(RunSyncChunkMessage::class, $envelope->getMessage());
         }
     }
 
-    public function testActiveBackfillWarningSkipsResourceAndContinuesOthers(): void
+    public function testActiveBackfillWarningSkipsDefaultResource(): void
     {
         $companyId = Uuid::uuid7()->toString();
         $connectionRef = Uuid::uuid7()->toString();
@@ -113,7 +111,6 @@ final class StartBackfillCommandTest extends IntegrationTestCase
 
         self::assertSame(Command::SUCCESS, $exit);
         self::assertStringContainsString('Backfill already running', $tester->getDisplay());
-        self::assertStringContainsString(OzonResourceType::REALIZATION, $tester->getDisplay());
 
         $newParentJobs = $this->connection->fetchAllAssociative(
             'SELECT resource_type
@@ -123,8 +120,22 @@ final class StartBackfillCommandTest extends IntegrationTestCase
             ['companyId' => $companyId],
         );
 
-        self::assertSame([OzonResourceType::DAILY_REPORT, OzonResourceType::REALIZATION], array_column($newParentJobs, 'resource_type'));
-        self::assertCount(5, $transport->getSent());
+        self::assertSame([OzonResourceType::DAILY_REPORT], array_column($newParentJobs, 'resource_type'));
+        self::assertCount(0, $transport->getSent());
+    }
+
+    public function testRealizationBackfillIsNotSupportedUntilMonthAlignedChunkingExists(): void
+    {
+        $tester = $this->tester('app:ingestion:start-backfill');
+        $exit = $tester->execute([
+            '--company-id' => Uuid::uuid7()->toString(),
+            '--connection-ref' => Uuid::uuid7()->toString(),
+            '--source' => 'ozon',
+            '--resource-type' => OzonResourceType::REALIZATION,
+        ]);
+
+        self::assertSame(Command::FAILURE, $exit);
+        self::assertStringContainsString('Unsupported resource type', $tester->getDisplay());
     }
 
     public function testInvalidCompanyUuidFails(): void

--- a/site/tests/Integration/Ingestion/Command/StartBackfillCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/StartBackfillCommandTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Command;
+
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Entity\SyncJob;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\SyncJobKind;
+use App\Ingestion\Message\RunSyncChunkMessage;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+
+final class StartBackfillCommandTest extends IntegrationTestCase
+{
+    public function testDryRunDoesNotCreateJobsOrDispatchMessages(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = Uuid::uuid7()->toString();
+        $transport = $this->getIngestFetchTransport();
+        $transport->reset();
+
+        $tester = $this->tester('app:ingestion:start-backfill');
+        $exit = $tester->execute([
+            '--company-id' => $companyId,
+            '--connection-ref' => $connectionRef,
+            '--source' => 'ozon',
+            '--days-back' => '30',
+            '--dry-run' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertStringContainsString('DRY-RUN ingestion backfill', $tester->getDisplay());
+        self::assertStringContainsString(OzonResourceType::DAILY_REPORT, $tester->getDisplay());
+        self::assertStringContainsString(OzonResourceType::REALIZATION, $tester->getDisplay());
+        self::assertSame(0, $this->syncJobCount($companyId));
+        self::assertCount(0, $transport->getSent());
+    }
+
+    public function testStartsBackfillForAllOzonResourceTypes(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = Uuid::uuid7()->toString();
+        $transport = $this->getIngestFetchTransport();
+        $transport->reset();
+
+        $tester = $this->tester('app:ingestion:start-backfill');
+        $exit = $tester->execute([
+            '--company-id' => $companyId,
+            '--connection-ref' => $connectionRef,
+            '--source' => 'ozon',
+            '--days-back' => '30',
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertStringContainsString(OzonResourceType::DAILY_REPORT, $tester->getDisplay());
+        self::assertStringContainsString(OzonResourceType::REALIZATION, $tester->getDisplay());
+
+        $parentJobs = $this->connection->fetchAllAssociative(
+            'SELECT resource_type, shop_ref, progress_total
+             FROM ingest_sync_jobs
+             WHERE company_id = :companyId AND parent_job_id IS NULL
+             ORDER BY resource_type',
+            ['companyId' => $companyId],
+        );
+
+        self::assertCount(2, $parentJobs);
+        self::assertSame([OzonResourceType::DAILY_REPORT, OzonResourceType::REALIZATION], array_column($parentJobs, 'resource_type'));
+        self::assertSame($connectionRef, $parentJobs[0]['shop_ref']);
+        self::assertSame($connectionRef, $parentJobs[1]['shop_ref']);
+        self::assertSame(5, (int) $parentJobs[0]['progress_total']);
+        self::assertSame(5, (int) $parentJobs[1]['progress_total']);
+
+        $envelopes = $transport->getSent();
+        self::assertCount(10, $envelopes);
+        foreach ($envelopes as $envelope) {
+            self::assertInstanceOf(RunSyncChunkMessage::class, $envelope->getMessage());
+        }
+    }
+
+    public function testActiveBackfillWarningSkipsResourceAndContinuesOthers(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = Uuid::uuid7()->toString();
+        $transport = $this->getIngestFetchTransport();
+        $transport->reset();
+
+        $activeJob = new SyncJob(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            source: IngestSource::OZON,
+            resourceType: OzonResourceType::DAILY_REPORT,
+            kind: SyncJobKind::BACKFILL,
+            windowFrom: new \DateTimeImmutable('2026-06-01'),
+            windowTo: new \DateTimeImmutable('2026-06-18'),
+            shopRef: $connectionRef,
+        );
+        $this->em->persist($activeJob);
+        $this->em->flush();
+
+        $tester = $this->tester('app:ingestion:start-backfill');
+        $exit = $tester->execute([
+            '--company-id' => $companyId,
+            '--connection-ref' => $connectionRef,
+            '--source' => 'ozon',
+            '--days-back' => '30',
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertStringContainsString('Backfill already running', $tester->getDisplay());
+        self::assertStringContainsString(OzonResourceType::REALIZATION, $tester->getDisplay());
+
+        $newParentJobs = $this->connection->fetchAllAssociative(
+            'SELECT resource_type
+             FROM ingest_sync_jobs
+             WHERE company_id = :companyId AND parent_job_id IS NULL
+             ORDER BY resource_type',
+            ['companyId' => $companyId],
+        );
+
+        self::assertSame([OzonResourceType::DAILY_REPORT, OzonResourceType::REALIZATION], array_column($newParentJobs, 'resource_type'));
+        self::assertCount(5, $transport->getSent());
+    }
+
+    public function testInvalidCompanyUuidFails(): void
+    {
+        $tester = $this->tester('app:ingestion:start-backfill');
+        $exit = $tester->execute([
+            '--company-id' => 'not-a-uuid',
+            '--connection-ref' => Uuid::uuid7()->toString(),
+            '--source' => 'ozon',
+        ]);
+
+        self::assertSame(Command::FAILURE, $exit);
+        self::assertStringContainsString('Invalid --company-id UUID', $tester->getDisplay());
+    }
+
+    private function syncJobCount(string $companyId): int
+    {
+        return (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM ingest_sync_jobs WHERE company_id = :companyId',
+            ['companyId' => $companyId],
+        );
+    }
+
+    private function tester(string $commandName): CommandTester
+    {
+        $app = new Application(self::$kernel);
+
+        return new CommandTester($app->find($commandName));
+    }
+
+    private function getIngestFetchTransport(): InMemoryTransport
+    {
+        /** @var InMemoryTransport $transport */
+        $transport = self::getContainer()->get('messenger.transport.ingest_fetch');
+
+        return $transport;
+    }
+}

--- a/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonSellerReportConnectorTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonSellerReportConnectorTest.php
@@ -73,6 +73,111 @@ final class OzonSellerReportConnectorTest extends TestCase
         self::assertSame([['operation_id' => 'op-1']], $result->rawBatch->rows);
     }
 
+    public function testPullDailyReportAdvancesCursorForNonWindowedIncremental(): void
+    {
+        $client = new class implements OzonClientAdapterInterface {
+            public ?\DateTimeImmutable $from = null;
+            public ?\DateTimeImmutable $to = null;
+
+            public function fetchTransactionList(
+                string $companyId,
+                string $connectionRef,
+                \DateTimeImmutable $from,
+                \DateTimeImmutable $to,
+                int $page,
+                int $pageSize,
+            ): OzonRawPage {
+                $this->from = $from;
+                $this->to = $to;
+
+                return new OzonRawPage(rows: [['operation_id' => 'op-1']], hasMore: false);
+            }
+
+            public function fetchRealization(string $companyId, string $connectionRef, int $year, int $month): OzonRawPage
+            {
+                throw new \LogicException('Not used.');
+            }
+
+            public function listClusters(string $companyId, string $connectionRef): array
+            {
+                return [new OzonShopDescriptor('shop-1', 'Shop 1')];
+            }
+        };
+
+        $connector = new OzonSellerReportConnector($client, new NullLogger());
+        $companyId = Uuid::uuid7()->toString();
+
+        $result = $connector->pull(new PullRequest(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            shopRef: 'shop-1',
+            resourceType: OzonResourceType::DAILY_REPORT,
+            cursorValue: '2026-06-12',
+            windowFrom: null,
+            windowTo: null,
+            syncJobId: Uuid::uuid7()->toString(),
+        ));
+
+        self::assertEquals(new \DateTimeImmutable('2026-06-12 00:00:00'), $client->from);
+        self::assertEquals(new \DateTimeImmutable('2026-06-18 23:59:59'), $client->to);
+        self::assertSame('2026-06-19', $result->nextCursorValue);
+        self::assertFalse($result->hasMore);
+    }
+
+    public function testPullRealizationAdvancesCursorForNonWindowedIncremental(): void
+    {
+        $client = new class implements OzonClientAdapterInterface {
+            public ?int $year = null;
+            public ?int $month = null;
+
+            public function fetchTransactionList(
+                string $companyId,
+                string $connectionRef,
+                \DateTimeImmutable $from,
+                \DateTimeImmutable $to,
+                int $page,
+                int $pageSize,
+            ): OzonRawPage {
+                throw new \LogicException('Not used.');
+            }
+
+            public function fetchRealization(string $companyId, string $connectionRef, int $year, int $month): OzonRawPage
+            {
+                $this->year = $year;
+                $this->month = $month;
+
+                return new OzonRawPage(
+                    rows: [['operation_id' => 'op-1']],
+                    hasMore: false,
+                    metadata: ['header' => ['doc_number' => 'doc-1']],
+                );
+            }
+
+            public function listClusters(string $companyId, string $connectionRef): array
+            {
+                return [new OzonShopDescriptor('shop-1', 'Shop 1')];
+            }
+        };
+
+        $connector = new OzonSellerReportConnector($client, new NullLogger());
+
+        $result = $connector->pull(new PullRequest(
+            companyId: Uuid::uuid7()->toString(),
+            connectionRef: 'connection-1',
+            shopRef: 'shop-1',
+            resourceType: OzonResourceType::REALIZATION,
+            cursorValue: '2026-05-01',
+            windowFrom: null,
+            windowTo: null,
+            syncJobId: Uuid::uuid7()->toString(),
+        ));
+
+        self::assertSame(2026, $client->year);
+        self::assertSame(5, $client->month);
+        self::assertSame('2026-06-01', $result->nextCursorValue);
+        self::assertFalse($result->hasMore);
+    }
+
     public function testCapabilitiesDiscoverAndUnsupportedPush(): void
     {
         $client = new class implements OzonClientAdapterInterface {


### PR DESCRIPTION
## Summary

- Add `app:ingestion:start-backfill` for Ozon daily-report backfill with dry-run, validation, shop discovery, and active-job warning behavior.
- Add `app:ingestion:run-incremental` plus `SyncFacade::startIncremental()` for Ozon incremental jobs when cursors already exist.
- Schedule `app:ingestion:run-incremental` daily at 03:00 in `docker/cron/app.cron` after owner approval.
- Add focused integration/unit tests and TASK-FIX-05 stage documentation.

## Review fixes

- Non-windowed Ozon incremental pulls now return the next cursor, so completed jobs can advance `IngestCursor`.
- Incremental `--limit` now selects eligible cursor work by oldest cursor timestamp instead of breaking on the first active companies in deterministic SQL order.
- `ozon_seller_realization` is disabled for backfill in this PR until month-aligned chunking is implemented separately.

## Notes

- Wildberries incremental is intentionally skipped because it is out of scope.
- Unrelated untracked local files were left out.

## Validation

- Targeted command integration tests: passed (`StartBackfillCommandTest|RunIncrementalCommandTest`, 10 tests / 47 assertions).
- Ozon connector unit test: passed (`OzonSellerReportConnectorTest`, 4 tests / 17 assertions).
- `make site-test-unit`: passed, with existing PHPUnit warning/deprecation.
- `php bin/console lint:container --env=prod`: passed, with existing deprecation notices.
- `docker compose run --rm site-php-cli php bin/console cache:clear --env=prod`: passed, with existing deprecation notices.
- `docker compose run --rm site-php-cli php bin/console list app:ingestion --env=prod | rg 'run-incremental'`: passed.
- `docker compose run --rm site-php-cli php bin/console app:ingestion:run-incremental --help --env=prod`: passed.
- GitHub Actions `🚀 Deploy to Production` for head `63b3904`: success.
- Touched-file PHP-CS-Fixer dry-run: passed.
- `git diff --check`: passed.
- `make site-cs-check`: fails on pre-existing project-wide CS drift outside this task.