### PR TITLE
feat(shared): Money VO arithmetic + Doctrine Embeddable mapping

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1763,6 +1763,40 @@ App\Shared\Service\SodiumFieldEncryptionService
 App\Shared\Service\SecretRotationService
 ```
 
+### Shared Value Objects — `Money`
+
+`App\Shared\Domain\ValueObject\Money` — `final readonly`, хранит сумму в минорных единицах
+(`int $amountMinor`) и валюту ISO-4217. Вся арифметика — bcmath, без float.
+
+```php
+// Создание / конвертация
+Money::fromMinor(int $amountMinor, string $currency): self
+Money::fromString(string $decimal, string $currency): self   // '1 234,56' -> minor; scale по валюте (Intl)
+$money->toDecimalString(): string                            // 12345 (RUB) -> '123.45'
+
+// Арифметика (валюта обязана совпадать → MoneyMismatchException)
+$money->add(self): self;  $money->subtract(self): self;  $money->negate(): self
+$money->multiply(string $factor, RoundingMode = HALF_UP): self
+$money->percentage(string $percent, RoundingMode = HALF_UP): self
+$money->abs(): self
+
+// Сравнение / предикаты
+$money->compareTo(self): int;  $money->equals(self): bool
+$money->isZero(): bool;  $money->isPositive(): bool;  $money->isNegative(): bool
+$money->amountMinor(): int;  $money->currency(): string
+```
+
+- `App\Shared\Domain\ValueObject\RoundingMode` — enum `HALF_UP` (от нуля) / `HALF_EVEN` (банковское).
+- Округление масштаба — по числу знаков валюты (`Intl\Currencies::getFractionDigits`, fallback 2).
+- Ограничение: PHP `int` 64-бит ≈ ±9.2·10¹⁶ ₽ (минор). За пределами — переполнение.
+
+**Doctrine-маппинг (Embeddable):** `Money` помечен `#[ORM\Embeddable]` и встраивается в Entity
+через `#[ORM\Embedded(class: Money::class)]` → две колонки (`*_amount_minor` bigint + `*_currency`).
+Сумма мапится кастомным типом `App\Shared\Infrastructure\Doctrine\MoneyAmountType`
+(`money_amount_minor`, extends `BigIntType`) — гидрирует bigint в PHP `int`, а не string.
+Зарегистрирован в `config/packages/doctrine.yaml > dbal.types`; namespace VO покрыт маппингом
+`SharedValueObject`. SQL-агрегация по сумме (`SUM`/`ORDER BY`) работает на отдельной колонке.
+
 ---
 
 ## Tagged Services — текущие группы

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1788,7 +1788,9 @@ $money->amountMinor(): int;  $money->currency(): string
 
 - `App\Shared\Domain\ValueObject\RoundingMode` — enum `HALF_UP` (от нуля) / `HALF_EVEN` (банковское).
 - Округление масштаба — по числу знаков валюты (`Intl\Currencies::getFractionDigits`, fallback 2).
-- Ограничение: PHP `int` 64-бит ≈ ±9.2·10¹⁶ ₽ (минор). За пределами — переполнение.
+- Диапазон: PHP `int` 64-бит ≈ ±9.2·10¹⁶ ₽ (минор). Выход за пределы (в `fromString`,
+  `multiply`, `percentage`, `abs` при `PHP_INT_MIN`) бросает `MoneyOverflowException` —
+  тихого int-wrap нет.
 
 **Doctrine-маппинг (Embeddable):** `Money` помечен `#[ORM\Embeddable]` и встраивается в Entity
 через `#[ORM\Embedded(class: Money::class)]` → две колонки (`*_amount_minor` bigint + `*_currency`).

--- a/docs/tasks/money-vo/handoff.md
+++ b/docs/tasks/money-vo/handoff.md
@@ -1,0 +1,61 @@
+# Handoff — Money VO + Doctrine-маппинг (Embeddable + custom Type)
+
+Ветка: `feature/money-vo-doctrine`. Базовая: `master`.
+Plan: `/home/deploy/.claude/plans/tidy-wiggling-lovelace.md`.
+
+## Summary по этапам
+
+| Stage | Риск | Суть | Статус |
+|---|---|---|---|
+| 1 | 🟡 | Расширение API `Money` (fromString/toDecimalString/multiply/percentage/abs/equals/isPositive/isNegative) | ✅ |
+| 2 | 🟢 | `RoundingMode` enum (HALF_UP/HALF_EVEN) | ✅ |
+| 3 | 🔴 | `MoneyAmountType` + Embeddable-атрибуты + регистрация в doctrine.yaml + ARCHITECTURE.md | ✅ |
+| 4 | 🟡 | Интеграционный тест маппинга (fixture-сущность, round-trip) | ✅ |
+
+## Коммиты
+1. `feat(shared): extend Money VO with decimal parsing and arithmetic` (Stage 1–2)
+2. `feat(shared): map Money as Doctrine Embeddable with custom amount type` (Stage 3–4)
+
+## Новый публичный контракт
+- `App\Shared\Domain\ValueObject\Money` — новые методы (см. список). Существующие сигнатуры
+  не менялись → обратная совместимость с Ingestion сохранена.
+- `App\Shared\Domain\ValueObject\RoundingMode` — new enum.
+- `App\Shared\Infrastructure\Doctrine\MoneyAmountType` — new DBAL-тип (`money_amount_minor`).
+- `Money` теперь `#[ORM\Embeddable]` — встраивается через `#[ORM\Embedded(class: Money::class)]`.
+
+## Миграции БД
+- **Нет.** Embeddable не создаёт таблиц; боевые Entity не трогались. `schema:validate --skip-sync`
+  — mapping OK по всему приложению.
+
+## Изменения конфигурации
+- `config/packages/doctrine.yaml`:
+  - `dbal.types.money_amount_minor`;
+  - `orm.mappings.SharedValueObject` (namespace `App\Shared\Domain\ValueObject`);
+  - `when@test`: `orm.mappings.TestFixtures` (для интеграционного теста).
+
+## Верификация
+- `composer test:unit -- --filter '(MoneyTest|RoundingModeTest|FinancialTransactionTest)'` → 34 ✅
+- `composer test -- --testsuite integration --filter MoneyEmbeddableMappingTest` → 3 ✅
+- `doctrine:schema:validate --skip-sync` → mapping OK
+- `composer cs:check` → изменённые файлы чистые
+- PHPStan — **N/A**: в проекте не установлен (есть только `cs:check`); `make stan` недоступен.
+
+> ⚠️ Окружение: embedded-DNS контейнера к `site-postgres` сбоит (`EAI_AGAIN`) —
+> инфраструктурная проблема, не связана с задачей. Интеграционные тесты запускались с
+> `-e DATABASE_URL=postgresql://app:secret@<postgres-ip>:5432/app`. Полный `make test`
+> в этом окружении не прогонялся целиком по той же причине; прогнаны таргетированные наборы.
+
+## Риски
+- ORM-атрибуты на доменном VO `Shared/Domain/Money` (по решению Владельца — без обёртки).
+- Переполнение `int` за ~±9.2·10¹⁶ ₽ (минор) — задокументированное ограничение.
+- `fromString` использует half-up; `OzonMoneyParser` исторически — иное округление 3-го знака.
+
+## Follow-ups (сознательно вне scope)
+- Адаптировать `Ingestion\FinancialTransaction` на Embedded `Money` (потребует миграцию — отдельно).
+- Унифицировать парсеры денег (`OzonMoneyParser`, телеграм-парсер, `FundController`) на
+  `Money::fromString`.
+- Внедрение Money в модуль Cash (устранение float-арифметики) — отдельная большая задача.
+- При желании — `Money::allocate()` для распределения по долям.
+
+## 🛑 Final Owner review
+Merge — только после одобрения Владельцем (PR из `feature/money-vo-doctrine`).

