### PR TITLE
[codex] Drain overdue ingestion incremental cursors

### DIFF
--- a/site/src/Ingestion/Application/Source/Ozon/OzonSellerReportConnector.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonSellerReportConnector.php
@@ -20,6 +20,8 @@ use Symfony\Component\Clock\ClockInterface;
 
 final readonly class OzonSellerReportConnector implements SourceConnectorInterface
 {
+    private const INCREMENTAL_CONTINUATION_DELAY_SECONDS = 1;
+
     public function __construct(
         private OzonAccrualClientInterface $accrualClient,
         private ClockInterface $clock,
@@ -130,6 +132,7 @@ final readonly class OzonSellerReportConnector implements SourceConnectorInterfa
             ),
             nextCursorValue: $nextCursor,
             hasMore: $windowHasMore || $incrementalHasMore,
+            continuationDelaySeconds: $incrementalHasMore ? self::INCREMENTAL_CONTINUATION_DELAY_SECONDS : null,
         );
     }
 

--- a/site/src/Ingestion/Application/Source/Ozon/OzonSellerReportConnector.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonSellerReportConnector.php
@@ -16,11 +16,13 @@ use App\Ingestion\Enum\Capability;
 use App\Ingestion\Enum\IngestSource;
 use App\Ingestion\Exception\UnsupportedCapabilityException;
 use App\Ingestion\Infrastructure\Api\Ozon\OzonAccrualClientInterface;
+use Symfony\Component\Clock\ClockInterface;
 
 final readonly class OzonSellerReportConnector implements SourceConnectorInterface
 {
     public function __construct(
         private OzonAccrualClientInterface $accrualClient,
+        private ClockInterface $clock,
         private int $chunkSizeDays = 7,
         private int $hotRewindDays = 14,
         private SourceDataHasher $sourceDataHasher = new SourceDataHasher(),
@@ -102,6 +104,9 @@ final readonly class OzonSellerReportConnector implements SourceConnectorInterfa
 
         $windowHasMore = null !== $request->windowTo && $to < $request->windowTo;
         $nextCursor = $windowHasMore || $this->isIncremental($request) ? $to->modify('+1 day')->format('Y-m-d') : null;
+        $incrementalHasMore = $this->isIncremental($request)
+            && null !== $nextCursor
+            && $this->dailyCursorIsDue($nextCursor);
 
         return new PullResult(
             rawBatch: new RawBatch(
@@ -124,7 +129,7 @@ final readonly class OzonSellerReportConnector implements SourceConnectorInterfa
                 ),
             ),
             nextCursorValue: $nextCursor,
-            hasMore: $windowHasMore,
+            hasMore: $windowHasMore || $incrementalHasMore,
         );
     }
 
