### PR TITLE
[codex] Show raw ingestion coverage

### DIFF
--- a/site/src/Ingestion/Infrastructure/Query/CoverageQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/CoverageQuery.php
@@ -28,8 +28,20 @@ final class CoverageQuery
     ): array {
         Assert::uuid($companyId);
 
-        $recordDate = "COALESCE(TO_CHAR(ft.occurred_at, 'YYYY-MM-DD'), TO_CHAR(j.window_from, 'YYYY-MM-DD'))";
+        $recordDate = "COALESCE(TO_CHAR(ft.occurred_at, 'YYYY-MM-DD'), TO_CHAR(j.window_from, 'YYYY-MM-DD'), TO_CHAR(r.fetched_at, 'YYYY-MM-DD'))";
         $shopExpression = "COALESCE(NULLIF(ft.shop_ref, ''), r.shop_ref)";
+        $dateFilter = <<<'SQL'
+            (
+                (ft.id IS NOT NULL AND ft.occurred_at >= :from AND ft.occurred_at < :toExclusive)
+                OR (
+                    ft.id IS NULL
+                    AND (
+                        (j.window_from IS NOT NULL AND j.window_from >= :fromDate AND j.window_from <= :toDate)
+                        OR (j.window_from IS NULL AND r.fetched_at >= :from AND r.fetched_at < :toExclusive)
+                    )
+                )
+            )
+            SQL;
 
         $qb = $this->connection->createQueryBuilder()
             ->select(
@@ -61,7 +73,7 @@ final class CoverageQuery
                 'ni.company_id = r.company_id AND ni.raw_record_id = r.id AND ni.resolved_at IS NULL',
             )
             ->where('r.company_id = :companyId')
-            ->andWhere('((ft.id IS NOT NULL AND ft.occurred_at >= :from AND ft.occurred_at < :toExclusive) OR (ft.id IS NULL AND j.window_from >= :fromDate AND j.window_from <= :toDate))')
+            ->andWhere($dateFilter)
             ->setParameter('companyId', $companyId)
             ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
             ->setParameter('toExclusive', $to->modify('+1 day'), Types::DATETIME_IMMUTABLE)

--- a/site/src/Ingestion/Infrastructure/Query/CoverageQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/CoverageQuery.php
@@ -28,42 +28,52 @@ final class CoverageQuery
     ): array {
         Assert::uuid($companyId);
 
+        $recordDate = "COALESCE(TO_CHAR(ft.occurred_at, 'YYYY-MM-DD'), TO_CHAR(j.window_from, 'YYYY-MM-DD'))";
+        $shopExpression = "COALESCE(NULLIF(ft.shop_ref, ''), r.shop_ref)";
+
         $qb = $this->connection->createQueryBuilder()
             ->select(
-                "TO_CHAR(ft.occurred_at, 'YYYY-MM-DD') AS record_date",
-                'ft.shop_ref',
+                $recordDate.' AS record_date',
+                $shopExpression.' AS shop_ref',
                 'r.resource_type',
                 'COUNT(DISTINCT r.id) AS raw_count',
                 'COUNT(DISTINCT ft.id) AS tx_count',
                 'COUNT(DISTINCT ni.id) AS issue_count',
                 'MAX(r.fetched_at) AS last_fetched_at',
             )
-            ->from('ingest_financial_transactions', 'ft')
+            ->from('ingest_raw_records', 'r')
             ->leftJoin(
-                'ft',
-                'ingest_raw_records',
                 'r',
-                'r.company_id = :companyId AND r.company_id = ft.company_id AND r.id = ft.raw_record_id',
+                'ingest_sync_jobs',
+                'j',
+                'j.company_id = r.company_id AND j.id::text = r.sync_job_id',
             )
             ->leftJoin(
+                'r',
+                'ingest_financial_transactions',
                 'ft',
+                'ft.company_id = r.company_id AND ft.raw_record_id = r.id',
+            )
+            ->leftJoin(
+                'r',
                 'ingest_normalization_issues',
                 'ni',
-                'ni.company_id = :companyId AND ni.company_id = ft.company_id AND ni.raw_record_id = r.id AND ni.resolved_at IS NULL',
+                'ni.company_id = r.company_id AND ni.raw_record_id = r.id AND ni.resolved_at IS NULL',
             )
-            ->where('ft.company_id = :companyId')
-            ->andWhere('ft.occurred_at >= :from')
-            ->andWhere('ft.occurred_at < :toExclusive')
+            ->where('r.company_id = :companyId')
+            ->andWhere('((ft.id IS NOT NULL AND ft.occurred_at >= :from AND ft.occurred_at < :toExclusive) OR (ft.id IS NULL AND j.window_from >= :fromDate AND j.window_from <= :toDate))')
             ->setParameter('companyId', $companyId)
             ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
             ->setParameter('toExclusive', $to->modify('+1 day'), Types::DATETIME_IMMUTABLE)
-            ->groupBy('record_date', 'ft.shop_ref', 'r.resource_type')
+            ->setParameter('fromDate', $from, Types::DATE_IMMUTABLE)
+            ->setParameter('toDate', $to, Types::DATE_IMMUTABLE)
+            ->groupBy($recordDate, $shopExpression, 'r.resource_type')
             ->orderBy('record_date', 'ASC')
-            ->addOrderBy('ft.shop_ref', 'ASC')
+            ->addOrderBy($shopExpression, 'ASC')
             ->addOrderBy('r.resource_type', 'ASC');
 
         if (null !== $shopRef && '' !== $shopRef) {
-            $qb->andWhere('ft.shop_ref = :shopRef')
+            $qb->andWhere($shopExpression.' = :shopRef')
                 ->setParameter('shopRef', $shopRef);
         }
 

--- a/site/tests/Functional/Ingestion/Controller/VerificationApiControllerTest.php
+++ b/site/tests/Functional/Ingestion/Controller/VerificationApiControllerTest.php
@@ -11,8 +11,10 @@ use App\Finance\Enum\PLFlow;
 use App\Ingestion\Entity\FinancialTransaction;
 use App\Ingestion\Entity\IngestRawRecord;
 use App\Ingestion\Entity\NormalizationIssue;
+use App\Ingestion\Entity\SyncJob;
 use App\Ingestion\Enum\IngestSource;
 use App\Ingestion\Enum\NormalizationIssueKind;
+use App\Ingestion\Enum\SyncJobKind;
 use App\Ingestion\Enum\TransactionDirection;
 use App\Ingestion\Enum\TransactionType;
 use App\Marketplace\Entity\OzonTransactionTotalsCheck;
@@ -152,6 +154,64 @@ final class VerificationApiControllerTest extends WebTestCaseBase
             self::assertSame(1, $cell['tx_count']);
             self::assertSame('2026-06-20T07:00:00Z', $cell['last_fetched_at']);
         }
