### PR TITLE
fix(telegram): восстановить приём/отправку и создание ДДС + безопасность вебхука

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1353,6 +1353,11 @@ Telegram создаёт ДДС-транзакции только через це
 - webhook отвечает `ok`;
 - пишется warning.
 
+**Webhook URL (конфигурация):**
+- Публичный URL вебхука задаётся через `.env` → `TELEGRAM_WEBHOOK_URL` (параметр `telegram.webhook_url`, bind `string $telegramWebhookUrl`).
+- Используется в `TelegramBotController::webhookSet()` (вызов `setWebhook`) и проверке статуса.
+- Прод-дефолт — шлюз `tg-gateway`: `https://tg.vashfindir.ru/telegram/webhook`. Хардкод URL запрещён.
+
 
 ## Enum — актуальные значения
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1359,6 +1359,12 @@ Telegram создаёт ДДС-транзакции только через це
 - Прод-дефолт — шлюз `tg-gateway`: `https://tg.vashfindir.ru/telegram/webhook`. Хардкод URL запрещён.
 - В проде значение передаётся через `docker-compose.prod.yml` (якорь `x-php-env`), а не через репозиторный `.env`.
 
+**Webhook secret_token (аутентификация):**
+- `TELEGRAM_WEBHOOK_SECRET` (параметр `telegram.webhook_secret`, bind `string $telegramWebhookSecret`).
+- При `setWebhook` передаётся как `secret_token`; Telegram шлёт его в заголовке `X-Telegram-Bot-Api-Secret-Token`.
+- `TelegramWebhookController` сверяет заголовок (`hash_equals`); несовпадение → HTTP 403, апдейт не обрабатывается.
+- Пустой секрет = проверка выключена (для совместимости при rollout). В проде задать случайным значением и переустановить вебхук.
+
 **Политика обработки ошибок вебхука:**
 - `TelegramWebhookController` ВСЕГДА отвечает HTTP 200 (иначе Telegram ретраит апдейт).
 - Ошибки не глушатся: непойманные исключения и сбои создания ДДС логируются через `LoggerInterface::error` (→ Sentry).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1357,6 +1357,13 @@ Telegram создаёт ДДС-транзакции только через це
 - Публичный URL вебхука задаётся через `.env` → `TELEGRAM_WEBHOOK_URL` (параметр `telegram.webhook_url`, bind `string $telegramWebhookUrl`).
 - Используется в `TelegramBotController::webhookSet()` (вызов `setWebhook`) и проверке статуса.
 - Прод-дефолт — шлюз `tg-gateway`: `https://tg.vashfindir.ru/telegram/webhook`. Хардкод URL запрещён.
