### PR TITLE
[codex] Add WB finance normalization preview

### DIFF
--- a/site/src/Ingestion/Application/Source/Wildberries/WbFinancePreviewResult.php
+++ b/site/src/Ingestion/Application/Source/Wildberries/WbFinancePreviewResult.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Source\Wildberries;
+
+final readonly class WbFinancePreviewResult
+{
+    /**
+     * @param list<WbFinancePreviewTransaction> $transactions
+     * @param list<WbFinancePreviewRowCheck>    $rowChecks
+     * @param list<WbFinancePreviewUnknownRow>  $unknownRows
+     */
+    public function __construct(
+        public array $transactions,
+        public array $rowChecks,
+        public array $unknownRows,
+        public int $scannedRows,
+        public int $emptyRows,
+    ) {
+    }
+}

--- a/site/src/Ingestion/Application/Source/Wildberries/WbFinancePreviewRowCheck.php
+++ b/site/src/Ingestion/Application/Source/Wildberries/WbFinancePreviewRowCheck.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Source\Wildberries;
+
+final readonly class WbFinancePreviewRowCheck
+{
+    public function __construct(
+        public string $rowKey,
+        public string $operationGroupId,
+        public string $date,
+        public string $currency,
+        public int $expectedNetMinor,
+        public int $actualNetMinor,
+        public int $deltaMinor,
+        public int $transactionCount,
+        public string $sellerOperName,
+        public string $docTypeName,
+    ) {
+    }
+}

--- a/site/src/Ingestion/Application/Source/Wildberries/WbFinancePreviewTransaction.php
+++ b/site/src/Ingestion/Application/Source/Wildberries/WbFinancePreviewTransaction.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Source\Wildberries;
+
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+
+final readonly class WbFinancePreviewTransaction
+{
+    /**
+     * @param array<string, mixed> $sourceData
+     */
+    public function __construct(
+        public string $sourceKey,
+        public string $operationGroupId,
+        public string $component,
+        public TransactionType $type,
+        public TransactionDirection $direction,
+        public int $amountMinor,
+        public string $currency,
+        public \DateTimeImmutable $occurredAt,
+        public string $sourceTz,
+        public ?string $field,
+        public string $sellerOperName,
+        public string $docTypeName,
+        public string $description,
+        public array $sourceData = [],
+    ) {
+    }
+
+    public function signedAmountMinor(): int
+    {
+        return TransactionDirection::OUT === $this->direction
+            ? -$this->amountMinor
+            : $this->amountMinor;
+    }
+}

--- a/site/src/Ingestion/Application/Source/Wildberries/WbFinancePreviewUnknownRow.php
+++ b/site/src/Ingestion/Application/Source/Wildberries/WbFinancePreviewUnknownRow.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Source\Wildberries;
+
+final readonly class WbFinancePreviewUnknownRow
+{
+    /**
+     * @param list<string> $nonZeroFields
+     */
+    public function __construct(
+        public string $rowKey,
+        public string $date,
+        public string $sellerOperName,
+        public string $docTypeName,
+        public array $nonZeroFields,
+    ) {
+    }
+}

