### PR TITLE
[codex] Add WB finance daily incremental strategies

### DIFF
--- a/docs/ingestion/INGESTION_ARCHITECTURE.md
+++ b/docs/ingestion/INGESTION_ARCHITECTURE.md
@@ -335,6 +335,10 @@ resolve(string $companyId, array $sourceData): ?string  // MarketplaceListing.id
 | `app:ingestion:normalize-pending` | Страховка: повторная нормализация зависших PENDING | `*/10 * * * *` |
 | `app:ingestion:enrich-pending-cogs` | Страховка: повторное обогащение COGS | `*/30 * * * *` |
 
+`app:ingestion:run-incremental` использует source/resource strategies. Сейчас поддержаны
+`ozon_finance_accrual_by_day` и `wildberries_finance_sales_report_detailed`; без
+`--source` команда обрабатывает оба источника, `--source=ozon|wildberries` ограничивает запуск.
+
 ---
 
 ## Правила модуля (обязательные)

--- a/docs/ingestion/runbook.md
+++ b/docs/ingestion/runbook.md
@@ -125,15 +125,17 @@ GROUP BY status;
 ```bash
 docker exec -it scheduler php /app/bin/console app:ingestion:run-incremental \
   --env=prod \
-  --source=ozon \
+  --source=wildberries \
   --company-id=UUID \
   --limit=1 \
   --no-interaction \
   -vv
 ```
 
-**Важно:** инкремент запускается только если есть cursor. Если `skippedWithoutCursor > 0`
-— сначала нужен backfill.
+`--source` можно опустить, чтобы запустить все поддержанные источники, или указать
+`ozon` / `wildberries` для точечной проверки. Ozon cursor seed-ится из legacy cursor
+или первого дня месяца. WB finance cursor seed-ится от последнего raw report date + 1 день,
+а если истории нет — с первого дня текущего месяца.
 
 ---
 

--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -187,6 +187,16 @@ services:
         arguments:
             $resolvers: !tagged_iterator app.ingestion.listing_resolver
 
+    App\Ingestion\Command\RunIncrementalCommand:
+        arguments:
+            $strategies: !tagged_iterator app.ingestion.incremental_strategy
+
+    App\Ingestion\Application\Service\OzonAccrualIncrementalStrategy:
+        tags: ['app.ingestion.incremental_strategy']
+
+    App\Ingestion\Application\Service\WbFinanceIncrementalStrategy:
+        tags: ['app.ingestion.incremental_strategy']
+
     App\Ingestion\Application\Source\Ozon\OzonListingResolver:
         tags: ['app.ingestion.listing_resolver']
 

