### PR TITLE
Enable Ozon accrual sale/refund canonical mapping

### DIFF
--- a/docs/tasks/ozon-ingestion-accrual-cutover-plan.md
+++ b/docs/tasks/ozon-ingestion-accrual-cutover-plan.md
@@ -10,9 +10,14 @@ Replace only the Ingestion canonical Ozon expense records with data from the new
   - `ozon_seller_daily_report`
   - `ozon_seller_realization`
 - Normalize `ozon_finance_accrual_by_day` into `ingest_financial_transactions`.
+  - `sale`
+  - `refund`
+  - `commission`
+  - `fee`
+  - `other`
 - Use the existing backfill window mechanism for month-to-date refresh.
 - Do not create new tables or new update modes.
-- Do not normalize sale/refund from accrual data in this stage.
+- Use accrual by-day as the single Ozon Ingestion canonical source.
 
 ## Implementation stages
 
@@ -24,13 +29,41 @@ Replace only the Ingestion canonical Ozon expense records with data from the new
 3. Reuse current backfill flow for month-to-date load:
    - on 2026-06-21, `--days-back=20` means `2026-06-01 -> 2026-06-20`.
 4. For already loaded `done` raw records, use an operational one-off reset to `pending` only for scoped `ozon_finance_accrual_by_day` raw records if re-normalization is needed.
-5. After production parity is confirmed, remove remaining legacy Ingestion code.
+5. Enable sale/refund normalization from accrual by-day after production preview confirms the canonical replacement strategy.
+6. Re-normalize scoped month-to-date accrual raw records after enabling sale/refund because already `done` raw records are skipped by normal workers.
+7. After production parity is confirmed, remove remaining legacy Ingestion code.
 
 ## Operational notes
 
 The existing raw store deduplicates unchanged payloads by company/source/resource/external id/hash. The existing canonical upsert deduplicates transactions by company/source/external id/type.
 
 If old Ingestion canonical rows exist for the same company/month, replacement must be scoped to Ingestion Ozon records only. Marketplace legacy tables and reports are outside this task.
+
+After deploying sale/refund canonical mapping, already normalized accrual raw records must be re-normalized because `done` raw records are skipped by normal workers. For the verified production company/month:
+
+```bash
+docker exec -it symfony-postgres psql -U app -d app -P pager=off -c "
+  UPDATE ingest_raw_records r
+  SET normalization_status = 'pending',
+      updated_at = NOW()
+  FROM ingest_sync_jobs j
+  WHERE r.company_id = '19621cff-b028-45d9-9193-11f47ad9a8b2'
+    AND r.source = 'ozon'
+    AND r.resource_type = 'ozon_finance_accrual_by_day'
+    AND r.normalization_status = 'done'
+    AND j.id::text = r.sync_job_id
+    AND j.company_id = r.company_id
+    AND j.window_from <= '2026-06-20'
+    AND j.window_to >= '2026-06-01'
+  RETURNING r.id, r.external_id, r.normalization_status;
+"
+
+docker exec -it scheduler php /app/bin/console app:ingestion:normalize-pending \
+  --limit=10 \
+  --threshold-minutes=1
+```
+
+Expected result for `2026-06-01..2026-06-20`: accrual canonical rows increase from `4854` to `5354` by adding the `500` sale/refund rows that were confirmed by preview.
 
 ## Validation
 