@@ -169,7 +174,7 @@ final readonly class OzonSellerReportConnector implements SourceConnectorInterfa
             : $maxTo;
 
         if (null === $request->windowTo && null !== $request->cursorValue && '' !== $request->cursorValue) {
-            $yesterday = (new \DateTimeImmutable('today'))->modify('-1 day')->setTime(23, 59, 59);
+            $yesterday = $this->now()->modify('-1 day')->setTime(23, 59, 59);
             if ($yesterday < $to) {
                 $to = $yesterday;
             }
@@ -200,6 +205,21 @@ final readonly class OzonSellerReportConnector implements SourceConnectorInterfa
             && '' !== $request->cursorValue
             && null === $request->windowFrom
             && null === $request->windowTo;
+    }
+
+    private function dailyCursorIsDue(string $cursorValue): bool
+    {
+        $cursorDate = \DateTimeImmutable::createFromFormat('!Y-m-d', $cursorValue);
+        if (false === $cursorDate || $cursorDate->format('Y-m-d') !== $cursorValue) {
+            return false;
+        }
+
+        return $cursorDate <= $this->now()->modify('-1 day')->setTime(0, 0);
+    }
+
+    private function now(): \DateTimeImmutable
+    {
+        return $this->clock->now()->setTimezone(new \DateTimeZone(date_default_timezone_get()));
     }
 
     /**

--- a/site/src/Ingestion/Application/Source/Wildberries/WbFinanceReportConnector.php
+++ b/site/src/Ingestion/Application/Source/Wildberries/WbFinanceReportConnector.php
@@ -67,6 +67,9 @@ final readonly class WbFinanceReportConnector implements SourceConnectorInterfac
         $nextCursor = $page->hasMore && null !== $page->nextRrdId
             ? $this->encodeCursor($date, $page->nextRrdId)
             : $this->nextIncrementalDateCursor($request, $date, $page->hasMore);
+        $incrementalHasMore = !$page->hasMore
+            && null !== $nextCursor
+            && $this->dailyCursorIsDue($nextCursor);
 
         return new PullResult(
             rawBatch: new RawBatch(
@@ -81,7 +84,7 @@ final readonly class WbFinanceReportConnector implements SourceConnectorInterfac
                 rows: $this->rowsOrEmptyMarker($this->sortRowsCanonically($page->rows), $page->metadata),
             ),
             nextCursorValue: $nextCursor,
-            hasMore: $page->hasMore,
+            hasMore: $page->hasMore || $incrementalHasMore,
             normalizeRawRecords: true,
             continuationDelaySeconds: $page->hasMore ? $this->continuationDelaySeconds : null,
         );
@@ -111,7 +114,7 @@ final readonly class WbFinanceReportConnector implements SourceConnectorInterfac
             return [$from, 0];
         }
 
-        $yesterday = (new \DateTimeImmutable('today'))->modify('-1 day')->setTime(0, 0);
+        $yesterday = $this->now()->modify('-1 day')->setTime(0, 0);
 
         return [$yesterday, 0];
     }
@@ -152,12 +155,27 @@ final readonly class WbFinanceReportConnector implements SourceConnectorInterfac
         }
 
         $nextDate = $date->modify('+1 day')->setTime(0, 0);
-        $today = $this->clock->now()->setTime(0, 0);
+        $today = $this->now()->setTime(0, 0);
         if ($nextDate > $today) {
             return null;
         }
 
         return $nextDate->format('Y-m-d');
+    }
+
+    private function dailyCursorIsDue(string $cursorValue): bool
+    {
+        $cursorDate = \DateTimeImmutable::createFromFormat('!Y-m-d', $cursorValue);
+        if (false === $cursorDate || $cursorDate->format('Y-m-d') !== $cursorValue) {
+            return false;
+        }
+
+        return $cursorDate <= $this->now()->modify('-1 day')->setTime(0, 0);
+    }
+
+    private function now(): \DateTimeImmutable
+    {
+        return $this->clock->now()->setTimezone(new \DateTimeZone(date_default_timezone_get()));
     }
 
     private function date(string $value): \DateTimeImmutable

--- a/site/src/Ingestion/Infrastructure/Query/CoverageQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/CoverageQuery.php
@@ -6,6 +6,7 @@ namespace App\Ingestion\Infrastructure\Query;
 
 use App\Ingestion\Application\DTO\CoverageCellView;
 use App\Ingestion\Application\DTO\ShopOptionView;
+use App\Ingestion\Enum\SyncJobKind;
 use App\Ingestion\Enum\SyncJobStatus;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Types;
@@ -212,6 +213,7 @@ final class CoverageQuery
                 FROM ingest_sync_jobs j
                 WHERE j.company_id = :companyId
                   AND j.status = :failedStatus
+                  AND (j.kind = :incrementalKind OR j.parent_job_id IS NOT NULL)
                   {$shopFilter}
             )
             SELECT
@@ -232,6 +234,7 @@ final class CoverageQuery
         $params = [
             'companyId' => $companyId,
             'failedStatus' => SyncJobStatus::FAILED->value,
+            'incrementalKind' => SyncJobKind::INCREMENTAL->value,
             'fromDate' => $from,
             'toDate' => $to,
         ];

--- a/site/src/Ingestion/Infrastructure/Query/CoverageQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/CoverageQuery.php
@@ -6,6 +6,7 @@ namespace App\Ingestion\Infrastructure\Query;
 
 use App\Ingestion\Application\DTO\CoverageCellView;
 use App\Ingestion\Application\DTO\ShopOptionView;
+use App\Ingestion\Enum\SyncJobStatus;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Types;
 use Webmozart\Assert\Assert;
@@ -104,6 +105,7 @@ final class CoverageQuery
         }
 
         $rows = $qb->executeQuery()->fetchAllAssociative();
+        $rows = $this->mergeRows($rows, $this->failedJobIssueRows($companyId, $shopRef, $from, $to));
 
         return array_map(
             static fn (array $row): CoverageCellView => new CoverageCellView(
@@ -117,6 +119,138 @@ final class CoverageQuery
             ),
             $rows,
         );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $baseRows
+     * @param list<array<string, mixed>> $issueRows
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function mergeRows(array $baseRows, array $issueRows): array
+    {
+        $merged = [];
+
+        foreach (array_merge($baseRows, $issueRows) as $row) {
+            $key = implode('|', [
+                (string) $row['record_date'],
+                (string) $row['shop_ref'],
+                (string) $row['resource_type'],
+            ]);
+
+            if (!isset($merged[$key])) {
+                $merged[$key] = [
+                    'record_date' => (string) $row['record_date'],
+                    'shop_ref' => (string) $row['shop_ref'],
+                    'resource_type' => (string) $row['resource_type'],
+                    'raw_count' => 0,
+                    'tx_count' => 0,
+                    'issue_count' => 0,
+                    'last_fetched_at' => null,
+                ];
+            }
+
+            $merged[$key]['raw_count'] += (int) ($row['raw_count'] ?? 0);
+            $merged[$key]['tx_count'] += (int) ($row['tx_count'] ?? 0);
+            $merged[$key]['issue_count'] += (int) ($row['issue_count'] ?? 0);
+
+            if (null !== ($row['last_fetched_at'] ?? null)) {
+                $current = $merged[$key]['last_fetched_at'];
+                if (null === $current || (string) $row['last_fetched_at'] > (string) $current) {
+                    $merged[$key]['last_fetched_at'] = $row['last_fetched_at'];
+                }
+            }
+        }
+
+        $rows = array_values($merged);
+        usort($rows, static fn (array $left, array $right): int => [
+            (string) $left['record_date'],
+            (string) $left['shop_ref'],
+            (string) $left['resource_type'],
+        ] <=> [
+            (string) $right['record_date'],
+            (string) $right['shop_ref'],
+            (string) $right['resource_type'],
+        ]);
+
+        return $rows;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function failedJobIssueRows(
+        string $companyId,
+        ?string $shopRef,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+    ): array {
+        $shopFilter = null !== $shopRef && '' !== $shopRef ? 'AND j.shop_ref = :shopRef' : '';
+        $sql = <<<SQL
+            WITH failed_jobs AS (
+                SELECT
+                    j.id,
+                    j.shop_ref,
+                    j.resource_type,
+                    COALESCE(
+                        j.window_from,
+                        CASE
+                            WHEN j.cursor_snapshot ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'
+                                THEN j.cursor_snapshot::date
+                            ELSE j.created_at::date
+                        END
+                    ) AS from_date,
+                    COALESCE(
+                        j.window_to,
+                        j.window_from,
+                        CASE
+                            WHEN j.cursor_snapshot ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'
+                                THEN j.cursor_snapshot::date
+                            ELSE j.created_at::date
+                        END
+                    ) AS to_date
+                FROM ingest_sync_jobs j
+                WHERE j.company_id = :companyId
+                  AND j.status = :failedStatus
+                  {$shopFilter}
+            )
+            SELECT
+                TO_CHAR(day.day, 'YYYY-MM-DD') AS record_date,
+                fj.shop_ref,
+                fj.resource_type,
+                0 AS raw_count,
+                0 AS tx_count,
+                COUNT(DISTINCT fj.id) AS issue_count,
+                NULL AS last_fetched_at
+            FROM failed_jobs fj
+            JOIN LATERAL (
+                SELECT day::date AS day
+                FROM generate_series(
+                    GREATEST(fj.from_date, :fromDate)::date,
+                    LEAST(fj.to_date, :toDate)::date,
+                    interval '1 day'
+                ) AS day
+            ) day ON fj.from_date <= :toDate AND fj.to_date >= :fromDate
+            GROUP BY day.day, fj.shop_ref, fj.resource_type
+            ORDER BY record_date ASC, fj.shop_ref ASC, fj.resource_type ASC
+            SQL;
+
+        $params = [
+            'companyId' => $companyId,
+            'failedStatus' => SyncJobStatus::FAILED->value,
+            'fromDate' => $from,
+            'toDate' => $to,
+        ];
+        $types = [
+            'fromDate' => Types::DATE_IMMUTABLE,
+            'toDate' => Types::DATE_IMMUTABLE,
+        ];
+
+        if (null !== $shopRef && '' !== $shopRef) {
+            $params['shopRef'] = $shopRef;
+        }
+
+        return $this->connection->executeQuery($sql, $params, $types)->fetchAllAssociative();
     }
 
     /**

--- a/site/src/Ingestion/Infrastructure/Query/CoverageQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/CoverageQuery.php
@@ -215,7 +215,7 @@ final class CoverageQuery
                   {$shopFilter}
             )
             SELECT
-                TO_CHAR(day.day, 'YYYY-MM-DD') AS record_date,
+                TO_CHAR(GREATEST(fj.from_date, :fromDate)::date, 'YYYY-MM-DD') AS record_date,
                 fj.shop_ref,
                 fj.resource_type,
                 0 AS raw_count,
@@ -223,15 +223,9 @@ final class CoverageQuery
                 COUNT(DISTINCT fj.id) AS issue_count,
                 NULL AS last_fetched_at
             FROM failed_jobs fj
-            JOIN LATERAL (
-                SELECT day::date AS day
-                FROM generate_series(
-                    GREATEST(fj.from_date, :fromDate)::date,
-                    LEAST(fj.to_date, :toDate)::date,
-                    interval '1 day'
-                ) AS day
-            ) day ON fj.from_date <= :toDate AND fj.to_date >= :fromDate
-            GROUP BY day.day, fj.shop_ref, fj.resource_type
+            WHERE fj.from_date <= :toDate
+              AND fj.to_date >= :fromDate
+            GROUP BY record_date, fj.shop_ref, fj.resource_type
             ORDER BY record_date ASC, fj.shop_ref ASC, fj.resource_type ASC
             SQL;
 

--- a/site/src/Ingestion/MessageHandler/RunSyncChunkHandler.php
+++ b/site/src/Ingestion/MessageHandler/RunSyncChunkHandler.php
@@ -140,7 +140,7 @@ final readonly class RunSyncChunkHandler
                 'resourceType' => $job->getResourceType(),
                 'retryAfterSeconds' => $exception->retryAfterSeconds(),
             ]);
-            $this->dispatchContinuation($message, $message->cursorValue, $exception->retryAfterSeconds());
+            $this->dispatchContinuation($message, $cursorValue, $exception->retryAfterSeconds());
 
             return;
         } catch (ConnectorTransientException $exception) {

--- a/site/tests/Integration/Ingestion/Fixtures/FakeConnector.php
+++ b/site/tests/Integration/Ingestion/Fixtures/FakeConnector.php
@@ -26,7 +26,7 @@ final class FakeConnector implements SourceConnectorInterface
     private array $pullRequests = [];
 
     /**
-     * @var list<array{externalId: string, nextCursorValue: ?string, hasMore: bool, rowExternalId: string, normalizeRawRecords: bool, continuationDelaySeconds: ?int}>
+     * @var list<array{externalId: string, nextCursorValue: ?string, hasMore: bool, rowExternalId: string, normalizeRawRecords: bool, continuationDelaySeconds: ?int}|\Throwable>
      */
     private array $queuedPullResults = [];
 
