### PR TITLE
Add Ozon accrual sale/refund preview

### DIFF
--- a/site/src/Ingestion/Application/Source/Ozon/OzonAccrualByDayPreviewMapper.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonAccrualByDayPreviewMapper.php
@@ -24,6 +24,7 @@ final readonly class OzonAccrualByDayPreviewMapper
         iterable $rows,
         ?\DateTimeImmutable $from = null,
         ?\DateTimeImmutable $to = null,
+        bool $includeSaleRefund = false,
     ): array {
         $transactions = [];
         $rowIndex = 0;
@@ -42,7 +43,7 @@ final readonly class OzonAccrualByDayPreviewMapper
             $unitNumber = $this->optionalString($row['unit_number'] ?? null);
 
             match ($category) {
-                'POSTING' => $this->collectPosting($transactions, $row, $operationGroupId, $date, $category, $accrualId, $unitNumber),
+                'POSTING' => $this->collectPosting($transactions, $row, $operationGroupId, $date, $category, $accrualId, $unitNumber, $includeSaleRefund),
                 'ITEM' => $this->collectItemFees($transactions, $row['item_fees'] ?? null, $operationGroupId, $date, $category, $accrualId, $unitNumber),
                 'NON_ITEM' => $this->collectNonItemFee($transactions, $row['non_item_fee'] ?? null, $operationGroupId, $date, $category, $accrualId, $unitNumber),
                 'CONTAINER' => $this->collectContainerFees($transactions, $row['container_fees'] ?? null, $operationGroupId, $date, $category, $accrualId, $unitNumber),
@@ -65,6 +66,7 @@ final readonly class OzonAccrualByDayPreviewMapper
         string $category,
         string $accrualId,
         ?string $unitNumber,
+        bool $includeSaleRefund,
     ): void {
         $posting = $row['posting'] ?? null;
         if (!is_array($posting)) {
@@ -81,9 +83,53 @@ final readonly class OzonAccrualByDayPreviewMapper
                 continue;
             }
 
+            if ($includeSaleRefund) {
+                $this->collectSaleOrRefund($transactions, $product['commission'] ?? null, $operationGroupId, $date, $category, $accrualId, (int) $productIndex, $unitNumber);
+            }
             $this->collectCommission($transactions, $product['commission'] ?? null, $operationGroupId, $date, $category, $accrualId, (int) $productIndex, $unitNumber);
             $this->collectDeliveryServices($transactions, $product['delivery']['services'] ?? null, $operationGroupId, $date, $category, $accrualId, (int) $productIndex, $unitNumber);
         }
+    }
+
+    /**
+     * @param list<OzonAccrualPreviewTransaction> $transactions
+     */
+    private function collectSaleOrRefund(
+        array &$transactions,
+        mixed $commission,
+        string $operationGroupId,
+        string $date,
+        string $category,
+        string $accrualId,
+        int $productIndex,
+        ?string $unitNumber,
+    ): void {
+        if (!is_array($commission)) {
+            return;
+        }
+
+        // Prefer sale_amount for sale/refund preview; seller_price is only a fallback.
+        $money = $this->moneyField($commission, ['sale_amount', 'seller_price']);
+        if (null === $money) {
+            return;
+        }
+
+        $field = $money['field'];
+        $amount = $money['amountMinor'];
+
+        $isRefund = $amount < 0;
+        $this->add(
+            transactions: $transactions,
+            operationGroupId: $operationGroupId,
+            date: $date,
+            category: $category,
+            accrualId: $accrualId,
+            component: sprintf('%s:product-%d', $isRefund ? 'refund' : 'sale', $productIndex),
+            type: $isRefund ? TransactionType::REFUND : TransactionType::SALE,
+            signedAmountMinor: $amount,
+            field: $field,
+            unitNumber: $unitNumber,
+        );
     }
 
     /**
@@ -367,6 +413,28 @@ final readonly class OzonAccrualByDayPreviewMapper
         }
 
         return $this->moneyParser->minor($value);
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     * @param list<string> $fields
+     *
+     * @return array{field: string, amountMinor: int}|null
+     */
+    private function moneyField(array $values, array $fields): ?array
+    {
+        foreach ($fields as $field) {
+            if (!array_key_exists($field, $values)) {
+                continue;
+            }
+
+            $amount = $this->moneyObjectMinor($values[$field]);
+            if (0 !== $amount) {
+                return ['field' => $field, 'amountMinor' => $amount];
+            }
+        }
+
+        return null;
     }
 
     private function directionFromSigned(int $amountMinor): TransactionDirection

