### PR TITLE
[codex] Split finance verification and data coverage

### DIFF
--- a/site/src/Ingestion/Controller/Page/CoveragePageController.php
+++ b/site/src/Ingestion/Controller/Page/CoveragePageController.php
@@ -12,9 +12,15 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted('ROLE_COMPANY_USER')]
 final class CoveragePageController extends AbstractController
 {
-    #[Route('/ingestion/verification/coverage', name: 'ingestion_verification_coverage', methods: ['GET'])]
+    #[Route('/ingestion/coverage', name: 'ingestion_coverage', methods: ['GET'])]
     public function __invoke(): Response
     {
         return $this->render('ingestion/verification/coverage.html.twig');
+    }
+
+    #[Route('/ingestion/verification/coverage', name: 'ingestion_verification_coverage', methods: ['GET'])]
+    public function legacyVerificationCoverage(): Response
+    {
+        return $this->redirectToRoute('ingestion_coverage');
     }
 }

--- a/site/src/Ingestion/Controller/Page/VerificationIndexPageController.php
+++ b/site/src/Ingestion/Controller/Page/VerificationIndexPageController.php
@@ -15,6 +15,6 @@ final class VerificationIndexPageController extends AbstractController
     #[Route('/ingestion/verification', name: 'ingestion_verification_index', methods: ['GET'])]
     public function __invoke(): Response
     {
-        return $this->redirectToRoute('ingestion_verification_coverage');
+        return $this->redirectToRoute('ingestion_verification_issues');
     }
 }

--- a/site/templates/ingestion/verification/_finance_tabs.html.twig
+++ b/site/templates/ingestion/verification/_finance_tabs.html.twig
@@ -1,16 +1,15 @@
 {% set current_route = app.request ? app.request.attributes.get('_route') : '' %}
 {% set tabs = [
-    {route: 'ingestion_verification_coverage', label: 'Покрытие данных'},
-    {route: 'ingestion_verification_reconciliation', label: 'Сверка сумм'},
     {route: 'ingestion_verification_issues', label: 'Проблемы'},
+    {route: 'ingestion_verification_reconciliation', label: 'Сверка сумм'},
     {route: 'ingestion_verification_financial_summary', label: 'Финансовая сводка'},
 ] %}
 
 <div class="page-header d-print-none mb-3">
     <div class="row align-items-center">
         <div class="col">
-            <h2 class="page-title">Загрузка данных</h2>
-            <div class="text-secondary mt-1">Покрытие и проверки ingestion-данных</div>
+            <h2 class="page-title">Финансы</h2>
+            <div class="text-secondary mt-1">Проверка качества загруженных финансовых данных</div>
         </div>
     </div>
 </div>

--- a/site/templates/ingestion/verification/coverage.html.twig
+++ b/site/templates/ingestion/verification/coverage.html.twig
@@ -1,9 +1,16 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Загрузка данных — Покрытие данных{% endblock %}
+{% block title %}Покрытие данных{% endblock %}
 
 {% block content %}
-    {% include 'ingestion/verification/_finance_tabs.html.twig' %}
+    <div class="page-header d-print-none mb-3">
+        <div class="row align-items-center">
+            <div class="col">
+                <h2 class="page-title">Покрытие данных</h2>
+                <div class="text-secondary mt-1">Контроль полноты загрузки данных по источникам и датам</div>
+            </div>
+        </div>
+    </div>
 
     <div
         id="ingestion-verification-coverage-root"

--- a/site/templates/ingestion/verification/financial-summary.html.twig
+++ b/site/templates/ingestion/verification/financial-summary.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Загрузка данных — Финансовая сводка{% endblock %}
+{% block title %}Финансы — Финансовая сводка{% endblock %}
 
 {% block content %}
     {% include 'ingestion/verification/_finance_tabs.html.twig' %}

--- a/site/templates/ingestion/verification/issues.html.twig
+++ b/site/templates/ingestion/verification/issues.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Загрузка данных — Проблемы{% endblock %}
+{% block title %}Финансы — Проблемы{% endblock %}
 
 {% block content %}
     {% include 'ingestion/verification/_finance_tabs.html.twig' %}

