### PR TITLE
[codex] Fix Ozon category identity reconciliation

### DIFF
--- a/site/src/Ingestion/Application/Action/RebuildMarketplaceCategoryIdentitiesAction.php
+++ b/site/src/Ingestion/Application/Action/RebuildMarketplaceCategoryIdentitiesAction.php
@@ -1,0 +1,341 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Action;
+
+use App\Ingestion\Application\Source\Ozon\OzonAccrualCategoryTaxonomyResolver;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Enum\ExternalCategoryStatus;
+use App\Ingestion\Enum\IngestSource;
+use Doctrine\DBAL\Connection;
+
+final readonly class RebuildMarketplaceCategoryIdentitiesAction
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    /**
+     * @return array{scanned: int, updated: int, deprecated: int, unchanged: int, skipped: int, conflicts: int}
+     */
+    public function rebuild(IngestSource $source, bool $execute): array
+    {
+        if (IngestSource::OZON !== $source) {
+            throw new \InvalidArgumentException(sprintf('Identity rebuild is not implemented for source "%s".', $source->value));
+        }
+
+        $stats = [
+            'scanned' => 0,
+            'updated' => 0,
+            'deprecated' => 0,
+            'unchanged' => 0,
+            'skipped' => 0,
+            'conflicts' => 0,
+        ];
+
+        $rows = $this->categoryRows($source);
+        $semanticByType = $this->semanticRowsByType($rows);
+
+        foreach ($rows as $row) {
+            ++$stats['scanned'];
+            $identity = $this->desiredIdentity($row);
+            if (null === $identity) {
+                if ($this->deprecateStaleTypeOnlyRow($row, $semanticByType, $execute)) {
+                    ++$stats['deprecated'];
+                    ++$stats['conflicts'];
+                    continue;
+                }
+
+                ++$stats['skipped'];
+                continue;
+            }
+
+            if ($identity['normalizedKey'] === (string) $row['normalized_key']) {
+                if ($this->hasMissingSemanticFields($row, $identity)) {
+                    if ($execute) {
+                        $this->updateCategory((string) $row['id'], $identity);
+                    }
+                    ++$stats['updated'];
+                } else {
+                    ++$stats['unchanged'];
+                }
+                continue;
+            }
+
+            $targetId = $this->findIdentityId(
+                source: (string) $row['source'],
+                resourceType: (string) $row['resource_type'],
+                scope: (string) $row['scope'],
+                normalizedKey: $identity['normalizedKey'],
+            );
+
+            if (null === $targetId) {
+                if ($execute) {
+                    $this->updateCategory((string) $row['id'], $identity);
+                }
+                ++$stats['updated'];
+                continue;
+            }
+
+            if ($targetId !== (string) $row['id']) {
+                if ($execute) {
+                    $this->updateCategory($targetId, $identity);
+                    $this->deprecateCategory((string) $row['id']);
+                }
+                ++$stats['deprecated'];
+                ++$stats['conflicts'];
+                continue;
+            }
+
+            ++$stats['unchanged'];
+        }
+
+        return $stats;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function categoryRows(IngestSource $source): array
+    {
+        return $this->connection->fetchAllAssociative(
+            'SELECT id,
+                    source,
+                    resource_type,
+                    scope,
+                    normalized_key,
+                    external_type_id,
+                    external_code,
+                    external_name,
+                    provider_label,
+                    display_label,
+                    status,
+                    seen_count,
+                    first_seen_at,
+                    last_seen_at
+             FROM ingest_external_categories
+             WHERE source = :source
+               AND resource_type = :resourceType
+             ORDER BY last_seen_at DESC, created_at DESC',
+            [
+                'source' => $source->value,
+                'resourceType' => OzonResourceType::ACCRUAL_BY_DAY,
+            ],
+        );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     *
+     * @return array<string, string>
+     */
+    private function semanticRowsByType(array $rows): array
+    {
+        $semanticByType = [];
+
+        foreach ($rows as $row) {
+            $typeId = $this->optionalString($row['external_type_id'] ?? null);
+            if (
+                null === $typeId
+                || (string) $row['status'] === ExternalCategoryStatus::DEPRECATED->value
+                || !$this->hasSemanticIdentity($row)
+            ) {
+                continue;
+            }
+
+            $semanticByType[$this->typeIdentityKey($row)] = (string) $row['id'];
+        }
+
+        return $semanticByType;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @param array<string, string> $semanticByType
+     */
+    private function deprecateStaleTypeOnlyRow(array $row, array $semanticByType, bool $execute): bool
+    {
+        if ((string) $row['status'] === ExternalCategoryStatus::DEPRECATED->value) {
+            return false;
+        }
+
+        $normalizedKey = (string) $row['normalized_key'];
+        if (!str_starts_with($normalizedKey, 'type:') || $this->hasSemanticIdentity($row)) {
+            return false;
+        }
+
+        $semanticId = $semanticByType[$this->typeIdentityKey($row)] ?? null;
+        if (null === $semanticId || $semanticId === (string) $row['id']) {
+            return false;
+        }
+
+        if ($execute) {
+            $this->deprecateCategory((string) $row['id']);
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hasSemanticIdentity(array $row): bool
+    {
+        return null !== $this->optionalString($row['external_code'] ?? null)
+            || null !== $this->optionalString($row['provider_label'] ?? null)
+            || null !== $this->semanticExternalName($row);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function semanticExternalName(array $row): ?string
+    {
+        $externalName = $this->optionalString($row['external_name'] ?? null);
+        if (null === $externalName) {
+            return null;
+        }
+
+        if (OzonAccrualCategoryTaxonomyResolver::looksLikeExternalCode($externalName)) {
+            return $externalName;
+        }
+
+        return $this->extractOzonTypeName($externalName) ?? $externalName;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function typeIdentityKey(array $row): string
+    {
+        return implode("\n", [
+            (string) $row['source'],
+            (string) $row['resource_type'],
+            (string) $row['scope'],
+            (string) $row['external_type_id'],
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     *
+     * @return array{normalizedKey: string, externalCode: ?string, providerLabel: ?string, displayLabel: ?string}|null
+     */
+    private function desiredIdentity(array $row): ?array
+    {
+        $externalCode = $this->optionalString($row['external_code'] ?? null);
+        $externalName = $this->optionalString($row['external_name'] ?? null);
+        $providerLabel = $this->optionalString($row['provider_label'] ?? null);
+        $displayLabel = $this->optionalString($row['display_label'] ?? null);
+
+        if (null === $externalCode && null !== $externalName && OzonAccrualCategoryTaxonomyResolver::looksLikeExternalCode($externalName)) {
+            $externalCode = $externalName;
+        }
+
+        if (null === $providerLabel && null !== $externalName && !OzonAccrualCategoryTaxonomyResolver::looksLikeExternalCode($externalName)) {
+            $providerLabel = $this->extractOzonTypeName($externalName) ?? $externalName;
+        }
+
+        $normalizedKey = OzonAccrualCategoryTaxonomyResolver::codeKey($externalCode)
+            ?? OzonAccrualCategoryTaxonomyResolver::nameKey($providerLabel);
+
+        if (null === $normalizedKey) {
+            return null;
+        }
+
+        return [
+            'normalizedKey' => $normalizedKey,
+            'externalCode' => $externalCode,
+            'providerLabel' => $providerLabel,
+            'displayLabel' => $displayLabel ?? $providerLabel,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @param array{normalizedKey: string, externalCode: ?string, providerLabel: ?string, displayLabel: ?string} $identity
+     */
+    private function hasMissingSemanticFields(array $row, array $identity): bool
+    {
+        return (null === $this->optionalString($row['external_code'] ?? null) && null !== $identity['externalCode'])
+            || (null === $this->optionalString($row['provider_label'] ?? null) && null !== $identity['providerLabel'])
+            || (null === $this->optionalString($row['display_label'] ?? null) && null !== $identity['displayLabel']);
+    }
+
+    /**
+     * @param array{normalizedKey: string, externalCode: ?string, providerLabel: ?string, displayLabel: ?string} $identity
+     */
+    private function updateCategory(string $id, array $identity): void
+    {
+        $this->connection->executeStatement(
+            'UPDATE ingest_external_categories
+                SET normalized_key = :normalizedKey,
+                    external_code = COALESCE(external_code, :externalCode),
+                    provider_label = COALESCE(provider_label, :providerLabel),
+                    display_label = COALESCE(display_label, :displayLabel),
+                    updated_at = :updatedAt
+              WHERE id = :id',
+            [
+                'id' => $id,
+                'normalizedKey' => $identity['normalizedKey'],
+                'externalCode' => $identity['externalCode'],
+                'providerLabel' => $identity['providerLabel'],
+                'displayLabel' => $identity['displayLabel'],
+                'updatedAt' => (new \DateTimeImmutable())->format('Y-m-d H:i:s.u'),
+            ],
+        );
+    }
+
+    private function deprecateCategory(string $id): void
+    {
+        $this->connection->executeStatement(
+            'UPDATE ingest_external_categories
+                SET status = :status,
+                    updated_at = :updatedAt
+              WHERE id = :id',
+            [
+                'id' => $id,
+                'status' => ExternalCategoryStatus::DEPRECATED->value,
+                'updatedAt' => (new \DateTimeImmutable())->format('Y-m-d H:i:s.u'),
+            ],
+        );
+    }
+
+    private function findIdentityId(string $source, string $resourceType, string $scope, string $normalizedKey): ?string
+    {
+        $id = $this->connection->fetchOne(
+            'SELECT id
+             FROM ingest_external_categories
+             WHERE source = :source
+               AND resource_type = :resourceType
+               AND scope = :scope
+               AND normalized_key = :normalizedKey
+             LIMIT 1',
+            [
+                'source' => $source,
+                'resourceType' => $resourceType,
+                'scope' => $scope,
+                'normalizedKey' => $normalizedKey,
+            ],
+        );
+
+        return false === $id ? null : (string) $id;
+    }
+
+    private function extractOzonTypeName(string $label): ?string
+    {
+        if (1 === preg_match('/^Неизвестная категория Ozon:\s*(.+)$/u', $label, $matches)) {
+            return trim($matches[1]);
+        }
+
+        return null;
+    }
+
+    private function optionalString(mixed $value): ?string
+    {
+        $value = trim((string) $value);
+
+        return '' === $value ? null : $value;
+    }
+}

--- a/site/src/Ingestion/Application/Action/RefreshOzonAccrualCategoryMetadataAction.php
+++ b/site/src/Ingestion/Application/Action/RefreshOzonAccrualCategoryMetadataAction.php
@@ -70,8 +70,10 @@ final readonly class RefreshOzonAccrualCategoryMetadataAction
         \DateTimeImmutable $to,
         ?string $shopRef,
         int $limit,
+        int $offset = 0,
     ): array {
         $limit = max(1, min(500, $limit));
+        $offset = max(0, $offset);
         $externalWindowFrom = "substring(r.external_id from '^accrual-by-day:([0-9]{4}-[0-9]{2}-[0-9]{2}):[0-9]{4}-[0-9]{2}-[0-9]{2}$')::date";
         $externalWindowTo = "substring(r.external_id from '^accrual-by-day:[0-9]{4}-[0-9]{2}-[0-9]{2}:([0-9]{4}-[0-9]{2}-[0-9]{2})$')::date";
         $windowFrom = sprintf('COALESCE(j.window_from, %s, DATE(r.fetched_at))', $externalWindowFrom);
@@ -112,13 +114,15 @@ final readonly class RefreshOzonAccrualCategoryMetadataAction
                  LEFT JOIN ingest_sync_jobs j ON j.id::text = r.sync_job_id AND j.company_id = r.company_id
                  WHERE %s
                  ORDER BY %s ASC, %s ASC, r.fetched_at ASC, r.created_at ASC
-                 LIMIT %d',
+                 LIMIT %d
+                 OFFSET %d',
                 $windowFrom,
                 $windowTo,
                 implode(' AND ', $conditions),
                 $windowFrom,
                 $windowTo,
                 $limit,
+                $offset,
             ),
             $params,
         );

--- a/site/src/Ingestion/Command/MarketplaceCategoryRebuildIdentitiesCommand.php
+++ b/site/src/Ingestion/Command/MarketplaceCategoryRebuildIdentitiesCommand.php
@@ -4,11 +4,8 @@ declare(strict_types=1);
 
 namespace App\Ingestion\Command;
 
-use App\Ingestion\Application\Source\Ozon\OzonAccrualCategoryTaxonomyResolver;
-use App\Ingestion\Application\Source\Ozon\OzonResourceType;
-use App\Ingestion\Enum\ExternalCategoryStatus;
+use App\Ingestion\Application\Action\RebuildMarketplaceCategoryIdentitiesAction;
 use App\Ingestion\Enum\IngestSource;
-use Doctrine\DBAL\Connection;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -22,7 +19,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 )]
 final class MarketplaceCategoryRebuildIdentitiesCommand extends Command
 {
-    public function __construct(private readonly Connection $connection)
+    public function __construct(private readonly RebuildMarketplaceCategoryIdentitiesAction $rebuildIdentities)
     {
         parent::__construct();
     }
@@ -45,7 +42,7 @@ final class MarketplaceCategoryRebuildIdentitiesCommand extends Command
             }
 
             $execute = (bool) $input->getOption('execute');
-            $result = $this->rebuild($source, $execute);
+            $result = $this->rebuildIdentities->rebuild($source, $execute);
         } catch (\Throwable $exception) {
             $io->error($exception->getMessage());
 
@@ -69,209 +66,5 @@ final class MarketplaceCategoryRebuildIdentitiesCommand extends Command
         }
 
         return Command::SUCCESS;
-    }
-
-    /**
-     * @return array{scanned: int, updated: int, deprecated: int, unchanged: int, skipped: int, conflicts: int}
-     */
-    private function rebuild(IngestSource $source, bool $execute): array
-    {
-        $stats = [
-            'scanned' => 0,
-            'updated' => 0,
-            'deprecated' => 0,
-            'unchanged' => 0,
-            'skipped' => 0,
-            'conflicts' => 0,
-        ];
-
-        $rows = $this->connection->fetchAllAssociative(
-            'SELECT id,
-                    source,
-                    resource_type,
-                    scope,
-                    normalized_key,
-                    external_type_id,
-                    external_code,
-                    external_name,
-                    provider_label,
-                    display_label,
-                    seen_count,
-                    first_seen_at,
-                    last_seen_at
-             FROM ingest_external_categories
-             WHERE source = :source
-               AND resource_type = :resourceType
-             ORDER BY last_seen_at DESC, created_at DESC',
-            [
-                'source' => $source->value,
-                'resourceType' => OzonResourceType::ACCRUAL_BY_DAY,
-            ],
-        );
-
-        foreach ($rows as $row) {
-            ++$stats['scanned'];
-            $identity = $this->desiredIdentity($row);
-            if (null === $identity) {
-                ++$stats['skipped'];
-                continue;
-            }
-
-            if ($identity['normalizedKey'] === (string) $row['normalized_key']) {
-                if ($this->hasMissingSemanticFields($row, $identity)) {
-                    if ($execute) {
-                        $this->updateCategory((string) $row['id'], $identity);
-                    }
-                    ++$stats['updated'];
-                } else {
-                    ++$stats['unchanged'];
-                }
-                continue;
-            }
-
-            $targetId = $this->findIdentityId(
-                source: (string) $row['source'],
-                resourceType: (string) $row['resource_type'],
-                scope: (string) $row['scope'],
-                normalizedKey: $identity['normalizedKey'],
-            );
-
-            if (null === $targetId) {
-                if ($execute) {
-                    $this->updateCategory((string) $row['id'], $identity);
-                }
-                ++$stats['updated'];
-                continue;
-            }
-
-            if ($targetId !== (string) $row['id']) {
-                if ($execute) {
-                    $this->updateCategory($targetId, $identity);
-                    $this->deprecateCategory((string) $row['id']);
-                }
-                ++$stats['deprecated'];
-                ++$stats['conflicts'];
-                continue;
-            }
-
-            ++$stats['unchanged'];
-        }
-
-        return $stats;
-    }
-
-    /**
-     * @param array<string, mixed> $row
-     *
-     * @return array{normalizedKey: string, externalCode: ?string, providerLabel: ?string, displayLabel: ?string}|null
-     */
-    private function desiredIdentity(array $row): ?array
-    {
-        $externalCode = $this->optionalString($row['external_code'] ?? null);
-        $externalName = $this->optionalString($row['external_name'] ?? null);
-        $providerLabel = $this->optionalString($row['provider_label'] ?? null);
-        $displayLabel = $this->optionalString($row['display_label'] ?? null);
-
-        if (null === $externalCode && OzonAccrualCategoryTaxonomyResolver::looksLikeExternalCode($externalName)) {
-            $externalCode = $externalName;
-        }
-
-        if (null === $providerLabel && null !== $externalName && !OzonAccrualCategoryTaxonomyResolver::looksLikeExternalCode($externalName)) {
-            $providerLabel = $this->extractOzonTypeName($externalName) ?? $externalName;
-        }
-
-        $normalizedKey = OzonAccrualCategoryTaxonomyResolver::codeKey($externalCode)
-            ?? OzonAccrualCategoryTaxonomyResolver::nameKey($providerLabel);
-
-        if (null === $normalizedKey) {
-            return null;
-        }
-
-        return [
-            'normalizedKey' => $normalizedKey,
-            'externalCode' => $externalCode,
-            'providerLabel' => $providerLabel,
-            'displayLabel' => $displayLabel ?? $providerLabel,
-        ];
-    }
-
-    private function hasMissingSemanticFields(array $row, array $identity): bool
-    {
-        return (null === $this->optionalString($row['external_code'] ?? null) && null !== $identity['externalCode'])
-            || (null === $this->optionalString($row['provider_label'] ?? null) && null !== $identity['providerLabel'])
-            || (null === $this->optionalString($row['display_label'] ?? null) && null !== $identity['displayLabel']);
-    }
-
-    private function updateCategory(string $id, array $identity): void
-    {
-        $this->connection->executeStatement(
-            'UPDATE ingest_external_categories
-                SET normalized_key = :normalizedKey,
-                    external_code = COALESCE(external_code, :externalCode),
-                    provider_label = COALESCE(provider_label, :providerLabel),
-                    display_label = COALESCE(display_label, :displayLabel),
-                    updated_at = :updatedAt
-              WHERE id = :id',
-            [
-                'id' => $id,
-                'normalizedKey' => $identity['normalizedKey'],
-                'externalCode' => $identity['externalCode'],
-                'providerLabel' => $identity['providerLabel'],
-                'displayLabel' => $identity['displayLabel'],
-                'updatedAt' => (new \DateTimeImmutable())->format('Y-m-d H:i:s.u'),
-            ],
-        );
-    }
-
-    private function deprecateCategory(string $id): void
-    {
-        $this->connection->executeStatement(
-            'UPDATE ingest_external_categories
-                SET status = :status,
-                    updated_at = :updatedAt
-              WHERE id = :id',
-            [
-                'id' => $id,
-                'status' => ExternalCategoryStatus::DEPRECATED->value,
-                'updatedAt' => (new \DateTimeImmutable())->format('Y-m-d H:i:s.u'),
-            ],
-        );
-    }
-
-    private function findIdentityId(string $source, string $resourceType, string $scope, string $normalizedKey): ?string
-    {
-        $id = $this->connection->fetchOne(
-            'SELECT id
-             FROM ingest_external_categories
-             WHERE source = :source
-               AND resource_type = :resourceType
-               AND scope = :scope
-               AND normalized_key = :normalizedKey
-             LIMIT 1',
-            [
-                'source' => $source,
-                'resourceType' => $resourceType,
-                'scope' => $scope,
-                'normalizedKey' => $normalizedKey,
-            ],
-        );
-
-        return false === $id ? null : (string) $id;
-    }
-
-    private function extractOzonTypeName(string $label): ?string
-    {
-        if (1 === preg_match('/^Неизвестная категория Ozon:\s*(.+)$/u', $label, $matches)) {
-            return trim($matches[1]);
-        }
-
-        return null;
-    }
-
-    private function optionalString(mixed $value): ?string
-    {
-        $value = trim((string) $value);
-
-        return '' === $value ? null : $value;
     }
 }

--- a/site/src/Ingestion/Command/OzonAccrualRefreshCategoryMetadataAllCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualRefreshCategoryMetadataAllCommand.php
@@ -1,0 +1,329 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Command;
+
+use App\Ingestion\Application\Action\DiscoverExternalCategoriesAction;
+use App\Ingestion\Application\Action\RebuildMarketplaceCategoryIdentitiesAction;
+use App\Ingestion\Application\Action\RefreshOzonAccrualCategoryMetadataAction;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\RawNormalizationStatus;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Webmozart\Assert\Assert;
+
+#[AsCommand(
+    name: 'app:ingestion:ozon-accrual:refresh-category-metadata-all',
+    description: 'Refreshes Ozon accrual category metadata for all stored by-day raw records in one run.',
+)]
+final class OzonAccrualRefreshCategoryMetadataAllCommand extends Command
+{
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly RefreshOzonAccrualCategoryMetadataAction $refreshMetadata,
+        private readonly DiscoverExternalCategoriesAction $discoverCategories,
+        private readonly RebuildMarketplaceCategoryIdentitiesAction $rebuildIdentities,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('from', null, InputOption::VALUE_REQUIRED, 'Optional start accrual date YYYY-MM-DD.')
+            ->addOption('to', null, InputOption::VALUE_REQUIRED, 'Optional end accrual date YYYY-MM-DD.')
+            ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Optional company UUID filter.')
+            ->addOption('shop-ref', null, InputOption::VALUE_REQUIRED, 'Optional shop reference filter.')
+            ->addOption('limit-per-shop', null, InputOption::VALUE_REQUIRED, 'Raw records to process per company/shop, 1..500.', 500)
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show selected targets and planned metadata updates without writing.')
+            ->addOption('execute-inline', null, InputOption::VALUE_NONE, 'Refresh metadata synchronously in this process.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        try {
+            $from = $this->optionalDateOption($input, 'from');
+            $to = $this->optionalDateOption($input, 'to');
+            if (null !== $from && null !== $to && $from > $to) {
+                throw new \InvalidArgumentException('--from cannot be later than --to.');
+            }
+
+            $companyId = $this->optionalUuidOption($input, 'company-id');
+            $shopRef = $this->optionalStringOption($input, 'shop-ref');
+            $limitPerShop = $this->intOption($input, 'limit-per-shop', 1, 500);
+            $mode = $this->mode($input);
+        } catch (\Throwable $exception) {
+            $io->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $dryRun = 'dry-run' === $mode;
+        $targets = $this->targets($from, $to, $companyId, $shopRef);
+
+        $io->title('Ozon accrual category metadata bulk refresh');
+        $this->printTargets($io, $targets);
+
+        if ([] === $targets) {
+            return Command::SUCCESS;
+        }
+
+        $totals = [
+            'targets' => count($targets),
+            'rawRecords' => 0,
+            'scanned' => 0,
+            'matched' => 0,
+            'updated' => 0,
+            'unchanged' => 0,
+            'missing' => 0,
+            'failedRawRecords' => 0,
+            'rawRecordPages' => 0,
+        ];
+
+        foreach ($targets as $target) {
+            $windowFrom = new \DateTimeImmutable((string) $target['window_from']);
+            $windowTo = new \DateTimeImmutable((string) $target['window_to']);
+            $offset = 0;
+
+            do {
+                $rawRecords = $this->refreshMetadata->rawRecords(
+                    companyId: (string) $target['company_id'],
+                    from: $from ?? $windowFrom,
+                    to: $to ?? $windowTo,
+                    shopRef: (string) $target['shop_ref'],
+                    limit: $limitPerShop,
+                    offset: $offset,
+                );
+
+                if ([] === $rawRecords) {
+                    break;
+                }
+
+                ++$totals['rawRecordPages'];
+                $offset += count($rawRecords);
+                $resultRows = $this->refreshMetadata->refresh((string) $target['company_id'], $rawRecords, $dryRun);
+                $totals['rawRecords'] += count($rawRecords);
+
+                foreach ($resultRows as $row) {
+                    $totals['scanned'] += (int) $row['scanned'];
+                    $totals['matched'] += (int) $row['matched'];
+                    $totals['updated'] += (int) $row['updated'];
+                    $totals['unchanged'] += (int) $row['unchanged'];
+                    $totals['missing'] += (int) $row['missing'];
+                    if ('error' === $row['status']) {
+                        ++$totals['failedRawRecords'];
+                    }
+                }
+            } while (count($rawRecords) === $limitPerShop);
+        }
+
+        $io->section('Bulk metadata refresh result');
+        $io->table(
+            ['metric', 'value'],
+            array_map(
+                static fn (string $metric, int $value): array => [$metric, (string) $value],
+                array_keys($totals),
+                array_values($totals),
+            ),
+        );
+
+        if ($totals['failedRawRecords'] > 0) {
+            $io->warning(sprintf('Metadata refresh finished with %d failed raw records.', $totals['failedRawRecords']));
+
+            return Command::FAILURE;
+        }
+
+        if ($dryRun) {
+            $io->note('Dry-run only. No canonical transactions or taxonomy rows were changed.');
+
+            return Command::SUCCESS;
+        }
+
+        $discover = ($this->discoverCategories)(IngestSource::OZON, 5000);
+        $rebuild = $this->rebuildIdentities->rebuild(IngestSource::OZON, execute: true);
+
+        $io->section('Taxonomy follow-up');
+        $io->table(
+            ['action', 'metric', 'value'],
+            array_merge(
+                $this->metricRows('discover', $discover),
+                $this->metricRows('rebuild-identities', $rebuild),
+            ),
+        );
+
+        $io->success(sprintf('Refreshed Ozon category metadata on %d canonical transactions.', $totals['updated']));
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function targets(
+        ?\DateTimeImmutable $from,
+        ?\DateTimeImmutable $to,
+        ?string $companyId,
+        ?string $shopRef,
+    ): array {
+        $externalWindowFrom = "substring(r.external_id from '^accrual-by-day:([0-9]{4}-[0-9]{2}-[0-9]{2}):[0-9]{4}-[0-9]{2}-[0-9]{2}$')::date";
+        $externalWindowTo = "substring(r.external_id from '^accrual-by-day:[0-9]{4}-[0-9]{2}-[0-9]{2}:([0-9]{4}-[0-9]{2}-[0-9]{2})$')::date";
+        $windowFrom = sprintf('COALESCE(j.window_from, %s, DATE(r.fetched_at))', $externalWindowFrom);
+        $windowTo = sprintf('COALESCE(j.window_to, j.window_from, %s, %s, DATE(r.fetched_at))', $externalWindowTo, $externalWindowFrom);
+        $conditions = [
+            'r.source = :source',
+            'r.resource_type = :resourceType',
+            'r.normalization_status = :status',
+        ];
+        $params = [
+            'source' => IngestSource::OZON->value,
+            'resourceType' => OzonResourceType::ACCRUAL_BY_DAY,
+            'status' => RawNormalizationStatus::DONE->value,
+        ];
+
+        if (null !== $from) {
+            $conditions[] = sprintf('%s >= :fromDate', $windowTo);
+            $params['fromDate'] = $from->format('Y-m-d');
+        }
+
+        if (null !== $to) {
+            $conditions[] = sprintf('%s <= :toDate', $windowFrom);
+            $params['toDate'] = $to->format('Y-m-d');
+        }
+
+        if (null !== $companyId) {
+            $conditions[] = 'r.company_id = :companyId';
+            $params['companyId'] = $companyId;
+        }
+
+        if (null !== $shopRef) {
+            $conditions[] = 'r.shop_ref = :shopRef';
+            $params['shopRef'] = $shopRef;
+        }
+
+        return $this->connection->fetchAllAssociative(
+            sprintf(
+                'SELECT r.company_id,
+                        r.shop_ref,
+                        TO_CHAR(MIN(%s), \'YYYY-MM-DD\') AS window_from,
+                        TO_CHAR(MAX(%s), \'YYYY-MM-DD\') AS window_to,
+                        COUNT(*) AS raw_count
+                 FROM ingest_raw_records r
+                 LEFT JOIN ingest_sync_jobs j ON j.id::text = r.sync_job_id AND j.company_id = r.company_id
+                 WHERE %s
+                 GROUP BY r.company_id, r.shop_ref
+                 ORDER BY r.company_id ASC, r.shop_ref ASC',
+                $windowFrom,
+                $windowTo,
+                implode(' AND ', $conditions),
+            ),
+            $params,
+        );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $targets
+     */
+    private function printTargets(SymfonyStyle $io, array $targets): void
+    {
+        $io->section('Selected company/shop targets');
+        if ([] === $targets) {
+            $io->writeln('No done Ozon accrual by-day raw records found for the selected filters.');
+
+            return;
+        }
+
+        $io->table(
+            ['companyId', 'shopRef', 'windowFrom', 'windowTo', 'rawRecords'],
+            array_map(static fn (array $target): array => [
+                (string) $target['company_id'],
+                (string) $target['shop_ref'],
+                (string) $target['window_from'],
+                (string) $target['window_to'],
+                (string) $target['raw_count'],
+            ], $targets),
+        );
+    }
+
+    /**
+     * @param array<string, int> $metrics
+     *
+     * @return list<array{0: string, 1: string, 2: string}>
+     */
+    private function metricRows(string $action, array $metrics): array
+    {
+        return array_map(
+            static fn (string $metric, int $value): array => [$action, $metric, (string) $value],
+            array_keys($metrics),
+            array_values($metrics),
+        );
+    }
+
+    private function optionalUuidOption(InputInterface $input, string $name): ?string
+    {
+        $value = $this->optionalStringOption($input, $name);
+        if (null === $value) {
+            return null;
+        }
+
+        Assert::uuid($value, sprintf('Invalid --%s UUID.', $name));
+
+        return $value;
+    }
+
+    private function optionalDateOption(InputInterface $input, string $name): ?\DateTimeImmutable
+    {
+        $value = $this->optionalStringOption($input, $name);
+        if (null === $value) {
+            return null;
+        }
+
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
+        if (false === $date || $date->format('Y-m-d') !== $value) {
+            throw new \InvalidArgumentException(sprintf('--%s must be a valid YYYY-MM-DD date.', $name));
+        }
+
+        return $date;
+    }
+
+    private function optionalStringOption(InputInterface $input, string $name): ?string
+    {
+        $value = trim((string) $input->getOption($name));
+
+        return '' === $value ? null : $value;
+    }
+
+    private function intOption(InputInterface $input, string $name, int $min, int $max): int
+    {
+        $value = (string) $input->getOption($name);
+        if (!ctype_digit($value)) {
+            throw new \InvalidArgumentException(sprintf('The --%s option must be an integer from %d to %d.', $name, $min, $max));
+        }
+
+        $number = (int) $value;
+
+        return max($min, min($max, $number));
+    }
+
+    private function mode(InputInterface $input): string
+    {
+        $modes = array_values(array_filter([
+            (bool) $input->getOption('dry-run') ? 'dry-run' : null,
+            (bool) $input->getOption('execute-inline') ? 'execute-inline' : null,
+        ]));
+
+        if (1 !== count($modes)) {
+            throw new \InvalidArgumentException('Choose exactly one action: --dry-run or --execute-inline.');
+        }
+
+        return $modes[0];
+    }
+}

--- a/site/tests/Integration/Ingestion/Application/RefreshOzonAccrualCategoryMetadataActionTest.php
+++ b/site/tests/Integration/Ingestion/Application/RefreshOzonAccrualCategoryMetadataActionTest.php
@@ -149,6 +149,66 @@ final class RefreshOzonAccrualCategoryMetadataActionTest extends IntegrationTest
         ));
     }
 
+    public function testRawRecordsCanBePagedWithOffset(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = Uuid::uuid7()->toString();
+        $firstRecord = $this->storeRawRecord(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            externalId: 'accrual-by-day:2026-06-01:2026-06-01',
+            rows: [$this->unknownFeeRow(901, 'FirstFee', '-1.00')],
+        );
+        $secondRecord = $this->storeRawRecord(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            externalId: 'accrual-by-day:2026-06-02:2026-06-02',
+            rows: [$this->unknownFeeRow(902, 'SecondFee', '-1.00')],
+        );
+        $thirdRecord = $this->storeRawRecord(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            externalId: 'accrual-by-day:2026-06-03:2026-06-03',
+            rows: [$this->unknownFeeRow(903, 'ThirdFee', '-1.00')],
+        );
+        foreach ([$firstRecord, $secondRecord, $thirdRecord] as $record) {
+            $record->markNormalizationDone();
+        }
+        $this->em->flush();
+
+        /** @var RefreshOzonAccrualCategoryMetadataAction $action */
+        $action = self::getContainer()->get(RefreshOzonAccrualCategoryMetadataAction::class);
+
+        $firstPage = $action->rawRecords(
+            companyId: $companyId,
+            from: new \DateTimeImmutable('2026-06-01'),
+            to: new \DateTimeImmutable('2026-06-03'),
+            shopRef: $connectionRef,
+            limit: 1,
+            offset: 0,
+        );
+        $secondPage = $action->rawRecords(
+            companyId: $companyId,
+            from: new \DateTimeImmutable('2026-06-01'),
+            to: new \DateTimeImmutable('2026-06-03'),
+            shopRef: $connectionRef,
+            limit: 1,
+            offset: 1,
+        );
+        $thirdPage = $action->rawRecords(
+            companyId: $companyId,
+            from: new \DateTimeImmutable('2026-06-01'),
+            to: new \DateTimeImmutable('2026-06-03'),
+            shopRef: $connectionRef,
+            limit: 1,
+            offset: 2,
+        );
+
+        self::assertSame($firstRecord->getId(), $firstPage[0]['id']);
+        self::assertSame($secondRecord->getId(), $secondPage[0]['id']);
+        self::assertSame($thirdRecord->getId(), $thirdPage[0]['id']);
+    }
+
     private function refreshActionWithFirstFlushFailure(): RefreshOzonAccrualCategoryMetadataAction
     {
         $entityManager = new class($this->em) extends EntityManagerDecorator {

--- a/site/tests/Integration/Ingestion/Command/MarketplaceCategoryRebuildIdentitiesCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/MarketplaceCategoryRebuildIdentitiesCommandTest.php
@@ -45,6 +45,45 @@ final class MarketplaceCategoryRebuildIdentitiesCommandTest extends IntegrationT
         self::assertSame('RfbsServiceFee', $rebuilt->getExternalCode());
     }
 
+    public function testDeprecatesStaleTypeOnlyCategoryWhenSemanticCategoryExists(): void
+    {
+        $staleTypeOnly = new ExternalCategory(
+            source: IngestSource::OZON,
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            scope: OzonAccrualCategoryTaxonomyResolver::SCOPE_NON_ITEM,
+            normalizedKey: 'type:55',
+            externalTypeId: '55',
+            status: ExternalCategoryStatus::NEW,
+        );
+        $semantic = new ExternalCategory(
+            source: IngestSource::OZON,
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            scope: OzonAccrualCategoryTaxonomyResolver::SCOPE_NON_ITEM,
+            normalizedKey: 'code:pushcampaign',
+            externalTypeId: '55',
+            externalCode: 'PushCampaign',
+            externalName: 'PushCampaign',
+            providerLabel: 'PushCampaign',
+            displayLabel: 'PushCampaign',
+            status: ExternalCategoryStatus::NEW,
+        );
+        $this->em->persist($staleTypeOnly);
+        $this->em->persist($semantic);
+        $this->em->flush();
+
+        $dryRun = $this->tester();
+        self::assertSame(Command::SUCCESS, $dryRun->execute([]));
+        $this->em->clear();
+        self::assertSame(ExternalCategoryStatus::NEW, $this->findCategory('type:55')?->getStatus());
+
+        $execute = $this->tester();
+        self::assertSame(Command::SUCCESS, $execute->execute(['--execute' => true]));
+        $this->em->clear();
+
+        self::assertSame(ExternalCategoryStatus::DEPRECATED, $this->findCategory('type:55')?->getStatus());
+        self::assertSame(ExternalCategoryStatus::NEW, $this->findCategory('code:pushcampaign')?->getStatus());
+    }
+
     private function tester(): CommandTester
     {
         $app = new Application(self::$kernel);


### PR DESCRIPTION
## Summary
- Move marketplace category identity rebuild logic into an application action.
- Deprecate stale `type:<id>` Ozon taxonomy rows when a semantic `code:`/`name:` identity exists for the same scope and type id.
- Add a bulk Ozon accrual category metadata refresh command that processes all stored by-day raw records for a period and then runs discovery plus identity rebuild.
- Page through all selected raw records in the bulk command before reporting success or running taxonomy follow-up.

## Why
Production still showed rows such as `type:55` in the admin UI after the semantic `PushCampaign` category had been discovered. The rebuild command skipped type-only rows with no semantic fields, so stale numeric categories stayed visible.

Operationally, refreshing every company/shop by UUID was too manual. The bulk command now processes all selected company/shop targets in one run and does not stop at the first limited batch.

## Review Fixes
- Fixed P2: `refresh-category-metadata-all` now pages through raw records with `limit + offset` until each target is fully processed.
- Added coverage for `RefreshOzonAccrualCategoryMetadataAction::rawRecords()` paging.

## Commands Added
- `app:ingestion:ozon-accrual:refresh-category-metadata-all`

Example:
```bash
php /app/bin/console app:ingestion:ozon-accrual:refresh-category-metadata-all \
  --from=2026-06-01 \
  --to=2026-06-26 \
  --execute-inline
```

## Checks
- `php -l` on changed PHP files
- `php /app/bin/phpunit /app/tests/Integration/Ingestion/Application/RefreshOzonAccrualCategoryMetadataActionTest.php` — passed, 3 tests / 15 assertions
- `php /app/bin/phpunit /app/tests/Integration/Ingestion/Command/MarketplaceCategoryRebuildIdentitiesCommandTest.php` — passed, 2 tests / 10 assertions
- `make site-test-unit` — passed, 1141 tests / 7065 assertions; existing 1 warning and 1 deprecation remain
- `git diff --check` — passed

## Notes
- The new bulk command works from already stored raw/dictionary data. It does not call the Ozon API or load `accrual-types`; automating dictionary loading can be a separate follow-up.
