### PR TITLE
[codex] Add Ozon accrual by-day compare audit

### DIFF
--- a/docs/tasks/ozon-accrual-compare-plan.md
+++ b/docs/tasks/ozon-accrual-compare-plan.md
@@ -1,0 +1,41 @@
+# Ozon accrual by-day compare plan
+
+## Goal
+
+Build a read-only audit for already loaded `ozon_finance_accrual_by_day` raw data, so we can decide how to normalize new Ozon accrual data without duplicating existing canonical transactions.
+
+## Scope
+
+- Use stored `ingest_raw_records` only.
+- Extend `app:ingestion:ozon-accrual:compare`.
+- Aggregate Ozon by-day raw rows by:
+  - day and `accrued_category`;
+  - delivery service `type_id`;
+  - commission money fields;
+  - item fee `type_id`;
+  - non-item fee `type_id`;
+  - container fee `type_id`.
+- Compare raw daily net amount with current Ozon `ingest_financial_transactions` daily net.
+
+## Out of scope
+
+- No writes to `ingest_financial_transactions`.
+- No new database tables or columns.
+- No schema migrations.
+- No changes to production jobs or scheduled ingestion.
+- No legacy marketplace cost formula changes.
+- No live Ozon API calls.
+
+## Execution stages
+
+1. Add raw aggregate DTO and service for `ozon_finance_accrual_by_day`.
+2. Extend compare command with by-day aggregate sections and raw-vs-canonical daily comparison.
+3. Add focused unit tests for nested accrual structures.
+4. Run syntax, style, unit checks, and self-review.
+
+## Testing
+
+- Focused unit test for raw by-day aggregation.
+- Symfony command container/autowire check via `--help`.
+- PHP CS Fixer dry-run for touched PHP files.
+- `make site-test-unit`.

--- a/site/src/Ingestion/Application/Source/Ozon/OzonAccrualByDayRawAggregate.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonAccrualByDayRawAggregate.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Source\Ozon;
+
+final readonly class OzonAccrualByDayRawAggregate
+{
+    /**
+     * @param list<array{date: string, category: string, count: int, totalMinor: int}> $dateCategoryRows
+     * @param list<array{date: string, typeId: string, count: int, totalMinor: int}> $deliveryServiceRows
+     * @param list<array{date: string, field: string, count: int, totalMinor: int}> $commissionRows
+     * @param list<array{date: string, typeId: string, count: int, totalMinor: int}> $itemFeeRows
+     * @param list<array{date: string, typeId: string, count: int, totalMinor: int}> $nonItemFeeRows
+     * @param list<array{date: string, typeId: string, count: int, totalMinor: int}> $containerFeeRows
+     */
+    public function __construct(
+        public int $scannedRows,
+        public array $dateCategoryRows,
+        public array $deliveryServiceRows,
+        public array $commissionRows,
+        public array $itemFeeRows,
+        public array $nonItemFeeRows,
+        public array $containerFeeRows,
+    ) {
+    }
+}

