### PR TITLE
[codex] Add WB finance production mapper

### DIFF
--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -172,6 +172,9 @@ services:
     App\Ingestion\Application\Source\Ozon\OzonAccrualShadowMapper:
         tags: ['app.ingestion.mapper']
 
+    App\Ingestion\Application\Source\Wildberries\WbFinanceSalesReportDetailedMapper:
+        tags: ['app.ingestion.mapper']
+
     App\Ingestion\Domain\Service\ConnectorRegistry:
         arguments:
             $connectors: !tagged_iterator app.ingestion.connector

--- a/site/src/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedMapper.php
+++ b/site/src/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedMapper.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Source\Wildberries;
+
+use App\Ingestion\Application\DTO\MappedControlSum;
+use App\Ingestion\Application\DTO\MappedTransaction;
+use App\Ingestion\Domain\Contract\RawRecordAwareControlSumMapperInterface;
+use App\Ingestion\Domain\Contract\SourceMapperInterface;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\IngestSource;
+use App\Shared\Domain\ValueObject\Money;
+
+final readonly class WbFinanceSalesReportDetailedMapper implements SourceMapperInterface, RawRecordAwareControlSumMapperInterface
+{
+    public function __construct(private WbFinanceSalesReportDetailedPreviewMapper $previewMapper)
+    {
+    }
+
+    public function source(): IngestSource
+    {
+        return IngestSource::WILDBERRIES;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function resourceTypes(): array
+    {
+        return [WbResourceType::FINANCE_SALES_REPORT_DETAILED];
+    }
+
+    /**
+     * @param iterable<array<string, mixed>> $rows
+     *
+     * @return list<MappedTransaction>
+     */
+    public function map(IngestRawRecord $rawRecord, iterable $rows): array
+    {
+        $preview = $this->previewMapper->preview($rawRecord->getCompanyId(), $rows);
+        $this->assertPreviewIsWritable($preview);
+
+        $transactions = [];
+        foreach ($preview->transactions as $transaction) {
+            $transactions[] = new MappedTransaction(
+                externalId: $transaction->sourceKey,
+                externalUpdatedAt: $rawRecord->getFetchedAt(),
+                operationGroupId: $transaction->operationGroupId,
+                type: $transaction->type,
+                direction: $transaction->direction,
+                money: Money::fromMinor($transaction->amountMinor, $transaction->currency),
+                occurredAt: $transaction->occurredAt,
+                sourceTz: $transaction->sourceTz,
+                orderRef: $this->nonEmptyString($transaction->sourceData['srid'] ?? null),
+                payoutRef: $this->nonEmptyString($transaction->sourceData['reportId'] ?? null),
+                description: $transaction->description,
+                sourceData: $transaction->sourceData,
+            );
+        }
+
+        return $transactions;
+    }
+
+    /**
+     * @param iterable<array<string, mixed>> $rows
+     *
+     * @return list<MappedControlSum>
+     */
+    public function controlSum(iterable $rows): array
+    {
+        return [];
+    }
+
+    /**
+     * @param iterable<array<string, mixed>> $rows
+     *
+     * @return list<MappedControlSum>
+     */
+    public function controlSumForRawRecord(IngestRawRecord $rawRecord, iterable $rows): array
+    {
+        $preview = $this->previewMapper->preview($rawRecord->getCompanyId(), $rows);
+        $this->assertPreviewIsWritable($preview);
+
+        $amountsByGroup = [];
+        foreach ($preview->transactions as $transaction) {
+            $amountsByGroup[$transaction->operationGroupId] ??= [
+                'currency' => $transaction->currency,
+                'amountMinor' => 0,
+            ];
+            $amountsByGroup[$transaction->operationGroupId]['amountMinor'] += $transaction->amountMinor;
+        }
+
+        $controlSums = [];
+        foreach ($amountsByGroup as $operationGroupId => $controlSum) {
+            $controlSums[] = new MappedControlSum(
+                operationGroupId: $operationGroupId,
+                currency: $controlSum['currency'],
+                amountMinor: $controlSum['amountMinor'],
+            );
+        }
+
+        return $controlSums;
+    }
+
+    private function assertPreviewIsWritable(WbFinancePreviewResult $preview): void
+    {
+        $mismatches = array_values(array_filter(
+            $preview->rowChecks,
+            static fn (WbFinancePreviewRowCheck $check): bool => 0 !== $check->deltaMinor,
+        ));
+        if ([] !== $mismatches) {
+            $first = $mismatches[0];
+
+            throw new \RuntimeException(sprintf('WB finance payout check mismatch for row "%s": expected %d, actual %d.', $first->rowKey, $first->expectedNetMinor, $first->actualNetMinor));
+        }
+
+        $unknownRowsWithAmounts = array_values(array_filter(
+            $preview->unknownRows,
+            static fn (WbFinancePreviewUnknownRow $row): bool => [] !== $row->nonZeroFields,
+        ));
+        if ([] !== $unknownRowsWithAmounts) {
+            $first = $unknownRowsWithAmounts[0];
+
+            throw new \RuntimeException(sprintf('WB finance row "%s" has unmapped non-zero fields: %s.', $first->rowKey, implode(', ', $first->nonZeroFields)));
+        }
+    }
+
+    private function nonEmptyString(mixed $value): ?string
+    {
+        $value = trim((string) $value);
+
+        return '' === $value || '0' === $value ? null : $value;
+    }
+}

--- a/site/tests/Integration/Ingestion/Application/Source/Wildberries/WbFinanceIngestionRegistryTest.php
+++ b/site/tests/Integration/Ingestion/Application/Source/Wildberries/WbFinanceIngestionRegistryTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Application\Source\Wildberries;
+
+use App\Ingestion\Application\Source\Wildberries\WbFinanceSalesReportDetailedMapper;
+use App\Ingestion\Application\Source\Wildberries\WbResourceType;
+use App\Ingestion\Domain\Service\MapperRegistry;
+use App\Ingestion\Enum\IngestSource;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+
+final class WbFinanceIngestionRegistryTest extends IntegrationTestCase
+{
+    public function testWildberriesFinanceMapperIsRegistered(): void
+    {
+        /** @var MapperRegistry $mapperRegistry */
+        $mapperRegistry = self::getContainer()->get(MapperRegistry::class);
+
+        self::assertInstanceOf(
+            WbFinanceSalesReportDetailedMapper::class,
+            $mapperRegistry->get(IngestSource::WILDBERRIES, WbResourceType::FINANCE_SALES_REPORT_DETAILED),
+        );
+    }
+}

--- a/site/tests/Integration/Ingestion/Application/Source/Wildberries/WbFinanceNormalizationFlowTest.php
+++ b/site/tests/Integration/Ingestion/Application/Source/Wildberries/WbFinanceNormalizationFlowTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Application\Source\Wildberries;
+
+use App\Ingestion\Application\Action\NormalizeRawRecordAction;
+use App\Ingestion\Application\Command\NormalizeRawRecordCommand;
+use App\Ingestion\Application\Source\Wildberries\WbResourceType;
+use App\Ingestion\DTO\RawBatch;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\NormalizationIssueKind;
+use App\Ingestion\Enum\RawNormalizationStatus;
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+use App\Ingestion\Facade\RawStorageFacade;
+use App\Ingestion\Repository\FinancialTransactionRepository;
+use App\Ingestion\Repository\IngestRawRecordRepository;
+use App\Ingestion\Repository\NormalizationIssueRepository;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class WbFinanceNormalizationFlowTest extends IntegrationTestCase
+{
+    public function testNormalizesStoredWildberriesFinanceRawRecordToCanonicalTransactions(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $record = $this->storeRawRecord($companyId, [[
+            'rrdId' => 101,
+            'reportId' => 42880202606211,
+            'currency' => 'RUB',
+            'docTypeName' => 'Продажа',
+            'sellerOperName' => 'Продажа',
+            'saleDt' => '2026-06-21T10:15:00Z',
+            'retailPriceWithDisc' => '1000.00',
+            'forPay' => '850.00',
+            'acquiringFee' => '20.00',
+            'deliveryAmount' => 1,
+            'deliveryService' => '-50.00',
+            'srid' => 'sale-srid',
+            'nmId' => 123,
+            'sku' => 'sku-1',
+        ]]);
+
+        $this->normalize($record->getId(), $companyId);
+        $this->em->clear();
+
+        /** @var IngestRawRecordRepository $rawRecordRepository */
+        $rawRecordRepository = self::getContainer()->get(IngestRawRecordRepository::class);
+        self::assertSame(
+            RawNormalizationStatus::DONE,
+            $rawRecordRepository->findByIdAndCompany($record->getId(), $companyId)?->getNormalizationStatus(),
+        );
+
+        /** @var FinancialTransactionRepository $transactionRepository */
+        $transactionRepository = self::getContainer()->get(FinancialTransactionRepository::class);
+        $transactions = $transactionRepository->findByRawRecordId($companyId, $record->getId());
+        self::assertCount(4, $transactions);
+
+        $byExternalId = [];
+        foreach ($transactions as $transaction) {
+            $byExternalId[$transaction->getExternalId()] = $transaction;
+            self::assertNull($transaction->getListingId());
+        }
+
+        self::assertArrayHasKey('wb:sales-report-detailed:101:sale', $byExternalId);
+        self::assertSame(TransactionType::SALE, $byExternalId['wb:sales-report-detailed:101:sale']->getType());
+        self::assertSame(TransactionDirection::IN, $byExternalId['wb:sales-report-detailed:101:sale']->getDirection());
+        self::assertSame(100000, $byExternalId['wb:sales-report-detailed:101:sale']->getAmountMinor());
+        self::assertSame('sale-srid', $byExternalId['wb:sales-report-detailed:101:sale']->getOrderRef());
+        self::assertSame('sku-1', $byExternalId['wb:sales-report-detailed:101:sale']->getSourceData()['sku']);
+
+        self::assertArrayHasKey('wb:sales-report-detailed:101:commission', $byExternalId);
+        self::assertSame(TransactionDirection::OUT, $byExternalId['wb:sales-report-detailed:101:commission']->getDirection());
+        self::assertSame(13000, $byExternalId['wb:sales-report-detailed:101:commission']->getAmountMinor());
+
+        self::assertArrayHasKey('wb:sales-report-detailed:101:acquiring', $byExternalId);
+        self::assertSame(TransactionDirection::OUT, $byExternalId['wb:sales-report-detailed:101:acquiring']->getDirection());
+        self::assertSame(2000, $byExternalId['wb:sales-report-detailed:101:acquiring']->getAmountMinor());
+
+        self::assertArrayHasKey('wb:sales-report-detailed:101:logistics_delivery', $byExternalId);
+        self::assertSame(TransactionType::LOGISTICS, $byExternalId['wb:sales-report-detailed:101:logistics_delivery']->getType());
+        self::assertSame(TransactionDirection::OUT, $byExternalId['wb:sales-report-detailed:101:logistics_delivery']->getDirection());
+        self::assertSame(5000, $byExternalId['wb:sales-report-detailed:101:logistics_delivery']->getAmountMinor());
+
+        /** @var NormalizationIssueRepository $issueRepository */
+        $issueRepository = self::getContainer()->get(NormalizationIssueRepository::class);
+        self::assertSame([], $issueRepository->findOpenByRawRecord($companyId, $record->getId()));
+    }
+
+    public function testUnknownNonZeroWildberriesFinanceRowsAreRecordedAsMapperFailures(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $record = $this->storeRawRecord($companyId, [[
+            'rrdId' => 102,
+            'sellerOperName' => 'Новая операция',
+            'rrDate' => '2026-06-21',
+            'forPay' => '12.34',
+        ]]);
+
+        $this->normalize($record->getId(), $companyId);
+        $this->em->clear();
+
+        /** @var IngestRawRecordRepository $rawRecordRepository */
+        $rawRecordRepository = self::getContainer()->get(IngestRawRecordRepository::class);
+        self::assertSame(
+            RawNormalizationStatus::FAILED,
+            $rawRecordRepository->findByIdAndCompany($record->getId(), $companyId)?->getNormalizationStatus(),
+        );
+
+        /** @var FinancialTransactionRepository $transactionRepository */
+        $transactionRepository = self::getContainer()->get(FinancialTransactionRepository::class);
+        self::assertSame([], $transactionRepository->findByRawRecordId($companyId, $record->getId()));
+
+        /** @var NormalizationIssueRepository $issueRepository */
+        $issueRepository = self::getContainer()->get(NormalizationIssueRepository::class);
+        $issues = $issueRepository->findOpenByRawRecord($companyId, $record->getId());
+        self::assertCount(1, $issues);
+        self::assertSame(NormalizationIssueKind::MAPPER_FAILURE, $issues[0]->getKind());
+        self::assertStringContainsString('unmapped non-zero fields', $issues[0]->getDetails()['message']);
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     */
+    private function storeRawRecord(string $companyId, array $rows): IngestRawRecord
+    {
+        /** @var RawStorageFacade $facade */
+        $facade = self::getContainer()->get(RawStorageFacade::class);
+        $connectionRef = Uuid::uuid7()->toString();
+
+        return $facade->store(new RawBatch(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            shopRef: $connectionRef,
+            source: IngestSource::WILDBERRIES,
+            resourceType: WbResourceType::FINANCE_SALES_REPORT_DETAILED,
+            externalId: 'wb-sales-report-detailed:2026-06-21:rrd-0:'.Uuid::uuid7()->toString(),
+            syncJobId: Uuid::uuid7()->toString(),
+            fetchedAt: new \DateTimeImmutable('2026-06-22 09:17:43+00:00'),
+            rows: $rows,
+        ))[0];
+    }
+
+    private function normalize(string $rawRecordId, string $companyId): void
+    {
+        /** @var NormalizeRawRecordAction $action */
+        $action = self::getContainer()->get(NormalizeRawRecordAction::class);
+        $action(new NormalizeRawRecordCommand($rawRecordId, $companyId));
+    }
+}

--- a/site/tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedMapperTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedMapperTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Application\Source\Wildberries;
+
+use App\Ingestion\Application\DTO\MappedTransaction;
+use App\Ingestion\Application\Source\Wildberries\WbFinanceSalesReportDetailedMapper;
+use App\Ingestion\Application\Source\Wildberries\WbFinanceSalesReportDetailedPreviewMapper;
+use App\Ingestion\Application\Source\Wildberries\WbResourceType;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+final class WbFinanceSalesReportDetailedMapperTest extends TestCase
+{
+    private const COMPANY_ID = '19621cff-b028-45d9-9193-11f47ad9a8b2';
+
+    public function testMapsPreviewTransactionsToCanonicalTransactions(): void
+    {
+        $rawRecord = $this->rawRecord();
+
+        $transactions = $this->mapper()->map($rawRecord, [[
+            'rrdId' => 101,
+            'reportId' => 42880202606211,
+            'currency' => 'RUB',
+            'docTypeName' => 'Продажа',
+            'sellerOperName' => 'Продажа',
+            'saleDt' => '2026-06-21T10:15:00Z',
+            'retailPriceWithDisc' => '1000.00',
+            'forPay' => '850.00',
+            'acquiringFee' => '20.00',
+            'srid' => 'sale-srid',
+            'nmId' => 123,
+            'sku' => 'sku-1',
+        ]]);
+
+        self::assertCount(3, $transactions);
+
+        $sale = $this->transaction($transactions, 'wb:sales-report-detailed:101:sale');
+        self::assertSame(TransactionType::SALE, $sale->type);
+        self::assertSame(TransactionDirection::IN, $sale->direction);
+        self::assertSame(100000, $sale->money->amountMinor());
+        self::assertSame('2026-06-21 10:15:00', $sale->occurredAt->format('Y-m-d H:i:s'));
+        self::assertSame('UTC', $sale->sourceTz);
+        self::assertSame($rawRecord->getFetchedAt(), $sale->externalUpdatedAt);
+        self::assertSame('sale-srid', $sale->orderRef);
+        self::assertSame('42880202606211', $sale->payoutRef);
+        self::assertSame(WbResourceType::FINANCE_SALES_REPORT_DETAILED, $sale->sourceData['_ingestion_resource']);
+        self::assertSame('sale', $sale->sourceData['_ingestion_component']);
+        self::assertSame('123', $sale->sourceData['nmId']);
+        self::assertSame('sku-1', $sale->sourceData['sku']);
+
+        $commission = $this->transaction($transactions, 'wb:sales-report-detailed:101:commission');
+        self::assertSame(TransactionType::COMMISSION, $commission->type);
+        self::assertSame(TransactionDirection::OUT, $commission->direction);
+        self::assertSame(13000, $commission->money->amountMinor());
+
+        $acquiring = $this->transaction($transactions, 'wb:sales-report-detailed:101:acquiring');
+        self::assertSame(TransactionType::ACQUIRING, $acquiring->type);
+        self::assertSame(TransactionDirection::OUT, $acquiring->direction);
+        self::assertSame(2000, $acquiring->money->amountMinor());
+    }
+
+    public function testBuildsTechnicalControlSumsFromMappedAmounts(): void
+    {
+        $controlSums = $this->mapper()->controlSumForRawRecord($this->rawRecord(), [[
+            'rrdId' => 101,
+            'currency' => 'RUB',
+            'docTypeName' => 'Продажа',
+            'sellerOperName' => 'Продажа',
+            'saleDt' => '2026-06-21T10:15:00Z',
+            'retailPriceWithDisc' => '1000.00',
+            'forPay' => '850.00',
+            'acquiringFee' => '20.00',
+        ]]);
+
+        self::assertCount(1, $controlSums);
+        self::assertSame('RUB', $controlSums[0]->currency);
+        self::assertSame(115000, $controlSums[0]->amountMinor);
+    }
+
+    public function testRejectsPayoutMismatches(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('WB finance payout check mismatch');
+
+        $this->mapper()->map($this->rawRecord(), [[
+            'rrdId' => 102,
+            'currency' => 'RUB',
+            'docTypeName' => 'Продажа',
+            'sellerOperName' => 'Продажа',
+            'saleDt' => '2026-06-21T10:15:00Z',
+            'retailPriceWithDisc' => '1000.00',
+            'forPay' => '1100.00',
+            'acquiringFee' => '0',
+        ]]);
+    }
+
+    public function testRejectsUnknownRowsWithNonZeroKnownAmounts(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('unmapped non-zero fields');
+
+        $this->mapper()->map($this->rawRecord(), [[
+            'rrdId' => 103,
+            'sellerOperName' => 'Новая операция',
+            'rrDate' => '2026-06-21',
+            'forPay' => '12.34',
+        ]]);
+    }
+
+    /**
+     * @param list<MappedTransaction> $transactions
+     */
+    private function transaction(array $transactions, string $externalId): MappedTransaction
+    {
+        foreach ($transactions as $transaction) {
+            if ($externalId === $transaction->externalId) {
+                return $transaction;
+            }
+        }
+
+        self::fail(sprintf('Mapped transaction with external id "%s" was not found.', $externalId));
+    }
+
+    private function mapper(): WbFinanceSalesReportDetailedMapper
+    {
+        return new WbFinanceSalesReportDetailedMapper(new WbFinanceSalesReportDetailedPreviewMapper());
+    }
+
+    private function rawRecord(): IngestRawRecord
+    {
+        return new IngestRawRecord(
+            companyId: self::COMPANY_ID,
+            connectionRef: Uuid::uuid7()->toString(),
+            shopRef: Uuid::uuid7()->toString(),
+            source: IngestSource::WILDBERRIES,
+            resourceType: WbResourceType::FINANCE_SALES_REPORT_DETAILED,
+            externalId: 'wb-sales-report-detailed:2026-06-21:rrd-0',
+            storagePath: 'raw.ndjson.gz',
+            hash: str_repeat('a', 64),
+            byteSize: 100,
+            fetchedAt: new \DateTimeImmutable('2026-06-22 09:17:43+00:00'),
+            syncJobId: Uuid::uuid7()->toString(),
+        );
+    }
+}


### PR DESCRIPTION
## What changed

- Added `WbFinanceSalesReportDetailedMapper` for canonical `MappedTransaction` creation from the existing WB finance preview mapper.
- Registered the mapper in the ingestion mapper registry for `wildberries_finance_sales_report_detailed`.
- Added unit and integration coverage for canonical mapping, registry lookup, manual raw normalization, and mapper failure handling for unsafe WB rows.

## Why

WB finance raw records are loaded and previewed, but they still have no production mapper into `ingest_financial_transactions`. This PR adds the production mapper as Stage 1 without enabling automatic WB normalization yet.

## Impact

- Manual normalization can now resolve a WB finance mapper and create canonical transactions.
- `WbFinanceReportConnector` remains raw-only: this PR does not set `normalizeRawRecords=true` and does not reprocess existing `skipped` raw records.
- Listing attribution remains nullable; the existing WB listing resolver still does not block normalization.

## Validation

- `php -l` on new/changed PHP files: OK
- `php bin/phpunit --testsuite unit --filter 'WbFinanceSalesReportDetailed.*MapperTest'`: OK, 11 tests / 101 assertions
- `php bin/phpunit --testsuite integration --filter 'WbFinance(IngestionRegistry|NormalizationFlow)Test'`: OK, 3 tests / 29 assertions, with existing PHPUnit deprecations
- Scoped php-cs-fixer on changed files: OK
- `git diff --check`: OK

## Notes

Full `composer cs:check` is currently red because the baseline project has existing style drift across 667 files outside this PR.
