### PR TITLE
[codex] Add ingestion category taxonomy

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -74,6 +74,8 @@
 | `SyncJob` | Ingestion | `string $companyId` + Doctrine `company` filter ✅ |
 | `FinancialTransaction` | Ingestion | `string $companyId` + Doctrine `company` filter ✅ |
 | `SystemCounterparty` | Ingestion | global dictionary, no company filter |
+| `ExternalCategory` | Ingestion | global marketplace source dictionary, no company filter |
+| `ExternalCategoryMapping` | Ingestion | global mapping dictionary, no company filter |
 | `NormalizationIssue` | Ingestion | `string $companyId` + Doctrine `company` filter ✅ |
 | `PLDirtyPeriod` | Ingestion | `string $companyId` + Doctrine `company` filter ✅ |
 | `ProductImport` | Catalog | `string $companyId` ✅ |
@@ -121,6 +123,7 @@
 - Amounts are stored in minor units. Shared `Money` is signed and can represent positive, negative, or zero values; `TransactionDirection` (`IN`/`OUT`) remains the normalized flow classification. `Money` enforces one ISO-4217 currency per arithmetic operation.
 - `operationGroupId` groups decomposed transactions from one source operation for audit and sum-control checks.
 - `SystemCounterparty` is a global source dictionary (`source`, `name`, optional `inn`) for marketplace/system counterparties. It is not tenant-owned and is resolved by source during normalization; missing source rows leave `FinancialTransaction.counterpartyId = null` and are logged.
+- `ExternalCategory` and `ExternalCategoryMapping` are global Ingestion dictionaries for marketplace source categories (`source`, `resourceType`, `scope`, normalized external key). They are intentionally not tenant-owned: Ozon/WB category names and base mappings are source-level semantics, while admin changes affect future normalization and metadata refresh across companies.
 - `FinancialTransaction.listingId` and `listingSku` are nullable marketplace listing attribution fields. Missing or ambiguous listing matches must not block normalization.
 - `ListingResolverInterface` resolves source-specific listing attribution from `MappedTransaction.sourceData`; implementations are registered with `app.ingestion.listing_resolver`. `OzonListingResolver` uses supplier SKU (`offer_id`/`item_code`) and marketplace SKU fallbacks; WB resolver is intentionally a warning-only stub until WB ingestion mapping is defined.
 - `MarketplaceListingFacade` is the Ingestion-facing boundary to legacy Marketplace listing repositories. Ingestion must not query Marketplace entities directly outside this facade.

--- a/docs/reviews/review-feature-ingestion-category-taxonomy.md
+++ b/docs/reviews/review-feature-ingestion-category-taxonomy.md
@@ -1,0 +1,222 @@
+# Проверенное ревью: `feature/ingestion-category-taxonomy` / PR #2042
+
+**Дата:** 2026-06-25  
+**Ветка:** `feature/ingestion-category-taxonomy`  
+**PR:** #2042 `[codex] Add ingestion category taxonomy` -> `master`  
+**Статус PR на момент первичной проверки:** открыт, draft, merge state `CLEAN`  
+**Первичный объем diff:** 27 файлов, +2424 / -17
+
+## Статус после исправлений
+
+После первичного ревью в этой ветке исправлены блокирующие и P2-замечания:
+
+- discover больше не создает duplicate taxonomy identity в одном запуске;
+- dry-run refresh metadata не записывает unknown taxonomy categories;
+- zero-amount fee строки не попадают в discovery queue;
+- resolver использует bulk-cache active mappings на один preview run;
+- legacy строки financial summary снова используют fallback на `description/type`;
+- mapping-based категории сохраняют static `parentLabel`;
+- Admin list показывает `new` категории перед `mapped` до применения `LIMIT`;
+- failed refresh row очищает Doctrine UnitOfWork после rollback.
+
+Покрытие добавлено в integration/unit checks, актуальный список проверок см. в финальном PR update/comment.
+
+## Итог
+
+Идея PR правильная: вынести категории затрат маркетплейсов в глобальную taxonomy Ingestion и дать Admin workflow вместо постоянной ручной правки кода и prod-команд.
+
+Первичная версия требовала исправлений P1/P2 ниже. Эти findings оставлены в отчете как история ревью; актуальная ветка содержит фиксы по ним.
+
+Проверка была review-only: код не менял, тесты не запускал.
+
+## Findings
+
+### P1: Discover может создать дубликаты `ExternalCategory` в одном запуске
+
+**Файлы:**
+
+- `site/src/Ingestion/Application/Action/DiscoverExternalCategoriesAction.php:48`
+- `site/src/Ingestion/Application/Action/DiscoverExternalCategoriesAction.php:62`
+- `site/src/Ingestion/Application/Action/DiscoverExternalCategoriesAction.php:69`
+- `site/src/Ingestion/Application/Action/DiscoverExternalCategoriesAction.php:107`
+- `site/migrations/Version20260625110000.php:27`
+
+`DiscoverExternalCategoriesAction` группирует строки по `type_id`, `label`, `component`, но сохраняет категорию по более грубой identity:
+
+```text
+source + resource_type + scope + normalized_key
+```
+
+`scopeFromComponent()` схлопывает разные компоненты в один scope, например все `delivery:*` -> `delivery`. `normalized_key` для type_id будет одинаковым, например `type:32`.
+
+Если в одном discover run попадут две строки с одинаковым type_id/scope, но разными label/component, обе могут пройти `findByIdentity()` как отсутствующие, потому что первая новая entity еще не `flush()`-нута. На финальном `flush()` сработает уникальный индекс `uniq_ingest_ext_category_identity`.
+
+**Последствие:** Admin нажимает Discover, операция падает целиком, новые категории не появляются.
+
+**Как исправить:** добавить in-memory cache по identity внутри `DiscoverExternalCategoriesAction`, аналогично `recordedUnknowns` в `OzonAccrualCategoryTaxonomyResolver`, или flush/clear по батчам с безопасной обработкой duplicate race.
+
+### P1: Dry-run refresh metadata не является side-effect-free
+
+**Файлы:**
+
+- `site/src/Ingestion/Application/Action/RefreshOzonAccrualCategoryMetadataAction.php:147`
+- `site/src/Ingestion/Application/Source/Ozon/OzonAccrualByDayMapper.php:45`
+- `site/src/Ingestion/Application/Source/Ozon/OzonAccrualCategoryTaxonomyResolver.php:201`
+
+В `RefreshOzonAccrualCategoryMetadataAction::refresh()` флаг `dryRun` защищает транзакцию, обновление транзакций и `flush()`. Но в dry-run все равно вызывается:
+
+```php
+$mappedTransactions = $this->mapper->map($rawRecord, $rows);
+```
+
+А `OzonAccrualByDayMapper::map()` вызывает preview с `recordUnknownCategories: true`. Это может привести к `entityManager->persist($category)` в resolver.
+
+Да, сам `RefreshOzonAccrualCategoryMetadataAction` в dry-run не вызывает `flush()`. Но новая entity остается в UnitOfWork. Любой последующий `flush()` в том же request/worker может записать эту категорию в БД.
+
+**Последствие:** dry-run может неявно мутировать taxonomy.
+
+**Как исправить:** прокинуть флаг записи unknown categories в mapper/preview и для dry-run передавать `false`. Дополнительно можно сделать dedicated preview path без side effects.
+
+### P2: `FinancialSummaryQuery` схлопывает legacy-строки без category label
+
+**Файл:** `site/src/Ingestion/Infrastructure/Query/FinancialSummaryQuery.php:171`
+
+Сейчас `category_name` считается так:
+
+```sql
+COALESCE(NULLIF(ft.source_data->>'_ozon_category_label', ''), 'Неклассифицированная категория Ozon')
+```
+
+До изменения fallback был более детальный: `description` / `type`. Поэтому старые транзакции, где еще нет `_ozon_category_label`, теперь попадают в одну строку UI-отчета.
+
+**Последствие:** в финансовой сводке может исчезнуть детализация по старым accrual-транзакциям до refresh metadata. Это как раз похоже на проблему, которую видели в UI: много технических или обобщенных строк.
+
+**Как исправить:** оставить новый taxonomy label для новых/обновленных строк, но для legacy-строк без label использовать безопасный fallback, который не схлопывает все в одну строку. Например:
+
+```sql
+COALESCE(NULLIF(_ozon_category_label, ''), NULLIF(ft.description, ''), ft.type)
+```
+
+Либо отдельно фильтровать только технические `Ozon accrual ...` descriptions и заменять их на понятный taxonomy fallback.
+
+### P2: Zero-amount fee строки записывают unknown categories
+
+**Файлы:**
+
+- `site/src/Ingestion/Application/Source/Ozon/OzonAccrualByDayPreviewMapper.php:267`
+- `site/src/Ingestion/Application/Source/Ozon/OzonAccrualByDayPreviewMapper.php:275`
+- `site/src/Ingestion/Application/Source/Ozon/OzonAccrualByDayPreviewMapper.php:436`
+- `site/src/Ingestion/Application/Source/Ozon/OzonAccrualByDayPreviewMapper.php:444`
+
+В `collectDeliveryServices()` и `collectTypedFee()` категория резолвится до проверки суммы на `0`.
+
+**Последствие:** Ozon может прислать неизвестный type_id с `accrued = 0`. Транзакция не создается, но неизвестная категория попадает в taxonomy/admin queue. Это добавит шум без финансового эффекта.
+
+**Как исправить:** сначала посчитать amount и выйти при `0`, потом резолвить/записывать категорию.
+
+### P2: Resolver делает N+1 запросы на hot path нормализации
+
+**Файлы:**
+
+- `site/src/Ingestion/Application/Source/Ozon/OzonAccrualCategoryTaxonomyResolver.php:54`
+- `site/src/Ingestion/Application/Source/Ozon/OzonAccrualCategoryTaxonomyResolver.php:60`
+- `site/src/Ingestion/Repository/ExternalCategoryMappingRepository.php:44`
+
+Для каждой typed fee строки resolver проверяет mapping по нескольким candidate keys:
+
+- scope + `type:<id>`
+- `any` + `type:<id>`
+- scope + `name:<name>`
+- `any` + `name:<name>`
+
+Каждая проверка идет через repository query. На raw record с тысячами fee строк это может дать тысячи SQL-запросов только на маппинг категорий.
+
+**Последствие:** нормализация accrual by-day станет тяжелее и может просесть на больших периодах.
+
+**Как исправить:** загрузить active mappings для `(source=ozon, resource=accrual_by_day)` один раз в in-memory map и резолвить по ключу без запроса на каждую строку. Cache должен быть request/message-scoped или invalidation-aware, чтобы не повторить прошлую проблему со stale resolver dictionary.
+
+### P3: `forField()` и seed не покрывают `SCOPE_FIELD`
+
+**Файлы:**
+
+- `site/src/Ingestion/Application/Source/Ozon/OzonAccrualCategoryTaxonomyResolver.php:37`
+- `site/src/Ingestion/Application/Source/Ozon/OzonAccrualCategoryTaxonomyResolver.php:44`
+- `site/src/Ingestion/Application/Action/SeedExternalCategoryMappingsAction.php:44`
+- `site/src/Ingestion/Application/Action/SeedExternalCategoryMappingsAction.php:98`
+
+`forField()` принимает `recordUnknown`, но не использует его. Seed action создает только `SCOPE_ANY` identities с `type:` / `name:` keys, но не создает `SCOPE_FIELD` / `field:` mappings.
+
+**Последствие:** admin override через taxonomy работает для typed fee, но не работает из коробки для field-derived категорий (`sale_amount`, `commission`, `bonus`). Сейчас они фактически остаются на static fallback.
+
+**Как исправить:** либо убрать неиспользуемый `recordUnknown` и явно документировать, что field categories статические, либо добавить seed/discovery для `SCOPE_FIELD`.
+
+### P3: Non-active mapping semantics надо явно определить
+
+**Файлы:**
+
+- `site/src/Ingestion/Application/Action/DiscoverExternalCategoriesAction.php:86`
+- `site/src/Ingestion/Application/Action/DiscoverExternalCategoriesAction.php:87`
+- `site/src/Ingestion/Repository/ExternalCategoryMappingRepository.php:35`
+- `site/src/Ingestion/Repository/ExternalCategoryMappingRepository.php:44`
+
+Исходное ревью утверждало, что категория "застревает навсегда", если есть non-active mapping. Я это понижаю: в Admin есть update mapping action, который может поменять статус существующего mapping.
+
+Но поведение все равно нужно зафиксировать. Discover использует `findByCategory()` без фильтра по статусу и поэтому не auto-create-ит ACTIVE mapping, если уже есть `DISABLED` или `NEEDS_REVIEW`. Runtime resolver читает только ACTIVE mappings через `findActiveByIdentity()`.
+
+**Последствие:** если это намеренно, Admin UI/status должен показывать такие категории как требующие ручного решения. Если не намеренно, discover будет считать категорию обработанной, а runtime продолжит видеть ее как unmapped.
+
+**Как исправить:** выбрать контракт:
+
+- non-active mapping блокирует auto-map намеренно: добавить явный статус/счетчик в Admin и не считать как auto-mapped;
+- non-active mapping не должен блокировать auto-map: использовать `findActiveByCategory()` или переактивировать mapping по static default.
+
+### P3: Дублируются SQL predicate и normalization logic
+
+**Файлы:**
+
+- `site/src/Ingestion/Application/Action/DiscoverExternalCategoriesAction.php:129`
+- `site/src/Ingestion/Infrastructure/Query/ExternalCategoryAdminQuery.php:106`
+- `site/src/Ingestion/Application/Source/Ozon/OzonAccrualCategoryTaxonomyResolver.php:97`
+
+Predicate "unclassified Ozon accrual" продублирован в discover action и admin query. Он завязан на человекочитаемые строки:
+
+- `Неизвестные категории Ozon`
+- `Требует классификации`
+- `Без группы Ozon`
+- `LIKE 'Неизвест%'`
+- `LIKE 'Ozon accrual%'`
+
+Также normalization key logic частично живет в resolver и рядом со static category logic.
+
+**Последствие:** при следующем переименовании группы или изменении формата description один экран может считать строку unclassified, а другой уже нет.
+
+**Как исправить:** вынести predicate в один query helper/specification или, лучше, опираться на стабильные поля (`_ozon_category_known`, `_ingestion_resource`, `_ingestion_type_id`) вместо текстовых labels.
+
+## Refuted / adjusted
+
+- **"Non-active mapping stuck forever"**: частично подтверждено, но формулировка завышена. Admin может изменить существующий mapping. Проблема не в невозможности исправить, а в неявном контракте между discover и runtime resolver.
+- **`known` checkbox parsing**: не подтверждено. Controller сравнивает с `'1'`, template передает `value="1"`, это корректно.
+- **Control sum path records unknown categories**: не подтверждено для текущего кода. `controlSumForRawRecord()` вызывает preview без `recordUnknownCategories: true`.
+
+## Рекомендуемый порядок исправлений
+
+1. Исправить duplicate identity в `DiscoverExternalCategoriesAction`.
+2. Сделать dry-run refresh действительно read-only.
+3. Вернуть безопасный fallback в `FinancialSummaryQuery`, чтобы legacy rows не схлопывались.
+4. Перенести zero-amount check до category resolve.
+5. Добавить request/message-scoped cache активных mappings в resolver.
+6. Решить контракт для `SCOPE_FIELD` и non-active mappings.
+7. Вынести unclassified predicate в одно место.
+
+## Проверки ревью
+
+Выполнено:
+
+- `pwd && git status --short && git branch --show-current`
+- `git diff --stat master...HEAD`
+- `gh pr view 2042 --json number,title,state,isDraft,headRefName,baseRefName,mergeStateStatus,url`
+- ручная проверка релевантных файлов с line numbers
+
+Не выполнялось:
+
+- unit/integration tests, потому что задача была review report без изменения production code.

--- a/site/migrations/Version20260625110000.php
+++ b/site/migrations/Version20260625110000.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260625110000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add Ingestion external category taxonomy tables';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        $this->abortIf(
+            !$platform instanceof PostgreSQLPlatform,
+            sprintf('Migration %s supports only PostgreSQL; got platform "%s".', self::class, $platform::class),
+        );
+
+        $this->addSql('CREATE TABLE ingest_external_categories (id UUID NOT NULL, source VARCHAR(64) NOT NULL, resource_type VARCHAR(100) NOT NULL, scope VARCHAR(64) NOT NULL, external_type_id VARCHAR(100) DEFAULT NULL, external_name VARCHAR(255) DEFAULT NULL, normalized_key VARCHAR(512) NOT NULL, status VARCHAR(32) NOT NULL, first_seen_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, last_seen_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, seen_count INT DEFAULT 1 NOT NULL, created_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE UNIQUE INDEX uniq_ingest_ext_category_identity ON ingest_external_categories (source, resource_type, scope, normalized_key)');
+        $this->addSql('CREATE INDEX idx_ingest_ext_category_status ON ingest_external_categories (status, last_seen_at)');
+        $this->addSql('CREATE INDEX idx_ingest_ext_category_source_resource ON ingest_external_categories (source, resource_type)');
+
+        $this->addSql('CREATE TABLE ingest_external_category_mappings (id UUID NOT NULL, external_category_id UUID NOT NULL, canonical_code VARCHAR(100) NOT NULL, canonical_label VARCHAR(255) NOT NULL, canonical_group VARCHAR(255) NOT NULL, transaction_type VARCHAR(64) NOT NULL, default_direction VARCHAR(8) DEFAULT NULL, sort_order INT DEFAULT 9000 NOT NULL, known BOOLEAN DEFAULT true NOT NULL, status VARCHAR(32) NOT NULL, updated_by UUID DEFAULT NULL, created_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE UNIQUE INDEX uniq_ingest_ext_category_mapping_category ON ingest_external_category_mappings (external_category_id)');
+        $this->addSql('CREATE INDEX idx_ingest_ext_category_mapping_status ON ingest_external_category_mappings (status, updated_at)');
+        $this->addSql('ALTER TABLE ingest_external_category_mappings ADD CONSTRAINT fk_ingest_ext_category_mapping_category FOREIGN KEY (external_category_id) REFERENCES ingest_external_categories (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        $this->abortIf(
+            !$platform instanceof PostgreSQLPlatform,
+            sprintf('Migration %s supports only PostgreSQL; got platform "%s".', self::class, $platform::class),
+        );
+
+        $this->addSql('DROP TABLE ingest_external_category_mappings');
+        $this->addSql('DROP TABLE ingest_external_categories');
+    }
+}

