### PR TITLE
[codex] Harden Ozon Performance rate limits

### DIFF
--- a/site/src/Ingestion/Application/Action/SplitJobIntoChunksAction.php
+++ b/site/src/Ingestion/Application/Action/SplitJobIntoChunksAction.php
@@ -14,6 +14,7 @@ use App\Ingestion\Message\RunSyncChunkMessage;
 use App\Ingestion\Repository\SyncJobRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
 
 final readonly class SplitJobIntoChunksAction
 {
@@ -64,8 +65,11 @@ final readonly class SplitJobIntoChunksAction
         $parent->markRunning();
         $this->entityManager->flush();
 
-        foreach ($chunkIds as $chunkId) {
-            $this->messageBus->dispatch(new RunSyncChunkMessage($command->companyId, $chunkId));
+        foreach ($chunkIds as $index => $chunkId) {
+            $delaySeconds = $command->initialDelaySeconds + ($index * $command->chunkDelayStepSeconds);
+            $stamps = $delaySeconds > 0 ? [new DelayStamp($delaySeconds * 1000)] : [];
+
+            $this->messageBus->dispatch(new RunSyncChunkMessage($command->companyId, $chunkId), $stamps);
         }
 
         return $chunkIds;

--- a/site/src/Ingestion/Application/Command/SplitJobCommand.php
+++ b/site/src/Ingestion/Application/Command/SplitJobCommand.php
@@ -12,9 +12,13 @@ final readonly class SplitJobCommand
         public string $parentJobId,
         public string $companyId,
         public int $chunkSizeInDays = 7,
+        public int $initialDelaySeconds = 0,
+        public int $chunkDelayStepSeconds = 0,
     ) {
         Assert::uuid($this->parentJobId);
         Assert::uuid($this->companyId);
         Assert::range($this->chunkSizeInDays, 1, 90);
+        Assert::range($this->initialDelaySeconds, 0, 86400);
+        Assert::range($this->chunkDelayStepSeconds, 0, 86400);
     }
 }

--- a/site/src/Ingestion/Application/Command/StartBackfillCommand.php
+++ b/site/src/Ingestion/Application/Command/StartBackfillCommand.php
@@ -17,10 +17,14 @@ final readonly class StartBackfillCommand
         public string $shopRef,
         public \DateTimeImmutable $windowFrom,
         public \DateTimeImmutable $windowTo,
+        public int $initialDelaySeconds = 0,
+        public int $chunkDelayStepSeconds = 0,
     ) {
         Assert::uuid($this->companyId);
         Assert::notEmpty($this->connectionRef);
         Assert::notEmpty($this->resourceType);
         Assert::lessThanEq($this->windowFrom, $this->windowTo);
+        Assert::range($this->initialDelaySeconds, 0, 86400);
+        Assert::range($this->chunkDelayStepSeconds, 0, 86400);
     }
 }

--- a/site/src/Ingestion/Command/OzonPerformanceBackfillCommand.php
+++ b/site/src/Ingestion/Command/OzonPerformanceBackfillCommand.php
@@ -37,6 +37,21 @@ final class OzonPerformanceBackfillCommand extends Command
         OzonResourceType::PERFORMANCE_EXPENSE_STATISTICS,
     ];
 
+    /**
+     * @var list<string>
+     */
+    private const CAMPAIGN_BACKED_RESOURCE_TYPES = [
+        OzonResourceType::PERFORMANCE_CAMPAIGNS,
+        OzonResourceType::PERFORMANCE_SKU_CAMPAIGN_OBJECTS,
+        OzonResourceType::PERFORMANCE_SEARCH_PROMO_PRODUCTS,
+        OzonResourceType::PERFORMANCE_SKU_PRODUCT_STATISTICS,
+        OzonResourceType::PERFORMANCE_SEARCH_PROMO_STATISTICS,
+    ];
+
+    private const BACKFILL_CHUNK_SIZE_DAYS = 7;
+    private const DEFAULT_DISPATCH_SPACING_SECONDS = 120;
+    private const MAX_DISPATCH_SPACING_SECONDS = 3600;
+
     public function __construct(
         private readonly MarketplaceFacade $marketplaceFacade,
         private readonly SyncFacade $syncFacade,
@@ -51,6 +66,7 @@ final class OzonPerformanceBackfillCommand extends Command
             ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Company UUID.')
             ->addOption('from', null, InputOption::VALUE_REQUIRED, 'Start date, YYYY-MM-DD.')
             ->addOption('to', null, InputOption::VALUE_REQUIRED, 'End date, YYYY-MM-DD.')
+            ->addOption('dispatch-spacing-seconds', null, InputOption::VALUE_REQUIRED, 'Delay between campaign-backed job dispatches, 0..3600.', self::DEFAULT_DISPATCH_SPACING_SECONDS)
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Print planned jobs without dispatching them.')
             ->addOption('execute', null, InputOption::VALUE_NONE, 'Dispatch jobs.');
     }
