### PR TITLE
[codex] Schedule Ozon Performance loads per connection

### DIFF
--- a/site/src/Ingestion/Command/OzonPerformanceBackfillCommand.php
+++ b/site/src/Ingestion/Command/OzonPerformanceBackfillCommand.php
@@ -112,7 +112,8 @@ final class OzonPerformanceBackfillCommand extends Command
         $started = 0;
         $skippedActive = 0;
         $failed = 0;
-        $nextCampaignDelaySeconds = 0;
+        /** @var array<string, int> $nextCampaignDelaySecondsByConnection */
+        $nextCampaignDelaySecondsByConnection = [];
         $chunkCount = $this->chunkCount($from, $to);
 
         foreach ($connections as $connection) {
@@ -121,10 +122,10 @@ final class OzonPerformanceBackfillCommand extends Command
 
             foreach (self::RESOURCE_TYPES as $resourceType) {
                 $campaignBacked = $this->isCampaignBackedResource($resourceType);
-                $initialDelaySeconds = $campaignBacked ? $nextCampaignDelaySeconds : 0;
+                $initialDelaySeconds = $campaignBacked ? ($nextCampaignDelaySecondsByConnection[$connectionRef] ?? 0) : 0;
                 $chunkDelayStepSeconds = $campaignBacked ? $dispatchSpacingSeconds : 0;
                 if ($campaignBacked) {
-                    $nextCampaignDelaySeconds += $dispatchSpacingSeconds * $chunkCount;
+                    $nextCampaignDelaySecondsByConnection[$connectionRef] = $initialDelaySeconds + ($dispatchSpacingSeconds * $chunkCount);
                 }
 
                 if ($dryRun) {

--- a/site/src/Ingestion/Command/OzonPerformanceDailyLoadCommand.php
+++ b/site/src/Ingestion/Command/OzonPerformanceDailyLoadCommand.php
@@ -136,7 +136,8 @@ final class OzonPerformanceDailyLoadCommand extends Command
         $started = 0;
         $skippedActive = 0;
         $failed = 0;
-        $nextCampaignDelaySeconds = 0;
+        /** @var array<string, int> $nextCampaignDelaySecondsByConnection */
+        $nextCampaignDelaySecondsByConnection = [];
         $chunkCount = $this->chunkCount($from, $to);
 
         foreach ($connections as $connection) {
@@ -145,10 +146,10 @@ final class OzonPerformanceDailyLoadCommand extends Command
 
             foreach (self::RESOURCE_TYPES as $resourceType) {
                 $campaignBacked = $this->isCampaignBackedResource($resourceType);
-                $initialDelaySeconds = $campaignBacked ? $nextCampaignDelaySeconds : 0;
+                $initialDelaySeconds = $campaignBacked ? ($nextCampaignDelaySecondsByConnection[$connectionRef] ?? 0) : 0;
                 $chunkDelayStepSeconds = $campaignBacked ? $dispatchSpacingSeconds : 0;
                 if ($campaignBacked) {
-                    $nextCampaignDelaySeconds += $dispatchSpacingSeconds * $chunkCount;
+                    $nextCampaignDelaySecondsByConnection[$connectionRef] = $initialDelaySeconds + ($dispatchSpacingSeconds * $chunkCount);
                 }
 
                 if ($dryRun) {

--- a/site/tests/Integration/Ingestion/Command/OzonPerformanceLoadCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/OzonPerformanceLoadCommandTest.php
@@ -83,6 +83,37 @@ final class OzonPerformanceLoadCommandTest extends IntegrationTestCase
         }
     }
 
+    public function testDailyLoadExecuteSchedulesCampaignBackedResourcesPerConnection(): void
+    {
+        $companies = [
+            $this->seedCompany('11111111-1111-1111-1111-00000000a112', 9112),
+            $this->seedCompany('11111111-1111-1111-1111-00000000a113', 9113),
+            $this->seedCompany('11111111-1111-1111-1111-00000000a114', 9114),
+        ];
+        $connectionIds = [
+            '77777777-7777-7777-7777-00000000a112',
+            '77777777-7777-7777-7777-00000000a113',
+            '77777777-7777-7777-7777-00000000a114',
+        ];
+        foreach ($connectionIds as $index => $connectionId) {
+            $this->seedPerformanceConnection($companies[$index], $connectionId);
+        }
+        $this->em->flush();
+
+        $transport = $this->getIngestFetchTransport();
+        $transport->reset();
+
+        $tester = $this->tester('app:ingestion:ozon-performance:daily-load');
+        $exit = $tester->execute([
+            '--days-back' => '14',
+            '--execute' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertCount(count($connectionIds) * count(self::RESOURCE_TYPES) * 2, $transport->getSent());
+        $this->assertTwoChunkSchedulePerConnection($connectionIds, $transport);
+    }
+
     public function testBackfillExecuteDispatchesAllPerformanceResourcesForExplicitPeriod(): void
     {
         $company = $this->seedCompany('11111111-1111-1111-1111-00000000a103', 9103);
@@ -217,6 +248,56 @@ final class OzonPerformanceLoadCommandTest extends IntegrationTestCase
                 $delays[] = $delay;
             }
         }
+
+        return $delays;
+    }
+
+    /**
+     * @param list<string> $connectionIds
+     */
+    private function assertTwoChunkSchedulePerConnection(array $connectionIds, InMemoryTransport $transport): void
+    {
+        $delays = $this->sentDelaysByConnectionAndResource($transport);
+
+        foreach ($connectionIds as $connectionId) {
+            self::assertArrayHasKey($connectionId, $delays);
+            self::assertSame([0, 120000], $delays[$connectionId][OzonResourceType::PERFORMANCE_CAMPAIGNS] ?? null);
+            self::assertSame([240000, 360000], $delays[$connectionId][OzonResourceType::PERFORMANCE_SKU_CAMPAIGN_OBJECTS] ?? null);
+            self::assertSame([480000, 600000], $delays[$connectionId][OzonResourceType::PERFORMANCE_SEARCH_PROMO_PRODUCTS] ?? null);
+            self::assertSame([720000, 840000], $delays[$connectionId][OzonResourceType::PERFORMANCE_SKU_PRODUCT_STATISTICS] ?? null);
+            self::assertSame([960000, 1080000], $delays[$connectionId][OzonResourceType::PERFORMANCE_SEARCH_PROMO_STATISTICS] ?? null);
+            self::assertSame([0, 0], $delays[$connectionId][OzonResourceType::PERFORMANCE_EXPENSE_STATISTICS] ?? null);
+        }
+    }
+
+    /**
+     * @return array<string, array<string, list<int>>>
+     */
+    private function sentDelaysByConnectionAndResource(InMemoryTransport $transport): array
+    {
+        $delays = [];
+
+        foreach ($transport->getSent() as $envelope) {
+            $message = $envelope->getMessage();
+            self::assertInstanceOf(RunSyncChunkMessage::class, $message);
+
+            $row = $this->connection->fetchAssociative(
+                'SELECT connection_ref, resource_type FROM ingest_sync_jobs WHERE id = :jobId',
+                ['jobId' => $message->jobId],
+            );
+            self::assertIsArray($row);
+
+            $connectionRef = (string) $row['connection_ref'];
+            $resourceType = (string) $row['resource_type'];
+            $delays[$connectionRef][$resourceType][] = $envelope->last(DelayStamp::class)?->getDelay() ?? 0;
+        }
+
+        foreach ($delays as &$resourceDelays) {
+            foreach ($resourceDelays as &$resourceDelayValues) {
+                sort($resourceDelayValues);
+            }
+        }
+        unset($resourceDelays, $resourceDelayValues);
 
         return $delays;
     }


### PR DESCRIPTION
## What changed

- Schedule Ozon Performance campaign-backed loads independently per `connectionRef` instead of using one global delay counter.
- Apply the same per-connection delay map to both daily load and explicit backfill commands.
- Add integration coverage proving 3 active Performance connections all start their first campaign chunks at `0s` while preserving the existing per-resource/per-chunk spacing inside each connection.

## Why

The previous global delay counter serialized unrelated Ozon Performance accounts. With the default `120s` spacing and 14-day window, each account consumed about 20 minutes of schedule, so 1000 accounts would take nearly 14 days before retries/API time are considered.

## Scope note

This PR intentionally changes only Ozon Performance scheduling code and its integration test. It does **not** delete, move, or replace `docs/tasks/ingestion`; any local workspace deletions under that path are unrelated and are not part of this PR diff.

Changed files in this PR:

- `site/src/Ingestion/Command/OzonPerformanceBackfillCommand.php`
- `site/src/Ingestion/Command/OzonPerformanceDailyLoadCommand.php`
- `site/tests/Integration/Ingestion/Command/OzonPerformanceLoadCommandTest.php`

## Validation

- `php -l` for changed command/test files
- `APP_ENV=test APP_DEBUG=1 php -d memory_limit=1G bin/phpunit --testsuite integration --filter OzonPerformanceLoadCommandTest`
- `git diff --check -- site/src site/tests`
- `make site-test-unit`
- GitHub Actions for PR #2058 are green; `deploy`/`migrations` are skipped until merge.