--- a/site/src/Admin/Controller/MarketplaceCategoryTaxonomyController.php
+++ b/site/src/Admin/Controller/MarketplaceCategoryTaxonomyController.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\Controller;
+
+use App\Ingestion\Application\Action\DiscoverExternalCategoriesAction;
+use App\Ingestion\Application\Action\RefreshOzonAccrualCategoryMetadataAction;
+use App\Ingestion\Application\Action\SeedExternalCategoryMappingsAction;
+use App\Ingestion\Application\Action\UpdateExternalCategoryMappingAction;
+use App\Ingestion\Enum\ExternalCategoryMappingStatus;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\TransactionType;
+use App\Ingestion\Infrastructure\Query\ExternalCategoryAdminQuery;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Webmozart\Assert\Assert;
+
+#[Route('/admin/marketplace/category-taxonomy', name: 'admin_marketplace_category_taxonomy_')]
+#[IsGranted('ROLE_ADMIN')]
+final class MarketplaceCategoryTaxonomyController extends AbstractController
+{
+    #[Route('', name: 'index', methods: ['GET'])]
+    public function index(ExternalCategoryAdminQuery $query): Response
+    {
+        return $this->render('admin/marketplace/category_taxonomy/index.html.twig', [
+            'status_summary' => $query->statusSummary(),
+            'unclassified' => $query->unclassifiedOzonAccrualTransactions(),
+            'latest_categories' => $query->latestCategories(),
+            'transaction_types' => TransactionType::cases(),
+            'mapping_statuses' => ExternalCategoryMappingStatus::cases(),
+            'last_refresh' => null,
+        ]);
+    }
+
+    #[Route('/seed-defaults', name: 'seed_defaults', methods: ['POST'])]
+    public function seedDefaults(
+        Request $request,
+        SeedExternalCategoryMappingsAction $seedDefaults,
+    ): Response {
+        $this->validateCsrf($request, 'admin_marketplace_category_taxonomy_seed_defaults');
+
+        try {
+            $stats = $seedDefaults(IngestSource::OZON);
+            $this->addFlash('success', sprintf(
+                'Базовые Ozon-маппинги обновлены: создано категорий %d, создано маппингов %d, уже существовало %d.',
+                $stats['categoriesCreated'],
+                $stats['mappingsCreated'],
+                $stats['mappingsExisting'],
+            ));
+        } catch (\Throwable $exception) {
+            $this->addFlash('error', $exception->getMessage());
+        }
+
+        return $this->redirectToRoute('admin_marketplace_category_taxonomy_index');
+    }
+
+    #[Route('/discover', name: 'discover', methods: ['POST'])]
+    public function discover(
+        Request $request,
+        DiscoverExternalCategoriesAction $discoverExternalCategories,
+    ): Response {
+        $this->validateCsrf($request, 'admin_marketplace_category_taxonomy_discover');
+
+        try {
+            $stats = $discoverExternalCategories(IngestSource::OZON, $this->intValue($request->request->get('limit'), 500, 1, 5000));
+            $this->addFlash('success', sprintf(
+                'Discovery завершен: просканировано %d, создано категорий %d, автомаппинг %d, без маппинга %d.',
+                $stats['scanned'],
+                $stats['categoriesCreated'],
+                $stats['autoMapped'],
+                $stats['unmapped'],
+            ));
+        } catch (\Throwable $exception) {
+            $this->addFlash('error', $exception->getMessage());
+        }
+
+        return $this->redirectToRoute('admin_marketplace_category_taxonomy_index');
+    }
+
+    #[Route('/refresh-ozon-metadata', name: 'refresh_ozon_metadata', methods: ['POST'])]
+    public function refreshOzonMetadata(
+        Request $request,
+        ExternalCategoryAdminQuery $query,
+        RefreshOzonAccrualCategoryMetadataAction $refreshMetadata,
+    ): Response {
+        $this->validateCsrf($request, 'admin_marketplace_category_taxonomy_refresh_ozon_metadata');
+
+        try {
+            $companyId = trim((string) $request->request->get('company_id', ''));
+            Assert::uuid($companyId, 'Company ID должен быть UUID.');
+
+            $from = $this->dateValue((string) $request->request->get('from', ''));
+            $to = $this->dateValue((string) $request->request->get('to', ''));
+            if ($from > $to) {
+                throw new \InvalidArgumentException('Дата from не может быть позже даты to.');
+            }
+
+            $mode = (string) $request->request->get('mode', 'dry-run');
+            if (!in_array($mode, ['dry-run', 'execute'], true)) {
+                throw new \InvalidArgumentException('Некорректный режим refresh.');
+            }
+
+            $result = $refreshMetadata(
+                companyId: $companyId,
+                from: $from,
+                to: $to,
+                shopRef: $this->optionalString($request->request->get('shop_ref')),
+                limit: $this->intValue($request->request->get('limit'), 100, 1, 500),
+                dryRun: 'dry-run' === $mode,
+            );
+
+            $updated = array_sum(array_map(static fn (array $row): int => (int) $row['updated'], $result['results']));
+            $failed = count(array_filter($result['results'], static fn (array $row): bool => 'error' === $row['status']));
+            $this->addFlash(
+                0 === $failed ? 'success' : 'error',
+                sprintf(
+                    '%s refresh metadata: raw records %d, updated %d, failed %d.',
+                    'dry-run' === $mode ? 'Dry-run' : 'Execute',
+                    count($result['rawRecords']),
+                    $updated,
+                    $failed,
+                ),
+            );
+
+            return $this->render('admin/marketplace/category_taxonomy/index.html.twig', [
+                'status_summary' => $query->statusSummary(),
+                'unclassified' => $query->unclassifiedOzonAccrualTransactions(),
+                'latest_categories' => $query->latestCategories(),
+                'transaction_types' => TransactionType::cases(),
+                'mapping_statuses' => ExternalCategoryMappingStatus::cases(),
+                'last_refresh' => $result + ['mode' => $mode],
+            ]);
+        } catch (\Throwable $exception) {
+            $this->addFlash('error', $exception->getMessage());
+
+            return $this->redirectToRoute('admin_marketplace_category_taxonomy_index');
+        }
+    }
+
+    #[Route('/mapping/{id}', name: 'update_mapping', methods: ['POST'])]
+    public function updateMapping(
+        string $id,
+        Request $request,
+        UpdateExternalCategoryMappingAction $updateMapping,
+    ): Response {
+        $this->validateCsrf($request, sprintf('admin_marketplace_category_taxonomy_update_mapping_%s', $id));
+
+        try {
+            Assert::uuid($id, 'Category ID должен быть UUID.');
+            $updateMapping(
+                categoryId: $id,
+                canonicalCode: trim((string) $request->request->get('canonical_code', '')),
+                canonicalLabel: trim((string) $request->request->get('canonical_label', '')),
+                canonicalGroup: trim((string) $request->request->get('canonical_group', '')),
+                transactionType: TransactionType::from((string) $request->request->get('transaction_type')),
+                sortOrder: $this->intValue($request->request->get('sort_order'), 9000, 1, 100000),
+                status: ExternalCategoryMappingStatus::from((string) $request->request->get('mapping_status')),
+                known: '1' === (string) $request->request->get('known', '0'),
+            );
+            $this->addFlash('success', 'Маппинг категории сохранен. Запустите refresh metadata для нужного периода.');
+        } catch (\Throwable $exception) {
+            $this->addFlash('error', $exception->getMessage());
+        }
+
+        return $this->redirectToRoute('admin_marketplace_category_taxonomy_index');
+    }
+
+    private function validateCsrf(Request $request, string $tokenId): void
+    {
+        if (!$this->isCsrfTokenValid($tokenId, (string) $request->request->get('_token', ''))) {
+            throw $this->createAccessDeniedException('Недействительный CSRF токен.');
+        }
+    }
+
+    private function dateValue(string $value): \DateTimeImmutable
+    {
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', trim($value));
+        if (false === $date || $date->format('Y-m-d') !== trim($value)) {
+            throw new \InvalidArgumentException('Дата должна быть в формате YYYY-MM-DD.');
+        }
+
+        return $date;
+    }
+
+    private function intValue(mixed $value, int $default, int $min, int $max): int
+    {
+        if (null === $value || '' === trim((string) $value)) {
+            return $default;
+        }
+
+        return max($min, min($max, (int) $value));
+    }
+
+    private function optionalString(mixed $value): ?string
+    {
+        $value = trim((string) $value);
+
+        return '' === $value ? null : $value;
+    }
+}

