### PR TITLE
[codex] sort reconciliation sales and refunds first

### DIFF
--- a/site/src/Ingestion/Infrastructure/Query/ReconciliationQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/ReconciliationQuery.php
@@ -95,7 +95,15 @@ final class ReconciliationQuery
             ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
             ->setParameter('toExclusive', $toExclusive, Types::DATETIME_IMMUTABLE)
             ->groupBy('ft.type')
-            ->orderBy('ft.type', 'ASC')
+            ->orderBy(
+                sprintf(
+                    "CASE ft.type WHEN '%s' THEN 0 WHEN '%s' THEN 1 ELSE 2 END",
+                    TransactionType::SALE->value,
+                    TransactionType::REFUND->value,
+                ),
+                'ASC',
+            )
+            ->addOrderBy('ft.type', 'ASC')
             ->executeQuery()
             ->fetchAllAssociative();
 

--- a/site/tests/Functional/Ingestion/Controller/VerificationApiControllerTest.php
+++ b/site/tests/Functional/Ingestion/Controller/VerificationApiControllerTest.php
@@ -39,17 +39,17 @@ final class VerificationApiControllerTest extends WebTestCaseBase
         $coverage = $this->json($client);
         self::assertSame('shop-1', $coverage['cells'][0]['shop_ref']);
         self::assertSame(1, $coverage['cells'][0]['raw_count']);
-        self::assertSame(2, $coverage['cells'][0]['tx_count']);
+        self::assertSame(3, $coverage['cells'][0]['tx_count']);
         self::assertSame(1, $coverage['cells'][0]['issue_count']);
         self::assertSame('shop-1', $coverage['shops'][0]['shop_ref']);
 
         $client->request('GET', '/api/ingestion/verification/reconciliation?shop_ref=shop-1&year=2026&month=6');
         self::assertResponseIsSuccessful();
         $reconciliation = $this->json($client);
-        self::assertSame(800, $reconciliation['summary']['canon_total_minor']);
+        self::assertSame(500, $reconciliation['summary']['canon_total_minor']);
         self::assertSame(750, $reconciliation['summary']['ozon_control_total_minor']);
-        self::assertSame(50, $reconciliation['summary']['canon_vs_ozon_delta_minor']);
-        self::assertSame('sale', $reconciliation['by_type'][1]['type']);
+        self::assertSame(-250, $reconciliation['summary']['canon_vs_ozon_delta_minor']);
+        self::assertSame(['sale', 'refund', 'commission'], array_column($reconciliation['by_type'], 'type'));
 
         $client->request('GET', '/api/ingestion/verification/issues?shop_ref=shop-1&page=1&limit=50');
         self::assertResponseIsSuccessful();
@@ -173,6 +173,7 @@ final class VerificationApiControllerTest extends WebTestCaseBase
         $em->persist($company);
         $em->persist($raw);
         $em->persist($this->transaction($companyId, $raw->getId(), 'api-sale-1', 1000, TransactionType::SALE));
+        $em->persist($this->transaction($companyId, $raw->getId(), 'api-refund-1', -300, TransactionType::REFUND));
         $em->persist($this->transaction($companyId, $raw->getId(), 'api-commission-1', -200, TransactionType::COMMISSION));
         $em->persist(new NormalizationIssue(
             $companyId,

--- a/site/tests/Integration/Ingestion/Infrastructure/Query/VerificationQueriesTest.php
+++ b/site/tests/Integration/Ingestion/Infrastructure/Query/VerificationQueriesTest.php
@@ -89,6 +89,7 @@ final class VerificationQueriesTest extends IntegrationTestCase
         $rawRecordId = Uuid::uuid7()->toString();
 
         $this->em->persist($this->transaction($companyId, $rawRecordId, 'sale-1', 1000, TransactionType::SALE));
+        $this->em->persist($this->transaction($companyId, $rawRecordId, 'refund-1', -300, TransactionType::REFUND));
         $this->em->persist($this->transaction($companyId, $rawRecordId, 'commission-1', -200, TransactionType::COMMISSION));
         $this->em->persist($this->transaction($companyId, $rawRecordId, 'other-shop-sale', 999, TransactionType::SALE, 'shop-2'));
 
@@ -108,12 +109,13 @@ final class VerificationQueriesTest extends IntegrationTestCase
         $summary = $query->summary($companyId, 'shop-1', 2026, 6);
         $byType = $query->breakdownByType($companyId, 'shop-1', 2026, 6);
 
-        self::assertSame(800, $summary->canonTotalMinor);
+        self::assertSame(500, $summary->canonTotalMinor);
         self::assertSame(750, $summary->ozonControlTotalMinor);
-        self::assertSame(50, $summary->canonVsOzonDeltaMinor);
+        self::assertSame(-250, $summary->canonVsOzonDeltaMinor);
         self::assertSame('RUB', $summary->currency);
+        self::assertSame(['sale', 'refund', 'commission'], array_column($byType, 'type'));
         self::assertSame(
-            ['commission' => -200, 'sale' => 1000],
+            ['sale' => 1000, 'refund' => -300, 'commission' => -200],
             array_column($byType, 'canonAmountMinor', 'type'),
         );
     }


### PR DESCRIPTION
## What changed

- Updated the ingestion reconciliation breakdown query so operation groups are ordered with sales first, refunds second, and all remaining transaction types after that.
- Added integration and functional coverage to lock the API response order.

## Why

The "Сверка сумм" report should show the most important groups first: Продажи, then Возвраты, then the rest.

## Validation

- `docker compose run --rm -e APP_ENV=test -e APP_DEBUG=1 site-php-cli php -d memory_limit=1G bin/phpunit --filter 'VerificationQueriesTest|VerificationApiControllerTest'` — passed, 7 tests / 56 assertions; PHPUnit reported 3 existing deprecations.
- `git diff --check` — passed.