+- В проде значение передаётся через `docker-compose.prod.yml` (якорь `x-php-env`), а не через репозиторный `.env`.
+
+**Политика обработки ошибок вебхука:**
+- `TelegramWebhookController` ВСЕГДА отвечает HTTP 200 (иначе Telegram ретраит апдейт).
+- Ошибки не глушатся: непойманные исключения и сбои создания ДДС логируются через `LoggerInterface::error` (→ Sentry).
+- Доменные ошибки создания операции (`\DomainException`, напр. закрытый период; `CurrencyMismatchException`) показываются пользователю текстом в чат; прочие сбои → сообщение «Не удалось сохранить операцию, попробуйте позже».
+- Нулевая сумма (`0.00`) операцией не считается — пользователю возвращается подсказка формата.
 
 
 ## Enum — актуальные значения

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -30,6 +30,8 @@ x-php-env: &php-env
     LLM_API_KEY: "change-me"
     # Публичный URL вебхука Telegram — точка приёма апдейтов (шлюз tg-gateway)
     TELEGRAM_WEBHOOK_URL: ${TELEGRAM_WEBHOOK_URL:-https://tg.vashfindir.ru/telegram/webhook}
+    # Секрет вебхука: задать случайным значением в host-env и переустановить webhook (пусто = проверка выключена)
+    TELEGRAM_WEBHOOK_SECRET: ${TELEGRAM_WEBHOOK_SECRET:-}
 
 services:
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -28,6 +28,8 @@ x-php-env: &php-env
     WB_LEGACY_RECONCILE_ENABLED: ${WB_LEGACY_RECONCILE_ENABLED:-0}
     LLM_API_URL: "https://example.com/v1/chat/completions"
     LLM_API_KEY: "change-me"
+    # Публичный URL вебхука Telegram — точка приёма апдейтов (шлюз tg-gateway)
+    TELEGRAM_WEBHOOK_URL: ${TELEGRAM_WEBHOOK_URL:-https://tg.vashfindir.ru/telegram/webhook}
 
 services:
 

--- a/docs/tasks/TG-WEBHOOK-DDS-FIX/handoff.md
+++ b/docs/tasks/TG-WEBHOOK-DDS-FIX/handoff.md
@@ -28,6 +28,10 @@
 - `setWebhook` передаёт `secret_token`; вебхук сверяет заголовок `X-Telegram-Bot-Api-Secret-Token` (`hash_equals`), несовпадение → HTTP 403.
 - Пустой секрет = проверка выключена (rollout-safe).
 
+### Stage 4 (🟡 MEDIUM) — не раскрывать произвольные доменные ошибки
+- Маркер-интерфейс `App\Shared\Domain\Exception\UserFacingException`; типизированное `App\Cash\Exception\FinancePeriodLockedException`.
+- `CashTransactionService` бросает типизированное исключение; Telegram показывает текст только `UserFacingException`, прочее → лог + обобщённый ответ.
+
 ## Изменённые публичные контракты / конфигурация
 - Новые env-переменные **`TELEGRAM_WEBHOOK_URL`**, **`TELEGRAM_WEBHOOK_SECRET`** (`.env`, `.env.test`, `docker-compose.prod.yml`).
 - Новые параметры контейнера `telegram.webhook_url`, `telegram.webhook_secret` + бинды.

--- a/docs/tasks/TG-WEBHOOK-DDS-FIX/handoff.md
+++ b/docs/tasks/TG-WEBHOOK-DDS-FIX/handoff.md
@@ -23,10 +23,15 @@
 - Защита от нулевой суммы (`0.00` → подсказка формата).
 - `TelegramWebhookController`: `strict_types`, `final`.
 
+### Stage 3 (🔴 HIGH) — аутентификация вебхука по secret_token
+- Новая env `TELEGRAM_WEBHOOK_SECRET` (параметр `telegram.webhook_secret`, bind `string $telegramWebhookSecret`).
+- `setWebhook` передаёт `secret_token`; вебхук сверяет заголовок `X-Telegram-Bot-Api-Secret-Token` (`hash_equals`), несовпадение → HTTP 403.
+- Пустой секрет = проверка выключена (rollout-safe).
+
 ## Изменённые публичные контракты / конфигурация
-- Новая env-переменная **`TELEGRAM_WEBHOOK_URL`** (`.env`, `.env.test`, `docker-compose.prod.yml`).
-- Новый параметр контейнера `telegram.webhook_url` + bind `string $telegramWebhookUrl`.
-- Поведение endpoint `/telegram/webhook` не изменилось по контракту (всегда 200); изменились тексты ответов пользователю при ошибках.
+- Новые env-переменные **`TELEGRAM_WEBHOOK_URL`**, **`TELEGRAM_WEBHOOK_SECRET`** (`.env`, `.env.test`, `docker-compose.prod.yml`).
+- Новые параметры контейнера `telegram.webhook_url`, `telegram.webhook_secret` + бинды.
+- Endpoint `/telegram/webhook`: на валидных апдейтах по-прежнему 200; при неверном/отсутствующем secret_token (когда секрет задан) → **403**. Тексты ответов пользователю при ошибках изменились.
 
 ## Миграции
 - Нет.
@@ -40,8 +45,10 @@
 
 ## Действия для деплоя (ОБЯЗАТЕЛЬНО, вне кода)
 1. Убедиться, что в прод-окружении доступен `TELEGRAM_WEBHOOK_URL` (дефолт уже в compose).
-2. После деплоя: в админке вызвать `POST /admin/telegram/bots/webhook-set` (нужен активный бот с токеном), затем проверить `webhook-health` / `getWebhookInfo` (`url`, `last_error_message`, `pending_update_count`).
-3. Проверить, что шлюз `tg-gateway` (`tg.vashfindir.ru`) реально проксирует на живой апстрим.
+2. (Опц., но рекомендовано) задать `TELEGRAM_WEBHOOK_SECRET` случайным значением (1–256 симв. `A-Z a-z 0-9 _ -`). Пока пусто — проверка secret_token выключена.
+3. После деплоя: в админке вызвать `POST /admin/telegram/bots/webhook-set` (нужен активный бот с токеном). **Если задан секрет — этот шаг ОБЯЗАТЕЛЕН**, иначе Telegram продолжит слать апдейты без заголовка и получит 403.
+4. Проверить `webhook-health` / `getWebhookInfo` (`url`, `last_error_message`, `pending_update_count`).
+5. Проверить, что шлюз `tg-gateway` (`tg.vashfindir.ru`) реально проксирует на живой апстрим.
 
 ## Риски
 - `CurrencyMismatchException` в Telegram-потоке практически недостижим (валюта = валюта кассы), обрабатывается защитно.

--- a/docs/tasks/TG-WEBHOOK-DDS-FIX/handoff.md
+++ b/docs/tasks/TG-WEBHOOK-DDS-FIX/handoff.md
@@ -1,0 +1,58 @@
+# Handoff — TG-WEBHOOK-DDS-FIX
+
+> Ветка: `feature/TG-WEBHOOK-DDS-FIX` (от `master`). Merge только через PR после ревью Владельца.
+> 🛑 Final Owner review.
+
+## Проблема (исходно)
+1. Telegram-бот не принимает/не отправляет команды.
+2. Создание операций ДДС из Telegram «молча» перестало работать.
+
+Анализ показал: оба симптома завязаны на доставку вебхука и на глобальный `catch(\Throwable)`, который глушил все ошибки и возвращал `{status:ok}`. Дополнительно — URL вебхука был захардкожен (`app.vashfindir.ru`) и разошёлся с новым шлюзом `tg-gateway` (`tg.vashfindir.ru`).
+
+## Что сделано по этапам
+
+### Stage 1 (🔴 HIGH) — конфигурируемый webhook URL
+- Убран хардкод `TARGET_WEBHOOK_URL`; URL берётся из `TELEGRAM_WEBHOOK_URL` (параметр `telegram.webhook_url`, bind `string $telegramWebhookUrl`).
+- Прод-дефолт — шлюз `https://tg.vashfindir.ru/telegram/webhook`.
+- Прод-значение объявлено в `docker-compose.prod.yml` (якорь `x-php-env`), т.к. прод-env идёт оттуда, а не из репозиторного `.env`.
+- `TelegramBotController`: `strict_types`, `final`, DI URL через конструктор.
+
+### Stage 2 (🟡 MEDIUM) — видимая обработка ошибок ДДС
+- Глобальный `catch` пишет `logger->error` (→ Sentry) вместо `error_log`, сохраняя HTTP 200.
+- Создание ДДС обёрнуто в `try/catch`: доменные ошибки (закрытый период, валюта) → текст пользователю; прочее → лог + «Не удалось сохранить операцию».
+- Защита от нулевой суммы (`0.00` → подсказка формата).
+- `TelegramWebhookController`: `strict_types`, `final`.
+
+## Изменённые публичные контракты / конфигурация
+- Новая env-переменная **`TELEGRAM_WEBHOOK_URL`** (`.env`, `.env.test`, `docker-compose.prod.yml`).
+- Новый параметр контейнера `telegram.webhook_url` + bind `string $telegramWebhookUrl`.
+- Поведение endpoint `/telegram/webhook` не изменилось по контракту (всегда 200); изменились тексты ответов пользователю при ошибках.
+
+## Миграции
+- Нет.
+
+## Тесты
+- `tests/Telegram/Functional/Admin/TelegramBotWebhookSetTest.php` — URL из конфигурации (Stage 1).
+- `tests/Telegram/Functional/TelegramWebhookCashTransactionTest.php` — закрытый период / нулевая сумма / успешная операция (Stage 2).
+- Прогон `tests/Telegram/Functional`: **4 теста, 19 ассертов — зелёные.**
+- CS-Fixer — чисто на всех изменённых файлах.
+- PHPStan — N/A (в репозитории не настроен).
+
+## Действия для деплоя (ОБЯЗАТЕЛЬНО, вне кода)
+1. Убедиться, что в прод-окружении доступен `TELEGRAM_WEBHOOK_URL` (дефолт уже в compose).
+2. После деплоя: в админке вызвать `POST /admin/telegram/bots/webhook-set` (нужен активный бот с токеном), затем проверить `webhook-health` / `getWebhookInfo` (`url`, `last_error_message`, `pending_update_count`).
+3. Проверить, что шлюз `tg-gateway` (`tg.vashfindir.ru`) реально проксирует на живой апстрим.
+
+## Риски
+- `CurrencyMismatchException` в Telegram-потоке практически недостижим (валюта = валюта кассы), обрабатывается защитно.
+- В контроллере остаются прочие `error_log` (диагностика HTTP-отправки) — вне scope.
+
+## Follow-ups (сознательно вне scope)
+- 🔧 Предсуществующие падения `tests/Telegram/Unit/BotLinkTest.php` и `BotLinkServiceTest.php` (16 ошибок): конструктор `BotLink` изменён в коммите `11d300d2` (25.01.2026), тесты не обновлены. Отдельная задача.
+- 🔧 Унификация логирования в `respondWithMessage`/`editMessageText` (error_log → logger).
+- 🔧 Валидация `CashTransactionDTO` в `CashFacade::createTransaction` (Assert не вызывается) — общий Cash-слой, отдельная задача.
+
+## Коммиты
+- `2b370fb5` fix(telegram): make webhook URL configurable via TELEGRAM_WEBHOOK_URL
+- `a09eba93` fix(telegram): wire TELEGRAM_WEBHOOK_URL into prod compose env
+- `b305f89a` fix(telegram): surface cash-transaction errors instead of silently swallowing

--- a/docs/tasks/TG-WEBHOOK-DDS-FIX/plan.md
+++ b/docs/tasks/TG-WEBHOOK-DDS-FIX/plan.md
@@ -1,0 +1,77 @@
+# Phase 0 — Plan: TG-WEBHOOK-DDS-FIX
+
+> Статус: **черновик плана, ожидает одобрения Владельца (🛑 STOP).**
+> Источник задачи: бриф в чате — «бот не принимает/не отправляет команды; создание операций ДДС перестало работать».
+> До одобрения этого плана код не пишется.
+
+## Контекст / проблема
+
+Модуль Telegram (`site/src/Telegram`) перестал работать по двум симптомам:
+
+1. **Бот не принимает/не отправляет команды.** Приём зависит от доставки вебхука. URL вебхука **захардкожен** в админ-контроллере:
+   `src/Telegram/Controller/Admin/TelegramBotController.php:20`
+   ```php
+   private const TARGET_WEBHOOK_URL = 'https://app.vashfindir.ru/telegram/webhook';
+   ```
+   18–20 июня 2026 введён новый шлюз `tg-gateway` (домен `tg.vashfindir.ru`, traefik+nginx, проксирует только `/telegram/webhook` → `app.vashfindir.ru`) — см. коммиты `3f1aed7b`, `e18e5644`. Шлюз задумывался публичной точкой приёма Telegram, но `setWebhook` по-прежнему прописывает прямой `app.vashfindir.ru`. URL нельзя менять без правки кода и редеплоя — это и есть рассинхрон.
+
+2. **ДДС-операции «молча» не создаются.** Весь `TelegramWebhookController::webhook()` обёрнут в `catch (\Throwable)` (`:106-111`), который пишет только в `error_log` и возвращает `{status:ok}`. Любая ошибка в цепочке `handleTextMessage → CreateTelegramCashTransactionAction → CashFacade::createTransaction → CashTransactionService::add()` невидима пользователю: он не получает ни операции, ни сообщения об ошибке.
+
+Цель задачи: (а) сделать URL вебхука конфигурируемым через `.env` и согласованным с архитектурой шлюза; (б) перестать глушить ошибки ДДС-потока — логировать корректно (ERROR→Sentry) и отвечать пользователю внятным сообщением, **сохраняя HTTP 200 для Telegram** (иначе Telegram ретраит и копит очередь).
+
+## Важное проектное ограничение
+
+Вебхук Telegram **обязан получать HTTP 200** почти всегда. Поэтому глобальный `ExceptionListener` здесь **не применяем** — endpoint должен сам ловить ошибки и всегда отдавать 200. Меняем не «отдавать 4xx/5xx», а «корректно логировать + отвечать пользователю в чат».
+
+## Этапы
+
+### Stage 1 — Конфигурируемый webhook URL (направление «а»)
+**Риск:** 🔴 HIGH (затрагивает публичный endpoint приёма Telegram + добавление env-переменной + редеплой).
+**Цель:** убрать хардкод, сделать URL вебхука параметром из `.env`, по умолчанию — адрес шлюза.
+
+Карта изменений:
+- `.env` — добавить `TELEGRAM_WEBHOOK_URL=https://tg.vashfindir.ru/telegram/webhook` (значение по умолчанию подтверждает Владелец: шлюз `tg.vashfindir.ru` ИЛИ прямой `app.vashfindir.ru`).
+- `.env.dev`, `.env.test` — нейтральное dev-значение.
+- `config/services.yaml` — параметр `parameters: telegram.webhook_url: '%env(TELEGRAM_WEBHOOK_URL)%'` (паттерн уже используется, напр. `app.encryption.key_file`).
+- `src/Telegram/Controller/Admin/TelegramBotController.php` — убрать `const TARGET_WEBHOOK_URL`, внедрить значение через конструктор (`bind` или явный аргумент сервиса), использовать в `webhookSet()` и `buildWebhookStatus()`.
+- Заодно привести контроллер к правилам проекта: `declare(strict_types=1)`, `final class` (если не ломает Symfony DI — проверить).
+
+**STOP-причины этапа:** изменение поведения публичного endpoint, новая env-переменная, выбор дефолтного URL. 🛑 Обязательное ревью SQL/конфига нет (миграции нет), но изменение публичного контракта вебхука → STOP перед редеплоем.
+
+Тесты:
+- Функциональный/юнит на `webhookSet()`: URL берётся из параметра, а не из константы (мок `HttpClientInterface`, проверка тела запроса `setWebhook`).
+
+### Stage 2 — Видимая обработка ошибок ДДС-потока (направление «б»)
+**Риск:** 🟡 MEDIUM (логика внутри Telegram-модуля, без изменения публичного контракта и БД).
+**Цель:** ошибки создания операции не глушить молча — логировать как ERROR (уйдёт в Sentry) и отвечать пользователю в чат, при этом Telegram получает 200.
+
+Карта изменений:
+- `src/Telegram/Controller/TelegramWebhookController.php`:
+  - Локальный `try/catch` вокруг вызова `createTelegramCashTransactionAction` в `handleTextMessage()` (`:827`): на доменные ошибки (напр. `\DomainException` «период закрыт», `CurrencyMismatchException`) — отдать пользователю понятный текст; на прочие `\Throwable` — `logger->error()` + сообщение «Не удалось сохранить операцию, попробуйте позже».
+  - Глобальный `catch (\Throwable)` (`:106`) — заменить `error_log` на `LoggerInterface::error` (Sentry), сохранив возврат 200.
+  - Привести файл к правилам: `declare(strict_types=1)`, `final class`.
+- Рассмотреть пробрасывание доменных исключений из `CreateTelegramCashTransactionAction` как есть (Action их не ловит — уже ок), маппинг текста — в контроллере (HTTP in/out слой).
+- (Опц., если подтвердит диагностика) `parseAmountFromText` возвращает `0.00` на нулевой ввод → добавить явный отказ с подсказкой формата вместо создания нулевой операции.
+
+**Не входит в scope:** изменение `CashTransactionService::add()` и общего Cash-контракта (это разделяемый код веб-UI) — только Telegram-слой.
+
+Тесты:
+- Юнит/функциональный на `handleTextMessage`: при выбросе `\DomainException` из Action пользователь получает текст ошибки, ответ HTTP 200, факт `logger->error`.
+- Регрессионный: «закрытый период» (`assertNotLockedForCompany`) → пользователь видит сообщение, а не тишину.
+
+## Что НЕ трогаем
+- `CashTransactionService` / `CashFacade` / общий Cash-контракт.
+- Маршруты `messenger.yaml`, security firewalls (вебхук уже `PUBLIC_ACCESS`).
+- Сам `tg-gateway` (отдельная инфраструктура, отдельная задача при необходимости).
+
+## Обновления ARCHITECTURE.md
+- Зафиксировать параметр `telegram.webhook_url` и факт, что URL вебхука конфигурируется через `.env`.
+- Зафиксировать политику обработки ошибок Telegram-вебхука (всегда 200 + логирование ERROR).
+
+## Открытые вопросы Владельцу (нужны до старта)
+1. **Дефолтный URL вебхука:** шлюз `https://tg.vashfindir.ru/telegram/webhook` (ради чего вводили gateway) или прямой `https://app.vashfindir.ru/telegram/webhook`?
+2. **Подтверждена ли рантайм-причина «тишины»?** Желательно вывод `getWebhookInfo` и грепа по логам — чтобы понимать, добавляет ли Stage 1 фактическое исправление приёма или только устраняет рассинхрон конфигурации.
+3. Нужно ли в Stage 2 добавлять отказ на нулевую сумму (`0.00`)?
+
+## Порядок
+Stage 1 (🔴 HIGH) → 🛑 STOP, ревью Владельца перед редеплоем → Stage 2 (🟡 MEDIUM) → Phase Final handoff (🛑 STOP).

--- a/docs/tasks/TG-WEBHOOK-DDS-FIX/stages/stage-1.md
+++ b/docs/tasks/TG-WEBHOOK-DDS-FIX/stages/stage-1.md
@@ -18,6 +18,7 @@
 - `site/.env.test` — modified (детерминированное тестовое значение tg.example.test)
 - `site/tests/Telegram/Functional/Admin/TelegramBotWebhookSetTest.php` — new
 - `ARCHITECTURE.md` — modified
+- `docker-compose.prod.yml` — modified (TELEGRAM_WEBHOOK_URL в якоре `x-php-env`)
 
 ### Self-review
 - [x] Scope compliance — только направление «а» из плана
@@ -35,7 +36,7 @@
 
 ### Риски / на что обратить внимание ревьюеру
 - 🔴 Это меняет ТОЛЬКО код установки вебхука. Чтобы фактически переключить приём на `tg.vashfindir.ru`, после деплоя нужно зайти в админку и вызвать `setWebhook` (POST `/admin/telegram/bots/webhook-set`), затем проверить `getWebhookInfo`.
-- На проде нужно прописать `TELEGRAM_WEBHOOK_URL` (через `compose dump-env prod` / реальное окружение) — `.env` даёт только дефолт.
+- Прод-env передаётся ТОЛЬКО через якорь `x-php-env` в `docker-compose.prod.yml` (репозиторный `.env` хоть и попадает в образ через `COPY ./ ./`, опираться на него в проде хрупко). Поэтому `TELEGRAM_WEBHOOK_URL` добавлен в `x-php-env` с дефолтом `https://tg.vashfindir.ru/telegram/webhook` и возможностью override через host-env `${TELEGRAM_WEBHOOK_URL:-...}`. Проверено: `docker compose -f docker-compose.prod.yml config` резолвит переменную во все PHP-сервисы (fpm/cli/workers).
 - Требуется подтверждение, что шлюз `tg-gateway` реально проксирует на работающий апстрим (отдельная инфраструктура).
 
 ### Предсуществующие проблемы (вне scope, НЕ вводились в этом этапе)

--- a/docs/tasks/TG-WEBHOOK-DDS-FIX/stages/stage-1.md
+++ b/docs/tasks/TG-WEBHOOK-DDS-FIX/stages/stage-1.md
@@ -1,0 +1,45 @@
+## Stage 1: Конфигурируемый webhook URL — DONE
+
+**Риск:** 🔴 HIGH
+**Следующее действие:** 🛑 STOP, ждать Владельца (изменён публичный контракт вебхука + новая env-переменная → ревью перед редеплоем).
+
+### Что сделано
+- Убран хардкод `TARGET_WEBHOOK_URL` из `TelegramBotController`; URL вебхука теперь берётся из конфигурации.
+- Добавлена env-переменная `TELEGRAM_WEBHOOK_URL` (прод-дефолт — шлюз `https://tg.vashfindir.ru/telegram/webhook`).
+- Параметр `telegram.webhook_url` + глобальный bind `string $telegramWebhookUrl` в `services.yaml`.
+- `TelegramBotController` приведён к правилам: `declare(strict_types=1)`, `final class`, инъекция URL через конструктор.
+- Функциональный тест: `setWebhook` уходит на URL из конфигурации, а не на захардкоженный адрес.
+- `ARCHITECTURE.md` — зафиксирован параметр и прод-дефолт.
+
+### Затронутые файлы
+- `site/src/Telegram/Controller/Admin/TelegramBotController.php` — modified (убрана const, конструктор с DI, strict_types, final)
+- `site/config/services.yaml` — modified (параметр + bind)
+- `site/.env` — modified (TELEGRAM_WEBHOOK_URL = tg.vashfindir.ru)
+- `site/.env.test` — modified (детерминированное тестовое значение tg.example.test)
+- `site/tests/Telegram/Functional/Admin/TelegramBotWebhookSetTest.php` — new
+- `ARCHITECTURE.md` — modified
+
+### Self-review
+- [x] Scope compliance — только направление «а» из плана
+- [x] Patterns / naming — параметр и bind как в проекте (ср. `app.encryption.*`); контроллер `final`, strict_types
+- [x] Forbidden actions — нет хардкода URL (устранён), нет dump/dd, нет new Service
+- [x] Security — изменения только в админ-зоне (`ROLE_SUPER_ADMIN`), публичный приём вебхука не ослаблен
+- [x] CS-Fixer — чисто на изменённых файлах (`--path-mode=intersection`)
+- [x] PHPStan — N/A: phpstan не настроен в репозитории (нет в vendor/bin, Makefile, composer scripts)
+- [x] Тест зелёный — `TelegramBotWebhookSetTest` (7 ассертов)
+- [x] ARCHITECTURE.md обновлён
+
+### Команды для проверки
+- `docker compose run --rm -T site-php-cli php bin/phpunit --filter TelegramBotWebhookSetTest`
+- `docker compose run --rm -T site-php-cli vendor/bin/php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.dist.php --path-mode=intersection src/Telegram/Controller/Admin/TelegramBotController.php tests/Telegram/Functional/Admin/TelegramBotWebhookSetTest.php`
+
+### Риски / на что обратить внимание ревьюеру
+- 🔴 Это меняет ТОЛЬКО код установки вебхука. Чтобы фактически переключить приём на `tg.vashfindir.ru`, после деплоя нужно зайти в админку и вызвать `setWebhook` (POST `/admin/telegram/bots/webhook-set`), затем проверить `getWebhookInfo`.
+- На проде нужно прописать `TELEGRAM_WEBHOOK_URL` (через `compose dump-env prod` / реальное окружение) — `.env` даёт только дефолт.
+- Требуется подтверждение, что шлюз `tg-gateway` реально проксирует на работающий апстрим (отдельная инфраструктура).
+
+### Предсуществующие проблемы (вне scope, НЕ вводились в этом этапе)
+- `tests/Telegram/Unit/BotLinkTest.php` и `BotLinkServiceTest.php` падают (16 ошибок): конструктор `BotLink` стал `(string $id, Company $company, ...)` в коммите `11d300d2` (25.01.2026 «Move Company entity to Company module»), тесты передают Company-mock первым аргументом. Файлы мной не менялись. → отдельная задача.
+
+### Открытые вопросы
+- нет (дефолтный URL подтверждён Владельцем — `tg.vashfindir.ru`).

--- a/docs/tasks/TG-WEBHOOK-DDS-FIX/stages/stage-2.md
+++ b/docs/tasks/TG-WEBHOOK-DDS-FIX/stages/stage-2.md
@@ -1,0 +1,42 @@
+## Stage 2: Видимая обработка ошибок ДДС-потока — DONE
+
+**Риск:** 🟡 MEDIUM
+**Следующее действие:** continue autonomously → Phase Final (handoff, 🛑 STOP).
+
+### Что сделано
+- `TelegramWebhookController` приведён к правилам: `declare(strict_types=1)`, `final class`.
+- Глобальный `catch (\Throwable)` больше не использует `error_log` — пишет `LoggerInterface::error` (→ Sentry), сохраняя ответ HTTP 200 (Telegram требует 200).
+- В `handleTextMessage()` создание ДДС обёрнуто в `try/catch`:
+  - `CurrencyMismatchException` (наследник `\DomainException`, ловится первым) → «Валюта операции не совпадает с валютой кассы.»
+  - `\DomainException` (напр. закрытый период) → текст исключения пользователю.
+  - прочие `\Throwable` → `logger->error` + «Не удалось сохранить операцию, попробуйте позже.»
+- В `CreateTelegramCashTransactionAction::parseAmountFromText()` добавлена защита от нулевой суммы (`0.00` → `null` → подсказка формата).
+- 3 функциональных теста на webhook end-to-end.
+- `ARCHITECTURE.md` — зафиксирована политика обработки ошибок вебхука.
+
+### Затронутые файлы
+- `site/src/Telegram/Controller/TelegramWebhookController.php` — modified (strict_types, final, logger в catch, try/catch вокруг создания ДДС)
+- `site/src/Telegram/Application/CreateTelegramCashTransactionAction.php` — modified (guard нулевой суммы)
+- `site/tests/Telegram/Functional/TelegramWebhookCashTransactionTest.php` — new
+- `ARCHITECTURE.md` — modified
+
+### Self-review
+- [x] Scope compliance — только обработка ошибок Telegram-слоя + guard нулевой суммы (по плану); общий Cash-контракт не тронут
+- [x] Patterns / naming — final, strict_types, инъекция logger (уже была)
+- [x] Forbidden actions — error_log в целевом catch убран; dump/dd нет; молчаливого глотания нет
+- [x] Security — изменений в репозиториях/companyId нет, IDOR не затронут
+- [x] CS-Fixer — чисто на изменённых файлах (`--path-mode=intersection`)
+- [x] PHPStan — N/A (не настроен в репозитории)
+- [x] Тесты зелёные — `tests/Telegram/Functional` (4 теста, 19 ассертов)
+- [x] ARCHITECTURE.md обновлён
+
+### Команды для проверки
+- `docker compose run --rm -T site-php-cli php bin/phpunit tests/Telegram/Functional`
+- `docker compose run --rm -T site-php-cli vendor/bin/php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.dist.php --path-mode=intersection src/Telegram/Controller/TelegramWebhookController.php src/Telegram/Application/CreateTelegramCashTransactionAction.php tests/Telegram/Functional/TelegramWebhookCashTransactionTest.php`
+
+### Риски / на что обратить внимание ревьюеру
+- `CurrencyMismatchException` в Telegram-потоке практически недостижим (валюта берётся из самой кассы), но обрабатывается защитно.
+- В контроллере остаются прочие `error_log` (в `respondWithMessage`/`editMessageText`) — диагностика HTTP-отправки, вне scope Stage 2. Кандидат на отдельный рефактор логирования.
+
+### Открытые вопросы
+- нет.

--- a/docs/tasks/TG-WEBHOOK-DDS-FIX/stages/stage-3.md
+++ b/docs/tasks/TG-WEBHOOK-DDS-FIX/stages/stage-3.md
@@ -1,0 +1,44 @@
+## Stage 3: Аутентификация вебхука по secret_token — DONE
+
+**Риск:** 🔴 HIGH
+**Следующее действие:** 🛑 STOP, ждать Владельца (аутентификация публичного endpoint + новая env + редеплой с обязательной переустановкой вебхука).
+
+### Что сделано
+- Новая env `TELEGRAM_WEBHOOK_SECRET` (параметр `telegram.webhook_secret`, bind `string $telegramWebhookSecret`).
+- `TelegramBotController::webhookSet()` передаёт `secret_token` в Telegram (если секрет задан).
+- `TelegramWebhookController` сверяет заголовок `X-Telegram-Bot-Api-Secret-Token` через `hash_equals`; несовпадение → HTTP 403, апдейт не обрабатывается, пишется warning.
+- Пустой секрет = проверка выключена (безопасный rollout: приём не ломается до установки секрета).
+- Прод-env (`docker-compose.prod.yml`) и `.env`/`.env.test` обновлены.
+- Тесты: отклонение без/с неверным секретом (403), проход с верным; в admin-тесте — проверка передачи `secret_token`.
+- `ARCHITECTURE.md` — зафиксирована политика secret_token.
+
+### Затронутые файлы
+- `site/src/Telegram/Controller/TelegramWebhookController.php` — modified (инъекция секрета, метод `isValidSecretToken`, проверка в `webhook()`)
+- `site/src/Telegram/Controller/Admin/TelegramBotController.php` — modified (`secret_token` в setWebhook)
+- `site/config/services.yaml` — modified (параметр + bind)
+- `site/.env`, `site/.env.test` — modified
+- `docker-compose.prod.yml` — modified (`TELEGRAM_WEBHOOK_SECRET` в `x-php-env`)
+- `site/tests/Telegram/Functional/TelegramWebhookSecretTokenTest.php` — new
+- `site/tests/Telegram/Functional/TelegramWebhookCashTransactionTest.php` — modified (шлёт заголовок секрета)
+- `site/tests/Telegram/Functional/Admin/TelegramBotWebhookSetTest.php` — modified (assert secret_token)
+- `ARCHITECTURE.md` — modified
+
+### Self-review
+- [x] Scope compliance — только аутентификация вебхука
+- [x] Patterns / naming — параметр + bind как в Stage 1; `hash_equals` (constant-time)
+- [x] Forbidden actions — секрет не логируется (логируется только факт несовпадения)
+- [x] Security — публичный endpoint теперь проверяет подлинность; пустой секрет — осознанный rollback-safe режим
+- [x] CS-Fixer — чисто на изменённых файлах
+- [x] PHPStan — N/A (не настроен)
+- [x] Тесты зелёные — `tests/Telegram/Functional` (7 тестов, 26 ассертов)
+- [x] ARCHITECTURE.md обновлён
+
+### Команды для проверки
+- `docker compose run --rm -T site-php-cli php bin/phpunit tests/Telegram/Functional`
+
+### Риски / на что обратить внимание ревьюеру
+- 🔴 ПОРЯДОК ДЕПЛОЯ ВАЖЕН: после установки `TELEGRAM_WEBHOOK_SECRET` в проде нужно ОБЯЗАТЕЛЬНО переустановить вебхук (`POST /admin/telegram/bots/webhook-set`), иначе Telegram продолжит слать апдейты без заголовка → все запросы будут получать 403. Пока секрет пустой — проверка выключена, приём работает как раньше.
+- Секрет должен соответствовать формату Telegram: 1–256 символов из `A-Z a-z 0-9 _ -`.
+
+### Открытые вопросы
+- нет.

--- a/docs/tasks/TG-WEBHOOK-DDS-FIX/stages/stage-4.md
+++ b/docs/tasks/TG-WEBHOOK-DDS-FIX/stages/stage-4.md
@@ -1,0 +1,41 @@
+## Stage 4: Не раскрывать пользователю произвольные доменные ошибки — DONE
+
+**Риск:** 🟡 MEDIUM (затрагивает Cash-сервис — смена типа исключения на наследника `\DomainException`, обратносовместимо).
+**Следующее действие:** 🛑 STOP, ждать Владельца (Phase Final).
+
+### Проблема (из ревью)
+`handleTextMessage` форвардил пользователю `getMessage()` ЛЮБОГО `\DomainException`. Сейчас безопасно (единственный — «период закрыт»), но будущее доменное исключение с техническим текстом утекло бы в чат.
+
+### Что сделано
+- Новый маркер-интерфейс `App\Shared\Domain\Exception\UserFacingException` — «сообщение можно показывать пользователю».
+- Новое типизированное исключение `App\Cash\Exception\FinancePeriodLockedException extends \DomainException implements UserFacingException`.
+- `CashTransactionService::assertNotLockedForCompany()` бросает `FinancePeriodLockedException` вместо безымянного `\DomainException` (обратносовместимо: подкласс `\DomainException`, существующие `catch (\DomainException)` в web-контроллерах работают как раньше).
+- `TelegramWebhookController`: вместо `catch (\DomainException)` теперь `catch (UserFacingException)`. Прочие доменные/любые исключения → лог + обобщённое «Не удалось сохранить операцию».
+- `ARCHITECTURE.md` — политика обновлена (показываем только `UserFacingException`).
+
+### Затронутые файлы
+- `site/src/Shared/Domain/Exception/UserFacingException.php` — new
+- `site/src/Cash/Exception/FinancePeriodLockedException.php` — new
+- `site/src/Cash/Service/Transaction/CashTransactionService.php` — modified (тип исключения)
+- `site/src/Telegram/Controller/TelegramWebhookController.php` — modified (catch по маркеру)
+- `ARCHITECTURE.md` — modified
+
+### Self-review
+- [x] Scope compliance — точечный фикс пункта ревью
+- [x] Patterns / naming — маркер в Shared/Domain/Exception (как `MoneyMismatchException`), исключение в Cash/Exception, `final`
+- [x] Forbidden actions — нет; смена типа исключения обратносовместима
+- [x] Security — техн. детали доменных ошибок больше не утекают пользователю Telegram
+- [x] CS-Fixer — чисто на изменённых файлах
+- [x] PHPStan — N/A
+- [x] Тесты зелёные — `tests/Telegram/Functional` (7), `CashTransactionServiceTest` (2) — регресса нет
+- [x] ARCHITECTURE.md обновлён
+
+### Команды для проверки
+- `docker compose run --rm -T site-php-cli php bin/phpunit tests/Telegram/Functional tests/Integration/Cash/Service/Transaction/CashTransactionServiceTest.php`
+
+### Риски / на что обратить внимание ревьюеру
+- Существующий e2e-тест «закрытый период» (`TelegramWebhookCashTransactionTest`) подтверждает, что сообщение по-прежнему показывается (теперь через маркер).
+- Обратная совместимость web: контроллеры Cash ловят `\DomainException` → `FinancePeriodLockedException` по-прежнему попадает в эти catch (parity сохранён).
+
+### Открытые вопросы
+- нет.

--- a/site/.env
+++ b/site/.env
@@ -63,6 +63,11 @@ WB_LEGACY_RECONCILE_ENABLED=false
 
 BANK_PROVIDERS=demo,alfa
 BANK_IMPORT_DEFAULT_SINCE_DAYS=30
+
+###> telegram ###
+# Публичный URL вебхука Telegram. Точка приёма апдейтов — шлюз tg-gateway.
+TELEGRAM_WEBHOOK_URL=https://tg.vashfindir.ru/telegram/webhook
+###< telegram ###
 LLM_API_URL="https://example.com/v1/chat/completions"
 LLM_API_KEY="change-me"
 

--- a/site/.env
+++ b/site/.env
@@ -67,6 +67,9 @@ BANK_IMPORT_DEFAULT_SINCE_DAYS=30
 ###> telegram ###
 # Публичный URL вебхука Telegram. Точка приёма апдейтов — шлюз tg-gateway.
 TELEGRAM_WEBHOOK_URL=https://tg.vashfindir.ru/telegram/webhook
+# Секрет вебхука: при setWebhook передаётся в Telegram, который шлёт его в заголовке
+# X-Telegram-Bot-Api-Secret-Token. Пустое значение = проверка выключена.
+TELEGRAM_WEBHOOK_SECRET=
 ###< telegram ###
 LLM_API_URL="https://example.com/v1/chat/completions"
 LLM_API_KEY="change-me"

--- a/site/.env.test
+++ b/site/.env.test
@@ -12,6 +12,7 @@ LLM_API_URL="https://example.com/v1/chat/completions"
 LLM_API_KEY="test-key"
 
 TELEGRAM_WEBHOOK_URL=https://tg.example.test/telegram/webhook
+TELEGRAM_WEBHOOK_SECRET=test-secret-123
 
 APP_ENCRYPTION_KEY_FILE=%kernel.project_dir%/var/secrets/encryption_keys.test.json
 APP_ENCRYPTION_CURRENT_KEY_VERSION=v1

--- a/site/.env.test
+++ b/site/.env.test
@@ -11,6 +11,8 @@ WB_LEGACY_RECONCILE_ENABLED=false
 LLM_API_URL="https://example.com/v1/chat/completions"
 LLM_API_KEY="test-key"
 
+TELEGRAM_WEBHOOK_URL=https://tg.example.test/telegram/webhook
+
 APP_ENCRYPTION_KEY_FILE=%kernel.project_dir%/var/secrets/encryption_keys.test.json
 APP_ENCRYPTION_CURRENT_KEY_VERSION=v1
 APP_ENCRYPTION_FALLBACK_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=

--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -18,6 +18,7 @@ parameters:
     wb_finance.rate_limit_interval_seconds: 70
     wb_finance.retry_delay_ms: 70000
     telegram.webhook_url: '%env(string:TELEGRAM_WEBHOOK_URL)%'
+    telegram.webhook_secret: '%env(string:TELEGRAM_WEBHOOK_SECRET)%'
 
 services:
     # default configuration for services in *this* file
@@ -29,6 +30,8 @@ services:
             Predis\Client $redisClient: '@session.redis'
             # Публичный URL вебхука Telegram (берём из .env, см. TELEGRAM_WEBHOOK_URL)
             string $telegramWebhookUrl: '%telegram.webhook_url%'
+            # Секрет вебхука Telegram: проверяем заголовок X-Telegram-Bot-Api-Secret-Token (пусто = проверка выключена)
+            string $telegramWebhookSecret: '%telegram.webhook_secret%'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -17,6 +17,7 @@ parameters:
     app.object_storage_s3_path_style_endpoint_default: '0'
     wb_finance.rate_limit_interval_seconds: 70
     wb_finance.retry_delay_ms: 70000
+    telegram.webhook_url: '%env(string:TELEGRAM_WEBHOOK_URL)%'
 
 services:
     # default configuration for services in *this* file
@@ -26,6 +27,8 @@ services:
         bind:
             # Говорим Symfony подставлять ваш клиент Redis туда, где запрашивают Predis\Client с именем $redisClient
             Predis\Client $redisClient: '@session.redis'
+            # Публичный URL вебхука Telegram (берём из .env, см. TELEGRAM_WEBHOOK_URL)
+            string $telegramWebhookUrl: '%telegram.webhook_url%'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/site/src/Cash/Exception/FinancePeriodLockedException.php
+++ b/site/src/Cash/Exception/FinancePeriodLockedException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Cash\Exception;
+
+use App\Shared\Domain\Exception\UserFacingException;
+
+/**
+ * Операция попадает в закрытый финансовый период компании.
+ * Сообщение пользовательское — помечено UserFacingException.
+ */
+final class FinancePeriodLockedException extends \DomainException implements UserFacingException
+{
+}

--- a/site/src/Cash/Service/Transaction/CashTransactionService.php
+++ b/site/src/Cash/Service/Transaction/CashTransactionService.php
@@ -3,11 +3,15 @@
 namespace App\Cash\Service\Transaction;
 
 use App\Analytics\Infrastructure\Cache\SnapshotCacheInvalidator;
+use App\Cash\Application\Service\DailyBalanceRecalculator;
 use App\Cash\DTO\CashTransactionDTO;
 use App\Cash\Entity\Accounts\MoneyAccount;
 use App\Cash\Entity\Transaction\CashflowCategory;
 use App\Cash\Entity\Transaction\CashTransaction;
 use App\Cash\Enum\Transaction\CashDirection;
+use App\Cash\Exception\CurrencyMismatchException;
+use App\Cash\Exception\FinancePeriodLockedException;
+use App\Cash\Message\ApplyAutoRulesForTransaction;
 use App\Cash\Repository\Transaction\CashTransactionRepository;
 use App\Cash\Service\PaymentPlan\PaymentPlanMatcher;
 use App\Cash\Service\Vat\VatCalculator;
@@ -15,9 +19,6 @@ use App\Cash\Service\Vat\VatPolicy;
 use App\Company\Entity\Company;
 use App\Company\Entity\Counterparty;
 use App\Company\Entity\ProjectDirection;
-use App\Cash\Exception\CurrencyMismatchException;
-use App\Cash\Message\ApplyAutoRulesForTransaction;
-use App\Cash\Application\Service\DailyBalanceRecalculator;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Exception\ORMException;
 use Ramsey\Uuid\Uuid;
@@ -318,7 +319,7 @@ class CashTransactionService
             : \DateTimeImmutable::createFromInterface($date)->setTime(0, 0);
 
         if ($current < $lock) {
-            throw new \DomainException(sprintf('Период закрыт. Операции с датами ранее %s запрещены.', $lock->format('d.m.Y')));
+            throw new FinancePeriodLockedException(sprintf('Период закрыт. Операции с датами ранее %s запрещены.', $lock->format('d.m.Y')));
         }
     }
 }