@@ -70,6 +86,7 @@ final class OzonPerformanceBackfillCommand extends Command
             $from = $this->dateOption($input, 'from');
             $to = $this->dateOption($input, 'to');
             Assert::lessThanEq($from, $to, 'The --from date must be less than or equal to --to.');
+            $dispatchSpacingSeconds = $this->dispatchSpacingSeconds($input);
         } catch (\Throwable $exception) {
             $io->error($exception->getMessage());
 
@@ -83,26 +100,35 @@ final class OzonPerformanceBackfillCommand extends Command
             return Command::SUCCESS;
         }
 
-        return $this->dispatch($io, $connections, $from, $to, $dryRun);
+        return $this->dispatch($io, $connections, $from, $to, $dryRun, $dispatchSpacingSeconds);
     }
 
     /**
      * @param list<array{connectionId: string, companyId: string, marketplace: string, connectionType: string, clientId: ?string}> $connections
      */
-    private function dispatch(SymfonyStyle $io, array $connections, \DateTimeImmutable $from, \DateTimeImmutable $to, bool $dryRun): int
+    private function dispatch(SymfonyStyle $io, array $connections, \DateTimeImmutable $from, \DateTimeImmutable $to, bool $dryRun, int $dispatchSpacingSeconds): int
     {
         $rows = [];
         $started = 0;
         $skippedActive = 0;
         $failed = 0;
+        $nextCampaignDelaySeconds = 0;
+        $chunkCount = $this->chunkCount($from, $to);
 
         foreach ($connections as $connection) {
             $companyId = $connection['companyId'];
             $connectionRef = $connection['connectionId'];
 
             foreach (self::RESOURCE_TYPES as $resourceType) {
+                $campaignBacked = $this->isCampaignBackedResource($resourceType);
+                $initialDelaySeconds = $campaignBacked ? $nextCampaignDelaySeconds : 0;
+                $chunkDelayStepSeconds = $campaignBacked ? $dispatchSpacingSeconds : 0;
+                if ($campaignBacked) {
+                    $nextCampaignDelaySeconds += $dispatchSpacingSeconds * $chunkCount;
+                }
+
                 if ($dryRun) {
-                    $rows[] = [$companyId, $connectionRef, $resourceType, $from->format('Y-m-d'), $to->format('Y-m-d'), 'dry-run'];
+                    $rows[] = [$companyId, $connectionRef, $resourceType, $from->format('Y-m-d'), $to->format('Y-m-d'), $this->delayLabel($initialDelaySeconds, $chunkDelayStepSeconds), 'dry-run'];
                     continue;
                 }
 
@@ -115,15 +141,17 @@ final class OzonPerformanceBackfillCommand extends Command
                         shopRef: $connectionRef,
                         windowFrom: $from,
                         windowTo: $to,
+                        initialDelaySeconds: $initialDelaySeconds,
+                        chunkDelayStepSeconds: $chunkDelayStepSeconds,
                     ));
                     ++$started;
-                    $rows[] = [$companyId, $connectionRef, $resourceType, $from->format('Y-m-d'), $to->format('Y-m-d'), $jobId];
+                    $rows[] = [$companyId, $connectionRef, $resourceType, $from->format('Y-m-d'), $to->format('Y-m-d'), $this->delayLabel($initialDelaySeconds, $chunkDelayStepSeconds), $jobId];
                 } catch (ActiveBackfillExistsException) {
                     ++$skippedActive;
-                    $rows[] = [$companyId, $connectionRef, $resourceType, $from->format('Y-m-d'), $to->format('Y-m-d'), 'active'];
+                    $rows[] = [$companyId, $connectionRef, $resourceType, $from->format('Y-m-d'), $to->format('Y-m-d'), $this->delayLabel($initialDelaySeconds, $chunkDelayStepSeconds), 'active'];
                 } catch (\Throwable $exception) {
                     ++$failed;
-                    $rows[] = [$companyId, $connectionRef, $resourceType, $from->format('Y-m-d'), $to->format('Y-m-d'), 'failed'];
+                    $rows[] = [$companyId, $connectionRef, $resourceType, $from->format('Y-m-d'), $to->format('Y-m-d'), $this->delayLabel($initialDelaySeconds, $chunkDelayStepSeconds), 'failed'];
                     $this->logger->warning('Failed to dispatch Ozon Performance backfill.', [
                         'companyId' => $companyId,
                         'connectionRef' => $connectionRef,
@@ -136,7 +164,7 @@ final class OzonPerformanceBackfillCommand extends Command
         }
 
         $io->title('Ozon Performance backfill');
-        $io->table(['companyId', 'connectionRef', 'resourceType', 'from', 'to', 'status'], $rows);
+        $io->table(['companyId', 'connectionRef', 'resourceType', 'from', 'to', 'delay', 'status'], $rows);
         $io->table([
             'metric',
             'value',
@@ -146,6 +174,7 @@ final class OzonPerformanceBackfillCommand extends Command
             ['started', (string) $started],
             ['skippedActive', (string) $skippedActive],
             ['failed', (string) $failed],
+            ['dispatchSpacingSeconds', (string) $dispatchSpacingSeconds],
         ]);
 
         if ($dryRun) {
@@ -174,5 +203,45 @@ final class OzonPerformanceBackfillCommand extends Command
         }
 
         return $date;
+    }
+
+    private function dispatchSpacingSeconds(InputInterface $input): int
+    {
+        $value = (string) $input->getOption('dispatch-spacing-seconds');
+        if (!ctype_digit($value)) {
+            throw new \InvalidArgumentException('The --dispatch-spacing-seconds option must be an integer from 0 to 3600.');
+        }
+
+        $seconds = (int) $value;
+        if ($seconds < 0 || $seconds > self::MAX_DISPATCH_SPACING_SECONDS) {
+            throw new \InvalidArgumentException('The --dispatch-spacing-seconds option must be an integer from 0 to 3600.');
+        }
+
+        return $seconds;
+    }
+
+    private function isCampaignBackedResource(string $resourceType): bool
+    {
+        return in_array($resourceType, self::CAMPAIGN_BACKED_RESOURCE_TYPES, true);
+    }
+
+    private function chunkCount(\DateTimeImmutable $from, \DateTimeImmutable $to): int
+    {
+        $days = ((int) $from->diff($to)->days) + 1;
+
+        return max(1, (int) ceil($days / self::BACKFILL_CHUNK_SIZE_DAYS));
+    }
+
+    private function delayLabel(int $initialDelaySeconds, int $chunkDelayStepSeconds): string
+    {
+        if (0 === $initialDelaySeconds && 0 === $chunkDelayStepSeconds) {
+            return 'none';
+        }
+
+        if ($chunkDelayStepSeconds > 0) {
+            return sprintf('%ds (+%ds/chunk)', $initialDelaySeconds, $chunkDelayStepSeconds);
+        }
+
+        return sprintf('%ds', $initialDelaySeconds);
     }
 }

