### PR TITLE
feat(logging): enrich Sentry scope with company/user/message context

### DIFF
--- a/docs/tasks/logging/stages/stage-5-scope-enrichment.md
+++ b/docs/tasks/logging/stages/stage-5-scope-enrichment.md
@@ -1,0 +1,47 @@
+## Stage 5: глобальное обогащение Sentry-scope + чистка logSlowExecution — DONE
+
+**Риск:** 🔴 HIGH (новая observability-инфраструктура + изменение Shared-сервиса `AppLogger`)
+**Следующее действие:** 🛑 STOP, ждать Владельца (PR)
+
+### Что сделано
+1. **`SentryMessengerScopeSubscriber`** (`Shared/Infrastructure/Sentry`) — на каждое принятое воркером сообщение (`WorkerMessageReceivedEvent`) выставляет в Sentry-scope теги `messenger.message` (класс) и `company_id` (если сообщение несёт). Теги перезаписываются на следующем сообщении (воркер последователен — push/pop не нужен; стейл между сообщениями безвреден). companyId извлекается duck-typing'ом (`getCompanyId()` или public `$companyId`) — без связывания Shared с feature-модулями.
+2. **`SentryRequestScopeSubscriber`** (`Shared/Infrastructure/Sentry`) — на `kernel.request` (main only) выставляет user id + тег `company_id`. Источник — существующий `AuditContextProvider` (уже безопасно гардит консоль/отсутствие запроса и ловит `NotFoundHttpException`).
+3. **`AppLogger::logSlowExecution`** — убран бэкдор в GlitchTip (`sentryHub->captureMessage`). Теперь только warning в файл; зависимость `HubInterface` удалена из конструктора (была нужна только для этого вызова). По конвенции §23: в GlitchTip только ERROR, медленное выполнение — не инцидент.
+
+### Дизайн-решения
+- **Без middleware → без правки `messenger.yaml`.** Использован автоконфигурируемый `WorkerMessage*`-подписчик (паттерн уже есть: `SyncJobFailureSubscriber`). Это снимает обязательный STOP на `messenger.yaml`.
+- **Без правки `sentry.yaml`.** Scope выставляется на текущем хабе (`HubInterface`), работает поверх существующей конфигурации.
+- **`AppLogger` теряет арг `HubInterface`** → обновлены 3 тестовых конструкции (`FetchOzonAdStatisticsHandlerTest` ×2, `ProcessAdRawDocumentHandlerTest`) + убраны неиспользуемые импорты.
+
+### Затронутые файлы
+- `src/Shared/Infrastructure/Sentry/SentryMessengerScopeSubscriber.php` — new (`final class`, EventSubscriber)
+- `src/Shared/Infrastructure/Sentry/SentryRequestScopeSubscriber.php` — new (`final class`, EventSubscriber)
+- `src/Shared/Service/AppLogger.php` — modified (убран hub + бэкдор)
+- `tests/Unit/Shared/Infrastructure/Sentry/SentryMessengerScopeSubscriberTest.php` — new
+- `tests/Unit/Shared/Infrastructure/Sentry/SentryRequestScopeSubscriberTest.php` — new
+- `tests/Unit/Shared/Service/AppLoggerTest.php` — new
+- `tests/Unit/MarketplaceAds/{FetchOzonAdStatisticsHandlerTest,ProcessAdRawDocumentHandlerTest}.php` — modified (AppLogger 1-арг)
+
+### Self-review
+- [x] Scope compliance — обогащение scope + чистка backdoor; продуктовая логика не тронута
+- [x] Patterns / naming — `final class`, EventSubscriber, слой `Infrastructure`, constructor injection; переиспользован `AuditContextProvider` вместо дублирования гардов
+- [x] Forbidden actions — none (нет миграций; `messenger.yaml`/`sentry.yaml` НЕ тронуты; нет новых зависимостей; не правил legacy `src/Service` сверх `AppLogger`, который уже Shared-сервис)
+- [x] Security — user id/company_id — не PII; `send_default_pii:false` сохранён; email/ФИО не выставляются
+- [x] CS — новые файлы чистые; `AppLogger.php` «Found 1» — преэкзистинг-долг в нетронутых методах `info()/error()` (точка в докблоке, `?\Throwable`, Yoda), намеренно не реформачу
+- [x] PHPStan — N/A (не настроен)
+- [x] Tests — 8 новых unit-тестов зелёные; полный unit-сьют **1200 OK**; `lint:container` OK
+- [x] ARCHITECTURE.md — N/A (подписчики не публичный интерфейс; `AppLogger` указан без сигнатуры)
+
+### Команды для проверки
+```
+docker compose run --rm -T site-php-cli php bin/phpunit --testsuite unit --filter 'SentryMessengerScopeSubscriber|SentryRequestScopeSubscriber|AppLoggerTest'
+docker compose run --rm -T site-php-cli php bin/console lint:container --env=test
+```
+
+### Риски / на что обратить внимание ревьюеру
+- `SentryRequestScopeSubscriber` на каждом main-запросе зовёт `AuditContextProvider::getCompanyId()` (читает сессию через `ActiveCompanyService`) — то же поведение, что и существующий `AuditLogSubscriber`, так что новый сайд-эффект не вводится.
+- Теги обогащают события, отправляемые во время обработки (через Monolog→Sentry на текущем scope). Реальный эффект — по факту в GlitchTip после деплоя.
+- `messenger.message` тег = FQCN (для анонимных классов в тестах — сгенерированное имя; в проде это реальные Message-классы).
+
+### Открытые вопросы
+- нет