--- a/docs/tasks/money-vo/stages/stage-1.md
+++ b/docs/tasks/money-vo/stages/stage-1.md
@@ -1,0 +1,38 @@
+## Stage 1: Расширение API Money VO — DONE
+
+**Риск:** 🟡 MEDIUM
+**Следующее действие:** continue autonomously (→ Stage 3 — 🛑 STOP, HIGH risk)
+
+### Что сделано
+- В `Money` добавлены методы (только дополнение, существующие сигнатуры не тронуты):
+  - `fromString(string $decimal, string $currency): self` — парсинг decimal-строк в минорные
+    единицы, currency-aware масштаб через `Intl\Currencies`, округление half-up, bcmath.
+  - `toDecimalString(): string` — обратное преобразование с числом знаков по валюте.
+  - `multiply(string $factor, RoundingMode $mode = HALF_UP): self`
+  - `percentage(string $percent, RoundingMode $mode = HALF_UP): self`
+  - `abs()`, `equals(self)`, `isPositive()`, `isNegative()`
+  - приватный `fractionDigits(string $currency): int` (fallback 2, как в CurrencyFormatExtension).
+- Вся арифметика — bcmath, без float.
+
+### Затронутые файлы
+- `site/src/Shared/Domain/ValueObject/Money.php` — modified
+- `site/tests/Unit/Shared/Domain/ValueObject/MoneyTest.php` — modified (новые кейсы)
+
+### Self-review
+- [x] Scope compliance — только Money API, существующие методы не менялись
+- [x] Patterns / naming — `final readonly class`, bcmath, без float
+- [x] Forbidden actions — none (нет dump/dd, нет new Service, нет flush)
+- [x] Security — N/A (чистый VO, без companyId/IDOR-поверхности)
+- [x] CS-Fixer — чисто на изменённых файлах; PHPStan — N/A (не установлен в проекте)
+- [x] Tests — `composer test:unit --filter MoneyTest` зелёные (старые 13 + новые)
+- [x] ARCHITECTURE.md — отложено до Stage 3 (вместе с Embeddable/типом)
+
+### Команды для проверки
+- `docker compose run --rm site-php-cli composer test:unit -- --filter MoneyTest`
+
+### Риски / на что обратить внимание ревьюеру
+- Переполнение `int` за пределами ~9.2·10¹⁶ ₽ — задокументированное ограничение.
+- `fromString` без параметра RoundingMode (фиксированный half-up) — по плану.
+
+### Открытые вопросы
+- нет

--- a/docs/tasks/money-vo/stages/stage-2.md
+++ b/docs/tasks/money-vo/stages/stage-2.md
@@ -1,0 +1,30 @@
+## Stage 2: RoundingMode enum — DONE
+
+**Риск:** 🟢 LOW
+**Следующее действие:** continue autonomously
+
+### Что сделано
+- Создан `enum RoundingMode` (HALF_UP, HALF_EVEN) с методом
+  `roundToInteger(string $value): string` — округление bcmath-decimal до целого
+  (half-up = от нуля; half-even = банковское, к чётному). Без float.
+
+### Затронутые файлы
+- `site/src/Shared/Domain/ValueObject/RoundingMode.php` — new
+- `site/tests/Unit/Shared/Domain/ValueObject/RoundingModeTest.php` — new
+
+### Self-review
+- [x] Scope compliance
+- [x] Patterns / naming — `enum` без `final` (PHP implicitly final)
+- [x] Forbidden actions — none
+- [x] Security — N/A
+- [x] CS-Fixer чисто; PHPStan — N/A (не установлен)
+- [x] Tests — `RoundingModeTest` зелёный (граничные .5 для обеих стратегий)
+
+### Команды для проверки
+- `docker compose run --rm site-php-cli composer test:unit -- --filter RoundingModeTest`
+
+### Риски / на что обратить внимание ревьюеру
+- нет
+
+### Открытые вопросы
+- нет

