### PR TITLE
[codex] Fix Ozon Performance campaign filters

### DIFF
--- a/site/src/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClient.php
+++ b/site/src/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClient.php
@@ -51,23 +51,26 @@ final readonly class OzonPerformanceReportClient implements OzonPerformanceRepor
     public function listCampaigns(string $companyId, string $connectionRef, array $advObjectTypes = []): OzonRawPage
     {
         $advObjectTypes = $this->normalizeStringList($advObjectTypes);
-        $query = [];
-        if ([] !== $advObjectTypes) {
-            $query['advObjectType'] = $advObjectTypes;
-        }
-
         $cacheKey = $this->campaignCacheKey($companyId, $connectionRef, $advObjectTypes);
 
-        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($companyId, $connectionRef, $query, $advObjectTypes): OzonRawPage {
+        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($companyId, $connectionRef, $advObjectTypes): OzonRawPage {
             $item->expiresAfter(self::CAMPAIGN_CACHE_TTL_SECONDS);
 
-            $payload = $this->requestJson($companyId, $connectionRef, 'GET', self::CAMPAIGN_PATH, ['query' => $query]);
-            $rows = $this->extractRows($payload);
+            $rows = [];
+            $resultKeys = [];
+            foreach ([] === $advObjectTypes ? [null] : $advObjectTypes as $advObjectType) {
+                $options = null === $advObjectType ? [] : ['query' => ['advObjectType' => $advObjectType]];
+                $payload = $this->requestJson($companyId, $connectionRef, 'GET', self::CAMPAIGN_PATH, $options);
+                array_push($rows, ...$this->extractRows($payload));
+                foreach (array_keys($payload) as $key) {
+                    $resultKeys[$key] = true;
+                }
+            }
 
             return new OzonRawPage($this->sortRows($rows), false, null, [
                 'endpoint' => self::CAMPAIGN_PATH,
                 'advObjectTypes' => $advObjectTypes,
-                'resultKeys' => array_keys($payload),
+                'resultKeys' => array_keys($resultKeys),
             ]);
         });
     }

--- a/site/tests/Integration/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClientTest.php
+++ b/site/tests/Integration/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClientTest.php
@@ -35,7 +35,15 @@ final class OzonPerformanceReportClientTest extends IntegrationTestCase
                 return new MockResponse('{"access_token":"test-token","expires_in":1800}', ['http_code' => 200]);
             }
             if (str_contains($url, '/api/client/campaign')) {
-                return new MockResponse('{"result":{"list":[{"id":"2"},{"id":"1"}]}}', ['http_code' => 200]);
+                $advObjectType = $options['query']['advObjectType'] ?? null;
+                if ('SEARCH_PROMO' === $advObjectType) {
+                    return new MockResponse('{"result":{"list":[{"id":"2","advObjectType":"SEARCH_PROMO"}]}}', ['http_code' => 200]);
+                }
+                if ('SKU' === $advObjectType) {
+                    return new MockResponse('{"result":{"list":[{"id":"1","advObjectType":"SKU"}]}}', ['http_code' => 200]);
+                }
+
+                throw new \LogicException(sprintf('Unexpected campaign query: %s', json_encode($options['query'] ?? [])));
             }
 
             throw new \LogicException(sprintf('Unexpected request: %s %s', $method, $url));
@@ -46,13 +54,18 @@ final class OzonPerformanceReportClientTest extends IntegrationTestCase
         $first = $client->listCampaigns($company->getId(), $connection->getId(), ['SKU', 'SEARCH_PROMO']);
         $second = $client->listCampaigns($company->getId(), $connection->getId(), ['SEARCH_PROMO', 'SKU']);
 
-        self::assertSame([['id' => '1'], ['id' => '2']], $first->rows);
+        self::assertSame([
+            ['id' => '1', 'advObjectType' => 'SKU'],
+            ['id' => '2', 'advObjectType' => 'SEARCH_PROMO'],
+        ], $first->rows);
         self::assertSame($first->rows, $second->rows);
         self::assertSame(['SEARCH_PROMO', 'SKU'], $first->metadata['advObjectTypes']);
-        self::assertCount(2, $calls);
+        self::assertCount(3, $calls);
         self::assertSame('POST', $calls[0]['method']);
         self::assertSame('GET', $calls[1]['method']);
-        self::assertSame(['SEARCH_PROMO', 'SKU'], $calls[1]['options']['query']['advObjectType']);
+        self::assertSame('GET', $calls[2]['method']);
+        self::assertSame('SEARCH_PROMO', $calls[1]['options']['query']['advObjectType']);
+        self::assertSame('SKU', $calls[2]['options']['query']['advObjectType']);
     }
 
     public function testRejectsMismatchedConnectionRefInsteadOfFallingBackToCompanyCredentials(): void


### PR DESCRIPTION
## What changed
- Changed Ozon Performance campaign loading to call `/api/client/campaign` once per `advObjectType` instead of sending multiple values in one request.
- Merges and sorts campaign rows under the existing combined cache key.
- Updated integration coverage to assert scalar `advObjectType` requests for `SEARCH_PROMO` and `SKU`.

## Why
Production smoke test showed Ozon returns HTTP 400 for requests like:

`too many values for field "adv_object_type": 0, SEARCH_PROMO`

That means the endpoint accepts only one advertising object type per request.

## Checks
- `php -l src/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClient.php`
- `php -l tests/Integration/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClientTest.php`
- `APP_ENV=test php -d memory_limit=1G bin/phpunit --testsuite unit --filter "ConnectorRegistryTest|OzonPerformanceReportConnectorTest"`
- `APP_ENV=test php -d memory_limit=1G bin/phpunit --testsuite integration --filter "OzonPerformanceReportClientTest|OzonIngestionRegistryTest|RunSyncChunkHandlerTest|OzonPerformanceLoadCommandTest"`
- `make site-test-unit`