+    }
+
+    public function testCoverageEndpointReturnsRawOnlyIngestionRecords(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $owner = UserBuilder::aUser()->withIndex(9151)->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId('11111111-1111-4111-8111-111111119151')
+            ->withOwner($owner)
+            ->build();
+        $companyId = $company->getId();
+        $connectionRef = 'b4c583ca-083e-46e2-8c9b-6e2deff1220f';
+        $job = new SyncJob(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            source: IngestSource::WILDBERRIES,
+            resourceType: 'wildberries_finance_sales_report_detailed',
+            kind: SyncJobKind::BACKFILL,
+            windowFrom: new \DateTimeImmutable('2026-06-21'),
+            windowTo: new \DateTimeImmutable('2026-06-21'),
+            shopRef: $connectionRef,
+        );
+        $raw = $this->rawRecord(
+            companyId: $companyId,
+            shopRef: $connectionRef,
+            resourceType: 'wildberries_finance_sales_report_detailed',
+            externalId: 'wb-sales-report-detailed:2026-06-21:rrd-0',
+            fetchedAt: new \DateTimeImmutable('2026-06-22 09:17:43+00:00'),
+            source: IngestSource::WILDBERRIES,
+            connectionRef: $connectionRef,
+            syncJobId: $job->getId(),
+        );
+        $raw->markNormalizationSkipped();
+
+        $em = $this->em();
+        $em->persist($owner);
+        $em->persist($company);
+        $em->persist($job);
+        $em->persist($raw);
+        $em->flush();
+
+        $this->loginWithActiveCompany($client, $owner, $company);
+        $client->request('GET', sprintf(
+            '/api/ingestion/verification/coverage?from=2026-06-01&to=2026-06-30&shop_ref=%s',
+            $connectionRef,
+        ));
+
+        self::assertResponseIsSuccessful();
+        $coverage = $this->json($client);
+        self::assertCount(1, $coverage['cells']);
+        self::assertSame('2026-06-21', $coverage['cells'][0]['date']);
+        self::assertSame($connectionRef, $coverage['cells'][0]['shop_ref']);
+        self::assertSame('wildberries_finance_sales_report_detailed', $coverage['cells'][0]['resource_type']);
+        self::assertSame(1, $coverage['cells'][0]['raw_count']);
+        self::assertSame(0, $coverage['cells'][0]['tx_count']);
+        self::assertSame(0, $coverage['cells'][0]['issue_count']);
     }
 
     public function testInvalidPeriodUsesUnifiedErrorFormat(): void