@@ -63,6 +63,11 @@ final class FakeConnector implements SourceConnectorInterface
             'normalizeRawRecords' => $normalizeRawRecords,
             'continuationDelaySeconds' => $continuationDelaySeconds,
         ];
+    }
+
+    public function enqueuePullFailure(\Throwable $exception): void
+    {
+        $this->queuedPullResults[] = $exception;
     }
 
     /**
@@ -112,7 +117,12 @@ final class FakeConnector implements SourceConnectorInterface
             throw $failure;
         }
 
-        $result = array_shift($this->queuedPullResults) ?? [
+        $result = array_shift($this->queuedPullResults);
+        if ($result instanceof \Throwable) {
+            throw $result;
+        }
+
+        $result ??= [
             'externalId' => sprintf('fake-report-%s', $request->syncJobId),
             'nextCursorValue' => 'cursor-after-fake-sale-1',
             'hasMore' => false,

--- a/site/tests/Integration/Ingestion/Infrastructure/Query/VerificationQueriesTest.php
+++ b/site/tests/Integration/Ingestion/Infrastructure/Query/VerificationQueriesTest.php
@@ -268,11 +268,11 @@ final class VerificationQueriesTest extends IntegrationTestCase
         self::assertNull($cells[0]->lastFetchedAt);
     }
 
-    public function testCoverageCountsFailedBackfillJobOnceAcrossWindow(): void
+    public function testCoverageCountsFailedBackfillChunkOnceAcrossWindow(): void
     {
         $companyId = Uuid::uuid7()->toString();
         $connectionRef = Uuid::uuid7()->toString();
-        $job = new SyncJob(
+        $parent = new SyncJob(
             companyId: $companyId,
             connectionRef: $connectionRef,
             source: IngestSource::OZON,
@@ -282,10 +282,22 @@ final class VerificationQueriesTest extends IntegrationTestCase
             windowTo: new \DateTimeImmutable('2026-06-30'),
             shopRef: $connectionRef,
         );
-        $job->markRunning();
-        $job->markFailed('Connector failed after retries.');
+        $chunk = new SyncJob(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            source: IngestSource::OZON,
+            resourceType: 'ozon_finance_accrual_by_day',
+            kind: SyncJobKind::BACKFILL,
+            windowFrom: new \DateTimeImmutable('2026-06-01'),
+            windowTo: new \DateTimeImmutable('2026-06-30'),
+            shopRef: $connectionRef,
+            parentJobId: $parent->getId(),
+        );
+        $chunk->markRunning();
+        $chunk->markFailed('Connector failed after retries.');
 
-        $this->em->persist($job);
+        $this->em->persist($parent);
+        $this->em->persist($chunk);
         $this->em->flush();
 
         /** @var CoverageQuery $query */