--- a/site/src/Ingestion/Command/OzonPerformanceDailyLoadCommand.php
+++ b/site/src/Ingestion/Command/OzonPerformanceDailyLoadCommand.php
@@ -41,6 +41,21 @@ final class OzonPerformanceDailyLoadCommand extends Command
         OzonResourceType::PERFORMANCE_EXPENSE_STATISTICS,
     ];
 
+    /**
+     * @var list<string>
+     */
+    private const CAMPAIGN_BACKED_RESOURCE_TYPES = [
+        OzonResourceType::PERFORMANCE_CAMPAIGNS,
+        OzonResourceType::PERFORMANCE_SKU_CAMPAIGN_OBJECTS,
+        OzonResourceType::PERFORMANCE_SEARCH_PROMO_PRODUCTS,
+        OzonResourceType::PERFORMANCE_SKU_PRODUCT_STATISTICS,
+        OzonResourceType::PERFORMANCE_SEARCH_PROMO_STATISTICS,
+    ];
+
+    private const BACKFILL_CHUNK_SIZE_DAYS = 7;
+    private const DEFAULT_DISPATCH_SPACING_SECONDS = 120;
+    private const MAX_DISPATCH_SPACING_SECONDS = 3600;
+
     public function __construct(
         private readonly MarketplaceFacade $marketplaceFacade,
         private readonly SyncFacade $syncFacade,
@@ -55,6 +70,7 @@ final class OzonPerformanceDailyLoadCommand extends Command
         $this
             ->addOption('days-back', null, InputOption::VALUE_REQUIRED, 'Rewind depth in days, 1..62.', 14)
             ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Optional company UUID filter.')
+            ->addOption('dispatch-spacing-seconds', null, InputOption::VALUE_REQUIRED, 'Delay between campaign-backed job dispatches, 0..3600.', self::DEFAULT_DISPATCH_SPACING_SECONDS)
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Print planned jobs without dispatching them.')
             ->addOption('execute', null, InputOption::VALUE_NONE, 'Dispatch jobs.');
     }
