### PR TITLE
ci(prod): inject SENTRY_RELEASE (git sha) for GlitchTip release tracking

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -133,6 +133,7 @@ jobs:
                     export POSTGRES_PASSWORD="${{ secrets.POSTGRES_PASSWORD }}"
                     export SITE_MAILER_DSN="${{ secrets.SITE_MAILER_DSN }}"
                     export SENTRY_DSN="${{ secrets.SENTRY_DSN }}"
+                    export SENTRY_RELEASE="${{ github.sha }}"
                     export HEALTH_CHECK_TOKEN="${{ secrets.HEALTH_CHECK_TOKEN }}"
 
                     echo "🚚 Скачивание свежих образов из GHCR"
@@ -205,6 +206,7 @@ jobs:
                     export POSTGRES_PASSWORD="${{ secrets.POSTGRES_PASSWORD }}"
                     export SITE_MAILER_DSN="${{ secrets.SITE_MAILER_DSN }}"
                     export SENTRY_DSN="${{ secrets.SENTRY_DSN }}"
+                    export SENTRY_RELEASE="${{ github.sha }}"
                     export HEALTH_CHECK_TOKEN="${{ secrets.HEALTH_CHECK_TOKEN }}"
 
                     docker compose -f docker-compose.prod.yml run --rm site-php-cli bin/console doctrine:migrations:migrate --no-interaction

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -21,6 +21,8 @@ x-php-env: &php-env
     MESSENGER_TRANSPORT_DSN_WB_FINANCE: redis://site-redis:6379/messages_wb_finance
     MAILER_DSN: ${SITE_MAILER_DSN}
     SENTRY_DSN: ${SENTRY_DSN}
+    # Релиз для GlitchTip — git sha из деплоя. Пусто = релиз-трекинг выключен (безопасно).
+    SENTRY_RELEASE: ${SENTRY_RELEASE:-}
     HEALTH_CHECK_TOKEN: ${HEALTH_CHECK_TOKEN}
     APP_MAIL_FROM: "Ваш Финдир <support@vashfindir.ru>"
     APP_MAIL_REPLY_TO: "support@vashfindir.ru"
@@ -401,6 +403,8 @@ services:
             MESSENGER_TRANSPORT_DSN_WB_FINANCE: redis://site-redis:6379/messages_wb_finance
             MAILER_DSN: ${SITE_MAILER_DSN}
             SENTRY_DSN: ${SENTRY_DSN}
+            # Релиз для GlitchTip — git sha из деплоя. Пусто = релиз-трекинг выключен (безопасно).
+            SENTRY_RELEASE: ${SENTRY_RELEASE:-}
             APP_MAIL_FROM: "Ваш Финдир <support@vashfindir.ru>"
             APP_MAIL_REPLY_TO: "support@vashfindir.ru"
             FEATURE_FUNDS_AND_WIDGET: ${FEATURE_FUNDS_AND_WIDGET:-1}


### PR DESCRIPTION
## Цель
Прокинуть `SENTRY_RELEASE` (git sha) в прод, чтобы события в GlitchTip тегировались релизом — для регрессий по деплоям, suspect commits и «resolve in next release».

Дополняет PR #2061 (там Symfony-сторона: `sentry.yaml` читает `release: '%env(default::SENTRY_RELEASE)%'`). **Сам по себе этот PR безопасен** даже без #2061 — переменная просто не используется.

## Изменения (4 строки, 2 файла)

**`docker-compose.prod.yml`** — прокидываем env в контейнеры:
- в anchor `&php-env` (покрывает `site-php-fpm`, `site-php-cli` и 3 воркера) рядом с `SENTRY_DSN`;
- в отдельном блоке `environment` сервиса `scheduler`.
- Значение `${SENTRY_RELEASE:-}` → при отсутствии переменной пусто = релиз-трекинг просто выключен, ничего не ломается.

**`.github/workflows/deploy.yml`** — задаём значение перед `docker compose up`:
- `export SENTRY_RELEASE="${{ github.sha }}"` в job `deploy` (там стартуют fpm/воркеры/scheduler);
- то же в job `migrations` (для симметрии env-блоков).
- Источник — `${{ github.sha }}`, тот же sha, которым уже тегируются образы (`build-and-push`).

## Почему обе правки
Compose-файл объявляет, что контейнер ждёт `SENTRY_RELEASE`; `deploy.yml` поставляет значение в окружение SSH-сессии перед `up`. Одна правка без другой бессмысленна.

## Проверки
- ✅ YAML-синтаксис обоих файлов валиден (`yaml.safe_load_all`)
- Без секретов (используется публичный `github.sha`), без изменения существующего поведения при пустом значении

## Как проверить после мержа (когда смержен и #2061)
В GlitchTip у новых событий появится `release` = git sha задеплоенного коммита.
