### PR TITLE
fix(logging): downgrade expected-condition logs from error to warning

### DIFF
--- a/docs/tasks/logging/stages/stage-7-error-level-followups.md
+++ b/docs/tasks/logging/stages/stage-7-error-level-followups.md
@@ -1,0 +1,42 @@
+## Stage 7: Follow-up — точечные правки уровней логирования — DONE
+
+**Риск:** 🟡 MEDIUM (правки в module-коде хендлеров/команды, не legacy-зона; поведение = только уровень лога)
+**Следующее действие:** 🛑 STOP, ждать Владельца (PR)
+
+### Что сделано
+Исправлены мислейблы `error→warning` из аудита Stage 6 (по конвенции PATTERNS.md §23: ожидаемо/повторяемо/невалидный-вход → warning, не error → не уходит в GlitchTip).
+
+| Файл:строка | Было | Стало | Канал |
+|---|---|---|---|
+| `Marketplace/MessageHandler/CloseMonthStageHandler.php:50` | `error` | `warning` | app → GlitchTip ⭐ |
+| `Marketplace/MessageHandler/SyncOzonReportHandler.php:96` | `error` | `warning` | app → GlitchTip ⭐ |
+| `MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php:210` | `error('msg', $e, [...])` | `warning('msg', ['exception' => $e, ...])` | marketplace_ads (файл) |
+| `MarketplaceAds/Command/AdBatchSchedulerCommand.php:185` | `error` | `warning` | marketplace_ads (файл) |
+
+Для `FetchOzonAdStatisticsHandler` логгер — кастомный `AppLogger` (3-арг `error(string, ?Throwable, array)`); у `AppLogger::warning(string, array)` нет аргумента-исключения, поэтому `$e` перенесён в контекст (`'exception' => $e`).
+
+### Решение по `SyncJobFailureSubscriber:70` (из follow-up)
+**Не меняю.** При детальном чтении это корректно: техническая ошибка персиста статуса — `error` (стр. 60), штатное «job failed after retries exhausted» — `warning` (стр. 70). Осознанное разделение, согласованное с §23. Флаг «на обсуждение» снят.
+
+### Тесты (регрессия: red-on-old, green-on-new — подтверждено)
+- `SyncOzonReportHandlerTest::testInvalidDateIsLoggedAsWarningNotError` — new
+- `CloseMonthStageHandlerTest` — new файл (Action `final` → мок через `BypassFinals`)
+- `FetchOzonAdStatisticsHandlerTest::testTransientErrorIsLoggedAsWarningNotError` — new (мок `AppLogger`)
+- `AdBatchSchedulerCommandTest::testTransientFailureIsLoggedAsWarningNotError` — new
+Каждый ассертит `warning()` once + `error()` never. Прогон с откатом src к HEAD → **4 failures** (старый код звал `error`); с фиксом → green.
+
+### Затронутые файлы
+- 4 src (modified), 3 теста (modified) + 1 тест (new `CloseMonthStageHandlerTest.php`)
+
+### Self-review
+- [x] Scope compliance — только уровень лога; сообщения/контекст/поток/rethrow без изменений
+- [x] Patterns / naming — тесты по паттерну репо (`createMock` + `BypassFinals`, builders)
+- [x] Forbidden actions — none (нет миграций/зависимостей/legacy-правок/API); не реформатил чужой код «заодно»
+- [x] Security — N/A
+- [x] CS — добавленные строки чистые; «Found 1» по 3 файлам — **преэкзистинг-долг** (Yoda/выравнивание), не мои строки, намеренно не трогаю (иначе scope creep)
+- [x] PHPStan — N/A (не настроен)
+- [x] Tests — полный unit-сьют зелёный (1192); 4 новых red-on-old/green-on-new
+- [x] ARCHITECTURE.md — N/A
+
+### Открытые вопросы
+- нет