--- a/docs/tasks/money-vo/stages/stage-3.md
+++ b/docs/tasks/money-vo/stages/stage-3.md
@@ -1,0 +1,49 @@
+## Stage 3: Doctrine custom Type + Embeddable-маппинг Money — DONE
+
+**Риск:** 🔴 HIGH
+**Следующее действие:** 🛑 STOP — обязательное ревью Владельцем (миграция конфига + правка
+домена, используемого Ingestion)
+
+### Что сделано
+- `App\Shared\Infrastructure\Doctrine\MoneyAmountType` (new) — `extends BigIntType`,
+  `NAME = 'money_amount_minor'`, `convertToPHPValue → ?int`. Мостик bigint→int для гидрации
+  `readonly int $amountMinor`.
+- `Money` помечен `#[ORM\Embeddable]`; на свойствах конструктора — `#[ORM\Column]`
+  (`amountMinor` через `MoneyAmountType::NAME`, `currency` — string(3)). Публичный API и
+  поведение VO не изменены.
+- `config/packages/doctrine.yaml`:
+  - зарегистрирован тип `money_amount_minor`;
+  - **(уточнение к плану)** добавлен маппинг `SharedValueObject` (dir
+    `src/Shared/Domain/ValueObject`) — в плане было ошибочно «регистрации не требует»: для
+    Symfony per-namespace driver chain namespace embeddable обязан быть покрыт маппингом,
+    иначе Doctrine не разрешит метаданные `Money`;
+  - `when@test` → маппинг `TestFixtures` (для fixture-сущности Stage 4).
+- `ARCHITECTURE.md` — добавлена секция «Shared Value Objects — Money» (API + Embeddable + тип).
+
+### Затронутые файлы
+- `site/src/Shared/Infrastructure/Doctrine/MoneyAmountType.php` — new
+- `site/src/Shared/Domain/ValueObject/Money.php` — modified (ORM-атрибуты)
+- `site/config/packages/doctrine.yaml` — modified
+- `ARCHITECTURE.md` — modified
+
+### Self-review
+- [x] Scope compliance — боевые Entity не тронуты, миграций БД нет
+- [x] Patterns — тип по образцу `EncryptedJsonType`; атрибутный маппинг как в проекте
+- [x] Forbidden actions — none (не legacy-зона; messenger.yaml не трогался)
+- [x] Security — N/A
+- [x] `doctrine:schema:validate --skip-sync` → mapping OK по всему приложению
+- [x] CS-Fixer чисто на изменённых файлах; PHPStan — N/A (не установлен)
+- [x] Regression — `MoneyTest`, `RoundingModeTest`, `FinancialTransactionTest` зелёные (34)
+- [x] ARCHITECTURE.md обновлён
+
+### Команды для проверки
+- `doctrine:schema:validate --skip-sync`
+- `composer test:unit -- --filter '(MoneyTest|FinancialTransactionTest)'`
+
+### Риски / на что обратить внимание ревьюеру
+- 🔴 Изменён `config/packages/doctrine.yaml` (новый dbal-тип + 2 маппинга) — требует ревью.
+- ORM-атрибуты добавлены на доменный VO в `Shared/Domain` (по решению Владельца — без обёртки).
+- Embeddable отдельной таблицы не создаёт; прод-схема не затронута (validate mapping OK).
+
+### Открытые вопросы
+- нет

--- a/docs/tasks/money-vo/stages/stage-4.md
+++ b/docs/tasks/money-vo/stages/stage-4.md
@@ -1,0 +1,39 @@
+## Stage 4: Интеграционный тест маппинга Money — DONE
+
+**Риск:** 🟡 MEDIUM
+**Следующее действие:** Phase Final (Handoff) — 🛑 STOP
+
+### Что сделано
+- Test-only fixture `App\Tests\Fixtures\Doctrine\MoneyHolder` с
+  `#[ORM\Embedded(class: Money::class, columnPrefix: false)]` (таблица `test_money_holder`).
+- `MoneyEmbeddableMappingTest` (KernelTestCase/IntegrationTestCase): таблица создаётся и
+  удаляется через `SchemaTool` в setUp/tearDown — в прод-схему/миграции не попадает. Кейсы:
+  - метадата: два поля `amount.amountMinor` / `amount.currency`, колонки `amount_minor` /
+    `currency`, тип поля `money_amount_minor`;
+  - round-trip persist→flush→clear→find: `Money::fromString('123.45','RUB')` читается обратно,
+    `amountMinor()` возвращает **int 12345** (ключевая проверка гидрации bigint→int для
+    `final readonly`), валюта 'RUB';
+  - round-trip отрицательной суммы (USD).
+
+### Затронутые файлы
+- `site/tests/Fixtures/Doctrine/MoneyHolder.php` — new
+- `site/tests/Integration/Shared/MoneyEmbeddableMappingTest.php` — new
+
+### Self-review
+- [x] Scope compliance — только тест + fixture, прод-код не тронут
+- [x] Гидрация `final readonly` Money через Embeddable подтверждена тестом (риск из плана закрыт)
+- [x] CS-Fixer чисто; PHPStan — N/A
+- [x] Tests — `MoneyEmbeddableMappingTest` зелёный (3 теста, 12 assertions)
+- [x] Прод-схема не затронута (таблица fixture создаётся/удаляется в тесте)
+
+### Команды для проверки
+- `composer test -- --testsuite integration --filter MoneyEmbeddableMappingTest`
+  (в этом окружении DNS контейнера к site-postgres сбоит — запускалось с
+  `-e DATABASE_URL=postgresql://app:secret@<postgres-ip>:5432/app`)
+
+### Риски / на что обратить внимание ревьюеру
+- 2 PHPUnit-deprecation в прогоне — конфиг-уровень PHPUnit (предсуществующие,
+  `--fail-on-deprecation` не падает), не из кода задачи.
+
+### Открытые вопросы
+- нет

--- a/site/config/packages/doctrine.yaml
+++ b/site/config/packages/doctrine.yaml
@@ -3,6 +3,7 @@ doctrine:
         url: '%env(resolve:DATABASE_URL)%'
         types:
             encrypted_json: App\Ingestion\Infrastructure\Doctrine\EncryptedJsonType
+            money_amount_minor: App\Shared\Infrastructure\Doctrine\MoneyAmountType
 
         # IMPORTANT: You MUST configure your server version,
         # either here or in the DATABASE_URL env var (see .env file)
@@ -86,6 +87,12 @@ doctrine:
                 dir: '%kernel.project_dir%/src/Shared/Entity'
                 prefix: 'App\Shared\Entity'
                 alias: Shared