--- a/site/src/Shared/Domain/Exception/UserFacingException.php
+++ b/site/src/Shared/Domain/Exception/UserFacingException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Domain\Exception;
+
+/**
+ * Маркер: сообщение исключения безопасно показывать конечному пользователю.
+ * Исключения БЕЗ этого маркера не должны раскрывать getMessage() наружу (логируем, отвечаем обобщённо).
+ */
+interface UserFacingException extends \Throwable
+{
+}

--- a/site/src/Telegram/Application/CreateTelegramCashTransactionAction.php
+++ b/site/src/Telegram/Application/CreateTelegramCashTransactionAction.php
@@ -16,7 +16,8 @@ final readonly class CreateTelegramCashTransactionAction
     public function __construct(
         private CashFacade $cashFacade,
         private TelegramCashTransactionExternalIdGenerator $externalIdGenerator,
-    ) {}
+    ) {
+    }
 
     public function __invoke(CreateTelegramCashTransactionCommand $command): ?CreateTelegramCashTransactionActionResult
     {
@@ -97,7 +98,14 @@ final readonly class CreateTelegramCashTransactionAction
         $fractionalPart = substr($fractionalPart, 0, 2);
         $fractionalPart = str_pad($fractionalPart, 2, '0');
 
-        return sprintf('%s.%s', $integerPart, $fractionalPart);
+        $amount = sprintf('%s.%s', $integerPart, $fractionalPart);
+
+        // Нулевая сумма — не операция: возвращаем null, чтобы контроллер показал подсказку формата
+        if ('0.00' === $amount) {
+            return null;
+        }
+
+        return $amount;
     }
 
     private function detectDirection(string $text): CashDirection