@@ -299,6 +311,59 @@ final class VerificationQueriesTest extends IntegrationTestCase
 
         self::assertCount(1, $cells);
         self::assertSame('2026-06-10', $cells[0]->date);
+        self::assertSame($connectionRef, $cells[0]->shopRef);
+        self::assertSame('ozon_finance_accrual_by_day', $cells[0]->resourceType);
+        self::assertSame(0, $cells[0]->rawCount);
+        self::assertSame(0, $cells[0]->txCount);
+        self::assertSame(1, $cells[0]->issueCount);
+    }
+
+    public function testCoverageIgnoresFailedAggregateBackfillParentIssue(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = Uuid::uuid7()->toString();
+        $parent = new SyncJob(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            source: IngestSource::OZON,
+            resourceType: 'ozon_finance_accrual_by_day',
+            kind: SyncJobKind::BACKFILL,
+            windowFrom: new \DateTimeImmutable('2026-06-01'),
+            windowTo: new \DateTimeImmutable('2026-06-30'),
+            shopRef: $connectionRef,
+        );
+        $parent->markRunning();
+        $parent->markFailed('partial failure: 1 failed, 0 cancelled, 4 completed');
+
+        $child = new SyncJob(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            source: IngestSource::OZON,
+            resourceType: 'ozon_finance_accrual_by_day',
+            kind: SyncJobKind::BACKFILL,
+            windowFrom: new \DateTimeImmutable('2026-06-15'),
+            windowTo: new \DateTimeImmutable('2026-06-21'),
+            shopRef: $connectionRef,
+            parentJobId: $parent->getId(),
+        );
+        $child->markRunning();
+        $child->markFailed('Connector failed after retries.');
+
+        $this->em->persist($parent);
+        $this->em->persist($child);
+        $this->em->flush();
+
+        /** @var CoverageQuery $query */
+        $query = self::getContainer()->get(CoverageQuery::class);
+        $cells = $query->heatmap(
+            $companyId,
+            $connectionRef,
+            new \DateTimeImmutable('2026-06-01'),
+            new \DateTimeImmutable('2026-06-30'),
+        );
+
+        self::assertCount(1, $cells);
+        self::assertSame('2026-06-15', $cells[0]->date);
         self::assertSame($connectionRef, $cells[0]->shopRef);
         self::assertSame('ozon_finance_accrual_by_day', $cells[0]->resourceType);
         self::assertSame(0, $cells[0]->rawCount);

--- a/site/tests/Integration/Ingestion/Infrastructure/Query/VerificationQueriesTest.php
+++ b/site/tests/Integration/Ingestion/Infrastructure/Query/VerificationQueriesTest.php
@@ -230,6 +230,44 @@ final class VerificationQueriesTest extends IntegrationTestCase
         self::assertSame(0, $cells[0]->issueCount);
     }
 
