### PR TITLE
[codex] Add Ozon accrual daily maintenance

### DIFF
--- a/docker/cron/app.cron
+++ b/docker/cron/app.cron
@@ -87,6 +87,10 @@
 # Ежедневный инкрементальный запуск нового Ingestion pipeline.
 0 3 * * * cd /app && php bin/console app:ingestion:run-incremental --no-interaction --quiet
 
+# Ежедневное обслуживание справочника категорий Ozon accrual:
+# seed code mappings → refresh metadata for all companies/shops → discover/rebuild taxonomy → health-check.
+15 5 * * * cd /app && php -d memory_limit=1G bin/console app:ingestion:ozon-accrual:daily-maintenance --days-back=45 --execute --no-interaction --quiet >> /proc/1/fd/1 2>> /proc/1/fd/2
+
 # Ежедневно в 02:10: снапшоты остатков по счетам
 #10 2 * * * php /app/bin/console app:money-account:snapshot --no-interaction
 

--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -107,6 +107,7 @@ services:
     App\Marketplace\Application\Service\WbFinancialReportSyncPlannerInterface: '@App\Marketplace\Application\Service\WbFinancialReportSyncPlanner'
     App\Marketplace\Infrastructure\Api\Ozon\OzonSellerCredentialValidatorInterface: '@App\Marketplace\Infrastructure\Api\Ozon\OzonSellerCredentialValidator'
     App\Ingestion\Domain\Contract\SecretCodec: '@App\Ingestion\Infrastructure\Security\PlaintextSecretCodec'
+    App\Ingestion\Command\OzonAccrualCategoryMetadataBulkRunnerInterface: '@App\Ingestion\Command\OzonAccrualCategoryMetadataBulkRunner'
     App\Shared\Service\Storage\ObjectStorageInterface:
         factory: ['@App\Shared\Service\Storage\ObjectStorageFactory', 'create']
 

--- a/site/src/Ingestion/Command/OzonAccrualCategoryMetadataBulkRunner.php
+++ b/site/src/Ingestion/Command/OzonAccrualCategoryMetadataBulkRunner.php
@@ -217,7 +217,7 @@ final readonly class OzonAccrualCategoryMetadataBulkRunner implements OzonAccrua
             $dryRun ? '--dry-run' : '--execute-inline',
             '--json-result',
             '--no-interaction',
-        ], $this->projectDir(), $this->subprocessEnv());
+        ], $this->projectDir(), $this->subprocessEnvOverlay());
         $process->setTimeout(null);
 
         try {
@@ -298,9 +298,12 @@ final readonly class OzonAccrualCategoryMetadataBulkRunner implements OzonAccrua
     }
 
     /**
+     * Symfony Process inherits the parent environment by default; these values
+     * are only an explicit overlay for runtime settings needed by child console runs.
+     *
      * @return array<string, string>
      */
