### PR TITLE
[codex] Fix ingestion P&L dirty period scope

### DIFF
--- a/site/src/Finance/EventSubscriber/NormalizationCompletedSubscriber.php
+++ b/site/src/Finance/EventSubscriber/NormalizationCompletedSubscriber.php
@@ -14,6 +14,8 @@ use Symfony\Component\Messenger\MessageBusInterface;
 
 final readonly class NormalizationCompletedSubscriber implements EventSubscriberInterface
 {
+    private const GLOBAL_SHOP_REF = '';
+
     public function __construct(
         private PnlPeriodResolver $periodResolver,
         private MessageBusInterface $messageBus,
@@ -40,7 +42,7 @@ final readonly class NormalizationCompletedSubscriber implements EventSubscriber
             }
 
             [$newYear, $newMonth] = $this->periodResolver->from($period->newOccurredAt);
-            $this->dispatchOnce($dispatched, $event->companyId, $newYear, $newMonth, $period->shopRef, PLDirtyPeriodReason::INGEST);
+            $this->dispatchOnce($dispatched, $event->companyId, $newYear, $newMonth, self::GLOBAL_SHOP_REF, PLDirtyPeriodReason::INGEST);
 
             if (null === $period->oldOccurredAt) {
                 continue;
@@ -48,7 +50,7 @@ final readonly class NormalizationCompletedSubscriber implements EventSubscriber
 
             [$oldYear, $oldMonth] = $this->periodResolver->from($period->oldOccurredAt);
             if ($oldYear !== $newYear || $oldMonth !== $newMonth) {
-                $this->dispatchOnce($dispatched, $event->companyId, $oldYear, $oldMonth, $period->shopRef, PLDirtyPeriodReason::MONTH_CHANGE);
+                $this->dispatchOnce($dispatched, $event->companyId, $oldYear, $oldMonth, self::GLOBAL_SHOP_REF, PLDirtyPeriodReason::MONTH_CHANGE);
             }
         }
     }

--- a/site/tests/Integration/Finance/EventSubscriber/NormalizationCompletedSubscriberTest.php
+++ b/site/tests/Integration/Finance/EventSubscriber/NormalizationCompletedSubscriberTest.php
@@ -43,7 +43,7 @@ final class NormalizationCompletedSubscriberTest extends IntegrationTestCase
 
         self::assertCount(2, $messages);
         self::assertContainsOnlyInstancesOf(MarkPnlPeriodDirtyMessage::class, $messages);
-        self::assertSame([2026, 2, 'ingest'], [$messages[0]->year, $messages[0]->month, $messages[0]->reasonValue]);
-        self::assertSame([2026, 1, 'month_change'], [$messages[1]->year, $messages[1]->month, $messages[1]->reasonValue]);
+        self::assertSame([2026, 2, '', 'ingest'], [$messages[0]->year, $messages[0]->month, $messages[0]->shopRef, $messages[0]->reasonValue]);
+        self::assertSame([2026, 1, '', 'month_change'], [$messages[1]->year, $messages[1]->month, $messages[1]->shopRef, $messages[1]->reasonValue]);
     }
 }


### PR DESCRIPTION
## What changed

- P&L dirty-period marking after ingestion normalization now uses the global `shopRef=''` scope.
- Updated the normalization-completed subscriber test to assert that both current and previous month dirty-period messages are global.

## Why

`RebuildPnlPeriodAction` currently rejects source/shop-scoped rebuilds. Ingestion normalization was creating dirty periods with the raw record `shopRef`, which led to failed P&L rebuild jobs like `Source-scoped P&L rebuild is not supported until Finance source-linking is decided.`

## Validation

- `docker compose run --rm -T site-php-cli php bin/phpunit -c phpunit.xml --testsuite=integration --filter NormalizationCompletedSubscriberTest` — passed, with 2 existing PHPUnit deprecations.
- `git diff --check` — passed.

## Notes

Unrelated staged deletions under `docs/tasks/...` were already present in the working tree and are not included in this PR.