@@ -87,6 +103,7 @@ final class OzonPerformanceDailyLoadCommand extends Command
 
             $daysBack = $this->daysBack($input);
             $companyId = $this->companyId($input);
+            $dispatchSpacingSeconds = $this->dispatchSpacingSeconds($input);
         } catch (\Throwable $exception) {
             $io->error($exception->getMessage());
 
@@ -106,6 +123,7 @@ final class OzonPerformanceDailyLoadCommand extends Command
             ['daysBack', (string) $daysBack],
             ['companyId', $companyId ?? 'all'],
             ['connections', (string) count($connections)],
+            ['dispatchSpacingSeconds', (string) $dispatchSpacingSeconds],
         ]);
 
         if ([] === $connections) {
@@ -118,14 +136,23 @@ final class OzonPerformanceDailyLoadCommand extends Command
         $started = 0;
         $skippedActive = 0;
         $failed = 0;
+        $nextCampaignDelaySeconds = 0;
+        $chunkCount = $this->chunkCount($from, $to);
 
         foreach ($connections as $connection) {
             $connectionCompanyId = $connection['companyId'];
             $connectionRef = $connection['connectionId'];
 
             foreach (self::RESOURCE_TYPES as $resourceType) {
+                $campaignBacked = $this->isCampaignBackedResource($resourceType);
+                $initialDelaySeconds = $campaignBacked ? $nextCampaignDelaySeconds : 0;
+                $chunkDelayStepSeconds = $campaignBacked ? $dispatchSpacingSeconds : 0;
+                if ($campaignBacked) {
+                    $nextCampaignDelaySeconds += $dispatchSpacingSeconds * $chunkCount;
+                }
+
                 if ($dryRun) {
-                    $rows[] = [$connectionCompanyId, $connectionRef, $resourceType, 'dry-run'];
+                    $rows[] = [$connectionCompanyId, $connectionRef, $resourceType, $this->delayLabel($initialDelaySeconds, $chunkDelayStepSeconds), 'dry-run'];
                     continue;
                 }
 
@@ -138,15 +165,17 @@ final class OzonPerformanceDailyLoadCommand extends Command
                         shopRef: $connectionRef,
                         windowFrom: $from,
                         windowTo: $to,
+                        initialDelaySeconds: $initialDelaySeconds,
+                        chunkDelayStepSeconds: $chunkDelayStepSeconds,
                     ));
                     ++$started;
-                    $rows[] = [$connectionCompanyId, $connectionRef, $resourceType, $jobId];
+                    $rows[] = [$connectionCompanyId, $connectionRef, $resourceType, $this->delayLabel($initialDelaySeconds, $chunkDelayStepSeconds), $jobId];
                 } catch (ActiveBackfillExistsException) {
                     ++$skippedActive;
-                    $rows[] = [$connectionCompanyId, $connectionRef, $resourceType, 'active'];
+                    $rows[] = [$connectionCompanyId, $connectionRef, $resourceType, $this->delayLabel($initialDelaySeconds, $chunkDelayStepSeconds), 'active'];
                 } catch (\Throwable $exception) {
                     ++$failed;
-                    $rows[] = [$connectionCompanyId, $connectionRef, $resourceType, 'failed'];
+                    $rows[] = [$connectionCompanyId, $connectionRef, $resourceType, $this->delayLabel($initialDelaySeconds, $chunkDelayStepSeconds), 'failed'];
                     $this->logger->warning('Failed to dispatch Ozon Performance daily load job.', [
                         'companyId' => $connectionCompanyId,
                         'connectionRef' => $connectionRef,
@@ -159,7 +188,7 @@ final class OzonPerformanceDailyLoadCommand extends Command
         }
 
         $io->section('Dispatch result');
-        $io->table(['companyId', 'connectionRef', 'resourceType', 'status'], $rows);
+        $io->table(['companyId', 'connectionRef', 'resourceType', 'delay', 'status'], $rows);
         $io->table(['metric', 'value'], [
             ['resources', (string) (count($connections) * count(self::RESOURCE_TYPES))],
             ['started', (string) $started],
@@ -191,6 +220,21 @@ final class OzonPerformanceDailyLoadCommand extends Command
         return $daysBack;
     }
 
+    private function dispatchSpacingSeconds(InputInterface $input): int
+    {
+        $value = (string) $input->getOption('dispatch-spacing-seconds');
+        if (!ctype_digit($value)) {
+            throw new \InvalidArgumentException('The --dispatch-spacing-seconds option must be an integer from 0 to 3600.');
+        }
+
+        $seconds = (int) $value;
+        if ($seconds < 0 || $seconds > self::MAX_DISPATCH_SPACING_SECONDS) {
+            throw new \InvalidArgumentException('The --dispatch-spacing-seconds option must be an integer from 0 to 3600.');
+        }
+
+        return $seconds;
+    }
+
     private function companyId(InputInterface $input): ?string
     {
         $companyId = trim((string) $input->getOption('company-id'));
@@ -201,5 +245,30 @@ final class OzonPerformanceDailyLoadCommand extends Command
         Assert::uuid($companyId, 'Invalid --company-id UUID.');
 
         return $companyId;
+    }
+
+    private function isCampaignBackedResource(string $resourceType): bool
+    {
+        return in_array($resourceType, self::CAMPAIGN_BACKED_RESOURCE_TYPES, true);
+    }
+
+    private function chunkCount(\DateTimeImmutable $from, \DateTimeImmutable $to): int
+    {
+        $days = ((int) $from->diff($to)->days) + 1;
+
+        return max(1, (int) ceil($days / self::BACKFILL_CHUNK_SIZE_DAYS));
+    }
+
+    private function delayLabel(int $initialDelaySeconds, int $chunkDelayStepSeconds): string
+    {
+        if (0 === $initialDelaySeconds && 0 === $chunkDelayStepSeconds) {
+            return 'none';
+        }
+
+        if ($chunkDelayStepSeconds > 0) {
+            return sprintf('%ds (+%ds/chunk)', $initialDelaySeconds, $chunkDelayStepSeconds);
+        }
+
+        return sprintf('%ds', $initialDelaySeconds);
     }
 }

--- a/site/src/Ingestion/Facade/SyncFacade.php
+++ b/site/src/Ingestion/Facade/SyncFacade.php
@@ -44,6 +44,8 @@ final readonly class SyncFacade
             $parentJobId,
             $command->companyId,
             WbResourceType::FINANCE_SALES_REPORT_DETAILED === $command->resourceType ? 1 : 7,
+            $command->initialDelaySeconds,
+            $command->chunkDelayStepSeconds,
         ));
 
         return $parentJobId;