+    public function testCoverageCountsFailedSyncJobsAsOpenIssues(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = Uuid::uuid7()->toString();
+        $job = new SyncJob(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            source: IngestSource::OZON,
+            resourceType: 'ozon_finance_accrual_by_day',
+            kind: SyncJobKind::INCREMENTAL,
+            shopRef: $connectionRef,
+        );
+        $job->setCursorSnapshot('2026-06-22');
+        $job->markRunning();
+        $job->markFailed('Connector failed after retries.');
+
+        $this->em->persist($job);
+        $this->em->flush();
+
+        /** @var CoverageQuery $query */
+        $query = self::getContainer()->get(CoverageQuery::class);
+        $cells = $query->heatmap(
+            $companyId,
+            $connectionRef,
+            new \DateTimeImmutable('2026-06-22'),
+            new \DateTimeImmutable('2026-06-22'),
+        );
+
+        self::assertCount(1, $cells);
+        self::assertSame('2026-06-22', $cells[0]->date);
+        self::assertSame($connectionRef, $cells[0]->shopRef);
+        self::assertSame('ozon_finance_accrual_by_day', $cells[0]->resourceType);
+        self::assertSame(0, $cells[0]->rawCount);
+        self::assertSame(0, $cells[0]->txCount);
+        self::assertSame(1, $cells[0]->issueCount);
+        self::assertNull($cells[0]->lastFetchedAt);
+    }
+
     public function testReconciliationComparesShopCanonWithCompanyPeriodOzonControl(): void
     {
         $companyId = Uuid::uuid7()->toString();

--- a/site/tests/Integration/Ingestion/Infrastructure/Query/VerificationQueriesTest.php
+++ b/site/tests/Integration/Ingestion/Infrastructure/Query/VerificationQueriesTest.php
@@ -268,6 +268,44 @@ final class VerificationQueriesTest extends IntegrationTestCase
         self::assertNull($cells[0]->lastFetchedAt);
     }
 
+    public function testCoverageCountsFailedBackfillJobOnceAcrossWindow(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = Uuid::uuid7()->toString();
+        $job = new SyncJob(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            source: IngestSource::OZON,
+            resourceType: 'ozon_finance_accrual_by_day',
+            kind: SyncJobKind::BACKFILL,
+            windowFrom: new \DateTimeImmutable('2026-06-01'),
+            windowTo: new \DateTimeImmutable('2026-06-30'),
+            shopRef: $connectionRef,
+        );
+        $job->markRunning();
+        $job->markFailed('Connector failed after retries.');
+
+        $this->em->persist($job);
+        $this->em->flush();
+
+        /** @var CoverageQuery $query */
+        $query = self::getContainer()->get(CoverageQuery::class);
+        $cells = $query->heatmap(
+            $companyId,
+            $connectionRef,
+            new \DateTimeImmutable('2026-06-10'),
+            new \DateTimeImmutable('2026-06-20'),
+        );
+
+        self::assertCount(1, $cells);
+        self::assertSame('2026-06-10', $cells[0]->date);
+        self::assertSame($connectionRef, $cells[0]->shopRef);
+        self::assertSame('ozon_finance_accrual_by_day', $cells[0]->resourceType);
+        self::assertSame(0, $cells[0]->rawCount);
+        self::assertSame(0, $cells[0]->txCount);
+        self::assertSame(1, $cells[0]->issueCount);
+    }
+
     public function testReconciliationComparesShopCanonWithCompanyPeriodOzonControl(): void
     {
         $companyId = Uuid::uuid7()->toString();

--- a/site/tests/Integration/Ingestion/MessageHandler/RunSyncChunkHandlerTest.php
+++ b/site/tests/Integration/Ingestion/MessageHandler/RunSyncChunkHandlerTest.php
@@ -10,6 +10,7 @@ use App\Ingestion\Enum\IngestSource;
 use App\Ingestion\Enum\RawNormalizationStatus;
 use App\Ingestion\Enum\SyncJobKind;
 use App\Ingestion\Enum\SyncJobStatus;
+use App\Ingestion\Exception\ConnectorRateLimitedException;
 use App\Ingestion\Exception\ConnectorTransientException;
 use App\Ingestion\Message\NormalizeRawRecordMessage;
 use App\Ingestion\Message\RunSyncChunkMessage;
@@ -137,6 +138,57 @@ final class RunSyncChunkHandlerTest extends IntegrationTestCase
         $completedJob = $jobRepository->findByIdAndCompany($job->getId(), $companyId);
         self::assertSame(SyncJobStatus::COMPLETED, $completedJob?->getStatus());
         self::assertSame('cursor-before', $completedJob?->getCursorSnapshot());
+    }
+
+    public function testIncrementalChunkContinuesPullingUntilConnectorHasNoMoreData(): void
+    {
+        $fakeConnector = $this->fakeConnector();
+        $fakeConnector->reset();
+        $fakeConnector->enqueuePullResult('fake-report-page-1', '2026-06-08', true, 'fake-sale-1');
+        $fakeConnector->enqueuePullResult('fake-report-page-2', '2026-06-15', false, 'fake-sale-2');
+
+        $companyId = Uuid::uuid7()->toString();
+        $job = new SyncJob(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            source: IngestSource::WILDBERRIES,
+            resourceType: FakeConnector::RESOURCE_TYPE,
+            kind: SyncJobKind::INCREMENTAL,
+            shopRef: 'shop-1',
+        );
+
+        $this->em->persist($job);
+        $this->em->flush();
+
+        /** @var IngestCursorRepository $cursorRepository */
+        $cursorRepository = self::getContainer()->get(IngestCursorRepository::class);
+        $cursor = $cursorRepository->getOrCreate($companyId, 'connection-1', FakeConnector::RESOURCE_TYPE, 'shop-1');
+        $cursor->advance('2026-06-01', $job->getId(), new \DateTimeImmutable('2026-06-18 09:00:00'));
+        $this->em->flush();
+
+        $normalizeTransport = $this->getNormalizeTransport();
+        $normalizeTransport->reset();
+
+        /** @var RunSyncChunkHandler $handler */
+        $handler = self::getContainer()->get(RunSyncChunkHandler::class);
+        $handler(new RunSyncChunkMessage($companyId, $job->getId()));
+        $this->em->clear();
+
+        $pullRequests = $fakeConnector->pullRequests();
+        self::assertCount(2, $pullRequests);
+        self::assertSame('2026-06-01', $pullRequests[0]->cursorValue);
+        self::assertSame('2026-06-08', $pullRequests[1]->cursorValue);
+        self::assertCount(2, $normalizeTransport->getSent());
+
+        $cursor = $cursorRepository->findOne($companyId, 'connection-1', FakeConnector::RESOURCE_TYPE, 'shop-1');
+        self::assertNotNull($cursor);
+        self::assertSame('2026-06-15', $cursor->getCursorValue());
+
+        /** @var SyncJobRepository $jobRepository */
+        $jobRepository = self::getContainer()->get(SyncJobRepository::class);
+        $completedJob = $jobRepository->findByIdAndCompany($job->getId(), $companyId);
+        self::assertSame(SyncJobStatus::COMPLETED, $completedJob?->getStatus());
+        self::assertSame('2026-06-01', $completedJob?->getCursorSnapshot());
     }
 
     public function testWindowedChunkIgnoresExistingSharedCursor(): void
