### PR TITLE
[codex] Add Ozon accrual normalization preview

### DIFF
--- a/docs/tasks/ozon-accrual-normalization-preview-plan.md
+++ b/docs/tasks/ozon-accrual-normalization-preview-plan.md
@@ -26,6 +26,7 @@ Add a safe dry-run view that shows which canonical financial transactions could 
 - Exact candidate: existing canonical transaction with the preview source key and transaction type.
 - Potential legacy candidate: existing canonical transaction on the same date with the same type, direction, and amount.
 - Aggregate comparison: preview totals vs canonical totals by date, type, and direction.
+- Raw rows are filtered by the requested `--from/--to` window before preview mapping, because stored raw records can cover a wider ingestion chunk than the CLI window.
 
 ## Checks
 

--- a/docs/tasks/ozon-accrual-normalization-preview-plan.md
+++ b/docs/tasks/ozon-accrual-normalization-preview-plan.md
@@ -1,0 +1,35 @@
+# Ozon accrual normalization preview plan
+
+## Goal
+
+Add a safe dry-run view that shows which canonical financial transactions could be produced from stored `ozon_finance_accrual_by_day` raw records.
+
+## Scope
+
+- Read only stored raw records and existing canonical transactions.
+- Do not call Ozon API.
+- Do not write to `ingest_financial_transactions`.
+- Do not change the shadow mapper used by the normal ingestion pipeline.
+- Do not add tables, columns, migrations, queues, or jobs.
+
+## Preview mapping
+
+- `POSTING` commission fields become `commission` transactions.
+- `POSTING` delivery service `type_id` rows become `fee` transactions.
+- `ITEM` fee `type_id` rows become `fee` transactions.
+- `NON_ITEM` fee `type_id` rows become `other` transactions, matching the current legacy aggregate shape.
+- `CONTAINER` fee `type_id` rows become `fee` transactions.
+- Sale/refund amount fields and non-transaction amount fields such as `bonus`, `coinvestment`, `sale_amount`, and `seller_price` are intentionally omitted from the preview to avoid known duplicate risk.
+
+## Duplicate checks
+
+- Exact candidate: existing canonical transaction with the preview source key and transaction type.
+- Potential legacy candidate: existing canonical transaction on the same date with the same type, direction, and amount.
+- Aggregate comparison: preview totals vs canonical totals by date, type, and direction.
+
+## Checks
+
+- Focused unit tests for the preview mapper.
+- Symfony command registration check via `--help`.
+- PHP CS Fixer dry-run for touched files.
+- Full `make site-test-unit`.

--- a/site/src/Ingestion/Application/Source/Ozon/OzonAccrualByDayPreviewMapper.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonAccrualByDayPreviewMapper.php
@@ -19,8 +19,12 @@ final readonly class OzonAccrualByDayPreviewMapper
      *
      * @return list<OzonAccrualPreviewTransaction>
      */
