### PR TITLE
[codex] Add Ozon Performance ingestion

### DIFF
--- a/docs/tasks/ozon/handoff.md
+++ b/docs/tasks/ozon/handoff.md
@@ -1,0 +1,61 @@
+# Ozon Performance Ingestion — Handoff
+
+## Summary
+
+Implemented the first raw-only Ozon Performance ingestion stage inside the existing Ingestion module.
+
+The implementation adds:
+
+- Ozon Performance API client with token acquisition, cached bearer token, request classification, JSON/CSV report decoding, and no secret logging.
+- Ozon Performance connector for campaigns, SKU CPC campaign objects, Search Promo products, SKU product statistics, Search Promo/CPO async statistics, and expense statistics.
+- Ingestion connector registry routing by source and resource type, so seller finance and performance resources can coexist under `ozon`.
+- Raw-only continuation handling for async report generation/polling.
+- Daily and explicit-period dispatch commands for active Ozon Performance connections.
+- Coverage readable labels/groups for new Performance resources.
+- Unit and integration test coverage for registry routing, raw-only continuation, connector flows, and command dispatch.
+
+## Commands
+
+- `app:ingestion:ozon-performance:daily-load --days-back=14 --execute`
+- `app:ingestion:ozon-performance:backfill --company-id=<uuid> --from=YYYY-MM-DD --to=YYYY-MM-DD --execute`
+
+Both commands dispatch Ingestion backfill jobs only. They do not normalize Performance data at this stage.
+
+## Files Changed
+
+- `site/src/Ingestion/Application/Source/Ozon/OzonPerformanceReportConnector.php`
+- `site/src/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClient.php`
+- `site/src/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClientInterface.php`
+- `site/src/Ingestion/Command/OzonPerformanceDailyLoadCommand.php`
+- `site/src/Ingestion/Command/OzonPerformanceBackfillCommand.php`
+- `site/src/Marketplace/Infrastructure/Query/ActiveOzonPerformanceConnectionsQuery.php`
+- `site/src/Marketplace/Facade/MarketplaceFacade.php`
+- `site/src/Ingestion/Domain/Service/ConnectorRegistry.php`
+- `site/src/Ingestion/MessageHandler/RunSyncChunkHandler.php`
+- `site/src/Ingestion/Application/Service/IngestionResourceLabelProvider.php`
+- Coverage DTO/query/controller/frontend schema/view files
+- Unit/integration tests under `site/tests/*/Ingestion`
+
+## Checks
+
+- `php -l` on new/changed PHP files — passed
+- `php bin/phpunit --testsuite unit --filter "ConnectorRegistryTest|OzonPerformanceReportConnectorTest"` — passed
+- `php bin/phpunit --testsuite integration --filter "OzonIngestionRegistryTest|RunSyncChunkHandlerTest|OzonPerformanceLoadCommandTest"` — passed, existing PHPUnit deprecations only
+- `make site-test-unit` — passed, existing warning/deprecation only
+- `npm run lint` — passed
+- `npm run build` — passed
+- OpenAPI schema regeneration diff against `assets/api/schema.d.ts` — passed
+- Symfony test/prod container command discovery — passed
+
+## Migrations / API / Cron
+
+- No database migrations.
+- No public API endpoints added.
+- Existing coverage API response was extended with optional readable fields: `resource_label`, `resource_group`.
+- No cron or worker configuration changed.
+
+## Risks / Follow-up
+
+- This stage stores raw Performance data only. Normalization, money field modeling, and business reporting remain out of scope.
+- Ozon Performance endpoint shapes should be validated with live samples before normalization design.
+- If multiple active Performance connections per company become common, credential lookup should be tightened to connection-specific credentials.

--- a/docs/tasks/ozon/ozon-advertising-api-research.md
+++ b/docs/tasks/ozon/ozon-advertising-api-research.md
@@ -1,0 +1,335 @@
+# Ozon Advertising / Performance API Research
+
+Дата исследования: 2026-06-27
+
+## Цель
+
+Изучить актуальные возможности Ozon API для получения данных о рекламе, особенно новые варианты доступа к Performance API без отдельного performance token.
+
+Код не менялся. Это исследовательская заметка для дальнейшего проектирования интеграции.
+
+## Основной вывод
+
+Обычный Seller API доступ через `api-seller.ozon.ru` с заголовками `Client-Id` и `Api-Key` в документации не показан как прямой способ вызова Performance API.
+
+Performance API по-прежнему находится на отдельном host:
+
+```text
+https://api-performance.ozon.ru
+```
+
+В примерах методов Performance API используется:
+
+```text
+Authorization: Bearer <token>
+```
+
+При этом Ozon опубликовал свежее обновление: с 2026-04-06 для Performance API продавцов РФ добавлен OAuth-доступ, аналогичный контуру прав Seller API. Практический смысл: вместо старого отдельного `client_id/client_secret` Performance API можно ожидать доступ через общий OAuth/Bearer-контур прав, но это не равно прямой поддержке обычных Seller API headers `Client-Id` / `Api-Key`.
+
+Перед реализацией нужно проверить на реальном кабинете, какой именно Bearer выдаётся для Performance API:
+
+- legacy token через `POST /api/client/token`;
+- новый OAuth token через общий Ozon OAuth/access flow;
+- обычный Seller API key, если Ozon фактически добавил bridge, хотя документация этого явно не показывает.
+
+## Авторизация
+
+### Legacy Performance API token
+
+Документация Performance API содержит получение Bearer token:
+
+```http
+POST /api/client/token
+Host: api-performance.ozon.ru
+Content-Type: application/json
+Accept: application/json
+```
+
+Тело:
+
+```json
+{
+  "client_id": "XYZ@advertising.performance.ozon.ru",
+  "client_secret": "...",
+  "grant_type": "client_credentials"
+}
+```
+
+Ответ содержит:
+
+```json
+{
+  "access_token": "...",
+  "expires_in": 1800,
+  "token_type": "Bearer"
+}
+```
+
+### Новый OAuth-доступ
+
+Ozon for dev сообщает об оптимизации контроля доступов Performance API через OAuth для продавцов РФ с 2026-04-06.
+
+Вывод для архитектуры: auth-слой рекламной интеграции нужно проектировать как отдельный provider, который умеет работать минимум в двух режимах:
+
+- legacy Performance credentials;
+- новый OAuth/Bearer token.
+
+Не стоит смешивать это с текущей моделью Seller API `Client-Id` + `Api-Key`, пока не будет подтверждения реальным запросом.
+
+## Методы получения рекламных данных
+
+### Кампании и рекламные объекты
+
+#### `GET /api/client/campaign`
+
+Получение списка рекламных кампаний.
+
+Основные фильтры:
+
+- `campaignIds[]`
+- `advObjectType`
+- `state`
+- `page`
+- `pageSize`
+
+Важные типы `advObjectType`:
+
+- `SKU` — товарная реклама / pay-per-click;
+- `BANNER` — баннерные кампании;
+- `SEARCH_PROMO` — продвижение с оплатой за заказ.
+
+Важные состояния:
+
+- `CAMPAIGN_STATE_RUNNING`
+- `CAMPAIGN_STATE_PLANNED`
+- `CAMPAIGN_STATE_STOPPED`
+- `CAMPAIGN_STATE_INACTIVE`
+- `CAMPAIGN_STATE_ARCHIVED`
+- `CAMPAIGN_STATE_MODERATION_DRAFT`
+- `CAMPAIGN_STATE_MODERATION_IN_PROGRESS`
+- `CAMPAIGN_STATE_MODERATION_FAILED`
+- `CAMPAIGN_STATE_FINISHED`
+
+#### `GET /api/client/campaign/{campaignId}/objects`
+
+Получение продвигаемых объектов кампании.
+
+Подходит для:
+
+- pay-per-click кампаний;
+- баннеров;
+- видеобаннеров.
+
+Для pay-per-order/search promo документация рекомендует использовать отдельный метод товаров search promo.
+
+#### `POST /api/client/campaign/search_promo/v2/products`
+
+Получение товаров в продвижении с оплатой за заказ.
+
+Метод read-like, несмотря на `POST`: используется для получения списка товаров search promo с пагинацией.
+
+#### `GET /api/client/products_with_bonuses`
+
+Получение SKU, по которым начислены бонусы, которые могут расходоваться на клики перед расходом основного бюджета кампании.
+
+## Методы статистики
+
+### Daily statistics
+
+#### `GET /api/client/statistics/daily`
+
+Ежедневная статистика кампаний. Если даты не переданы, документация указывает поведение по последним 7 дням.
+
+#### `GET /api/client/statistics/daily/json`
+
+То же, но в JSON-формате.
+
+### Product campaign statistics
+
+#### `GET /api/client/statistics/campaign/product`
+
+Статистика товарных кампаний. Поддерживает фильтр по датам и `campaignIds`.
+
+Параметры дат:
+
+- `from` / `to` в RFC3339;
+- `dateFrom` / `dateTo`, приоритетнее, если переданы обе пары.
+
+#### `GET /api/client/statistics/campaign/product/json`
+
+JSON-вариант отчёта по товарным кампаниям.
+
+### Media campaign statistics
+
+#### `GET /api/client/statistics/campaign/media`
+
+Статистика media/banner кампаний. Поддерживает фильтр по датам и `campaignIds`.
+
+#### `GET /api/client/statistics/campaign/media/json`
+
+JSON-вариант отчёта по media/banner кампаниям.
+
+### Асинхронные отчёты
+
+#### `POST /api/client/statistics`
+
+Генерация отчёта статистики. Возвращает UUID отчёта.
+
+Использовать, когда нужен файл/архив или большой период/набор кампаний.
+
+#### `GET /api/client/statistics/{uuid}`
+
+Получение статуса и метаданных отчёта по UUID.
+
+#### `GET /api/client/statistics/report?UUID=...`
+
+Скачивание готового отчёта.
+
+#### `GET /api/client/statistics/list`
+
+Список отчётов, созданных через интерфейс рекламного кабинета.
+
+#### `GET /api/client/statistics/externallist`
+
+Список отчётов, созданных через API/service accounts.
+
+### Отчёты по заказам и товарам
+
+#### `POST /api/client/statistic/orders/generate`
+
+Генерация отчёта по заказам.
+
+#### `POST /api/client/statistic/products/generate`
+
+Генерация отчёта по товарам.
+
+### Video statistics
+
+#### `POST /api/client/statistics/video`
+
+Статистика видеобаннеров.
+
+## External traffic / vendor analytics
+
+Эти методы относятся к аналитике внешнего трафика. Это не прямой аналог рекламных расходов Performance, но может быть полезно для attribution/marketing analytics.
+
+#### `POST /api/client/vendors/statistics`
+
+Генерация отчёта по external traffic analytics.
+
+Типы отчётов из документации:
+
+- `TRAFFIC_SOURCES`
+- `ORDERS`
+
+Ограничение периода: не более 3 месяцев.
+
+#### `GET /api/client/vendors/statistics/list`
+
+Список запрошенных отчётов external traffic analytics.
+
+#### `GET /api/client/vendors/statistics/{uuid}`
+
+Получение информации по конкретному отчёту external traffic analytics.
+
+В документации также встречается вариант пути `/vendors/statistics/{UUID}`. Перед реализацией нужно уточнить точный актуальный path в консоли Ozon или через тестовый запрос.
+
+## Ставки и справочные рекламные данные
+
+Эти методы полезны не для факта расходов, а для понимания рекламных настроек и рекомендаций.
+
+#### `GET /api/client/campaign/{campaignId}/products/bids/competitive`
+
+Получение конкурентных ставок по товарам кампании.
+
+#### `POST /api/client/search_promo/get_cpo_min_bids`
+
+Получение минимальных/fixed CPO ставок для товаров.
+
+#### `POST /api/client/search_promo/bids/recommendation`
+
+Рекомендации ставок для search promo.
+
+## Методы управления рекламой, которые не нужны для read-only интеграции
+
+Не включать в первую read-only интеграцию:
+
+- создание кампаний;
+- активация/деактивация кампаний;
+- изменение бюджета;
+- добавление/удаление товаров;
+- изменение ставок.
+
+Примеры таких методов:
+
+- `POST /api/client/campaign/cpc/v2/product`
+- `PATCH /api/client/campaign/{campaignId}`
+- `POST /api/client/campaign/{campaignId}/activate`
+- `POST /api/client/campaign/{campaignId}/deactivate`
+- `POST /api/client/campaign/{campaignId}/products/delete`
+- `POST /api/client/campaign/search_promo/v2/bids/set`
+- `POST /api/client/campaign/search_promo/v2/bids/delete`
+- `POST /api/client/search_promo/product/enable`
+- `POST /api/client/search_promo/product/disable`
+- `POST /api/client/search_promo/product/update`
+
+## ORD API
+
+ORD API — отдельный рекламно-юридический контур, не основной источник расходов Performance.
+
+Может понадобиться, если нужно:
+
+- рекламные креативы;
+- площадки;
+- договоры;
+- акты;
+- маркировка интернет-рекламы;
+- данные для отчётности ОРД.
+
+Релевантный метод:
+
+#### `POST /api/external/v2/statistic`
+
+Получение/фильтрация рекламной статистики ORD.
+
+## Рекомендация по будущей реализации
+
+Создать отдельный Ozon Advertising integration, не смешивая его с обычным Ozon Seller API ingestion.
+
+Минимальный read-only MVP:
+
+1. Auth provider:
+   - legacy Performance token;
+   - новый OAuth/Bearer token.
+2. Sync campaigns:
+   - `GET /api/client/campaign`.
+3. Sync campaign objects:
+   - `GET /api/client/campaign/{campaignId}/objects`;
+   - `POST /api/client/campaign/search_promo/v2/products`.
+4. Sync daily statistics:
+   - `GET /api/client/statistics/daily/json`;
+   - `GET /api/client/statistics/campaign/product/json`;
+   - `GET /api/client/statistics/campaign/media/json`.
+5. Async report fallback:
+   - `POST /api/client/statistics`;
+   - `GET /api/client/statistics/{uuid}`;
+   - `GET /api/client/statistics/report?UUID=...`.
+
+Первую версию лучше делать строго read-only.
+
+## Открытые вопросы перед кодом
+
+1. Проверить на реальном кабинете, какой token реально принимает `api-performance.ozon.ru` после OAuth-обновления.
+2. Проверить, работает ли Performance API с текущим стандартным Seller API ключом напрямую. Документация этого явно не подтверждает.
+3. Уточнить точный path для external traffic report by UUID:
+   - `/api/client/vendors/statistics/{uuid}`;
+   - или `/vendors/statistics/{UUID}`.
+4. Уточнить лимиты, ретраи и максимальные периоды для каждого статистического метода.
+5. Проверить, какие отчёты возвращают JSON сразу, а какие требуют async UUID flow.
+
+## Источники
+
+- https://docs.ozon.ru/api/performance
+- https://dev.ozon.ru/news/691-Performance-API-Optimizatsiia-kontrolia-dostupov-cherez-OAuth/
+- https://docs.ozon.ru/api/seller/
+- https://docs.ozon.ru/api/ord