@@ -290,6 +342,65 @@ final class RunSyncChunkHandlerTest extends IntegrationTestCase
         $rawRecords = $rawRecordRepository->findBy(['companyId' => $companyId, 'syncJobId' => $job->getId()]);
         self::assertCount(1, $rawRecords);
         self::assertSame(RawNormalizationStatus::SKIPPED, $rawRecords[0]->getNormalizationStatus());
+    }
+
+    public function testRateLimitContinuationUsesCurrentCursorAfterSuccessfulChunk(): void
+    {
+        $fakeConnector = $this->fakeConnector();
+        $fakeConnector->reset();
+        $fakeConnector->enqueuePullResult(
+            externalId: 'fake-report-page-1',
+            nextCursorValue: '2026-06-08',
+            hasMore: true,
+            rowExternalId: 'fake-sale-1',
+            normalizeRawRecords: false,
+        );
+        $fakeConnector->enqueuePullFailure(new ConnectorRateLimitedException('Local rate limit is active.', 70));
+
+        $companyId = Uuid::uuid7()->toString();
+        $job = new SyncJob(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            source: IngestSource::WILDBERRIES,
+            resourceType: FakeConnector::RESOURCE_TYPE,
+            kind: SyncJobKind::INCREMENTAL,
+            shopRef: 'shop-1',
+        );
+
+        $this->em->persist($job);
+        $this->em->flush();
+
+        /** @var IngestCursorRepository $cursorRepository */
+        $cursorRepository = self::getContainer()->get(IngestCursorRepository::class);
+        $cursor = $cursorRepository->getOrCreate($companyId, 'connection-1', FakeConnector::RESOURCE_TYPE, 'shop-1');
+        $cursor->advance('2026-06-01', $job->getId(), new \DateTimeImmutable('2026-06-18 09:00:00'));
+        $this->em->flush();
+
+        $fetchTransport = $this->getFetchTransport();
+        $fetchTransport->reset();
+        $this->getNormalizeTransport()->reset();
+
+        /** @var RunSyncChunkHandler $handler */
+        $handler = self::getContainer()->get(RunSyncChunkHandler::class);
+        $handler(new RunSyncChunkMessage($companyId, $job->getId()));
+        $this->em->clear();
+
+        $pullRequests = $fakeConnector->pullRequests();
+        self::assertCount(2, $pullRequests);
+        self::assertSame('2026-06-01', $pullRequests[0]->cursorValue);
+        self::assertSame('2026-06-08', $pullRequests[1]->cursorValue);
+
+        $sent = $fetchTransport->getSent();
+        self::assertCount(1, $sent);
+        self::assertInstanceOf(RunSyncChunkMessage::class, $sent[0]->getMessage());
+
+        /** @var RunSyncChunkMessage $continuation */
+        $continuation = $sent[0]->getMessage();
+        self::assertSame('2026-06-08', $continuation->cursorValue);
+
+        $cursor = $cursorRepository->findOne($companyId, 'connection-1', FakeConnector::RESOURCE_TYPE, 'shop-1');
+        self::assertNotNull($cursor);
+        self::assertSame('2026-06-08', $cursor->getCursorValue());
     }
 
     public function testRateLimitLockContentionKeepsJobRetryable(): void

