### PR TITLE
[codex] fix ozon accrual postings request

### DIFF
--- a/site/src/Ingestion/Application/Source/Ozon/OzonSellerReportConnector.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonSellerReportConnector.php
@@ -173,66 +173,7 @@ final readonly class OzonSellerReportConnector implements SourceConnectorInterfa
 
     private function pullAccrualPostings(PullRequest $request): PullResult
     {
-        [$from, $to] = $this->resolveDailyWindow($request);
-        $rows = [];
-        $page = 1;
-        $hasRemoteMore = false;
-
-        do {
-            $pageResult = $this->accrualClient->fetchPostings(
-                $request->companyId,
-                $request->connectionRef,
-                $from,
-                $to,
-                $page,
-                self::PAGE_SIZE,
-            );
-
-            if ([] !== $pageResult->rows) {
-                array_push($rows, ...$pageResult->rows);
-            }
-
-            $hasRemoteMore = $pageResult->hasMore;
-            ++$page;
-        } while ($hasRemoteMore && $page <= self::MAX_PAGES_PER_PULL);
-
-        if ($hasRemoteMore) {
-            $this->logger->warning('Ozon accrual postings pagination cap reached.', [
-                'companyId' => $request->companyId,
-                'connectionRef' => $request->connectionRef,
-                'from' => $from->format('Y-m-d'),
-                'to' => $to->format('Y-m-d'),
-                'maxPages' => self::MAX_PAGES_PER_PULL,
-            ]);
-
-            throw new \RuntimeException('Ozon accrual postings pagination cap reached before all rows were fetched.');
-        }
-
-        $windowHasMore = null !== $request->windowTo && $to < $request->windowTo;
-        $nextCursor = $windowHasMore || $this->isIncremental($request) ? $to->modify('+1 day')->format('Y-m-d') : null;
-
-        return new PullResult(
-            rawBatch: new RawBatch(
-                companyId: $request->companyId,
-                connectionRef: $request->connectionRef,
-                shopRef: $request->shopRef,
-                source: IngestSource::OZON,
-                resourceType: OzonResourceType::ACCRUAL_POSTINGS,
-                externalId: sprintf('accrual-postings:%s:%s', $from->format('Y-m-d'), $to->format('Y-m-d')),
-                syncJobId: $request->syncJobId,
-                fetchedAt: new \DateTimeImmutable(),
-                rows: $this->rowsOrEmptyMarker(
-                    $rows,
-                    OzonResourceType::ACCRUAL_POSTINGS,
-                    [
-                        'windowFrom' => $from->format('Y-m-d'),
-                        'windowTo' => $to->format('Y-m-d'),
-                    ],
-                ),
-            ),
-            nextCursorValue: $nextCursor,
-            hasMore: $windowHasMore,
-        );
+        throw new \LogicException('Ozon accrual postings require explicit posting_numbers and cannot be loaded by date backfill.');
     }
 
     private function pullAccrualByDay(PullRequest $request): PullResult

--- a/site/src/Ingestion/Command/OzonAccrualProbeCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualProbeCommand.php
@@ -31,10 +31,10 @@ final class OzonAccrualProbeCommand extends Command
             ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Company UUID.')
             ->addOption('connection-ref', null, InputOption::VALUE_REQUIRED, 'Marketplace connection UUID.')
             ->addOption('endpoint', null, InputOption::VALUE_REQUIRED, 'Endpoint: postings, by-day, or types.', 'postings')
-            ->addOption('from', null, InputOption::VALUE_REQUIRED, 'Start date YYYY-MM-DD. Required for postings and by-day.')
-            ->addOption('to', null, InputOption::VALUE_REQUIRED, 'End date YYYY-MM-DD. Required for postings and by-day.')
+            ->addOption('posting-number', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ozon posting number. Repeat up to 200 times for postings endpoint.')
+            ->addOption('from', null, InputOption::VALUE_REQUIRED, 'Start date YYYY-MM-DD. Required for by-day.')
+            ->addOption('to', null, InputOption::VALUE_REQUIRED, 'End date YYYY-MM-DD. Required for by-day.')
             ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Sample rows to show, 1..20.', 5)
-            ->addOption('page-size', null, InputOption::VALUE_REQUIRED, 'Postings page size, 1..1000.', 100)
             ->addOption('with-values', null, InputOption::VALUE_NONE, 'Print truncated sample JSON values. By default only keys are shown.');
     }
 
@@ -47,12 +47,10 @@ final class OzonAccrualProbeCommand extends Command
             $connectionRef = $this->requiredUuidOption($input, 'connection-ref');
             $endpoint = $this->endpoint($input);
             $limit = $this->intOption($input, 'limit', 1, 20);