--- a/site/src/Ingestion/Command/OzonAccrualPreviewNormalizationCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualPreviewNormalizationCommand.php
@@ -28,7 +28,7 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
     /**
      * @var list<string>
      */
-    private const OMITTED_CANONICAL_TYPES = ['sale', 'refund'];
+    private const SALE_REFUND_TYPES = ['sale', 'refund'];
 
     public function __construct(
         private readonly Connection $connection,
@@ -47,6 +47,7 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
             ->addOption('raw-limit', null, InputOption::VALUE_REQUIRED, 'Raw records to scan, 1..50.', 20)
             ->addOption('raw-row-limit', null, InputOption::VALUE_REQUIRED, 'Rows to scan per raw record, 1..50000.', 5000)
             ->addOption('sample-limit', null, InputOption::VALUE_REQUIRED, 'Preview rows to print, 1..200.', 50)
+            ->addOption('include-sale-refund', null, InputOption::VALUE_NONE, 'Read-only preview for sale/refund rows; active normalization still excludes them.')
             ->addOption('parity-only', null, InputOption::VALUE_NONE, 'Print only summary and parity report sections.');
     }
 
@@ -60,6 +61,7 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
             $rawLimit = $this->intOption($input, 'raw-limit', 1, 50);
             $rawRowLimit = $this->intOption($input, 'raw-row-limit', 1, 50000);
             $sampleLimit = $this->intOption($input, 'sample-limit', 1, 200);
+            $includeSaleRefund = (bool) $input->getOption('include-sale-refund');
             $parityOnly = (bool) $input->getOption('parity-only');
         } catch (\Throwable $exception) {
             $io->error($exception->getMessage());
@@ -68,18 +70,22 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
         }
 
         $rawRecords = $this->rawRecords($companyId, $from, $to, $rawLimit);
-        $previewRows = $this->previewMapper->preview($companyId, $this->rawRows($companyId, $rawRecords, $rawRowLimit, $from, $to), $from, $to);
+        $previewRows = $this->previewMapper->preview($companyId, $this->rawRows($companyId, $rawRecords, $rawRowLimit, $from, $to), $from, $to, $includeSaleRefund);
         $exactMatches = $this->exactNaturalKeyMatches($companyId, $previewRows);
         $sameAmountCandidates = $this->sameAmountCandidateCounts($companyId, $from, $to);
         $canonicalGroups = $this->canonicalGroups($companyId, $from, $to);
-        $parityRows = $this->parityRows($previewRows, $canonicalGroups);
+        $omittedTypes = $includeSaleRefund ? [] : self::SALE_REFUND_TYPES;
+        $parityRows = $this->parityRows($previewRows, $canonicalGroups, $omittedTypes);
 
         $io->title('Ozon accrual normalization preview');
         $io->writeln('Read-only: no canonical transactions are written.');
-        $io->writeln('Preview intentionally omits sale/refund amount fields, bonus, coinvestment, sale_amount, and seller_price.');
+        $io->writeln($includeSaleRefund
+            ? 'Preview includes sale/refund from sale_amount or seller_price, and intentionally omits bonus and coinvestment.'
+            : 'Preview intentionally omits sale/refund amount fields, bonus, coinvestment, sale_amount, and seller_price.'
+        );
         $this->printRawRecords($io, $rawRecords);
         $this->printSummary($io, $previewRows, $exactMatches, $sameAmountCandidates);