--- a/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonSellerReportConnectorTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonSellerReportConnectorTest.php
@@ -252,6 +252,7 @@ final class OzonSellerReportConnectorTest extends TestCase
         self::assertSame(['2026-06-15', '2026-06-16', '2026-06-17', '2026-06-18', '2026-06-19', '2026-06-20', '2026-06-21'], $accrualClient->dates);
         self::assertSame('2026-06-22', $result->nextCursorValue);
         self::assertTrue($result->hasMore);
+        self::assertSame(1, $result->continuationDelaySeconds);
     }
 
     public function testIncrementalAccrualByDayStopsWhenNextCursorIsToday(): void
@@ -294,6 +295,7 @@ final class OzonSellerReportConnectorTest extends TestCase
         self::assertSame(['2026-06-22', '2026-06-23'], $accrualClient->dates);
         self::assertSame('2026-06-24', $result->nextCursorValue);
         self::assertFalse($result->hasMore);
+        self::assertNull($result->continuationDelaySeconds);
     }
 
     public function testPullAccrualTypesFetchesStaticDictionaryOnce(): void

--- a/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonSellerReportConnectorTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonSellerReportConnectorTest.php
@@ -15,12 +15,13 @@ use App\Ingestion\Infrastructure\Api\Ozon\OzonRawPage;
 use App\Ingestion\Infrastructure\Storage\RawNdjsonCodec;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
+use Symfony\Component\Clock\MockClock;
 
 final class OzonSellerReportConnectorTest extends TestCase
 {
     public function testCapabilitiesDiscoverAndUnsupportedPush(): void
     {
-        $connector = new OzonSellerReportConnector($this->unusedAccrualClient());
+        $connector = $this->connector($this->unusedAccrualClient());
         $connectionRef = Uuid::uuid7()->toString();
 
         self::assertSame([Capability::CAN_DISCOVER_SHOPS, Capability::CAN_PULL], $connector->capabilities());
@@ -38,7 +39,7 @@ final class OzonSellerReportConnectorTest extends TestCase
 
     public function testLegacyOzonResourcesAreUnsupported(): void
     {
-        $connector = new OzonSellerReportConnector($this->unusedAccrualClient());
+        $connector = $this->connector($this->unusedAccrualClient());
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Unsupported Ozon resource type');
@@ -78,7 +79,7 @@ final class OzonSellerReportConnectorTest extends TestCase
             }
         };
 
-        $connector = new OzonSellerReportConnector($accrualClient);
+        $connector = $this->connector($accrualClient);
 
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('posting_numbers');
@@ -125,7 +126,7 @@ final class OzonSellerReportConnectorTest extends TestCase
             }
         };
 
-        $connector = new OzonSellerReportConnector($accrualClient);
+        $connector = $this->connector($accrualClient);
         $result = $connector->pull(new PullRequest(
             companyId: Uuid::uuid7()->toString(),
             connectionRef: 'connection-1',
@@ -191,7 +192,7 @@ final class OzonSellerReportConnectorTest extends TestCase
             }
         };
 
-        $connector = new OzonSellerReportConnector($accrualClient);
+        $connector = $this->connector($accrualClient);
         $result = $connector->pull(new PullRequest(
             companyId: Uuid::uuid7()->toString(),
             connectionRef: 'connection-1',
@@ -209,6 +210,90 @@ final class OzonSellerReportConnectorTest extends TestCase
             ['date' => '2026-06-02', 'accrual_id' => '2026-06-02'],
         ], $result->rawBatch->rows);
         self::assertSame('accrual-by-day:2026-06-01:2026-06-02', $result->rawBatch->externalId);
+    }
+
+    public function testIncrementalAccrualByDayContinuesWhileNextCursorIsOverdue(): void
+    {
+        $accrualClient = new class implements OzonAccrualClientInterface {
+            /**
+             * @var list<string>
+             */
+            public array $dates = [];
+
+            public function fetchPostings(string $companyId, string $connectionRef, array $postingNumbers): OzonRawPage
+            {
+                throw new \LogicException('Not used.');
+            }
+
+            public function fetchByDay(string $companyId, string $connectionRef, \DateTimeImmutable $date): OzonRawPage
+            {
+                $this->dates[] = $date->format('Y-m-d');
+
+                return new OzonRawPage(rows: [], hasMore: false);
+            }
+
+            public function fetchTypes(string $companyId, string $connectionRef): OzonRawPage
+            {
+                throw new \LogicException('Not used.');
+            }
+        };
+
+        $result = $this->connector($accrualClient, now: '2026-06-24T00:00:00+00:00')->pull(new PullRequest(
+            companyId: Uuid::uuid7()->toString(),
+            connectionRef: 'connection-1',
+            shopRef: 'shop-1',
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            cursorValue: '2026-06-15',
+            windowFrom: null,
+            windowTo: null,
+            syncJobId: Uuid::uuid7()->toString(),
+        ));
+
+        self::assertSame(['2026-06-15', '2026-06-16', '2026-06-17', '2026-06-18', '2026-06-19', '2026-06-20', '2026-06-21'], $accrualClient->dates);
+        self::assertSame('2026-06-22', $result->nextCursorValue);
+        self::assertTrue($result->hasMore);
+    }
+
+    public function testIncrementalAccrualByDayStopsWhenNextCursorIsToday(): void
+    {
+        $accrualClient = new class implements OzonAccrualClientInterface {
+            /**
+             * @var list<string>
+             */
+            public array $dates = [];
+
+            public function fetchPostings(string $companyId, string $connectionRef, array $postingNumbers): OzonRawPage
+            {
+                throw new \LogicException('Not used.');
+            }
+
+            public function fetchByDay(string $companyId, string $connectionRef, \DateTimeImmutable $date): OzonRawPage
+            {
+                $this->dates[] = $date->format('Y-m-d');
+
+                return new OzonRawPage(rows: [], hasMore: false);
+            }
+
+            public function fetchTypes(string $companyId, string $connectionRef): OzonRawPage
+            {
+                throw new \LogicException('Not used.');
+            }
+        };
+
+        $result = $this->connector($accrualClient, now: '2026-06-24T00:00:00+00:00')->pull(new PullRequest(
+            companyId: Uuid::uuid7()->toString(),
+            connectionRef: 'connection-1',
+            shopRef: 'shop-1',
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            cursorValue: '2026-06-22',
+            windowFrom: null,
+            windowTo: null,
+            syncJobId: Uuid::uuid7()->toString(),
+        ));
+
+        self::assertSame(['2026-06-22', '2026-06-23'], $accrualClient->dates);
+        self::assertSame('2026-06-24', $result->nextCursorValue);
+        self::assertFalse($result->hasMore);
     }
 
     public function testPullAccrualTypesFetchesStaticDictionaryOnce(): void