+            SharedValueObject:
+                type: attribute
+                is_bundle: false
+                dir: '%kernel.project_dir%/src/Shared/Domain/ValueObject'
+                prefix: 'App\Shared\Domain\ValueObject'
+                alias: SharedValueObject
             Catalog:
                 type: attribute
                 is_bundle: false
@@ -140,6 +147,14 @@ when@test:
         dbal:
             # "TEST_TOKEN" is typically set by ParaTest
             dbname_suffix: '_test%env(default::TEST_TOKEN)%'
+        orm:
+            mappings:
+                TestFixtures:
+                    type: attribute
+                    is_bundle: false
+                    dir: '%kernel.project_dir%/tests/Fixtures/Doctrine'
+                    prefix: 'App\Tests\Fixtures\Doctrine'
+                    alias: TestFixtures
 
 when@prod:
     doctrine:

--- a/site/src/Shared/Domain/Exception/MoneyOverflowException.php
+++ b/site/src/Shared/Domain/Exception/MoneyOverflowException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Domain\Exception;
+
+final class MoneyOverflowException extends \DomainException
+{
+}

--- a/site/src/Shared/Domain/ValueObject/Money.php
+++ b/site/src/Shared/Domain/ValueObject/Money.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Shared\Domain\ValueObject;
 
 use App\Shared\Domain\Exception\MoneyMismatchException;
+use Symfony\Component\Intl\Currencies;
 use Webmozart\Assert\Assert;
 
 final readonly class Money
@@ -19,6 +20,26 @@ final readonly class Money
     public static function fromMinor(int $amountMinor, string $currency): self
     {
         return new self($amountMinor, strtoupper($currency));
+    }
+
+    /**
+     * Парсит decimal-строку («123.45», «1 234,56») в минорные единицы валюты.
+     *
+     * Масштаб определяется по валюте (RUB=2, JPY=0, BHD=3) через Intl,
+     * округление — half-up. Арифметика через bcmath, без float.
+     */
+    public static function fromString(string $decimal, string $currency): self
+    {
+        $currency = strtoupper(trim($currency));
+
+        $normalized = str_replace(["\u{00A0}", ' ', ','], ['', '', '.'], trim($decimal));
+        Assert::regex($normalized, '/^-?\d+(\.\d+)?$/');
+
+        $scale = self::fractionDigits($currency);
+        $scaled = \bcmul($normalized, \bcpow('10', (string) $scale), 12);
+        $minor = RoundingMode::HALF_UP->roundToInteger($scaled);
+
+        return new self((int) $minor, $currency);
     }
 
     public function add(self $other): self
@@ -52,6 +73,47 @@ final readonly class Money
         return 0 === $this->amountMinor;
     }
 
