### PR TITLE
[codex] fix ozon accrual by-day request

### DIFF
--- a/site/src/Ingestion/Application/Source/Ozon/OzonSellerReportConnector.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonSellerReportConnector.php
@@ -179,12 +179,25 @@ final readonly class OzonSellerReportConnector implements SourceConnectorInterfa
     private function pullAccrualByDay(PullRequest $request): PullResult
     {
         [$from, $to] = $this->resolveDailyWindow($request);
-        $page = $this->accrualClient->fetchByDay(
-            $request->companyId,
-            $request->connectionRef,
-            $from,
-            $to,
-        );
+        $rows = [];
+        $apiMetadata = [];
+
+        foreach ($this->eachDay($from, $to) as $date) {
+            $page = $this->accrualClient->fetchByDay(
+                $request->companyId,
+                $request->connectionRef,
+                $date,
+            );
+
+            if ([] !== $page->rows) {
+                array_push($rows, ...$page->rows);
+            }
+
+            $apiMetadata[] = [
+                'date' => $date->format('Y-m-d'),
+                'metadata' => $page->metadata,
+            ];
+        }
 
         $windowHasMore = null !== $request->windowTo && $to < $request->windowTo;
         $nextCursor = $windowHasMore || $this->isIncremental($request) ? $to->modify('+1 day')->format('Y-m-d') : null;
@@ -200,12 +213,12 @@ final readonly class OzonSellerReportConnector implements SourceConnectorInterfa
                 syncJobId: $request->syncJobId,
                 fetchedAt: new \DateTimeImmutable(),
                 rows: $this->rowsOrEmptyMarker(
-                    $page->rows,
+                    $rows,
                     OzonResourceType::ACCRUAL_BY_DAY,
                     [
                         'windowFrom' => $from->format('Y-m-d'),
                         'windowTo' => $to->format('Y-m-d'),
-                        'apiMetadata' => $page->metadata,
+                        'apiMetadata' => $apiMetadata,
                     ],
                 ),
             ),
@@ -268,6 +281,16 @@ final readonly class OzonSellerReportConnector implements SourceConnectorInterfa
         }
 
         return [$from, $to];
+    }
+
+    /**
+     * @return \Generator<int, \DateTimeImmutable>
+     */
+    private function eachDay(\DateTimeImmutable $from, \DateTimeImmutable $to): \Generator
+    {
+        for ($date = $from->setTime(0, 0); $date <= $to; $date = $date->modify('+1 day')) {
+            yield $date;
+        }
     }
 
     private function resolveRealizationMonth(PullRequest $request): \DateTimeImmutable

