### PR TITLE
[codex] Add Ozon accrual ingestion shadow flow

### DIFF
--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -139,6 +139,7 @@ services:
 
     App\Ingestion\Infrastructure\Api\Ozon\OzonCredentialProviderInterface: '@App\Ingestion\Infrastructure\Api\Ozon\CredentialFacadeOzonCredentialProvider'
     App\Ingestion\Infrastructure\Api\Ozon\OzonClientAdapterInterface: '@App\Ingestion\Infrastructure\Api\Ozon\LegacyOzonClientAdapter'
+    App\Ingestion\Infrastructure\Api\Ozon\OzonAccrualClientInterface: '@App\Ingestion\Infrastructure\Api\Ozon\OzonAccrualClient'
 
     App\Ingestion\Application\Source\Ozon\OzonSellerReportConnector:
         arguments:
@@ -151,6 +152,9 @@ services:
         tags: ['app.ingestion.mapper']
 
     App\Ingestion\Application\Source\Ozon\OzonRealizationMapper:
+        tags: ['app.ingestion.mapper']
+
+    App\Ingestion\Application\Source\Ozon\OzonAccrualShadowMapper:
         tags: ['app.ingestion.mapper']
 
     App\Ingestion\Domain\Service\ConnectorRegistry:

--- a/site/src/Ingestion/Application/Source/Ozon/OzonAccrualShadowMapper.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonAccrualShadowMapper.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Source\Ozon;
+
+use App\Ingestion\Application\DTO\MappedControlSum;
+use App\Ingestion\Application\DTO\MappedTransaction;
+use App\Ingestion\Domain\Contract\SourceMapperInterface;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\IngestSource;
+
+final readonly class OzonAccrualShadowMapper implements SourceMapperInterface
+{
+    public function source(): IngestSource
+    {
+        return IngestSource::OZON;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function resourceTypes(): array
+    {
+        return [
+            OzonResourceType::ACCRUAL_POSTINGS,
+            OzonResourceType::ACCRUAL_BY_DAY,
+            OzonResourceType::ACCRUAL_TYPES,
+        ];
+    }
+
+    /**
+     * @param iterable<array<string, mixed>> $rows
+     *
+     * @return list<MappedTransaction>
+     */
+    public function map(IngestRawRecord $rawRecord, iterable $rows): array
+    {
+        return [];
+    }
+
+    /**
+     * @param iterable<array<string, mixed>> $rows
+     *
+     * @return list<MappedControlSum>
+     */
+    public function controlSum(iterable $rows): array
+    {
+        return [];
+    }
+}

--- a/site/src/Ingestion/Application/Source/Ozon/OzonResourceType.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonResourceType.php
@@ -8,4 +8,7 @@ final class OzonResourceType
 {
     public const DAILY_REPORT = 'ozon_seller_daily_report';
     public const REALIZATION = 'ozon_seller_realization';
+    public const ACCRUAL_POSTINGS = 'ozon_finance_accrual_postings';
+    public const ACCRUAL_BY_DAY = 'ozon_finance_accrual_by_day';
+    public const ACCRUAL_TYPES = 'ozon_finance_accrual_types';
 }

--- a/site/src/Ingestion/Application/Source/Ozon/OzonSellerReportConnector.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonSellerReportConnector.php
@@ -14,6 +14,7 @@ use App\Ingestion\DTO\RawBatch;
 use App\Ingestion\Enum\Capability;
 use App\Ingestion\Enum\IngestSource;
 use App\Ingestion\Exception\UnsupportedCapabilityException;
+use App\Ingestion\Infrastructure\Api\Ozon\OzonAccrualClientInterface;
 use App\Ingestion\Infrastructure\Api\Ozon\OzonClientAdapterInterface;
 use Psr\Log\LoggerInterface;
 
@@ -24,6 +25,7 @@ final readonly class OzonSellerReportConnector implements SourceConnectorInterfa
 
     public function __construct(
         private OzonClientAdapterInterface $client,
+        private OzonAccrualClientInterface $accrualClient,
         private LoggerInterface $logger,
         private int $chunkSizeDays = 7,
         private int $hotRewindDays = 14,
@@ -65,6 +67,9 @@ final readonly class OzonSellerReportConnector implements SourceConnectorInterfa
         return match ($request->resourceType) {
             OzonResourceType::DAILY_REPORT => $this->pullDailyReport($request),
             OzonResourceType::REALIZATION => $this->pullRealization($request),
+            OzonResourceType::ACCRUAL_POSTINGS => $this->pullAccrualPostings($request),
+            OzonResourceType::ACCRUAL_BY_DAY => $this->pullAccrualByDay($request),
+            OzonResourceType::ACCRUAL_TYPES => $this->pullAccrualTypes($request),
             default => throw new \InvalidArgumentException(sprintf('Unsupported Ozon resource type "%s".', $request->resourceType)),
         };
     }
@@ -166,6 +171,133 @@ final readonly class OzonSellerReportConnector implements SourceConnectorInterfa
         );
     }
 
+    private function pullAccrualPostings(PullRequest $request): PullResult
+    {
+        [$from, $to] = $this->resolveDailyWindow($request);
+        $rows = [];
+        $page = 1;
+        $hasRemoteMore = false;
+
+        do {
+            $pageResult = $this->accrualClient->fetchPostings(
+                $request->companyId,
+                $request->connectionRef,
+                $from,
+                $to,
+                $page,
+                self::PAGE_SIZE,
+            );
+
+            if ([] !== $pageResult->rows) {
+                array_push($rows, ...$pageResult->rows);
+            }
+
+            $hasRemoteMore = $pageResult->hasMore;
+            ++$page;
+        } while ($hasRemoteMore && $page <= self::MAX_PAGES_PER_PULL);
+
+        if ($hasRemoteMore) {
+            $this->logger->warning('Ozon accrual postings pagination cap reached.', [
+                'companyId' => $request->companyId,
+                'connectionRef' => $request->connectionRef,
+                'from' => $from->format('Y-m-d'),
+                'to' => $to->format('Y-m-d'),
+                'maxPages' => self::MAX_PAGES_PER_PULL,
+            ]);
+
+            throw new \RuntimeException('Ozon accrual postings pagination cap reached before all rows were fetched.');
+        }
+
+        $windowHasMore = null !== $request->windowTo && $to < $request->windowTo;
+        $nextCursor = $windowHasMore || $this->isIncremental($request) ? $to->modify('+1 day')->format('Y-m-d') : null;
+
+        return new PullResult(
+            rawBatch: new RawBatch(
+                companyId: $request->companyId,
+                connectionRef: $request->connectionRef,
+                shopRef: $request->shopRef,
+                source: IngestSource::OZON,
+                resourceType: OzonResourceType::ACCRUAL_POSTINGS,
+                externalId: sprintf('accrual-postings:%s:%s', $from->format('Y-m-d'), $to->format('Y-m-d')),
+                syncJobId: $request->syncJobId,
+                fetchedAt: new \DateTimeImmutable(),
+                rows: $this->rowsOrEmptyMarker(
+                    $rows,
+                    OzonResourceType::ACCRUAL_POSTINGS,
+                    [
+                        'windowFrom' => $from->format('Y-m-d'),
+                        'windowTo' => $to->format('Y-m-d'),
+                    ],
+                ),
+            ),
+            nextCursorValue: $nextCursor,
+            hasMore: $windowHasMore,
+        );
+    }
+
+    private function pullAccrualByDay(PullRequest $request): PullResult
+    {
+        [$from, $to] = $this->resolveDailyWindow($request);
+        $page = $this->accrualClient->fetchByDay(
+            $request->companyId,
+            $request->connectionRef,
+            $from,
+            $to,
+        );
+
+        $windowHasMore = null !== $request->windowTo && $to < $request->windowTo;
+        $nextCursor = $windowHasMore || $this->isIncremental($request) ? $to->modify('+1 day')->format('Y-m-d') : null;
+
+        return new PullResult(
+            rawBatch: new RawBatch(
+                companyId: $request->companyId,
+                connectionRef: $request->connectionRef,
+                shopRef: $request->shopRef,
+                source: IngestSource::OZON,
+                resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+                externalId: sprintf('accrual-by-day:%s:%s', $from->format('Y-m-d'), $to->format('Y-m-d')),
+                syncJobId: $request->syncJobId,
+                fetchedAt: new \DateTimeImmutable(),
+                rows: $this->rowsOrEmptyMarker(
+                    $page->rows,
+                    OzonResourceType::ACCRUAL_BY_DAY,
+                    [
+                        'windowFrom' => $from->format('Y-m-d'),
+                        'windowTo' => $to->format('Y-m-d'),
+                        'apiMetadata' => $page->metadata,
+                    ],
+                ),
+            ),
+            nextCursorValue: $nextCursor,
+            hasMore: $windowHasMore,
+        );
+    }
+
+    private function pullAccrualTypes(PullRequest $request): PullResult
+    {
+        $page = $this->accrualClient->fetchTypes($request->companyId, $request->connectionRef);
+
+        return new PullResult(
+            rawBatch: new RawBatch(
+                companyId: $request->companyId,
+                connectionRef: $request->connectionRef,
+                shopRef: $request->shopRef,
+                source: IngestSource::OZON,
+                resourceType: OzonResourceType::ACCRUAL_TYPES,
+                externalId: 'accrual-types',
+                syncJobId: $request->syncJobId,
+                fetchedAt: new \DateTimeImmutable(),
+                rows: $this->rowsOrEmptyMarker(
+                    $page->rows,
+                    OzonResourceType::ACCRUAL_TYPES,
+                    ['apiMetadata' => $page->metadata],
+                ),
+            ),
+            nextCursorValue: null,
+            hasMore: false,
+        );
+    }
+
     /**
      * @return array{0: \DateTimeImmutable, 1: \DateTimeImmutable}
      */