+    public function isPositive(): bool
+    {
+        return $this->amountMinor > 0;
+    }
+
+    public function isNegative(): bool
+    {
+        return $this->amountMinor < 0;
+    }
+
+    public function abs(): self
+    {
+        return $this->amountMinor < 0 ? new self(-$this->amountMinor, $this->currency) : $this;
+    }
+
+    /**
+     * Умножает сумму на произвольный множитель (decimal-строка), округляя результат
+     * до целых минорных единиц. Валюта сохраняется.
+     */
+    public function multiply(string $factor, RoundingMode $mode = RoundingMode::HALF_UP): self
+    {
+        $product = \bcmul((string) $this->amountMinor, $factor, 12);
+
+        return new self((int) $mode->roundToInteger($product), $this->currency);
+    }
+
+    /**
+     * Возвращает указанный процент от суммы (например percentage('20') — 20%).
+     */
+    public function percentage(string $percent, RoundingMode $mode = RoundingMode::HALF_UP): self
+    {
+        $value = \bcdiv(\bcmul((string) $this->amountMinor, $percent, 12), '100', 12);
+
+        return new self((int) $mode->roundToInteger($value), $this->currency);
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this->amountMinor === $other->amountMinor && $this->currency === $other->currency;
+    }
+
     public function amountMinor(): int
     {
         return $this->amountMinor;
@@ -60,6 +122,28 @@ final readonly class Money
     public function currency(): string
     {
         return $this->currency;
+    }
+
+    /**
+     * Представляет сумму как decimal-строку с числом знаков по валюте («12345» RUB → «123.45»).
+     */
+    public function toDecimalString(): string
+    {
+        $scale = self::fractionDigits($this->currency);
+        if (0 === $scale) {
+            return (string) $this->amountMinor;
+        }
+
+        return \bcdiv((string) $this->amountMinor, \bcpow('10', (string) $scale), $scale);
+    }
+
+    private static function fractionDigits(string $currency): int
+    {
+        try {
+            return Currencies::getFractionDigits($currency);
+        } catch (\Throwable) {
+            return 2;
+        }
     }
 
     private function assertSameCurrency(self $other): void

--- a/site/src/Shared/Domain/ValueObject/Money.php
+++ b/site/src/Shared/Domain/ValueObject/Money.php
@@ -105,6 +105,8 @@ final readonly class Money
      */
     public function multiply(string $factor, RoundingMode $mode = RoundingMode::HALF_UP): self
     {
+        Assert::regex($factor, '/^-?\d+(\.\d+)?$/', 'Factor must be a valid decimal string.');
+
         $product = \bcmul((string) $this->amountMinor, $factor, 12);
 
         return self::createSafe($mode->roundToInteger($product), $this->currency);
@@ -115,6 +117,8 @@ final readonly class Money
      */
     public function percentage(string $percent, RoundingMode $mode = RoundingMode::HALF_UP): self
     {
+        Assert::regex($percent, '/^-?\d+(\.\d+)?$/', 'Percent must be a valid decimal string.');
+
         $value = \bcdiv(\bcmul((string) $this->amountMinor, $percent, 12), '100', 12);
 
         return self::createSafe($mode->roundToInteger($value), $this->currency);

--- a/site/src/Shared/Domain/ValueObject/Money.php
+++ b/site/src/Shared/Domain/ValueObject/Money.php
@@ -5,13 +5,19 @@ declare(strict_types=1);
 namespace App\Shared\Domain\ValueObject;
 
 use App\Shared\Domain\Exception\MoneyMismatchException;
+use App\Shared\Infrastructure\Doctrine\MoneyAmountType;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Intl\Currencies;
 use Webmozart\Assert\Assert;
 
+#[ORM\Embeddable]
 final readonly class Money
 {
     private function __construct(
+        #[ORM\Column(type: MoneyAmountType::NAME)]
         private int $amountMinor,
+        #[ORM\Column(type: Types::STRING, length: 3)]
         private string $currency,
     ) {
         Assert::regex($this->currency, '/^[A-Z]{3}$/');

--- a/site/src/Shared/Domain/ValueObject/Money.php
+++ b/site/src/Shared/Domain/ValueObject/Money.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Shared\Domain\ValueObject;
 
 use App\Shared\Domain\Exception\MoneyMismatchException;
+use App\Shared\Domain\Exception\MoneyOverflowException;
 use App\Shared\Infrastructure\Doctrine\MoneyAmountType;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
@@ -45,7 +46,7 @@ final readonly class Money
         $scaled = \bcmul($normalized, \bcpow('10', (string) $scale), 12);
         $minor = RoundingMode::HALF_UP->roundToInteger($scaled);
 
-        return new self((int) $minor, $currency);
+        return self::createSafe($minor, $currency);
     }
 
     public function add(self $other): self
@@ -91,6 +92,10 @@ final readonly class Money
 
     public function abs(): self
     {
+        if (\PHP_INT_MIN === $this->amountMinor) {
+            throw new MoneyOverflowException('Money amount overflows integer limits.');
+        }
+
         return $this->amountMinor < 0 ? new self(-$this->amountMinor, $this->currency) : $this;
     }
 
@@ -102,7 +107,7 @@ final readonly class Money
     {
         $product = \bcmul((string) $this->amountMinor, $factor, 12);
 
-        return new self((int) $mode->roundToInteger($product), $this->currency);
+        return self::createSafe($mode->roundToInteger($product), $this->currency);
     }
 
     /**
@@ -112,7 +117,7 @@ final readonly class Money
     {
         $value = \bcdiv(\bcmul((string) $this->amountMinor, $percent, 12), '100', 12);
 
-        return new self((int) $mode->roundToInteger($value), $this->currency);
+        return self::createSafe($mode->roundToInteger($value), $this->currency);
     }
 
     public function equals(self $other): bool
@@ -141,6 +146,20 @@ final readonly class Money
         }
 
         return \bcdiv((string) $this->amountMinor, \bcpow('10', (string) $scale), $scale);
+    }
+
+    /**
+     * Создаёт Money из строкового значения минорных единиц, защищаясь от тихого
+     * переполнения int: `(int)` для строки вне диапазона PHP_INT_MAX/MIN молча
+     * оборачивается (в т.ч. в отрицательное значение), что недопустимо в деньгах.
+     */
+    private static function createSafe(string $amountMinor, string $currency): self
+    {
+        if (\bccomp($amountMinor, (string) \PHP_INT_MAX, 0) > 0 || \bccomp($amountMinor, (string) \PHP_INT_MIN, 0) < 0) {
+            throw new MoneyOverflowException('Money amount overflows integer limits.');
+        }
+
+        return new self((int) $amountMinor, $currency);
     }
 
     private static function fractionDigits(string $currency): int

--- a/site/src/Shared/Domain/ValueObject/RoundingMode.php
+++ b/site/src/Shared/Domain/ValueObject/RoundingMode.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Domain\ValueObject;
+
+/**
+ * Стратегии округления денежной величины до целых минорных единиц.
+ *
+ * Все вычисления — через bcmath, без float.
+ */
+enum RoundingMode
+{
+    /** Половина — от нуля (1.5 → 2, -1.5 → -2). Финансовый дефолт. */
+    case HALF_UP;
+
+    /** Банковское округление: половина — к чётному (0.5 → 0, 1.5 → 2, 2.5 → 2). */
+    case HALF_EVEN;
+
+    /**
+     * Округляет bcmath-decimal до целого (строка без дробной части).
+     */
+    public function roundToInteger(string $value): string
+    {
+        $value = trim($value);
+        if ('' === $value) {
+            return '0';
+        }
+
+        $negative = str_starts_with($value, '-');
+        $abs = ltrim($negative ? substr($value, 1) : $value, '+');
+        if ('' === $abs) {
+            $abs = '0';
+        }
+
+        $dot = strpos($abs, '.');
+        $fracLen = false === $dot ? 0 : strlen($abs) - $dot - 1;
+
+        $intPart = \bcadd($abs, '0', 0); // усечение к нулю
+
+        if (0 === $fracLen) {
+            $resultAbs = $intPart;
+        } else {
+            $frac = \bcsub($abs, $intPart, $fracLen);
+            $cmp = \bccomp($frac, '0.5', $fracLen);
+
+            $roundUp = match ($this) {
+                self::HALF_UP => $cmp >= 0,
+                self::HALF_EVEN => $cmp > 0 || (0 === $cmp && '0' !== \bcmod($intPart, '2')),
+            };
+
+            $resultAbs = $roundUp ? \bcadd($intPart, '1', 0) : $intPart;
+        }
+
+        return $negative && '0' !== $resultAbs ? '-'.$resultAbs : $resultAbs;
+    }
+}

--- a/site/src/Shared/Infrastructure/Doctrine/MoneyAmountType.php
+++ b/site/src/Shared/Infrastructure/Doctrine/MoneyAmountType.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Doctrine;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\BigIntType;
+
+/**
+ * BIGINT-колонка, гидрируемая в PHP `int` (а не `string`, как штатный BigIntType).
+ *
+ * Нужен для маппинга `Money::$amountMinor` (readonly int) в Embeddable: штатный
+ * bigint отдаёт строку, что несовместимо с типизированным int-свойством.
+ *
+ * Диапазон: PHP int 64-бит = ±9.2·10^18 копеек ≈ ±9.2·10^16 ₽ — покрывает decimal(18,2).
+ */
+final class MoneyAmountType extends BigIntType
+{
+    public const NAME = 'money_amount_minor';
+
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?int
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        return (int) $value;
+    }
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+}

--- a/site/tests/Fixtures/Doctrine/MoneyHolder.php
+++ b/site/tests/Fixtures/Doctrine/MoneyHolder.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Fixtures\Doctrine;
+
+use App\Shared\Domain\ValueObject\Money;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Тестовая Entity для проверки маппинга Money как Embeddable.
+ * Таблица создаётся/удаляется в тесте через SchemaTool, в прод-схему не попадает.
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'test_money_holder')]
+class MoneyHolder
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'string', length: 36)]
+    private string $id;
+
+    #[ORM\Embedded(class: Money::class, columnPrefix: false)]
+    private Money $amount;
+
+    public function __construct(string $id, Money $amount)
+    {
+        $this->id = $id;
+        $this->amount = $amount;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getAmount(): Money
+    {
+        return $this->amount;
+    }
+}