--- a/site/templates/ingestion/verification/reconciliation.html.twig
+++ b/site/templates/ingestion/verification/reconciliation.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Загрузка данных — Сверка сумм{% endblock %}
+{% block title %}Финансы — Сверка сумм{% endblock %}
 
 {% block content %}
     {% include 'ingestion/verification/_finance_tabs.html.twig' %}

--- a/site/templates/partials/_sidebar_report.html.twig
+++ b/site/templates/partials/_sidebar_report.html.twig
@@ -87,14 +87,19 @@
 <!-- Справочники -->
 
 {% set ingestion_verification_active = current_route starts with 'ingestion_verification_' %}
-<li class="nav-item dropdown {{ ingestion_verification_active ? 'show' : '' }}">
-    <a class="nav-link dropdown-toggle {{ ingestion_verification_active ? 'show active' : '' }}" href="#" data-bs-toggle="dropdown" data-bs-auto-close="false" role="button" aria-expanded="{{ ingestion_verification_active ? 'true' : 'false' }}">
+{% set ingestion_coverage_active = current_route == 'ingestion_coverage' %}
+{% set ingestion_menu_active = ingestion_verification_active or ingestion_coverage_active %}
+<li class="nav-item dropdown {{ ingestion_menu_active ? 'show' : '' }}">
+    <a class="nav-link dropdown-toggle {{ ingestion_menu_active ? 'show active' : '' }}" href="#" data-bs-toggle="dropdown" data-bs-auto-close="false" role="button" aria-expanded="{{ ingestion_menu_active ? 'true' : 'false' }}">
         <span class="nav-link-icon"><i class="ti ti-cloud-upload"></i></span>
         <span class="nav-link-title">Загрузка данных</span>
     </a>
-    <div class="dropdown-menu {{ ingestion_verification_active ? 'show' : '' }}">
+    <div class="dropdown-menu {{ ingestion_menu_active ? 'show' : '' }}">
         <div class="dropdown-menu-column">
             <a class="dropdown-item {{ ingestion_verification_active ? 'active' : '' }}" href="{{ path('ingestion_verification_index') }}">
+                <span>Финансы</span>
+            </a>
+            <a class="dropdown-item {{ ingestion_coverage_active ? 'active' : '' }}" href="{{ path('ingestion_coverage') }}">
                 <span>Покрытие данных</span>
             </a>
         </div>

--- a/site/tests/Functional/Ingestion/Controller/VerificationPageControllerTest.php
+++ b/site/tests/Functional/Ingestion/Controller/VerificationPageControllerTest.php
@@ -10,6 +10,7 @@ use App\Tests\Builders\Company\CompanyBuilder;
 use App\Tests\Builders\Company\UserBuilder;
 use App\Tests\Support\Kernel\WebTestCaseBase;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\DomCrawler\Crawler;
 
 final class VerificationPageControllerTest extends WebTestCaseBase
 {
@@ -32,7 +33,10 @@ final class VerificationPageControllerTest extends WebTestCaseBase
         $this->loginWithActiveCompany($client, $owner, $company);
 
         $client->request('GET', '/ingestion/verification');
-        self::assertResponseRedirects('/ingestion/verification/coverage');
+        self::assertResponseRedirects('/ingestion/verification/issues');
+
+        $client->request('GET', '/ingestion/verification/coverage');
+        self::assertResponseRedirects('/ingestion/coverage');
 
         foreach ($this->pages() as [$url, $mountId, $entryKey, $activeTabLabel]) {
             $crawler = $client->request('GET', $url);
@@ -43,12 +47,9 @@ final class VerificationPageControllerTest extends WebTestCaseBase
                 $entryKey,
                 $crawler->filter(sprintf('#%s', $mountId))->attr('data-vite-entry'),
             );
-            self::assertSame(1, $crawler->filter('aside a[href="/ingestion/verification"]')->count());
-            self::assertStringContainsString(
-                'Покрытие данных',
-                trim($crawler->filter('aside a[href="/ingestion/verification"]')->text()),
-            );
-            self::assertSame(4, $crawler->filter('.nav-tabs .nav-link')->count());
+            $this->assertIngestionMenu($crawler);
+
+            self::assertSame(3, $crawler->filter('.nav-tabs .nav-link')->count());
             self::assertSame(
                 $url,
                 $crawler->filter('.nav-tabs .nav-link.active')->attr('href'),
@@ -57,13 +58,28 @@ final class VerificationPageControllerTest extends WebTestCaseBase
                 $activeTabLabel,
                 trim($crawler->filter('.nav-tabs .nav-link.active')->text()),
             );
+            self::assertStringNotContainsString(
+                'Покрытие',
+                trim($crawler->filter('.nav-tabs')->text()),
+            );
         }