--- a/site/src/Ingestion/Application/Action/DiscoverExternalCategoriesAction.php
+++ b/site/src/Ingestion/Application/Action/DiscoverExternalCategoriesAction.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Action;
+
+use App\Ingestion\Application\Source\Ozon\OzonAccrualCategory;
+use App\Ingestion\Application\Source\Ozon\OzonAccrualCategoryTaxonomyResolver;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Entity\ExternalCategory;
+use App\Ingestion\Entity\ExternalCategoryMapping;
+use App\Ingestion\Enum\ExternalCategoryMappingStatus;
+use App\Ingestion\Enum\ExternalCategoryStatus;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Repository\ExternalCategoryMappingRepository;
+use App\Ingestion\Repository\ExternalCategoryRepository;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class DiscoverExternalCategoriesAction
+{
+    public function __construct(
+        private Connection $connection,
+        private ExternalCategoryRepository $categoryRepository,
+        private ExternalCategoryMappingRepository $mappingRepository,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    /**
+     * @return array{scanned: int, categoriesCreated: int, categoriesSeen: int, autoMapped: int, unmapped: int}
+     */
+    public function __invoke(IngestSource $source = IngestSource::OZON, int $limit = 500): array
+    {
+        if (IngestSource::OZON !== $source) {
+            throw new \InvalidArgumentException(sprintf('External category discovery is not implemented for source "%s".', $source->value));
+        }
+
+        $limit = max(1, min(5000, $limit));
+        $stats = [
+            'scanned' => 0,
+            'categoriesCreated' => 0,
+            'categoriesSeen' => 0,
+            'autoMapped' => 0,
+            'unmapped' => 0,
+        ];
+
+        foreach ($this->unknownOzonAccrualRows($limit) as $row) {
+            ++$stats['scanned'];
+
+            $typeId = $this->optionalString($row['type_id'] ?? null);
+            $typeName = $this->extractOzonTypeName($this->optionalString($row['label'] ?? null));
+            $normalizedKey = OzonAccrualCategoryTaxonomyResolver::typeKey($typeId)
+                ?? OzonAccrualCategoryTaxonomyResolver::nameKey($typeName);
+
+            if (null === $normalizedKey) {
+                ++$stats['unmapped'];
+                continue;
+            }
+
+            $scope = $this->scopeFromComponent($this->optionalString($row['component'] ?? null));
+            $externalCategory = $this->categoryRepository->findByIdentity(
+                IngestSource::OZON,
+                OzonResourceType::ACCRUAL_BY_DAY,
+                $scope,
+                $normalizedKey,
+            );
+
+            if (!$externalCategory instanceof ExternalCategory) {
+                $externalCategory = new ExternalCategory(
+                    source: IngestSource::OZON,
+                    resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+                    scope: $scope,
+                    normalizedKey: $normalizedKey,
+                    externalTypeId: $typeId,
+                    externalName: $typeName,
+                    status: ExternalCategoryStatus::NEW,
+                );
+                $this->entityManager->persist($externalCategory);
+                ++$stats['categoriesCreated'];
+            } else {
+                $externalCategory->markSeen($typeId, $typeName);
+                ++$stats['categoriesSeen'];
+            }
+
+            $mappedCategory = OzonAccrualCategory::findByTypeId($typeId) ?? OzonAccrualCategory::findByOzonName($typeName);
+            $existingMapping = $this->mappingRepository->findByCategory($externalCategory);
+            if ($mappedCategory instanceof OzonAccrualCategory && null === $existingMapping) {
+                $this->entityManager->persist(new ExternalCategoryMapping(
+                    externalCategory: $externalCategory,
+                    canonicalCode: $mappedCategory->code,
+                    canonicalLabel: $mappedCategory->label,
+                    canonicalGroup: $mappedCategory->group,
+                    transactionType: $mappedCategory->transactionType,
+                    sortOrder: $mappedCategory->sortOrder,
+                    known: true,
+                    status: ExternalCategoryMappingStatus::ACTIVE,
+                ));
+                ++$stats['autoMapped'];
+            }
+
+            if (!$mappedCategory instanceof OzonAccrualCategory) {
+                ++$stats['unmapped'];
+            }
+        }
+
+        $this->entityManager->flush();
+
+        return $stats;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function unknownOzonAccrualRows(int $limit): array
+    {
+        return $this->connection->fetchAllAssociative(
+            sprintf(
+                "SELECT
+                    ft.source_data->>'_ingestion_type_id' AS type_id,
+                    ft.source_data->>'_ozon_category_label' AS label,
+                    ft.source_data->>'_ingestion_component' AS component,
+                    COUNT(*) AS tx_count,
+                    MIN(ft.occurred_at) AS first_seen_at,
+                    MAX(ft.occurred_at) AS last_seen_at
+                 FROM ingest_financial_transactions ft
+                 WHERE ft.source = :source
+                   AND ft.source_data->>'_ingestion_resource' = :resourceType
+                   AND (
+                        ft.source_data->>'_ozon_category_known' = 'false'
+                        OR NULLIF(ft.source_data->>'_ozon_category_group', '') IS NULL
+                        OR ft.source_data->>'_ozon_category_group' IN ('Неизвестные категории Ozon', 'Требует классификации', 'Без группы Ozon')
+                        OR ft.source_data->>'_ozon_category_label' LIKE 'Неизвест%%'
+                        OR ft.source_data->>'_ozon_category_label' LIKE 'Ozon accrual%%'
+                   )
+                   AND NULLIF(ft.source_data->>'_ingestion_type_id', '') IS NOT NULL
+                 GROUP BY type_id, label, component
+                 ORDER BY MAX(ft.occurred_at) DESC, COUNT(*) DESC
+                 LIMIT %d",
+                $limit,
+            ),
+            [
+                'source' => IngestSource::OZON->value,
+                'resourceType' => OzonResourceType::ACCRUAL_BY_DAY,
+            ],
+        );
+    }
+
+    private function extractOzonTypeName(?string $label): ?string
+    {
+        if (null === $label) {
+            return null;
+        }
+
+        if (1 === preg_match('/^Неизвестная категория Ozon:\s*(.+)$/u', $label, $matches)) {
+            return trim($matches[1]);
+        }
+
+        return null;
+    }
+
+    private function scopeFromComponent(?string $component): string
+    {
+        $component = (string) $component;
+
+        return match (true) {
+            str_starts_with($component, 'delivery:') => OzonAccrualCategoryTaxonomyResolver::SCOPE_DELIVERY,
+            str_starts_with($component, 'item_fee:') => OzonAccrualCategoryTaxonomyResolver::SCOPE_ITEM,
+            str_starts_with($component, 'non_item_fee') => OzonAccrualCategoryTaxonomyResolver::SCOPE_NON_ITEM,
+            str_starts_with($component, 'container_fee') => OzonAccrualCategoryTaxonomyResolver::SCOPE_CONTAINER,
+            default => OzonAccrualCategoryTaxonomyResolver::SCOPE_ANY,
+        };
+    }
+
+    private function optionalString(mixed $value): ?string
+    {
+        $value = trim((string) $value);
+
+        return '' === $value ? null : $value;
+    }
+}

--- a/site/src/Ingestion/Application/Action/DiscoverExternalCategoriesAction.php
+++ b/site/src/Ingestion/Application/Action/DiscoverExternalCategoriesAction.php
@@ -44,6 +44,8 @@ final readonly class DiscoverExternalCategoriesAction
             'autoMapped' => 0,
             'unmapped' => 0,
         ];
+        $categoriesByIdentity = [];
+        $mappingKnownByCategoryId = [];
 
         foreach ($this->unknownOzonAccrualRows($limit) as $row) {
             ++$stats['scanned'];
@@ -59,33 +61,45 @@ final readonly class DiscoverExternalCategoriesAction
             }
 
             $scope = $this->scopeFromComponent($this->optionalString($row['component'] ?? null));
-            $externalCategory = $this->categoryRepository->findByIdentity(
-                IngestSource::OZON,
-                OzonResourceType::ACCRUAL_BY_DAY,
-                $scope,
-                $normalizedKey,
-            );
+            $identityKey = $this->identityKey($scope, $normalizedKey);
+            $externalCategory = $categoriesByIdentity[$identityKey] ?? null;
 
-            if (!$externalCategory instanceof ExternalCategory) {
-                $externalCategory = new ExternalCategory(
-                    source: IngestSource::OZON,
-                    resourceType: OzonResourceType::ACCRUAL_BY_DAY,
-                    scope: $scope,
-                    normalizedKey: $normalizedKey,
-                    externalTypeId: $typeId,
-                    externalName: $typeName,
-                    status: ExternalCategoryStatus::NEW,
-                );
-                $this->entityManager->persist($externalCategory);
-                ++$stats['categoriesCreated'];
-            } else {
+            if ($externalCategory instanceof ExternalCategory) {
                 $externalCategory->markSeen($typeId, $typeName);
                 ++$stats['categoriesSeen'];
+            } else {
+                $externalCategory = $this->categoryRepository->findByIdentity(
+                    IngestSource::OZON,
+                    OzonResourceType::ACCRUAL_BY_DAY,
+                    $scope,
+                    $normalizedKey,
+                );
+
+                if (!$externalCategory instanceof ExternalCategory) {
+                    $externalCategory = new ExternalCategory(
+                        source: IngestSource::OZON,
+                        resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+                        scope: $scope,
+                        normalizedKey: $normalizedKey,
+                        externalTypeId: $typeId,
+                        externalName: $typeName,
+                        status: ExternalCategoryStatus::NEW,
+                    );
+                    $this->entityManager->persist($externalCategory);
+                    ++$stats['categoriesCreated'];
+                } else {
+                    $externalCategory->markSeen($typeId, $typeName);
+                    ++$stats['categoriesSeen'];
+                }
+
+                $categoriesByIdentity[$identityKey] = $externalCategory;
             }
 
             $mappedCategory = OzonAccrualCategory::findByTypeId($typeId) ?? OzonAccrualCategory::findByOzonName($typeName);
-            $existingMapping = $this->mappingRepository->findByCategory($externalCategory);
-            if ($mappedCategory instanceof OzonAccrualCategory && null === $existingMapping) {
+            $categoryId = $externalCategory->getId();
+            $mappingKnownByCategoryId[$categoryId] ??= $this->mappingRepository->findByCategory($externalCategory) instanceof ExternalCategoryMapping;
+
+            if ($mappedCategory instanceof OzonAccrualCategory && !$mappingKnownByCategoryId[$categoryId]) {
                 $this->entityManager->persist(new ExternalCategoryMapping(
                     externalCategory: $externalCategory,
                     canonicalCode: $mappedCategory->code,
@@ -96,6 +110,7 @@ final readonly class DiscoverExternalCategoriesAction
                     known: true,
                     status: ExternalCategoryMappingStatus::ACTIVE,
                 ));
+                $mappingKnownByCategoryId[$categoryId] = true;
                 ++$stats['autoMapped'];
             }
 
@@ -170,6 +185,11 @@ final readonly class DiscoverExternalCategoriesAction
             str_starts_with($component, 'container_fee') => OzonAccrualCategoryTaxonomyResolver::SCOPE_CONTAINER,
             default => OzonAccrualCategoryTaxonomyResolver::SCOPE_ANY,
         };
+    }
+
+    private function identityKey(string $scope, string $normalizedKey): string
+    {
+        return sprintf('%s:%s', $scope, $normalizedKey);
     }
 
     private function optionalString(mixed $value): ?string

--- a/site/src/Ingestion/Application/Action/RefreshOzonAccrualCategoryMetadataAction.php
+++ b/site/src/Ingestion/Application/Action/RefreshOzonAccrualCategoryMetadataAction.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Action;
+
+use App\Ingestion\Application\DTO\MappedTransaction;
+use App\Ingestion\Application\Source\Ozon\OzonAccrualByDayMapper;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Entity\FinancialTransaction;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\RawNormalizationStatus;
+use App\Ingestion\Facade\RawStorageFacade;
+use App\Ingestion\Repository\FinancialTransactionRepository;
+use App\Ingestion\Repository\IngestRawRecordRepository;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class RefreshOzonAccrualCategoryMetadataAction
+{
+    private const CATEGORY_SOURCE_DATA_KEYS = [
+        '_ozon_category_code',
+        '_ozon_category_label',
+        '_ozon_category_group',
+        '_ozon_category_parent',
+        '_ozon_category_sort_order',
+        '_ozon_category_known',
+    ];
+
+    public function __construct(
+        private Connection $connection,
+        private IngestRawRecordRepository $rawRecordRepository,
+        private FinancialTransactionRepository $financialTransactionRepository,
+        private RawStorageFacade $rawStorageFacade,
+        private OzonAccrualByDayMapper $mapper,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    /**
+     * @return array{rawRecords: list<array<string, mixed>>, results: list<array<string, string|int>>}
+     */
+    public function __invoke(
+        string $companyId,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        ?string $shopRef,
+        int $limit,
+        bool $dryRun,
+    ): array {
+        $rawRecords = $this->rawRecords($companyId, $from, $to, $shopRef, $limit);
+
+        return [
+            'rawRecords' => $rawRecords,
+            'results' => $this->refresh($companyId, $rawRecords, $dryRun),
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function rawRecords(
+        string $companyId,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        ?string $shopRef,
+        int $limit,
+    ): array {
+        $limit = max(1, min(500, $limit));
+        $externalWindowFrom = "substring(r.external_id from '^accrual-by-day:([0-9]{4}-[0-9]{2}-[0-9]{2}):[0-9]{4}-[0-9]{2}-[0-9]{2}$')::date";
+        $externalWindowTo = "substring(r.external_id from '^accrual-by-day:[0-9]{4}-[0-9]{2}-[0-9]{2}:([0-9]{4}-[0-9]{2}-[0-9]{2})$')::date";
+        $windowFrom = sprintf('COALESCE(j.window_from, %s, DATE(r.fetched_at))', $externalWindowFrom);
+        $windowTo = sprintf('COALESCE(j.window_to, j.window_from, %s, %s, DATE(r.fetched_at))', $externalWindowTo, $externalWindowFrom);
+        $conditions = [
+            'r.company_id = :companyId',
+            'r.source = :source',
+            'r.resource_type = :resourceType',
+            'r.normalization_status = :status',
+            sprintf('%s <= :toDate', $windowFrom),
+            sprintf('%s >= :fromDate', $windowTo),
+        ];
+        $params = [
+            'companyId' => $companyId,
+            'source' => IngestSource::OZON->value,
+            'resourceType' => OzonResourceType::ACCRUAL_BY_DAY,
+            'status' => RawNormalizationStatus::DONE->value,
+            'fromDate' => $from->format('Y-m-d'),
+            'toDate' => $to->format('Y-m-d'),
+        ];
+
+        if (null !== $shopRef && '' !== $shopRef) {
+            $conditions[] = 'r.shop_ref = :shopRef';
+            $params['shopRef'] = $shopRef;
+        }
+
+        return $this->connection->fetchAllAssociative(
+            sprintf(
+                'SELECT r.id,
+                        r.external_id,
+                        r.shop_ref,
+                        r.fetched_at,
+                        r.byte_size,
+                        r.normalization_status,
+                        TO_CHAR(%s, \'YYYY-MM-DD\') AS window_from,
+                        TO_CHAR(%s, \'YYYY-MM-DD\') AS window_to
+                 FROM ingest_raw_records r
+                 LEFT JOIN ingest_sync_jobs j ON j.id::text = r.sync_job_id AND j.company_id = r.company_id
+                 WHERE %s
+                 ORDER BY %s ASC, %s ASC, r.fetched_at ASC, r.created_at ASC
+                 LIMIT %d',
+                $windowFrom,
+                $windowTo,
+                implode(' AND ', $conditions),
+                $windowFrom,
+                $windowTo,
+                $limit,
+            ),
+            $params,
+        );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rawRecords
+     *
+     * @return list<array<string, string|int>>
+     */
+    public function refresh(string $companyId, array $rawRecords, bool $dryRun): array
+    {
+        $resultRows = [];
+
+        foreach ($rawRecords as $row) {
+            $rawRecordId = (string) $row['id'];
+
+            if (!$dryRun) {
+                $this->connection->beginTransaction();
+            }
+
+            try {
+                $rawRecord = $this->rawRecordRepository->findByIdAndCompany($rawRecordId, $companyId);
+                if (null === $rawRecord || RawNormalizationStatus::DONE !== $rawRecord->getNormalizationStatus()) {
+                    throw new \RuntimeException('Done Ozon accrual raw record was not found.');
+                }
+
+                /** @var list<array<string, mixed>> $rows */
+                $rows = array_values(iterator_to_array($this->rawStorageFacade->read($rawRecord->getId(), $companyId), false));
+                $mappedTransactions = $this->mapper->map($rawRecord, $rows);
+                $existingByKey = $this->existingTransactionsByNaturalKey($companyId, $rawRecord);
+
+                $scanned = 0;
+                $matched = 0;
+                $updated = 0;
+                $unchanged = 0;
+                $missing = 0;
+
+                foreach ($mappedTransactions as $mappedTransaction) {
+                    ++$scanned;
+                    $transaction = $existingByKey[$this->naturalKey($mappedTransaction)] ?? null;
+                    if (!$transaction instanceof FinancialTransaction) {
+                        $transaction = $this->financialTransactionRepository->findByNaturalKey(
+                            $companyId,
+                            IngestSource::OZON,
+                            $mappedTransaction->externalId,
+                            $mappedTransaction->type,
+                        );
+                    }
+
+                    if (!$transaction instanceof FinancialTransaction) {
+                        ++$missing;
+                        continue;
+                    }
+
+                    ++$matched;
+                    if (!$this->metadataDiffers($transaction, $mappedTransaction)) {
+                        ++$unchanged;
+                        continue;
+                    }
+
+                    ++$updated;
+                    if (!$dryRun) {
+                        $transaction->replaceSourceDataFields(
+                            $mappedTransaction->sourceData,
+                            self::CATEGORY_SOURCE_DATA_KEYS,
+                            $mappedTransaction->description,
+                        );
+                    }
+                }
+
+                if (!$dryRun) {
+                    $this->entityManager->flush();
+                    $this->connection->commit();
+                }
+
+                $resultRows[] = [
+                    'rawId' => $rawRecordId,
+                    'status' => $dryRun ? 'dry-run' : 'done',
+                    'scanned' => $scanned,
+                    'matched' => $matched,
+                    'updated' => $updated,
+                    'unchanged' => $unchanged,
+                    'missing' => $missing,
+                ];
+            } catch (\Throwable $exception) {
+                if (!$dryRun && $this->connection->isTransactionActive()) {
+                    $this->connection->rollBack();
+                }
+
+                $resultRows[] = [
+                    'rawId' => $rawRecordId,
+                    'status' => 'error',
+                    'scanned' => 0,
+                    'matched' => 0,
+                    'updated' => 0,
+                    'unchanged' => 0,
+                    'missing' => 0,
+                    'error' => $exception->getMessage(),
+                ];
+            }
+        }
+
+        return $resultRows;
+    }
+
+    /**
+     * @return array<string, FinancialTransaction>
+     */
+    private function existingTransactionsByNaturalKey(string $companyId, IngestRawRecord $rawRecord): array
+    {
+        $transactions = [];
+        foreach ($this->financialTransactionRepository->findByRawRecordId($companyId, $rawRecord->getId()) as $transaction) {
+            $transactions[sprintf('%s:%s', $transaction->getExternalId(), $transaction->getType()->value)] = $transaction;
+        }
+
+        return $transactions;
+    }
+
+    private function naturalKey(MappedTransaction $transaction): string
+    {
+        return sprintf('%s:%s', $transaction->externalId, $transaction->type->value);
+    }
+
+    private function metadataDiffers(FinancialTransaction $transaction, MappedTransaction $mappedTransaction): bool
+    {
+        $existing = $transaction->getSourceData();
+        foreach (self::CATEGORY_SOURCE_DATA_KEYS as $key) {
+            if (!array_key_exists($key, $mappedTransaction->sourceData)) {
+                continue;
+            }
+
+            if (!array_key_exists($key, $existing) || $existing[$key] !== $mappedTransaction->sourceData[$key]) {
+                return true;
+            }
+        }
+
+        return null !== $mappedTransaction->description && $transaction->getDescription() !== $mappedTransaction->description;
+    }
+}

--- a/site/src/Ingestion/Application/Action/RefreshOzonAccrualCategoryMetadataAction.php
+++ b/site/src/Ingestion/Application/Action/RefreshOzonAccrualCategoryMetadataAction.php
@@ -144,7 +144,11 @@ final readonly class RefreshOzonAccrualCategoryMetadataAction
 
                 /** @var list<array<string, mixed>> $rows */
                 $rows = array_values(iterator_to_array($this->rawStorageFacade->read($rawRecord->getId(), $companyId), false));
-                $mappedTransactions = $this->mapper->map($rawRecord, $rows);
+                $mappedTransactions = $this->mapper->mapForCategoryMetadataRefresh(
+                    rawRecord: $rawRecord,
+                    rows: $rows,
+                    recordUnknownCategories: !$dryRun,
+                );
                 $existingByKey = $this->existingTransactionsByNaturalKey($companyId, $rawRecord);
 
                 $scanned = 0;
@@ -201,8 +205,11 @@ final readonly class RefreshOzonAccrualCategoryMetadataAction
                     'missing' => $missing,
                 ];
             } catch (\Throwable $exception) {
-                if (!$dryRun && $this->connection->isTransactionActive()) {
-                    $this->connection->rollBack();
+                if (!$dryRun) {
+                    if ($this->connection->isTransactionActive()) {
+                        $this->connection->rollBack();
+                    }
+                    $this->entityManager->clear();
                 }
 
                 $resultRows[] = [

--- a/site/src/Ingestion/Application/Action/SeedExternalCategoryMappingsAction.php
+++ b/site/src/Ingestion/Application/Action/SeedExternalCategoryMappingsAction.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Action;
+
+use App\Ingestion\Application\Source\Ozon\OzonAccrualCategory;
+use App\Ingestion\Application\Source\Ozon\OzonAccrualCategoryTaxonomyResolver;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Entity\ExternalCategory;
+use App\Ingestion\Entity\ExternalCategoryMapping;
+use App\Ingestion\Enum\ExternalCategoryMappingStatus;
+use App\Ingestion\Enum\ExternalCategoryStatus;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Repository\ExternalCategoryMappingRepository;
+use App\Ingestion\Repository\ExternalCategoryRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class SeedExternalCategoryMappingsAction
+{
+    public function __construct(
+        private ExternalCategoryRepository $categoryRepository,
+        private ExternalCategoryMappingRepository $mappingRepository,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    /**
+     * @return array{categoriesCreated: int, categoriesSeen: int, mappingsCreated: int, mappingsExisting: int}
+     */
+    public function __invoke(IngestSource $source = IngestSource::OZON): array
+    {
+        if (IngestSource::OZON !== $source) {
+            throw new \InvalidArgumentException(sprintf('Default external category seeding is not implemented for source "%s".', $source->value));
+        }
+
+        $stats = [
+            'categoriesCreated' => 0,
+            'categoriesSeen' => 0,
+            'mappingsCreated' => 0,
+            'mappingsExisting' => 0,
+        ];
+
+        foreach (OzonAccrualCategory::all() as $category) {
+            foreach ($this->ozonIdentities($category) as $identity) {
+                $externalCategory = $this->categoryRepository->findByIdentity(
+                    IngestSource::OZON,
+                    OzonResourceType::ACCRUAL_BY_DAY,
+                    OzonAccrualCategoryTaxonomyResolver::SCOPE_ANY,
+                    $identity['normalizedKey'],
+                );
+
+                if (!$externalCategory instanceof ExternalCategory) {
+                    $externalCategory = new ExternalCategory(
+                        source: IngestSource::OZON,
+                        resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+                        scope: OzonAccrualCategoryTaxonomyResolver::SCOPE_ANY,
+                        normalizedKey: $identity['normalizedKey'],
+                        externalTypeId: $identity['externalTypeId'],
+                        externalName: $identity['externalName'],
+                        status: ExternalCategoryStatus::MAPPED,
+                    );
+                    $this->entityManager->persist($externalCategory);
+                    ++$stats['categoriesCreated'];
+                } else {
+                    $externalCategory->markSeen($identity['externalTypeId'], $identity['externalName']);
+                    ++$stats['categoriesSeen'];
+                }
+
+                $mapping = $this->mappingRepository->findByCategory($externalCategory);
+                if ($mapping instanceof ExternalCategoryMapping) {
+                    ++$stats['mappingsExisting'];
+                    continue;
+                }
+
+                $this->entityManager->persist(new ExternalCategoryMapping(
+                    externalCategory: $externalCategory,
+                    canonicalCode: $category->code,
+                    canonicalLabel: $category->label,
+                    canonicalGroup: $category->group,
+                    transactionType: $category->transactionType,
+                    sortOrder: $category->sortOrder,
+                    known: true,
+                    status: ExternalCategoryMappingStatus::ACTIVE,
+                ));
+                ++$stats['mappingsCreated'];
+            }
+        }
+
+        $this->entityManager->flush();
+
+        return $stats;
+    }
+
+    /**
+     * @return list<array{normalizedKey: string, externalTypeId: ?string, externalName: ?string}>
+     */
+    private function ozonIdentities(OzonAccrualCategory $category): array
+    {
+        $identities = [];
+
+        foreach ($category->typeIds as $typeId) {
+            $normalizedKey = OzonAccrualCategoryTaxonomyResolver::typeKey($typeId);
+            if (null !== $normalizedKey) {
+                $identities[$normalizedKey] = [
+                    'normalizedKey' => $normalizedKey,
+                    'externalTypeId' => (string) $typeId,
+                    'externalName' => null,
+                ];
+            }
+        }
+
+        foreach (array_merge([$category->label], $category->aliases) as $alias) {
+            $normalizedKey = OzonAccrualCategoryTaxonomyResolver::nameKey($alias);
+            if (null !== $normalizedKey) {
+                $identities[$normalizedKey] = [
+                    'normalizedKey' => $normalizedKey,
+                    'externalTypeId' => null,
+                    'externalName' => (string) $alias,
+                ];
+            }
+        }
+
+        return array_values($identities);
+    }
+}

--- a/site/src/Ingestion/Application/Action/UpdateExternalCategoryMappingAction.php
+++ b/site/src/Ingestion/Application/Action/UpdateExternalCategoryMappingAction.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Action;
+
+use App\Ingestion\Entity\ExternalCategory;
+use App\Ingestion\Entity\ExternalCategoryMapping;
+use App\Ingestion\Enum\ExternalCategoryMappingStatus;
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+use App\Ingestion\Repository\ExternalCategoryMappingRepository;
+use App\Ingestion\Repository\ExternalCategoryRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class UpdateExternalCategoryMappingAction
+{
+    public function __construct(
+        private ExternalCategoryRepository $categoryRepository,
+        private ExternalCategoryMappingRepository $mappingRepository,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function __invoke(
+        string $categoryId,
+        string $canonicalCode,
+        string $canonicalLabel,
+        string $canonicalGroup,
+        TransactionType $transactionType,
+        int $sortOrder,
+        ExternalCategoryMappingStatus $status,
+        bool $known,
+        ?TransactionDirection $defaultDirection = null,
+        ?string $updatedBy = null,
+    ): void {
+        $category = $this->categoryRepository->find($categoryId);
+        if (!$category instanceof ExternalCategory) {
+            throw new \InvalidArgumentException('External category was not found.');
+        }
+
+        $mapping = $this->mappingRepository->findByCategory($category);
+        if ($mapping instanceof ExternalCategoryMapping) {
+            $mapping->update(
+                canonicalCode: $canonicalCode,
+                canonicalLabel: $canonicalLabel,
+                canonicalGroup: $canonicalGroup,
+                transactionType: $transactionType,
+                sortOrder: $sortOrder,
+                defaultDirection: $defaultDirection,
+                known: $known,
+                status: $status,
+                updatedBy: $updatedBy,
+            );
+        } else {
+            $this->entityManager->persist(new ExternalCategoryMapping(
+                externalCategory: $category,
+                canonicalCode: $canonicalCode,
+                canonicalLabel: $canonicalLabel,
+                canonicalGroup: $canonicalGroup,
+                transactionType: $transactionType,
+                sortOrder: $sortOrder,
+                defaultDirection: $defaultDirection,
+                known: $known,
+                status: $status,
+                updatedBy: $updatedBy,
+            ));
+        }
+
+        if (ExternalCategoryMappingStatus::NEEDS_REVIEW === $status) {
+            $category->markNew();
+        }
+        if (ExternalCategoryMappingStatus::DISABLED === $status) {
+            $category->markIgnored();
+        }
+
+        $this->entityManager->flush();
+    }
+}

--- a/site/src/Ingestion/Application/Source/Ozon/OzonAccrualByDayMapper.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonAccrualByDayMapper.php
@@ -42,7 +42,7 @@ final readonly class OzonAccrualByDayMapper implements SourceMapperInterface, Ra
     {
         $transactions = [];
 
-        foreach ($this->previewMapper->preview($rawRecord->getCompanyId(), $rows, includeSaleRefund: true) as $row) {
+        foreach ($this->previewMapper->preview($rawRecord->getCompanyId(), $rows, includeSaleRefund: true, recordUnknownCategories: true) as $row) {
             $transactions[] = new MappedTransaction(
                 externalId: $row->sourceKey,
                 externalUpdatedAt: $rawRecord->getFetchedAt(),

--- a/site/src/Ingestion/Application/Source/Ozon/OzonAccrualByDayMapper.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonAccrualByDayMapper.php
@@ -40,9 +40,29 @@ final readonly class OzonAccrualByDayMapper implements SourceMapperInterface, Ra
      */
     public function map(IngestRawRecord $rawRecord, iterable $rows): array
     {
+        return $this->mapRows($rawRecord, $rows, recordUnknownCategories: true);
+    }
+
+    /**
+     * @param iterable<array<string, mixed>> $rows
+     *
+     * @return list<MappedTransaction>
+     */
+    public function mapForCategoryMetadataRefresh(IngestRawRecord $rawRecord, iterable $rows, bool $recordUnknownCategories): array
+    {
+        return $this->mapRows($rawRecord, $rows, $recordUnknownCategories);
+    }
+
+    /**
+     * @param iterable<array<string, mixed>> $rows
+     *
+     * @return list<MappedTransaction>
+     */
+    private function mapRows(IngestRawRecord $rawRecord, iterable $rows, bool $recordUnknownCategories): array
+    {
         $transactions = [];
 
-        foreach ($this->previewMapper->preview($rawRecord->getCompanyId(), $rows, includeSaleRefund: true, recordUnknownCategories: true) as $row) {
+        foreach ($this->previewMapper->preview($rawRecord->getCompanyId(), $rows, includeSaleRefund: true, recordUnknownCategories: $recordUnknownCategories) as $row) {
             $transactions[] = new MappedTransaction(
                 externalId: $row->sourceKey,
                 externalUpdatedAt: $rawRecord->getFetchedAt(),

--- a/site/src/Ingestion/Application/Source/Ozon/OzonAccrualByDayPreviewMapper.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonAccrualByDayPreviewMapper.php
@@ -32,6 +32,8 @@ final readonly class OzonAccrualByDayPreviewMapper
         bool $includeSaleRefund = false,
         bool $recordUnknownCategories = false,
     ): array {
+        $this->categoryResolver?->resetPerPreviewState();
+
         $transactions = [];
 
         foreach ($rows as $row) {
@@ -264,6 +266,11 @@ final readonly class OzonAccrualByDayPreviewMapper
                 continue;
             }
 
+            $amount = $this->moneyObjectMinor($service['accrued'] ?? null);
+            if (0 === $amount) {
+                continue;
+            }
+
             $typeId = $this->typeId($service);
             $ozonCategory = $this->categoryForTypedFee(
                 typeId: $typeId,
@@ -272,10 +279,6 @@ final readonly class OzonAccrualByDayPreviewMapper
                 scope: OzonAccrualCategoryTaxonomyResolver::SCOPE_DELIVERY,
                 recordUnknown: $recordUnknownCategories,
             );
-            $amount = $this->moneyObjectMinor($service['accrued'] ?? null);
-            if (0 === $amount) {
-                continue;
-            }
 
             $this->add(
                 transactions: $transactions,
@@ -433,6 +436,11 @@ final readonly class OzonAccrualByDayPreviewMapper
             return;
         }
 
+        $amount = $this->moneyObjectMinor($fee['accrued']);
+        if (0 === $amount) {
+            return;
+        }
+
         $typeId = $this->typeId($fee);
         $ozonCategory = $this->categoryForTypedFee(
             typeId: $typeId,
@@ -441,10 +449,6 @@ final readonly class OzonAccrualByDayPreviewMapper
             scope: $scope,
             recordUnknown: $recordUnknownCategories,
         );
-        $amount = $this->moneyObjectMinor($fee['accrued']);
-        if (0 === $amount) {
-            return;
-        }
 
         $this->add(
             transactions: $transactions,

--- a/site/src/Ingestion/Application/Source/Ozon/OzonAccrualByDayPreviewMapper.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonAccrualByDayPreviewMapper.php
@@ -15,6 +15,7 @@ final readonly class OzonAccrualByDayPreviewMapper
         private OzonMoneyParser $moneyParser,
         private SourceDataHasher $sourceDataHasher,
         private ?StoredOzonAccrualTypeNameResolver $typeNameResolver = null,
+        private ?OzonAccrualCategoryTaxonomyResolver $categoryResolver = null,
     ) {
     }
 
@@ -29,6 +30,7 @@ final readonly class OzonAccrualByDayPreviewMapper
         ?\DateTimeImmutable $from = null,
         ?\DateTimeImmutable $to = null,
         bool $includeSaleRefund = false,
+        bool $recordUnknownCategories = false,
     ): array {
         $transactions = [];
 
@@ -44,10 +46,10 @@ final readonly class OzonAccrualByDayPreviewMapper
             $unitNumber = $this->optionalString($row['unit_number'] ?? null);
 
             match ($category) {
-                'POSTING' => $this->collectPosting($transactions, $companyId, $row, $operationGroupId, $date, $category, $accrualId, $unitNumber, $includeSaleRefund),
-                'ITEM' => $this->collectItemFees($transactions, $companyId, $row['item_fees'] ?? null, $operationGroupId, $date, $category, $accrualId, $unitNumber),
-                'NON_ITEM' => $this->collectNonItemFee($transactions, $companyId, $row['non_item_fee'] ?? null, $operationGroupId, $date, $category, $accrualId, $unitNumber),
-                'CONTAINER' => $this->collectContainerFees($transactions, $companyId, $row['container_fees'] ?? null, $operationGroupId, $date, $category, $accrualId, $unitNumber),
+                'POSTING' => $this->collectPosting($transactions, $companyId, $row, $operationGroupId, $date, $category, $accrualId, $unitNumber, $includeSaleRefund, $recordUnknownCategories),
+                'ITEM' => $this->collectItemFees($transactions, $companyId, $row['item_fees'] ?? null, $operationGroupId, $date, $category, $accrualId, $unitNumber, $recordUnknownCategories),
+                'NON_ITEM' => $this->collectNonItemFee($transactions, $companyId, $row['non_item_fee'] ?? null, $operationGroupId, $date, $category, $accrualId, $unitNumber, $recordUnknownCategories),
+                'CONTAINER' => $this->collectContainerFees($transactions, $companyId, $row['container_fees'] ?? null, $operationGroupId, $date, $category, $accrualId, $unitNumber, recordUnknownCategories: $recordUnknownCategories),
                 default => null,
             };
         }
@@ -69,6 +71,7 @@ final readonly class OzonAccrualByDayPreviewMapper
         string $accrualId,
         ?string $unitNumber,
         bool $includeSaleRefund,
+        bool $recordUnknownCategories,
     ): void {
         $posting = $row['posting'] ?? null;
         if (!is_array($posting)) {
@@ -102,7 +105,7 @@ final readonly class OzonAccrualByDayPreviewMapper
                 canonicalComponent: 'partner_programs',
             );
             $this->collectCommission($transactions, $product['commission'] ?? null, $operationGroupId, $date, $category, $accrualId, (int) $productIndex, $unitNumber);
-            $this->collectDeliveryServices($transactions, $companyId, $product['delivery']['services'] ?? null, $operationGroupId, $date, $category, $accrualId, (int) $productIndex, $unitNumber);
+            $this->collectDeliveryServices($transactions, $companyId, $product['delivery']['services'] ?? null, $operationGroupId, $date, $category, $accrualId, (int) $productIndex, $unitNumber, $recordUnknownCategories);
         }
     }
 
@@ -144,7 +147,7 @@ final readonly class OzonAccrualByDayPreviewMapper
             signedAmountMinor: $amount,
             field: $field,
             unitNumber: $unitNumber,
-            ozonCategory: OzonAccrualCategory::forField($field, $amount),
+            ozonCategory: $this->categoryForField($field, $amount),
         );
     }
 
@@ -178,7 +181,7 @@ final readonly class OzonAccrualByDayPreviewMapper
                 continue;
             }
 
-            $ozonCategory = OzonAccrualCategory::forField($field, $amount);
+            $ozonCategory = $this->categoryForField($field, $amount);
             $this->add(
                 transactions: $transactions,
                 operationGroupId: $operationGroupId,
@@ -233,7 +236,7 @@ final readonly class OzonAccrualByDayPreviewMapper
             signedAmountMinor: $amount,
             field: $field,
             unitNumber: $unitNumber,
-            ozonCategory: OzonAccrualCategory::forField($field, $amount),
+            ozonCategory: $this->categoryForField($field, $amount),
         );
     }
 
@@ -250,6 +253,7 @@ final readonly class OzonAccrualByDayPreviewMapper
         string $accrualId,
         int $productIndex,
         ?string $unitNumber,
+        bool $recordUnknownCategories,
     ): void {
         if (!is_array($services)) {
             return;
@@ -261,7 +265,13 @@ final readonly class OzonAccrualByDayPreviewMapper
             }
 
             $typeId = $this->typeId($service);
-            $ozonCategory = OzonAccrualCategory::forTypedFee($typeId, $this->resolvedTypeName($companyId, $typeId, $service), TransactionType::FEE);
+            $ozonCategory = $this->categoryForTypedFee(
+                typeId: $typeId,
+                typeName: $this->resolvedTypeName($companyId, $typeId, $service),
+                fallbackType: TransactionType::FEE,
+                scope: OzonAccrualCategoryTaxonomyResolver::SCOPE_DELIVERY,
+                recordUnknown: $recordUnknownCategories,
+            );
             $amount = $this->moneyObjectMinor($service['accrued'] ?? null);
             if (0 === $amount) {
                 continue;
@@ -295,6 +305,7 @@ final readonly class OzonAccrualByDayPreviewMapper
         string $category,
         string $accrualId,
         ?string $unitNumber,
+        bool $recordUnknownCategories,
     ): void {
         if (!is_array($itemFeesBlock)) {
             return;
@@ -322,6 +333,8 @@ final readonly class OzonAccrualByDayPreviewMapper
                     componentPrefix: sprintf('item_fee:group-%d:fee-%d', (int) $groupIndex, (int) $feeIndex),
                     type: TransactionType::FEE,
                     unitNumber: $unitNumber,
+                    scope: OzonAccrualCategoryTaxonomyResolver::SCOPE_ITEM,
+                    recordUnknownCategories: $recordUnknownCategories,
                 );
             }
         }
@@ -339,6 +352,7 @@ final readonly class OzonAccrualByDayPreviewMapper
         string $category,
         string $accrualId,
         ?string $unitNumber,
+        bool $recordUnknownCategories,
     ): void {
         $this->collectTypedFee(
             transactions: $transactions,
@@ -351,6 +365,8 @@ final readonly class OzonAccrualByDayPreviewMapper
             componentPrefix: 'non_item_fee',
             type: TransactionType::OTHER,
             unitNumber: $unitNumber,
+            scope: OzonAccrualCategoryTaxonomyResolver::SCOPE_NON_ITEM,
+            recordUnknownCategories: $recordUnknownCategories,
         );
     }
 
@@ -367,6 +383,8 @@ final readonly class OzonAccrualByDayPreviewMapper
         string $accrualId,
         ?string $unitNumber,
         string $path = 'container_fee',
+        string $scope = OzonAccrualCategoryTaxonomyResolver::SCOPE_CONTAINER,
+        bool $recordUnknownCategories = false,
     ): void {
         if (!is_array($value)) {
             return;
@@ -383,11 +401,13 @@ final readonly class OzonAccrualByDayPreviewMapper
             componentPrefix: $path,
             type: TransactionType::FEE,
             unitNumber: $unitNumber,
+            scope: $scope,
+            recordUnknownCategories: $recordUnknownCategories,
         );
 
         foreach ($value as $childKey => $child) {
             if (is_array($child)) {
-                $this->collectContainerFees($transactions, $companyId, $child, $operationGroupId, $date, $category, $accrualId, $unitNumber, sprintf('%s:%s', $path, $this->normalizeComponent((string) $childKey)));
+                $this->collectContainerFees($transactions, $companyId, $child, $operationGroupId, $date, $category, $accrualId, $unitNumber, sprintf('%s:%s', $path, $this->normalizeComponent((string) $childKey)), $scope, $recordUnknownCategories);
             }
         }
     }
@@ -406,13 +426,21 @@ final readonly class OzonAccrualByDayPreviewMapper
         string $componentPrefix,
         TransactionType $type,
         ?string $unitNumber,
+        string $scope,
+        bool $recordUnknownCategories,
     ): void {
         if (!is_array($fee) || !array_key_exists('accrued', $fee)) {
             return;
         }
 
         $typeId = $this->typeId($fee);
-        $ozonCategory = OzonAccrualCategory::forTypedFee($typeId, $this->resolvedTypeName($companyId, $typeId, $fee), $type);
+        $ozonCategory = $this->categoryForTypedFee(
+            typeId: $typeId,
+            typeName: $this->resolvedTypeName($companyId, $typeId, $fee),
+            fallbackType: $type,
+            scope: $scope,
+            recordUnknown: $recordUnknownCategories,
+        );
         $amount = $this->moneyObjectMinor($fee['accrued']);
         if (0 === $amount) {
             return;
@@ -515,6 +543,23 @@ final readonly class OzonAccrualByDayPreviewMapper
     private function resolvedTypeName(string $companyId, string $typeId, array $fee): ?string
     {
         return $this->typeName($fee) ?? $this->typeNameResolver?->resolve($companyId, $typeId);
+    }
+
+    private function categoryForField(string $field, int $signedAmountMinor): ?OzonAccrualCategory
+    {
+        return $this->categoryResolver?->forField($field, $signedAmountMinor)
+            ?? OzonAccrualCategory::forField($field, $signedAmountMinor);
+    }
+
+    private function categoryForTypedFee(
+        ?string $typeId,
+        ?string $typeName,
+        TransactionType $fallbackType,
+        string $scope,
+        bool $recordUnknown,
+    ): OzonAccrualCategory {
+        return $this->categoryResolver?->forTypedFee($typeId, $typeName, $fallbackType, $scope, $recordUnknown)
+            ?? OzonAccrualCategory::forTypedFee($typeId, $typeName, $fallbackType);
     }
 
     private function moneyObjectMinor(mixed $value): int

--- a/site/src/Ingestion/Application/Source/Ozon/OzonAccrualCategory.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonAccrualCategory.php
@@ -8,7 +8,7 @@ use App\Ingestion\Enum\TransactionType;
 
 final readonly class OzonAccrualCategory
 {
-    private const UNKNOWN_GROUP = 'Неизвестные категории Ozon';
+    private const UNKNOWN_GROUP = 'Требует классификации';
 
     /**
      * @param list<string> $typeIds

--- a/site/src/Ingestion/Application/Source/Ozon/OzonAccrualCategoryTaxonomyResolver.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonAccrualCategoryTaxonomyResolver.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Source\Ozon;
+
+use App\Ingestion\Entity\ExternalCategory;
+use App\Ingestion\Entity\ExternalCategoryMapping;
+use App\Ingestion\Enum\ExternalCategoryStatus;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\TransactionType;
+use App\Ingestion\Repository\ExternalCategoryMappingRepository;
+use App\Ingestion\Repository\ExternalCategoryRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+final class OzonAccrualCategoryTaxonomyResolver
+{
+    public const SCOPE_ANY = 'any';
+    public const SCOPE_FIELD = 'field';
+    public const SCOPE_DELIVERY = 'delivery';
+    public const SCOPE_ITEM = 'item';
+    public const SCOPE_NON_ITEM = 'non_item';
+    public const SCOPE_CONTAINER = 'container';
+
+    /**
+     * @var array<string, ExternalCategory>
+     */
+    private array $recordedUnknowns = [];
+
+    public function __construct(
+        private readonly ExternalCategoryRepository $categoryRepository,
+        private readonly ExternalCategoryMappingRepository $mappingRepository,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function forField(string $field, int $signedAmountMinor, bool $recordUnknown = false): ?OzonAccrualCategory
+    {
+        $static = OzonAccrualCategory::forField($field, $signedAmountMinor);
+        if (null === $static) {
+            return null;
+        }
+
+        return $this->categoryFromMapping($this->findMapping(self::SCOPE_FIELD, self::fieldKey($field))) ?? $static;
+    }
+
+    public function forTypedFee(
+        ?string $typeId,
+        ?string $typeName,
+        TransactionType $fallbackType,
+        string $scope,
+        bool $recordUnknown = false,
+    ): OzonAccrualCategory {
+        foreach ($this->candidateKeys($typeId, $typeName) as $normalizedKey) {
+            $mapped = $this->categoryFromMapping($this->findMapping($scope, $normalizedKey));
+            if (null !== $mapped) {
+                return $mapped;
+            }
+
+            $mapped = $this->categoryFromMapping($this->findMapping(self::SCOPE_ANY, $normalizedKey));
+            if (null !== $mapped) {
+                return $mapped;
+            }
+        }
+
+        $static = OzonAccrualCategory::forTypedFee($typeId, $typeName, $fallbackType);
+        if ($static->known) {
+            return $static;
+        }
+
+        if ($recordUnknown) {
+            $this->recordUnknown($scope, $typeId, $typeName);
+        }
+
+        return $static;
+    }
+
+    public static function typeKey(?string $typeId): ?string
+    {
+        $typeId = self::normalizeTypeId($typeId);
+
+        return null !== $typeId ? sprintf('type:%s', $typeId) : null;
+    }
+
+    public static function nameKey(?string $name): ?string
+    {
+        $name = self::normalizeName($name);
+
+        return null !== $name ? sprintf('name:%s', $name) : null;
+    }
+
+    public static function fieldKey(string $field): string
+    {
+        return sprintf('field:%s', strtolower(trim($field)));
+    }
+
+    public static function normalizeName(?string $name): ?string
+    {
+        $name = trim((string) $name);
+        if ('' === $name) {
+            return null;
+        }
+
+        $name = mb_strtolower($name);
+        $name = str_replace('ё', 'е', $name);
+        $name = preg_replace('/\s+/u', ' ', $name) ?? $name;
+
+        return $name;
+    }
+
+    private static function normalizeTypeId(?string $typeId): ?string
+    {
+        $typeId = trim((string) $typeId);
+
+        return '' !== $typeId && 'unknown' !== strtolower($typeId) ? $typeId : null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function candidateKeys(?string $typeId, ?string $typeName): array
+    {
+        $keys = [];
+        $typeKey = self::typeKey($typeId);
+        if (null !== $typeKey) {
+            $keys[] = $typeKey;
+        }
+
+        $nameKey = self::nameKey($typeName);
+        if (null !== $nameKey) {
+            $keys[] = $nameKey;
+        }
+
+        return array_values(array_unique($keys));
+    }
+
+    private function findMapping(string $scope, string $normalizedKey): ?ExternalCategoryMapping
+    {
+        return $this->mappingRepository->findActiveByIdentity(
+            IngestSource::OZON,
+            OzonResourceType::ACCRUAL_BY_DAY,
+            $scope,
+            $normalizedKey,
+        );
+    }
+
+    private function categoryFromMapping(?ExternalCategoryMapping $mapping): ?OzonAccrualCategory
+    {
+        if (null === $mapping) {
+            return null;
+        }
+
+        return new OzonAccrualCategory(
+            code: $mapping->getCanonicalCode(),
+            label: $mapping->getCanonicalLabel(),
+            group: $mapping->getCanonicalGroup(),
+            transactionType: $mapping->getTransactionType(),
+            sortOrder: $mapping->getSortOrder(),
+            known: $mapping->isKnown(),
+        );
+    }
+
+    private function recordUnknown(string $scope, ?string $typeId, ?string $typeName): void
+    {
+        $normalizedKey = self::typeKey($typeId) ?? self::nameKey($typeName);
+        if (null === $normalizedKey) {
+            return;
+        }
+
+        $cacheKey = sprintf('%s:%s', $scope, $normalizedKey);
+        if (isset($this->recordedUnknowns[$cacheKey])) {
+            $this->recordedUnknowns[$cacheKey]->markSeen($typeId, $typeName);
+
+            return;
+        }
+
+        $category = $this->categoryRepository->findByIdentity(
+            IngestSource::OZON,
+            OzonResourceType::ACCRUAL_BY_DAY,
+            $scope,
+            $normalizedKey,
+        );
+
+        if ($category instanceof ExternalCategory) {
+            $category->markSeen($typeId, $typeName);
+            $this->recordedUnknowns[$cacheKey] = $category;
+
+            return;
+        }
+
+        $category = new ExternalCategory(
+            source: IngestSource::OZON,
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            scope: $scope,
+            normalizedKey: $normalizedKey,
+            externalTypeId: $typeId,
+            externalName: $typeName,
+            status: ExternalCategoryStatus::NEW,
+        );
+
+        $this->entityManager->persist($category);
+        $this->recordedUnknowns[$cacheKey] = $category;
+    }
+}

--- a/site/src/Ingestion/Application/Source/Ozon/OzonAccrualCategoryTaxonomyResolver.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonAccrualCategoryTaxonomyResolver.php
@@ -27,6 +27,11 @@ final class OzonAccrualCategoryTaxonomyResolver
      */
     private array $recordedUnknowns = [];
 
+    /**
+     * @var array<string, ExternalCategoryMapping>|null
+     */
+    private ?array $activeMappingsByIdentity = null;
+
     public function __construct(
         private readonly ExternalCategoryRepository $categoryRepository,
         private readonly ExternalCategoryMappingRepository $mappingRepository,
@@ -42,6 +47,12 @@ final class OzonAccrualCategoryTaxonomyResolver
         }
 
         return $this->categoryFromMapping($this->findMapping(self::SCOPE_FIELD, self::fieldKey($field))) ?? $static;
+    }
+
+    public function resetPerPreviewState(): void
+    {
+        $this->activeMappingsByIdentity = null;
+        $this->recordedUnknowns = [];
     }
 
     public function forTypedFee(
@@ -136,12 +147,30 @@ final class OzonAccrualCategoryTaxonomyResolver
 
     private function findMapping(string $scope, string $normalizedKey): ?ExternalCategoryMapping
     {
-        return $this->mappingRepository->findActiveByIdentity(
-            IngestSource::OZON,
-            OzonResourceType::ACCRUAL_BY_DAY,
-            $scope,
-            $normalizedKey,
-        );
+        return $this->activeMappingsByIdentity()[$this->mappingIdentityKey($scope, $normalizedKey)] ?? null;
+    }
+
+    /**
+     * @return array<string, ExternalCategoryMapping>
+     */
+    private function activeMappingsByIdentity(): array
+    {
+        if (null !== $this->activeMappingsByIdentity) {
+            return $this->activeMappingsByIdentity;
+        }
+
+        $this->activeMappingsByIdentity = [];
+        foreach ($this->mappingRepository->findActiveBySourceAndResource(IngestSource::OZON, OzonResourceType::ACCRUAL_BY_DAY) as $mapping) {
+            $category = $mapping->getExternalCategory();
+            $this->activeMappingsByIdentity[$this->mappingIdentityKey($category->getScope(), $category->getNormalizedKey())] = $mapping;
+        }
+
+        return $this->activeMappingsByIdentity;
+    }
+
+    private function mappingIdentityKey(string $scope, string $normalizedKey): string
+    {
+        return sprintf('%s:%s', $scope, $normalizedKey);
     }
 
     private function categoryFromMapping(?ExternalCategoryMapping $mapping): ?OzonAccrualCategory
@@ -150,12 +179,15 @@ final class OzonAccrualCategoryTaxonomyResolver
             return null;
         }
 
+        $staticCategory = OzonAccrualCategory::findByCode($mapping->getCanonicalCode());
+
         return new OzonAccrualCategory(
             code: $mapping->getCanonicalCode(),
             label: $mapping->getCanonicalLabel(),
             group: $mapping->getCanonicalGroup(),
             transactionType: $mapping->getTransactionType(),
             sortOrder: $mapping->getSortOrder(),
+            parentLabel: $staticCategory?->parentLabel,
             known: $mapping->isKnown(),
         );
     }

--- a/site/src/Ingestion/Command/MarketplaceCategoryDiscoverCommand.php
+++ b/site/src/Ingestion/Command/MarketplaceCategoryDiscoverCommand.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Command;
+
+use App\Ingestion\Application\Action\DiscoverExternalCategoriesAction;
+use App\Ingestion\Enum\IngestSource;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:ingestion:marketplace-categories:discover',
+    description: 'Discovers unknown marketplace external categories from normalized Ingestion transactions.',
+)]
+final class MarketplaceCategoryDiscoverCommand extends Command
+{
+    public function __construct(private readonly DiscoverExternalCategoriesAction $discoverExternalCategories)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('source', null, InputOption::VALUE_REQUIRED, 'Marketplace source.', IngestSource::OZON->value)
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Max grouped unknown categories to scan.', 500);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        try {
+            $source = IngestSource::from((string) $input->getOption('source'));
+            $limit = (int) $input->getOption('limit');
+            $stats = ($this->discoverExternalCategories)($source, $limit);
+        } catch (\Throwable $exception) {
+            $io->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $io->title('Marketplace category discovery');
+        $io->table(
+            ['metric', 'value'],
+            array_map(
+                static fn (string $metric, int $value): array => [$metric, (string) $value],
+                array_keys($stats),
+                array_values($stats),
+            ),
+        );
+        $io->success('Marketplace category discovery finished.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/site/src/Ingestion/Command/MarketplaceCategorySeedDefaultsCommand.php
+++ b/site/src/Ingestion/Command/MarketplaceCategorySeedDefaultsCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Command;
+
+use App\Ingestion\Application\Action\SeedExternalCategoryMappingsAction;
+use App\Ingestion\Enum\IngestSource;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:ingestion:marketplace-categories:seed-defaults',
+    description: 'Seeds default global marketplace external category mappings.',
+)]
+final class MarketplaceCategorySeedDefaultsCommand extends Command
+{
+    public function __construct(private readonly SeedExternalCategoryMappingsAction $seedDefaults)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('source', null, InputOption::VALUE_REQUIRED, 'Marketplace source.', IngestSource::OZON->value);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        try {
+            $source = IngestSource::from((string) $input->getOption('source'));
+            $stats = ($this->seedDefaults)($source);
+        } catch (\Throwable $exception) {
+            $io->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $io->title('Marketplace category default mappings');
+        $io->table(
+            ['metric', 'value'],
+            array_map(
+                static fn (string $metric, int $value): array => [$metric, (string) $value],
+                array_keys($stats),
+                array_values($stats),
+            ),
+        );
+        $io->success('Default marketplace category mappings are up to date.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/site/src/Ingestion/Command/MarketplaceCategoryStatusCommand.php
+++ b/site/src/Ingestion/Command/MarketplaceCategoryStatusCommand.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Command;
+
+use App\Ingestion\Infrastructure\Query\ExternalCategoryAdminQuery;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:ingestion:marketplace-categories:status',
+    description: 'Shows marketplace external category mapping status.',
+)]
+final class MarketplaceCategoryStatusCommand extends Command
+{
+    public function __construct(private readonly ExternalCategoryAdminQuery $query)
+    {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $io->title('Marketplace category taxonomy status');
+
+        $unclassified = $this->query->unclassifiedOzonAccrualTransactions();
+        $io->section('Ozon accrual report health');
+        $io->table(
+            ['metric', 'value'],
+            [
+                ['unclassifiedTransactions', (string) $unclassified['transactions']],
+                ['unclassifiedGroups', (string) $unclassified['groups']],
+            ],
+        );
+
+        $summary = $this->query->statusSummary();
+        $io->section('External categories by status');
+        if ([] === $summary) {
+            $io->writeln('No external categories have been recorded yet.');
+        } else {
+            $io->table(
+                ['source', 'resourceType', 'status', 'categories'],
+                array_map(static fn (array $row): array => [
+                    $row['source'],
+                    $row['resource_type'],
+                    $row['status'],
+                    (string) $row['categories'],
+                ], $summary),
+            );
+        }
+
+        $latest = $this->query->latestCategories(20);
+        $io->section('Latest categories');
+        if ([] === $latest) {
+            $io->writeln('No external categories.');
+        } else {
+            $io->table(
+                ['status', 'source', 'scope', 'external', 'mappedTo', 'seen', 'lastSeenAt'],
+                array_map(static fn (array $row): array => [
+                    (string) $row['status'],
+                    (string) $row['source'],
+                    (string) $row['scope'],
+                    (string) ($row['external_name'] ?? $row['external_type_id'] ?? $row['normalized_key']),
+                    trim(sprintf('%s %s', (string) ($row['canonical_group'] ?? ''), (string) ($row['canonical_label'] ?? ''))),
+                    (string) $row['seen_count'],
+                    (string) $row['last_seen_at'],
+                ], $latest),
+            );
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/site/src/Ingestion/Command/OzonAccrualRefreshCategoryMetadataCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualRefreshCategoryMetadataCommand.php
@@ -197,7 +197,11 @@ final class OzonAccrualRefreshCategoryMetadataCommand extends Command
 
                 /** @var list<array<string, mixed>> $rows */
                 $rows = array_values(iterator_to_array($this->rawStorageFacade->read($rawRecord->getId(), $companyId), false));
-                $mappedTransactions = $this->mapper->map($rawRecord, $rows);
+                $mappedTransactions = $this->mapper->mapForCategoryMetadataRefresh(
+                    rawRecord: $rawRecord,
+                    rows: $rows,
+                    recordUnknownCategories: !$dryRun,
+                );
                 $existingByKey = $this->existingTransactionsByNaturalKey($companyId, $rawRecord);
 
                 $scanned = 0;
@@ -254,8 +258,11 @@ final class OzonAccrualRefreshCategoryMetadataCommand extends Command
                     'missing' => $missing,
                 ];
             } catch (\Throwable $exception) {
-                if (!$dryRun && $connection->isTransactionActive()) {
-                    $connection->rollBack();
+                if (!$dryRun) {
+                    if ($connection->isTransactionActive()) {
+                        $connection->rollBack();
+                    }
+                    $this->entityManager->clear();
                 }
 
                 $resultRows[] = [

--- a/site/src/Ingestion/Entity/ExternalCategory.php
+++ b/site/src/Ingestion/Entity/ExternalCategory.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Entity;
+
+use App\Ingestion\Enum\ExternalCategoryStatus;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Repository\ExternalCategoryRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity(repositoryClass: ExternalCategoryRepository::class)]
+#[ORM\Table(name: 'ingest_external_categories')]
+#[ORM\UniqueConstraint(name: 'uniq_ingest_ext_category_identity', columns: ['source', 'resource_type', 'scope', 'normalized_key'])]
+#[ORM\Index(name: 'idx_ingest_ext_category_status', columns: ['status', 'last_seen_at'])]
+#[ORM\Index(name: 'idx_ingest_ext_category_source_resource', columns: ['source', 'resource_type'])]
+class ExternalCategory
+{
+    #[ORM\Id]
+    #[ORM\Column(type: Types::GUID)]
+    private string $id;
+
+    #[ORM\Column(type: Types::STRING, length: 64, enumType: IngestSource::class)]
+    private IngestSource $source;
+
+    #[ORM\Column(type: Types::STRING, length: 100)]
+    private string $resourceType;
+
+    #[ORM\Column(type: Types::STRING, length: 64)]
+    private string $scope;
+
+    #[ORM\Column(type: Types::STRING, length: 100, nullable: true)]
+    private ?string $externalTypeId;
+
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
+    private ?string $externalName;
+
+    #[ORM\Column(type: Types::STRING, length: 512)]
+    private string $normalizedKey;
+
+    #[ORM\Column(type: Types::STRING, length: 32, enumType: ExternalCategoryStatus::class)]
+    private ExternalCategoryStatus $status;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6)]
+    private \DateTimeImmutable $firstSeenAt;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6)]
+    private \DateTimeImmutable $lastSeenAt;
+
+    #[ORM\Column(type: Types::INTEGER, options: ['default' => 1])]
+    private int $seenCount = 1;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6)]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6)]
+    private \DateTimeImmutable $updatedAt;
+
+    public function __construct(
+        IngestSource $source,
+        string $resourceType,
+        string $scope,
+        string $normalizedKey,
+        ?string $externalTypeId = null,
+        ?string $externalName = null,
+        ExternalCategoryStatus $status = ExternalCategoryStatus::NEW,
+        ?\DateTimeImmutable $seenAt = null,
+    ) {
+        Assert::notEmpty($resourceType);
+        Assert::notEmpty($scope);
+        Assert::notEmpty($normalizedKey);
+
+        $now = $seenAt ?? new \DateTimeImmutable();
+
+        $this->id = Uuid::uuid7()->toString();
+        $this->source = $source;
+        $this->resourceType = $resourceType;
+        $this->scope = $scope;
+        $this->normalizedKey = $normalizedKey;
+        $this->externalTypeId = $this->normalizeNullable($externalTypeId);
+        $this->externalName = $this->normalizeNullable($externalName);
+        $this->status = $status;
+        $this->firstSeenAt = $now;
+        $this->lastSeenAt = $now;
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getSource(): IngestSource
+    {
+        return $this->source;
+    }
+
+    public function getResourceType(): string
+    {
+        return $this->resourceType;
+    }
+
+    public function getScope(): string
+    {
+        return $this->scope;
+    }
+
+    public function getExternalTypeId(): ?string
+    {
+        return $this->externalTypeId;
+    }
+
+    public function getExternalName(): ?string
+    {
+        return $this->externalName;
+    }
+
+    public function getNormalizedKey(): string
+    {
+        return $this->normalizedKey;
+    }
+
+    public function getStatus(): ExternalCategoryStatus
+    {
+        return $this->status;
+    }
+
+    public function getFirstSeenAt(): \DateTimeImmutable
+    {
+        return $this->firstSeenAt;
+    }
+
+    public function getLastSeenAt(): \DateTimeImmutable
+    {
+        return $this->lastSeenAt;
+    }
+
+    public function getSeenCount(): int
+    {
+        return $this->seenCount;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function markSeen(?string $externalTypeId = null, ?string $externalName = null, ?\DateTimeImmutable $seenAt = null): void
+    {
+        $this->externalTypeId ??= $this->normalizeNullable($externalTypeId);
+        $this->externalName ??= $this->normalizeNullable($externalName);
+        $this->lastSeenAt = $seenAt ?? new \DateTimeImmutable();
+        ++$this->seenCount;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function markMapped(): void
+    {
+        $this->status = ExternalCategoryStatus::MAPPED;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function markNew(): void
+    {
+        $this->status = ExternalCategoryStatus::NEW;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function markIgnored(): void
+    {
+        $this->status = ExternalCategoryStatus::IGNORED;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function markDeprecated(): void
+    {
+        $this->status = ExternalCategoryStatus::DEPRECATED;
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    private function normalizeNullable(?string $value): ?string
+    {
+        $value = null === $value ? null : trim($value);
+
+        return '' === $value ? null : $value;
+    }
+}

--- a/site/src/Ingestion/Entity/ExternalCategoryMapping.php
+++ b/site/src/Ingestion/Entity/ExternalCategoryMapping.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Entity;
+
+use App\Ingestion\Enum\ExternalCategoryMappingStatus;
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+use App\Ingestion\Repository\ExternalCategoryMappingRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity(repositoryClass: ExternalCategoryMappingRepository::class)]
+#[ORM\Table(name: 'ingest_external_category_mappings')]
+#[ORM\UniqueConstraint(name: 'uniq_ingest_ext_category_mapping_category', columns: ['external_category_id'])]
+#[ORM\Index(name: 'idx_ingest_ext_category_mapping_status', columns: ['status', 'updated_at'])]
+class ExternalCategoryMapping
+{
+    #[ORM\Id]
+    #[ORM\Column(type: Types::GUID)]
+    private string $id;
+
+    #[ORM\OneToOne(targetEntity: ExternalCategory::class)]
+    #[ORM\JoinColumn(name: 'external_category_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private ExternalCategory $externalCategory;
+
+    #[ORM\Column(type: Types::STRING, length: 100)]
+    private string $canonicalCode;
+
+    #[ORM\Column(type: Types::STRING, length: 255)]
+    private string $canonicalLabel;
+
+    #[ORM\Column(type: Types::STRING, length: 255)]
+    private string $canonicalGroup;
+
+    #[ORM\Column(type: Types::STRING, length: 64, enumType: TransactionType::class)]
+    private TransactionType $transactionType;
+
+    #[ORM\Column(type: Types::STRING, length: 8, enumType: TransactionDirection::class, nullable: true)]
+    private ?TransactionDirection $defaultDirection;
+
+    #[ORM\Column(type: Types::INTEGER, options: ['default' => 9000])]
+    private int $sortOrder;
+
+    #[ORM\Column(type: Types::BOOLEAN, options: ['default' => true])]
+    private bool $known;
+
+    #[ORM\Column(type: Types::STRING, length: 32, enumType: ExternalCategoryMappingStatus::class)]
+    private ExternalCategoryMappingStatus $status;
+
+    #[ORM\Column(type: Types::GUID, nullable: true)]
+    private ?string $updatedBy;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6)]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, precision: 6)]
+    private \DateTimeImmutable $updatedAt;
+
+    public function __construct(
+        ExternalCategory $externalCategory,
+        string $canonicalCode,
+        string $canonicalLabel,
+        string $canonicalGroup,
+        TransactionType $transactionType,
+        int $sortOrder,
+        ?TransactionDirection $defaultDirection = null,
+        bool $known = true,
+        ExternalCategoryMappingStatus $status = ExternalCategoryMappingStatus::ACTIVE,
+        ?string $updatedBy = null,
+    ) {
+        Assert::notEmpty($canonicalCode);
+        Assert::notEmpty($canonicalLabel);
+        Assert::notEmpty($canonicalGroup);
+        Assert::greaterThan($sortOrder, 0);
+        if (null !== $updatedBy) {
+            Assert::uuid($updatedBy);
+        }
+
+        $now = new \DateTimeImmutable();
+
+        $this->id = Uuid::uuid7()->toString();
+        $this->externalCategory = $externalCategory;
+        $this->canonicalCode = $canonicalCode;
+        $this->canonicalLabel = $canonicalLabel;
+        $this->canonicalGroup = $canonicalGroup;
+        $this->transactionType = $transactionType;
+        $this->sortOrder = $sortOrder;
+        $this->defaultDirection = $defaultDirection;
+        $this->known = $known;
+        $this->status = $status;
+        $this->updatedBy = $updatedBy;
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+
+        if (ExternalCategoryMappingStatus::ACTIVE === $status) {
+            $externalCategory->markMapped();
+        }
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getExternalCategory(): ExternalCategory
+    {
+        return $this->externalCategory;
+    }
+
+    public function getCanonicalCode(): string
+    {
+        return $this->canonicalCode;
+    }
+
+    public function getCanonicalLabel(): string
+    {
+        return $this->canonicalLabel;
+    }
+
+    public function getCanonicalGroup(): string
+    {
+        return $this->canonicalGroup;
+    }
+
+    public function getTransactionType(): TransactionType
+    {
+        return $this->transactionType;
+    }
+
+    public function getDefaultDirection(): ?TransactionDirection
+    {
+        return $this->defaultDirection;
+    }
+
+    public function getSortOrder(): int
+    {
+        return $this->sortOrder;
+    }
+
+    public function isKnown(): bool
+    {
+        return $this->known;
+    }
+
+    public function getStatus(): ExternalCategoryMappingStatus
+    {
+        return $this->status;
+    }
+
+    public function getUpdatedBy(): ?string
+    {
+        return $this->updatedBy;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function update(
+        string $canonicalCode,
+        string $canonicalLabel,
+        string $canonicalGroup,
+        TransactionType $transactionType,
+        int $sortOrder,
+        ?TransactionDirection $defaultDirection,
+        bool $known,
+        ExternalCategoryMappingStatus $status,
+        ?string $updatedBy = null,
+    ): void {
+        Assert::notEmpty($canonicalCode);
+        Assert::notEmpty($canonicalLabel);
+        Assert::notEmpty($canonicalGroup);
+        Assert::greaterThan($sortOrder, 0);
+        if (null !== $updatedBy) {
+            Assert::uuid($updatedBy);
+        }
+
+        $this->canonicalCode = $canonicalCode;
+        $this->canonicalLabel = $canonicalLabel;
+        $this->canonicalGroup = $canonicalGroup;
+        $this->transactionType = $transactionType;
+        $this->sortOrder = $sortOrder;
+        $this->defaultDirection = $defaultDirection;
+        $this->known = $known;
+        $this->status = $status;
+        $this->updatedBy = $updatedBy;
+        $this->updatedAt = new \DateTimeImmutable();
+
+        if (ExternalCategoryMappingStatus::ACTIVE === $status) {
+            $this->externalCategory->markMapped();
+        }
+    }
+}

--- a/site/src/Ingestion/Enum/ExternalCategoryMappingStatus.php
+++ b/site/src/Ingestion/Enum/ExternalCategoryMappingStatus.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Enum;
+
+enum ExternalCategoryMappingStatus: string
+{
+    case ACTIVE = 'active';
+    case NEEDS_REVIEW = 'needs_review';
+    case DISABLED = 'disabled';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::ACTIVE => 'Активна',
+            self::NEEDS_REVIEW => 'Требует проверки',
+            self::DISABLED => 'Отключена',
+        };
+    }
+}

--- a/site/src/Ingestion/Enum/ExternalCategoryStatus.php
+++ b/site/src/Ingestion/Enum/ExternalCategoryStatus.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Enum;
+
+enum ExternalCategoryStatus: string
+{
+    case NEW = 'new';
+    case MAPPED = 'mapped';
+    case IGNORED = 'ignored';
+    case DEPRECATED = 'deprecated';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::NEW => 'Требует классификации',
+            self::MAPPED => 'Сопоставлена',
+            self::IGNORED => 'Игнорируется',
+            self::DEPRECATED => 'Устарела',
+        };
+    }
+}

--- a/site/src/Ingestion/Infrastructure/Query/ExternalCategoryAdminQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/ExternalCategoryAdminQuery.php
@@ -83,7 +83,15 @@ final readonly class ExternalCategoryAdminQuery
                             m.status AS mapping_status
                      FROM ingest_external_categories c
                      LEFT JOIN ingest_external_category_mappings m ON m.external_category_id = c.id
-                     ORDER BY c.status ASC, c.last_seen_at DESC, c.created_at DESC
+                     ORDER BY CASE c.status
+                                WHEN \'new\' THEN 0
+                                WHEN \'mapped\' THEN 1
+                                WHEN \'ignored\' THEN 2
+                                WHEN \'deprecated\' THEN 3
+                                ELSE 9
+                              END ASC,
+                              c.last_seen_at DESC,
+                              c.created_at DESC
                      LIMIT %d',
                     $limit,
                 ),

--- a/site/src/Ingestion/Infrastructure/Query/ExternalCategoryAdminQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/ExternalCategoryAdminQuery.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Query;
+
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Enum\IngestSource;
+use Doctrine\DBAL\Connection;
+
+final readonly class ExternalCategoryAdminQuery
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    /**
+     * @return list<array{source: string, resource_type: string, status: string, categories: int}>
+     */
+    public function statusSummary(): array
+    {
+        return array_map(
+            static fn (array $row): array => [
+                'source' => (string) $row['source'],
+                'resource_type' => (string) $row['resource_type'],
+                'status' => (string) $row['status'],
+                'categories' => (int) $row['categories'],
+            ],
+            $this->connection->fetchAllAssociative(
+                'SELECT source, resource_type, status, COUNT(*) AS categories
+                 FROM ingest_external_categories
+                 GROUP BY source, resource_type, status
+                 ORDER BY source ASC, resource_type ASC, status ASC',
+            ),
+        );
+    }
+
+    /**
+     * @return list<array<string, string|int|null>>
+     */
+    public function latestCategories(int $limit = 50): array
+    {
+        $limit = max(1, min(200, $limit));
+
+        return array_map(
+            static fn (array $row): array => [
+                'id' => (string) $row['id'],
+                'source' => (string) $row['source'],
+                'resource_type' => (string) $row['resource_type'],
+                'scope' => (string) $row['scope'],
+                'normalized_key' => (string) $row['normalized_key'],
+                'external_type_id' => null !== $row['external_type_id'] ? (string) $row['external_type_id'] : null,
+                'external_name' => null !== $row['external_name'] ? (string) $row['external_name'] : null,
+                'status' => (string) $row['status'],
+                'seen_count' => (int) $row['seen_count'],
+                'last_seen_at' => (string) $row['last_seen_at'],
+                'canonical_code' => null !== $row['canonical_code'] ? (string) $row['canonical_code'] : null,
+                'canonical_group' => null !== $row['canonical_group'] ? (string) $row['canonical_group'] : null,
+                'canonical_label' => null !== $row['canonical_label'] ? (string) $row['canonical_label'] : null,
+                'transaction_type' => null !== $row['transaction_type'] ? (string) $row['transaction_type'] : null,
+                'sort_order' => null !== $row['sort_order'] ? (int) $row['sort_order'] : null,
+                'known' => null !== $row['known'] ? (bool) $row['known'] : null,
+                'mapping_status' => null !== $row['mapping_status'] ? (string) $row['mapping_status'] : null,
+            ],
+            $this->connection->fetchAllAssociative(
+                sprintf(
+                    'SELECT c.id,
+                            c.source,
+                            c.resource_type,
+                            c.scope,
+                            c.normalized_key,
+                            c.external_type_id,
+                            c.external_name,
+                            c.status,
+                            c.seen_count,
+                            c.last_seen_at,
+                            m.canonical_code,
+                            m.canonical_group,
+                            m.canonical_label,
+                            m.transaction_type,
+                            m.sort_order,
+                            m.known,
+                            m.status AS mapping_status
+                     FROM ingest_external_categories c
+                     LEFT JOIN ingest_external_category_mappings m ON m.external_category_id = c.id
+                     ORDER BY c.status ASC, c.last_seen_at DESC, c.created_at DESC
+                     LIMIT %d',
+                    $limit,
+                ),
+            ),
+        );
+    }
+
+    /**
+     * @return array{transactions: int, groups: int}
+     */
+    public function unclassifiedOzonAccrualTransactions(): array
+    {
+        $row = $this->connection->fetchAssociative(
+            "SELECT
+                COUNT(*) AS transactions,
+                COUNT(DISTINCT COALESCE(NULLIF(ft.source_data->>'_ozon_category_label', ''), ft.description, ft.type)) AS groups
+             FROM ingest_financial_transactions ft
+             WHERE ft.source = :source
+               AND ft.source_data->>'_ingestion_resource' = :resourceType
+               AND (
+                    ft.source_data->>'_ozon_category_known' = 'false'
+                    OR NULLIF(ft.source_data->>'_ozon_category_group', '') IS NULL
+                    OR ft.source_data->>'_ozon_category_group' IN ('Неизвестные категории Ozon', 'Требует классификации', 'Без группы Ozon')
+                    OR ft.source_data->>'_ozon_category_label' LIKE 'Неизвест%'
+                    OR COALESCE(ft.description, '') LIKE 'Ozon accrual%'
+               )",
+            [
+                'source' => IngestSource::OZON->value,
+                'resourceType' => OzonResourceType::ACCRUAL_BY_DAY,
+            ],
+        );
+
+        return [
+            'transactions' => (int) ($row['transactions'] ?? 0),
+            'groups' => (int) ($row['groups'] ?? 0),
+        ];
+    }
+}

--- a/site/src/Ingestion/Infrastructure/Query/FinancialSummaryQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/FinancialSummaryQuery.php
@@ -168,8 +168,8 @@ final class FinancialSummaryQuery
                 "WITH base AS (
                     SELECT
                         ft.source,
-                        COALESCE(NULLIF(ft.source_data->>'_ozon_category_group', ''), 'Без группы Ozon') AS category_group,
-                        COALESCE(NULLIF(ft.source_data->>'_ozon_category_label', ''), ft.description, ft.type) AS category_name,
+                        COALESCE(NULLIF(ft.source_data->>'_ozon_category_group', ''), 'Требует классификации') AS category_group,
+                        COALESCE(NULLIF(ft.source_data->>'_ozon_category_label', ''), 'Неклассифицированная категория Ozon') AS category_name,
                         ft.type,
                         ft.direction,
                         ABS(ft.amount_minor::bigint) AS amount_minor,

--- a/site/src/Ingestion/Infrastructure/Query/FinancialSummaryQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/FinancialSummaryQuery.php
@@ -169,7 +169,7 @@ final class FinancialSummaryQuery
                     SELECT
                         ft.source,
                         COALESCE(NULLIF(ft.source_data->>'_ozon_category_group', ''), 'Требует классификации') AS category_group,
-                        COALESCE(NULLIF(ft.source_data->>'_ozon_category_label', ''), 'Неклассифицированная категория Ozon') AS category_name,
+                        COALESCE(NULLIF(ft.source_data->>'_ozon_category_label', ''), NULLIF(ft.description, ''), ft.type, 'Неклассифицированная категория Ozon') AS category_name,
                         ft.type,
                         ft.direction,
                         ABS(ft.amount_minor::bigint) AS amount_minor,

--- a/site/src/Ingestion/Repository/ExternalCategoryMappingRepository.php
+++ b/site/src/Ingestion/Repository/ExternalCategoryMappingRepository.php
@@ -62,4 +62,22 @@ final class ExternalCategoryMappingRepository extends ServiceEntityRepository
             ->getQuery()
             ->getOneOrNullResult();
     }