--- a/site/src/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapper.php
+++ b/site/src/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapper.php
@@ -1,0 +1,533 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Source\Wildberries;
+
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+use Ramsey\Uuid\Uuid;
+
+final readonly class WbFinanceSalesReportDetailedPreviewMapper
+{
+    private const SOURCE_TZ = 'UTC';
+
+    /**
+     * @param iterable<array<string, mixed>> $rows
+     */
+    public function preview(string $companyId, iterable $rows): WbFinancePreviewResult
+    {
+        $transactions = [];
+        $rowChecks = [];
+        $unknownRows = [];
+        $scannedRows = 0;
+        $emptyRows = 0;
+
+        foreach ($rows as $rowIndex => $row) {
+            if (($row['_ingestion_empty'] ?? false) === true) {
+                ++$emptyRows;
+                continue;
+            }
+
+            ++$scannedRows;
+            $rowKey = $this->rowKey($row, (int) $rowIndex);
+            $operationGroupId = Uuid::uuid5(
+                Uuid::NAMESPACE_URL,
+                sprintf('%s:wildberries:sales-report-detailed:%s', $companyId, $rowKey),
+            )->toString();
+            $currency = $this->currency($row);
+            $docTypeName = $this->string($row, 'docTypeName', 'doc_type_name');
+            $sellerOperName = $this->string($row, 'sellerOperName', 'supplier_oper_name');
+            $occurredAt = $this->operationDate($row);
+            $rowTransactionsStart = count($transactions);
+
+            $this->collectSaleRefundComponents($transactions, $row, $operationGroupId, $rowKey, $currency, $occurredAt, $sellerOperName, $docTypeName);
+            $this->collectCostComponents($transactions, $row, $operationGroupId, $rowKey, $currency, $occurredAt, $sellerOperName, $docTypeName);
+
+            $rowTransactions = array_slice($transactions, $rowTransactionsStart);
+            if ([] !== $rowTransactions && $this->isSaleOrReturn($docTypeName)) {
+                $expectedNetMinor = $this->minor($row, 'forPay', 'ppvz_for_pay');
+                if ($this->isReturn($docTypeName)) {
+                    $expectedNetMinor *= -1;
+                }
+
+                $actualNetMinor = array_sum(array_map(
+                    static fn (WbFinancePreviewTransaction $transaction): int => $transaction->signedAmountMinor(),
+                    $rowTransactions,
+                ));
+
+                $rowChecks[] = new WbFinancePreviewRowCheck(
+                    rowKey: $rowKey,
+                    operationGroupId: $operationGroupId,
+                    date: $occurredAt->format('Y-m-d'),
+                    currency: $currency,
+                    expectedNetMinor: $expectedNetMinor,
+                    actualNetMinor: $actualNetMinor,
+                    deltaMinor: $actualNetMinor - $expectedNetMinor,
+                    transactionCount: count($rowTransactions),
+                    sellerOperName: $sellerOperName,
+                    docTypeName: $docTypeName,
+                );
+            }
+
+            if ([] === $rowTransactions && ('' !== $sellerOperName || '' !== $docTypeName)) {
+                $unknownRows[] = new WbFinancePreviewUnknownRow(
+                    rowKey: $rowKey,
+                    date: $occurredAt->format('Y-m-d'),
+                    sellerOperName: $sellerOperName,
+                    docTypeName: $docTypeName,
+                    nonZeroFields: $this->nonZeroKnownMoneyFields($row),
+                );
+            }
+        }
+
+        return new WbFinancePreviewResult($transactions, $rowChecks, $unknownRows, $scannedRows, $emptyRows);
+    }
+
+    /**
+     * @param list<WbFinancePreviewTransaction> $transactions
+     * @param array<string, mixed>              $row
+     */
+    private function collectSaleRefundComponents(
+        array &$transactions,
+        array $row,
+        string $operationGroupId,
+        string $rowKey,
+        string $currency,
+        \DateTimeImmutable $occurredAt,
+        string $sellerOperName,
+        string $docTypeName,
+    ): void {
+        if (!$this->isSaleOrReturn($docTypeName)) {
+            return;
+        }
+
+        $retailMinor = $this->minor($row, 'retailPriceWithDisc', 'retail_price_withdisc_rub');
+        if (0 === $retailMinor) {
+            $retailMinor = $this->minor($row, 'retailAmount', 'retail_amount');
+        }
+
+        $forPayMinor = $this->minor($row, 'forPay', 'ppvz_for_pay');
+        $acquiringMinor = $this->minor($row, 'acquiringFee', 'acquiring_fee');
+        $commissionMinor = $retailMinor - $forPayMinor - $acquiringMinor;
+        $isReturn = $this->isReturn($docTypeName);
+
+        if (0 !== $retailMinor) {
+            $this->add(
+                transactions: $transactions,
+                operationGroupId: $operationGroupId,
+                rowKey: $rowKey,
+                component: $isReturn ? 'refund' : 'sale',
+                type: $isReturn ? TransactionType::REFUND : TransactionType::SALE,
+                signedAmountMinor: $isReturn ? -abs($retailMinor) : abs($retailMinor),
+                currency: $currency,
+                occurredAt: $occurredAt,
+                field: 0 !== $this->minor($row, 'retailPriceWithDisc', 'retail_price_withdisc_rub') ? 'retailPriceWithDisc' : 'retailAmount',
+                sellerOperName: $sellerOperName,
+                docTypeName: $docTypeName,
+                description: $isReturn ? 'WB refund gross amount' : 'WB sale gross amount',
+                row: $row,
+            );
+        }
+
+        if (0 !== $commissionMinor) {
+            $this->add(
+                transactions: $transactions,
+                operationGroupId: $operationGroupId,
+                rowKey: $rowKey,
+                component: 'commission',
+                type: TransactionType::COMMISSION,
+                signedAmountMinor: $isReturn ? abs($commissionMinor) : -abs($commissionMinor),
+                currency: $currency,
+                occurredAt: $occurredAt,
+                field: 'retailPriceWithDisc-forPay-acquiringFee',
+                sellerOperName: $sellerOperName,
+                docTypeName: $docTypeName,
+                description: 'WB marketplace commission',
+                row: $row,
+            );
+        }
+
+        if (0 !== $acquiringMinor) {
+            $this->add(
+                transactions: $transactions,
+                operationGroupId: $operationGroupId,
+                rowKey: $rowKey,
+                component: 'acquiring',
+                type: TransactionType::ACQUIRING,
+                signedAmountMinor: $isReturn ? abs($acquiringMinor) : -abs($acquiringMinor),
+                currency: $currency,
+                occurredAt: $occurredAt,
+                field: 'acquiringFee',
+                sellerOperName: $sellerOperName,
+                docTypeName: $docTypeName,
+                description: 'WB acquiring fee',
+                row: $row,
+            );
+        }
+    }
+
+    /**
+     * @param list<WbFinancePreviewTransaction> $transactions
+     * @param array<string, mixed>              $row
+     */
+    private function collectCostComponents(
+        array &$transactions,
+        array $row,
+        string $operationGroupId,
+        string $rowKey,
+        string $currency,
+        \DateTimeImmutable $occurredAt,
+        string $sellerOperName,
+        string $docTypeName,
+    ): void {
+        $normalizedOperation = mb_strtolower($sellerOperName);
+        $deliveryServiceMinor = $this->minor($row, 'deliveryService', 'delivery_rub');
+        if (0 !== $deliveryServiceMinor && (
+            str_contains($normalizedOperation, 'логист')
+            || 0 !== $this->minor($row, 'deliveryAmount', 'delivery_amount')
+            || 0 !== $this->minor($row, 'returnAmount', 'return_amount')
+        )) {
+            $component = 'logistics';
+            if (0 !== $this->minor($row, 'deliveryAmount', 'delivery_amount')) {
+                $component = 'logistics_delivery';
+            } elseif (0 !== $this->minor($row, 'returnAmount', 'return_amount')) {
+                $component = 'logistics_return';
+            } elseif (str_contains($normalizedOperation, 'коррек')) {
+                $component = 'logistics_correction';
+            }
+
+            $this->addCost($transactions, $operationGroupId, $rowKey, $component, TransactionType::LOGISTICS, -$deliveryServiceMinor, $currency, $occurredAt, 'deliveryService', $sellerOperName, $docTypeName, 'WB logistics', $row);
+        }
+
+        $this->addCostField($transactions, $row, $operationGroupId, $rowKey, $currency, $occurredAt, $sellerOperName, $docTypeName, 'storage', TransactionType::STORAGE, 'paidStorage', 'storage_fee', 'WB storage fee');
+        $this->addCostField($transactions, $row, $operationGroupId, $rowKey, $currency, $occurredAt, $sellerOperName, $docTypeName, 'acceptance', TransactionType::ACCEPTANCE, 'paidAcceptance', 'acceptance', 'WB acceptance fee');
+        $this->addCostField($transactions, $row, $operationGroupId, $rowKey, $currency, $occurredAt, $sellerOperName, $docTypeName, 'penalty', TransactionType::PENALTY, 'penalty', null, 'WB penalty');
+        $this->addCostField($transactions, $row, $operationGroupId, $rowKey, $currency, $occurredAt, $sellerOperName, $docTypeName, 'deduction', TransactionType::ADJUSTMENT, 'deduction', null, 'WB deduction');
+        $this->addCostField($transactions, $row, $operationGroupId, $rowKey, $currency, $occurredAt, $sellerOperName, $docTypeName, 'warehouse_logistics', TransactionType::LOGISTICS, 'rebillLogisticCost', 'rebill_logistic_cost', 'WB warehouse logistics');
+
+        $additionalPaymentMinor = $this->minor($row, 'additionalPayment', 'additional_payment');
+        if (0 !== $additionalPaymentMinor) {
+            $this->add(
+                transactions: $transactions,
+                operationGroupId: $operationGroupId,
+                rowKey: $rowKey,
+                component: 'additional_payment',
+                type: TransactionType::BONUS,
+                signedAmountMinor: $additionalPaymentMinor,
+                currency: $currency,
+                occurredAt: $occurredAt,
+                field: 'additionalPayment',
+                sellerOperName: $sellerOperName,
+                docTypeName: $docTypeName,
+                description: 'WB additional payment',
+                row: $row,
+            );
+        }
+    }
+
+    /**
+     * @param list<WbFinancePreviewTransaction> $transactions
+     * @param array<string, mixed>              $row
+     */
+    private function addCostField(
+        array &$transactions,
+        array $row,
+        string $operationGroupId,
+        string $rowKey,
+        string $currency,
+        \DateTimeImmutable $occurredAt,
+        string $sellerOperName,
+        string $docTypeName,
+        string $component,
+        TransactionType $type,
+        string $camelField,
+        ?string $snakeField,
+        string $description,
+    ): void {
+        $amountMinor = null === $snakeField
+            ? $this->minor($row, $camelField)
+            : $this->minor($row, $camelField, $snakeField);
+
+        if (0 === $amountMinor) {
+            return;
+        }
+
+        $this->addCost(
+            transactions: $transactions,
+            operationGroupId: $operationGroupId,
+            rowKey: $rowKey,
+            component: $component,
+            type: $type,
+            signedAmountMinor: -$amountMinor,
+            currency: $currency,
+            occurredAt: $occurredAt,
+            field: $camelField,
+            sellerOperName: $sellerOperName,
+            docTypeName: $docTypeName,
+            description: $description,
+            row: $row,
+        );
+    }
+
+    /**
+     * @param list<WbFinancePreviewTransaction> $transactions
+     * @param array<string, mixed>              $row
+     */
+    private function addCost(
+        array &$transactions,
+        string $operationGroupId,
+        string $rowKey,
+        string $component,
+        TransactionType $type,
+        int $signedAmountMinor,
+        string $currency,
+        \DateTimeImmutable $occurredAt,
+        string $field,
+        string $sellerOperName,
+        string $docTypeName,
+        string $description,
+        array $row,
+    ): void {
+        $this->add($transactions, $operationGroupId, $rowKey, $component, $type, $signedAmountMinor, $currency, $occurredAt, $field, $sellerOperName, $docTypeName, $description, $row);
+    }
+
+    /**
+     * @param list<WbFinancePreviewTransaction> $transactions
+     * @param array<string, mixed>              $row
+     */
+    private function add(
+        array &$transactions,
+        string $operationGroupId,
+        string $rowKey,
+        string $component,
+        TransactionType $type,
+        int $signedAmountMinor,
+        string $currency,
+        \DateTimeImmutable $occurredAt,
+        ?string $field,
+        string $sellerOperName,
+        string $docTypeName,
+        string $description,
+        array $row,
+    ): void {
+        if (0 === $signedAmountMinor) {
+            return;
+        }
+
+        $transactions[] = new WbFinancePreviewTransaction(
+            sourceKey: sprintf('wb:sales-report-detailed:%s:%s', $this->normalizeComponent($rowKey), $component),
+            operationGroupId: $operationGroupId,
+            component: $component,
+            type: $type,
+            direction: $this->direction($signedAmountMinor),
+            amountMinor: abs($signedAmountMinor),
+            currency: $currency,
+            occurredAt: $occurredAt,
+            sourceTz: self::SOURCE_TZ,
+            field: $field,
+            sellerOperName: $sellerOperName,
+            docTypeName: $docTypeName,
+            description: $description,
+            sourceData: [
+                '_ingestion_resource' => WbResourceType::FINANCE_SALES_REPORT_DETAILED,
+                '_ingestion_component' => $component,
+                '_ingestion_field' => $field,
+                '_ingestion_source_key' => sprintf('wb:sales-report-detailed:%s:%s', $this->normalizeComponent($rowKey), $component),
+                'rrdId' => $this->string($row, 'rrdId', 'rrd_id'),
+                'reportId' => $this->string($row, 'reportId', 'realizationreport_id'),
+                'sellerOperName' => $sellerOperName,
+                'docTypeName' => $docTypeName,
+                'srid' => $this->string($row, 'srid'),
+                'nmId' => $this->string($row, 'nmId', 'nm_id'),
+                'sku' => $this->string($row, 'sku', 'barcode'),
+                'retailPriceWithDisc' => $this->raw($row, 'retailPriceWithDisc', 'retail_price_withdisc_rub'),
+                'forPay' => $this->raw($row, 'forPay', 'ppvz_for_pay'),
+                'acquiringFee' => $this->raw($row, 'acquiringFee', 'acquiring_fee'),
+            ],
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     *
+     * @return list<string>
+     */
+    private function nonZeroKnownMoneyFields(array $row): array
+    {
+        $fields = [
+            ['retailPriceWithDisc', 'retail_price_withdisc_rub'],
+            ['forPay', 'ppvz_for_pay'],
+            ['acquiringFee', 'acquiring_fee'],
+            ['deliveryService', 'delivery_rub'],
+            ['paidStorage', 'storage_fee'],
+            ['paidAcceptance', 'acceptance'],
+            ['penalty'],
+            ['deduction'],
+            ['rebillLogisticCost', 'rebill_logistic_cost'],
+            ['additionalPayment', 'additional_payment'],
+        ];
+
+        $nonZero = [];
+        foreach ($fields as $fieldAliases) {
+            if (0 !== $this->minor($row, ...$fieldAliases)) {
+                $nonZero[] = $fieldAliases[0];
+            }
+        }
+
+        return $nonZero;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function rowKey(array $row, int $rowIndex): string
+    {
+        foreach (['rrdId', 'rrd_id', 'srid', 'shkId', 'shk_id', 'orderId', 'order_id'] as $key) {
+            $value = $this->string($row, $key);
+            if ('' !== $value && '0' !== $value) {
+                return $value;
+            }
+        }
+
+        $reportId = $this->string($row, 'reportId', 'realizationreport_id');
+        if ('' !== $reportId) {
+            return sprintf('%s:row-%d', $reportId, $rowIndex);
+        }
+
+        return sprintf('row-%d', $rowIndex);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function operationDate(array $row): \DateTimeImmutable
+    {
+        foreach (['saleDt', 'sale_dt', 'rrDate', 'rr_dt', 'createDate', 'create_dt', 'dateFrom', 'date_from'] as $key) {
+            $value = $this->string($row, $key);
+            if ('' === $value) {
+                continue;
+            }
+
+            return new \DateTimeImmutable($value, new \DateTimeZone(self::SOURCE_TZ));
+        }
+
+        return new \DateTimeImmutable('@0');
+    }
+
+    private function direction(int $signedAmountMinor): TransactionDirection
+    {
+        return $signedAmountMinor < 0 ? TransactionDirection::OUT : TransactionDirection::IN;
+    }
+
+    private function isSaleOrReturn(string $docTypeName): bool
+    {
+        return $this->isSale($docTypeName) || $this->isReturn($docTypeName);
+    }
+
+    private function isSale(string $docTypeName): bool
+    {
+        return in_array(mb_strtolower(trim($docTypeName)), ['продажа', 'sale'], true);
+    }
+
+    private function isReturn(string $docTypeName): bool
+    {
+        return in_array(mb_strtolower(trim($docTypeName)), ['возврат', 'return'], true);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function currency(array $row): string
+    {
+        $currency = strtoupper($this->string($row, 'currency'));
+
+        return preg_match('/^[A-Z]{3}$/', $currency) ? $currency : 'RUB';
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function minor(array $row, string ...$keys): int
+    {
+        $value = $this->raw($row, ...$keys);
+        if (null === $value) {
+            return 0;
+        }
+
+        return $this->decimalToMinor($value);
+    }
+
+    private function decimalToMinor(mixed $value): int
+    {
+        if (is_int($value)) {
+            return $value * 100;
+        }
+
+        if (is_float($value)) {
+            return (int) round($value * 100);
+        }
+
+        if (!is_string($value)) {
+            return 0;
+        }
+
+        $normalized = str_replace(["\xc2\xa0", ' ', ','], ['', '', '.'], trim($value));
+        if (!preg_match('/^-?\d+(?:\.\d+)?$/', $normalized)) {
+            return 0;
+        }
+
+        $sign = str_starts_with($normalized, '-') ? -1 : 1;
+        $unsigned = ltrim($normalized, '-');
+        [$rubles, $fraction] = array_pad(explode('.', $unsigned, 2), 2, '');
+        $fraction = str_pad($fraction, 3, '0');
+        $minor = ((int) $rubles) * 100 + (int) substr($fraction, 0, 2);
+        if ((int) $fraction[2] >= 5) {
+            ++$minor;
+        }
+
+        return $sign * $minor;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function string(array $row, string ...$keys): string
+    {
+        $value = $this->raw($row, ...$keys);
+
+        return null === $value ? '' : trim((string) $value);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function raw(array $row, string ...$keys): mixed
+    {
+        foreach ($keys as $key) {
+            if (!array_key_exists($key, $row)) {
+                continue;
+            }
+
+            $value = $row[$key];
+            if (null === $value) {
+                continue;
+            }
+
+            if (is_string($value) && '' === trim($value)) {
+                continue;
+            }
+
+            return $value;
+        }
+
+        return null;
+    }
+
+    private function normalizeComponent(string $value): string
+    {
+        $normalized = preg_replace('/[^a-zA-Z0-9._-]+/', '-', $value);
+
+        return trim((string) $normalized, '-') ?: 'unknown';
+    }
+}

--- a/site/src/Ingestion/Command/WbFinancePreviewNormalizationCommand.php
+++ b/site/src/Ingestion/Command/WbFinancePreviewNormalizationCommand.php
@@ -1,0 +1,391 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Command;
+
+use App\Ingestion\Application\Source\Wildberries\WbFinancePreviewResult;
+use App\Ingestion\Application\Source\Wildberries\WbFinancePreviewTransaction;
+use App\Ingestion\Application\Source\Wildberries\WbFinanceSalesReportDetailedPreviewMapper;
+use App\Ingestion\Application\Source\Wildberries\WbResourceType;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Facade\RawStorageFacade;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Webmozart\Assert\Assert;
+
+#[AsCommand(
+    name: 'app:ingestion:wb-finance:preview-normalization',
+    description: 'Previews Wildberries finance canonical mapping from stored raw records without writing transactions.',
+)]
+final class WbFinancePreviewNormalizationCommand extends Command
+{
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly RawStorageFacade $rawStorageFacade,
+        private readonly WbFinanceSalesReportDetailedPreviewMapper $mapper,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Company UUID.')
+            ->addOption('from', null, InputOption::VALUE_REQUIRED, 'Start date YYYY-MM-DD.')
+            ->addOption('to', null, InputOption::VALUE_REQUIRED, 'End date YYYY-MM-DD.')
+            ->addOption('shop-ref', null, InputOption::VALUE_REQUIRED, 'Optional shop reference.')
+            ->addOption('raw-limit', null, InputOption::VALUE_REQUIRED, 'Raw records to scan, 1..500.', 100)
+            ->addOption('raw-row-limit', null, InputOption::VALUE_REQUIRED, 'Rows to scan per raw record, 1..100000.', 100000)
+            ->addOption('sample-limit', null, InputOption::VALUE_REQUIRED, 'Mismatch/unknown sample rows, 1..100.', 20);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        try {
+            $companyId = $this->requiredUuidOption($input, 'company-id');
+            [$from, $to] = $this->requiredDateWindow($input);
+            $shopRef = $this->optionalStringOption($input, 'shop-ref');
+            $rawLimit = $this->intOption($input, 'raw-limit', 1, 500);
+            $rawRowLimit = $this->intOption($input, 'raw-row-limit', 1, 100000);
+            $sampleLimit = $this->intOption($input, 'sample-limit', 1, 100);
+        } catch (\Throwable $exception) {
+            $io->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $rawRecords = $this->rawRecords($companyId, $from, $to, $shopRef, $rawLimit);
+        $result = $this->preview($companyId, $rawRecords, $rawRowLimit);
+
+        $io->title('Wildberries finance normalization preview');
+        $this->printRawRecords($io, $rawRecords);
+        $this->printTransactionSummary($io, $result);
+        $this->printDailyNet($io, $result);
+        $this->printPayoutChecks($io, $result, $sampleLimit);
+        $this->printUnknownRows($io, $result, $sampleLimit);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function rawRecords(
+        string $companyId,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        ?string $shopRef,
+        int $limit,
+    ): array {
+        $conditions = [
+            'r.company_id = :companyId',
+            'r.source = :source',
+            'r.resource_type = :resourceType',
+            "(
+                (j.window_from IS NOT NULL AND j.window_from <= :toDate AND COALESCE(j.window_to, j.window_from) >= :fromDate)
+                OR (j.window_from IS NULL AND r.fetched_at >= :fromAt AND r.fetched_at < :toExclusive)
+            )",
+        ];
+        $params = [
+            'companyId' => $companyId,
+            'source' => IngestSource::WILDBERRIES->value,
+            'resourceType' => WbResourceType::FINANCE_SALES_REPORT_DETAILED,
+            'fromDate' => $from->format('Y-m-d'),
+            'toDate' => $to->format('Y-m-d'),
+            'fromAt' => $from->format('Y-m-d 00:00:00'),
+            'toExclusive' => $to->modify('+1 day')->format('Y-m-d 00:00:00'),
+        ];
+
+        if (null !== $shopRef && '' !== $shopRef) {
+            $conditions[] = 'r.shop_ref = :shopRef';
+            $params['shopRef'] = $shopRef;
+        }
+
+        return $this->connection->fetchAllAssociative(
+            sprintf(
+                'SELECT r.id,
+                        r.external_id,
+                        r.shop_ref,
+                        r.fetched_at,
+                        r.byte_size,
+                        r.normalization_status,
+                        COALESCE(j.window_from::text, DATE(r.fetched_at)::text) AS record_date
+                 FROM ingest_raw_records r
+                 LEFT JOIN ingest_sync_jobs j ON j.id::text = r.sync_job_id AND j.company_id = r.company_id
+                 WHERE %s
+                 ORDER BY record_date ASC, r.fetched_at ASC, r.created_at ASC
+                 LIMIT %d',
+                implode(' AND ', $conditions),
+                $limit,
+            ),
+            $params,
+        );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rawRecords
+     */
+    private function preview(string $companyId, array $rawRecords, int $rowLimit): WbFinancePreviewResult
+    {
+        $transactions = [];
+        $rowChecks = [];
+        $unknownRows = [];
+        $scannedRows = 0;
+        $emptyRows = 0;
+
+        foreach ($rawRecords as $rawRecord) {
+            $rows = [];
+            $recordRows = 0;
+            foreach ($this->rawStorageFacade->read((string) $rawRecord['id'], $companyId) as $row) {
+                if ($recordRows >= $rowLimit) {
+                    break;
+                }
+
+                ++$recordRows;
+                $rows[] = $row;
+            }
+
+            $result = $this->mapper->preview($companyId, $rows);
+            array_push($transactions, ...$result->transactions);
+            array_push($rowChecks, ...$result->rowChecks);
+            array_push($unknownRows, ...$result->unknownRows);
+            $scannedRows += $result->scannedRows;
+            $emptyRows += $result->emptyRows;
+        }
+
+        return new WbFinancePreviewResult($transactions, $rowChecks, $unknownRows, $scannedRows, $emptyRows);
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rawRecords
+     */
+    private function printRawRecords(SymfonyStyle $io, array $rawRecords): void
+    {
+        $io->section('Stored raw records');
+        if ([] === $rawRecords) {
+            $io->writeln('No raw records found for the selected period.');
+
+            return;
+        }
+
+        $io->table(
+            ['date', 'rawId', 'externalId', 'shopRef', 'status', 'bytes', 'fetchedAt'],
+            array_map(static fn (array $row): array => [
+                (string) ($row['record_date'] ?? ''),
+                (string) $row['id'],
+                (string) $row['external_id'],
+                (string) $row['shop_ref'],
+                (string) $row['normalization_status'],
+                (string) $row['byte_size'],
+                (string) $row['fetched_at'],
+            ], $rawRecords),
+        );
+    }
+
+    private function printTransactionSummary(SymfonyStyle $io, WbFinancePreviewResult $result): void
+    {
+        $io->section('Mapped transaction summary');
+        $io->writeln(sprintf('Scanned rows: %d, empty markers: %d, mapped transactions: %d', $result->scannedRows, $result->emptyRows, count($result->transactions)));
+
+        if ([] === $result->transactions) {
+            $io->writeln('No transactions would be mapped.');
+
+            return;
+        }
+
+        $summary = [];
+        foreach ($result->transactions as $transaction) {
+            $key = $transaction->type->value.':'.$transaction->direction->value;
+            $summary[$key] ??= [
+                'type' => $transaction->type->value,
+                'direction' => $transaction->direction->value,
+                'count' => 0,
+                'amountMinor' => 0,
+            ];
+            ++$summary[$key]['count'];
+            $summary[$key]['amountMinor'] += $transaction->amountMinor;
+        }
+
+        uasort($summary, static fn (array $a, array $b): int => [$a['type'], $a['direction']] <=> [$b['type'], $b['direction']]);
+        $io->table(
+            ['type', 'direction', 'txCount', 'totalRub'],
+            array_map(fn (array $row): array => [
+                (string) $row['type'],
+                (string) $row['direction'],
+                (string) $row['count'],
+                $this->minorToRub((int) $row['amountMinor']),
+            ], array_values($summary)),
+        );
+    }
+
+    private function printDailyNet(SymfonyStyle $io, WbFinancePreviewResult $result): void
+    {
+        $io->section('Mapped net by occurred date');
+        if ([] === $result->transactions) {
+            $io->writeln('No rows.');
+
+            return;
+        }
+
+        $byDate = [];
+        foreach ($result->transactions as $transaction) {
+            $date = $transaction->occurredAt->format('Y-m-d');
+            $byDate[$date] ??= ['count' => 0, 'netMinor' => 0];
+            ++$byDate[$date]['count'];
+            $byDate[$date]['netMinor'] += $transaction->signedAmountMinor();
+        }
+
+        ksort($byDate);
+        $io->table(
+            ['date', 'txCount', 'netRub'],
+            array_map(fn (string $date, array $row): array => [
+                $date,
+                (string) $row['count'],
+                $this->minorToRub((int) $row['netMinor']),
+            ], array_keys($byDate), $byDate),
+        );
+    }
+
+    private function printPayoutChecks(SymfonyStyle $io, WbFinancePreviewResult $result, int $sampleLimit): void
+    {
+        $io->section('Sale/refund row payout checks');
+        if ([] === $result->rowChecks) {
+            $io->writeln('No sale/refund payout checks.');
+
+            return;
+        }
+
+        $expectedMinor = 0;
+        $actualMinor = 0;
+        $mismatches = [];
+        foreach ($result->rowChecks as $check) {
+            $expectedMinor += $check->expectedNetMinor;
+            $actualMinor += $check->actualNetMinor;
+            if (0 !== $check->deltaMinor) {
+                $mismatches[] = $check;
+            }
+        }
+
+        $io->table(
+            ['checks', 'mismatches', 'expectedForPayRub', 'mappedNetRub', 'deltaRub'],
+            [[
+                (string) count($result->rowChecks),
+                (string) count($mismatches),
+                $this->minorToRub($expectedMinor),
+                $this->minorToRub($actualMinor),
+                $this->minorToRub($actualMinor - $expectedMinor),
+            ]],
+        );
+
+        if ([] === $mismatches) {
+            return;
+        }
+
+        $io->section('Payout mismatch sample');
+        $io->table(
+            ['date', 'rowKey', 'sellerOperName', 'docTypeName', 'txCount', 'expectedRub', 'actualRub', 'deltaRub'],
+            array_map(fn (object $check): array => [
+                (string) $check->date,
+                (string) $check->rowKey,
+                (string) $check->sellerOperName,
+                (string) $check->docTypeName,
+                (string) $check->transactionCount,
+                $this->minorToRub((int) $check->expectedNetMinor),
+                $this->minorToRub((int) $check->actualNetMinor),
+                $this->minorToRub((int) $check->deltaMinor),
+            ], array_slice($mismatches, 0, $sampleLimit)),
+        );
+    }
+
+    private function printUnknownRows(SymfonyStyle $io, WbFinancePreviewResult $result, int $sampleLimit): void
+    {
+        $io->section('Unknown non-mapped operation rows');
+        if ([] === $result->unknownRows) {
+            $io->writeln('No unknown operation rows.');
+
+            return;
+        }
+
+        $io->writeln(sprintf('Unknown rows: %d', count($result->unknownRows)));
+        $io->table(
+            ['date', 'rowKey', 'sellerOperName', 'docTypeName', 'nonZeroKnownFields'],
+            array_map(static fn (object $row): array => [
+                (string) $row->date,
+                (string) $row->rowKey,
+                (string) $row->sellerOperName,
+                (string) $row->docTypeName,
+                implode(', ', $row->nonZeroFields),
+            ], array_slice($result->unknownRows, 0, $sampleLimit)),
+        );
+    }
+
+    private function requiredUuidOption(InputInterface $input, string $name): string
+    {
+        $value = trim((string) $input->getOption($name));
+        Assert::uuid($value, sprintf('Invalid --%s UUID.', $name));
+
+        return $value;
+    }
+
+    /**
+     * @return array{0: \DateTimeImmutable, 1: \DateTimeImmutable}
+     */
+    private function requiredDateWindow(InputInterface $input): array
+    {
+        $from = $this->requiredDateOption($input, 'from');
+        $to = $this->requiredDateOption($input, 'to');
+        if ($from > $to) {
+            throw new \InvalidArgumentException('The --from date cannot be later than --to.');
+        }
+
+        return [$from, $to];
+    }
+
+    private function requiredDateOption(InputInterface $input, string $name): \DateTimeImmutable
+    {
+        $value = trim((string) $input->getOption($name));
+        Assert::notEmpty($value, sprintf('The --%s option is required.', $name));
+
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
+        if (false === $date || $date->format('Y-m-d') !== $value) {
+            throw new \InvalidArgumentException(sprintf('The --%s option must be a YYYY-MM-DD date.', $name));
+        }
+
+        return $date;
+    }
+
+    private function optionalStringOption(InputInterface $input, string $name): ?string
+    {
+        $value = trim((string) $input->getOption($name));
+
+        return '' === $value ? null : $value;
+    }
+
+    private function intOption(InputInterface $input, string $name, int $min, int $max): int
+    {
+        $value = (string) $input->getOption($name);
+        if (!ctype_digit($value)) {
+            throw new \InvalidArgumentException(sprintf('The --%s option must be an integer from %d to %d.', $name, $min, $max));
+        }
+
+        $number = (int) $value;
+        if ($number < $min || $number > $max) {
+            throw new \InvalidArgumentException(sprintf('The --%s option must be an integer from %d to %d.', $name, $min, $max));
+        }
+
+        return $number;
+    }
+
+    private function minorToRub(int $minor): string
+    {
+        return number_format($minor / 100, 2, '.', '');
+    }
+}

--- a/site/tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapperTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapperTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Application\Source\Wildberries;
+
+use App\Ingestion\Application\Source\Wildberries\WbFinancePreviewTransaction;
+use App\Ingestion\Application\Source\Wildberries\WbFinanceSalesReportDetailedPreviewMapper;
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+use PHPUnit\Framework\TestCase;
+
+final class WbFinanceSalesReportDetailedPreviewMapperTest extends TestCase
+{
+    private const COMPANY_ID = '19621cff-b028-45d9-9193-11f47ad9a8b2';
+
+    public function testMapsSaleRowToGrossSaleCommissionAndAcquiring(): void
+    {
+        $result = $this->mapper()->preview(self::COMPANY_ID, [[
+            'rrdId' => 101,
+            'currency' => 'RUB',
+            'docTypeName' => 'Продажа',
+            'sellerOperName' => 'Продажа',
+            'saleDt' => '2026-06-21T10:15:00Z',
+            'retailPriceWithDisc' => '1000.00',
+            'forPay' => '850.00',
+            'acquiringFee' => '20.00',
+            'srid' => 'sale-srid',
+            'nmId' => 123,
+            'sku' => 'sku-1',
+        ]]);
+
+        self::assertCount(3, $result->transactions);
+
+        $sale = $this->transaction($result->transactions, 'wb:sales-report-detailed:101:sale');
+        self::assertSame(TransactionType::SALE, $sale->type);
+        self::assertSame(TransactionDirection::IN, $sale->direction);
+        self::assertSame(100000, $sale->amountMinor);
+        self::assertSame('2026-06-21 10:15:00', $sale->occurredAt->format('Y-m-d H:i:s'));
+
+        $commission = $this->transaction($result->transactions, 'wb:sales-report-detailed:101:commission');
+        self::assertSame(TransactionType::COMMISSION, $commission->type);
+        self::assertSame(TransactionDirection::OUT, $commission->direction);
+        self::assertSame(13000, $commission->amountMinor);
+        self::assertSame('retailPriceWithDisc-forPay-acquiringFee', $commission->field);
+
+        $acquiring = $this->transaction($result->transactions, 'wb:sales-report-detailed:101:acquiring');
+        self::assertSame(TransactionType::ACQUIRING, $acquiring->type);
+        self::assertSame(TransactionDirection::OUT, $acquiring->direction);
+        self::assertSame(2000, $acquiring->amountMinor);
+
+        self::assertCount(1, $result->rowChecks);
+        self::assertSame(85000, $result->rowChecks[0]->expectedNetMinor);
+        self::assertSame(85000, $result->rowChecks[0]->actualNetMinor);
+        self::assertSame(0, $result->rowChecks[0]->deltaMinor);
+    }
+
+    public function testMapsReturnRowAsOutboundRefundWithCommissionAndAcquiringStorno(): void
+    {
+        $result = $this->mapper()->preview(self::COMPANY_ID, [[
+            'rrdId' => 102,
+            'currency' => 'RUB',
+            'docTypeName' => 'Возврат',
+            'sellerOperName' => 'Возврат',
+            'saleDt' => '2026-06-21T12:00:00Z',
+            'retailPriceWithDisc' => '1000.00',
+            'forPay' => '850.00',
+            'acquiringFee' => '20.00',
+        ]]);
+
+        self::assertCount(3, $result->transactions);
+
+        $refund = $this->transaction($result->transactions, 'wb:sales-report-detailed:102:refund');
+        self::assertSame(TransactionType::REFUND, $refund->type);
+        self::assertSame(TransactionDirection::OUT, $refund->direction);
+        self::assertSame(100000, $refund->amountMinor);
+
+        $commission = $this->transaction($result->transactions, 'wb:sales-report-detailed:102:commission');
+        self::assertSame(TransactionType::COMMISSION, $commission->type);
+        self::assertSame(TransactionDirection::IN, $commission->direction);
+        self::assertSame(13000, $commission->amountMinor);
+
+        $acquiring = $this->transaction($result->transactions, 'wb:sales-report-detailed:102:acquiring');
+        self::assertSame(TransactionType::ACQUIRING, $acquiring->type);
+        self::assertSame(TransactionDirection::IN, $acquiring->direction);
+        self::assertSame(2000, $acquiring->amountMinor);
+
+        self::assertCount(1, $result->rowChecks);
+        self::assertSame(-85000, $result->rowChecks[0]->expectedNetMinor);
+        self::assertSame(-85000, $result->rowChecks[0]->actualNetMinor);
+        self::assertSame(0, $result->rowChecks[0]->deltaMinor);
+    }
+
+    public function testMapsCostFieldsWithAccountingDirectionsAndRounding(): void
+    {
+        $result = $this->mapper()->preview(self::COMPANY_ID, [[
+            'rrdId' => 103,
+            'currency' => 'RUB',
+            'sellerOperName' => 'Логистика',
+            'rrDate' => '2026-06-21',
+            'deliveryAmount' => 1,
+            'deliveryService' => '149.03',
+            'paidStorage' => '10.00',
+            'paidAcceptance' => '3.335',
+            'penalty' => '-5.00',
+            'deduction' => '7',
+            'rebillLogisticCost' => '1.349',
+            'additionalPayment' => '2.50',
+        ]]);
+
+        self::assertCount(7, $result->transactions);
+
+        $logistics = $this->transaction($result->transactions, 'wb:sales-report-detailed:103:logistics_delivery');
+        self::assertSame(TransactionType::LOGISTICS, $logistics->type);
+        self::assertSame(TransactionDirection::OUT, $logistics->direction);
+        self::assertSame(14903, $logistics->amountMinor);
+
+        self::assertSame(1000, $this->transaction($result->transactions, 'wb:sales-report-detailed:103:storage')->amountMinor);
+        self::assertSame(334, $this->transaction($result->transactions, 'wb:sales-report-detailed:103:acceptance')->amountMinor);
+        self::assertSame(700, $this->transaction($result->transactions, 'wb:sales-report-detailed:103:deduction')->amountMinor);
+        self::assertSame(135, $this->transaction($result->transactions, 'wb:sales-report-detailed:103:warehouse_logistics')->amountMinor);
+
+        $penalty = $this->transaction($result->transactions, 'wb:sales-report-detailed:103:penalty');
+        self::assertSame(TransactionType::PENALTY, $penalty->type);
+        self::assertSame(TransactionDirection::IN, $penalty->direction);
+        self::assertSame(500, $penalty->amountMinor);
+
+        $additionalPayment = $this->transaction($result->transactions, 'wb:sales-report-detailed:103:additional_payment');
+        self::assertSame(TransactionType::BONUS, $additionalPayment->type);
+        self::assertSame(TransactionDirection::IN, $additionalPayment->direction);
+        self::assertSame(250, $additionalPayment->amountMinor);
+    }
+
+    public function testReportsUnknownRowsWithNoMappedTransactions(): void
+    {
+        $result = $this->mapper()->preview(self::COMPANY_ID, [[
+            'rrdId' => 104,
+            'sellerOperName' => 'Новая операция',
+            'rrDate' => '2026-06-21',
+            'forPay' => '12.34',
+        ]]);
+
+        self::assertSame([], $result->transactions);
+        self::assertCount(1, $result->unknownRows);
+        self::assertSame('104', $result->unknownRows[0]->rowKey);
+        self::assertSame('Новая операция', $result->unknownRows[0]->sellerOperName);
+        self::assertSame(['forPay'], $result->unknownRows[0]->nonZeroFields);
+    }
+
+    /**
+     * @param list<WbFinancePreviewTransaction> $transactions
+     */
+    private function transaction(array $transactions, string $sourceKey): WbFinancePreviewTransaction
+    {
+        foreach ($transactions as $transaction) {
+            if ($sourceKey === $transaction->sourceKey) {
+                return $transaction;
+            }
+        }
+
+        self::fail(sprintf('Transaction "%s" was not mapped.', $sourceKey));
+    }
+
+    private function mapper(): WbFinanceSalesReportDetailedPreviewMapper
+    {
+        return new WbFinanceSalesReportDetailedPreviewMapper();
+    }
+}


### PR DESCRIPTION
## Summary
- add a pure Wildberries finance detailed report preview mapper for canonical transaction components
- add a read-only CLI command to preview mapped transactions, daily net, forPay checks, and unknown rows from stored raw records
- add unit coverage for sale, refund, costs, sign handling, rounding, and unknown operations

## Safety
- does not register a production SourceMapperInterface for WB
- does not dispatch normalization jobs
- does not write ingest_financial_transactions or change raw normalization statuses

## Checks
- php -l for new files
- phpunit --testsuite unit --filter WbFinanceSalesReportDetailedPreviewMapperTest
- phpunit --testsuite unit --filter WbFinance
- bin/console lint:container
- git diff --check