--- a/site/src/Finance/Application/Service/PnlCategoryResolver.php
+++ b/site/src/Finance/Application/Service/PnlCategoryResolver.php
@@ -22,6 +22,7 @@ final readonly class PnlCategoryResolver
 {
     private const OTHER_INCOME_CODE = 'INGESTION_OTHER_INCOME';
     private const OTHER_EXPENSE_CODE = 'INGESTION_OTHER_EXPENSE';
+    private const REFUND_OUT_CODE = 'INGESTION_REFUND_OUT';
 
     public function __construct(
         private CompanyRepository $companyRepository,
@@ -37,7 +38,9 @@ final readonly class PnlCategoryResolver
             throw new PnlCategoryResolveException(sprintf('Company "%s" was not found for P&L category resolution.', $companyId));
         }
 
-        $category = $this->findByCode($company, $this->codeFor($type, $direction))
+        $categoryCode = $this->codeFor($type, $direction);
+        $category = $this->findByCode($company, $categoryCode)
+            ?? $this->createKnownIngestionCategory($company, $categoryCode)
             ?? $this->findByCode($company, $this->fallbackCode($direction))
             ?? $this->createFallback($company, $direction);
 
@@ -71,6 +74,7 @@ final readonly class PnlCategoryResolver
             TransactionType::ACQUIRING => 'INGESTION_ACQUIRING',
             TransactionType::TAX => 'INGESTION_TAX',
             TransactionType::FEE => 'INGESTION_FEE',
+            TransactionType::REFUND => self::REFUND_OUT_CODE,
             default => self::OTHER_EXPENSE_CODE,
         };
     }
@@ -88,16 +92,47 @@ final readonly class PnlCategoryResolver
         ]);
     }
 