-            $pageSize = $this->intOption($input, 'page-size', 1, 1000);
-            [$from, $to] = 'types' === $endpoint ? [null, null] : $this->requiredDateWindow($input);
 
             $page = match ($endpoint) {
-                'postings' => $this->client->fetchPostings($companyId, $connectionRef, $from, $to, 1, $pageSize),
-                'by-day' => $this->client->fetchByDay($companyId, $connectionRef, $from, $to),
+                'postings' => $this->client->fetchPostings($companyId, $connectionRef, $this->postingNumbers($input)),
+                'by-day' => $this->fetchByDay($input, $companyId, $connectionRef),
                 'types' => $this->client->fetchTypes($companyId, $connectionRef),
             };
         } catch (\Throwable $exception) {
@@ -125,6 +123,45 @@ final class OzonAccrualProbeCommand extends Command
         }
 
         return $date;
+    }
+
+    private function fetchByDay(InputInterface $input, string $companyId, string $connectionRef): OzonRawPage
+    {
+        [$from, $to] = $this->requiredDateWindow($input);
+
+        return $this->client->fetchByDay($companyId, $connectionRef, $from, $to);
+    }
+
+    /**
+     * @return non-empty-list<string>
+     */
+    private function postingNumbers(InputInterface $input): array
+    {
+        $values = $input->getOption('posting-number');
+        if (!is_array($values)) {
+            $values = [$values];
+        }
+
+        $postingNumbers = [];
+        foreach ($values as $value) {
+            $postingNumber = trim((string) $value);
+            if ('' === $postingNumber) {
+                continue;
+            }
+
+            $postingNumbers[$postingNumber] = $postingNumber;
+        }
+
+        $postingNumbers = array_values($postingNumbers);
+        if ([] === $postingNumbers) {
+            throw new \InvalidArgumentException('The --posting-number option is required for postings endpoint.');
+        }
+
+        if (count($postingNumbers) > 200) {
+            throw new \InvalidArgumentException('The postings endpoint supports at most 200 --posting-number values.');
+        }
+
+        return $postingNumbers;
     }
 
     private function intOption(InputInterface $input, string $name, int $min, int $max): int

--- a/site/src/Ingestion/Command/StartBackfillCommand.php
+++ b/site/src/Ingestion/Command/StartBackfillCommand.php
@@ -41,7 +41,6 @@ final class StartBackfillCommand extends Command
     private const ALLOWED_RESOURCE_TYPES_BY_SOURCE = [
         'ozon' => [
             OzonResourceType::DAILY_REPORT,
-            OzonResourceType::ACCRUAL_POSTINGS,
             OzonResourceType::ACCRUAL_BY_DAY,
         ],
     ];

--- a/site/src/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClient.php
+++ b/site/src/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClient.php
@@ -28,30 +28,17 @@ final readonly class OzonAccrualClient implements OzonAccrualClientInterface
     public function fetchPostings(
         string $companyId,
         string $connectionRef,
-        \DateTimeImmutable $from,
-        \DateTimeImmutable $to,
-        int $page,
-        int $pageSize,
+        array $postingNumbers,
     ): OzonRawPage {
-        $page = max(1, $page);
-        $pageSize = max(1, min(1000, $pageSize));
-        $offset = ($page - 1) * $pageSize;
+        $postingNumbers = $this->normalizePostingNumbers($postingNumbers);
 
         return $this->requestPage(
             companyId: $companyId,
             connectionRef: $connectionRef,
             endpoint: self::POSTINGS_ENDPOINT,
             json: [
-                'date' => [
-                    'from' => $from->format('Y-m-d'),
-                    'to' => $to->format('Y-m-d'),
-                ],
-                'limit' => $pageSize,
-                'offset' => $offset,
+                'posting_numbers' => $postingNumbers,
             ],
-            page: $page,
-            pageSize: $pageSize,
-            offset: $offset,
         );
     }
 
@@ -222,6 +209,35 @@ final readonly class OzonAccrualClient implements OzonAccrualClientInterface
     }
 
     /**
+     * @param list<string> $postingNumbers
+     *
+     * @return non-empty-list<string>
+     */
+    private function normalizePostingNumbers(array $postingNumbers): array
+    {
+        $normalized = [];
+        foreach ($postingNumbers as $postingNumber) {
+            $postingNumber = trim((string) $postingNumber);
+            if ('' === $postingNumber) {
+                continue;
+            }
+
+            $normalized[$postingNumber] = $postingNumber;
+        }
+
+        $normalized = array_values($normalized);
+        if ([] === $normalized) {
+            throw new \InvalidArgumentException('At least one Ozon posting number is required.');
+        }
+
+        if (\count($normalized) > 200) {
+            throw new \InvalidArgumentException('Ozon accrual postings request supports at most 200 posting numbers.');
+        }
+
+        return $normalized;
+    }
+
+    /**
      * @return array{api_key: string, client_id: string}
      */
     private function credentials(string $companyId, string $connectionRef): array