--- a/docs/tasks/ozon/ozon-performance-ingestion-plan.md
+++ b/docs/tasks/ozon/ozon-performance-ingestion-plan.md
@@ -1,0 +1,704 @@
+# План загрузки Ozon Performance через модуль Ingestion
+
+Дата: 2026-06-27
+
+## Цель
+
+Развить модуль `Ingestion` так, чтобы рекламные данные Ozon Performance загружались через общий ingestion-пайплайн: `SyncJob` -> connector `pull()` -> `RawBatch` -> `IngestRawRecord`.
+
+Фокус первого этапа: загрузка и хранение сырых данных. Нормализация в расходы, P&L, распределение по SKU/listing и UI-аналитика остаются отдельными этапами.
+
+Денежное правило проекта: при будущей нормализации любые суммы рекламы/затрат должны проходить через `App\Shared\Domain\ValueObject\Money`. Raw-этап сохраняет payload как есть, но mapper не должен использовать `float` для денег.
+
+## Исправленное архитектурное решение
+
+Целевой модуль: `site/src/Ingestion`.
+
+`Marketplace` используется только как источник подключений и credentials, по аналогии с текущей загрузкой финансовых отчетов.
+
+`MarketplaceAds` не является целевым модулем для нового пайплайна. Его можно использовать как источник опыта по Ozon Performance API, batch/polling ограничениям и существующим клиентским методам, но новая загрузка должна жить в `Ingestion`.
+
+## Что уже есть в Ingestion
+
+Подходящие строительные блоки уже есть:
+
+- `SourceConnectorInterface` - единый контракт источника.
+- `PullRequest` / `PullResult` - модель загрузки чанка.
+- `RawBatch` - контейнер сырого результата.
+- `StoreRawBatchAction` - идемпотентное сохранение raw payload в объектное хранилище и `ingest_raw_records`.
+- `SyncJob` - job для incremental/backfill.
+- `SplitJobIntoChunksAction` - разбиение backfill на окна.
+- `RunSyncChunkHandler` - запуск connector `pull()`, сохранение raw, retry/rate-limit flow.
+- `ConnectorAuthException`, `ConnectorRateLimitedException`, `ConnectorTransientException` - уже существующая модель ошибок.
+- `OzonResourceType` - место для новых resource type Ozon.
+- `OzonSellerReportConnector` - пример Ozon connector для финансовых отчетов.
+
+Вывод: не нужно создавать отдельную систему загрузки. Нужно добавить новые Ozon Performance resources в существующий ingestion-контур.
+
+## Подключение к Performance API
+
+### На старте
+
+Новый OAuth через seller connection на старте не поддерживаем.
+
+Используем отдельное Performance-подключение из модуля `Marketplace`:
+
+```php
+MarketplaceFacade::getConnectionCredentials(
+    $companyId,
+    MarketplaceType::OZON,
+    MarketplaceConnectionType::PERFORMANCE,
+)
+```
+
+Ожидаемый режим авторизации:
+
+```text
+POST https://api-performance.ozon.ru/api/client/token
+grant_type=client_credentials
+client_id=<performance client id>
+client_secret=<performance secret>
+```
+
+Дальше все Performance API запросы идут с:
+
+```text
+Authorization: Bearer <access_token>
+```
+
+### Что нужно добавить в Marketplace facade
+
+Сейчас в `MarketplaceFacade` есть публичный метод для активных Ozon seller-подключений. Для Ingestion лучше добавить аналогичный публичный метод:
+
+```php
+getActiveOzonPerformanceConnections(?string $companyId = null): array
+```
+
+Он должен возвращать безопасный список:
+
+```text
+connectionId
+companyId
+marketplace=ozon
+connectionType=performance
+clientId
+```
+
+Ingestion не должен читать секреты напрямую из таблиц.
+
+## Новый connector
+
+Добавить отдельный connector:
+
+```text
+App\Ingestion\Application\Source\Ozon\OzonPerformanceReportConnector
+```
+
+Он должен реализовать `SourceConnectorInterface`:
+
+- `source()` -> `IngestSource::OZON`;
+- `capabilities()` -> `CAN_DISCOVER_SHOPS`, `CAN_PULL`;
+- `discoverShops()` -> один shop descriptor на Performance connection;
+- `pull()` -> route по новым `OzonResourceType::*`.
+
+Важно: не расширять бесконечно `OzonSellerReportConnector`. Финансы и реклама должны быть разными connector/service классами внутри `Ingestion\Application\Source\Ozon`.
+
+## Новые resource types
+
+Добавить в `OzonResourceType`:
+
+```php
+public const PERFORMANCE_CAMPAIGNS = 'ozon_performance_campaigns';
+public const PERFORMANCE_SKU_CAMPAIGN_OBJECTS = 'ozon_performance_sku_campaign_objects';
+public const PERFORMANCE_SEARCH_PROMO_PRODUCTS = 'ozon_performance_search_promo_products';
+public const PERFORMANCE_SKU_PRODUCT_STATISTICS = 'ozon_performance_sku_product_statistics';
+public const PERFORMANCE_SEARCH_PROMO_STATISTICS = 'ozon_performance_search_promo_statistics';
+public const PERFORMANCE_EXPENSE_STATISTICS = 'ozon_performance_expense_statistics';
+```
+
+Первый этап включает сразу:
+
+- SKU CPC;
+- Search Promo / CPO;
+- expense statistics как контроль.
+
+Media/banner/video можно не нормализовать в первом этапе, но campaign catalog должен сохранять типы кампаний, чтобы мы не потеряли их наличие.
+
+## Какие методы грузить
+
+По дополнительной проверке документации/публичных материалов Ozon for dev:
+
+- Search Promo / CPO представлен отдельными методами, не тем же самым payload, что SKU CPC;
+- для CPO есть как минимум два отчётных направления: отчёт по товарам и отчёт по заказам;
+- поэтому вопрос про exact endpoints был не про то, грузить CPO или нет, а про источник истины для будущей нормализации CPO.
+
+Решение для первого этапа: грузим оба CPO-отчёта в raw, а нормализацию выбираем позже на реальных payload.
+
+### Campaign catalog
+
+Метод:
+
+```text
+GET /api/client/campaign
+```
+
+Грузить минимум типы:
+
+```text
+SKU
+SEARCH_PROMO
+```
+
+Raw resource:
+
+```text
+ozon_performance_campaigns
+```
+
+Назначение:
+
+- campaign id;
+- campaign name;
+- state;
+- advObjectType;
+- период активности;
+- связь для последующей статистики.
+
+### SKU CPC promoted objects
+
+Метод:
+
+```text
+GET /api/client/campaign/{campaignId}/objects
+```
+
+Raw resource:
+
+```text
+ozon_performance_sku_campaign_objects
+```
+
+Назначение:
+
+- какие SKU участвуют в CPC campaign;
+- mapping campaign -> SKU;
+- контроль, что статистика не потеряла товар.
+
+### Search Promo / CPO products
+
+Метод:
+
+```text
+POST /api/client/campaign/search_promo/v2/products
+```
+
+Raw resource:
+
+```text
+ozon_performance_search_promo_products
+```
+
+Назначение:
+
+- товары в продвижении с оплатой за заказ;
+- mapping search promo campaign -> SKU/product;
+- отдельный источник для CPO, не смешивать с CPC objects.
+
+### SKU CPC statistics
+
+Основной кандидат:
+
+```text
+GET /api/client/statistics/campaign/product/json
+```
+
+Fallback:
+
+```text
+POST /api/client/statistics
+GET /api/client/statistics/{uuid}
+GET /api/client/statistics/report?UUID=...
+```
+
+Raw resource:
+
+```text
+ozon_performance_sku_product_statistics
+```
+
+Назначение:
+
+- расходы/показы/клики/заказы по SKU или товарной строке, если Ozon возвращает этот разрез;
+- сырой payload без попытки сразу привести к финансовой модели.
+
+### Search Promo / CPO statistics
+
+Методы первого этапа:
+
+```text
+POST /api/client/statistic/products/generate
+POST /api/client/statistic/orders/generate
+```
+
+Raw resource:
+
+```text
+ozon_performance_search_promo_statistics
+```
+
+Назначение:
+
+- `products/generate` - основной raw-кандидат для будущих затрат/метрик по товарам в Search Promo/CPO;
+- `orders/generate` - raw-кандидат для будущей проверки заказной атрибуции и CPO-событий;
+- сохранить оба сырьевых отчёта, даже если структура отличается от CPC.
+
+Важно: CPO нельзя маппить тем же parser'ом, что CPC. Это отдельный resource и отдельный будущий mapper.
+
+### Expense control
+
+Метод:
+
+```text
+GET /api/client/statistics/expense/json
+```
+
+Raw resource:
+
+```text
+ozon_performance_expense_statistics
+```
+
+Назначение:
+
+- контрольная сумма по кампаниям;
+- сверка с product/search-promo статистикой;
+- диагностика расхождений.
+
+Это не основной источник SKU-затрат.
+
+## Raw idempotency
+
+Используем существующую механику `StoreRawBatchAction`:
+
+- один `RawBatch` -> один `IngestRawRecord`;
+- `externalId + hash` защищает от дублей;
+- если payload не изменился, запись просто `markSeen()`.
+
+Для каждого resource нужен стабильный `externalId`.
+
+Примеры:
+
+```text
+performance-campaigns:<date>
+performance-sku-objects:<campaignId>:<date>
+performance-search-promo-products:<campaignId>:<date>
+performance-sku-stats:<from>:<to>:batch:<batchHash>
+performance-search-promo-stats:<from>:<to>:batch:<batchHash>
+performance-expense-stats:<from>:<to>
+```
+
+Если Ozon отдает данные в нестабильном порядке, connector должен сортировать строки перед созданием `RawBatch`, как это уже сделано для accrual rows.
+
+## Cursor и pagination
+
+`PullRequest::cursorValue` - строка, поэтому для Performance можно использовать компактный JSON cursor.
+
+Пример:
+
+```json
+{
+  "date": "2026-06-26",
+  "resource": "sku_stats",
+  "campaignOffset": 20,
+  "page": 1
+}
+```
+
+Правила:
+
+- cursor должен быть stable и backward compatible;
+- при ошибке batch должен повториться с тем же cursor;
+- cursor не должен содержать secrets или большие payload.
+
+## Ежедневная загрузка
+
+Команда-оркестратор в `Ingestion`:
+
+```bash
+php bin/console app:ingestion:ozon-performance:daily-load \
+  --days-back=14 \
+  --execute
+```
+
+Поведение:
+
+1. Получить все активные Ozon Performance connections через `MarketplaceFacade`.
+2. Для каждого подключения построить окно:
+
+```text
+from = today - daysBack
+to = yesterday
+```
+
+3. Для каждого подключения запустить ingestion jobs по ресурсам:
+   - campaigns;
+   - SKU campaign objects;
+   - Search Promo products;
+   - SKU product statistics;
+   - Search Promo/CPO statistics;
+   - expense statistics.
+4. Ошибка одного аккаунта или resource не должна останавливать остальные.
+5. В конце вывести summary:
+   - connections total/success/failed;
+   - jobs created/skipped/failed;
+   - raw records created/seen/failed;
+   - failed resources;
+   - auth/rate-limit/transient errors.
+
+Для первого варианта можно сделать orchestration синхронной только на уровне создания jobs. Сами загрузки должны идти через существующий `RunSyncChunkMessage`.
+
+## Отображение в разделе "Покрытие данных"
+
+Все новые загрузки Ozon Performance должны отображаться в существующем разделе:
+
+```text
+/ingestion/coverage
+```
+
+Текущий `CoverageQuery` уже строит heatmap по `ingest_raw_records.resource_type`, `sync_job.window_from/window_to`, `shop_ref`, failed jobs и normalization issues.
+
+Требования:
+
+1. Каждый Performance resource должен сохраняться через `RawBatch` -> `IngestRawRecord`.
+2. У каждого `SyncJob` должны быть корректные:
+   - `company_id`;
+   - `connection_ref`;
+   - `shop_ref`;
+   - `resource_type`;
+   - `window_from`;
+   - `window_to`.
+3. Для raw-only этапа `tx_count` в покрытии будет `0` - это нормально.
+4. Зеленое покрытие для raw-only ресурса означает `raw_count > 0` и `issue_count = 0`.
+5. Failed jobs должны попадать в покрытие через текущий `failedJobIssueRows()`.
+6. Для отсутствующего Performance-подключения не создавать failed coverage row; это не ошибка загрузки, а отсутствие источника. Такое состояние должно быть видно в отдельном status/health summary.
+
+Дополнительно стоит улучшить читаемость UI:
+
+- добавить человекочитаемые labels для новых resource types;
+- сгруппировать ресурсы в покрытии по направлению:
+  - `Ozon Performance / Campaigns`;
+  - `Ozon Performance / SKU CPC`;
+  - `Ozon Performance / Search Promo CPO`;
+  - `Ozon Performance / Expense control`;
+- оставить технический `resource_type` в tooltip.
+
+Если UI-группировку делать не сразу, минимально достаточно появления строк с новыми `resource_type` в текущей heatmap.
+
+## Backfill при подключении клиента
+
+По умолчанию - с начала текущего месяца, как финансовые отчеты.
+
+Команда:
+
+```bash
+php bin/console app:ingestion:ozon-performance:backfill \
+  --company-id=<uuid> \
+  --from=2026-06-01 \
+  --to=2026-06-26 \
+  --execute
+```
+
+Если клиент подключился в середине квартала и нужна история квартала, это должен быть явный запуск:
+
+```bash
+php bin/console app:ingestion:ozon-performance:backfill \
+  --company-id=<uuid> \
+  --from=2026-04-01 \
+  --to=2026-06-26 \
+  --execute
+```
+
+Автоматически грузить год назад не нужно.
+
+## Батчинг
+
+Рекомендуемые ограничения:
+
+```text
+campaignIds per stats request: 10
+daily rewind: 14 дней
+backfill chunk: 7 дней
+max async range guard: 62 дня
+active async statistics report per account: 1
+```
+
+Почему:
+
+- в текущем Ozon Performance опыте уже зафиксирован лимит 10 campaignIds;
+- async отчеты Ozon могут зависать в очереди;
+- при 1000 кабинетах важнее продолжение и retry, чем скорость одного кабинета.
+
+## Ошибки и retry
+
+Использовать существующие ingestion exceptions:
+
+- `ConnectorAuthException` - 401/403, неверные credentials, нет прав;
+- `ConnectorRateLimitedException` - 429, есть retry-after или расчетная задержка;
+- `ConnectorTransientException` - 5xx/network/timeouts;
+- unexpected exception - логировать и дать Messenger retry.
+
+Правила:
+
+- 401: сброс token cache, один retry, затем auth failure;
+- 403: permanent auth/permission failure;
+- 429: continuation/retry delay;
+- 5xx/network: retry;
+- ошибка одного child job не должна ломать остальные company/resource jobs;
+- оркестратор должен завершаться с понятным summary.
+
+Sentry/log context:
+
+```text
+companyId
+connectionRef
+resourceType
+syncJobId
+windowFrom/windowTo
+cursorValue
+campaignIds count/hash
+endpoint
+httpStatus
+ozonReportUuid
+```
+
+Запрещено логировать:
+
+```text
+client_secret
+api_key
+access_token
+refresh_token
+```
+
+## Нормализация
+
+В первом этапе отключить нормализацию:
+
+```php
+new PullResult(
+    rawBatch: $batch,
+    nextCursorValue: $nextCursor,
+    hasMore: $hasMore,
+    normalizeRawRecords: false,
+)
+```
+
+Причина:
+
+- сначала нужен надежный raw слой;
+- CPC и CPO имеют разную семантику;
+- expense statistics - контрольный источник, а не транзакционная строка;
+- нормализация рекламных расходов должна быть отдельным reviewable stage.
+
+## Деньги и Money
+
+Правило из `ARCHITECTURE.md`: суммы хранятся в minor units, shared `Money` signed и контролирует ISO-4217 валюту.
+
+Для первого raw-only этапа:
+
+- сохраняем денежные поля Ozon в сыром payload без преобразования;
+- не округляем;
+- не приводим к `float`;
+- не пытаемся заранее угадать знак расхода.
+
+Для будущей нормализации:
+
+- все money-like поля нужно парсить в minor units;
+- создавать `Money::fromMinor($amountMinor, $currency)`;
+- направление расхода задавать через `TransactionDirection`, а не только через знак;
+- CPC и CPO нормализовать отдельными mapper'ами;
+- сверять суммы с `ozon_performance_expense_statistics`;
+- при несовпадении валюты или невозможности разобрать сумму создавать `NormalizationIssue`, а не молча пропускать строку.
+
+Кодовые ориентиры:
+
+- `App\Shared\Domain\ValueObject\Money`;
+- `Ingestion\Application\DTO\MappedTransaction`;
+- `Ingestion\Entity\FinancialTransaction`;
+- `OzonMoneyParser` как пример decimal -> minor parsing для Ozon.
+
+## Что не делать
+
+- Не развивать новый пайплайн в `MarketplaceAds`.
+- Не смешивать рекламную загрузку с финансовым `OzonSellerReportConnector`.
+- Не поддерживать новый OAuth через seller connection в первом этапе.
+- Не маппить CPC и CPO одним parser'ом.
+- Не превращать один connector в огромный класс со всей логикой; API client, cursor planner и resource pullers должны быть разделены.
+- Не делать автоматический годовой backfill при подключении клиента.
+
+## Этапы реализации
+
+### Этап 1. Contracts and resource skeleton
+
+Риск: medium.
+
+Действия:
+
+- добавить Ozon Performance resource types;
+- добавить `OzonPerformanceReportConnector`;
+- добавить Performance API client/resolver внутри `Ingestion`;
+- подключение credentials брать через `MarketplaceFacade` и `MarketplaceConnectionType::PERFORMANCE`;
+- нормализацию выключить.
+
+Результат:
+
+- Ingestion знает новые Ozon Performance resources, но еще не делает тяжелой бизнес-нормализации.
+
+### Этап 2. Campaign catalog + objects
+
+Риск: medium.
+
+Действия:
+
+- `GET /api/client/campaign`;
+- `GET /api/client/campaign/{campaignId}/objects` для SKU CPC;
+- `POST /api/client/campaign/search_promo/v2/products` для Search Promo/CPO;
+- raw external ids и стабильная сортировка.
+
+Результат:
+
+- есть сырая карта campaigns -> SKU/products для CPC и CPO.
+
+### Этап 3. Statistics raw loading
+
+Риск: medium/high.
+
+Действия:
+
+- SKU CPC product statistics;
+- Search Promo/CPO reports;
+- expense statistics;
+- batching по 10 campaign ids;
+- cursor/pagination;
+- auth/rate-limit/transient exceptions.
+
+Результат:
+
+- сырые расходы и метрики рекламы лежат в `ingest_raw_records`.
+
+### Этап 4. Coverage integration
+
+Риск: medium.
+
+Действия:
+
+- убедиться, что все Performance raw jobs имеют корректные `window_from/window_to`;
+- проверить, что raw-only resources появляются в `/ingestion/coverage`;
+- добавить labels/grouping для новых Ozon Performance resource types;
+- failed jobs должны давать issue rows в покрытии;
+- отсутствие Performance-подключения не должно считаться failed coverage.
+
+Результат:
+
+- оператор видит рекламные загрузки в "Покрытии данных" вместе с финансовыми ingestion-ресурсами.
+
+### Этап 5. Daily/backfill orchestrators
+
+Риск: high, потому что operational behavior.
+
+Действия:
+
+- `app:ingestion:ozon-performance:daily-load --days-back=14 --execute`;
+- `app:ingestion:ozon-performance:backfill --company-id --from --to --execute`;
+- создание `SyncJob`/child chunks через существующие actions;
+- summary;
+- partial failure behavior.
+
+Результат:
+
+- одна команда запускает все компании/resources без ручного UUID-by-UUID цикла.
+
+### Этап 6. Health/status
+
+Риск: low.
+
+Действия:
+
+- команда статуса:
+  - активные Performance connections;
+  - last successful raw by resource;
+  - failed jobs;
+  - missing days;
+  - rate-limit/auth errors;
+  - expense reconciliation diff, если достаточно данных.
+
+Результат:
+
+- проблему видно без SQL руками.
+
+### Этап 7. Нормализация
+
+Риск: high, отдельно от этого плана.
+
+Действия:
+
+- отдельно спроектировать mapper для CPC;
+- отдельно mapper для Search Promo/CPO;
+- отдельно reconciliation с expense stats;
+- отдельно влияние на P&L и existing advertising reports.
+- использовать `Money::fromMinor(...)` для всех денежных значений;
+- запретить `float` в money-path;
+- фиксировать currency/rounding/sign правила тестами.
+
+Результат:
+
+- raw данные превращаются в финансовую модель только после отдельного review.
+
+## Вопрос -> предложение
+
+| Вопрос | Предложение |
+| --- | --- |
+| Где живет новый pipeline? | В `Ingestion`. |
+| Где брать credentials? | Через `MarketplaceFacade`, `MarketplaceConnectionType::PERFORMANCE`. |
+| Поддерживать новый OAuth через seller connection? | Нет на старте. Только отдельное Performance-подключение. |
+| Что включать в первый этап? | SKU CPC + Search Promo/CPO + expense control raw. |
+| Использовать `MarketplaceAds`? | Не как целевой модуль. Только как reference для Ozon Performance API ограничений. |
+| Нужна ли нормализация сразу? | Нет. `normalizeRawRecords=false`, нормализация отдельным этапом. |
+| Как делать ежедневную загрузку? | Rolling 14 дней по всем активным Performance connections. |
+| Как делать подключение клиента в середине месяца? | Backfill с начала текущего месяца. Квартал - только явной командой. |
+| Как не получить мусорку? | Resource-specific pullers: campaigns, sku objects, search promo products, sku stats, cpo stats, expenses. |
+| Как пережить 1000 кабинетов? | Jobs/chunks/cursors, rate-limit lock, partial failures, retry через Messenger. |
+| Какой endpoint для CPO? | В raw грузить оба: `POST /api/client/statistic/products/generate` и `POST /api/client/statistic/orders/generate`. Для будущей нормализации primary candidate - products report, orders report - контроль/атрибуция. |
+| Должно ли это быть видно в "Покрытии"? | Да. Все Performance resources должны идти через `ingest_raw_records` и появляться в `/ingestion/coverage`; raw-only ресурсы имеют `tx_count=0`. |
+| Как работать с денежными полями? | В raw сохранять как пришло от Ozon; при нормализации парсить в minor units и использовать `Money::fromMinor(...)`, без `float`. |
+
+## Закрытие ранее открытых вопросов
+
+1. Performance-подключение: считаем отдельное `performance` подключение обязательным на старте. Если его нет - аккаунт пропускается без failed job.
+2. CPO endpoints: грузим оба raw отчета: `products/generate` и `orders/generate`.
+3. Rolling window: стартовое значение 14 дней. Если на live CPO покажет позднюю атрибуцию глубже 14 дней - поднять до 30 дней отдельным config change.
+4. `MarketplaceAds`: не переносить исторические данные в первом этапе. Новый pipeline стартует в `Ingestion`; legacy данные остаются как есть до отдельного решения.
+5. Финансовая модель: не решать в raw-loading PR. После накопления raw sample сделать отдельный план нормализации CPC/CPO и влияния на P&L.
+6. Покрытие: обязательно включить новые resources в `/ingestion/coverage` на этапе raw-loading.
+
+## Оставшиеся проверки перед кодом
+
+1. На одном тестовом Performance-подключении снять live sample по:
+   - SKU CPC product statistics;
+   - Search Promo products;
+   - Search Promo products report;
+   - Search Promo orders report;
+   - expense stats.
+2. Зафиксировать реальные поля payload и pagination/cursor.
+3. Проверить, какие CPO отчёты возвращают денежные поля, а какие только атрибуцию заказов.
+4. Проверить лимиты Ozon по датам и campaignIds на текущем кабинете.
+
+## Рекомендация
+
+Делать первый релиз как raw-only ingestion:
+
+1. Performance credentials через `Marketplace`.
+2. Новый `OzonPerformanceReportConnector` в `Ingestion`.
+3. Все основные рекламные источники первого этапа: SKU CPC + Search Promo/CPO + expense control.
+4. Daily/backfill команды только создают и ведут ingestion jobs.
+5. Нормализация и влияние на отчеты - отдельный план и отдельный PR.

