### PR TITLE
[codex] Add WB finance raw ingestion

### DIFF
--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -153,7 +153,7 @@ services:
 
     App\Ingestion\Infrastructure\Api\Wildberries\WbFinanceReportClient:
         arguments:
-            $rateLimiterFactory: '@limiter.wb_finance'
+            $rateLimiter: '@App\Marketplace\Application\Service\WbFinanceRateLimiter'
 
     App\Ingestion\Application\Source\Ozon\OzonSellerReportConnector:
         arguments:

--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -148,11 +148,22 @@ services:
 
     App\Ingestion\Infrastructure\Api\Ozon\OzonCredentialProviderInterface: '@App\Ingestion\Infrastructure\Api\Ozon\CredentialFacadeOzonCredentialProvider'
     App\Ingestion\Infrastructure\Api\Ozon\OzonAccrualClientInterface: '@App\Ingestion\Infrastructure\Api\Ozon\OzonAccrualClient'
+    App\Ingestion\Infrastructure\Api\Wildberries\WbCredentialProviderInterface: '@App\Ingestion\Infrastructure\Api\Wildberries\CredentialFacadeWbCredentialProvider'
+    App\Ingestion\Infrastructure\Api\Wildberries\WbFinanceReportClientInterface: '@App\Ingestion\Infrastructure\Api\Wildberries\WbFinanceReportClient'
+
+    App\Ingestion\Infrastructure\Api\Wildberries\WbFinanceReportClient:
+        arguments:
+            $rateLimiterFactory: '@limiter.wb_finance'
 
     App\Ingestion\Application\Source\Ozon\OzonSellerReportConnector:
         arguments:
             $chunkSizeDays: 7
             $hotRewindDays: 14
+        tags: ['app.ingestion.connector']
+
+    App\Ingestion\Application\Source\Wildberries\WbFinanceReportConnector:
+        arguments:
+            $continuationDelaySeconds: '%wb_finance.rate_limit_interval_seconds%'
         tags: ['app.ingestion.connector']
 
     App\Ingestion\Application\Source\Ozon\OzonAccrualByDayMapper:

--- a/site/config/services_test.yaml
+++ b/site/config/services_test.yaml
@@ -12,6 +12,9 @@ services:
     App\Tests\Integration\Ingestion\Fixtures\FakeMapper:
         tags: ['app.ingestion.mapper']
 
+    App\Ingestion\Application\Source\Wildberries\WbFinanceReportConnector:
+        tags: []
+
     App\Ingestion\Infrastructure\Api\Ozon\OzonAccrualClientInterface: '@App\Tests\Integration\Ingestion\Fixtures\FakeOzonAccrualClient'
 
     test.ingestion_lock_store:

--- a/site/src/Ingestion/Application/DTO/PullResult.php
+++ b/site/src/Ingestion/Application/DTO/PullResult.php
@@ -12,6 +12,8 @@ final readonly class PullResult
         public RawBatch $rawBatch,
         public ?string $nextCursorValue,
         public bool $hasMore,
+        public bool $normalizeRawRecords = true,
+        public ?int $continuationDelaySeconds = null,
     ) {
     }
 }

--- a/site/src/Ingestion/Application/Source/Wildberries/WbFinanceReportConnector.php
+++ b/site/src/Ingestion/Application/Source/Wildberries/WbFinanceReportConnector.php
@@ -15,11 +15,13 @@ use App\Ingestion\Enum\Capability;
 use App\Ingestion\Enum\IngestSource;
 use App\Ingestion\Exception\UnsupportedCapabilityException;
 use App\Ingestion\Infrastructure\Api\Wildberries\WbFinanceReportClientInterface;
+use Symfony\Component\Clock\ClockInterface;
 
 final readonly class WbFinanceReportConnector implements SourceConnectorInterface
 {
     public function __construct(
         private WbFinanceReportClientInterface $client,
+        private ClockInterface $clock,
         private int $continuationDelaySeconds = 70,
     ) {
     }
@@ -147,7 +149,13 @@ final readonly class WbFinanceReportConnector implements SourceConnectorInterfac
             return null;
         }
 
-        return $date->modify('+1 day')->format('Y-m-d');
+        $nextDate = $date->modify('+1 day')->setTime(0, 0);
+        $yesterday = $this->clock->now()->modify('-1 day')->setTime(0, 0);
+        if ($nextDate > $yesterday) {
+            return null;
+        }
+
+        return $nextDate->format('Y-m-d');
     }
 
     private function date(string $value): \DateTimeImmutable
@@ -192,7 +200,6 @@ final readonly class WbFinanceReportConnector implements SourceConnectorInterfac
         return array_map(
             static fn (array $row): array => $row + [
                 '_ingestion_resource' => WbResourceType::FINANCE_SALES_REPORT_DETAILED,
-                '_ingestion_metadata' => $metadata,
             ],
             $rows,
         );

--- a/site/src/Ingestion/Application/Source/Wildberries/WbFinanceReportConnector.php
+++ b/site/src/Ingestion/Application/Source/Wildberries/WbFinanceReportConnector.php
@@ -150,8 +150,8 @@ final readonly class WbFinanceReportConnector implements SourceConnectorInterfac
         }
 
         $nextDate = $date->modify('+1 day')->setTime(0, 0);