--- a/site/tests/Integration/Shared/MoneyEmbeddableMappingTest.php
+++ b/site/tests/Integration/Shared/MoneyEmbeddableMappingTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Shared;
+
+use App\Shared\Domain\ValueObject\Money;
+use App\Tests\Fixtures\Doctrine\MoneyHolder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Doctrine\ORM\Tools\SchemaTool;
+use Ramsey\Uuid\Uuid;
+
+final class MoneyEmbeddableMappingTest extends IntegrationTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $tool = new SchemaTool($this->em);
+        $meta = [$this->em->getClassMetadata(MoneyHolder::class)];
+        $tool->dropSchema($meta);
+        $tool->createSchema($meta);
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->em)) {
+            (new SchemaTool($this->em))->dropSchema([$this->em->getClassMetadata(MoneyHolder::class)]);
+        }
+
+        parent::tearDown();
+    }
+
+    public function testEmbeddableMapsTwoColumns(): void
+    {
+        $meta = $this->em->getClassMetadata(MoneyHolder::class);
+
+        self::assertTrue($meta->hasField('amount.amountMinor'));
+        self::assertTrue($meta->hasField('amount.currency'));
+        self::assertSame('amount_minor', $meta->getColumnName('amount.amountMinor'));
+        self::assertSame('currency', $meta->getColumnName('amount.currency'));
+        self::assertSame('money_amount_minor', $meta->getTypeOfField('amount.amountMinor'));
+    }
+
+    public function testRoundTripPersistAndHydrate(): void
+    {
+        $id = Uuid::uuid7()->toString();
+
+        $this->em->persist(new MoneyHolder($id, Money::fromString('123.45', 'RUB')));
+        $this->em->flush();
+        $this->em->clear();
+
+        $found = $this->em->getRepository(MoneyHolder::class)->find($id);
+
+        self::assertNotNull($found);
+        // ключевая проверка: readonly int гидрируется из bigint как int, не string
+        self::assertSame(12345, $found->getAmount()->amountMinor());
+        self::assertSame('RUB', $found->getAmount()->currency());
+        self::assertTrue($found->getAmount()->equals(Money::fromMinor(12345, 'RUB')));
+    }
+
+    public function testRoundTripNegativeAmount(): void
+    {
+        $id = Uuid::uuid7()->toString();
+
+        $this->em->persist(new MoneyHolder($id, Money::fromMinor(-50000, 'USD')));
+        $this->em->flush();
+        $this->em->clear();
+
+        $found = $this->em->getRepository(MoneyHolder::class)->find($id);
+
+        self::assertNotNull($found);
+        self::assertSame(-50000, $found->getAmount()->amountMinor());
+        self::assertSame('USD', $found->getAmount()->currency());
+    }
+}

--- a/site/tests/Unit/Shared/Domain/ValueObject/MoneyTest.php
+++ b/site/tests/Unit/Shared/Domain/ValueObject/MoneyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Shared\Domain\ValueObject;
 
 use App\Shared\Domain\Exception\MoneyMismatchException;
+use App\Shared\Domain\Exception\MoneyOverflowException;
 use App\Shared\Domain\ValueObject\Money;
 use App\Shared\Domain\ValueObject\RoundingMode;
 use PHPUnit\Framework\TestCase;
@@ -173,6 +174,47 @@ final class MoneyTest extends TestCase
     {
         self::assertSame(12345, Money::fromMinor(-12345, 'RUB')->abs()->amountMinor());
         self::assertSame(12345, Money::fromMinor(12345, 'RUB')->abs()->amountMinor());
+    }
+
+    public function testAbsRejectsIntMinOverflow(): void
+    {
+        $this->expectException(MoneyOverflowException::class);
+
+        Money::fromMinor(\PHP_INT_MIN, 'RUB')->abs();
+    }
+
+    public function testFromStringRejectsOverflow(): void
+    {
+        $this->expectException(MoneyOverflowException::class);
+
+        // 22 цифры после умножения на 100 — заведомо больше PHP_INT_MAX (~9.2e18)
+        Money::fromString('99999999999999999999', 'RUB');
+    }
+
+    public function testMultiplyRejectsOverflow(): void
+    {
+        $this->expectException(MoneyOverflowException::class);
+
+        Money::fromMinor(\PHP_INT_MAX, 'RUB')->multiply('2');
+    }
+
+    public function testMultiplyRejectsNegativeOverflow(): void
+    {
+        $this->expectException(MoneyOverflowException::class);
+
+        Money::fromMinor(\PHP_INT_MAX, 'RUB')->multiply('-2');
+    }
+
+    public function testPercentageRejectsOverflow(): void
+    {
+        $this->expectException(MoneyOverflowException::class);
+
+        Money::fromMinor(\PHP_INT_MAX, 'RUB')->percentage('1000');
+    }
+
+    public function testArithmeticStaysWithinRangeDoesNotThrow(): void
+    {
+        self::assertSame(\PHP_INT_MAX, Money::fromMinor(\PHP_INT_MAX, 'RUB')->multiply('1')->amountMinor());
     }
 
     public function testPredicates(): void