@@ -372,19 +432,22 @@ final class VerificationApiControllerTest extends WebTestCaseBase
         string $resourceType,
         string $externalId,
         ?\DateTimeImmutable $fetchedAt = null,
+        IngestSource $source = IngestSource::OZON,
+        string $connectionRef = 'connection-1',
+        ?string $syncJobId = null,
     ): IngestRawRecord {
         return new IngestRawRecord(
             companyId: $companyId,
-            connectionRef: 'connection-1',
+            connectionRef: $connectionRef,
             shopRef: $shopRef,
-            source: IngestSource::OZON,
+            source: $source,
             resourceType: $resourceType,
             externalId: $externalId,
             storagePath: sprintf('%s/%s.ndjson.gz', $companyId, $externalId),
             hash: hash('sha256', $companyId.$externalId),
             byteSize: 100,
             fetchedAt: $fetchedAt ?? new \DateTimeImmutable('2026-06-15 10:00:00+00:00'),
-            syncJobId: 'job-'.$externalId,
+            syncJobId: $syncJobId ?? 'job-'.$externalId,
         );
     }
 

--- a/site/tests/Functional/Ingestion/Controller/VerificationApiControllerTest.php
+++ b/site/tests/Functional/Ingestion/Controller/VerificationApiControllerTest.php
@@ -214,6 +214,62 @@ final class VerificationApiControllerTest extends WebTestCaseBase
         self::assertSame(0, $coverage['cells'][0]['issue_count']);
     }
 
+    public function testCoverageEndpointFallsBackToFetchedDateForRawOnlyRecordsWithoutJobWindow(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $owner = UserBuilder::aUser()->withIndex(9152)->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId('11111111-1111-4111-8111-111111119152')
+            ->withOwner($owner)
+            ->build();
+        $companyId = $company->getId();
+        $connectionRef = 'b4c583ca-083e-46e2-8c9b-6e2deff1220f';
+        $job = new SyncJob(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            source: IngestSource::WILDBERRIES,
+            resourceType: 'wildberries_finance_sales_report_detailed',
+            kind: SyncJobKind::INCREMENTAL,
+            shopRef: $connectionRef,
+        );
+        $raw = $this->rawRecord(
+            companyId: $companyId,
+            shopRef: $connectionRef,
+            resourceType: 'wildberries_finance_sales_report_detailed',
+            externalId: 'wb-sales-report-detailed:incremental:rrd-0',
+            fetchedAt: new \DateTimeImmutable('2026-06-22 09:17:43+00:00'),
+            source: IngestSource::WILDBERRIES,
+            connectionRef: $connectionRef,
+            syncJobId: $job->getId(),
+        );
+        $raw->markNormalizationSkipped();
+
+        $em = $this->em();
+        $em->persist($owner);
+        $em->persist($company);
+        $em->persist($job);
+        $em->persist($raw);
+        $em->flush();
+
+        $this->loginWithActiveCompany($client, $owner, $company);
+        $client->request('GET', sprintf(
+            '/api/ingestion/verification/coverage?from=2026-06-22&to=2026-06-22&shop_ref=%s',
+            $connectionRef,
+        ));
+
+        self::assertResponseIsSuccessful();
+        $coverage = $this->json($client);
+        self::assertCount(1, $coverage['cells']);
+        self::assertSame('2026-06-22', $coverage['cells'][0]['date']);
+        self::assertSame($connectionRef, $coverage['cells'][0]['shop_ref']);
+        self::assertSame('wildberries_finance_sales_report_detailed', $coverage['cells'][0]['resource_type']);
+        self::assertSame(1, $coverage['cells'][0]['raw_count']);
+        self::assertSame(0, $coverage['cells'][0]['tx_count']);
+        self::assertSame(0, $coverage['cells'][0]['issue_count']);
+    }
+
     public function testInvalidPeriodUsesUnifiedErrorFormat(): void
     {
         $client = static::createClient();

--- a/site/tests/Integration/Ingestion/Infrastructure/Query/VerificationQueriesTest.php
+++ b/site/tests/Integration/Ingestion/Infrastructure/Query/VerificationQueriesTest.php
@@ -134,6 +134,52 @@ final class VerificationQueriesTest extends IntegrationTestCase
         self::assertNotNull($cells[0]->lastFetchedAt);
     }
 
