### PR TITLE
[codex] Map observed Ozon accrual type aliases

### DIFF
--- a/site/src/Ingestion/Application/Source/Ozon/OzonAccrualCategory.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonAccrualCategory.php
@@ -51,17 +51,17 @@ final readonly class OzonAccrualCategory
             new self('ozon_sale_commission', 'Вознаграждение за продажу', 'Вознаграждение Ozon', TransactionType::COMMISSION, 300),
             new self('ozon_commission_refund', 'Возврат вознаграждения', 'Вознаграждение Ozon', TransactionType::COMMISSION, 310),
 
-            new self('ozon_logistics', 'Логистика', 'Услуги доставки', TransactionType::LOGISTICS, 400, typeIds: ['29'], aliases: ['Логистика Ozon']),
-            new self('ozon_reverse_logistics', 'Обратная логистика', 'Услуги доставки', TransactionType::LOGISTICS, 410, aliases: ['Обратная логистика Ozon']),
-            new self('ozon_delivery_to_pickup_ozon', 'Доставка до места выдачи силами Ozon', 'Услуги доставки', TransactionType::LAST_MILE, 420, typeIds: ['45'], aliases: ['Доставка до ПВЗ силами Ozon']),
+            new self('ozon_logistics', 'Логистика', 'Услуги доставки', TransactionType::LOGISTICS, 400, typeIds: ['29'], aliases: ['Логистика Ozon', 'Logistic']),
+            new self('ozon_reverse_logistics', 'Обратная логистика', 'Услуги доставки', TransactionType::LOGISTICS, 410, aliases: ['Обратная логистика Ozon', 'ReturnFlowLogistic']),
+            new self('ozon_delivery_to_pickup_ozon', 'Доставка до места выдачи силами Ozon', 'Услуги доставки', TransactionType::LAST_MILE, 420, typeIds: ['45'], aliases: ['Доставка до ПВЗ силами Ozon', 'DeliveryToHandoverPlaceByOzon']),
 
-            new self('ozon_partner_return_processing', 'Обработка возвратов, отмен и невыкупов партнёрами', 'Услуги партнёров', TransactionType::FEE, 500, aliases: ['Обработка возвратов, отмен и невыкупов партнерами']),
-            new self('ozon_acquiring', 'Эквайринг', 'Услуги партнёров', TransactionType::ACQUIRING, 510, aliases: ['Эквайринг Ozon']),
-            new self('ozon_partner_packaging', 'Упаковка товара партнёрами', 'Услуги партнёров', TransactionType::FEE, 520, aliases: ['Упаковка товара партнерами']),
+            new self('ozon_partner_return_processing', 'Обработка возвратов, отмен и невыкупов партнёрами', 'Услуги партнёров', TransactionType::FEE, 500, aliases: ['Обработка возвратов, отмен и невыкупов партнерами', 'SellerReturns']),
+            new self('ozon_acquiring', 'Эквайринг', 'Услуги партнёров', TransactionType::ACQUIRING, 510, aliases: ['Эквайринг Ozon', 'Acquiring']),
+            new self('ozon_partner_packaging', 'Упаковка товара партнёрами', 'Услуги партнёров', TransactionType::FEE, 520, aliases: ['Упаковка товара партнерами', 'ItemPacking', 'PackingFee']),
             new self('ozon_delivery_to_pickup_partners', 'Доставка до места выдачи партнёрами', 'Услуги партнёров', TransactionType::LAST_MILE, 530, aliases: ['Доставка до места выдачи партнерами']),
-            new self('ozon_temporary_partner_storage', 'Временное размещение товара партнёрами', 'Услуги партнёров', TransactionType::STORAGE, 540, aliases: ['Временное размещение товара партнерами']),
+            new self('ozon_temporary_partner_storage', 'Временное размещение товара партнёрами', 'Услуги партнёров', TransactionType::STORAGE, 540, aliases: ['Временное размещение товара партнерами', 'TemporaryPlacementsAgent']),
 
-            new self('ozon_cross_docking', 'Кросс-докинг', 'Услуги FBO', TransactionType::LOGISTICS, 600, parentLabel: 'Доставка до склада', aliases: ['Кросс-докинг Ozon']),
+            new self('ozon_cross_docking', 'Кросс-докинг', 'Услуги FBO', TransactionType::LOGISTICS, 600, parentLabel: 'Доставка до склада', aliases: ['Кросс-докинг Ozon', 'CrossDock']),
             new self('ozon_warehouse_export', 'Вывоз товара со склада силами Ozon', 'Услуги FBO', TransactionType::STORAGE, 700, parentLabel: 'Складские услуги'),
             new self('ozon_warehouse_placement', 'Размещение товаров на складах', 'Услуги FBO', TransactionType::STORAGE, 710, parentLabel: 'Складские услуги'),
             new self('ozon_warehouse_export_preparation', 'Подготовка товара к вывозу', 'Услуги FBO', TransactionType::STORAGE, 720, parentLabel: 'Складские услуги'),