--- a/site/assets/api/schema.d.ts
+++ b/site/assets/api/schema.d.ts
@@ -492,6 +492,10 @@ export interface operations {
                             shop_ref?: string;
                             /** @example ozon_finance_accrual_by_day */
                             resource_type?: string;
+                            /** @example Accrual by day */
+                            resource_label?: string;
+                            /** @example Ozon Finance */
+                            resource_group?: string;
                             /** @example 1 */
                             raw_count?: number;
                             /** @example 287 */

--- a/site/assets/react/_legacy/ingestion-verification/views/CoverageHeatmapView.tsx
+++ b/site/assets/react/_legacy/ingestion-verification/views/CoverageHeatmapView.tsx
@@ -13,6 +13,8 @@ interface CoverageHeatmapViewProps {
 interface AggregatedCell {
     date: string;
     resourceType: string;
+    resourceLabel: string;
+    resourceGroup: string;
     rawCount: number;
     txCount: number;
     issueCount: number;
@@ -33,7 +35,8 @@ function buildCellTitle(cell: AggregatedCell): string {
         : '';
 
     return [
-        `${formatDate(cell.date)} · ${cell.resourceType}`,
+        `${formatDate(cell.date)} · ${cell.resourceGroup} · ${cell.resourceLabel}`,
+        `Тип: ${cell.resourceType}`,
         `Raw: ${formatNumber(cell.rawCount)}`,
         `Транзакции: ${formatNumber(cell.txCount)}`,
         `Проблемы: ${formatNumber(cell.issueCount)}${lastFetched}`,
@@ -55,15 +58,17 @@ function statusClass(cell: AggregatedCell | null): string {
 const CoverageHeatmapView: React.FC<CoverageHeatmapViewProps> = ({ cells, from, to }) => {
     const dates = useMemo(() => buildDateRange(from, to), [from, to]);
 
-    const { resourceTypes, cellsByKey, coveredDays, totalIssues } = useMemo(() => {
+    const { resourceTypes, resourceLabels, cellsByKey, coveredDays, totalIssues } = useMemo(() => {
         const aggregated = new Map<string, AggregatedCell>();
-        const resources = new Set<string>();
+        const resources = new Map<string, { label: string; group: string }>();
         const days = new Set<string>();
         let issues = 0;
 
         cells.forEach((cell) => {
             const date = typeof cell.date === 'string' ? cell.date : '';
             const resourceType = typeof cell.resource_type === 'string' ? cell.resource_type : '';
+            const resourceLabel = typeof cell.resource_label === 'string' ? cell.resource_label : resourceType;
+            const resourceGroup = typeof cell.resource_group === 'string' ? cell.resource_group : 'Ingestion';
 
             if (date === '' || resourceType === '') {
                 return;
@@ -76,7 +81,7 @@ const CoverageHeatmapView: React.FC<CoverageHeatmapViewProps> = ({ cells, from, 
             const issueCount = numberValue(cell.issue_count);
             const lastFetchedAt = typeof cell.last_fetched_at === 'string' ? cell.last_fetched_at : null;
 
-            resources.add(resourceType);
+            resources.set(resourceType, { label: resourceLabel, group: resourceGroup });
             issues += issueCount;
 
             if (rawCount > 0) {
@@ -87,6 +92,8 @@ const CoverageHeatmapView: React.FC<CoverageHeatmapViewProps> = ({ cells, from, 
                 aggregated.set(key, {
                     date,
                     resourceType,
+                    resourceLabel,
+                    resourceGroup,
                     rawCount,
                     txCount,
                     issueCount,
@@ -97,6 +104,8 @@ const CoverageHeatmapView: React.FC<CoverageHeatmapViewProps> = ({ cells, from, 
 
             aggregated.set(key, {
                 ...existing,
+                resourceLabel,
+                resourceGroup,
                 rawCount: existing.rawCount + rawCount,
                 txCount: existing.txCount + txCount,
                 issueCount: existing.issueCount + issueCount,
@@ -105,7 +114,8 @@ const CoverageHeatmapView: React.FC<CoverageHeatmapViewProps> = ({ cells, from, 
         });
 
         return {
-            resourceTypes: Array.from(resources).sort(),
+            resourceTypes: Array.from(resources.keys()).sort(),
+            resourceLabels: resources,
             cellsByKey: aggregated,
             coveredDays: days.size,
             totalIssues: issues,
@@ -155,28 +165,35 @@ const CoverageHeatmapView: React.FC<CoverageHeatmapViewProps> = ({ cells, from, 
                             </tr>
                         </thead>
                         <tbody>
-                            {resourceTypes.map((resourceType) => (
-                                <tr key={resourceType}>
-                                    <td className="text-nowrap">{resourceType}</td>
-                                    {dates.map((date) => {
-                                        const cell = cellsByKey.get(cellKey(date, resourceType)) ?? null;
-                                        const label = cell === null
-                                            ? '—'
-                                            : String(cell.issueCount > 0 ? cell.issueCount : cell.rawCount);
+                            {resourceTypes.map((resourceType) => {
+                                const description = resourceLabels.get(resourceType);
+                                const label = description === undefined
+                                    ? resourceType
+                                    : `${description.group} · ${description.label}`;
 
-                                        return (
-                                            <td key={date} className="text-center">
-                                                <span
-                                                    className={`avatar avatar-sm rounded-1 ${statusClass(cell)}`}
-                                                    title={cell === null ? date : buildCellTitle(cell)}
-                                                >
-                                                    {label}
-                                                </span>
-                                            </td>
-                                        );
-                                    })}
-                                </tr>
-                            ))}
+                                return (
+                                    <tr key={resourceType}>
+                                        <td className="text-nowrap" title={resourceType}>{label}</td>
+                                        {dates.map((date) => {
+                                            const cell = cellsByKey.get(cellKey(date, resourceType)) ?? null;
+                                            const countLabel = cell === null
+                                                ? '—'
+                                                : String(cell.issueCount > 0 ? cell.issueCount : cell.rawCount);
+
+                                            return (
+                                                <td key={date} className="text-center">
+                                                    <span
+                                                        className={`avatar avatar-sm rounded-1 ${statusClass(cell)}`}
+                                                        title={cell === null ? date : buildCellTitle(cell)}
+                                                    >
+                                                        {countLabel}
+                                                    </span>
+                                                </td>
+                                            );
+                                        })}
+                                    </tr>
+                                );
+                            })}
                         </tbody>
                     </table>
                 </div>

--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -17,6 +17,8 @@ parameters:
     app.object_storage_s3_path_style_endpoint_default: '0'
     wb_finance.rate_limit_interval_seconds: 70
     wb_finance.retry_delay_ms: 70000
+    ozon_performance.api_base_url_default: 'https://api-performance.ozon.ru'
+    ozon_performance.api_base_url: '%env(default:ozon_performance.api_base_url_default:string:OZON_PERFORMANCE_API_BASE_URL)%'
     telegram.webhook_url: '%env(string:TELEGRAM_WEBHOOK_URL)%'
     telegram.webhook_secret: '%env(string:TELEGRAM_WEBHOOK_SECRET)%'
     telegram.api_base_url: '%env(string:TELEGRAM_API_BASE_URL)%'
@@ -150,6 +152,9 @@ services:
     App\Ingestion\Infrastructure\Api\Ozon\OzonCredentialProviderInterface: '@App\Ingestion\Infrastructure\Api\Ozon\CredentialFacadeOzonCredentialProvider'
     App\Ingestion\Infrastructure\Api\Ozon\OzonAccrualClientInterface: '@App\Ingestion\Infrastructure\Api\Ozon\OzonAccrualClient'
     App\Ingestion\Infrastructure\Api\Ozon\OzonPerformanceReportClientInterface: '@App\Ingestion\Infrastructure\Api\Ozon\OzonPerformanceReportClient'
+    App\Ingestion\Infrastructure\Api\Ozon\OzonPerformanceReportClient:
+        arguments:
+            $baseUrl: '%ozon_performance.api_base_url%'
     App\Ingestion\Infrastructure\Api\Wildberries\WbCredentialProviderInterface: '@App\Ingestion\Infrastructure\Api\Wildberries\CredentialFacadeWbCredentialProvider'
     App\Ingestion\Infrastructure\Api\Wildberries\WbFinanceReportClientInterface: '@App\Ingestion\Infrastructure\Api\Wildberries\WbFinanceReportClient'
 

--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -149,6 +149,7 @@ services:
 
     App\Ingestion\Infrastructure\Api\Ozon\OzonCredentialProviderInterface: '@App\Ingestion\Infrastructure\Api\Ozon\CredentialFacadeOzonCredentialProvider'
     App\Ingestion\Infrastructure\Api\Ozon\OzonAccrualClientInterface: '@App\Ingestion\Infrastructure\Api\Ozon\OzonAccrualClient'
+    App\Ingestion\Infrastructure\Api\Ozon\OzonPerformanceReportClientInterface: '@App\Ingestion\Infrastructure\Api\Ozon\OzonPerformanceReportClient'
     App\Ingestion\Infrastructure\Api\Wildberries\WbCredentialProviderInterface: '@App\Ingestion\Infrastructure\Api\Wildberries\CredentialFacadeWbCredentialProvider'
     App\Ingestion\Infrastructure\Api\Wildberries\WbFinanceReportClientInterface: '@App\Ingestion\Infrastructure\Api\Wildberries\WbFinanceReportClient'
 
@@ -160,6 +161,9 @@ services:
         arguments:
             $chunkSizeDays: 7
             $hotRewindDays: 14
+        tags: ['app.ingestion.connector']
+
+    App\Ingestion\Application\Source\Ozon\OzonPerformanceReportConnector:
         tags: ['app.ingestion.connector']
 
     App\Ingestion\Application\Source\Wildberries\WbFinanceReportConnector:

--- a/site/src/Ingestion/Application/DTO/CoverageCellView.php
+++ b/site/src/Ingestion/Application/DTO/CoverageCellView.php
@@ -10,6 +10,8 @@ final readonly class CoverageCellView
         public string $date,
         public string $shopRef,
         public string $resourceType,
+        public string $resourceLabel,
+        public string $resourceGroup,
         public int $rawCount,
         public int $txCount,
         public int $issueCount,
@@ -18,7 +20,7 @@ final readonly class CoverageCellView
     }
 
     /**
-     * @return array{date: string, shop_ref: string, resource_type: string, raw_count: int, tx_count: int, issue_count: int, last_fetched_at: string|null}
+     * @return array{date: string, shop_ref: string, resource_type: string, resource_label: string, resource_group: string, raw_count: int, tx_count: int, issue_count: int, last_fetched_at: string|null}
      */
     public function toArray(): array
     {
@@ -26,6 +28,8 @@ final readonly class CoverageCellView
             'date' => $this->date,
             'shop_ref' => $this->shopRef,
             'resource_type' => $this->resourceType,
+            'resource_label' => $this->resourceLabel,
+            'resource_group' => $this->resourceGroup,
             'raw_count' => $this->rawCount,
             'tx_count' => $this->txCount,
             'issue_count' => $this->issueCount,

--- a/site/src/Ingestion/Application/DTO/PullResult.php
+++ b/site/src/Ingestion/Application/DTO/PullResult.php
@@ -9,7 +9,7 @@ use App\Ingestion\DTO\RawBatch;
 final readonly class PullResult
 {
     public function __construct(
-        public RawBatch $rawBatch,
+        public ?RawBatch $rawBatch,
         public ?string $nextCursorValue,
         public bool $hasMore,
         public bool $normalizeRawRecords = true,

--- a/site/src/Ingestion/Application/Service/IngestionResourceLabelProvider.php
+++ b/site/src/Ingestion/Application/Service/IngestionResourceLabelProvider.php
@@ -7,7 +7,7 @@ namespace App\Ingestion\Application\Service;
 use App\Ingestion\Application\Source\Ozon\OzonResourceType;
 use App\Ingestion\Application\Source\Wildberries\WbResourceType;
 
-final class IngestionResourceLabelProvider
+final readonly class IngestionResourceLabelProvider
 {
     /**
      * @var array<string, array{group: string, label: string}>

--- a/site/src/Ingestion/Application/Service/IngestionResourceLabelProvider.php
+++ b/site/src/Ingestion/Application/Service/IngestionResourceLabelProvider.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Service;
+
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Application\Source\Wildberries\WbResourceType;
+
+final class IngestionResourceLabelProvider
+{
+    /**
+     * @var array<string, array{group: string, label: string}>
+     */
+    private const LABELS = [
+        OzonResourceType::ACCRUAL_BY_DAY => [
+            'group' => 'Ozon Finance',
+            'label' => 'Accrual by day',
+        ],
+        OzonResourceType::ACCRUAL_TYPES => [
+            'group' => 'Ozon Finance',
+            'label' => 'Accrual types',
+        ],
+        OzonResourceType::ACCRUAL_POSTINGS => [
+            'group' => 'Ozon Finance',
+            'label' => 'Accrual postings',
+        ],
+        OzonResourceType::PERFORMANCE_CAMPAIGNS => [
+            'group' => 'Ozon Performance / Campaigns',
+            'label' => 'Campaign catalog',
+        ],
+        OzonResourceType::PERFORMANCE_SKU_CAMPAIGN_OBJECTS => [
+            'group' => 'Ozon Performance / SKU CPC',
+            'label' => 'Campaign SKU objects',
+        ],
+        OzonResourceType::PERFORMANCE_SEARCH_PROMO_PRODUCTS => [
+            'group' => 'Ozon Performance / Search Promo CPO',
+            'label' => 'Search Promo products',
+        ],
+        OzonResourceType::PERFORMANCE_SKU_PRODUCT_STATISTICS => [
+            'group' => 'Ozon Performance / SKU CPC',
+            'label' => 'SKU product statistics',
+        ],
+        OzonResourceType::PERFORMANCE_SEARCH_PROMO_STATISTICS => [
+            'group' => 'Ozon Performance / Search Promo CPO',
+            'label' => 'Search Promo statistics',
+        ],
+        OzonResourceType::PERFORMANCE_EXPENSE_STATISTICS => [
+            'group' => 'Ozon Performance / Expense control',
+            'label' => 'Expense statistics',
+        ],
+        WbResourceType::FINANCE_SALES_REPORT_DETAILED => [
+            'group' => 'Wildberries Finance',
+            'label' => 'Sales report detailed',
+        ],
+    ];
+
+    /**
+     * @return array{group: string, label: string}
+     */
+    public function describe(string $resourceType): array
+    {
+        return self::LABELS[$resourceType] ?? [
+            'group' => 'Ingestion',
+            'label' => $resourceType,
+        ];
+    }
+}

--- a/site/src/Ingestion/Application/Source/Ozon/OzonPerformanceReportConnector.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonPerformanceReportConnector.php
@@ -1,0 +1,551 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Source\Ozon;
+
+use App\Ingestion\Application\DTO\PullRequest;
+use App\Ingestion\Application\DTO\PullResult;
+use App\Ingestion\Application\DTO\PushRequest;
+use App\Ingestion\Application\DTO\PushResult;
+use App\Ingestion\Application\DTO\ShopDescriptor;
+use App\Ingestion\Domain\Contract\SourceConnectorInterface;
+use App\Ingestion\DTO\RawBatch;
+use App\Ingestion\Enum\Capability;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Exception\UnsupportedCapabilityException;
+use App\Ingestion\Infrastructure\Api\Ozon\OzonPerformanceReportClientInterface;
+use App\Ingestion\Infrastructure\Api\Ozon\OzonRawPage;
+use Symfony\Component\Clock\ClockInterface;
+
+final readonly class OzonPerformanceReportConnector implements SourceConnectorInterface
+{
+    private const CAMPAIGN_BATCH_SIZE = 10;
+    private const SEARCH_PROMO_POLL_DELAY_SECONDS = 60;
+
+    private const ADV_OBJECT_TYPE_SKU = 'SKU';
+    private const ADV_OBJECT_TYPE_SEARCH_PROMO = 'SEARCH_PROMO';
+
+    private const SEARCH_PROMO_REPORT_PRODUCTS = 'products';
+    private const SEARCH_PROMO_REPORT_ORDERS = 'orders';
+
+    public function __construct(
+        private OzonPerformanceReportClientInterface $client,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function source(): IngestSource
+    {
+        return IngestSource::OZON;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function resourceTypes(): array
+    {
+        return [
+            OzonResourceType::PERFORMANCE_CAMPAIGNS,
+            OzonResourceType::PERFORMANCE_SKU_CAMPAIGN_OBJECTS,
+            OzonResourceType::PERFORMANCE_SEARCH_PROMO_PRODUCTS,
+            OzonResourceType::PERFORMANCE_SKU_PRODUCT_STATISTICS,
+            OzonResourceType::PERFORMANCE_SEARCH_PROMO_STATISTICS,
+            OzonResourceType::PERFORMANCE_EXPENSE_STATISTICS,
+        ];
+    }
+
+    /**
+     * @return list<Capability>
+     */
+    public function capabilities(): array
+    {
+        return [Capability::CAN_DISCOVER_SHOPS, Capability::CAN_PULL];
+    }
+
+    /**
+     * @return list<ShopDescriptor>
+     */
+    public function discoverShops(string $companyId, string $connectionRef): array
+    {
+        return [
+            new ShopDescriptor(
+                externalId: $connectionRef,
+                name: 'Ozon Performance',
+                currency: 'RUB',
+                metadata: ['connectionRef' => $connectionRef],
+            ),
+        ];
+    }
+
+    public function pull(PullRequest $request): PullResult
+    {
+        return match ($request->resourceType) {
+            OzonResourceType::PERFORMANCE_CAMPAIGNS => $this->pullCampaigns($request),
+            OzonResourceType::PERFORMANCE_SKU_CAMPAIGN_OBJECTS => $this->pullSkuCampaignObjects($request),
+            OzonResourceType::PERFORMANCE_SEARCH_PROMO_PRODUCTS => $this->pullSearchPromoProducts($request),
+            OzonResourceType::PERFORMANCE_SKU_PRODUCT_STATISTICS => $this->pullSkuProductStatistics($request),
+            OzonResourceType::PERFORMANCE_SEARCH_PROMO_STATISTICS => $this->pullSearchPromoStatistics($request),
+            OzonResourceType::PERFORMANCE_EXPENSE_STATISTICS => $this->pullExpenseStatistics($request),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported Ozon Performance resource type "%s".', $request->resourceType)),
+        };
+    }
+
+    public function push(PushRequest $request): PushResult
+    {
+        throw new UnsupportedCapabilityException('Ozon Performance connector does not support push operations.');
+    }
+
+    private function pullCampaigns(PullRequest $request): PullResult
+    {
+        $page = $this->client->listCampaigns($request->companyId, $request->connectionRef, [
+            self::ADV_OBJECT_TYPE_SKU,
+            self::ADV_OBJECT_TYPE_SEARCH_PROMO,
+        ]);
+
+        return $this->doneResult($request, $page, OzonResourceType::PERFORMANCE_CAMPAIGNS, 'performance-campaigns');
+    }
+
+    private function pullSkuCampaignObjects(PullRequest $request): PullResult
+    {
+        $campaigns = $this->campaignIds($request, self::ADV_OBJECT_TYPE_SKU);
+        if ([] === $campaigns) {
+            return $this->doneEmptyResult($request, OzonResourceType::PERFORMANCE_SKU_CAMPAIGN_OBJECTS, 'performance-sku-objects:empty');
+        }
+
+        $cursor = $this->cursor($request->cursorValue, ['campaignOffset' => 0]);
+        $offset = $this->cursorInt($cursor, 'campaignOffset');
+        $campaignId = $campaigns[$offset] ?? null;
+        if (null === $campaignId) {
+            return $this->doneEmptyResult($request, OzonResourceType::PERFORMANCE_SKU_CAMPAIGN_OBJECTS, 'performance-sku-objects:done');
+        }
+
+        $page = $this->client->fetchCampaignObjects($request->companyId, $request->connectionRef, $campaignId);
+        $nextOffset = $offset + 1;
+        $hasMore = $nextOffset < count($campaigns);
+
+        return $this->rawResult(
+            request: $request,
+            resourceType: OzonResourceType::PERFORMANCE_SKU_CAMPAIGN_OBJECTS,
+            externalId: sprintf('performance-sku-objects:%s:%s', $campaignId, $this->windowId($request)),
+            rows: $page->rows,
+            metadata: [
+                'apiMetadata' => $page->metadata,
+                'campaignId' => $campaignId,
+                'campaignOffset' => $offset,
+                'campaignCount' => count($campaigns),
+            ],
+            nextCursor: $hasMore ? $this->encodeCursor(['campaignOffset' => $nextOffset]) : null,
+            hasMore: $hasMore,
+        );
+    }
+
+    private function pullSearchPromoProducts(PullRequest $request): PullResult
+    {
+        $campaigns = $this->campaignIds($request, self::ADV_OBJECT_TYPE_SEARCH_PROMO);
+        if ([] === $campaigns) {
+            return $this->doneEmptyResult($request, OzonResourceType::PERFORMANCE_SEARCH_PROMO_PRODUCTS, 'performance-search-promo-products:empty');
+        }
+
+        $cursor = $this->cursor($request->cursorValue, ['campaignOffset' => 0, 'page' => 1]);
+        $offset = $this->cursorInt($cursor, 'campaignOffset');
+        $pageNumber = max(1, $this->cursorInt($cursor, 'page', 1));
+        $campaignId = $campaigns[$offset] ?? null;
+        if (null === $campaignId) {
+            return $this->doneEmptyResult($request, OzonResourceType::PERFORMANCE_SEARCH_PROMO_PRODUCTS, 'performance-search-promo-products:done');
+        }
+
+        $page = $this->client->fetchSearchPromoProducts($request->companyId, $request->connectionRef, $campaignId, $pageNumber);
+        $nextCursor = null;
+        if ($page->hasMore) {
+            $nextCursor = $this->encodeCursor(['campaignOffset' => $offset, 'page' => $pageNumber + 1]);
+        } elseif ($offset + 1 < count($campaigns)) {
+            $nextCursor = $this->encodeCursor(['campaignOffset' => $offset + 1, 'page' => 1]);
+        }
+
+        return $this->rawResult(
+            request: $request,
+            resourceType: OzonResourceType::PERFORMANCE_SEARCH_PROMO_PRODUCTS,
+            externalId: sprintf('performance-search-promo-products:%s:%s:page:%d', $campaignId, $this->windowId($request), $pageNumber),
+            rows: $page->rows,
+            metadata: [
+                'apiMetadata' => $page->metadata,
+                'campaignId' => $campaignId,
+                'campaignOffset' => $offset,
+                'campaignCount' => count($campaigns),
+                'page' => $pageNumber,
+            ],
+            nextCursor: $nextCursor,
+            hasMore: null !== $nextCursor,
+        );
+    }
+
+    private function pullSkuProductStatistics(PullRequest $request): PullResult
+    {
+        [$from, $to] = $this->window($request);
+        $campaigns = $this->campaignIds($request, self::ADV_OBJECT_TYPE_SKU);
+        if ([] === $campaigns) {
+            return $this->doneEmptyResult($request, OzonResourceType::PERFORMANCE_SKU_PRODUCT_STATISTICS, 'performance-sku-stats:empty');
+        }
+
+        $cursor = $this->cursor($request->cursorValue, ['batchOffset' => 0]);
+        $batchOffset = $this->cursorInt($cursor, 'batchOffset');
+        $campaignBatch = array_slice($campaigns, $batchOffset, self::CAMPAIGN_BATCH_SIZE);
+        if ([] === $campaignBatch) {
+            return $this->doneEmptyResult($request, OzonResourceType::PERFORMANCE_SKU_PRODUCT_STATISTICS, 'performance-sku-stats:done');
+        }
+
+        $page = $this->client->fetchSkuProductStatistics($request->companyId, $request->connectionRef, $from, $to, $campaignBatch);
+        $nextOffset = $batchOffset + self::CAMPAIGN_BATCH_SIZE;
+        $hasMore = $nextOffset < count($campaigns);
+
+        return $this->rawResult(
+            request: $request,
+            resourceType: OzonResourceType::PERFORMANCE_SKU_PRODUCT_STATISTICS,
+            externalId: sprintf('performance-sku-stats:%s:%s:batch:%s', $from->format('Y-m-d'), $to->format('Y-m-d'), $this->campaignBatchHash($campaignBatch)),
+            rows: $page->rows,
+            metadata: [
+                'apiMetadata' => $page->metadata,
+                'campaignIds' => $campaignBatch,
+                'batchOffset' => $batchOffset,
+                'campaignCount' => count($campaigns),
+                'windowFrom' => $from->format('Y-m-d'),
+                'windowTo' => $to->format('Y-m-d'),
+            ],
+            nextCursor: $hasMore ? $this->encodeCursor(['batchOffset' => $nextOffset]) : null,
+            hasMore: $hasMore,
+        );
+    }
+
+    private function pullSearchPromoStatistics(PullRequest $request): PullResult
+    {
+        [$from, $to] = $this->window($request);
+        $campaigns = $this->campaignIds($request, self::ADV_OBJECT_TYPE_SEARCH_PROMO);
+        if ([] === $campaigns) {
+            return $this->doneEmptyResult($request, OzonResourceType::PERFORMANCE_SEARCH_PROMO_STATISTICS, 'performance-search-promo-stats:empty');
+        }
+
+        $cursor = $this->cursor($request->cursorValue, [
+            'batchOffset' => 0,
+            'reportType' => self::SEARCH_PROMO_REPORT_PRODUCTS,
+            'state' => 'request',
+        ]);
+        $batchOffset = $this->cursorInt($cursor, 'batchOffset');
+        $reportType = $this->searchPromoReportType($cursor['reportType'] ?? self::SEARCH_PROMO_REPORT_PRODUCTS);
+        $campaignBatch = array_slice($campaigns, $batchOffset, self::CAMPAIGN_BATCH_SIZE);
+        if ([] === $campaignBatch) {
+            return $this->doneEmptyResult($request, OzonResourceType::PERFORMANCE_SEARCH_PROMO_STATISTICS, 'performance-search-promo-stats:done');
+        }
+
+        if ('poll' !== ($cursor['state'] ?? 'request')) {
+            $uuid = $this->client->generateSearchPromoReport($request->companyId, $request->connectionRef, $reportType, $from, $to, $campaignBatch);
+
+            return new PullResult(
+                rawBatch: null,
+                nextCursorValue: $this->encodeCursor([
+                    'batchOffset' => $batchOffset,
+                    'reportType' => $reportType,
+                    'state' => 'poll',
+                    'uuid' => $uuid,
+                ]),
+                hasMore: true,
+                normalizeRawRecords: false,
+                continuationDelaySeconds: self::SEARCH_PROMO_POLL_DELAY_SECONDS,
+            );
+        }
+
+        $uuid = $this->cursorString($cursor, 'uuid');
+        if ('' === $uuid) {
+            throw new \InvalidArgumentException('Ozon Search Promo statistics cursor does not contain report uuid.');
+        }
+
+        $reportLink = $this->client->pollReport($request->companyId, $request->connectionRef, $uuid);
+        if (null === $reportLink) {
+            return new PullResult(
+                rawBatch: null,
+                nextCursorValue: $request->cursorValue,
+                hasMore: true,
+                normalizeRawRecords: false,
+                continuationDelaySeconds: self::SEARCH_PROMO_POLL_DELAY_SECONDS,
+            );
+        }
+
+        $page = $this->client->downloadReport($request->companyId, $request->connectionRef, $uuid, $reportLink);
+        $nextCursor = $this->nextSearchPromoStatisticsCursor($reportType, $batchOffset, count($campaigns));
+
+        return $this->rawResult(
+            request: $request,
+            resourceType: OzonResourceType::PERFORMANCE_SEARCH_PROMO_STATISTICS,
+            externalId: sprintf(
+                'performance-search-promo-stats:%s:%s:%s:batch:%s',
+                $from->format('Y-m-d'),
+                $to->format('Y-m-d'),
+                $reportType,
+                $this->campaignBatchHash($campaignBatch),
+            ),
+            rows: $page->rows,
+            metadata: [
+                'apiMetadata' => $page->metadata,
+                'campaignIds' => $campaignBatch,
+                'batchOffset' => $batchOffset,
+                'campaignCount' => count($campaigns),
+                'reportType' => $reportType,
+                'reportUuid' => $uuid,
+                'windowFrom' => $from->format('Y-m-d'),
+                'windowTo' => $to->format('Y-m-d'),
+            ],
+            nextCursor: $nextCursor,
+            hasMore: null !== $nextCursor,
+        );
+    }
+
+    private function pullExpenseStatistics(PullRequest $request): PullResult
+    {
+        [$from, $to] = $this->window($request);
+        $page = $this->client->fetchExpenseStatistics($request->companyId, $request->connectionRef, $from, $to);
+
+        return $this->rawResult(
+            request: $request,
+            resourceType: OzonResourceType::PERFORMANCE_EXPENSE_STATISTICS,
+            externalId: sprintf('performance-expense-stats:%s:%s', $from->format('Y-m-d'), $to->format('Y-m-d')),
+            rows: $page->rows,
+            metadata: [
+                'apiMetadata' => $page->metadata,
+                'windowFrom' => $from->format('Y-m-d'),
+                'windowTo' => $to->format('Y-m-d'),
+            ],
+            nextCursor: null,
+            hasMore: false,
+        );
+    }
+
+    private function doneResult(PullRequest $request, OzonRawPage $page, string $resourceType, string $externalIdPrefix): PullResult
+    {
+        return $this->rawResult(
+            request: $request,
+            resourceType: $resourceType,
+            externalId: sprintf('%s:%s', $externalIdPrefix, $this->windowId($request)),
+            rows: $page->rows,
+            metadata: ['apiMetadata' => $page->metadata],
+            nextCursor: null,
+            hasMore: false,
+        );
+    }
+
+    private function doneEmptyResult(PullRequest $request, string $resourceType, string $externalId): PullResult
+    {
+        return $this->rawResult(
+            request: $request,
+            resourceType: $resourceType,
+            externalId: $externalId.':'.$this->windowId($request),
+            rows: [],
+            metadata: [],
+            nextCursor: null,
+            hasMore: false,
+        );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     * @param array<string, mixed>       $metadata
+     */
+    private function rawResult(
+        PullRequest $request,
+        string $resourceType,
+        string $externalId,
+        array $rows,
+        array $metadata,
+        ?string $nextCursor,
+        bool $hasMore,
+    ): PullResult {
+        return new PullResult(
+            rawBatch: new RawBatch(
+                companyId: $request->companyId,
+                connectionRef: $request->connectionRef,
+                shopRef: $request->shopRef,
+                source: IngestSource::OZON,
+                resourceType: $resourceType,
+                externalId: $externalId,
+                syncJobId: $request->syncJobId,
+                fetchedAt: new \DateTimeImmutable(),
+                rows: $this->rowsOrEmptyMarker($rows, $resourceType, $metadata),
+            ),
+            nextCursorValue: $nextCursor,
+            hasMore: $hasMore,
+            normalizeRawRecords: false,
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function campaignIds(PullRequest $request, string $advObjectType): array
+    {
+        $page = $this->client->listCampaigns($request->companyId, $request->connectionRef, [$advObjectType]);
+        $campaignIds = [];
+
+        foreach ($page->rows as $row) {
+            $id = $this->campaignId($row);
+            if ('' !== $id) {
+                $campaignIds[] = $id;
+            }
+        }
+
+        sort($campaignIds);
+
+        return array_values(array_unique($campaignIds));
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function campaignId(array $row): string
+    {
+        foreach (['id', 'campaignId', 'campaign_id', 'campaignID'] as $key) {
+            $value = $row[$key] ?? null;
+            if (is_scalar($value) && '' !== trim((string) $value)) {
+                return trim((string) $value);
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * @return array{0: \DateTimeImmutable, 1: \DateTimeImmutable}
+     */
+    private function window(PullRequest $request): array
+    {
+        $to = ($request->windowTo ?? $this->clock->now()->modify('-1 day'))->setTime(23, 59, 59);
+        $from = ($request->windowFrom ?? $to->modify('-14 days'))->setTime(0, 0);
+        if ($from > $to) {
+            throw new \InvalidArgumentException('Ozon Performance window is empty.');
+        }
+
+        return [$from, $to];
+    }
+
+    private function windowId(PullRequest $request): string
+    {
+        [$from, $to] = $this->window($request);
+
+        return sprintf('%s:%s', $from->format('Y-m-d'), $to->format('Y-m-d'));
+    }
+
+    /**
+     * @param array<string, mixed> $defaults
+     *
+     * @return array<string, mixed>
+     */
+    private function cursor(?string $cursorValue, array $defaults): array
+    {
+        if (null === $cursorValue || '' === $cursorValue) {
+            return $defaults;
+        }
+
+        try {
+            $decoded = json_decode($cursorValue, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $exception) {
+            throw new \InvalidArgumentException('Ozon Performance cursor is not valid JSON.', previous: $exception);
+        }
+
+        if (!is_array($decoded) || array_is_list($decoded)) {
+            throw new \InvalidArgumentException('Ozon Performance cursor must be a JSON object.');
+        }
+
+        return $decoded + $defaults;
+    }
+
+    /**
+     * @param array<string, mixed> $cursor
+     */
+    private function cursorInt(array $cursor, string $key, int $default = 0): int
+    {
+        $value = $cursor[$key] ?? $default;
+        if (is_int($value)) {
+            return max(0, $value);
+        }
+        if (is_string($value) && ctype_digit($value)) {
+            return max(0, (int) $value);
+        }
+
+        return max(0, $default);
+    }
+
+    /**
+     * @param array<string, mixed> $cursor
+     */
+    private function cursorString(array $cursor, string $key): string
+    {
+        $value = $cursor[$key] ?? null;
+
+        return is_scalar($value) ? trim((string) $value) : '';
+    }
+
+    /**
+     * @param array<string, mixed> $cursor
+     */
+    private function encodeCursor(array $cursor): string
+    {
+        return json_encode($cursor, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES);
+    }
+
+    private function searchPromoReportType(mixed $value): string
+    {
+        $reportType = is_scalar($value) ? (string) $value : self::SEARCH_PROMO_REPORT_PRODUCTS;
+
+        return match ($reportType) {
+            self::SEARCH_PROMO_REPORT_PRODUCTS, self::SEARCH_PROMO_REPORT_ORDERS => $reportType,
+            default => throw new \InvalidArgumentException(sprintf('Unsupported Ozon Search Promo report type "%s".', $reportType)),
+        };
+    }
+
+    private function nextSearchPromoStatisticsCursor(string $reportType, int $batchOffset, int $campaignCount): ?string
+    {
+        if (self::SEARCH_PROMO_REPORT_PRODUCTS === $reportType) {
+            return $this->encodeCursor([
+                'batchOffset' => $batchOffset,
+                'reportType' => self::SEARCH_PROMO_REPORT_ORDERS,
+                'state' => 'request',
+            ]);
+        }
+
+        $nextBatchOffset = $batchOffset + self::CAMPAIGN_BATCH_SIZE;
+        if ($nextBatchOffset >= $campaignCount) {
+            return null;
+        }
+
+        return $this->encodeCursor([
+            'batchOffset' => $nextBatchOffset,
+            'reportType' => self::SEARCH_PROMO_REPORT_PRODUCTS,
+            'state' => 'request',
+        ]);
+    }
+
+    /**
+     * @param list<string> $campaignIds
+     */
+    private function campaignBatchHash(array $campaignIds): string
+    {
+        return substr(hash('sha256', implode(',', $campaignIds)), 0, 16);
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     * @param array<string, mixed>       $metadata
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function rowsOrEmptyMarker(array $rows, string $resourceType, array $metadata): array
+    {
+        if ([] !== $rows) {
+            return $rows;
+        }
+
+        return [[
+            '_ingestion_empty' => true,
+            '_ingestion_resource' => $resourceType,
+            '_ingestion_metadata' => $metadata,
+        ]];
+    }
+}

--- a/site/src/Ingestion/Application/Source/Ozon/OzonPerformanceReportConnector.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonPerformanceReportConnector.php
@@ -13,6 +13,7 @@ use App\Ingestion\Domain\Contract\SourceConnectorInterface;
 use App\Ingestion\DTO\RawBatch;
 use App\Ingestion\Enum\Capability;
 use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Exception\ConnectorTransientException;
 use App\Ingestion\Exception\UnsupportedCapabilityException;
 use App\Ingestion\Infrastructure\Api\Ozon\OzonPerformanceReportClientInterface;
 use App\Ingestion\Infrastructure\Api\Ozon\OzonRawPage;
@@ -22,6 +23,8 @@ final readonly class OzonPerformanceReportConnector implements SourceConnectorIn
 {
     private const CAMPAIGN_BATCH_SIZE = 10;
     private const SEARCH_PROMO_POLL_DELAY_SECONDS = 60;
+    private const SEARCH_PROMO_POLL_MAX_ATTEMPTS = 60;
+    private const SEARCH_PROMO_POLL_TIMEOUT_SECONDS = 3600;
 
     private const ADV_OBJECT_TYPE_SKU = 'SKU';
     private const ADV_OBJECT_TYPE_SEARCH_PROMO = 'SEARCH_PROMO';
@@ -229,6 +232,8 @@ final readonly class OzonPerformanceReportConnector implements SourceConnectorIn
             'batchOffset' => 0,
             'reportType' => self::SEARCH_PROMO_REPORT_PRODUCTS,
             'state' => 'request',
+            'pollAttempts' => 0,
+            'pollStartedAt' => $this->clock->now()->format(\DATE_ATOM),
         ]);
         $batchOffset = $this->cursorInt($cursor, 'batchOffset');
         $reportType = $this->searchPromoReportType($cursor['reportType'] ?? self::SEARCH_PROMO_REPORT_PRODUCTS);
@@ -247,6 +252,8 @@ final readonly class OzonPerformanceReportConnector implements SourceConnectorIn
                     'reportType' => $reportType,
                     'state' => 'poll',
                     'uuid' => $uuid,
+                    'pollAttempts' => 0,
+                    'pollStartedAt' => $this->clock->now()->format(\DATE_ATOM),
                 ]),
                 hasMore: true,
                 normalizeRawRecords: false,
@@ -261,9 +268,28 @@ final readonly class OzonPerformanceReportConnector implements SourceConnectorIn
 
         $reportLink = $this->client->pollReport($request->companyId, $request->connectionRef, $uuid);
         if (null === $reportLink) {
+            $nextPollAttempts = $this->cursorInt($cursor, 'pollAttempts') + 1;
+            $pollStartedAt = $this->cursorDate($cursor, 'pollStartedAt') ?? $this->clock->now();
+            $elapsedSeconds = $this->clock->now()->getTimestamp() - $pollStartedAt->getTimestamp();
+            if ($nextPollAttempts > self::SEARCH_PROMO_POLL_MAX_ATTEMPTS || $elapsedSeconds >= self::SEARCH_PROMO_POLL_TIMEOUT_SECONDS) {
+                throw new ConnectorTransientException(sprintf(
+                    'Ozon Search Promo report %s was not ready after %d attempts and %d seconds.',
+                    $uuid,
+                    $nextPollAttempts,
+                    max(0, $elapsedSeconds),
+                ));
+            }
+
             return new PullResult(
                 rawBatch: null,
-                nextCursorValue: $request->cursorValue,
+                nextCursorValue: $this->encodeCursor([
+                    'batchOffset' => $batchOffset,
+                    'reportType' => $reportType,
+                    'state' => 'poll',
+                    'uuid' => $uuid,
+                    'pollAttempts' => $nextPollAttempts,
+                    'pollStartedAt' => $pollStartedAt->format(\DATE_ATOM),
+                ]),
                 hasMore: true,
                 normalizeRawRecords: false,
                 continuationDelaySeconds: self::SEARCH_PROMO_POLL_DELAY_SECONDS,
@@ -480,6 +506,23 @@ final readonly class OzonPerformanceReportConnector implements SourceConnectorIn
         $value = $cursor[$key] ?? null;
 
         return is_scalar($value) ? trim((string) $value) : '';
+    }
+
+    /**
+     * @param array<string, mixed> $cursor
+     */
+    private function cursorDate(array $cursor, string $key): ?\DateTimeImmutable
+    {
+        $value = $cursor[$key] ?? null;
+        if (!is_string($value) || '' === trim($value)) {
+            return null;
+        }
+
+        try {
+            return new \DateTimeImmutable($value);
+        } catch (\Exception) {
+            return null;
+        }
     }
 
     /**

--- a/site/src/Ingestion/Application/Source/Ozon/OzonResourceType.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonResourceType.php
@@ -9,4 +9,11 @@ final class OzonResourceType
     public const ACCRUAL_POSTINGS = 'ozon_finance_accrual_postings';
     public const ACCRUAL_BY_DAY = 'ozon_finance_accrual_by_day';
     public const ACCRUAL_TYPES = 'ozon_finance_accrual_types';
+
+    public const PERFORMANCE_CAMPAIGNS = 'ozon_performance_campaigns';
+    public const PERFORMANCE_SKU_CAMPAIGN_OBJECTS = 'ozon_performance_sku_campaign_objects';
+    public const PERFORMANCE_SEARCH_PROMO_PRODUCTS = 'ozon_performance_search_promo_products';
+    public const PERFORMANCE_SKU_PRODUCT_STATISTICS = 'ozon_performance_sku_product_statistics';
+    public const PERFORMANCE_SEARCH_PROMO_STATISTICS = 'ozon_performance_search_promo_statistics';
+    public const PERFORMANCE_EXPENSE_STATISTICS = 'ozon_performance_expense_statistics';
 }

--- a/site/src/Ingestion/Application/Source/Ozon/OzonSellerReportConnector.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonSellerReportConnector.php
@@ -37,6 +37,18 @@ final readonly class OzonSellerReportConnector implements SourceConnectorInterfa
     }
 
     /**
+     * @return list<string>
+     */
+    public function resourceTypes(): array
+    {
+        return [
+            OzonResourceType::ACCRUAL_POSTINGS,
+            OzonResourceType::ACCRUAL_BY_DAY,
+            OzonResourceType::ACCRUAL_TYPES,
+        ];
+    }
+
+    /**
      * @return list<Capability>
      */
     public function capabilities(): array

--- a/site/src/Ingestion/Application/Source/Wildberries/WbFinanceReportConnector.php
+++ b/site/src/Ingestion/Application/Source/Wildberries/WbFinanceReportConnector.php
@@ -34,6 +34,14 @@ final readonly class WbFinanceReportConnector implements SourceConnectorInterfac
     }
 
     /**
+     * @return list<string>
+     */
+    public function resourceTypes(): array
+    {
+        return [WbResourceType::FINANCE_SALES_REPORT_DETAILED];
+    }
+
+    /**
      * @return list<Capability>
      */
     public function capabilities(): array

--- a/site/src/Ingestion/Command/OzonPerformanceBackfillCommand.php
+++ b/site/src/Ingestion/Command/OzonPerformanceBackfillCommand.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Command;
+
+use App\Ingestion\Application\Command\StartBackfillCommand as StartBackfillApplicationCommand;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Exception\ActiveBackfillExistsException;
+use App\Ingestion\Facade\SyncFacade;
+use App\Marketplace\Facade\MarketplaceFacade;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Webmozart\Assert\Assert;
+
+#[AsCommand(
+    name: 'app:ingestion:ozon-performance:backfill',
+    description: 'Dispatches Ozon Performance ingestion backfill jobs for one company.',
+)]
+final class OzonPerformanceBackfillCommand extends Command
+{
+    /**
+     * @var list<string>
+     */
+    private const RESOURCE_TYPES = [
+        OzonResourceType::PERFORMANCE_CAMPAIGNS,
+        OzonResourceType::PERFORMANCE_SKU_CAMPAIGN_OBJECTS,
+        OzonResourceType::PERFORMANCE_SEARCH_PROMO_PRODUCTS,
+        OzonResourceType::PERFORMANCE_SKU_PRODUCT_STATISTICS,
+        OzonResourceType::PERFORMANCE_SEARCH_PROMO_STATISTICS,
+        OzonResourceType::PERFORMANCE_EXPENSE_STATISTICS,
+    ];
+
+    public function __construct(
+        private readonly MarketplaceFacade $marketplaceFacade,
+        private readonly SyncFacade $syncFacade,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Company UUID.')
+            ->addOption('from', null, InputOption::VALUE_REQUIRED, 'Start date, YYYY-MM-DD.')
+            ->addOption('to', null, InputOption::VALUE_REQUIRED, 'End date, YYYY-MM-DD.')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Print planned jobs without dispatching them.')
+            ->addOption('execute', null, InputOption::VALUE_NONE, 'Dispatch jobs.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        try {
+            $dryRun = (bool) $input->getOption('dry-run');
+            $execute = (bool) $input->getOption('execute');
+            if ($dryRun === $execute) {
+                throw new \InvalidArgumentException('Choose exactly one action: --dry-run or --execute.');
+            }
+
+            $companyId = $this->companyId($input);
+            $from = $this->dateOption($input, 'from');
+            $to = $this->dateOption($input, 'to');
+            Assert::lessThanEq($from, $to, 'The --from date must be less than or equal to --to.');
+        } catch (\Throwable $exception) {
+            $io->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $connections = $this->marketplaceFacade->getActiveOzonPerformanceConnections($companyId);
+        if ([] === $connections) {
+            $io->warning('No active Ozon Performance connections found for company.');
+
+            return Command::SUCCESS;
+        }
+
+        return $this->dispatch($io, $connections, $from, $to, $dryRun);
+    }
+
+    /**
+     * @param list<array{connectionId: string, companyId: string, marketplace: string, connectionType: string, clientId: ?string}> $connections
+     */
+    private function dispatch(SymfonyStyle $io, array $connections, \DateTimeImmutable $from, \DateTimeImmutable $to, bool $dryRun): int
+    {
+        $rows = [];
+        $started = 0;
+        $skippedActive = 0;
+        $failed = 0;
+
+        foreach ($connections as $connection) {
+            $companyId = $connection['companyId'];
+            $connectionRef = $connection['connectionId'];
+
+            foreach (self::RESOURCE_TYPES as $resourceType) {
+                if ($dryRun) {
+                    $rows[] = [$companyId, $connectionRef, $resourceType, $from->format('Y-m-d'), $to->format('Y-m-d'), 'dry-run'];
+                    continue;
+                }
+
+                try {
+                    $jobId = $this->syncFacade->startBackfill(new StartBackfillApplicationCommand(
+                        companyId: $companyId,
+                        connectionRef: $connectionRef,
+                        source: IngestSource::OZON,
+                        resourceType: $resourceType,
+                        shopRef: $connectionRef,
+                        windowFrom: $from,
+                        windowTo: $to,
+                    ));
+                    ++$started;
+                    $rows[] = [$companyId, $connectionRef, $resourceType, $from->format('Y-m-d'), $to->format('Y-m-d'), $jobId];
+                } catch (ActiveBackfillExistsException) {
+                    ++$skippedActive;
+                    $rows[] = [$companyId, $connectionRef, $resourceType, $from->format('Y-m-d'), $to->format('Y-m-d'), 'active'];
+                } catch (\Throwable $exception) {
+                    ++$failed;
+                    $rows[] = [$companyId, $connectionRef, $resourceType, $from->format('Y-m-d'), $to->format('Y-m-d'), 'failed'];
+                    $this->logger->warning('Failed to dispatch Ozon Performance backfill.', [
+                        'companyId' => $companyId,
+                        'connectionRef' => $connectionRef,
+                        'resourceType' => $resourceType,
+                        'exceptionClass' => $exception::class,
+                        'errorMessage' => $exception->getMessage(),
+                    ]);
+                }
+            }
+        }
+
+        $io->title('Ozon Performance backfill');
+        $io->table(['companyId', 'connectionRef', 'resourceType', 'from', 'to', 'status'], $rows);
+        $io->table([
+            'metric',
+            'value',
+        ], [
+            ['connections', (string) count($connections)],
+            ['resources', (string) (count($connections) * count(self::RESOURCE_TYPES))],
+            ['started', (string) $started],
+            ['skippedActive', (string) $skippedActive],
+            ['failed', (string) $failed],
+        ]);
+
+        if ($dryRun) {
+            $io->note('Dry-run only. No jobs were dispatched.');
+
+            return Command::SUCCESS;
+        }
+
+        return 0 === $started && $failed > 0 ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    private function companyId(InputInterface $input): string
+    {
+        $companyId = trim((string) $input->getOption('company-id'));
+        Assert::uuid($companyId, 'Invalid --company-id UUID.');
+
+        return $companyId;
+    }
+
+    private function dateOption(InputInterface $input, string $name): \DateTimeImmutable
+    {
+        $value = trim((string) $input->getOption($name));
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
+        if (false === $date || $date->format('Y-m-d') !== $value) {
+            throw new \InvalidArgumentException(sprintf('Invalid --%s date. Expected YYYY-MM-DD.', $name));
+        }
+
+        return $date;
+    }
+}

--- a/site/src/Ingestion/Command/OzonPerformanceDailyLoadCommand.php
+++ b/site/src/Ingestion/Command/OzonPerformanceDailyLoadCommand.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Command;
+
+use App\Ingestion\Application\Command\StartBackfillCommand as StartBackfillApplicationCommand;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Exception\ActiveBackfillExistsException;
+use App\Ingestion\Facade\SyncFacade;
+use App\Marketplace\Facade\MarketplaceFacade;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\LockableTrait;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Clock\ClockInterface;
+use Webmozart\Assert\Assert;
+
+#[AsCommand(
+    name: 'app:ingestion:ozon-performance:daily-load',
+    description: 'Dispatches daily Ozon Performance ingestion jobs for active connections.',
+)]
+final class OzonPerformanceDailyLoadCommand extends Command
+{
+    use LockableTrait;
+
+    /**
+     * @var list<string>
+     */
+    private const RESOURCE_TYPES = [
+        OzonResourceType::PERFORMANCE_CAMPAIGNS,
+        OzonResourceType::PERFORMANCE_SKU_CAMPAIGN_OBJECTS,
+        OzonResourceType::PERFORMANCE_SEARCH_PROMO_PRODUCTS,
+        OzonResourceType::PERFORMANCE_SKU_PRODUCT_STATISTICS,
+        OzonResourceType::PERFORMANCE_SEARCH_PROMO_STATISTICS,
+        OzonResourceType::PERFORMANCE_EXPENSE_STATISTICS,
+    ];
+
+    public function __construct(
+        private readonly MarketplaceFacade $marketplaceFacade,
+        private readonly SyncFacade $syncFacade,
+        private readonly ClockInterface $clock,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('days-back', null, InputOption::VALUE_REQUIRED, 'Rewind depth in days, 1..62.', 14)
+            ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Optional company UUID filter.')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Print planned jobs without dispatching them.')
+            ->addOption('execute', null, InputOption::VALUE_NONE, 'Dispatch jobs.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        if (!$this->lock()) {
+            $io->warning('Command is already running in another process.');
+
+            return Command::SUCCESS;
+        }
+
+        try {
+            return $this->runDaily($input, $io);
+        } finally {
+            $this->release();
+        }
+    }
+
+    private function runDaily(InputInterface $input, SymfonyStyle $io): int
+    {
+        try {
+            $dryRun = (bool) $input->getOption('dry-run');
+            $execute = (bool) $input->getOption('execute');
+            if ($dryRun === $execute) {
+                throw new \InvalidArgumentException('Choose exactly one action: --dry-run or --execute.');
+            }
+
+            $daysBack = $this->daysBack($input);
+            $companyId = $this->companyId($input);
+        } catch (\Throwable $exception) {
+            $io->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $today = $this->clock->now()->setTime(0, 0);
+        $from = $today->modify(sprintf('-%d days', $daysBack));
+        $to = $today->modify('-1 day');
+        $connections = $this->marketplaceFacade->getActiveOzonPerformanceConnections($companyId);
+
+        $io->title('Ozon Performance daily load');
+        $io->table(['setting', 'value'], [
+            ['mode', $dryRun ? 'dry-run' : 'execute'],
+            ['from', $from->format('Y-m-d')],
+            ['to', $to->format('Y-m-d')],
+            ['daysBack', (string) $daysBack],
+            ['companyId', $companyId ?? 'all'],
+            ['connections', (string) count($connections)],
+        ]);
+
+        if ([] === $connections) {
+            $io->warning('No active Ozon Performance connections found.');
+
+            return Command::SUCCESS;
+        }
+
+        $rows = [];
+        $started = 0;
+        $skippedActive = 0;
+        $failed = 0;
+
+        foreach ($connections as $connection) {
+            $connectionCompanyId = $connection['companyId'];
+            $connectionRef = $connection['connectionId'];
+
+            foreach (self::RESOURCE_TYPES as $resourceType) {
+                if ($dryRun) {
+                    $rows[] = [$connectionCompanyId, $connectionRef, $resourceType, 'dry-run'];
+                    continue;
+                }
+
+                try {
+                    $jobId = $this->syncFacade->startBackfill(new StartBackfillApplicationCommand(
+                        companyId: $connectionCompanyId,
+                        connectionRef: $connectionRef,
+                        source: IngestSource::OZON,
+                        resourceType: $resourceType,
+                        shopRef: $connectionRef,
+                        windowFrom: $from,
+                        windowTo: $to,
+                    ));
+                    ++$started;
+                    $rows[] = [$connectionCompanyId, $connectionRef, $resourceType, $jobId];
+                } catch (ActiveBackfillExistsException) {
+                    ++$skippedActive;
+                    $rows[] = [$connectionCompanyId, $connectionRef, $resourceType, 'active'];
+                } catch (\Throwable $exception) {
+                    ++$failed;
+                    $rows[] = [$connectionCompanyId, $connectionRef, $resourceType, 'failed'];
+                    $this->logger->warning('Failed to dispatch Ozon Performance daily load job.', [
+                        'companyId' => $connectionCompanyId,
+                        'connectionRef' => $connectionRef,
+                        'resourceType' => $resourceType,
+                        'exceptionClass' => $exception::class,
+                        'errorMessage' => $exception->getMessage(),
+                    ]);
+                }
+            }
+        }
+
+        $io->section('Dispatch result');
+        $io->table(['companyId', 'connectionRef', 'resourceType', 'status'], $rows);
+        $io->table(['metric', 'value'], [
+            ['resources', (string) (count($connections) * count(self::RESOURCE_TYPES))],
+            ['started', (string) $started],
+            ['skippedActive', (string) $skippedActive],
+            ['failed', (string) $failed],
+        ]);
+
+        if ($dryRun) {
+            $io->note('Dry-run only. No jobs were dispatched.');
+
+            return Command::SUCCESS;
+        }
+
+        return 0 === $started && $failed > 0 ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    private function daysBack(InputInterface $input): int
+    {
+        $value = (string) $input->getOption('days-back');
+        if (!ctype_digit($value)) {
+            throw new \InvalidArgumentException('The --days-back option must be an integer from 1 to 62.');
+        }
+
+        $daysBack = (int) $value;
+        if ($daysBack < 1 || $daysBack > 62) {
+            throw new \InvalidArgumentException('The --days-back option must be an integer from 1 to 62.');
+        }
+
+        return $daysBack;
+    }
+
+    private function companyId(InputInterface $input): ?string
+    {
+        $companyId = trim((string) $input->getOption('company-id'));
+        if ('' === $companyId) {
+            return null;
+        }
+
+        Assert::uuid($companyId, 'Invalid --company-id UUID.');
+
+        return $companyId;
+    }
+}

--- a/site/src/Ingestion/Command/StartBackfillCommand.php
+++ b/site/src/Ingestion/Command/StartBackfillCommand.php
@@ -45,6 +45,12 @@ final class StartBackfillCommand extends Command
     private const ALLOWED_RESOURCE_TYPES_BY_SOURCE = [
         'ozon' => [
             OzonResourceType::ACCRUAL_BY_DAY,
+            OzonResourceType::PERFORMANCE_CAMPAIGNS,
+            OzonResourceType::PERFORMANCE_SKU_CAMPAIGN_OBJECTS,
+            OzonResourceType::PERFORMANCE_SEARCH_PROMO_PRODUCTS,
+            OzonResourceType::PERFORMANCE_SKU_PRODUCT_STATISTICS,
+            OzonResourceType::PERFORMANCE_SEARCH_PROMO_STATISTICS,
+            OzonResourceType::PERFORMANCE_EXPENSE_STATISTICS,
         ],
         'wildberries' => [
             WbResourceType::FINANCE_SALES_REPORT_DETAILED,
@@ -81,7 +87,7 @@ final class StartBackfillCommand extends Command
             $source = $this->source($input);
             $daysBack = $this->daysBack($input);
             $resourceTypes = $this->resourceTypes($source, $input);
-            $shopRef = $this->shopRef($source, $companyId, $connectionRef, $input);
+            $shopRef = $this->shopRef($source, $resourceTypes[0], $companyId, $connectionRef, $input);
         } catch (ConnectorAuthException) {
             $io->error('Auth failed: check credentials for connection.');
 
@@ -219,14 +225,14 @@ final class StartBackfillCommand extends Command
         return [$requested];
     }
 
-    private function shopRef(IngestSource $source, string $companyId, string $connectionRef, InputInterface $input): string
+    private function shopRef(IngestSource $source, string $resourceType, string $companyId, string $connectionRef, InputInterface $input): string
     {
         $shopRef = trim((string) $input->getOption('shop-ref'));
         if ('' !== $shopRef) {
             return $shopRef;
         }
 
-        $shops = $this->connectorRegistry->get($source)->discoverShops($companyId, $connectionRef);
+        $shops = $this->connectorRegistry->get($source, $resourceType)->discoverShops($companyId, $connectionRef);
         if ([] === $shops) {
             throw new \RuntimeException('No shops found for connection.');
         }

--- a/site/src/Ingestion/Controller/Api/Verification/GetCoverageController.php
+++ b/site/src/Ingestion/Controller/Api/Verification/GetCoverageController.php
@@ -44,6 +44,8 @@ final class GetCoverageController extends AbstractController
                             new OA\Property(property: 'date', type: 'string', format: 'date', example: '2026-06-01'),
                             new OA\Property(property: 'shop_ref', type: 'string', example: 'ozon-shop-123'),
                             new OA\Property(property: 'resource_type', type: 'string', example: 'ozon_finance_accrual_by_day'),
+                            new OA\Property(property: 'resource_label', type: 'string', example: 'Accrual by day'),
+                            new OA\Property(property: 'resource_group', type: 'string', example: 'Ozon Finance'),
                             new OA\Property(property: 'raw_count', type: 'integer', example: 1),
                             new OA\Property(property: 'tx_count', type: 'integer', example: 287),
                             new OA\Property(property: 'issue_count', type: 'integer', example: 0),

--- a/site/src/Ingestion/Domain/Contract/SourceConnectorInterface.php
+++ b/site/src/Ingestion/Domain/Contract/SourceConnectorInterface.php
@@ -17,6 +17,11 @@ interface SourceConnectorInterface
     public function source(): IngestSource;
 
     /**
+     * @return list<string>
+     */
+    public function resourceTypes(): array;
+
+    /**
      * @return list<Capability>
      */
     public function capabilities(): array;

--- a/site/src/Ingestion/Domain/Service/ConnectorRegistry.php
+++ b/site/src/Ingestion/Domain/Service/ConnectorRegistry.php
@@ -11,7 +11,7 @@ use App\Ingestion\Exception\ConnectorNotFoundException;
 final class ConnectorRegistry
 {
     /**
-     * @var array<string, SourceConnectorInterface>
+     * @var array<string, array<string, SourceConnectorInterface>>
      */
     private array $connectors = [];
 
@@ -22,22 +22,24 @@ final class ConnectorRegistry
     {
         foreach ($connectors as $connector) {
             $source = $connector->source()->value;
-            if (isset($this->connectors[$source])) {
-                throw new \InvalidArgumentException(sprintf('Duplicate ingestion connector for source "%s".', $source));
-            }
+            foreach ($connector->resourceTypes() as $resourceType) {
+                if (isset($this->connectors[$source][$resourceType])) {
+                    throw new \InvalidArgumentException(sprintf('Duplicate ingestion connector for source "%s" and resource "%s".', $source, $resourceType));
+                }
 
-            $this->connectors[$source] = $connector;
+                $this->connectors[$source][$resourceType] = $connector;
+            }
         }
     }
 
-    public function get(IngestSource $source): SourceConnectorInterface
+    public function get(IngestSource $source, string $resourceType): SourceConnectorInterface
     {
-        return $this->connectors[$source->value]
-            ?? throw new ConnectorNotFoundException(sprintf('Connector for source "%s" was not found.', $source->value));
+        return $this->connectors[$source->value][$resourceType]
+            ?? throw new ConnectorNotFoundException(sprintf('Connector for source "%s" and resource "%s" was not found.', $source->value, $resourceType));
     }
 
-    public function has(IngestSource $source): bool
+    public function has(IngestSource $source, string $resourceType): bool
     {
-        return isset($this->connectors[$source->value]);
+        return isset($this->connectors[$source->value][$resourceType]);
     }
 }

--- a/site/src/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClient.php
+++ b/site/src/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClient.php
@@ -273,14 +273,14 @@ final readonly class OzonPerformanceReportClient implements OzonPerformanceRepor
     {
         $absoluteUrl = isset($options['absoluteUrl']) && is_string($options['absoluteUrl']) && '' !== $options['absoluteUrl'];
         $url = $absoluteUrl
-            ? $options['absoluteUrl']
+            ? $this->normalizeReportUrl($options['absoluteUrl'])
             : $this->baseUrl.$endpoint;
         unset($options['absoluteUrl']);
 
         $options['headers'] = array_merge($options['headers'] ?? [], [
             'Accept' => 'application/json',
         ]);
-        if (!$absoluteUrl) {
+        if (!$absoluteUrl || !$this->isExternalUrl($url)) {
             $options['headers']['Authorization'] = 'Bearer '.$token;
         }
         $options['timeout'] ??= self::REQUEST_TIMEOUT;
@@ -484,7 +484,71 @@ final readonly class OzonPerformanceReportClient implements OzonPerformanceRepor
         } catch (\JsonException) {
         }
 
+        if ($this->isZipContent($content)) {
+            return $this->decodeZip($content);
+        }
+
         return $this->decodeCsv($content);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function decodeZip(string $content): array
+    {
+        if (!class_exists(\ZipArchive::class)) {
+            throw new ConnectorTransientException('Ozon Performance ZIP report cannot be read because ext-zip is unavailable.');
+        }
+
+        $file = tempnam(sys_get_temp_dir(), 'ozon_perf_report_');
+        if (false === $file) {
+            throw new ConnectorTransientException('Ozon Performance ZIP report temporary file cannot be created.');
+        }
+
+        try {
+            if (false === file_put_contents($file, $content)) {
+                throw new ConnectorTransientException('Ozon Performance ZIP report temporary file cannot be written.');
+            }
+
+            $zip = new \ZipArchive();
+            if (true !== $zip->open($file)) {
+                throw new ConnectorTransientException('Ozon Performance ZIP report cannot be opened.');
+            }
+
+            try {
+                $rows = [];
+                $csvFiles = 0;
+                for ($index = 0; $index < $zip->numFiles; ++$index) {
+                    $name = (string) ($zip->getNameIndex($index) ?: '');
+                    if ('' === $name || str_ends_with($name, '/')) {
+                        continue;
+                    }
+
+                    $extension = strtolower(pathinfo($name, \PATHINFO_EXTENSION));
+                    if (!in_array($extension, ['csv', 'txt'], true)) {
+                        continue;
+                    }
+
+                    $csv = $zip->getFromIndex($index);
+                    if (!is_string($csv)) {
+                        continue;
+                    }
+
+                    ++$csvFiles;
+                    array_push($rows, ...$this->decodeCsv($csv));
+                }
+
+                if (0 === $csvFiles) {
+                    throw new ConnectorTransientException('Ozon Performance ZIP report does not contain CSV files.');
+                }
+
+                return $rows;
+            } finally {
+                $zip->close();
+            }
+        } finally {
+            @unlink($file);
+        }
     }
 
     /**
@@ -614,6 +678,35 @@ final readonly class OzonPerformanceReportClient implements OzonPerformanceRepor
     private function stringField(mixed $value): string
     {
         return is_scalar($value) ? trim((string) $value) : '';
+    }
+
+    private function normalizeReportUrl(string $url): string
+    {
+        $url = trim($url);
+        if ('' === $url) {
+            return $url;
+        }
+
+        if (null !== parse_url($url, \PHP_URL_SCHEME)) {
+            return $url;
+        }
+
+        return $this->baseUrl.'/'.ltrim($url, '/');
+    }
+
+    private function isExternalUrl(string $url): bool
+    {
+        $baseHost = parse_url($this->baseUrl, \PHP_URL_HOST);
+        $urlHost = parse_url($url, \PHP_URL_HOST);
+
+        return is_string($urlHost) && '' !== $urlHost && $urlHost !== $baseHost;
+    }
+
+    private function isZipContent(string $content): bool
+    {
+        return str_starts_with($content, "PK\x03\x04")
+            || str_starts_with($content, "PK\x05\x06")
+            || str_starts_with($content, "PK\x07\x08");
     }
 
     private function startOfDayUtc(\DateTimeImmutable $date): string

--- a/site/src/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClient.php
+++ b/site/src/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClient.php
@@ -19,7 +19,6 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final readonly class OzonPerformanceReportClient implements OzonPerformanceReportClientInterface
 {
-    private const BASE_URL = 'https://api-performance.ozon.ru';
     private const TOKEN_PATH = '/api/client/token';
     private const CAMPAIGN_PATH = '/api/client/campaign';
     private const CAMPAIGN_OBJECTS_PATH = '/api/client/campaign/%s/objects';
@@ -37,12 +36,16 @@ final readonly class OzonPerformanceReportClient implements OzonPerformanceRepor
     private const CACHE_KEY_CAMPAIGNS_PREFIX = 'ingestion_ozon_perf_campaigns_';
     private const CAMPAIGN_CACHE_TTL_SECONDS = 300;
 
+    private string $baseUrl;
+
     public function __construct(
         private HttpClientInterface $httpClient,
         private MarketplaceFacade $marketplaceFacade,
         private CacheInterface $cache,
         private LoggerInterface $logger,
+        string $baseUrl,
     ) {
+        $this->baseUrl = rtrim($baseUrl, '/');
     }
 
     public function listCampaigns(string $companyId, string $connectionRef, array $advObjectTypes = []): OzonRawPage
@@ -248,11 +251,11 @@ final readonly class OzonPerformanceReportClient implements OzonPerformanceRepor
      */
     private function requestContent(string $companyId, string $connectionRef, string $method, string $endpoint, array $options = []): string
     {
-        $credentials = $this->credentials($companyId);
-        $token = $this->accessToken($companyId, $credentials['client_id'], $credentials['client_secret'], false);
+        $credentials = $this->credentials($companyId, $connectionRef);
+        $token = $this->accessToken($companyId, $connectionRef, $credentials['client_id'], $credentials['client_secret'], false);
         $response = $this->requestWithToken($companyId, $connectionRef, $method, $endpoint, $token, $options);
         if (401 === $response->getStatusCode()) {
-            $token = $this->accessToken($companyId, $credentials['client_id'], $credentials['client_secret'], true);
+            $token = $this->accessToken($companyId, $connectionRef, $credentials['client_id'], $credentials['client_secret'], true);
             $response = $this->requestWithToken($companyId, $connectionRef, $method, $endpoint, $token, $options);
         }
 
@@ -268,15 +271,18 @@ final readonly class OzonPerformanceReportClient implements OzonPerformanceRepor
      */
     private function requestWithToken(string $companyId, string $connectionRef, string $method, string $endpoint, string $token, array $options): ResponseInterface
     {
-        $url = isset($options['absoluteUrl']) && is_string($options['absoluteUrl']) && '' !== $options['absoluteUrl']
+        $absoluteUrl = isset($options['absoluteUrl']) && is_string($options['absoluteUrl']) && '' !== $options['absoluteUrl'];
+        $url = $absoluteUrl
             ? $options['absoluteUrl']
-            : self::BASE_URL.$endpoint;
+            : $this->baseUrl.$endpoint;
         unset($options['absoluteUrl']);
 
         $options['headers'] = array_merge($options['headers'] ?? [], [
-            'Authorization' => 'Bearer '.$token,
             'Accept' => 'application/json',
         ]);
+        if (!$absoluteUrl) {
+            $options['headers']['Authorization'] = 'Bearer '.$token;
+        }
         $options['timeout'] ??= self::REQUEST_TIMEOUT;
 
         $startedAt = microtime(true);
@@ -303,12 +309,13 @@ final readonly class OzonPerformanceReportClient implements OzonPerformanceRepor
     /**
      * @return array{client_id: string, client_secret: string}
      */
-    private function credentials(string $companyId): array
+    private function credentials(string $companyId, string $connectionRef): array
     {
         $credentials = $this->marketplaceFacade->getConnectionCredentials(
             $companyId,
             MarketplaceType::OZON,
             MarketplaceConnectionType::PERFORMANCE,
+            $connectionRef,
         );
 
         if (null === $credentials) {
@@ -324,16 +331,16 @@ final readonly class OzonPerformanceReportClient implements OzonPerformanceRepor
         return ['client_id' => $clientId, 'client_secret' => $clientSecret];
     }
 
-    private function accessToken(string $companyId, string $clientId, string $clientSecret, bool $forceRefresh): string
+    private function accessToken(string $companyId, string $connectionRef, string $clientId, string $clientSecret, bool $forceRefresh): string
     {
-        $cacheKey = self::CACHE_KEY_TOKEN_PREFIX.$companyId;
+        $cacheKey = self::CACHE_KEY_TOKEN_PREFIX.hash('sha256', $companyId.'|'.$connectionRef);
         if ($forceRefresh) {
             $this->cache->delete($cacheKey);
         }
 
         return $this->cache->get($cacheKey, function (ItemInterface $item) use ($clientId, $clientSecret): string {
             try {
-                $response = $this->httpClient->request('POST', self::BASE_URL.self::TOKEN_PATH, [
+                $response = $this->httpClient->request('POST', $this->baseUrl.self::TOKEN_PATH, [
                     'headers' => ['Content-Type' => 'application/json', 'Accept' => 'application/json'],
                     'json' => [
                         'client_id' => $clientId,

--- a/site/src/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClient.php
+++ b/site/src/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClient.php
@@ -1,0 +1,555 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Api\Ozon;
+
+use App\Ingestion\Exception\ConnectorAuthException;
+use App\Ingestion\Exception\ConnectorRateLimitedException;
+use App\Ingestion\Exception\ConnectorTransientException;
+use App\Marketplace\Enum\MarketplaceConnectionType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Facade\MarketplaceFacade;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final readonly class OzonPerformanceReportClient implements OzonPerformanceReportClientInterface
+{
+    private const BASE_URL = 'https://api-performance.ozon.ru';
+    private const TOKEN_PATH = '/api/client/token';
+    private const CAMPAIGN_PATH = '/api/client/campaign';
+    private const CAMPAIGN_OBJECTS_PATH = '/api/client/campaign/%s/objects';
+    private const SEARCH_PROMO_PRODUCTS_PATH = '/api/client/campaign/search_promo/v2/products';
+    private const PRODUCT_STATISTICS_PATH = '/api/client/statistics/campaign/product/json';
+    private const PRODUCTS_REPORT_PATH = '/api/client/statistic/products/generate';
+    private const ORDERS_REPORT_PATH = '/api/client/statistic/orders/generate';
+    private const REPORT_STATE_PATH = '/api/client/statistics/%s';
+    private const REPORT_DOWNLOAD_PATH = '/api/client/statistics/report';
+    private const EXPENSE_STATISTICS_PATH = '/api/client/statistics/expense/json';
+
+    private const REQUEST_TIMEOUT = 60;
+    private const TOKEN_TTL_SAFETY_MARGIN = 300;
+    private const CACHE_KEY_TOKEN_PREFIX = 'ingestion_ozon_perf_token_';
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private MarketplaceFacade $marketplaceFacade,
+        private CacheInterface $cache,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function listCampaigns(string $companyId, string $connectionRef, array $advObjectTypes = []): OzonRawPage
+    {
+        $query = [];
+        if ([] !== $advObjectTypes) {
+            $query['advObjectType'] = array_values($advObjectTypes);
+        }
+
+        $payload = $this->requestJson($companyId, $connectionRef, 'GET', self::CAMPAIGN_PATH, ['query' => $query]);
+        $rows = $this->extractRows($payload);
+
+        return new OzonRawPage($this->sortRows($rows), false, null, [
+            'endpoint' => self::CAMPAIGN_PATH,
+            'advObjectTypes' => array_values($advObjectTypes),
+            'resultKeys' => array_keys($payload),
+        ]);
+    }
+
+    public function fetchCampaignObjects(string $companyId, string $connectionRef, string $campaignId): OzonRawPage
+    {
+        $endpoint = sprintf(self::CAMPAIGN_OBJECTS_PATH, rawurlencode($campaignId));
+        $payload = $this->requestJson($companyId, $connectionRef, 'GET', $endpoint);
+
+        return new OzonRawPage($this->rowsWithMetadata($this->extractRows($payload), ['campaignId' => $campaignId]), false, null, [
+            'endpoint' => $endpoint,
+            'campaignId' => $campaignId,
+            'resultKeys' => array_keys($payload),
+        ]);
+    }
+
+    public function fetchSearchPromoProducts(string $companyId, string $connectionRef, string $campaignId, int $page): OzonRawPage
+    {
+        $page = max(1, $page);
+        $payload = $this->requestJson($companyId, $connectionRef, 'POST', self::SEARCH_PROMO_PRODUCTS_PATH, [
+            'json' => [
+                'campaign_id' => $campaignId,
+                'campaignId' => $campaignId,
+                'page' => $page,
+                'page_size' => 1000,
+                'pageSize' => 1000,
+            ],
+        ]);
+        $rows = $this->rowsWithMetadata($this->extractRows($payload), ['campaignId' => $campaignId, 'page' => $page]);
+        $hasMore = $this->hasMore($payload, $page, count($rows), 1000);
+
+        return new OzonRawPage($this->sortRows($rows), $hasMore, $hasMore ? (string) ($page + 1) : null, [
+            'endpoint' => self::SEARCH_PROMO_PRODUCTS_PATH,
+            'campaignId' => $campaignId,
+            'page' => $page,
+            'resultKeys' => array_keys($payload),
+        ]);
+    }
+
+    public function fetchSkuProductStatistics(
+        string $companyId,
+        string $connectionRef,
+        \DateTimeImmutable $dateFrom,
+        \DateTimeImmutable $dateTo,
+        array $campaignIds,
+    ): OzonRawPage {
+        $campaignIds = $this->normalizeCampaignIds($campaignIds);
+        $payload = $this->requestJson($companyId, $connectionRef, 'GET', self::PRODUCT_STATISTICS_PATH, [
+            'query' => [
+                'dateFrom' => $dateFrom->format('Y-m-d'),
+                'dateTo' => $dateTo->format('Y-m-d'),
+                'from' => $this->startOfDayUtc($dateFrom),
+                'to' => $this->endOfDayUtc($dateTo),
+                'campaignIds' => $campaignIds,
+            ],
+        ]);
+
+        return new OzonRawPage($this->rowsWithMetadata($this->extractRows($payload), ['campaignIds' => $campaignIds]), false, null, [
+            'endpoint' => self::PRODUCT_STATISTICS_PATH,
+            'campaignIds' => $campaignIds,
+            'windowFrom' => $dateFrom->format('Y-m-d'),
+            'windowTo' => $dateTo->format('Y-m-d'),
+            'resultKeys' => array_keys($payload),
+        ]);
+    }
+
+    public function generateSearchPromoReport(
+        string $companyId,
+        string $connectionRef,
+        string $reportType,
+        \DateTimeImmutable $dateFrom,
+        \DateTimeImmutable $dateTo,
+        array $campaignIds,
+    ): string {
+        $campaignIds = $this->normalizeCampaignIds($campaignIds);
+        $endpoint = match ($reportType) {
+            'products' => self::PRODUCTS_REPORT_PATH,
+            'orders' => self::ORDERS_REPORT_PATH,
+            default => throw new \InvalidArgumentException(sprintf('Unsupported Ozon Search Promo report type "%s".', $reportType)),
+        };
+
+        $payload = $this->requestJson($companyId, $connectionRef, 'POST', $endpoint, [
+            'json' => [
+                'campaigns' => $campaignIds,
+                'campaignIds' => $campaignIds,
+                'dateFrom' => $dateFrom->format('Y-m-d'),
+                'dateTo' => $dateTo->format('Y-m-d'),
+                'from' => $this->startOfDayUtc($dateFrom),
+                'to' => $this->endOfDayUtc($dateTo),
+            ],
+        ]);
+
+        $uuid = $this->stringField($payload['UUID'] ?? $payload['uuid'] ?? $payload['report_uuid'] ?? $payload['reportUuid'] ?? null);
+        if ('' === $uuid) {
+            throw new ConnectorTransientException(sprintf('Ozon Performance %s report response does not contain UUID.', $reportType));
+        }
+
+        return $uuid;
+    }
+
+    public function pollReport(string $companyId, string $connectionRef, string $reportUuid): ?string
+    {
+        $endpoint = sprintf(self::REPORT_STATE_PATH, rawurlencode($reportUuid));
+        $payload = $this->requestJson($companyId, $connectionRef, 'GET', $endpoint);
+        $state = strtolower($this->stringField($payload['state'] ?? $payload['status'] ?? $payload['result']['state'] ?? $payload['result']['status'] ?? null));
+
+        if (in_array($state, ['error', 'failed', 'failure'], true)) {
+            throw new ConnectorTransientException(sprintf('Ozon Performance report %s failed.', $reportUuid));
+        }
+
+        $link = $this->stringField($payload['link'] ?? $payload['report']['link'] ?? $payload['result']['link'] ?? $payload['result']['report']['link'] ?? null);
+        if ('' !== $link || in_array($state, ['ok', 'ready', 'done', 'success'], true)) {
+            return $link;
+        }
+
+        return null;
+    }
+
+    public function downloadReport(string $companyId, string $connectionRef, string $reportUuid, string $reportLink): OzonRawPage
+    {
+        $options = '' !== $reportLink
+            ? ['absoluteUrl' => $reportLink]
+            : ['query' => ['UUID' => $reportUuid]];
+        $content = $this->requestContent($companyId, $connectionRef, 'GET', self::REPORT_DOWNLOAD_PATH, $options);
+        $rows = $this->decodeReportContent($content);
+
+        return new OzonRawPage($this->rowsWithMetadata($rows, ['reportUuid' => $reportUuid]), false, null, [
+            'endpoint' => self::REPORT_DOWNLOAD_PATH,
+            'reportUuid' => $reportUuid,
+            'reportLinkProvided' => '' !== $reportLink,
+        ]);
+    }
+
+    public function fetchExpenseStatistics(
+        string $companyId,
+        string $connectionRef,
+        \DateTimeImmutable $dateFrom,
+        \DateTimeImmutable $dateTo,
+    ): OzonRawPage {
+        $payload = $this->requestJson($companyId, $connectionRef, 'GET', self::EXPENSE_STATISTICS_PATH, [
+            'query' => [
+                'dateFrom' => $dateFrom->format('Y-m-d'),
+                'dateTo' => $dateTo->format('Y-m-d'),
+                'from' => $this->startOfDayUtc($dateFrom),
+                'to' => $this->endOfDayUtc($dateTo),
+            ],
+        ]);
+
+        return new OzonRawPage($this->sortRows($this->extractRows($payload)), false, null, [
+            'endpoint' => self::EXPENSE_STATISTICS_PATH,
+            'windowFrom' => $dateFrom->format('Y-m-d'),
+            'windowTo' => $dateTo->format('Y-m-d'),
+            'resultKeys' => array_keys($payload),
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @return array<string, mixed>
+     */
+    private function requestJson(string $companyId, string $connectionRef, string $method, string $endpoint, array $options = []): array
+    {
+        $content = $this->requestContent($companyId, $connectionRef, $method, $endpoint, $options);
+
+        try {
+            $payload = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $exception) {
+            throw new ConnectorTransientException(sprintf('Ozon Performance returned invalid JSON for %s.', $endpoint), previous: $exception);
+        }
+
+        if (!is_array($payload)) {
+            throw new ConnectorTransientException(sprintf('Ozon Performance returned unexpected payload for %s.', $endpoint));
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function requestContent(string $companyId, string $connectionRef, string $method, string $endpoint, array $options = []): string
+    {
+        $credentials = $this->credentials($companyId);
+        $token = $this->accessToken($companyId, $credentials['client_id'], $credentials['client_secret'], false);
+        $response = $this->requestWithToken($companyId, $connectionRef, $method, $endpoint, $token, $options);
+        if (401 === $response->getStatusCode()) {
+            $token = $this->accessToken($companyId, $credentials['client_id'], $credentials['client_secret'], true);
+            $response = $this->requestWithToken($companyId, $connectionRef, $method, $endpoint, $token, $options);
+        }
+
+        $statusCode = $response->getStatusCode();
+        $content = $response->getContent(false);
+        $this->classifyStatus($statusCode, $endpoint, $content);
+
+        return $content;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function requestWithToken(string $companyId, string $connectionRef, string $method, string $endpoint, string $token, array $options): ResponseInterface
+    {
+        $url = isset($options['absoluteUrl']) && is_string($options['absoluteUrl']) && '' !== $options['absoluteUrl']
+            ? $options['absoluteUrl']
+            : self::BASE_URL.$endpoint;
+        unset($options['absoluteUrl']);
+
+        $options['headers'] = array_merge($options['headers'] ?? [], [
+            'Authorization' => 'Bearer '.$token,
+            'Accept' => 'application/json',
+        ]);
+        $options['timeout'] ??= self::REQUEST_TIMEOUT;
+
+        $startedAt = microtime(true);
+        $statusCode = null;
+        try {
+            $response = $this->httpClient->request($method, $url, $options);
+            $statusCode = $response->getStatusCode();
+
+            return $response;
+        } catch (TransportExceptionInterface $exception) {
+            throw new ConnectorTransientException(sprintf('Ozon Performance transport error for %s.', $endpoint), previous: $exception);
+        } finally {
+            $this->logger->info('Ozon Performance API request finished.', [
+                'companyId' => $companyId,
+                'connectionRef' => $connectionRef,
+                'endpoint' => $endpoint,
+                'method' => $method,
+                'statusCode' => $statusCode,
+                'durationMs' => (int) ((microtime(true) - $startedAt) * 1000),
+            ]);
+        }
+    }
+
+    /**
+     * @return array{client_id: string, client_secret: string}
+     */
+    private function credentials(string $companyId): array
+    {
+        $credentials = $this->marketplaceFacade->getConnectionCredentials(
+            $companyId,
+            MarketplaceType::OZON,
+            MarketplaceConnectionType::PERFORMANCE,
+        );
+
+        if (null === $credentials) {
+            throw new ConnectorAuthException('Ozon Performance credentials were not found.');
+        }
+
+        $clientId = trim((string) ($credentials['client_id'] ?? ''));
+        $clientSecret = trim((string) ($credentials['api_key'] ?? ''));
+        if ('' === $clientId || '' === $clientSecret) {
+            throw new ConnectorAuthException('Ozon Performance credentials are incomplete.');
+        }
+
+        return ['client_id' => $clientId, 'client_secret' => $clientSecret];
+    }
+
+    private function accessToken(string $companyId, string $clientId, string $clientSecret, bool $forceRefresh): string
+    {
+        $cacheKey = self::CACHE_KEY_TOKEN_PREFIX.$companyId;
+        if ($forceRefresh) {
+            $this->cache->delete($cacheKey);
+        }
+
+        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($clientId, $clientSecret): string {
+            try {
+                $response = $this->httpClient->request('POST', self::BASE_URL.self::TOKEN_PATH, [
+                    'headers' => ['Content-Type' => 'application/json', 'Accept' => 'application/json'],
+                    'json' => [
+                        'client_id' => $clientId,
+                        'client_secret' => $clientSecret,
+                        'grant_type' => 'client_credentials',
+                    ],
+                    'timeout' => self::REQUEST_TIMEOUT,
+                ]);
+            } catch (TransportExceptionInterface $exception) {
+                throw new ConnectorTransientException('Ozon Performance token transport error.', previous: $exception);
+            }
+
+            $statusCode = $response->getStatusCode();
+            $content = $response->getContent(false);
+            if (401 === $statusCode || 403 === $statusCode || 400 === $statusCode) {
+                throw new ConnectorAuthException('Ozon Performance token request failed.');
+            }
+            if ($statusCode >= 500 || 429 === $statusCode) {
+                throw new ConnectorTransientException(sprintf('Ozon Performance token request returned HTTP %d.', $statusCode));
+            }
+            if ($statusCode < 200 || $statusCode >= 300) {
+                throw new \RuntimeException(sprintf('Ozon Performance token request returned HTTP %d.', $statusCode));
+            }
+
+            try {
+                $payload = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+            } catch (\JsonException $exception) {
+                throw new ConnectorTransientException('Ozon Performance token response is invalid JSON.', previous: $exception);
+            }
+
+            $token = is_array($payload) ? $this->stringField($payload['access_token'] ?? null) : '';
+            if ('' === $token) {
+                throw new ConnectorTransientException('Ozon Performance token response does not contain access_token.');
+            }
+
+            $expiresIn = isset($payload['expires_in']) && is_int($payload['expires_in']) ? $payload['expires_in'] : 1800;
+            $item->expiresAfter(max(60, $expiresIn - self::TOKEN_TTL_SAFETY_MARGIN));
+
+            return $token;
+        });
+    }
+
+    private function classifyStatus(int $statusCode, string $endpoint, string $content): void
+    {
+        if (401 === $statusCode || 403 === $statusCode) {
+            throw new ConnectorAuthException(sprintf('Ozon Performance auth failed for %s.', $endpoint));
+        }
+
+        if (429 === $statusCode) {
+            throw new ConnectorRateLimitedException(sprintf('Ozon Performance rate limit for %s.', $endpoint), 120);
+        }
+
+        if ($statusCode >= 500) {
+            throw new ConnectorTransientException(sprintf('Ozon Performance server error %d for %s.', $statusCode, $endpoint));
+        }
+
+        if ($statusCode < 200 || $statusCode >= 300) {
+            throw new \RuntimeException(sprintf('Ozon Performance returned HTTP %d for %s: %s', $statusCode, $endpoint, mb_substr($content, 0, 500)));
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function extractRows(array $payload): array
+    {
+        foreach ([$payload['result'] ?? null, $payload['data'] ?? null, $payload] as $candidate) {
+            if (!is_array($candidate)) {
+                continue;
+            }
+
+            if (array_is_list($candidate)) {
+                return $this->objectRows($candidate);
+            }
+
+            foreach (['list', 'items', 'rows', 'campaigns', 'products', 'orders', 'statistics', 'expenses', 'data'] as $key) {
+                $rows = $candidate[$key] ?? null;
+                if (is_array($rows) && array_is_list($rows)) {
+                    return $this->objectRows($rows);
+                }
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param list<mixed> $rows
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function objectRows(array $rows): array
+    {
+        return array_values(array_filter($rows, static fn (mixed $row): bool => is_array($row) && !array_is_list($row)));
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     * @param array<string, mixed>       $metadata
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function rowsWithMetadata(array $rows, array $metadata): array
+    {
+        return $this->sortRows(array_map(static fn (array $row): array => $row + ['_ingestion_metadata' => $metadata], $rows));
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function sortRows(array $rows): array
+    {
+        usort($rows, static fn (array $left, array $right): int => json_encode($left, \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES) <=> json_encode($right, \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES));
+
+        return array_values($rows);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function decodeReportContent(string $content): array
+    {
+        try {
+            $payload = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+            if (is_array($payload)) {
+                return $this->extractRows($payload);
+            }
+        } catch (\JsonException) {
+        }
+
+        return $this->decodeCsv($content);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function decodeCsv(string $content): array
+    {
+        $lines = preg_split('/\R/u', trim($content));
+        if (false === $lines || count($lines) < 2) {
+            return [];
+        }
+
+        $header = str_getcsv((string) array_shift($lines));
+        $rows = [];
+        foreach ($lines as $line) {
+            if ('' === trim((string) $line)) {
+                continue;
+            }
+
+            $values = str_getcsv((string) $line);
+            $row = [];
+            foreach ($header as $index => $name) {
+                if ('' === (string) $name) {
+                    continue;
+                }
+
+                $row[(string) $name] = $values[$index] ?? null;
+            }
+            if ([] !== $row) {
+                $rows[] = $row;
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param list<string> $campaignIds
+     *
+     * @return non-empty-list<string>
+     */
+    private function normalizeCampaignIds(array $campaignIds): array
+    {
+        $normalized = array_values(array_unique(array_filter(array_map(static fn (mixed $id): string => trim((string) $id), $campaignIds))));
+        if ([] === $normalized) {
+            throw new \InvalidArgumentException('Ozon Performance request requires at least one campaign id.');
+        }
+        if (count($normalized) > 10) {
+            throw new \InvalidArgumentException('Ozon Performance request supports at most 10 campaign ids.');
+        }
+
+        return $normalized;
+    }
+
+    private function hasMore(array $payload, int $page, int $rowCount, int $pageSize): bool
+    {
+        $result = is_array($payload['result'] ?? null) ? $payload['result'] : $payload;
+        if ((bool) ($result['has_next'] ?? $result['has_more'] ?? $payload['has_next'] ?? $payload['has_more'] ?? false)) {
+            return true;
+        }
+
+        $total = $this->intValue($result['total'] ?? $payload['total'] ?? null);
+
+        return $total > 0 && (($page - 1) * $pageSize + $rowCount) < $total;
+    }
+
+    private function intValue(mixed $value): int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+        if (is_string($value) && ctype_digit($value)) {
+            return (int) $value;
+        }
+
+        return 0;
+    }
+
+    private function stringField(mixed $value): string
+    {
+        return is_scalar($value) ? trim((string) $value) : '';
+    }
+
+    private function startOfDayUtc(\DateTimeImmutable $date): string
+    {
+        return $date->setTime(0, 0)->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d\TH:i:s\Z');
+    }
+
+    private function endOfDayUtc(\DateTimeImmutable $date): string
+    {
+        return $date->setTime(23, 59, 59)->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d\TH:i:s\Z');
+    }
+}

--- a/site/src/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClient.php
+++ b/site/src/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClient.php
@@ -34,6 +34,8 @@ final readonly class OzonPerformanceReportClient implements OzonPerformanceRepor
     private const REQUEST_TIMEOUT = 60;
     private const TOKEN_TTL_SAFETY_MARGIN = 300;
     private const CACHE_KEY_TOKEN_PREFIX = 'ingestion_ozon_perf_token_';
+    private const CACHE_KEY_CAMPAIGNS_PREFIX = 'ingestion_ozon_perf_campaigns_';
+    private const CAMPAIGN_CACHE_TTL_SECONDS = 300;
 
     public function __construct(
         private HttpClientInterface $httpClient,
@@ -45,19 +47,26 @@ final readonly class OzonPerformanceReportClient implements OzonPerformanceRepor
 
     public function listCampaigns(string $companyId, string $connectionRef, array $advObjectTypes = []): OzonRawPage
     {
+        $advObjectTypes = $this->normalizeStringList($advObjectTypes);
         $query = [];
         if ([] !== $advObjectTypes) {
-            $query['advObjectType'] = array_values($advObjectTypes);
+            $query['advObjectType'] = $advObjectTypes;
         }
 
-        $payload = $this->requestJson($companyId, $connectionRef, 'GET', self::CAMPAIGN_PATH, ['query' => $query]);
-        $rows = $this->extractRows($payload);
+        $cacheKey = $this->campaignCacheKey($companyId, $connectionRef, $advObjectTypes);
 
-        return new OzonRawPage($this->sortRows($rows), false, null, [
-            'endpoint' => self::CAMPAIGN_PATH,
-            'advObjectTypes' => array_values($advObjectTypes),
-            'resultKeys' => array_keys($payload),
-        ]);
+        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($companyId, $connectionRef, $query, $advObjectTypes): OzonRawPage {
+            $item->expiresAfter(self::CAMPAIGN_CACHE_TTL_SECONDS);
+
+            $payload = $this->requestJson($companyId, $connectionRef, 'GET', self::CAMPAIGN_PATH, ['query' => $query]);
+            $rows = $this->extractRows($payload);
+
+            return new OzonRawPage($this->sortRows($rows), false, null, [
+                'endpoint' => self::CAMPAIGN_PATH,
+                'advObjectTypes' => $advObjectTypes,
+                'resultKeys' => array_keys($payload),
+            ]);
+        });
     }
 
     public function fetchCampaignObjects(string $companyId, string $connectionRef, string $campaignId): OzonRawPage
@@ -441,7 +450,16 @@ final readonly class OzonPerformanceReportClient implements OzonPerformanceRepor
      */
     private function sortRows(array $rows): array
     {
-        usort($rows, static fn (array $left, array $right): int => json_encode($left, \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES) <=> json_encode($right, \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES));
+        if (count($rows) < 2) {
+            return array_values($rows);
+        }
+
+        $serialized = [];
+        foreach ($rows as $index => $row) {
+            $serialized[$index] = (string) json_encode($row, \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES);
+        }
+
+        uksort($rows, static fn (int|string $left, int|string $right): int => $serialized[$left] <=> $serialized[$right]);
 
         return array_values($rows);
     }
@@ -467,33 +485,56 @@ final readonly class OzonPerformanceReportClient implements OzonPerformanceRepor
      */
     private function decodeCsv(string $content): array
     {
-        $lines = preg_split('/\R/u', trim($content));
-        if (false === $lines || count($lines) < 2) {
+        if (str_starts_with($content, "\xEF\xBB\xBF")) {
+            $content = substr($content, 3);
+        }
+
+        $stream = fopen('php://memory', 'r+');
+        if (false === $stream) {
             return [];
         }
 
-        $header = str_getcsv((string) array_shift($lines));
-        $rows = [];
-        foreach ($lines as $line) {
-            if ('' === trim((string) $line)) {
-                continue;
+        try {
+            if (false === fwrite($stream, $content)) {
+                return [];
+            }
+            rewind($stream);
+
+            $firstLine = fgets($stream);
+            if (false === $firstLine) {
+                return [];
+            }
+            $separator = substr_count($firstLine, ';') > substr_count($firstLine, ',') ? ';' : ',';
+            rewind($stream);
+
+            $header = fgetcsv($stream, 0, $separator, '"', '');
+            if (false === $header) {
+                return [];
             }
 
-            $values = str_getcsv((string) $line);
-            $row = [];
-            foreach ($header as $index => $name) {
-                if ('' === (string) $name) {
+            $rows = [];
+            while (false !== ($values = fgetcsv($stream, 0, $separator, '"', ''))) {
+                if ([null] === $values || [''] === $values) {
                     continue;
                 }
 
-                $row[(string) $name] = $values[$index] ?? null;
-            }
-            if ([] !== $row) {
-                $rows[] = $row;
-            }
-        }
+                $row = [];
+                foreach ($header as $index => $name) {
+                    if ('' === (string) $name) {
+                        continue;
+                    }
 
-        return $rows;
+                    $row[(string) $name] = $values[$index] ?? null;
+                }
+                if ([] !== $row) {
+                    $rows[] = $row;
+                }
+            }
+
+            return $rows;
+        } finally {
+            fclose($stream);
+        }
     }
 
     /**
@@ -512,6 +553,31 @@ final readonly class OzonPerformanceReportClient implements OzonPerformanceRepor
         }
 
         return $normalized;
+    }
+
+    /**
+     * @param list<mixed> $values
+     *
+     * @return list<string>
+     */
+    private function normalizeStringList(array $values): array
+    {
+        $normalized = array_values(array_unique(array_filter(array_map(static fn (mixed $value): string => trim((string) $value), $values))));
+        sort($normalized);
+
+        return $normalized;
+    }
+
+    /**
+     * @param list<string> $advObjectTypes
+     */
+    private function campaignCacheKey(string $companyId, string $connectionRef, array $advObjectTypes): string
+    {
+        return self::CACHE_KEY_CAMPAIGNS_PREFIX.hash('sha256', implode('|', [
+            $companyId,
+            $connectionRef,
+            implode(',', $advObjectTypes),
+        ]));
     }
 
     private function hasMore(array $payload, int $page, int $rowCount, int $pageSize): bool

--- a/site/src/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClientInterface.php
+++ b/site/src/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClientInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Api\Ozon;
+
+interface OzonPerformanceReportClientInterface
+{
+    /**
+     * @param list<string> $advObjectTypes
+     */
+    public function listCampaigns(string $companyId, string $connectionRef, array $advObjectTypes = []): OzonRawPage;
+
+    public function fetchCampaignObjects(string $companyId, string $connectionRef, string $campaignId): OzonRawPage;
+
+    public function fetchSearchPromoProducts(string $companyId, string $connectionRef, string $campaignId, int $page): OzonRawPage;
+
+    /**
+     * @param list<string> $campaignIds
+     */
+    public function fetchSkuProductStatistics(
+        string $companyId,
+        string $connectionRef,
+        \DateTimeImmutable $dateFrom,
+        \DateTimeImmutable $dateTo,
+        array $campaignIds,
+    ): OzonRawPage;
+
+    /**
+     * @param list<string> $campaignIds
+     */
+    public function generateSearchPromoReport(
+        string $companyId,
+        string $connectionRef,
+        string $reportType,
+        \DateTimeImmutable $dateFrom,
+        \DateTimeImmutable $dateTo,
+        array $campaignIds,
+    ): string;
+
+    public function pollReport(string $companyId, string $connectionRef, string $reportUuid): ?string;
+
+    public function downloadReport(string $companyId, string $connectionRef, string $reportUuid, string $reportLink): OzonRawPage;
+
+    public function fetchExpenseStatistics(
+        string $companyId,
+        string $connectionRef,
+        \DateTimeImmutable $dateFrom,
+        \DateTimeImmutable $dateTo,
+    ): OzonRawPage;
+}

--- a/site/src/Ingestion/Infrastructure/Query/CoverageQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/CoverageQuery.php
@@ -6,6 +6,7 @@ namespace App\Ingestion\Infrastructure\Query;
 
 use App\Ingestion\Application\DTO\CoverageCellView;
 use App\Ingestion\Application\DTO\ShopOptionView;
+use App\Ingestion\Application\Service\IngestionResourceLabelProvider;
 use App\Ingestion\Enum\SyncJobKind;
 use App\Ingestion\Enum\SyncJobStatus;
 use Doctrine\DBAL\Connection;
@@ -16,6 +17,7 @@ final class CoverageQuery
 {
     public function __construct(
         private readonly Connection $connection,
+        private readonly IngestionResourceLabelProvider $resourceLabelProvider,
     ) {
     }
 
@@ -108,18 +110,22 @@ final class CoverageQuery
         $rows = $qb->executeQuery()->fetchAllAssociative();
         $rows = $this->mergeRows($rows, $this->failedJobIssueRows($companyId, $shopRef, $from, $to));
 
-        return array_map(
-            static fn (array $row): CoverageCellView => new CoverageCellView(
+        return array_map(function (array $row): CoverageCellView {
+            $resourceType = (string) $row['resource_type'];
+            $description = $this->resourceLabelProvider->describe($resourceType);
+
+            return new CoverageCellView(
                 date: (string) $row['record_date'],
                 shopRef: (string) $row['shop_ref'],
-                resourceType: (string) $row['resource_type'],
+                resourceType: $resourceType,
+                resourceLabel: $description['label'],
+                resourceGroup: $description['group'],
                 rawCount: (int) $row['raw_count'],
                 txCount: (int) $row['tx_count'],
                 issueCount: (int) $row['issue_count'],
                 lastFetchedAt: self::formatDateTime($row['last_fetched_at'] ?? null),
-            ),
-            $rows,
-        );
+            );
+        }, $rows);
     }
 
     /**

--- a/site/src/Ingestion/MessageHandler/RunSyncChunkHandler.php
+++ b/site/src/Ingestion/MessageHandler/RunSyncChunkHandler.php
@@ -78,7 +78,7 @@ final readonly class RunSyncChunkHandler
         $lock = null;
 
         try {
-            $connector = $this->connectorRegistry->get($job->getSource());
+            $connector = $this->connectorRegistry->get($job->getSource(), $job->getResourceType());
             $lock = $this->rateLimitGuard->acquire(sprintf('%s:%s', $job->getSource()->value, $job->getConnectionRef()));
 
             do {
@@ -93,13 +93,17 @@ final readonly class RunSyncChunkHandler
                     syncJobId: $job->getId(),
                 ));
 
-                $records = $this->rawStorageFacade->store($result->rawBatch);
-                if ($result->normalizeRawRecords) {
-                    foreach ($records as $record) {
-                        $this->messageBus->dispatch(new NormalizeRawRecordMessage($record->getId(), $record->getCompanyId()));
+                if (null !== $result->rawBatch) {
+                    $records = $this->rawStorageFacade->store($result->rawBatch);
+                    if ($result->normalizeRawRecords) {
+                        foreach ($records as $record) {
+                            $this->messageBus->dispatch(new NormalizeRawRecordMessage($record->getId(), $record->getCompanyId()));
+                        }
+                    } else {
+                        $this->markNormalizationSkipped($records);
                     }
-                } else {
-                    $this->markNormalizationSkipped($records);
+                } elseif (!$result->hasMore) {
+                    throw new \RuntimeException('Ingestion connector returned no raw batch without continuation.');
                 }
 
                 if (null !== $result->nextCursorValue && '' !== $result->nextCursorValue) {

--- a/site/src/Marketplace/Facade/MarketplaceFacade.php
+++ b/site/src/Marketplace/Facade/MarketplaceFacade.php
@@ -14,6 +14,7 @@ use App\Marketplace\Enum\MarketplaceConnectionType;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Inventory\CostPriceResolverInterface;
 use App\Marketplace\Infrastructure\Query\CostCategoriesQuery;
+use App\Marketplace\Infrastructure\Query\ActiveOzonPerformanceConnectionsQuery;
 use App\Marketplace\Infrastructure\Query\ListingCostAggregateQuery;
 use App\Marketplace\Infrastructure\Query\ListingMetaQuery;
 use App\Marketplace\Infrastructure\Query\ListingReturnAggregateQuery;
@@ -42,6 +43,7 @@ final readonly class MarketplaceFacade
         private ListingMetaQuery $listingMetaQuery,
         private MarketplaceCredentialsQuery $credentialsQuery,
         private ActiveOzonConnectionsQuery $activeOzonConnectionsQuery,
+        private ActiveOzonPerformanceConnectionsQuery $activeOzonPerformanceConnectionsQuery,
     ) {}
 
     /**
@@ -69,6 +71,37 @@ final readonly class MarketplaceFacade
                 'companyId' => $row['company_id'],
                 'marketplace' => MarketplaceType::OZON->value,
                 'connectionType' => MarketplaceConnectionType::SELLER->value,
+                'clientId' => $row['client_id'],
+            ],
+            $rows,
+        );
+    }
+
+    /**
+     * Публичный безопасный контракт для активных Ozon PERFORMANCE-подключений.
+     *
+     * @return array<int, array{
+     *     connectionId: string,
+     *     companyId: string,
+     *     marketplace: string,
+     *     connectionType: string,
+     *     clientId: ?string
+     * }>
+     */
+    public function getActiveOzonPerformanceConnections(?string $companyId = null): array
+    {
+        if (null !== $companyId) {
+            Assert::uuid($companyId);
+        }
+
+        $rows = $this->activeOzonPerformanceConnectionsQuery->execute($companyId);
+
+        return array_map(
+            static fn (array $row): array => [
+                'connectionId' => $row['id'],
+                'companyId' => $row['company_id'],
+                'marketplace' => MarketplaceType::OZON->value,
+                'connectionType' => MarketplaceConnectionType::PERFORMANCE->value,
                 'clientId' => $row['client_id'],
             ],
             $rows,

--- a/site/src/Marketplace/Facade/MarketplaceFacade.php
+++ b/site/src/Marketplace/Facade/MarketplaceFacade.php
@@ -120,8 +120,13 @@ final readonly class MarketplaceFacade
         string $companyId,
         MarketplaceType $marketplace,
         MarketplaceConnectionType $connectionType,
+        ?string $connectionRef = null,
     ): ?array {
-        return $this->credentialsQuery->getCredentials($companyId, $marketplace, $connectionType);
+        if (null !== $connectionRef) {
+            Assert::uuid($connectionRef);
+        }
+
+        return $this->credentialsQuery->getCredentials($companyId, $marketplace, $connectionType, $connectionRef);
     }
 
     /**

--- a/site/src/Marketplace/Infrastructure/Query/ActiveOzonPerformanceConnectionsQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/ActiveOzonPerformanceConnectionsQuery.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Marketplace\Infrastructure\Query;
+
+use App\Marketplace\Enum\MarketplaceConnectionType;
+use App\Marketplace\Enum\MarketplaceType;
+use Doctrine\DBAL\Connection;
+
+/**
+ * DBAL Query: active Ozon Performance connections for ingestion orchestration.
+ */
+final readonly class ActiveOzonPerformanceConnectionsQuery
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    /**
+     * @return list<array{id: string, company_id: string, client_id: null|string}>
+     */
+    public function execute(?string $companyId = null): array
+    {
+        $sql = <<<'SQL'
+            SELECT mc.id, mc.company_id, mc.client_id
+            FROM marketplace_connections mc
+            WHERE mc.marketplace = :marketplace
+              AND mc.connection_type = :connection_type
+              AND mc.is_active = true
+        SQL;
+
+        $params = [
+            'marketplace' => MarketplaceType::OZON->value,
+            'connection_type' => MarketplaceConnectionType::PERFORMANCE->value,
+        ];
+
+        if (null !== $companyId) {
+            $sql .= ' AND mc.company_id = :company_id';
+            $params['company_id'] = $companyId;
+        }
+
+        $sql .= ' ORDER BY mc.created_at ASC, mc.id ASC';
+
+        return $this->connection->fetchAllAssociative($sql, $params);
+    }
+}

--- a/site/src/Marketplace/Infrastructure/Query/MarketplaceCredentialsQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/MarketplaceCredentialsQuery.php
@@ -21,6 +21,7 @@ final readonly class MarketplaceCredentialsQuery
         string $companyId,
         MarketplaceType $marketplace,
         MarketplaceConnectionType $connectionType = MarketplaceConnectionType::SELLER,
+        ?string $connectionRef = null,
     ): ?array {
         $sql = <<<'SQL'
             SELECT mc.api_key, mc.client_id
@@ -29,14 +30,19 @@ final readonly class MarketplaceCredentialsQuery
               AND mc.marketplace = :marketplace
               AND mc.connection_type = :connection_type
               AND mc.is_active = true
-            LIMIT 1
         SQL;
+
+        if (null !== $connectionRef) {
+            $sql .= ' AND mc.id = :connection_id';
+        }
+
+        $sql .= ' LIMIT 1';
 
         $row = $this->connection->fetchAssociative($sql, [
             'company_id' => $companyId,
             'marketplace' => $marketplace->value,
             'connection_type' => $connectionType->value,
-        ]);
+        ] + (null === $connectionRef ? [] : ['connection_id' => $connectionRef]));
 
         if (false === $row) {
             return null;

--- a/site/tests/Integration/Ingestion/Application/Source/Ozon/OzonIngestionRegistryTest.php
+++ b/site/tests/Integration/Ingestion/Application/Source/Ozon/OzonIngestionRegistryTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\Ingestion\Application\Source\Ozon;
 
 use App\Ingestion\Application\Source\Ozon\OzonAccrualByDayMapper;
 use App\Ingestion\Application\Source\Ozon\OzonAccrualShadowMapper;
+use App\Ingestion\Application\Source\Ozon\OzonPerformanceReportConnector;
 use App\Ingestion\Application\Source\Ozon\OzonResourceType;
 use App\Ingestion\Application\Source\Ozon\OzonSellerReportConnector;
 use App\Ingestion\Domain\Service\ConnectorRegistry;
@@ -23,7 +24,14 @@ final class OzonIngestionRegistryTest extends IntegrationTestCase
         /** @var MapperRegistry $mapperRegistry */
         $mapperRegistry = self::getContainer()->get(MapperRegistry::class);
 
-        self::assertInstanceOf(OzonSellerReportConnector::class, $connectorRegistry->get(IngestSource::OZON));
+        self::assertInstanceOf(
+            OzonSellerReportConnector::class,
+            $connectorRegistry->get(IngestSource::OZON, OzonResourceType::ACCRUAL_BY_DAY),
+        );
+        self::assertInstanceOf(
+            OzonPerformanceReportConnector::class,
+            $connectorRegistry->get(IngestSource::OZON, OzonResourceType::PERFORMANCE_CAMPAIGNS),
+        );
         self::assertInstanceOf(
             OzonAccrualShadowMapper::class,
             $mapperRegistry->get(IngestSource::OZON, OzonResourceType::ACCRUAL_POSTINGS),

--- a/site/tests/Integration/Ingestion/Command/OzonPerformanceLoadCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/OzonPerformanceLoadCommandTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Command;
+
+use App\Company\Entity\Company;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Message\RunSyncChunkMessage;
+use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Enum\MarketplaceConnectionType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+
+final class OzonPerformanceLoadCommandTest extends IntegrationTestCase
+{
+    /**
+     * @var list<string>
+     */
+    private const RESOURCE_TYPES = [
+        OzonResourceType::PERFORMANCE_CAMPAIGNS,
+        OzonResourceType::PERFORMANCE_SKU_CAMPAIGN_OBJECTS,
+        OzonResourceType::PERFORMANCE_SEARCH_PROMO_PRODUCTS,
+        OzonResourceType::PERFORMANCE_SKU_PRODUCT_STATISTICS,
+        OzonResourceType::PERFORMANCE_SEARCH_PROMO_STATISTICS,
+        OzonResourceType::PERFORMANCE_EXPENSE_STATISTICS,
+    ];
+
+    public function testDailyLoadDryRunDoesNotCreateJobs(): void
+    {
+        $company = $this->seedCompany('11111111-1111-1111-1111-00000000a101', 9101);
+        $this->seedPerformanceConnection($company, '77777777-7777-7777-7777-00000000a101');
+        $this->em->flush();
+
+        $transport = $this->getIngestFetchTransport();
+        $transport->reset();
+
+        $tester = $this->tester('app:ingestion:ozon-performance:daily-load');
+        $exit = $tester->execute([
+            '--company-id' => $company->getId(),
+            '--days-back' => '7',
+            '--dry-run' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertStringContainsString('Ozon Performance daily load', $tester->getDisplay());
+        self::assertStringContainsString(OzonResourceType::PERFORMANCE_SEARCH_PROMO_STATISTICS, $tester->getDisplay());
+        self::assertSame(0, $this->syncJobCount($company->getId()));
+        self::assertCount(0, $transport->getSent());
+    }
+
+    public function testDailyLoadExecuteDispatchesAllPerformanceResources(): void
+    {
+        $company = $this->seedCompany('11111111-1111-1111-1111-00000000a102', 9102);
+        $connection = $this->seedPerformanceConnection($company, '77777777-7777-7777-7777-00000000a102');
+        $this->em->flush();
+
+        $transport = $this->getIngestFetchTransport();
+        $transport->reset();
+
+        $tester = $this->tester('app:ingestion:ozon-performance:daily-load');
+        $exit = $tester->execute([
+            '--company-id' => $company->getId(),
+            '--days-back' => '7',
+            '--execute' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertSame($this->sortedResourceTypes(), $this->parentResourceTypes($company->getId()));
+        self::assertSame(array_fill(0, count(self::RESOURCE_TYPES), $connection->getId()), $this->parentShopRefs($company->getId()));
+        self::assertCount(count(self::RESOURCE_TYPES), $transport->getSent());
+        foreach ($transport->getSent() as $envelope) {
+            self::assertInstanceOf(RunSyncChunkMessage::class, $envelope->getMessage());
+        }
+    }
+
+    public function testBackfillExecuteDispatchesAllPerformanceResourcesForExplicitPeriod(): void
+    {
+        $company = $this->seedCompany('11111111-1111-1111-1111-00000000a103', 9103);
+        $this->seedPerformanceConnection($company, '77777777-7777-7777-7777-00000000a103');
+        $this->em->flush();
+
+        $transport = $this->getIngestFetchTransport();
+        $transport->reset();
+
+        $tester = $this->tester('app:ingestion:ozon-performance:backfill');
+        $exit = $tester->execute([
+            '--company-id' => $company->getId(),
+            '--from' => '2026-06-01',
+            '--to' => '2026-06-07',
+            '--execute' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertSame($this->sortedResourceTypes(), $this->parentResourceTypes($company->getId()));
+        self::assertCount(count(self::RESOURCE_TYPES), $transport->getSent());
+    }
+
+    private function seedCompany(string $companyId, int $ownerIndex): Company
+    {
+        $owner = UserBuilder::aUser()
+            ->withIndex($ownerIndex)
+            ->withEmail(sprintf('%s@example.test', str_replace('-', '', $companyId)))
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId($companyId)
+            ->withOwner($owner)
+            ->build();
+
+        $this->em->persist($owner);
+        $this->em->persist($company);
+
+        return $company;
+    }
+
+    private function seedPerformanceConnection(Company $company, string $connectionId): MarketplaceConnection
+    {
+        $connection = new MarketplaceConnection(
+            $connectionId,
+            $company,
+            MarketplaceType::OZON,
+            MarketplaceConnectionType::PERFORMANCE,
+        );
+        $connection->setApiKey('performance-secret');
+        $connection->setClientId('performance-client');
+        $connection->setIsActive(true);
+
+        $this->em->persist($connection);
+
+        return $connection;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function parentResourceTypes(string $companyId): array
+    {
+        $rows = $this->connection->fetchFirstColumn(
+            'SELECT resource_type
+             FROM ingest_sync_jobs
+             WHERE company_id = :companyId AND parent_job_id IS NULL
+             ORDER BY resource_type',
+            ['companyId' => $companyId],
+        );
+
+        return array_map(static fn (mixed $value): string => (string) $value, $rows);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function parentShopRefs(string $companyId): array
+    {
+        $rows = $this->connection->fetchFirstColumn(
+            'SELECT shop_ref
+             FROM ingest_sync_jobs
+             WHERE company_id = :companyId AND parent_job_id IS NULL
+             ORDER BY resource_type',
+            ['companyId' => $companyId],
+        );
+
+        return array_map(static fn (mixed $value): string => (string) $value, $rows);
+    }
+
+    private function syncJobCount(string $companyId): int
+    {
+        return (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM ingest_sync_jobs WHERE company_id = :companyId',
+            ['companyId' => $companyId],
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function sortedResourceTypes(): array
+    {
+        $resourceTypes = self::RESOURCE_TYPES;
+        sort($resourceTypes);
+
+        return $resourceTypes;
+    }
+
+    private function tester(string $commandName): CommandTester
+    {
+        $app = new Application(self::$kernel);
+
+        return new CommandTester($app->find($commandName));
+    }
+
+    private function getIngestFetchTransport(): InMemoryTransport
+    {
+        /** @var InMemoryTransport $transport */
+        $transport = self::getContainer()->get('messenger.transport.ingest_fetch');
+
+        return $transport;
+    }
+}

--- a/site/tests/Integration/Ingestion/Fixtures/FakeConnector.php
+++ b/site/tests/Integration/Ingestion/Fixtures/FakeConnector.php
@@ -26,7 +26,7 @@ final class FakeConnector implements SourceConnectorInterface
     private array $pullRequests = [];
 
     /**
-     * @var list<array{externalId: string, nextCursorValue: ?string, hasMore: bool, rowExternalId: string, normalizeRawRecords: bool, continuationDelaySeconds: ?int}|\Throwable>
+     * @var list<array{externalId: string, nextCursorValue: ?string, hasMore: bool, rowExternalId: string, normalizeRawRecords: bool, continuationDelaySeconds: ?int, rawBatch: bool}|\Throwable>
      */
     private array $queuedPullResults = [];
 
@@ -62,6 +62,20 @@ final class FakeConnector implements SourceConnectorInterface
             'rowExternalId' => $rowExternalId,
             'normalizeRawRecords' => $normalizeRawRecords,
             'continuationDelaySeconds' => $continuationDelaySeconds,
+            'rawBatch' => true,
+        ];
+    }
+
+    public function enqueueContinuationOnly(?string $nextCursorValue, int $continuationDelaySeconds = 70): void
+    {
+        $this->queuedPullResults[] = [
+            'externalId' => 'fake-continuation-only',
+            'nextCursorValue' => $nextCursorValue,
+            'hasMore' => true,
+            'rowExternalId' => '',
+            'normalizeRawRecords' => false,
+            'continuationDelaySeconds' => $continuationDelaySeconds,
+            'rawBatch' => false,
         ];
     }
 
@@ -81,6 +95,14 @@ final class FakeConnector implements SourceConnectorInterface
     public function source(): IngestSource
     {
         return IngestSource::WILDBERRIES;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function resourceTypes(): array
+    {
+        return [self::RESOURCE_TYPE];
     }
 
     /**
@@ -129,7 +151,18 @@ final class FakeConnector implements SourceConnectorInterface
             'rowExternalId' => 'fake-sale-1',
             'normalizeRawRecords' => true,
             'continuationDelaySeconds' => null,
+            'rawBatch' => true,
         ];
+        if (false === $result['rawBatch']) {
+            return new PullResult(
+                rawBatch: null,
+                nextCursorValue: $result['nextCursorValue'],
+                hasMore: $result['hasMore'],
+                normalizeRawRecords: $result['normalizeRawRecords'],
+                continuationDelaySeconds: $result['continuationDelaySeconds'],
+            );
+        }
+
         $operationGroupId = Uuid::uuid7()->toString();
 
         return new PullResult(

--- a/site/tests/Integration/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClientTest.php
+++ b/site/tests/Integration/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClientTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Integration\Ingestion\Infrastructure\Api\Ozon;
 
 use App\Company\Entity\Company;
+use App\Ingestion\Exception\ConnectorAuthException;
 use App\Ingestion\Infrastructure\Api\Ozon\OzonPerformanceReportClient;
 use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Enum\MarketplaceConnectionType;
@@ -54,6 +55,50 @@ final class OzonPerformanceReportClientTest extends IntegrationTestCase
         self::assertSame(['SEARCH_PROMO', 'SKU'], $calls[1]['options']['query']['advObjectType']);
     }
 
+    public function testRejectsMismatchedConnectionRefInsteadOfFallingBackToCompanyCredentials(): void
+    {
+        $company = $this->seedCompany('11111111-1111-4111-8111-00000000b203', 9203);
+        $this->seedPerformanceConnection(
+            $company,
+            '77777777-7777-4777-8777-00000000b203',
+            'performance-client',
+            'performance-secret',
+        );
+        $sellerConnection = $this->seedConnection(
+            $company,
+            '77777777-7777-4777-8777-00000000b204',
+            MarketplaceConnectionType::SELLER,
+            'seller-client',
+            'seller-secret',
+        );
+        $this->em->flush();
+
+        $calls = [];
+        $http = new MockHttpClient(static function (string $method, string $url, array $options = []) use (&$calls): MockResponse {
+            $calls[] = ['method' => $method, 'url' => $url, 'options' => $options];
+
+            if (str_ends_with($url, '/api/client/token')) {
+                return new MockResponse('{"access_token":"second-token","expires_in":1800}', ['http_code' => 200]);
+            }
+            if (str_contains($url, '/api/client/campaign')) {
+                return new MockResponse('{"result":{"list":[{"id":"1"}]}}', ['http_code' => 200]);
+            }
+
+            throw new \LogicException(sprintf('Unexpected request: %s %s', $method, $url));
+        });
+
+        $client = $this->client($http);
+
+        $this->expectException(ConnectorAuthException::class);
+        $this->expectExceptionMessage('Ozon Performance credentials were not found.');
+
+        try {
+            $client->listCampaigns($company->getId(), $sellerConnection->getId(), ['SKU']);
+        } finally {
+            self::assertSame([], $calls);
+        }
+    }
+
     public function testDownloadReportParsesCsvWithBomSemicolonAndQuotedNewlines(): void
     {
         $company = $this->seedCompany('11111111-1111-4111-8111-00000000b202', 9202);
@@ -90,6 +135,7 @@ final class OzonPerformanceReportClientTest extends IntegrationTestCase
         self::assertCount(2, $calls);
         self::assertSame('https://download.example.test/report.csv', $calls[1]['url']);
         self::assertSame([], $calls[1]['options']['query'] ?? []);
+        self::assertStringNotContainsString('Authorization:', implode("\n", $this->headerLines($calls[1]['options'])));
     }
 
     private function client(MockHttpClient $http): OzonPerformanceReportClient
@@ -99,6 +145,7 @@ final class OzonPerformanceReportClientTest extends IntegrationTestCase
             self::getContainer()->get(MarketplaceFacade::class),
             new ArrayAdapter(),
             new NullLogger(),
+            'https://api-performance.ozon.ru',
         );
     }
 
@@ -119,20 +166,52 @@ final class OzonPerformanceReportClientTest extends IntegrationTestCase
         return $company;
     }
 
-    private function seedPerformanceConnection(Company $company, string $connectionId): MarketplaceConnection
-    {
+    private function seedPerformanceConnection(
+        Company $company,
+        string $connectionId,
+        string $clientId = 'performance-client',
+        string $apiKey = 'performance-secret',
+    ): MarketplaceConnection {
+        return $this->seedConnection($company, $connectionId, MarketplaceConnectionType::PERFORMANCE, $clientId, $apiKey);
+    }
+
+    private function seedConnection(
+        Company $company,
+        string $connectionId,
+        MarketplaceConnectionType $connectionType,
+        string $clientId,
+        string $apiKey,
+    ): MarketplaceConnection {
         $connection = new MarketplaceConnection(
             $connectionId,
             $company,
             MarketplaceType::OZON,
-            MarketplaceConnectionType::PERFORMANCE,
+            $connectionType,
         );
-        $connection->setApiKey('performance-secret');
-        $connection->setClientId('performance-client');
+        $connection->setApiKey($apiKey);
+        $connection->setClientId($clientId);
         $connection->setIsActive(true);
 
         $this->em->persist($connection);
 
         return $connection;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @return list<string>
+     */
+    private function headerLines(array $options): array
+    {
+        $headers = $options['headers'] ?? [];
+        if (!is_array($headers)) {
+            return [];
+        }
+
+        return array_values(array_map(
+            static fn (mixed $header): string => is_scalar($header) ? (string) $header : '',
+            $headers,
+        ));
     }
 }

--- a/site/tests/Integration/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClientTest.php
+++ b/site/tests/Integration/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClientTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Infrastructure\Api\Ozon;
+
+use App\Company\Entity\Company;
+use App\Ingestion\Infrastructure\Api\Ozon\OzonPerformanceReportClient;
+use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Enum\MarketplaceConnectionType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Facade\MarketplaceFacade;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class OzonPerformanceReportClientTest extends IntegrationTestCase
+{
+    public function testListCampaignsCachesResponseByConnectionAndTypeSet(): void
+    {
+        $company = $this->seedCompany('11111111-1111-4111-8111-00000000b201', 9201);
+        $connection = $this->seedPerformanceConnection($company, '77777777-7777-4777-8777-00000000b201');
+        $this->em->flush();
+
+        $calls = [];
+        $http = new MockHttpClient(static function (string $method, string $url, array $options = []) use (&$calls): MockResponse {
+            $calls[] = ['method' => $method, 'url' => $url, 'options' => $options];
+
+            if (str_ends_with($url, '/api/client/token')) {
+                return new MockResponse('{"access_token":"test-token","expires_in":1800}', ['http_code' => 200]);
+            }
+            if (str_contains($url, '/api/client/campaign')) {
+                return new MockResponse('{"result":{"list":[{"id":"2"},{"id":"1"}]}}', ['http_code' => 200]);
+            }
+
+            throw new \LogicException(sprintf('Unexpected request: %s %s', $method, $url));
+        });
+
+        $client = $this->client($http);
+
+        $first = $client->listCampaigns($company->getId(), $connection->getId(), ['SKU', 'SEARCH_PROMO']);
+        $second = $client->listCampaigns($company->getId(), $connection->getId(), ['SEARCH_PROMO', 'SKU']);
+
+        self::assertSame([['id' => '1'], ['id' => '2']], $first->rows);
+        self::assertSame($first->rows, $second->rows);
+        self::assertSame(['SEARCH_PROMO', 'SKU'], $first->metadata['advObjectTypes']);
+        self::assertCount(2, $calls);
+        self::assertSame('POST', $calls[0]['method']);
+        self::assertSame('GET', $calls[1]['method']);
+        self::assertSame(['SEARCH_PROMO', 'SKU'], $calls[1]['options']['query']['advObjectType']);
+    }
+
+    public function testDownloadReportParsesCsvWithBomSemicolonAndQuotedNewlines(): void
+    {
+        $company = $this->seedCompany('11111111-1111-4111-8111-00000000b202', 9202);
+        $connection = $this->seedPerformanceConnection($company, '77777777-7777-4777-8777-00000000b202');
+        $this->em->flush();
+
+        $calls = [];
+        $csv = "\xEF\xBB\xBFsku;title;cost\nsku-1;\"Line 1\nLine 2\";12.30\n";
+        $http = new MockHttpClient(static function (string $method, string $url, array $options = []) use (&$calls, $csv): MockResponse {
+            $calls[] = ['method' => $method, 'url' => $url, 'options' => $options];
+
+            if (str_ends_with($url, '/api/client/token')) {
+                return new MockResponse('{"access_token":"test-token","expires_in":1800}', ['http_code' => 200]);
+            }
+            if ('https://download.example.test/report.csv' === $url) {
+                return new MockResponse($csv, ['http_code' => 200]);
+            }
+
+            throw new \LogicException(sprintf('Unexpected request: %s %s', $method, $url));
+        });
+
+        $client = $this->client($http);
+
+        $page = $client->downloadReport($company->getId(), $connection->getId(), 'report-uuid-1', 'https://download.example.test/report.csv');
+
+        self::assertSame([
+            [
+                'sku' => 'sku-1',
+                'title' => "Line 1\nLine 2",
+                'cost' => '12.30',
+                '_ingestion_metadata' => ['reportUuid' => 'report-uuid-1'],
+            ],
+        ], $page->rows);
+        self::assertCount(2, $calls);
+        self::assertSame('https://download.example.test/report.csv', $calls[1]['url']);
+        self::assertSame([], $calls[1]['options']['query'] ?? []);
+    }
+
+    private function client(MockHttpClient $http): OzonPerformanceReportClient
+    {
+        return new OzonPerformanceReportClient(
+            $http,
+            self::getContainer()->get(MarketplaceFacade::class),
+            new ArrayAdapter(),
+            new NullLogger(),
+        );
+    }
+
+    private function seedCompany(string $companyId, int $ownerIndex): Company
+    {
+        $owner = UserBuilder::aUser()
+            ->withIndex($ownerIndex)
+            ->withEmail(sprintf('%s@example.test', str_replace('-', '', $companyId)))
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId($companyId)
+            ->withOwner($owner)
+            ->build();
+
+        $this->em->persist($owner);
+        $this->em->persist($company);
+
+        return $company;
+    }
+
+    private function seedPerformanceConnection(Company $company, string $connectionId): MarketplaceConnection
+    {
+        $connection = new MarketplaceConnection(
+            $connectionId,
+            $company,
+            MarketplaceType::OZON,
+            MarketplaceConnectionType::PERFORMANCE,
+        );
+        $connection->setApiKey('performance-secret');
+        $connection->setClientId('performance-client');
+        $connection->setIsActive(true);
+
+        $this->em->persist($connection);
+
+        return $connection;
+    }
+}

--- a/site/tests/Integration/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClientTest.php
+++ b/site/tests/Integration/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClientTest.php
@@ -138,6 +138,80 @@ final class OzonPerformanceReportClientTest extends IntegrationTestCase
         self::assertStringNotContainsString('Authorization:', implode("\n", $this->headerLines($calls[1]['options'])));
     }
 
+    public function testDownloadReportNormalizesRelativeOzonLinkAndKeepsBearerAuth(): void
+    {
+        $company = $this->seedCompany('11111111-1111-4111-8111-00000000b205', 9205);
+        $connection = $this->seedPerformanceConnection($company, '77777777-7777-4777-8777-00000000b205');
+        $this->em->flush();
+
+        $calls = [];
+        $csv = "sku,cost\nsku-2,45.60\n";
+        $http = new MockHttpClient(static function (string $method, string $url, array $options = []) use (&$calls, $csv): MockResponse {
+            $calls[] = ['method' => $method, 'url' => $url, 'options' => $options];
+
+            if (str_ends_with($url, '/api/client/token')) {
+                return new MockResponse('{"access_token":"relative-token","expires_in":1800}', ['http_code' => 200]);
+            }
+            if ('https://api-performance.ozon.ru/api/client/statistics/report?UUID=report-uuid-2' === $url) {
+                return new MockResponse($csv, ['http_code' => 200]);
+            }
+
+            throw new \LogicException(sprintf('Unexpected request: %s %s', $method, $url));
+        });
+
+        $page = $this->client($http)->downloadReport(
+            $company->getId(),
+            $connection->getId(),
+            'report-uuid-2',
+            '/api/client/statistics/report?UUID=report-uuid-2',
+        );
+
+        self::assertSame('https://api-performance.ozon.ru/api/client/statistics/report?UUID=report-uuid-2', $calls[1]['url']);
+        self::assertStringContainsString('Authorization: Bearer relative-token', implode("\n", $this->headerLines($calls[1]['options'])));
+        self::assertSame('sku-2', $page->rows[0]['sku'] ?? null);
+    }
+
+    public function testDownloadReportExtractsCsvFromZipPayload(): void
+    {
+        if (!class_exists(\ZipArchive::class)) {
+            self::markTestSkipped('ext-zip is required for this test.');
+        }
+
+        $company = $this->seedCompany('11111111-1111-4111-8111-00000000b206', 9206);
+        $connection = $this->seedPerformanceConnection($company, '77777777-7777-4777-8777-00000000b206');
+        $this->em->flush();
+
+        $calls = [];
+        $zip = $this->zipWithCsv("sku;cost\nsku-zip;78.90\n");
+        $http = new MockHttpClient(static function (string $method, string $url, array $options = []) use (&$calls, $zip): MockResponse {
+            $calls[] = ['method' => $method, 'url' => $url, 'options' => $options];
+
+            if (str_ends_with($url, '/api/client/token')) {
+                return new MockResponse('{"access_token":"zip-token","expires_in":1800}', ['http_code' => 200]);
+            }
+            if ('https://download.example.test/report.zip' === $url) {
+                return new MockResponse($zip, ['http_code' => 200]);
+            }
+
+            throw new \LogicException(sprintf('Unexpected request: %s %s', $method, $url));
+        });
+
+        $page = $this->client($http)->downloadReport(
+            $company->getId(),
+            $connection->getId(),
+            'report-uuid-zip',
+            'https://download.example.test/report.zip',
+        );
+
+        self::assertSame([
+            [
+                'sku' => 'sku-zip',
+                'cost' => '78.90',
+                '_ingestion_metadata' => ['reportUuid' => 'report-uuid-zip'],
+            ],
+        ], $page->rows);
+    }
+
     private function client(MockHttpClient $http): OzonPerformanceReportClient
     {
         return new OzonPerformanceReportClient(
@@ -213,5 +287,23 @@ final class OzonPerformanceReportClientTest extends IntegrationTestCase
             static fn (mixed $header): string => is_scalar($header) ? (string) $header : '',
             $headers,
         ));
+    }
+
+    private function zipWithCsv(string $csv): string
+    {
+        $file = tempnam(sys_get_temp_dir(), 'ozon_perf_zip_test_');
+        self::assertIsString($file);
+
+        $zip = new \ZipArchive();
+        self::assertTrue($zip->open($file, \ZipArchive::CREATE | \ZipArchive::OVERWRITE));
+        self::assertTrue($zip->addFromString('report.csv', $csv));
+        self::assertTrue($zip->close());
+
+        $content = file_get_contents($file);
+        @unlink($file);
+
+        self::assertIsString($content);
+
+        return $content;
     }
 }

--- a/site/tests/Integration/Ingestion/MessageHandler/RunSyncChunkHandlerTest.php
+++ b/site/tests/Integration/Ingestion/MessageHandler/RunSyncChunkHandlerTest.php
@@ -344,6 +344,54 @@ final class RunSyncChunkHandlerTest extends IntegrationTestCase
         self::assertSame(RawNormalizationStatus::SKIPPED, $rawRecords[0]->getNormalizationStatus());
     }
 
+    public function testWindowedChunkSchedulesDelayedContinuationWhenConnectorReturnsNoRawBatch(): void
+    {
+        $fakeConnector = $this->fakeConnector();
+        $fakeConnector->reset();
+        $fakeConnector->enqueueContinuationOnly('cursor-page-2', 60);
+
+        $companyId = Uuid::uuid7()->toString();
+        $job = new SyncJob(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            source: IngestSource::WILDBERRIES,
+            resourceType: FakeConnector::RESOURCE_TYPE,
+            kind: SyncJobKind::BACKFILL,
+            windowFrom: new \DateTimeImmutable('2026-06-01'),
+            windowTo: new \DateTimeImmutable('2026-06-01'),
+            shopRef: 'shop-1',
+        );
+
+        $this->em->persist($job);
+        $this->em->flush();
+
+        $fetchTransport = $this->getFetchTransport();
+        $fetchTransport->reset();
+        $this->getNormalizeTransport()->reset();
+
+        /** @var RunSyncChunkHandler $handler */
+        $handler = self::getContainer()->get(RunSyncChunkHandler::class);
+        $handler(new RunSyncChunkMessage($companyId, $job->getId()));
+        $this->em->clear();
+
+        self::assertCount(1, $fakeConnector->pullRequests());
+
+        $sent = $fetchTransport->getSent();
+        self::assertCount(1, $sent);
+
+        /** @var RunSyncChunkMessage $continuation */
+        $continuation = $sent[0]->getMessage();
+        self::assertSame('cursor-page-2', $continuation->cursorValue);
+
+        $delayStamps = $sent[0]->all(DelayStamp::class);
+        self::assertCount(1, $delayStamps);
+        self::assertSame(60000, $delayStamps[0]->getDelay());
+
+        /** @var IngestRawRecordRepository $rawRecordRepository */
+        $rawRecordRepository = self::getContainer()->get(IngestRawRecordRepository::class);
+        self::assertSame([], $rawRecordRepository->findBy(['companyId' => $companyId, 'syncJobId' => $job->getId()]));
+    }
+
     public function testRateLimitContinuationUsesCurrentCursorAfterSuccessfulChunk(): void
     {
         $fakeConnector = $this->fakeConnector();

--- a/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonPerformanceReportConnectorTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonPerformanceReportConnectorTest.php
@@ -9,6 +9,7 @@ use App\Ingestion\Application\DTO\PushRequest;
 use App\Ingestion\Application\Source\Ozon\OzonPerformanceReportConnector;
 use App\Ingestion\Application\Source\Ozon\OzonResourceType;
 use App\Ingestion\Enum\Capability;
+use App\Ingestion\Exception\ConnectorTransientException;
 use App\Ingestion\Exception\UnsupportedCapabilityException;
 use App\Ingestion\Infrastructure\Api\Ozon\OzonPerformanceReportClientInterface;
 use App\Ingestion\Infrastructure\Api\Ozon\OzonRawPage;
@@ -92,8 +93,44 @@ final class OzonPerformanceReportConnectorTest extends TestCase
         self::assertNull($result->rawBatch);
         self::assertTrue($result->hasMore);
         self::assertSame(60, $result->continuationDelaySeconds);
-        self::assertSame('{"batchOffset":0,"reportType":"products","state":"poll","uuid":"report-uuid-1"}', $result->nextCursorValue);
+        self::assertSame(
+            '{"batchOffset":0,"reportType":"products","state":"poll","uuid":"report-uuid-1","pollAttempts":0,"pollStartedAt":"2026-06-27T12:00:00+00:00"}',
+            $result->nextCursorValue,
+        );
         self::assertSame([['products', ['search-1']]], $client->generatedReports);
+    }
+
+    public function testSearchPromoStatisticsRequeuesPollWithIncrementedAttempt(): void
+    {
+        $client = new FakeOzonPerformanceReportClient();
+        $client->campaignsByType['SEARCH_PROMO'] = [['id' => 'search-1']];
+
+        $result = $this->connector($client)->pull($this->request(
+            OzonResourceType::PERFORMANCE_SEARCH_PROMO_STATISTICS,
+            cursorValue: '{"batchOffset":0,"reportType":"products","state":"poll","uuid":"report-uuid-1","pollAttempts":2,"pollStartedAt":"2026-06-27T11:55:00+00:00"}',
+        ));
+
+        self::assertNull($result->rawBatch);
+        self::assertTrue($result->hasMore);
+        self::assertSame(60, $result->continuationDelaySeconds);
+        self::assertSame(
+            '{"batchOffset":0,"reportType":"products","state":"poll","uuid":"report-uuid-1","pollAttempts":3,"pollStartedAt":"2026-06-27T11:55:00+00:00"}',
+            $result->nextCursorValue,
+        );
+    }
+
+    public function testSearchPromoStatisticsFailsWhenReportPollingExceedsTimeout(): void
+    {
+        $client = new FakeOzonPerformanceReportClient();
+        $client->campaignsByType['SEARCH_PROMO'] = [['id' => 'search-1']];
+
+        $this->expectException(ConnectorTransientException::class);
+        $this->expectExceptionMessage('Ozon Search Promo report report-uuid-1 was not ready');
+
+        $this->connector($client)->pull($this->request(
+            OzonResourceType::PERFORMANCE_SEARCH_PROMO_STATISTICS,
+            cursorValue: '{"batchOffset":0,"reportType":"products","state":"poll","uuid":"report-uuid-1","pollAttempts":12,"pollStartedAt":"2026-06-27T10:59:59+00:00"}',
+        ));
     }
 
     public function testSearchPromoStatisticsPollsAndStoresDownloadedReport(): void

--- a/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonPerformanceReportConnectorTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonPerformanceReportConnectorTest.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Application\Source\Ozon;
+
+use App\Ingestion\Application\DTO\PullRequest;
+use App\Ingestion\Application\DTO\PushRequest;
+use App\Ingestion\Application\Source\Ozon\OzonPerformanceReportConnector;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Enum\Capability;
+use App\Ingestion\Exception\UnsupportedCapabilityException;
+use App\Ingestion\Infrastructure\Api\Ozon\OzonPerformanceReportClientInterface;
+use App\Ingestion\Infrastructure\Api\Ozon\OzonRawPage;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Clock\MockClock;
+
+final class OzonPerformanceReportConnectorTest extends TestCase
+{
+    public function testCapabilitiesResourcesDiscoverAndUnsupportedPush(): void
+    {
+        $connector = $this->connector(new FakeOzonPerformanceReportClient());
+        $connectionRef = Uuid::uuid7()->toString();
+
+        self::assertSame([Capability::CAN_DISCOVER_SHOPS, Capability::CAN_PULL], $connector->capabilities());
+        self::assertContains(OzonResourceType::PERFORMANCE_CAMPAIGNS, $connector->resourceTypes());
+        self::assertContains(OzonResourceType::PERFORMANCE_SEARCH_PROMO_STATISTICS, $connector->resourceTypes());
+        self::assertSame($connectionRef, $connector->discoverShops(Uuid::uuid7()->toString(), $connectionRef)[0]->externalId);
+
+        $this->expectException(UnsupportedCapabilityException::class);
+        $connector->push(new PushRequest(
+            companyId: Uuid::uuid7()->toString(),
+            connectionRef: $connectionRef,
+            documentType: 'doc',
+            payload: [],
+            idempotencyKey: 'key-1',
+        ));
+    }
+
+    public function testPullCampaignCatalogStoresRawOnlyBatch(): void
+    {
+        $client = new FakeOzonPerformanceReportClient();
+        $client->campaignsByType['SKU'] = [['id' => '10', 'title' => 'SKU campaign']];
+        $client->campaignsByType['SEARCH_PROMO'] = [['id' => '20', 'title' => 'Search campaign']];
+
+        $result = $this->connector($client)->pull($this->request(OzonResourceType::PERFORMANCE_CAMPAIGNS));
+
+        self::assertNotNull($result->rawBatch);
+        self::assertSame(OzonResourceType::PERFORMANCE_CAMPAIGNS, $result->rawBatch->resourceType);
+        self::assertSame('performance-campaigns:2026-06-01:2026-06-07', $result->rawBatch->externalId);
+        self::assertFalse($result->normalizeRawRecords);
+        self::assertFalse($result->hasMore);
+        self::assertSame([
+            ['id' => '10', 'title' => 'SKU campaign'],
+            ['id' => '20', 'title' => 'Search campaign'],
+        ], $result->rawBatch->rows);
+    }
+
+    public function testPullSkuStatisticsBatchesCampaignIdsByTen(): void
+    {
+        $client = new FakeOzonPerformanceReportClient();
+        $client->campaignsByType['SKU'] = array_map(
+            static fn (int $id): array => ['id' => (string) $id],
+            range(1, 12),
+        );
+
+        $connector = $this->connector($client);
+        $first = $connector->pull($this->request(OzonResourceType::PERFORMANCE_SKU_PRODUCT_STATISTICS));
+
+        self::assertTrue($first->hasMore);
+        self::assertSame('{"batchOffset":10}', $first->nextCursorValue);
+        self::assertSame([['1', '2', '3', '4', '5', '6', '7', '8', '9', '10']], $client->skuStatsCampaignCalls);
+
+        $second = $connector->pull($this->request(
+            OzonResourceType::PERFORMANCE_SKU_PRODUCT_STATISTICS,
+            cursorValue: $first->nextCursorValue,
+        ));
+
+        self::assertFalse($second->hasMore);
+        self::assertNull($second->nextCursorValue);
+        self::assertSame(['11', '12'], $client->skuStatsCampaignCalls[1]);
+    }
+
+    public function testSearchPromoStatisticsGeneratesAsyncReportBeforeRawBatch(): void
+    {
+        $client = new FakeOzonPerformanceReportClient();
+        $client->campaignsByType['SEARCH_PROMO'] = [['id' => 'search-1']];
+
+        $result = $this->connector($client)->pull($this->request(OzonResourceType::PERFORMANCE_SEARCH_PROMO_STATISTICS));
+
+        self::assertNull($result->rawBatch);
+        self::assertTrue($result->hasMore);
+        self::assertSame(60, $result->continuationDelaySeconds);
+        self::assertSame('{"batchOffset":0,"reportType":"products","state":"poll","uuid":"report-uuid-1"}', $result->nextCursorValue);
+        self::assertSame([['products', ['search-1']]], $client->generatedReports);
+    }
+
+    public function testSearchPromoStatisticsPollsAndStoresDownloadedReport(): void
+    {
+        $client = new FakeOzonPerformanceReportClient();
+        $client->campaignsByType['SEARCH_PROMO'] = [['id' => 'search-1']];
+        $client->readyReports['report-uuid-1'] = 'https://example.test/report.csv';
+
+        $result = $this->connector($client)->pull($this->request(
+            OzonResourceType::PERFORMANCE_SEARCH_PROMO_STATISTICS,
+            cursorValue: '{"batchOffset":0,"reportType":"products","state":"poll","uuid":"report-uuid-1"}',
+        ));
+
+        self::assertNotNull($result->rawBatch);
+        self::assertSame(OzonResourceType::PERFORMANCE_SEARCH_PROMO_STATISTICS, $result->rawBatch->resourceType);
+        self::assertSame('performance-search-promo-stats:2026-06-01:2026-06-07:products:batch:de72244d92630c60', $result->rawBatch->externalId);
+        self::assertTrue($result->hasMore);
+        self::assertSame('{"batchOffset":0,"reportType":"orders","state":"request"}', $result->nextCursorValue);
+        self::assertSame([['sku' => 'sku-1', '_ingestion_metadata' => ['reportUuid' => 'report-uuid-1']]], $result->rawBatch->rows);
+    }
+
+    private function connector(OzonPerformanceReportClientInterface $client): OzonPerformanceReportConnector
+    {
+        return new OzonPerformanceReportConnector($client, new MockClock('2026-06-27 12:00:00 UTC'));
+    }
+
+    private function request(string $resourceType, ?string $cursorValue = null): PullRequest
+    {
+        return new PullRequest(
+            companyId: Uuid::uuid7()->toString(),
+            connectionRef: 'performance-connection-1',
+            shopRef: 'performance-connection-1',
+            resourceType: $resourceType,
+            cursorValue: $cursorValue,
+            windowFrom: new \DateTimeImmutable('2026-06-01'),
+            windowTo: new \DateTimeImmutable('2026-06-07'),
+            syncJobId: Uuid::uuid7()->toString(),
+        );
+    }
+}
+
+final class FakeOzonPerformanceReportClient implements OzonPerformanceReportClientInterface
+{
+    /**
+     * @var array<string, list<array<string, mixed>>>
+     */
+    public array $campaignsByType = [];
+
+    /**
+     * @var list<list<string>>
+     */
+    public array $skuStatsCampaignCalls = [];
+
+    /**
+     * @var list<array{0: string, 1: list<string>}>
+     */
+    public array $generatedReports = [];
+
+    /**
+     * @var array<string, string>
+     */
+    public array $readyReports = [];
+
+    public function listCampaigns(string $companyId, string $connectionRef, array $advObjectTypes = []): OzonRawPage
+    {
+        $rows = [];
+        foreach ($advObjectTypes as $type) {
+            array_push($rows, ...($this->campaignsByType[$type] ?? []));
+        }
+
+        return new OzonRawPage($rows, false, metadata: ['advObjectTypes' => $advObjectTypes]);
+    }
+
+    public function fetchCampaignObjects(string $companyId, string $connectionRef, string $campaignId): OzonRawPage
+    {
+        return new OzonRawPage([['campaign_id' => $campaignId, 'sku' => 'sku-1']], false);
+    }
+
+    public function fetchSearchPromoProducts(string $companyId, string $connectionRef, string $campaignId, int $page): OzonRawPage
+    {
+        return new OzonRawPage([['campaign_id' => $campaignId, 'page' => $page, 'sku' => 'sku-1']], false);
+    }
+
+    public function fetchSkuProductStatistics(
+        string $companyId,
+        string $connectionRef,
+        \DateTimeImmutable $dateFrom,
+        \DateTimeImmutable $dateTo,
+        array $campaignIds,
+    ): OzonRawPage {
+        $this->skuStatsCampaignCalls[] = $campaignIds;
+
+        return new OzonRawPage([['campaignIds' => $campaignIds]], false);
+    }
+
+    public function generateSearchPromoReport(
+        string $companyId,
+        string $connectionRef,
+        string $reportType,
+        \DateTimeImmutable $dateFrom,
+        \DateTimeImmutable $dateTo,
+        array $campaignIds,
+    ): string {
+        $this->generatedReports[] = [$reportType, $campaignIds];
+
+        return 'report-uuid-1';
+    }
+
+    public function pollReport(string $companyId, string $connectionRef, string $reportUuid): ?string
+    {
+        return $this->readyReports[$reportUuid] ?? null;
+    }
+
+    public function downloadReport(string $companyId, string $connectionRef, string $reportUuid, string $reportLink): OzonRawPage
+    {
+        return new OzonRawPage([['sku' => 'sku-1', '_ingestion_metadata' => ['reportUuid' => $reportUuid]]], false);
+    }
+
+    public function fetchExpenseStatistics(
+        string $companyId,
+        string $connectionRef,
+        \DateTimeImmutable $dateFrom,
+        \DateTimeImmutable $dateTo,
+    ): OzonRawPage {
+        return new OzonRawPage([['cost' => '12.34']], false);
+    }
+}

--- a/site/tests/Unit/Ingestion/Domain/Service/ConnectorRegistryTest.php
+++ b/site/tests/Unit/Ingestion/Domain/Service/ConnectorRegistryTest.php
@@ -20,12 +20,12 @@ final class ConnectorRegistryTest extends TestCase
 {
     public function testReturnsConnectorBySource(): void
     {
-        $connector = $this->connector(IngestSource::OZON);
+        $connector = $this->connector(IngestSource::OZON, ['ozon_resource']);
         $registry = new ConnectorRegistry([$connector]);
 
-        self::assertTrue($registry->has(IngestSource::OZON));
-        self::assertSame($connector, $registry->get(IngestSource::OZON));
-        self::assertFalse($registry->has(IngestSource::WILDBERRIES));
+        self::assertTrue($registry->has(IngestSource::OZON, 'ozon_resource'));
+        self::assertSame($connector, $registry->get(IngestSource::OZON, 'ozon_resource'));
+        self::assertFalse($registry->has(IngestSource::WILDBERRIES, 'wb_resource'));
     }
 
     public function testMissingConnectorThrowsDomainException(): void
@@ -33,29 +33,53 @@ final class ConnectorRegistryTest extends TestCase
         $registry = new ConnectorRegistry([]);
 
         $this->expectException(ConnectorNotFoundException::class);
-        $registry->get(IngestSource::OZON);
+        $registry->get(IngestSource::OZON, 'ozon_resource');
     }
 
-    public function testDuplicateSourceIsRejected(): void
+    public function testDuplicateSourceAndResourceIsRejected(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
         new ConnectorRegistry([
-            $this->connector(IngestSource::OZON),
-            $this->connector(IngestSource::OZON),
+            $this->connector(IngestSource::OZON, ['ozon_resource']),
+            $this->connector(IngestSource::OZON, ['ozon_resource']),
         ]);
     }
 
-    private function connector(IngestSource $source): SourceConnectorInterface
+    public function testSameSourceWithDifferentResourcesIsAllowed(): void
     {
-        return new class($source) implements SourceConnectorInterface {
-            public function __construct(private readonly IngestSource $source)
+        $first = $this->connector(IngestSource::OZON, ['first_resource']);
+        $second = $this->connector(IngestSource::OZON, ['second_resource']);
+        $registry = new ConnectorRegistry([$first, $second]);
+
+        self::assertSame($first, $registry->get(IngestSource::OZON, 'first_resource'));
+        self::assertSame($second, $registry->get(IngestSource::OZON, 'second_resource'));
+    }
+
+    /**
+     * @param list<string> $resourceTypes
+     */
+    private function connector(IngestSource $source, array $resourceTypes): SourceConnectorInterface
+    {
+        return new class($source, $resourceTypes) implements SourceConnectorInterface {
+            /**
+             * @param list<string> $resourceTypes
+             */
+            public function __construct(private readonly IngestSource $source, private readonly array $resourceTypes)
             {
             }
 
             public function source(): IngestSource
             {
                 return $this->source;
+            }
+
+            /**
+             * @return list<string>
+             */
+            public function resourceTypes(): array
+            {
+                return $this->resourceTypes;
             }
 
             /**


### PR DESCRIPTION
## Summary

- Adds raw-only Ozon Performance ingestion in the existing Ingestion module.
- Adds Performance API client, connector, daily/backfill dispatch commands, and source+resource connector routing.
- Adds readable coverage labels/groups for new Performance resources.
- Adds research/plan/handoff docs under `docs/tasks/ozon`.

## Review fixes

- Caches `listCampaigns()` responses for 5 minutes by `companyId + connectionRef + advObjectTypes` to reduce redundant `/api/client/campaign` calls.
- Optimizes raw row sorting by precomputing JSON sort keys before sorting.
- Reworks CSV report parsing to stream-based `fgetcsv()` with BOM handling, `;`/`,` separator detection, quoted newline support, and `escape=''`.
- Scopes Ozon Performance credentials lookup by `connectionRef` instead of falling back to any company Performance connection.
- Separates Performance access-token cache by `companyId + connectionRef`.
- Stops sending `Authorization: Bearer ...` to pre-signed external report download URLs.
- Normalizes relative Ozon report links against `OZON_PERFORMANCE_API_BASE_URL` and keeps bearer auth for Ozon API report URLs.
- Extracts CSV files from ZIP async report payloads before parsing.
- Bounds Search Promo async report polling with cursor `pollStartedAt`/`pollAttempts`; stale never-ready reports now fail instead of requeueing forever.
- Moves the Performance API base URL to `OZON_PERFORMANCE_API_BASE_URL` with default `https://api-performance.ozon.ru`.
- Makes `IngestionResourceLabelProvider` `final readonly`.
- Adds integration/unit coverage for campaign caching, connection-scoped credentials, report download auth headers, ZIP reports, relative report URLs, and bounded polling.

## Pagination note

- Did not add pagination to `GET /api/client/campaign`: the currently available official Ozon Performance docs snapshot does not confirm a `page`/`pageSize`/`offset` contract for this endpoint. No live Ozon API calls were made to infer undocumented behavior.

## Validation

- `php -l` on changed PHP files
- `php bin/phpunit --testsuite unit --filter "ConnectorRegistryTest|OzonPerformanceReportConnectorTest"`
- `php bin/phpunit --testsuite integration --filter "OzonPerformanceReportClientTest|OzonIngestionRegistryTest|RunSyncChunkHandlerTest|OzonPerformanceLoadCommandTest"`
- `make site-test-unit` — passed; existing warning/deprecation are unrelated to this PR
- Symfony test command discovery for `app:ingestion:ozon-performance`
- GitHub checks are green after commit `a8f7f8b4`.

## Notes

- No migrations.
- No cron or worker config changes.
- No live Ozon API calls were made during validation.
- Performance normalization is intentionally out of scope for this stage.