### PR TITLE
[codex] fix coverage heatmap grouping

### DIFF
--- a/site/src/Ingestion/Infrastructure/Query/CoverageQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/CoverageQuery.php
@@ -30,40 +30,40 @@ final class CoverageQuery
 
         $qb = $this->connection->createQueryBuilder()
             ->select(
-                "TO_CHAR(r.fetched_at, 'YYYY-MM-DD') AS record_date",
-                'r.shop_ref',
+                "TO_CHAR(ft.occurred_at, 'YYYY-MM-DD') AS record_date",
+                'ft.shop_ref',
                 'r.resource_type',
                 'COUNT(DISTINCT r.id) AS raw_count',
-                'COUNT(DISTINCT ft.id) AS tx_count',
+                'COUNT(ft.id) AS tx_count',
                 'COUNT(DISTINCT ni.id) AS issue_count',
                 'MAX(r.fetched_at) AS last_fetched_at',
             )
-            ->from('ingest_raw_records', 'r')
+            ->from('ingest_financial_transactions', 'ft')
             ->leftJoin(
-                'r',
-                'ingest_financial_transactions',
                 'ft',
-                'ft.company_id = r.company_id AND ft.raw_record_id = r.id',
+                'ingest_raw_records',
+                'r',
+                'r.company_id = :companyId AND r.company_id = ft.company_id AND r.id = ft.raw_record_id',
             )
             ->leftJoin(
-                'r',
+                'ft',
                 'ingest_normalization_issues',
                 'ni',
-                'ni.company_id = r.company_id AND ni.raw_record_id = r.id AND ni.resolved_at IS NULL',
+                'ni.company_id = :companyId AND ni.company_id = ft.company_id AND ni.raw_record_id = r.id AND ni.resolved_at IS NULL',
             )
-            ->where('r.company_id = :companyId')
-            ->andWhere('r.fetched_at >= :from')
-            ->andWhere('r.fetched_at < :toExclusive')
+            ->where('ft.company_id = :companyId')
+            ->andWhere('ft.occurred_at >= :from')
+            ->andWhere('ft.occurred_at < :toExclusive')
             ->setParameter('companyId', $companyId)
             ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
             ->setParameter('toExclusive', $to->modify('+1 day'), Types::DATETIME_IMMUTABLE)
-            ->groupBy('record_date', 'r.shop_ref', 'r.resource_type')
+            ->groupBy('record_date', 'ft.shop_ref', 'r.resource_type')
             ->orderBy('record_date', 'ASC')
-            ->addOrderBy('r.shop_ref', 'ASC')
+            ->addOrderBy('ft.shop_ref', 'ASC')
             ->addOrderBy('r.resource_type', 'ASC');
 
         if (null !== $shopRef && '' !== $shopRef) {
-            $qb->andWhere('r.shop_ref = :shopRef')
+            $qb->andWhere('ft.shop_ref = :shopRef')
                 ->setParameter('shopRef', $shopRef);
         }
 

--- a/site/src/Ingestion/Infrastructure/Query/CoverageQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/CoverageQuery.php
@@ -34,7 +34,7 @@ final class CoverageQuery
                 'ft.shop_ref',
                 'r.resource_type',
                 'COUNT(DISTINCT r.id) AS raw_count',
-                'COUNT(ft.id) AS tx_count',
+                'COUNT(DISTINCT ft.id) AS tx_count',
                 'COUNT(DISTINCT ni.id) AS issue_count',
                 'MAX(r.fetched_at) AS last_fetched_at',
             )

--- a/site/tests/Functional/Ingestion/Controller/VerificationApiControllerTest.php
+++ b/site/tests/Functional/Ingestion/Controller/VerificationApiControllerTest.php
@@ -69,6 +69,84 @@ final class VerificationApiControllerTest extends WebTestCaseBase
         self::assertSame('income', $summary['by_category'][1]['flow']);
     }
 