-    public function preview(string $companyId, iterable $rows): array
-    {
+    public function preview(
+        string $companyId,
+        iterable $rows,
+        ?\DateTimeImmutable $from = null,
+        ?\DateTimeImmutable $to = null,
+    ): array {
         $transactions = [];
         $rowIndex = 0;
 
@@ -28,6 +32,10 @@ final readonly class OzonAccrualByDayPreviewMapper
             ++$rowIndex;
 
             $date = $this->stringValue($row['date'] ?? 'unknown');
+            if (!$this->dateInWindow($date, $from, $to)) {
+                continue;
+            }
+
             $category = $this->stringValue($row['accrued_category'] ?? 'unknown');
             $accrualId = $this->accrualId($row, $rowIndex);
             $operationGroupId = Uuid::uuid5(Uuid::NAMESPACE_URL, sprintf('%s:ozon:accrual-by-day:%s', $companyId, $accrualId))->toString();
@@ -364,6 +372,23 @@ final readonly class OzonAccrualByDayPreviewMapper
     private function directionFromSigned(int $amountMinor): TransactionDirection
     {
         return $amountMinor >= 0 ? TransactionDirection::IN : TransactionDirection::OUT;
+    }
+
+    private function dateInWindow(string $date, ?\DateTimeImmutable $from, ?\DateTimeImmutable $to): bool
+    {
+        if (null === $from && null === $to) {
+            return true;
+        }
+
+        if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) {
+            return false;
+        }
+
+        if (null !== $from && $date < $from->format('Y-m-d')) {
+            return false;
+        }
+
+        return null === $to || $date <= $to->format('Y-m-d');
     }
 
     private function optionalString(mixed $value): ?string

--- a/site/src/Ingestion/Application/Source/Ozon/OzonAccrualByDayPreviewMapper.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonAccrualByDayPreviewMapper.php
@@ -1,0 +1,389 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Source\Ozon;
+
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+use Ramsey\Uuid\Uuid;
+
+final readonly class OzonAccrualByDayPreviewMapper
+{
+    public function __construct(private OzonMoneyParser $moneyParser)
+    {
+    }
+
+    /**
+     * @param iterable<array<string, mixed>> $rows
+     *
+     * @return list<OzonAccrualPreviewTransaction>
+     */
+    public function preview(string $companyId, iterable $rows): array
+    {
+        $transactions = [];
+        $rowIndex = 0;
+
+        foreach ($rows as $row) {
+            ++$rowIndex;
+
+            $date = $this->stringValue($row['date'] ?? 'unknown');
+            $category = $this->stringValue($row['accrued_category'] ?? 'unknown');
+            $accrualId = $this->accrualId($row, $rowIndex);
+            $operationGroupId = Uuid::uuid5(Uuid::NAMESPACE_URL, sprintf('%s:ozon:accrual-by-day:%s', $companyId, $accrualId))->toString();
+            $unitNumber = $this->optionalString($row['unit_number'] ?? null);
+
+            match ($category) {
+                'POSTING' => $this->collectPosting($transactions, $row, $operationGroupId, $date, $category, $accrualId, $unitNumber),
+                'ITEM' => $this->collectItemFees($transactions, $row['item_fees'] ?? null, $operationGroupId, $date, $category, $accrualId, $unitNumber),
+                'NON_ITEM' => $this->collectNonItemFee($transactions, $row['non_item_fee'] ?? null, $operationGroupId, $date, $category, $accrualId, $unitNumber),
+                'CONTAINER' => $this->collectContainerFees($transactions, $row['container_fees'] ?? null, $operationGroupId, $date, $category, $accrualId, $unitNumber),
+                default => null,
+            };
+        }
+
+        return $transactions;
+    }
+
+    /**
+     * @param list<OzonAccrualPreviewTransaction> $transactions
+     * @param array<string, mixed> $row
+     */
+    private function collectPosting(
+        array &$transactions,
+        array $row,
+        string $operationGroupId,
+        string $date,
+        string $category,
+        string $accrualId,
+        ?string $unitNumber,
+    ): void {
+        $posting = $row['posting'] ?? null;
+        if (!is_array($posting)) {
+            return;
+        }
+
+        $products = $posting['products'] ?? [];
+        if (!is_array($products)) {
+            return;
+        }
+
+        foreach ($products as $productIndex => $product) {
+            if (!is_array($product)) {
+                continue;
+            }
+
+            $this->collectCommission($transactions, $product['commission'] ?? null, $operationGroupId, $date, $category, $accrualId, (int) $productIndex, $unitNumber);
+            $this->collectDeliveryServices($transactions, $product['delivery']['services'] ?? null, $operationGroupId, $date, $category, $accrualId, (int) $productIndex, $unitNumber);
+        }
+    }
+
+    /**
+     * @param list<OzonAccrualPreviewTransaction> $transactions
+     */
+    private function collectCommission(
+        array &$transactions,
+        mixed $commission,
+        string $operationGroupId,
+        string $date,
+        string $category,
+        string $accrualId,
+        int $productIndex,
+        ?string $unitNumber,
+    ): void {
+        if (!is_array($commission)) {
+            return;
+        }
+
+        $amount = $this->moneyObjectMinor($commission['commission'] ?? $commission['sale_commission'] ?? null);
+        if (0 === $amount) {
+            return;
+        }
+
+        $this->add(
+            transactions: $transactions,
+            operationGroupId: $operationGroupId,
+            date: $date,
+            category: $category,
+            accrualId: $accrualId,
+            component: sprintf('commission:product-%d', $productIndex),
+            type: TransactionType::COMMISSION,
+            signedAmountMinor: $amount,
+            field: array_key_exists('commission', $commission) ? 'commission' : 'sale_commission',
+            unitNumber: $unitNumber,
+        );
+    }
+
+    /**
+     * @param list<OzonAccrualPreviewTransaction> $transactions
+     */
+    private function collectDeliveryServices(
+        array &$transactions,
+        mixed $services,
+        string $operationGroupId,
+        string $date,
+        string $category,
+        string $accrualId,
+        int $productIndex,
+        ?string $unitNumber,
+    ): void {
+        if (!is_array($services)) {
+            return;
+        }
+
+        foreach ($services as $serviceIndex => $service) {
+            if (!is_array($service)) {
+                continue;
+            }
+
+            $typeId = $this->typeId($service);
+            $amount = $this->moneyObjectMinor($service['accrued'] ?? null);
+            if (0 === $amount) {
+                continue;
+            }
+
+            $this->add(
+                transactions: $transactions,
+                operationGroupId: $operationGroupId,
+                date: $date,
+                category: $category,
+                accrualId: $accrualId,
+                component: sprintf('delivery:product-%d:service-%d:type-%s', $productIndex, (int) $serviceIndex, $typeId),
+                type: TransactionType::FEE,
+                signedAmountMinor: $amount,
+                typeId: $typeId,
+                unitNumber: $unitNumber,
+            );
+        }
+    }
+
+    /**
+     * @param list<OzonAccrualPreviewTransaction> $transactions
+     */
+    private function collectItemFees(
+        array &$transactions,
+        mixed $itemFeesBlock,
+        string $operationGroupId,
+        string $date,
+        string $category,
+        string $accrualId,
+        ?string $unitNumber,
+    ): void {
+        if (!is_array($itemFeesBlock)) {
+            return;
+        }
+
+        $skuFeeGroups = $itemFeesBlock['fees'] ?? [];
+        if (!is_array($skuFeeGroups)) {
+            return;
+        }
+
+        foreach ($skuFeeGroups as $groupIndex => $skuFeeGroup) {
+            if (!is_array($skuFeeGroup) || !is_array($skuFeeGroup['fees'] ?? null)) {
+                continue;
+            }
+
+            foreach ($skuFeeGroup['fees'] as $feeIndex => $fee) {
+                $this->collectTypedFee(
+                    transactions: $transactions,
+                    fee: $fee,
+                    operationGroupId: $operationGroupId,
+                    date: $date,
+                    category: $category,
+                    accrualId: $accrualId,
+                    componentPrefix: sprintf('item_fee:group-%d:fee-%d', (int) $groupIndex, (int) $feeIndex),
+                    type: TransactionType::FEE,
+                    unitNumber: $unitNumber,
+                );
+            }
+        }
+    }
+
+    /**
+     * @param list<OzonAccrualPreviewTransaction> $transactions
+     */
+    private function collectNonItemFee(
+        array &$transactions,
+        mixed $fee,
+        string $operationGroupId,
+        string $date,
+        string $category,
+        string $accrualId,
+        ?string $unitNumber,
+    ): void {
+        $this->collectTypedFee(
+            transactions: $transactions,
+            fee: $fee,
+            operationGroupId: $operationGroupId,
+            date: $date,
+            category: $category,
+            accrualId: $accrualId,
+            componentPrefix: 'non_item_fee',
+            type: TransactionType::OTHER,
+            unitNumber: $unitNumber,
+        );
+    }
+
+    /**
+     * @param list<OzonAccrualPreviewTransaction> $transactions
+     */
+    private function collectContainerFees(
+        array &$transactions,
+        mixed $value,
+        string $operationGroupId,
+        string $date,
+        string $category,
+        string $accrualId,
+        ?string $unitNumber,
+        string $path = 'container_fee',
+    ): void {
+        if (!is_array($value)) {
+            return;
+        }
+
+        $this->collectTypedFee(
+            transactions: $transactions,
+            fee: $value,
+            operationGroupId: $operationGroupId,
+            date: $date,
+            category: $category,
+            accrualId: $accrualId,
+            componentPrefix: $path,
+            type: TransactionType::FEE,
+            unitNumber: $unitNumber,
+        );
+
+        foreach ($value as $childKey => $child) {
+            if (is_array($child)) {
+                $this->collectContainerFees($transactions, $child, $operationGroupId, $date, $category, $accrualId, $unitNumber, sprintf('%s:%s', $path, $this->normalizeComponent((string) $childKey)));
+            }
+        }
+    }
+
+    /**
+     * @param list<OzonAccrualPreviewTransaction> $transactions
+     */
+    private function collectTypedFee(
+        array &$transactions,
+        mixed $fee,
+        string $operationGroupId,
+        string $date,
+        string $category,
+        string $accrualId,
+        string $componentPrefix,
+        TransactionType $type,
+        ?string $unitNumber,
+    ): void {
+        if (!is_array($fee) || !array_key_exists('accrued', $fee)) {
+            return;
+        }
+
+        $typeId = $this->typeId($fee);
+        $amount = $this->moneyObjectMinor($fee['accrued']);
+        if (0 === $amount) {
+            return;
+        }
+
+        $this->add(
+            transactions: $transactions,
+            operationGroupId: $operationGroupId,
+            date: $date,
+            category: $category,
+            accrualId: $accrualId,
+            component: sprintf('%s:type-%s', $componentPrefix, $typeId),
+            type: $type,
+            signedAmountMinor: $amount,
+            typeId: $typeId,
+            unitNumber: $unitNumber,
+        );
+    }
+
+    /**
+     * @param list<OzonAccrualPreviewTransaction> $transactions
+     */
+    private function add(
+        array &$transactions,
+        string $operationGroupId,
+        string $date,
+        string $category,
+        string $accrualId,
+        string $component,
+        TransactionType $type,
+        int $signedAmountMinor,
+        ?string $typeId = null,
+        ?string $field = null,
+        ?string $unitNumber = null,
+    ): void {
+        $transactions[] = new OzonAccrualPreviewTransaction(
+            sourceKey: sprintf('ozon:accrual-by-day:%s:%s', $accrualId, $this->normalizeComponent($component)),
+            operationGroupId: $operationGroupId,
+            date: $date,
+            category: $category,
+            component: $component,
+            type: $type,
+            direction: $this->directionFromSigned($signedAmountMinor),
+            amountMinor: abs($signedAmountMinor),
+            typeId: $typeId,
+            field: $field,
+            unitNumber: $unitNumber,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function accrualId(array $row, int $rowIndex): string
+    {
+        $accrualId = $this->optionalString($row['accrual_id'] ?? null);
+        if (null !== $accrualId) {
+            return $accrualId;
+        }
+
+        $json = json_encode($row, \JSON_THROW_ON_ERROR);
+
+        return sprintf('fallback-%d-%s', $rowIndex, substr(hash('sha256', $json), 0, 16));
+    }
+
+    /**
+     * @param array<string, mixed> $fee
+     */
+    private function typeId(array $fee): string
+    {
+        return $this->stringValue($fee['type_id'] ?? $fee['typeId'] ?? 'unknown');
+    }
+
+    private function moneyObjectMinor(mixed $value): int
+    {
+        if (is_array($value) && array_key_exists('amount', $value)) {
+            return $this->moneyParser->minor($value['amount']);
+        }
+
+        return $this->moneyParser->minor($value);
+    }
+
+    private function directionFromSigned(int $amountMinor): TransactionDirection
+    {
+        return $amountMinor >= 0 ? TransactionDirection::IN : TransactionDirection::OUT;
+    }
+
+    private function optionalString(mixed $value): ?string
+    {
+        $value = trim((string) $value);
+
+        return '' !== $value ? $value : null;
+    }
+
+    private function stringValue(mixed $value): string
+    {
+        return $this->optionalString($value) ?? 'unknown';
+    }
+
+    private function normalizeComponent(string $component): string
+    {
+        $normalized = strtolower(trim($component));
+        $normalized = preg_replace('/[^a-z0-9_:-]+/', '_', $normalized) ?? 'component';
+        $normalized = trim($normalized, '_:-');
+
+        return '' !== $normalized ? $normalized : 'component';
+    }
+}

--- a/site/src/Ingestion/Application/Source/Ozon/OzonAccrualPreviewTransaction.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonAccrualPreviewTransaction.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Source\Ozon;
+
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+
+final readonly class OzonAccrualPreviewTransaction
+{
+    public function __construct(
+        public string $sourceKey,
+        public string $operationGroupId,
+        public string $date,
+        public string $category,
+        public string $component,
+        public TransactionType $type,
+        public TransactionDirection $direction,
+        public int $amountMinor,
+        public string $currency = 'RUB',
+        public ?string $typeId = null,
+        public ?string $field = null,
+        public ?string $unitNumber = null,
+    ) {
+    }
+
+    public function signedAmountMinor(): int
+    {
+        return TransactionDirection::OUT === $this->direction ? -$this->amountMinor : $this->amountMinor;
+    }
+}

--- a/site/src/Ingestion/Command/OzonAccrualPreviewNormalizationCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualPreviewNormalizationCommand.php
@@ -1,0 +1,504 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Command;
+
+use App\Ingestion\Application\Source\Ozon\OzonAccrualByDayPreviewMapper;
+use App\Ingestion\Application\Source\Ozon\OzonAccrualPreviewTransaction;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Facade\RawStorageFacade;
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Webmozart\Assert\Assert;
+
+#[AsCommand(
+    name: 'app:ingestion:ozon-accrual:preview-normalization',
+    description: 'Builds a read-only normalization preview from stored Ozon accrual by-day raw records.',
+)]
+final class OzonAccrualPreviewNormalizationCommand extends Command
+{
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly RawStorageFacade $rawStorageFacade,
+        private readonly OzonAccrualByDayPreviewMapper $previewMapper,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Company UUID.')
+            ->addOption('from', null, InputOption::VALUE_REQUIRED, 'Start date YYYY-MM-DD.')
+            ->addOption('to', null, InputOption::VALUE_REQUIRED, 'End date YYYY-MM-DD.')
+            ->addOption('raw-limit', null, InputOption::VALUE_REQUIRED, 'Raw records to scan, 1..50.', 20)
+            ->addOption('raw-row-limit', null, InputOption::VALUE_REQUIRED, 'Rows to scan per raw record, 1..50000.', 5000)
+            ->addOption('sample-limit', null, InputOption::VALUE_REQUIRED, 'Preview rows to print, 1..200.', 50);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        try {
+            $companyId = $this->requiredUuidOption($input, 'company-id');
+            [$from, $to] = $this->requiredDateWindow($input);
+            $rawLimit = $this->intOption($input, 'raw-limit', 1, 50);
+            $rawRowLimit = $this->intOption($input, 'raw-row-limit', 1, 50000);
+            $sampleLimit = $this->intOption($input, 'sample-limit', 1, 200);
+        } catch (\Throwable $exception) {
+            $io->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $rawRecords = $this->rawRecords($companyId, $from, $to, $rawLimit);
+        $previewRows = $this->previewMapper->preview($companyId, $this->rawRows($companyId, $rawRecords, $rawRowLimit));
+        $exactMatches = $this->exactNaturalKeyMatches($companyId, $previewRows);
+        $sameAmountCandidates = $this->sameAmountCandidateCounts($companyId, $from, $to);
+        $canonicalGroups = $this->canonicalGroups($companyId, $from, $to);
+
+        $io->title('Ozon accrual normalization preview');
+        $io->writeln('Read-only: no canonical transactions are written.');
+        $io->writeln('Preview intentionally omits sale/refund amount fields, bonus, coinvestment, sale_amount, and seller_price.');
+        $this->printRawRecords($io, $rawRecords);
+        $this->printSummary($io, $previewRows, $exactMatches, $sameAmountCandidates);
+        $this->printPreviewSamples($io, $previewRows, $exactMatches, $sameAmountCandidates, $sampleLimit);
+        $this->printGroupComparison($io, $previewRows, $canonicalGroups);
+        $this->printDailyNetComparison($io, $previewRows, $canonicalGroups);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function rawRecords(string $companyId, \DateTimeImmutable $from, \DateTimeImmutable $to, int $limit): array
+    {
+        return $this->connection->fetchAllAssociative(
+            sprintf(
+                'SELECT r.id,
+                        r.resource_type,
+                        r.external_id,
+                        r.fetched_at,
+                        r.byte_size,
+                        r.normalization_status
+                 FROM ingest_raw_records r
+                 LEFT JOIN ingest_sync_jobs j ON j.id::text = r.sync_job_id AND j.company_id = r.company_id
+                 WHERE r.company_id = :companyId
+                   AND r.source = :source
+                   AND r.resource_type = :resourceType
+                   AND (j.id IS NULL OR j.window_from IS NULL OR j.window_to IS NULL OR (j.window_from <= :toDate AND j.window_to >= :fromDate))
+                 ORDER BY r.fetched_at DESC, r.created_at DESC
+                 LIMIT %d',
+                $limit,
+            ),
+            [
+                'companyId' => $companyId,
+                'source' => IngestSource::OZON->value,
+                'resourceType' => OzonResourceType::ACCRUAL_BY_DAY,
+                'fromDate' => $from->format('Y-m-d'),
+                'toDate' => $to->format('Y-m-d'),
+            ],
+        );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rawRecords
+     */
+    private function printRawRecords(SymfonyStyle $io, array $rawRecords): void
+    {
+        $io->section('Stored accrual by-day raw records');
+        if ([] === $rawRecords) {
+            $io->writeln('No raw records found for the selected period.');
+
+            return;
+        }
+
+        $io->table(
+            ['rawId', 'externalId', 'status', 'bytes', 'fetchedAt'],
+            array_map(static fn (array $row): array => [
+                (string) $row['id'],
+                (string) $row['external_id'],
+                (string) $row['normalization_status'],
+                (string) $row['byte_size'],
+                (string) $row['fetched_at'],
+            ], $rawRecords),
+        );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rawRecords
+     *
+     * @return \Generator<int, array<string, mixed>>
+     */
+    private function rawRows(string $companyId, array $rawRecords, int $rowLimit): \Generator
+    {
+        foreach ($rawRecords as $rawRecord) {
+            $recordRows = 0;
+            foreach ($this->rawStorageFacade->read((string) $rawRecord['id'], $companyId) as $row) {
+                if ($recordRows >= $rowLimit) {
+                    break;
+                }
+
+                ++$recordRows;
+                yield $row;
+            }
+        }
+    }
+
+    /**
+     * @param list<OzonAccrualPreviewTransaction> $previewRows
+     *
+     * @return array<string, int>
+     */
+    private function exactNaturalKeyMatches(string $companyId, array $previewRows): array
+    {
+        $sourceKeys = array_values(array_unique(array_map(static fn (OzonAccrualPreviewTransaction $row): string => $row->sourceKey, $previewRows)));
+        if ([] === $sourceKeys) {
+            return [];
+        }
+
+        $rows = $this->connection->executeQuery(
+            'SELECT external_id, type, COUNT(*) AS count
+             FROM ingest_financial_transactions
+             WHERE company_id = :companyId
+               AND source = :source
+               AND external_id IN (:sourceKeys)
+             GROUP BY external_id, type',
+            [
+                'companyId' => $companyId,
+                'source' => IngestSource::OZON->value,
+                'sourceKeys' => $sourceKeys,
+            ],
+            [
+                'sourceKeys' => ArrayParameterType::STRING,
+            ],
+        )->fetchAllAssociative();
+
+        $matches = [];
+        foreach ($rows as $row) {
+            $matches[$this->exactMatchKey((string) $row['external_id'], (string) $row['type'])] = (int) $row['count'];
+        }
+
+        return $matches;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function sameAmountCandidateCounts(string $companyId, \DateTimeImmutable $from, \DateTimeImmutable $to): array
+    {
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT DATE(occurred_at) AS date,
+                    type,
+                    direction,
+                    amount_minor,
+                    COUNT(*) AS count
+             FROM ingest_financial_transactions
+             WHERE company_id = :companyId
+               AND source = :source
+               AND occurred_at >= :fromAt
+               AND occurred_at <= :toAt
+             GROUP BY DATE(occurred_at), type, direction, amount_minor',
+            [
+                'companyId' => $companyId,
+                'source' => IngestSource::OZON->value,
+                'fromAt' => $from->format('Y-m-d 00:00:00'),
+                'toAt' => $to->format('Y-m-d 23:59:59'),
+            ],
+        );
+
+        $counts = [];
+        foreach ($rows as $row) {
+            $counts[$this->sameAmountKey((string) $row['date'], (string) $row['type'], (string) $row['direction'], (int) $row['amount_minor'])] = (int) $row['count'];
+        }
+
+        return $counts;
+    }
+
+    /**
+     * @return array<string, array{count: int, totalMinor: int}>
+     */
+    private function canonicalGroups(string $companyId, \DateTimeImmutable $from, \DateTimeImmutable $to): array
+    {
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT DATE(occurred_at) AS date,
+                    type,
+                    direction,
+                    COUNT(*) AS count,
+                    COALESCE(SUM(amount_minor), 0) AS total_minor
+             FROM ingest_financial_transactions
+             WHERE company_id = :companyId
+               AND source = :source
+               AND occurred_at >= :fromAt
+               AND occurred_at <= :toAt
+             GROUP BY DATE(occurred_at), type, direction',
+            [
+                'companyId' => $companyId,
+                'source' => IngestSource::OZON->value,
+                'fromAt' => $from->format('Y-m-d 00:00:00'),
+                'toAt' => $to->format('Y-m-d 23:59:59'),
+            ],
+        );
+
+        $groups = [];
+        foreach ($rows as $row) {
+            $groups[$this->groupKey((string) $row['date'], (string) $row['type'], (string) $row['direction'])] = [
+                'count' => (int) $row['count'],
+                'totalMinor' => (int) $row['total_minor'],
+            ];
+        }
+
+        return $groups;
+    }
+
+    /**
+     * @param list<OzonAccrualPreviewTransaction> $previewRows
+     * @param array<string, int> $exactMatches
+     * @param array<string, int> $sameAmountCandidates
+     */
+    private function printSummary(SymfonyStyle $io, array $previewRows, array $exactMatches, array $sameAmountCandidates): void
+    {
+        $exactMatchRows = 0;
+        $sameAmountCandidateRows = 0;
+
+        foreach ($previewRows as $row) {
+            if (($exactMatches[$this->exactMatchKey($row->sourceKey, $row->type->value)] ?? 0) > 0) {
+                ++$exactMatchRows;
+            }
+
+            if (($sameAmountCandidates[$this->sameAmountKey($row->date, $row->type->value, $row->direction->value, $row->amountMinor)] ?? 0) > 0) {
+                ++$sameAmountCandidateRows;
+            }
+        }
+
+        $io->section('Preview summary');
+        $io->table(
+            ['metric', 'value'],
+            [
+                ['proposedRows', (string) count($previewRows)],
+                ['exactNaturalKeyMatches', (string) $exactMatchRows],
+                ['sameDayTypeDirectionAmountCandidates', (string) $sameAmountCandidateRows],
+            ],
+        );
+    }
+
+    /**
+     * @param list<OzonAccrualPreviewTransaction> $previewRows
+     * @param array<string, int> $exactMatches
+     * @param array<string, int> $sameAmountCandidates
+     */
+    private function printPreviewSamples(
+        SymfonyStyle $io,
+        array $previewRows,
+        array $exactMatches,
+        array $sameAmountCandidates,
+        int $sampleLimit,
+    ): void {
+        $io->section('Preview transaction samples');
+        if ([] === $previewRows) {
+            $io->writeln('No preview rows.');
+
+            return;
+        }
+
+        $rows = [];
+        foreach (array_slice($previewRows, 0, $sampleLimit) as $row) {
+            $rows[] = [
+                $row->date,
+                $row->type->value,
+                $row->direction->value,
+                $this->minorToRub($row->amountMinor),
+                $row->category,
+                $row->component,
+                $row->typeId ?? $row->field ?? '',
+                $row->sourceKey,
+                (string) ($exactMatches[$this->exactMatchKey($row->sourceKey, $row->type->value)] ?? 0),
+                (string) ($sameAmountCandidates[$this->sameAmountKey($row->date, $row->type->value, $row->direction->value, $row->amountMinor)] ?? 0),
+            ];
+        }
+
+        $io->table(
+            ['date', 'type', 'direction', 'amountRub', 'category', 'component', 'typeIdOrField', 'sourceKey', 'exact', 'sameAmount'],
+            $rows,
+        );
+    }
+
+    /**
+     * @param list<OzonAccrualPreviewTransaction> $previewRows
+     * @param array<string, array{count: int, totalMinor: int}> $canonicalGroups
+     */
+    private function printGroupComparison(SymfonyStyle $io, array $previewRows, array $canonicalGroups): void
+    {
+        $previewGroups = [];
+        foreach ($previewRows as $row) {
+            $key = $this->groupKey($row->date, $row->type->value, $row->direction->value);
+            if (!isset($previewGroups[$key])) {
+                $previewGroups[$key] = [
+                    'date' => $row->date,
+                    'type' => $row->type->value,
+                    'direction' => $row->direction->value,
+                    'count' => 0,
+                    'totalMinor' => 0,
+                ];
+            }
+
+            ++$previewGroups[$key]['count'];
+            $previewGroups[$key]['totalMinor'] += $row->amountMinor;
+        }
+
+        $keys = array_values(array_unique(array_merge(array_keys($previewGroups), array_keys($canonicalGroups))));
+        sort($keys);
+
+        $io->section('Preview vs canonical by date/type/direction');
+        if ([] === $keys) {
+            $io->writeln('No rows.');
+
+            return;
+        }
+
+        $rows = [];
+        foreach ($keys as $key) {
+            [$date, $type, $direction] = explode('|', $key, 3);
+            $previewCount = (int) ($previewGroups[$key]['count'] ?? 0);
+            $previewTotal = (int) ($previewGroups[$key]['totalMinor'] ?? 0);
+            $canonicalCount = (int) ($canonicalGroups[$key]['count'] ?? 0);
+            $canonicalTotal = (int) ($canonicalGroups[$key]['totalMinor'] ?? 0);
+
+            $rows[] = [
+                $date,
+                $type,
+                $direction,
+                (string) $previewCount,
+                $this->minorToRub($previewTotal),
+                (string) $canonicalCount,
+                $this->minorToRub($canonicalTotal),
+                $this->minorToRub($previewTotal - $canonicalTotal),
+            ];
+        }
+
+        $io->table(['date', 'type', 'direction', 'previewCount', 'previewRub', 'canonicalCount', 'canonicalRub', 'deltaRub'], $rows);
+    }
+
+    /**
+     * @param list<OzonAccrualPreviewTransaction> $previewRows
+     * @param array<string, array{count: int, totalMinor: int}> $canonicalGroups
+     */
+    private function printDailyNetComparison(SymfonyStyle $io, array $previewRows, array $canonicalGroups): void
+    {
+        $previewByDate = [];
+        foreach ($previewRows as $row) {
+            $previewByDate[$row->date] = ($previewByDate[$row->date] ?? 0) + $row->signedAmountMinor();
+        }
+
+        $canonicalByDate = [];
+        foreach ($canonicalGroups as $key => $group) {
+            [$date, , $direction] = explode('|', $key, 3);
+            $signed = 'out' === $direction ? -$group['totalMinor'] : $group['totalMinor'];
+            $canonicalByDate[$date] = ($canonicalByDate[$date] ?? 0) + $signed;
+        }
+
+        $dates = array_values(array_unique(array_merge(array_keys($previewByDate), array_keys($canonicalByDate))));
+        sort($dates);
+
+        $io->section('Preview net vs canonical net by date');
+        if ([] === $dates) {
+            $io->writeln('No rows.');
+
+            return;
+        }
+
+        $rows = [];
+        foreach ($dates as $date) {
+            $previewTotal = (int) ($previewByDate[$date] ?? 0);
+            $canonicalTotal = (int) ($canonicalByDate[$date] ?? 0);
+            $rows[] = [
+                $date,
+                $this->minorToRub($previewTotal),
+                $this->minorToRub($canonicalTotal),
+                $this->minorToRub($previewTotal - $canonicalTotal),
+            ];
+        }
+
+        $io->table(['date', 'previewNetRub', 'canonicalNetRub', 'deltaRub'], $rows);
+    }
+
+    private function exactMatchKey(string $sourceKey, string $type): string
+    {
+        return sprintf('%s|%s', $sourceKey, $type);
+    }
+
+    private function sameAmountKey(string $date, string $type, string $direction, int $amountMinor): string
+    {
+        return sprintf('%s|%s|%s|%d', $date, $type, $direction, $amountMinor);
+    }
+
+    private function groupKey(string $date, string $type, string $direction): string
+    {
+        return sprintf('%s|%s|%s', $date, $type, $direction);
+    }
+
+    private function minorToRub(int $minor): string
+    {
+        return number_format($minor / 100, 2, '.', '');
+    }
+
+    private function requiredUuidOption(InputInterface $input, string $name): string
+    {
+        $value = trim((string) $input->getOption($name));
+        Assert::uuid($value, sprintf('Invalid --%s UUID.', $name));
+
+        return $value;
+    }
+
+    /**
+     * @return array{0: \DateTimeImmutable, 1: \DateTimeImmutable}
+     */
+    private function requiredDateWindow(InputInterface $input): array
+    {
+        $from = $this->requiredDateOption($input, 'from');
+        $to = $this->requiredDateOption($input, 'to');
+        if ($from > $to) {
+            throw new \InvalidArgumentException('The --from date cannot be later than --to.');
+        }
+
+        return [$from, $to];
+    }
+
+    private function requiredDateOption(InputInterface $input, string $name): \DateTimeImmutable
+    {
+        $value = trim((string) $input->getOption($name));
+        Assert::notEmpty($value, sprintf('The --%s option is required.', $name));
+
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
+        if (false === $date || $date->format('Y-m-d') !== $value) {
+            throw new \InvalidArgumentException(sprintf('The --%s option must be a YYYY-MM-DD date.', $name));
+        }
+
+        return $date;
+    }
+
+    private function intOption(InputInterface $input, string $name, int $min, int $max): int
+    {
+        $value = (string) $input->getOption($name);
+        if (!ctype_digit($value)) {
+            throw new \InvalidArgumentException(sprintf('The --%s option must be an integer from %d to %d.', $name, $min, $max));
+        }
+
+        $number = (int) $value;
+        if ($number < $min || $number > $max) {
+            throw new \InvalidArgumentException(sprintf('The --%s option must be an integer from %d to %d.', $name, $min, $max));
+        }
+
+        return $number;
+    }
+}

--- a/site/src/Ingestion/Command/OzonAccrualPreviewNormalizationCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualPreviewNormalizationCommand.php
@@ -61,7 +61,7 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
         }
 
         $rawRecords = $this->rawRecords($companyId, $from, $to, $rawLimit);
-        $previewRows = $this->previewMapper->preview($companyId, $this->rawRows($companyId, $rawRecords, $rawRowLimit));
+        $previewRows = $this->previewMapper->preview($companyId, $this->rawRows($companyId, $rawRecords, $rawRowLimit, $from, $to), $from, $to);
         $exactMatches = $this->exactNaturalKeyMatches($companyId, $previewRows);
         $sameAmountCandidates = $this->sameAmountCandidateCounts($companyId, $from, $to);
         $canonicalGroups = $this->canonicalGroups($companyId, $from, $to);
@@ -140,8 +140,13 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
      *
      * @return \Generator<int, array<string, mixed>>
      */
-    private function rawRows(string $companyId, array $rawRecords, int $rowLimit): \Generator
-    {
+    private function rawRows(
+        string $companyId,
+        array $rawRecords,
+        int $rowLimit,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+    ): \Generator {
         foreach ($rawRecords as $rawRecord) {
             $recordRows = 0;
             foreach ($this->rawStorageFacade->read((string) $rawRecord['id'], $companyId) as $row) {
@@ -150,9 +155,26 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
                 }
 
                 ++$recordRows;
+                if (!$this->rowDateInWindow($row, $from, $to)) {
+                    continue;
+                }
+
                 yield $row;
             }
         }
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function rowDateInWindow(array $row, \DateTimeImmutable $from, \DateTimeImmutable $to): bool
+    {
+        $date = trim((string) ($row['date'] ?? ''));
+        if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) {
+            return false;
+        }
+
+        return $date >= $from->format('Y-m-d') && $date <= $to->format('Y-m-d');
     }
 
     /**

--- a/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonAccrualByDayPreviewMapperTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonAccrualByDayPreviewMapperTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Application\Source\Ozon;
+
+use App\Ingestion\Application\Source\Ozon\OzonAccrualByDayPreviewMapper;
+use App\Ingestion\Application\Source\Ozon\OzonAccrualPreviewTransaction;
+use App\Ingestion\Application\Source\Ozon\OzonMoneyParser;
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+use PHPUnit\Framework\TestCase;
+
+final class OzonAccrualByDayPreviewMapperTest extends TestCase
+{
+    public function testBuildsPreviewRowsForWritableAccrualComponentsOnly(): void
+    {
+        $rows = $this->mapper()->preview('19621cff-b028-45d9-9193-11f47ad9a8b2', [
+            [
+                'accrual_id' => 53675409100,
+                'date' => '2026-06-13',
+                'unit_number' => '41774559-0885-1',
+                'accrued_category' => 'POSTING',
+                'posting' => [
+                    'products' => [[
+                        'delivery' => [
+                            'services' => [
+                                ['type_id' => 29, 'accrued' => ['amount' => '-7.86', 'currency' => 'RUB']],
+                                ['type_id' => 45, 'accrued' => ['amount' => '-15', 'currency' => 'RUB']],
+                            ],
+                        ],
+                        'commission' => [
+                            'bonus' => ['amount' => '12.79', 'currency' => 'RUB'],
+                            'commission' => ['amount' => '-120.05', 'currency' => 'RUB'],
+                            'sale_amount' => ['amount' => '66718', 'currency' => 'RUB'],
+                            'sale_commission' => ['amount' => '-120.05', 'currency' => 'RUB'],
+                        ],
+                    ]],
+                ],
+            ],
+            [
+                'accrual_id' => 53675409101,
+                'date' => '2026-06-13',
+                'accrued_category' => 'ITEM',
+                'item_fees' => [
+                    'fees' => [[
+                        'fees' => [
+                            ['type_id' => 1, 'accrued' => ['amount' => '18.66', 'currency' => 'RUB']],
+                        ],
+                    ]],
+                ],
+            ],
+            [
+                'accrual_id' => 53675409102,
+                'date' => '2026-06-14',
+                'accrued_category' => 'NON_ITEM',
+                'non_item_fee' => ['type_id' => 46, 'accrued' => ['amount' => '-78.28', 'currency' => 'RUB']],
+            ],
+            [
+                'accrual_id' => 53675409103,
+                'date' => '2026-06-14',
+                'accrued_category' => 'CONTAINER',
+                'container_fees' => [
+                    'fees' => [
+                        ['type_id' => 77, 'accrued' => ['amount' => '-3.50', 'currency' => 'RUB']],
+                    ],
+                ],
+            ],
+        ]);
+
+        self::assertCount(6, $rows);
+
+        $commission = $this->row($rows, 'commission:product-0');
+        self::assertSame(TransactionType::COMMISSION, $commission->type);
+        self::assertSame(TransactionDirection::OUT, $commission->direction);
+        self::assertSame(12005, $commission->amountMinor);
+        self::assertSame(-12005, $commission->signedAmountMinor());
+        self::assertSame('commission', $commission->field);
+        self::assertSame('ozon:accrual-by-day:53675409100:commission:product-0', $commission->sourceKey);
+
+        $delivery = $this->row($rows, 'delivery:product-0:service-0:type-29');
+        self::assertSame(TransactionType::FEE, $delivery->type);
+        self::assertSame(TransactionDirection::OUT, $delivery->direction);
+        self::assertSame(786, $delivery->amountMinor);
+        self::assertSame('29', $delivery->typeId);
+
+        $item = $this->row($rows, 'item_fee:group-0:fee-0:type-1');
+        self::assertSame(TransactionType::FEE, $item->type);
+        self::assertSame(TransactionDirection::IN, $item->direction);
+        self::assertSame(1866, $item->amountMinor);
+
+        $nonItem = $this->row($rows, 'non_item_fee:type-46');
+        self::assertSame(TransactionType::OTHER, $nonItem->type);
+        self::assertSame(TransactionDirection::OUT, $nonItem->direction);
+        self::assertSame(7828, $nonItem->amountMinor);
+
+        $container = $this->row($rows, 'container_fee:fees:0:type-77');
+        self::assertSame(TransactionType::FEE, $container->type);
+        self::assertSame(TransactionDirection::OUT, $container->direction);
+        self::assertSame(350, $container->amountMinor);
+    }
+
+    public function testIgnoresUnknownCategoriesAndZeroAmounts(): void
+    {
+        $rows = $this->mapper()->preview('19621cff-b028-45d9-9193-11f47ad9a8b2', [
+            [
+                'date' => '2026-06-13',
+                'accrued_category' => 'UNKNOWN',
+                'total_amount' => ['amount' => '99', 'currency' => 'RUB'],
+            ],
+            [
+                'accrual_id' => 53675409100,
+                'date' => '2026-06-13',
+                'accrued_category' => 'POSTING',
+                'posting' => [
+                    'products' => [[
+                        'delivery' => [
+                            'services' => [
+                                ['type_id' => 29, 'accrued' => ['amount' => '0', 'currency' => 'RUB']],
+                            ],
+                        ],
+                        'commission' => [
+                            'commission' => ['amount' => '0', 'currency' => 'RUB'],
+                        ],
+                    ]],
+                ],
+            ],
+        ]);
+
+        self::assertSame([], $rows);
+    }
+
+    /**
+     * @param list<OzonAccrualPreviewTransaction> $rows
+     */
+    private function row(array $rows, string $component): OzonAccrualPreviewTransaction
+    {
+        foreach ($rows as $row) {
+            if ($component === $row->component) {
+                return $row;
+            }
+        }
+
+        self::fail(sprintf('Preview row with component "%s" was not found.', $component));
+    }
+
+    private function mapper(): OzonAccrualByDayPreviewMapper
+    {
+        return new OzonAccrualByDayPreviewMapper(new OzonMoneyParser());
+    }
+}

--- a/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonAccrualByDayPreviewMapperTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonAccrualByDayPreviewMapperTest.php
@@ -130,6 +130,25 @@ final class OzonAccrualByDayPreviewMapperTest extends TestCase
         self::assertSame([], $rows);
     }
 
