### PR TITLE
[codex] Fix Ozon Performance resource fetch errors

### DIFF
--- a/site/src/Ingestion/Application/Source/Ozon/OzonPerformanceReportConnector.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonPerformanceReportConnector.php
@@ -15,6 +15,7 @@ use App\Ingestion\Enum\Capability;
 use App\Ingestion\Enum\IngestSource;
 use App\Ingestion\Exception\ConnectorTransientException;
 use App\Ingestion\Exception\UnsupportedCapabilityException;
+use App\Ingestion\Infrastructure\Api\Ozon\OzonPerformanceCampaignNotFoundException;
 use App\Ingestion\Infrastructure\Api\Ozon\OzonPerformanceReportClientInterface;
 use App\Ingestion\Infrastructure\Api\Ozon\OzonRawPage;
 use Symfony\Component\Clock\ClockInterface;
@@ -123,21 +124,40 @@ final readonly class OzonPerformanceReportConnector implements SourceConnectorIn
             return $this->doneEmptyResult($request, OzonResourceType::PERFORMANCE_SKU_CAMPAIGN_OBJECTS, 'performance-sku-objects:done');
         }
 
-        $page = $this->client->fetchCampaignObjects($request->companyId, $request->connectionRef, $campaignId);
+        $skippedReason = null;
+        try {
+            $page = $this->client->fetchCampaignObjects($request->companyId, $request->connectionRef, $campaignId);
+            $rows = $page->rows;
+            $apiMetadata = $page->metadata;
+        } catch (OzonPerformanceCampaignNotFoundException $exception) {
+            $rows = [];
+            $skippedReason = 'campaign_not_found';
+            $apiMetadata = [
+                'endpoint' => $exception->endpoint,
+                'campaignId' => $exception->campaignId,
+                'skippedReason' => $skippedReason,
+                'responseBody' => $exception->responseBody,
+            ];
+        }
+
         $nextOffset = $offset + 1;
         $hasMore = $nextOffset < count($campaigns);
+        $metadata = [
+            'apiMetadata' => $apiMetadata,
+            'campaignId' => $campaignId,
+            'campaignOffset' => $offset,
+            'campaignCount' => count($campaigns),
+        ];
+        if (null !== $skippedReason) {
+            $metadata['skippedReason'] = $skippedReason;
+        }
 
         return $this->rawResult(
             request: $request,
             resourceType: OzonResourceType::PERFORMANCE_SKU_CAMPAIGN_OBJECTS,
             externalId: sprintf('performance-sku-objects:%s:%s', $campaignId, $this->windowId($request)),
-            rows: $page->rows,
-            metadata: [
-                'apiMetadata' => $page->metadata,
-                'campaignId' => $campaignId,
-                'campaignOffset' => $offset,
-                'campaignCount' => count($campaigns),
-            ],
+            rows: $rows,
+            metadata: $metadata,
             nextCursor: $hasMore ? $this->encodeCursor(['campaignOffset' => $nextOffset]) : null,
             hasMore: $hasMore,
         );

--- a/site/src/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceCampaignNotFoundException.php
+++ b/site/src/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceCampaignNotFoundException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Api\Ozon;
+
+final class OzonPerformanceCampaignNotFoundException extends \RuntimeException
+{
+    public function __construct(
+        public readonly string $campaignId,
+        public readonly string $endpoint,
+        public readonly string $responseBody,
+    ) {
+        parent::__construct(sprintf('Ozon Performance campaign "%s" was not found for %s.', $campaignId, $endpoint));
+    }
+}

--- a/site/src/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClient.php
+++ b/site/src/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClient.php
@@ -107,10 +107,8 @@ final readonly class OzonPerformanceReportClient implements OzonPerformanceRepor
         $page = max(1, $page);
         $payload = $this->requestJson($companyId, $connectionRef, 'POST', self::SEARCH_PROMO_PRODUCTS_PATH, [
             'json' => [
-                'campaign_id' => $campaignId,
                 'campaignId' => $campaignId,
                 'page' => $page,
-                'page_size' => 1000,
                 'pageSize' => 1000,
             ],
         ]);
