### PR TITLE
[codex] Map WB PVZ and loyalty preview operations

### DIFF
--- a/site/src/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapper.php
+++ b/site/src/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapper.php
@@ -45,7 +45,7 @@ final readonly class WbFinanceSalesReportDetailedPreviewMapper
             $this->collectCostComponents($transactions, $row, $operationGroupId, $rowKey, $currency, $occurredAt, $sellerOperName, $docTypeName);
 
             $rowTransactions = array_slice($transactions, $rowTransactionsStart);
-            if ([] !== $rowTransactions && $this->isSaleOrReturn($docTypeName)) {
+            if ([] !== $rowTransactions && $this->isSaleOrReturn($docTypeName) && $this->hasPayoutCheckFields($row)) {
                 $expectedNetMinor = $this->minor($row, 'forPay', 'ppvz_for_pay');
                 if ($this->isReturn($docTypeName)) {
                     $expectedNetMinor *= -1;
@@ -205,6 +205,7 @@ final readonly class WbFinanceSalesReportDetailedPreviewMapper
         $this->addCostField($transactions, $row, $operationGroupId, $rowKey, $currency, $occurredAt, $sellerOperName, $docTypeName, 'penalty', TransactionType::PENALTY, 'penalty', null, 'WB penalty');
         $this->addCostField($transactions, $row, $operationGroupId, $rowKey, $currency, $occurredAt, $sellerOperName, $docTypeName, 'deduction', TransactionType::ADJUSTMENT, 'deduction', null, 'WB deduction');
         $this->addCostField($transactions, $row, $operationGroupId, $rowKey, $currency, $occurredAt, $sellerOperName, $docTypeName, 'warehouse_logistics', TransactionType::LOGISTICS, 'rebillLogisticCost', 'rebill_logistic_cost', 'WB warehouse logistics');
+        $this->addCostField($transactions, $row, $operationGroupId, $rowKey, $currency, $occurredAt, $sellerOperName, $docTypeName, 'pvz_processing', TransactionType::LOGISTICS, 'ppvzReward', 'ppvz_reward', 'WB PVZ processing');
 
         $additionalPaymentMinor = $this->minor($row, 'additionalPayment', 'additional_payment');
         if (0 !== $additionalPaymentMinor) {
@@ -221,6 +222,25 @@ final readonly class WbFinanceSalesReportDetailedPreviewMapper
                 sellerOperName: $sellerOperName,
                 docTypeName: $docTypeName,
                 description: 'WB additional payment',
+                row: $row,
+            );
+        }
+
+        $cashbackDiscountMinor = $this->minor($row, 'cashbackDiscount', 'cashback_discount');
+        if (0 !== $cashbackDiscountMinor) {
+            $this->add(
+                transactions: $transactions,
+                operationGroupId: $operationGroupId,
+                rowKey: $rowKey,
+                component: 'loyalty_discount_compensation',
+                type: TransactionType::BONUS,
+                signedAmountMinor: $cashbackDiscountMinor,
+                currency: $currency,
+                occurredAt: $occurredAt,
+                field: 'cashbackDiscount',
+                sellerOperName: $sellerOperName,
+                docTypeName: $docTypeName,
+                description: 'WB loyalty discount compensation',
                 row: $row,
             );
         }
@@ -344,6 +364,8 @@ final readonly class WbFinanceSalesReportDetailedPreviewMapper
                 'retailPriceWithDisc' => $this->raw($row, 'retailPriceWithDisc', 'retail_price_withdisc_rub'),
                 'forPay' => $this->raw($row, 'forPay', 'ppvz_for_pay'),
                 'acquiringFee' => $this->raw($row, 'acquiringFee', 'acquiring_fee'),
+                'ppvzReward' => $this->raw($row, 'ppvzReward', 'ppvz_reward'),
+                'cashbackDiscount' => $this->raw($row, 'cashbackDiscount', 'cashback_discount'),
             ],
         );
     }
@@ -366,6 +388,10 @@ final readonly class WbFinanceSalesReportDetailedPreviewMapper
             ['deduction'],
             ['rebillLogisticCost', 'rebill_logistic_cost'],
             ['additionalPayment', 'additional_payment'],