+    private function createKnownIngestionCategory(Company $company, string $code): ?PLCategory
+    {
+        if (self::REFUND_OUT_CODE !== $code) {
+            return null;
+        }
+
+        return $this->createCategory(
+            company: $company,
+            name: 'Ingestion: возвраты',
+            code: self::REFUND_OUT_CODE,
+            flow: PLFlow::EXPENSE,
+            expenseType: PLExpenseType::VARIABLE,
+        );
+    }
+
     private function createFallback(Company $company, TransactionDirection $direction): PLCategory
     {
+        return $this->createCategory(
+            company: $company,
+            name: TransactionDirection::IN === $direction ? 'Ingestion: прочие доходы' : 'Ingestion: прочие расходы',
+            code: $this->fallbackCode($direction),
+            flow: TransactionDirection::IN === $direction ? PLFlow::INCOME : PLFlow::EXPENSE,
+            expenseType: TransactionDirection::IN === $direction ? PLExpenseType::OTHER : PLExpenseType::VARIABLE,
+        );
+    }
+
+    private function createCategory(
+        Company $company,
+        string $name,
+        string $code,
+        PLFlow $flow,
+        PLExpenseType $expenseType,
+    ): PLCategory {
         $category = new PLCategory(Uuid::uuid7()->toString(), $company);
         $category
-            ->setName(TransactionDirection::IN === $direction ? 'Ingestion: прочие доходы' : 'Ingestion: прочие расходы')
-            ->setCode($this->fallbackCode($direction))
+            ->setName($name)
+            ->setCode($code)
             ->setType(PLCategoryType::LEAF_INPUT)
             ->setFormat(PLValueFormat::MONEY)
-            ->setFlow(TransactionDirection::IN === $direction ? PLFlow::INCOME : PLFlow::EXPENSE)
-            ->setExpenseType(TransactionDirection::IN === $direction ? PLExpenseType::OTHER : PLExpenseType::VARIABLE)
+            ->setFlow($flow)
+            ->setExpenseType($expenseType)
             ->setSortOrder($this->categoryRepository->getNextSortOrder($company, null));
 
         $this->entityManager->persist($category);

--- a/site/src/Ingestion/Application/Source/Ozon/OzonAccrualByDayMapper.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonAccrualByDayMapper.php
@@ -42,7 +42,7 @@ final readonly class OzonAccrualByDayMapper implements SourceMapperInterface, Ra
     {
         $transactions = [];
 
-        foreach ($this->previewMapper->preview($rawRecord->getCompanyId(), $rows) as $row) {
+        foreach ($this->previewMapper->preview($rawRecord->getCompanyId(), $rows, includeSaleRefund: true) as $row) {
             $transactions[] = new MappedTransaction(
                 externalId: $row->sourceKey,
                 externalUpdatedAt: $rawRecord->getFetchedAt(),
@@ -92,7 +92,7 @@ final readonly class OzonAccrualByDayMapper implements SourceMapperInterface, Ra
     public function controlSumForRawRecord(IngestRawRecord $rawRecord, iterable $rows): array
     {
         $amountsByGroup = [];
-        foreach ($this->previewMapper->preview($rawRecord->getCompanyId(), $rows) as $row) {
+        foreach ($this->previewMapper->preview($rawRecord->getCompanyId(), $rows, includeSaleRefund: true) as $row) {
             $amountsByGroup[$row->operationGroupId] ??= ['currency' => $row->currency, 'amountMinor' => 0];
             $amountsByGroup[$row->operationGroupId]['amountMinor'] += $row->amountMinor;
         }

--- a/site/src/Ingestion/Command/OzonAccrualPreviewNormalizationCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualPreviewNormalizationCommand.php
@@ -47,7 +47,8 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
             ->addOption('raw-limit', null, InputOption::VALUE_REQUIRED, 'Raw records to scan, 1..50.', 20)
             ->addOption('raw-row-limit', null, InputOption::VALUE_REQUIRED, 'Rows to scan per raw record, 1..50000.', 5000)
             ->addOption('sample-limit', null, InputOption::VALUE_REQUIRED, 'Preview rows to print, 1..200.', 50)
-            ->addOption('include-sale-refund', null, InputOption::VALUE_NONE, 'Read-only preview for sale/refund rows; active normalization still excludes them.')
+            ->addOption('include-sale-refund', null, InputOption::VALUE_NONE, 'Deprecated compatibility flag; sale/refund rows are included by default.')
+            ->addOption('expenses-only', null, InputOption::VALUE_NONE, 'Exclude sale/refund rows for expense-only parity diagnostics.')
             ->addOption('parity-only', null, InputOption::VALUE_NONE, 'Print only summary and parity report sections.');
     }
 
@@ -61,7 +62,7 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
             $rawLimit = $this->intOption($input, 'raw-limit', 1, 50);
             $rawRowLimit = $this->intOption($input, 'raw-row-limit', 1, 50000);
             $sampleLimit = $this->intOption($input, 'sample-limit', 1, 200);
-            $includeSaleRefund = (bool) $input->getOption('include-sale-refund');
+            $includeSaleRefund = !(bool) $input->getOption('expenses-only');
             $parityOnly = (bool) $input->getOption('parity-only');
         } catch (\Throwable $exception) {
             $io->error($exception->getMessage());
@@ -81,7 +82,7 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
         $io->writeln('Read-only: no canonical transactions are written.');
         $io->writeln($includeSaleRefund
             ? 'Preview includes sale/refund from sale_amount or seller_price, and intentionally omits bonus and coinvestment.'
-            : 'Preview intentionally omits sale/refund amount fields, bonus, coinvestment, sale_amount, and seller_price.'
+            : 'Preview excludes sale/refund amount fields for expense-only diagnostics, and intentionally omits bonus and coinvestment.'
         );
         $this->printRawRecords($io, $rawRecords);
         $this->printSummary($io, $previewRows, $exactMatches, $sameAmountCandidates);
@@ -306,8 +307,8 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
 
     /**
      * @param list<OzonAccrualPreviewTransaction> $previewRows
-     * @param array<string, int>                  $exactMatches
-     * @param array<string, int>                  $sameAmountCandidates
+     * @param array<string, int> $exactMatches
+     * @param array<string, int> $sameAmountCandidates
      */
     private function printSummary(SymfonyStyle $io, array $previewRows, array $exactMatches, array $sameAmountCandidates): void
     {
@@ -337,8 +338,8 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
 
     /**
      * @param list<OzonAccrualPreviewTransaction> $previewRows
-     * @param array<string, int>                  $exactMatches
-     * @param array<string, int>                  $sameAmountCandidates
+     * @param array<string, int> $exactMatches
+     * @param array<string, int> $sameAmountCandidates
      */
     private function printPreviewSamples(
         SymfonyStyle $io,
@@ -377,7 +378,7 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
     }
 
     /**
-     * @param list<OzonAccrualPreviewTransaction>               $previewRows
+     * @param list<OzonAccrualPreviewTransaction> $previewRows
      * @param array<string, array{count: int, totalMinor: int}> $canonicalGroups
      *
      * @return list<array{date: string, type: string, direction: string, previewCount: int, canonicalCount: int, previewTotalMinor: int, canonicalTotalMinor: int, countDelta: int, totalDeltaMinor: int}>
@@ -441,11 +442,11 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
     }
 
     /**
-     * @param list<OzonAccrualPreviewTransaction>                                                                                                                                                         $previewRows
-     * @param array<string, int>                                                                                                                                                                          $exactMatches
-     * @param array<string, int>                                                                                                                                                                          $sameAmountCandidates
+     * @param list<OzonAccrualPreviewTransaction> $previewRows
+     * @param array<string, int> $exactMatches
+     * @param array<string, int> $sameAmountCandidates
      * @param list<array{date: string, type: string, direction: string, previewCount: int, canonicalCount: int, previewTotalMinor: int, canonicalTotalMinor: int, countDelta: int, totalDeltaMinor: int}> $parityRows
-     * @param list<string>                                                                                                                                                                                $omittedTypes
+     * @param list<string> $omittedTypes
      */
     private function printParityDecision(
         SymfonyStyle $io,
@@ -531,7 +532,7 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
     }
 
     /**
-     * @param list<OzonAccrualPreviewTransaction>               $previewRows
+     * @param list<OzonAccrualPreviewTransaction> $previewRows
      * @param array<string, array{count: int, totalMinor: int}> $canonicalGroups
      */
     private function printGroupComparison(SymfonyStyle $io, array $previewRows, array $canonicalGroups): void
@@ -571,7 +572,7 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
     }
 
     /**
-     * @param list<OzonAccrualPreviewTransaction>               $previewRows
+     * @param list<OzonAccrualPreviewTransaction> $previewRows
      * @param array<string, array{count: int, totalMinor: int}> $canonicalGroups
      */
     private function printDailyNetComparison(SymfonyStyle $io, array $previewRows, array $canonicalGroups): void

--- a/site/tests/Integration/Finance/Application/RebuildPnlPeriodActionTest.php
+++ b/site/tests/Integration/Finance/Application/RebuildPnlPeriodActionTest.php
@@ -44,6 +44,42 @@ final class RebuildPnlPeriodActionTest extends IntegrationTestCase
         self::assertSame(2, (int) $this->connection->fetchOne('SELECT COUNT(*) FROM pl_daily_totals WHERE company_id = :company_id AND rebuilt_at IS NOT NULL', ['company_id' => $companyId]));
     }
 
+    public function testRebuildMapsOutboundRefundToRefundCategory(): void
+    {
+        $company = $this->createCompanyWithDefaultProject();
+        $companyId = (string) $company->getId();
+        $this->persistTransaction($companyId, TransactionType::REFUND, TransactionDirection::OUT, 283700, '2026-02-11 10:00:00 UTC', 'refund-1');
+        $this->em->flush();
+
+        /** @var RebuildPnlPeriodAction $action */
+        $action = self::getContainer()->get(RebuildPnlPeriodAction::class);
+        $action(new RebuildPnlPeriodCommand($companyId, 2026, 2));
+
+        $row = $this->connection->fetchAssociative(
+            'SELECT c.code,
+                    COALESCE(SUM(d.amount_income), 0)::numeric(18,2)::text AS amount_income,
+                    COALESCE(SUM(d.amount_expense), 0)::numeric(18,2)::text AS amount_expense
+             FROM pl_daily_totals d
+             INNER JOIN pl_categories c ON c.id = d.pl_category_id
+             WHERE d.company_id = :company_id
+             GROUP BY c.code',
+            ['company_id' => $companyId],
+        );
+
+        self::assertIsArray($row);
+        self::assertSame('INGESTION_REFUND_OUT', $row['code']);
+        self::assertSame('0.00', $row['amount_income']);
+        self::assertSame('2837.00', $row['amount_expense']);
+        self::assertSame(0, (int) $this->connection->fetchOne(
+            "SELECT COUNT(*)
+             FROM pl_daily_totals d
+             INNER JOIN pl_categories c ON c.id = d.pl_category_id
+             WHERE d.company_id = :company_id
+               AND c.code = 'INGESTION_OTHER_EXPENSE'",
+            ['company_id' => $companyId],
+        ));
+    }
+
     public function testSourceScopedRebuildIsFailedUntilFinanceSourceLinkingIsDecided(): void
     {
         $company = $this->createCompanyWithDefaultProject();

--- a/site/tests/Integration/Ingestion/Application/Source/Ozon/OzonIngestionFlowTest.php
+++ b/site/tests/Integration/Ingestion/Application/Source/Ozon/OzonIngestionFlowTest.php
@@ -74,12 +74,13 @@ final class OzonIngestionFlowTest extends IntegrationTestCase
         $transactionRepository = self::getContainer()->get(FinancialTransactionRepository::class);
         $transactions = $transactionRepository->findByRawRecordId($companyId, $normalizeMessage->rawRecordId);
 
-        self::assertCount(2, $transactions);
+        self::assertCount(3, $transactions);
         $externalIds = array_map(static fn ($transaction): string => $transaction->getExternalId(), $transactions);
         sort($externalIds);
         self::assertSame([
             'ozon:accrual-by-day:53675409100:commission:product-0',
             'ozon:accrual-by-day:53675409100:delivery:product-0:service-0:type-29',
+            'ozon:accrual-by-day:53675409100:sale:product-0',
         ], $externalIds);
 
         /** @var NormalizationIssueRepository $issueRepository */

--- a/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonAccrualByDayMapperTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonAccrualByDayMapperTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Ingestion\Application\Source\Ozon;
 
+use App\Ingestion\Application\DTO\MappedTransaction;
 use App\Ingestion\Application\Source\Ozon\OzonAccrualByDayMapper;
 use App\Ingestion\Application\Source\Ozon\OzonAccrualByDayPreviewMapper;
 use App\Ingestion\Application\Source\Ozon\OzonMoneyParser;
@@ -43,9 +44,16 @@ final class OzonAccrualByDayMapperTest extends TestCase
             ],
         ]]);
 
-        self::assertCount(2, $transactions);
+        self::assertCount(3, $transactions);
 
-        $commission = $transactions[0];
+        $sale = $this->transaction($transactions, 'ozon:accrual-by-day:53675409100:sale:product-0');
+        self::assertSame(TransactionType::SALE, $sale->type);
+        self::assertSame(TransactionDirection::IN, $sale->direction);
+        self::assertSame(6671800, $sale->money->amountMinor());
+        self::assertSame('sale:product-0', $sale->sourceData['_ingestion_component']);
+        self::assertSame('sale_amount', $sale->sourceData['_ingestion_field']);
+
+        $commission = $this->transaction($transactions, 'ozon:accrual-by-day:53675409100:commission:product-0');
         self::assertSame('ozon:accrual-by-day:53675409100:commission:product-0', $commission->externalId);
         self::assertSame(TransactionType::COMMISSION, $commission->type);
         self::assertSame(TransactionDirection::OUT, $commission->direction);
@@ -55,7 +63,7 @@ final class OzonAccrualByDayMapperTest extends TestCase
         self::assertSame(OzonResourceType::ACCRUAL_BY_DAY, $commission->sourceData['_ingestion_resource']);
         self::assertSame('commission:product-0', $commission->sourceData['_ingestion_component']);
 
-        $delivery = $transactions[1];
+        $delivery = $this->transaction($transactions, 'ozon:accrual-by-day:53675409100:delivery:product-0:service-0:type-29');
         self::assertSame('ozon:accrual-by-day:53675409100:delivery:product-0:service-0:type-29', $delivery->externalId);
         self::assertSame(TransactionType::FEE, $delivery->type);
         self::assertSame(TransactionDirection::OUT, $delivery->direction);
@@ -81,6 +89,7 @@ final class OzonAccrualByDayMapperTest extends TestCase
                     ],
                     'commission' => [
                         'commission' => ['amount' => '-120.05', 'currency' => 'RUB'],
+                        'sale_amount' => ['amount' => '66718', 'currency' => 'RUB'],
                     ],
                 ]],
             ],