@@ -234,7 +319,7 @@ final class OzonSellerReportConnectorTest extends TestCase
             }
         };
 
-        $connector = new OzonSellerReportConnector($accrualClient);
+        $connector = $this->connector($accrualClient);
         $result = $connector->pull(new PullRequest(
             companyId: Uuid::uuid7()->toString(),
             connectionRef: 'connection-1',
@@ -305,7 +390,7 @@ final class OzonSellerReportConnectorTest extends TestCase
             }
         };
 
-        $connector = new OzonSellerReportConnector($accrualClient);
+        $connector = $this->connector($accrualClient);
         $result = $connector->pull(new PullRequest(
             companyId: Uuid::uuid7()->toString(),
             connectionRef: 'connection-1',
@@ -318,6 +403,20 @@ final class OzonSellerReportConnectorTest extends TestCase
         ));
 
         return $result->rawBatch->rows;
+    }
+
+    private function connector(
+        OzonAccrualClientInterface $accrualClient,
+        string $now = '2026-06-24T00:00:00+00:00',
+        int $chunkSizeDays = 7,
+        int $hotRewindDays = 14,
+    ): OzonSellerReportConnector {
+        return new OzonSellerReportConnector(
+            $accrualClient,
+            new MockClock($now),
+            $chunkSizeDays,
+            $hotRewindDays,
+        );
     }
 
     private function unusedAccrualClient(): OzonAccrualClientInterface

--- a/site/tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceReportConnectorTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceReportConnectorTest.php
@@ -158,7 +158,7 @@ final class WbFinanceReportConnectorTest extends TestCase
         $result = $connector->pull($this->request(cursorValue: '2026-06-20'));
 
         self::assertSame('2026-06-21', $result->nextCursorValue);
-        self::assertFalse($result->hasMore);
+        self::assertTrue($result->hasMore);
     }
 
     public function testIncrementalCursorDoesNotAdvancePastToday(): void


### PR DESCRIPTION
## Root cause

Данные не грузились до актуальной даты, потому что daily incremental создавал один job за cron tick, а `OzonSellerReportConnector` и `WbFinanceReportConnector` возвращали `hasMore=false` после одного bounded шага cursor; `RunSyncChunkHandler` поэтому завершал job без дренажа просроченного cursor backlog. При этом job был `completed`, failure transport пустой, а `CoverageQuery` считал только unresolved normalization issues, поэтому «Открытых проблем» оставалось 0.

Relevant files:
- `site/src/Ingestion/Application/Source/Ozon/OzonSellerReportConnector.php`
- `site/src/Ingestion/Application/Source/Wildberries/WbFinanceReportConnector.php`
- `site/src/Ingestion/MessageHandler/RunSyncChunkHandler.php`
- `site/src/Ingestion/Infrastructure/Query/CoverageQuery.php`

## What changed

- Ozon/WB daily incremental now keeps `hasMore=true` while the next daily cursor is already due, so the existing `RunSyncChunkHandler` drains overdue dates inside the same job.
- WB rrd pagination still uses delayed continuation.
- Rate-limit continuation now uses the current cursor after already-successful chunks.
- Coverage heatmap now includes failed sync jobs as issue cells, even when no raw record exists.
- Added unit and integration coverage for cursor draining, continuation cursor handling, and failed-job coverage.

## Checks

- `php -l` on changed PHP files — OK
- targeted unit tests for Ozon/WB connectors — OK, 19 tests
- targeted ingestion integration tests — OK, 17 tests
- `php bin/console lint:container --no-debug --env=test` — OK
- php-cs-fixer dry-run on changed files — OK
- `composer test:unit` — OK, 1132 tests, existing 1 warning and 1 deprecation

## Operational note

After merge/deploy, run existing incremental/backfill flow for the affected tenant-resource pairs and verify coverage through 2026-06-23. No new commands, tables, transports, or subscribers were added.