+            ['ppvzReward', 'ppvz_reward'],
+            ['cashbackDiscount', 'cashback_discount'],
+            ['loyaltyDiscount', 'loyalty_discount'],
+            ['cashbackAmount', 'cashback_amount'],
         ];
 
         $nonZero = [];
@@ -423,6 +449,17 @@ final readonly class WbFinanceSalesReportDetailedPreviewMapper
     private function isSaleOrReturn(string $docTypeName): bool
     {
         return $this->isSale($docTypeName) || $this->isReturn($docTypeName);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hasPayoutCheckFields(array $row): bool
+    {
+        return 0 !== $this->minor($row, 'retailPriceWithDisc', 'retail_price_withdisc_rub')
+            || 0 !== $this->minor($row, 'retailAmount', 'retail_amount')
+            || 0 !== $this->minor($row, 'forPay', 'ppvz_for_pay')
+            || 0 !== $this->minor($row, 'acquiringFee', 'acquiring_fee');
     }
 
     private function isSale(string $docTypeName): bool

--- a/site/src/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapper.php
+++ b/site/src/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapper.php
@@ -197,7 +197,21 @@ final readonly class WbFinanceSalesReportDetailedPreviewMapper
                 $component = 'logistics_correction';
             }
 
-            $this->addCost($transactions, $operationGroupId, $rowKey, $component, TransactionType::LOGISTICS, -$deliveryServiceMinor, $currency, $occurredAt, 'deliveryService', $sellerOperName, $docTypeName, 'WB logistics', $row);
+            $this->addCost(
+                transactions: $transactions,
+                operationGroupId: $operationGroupId,
+                rowKey: $rowKey,
+                component: $component,
+                type: TransactionType::LOGISTICS,
+                signedAmountMinor: $this->costSignedAmountMinor($deliveryServiceMinor),
+                currency: $currency,
+                occurredAt: $occurredAt,
+                field: 'deliveryService',
+                sellerOperName: $sellerOperName,
+                docTypeName: $docTypeName,
+                description: 'WB logistics',
+                row: $row,
+            );
         }
 
         $this->addCostField($transactions, $row, $operationGroupId, $rowKey, $currency, $occurredAt, $sellerOperName, $docTypeName, 'storage', TransactionType::STORAGE, 'paidStorage', 'storage_fee', 'WB storage fee');
@@ -279,7 +293,7 @@ final readonly class WbFinanceSalesReportDetailedPreviewMapper
             rowKey: $rowKey,
             component: $component,
             type: $type,
-            signedAmountMinor: -$amountMinor,
+            signedAmountMinor: $this->costSignedAmountMinor($amountMinor),
             currency: $currency,
             occurredAt: $occurredAt,
             field: $camelField,