+    public function testCoverageUsesTransactionOccurredDateForBackfillHeatmap(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $owner = UserBuilder::aUser()->withIndex(9150)->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId('11111111-1111-4111-8111-111111119150')
+            ->withOwner($owner)
+            ->build();
+
+        $em = $this->em();
+        $em->persist($owner);
+        $em->persist($company);
+
+        $dates = [];
+        $firstRaw = null;
+        foreach (range(13, 19) as $day) {
+            $date = sprintf('2026-06-%02d', $day);
+            $dates[] = $date;
+            $raw = $this->rawRecord(
+                $company->getId(),
+                'shop-backfill',
+                'ozon_seller_daily_report',
+                'backfill-raw-'.$date,
+                new \DateTimeImmutable('2026-06-20 10:00:00+00:00'),
+            );
+            $firstRaw ??= $raw;
+
+            $em->persist($raw);
+            $em->persist($this->transaction(
+                $company->getId(),
+                $raw->getId(),
+                'backfill-sale-'.$date,
+                100,
+                TransactionType::SALE,
+                'shop-backfill',
+                new \DateTimeImmutable($date.' 12:00:00+00:00'),
+            ));
+        }
+
+        self::assertNotNull($firstRaw);
+        $resolvedIssue = new NormalizationIssue(
+            $company->getId(),
+            $firstRaw->getId(),
+            null,
+            NormalizationIssueKind::MAPPER_FAILURE,
+            [],
+        );
+        $resolvedIssue->markResolved(new \DateTimeImmutable('2026-06-20 11:00:00+00:00'));
+        $em->persist(new NormalizationIssue(
+            $company->getId(),
+            $firstRaw->getId(),
+            null,
+            NormalizationIssueKind::SUM_MISMATCH,
+            [],
+        ));
+        $em->persist($resolvedIssue);
+        $em->flush();
+
+        $this->loginWithActiveCompany($client, $owner, $company);
+        $client->request('GET', '/api/ingestion/verification/coverage?from=2026-06-13&to=2026-06-19&shop_ref=shop-backfill');
+
+        self::assertResponseIsSuccessful();
+        $coverage = $this->json($client);
+        self::assertCount(7, $coverage['cells']);
+        self::assertSame($dates, array_column($coverage['cells'], 'date'));
+        self::assertSame([1, 0, 0, 0, 0, 0, 0], array_column($coverage['cells'], 'issue_count'));
+
+        foreach ($coverage['cells'] as $cell) {
+            self::assertSame('shop-backfill', $cell['shop_ref']);
+            self::assertSame('ozon_seller_daily_report', $cell['resource_type']);
+            self::assertSame(1, $cell['raw_count']);
+            self::assertSame(1, $cell['tx_count']);
+            self::assertSame('2026-06-20T07:00:00Z', $cell['last_fetched_at']);
+        }
+    }
+
     public function testInvalidPeriodUsesUnifiedErrorFormat(): void
     {
         $client = static::createClient();
@@ -108,6 +186,7 @@ final class VerificationApiControllerTest extends WebTestCaseBase
         self::assertResponseIsSuccessful();
         $coverage = $this->json($client);
         self::assertSame(['shop-a'], array_column($coverage['cells'], 'shop_ref'));
+        self::assertSame([1], array_column($coverage['cells'], 'issue_count'));
         self::assertSame(['shop-a'], array_column($coverage['shops'], 'shop_ref'));
 
         $client->request('GET', '/api/ingestion/verification/reconciliation?shop_ref=shop-a&year=2026&month=6');
@@ -265,6 +344,13 @@ final class VerificationApiControllerTest extends WebTestCaseBase
             NormalizationIssueKind::MAPPER_FAILURE,
             [],
         ));
+        $em->persist(new NormalizationIssue(
+            $companyB->getId(),
+            $rawA->getId(),
+            null,
+            NormalizationIssueKind::MAPPER_FAILURE,
+            [],
+        ));
         foreach ([$checkA, $checkB, $categoryA, $categoryB, $snapshotA, $snapshotB] as $entity) {
             $em->persist($entity);
         }
@@ -273,8 +359,13 @@ final class VerificationApiControllerTest extends WebTestCaseBase
         return [$ownerA, $companyA];
     }
 