--- a/site/tests/Unit/Shared/Domain/ValueObject/MoneyTest.php
+++ b/site/tests/Unit/Shared/Domain/ValueObject/MoneyTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Shared\Domain\ValueObject;
 
 use App\Shared\Domain\Exception\MoneyMismatchException;
 use App\Shared\Domain\ValueObject\Money;
+use App\Shared\Domain\ValueObject\RoundingMode;
 use PHPUnit\Framework\TestCase;
 
 final class MoneyTest extends TestCase
@@ -98,5 +99,94 @@ final class MoneyTest extends TestCase
         $this->expectException(MoneyMismatchException::class);
 
         Money::fromMinor(1000, 'RUB')->compareTo(Money::fromMinor(100, 'USD'));
+    }
+
+    public function testFromStringParsesDecimalForTwoFractionCurrency(): void
+    {
+        self::assertSame(12345, Money::fromString('123.45', 'rub')->amountMinor());
+        self::assertSame('RUB', Money::fromString('123.45', 'rub')->currency());
+    }
+
+    public function testFromStringNormalizesSpacesAndComma(): void
+    {
+        self::assertSame(123456, Money::fromString('1 234,56', 'RUB')->amountMinor());
+        self::assertSame(123456, Money::fromString("1\u{00A0}234.56", 'RUB')->amountMinor());
+    }
+
+    public function testFromStringParsesNegative(): void
+    {
+        self::assertSame(-12345, Money::fromString('-123.45', 'RUB')->amountMinor());
+    }
+
+    public function testFromStringUsesCurrencyFractionDigits(): void
+    {
+        self::assertSame(1000, Money::fromString('1000', 'JPY')->amountMinor());
+        self::assertSame(1000, Money::fromString('1000.4', 'JPY')->amountMinor());
+    }
+
+    public function testFromStringRoundsHalfUp(): void
+    {
+        self::assertSame(12346, Money::fromString('123.455', 'RUB')->amountMinor());
+        self::assertSame(12345, Money::fromString('123.454', 'RUB')->amountMinor());
+    }
+
+    public function testFromStringRejectsGarbage(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Money::fromString('abc', 'RUB');
+    }
+
+    public function testToDecimalString(): void
+    {
+        self::assertSame('123.45', Money::fromMinor(12345, 'RUB')->toDecimalString());
+        self::assertSame('-123.45', Money::fromMinor(-12345, 'RUB')->toDecimalString());
+        self::assertSame('0.05', Money::fromMinor(5, 'RUB')->toDecimalString());
+        self::assertSame('1000', Money::fromMinor(1000, 'JPY')->toDecimalString());
+    }
+
+    public function testRoundTripStringConversion(): void
+    {
+        self::assertSame('123.45', Money::fromString('123.45', 'RUB')->toDecimalString());
+    }
+
+    public function testMultiply(): void
+    {
+        self::assertSame(1500, Money::fromMinor(1000, 'RUB')->multiply('1.5')->amountMinor());
+        self::assertSame(100, Money::fromMinor(1000, 'RUB')->multiply('0.1')->amountMinor());
+    }
+
+    public function testMultiplyRoundingModes(): void
+    {
+        self::assertSame(101, Money::fromMinor(100, 'RUB')->multiply('1.005', RoundingMode::HALF_UP)->amountMinor());
+        self::assertSame(100, Money::fromMinor(100, 'RUB')->multiply('1.005', RoundingMode::HALF_EVEN)->amountMinor());
+    }
+
+    public function testPercentage(): void
+    {
+        self::assertSame(2000, Money::fromMinor(10000, 'RUB')->percentage('20')->amountMinor());
+        self::assertSame(1, Money::fromMinor(100, 'RUB')->percentage('0.5', RoundingMode::HALF_UP)->amountMinor());
+        self::assertSame(0, Money::fromMinor(100, 'RUB')->percentage('0.5', RoundingMode::HALF_EVEN)->amountMinor());
+    }
+
+    public function testAbs(): void
+    {
+        self::assertSame(12345, Money::fromMinor(-12345, 'RUB')->abs()->amountMinor());
+        self::assertSame(12345, Money::fromMinor(12345, 'RUB')->abs()->amountMinor());
+    }
+
+    public function testPredicates(): void
+    {
+        self::assertTrue(Money::fromMinor(1, 'RUB')->isPositive());
+        self::assertFalse(Money::fromMinor(0, 'RUB')->isPositive());
+        self::assertTrue(Money::fromMinor(-1, 'RUB')->isNegative());
+        self::assertFalse(Money::fromMinor(0, 'RUB')->isNegative());
+    }
+
+    public function testEquals(): void
+    {
+        self::assertTrue(Money::fromMinor(100, 'RUB')->equals(Money::fromMinor(100, 'RUB')));
+        self::assertFalse(Money::fromMinor(100, 'RUB')->equals(Money::fromMinor(101, 'RUB')));
+        self::assertFalse(Money::fromMinor(100, 'RUB')->equals(Money::fromMinor(100, 'USD')));
     }
 }

--- a/site/tests/Unit/Shared/Domain/ValueObject/MoneyTest.php
+++ b/site/tests/Unit/Shared/Domain/ValueObject/MoneyTest.php
@@ -212,6 +212,20 @@ final class MoneyTest extends TestCase
         Money::fromMinor(\PHP_INT_MAX, 'RUB')->percentage('1000');
     }
 