--- a/site/src/Shared/Infrastructure/Sentry/SentryMessengerScopeSubscriber.php
+++ b/site/src/Shared/Infrastructure/Sentry/SentryMessengerScopeSubscriber.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Sentry;
+
+use Sentry\State\HubInterface;
+use Sentry\State\Scope;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
+
+/**
+ * Обогащает Sentry-scope контекстом обрабатываемого сообщения (в воркерах).
+ *
+ * На каждое принятое воркером сообщение выставляет теги `messenger.message`
+ * (класс) и `company_id` (если сообщение его несёт). Теги перезаписываются на
+ * следующем сообщении — баланса push/pop не требуется (воркер обрабатывает
+ * сообщения последовательно). Это даёт триаж по компании/типу сообщения для
+ * ошибок, залогированных во время обработки.
+ *
+ * Реализовано через WorkerMessage-событие (автоконфигурируемый подписчик),
+ * а не Messenger-middleware — без правки messenger.yaml.
+ */
+final class SentryMessengerScopeSubscriber implements EventSubscriberInterface
+{
+    public function __construct(private readonly HubInterface $hub)
+    {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            WorkerMessageReceivedEvent::class => 'onMessageReceived',
+        ];
+    }
+
+    public function onMessageReceived(WorkerMessageReceivedEvent $event): void
+    {
+        $message = $event->getEnvelope()->getMessage();
+        $companyId = $this->companyId($message);
+
+        $this->hub->configureScope(static function (Scope $scope) use ($message, $companyId): void {
+            $scope->setTag('messenger.message', $message::class);
+
+            if (null !== $companyId) {
+                $scope->setTag('company_id', $companyId);
+            } else {
+                $scope->removeTag('company_id');
+            }
+        });
+    }
+
+    private function companyId(object $message): ?string
+    {
+        if (method_exists($message, 'getCompanyId')) {
+            $value = $message->getCompanyId();
+
+            return \is_string($value) ? $value : null;
+        }
+
+        if (property_exists($message, 'companyId')) {
+            $value = $message->companyId;
+
+            return \is_string($value) ? $value : null;
+        }
+
+        return null;
+    }
+}