-    private function rawRecord(string $companyId, string $shopRef, string $resourceType, string $externalId): IngestRawRecord
-    {
+    private function rawRecord(
+        string $companyId,
+        string $shopRef,
+        string $resourceType,
+        string $externalId,
+        ?\DateTimeImmutable $fetchedAt = null,
+    ): IngestRawRecord {
         return new IngestRawRecord(
             companyId: $companyId,
             connectionRef: 'connection-1',
@@ -285,7 +376,7 @@ final class VerificationApiControllerTest extends WebTestCaseBase
             storagePath: sprintf('%s/%s.ndjson.gz', $companyId, $externalId),
             hash: hash('sha256', $companyId.$externalId),
             byteSize: 100,
-            fetchedAt: new \DateTimeImmutable('2026-06-15 10:00:00+00:00'),
+            fetchedAt: $fetchedAt ?? new \DateTimeImmutable('2026-06-15 10:00:00+00:00'),
             syncJobId: 'job-'.$externalId,
         );
     }
@@ -297,6 +388,7 @@ final class VerificationApiControllerTest extends WebTestCaseBase
         int $amountMinor,
         TransactionType $type,
         string $shopRef = 'shop-1',
+        ?\DateTimeImmutable $occurredAt = null,
     ): FinancialTransaction {
         return new FinancialTransaction(
             companyId: $companyId,
@@ -309,7 +401,7 @@ final class VerificationApiControllerTest extends WebTestCaseBase
             type: $type,
             direction: $amountMinor >= 0 ? TransactionDirection::IN : TransactionDirection::OUT,
             money: Money::fromMinor($amountMinor, 'RUB'),
-            occurredAt: new \DateTimeImmutable('2026-06-15 10:00:00+00:00'),
+            occurredAt: $occurredAt ?? new \DateTimeImmutable('2026-06-15 10:00:00+00:00'),
             rawRecordId: $rawRecordId,
         );
     }

--- a/site/tests/Functional/Ingestion/Controller/VerificationApiControllerTest.php
+++ b/site/tests/Functional/Ingestion/Controller/VerificationApiControllerTest.php
@@ -126,6 +126,13 @@ final class VerificationApiControllerTest extends WebTestCaseBase
             NormalizationIssueKind::SUM_MISMATCH,
             [],
         ));
+        $em->persist(new NormalizationIssue(
+            $company->getId(),
+            $firstRaw->getId(),
+            null,
+            NormalizationIssueKind::MAPPER_FAILURE,
+            [],
+        ));
         $em->persist($resolvedIssue);
         $em->flush();
 
@@ -136,7 +143,7 @@ final class VerificationApiControllerTest extends WebTestCaseBase
         $coverage = $this->json($client);
         self::assertCount(7, $coverage['cells']);
         self::assertSame($dates, array_column($coverage['cells'], 'date'));
-        self::assertSame([1, 0, 0, 0, 0, 0, 0], array_column($coverage['cells'], 'issue_count'));
+        self::assertSame([2, 0, 0, 0, 0, 0, 0], array_column($coverage['cells'], 'issue_count'));
 
         foreach ($coverage['cells'] as $cell) {
             self::assertSame('shop-backfill', $cell['shop_ref']);


### PR DESCRIPTION
## Summary
- Build ingestion coverage heatmap from canonical transaction `occurred_at` dates instead of raw fetch dates.
- Keep raw records as LEFT JOIN data for `raw_count`, `resource_type`, and `last_fetched_at`.
- Keep normalization issues as an open-only LEFT JOIN and enforce `company_id` on every joined table.
- Add functional regression coverage for 13-19 June backfill, open-only issues, and tenant isolation.

## Root Cause
`CoverageQuery::heatmap()` used `ingest_raw_records.fetched_at` as the grouping and period source. During backfill, all raw records are fetched on the same day, so the client saw one heatmap day even when canonical transactions covered multiple operation days.

## Validation
- `make site-test-prepare` passed.
- `docker compose run --rm site-php-cli php bin/phpunit --testsuite functional --filter VerificationApiControllerTest` passed: 4 tests, 76 assertions.
- Targeted PHP-CS-Fixer dry-run for changed files passed.
- `git diff --check` passed.

## Note
`make site-cs-check` still fails on pre-existing repo-wide formatting issues outside this PR scope: 661 of 1780 files can be fixed.