-    private function subprocessEnv(): array
+    private function subprocessEnvOverlay(): array
     {
         $env = [];
         foreach (['APP_ENV', 'APP_DEBUG', 'DATABASE_URL', 'KERNEL_CLASS', 'SYMFONY_DEPRECATIONS_HELPER'] as $name) {

--- a/site/src/Ingestion/Command/OzonAccrualCategoryMetadataBulkRunner.php
+++ b/site/src/Ingestion/Command/OzonAccrualCategoryMetadataBulkRunner.php
@@ -1,0 +1,332 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Command;
+
+use App\Ingestion\Application\Action\RefreshOzonAccrualCategoryMetadataAction;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\RawNormalizationStatus;
+use Doctrine\DBAL\Connection;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Process\Process;
+
+final readonly class OzonAccrualCategoryMetadataBulkRunner implements OzonAccrualCategoryMetadataBulkRunnerInterface
+{
+    public function __construct(
+        private Connection $connection,
+        private RefreshOzonAccrualCategoryMetadataAction $refreshMetadata,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function targets(
+        ?\DateTimeImmutable $from,
+        ?\DateTimeImmutable $to,
+        ?string $companyId,
+        ?string $shopRef,
+    ): array {
+        $externalWindowFrom = "substring(r.external_id from '^accrual-by-day:([0-9]{4}-[0-9]{2}-[0-9]{2}):[0-9]{4}-[0-9]{2}-[0-9]{2}$')::date";
+        $externalWindowTo = "substring(r.external_id from '^accrual-by-day:[0-9]{4}-[0-9]{2}-[0-9]{2}:([0-9]{4}-[0-9]{2}-[0-9]{2})$')::date";
+        $windowFrom = sprintf('COALESCE(j.window_from, %s, DATE(r.fetched_at))', $externalWindowFrom);
+        $windowTo = sprintf('COALESCE(j.window_to, j.window_from, %s, %s, DATE(r.fetched_at))', $externalWindowTo, $externalWindowFrom);
+        $conditions = [
+            'r.source = :source',
+            'r.resource_type = :resourceType',
+            'r.normalization_status = :status',
+        ];
+        $params = [
+            'source' => IngestSource::OZON->value,
+            'resourceType' => OzonResourceType::ACCRUAL_BY_DAY,
+            'status' => RawNormalizationStatus::DONE->value,
+        ];
+
+        if (null !== $from) {
+            $conditions[] = sprintf('%s >= :fromDate', $windowTo);
+            $params['fromDate'] = $from->format('Y-m-d');
+        }
+
+        if (null !== $to) {
+            $conditions[] = sprintf('%s <= :toDate', $windowFrom);
+            $params['toDate'] = $to->format('Y-m-d');
+        }
+
+        if (null !== $companyId) {
+            $conditions[] = 'r.company_id = :companyId';
+            $params['companyId'] = $companyId;
+        }
+
+        if (null !== $shopRef) {
+            $conditions[] = 'r.shop_ref = :shopRef';
+            $params['shopRef'] = $shopRef;
+        }
+
+        return $this->connection->fetchAllAssociative(
+            sprintf(
+                'SELECT r.company_id,
+                        r.shop_ref,
+                        TO_CHAR(MIN(%s), \'YYYY-MM-DD\') AS window_from,
+                        TO_CHAR(MAX(%s), \'YYYY-MM-DD\') AS window_to,
+                        COUNT(*) AS raw_count
+                 FROM ingest_raw_records r
+                 LEFT JOIN ingest_sync_jobs j ON j.id::text = r.sync_job_id AND j.company_id = r.company_id
+                 WHERE %s
+                 GROUP BY r.company_id, r.shop_ref
+                 ORDER BY r.company_id ASC, r.shop_ref ASC',
+                $windowFrom,
+                $windowTo,
+                implode(' AND ', $conditions),
+            ),
+            $params,
+        );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $targets
+     *
+     * @return array{
+     *     totals: array<string, int>,
+     *     failedRawRecords: list<array<string, string>>,
+     *     failedTargets: list<array<string, string>>
+     * }
+     */
+    public function refreshTargets(
+        array $targets,
+        ?\DateTimeImmutable $from,
+        ?\DateTimeImmutable $to,
+        int $limitPerShop,
+        bool $dryRun,
+    ): array {
+        $totals = [
+            'targets' => count($targets),
+            'rawRecords' => 0,
+            'scanned' => 0,
+            'matched' => 0,
+            'updated' => 0,
+            'unchanged' => 0,
+            'missing' => 0,
+            'failedRawRecords' => 0,
+            'failedTargets' => 0,
+            'rawRecordPages' => 0,
+        ];
+        $failedRawRecords = [];
+        $failedTargets = [];
+
+        foreach ($targets as $target) {
+            $targetCompanyId = (string) $target['company_id'];
+            $targetShopRef = (string) $target['shop_ref'];
+            $windowFrom = new \DateTimeImmutable((string) $target['window_from']);
+            $windowTo = new \DateTimeImmutable((string) $target['window_to']);
+            $offset = 0;
+
+            do {
+                try {
+                    $rawRecords = $this->refreshMetadata->rawRecords(
+                        companyId: $targetCompanyId,
+                        from: $from ?? $windowFrom,
+                        to: $to ?? $windowTo,
+                        shopRef: $targetShopRef,
+                        limit: $limitPerShop,
+                        offset: $offset,
+                    );
+                } catch (\Throwable $exception) {
+                    ++$totals['failedTargets'];
+                    $failedTargets[] = [
+                        'companyId' => $targetCompanyId,
+                        'shopRef' => $targetShopRef,
+                        'error' => $exception->getMessage(),
+                    ];
+                    $this->logger->error('Ozon accrual category metadata target page failed.', [
+                        'exception' => $exception,
+                        'company_id' => $targetCompanyId,
+                        'shop_ref' => $targetShopRef,
+                        'offset' => $offset,
+                        'limit' => $limitPerShop,
+                    ]);
+
+                    break;
+                }
+
+                if ([] === $rawRecords) {
+                    break;
+                }
+
+                ++$totals['rawRecordPages'];
+                $totals['rawRecords'] += count($rawRecords);
+
+                foreach ($rawRecords as $rawRecord) {
+                    $rawRecordId = (string) $rawRecord['id'];
+                    $resultRows = $this->refreshRawRecordInSubprocess($targetCompanyId, $targetShopRef, $rawRecordId, $dryRun);
+
+                    foreach ($resultRows as $row) {
+                        $totals['scanned'] += (int) $row['scanned'];
+                        $totals['matched'] += (int) $row['matched'];
+                        $totals['updated'] += (int) $row['updated'];
+                        $totals['unchanged'] += (int) $row['unchanged'];
+                        $totals['missing'] += (int) $row['missing'];
+
+                        if ('error' === $row['status']) {
+                            ++$totals['failedRawRecords'];
+                            $error = (string) ($row['error'] ?? 'Unknown raw record refresh error.');
+                            $failedRawRecords[] = [
+                                'companyId' => $targetCompanyId,
+                                'shopRef' => $targetShopRef,
+                                'rawId' => (string) ($row['rawId'] ?? $rawRecordId),
+                                'error' => $error,
+                            ];
+                            $this->logger->error('Ozon accrual category metadata raw record failed.', [
+                                'company_id' => $targetCompanyId,
+                                'shop_ref' => $targetShopRef,
+                                'raw_record_id' => (string) ($row['rawId'] ?? $rawRecordId),
+                                'error' => $error,
+                            ]);
+                        }
+                    }
+
+                    $this->releaseMemory();
+                }
+
+                $offset += count($rawRecords);
+            } while (count($rawRecords) === $limitPerShop);
+        }
+
+        return [
+            'totals' => $totals,
+            'failedRawRecords' => $failedRawRecords,
+            'failedTargets' => $failedTargets,
+        ];
+    }
+
+    /**
+     * @return list<array<string, string|int>>
+     */
+    private function refreshRawRecordInSubprocess(string $companyId, string $shopRef, string $rawRecordId, bool $dryRun): array
+    {
+        $process = new Process([
+            PHP_BINARY,
+            '-d',
+            sprintf('memory_limit=%s', $this->memoryLimit()),
+            $this->consolePath(),
+            'app:ingestion:ozon-accrual:refresh-category-metadata',
+            sprintf('--company-id=%s', $companyId),
+            sprintf('--raw-id=%s', $rawRecordId),
+            $dryRun ? '--dry-run' : '--execute-inline',
+            '--json-result',
+            '--no-interaction',
+        ], $this->projectDir(), $this->subprocessEnv());
+        $process->setTimeout(null);
+
+        try {
+            $process->run();
+        } catch (\Throwable $exception) {
+            $this->logger->error('Ozon accrual category metadata subprocess crashed.', [
+                'exception' => $exception,
+                'company_id' => $companyId,
+                'shop_ref' => $shopRef,
+                'raw_record_id' => $rawRecordId,
+            ]);
+
+            return [$this->errorRow($rawRecordId, $exception->getMessage())];
+        }
+
+        $rows = $this->decodeResultRows($process->getOutput());
+        if ([] !== $rows) {
+            return $rows;
+        }
+
+        if ($process->isSuccessful()) {
+            return [];
+        }
+
+        $error = trim($process->getErrorOutput()) ?: trim($process->getOutput()) ?: sprintf('Subprocess exited with code %s.', (string) $process->getExitCode());
+
+        return [$this->errorRow($rawRecordId, $error)];
+    }
+
+    /**
+     * @return list<array<string, string|int>>
+     */
+    private function decodeResultRows(string $output): array
+    {
+        $output = trim($output);
+        if ('' === $output) {
+            return [];
+        }
+
+        try {
+            $decoded = json_decode($output, true, flags: JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return [];
+        }
+
+        if (!is_array($decoded)) {
+            return [];
+        }
+
+        return array_values(array_filter($decoded, static fn (mixed $row): bool => is_array($row)));
+    }
+
+    /**
+     * @return array<string, string|int>
+     */
+    private function errorRow(string $rawRecordId, string $error): array
+    {
+        return [
+            'rawId' => $rawRecordId,
+            'status' => 'error',
+            'scanned' => 0,
+            'matched' => 0,
+            'updated' => 0,
+            'unchanged' => 0,
+            'missing' => 0,
+            'error' => $error,
+        ];
+    }
+
+    private function consolePath(): string
+    {
+        return $this->projectDir().'/bin/console';
+    }
+
+    private function projectDir(): string
+    {
+        return dirname(__DIR__, 3);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function subprocessEnv(): array
+    {
+        $env = [];
+        foreach (['APP_ENV', 'APP_DEBUG', 'DATABASE_URL', 'KERNEL_CLASS', 'SYMFONY_DEPRECATIONS_HELPER'] as $name) {
+            $value = $_SERVER[$name] ?? $_ENV[$name] ?? getenv($name);
+            if (null === $value || false === $value || '' === $value) {
+                continue;
+            }
+
+            $env[$name] = (string) $value;
+        }
+
+        return $env;
+    }
+
+    private function memoryLimit(): string
+    {
+        $memoryLimit = ini_get('memory_limit');
+
+        return false === $memoryLimit || '' === $memoryLimit ? '1G' : $memoryLimit;
+    }
+
+    private function releaseMemory(): void
+    {
+        gc_collect_cycles();
+        if (function_exists('gc_mem_caches')) {
+            gc_mem_caches();
+        }
+    }
+}

--- a/site/src/Ingestion/Command/OzonAccrualCategoryMetadataBulkRunnerInterface.php
+++ b/site/src/Ingestion/Command/OzonAccrualCategoryMetadataBulkRunnerInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Command;
+
+interface OzonAccrualCategoryMetadataBulkRunnerInterface
+{
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function targets(
+        ?\DateTimeImmutable $from,
+        ?\DateTimeImmutable $to,
+        ?string $companyId,
+        ?string $shopRef,
+    ): array;
+
+    /**
+     * @param list<array<string, mixed>> $targets
+     *
+     * @return array{
+     *     totals: array<string, int>,
+     *     failedRawRecords: list<array<string, string>>,
+     *     failedTargets: list<array<string, string>>
+     * }
+     */
+    public function refreshTargets(
+        array $targets,
+        ?\DateTimeImmutable $from,
+        ?\DateTimeImmutable $to,
+        int $limitPerShop,
+        bool $dryRun,
+    ): array;
+}

--- a/site/src/Ingestion/Command/OzonAccrualCommandHelperTrait.php
+++ b/site/src/Ingestion/Command/OzonAccrualCommandHelperTrait.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Webmozart\Assert\Assert;
+
+trait OzonAccrualCommandHelperTrait
+{
+    private function optionalUuidOption(InputInterface $input, string $name): ?string
+    {
+        $value = $this->optionalStringOption($input, $name);
+        if (null === $value) {
+            return null;
+        }
+
+        Assert::uuid($value, sprintf('Invalid --%s UUID.', $name));
+
+        return $value;
+    }
+
+    private function optionalDateOption(InputInterface $input, string $name): ?\DateTimeImmutable
+    {
+        $value = $this->optionalStringOption($input, $name);
+        if (null === $value) {
+            return null;
+        }
+
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
+        if (false === $date || $date->format('Y-m-d') !== $value) {
+            throw new \InvalidArgumentException(sprintf('--%s must be a valid YYYY-MM-DD date.', $name));
+        }
+
+        return $date;
+    }
+
+    private function optionalStringOption(InputInterface $input, string $name): ?string
+    {
+        $value = trim((string) $input->getOption($name));
+
+        return '' === $value ? null : $value;
+    }
+
+    private function intOption(InputInterface $input, string $name, int $min, int $max): int
+    {
+        $value = (string) $input->getOption($name);
+        if (!ctype_digit($value)) {
+            throw new \InvalidArgumentException(sprintf('The --%s option must be an integer from %d to %d.', $name, $min, $max));
+        }
+
+        $number = (int) $value;
+        if ($number < $min || $number > $max) {
+            throw new \InvalidArgumentException(sprintf('The --%s option must be an integer from %d to %d.', $name, $min, $max));
+        }
+
+        return $number;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $targets
+     */
+    private function printTargets(SymfonyStyle $io, array $targets): void
+    {
+        if ([] === $targets) {
+            $io->writeln('No done Ozon accrual by-day raw records found for the selected filters.');
+
+            return;
+        }
+
+        $io->table(
+            ['companyId', 'shopRef', 'windowFrom', 'windowTo', 'rawRecords'],
+            array_map(static fn (array $target): array => [
+                (string) $target['company_id'],
+                (string) $target['shop_ref'],
+                (string) $target['window_from'],
+                (string) $target['window_to'],
+                (string) $target['raw_count'],
+            ], $targets),
+        );
+    }
+
+    /**
+     * @param array<string, int> $metrics
+     */
+    private function printMetrics(SymfonyStyle $io, array $metrics): void
+    {
+        $io->table(
+            ['metric', 'value'],
+            array_map(
+                static fn (string $metric, int $value): array => [$metric, (string) $value],
+                array_keys($metrics),
+                array_values($metrics),
+            ),
+        );
+    }
+
+    /**
+     * @param array<string, int> $metrics
+     *
+     * @return list<array{0: string, 1: string, 2: string}>
+     */
+    private function metricRows(string $action, array $metrics): array
+    {
+        return array_map(
+            static fn (string $metric, int $value): array => [$action, $metric, (string) $value],
+            array_keys($metrics),
+            array_values($metrics),
+        );
+    }
+}

--- a/site/src/Ingestion/Command/OzonAccrualDailyMaintenanceCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualDailyMaintenanceCommand.php
@@ -1,0 +1,401 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Command;
+
+use App\Ingestion\Application\Action\DiscoverExternalCategoriesAction;
+use App\Ingestion\Application\Action\RebuildMarketplaceCategoryIdentitiesAction;
+use App\Ingestion\Application\Action\SeedExternalCategoryMappingsAction;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Enum\ExternalCategoryStatus;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Infrastructure\Query\ExternalCategoryAdminQuery;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\LockableTrait;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Webmozart\Assert\Assert;
+
+#[AsCommand(
+    name: 'app:ingestion:ozon-accrual:daily-maintenance',
+    description: 'Runs daily Ozon accrual category taxonomy maintenance for all stored by-day raw records.',
+)]
+final class OzonAccrualDailyMaintenanceCommand extends Command
+{
+    use LockableTrait;
+
+    private const BUSINESS_TIMEZONE = 'Europe/Moscow';
+
+    public function __construct(
+        private readonly ClockInterface $clock,
+        private readonly SeedExternalCategoryMappingsAction $seedDefaults,
+        private readonly OzonAccrualCategoryMetadataBulkRunnerInterface $bulkRunner,
+        private readonly DiscoverExternalCategoriesAction $discoverCategories,
+        private readonly RebuildMarketplaceCategoryIdentitiesAction $rebuildIdentities,
+        private readonly ExternalCategoryAdminQuery $categoryAdminQuery,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('days-back', null, InputOption::VALUE_REQUIRED, 'Rolling window size. Used when --from/--to are omitted.', 45)
+            ->addOption('from', null, InputOption::VALUE_REQUIRED, 'Optional start accrual date YYYY-MM-DD. Must be paired with --to.')
+            ->addOption('to', null, InputOption::VALUE_REQUIRED, 'Optional end accrual date YYYY-MM-DD. Must be paired with --from.')
+            ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Optional company UUID filter.')
+            ->addOption('shop-ref', null, InputOption::VALUE_REQUIRED, 'Optional shop reference filter.')
+            ->addOption('limit-per-shop', null, InputOption::VALUE_REQUIRED, 'Raw records to process per company/shop page, 1..500.', 500)
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show selected targets and planned metadata updates without writing.')
+            ->addOption('execute', null, InputOption::VALUE_NONE, 'Persist maintenance changes.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (!$this->lock()) {
+            $output->writeln('<comment>Ozon accrual daily maintenance is already running.</comment>');
+
+            return Command::SUCCESS;
+        }
+
+        $io = new SymfonyStyle($input, $output);
+
+        try {
+            return $this->runMaintenance($input, $io);
+        } finally {
+            $this->release();
+        }
+    }
+
+    private function runMaintenance(InputInterface $input, SymfonyStyle $io): int
+    {
+        try {
+            [$from, $to, $daysBack] = $this->dateWindow($input);
+            $companyId = $this->optionalUuidOption($input, 'company-id');
+            $shopRef = $this->optionalStringOption($input, 'shop-ref');
+            $limitPerShop = $this->intOption($input, 'limit-per-shop', 1, 500);
+            $mode = $this->mode($input);
+        } catch (\Throwable $exception) {
+            $io->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $dryRun = 'dry-run' === $mode;
+        $hasFailure = false;
+
+        $io->title('Ozon accrual daily maintenance');
+        $io->table(
+            ['setting', 'value'],
+            [
+                ['mode', $dryRun ? 'dry-run' : 'execute'],
+                ['from', $from->format('Y-m-d')],
+                ['to', $to->format('Y-m-d')],
+                ['daysBack', null === $daysBack ? 'custom' : (string) $daysBack],
+                ['companyId', $companyId ?? 'all'],
+                ['shopRef', $shopRef ?? 'all'],
+                ['limitPerShop', (string) $limitPerShop],
+            ],
+        );
+
+        if ($dryRun) {
+            $seedStats = ['skippedDryRun' => 1];
+            $io->note('Dry-run mode: seed defaults and taxonomy follow-up are skipped.');
+        } else {
+            try {
+                $seedStats = ($this->seedDefaults)(IngestSource::OZON);
+            } catch (\Throwable $exception) {
+                $this->logger->error('Ozon accrual daily maintenance seed defaults failed.', [
+                    'exception' => $exception,
+                    'from' => $from->format('Y-m-d'),
+                    'to' => $to->format('Y-m-d'),
+                    'company_id' => $companyId,
+                    'shop_ref' => $shopRef,
+                ]);
+                $io->error($exception->getMessage());
+
+                return Command::FAILURE;
+            }
+        }
+
+        $io->section('Seed defaults');
+        $this->printMetrics($io, $seedStats);
+
+        try {
+            $targets = $this->bulkRunner->targets($from, $to, $companyId, $shopRef);
+        } catch (\Throwable $exception) {
+            $this->logger->error('Ozon accrual daily maintenance target selection failed.', [
+                'exception' => $exception,
+                'from' => $from->format('Y-m-d'),
+                'to' => $to->format('Y-m-d'),
+                'company_id' => $companyId,
+                'shop_ref' => $shopRef,
+            ]);
+            $io->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $io->section('Selected company/shop targets');
+        $this->printTargets($io, $targets);
+
+        $refreshResult = $this->bulkRunner->refreshTargets($targets, $from, $to, $limitPerShop, $dryRun);
+        $refreshTotals = $refreshResult['totals'];
+        if ($refreshTotals['failedRawRecords'] > 0 || $refreshTotals['failedTargets'] > 0) {
+            $hasFailure = true;
+        }
+
+        $io->section('Bulk metadata refresh result');
+        $this->printMetrics($io, $refreshTotals);
+
+        if ($dryRun) {
+            $io->note('Dry-run only. No canonical transactions or taxonomy rows were changed.');
+            $this->printHealth($io);
+
+            return $hasFailure ? Command::FAILURE : Command::SUCCESS;
+        }
+
+        try {
+            $discover = ($this->discoverCategories)(IngestSource::OZON, 5000);
+            $rebuild = $this->rebuildIdentities->rebuild(IngestSource::OZON, execute: true);
+        } catch (\Throwable $exception) {
+            $hasFailure = true;
+            $this->logger->error('Ozon accrual daily maintenance taxonomy follow-up failed.', [
+                'exception' => $exception,
+                'from' => $from->format('Y-m-d'),
+                'to' => $to->format('Y-m-d'),
+                'company_id' => $companyId,
+                'shop_ref' => $shopRef,
+            ]);
+            $io->error($exception->getMessage());
+            $discover = [];
+            $rebuild = [];
+        }
+
+        $io->section('Taxonomy follow-up');
+        $io->table(
+            ['action', 'metric', 'value'],
+            array_merge(
+                $this->metricRows('discover', $discover),
+                $this->metricRows('rebuild-identities', $rebuild),
+            ),
+        );
+
+        $health = $this->health();
+        $io->section('Health check');
+        $this->printMetrics($io, $health);
+
+        if ($health['unclassifiedTransactions'] > 0 || $health['unclassifiedGroups'] > 0 || $health['unmappedCategories'] > 0) {
+            $hasFailure = true;
+            $this->logger->error('Ozon accrual daily maintenance health check failed.', [
+                'from' => $from->format('Y-m-d'),
+                'to' => $to->format('Y-m-d'),
+                'company_id' => $companyId,
+                'shop_ref' => $shopRef,
+                'health' => $health,
+            ]);
+        }
+
+        if ($hasFailure) {
+            $io->warning('Ozon accrual daily maintenance finished with failures. See logs/Sentry for details.');
+
+            return Command::FAILURE;
+        }
+
+        $io->success(sprintf('Ozon accrual daily maintenance finished. Updated %d canonical transactions.', $refreshTotals['updated']));
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @return array{0: \DateTimeImmutable, 1: \DateTimeImmutable, 2: int|null}
+     */
+    private function dateWindow(InputInterface $input): array
+    {
+        $from = $this->optionalDateOption($input, 'from');
+        $to = $this->optionalDateOption($input, 'to');
+        if ((null === $from) !== (null === $to)) {
+            throw new \InvalidArgumentException('Options --from and --to must be provided together.');
+        }
+
+        if (null !== $from && null !== $to) {
+            if ($from > $to) {
+                throw new \InvalidArgumentException('--from cannot be later than --to.');
+            }
+
+            return [$from, $to, null];
+        }
+
+        $daysBack = $this->intOption($input, 'days-back', 1, 365);
+        $today = \DateTimeImmutable::createFromInterface(
+            $this->clock->now()->setTimezone(new \DateTimeZone(self::BUSINESS_TIMEZONE)),
+        )->setTime(0, 0);
+
+        return [
+            $today->modify(sprintf('-%d days', $daysBack)),
+            $today->modify('-1 day'),
+            $daysBack,
+        ];
+    }
+
+    private function optionalUuidOption(InputInterface $input, string $name): ?string
+    {
+        $value = $this->optionalStringOption($input, $name);
+        if (null === $value) {
+            return null;
+        }
+
+        Assert::uuid($value, sprintf('Invalid --%s UUID.', $name));
+
+        return $value;
+    }
+
+    private function optionalDateOption(InputInterface $input, string $name): ?\DateTimeImmutable
+    {
+        $value = $this->optionalStringOption($input, $name);
+        if (null === $value) {
+            return null;
+        }
+
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
+        if (false === $date || $date->format('Y-m-d') !== $value) {
+            throw new \InvalidArgumentException(sprintf('--%s must be a valid YYYY-MM-DD date.', $name));
+        }
+
+        return $date;
+    }
+
+    private function optionalStringOption(InputInterface $input, string $name): ?string
+    {
+        $value = trim((string) $input->getOption($name));
+
+        return '' === $value ? null : $value;
+    }
+
+    private function intOption(InputInterface $input, string $name, int $min, int $max): int
+    {
+        $value = (string) $input->getOption($name);
+        if (!ctype_digit($value)) {
+            throw new \InvalidArgumentException(sprintf('The --%s option must be an integer from %d to %d.', $name, $min, $max));
+        }
+
+        $number = (int) $value;
+
+        return max($min, min($max, $number));
+    }
+
+    private function mode(InputInterface $input): string
+    {
+        $modes = array_values(array_filter([
+            (bool) $input->getOption('dry-run') ? 'dry-run' : null,
+            (bool) $input->getOption('execute') ? 'execute' : null,
+        ]));
+
+        if (1 !== count($modes)) {
+            throw new \InvalidArgumentException('Choose exactly one action: --dry-run or --execute.');
+        }
+
+        return $modes[0];
+    }
+
+    /**
+     * @param list<array<string, mixed>> $targets
+     */
+    private function printTargets(SymfonyStyle $io, array $targets): void
+    {
+        if ([] === $targets) {
+            $io->writeln('No done Ozon accrual by-day raw records found for the selected filters.');
+
+            return;
+        }
+
+        $io->table(
+            ['companyId', 'shopRef', 'windowFrom', 'windowTo', 'rawRecords'],
+            array_map(static fn (array $target): array => [
+                (string) $target['company_id'],
+                (string) $target['shop_ref'],
+                (string) $target['window_from'],
+                (string) $target['window_to'],
+                (string) $target['raw_count'],
+            ], $targets),
+        );
+    }
+
+    /**
+     * @param array<string, int> $metrics
+     */
+    private function printMetrics(SymfonyStyle $io, array $metrics): void
+    {
+        $io->table(
+            ['metric', 'value'],
+            array_map(
+                static fn (string $metric, int $value): array => [$metric, (string) $value],
+                array_keys($metrics),
+                array_values($metrics),
+            ),
+        );
+    }
+
+    private function printHealth(SymfonyStyle $io): void
+    {
+        $io->section('Health check');
+        $this->printMetrics($io, $this->health());
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function health(): array
+    {
+        $unclassified = $this->categoryAdminQuery->unclassifiedOzonAccrualTransactions();
+
+        return [
+            'unclassifiedTransactions' => $unclassified['transactions'],
+            'unclassifiedGroups' => $unclassified['groups'],
+            'unmappedCategories' => $this->unmappedOzonAccrualCategories(),
+        ];
+    }
+
+    private function unmappedOzonAccrualCategories(): int
+    {
+        $total = 0;
+        foreach ($this->categoryAdminQuery->statusSummary() as $row) {
+            if (IngestSource::OZON->value !== $row['source']) {
+                continue;
+            }
+
+            if (OzonResourceType::ACCRUAL_BY_DAY !== $row['resource_type']) {
+                continue;
+            }
+
+            if (!\in_array($row['status'], [ExternalCategoryStatus::NEW->value, ExternalCategoryStatus::NEEDS_IDENTIFICATION->value], true)) {
+                continue;
+            }
+
+            $total += $row['categories'];
+        }
+
+        return $total;
+    }
+
+    /**
+     * @param array<string, int> $metrics
+     *
+     * @return list<array{0: string, 1: string, 2: string}>
+     */
+    private function metricRows(string $action, array $metrics): array
+    {
+        return array_map(
+            static fn (string $metric, int $value): array => [$action, $metric, (string) $value],
+            array_keys($metrics),
+            array_values($metrics),
+        );
+    }
+}

--- a/site/src/Ingestion/Command/OzonAccrualDailyMaintenanceCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualDailyMaintenanceCommand.php
@@ -20,7 +20,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Webmozart\Assert\Assert;
 
 #[AsCommand(
     name: 'app:ingestion:ozon-accrual:daily-maintenance',
@@ -29,6 +28,7 @@ use Webmozart\Assert\Assert;
 final class OzonAccrualDailyMaintenanceCommand extends Command
 {
     use LockableTrait;
+    use OzonAccrualCommandHelperTrait;
 
     private const BUSINESS_TIMEZONE = 'Europe/Moscow';
 
@@ -157,7 +157,7 @@ final class OzonAccrualDailyMaintenanceCommand extends Command
 
         if ($dryRun) {
             $io->note('Dry-run only. No canonical transactions or taxonomy rows were changed.');
-            $this->printHealth($io);
+            $this->printHealth($io, scoped: null !== $companyId || null !== $shopRef);
 
             return $hasFailure ? Command::FAILURE : Command::SUCCESS;
         }
@@ -188,11 +188,21 @@ final class OzonAccrualDailyMaintenanceCommand extends Command
             ),
         );
 
+        $scopedRun = null !== $companyId || null !== $shopRef;
         $health = $this->health();
         $io->section('Health check');
         $this->printMetrics($io, $health);
 
-        if ($health['unclassifiedTransactions'] > 0 || $health['unclassifiedGroups'] > 0 || $health['unmappedCategories'] > 0) {
+        if ($scopedRun) {
+            $this->logger->warning('Ozon accrual daily maintenance scoped run skipped global health gate.', [
+                'from' => $from->format('Y-m-d'),
+                'to' => $to->format('Y-m-d'),
+                'company_id' => $companyId,
+                'shop_ref' => $shopRef,
+                'health' => $health,
+            ]);
+            $io->note('Scoped run: global taxonomy health is informational and does not affect exit code.');
+        } elseif ($health['unclassifiedTransactions'] > 0 || $health['unclassifiedGroups'] > 0) {
             $hasFailure = true;
             $this->logger->error('Ozon accrual daily maintenance health check failed.', [
                 'from' => $from->format('Y-m-d'),
@@ -201,6 +211,13 @@ final class OzonAccrualDailyMaintenanceCommand extends Command
                 'shop_ref' => $shopRef,
                 'health' => $health,
             ]);
+        } elseif ($health['unmappedCategories'] > 0) {
+            $this->logger->warning('Ozon accrual daily maintenance has categories awaiting mapping.', [
+                'from' => $from->format('Y-m-d'),
+                'to' => $to->format('Y-m-d'),
+                'health' => $health,
+            ]);
+            $io->warning('Ozon accrual categories are awaiting mapping, but canonical transactions are classified.');
         }
 
         if ($hasFailure) {
@@ -245,52 +262,6 @@ final class OzonAccrualDailyMaintenanceCommand extends Command
         ];
     }
 
-    private function optionalUuidOption(InputInterface $input, string $name): ?string
-    {
-        $value = $this->optionalStringOption($input, $name);
-        if (null === $value) {
-            return null;
-        }
-
-        Assert::uuid($value, sprintf('Invalid --%s UUID.', $name));
-
-        return $value;
-    }
-
-    private function optionalDateOption(InputInterface $input, string $name): ?\DateTimeImmutable
-    {
-        $value = $this->optionalStringOption($input, $name);
-        if (null === $value) {
-            return null;
-        }
-
-        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
-        if (false === $date || $date->format('Y-m-d') !== $value) {
-            throw new \InvalidArgumentException(sprintf('--%s must be a valid YYYY-MM-DD date.', $name));
-        }
-
-        return $date;
-    }
-
-    private function optionalStringOption(InputInterface $input, string $name): ?string
-    {
-        $value = trim((string) $input->getOption($name));
-
-        return '' === $value ? null : $value;
-    }
-
-    private function intOption(InputInterface $input, string $name, int $min, int $max): int
-    {
-        $value = (string) $input->getOption($name);
-        if (!ctype_digit($value)) {
-            throw new \InvalidArgumentException(sprintf('The --%s option must be an integer from %d to %d.', $name, $min, $max));
-        }
-
-        $number = (int) $value;
-
-        return max($min, min($max, $number));
-    }
-
     private function mode(InputInterface $input): string
     {
         $modes = array_values(array_filter([
@@ -305,48 +276,13 @@ final class OzonAccrualDailyMaintenanceCommand extends Command
         return $modes[0];
     }
 
-    /**
-     * @param list<array<string, mixed>> $targets
-     */
-    private function printTargets(SymfonyStyle $io, array $targets): void
-    {
-        if ([] === $targets) {
-            $io->writeln('No done Ozon accrual by-day raw records found for the selected filters.');
-
-            return;
-        }
-
-        $io->table(
-            ['companyId', 'shopRef', 'windowFrom', 'windowTo', 'rawRecords'],
-            array_map(static fn (array $target): array => [
-                (string) $target['company_id'],
-                (string) $target['shop_ref'],
-                (string) $target['window_from'],
-                (string) $target['window_to'],
-                (string) $target['raw_count'],
-            ], $targets),
-        );
-    }
-
-    /**
-     * @param array<string, int> $metrics
-     */
-    private function printMetrics(SymfonyStyle $io, array $metrics): void
-    {
-        $io->table(
-            ['metric', 'value'],
-            array_map(
-                static fn (string $metric, int $value): array => [$metric, (string) $value],
-                array_keys($metrics),
-                array_values($metrics),
-            ),
-        );
-    }
-
-    private function printHealth(SymfonyStyle $io): void
+    private function printHealth(SymfonyStyle $io, bool $scoped): void
     {
         $io->section('Health check');
         $this->printMetrics($io, $this->health());
+        if ($scoped) {
+            $io->note('Scoped run: global taxonomy health is informational and does not affect exit code.');
+        }
     }
 
     /**
@@ -383,19 +319,5 @@ final class OzonAccrualDailyMaintenanceCommand extends Command
         }
 
         return $total;
-    }
-
-    /**
-     * @param array<string, int> $metrics
-     *
-     * @return list<array{0: string, 1: string, 2: string}>
-     */
-    private function metricRows(string $action, array $metrics): array
-    {
-        return array_map(
-            static fn (string $metric, int $value): array => [$action, $metric, (string) $value],
-            array_keys($metrics),
-            array_values($metrics),
-        );
     }
 }

--- a/site/src/Ingestion/Command/OzonAccrualRefreshCategoryMetadataAllCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualRefreshCategoryMetadataAllCommand.php
@@ -13,7 +13,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Webmozart\Assert\Assert;
 
 #[AsCommand(
     name: 'app:ingestion:ozon-accrual:refresh-category-metadata-all',
@@ -21,6 +20,8 @@ use Webmozart\Assert\Assert;
 )]
 final class OzonAccrualRefreshCategoryMetadataAllCommand extends Command
 {
+    use OzonAccrualCommandHelperTrait;
+
     public function __construct(
         private readonly OzonAccrualCategoryMetadataBulkRunnerInterface $bulkRunner,
         private readonly DiscoverExternalCategoriesAction $discoverCategories,
@@ -66,6 +67,7 @@ final class OzonAccrualRefreshCategoryMetadataAllCommand extends Command
         $targets = $this->bulkRunner->targets($from, $to, $companyId, $shopRef);
 
         $io->title('Ozon accrual category metadata bulk refresh');
+        $io->section('Selected company/shop targets');
         $this->printTargets($io, $targets);
 
         if ([] === $targets) {
@@ -76,14 +78,7 @@ final class OzonAccrualRefreshCategoryMetadataAllCommand extends Command
         $totals = $refreshResult['totals'];
 
         $io->section('Bulk metadata refresh result');
-        $io->table(
-            ['metric', 'value'],
-            array_map(
-                static fn (string $metric, int $value): array => [$metric, (string) $value],
-                array_keys($totals),
-                array_values($totals),
-            ),
-        );
+        $this->printMetrics($io, $totals);
 
         if ($totals['failedRawRecords'] > 0 || $totals['failedTargets'] > 0) {
             $io->warning(sprintf(
@@ -116,90 +111,6 @@ final class OzonAccrualRefreshCategoryMetadataAllCommand extends Command
         $io->success(sprintf('Refreshed Ozon category metadata on %d canonical transactions.', $totals['updated']));
 
         return Command::SUCCESS;
-    }
-
-    /**
-     * @param list<array<string, mixed>> $targets
-     */
-    private function printTargets(SymfonyStyle $io, array $targets): void
-    {
-        $io->section('Selected company/shop targets');
-        if ([] === $targets) {
-            $io->writeln('No done Ozon accrual by-day raw records found for the selected filters.');
-
-            return;
-        }
-
-        $io->table(
-            ['companyId', 'shopRef', 'windowFrom', 'windowTo', 'rawRecords'],
-            array_map(static fn (array $target): array => [
-                (string) $target['company_id'],
-                (string) $target['shop_ref'],
-                (string) $target['window_from'],
-                (string) $target['window_to'],
-                (string) $target['raw_count'],
-            ], $targets),
-        );
-    }
-
-    /**
-     * @param array<string, int> $metrics
-     *
-     * @return list<array{0: string, 1: string, 2: string}>
-     */
-    private function metricRows(string $action, array $metrics): array
-    {
-        return array_map(
-            static fn (string $metric, int $value): array => [$action, $metric, (string) $value],
-            array_keys($metrics),
-            array_values($metrics),
-        );
-    }
-
-    private function optionalUuidOption(InputInterface $input, string $name): ?string
-    {
-        $value = $this->optionalStringOption($input, $name);
-        if (null === $value) {
-            return null;
-        }
-
-        Assert::uuid($value, sprintf('Invalid --%s UUID.', $name));
-
-        return $value;
-    }
-
-    private function optionalDateOption(InputInterface $input, string $name): ?\DateTimeImmutable
-    {
-        $value = $this->optionalStringOption($input, $name);
-        if (null === $value) {
-            return null;
-        }
-
-        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
-        if (false === $date || $date->format('Y-m-d') !== $value) {
-            throw new \InvalidArgumentException(sprintf('--%s must be a valid YYYY-MM-DD date.', $name));
-        }
-
-        return $date;
-    }
-
-    private function optionalStringOption(InputInterface $input, string $name): ?string
-    {
-        $value = trim((string) $input->getOption($name));
-
-        return '' === $value ? null : $value;
-    }
-
-    private function intOption(InputInterface $input, string $name, int $min, int $max): int
-    {
-        $value = (string) $input->getOption($name);
-        if (!ctype_digit($value)) {
-            throw new \InvalidArgumentException(sprintf('The --%s option must be an integer from %d to %d.', $name, $min, $max));
-        }
-
-        $number = (int) $value;
-
-        return max($min, min($max, $number));
     }
 
     private function mode(InputInterface $input): string

--- a/site/src/Ingestion/Command/OzonAccrualRefreshCategoryMetadataAllCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualRefreshCategoryMetadataAllCommand.php
@@ -6,18 +6,13 @@ namespace App\Ingestion\Command;
 
 use App\Ingestion\Application\Action\DiscoverExternalCategoriesAction;
 use App\Ingestion\Application\Action\RebuildMarketplaceCategoryIdentitiesAction;
-use App\Ingestion\Application\Action\RefreshOzonAccrualCategoryMetadataAction;
-use App\Ingestion\Application\Source\Ozon\OzonResourceType;
 use App\Ingestion\Enum\IngestSource;
-use App\Ingestion\Enum\RawNormalizationStatus;
-use Doctrine\DBAL\Connection;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\Process\Process;
 use Webmozart\Assert\Assert;
 
 #[AsCommand(
@@ -27,8 +22,7 @@ use Webmozart\Assert\Assert;
 final class OzonAccrualRefreshCategoryMetadataAllCommand extends Command
 {
     public function __construct(
-        private readonly Connection $connection,
-        private readonly RefreshOzonAccrualCategoryMetadataAction $refreshMetadata,
+        private readonly OzonAccrualCategoryMetadataBulkRunnerInterface $bulkRunner,
         private readonly DiscoverExternalCategoriesAction $discoverCategories,
         private readonly RebuildMarketplaceCategoryIdentitiesAction $rebuildIdentities,
     ) {
@@ -69,7 +63,7 @@ final class OzonAccrualRefreshCategoryMetadataAllCommand extends Command
         }
 
         $dryRun = 'dry-run' === $mode;
-        $targets = $this->targets($from, $to, $companyId, $shopRef);
+        $targets = $this->bulkRunner->targets($from, $to, $companyId, $shopRef);
 
         $io->title('Ozon accrual category metadata bulk refresh');
         $this->printTargets($io, $targets);
@@ -78,67 +72,8 @@ final class OzonAccrualRefreshCategoryMetadataAllCommand extends Command
             return Command::SUCCESS;
         }
 
-        $totals = [
-            'targets' => count($targets),
-            'rawRecords' => 0,
-            'scanned' => 0,
-            'matched' => 0,
-            'updated' => 0,
-            'unchanged' => 0,
-            'missing' => 0,
-            'failedRawRecords' => 0,
-            'rawRecordPages' => 0,
-        ];
-
-        foreach ($targets as $target) {
-            $windowFrom = new \DateTimeImmutable((string) $target['window_from']);
-            $windowTo = new \DateTimeImmutable((string) $target['window_to']);
-            $offset = 0;
-
-            do {
-                $rawRecords = $this->refreshMetadata->rawRecords(
-                    companyId: (string) $target['company_id'],
-                    from: $from ?? $windowFrom,
-                    to: $to ?? $windowTo,
-                    shopRef: (string) $target['shop_ref'],
-                    limit: $limitPerShop,
-                    offset: $offset,
-                );
-
-                if ([] === $rawRecords) {
-                    break;
-                }
-
-                ++$totals['rawRecordPages'];
-                $totals['rawRecords'] += count($rawRecords);
-
-                $resultRows = [];
-                foreach ($rawRecords as $rawRecord) {
-                    $resultRows = array_merge(
-                        $resultRows,
-                        $this->refreshRawRecordInSubprocess(
-                            companyId: (string) $target['company_id'],
-                            rawRecordId: (string) $rawRecord['id'],
-                            dryRun: $dryRun,
-                        ),
-                    );
-                    $this->releaseMemory();
-                }
-
-                foreach ($resultRows as $row) {
-                    $totals['scanned'] += (int) $row['scanned'];
-                    $totals['matched'] += (int) $row['matched'];
-                    $totals['updated'] += (int) $row['updated'];
-                    $totals['unchanged'] += (int) $row['unchanged'];
-                    $totals['missing'] += (int) $row['missing'];
-                    if ('error' === $row['status']) {
-                        ++$totals['failedRawRecords'];
-                    }
-                }
-
-                $offset += count($rawRecords);
-            } while (count($rawRecords) === $limitPerShop);
-        }
+        $refreshResult = $this->bulkRunner->refreshTargets($targets, $from, $to, $limitPerShop, $dryRun);
+        $totals = $refreshResult['totals'];
 
         $io->section('Bulk metadata refresh result');
         $io->table(
@@ -150,8 +85,12 @@ final class OzonAccrualRefreshCategoryMetadataAllCommand extends Command
             ),
         );
 
-        if ($totals['failedRawRecords'] > 0) {
-            $io->warning(sprintf('Metadata refresh finished with %d failed raw records.', $totals['failedRawRecords']));
+        if ($totals['failedRawRecords'] > 0 || $totals['failedTargets'] > 0) {
+            $io->warning(sprintf(
+                'Metadata refresh finished with %d failed raw records and %d failed targets.',
+                $totals['failedRawRecords'],
+                $totals['failedTargets'],
+            ));
 
             return Command::FAILURE;
         }
@@ -177,70 +116,6 @@ final class OzonAccrualRefreshCategoryMetadataAllCommand extends Command
         $io->success(sprintf('Refreshed Ozon category metadata on %d canonical transactions.', $totals['updated']));
 
         return Command::SUCCESS;
-    }
-
-    /**
-     * @return list<array<string, mixed>>
-     */
-    private function targets(
-        ?\DateTimeImmutable $from,
-        ?\DateTimeImmutable $to,
-        ?string $companyId,
-        ?string $shopRef,
-    ): array {
-        $externalWindowFrom = "substring(r.external_id from '^accrual-by-day:([0-9]{4}-[0-9]{2}-[0-9]{2}):[0-9]{4}-[0-9]{2}-[0-9]{2}$')::date";
-        $externalWindowTo = "substring(r.external_id from '^accrual-by-day:[0-9]{4}-[0-9]{2}-[0-9]{2}:([0-9]{4}-[0-9]{2}-[0-9]{2})$')::date";
-        $windowFrom = sprintf('COALESCE(j.window_from, %s, DATE(r.fetched_at))', $externalWindowFrom);
-        $windowTo = sprintf('COALESCE(j.window_to, j.window_from, %s, %s, DATE(r.fetched_at))', $externalWindowTo, $externalWindowFrom);
-        $conditions = [
-            'r.source = :source',
-            'r.resource_type = :resourceType',
-            'r.normalization_status = :status',
-        ];
-        $params = [
-            'source' => IngestSource::OZON->value,
-            'resourceType' => OzonResourceType::ACCRUAL_BY_DAY,
-            'status' => RawNormalizationStatus::DONE->value,
-        ];
-
-        if (null !== $from) {
-            $conditions[] = sprintf('%s >= :fromDate', $windowTo);
-            $params['fromDate'] = $from->format('Y-m-d');
-        }
-
-        if (null !== $to) {
-            $conditions[] = sprintf('%s <= :toDate', $windowFrom);
-            $params['toDate'] = $to->format('Y-m-d');
-        }
-
-        if (null !== $companyId) {
-            $conditions[] = 'r.company_id = :companyId';
-            $params['companyId'] = $companyId;
-        }
-
-        if (null !== $shopRef) {
-            $conditions[] = 'r.shop_ref = :shopRef';
-            $params['shopRef'] = $shopRef;
-        }
-
-        return $this->connection->fetchAllAssociative(
-            sprintf(
-                'SELECT r.company_id,
-                        r.shop_ref,
-                        TO_CHAR(MIN(%s), \'YYYY-MM-DD\') AS window_from,
-                        TO_CHAR(MAX(%s), \'YYYY-MM-DD\') AS window_to,
-                        COUNT(*) AS raw_count
-                 FROM ingest_raw_records r
-                 LEFT JOIN ingest_sync_jobs j ON j.id::text = r.sync_job_id AND j.company_id = r.company_id
-                 WHERE %s
-                 GROUP BY r.company_id, r.shop_ref
-                 ORDER BY r.company_id ASC, r.shop_ref ASC',
-                $windowFrom,
-                $windowTo,
-                implode(' AND ', $conditions),
-            ),
-            $params,
-        );
     }
 
     /**
@@ -279,92 +154,6 @@ final class OzonAccrualRefreshCategoryMetadataAllCommand extends Command
             array_keys($metrics),
             array_values($metrics),
         );
-    }
-
-    /**
-     * @return list<array<string, string|int>>
-     */
-    private function refreshRawRecordInSubprocess(string $companyId, string $rawRecordId, bool $dryRun): array
-    {
-        $process = new Process([
-            PHP_BINARY,
-            '-d',
-            sprintf('memory_limit=%s', $this->memoryLimit()),
-            $this->consolePath(),
-            'app:ingestion:ozon-accrual:refresh-category-metadata',
-            sprintf('--company-id=%s', $companyId),
-            sprintf('--raw-id=%s', $rawRecordId),
-            $dryRun ? '--dry-run' : '--execute-inline',
-            '--json-result',
-            '--no-interaction',
-        ]);
-        $process->setTimeout(null);
-        $process->run();
-
-        $rows = $this->decodeResultRows($process->getOutput());
-        if ([] !== $rows) {
-            return $rows;
-        }
-
-        if ($process->isSuccessful()) {
-            return [];
-        }
-
-        $error = trim($process->getErrorOutput()) ?: trim($process->getOutput()) ?: sprintf('Subprocess exited with code %s.', (string) $process->getExitCode());
-
-        return [[
-            'rawId' => $rawRecordId,
-            'status' => 'error',
-            'scanned' => 0,
-            'matched' => 0,
-            'updated' => 0,
-            'unchanged' => 0,
-            'missing' => 0,
-            'error' => $error,
-        ]];
-    }
-
-    /**
-     * @return list<array<string, string|int>>
-     */
-    private function decodeResultRows(string $output): array
-    {
-        $output = trim($output);
-        if ('' === $output) {
-            return [];
-        }
-
-        try {
-            $decoded = json_decode($output, true, flags: JSON_THROW_ON_ERROR);
-        } catch (\JsonException) {
-            return [];
-        }
-
-        if (!is_array($decoded)) {
-            return [];
-        }
-
-        return array_values(array_filter($decoded, static fn (mixed $row): bool => is_array($row)));
-    }
-
-    private function consolePath(): string
-    {
-        return dirname(__DIR__, 3) . '/bin/console';
-    }
-
-    private function memoryLimit(): string
-    {
-        $memoryLimit = ini_get('memory_limit');
-
-        return false === $memoryLimit || '' === $memoryLimit ? '1G' : $memoryLimit;
-    }
-
-    private function releaseMemory(): void
-    {
-        gc_collect_cycles();
-        if (function_exists('gc_mem_caches')) {
-            gc_mem_caches();
-        }
     }
 
     private function optionalUuidOption(InputInterface $input, string $name): ?string

--- a/site/tests/Integration/Ingestion/Command/OzonAccrualDailyMaintenanceCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/OzonAccrualDailyMaintenanceCommandTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Command;
+
+use App\Ingestion\Command\OzonAccrualCategoryMetadataBulkRunnerInterface;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class OzonAccrualDailyMaintenanceCommandTest extends IntegrationTestCase
+{
+    public function testExecuteRunsFullMaintenancePipeline(): void
+    {
+        $runner = new FakeOzonAccrualCategoryMetadataBulkRunner();
+        self::getContainer()->set(OzonAccrualCategoryMetadataBulkRunnerInterface::class, $runner);
+
+        $tester = $this->tester();
+        $exit = $tester->execute([
+            '--from' => '2026-06-01',
+            '--to' => '2026-06-25',
+            '--limit-per-shop' => '10',
+            '--execute' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exit, $tester->getDisplay());
+        self::assertStringContainsString('Ozon accrual daily maintenance finished.', $tester->getDisplay());
+        self::assertSame('2026-06-01', $runner->from?->format('Y-m-d'));
+        self::assertSame('2026-06-25', $runner->to?->format('Y-m-d'));
+        self::assertSame(10, $runner->limitPerShop);
+        self::assertFalse($runner->dryRun);
+    }
+
+    public function testReturnsFailureAfterProcessingWhenBulkRefreshHasFailures(): void
+    {
+        $runner = new FakeOzonAccrualCategoryMetadataBulkRunner();
+        $runner->totals['failedRawRecords'] = 1;
+        self::getContainer()->set(OzonAccrualCategoryMetadataBulkRunnerInterface::class, $runner);
+
+        $tester = $this->tester();
+        $exit = $tester->execute([
+            '--from' => '2026-06-01',
+            '--to' => '2026-06-25',
+            '--execute' => true,
+        ]);
+
+        self::assertSame(Command::FAILURE, $exit, $tester->getDisplay());
+        self::assertStringContainsString('finished with failures', $tester->getDisplay());
+        self::assertFalse($runner->dryRun);
+    }
+
+    private function tester(): CommandTester
+    {
+        $app = new Application(self::$kernel);
+
+        return new CommandTester($app->find('app:ingestion:ozon-accrual:daily-maintenance'));
+    }
+}
+
+final class FakeOzonAccrualCategoryMetadataBulkRunner implements OzonAccrualCategoryMetadataBulkRunnerInterface
+{
+    public ?\DateTimeImmutable $from = null;
+    public ?\DateTimeImmutable $to = null;
+    public int $limitPerShop = 0;
+    public bool $dryRun = false;
+
+    /**
+     * @var array<string, int>
+     */
+    public array $totals = [
+        'targets' => 1,
+        'rawRecords' => 1,
+        'scanned' => 3,
+        'matched' => 3,
+        'updated' => 2,
+        'unchanged' => 1,
+        'missing' => 0,
+        'failedRawRecords' => 0,
+        'failedTargets' => 0,
+        'rawRecordPages' => 1,
+    ];
+
+    public function targets(
+        ?\DateTimeImmutable $from,
+        ?\DateTimeImmutable $to,
+        ?string $companyId,
+        ?string $shopRef,
+    ): array {
+        $this->from = $from;
+        $this->to = $to;
+
+        return [[
+            'company_id' => Uuid::uuid7()->toString(),
+            'shop_ref' => Uuid::uuid7()->toString(),
+            'window_from' => '2026-06-01',
+            'window_to' => '2026-06-25',
+            'raw_count' => 1,
+        ]];
+    }
+
+    public function refreshTargets(
+        array $targets,
+        ?\DateTimeImmutable $from,
+        ?\DateTimeImmutable $to,
+        int $limitPerShop,
+        bool $dryRun,
+    ): array {
+        $this->from = $from;
+        $this->to = $to;
+        $this->limitPerShop = $limitPerShop;
+        $this->dryRun = $dryRun;
+
+        return [
+            'totals' => $this->totals,
+            'failedRawRecords' => [],
+            'failedTargets' => [],
+        ];
+    }
+}

--- a/site/tests/Integration/Ingestion/Command/OzonAccrualDailyMaintenanceCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/OzonAccrualDailyMaintenanceCommandTest.php
@@ -4,7 +4,16 @@ declare(strict_types=1);
 
 namespace App\Tests\Integration\Ingestion\Command;
 
+use App\Ingestion\Application\Source\Ozon\OzonAccrualCategoryTaxonomyResolver;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
 use App\Ingestion\Command\OzonAccrualCategoryMetadataBulkRunnerInterface;
+use App\Ingestion\Entity\ExternalCategory;
+use App\Ingestion\Entity\FinancialTransaction;
+use App\Ingestion\Enum\ExternalCategoryStatus;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+use App\Shared\Domain\ValueObject\Money;
 use App\Tests\Support\Kernel\IntegrationTestCase;
 use Ramsey\Uuid\Uuid;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -52,11 +61,106 @@ final class OzonAccrualDailyMaintenanceCommandTest extends IntegrationTestCase
         self::assertFalse($runner->dryRun);
     }
 
+    public function testExecuteSucceedsWhenOnlyUnmappedCategoriesRemain(): void
+    {
+        $runner = new FakeOzonAccrualCategoryMetadataBulkRunner();
+        self::getContainer()->set(OzonAccrualCategoryMetadataBulkRunnerInterface::class, $runner);
+        $this->em->persist(new ExternalCategory(
+            source: IngestSource::OZON,
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            scope: OzonAccrualCategoryTaxonomyResolver::SCOPE_ANY,
+            normalizedKey: 'code:reviewonlyunmapped',
+            externalCode: 'ReviewOnlyUnmapped',
+            externalName: 'ReviewOnlyUnmapped',
+            status: ExternalCategoryStatus::NEW,
+            seenAt: new \DateTimeImmutable('2026-06-25 12:00:00+00:00'),
+        ));
+        $this->em->flush();
+
+        $tester = $this->tester();
+        $exit = $tester->execute([
+            '--from' => '2026-06-01',
+            '--to' => '2026-06-25',
+            '--execute' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exit, $tester->getDisplay());
+        self::assertStringContainsString('categories are awaiting mapping', $tester->getDisplay());
+    }
+
+    public function testScopedExecuteIgnoresGlobalHealthFailures(): void
+    {
+        $runner = new FakeOzonAccrualCategoryMetadataBulkRunner();
+        self::getContainer()->set(OzonAccrualCategoryMetadataBulkRunnerInterface::class, $runner);
+        $this->persistUnclassifiedTransaction();
+
+        $tester = $this->tester();
+        $exit = $tester->execute([
+            '--from' => '2026-06-01',
+            '--to' => '2026-06-25',
+            '--company-id' => Uuid::uuid7()->toString(),
+            '--execute' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exit, $tester->getDisplay());
+        self::assertStringContainsString('global taxonomy health is informational', $tester->getDisplay());
+    }
+
+    public function testRejectsOutOfRangeIntegerOptions(): void
+    {
+        $runner = new FakeOzonAccrualCategoryMetadataBulkRunner();
+        self::getContainer()->set(OzonAccrualCategoryMetadataBulkRunnerInterface::class, $runner);
+
+        $tester = $this->tester();
+        $exit = $tester->execute([
+            '--from' => '2026-06-01',
+            '--to' => '2026-06-25',
+            '--limit-per-shop' => '99999',
+            '--execute' => true,
+        ]);
+
+        self::assertSame(Command::FAILURE, $exit, $tester->getDisplay());
+        self::assertStringContainsString('The --limit-per-shop option must be an integer from 1 to 500.', $tester->getDisplay());
+        self::assertSame(0, $runner->limitPerShop);
+    }
+
     private function tester(): CommandTester
     {
         $app = new Application(self::$kernel);
 
         return new CommandTester($app->find('app:ingestion:ozon-accrual:daily-maintenance'));
+    }
+
+    private function persistUnclassifiedTransaction(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = Uuid::uuid7()->toString();
+        $rawRecordId = Uuid::uuid7()->toString();
+
+        $this->em->persist(new FinancialTransaction(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            shopRef: $connectionRef,
+            source: IngestSource::OZON,
+            externalId: 'ozon:accrual-by-day:test-unclassified',
+            externalUpdatedAt: new \DateTimeImmutable('2026-06-25 00:00:00+00:00'),
+            operationGroupId: Uuid::uuid5(Uuid::NAMESPACE_URL, sprintf('%s:ozon:unclassified', $companyId))->toString(),
+            type: TransactionType::FEE,
+            direction: TransactionDirection::OUT,
+            money: Money::fromMinor(100, 'RUB'),
+            occurredAt: new \DateTimeImmutable('2026-06-25 00:00:00+03:00'),
+            rawRecordId: $rawRecordId,
+            description: 'Ozon accrual unclassified test',
+            sourceData: [
+                '_ingestion_resource' => OzonResourceType::ACCRUAL_BY_DAY,
+                '_ingestion_type_id' => '999',
+                '_ozon_category_label' => 'Неизвестный type_id Ozon: 999',
+                '_ozon_category_group' => 'Требует классификации',
+                '_ozon_category_known' => false,
+            ],
+            sourceTz: 'Europe/Moscow',
+        ));
+        $this->em->flush();
     }
 }
 


### PR DESCRIPTION
## Summary
- add `app:ingestion:ozon-accrual:daily-maintenance` to run daily Ozon accrual category maintenance end to end
- extract shared bulk metadata refresh runner and reuse it from `refresh-category-metadata-all`
- continue processing remaining raw records/targets after per-record failures while logging errors for Sentry via Monolog
- schedule daily maintenance in the existing `scheduler` cron at 05:15 MSK

## Behavior
- `--execute` runs seed defaults, bulk metadata refresh, category discovery, identity rebuild, and health check
- `--dry-run` avoids mutations and still reports target/refresh/health state
- one failed raw record or target is counted and logged, but does not stop the rest of the batch
- final exit is non-zero for refresh failures or unclassified canonical transactions
- unmapped/new categories are reported as warning only; they do not fail the daily run by themselves
- scoped runs with `--company-id` or `--shop-ref` treat global taxonomy health as informational

## Review Fixes
- changed health gate severity so pending mapping work does not create daily failure noise
- prevented scoped runs from failing because of unrelated tenant/global health
- moved shared CLI option/table helpers into `OzonAccrualCommandHelperTrait`
- renamed and documented subprocess env handling as an explicit overlay
- changed integer option parsing from silent clamping to strict range validation

## Checks
- `php -l` on changed PHP files
- `php bin/phpunit tests/Integration/Ingestion/Command/OzonAccrualRefreshCategoryMetadataCommandTest.php tests/Integration/Ingestion/Command/OzonAccrualDailyMaintenanceCommandTest.php`
- `make site-test-unit` (passed with existing 1 warning and 1 deprecation)
- `php bin/console lint:container --no-debug`
- `git diff --check`
- `supercronic -test /etc/crontabs/app.cron` via prod compose