--- a/site/src/Shared/Infrastructure/Sentry/SentryMessengerScopeSubscriber.php
+++ b/site/src/Shared/Infrastructure/Sentry/SentryMessengerScopeSubscriber.php
@@ -53,15 +53,31 @@ final class SentryMessengerScopeSubscriber implements EventSubscriberInterface
     private function companyId(object $message): ?string
     {
         if (method_exists($message, 'getCompanyId')) {
-            $value = $message->getCompanyId();
-
-            return \is_string($value) ? $value : null;
+            return $this->stringify($message->getCompanyId());
         }
 
-        if (property_exists($message, 'companyId')) {
-            $value = $message->companyId;
+        // isset() (а не property_exists + прямой доступ) безопасно вернёт false
+        // для private/protected/неинициализированного свойства — воркер не упадёт.
+        if (isset($message->companyId)) {
+            return $this->stringify($message->companyId);
+        }
 
-            return \is_string($value) ? $value : null;
+        return null;
+    }
+
+    private function stringify(mixed $value): ?string
+    {
+        if (\is_string($value)) {
+            return $value;
+        }
+
+        if (\is_int($value)) {
+            return (string) $value;
+        }
+
+        // PHP 8: класс с __toString() неявно реализует Stringable (UUID VO и т.п.).
+        if ($value instanceof \Stringable) {
+            return (string) $value;
         }
 
         return null;

--- a/site/src/Shared/Infrastructure/Sentry/SentryRequestScopeSubscriber.php
+++ b/site/src/Shared/Infrastructure/Sentry/SentryRequestScopeSubscriber.php
@@ -43,13 +43,21 @@ final class SentryRequestScopeSubscriber implements EventSubscriberInterface
         $userId = $this->auditContext->getActorUserId();
         $companyId = $this->auditContext->getCompanyId();
 
+        // Явно сбрасываем в else-ветках: при переиспользовании процесса/scope
+        // (тесты, RoadRunner/Swoole/FrankenPHP) анонимный запрос не должен
+        // унаследовать user/company предыдущего. setUser(null) бросает TypeError —
+        // для сброса используем removeUser().
         $this->hub->configureScope(static function (Scope $scope) use ($userId, $companyId): void {
             if (null !== $userId) {
                 $scope->setUser(UserDataBag::createFromUserIdentifier($userId));
+            } else {
+                $scope->removeUser();
             }
 
             if (null !== $companyId) {
                 $scope->setTag('company_id', $companyId);
+            } else {
+                $scope->removeTag('company_id');
             }
         });
     }

--- a/site/src/Shared/Infrastructure/Sentry/SentryRequestScopeSubscriber.php
+++ b/site/src/Shared/Infrastructure/Sentry/SentryRequestScopeSubscriber.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Sentry;
+
+use App\Shared\Audit\AuditContextProvider;
+use Sentry\State\HubInterface;
+use Sentry\State\Scope;
+use Sentry\UserDataBag;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Обогащает Sentry-scope контекстом HTTP-запроса: user id и company_id.
+ *
+ * Источник — {@see AuditContextProvider} (уже безопасно гардит консоль/отсутствие
+ * запроса и ловит NotFoundHttpException для активной компании). Даёт триаж по
+ * пользователю/компании для ошибок, залогированных в рамках запроса.
+ */
+final class SentryRequestScopeSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly HubInterface $hub,
+        private readonly AuditContextProvider $auditContext,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest', 0],
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $userId = $this->auditContext->getActorUserId();
+        $companyId = $this->auditContext->getCompanyId();
+
+        $this->hub->configureScope(static function (Scope $scope) use ($userId, $companyId): void {
+            if (null !== $userId) {
+                $scope->setUser(UserDataBag::createFromUserIdentifier($userId));
+            }
+
+            if (null !== $companyId) {
+                $scope->setTag('company_id', $companyId);
+            }
+        });
+    }
+}

--- a/site/src/Shared/Service/AppLogger.php
+++ b/site/src/Shared/Service/AppLogger.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace App\Shared\Service;
 
 use Psr\Log\LoggerInterface;
-use Sentry\State\HubInterface;
-use Sentry\Severity;
 
 /**
  * Единая точка входа для логирования бизнес-событий и метрик.
@@ -15,7 +13,6 @@ class AppLogger
 {
     public function __construct(
         private readonly LoggerInterface $logger,
-        private readonly HubInterface $sentryHub
     ) {
     }
 
@@ -51,7 +48,11 @@ class AppLogger
     }
 
     /**
-     * Точечная отправка аномалий производительности (деградации) в Sentry
+     * Фиксация деградации производительности.
+     *
+     * Пишет ТОЛЬКО в локальный лог как warning. В GlitchTip намеренно не уходит:
+     * по конвенции туда попадает только ERROR (медленное выполнение — не инцидент).
+     * Перформанс отслеживается отдельно (Sentry tracing выключен осознанно).
      */
     public function logSlowExecution(string $operationName, int $durationMs, int $thresholdMs = 0): void
     {
@@ -65,10 +66,6 @@ class AppLogger
             $message .= sprintf(' (лимит: %d мс)', $thresholdMs);
         }
 
-        // 1. Пишем в локальный лог как Warning
         $this->logger->warning($message);
-
-        // 2. Отправляем алерт в GlitchTip вручную
-        $this->sentryHub->captureMessage($message, Severity::warning());
     }
 }

--- a/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/FetchOzonAdStatisticsHandlerTest.php
@@ -21,7 +21,6 @@ use App\Tests\Builders\MarketplaceAds\AdLoadJobBuilder;
 use DG\BypassFinals;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
