### PR TITLE
fix(telegram): знак +/- приоритетнее ключевых слов при определении ДДС

### DIFF
--- a/site/src/Telegram/Application/CreateTelegramCashTransactionAction.php
+++ b/site/src/Telegram/Application/CreateTelegramCashTransactionAction.php
@@ -110,6 +110,13 @@ final readonly class CreateTelegramCashTransactionAction
 
     private function detectDirection(string $text): CashDirection
     {
+        // Явный знак перед суммой имеет приоритет над ключевыми словами:
+        // "+1000 оплата прочие" — доход, "-3500 реклама" — расход.
+        if (preg_match('/([+\-])\s*\d/u', $text, $matches)) {
+            return '+' === $matches[1] ? CashDirection::INFLOW : CashDirection::OUTFLOW;
+        }
+
+        // Без знака — эвристика по ключевым словам.
         $normalized = mb_strtolower($text);
 
         if (preg_match('/потрат|расход|купил|оплат/u', $normalized)) {

--- a/site/tests/Telegram/Functional/TelegramWebhookCashTransactionTest.php
+++ b/site/tests/Telegram/Functional/TelegramWebhookCashTransactionTest.php
@@ -85,6 +85,40 @@ final class TelegramWebhookCashTransactionTest extends WebTestCaseBase
         self::assertSame(1, $this->countCashTransactions());
     }
 
+    public function testPlusSignMeansInflowEvenWithPaymentWord(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $this->seedBoundUserWithAccount(financeLockBefore: null);
+
+        $captured = [];
+        $this->captureTelegramCalls($client, $captured);
+
+        // "+" имеет приоритет над словом "оплата" (которое само по себе → расход)
+        $this->postUpdate($client, '+1000 оплата прочие');
+
+        self::assertResponseIsSuccessful();
+        $body = $this->lastSentMessageText($captured);
+        self::assertStringContainsString('доход', $body);
+        self::assertStringNotContainsString('расход', $body);
+    }
+
+    public function testMinusSignMeansOutflow(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $this->seedBoundUserWithAccount(financeLockBefore: null);
+
+        $captured = [];
+        $this->captureTelegramCalls($client, $captured);
+
+        $this->postUpdate($client, '-500 поступление прочие');
+
+        self::assertResponseIsSuccessful();
+        $body = $this->lastSentMessageText($captured);
+        self::assertStringContainsString('расход', $body);
+    }
+
     private function seedBoundUserWithAccount(?\DateTimeImmutable $financeLockBefore): void
     {
         $em = $this->em();


### PR DESCRIPTION
## Баг
«+1000 оплата прочие» → сервис отвечал «Записал расход»: слово «оплат» в `detectDirection` перебивало явный знак «+».

## Фикс
Явный знак перед суммой имеет приоритет: `+` → доход, `-` → расход. Ключевые слова — только fallback при отсутствии знака. Соответствует подсказке самого бота (`+120000 оплата от клиента` = доход).

## Тесты
Добавлены регрессионные (красные на старом коде):
- `+1000 оплата прочие` → доход;
- `-500 поступление прочие` → расход (знак перебивает слово «поступ»).

`tests/Telegram/Functional` — 9/9. CS чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)