@@ -310,6 +324,11 @@ final readonly class WbFinanceSalesReportDetailedPreviewMapper
         array $row,
     ): void {
         $this->add($transactions, $operationGroupId, $rowKey, $component, $type, $signedAmountMinor, $currency, $occurredAt, $field, $sellerOperName, $docTypeName, $description, $row);
+    }
+
+    private function costSignedAmountMinor(int $amountMinor): int
+    {
+        return -abs($amountMinor);
     }
 
     /**

--- a/site/tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapperTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapperTest.php
@@ -131,20 +131,67 @@ final class WbFinanceSalesReportDetailedPreviewMapperTest extends TestCase
         self::assertSame(250, $additionalPayment->amountMinor);
     }
 
-    public function testReportsUnknownRowsWithNoMappedTransactions(): void
+    public function testMapsPvzProcessingRewardAsLogisticsExpense(): void
     {
         $result = $this->mapper()->preview(self::COMPANY_ID, [[
             'rrdId' => 104,
+            'currency' => 'RUB',
+            'sellerOperName' => 'Возмещение за выдачу и возврат товаров на ПВЗ',
+            'docTypeName' => 'Продажа',
+            'rrDate' => '2026-06-21',
+            'ppvzReward' => '17.25',
+        ]]);
+
+        self::assertCount(1, $result->transactions);
+        self::assertSame([], $result->rowChecks);
+        self::assertSame([], $result->unknownRows);
+
+        $transaction = $this->transaction($result->transactions, 'wb:sales-report-detailed:104:pvz_processing');
+        self::assertSame(TransactionType::LOGISTICS, $transaction->type);
+        self::assertSame(TransactionDirection::OUT, $transaction->direction);
+        self::assertSame(1725, $transaction->amountMinor);
+        self::assertSame('ppvzReward', $transaction->field);
+        self::assertSame('17.25', $transaction->sourceData['ppvzReward']);
+    }
+
+    public function testMapsLoyaltyDiscountCompensationAsBonusIncome(): void
+    {
+        $result = $this->mapper()->preview(self::COMPANY_ID, [[
+            'rrdId' => 105,
+            'currency' => 'RUB',
+            'sellerOperName' => 'Компенсация скидки по программе лояльности',
+            'docTypeName' => 'Продажа',
+            'rrDate' => '2026-06-21',
+            'cashbackDiscount' => '42.10',
+        ]]);
+
+        self::assertCount(1, $result->transactions);
+        self::assertSame([], $result->rowChecks);
+        self::assertSame([], $result->unknownRows);
+
+        $transaction = $this->transaction($result->transactions, 'wb:sales-report-detailed:105:loyalty_discount_compensation');
+        self::assertSame(TransactionType::BONUS, $transaction->type);
+        self::assertSame(TransactionDirection::IN, $transaction->direction);
+        self::assertSame(4210, $transaction->amountMinor);
+        self::assertSame('cashbackDiscount', $transaction->field);
+        self::assertSame('42.10', $transaction->sourceData['cashbackDiscount']);
+    }
+
+    public function testReportsUnknownRowsWithNoMappedTransactions(): void
+    {
+        $result = $this->mapper()->preview(self::COMPANY_ID, [[
+            'rrdId' => 106,
             'sellerOperName' => 'Новая операция',
             'rrDate' => '2026-06-21',
             'forPay' => '12.34',
+            'loyaltyDiscount' => '5.67',
         ]]);
 
         self::assertSame([], $result->transactions);
         self::assertCount(1, $result->unknownRows);
-        self::assertSame('104', $result->unknownRows[0]->rowKey);
+        self::assertSame('106', $result->unknownRows[0]->rowKey);
         self::assertSame('Новая операция', $result->unknownRows[0]->sellerOperName);
-        self::assertSame(['forPay'], $result->unknownRows[0]->nonZeroFields);
+        self::assertSame(['forPay', 'loyaltyDiscount'], $result->unknownRows[0]->nonZeroFields);
     }
 
     /**

--- a/site/tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapperTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapperTest.php
@@ -99,12 +99,12 @@ final class WbFinanceSalesReportDetailedPreviewMapperTest extends TestCase
             'sellerOperName' => 'Логистика',
             'rrDate' => '2026-06-21',
             'deliveryAmount' => 1,
-            'deliveryService' => '149.03',
-            'paidStorage' => '10.00',
+            'deliveryService' => '-149.03',
+            'paidStorage' => '-10.00',
             'paidAcceptance' => '3.335',
             'penalty' => '-5.00',
-            'deduction' => '7',
-            'rebillLogisticCost' => '1.349',
+            'deduction' => '-7',
+            'rebillLogisticCost' => '-1.349',
             'additionalPayment' => '2.50',
         ]]);
 
@@ -115,14 +115,25 @@ final class WbFinanceSalesReportDetailedPreviewMapperTest extends TestCase
         self::assertSame(TransactionDirection::OUT, $logistics->direction);
         self::assertSame(14903, $logistics->amountMinor);
 
-        self::assertSame(1000, $this->transaction($result->transactions, 'wb:sales-report-detailed:103:storage')->amountMinor);
-        self::assertSame(334, $this->transaction($result->transactions, 'wb:sales-report-detailed:103:acceptance')->amountMinor);
-        self::assertSame(700, $this->transaction($result->transactions, 'wb:sales-report-detailed:103:deduction')->amountMinor);
-        self::assertSame(135, $this->transaction($result->transactions, 'wb:sales-report-detailed:103:warehouse_logistics')->amountMinor);
+        $storage = $this->transaction($result->transactions, 'wb:sales-report-detailed:103:storage');
+        self::assertSame(TransactionDirection::OUT, $storage->direction);
+        self::assertSame(1000, $storage->amountMinor);
+
+        $acceptance = $this->transaction($result->transactions, 'wb:sales-report-detailed:103:acceptance');
+        self::assertSame(TransactionDirection::OUT, $acceptance->direction);
+        self::assertSame(334, $acceptance->amountMinor);
+
+        $deduction = $this->transaction($result->transactions, 'wb:sales-report-detailed:103:deduction');
+        self::assertSame(TransactionDirection::OUT, $deduction->direction);
+        self::assertSame(700, $deduction->amountMinor);
+
+        $warehouseLogistics = $this->transaction($result->transactions, 'wb:sales-report-detailed:103:warehouse_logistics');
+        self::assertSame(TransactionDirection::OUT, $warehouseLogistics->direction);
+        self::assertSame(135, $warehouseLogistics->amountMinor);
 
         $penalty = $this->transaction($result->transactions, 'wb:sales-report-detailed:103:penalty');
         self::assertSame(TransactionType::PENALTY, $penalty->type);
-        self::assertSame(TransactionDirection::IN, $penalty->direction);
+        self::assertSame(TransactionDirection::OUT, $penalty->direction);
         self::assertSame(500, $penalty->amountMinor);
 
         $additionalPayment = $this->transaction($result->transactions, 'wb:sales-report-detailed:103:additional_payment');
@@ -139,7 +150,7 @@ final class WbFinanceSalesReportDetailedPreviewMapperTest extends TestCase
             'sellerOperName' => 'Возмещение за выдачу и возврат товаров на ПВЗ',
             'docTypeName' => 'Продажа',
             'rrDate' => '2026-06-21',
-            'ppvzReward' => '17.25',
+            'ppvzReward' => '-17.25',
         ]]);
 
         self::assertCount(1, $result->transactions);
@@ -151,7 +162,7 @@ final class WbFinanceSalesReportDetailedPreviewMapperTest extends TestCase
         self::assertSame(TransactionDirection::OUT, $transaction->direction);
         self::assertSame(1725, $transaction->amountMinor);
         self::assertSame('ppvzReward', $transaction->field);
-        self::assertSame('17.25', $transaction->sourceData['ppvzReward']);
+        self::assertSame('-17.25', $transaction->sourceData['ppvzReward']);
     }
 
     public function testMapsLoyaltyDiscountCompensationAsBonusIncome(): void


### PR DESCRIPTION
## Summary
- map WB PVZ processing rows via `ppvzReward` as logistics expense in normalization preview
- map WB loyalty discount compensation via `cashbackDiscount` as bonus income in normalization preview
- include `ppvzReward`, `cashbackDiscount`, `loyaltyDiscount`, and `cashbackAmount` in unknown-row diagnostics
- avoid `forPay` payout checks for non-gross rows that only carry auxiliary operation fields
- keep WB cost fields as expenses with `OUT` direction even when WB sends negative charge amounts

## Review fixes
- addressed P2 review: `deliveryService` and shared cost-field mapping now use `-abs(amount)` instead of negating the raw value
- added/updated unit assertions for negative logistics, storage, penalty, deduction, warehouse logistics, and PVZ processing amounts

## Safety
- preview-only change
- does not register production WB `SourceMapperInterface`
- does not write `ingest_financial_transactions` or change raw normalization statuses
- listing binding remains optional; WB operation identifiers stay in `sourceData` for auditability

## Production verification after deploy
Run:

```bash
docker exec -it scheduler php /app/bin/console app:ingestion:wb-finance:preview-normalization \
  --company-id=19621cff-b028-45d9-9193-11f47ad9a8b2 \
  --from=2026-06-01 \
  --to=2026-06-21 \
  --shop-ref=b4c583ca-083e-46e2-8c9b-6e2deff1220f
```

Expected checks:
- `Sale/refund row payout checks` keeps `mismatches=0`
- `Unknown non-mapped operation rows` drops from the previous 232 rows
- PVZ rows are reflected as `logistics`, loyalty compensation rows as `bonus`
- negative WB cost rows stay `OUT` and reduce daily net

## Checks
- `php -l src/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapper.php`
- `php -l tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapperTest.php`
- `phpunit --testsuite unit --filter WbFinanceSalesReportDetailedPreviewMapperTest`
- `phpunit --testsuite unit --filter WbFinance`
- `bin/console lint:container`
- `git diff --check`