@@ -413,6 +411,18 @@ final readonly class OzonPerformanceReportClient implements OzonPerformanceRepor
 
         if ($statusCode >= 500) {
             throw new ConnectorTransientException(sprintf('Ozon Performance server error %d for %s.', $statusCode, $endpoint));
+        }
+
+        if (
+            404 === $statusCode
+            && preg_match('#^/api/client/campaign/([^/]+)/objects$#', $endpoint, $matches)
+            && str_contains(strtolower($content), 'campaign not found')
+        ) {
+            throw new OzonPerformanceCampaignNotFoundException(
+                rawurldecode($matches[1]),
+                $endpoint,
+                mb_substr($content, 0, 500),
+            );
         }
 
         if ($statusCode < 200 || $statusCode >= 300) {

--- a/site/tests/Integration/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClientTest.php
+++ b/site/tests/Integration/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClientTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Integration\Ingestion\Infrastructure\Api\Ozon;
 use App\Company\Entity\Company;
 use App\Ingestion\Exception\ConnectorAuthException;
 use App\Ingestion\Exception\ConnectorRateLimitedException;
+use App\Ingestion\Infrastructure\Api\Ozon\OzonPerformanceCampaignNotFoundException;
 use App\Ingestion\Infrastructure\Api\Ozon\OzonPerformanceReportClient;
 use App\Marketplace\Entity\MarketplaceConnection;
 use App\Marketplace\Enum\MarketplaceConnectionType;
@@ -118,6 +119,66 @@ final class OzonPerformanceReportClientTest extends IntegrationTestCase
         self::assertSame('SEARCH_PROMO', $calls[1]['options']['query']['advObjectType']);
         self::assertSame('SKU', $calls[2]['options']['query']['advObjectType']);
         self::assertSame('SKU', $calls[3]['options']['query']['advObjectType']);
+    }
+
+    public function testFetchSearchPromoProductsUsesOneCanonicalPageSizeField(): void
+    {
+        $company = $this->seedCompany('11111111-1111-4111-8111-00000000b208', 9208);
+        $connection = $this->seedPerformanceConnection($company, '77777777-7777-4777-8777-00000000b208');
+        $this->em->flush();
+
+        $calls = [];
+        $http = new MockHttpClient(static function (string $method, string $url, array $options = []) use (&$calls): MockResponse {
+            $calls[] = ['method' => $method, 'url' => $url, 'options' => $options];
+
+            if (str_ends_with($url, '/api/client/token')) {
+                return new MockResponse('{"access_token":"test-token","expires_in":1800}', ['http_code' => 200]);
+            }
+            if (str_ends_with($url, '/api/client/campaign/search_promo/v2/products')) {
+                return new MockResponse('{"result":{"products":[{"sku":"sku-1"}],"total":1}}', ['http_code' => 200]);
+            }
+
+            throw new \LogicException(sprintf('Unexpected request: %s %s', $method, $url));
+        });
+
+        $page = $this->client($http)->fetchSearchPromoProducts($company->getId(), $connection->getId(), 'campaign-1', 2);
+
+        self::assertSame('POST', $calls[1]['method']);
+        $requestBody = json_decode((string) ($calls[1]['options']['body'] ?? ''), true, 512, \JSON_THROW_ON_ERROR);
+        self::assertSame([
+            'campaignId' => 'campaign-1',
+            'page' => 2,
+            'pageSize' => 1000,
+        ], $requestBody);
+        self::assertSame([
+            [
+                'sku' => 'sku-1',
+                '_ingestion_metadata' => ['campaignId' => 'campaign-1', 'page' => 2],
+            ],
+        ], $page->rows);
+    }
+
+    public function testFetchCampaignObjectsRaisesTypedExceptionWhenCampaignIsMissing(): void
+    {
+        $company = $this->seedCompany('11111111-1111-4111-8111-00000000b209', 9209);
+        $connection = $this->seedPerformanceConnection($company, '77777777-7777-4777-8777-00000000b209');
+        $this->em->flush();
+
+        $http = new MockHttpClient(static function (string $method, string $url): MockResponse {
+            if (str_ends_with($url, '/api/client/token')) {
+                return new MockResponse('{"access_token":"test-token","expires_in":1800}', ['http_code' => 200]);
+            }
+            if (str_ends_with($url, '/api/client/campaign/13815400/objects')) {
+                return new MockResponse('{"error":"campaign not found"}', ['http_code' => 404]);
+            }
+
+            throw new \LogicException(sprintf('Unexpected request: %s %s', $method, $url));
+        });
+
+        $this->expectException(OzonPerformanceCampaignNotFoundException::class);
+        $this->expectExceptionMessage('campaign "13815400" was not found');
+
+        $this->client($http)->fetchCampaignObjects($company->getId(), $connection->getId(), '13815400');
     }
 
     public function testRejectsMismatchedConnectionRefInsteadOfFallingBackToCompanyCredentials(): void

--- a/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonPerformanceReportConnectorTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonPerformanceReportConnectorTest.php
@@ -11,6 +11,7 @@ use App\Ingestion\Application\Source\Ozon\OzonResourceType;
 use App\Ingestion\Enum\Capability;
 use App\Ingestion\Exception\ConnectorTransientException;
 use App\Ingestion\Exception\UnsupportedCapabilityException;
+use App\Ingestion\Infrastructure\Api\Ozon\OzonPerformanceCampaignNotFoundException;
 use App\Ingestion\Infrastructure\Api\Ozon\OzonPerformanceReportClientInterface;
 use App\Ingestion\Infrastructure\Api\Ozon\OzonRawPage;
 use PHPUnit\Framework\TestCase;
@@ -81,6 +82,50 @@ final class OzonPerformanceReportConnectorTest extends TestCase
         self::assertFalse($second->hasMore);
         self::assertNull($second->nextCursorValue);
         self::assertSame(['11', '12'], $client->skuStatsCampaignCalls[1]);
