### PR TITLE
[codex] Fix ingestion coverage date windows

### DIFF
--- a/site/src/Ingestion/Command/WbFinancePreviewNormalizationCommand.php
+++ b/site/src/Ingestion/Command/WbFinancePreviewNormalizationCommand.php
@@ -85,13 +85,15 @@ final class WbFinancePreviewNormalizationCommand extends Command
         ?string $shopRef,
         int $limit,
     ): array {
+        $externalReportDate = "substring(r.external_id from '^wb-sales-report-detailed:([0-9]{4}-[0-9]{2}-[0-9]{2}):rrd-[0-9]+$')::date";
+        $recordDate = sprintf('COALESCE(j.window_from, %s, DATE(r.fetched_at))', $externalReportDate);
         $conditions = [
             'r.company_id = :companyId',
             'r.source = :source',
             'r.resource_type = :resourceType',
             "(
                 (j.window_from IS NOT NULL AND j.window_from <= :toDate AND COALESCE(j.window_to, j.window_from) >= :fromDate)
-                OR (j.window_from IS NULL AND r.fetched_at >= :fromAt AND r.fetched_at < :toExclusive)
+                OR (j.window_from IS NULL AND {$recordDate} >= :fromDate AND {$recordDate} <= :toDate)
             )",
         ];
         $params = [
@@ -100,8 +102,6 @@ final class WbFinancePreviewNormalizationCommand extends Command
             'resourceType' => WbResourceType::FINANCE_SALES_REPORT_DETAILED,
             'fromDate' => $from->format('Y-m-d'),
             'toDate' => $to->format('Y-m-d'),
-            'fromAt' => $from->format('Y-m-d 00:00:00'),
-            'toExclusive' => $to->modify('+1 day')->format('Y-m-d 00:00:00'),
         ];
 
         if (null !== $shopRef && '' !== $shopRef) {
@@ -117,12 +117,13 @@ final class WbFinancePreviewNormalizationCommand extends Command
                         r.fetched_at,
                         r.byte_size,
                         r.normalization_status,
-                        COALESCE(j.window_from::text, DATE(r.fetched_at)::text) AS record_date
+                        TO_CHAR(%s, \'YYYY-MM-DD\') AS record_date
                  FROM ingest_raw_records r
                  LEFT JOIN ingest_sync_jobs j ON j.id::text = r.sync_job_id AND j.company_id = r.company_id
                  WHERE %s
                  ORDER BY record_date ASC, r.fetched_at ASC, r.created_at ASC
                  LIMIT %d',
+                $recordDate,
                 implode(' AND ', $conditions),
                 $limit,
             ),

--- a/site/src/Ingestion/Infrastructure/Query/CoverageQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/CoverageQuery.php
@@ -28,7 +28,7 @@ final class CoverageQuery
     ): array {
         Assert::uuid($companyId);
 
-        $recordDate = "COALESCE(TO_CHAR(ft.occurred_at, 'YYYY-MM-DD'), TO_CHAR(j.window_from, 'YYYY-MM-DD'), TO_CHAR(r.fetched_at, 'YYYY-MM-DD'))";
+        $recordDate = "COALESCE(TO_CHAR(ft.occurred_at, 'YYYY-MM-DD'), TO_CHAR(raw_window.day, 'YYYY-MM-DD'), TO_CHAR(r.fetched_at, 'YYYY-MM-DD'))";
         $shopExpression = "COALESCE(NULLIF(ft.shop_ref, ''), r.shop_ref)";
         $dateFilter = <<<'SQL'
             (
@@ -36,7 +36,7 @@ final class CoverageQuery
                 OR (
                     ft.id IS NULL
                     AND (
-                        (j.window_from IS NOT NULL AND j.window_from >= :fromDate AND j.window_from <= :toDate)
+                        (j.window_from IS NOT NULL AND j.window_from <= :toDate AND COALESCE(j.window_to, j.window_from) >= :fromDate)
                         OR (j.window_from IS NULL AND r.fetched_at >= :from AND r.fetched_at < :toExclusive)
                     )
                 )
@@ -65,6 +65,20 @@ final class CoverageQuery
                 'ingest_financial_transactions',
                 'ft',
                 'ft.company_id = r.company_id AND ft.raw_record_id = r.id',
+            )
+            ->leftJoin(
+                'r',
+                "LATERAL (
+                    SELECT day::date AS day
+                    FROM generate_series(
+                        GREATEST(j.window_from, :fromDate)::date,
+                        LEAST(COALESCE(j.window_to, j.window_from), :toDate)::date,
+                        interval '1 day'
+                    ) AS day
+                    WHERE ft.id IS NULL AND j.window_from IS NOT NULL
+                )",
+                'raw_window',
+                'true',
             )
             ->leftJoin(
                 'r',

--- a/site/tests/Integration/Ingestion/Command/WbFinancePreviewNormalizationCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/WbFinancePreviewNormalizationCommandTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Command;
+
+use App\Ingestion\Application\Source\Wildberries\WbResourceType;
+use App\Ingestion\DTO\RawBatch;
+use App\Ingestion\Entity\SyncJob;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\SyncJobKind;
+use App\Ingestion\Facade\RawStorageFacade;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class WbFinancePreviewNormalizationCommandTest extends IntegrationTestCase
+{
+    public function testWindowlessRecordsAreSelectedByReportDateFromExternalId(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = Uuid::uuid7()->toString();
+        $job = new SyncJob(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            source: IngestSource::WILDBERRIES,
+            resourceType: WbResourceType::FINANCE_SALES_REPORT_DETAILED,
+            kind: SyncJobKind::INCREMENTAL,
+            shopRef: $connectionRef,
+        );
+
+        $this->em->persist($job);
+        $this->em->flush();
+
+        /** @var RawStorageFacade $rawStorage */
+        $rawStorage = self::getContainer()->get(RawStorageFacade::class);
+        $rawStorage->store($this->batch(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            syncJobId: $job->getId(),
+            externalId: 'wb-sales-report-detailed:2026-06-20:rrd-0',
+            fetchedAt: new \DateTimeImmutable('2026-06-21 10:00:00+00:00'),
+        ));
+        $rawStorage->store($this->batch(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            syncJobId: $job->getId(),
+            externalId: 'wb-sales-report-detailed:2026-06-21:rrd-0',
+            fetchedAt: new \DateTimeImmutable('2026-06-22 09:17:43+00:00'),
+        ));
+
+        $tester = $this->tester();
+        $exit = $tester->execute([
+            '--company-id' => $companyId,
+            '--from' => '2026-06-21',
+            '--to' => '2026-06-21',
+            '--shop-ref' => $connectionRef,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('wb-sales-report-detailed:2026-06-21:rrd-0', $display);
+        self::assertStringNotContainsString('wb-sales-report-detailed:2026-06-20:rrd-0', $display);
+        self::assertStringContainsString('No unknown operation rows.', $display);
+    }
+
+    private function tester(): CommandTester
+    {
+        $app = new Application(self::$kernel);
+
+        return new CommandTester($app->find('app:ingestion:wb-finance:preview-normalization'));
+    }
+
+    private function batch(
+        string $companyId,
+        string $connectionRef,
+        string $syncJobId,
+        string $externalId,
+        \DateTimeImmutable $fetchedAt,
+    ): RawBatch {
+        return new RawBatch(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            shopRef: $connectionRef,
+            source: IngestSource::WILDBERRIES,
+            resourceType: WbResourceType::FINANCE_SALES_REPORT_DETAILED,
+            externalId: $externalId,
+            syncJobId: $syncJobId,
+            fetchedAt: $fetchedAt,
+            rows: [[
+                'rrdId' => 1,
+                'rrDate' => '2026-06-21',
+                'currency' => 'RUB',
+                'sellerOperName' => '',
+                'docTypeName' => '',
+            ]],
+        );
+    }
+}

--- a/site/tests/Integration/Ingestion/Infrastructure/Query/VerificationQueriesTest.php
+++ b/site/tests/Integration/Ingestion/Infrastructure/Query/VerificationQueriesTest.php
@@ -134,6 +134,56 @@ final class VerificationQueriesTest extends IntegrationTestCase
         self::assertNotNull($cells[0]->lastFetchedAt);
     }
 
+    public function testCoverageExpandsRawOnlyMultiDayJobWindowAcrossRequestedOverlap(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = Uuid::uuid7()->toString();
+        $job = new SyncJob(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            source: IngestSource::OZON,
+            resourceType: 'ozon_finance_accrual_by_day',
+            kind: SyncJobKind::BACKFILL,
+            windowFrom: new \DateTimeImmutable('2026-06-01'),
+            windowTo: new \DateTimeImmutable('2026-06-07'),
+            shopRef: $connectionRef,
+        );
+        $raw = $this->rawRecord(
+            companyId: $companyId,
+            shopRef: $connectionRef,
+            resourceType: 'ozon_finance_accrual_by_day',
+            fetchedAt: new \DateTimeImmutable('2026-06-08 09:00:00+00:00'),
+            externalId: 'ozon-accrual-by-day:2026-06-01:2026-06-07',
+            source: IngestSource::OZON,
+            connectionRef: $connectionRef,
+            syncJobId: $job->getId(),
+        );
+        $raw->markNormalizationSkipped();
+
+        $this->em->persist($job);
+        $this->em->persist($raw);
+        $this->em->flush();
+
+        /** @var CoverageQuery $query */
+        $query = self::getContainer()->get(CoverageQuery::class);
+        $cells = $query->heatmap(
+            $companyId,
+            $connectionRef,
+            new \DateTimeImmutable('2026-06-05'),
+            new \DateTimeImmutable('2026-06-06'),
+        );
+
+        self::assertCount(2, $cells);
+        self::assertSame(['2026-06-05', '2026-06-06'], array_map(static fn ($cell): string => $cell->date, $cells));
+        foreach ($cells as $cell) {
+            self::assertSame($connectionRef, $cell->shopRef);
+            self::assertSame('ozon_finance_accrual_by_day', $cell->resourceType);
+            self::assertSame(1, $cell->rawCount);
+            self::assertSame(0, $cell->txCount);
+            self::assertSame(0, $cell->issueCount);
+        }
+    }
+
     public function testCoverageFallsBackToFetchedDateForRawOnlyRecordsWithoutJobWindow(): void
     {
         $companyId = Uuid::uuid7()->toString();


### PR DESCRIPTION
## Summary
- Select windowless WB finance preview raw records by report date from external_id before falling back to fetched_at.
- Match raw-only coverage by job-window overlap and expand multi-day raw-only windows across the requested date range.
- Add regression coverage for both date-window cases.

## Checks
- docker compose run --rm -T site-php-cli sh -lc 'php -l src/Ingestion/Command/WbFinancePreviewNormalizationCommand.php && php -l src/Ingestion/Infrastructure/Query/CoverageQuery.php && php -l tests/Integration/Ingestion/Command/WbFinancePreviewNormalizationCommandTest.php && php -l tests/Integration/Ingestion/Infrastructure/Query/VerificationQueriesTest.php'
- docker compose run --rm -T site-php-cli php -d memory_limit=1G bin/phpunit --testsuite integration --filter 'WbFinancePreviewNormalizationCommandTest|VerificationQueriesTest'
- docker compose run --rm -T site-php-cli php -d memory_limit=1G bin/console lint:container