-use Sentry\State\HubInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -393,7 +392,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             $pendingRepo,
             $finalizer,
             $messageBus,
-            new AppLogger(new NullLogger(), $this->createMock(HubInterface::class)),
+            new AppLogger(new NullLogger()),
             $marketplaceAdsLogger,
         );
 
@@ -769,7 +768,7 @@ final class FetchOzonAdStatisticsHandlerTest extends TestCase
             $pendingRepo,
             $finalizer ?? $this->createMock(AdLoadJobFinalizer::class),
             $messageBus,
-            new AppLogger(new NullLogger(), $this->createMock(HubInterface::class)),
+            new AppLogger(new NullLogger()),
             new NullLogger(),
         );
     }

--- a/site/tests/Unit/MarketplaceAds/ProcessAdRawDocumentHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/ProcessAdRawDocumentHandlerTest.php
@@ -20,7 +20,6 @@ use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
-use Sentry\State\HubInterface;
 
 // Bootstrap pins BypassFinals to an allowlist; extend it so the action and finalizer
 // under test can be doubled without touching the global bootstrap configuration.
@@ -69,7 +68,7 @@ final class ProcessAdRawDocumentHandlerTest extends TestCase
         $this->jobRepo = $this->createMock(AdLoadJobRepositoryInterface::class);
         $this->finalizer = $this->createMock(AdLoadJobFinalizer::class);
         $this->entityManager = $this->createMock(EntityManagerInterface::class);
-        $this->logger = new AppLogger(new NullLogger(), $this->createMock(HubInterface::class));
+        $this->logger = new AppLogger(new NullLogger());
 
         $this->handler = new ProcessAdRawDocumentHandler(
             $this->action,

--- a/site/tests/Unit/Shared/Infrastructure/Sentry/SentryMessengerScopeSubscriberTest.php
+++ b/site/tests/Unit/Shared/Infrastructure/Sentry/SentryMessengerScopeSubscriberTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Infrastructure\Sentry;
+
+use App\Shared\Infrastructure\Sentry\SentryMessengerScopeSubscriber;
+use PHPUnit\Framework\TestCase;
+use Sentry\Event;
+use Sentry\State\HubInterface;
+use Sentry\State\Scope;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
+
+final class SentryMessengerScopeSubscriberTest extends TestCase
+{
+    public function testSetsMessageClassAndCompanyIdTags(): void
+    {
+        $message = new class {
+            public string $companyId = 'comp-123';
+        };
+
+        $event = $this->scopeAfterReceiving($message, new Scope());
+
+        self::assertSame('comp-123', $event->getTags()['company_id'] ?? null);
+        self::assertSame($message::class, $event->getTags()['messenger.message'] ?? null);
+    }
+
+    public function testClearsStaleCompanyIdWhenMessageHasNone(): void
+    {
+        // Воркер последовательно обрабатывает сообщения; сообщение без companyId
+        // не должно унаследовать тег от предыдущего.
+        $scope = new Scope();
+        $scope->setTag('company_id', 'stale');
+
+        $message = new class {};
+        $event = $this->scopeAfterReceiving($message, $scope);
+
+        self::assertArrayNotHasKey('company_id', $event->getTags());
+        self::assertSame($message::class, $event->getTags()['messenger.message'] ?? null);
+    }
+
+    public function testReadsCompanyIdFromGetter(): void
+    {
+        $message = new class {
+            public function getCompanyId(): string
+            {
+                return 'from-getter';
+            }
+        };
+
+        $event = $this->scopeAfterReceiving($message, new Scope());
+
+        self::assertSame('from-getter', $event->getTags()['company_id'] ?? null);
+    }
+
+    private function scopeAfterReceiving(object $message, Scope $scope): Event
+    {
+        $hub = $this->createMock(HubInterface::class);
+        $hub->expects(self::once())
+            ->method('configureScope')
+            ->willReturnCallback(static fn (callable $cb) => $cb($scope));
+
+        $subscriber = new SentryMessengerScopeSubscriber($hub);
+        $subscriber->onMessageReceived(new WorkerMessageReceivedEvent(new Envelope($message), 'async'));
+
+        $event = Event::createEvent();
+        $scope->applyToEvent($event);
+
+        return $event;
+    }
+}

--- a/site/tests/Unit/Shared/Infrastructure/Sentry/SentryMessengerScopeSubscriberTest.php
+++ b/site/tests/Unit/Shared/Infrastructure/Sentry/SentryMessengerScopeSubscriberTest.php
@@ -54,6 +54,31 @@ final class SentryMessengerScopeSubscriberTest extends TestCase
         self::assertSame('from-getter', $event->getTags()['company_id'] ?? null);
     }
 