@@ -88,10 +97,11 @@ final class OzonAccrualByDayMapperTest extends TestCase
 
         self::assertCount(1, $controlSums);
         self::assertSame('RUB', $controlSums[0]->currency);
-        self::assertSame(12791, $controlSums[0]->amountMinor);
+        // Sale/refund cutover includes all accrual components in the operation group control sum.
+        self::assertSame(6684591, $controlSums[0]->amountMinor);
     }
 
-    public function testOmitsSaleAndRefundInActiveMapper(): void
+    public function testMapsRefundInActiveMapper(): void
     {
         $companyId = '19621cff-b028-45d9-9193-11f47ad9a8b2';
         $rawRecord = $this->rawRecord($companyId);
@@ -110,12 +120,32 @@ final class OzonAccrualByDayMapperTest extends TestCase
             ],
         ]]);
 
-        self::assertCount(1, $transactions);
+        self::assertCount(2, $transactions);
 
-        $commission = $transactions[0];
+        $refund = $this->transaction($transactions, 'ozon:accrual-by-day:53675409104:refund:product-0');
+        self::assertSame(TransactionType::REFUND, $refund->type);
+        self::assertSame(TransactionDirection::OUT, $refund->direction);
+        self::assertSame(283700, $refund->money->amountMinor());
+        self::assertSame('sale_amount', $refund->sourceData['_ingestion_field']);
+
+        $commission = $this->transaction($transactions, 'ozon:accrual-by-day:53675409104:commission:product-0');
         self::assertSame(TransactionType::COMMISSION, $commission->type);
         self::assertSame(TransactionDirection::IN, $commission->direction);
         self::assertSame(130502, $commission->money->amountMinor());
