### PR TITLE
[codex] Move data coverage navigation

### DIFF
--- a/site/templates/ingestion/verification/_finance_tabs.html.twig
+++ b/site/templates/ingestion/verification/_finance_tabs.html.twig
@@ -1,16 +1,16 @@
 {% set current_route = app.request ? app.request.attributes.get('_route') : '' %}
 {% set tabs = [
-    { route: 'ingestion_verification_coverage', label: 'Покрытие' },
-    { route: 'ingestion_verification_reconciliation', label: 'Сверка сумм' },
-    { route: 'ingestion_verification_issues', label: 'Проблемы' },
-    { route: 'ingestion_verification_financial_summary', label: 'Финансовая сводка' },
+    {route: 'ingestion_verification_coverage', label: 'Покрытие данных'},
+    {route: 'ingestion_verification_reconciliation', label: 'Сверка сумм'},
+    {route: 'ingestion_verification_issues', label: 'Проблемы'},
+    {route: 'ingestion_verification_financial_summary', label: 'Финансовая сводка'},
 ] %}
 
 <div class="page-header d-print-none mb-3">
     <div class="row align-items-center">
         <div class="col">
-            <h2 class="page-title">Финансы</h2>
-            <div class="text-secondary mt-1">Проверка качества ingestion-данных</div>
+            <h2 class="page-title">Загрузка данных</h2>
+            <div class="text-secondary mt-1">Покрытие и проверки ingestion-данных</div>
         </div>
     </div>
 </div>

--- a/site/templates/ingestion/verification/coverage.html.twig
+++ b/site/templates/ingestion/verification/coverage.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Финансы — Покрытие{% endblock %}
+{% block title %}Загрузка данных — Покрытие данных{% endblock %}
 
 {% block content %}
     {% include 'ingestion/verification/_finance_tabs.html.twig' %}

--- a/site/templates/ingestion/verification/financial-summary.html.twig
+++ b/site/templates/ingestion/verification/financial-summary.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Финансы — Финансовая сводка{% endblock %}
+{% block title %}Загрузка данных — Финансовая сводка{% endblock %}
 
 {% block content %}
     {% include 'ingestion/verification/_finance_tabs.html.twig' %}

--- a/site/templates/ingestion/verification/issues.html.twig
+++ b/site/templates/ingestion/verification/issues.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Финансы — Проблемы{% endblock %}
+{% block title %}Загрузка данных — Проблемы{% endblock %}
 
 {% block content %}
     {% include 'ingestion/verification/_finance_tabs.html.twig' %}

--- a/site/templates/ingestion/verification/reconciliation.html.twig
+++ b/site/templates/ingestion/verification/reconciliation.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Финансы — Сверка сумм{% endblock %}
+{% block title %}Загрузка данных — Сверка сумм{% endblock %}
 
 {% block content %}
     {% include 'ingestion/verification/_finance_tabs.html.twig' %}

--- a/site/templates/partials/_sidebar_report.html.twig
+++ b/site/templates/partials/_sidebar_report.html.twig
@@ -95,9 +95,8 @@
     <div class="dropdown-menu {{ ingestion_verification_active ? 'show' : '' }}">
         <div class="dropdown-menu-column">
             <a class="dropdown-item {{ ingestion_verification_active ? 'active' : '' }}" href="{{ path('ingestion_verification_index') }}">
-                <span>Финансы</span>
+                <span>Покрытие данных</span>
             </a>
         </div>
     </div>
 </li>
-

--- a/site/tests/Functional/Ingestion/Controller/VerificationPageControllerTest.php
+++ b/site/tests/Functional/Ingestion/Controller/VerificationPageControllerTest.php
@@ -45,7 +45,7 @@ final class VerificationPageControllerTest extends WebTestCaseBase
             );
             self::assertSame(1, $crawler->filter('aside a[href="/ingestion/verification"]')->count());
             self::assertStringContainsString(
-                'Финансы',
+                'Покрытие данных',
                 trim($crawler->filter('aside a[href="/ingestion/verification"]')->text()),
             );
             self::assertSame(4, $crawler->filter('.nav-tabs .nav-link')->count());
@@ -87,7 +87,7 @@ final class VerificationPageControllerTest extends WebTestCaseBase
             '/ingestion/verification/coverage',
             'ingestion-verification-coverage-root',
             'ingestion_verification_coverage_page',
-            'Покрытие',
+            'Покрытие данных',
         ];
         yield [
             '/ingestion/verification/reconciliation',


### PR DESCRIPTION
## Summary
- move ingestion coverage entry under Data loading as Покрытие данных
- rename ingestion verification page titles away from Финансы
- update functional page assertions

## Validation
- docker compose run --rm site-php-cli composer test:functional -- --filter VerificationPageControllerTest
- git diff --check

Note: twigcs still reports existing repository-wide template violations outside this change; touched files are clean in filtered output.