--- a/site/src/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClient.php
+++ b/site/src/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClient.php
@@ -51,26 +51,41 @@ final readonly class OzonPerformanceReportClient implements OzonPerformanceRepor
     public function listCampaigns(string $companyId, string $connectionRef, array $advObjectTypes = []): OzonRawPage
     {
         $advObjectTypes = $this->normalizeStringList($advObjectTypes);
-        $cacheKey = $this->campaignCacheKey($companyId, $connectionRef, $advObjectTypes);
 
-        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($companyId, $connectionRef, $advObjectTypes): OzonRawPage {
-            $item->expiresAfter(self::CAMPAIGN_CACHE_TTL_SECONDS);
-
-            $rows = [];
-            $resultKeys = [];
-            foreach ([] === $advObjectTypes ? [null] : $advObjectTypes as $advObjectType) {
-                $options = null === $advObjectType ? [] : ['query' => ['advObjectType' => $advObjectType]];
-                $payload = $this->requestJson($companyId, $connectionRef, 'GET', self::CAMPAIGN_PATH, $options);
-                array_push($rows, ...$this->extractRows($payload));
-                foreach (array_keys($payload) as $key) {
+        $rows = [];
+        $resultKeys = [];
+        foreach ([] === $advObjectTypes ? [null] : $advObjectTypes as $advObjectType) {
+            $page = $this->cachedCampaignPage($companyId, $connectionRef, $advObjectType);
+            array_push($rows, ...$page->rows);
+            foreach ($page->metadata['resultKeys'] ?? [] as $key) {
+                if (is_string($key) && '' !== $key) {
                     $resultKeys[$key] = true;
                 }
             }
+        }
 
-            return new OzonRawPage($this->sortRows($rows), false, null, [
+        return new OzonRawPage($this->sortRows($rows), false, null, [
+            'endpoint' => self::CAMPAIGN_PATH,
+            'advObjectTypes' => $advObjectTypes,
+            'resultKeys' => array_keys($resultKeys),
+        ]);
+    }
+
+    private function cachedCampaignPage(string $companyId, string $connectionRef, ?string $advObjectType): OzonRawPage
+    {
+        $advObjectTypes = null === $advObjectType ? [] : [$advObjectType];
+        $cacheKey = $this->campaignCacheKey($companyId, $connectionRef, $advObjectTypes);
+
+        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($companyId, $connectionRef, $advObjectType, $advObjectTypes): OzonRawPage {
+            $item->expiresAfter(self::CAMPAIGN_CACHE_TTL_SECONDS);
+
+            $options = null === $advObjectType ? [] : ['query' => ['advObjectType' => $advObjectType]];
+            $payload = $this->requestJson($companyId, $connectionRef, 'GET', self::CAMPAIGN_PATH, $options);
+
+            return new OzonRawPage($this->sortRows($this->extractRows($payload)), false, null, [
                 'endpoint' => self::CAMPAIGN_PATH,
                 'advObjectTypes' => $advObjectTypes,
-                'resultKeys' => array_keys($resultKeys),
+                'resultKeys' => array_keys($payload),
             ]);
         });
     }

--- a/site/src/Ingestion/MessageHandler/RunSyncChunkHandler.php
+++ b/site/src/Ingestion/MessageHandler/RunSyncChunkHandler.php
@@ -33,6 +33,8 @@ use Symfony\Component\Messenger\Stamp\DelayStamp;
 #[AsMessageHandler]
 final readonly class RunSyncChunkHandler
 {
+    private const MAX_RATE_LIMIT_ATTEMPTS = 12;
+
     public function __construct(
         private SyncJobRepository $syncJobRepository,
         private IngestCursorRepository $cursorRepository,
@@ -137,6 +139,21 @@ final readonly class RunSyncChunkHandler
 
             throw new UnrecoverableMessageHandlingException('Ingestion connector authentication failed.', 0, $exception);
         } catch (ConnectorRateLimitedException $exception) {
+            if ($job->getAttempts() >= self::MAX_RATE_LIMIT_ATTEMPTS) {
+                $reason = sprintf('rate_limit_exhausted_after_%d_attempts', $job->getAttempts());
+                $this->logger->warning('Ingestion connector rate-limited too many times; job failed.', [
+                    'companyId' => $job->getCompanyId(),
+                    'jobId' => $job->getId(),
+                    'source' => $job->getSource()->value,
+                    'resourceType' => $job->getResourceType(),
+                    'attempts' => $job->getAttempts(),
+                    'retryAfterSeconds' => $exception->retryAfterSeconds(),
+                ]);
+                $this->markJobFailed($job->getId(), $job->getCompanyId(), $reason);
+
+                return;
+            }
+
             $this->logger->info('Ingestion connector rate-limited; chunk continuation scheduled.', [
                 'companyId' => $job->getCompanyId(),
                 'jobId' => $job->getId(),

--- a/site/tests/Integration/Ingestion/Application/SyncFacadeTest.php
+++ b/site/tests/Integration/Ingestion/Application/SyncFacadeTest.php
@@ -16,6 +16,7 @@ use App\Ingestion\Repository\IngestCursorRepository;
 use App\Ingestion\Repository\SyncJobRepository;
 use App\Tests\Support\Kernel\IntegrationTestCase;
 use Ramsey\Uuid\Uuid;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
 
 final class SyncFacadeTest extends IntegrationTestCase
@@ -54,6 +55,35 @@ final class SyncFacadeTest extends IntegrationTestCase
             self::assertInstanceOf(RunSyncChunkMessage::class, $envelope->getMessage());
             self::assertSame($companyId, $envelope->getMessage()->getCompanyId());
         }
+    }
+
+    public function testStartBackfillCanDelayDispatchedChunkMessages(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $transport = $this->getIngestFetchTransport();
+        $transport->reset();
+
+        /** @var SyncFacade $facade */
+        $facade = self::getContainer()->get(SyncFacade::class);
+
+        $facade->startBackfill(new StartBackfillCommand(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            source: IngestSource::OZON,
+            resourceType: 'resource-1',
+            shopRef: 'shop-1',
+            windowFrom: new \DateTimeImmutable('2026-06-01'),
+            windowTo: new \DateTimeImmutable('2026-06-14'),
+            initialDelaySeconds: 120,
+            chunkDelayStepSeconds: 30,
+        ));
+
+        $envelopes = $transport->getSent();
+        self::assertCount(2, $envelopes);
+        self::assertSame([120000, 150000], array_map(
+            static fn ($envelope): ?int => $envelope->last(DelayStamp::class)?->getDelay(),
+            $envelopes,
+        ));
     }
 
     public function testCompletingAllChildrenFinalizesParent(): void

--- a/site/tests/Integration/Ingestion/Command/OzonPerformanceLoadCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/OzonPerformanceLoadCommandTest.php
@@ -17,6 +17,7 @@ use Ramsey\Uuid\Uuid;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
 
 final class OzonPerformanceLoadCommandTest extends IntegrationTestCase
@@ -76,6 +77,7 @@ final class OzonPerformanceLoadCommandTest extends IntegrationTestCase
         self::assertSame($this->sortedResourceTypes(), $this->parentResourceTypes($company->getId()));
         self::assertSame(array_fill(0, count(self::RESOURCE_TYPES), $connection->getId()), $this->parentShopRefs($company->getId()));
         self::assertCount(count(self::RESOURCE_TYPES), $transport->getSent());
+        self::assertSame([120000, 240000, 360000, 480000], $this->nonZeroSentDelays($transport));
         foreach ($transport->getSent() as $envelope) {
             self::assertInstanceOf(RunSyncChunkMessage::class, $envelope->getMessage());
         }
@@ -201,5 +203,21 @@ final class OzonPerformanceLoadCommandTest extends IntegrationTestCase
         $transport = self::getContainer()->get('messenger.transport.ingest_fetch');
 
         return $transport;
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function nonZeroSentDelays(InMemoryTransport $transport): array
+    {
+        $delays = [];
+        foreach ($transport->getSent() as $envelope) {
+            $delay = $envelope->last(DelayStamp::class)?->getDelay();
+            if (null !== $delay && $delay > 0) {
+                $delays[] = $delay;
+            }
+        }
+
+        return $delays;
     }
 }

--- a/site/tests/Integration/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClientTest.php
+++ b/site/tests/Integration/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClientTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\Ingestion\Infrastructure\Api\Ozon;
 
 use App\Company\Entity\Company;
 use App\Ingestion\Exception\ConnectorAuthException;
+use App\Ingestion\Exception\ConnectorRateLimitedException;
 use App\Ingestion\Infrastructure\Api\Ozon\OzonPerformanceReportClient;
 use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Enum\MarketplaceConnectionType;
@@ -21,7 +22,7 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 
 final class OzonPerformanceReportClientTest extends IntegrationTestCase
 {
-    public function testListCampaignsCachesResponseByConnectionAndTypeSet(): void
+    public function testListCampaignsCachesResponsesPerConnectionAndAdvObjectType(): void
     {
         $company = $this->seedCompany('11111111-1111-4111-8111-00000000b201', 9201);
         $connection = $this->seedPerformanceConnection($company, '77777777-7777-4777-8777-00000000b201');
@@ -66,6 +67,57 @@ final class OzonPerformanceReportClientTest extends IntegrationTestCase
         self::assertSame('GET', $calls[2]['method']);
         self::assertSame('SEARCH_PROMO', $calls[1]['options']['query']['advObjectType']);
         self::assertSame('SKU', $calls[2]['options']['query']['advObjectType']);
+    }
+
+    public function testListCampaignsKeepsSuccessfulTypeCacheWhenAnotherTypeIsRateLimited(): void
+    {
+        $company = $this->seedCompany('11111111-1111-4111-8111-00000000b207', 9207);
+        $connection = $this->seedPerformanceConnection($company, '77777777-7777-4777-8777-00000000b207');
+        $this->em->flush();
+
+        $calls = [];
+        $skuCalls = 0;
+        $http = new MockHttpClient(static function (string $method, string $url, array $options = []) use (&$calls, &$skuCalls): MockResponse {
+            $calls[] = ['method' => $method, 'url' => $url, 'options' => $options];
+
+            if (str_ends_with($url, '/api/client/token')) {
+                return new MockResponse('{"access_token":"test-token","expires_in":1800}', ['http_code' => 200]);
+            }
+            if (str_contains($url, '/api/client/campaign')) {
+                $advObjectType = $options['query']['advObjectType'] ?? null;
+                if ('SEARCH_PROMO' === $advObjectType) {
+                    return new MockResponse('{"result":{"list":[{"id":"2","advObjectType":"SEARCH_PROMO"}]}}', ['http_code' => 200]);
+                }
+                if ('SKU' === $advObjectType) {
+                    ++$skuCalls;
+
+                    return 1 === $skuCalls
+                        ? new MockResponse('{"error":"rate limit"}', ['http_code' => 429])
+                        : new MockResponse('{"result":{"list":[{"id":"1","advObjectType":"SKU"}]}}', ['http_code' => 200]);
+                }
+            }
+
+            throw new \LogicException(sprintf('Unexpected request: %s %s', $method, $url));
+        });
+
+        $client = $this->client($http);
+
+        try {
+            $client->listCampaigns($company->getId(), $connection->getId(), ['SKU', 'SEARCH_PROMO']);
+            self::fail('Expected first campaign list request to be rate-limited.');
+        } catch (ConnectorRateLimitedException) {
+        }
+
+        $page = $client->listCampaigns($company->getId(), $connection->getId(), ['SKU', 'SEARCH_PROMO']);
+
+        self::assertSame([
+            ['id' => '1', 'advObjectType' => 'SKU'],
+            ['id' => '2', 'advObjectType' => 'SEARCH_PROMO'],
+        ], $page->rows);
+        self::assertCount(4, $calls);
+        self::assertSame('SEARCH_PROMO', $calls[1]['options']['query']['advObjectType']);
+        self::assertSame('SKU', $calls[2]['options']['query']['advObjectType']);
+        self::assertSame('SKU', $calls[3]['options']['query']['advObjectType']);
     }
 
     public function testRejectsMismatchedConnectionRefInsteadOfFallingBackToCompanyCredentials(): void

--- a/site/tests/Integration/Ingestion/MessageHandler/RunSyncChunkHandlerTest.php
+++ b/site/tests/Integration/Ingestion/MessageHandler/RunSyncChunkHandlerTest.php
@@ -451,6 +451,57 @@ final class RunSyncChunkHandlerTest extends IntegrationTestCase
         self::assertSame('2026-06-08', $cursor->getCursorValue());
     }
 
+    public function testRepeatedRateLimitMarksJobFailedInsteadOfSchedulingForever(): void
+    {
+        $fakeConnector = $this->fakeConnector();
+        $fakeConnector->reset();
+
+        $companyId = Uuid::uuid7()->toString();
+        $job = new SyncJob(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            source: IngestSource::WILDBERRIES,
+            resourceType: FakeConnector::RESOURCE_TYPE,
+            kind: SyncJobKind::BACKFILL,
+            windowFrom: new \DateTimeImmutable('2026-06-18'),
+            windowTo: new \DateTimeImmutable('2026-06-18'),
+            shopRef: 'shop-1',
+        );
+
+        $this->em->persist($job);
+        $this->em->flush();
+
+        $fetchTransport = $this->getFetchTransport();
+        $fetchTransport->reset();
+
+        /** @var RunSyncChunkHandler $handler */
+        $handler = self::getContainer()->get(RunSyncChunkHandler::class);
+
+        for ($attempt = 1; $attempt < 12; ++$attempt) {
+            $fakeConnector->enqueuePullFailure(new ConnectorRateLimitedException('Local rate limit is active.', 70));
+            $handler(new RunSyncChunkMessage($companyId, $job->getId()));
+
+            self::assertCount(1, $fetchTransport->getSent());
+            $fetchTransport->reset();
+            $this->em->clear();
+        }
+
+        $fakeConnector->enqueuePullFailure(new ConnectorRateLimitedException('Local rate limit is active.', 70));
+        $handler(new RunSyncChunkMessage($companyId, $job->getId()));
+        $this->em->clear();
+
+        self::assertCount(0, $fetchTransport->getSent());
+
+        /** @var SyncJobRepository $jobRepository */
+        $jobRepository = self::getContainer()->get(SyncJobRepository::class);
+        $failedJob = $jobRepository->findByIdAndCompany($job->getId(), $companyId);
+
+        self::assertNotNull($failedJob);
+        self::assertSame(SyncJobStatus::FAILED, $failedJob->getStatus());
+        self::assertSame(12, $failedJob->getAttempts());
+        self::assertSame('rate_limit_exhausted_after_12_attempts', $failedJob->getLastError());
+    }
+
     public function testRateLimitLockContentionKeepsJobRetryable(): void
     {
         $this->fakeConnector()->reset();


### PR DESCRIPTION
## Summary
- cache Ozon Performance campaign lists per `advObjectType` so a 429 on one type does not discard successful campaign responses for another type
- add delayed dispatch support for backfill chunks and apply 120s default spacing to Ozon Performance campaign-backed resources
- stop infinite rate-limit continuations by failing a sync job after 12 rate-limited attempts

## Root cause
Production workers could not persist Symfony cache, so every retry fetched a new token and campaign list. After the scalar `advObjectType` fix, Ozon returned 429 for `/api/client/campaign`; the handler kept scheduling 120s continuations forever and daily-load had dispatched all campaign-backed resources at once.

## Validation
- `docker compose run --rm site-php-cli php -l ...` for changed PHP files
- `docker compose run --rm --user root site-php-cli ... bin/phpunit --testsuite integration --filter "OzonPerformanceReportClientTest|OzonPerformanceLoadCommandTest|RunSyncChunkHandlerTest|SyncFacadeTest"` — 24 tests, 162 assertions
- `make site-test-unit` — 1149 tests, 7271 assertions

## Notes
- no migrations
- no messenger transport/routing config changes
- `--dispatch-spacing-seconds=0` can restore immediate dispatch for controlled local runs
