### PR TITLE
feat(telegram): исходящие вызовы Telegram через шлюз tg-gateway

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -32,6 +32,8 @@ x-php-env: &php-env
     TELEGRAM_WEBHOOK_URL: ${TELEGRAM_WEBHOOK_URL:-https://tg.vashfindir.ru/telegram/webhook}
     # Секрет вебхука: задать случайным значением в host-env и переустановить webhook (пусто = проверка выключена)
     TELEGRAM_WEBHOOK_SECRET: ${TELEGRAM_WEBHOOK_SECRET:-}
+    # Базовый URL Telegram Bot API через шлюз tg-gateway (app-сервер не имеет прямого доступа к api.telegram.org)
+    TELEGRAM_API_BASE_URL: ${TELEGRAM_API_BASE_URL:-https://tg.vashfindir.ru/bot-api}
 
 services:
 
@@ -403,6 +405,8 @@ services:
             APP_MAIL_REPLY_TO: "support@vashfindir.ru"
             FEATURE_FUNDS_AND_WIDGET: ${FEATURE_FUNDS_AND_WIDGET:-1}
             WB_LEGACY_RECONCILE_ENABLED: ${WB_LEGACY_RECONCILE_ENABLED:-0}
+            # Нужно для app:telegram:send-reports (исходящие в Telegram через шлюз)
+            TELEGRAM_API_BASE_URL: ${TELEGRAM_API_BASE_URL:-https://tg.vashfindir.ru/bot-api}
         volumes:
             - ./docker/cron/app.cron:/etc/crontabs/app.cron:ro
             - site_storage:/app/var/storage

--- a/docs/tasks/TG-API-EGRESS-PROXY/handoff.md
+++ b/docs/tasks/TG-API-EGRESS-PROXY/handoff.md
@@ -1,0 +1,41 @@
+# Handoff — TG-API-EGRESS-PROXY
+
+> Ветка: `feature/TG-API-EGRESS-PROXY` (от `master`). Merge только через PR.
+
+## Проблема
+Бот принимал апдейты (через `tg.vashfindir.ru/telegram/webhook`), но не отвечал: app-сервер (РФ, `217.198.13.171`) не имеет прямого доступа к `api.telegram.org` (`Connection timed out`). Значит все исходящие вызовы Telegram (sendMessage, setWebhook, getFile…) не проходили.
+
+## Решение
+Исходящие вызовы Telegram пускаем через тот же шлюз `tg-gateway` (KZ-VPS), что и вход. Базовый URL Telegram API в app сделан конфигурируемым.
+
+## Этапы
+- **Stage 1 (🔴):** `tg-gateway/nginx/tg.conf` — `location /bot-api/` → `https://api.telegram.org/`; `tg-gateway/docker-compose.yml` — Traefik-роутер `tg-bot-api` (`PathPrefix(/bot-api/)`) + `ipAllowList` на `217.198.13.171/32`. **Задеплоен и проверен** (`getMe` → `ok:true`).
+- **Stage 2 (🟡):** env `TELEGRAM_API_BASE_URL` + параметр/bind; убран хардкод `https://api.telegram.org` в `TelegramWebhookController` (sendMessage/editMessage/getFile/file) и `TelegramBotController` (setWebhook/getWebhookInfo). Дефолт прежний.
+- **Stage 3 (🔴):** прод-значение `TELEGRAM_API_BASE_URL=https://tg.vashfindir.ru/bot-api` в `docker-compose.prod.yml` (`x-php-env` + `scheduler`); дозакрыт хардкод в `SendTelegramReportsCommand`.
+
+## Изменённые контракты / конфигурация
+- Новая env **`TELEGRAM_API_BASE_URL`** (`.env`=api.telegram.org, `.env.test`=tg-proxy.example.test, прод=шлюз). Параметр `telegram.api_base_url` + bind `string $telegramApiBaseUrl`.
+- Инфра шлюза: новый публичный путь `/bot-api/` (ограничен по IP app-сервера на Traefik).
+
+## Миграции
+- Нет.
+
+## Тесты
+- `tests/Telegram/Functional` — 7/7 (27 ассертов). CS чисто. PHPStan — N/A.
+- Прод-smoke: `curl https://tg.vashfindir.ru/bot-api/bot$TOKEN/getMe` → `{"ok":true,...}`.
+
+## Cutover (Владелец, по порядку)
+1. Шлюз (Stage 1) — уже задеплоен ✓.
+2. Смержить ветку → деплой app.
+3. Админка → «Установить webhook» (setWebhook теперь идёт через шлюз).
+4. «Проверить webhook» → `url` шлюзовой, `last_error_message` пусто.
+5. Написать боту → ответ; в логах app `Telegram update получен`.
+
+## Риски
+- Весь Telegram-трафик (вход+выход) через `tg.vashfindir.ru`: падение шлюза = бот молчит в обе стороны.
+- IP app-сервера зашит в `tg-gateway` (`217.198.13.171/32`). Смена IP → обновить label шлюза.
+
+## Follow-ups
+- Вынести IP app-сервера в переменную деплоя шлюза (сейчас захардкожен).
+- (Опц.) усилить `/bot-api/` секретным заголовком в дополнение к IP.
+- Предсуществующие сломанные тесты вне scope: `CreateDocumentFromTransactionActionTest`, `AccountBalanceServiceTest`, `BotLink*Test`.

--- a/docs/tasks/TG-API-EGRESS-PROXY/stages/stage-3.md
+++ b/docs/tasks/TG-API-EGRESS-PROXY/stages/stage-3.md
@@ -1,0 +1,41 @@
+## Stage 3: Прод-конфиг + cutover (выход через шлюз) — DONE (код), cutover — за Владельцем
+
+**Риск:** 🔴 HIGH
+**Следующее действие:** 🛑 STOP — деплой/cutover выполняет Владелец.
+
+### Что сделано (код/конфиг)
+- `docker-compose.prod.yml`:
+  - в якорь `x-php-env` добавлен `TELEGRAM_API_BASE_URL: ${TELEGRAM_API_BASE_URL:-https://tg.vashfindir.ru/bot-api}` (покрывает php-fpm, cli, messenger-воркеры);
+  - в env-блок `scheduler` добавлена та же переменная (для `app:telegram:send-reports`).
+- Дозакрыт пропущенный хардкод: `SendTelegramReportsCommand` (`app:telegram:send-reports`) тоже использовал `https://api.telegram.org` напрямую → переведён на `$telegramApiBaseUrl` (в cron сейчас не стоит, но исправлено во избежание латентного бага).
+
+### Подтверждено на проде (до cutover)
+Шлюз Stage 1 уже задеплоен и работает:
+```
+curl "https://tg.vashfindir.ru/bot-api/bot$TOKEN/getMe"
+→ {"ok":true,"result":{"id":8250137233,"username":"your_cfo_bot",...}}
+```
+
+### Затронутые файлы
+- `docker-compose.prod.yml` — modified (x-php-env + scheduler)
+- `site/src/Telegram/Command/SendTelegramReportsCommand.php` — modified (база API)
+
+### Self-review
+- [x] Scope compliance — прод-конфиг cutover + закрытие пропущенного хардкода
+- [x] CS-Fixer — чисто; `docker compose -f docker-compose.prod.yml config` — валидно (переменная резолвится во все PHP-сервисы)
+- [x] Тесты — `tests/Telegram/Functional` 7/7 (контейнер компилируется с новым bind команды)
+- [x] PHPStan — N/A
+
+### Cutover (выполняет Владелец, по порядку)
+1. Смержить ветку → деплой app (`deploy.yml`).
+2. (Опц.) задать `TELEGRAM_WEBHOOK_SECRET` в host-env.
+3. Админка → «Установить webhook» (теперь setWebhook идёт ЧЕРЕЗ шлюз и реально дойдёт).
+4. «Проверить webhook» → `url=https://tg.vashfindir.ru/telegram/webhook`, `last_error_message` пусто.
+5. Написать боту → должен ответить; в логах app — `Telegram update получен`.
+
+### Риски / ревьюеру
+- 🔴 После деплоя весь Telegram-трафик (вход и выход) идёт через `tg.vashfindir.ru`. Если шлюз ляжет — бот замолчит в обе стороны.
+- `scheduler` теперь тоже знает базу — `send-reports` при включении в cron пойдёт через шлюз.
+
+### Открытые вопросы
+- нет.

--- a/site/src/Telegram/Command/SendTelegramReportsCommand.php
+++ b/site/src/Telegram/Command/SendTelegramReportsCommand.php
@@ -28,6 +28,7 @@ final class SendTelegramReportsCommand extends Command
         private readonly HttpClientInterface $httpClient,
         private readonly MoneyAccountRepository $moneyAccountRepository,
         private readonly CashTransactionRepository $cashTransactionRepository,
+        private readonly string $telegramApiBaseUrl = 'https://api.telegram.org',
     ) {
         parent::__construct();
     }
@@ -59,7 +60,7 @@ final class SendTelegramReportsCommand extends Command
                 $text = $this->buildReportText($subscription);
                 $chatId = $subscription->getTelegramUser()->getTgUserId();
 
-                $response = $this->httpClient->request('POST', sprintf('https://api.telegram.org/bot%s/sendMessage', $bot->getToken()), [
+                $response = $this->httpClient->request('POST', sprintf('%s/bot%s/sendMessage', $this->telegramApiBaseUrl, $bot->getToken()), [
                     'json' => [
                         'chat_id' => $chatId,
                         'text' => $text,


### PR DESCRIPTION
## Проблема
Бот принимал апдейты, но не отвечал: app-сервер (РФ) не имеет прямого доступа к `api.telegram.org` (`Connection timed out`). Все исходящие вызовы Telegram (sendMessage, setWebhook, getFile…) не проходили.

## Решение
Исходящие вызовы Telegram пускаем через тот же шлюз `tg-gateway` (KZ-VPS), что и вход. Базовый URL Telegram API в app сделан конфигурируемым.

## Стадии
1. **Шлюз** (`tg-gateway`): `location /bot-api/` → `api.telegram.org` + Traefik-роутер с `ipAllowList` на IP app-сервера. ✅ задеплоен, проверен (`getMe` → `ok:true`).
2. **App**: env `TELEGRAM_API_BASE_URL` (параметр+bind), убран хардкод `https://api.telegram.org` в `TelegramWebhookController` и `TelegramBotController`.
3. **Прод**: `TELEGRAM_API_BASE_URL=https://tg.vashfindir.ru/bot-api` в `docker-compose.prod.yml` (x-php-env + scheduler); дозакрыт хардкод в `SendTelegramReportsCommand`.

## Тесты
`tests/Telegram/Functional` — 7/7. CS чисто. Прод-smoke `getMe` через шлюз — `ok:true`.

## После merge (cutover)
1. Деплой app (этот merge).
2. Админка → «Установить webhook» (теперь идёт через шлюз).
3. «Проверить webhook» → url шлюзовой, без ошибок.
4. Написать боту → ответ.

Подробности: `docs/tasks/TG-API-EGRESS-PROXY/handoff.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)