### PR TITLE
[codex] Fix stale Ozon type category cleanup

### DIFF
--- a/site/src/Ingestion/Application/Action/RebuildMarketplaceCategoryIdentitiesAction.php
+++ b/site/src/Ingestion/Application/Action/RebuildMarketplaceCategoryIdentitiesAction.php
@@ -35,18 +35,22 @@ final readonly class RebuildMarketplaceCategoryIdentitiesAction
         ];
 
         $rows = $this->categoryRows($source);
-        $semanticByType = $this->semanticRowsByType($rows);
+        $staleTypeOnlyIds = $this->staleTypeOnlyCategoryIds($source);
 
         foreach ($rows as $row) {
             ++$stats['scanned'];
+
+            if (isset($staleTypeOnlyIds[(string) $row['id']])) {
+                if ($execute) {
+                    $this->deprecateCategory((string) $row['id']);
+                }
+                ++$stats['deprecated'];
+                ++$stats['conflicts'];
+                continue;
+            }
+
             $identity = $this->desiredIdentity($row);
             if (null === $identity) {
-                if ($this->deprecateStaleTypeOnlyRow($row, $semanticByType, $execute)) {
-                    ++$stats['deprecated'];
-                    ++$stats['conflicts'];
-                    continue;
-                }
-
                 ++$stats['skipped'];
                 continue;
             }
@@ -126,95 +130,44 @@ final readonly class RebuildMarketplaceCategoryIdentitiesAction
     }
 
     /**
-     * @param list<array<string, mixed>> $rows
-     *
-     * @return array<string, string>
+     * @return array<string, true>
      */
