### PR TITLE
fix(ingestion): keep WB sale payout adjustments positive

### DIFF
--- a/site/src/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapper.php
+++ b/site/src/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapper.php
@@ -11,6 +11,7 @@ use Ramsey\Uuid\Uuid;
 final readonly class WbFinanceSalesReportDetailedPreviewMapper
 {
     private const SOURCE_TZ = 'UTC';
+    private const COMPONENT_SALE_PAYOUT_ADJUSTMENT = 'sale_payout_adjustment';
 
     /**
      * @param iterable<array<string, mixed>> $rows
@@ -87,7 +88,7 @@ final readonly class WbFinanceSalesReportDetailedPreviewMapper
 
     /**
      * @param list<WbFinancePreviewTransaction> $transactions
-     * @param array<string, mixed>              $row
+     * @param array<string, mixed> $row
      */
     private function collectSaleRefundComponents(
         array &$transactions,
@@ -110,6 +111,31 @@ final readonly class WbFinanceSalesReportDetailedPreviewMapper
 
         $forPayMinor = $this->minor($row, 'forPay', 'ppvz_for_pay');
         $acquiringMinor = $this->minor($row, 'acquiringFee', 'acquiring_fee');
+        if (
+            $this->isSalePayoutAdjustment($sellerOperName, $docTypeName)
+            && 0 === $retailMinor
+            && 0 === $acquiringMinor
+            && 0 !== $forPayMinor
+        ) {
+            $this->add(
+                transactions: $transactions,
+                operationGroupId: $operationGroupId,
+                rowKey: $rowKey,
+                component: self::COMPONENT_SALE_PAYOUT_ADJUSTMENT,
+                type: TransactionType::ADJUSTMENT,
+                signedAmountMinor: $forPayMinor,
+                currency: $currency,
+                occurredAt: $occurredAt,
+                field: 'forPay',
+                sellerOperName: $sellerOperName,
+                docTypeName: $docTypeName,
+                description: 'WB sale payout adjustment',
+                row: $row,
+            );
+
+            return;
+        }
+
         $commissionMinor = $retailMinor - $forPayMinor - $acquiringMinor;
         $isReturn = $this->isReturn($docTypeName);
 
@@ -170,7 +196,7 @@ final readonly class WbFinanceSalesReportDetailedPreviewMapper
 
     /**
      * @param list<WbFinancePreviewTransaction> $transactions
-     * @param array<string, mixed>              $row
+     * @param array<string, mixed> $row
      */
     private function collectCostComponents(
         array &$transactions,
@@ -263,7 +289,7 @@ final readonly class WbFinanceSalesReportDetailedPreviewMapper
 
     /**
      * @param list<WbFinancePreviewTransaction> $transactions
-     * @param array<string, mixed>              $row
+     * @param array<string, mixed> $row
      */
     private function addCostField(
         array &$transactions,
@@ -307,7 +333,7 @@ final readonly class WbFinanceSalesReportDetailedPreviewMapper
 
     /**
      * @param list<WbFinancePreviewTransaction> $transactions
-     * @param array<string, mixed>              $row
+     * @param array<string, mixed> $row
      */
     private function addCost(
         array &$transactions,
@@ -341,17 +367,18 @@ final readonly class WbFinanceSalesReportDetailedPreviewMapper
     {
         return array_values(array_filter(
             $transactions,
-            static fn (WbFinancePreviewTransaction $transaction): bool => in_array(
-                $transaction->type,
-                [TransactionType::SALE, TransactionType::REFUND, TransactionType::COMMISSION, TransactionType::ACQUIRING],
-                true,
-            ),
+            static fn (WbFinancePreviewTransaction $transaction): bool => self::COMPONENT_SALE_PAYOUT_ADJUSTMENT === $transaction->component
+                || in_array(
+                    $transaction->type,
+                    [TransactionType::SALE, TransactionType::REFUND, TransactionType::COMMISSION, TransactionType::ACQUIRING],
+                    true,
+                ),
         ));
     }
 
     /**
      * @param list<WbFinancePreviewTransaction> $transactions
-     * @param array<string, mixed>              $row
+     * @param array<string, mixed> $row
      */
     private function add(
         array &$transactions,
@@ -507,6 +534,19 @@ final readonly class WbFinanceSalesReportDetailedPreviewMapper
     private function isReturn(string $docTypeName): bool
     {
         return in_array(mb_strtolower(trim($docTypeName)), ['возврат', 'return'], true);
+    }
+
+    private function isSalePayoutAdjustment(string $sellerOperName, string $docTypeName): bool
+    {
+        if (!$this->isSale($docTypeName)) {
+            return false;
+        }
+
+        return in_array(
+            mb_strtolower(trim($sellerOperName)),
+            ['коррекция продаж', 'добровольная компенсация при возврате'],
+            true,
+        );
     }
 
     /**

--- a/site/tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedMapperTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedMapperTest.php
@@ -83,6 +83,44 @@ final class WbFinanceSalesReportDetailedMapperTest extends TestCase
         self::assertSame(115000, $controlSums[0]->amountMinor);
     }
 
+    public function testMapsSalePayoutAdjustmentRowsWithoutPayoutMismatch(): void
+    {
+        $transactions = $this->mapper()->map($this->rawRecord(), [
+            [
+                'rrdId' => 201,
+                'currency' => 'RUB',
+                'docTypeName' => 'Продажа',
+                'sellerOperName' => 'Коррекция продаж',
+                'saleDt' => '2026-06-10T10:15:00Z',
+                'retailPriceWithDisc' => '0',
+                'forPay' => '12.77',
+                'acquiringFee' => '0',
+            ],
+            [
+                'rrdId' => 202,
+                'currency' => 'RUB',
+                'docTypeName' => 'Продажа',
+                'sellerOperName' => 'Добровольная компенсация при возврате',
+                'saleDt' => '2026-06-17T10:15:00Z',
+                'retailPriceWithDisc' => '0',
+                'forPay' => '197.22',
+                'acquiringFee' => '0',
+            ],
+        ]);
+
+        self::assertCount(2, $transactions);
+
+        $correction = $this->transaction($transactions, 'wb:sales-report-detailed:201:sale_payout_adjustment');
+        self::assertSame(TransactionType::ADJUSTMENT, $correction->type);
+        self::assertSame(TransactionDirection::IN, $correction->direction);
+        self::assertSame(1277, $correction->money->amountMinor());
+
+        $compensation = $this->transaction($transactions, 'wb:sales-report-detailed:202:sale_payout_adjustment');
+        self::assertSame(TransactionType::ADJUSTMENT, $compensation->type);
+        self::assertSame(TransactionDirection::IN, $compensation->direction);
+        self::assertSame(19722, $compensation->money->amountMinor());
+    }
+
     public function testRejectsPayoutMismatches(): void
     {
         $this->expectException(\RuntimeException::class);

--- a/site/tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapperTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapperTest.php
@@ -84,6 +84,39 @@ final class WbFinanceSalesReportDetailedPreviewMapperTest extends TestCase
         self::assertSame(3, $result->rowChecks[0]->transactionCount);
     }
 
+    public function testMapsSalePayoutAdjustmentsWithoutFlippingForPaySign(): void
+    {
+        foreach ([
+            ['rrdId' => 108, 'sellerOperName' => 'Коррекция продаж', 'forPay' => '12.77', 'amountMinor' => 1277],
+            ['rrdId' => 109, 'sellerOperName' => 'Добровольная компенсация при возврате', 'forPay' => '197.22', 'amountMinor' => 19722],
+        ] as $case) {
+            $result = $this->mapper()->preview(self::COMPANY_ID, [[
+                'rrdId' => $case['rrdId'],
+                'currency' => 'RUB',
+                'docTypeName' => 'Продажа',
+                'sellerOperName' => $case['sellerOperName'],
+                'saleDt' => '2026-06-21T10:15:00Z',
+                'retailPriceWithDisc' => '0',
+                'forPay' => $case['forPay'],
+                'acquiringFee' => '0',
+            ]]);
+
+            self::assertCount(1, $result->transactions);
+
+            $transaction = $this->transaction($result->transactions, sprintf('wb:sales-report-detailed:%d:sale_payout_adjustment', $case['rrdId']));
+            self::assertSame(TransactionType::ADJUSTMENT, $transaction->type);
+            self::assertSame(TransactionDirection::IN, $transaction->direction);
+            self::assertSame($case['amountMinor'], $transaction->amountMinor);
+            self::assertSame('forPay', $transaction->field);
+
+            self::assertCount(1, $result->rowChecks);
+            self::assertSame($case['amountMinor'], $result->rowChecks[0]->expectedNetMinor);
+            self::assertSame($case['amountMinor'], $result->rowChecks[0]->actualNetMinor);
+            self::assertSame(0, $result->rowChecks[0]->deltaMinor);
+            self::assertSame(1, $result->rowChecks[0]->transactionCount);
+        }
+    }
+
     public function testMapsReturnRowAsOutboundRefundWithCommissionAndAcquiringStorno(): void
     {
         $result = $this->mapper()->preview(self::COMPANY_ID, [[


### PR DESCRIPTION
## Summary
- Treat WB sale payout adjustment rows as signed `forPay` adjustments instead of derived commission.
- Include only the new `sale_payout_adjustment` component in payout checks, without broadening all adjustments.
- Add regression coverage for `Коррекция продаж` and `Добровольная компенсация при возврате` rows.

## Root cause
WB rows with `docTypeName=Продажа`, `retail=0`, `acquiring=0`, `forPay>0` for `Коррекция продаж` / `Добровольная компенсация при возврате` were mapped by the generic sale formula as negative commission, so payout validation saw `expected +X, actual -X` and marked normalization as failed.

## Checks
- `docker compose run --rm -T site-php-cli php -l src/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapper.php`
- `docker compose run --rm -T site-php-cli php -l tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapperTest.php`
- `docker compose run --rm -T site-php-cli php -l tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedMapperTest.php`
- `docker compose run --rm -T site-php-cli php bin/phpunit -c phpunit.xml tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapperTest.php tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedMapperTest.php`
- `docker compose run --rm -T site-php-cli ./vendor/bin/php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.php --cache-file=var/cache/.php-cs-fixer.wb-mapper.cache src/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapper.php tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedPreviewMapperTest.php tests/Unit/Ingestion/Application/Source/Wildberries/WbFinanceSalesReportDetailedMapperTest.php`
- `git diff --check`

Note: full `composer cs:check` is red on existing repository-wide formatting issues outside this PR.