-        $this->printParityDecision($io, $previewRows, $exactMatches, $sameAmountCandidates, $parityRows);
+        $this->printParityDecision($io, $previewRows, $exactMatches, $sameAmountCandidates, $parityRows, $omittedTypes);
         $this->printParityRows($io, $parityRows);
 
         if ($parityOnly) {
@@ -300,8 +306,8 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
 
     /**
      * @param list<OzonAccrualPreviewTransaction> $previewRows
-     * @param array<string, int> $exactMatches
-     * @param array<string, int> $sameAmountCandidates
+     * @param array<string, int>                  $exactMatches
+     * @param array<string, int>                  $sameAmountCandidates
      */
     private function printSummary(SymfonyStyle $io, array $previewRows, array $exactMatches, array $sameAmountCandidates): void
     {
@@ -331,8 +337,8 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
 
     /**
      * @param list<OzonAccrualPreviewTransaction> $previewRows
-     * @param array<string, int> $exactMatches
-     * @param array<string, int> $sameAmountCandidates
+     * @param array<string, int>                  $exactMatches
+     * @param array<string, int>                  $sameAmountCandidates
      */
     private function printPreviewSamples(
         SymfonyStyle $io,
@@ -371,12 +377,12 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
     }
 
     /**
-     * @param list<OzonAccrualPreviewTransaction> $previewRows
+     * @param list<OzonAccrualPreviewTransaction>               $previewRows
      * @param array<string, array{count: int, totalMinor: int}> $canonicalGroups
      *
      * @return list<array{date: string, type: string, direction: string, previewCount: int, canonicalCount: int, previewTotalMinor: int, canonicalTotalMinor: int, countDelta: int, totalDeltaMinor: int}>
      */
-    private function parityRows(array $previewRows, array $canonicalGroups): array
+    private function parityRows(array $previewRows, array $canonicalGroups, array $omittedTypes): array
     {
         $previewGroups = $this->previewGroups($previewRows);
         $keys = array_values(array_unique(array_merge(array_keys($previewGroups), array_keys($canonicalGroups))));
@@ -385,7 +391,7 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
         $rows = [];
         foreach ($keys as $key) {
             [$date, $type, $direction] = explode('|', $key, 3);
-            if (in_array($type, self::OMITTED_CANONICAL_TYPES, true)) {
+            if (in_array($type, $omittedTypes, true)) {
                 continue;
             }
 
@@ -435,10 +441,11 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
     }
 
     /**
-     * @param list<OzonAccrualPreviewTransaction> $previewRows
-     * @param array<string, int> $exactMatches
-     * @param array<string, int> $sameAmountCandidates
+     * @param list<OzonAccrualPreviewTransaction>                                                                                                                                                         $previewRows
+     * @param array<string, int>                                                                                                                                                                          $exactMatches
+     * @param array<string, int>                                                                                                                                                                          $sameAmountCandidates
      * @param list<array{date: string, type: string, direction: string, previewCount: int, canonicalCount: int, previewTotalMinor: int, canonicalTotalMinor: int, countDelta: int, totalDeltaMinor: int}> $parityRows
+     * @param list<string>                                                                                                                                                                                $omittedTypes
      */
     private function printParityDecision(
         SymfonyStyle $io,
@@ -446,6 +453,7 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
         array $exactMatches,
         array $sameAmountCandidates,
         array $parityRows,
+        array $omittedTypes,
     ): void {
         $exactMatchRows = 0;
         $sameAmountCandidateRows = 0;
@@ -473,7 +481,7 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
 
         $status = 0 === $amountMismatches ? 'amount-parity-pass' : 'amount-parity-fail';
         $recommendation = 0 === $amountMismatches
-            ? 'Use accrual by-day as shadow/replacement only; additive writes would duplicate existing canonical expense components.'
+            ? 'Use accrual by-day as replacement source; additive writes would duplicate existing canonical components.'
             : 'Review amount mismatches before enabling accrual by-day normalization.';
 
         $io->section('Parity decision');
@@ -486,7 +494,7 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
                 ['countMismatches', (string) $countMismatches],
                 ['exactNaturalKeyMatches', (string) $exactMatchRows],
                 ['sameAmountCandidateRows', sprintf('%d/%d', $sameAmountCandidateRows, count($previewRows))],
-                ['omittedCanonicalTypes', implode(', ', self::OMITTED_CANONICAL_TYPES)],
+                ['omittedCanonicalTypes', [] === $omittedTypes ? 'none' : implode(', ', $omittedTypes)],
                 ['recommendation', $recommendation],
             ],
         );
@@ -523,7 +531,7 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
     }
 
     /**
-     * @param list<OzonAccrualPreviewTransaction> $previewRows
+     * @param list<OzonAccrualPreviewTransaction>               $previewRows
      * @param array<string, array{count: int, totalMinor: int}> $canonicalGroups
      */
     private function printGroupComparison(SymfonyStyle $io, array $previewRows, array $canonicalGroups): void
@@ -563,7 +571,7 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
     }
 
     /**
-     * @param list<OzonAccrualPreviewTransaction> $previewRows
+     * @param list<OzonAccrualPreviewTransaction>               $previewRows
      * @param array<string, array{count: int, totalMinor: int}> $canonicalGroups
      */
     private function printDailyNetComparison(SymfonyStyle $io, array $previewRows, array $canonicalGroups): void

--- a/site/tests/Integration/Ingestion/Fixtures/FakeOzonAccrualClient.php
+++ b/site/tests/Integration/Ingestion/Fixtures/FakeOzonAccrualClient.php
@@ -31,6 +31,7 @@ final class FakeOzonAccrualClient implements OzonAccrualClientInterface
                         ],
                         'commission' => [
                             'commission' => ['amount' => '-120.05', 'currency' => 'RUB'],
+                            'sale_amount' => ['amount' => '66718', 'currency' => 'RUB'],
                         ],
                     ]],
                 ],