+    public function testIgnoresInaccessiblePrivateCompanyIdWithoutGetter(): void
+    {
+        // Приватное свойство без геттера: isset() извне вернёт false — без фатала.
+        $message = new class('secret') {
+            public function __construct(private readonly string $companyId)
+            {
+            }
+        };
+
+        $event = $this->scopeAfterReceiving($message, new Scope());
+
+        self::assertArrayNotHasKey('company_id', $event->getTags());
+    }
+
+    public function testStringifiesIntCompanyId(): void
+    {
+        $message = new class {
+            public int $companyId = 42;
+        };
+
+        $event = $this->scopeAfterReceiving($message, new Scope());
+
+        self::assertSame('42', $event->getTags()['company_id'] ?? null);
+    }
+
     private function scopeAfterReceiving(object $message, Scope $scope): Event
     {
         $hub = $this->createMock(HubInterface::class);

--- a/site/tests/Unit/Shared/Infrastructure/Sentry/SentryRequestScopeSubscriberTest.php
+++ b/site/tests/Unit/Shared/Infrastructure/Sentry/SentryRequestScopeSubscriberTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 use Sentry\Event;
 use Sentry\State\HubInterface;
 use Sentry\State\Scope;
+use Sentry\UserDataBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -37,13 +38,18 @@ final class SentryRequestScopeSubscriberTest extends TestCase
         self::assertSame('comp-1', $event->getTags()['company_id'] ?? null);
     }
 
-    public function testSkipsWhenNoUserOrCompany(): void
+    public function testClearsStaleUserAndCompanyForAnonymousRequest(): void
     {
+        // Переиспользование scope (тесты/RoadRunner/Swoole): анонимный запрос
+        // не должен унаследовать user/company предыдущего.
         $audit = $this->createMock(AuditContextProvider::class);
         $audit->method('getActorUserId')->willReturn(null);
         $audit->method('getCompanyId')->willReturn(null);
 
         $scope = new Scope();
+        $scope->setUser(UserDataBag::createFromUserIdentifier('stale-user'));
+        $scope->setTag('company_id', 'stale-company');
+
         $hub = $this->createMock(HubInterface::class);
         $hub->method('configureScope')->willReturnCallback(static fn (callable $cb) => $cb($scope));
 

--- a/site/tests/Unit/Shared/Infrastructure/Sentry/SentryRequestScopeSubscriberTest.php
+++ b/site/tests/Unit/Shared/Infrastructure/Sentry/SentryRequestScopeSubscriberTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Infrastructure\Sentry;
+
+use App\Shared\Audit\AuditContextProvider;
+use App\Shared\Infrastructure\Sentry\SentryRequestScopeSubscriber;
+use PHPUnit\Framework\TestCase;
+use Sentry\Event;
+use Sentry\State\HubInterface;
+use Sentry\State\Scope;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+final class SentryRequestScopeSubscriberTest extends TestCase
+{
+    public function testSetsUserAndCompanyTagsForMainRequest(): void
+    {
+        $audit = $this->createMock(AuditContextProvider::class);
+        $audit->method('getActorUserId')->willReturn('user-1');
+        $audit->method('getCompanyId')->willReturn('comp-1');
+
+        $scope = new Scope();
+        $hub = $this->createMock(HubInterface::class);
+        $hub->expects(self::once())
+            ->method('configureScope')
+            ->willReturnCallback(static fn (callable $cb) => $cb($scope));
+
+        (new SentryRequestScopeSubscriber($hub, $audit))->onKernelRequest($this->requestEvent(HttpKernelInterface::MAIN_REQUEST));
+
+        $event = Event::createEvent();
+        $scope->applyToEvent($event);
+
+        self::assertSame('user-1', $event->getUser()?->getId());
+        self::assertSame('comp-1', $event->getTags()['company_id'] ?? null);
+    }
+
+    public function testSkipsWhenNoUserOrCompany(): void
+    {
+        $audit = $this->createMock(AuditContextProvider::class);
+        $audit->method('getActorUserId')->willReturn(null);
+        $audit->method('getCompanyId')->willReturn(null);
+
+        $scope = new Scope();
+        $hub = $this->createMock(HubInterface::class);
+        $hub->method('configureScope')->willReturnCallback(static fn (callable $cb) => $cb($scope));
+
+        (new SentryRequestScopeSubscriber($hub, $audit))->onKernelRequest($this->requestEvent(HttpKernelInterface::MAIN_REQUEST));
+
+        $event = Event::createEvent();
+        $scope->applyToEvent($event);
+
+        self::assertNull($event->getUser());
+        self::assertArrayNotHasKey('company_id', $event->getTags());
+    }
+
+    public function testIgnoresSubRequest(): void
+    {
+        $audit = $this->createMock(AuditContextProvider::class);
+        $audit->expects(self::never())->method('getActorUserId');
+
+        $hub = $this->createMock(HubInterface::class);
+        $hub->expects(self::never())->method('configureScope');
+
+        (new SentryRequestScopeSubscriber($hub, $audit))->onKernelRequest($this->requestEvent(HttpKernelInterface::SUB_REQUEST));
+    }
+
+    private function requestEvent(int $requestType): RequestEvent
+    {
+        return new RequestEvent(
+            $this->createMock(HttpKernelInterface::class),
+            new Request(),
+            $requestType,
+        );
+    }
+}

--- a/site/tests/Unit/Shared/Service/AppLoggerTest.php
+++ b/site/tests/Unit/Shared/Service/AppLoggerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Service;
+
+use App\Shared\Service\AppLogger;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+final class AppLoggerTest extends TestCase
+{
+    public function testLogSlowExecutionWritesWarningToLogOnly(): void
+    {
+        // Регрессия Stage 5: бэкдор в GlitchTip убран — медленное выполнение
+        // пишется только в локальный лог как warning (AppLogger больше не знает о Sentry).
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::never())->method('error');
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with(self::stringContains('Медленное выполнение: [CashflowReportBuilder::build]'));
+
+        $appLogger = new AppLogger($logger);
+        $appLogger->logSlowExecution('CashflowReportBuilder::build', 5000, 3000);
+    }
+
+    public function testErrorAndWarningDelegateToLogger(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('error')->with('boom', self::arrayHasKey('exception'));
+        $logger->expects(self::once())->method('warning')->with('careful', ['k' => 'v']);
+
+        $appLogger = new AppLogger($logger);
+        $appLogger->error('boom', new \RuntimeException('x'));
+        $appLogger->warning('careful', ['k' => 'v']);
+    }
+}