+    public function testMultiplyRejectsNonNumericFactor(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Money::fromMinor(1000, 'RUB')->multiply('abc');
+    }
+
+    public function testPercentageRejectsNonNumericPercent(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Money::fromMinor(1000, 'RUB')->percentage('20%');
+    }
+
     public function testArithmeticStaysWithinRangeDoesNotThrow(): void
     {
         self::assertSame(\PHP_INT_MAX, Money::fromMinor(\PHP_INT_MAX, 'RUB')->multiply('1')->amountMinor());

--- a/site/tests/Unit/Shared/Domain/ValueObject/RoundingModeTest.php
+++ b/site/tests/Unit/Shared/Domain/ValueObject/RoundingModeTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Domain\ValueObject;
+
+use App\Shared\Domain\ValueObject\RoundingMode;
+use PHPUnit\Framework\TestCase;
+
+final class RoundingModeTest extends TestCase
+{
+    public function testHalfUpRoundsAwayFromZeroOnTie(): void
+    {
+        self::assertSame('2', RoundingMode::HALF_UP->roundToInteger('1.5'));
+        self::assertSame('3', RoundingMode::HALF_UP->roundToInteger('2.5'));
+        self::assertSame('-2', RoundingMode::HALF_UP->roundToInteger('-1.5'));
+    }
+
+    public function testHalfUpBelowAndAboveTie(): void
+    {
+        self::assertSame('1', RoundingMode::HALF_UP->roundToInteger('1.4'));
+        self::assertSame('2', RoundingMode::HALF_UP->roundToInteger('1.6'));
+        self::assertSame('-1', RoundingMode::HALF_UP->roundToInteger('-1.4'));
+    }
+
+    public function testHalfEvenRoundsToEvenOnTie(): void
+    {
+        self::assertSame('0', RoundingMode::HALF_EVEN->roundToInteger('0.5'));
+        self::assertSame('2', RoundingMode::HALF_EVEN->roundToInteger('1.5'));
+        self::assertSame('2', RoundingMode::HALF_EVEN->roundToInteger('2.5'));
+        self::assertSame('4', RoundingMode::HALF_EVEN->roundToInteger('3.5'));
+        self::assertSame('-2', RoundingMode::HALF_EVEN->roundToInteger('-2.5'));
+    }
+
+    public function testHalfEvenNonTie(): void
+    {
+        self::assertSame('3', RoundingMode::HALF_EVEN->roundToInteger('2.6'));
+        self::assertSame('2', RoundingMode::HALF_EVEN->roundToInteger('2.4'));
+    }
+
+    public function testIntegerInputUnchanged(): void
+    {
+        self::assertSame('5', RoundingMode::HALF_UP->roundToInteger('5'));
+        self::assertSame('0', RoundingMode::HALF_UP->roundToInteger('0'));
+        self::assertSame('-7', RoundingMode::HALF_EVEN->roundToInteger('-7'));
+    }
+}


### PR DESCRIPTION
## Зачем

Инфраструктурная задача (отдельная от миграции модуля Cash): сделать `Money` самодостаточным финансовым VO и встраиваемым в Entity через Doctrine.

Было: `Money` умел только `fromMinor/add/subtract/negate/compareTo/isZero` и использовался лишь в Ingestion, где вручную распаковывался в два скалярных поля. Парсинг денег продублирован в ≥3 местах с разным округлением.

## Что в PR

**Money VO** (`src/Shared/Domain/ValueObject/Money.php`) — добавлено без изменения существующих сигнатур (обратная совместимость с Ingestion):
- `fromString` / `toDecimalString` — парсинг decimal ↔ минорные единицы; масштаб по валюте через `Intl\Currencies`; вся арифметика на bcmath, без float
- `multiply` / `percentage` (с `RoundingMode`), `abs`, `equals`, `isPositive`, `isNegative`

**`RoundingMode` enum** — `HALF_UP` / `HALF_EVEN`.

**Защита денежной арифметики** (по ревью Gemini):
- `createSafe()` — все фабрики/операции (`fromString`, `multiply`, `percentage`) проверяют диапазон через `bccomp` и бросают `MoneyOverflowException` вместо тихого int-wrap при выходе за `PHP_INT_MAX/MIN`
- `abs()` — guard на `PHP_INT_MIN` (отрицание дало бы `float` → `TypeError` под `strict_types`)
- `multiply`/`percentage` валидируют аргумент через `Assert::regex` → понятный `InvalidArgumentException` вместо сырого `ValueError` из bcmath

**Doctrine-маппинг:**
- `MoneyAmountType` (custom DBAL-тип, `bigint → int`) — `readonly int $amountMinor` корректно гидрируется из bigint
- `Money` → `#[ORM\Embeddable]` (две колонки → `SUM`/`ORDER BY` по сумме работают)
- регистрация типа + namespace-маппинга `SharedValueObject` в `doctrine.yaml`
- `ARCHITECTURE.md` — новая секция «Shared Value Objects — Money»

**Тесты:** unit на Money/RoundingMode (вкл. overflow и валидацию аргументов) + интеграционный round-trip через test-only fixture-сущность.

## Scope / границы
- Боевые Entity **не трогаются** (включая `FinancialTransaction`), **миграций БД нет** — embeddable не создаёт таблиц.
- Адаптация существующих сущностей и внедрение в Cash — отдельные follow-up задачи (см. `docs/tasks/money-vo/handoff.md`).

## Верификация
- `composer test:unit -- --filter '(MoneyTest|RoundingModeTest|FinancialTransactionTest)'` → 39 ✅
- `composer test -- --testsuite integration --filter MoneyEmbeddableMappingTest` → 3 ✅ (round-trip; int из bigint)
- `doctrine:schema:validate --skip-sync` → mapping OK по всему приложению
- `composer cs:check` → изменённые файлы чистые

## На что смотреть ревьюеру
1. **Правка `config/packages/doctrine.yaml`** — новый dbal-тип + маппинг `SharedValueObject` (namespace embeddable обязан быть покрыт driver chain Symfony) + `when@test` маппинг фикстур.
2. ORM-атрибуты на доменном VO `Shared/Domain/Money` — осознанное решение (без infrastructure-обёртки). Замечание: VO импортирует `MoneyAmountType` (Domain → Infrastructure).
3. Диапазон: PHP `int` 64-бит ≈ ±9.2·10¹⁶ ₽ (минор); за пределами — `MoneyOverflowException`, тихого wrap нет.
4. PHPStan в проекте не установлен (`make stan` недоступен) — прогнан только `cs:check`.

## История ревью
- Gemini Code Assist (bot): отмечены риски тихого int-overflow в `fromString`/`multiply`/`percentage` и `TypeError` в `abs()` при `PHP_INT_MIN` — **исправлено** (`createSafe` + guard). Рекомендация валидировать аргументы `multiply`/`percentage` — **добавлено** (`Assert::regex`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)