+
+    /**
+     * @return list<ExternalCategoryMapping>
+     */
+    public function findActiveBySourceAndResource(IngestSource $source, string $resourceType): array
+    {
+        return $this->createQueryBuilder('mapping')
+            ->innerJoin('mapping.externalCategory', 'category')
+            ->addSelect('category')
+            ->andWhere('category.source = :source')
+            ->andWhere('category.resourceType = :resourceType')
+            ->andWhere('mapping.status = :status')
+            ->setParameter('source', $source->value)
+            ->setParameter('resourceType', $resourceType)
+            ->setParameter('status', ExternalCategoryMappingStatus::ACTIVE->value)
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/site/src/Ingestion/Repository/ExternalCategoryMappingRepository.php
+++ b/site/src/Ingestion/Repository/ExternalCategoryMappingRepository.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Repository;
+
+use App\Ingestion\Entity\ExternalCategory;
+use App\Ingestion\Entity\ExternalCategoryMapping;
+use App\Ingestion\Enum\ExternalCategoryMappingStatus;
+use App\Ingestion\Enum\IngestSource;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<ExternalCategoryMapping>
+ */
+final class ExternalCategoryMappingRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ExternalCategoryMapping::class);
+    }
+
+    public function findActiveByCategory(ExternalCategory $category): ?ExternalCategoryMapping
+    {
+        return $this->createQueryBuilder('mapping')
+            ->andWhere('mapping.externalCategory = :category')
+            ->andWhere('mapping.status = :status')
+            ->setParameter('category', $category)
+            ->setParameter('status', ExternalCategoryMappingStatus::ACTIVE->value)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    public function findByCategory(ExternalCategory $category): ?ExternalCategoryMapping
+    {
+        return $this->createQueryBuilder('mapping')
+            ->andWhere('mapping.externalCategory = :category')
+            ->setParameter('category', $category)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    public function findActiveByIdentity(
+        IngestSource $source,
+        string $resourceType,
+        string $scope,
+        string $normalizedKey,
+    ): ?ExternalCategoryMapping {
+        return $this->createQueryBuilder('mapping')
+            ->innerJoin('mapping.externalCategory', 'category')
+            ->andWhere('category.source = :source')
+            ->andWhere('category.resourceType = :resourceType')
+            ->andWhere('category.scope = :scope')
+            ->andWhere('category.normalizedKey = :normalizedKey')
+            ->andWhere('mapping.status = :status')
+            ->setParameter('source', $source->value)
+            ->setParameter('resourceType', $resourceType)
+            ->setParameter('scope', $scope)
+            ->setParameter('normalizedKey', $normalizedKey)
+            ->setParameter('status', ExternalCategoryMappingStatus::ACTIVE->value)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+}

--- a/site/src/Ingestion/Repository/ExternalCategoryRepository.php
+++ b/site/src/Ingestion/Repository/ExternalCategoryRepository.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Repository;
+
+use App\Ingestion\Entity\ExternalCategory;
+use App\Ingestion\Enum\ExternalCategoryStatus;
+use App\Ingestion\Enum\IngestSource;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<ExternalCategory>
+ */
+final class ExternalCategoryRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ExternalCategory::class);
+    }
+
+    public function findByIdentity(
+        IngestSource $source,
+        string $resourceType,
+        string $scope,
+        string $normalizedKey,
+    ): ?ExternalCategory {
+        return $this->createQueryBuilder('category')
+            ->andWhere('category.source = :source')
+            ->andWhere('category.resourceType = :resourceType')
+            ->andWhere('category.scope = :scope')
+            ->andWhere('category.normalizedKey = :normalizedKey')
+            ->setParameter('source', $source->value)
+            ->setParameter('resourceType', $resourceType)
+            ->setParameter('scope', $scope)
+            ->setParameter('normalizedKey', $normalizedKey)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    /**
+     * @return list<ExternalCategory>
+     */
+    public function findByStatus(ExternalCategoryStatus $status, int $limit = 100): array
+    {
+        return $this->createQueryBuilder('category')
+            ->andWhere('category.status = :status')
+            ->setParameter('status', $status->value)
+            ->orderBy('category.lastSeenAt', 'DESC')
+            ->addOrderBy('category.createdAt', 'DESC')
+            ->setMaxResults(max(1, min(500, $limit)))
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/site/templates/admin/marketplace/category_taxonomy/index.html.twig
+++ b/site/templates/admin/marketplace/category_taxonomy/index.html.twig
@@ -1,0 +1,271 @@
+{% extends 'admin/base.html.twig' %}
+
+{% block title %}Admin · Категории затрат маркетплейсов{% endblock %}
+
+{% block body %}
+  <div class="page-header d-print-none">
+    <div class="row align-items-center">
+      <div class="col">
+        <h2 class="page-title">Категории затрат маркетплейсов</h2>
+      </div>
+    </div>
+  </div>
+
+  {% for message in app.flashes('success') %}
+    <div class="alert alert-success alert-dismissible mt-3" role="alert">
+      <div>{{ message|nl2br }}</div>
+      <a class="btn-close" data-bs-dismiss="alert" aria-label="Close"></a>
+    </div>
+  {% endfor %}
+
+  {% for message in app.flashes('error') %}
+    <div class="alert alert-danger alert-dismissible mt-3" role="alert">
+      <div>{{ message|nl2br }}</div>
+      <a class="btn-close" data-bs-dismiss="alert" aria-label="Close"></a>
+    </div>
+  {% endfor %}
+
+  <div class="row row-cards mt-3">
+    <div class="col-sm-6 col-lg-3">
+      <div class="card">
+        <div class="card-body">
+          <div class="subheader">Неклассифицированные операции Ozon</div>
+          <div class="h1 mb-0">{{ unclassified.transactions }}</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-sm-6 col-lg-3">
+      <div class="card">
+        <div class="card-body">
+          <div class="subheader">Неклассифицированные группы</div>
+          <div class="h1 mb-0">{{ unclassified.groups }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row row-cards mt-3">
+    <div class="col-lg-4">
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">Операции</h3>
+        </div>
+        <div class="card-body">
+          <form action="{{ path('admin_marketplace_category_taxonomy_seed_defaults') }}" method="POST" class="mb-3">
+            <input type="hidden" name="_token" value="{{ csrf_token('admin_marketplace_category_taxonomy_seed_defaults') }}">
+            <button type="submit" class="btn btn-primary w-100">Обновить базовые Ozon-маппинги</button>
+          </form>
+
+          <form action="{{ path('admin_marketplace_category_taxonomy_discover') }}" method="POST">
+            <input type="hidden" name="_token" value="{{ csrf_token('admin_marketplace_category_taxonomy_discover') }}">
+            <div class="mb-3">
+              <label class="form-label" for="discover_limit">Лимит discovery</label>
+              <input type="number" min="1" max="5000" class="form-control" id="discover_limit" name="limit" value="500">
+            </div>
+            <button type="submit" class="btn btn-outline-primary w-100">Найти новые категории</button>
+          </form>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-lg-8">
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">Refresh metadata Ozon accrual</h3>
+        </div>
+        <div class="card-body">
+          <form action="{{ path('admin_marketplace_category_taxonomy_refresh_ozon_metadata') }}" method="POST">
+            <input type="hidden" name="_token" value="{{ csrf_token('admin_marketplace_category_taxonomy_refresh_ozon_metadata') }}">
+            <div class="row">
+              <div class="col-md-6 mb-3">
+                <label class="form-label" for="refresh_company_id">Company ID</label>
+                <input type="text" class="form-control" id="refresh_company_id" name="company_id" placeholder="UUID компании" required>
+              </div>
+              <div class="col-md-6 mb-3">
+                <label class="form-label" for="refresh_shop_ref">Shop ref</label>
+                <input type="text" class="form-control" id="refresh_shop_ref" name="shop_ref" placeholder="опционально">
+              </div>
+              <div class="col-md-4 mb-3">
+                <label class="form-label" for="refresh_from">From</label>
+                <input type="date" class="form-control" id="refresh_from" name="from" required>
+              </div>
+              <div class="col-md-4 mb-3">
+                <label class="form-label" for="refresh_to">To</label>
+                <input type="date" class="form-control" id="refresh_to" name="to" required>
+              </div>
+              <div class="col-md-4 mb-3">
+                <label class="form-label" for="refresh_limit">Raw limit</label>
+                <input type="number" min="1" max="500" class="form-control" id="refresh_limit" name="limit" value="100">
+              </div>
+            </div>
+            <div class="btn-list">
+              <button type="submit" name="mode" value="dry-run" class="btn btn-outline-primary">Dry-run</button>
+              <button type="submit" name="mode" value="execute" class="btn btn-danger">Execute refresh</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {% if last_refresh %}
+    <div class="card mt-3">
+      <div class="card-header">
+        <h3 class="card-title">Последний refresh: {{ last_refresh.mode }}</h3>
+      </div>
+      <div class="card-body">
+        <div class="table-responsive">
+          <table class="table table-vcenter">
+            <thead>
+              <tr>
+                <th>Raw ID</th>
+                <th>Status</th>
+                <th>Scanned</th>
+                <th>Matched</th>
+                <th>Updated</th>
+                <th>Unchanged</th>
+                <th>Missing</th>
+                <th>Error</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for row in last_refresh.results %}
+                <tr>
+                  <td><code>{{ row.rawId }}</code></td>
+                  <td>{{ row.status }}</td>
+                  <td>{{ row.scanned }}</td>
+                  <td>{{ row.matched }}</td>
+                  <td>{{ row.updated }}</td>
+                  <td>{{ row.unchanged }}</td>
+                  <td>{{ row.missing }}</td>
+                  <td>{{ row.error|default('') }}</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  {% endif %}
+
+  <div class="card mt-3">
+    <div class="card-header">
+      <h3 class="card-title">Статусы справочника</h3>
+    </div>
+    <div class="card-body">
+      {% if status_summary is empty %}
+        <div class="alert alert-info mb-0">Справочник еще не заполнен</div>
+      {% else %}
+        <div class="table-responsive">
+          <table class="table table-vcenter">
+            <thead>
+              <tr>
+                <th>Source</th>
+                <th>Resource</th>
+                <th>Status</th>
+                <th>Categories</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for row in status_summary %}
+                <tr>
+                  <td>{{ row.source }}</td>
+                  <td>{{ row.resource_type }}</td>
+                  <td>{{ row.status }}</td>
+                  <td>{{ row.categories }}</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% endif %}
+    </div>
+  </div>
+
+  <div class="card mt-3">
+    <div class="card-header">
+      <h3 class="card-title">Последние внешние категории</h3>
+    </div>
+    <div class="card-body">
+      {% if latest_categories is empty %}
+        <div class="alert alert-info mb-0">Категорий пока нет</div>
+      {% else %}
+        <div class="table-responsive">
+          <table class="table table-vcenter">
+            <thead>
+              <tr>
+                <th>Status</th>
+                <th>Scope</th>
+                <th>External</th>
+                <th>Mapping</th>
+                <th>Seen</th>
+                <th>Last seen</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for row in latest_categories %}
+                <tr>
+                  <td>{{ row.status }}</td>
+                  <td>{{ row.scope }}</td>
+                  <td>
+                    {% if row.external_name %}
+                      {{ row.external_name }}
+                    {% elseif row.external_type_id %}
+                      type_id {{ row.external_type_id }}
+                    {% else %}
+                      {{ row.normalized_key }}
+                    {% endif %}
+                  </td>
+                  <td>
+                    <form action="{{ path('admin_marketplace_category_taxonomy_update_mapping', {id: row.id}) }}" method="POST">
+                      <input type="hidden" name="_token" value="{{ csrf_token('admin_marketplace_category_taxonomy_update_mapping_' ~ row.id) }}">
+                      <div class="row g-2">
+                        <div class="col-md-3">
+                          <input class="form-control form-control-sm" name="canonical_code" value="{{ row.canonical_code ?? '' }}" placeholder="code" required>
+                        </div>
+                        <div class="col-md-3">
+                          <input class="form-control form-control-sm" name="canonical_group" value="{{ row.canonical_group ?? '' }}" placeholder="group" required>
+                        </div>
+                        <div class="col-md-3">
+                          <input class="form-control form-control-sm" name="canonical_label" value="{{ row.canonical_label ?? '' }}" placeholder="label" required>
+                        </div>
+                        <div class="col-md-3">
+                          <select class="form-select form-select-sm" name="transaction_type" required>
+                            {% for type in transaction_types %}
+                              <option value="{{ type.value }}" {% if row.transaction_type == type.value %}selected{% endif %}>{{ type.label }}</option>
+                            {% endfor %}
+                          </select>
+                        </div>
+                        <div class="col-md-2">
+                          <input type="number" min="1" max="100000" class="form-control form-control-sm" name="sort_order" value="{{ row.sort_order ?? 9000 }}" placeholder="sort" required>
+                        </div>
+                        <div class="col-md-3">
+                          <select class="form-select form-select-sm" name="mapping_status" required>
+                            {% for status in mapping_statuses %}
+                              <option value="{{ status.value }}" {% if (row.mapping_status ?? 'active') == status.value %}selected{% endif %}>{{ status.label }}</option>
+                            {% endfor %}
+                          </select>
+                        </div>
+                        <div class="col-md-2">
+                          <label class="form-check mt-1">
+                            <input type="checkbox" class="form-check-input" name="known" value="1" {% if row.known is same as(true) or row.known is null %}checked{% endif %}>
+                            <span class="form-check-label">known</span>
+                          </label>
+                        </div>
+                        <div class="col-md-3">
+                          <button type="submit" class="btn btn-sm btn-outline-primary w-100">Сохранить</button>
+                        </div>
+                      </div>
+                    </form>
+                  </td>
+                  <td>{{ row.seen_count }}</td>
+                  <td>{{ row.last_seen_at }}</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}