+    public function testCoverageFallsBackToFetchedDateForRawOnlyRecordsWithoutJobWindow(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = Uuid::uuid7()->toString();
+        $job = new SyncJob(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            source: IngestSource::WILDBERRIES,
+            resourceType: 'wildberries_finance_sales_report_detailed',
+            kind: SyncJobKind::INCREMENTAL,
+            shopRef: $connectionRef,
+        );
+        $raw = $this->rawRecord(
+            companyId: $companyId,
+            shopRef: $connectionRef,
+            resourceType: 'wildberries_finance_sales_report_detailed',
+            fetchedAt: new \DateTimeImmutable('2026-06-22 09:17:43+00:00'),
+            externalId: 'wb-sales-report-detailed:incremental:rrd-0',
+            source: IngestSource::WILDBERRIES,
+            connectionRef: $connectionRef,
+            syncJobId: $job->getId(),
+        );
+        $raw->markNormalizationSkipped();
+
+        $this->em->persist($job);
+        $this->em->persist($raw);
+        $this->em->flush();
+
+        /** @var CoverageQuery $query */
+        $query = self::getContainer()->get(CoverageQuery::class);
+        $cells = $query->heatmap(
+            $companyId,
+            $connectionRef,
+            new \DateTimeImmutable('2026-06-22'),
+            new \DateTimeImmutable('2026-06-22'),
+        );
+
+        self::assertCount(1, $cells);
+        self::assertSame('2026-06-22', $cells[0]->date);
+        self::assertSame($connectionRef, $cells[0]->shopRef);
+        self::assertSame('wildberries_finance_sales_report_detailed', $cells[0]->resourceType);
+        self::assertSame(1, $cells[0]->rawCount);
+        self::assertSame(0, $cells[0]->txCount);
+        self::assertSame(0, $cells[0]->issueCount);
+    }
+
     public function testReconciliationComparesShopCanonWithCompanyPeriodOzonControl(): void
     {
         $companyId = Uuid::uuid7()->toString();

--- a/site/tests/Integration/Ingestion/Infrastructure/Query/VerificationQueriesTest.php
+++ b/site/tests/Integration/Ingestion/Infrastructure/Query/VerificationQueriesTest.php
@@ -9,8 +9,10 @@ use App\Finance\Enum\PLFlow;
 use App\Ingestion\Entity\FinancialTransaction;
 use App\Ingestion\Entity\IngestRawRecord;
 use App\Ingestion\Entity\NormalizationIssue;
+use App\Ingestion\Entity\SyncJob;
 use App\Ingestion\Enum\IngestSource;
 use App\Ingestion\Enum\NormalizationIssueKind;
+use App\Ingestion\Enum\SyncJobKind;
 use App\Ingestion\Enum\TransactionDirection;
 use App\Ingestion\Enum\TransactionType;
 use App\Ingestion\Facade\IngestionFacade;
@@ -81,6 +83,55 @@ final class VerificationQueriesTest extends IntegrationTestCase
         self::assertSame(1, $cells[0]->rawCount);
         self::assertSame(2, $cells[0]->txCount);
         self::assertSame(1, $cells[0]->issueCount);
+    }
+
+    public function testCoverageIncludesRawOnlyIngestionRecordsByJobWindowDate(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = Uuid::uuid7()->toString();
+        $job = new SyncJob(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            source: IngestSource::WILDBERRIES,
+            resourceType: 'wildberries_finance_sales_report_detailed',
+            kind: SyncJobKind::BACKFILL,
+            windowFrom: new \DateTimeImmutable('2026-06-21'),
+            windowTo: new \DateTimeImmutable('2026-06-21'),
+            shopRef: $connectionRef,
+        );
+        $raw = $this->rawRecord(
+            companyId: $companyId,
+            shopRef: $connectionRef,
+            resourceType: 'wildberries_finance_sales_report_detailed',
+            fetchedAt: new \DateTimeImmutable('2026-06-22 09:17:43+00:00'),
+            externalId: 'wb-sales-report-detailed:2026-06-21:rrd-0',
+            source: IngestSource::WILDBERRIES,
+            connectionRef: $connectionRef,
+            syncJobId: $job->getId(),
+        );
+        $raw->markNormalizationSkipped();
+
+        $this->em->persist($job);
+        $this->em->persist($raw);
+        $this->em->flush();
+
+        /** @var CoverageQuery $query */
+        $query = self::getContainer()->get(CoverageQuery::class);
+        $cells = $query->heatmap(
+            $companyId,
+            $connectionRef,
+            new \DateTimeImmutable('2026-06-01'),
+            new \DateTimeImmutable('2026-06-30'),
+        );
+
+        self::assertCount(1, $cells);
+        self::assertSame('2026-06-21', $cells[0]->date);
+        self::assertSame($connectionRef, $cells[0]->shopRef);
+        self::assertSame('wildberries_finance_sales_report_detailed', $cells[0]->resourceType);
+        self::assertSame(1, $cells[0]->rawCount);
+        self::assertSame(0, $cells[0]->txCount);
+        self::assertSame(0, $cells[0]->issueCount);
+        self::assertNotNull($cells[0]->lastFetchedAt);
     }
 
     public function testReconciliationComparesShopCanonWithCompanyPeriodOzonControl(): void