--- a/site/src/Ingestion/Application/Action/EnsureWbFinanceCursorAction.php
+++ b/site/src/Ingestion/Application/Action/EnsureWbFinanceCursorAction.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Action;
+
+use App\Ingestion\Application\Command\EnsureWbFinanceCursorCommand;
+use App\Ingestion\Application\Source\Wildberries\WbResourceType;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Repository\IngestCursorRepository;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+
+final readonly class EnsureWbFinanceCursorAction
+{
+    public function __construct(
+        private IngestCursorRepository $cursorRepository,
+        private Connection $connection,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function __invoke(EnsureWbFinanceCursorCommand $command): void
+    {
+        if ([] !== $this->cursorRepository->findByResource($command->companyId, $command->connectionRef, WbResourceType::FINANCE_SALES_REPORT_DETAILED)) {
+            return;
+        }
+
+        $cursor = $this->cursorRepository->getOrCreate(
+            $command->companyId,
+            $command->connectionRef,
+            WbResourceType::FINANCE_SALES_REPORT_DETAILED,
+            $command->connectionRef,
+        );
+        $cursor->advance($this->seedCursorValue($command), Uuid::uuid7()->toString());
+        $this->entityManager->flush();
+    }
+
+    private function seedCursorValue(EnsureWbFinanceCursorCommand $command): string
+    {
+        $latestRawDate = $this->latestRawReportDate($command);
+        if (null !== $latestRawDate) {
+            return $latestRawDate->modify('+1 day')->format('Y-m-d');
+        }
+
+        return (new \DateTimeImmutable('first day of this month'))->format('Y-m-d');
+    }
+
+    private function latestRawReportDate(EnsureWbFinanceCursorCommand $command): ?\DateTimeImmutable
+    {
+        $value = $this->connection->fetchOne(
+            "SELECT MAX(substring(external_id from '^wb-sales-report-detailed:([0-9]{4}-[0-9]{2}-[0-9]{2}):rrd-[0-9]+$')::date)
+             FROM ingest_raw_records
+             WHERE company_id = :companyId
+               AND connection_ref = :connectionRef
+               AND shop_ref = :shopRef
+               AND source = :source
+               AND resource_type = :resourceType
+               AND external_id ~ '^wb-sales-report-detailed:[0-9]{4}-[0-9]{2}-[0-9]{2}:rrd-[0-9]+$'",
+            [
+                'companyId' => $command->companyId,
+                'connectionRef' => $command->connectionRef,
+                'shopRef' => $command->connectionRef,
+                'source' => IngestSource::WILDBERRIES->value,
+                'resourceType' => WbResourceType::FINANCE_SALES_REPORT_DETAILED,
+            ],
+        );
+
+        if (!is_string($value) || '' === $value) {
+            return null;
+        }
+
+        return new \DateTimeImmutable($value);
+    }
+}

--- a/site/src/Ingestion/Application/Action/EnsureWbFinanceCursorAction.php
+++ b/site/src/Ingestion/Application/Action/EnsureWbFinanceCursorAction.php
@@ -11,6 +11,7 @@ use App\Ingestion\Repository\IngestCursorRepository;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Ramsey\Uuid\Uuid;
+use Symfony\Component\Clock\ClockInterface;
 
 final readonly class EnsureWbFinanceCursorAction
 {
@@ -18,6 +19,7 @@ final readonly class EnsureWbFinanceCursorAction
         private IngestCursorRepository $cursorRepository,
         private Connection $connection,
         private EntityManagerInterface $entityManager,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -44,11 +46,12 @@ final readonly class EnsureWbFinanceCursorAction
             return $latestRawDate->modify('+1 day')->format('Y-m-d');
         }
 
-        return (new \DateTimeImmutable('first day of this month'))->format('Y-m-d');
+        return $this->clock->now()->modify('first day of this month')->format('Y-m-d');
     }
 
     private function latestRawReportDate(EnsureWbFinanceCursorCommand $command): ?\DateTimeImmutable
     {
+        // WbFinanceReportConnector stores raw pages as wb-sales-report-detailed:YYYY-MM-DD:rrd-N.
         $value = $this->connection->fetchOne(
             "SELECT MAX(substring(external_id from '^wb-sales-report-detailed:([0-9]{4}-[0-9]{2}-[0-9]{2}):rrd-[0-9]+$')::date)
              FROM ingest_raw_records

--- a/site/src/Ingestion/Application/Command/EnsureWbFinanceCursorCommand.php
+++ b/site/src/Ingestion/Application/Command/EnsureWbFinanceCursorCommand.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Command;
+
+use Webmozart\Assert\Assert;
+
+final readonly class EnsureWbFinanceCursorCommand
+{
+    public function __construct(
+        public string $companyId,
+        public string $connectionRef,
+    ) {
+        Assert::uuid($this->companyId);
+        Assert::notEmpty($this->connectionRef);
+    }
+}

--- a/site/src/Ingestion/Application/Service/AbstractDailyCursorIncrementalStrategy.php
+++ b/site/src/Ingestion/Application/Service/AbstractDailyCursorIncrementalStrategy.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Service;
+
+use Symfony\Component\Clock\ClockInterface;
+
+abstract readonly class AbstractDailyCursorIncrementalStrategy implements IncrementalResourceStrategyInterface
+{
+    public function __construct(private ClockInterface $clock)
+    {
+    }
+
+    public function cursorIsDue(string $cursorValue): bool
+    {
+        $cursorDate = $this->normalizedCursorDate($cursorValue);
+        if (null === $cursorDate) {
+            return true;
+        }
+
+        return $cursorDate <= $this->yesterdayDate();
+    }
+
+    private function normalizedCursorDate(string $cursorValue): ?string
+    {
+        try {
+            return (new \DateTimeImmutable($cursorValue))->format('Y-m-d');
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private function yesterdayDate(): string
+    {
+        return $this->clock->now()->modify('-1 day')->format('Y-m-d');
+    }
+}

--- a/site/src/Ingestion/Application/Service/IncrementalResourceStrategyInterface.php
+++ b/site/src/Ingestion/Application/Service/IncrementalResourceStrategyInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Service;
+
+use App\Ingestion\Enum\IngestSource;
+
+interface IncrementalResourceStrategyInterface
+{
+    public function source(): IngestSource;
+
+    public function resourceType(): string;
+
+    /**
+     * @param array{id: string, company_id: string, marketplace: string} $connection
+     */
+    public function supportsConnection(array $connection): bool;
+
+    public function ensureCursor(string $companyId, string $connectionRef): void;
+
+    public function cursorIsDue(string $cursorValue): bool;
+}

--- a/site/src/Ingestion/Application/Service/OzonAccrualIncrementalStrategy.php
+++ b/site/src/Ingestion/Application/Service/OzonAccrualIncrementalStrategy.php
@@ -8,11 +8,15 @@ use App\Ingestion\Application\Action\EnsureOzonAccrualCursorAction;
 use App\Ingestion\Application\Command\EnsureOzonAccrualCursorCommand;
 use App\Ingestion\Application\Source\Ozon\OzonResourceType;
 use App\Ingestion\Enum\IngestSource;
+use Symfony\Component\Clock\ClockInterface;
 
-final readonly class OzonAccrualIncrementalStrategy implements IncrementalResourceStrategyInterface
+final readonly class OzonAccrualIncrementalStrategy extends AbstractDailyCursorIncrementalStrategy
 {
-    public function __construct(private EnsureOzonAccrualCursorAction $ensureCursorAction)
-    {
+    public function __construct(
+        private EnsureOzonAccrualCursorAction $ensureCursorAction,
+        ClockInterface $clock,
+    ) {
+        parent::__construct($clock);
     }
 
     public function source(): IngestSource
@@ -33,29 +37,5 @@ final readonly class OzonAccrualIncrementalStrategy implements IncrementalResour
     public function ensureCursor(string $companyId, string $connectionRef): void
     {
         ($this->ensureCursorAction)(new EnsureOzonAccrualCursorCommand($companyId, $connectionRef));
-    }
-
-    public function cursorIsDue(string $cursorValue): bool
-    {
-        $cursorDate = $this->normalizedCursorDate($cursorValue);
-        if (null === $cursorDate) {
-            return true;
-        }
-
-        return new \DateTimeImmutable($cursorDate) <= $this->yesterday();
-    }
-
-    private function normalizedCursorDate(string $cursorValue): ?string
-    {
-        try {
-            return (new \DateTimeImmutable($cursorValue))->format('Y-m-d');
-        } catch (\Throwable) {
-            return null;
-        }
-    }
-
-    private function yesterday(): \DateTimeImmutable
-    {
-        return (new \DateTimeImmutable('today'))->modify('-1 day')->setTime(0, 0);
     }
 }

--- a/site/src/Ingestion/Application/Service/OzonAccrualIncrementalStrategy.php
+++ b/site/src/Ingestion/Application/Service/OzonAccrualIncrementalStrategy.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Service;
+
+use App\Ingestion\Application\Action\EnsureOzonAccrualCursorAction;
+use App\Ingestion\Application\Command\EnsureOzonAccrualCursorCommand;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Enum\IngestSource;
+
+final readonly class OzonAccrualIncrementalStrategy implements IncrementalResourceStrategyInterface
+{
+    public function __construct(private EnsureOzonAccrualCursorAction $ensureCursorAction)
+    {
+    }
+
+    public function source(): IngestSource
+    {
+        return IngestSource::OZON;
+    }
+
+    public function resourceType(): string
+    {
+        return OzonResourceType::ACCRUAL_BY_DAY;
+    }
+
+    public function supportsConnection(array $connection): bool
+    {
+        return IngestSource::OZON->value === (string) $connection['marketplace'];
+    }
+
+    public function ensureCursor(string $companyId, string $connectionRef): void
+    {
+        ($this->ensureCursorAction)(new EnsureOzonAccrualCursorCommand($companyId, $connectionRef));
+    }
+
+    public function cursorIsDue(string $cursorValue): bool
+    {
+        $cursorDate = $this->normalizedCursorDate($cursorValue);
+        if (null === $cursorDate) {
+            return true;
+        }
+
+        return new \DateTimeImmutable($cursorDate) <= $this->yesterday();
+    }
+
+    private function normalizedCursorDate(string $cursorValue): ?string
+    {
+        try {
+            return (new \DateTimeImmutable($cursorValue))->format('Y-m-d');
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private function yesterday(): \DateTimeImmutable
+    {
+        return (new \DateTimeImmutable('today'))->modify('-1 day')->setTime(0, 0);
+    }
+}

--- a/site/src/Ingestion/Application/Service/WbFinanceIncrementalStrategy.php
+++ b/site/src/Ingestion/Application/Service/WbFinanceIncrementalStrategy.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Service;
+
+use App\Ingestion\Application\Action\EnsureWbFinanceCursorAction;
+use App\Ingestion\Application\Command\EnsureWbFinanceCursorCommand;
+use App\Ingestion\Application\Source\Wildberries\WbResourceType;
+use App\Ingestion\Enum\IngestSource;
+
+final readonly class WbFinanceIncrementalStrategy implements IncrementalResourceStrategyInterface
+{
+    public function __construct(private EnsureWbFinanceCursorAction $ensureCursorAction)
+    {
+    }
+
+    public function source(): IngestSource
+    {
+        return IngestSource::WILDBERRIES;
+    }
+
+    public function resourceType(): string
+    {
+        return WbResourceType::FINANCE_SALES_REPORT_DETAILED;
+    }
+
+    public function supportsConnection(array $connection): bool
+    {
+        return IngestSource::WILDBERRIES->value === (string) $connection['marketplace'];
+    }
+
+    public function ensureCursor(string $companyId, string $connectionRef): void
+    {
+        ($this->ensureCursorAction)(new EnsureWbFinanceCursorCommand($companyId, $connectionRef));
+    }
+
+    public function cursorIsDue(string $cursorValue): bool
+    {
+        $cursorDate = $this->normalizedCursorDate($cursorValue);
+        if (null === $cursorDate) {
+            return true;
+        }
+
+        return new \DateTimeImmutable($cursorDate) <= $this->yesterday();
+    }
+
+    private function normalizedCursorDate(string $cursorValue): ?string
+    {
+        try {
+            return (new \DateTimeImmutable($cursorValue))->format('Y-m-d');
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private function yesterday(): \DateTimeImmutable
+    {
+        return (new \DateTimeImmutable('today'))->modify('-1 day')->setTime(0, 0);
+    }
+}

--- a/site/src/Ingestion/Application/Service/WbFinanceIncrementalStrategy.php
+++ b/site/src/Ingestion/Application/Service/WbFinanceIncrementalStrategy.php
@@ -8,11 +8,15 @@ use App\Ingestion\Application\Action\EnsureWbFinanceCursorAction;
 use App\Ingestion\Application\Command\EnsureWbFinanceCursorCommand;
 use App\Ingestion\Application\Source\Wildberries\WbResourceType;
 use App\Ingestion\Enum\IngestSource;
+use Symfony\Component\Clock\ClockInterface;
 
-final readonly class WbFinanceIncrementalStrategy implements IncrementalResourceStrategyInterface
+final readonly class WbFinanceIncrementalStrategy extends AbstractDailyCursorIncrementalStrategy
 {
-    public function __construct(private EnsureWbFinanceCursorAction $ensureCursorAction)
-    {
+    public function __construct(
+        private EnsureWbFinanceCursorAction $ensureCursorAction,
+        ClockInterface $clock,
+    ) {
+        parent::__construct($clock);
     }
 
     public function source(): IngestSource
@@ -33,29 +37,5 @@ final readonly class WbFinanceIncrementalStrategy implements IncrementalResource
     public function ensureCursor(string $companyId, string $connectionRef): void
     {
         ($this->ensureCursorAction)(new EnsureWbFinanceCursorCommand($companyId, $connectionRef));
-    }
-
-    public function cursorIsDue(string $cursorValue): bool
-    {
-        $cursorDate = $this->normalizedCursorDate($cursorValue);
-        if (null === $cursorDate) {
-            return true;
-        }
-
-        return new \DateTimeImmutable($cursorDate) <= $this->yesterday();
-    }
-
-    private function normalizedCursorDate(string $cursorValue): ?string
-    {
-        try {
-            return (new \DateTimeImmutable($cursorValue))->format('Y-m-d');
-        } catch (\Throwable) {
-            return null;
-        }
-    }
-
-    private function yesterday(): \DateTimeImmutable
-    {
-        return (new \DateTimeImmutable('today'))->modify('-1 day')->setTime(0, 0);
     }
 }

--- a/site/src/Ingestion/Application/Source/Wildberries/WbFinanceReportConnector.php
+++ b/site/src/Ingestion/Application/Source/Wildberries/WbFinanceReportConnector.php
@@ -80,7 +80,7 @@ final readonly class WbFinanceReportConnector implements SourceConnectorInterfac
             ),
             nextCursorValue: $nextCursor,
             hasMore: $page->hasMore,
-            normalizeRawRecords: false,
+            normalizeRawRecords: true,
             continuationDelaySeconds: $page->hasMore ? $this->continuationDelaySeconds : null,
         );
     }
@@ -183,7 +183,7 @@ final readonly class WbFinanceReportConnector implements SourceConnectorInterfac
 
     /**
      * @param list<array<string, mixed>> $rows
-     * @param array<string, mixed>       $metadata
+     * @param array<string, mixed> $metadata
      *
      * @return list<array<string, mixed>>
      */

--- a/site/src/Ingestion/Command/RunIncrementalCommand.php
+++ b/site/src/Ingestion/Command/RunIncrementalCommand.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace App\Ingestion\Command;
 
-use App\Ingestion\Application\Action\EnsureOzonAccrualCursorAction;
-use App\Ingestion\Application\Command\EnsureOzonAccrualCursorCommand;
 use App\Ingestion\Application\Command\StartIncrementalCommand as StartIncrementalApplicationCommand;
-use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Application\Service\IncrementalResourceStrategyInterface;
 use App\Ingestion\Enum\IngestSource;
 use App\Ingestion\Exception\ActiveBackfillExistsException;
 use App\Ingestion\Facade\SyncFacade;
@@ -32,26 +30,31 @@ final class RunIncrementalCommand extends Command
     use LockableTrait;
 
     /**
-     * @var list<string>
+     * @var list<IncrementalResourceStrategyInterface>
      */
-    private const OZON_RESOURCE_TYPES = [
-        OzonResourceType::ACCRUAL_BY_DAY,
-    ];
+    private array $strategies;
 
+    /**
+     * @param iterable<IncrementalResourceStrategyInterface> $strategies
+     */
     public function __construct(
         private readonly ActiveSellerConnectionsQuery $connectionsQuery,
         private readonly IngestCursorRepository $cursorRepository,
         private readonly SyncFacade $syncFacade,
-        private readonly EnsureOzonAccrualCursorAction $ensureOzonAccrualCursorAction,
+        iterable $strategies,
         private readonly LoggerInterface $logger,
     ) {
+        $this->strategies = $strategies instanceof \Traversable
+            ? array_values(iterator_to_array($strategies, false))
+            : array_values(is_array($strategies) ? $strategies : []);
+
         parent::__construct();
     }
 
     protected function configure(): void
     {
         $this
-            ->addOption('source', null, InputOption::VALUE_REQUIRED, 'Optional source filter. Only "ozon" is supported now.')
+            ->addOption('source', null, InputOption::VALUE_REQUIRED, 'Optional source filter.')
             ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Optional company UUID filter.')
             ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Maximum companies per tick.', 50);
     }
@@ -76,7 +79,7 @@ final class RunIncrementalCommand extends Command
     private function runIncremental(InputInterface $input, SymfonyStyle $io): int
     {
         try {
-            $source = $this->source($input);
+            $source = $this->sourceFilter($input);
             $companyId = $this->companyId($input);
             $limit = $this->limit($input);
         } catch (\Throwable $exception) {
@@ -85,10 +88,12 @@ final class RunIncrementalCommand extends Command
             return Command::FAILURE;
         }
 
-        if (IngestSource::OZON !== $source) {
-            $io->warning(sprintf('Incremental ingestion for "%s" is not supported yet.', $source->value));
+        $strategies = $this->strategiesForSource($source);
+        if ([] === $strategies) {
+            $sourceValue = $source?->value ?? 'all';
+            $io->warning(sprintf('No incremental ingestion strategies are registered for "%s".', $sourceValue));
             $this->logger->info('Ingestion incremental skipped because source is not supported yet.', [
-                'source' => $source->value,
+                'source' => $sourceValue,
                 'companyId' => $companyId,
             ]);
 
@@ -104,19 +109,19 @@ final class RunIncrementalCommand extends Command
         $failed = 0;
 
         foreach ($connections as $connection) {
-            if (IngestSource::OZON->value !== (string) $connection['marketplace']) {
-                continue;
-            }
-
             $connectionCompanyId = (string) $connection['company_id'];
             if (null !== $companyId && $connectionCompanyId !== $companyId) {
                 continue;
             }
 
             $connectionRef = (string) $connection['id'];
-            ($this->ensureOzonAccrualCursorAction)(new EnsureOzonAccrualCursorCommand($connectionCompanyId, $connectionRef));
+            foreach ($strategies as $strategy) {
+                if (!$strategy->supportsConnection($connection)) {
+                    continue;
+                }
 
-            foreach (self::OZON_RESOURCE_TYPES as $resourceType) {
+                $strategy->ensureCursor($connectionCompanyId, $connectionRef);
+                $resourceType = $strategy->resourceType();
                 $cursors = $this->cursorRepository->findByResource($connectionCompanyId, $connectionRef, $resourceType);
                 if ([] === $cursors) {
                     ++$skippedWithoutCursor;
@@ -129,7 +134,7 @@ final class RunIncrementalCommand extends Command
                         continue;
                     }
 
-                    if (!$this->cursorHasDueWork($resourceType, $cursor->getCursorValue())) {
+                    if (!$strategy->cursorIsDue($cursor->getCursorValue())) {
                         ++$skippedNotDue;
                         continue;
                     }
@@ -145,6 +150,7 @@ final class RunIncrementalCommand extends Command
                     }
                     $eligibleWork[$connectionCompanyId]['jobs'][] = [
                         'connectionRef' => $connectionRef,
+                        'source' => $strategy->source(),
                         'resourceType' => $resourceType,
                         'shopRef' => $cursor->getShopRef(),
                     ];
@@ -167,7 +173,7 @@ final class RunIncrementalCommand extends Command
                     $this->syncFacade->startIncremental(new StartIncrementalApplicationCommand(
                         companyId: $connectionCompanyId,
                         connectionRef: $job['connectionRef'],
-                        source: IngestSource::OZON,
+                        source: $job['source'],
                         resourceType: $job['resourceType'],
                         shopRef: $job['shopRef'],
                     ));
@@ -186,7 +192,7 @@ final class RunIncrementalCommand extends Command
                     $this->logger->warning('Failed to dispatch ingestion incremental job.', [
                         'companyId' => $connectionCompanyId,
                         'connectionRef' => $job['connectionRef'],
-                        'source' => IngestSource::OZON->value,
+                        'source' => $job['source']->value,
                         'resourceType' => $job['resourceType'],
                         'shopRef' => $job['shopRef'],
                         'exceptionClass' => $exception::class,
@@ -204,7 +210,7 @@ final class RunIncrementalCommand extends Command
             'skippedActive' => $skippedActive,
             'companyLimit' => $limit,
             'companyId' => $companyId,
-            'source' => $source->value,
+            'source' => $source?->value ?? 'all',
         ]);
 
         $io->success(sprintf(
@@ -219,11 +225,11 @@ final class RunIncrementalCommand extends Command
         return 0 === $dispatched && $failed > 0 ? Command::FAILURE : Command::SUCCESS;
     }
 
-    private function source(InputInterface $input): IngestSource
+    private function sourceFilter(InputInterface $input): ?IngestSource
     {
         $value = trim((string) $input->getOption('source'));
         if ('' === $value) {
-            return IngestSource::OZON;
+            return null;
         }
 
         $source = IngestSource::tryFrom($value);
@@ -232,6 +238,21 @@ final class RunIncrementalCommand extends Command
         }
 
         return $source;
+    }
+
+    /**
+     * @return list<IncrementalResourceStrategyInterface>
+     */
+    private function strategiesForSource(?IngestSource $source): array
+    {
+        if (null === $source) {
+            return $this->strategies;
+        }
+
+        return array_values(array_filter(
+            $this->strategies,
+            static fn (IncrementalResourceStrategyInterface $strategy): bool => $strategy->source() === $source,
+        ));
     }
 
     private function companyId(InputInterface $input): ?string
@@ -259,30 +280,5 @@ final class RunIncrementalCommand extends Command
         }
 
         return $limit;
-    }
-
-    private function cursorHasDueWork(string $resourceType, string $cursorValue): bool
-    {
-        if (OzonResourceType::ACCRUAL_BY_DAY !== $resourceType) {
-            return true;
-        }
-
-        $cursorDate = $this->normalizedCursorDate($cursorValue);
-        if (null === $cursorDate) {
-            return true;
-        }
-
-        $yesterday = (new \DateTimeImmutable('today'))->modify('-1 day')->setTime(0, 0);
-
-        return new \DateTimeImmutable($cursorDate) <= $yesterday;
-    }
-
-    private function normalizedCursorDate(string $cursorValue): ?string
-    {
-        try {
-            return (new \DateTimeImmutable($cursorValue))->format('Y-m-d');
-        } catch (\Throwable) {
-            return null;
-        }
     }
 }

--- a/site/tests/Integration/Ingestion/Application/Source/Wildberries/WbFinanceNormalizationFlowTest.php
+++ b/site/tests/Integration/Ingestion/Application/Source/Wildberries/WbFinanceNormalizationFlowTest.php
@@ -121,6 +121,34 @@ final class WbFinanceNormalizationFlowTest extends IntegrationTestCase
         self::assertStringContainsString('unmapped non-zero fields', $issues[0]->getDetails()['message']);
     }
 
+    public function testEmptyWildberriesFinanceRawRecordNormalizesWithoutTransactions(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $record = $this->storeRawRecord($companyId, [[
+            '_ingestion_empty' => true,
+            '_ingestion_resource' => WbResourceType::FINANCE_SALES_REPORT_DETAILED,
+            '_ingestion_metadata' => ['date' => '2026-06-22', 'statusCode' => 204],
+        ]]);
+
+        $this->normalize($record->getId(), $companyId);
+        $this->em->clear();
+
+        /** @var IngestRawRecordRepository $rawRecordRepository */
+        $rawRecordRepository = self::getContainer()->get(IngestRawRecordRepository::class);
+        self::assertSame(
+            RawNormalizationStatus::DONE,
+            $rawRecordRepository->findByIdAndCompany($record->getId(), $companyId)?->getNormalizationStatus(),
+        );
+
+        /** @var FinancialTransactionRepository $transactionRepository */
+        $transactionRepository = self::getContainer()->get(FinancialTransactionRepository::class);
+        self::assertSame([], $transactionRepository->findByRawRecordId($companyId, $record->getId()));
+
+        /** @var NormalizationIssueRepository $issueRepository */
+        $issueRepository = self::getContainer()->get(NormalizationIssueRepository::class);
+        self::assertSame([], $issueRepository->findOpenByRawRecord($companyId, $record->getId()));
+    }
+
     /**
      * @param list<array<string, mixed>> $rows
      */

--- a/site/tests/Integration/Ingestion/Command/RunIncrementalCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/RunIncrementalCommandTest.php
@@ -6,7 +6,11 @@ namespace App\Tests\Integration\Ingestion\Command;
 
 use App\Company\Entity\Company;
 use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Application\Source\Wildberries\WbResourceType;
+use App\Ingestion\DTO\RawBatch;
+use App\Ingestion\Enum\IngestSource;
 use App\Ingestion\Enum\SyncJobKind;
+use App\Ingestion\Facade\RawStorageFacade;
 use App\Ingestion\Message\RunSyncChunkMessage;
 use App\Ingestion\Repository\IngestCursorRepository;
 use App\Marketplace\Entity\MarketplaceConnection;
@@ -180,13 +184,109 @@ final class RunIncrementalCommandTest extends IntegrationTestCase
         self::assertCount(0, $transport->getSent());
     }
 
-    public function testWildberriesSourceIsSkipped(): void
+    public function testWildberriesSourceSeedsCursorFromLatestRawAndDispatches(): void
     {
+        $company = $this->seedCompany(1008);
+        $connection = $this->seedConnection($company, '77777777-7777-7777-7777-000000001008', MarketplaceType::WILDBERRIES);
+        $this->storeWbRawRecord($company->getId(), $connection->getId(), '2025-01-10');
+
+        $transport = $this->getIngestFetchTransport();
+        $transport->reset();
+
+        $tester = $this->tester('app:ingestion:run-incremental');
+        $exit = $tester->execute([
+            '--source' => 'wildberries',
+            '--company-id' => $company->getId(),
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertStringContainsString('Dispatched 1 incremental jobs', $tester->getDisplay());
+        self::assertSame(1, $this->incrementalJobCount($company->getId()));
+        self::assertCount(1, $transport->getSent());
+
+        /** @var IngestCursorRepository $cursorRepository */
+        $cursorRepository = self::getContainer()->get(IngestCursorRepository::class);
+        $cursor = $cursorRepository->findOne($company->getId(), $connection->getId(), WbResourceType::FINANCE_SALES_REPORT_DETAILED, $connection->getId());
+
+        self::assertNotNull($cursor);
+        self::assertSame('2025-01-11', $cursor->getCursorValue());
+    }
+
+    public function testWildberriesSourceSeedsCursorFromFirstDayOfCurrentMonthWithoutRawHistory(): void
+    {
+        $company = $this->seedCompany(1009);
+        $connection = $this->seedConnection($company, '77777777-7777-7777-7777-000000001009', MarketplaceType::WILDBERRIES);
+
+        $transport = $this->getIngestFetchTransport();
+        $transport->reset();
+
+        $tester = $this->tester('app:ingestion:run-incremental');
+        $exit = $tester->execute([
+            '--source' => 'wildberries',
+            '--company-id' => $company->getId(),
+        ]);
+
+        $expectedSeed = (new \DateTimeImmutable('first day of this month'))->format('Y-m-d');
+        $isSeedDue = new \DateTimeImmutable($expectedSeed) <= (new \DateTimeImmutable('today'))->modify('-1 day')->setTime(0, 0);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertStringContainsString($isSeedDue ? 'Dispatched 1 incremental jobs' : 'not due: 1', $tester->getDisplay());
+        self::assertSame($isSeedDue ? 1 : 0, $this->incrementalJobCount($company->getId()));
+        self::assertCount($isSeedDue ? 1 : 0, $transport->getSent());
+
+        /** @var IngestCursorRepository $cursorRepository */
+        $cursorRepository = self::getContainer()->get(IngestCursorRepository::class);
+        $cursor = $cursorRepository->findOne($company->getId(), $connection->getId(), WbResourceType::FINANCE_SALES_REPORT_DETAILED, $connection->getId());
+
+        self::assertNotNull($cursor);
+        self::assertSame($expectedSeed, $cursor->getCursorValue());
+    }
+
+    public function testWildberriesCursorThatIsNotDueYetIsSkipped(): void
+    {
+        $company = $this->seedCompany(1010);
+        $connection = $this->seedConnection($company, '77777777-7777-7777-7777-000000001010', MarketplaceType::WILDBERRIES);
+        $this->seedCursor(
+            $company->getId(),
+            $connection->getId(),
+            WbResourceType::FINANCE_SALES_REPORT_DETAILED,
+            $connection->getId(),
+            (new \DateTimeImmutable('tomorrow'))->format('Y-m-d'),
+        );
+
+        $transport = $this->getIngestFetchTransport();
+        $transport->reset();
+
         $tester = $this->tester('app:ingestion:run-incremental');
         $exit = $tester->execute(['--source' => 'wildberries']);
 
         self::assertSame(Command::SUCCESS, $exit);
-        self::assertStringContainsString('not supported yet', $tester->getDisplay());
+        self::assertStringContainsString('not due: 1', $tester->getDisplay());
+        self::assertSame(0, $this->incrementalJobCount($company->getId()));
+        self::assertCount(0, $transport->getSent());
+    }
+
+    public function testDefaultRunDispatchesEligibleOzonAndWildberriesJobs(): void
+    {
+        $ozonCompany = $this->seedCompany(1012);
+        $ozonConnection = $this->seedConnection($ozonCompany, '77777777-7777-7777-7777-000000001012');
+        $this->seedCursor($ozonCompany->getId(), $ozonConnection->getId(), OzonResourceType::ACCRUAL_BY_DAY, $ozonConnection->getId(), '2025-01-10');
+
+        $wbCompany = $this->seedCompany(1013);
+        $wbConnection = $this->seedConnection($wbCompany, '77777777-7777-7777-7777-000000001013', MarketplaceType::WILDBERRIES);
+        $this->seedCursor($wbCompany->getId(), $wbConnection->getId(), WbResourceType::FINANCE_SALES_REPORT_DETAILED, $wbConnection->getId(), '2025-01-10');
+
+        $transport = $this->getIngestFetchTransport();
+        $transport->reset();
+
+        $tester = $this->tester('app:ingestion:run-incremental');
+        $exit = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertStringContainsString('Dispatched 2 incremental jobs', $tester->getDisplay());
+        self::assertSame(1, $this->incrementalJobCount($ozonCompany->getId()));
+        self::assertSame(1, $this->incrementalJobCount($wbCompany->getId()));
+        self::assertCount(2, $transport->getSent());
     }
 
     private function seedCompany(int $index): Company
@@ -201,12 +301,15 @@ final class RunIncrementalCommandTest extends IntegrationTestCase
         return $company;
     }
 
-    private function seedConnection(Company $company, string $id): MarketplaceConnection
-    {
+    private function seedConnection(
+        Company $company,
+        string $id,
+        MarketplaceType $marketplace = MarketplaceType::OZON,
+    ): MarketplaceConnection {
         $connection = new MarketplaceConnection(
             id: $id,
             company: $company,
-            marketplace: MarketplaceType::OZON,
+            marketplace: $marketplace,
             connectionType: MarketplaceConnectionType::SELLER,
         );
         $connection->setApiKey('test-key');
@@ -217,6 +320,29 @@ final class RunIncrementalCommandTest extends IntegrationTestCase
         $this->em->flush();
 
         return $connection;
+    }
+
+    private function storeWbRawRecord(string $companyId, string $connectionRef, string $date): void
+    {
+        /** @var RawStorageFacade $facade */
+        $facade = self::getContainer()->get(RawStorageFacade::class);
+
+        $facade->store(new RawBatch(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            shopRef: $connectionRef,
+            source: IngestSource::WILDBERRIES,
+            resourceType: WbResourceType::FINANCE_SALES_REPORT_DETAILED,
+            externalId: sprintf('wb-sales-report-detailed:%s:rrd-0', $date),
+            syncJobId: Uuid::uuid7()->toString(),
+            fetchedAt: new \DateTimeImmutable(sprintf('%s 10:00:00+00:00', $date)),
+            rows: [[
+                'rrdId' => 1,
+                'rrDate' => $date,
+                'currency' => 'RUB',
+            ]],
+        ));
+        $this->em->flush();
     }
 
     private function seedCursor(

--- a/site/tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceReportConnectorTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceReportConnectorTest.php
@@ -36,7 +36,7 @@ final class WbFinanceReportConnectorTest extends TestCase
         ));
     }
 
-    public function testPullStoresOnePageRawWithoutNormalization(): void
+    public function testPullStoresOnePageRawWithNormalization(): void
     {
         $client = $this->client(new WbFinanceReportPage(
             rows: [['rrdId' => 10, 'docTypeName' => 'Продажа']],
@@ -53,7 +53,7 @@ final class WbFinanceReportConnectorTest extends TestCase
 
         self::assertSame(WbResourceType::FINANCE_SALES_REPORT_DETAILED, $result->rawBatch->resourceType);
         self::assertSame('wb-sales-report-detailed:2026-06-20:rrd-0', $result->rawBatch->externalId);
-        self::assertFalse($result->normalizeRawRecords);
+        self::assertTrue($result->normalizeRawRecords);
         self::assertFalse($result->hasMore);
         self::assertNull($result->nextCursorValue);
         self::assertSame([


### PR DESCRIPTION
## What changed
- Added source/resource strategies for `app:ingestion:run-incremental`.
- Moved Ozon accrual incremental behavior behind an Ozon strategy.
- Added Wildberries finance incremental strategy and cursor bootstrap from latest WB raw report date + 1 day, with first-day-of-month fallback.
- Extracted shared daily cursor due logic into `AbstractDailyCursorIncrementalStrategy`.
- Switched daily due/bootstrap date logic in the new WB/Ozon incremental path to `ClockInterface` where applicable.
- Enabled automatic normalization for new WB finance raw records.
- Documented the canonical WB raw `external_id` format used for cursor bootstrap: `wb-sales-report-detailed:YYYY-MM-DD:rrd-N`.
- Updated ingestion docs/runbook for multi-source incremental behavior.

## Why
WB finance raw loading and production normalization are now validated manually for 2026-06-01..2026-06-21. The next step is to let the existing daily ingestion cron pick up new WB finance days automatically without embedding source-specific branching in the command.

## Validation
- `docker compose run --rm site-php-cli php bin/console lint:container --no-debug` — OK
- targeted PHPUnit: `RunIncrementalCommandTest`, `WbFinanceReportConnectorTest`, `WbFinanceNormalizationFlowTest` — OK, 22 tests / 104 assertions
- scoped `php-cs-fixer --dry-run --diff` — OK
- `make site-test-unit` — OK, 1120 tests / 6653 assertions; existing unrelated warning/deprecation in `StorageServiceTest` and `XlsxReaderServiceTest`
- GitHub Actions for PR head `b9b5ae28` — green; deploy/migrations jobs skipped as expected for PR
