### PR TITLE
[codex] Isolate Ozon metadata bulk refresh records

### DIFF
--- a/site/src/Ingestion/Application/Action/RefreshOzonAccrualCategoryMetadataAction.php
+++ b/site/src/Ingestion/Application/Action/RefreshOzonAccrualCategoryMetadataAction.php
@@ -129,6 +129,49 @@ final readonly class RefreshOzonAccrualCategoryMetadataAction
     }
 
     /**
+     * @return array<string, mixed>|null
+     */
+    public function rawRecord(string $companyId, string $rawRecordId): ?array
+    {
+        $externalWindowFrom = "substring(r.external_id from '^accrual-by-day:([0-9]{4}-[0-9]{2}-[0-9]{2}):[0-9]{4}-[0-9]{2}-[0-9]{2}$')::date";
+        $externalWindowTo = "substring(r.external_id from '^accrual-by-day:[0-9]{4}-[0-9]{2}-[0-9]{2}:([0-9]{4}-[0-9]{2}-[0-9]{2})$')::date";
+        $windowFrom = sprintf('COALESCE(j.window_from, %s, DATE(r.fetched_at))', $externalWindowFrom);
+        $windowTo = sprintf('COALESCE(j.window_to, j.window_from, %s, %s, DATE(r.fetched_at))', $externalWindowTo, $externalWindowFrom);
+
+        $row = $this->connection->fetchAssociative(
+            sprintf(
+                'SELECT r.id,
+                        r.external_id,
+                        r.shop_ref,
+                        r.fetched_at,
+                        r.byte_size,
+                        r.normalization_status,
+                        TO_CHAR(%s, \'YYYY-MM-DD\') AS window_from,
+                        TO_CHAR(%s, \'YYYY-MM-DD\') AS window_to
+                 FROM ingest_raw_records r
+                 LEFT JOIN ingest_sync_jobs j ON j.id::text = r.sync_job_id AND j.company_id = r.company_id
+                 WHERE r.id = :rawRecordId
+                   AND r.company_id = :companyId
+                   AND r.source = :source
+                   AND r.resource_type = :resourceType
+                   AND r.normalization_status = :status
+                 LIMIT 1',
+                $windowFrom,
+                $windowTo,
+            ),
+            [
+                'rawRecordId' => $rawRecordId,
+                'companyId' => $companyId,
+                'source' => IngestSource::OZON->value,
+                'resourceType' => OzonResourceType::ACCRUAL_BY_DAY,
+                'status' => RawNormalizationStatus::DONE->value,
+            ],
+        );
+
+        return false === $row ? null : $row;
+    }
+
+    /**
      * @param list<array<string, mixed>> $rawRecords
      *
      * @return list<array<string, string|int>>

--- a/site/src/Ingestion/Command/OzonAccrualRefreshCategoryMetadataAllCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualRefreshCategoryMetadataAllCommand.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Process\Process;
 use Webmozart\Assert\Assert;
 
 #[AsCommand(
@@ -109,9 +110,20 @@ final class OzonAccrualRefreshCategoryMetadataAllCommand extends Command
                 }
 
                 ++$totals['rawRecordPages'];
-                $offset += count($rawRecords);
-                $resultRows = $this->refreshMetadata->refresh((string) $target['company_id'], $rawRecords, $dryRun);
                 $totals['rawRecords'] += count($rawRecords);
+
+                $resultRows = [];
+                foreach ($rawRecords as $rawRecord) {
+                    $resultRows = array_merge(
+                        $resultRows,
+                        $this->refreshRawRecordInSubprocess(
+                            companyId: (string) $target['company_id'],
+                            rawRecordId: (string) $rawRecord['id'],
+                            dryRun: $dryRun,
+                        ),
+                    );
+                    $this->releaseMemory();
+                }
 
                 foreach ($resultRows as $row) {
                     $totals['scanned'] += (int) $row['scanned'];
@@ -123,6 +135,8 @@ final class OzonAccrualRefreshCategoryMetadataAllCommand extends Command
                         ++$totals['failedRawRecords'];
                     }
                 }
+
+                $offset += count($rawRecords);
             } while (count($rawRecords) === $limitPerShop);
         }
 
@@ -265,6 +279,92 @@ final class OzonAccrualRefreshCategoryMetadataAllCommand extends Command
             array_keys($metrics),
             array_values($metrics),
         );
+    }
+
+    /**
+     * @return list<array<string, string|int>>
+     */
+    private function refreshRawRecordInSubprocess(string $companyId, string $rawRecordId, bool $dryRun): array
+    {
+        $process = new Process([
+            PHP_BINARY,
+            '-d',
+            sprintf('memory_limit=%s', $this->memoryLimit()),
+            $this->consolePath(),
+            'app:ingestion:ozon-accrual:refresh-category-metadata',
+            sprintf('--company-id=%s', $companyId),
+            sprintf('--raw-id=%s', $rawRecordId),
+            $dryRun ? '--dry-run' : '--execute-inline',
+            '--json-result',
+            '--no-interaction',
+        ]);
+        $process->setTimeout(null);
+        $process->run();
+
+        $rows = $this->decodeResultRows($process->getOutput());
+        if ([] !== $rows) {
+            return $rows;
+        }
+
+        if ($process->isSuccessful()) {
+            return [];
+        }
+
+        $error = trim($process->getErrorOutput()) ?: trim($process->getOutput()) ?: sprintf('Subprocess exited with code %s.', (string) $process->getExitCode());
+
+        return [[
+            'rawId' => $rawRecordId,
+            'status' => 'error',
+            'scanned' => 0,
+            'matched' => 0,
+            'updated' => 0,
+            'unchanged' => 0,
+            'missing' => 0,
+            'error' => $error,
+        ]];
+    }
+
+    /**
+     * @return list<array<string, string|int>>
+     */
+    private function decodeResultRows(string $output): array
+    {
+        $output = trim($output);
+        if ('' === $output) {
+            return [];
+        }
+
+        try {
+            $decoded = json_decode($output, true, flags: JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return [];
+        }
+
+        if (!is_array($decoded)) {
+            return [];
+        }
+
+        return array_values(array_filter($decoded, static fn (mixed $row): bool => is_array($row)));
+    }
+
+    private function consolePath(): string
+    {
+        return dirname(__DIR__, 3) . '/bin/console';
+    }
+
+    private function memoryLimit(): string
+    {
+        $memoryLimit = ini_get('memory_limit');
+
+        return false === $memoryLimit || '' === $memoryLimit ? '1G' : $memoryLimit;
+    }
+
+    private function releaseMemory(): void
+    {
+        gc_collect_cycles();
+        if (function_exists('gc_mem_caches')) {
+            gc_mem_caches();
+        }
     }
 
     private function optionalUuidOption(InputInterface $input, string $name): ?string

--- a/site/src/Ingestion/Command/OzonAccrualRefreshCategoryMetadataCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualRefreshCategoryMetadataCommand.php
@@ -28,12 +28,14 @@ final class OzonAccrualRefreshCategoryMetadataCommand extends Command
     {
         $this
             ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Company UUID.')
+            ->addOption('raw-id', null, InputOption::VALUE_REQUIRED, 'Optional raw record UUID. When set, --from and --to are not required.')
             ->addOption('from', null, InputOption::VALUE_REQUIRED, 'Start accrual date YYYY-MM-DD.')
             ->addOption('to', null, InputOption::VALUE_REQUIRED, 'End accrual date YYYY-MM-DD.')
             ->addOption('shop-ref', null, InputOption::VALUE_REQUIRED, 'Optional shop reference.')
             ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Raw records to process, 1..500.', 100)
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show selected records and planned metadata updates without writing.')
-            ->addOption('execute-inline', null, InputOption::VALUE_NONE, 'Refresh metadata synchronously in this process.');
+            ->addOption('execute-inline', null, InputOption::VALUE_NONE, 'Refresh metadata synchronously in this process.')
+            ->addOption('json-result', null, InputOption::VALUE_NONE, 'Print only JSON action results.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -42,7 +44,8 @@ final class OzonAccrualRefreshCategoryMetadataCommand extends Command
 
         try {
             $companyId = $this->requiredUuidOption($input, 'company-id');
-            [$from, $to] = $this->requiredDateWindow($input);
+            $rawRecordId = $this->optionalUuidOption($input, 'raw-id');
+            [$from, $to] = null === $rawRecordId ? $this->requiredDateWindow($input) : [null, null];
             $shopRef = $this->optionalStringOption($input, 'shop-ref');
             $limit = $this->intOption($input, 'limit', 1, 500);
             $mode = $this->mode($input);
@@ -52,34 +55,56 @@ final class OzonAccrualRefreshCategoryMetadataCommand extends Command
             return Command::FAILURE;
         }
 
-        $rawRecords = $this->refreshMetadata->rawRecords($companyId, $from, $to, $shopRef, $limit);
+        $rawRecords = null !== $rawRecordId
+            ? array_values(array_filter([$this->refreshMetadata->rawRecord($companyId, $rawRecordId)]))
+            : $this->refreshMetadata->rawRecords($companyId, $from, $to, $shopRef, $limit);
 
-        $io->title('Ozon accrual category metadata refresh');
-        $this->printRawRecords($io, $rawRecords);
+        $jsonResult = (bool) $input->getOption('json-result');
+        $dryRun = 'dry-run' === $mode;
+
+        if ($jsonResult && [] === $rawRecords) {
+            $output->writeln('[]');
+
+            return Command::SUCCESS;
+        }
+
+        if (!$jsonResult) {
+            $io->title('Ozon accrual category metadata refresh');
+            $this->printRawRecords($io, $rawRecords);
+        }
 
         if ([] === $rawRecords) {
             return Command::SUCCESS;
         }
 
-        $dryRun = 'dry-run' === $mode;
         $resultRows = $this->refreshMetadata->refresh($companyId, $rawRecords, $dryRun);
-        $this->printActionResult($io, $resultRows);
+        if ($jsonResult) {
+            $output->writeln(json_encode($resultRows, JSON_THROW_ON_ERROR));
+        } else {
+            $this->printActionResult($io, $resultRows);
+        }
 
         $failed = array_values(array_filter($resultRows, static fn (array $row): bool => 'error' === $row['status']));
         if ([] !== $failed) {
-            $io->warning(sprintf('Metadata refresh finished with %d failed raw records.', count($failed)));
+            if (!$jsonResult) {
+                $io->warning(sprintf('Metadata refresh finished with %d failed raw records.', count($failed)));
+            }
 
             return Command::FAILURE;
         }
 
         if ($dryRun) {
-            $io->note('Dry-run only. No canonical transactions were changed.');
+            if (!$jsonResult) {
+                $io->note('Dry-run only. No canonical transactions were changed.');
+            }
 
             return Command::SUCCESS;
         }
 
         $updated = array_sum(array_map(static fn (array $row): int => (int) $row['updated'], $resultRows));
-        $io->success(sprintf('Refreshed Ozon category metadata on %d canonical transactions.', $updated));
+        if (!$jsonResult) {
+            $io->success(sprintf('Refreshed Ozon category metadata on %d canonical transactions.', $updated));
+        }
 
         return Command::SUCCESS;
     }
@@ -141,6 +166,18 @@ final class OzonAccrualRefreshCategoryMetadataCommand extends Command
     private function requiredUuidOption(InputInterface $input, string $name): string
     {
         $value = trim((string) $input->getOption($name));
+        Assert::uuid($value, sprintf('Invalid --%s UUID.', $name));
+
+        return $value;
+    }
+
+    private function optionalUuidOption(InputInterface $input, string $name): ?string
+    {
+        $value = $this->optionalStringOption($input, $name);
+        if (null === $value) {
+            return null;
+        }
+
         Assert::uuid($value, sprintf('Invalid --%s UUID.', $name));
 
         return $value;

--- a/site/tests/Integration/Ingestion/Application/RefreshOzonAccrualCategoryMetadataActionTest.php
+++ b/site/tests/Integration/Ingestion/Application/RefreshOzonAccrualCategoryMetadataActionTest.php
@@ -207,6 +207,12 @@ final class RefreshOzonAccrualCategoryMetadataActionTest extends IntegrationTest
         self::assertSame($firstRecord->getId(), $firstPage[0]['id']);
         self::assertSame($secondRecord->getId(), $secondPage[0]['id']);
         self::assertSame($thirdRecord->getId(), $thirdPage[0]['id']);
+
+        $rawRecord = $action->rawRecord($companyId, $secondRecord->getId());
+        self::assertNotNull($rawRecord);
+        self::assertSame($secondRecord->getId(), $rawRecord['id']);
+        self::assertSame('2026-06-02', $rawRecord['window_from']);
+        self::assertSame('2026-06-02', $rawRecord['window_to']);
     }
 
     private function refreshActionWithFirstFlushFailure(): RefreshOzonAccrualCategoryMetadataAction

--- a/site/tests/Integration/Ingestion/Command/OzonAccrualRefreshCategoryMetadataCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/OzonAccrualRefreshCategoryMetadataCommandTest.php
@@ -117,6 +117,60 @@ final class OzonAccrualRefreshCategoryMetadataCommandTest extends IntegrationTes
         self::assertStringContainsString('Refreshed Ozon category metadata on 0 canonical transactions.', $secondTester->getDisplay());
     }
 
+    public function testRawIdJsonResultRefreshesSingleRawRecord(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = Uuid::uuid7()->toString();
+        $record = $this->storeRawRecord(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            externalId: 'accrual-by-day:2026-06-01:2026-06-01',
+            fetchedAt: new \DateTimeImmutable('2026-06-02 03:00:00+00:00'),
+            rows: [$this->itemFeeRow()],
+        );
+        $record->markNormalizationDone();
+
+        $this->em->persist(new FinancialTransaction(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            shopRef: $connectionRef,
+            source: IngestSource::OZON,
+            externalId: 'ozon:accrual-by-day:53675409101:item_fee:group-0:fee-0:type-1',
+            externalUpdatedAt: new \DateTimeImmutable('2026-06-02 03:00:00+00:00'),
+            operationGroupId: Uuid::uuid5(Uuid::NAMESPACE_URL, sprintf('%s:ozon:accrual-by-day:%s', $companyId, '53675409101'))->toString(),
+            type: TransactionType::FEE,
+            direction: TransactionDirection::OUT,
+            money: Money::fromMinor(1234, 'RUB'),
+            occurredAt: new \DateTimeImmutable('2026-06-01 00:00:00+03:00'),
+            rawRecordId: $record->getId(),
+            description: 'Existing Ozon accrual transaction',
+            sourceData: [
+                '_ingestion_resource' => OzonResourceType::ACCRUAL_BY_DAY,
+                '_ozon_category_code' => 'ozon_unknown_1',
+                '_ozon_category_label' => 'Неизвестный type_id Ozon: 1',
+                '_ozon_category_group' => 'Неизвестные категории Ozon',
+                '_ozon_category_sort_order' => 9000,
+                '_ozon_category_known' => false,
+            ],
+            sourceTz: 'Europe/Moscow',
+        ));
+        $this->em->flush();
+
+        $tester = $this->tester();
+        $exit = $tester->execute([
+            '--company-id' => $companyId,
+            '--raw-id' => $record->getId(),
+            '--execute-inline' => true,
+            '--json-result' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exit, $tester->getDisplay());
+        $resultRows = json_decode(trim($tester->getDisplay()), true, flags: JSON_THROW_ON_ERROR);
+        self::assertSame('done', $resultRows[0]['status']);
+        self::assertSame(1, $resultRows[0]['updated']);
+        self::assertStringNotContainsString('Ozon accrual category metadata refresh', $tester->getDisplay());
+    }
+
     private function tester(): CommandTester
     {
         $app = new Application(self::$kernel);


### PR DESCRIPTION
## What changed
- Added `--raw-id` and `--json-result` to `app:ingestion:ozon-accrual:refresh-category-metadata`.
- Changed `refresh-category-metadata-all` to process each raw record in a separate PHP subprocess and aggregate JSON metrics in the parent command.
- Added raw-record lookup by id in `RefreshOzonAccrualCategoryMetadataAction`.
- Added integration coverage for raw-id lookup and JSON command output.

## Root cause
The bulk command refreshed all selected raw records inside one PHP process. Each raw record can expand into thousands of mapped/canonical transaction objects, and processing all company/shop targets in one process caused the worker container to be OOM-killed with exit 137 before printing the result block.

## Impact
The operator can run one bulk command for all shops without splitting by company UUID. Memory is released by the OS after every raw-record subprocess, while the parent command still reports totals and runs taxonomy follow-up.

## Checks
- `docker compose run --rm -T site-php-cli php -l /app/src/Ingestion/Application/Action/RefreshOzonAccrualCategoryMetadataAction.php`
- `docker compose run --rm -T site-php-cli php -l /app/src/Ingestion/Command/OzonAccrualRefreshCategoryMetadataCommand.php`
- `docker compose run --rm -T site-php-cli php -l /app/src/Ingestion/Command/OzonAccrualRefreshCategoryMetadataAllCommand.php`
- `docker compose run --rm -T site-php-cli php -d memory_limit=1G /app/bin/phpunit /app/tests/Integration/Ingestion/Application/RefreshOzonAccrualCategoryMetadataActionTest.php`
- `docker compose run --rm -T site-php-cli php -d memory_limit=1G /app/bin/phpunit /app/tests/Integration/Ingestion/Command/OzonAccrualRefreshCategoryMetadataCommandTest.php`
- `git diff --check`