--- a/site/templates/admin/partials/_sidebar.html.twig
+++ b/site/templates/admin/partials/_sidebar.html.twig
@@ -74,6 +74,12 @@
                                     <span class="nav-link-title">Переобработка затрат</span>
                                 </a>
                             </li>
+                            <li class="nav-item">
+                                <a class="nav-link {% if app.request.get('_route') starts with 'admin_marketplace_category_taxonomy_' %}active{% endif %}"
+                                   href="{{ path('admin_marketplace_category_taxonomy_index') }}">
+                                    <span class="nav-link-title">Категории затрат</span>
+                                </a>
+                            </li>
                         </ul>
                     </div>
                 </li>

--- a/site/tests/Integration/Ingestion/Application/DiscoverExternalCategoriesActionTest.php
+++ b/site/tests/Integration/Ingestion/Application/DiscoverExternalCategoriesActionTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Application;
+
+use App\Ingestion\Application\Action\DiscoverExternalCategoriesAction;
+use App\Ingestion\Application\Source\Ozon\OzonAccrualCategoryTaxonomyResolver;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Entity\ExternalCategory;
+use App\Ingestion\Entity\ExternalCategoryMapping;
+use App\Ingestion\Entity\FinancialTransaction;
+use App\Ingestion\Enum\ExternalCategoryMappingStatus;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+use App\Ingestion\Repository\ExternalCategoryMappingRepository;
+use App\Ingestion\Repository\ExternalCategoryRepository;
+use App\Shared\Domain\ValueObject\Money;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class DiscoverExternalCategoriesActionTest extends IntegrationTestCase
+{
+    public function testDeduplicatesCategoryAndMappingIdentityWithinSingleRun(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $rawRecordId = Uuid::uuid7()->toString();
+
+        $this->em->persist($this->unknownOzonFeeTransaction(
+            companyId: $companyId,
+            rawRecordId: $rawRecordId,
+            externalId: 'ozon:accrual-by-day:1:delivery:product-0:service-0:type-29',
+            component: 'delivery:product-0:service-0:type-29',
+            label: 'Неизвестная категория Ozon: Logistic',
+        ));
+        $this->em->persist($this->unknownOzonFeeTransaction(
+            companyId: $companyId,
+            rawRecordId: $rawRecordId,
+            externalId: 'ozon:accrual-by-day:2:delivery:product-1:service-0:type-29',
+            component: 'delivery:product-1:service-0:type-29',
+            label: 'Неизвестная категория Ozon: Logistic duplicate label',
+        ));
+        $this->em->flush();
+
+        /** @var DiscoverExternalCategoriesAction $action */
+        $action = self::getContainer()->get(DiscoverExternalCategoriesAction::class);
+        $stats = $action(IngestSource::OZON, 10);
+
+        self::assertSame(2, $stats['scanned']);
+        self::assertSame(1, $stats['categoriesCreated']);
+        self::assertSame(1, $stats['categoriesSeen']);
+        self::assertSame(1, $stats['autoMapped']);
+        self::assertSame(0, $stats['unmapped']);
+
+        /** @var ExternalCategoryRepository $categoryRepository */
+        $categoryRepository = self::getContainer()->get(ExternalCategoryRepository::class);
+        $category = $categoryRepository->findByIdentity(
+            IngestSource::OZON,
+            OzonResourceType::ACCRUAL_BY_DAY,
+            OzonAccrualCategoryTaxonomyResolver::SCOPE_DELIVERY,
+            'type:29',
+        );
+
+        self::assertInstanceOf(ExternalCategory::class, $category);
+        self::assertSame(2, $category->getSeenCount());
+
+        /** @var ExternalCategoryMappingRepository $mappingRepository */
+        $mappingRepository = self::getContainer()->get(ExternalCategoryMappingRepository::class);
+        $mapping = $mappingRepository->findByCategory($category);
+
+        self::assertInstanceOf(ExternalCategoryMapping::class, $mapping);
+        self::assertSame(ExternalCategoryMappingStatus::ACTIVE, $mapping->getStatus());
+        self::assertSame('ozon_logistics', $mapping->getCanonicalCode());
+    }
+
+    private function unknownOzonFeeTransaction(
+        string $companyId,
+        string $rawRecordId,
+        string $externalId,
+        string $component,
+        string $label,
+    ): FinancialTransaction {
+        return new FinancialTransaction(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            shopRef: 'shop-1',
+            source: IngestSource::OZON,
+            externalId: $externalId,
+            externalUpdatedAt: new \DateTimeImmutable('2026-06-15 10:00:00+00:00'),
+            operationGroupId: Uuid::uuid7()->toString(),
+            type: TransactionType::FEE,
+            direction: TransactionDirection::OUT,
+            money: Money::fromMinor(100, 'RUB'),
+            occurredAt: new \DateTimeImmutable('2026-06-15 10:00:00+00:00'),
+            rawRecordId: $rawRecordId,
+            description: $label,
+            sourceData: [
+                '_ingestion_resource' => OzonResourceType::ACCRUAL_BY_DAY,
+                '_ingestion_type_id' => '29',
+                '_ingestion_component' => $component,
+                '_ozon_category_known' => false,
+                '_ozon_category_group' => 'Неизвестные категории Ozon',
+                '_ozon_category_label' => $label,
+            ],
+        );
+    }
+}

