### PR TITLE
[codex] Add safe WB finance stored normalization rollout

### DIFF
--- a/site/src/Ingestion/Command/WbFinanceNormalizeStoredCommand.php
+++ b/site/src/Ingestion/Command/WbFinanceNormalizeStoredCommand.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace App\Ingestion\Command;
 
 use App\Ingestion\Application\Action\NormalizeRawRecordAction;
+use App\Ingestion\Application\Action\RecordNormalizationIssueAction;
 use App\Ingestion\Application\Command\NormalizeRawRecordCommand;
+use App\Ingestion\Application\Command\RecordNormalizationIssueCommand;
 use App\Ingestion\Application\Source\Wildberries\WbResourceType;
 use App\Ingestion\Entity\IngestRawRecord;
 use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\NormalizationIssueKind;
 use App\Ingestion\Enum\RawNormalizationStatus;
 use App\Ingestion\Message\NormalizeRawRecordMessage;
 use App\Ingestion\Repository\IngestRawRecordRepository;
@@ -38,6 +41,7 @@ final class WbFinanceNormalizeStoredCommand extends Command
         private readonly EntityManagerInterface $entityManager,
         private readonly MessageBusInterface $messageBus,
         private readonly NormalizeRawRecordAction $normalizeRawRecordAction,
+        private readonly RecordNormalizationIssueAction $recordNormalizationIssueAction,
     ) {
         parent::__construct();
     }
@@ -218,6 +222,8 @@ final class WbFinanceNormalizeStoredCommand extends Command
             try {
                 ($this->normalizeRawRecordAction)(new NormalizeRawRecordCommand($rawRecordId, $companyId));
             } catch (\Throwable $exception) {
+                $this->markInlineFailure($record, $exception);
+
                 $resultRows[] = [
                     'rawId' => $rawRecordId,
                     'status' => 'error',
@@ -260,6 +266,23 @@ final class WbFinanceNormalizeStoredCommand extends Command
         }
 
         return $records;
+    }
+
+    private function markInlineFailure(IngestRawRecord $record, \Throwable $exception): void
+    {
+        $record->markNormalizationFailed();
+        ($this->recordNormalizationIssueAction)(new RecordNormalizationIssueCommand(
+            companyId: $record->getCompanyId(),
+            rawRecordId: $record->getId(),
+            operationGroupId: null,
+            kind: NormalizationIssueKind::MAPPER_FAILURE,
+            details: [
+                'exceptionClass' => $exception::class,
+                'message' => $exception->getMessage(),
+                'source' => 'wb_finance_normalize_stored_inline',
+            ],
+        ));
+        $this->entityManager->flush();
     }
 
     private function resolveOpenIssues(string $companyId, string $rawRecordId): void