--- a/site/src/Marketplace/MessageHandler/CloseMonthStageHandler.php
+++ b/site/src/Marketplace/MessageHandler/CloseMonthStageHandler.php
@@ -46,8 +46,9 @@ final class CloseMonthStageHandler
                 'pl_documents'   => count($result['plDocumentIds']),
             ]);
         } catch (\DomainException $e) {
-            // DomainException — не ретраим, данные не готовы
-            $this->logger->error('[MonthClose] Domain error — no retry', [
+            // DomainException — ожидаемое доменное условие («данные не готовы»),
+            // не ретраим и НЕ инцидент → warning (в GlitchTip не уходит).
+            $this->logger->warning('[MonthClose] Domain error — no retry', [
                 'company_id' => $message->companyId,
                 'stage'      => $message->stage,
                 'error'      => $e->getMessage(),

--- a/site/src/Marketplace/MessageHandler/SyncOzonReportHandler.php
+++ b/site/src/Marketplace/MessageHandler/SyncOzonReportHandler.php
@@ -93,7 +93,8 @@ final class SyncOzonReportHandler
         if ($date !== null) {
             $parsed = \DateTimeImmutable::createFromFormat('!Y-m-d', $date, $timezone);
             if ($parsed === false || $parsed->format('Y-m-d') !== $date) {
-                $this->logger->error('Invalid date in SyncOzonReportMessage, skipping', [
+                // Невалидный вход → skip. Это не системный сбой → warning (не в GlitchTip).
+                $this->logger->warning('Invalid date in SyncOzonReportMessage, skipping', [
                     'company_id' => $companyId,
                     'date'       => $date,
                 ]);

--- a/site/src/MarketplaceAds/Command/AdBatchSchedulerCommand.php
+++ b/site/src/MarketplaceAds/Command/AdBatchSchedulerCommand.php
@@ -182,7 +182,8 @@ final class AdBatchSchedulerCommand extends Command
             // транзакцию, batch остаётся PLANNED, cron попробует на следующем тике.
             $this->connection->rollBack();
 
-            $this->logger->error('Scheduler: transient failure, batch stays PLANNED', [
+            // Transient: batch остаётся PLANNED, cron повторит → warning, не инцидент.
+            $this->logger->warning('Scheduler: transient failure, batch stays PLANNED', [
                 'error' => $e->getMessage(),
                 'exception' => $e::class,
             ]);

--- a/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/FetchOzonAdStatisticsHandler.php
@@ -206,8 +206,10 @@ final class FetchOzonAdStatisticsHandler
         } catch (\Throwable $e) {
             // Сетевые сбои / 5xx / JSON-ошибки на prep-стадии — transient,
             // Messenger сделает retry. prepareStatisticsBatches идемпотентен
-            // (ничего не персистит), повтор безопасен.
-            $this->logger->error('Transient failure preparing Ozon ad statistics batches', $e, [
+            // (ничего не персистит), повтор безопасен. Ожидаемо-повторяемо → warning,
+            // не error (исключение кладём в контекст: AppLogger::warning(string, array)).
+            $this->logger->warning('Transient failure preparing Ozon ad statistics batches', [
+                'exception' => $e,
                 'jobId' => $message->jobId,
                 'companyId' => $message->companyId,
                 'dateFrom' => $message->dateFrom,

--- a/site/tests/Unit/Marketplace/MessageHandler/CloseMonthStageHandlerTest.php
+++ b/site/tests/Unit/Marketplace/MessageHandler/CloseMonthStageHandlerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\MessageHandler;
+
+use App\Marketplace\Application\CloseMonthStageAction;
+use App\Marketplace\Message\CloseMonthStageMessage;
+use App\Marketplace\MessageHandler\CloseMonthStageHandler;
+use DG\BypassFinals;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+// CloseMonthStageAction — final, нужен BypassFinals для createMock.
+BypassFinals::allowPaths([
+    '*/src/Marketplace/Application/CloseMonthStageAction.php',
+]);
+
+final class CloseMonthStageHandlerTest extends TestCase
+{
+    private const COMPANY_ID = '11111111-1111-1111-1111-111111111111';
+    private const ACTOR_ID = '22222222-2222-2222-2222-222222222222';
+
+    public function testDomainExceptionIsLoggedAsWarningNotError(): void
+    {
+        // Регрессия follow-up: DomainException — ожидаемое доменное условие
+        // («данные не готовы»), не ретраится и не инцидент → warning, не error.
+        $action = $this->createMock(CloseMonthStageAction::class);
+        $action->method('__invoke')->willThrowException(new \DomainException('Данные не готовы'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::never())->method('error');
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with(
+                self::stringContains('[MonthClose] Domain error'),
+                self::arrayHasKey('error'),
+            );
+
+        $handler = new CloseMonthStageHandler($action, $logger);
+
+        // DomainException проглатывается (no retry) — наружу не пробрасывается.
+        $handler(new CloseMonthStageMessage(
+            companyId: self::COMPANY_ID,
+            marketplace: 'ozon',
+            year: 2026,
+            month: 4,
+            stage: 'sales_returns',
+            actorUserId: self::ACTOR_ID,
+        ));
+    }
+}

--- a/site/tests/Unit/Marketplace/MessageHandler/SyncOzonReportHandlerTest.php
+++ b/site/tests/Unit/Marketplace/MessageHandler/SyncOzonReportHandlerTest.php
@@ -358,6 +358,38 @@ final class SyncOzonReportHandlerTest extends TestCase
         self::assertSame(1, $otherCompanyDoc->getRecordsCount());
     }
 
+    public function testInvalidDateIsLoggedAsWarningNotError(): void
+    {
+        // Регрессия follow-up: невалидный вход (дата) — это skip, не инцидент.
+        // Должен логироваться как warning (не уходит в GlitchTip), а не error.
+        $company = CompanyBuilder::aCompany()->withId(self::COMPANY_ID)->build();
+        $connection = new MarketplaceConnection(self::CONNECTION_ID, $company, MarketplaceType::OZON);
+
+        $em = $this->createEmMock($company, $connection);
+        $em->expects(self::never())->method('persist');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::never())->method('error');
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with(
+                self::stringContains('Invalid date in SyncOzonReportMessage'),
+                self::arrayHasKey('date'),
+            );
+
+        $adapter = $this->createMock(MarketplaceAdapterInterface::class);
+        $adapter->method('getMarketplaceType')->willReturn(MarketplaceType::OZON->value);
+        $adapter->expects(self::never())->method('fetchRawReport');
+
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::never())->method('dispatch');
+
+        $rawDocRepo = $this->createMock(MarketplaceRawDocumentRepository::class);
+
+        $handler = $this->createHandler($em, $adapter, $messageBus, $rawDocRepo, $logger);
+        $handler(new SyncOzonReportMessage(self::COMPANY_ID, self::CONNECTION_ID, 'not-a-date'));
+    }
+
     private function buildDocForDate(Company $company): MarketplaceRawDocument
     {
         $day = new \DateTimeImmutable(self::DATE);

--- a/site/tests/Unit/MarketplaceAds/Command/AdBatchSchedulerCommandTest.php
+++ b/site/tests/Unit/MarketplaceAds/Command/AdBatchSchedulerCommandTest.php
@@ -16,6 +16,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -171,6 +172,40 @@ final class AdBatchSchedulerCommandTest extends TestCase
         // Объект batch в памяти не изменился на successful path'е,
         // но мог быть частично модифицирован — это неважно, rollback на уровне БД
         // вернёт запись к исходному состоянию.
+    }
+
+    public function testTransientFailureIsLoggedAsWarningNotError(): void
+    {
+        // Регрессия follow-up: transient (batch остаётся PLANNED, cron повторит)
+        // не инцидент → warning, не error.
+        $batch = $this->buildBatch();
+
+        $this->batchRepo->method('findNextPlanned')->willReturn($batch);
+        $this->ozonClient->method('postStatistics')
+            ->willThrowException(new \RuntimeException('Ozon POST вернул HTTP 502'));
+
+        $this->connection->expects(self::once())->method('beginTransaction');
+        $this->connection->expects(self::once())->method('rollBack');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::never())->method('error');
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with(
+                self::stringContains('Scheduler: transient failure, batch stays PLANNED'),
+                self::arrayHasKey('exception'),
+            );
+
+        $command = new AdBatchSchedulerCommand(
+            $this->ozonClient,
+            $this->batchRepo,
+            $this->em,
+            $this->connection,
+            $logger,
+        );
+
+        $tester = new CommandTester($command);
+        self::assertSame(1, $tester->execute([]));
     }
 
     private function buildBatch(): AdScheduledBatch

--- a/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
@@ -702,6 +702,51 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
         ));
     }
 
+    public function testTransientErrorIsLoggedAsWarningNotError(): void
+    {
+        // Регрессия follow-up: transient prep-сбой повторяется Messenger'ом —
+        // ожидаемо-повторяемо → warning, не error.
+        $job = AdLoadJobBuilder::aJob()->asRunning()->build();
+
+        $jobRepo = $this->createMock(AdLoadJobRepository::class);
+        $jobRepo->method('findByIdAndCompany')->willReturn($job);
+
+        $ozonClient = $this->createMock(OzonAdClient::class);
+        $ozonClient->method('prepareStatisticsBatches')
+            ->willThrowException(new \RuntimeException('Ozon 502 Bad Gateway'));
+
+        $appLogger = $this->createMock(AppLogger::class);
+        $appLogger->expects(self::never())->method('error');
+        $appLogger->expects(self::once())
+            ->method('warning')
+            ->with(
+                self::stringContains('Transient failure preparing Ozon ad statistics batches'),
+                self::arrayHasKey('exception'),
+            );
+
+        $handler = new FetchOzonAdStatisticsHandler(
+            $ozonClient,
+            $jobRepo,
+            $this->createMock(AdScheduledBatchRepositoryInterface::class),
+            $this->createMock(AdChunkProgressRepositoryInterface::class),
+            $this->createMock(OzonAdPendingReportRepository::class),
+            $this->createMock(AdLoadJobFinalizer::class),
+            $this->createMock(MessageBusInterface::class),
+            $appLogger,
+            new NullLogger(),
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Ozon 502 Bad Gateway');
+
+        $handler(new FetchOzonAdStatisticsMessage(
+            AdLoadJobBuilder::DEFAULT_ID,
+            self::COMPANY_ID,
+            self::DATE_FROM,
+            self::DATE_TO,
+        ));
+    }
+
     private function createHandler(
         OzonAdClient $ozonClient,
         AdLoadJobRepository $jobRepo,


### PR DESCRIPTION
## Цель
Закрыть зафиксированные follow-up'ы аудита логирования (Stage 6): убрать мислейблы `error→warning`, из-за которых ожидаемые/повторяемые ситуации создают ложные инциденты в GlitchTip. Правило — `PATTERNS.md` §23.

## Изменения (только уровень лога, поведение иначе идентично)
| Файл:строка | error → warning | Эффект |
|---|---|---|
| `CloseMonthStageHandler.php:50` | DomainException «данные не готовы» (не ретраим) | убирает ложный алерт в GlitchTip ⭐ |
| `SyncOzonReportHandler.php:96` | невалидная дата → skip | убирает ложный алерт ⭐ |
| `FetchOzonAdStatisticsHandler.php:210` | transient prep-сбой (Messenger retry) | косметика (канал ads файловый) |
| `AdBatchSchedulerCommand.php:185` | transient (batch остаётся PLANNED) | косметика (файловый) |

`FetchOzonAdStatisticsHandler` использует кастомный `AppLogger` (3-арг `error`); у `AppLogger::warning(string,array)` нет арг-исключения → `$e` перенесён в контекст.

## Не тронуто
`Ingestion/SyncJobFailureSubscriber:70` — при детальном чтении корректен: техническая ошибка персиста = `error` (стр. 60), штатный terminal = `warning` (стр. 70). Осознанное разделение по §23.

## Тесты (red-on-old / green-on-new — подтверждено)
4 регрессионных теста (по одному на правку), каждый ассертит `warning()` once + `error()` never. С откатом src к HEAD → 4 failures; с фиксом → green. Полный unit-сьют: **1192 OK**.

## Заметка по CS
3 затронутых файла показывают `php-cs-fixer` «Found 1» — это **преэкзистинг-долг** (Yoda/выравнивание `=>`), не мои строки. Намеренно не реформатил, чтобы не раздувать диф несвязанными правками.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