@@ -238,19 +289,22 @@ final class VerificationQueriesTest extends IntegrationTestCase
         string $resourceType,
         \DateTimeImmutable $fetchedAt,
         string $externalId,
+        IngestSource $source = IngestSource::OZON,
+        string $connectionRef = 'connection-1',
+        ?string $syncJobId = null,
     ): IngestRawRecord {
         return new IngestRawRecord(
             companyId: $companyId,
-            connectionRef: 'connection-1',
+            connectionRef: $connectionRef,
             shopRef: $shopRef,
-            source: IngestSource::OZON,
+            source: $source,
             resourceType: $resourceType,
             externalId: $externalId,
             storagePath: sprintf('%s/%s.ndjson.gz', $companyId, $externalId),
             hash: hash('sha256', $companyId.$externalId),
             byteSize: 100,
             fetchedAt: $fetchedAt,
-            syncJobId: 'job-'.$externalId,
+            syncJobId: $syncJobId ?? 'job-'.$externalId,
         );
     }
 


### PR DESCRIPTION
## Summary
- Change ingestion coverage to read from raw ingestion records first, so raw-only loads are visible before canonical normalization exists.
- Keep existing coverage counts for canonical transactions and open normalization issues.
- Add query and API coverage tests for raw-only Wildberries finance records.

## Validation
- `php -l` on changed files
- `php bin/phpunit --testsuite integration --filter VerificationQueriesTest`
- `php bin/phpunit --testsuite functional --filter VerificationApiControllerTest`
- `php bin/console lint:container`
- `git diff --check`