-        $yesterday = $this->clock->now()->modify('-1 day')->setTime(0, 0);
-        if ($nextDate > $yesterday) {
+        $today = $this->clock->now()->setTime(0, 0);
+        if ($nextDate > $today) {
             return null;
         }
 

--- a/site/src/Ingestion/Application/Source/Wildberries/WbFinanceReportConnector.php
+++ b/site/src/Ingestion/Application/Source/Wildberries/WbFinanceReportConnector.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Source\Wildberries;
+
+use App\Ingestion\Application\DTO\PullRequest;
+use App\Ingestion\Application\DTO\PullResult;
+use App\Ingestion\Application\DTO\PushRequest;
+use App\Ingestion\Application\DTO\PushResult;
+use App\Ingestion\Application\DTO\ShopDescriptor;
+use App\Ingestion\Domain\Contract\SourceConnectorInterface;
+use App\Ingestion\DTO\RawBatch;
+use App\Ingestion\Enum\Capability;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Exception\UnsupportedCapabilityException;
+use App\Ingestion\Infrastructure\Api\Wildberries\WbFinanceReportClientInterface;
+
+final readonly class WbFinanceReportConnector implements SourceConnectorInterface
+{
+    public function __construct(
+        private WbFinanceReportClientInterface $client,
+        private int $continuationDelaySeconds = 70,
+    ) {
+    }
+
+    public function source(): IngestSource
+    {
+        return IngestSource::WILDBERRIES;
+    }
+
+    /**
+     * @return list<Capability>
+     */
+    public function capabilities(): array
+    {
+        return [Capability::CAN_DISCOVER_SHOPS, Capability::CAN_PULL];
+    }
+
+    /**
+     * @return list<ShopDescriptor>
+     */
+    public function discoverShops(string $companyId, string $connectionRef): array
+    {
+        return [
+            new ShopDescriptor(
+                externalId: $connectionRef,
+                name: 'Wildberries Seller',
+                currency: 'RUB',
+                metadata: ['connectionRef' => $connectionRef],
+            ),
+        ];
+    }
+
+    public function pull(PullRequest $request): PullResult
+    {
+        if (WbResourceType::FINANCE_SALES_REPORT_DETAILED !== $request->resourceType) {
+            throw new \InvalidArgumentException(sprintf('Unsupported Wildberries resource type "%s".', $request->resourceType));
+        }
+
+        [$date, $rrdId] = $this->resolveCursor($request);
+        $page = $this->client->fetchDetailedDayPage($request->companyId, $request->connectionRef, $date, $rrdId);
+        $nextCursor = $page->hasMore && null !== $page->nextRrdId
+            ? $this->encodeCursor($date, $page->nextRrdId)
+            : $this->nextIncrementalDateCursor($request, $date, $page->hasMore);
+
+        return new PullResult(
+            rawBatch: new RawBatch(
+                companyId: $request->companyId,
+                connectionRef: $request->connectionRef,
+                shopRef: $request->shopRef,
+                source: IngestSource::WILDBERRIES,
+                resourceType: WbResourceType::FINANCE_SALES_REPORT_DETAILED,
+                externalId: sprintf('wb-sales-report-detailed:%s:rrd-%d', $date->format('Y-m-d'), $rrdId),
+                syncJobId: $request->syncJobId,
+                fetchedAt: new \DateTimeImmutable(),
+                rows: $this->rowsOrEmptyMarker($page->rows, $page->metadata),
+            ),
+            nextCursorValue: $nextCursor,
+            hasMore: $page->hasMore,
+            normalizeRawRecords: false,
+            continuationDelaySeconds: $page->hasMore ? $this->continuationDelaySeconds : null,
+        );
+    }
+
+    public function push(PushRequest $request): PushResult
+    {
+        throw new UnsupportedCapabilityException('Wildberries finance connector does not support push operations.');
+    }
+
+    /**
+     * @return array{0: \DateTimeImmutable, 1: int}
+     */
+    private function resolveCursor(PullRequest $request): array
+    {
+        if (null !== $request->cursorValue && '' !== $request->cursorValue) {
+            return $this->decodeCursor($request->cursorValue);
+        }
+
+        if (null !== $request->windowFrom) {
+            $from = $request->windowFrom->setTime(0, 0);
+            $to = ($request->windowTo ?? $request->windowFrom)->setTime(0, 0);
+            if ($from != $to) {
+                throw new \InvalidArgumentException('Wildberries finance report backfill expects one-day chunks.');
+            }
+
+            return [$from, 0];
+        }
+
+        $yesterday = (new \DateTimeImmutable('today'))->modify('-1 day')->setTime(0, 0);
+
+        return [$yesterday, 0];
+    }
+
+    /**
+     * @return array{0: \DateTimeImmutable, 1: int}
+     */
+    private function decodeCursor(string $cursorValue): array
+    {
+        try {
+            $payload = json_decode($cursorValue, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            $payload = null;
+        }
+
+        if (is_array($payload)) {
+            $date = (string) ($payload['date'] ?? '');
+            $rrdId = $payload['rrdId'] ?? 0;
+
+            return [$this->date($date), $this->rrdId($rrdId)];
+        }
+
+        return [$this->date($cursorValue), 0];
+    }
+
+    private function encodeCursor(\DateTimeImmutable $date, int $rrdId): string
+    {
+        return json_encode([
+            'date' => $date->format('Y-m-d'),
+            'rrdId' => $rrdId,
+        ], \JSON_THROW_ON_ERROR);
+    }
+
+    private function nextIncrementalDateCursor(PullRequest $request, \DateTimeImmutable $date, bool $hasMore): ?string
+    {
+        if ($hasMore || null !== $request->windowFrom || null !== $request->windowTo) {
+            return null;
+        }
+
+        return $date->modify('+1 day')->format('Y-m-d');
+    }
+
+    private function date(string $value): \DateTimeImmutable
+    {
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
+        if (false === $date || $date->format('Y-m-d') !== $value) {
+            throw new \InvalidArgumentException('Wildberries finance report cursor date must be YYYY-MM-DD.');
+        }
+
+        return $date;
+    }
+
+    private function rrdId(mixed $value): int
+    {
+        if (is_int($value) && $value >= 0) {
+            return $value;
+        }
+
+        if (is_string($value) && ctype_digit($value)) {
+            return (int) $value;
+        }
+
+        throw new \InvalidArgumentException('Wildberries finance report cursor rrdId must be a non-negative integer.');
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     * @param array<string, mixed>       $metadata
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function rowsOrEmptyMarker(array $rows, array $metadata): array
+    {
+        if ([] === $rows) {
+            return [[
+                '_ingestion_empty' => true,
+                '_ingestion_resource' => WbResourceType::FINANCE_SALES_REPORT_DETAILED,
+                '_ingestion_metadata' => $metadata,
+            ]];
+        }
+
+        return array_map(
+            static fn (array $row): array => $row + [
+                '_ingestion_resource' => WbResourceType::FINANCE_SALES_REPORT_DETAILED,
+                '_ingestion_metadata' => $metadata,
+            ],
+            $rows,
+        );
+    }
+}

--- a/site/src/Ingestion/Application/Source/Wildberries/WbResourceType.php
+++ b/site/src/Ingestion/Application/Source/Wildberries/WbResourceType.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Source\Wildberries;
+
+final class WbResourceType
+{
+    public const FINANCE_SALES_REPORT_DETAILED = 'wildberries_finance_sales_report_detailed';
+}

--- a/site/src/Ingestion/Command/NormalizePendingRawRecordsCommand.php
+++ b/site/src/Ingestion/Command/NormalizePendingRawRecordsCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Ingestion\Command;
 
+use App\Ingestion\Domain\Service\MapperRegistry;
 use App\Ingestion\Message\NormalizeRawRecordMessage;
 use App\Ingestion\Repository\IngestRawRecordRepository;
 use Psr\Log\LoggerInterface;
@@ -23,6 +24,7 @@ final class NormalizePendingRawRecordsCommand extends Command
 {
     public function __construct(
         private readonly IngestRawRecordRepository $rawRecordRepository,
+        private readonly MapperRegistry $mapperRegistry,
         private readonly MessageBusInterface $messageBus,
         private readonly LoggerInterface $logger,
     ) {
@@ -70,6 +72,17 @@ final class NormalizePendingRawRecordsCommand extends Command
         $rawRecordIds = [];
         $dispatched = 0;
         foreach ($records as $record) {
+            if (!$this->mapperRegistry->has($record->getSource(), $record->getResourceType())) {
+                $this->logger->debug('Stale pending ingestion raw record skipped because mapper is not registered.', [
+                    'companyId' => $record->getCompanyId(),
+                    'rawRecordId' => $record->getId(),
+                    'source' => $record->getSource()->value,
+                    'resourceType' => $record->getResourceType(),
+                ]);
+
+                continue;
+            }
+
             $rawRecordIds[] = $record->getId();
 
             try {

--- a/site/src/Ingestion/Command/StartBackfillCommand.php
+++ b/site/src/Ingestion/Command/StartBackfillCommand.php
@@ -6,6 +6,7 @@ namespace App\Ingestion\Command;
 
 use App\Ingestion\Application\Command\StartBackfillCommand as StartBackfillApplicationCommand;
 use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Application\Source\Wildberries\WbResourceType;
 use App\Ingestion\Domain\Service\ConnectorRegistry;
 use App\Ingestion\Enum\IngestSource;
 use App\Ingestion\Exception\ActiveBackfillExistsException;
@@ -33,6 +34,9 @@ final class StartBackfillCommand extends Command
         'ozon' => [
             OzonResourceType::ACCRUAL_BY_DAY,
         ],
+        'wildberries' => [
+            WbResourceType::FINANCE_SALES_REPORT_DETAILED,
+        ],
     ];
 
     /**
@@ -41,6 +45,9 @@ final class StartBackfillCommand extends Command
     private const ALLOWED_RESOURCE_TYPES_BY_SOURCE = [
         'ozon' => [
             OzonResourceType::ACCRUAL_BY_DAY,
+        ],
+        'wildberries' => [
+            WbResourceType::FINANCE_SALES_REPORT_DETAILED,
         ],
     ];
 
@@ -57,7 +64,7 @@ final class StartBackfillCommand extends Command
         $this
             ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Company UUID.')
             ->addOption('connection-ref', null, InputOption::VALUE_REQUIRED, 'Marketplace connection UUID.')
-            ->addOption('source', null, InputOption::VALUE_REQUIRED, 'Ingestion source, for example "ozon".')
+            ->addOption('source', null, InputOption::VALUE_REQUIRED, 'Ingestion source, for example "ozon" or "wildberries".')
             ->addOption('days-back', null, InputOption::VALUE_REQUIRED, 'Backfill depth in days, 1..365.', 30)
             ->addOption('shop-ref', null, InputOption::VALUE_REQUIRED, 'Optional concrete shop reference.')
             ->addOption('resource-type', null, InputOption::VALUE_REQUIRED, 'Optional concrete resource type.')

--- a/site/src/Ingestion/Command/WbFinanceProbeCommand.php
+++ b/site/src/Ingestion/Command/WbFinanceProbeCommand.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Command;
+
+use App\Ingestion\Infrastructure\Api\Wildberries\WbFinanceReportClientInterface;
+use App\Ingestion\Infrastructure\Api\Wildberries\WbFinanceReportPage;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Webmozart\Assert\Assert;
+
+#[AsCommand(
+    name: 'app:ingestion:wb-finance:probe',
+    description: 'Reads one Wildberries finance report page without writing anything to storage.',
+)]
+final class WbFinanceProbeCommand extends Command
+{
+    public function __construct(private readonly WbFinanceReportClientInterface $client)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Company UUID.')
+            ->addOption('connection-ref', null, InputOption::VALUE_REQUIRED, 'Marketplace connection UUID.')
+            ->addOption('date', null, InputOption::VALUE_REQUIRED, 'Report date YYYY-MM-DD.')
+            ->addOption('rrd-id', null, InputOption::VALUE_REQUIRED, 'Page cursor rrdId.', 0)
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'API page limit, 1..100000.', 100000)
+            ->addOption('sample-limit', null, InputOption::VALUE_REQUIRED, 'Sample rows to show, 1..20.', 5)
+            ->addOption('with-values', null, InputOption::VALUE_NONE, 'Print truncated sample JSON values. By default only keys are shown.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        try {
+            $companyId = $this->requiredUuidOption($input, 'company-id');
+            $connectionRef = $this->requiredUuidOption($input, 'connection-ref');
+            $date = $this->requiredDateOption($input, 'date');
+            $rrdId = $this->intOption($input, 'rrd-id', 0, PHP_INT_MAX);
+            $limit = $this->intOption($input, 'limit', 1, 100000);
+            $sampleLimit = $this->intOption($input, 'sample-limit', 1, 20);
+
+            $page = $this->client->fetchDetailedDayPage($companyId, $connectionRef, $date, $rrdId, $limit);
+        } catch (\Throwable $exception) {
+            $io->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $io->title('Wildberries finance report probe');
+        $io->table(
+            ['date', 'rrdId', 'rows', 'hasMore', 'nextRrdId'],
+            [[
+                $date->format('Y-m-d'),
+                (string) $rrdId,
+                (string) count($page->rows),
+                $page->hasMore ? 'yes' : 'no',
+                null !== $page->nextRrdId ? (string) $page->nextRrdId : '',
+            ]],
+        );
+
+        if ([] !== $page->metadata) {
+            $io->section('API metadata');
+            $io->writeln($this->json($page->metadata));
+        }
+
+        $this->printSamples($io, $page, $sampleLimit, (bool) $input->getOption('with-values'));
+
+        return Command::SUCCESS;
+    }
+
+    private function requiredUuidOption(InputInterface $input, string $name): string
+    {
+        $value = trim((string) $input->getOption($name));
+        Assert::uuid($value, sprintf('Invalid --%s UUID.', $name));
+
+        return $value;
+    }
+
+    private function requiredDateOption(InputInterface $input, string $name): \DateTimeImmutable
+    {
+        $value = trim((string) $input->getOption($name));
+        Assert::notEmpty($value, sprintf('The --%s option is required.', $name));
+
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
+        if (false === $date || $date->format('Y-m-d') !== $value) {
+            throw new \InvalidArgumentException(sprintf('The --%s option must be a YYYY-MM-DD date.', $name));
+        }
+
+        return $date;
+    }
+
+    private function intOption(InputInterface $input, string $name, int $min, int $max): int
+    {
+        $value = (string) $input->getOption($name);
+        if (!ctype_digit($value)) {
+            throw new \InvalidArgumentException(sprintf('The --%s option must be an integer.', $name));
+        }
+
+        $number = (int) $value;
+        if ($number < $min || $number > $max) {
+            throw new \InvalidArgumentException(sprintf('The --%s option must be between %d and %d.', $name, $min, $max));
+        }
+
+        return $number;
+    }
+
+    private function printSamples(SymfonyStyle $io, WbFinanceReportPage $page, int $limit, bool $withValues): void
+    {
+        if ([] === $page->rows) {
+            $io->note('Endpoint returned no rows.');
+
+            return;
+        }
+
+        $rows = [];
+        foreach (array_slice($page->rows, 0, $limit) as $index => $row) {
+            $keys = array_keys($row);
+            sort($keys);
+
+            $rows[] = [
+                (string) ($index + 1),
+                implode(', ', $keys),
+                $withValues ? $this->truncate($this->json($row), 2000) : '',
+            ];
+        }
+
+        $io->section('Sample rows');
+        $io->table($withValues ? ['#', 'keys', 'json'] : ['#', 'keys'], array_map(
+            static fn (array $row): array => $withValues ? $row : [$row[0], $row[1]],
+            $rows,
+        ));
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function json(array $payload): string
+    {
+        return json_encode($payload, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES | \JSON_PRETTY_PRINT);
+    }
+
+    private function truncate(string $value, int $maxLength): string
+    {
+        if (mb_strlen($value) <= $maxLength) {
+            return $value;
+        }
+
+        return mb_substr($value, 0, $maxLength - 3).'...';
+    }
+}

--- a/site/src/Ingestion/Command/WbFinanceStatusCommand.php
+++ b/site/src/Ingestion/Command/WbFinanceStatusCommand.php
@@ -1,0 +1,325 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Command;
+
+use App\Ingestion\Application\Source\Wildberries\WbResourceType;
+use App\Ingestion\Enum\IngestSource;
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Webmozart\Assert\Assert;
+
+#[AsCommand(
+    name: 'app:ingestion:wb-finance:status',
+    description: 'Shows Wildberries finance ingestion jobs and raw storage status.',
+)]
+final class WbFinanceStatusCommand extends Command
+{
+    /**
+     * @var list<string>
+     */
+    private const RESOURCE_TYPES = [
+        WbResourceType::FINANCE_SALES_REPORT_DETAILED,
+    ];
+
+    public function __construct(private readonly Connection $connection)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Company UUID.')
+            ->addOption('from', null, InputOption::VALUE_REQUIRED, 'Optional job window start date YYYY-MM-DD.')
+            ->addOption('to', null, InputOption::VALUE_REQUIRED, 'Optional job window end date YYYY-MM-DD.')
+            ->addOption('resource-type', null, InputOption::VALUE_REQUIRED, 'Optional resource type filter.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        try {
+            $companyId = $this->requiredUuidOption($input, 'company-id');
+            $resourceTypes = $this->resourceTypes($input);
+            [$from, $to] = $this->dateWindow($input);
+        } catch (\Throwable $exception) {
+            $io->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $io->title('Wildberries finance ingestion status');
+        $this->printJobs($io, $companyId, $resourceTypes, $from, $to);
+        $this->printRawRecords($io, $companyId, $resourceTypes, $from, $to);
+        $this->printLatestErrors($io, $companyId, $resourceTypes, $from, $to);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param list<string> $resourceTypes
+     */
+    private function printJobs(
+        SymfonyStyle $io,
+        string $companyId,
+        array $resourceTypes,
+        ?\DateTimeImmutable $from,
+        ?\DateTimeImmutable $to,
+    ): void {
+        [$conditions, $params, $types] = $this->jobFilter($companyId, $resourceTypes, $from, $to);
+
+        $rows = $this->connection->fetchAllAssociative(
+            sprintf(
+                'SELECT resource_type, status, COUNT(*) AS jobs, COALESCE(SUM(progress_total), 0) AS progress_total, COALESCE(SUM(progress_done), 0) AS progress_done, MAX(updated_at) AS latest_update
+                 FROM ingest_sync_jobs
+                 WHERE %s
+                 GROUP BY resource_type, status
+                 ORDER BY resource_type, status',
+                implode(' AND ', $conditions),
+            ),
+            $params,
+            $types,
+        );
+
+        $io->section('Sync jobs');
+        if ([] === $rows) {
+            $io->writeln('No jobs found.');
+
+            return;
+        }
+
+        $io->table(
+            ['resourceType', 'status', 'jobs', 'progress', 'latestUpdate'],
+            array_map(static fn (array $row): array => [
+                (string) $row['resource_type'],
+                (string) $row['status'],
+                (string) $row['jobs'],
+                sprintf('%s/%s', (string) $row['progress_done'], (string) $row['progress_total']),
+                (string) ($row['latest_update'] ?? ''),
+            ], $rows),
+        );
+    }
+
+    /**
+     * @param list<string> $resourceTypes
+     */
+    private function printRawRecords(
+        SymfonyStyle $io,
+        string $companyId,
+        array $resourceTypes,
+        ?\DateTimeImmutable $from,
+        ?\DateTimeImmutable $to,
+    ): void {
+        $conditions = [
+            'r.company_id = :companyId',
+            'r.source = :source',
+            'r.resource_type IN (:resourceTypes)',
+        ];
+        $params = [
+            'companyId' => $companyId,
+            'source' => IngestSource::WILDBERRIES->value,
+            'resourceTypes' => $resourceTypes,
+        ];
+        $types = ['resourceTypes' => ArrayParameterType::STRING];
+
+        if (null !== $from && null !== $to) {
+            $conditions[] = '(j.id IS NULL OR j.window_from IS NULL OR j.window_to IS NULL OR (j.window_from <= :toDate AND j.window_to >= :fromDate))';
+            $params['fromDate'] = $from->format('Y-m-d');
+            $params['toDate'] = $to->format('Y-m-d');
+        }
+
+        $rows = $this->connection->fetchAllAssociative(
+            sprintf(
+                "SELECT r.resource_type,
+                        COUNT(*) AS raw_records,
+                        COALESCE(SUM(r.byte_size), 0) AS byte_size,
+                        MAX(r.fetched_at) AS last_fetched_at,
+                        COUNT(*) FILTER (WHERE r.normalization_status = 'pending') AS pending_raw,
+                        COUNT(*) FILTER (WHERE r.normalization_status = 'done') AS done_raw,
+                        COUNT(*) FILTER (WHERE r.normalization_status = 'failed') AS failed_raw
+                 FROM ingest_raw_records r
+                 LEFT JOIN ingest_sync_jobs j ON j.id::text = r.sync_job_id AND j.company_id = r.company_id
+                 WHERE %s
+                 GROUP BY r.resource_type
+                 ORDER BY r.resource_type",
+                implode(' AND ', $conditions),
+            ),
+            $params,
+            $types,
+        );
+
+        $io->section('Raw records');
+        if ([] === $rows) {
+            $io->writeln('No raw records found.');
+
+            return;
+        }
+
+        $io->table(
+            ['resourceType', 'raw', 'pending', 'done', 'failed', 'bytes', 'lastFetchedAt'],
+            array_map(static fn (array $row): array => [
+                (string) $row['resource_type'],
+                (string) $row['raw_records'],
+                (string) $row['pending_raw'],
+                (string) $row['done_raw'],
+                (string) $row['failed_raw'],
+                (string) $row['byte_size'],
+                (string) ($row['last_fetched_at'] ?? ''),
+            ], $rows),
+        );
+    }
+
+    /**
+     * @param list<string> $resourceTypes
+     */
+    private function printLatestErrors(
+        SymfonyStyle $io,
+        string $companyId,
+        array $resourceTypes,
+        ?\DateTimeImmutable $from,
+        ?\DateTimeImmutable $to,
+    ): void {
+        [$conditions, $params, $types] = $this->jobFilter($companyId, $resourceTypes, $from, $to);
+        $conditions[] = 'last_error IS NOT NULL';
+
+        $rows = $this->connection->fetchAllAssociative(
+            sprintf(
+                'SELECT id, resource_type, status, updated_at, last_error
+                 FROM ingest_sync_jobs
+                 WHERE %s
+                 ORDER BY updated_at DESC
+                 LIMIT 10',
+                implode(' AND ', $conditions),
+            ),
+            $params,
+            $types,
+        );
+
+        $io->section('Latest job errors');
+        if ([] === $rows) {
+            $io->writeln('No job errors found.');
+
+            return;
+        }
+
+        $io->table(
+            ['jobId', 'resourceType', 'status', 'updatedAt', 'error'],
+            array_map(fn (array $row): array => [
+                (string) $row['id'],
+                (string) $row['resource_type'],
+                (string) $row['status'],
+                (string) $row['updated_at'],
+                $this->truncate((string) $row['last_error'], 180),
+            ], $rows),
+        );
+    }
+
+    private function requiredUuidOption(InputInterface $input, string $name): string
+    {
+        $value = trim((string) $input->getOption($name));
+        Assert::uuid($value, sprintf('Invalid --%s UUID.', $name));
+
+        return $value;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function resourceTypes(InputInterface $input): array
+    {
+        $requested = trim((string) $input->getOption('resource-type'));
+        if ('' === $requested) {
+            return self::RESOURCE_TYPES;
+        }
+
+        if (!in_array($requested, self::RESOURCE_TYPES, true)) {
+            throw new \InvalidArgumentException(sprintf('Unsupported Wildberries finance resource type "%s".', $requested));
+        }
+
+        return [$requested];
+    }
+
+    /**
+     * @return array{0: ?\DateTimeImmutable, 1: ?\DateTimeImmutable}
+     */
+    private function dateWindow(InputInterface $input): array
+    {
+        $fromValue = trim((string) $input->getOption('from'));
+        $toValue = trim((string) $input->getOption('to'));
+        if ('' === $fromValue && '' === $toValue) {
+            return [null, null];
+        }
+
+        if ('' === $fromValue || '' === $toValue) {
+            throw new \InvalidArgumentException('Both --from and --to must be provided together.');
+        }
+
+        $from = $this->date($fromValue, 'from');
+        $to = $this->date($toValue, 'to');
+        if ($from > $to) {
+            throw new \InvalidArgumentException('The --from date cannot be later than --to.');
+        }
+
+        return [$from, $to];
+    }
+
+    private function date(string $value, string $name): \DateTimeImmutable
+    {
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
+        if (false === $date || $date->format('Y-m-d') !== $value) {
+            throw new \InvalidArgumentException(sprintf('The --%s option must be a YYYY-MM-DD date.', $name));
+        }
+
+        return $date;
+    }
+
+    /**
+     * @param list<string> $resourceTypes
+     *
+     * @return array{0: list<string>, 1: array<string, mixed>, 2: array<string, mixed>}
+     */
+    private function jobFilter(
+        string $companyId,
+        array $resourceTypes,
+        ?\DateTimeImmutable $from,
+        ?\DateTimeImmutable $to,
+    ): array {
+        $conditions = [
+            'company_id = :companyId',
+            'source = :source',
+            'resource_type IN (:resourceTypes)',
+        ];
+        $params = [
+            'companyId' => $companyId,
+            'source' => IngestSource::WILDBERRIES->value,
+            'resourceTypes' => $resourceTypes,
+        ];
+        $types = ['resourceTypes' => ArrayParameterType::STRING];
+
+        if (null !== $from && null !== $to) {
+            $conditions[] = '(window_from IS NULL OR window_to IS NULL OR (window_from <= :toDate AND window_to >= :fromDate))';
+            $params['fromDate'] = $from->format('Y-m-d');
+            $params['toDate'] = $to->format('Y-m-d');
+        }
+
+        return [$conditions, $params, $types];
+    }
+
+    private function truncate(string $value, int $maxLength): string
+    {
+        if (mb_strlen($value) <= $maxLength) {
+            return $value;
+        }
+
+        return mb_substr($value, 0, $maxLength - 3).'...';
+    }
+}

--- a/site/src/Ingestion/Command/WbFinanceStatusCommand.php
+++ b/site/src/Ingestion/Command/WbFinanceStatusCommand.php
@@ -144,6 +144,7 @@ final class WbFinanceStatusCommand extends Command
                         COALESCE(SUM(r.byte_size), 0) AS byte_size,
                         MAX(r.fetched_at) AS last_fetched_at,
                         COUNT(*) FILTER (WHERE r.normalization_status = 'pending') AS pending_raw,
+                        COUNT(*) FILTER (WHERE r.normalization_status = 'skipped') AS skipped_raw,
                         COUNT(*) FILTER (WHERE r.normalization_status = 'done') AS done_raw,
                         COUNT(*) FILTER (WHERE r.normalization_status = 'failed') AS failed_raw
                  FROM ingest_raw_records r
@@ -165,11 +166,12 @@ final class WbFinanceStatusCommand extends Command
         }
 
         $io->table(
-            ['resourceType', 'raw', 'pending', 'done', 'failed', 'bytes', 'lastFetchedAt'],
+            ['resourceType', 'raw', 'pending', 'skipped', 'done', 'failed', 'bytes', 'lastFetchedAt'],
             array_map(static fn (array $row): array => [
                 (string) $row['resource_type'],
                 (string) $row['raw_records'],
                 (string) $row['pending_raw'],
+                (string) $row['skipped_raw'],
                 (string) $row['done_raw'],
                 (string) $row['failed_raw'],
                 (string) $row['byte_size'],

--- a/site/src/Ingestion/Domain/Service/MapperRegistry.php
+++ b/site/src/Ingestion/Domain/Service/MapperRegistry.php
@@ -37,4 +37,9 @@ final class MapperRegistry
         return $this->mappers[$source->value][$resourceType]
             ?? throw new MapperNotFoundException(sprintf('Mapper for source "%s" and resource "%s" was not found.', $source->value, $resourceType));
     }
+
+    public function has(IngestSource $source, string $resourceType): bool
+    {
+        return isset($this->mappers[$source->value][$resourceType]);
+    }
 }

--- a/site/src/Ingestion/Entity/IngestRawRecord.php
+++ b/site/src/Ingestion/Entity/IngestRawRecord.php
@@ -203,6 +203,12 @@ class IngestRawRecord implements TenantOwnedInterface
         $this->updatedAt = new \DateTimeImmutable();
     }
 
+    public function markNormalizationSkipped(): void
+    {
+        $this->normalizationStatus = RawNormalizationStatus::SKIPPED;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
     public function markNormalizationFailed(): void
     {
         $this->normalizationStatus = RawNormalizationStatus::FAILED;

--- a/site/src/Ingestion/Enum/RawNormalizationStatus.php
+++ b/site/src/Ingestion/Enum/RawNormalizationStatus.php
@@ -7,6 +7,7 @@ namespace App\Ingestion\Enum;
 enum RawNormalizationStatus: string
 {
     case PENDING = 'pending';
+    case SKIPPED = 'skipped';
     case DONE = 'done';
     case FAILED = 'failed';
 }

--- a/site/src/Ingestion/Exception/ConnectorRateLimitedException.php
+++ b/site/src/Ingestion/Exception/ConnectorRateLimitedException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Exception;
+
+final class ConnectorRateLimitedException extends \RuntimeException
+{
+    public function __construct(
+        string $message,
+        private readonly int $retryAfterSeconds,
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
+
+    public function retryAfterSeconds(): int
+    {
+        return max(1, $this->retryAfterSeconds);
+    }
+}

--- a/site/src/Ingestion/Facade/SyncFacade.php
+++ b/site/src/Ingestion/Facade/SyncFacade.php
@@ -19,6 +19,7 @@ use App\Ingestion\Application\Command\StartBackfillCommand;
 use App\Ingestion\Application\Command\StartIncrementalCommand;
 use App\Ingestion\Application\Command\UpdateCursorCommand;
 use App\Ingestion\Application\DTO\SyncJobProgressView;
+use App\Ingestion\Application\Source\Wildberries\WbResourceType;
 use App\Ingestion\Exception\SyncJobNotFoundException;
 use App\Ingestion\Repository\SyncJobRepository;
 
@@ -39,7 +40,11 @@ final readonly class SyncFacade
     public function startBackfill(StartBackfillCommand $command): string
     {
         $parentJobId = ($this->startBackfillAction)($command);
-        ($this->splitJobIntoChunksAction)(new SplitJobCommand($parentJobId, $command->companyId));
+        ($this->splitJobIntoChunksAction)(new SplitJobCommand(
+            $parentJobId,
+            $command->companyId,
+            WbResourceType::FINANCE_SALES_REPORT_DETAILED === $command->resourceType ? 1 : 7,
+        ));
 
         return $parentJobId;
     }

--- a/site/src/Ingestion/Infrastructure/Api/Wildberries/CredentialFacadeWbCredentialProvider.php
+++ b/site/src/Ingestion/Infrastructure/Api/Wildberries/CredentialFacadeWbCredentialProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Api\Wildberries;
+
+use App\Ingestion\Facade\CredentialFacade;
+
+final readonly class CredentialFacadeWbCredentialProvider implements WbCredentialProviderInterface
+{
+    public function __construct(private CredentialFacade $credentialFacade)
+    {
+    }
+
+    /**
+     * @return array{api_key: string}
+     */
+    public function read(string $companyId, string $connectionRef): array
+    {
+        $payload = $this->credentialFacade->read($companyId, $connectionRef);
+
+        return [
+            'api_key' => (string) ($payload['api_key'] ?? ''),
+        ];
+    }
+}

--- a/site/src/Ingestion/Infrastructure/Api/Wildberries/WbCredentialProviderInterface.php
+++ b/site/src/Ingestion/Infrastructure/Api/Wildberries/WbCredentialProviderInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Api\Wildberries;
+
+interface WbCredentialProviderInterface
+{
+    /**
+     * @return array{api_key: string}
+     */
+    public function read(string $companyId, string $connectionRef): array;
+}

--- a/site/src/Ingestion/Infrastructure/Api/Wildberries/WbFinanceReportClient.php
+++ b/site/src/Ingestion/Infrastructure/Api/Wildberries/WbFinanceReportClient.php
@@ -8,9 +8,9 @@ use App\Ingestion\Exception\ConnectorAuthException;
 use App\Ingestion\Exception\ConnectorRateLimitedException;
 use App\Ingestion\Exception\ConnectorTransientException;
 use App\Ingestion\Exception\CredentialNotFoundException;
+use App\Marketplace\Application\Service\WbFinanceRateLimiter;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Clock\ClockInterface;
-use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -21,11 +21,12 @@ final readonly class WbFinanceReportClient implements WbFinanceReportClientInter
     private const BASE_URL = 'https://finance-api.wildberries.ru';
     private const ENDPOINT = '/api/finance/v1/sales-reports/detailed';
     private const DEFAULT_RETRY_AFTER_SECONDS = 70;
+    private const GLOBAL_SELLER_BUCKET = 'global';
 
     public function __construct(
         private HttpClientInterface $httpClient,
         private WbCredentialProviderInterface $credentialProvider,
-        private RateLimiterFactory $rateLimiterFactory,
+        private WbFinanceRateLimiter $rateLimiter,
         private ClockInterface $clock,
         private LoggerInterface $logger,
     ) {
@@ -94,7 +95,7 @@ final readonly class WbFinanceReportClient implements WbFinanceReportClientInter
             );
         }
 
-        $this->classifyStatus($statusCode, $headers);
+        $this->classifyStatus($statusCode, $headers, $connectionRef);
         $rows = $this->decodeRows($body);
         if ([] === $rows) {
             return new WbFinanceReportPage(
@@ -121,16 +122,26 @@ final readonly class WbFinanceReportClient implements WbFinanceReportClientInter
 
     private function consumeRateLimit(string $connectionRef): void
     {
-        $limit = $this->rateLimiterFactory->create(sprintf('wb-finance:%s', $connectionRef))->consume(1);
-        if ($limit->isAccepted()) {
+        $sellerBucketId = $this->sellerBucketId($connectionRef);
+        $cooldownUntil = $this->rateLimiter->getActiveSalesReportsCooldownUntil($sellerBucketId);
+        if (null !== $cooldownUntil) {
+            throw new ConnectorRateLimitedException(
+                'WB finance report shared cooldown is active.',
+                $this->rateLimiter->secondsUntil($cooldownUntil),
+            );
+        }
+
+        $retryAfter = $this->rateLimiter->tryConsume(
+            $this->rateLimiter->buildSalesReportsRateLimitKeyForSellerBucket($sellerBucketId),
+        );
+        if (null === $retryAfter) {
             return;
         }
 
-        $retryAfter = $limit->getRetryAfter();
-        $now = $this->clock->now();
-        $retryAfterSeconds = max(1, $retryAfter->getTimestamp() - $now->getTimestamp());
-
-        throw new ConnectorRateLimitedException('WB finance report local rate limit is active.', $retryAfterSeconds);
+        throw new ConnectorRateLimitedException(
+            'WB finance report local rate limit is active.',
+            $this->rateLimiter->secondsUntil($retryAfter),
+        );
     }
 
     /**
@@ -155,16 +166,21 @@ final readonly class WbFinanceReportClient implements WbFinanceReportClientInter
     /**
      * @param array<string, list<string>> $headers
      */
-    private function classifyStatus(int $statusCode, array $headers): void
+    private function classifyStatus(int $statusCode, array $headers, string $connectionRef): void
     {
         if (401 === $statusCode || 403 === $statusCode) {
             throw new ConnectorAuthException('WB finance API authentication failed.');
         }
 
         if (429 === $statusCode) {
+            $retryAfterSeconds = $this->retryAfterSeconds($headers);
+            $sellerBucketId = $this->sellerBucketId($connectionRef);
+            $cooldownUntil = $this->rateLimiter->cooldownUntilAfterRemote429($retryAfterSeconds, self::DEFAULT_RETRY_AFTER_SECONDS);
+            $this->rateLimiter->setSalesReportsCooldownUntil($sellerBucketId, $cooldownUntil);
+
             throw new ConnectorRateLimitedException(
                 'WB finance API remote rate limit is active.',
-                $this->retryAfterSeconds($headers),
+                $this->rateLimiter->secondsUntil($cooldownUntil),
             );
         }
 
@@ -229,7 +245,7 @@ final readonly class WbFinanceReportClient implements WbFinanceReportClientInter
     /**
      * @param array<string, list<string>> $headers
      */
-    private function retryAfterSeconds(array $headers): int
+    private function retryAfterSeconds(array $headers): ?int
     {
         foreach (['retry-after', 'x-ratelimit-retry', 'x-ratelimit-reset'] as $headerName) {
             $value = $headers[$headerName][0] ?? null;
@@ -243,7 +259,7 @@ final readonly class WbFinanceReportClient implements WbFinanceReportClientInter
             }
         }
 
-        return self::DEFAULT_RETRY_AFTER_SECONDS;
+        return null;
     }
 
     private function parseRetryHeader(string $value, bool $allowRelativeSeconds): ?int
@@ -264,6 +280,16 @@ final readonly class WbFinanceReportClient implements WbFinanceReportClientInter
         }
 
         return max(1, $date->getTimestamp() - $this->clock->now()->getTimestamp());
+    }
+
+    private function sellerBucketId(string $connectionRef): string
+    {
+        $connectionRef = trim($connectionRef);
+        if ('' === $connectionRef) {
+            return self::GLOBAL_SELLER_BUCKET;
+        }
+
+        return 'connection:'.$connectionRef;
     }
 
     /**

--- a/site/src/Ingestion/Infrastructure/Api/Wildberries/WbFinanceReportClient.php
+++ b/site/src/Ingestion/Infrastructure/Api/Wildberries/WbFinanceReportClient.php
@@ -1,0 +1,290 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Api\Wildberries;
+
+use App\Ingestion\Exception\ConnectorAuthException;
+use App\Ingestion\Exception\ConnectorRateLimitedException;
+use App\Ingestion\Exception\ConnectorTransientException;
+use App\Ingestion\Exception\CredentialNotFoundException;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final readonly class WbFinanceReportClient implements WbFinanceReportClientInterface
+{
+    public const PAGE_SIZE = 100000;
+
+    private const BASE_URL = 'https://finance-api.wildberries.ru';
+    private const ENDPOINT = '/api/finance/v1/sales-reports/detailed';
+    private const DEFAULT_RETRY_AFTER_SECONDS = 70;
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private WbCredentialProviderInterface $credentialProvider,
+        private RateLimiterFactory $rateLimiterFactory,
+        private ClockInterface $clock,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function fetchDetailedDayPage(
+        string $companyId,
+        string $connectionRef,
+        \DateTimeImmutable $date,
+        int $rrdId,
+        int $limit = self::PAGE_SIZE,
+    ): WbFinanceReportPage {
+        if ($rrdId < 0) {
+            throw new \InvalidArgumentException('WB finance report rrdId cannot be negative.');
+        }
+        if ($limit < 1 || $limit > self::PAGE_SIZE) {
+            throw new \InvalidArgumentException(sprintf('WB finance report limit must be between 1 and %d.', self::PAGE_SIZE));
+        }
+
+        $this->consumeRateLimit($connectionRef);
+        $credentials = $this->credentials($companyId, $connectionRef);
+        $dateString = $date->format('Y-m-d');
+        $startedAt = microtime(true);
+        $statusCode = null;
+
+        try {
+            $response = $this->httpClient->request('POST', self::BASE_URL.self::ENDPOINT, [
+                'headers' => [
+                    'Authorization' => $credentials['api_key'],
+                    'Content-Type' => 'application/json',
+                ],
+                'json' => [
+                    'dateFrom' => $dateString,
+                    'dateTo' => $dateString,
+                    'limit' => $limit,
+                    'rrdId' => $rrdId,
+                    'period' => 'daily',
+                ],
+                'timeout' => 120,
+            ]);
+
+            $statusCode = $response->getStatusCode();
+            $headers = $response->getHeaders(false);
+            $body = $response->getContent(false);
+        } catch (TransportExceptionInterface $exception) {
+            throw new ConnectorTransientException('WB finance report transport error.', previous: $exception);
+        } finally {
+            $this->logger->info('WB finance report API request finished.', [
+                'companyId' => $companyId,
+                'connectionRef' => $connectionRef,
+                'endpoint' => self::ENDPOINT,
+                'date' => $dateString,
+                'rrdId' => $rrdId,
+                'limit' => $limit,
+                'statusCode' => $statusCode,
+                'durationMs' => (int) ((microtime(true) - $startedAt) * 1000),
+            ]);
+        }
+
+        if (204 === $statusCode) {
+            return new WbFinanceReportPage(
+                rows: [],
+                nextRrdId: null,
+                hasMore: false,
+                metadata: $this->metadata($dateString, $rrdId, $limit, 0, $statusCode),
+            );
+        }
+
+        $this->classifyStatus($statusCode, $headers);
+        $rows = $this->decodeRows($body);
+        if ([] === $rows) {
+            return new WbFinanceReportPage(
+                rows: [],
+                nextRrdId: null,
+                hasMore: false,
+                metadata: $this->metadata($dateString, $rrdId, $limit, 0, $statusCode),
+            );
+        }
+
+        $last = $rows[array_key_last($rows)];
+        $nextRrdId = $this->rrdId($last);
+        if (null === $nextRrdId || $nextRrdId <= $rrdId) {
+            throw new \RuntimeException('WB finance report pagination rrdId must grow monotonically.');
+        }
+
+        return new WbFinanceReportPage(
+            rows: $rows,
+            nextRrdId: $nextRrdId,
+            hasMore: count($rows) >= $limit,
+            metadata: $this->metadata($dateString, $rrdId, $limit, count($rows), $statusCode, $nextRrdId),
+        );
+    }
+
+    private function consumeRateLimit(string $connectionRef): void
+    {
+        $limit = $this->rateLimiterFactory->create(sprintf('wb-finance:%s', $connectionRef))->consume(1);
+        if ($limit->isAccepted()) {
+            return;
+        }
+
+        $retryAfter = $limit->getRetryAfter();
+        $now = $this->clock->now();
+        $retryAfterSeconds = max(1, $retryAfter->getTimestamp() - $now->getTimestamp());
+
+        throw new ConnectorRateLimitedException('WB finance report local rate limit is active.', $retryAfterSeconds);
+    }
+
+    /**
+     * @return array{api_key: string}
+     */
+    private function credentials(string $companyId, string $connectionRef): array
+    {
+        try {
+            $credentials = $this->credentialProvider->read($companyId, $connectionRef);
+        } catch (CredentialNotFoundException $exception) {
+            throw new ConnectorAuthException('WB finance credentials were not found.', previous: $exception);
+        }
+
+        $apiKey = trim((string) ($credentials['api_key'] ?? ''));
+        if ('' === $apiKey) {
+            throw new ConnectorAuthException('WB finance credentials are incomplete.');
+        }
+
+        return ['api_key' => $apiKey];
+    }
+
+    /**
+     * @param array<string, list<string>> $headers
+     */
+    private function classifyStatus(int $statusCode, array $headers): void
+    {
+        if (401 === $statusCode || 403 === $statusCode) {
+            throw new ConnectorAuthException('WB finance API authentication failed.');
+        }
+
+        if (429 === $statusCode) {
+            throw new ConnectorRateLimitedException(
+                'WB finance API remote rate limit is active.',
+                $this->retryAfterSeconds($headers),
+            );
+        }
+
+        if ($statusCode >= 500) {
+            throw new ConnectorTransientException(sprintf('WB finance API server error %d.', $statusCode));
+        }
+
+        if (200 !== $statusCode) {
+            throw new \RuntimeException(sprintf('WB finance API returned HTTP %d.', $statusCode));
+        }
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function decodeRows(string $body): array
+    {
+        if ('' === trim($body)) {
+            throw new \RuntimeException('WB finance API returned an empty response body for HTTP 200.');
+        }
+
+        try {
+            $decoded = json_decode($body, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $exception) {
+            throw new \RuntimeException('WB finance API returned invalid JSON.', previous: $exception);
+        }
+
+        if (!is_array($decoded) || !array_is_list($decoded)) {
+            throw new \RuntimeException('WB finance API response must be a JSON list.');
+        }
+
+        $rows = [];
+        foreach ($decoded as $row) {
+            if (!is_array($row) || array_is_list($row)) {
+                throw new \RuntimeException('WB finance API response rows must be JSON objects.');
+            }
+
+            $rows[] = $row;
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function rrdId(array $row): ?int
+    {
+        foreach (['rrdId', 'rrd_id'] as $key) {
+            $value = $row[$key] ?? null;
+            if (is_int($value)) {
+                return $value;
+            }
+            if (is_string($value) && ctype_digit($value)) {
+                return (int) $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, list<string>> $headers
+     */
+    private function retryAfterSeconds(array $headers): int
+    {
+        foreach (['retry-after', 'x-ratelimit-retry', 'x-ratelimit-reset'] as $headerName) {
+            $value = $headers[$headerName][0] ?? null;
+            if (null === $value || '' === trim($value)) {
+                continue;
+            }
+
+            $seconds = $this->parseRetryHeader(trim($value), 'x-ratelimit-reset' !== $headerName);
+            if (null !== $seconds) {
+                return $seconds;
+            }
+        }
+
+        return self::DEFAULT_RETRY_AFTER_SECONDS;
+    }
+
+    private function parseRetryHeader(string $value, bool $allowRelativeSeconds): ?int
+    {
+        if (ctype_digit($value)) {
+            $number = (int) $value;
+            if ($allowRelativeSeconds) {
+                return max(1, $number);
+            }
+
+            return max(1, $number - $this->clock->now()->getTimestamp());
+        }
+
+        try {
+            $date = new \DateTimeImmutable($value);
+        } catch (\Throwable) {
+            return null;
+        }
+
+        return max(1, $date->getTimestamp() - $this->clock->now()->getTimestamp());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function metadata(
+        string $date,
+        int $rrdId,
+        int $limit,
+        int $rows,
+        int $statusCode,
+        ?int $nextRrdId = null,
+    ): array {
+        return [
+            'endpoint' => self::ENDPOINT,
+            'date' => $date,
+            'rrdId' => $rrdId,
+            'limit' => $limit,
+            'rows' => $rows,
+            'statusCode' => $statusCode,
+            'nextRrdId' => $nextRrdId,
+        ];
+    }
+}

--- a/site/src/Ingestion/Infrastructure/Api/Wildberries/WbFinanceReportClientInterface.php
+++ b/site/src/Ingestion/Infrastructure/Api/Wildberries/WbFinanceReportClientInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Api\Wildberries;
+
+interface WbFinanceReportClientInterface
+{
+    public function fetchDetailedDayPage(
+        string $companyId,
+        string $connectionRef,
+        \DateTimeImmutable $date,
+        int $rrdId,
+        int $limit = 100000,
+    ): WbFinanceReportPage;
+}

--- a/site/src/Ingestion/Infrastructure/Api/Wildberries/WbFinanceReportPage.php
+++ b/site/src/Ingestion/Infrastructure/Api/Wildberries/WbFinanceReportPage.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Api\Wildberries;
+
+final readonly class WbFinanceReportPage
+{
+    /**
+     * @param list<array<string, mixed>> $rows
+     * @param array<string, mixed>       $metadata
+     */
+    public function __construct(
+        public array $rows,
+        public ?int $nextRrdId,
+        public bool $hasMore,
+        public array $metadata = [],
+    ) {
+    }
+}

--- a/site/src/Ingestion/Message/RunSyncChunkMessage.php
+++ b/site/src/Ingestion/Message/RunSyncChunkMessage.php
@@ -11,9 +11,13 @@ final readonly class RunSyncChunkMessage implements CompanyAwareMessage
     public function __construct(
         public string $companyId,
         public string $jobId,
+        public ?string $cursorValue = null,
     ) {
         Assert::uuid($this->companyId);
         Assert::uuid($this->jobId);
+        if (null !== $this->cursorValue) {
+            Assert::notEmpty($this->cursorValue);
+        }
     }
 
     public function getCompanyId(): string

--- a/site/src/Ingestion/MessageHandler/RunSyncChunkHandler.php
+++ b/site/src/Ingestion/MessageHandler/RunSyncChunkHandler.php
@@ -22,6 +22,7 @@ use App\Ingestion\Message\NormalizeRawRecordMessage;
 use App\Ingestion\Message\RunSyncChunkMessage;
 use App\Ingestion\Repository\IngestCursorRepository;
 use App\Ingestion\Repository\SyncJobRepository;
+use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Lock\LockInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -39,6 +40,7 @@ final readonly class RunSyncChunkHandler
         private RawStorageFacade $rawStorageFacade,
         private SyncFacade $syncFacade,
         private IngestRateLimitGuard $rateLimitGuard,
+        private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
         private LoggerInterface $logger,
     ) {
@@ -96,6 +98,8 @@ final readonly class RunSyncChunkHandler
                     foreach ($records as $record) {
                         $this->messageBus->dispatch(new NormalizeRawRecordMessage($record->getId(), $record->getCompanyId()));
                     }
+                } else {
+                    $this->markNormalizationSkipped($records);
                 }
 
                 if (null !== $result->nextCursorValue && '' !== $result->nextCursorValue) {
@@ -212,6 +216,22 @@ final readonly class RunSyncChunkHandler
                 'errorMessage' => $exception->getMessage(),
             ]);
         }
+    }
+
+    /**
+     * @param list<\App\Ingestion\Entity\IngestRawRecord> $records
+     */
+    private function markNormalizationSkipped(array $records): void
+    {
+        if ([] === $records) {
+            return;
+        }
+
+        foreach ($records as $record) {
+            $record->markNormalizationSkipped();
+        }
+
+        $this->entityManager->flush();
     }
 
     private function dispatchContinuation(RunSyncChunkMessage $message, ?string $cursorValue, int $delaySeconds): void

--- a/site/src/Ingestion/MessageHandler/RunSyncChunkHandler.php
+++ b/site/src/Ingestion/MessageHandler/RunSyncChunkHandler.php
@@ -13,6 +13,7 @@ use App\Ingestion\Application\Service\IngestRateLimitGuard;
 use App\Ingestion\Domain\Service\ConnectorRegistry;
 use App\Ingestion\Entity\SyncJob;
 use App\Ingestion\Exception\ConnectorAuthException;
+use App\Ingestion\Exception\ConnectorRateLimitedException;
 use App\Ingestion\Exception\ConnectorTransientException;
 use App\Ingestion\Exception\SyncJobNotFoundException;
 use App\Ingestion\Facade\RawStorageFacade;
@@ -26,6 +27,7 @@ use Symfony\Component\Lock\LockInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
 
 #[AsMessageHandler]
 final readonly class RunSyncChunkHandler
@@ -60,7 +62,7 @@ final readonly class RunSyncChunkHandler
         }
 
         $isWindowed = $this->isWindowed($job);
-        $cursorValue = $isWindowed ? null : $this->sharedCursorValue($job);
+        $cursorValue = $message->cursorValue ?? ($isWindowed ? null : $this->sharedCursorValue($job));
         $cursorSnapshot = !$isWindowed && null === $job->getStartedAt() && null !== $cursorValue && '' !== $cursorValue
             ? $cursorValue
             : null;
@@ -90,11 +92,19 @@ final readonly class RunSyncChunkHandler
                 ));
 
                 $records = $this->rawStorageFacade->store($result->rawBatch);
-                foreach ($records as $record) {
-                    $this->messageBus->dispatch(new NormalizeRawRecordMessage($record->getId(), $record->getCompanyId()));
+                if ($result->normalizeRawRecords) {
+                    foreach ($records as $record) {
+                        $this->messageBus->dispatch(new NormalizeRawRecordMessage($record->getId(), $record->getCompanyId()));
+                    }
                 }
 
                 if (null !== $result->nextCursorValue && '' !== $result->nextCursorValue) {
+                    if ($result->hasMore && null !== $result->continuationDelaySeconds) {
+                        $this->dispatchContinuation($message, $result->nextCursorValue, $result->continuationDelaySeconds);
+
+                        return;
+                    }
+
                     if (!$isWindowed) {
                         $this->syncFacade->updateCursor(new UpdateCursorCommand(
                             companyId: $job->getCompanyId(),
@@ -118,6 +128,17 @@ final readonly class RunSyncChunkHandler
             $this->markJobFailed($job->getId(), $job->getCompanyId(), 'auth');
 
             throw new UnrecoverableMessageHandlingException('Ingestion connector authentication failed.', 0, $exception);
+        } catch (ConnectorRateLimitedException $exception) {
+            $this->logger->info('Ingestion connector rate-limited; chunk continuation scheduled.', [
+                'companyId' => $job->getCompanyId(),
+                'jobId' => $job->getId(),
+                'source' => $job->getSource()->value,
+                'resourceType' => $job->getResourceType(),
+                'retryAfterSeconds' => $exception->retryAfterSeconds(),
+            ]);
+            $this->dispatchContinuation($message, $message->cursorValue, $exception->retryAfterSeconds());
+
+            return;
         } catch (ConnectorTransientException $exception) {
             $this->logger->warning('Ingestion connector transient failure; message will be retried.', [
                 'companyId' => $job->getCompanyId(),
@@ -191,5 +212,13 @@ final readonly class RunSyncChunkHandler
                 'errorMessage' => $exception->getMessage(),
             ]);
         }
+    }
+
+    private function dispatchContinuation(RunSyncChunkMessage $message, ?string $cursorValue, int $delaySeconds): void
+    {
+        $this->messageBus->dispatch(
+            new RunSyncChunkMessage($message->companyId, $message->jobId, $cursorValue),
+            [new DelayStamp(max(1, $delaySeconds) * 1000)],
+        );
     }
 }

--- a/site/tests/Integration/Ingestion/Command/StartBackfillCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/StartBackfillCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Integration\Ingestion\Command;
 
 use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Application\Source\Wildberries\WbResourceType;
 use App\Ingestion\Entity\SyncJob;
 use App\Ingestion\Enum\IngestSource;
 use App\Ingestion\Enum\SyncJobKind;
@@ -79,6 +80,39 @@ final class StartBackfillCommandTest extends IntegrationTestCase
         foreach ($envelopes as $envelope) {
             self::assertInstanceOf(RunSyncChunkMessage::class, $envelope->getMessage());
         }
+    }
+
+    public function testStartsBackfillForDefaultWildberriesFinanceResourceTypeWithDailyChunks(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = Uuid::uuid7()->toString();
+        $transport = $this->getIngestFetchTransport();
+        $transport->reset();
+
+        $tester = $this->tester('app:ingestion:start-backfill');
+        $exit = $tester->execute([
+            '--company-id' => $companyId,
+            '--connection-ref' => $connectionRef,
+            '--source' => 'wildberries',
+            '--days-back' => '3',
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertStringContainsString(WbResourceType::FINANCE_SALES_REPORT_DETAILED, $tester->getDisplay());
+
+        $parentJobs = $this->connection->fetchAllAssociative(
+            'SELECT resource_type, shop_ref, progress_total
+             FROM ingest_sync_jobs
+             WHERE company_id = :companyId AND parent_job_id IS NULL
+             ORDER BY resource_type',
+            ['companyId' => $companyId],
+        );
+
+        self::assertCount(1, $parentJobs);
+        self::assertSame([WbResourceType::FINANCE_SALES_REPORT_DETAILED], array_column($parentJobs, 'resource_type'));
+        self::assertSame('fake-shop', $parentJobs[0]['shop_ref']);
+        self::assertSame(3, (int) $parentJobs[0]['progress_total']);
+        self::assertCount(3, $transport->getSent());
     }
 
     public function testActiveBackfillWarningSkipsDefaultResource(): void

--- a/site/tests/Integration/Ingestion/Fixtures/FakeConnector.php
+++ b/site/tests/Integration/Ingestion/Fixtures/FakeConnector.php
@@ -26,7 +26,7 @@ final class FakeConnector implements SourceConnectorInterface
     private array $pullRequests = [];
 
     /**
-     * @var list<array{externalId: string, nextCursorValue: ?string, hasMore: bool, rowExternalId: string}>
+     * @var list<array{externalId: string, nextCursorValue: ?string, hasMore: bool, rowExternalId: string, normalizeRawRecords: bool, continuationDelaySeconds: ?int}>
      */
     private array $queuedPullResults = [];
 
@@ -41,12 +41,16 @@ final class FakeConnector implements SourceConnectorInterface
         ?string $nextCursorValue,
         bool $hasMore,
         string $rowExternalId = 'fake-sale-1',
+        bool $normalizeRawRecords = true,
+        ?int $continuationDelaySeconds = null,
     ): void {
         $this->queuedPullResults[] = [
             'externalId' => $externalId,
             'nextCursorValue' => $nextCursorValue,
             'hasMore' => $hasMore,
             'rowExternalId' => $rowExternalId,
+            'normalizeRawRecords' => $normalizeRawRecords,
+            'continuationDelaySeconds' => $continuationDelaySeconds,
         ];
     }
 
@@ -94,6 +98,8 @@ final class FakeConnector implements SourceConnectorInterface
             'nextCursorValue' => 'cursor-after-fake-sale-1',
             'hasMore' => false,
             'rowExternalId' => 'fake-sale-1',
+            'normalizeRawRecords' => true,
+            'continuationDelaySeconds' => null,
         ];
         $operationGroupId = Uuid::uuid7()->toString();
 
@@ -122,6 +128,8 @@ final class FakeConnector implements SourceConnectorInterface
             ),
             nextCursorValue: $result['nextCursorValue'],
             hasMore: $result['hasMore'],
+            normalizeRawRecords: $result['normalizeRawRecords'],
+            continuationDelaySeconds: $result['continuationDelaySeconds'],
         );
     }
 

--- a/site/tests/Integration/Ingestion/MessageHandler/RunSyncChunkHandlerTest.php
+++ b/site/tests/Integration/Ingestion/MessageHandler/RunSyncChunkHandlerTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Integration\Ingestion\MessageHandler;
 use App\Ingestion\Application\Service\IngestRateLimitGuard;
 use App\Ingestion\Entity\SyncJob;
 use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\RawNormalizationStatus;
 use App\Ingestion\Enum\SyncJobKind;
 use App\Ingestion\Enum\SyncJobStatus;
 use App\Ingestion\Exception\ConnectorTransientException;
@@ -283,6 +284,12 @@ final class RunSyncChunkHandlerTest extends IntegrationTestCase
         /** @var SyncJobRepository $jobRepository */
         $jobRepository = self::getContainer()->get(SyncJobRepository::class);
         self::assertSame(SyncJobStatus::RUNNING, $jobRepository->findByIdAndCompany($job->getId(), $companyId)?->getStatus());
+
+        /** @var IngestRawRecordRepository $rawRecordRepository */
+        $rawRecordRepository = self::getContainer()->get(IngestRawRecordRepository::class);
+        $rawRecords = $rawRecordRepository->findBy(['companyId' => $companyId, 'syncJobId' => $job->getId()]);
+        self::assertCount(1, $rawRecords);
+        self::assertSame(RawNormalizationStatus::SKIPPED, $rawRecords[0]->getNormalizationStatus());
     }
 
     public function testRateLimitLockContentionKeepsJobRetryable(): void

--- a/site/tests/Integration/Ingestion/MessageHandler/RunSyncChunkHandlerTest.php
+++ b/site/tests/Integration/Ingestion/MessageHandler/RunSyncChunkHandlerTest.php
@@ -21,6 +21,7 @@ use App\Ingestion\Repository\SyncJobRepository;
 use App\Tests\Integration\Ingestion\Fixtures\FakeConnector;
 use App\Tests\Support\Kernel\IntegrationTestCase;
 use Ramsey\Uuid\Uuid;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
 
 final class RunSyncChunkHandlerTest extends IntegrationTestCase
@@ -224,6 +225,66 @@ final class RunSyncChunkHandlerTest extends IntegrationTestCase
         self::assertNull($cursorRepository->findOne($companyId, 'connection-1', FakeConnector::RESOURCE_TYPE, 'shop-1'));
     }
 
+    public function testWindowedChunkSchedulesDelayedContinuationWhenConnectorRequestsDelay(): void
+    {
+        $fakeConnector = $this->fakeConnector();
+        $fakeConnector->reset();
+        $fakeConnector->enqueuePullResult(
+            externalId: 'fake-report-page-1',
+            nextCursorValue: 'cursor-page-2',
+            hasMore: true,
+            rowExternalId: 'fake-sale-1',
+            normalizeRawRecords: false,
+            continuationDelaySeconds: 70,
+        );
+
+        $companyId = Uuid::uuid7()->toString();
+        $job = new SyncJob(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            source: IngestSource::WILDBERRIES,
+            resourceType: FakeConnector::RESOURCE_TYPE,
+            kind: SyncJobKind::BACKFILL,
+            windowFrom: new \DateTimeImmutable('2026-06-01'),
+            windowTo: new \DateTimeImmutable('2026-06-01'),
+            shopRef: 'shop-1',
+        );
+
+        $this->em->persist($job);
+        $this->em->flush();
+
+        $fetchTransport = $this->getFetchTransport();
+        $fetchTransport->reset();
+        $normalizeTransport = $this->getNormalizeTransport();
+        $normalizeTransport->reset();
+
+        /** @var RunSyncChunkHandler $handler */
+        $handler = self::getContainer()->get(RunSyncChunkHandler::class);
+        $handler(new RunSyncChunkMessage($companyId, $job->getId()));
+        $this->em->clear();
+
+        self::assertCount(1, $fakeConnector->pullRequests());
+        self::assertCount(0, $normalizeTransport->getSent());
+
+        $sent = $fetchTransport->getSent();
+        self::assertCount(1, $sent);
+        self::assertInstanceOf(RunSyncChunkMessage::class, $sent[0]->getMessage());
+
+        /** @var RunSyncChunkMessage $continuation */
+        $continuation = $sent[0]->getMessage();
+        self::assertSame($companyId, $continuation->companyId);
+        self::assertSame($job->getId(), $continuation->jobId);
+        self::assertSame('cursor-page-2', $continuation->cursorValue);
+
+        $delayStamps = $sent[0]->all(DelayStamp::class);
+        self::assertCount(1, $delayStamps);
+        self::assertSame(70000, $delayStamps[0]->getDelay());
+
+        /** @var SyncJobRepository $jobRepository */
+        $jobRepository = self::getContainer()->get(SyncJobRepository::class);
+        self::assertSame(SyncJobStatus::RUNNING, $jobRepository->findByIdAndCompany($job->getId(), $companyId)?->getStatus());
+    }
+
     public function testRateLimitLockContentionKeepsJobRetryable(): void
     {
         $this->fakeConnector()->reset();
@@ -280,6 +341,14 @@ final class RunSyncChunkHandlerTest extends IntegrationTestCase
     {
         /** @var InMemoryTransport $transport */
         $transport = self::getContainer()->get('messenger.transport.ingest_normalize');
+
+        return $transport;
+    }
+
+    private function getFetchTransport(): InMemoryTransport
+    {
+        /** @var InMemoryTransport $transport */
+        $transport = self::getContainer()->get('messenger.transport.ingest_fetch');
 
         return $transport;
     }

--- a/site/tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceReportConnectorTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceReportConnectorTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Application\Source\Wildberries;
+
+use App\Ingestion\Application\DTO\PullRequest;
+use App\Ingestion\Application\DTO\PushRequest;
+use App\Ingestion\Application\Source\Wildberries\WbFinanceReportConnector;
+use App\Ingestion\Application\Source\Wildberries\WbResourceType;
+use App\Ingestion\Enum\Capability;
+use App\Ingestion\Exception\UnsupportedCapabilityException;
+use App\Ingestion\Infrastructure\Api\Wildberries\WbFinanceReportClientInterface;
+use App\Ingestion\Infrastructure\Api\Wildberries\WbFinanceReportPage;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+final class WbFinanceReportConnectorTest extends TestCase
+{
+    public function testCapabilitiesDiscoverAndUnsupportedPush(): void
+    {
+        $connector = new WbFinanceReportConnector($this->client(new WbFinanceReportPage([], null, false)));
+        $connectionRef = Uuid::uuid7()->toString();
+
+        self::assertSame([Capability::CAN_DISCOVER_SHOPS, Capability::CAN_PULL], $connector->capabilities());
+        self::assertSame($connectionRef, $connector->discoverShops(Uuid::uuid7()->toString(), $connectionRef)[0]->externalId);
+
+        $this->expectException(UnsupportedCapabilityException::class);
+        $connector->push(new PushRequest(
+            companyId: Uuid::uuid7()->toString(),
+            connectionRef: $connectionRef,
+            documentType: 'doc',
+            payload: [],
+            idempotencyKey: 'key-1',
+        ));
+    }
+
+    public function testPullStoresOnePageRawWithoutNormalization(): void
+    {
+        $client = $this->client(new WbFinanceReportPage(
+            rows: [['rrdId' => 10, 'docTypeName' => 'Продажа']],
+            nextRrdId: 10,
+            hasMore: false,
+            metadata: ['endpoint' => '/api/finance/v1/sales-reports/detailed'],
+        ));
+        $connector = new WbFinanceReportConnector($client);
+
+        $result = $connector->pull($this->request(
+            windowFrom: new \DateTimeImmutable('2026-06-20'),
+            windowTo: new \DateTimeImmutable('2026-06-20'),
+        ));
+
+        self::assertSame(WbResourceType::FINANCE_SALES_REPORT_DETAILED, $result->rawBatch->resourceType);
+        self::assertSame('wb-sales-report-detailed:2026-06-20:rrd-0', $result->rawBatch->externalId);
+        self::assertFalse($result->normalizeRawRecords);
+        self::assertFalse($result->hasMore);
+        self::assertNull($result->nextCursorValue);
+        self::assertSame([
+            [
+                'rrdId' => 10,
+                'docTypeName' => 'Продажа',
+                '_ingestion_resource' => WbResourceType::FINANCE_SALES_REPORT_DETAILED,
+                '_ingestion_metadata' => ['endpoint' => '/api/finance/v1/sales-reports/detailed'],
+            ],
+        ], $result->rawBatch->rows);
+        self::assertSame([
+            ['2026-06-20', 0],
+        ], $client->calls);
+    }
+
+    public function testPullFullPageReturnsDelayedContinuationCursor(): void
+    {
+        $client = $this->client(new WbFinanceReportPage(
+            rows: [['rrdId' => 100]],
+            nextRrdId: 100,
+            hasMore: true,
+            metadata: ['date' => '2026-06-20'],
+        ));
+        $connector = new WbFinanceReportConnector($client, continuationDelaySeconds: 70);
+
+        $result = $connector->pull($this->request(
+            windowFrom: new \DateTimeImmutable('2026-06-20'),
+            windowTo: new \DateTimeImmutable('2026-06-20'),
+        ));
+
+        self::assertTrue($result->hasMore);
+        self::assertSame(70, $result->continuationDelaySeconds);
+        self::assertSame('{"date":"2026-06-20","rrdId":100}', $result->nextCursorValue);
+    }
+
+    public function testPullContinuationUsesEncodedCursor(): void
+    {
+        $client = $this->client(new WbFinanceReportPage([], null, false));
+        $connector = new WbFinanceReportConnector($client);
+
+        $connector->pull($this->request(cursorValue: '{"date":"2026-06-20","rrdId":100}'));
+
+        self::assertSame([
+            ['2026-06-20', 100],
+        ], $client->calls);
+    }
+
+    public function testPullEmptyPageStoresEmptyMarker(): void
+    {
+        $connector = new WbFinanceReportConnector($this->client(new WbFinanceReportPage(
+            rows: [],
+            nextRrdId: null,
+            hasMore: false,
+            metadata: ['date' => '2026-06-20'],
+        )));
+
+        $result = $connector->pull($this->request(
+            windowFrom: new \DateTimeImmutable('2026-06-20'),
+            windowTo: new \DateTimeImmutable('2026-06-20'),
+        ));
+
+        self::assertSame([[
+            '_ingestion_empty' => true,
+            '_ingestion_resource' => WbResourceType::FINANCE_SALES_REPORT_DETAILED,
+            '_ingestion_metadata' => ['date' => '2026-06-20'],
+        ]], $result->rawBatch->rows);
+    }
+
+    public function testWindowMustBeOneDay(): void
+    {
+        $connector = new WbFinanceReportConnector($this->client(new WbFinanceReportPage([], null, false)));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('one-day chunks');
+
+        $connector->pull($this->request(
+            windowFrom: new \DateTimeImmutable('2026-06-20'),
+            windowTo: new \DateTimeImmutable('2026-06-21'),
+        ));
+    }
+
+    private function request(
+        ?string $cursorValue = null,
+        ?\DateTimeImmutable $windowFrom = null,
+        ?\DateTimeImmutable $windowTo = null,
+    ): PullRequest {
+        return new PullRequest(
+            companyId: Uuid::uuid7()->toString(),
+            connectionRef: 'connection-1',
+            shopRef: 'shop-1',
+            resourceType: WbResourceType::FINANCE_SALES_REPORT_DETAILED,
+            cursorValue: $cursorValue,
+            windowFrom: $windowFrom,
+            windowTo: $windowTo,
+            syncJobId: Uuid::uuid7()->toString(),
+        );
+    }
+
+    private function client(WbFinanceReportPage $page): WbFinanceReportClientInterface
+    {
+        return new class($page) implements WbFinanceReportClientInterface {
+            /**
+             * @var list<array{0: string, 1: int}>
+             */
+            public array $calls = [];
+
+            public function __construct(private readonly WbFinanceReportPage $page)
+            {
+            }
+
+            public function fetchDetailedDayPage(
+                string $companyId,
+                string $connectionRef,
+                \DateTimeImmutable $date,
+                int $rrdId,
+                int $limit = 100000,
+            ): WbFinanceReportPage {
+                $this->calls[] = [$date->format('Y-m-d'), $rrdId];
+
+                return $this->page;
+            }
+        };
+    }
+}

--- a/site/tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceReportConnectorTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceReportConnectorTest.php
@@ -134,7 +134,7 @@ final class WbFinanceReportConnectorTest extends TestCase
         ));
     }
 
-    public function testIncrementalCursorDoesNotAdvancePastYesterday(): void
+    public function testIncrementalCursorAdvancesFromYesterdayToToday(): void
     {
         $connector = $this->connector(
             $this->client(new WbFinanceReportPage(rows: [], nextRrdId: null, hasMore: false)),
@@ -143,7 +143,7 @@ final class WbFinanceReportConnectorTest extends TestCase
 
         $result = $connector->pull($this->request(cursorValue: '2026-06-21'));
 
-        self::assertNull($result->nextCursorValue);
+        self::assertSame('2026-06-22', $result->nextCursorValue);
         self::assertFalse($result->hasMore);
     }
 
@@ -157,6 +157,19 @@ final class WbFinanceReportConnectorTest extends TestCase
         $result = $connector->pull($this->request(cursorValue: '2026-06-20'));
 
         self::assertSame('2026-06-21', $result->nextCursorValue);
+        self::assertFalse($result->hasMore);
+    }
+
+    public function testIncrementalCursorDoesNotAdvancePastToday(): void
+    {
+        $connector = $this->connector(
+            $this->client(new WbFinanceReportPage(rows: [], nextRrdId: null, hasMore: false)),
+            now: '2026-06-22T00:00:00+00:00',
+        );
+
+        $result = $connector->pull($this->request(cursorValue: '2026-06-22'));
+
+        self::assertNull($result->nextCursorValue);
         self::assertFalse($result->hasMore);
     }
 

--- a/site/tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceReportConnectorTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceReportConnectorTest.php
@@ -14,12 +14,13 @@ use App\Ingestion\Infrastructure\Api\Wildberries\WbFinanceReportClientInterface;
 use App\Ingestion\Infrastructure\Api\Wildberries\WbFinanceReportPage;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
+use Symfony\Component\Clock\MockClock;
 
 final class WbFinanceReportConnectorTest extends TestCase
 {
     public function testCapabilitiesDiscoverAndUnsupportedPush(): void
     {
-        $connector = new WbFinanceReportConnector($this->client(new WbFinanceReportPage([], null, false)));
+        $connector = $this->connector($this->client(new WbFinanceReportPage([], null, false)));
         $connectionRef = Uuid::uuid7()->toString();
 
         self::assertSame([Capability::CAN_DISCOVER_SHOPS, Capability::CAN_PULL], $connector->capabilities());
@@ -43,7 +44,7 @@ final class WbFinanceReportConnectorTest extends TestCase
             hasMore: false,
             metadata: ['endpoint' => '/api/finance/v1/sales-reports/detailed'],
         ));
-        $connector = new WbFinanceReportConnector($client);
+        $connector = $this->connector($client);
 
         $result = $connector->pull($this->request(
             windowFrom: new \DateTimeImmutable('2026-06-20'),
@@ -60,7 +61,6 @@ final class WbFinanceReportConnectorTest extends TestCase
                 'rrdId' => 10,
                 'docTypeName' => 'Продажа',
                 '_ingestion_resource' => WbResourceType::FINANCE_SALES_REPORT_DETAILED,
-                '_ingestion_metadata' => ['endpoint' => '/api/finance/v1/sales-reports/detailed'],
             ],
         ], $result->rawBatch->rows);
         self::assertSame([
@@ -76,7 +76,7 @@ final class WbFinanceReportConnectorTest extends TestCase
             hasMore: true,
             metadata: ['date' => '2026-06-20'],
         ));
-        $connector = new WbFinanceReportConnector($client, continuationDelaySeconds: 70);
+        $connector = $this->connector($client, continuationDelaySeconds: 70);
 
         $result = $connector->pull($this->request(
             windowFrom: new \DateTimeImmutable('2026-06-20'),
@@ -91,7 +91,7 @@ final class WbFinanceReportConnectorTest extends TestCase
     public function testPullContinuationUsesEncodedCursor(): void
     {
         $client = $this->client(new WbFinanceReportPage([], null, false));
-        $connector = new WbFinanceReportConnector($client);
+        $connector = $this->connector($client);
 
         $connector->pull($this->request(cursorValue: '{"date":"2026-06-20","rrdId":100}'));
 
@@ -102,7 +102,7 @@ final class WbFinanceReportConnectorTest extends TestCase
 
     public function testPullEmptyPageStoresEmptyMarker(): void
     {
-        $connector = new WbFinanceReportConnector($this->client(new WbFinanceReportPage(
+        $connector = $this->connector($this->client(new WbFinanceReportPage(
             rows: [],
             nextRrdId: null,
             hasMore: false,
@@ -123,7 +123,7 @@ final class WbFinanceReportConnectorTest extends TestCase
 
     public function testWindowMustBeOneDay(): void
     {
-        $connector = new WbFinanceReportConnector($this->client(new WbFinanceReportPage([], null, false)));
+        $connector = $this->connector($this->client(new WbFinanceReportPage([], null, false)));
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('one-day chunks');
@@ -132,6 +132,32 @@ final class WbFinanceReportConnectorTest extends TestCase
             windowFrom: new \DateTimeImmutable('2026-06-20'),
             windowTo: new \DateTimeImmutable('2026-06-21'),
         ));
+    }
+
+    public function testIncrementalCursorDoesNotAdvancePastYesterday(): void
+    {
+        $connector = $this->connector(
+            $this->client(new WbFinanceReportPage(rows: [], nextRrdId: null, hasMore: false)),
+            now: '2026-06-22T00:00:00+00:00',
+        );
+
+        $result = $connector->pull($this->request(cursorValue: '2026-06-21'));
+
+        self::assertNull($result->nextCursorValue);
+        self::assertFalse($result->hasMore);
+    }
+
+    public function testIncrementalCursorAdvancesUntilYesterday(): void
+    {
+        $connector = $this->connector(
+            $this->client(new WbFinanceReportPage(rows: [], nextRrdId: null, hasMore: false)),
+            now: '2026-06-22T00:00:00+00:00',
+        );
+
+        $result = $connector->pull($this->request(cursorValue: '2026-06-20'));
+
+        self::assertSame('2026-06-21', $result->nextCursorValue);
+        self::assertFalse($result->hasMore);
     }
 
     private function request(
@@ -175,5 +201,17 @@ final class WbFinanceReportConnectorTest extends TestCase
                 return $this->page;
             }
         };
+    }
+
+    private function connector(
+        WbFinanceReportClientInterface $client,
+        int $continuationDelaySeconds = 70,
+        string $now = '2026-06-22T00:00:00+00:00',
+    ): WbFinanceReportConnector {
+        return new WbFinanceReportConnector(
+            $client,
+            new MockClock($now),
+            $continuationDelaySeconds,
+        );
     }
 }

--- a/site/tests/Unit/Ingestion/Infrastructure/Api/Wildberries/WbFinanceReportClientTest.php
+++ b/site/tests/Unit/Ingestion/Infrastructure/Api/Wildberries/WbFinanceReportClientTest.php
@@ -8,6 +8,8 @@ use App\Ingestion\Exception\ConnectorAuthException;
 use App\Ingestion\Exception\ConnectorRateLimitedException;
 use App\Ingestion\Infrastructure\Api\Wildberries\WbCredentialProviderInterface;
 use App\Ingestion\Infrastructure\Api\Wildberries\WbFinanceReportClient;
+use App\Marketplace\Application\Service\WbFinanceCooldownStorageInterface;
+use App\Marketplace\Application\Service\WbFinanceRateLimiter;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\Clock\MockClock;
@@ -97,13 +99,15 @@ final class WbFinanceReportClientTest extends TestCase
 
     public function testRemoteRateLimitUsesRetryHeader(): void
     {
+        $clock = new MockClock('2026-06-22T00:00:00+00:00');
+        $storage = new InMemoryWbFinanceCooldownStorage();
         $http = new MockHttpClient(new MockResponse('{"error":"rate"}', [
             'http_code' => 429,
             'response_headers' => ['x-ratelimit-retry' => '12'],
         ]));
 
         try {
-            $this->client($http)->fetchDetailedDayPage(
+            $this->client($http, $storage, $clock)->fetchDetailedDayPage(
                 '0192f0c2-0000-7000-8000-000000000001',
                 'connection-1',
                 new \DateTimeImmutable('2026-06-20'),
@@ -112,6 +116,35 @@ final class WbFinanceReportClientTest extends TestCase
             self::fail('Expected rate limit exception.');
         } catch (ConnectorRateLimitedException $exception) {
             self::assertSame(12, $exception->retryAfterSeconds());
+            self::assertSame(
+                $clock->now()->modify('+12 seconds')->getTimestamp(),
+                $storage->getUntilTimestamp('wb_finance:sales_reports:cooldown:connection:connection-1'),
+            );
+        }
+    }
+
+    public function testSharedCooldownPreventsRequestForConnection(): void
+    {
+        $clock = new MockClock('2026-06-22T00:00:00+00:00');
+        $storage = new InMemoryWbFinanceCooldownStorage();
+        $storage->setUntilTimestamp('wb_finance:sales_reports:cooldown:connection:connection-1', $clock->now()->modify('+30 seconds')->getTimestamp(), 30);
+        $requestCount = 0;
+        $http = new MockHttpClient(static function () use (&$requestCount): MockResponse {
+            ++$requestCount;
+
+            return new MockResponse('[]', ['http_code' => 200]);
+        });
+
+        $this->expectException(ConnectorRateLimitedException::class);
+        try {
+            $this->client($http, $storage, $clock)->fetchDetailedDayPage(
+                '0192f0c2-0000-7000-8000-000000000001',
+                'connection-1',
+                new \DateTimeImmutable('2026-06-20'),
+                0,
+            );
+        } finally {
+            self::assertSame(0, $requestCount);
         }
     }
 
@@ -145,8 +178,14 @@ final class WbFinanceReportClientTest extends TestCase
         }
     }
 
-    private function client(MockHttpClient $http): WbFinanceReportClient
+    private function client(
+        MockHttpClient $http,
+        ?WbFinanceCooldownStorageInterface $cooldownStorage = null,
+        ?MockClock $clock = null,
+    ): WbFinanceReportClient
     {
+        $clock ??= new MockClock('2026-06-22T00:00:00+00:00');
+
         return new WbFinanceReportClient(
             $http,
             new class implements WbCredentialProviderInterface {
@@ -155,7 +194,7 @@ final class WbFinanceReportClientTest extends TestCase
                     return ['api_key' => 'wb-token'];
                 }
             },
-            new RateLimiterFactory(
+            new WbFinanceRateLimiter(new RateLimiterFactory(
                 [
                     'id' => 'wb_finance',
                     'policy' => 'fixed_window',
@@ -163,9 +202,25 @@ final class WbFinanceReportClientTest extends TestCase
                     'interval' => '70 seconds',
                 ],
                 new InMemoryStorage(),
-            ),
-            new MockClock('2026-06-22T00:00:00+00:00'),
+            ), $clock, null, $cooldownStorage),
+            $clock,
             new NullLogger(),
         );
+    }
+}
+
+final class InMemoryWbFinanceCooldownStorage implements WbFinanceCooldownStorageInterface
+{
+    /** @var array<string, int> */
+    private array $values = [];
+
+    public function getUntilTimestamp(string $key): ?int
+    {
+        return $this->values[$key] ?? null;
+    }
+
+    public function setUntilTimestamp(string $key, int $untilTimestamp, int $ttlSeconds): void
+    {
+        $this->values[$key] = max($this->values[$key] ?? 0, $untilTimestamp);
     }
 }

--- a/site/tests/Unit/Ingestion/Infrastructure/Api/Wildberries/WbFinanceReportClientTest.php
+++ b/site/tests/Unit/Ingestion/Infrastructure/Api/Wildberries/WbFinanceReportClientTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Infrastructure\Api\Wildberries;
+
+use App\Ingestion\Exception\ConnectorAuthException;
+use App\Ingestion\Exception\ConnectorRateLimitedException;
+use App\Ingestion\Infrastructure\Api\Wildberries\WbCredentialProviderInterface;
+use App\Ingestion\Infrastructure\Api\Wildberries\WbFinanceReportClient;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
+
+final class WbFinanceReportClientTest extends TestCase
+{
+    public function testFetchDetailedDayPageSendsExpectedRequestAndParsesRows(): void
+    {
+        $capturedUrl = null;
+        $capturedOptions = null;
+        $http = new MockHttpClient(static function (string $method, string $url, array $options) use (&$capturedUrl, &$capturedOptions): MockResponse {
+            $capturedUrl = $url;
+            $capturedOptions = $options;
+
+            return new MockResponse('[{"rrdId":10,"docTypeName":"Продажа"}]', ['http_code' => 200]);
+        });
+
+        $client = $this->client($http);
+        $page = $client->fetchDetailedDayPage(
+            '0192f0c2-0000-7000-8000-000000000001',
+            'connection-1',
+            new \DateTimeImmutable('2026-06-20T12:00:00+03:00'),
+            0,
+            100,
+        );
+
+        self::assertSame('https://finance-api.wildberries.ru/api/finance/v1/sales-reports/detailed', $capturedUrl);
+        $requestPayload = $capturedOptions['json'] ?? json_decode((string) ($capturedOptions['body'] ?? ''), true, 512, \JSON_THROW_ON_ERROR);
+        self::assertSame('2026-06-20', $requestPayload['dateFrom'] ?? null);
+        self::assertSame('2026-06-20', $requestPayload['dateTo'] ?? null);
+        self::assertSame(100, $requestPayload['limit'] ?? null);
+        self::assertSame(0, $requestPayload['rrdId'] ?? null);
+        self::assertSame('daily', $requestPayload['period'] ?? null);
+        self::assertSame(['Authorization: wb-token'], $capturedOptions['normalized_headers']['authorization'] ?? null);
+        self::assertSame([['rrdId' => 10, 'docTypeName' => 'Продажа']], $page->rows);
+        self::assertSame(10, $page->nextRrdId);
+        self::assertFalse($page->hasMore);
+    }
+
+    public function testFullPageReturnsHasMore(): void
+    {
+        $http = new MockHttpClient(new MockResponse('[{"rrdId":11}]', ['http_code' => 200]));
+        $page = $this->client($http)->fetchDetailedDayPage(
+            '0192f0c2-0000-7000-8000-000000000001',
+            'connection-1',
+            new \DateTimeImmutable('2026-06-20'),
+            10,
+            1,
+        );
+
+        self::assertTrue($page->hasMore);
+        self::assertSame(11, $page->nextRrdId);
+    }
+
+    public function testNoContentReturnsEmptyPage(): void
+    {
+        $http = new MockHttpClient(new MockResponse('', ['http_code' => 204]));
+        $page = $this->client($http)->fetchDetailedDayPage(
+            '0192f0c2-0000-7000-8000-000000000001',
+            'connection-1',
+            new \DateTimeImmutable('2026-06-20'),
+            0,
+        );
+
+        self::assertSame([], $page->rows);
+        self::assertNull($page->nextRrdId);
+        self::assertFalse($page->hasMore);
+    }
+
+    public function testAuthFailureIsClassified(): void
+    {
+        $http = new MockHttpClient(new MockResponse('', ['http_code' => 403]));
+
+        $this->expectException(ConnectorAuthException::class);
+
+        $this->client($http)->fetchDetailedDayPage(
+            '0192f0c2-0000-7000-8000-000000000001',
+            'connection-1',
+            new \DateTimeImmutable('2026-06-20'),
+            0,
+        );
+    }
+
+    public function testRemoteRateLimitUsesRetryHeader(): void
+    {
+        $http = new MockHttpClient(new MockResponse('{"error":"rate"}', [
+            'http_code' => 429,
+            'response_headers' => ['x-ratelimit-retry' => '12'],
+        ]));
+
+        try {
+            $this->client($http)->fetchDetailedDayPage(
+                '0192f0c2-0000-7000-8000-000000000001',
+                'connection-1',
+                new \DateTimeImmutable('2026-06-20'),
+                0,
+            );
+            self::fail('Expected rate limit exception.');
+        } catch (ConnectorRateLimitedException $exception) {
+            self::assertSame(12, $exception->retryAfterSeconds());
+        }
+    }
+
+    public function testLocalRateLimitPreventsSecondRequestForSameConnection(): void
+    {
+        $requestCount = 0;
+        $http = new MockHttpClient(static function () use (&$requestCount): MockResponse {
+            ++$requestCount;
+
+            return new MockResponse('[]', ['http_code' => 200]);
+        });
+        $client = $this->client($http);
+
+        $client->fetchDetailedDayPage(
+            '0192f0c2-0000-7000-8000-000000000001',
+            'connection-1',
+            new \DateTimeImmutable('2026-06-20'),
+            0,
+        );
+
+        $this->expectException(ConnectorRateLimitedException::class);
+        try {
+            $client->fetchDetailedDayPage(
+                '0192f0c2-0000-7000-8000-000000000001',
+                'connection-1',
+                new \DateTimeImmutable('2026-06-20'),
+                0,
+            );
+        } finally {
+            self::assertSame(1, $requestCount);
+        }
+    }
+
+    private function client(MockHttpClient $http): WbFinanceReportClient
+    {
+        return new WbFinanceReportClient(
+            $http,
+            new class implements WbCredentialProviderInterface {
+                public function read(string $companyId, string $connectionRef): array
+                {
+                    return ['api_key' => 'wb-token'];
+                }
+            },
+            new RateLimiterFactory(
+                [
+                    'id' => 'wb_finance',
+                    'policy' => 'fixed_window',
+                    'limit' => 1,
+                    'interval' => '70 seconds',
+                ],
+                new InMemoryStorage(),
+            ),
+            new MockClock('2026-06-22T00:00:00+00:00'),
+            new NullLogger(),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds Stage 1 of the Wildberries Finance Ingestion pipeline: raw loading only, without canonical normalization or FinancialTransaction writes.

## Changes

- Added `wildberries_finance_sales_report_detailed` resource support.
- Added a new Ingestion WB Finance client for `POST /api/finance/v1/sales-reports/detailed`.
- Added a WB connector that stores one raw report page per pull and uses `rrdId` cursor continuation.
- Added delayed continuation support in the generic Ingestion chunk handler for rate-limited paged sources.
- Added `app:ingestion:wb-finance:probe` and `app:ingestion:wb-finance:status` diagnostics.
- Extended `app:ingestion:start-backfill` for `source=wildberries` with one-day chunks.
- Kept normalization disabled for this resource until Stage 2.

## Validation

- PHP lint on changed files: passed.
- `php bin/phpunit --testsuite unit --filter 'WbFinanceReport(Client|Connector)Test'`: passed, 12 tests.
- `php bin/phpunit --testsuite integration --filter 'RunSyncChunkHandlerTest|StartBackfillCommandTest'`: passed, 16 tests, 2 existing PHPUnit deprecations.
- `php bin/console lint:container`: passed.
- `git diff --check`: passed.

## Notes

Legacy Marketplace WB pipeline is not used by the new runtime path and was not changed. This PR intentionally stops at raw loading; normalization/preview is the next stage.