--- a/site/src/Ingestion/Application/Source/Ozon/OzonAccrualByDayRawAggregator.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonAccrualByDayRawAggregator.php
@@ -1,0 +1,272 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Source\Ozon;
+
+final readonly class OzonAccrualByDayRawAggregator
+{
+    public function __construct(private OzonMoneyParser $moneyParser)
+    {
+    }
+
+    /**
+     * @param iterable<array<string, mixed>> $rows
+     */
+    public function aggregate(iterable $rows): OzonAccrualByDayRawAggregate
+    {
+        $scannedRows = 0;
+        $dateCategory = [];
+        $deliveryServices = [];
+        $commissions = [];
+        $itemFees = [];
+        $nonItemFees = [];
+        $containerFees = [];
+
+        foreach ($rows as $row) {
+            ++$scannedRows;
+
+            $date = $this->stringValue($row['date'] ?? 'unknown');
+            $category = $this->stringValue($row['accrued_category'] ?? 'unknown');
+
+            $this->add($dateCategory, [$date, $category], [
+                'date' => $date,
+                'category' => $category,
+            ], $this->moneyObjectMinor($row['total_amount'] ?? null));
+
+            $this->collectPosting($row['posting'] ?? null, $date, $deliveryServices, $commissions);
+            $this->collectItemFees($row['item_fees'] ?? null, $date, $itemFees);
+            $this->collectNonItemFee($row['non_item_fee'] ?? null, $date, $nonItemFees);
+            $this->collectContainerFees($row['container_fees'] ?? null, $date, $containerFees);
+        }
+
+        return new OzonAccrualByDayRawAggregate(
+            scannedRows: $scannedRows,
+            dateCategoryRows: $this->flatten($dateCategory),
+            deliveryServiceRows: $this->flatten($deliveryServices),
+            commissionRows: $this->flatten($commissions),
+            itemFeeRows: $this->flatten($itemFees),
+            nonItemFeeRows: $this->flatten($nonItemFees),
+            containerFeeRows: $this->flatten($containerFees),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @param array<string, array<string, int|string>> $deliveryServices
+     * @param array<string, array<string, int|string>> $commissions
+     */
+    private function collectPosting(mixed $row, string $date, array &$deliveryServices, array &$commissions): void
+    {
+        if (!is_array($row)) {
+            return;
+        }
+
+        $products = $row['products'] ?? [];
+        if (!is_array($products)) {
+            return;
+        }
+
+        foreach ($products as $product) {
+            if (!is_array($product)) {
+                continue;
+            }
+
+            $this->collectDeliveryServices($product['delivery']['services'] ?? null, $date, $deliveryServices);
+            $this->collectCommission($product['commission'] ?? null, $date, $commissions);
+        }
+    }
+
+    /**
+     * @param array<string, array<string, int|string>> $deliveryServices
+     */
+    private function collectDeliveryServices(mixed $services, string $date, array &$deliveryServices): void
+    {
+        if (!is_array($services)) {
+            return;
+        }
+
+        foreach ($services as $service) {
+            if (!is_array($service)) {
+                continue;
+            }
+
+            $typeId = $this->typeId($service);
+            $amountMinor = $this->moneyObjectMinor($service['accrued'] ?? null);
+            if (0 === $amountMinor) {
+                continue;
+            }
+
+            $this->add($deliveryServices, [$date, $typeId], [
+                'date' => $date,
+                'typeId' => $typeId,
+            ], $amountMinor);
+        }
+    }
+
+    /**
+     * @param array<string, array<string, int|string>> $commissions
+     */
+    private function collectCommission(mixed $commission, string $date, array &$commissions): void
+    {
+        if (!is_array($commission)) {
+            return;
+        }
+
+        foreach ($commission as $field => $value) {
+            if (!is_array($value) || !array_key_exists('amount', $value)) {
+                continue;
+            }
+
+            $amountMinor = $this->moneyObjectMinor($value);
+            if (0 === $amountMinor) {
+                continue;
+            }
+
+            $field = (string) $field;
+            $this->add($commissions, [$date, $field], [
+                'date' => $date,
+                'field' => $field,
+            ], $amountMinor);
+        }
+    }
+
+    /**
+     * @param array<string, array<string, int|string>> $itemFees
+     */
+    private function collectItemFees(mixed $itemFeesBlock, string $date, array &$itemFees): void
+    {
+        if (!is_array($itemFeesBlock)) {
+            return;
+        }
+
+        $skuFeeGroups = $itemFeesBlock['fees'] ?? [];
+        if (!is_array($skuFeeGroups)) {
+            return;
+        }
+
+        foreach ($skuFeeGroups as $skuFeeGroup) {
+            if (!is_array($skuFeeGroup) || !is_array($skuFeeGroup['fees'] ?? null)) {
+                continue;
+            }
+
+            foreach ($skuFeeGroup['fees'] as $fee) {
+                $this->collectTypedFee($fee, $date, $itemFees);
+            }
+        }
+    }
+
+    /**
+     * @param array<string, array<string, int|string>> $nonItemFees
+     */
+    private function collectNonItemFee(mixed $fee, string $date, array &$nonItemFees): void
+    {
+        $this->collectTypedFee($fee, $date, $nonItemFees);
+    }
+
+    /**
+     * @param array<string, array<string, int|string>> $containerFees
+     */
+    private function collectContainerFees(mixed $value, string $date, array &$containerFees): void
+    {
+        if (!is_array($value)) {
+            return;
+        }
+
+        $this->collectTypedFee($value, $date, $containerFees);
+
+        foreach ($value as $child) {
+            if (is_array($child)) {
+                $this->collectContainerFees($child, $date, $containerFees);
+            }
+        }
+    }
+
+    /**
+     * @param array<string, array<string, int|string>> $bucket
+     */
+    private function collectTypedFee(mixed $fee, string $date, array &$bucket): void
+    {
+        if (!is_array($fee) || !array_key_exists('accrued', $fee)) {
+            return;
+        }
+
+        $typeId = $this->typeId($fee);
+        $amountMinor = $this->moneyObjectMinor($fee['accrued']);
+        if (0 === $amountMinor) {
+            return;
+        }
+
+        $this->add($bucket, [$date, $typeId], [
+            'date' => $date,
+            'typeId' => $typeId,
+        ], $amountMinor);
+    }
+
+    /**
+     * @param array<string, array<string, int|string>> $bucket
+     * @param list<string> $keyParts
+     * @param array<string, string> $dimensions
+     */
+    private function add(array &$bucket, array $keyParts, array $dimensions, int $amountMinor): void
+    {
+        $key = implode('|', $keyParts);
+        if (!isset($bucket[$key])) {
+            $bucket[$key] = $dimensions + [
+                'count' => 0,
+                'totalMinor' => 0,
+            ];
+        }
+
+        $bucket[$key]['count'] = (int) $bucket[$key]['count'] + 1;
+        $bucket[$key]['totalMinor'] = (int) $bucket[$key]['totalMinor'] + $amountMinor;
+    }
+
+    /**
+     * @param array<string, array<string, int|string>> $bucket
+     *
+     * @return list<array<string, int|string>>
+     */
+    private function flatten(array $bucket): array
+    {
+        $rows = array_values($bucket);
+        usort($rows, static function (array $left, array $right): int {
+            foreach (['date', 'category', 'typeId', 'field'] as $key) {
+                $comparison = strcmp((string) ($left[$key] ?? ''), (string) ($right[$key] ?? ''));
+                if (0 !== $comparison) {
+                    return $comparison;
+                }
+            }
+
+            return 0;
+        });
+
+        return $rows;
+    }
+
+    /**
+     * @param array<string, mixed> $fee
+     */
+    private function typeId(array $fee): string
+    {
+        $typeId = $fee['type_id'] ?? $fee['typeId'] ?? 'unknown';
+
+        return $this->stringValue($typeId);
+    }
+
+    private function moneyObjectMinor(mixed $value): int
+    {
+        if (is_array($value) && array_key_exists('amount', $value)) {
+            return $this->moneyParser->minor($value['amount']);
+        }
+
+        return $this->moneyParser->minor($value);
+    }
+
+    private function stringValue(mixed $value): string
+    {
+        $value = trim((string) $value);
+
+        return '' === $value ? 'unknown' : $value;
+    }
+}

--- a/site/src/Ingestion/Command/OzonAccrualCompareCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualCompareCommand.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Ingestion\Command;
 
+use App\Ingestion\Application\Source\Ozon\OzonAccrualByDayRawAggregate;
+use App\Ingestion\Application\Source\Ozon\OzonAccrualByDayRawAggregator;
 use App\Ingestion\Application\Source\Ozon\OzonResourceType;
 use App\Ingestion\Enum\IngestSource;
 use App\Ingestion\Facade\RawStorageFacade;
@@ -34,6 +36,7 @@ final class OzonAccrualCompareCommand extends Command
     public function __construct(
         private readonly Connection $connection,
         private readonly RawStorageFacade $rawStorageFacade,
+        private readonly OzonAccrualByDayRawAggregator $byDayRawAggregator,
     ) {
         parent::__construct();
     }
@@ -70,6 +73,11 @@ final class OzonAccrualCompareCommand extends Command
         $rawRecords = $this->rawRecords($companyId, $resourceType, $from, $to, $rawLimit);
         $this->printRawRecords($io, $rawRecords);
         $this->printRawStructureSummary($io, $companyId, $rawRecords, $rawRowLimit);
+        if (OzonResourceType::ACCRUAL_BY_DAY === $resourceType) {
+            $aggregate = $this->byDayRawAggregator->aggregate($this->rawRows($companyId, $rawRecords, $rawRowLimit));
+            $this->printByDayAggregate($io, $aggregate);
+            $this->printDailyComparison($io, $aggregate, $this->canonicalDailyNetRows($companyId, $from, $to));
+        }
 
         return Command::SUCCESS;
     }
@@ -114,6 +122,41 @@ final class OzonAccrualCompareCommand extends Command
                 (string) $row['total_rub'],
             ], $rows),
         );
