### PR TITLE
[codex] Add Ozon marketplace category summary

### DIFF
--- a/site/assets/api/schema.d.ts
+++ b/site/assets/api/schema.d.ts
@@ -574,6 +574,24 @@ export interface operations {
                             /** @example 1500000000 */
                             amount_minor?: number;
                         }[];
+                        marketplace_categories?: {
+                            /** @example ozon */
+                            source?: string;
+                            /** @example Услуги доставки */
+                            category_group?: string;
+                            /** @example Логистика */
+                            category_name?: string;
+                            /** @example fee */
+                            type?: string;
+                            /** @example out */
+                            direction?: string;
+                            /** @example -5374795 */
+                            amount_minor?: number;
+                            /** @example 1418 */
+                            tx_count?: number;
+                            /** @example 400 */
+                            sort_order?: number;
+                        }[];
                     };
                 };
             };

--- a/site/assets/react/ingestion-verification/api/ingestionVerificationApi.ts
+++ b/site/assets/react/ingestion-verification/api/ingestionVerificationApi.ts
@@ -54,7 +54,11 @@ const EMPTY_ISSUES: IssuesResponse = {
     items: [],
     meta: { page: 1, limit: 50, total: 0, total_pages: 0 },
 };
-const EMPTY_FINANCIAL_SUMMARY: FinancialSummaryResponse = { by_month: [], by_category: [] };
+const EMPTY_FINANCIAL_SUMMARY: FinancialSummaryResponse = {
+    by_month: [],
+    by_category: [],
+    marketplace_categories: [],
+};
 
 function nullableShopRef(shopRef: string | null): string | undefined {
     return shopRef === null || shopRef.trim() === '' ? undefined : shopRef.trim();

--- a/site/assets/react/ingestion-verification/types.ts
+++ b/site/assets/react/ingestion-verification/types.ts
@@ -33,6 +33,7 @@ export type FinancialSummaryResponse = JsonResponse<'get_api_ingestion_verificat
 export type FinancialSummaryQuery = QueryParameters<'get_api_ingestion_verification_financial_summary'>;
 export type FinancialSummaryMonthDto = NonNullable<FinancialSummaryResponse['by_month']>[number];
 export type FinancialSummaryCategoryDto = NonNullable<FinancialSummaryResponse['by_category']>[number];
+export type FinancialSummaryMarketplaceCategoryDto = NonNullable<FinancialSummaryResponse['marketplace_categories']>[number];
 
 export interface MonthPeriod {
     year: number;

--- a/site/assets/react/ingestion-verification/views/FinancialSummaryView.tsx
+++ b/site/assets/react/ingestion-verification/views/FinancialSummaryView.tsx
@@ -1,12 +1,18 @@
 import React, { useMemo } from 'react';
 import MoneyCell from '../components/MoneyCell';
 import StatusBadge from '../components/StatusBadge';
-import type { FinancialSummaryCategoryDto, FinancialSummaryMonthDto, MonthRangePeriod } from '../types';
+import type {
+    FinancialSummaryCategoryDto,
+    FinancialSummaryMarketplaceCategoryDto,
+    FinancialSummaryMonthDto,
+    MonthRangePeriod,
+} from '../types';
 import { formatMonthLabel } from '../utils/date';
 
 interface FinancialSummaryViewProps {
     by_month: FinancialSummaryMonthDto[];
     by_category: FinancialSummaryCategoryDto[];
+    marketplace_categories: FinancialSummaryMarketplaceCategoryDto[];
     period: MonthRangePeriod;
 }
 
@@ -16,6 +22,32 @@ interface FinancialTotals {
     net: number;
     currency: string;
 }
+
+interface MarketplaceCategoryGroup {
+    group: string;
+    items: FinancialSummaryMarketplaceCategoryDto[];
+}
+
+const TYPE_LABELS: Record<string, string> = {
+    sale: 'Продажа',
+    refund: 'Возврат',
+    commission: 'Комиссия',
+    logistics: 'Логистика',
+    storage: 'Хранение',
+    last_mile: 'Последняя миля',
+    acceptance: 'Приемка',
+    advertising: 'Реклама',
+    penalty: 'Штраф',
+    bonus: 'Бонус',
+    acquiring: 'Эквайринг',
+    adjustment: 'Корректировка',
+    payout: 'Выплата',
+    deposit: 'Поступление',
+    transfer: 'Перевод',
+    tax: 'Налог',
+    fee: 'Сбор',
+    other: 'Прочее',
+};
 
 function flowBadge(flow: string | undefined): React.ReactNode {
     if (flow === 'income') {
@@ -29,6 +61,18 @@ function flowBadge(flow: string | undefined): React.ReactNode {
     return <StatusBadge status="neutral" label={flow ?? '—'} />;
 }
 
+function directionBadge(direction: string | undefined): React.ReactNode {
+    if (direction === 'in') {
+        return <StatusBadge status="success" label="Вход" />;
+    }
+
+    if (direction === 'out') {
+        return <StatusBadge status="error" label="Выход" />;
+    }
+
+    return <StatusBadge status="neutral" label={direction ?? '—'} />;
+}
+
 function categoryKey(item: FinancialSummaryCategoryDto): string {
     return item.category_id ?? JSON.stringify([
         'category',
@@ -38,9 +82,20 @@ function categoryKey(item: FinancialSummaryCategoryDto): string {
     ]);
 }
 
+function marketplaceCategoryKey(item: FinancialSummaryMarketplaceCategoryDto): string {
+    return JSON.stringify([
+        item.source ?? null,
+        item.category_group ?? null,
+        item.category_name ?? null,
+        item.type ?? null,
+        item.direction ?? null,
+    ]);
+}
+
 const FinancialSummaryView: React.FC<FinancialSummaryViewProps> = ({
     by_month,
     by_category,
+    marketplace_categories,
     period,
 }) => {
     const totals = useMemo<FinancialTotals>(() => by_month.reduce<FinancialTotals>(
@@ -52,6 +107,24 @@ const FinancialSummaryView: React.FC<FinancialSummaryViewProps> = ({
         }),
         { income: 0, expense: 0, net: 0, currency: 'RUB' },
     ), [by_month]);
+
+    const marketplaceGroups = useMemo<MarketplaceCategoryGroup[]>(() => {
+        const groupMap = new Map<string, MarketplaceCategoryGroup>();
+
+        marketplace_categories.forEach((item) => {
+            const group = item.category_group ?? 'Без группы Ozon';
+            const existing = groupMap.get(group);
+
+            if (existing !== undefined) {
+                existing.items.push(item);
+                return;
+            }
+
+            groupMap.set(group, { group, items: [item] });
+        });
+
+        return Array.from(groupMap.values());
+    }, [marketplace_categories]);
 
     const categoryMonth = formatMonthLabel(period.yearTo, period.monthTo);
 
@@ -168,6 +241,65 @@ const FinancialSummaryView: React.FC<FinancialSummaryViewProps> = ({
                         </div>
                     </div>
                 </div>
+            </div>
+
+            <div className="card mt-3">
+                <div className="card-header">
+                    <div>
+                        <h3 className="card-title">Категории Ozon</h3>
+                        <div className="card-subtitle">{categoryMonth}</div>
+                    </div>
+                </div>
+                {marketplaceGroups.length === 0 ? (
+                    <div className="card-body text-secondary">
+                        Нет данных Ozon за выбранный месяц
+                    </div>
+                ) : (
+                    <div className="table-responsive">
+                        <table className="table table-vcenter card-table">
+                            <thead>
+                                <tr>
+                                    <th>Статья</th>
+                                    <th>Тип</th>
+                                    <th>Направление</th>
+                                    <th className="text-end">Операций</th>
+                                    <th className="text-end">Сумма</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {marketplaceGroups.map((group) => (
+                                    <React.Fragment key={group.group}>
+                                        <tr className="table-light">
+                                            <td colSpan={5}>
+                                                <strong>{group.group}</strong>
+                                            </td>
+                                        </tr>
+                                        {group.items.map((item) => {
+                                            const amount = item.amount_minor ?? 0;
+                                            const type = item.type ?? 'other';
+
+                                            return (
+                                                <tr key={marketplaceCategoryKey(item)}>
+                                                    <td>{item.category_name ?? 'Без категории'}</td>
+                                                    <td>{TYPE_LABELS[type] ?? type}</td>
+                                                    <td>{directionBadge(item.direction)}</td>
+                                                    <td className="text-end">{item.tx_count ?? 0}</td>
+                                                    <td className="text-end">
+                                                        <MoneyCell
+                                                            amountMinor={amount}
+                                                            currency={totals.currency}
+                                                            className={amount >= 0 ? 'text-success' : 'text-danger'}
+                                                        />
+                                                    </td>
+                                                </tr>
+                                            );
+                                        })}
+                                    </React.Fragment>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                )}
             </div>
         </>
     );

--- a/site/assets/react/ingestion-verification/widgets/FinancialSummaryWidget.tsx
+++ b/site/assets/react/ingestion-verification/widgets/FinancialSummaryWidget.tsx
@@ -26,6 +26,8 @@ const FinancialSummaryWidget: React.FC = () => {
     const summary = useFinancialSummaryData(debouncedParams);
     const by_month = summary.data.by_month ?? [];
     const by_category = summary.data.by_category ?? [];
+    const marketplace_categories = summary.data.marketplace_categories ?? [];
+    const hasSummary = by_month.length > 0 || by_category.length > 0 || marketplace_categories.length > 0;
 
     return (
         <div>
@@ -57,14 +59,15 @@ const FinancialSummaryWidget: React.FC = () => {
 
             {!shopOptions.isError && !summary.isError && summary.isLoading && <LoadingState />}
 
-            {!shopOptions.isError && !summary.isError && !summary.isLoading && by_month.length === 0 && (
+            {!shopOptions.isError && !summary.isError && !summary.isLoading && !hasSummary && (
                 <EmptyState message="Финансовой сводки за выбранный период нет" />
             )}
 
-            {!shopOptions.isError && !summary.isError && !summary.isLoading && by_month.length > 0 && (
+            {!shopOptions.isError && !summary.isError && !summary.isLoading && hasSummary && (
                 <FinancialSummaryView
                     by_month={by_month}
                     by_category={by_category}
+                    marketplace_categories={marketplace_categories}
                     period={period}
                 />
             )}

--- a/site/src/Ingestion/Application/DTO/FinancialSummaryMarketplaceCategoryView.php
+++ b/site/src/Ingestion/Application/DTO/FinancialSummaryMarketplaceCategoryView.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\DTO;
+
+final readonly class FinancialSummaryMarketplaceCategoryView
+{
+    public function __construct(
+        public string $source,
+        public string $categoryGroup,
+        public string $categoryName,
+        public string $type,
+        public string $direction,
+        public int $amountMinor,
+        public int $txCount,
+        public int $sortOrder,
+    ) {
+    }
+
+    /**
+     * @return array{source: string, category_group: string, category_name: string, type: string, direction: string, amount_minor: int, tx_count: int, sort_order: int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'source' => $this->source,
+            'category_group' => $this->categoryGroup,
+            'category_name' => $this->categoryName,
+            'type' => $this->type,
+            'direction' => $this->direction,
+            'amount_minor' => $this->amountMinor,
+            'tx_count' => $this->txCount,
+            'sort_order' => $this->sortOrder,
+        ];
+    }
+}

--- a/site/src/Ingestion/Command/OzonAccrualRefreshCategoryMetadataCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualRefreshCategoryMetadataCommand.php
@@ -1,0 +1,425 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Command;
+
+use App\Ingestion\Application\DTO\MappedTransaction;
+use App\Ingestion\Application\Source\Ozon\OzonAccrualByDayMapper;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Entity\FinancialTransaction;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\RawNormalizationStatus;
+use App\Ingestion\Facade\RawStorageFacade;
+use App\Ingestion\Repository\FinancialTransactionRepository;
+use App\Ingestion\Repository\IngestRawRecordRepository;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Webmozart\Assert\Assert;
+
+#[AsCommand(
+    name: 'app:ingestion:ozon-accrual:refresh-category-metadata',
+    description: 'Refreshes Ozon accrual category metadata on already normalized canonical transactions.',
+)]
+final class OzonAccrualRefreshCategoryMetadataCommand extends Command
+{
+    private const CATEGORY_SOURCE_DATA_KEYS = [
+        '_ozon_category_code',
+        '_ozon_category_label',
+        '_ozon_category_group',
+        '_ozon_category_parent',
+        '_ozon_category_sort_order',
+        '_ozon_category_known',
+    ];
+
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly IngestRawRecordRepository $rawRecordRepository,
+        private readonly FinancialTransactionRepository $financialTransactionRepository,
+        private readonly RawStorageFacade $rawStorageFacade,
+        private readonly OzonAccrualByDayMapper $mapper,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Company UUID.')
+            ->addOption('from', null, InputOption::VALUE_REQUIRED, 'Start accrual date YYYY-MM-DD.')
+            ->addOption('to', null, InputOption::VALUE_REQUIRED, 'End accrual date YYYY-MM-DD.')
+            ->addOption('shop-ref', null, InputOption::VALUE_REQUIRED, 'Optional shop reference.')
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Raw records to process, 1..500.', 100)
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show selected records and planned metadata updates without writing.')
+            ->addOption('execute-inline', null, InputOption::VALUE_NONE, 'Refresh metadata synchronously in this process.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        try {
+            $companyId = $this->requiredUuidOption($input, 'company-id');
+            [$from, $to] = $this->requiredDateWindow($input);
+            $shopRef = $this->optionalStringOption($input, 'shop-ref');
+            $limit = $this->intOption($input, 'limit', 1, 500);
+            $mode = $this->mode($input);
+        } catch (\Throwable $exception) {
+            $io->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $rawRecords = $this->rawRecords($companyId, $from, $to, $shopRef, $limit);
+
+        $io->title('Ozon accrual category metadata refresh');
+        $this->printRawRecords($io, $rawRecords);
+
+        if ([] === $rawRecords) {
+            return Command::SUCCESS;
+        }
+
+        $dryRun = 'dry-run' === $mode;
+        $resultRows = $this->refresh($companyId, $rawRecords, $dryRun);
+        $this->printActionResult($io, $resultRows);
+
+        $failed = array_values(array_filter($resultRows, static fn (array $row): bool => 'error' === $row['status']));
+        if ([] !== $failed) {
+            $io->warning(sprintf('Metadata refresh finished with %d failed raw records.', count($failed)));
+
+            return Command::FAILURE;
+        }
+
+        if ($dryRun) {
+            $io->note('Dry-run only. No canonical transactions were changed.');
+
+            return Command::SUCCESS;
+        }
+
+        $updated = array_sum(array_map(static fn (array $row): int => (int) $row['updated'], $resultRows));
+        $io->success(sprintf('Refreshed Ozon category metadata on %d canonical transactions.', $updated));
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function rawRecords(
+        string $companyId,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        ?string $shopRef,
+        int $limit,
+    ): array {
+        $externalWindowFrom = "substring(r.external_id from '^accrual-by-day:([0-9]{4}-[0-9]{2}-[0-9]{2}):[0-9]{4}-[0-9]{2}-[0-9]{2}$')::date";
+        $externalWindowTo = "substring(r.external_id from '^accrual-by-day:[0-9]{4}-[0-9]{2}-[0-9]{2}:([0-9]{4}-[0-9]{2}-[0-9]{2})$')::date";
+        $windowFrom = sprintf('COALESCE(j.window_from, %s, DATE(r.fetched_at))', $externalWindowFrom);
+        $windowTo = sprintf('COALESCE(j.window_to, j.window_from, %s, %s, DATE(r.fetched_at))', $externalWindowTo, $externalWindowFrom);
+        $conditions = [
+            'r.company_id = :companyId',
+            'r.source = :source',
+            'r.resource_type = :resourceType',
+            'r.normalization_status = :status',
+            sprintf('%s <= :toDate', $windowFrom),
+            sprintf('%s >= :fromDate', $windowTo),
+        ];
+        $params = [
+            'companyId' => $companyId,
+            'source' => IngestSource::OZON->value,
+            'resourceType' => OzonResourceType::ACCRUAL_BY_DAY,
+            'status' => RawNormalizationStatus::DONE->value,
+            'fromDate' => $from->format('Y-m-d'),
+            'toDate' => $to->format('Y-m-d'),
+        ];
+
+        if (null !== $shopRef && '' !== $shopRef) {
+            $conditions[] = 'r.shop_ref = :shopRef';
+            $params['shopRef'] = $shopRef;
+        }
+
+        return $this->connection->fetchAllAssociative(
+            sprintf(
+                'SELECT r.id,
+                        r.external_id,
+                        r.shop_ref,
+                        r.fetched_at,
+                        r.byte_size,
+                        r.normalization_status,
+                        TO_CHAR(%s, \'YYYY-MM-DD\') AS window_from,
+                        TO_CHAR(%s, \'YYYY-MM-DD\') AS window_to
+                 FROM ingest_raw_records r
+                 LEFT JOIN ingest_sync_jobs j ON j.id::text = r.sync_job_id AND j.company_id = r.company_id
+                 WHERE %s
+                 ORDER BY %s ASC, %s ASC, r.fetched_at ASC, r.created_at ASC
+                 LIMIT %d',
+                $windowFrom,
+                $windowTo,
+                implode(' AND ', $conditions),
+                $windowFrom,
+                $windowTo,
+                $limit,
+            ),
+            $params,
+        );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rawRecords
+     *
+     * @return list<array<string, string|int>>
+     */
+    private function refresh(string $companyId, array $rawRecords, bool $dryRun): array
+    {
+        $resultRows = [];
+
+        foreach ($rawRecords as $row) {
+            $rawRecordId = (string) $row['id'];
+            $connection = $this->entityManager->getConnection();
+
+            if (!$dryRun) {
+                $connection->beginTransaction();
+            }
+
+            try {
+                $rawRecord = $this->rawRecordRepository->findByIdAndCompany($rawRecordId, $companyId);
+                if (null === $rawRecord || RawNormalizationStatus::DONE !== $rawRecord->getNormalizationStatus()) {
+                    throw new \RuntimeException('Done Ozon accrual raw record was not found.');
+                }
+
+                /** @var list<array<string, mixed>> $rows */
+                $rows = array_values(iterator_to_array($this->rawStorageFacade->read($rawRecord->getId(), $companyId), false));
+                $mappedTransactions = $this->mapper->map($rawRecord, $rows);
+                $existingByKey = $this->existingTransactionsByNaturalKey($companyId, $rawRecord);
+
+                $scanned = 0;
+                $matched = 0;
+                $updated = 0;
+                $unchanged = 0;
+                $missing = 0;
+
+                foreach ($mappedTransactions as $mappedTransaction) {
+                    ++$scanned;
+                    $transaction = $existingByKey[$this->naturalKey($mappedTransaction)] ?? null;
+                    if (!$transaction instanceof FinancialTransaction) {
+                        $transaction = $this->financialTransactionRepository->findByNaturalKey(
+                            $companyId,
+                            IngestSource::OZON,
+                            $mappedTransaction->externalId,
+                            $mappedTransaction->type,
+                        );
+                    }
+
+                    if (!$transaction instanceof FinancialTransaction) {
+                        ++$missing;
+                        continue;
+                    }
+
+                    ++$matched;
+                    if (!$this->metadataDiffers($transaction, $mappedTransaction)) {
+                        ++$unchanged;
+                        continue;
+                    }
+
+                    ++$updated;
+                    if (!$dryRun) {
+                        $transaction->replaceSourceDataFields(
+                            $mappedTransaction->sourceData,
+                            self::CATEGORY_SOURCE_DATA_KEYS,
+                            $mappedTransaction->description,
+                        );
+                    }
+                }
+
+                if (!$dryRun) {
+                    $this->entityManager->flush();
+                    $connection->commit();
+                }
+
+                $resultRows[] = [
+                    'rawId' => $rawRecordId,
+                    'status' => $dryRun ? 'dry-run' : 'done',
+                    'scanned' => $scanned,
+                    'matched' => $matched,
+                    'updated' => $updated,
+                    'unchanged' => $unchanged,
+                    'missing' => $missing,
+                ];
+            } catch (\Throwable $exception) {
+                if (!$dryRun && $connection->isTransactionActive()) {
+                    $connection->rollBack();
+                }
+
+                $resultRows[] = [
+                    'rawId' => $rawRecordId,
+                    'status' => 'error',
+                    'scanned' => 0,
+                    'matched' => 0,
+                    'updated' => 0,
+                    'unchanged' => 0,
+                    'missing' => 0,
+                    'error' => $exception->getMessage(),
+                ];
+            }
+        }
+
+        return $resultRows;
+    }
+
+    /**
+     * @return array<string, FinancialTransaction>
+     */
+    private function existingTransactionsByNaturalKey(string $companyId, IngestRawRecord $rawRecord): array
+    {
+        $transactions = [];
+        foreach ($this->financialTransactionRepository->findByRawRecordId($companyId, $rawRecord->getId()) as $transaction) {
+            $transactions[sprintf('%s:%s', $transaction->getExternalId(), $transaction->getType()->value)] = $transaction;
+        }
+
+        return $transactions;
+    }
+
+    private function naturalKey(MappedTransaction $transaction): string
+    {
+        return sprintf('%s:%s', $transaction->externalId, $transaction->type->value);
+    }
+
+    private function metadataDiffers(FinancialTransaction $transaction, MappedTransaction $mappedTransaction): bool
+    {
+        $existing = $transaction->getSourceData();
+        foreach (self::CATEGORY_SOURCE_DATA_KEYS as $key) {
+            if (!array_key_exists($key, $mappedTransaction->sourceData)) {
+                continue;
+            }
+
+            if (!array_key_exists($key, $existing) || $existing[$key] !== $mappedTransaction->sourceData[$key]) {
+                return true;
+            }
+        }
+
+        return null !== $mappedTransaction->description && $transaction->getDescription() !== $mappedTransaction->description;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rawRecords
+     */
+    private function printRawRecords(SymfonyStyle $io, array $rawRecords): void
+    {
+        $io->section('Selected raw records');
+        if ([] === $rawRecords) {
+            $io->writeln('No done Ozon accrual by-day raw records found for the selected period.');
+
+            return;
+        }
+
+        $io->table(
+            ['windowFrom', 'windowTo', 'rawId', 'externalId', 'shopRef', 'status', 'bytes', 'fetchedAt'],
+            array_map(static fn (array $row): array => [
+                (string) ($row['window_from'] ?? ''),
+                (string) ($row['window_to'] ?? ''),
+                (string) $row['id'],
+                (string) $row['external_id'],
+                (string) $row['shop_ref'],
+                (string) $row['normalization_status'],
+                (string) $row['byte_size'],
+                (string) $row['fetched_at'],
+            ], $rawRecords),
+        );
+    }
+
+    /**
+     * @param list<array<string, string|int>> $resultRows
+     */
+    private function printActionResult(SymfonyStyle $io, array $resultRows): void
+    {
+        $io->section('Metadata refresh result');
+        if ([] === $resultRows) {
+            $io->writeln('No records were processed.');
+
+            return;
+        }
+
+        $io->table(
+            ['rawId', 'status', 'scanned', 'matched', 'updated', 'unchanged', 'missing', 'error'],
+            array_map(static fn (array $row): array => [
+                (string) $row['rawId'],
+                (string) $row['status'],
+                (string) $row['scanned'],
+                (string) $row['matched'],
+                (string) $row['updated'],
+                (string) $row['unchanged'],
+                (string) $row['missing'],
+                (string) ($row['error'] ?? ''),
+            ], $resultRows),
+        );
+    }
+
+    private function requiredUuidOption(InputInterface $input, string $name): string
+    {
+        $value = trim((string) $input->getOption($name));
+        Assert::uuid($value, sprintf('Invalid --%s UUID.', $name));
+
+        return $value;
+    }
+
+    /**
+     * @return array{0: \DateTimeImmutable, 1: \DateTimeImmutable}
+     */
+    private function requiredDateWindow(InputInterface $input): array
+    {
+        $from = $this->dateOption($input, 'from');
+        $to = $this->dateOption($input, 'to');
+        if ($from > $to) {
+            throw new \InvalidArgumentException('--from cannot be later than --to.');
+        }
+
+        return [$from, $to];
+    }
+
+    private function dateOption(InputInterface $input, string $name): \DateTimeImmutable
+    {
+        $value = trim((string) $input->getOption($name));
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
+        if (false === $date || $date->format('Y-m-d') !== $value) {
+            throw new \InvalidArgumentException(sprintf('--%s must be a valid YYYY-MM-DD date.', $name));
+        }
+
+        return $date;
+    }
+
+    private function optionalStringOption(InputInterface $input, string $name): ?string
+    {
+        $value = trim((string) $input->getOption($name));
+
+        return '' === $value ? null : $value;
+    }
+
+    private function intOption(InputInterface $input, string $name, int $min, int $max): int
+    {
+        $value = (int) $input->getOption($name);
+
+        return max($min, min($max, $value));
+    }
+
+    private function mode(InputInterface $input): string
+    {
+        $modes = array_values(array_filter([
+            (bool) $input->getOption('dry-run') ? 'dry-run' : null,
+            (bool) $input->getOption('execute-inline') ? 'execute-inline' : null,
+        ]));
+
+        if (1 !== count($modes)) {
+            throw new \InvalidArgumentException('Choose exactly one action: --dry-run or --execute-inline.');
+        }
+
+        return $modes[0];
+    }
+}

--- a/site/src/Ingestion/Controller/Api/Verification/GetFinancialSummaryController.php
+++ b/site/src/Ingestion/Controller/Api/Verification/GetFinancialSummaryController.php
@@ -66,6 +66,23 @@ final class GetFinancialSummaryController extends AbstractController
                         type: 'object',
                     ),
                 ),
+                new OA\Property(
+                    property: 'marketplace_categories',
+                    type: 'array',
+                    items: new OA\Items(
+                        properties: [
+                            new OA\Property(property: 'source', type: 'string', example: 'ozon'),
+                            new OA\Property(property: 'category_group', type: 'string', example: 'Услуги доставки'),
+                            new OA\Property(property: 'category_name', type: 'string', example: 'Логистика'),
+                            new OA\Property(property: 'type', type: 'string', example: 'fee'),
+                            new OA\Property(property: 'direction', type: 'string', example: 'out'),
+                            new OA\Property(property: 'amount_minor', type: 'integer', example: -5374795),
+                            new OA\Property(property: 'tx_count', type: 'integer', example: 1418),
+                            new OA\Property(property: 'sort_order', type: 'integer', example: 400),
+                        ],
+                        type: 'object',
+                    ),
+                ),
             ],
             type: 'object',
         ),
@@ -112,6 +129,7 @@ final class GetFinancialSummaryController extends AbstractController
         return $this->json([
             'by_month' => array_map(static fn ($item): array => $item->toArray(), $summary['byMonth']),
             'by_category' => array_map(static fn ($item): array => $item->toArray(), $summary['byCategory']),
+            'marketplace_categories' => array_map(static fn ($item): array => $item->toArray(), $summary['marketplaceCategories']),
         ]);
     }
 

--- a/site/src/Ingestion/Entity/FinancialTransaction.php
+++ b/site/src/Ingestion/Entity/FinancialTransaction.php
@@ -219,6 +219,44 @@ class FinancialTransaction implements TenantOwnedInterface
         $this->updatedAt = new \DateTimeImmutable();
     }
 
+    /**
+     * @param array<string, mixed> $sourceData
+     * @param list<string> $keys
+     */
+    public function replaceSourceDataFields(array $sourceData, array $keys, ?string $description = null): bool
+    {
+        Assert::allString($keys);
+        Assert::allNotEmpty($keys);
+
+        $changed = false;
+        $nextSourceData = $this->sourceData;
+
+        foreach ($keys as $key) {
+            if (!array_key_exists($key, $sourceData)) {
+                continue;
+            }
+
+            if (!array_key_exists($key, $nextSourceData) || $nextSourceData[$key] !== $sourceData[$key]) {
+                $nextSourceData[$key] = $sourceData[$key];
+                $changed = true;
+            }
+        }
+
+        if (null !== $description && $this->description !== $description) {
+            $this->description = $description;
+            $changed = true;
+        }
+
+        if (!$changed) {
+            return false;
+        }
+
+        $this->sourceData = $nextSourceData;
+        $this->updatedAt = new \DateTimeImmutable();
+
+        return true;
+    }
+
     public function oldOccurredAt(): \DateTimeImmutable
     {
         return $this->oldOccurredAt ?? $this->occurredAt;

--- a/site/src/Ingestion/Facade/IngestionFacade.php
+++ b/site/src/Ingestion/Facade/IngestionFacade.php
@@ -6,6 +6,7 @@ namespace App\Ingestion\Facade;
 
 use App\Ingestion\Application\DTO\CoverageCellView;
 use App\Ingestion\Application\DTO\FinancialSummaryCategoryView;
+use App\Ingestion\Application\DTO\FinancialSummaryMarketplaceCategoryView;
 use App\Ingestion\Application\DTO\FinancialSummaryMonthView;
 use App\Ingestion\Application\DTO\FinancialTransactionView;
 use App\Ingestion\Application\DTO\IssueListItemView;
@@ -152,7 +153,7 @@ final readonly class IngestionFacade
     }
 
     /**
-     * @return array{byMonth: list<FinancialSummaryMonthView>, byCategory: list<FinancialSummaryCategoryView>}
+     * @return array{byMonth: list<FinancialSummaryMonthView>, byCategory: list<FinancialSummaryCategoryView>, marketplaceCategories: list<FinancialSummaryMarketplaceCategoryView>}
      */
     public function getFinancialSummary(
         string $companyId,
@@ -172,6 +173,7 @@ final readonly class IngestionFacade
                 $monthTo,
             ),
             'byCategory' => $this->financialSummaryQuery->byCategory($companyId, $shopRef, $yearTo, $monthTo),
+            'marketplaceCategories' => $this->financialSummaryQuery->marketplaceCategories($companyId, $shopRef, $yearTo, $monthTo),
         ];
     }
 

--- a/site/src/Ingestion/Infrastructure/Query/FinancialSummaryQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/FinancialSummaryQuery.php
@@ -6,8 +6,13 @@ namespace App\Ingestion\Infrastructure\Query;
 
 use App\Finance\Enum\PLFlow;
 use App\Ingestion\Application\DTO\FinancialSummaryCategoryView;
+use App\Ingestion\Application\DTO\FinancialSummaryMarketplaceCategoryView;
 use App\Ingestion\Application\DTO\FinancialSummaryMonthView;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\TransactionDirection;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Types\Types;
 use Webmozart\Assert\Assert;
 
 final class FinancialSummaryQuery
@@ -125,6 +130,90 @@ final class FinancialSummaryQuery
         );
     }
 
+    /**
+     * @return list<FinancialSummaryMarketplaceCategoryView>
+     */
+    public function marketplaceCategories(string $companyId, ?string $shopRef, int $year, int $month): array
+    {
+        Assert::uuid($companyId);
+        [$from, $toExclusive] = $this->monthBounds($year, $month);
+
+        $conditions = [
+            'ft.company_id = :companyId',
+            'ft.source = :source',
+            "ft.source_data->>'_ingestion_resource' = :resourceType",
+            'ft.occurred_at >= :from',
+            'ft.occurred_at < :toExclusive',
+        ];
+        $params = [
+            'companyId' => $companyId,
+            'source' => IngestSource::OZON->value,
+            'resourceType' => OzonResourceType::ACCRUAL_BY_DAY,
+            'from' => $from,
+            'toExclusive' => $toExclusive,
+            'outDirection' => TransactionDirection::OUT->value,
+        ];
+        $types = [
+            'from' => Types::DATETIME_IMMUTABLE,
+            'toExclusive' => Types::DATETIME_IMMUTABLE,
+        ];
+
+        if (null !== $shopRef && '' !== trim($shopRef)) {
+            $conditions[] = 'ft.shop_ref = :shopRef';
+            $params['shopRef'] = trim($shopRef);
+        }
+
+        $rows = $this->connection->fetchAllAssociative(
+            sprintf(
+                "WITH base AS (
+                    SELECT
+                        ft.source,
+                        COALESCE(NULLIF(ft.source_data->>'_ozon_category_group', ''), 'Без группы Ozon') AS category_group,
+                        COALESCE(NULLIF(ft.source_data->>'_ozon_category_label', ''), ft.description, ft.type) AS category_name,
+                        ft.type,
+                        ft.direction,
+                        ABS(ft.amount_minor::bigint) AS amount_minor,
+                        CASE
+                            WHEN ft.source_data->>'_ozon_category_sort_order' ~ '^[0-9]+$'
+                                THEN (ft.source_data->>'_ozon_category_sort_order')::int
+                            ELSE 9999
+                        END AS sort_order
+                    FROM ingest_financial_transactions ft
+                    WHERE %s
+                )
+                SELECT
+                    source,
+                    category_group,
+                    category_name,
+                    type,
+                    direction,
+                    COALESCE(SUM(CASE WHEN direction = :outDirection THEN -amount_minor ELSE amount_minor END), 0) AS amount_minor,
+                    COUNT(*) AS tx_count,
+                    MIN(sort_order) AS sort_order
+                FROM base
+                GROUP BY source, category_group, category_name, type, direction
+                ORDER BY sort_order ASC, category_group ASC, category_name ASC, type ASC, direction ASC",
+                implode(' AND ', $conditions),
+            ),
+            $params,
+            $types,
+        );
+
+        return array_map(
+            static fn (array $row): FinancialSummaryMarketplaceCategoryView => new FinancialSummaryMarketplaceCategoryView(
+                source: (string) $row['source'],
+                categoryGroup: (string) $row['category_group'],
+                categoryName: (string) $row['category_name'],
+                type: (string) $row['type'],
+                direction: (string) $row['direction'],
+                amountMinor: (int) $row['amount_minor'],
+                txCount: (int) $row['tx_count'],
+                sortOrder: (int) $row['sort_order'],
+            ),
+            $rows,
+        );
+    }
+
     private static function decimalToMinor(string $amount): int
     {
         $amount = trim($amount);
@@ -134,5 +223,16 @@ final class FinancialSummaryQuery
         $minor = ((int) $whole * 100) + (int) str_pad(substr($fraction, 0, 2), 2, '0');
 
         return $negative ? -$minor : $minor;
+    }
+
+    /**
+     * @return array{0: \DateTimeImmutable, 1: \DateTimeImmutable}
+     */
+    private function monthBounds(int $year, int $month): array
+    {
+        Assert::range($month, 1, 12);
+        $from = new \DateTimeImmutable(sprintf('%04d-%02d-01 00:00:00', $year, $month));
+
+        return [$from, $from->modify('first day of next month')];
     }
 }

--- a/site/tests/Functional/Ingestion/Controller/VerificationApiControllerTest.php
+++ b/site/tests/Functional/Ingestion/Controller/VerificationApiControllerTest.php
@@ -8,6 +8,7 @@ use App\Company\Entity\Company;
 use App\Company\Entity\User;
 use App\Finance\Entity\PLMonthlySnapshot;
 use App\Finance\Enum\PLFlow;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
 use App\Ingestion\Entity\FinancialTransaction;
 use App\Ingestion\Entity\IngestRawRecord;
 use App\Ingestion\Entity\NormalizationIssue;
@@ -69,6 +70,9 @@ final class VerificationApiControllerTest extends WebTestCaseBase
         self::assertSame(2345, $summary['by_month'][0]['expense_minor']);
         self::assertSame(10000, $summary['by_month'][0]['net_minor']);
         self::assertSame('income', $summary['by_category'][1]['flow']);
+        self::assertSame('Услуги доставки', $summary['marketplace_categories'][0]['category_group']);
+        self::assertSame('Логистика', $summary['marketplace_categories'][0]['category_name']);
+        self::assertSame(-200, $summary['marketplace_categories'][0]['amount_minor']);
     }
 
     public function testCoverageUsesTransactionOccurredDateForBackfillHeatmap(): void
@@ -376,7 +380,19 @@ final class VerificationApiControllerTest extends WebTestCaseBase
         $em->persist($raw);
         $em->persist($this->transaction($companyId, $raw->getId(), 'api-sale-1', 1000, TransactionType::SALE));
         $em->persist($this->transaction($companyId, $raw->getId(), 'api-refund-1', -300, TransactionType::REFUND));
-        $em->persist($this->transaction($companyId, $raw->getId(), 'api-commission-1', -200, TransactionType::COMMISSION));
+        $em->persist($this->transaction(
+            $companyId,
+            $raw->getId(),
+            'api-commission-1',
+            -200,
+            TransactionType::COMMISSION,
+            sourceData: [
+                '_ingestion_resource' => OzonResourceType::ACCRUAL_BY_DAY,
+                '_ozon_category_group' => 'Услуги доставки',
+                '_ozon_category_label' => 'Логистика',
+                '_ozon_category_sort_order' => 400,
+            ],
+        ));
         $em->persist(new NormalizationIssue(
             $companyId,
             $raw->getId(),
@@ -515,6 +531,8 @@ final class VerificationApiControllerTest extends WebTestCaseBase
         TransactionType $type,
         string $shopRef = 'shop-1',
         ?\DateTimeImmutable $occurredAt = null,
+        ?TransactionDirection $direction = null,
+        array $sourceData = [],
     ): FinancialTransaction {
         return new FinancialTransaction(
             companyId: $companyId,
@@ -525,10 +543,11 @@ final class VerificationApiControllerTest extends WebTestCaseBase
             externalUpdatedAt: new \DateTimeImmutable('2026-06-15 10:00:00+00:00'),
             operationGroupId: Uuid::uuid7()->toString(),
             type: $type,
-            direction: $amountMinor >= 0 ? TransactionDirection::IN : TransactionDirection::OUT,
+            direction: $direction ?? ($amountMinor >= 0 ? TransactionDirection::IN : TransactionDirection::OUT),
             money: Money::fromMinor($amountMinor, 'RUB'),
             occurredAt: $occurredAt ?? new \DateTimeImmutable('2026-06-15 10:00:00+00:00'),
             rawRecordId: $rawRecordId,
+            sourceData: $sourceData,
         );
     }
 

--- a/site/tests/Integration/Ingestion/Command/OzonAccrualRefreshCategoryMetadataCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/OzonAccrualRefreshCategoryMetadataCommandTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Command;
+
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\DTO\RawBatch;
+use App\Ingestion\Entity\FinancialTransaction;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+use App\Ingestion\Facade\RawStorageFacade;
+use App\Ingestion\Repository\FinancialTransactionRepository;
+use App\Shared\Domain\ValueObject\Money;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class OzonAccrualRefreshCategoryMetadataCommandTest extends IntegrationTestCase
+{
+    public function testDryRunDoesNotMutateAndExecuteRefreshesOnlyCategoryMetadata(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = Uuid::uuid7()->toString();
+        $record = $this->storeRawRecord(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            externalId: 'accrual-by-day:2026-06-01:2026-06-07',
+            fetchedAt: new \DateTimeImmutable('2026-06-08 03:00:00+00:00'),
+            rows: [$this->itemFeeRow()],
+        );
+        $record->markNormalizationDone();
+
+        $externalUpdatedAt = new \DateTimeImmutable('2026-06-08 03:00:00+00:00');
+        $this->em->persist(new FinancialTransaction(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            shopRef: $connectionRef,
+            source: IngestSource::OZON,
+            externalId: 'ozon:accrual-by-day:53675409101:item_fee:group-0:fee-0:type-1',
+            externalUpdatedAt: $externalUpdatedAt,
+            operationGroupId: Uuid::uuid5(Uuid::NAMESPACE_URL, sprintf('%s:ozon:accrual-by-day:%s', $companyId, '53675409101'))->toString(),
+            type: TransactionType::FEE,
+            direction: TransactionDirection::OUT,
+            money: Money::fromMinor(1234, 'RUB'),
+            occurredAt: new \DateTimeImmutable('2026-06-01 00:00:00+03:00'),
+            rawRecordId: $record->getId(),
+            description: 'Existing Ozon accrual transaction',
+            sourceData: [
+                '_ingestion_resource' => OzonResourceType::ACCRUAL_BY_DAY,
+                '_ozon_category_code' => 'ozon_unknown_1',
+                '_ozon_category_label' => 'Неизвестный type_id Ozon: 1',
+                '_ozon_category_group' => 'Неизвестные категории Ozon',
+                '_ozon_category_parent' => null,
+                '_ozon_category_sort_order' => 9000,
+                '_ozon_category_known' => false,
+                'preserved' => 'yes',
+            ],
+            sourceTz: 'Europe/Moscow',
+        ));
+        $this->em->flush();
+
+        $dryRunTester = $this->tester();
+        $dryRunExit = $dryRunTester->execute([
+            '--company-id' => $companyId,
+            '--from' => '2026-06-01',
+            '--to' => '2026-06-07',
+            '--shop-ref' => $connectionRef,
+            '--dry-run' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $dryRunExit, $dryRunTester->getDisplay());
+        $afterDryRun = $this->transaction($companyId);
+        $externalUpdatedAtBeforeExecute = $afterDryRun->getExternalUpdatedAt()->format(\DateTimeInterface::ATOM);
+        self::assertSame('Неизвестный type_id Ozon: 1', $afterDryRun->getSourceData()['_ozon_category_label']);
+        self::assertSame('Existing Ozon accrual transaction', $afterDryRun->getDescription());
+
+        $executeTester = $this->tester();
+        $executeExit = $executeTester->execute([
+            '--company-id' => $companyId,
+            '--from' => '2026-06-01',
+            '--to' => '2026-06-07',
+            '--shop-ref' => $connectionRef,
+            '--execute-inline' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $executeExit, $executeTester->getDisplay());
+        $updated = $this->transaction($companyId);
+        $sourceData = $updated->getSourceData();
+        self::assertSame(1234, $updated->getAmountMinor());
+        self::assertSame(TransactionDirection::OUT, $updated->getDirection());
+        self::assertSame($externalUpdatedAtBeforeExecute, $updated->getExternalUpdatedAt()->format(\DateTimeInterface::ATOM));
+        self::assertSame('yes', $sourceData['preserved']);
+        self::assertSame('ozon_acquiring', $sourceData['_ozon_category_code']);
+        self::assertSame('Эквайринг', $sourceData['_ozon_category_label']);
+        self::assertSame('Услуги партнёров', $sourceData['_ozon_category_group']);
+        self::assertSame(510, $sourceData['_ozon_category_sort_order']);
+        self::assertTrue($sourceData['_ozon_category_known']);
+        self::assertSame('Ozon: Эквайринг', $updated->getDescription());
+
+        $secondTester = $this->tester();
+        $secondExit = $secondTester->execute([
+            '--company-id' => $companyId,
+            '--from' => '2026-06-01',
+            '--to' => '2026-06-07',
+            '--shop-ref' => $connectionRef,
+            '--execute-inline' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $secondExit, $secondTester->getDisplay());
+        self::assertStringContainsString('Refreshed Ozon category metadata on 0 canonical transactions.', $secondTester->getDisplay());
+    }
+
+    private function tester(): CommandTester
+    {
+        $app = new Application(self::$kernel);
+
+        return new CommandTester($app->find('app:ingestion:ozon-accrual:refresh-category-metadata'));
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     */
+    private function storeRawRecord(
+        string $companyId,
+        string $connectionRef,
+        string $externalId,
+        \DateTimeImmutable $fetchedAt,
+        array $rows,
+    ): IngestRawRecord {
+        /** @var RawStorageFacade $facade */
+        $facade = self::getContainer()->get(RawStorageFacade::class);
+
+        return $facade->store(new RawBatch(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            shopRef: $connectionRef,
+            source: IngestSource::OZON,
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            externalId: $externalId,
+            syncJobId: Uuid::uuid7()->toString(),
+            fetchedAt: $fetchedAt,
+            rows: $rows,
+        ))[0];
+    }
+
+    private function transaction(string $companyId): FinancialTransaction
+    {
+        $this->em->clear();
+
+        /** @var FinancialTransactionRepository $repository */
+        $repository = self::getContainer()->get(FinancialTransactionRepository::class);
+        $transaction = $repository->findByNaturalKey(
+            $companyId,
+            IngestSource::OZON,
+            'ozon:accrual-by-day:53675409101:item_fee:group-0:fee-0:type-1',
+            TransactionType::FEE,
+        );
+
+        self::assertInstanceOf(FinancialTransaction::class, $transaction);
+
+        return $transaction;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function itemFeeRow(): array
+    {
+        return [
+            'accrual_id' => 53675409101,
+            'date' => '2026-06-01',
+            'unit_number' => '41774559-0885-1',
+            'accrued_category' => 'ITEM',
+            'item_fees' => [
+                'fees' => [[
+                    'fees' => [[
+                        'type_id' => 1,
+                        'name' => 'Acquiring',
+                        'accrued' => ['amount' => '-12.34', 'currency' => 'RUB'],
+                    ]],
+                ]],
+            ],
+        ];
+    }
+}

--- a/site/tests/Integration/Ingestion/Infrastructure/Query/VerificationQueriesTest.php
+++ b/site/tests/Integration/Ingestion/Infrastructure/Query/VerificationQueriesTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\Ingestion\Infrastructure\Query;
 
 use App\Finance\Entity\PLMonthlySnapshot;
 use App\Finance\Enum\PLFlow;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
 use App\Ingestion\Entity\FinancialTransaction;
 use App\Ingestion\Entity\IngestRawRecord;
 use App\Ingestion\Entity\NormalizationIssue;
@@ -520,6 +521,101 @@ final class VerificationQueriesTest extends IntegrationTestCase
         );
     }
 
+    public function testFinancialSummaryMarketplaceCategoriesUseOzonSourceDataAndShopFilter(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $raw = $this->rawRecord(
+            companyId: $companyId,
+            shopRef: 'shop-1',
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            fetchedAt: new \DateTimeImmutable('2026-06-15 10:00:00+00:00'),
+            externalId: 'marketplace-category-raw-1',
+        );
+        $otherShopRaw = $this->rawRecord(
+            companyId: $companyId,
+            shopRef: 'shop-2',
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            fetchedAt: new \DateTimeImmutable('2026-06-15 10:00:00+00:00'),
+            externalId: 'marketplace-category-raw-2',
+        );
+
+        $this->em->persist($raw);
+        $this->em->persist($otherShopRaw);
+        $this->em->persist($this->marketplaceCategoryTransaction(
+            companyId: $companyId,
+            rawRecordId: $raw->getId(),
+            externalId: 'ozon:accrual-by-day:1:delivery:type-29',
+            amountMinor: 1000,
+            type: TransactionType::FEE,
+            direction: TransactionDirection::OUT,
+            group: 'Услуги доставки',
+            label: 'Логистика',
+            sortOrder: 400,
+        ));
+        $this->em->persist($this->marketplaceCategoryTransaction(
+            companyId: $companyId,
+            rawRecordId: $raw->getId(),
+            externalId: 'ozon:accrual-by-day:2:delivery:type-29',
+            amountMinor: 500,
+            type: TransactionType::FEE,
+            direction: TransactionDirection::OUT,
+            group: 'Услуги доставки',
+            label: 'Логистика',
+            sortOrder: 400,
+        ));
+        $this->em->persist($this->marketplaceCategoryTransaction(
+            companyId: $companyId,
+            rawRecordId: $raw->getId(),
+            externalId: 'ozon:accrual-by-day:3:acquiring:type-1',
+            amountMinor: 120,
+            type: TransactionType::FEE,
+            direction: TransactionDirection::IN,
+            group: 'Услуги партнёров',
+            label: 'Эквайринг',
+            sortOrder: 510,
+        ));
+        $this->em->persist($this->marketplaceCategoryTransaction(
+            companyId: $companyId,
+            rawRecordId: $otherShopRaw->getId(),
+            externalId: 'ozon:accrual-by-day:4:delivery:type-29',
+            amountMinor: 999,
+            type: TransactionType::FEE,
+            direction: TransactionDirection::OUT,
+            group: 'Услуги доставки',
+            label: 'Логистика',
+            sortOrder: 400,
+            shopRef: 'shop-2',
+        ));
+        $this->em->persist($this->marketplaceCategoryTransaction(
+            companyId: $companyId,
+            rawRecordId: $raw->getId(),
+            externalId: 'ozon:legacy:ignored',
+            amountMinor: 777,
+            type: TransactionType::FEE,
+            direction: TransactionDirection::OUT,
+            group: 'Услуги доставки',
+            label: 'Логистика',
+            sortOrder: 400,
+            resourceType: 'ozon_finance_legacy',
+        ));
+        $this->em->flush();
+
+        /** @var FinancialSummaryQuery $query */
+        $query = self::getContainer()->get(FinancialSummaryQuery::class);
+        $categories = $query->marketplaceCategories($companyId, 'shop-1', 2026, 6);
+
+        self::assertCount(2, $categories);
+        self::assertSame('Логистика', $categories[0]->categoryName);
+        self::assertSame('Услуги доставки', $categories[0]->categoryGroup);
+        self::assertSame(TransactionType::FEE->value, $categories[0]->type);
+        self::assertSame(TransactionDirection::OUT->value, $categories[0]->direction);
+        self::assertSame(-1500, $categories[0]->amountMinor);
+        self::assertSame(2, $categories[0]->txCount);
+        self::assertSame('Эквайринг', $categories[1]->categoryName);
+        self::assertSame(120, $categories[1]->amountMinor);
+        self::assertSame(1, $categories[1]->txCount);
+    }
+
     private function rawRecord(
         string $companyId,
         string $shopRef,
@@ -542,6 +638,42 @@ final class VerificationQueriesTest extends IntegrationTestCase
             byteSize: 100,
             fetchedAt: $fetchedAt,
             syncJobId: $syncJobId ?? 'job-'.$externalId,
+        );
+    }
+
+    private function marketplaceCategoryTransaction(
+        string $companyId,
+        string $rawRecordId,
+        string $externalId,
+        int $amountMinor,
+        TransactionType $type,
+        TransactionDirection $direction,
+        string $group,
+        string $label,
+        int $sortOrder,
+        string $shopRef = 'shop-1',
+        string $resourceType = OzonResourceType::ACCRUAL_BY_DAY,
+    ): FinancialTransaction {
+        return new FinancialTransaction(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            shopRef: $shopRef,
+            source: IngestSource::OZON,
+            externalId: $externalId,
+            externalUpdatedAt: new \DateTimeImmutable('2026-06-15 10:00:00+00:00'),
+            operationGroupId: Uuid::uuid7()->toString(),
+            type: $type,
+            direction: $direction,
+            money: Money::fromMinor($amountMinor, 'RUB'),
+            occurredAt: new \DateTimeImmutable('2026-06-15 10:00:00+00:00'),
+            rawRecordId: $rawRecordId,
+            description: sprintf('Ozon: %s', $label),
+            sourceData: [
+                '_ingestion_resource' => $resourceType,
+                '_ozon_category_group' => $group,
+                '_ozon_category_label' => $label,
+                '_ozon_category_sort_order' => $sortOrder,
+            ],
         );
     }
 


### PR DESCRIPTION
## What changed

- Added `app:ingestion:ozon-accrual:refresh-category-metadata` to refresh Ozon category metadata on already normalized canonical transactions.
- Added `marketplace_categories` to the financial summary API response.
- Added a separate `Категории Ozon` block in the financial summary UI while leaving the existing P&L category table unchanged.
- Added focused coverage for metadata refresh, marketplace category grouping, and API response shape.

## Why

The existing UI category table is based on P&L monthly snapshots, so it still shows the legacy coarse categories. Ozon accrual normalization now has detailed category metadata in transaction `source_data`; this PR exposes it as a separate operational breakdown without changing P&L snapshot semantics.

## Validation

- `docker compose run --rm -T site-php-cli php bin/phpunit -c phpunit.xml --filter 'OzonAccrualRefreshCategoryMetadataCommandTest|VerificationQueriesTest::testFinancialSummaryMarketplaceCategoriesUseOzonSourceDataAndShopFilter|VerificationApiControllerTest::testVerificationEndpointsReturnExpectedPayloads'` — passed.
- `make site-test-unit` — passed (`1141` tests; existing warning/deprecation remain).
- `docker compose run --rm -T site-frontend npm run build` — passed.
- OpenAPI schema diff check — passed.
- `git diff --check` — passed.
- PHP CS fixer on changed PHP files — passed.

## Notes

Full repository `composer cs:check` is still red on pre-existing unrelated formatting issues across many files, so this PR only verified CS on the touched PHP files.