+    }
+
+    /**
+     * @param list<MappedTransaction> $transactions
+     */
+    private function transaction(array $transactions, string $externalId): MappedTransaction
+    {
+        foreach ($transactions as $transaction) {
+            if ($externalId === $transaction->externalId) {
+                return $transaction;
+            }
+        }
+
+        self::fail(sprintf('Mapped transaction with external id "%s" was not found.', $externalId));
     }
 
     private function mapper(): OzonAccrualByDayMapper

--- a/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonAccrualByDayPreviewMapperTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonAccrualByDayPreviewMapperTest.php
@@ -111,21 +111,25 @@ final class OzonAccrualByDayPreviewMapperTest extends TestCase
         self::assertSame(350, $container->amountMinor);
     }
 
-    public function testOmitsSaleAndRefundByDefaultForActiveNormalizationSafety(): void
+    public function testOmitsSaleAndRefundWhenExplicitlyExcluded(): void
     {
-        $rows = $this->mapper()->preview('19621cff-b028-45d9-9193-11f47ad9a8b2', [[
-            'accrual_id' => 53675409100,
-            'date' => '2026-06-13',
-            'accrued_category' => 'POSTING',
-            'posting' => [
-                'products' => [[
-                    'commission' => [
-                        'commission' => ['amount' => '-120.05', 'currency' => 'RUB'],
-                        'sale_amount' => ['amount' => '66718', 'currency' => 'RUB'],
-                    ],
-                ]],
-            ],
-        ]]);
+        $rows = $this->mapper()->preview(
+            '19621cff-b028-45d9-9193-11f47ad9a8b2',
+            [[
+                'accrual_id' => 53675409100,
+                'date' => '2026-06-13',
+                'accrued_category' => 'POSTING',
+                'posting' => [
+                    'products' => [[
+                        'commission' => [
+                            'commission' => ['amount' => '-120.05', 'currency' => 'RUB'],
+                            'sale_amount' => ['amount' => '66718', 'currency' => 'RUB'],
+                        ],
+                    ]],
+                ],
+            ]],
+            includeSaleRefund: false,
+        );
 
         self::assertCount(1, $rows);
         self::assertSame(TransactionType::COMMISSION, $rows[0]->type);


### PR DESCRIPTION
## What changed
- Enables `sale` and `refund` rows in the active `ozon_finance_accrual_by_day` mapper.
- Makes `app:ingestion:ozon-accrual:preview-normalization` include sale/refund by default so preview matches active canonical mapping.
- Keeps `--expenses-only` for expense-only parity diagnostics; `--include-sale-refund` remains as a deprecated compatibility no-op.
- Maps outbound ingestion refunds to `INGESTION_REFUND_OUT` during P&L rebuilds instead of falling back to `INGESTION_OTHER_EXPENSE`.
- Updates mapper, preview, P&L rebuild integration tests, and the accrual cutover plan.

## Production rollout note
Already normalized accrual raw records are `done` and will be skipped by normal workers. After deployment, re-normalize scoped month-to-date `ozon_finance_accrual_by_day` raw records to add the new sale/refund canonical rows.

```bash
docker exec -it symfony-postgres psql -U app -d app -P pager=off -c "
  UPDATE ingest_raw_records r
  SET normalization_status = 'pending',\n      updated_at = NOW()\n  FROM ingest_sync_jobs j\n  WHERE r.company_id = '19621cff-b028-45d9-9193-11f47ad9a8b2'\n    AND r.source = 'ozon'\n    AND r.resource_type = 'ozon_finance_accrual_by_day'\n    AND r.normalization_status = 'done'\n    AND j.id::text = r.sync_job_id\n    AND j.company_id = r.company_id\n    AND j.window_from <= '2026-06-20'\n    AND j.window_to >= '2026-06-01'\n  RETURNING r.id, r.external_id, r.normalization_status;\n"\n\ndocker exec -it scheduler php /app/bin/console app:ingestion:normalize-pending \\\n  --limit=10 \\\n  --threshold-minutes=1\n```\n\nExpected June 1-20 result for the verified company after re-normalization: current 4854 rows + 500 sale/refund rows = 5354 accrual canonical rows.\n\n## Validation\n- `docker compose run --rm -T site-php-cli php bin/phpunit -c phpunit.xml --testsuite unit --filter 'OzonAccrualByDayPreviewMapperTest|OzonAccrualByDayMapperTest'` — OK, 8 tests / 72 assertions.\n- `docker compose run --rm -T site-php-cli php bin/phpunit -c phpunit.xml --testsuite integration --filter 'RebuildPnlPeriodActionTest|OzonIngestionFlowTest'` — OK, with 2 PHPUnit deprecations.\n- `make site-test-unit` — OK, with existing 1 warning and 1 deprecation.\n- `docker compose run --rm -T site-php-cli php bin/console lint:container --env=test` — OK.\n- php-cs-fixer dry-run for changed PHP files — OK.\n- `git diff --check` — OK.\n\n## Reviewer focus\n- This intentionally changes Ozon Ingestion canonical financial mapping by adding active sale/refund rows from accrual by-day.\n- P&L category mapping for `refund/out` now uses `INGESTION_REFUND_OUT`.\n- Legacy Marketplace mapping/tables are intentionally untouched.