@@ -277,11 +293,8 @@ final readonly class OzonAccrualClient implements OzonAccrualClientInterface
             return false;
         }
 
-        $code = $payload['code'] ?? null;
-        if (3 === $code || '3' === $code) {
-            return true;
-        }
-
+        // Ozon uses code=3 both for credential problems and ordinary request validation
+        // errors, for example invalid accrual posting_numbers. Classify only by text.
         return $this->containsCredentialError($payload);
     }
 

--- a/site/src/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClientInterface.php
+++ b/site/src/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClientInterface.php
@@ -6,13 +6,13 @@ namespace App\Ingestion\Infrastructure\Api\Ozon;
 
 interface OzonAccrualClientInterface
 {
+    /**
+     * @param list<string> $postingNumbers Ozon posting numbers, 1..200 per request.
+     */
     public function fetchPostings(
         string $companyId,
         string $connectionRef,
-        \DateTimeImmutable $from,
-        \DateTimeImmutable $to,
-        int $page,
-        int $pageSize,
+        array $postingNumbers,
     ): OzonRawPage;
 
     public function fetchByDay(

--- a/site/tests/Integration/Ingestion/Command/StartBackfillCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/StartBackfillCommandTest.php
@@ -124,7 +124,7 @@ final class StartBackfillCommandTest extends IntegrationTestCase
         self::assertCount(0, $transport->getSent());
     }
 
-    public function testStartsBackfillForExplicitAccrualResourceType(): void
+    public function testStartsBackfillForExplicitAccrualByDayResourceType(): void
     {
         $companyId = Uuid::uuid7()->toString();
         $connectionRef = Uuid::uuid7()->toString();
@@ -137,11 +137,11 @@ final class StartBackfillCommandTest extends IntegrationTestCase
             '--connection-ref' => $connectionRef,
             '--source' => 'ozon',
             '--days-back' => '30',
-            '--resource-type' => OzonResourceType::ACCRUAL_POSTINGS,
+            '--resource-type' => OzonResourceType::ACCRUAL_BY_DAY,
         ]);
 
         self::assertSame(Command::SUCCESS, $exit);
-        self::assertStringContainsString(OzonResourceType::ACCRUAL_POSTINGS, $tester->getDisplay());
+        self::assertStringContainsString(OzonResourceType::ACCRUAL_BY_DAY, $tester->getDisplay());
 
         $parentJobs = $this->connection->fetchAllAssociative(
             'SELECT resource_type, progress_total
@@ -152,9 +152,23 @@ final class StartBackfillCommandTest extends IntegrationTestCase
         );
 
         self::assertCount(1, $parentJobs);
-        self::assertSame([OzonResourceType::ACCRUAL_POSTINGS], array_column($parentJobs, 'resource_type'));
+        self::assertSame([OzonResourceType::ACCRUAL_BY_DAY], array_column($parentJobs, 'resource_type'));
         self::assertSame(5, (int) $parentJobs[0]['progress_total']);
         self::assertCount(5, $transport->getSent());
+    }
+
+    public function testAccrualPostingsBackfillIsNotSupported(): void
+    {
+        $tester = $this->tester('app:ingestion:start-backfill');
+        $exit = $tester->execute([
+            '--company-id' => Uuid::uuid7()->toString(),
+            '--connection-ref' => Uuid::uuid7()->toString(),
+            '--source' => 'ozon',
+            '--resource-type' => OzonResourceType::ACCRUAL_POSTINGS,
+        ]);
+
+        self::assertSame(Command::FAILURE, $exit);
+        self::assertStringContainsString('Unsupported resource type', $tester->getDisplay());
     }
 
     public function testRealizationBackfillIsNotSupportedUntilMonthAlignedChunkingExists(): void

--- a/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonSellerReportConnectorTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonSellerReportConnectorTest.php
@@ -218,28 +218,16 @@ final class OzonSellerReportConnectorTest extends TestCase
         ));
     }
 