--- a/site/src/Ingestion/Command/OzonAccrualProbeCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualProbeCommand.php
@@ -128,8 +128,32 @@ final class OzonAccrualProbeCommand extends Command
     private function fetchByDay(InputInterface $input, string $companyId, string $connectionRef): OzonRawPage
     {
         [$from, $to] = $this->requiredDateWindow($input);
+        $rows = [];
+        $metadata = [];
 
-        return $this->client->fetchByDay($companyId, $connectionRef, $from, $to);
+        foreach ($this->eachDay($from, $to) as $date) {
+            $page = $this->client->fetchByDay($companyId, $connectionRef, $date);
+            if ([] !== $page->rows) {
+                array_push($rows, ...$page->rows);
+            }
+
+            $metadata[] = [
+                'date' => $date->format('Y-m-d'),
+                'metadata' => $page->metadata,
+            ];
+        }
+
+        return new OzonRawPage(rows: $rows, hasMore: false, metadata: ['days' => $metadata]);
+    }
+
+    /**
+     * @return \Generator<int, \DateTimeImmutable>
+     */
+    private function eachDay(\DateTimeImmutable $from, \DateTimeImmutable $to): \Generator
+    {
+        for ($date = $from->setTime(0, 0); $date <= $to; $date = $date->modify('+1 day')) {
+            yield $date;
+        }
     }
 
     /**

--- a/site/src/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClient.php
+++ b/site/src/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClient.php
@@ -45,18 +45,14 @@ final readonly class OzonAccrualClient implements OzonAccrualClientInterface
     public function fetchByDay(
         string $companyId,
         string $connectionRef,
-        \DateTimeImmutable $from,
-        \DateTimeImmutable $to,
+        \DateTimeImmutable $date,
     ): OzonRawPage {
         return $this->requestPage(
             companyId: $companyId,
             connectionRef: $connectionRef,
             endpoint: self::BY_DAY_ENDPOINT,
             json: [
-                'date' => [
-                    'from' => $from->format('Y-m-d'),
-                    'to' => $to->format('Y-m-d'),
-                ],
+                'date' => $date->format('Y-m-d'),
             ],
         );
     }

--- a/site/src/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClientInterface.php
+++ b/site/src/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClientInterface.php
@@ -18,8 +18,7 @@ interface OzonAccrualClientInterface
     public function fetchByDay(
         string $companyId,
         string $connectionRef,
-        \DateTimeImmutable $from,
-        \DateTimeImmutable $to,
+        \DateTimeImmutable $date,
     ): OzonRawPage;
 
     public function fetchTypes(string $companyId, string $connectionRef): OzonRawPage;

--- a/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonSellerReportConnectorTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonSellerReportConnectorTest.php
@@ -233,8 +233,7 @@ final class OzonSellerReportConnectorTest extends TestCase
             public function fetchByDay(
                 string $companyId,
                 string $connectionRef,
-                \DateTimeImmutable $from,
-                \DateTimeImmutable $to,
+                \DateTimeImmutable $date,
             ): OzonRawPage {
                 throw new \LogicException('Not used.');
             }
@@ -269,6 +268,9 @@ final class OzonSellerReportConnectorTest extends TestCase
     public function testPullAccrualByDayStoresEmptyMarkerForEmptyResponse(): void
     {
         $accrualClient = new class implements OzonAccrualClientInterface {
+            /** @var list<string> */
+            public array $dates = [];
+
             public function fetchPostings(string $companyId, string $connectionRef, array $postingNumbers): OzonRawPage
             {
                 throw new \LogicException('Not used.');
@@ -277,9 +279,10 @@ final class OzonSellerReportConnectorTest extends TestCase
             public function fetchByDay(
                 string $companyId,
                 string $connectionRef,
-                \DateTimeImmutable $from,
-                \DateTimeImmutable $to,
+                \DateTimeImmutable $date,
             ): OzonRawPage {
+                $this->dates[] = $date->format('Y-m-d');
+
                 return new OzonRawPage(rows: [], hasMore: false, metadata: ['endpoint' => '/v1/finance/accrual/by-day']);
             }
 
@@ -303,6 +306,7 @@ final class OzonSellerReportConnectorTest extends TestCase
 
         self::assertSame(OzonResourceType::ACCRUAL_BY_DAY, $result->rawBatch->resourceType);
         self::assertSame('accrual-by-day:2026-06-01:2026-06-02', $result->rawBatch->externalId);
+        self::assertSame(['2026-06-01', '2026-06-02'], $accrualClient->dates);
         self::assertSame([
             [
                 '_ingestion_empty' => true,
@@ -310,12 +314,69 @@ final class OzonSellerReportConnectorTest extends TestCase
                 '_ingestion_metadata' => [
                     'windowFrom' => '2026-06-01',
                     'windowTo' => '2026-06-02',
-                    'apiMetadata' => ['endpoint' => '/v1/finance/accrual/by-day'],
+                    'apiMetadata' => [
+                        [
+                            'date' => '2026-06-01',
+                            'metadata' => ['endpoint' => '/v1/finance/accrual/by-day'],
+                        ],
+                        [
+                            'date' => '2026-06-02',
+                            'metadata' => ['endpoint' => '/v1/finance/accrual/by-day'],
+                        ],
+                    ],
                 ],
             ],
         ], $result->rawBatch->rows);
         self::assertNull($result->nextCursorValue);
         self::assertFalse($result->hasMore);
+    }
+
+    public function testPullAccrualByDayFetchesEachDateInWindow(): void
+    {
+        $accrualClient = new class implements OzonAccrualClientInterface {
+            /** @var list<string> */
+            public array $dates = [];
+
+            public function fetchPostings(string $companyId, string $connectionRef, array $postingNumbers): OzonRawPage
+            {
+                throw new \LogicException('Not used.');
+            }
+
+            public function fetchByDay(
+                string $companyId,
+                string $connectionRef,
+                \DateTimeImmutable $date,
+            ): OzonRawPage {
+                $dateString = $date->format('Y-m-d');
+                $this->dates[] = $dateString;
+
+                return new OzonRawPage(rows: [['date' => $dateString, 'accrual_id' => $dateString]], hasMore: false);
+            }
+
+            public function fetchTypes(string $companyId, string $connectionRef): OzonRawPage
+            {
+                throw new \LogicException('Not used.');
+            }
+        };
+
+        $connector = new OzonSellerReportConnector($this->unusedClient(), $accrualClient, new NullLogger());
+        $result = $connector->pull(new PullRequest(
+            companyId: Uuid::uuid7()->toString(),
+            connectionRef: 'connection-1',
+            shopRef: 'shop-1',
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            cursorValue: null,
+            windowFrom: new \DateTimeImmutable('2026-06-01'),
+            windowTo: new \DateTimeImmutable('2026-06-02'),
+            syncJobId: Uuid::uuid7()->toString(),
+        ));
+
+        self::assertSame(['2026-06-01', '2026-06-02'], $accrualClient->dates);
+        self::assertSame([
+            ['date' => '2026-06-01', 'accrual_id' => '2026-06-01'],
+            ['date' => '2026-06-02', 'accrual_id' => '2026-06-02'],
+        ], $result->rawBatch->rows);
+        self::assertSame('accrual-by-day:2026-06-01:2026-06-02', $result->rawBatch->externalId);
     }
 
     private function unusedClient(): OzonClientAdapterInterface