+    }
+
+    /**
+     * @return array<string, array{txCount: int, totalMinor: int}>
+     */
+    private function canonicalDailyNetRows(string $companyId, \DateTimeImmutable $from, \DateTimeImmutable $to): array
+    {
+        $rows = $this->connection->fetchAllAssociative(
+            "SELECT DATE(occurred_at) AS date,
+                    COUNT(*) AS tx_count,
+                    COALESCE(SUM(CASE WHEN direction = 'out' THEN -amount_minor ELSE amount_minor END), 0) AS total_minor
+             FROM ingest_financial_transactions
+             WHERE company_id = :companyId
+               AND source = :source
+               AND occurred_at >= :fromAt
+               AND occurred_at <= :toAt
+             GROUP BY DATE(occurred_at)
+             ORDER BY DATE(occurred_at)",
+            [
+                'companyId' => $companyId,
+                'source' => IngestSource::OZON->value,
+                'fromAt' => $from->format('Y-m-d 00:00:00'),
+                'toAt' => $to->format('Y-m-d 23:59:59'),
+            ],
+        );
+
+        $indexed = [];
+        foreach ($rows as $row) {
+            $indexed[(string) $row['date']] = [
+                'txCount' => (int) $row['tx_count'],
+                'totalMinor' => (int) $row['total_minor'],
+            ];
+        }
+
+        return $indexed;
     }
 
     /**
@@ -270,6 +313,114 @@ final class OzonAccrualCompareCommand extends Command
         }
 
         $io->table(['key', 'sum'], $rows);
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rawRecords
+     *
+     * @return \Generator<int, array<string, mixed>>
+     */
+    private function rawRows(string $companyId, array $rawRecords, int $rowLimit): \Generator
+    {
+        foreach ($rawRecords as $rawRecord) {
+            $recordRows = 0;
+            foreach ($this->rawStorageFacade->read((string) $rawRecord['id'], $companyId) as $row) {
+                if ($recordRows >= $rowLimit) {
+                    break;
+                }
+
+                ++$recordRows;
+                yield $row;
+            }
+        }
+    }
+
+    private function printByDayAggregate(SymfonyStyle $io, OzonAccrualByDayRawAggregate $aggregate): void
+    {
+        $io->section('Accrual by-day raw aggregates');
+        $io->writeln(sprintf('Scanned rows: %d', $aggregate->scannedRows));
+
+        $this->printMinorRows($io, 'Raw totals by date/category', ['date', 'category', 'count', 'totalRub'], $aggregate->dateCategoryRows);
+        $this->printMinorRows($io, 'Delivery services by date/type_id', ['date', 'typeId', 'count', 'totalRub'], $aggregate->deliveryServiceRows);
+        $this->printMinorRows($io, 'Commission money fields by date/field', ['date', 'field', 'count', 'totalRub'], $aggregate->commissionRows);
+        $this->printMinorRows($io, 'Item fees by date/type_id', ['date', 'typeId', 'count', 'totalRub'], $aggregate->itemFeeRows);
+        $this->printMinorRows($io, 'Non-item fees by date/type_id', ['date', 'typeId', 'count', 'totalRub'], $aggregate->nonItemFeeRows);
+        $this->printMinorRows($io, 'Container fees by date/type_id', ['date', 'typeId', 'count', 'totalRub'], $aggregate->containerFeeRows);
+    }
+
+    /**
+     * @param list<string> $headers
+     * @param list<array<string, int|string>> $rows
+     */
+    private function printMinorRows(SymfonyStyle $io, string $title, array $headers, array $rows): void
+    {
+        $io->section($title);
+        if ([] === $rows) {
+            $io->writeln('No rows.');
+
+            return;
+        }
+
+        $io->table($headers, array_map(fn (array $row): array => $this->formatMinorRow($headers, $row), $rows));
+    }
+
+    /**
+     * @param list<string> $headers
+     * @param array<string, int|string> $row
+     *
+     * @return list<string>
+     */
+    private function formatMinorRow(array $headers, array $row): array
+    {
+        return array_map(function (string $header) use ($row): string {
+            if ('totalRub' === $header) {
+                return $this->minorToRub((int) $row['totalMinor']);
+            }
+
+            return (string) ($row[$header] ?? '');
+        }, $headers);
+    }
+
+    /**
+     * @param array<string, array{txCount: int, totalMinor: int}> $canonicalByDate
+     */
+    private function printDailyComparison(SymfonyStyle $io, OzonAccrualByDayRawAggregate $aggregate, array $canonicalByDate): void
+    {
+        $rawByDate = [];
+        foreach ($aggregate->dateCategoryRows as $row) {
+            $date = (string) $row['date'];
+            $rawByDate[$date] = ($rawByDate[$date] ?? 0) + (int) $row['totalMinor'];
+        }
+
+        $dates = array_values(array_unique(array_merge(array_keys($rawByDate), array_keys($canonicalByDate))));
+        sort($dates);
+
+        $io->section('Raw accrual net vs canonical net by date');
+        if ([] === $dates) {
+            $io->writeln('No rows.');
+
+            return;
+        }
+
+        $rows = [];
+        foreach ($dates as $date) {
+            $rawTotalMinor = (int) ($rawByDate[$date] ?? 0);
+            $canonicalTotalMinor = (int) ($canonicalByDate[$date]['totalMinor'] ?? 0);
+            $rows[] = [
+                $date,
+                $this->minorToRub($rawTotalMinor),
+                (string) ($canonicalByDate[$date]['txCount'] ?? 0),
+                $this->minorToRub($canonicalTotalMinor),
+                $this->minorToRub($rawTotalMinor - $canonicalTotalMinor),
+            ];
+        }
+
+        $io->table(['date', 'rawNetRub', 'canonicalTxCount', 'canonicalNetRub', 'deltaRub'], $rows);
+    }
+
+    private function minorToRub(int $minor): string
+    {
+        return number_format($minor / 100, 2, '.', '');
     }
 
     private function requiredUuidOption(InputInterface $input, string $name): string