+    }
+
+    public function testPullSkuCampaignObjectsSkipsMissingCampaignAndContinues(): void
+    {
+        $client = new FakeOzonPerformanceReportClient();
+        $client->campaignsByType['SKU'] = [
+            ['id' => '13815400'],
+            ['id' => '13815401'],
+        ];
+        $client->missingCampaignObjects['13815400'] = true;
+
+        $connector = $this->connector($client);
+        $first = $connector->pull($this->request(OzonResourceType::PERFORMANCE_SKU_CAMPAIGN_OBJECTS));
+
+        self::assertNotNull($first->rawBatch);
+        self::assertTrue($first->hasMore);
+        self::assertSame('{"campaignOffset":1}', $first->nextCursorValue);
+        self::assertSame('performance-sku-objects:13815400:2026-06-01:2026-06-07', $first->rawBatch->externalId);
+        self::assertSame([
+            [
+                '_ingestion_empty' => true,
+                '_ingestion_resource' => OzonResourceType::PERFORMANCE_SKU_CAMPAIGN_OBJECTS,
+                '_ingestion_metadata' => [
+                    'apiMetadata' => [
+                        'endpoint' => '/api/client/campaign/13815400/objects',
+                        'campaignId' => '13815400',
+                        'skippedReason' => 'campaign_not_found',
+                        'responseBody' => '{"error":"campaign not found"}',
+                    ],
+                    'campaignId' => '13815400',
+                    'campaignOffset' => 0,
+                    'campaignCount' => 2,
+                    'skippedReason' => 'campaign_not_found',
+                ],
+            ],
+        ], $first->rawBatch->rows);
+
+        $second = $connector->pull($this->request(
+            OzonResourceType::PERFORMANCE_SKU_CAMPAIGN_OBJECTS,
+            cursorValue: $first->nextCursorValue,
+        ));
+
+        self::assertFalse($second->hasMore);
+        self::assertSame([['campaign_id' => '13815401', 'sku' => 'sku-1']], $second->rawBatch?->rows);
     }
 
     public function testSearchPromoStatisticsGeneratesAsyncReportBeforeRawBatch(): void
@@ -194,6 +239,11 @@ final class FakeOzonPerformanceReportClient implements OzonPerformanceReportClie
      */
     public array $readyReports = [];
 
+    /**
+     * @var array<string, bool>
+     */
+    public array $missingCampaignObjects = [];
+
     public function listCampaigns(string $companyId, string $connectionRef, array $advObjectTypes = []): OzonRawPage
     {
         $rows = [];
@@ -206,6 +256,14 @@ final class FakeOzonPerformanceReportClient implements OzonPerformanceReportClie
 
     public function fetchCampaignObjects(string $companyId, string $connectionRef, string $campaignId): OzonRawPage
     {
+        if (($this->missingCampaignObjects[$campaignId] ?? false) === true) {
+            throw new OzonPerformanceCampaignNotFoundException(
+                $campaignId,
+                sprintf('/api/client/campaign/%s/objects', $campaignId),
+                '{"error":"campaign not found"}',
+            );
+        }
+
         return new OzonRawPage([['campaign_id' => $campaignId, 'sku' => 'sku-1']], false);
     }
 


### PR DESCRIPTION
## Summary
- send a single canonical `pageSize` field for Search Promo products requests
- convert Ozon `campaign not found` responses for SKU campaign objects into typed skips instead of failing the whole resource job
- add regression coverage for both production failures

## Root cause
The Search Promo products request sent both snake_case and camelCase pagination fields, which Ozon parsed as duplicate `pageSize`. Separately, deleted or unavailable SKU campaign ids returned `404 campaign not found`, and the connector treated that as a fatal resource error.

## Validation
- `docker compose run --rm site-php-cli sh -lc 'php -l src/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceCampaignNotFoundException.php && php -l src/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClient.php && php -l src/Ingestion/Application/Source/Ozon/OzonPerformanceReportConnector.php && php -l tests/Integration/Ingestion/Infrastructure/Api/Ozon/OzonPerformanceReportClientTest.php && php -l tests/Unit/Ingestion/Application/Source/Ozon/OzonPerformanceReportConnectorTest.php'`\n- `docker compose run --rm site-php-cli php -d memory_limit=1G bin/phpunit --testsuite unit --filter OzonPerformanceReportConnectorTest`\n- targeted integration: `APP_ENV=test APP_DEBUG=1 php -d memory_limit=1G bin/phpunit --testsuite integration --filter OzonPerformanceReportClientTest`\n- `git diff --check -- site/src/Ingestion site/tests/Integration/Ingestion site/tests/Unit/Ingestion`\n- `make site-test-unit`\n\n## Scope note\nExisting local `docs/tasks/ingestion` deletions and untracked docs/ui-kit files are unrelated and are not included in this PR.