--- a/site/tests/Integration/Ingestion/Application/RefreshOzonAccrualCategoryMetadataActionTest.php
+++ b/site/tests/Integration/Ingestion/Application/RefreshOzonAccrualCategoryMetadataActionTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Application;
+
+use App\Ingestion\Application\Action\RefreshOzonAccrualCategoryMetadataAction;
+use App\Ingestion\Application\Source\Ozon\OzonAccrualByDayMapper;
+use App\Ingestion\Application\Source\Ozon\OzonAccrualCategoryTaxonomyResolver;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\DTO\RawBatch;
+use App\Ingestion\Entity\FinancialTransaction;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+use App\Ingestion\Facade\RawStorageFacade;
+use App\Ingestion\Repository\ExternalCategoryRepository;
+use App\Ingestion\Repository\FinancialTransactionRepository;
+use App\Ingestion\Repository\IngestRawRecordRepository;
+use App\Shared\Domain\ValueObject\Money;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\Decorator\EntityManagerDecorator;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+
+final class RefreshOzonAccrualCategoryMetadataActionTest extends IntegrationTestCase
+{
+    public function testFailedRowRollbackDoesNotLeakPendingUnknownCategoryIntoLaterFlush(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = Uuid::uuid7()->toString();
+
+        $failedRecord = $this->storeRawRecord(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            externalId: 'accrual-by-day:2026-06-01:2026-06-01',
+            rows: [
+                $this->unknownFeeRow(777, 'UnknownBeforeFailure', '-10.00'),
+            ],
+        );
+        $failedRecord->markNormalizationDone();
+
+        $successfulRecord = $this->storeRawRecord(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            externalId: 'accrual-by-day:2026-06-02:2026-06-02',
+            rows: [$this->itemFeeRow()],
+        );
+        $successfulRecord->markNormalizationDone();
+        $this->em->persist($this->existingTransaction($companyId, $connectionRef, $successfulRecord));
+        $this->em->flush();
+
+        $action = $this->refreshActionWithFirstFlushFailure();
+        $resultRows = $action->refresh($companyId, [
+            ['id' => $failedRecord->getId()],
+            ['id' => $successfulRecord->getId()],
+        ], dryRun: false);
+
+        self::assertSame('error', $resultRows[0]['status']);
+        self::assertSame('done', $resultRows[1]['status']);
+        self::assertSame(1, $resultRows[1]['updated']);
+
+        /** @var ExternalCategoryRepository $categoryRepository */
+        $categoryRepository = self::getContainer()->get(ExternalCategoryRepository::class);
+        self::assertNull($categoryRepository->findByIdentity(
+            IngestSource::OZON,
+            OzonResourceType::ACCRUAL_BY_DAY,
+            OzonAccrualCategoryTaxonomyResolver::SCOPE_NON_ITEM,
+            'type:777',
+        ));
+    }
+
+    private function refreshActionWithFirstFlushFailure(): RefreshOzonAccrualCategoryMetadataAction
+    {
+        $entityManager = new class($this->em) extends EntityManagerDecorator {
+            private int $flushCalls = 0;
+
+            public function __construct(EntityManagerInterface $wrapped)
+            {
+                parent::__construct($wrapped);
+            }
+
+            public function flush(): void
+            {
+                ++$this->flushCalls;
+                if (1 === $this->flushCalls) {
+                    throw new \RuntimeException('Controlled refresh row failure after mapper side effects.');
+                }
+
+                parent::flush();
+            }
+        };
+
+        return new RefreshOzonAccrualCategoryMetadataAction(
+            connection: self::getContainer()->get(Connection::class),
+            rawRecordRepository: self::getContainer()->get(IngestRawRecordRepository::class),
+            financialTransactionRepository: self::getContainer()->get(FinancialTransactionRepository::class),
+            rawStorageFacade: self::getContainer()->get(RawStorageFacade::class),
+            mapper: self::getContainer()->get(OzonAccrualByDayMapper::class),
+            entityManager: $entityManager,
+        );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     */
+    private function storeRawRecord(
+        string $companyId,
+        string $connectionRef,
+        string $externalId,
+        array $rows,
+    ): IngestRawRecord {
+        /** @var RawStorageFacade $facade */
+        $facade = self::getContainer()->get(RawStorageFacade::class);
+
+        return $facade->store(new RawBatch(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            shopRef: $connectionRef,
+            source: IngestSource::OZON,
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            externalId: $externalId,
+            syncJobId: Uuid::uuid7()->toString(),
+            fetchedAt: new \DateTimeImmutable('2026-06-08 03:00:00+00:00'),
+            rows: $rows,
+        ))[0];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function unknownFeeRow(int|string $typeId, string $name, string $amount): array
+    {
+        return [
+            'accrual_id' => $typeId,
+            'date' => '2026-06-01',
+            'unit_number' => 'unit-1',
+            'accrued_category' => 'NON_ITEM',
+            'non_item_fee' => [
+                'type_id' => $typeId,
+                'name' => $name,
+                'accrued' => ['amount' => $amount, 'currency' => 'RUB'],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function itemFeeRow(): array
+    {
+        return [
+            'accrual_id' => 53675409101,
+            'date' => '2026-06-02',
+            'unit_number' => '41774559-0885-1',
+            'accrued_category' => 'ITEM',
+            'item_fees' => [
+                'fees' => [[
+                    'fees' => [[
+                        'type_id' => 1,
+                        'name' => 'Acquiring',
+                        'accrued' => ['amount' => '-12.34', 'currency' => 'RUB'],
+                    ]],
+                ]],
+            ],
+        ];
+    }
+
+    private function existingTransaction(string $companyId, string $connectionRef, IngestRawRecord $record): FinancialTransaction
+    {
+        return new FinancialTransaction(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            shopRef: $connectionRef,
+            source: IngestSource::OZON,
+            externalId: 'ozon:accrual-by-day:53675409101:item_fee:group-0:fee-0:type-1',
+            externalUpdatedAt: new \DateTimeImmutable('2026-06-08 03:00:00+00:00'),
+            operationGroupId: Uuid::uuid5(Uuid::NAMESPACE_URL, sprintf('%s:ozon:accrual-by-day:%s', $companyId, '53675409101'))->toString(),
+            type: TransactionType::FEE,
+            direction: TransactionDirection::OUT,
+            money: Money::fromMinor(1234, 'RUB'),
+            occurredAt: new \DateTimeImmutable('2026-06-02 00:00:00+03:00'),
+            rawRecordId: $record->getId(),
+            description: 'Existing Ozon accrual transaction',
+            sourceData: [
+                '_ingestion_resource' => OzonResourceType::ACCRUAL_BY_DAY,
+                '_ozon_category_code' => 'ozon_unknown_1',
+                '_ozon_category_label' => 'Неизвестный type_id Ozon: 1',
+                '_ozon_category_group' => 'Неизвестные категории Ozon',
+                '_ozon_category_sort_order' => 9000,
+                '_ozon_category_known' => false,
+            ],
+            sourceTz: 'Europe/Moscow',
+        );
+    }
+}

--- a/site/tests/Integration/Ingestion/Application/SeedExternalCategoryMappingsActionTest.php
+++ b/site/tests/Integration/Ingestion/Application/SeedExternalCategoryMappingsActionTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Application;
+
+use App\Ingestion\Application\Action\SeedExternalCategoryMappingsAction;
+use App\Ingestion\Application\Action\UpdateExternalCategoryMappingAction;
+use App\Ingestion\Application\Source\Ozon\OzonAccrualCategoryTaxonomyResolver;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Entity\ExternalCategoryMapping;
+use App\Ingestion\Enum\ExternalCategoryMappingStatus;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\TransactionType;
+use App\Ingestion\Repository\ExternalCategoryMappingRepository;
+use App\Ingestion\Repository\ExternalCategoryRepository;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+
+final class SeedExternalCategoryMappingsActionTest extends IntegrationTestCase
+{
+    public function testSeedsDefaultOzonMappingsIdempotently(): void
+    {
+        /** @var SeedExternalCategoryMappingsAction $action */
+        $action = self::getContainer()->get(SeedExternalCategoryMappingsAction::class);
+
+        $first = $action(IngestSource::OZON);
+        $second = $action(IngestSource::OZON);
+
+        self::assertGreaterThan(0, $first['categoriesCreated']);
+        self::assertSame($first['mappingsCreated'], $second['mappingsExisting']);
+        self::assertSame(0, $second['mappingsCreated']);
+
+        /** @var ExternalCategoryMappingRepository $mappingRepository */
+        $mappingRepository = self::getContainer()->get(ExternalCategoryMappingRepository::class);
+        $normalizedKey = OzonAccrualCategoryTaxonomyResolver::nameKey('Acquiring');
+        self::assertNotNull($normalizedKey);
+
+        $mapping = $mappingRepository->findActiveByIdentity(
+            IngestSource::OZON,
+            OzonResourceType::ACCRUAL_BY_DAY,
+            OzonAccrualCategoryTaxonomyResolver::SCOPE_ANY,
+            $normalizedKey,
+        );
+
+        self::assertInstanceOf(ExternalCategoryMapping::class, $mapping);
+        self::assertSame('ozon_acquiring', $mapping->getCanonicalCode());
+        self::assertSame('Эквайринг', $mapping->getCanonicalLabel());
+        self::assertSame('Услуги партнёров', $mapping->getCanonicalGroup());
+    }
+
+    public function testAdminCanUpdateSeededMapping(): void
+    {
+        /** @var SeedExternalCategoryMappingsAction $seedAction */
+        $seedAction = self::getContainer()->get(SeedExternalCategoryMappingsAction::class);
+        $seedAction(IngestSource::OZON);
+
+        $normalizedKey = OzonAccrualCategoryTaxonomyResolver::nameKey('Acquiring');
+        self::assertNotNull($normalizedKey);
+
+        /** @var ExternalCategoryRepository $categoryRepository */
+        $categoryRepository = self::getContainer()->get(ExternalCategoryRepository::class);
+        $category = $categoryRepository->findByIdentity(
+            IngestSource::OZON,
+            OzonResourceType::ACCRUAL_BY_DAY,
+            OzonAccrualCategoryTaxonomyResolver::SCOPE_ANY,
+            $normalizedKey,
+        );
+        self::assertNotNull($category);
+
+        /** @var UpdateExternalCategoryMappingAction $updateAction */
+        $updateAction = self::getContainer()->get(UpdateExternalCategoryMappingAction::class);
+        $updateAction(
+            categoryId: $category->getId(),
+            canonicalCode: 'ozon_custom_acquiring',
+            canonicalLabel: 'Эквайринг Ozon custom',
+            canonicalGroup: 'Услуги партнёров custom',
+            transactionType: TransactionType::FEE,
+            sortOrder: 777,
+            status: ExternalCategoryMappingStatus::ACTIVE,
+            known: true,
+        );
+
+        /** @var ExternalCategoryMappingRepository $mappingRepository */
+        $mappingRepository = self::getContainer()->get(ExternalCategoryMappingRepository::class);
+        $mapping = $mappingRepository->findActiveByIdentity(
+            IngestSource::OZON,
+            OzonResourceType::ACCRUAL_BY_DAY,
+            OzonAccrualCategoryTaxonomyResolver::SCOPE_ANY,
+            $normalizedKey,
+        );
+
+        self::assertInstanceOf(ExternalCategoryMapping::class, $mapping);
+        self::assertSame('ozon_custom_acquiring', $mapping->getCanonicalCode());
+        self::assertSame('Эквайринг Ozon custom', $mapping->getCanonicalLabel());
+        self::assertSame('Услуги партнёров custom', $mapping->getCanonicalGroup());
+        self::assertSame(TransactionType::FEE, $mapping->getTransactionType());
+        self::assertSame(777, $mapping->getSortOrder());
+    }
+}

--- a/site/tests/Integration/Ingestion/Application/Source/Ozon/OzonAccrualByDayMapperTaxonomyTest.php
+++ b/site/tests/Integration/Ingestion/Application/Source/Ozon/OzonAccrualByDayMapperTaxonomyTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Application\Source\Ozon;
+
+use App\Ingestion\Application\Action\SeedExternalCategoryMappingsAction;
+use App\Ingestion\Application\Source\Ozon\OzonAccrualByDayMapper;
+use App\Ingestion\Application\Source\Ozon\OzonAccrualCategoryTaxonomyResolver;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Entity\ExternalCategory;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Repository\ExternalCategoryRepository;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+final class OzonAccrualByDayMapperTaxonomyTest extends IntegrationTestCase
+{
+    public function testMappedCategoryKeepsStaticParentLabel(): void
+    {
+        /** @var SeedExternalCategoryMappingsAction $seedAction */
+        $seedAction = self::getContainer()->get(SeedExternalCategoryMappingsAction::class);
+        $seedAction(IngestSource::OZON);
+
+        $companyId = Uuid::uuid7()->toString();
+        $rawRecord = $this->rawRecord($companyId);
+
+        /** @var OzonAccrualByDayMapper $mapper */
+        $mapper = self::getContainer()->get(OzonAccrualByDayMapper::class);
+        $transactions = $mapper->mapForCategoryMetadataRefresh($rawRecord, [[
+            'accrual_id' => 777000,
+            'date' => '2026-06-15',
+            'unit_number' => 'unit-1',
+            'accrued_category' => 'NON_ITEM',
+            'non_item_fee' => [
+                'type_id' => 999,
+                'name' => 'CrossDock',
+                'accrued' => ['amount' => '-10.00', 'currency' => 'RUB'],
+            ],
+        ]], recordUnknownCategories: false);
+
+        self::assertCount(1, $transactions);
+        self::assertSame('ozon_cross_docking', $transactions[0]->sourceData['_ozon_category_code']);
+        self::assertSame('Доставка до склада', $transactions[0]->sourceData['_ozon_category_parent']);
+    }
+
+    public function testMetadataRefreshCanMapUnknownFeeWithoutRecordingCategory(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $rawRecord = $this->rawRecord($companyId);
+
+        /** @var OzonAccrualByDayMapper $mapper */
+        $mapper = self::getContainer()->get(OzonAccrualByDayMapper::class);
+        $transactions = $mapper->mapForCategoryMetadataRefresh($rawRecord, [[
+            'accrual_id' => 777001,
+            'date' => '2026-06-15',
+            'unit_number' => 'unit-1',
+            'accrued_category' => 'NON_ITEM',
+            'non_item_fee' => [
+                'type_id' => 777,
+                'name' => 'NewUnknownFee',
+                'accrued' => ['amount' => '-10.00', 'currency' => 'RUB'],
+            ],
+        ]], recordUnknownCategories: false);
+
+        self::assertCount(1, $transactions);
+        $this->em->flush();
+
+        self::assertNull($this->findExternalCategory(
+            OzonAccrualCategoryTaxonomyResolver::SCOPE_NON_ITEM,
+            'type:777',
+        ));
+    }
+
+    public function testZeroAmountTypedFeeDoesNotRecordUnknownCategory(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $rawRecord = $this->rawRecord($companyId);
+
+        /** @var OzonAccrualByDayMapper $mapper */
+        $mapper = self::getContainer()->get(OzonAccrualByDayMapper::class);
+        $transactions = $mapper->map($rawRecord, [[
+            'accrual_id' => 777002,
+            'date' => '2026-06-15',
+            'unit_number' => 'unit-1',
+            'accrued_category' => 'NON_ITEM',
+            'non_item_fee' => [
+                'type_id' => 778,
+                'name' => 'ZeroUnknownFee',
+                'accrued' => ['amount' => '0.00', 'currency' => 'RUB'],
+            ],
+        ]]);
+
+        self::assertCount(0, $transactions);
+        $this->em->flush();
+
+        self::assertNull($this->findExternalCategory(
+            OzonAccrualCategoryTaxonomyResolver::SCOPE_NON_ITEM,
+            'type:778',
+        ));
+    }
+
+    private function findExternalCategory(string $scope, string $normalizedKey): ?ExternalCategory
+    {
+        /** @var ExternalCategoryRepository $categoryRepository */
+        $categoryRepository = self::getContainer()->get(ExternalCategoryRepository::class);
+
+        return $categoryRepository->findByIdentity(
+            IngestSource::OZON,
+            OzonResourceType::ACCRUAL_BY_DAY,
+            $scope,
+            $normalizedKey,
+        );
+    }
+
+    private function rawRecord(string $companyId): IngestRawRecord
+    {
+        return new IngestRawRecord(
+            companyId: $companyId,
+            connectionRef: Uuid::uuid7()->toString(),
+            shopRef: Uuid::uuid7()->toString(),
+            source: IngestSource::OZON,
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            externalId: 'accrual-by-day:2026-06-15:2026-06-15',
+            storagePath: 'raw.ndjson.gz',
+            hash: str_repeat('a', 64),
+            byteSize: 100,
+            fetchedAt: new \DateTimeImmutable('2026-06-20 20:35:35'),
+            syncJobId: Uuid::uuid7()->toString(),
+        );
+    }
+}

--- a/site/tests/Integration/Ingestion/Infrastructure/Query/ExternalCategoryAdminQueryTest.php
+++ b/site/tests/Integration/Ingestion/Infrastructure/Query/ExternalCategoryAdminQueryTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Infrastructure\Query;
+
+use App\Ingestion\Application\Source\Ozon\OzonAccrualCategoryTaxonomyResolver;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Entity\ExternalCategory;
+use App\Ingestion\Entity\ExternalCategoryMapping;
+use App\Ingestion\Enum\ExternalCategoryMappingStatus;
+use App\Ingestion\Enum\ExternalCategoryStatus;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\TransactionType;
+use App\Ingestion\Infrastructure\Query\ExternalCategoryAdminQuery;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+
+final class ExternalCategoryAdminQueryTest extends IntegrationTestCase
+{
+    public function testLatestCategoriesPrioritizesNewCategoriesBeforeLimit(): void
+    {
+        for ($index = 0; $index < 3; ++$index) {
+            $category = new ExternalCategory(
+                source: IngestSource::OZON,
+                resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+                scope: OzonAccrualCategoryTaxonomyResolver::SCOPE_ANY,
+                normalizedKey: sprintf('type:mapped-%d', $index),
+                externalTypeId: sprintf('mapped-%d', $index),
+                status: ExternalCategoryStatus::MAPPED,
+                seenAt: new \DateTimeImmutable(sprintf('2026-06-25 12:0%d:00', $index)),
+            );
+            $this->em->persist($category);
+            $this->em->persist(new ExternalCategoryMapping(
+                externalCategory: $category,
+                canonicalCode: sprintf('mapped_%d', $index),
+                canonicalLabel: sprintf('Mapped %d', $index),
+                canonicalGroup: 'Mapped',
+                transactionType: TransactionType::FEE,
+                sortOrder: 100 + $index,
+                status: ExternalCategoryMappingStatus::ACTIVE,
+            ));
+        }
+
+        $newCategory = new ExternalCategory(
+            source: IngestSource::OZON,
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            scope: OzonAccrualCategoryTaxonomyResolver::SCOPE_NON_ITEM,
+            normalizedKey: 'type:new-1',
+            externalTypeId: 'new-1',
+            status: ExternalCategoryStatus::NEW,
+            seenAt: new \DateTimeImmutable('2026-06-24 12:00:00'),
+        );
+        $this->em->persist($newCategory);
+        $this->em->flush();
+
+        /** @var ExternalCategoryAdminQuery $query */
+        $query = self::getContainer()->get(ExternalCategoryAdminQuery::class);
+        $rows = $query->latestCategories(2);
+
+        self::assertCount(2, $rows);
+        self::assertSame($newCategory->getId(), $rows[0]['id']);
+        self::assertSame('new', $rows[0]['status']);
+    }
+}

--- a/site/tests/Integration/Ingestion/Infrastructure/Query/VerificationQueriesTest.php
+++ b/site/tests/Integration/Ingestion/Infrastructure/Query/VerificationQueriesTest.php
@@ -616,6 +616,43 @@ final class VerificationQueriesTest extends IntegrationTestCase
         self::assertSame(1, $categories[1]->txCount);
     }
 
+    public function testFinancialSummaryMarketplaceCategoriesKeepLegacyDescriptionFallback(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $raw = $this->rawRecord(
+            companyId: $companyId,
+            shopRef: 'shop-1',
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            fetchedAt: new \DateTimeImmutable('2026-06-15 10:00:00+00:00'),
+            externalId: 'marketplace-category-legacy-raw',
+        );
+
+        $this->em->persist($raw);
+        $this->em->persist($this->legacyMarketplaceCategoryTransaction(
+            companyId: $companyId,
+            rawRecordId: $raw->getId(),
+            externalId: 'ozon:accrual-by-day:legacy:posting:32',
+            amountMinor: 1000,
+            description: 'Ozon accrual posting 32',
+        ));
+        $this->em->persist($this->legacyMarketplaceCategoryTransaction(
+            companyId: $companyId,
+            rawRecordId: $raw->getId(),
+            externalId: 'ozon:accrual-by-day:legacy:item:1',
+            amountMinor: 250,
+            description: 'Ozon accrual item 1',
+        ));
+        $this->em->flush();
+
+        /** @var FinancialSummaryQuery $query */
+        $query = self::getContainer()->get(FinancialSummaryQuery::class);
+        $categories = $query->marketplaceCategories($companyId, 'shop-1', 2026, 6);
+        $amountsByName = array_column($categories, 'amountMinor', 'categoryName');
+
+        self::assertSame(-250, $amountsByName['Ozon accrual item 1'] ?? null);
+        self::assertSame(-1000, $amountsByName['Ozon accrual posting 32'] ?? null);
+    }
+
     private function rawRecord(
         string $companyId,
         string $shopRef,
@@ -673,6 +710,33 @@ final class VerificationQueriesTest extends IntegrationTestCase
                 '_ozon_category_group' => $group,
                 '_ozon_category_label' => $label,
                 '_ozon_category_sort_order' => $sortOrder,
+            ],
+        );
+    }
+
+    private function legacyMarketplaceCategoryTransaction(
+        string $companyId,
+        string $rawRecordId,
+        string $externalId,
+        int $amountMinor,
+        string $description,
+    ): FinancialTransaction {
+        return new FinancialTransaction(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            shopRef: 'shop-1',
+            source: IngestSource::OZON,
+            externalId: $externalId,
+            externalUpdatedAt: new \DateTimeImmutable('2026-06-15 10:00:00+00:00'),
+            operationGroupId: Uuid::uuid7()->toString(),
+            type: TransactionType::FEE,
+            direction: TransactionDirection::OUT,
+            money: Money::fromMinor($amountMinor, 'RUB'),
+            occurredAt: new \DateTimeImmutable('2026-06-15 10:00:00+00:00'),
+            rawRecordId: $rawRecordId,
+            description: $description,
+            sourceData: [
+                '_ingestion_resource' => OzonResourceType::ACCRUAL_BY_DAY,
             ],
         );
     }

--- a/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonAccrualByDayPreviewMapperTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonAccrualByDayPreviewMapperTest.php
@@ -119,7 +119,7 @@ final class OzonAccrualByDayPreviewMapperTest extends TestCase
         self::assertSame(TransactionType::OTHER, $nonItem->type);
         self::assertSame(TransactionDirection::OUT, $nonItem->direction);
         self::assertSame(7828, $nonItem->amountMinor);
-        self::assertSame('Неизвестные категории Ozon', $nonItem->ozonCategoryGroup);
+        self::assertSame('Требует классификации', $nonItem->ozonCategoryGroup);
 
         $container = $this->row($rows, 'container_fee:fees:0:type-77');
         self::assertSame(TransactionType::FEE, $container->type);

--- a/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonAccrualCategoryTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonAccrualCategoryTest.php
@@ -108,7 +108,7 @@ final class OzonAccrualCategoryTest extends TestCase
 
         self::assertFalse($unknown->known);
         self::assertSame(TransactionType::FEE, $unknown->transactionType);
-        self::assertSame('Неизвестные категории Ozon', $unknown->group);
+        self::assertSame('Требует классификации', $unknown->group);
         self::assertSame(['999999'], $unknown->typeIds);
     }
 }


### PR DESCRIPTION
## Summary
- add global Ingestion external category and mapping dictionaries for marketplace source categories
- wire Ozon accrual normalization to DB-backed taxonomy with static fallback and unknown-category discovery
- add Admin workflow to seed defaults, discover unknown categories, edit mappings, and refresh Ozon accrual metadata
- add CLI status/seed/discover commands and update financial-summary fallback labels

## Why
Ozon keeps adding/changing cost categories, which forced repeated code fixes and production shell runs. This adds an admin-managed source taxonomy so new categories can be classified operationally and then applied to existing normalized transactions through metadata refresh.

## Validation
- `git diff --cached --check`
- targeted `php -l` on new/changed PHP files
- targeted php-cs-fixer on changed PHP files
- targeted PHPUnit: Ozon category/preview, seed mapping action, refresh metadata command
- `make site-test-unit` passed with existing unrelated warning/deprecation
- `doctrine:schema:validate --env=test --skip-sync`
- admin routes verified with `debug:router`

## Notes
- Legacy Marketplace module is not changed.
- `docs/tasks/*` is not touched.
- Deployment requires applying the new migration before using the Admin taxonomy page.