-    private function semanticRowsByType(array $rows): array
+    private function staleTypeOnlyCategoryIds(IngestSource $source): array
     {
-        $semanticByType = [];
+        $ids = $this->connection->fetchFirstColumn(
+            'SELECT stale.id
+             FROM ingest_external_categories stale
+             WHERE stale.source = :source
+               AND stale.resource_type = :resourceType
+               AND stale.status <> :deprecatedStatus
+               AND stale.external_type_id IS NOT NULL
+               AND stale.normalized_key = CONCAT(\'type:\', stale.external_type_id)
+               AND NULLIF(TRIM(COALESCE(stale.external_code, \'\')), \'\') IS NULL
+               AND NULLIF(TRIM(COALESCE(stale.provider_label, \'\')), \'\') IS NULL
+               AND NULLIF(TRIM(COALESCE(stale.external_name, \'\')), \'\') IS NULL
+               AND EXISTS (
+                   SELECT 1
+                   FROM ingest_external_categories semantic
+                   WHERE semantic.source = stale.source
+                     AND semantic.resource_type = stale.resource_type
+                     AND semantic.external_type_id = stale.external_type_id
+                     AND semantic.id <> stale.id
+                     AND semantic.status <> :deprecatedStatus
+                     AND semantic.normalized_key <> CONCAT(\'type:\', semantic.external_type_id)
+                     AND (
+                         NULLIF(TRIM(COALESCE(semantic.external_code, \'\')), \'\') IS NOT NULL
+                         OR NULLIF(TRIM(COALESCE(semantic.provider_label, \'\')), \'\') IS NOT NULL
+                         OR NULLIF(TRIM(COALESCE(semantic.external_name, \'\')), \'\') IS NOT NULL
+                     )
+               )',
+            [
+                'source' => $source->value,
+                'resourceType' => OzonResourceType::ACCRUAL_BY_DAY,
+                'deprecatedStatus' => ExternalCategoryStatus::DEPRECATED->value,
+            ],
+        );
 
-        foreach ($rows as $row) {
-            $typeId = $this->optionalString($row['external_type_id'] ?? null);
-            if (
-                null === $typeId
-                || (string) $row['status'] === ExternalCategoryStatus::DEPRECATED->value
-                || !$this->hasSemanticIdentity($row)
-            ) {
-                continue;
-            }
-
-            $semanticByType[$this->typeIdentityKey($row)] = (string) $row['id'];
-        }
-
-        return $semanticByType;
-    }
-
-    /**
-     * @param array<string, mixed> $row
-     * @param array<string, string> $semanticByType
-     */
-    private function deprecateStaleTypeOnlyRow(array $row, array $semanticByType, bool $execute): bool
-    {
-        if ((string) $row['status'] === ExternalCategoryStatus::DEPRECATED->value) {
-            return false;
-        }
-
-        $normalizedKey = (string) $row['normalized_key'];
-        if (!str_starts_with($normalizedKey, 'type:') || $this->hasSemanticIdentity($row)) {
-            return false;
-        }
-
-        $semanticId = $semanticByType[$this->typeIdentityKey($row)] ?? null;
-        if (null === $semanticId || $semanticId === (string) $row['id']) {
-            return false;
-        }
-
-        if ($execute) {
-            $this->deprecateCategory((string) $row['id']);
-        }
-
-        return true;
-    }
-
-    /**
-     * @param array<string, mixed> $row
-     */
-    private function hasSemanticIdentity(array $row): bool
-    {
-        return null !== $this->optionalString($row['external_code'] ?? null)
-            || null !== $this->optionalString($row['provider_label'] ?? null)
-            || null !== $this->semanticExternalName($row);
-    }
-
-    /**
-     * @param array<string, mixed> $row
-     */
-    private function semanticExternalName(array $row): ?string
-    {
-        $externalName = $this->optionalString($row['external_name'] ?? null);
-        if (null === $externalName) {
-            return null;
-        }
-
-        if (OzonAccrualCategoryTaxonomyResolver::looksLikeExternalCode($externalName)) {
-            return $externalName;
-        }
-
-        return $this->extractOzonTypeName($externalName) ?? $externalName;
-    }
-
-    /**
-     * @param array<string, mixed> $row
-     */
-    private function typeIdentityKey(array $row): string
-    {
-        return implode("\n", [
-            (string) $row['source'],
-            (string) $row['resource_type'],
-            (string) $row['scope'],
-            (string) $row['external_type_id'],
-        ]);
+        return array_fill_keys(array_map('strval', $ids), true);
     }
 
     /**

--- a/site/tests/Integration/Ingestion/Command/MarketplaceCategoryRebuildIdentitiesCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/MarketplaceCategoryRebuildIdentitiesCommandTest.php
@@ -84,6 +84,43 @@ final class MarketplaceCategoryRebuildIdentitiesCommandTest extends IntegrationT
         self::assertSame(ExternalCategoryStatus::NEW, $this->findCategory('code:pushcampaign')?->getStatus());
     }
 
+    public function testDeprecatesStaleTypeOnlyCategoryWhenSemanticCategoryExistsInAnotherScope(): void
+    {
+        $staleTypeOnly = new ExternalCategory(
+            source: IngestSource::OZON,
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            scope: OzonAccrualCategoryTaxonomyResolver::SCOPE_ITEM,
+            normalizedKey: 'type:55',
+            externalTypeId: '55',
+            status: ExternalCategoryStatus::NEW,
+        );
+        $semantic = new ExternalCategory(
+            source: IngestSource::OZON,
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            scope: OzonAccrualCategoryTaxonomyResolver::SCOPE_NON_ITEM,
+            normalizedKey: 'code:pushcampaign',
+            externalTypeId: '55',
+            externalCode: 'PushCampaign',
+            externalName: 'PushCampaign',
+            providerLabel: 'PushCampaign',
+            displayLabel: 'PushCampaign',
+            status: ExternalCategoryStatus::NEW,
+        );
+        $this->em->persist($staleTypeOnly);
+        $this->em->persist($semantic);
+        $this->em->flush();
+
+        $execute = $this->tester();
+        self::assertSame(Command::SUCCESS, $execute->execute(['--execute' => true]));
+        $this->em->clear();
+
+        self::assertSame(
+            ExternalCategoryStatus::DEPRECATED,
+            $this->findCategory('type:55', OzonAccrualCategoryTaxonomyResolver::SCOPE_ITEM)?->getStatus(),
+        );
+        self::assertSame(ExternalCategoryStatus::NEW, $this->findCategory('code:pushcampaign')?->getStatus());
+    }
+
     private function tester(): CommandTester
     {
         $app = new Application(self::$kernel);
@@ -91,7 +128,10 @@ final class MarketplaceCategoryRebuildIdentitiesCommandTest extends IntegrationT
         return new CommandTester($app->find('app:ingestion:marketplace-categories:rebuild-identities'));
     }
 
-    private function findCategory(string $normalizedKey): ?ExternalCategory
+    private function findCategory(
+        string $normalizedKey,
+        string $scope = OzonAccrualCategoryTaxonomyResolver::SCOPE_NON_ITEM,
+    ): ?ExternalCategory
     {
         /** @var ExternalCategoryRepository $repository */
         $repository = self::getContainer()->get(ExternalCategoryRepository::class);
@@ -99,7 +139,7 @@ final class MarketplaceCategoryRebuildIdentitiesCommandTest extends IntegrationT
         return $repository->findByIdentity(
             IngestSource::OZON,
             OzonResourceType::ACCRUAL_BY_DAY,
-            OzonAccrualCategoryTaxonomyResolver::SCOPE_NON_ITEM,
+            $scope,
             $normalizedKey,
         );
     }


### PR DESCRIPTION
## What changed
- Rebuild identities now deprecates active `type:<id>` fallback rows when a semantic Ozon category identity exists for the same accrual `type_id`.
- The cleanup no longer depends on the old inferred `scope`, so rows like `type:55` are removed from the active UI list once `PushCampaign` exists.
- Added an integration test for stale type-only cleanup across scopes.

## Root cause
The previous cleanup matched stale `type:<id>` rows to semantic rows through an in-memory key that included `scope`. Old fallback rows could remain active even after semantic identities were discovered, so the admin UI still showed `type:*` categories.

## Checks
- `docker compose run --rm -T site-php-cli php -l /app/src/Ingestion/Application/Action/RebuildMarketplaceCategoryIdentitiesAction.php`
- `docker compose run --rm -T site-php-cli php -l /app/tests/Integration/Ingestion/Command/MarketplaceCategoryRebuildIdentitiesCommandTest.php`
- `docker compose run --rm -T site-php-cli php -d memory_limit=1G /app/bin/phpunit /app/tests/Integration/Ingestion/Command/MarketplaceCategoryRebuildIdentitiesCommandTest.php`
- `git diff --check`