@@ -212,5 +344,24 @@ final readonly class OzonSellerReportConnector implements SourceConnectorInterfa
             && '' !== $request->cursorValue
             && null === $request->windowFrom
             && null === $request->windowTo;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     * @param array<string, mixed> $metadata
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function rowsOrEmptyMarker(array $rows, string $resourceType, array $metadata): array
+    {
+        if ([] !== $rows) {
+            return $rows;
+        }
+
+        return [[
+            '_ingestion_empty' => true,
+            '_ingestion_resource' => $resourceType,
+            '_ingestion_metadata' => $metadata,
+        ]];
     }
 }

--- a/site/src/Ingestion/Command/OzonAccrualCompareCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualCompareCommand.php
@@ -1,0 +1,352 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Command;
+
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Facade\RawStorageFacade;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Webmozart\Assert\Assert;
+
+#[AsCommand(
+    name: 'app:ingestion:ozon-accrual:compare',
+    description: 'Compares current Ozon canonical transactions with stored Ozon accrual raw structures.',
+)]
+final class OzonAccrualCompareCommand extends Command
+{
+    /**
+     * @var list<string>
+     */
+    private const RESOURCE_TYPES = [
+        OzonResourceType::ACCRUAL_POSTINGS,
+        OzonResourceType::ACCRUAL_BY_DAY,
+        OzonResourceType::ACCRUAL_TYPES,
+    ];
+
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly RawStorageFacade $rawStorageFacade,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Company UUID.')
+            ->addOption('from', null, InputOption::VALUE_REQUIRED, 'Start date YYYY-MM-DD.')
+            ->addOption('to', null, InputOption::VALUE_REQUIRED, 'End date YYYY-MM-DD.')
+            ->addOption('resource-type', null, InputOption::VALUE_REQUIRED, 'Accrual resource type.', OzonResourceType::ACCRUAL_POSTINGS)
+            ->addOption('raw-limit', null, InputOption::VALUE_REQUIRED, 'Raw records to scan, 1..50.', 20)
+            ->addOption('raw-row-limit', null, InputOption::VALUE_REQUIRED, 'Rows to scan per raw record, 1..50000.', 5000);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        try {
+            $companyId = $this->requiredUuidOption($input, 'company-id');
+            [$from, $to] = $this->requiredDateWindow($input);
+            $resourceType = $this->resourceType($input);
+            $rawLimit = $this->intOption($input, 'raw-limit', 1, 50);
+            $rawRowLimit = $this->intOption($input, 'raw-row-limit', 1, 50000);
+        } catch (\Throwable $exception) {
+            $io->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $io->title('Ozon accrual compare');
+        $this->printCanonicalSummary($io, $companyId, $from, $to);
+        $rawRecords = $this->rawRecords($companyId, $resourceType, $from, $to, $rawLimit);
+        $this->printRawRecords($io, $rawRecords);
+        $this->printRawStructureSummary($io, $companyId, $rawRecords, $rawRowLimit);
+
+        return Command::SUCCESS;
+    }
+
+    private function printCanonicalSummary(SymfonyStyle $io, string $companyId, \DateTimeImmutable $from, \DateTimeImmutable $to): void
+    {
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT DATE(occurred_at) AS date,
+                    type,
+                    direction,
+                    COUNT(*) AS tx_count,
+                    COALESCE(SUM(amount_minor), 0)::numeric / 100 AS total_rub
+             FROM ingest_financial_transactions
+             WHERE company_id = :companyId
+               AND source = :source
+               AND occurred_at >= :fromAt
+               AND occurred_at <= :toAt
+             GROUP BY DATE(occurred_at), type, direction
+             ORDER BY DATE(occurred_at), type, direction',
+            [
+                'companyId' => $companyId,
+                'source' => IngestSource::OZON->value,
+                'fromAt' => $from->format('Y-m-d 00:00:00'),
+                'toAt' => $to->format('Y-m-d 23:59:59'),
+            ],
+        );
+
+        $io->section('Current canonical transactions');
+        if ([] === $rows) {
+            $io->writeln('No canonical Ozon transactions found for the period.');
+
+            return;
+        }
+
+        $io->table(
+            ['date', 'type', 'direction', 'txCount', 'totalRub'],
+            array_map(static fn (array $row): array => [
+                (string) $row['date'],
+                (string) $row['type'],
+                (string) $row['direction'],
+                (string) $row['tx_count'],
+                (string) $row['total_rub'],
+            ], $rows),
+        );
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function rawRecords(
+        string $companyId,
+        string $resourceType,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        int $limit,
+    ): array {
+        return $this->connection->fetchAllAssociative(
+            sprintf(
+                'SELECT r.id,
+                        r.resource_type,
+                        r.external_id,
+                        r.fetched_at,
+                        r.byte_size,
+                        r.normalization_status
+                 FROM ingest_raw_records r
+                 LEFT JOIN ingest_sync_jobs j ON j.id::text = r.sync_job_id AND j.company_id = r.company_id
+                 WHERE r.company_id = :companyId
+                   AND r.source = :source
+                   AND r.resource_type = :resourceType
+                   AND (j.id IS NULL OR j.window_from IS NULL OR j.window_to IS NULL OR (j.window_from <= :toDate AND j.window_to >= :fromDate))
+                 ORDER BY r.fetched_at DESC, r.created_at DESC
+                 LIMIT %d',
+                $limit,
+            ),
+            [
+                'companyId' => $companyId,
+                'source' => IngestSource::OZON->value,
+                'resourceType' => $resourceType,
+                'fromDate' => $from->format('Y-m-d'),
+                'toDate' => $to->format('Y-m-d'),
+            ],
+        );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rawRecords
+     */
+    private function printRawRecords(SymfonyStyle $io, array $rawRecords): void
+    {
+        $io->section('Stored accrual raw records');
+        if ([] === $rawRecords) {
+            $io->writeln('No raw records found for the selected accrual resource type and period.');
+
+            return;
+        }
+
+        $io->table(
+            ['rawId', 'resourceType', 'externalId', 'status', 'bytes', 'fetchedAt'],
+            array_map(static fn (array $row): array => [
+                (string) $row['id'],
+                (string) $row['resource_type'],
+                (string) $row['external_id'],
+                (string) $row['normalization_status'],
+                (string) $row['byte_size'],
+                (string) $row['fetched_at'],
+            ], $rawRecords),
+        );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rawRecords
+     */
+    private function printRawStructureSummary(SymfonyStyle $io, string $companyId, array $rawRecords, int $rowLimit): void
+    {
+        if ([] === $rawRecords) {
+            return;
+        }
+
+        $keyCounts = [];
+        $identifierCounts = [];
+        $amountSums = [];
+        $scannedRows = 0;
+
+        foreach ($rawRecords as $rawRecord) {
+            $recordRows = 0;
+            foreach ($this->rawStorageFacade->read((string) $rawRecord['id'], $companyId) as $row) {
+                if ($recordRows >= $rowLimit) {
+                    break;
+                }
+
+                ++$recordRows;
+                ++$scannedRows;
+
+                foreach ($row as $key => $value) {
+                    $keyCounts[$key] = ($keyCounts[$key] ?? 0) + 1;
+
+                    if (preg_match('/(?:operation_id|posting_number|accrual_id|type_id|sku|order_id)/i', $key)) {
+                        $identifierCounts[$key] = ($identifierCounts[$key] ?? 0) + 1;
+                    }
+
+                    if (preg_match('/(?:amount|price|sum|commission|fee|delivery|acquiring|service|charge)/i', $key)) {
+                        $numeric = $this->numericValue($value);
+                        if (null !== $numeric) {
+                            $amountSums[$key] = ($amountSums[$key] ?? 0.0) + $numeric;
+                        }
+                    }
+                }
+            }
+        }
+
+        arsort($keyCounts);
+        arsort($identifierCounts);
+        arsort($amountSums);
+
+        $io->section('Raw structure summary');
+        $io->writeln(sprintf('Scanned rows: %d', $scannedRows));
+
+        $this->printFrequencyTable($io, 'Top keys', $keyCounts);
+        $this->printFrequencyTable($io, 'Identifier-like keys', $identifierCounts);
+        $this->printAmountTable($io, $amountSums);
+    }
+
+    /**
+     * @param array<string, int> $counts
+     */
+    private function printFrequencyTable(SymfonyStyle $io, string $title, array $counts): void
+    {
+        $io->section($title);
+        if ([] === $counts) {
+            $io->writeln('No matching keys found.');
+
+            return;
+        }
+
+        $rows = [];
+        foreach (array_slice($counts, 0, 20, true) as $key => $count) {
+            $rows[] = [$key, (string) $count];
+        }
+
+        $io->table(['key', 'count'], $rows);
+    }
+
+    /**
+     * @param array<string, float> $amountSums
+     */
+    private function printAmountTable(SymfonyStyle $io, array $amountSums): void
+    {
+        $io->section('Amount-like key sums');
+        if ([] === $amountSums) {
+            $io->writeln('No numeric amount-like keys found.');
+
+            return;
+        }
+
+        $rows = [];
+        foreach (array_slice($amountSums, 0, 20, true) as $key => $sum) {
+            $rows[] = [$key, number_format($sum, 2, '.', '')];
+        }
+
+        $io->table(['key', 'sum'], $rows);
+    }
+
+    private function requiredUuidOption(InputInterface $input, string $name): string
+    {
+        $value = trim((string) $input->getOption($name));
+        Assert::uuid($value, sprintf('Invalid --%s UUID.', $name));
+
+        return $value;
+    }
+
+    /**
+     * @return array{0: \DateTimeImmutable, 1: \DateTimeImmutable}
+     */
+    private function requiredDateWindow(InputInterface $input): array
+    {
+        $from = $this->requiredDateOption($input, 'from');
+        $to = $this->requiredDateOption($input, 'to');
+        if ($from > $to) {
+            throw new \InvalidArgumentException('The --from date cannot be later than --to.');
+        }
+
+        return [$from, $to];
+    }
+
+    private function requiredDateOption(InputInterface $input, string $name): \DateTimeImmutable
+    {
+        $value = trim((string) $input->getOption($name));
+        Assert::notEmpty($value, sprintf('The --%s option is required.', $name));
+
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
+        if (false === $date || $date->format('Y-m-d') !== $value) {
+            throw new \InvalidArgumentException(sprintf('The --%s option must be a YYYY-MM-DD date.', $name));
+        }
+
+        return $date;
+    }
+
+    private function resourceType(InputInterface $input): string
+    {
+        $value = trim((string) $input->getOption('resource-type'));
+        if (!in_array($value, self::RESOURCE_TYPES, true)) {
+            throw new \InvalidArgumentException(sprintf('Unsupported accrual resource type "%s".', $value));
+        }
+
+        return $value;
+    }
+
+    private function intOption(InputInterface $input, string $name, int $min, int $max): int
+    {
+        $value = (string) $input->getOption($name);
+        if (!ctype_digit($value)) {
+            throw new \InvalidArgumentException(sprintf('The --%s option must be an integer from %d to %d.', $name, $min, $max));
+        }
+
+        $number = (int) $value;
+        if ($number < $min || $number > $max) {
+            throw new \InvalidArgumentException(sprintf('The --%s option must be an integer from %d to %d.', $name, $min, $max));
+        }
+
+        return $number;
+    }
+
+    private function numericValue(mixed $value): ?float
+    {
+        if (is_int($value) || is_float($value)) {
+            return (float) $value;
+        }
+
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $normalized = str_replace([' ', ','], ['', '.'], trim($value));
+        if (!is_numeric($normalized)) {
+            return null;
+        }
+
+        return (float) $normalized;
+    }
+}

--- a/site/src/Ingestion/Command/OzonAccrualProbeCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualProbeCommand.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Command;
+
+use App\Ingestion\Infrastructure\Api\Ozon\OzonAccrualClientInterface;
+use App\Ingestion\Infrastructure\Api\Ozon\OzonRawPage;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Webmozart\Assert\Assert;
+
+#[AsCommand(
+    name: 'app:ingestion:ozon-accrual:probe',
+    description: 'Reads Ozon accrual endpoints without writing anything to storage.',
+)]
+final class OzonAccrualProbeCommand extends Command
+{
+    public function __construct(private readonly OzonAccrualClientInterface $client)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Company UUID.')
+            ->addOption('connection-ref', null, InputOption::VALUE_REQUIRED, 'Marketplace connection UUID.')
+            ->addOption('endpoint', null, InputOption::VALUE_REQUIRED, 'Endpoint: postings, by-day, or types.', 'postings')
+            ->addOption('from', null, InputOption::VALUE_REQUIRED, 'Start date YYYY-MM-DD. Required for postings and by-day.')
+            ->addOption('to', null, InputOption::VALUE_REQUIRED, 'End date YYYY-MM-DD. Required for postings and by-day.')
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Sample rows to show, 1..20.', 5)
+            ->addOption('page-size', null, InputOption::VALUE_REQUIRED, 'Postings page size, 1..1000.', 100)
+            ->addOption('with-values', null, InputOption::VALUE_NONE, 'Print truncated sample JSON values. By default only keys are shown.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        try {
+            $companyId = $this->requiredUuidOption($input, 'company-id');
+            $connectionRef = $this->requiredUuidOption($input, 'connection-ref');
+            $endpoint = $this->endpoint($input);
+            $limit = $this->intOption($input, 'limit', 1, 20);
+            $pageSize = $this->intOption($input, 'page-size', 1, 1000);
+            [$from, $to] = 'types' === $endpoint ? [null, null] : $this->requiredDateWindow($input);
+
+            $page = match ($endpoint) {
+                'postings' => $this->client->fetchPostings($companyId, $connectionRef, $from, $to, 1, $pageSize),
+                'by-day' => $this->client->fetchByDay($companyId, $connectionRef, $from, $to),
+                'types' => $this->client->fetchTypes($companyId, $connectionRef),
+            };
+        } catch (\Throwable $exception) {
+            $io->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $io->title('Ozon accrual probe');
+        $io->table(
+            ['endpoint', 'rows', 'hasMore', 'nextPageToken'],
+            [[
+                $endpoint,
+                (string) count($page->rows),
+                $page->hasMore ? 'yes' : 'no',
+                $page->nextPageToken ?? '',
+            ]],
+        );
+
+        if ([] !== $page->metadata) {
+            $io->section('API metadata');
+            $io->writeln($this->json($page->metadata));
+        }
+
+        $this->printSamples($io, $page, $limit, (bool) $input->getOption('with-values'));
+
+        return Command::SUCCESS;
+    }
+
+    private function requiredUuidOption(InputInterface $input, string $name): string
+    {
+        $value = trim((string) $input->getOption($name));
+        Assert::uuid($value, sprintf('Invalid --%s UUID.', $name));
+
+        return $value;
+    }
+
+    private function endpoint(InputInterface $input): string
+    {
+        $value = trim((string) $input->getOption('endpoint'));
+        if (!in_array($value, ['postings', 'by-day', 'types'], true)) {
+            throw new \InvalidArgumentException('The --endpoint option must be one of: postings, by-day, types.');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return array{0: \DateTimeImmutable, 1: \DateTimeImmutable}
+     */
+    private function requiredDateWindow(InputInterface $input): array
+    {
+        $from = $this->requiredDateOption($input, 'from')->setTime(0, 0);
+        $to = $this->requiredDateOption($input, 'to')->setTime(23, 59, 59);
+        if ($from > $to) {
+            throw new \InvalidArgumentException('The --from date cannot be later than --to.');
+        }
+
+        return [$from, $to];
+    }
+
+    private function requiredDateOption(InputInterface $input, string $name): \DateTimeImmutable
+    {
+        $value = trim((string) $input->getOption($name));
+        Assert::notEmpty($value, sprintf('The --%s option is required.', $name));
+
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
+        if (false === $date || $date->format('Y-m-d') !== $value) {
+            throw new \InvalidArgumentException(sprintf('The --%s option must be a YYYY-MM-DD date.', $name));
+        }
+
+        return $date;
+    }
+
+    private function intOption(InputInterface $input, string $name, int $min, int $max): int
+    {
+        $value = (string) $input->getOption($name);
+        if (!ctype_digit($value)) {
+            throw new \InvalidArgumentException(sprintf('The --%s option must be an integer from %d to %d.', $name, $min, $max));
+        }
+
+        $number = (int) $value;
+        if ($number < $min || $number > $max) {
+            throw new \InvalidArgumentException(sprintf('The --%s option must be an integer from %d to %d.', $name, $min, $max));
+        }
+
+        return $number;
+    }
+
+    private function printSamples(SymfonyStyle $io, OzonRawPage $page, int $limit, bool $withValues): void
+    {
+        if ([] === $page->rows) {
+            $io->note('Endpoint returned no rows.');
+
+            return;
+        }
+
+        $rows = [];
+        foreach (array_slice($page->rows, 0, $limit) as $index => $row) {
+            $keys = array_keys($row);
+            sort($keys);
+
+            $rows[] = [
+                (string) ($index + 1),
+                implode(', ', $keys),
+                $withValues ? $this->truncate($this->json($row), 2000) : '',
+            ];
+        }
+
+        $io->section('Sample rows');
+        $io->table($withValues ? ['#', 'keys', 'json'] : ['#', 'keys'], array_map(
+            static fn (array $row): array => $withValues ? $row : [$row[0], $row[1]],
+            $rows,
+        ));
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function json(array $payload): string
+    {
+        return json_encode($payload, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES | \JSON_PRETTY_PRINT);
+    }
+
+    private function truncate(string $value, int $limit): string
+    {
+        if (strlen($value) <= $limit) {
+            return $value;
+        }
+
+        return substr($value, 0, $limit).'...';
+    }
+}

--- a/site/src/Ingestion/Command/OzonAccrualStatusCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualStatusCommand.php
@@ -1,0 +1,323 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Command;
+
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Enum\IngestSource;
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Webmozart\Assert\Assert;
+
+#[AsCommand(
+    name: 'app:ingestion:ozon-accrual:status',
+    description: 'Shows Ozon accrual ingestion jobs and raw storage status.',
+)]
+final class OzonAccrualStatusCommand extends Command
+{
+    /**
+     * @var list<string>
+     */
+    private const RESOURCE_TYPES = [
+        OzonResourceType::ACCRUAL_POSTINGS,
+        OzonResourceType::ACCRUAL_BY_DAY,
+        OzonResourceType::ACCRUAL_TYPES,
+    ];
+
+    public function __construct(private readonly Connection $connection)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Company UUID.')
+            ->addOption('from', null, InputOption::VALUE_REQUIRED, 'Optional job window start date YYYY-MM-DD.')
+            ->addOption('to', null, InputOption::VALUE_REQUIRED, 'Optional job window end date YYYY-MM-DD.')
+            ->addOption('resource-type', null, InputOption::VALUE_REQUIRED, 'Optional accrual resource type filter.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        try {
+            $companyId = $this->requiredUuidOption($input, 'company-id');
+            $resourceTypes = $this->resourceTypes($input);
+            [$from, $to] = $this->dateWindow($input);
+        } catch (\Throwable $exception) {
+            $io->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $io->title('Ozon accrual ingestion status');
+        $this->printJobs($io, $companyId, $resourceTypes, $from, $to);
+        $this->printRawRecords($io, $companyId, $resourceTypes, $from, $to);
+        $this->printLatestErrors($io, $companyId, $resourceTypes, $from, $to);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param list<string> $resourceTypes
+     */
+    private function printJobs(
+        SymfonyStyle $io,
+        string $companyId,
+        array $resourceTypes,
+        ?\DateTimeImmutable $from,
+        ?\DateTimeImmutable $to,
+    ): void {
+        [$conditions, $params, $types] = $this->jobFilter($companyId, $resourceTypes, $from, $to);
+
+        $rows = $this->connection->fetchAllAssociative(
+            sprintf(
+                'SELECT resource_type, status, COUNT(*) AS jobs, COALESCE(SUM(progress_total), 0) AS progress_total, COALESCE(SUM(progress_done), 0) AS progress_done, MAX(updated_at) AS latest_update
+                 FROM ingest_sync_jobs
+                 WHERE %s
+                 GROUP BY resource_type, status
+                 ORDER BY resource_type, status',
+                implode(' AND ', $conditions),
+            ),
+            $params,
+            $types,
+        );
+
+        $io->section('Sync jobs');
+        if ([] === $rows) {
+            $io->writeln('No jobs found.');
+
+            return;
+        }
+
+        $io->table(
+            ['resourceType', 'status', 'jobs', 'progress', 'latestUpdate'],
+            array_map(static fn (array $row): array => [
+                (string) $row['resource_type'],
+                (string) $row['status'],
+                (string) $row['jobs'],
+                sprintf('%s/%s', (string) $row['progress_done'], (string) $row['progress_total']),
+                (string) ($row['latest_update'] ?? ''),
+            ], $rows),
+        );
+    }
+
+    /**
+     * @param list<string> $resourceTypes
+     */
+    private function printRawRecords(
+        SymfonyStyle $io,
+        string $companyId,
+        array $resourceTypes,
+        ?\DateTimeImmutable $from,
+        ?\DateTimeImmutable $to,
+    ): void {
+        $conditions = [
+            'r.company_id = :companyId',
+            'r.source = :source',
+            'r.resource_type IN (:resourceTypes)',
+        ];
+        $params = [
+            'companyId' => $companyId,
+            'source' => IngestSource::OZON->value,
+            'resourceTypes' => $resourceTypes,
+        ];
+        $types = ['resourceTypes' => ArrayParameterType::STRING];
+
+        if (null !== $from && null !== $to) {
+            $conditions[] = '(j.id IS NULL OR j.window_from IS NULL OR j.window_to IS NULL OR (j.window_from <= :toDate AND j.window_to >= :fromDate))';
+            $params['fromDate'] = $from->format('Y-m-d');
+            $params['toDate'] = $to->format('Y-m-d');
+        }
+
+        $rows = $this->connection->fetchAllAssociative(
+            sprintf(
+                "SELECT r.resource_type,
+                        COUNT(*) AS raw_records,
+                        COALESCE(SUM(r.byte_size), 0) AS byte_size,
+                        MAX(r.fetched_at) AS last_fetched_at,
+                        COUNT(*) FILTER (WHERE r.normalization_status = 'pending') AS pending_raw,
+                        COUNT(*) FILTER (WHERE r.normalization_status = 'done') AS done_raw,
+                        COUNT(*) FILTER (WHERE r.normalization_status = 'failed') AS failed_raw
+                 FROM ingest_raw_records r
+                 LEFT JOIN ingest_sync_jobs j ON j.id::text = r.sync_job_id AND j.company_id = r.company_id
+                 WHERE %s
+                 GROUP BY r.resource_type
+                 ORDER BY r.resource_type",
+                implode(' AND ', $conditions),
+            ),
+            $params,
+            $types,
+        );
+
+        $io->section('Raw records');
+        if ([] === $rows) {
+            $io->writeln('No raw records found.');
+
+            return;
+        }
+
+        $io->table(
+            ['resourceType', 'raw', 'pending', 'done', 'failed', 'bytes', 'lastFetchedAt'],
+            array_map(static fn (array $row): array => [
+                (string) $row['resource_type'],
+                (string) $row['raw_records'],
+                (string) $row['pending_raw'],
+                (string) $row['done_raw'],
+                (string) $row['failed_raw'],
+                (string) $row['byte_size'],
+                (string) ($row['last_fetched_at'] ?? ''),
+            ], $rows),
+        );
+    }
+
+    /**
+     * @param list<string> $resourceTypes
+     */
+    private function printLatestErrors(
+        SymfonyStyle $io,
+        string $companyId,
+        array $resourceTypes,
+        ?\DateTimeImmutable $from,
+        ?\DateTimeImmutable $to,
+    ): void {
+        [$conditions, $params, $types] = $this->jobFilter($companyId, $resourceTypes, $from, $to);
+        $conditions[] = 'last_error IS NOT NULL';
+
+        $rows = $this->connection->fetchAllAssociative(
+            sprintf(
+                'SELECT id, resource_type, status, updated_at, last_error
+                 FROM ingest_sync_jobs
+                 WHERE %s
+                 ORDER BY updated_at DESC
+                 LIMIT 10',
+                implode(' AND ', $conditions),
+            ),
+            $params,
+            $types,
+        );
+
+        $io->section('Latest job errors');
+        if ([] === $rows) {
+            $io->writeln('No job errors found.');
+
+            return;
+        }
+
+        $io->table(
+            ['jobId', 'resourceType', 'status', 'updatedAt', 'error'],
+            array_map(fn (array $row): array => [
+                (string) $row['id'],
+                (string) $row['resource_type'],
+                (string) $row['status'],
+                (string) $row['updated_at'],
+                $this->truncate((string) $row['last_error'], 180),
+            ], $rows),
+        );
+    }
+
+    private function requiredUuidOption(InputInterface $input, string $name): string
+    {
+        $value = trim((string) $input->getOption($name));
+        Assert::uuid($value, sprintf('Invalid --%s UUID.', $name));
+
+        return $value;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function resourceTypes(InputInterface $input): array
+    {
+        $requested = trim((string) $input->getOption('resource-type'));
+        if ('' === $requested) {
+            return self::RESOURCE_TYPES;
+        }
+
+        if (!in_array($requested, self::RESOURCE_TYPES, true)) {
+            throw new \InvalidArgumentException(sprintf('Unsupported accrual resource type "%s".', $requested));
+        }
+
+        return [$requested];
+    }
+
+    /**
+     * @return array{0: ?\DateTimeImmutable, 1: ?\DateTimeImmutable}
+     */
+    private function dateWindow(InputInterface $input): array
+    {
+        $fromValue = trim((string) $input->getOption('from'));
+        $toValue = trim((string) $input->getOption('to'));
+        if ('' === $fromValue && '' === $toValue) {
+            return [null, null];
+        }
+
+        if ('' === $fromValue || '' === $toValue) {
+            throw new \InvalidArgumentException('Both --from and --to must be provided when filtering by window.');
+        }
+
+        $from = $this->date($fromValue, 'from');
+        $to = $this->date($toValue, 'to');
+        if ($from > $to) {
+            throw new \InvalidArgumentException('The --from date cannot be later than --to.');
+        }
+
+        return [$from, $to];
+    }
+
+    private function date(string $value, string $name): \DateTimeImmutable
+    {
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
+        if (false === $date || $date->format('Y-m-d') !== $value) {
+            throw new \InvalidArgumentException(sprintf('The --%s option must be a YYYY-MM-DD date.', $name));
+        }
+
+        return $date;
+    }
+
+    /**
+     * @param list<string> $resourceTypes
+     *
+     * @return array{0: list<string>, 1: array<string, mixed>, 2: array<string, mixed>}
+     */
+    private function jobFilter(string $companyId, array $resourceTypes, ?\DateTimeImmutable $from, ?\DateTimeImmutable $to): array
+    {
+        $conditions = [
+            'company_id = :companyId',
+            'source = :source',
+            'resource_type IN (:resourceTypes)',
+        ];
+        $params = [
+            'companyId' => $companyId,
+            'source' => IngestSource::OZON->value,
+            'resourceTypes' => $resourceTypes,
+        ];
+        $types = ['resourceTypes' => ArrayParameterType::STRING];
+
+        if (null !== $from && null !== $to) {
+            $conditions[] = '(window_from IS NULL OR window_to IS NULL OR (window_from <= :toDate AND window_to >= :fromDate))';
+            $params['fromDate'] = $from->format('Y-m-d');
+            $params['toDate'] = $to->format('Y-m-d');
+        }
+
+        return [$conditions, $params, $types];
+    }
+
+    private function truncate(string $value, int $limit): string
+    {
+        if (strlen($value) <= $limit) {
+            return $value;
+        }
+
+        return substr($value, 0, $limit).'...';
+    }
+}

--- a/site/src/Ingestion/Command/RawInspectCommand.php
+++ b/site/src/Ingestion/Command/RawInspectCommand.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Command;
+
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Facade\RawStorageFacade;
+use App\Ingestion\Repository\IngestRawRecordRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Webmozart\Assert\Assert;
+
+#[AsCommand(
+    name: 'app:ingestion:raw:inspect',
+    description: 'Shows one stored ingestion raw record structure for a company.',
+)]
+final class RawInspectCommand extends Command
+{
+    public function __construct(
+        private readonly IngestRawRecordRepository $rawRecordRepository,
+        private readonly RawStorageFacade $rawStorageFacade,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('raw-record-id', InputArgument::REQUIRED, 'Raw record UUID.')
+            ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Company UUID.')
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Sample rows to inspect, 1..20.', 3)
+            ->addOption('with-values', null, InputOption::VALUE_NONE, 'Print truncated sample JSON values. By default only keys are shown.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        try {
+            $rawRecordId = trim((string) $input->getArgument('raw-record-id'));
+            Assert::uuid($rawRecordId, 'Invalid raw record UUID.');
+
+            $companyId = $this->requiredUuidOption($input, 'company-id');
+            $limit = $this->intOption($input, 'limit', 1, 20);
+            $withValues = (bool) $input->getOption('with-values');
+
+            $record = $this->rawRecordRepository->findByIdAndCompany($rawRecordId, $companyId);
+            if (null === $record) {
+                throw new \RuntimeException('Raw record was not found for the requested company.');
+            }
+        } catch (\Throwable $exception) {
+            $io->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $io->title('Ingestion raw record');
+        $this->printMetadata($io, $record);
+        $this->printRows($io, $record, $companyId, $limit, $withValues);
+
+        return Command::SUCCESS;
+    }
+
+    private function printMetadata(SymfonyStyle $io, IngestRawRecord $record): void
+    {
+        $io->table(
+            ['field', 'value'],
+            [
+                ['id', $record->getId()],
+                ['companyId', $record->getCompanyId()],
+                ['connectionRef', $record->getConnectionRef()],
+                ['shopRef', $record->getShopRef()],
+                ['source', $record->getSource()->value],
+                ['resourceType', $record->getResourceType()],
+                ['externalId', $record->getExternalId()],
+                ['syncJobId', $record->getSyncJobId()],
+                ['normalizationStatus', $record->getNormalizationStatus()->value],
+                ['fetchedAt', $record->getFetchedAt()->format('Y-m-d H:i:s')],
+                ['byteSize', (string) $record->getByteSize()],
+                ['hash', $record->getHash()],
+                ['storagePath', $record->getStoragePath()],
+            ],
+        );
+    }
+
+    private function printRows(SymfonyStyle $io, IngestRawRecord $record, string $companyId, int $limit, bool $withValues): void
+    {
+        $rows = [];
+        $totalSeen = 0;
+
+        foreach ($this->rawStorageFacade->read($record->getId(), $companyId) as $row) {
+            ++$totalSeen;
+            if (count($rows) >= $limit) {
+                continue;
+            }
+
+            $keys = array_keys($row);
+            sort($keys);
+
+            $rows[] = [
+                (string) $totalSeen,
+                implode(', ', $keys),
+                $withValues ? $this->truncate($this->json($row), 3000) : '',
+            ];
+        }
+
+        $io->section('Rows');
+        $io->writeln(sprintf('Read rows: %d', $totalSeen));
+        if ([] === $rows) {
+            $io->writeln('No rows found in storage.');
+
+            return;
+        }
+
+        $io->table($withValues ? ['#', 'keys', 'json'] : ['#', 'keys'], array_map(
+            static fn (array $row): array => $withValues ? $row : [$row[0], $row[1]],
+            $rows,
+        ));
+    }
+
+    private function requiredUuidOption(InputInterface $input, string $name): string
+    {
+        $value = trim((string) $input->getOption($name));
+        Assert::uuid($value, sprintf('Invalid --%s UUID.', $name));
+
+        return $value;
+    }
+
+    private function intOption(InputInterface $input, string $name, int $min, int $max): int
+    {
+        $value = (string) $input->getOption($name);
+        if (!ctype_digit($value)) {
+            throw new \InvalidArgumentException(sprintf('The --%s option must be an integer from %d to %d.', $name, $min, $max));
+        }
+
+        $number = (int) $value;
+        if ($number < $min || $number > $max) {
+            throw new \InvalidArgumentException(sprintf('The --%s option must be an integer from %d to %d.', $name, $min, $max));
+        }
+
+        return $number;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function json(array $payload): string
+    {
+        return json_encode($payload, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES | \JSON_PRETTY_PRINT);
+    }
+
+    private function truncate(string $value, int $limit): string
+    {
+        if (strlen($value) <= $limit) {
+            return $value;
+        }
+
+        return substr($value, 0, $limit).'...';
+    }
+}

--- a/site/src/Ingestion/Command/StartBackfillCommand.php
+++ b/site/src/Ingestion/Command/StartBackfillCommand.php
@@ -43,7 +43,6 @@ final class StartBackfillCommand extends Command
             OzonResourceType::DAILY_REPORT,
             OzonResourceType::ACCRUAL_POSTINGS,
             OzonResourceType::ACCRUAL_BY_DAY,
-            OzonResourceType::ACCRUAL_TYPES,
         ],
     ];
 

--- a/site/src/Ingestion/Command/StartBackfillCommand.php
+++ b/site/src/Ingestion/Command/StartBackfillCommand.php
@@ -29,9 +29,21 @@ final class StartBackfillCommand extends Command
     /**
      * @var array<string, list<string>>
      */
-    private const RESOURCE_TYPES_BY_SOURCE = [
+    private const DEFAULT_RESOURCE_TYPES_BY_SOURCE = [
         'ozon' => [
             OzonResourceType::DAILY_REPORT,
+        ],
+    ];
+
+    /**
+     * @var array<string, list<string>>
+     */
+    private const ALLOWED_RESOURCE_TYPES_BY_SOURCE = [
+        'ozon' => [
+            OzonResourceType::DAILY_REPORT,
+            OzonResourceType::ACCRUAL_POSTINGS,
+            OzonResourceType::ACCRUAL_BY_DAY,
+            OzonResourceType::ACCRUAL_TYPES,
         ],
     ];
 
@@ -161,7 +173,7 @@ final class StartBackfillCommand extends Command
         Assert::notEmpty($value, 'The --source option is required.');
 
         $source = IngestSource::tryFrom($value);
-        if (null === $source || !isset(self::RESOURCE_TYPES_BY_SOURCE[$source->value])) {
+        if (null === $source || !isset(self::ALLOWED_RESOURCE_TYPES_BY_SOURCE[$source->value])) {
             throw new \InvalidArgumentException(sprintf('Unsupported ingestion source "%s".', $value));
         }
 
@@ -188,14 +200,15 @@ final class StartBackfillCommand extends Command
      */
     private function resourceTypes(IngestSource $source, InputInterface $input): array
     {
-        $resourceTypes = self::RESOURCE_TYPES_BY_SOURCE[$source->value];
+        $defaultResourceTypes = self::DEFAULT_RESOURCE_TYPES_BY_SOURCE[$source->value];
+        $allowedResourceTypes = self::ALLOWED_RESOURCE_TYPES_BY_SOURCE[$source->value];
         $requested = trim((string) $input->getOption('resource-type'));
 
         if ('' === $requested) {
-            return $resourceTypes;
+            return $defaultResourceTypes;
         }
 
-        if (!in_array($requested, $resourceTypes, true)) {
+        if (!in_array($requested, $allowedResourceTypes, true)) {
             throw new \InvalidArgumentException(sprintf('Unsupported resource type "%s" for source "%s".', $requested, $source->value));
         }
 

--- a/site/src/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClient.php
+++ b/site/src/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClient.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Api\Ozon;
+
+use App\Ingestion\Exception\ConnectorAuthException;
+use App\Ingestion\Exception\ConnectorTransientException;
+use App\Ingestion\Exception\CredentialNotFoundException;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final readonly class OzonAccrualClient implements OzonAccrualClientInterface
+{
+    private const BASE_URL = 'https://api-seller.ozon.ru';
+    private const POSTINGS_ENDPOINT = '/v1/finance/accrual/postings';
+    private const BY_DAY_ENDPOINT = '/v1/finance/accrual/by-day';
+    private const TYPES_ENDPOINT = '/v1/finance/accrual/types';
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private OzonCredentialProviderInterface $credentialProvider,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function fetchPostings(
+        string $companyId,
+        string $connectionRef,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        int $page,
+        int $pageSize,
+    ): OzonRawPage {
+        $page = max(1, $page);
+        $pageSize = max(1, min(1000, $pageSize));
+        $offset = ($page - 1) * $pageSize;
+
+        return $this->requestPage(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            endpoint: self::POSTINGS_ENDPOINT,
+            json: [
+                'date' => [
+                    'from' => $from->format('Y-m-d'),
+                    'to' => $to->format('Y-m-d'),
+                ],
+                'limit' => $pageSize,
+                'offset' => $offset,
+            ],
+            page: $page,
+            pageSize: $pageSize,
+            offset: $offset,
+        );
+    }
+
+    public function fetchByDay(
+        string $companyId,
+        string $connectionRef,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+    ): OzonRawPage {
+        return $this->requestPage(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            endpoint: self::BY_DAY_ENDPOINT,
+            json: [
+                'date' => [
+                    'from' => $from->format('Y-m-d'),
+                    'to' => $to->format('Y-m-d'),
+                ],
+            ],
+        );
+    }
+
+    public function fetchTypes(string $companyId, string $connectionRef): OzonRawPage
+    {
+        return $this->requestPage(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            endpoint: self::TYPES_ENDPOINT,
+            json: [],
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $json
+     */
+    private function requestPage(
+        string $companyId,
+        string $connectionRef,
+        string $endpoint,
+        array $json,
+        int $page = 1,
+        int $pageSize = 0,
+        int $offset = 0,
+    ): OzonRawPage {
+        $payload = $this->requestJson($companyId, $connectionRef, $endpoint, $json);
+        $rows = $this->extractRows($payload);
+        $result = is_array($payload['result'] ?? null) ? $payload['result'] : [];
+        $total = $this->intValue($result['total'] ?? $payload['total'] ?? null);
+        $hasMore = (bool) ($result['has_next'] ?? $result['has_more'] ?? $payload['has_next'] ?? $payload['has_more'] ?? false);
+
+        if (!$hasMore && $total > 0 && $pageSize > 0) {
+            $hasMore = ($offset + \count($rows)) < $total;
+        }
+
+        return new OzonRawPage(
+            rows: $rows,
+            hasMore: $hasMore,
+            nextPageToken: $hasMore ? (string) ($page + 1) : null,
+            metadata: [
+                'endpoint' => $endpoint,
+                'page' => $page,
+                'pageSize' => $pageSize,
+                'offset' => $offset,
+                'total' => $total > 0 ? $total : null,
+                'resultKeys' => array_keys($result),
+            ],
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $json
+     *
+     * @return array<string, mixed>
+     */
+    private function requestJson(string $companyId, string $connectionRef, string $endpoint, array $json): array
+    {
+        $credentials = $this->credentials($companyId, $connectionRef);
+        $startedAt = microtime(true);
+        $statusCode = null;
+
+        try {
+            $response = $this->httpClient->request('POST', self::BASE_URL.$endpoint, [
+                'headers' => [
+                    'Client-Id' => $credentials['client_id'],
+                    'Api-Key' => $credentials['api_key'],
+                    'Content-Type' => 'application/json',
+                ],
+                'json' => $json,
+                'timeout' => 120,
+            ]);
+
+            $statusCode = $response->getStatusCode();
+            $this->classifyStatus($statusCode, $endpoint);
+
+            $content = $response->getContent(false);
+        } catch (TransportExceptionInterface $exception) {
+            throw new ConnectorTransientException(sprintf('Ozon accrual transport error for %s.', $endpoint), previous: $exception);
+        } finally {
+            $this->logger->info('Ozon accrual API request finished.', [
+                'companyId' => $companyId,
+                'connectionRef' => $connectionRef,
+                'endpoint' => $endpoint,
+                'statusCode' => $statusCode,
+                'durationMs' => (int) ((microtime(true) - $startedAt) * 1000),
+            ]);
+        }
+
+        try {
+            $payload = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $exception) {
+            throw new \RuntimeException(sprintf('Ozon accrual returned invalid JSON for %s.', $endpoint), previous: $exception);
+        }
+
+        if (!is_array($payload)) {
+            throw new \RuntimeException(sprintf('Ozon accrual returned unexpected non-object payload for %s.', $endpoint));
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function extractRows(array $payload): array
+    {
+        foreach ([$payload['result'] ?? null, $payload] as $candidate) {
+            if (!is_array($candidate)) {
+                continue;
+            }
+
+            if (array_is_list($candidate)) {
+                return $this->objectRows($candidate);
+            }
+
+            foreach (['items', 'postings', 'accruals', 'operations', 'rows', 'data', 'types'] as $key) {
+                $rows = $candidate[$key] ?? null;
+                if (is_array($rows) && array_is_list($rows)) {
+                    return $this->objectRows($rows);
+                }
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param list<mixed> $rows
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function objectRows(array $rows): array
+    {
+        return array_values(array_filter($rows, static fn (mixed $row): bool => is_array($row) && !array_is_list($row)));
+    }
+
+    private function intValue(mixed $value): int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (is_string($value) && ctype_digit($value)) {
+            return (int) $value;
+        }
+
+        return 0;
+    }
+
+    /**
+     * @return array{api_key: string, client_id: string}
+     */
+    private function credentials(string $companyId, string $connectionRef): array
+    {
+        try {
+            $credentials = $this->credentialProvider->read($companyId, $connectionRef);
+        } catch (CredentialNotFoundException $exception) {
+            throw new ConnectorAuthException('Ozon Seller credentials were not found.', previous: $exception);
+        }
+
+        $apiKey = trim((string) ($credentials['api_key'] ?? ''));
+        $clientId = trim((string) ($credentials['client_id'] ?? ''));
+
+        if ('' === $apiKey || '' === $clientId) {
+            throw new ConnectorAuthException('Ozon Seller credentials are incomplete.');
+        }
+
+        return ['api_key' => $apiKey, 'client_id' => $clientId];
+    }
+
+    private function classifyStatus(int $statusCode, string $endpoint): void
+    {
+        if (401 === $statusCode || 403 === $statusCode) {
+            throw new ConnectorAuthException(sprintf('Ozon accrual API auth failed for %s.', $endpoint));
+        }
+
+        if (429 === $statusCode) {
+            throw new ConnectorTransientException(sprintf('Ozon accrual API rate limit for %s.', $endpoint));
+        }
+
+        if ($statusCode >= 500) {
+            throw new ConnectorTransientException(sprintf('Ozon accrual API server error %d for %s.', $statusCode, $endpoint));
+        }
+
+        if ($statusCode < 200 || $statusCode >= 300) {
+            throw new \RuntimeException(sprintf('Ozon accrual API returned HTTP %d for %s.', $statusCode, $endpoint));
+        }
+    }
+}

--- a/site/src/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClient.php
+++ b/site/src/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClient.php
@@ -144,9 +144,8 @@ final readonly class OzonAccrualClient implements OzonAccrualClientInterface
             ]);
 
             $statusCode = $response->getStatusCode();
-            $this->classifyStatus($statusCode, $endpoint);
-
             $content = $response->getContent(false);
+            $this->classifyStatus($statusCode, $endpoint, $content);
         } catch (TransportExceptionInterface $exception) {
             throw new ConnectorTransientException(sprintf('Ozon accrual transport error for %s.', $endpoint), previous: $exception);
         } finally {
@@ -243,9 +242,13 @@ final readonly class OzonAccrualClient implements OzonAccrualClientInterface
         return ['api_key' => $apiKey, 'client_id' => $clientId];
     }
 
-    private function classifyStatus(int $statusCode, string $endpoint): void
+    private function classifyStatus(int $statusCode, string $endpoint, string $content): void
     {
         if (401 === $statusCode || 403 === $statusCode) {
+            throw new ConnectorAuthException(sprintf('Ozon accrual API auth failed for %s.', $endpoint));
+        }
+
+        if (400 === $statusCode && $this->isCredentialBadRequest($content)) {
             throw new ConnectorAuthException(sprintf('Ozon accrual API auth failed for %s.', $endpoint));
         }
 
@@ -260,5 +263,50 @@ final readonly class OzonAccrualClient implements OzonAccrualClientInterface
         if ($statusCode < 200 || $statusCode >= 300) {
             throw new \RuntimeException(sprintf('Ozon accrual API returned HTTP %d for %s.', $statusCode, $endpoint));
         }
+    }
+
+    private function isCredentialBadRequest(string $content): bool
+    {
+        try {
+            $payload = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return false;
+        }
+
+        if (!is_array($payload)) {
+            return false;
+        }
+
+        $code = $payload['code'] ?? null;
+        if (3 === $code || '3' === $code) {
+            return true;
+        }
+
+        return $this->containsCredentialError($payload);
+    }
+
+    /**
+     * @param array<mixed> $payload
+     */
+    private function containsCredentialError(array $payload): bool
+    {
+        foreach ($payload as $value) {
+            if (is_array($value) && $this->containsCredentialError($value)) {
+                return true;
+            }
+
+            if (!is_scalar($value)) {
+                continue;
+            }
+
+            $text = strtolower((string) $value);
+            foreach (['client-id', 'client id', 'api-key', 'api key', 'credential', 'auth', 'unauthorized', 'forbidden'] as $needle) {
+                if (str_contains($text, $needle)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/site/src/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClientInterface.php
+++ b/site/src/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClientInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Api\Ozon;
+
+interface OzonAccrualClientInterface
+{
+    public function fetchPostings(
+        string $companyId,
+        string $connectionRef,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        int $page,
+        int $pageSize,
+    ): OzonRawPage;
+
+    public function fetchByDay(
+        string $companyId,
+        string $connectionRef,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+    ): OzonRawPage;
+
+    public function fetchTypes(string $companyId, string $connectionRef): OzonRawPage;
+}

--- a/site/tests/Integration/Ingestion/Application/Source/Ozon/OzonIngestionRegistryTest.php
+++ b/site/tests/Integration/Ingestion/Application/Source/Ozon/OzonIngestionRegistryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Integration\Ingestion\Application\Source\Ozon;
 
+use App\Ingestion\Application\Source\Ozon\OzonAccrualShadowMapper;
 use App\Ingestion\Application\Source\Ozon\OzonRealizationMapper;
 use App\Ingestion\Application\Source\Ozon\OzonResourceType;
 use App\Ingestion\Application\Source\Ozon\OzonSellerReportConnector;
@@ -30,6 +31,18 @@ final class OzonIngestionRegistryTest extends IntegrationTestCase
         self::assertInstanceOf(
             OzonRealizationMapper::class,
             $mapperRegistry->get(IngestSource::OZON, OzonResourceType::REALIZATION),
+        );
+        self::assertInstanceOf(
+            OzonAccrualShadowMapper::class,
+            $mapperRegistry->get(IngestSource::OZON, OzonResourceType::ACCRUAL_POSTINGS),
+        );
+        self::assertInstanceOf(
+            OzonAccrualShadowMapper::class,
+            $mapperRegistry->get(IngestSource::OZON, OzonResourceType::ACCRUAL_BY_DAY),
+        );
+        self::assertInstanceOf(
+            OzonAccrualShadowMapper::class,
+            $mapperRegistry->get(IngestSource::OZON, OzonResourceType::ACCRUAL_TYPES),
         );
     }
 }

--- a/site/tests/Integration/Ingestion/Command/StartBackfillCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/StartBackfillCommandTest.php
@@ -171,6 +171,20 @@ final class StartBackfillCommandTest extends IntegrationTestCase
         self::assertStringContainsString('Unsupported resource type', $tester->getDisplay());
     }
 
+    public function testStaticAccrualTypesBackfillIsNotSupported(): void
+    {
+        $tester = $this->tester('app:ingestion:start-backfill');
+        $exit = $tester->execute([
+            '--company-id' => Uuid::uuid7()->toString(),
+            '--connection-ref' => Uuid::uuid7()->toString(),
+            '--source' => 'ozon',
+            '--resource-type' => OzonResourceType::ACCRUAL_TYPES,
+        ]);
+
+        self::assertSame(Command::FAILURE, $exit);
+        self::assertStringContainsString('Unsupported resource type', $tester->getDisplay());
+    }
+
     public function testInvalidCompanyUuidFails(): void
     {
         $tester = $this->tester('app:ingestion:start-backfill');

--- a/site/tests/Integration/Ingestion/Command/StartBackfillCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/StartBackfillCommandTest.php
@@ -124,6 +124,39 @@ final class StartBackfillCommandTest extends IntegrationTestCase
         self::assertCount(0, $transport->getSent());
     }
 
+    public function testStartsBackfillForExplicitAccrualResourceType(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = Uuid::uuid7()->toString();
+        $transport = $this->getIngestFetchTransport();
+        $transport->reset();
+
+        $tester = $this->tester('app:ingestion:start-backfill');
+        $exit = $tester->execute([
+            '--company-id' => $companyId,
+            '--connection-ref' => $connectionRef,
+            '--source' => 'ozon',
+            '--days-back' => '30',
+            '--resource-type' => OzonResourceType::ACCRUAL_POSTINGS,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertStringContainsString(OzonResourceType::ACCRUAL_POSTINGS, $tester->getDisplay());
+
+        $parentJobs = $this->connection->fetchAllAssociative(
+            'SELECT resource_type, progress_total
+             FROM ingest_sync_jobs
+             WHERE company_id = :companyId AND parent_job_id IS NULL
+             ORDER BY resource_type',
+            ['companyId' => $companyId],
+        );
+
+        self::assertCount(1, $parentJobs);
+        self::assertSame([OzonResourceType::ACCRUAL_POSTINGS], array_column($parentJobs, 'resource_type'));
+        self::assertSame(5, (int) $parentJobs[0]['progress_total']);
+        self::assertCount(5, $transport->getSent());
+    }
+
     public function testRealizationBackfillIsNotSupportedUntilMonthAlignedChunkingExists(): void
     {
         $tester = $this->tester('app:ingestion:start-backfill');

--- a/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonAccrualShadowMapperTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonAccrualShadowMapperTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Application\Source\Ozon;
+
+use App\Ingestion\Application\Source\Ozon\OzonAccrualShadowMapper;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\IngestSource;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+final class OzonAccrualShadowMapperTest extends TestCase
+{
+    public function testRegistersOnlyAccrualResourceTypes(): void
+    {
+        $mapper = new OzonAccrualShadowMapper();
+
+        self::assertSame(IngestSource::OZON, $mapper->source());
+        self::assertSame([
+            OzonResourceType::ACCRUAL_POSTINGS,
+            OzonResourceType::ACCRUAL_BY_DAY,
+            OzonResourceType::ACCRUAL_TYPES,
+        ], $mapper->resourceTypes());
+    }
+
+    public function testDoesNotCreateCanonicalTransactionsOrControlSums(): void
+    {
+        $mapper = new OzonAccrualShadowMapper();
+        $rawRecord = new IngestRawRecord(
+            companyId: Uuid::uuid7()->toString(),
+            connectionRef: 'connection-1',
+            shopRef: 'shop-1',
+            source: IngestSource::OZON,
+            resourceType: OzonResourceType::ACCRUAL_POSTINGS,
+            externalId: 'accrual-postings:2026-06-13:2026-06-19',
+            storagePath: 'raw.ndjson.gz',
+            hash: str_repeat('a', 64),
+            byteSize: 10,
+            fetchedAt: new \DateTimeImmutable('2026-06-20 10:00:00'),
+            syncJobId: Uuid::uuid7()->toString(),
+        );
+
+        self::assertSame([], $mapper->map($rawRecord, [['posting_number' => 'posting-1']]));
+        self::assertSame([], $mapper->controlSum([['posting_number' => 'posting-1']]));
+    }
+}

--- a/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonSellerReportConnectorTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonSellerReportConnectorTest.php
@@ -10,6 +10,7 @@ use App\Ingestion\Application\Source\Ozon\OzonResourceType;
 use App\Ingestion\Application\Source\Ozon\OzonSellerReportConnector;
 use App\Ingestion\Enum\Capability;
 use App\Ingestion\Exception\UnsupportedCapabilityException;
+use App\Ingestion\Infrastructure\Api\Ozon\OzonAccrualClientInterface;
 use App\Ingestion\Infrastructure\Api\Ozon\OzonClientAdapterInterface;
 use App\Ingestion\Infrastructure\Api\Ozon\OzonRawPage;
 use App\Ingestion\Infrastructure\Api\Ozon\OzonShopDescriptor;
@@ -50,7 +51,7 @@ final class OzonSellerReportConnectorTest extends TestCase
             }
         };
 
-        $connector = new OzonSellerReportConnector($client, new NullLogger());
+        $connector = new OzonSellerReportConnector($client, $this->unusedAccrualClient(), new NullLogger());
         $companyId = Uuid::uuid7()->toString();
         $syncJobId = Uuid::uuid7()->toString();
 
@@ -104,7 +105,7 @@ final class OzonSellerReportConnectorTest extends TestCase
             }
         };
 
-        $connector = new OzonSellerReportConnector($client, new NullLogger());
+        $connector = new OzonSellerReportConnector($client, $this->unusedAccrualClient(), new NullLogger());
         $companyId = Uuid::uuid7()->toString();
 
         $result = $connector->pull(new PullRequest(
@@ -159,7 +160,7 @@ final class OzonSellerReportConnectorTest extends TestCase
             }
         };
 
-        $connector = new OzonSellerReportConnector($client, new NullLogger());
+        $connector = new OzonSellerReportConnector($client, $this->unusedAccrualClient(), new NullLogger());
 
         $result = $connector->pull(new PullRequest(
             companyId: Uuid::uuid7()->toString(),
@@ -203,7 +204,7 @@ final class OzonSellerReportConnectorTest extends TestCase
             }
         };
 
-        $connector = new OzonSellerReportConnector($client, new NullLogger());
+        $connector = new OzonSellerReportConnector($client, $this->unusedAccrualClient(), new NullLogger());
         self::assertSame([Capability::CAN_DISCOVER_SHOPS, Capability::CAN_PULL], $connector->capabilities());
         self::assertSame('shop-1', $connector->discoverShops(Uuid::uuid7()->toString(), 'connection-1')[0]->externalId);
 
@@ -215,5 +216,181 @@ final class OzonSellerReportConnectorTest extends TestCase
             payload: [],
             idempotencyKey: 'key-1',
         ));
+    }
+
+    public function testPullAccrualPostingsUsesWindowAndReturnsRawBatch(): void
+    {
+        $accrualClient = new class implements OzonAccrualClientInterface {
+            public ?\DateTimeImmutable $from = null;
+            public ?\DateTimeImmutable $to = null;
+            public ?int $page = null;
+            public ?int $pageSize = null;
+
+            public function fetchPostings(
+                string $companyId,
+                string $connectionRef,
+                \DateTimeImmutable $from,
+                \DateTimeImmutable $to,
+                int $page,
+                int $pageSize,
+            ): OzonRawPage {
+                $this->from = $from;
+                $this->to = $to;
+                $this->page = $page;
+                $this->pageSize = $pageSize;
+
+                return new OzonRawPage(rows: [['posting_number' => 'posting-1']], hasMore: false);
+            }
+
+            public function fetchByDay(
+                string $companyId,
+                string $connectionRef,
+                \DateTimeImmutable $from,
+                \DateTimeImmutable $to,
+            ): OzonRawPage {
+                throw new \LogicException('Not used.');
+            }
+
+            public function fetchTypes(string $companyId, string $connectionRef): OzonRawPage
+            {
+                throw new \LogicException('Not used.');
+            }
+        };
+
+        $connector = new OzonSellerReportConnector($this->unusedClient(), $accrualClient, new NullLogger());
+        $result = $connector->pull(new PullRequest(
+            companyId: Uuid::uuid7()->toString(),
+            connectionRef: 'connection-1',
+            shopRef: 'shop-1',
+            resourceType: OzonResourceType::ACCRUAL_POSTINGS,
+            cursorValue: null,
+            windowFrom: new \DateTimeImmutable('2026-06-01'),
+            windowTo: new \DateTimeImmutable('2026-06-18'),
+            syncJobId: Uuid::uuid7()->toString(),
+        ));
+
+        self::assertEquals(new \DateTimeImmutable('2026-06-01 00:00:00'), $accrualClient->from);
+        self::assertEquals(new \DateTimeImmutable('2026-06-07 23:59:59'), $accrualClient->to);
+        self::assertSame(1, $accrualClient->page);
+        self::assertSame(1000, $accrualClient->pageSize);
+        self::assertSame(OzonResourceType::ACCRUAL_POSTINGS, $result->rawBatch->resourceType);
+        self::assertSame('accrual-postings:2026-06-01:2026-06-07', $result->rawBatch->externalId);
+        self::assertSame([['posting_number' => 'posting-1']], $result->rawBatch->rows);
+        self::assertSame('2026-06-08', $result->nextCursorValue);
+        self::assertTrue($result->hasMore);
+    }
+
+    public function testPullAccrualByDayStoresEmptyMarkerForEmptyResponse(): void
+    {
+        $accrualClient = new class implements OzonAccrualClientInterface {
+            public function fetchPostings(
+                string $companyId,
+                string $connectionRef,
+                \DateTimeImmutable $from,
+                \DateTimeImmutable $to,
+                int $page,
+                int $pageSize,
+            ): OzonRawPage {
+                throw new \LogicException('Not used.');
+            }
+
+            public function fetchByDay(
+                string $companyId,
+                string $connectionRef,
+                \DateTimeImmutable $from,
+                \DateTimeImmutable $to,
+            ): OzonRawPage {
+                return new OzonRawPage(rows: [], hasMore: false, metadata: ['endpoint' => '/v1/finance/accrual/by-day']);
+            }
+
+            public function fetchTypes(string $companyId, string $connectionRef): OzonRawPage
+            {
+                throw new \LogicException('Not used.');
+            }
+        };
+
+        $connector = new OzonSellerReportConnector($this->unusedClient(), $accrualClient, new NullLogger());
+        $result = $connector->pull(new PullRequest(
+            companyId: Uuid::uuid7()->toString(),
+            connectionRef: 'connection-1',
+            shopRef: 'shop-1',
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            cursorValue: null,
+            windowFrom: new \DateTimeImmutable('2026-06-01'),
+            windowTo: new \DateTimeImmutable('2026-06-02'),
+            syncJobId: Uuid::uuid7()->toString(),
+        ));
+
+        self::assertSame(OzonResourceType::ACCRUAL_BY_DAY, $result->rawBatch->resourceType);
+        self::assertSame('accrual-by-day:2026-06-01:2026-06-02', $result->rawBatch->externalId);
+        self::assertSame([
+            [
+                '_ingestion_empty' => true,
+                '_ingestion_resource' => OzonResourceType::ACCRUAL_BY_DAY,
+                '_ingestion_metadata' => [
+                    'windowFrom' => '2026-06-01',
+                    'windowTo' => '2026-06-02',
+                    'apiMetadata' => ['endpoint' => '/v1/finance/accrual/by-day'],
+                ],
+            ],
+        ], $result->rawBatch->rows);
+        self::assertNull($result->nextCursorValue);
+        self::assertFalse($result->hasMore);
+    }
+
+    private function unusedClient(): OzonClientAdapterInterface
+    {
+        return new class implements OzonClientAdapterInterface {
+            public function fetchTransactionList(
+                string $companyId,
+                string $connectionRef,
+                \DateTimeImmutable $from,
+                \DateTimeImmutable $to,
+                int $page,
+                int $pageSize,
+            ): OzonRawPage {
+                throw new \LogicException('Not used.');
+            }
+
+            public function fetchRealization(string $companyId, string $connectionRef, int $year, int $month): OzonRawPage
+            {
+                throw new \LogicException('Not used.');
+            }
+
+            public function listClusters(string $companyId, string $connectionRef): array
+            {
+                return [new OzonShopDescriptor('shop-1', 'Shop 1')];
+            }
+        };
+    }
+
+    private function unusedAccrualClient(): OzonAccrualClientInterface
+    {
+        return new class implements OzonAccrualClientInterface {
+            public function fetchPostings(
+                string $companyId,
+                string $connectionRef,
+                \DateTimeImmutable $from,
+                \DateTimeImmutable $to,
+                int $page,
+                int $pageSize,
+            ): OzonRawPage {
+                throw new \LogicException('Not used.');
+            }
+
+            public function fetchByDay(
+                string $companyId,
+                string $connectionRef,
+                \DateTimeImmutable $from,
+                \DateTimeImmutable $to,
+            ): OzonRawPage {
+                throw new \LogicException('Not used.');
+            }
+
+            public function fetchTypes(string $companyId, string $connectionRef): OzonRawPage
+            {
+                throw new \LogicException('Not used.');
+            }
+        };
     }
 }

--- a/site/tests/Unit/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClientTest.php
+++ b/site/tests/Unit/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClientTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Infrastructure\Api\Ozon;
+
+use App\Ingestion\Exception\ConnectorAuthException;
+use App\Ingestion\Exception\ConnectorTransientException;
+use App\Ingestion\Infrastructure\Api\Ozon\OzonAccrualClient;
+use App\Ingestion\Infrastructure\Api\Ozon\OzonCredentialProviderInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class OzonAccrualClientTest extends TestCase
+{
+    public function testFetchPostingsSendsExpectedRequestAndExtractsRows(): void
+    {
+        $capturedUrl = null;
+        $capturedOptions = null;
+        $http = new MockHttpClient(static function (string $method, string $url, array $options) use (&$capturedUrl, &$capturedOptions): MockResponse {
+            $capturedUrl = $url;
+            $capturedOptions = $options;
+
+            return new MockResponse(
+                '{"result":{"postings":[{"posting_number":"posting-1"}],"total":12}}',
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new OzonAccrualClient($http, $this->credentialProvider(), new NullLogger());
+        $page = $client->fetchPostings(
+            '0192f0c2-0000-7000-8000-000000000001',
+            '0192f0c2-0000-7000-8000-000000000002',
+            new \DateTimeImmutable('2026-06-13'),
+            new \DateTimeImmutable('2026-06-19'),
+            3,
+            5,
+        );
+
+        self::assertSame('https://api-seller.ozon.ru/v1/finance/accrual/postings', $capturedUrl);
+        $requestPayload = $capturedOptions['json'] ?? json_decode((string) ($capturedOptions['body'] ?? ''), true, 512, \JSON_THROW_ON_ERROR);
+        self::assertSame('2026-06-13', $requestPayload['date']['from']);
+        self::assertSame('2026-06-19', $requestPayload['date']['to']);
+        self::assertSame(5, $requestPayload['limit']);
+        self::assertSame(10, $requestPayload['offset']);
+        self::assertSame(['Client-Id: client-id'], $capturedOptions['normalized_headers']['client-id'] ?? null);
+        self::assertSame(['Api-Key: api-key'], $capturedOptions['normalized_headers']['api-key'] ?? null);
+        self::assertSame([['posting_number' => 'posting-1']], $page->rows);
+        self::assertTrue($page->hasMore);
+        self::assertSame('4', $page->nextPageToken);
+    }
+
+    public function testFetchByDayExtractsResultListRows(): void
+    {
+        $client = new OzonAccrualClient(
+            new MockHttpClient(new MockResponse(
+                '{"result":[{"date":"2026-06-13","accruals":[{"accrual_id":1}]}]}',
+                ['http_code' => 200],
+            )),
+            $this->credentialProvider(),
+            new NullLogger(),
+        );
+
+        $page = $client->fetchByDay(
+            '0192f0c2-0000-7000-8000-000000000001',
+            '0192f0c2-0000-7000-8000-000000000002',
+            new \DateTimeImmutable('2026-06-13'),
+            new \DateTimeImmutable('2026-06-19'),
+        );
+
+        self::assertSame([['date' => '2026-06-13', 'accruals' => [['accrual_id' => 1]]]], $page->rows);
+        self::assertFalse($page->hasMore);
+    }
+
+    public function testUnauthorizedStatusBecomesAuthException(): void
+    {
+        $client = new OzonAccrualClient(
+            new MockHttpClient(new MockResponse('{"error":"forbidden"}', ['http_code' => 403])),
+            $this->credentialProvider(),
+            new NullLogger(),
+        );
+
+        $this->expectException(ConnectorAuthException::class);
+        $client->fetchTypes(
+            '0192f0c2-0000-7000-8000-000000000001',
+            '0192f0c2-0000-7000-8000-000000000002',
+        );
+    }
+
+    public function testRateLimitStatusBecomesTransientException(): void
+    {
+        $client = new OzonAccrualClient(
+            new MockHttpClient(new MockResponse('{"error":"rate"}', ['http_code' => 429])),
+            $this->credentialProvider(),
+            new NullLogger(),
+        );
+
+        $this->expectException(ConnectorTransientException::class);
+        $client->fetchTypes(
+            '0192f0c2-0000-7000-8000-000000000001',
+            '0192f0c2-0000-7000-8000-000000000002',
+        );
+    }
+
+    private function credentialProvider(): OzonCredentialProviderInterface
+    {
+        return new class implements OzonCredentialProviderInterface {
+            public function read(string $companyId, string $connectionRef): array
+            {
+                return ['api_key' => 'api-key', 'client_id' => 'client-id'];
+            }
+        };
+    }
+}

--- a/site/tests/Unit/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClientTest.php
+++ b/site/tests/Unit/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClientTest.php
@@ -89,6 +89,42 @@ final class OzonAccrualClientTest extends TestCase
         );
     }
 
+    public function testCredentialBadRequestStatusBecomesAuthException(): void
+    {
+        $client = new OzonAccrualClient(
+            new MockHttpClient(new MockResponse('{"code":3,"message":"Client-Id is invalid"}', ['http_code' => 400])),
+            $this->credentialProvider(),
+            new NullLogger(),
+        );
+
+        $this->expectException(ConnectorAuthException::class);
+        $client->fetchTypes(
+            '0192f0c2-0000-7000-8000-000000000001',
+            '0192f0c2-0000-7000-8000-000000000002',
+        );
+    }
+
+    public function testGenericBadRequestStatusStaysRuntimeException(): void
+    {
+        $client = new OzonAccrualClient(
+            new MockHttpClient(new MockResponse('{"message":"bad date range"}', ['http_code' => 400])),
+            $this->credentialProvider(),
+            new NullLogger(),
+        );
+
+        try {
+            $client->fetchTypes(
+                '0192f0c2-0000-7000-8000-000000000001',
+                '0192f0c2-0000-7000-8000-000000000002',
+            );
+            self::fail('Expected generic runtime exception.');
+        } catch (ConnectorAuthException) {
+            self::fail('Generic bad request must not be classified as auth.');
+        } catch (\RuntimeException $exception) {
+            self::assertStringContainsString('HTTP 400', $exception->getMessage());
+        }
+    }
+
     public function testRateLimitStatusBecomesTransientException(): void
     {
         $client = new OzonAccrualClient(


### PR DESCRIPTION
## Summary

Adds the first Ingestion-only shadow path for the new Ozon finance accrual endpoints without changing legacy Marketplace code or canonical mapping.

## What changed

- Added Ozon accrual resource types for postings, by-day, and types.
- Added `OzonAccrualClient` and interface for the new `/v1/finance/accrual/*` endpoints.
- Extended the existing Ozon ingestion connector to load accrual postings and by-day raw data by explicit backfill resource type.
- Kept static `ozon_finance_accrual_types` out of `start-backfill`; it remains available through the read-only `probe` command to avoid duplicate windowed API calls.
- Added `OzonAccrualShadowMapper` so newly stored accrual raw records normalize to done without producing canonical transactions yet.
- Kept `app:ingestion:start-backfill` default behavior on the legacy daily report.
- Added diagnostic commands for probing Ozon, checking raw/job status, comparing raw structures, and inspecting one raw record.
- Added focused unit and integration coverage for routing, mapper registration, client behavior, explicit accrual backfill, auth-like Ozon `400/code=3`, and rejected static types backfill.

## Validation

- `make site-test-unit` - passed; existing suite reports 1 warning and 1 deprecation.
- `php bin/phpunit --testsuite unit --filter "OzonAccrualClientTest|OzonSellerReportConnector|OzonAccrualShadow"` - passed.
- `php bin/phpunit --testsuite integration --filter "StartBackfillCommandTest|OzonIngestionRegistryTest"` - passed with 2 PHPUnit deprecations.
- `php bin/console app:ingestion:ozon-accrual:status --env=test ...` - passed on empty test company.
- `php bin/console app:ingestion:ozon-accrual:compare --env=test ...` - passed on empty test company.
- Targeted PHP-CS-Fixer on changed files - passed.
- `git diff --check` - passed.

## Notes

`make site-cs-check` still fails repo-wide on 663 pre-existing unrelated files, but the files in this PR are clean under the same fixer config.

No migrations, public API changes, cron/worker routing changes, or legacy Marketplace changes are included.