+    public function testFiltersRowsOutsideRequestedDateWindow(): void
+    {
+        $rows = $this->mapper()->preview(
+            '19621cff-b028-45d9-9193-11f47ad9a8b2',
+            [
+                $this->postingCommissionRow(53675409100, '2026-06-14', '-10'),
+                $this->postingCommissionRow(53675409101, '2026-06-15', '-20'),
+                $this->postingCommissionRow(53675409102, '2026-06-16', '-30'),
+            ],
+            new \DateTimeImmutable('2026-06-15'),
+            new \DateTimeImmutable('2026-06-15'),
+        );
+
+        self::assertCount(1, $rows);
+        self::assertSame('2026-06-15', $rows[0]->date);
+        self::assertSame(2000, $rows[0]->amountMinor);
+        self::assertSame('ozon:accrual-by-day:53675409101:commission:product-0', $rows[0]->sourceKey);
+    }
+
     /**
      * @param list<OzonAccrualPreviewTransaction> $rows
      */
@@ -147,5 +166,24 @@ final class OzonAccrualByDayPreviewMapperTest extends TestCase
     private function mapper(): OzonAccrualByDayPreviewMapper
     {
         return new OzonAccrualByDayPreviewMapper(new OzonMoneyParser());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function postingCommissionRow(int $accrualId, string $date, string $amount): array
+    {
+        return [
+            'accrual_id' => $accrualId,
+            'date' => $date,
+            'accrued_category' => 'POSTING',
+            'posting' => [
+                'products' => [[
+                    'commission' => [
+                        'commission' => ['amount' => $amount, 'currency' => 'RUB'],
+                    ],
+                ]],
+            ],
+        ];
     }
 }


### PR DESCRIPTION
## Summary
- add a read-only normalization preview command for stored `ozon_finance_accrual_by_day` raw records
- map preview candidates for commission, delivery fees, item fees, non-item fees, and container fees
- show exact natural-key matches and same-day/type/direction/amount legacy candidates
- compare preview totals with existing canonical Ozon transactions by date/type/direction and daily net
- document the preview scope and duplicate checks

## Scope
No canonical writes, no migrations, no production job wiring, no Ozon API calls, and no change to the shadow mapper used by ingestion normalization.

## Checks
- `php -l` for touched PHP files
- `php bin/phpunit --testsuite unit --filter "OzonAccrualByDayPreviewMapperTest"`
- `php bin/console app:ingestion:ozon-accrual:preview-normalization --help`
- `vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --dry-run --diff --cache-file=var/cache/.php-cs-fixer.cache ...`
- `php bin/phpunit --testsuite unit --filter "OzonAccrualByDay"`
- `make site-test-unit`

## Note
A local command execution with real SQL could not run because the local database did not have `ingest_raw_records`; command registration/autowire was checked via `--help`.