@@ -73,9 +73,9 @@ final readonly class OzonAccrualCategory
             new self('ozon_accelerated_reviews', 'Ускоренный сбор отзывов', 'Продвижение и реклама', TransactionType::ADVERTISING, 910, aliases: ['Приобретение отзывов Ozon', 'Баллы за отзывы']),
 
             new self('ozon_early_payout', 'Досрочная выплата', 'Другие услуги и штрафы', TransactionType::FEE, 1000),
-            new self('ozon_disposal', 'Утилизация товара', 'Другие услуги и штрафы', TransactionType::FEE, 1010),
-            new self('ozon_packaging_materials', 'Обеспечение материалами для упаковки товара', 'Другие услуги и штрафы', TransactionType::FEE, 1020),
-            new self('ozon_other_services', 'Другие услуги', 'Другие услуги и штрафы', TransactionType::FEE, 1090),
+            new self('ozon_disposal', 'Утилизация товара', 'Другие услуги и штрафы', TransactionType::FEE, 1010, aliases: ['Disposal']),
+            new self('ozon_packaging_materials', 'Обеспечение материалами для упаковки товара', 'Другие услуги и штрафы', TransactionType::FEE, 1020, aliases: ['PackageCost']),
+            new self('ozon_other_services', 'Другие услуги', 'Другие услуги и штрафы', TransactionType::FEE, 1090, aliases: ['DefectFineErrors', 'PremiumCashbackIndividualPoints', 'PremiumMailingCommission', 'RfbsServiceFee']),
         ];
 
         return $cache;

--- a/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonAccrualCategoryTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonAccrualCategoryTest.php
@@ -62,6 +62,34 @@ final class OzonAccrualCategoryTest extends TestCase
         self::assertSame('ozon_cross_docking', $crossDocking->code);
     }
 
+    public function testFindsObservedInternalOzonTypeNames(): void
+    {
+        $expectedCodes = [
+            'Acquiring' => 'ozon_acquiring',
+            'CrossDock' => 'ozon_cross_docking',
+            'DefectFineErrors' => 'ozon_other_services',
+            'DeliveryToHandoverPlaceByOzon' => 'ozon_delivery_to_pickup_ozon',
+            'Disposal' => 'ozon_disposal',
+            'ItemPacking' => 'ozon_partner_packaging',
+            'Logistic' => 'ozon_logistics',
+            'PackageCost' => 'ozon_packaging_materials',
+            'PackingFee' => 'ozon_partner_packaging',
+            'PremiumCashbackIndividualPoints' => 'ozon_other_services',
+            'PremiumMailingCommission' => 'ozon_other_services',
+            'ReturnFlowLogistic' => 'ozon_reverse_logistics',
+            'RfbsServiceFee' => 'ozon_other_services',
+            'SellerReturns' => 'ozon_partner_return_processing',
+            'TemporaryPlacementsAgent' => 'ozon_temporary_partner_storage',
+        ];
+
+        foreach ($expectedCodes as $ozonTypeName => $expectedCode) {
+            $category = OzonAccrualCategory::forTypedFee(null, $ozonTypeName, TransactionType::FEE);
+
+            self::assertTrue($category->known, sprintf('Ozon type name "%s" must not resolve as unknown.', $ozonTypeName));
+            self::assertSame($expectedCode, $category->code, sprintf('Unexpected category for Ozon type name "%s".', $ozonTypeName));
+        }
+    }
+
     public function testFindsFieldCategoriesBySignedAmount(): void
     {
         self::assertSame('ozon_revenue', OzonAccrualCategory::forField('sale_amount', 100)?->code);


### PR DESCRIPTION
## What changed
- Added aliases for observed Ozon internal accrual type names from production preview.
- Mapped those names to the existing standard Ozon category list without changing transaction keys, signs, or amounts.
- Added a unit test that asserts each observed internal type name resolves to a known standard category.

## Mapped aliases
- `Acquiring` -> `Эквайринг`
- `Logistic` -> `Логистика`
- `ReturnFlowLogistic` -> `Обратная логистика`
- `DeliveryToHandoverPlaceByOzon` -> `Доставка до места выдачи силами Ozon`
- `CrossDock` -> `Кросс-докинг`
- `ItemPacking`, `PackingFee` -> `Упаковка товара партнёрами`
- `TemporaryPlacementsAgent` -> `Временное размещение товара партнёрами`
- `SellerReturns` -> `Обработка возвратов, отмен и невыкупов партнёрами`
- `Disposal` -> `Утилизация товара`
- `PackageCost` -> `Обеспечение материалами для упаковки товара`
- Remaining observed service/fine-like codes -> `Другие услуги`

## Validation
- `php -l` on changed PHP files
- `php bin/phpunit --testsuite unit --filter OzonAccrualCategoryTest` — passed, 5 tests
- `php bin/phpunit --testsuite unit --filter 'OzonAccrual(Client|Category|ByDayPreviewMapper|ByDayMapper|SellerReportConnector)Test'` — passed, 24 tests
- `make site-test-unit` — passed, 1141 tests, with existing 1 warning and 1 deprecation
- Targeted `php-cs-fixer --dry-run` on changed files — passed
- `git diff --check` — passed
