### PR TITLE
Prune stale Ozon type-only categories

### DIFF
--- a/site/src/Ingestion/Application/Action/RebuildMarketplaceCategoryIdentitiesAction.php
+++ b/site/src/Ingestion/Application/Action/RebuildMarketplaceCategoryIdentitiesAction.php
@@ -145,25 +145,58 @@ final readonly class RebuildMarketplaceCategoryIdentitiesAction
                AND NULLIF(TRIM(COALESCE(stale.external_code, \'\')), \'\') IS NULL
                AND NULLIF(TRIM(COALESCE(stale.provider_label, \'\')), \'\') IS NULL
                AND NULLIF(TRIM(COALESCE(stale.external_name, \'\')), \'\') IS NULL
-               AND EXISTS (
-                   SELECT 1
-                   FROM ingest_external_categories semantic
-                   WHERE semantic.source = stale.source
-                     AND semantic.resource_type = stale.resource_type
-                     AND semantic.external_type_id = stale.external_type_id
-                     AND semantic.id <> stale.id
-                     AND semantic.status <> :deprecatedStatus
-                     AND semantic.normalized_key <> CONCAT(\'type:\', semantic.external_type_id)
-                     AND (
-                         NULLIF(TRIM(COALESCE(semantic.external_code, \'\')), \'\') IS NOT NULL
-                         OR NULLIF(TRIM(COALESCE(semantic.provider_label, \'\')), \'\') IS NOT NULL
-                         OR NULLIF(TRIM(COALESCE(semantic.external_name, \'\')), \'\') IS NOT NULL
+               AND (
+                   EXISTS (
+                       SELECT 1
+                       FROM ingest_external_categories semantic
+                       WHERE semantic.source = stale.source
+                         AND semantic.resource_type = stale.resource_type
+                         AND semantic.external_type_id = stale.external_type_id
+                         AND semantic.id <> stale.id
+                         AND semantic.status <> :deprecatedStatus
+                         AND semantic.normalized_key <> CONCAT(\'type:\', semantic.external_type_id)
+                         AND (
+                             NULLIF(TRIM(COALESCE(semantic.external_code, \'\')), \'\') IS NOT NULL
+                             OR NULLIF(TRIM(COALESCE(semantic.provider_label, \'\')), \'\') IS NOT NULL
+                             OR NULLIF(TRIM(COALESCE(semantic.external_name, \'\')), \'\') IS NOT NULL
+                         )
+                   )
+                   OR NOT EXISTS (
+                       SELECT 1
+                       FROM ingest_financial_transactions ft
+                       WHERE ft.source = stale.source
+                         AND ft.source_data->>\'_ingestion_resource\' = stale.resource_type
+                         AND ft.source_data->>\'_ingestion_type_id\' = stale.external_type_id
+                         AND NULLIF(TRIM(COALESCE(ft.source_data->>\'_ingestion_external_code\', \'\')), \'\') IS NULL
+                         AND NULLIF(TRIM(COALESCE(ft.source_data->>\'_ingestion_provider_label\', \'\')), \'\') IS NULL
+                         AND (
+                             ft.source_data->>\'_ozon_category_known\' = \'false\'
+                             OR NULLIF(ft.source_data->>\'_ozon_category_group\', \'\') IS NULL
+                             OR ft.source_data->>\'_ozon_category_group\' IN (\'Неизвестные категории Ozon\', \'Требует классификации\', \'Без группы Ozon\')
+                             OR ft.source_data->>\'_ozon_category_label\' LIKE \'Неизвест%%\'
+                             OR ft.source_data->>\'_ozon_category_label\' LIKE \'Ozon accrual%%\'
+                         )
+                         AND COALESCE(ft.source_data->>\'_ozon_category_label\', \'\') NOT LIKE \'Неизвестная категория Ozon:%%\'
+                         AND (
+                             CASE
+                                 WHEN COALESCE(ft.source_data->>\'_ingestion_component\', \'\') LIKE \'delivery:%%\' THEN :deliveryScope
+                                 WHEN COALESCE(ft.source_data->>\'_ingestion_component\', \'\') LIKE \'item_fee:%%\' THEN :itemScope
+                                 WHEN COALESCE(ft.source_data->>\'_ingestion_component\', \'\') LIKE \'non_item_fee%%\' THEN :nonItemScope
+                                 WHEN COALESCE(ft.source_data->>\'_ingestion_component\', \'\') LIKE \'container_fee%%\' THEN :containerScope
+                                 ELSE :anyScope
+                             END
+                         ) = stale.scope
                      )
                )',
             [
                 'source' => $source->value,
                 'resourceType' => OzonResourceType::ACCRUAL_BY_DAY,
                 'deprecatedStatus' => ExternalCategoryStatus::DEPRECATED->value,
+                'deliveryScope' => OzonAccrualCategoryTaxonomyResolver::SCOPE_DELIVERY,
+                'itemScope' => OzonAccrualCategoryTaxonomyResolver::SCOPE_ITEM,
+                'nonItemScope' => OzonAccrualCategoryTaxonomyResolver::SCOPE_NON_ITEM,
+                'containerScope' => OzonAccrualCategoryTaxonomyResolver::SCOPE_CONTAINER,
+                'anyScope' => OzonAccrualCategoryTaxonomyResolver::SCOPE_ANY,
             ],
         );
 

--- a/site/tests/Integration/Ingestion/Command/MarketplaceCategoryRebuildIdentitiesCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/MarketplaceCategoryRebuildIdentitiesCommandTest.php
@@ -7,10 +7,15 @@ namespace App\Tests\Integration\Ingestion\Command;
 use App\Ingestion\Application\Source\Ozon\OzonAccrualCategoryTaxonomyResolver;
 use App\Ingestion\Application\Source\Ozon\OzonResourceType;
 use App\Ingestion\Entity\ExternalCategory;
+use App\Ingestion\Entity\FinancialTransaction;
 use App\Ingestion\Enum\ExternalCategoryStatus;
 use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
 use App\Ingestion\Repository\ExternalCategoryRepository;
+use App\Shared\Domain\ValueObject\Money;
 use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -121,6 +126,53 @@ final class MarketplaceCategoryRebuildIdentitiesCommandTest extends IntegrationT
         self::assertSame(ExternalCategoryStatus::NEW, $this->findCategory('code:pushcampaign')?->getStatus());
     }
 
+    public function testDeprecatesStaleTypeOnlyCategoryWhenNoCurrentFallbackTransactionExists(): void
+    {
+        $staleTypeOnly = new ExternalCategory(
+            source: IngestSource::OZON,
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            scope: OzonAccrualCategoryTaxonomyResolver::SCOPE_DELIVERY,
+            normalizedKey: 'type:32',
+            externalTypeId: '32',
+            status: ExternalCategoryStatus::NEW,
+        );
+        $this->em->persist($staleTypeOnly);
+        $this->em->flush();
+
+        $execute = $this->tester();
+        self::assertSame(Command::SUCCESS, $execute->execute(['--execute' => true]));
+        $this->em->clear();
+
+        self::assertSame(
+            ExternalCategoryStatus::DEPRECATED,
+            $this->findCategory('type:32', OzonAccrualCategoryTaxonomyResolver::SCOPE_DELIVERY)?->getStatus(),
+        );
+    }
+
+    public function testKeepsTypeOnlyCategoryWhenCurrentFallbackTransactionExists(): void
+    {
+        $activeTypeOnly = new ExternalCategory(
+            source: IngestSource::OZON,
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            scope: OzonAccrualCategoryTaxonomyResolver::SCOPE_DELIVERY,
+            normalizedKey: 'type:32',
+            externalTypeId: '32',
+            status: ExternalCategoryStatus::NEW,
+        );
+        $this->em->persist($activeTypeOnly);
+        $this->em->persist($this->unknownFallbackTransaction('32'));
+        $this->em->flush();
+
+        $execute = $this->tester();
+        self::assertSame(Command::SUCCESS, $execute->execute(['--execute' => true]));
+        $this->em->clear();
+
+        self::assertSame(
+            ExternalCategoryStatus::NEW,
+            $this->findCategory('type:32', OzonAccrualCategoryTaxonomyResolver::SCOPE_DELIVERY)?->getStatus(),
+        );
+    }
+
     private function tester(): CommandTester
     {
         $app = new Application(self::$kernel);
@@ -141,6 +193,37 @@ final class MarketplaceCategoryRebuildIdentitiesCommandTest extends IntegrationT
             OzonResourceType::ACCRUAL_BY_DAY,
             $scope,
             $normalizedKey,
+        );
+    }
+
+    private function unknownFallbackTransaction(string $typeId): FinancialTransaction
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = Uuid::uuid7()->toString();
+
+        return new FinancialTransaction(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            shopRef: $connectionRef,
+            source: IngestSource::OZON,
+            externalId: sprintf('ozon:accrual-by-day:test:type-%s', $typeId),
+            externalUpdatedAt: new \DateTimeImmutable('2026-06-26 00:00:00+00:00'),
+            operationGroupId: Uuid::uuid7()->toString(),
+            type: TransactionType::FEE,
+            direction: TransactionDirection::OUT,
+            money: Money::fromMinor(100, 'RUB'),
+            occurredAt: new \DateTimeImmutable('2026-06-26 00:00:00+03:00'),
+            rawRecordId: Uuid::uuid7()->toString(),
+            description: sprintf('Ozon accrual fee %s', $typeId),
+            sourceData: [
+                '_ingestion_resource' => OzonResourceType::ACCRUAL_BY_DAY,
+                '_ingestion_type_id' => $typeId,
+                '_ingestion_component' => sprintf('delivery:product-0:service-0:type-%s', $typeId),
+                '_ozon_category_known' => false,
+                '_ozon_category_label' => sprintf('Неизвестный type_id Ozon: %s', $typeId),
+                '_ozon_category_group' => 'Требует классификации',
+            ],
+            sourceTz: 'Europe/Moscow',
         );
     }
 }


### PR DESCRIPTION
## What changed
- Extended Ozon category identity rebuild cleanup for stale type-only categories.
- A `type:*` external category with no code/name is now deprecated when current normalized transactions no longer require that exact fallback identity.
- Active fallback `type:*` categories are kept when matching unknown transactions still exist.
- Added integration coverage for both stale pruning and active fallback preservation.

## Why
After the metadata refresh, semantic identities such as `StarsMembership` and `BrandCommission` were updated, but old `type:*` rows stayed visible in the admin UI because they were historical catalog rows, not current discoveries. Re-running refresh cannot change those rows.

## Checks
- `docker compose run --rm -T site-php-cli php -l src/Ingestion/Application/Action/RebuildMarketplaceCategoryIdentitiesAction.php`
- `docker compose run --rm -T site-php-cli php -l tests/Integration/Ingestion/Command/MarketplaceCategoryRebuildIdentitiesCommandTest.php`
- `docker compose run --rm -T site-php-cli php -d memory_limit=1G bin/phpunit -c phpunit.xml --testsuite=integration --filter MarketplaceCategoryRebuildIdentitiesCommandTest`
- `make site-test-unit`