+
+        $crawler = $client->request('GET', '/ingestion/coverage');
+
+        self::assertResponseIsSuccessful();
+        $this->assertIngestionMenu($crawler);
+        self::assertSame(1, $crawler->filter('#ingestion-verification-coverage-root')->count());
+        self::assertSame(
+            'ingestion_verification_coverage_page',
+            $crawler->filter('#ingestion-verification-coverage-root')->attr('data-vite-entry'),
+        );
+        self::assertSame(0, $crawler->filter('.nav-tabs .nav-link')->count());
     }
 
     public function testVerificationPagesRequireAuthentication(): void
     {
         $client = static::createClient();
-        $client->request('GET', '/ingestion/verification/coverage');
+        $client->request('GET', '/ingestion/coverage');
 
         $response = $client->getResponse();
         $statusCode = $response->getStatusCode();
@@ -84,10 +100,10 @@ final class VerificationPageControllerTest extends WebTestCaseBase
     private function pages(): iterable
     {
         yield [
-            '/ingestion/verification/coverage',
-            'ingestion-verification-coverage-root',
-            'ingestion_verification_coverage_page',
-            'Покрытие данных',
+            '/ingestion/verification/issues',
+            'ingestion-verification-issues-root',
+            'ingestion_verification_issues_page',
+            'Проблемы',
         ];
         yield [
             '/ingestion/verification/reconciliation',
@@ -96,17 +112,20 @@ final class VerificationPageControllerTest extends WebTestCaseBase
             'Сверка сумм',
         ];
         yield [
-            '/ingestion/verification/issues',
-            'ingestion-verification-issues-root',
-            'ingestion_verification_issues_page',
-            'Проблемы',
-        ];
-        yield [
             '/ingestion/verification/financial-summary',
             'ingestion-verification-financial-summary-root',
             'ingestion_verification_financial_summary_page',
             'Финансовая сводка',
         ];
+    }
+
+    private function assertIngestionMenu(Crawler $crawler): void
+    {
+        $items = $crawler->filter('aside a[href="/ingestion/verification"], aside a[href="/ingestion/coverage"]');
+
+        self::assertSame(2, $items->count());
+        self::assertSame('Финансы', trim($items->eq(0)->text()));
+        self::assertSame('Покрытие данных', trim($items->eq(1)->text()));
     }
 
     private function loginWithActiveCompany(KernelBrowser $client, User $user, Company $company): void


### PR DESCRIPTION
## Summary
- restore Data loading -> Finance as the financial verification workspace
- move data coverage to a separate /ingestion/coverage page
- keep the legacy /ingestion/verification/coverage URL as a redirect
- update functional coverage for menu order and redirects

## Validation
- docker compose run --rm site-php-cli composer test:functional -- --filter VerificationPageControllerTest
- docker compose run --rm site-php-cli php bin/console lint:twig templates/ingestion/verification templates/partials/_sidebar_report.html.twig
- docker compose run --rm site-php-cli php bin/console debug:router --show-controllers | rg "ingestion_(coverage|verification)"
- git diff --check