--- a/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonAccrualByDayMapperTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonAccrualByDayMapperTest.php
@@ -91,6 +91,33 @@ final class OzonAccrualByDayMapperTest extends TestCase
         self::assertSame(12791, $controlSums[0]->amountMinor);
     }
 
+    public function testOmitsSaleAndRefundInActiveMapper(): void
+    {
+        $companyId = '19621cff-b028-45d9-9193-11f47ad9a8b2';
+        $rawRecord = $this->rawRecord($companyId);
+
+        $transactions = $this->mapper()->map($rawRecord, [[
+            'accrual_id' => 53675409104,
+            'date' => '2026-06-13',
+            'accrued_category' => 'POSTING',
+            'posting' => [
+                'products' => [[
+                    'commission' => [
+                        'commission' => ['amount' => '1305.02', 'currency' => 'RUB'],
+                        'sale_amount' => ['amount' => '-2837.00', 'currency' => 'RUB'],
+                    ],
+                ]],
+            ],
+        ]]);
+
+        self::assertCount(1, $transactions);
+
+        $commission = $transactions[0];
+        self::assertSame(TransactionType::COMMISSION, $commission->type);
+        self::assertSame(TransactionDirection::IN, $commission->direction);
+        self::assertSame(130502, $commission->money->amountMinor());
+    }
+
     private function mapper(): OzonAccrualByDayMapper
     {
         return new OzonAccrualByDayMapper(new OzonAccrualByDayPreviewMapper(new OzonMoneyParser()));

--- a/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonAccrualByDayPreviewMapperTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonAccrualByDayPreviewMapperTest.php
@@ -13,62 +13,73 @@ use PHPUnit\Framework\TestCase;
 
 final class OzonAccrualByDayPreviewMapperTest extends TestCase
 {
-    public function testBuildsPreviewRowsForWritableAccrualComponentsOnly(): void
+    public function testBuildsPreviewRowsForWritableAccrualComponents(): void
     {
-        $rows = $this->mapper()->preview('19621cff-b028-45d9-9193-11f47ad9a8b2', [
+        $rows = $this->mapper()->preview(
+            '19621cff-b028-45d9-9193-11f47ad9a8b2',
             [
-                'accrual_id' => 53675409100,
-                'date' => '2026-06-13',
-                'unit_number' => '41774559-0885-1',
-                'accrued_category' => 'POSTING',
-                'posting' => [
-                    'products' => [[
-                        'delivery' => [
-                            'services' => [
-                                ['type_id' => 29, 'accrued' => ['amount' => '-7.86', 'currency' => 'RUB']],
-                                ['type_id' => 45, 'accrued' => ['amount' => '-15', 'currency' => 'RUB']],
+                [
+                    'accrual_id' => 53675409100,
+                    'date' => '2026-06-13',
+                    'unit_number' => '41774559-0885-1',
+                    'accrued_category' => 'POSTING',
+                    'posting' => [
+                        'products' => [[
+                            'delivery' => [
+                                'services' => [
+                                    ['type_id' => 29, 'accrued' => ['amount' => '-7.86', 'currency' => 'RUB']],
+                                    ['type_id' => 45, 'accrued' => ['amount' => '-15', 'currency' => 'RUB']],
+                                ],
                             ],
-                        ],
-                        'commission' => [
-                            'bonus' => ['amount' => '12.79', 'currency' => 'RUB'],
-                            'commission' => ['amount' => '-120.05', 'currency' => 'RUB'],
-                            'sale_amount' => ['amount' => '66718', 'currency' => 'RUB'],
-                            'sale_commission' => ['amount' => '-120.05', 'currency' => 'RUB'],
-                        ],
-                    ]],
+                            'commission' => [
+                                'bonus' => ['amount' => '12.79', 'currency' => 'RUB'],
+                                'commission' => ['amount' => '-120.05', 'currency' => 'RUB'],
+                                'sale_amount' => ['amount' => '66718', 'currency' => 'RUB'],
+                                'sale_commission' => ['amount' => '-120.05', 'currency' => 'RUB'],
+                            ],
+                        ]],
+                    ],
                 ],
-            ],
-            [
-                'accrual_id' => 53675409101,
-                'date' => '2026-06-13',
-                'accrued_category' => 'ITEM',
-                'item_fees' => [
-                    'fees' => [[
+                [
+                    'accrual_id' => 53675409101,
+                    'date' => '2026-06-13',
+                    'accrued_category' => 'ITEM',
+                    'item_fees' => [
+                        'fees' => [[
+                            'fees' => [
+                                ['type_id' => 1, 'accrued' => ['amount' => '18.66', 'currency' => 'RUB']],
+                            ],
+                        ]],
+                    ],
+                ],
+                [
+                    'accrual_id' => 53675409102,
+                    'date' => '2026-06-14',
+                    'accrued_category' => 'NON_ITEM',
+                    'non_item_fee' => ['type_id' => 46, 'accrued' => ['amount' => '-78.28', 'currency' => 'RUB']],
+                ],
+                [
+                    'accrual_id' => 53675409103,
+                    'date' => '2026-06-14',
+                    'accrued_category' => 'CONTAINER',
+                    'container_fees' => [
                         'fees' => [
-                            ['type_id' => 1, 'accrued' => ['amount' => '18.66', 'currency' => 'RUB']],
+                            ['type_id' => 77, 'accrued' => ['amount' => '-3.50', 'currency' => 'RUB']],
                         ],
-                    ]],
-                ],
-            ],
-            [
-                'accrual_id' => 53675409102,
-                'date' => '2026-06-14',
-                'accrued_category' => 'NON_ITEM',
-                'non_item_fee' => ['type_id' => 46, 'accrued' => ['amount' => '-78.28', 'currency' => 'RUB']],
-            ],
-            [
-                'accrual_id' => 53675409103,
-                'date' => '2026-06-14',
-                'accrued_category' => 'CONTAINER',
-                'container_fees' => [
-                    'fees' => [
-                        ['type_id' => 77, 'accrued' => ['amount' => '-3.50', 'currency' => 'RUB']],
                     ],
                 ],
             ],
-        ]);
+            includeSaleRefund: true,
+        );
 
-        self::assertCount(6, $rows);
+        self::assertCount(7, $rows);
+
+        $sale = $this->row($rows, 'sale:product-0');
+        self::assertSame(TransactionType::SALE, $sale->type);
+        self::assertSame(TransactionDirection::IN, $sale->direction);
+        self::assertSame(6671800, $sale->amountMinor);
+        self::assertSame('sale_amount', $sale->field);
+        self::assertSame('ozon:accrual-by-day:53675409100:sale:product-0', $sale->sourceKey);
 
         $commission = $this->row($rows, 'commission:product-0');
         self::assertSame(TransactionType::COMMISSION, $commission->type);
@@ -98,6 +109,59 @@ final class OzonAccrualByDayPreviewMapperTest extends TestCase
         self::assertSame(TransactionType::FEE, $container->type);
         self::assertSame(TransactionDirection::OUT, $container->direction);
         self::assertSame(350, $container->amountMinor);
+    }
+
+    public function testOmitsSaleAndRefundByDefaultForActiveNormalizationSafety(): void
+    {
+        $rows = $this->mapper()->preview('19621cff-b028-45d9-9193-11f47ad9a8b2', [[
+            'accrual_id' => 53675409100,
+            'date' => '2026-06-13',
+            'accrued_category' => 'POSTING',
+            'posting' => [
+                'products' => [[
+                    'commission' => [
+                        'commission' => ['amount' => '-120.05', 'currency' => 'RUB'],
+                        'sale_amount' => ['amount' => '66718', 'currency' => 'RUB'],
+                    ],
+                ]],
+            ],
+        ]]);
+
+        self::assertCount(1, $rows);
+        self::assertSame(TransactionType::COMMISSION, $rows[0]->type);
+    }
+
+    public function testBuildsRefundFromNegativeSaleAmountAndKeepsCommissionStorno(): void
+    {
+        $rows = $this->mapper()->preview('19621cff-b028-45d9-9193-11f47ad9a8b2', [[
+            'accrual_id' => 53675409104,
+            'date' => '2026-06-13',
+            'unit_number' => '41774559-0885-1',
+            'accrued_category' => 'POSTING',
+            'posting' => [
+                'products' => [[
+                    'commission' => [
+                        'commission' => ['amount' => '1305.02', 'currency' => 'RUB'],
+                        'sale_amount' => ['amount' => '-2837.00', 'currency' => 'RUB'],
+                    ],
+                ]],
+            ],
+        ]], includeSaleRefund: true);
+
+        self::assertCount(2, $rows);
+
+        $refund = $this->row($rows, 'refund:product-0');
+        self::assertSame(TransactionType::REFUND, $refund->type);
+        self::assertSame(TransactionDirection::OUT, $refund->direction);
+        self::assertSame(283700, $refund->amountMinor);
+        self::assertSame(-283700, $refund->signedAmountMinor());
+        self::assertSame('sale_amount', $refund->field);
+        self::assertSame('ozon:accrual-by-day:53675409104:refund:product-0', $refund->sourceKey);
+
+        $commission = $this->row($rows, 'commission:product-0');
+        self::assertSame(TransactionType::COMMISSION, $commission->type);
+        self::assertSame(TransactionDirection::IN, $commission->direction);
+        self::assertSame(130502, $commission->amountMinor);
     }
 
     public function testIgnoresUnknownCategoriesAndZeroAmounts(): void


### PR DESCRIPTION
## What changed
- Added Ozon accrual by-day sale/refund extraction for read-only preview.
- Kept active accrual normalization limited to commission, fee, and other components to avoid duplicating legacy sale/refund rows during migrated-period normalization.
- Added `--include-sale-refund` for `app:ingestion:ozon-accrual:preview-normalization`.
- Updated unit and integration tests for the safe default behavior.

## Validation
- `make site-test-unit` — OK, with existing 1 warning and 1 deprecation.
- `docker compose run --rm -T site-php-cli php bin/console lint:container --env=test` — OK.
- `docker compose run --rm -T site-php-cli php bin/phpunit -c phpunit.xml --testsuite integration --filter OzonIngestionFlowTest` — OK, with 2 PHPUnit deprecations.
- `git diff --check` — OK.

## Reviewer focus
- Confirm that sale/refund remain read-only preview only until legacy replacement/cleanup semantics are explicitly finalized.