### PR DESCRIPTION
## Цель
Stage 5 из задачи логирования: глобально обогащать события GlitchTip контекстом (`company_id`, user id, класс сообщения) для триажа, и убрать бэкдор `AppLogger::logSlowExecution` (warning напрямую в GlitchTip в обход конвенции «туда только ERROR»).

## Изменения
- **`SentryMessengerScopeSubscriber`** (new) — на `WorkerMessageReceivedEvent` ставит теги `messenger.message` + `company_id` (duck-typing по `getCompanyId()`/public `$companyId`). Воркеры — где больше всего ошибок и меньше контекста.
- **`SentryRequestScopeSubscriber`** (new) — на `kernel.request` (main) ставит user id + `company_id` через существующий `AuditContextProvider` (уже гардит консоль/сессию).
- **`AppLogger`** — `logSlowExecution` пишет только warning в файл; убрана неиспользуемая зависимость `HubInterface`.

## Почему так
- **Подписчики на `WorkerMessage*`-события, а не Messenger-middleware** → **без правки `messenger.yaml`** (это был бы обязательный STOP). Паттерн уже есть — `SyncJobFailureSubscriber`.
- **Без правки `sentry.yaml`** — scope выставляется на текущем хабе.
- Удаление арг `HubInterface` из `AppLogger` → обновлены 3 тестовые конструкции.

## Проверки
- ✅ 8 новых unit-тестов; полный unit-сьют **1200 OK**
- ✅ `lint:container` OK (подписчики автоварятся, `AppLogger` 1-арг)
- CS: новые файлы чистые; `AppLogger.php` «Found 1» — преэкзистинг-долг в нетронутых методах (`?\Throwable`/Yoda), намеренно не реформатил
- N/A PHPStan (не настроен)

## Замечания ревьюеру
- `SentryRequestScopeSubscriber` зовёт `AuditContextProvider::getCompanyId()` на каждом main-запросе — то же поведение, что уже есть у `AuditLogSubscriber` (новый сайд-эффект не вводится).
- Реальный эффект тегов — по факту в GlitchTip после деплоя.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
