### PR TITLE
[codex] Fix WB preview payout checks

### DIFF
--- a/site/src/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapper.php
+++ b/site/src/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapper.php
@@ -51,9 +51,10 @@ final readonly class WbFinanceSalesReportDetailedPreviewMapper
                     $expectedNetMinor *= -1;
                 }
 
+                $payoutTransactions = $this->payoutCheckTransactions($rowTransactions);
                 $actualNetMinor = array_sum(array_map(
                     static fn (WbFinancePreviewTransaction $transaction): int => $transaction->signedAmountMinor(),
-                    $rowTransactions,
+                    $payoutTransactions,
                 ));
 
                 $rowChecks[] = new WbFinancePreviewRowCheck(
@@ -64,7 +65,7 @@ final readonly class WbFinanceSalesReportDetailedPreviewMapper
                     expectedNetMinor: $expectedNetMinor,
                     actualNetMinor: $actualNetMinor,
                     deltaMinor: $actualNetMinor - $expectedNetMinor,
-                    transactionCount: count($rowTransactions),
+                    transactionCount: count($payoutTransactions),
                     sellerOperName: $sellerOperName,
                     docTypeName: $docTypeName,
                 );
@@ -329,6 +330,23 @@ final readonly class WbFinanceSalesReportDetailedPreviewMapper
     private function costSignedAmountMinor(int $amountMinor): int
     {
         return -abs($amountMinor);
+    }
+
+    /**
+     * @param list<WbFinancePreviewTransaction> $transactions
+     *
+     * @return list<WbFinancePreviewTransaction>
+     */
+    private function payoutCheckTransactions(array $transactions): array
+    {
+        return array_values(array_filter(
+            $transactions,
+            static fn (WbFinancePreviewTransaction $transaction): bool => in_array(
+                $transaction->type,
+                [TransactionType::SALE, TransactionType::REFUND, TransactionType::COMMISSION, TransactionType::ACQUIRING],
+                true,
+            ),
+        ));
     }
 
     /**

--- a/site/tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapperTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapperTest.php
@@ -55,6 +55,35 @@ final class WbFinanceSalesReportDetailedPreviewMapperTest extends TestCase
         self::assertSame(0, $result->rowChecks[0]->deltaMinor);
     }
 
+    public function testPayoutCheckIgnoresAuxiliaryOperationsOnSaleRow(): void
+    {
+        $result = $this->mapper()->preview(self::COMPANY_ID, [[
+            'rrdId' => 107,
+            'currency' => 'RUB',
+            'docTypeName' => 'Продажа',
+            'sellerOperName' => 'Продажа',
+            'saleDt' => '2026-06-21T10:15:00Z',
+            'retailPriceWithDisc' => '1000.00',
+            'forPay' => '850.00',
+            'acquiringFee' => '20.00',
+            'deliveryAmount' => 1,
+            'deliveryService' => '-50.00',
+            'ppvzReward' => '-17.25',
+            'cashbackDiscount' => '4.10',
+        ]]);
+
+        self::assertCount(6, $result->transactions);
+        $this->transaction($result->transactions, 'wb:sales-report-detailed:107:logistics_delivery');
+        $this->transaction($result->transactions, 'wb:sales-report-detailed:107:pvz_processing');
+        $this->transaction($result->transactions, 'wb:sales-report-detailed:107:loyalty_discount_compensation');
+
+        self::assertCount(1, $result->rowChecks);
+        self::assertSame(85000, $result->rowChecks[0]->expectedNetMinor);
+        self::assertSame(85000, $result->rowChecks[0]->actualNetMinor);
+        self::assertSame(0, $result->rowChecks[0]->deltaMinor);
+        self::assertSame(3, $result->rowChecks[0]->transactionCount);
+    }
+
     public function testMapsReturnRowAsOutboundRefundWithCommissionAndAcquiringStorno(): void
     {
         $result = $this->mapper()->preview(self::COMPANY_ID, [[


### PR DESCRIPTION
## Summary
- limit WB sale/refund payout preview checks to payout components only
- keep auxiliary mapped operations in preview totals without including them in `forPay` row checks
- add regression coverage for sale rows that also carry logistics, PVZ processing, and loyalty compensation

## Root cause
After PVZ and loyalty operations started mapping, sale rows could contain both payout components and auxiliary operations. The preview compared `forPay` against every mapped transaction on the row, so logistics/PVZ/bonus changed `actualNetMinor` and produced false payout mismatches.

## Safety
- preview-only change
- does not write `ingest_financial_transactions`
- does not change raw normalization status or production mapper registration

## Checks
- `php -l src/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapper.php`
- `php -l tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapperTest.php`
- `phpunit --testsuite unit --filter WbFinanceSalesReportDetailedPreviewMapperTest`
- `phpunit --testsuite unit --filter WbFinance`
- `bin/console lint:container`
- `git diff --check`