-    public function testPullAccrualPostingsUsesWindowAndReturnsRawBatch(): void
+    public function testPullAccrualPostingsRejectsDateBackfill(): void
     {
         $accrualClient = new class implements OzonAccrualClientInterface {
-            public ?\DateTimeImmutable $from = null;
-            public ?\DateTimeImmutable $to = null;
-            public ?int $page = null;
-            public ?int $pageSize = null;
+            public bool $called = false;
 
-            public function fetchPostings(
-                string $companyId,
-                string $connectionRef,
-                \DateTimeImmutable $from,
-                \DateTimeImmutable $to,
-                int $page,
-                int $pageSize,
-            ): OzonRawPage {
-                $this->from = $from;
-                $this->to = $to;
-                $this->page = $page;
-                $this->pageSize = $pageSize;
+            public function fetchPostings(string $companyId, string $connectionRef, array $postingNumbers): OzonRawPage
+            {
+                $this->called = true;
 
-                return new OzonRawPage(rows: [['posting_number' => 'posting-1']], hasMore: false);
+                throw new \LogicException('Not used.');
             }
 
             public function fetchByDay(
@@ -258,39 +246,31 @@ final class OzonSellerReportConnectorTest extends TestCase
         };
 
         $connector = new OzonSellerReportConnector($this->unusedClient(), $accrualClient, new NullLogger());
-        $result = $connector->pull(new PullRequest(
-            companyId: Uuid::uuid7()->toString(),
-            connectionRef: 'connection-1',
-            shopRef: 'shop-1',
-            resourceType: OzonResourceType::ACCRUAL_POSTINGS,
-            cursorValue: null,
-            windowFrom: new \DateTimeImmutable('2026-06-01'),
-            windowTo: new \DateTimeImmutable('2026-06-18'),
-            syncJobId: Uuid::uuid7()->toString(),
-        ));
 
-        self::assertEquals(new \DateTimeImmutable('2026-06-01 00:00:00'), $accrualClient->from);
-        self::assertEquals(new \DateTimeImmutable('2026-06-07 23:59:59'), $accrualClient->to);
-        self::assertSame(1, $accrualClient->page);
-        self::assertSame(1000, $accrualClient->pageSize);
-        self::assertSame(OzonResourceType::ACCRUAL_POSTINGS, $result->rawBatch->resourceType);
-        self::assertSame('accrual-postings:2026-06-01:2026-06-07', $result->rawBatch->externalId);
-        self::assertSame([['posting_number' => 'posting-1']], $result->rawBatch->rows);
-        self::assertSame('2026-06-08', $result->nextCursorValue);
-        self::assertTrue($result->hasMore);
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('posting_numbers');
+
+        try {
+            $connector->pull(new PullRequest(
+                companyId: Uuid::uuid7()->toString(),
+                connectionRef: 'connection-1',
+                shopRef: 'shop-1',
+                resourceType: OzonResourceType::ACCRUAL_POSTINGS,
+                cursorValue: null,
+                windowFrom: new \DateTimeImmutable('2026-06-01'),
+                windowTo: new \DateTimeImmutable('2026-06-18'),
+                syncJobId: Uuid::uuid7()->toString(),
+            ));
+        } finally {
+            self::assertFalse($accrualClient->called);
+        }
     }
 
     public function testPullAccrualByDayStoresEmptyMarkerForEmptyResponse(): void
     {
         $accrualClient = new class implements OzonAccrualClientInterface {
-            public function fetchPostings(
-                string $companyId,
-                string $connectionRef,
-                \DateTimeImmutable $from,
-                \DateTimeImmutable $to,
-                int $page,
-                int $pageSize,
-            ): OzonRawPage {
+            public function fetchPostings(string $companyId, string $connectionRef, array $postingNumbers): OzonRawPage
+            {
                 throw new \LogicException('Not used.');
             }
 
@@ -367,14 +347,8 @@ final class OzonSellerReportConnectorTest extends TestCase
     private function unusedAccrualClient(): OzonAccrualClientInterface
     {
         return new class implements OzonAccrualClientInterface {
-            public function fetchPostings(
-                string $companyId,
-                string $connectionRef,
-                \DateTimeImmutable $from,
-                \DateTimeImmutable $to,
-                int $page,
-                int $pageSize,
-            ): OzonRawPage {
+            public function fetchPostings(string $companyId, string $connectionRef, array $postingNumbers): OzonRawPage
+            {
                 throw new \LogicException('Not used.');
             }
 

--- a/site/tests/Unit/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClientTest.php
+++ b/site/tests/Unit/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClientTest.php
@@ -24,7 +24,7 @@ final class OzonAccrualClientTest extends TestCase
             $capturedOptions = $options;
 
             return new MockResponse(
-                '{"result":{"postings":[{"posting_number":"posting-1"}],"total":12}}',
+                '{"result":{"postings":[{"posting_number":"posting-1"}]}}',
                 ['http_code' => 200],
             );
         });
@@ -33,23 +33,17 @@ final class OzonAccrualClientTest extends TestCase
         $page = $client->fetchPostings(
             '0192f0c2-0000-7000-8000-000000000001',
             '0192f0c2-0000-7000-8000-000000000002',
-            new \DateTimeImmutable('2026-06-13'),
-            new \DateTimeImmutable('2026-06-19'),
-            3,
-            5,
+            ['posting-1', ' posting-2 ', 'posting-1'],
         );
 
         self::assertSame('https://api-seller.ozon.ru/v1/finance/accrual/postings', $capturedUrl);
         $requestPayload = $capturedOptions['json'] ?? json_decode((string) ($capturedOptions['body'] ?? ''), true, 512, \JSON_THROW_ON_ERROR);
-        self::assertSame('2026-06-13', $requestPayload['date']['from']);
-        self::assertSame('2026-06-19', $requestPayload['date']['to']);
-        self::assertSame(5, $requestPayload['limit']);
-        self::assertSame(10, $requestPayload['offset']);
+        self::assertSame(['posting-1', 'posting-2'], $requestPayload['posting_numbers']);
         self::assertSame(['Client-Id: client-id'], $capturedOptions['normalized_headers']['client-id'] ?? null);
         self::assertSame(['Api-Key: api-key'], $capturedOptions['normalized_headers']['api-key'] ?? null);
         self::assertSame([['posting_number' => 'posting-1']], $page->rows);
-        self::assertTrue($page->hasMore);
-        self::assertSame('4', $page->nextPageToken);
+        self::assertFalse($page->hasMore);
+        self::assertNull($page->nextPageToken);
     }
 
     public function testFetchByDayExtractsResultListRows(): void
@@ -72,6 +66,24 @@ final class OzonAccrualClientTest extends TestCase
 
         self::assertSame([['date' => '2026-06-13', 'accruals' => [['accrual_id' => 1]]]], $page->rows);
         self::assertFalse($page->hasMore);
+    }
+
+    public function testFetchPostingsRequiresPostingNumbers(): void
+    {
+        $client = new OzonAccrualClient(
+            new MockHttpClient(new MockResponse('{}', ['http_code' => 200])),
+            $this->credentialProvider(),
+            new NullLogger(),
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('posting number');
+
+        $client->fetchPostings(
+            '0192f0c2-0000-7000-8000-000000000001',
+            '0192f0c2-0000-7000-8000-000000000002',
+            ['', '  '],
+        );
     }
 
     public function testUnauthorizedStatusBecomesAuthException(): void
@@ -107,7 +119,10 @@ final class OzonAccrualClientTest extends TestCase
     public function testGenericBadRequestStatusStaysRuntimeException(): void
     {
         $client = new OzonAccrualClient(
-            new MockHttpClient(new MockResponse('{"message":"bad date range"}', ['http_code' => 400])),
+            new MockHttpClient(new MockResponse(
+                '{"code":3,"message":"Request validation error: invalid GetFinanceAccrualPostingsRequest.PostingNumbers: value must contain between 1 and 200 items, inclusive"}',
+                ['http_code' => 400],
+            )),
             $this->credentialProvider(),
             new NullLogger(),
         );


### PR DESCRIPTION
## What changed

- Changed Ozon accrual postings API calls to use explicit `posting_numbers` instead of date/page parameters.
- Removed `ozon_finance_accrual_postings` from date backfill because the Ozon endpoint does not support period-based loading.
- Kept `ozon_finance_accrual_by_day` available for period backfill.
- Updated `app:ingestion:ozon-accrual:probe` so postings require repeated `--posting-number` options.
- Stopped treating all Ozon HTTP 400 `code=3` responses as auth failures; `code=3` can also be request validation.

## Why

Ozon `/v1/finance/accrual/postings` rejects date-based requests and requires 1..200 posting numbers per request. The previous implementation routed this endpoint through the date backfill path, which produced validation errors and misleading auth failure handling.

## Validation

- `php bin/phpunit --testsuite unit --filter "OzonAccrualClientTest|OzonSellerReportConnectorTest"` — passed
- `php bin/phpunit --testsuite integration --filter "StartBackfillCommandTest"` — passed with existing PHPUnit deprecations
- `make site-test-unit` — passed with existing 1 warning and 1 deprecation
- targeted `php-cs-fixer` on changed files — passed
- `git diff --check` — passed

## Notes

`make site-cs-check` still fails repo-wide on existing unrelated style issues outside this PR. The changed files pass targeted PHP-CS-Fixer.