--- a/site/src/Telegram/Controller/Admin/TelegramBotController.php
+++ b/site/src/Telegram/Controller/Admin/TelegramBotController.php
@@ -21,6 +21,8 @@ final class TelegramBotController extends AbstractController
     public function __construct(
         // Публичный URL вебхука берём из конфигурации (.env: TELEGRAM_WEBHOOK_URL), а не из хардкода
         private readonly string $telegramWebhookUrl,
+        // Секрет вебхука: передаётся в Telegram при setWebhook (пусто = без секрета)
+        private readonly string $telegramWebhookSecret = '',
     ) {
     }
 
@@ -152,12 +154,17 @@ final class TelegramBotController extends AbstractController
         }
 
         try {
+            // Адрес вебхука берём из конфигурации (TELEGRAM_WEBHOOK_URL)
+            $body = ['url' => $this->telegramWebhookUrl];
+
+            // Если задан секрет — Telegram будет слать его в заголовке X-Telegram-Bot-Api-Secret-Token
+            if ('' !== $this->telegramWebhookSecret) {
+                $body['secret_token'] = $this->telegramWebhookSecret;
+            }
+
             // Запрашиваем Telegram API setWebhook, чтобы привязать бота к фиксированному URL
             $response = $httpClient->request('POST', sprintf('https://api.telegram.org/bot%s/setWebhook', $bot->getToken()), [
-                'body' => [
-                    // Адрес вебхука берём из конфигурации (TELEGRAM_WEBHOOK_URL)
-                    'url' => $this->telegramWebhookUrl,
-                ],
+                'body' => $body,
             ]);
 
             if (200 !== $response->getStatusCode()) {

--- a/site/src/Telegram/Controller/Admin/TelegramBotController.php
+++ b/site/src/Telegram/Controller/Admin/TelegramBotController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Telegram\Controller\Admin;
 
 use App\Telegram\Entity\TelegramBot;
@@ -14,10 +16,13 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 #[Route('/admin/telegram/bots', name: 'admin_telegram_bot_')]
-class TelegramBotController extends AbstractController
+final class TelegramBotController extends AbstractController
 {
-    // Для MVP вебхук всегда должен указывать на продакшн-домен, поэтому URL захардкожен
-    private const TARGET_WEBHOOK_URL = 'https://app.vashfindir.ru/telegram/webhook';
+    public function __construct(
+        // Публичный URL вебхука берём из конфигурации (.env: TELEGRAM_WEBHOOK_URL), а не из хардкода
+        private readonly string $telegramWebhookUrl,
+    ) {
+    }
 
     #[Route('', name: 'index', methods: ['GET'])]
     public function index(TelegramBotRepository $repository): Response
@@ -150,8 +155,8 @@ class TelegramBotController extends AbstractController
             // Запрашиваем Telegram API setWebhook, чтобы привязать бота к фиксированному URL
             $response = $httpClient->request('POST', sprintf('https://api.telegram.org/bot%s/setWebhook', $bot->getToken()), [
                 'body' => [
-                    // Для MVP жёстко задаём адрес вебхука на продакшн-домен
-                    'url' => self::TARGET_WEBHOOK_URL,
+                    // Адрес вебхука берём из конфигурации (TELEGRAM_WEBHOOK_URL)
+                    'url' => $this->telegramWebhookUrl,
                 ],
             ]);
 
@@ -173,7 +178,7 @@ class TelegramBotController extends AbstractController
             $this->addFlash('success', 'Webhook установлен');
 
             // Сохраняем ожидаемый URL вебхука в базе, чтобы админ видел последнюю попытку установки
-            $bot->setWebhookUrl(self::TARGET_WEBHOOK_URL);
+            $bot->setWebhookUrl($this->telegramWebhookUrl);
             $bot->setUpdatedAt(new \DateTimeImmutable());
             $entityManager->flush();
         } else {
@@ -250,12 +255,12 @@ class TelegramBotController extends AbstractController
         $lastErrorMessage = $result['last_error_message'] ?? null;
 
         // Вебхук считаем установленным, когда Telegram возвращает ожидаемый адрес
-        $webhookInstalled = self::TARGET_WEBHOOK_URL === $url;
+        $webhookInstalled = $this->telegramWebhookUrl === $url;
         // Эвристика для MVP: webhook считаем живым, если он установлен и Telegram не сообщает об ошибках доставки
         $webhookAlive = $webhookInstalled && empty($lastErrorMessage);
 
         return [
-            'expectedUrl' => self::TARGET_WEBHOOK_URL,
+            'expectedUrl' => $this->telegramWebhookUrl,
             'actualUrl' => $url,
             'pendingUpdateCount' => $pending,
             'lastErrorDate' => $lastErrorDate,

--- a/site/src/Telegram/Controller/TelegramWebhookController.php
+++ b/site/src/Telegram/Controller/TelegramWebhookController.php
@@ -6,6 +6,7 @@ namespace App\Telegram\Controller;
 
 use App\Cash\Entity\Accounts\MoneyAccount;
 use App\Cash\Exception\CurrencyMismatchException;
+use App\Shared\Domain\Exception\UserFacingException;
 use App\Telegram\Application\CreateTelegramCashTransactionAction;
 use App\Telegram\Application\DTO\CreateTelegramCashTransactionCommand;
 use App\Telegram\Entity\ClientBinding;
@@ -858,10 +859,10 @@ final class TelegramWebhookController extends AbstractController
                 text: $text,
             ));
         } catch (CurrencyMismatchException) {
-            // Валюта операции должна совпадать с валютой кассы (CurrencyMismatchException — наследник DomainException, ловим раньше)
+            // Валюта операции должна совпадать с валютой кассы (ловим раньше: своё сообщение)
             return $this->respondWithMessage($bot, $message, 'Валюта операции не совпадает с валютой кассы.');
-        } catch (\DomainException $e) {
-            // Доменное ограничение (например, закрытый период) — показываем пользователю причину
+        } catch (UserFacingException $e) {
+            // Только помеченные пользовательские исключения (напр. закрытый период) показываем как есть
             return $this->respondWithMessage($bot, $message, $e->getMessage());
         } catch (\Throwable $e) {
             // Прочие сбои не глушим: пишем в Sentry и сообщаем пользователю, что операция не сохранена

--- a/site/src/Telegram/Controller/TelegramWebhookController.php
+++ b/site/src/Telegram/Controller/TelegramWebhookController.php
@@ -1,14 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Telegram\Controller;
 
 use App\Cash\Entity\Accounts\MoneyAccount;
+use App\Cash\Exception\CurrencyMismatchException;
+use App\Telegram\Application\CreateTelegramCashTransactionAction;
+use App\Telegram\Application\DTO\CreateTelegramCashTransactionCommand;
 use App\Telegram\Entity\ClientBinding;
 use App\Telegram\Entity\ImportJob;
 use App\Telegram\Entity\ReportSubscription;
 use App\Telegram\Entity\TelegramBot;
-use App\Telegram\Application\CreateTelegramCashTransactionAction;
-use App\Telegram\Application\DTO\CreateTelegramCashTransactionCommand;
 use App\Telegram\Entity\TelegramUser;
 use App\Telegram\Repository\BotLinkRepository;
 use App\Telegram\Repository\TelegramBotRepository;
@@ -22,7 +25,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
-class TelegramWebhookController extends AbstractController
+final class TelegramWebhookController extends AbstractController
 {
     public function __construct(
         private readonly TelegramBotRepository $botRepository,
@@ -104,8 +107,11 @@ class TelegramWebhookController extends AbstractController
 
             return $this->handleTextMessage($bot, $update, $message, $text);
         } catch (\Throwable $e) {
-            error_log('[TELEGRAM_WEBHOOK_EXCEPTION] '.$e->getMessage());
-            error_log('[TELEGRAM_WEBHOOK_EXCEPTION] file='.$e->getFile().':'.$e->getLine());
+            // Telegram требует ответ 200, иначе апдейт будет ретраиться. Ошибку отдаём в Sentry через logger.
+            $this->logger->error('Telegram webhook unhandled exception', [
+                'exception' => $e,
+                'update_id' => $update['update_id'] ?? null,
+            ]);
 
             return new JsonResponse(['status' => 'ok']);
         }
@@ -824,23 +830,39 @@ class TelegramWebhookController extends AbstractController
             return $this->respondWithMessage($bot, $message, 'Сначала выберите кассу: /set_cash');
         }
 
-        $result = ($this->createTelegramCashTransactionAction)(new CreateTelegramCashTransactionCommand(
-            botId: $bot->getId(),
-            companyId: $clientBinding->getCompany()->getId(),
-            moneyAccountId: $moneyAccount->getId(),
-            currency: $moneyAccount->getCurrency(),
-            chatId: isset($message['chat']['id']) ? (string) $message['chat']['id'] : null,
-            messageId: isset($message['message_id']) ? (string) $message['message_id'] : null,
-            fromId: isset($message['from']['id']) ? (string) $message['from']['id'] : null,
-            updateId: isset($update['update_id']) ? (int) $update['update_id'] : null,
-            messageDate: isset($message['date']) ? (int) $message['date'] : null,
-            text: $text,
-        ));
+        try {
+            $result = ($this->createTelegramCashTransactionAction)(new CreateTelegramCashTransactionCommand(
+                botId: $bot->getId(),
+                companyId: $clientBinding->getCompany()->getId(),
+                moneyAccountId: $moneyAccount->getId(),
+                currency: $moneyAccount->getCurrency(),
+                chatId: isset($message['chat']['id']) ? (string) $message['chat']['id'] : null,
+                messageId: isset($message['message_id']) ? (string) $message['message_id'] : null,
+                fromId: isset($message['from']['id']) ? (string) $message['from']['id'] : null,
+                updateId: isset($update['update_id']) ? (int) $update['update_id'] : null,
+                messageDate: isset($message['date']) ? (int) $message['date'] : null,
+                text: $text,
+            ));
+        } catch (CurrencyMismatchException) {
+            // Валюта операции должна совпадать с валютой кассы (CurrencyMismatchException — наследник DomainException, ловим раньше)
+            return $this->respondWithMessage($bot, $message, 'Валюта операции не совпадает с валютой кассы.');
+        } catch (\DomainException $e) {
+            // Доменное ограничение (например, закрытый период) — показываем пользователю причину
+            return $this->respondWithMessage($bot, $message, $e->getMessage());
+        } catch (\Throwable $e) {
+            // Прочие сбои не глушим: пишем в Sentry и сообщаем пользователю, что операция не сохранена
+            $this->logger->error('Telegram cash transaction failed', [
+                'exception' => $e,
+                'company_id' => $clientBinding->getCompany()->getId(),
+                'money_account_id' => $moneyAccount->getId(),
+            ]);
+
+            return $this->respondWithMessage($bot, $message, 'Не удалось сохранить операцию, попробуйте позже.');
+        }
 
         if (null === $result) {
             return $this->respondWithMessage($bot, $message, 'Формат: потратил 2500 на рекламу');
         }
-
 
         if ($result->skippedMissingMessageIdentity) {
             $this->logger->warning('Telegram cash transaction skipped: message identity is incomplete.', [

--- a/site/src/Telegram/Controller/TelegramWebhookController.php
+++ b/site/src/Telegram/Controller/TelegramWebhookController.php
@@ -34,6 +34,7 @@ final class TelegramWebhookController extends AbstractController
         private readonly HttpClientInterface $httpClient,
         private readonly LoggerInterface $logger,
         private readonly CreateTelegramCashTransactionAction $createTelegramCashTransactionAction,
+        private readonly string $telegramWebhookSecret = '',
     ) {
     }
 
@@ -52,6 +53,19 @@ final class TelegramWebhookController extends AbstractController
         try {
             if ($request->isMethod(Request::METHOD_GET)) {
                 return new JsonResponse(['status' => 'ok']);
+            }
+
+            // Проверяем подлинность запроса: Telegram шлёт заданный secret_token в заголовке.
+            // Это защищает публичный endpoint от поддельных апдейтов (создание чужих операций, спам).
+            if (!$this->isValidSecretToken($request)) {
+                $this->logger->warning('Telegram webhook: invalid secret token', [
+                    'update_id' => $update['update_id'] ?? null,
+                ]);
+
+                return new JsonResponse(
+                    ['error' => ['code' => 'forbidden', 'message' => 'Invalid secret token']],
+                    Response::HTTP_FORBIDDEN,
+                );
             }
 
             // Находим активного бота, чтобы принимать сообщения независимо от конкретного токена маршрута
@@ -1068,6 +1082,19 @@ final class TelegramWebhookController extends AbstractController
         }
 
         return null;
+    }
+
+    private function isValidSecretToken(Request $request): bool
+    {
+        // Пустой секрет = проверка выключена (безопасный rollout: приём не ломается до установки секрета)
+        if ('' === $this->telegramWebhookSecret) {
+            return true;
+        }
+
+        $provided = (string) $request->headers->get('X-Telegram-Bot-Api-Secret-Token', '');
+
+        // hash_equals — сравнение без утечки времени
+        return hash_equals($this->telegramWebhookSecret, $provided);
     }
 
     private function respondWithMessage(TelegramBot $bot, array $message, string $text, ?array $replyMarkup = null): Response

--- a/site/tests/Telegram/Functional/Admin/TelegramBotWebhookSetTest.php
+++ b/site/tests/Telegram/Functional/Admin/TelegramBotWebhookSetTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Telegram\Functional\Admin;
+
+use App\Telegram\Entity\TelegramBot;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Stage 1 (TG-WEBHOOK-DDS-FIX): URL вебхука берётся из конфигурации (TELEGRAM_WEBHOOK_URL),
+ * а не из захардкоженной константы. В .env.test задано https://tg.example.test/telegram/webhook.
+ */
+final class TelegramBotWebhookSetTest extends WebTestCaseBase
+{
+    private const ADMIN_ID = '22222222-2222-2222-2222-abcd0000aa01';
+    private const EXPECTED_WEBHOOK_URL = 'https://tg.example.test/telegram/webhook';
+
+    public function testWebhookSetUsesConfiguredUrl(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $this->seedActiveBot('TEST-TOKEN-123');
+
+        /** @var list<array{method: string, url: string, options: array<string, mixed>}> $captured */
+        $captured = [];
+        $this->setHttpClient($client, $captured, [
+            new MockResponse(json_encode(['ok' => true, 'result' => true], \JSON_THROW_ON_ERROR)),
+            new MockResponse(json_encode([
+                'ok' => true,
+                'result' => ['url' => self::EXPECTED_WEBHOOK_URL, 'pending_update_count' => 0],
+            ], \JSON_THROW_ON_ERROR)),
+        ]);
+
+        $admin = UserBuilder::aUser()
+            ->withId(self::ADMIN_ID)
+            ->withEmail('tg-admin@example.test')
+            ->withRoles(['ROLE_COMPANY_OWNER', 'ROLE_SUPER_ADMIN'])
+            ->build();
+        $this->em()->persist($admin);
+        $this->em()->flush();
+
+        // Маршрут /admin обслуживает отдельный firewall "admin" (security.yaml), логинимся в него
+        $client->loginUser($admin, 'admin');
+        $client->request('POST', '/admin/telegram/bots/webhook-set');
+
+        self::assertResponseRedirects();
+
+        // Первый исходящий запрос — setWebhook на токен бота с URL из конфигурации
+        self::assertNotEmpty($captured, 'setWebhook должен быть вызван');
+        self::assertStringContainsString('/setWebhook', $captured[0]['url']);
+        $body = $this->bodyAsString($captured[0]['options']);
+        self::assertStringContainsString('tg.example.test', $body);
+        self::assertStringNotContainsString('app.vashfindir.ru', $body);
+
+        // Сохранённый в БД webhookUrl совпадает с конфигурацией
+        $this->em()->clear();
+        $bot = $this->em()->getRepository(TelegramBot::class)->findOneBy([]);
+        self::assertInstanceOf(TelegramBot::class, $bot);
+        self::assertSame(self::EXPECTED_WEBHOOK_URL, $bot->getWebhookUrl());
+    }
+
+    private function seedActiveBot(string $token): void
+    {
+        $bot = new TelegramBot(Uuid::uuid4()->toString(), $token);
+        $bot->setIsActive(true);
+        $this->em()->persist($bot);
+        $this->em()->flush();
+    }
+
+    /**
+     * @param list<array{method: string, url: string, options: array<string, mixed>}> $captured
+     * @param list<MockResponse>                                                      $responses
+     */
+    private function setHttpClient(KernelBrowser $client, array &$captured, array $responses): void
+    {
+        $i = 0;
+        $callable = static function (string $method, string $url, array $options) use ($responses, &$i, &$captured): ResponseInterface {
+            $captured[] = ['method' => $method, 'url' => $url, 'options' => $options];
+
+            if (!isset($responses[$i])) {
+                throw new \LogicException(sprintf('MockHttpClient: нет ответа для запроса #%d (%s %s)', $i + 1, $method, $url));
+            }
+
+            return $responses[$i++];
+        };
+
+        $client->getContainer()->set('http_client', new MockHttpClient($callable));
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function bodyAsString(array $options): string
+    {
+        $body = $options['body'] ?? '';
+
+        if (is_string($body)) {
+            return $body;
+        }
+
+        if (is_iterable($body)) {
+            $parts = [];
+            foreach ($body as $chunk) {
+                $parts[] = is_string($chunk) ? $chunk : '';
+            }
+
+            return implode('', $parts);
+        }
+
+        return '';
+    }
+}

--- a/site/tests/Telegram/Functional/Admin/TelegramBotWebhookSetTest.php
+++ b/site/tests/Telegram/Functional/Admin/TelegramBotWebhookSetTest.php
@@ -59,6 +59,9 @@ final class TelegramBotWebhookSetTest extends WebTestCaseBase
         $body = $this->bodyAsString($captured[0]['options']);
         self::assertStringContainsString('tg.example.test', $body);
         self::assertStringNotContainsString('app.vashfindir.ru', $body);
+        // Секрет из .env.test передаётся в Telegram при setWebhook
+        self::assertStringContainsString('secret_token', $body);
+        self::assertStringContainsString('test-secret-123', $body);
 
         // Сохранённый в БД webhookUrl совпадает с конфигурацией
         $this->em()->clear();

--- a/site/tests/Telegram/Functional/TelegramWebhookCashTransactionTest.php
+++ b/site/tests/Telegram/Functional/TelegramWebhookCashTransactionTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Telegram\Functional;
+
+use App\Telegram\Entity\ClientBinding;
+use App\Telegram\Entity\TelegramBot;
+use App\Telegram\Entity\TelegramUser;
+use App\Tests\Builders\Cash\MoneyAccountBuilder;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Stage 2 (TG-WEBHOOK-DDS-FIX): ошибки создания ДДС больше не глушатся молча —
+ * пользователь получает понятное сообщение, webhook всегда отвечает 200.
+ */
+final class TelegramWebhookCashTransactionTest extends WebTestCaseBase
+{
+    private const TG_USER_ID = '67890';
+    private const CHAT_ID = 12345;
+
+    public function testClosedPeriodReportsReasonToUser(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        // Закрытый период: дата операции (сегодня) раньше замка → доменное исключение «Период закрыт»
+        $this->seedBoundUserWithAccount(financeLockBefore: new \DateTimeImmutable('2099-01-01'));
+
+        $captured = [];
+        $this->captureTelegramCalls($client, $captured);
+
+        $this->postUpdate($client, '+1000 доход');
+
+        self::assertResponseIsSuccessful();
+        $body = $this->lastSentMessageText($captured);
+        self::assertStringContainsString('Период закрыт', $body);
+
+        // Транзакция не создана
+        self::assertSame(0, $this->countCashTransactions());
+    }
+
+    public function testZeroAmountReturnsFormatHint(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $this->seedBoundUserWithAccount(financeLockBefore: null);
+
+        $captured = [];
+        $this->captureTelegramCalls($client, $captured);
+
+        $this->postUpdate($client, '0 расход');
+
+        self::assertResponseIsSuccessful();
+        $body = $this->lastSentMessageText($captured);
+        self::assertStringContainsString('Формат', $body);
+
+        self::assertSame(0, $this->countCashTransactions());
+    }
+
+    public function testValidOperationIsRecorded(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $this->seedBoundUserWithAccount(financeLockBefore: null);
+
+        $captured = [];
+        $this->captureTelegramCalls($client, $captured);
+
+        $this->postUpdate($client, '+1500 доход');
+
+        self::assertResponseIsSuccessful();
+        $body = $this->lastSentMessageText($captured);
+        self::assertStringContainsString('Записал', $body);
+
+        self::assertSame(1, $this->countCashTransactions());
+    }
+
+    private function seedBoundUserWithAccount(?\DateTimeImmutable $financeLockBefore): void
+    {
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withId('22222222-2222-2222-2222-abcd0000bb01')
+            ->withEmail('tg-cash-owner@example.test')
+            ->build();
+        $em->persist($owner);
+
+        $company = CompanyBuilder::aCompany()
+            ->withId('11111111-1111-1111-1111-abcd0000bb01')
+            ->withOwner($owner)
+            ->build();
+        if (null !== $financeLockBefore) {
+            $company->setFinanceLockBefore($financeLockBefore);
+        }
+        $em->persist($company);
+
+        $account = MoneyAccountBuilder::aMoneyAccount()
+            ->withId('33333333-3333-3333-3333-abcd0000bb01')
+            ->forCompany($company)
+            ->withCurrency('RUB')
+            ->build();
+        $em->persist($account);
+
+        $bot = new TelegramBot(Uuid::uuid4()->toString(), 'TEST-TOKEN');
+        $bot->setIsActive(true);
+        $em->persist($bot);
+
+        $telegramUser = new TelegramUser(Uuid::uuid4()->toString(), self::TG_USER_ID);
+        $em->persist($telegramUser);
+
+        $binding = new ClientBinding(Uuid::uuid4()->toString(), $company, $bot, $telegramUser);
+        $binding->setMoneyAccount($account);
+        $em->persist($binding);
+
+        $em->flush();
+    }
+
+    private function postUpdate(KernelBrowser $client, string $text): void
+    {
+        $payload = [
+            'update_id' => 1001,
+            'message' => [
+                'message_id' => 55,
+                'date' => 1718000000,
+                'chat' => ['id' => self::CHAT_ID],
+                'from' => ['id' => (int) self::TG_USER_ID, 'first_name' => 'Test'],
+                'text' => $text,
+            ],
+        ];
+
+        $client->request(
+            'POST',
+            '/telegram/webhook',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode($payload, \JSON_THROW_ON_ERROR),
+        );
+    }
+
+    /**
+     * @param list<array{method: string, url: string, options: array<string, mixed>}> $captured
+     */
+    private function captureTelegramCalls(KernelBrowser $client, array &$captured): void
+    {
+        $callable = static function (string $method, string $url, array $options) use (&$captured): ResponseInterface {
+            $captured[] = ['method' => $method, 'url' => $url, 'options' => $options];
+
+            return new MockResponse(json_encode(['ok' => true, 'result' => true], \JSON_THROW_ON_ERROR));
+        };
+
+        $client->getContainer()->set('http_client', new MockHttpClient($callable));
+    }
+
+    /**
+     * Текст последнего sendMessage, отправленного в Telegram.
+     *
+     * @param list<array{method: string, url: string, options: array<string, mixed>}> $captured
+     */
+    private function lastSentMessageText(array $captured): string
+    {
+        $text = '';
+        foreach ($captured as $call) {
+            if (!str_contains($call['url'], '/sendMessage')) {
+                continue;
+            }
+
+            // Symfony HttpClient опцию "json" преобразует в "body" (JSON-строка) до вызова MockHttpClient
+            $body = $call['options']['body'] ?? null;
+            if (!is_string($body) || '' === $body) {
+                continue;
+            }
+
+            $decoded = json_decode($body, true);
+            if (is_array($decoded) && isset($decoded['text']) && is_string($decoded['text'])) {
+                $text = $decoded['text'];
+            }
+        }
+
+        self::assertNotSame('', $text, 'Ожидался хотя бы один sendMessage с текстом');
+
+        return $text;
+    }
+
+    private function countCashTransactions(): int
+    {
+        $this->em()->clear();
+
+        return (int) $this->em()->createQuery(
+            'SELECT COUNT(t.id) FROM '.\App\Cash\Entity\Transaction\CashTransaction::class.' t WHERE t.deletedAt IS NULL'
+        )->getSingleScalarResult();
+    }
+}

--- a/site/tests/Telegram/Functional/TelegramWebhookCashTransactionTest.php
+++ b/site/tests/Telegram/Functional/TelegramWebhookCashTransactionTest.php
@@ -143,7 +143,11 @@ final class TelegramWebhookCashTransactionTest extends WebTestCaseBase
             '/telegram/webhook',
             [],
             [],
-            ['CONTENT_TYPE' => 'application/json'],
+            [
+                'CONTENT_TYPE' => 'application/json',
+                // Секрет из .env.test — иначе запрос отклонится как поддельный (403)
+                'HTTP_X_TELEGRAM_BOT_API_SECRET_TOKEN' => 'test-secret-123',
+            ],
             json_encode($payload, \JSON_THROW_ON_ERROR),
         );
     }

--- a/site/tests/Telegram/Functional/TelegramWebhookSecretTokenTest.php
+++ b/site/tests/Telegram/Functional/TelegramWebhookSecretTokenTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Telegram\Functional;
+
+use App\Tests\Support\Kernel\WebTestCaseBase;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Stage 3 (TG-WEBHOOK-DDS-FIX): защита публичного вебхука по secret_token.
+ * В .env.test задан TELEGRAM_WEBHOOK_SECRET=test-secret-123.
+ */
+final class TelegramWebhookSecretTokenTest extends WebTestCaseBase
+{
+    private const SECRET = 'test-secret-123';
+
+    public function testMissingSecretIsRejected(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $this->postUpdate($client, null);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    public function testWrongSecretIsRejected(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $this->postUpdate($client, 'wrong-secret');
+
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    public function testValidSecretPassesGate(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        // Корректный секрет, но активного бота нет → проходит проверку и доходит до выбора бота (200)
+        $this->postUpdate($client, self::SECRET);
+
+        self::assertResponseIsSuccessful();
+        $data = json_decode((string) $client->getResponse()->getContent(), true);
+        self::assertIsArray($data);
+        self::assertSame('inactive_bot', $data['status'] ?? null);
+    }
+
+    private function postUpdate(KernelBrowser $client, ?string $secret): void
+    {
+        $server = ['CONTENT_TYPE' => 'application/json'];
+        if (null !== $secret) {
+            $server['HTTP_X_TELEGRAM_BOT_API_SECRET_TOKEN'] = $secret;
+        }
+
+        $payload = [
+            'update_id' => 2001,
+            'message' => [
+                'message_id' => 7,
+                'date' => 1718000000,
+                'chat' => ['id' => 999],
+                'from' => ['id' => 999, 'first_name' => 'Probe'],
+                'text' => 'ping',
+            ],
+        ];
+
+        $client->request('POST', '/telegram/webhook', [], [], $server, json_encode($payload, \JSON_THROW_ON_ERROR));
+    }
+}


### PR DESCRIPTION
## Проблема
Telegram-бот не принимал/не отправлял команды; создание операций ДДС «молча» перестало работать. Причины: захардкоженный URL вебхука разошёлся с новым шлюзом `tg-gateway`, а глобальный `catch(\Throwable)` глушил все ошибки.

## Что сделано (4 стадии)
1. **webhook URL → конфиг** (`TELEGRAM_WEBHOOK_URL`, параметр+bind); прод-значение в `docker-compose.prod.yml`. Убран хардкод.
2. **Видимая обработка ошибок ДДС**: ошибки логируются (Sentry) и показываются пользователю, webhook всегда отвечает 200. Защита от нулевой суммы.
3. **Аутентификация вебхука по `secret_token`** (`TELEGRAM_WEBHOOK_SECRET`): сверка заголовка `X-Telegram-Bot-Api-Secret-Token` (`hash_equals`), несовпадение → 403. Пустой секрет = проверка выключена (rollout-safe).
4. **Не раскрывать произвольные доменные ошибки**: маркер `UserFacingException` + типизированное `FinancePeriodLockedException`.

## Тесты
`tests/Telegram/Functional` — 7 тестов; `CashTransactionServiceTest` — без регресса. CS чисто.

## ⚠️ Обязательно после деплоя
1. Задать `TELEGRAM_WEBHOOK_SECRET` случайным значением (опц., но рекомендовано).
2. Вызвать `POST /admin/telegram/bots/webhook-set` (нужен активный бот с токеном) — иначе при заданном секрете Telegram будет получать 403.
3. Проверить `webhook-health` / `getWebhookInfo`.

Подробности: `docs/tasks/TG-WEBHOOK-DDS-FIX/handoff.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)