@@ -355,8 +416,7 @@ final class OzonSellerReportConnectorTest extends TestCase
             public function fetchByDay(
                 string $companyId,
                 string $connectionRef,
-                \DateTimeImmutable $from,
-                \DateTimeImmutable $to,
+                \DateTimeImmutable $date,
             ): OzonRawPage {
                 throw new \LogicException('Not used.');
             }

--- a/site/tests/Unit/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClientTest.php
+++ b/site/tests/Unit/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClientTest.php
@@ -48,11 +48,20 @@ final class OzonAccrualClientTest extends TestCase
 
     public function testFetchByDayExtractsResultListRows(): void
     {
-        $client = new OzonAccrualClient(
-            new MockHttpClient(new MockResponse(
-                '{"result":[{"date":"2026-06-13","accruals":[{"accrual_id":1}]}]}',
+        $capturedUrl = null;
+        $capturedOptions = null;
+        $http = new MockHttpClient(static function (string $method, string $url, array $options) use (&$capturedUrl, &$capturedOptions): MockResponse {
+            $capturedUrl = $url;
+            $capturedOptions = $options;
+
+            return new MockResponse(
+                '{"accruals":[{"date":"2026-06-13","accrual_id":1}],"last_id":""}',
                 ['http_code' => 200],
-            )),
+            );
+        });
+
+        $client = new OzonAccrualClient(
+            $http,
             $this->credentialProvider(),
             new NullLogger(),
         );
@@ -61,10 +70,12 @@ final class OzonAccrualClientTest extends TestCase
             '0192f0c2-0000-7000-8000-000000000001',
             '0192f0c2-0000-7000-8000-000000000002',
             new \DateTimeImmutable('2026-06-13'),
-            new \DateTimeImmutable('2026-06-19'),
         );
 
-        self::assertSame([['date' => '2026-06-13', 'accruals' => [['accrual_id' => 1]]]], $page->rows);
+        self::assertSame('https://api-seller.ozon.ru/v1/finance/accrual/by-day', $capturedUrl);
+        $requestPayload = $capturedOptions['json'] ?? json_decode((string) ($capturedOptions['body'] ?? ''), true, 512, \JSON_THROW_ON_ERROR);
+        self::assertSame('2026-06-13', $requestPayload['date']);
+        self::assertSame([['date' => '2026-06-13', 'accrual_id' => 1]], $page->rows);
         self::assertFalse($page->hasMore);
     }
 


### PR DESCRIPTION
## What changed

- Changed Ozon accrual `by-day` client request from a date range object to a single `date` string.
- Updated the Ozon accrual connector to fetch each date in the chunk window and merge rows into the existing raw batch.
- Updated the probe command to do the same for `--endpoint=by-day --from ... --to ...`.
- Updated unit tests for the real top-level `accruals` response shape and the per-day connector calls.

## Why

Live Ozon returned validation for `/v1/finance/accrual/by-day` when called with `{ "date": { "from": "...", "to": "..." } }`:

```text
proto: (line 1:9): invalid value for string field date
```

A direct request with `{ "date": "2026-06-13" }` returned HTTP 200 and accrual rows. The endpoint is day-based, not range-based.

## Validation

- Direct Ozon curl with single-date payload returned HTTP 200.
- `php -l` on changed PHP source files — passed
- `php bin/phpunit --testsuite unit --filter "OzonAccrualClientTest|OzonSellerReportConnectorTest"` — passed
- `php bin/phpunit --testsuite integration --filter "StartBackfillCommandTest"` — passed with existing PHPUnit deprecations
- `make site-test-unit` — passed with existing 1 warning and 1 deprecation
- targeted `php-cs-fixer` on changed files — passed
- `git diff --check` — passed