--- a/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonAccrualByDayRawAggregatorTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonAccrualByDayRawAggregatorTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Application\Source\Ozon;
+
+use App\Ingestion\Application\Source\Ozon\OzonAccrualByDayRawAggregator;
+use App\Ingestion\Application\Source\Ozon\OzonMoneyParser;
+use PHPUnit\Framework\TestCase;
+
+final class OzonAccrualByDayRawAggregatorTest extends TestCase
+{
+    public function testAggregatesByDayAccrualRowsByCategoryAndNestedTypeIds(): void
+    {
+        $aggregate = $this->aggregator()->aggregate([
+            [
+                'date' => '2026-06-13',
+                'total_amount' => ['amount' => '-7.86', 'currency' => 'RUB'],
+                'accrued_category' => 'POSTING',
+                'posting' => [
+                    'products' => [[
+                        'delivery' => [
+                            'services' => [
+                                ['type_id' => 29, 'accrued' => ['amount' => '-7.86', 'currency' => 'RUB']],
+                                ['type_id' => 45, 'accrued' => ['amount' => '-15', 'currency' => 'RUB']],
+                            ],
+                        ],
+                        'commission' => [
+                            'sale_commission' => ['amount' => '-120.05', 'currency' => 'RUB'],
+                            'bonus' => ['amount' => '12.79', 'currency' => 'RUB'],
+                        ],
+                    ]],
+                ],
+            ],
+            [
+                'date' => '2026-06-13',
+                'total_amount' => ['amount' => '18.66', 'currency' => 'RUB'],
+                'accrued_category' => 'ITEM',
+                'item_fees' => [
+                    'fees' => [[
+                        'sku' => 1402860328,
+                        'fees' => [
+                            ['type_id' => 1, 'accrued' => ['amount' => '18.66', 'currency' => 'RUB']],
+                        ],
+                    ]],
+                ],
+            ],
+            [
+                'date' => '2026-06-14',
+                'total_amount' => ['amount' => '-78.28', 'currency' => 'RUB'],
+                'accrued_category' => 'NON_ITEM',
+                'non_item_fee' => ['type_id' => 46, 'accrued' => ['amount' => '-78.28', 'currency' => 'RUB']],
+            ],
+            [
+                'date' => '2026-06-14',
+                'total_amount' => ['amount' => '-3.50', 'currency' => 'RUB'],
+                'accrued_category' => 'CONTAINER',
+                'container_fees' => [
+                    'fees' => [
+                        ['type_id' => 77, 'accrued' => ['amount' => '-3.50', 'currency' => 'RUB']],
+                    ],
+                ],
+            ],
+        ]);
+
+        self::assertSame(4, $aggregate->scannedRows);
+        self::assertSame([
+            ['date' => '2026-06-13', 'category' => 'ITEM', 'count' => 1, 'totalMinor' => 1866],
+            ['date' => '2026-06-13', 'category' => 'POSTING', 'count' => 1, 'totalMinor' => -786],
+            ['date' => '2026-06-14', 'category' => 'CONTAINER', 'count' => 1, 'totalMinor' => -350],
+            ['date' => '2026-06-14', 'category' => 'NON_ITEM', 'count' => 1, 'totalMinor' => -7828],
+        ], $aggregate->dateCategoryRows);
+        self::assertSame([
+            ['date' => '2026-06-13', 'typeId' => '29', 'count' => 1, 'totalMinor' => -786],
+            ['date' => '2026-06-13', 'typeId' => '45', 'count' => 1, 'totalMinor' => -1500],
+        ], $aggregate->deliveryServiceRows);
+        self::assertSame([
+            ['date' => '2026-06-13', 'field' => 'bonus', 'count' => 1, 'totalMinor' => 1279],
+            ['date' => '2026-06-13', 'field' => 'sale_commission', 'count' => 1, 'totalMinor' => -12005],
+        ], $aggregate->commissionRows);
+        self::assertSame([
+            ['date' => '2026-06-13', 'typeId' => '1', 'count' => 1, 'totalMinor' => 1866],
+        ], $aggregate->itemFeeRows);
+        self::assertSame([
+            ['date' => '2026-06-14', 'typeId' => '46', 'count' => 1, 'totalMinor' => -7828],
+        ], $aggregate->nonItemFeeRows);
+        self::assertSame([
+            ['date' => '2026-06-14', 'typeId' => '77', 'count' => 1, 'totalMinor' => -350],
+        ], $aggregate->containerFeeRows);
+    }
+
+    public function testIgnoresMissingNestedBlocks(): void
+    {
+        $aggregate = $this->aggregator()->aggregate([
+            [
+                'date' => '2026-06-13',
+                'total_amount' => ['amount' => '0', 'currency' => 'RUB'],
+                'accrued_category' => 'POSTING',
+                'posting' => null,
+                'item_fees' => null,
+                'non_item_fee' => null,
+                'container_fees' => null,
+            ],
+        ]);
+
+        self::assertSame(1, $aggregate->scannedRows);
+        self::assertSame([
+            ['date' => '2026-06-13', 'category' => 'POSTING', 'count' => 1, 'totalMinor' => 0],
+        ], $aggregate->dateCategoryRows);
+        self::assertSame([], $aggregate->deliveryServiceRows);
+        self::assertSame([], $aggregate->commissionRows);
+        self::assertSame([], $aggregate->itemFeeRows);
+        self::assertSame([], $aggregate->nonItemFeeRows);
+        self::assertSame([], $aggregate->containerFeeRows);
+    }
+
+    private function aggregator(): OzonAccrualByDayRawAggregator
+    {
+        return new OzonAccrualByDayRawAggregator(new OzonMoneyParser());
+    }
+}


### PR DESCRIPTION
## Summary
- add a read-only `ozon_finance_accrual_by_day` raw aggregator
- extend `app:ingestion:ozon-accrual:compare` with by-day/category/type_id breakdowns
- compare raw daily net against current canonical Ozon transaction net
- document the audit plan

## Scope
No canonical writes, no migrations, no production job wiring, no live Ozon API calls.

## Checks
- `php bin/phpunit --testsuite unit --filter "OzonAccrualByDayRawAggregatorTest"`
- `vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --dry-run --diff --cache-file=var/cache/.php-cs-fixer.cache src/Ingestion/Command/OzonAccrualCompareCommand.php src/Ingestion/Application/Source/Ozon/OzonAccrualByDayRawAggregate.php src/Ingestion/Application/Source/Ozon/OzonAccrualByDayRawAggregator.php tests/Unit/Ingestion/Application/Source/Ozon/OzonAccrualByDayRawAggregatorTest.php`
- `make site-test-unit`
- `git diff --check`
