### PR TITLE
[codex] Add Ozon accrual replay normalization command

### DIFF
--- a/site/src/Ingestion/Command/OzonAccrualNormalizeStoredCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualNormalizeStoredCommand.php
@@ -1,0 +1,463 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Command;
+
+use App\Ingestion\Application\Action\NormalizeRawRecordAction;
+use App\Ingestion\Application\Action\RecordNormalizationIssueAction;
+use App\Ingestion\Application\Command\NormalizeRawRecordCommand;
+use App\Ingestion\Application\Command\RecordNormalizationIssueCommand;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\NormalizationIssueKind;
+use App\Ingestion\Enum\RawNormalizationStatus;
+use App\Ingestion\Message\NormalizeRawRecordMessage;
+use App\Ingestion\Repository\IngestRawRecordRepository;
+use App\Ingestion\Repository\NormalizationIssueRepository;
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Webmozart\Assert\Assert;
+
+#[AsCommand(
+    name: 'app:ingestion:ozon-accrual:normalize-stored',
+    description: 'Safely resets and normalizes stored Ozon accrual by-day raw records by accrual window.',
+)]
+final class OzonAccrualNormalizeStoredCommand extends Command
+{
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly IngestRawRecordRepository $rawRecordRepository,
+        private readonly NormalizationIssueRepository $normalizationIssueRepository,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly MessageBusInterface $messageBus,
+        private readonly NormalizeRawRecordAction $normalizeRawRecordAction,
+        private readonly RecordNormalizationIssueAction $recordNormalizationIssueAction,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Company UUID.')
+            ->addOption('from', null, InputOption::VALUE_REQUIRED, 'Start accrual date YYYY-MM-DD.')
+            ->addOption('to', null, InputOption::VALUE_REQUIRED, 'End accrual date YYYY-MM-DD.')
+            ->addOption('shop-ref', null, InputOption::VALUE_REQUIRED, 'Optional shop reference.')
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Raw records to process, 1..500.', 100)
+            ->addOption('include-done', null, InputOption::VALUE_NONE, 'Explicitly include already normalized raw records for replay.')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show selected records without changing them.')
+            ->addOption('dispatch', null, InputOption::VALUE_NONE, 'Reset selected records to pending and dispatch async normalization messages.')
+            ->addOption('execute-inline', null, InputOption::VALUE_NONE, 'Reset selected records and normalize them synchronously in this process.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        try {
+            $companyId = $this->requiredUuidOption($input, 'company-id');
+            [$from, $to] = $this->requiredDateWindow($input);
+            $shopRef = $this->optionalStringOption($input, 'shop-ref');
+            $limit = $this->intOption($input, 'limit', 1, 500);
+            $includeDone = (bool) $input->getOption('include-done');
+            $mode = $this->mode($input);
+        } catch (\Throwable $exception) {
+            $io->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $rawRecords = $this->rawRecords($companyId, $from, $to, $shopRef, $limit, $includeDone);
+
+        $io->title('Ozon accrual stored normalization');
+        $this->printRawRecords($io, $rawRecords);
+
+        if ([] === $rawRecords) {
+            return Command::SUCCESS;
+        }
+
+        if ('dry-run' === $mode) {
+            $io->note('Dry-run only. No raw records were changed and no messages were dispatched.');
+
+            return Command::SUCCESS;
+        }
+
+        if ('dispatch' === $mode) {
+            $resultRows = $this->dispatch($companyId, $rawRecords, $includeDone);
+            $this->printActionResult($io, $resultRows);
+            $io->success(sprintf('Dispatched %d Ozon accrual raw records for normalization.', count($resultRows)));
+
+            return Command::SUCCESS;
+        }
+
+        $resultRows = $this->executeInline($companyId, $rawRecords, $includeDone);
+        $this->printActionResult($io, $resultRows);
+
+        $failed = array_values(array_filter($resultRows, static fn (array $row): bool => 'done' !== $row['status']));
+        if ([] !== $failed) {
+            $io->warning(sprintf('Inline normalization finished with %d non-done raw records.', count($failed)));
+
+            return Command::FAILURE;
+        }
+
+        $io->success(sprintf('Normalized %d Ozon accrual raw records inline.', count($resultRows)));
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function rawRecords(
+        string $companyId,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        ?string $shopRef,
+        int $limit,
+        bool $includeDone,
+    ): array {
+        $externalWindowFrom = "substring(r.external_id from '^accrual-by-day:([0-9]{4}-[0-9]{2}-[0-9]{2}):[0-9]{4}-[0-9]{2}-[0-9]{2}$')::date";
+        $externalWindowTo = "substring(r.external_id from '^accrual-by-day:[0-9]{4}-[0-9]{2}-[0-9]{2}:([0-9]{4}-[0-9]{2}-[0-9]{2})$')::date";
+        $windowFrom = sprintf('COALESCE(j.window_from, %s, DATE(r.fetched_at))', $externalWindowFrom);
+        $windowTo = sprintf('COALESCE(j.window_to, j.window_from, %s, %s, DATE(r.fetched_at))', $externalWindowTo, $externalWindowFrom);
+        $conditions = [
+            'r.company_id = :companyId',
+            'r.source = :source',
+            'r.resource_type = :resourceType',
+            'r.normalization_status IN (:statuses)',
+            sprintf('%s <= :toDate', $windowFrom),
+            sprintf('%s >= :fromDate', $windowTo),
+        ];
+        $statuses = [
+            RawNormalizationStatus::SKIPPED->value,
+            RawNormalizationStatus::FAILED->value,
+        ];
+        if ($includeDone) {
+            $statuses[] = RawNormalizationStatus::DONE->value;
+        }
+        $params = [
+            'companyId' => $companyId,
+            'source' => IngestSource::OZON->value,
+            'resourceType' => OzonResourceType::ACCRUAL_BY_DAY,
+            'statuses' => $statuses,
+            'fromDate' => $from->format('Y-m-d'),
+            'toDate' => $to->format('Y-m-d'),
+        ];
+        $types = [
+            'statuses' => ArrayParameterType::STRING,
+        ];
+
+        if (null !== $shopRef && '' !== $shopRef) {
+            $conditions[] = 'r.shop_ref = :shopRef';
+            $params['shopRef'] = $shopRef;
+        }
+
+        return $this->connection->fetchAllAssociative(
+            sprintf(
+                'SELECT r.id,
+                        r.external_id,
+                        r.shop_ref,
+                        r.fetched_at,
+                        r.byte_size,
+                        r.normalization_status,
+                        TO_CHAR(%s, \'YYYY-MM-DD\') AS window_from,
+                        TO_CHAR(%s, \'YYYY-MM-DD\') AS window_to
+                 FROM ingest_raw_records r
+                 LEFT JOIN ingest_sync_jobs j ON j.id::text = r.sync_job_id AND j.company_id = r.company_id
+                 WHERE %s
+                 ORDER BY %s ASC, %s ASC, r.fetched_at ASC, r.created_at ASC
+                 LIMIT %d',
+                $windowFrom,
+                $windowTo,
+                implode(' AND ', $conditions),
+                $windowFrom,
+                $windowTo,
+                $limit,
+            ),
+            $params,
+            $types,
+        );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rawRecords
+     *
+     * @return list<array<string, string|int>>
+     */
+    private function dispatch(string $companyId, array $rawRecords, bool $includeDone): array
+    {
+        $records = $this->resetSelectedRecordsToPending($companyId, $rawRecords, $includeDone);
+        $this->entityManager->flush();
+
+        $resultRows = [];
+        foreach ($records as $record) {
+            $this->messageBus->dispatch(new NormalizeRawRecordMessage($record->getId(), $record->getCompanyId()));
+            $resultRows[] = [
+                'rawId' => $record->getId(),
+                'status' => RawNormalizationStatus::PENDING->value,
+                'txCount' => 0,
+                'openIssues' => 0,
+            ];
+        }
+
+        return $resultRows;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rawRecords
+     *
+     * @return list<array<string, string|int>>
+     */
+    private function executeInline(string $companyId, array $rawRecords, bool $includeDone): array
+    {
+        $resultRows = [];
+
+        foreach ($rawRecords as $row) {
+            $rawRecordId = (string) $row['id'];
+            $record = $this->rawRecordRepository->findByIdAndCompany($rawRecordId, $companyId);
+            if (null === $record || !$this->canReset($record, $includeDone)) {
+                continue;
+            }
+
+            $this->resetRecordToPending($record);
+            $this->resolveOpenIssues($companyId, $rawRecordId);
+            $this->entityManager->flush();
+
+            try {
+                ($this->normalizeRawRecordAction)(new NormalizeRawRecordCommand($rawRecordId, $companyId));
+            } catch (\Throwable $exception) {
+                $this->markInlineFailure($record, $exception);
+
+                $resultRows[] = [
+                    'rawId' => $rawRecordId,
+                    'status' => 'error',
+                    'txCount' => $this->transactionCount($companyId, $rawRecordId),
+                    'openIssues' => $this->openIssueCount($companyId, $rawRecordId),
+                    'error' => $exception->getMessage(),
+                ];
+
+                continue;
+            }
+
+            $resultRows[] = [
+                'rawId' => $rawRecordId,
+                'status' => $this->normalizationStatus($companyId, $rawRecordId),
+                'txCount' => $this->transactionCount($companyId, $rawRecordId),
+                'openIssues' => $this->openIssueCount($companyId, $rawRecordId),
+            ];
+        }
+
+        return $resultRows;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rawRecords
+     *
+     * @return list<IngestRawRecord>
+     */
+    private function resetSelectedRecordsToPending(string $companyId, array $rawRecords, bool $includeDone): array
+    {
+        $records = [];
+        foreach ($rawRecords as $row) {
+            $record = $this->rawRecordRepository->findByIdAndCompany((string) $row['id'], $companyId);
+            if (null === $record || !$this->canReset($record, $includeDone)) {
+                continue;
+            }
+
+            $this->resetRecordToPending($record);
+            $this->resolveOpenIssues($companyId, $record->getId());
+            $records[] = $record;
+        }
+
+        return $records;
+    }
+
+    private function canReset(IngestRawRecord $record, bool $includeDone): bool
+    {
+        if (RawNormalizationStatus::DONE === $record->getNormalizationStatus()) {
+            return $includeDone;
+        }
+
+        return in_array($record->getNormalizationStatus(), [RawNormalizationStatus::SKIPPED, RawNormalizationStatus::FAILED], true);
+    }
+
+    private function resetRecordToPending(IngestRawRecord $record): void
+    {
+        if (RawNormalizationStatus::DONE === $record->getNormalizationStatus()) {
+            $record->markNormalizationFailed();
+        }
+
+        $record->markNormalizationPending();
+    }
+
+    private function markInlineFailure(IngestRawRecord $record, \Throwable $exception): void
+    {
+        $record->markNormalizationFailed();
+        ($this->recordNormalizationIssueAction)(new RecordNormalizationIssueCommand(
+            companyId: $record->getCompanyId(),
+            rawRecordId: $record->getId(),
+            operationGroupId: null,
+            kind: NormalizationIssueKind::MAPPER_FAILURE,
+            details: [
+                'exceptionClass' => $exception::class,
+                'message' => $exception->getMessage(),
+                'source' => 'ozon_accrual_normalize_stored_inline',
+            ],
+        ));
+        $this->entityManager->flush();
+    }
+
+    private function resolveOpenIssues(string $companyId, string $rawRecordId): void
+    {
+        foreach ($this->normalizationIssueRepository->findOpenByRawRecord($companyId, $rawRecordId) as $issue) {
+            $issue->markResolved();
+        }
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rawRecords
+     */
+    private function printRawRecords(SymfonyStyle $io, array $rawRecords): void
+    {
+        $io->section('Selected raw records');
+        if ([] === $rawRecords) {
+            $io->writeln('No skipped, failed, or explicitly included done raw records found for the selected period.');
+
+            return;
+        }
+
+        $io->table(
+            ['windowFrom', 'windowTo', 'rawId', 'externalId', 'shopRef', 'status', 'bytes', 'fetchedAt'],
+            array_map(static fn (array $row): array => [
+                (string) ($row['window_from'] ?? ''),
+                (string) ($row['window_to'] ?? ''),
+                (string) $row['id'],
+                (string) $row['external_id'],
+                (string) $row['shop_ref'],
+                (string) $row['normalization_status'],
+                (string) $row['byte_size'],
+                (string) $row['fetched_at'],
+            ], $rawRecords),
+        );
+    }
+
+    /**
+     * @param list<array<string, string|int>> $resultRows
+     */
+    private function printActionResult(SymfonyStyle $io, array $resultRows): void
+    {
+        $io->section('Normalization action result');
+        if ([] === $resultRows) {
+            $io->writeln('No records were changed.');
+
+            return;
+        }
+
+        $io->table(
+            ['rawId', 'status', 'txCount', 'openIssues', 'error'],
+            array_map(static fn (array $row): array => [
+                (string) $row['rawId'],
+                (string) $row['status'],
+                (string) $row['txCount'],
+                (string) $row['openIssues'],
+                (string) ($row['error'] ?? ''),
+            ], $resultRows),
+        );
+    }
+
+    private function normalizationStatus(string $companyId, string $rawRecordId): string
+    {
+        return (string) $this->connection->fetchOne(
+            'SELECT normalization_status FROM ingest_raw_records WHERE company_id = :companyId AND id = :rawRecordId',
+            ['companyId' => $companyId, 'rawRecordId' => $rawRecordId],
+        );
+    }
+
+    private function transactionCount(string $companyId, string $rawRecordId): int
+    {
+        return (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM ingest_financial_transactions WHERE company_id = :companyId AND raw_record_id = :rawRecordId',
+            ['companyId' => $companyId, 'rawRecordId' => $rawRecordId],
+        );
+    }
+
+    private function openIssueCount(string $companyId, string $rawRecordId): int
+    {
+        return (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM ingest_normalization_issues WHERE company_id = :companyId AND raw_record_id = :rawRecordId AND resolved_at IS NULL',
+            ['companyId' => $companyId, 'rawRecordId' => $rawRecordId],
+        );
+    }
+
+    private function requiredUuidOption(InputInterface $input, string $name): string
+    {
+        $value = trim((string) $input->getOption($name));
+        Assert::uuid($value, sprintf('Invalid --%s UUID.', $name));
+
+        return $value;
+    }
+
+    /**
+     * @return array{0: \DateTimeImmutable, 1: \DateTimeImmutable}
+     */
+    private function requiredDateWindow(InputInterface $input): array
+    {
+        $from = $this->dateOption($input, 'from');
+        $to = $this->dateOption($input, 'to');
+        if ($from > $to) {
+            throw new \InvalidArgumentException('--from cannot be later than --to.');
+        }
+
+        return [$from, $to];
+    }
+
+    private function dateOption(InputInterface $input, string $name): \DateTimeImmutable
+    {
+        $value = trim((string) $input->getOption($name));
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
+        if (false === $date || $date->format('Y-m-d') !== $value) {
+            throw new \InvalidArgumentException(sprintf('--%s must be a valid YYYY-MM-DD date.', $name));
+        }
+
+        return $date;
+    }
+
+    private function optionalStringOption(InputInterface $input, string $name): ?string
+    {
+        $value = trim((string) $input->getOption($name));
+
+        return '' === $value ? null : $value;
+    }
+
+    private function intOption(InputInterface $input, string $name, int $min, int $max): int
+    {
+        $value = (int) $input->getOption($name);
+
+        return max($min, min($max, $value));
+    }
+
+    private function mode(InputInterface $input): string
+    {
+        $modes = array_values(array_filter([
+            (bool) $input->getOption('dry-run') ? 'dry-run' : null,
+            (bool) $input->getOption('dispatch') ? 'dispatch' : null,
+            (bool) $input->getOption('execute-inline') ? 'execute-inline' : null,
+        ]));
+
+        if (1 !== count($modes)) {
+            throw new \InvalidArgumentException('Choose exactly one action: --dry-run, --dispatch, or --execute-inline.');
+        }
+
+        return $modes[0];
+    }
+}

--- a/site/tests/Integration/Ingestion/Command/OzonAccrualNormalizeStoredCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/OzonAccrualNormalizeStoredCommandTest.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Command;
+
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\DTO\RawBatch;
+use App\Ingestion\Entity\FinancialTransaction;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\RawNormalizationStatus;
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+use App\Ingestion\Facade\RawStorageFacade;
+use App\Ingestion\Repository\IngestRawRecordRepository;
+use App\Shared\Domain\ValueObject\Money;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class OzonAccrualNormalizeStoredCommandTest extends IntegrationTestCase
+{
+    public function testDryRunExcludesDoneRecordsUnlessExplicitlyIncluded(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = Uuid::uuid7()->toString();
+        $record = $this->storeRawRecord(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            externalId: 'accrual-by-day:2026-06-01:2026-06-07',
+            fetchedAt: new \DateTimeImmutable('2026-06-08 03:00:00+00:00'),
+            rows: [$this->postingRow()],
+        );
+        $record->markNormalizationDone();
+        $this->em->flush();
+
+        $defaultTester = $this->tester();
+        $defaultExit = $defaultTester->execute([
+            '--company-id' => $companyId,
+            '--from' => '2026-06-01',
+            '--to' => '2026-06-07',
+            '--shop-ref' => $connectionRef,
+            '--dry-run' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $defaultExit);
+        self::assertStringNotContainsString('accrual-by-day:2026-06-01:2026-06-07', $defaultTester->getDisplay());
+        self::assertSame(RawNormalizationStatus::DONE, $this->rawStatus($record));
+
+        $includeDoneTester = $this->tester();
+        $includeDoneExit = $includeDoneTester->execute([
+            '--company-id' => $companyId,
+            '--from' => '2026-06-01',
+            '--to' => '2026-06-07',
+            '--shop-ref' => $connectionRef,
+            '--include-done' => true,
+            '--dry-run' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $includeDoneExit);
+        self::assertStringContainsString('accrual-by-day:2026-06-01:2026-06-07', $includeDoneTester->getDisplay());
+        self::assertSame(RawNormalizationStatus::DONE, $this->rawStatus($record));
+    }
+
+    public function testExecuteInlineCanReplayDoneRecordAndInsertMissingBonusWithoutDuplicates(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = Uuid::uuid7()->toString();
+        $record = $this->storeRawRecord(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            externalId: 'accrual-by-day:2026-06-01:2026-06-07',
+            fetchedAt: new \DateTimeImmutable('2026-06-08 03:00:00+00:00'),
+            rows: [$this->postingRow()],
+        );
+        $operationGroupId = Uuid::uuid5(Uuid::NAMESPACE_URL, sprintf('%s:ozon:accrual-by-day:%s', $companyId, '53675409100'))->toString();
+        $this->persistExistingTransaction(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            rawRecordId: $record->getId(),
+            operationGroupId: $operationGroupId,
+            externalId: 'ozon:accrual-by-day:53675409100:sale:product-0',
+            type: TransactionType::SALE,
+            direction: TransactionDirection::IN,
+            amountMinor: 10000,
+            occurredAt: new \DateTimeImmutable('2026-06-01 00:00:00+03:00'),
+        );
+        $this->persistExistingTransaction(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            rawRecordId: $record->getId(),
+            operationGroupId: $operationGroupId,
+            externalId: 'ozon:accrual-by-day:53675409100:commission:product-0',
+            type: TransactionType::COMMISSION,
+            direction: TransactionDirection::OUT,
+            amountMinor: 3000,
+            occurredAt: new \DateTimeImmutable('2026-06-01 00:00:00+03:00'),
+        );
+        $record->markNormalizationDone();
+        $this->em->flush();
+
+        $tester = $this->tester();
+        $exit = $tester->execute([
+            '--company-id' => $companyId,
+            '--from' => '2026-06-01',
+            '--to' => '2026-06-07',
+            '--shop-ref' => $connectionRef,
+            '--include-done' => true,
+            '--execute-inline' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exit, $tester->getDisplay());
+        self::assertSame(RawNormalizationStatus::DONE, $this->rawStatusById($companyId, $record->getId()));
+        self::assertSame(3, $this->transactionCount($companyId, $record->getId()));
+        self::assertSame(1, $this->transactionCountByType($companyId, $record->getId(), TransactionType::SALE));
+        self::assertSame(1, $this->transactionCountByType($companyId, $record->getId(), TransactionType::COMMISSION));
+        self::assertSame(1, $this->transactionCountByType($companyId, $record->getId(), TransactionType::BONUS));
+        self::assertSame(0, $this->duplicateNaturalKeyCount($companyId));
+        self::assertSame(0, $this->openIssueCount($companyId, $record->getId()));
+        self::assertStringContainsString('Normalized 1 Ozon accrual raw records inline.', $tester->getDisplay());
+    }
+
+    private function tester(): CommandTester
+    {
+        $app = new Application(self::$kernel);
+
+        return new CommandTester($app->find('app:ingestion:ozon-accrual:normalize-stored'));
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     */
+    private function storeRawRecord(
+        string $companyId,
+        string $connectionRef,
+        string $externalId,
+        \DateTimeImmutable $fetchedAt,
+        array $rows,
+    ): IngestRawRecord {
+        /** @var RawStorageFacade $facade */
+        $facade = self::getContainer()->get(RawStorageFacade::class);
+
+        return $facade->store(new RawBatch(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            shopRef: $connectionRef,
+            source: IngestSource::OZON,
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            externalId: $externalId,
+            syncJobId: Uuid::uuid7()->toString(),
+            fetchedAt: $fetchedAt,
+            rows: $rows,
+        ))[0];
+    }
+
+    private function persistExistingTransaction(
+        string $companyId,
+        string $connectionRef,
+        string $rawRecordId,
+        string $operationGroupId,
+        string $externalId,
+        TransactionType $type,
+        TransactionDirection $direction,
+        int $amountMinor,
+        \DateTimeImmutable $occurredAt,
+    ): void {
+        $this->em->persist(new FinancialTransaction(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            shopRef: $connectionRef,
+            source: IngestSource::OZON,
+            externalId: $externalId,
+            externalUpdatedAt: new \DateTimeImmutable('2026-06-08 03:00:00+00:00'),
+            operationGroupId: $operationGroupId,
+            type: $type,
+            direction: $direction,
+            money: Money::fromMinor($amountMinor, 'RUB'),
+            occurredAt: $occurredAt,
+            rawRecordId: $rawRecordId,
+            description: 'Existing Ozon accrual transaction',
+            sourceData: [],
+            sourceTz: 'Europe/Moscow',
+        ));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function postingRow(): array
+    {
+        return [
+            'accrual_id' => 53675409100,
+            'date' => '2026-06-01',
+            'unit_number' => '41774559-0885-1',
+            'accrued_category' => 'POSTING',
+            'posting' => [
+                'products' => [[
+                    'commission' => [
+                        'sale_amount' => ['amount' => '100.00', 'currency' => 'RUB'],
+                        'bonus' => ['amount' => '20.00', 'currency' => 'RUB'],
+                        'commission' => ['amount' => '-30.00', 'currency' => 'RUB'],
+                    ],
+                ]],
+            ],
+        ];
+    }
+
+    private function rawStatus(IngestRawRecord $record): RawNormalizationStatus
+    {
+        return $this->rawStatusById($record->getCompanyId(), $record->getId());
+    }
+
+    private function rawStatusById(string $companyId, string $rawRecordId): RawNormalizationStatus
+    {
+        /** @var IngestRawRecordRepository $repository */
+        $repository = self::getContainer()->get(IngestRawRecordRepository::class);
+
+        return $repository->findByIdAndCompany($rawRecordId, $companyId)?->getNormalizationStatus()
+            ?? throw new \RuntimeException('Raw record was not found.');
+    }
+
+    private function transactionCount(string $companyId, string $rawRecordId): int
+    {
+        return (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM ingest_financial_transactions WHERE company_id = :companyId AND raw_record_id = :rawRecordId',
+            ['companyId' => $companyId, 'rawRecordId' => $rawRecordId],
+        );
+    }
+
+    private function transactionCountByType(string $companyId, string $rawRecordId, TransactionType $type): int
+    {
+        return (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM ingest_financial_transactions WHERE company_id = :companyId AND raw_record_id = :rawRecordId AND type = :type',
+            ['companyId' => $companyId, 'rawRecordId' => $rawRecordId, 'type' => $type->value],
+        );
+    }
+
+    private function duplicateNaturalKeyCount(string $companyId): int
+    {
+        return (int) $this->connection->fetchOne(
+            'SELECT COUNT(*)
+             FROM (
+                 SELECT external_id, type
+                 FROM ingest_financial_transactions
+                 WHERE company_id = :companyId
+                   AND source = :source
+                 GROUP BY external_id, type
+                 HAVING COUNT(*) > 1
+             ) duplicate_keys',
+            ['companyId' => $companyId, 'source' => IngestSource::OZON->value],
+        );
+    }
+
+    private function openIssueCount(string $companyId, string $rawRecordId): int
+    {
+        return (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM ingest_normalization_issues WHERE company_id = :companyId AND raw_record_id = :rawRecordId AND resolved_at IS NULL',
+            ['companyId' => $companyId, 'rawRecordId' => $rawRecordId],
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add `app:ingestion:ozon-accrual:normalize-stored` for stored Ozon accrual by-day replay
- require explicit `--include-done` before already normalized raw records are replayed
- cover dry-run protection and inline replay inserting missing `bonus` rows without duplicate natural keys

## Why
Old Ozon canonical rows for 2026-06-01..2026-06-07 were normalized before bonus components were enabled. The generic normalizer skips `DONE` raw records, so we need an explicit maintenance command to replay stored raw safely.

## Validation
- `docker compose run --rm -e COMPOSER_PROCESS_TIMEOUT=0 site-php-cli php bin/phpunit -c phpunit.xml --testsuite=integration --filter OzonAccrualNormalizeStoredCommandTest`
- `make site-test-unit`
- `git diff --check`

## Notes
Replay inserts missing natural keys such as `bonus`; existing rows with the same natural key are still protected by the current stale-update guard. Historical category metadata rebuild for already existing rows remains a separate explicit step if needed.