--- a/site/src/Ingestion/Command/WbFinanceNormalizeStoredCommand.php
+++ b/site/src/Ingestion/Command/WbFinanceNormalizeStoredCommand.php
@@ -1,0 +1,407 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Command;
+
+use App\Ingestion\Application\Action\NormalizeRawRecordAction;
+use App\Ingestion\Application\Command\NormalizeRawRecordCommand;
+use App\Ingestion\Application\Source\Wildberries\WbResourceType;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\RawNormalizationStatus;
+use App\Ingestion\Message\NormalizeRawRecordMessage;
+use App\Ingestion\Repository\IngestRawRecordRepository;
+use App\Ingestion\Repository\NormalizationIssueRepository;
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Webmozart\Assert\Assert;
+
+#[AsCommand(
+    name: 'app:ingestion:wb-finance:normalize-stored',
+    description: 'Safely resets and normalizes stored Wildberries finance raw records by report date.',
+)]
+final class WbFinanceNormalizeStoredCommand extends Command
+{
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly IngestRawRecordRepository $rawRecordRepository,
+        private readonly NormalizationIssueRepository $normalizationIssueRepository,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly MessageBusInterface $messageBus,
+        private readonly NormalizeRawRecordAction $normalizeRawRecordAction,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Company UUID.')
+            ->addOption('from', null, InputOption::VALUE_REQUIRED, 'Start report date YYYY-MM-DD.')
+            ->addOption('to', null, InputOption::VALUE_REQUIRED, 'End report date YYYY-MM-DD.')
+            ->addOption('shop-ref', null, InputOption::VALUE_REQUIRED, 'Optional shop reference.')
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Raw records to process, 1..500.', 100)
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show selected records without changing them.')
+            ->addOption('dispatch', null, InputOption::VALUE_NONE, 'Reset selected records to pending and dispatch async normalization messages.')
+            ->addOption('execute-inline', null, InputOption::VALUE_NONE, 'Reset selected records and normalize them synchronously in this process.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        try {
+            $companyId = $this->requiredUuidOption($input, 'company-id');
+            [$from, $to] = $this->requiredDateWindow($input);
+            $shopRef = $this->optionalStringOption($input, 'shop-ref');
+            $limit = $this->intOption($input, 'limit', 1, 500);
+            $mode = $this->mode($input);
+        } catch (\Throwable $exception) {
+            $io->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $rawRecords = $this->rawRecords($companyId, $from, $to, $shopRef, $limit);
+
+        $io->title('Wildberries finance stored normalization');
+        $this->printRawRecords($io, $rawRecords);
+
+        if ([] === $rawRecords) {
+            return Command::SUCCESS;
+        }
+
+        if ('dry-run' === $mode) {
+            $io->note('Dry-run only. No raw records were changed and no messages were dispatched.');
+
+            return Command::SUCCESS;
+        }
+
+        if ('dispatch' === $mode) {
+            $resultRows = $this->dispatch($companyId, $rawRecords);
+            $this->printActionResult($io, $resultRows);
+            $io->success(sprintf('Dispatched %d Wildberries finance raw records for normalization.', count($resultRows)));
+
+            return Command::SUCCESS;
+        }
+
+        $resultRows = $this->executeInline($companyId, $rawRecords);
+        $this->printActionResult($io, $resultRows);
+
+        $failed = array_values(array_filter($resultRows, static fn (array $row): bool => 'done' !== $row['status']));
+        if ([] !== $failed) {
+            $io->warning(sprintf('Inline normalization finished with %d non-done raw records.', count($failed)));
+
+            return Command::FAILURE;
+        }
+
+        $io->success(sprintf('Normalized %d Wildberries finance raw records inline.', count($resultRows)));
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function rawRecords(
+        string $companyId,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        ?string $shopRef,
+        int $limit,
+    ): array {
+        $externalReportDate = "substring(r.external_id from '^wb-sales-report-detailed:([0-9]{4}-[0-9]{2}-[0-9]{2}):rrd-[0-9]+$')::date";
+        $recordDate = sprintf('COALESCE(j.window_from, %s, DATE(r.fetched_at))', $externalReportDate);
+        $conditions = [
+            'r.company_id = :companyId',
+            'r.source = :source',
+            'r.resource_type = :resourceType',
+            'r.normalization_status IN (:statuses)',
+            "(
+                (j.window_from IS NOT NULL AND j.window_from <= :toDate AND COALESCE(j.window_to, j.window_from) >= :fromDate)
+                OR (j.window_from IS NULL AND {$recordDate} >= :fromDate AND {$recordDate} <= :toDate)
+            )",
+        ];
+        $params = [
+            'companyId' => $companyId,
+            'source' => IngestSource::WILDBERRIES->value,
+            'resourceType' => WbResourceType::FINANCE_SALES_REPORT_DETAILED,
+            'statuses' => [RawNormalizationStatus::SKIPPED->value, RawNormalizationStatus::FAILED->value],
+            'fromDate' => $from->format('Y-m-d'),
+            'toDate' => $to->format('Y-m-d'),
+        ];
+        $types = [
+            'statuses' => ArrayParameterType::STRING,
+        ];
+
+        if (null !== $shopRef && '' !== $shopRef) {
+            $conditions[] = 'r.shop_ref = :shopRef';
+            $params['shopRef'] = $shopRef;
+        }
+
+        return $this->connection->fetchAllAssociative(
+            sprintf(
+                'SELECT r.id,
+                        r.external_id,
+                        r.shop_ref,
+                        r.fetched_at,
+                        r.byte_size,
+                        r.normalization_status,
+                        TO_CHAR(%s, \'YYYY-MM-DD\') AS record_date
+                 FROM ingest_raw_records r
+                 LEFT JOIN ingest_sync_jobs j ON j.id::text = r.sync_job_id AND j.company_id = r.company_id
+                 WHERE %s
+                 ORDER BY record_date ASC, r.fetched_at ASC, r.created_at ASC
+                 LIMIT %d',
+                $recordDate,
+                implode(' AND ', $conditions),
+                $limit,
+            ),
+            $params,
+            $types,
+        );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rawRecords
+     *
+     * @return list<array<string, string|int>>
+     */
+    private function dispatch(string $companyId, array $rawRecords): array
+    {
+        $records = $this->resetSelectedRecordsToPending($companyId, $rawRecords);
+        $this->entityManager->flush();
+
+        $resultRows = [];
+        foreach ($records as $record) {
+            $this->messageBus->dispatch(new NormalizeRawRecordMessage($record->getId(), $record->getCompanyId()));
+            $resultRows[] = [
+                'rawId' => $record->getId(),
+                'status' => RawNormalizationStatus::PENDING->value,
+                'txCount' => 0,
+                'openIssues' => 0,
+            ];
+        }
+
+        return $resultRows;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rawRecords
+     *
+     * @return list<array<string, string|int>>
+     */
+    private function executeInline(string $companyId, array $rawRecords): array
+    {
+        $resultRows = [];
+
+        foreach ($rawRecords as $row) {
+            $rawRecordId = (string) $row['id'];
+            $record = $this->rawRecordRepository->findByIdAndCompany($rawRecordId, $companyId);
+            if (null === $record || RawNormalizationStatus::DONE === $record->getNormalizationStatus()) {
+                continue;
+            }
+
+            $record->markNormalizationPending();
+            $this->resolveOpenIssues($companyId, $rawRecordId);
+            $this->entityManager->flush();
+
+            try {
+                ($this->normalizeRawRecordAction)(new NormalizeRawRecordCommand($rawRecordId, $companyId));
+            } catch (\Throwable $exception) {
+                $resultRows[] = [
+                    'rawId' => $rawRecordId,
+                    'status' => 'error',
+                    'txCount' => $this->transactionCount($companyId, $rawRecordId),
+                    'openIssues' => $this->openIssueCount($companyId, $rawRecordId),
+                    'error' => $exception->getMessage(),
+                ];
+
+                continue;
+            }
+
+            $resultRows[] = [
+                'rawId' => $rawRecordId,
+                'status' => $this->normalizationStatus($companyId, $rawRecordId),
+                'txCount' => $this->transactionCount($companyId, $rawRecordId),
+                'openIssues' => $this->openIssueCount($companyId, $rawRecordId),
+            ];
+        }
+
+        return $resultRows;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rawRecords
+     *
+     * @return list<IngestRawRecord>
+     */
+    private function resetSelectedRecordsToPending(string $companyId, array $rawRecords): array
+    {
+        $records = [];
+        foreach ($rawRecords as $row) {
+            $record = $this->rawRecordRepository->findByIdAndCompany((string) $row['id'], $companyId);
+            if (null === $record || RawNormalizationStatus::DONE === $record->getNormalizationStatus()) {
+                continue;
+            }
+
+            $record->markNormalizationPending();
+            $this->resolveOpenIssues($companyId, $record->getId());
+            $records[] = $record;
+        }
+
+        return $records;
+    }
+
+    private function resolveOpenIssues(string $companyId, string $rawRecordId): void
+    {
+        foreach ($this->normalizationIssueRepository->findOpenByRawRecord($companyId, $rawRecordId) as $issue) {
+            $issue->markResolved();
+        }
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rawRecords
+     */
+    private function printRawRecords(SymfonyStyle $io, array $rawRecords): void
+    {
+        $io->section('Selected raw records');
+        if ([] === $rawRecords) {
+            $io->writeln('No skipped or failed raw records found for the selected period.');
+
+            return;
+        }
+
+        $io->table(
+            ['date', 'rawId', 'externalId', 'shopRef', 'status', 'bytes', 'fetchedAt'],
+            array_map(static fn (array $row): array => [
+                (string) ($row['record_date'] ?? ''),
+                (string) $row['id'],
+                (string) $row['external_id'],
+                (string) $row['shop_ref'],
+                (string) $row['normalization_status'],
+                (string) $row['byte_size'],
+                (string) $row['fetched_at'],
+            ], $rawRecords),
+        );
+    }
+
+    /**
+     * @param list<array<string, string|int>> $resultRows
+     */
+    private function printActionResult(SymfonyStyle $io, array $resultRows): void
+    {
+        $io->section('Normalization action result');
+        if ([] === $resultRows) {
+            $io->writeln('No records were changed.');
+
+            return;
+        }
+
+        $io->table(
+            ['rawId', 'status', 'txCount', 'openIssues', 'error'],
+            array_map(static fn (array $row): array => [
+                (string) $row['rawId'],
+                (string) $row['status'],
+                (string) $row['txCount'],
+                (string) $row['openIssues'],
+                (string) ($row['error'] ?? ''),
+            ], $resultRows),
+        );
+    }
+
+    private function normalizationStatus(string $companyId, string $rawRecordId): string
+    {
+        return (string) $this->connection->fetchOne(
+            'SELECT normalization_status FROM ingest_raw_records WHERE company_id = :companyId AND id = :rawRecordId',
+            ['companyId' => $companyId, 'rawRecordId' => $rawRecordId],
+        );
+    }
+
+    private function transactionCount(string $companyId, string $rawRecordId): int
+    {
+        return (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM ingest_financial_transactions WHERE company_id = :companyId AND raw_record_id = :rawRecordId',
+            ['companyId' => $companyId, 'rawRecordId' => $rawRecordId],
+        );
+    }
+
+    private function openIssueCount(string $companyId, string $rawRecordId): int
+    {
+        return (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM ingest_normalization_issues WHERE company_id = :companyId AND raw_record_id = :rawRecordId AND resolved_at IS NULL',
+            ['companyId' => $companyId, 'rawRecordId' => $rawRecordId],
+        );
+    }
+
+    private function requiredUuidOption(InputInterface $input, string $name): string
+    {
+        $value = trim((string) $input->getOption($name));
+        Assert::uuid($value, sprintf('Invalid --%s UUID.', $name));
+
+        return $value;
+    }
+
+    /**
+     * @return array{0: \DateTimeImmutable, 1: \DateTimeImmutable}
+     */
+    private function requiredDateWindow(InputInterface $input): array
+    {
+        $from = $this->dateOption($input, 'from');
+        $to = $this->dateOption($input, 'to');
+        if ($from > $to) {
+            throw new \InvalidArgumentException('--from cannot be later than --to.');
+        }
+
+        return [$from, $to];
+    }
+
+    private function dateOption(InputInterface $input, string $name): \DateTimeImmutable
+    {
+        $value = trim((string) $input->getOption($name));
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
+        if (false === $date || $date->format('Y-m-d') !== $value) {
+            throw new \InvalidArgumentException(sprintf('--%s must be a valid YYYY-MM-DD date.', $name));
+        }
+
+        return $date;
+    }
+
+    private function optionalStringOption(InputInterface $input, string $name): ?string
+    {
+        $value = trim((string) $input->getOption($name));
+
+        return '' === $value ? null : $value;
+    }
+
+    private function intOption(InputInterface $input, string $name, int $min, int $max): int
+    {
+        $value = (int) $input->getOption($name);
+
+        return max($min, min($max, $value));
+    }
+
+    private function mode(InputInterface $input): string
+    {
+        $modes = array_values(array_filter([
+            (bool) $input->getOption('dry-run') ? 'dry-run' : null,
+            (bool) $input->getOption('dispatch') ? 'dispatch' : null,
+            (bool) $input->getOption('execute-inline') ? 'execute-inline' : null,
+        ]));
+
+        if (1 !== count($modes)) {
+            throw new \InvalidArgumentException('Choose exactly one action: --dry-run, --dispatch, or --execute-inline.');
+        }
+
+        return $modes[0];
+    }
+}

--- a/site/src/Ingestion/Entity/IngestRawRecord.php
+++ b/site/src/Ingestion/Entity/IngestRawRecord.php
@@ -203,6 +203,16 @@ class IngestRawRecord implements TenantOwnedInterface
         $this->updatedAt = new \DateTimeImmutable();
     }
 
+    public function markNormalizationPending(): void
+    {
+        if (RawNormalizationStatus::DONE === $this->normalizationStatus) {
+            throw new \DomainException('Done raw record cannot be reset to pending.');
+        }
+
+        $this->normalizationStatus = RawNormalizationStatus::PENDING;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
     public function markNormalizationSkipped(): void
     {
         $this->normalizationStatus = RawNormalizationStatus::SKIPPED;

--- a/site/tests/Integration/Ingestion/Command/WbFinanceNormalizeStoredCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/WbFinanceNormalizeStoredCommandTest.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Command;
+
+use App\Ingestion\Application\Source\Wildberries\WbResourceType;
+use App\Ingestion\DTO\RawBatch;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Entity\NormalizationIssue;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\NormalizationIssueKind;
+use App\Ingestion\Enum\RawNormalizationStatus;
+use App\Ingestion\Facade\RawStorageFacade;
+use App\Ingestion\Message\NormalizeRawRecordMessage;
+use App\Ingestion\Repository\FinancialTransactionRepository;
+use App\Ingestion\Repository\IngestRawRecordRepository;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+
+final class WbFinanceNormalizeStoredCommandTest extends IntegrationTestCase
+{
+    public function testDryRunSelectsWindowlessRecordsByReportDateFromExternalId(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = Uuid::uuid7()->toString();
+        $transport = $this->getNormalizeTransport();
+        $transport->reset();
+
+        $oldReport = $this->storeRawRecord(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            externalId: 'wb-sales-report-detailed:2026-06-20:rrd-0',
+            fetchedAt: new \DateTimeImmutable('2026-06-21 10:00:00+00:00'),
+            rows: [$this->emptyRow(1)],
+        );
+        $selected = $this->storeRawRecord(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            externalId: 'wb-sales-report-detailed:2026-06-21:rrd-0',
+            fetchedAt: new \DateTimeImmutable('2026-06-22 09:17:43+00:00'),
+            rows: [$this->emptyRow(2)],
+        );
+        $done = $this->storeRawRecord(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            externalId: 'wb-sales-report-detailed:2026-06-21:rrd-1',
+            fetchedAt: new \DateTimeImmutable('2026-06-22 09:18:00+00:00'),
+            rows: [$this->emptyRow(3)],
+        );
+
+        $oldReport->markNormalizationSkipped();
+        $selected->markNormalizationSkipped();
+        $done->markNormalizationDone();
+        $this->em->flush();
+
+        $tester = $this->tester();
+        $exit = $tester->execute([
+            '--company-id' => $companyId,
+            '--from' => '2026-06-21',
+            '--to' => '2026-06-21',
+            '--shop-ref' => $connectionRef,
+            '--dry-run' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('wb-sales-report-detailed:2026-06-21:rrd-0', $display);
+        self::assertStringNotContainsString('wb-sales-report-detailed:2026-06-20:rrd-0', $display);
+        self::assertStringNotContainsString('wb-sales-report-detailed:2026-06-21:rrd-1', $display);
+        self::assertSame(RawNormalizationStatus::SKIPPED, $this->rawStatus($selected));
+        self::assertCount(0, $transport->getSent());
+    }
+
+    public function testDispatchResetsSkippedAndFailedRecordsToPendingAndQueuesNormalization(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = Uuid::uuid7()->toString();
+        $transport = $this->getNormalizeTransport();
+        $transport->reset();
+
+        $skipped = $this->storeRawRecord(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            externalId: 'wb-sales-report-detailed:2026-06-21:rrd-0',
+            fetchedAt: new \DateTimeImmutable('2026-06-22 09:17:43+00:00'),
+            rows: [$this->emptyRow(11)],
+        );
+        $failed = $this->storeRawRecord(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            externalId: 'wb-sales-report-detailed:2026-06-21:rrd-1',
+            fetchedAt: new \DateTimeImmutable('2026-06-22 09:18:43+00:00'),
+            rows: [$this->emptyRow(12)],
+        );
+        $done = $this->storeRawRecord(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            externalId: 'wb-sales-report-detailed:2026-06-21:rrd-2',
+            fetchedAt: new \DateTimeImmutable('2026-06-22 09:19:43+00:00'),
+            rows: [$this->emptyRow(13)],
+        );
+
+        $skipped->markNormalizationSkipped();
+        $failed->markNormalizationFailed();
+        $done->markNormalizationDone();
+        $this->em->persist(new NormalizationIssue(
+            companyId: $companyId,
+            rawRecordId: $failed->getId(),
+            operationGroupId: null,
+            kind: NormalizationIssueKind::MAPPER_FAILURE,
+            details: ['message' => 'old failure'],
+        ));
+        $this->em->flush();
+
+        $tester = $this->tester();
+        $exit = $tester->execute([
+            '--company-id' => $companyId,
+            '--from' => '2026-06-21',
+            '--to' => '2026-06-21',
+            '--shop-ref' => $connectionRef,
+            '--dispatch' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertSame(RawNormalizationStatus::PENDING, $this->rawStatus($skipped));
+        self::assertSame(RawNormalizationStatus::PENDING, $this->rawStatus($failed));
+        self::assertSame(RawNormalizationStatus::DONE, $this->rawStatus($done));
+        self::assertSame(0, $this->openIssueCount($companyId, $failed->getId()));
+
+        $messages = array_map(static fn ($envelope): object => $envelope->getMessage(), $transport->getSent());
+        self::assertCount(2, $messages);
+        foreach ($messages as $message) {
+            self::assertInstanceOf(NormalizeRawRecordMessage::class, $message);
+        }
+        self::assertEqualsCanonicalizing(
+            [$skipped->getId(), $failed->getId()],
+            array_map(static fn (NormalizeRawRecordMessage $message): string => $message->rawRecordId, $messages),
+        );
+    }
+
+    public function testExecuteInlineNormalizesSelectedRecordToCanonicalTransactions(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = Uuid::uuid7()->toString();
+        $record = $this->storeRawRecord(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            externalId: 'wb-sales-report-detailed:2026-06-21:rrd-0',
+            fetchedAt: new \DateTimeImmutable('2026-06-22 09:17:43+00:00'),
+            rows: [[
+                'rrdId' => 101,
+                'reportId' => 42880202606211,
+                'currency' => 'RUB',
+                'docTypeName' => 'Продажа',
+                'sellerOperName' => 'Продажа',
+                'saleDt' => '2026-06-21T10:15:00Z',
+                'retailPriceWithDisc' => '1000.00',
+                'forPay' => '850.00',
+                'acquiringFee' => '20.00',
+                'deliveryAmount' => 1,
+                'deliveryService' => '-50.00',
+                'srid' => 'sale-srid',
+                'nmId' => 123,
+                'sku' => 'sku-1',
+            ]],
+        );
+        $record->markNormalizationSkipped();
+        $this->em->flush();
+
+        $tester = $this->tester();
+        $exit = $tester->execute([
+            '--company-id' => $companyId,
+            '--from' => '2026-06-21',
+            '--to' => '2026-06-21',
+            '--shop-ref' => $connectionRef,
+            '--execute-inline' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exit, $tester->getDisplay());
+        self::assertSame(RawNormalizationStatus::DONE, $this->rawStatus($record));
+
+        /** @var FinancialTransactionRepository $transactionRepository */
+        $transactionRepository = self::getContainer()->get(FinancialTransactionRepository::class);
+        self::assertCount(4, $transactionRepository->findByRawRecordId($companyId, $record->getId()));
+        self::assertStringContainsString('Normalized 1 Wildberries finance raw records inline.', $tester->getDisplay());
+    }
+
+    private function tester(): CommandTester
+    {
+        $app = new Application(self::$kernel);
+
+        return new CommandTester($app->find('app:ingestion:wb-finance:normalize-stored'));
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     */
+    private function storeRawRecord(
+        string $companyId,
+        string $connectionRef,
+        string $externalId,
+        \DateTimeImmutable $fetchedAt,
+        array $rows,
+    ): IngestRawRecord {
+        /** @var RawStorageFacade $facade */
+        $facade = self::getContainer()->get(RawStorageFacade::class);
+
+        return $facade->store(new RawBatch(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            shopRef: $connectionRef,
+            source: IngestSource::WILDBERRIES,
+            resourceType: WbResourceType::FINANCE_SALES_REPORT_DETAILED,
+            externalId: $externalId,
+            syncJobId: Uuid::uuid7()->toString(),
+            fetchedAt: $fetchedAt,
+            rows: $rows,
+        ))[0];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function emptyRow(int $rrdId): array
+    {
+        return [
+            'rrdId' => $rrdId,
+            'rrDate' => '2026-06-21',
+            'currency' => 'RUB',
+            'sellerOperName' => '',
+            'docTypeName' => '',
+        ];
+    }
+
+    private function rawStatus(IngestRawRecord $record): RawNormalizationStatus
+    {
+        /** @var IngestRawRecordRepository $repository */
+        $repository = self::getContainer()->get(IngestRawRecordRepository::class);
+
+        return $repository->findByIdAndCompany($record->getId(), $record->getCompanyId())?->getNormalizationStatus()
+            ?? throw new \RuntimeException('Raw record was not found.');
+    }
+
+    private function openIssueCount(string $companyId, string $rawRecordId): int
+    {
+        return (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM ingest_normalization_issues WHERE company_id = :companyId AND raw_record_id = :rawRecordId AND resolved_at IS NULL',
+            ['companyId' => $companyId, 'rawRecordId' => $rawRecordId],
+        );
+    }
+
+    private function getNormalizeTransport(): InMemoryTransport
+    {
+        /** @var InMemoryTransport $transport */
+        $transport = self::getContainer()->get('messenger.transport.ingest_normalize');
+
+        return $transport;
+    }
+}

--- a/site/tests/Integration/Ingestion/Command/WbFinanceNormalizeStoredCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/WbFinanceNormalizeStoredCommandTest.php
@@ -15,6 +15,7 @@ use App\Ingestion\Facade\RawStorageFacade;
 use App\Ingestion\Message\NormalizeRawRecordMessage;
 use App\Ingestion\Repository\FinancialTransactionRepository;
 use App\Ingestion\Repository\IngestRawRecordRepository;
+use App\Shared\Service\Storage\ObjectStorageInterface;
 use App\Tests\Support\Kernel\IntegrationTestCase;
 use Ramsey\Uuid\Uuid;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -190,6 +191,61 @@ final class WbFinanceNormalizeStoredCommandTest extends IntegrationTestCase
         self::assertStringContainsString('Normalized 1 Wildberries finance raw records inline.', $tester->getDisplay());
     }
 
+    public function testExecuteInlineMarksUnexpectedNormalizationExceptionAsFailed(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = Uuid::uuid7()->toString();
+        $record = $this->storeRawRecord(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            externalId: 'wb-sales-report-detailed:2026-06-21:rrd-0',
+            fetchedAt: new \DateTimeImmutable('2026-06-22 09:17:43+00:00'),
+            rows: [$this->emptyRow(21)],
+        );
+        $record->markNormalizationSkipped();
+        $this->em->persist(new NormalizationIssue(
+            companyId: $companyId,
+            rawRecordId: $record->getId(),
+            operationGroupId: null,
+            kind: NormalizationIssueKind::MAPPER_FAILURE,
+            details: ['message' => 'old failure'],
+        ));
+        $this->em->flush();
+
+        /** @var ObjectStorageInterface $objectStorage */
+        $objectStorage = self::getContainer()->get(ObjectStorageInterface::class);
+        $corruptedPayload = gzencode("{bad json}\n", 6);
+        self::assertIsString($corruptedPayload);
+        $objectStorage->write($record->getStoragePath(), $corruptedPayload);
+        $this->em->clear();
+
+        $tester = $this->tester();
+        $exit = $tester->execute([
+            '--company-id' => $companyId,
+            '--from' => '2026-06-21',
+            '--to' => '2026-06-21',
+            '--shop-ref' => $connectionRef,
+            '--execute-inline' => true,
+        ]);
+
+        self::assertSame(Command::FAILURE, $exit, $tester->getDisplay());
+        self::assertSame(RawNormalizationStatus::FAILED, $this->rawStatusById($companyId, $record->getId()));
+        self::assertSame(1, $this->openIssueCount($companyId, $record->getId()));
+        self::assertStringContainsString('Inline normalization finished with 1 non-done raw records.', $tester->getDisplay());
+
+        $retryTester = $this->tester();
+        $retryExit = $retryTester->execute([
+            '--company-id' => $companyId,
+            '--from' => '2026-06-21',
+            '--to' => '2026-06-21',
+            '--shop-ref' => $connectionRef,
+            '--dry-run' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $retryExit);
+        self::assertStringContainsString('wb-sales-report-detailed:2026-06-21:rrd-0', $retryTester->getDisplay());
+    }
+
     private function tester(): CommandTester
     {
         $app = new Application(self::$kernel);
@@ -239,10 +295,15 @@ final class WbFinanceNormalizeStoredCommandTest extends IntegrationTestCase
 
     private function rawStatus(IngestRawRecord $record): RawNormalizationStatus
     {
+        return $this->rawStatusById($record->getCompanyId(), $record->getId());
+    }
+
+    private function rawStatusById(string $companyId, string $rawRecordId): RawNormalizationStatus
+    {
         /** @var IngestRawRecordRepository $repository */
         $repository = self::getContainer()->get(IngestRawRecordRepository::class);
 
-        return $repository->findByIdAndCompany($record->getId(), $record->getCompanyId())?->getNormalizationStatus()
+        return $repository->findByIdAndCompany($rawRecordId, $companyId)?->getNormalizationStatus()
             ?? throw new \RuntimeException('Raw record was not found.');
     }
 


### PR DESCRIPTION
## Summary
- add `app:ingestion:wb-finance:normalize-stored` for manual-first WB finance normalization rollout
- keep WB connector auto-normalization disabled; command only processes selected stored `skipped`/`failed` raw records
- add a safe `skipped|failed -> pending` reset path that never resets `done` records and resolves stale open normalization issues before retry
- cover dry-run, async dispatch, inline execution, report-date selection, and done-record skipping

## Rollout
1. Run `preview-normalization` for one day.
2. Run `normalize-stored --dry-run` for the same day.
3. Run `normalize-stored --execute-inline` for one day and verify `normalization_status=done`, transactions, and issues.
4. Run `normalize-stored --dispatch --from=2026-06-01 --to=2026-06-21 --limit=100` after the one-day check passes.

## Validation
- `git diff --check`
- PHP lint for changed PHP files
- targeted integration: `WbFinanceNormalizeStoredCommandTest`, `WbFinanceNormalizationFlowTest`, `WbFinanceIngestionRegistryTest` — OK (6 tests, 48 assertions)
- targeted unit: WB finance mapper and preview mapper — OK (11 tests, 101 assertions)
- scoped php-cs-fixer dry-run — OK

## Notes
- This PR intentionally does not flip `WbFinanceReportConnector` to auto-normalize new raw records.