### PR TITLE
[codex] Fix Ozon accrual types request body

### DIFF
--- a/site/src/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClient.php
+++ b/site/src/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClient.php
@@ -63,18 +63,18 @@ final readonly class OzonAccrualClient implements OzonAccrualClientInterface
             companyId: $companyId,
             connectionRef: $connectionRef,
             endpoint: self::TYPES_ENDPOINT,
-            json: [],
+            json: new \stdClass(),
         );
     }
 
     /**
-     * @param array<string, mixed> $json
+     * @param array<string, mixed>|\stdClass $json
      */
     private function requestPage(
         string $companyId,
         string $connectionRef,
         string $endpoint,
-        array $json,
+        array|\stdClass $json,
         int $page = 1,
         int $pageSize = 0,
         int $offset = 0,
@@ -105,11 +105,11 @@ final readonly class OzonAccrualClient implements OzonAccrualClientInterface
     }
 
     /**
-     * @param array<string, mixed> $json
+     * @param array<string, mixed>|\stdClass $json
      *
      * @return array<string, mixed>
      */
-    private function requestJson(string $companyId, string $connectionRef, string $endpoint, array $json): array
+    private function requestJson(string $companyId, string $connectionRef, string $endpoint, array|\stdClass $json): array
     {
         $credentials = $this->credentials($companyId, $connectionRef);
         $startedAt = microtime(true);
@@ -170,7 +170,7 @@ final readonly class OzonAccrualClient implements OzonAccrualClientInterface
                 return $this->objectRows($candidate);
             }
 
-            foreach (['items', 'postings', 'accruals', 'operations', 'rows', 'data', 'types'] as $key) {
+            foreach (['items', 'postings', 'accruals', 'accrual_types', 'operations', 'rows', 'data', 'types'] as $key) {
                 $rows = $candidate[$key] ?? null;
                 if (is_array($rows) && array_is_list($rows)) {
                     return $this->objectRows($rows);

--- a/site/tests/Unit/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClientTest.php
+++ b/site/tests/Unit/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClientTest.php
@@ -79,6 +79,37 @@ final class OzonAccrualClientTest extends TestCase
         self::assertFalse($page->hasMore);
     }
 
+    public function testFetchTypesSendsEmptyJsonObjectAndExtractsAccrualTypes(): void
+    {
+        $capturedUrl = null;
+        $capturedOptions = null;
+        $http = new MockHttpClient(static function (string $method, string $url, array $options) use (&$capturedUrl, &$capturedOptions): MockResponse {
+            $capturedUrl = $url;
+            $capturedOptions = $options;
+
+            return new MockResponse(
+                '{"result":{"accrual_types":[{"id":1,"name":"Эквайринг"}]}}',
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new OzonAccrualClient(
+            $http,
+            $this->credentialProvider(),
+            new NullLogger(),
+        );
+
+        $page = $client->fetchTypes(
+            '0192f0c2-0000-7000-8000-000000000001',
+            '0192f0c2-0000-7000-8000-000000000002',
+        );
+
+        self::assertSame('https://api-seller.ozon.ru/v1/finance/accrual/types', $capturedUrl);
+        self::assertSame('{}', (string) ($capturedOptions['body'] ?? ''));
+        self::assertSame([['id' => 1, 'name' => 'Эквайринг']], $page->rows);
+        self::assertFalse($page->hasMore);
+    }
+
     public function testFetchPostingsRequiresPostingNumbers(): void
     {
         $client = new OzonAccrualClient(


### PR DESCRIPTION
## What changed
- Send an empty JSON object (`{}`) to `/v1/finance/accrual/types` instead of an empty JSON array (`[]`).
- Parse Ozon accrual type rows from `result.accrual_types` in addition to existing generic row keys.
- Added a unit test that verifies the request body and accrual type extraction.

## Why
Production check showed Ozon returning HTTP 400 with:

```json
{"code":3,"message":"proto: syntax error (line 1:1): unexpected token ["}
```

Root cause: PHP `[]` serializes as JSON array `[]`, but this endpoint expects an object body. For an empty request, Ozon accepts `{}`.

## Validation
- `php -l` on changed PHP files
- `php bin/phpunit --testsuite unit --filter OzonAccrualClientTest` — passed, 8 tests
- `php bin/phpunit --testsuite unit --filter 'OzonAccrual(Client|Category|ByDayPreviewMapper|ByDayMapper|SellerReportConnector)Test'` — passed, 23 tests
- Targeted `php-cs-fixer --dry-run` on changed files — passed
- `git diff --check` — passed
