### PR TITLE
[codex] Implement account P0 hardening

### DIFF
--- a/docs/tasks/account/handoff.md
+++ b/docs/tasks/account/handoff.md
@@ -1,0 +1,47 @@
+# Account P0 implementation handoff
+
+## Summary
+
+- Implemented P0 creation invariant: every new company created through public/admin owner-account creation, `/company/new`, and `AccountBootstrapper` now gets an owner `CompanyMember`.
+- Implemented P0 member-management hardening: disable/enable actions, owner/self disable guards, active membership access check, disabled-member invite accept rejection.
+- Fixed `CompanyRepository::getAllActiveCompanyIds()` to query the real `companies` table until a future CompanyStatus exists.
+- Did not implement P1/HIGH items: user block/unblock, company suspension, migrations, `security.yaml`, voters/RBAC rollout, admin blocking UI.
+
+## Files changed
+
+- `site/src/Company/Application/Service/CompanyOwnerMembershipCreator.php` — new
+- `site/src/Company/Application/DisableCompanyMemberAction.php` — new
+- `site/src/Company/Application/EnableCompanyMemberAction.php` — new
+- `site/src/Company/**` — focused wiring/repository/controller updates
+- `site/tests/**/Company/**` — unit/functional/integration coverage
+- `docs/tasks/account/stages/stage-1.md` — new
+- `docs/tasks/account/stages/stage-2.md` — new
+
+## Migrations
+
+- None.
+- No destructive DB changes.
+
+## Public API / contracts
+
+- No new public endpoint.
+- Existing member disable/enable routes now enforce owner/self guards.
+- Existing invite accept now rejects disabled existing membership.
+
+## Checks
+
+- `make site-test-unit` — OK, 1213 tests, 7451 assertions; existing PHPUnit output includes 1 warning and 1 deprecation.
+- Targeted DB functional/integration PHPUnit filter — OK, 17 tests, 96 assertions; existing Symfony validator deprecations remain.
+- Targeted unit PHPUnit filter — OK, 23 tests, 139 assertions.
+- `git diff --check -- <changed paths>` — OK.
+
+## Notes
+
+- `make codex-test-unit-filter ...` could not run in this environment because `codex-prepare` expects host `php` on PATH. Docker-based checks were used instead.
+- DB tests needed a local `DATABASE_URL` host override from `site-postgres` to the running container name because one-off `site-php-cli` containers did not resolve the Compose service alias here.
+- Existing unrelated working-tree changes under `docs/tasks/ingestion/*` and other untracked docs were not touched.
+
+## Owner review focus
+
+- Confirm the chosen disabled invite behavior: disabled member cannot regain access via invite; owner must use explicit enable.
+- Confirm P1 ordering before any migration/security work: user lifecycle, company suspension, audit trail, scoped authorization.

--- a/docs/tasks/account/plan.md
+++ b/docs/tasks/account/plan.md
@@ -1,0 +1,435 @@
+# Account / Company module plan
+
+Дата анализа: 2026-06-28
+
+## Задача
+
+Изучить модуль `Company`, сценарии создания, управления и блокировки аккаунтов, определить:
+
+- какие базовые функции уже есть;
+- какие функции отсутствуют или реализованы неполно;
+- каким поэтапным планом безопасно довести модуль до полноценного account management.
+
+Под "аккаунтом" в этом плане понимается SaaS-аккаунт клиента: `User` + `Company` + `CompanyMember`. Денежные счета `Cash/MoneyAccount` не входят в scope.
+
+## Изученные области
+
+- `site/src/Company/Entity/User.php`
+- `site/src/Company/Entity/Company.php`
+- `site/src/Company/Entity/CompanyMember.php`
+- `site/src/Company/Entity/CompanyInvite.php`
+- `site/src/Company/Service/CompanyOwnerAccountCreator.php`
+- `site/src/Company/Service/CompanyInviteManager.php`
+- `site/src/Company/Application/Service/AccountBootstrapper.php`
+- `site/src/Company/Controller/RegistrationController.php`
+- `site/src/Company/Controller/CompanyController.php`
+- `site/src/Company/Controller/CompanyMemberController.php`
+- `site/src/Company/Controller/InviteController.php`
+- `site/src/Company/Facade/CompanyFacade.php`
+- `site/src/Admin/Application/CreateAccountAction.php`
+- `site/src/Admin/Controller/CreateAccountController.php`
+- `site/src/Admin/Controller/UserController.php`
+- `site/src/Shared/Service/ActiveCompanyService.php`
+- `site/config/packages/security.yaml`
+- релевантные шаблоны `site/templates/company/*`, `site/templates/admin/users/*`
+- unit-тесты `site/tests/Unit/Company/*`, `site/tests/Unit/Admin/Application/CreateAccountActionTest.php`
+- `ARCHITECTURE.md`, `PATTERNS.md`, `site/src/Billing/README.md`
+
+## Что уже есть
+
+### Пользователь и роли
+
+- `User` хранит `id`, `email`, `roles`, `password`, `createdAt`.
+- Email нормализуется через `User::normalizeEmail()` и уникален на уровне ORM/БД.
+- `User::getRoles()` всегда добавляет `ROLE_USER`.
+- Есть CLI-команды:
+  - `app:user:promote-super-admin` — выдать `ROLE_SUPER_ADMIN`;
+  - `app:user:reset-password` — сбросить пароль и вывести временный пароль.
+- В `security.yaml` настроены роли `ROLE_COMPANY_USER`, `ROLE_COMPANY_OWNER`, `ROLE_SUPER_ADMIN`, отдельный admin firewall и общий доступ `^/` только для `ROLE_USER`.
+
+Ограничение: у `User` нет lifecycle/status-поля. Нельзя штатно заблокировать логин, пометить аккаунт как suspended/blocked, хранить причину блокировки, дату, автора действия.
+
+### Создание owner-аккаунта
+
+- Публичная регистрация `/register` без invite создаёт пользователя-владельца через `CompanyOwnerAccountCreator`.
+- `CompanyOwnerAccountCreator`:
+  - хеширует пароль;
+  - ставит `ROLE_COMPANY_OWNER`;
+  - создаёт `Company`;
+  - создаёт активного `CompanyMember` с ролью `OWNER`;
+  - отправляет `SendRegistrationEmailMessage`, если включено.
+- Admin может создать owner-account через `/admin/users/new-account`.
+- Admin-сценарий идёт через `Admin\Application\CreateAccountAction` -> `CompanyFacade::createOwnerAccount()`.
+- `CompanyFacade::createOwnerAccount()` зафиксирован в `ARCHITECTURE.md` как публичный контракт Company-модуля.
+- Unit-тесты покрывают создание owner-account и отсутствие `ROLE_ADMIN` у создаваемого пользователя.
+
+Ограничение: создание компании не единообразно. `CompanyController::new()` и `AccountBootstrapper::bootstrapForUser()` создают `Company`, но не создают `CompanyMember OWNER`. Также `CompanyOwnerAccountCreator` не использует `AccountBootstrapper`, поэтому дефолтные cashflow/PL/money accounts могут не создаваться тем же путём, что bootstrap.
+
+### Компания
+
+- `Company` хранит `id`, `name`, `inn`, `user` owner, `financeLockBefore`, `taxSystem`.
+- Owner определяется через `Company::getUser()`.
+- Есть CRUD UI для компаний:
+  - список своих компаний;
+  - создание;
+  - редактирование;
+  - удаление;
+  - выбор active company через session key `active_company_id`.
+- `financeLockBefore` используется как финансовая блокировка периода, но это не блокировка аккаунта.
+
+Ограничение: у `Company` нет статуса активности/блокировки. При этом `CompanyRepository::getAllActiveCompanyIds()` уже ожидает "активные компании", но SQL ссылается на таблицу `company` и поле `is_active`, которых нет в текущей entity/table (`companies`). Это отдельный технический долг и риск для worker/CLI-сценариев.
+
+### Участники компании
+
+- `CompanyMember` связывает `Company` и `User`.
+- Есть роли `OWNER` и `OPERATOR`.
+- Есть статусы `ACTIVE` и `DISABLED`.
+- Owner может:
+  - смотреть участников;
+  - приглашать operator по email;
+  - отзывать invite;
+  - отключать/включать участника.
+- `ActiveCompanyService` учитывает только active membership при выборе company для приглашённых пользователей.
+- Unit-тесты покрывают `CompanyMember::disable()` / `enable()`.
+
+Ограничения:
+
+- `CompanyMember::role` и `status` — строковые константы, не enum.
+- Нет `disabledAt`, `disabledBy`, `disableReason`, `enabledAt`, аудита изменения.
+- `CompanyMemberController::disableMember()` может отключить owner-member, если он есть в списке. Для owner-доступа это не блокирует `Company::user`, но создаёт неконсистентное состояние.
+- `CompanyMemberController::assertCompanyMemberAccess()` использует `findOneByCompanyAndUser()`, а не `findActiveOneByCompanyAndUser()`, поэтому часть проверок не различает disabled member.
+- Если disabled member получает новый invite, `CompanyInviteManager::acceptInvite()` найдёт существующий member и примет invite, но не включит member обратно и не сообщит о disabled-состоянии.
+- Виджет active company (`_active_company_widget.html.twig`) показывает только `app.user.companies`, то есть owned-компании, и не показывает компании, где пользователь является invited member.
+
+### Приглашения
+
+- `CompanyInvite` хранит company, email, role, token hash, expiresAt, createdAt, createdBy, accepted/revoked поля.
+- Invite token хранится только как hash.
+- Pending invite на тот же email переиспользуется: токен обновляется и срок продлевается.
+- Invite можно принять существующим пользователем или через регистрацию по invite.
+- `acceptInvite()` проверяет:
+  - token hash;
+  - pending status;
+  - email пользователя совпадает с email invite.
+- Invite можно отозвать.
+- Unit-тесты покрывают создание invite, renew и accept.
+
+Ограничения:
+
+- Invite поддерживает только `OPERATOR`; нет выбора роли.
+- Нет rate limit на invite endpoints.
+- Страница просмотра invite показывает expired/revoked invite без явного UX-блокера до POST.
+- Нет защиты от приглашения уже активного участника как отдельного доменного результата.
+
+### Admin management
+
+- Admin видит список пользователей, дату регистрации, id, роли.
+- Admin может создать owner-account.
+- Admin может изменить глобальную роль пользователя.
+- Удаление пользователя есть как `UserDeletionService`, но route и кнопка закомментированы.
+
+Ограничения:
+
+- Нет admin block/unblock пользователя.
+- Нет admin suspend/activate компании.
+- Нет фильтрации/индикации account status.
+- `UserDeletionService` не участвует в UI и выглядит как устаревший destructive-path; включать его без отдельной ревизии нельзя.
+
+### Billing
+
+- В Billing уже есть `SubscriptionStatus::{TRIAL, ACTIVE, GRACE, SUSPENDED, CANCELED}`.
+- `Billing\AccessManagerInterface` задуман как единая точка доступа/лимитов.
+
+Ограничение: текущий `Billing\Service\AccessManager` — stub, все проверки возвращают allow. Billing-статусы пока не ограничивают доступ к Company/account.
+
+## Главные пробелы базового account management
+
+1. Нет глобальной блокировки пользователя.
+   Нужен `User` lifecycle: active/blocked, причина, actor, timestamp, запрет логина и запрет дальнейшей работы для уже авторизованных сессий.
+
+2. Нет блокировки/suspension компании.
+   Нужен company-level lifecycle, который влияет на `ActiveCompanyService`, UI, фоновые jobs и `CompanyFacade::getAllActiveCompanyIds()`.
+
+3. Глобальные Symfony-роли не равны ролям в активной компании.
+   `ROLE_COMPANY_OWNER` хранится на `User`, а ownership в продукте company-scoped. Пользователь может быть owner одной компании и operator другой, но `#[IsGranted('ROLE_COMPANY_OWNER')]` даст owner-доступ глобально. Нужна company-scoped authorization policy/voter или обязательная проверка active company role.
+
+4. Создание компании не единообразно.
+   Разные пути создают разный набор связанных данных: owner-account создаёт `CompanyMember OWNER`, а `/company/new` и `AccountBootstrapper` нет.
+
+5. Управление участниками не защищает важные инварианты.
+   Нужно запретить отключение owner/self без явно согласованного сценария передачи владельца, корректно обрабатывать повторный invite disabled member, использовать active membership в access checks.
+
+6. Нет audit trail для блокировок и управления доступом.
+   Для финансового SaaS нужны минимум actor, timestamp, reason для block/unblock/suspend/activate/disable/enable.
+
+7. Нет единого Application-слоя для account operations.
+   Часть логики находится прямо в контроллерах (`CompanyController`, `CompanyMemberController`), хотя проектный паттерн — Controller -> Action -> Domain/Repository.
+
+## Что необходимо добавить
+
+### Обязательный минимум
+
+- `UserStatus` или эквивалентное lifecycle-поле для `User`.
+- Block/unblock user actions с причиной и actor id.
+- Symfony `UserCheckerInterface` или эквивалентная security-проверка, чтобы blocked user не мог войти.
+- Runtime guard для уже активных blocked-сессий.
+- `CompanyStatus` или явный `isActive/isSuspended` для `Company`.
+- Suspend/activate company actions.
+- Исправить `CompanyRepository::getAllActiveCompanyIds()` под реальную таблицу и новый company status.
+- Единый `CreateCompanyAction` / `CompanyCreator`, который всегда создаёт owner-member и запускает нужный bootstrap.
+- Company-scoped authorization для owner/operator прав.
+- Admin UI/actions для block/unblock user и suspend/activate company.
+- Тесты на запрет доступа blocked user / suspended company / disabled member.
+
+### Желательно добавить рядом
+
+- `CompanyMemberRole` и `CompanyMemberStatus` enum вместо строковых констант.
+- Audit fields для `CompanyMember` disable/enable.
+- Отдельный `AccountAuditLog` или использование существующего Shared audit-подхода, если он подходит.
+- Список доступных компаний: owned + active memberships.
+- Корректный UI для invited member company switcher.
+- Invite result types для already-member / disabled-member / email-mismatch / expired.
+- Защита от self-block/self-demote в admin, если нет второго admin/super-admin.
+
+### Отложить до отдельного решения
+
+- Жёсткое удаление пользователей/компаний.
+- Связку Billing `SubscriptionStatus::SUSPENDED` -> Company suspension.
+- Перенос всех legacy company-owned entity с `Company $company` на `string $companyId`.
+- Массовую замену всех `#[IsGranted('ROLE_COMPANY_OWNER')]` без предварительной инвентаризации affected routes.
+
+## Best practices и use cases по приоритету
+
+| Приоритет | Use case | Что добавить | Best practice | Почему важно | Risk | Acceptance criteria |
+|---|---|---|---|---|---|---|
+| P0 | Единообразно создать owner-account из public registration и admin | Единый `CreateOwnerAccountAction` / `CreateCompanyAction`, создание `Company`, `CompanyMember OWNER`, обязательный bootstrap данных | Один write-use-case = один Application Action; контроллеры только собирают input и вызывают action; все внешние модули идут через `CompanyFacade` | Сейчас разные пути создания дают разный набор связанных данных | MEDIUM | Любой owner-account имеет owner membership; public/admin tests проходят; нет дублирования создания company в контроллерах |
+| P0 | Пользователь не может работать после отключения в компании | Усилить `CompanyMember` access checks: только `ACTIVE` membership даёт доступ к invited company | Проверять доступ по active company + active membership, не по `find($id)` и не по глобальной роли | Disabled member сейчас частично может оставаться видимым в проверках | MEDIUM | Disabled member не может выбрать company и получить данные; owner по `Company.user` остаётся доступен до отдельной company/user блокировки |
+| P0 | Запретить неконсистентное отключение владельца | Guard в disable-member action: нельзя отключить owner/self без отдельного transfer-owner сценария | Доменные инварианты держать в Action/Policy, не в Twig/UI | Отключение owner-member создаёт противоречие между `Company.user` и `CompanyMember` | MEDIUM | POST disable owner/self возвращает доменную ошибку/403; тест покрывает запрет |
+| P0 | Понять, какие компании активны для workers/CLI | Исправить/спланировать `CompanyRepository::getAllActiveCompanyIds()` под `companies` и будущий status | Репозиторий Company должен быть единственным источником списка active company ids | Сейчас метод ссылается на несуществующие `company.is_active` | HIGH при миграции, LOW для фикса SQL без нового поля | Метод возвращает реальные company ids; есть тест на active list |
+| P1 | Заблокировать пользователя глобально | `UserStatus`, `blockedAt`, `blockedBy`, `blockReason`, `BlockUserAction`, `UnblockUserAction` | Не удалять пользователя; использовать explicit lifecycle state + audit; blocked user denied на login и runtime | Это базовая account-blocking функция | HIGH | Blocked user не может войти; активная сессия получает deny/logout; admin не может заблокировать себя |
+| P1 | Заблокировать компанию целиком | `CompanyStatus` или `isActive/isSuspended`, `SuspendCompanyAction`, `ActivateCompanyAction` | Company lifecycle отдельно от user lifecycle; не смешивать manual suspension и billing suspension без policy | Нужно отключать весь tenant, включая owner и фоновые задачи | HIGH | Suspended company не выбирается active; не попадает в `getAllActiveCompanyIds()`; UI/API возвращают controlled deny |
+| P1 | Админ управляет блокировками безопасно | Admin UI/API: block/unblock user, suspend/activate company, reason field, CSRF | Все state-changing admin actions только POST + CSRF + audit; focused controllers per action | Без UI операции останутся ручными и неаудируемыми | HIGH | Admin видит status; действия защищены CSRF; audit содержит actor/reason/time |
+| P1 | Хранить историю действий по доступу | `AccountAuditLog` или интеграция с существующим Shared audit | Append-only audit для block/unblock/suspend/activate/disable/enable; не перетирать историю полями entity | Для финансового SaaS нужны разбор инцидентов и ответственность | MEDIUM | Каждое access-management действие пишет audit event без секретов/PII сверх необходимого |
+| P1 | Разделить глобальные роли и роли в компании | Company-scoped permission checker/voter для owner/operator | Глобальные Symfony-роли использовать только для coarse access; бизнес-права считать в контексте active company | `ROLE_COMPANY_OWNER` сейчас даёт owner-доступ глобально | HIGH | User owner компании A и operator компании B не имеет owner-доступа в B |
+| P2 | Переключать все доступные компании | Read-model доступных компаний: owned + active memberships; обновить company switcher | UI должен использовать Application/Query read-model, а не `app.user.companies` напрямую | Invited companies сейчас не попадают в виджет выбора | MEDIUM | Пользователь видит owned и invited active companies; disabled/suspended скрыты или помечены согласно policy |
+| P2 | Корректно обработать повторный invite | Явные result types: already active member, disabled member, renewed invite, created invite | Use case возвращает доменный результат, контроллер переводит его в flash/response | Сейчас disabled existing member может принять invite без восстановления доступа | MEDIUM | Повторный invite active member не создаёт мусор; disabled-member case имеет согласованное поведение |
+| P2 | Типизировать роли и статусы участников | `CompanyMemberRole` и `CompanyMemberStatus` backed enums | Enum вместо строковых констант для всех finite state/status fields | Меньше ошибок статусов и проще мигрировать authorization policy | MEDIUM | Entity и формы используют enum; старые значения мигрированы безопасно |
+| P2 | Управлять ролями участников | Use cases: change member role, transfer ownership | Роль меняется только через policy/action с guard against no-owner state | Без transfer-owner нельзя безопасно отключать/передавать владельца | HIGH | В компании всегда есть ровно один или минимум один owner согласно выбранному правилу |
+| P3 | Связать billing suspension с доступом | Policy mapping Billing status -> access mode | Billing status не должен напрямую менять Company status без явного precedence rule | Сейчас Billing `AccessManager` stub и не enforcement layer | HIGH | Есть документированная матрица `TRIAL/ACTIVE/GRACE/SUSPENDED/CANCELED`; tests на write/read deny |
+| P3 | Удаление аккаунта/компании | Soft delete/deactivation вместо hard delete; hard delete только отдельной задачей | Для финансовых данных предпочтителен reversible disable/archive, не каскадное удаление | `UserDeletionService` destructive и route закомментирован | HIGH | Нет hard delete в обычном admin flow; archive/delete policy утверждена отдельно |
+
+Рекомендуемый порядок реализации: сначала P0, затем P1. P2 улучшает UX и типобезопасность, но не должен блокировать security foundation. P3 требует отдельных бизнес-решений и owner review.
+
+## Предлагаемый staged plan
+
+### Stage 1: Зафиксировать текущие инварианты создания компании
+
+**Risk:** MEDIUM
+
+Цель: сделать создание компании единообразным без изменения auth/RBAC.
+
+Работы:
+
+- Добавить/выделить `CreateCompanyAction` или `CompanyCreator` в `Company/Application`.
+- Использовать его в `CompanyOwnerAccountCreator`, `CompanyController::new()` и при необходимости `AccountBootstrapper`.
+- Всегда создавать `CompanyMember OWNER` для owner.
+- Явно решить, какие seed-операции обязательны при создании компании: balance, cashflow, PL, money accounts.
+- Добавить unit/functional тесты на оба пути: public/admin owner-account и `/company/new`.
+
+Ожидаемые файлы:
+
+- `site/src/Company/Application/...`
+- `site/src/Company/Service/CompanyOwnerAccountCreator.php`
+- `site/src/Company/Controller/CompanyController.php`
+- `site/src/Company/Application/Service/AccountBootstrapper.php`
+- `site/tests/Unit/Company/*`
+- `site/tests/Functional/Company/*` или ближайший существующий test namespace
+
+### Stage 2: Укрепить управление участниками и invite-flow
+
+**Risk:** MEDIUM
+
+Цель: сделать текущий per-company disable реальной и непротиворечивой функцией управления доступом.
+
+Работы:
+
+- Вынести enable/disable member в Application action.
+- Запретить отключение owner-member/self без отдельного сценария передачи владельца.
+- В `assertCompanyMemberAccess()` использовать active membership там, где нужен доступ активного участника.
+- Для disabled existing member при accept invite: либо явно re-enable, либо вернуть доменную ошибку. Правило нужно зафиксировать до реализации.
+- Обновить UI/flash messages для already-member/disabled-member cases.
+- Добавить тесты на disabled member access и invite edge cases.
+
+Ожидаемые файлы:
+
+- `site/src/Company/Application/...`
+- `site/src/Company/Service/CompanyInviteManager.php`
+- `site/src/Company/Controller/CompanyMemberController.php`
+- `site/tests/Unit/Company/CompanyInviteManagerTest.php`
+- `site/tests/Functional/Company/*`
+
+### Stage 3: Добавить глобальную блокировку пользователя
+
+**Risk:** HIGH
+
+Причина HIGH: миграция БД + изменение auth/security поведения.
+
+Работы:
+
+- Добавить `UserStatus` enum или эквивалентные поля в `User`.
+- Добавить поля аудита блокировки: `blockedAt`, `blockedBy`, `blockReason` или отдельную audit-сущность.
+- Создать Doctrine migration.
+- Добавить `BlockUserAction` / `UnblockUserAction`.
+- Подключить Symfony user checker к `main` и `admin` firewall или согласованный runtime guard.
+- Обеспечить logout/deny для уже заблокированных сессий.
+- Добавить admin self-protection: нельзя заблокировать текущего пользователя; возможно нельзя оставить систему без admin.
+- Добавить unit/functional tests для логина и доступа blocked user.
+
+Ожидаемые файлы:
+
+- `site/src/Company/Entity/User.php`
+- `site/src/Company/Enum/UserStatus.php`
+- `site/src/Company/Application/...`
+- `site/src/Company/Security/...` или `site/src/Shared/Security/...`
+- `site/config/packages/security.yaml`
+- `site/migrations/*`
+- `site/tests/Unit/Company/*`
+- `site/tests/Functional/Security/*`
+
+STOP: owner review required before migration/security changes.
+
+### Stage 4: Добавить блокировку/suspension компании
+
+**Risk:** HIGH
+
+Причина HIGH: миграция БД + изменение tenant access + влияние на workers/CLI.
+
+Работы:
+
+- Добавить company status (`ACTIVE`, `SUSPENDED`, возможно `ARCHIVED`) или явное `isActive`.
+- Добавить audit поля suspension.
+- Исправить `CompanyRepository::getAllActiveCompanyIds()` на `companies` и новый status.
+- Обновить `ActiveCompanyService`: suspended company нельзя выбрать как active.
+- Обновить company switcher: показывать только доступные active companies, отдельно сообщать о suspended при необходимости.
+- Проверить CLI/worker места, где берутся все active company ids.
+- Добавить тесты на suspended company: UI access, active company fallback, worker list.
+
+Ожидаемые файлы:
+
+- `site/src/Company/Entity/Company.php`
+- `site/src/Company/Enum/CompanyStatus.php`
+- `site/src/Company/Infrastructure/Repository/CompanyRepository.php`
+- `site/src/Shared/Service/ActiveCompanyService.php`
+- `site/templates/partials/_active_company_widget.html.twig`
+- `site/migrations/*`
+- `site/tests/Unit/Company/*`
+- `site/tests/Functional/Company/*`
+
+STOP: owner review required before migration/tenant-access changes.
+
+### Stage 5: Admin UI для управления блокировками
+
+**Risk:** HIGH
+
+Причина HIGH: новые admin actions/endpoints + RBAC-sensitive behavior.
+
+Работы:
+
+- Добавить в admin user list статус пользователя и действия block/unblock.
+- Добавить company status в admin context: список компаний пользователя, suspend/activate.
+- Все POST actions с CSRF.
+- Логи/audit для всех действий.
+- Запретить destructive delete в рамках этой стадии.
+- Добавить functional tests для admin permissions, CSRF, self-block guard.
+
+Ожидаемые файлы:
+
+- `site/src/Admin/Controller/UserController.php` или новые focused controllers
+- `site/src/Admin/Application/...`
+- `site/templates/admin/users/index.html.twig`
+- `site/tests/Functional/Admin/*`
+
+STOP: owner review required before continuing after this stage.
+
+### Stage 6: Company-scoped authorization
+
+**Risk:** HIGH
+
+Причина HIGH: изменение auth/RBAC/Voter и большое влияние на продуктовые routes.
+
+Работы:
+
+- Инвентаризировать все `#[IsGranted('ROLE_COMPANY_OWNER')]` и места с owner-only логикой.
+- Ввести company-scoped permission layer:
+  - `CompanyAccessPolicy`, или
+  - Symfony Voter для active company, или
+  - явный `ActiveCompanyPermissionChecker`.
+- Owner/operator права проверять по active company membership/ownership, а не только по глобальной роли пользователя.
+- Сохранить глобальные роли только для coarse access/login, если они нужны.
+- Постепенно заменить sensitive owner-only routes на company-scoped проверку.
+- Добавить regression tests: пользователь owner компании A и operator компании B не получает owner-доступ в B.
+
+Ожидаемые файлы:
+
+- `site/src/Company/Application/...`
+- `site/src/Company/Security/...` или `site/src/Shared/Security/...`
+- affected controllers with `ROLE_COMPANY_OWNER`
+- `site/tests/Functional/*`
+
+STOP: owner review required before RBAC rollout.
+
+### Stage 7: Billing integration decision
+
+**Risk:** MEDIUM/HIGH
+
+Цель: решить, должен ли `SubscriptionStatus::SUSPENDED` автоматически блокировать запись/доступ компании.
+
+Работы:
+
+- Реализовать реальный `Billing\AccessManager`, если задача включает billing enforcement.
+- Определить mapping:
+  - `TRIAL/ACTIVE` -> allow;
+  - `GRACE` -> read + ограниченная write policy;
+  - `SUSPENDED/CANCELED` -> deny write или deny all кроме billing page.
+- Не смешивать manual admin suspension и billing suspension без явного правила приоритета.
+
+STOP: требуется отдельное бизнес-решение перед реализацией.
+
+## Проверки для будущей реализации
+
+Минимум для каждого stage:
+
+- `git status --short`
+- `git diff --stat`
+- self-review diff
+- targeted PHPUnit по изменённому модулю, если есть удобный command
+- `make site-test-unit` или `make codex-test-unit` перед handoff
+
+Для security/RBAC stages:
+
+- functional login/access tests;
+- проверки self-block/self-demote;
+- тесты disabled member и suspended company;
+- регрессия company-scoped owner/operator прав.
+
+## Что не менять без отдельного owner approval
+
+- Не включать hard delete пользователей/компаний.
+- Не менять финансовые формулы, `financeLockBefore` semantics, периоды закрытия.
+- Не подключать Billing suspension к production access без отдельного решения.
+- Не менять Messenger transports/workers/cron.
+- Не делать массовую замену RBAC по всему проекту в одном stage.
+- Не устанавливать новые зависимости.
+- Не выполнять миграции на staging/production.
+
+## Acceptance criteria для всей задачи account management
+
+- Owner-account создаётся единым путём и всегда имеет owner membership.
+- Invited user имеет доступ только к active companies, где membership active.
+- Disabled member не может работать в компании.
+- Blocked user не может войти и не может продолжать работу в активной сессии.
+- Suspended company не выбирается как active и не попадает в worker/CLI списки active companies.
+- Admin может block/unblock user и suspend/activate company через CSRF-protected actions.
+- Owner/operator права проверяются в контексте active company.
+- Все блокировки имеют audit trail: actor, timestamp, reason.
+- Есть unit/functional tests на основные happy-path и denial-path сценарии.

--- a/docs/tasks/account/plan.md
+++ b/docs/tasks/account/plan.md
@@ -1,6 +1,32 @@
 # Account / Company module plan
 
 Дата анализа: 2026-06-28
+Дата реализации P0: 2026-06-28
+
+## Статус реализации
+
+### P0 — DONE
+
+- [x] Единое создание новой компании с обязательным owner membership вынесено в `CompanyOwnerMembershipCreator`.
+- [x] `CompanyOwnerMembershipCreator` подключён к `CompanyOwnerAccountCreator`, `CompanyController::new()` и `AccountBootstrapper`.
+- [x] `CompanyMember` привязан к `CompanyMemberRepository` в Doctrine metadata, чтобы `getRepository(CompanyMember::class)` возвращал проектный repository.
+- [x] Disable/enable участника вынесены в Application actions: `DisableCompanyMemberAction`, `EnableCompanyMemberAction`.
+- [x] Добавлены guard-правила: нельзя отключить self, `Company.user` owner и member с `ROLE_OWNER`.
+- [x] Access check для invited member в `CompanyMemberController` использует только active membership.
+- [x] Accept invite для существующего disabled member теперь возвращает отказ, а восстановление доступа остаётся явным owner-действием `enable`.
+- [x] `CompanyRepository::getAllActiveCompanyIds()` исправлен под реальную таблицу `companies`; до появления `CompanyStatus` все rows считаются активными.
+- [x] Добавлены/обновлены unit, functional и integration tests для P0-сценариев.
+- [x] Stage reports сохранены в `docs/tasks/account/stages/stage-1.md` и `docs/tasks/account/stages/stage-2.md`.
+- [x] Handoff сохранён в `docs/tasks/account/handoff.md`.
+
+### Осталось вне P0
+
+- [ ] Глобальная блокировка пользователя (`UserStatus`, block/unblock actions, login/runtime guard).
+- [ ] Company suspension/status с миграцией и влиянием на `ActiveCompanyService`/workers.
+- [ ] Audit trail для block/unblock/suspend/activate/disable/enable.
+- [ ] Admin UI для блокировок.
+- [ ] Company-scoped authorization/RBAC rollout.
+- [ ] `ProjectDirection` и `ReportApiKey` не смешивались с P0 и должны идти отдельными задачами.
 
 ## Задача
 
@@ -63,7 +89,9 @@
 - `CompanyFacade::createOwnerAccount()` зафиксирован в `ARCHITECTURE.md` как публичный контракт Company-модуля.
 - Unit-тесты покрывают создание owner-account и отсутствие `ROLE_ADMIN` у создаваемого пользователя.
 
-Ограничение: создание компании не единообразно. `CompanyController::new()` и `AccountBootstrapper::bootstrapForUser()` создают `Company`, но не создают `CompanyMember OWNER`. Также `CompanyOwnerAccountCreator` не использует `AccountBootstrapper`, поэтому дефолтные cashflow/PL/money accounts могут не создаваться тем же путём, что bootstrap.
+P0-статус: инвариант owner membership закрыт. `CompanyOwnerMembershipCreator` используется в `CompanyOwnerAccountCreator`, `CompanyController::new()` и `AccountBootstrapper`, поэтому новая компания всегда получает `CompanyMember OWNER`.
+
+Оставшееся ограничение: `CompanyOwnerAccountCreator` всё ещё не использует полный `AccountBootstrapper`, поэтому дефолтные cashflow/PL/money accounts могут создаваться не тем же путём, что bootstrap. Это отдельное решение о seed-policy.
 
 ### Компания
 
@@ -77,7 +105,9 @@
   - выбор active company через session key `active_company_id`.
 - `financeLockBefore` используется как финансовая блокировка периода, но это не блокировка аккаунта.
 
-Ограничение: у `Company` нет статуса активности/блокировки. При этом `CompanyRepository::getAllActiveCompanyIds()` уже ожидает "активные компании", но SQL ссылается на таблицу `company` и поле `is_active`, которых нет в текущей entity/table (`companies`). Это отдельный технический долг и риск для worker/CLI-сценариев.
+P0-статус: технический баг в `CompanyRepository::getAllActiveCompanyIds()` закрыт — метод читает реальные ids из `companies`.
+
+Оставшееся ограничение: у `Company` нет статуса активности/блокировки. До появления `CompanyStatus` все сохранённые companies считаются активными, поэтому полноценная company suspension остаётся P1/HIGH задачей.
 
 ### Участники компании
 
@@ -96,9 +126,9 @@
 
 - `CompanyMember::role` и `status` — строковые константы, не enum.
 - Нет `disabledAt`, `disabledBy`, `disableReason`, `enabledAt`, аудита изменения.
-- `CompanyMemberController::disableMember()` может отключить owner-member, если он есть в списке. Для owner-доступа это не блокирует `Company::user`, но создаёт неконсистентное состояние.
-- `CompanyMemberController::assertCompanyMemberAccess()` использует `findOneByCompanyAndUser()`, а не `findActiveOneByCompanyAndUser()`, поэтому часть проверок не различает disabled member.
-- Если disabled member получает новый invite, `CompanyInviteManager::acceptInvite()` найдёт существующий member и примет invite, но не включит member обратно и не сообщит о disabled-состоянии.
+- P0 закрыто: `DisableCompanyMemberAction` запрещает отключать self, `Company.user` owner и member с `ROLE_OWNER`.
+- P0 закрыто: `CompanyMemberController::assertCompanyMemberAccess()` использует active membership для invited member access.
+- P0 закрыто: если disabled member принимает invite, `CompanyInviteManager::acceptInvite()` возвращает отказ; восстановление доступа идёт через explicit enable.
 - Виджет active company (`_active_company_widget.html.twig`) показывает только `app.user.companies`, то есть owned-компании, и не показывает компании, где пользователь является invited member.
 
 ### Приглашения
@@ -202,10 +232,10 @@
 
 | Приоритет | Use case | Что добавить | Best practice | Почему важно | Risk | Acceptance criteria |
 |---|---|---|---|---|---|---|
-| P0 | Единообразно создать owner-account из public registration и admin | Единый `CreateOwnerAccountAction` / `CreateCompanyAction`, создание `Company`, `CompanyMember OWNER`, обязательный bootstrap данных | Один write-use-case = один Application Action; контроллеры только собирают input и вызывают action; все внешние модули идут через `CompanyFacade` | Сейчас разные пути создания дают разный набор связанных данных | MEDIUM | Любой owner-account имеет owner membership; public/admin tests проходят; нет дублирования создания company в контроллерах |
-| P0 | Пользователь не может работать после отключения в компании | Усилить `CompanyMember` access checks: только `ACTIVE` membership даёт доступ к invited company | Проверять доступ по active company + active membership, не по `find($id)` и не по глобальной роли | Disabled member сейчас частично может оставаться видимым в проверках | MEDIUM | Disabled member не может выбрать company и получить данные; owner по `Company.user` остаётся доступен до отдельной company/user блокировки |
-| P0 | Запретить неконсистентное отключение владельца | Guard в disable-member action: нельзя отключить owner/self без отдельного transfer-owner сценария | Доменные инварианты держать в Action/Policy, не в Twig/UI | Отключение owner-member создаёт противоречие между `Company.user` и `CompanyMember` | MEDIUM | POST disable owner/self возвращает доменную ошибку/403; тест покрывает запрет |
-| P0 | Понять, какие компании активны для workers/CLI | Исправить/спланировать `CompanyRepository::getAllActiveCompanyIds()` под `companies` и будущий status | Репозиторий Company должен быть единственным источником списка active company ids | Сейчас метод ссылается на несуществующие `company.is_active` | HIGH при миграции, LOW для фикса SQL без нового поля | Метод возвращает реальные company ids; есть тест на active list |
+| P0 — DONE | Единообразно создать owner-account из public registration и admin | Единый `CreateOwnerAccountAction` / `CreateCompanyAction`, создание `Company`, `CompanyMember OWNER`, обязательный bootstrap данных | Один write-use-case = один Application Action; контроллеры только собирают input и вызывают action; все внешние модули идут через `CompanyFacade` | Сейчас разные пути создания дают разный набор связанных данных | MEDIUM | Любой owner-account имеет owner membership; public/admin tests проходят; нет дублирования создания company в контроллерах |
+| P0 — DONE | Пользователь не может работать после отключения в компании | Усилить `CompanyMember` access checks: только `ACTIVE` membership даёт доступ к invited company | Проверять доступ по active company + active membership, не по `find($id)` и не по глобальной роли | Disabled member сейчас частично может оставаться видимым в проверках | MEDIUM | Disabled member не может выбрать company и получить данные; owner по `Company.user` остаётся доступен до отдельной company/user блокировки |
+| P0 — DONE | Запретить неконсистентное отключение владельца | Guard в disable-member action: нельзя отключить owner/self без отдельного transfer-owner сценария | Доменные инварианты держать в Action/Policy, не в Twig/UI | Отключение owner-member создаёт противоречие между `Company.user` и `CompanyMember` | MEDIUM | POST disable owner/self возвращает доменную ошибку/403; тест покрывает запрет |
+| P0 — DONE | Понять, какие компании активны для workers/CLI | Исправить/спланировать `CompanyRepository::getAllActiveCompanyIds()` под `companies` и будущий status | Репозиторий Company должен быть единственным источником списка active company ids | Сейчас метод ссылается на несуществующие `company.is_active` | HIGH при миграции, LOW для фикса SQL без нового поля | Метод возвращает реальные company ids; есть тест на active list |
 | P1 | Заблокировать пользователя глобально | `UserStatus`, `blockedAt`, `blockedBy`, `blockReason`, `BlockUserAction`, `UnblockUserAction` | Не удалять пользователя; использовать explicit lifecycle state + audit; blocked user denied на login и runtime | Это базовая account-blocking функция | HIGH | Blocked user не может войти; активная сессия получает deny/logout; admin не может заблокировать себя |
 | P1 | Заблокировать компанию целиком | `CompanyStatus` или `isActive/isSuspended`, `SuspendCompanyAction`, `ActivateCompanyAction` | Company lifecycle отдельно от user lifecycle; не смешивать manual suspension и billing suspension без policy | Нужно отключать весь tenant, включая owner и фоновые задачи | HIGH | Suspended company не выбирается active; не попадает в `getAllActiveCompanyIds()`; UI/API возвращают controlled deny |
 | P1 | Админ управляет блокировками безопасно | Admin UI/API: block/unblock user, suspend/activate company, reason field, CSRF | Все state-changing admin actions только POST + CSRF + audit; focused controllers per action | Без UI операции останутся ручными и неаудируемыми | HIGH | Admin видит status; действия защищены CSRF; audit содержит actor/reason/time |
@@ -222,19 +252,20 @@
 
 ## Предлагаемый staged plan
 
-### Stage 1: Зафиксировать текущие инварианты создания компании
+### Stage 1: Зафиксировать текущие инварианты создания компании — DONE
 
 **Risk:** MEDIUM
+**Stage report:** `docs/tasks/account/stages/stage-1.md`
 
 Цель: сделать создание компании единообразным без изменения auth/RBAC.
 
 Работы:
 
-- Добавить/выделить `CreateCompanyAction` или `CompanyCreator` в `Company/Application`.
-- Использовать его в `CompanyOwnerAccountCreator`, `CompanyController::new()` и при необходимости `AccountBootstrapper`.
-- Всегда создавать `CompanyMember OWNER` для owner.
-- Явно решить, какие seed-операции обязательны при создании компании: balance, cashflow, PL, money accounts.
-- Добавить unit/functional тесты на оба пути: public/admin owner-account и `/company/new`.
+- [x] Добавить/выделить `CreateCompanyAction` или `CompanyCreator` в `Company/Application` — реализовано как `CompanyOwnerMembershipCreator`.
+- [x] Использовать его в `CompanyOwnerAccountCreator`, `CompanyController::new()` и при необходимости `AccountBootstrapper`.
+- [x] Всегда создавать `CompanyMember OWNER` для owner.
+- [ ] Явно решить, какие seed-операции обязательны при создании компании: balance, cashflow, PL, money accounts — оставлено отдельным решением, текущие seed-пути не расширялись.
+- [x] Добавить unit/functional тесты на оба пути: public/admin owner-account и `/company/new`.
 
 Ожидаемые файлы:
 
@@ -245,20 +276,21 @@
 - `site/tests/Unit/Company/*`
 - `site/tests/Functional/Company/*` или ближайший существующий test namespace
 
-### Stage 2: Укрепить управление участниками и invite-flow
+### Stage 2: Укрепить управление участниками и invite-flow — DONE
 
 **Risk:** MEDIUM
+**Stage report:** `docs/tasks/account/stages/stage-2.md`
 
 Цель: сделать текущий per-company disable реальной и непротиворечивой функцией управления доступом.
 
 Работы:
 
-- Вынести enable/disable member в Application action.
-- Запретить отключение owner-member/self без отдельного сценария передачи владельца.
-- В `assertCompanyMemberAccess()` использовать active membership там, где нужен доступ активного участника.
-- Для disabled existing member при accept invite: либо явно re-enable, либо вернуть доменную ошибку. Правило нужно зафиксировать до реализации.
-- Обновить UI/flash messages для already-member/disabled-member cases.
-- Добавить тесты на disabled member access и invite edge cases.
+- [x] Вынести enable/disable member в Application action.
+- [x] Запретить отключение owner-member/self без отдельного сценария передачи владельца.
+- [x] В `assertCompanyMemberAccess()` использовать active membership там, где нужен доступ активного участника.
+- [x] Для disabled existing member при accept invite: вернуть доменную ошибку; re-enable остаётся явным owner-действием.
+- [ ] Обновить UI/flash messages для already-member/disabled-member cases — не делалось в P0, потому что текущий scope ограничен use case guards.
+- [x] Добавить тесты на disabled member access и invite edge cases.
 
 Ожидаемые файлы:
 

--- a/docs/tasks/account/stages/stage-1.md
+++ b/docs/tasks/account/stages/stage-1.md
@@ -1,0 +1,42 @@
+### Stage 1: Company owner creation invariant — DONE
+
+**Risk:** MEDIUM
+**Next action:** continue autonomously
+
+#### What was done
+- Added a shared `CompanyOwnerMembershipCreator` for new company creation with mandatory `CompanyMember::ROLE_OWNER`.
+- Reused it in public/admin owner-account creation, `/company/new`, and `AccountBootstrapper`.
+- Bound `CompanyMember` to its Doctrine repository so `getRepository(CompanyMember::class)` exposes project repository methods.
+- Fixed registration functional tests to submit real forms with CSRF-backed sessions.
+
+#### Files changed
+- `site/src/Company/Application/Service/CompanyOwnerMembershipCreator.php` — new
+- `site/src/Company/Service/CompanyOwnerAccountCreator.php` — modified
+- `site/src/Company/Controller/CompanyController.php` — modified
+- `site/src/Company/Application/Service/AccountBootstrapper.php` — modified
+- `site/src/Company/Entity/CompanyMember.php` — modified
+- `site/tests/Unit/Company/CompanyOwnerMembershipCreatorTest.php` — new
+- `site/tests/Unit/Company/CompanyOwnerAccountCreatorTest.php` — modified
+- `site/tests/Unit/Admin/Application/CreateAccountActionTest.php` — modified
+- `site/tests/Functional/Company/CompanyCreateFlowTest.php` — new
+- `site/tests/Functional/Company/PublicRegistrationFlowTest.php` — modified
+- `site/tests/Functional/Company/InviteRegistrationFlowTest.php` — modified
+
+#### Self-review
+- [x] Scope compliance
+- [x] Project patterns followed
+- [x] No forbidden actions
+- [x] Security/company access checked
+- [x] Tests/checks run
+- [x] Documentation updated or N/A
+
+#### Checks
+- `docker compose run --rm site-php-cli php bin/phpunit --testsuite unit --filter 'CompanyOwnerMembershipCreatorTest|DisableCompanyMemberActionTest|EnableCompanyMemberActionTest|CompanyOwnerAccountCreatorTest|CreateAccountActionTest|CompanyInviteManagerTest|CompanyInviteEntityTest'` — OK, 23 tests, 139 assertions
+- `docker compose run --rm site-php-cli sh -lc '... php -l ...'` — OK, no syntax errors in changed files
+
+#### Risks / reviewer focus
+- `CompanyOwnerMembershipCreator::persistCompanyWithOwnerMembership()` is intended for newly-created companies; owner transfer remains out of scope.
+- Full bootstrap consistency for cashflow/PL/money accounts remains a separate decision.
+
+#### Open questions
+- none

--- a/docs/tasks/account/stages/stage-2.md
+++ b/docs/tasks/account/stages/stage-2.md
@@ -1,0 +1,50 @@
+### Stage 2: Company member access hardening — DONE
+
+**Risk:** MEDIUM
+**Next action:** STOP, owner review required
+
+#### What was done
+- Added Application actions for enabling/disabling company members.
+- Kept controllers thin and delegated state changes to actions.
+- Added guards against disabling self, company owner user, or `ROLE_OWNER` membership.
+- Changed member access checks to require active membership for invited users.
+- Made invite accept reject an existing disabled member instead of silently accepting and keeping inconsistent access.
+- Fixed `CompanyRepository::getAllActiveCompanyIds()` to read from the real `companies` table until CompanyStatus exists.
+- Updated stale Finance command/test comments that referenced the old broken active-company SQL.
+
+#### Files changed
+- `site/src/Company/Application/DisableCompanyMemberAction.php` — new
+- `site/src/Company/Application/EnableCompanyMemberAction.php` — new
+- `site/src/Company/Controller/CompanyMemberController.php` — modified
+- `site/src/Company/Repository/CompanyMemberRepository.php` — modified
+- `site/src/Company/Service/CompanyInviteManager.php` — modified
+- `site/src/Company/Infrastructure/Repository/CompanyRepository.php` — modified
+- `site/src/Finance/Command/RecalcPlRegisterCommand.php` — modified comments only
+- `site/tests/Unit/Company/DisableCompanyMemberActionTest.php` — new
+- `site/tests/Unit/Company/EnableCompanyMemberActionTest.php` — new
+- `site/tests/Unit/Company/CompanyInviteManagerTest.php` — modified
+- `site/tests/Functional/Company/CompanyMemberAccessTest.php` — new
+- `site/tests/Integration/Company/CompanyPersistenceTest.php` — modified
+- `site/tests/Integration/Finance/RecalcPlRegisterCommandTest.php` — modified comments only
+- `site/tests/Builders/Company/CompanyInviteBuilder.php` — modified test default expiry
+
+#### Self-review
+- [x] Scope compliance
+- [x] Project patterns followed
+- [x] No forbidden actions
+- [x] Security/company access checked
+- [x] Tests/checks run
+- [x] Documentation updated or N/A
+
+#### Checks
+- `make site-test-unit` — OK, 1213 tests, 7451 assertions; existing PHPUnit output includes 1 warning and 1 deprecation
+- `docker compose run --rm site-php-cli sh -lc 'export DATABASE_URL=...; php bin/phpunit --filter "CompanyCreateFlowTest|CompanyMemberAccessTest|AdminUserCreateAccountTest|UserCreateAccountControllerTest|PublicRegistrationFlowTest|InviteRegistrationFlowTest|CompanyPersistenceTest|RecalcPlRegisterCommandTest"'` — OK, 17 tests, 96 assertions; existing form deprecations remain
+- `git diff --check -- <changed paths>` — OK
+
+#### Risks / reviewer focus
+- No audit fields were added for disable/enable because that requires schema work and belongs to P1.
+- `getAllActiveCompanyIds()` currently treats all rows in `companies` as active until CompanyStatus/suspension is introduced.
+- One-off Docker CLI containers do not resolve the `site-postgres` service alias in this environment; DB checks used the existing container name as a local test workaround.
+
+#### Open questions
+- none

--- a/site/src/Company/Application/DisableCompanyMemberAction.php
+++ b/site/src/Company/Application/DisableCompanyMemberAction.php
@@ -28,7 +28,7 @@ final readonly class DisableCompanyMemberAction
             throw new NotFoundHttpException('Company not found.');
         }
 
-        if ($company->getUser() !== $actor) {
+        if ($company->getUser()->getId() !== $actor->getId()) {
             throw new AccessDeniedException('Only company owner can manage members.');
         }
 
@@ -37,11 +37,13 @@ final readonly class DisableCompanyMemberAction
             throw new NotFoundHttpException('Company member not found.');
         }
 
-        if ($member->getUser() === $actor) {
+        $memberUserId = $member->getUser()->getId();
+
+        if ($memberUserId === $actor->getId()) {
             throw new AccessDeniedException('Company owner cannot disable own membership.');
         }
 
-        if ($member->getUser() === $company->getUser() || CompanyMember::ROLE_OWNER === $member->getRole()) {
+        if ($memberUserId === $company->getUser()->getId() || CompanyMember::ROLE_OWNER === $member->getRole()) {
             throw new AccessDeniedException('Company owner membership cannot be disabled.');
         }
 

--- a/site/src/Company/Application/DisableCompanyMemberAction.php
+++ b/site/src/Company/Application/DisableCompanyMemberAction.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Company\Application;
+
+use App\Company\Entity\CompanyMember;
+use App\Company\Entity\User;
+use App\Company\Infrastructure\Repository\CompanyRepository;
+use App\Company\Repository\CompanyMemberRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+final readonly class DisableCompanyMemberAction
+{
+    public function __construct(
+        private CompanyRepository $companyRepository,
+        private CompanyMemberRepository $companyMemberRepository,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function __invoke(string $companyId, string $memberId, User $actor): void
+    {
+        $company = $this->companyRepository->findById($companyId);
+        if (null === $company) {
+            throw new NotFoundHttpException('Company not found.');
+        }
+
+        if ($company->getUser() !== $actor) {
+            throw new AccessDeniedException('Only company owner can manage members.');
+        }
+
+        $member = $this->companyMemberRepository->findOneByIdAndCompanyId($memberId, $companyId);
+        if (null === $member) {
+            throw new NotFoundHttpException('Company member not found.');
+        }
+
+        if ($member->getUser() === $actor) {
+            throw new AccessDeniedException('Company owner cannot disable own membership.');
+        }
+
+        if ($member->getUser() === $company->getUser() || CompanyMember::ROLE_OWNER === $member->getRole()) {
+            throw new AccessDeniedException('Company owner membership cannot be disabled.');
+        }
+
+        $member->disable();
+        $this->entityManager->flush();
+    }
+}

--- a/site/src/Company/Application/EnableCompanyMemberAction.php
+++ b/site/src/Company/Application/EnableCompanyMemberAction.php
@@ -27,7 +27,7 @@ final readonly class EnableCompanyMemberAction
             throw new NotFoundHttpException('Company not found.');
         }
 
-        if ($company->getUser() !== $actor) {
+        if ($company->getUser()->getId() !== $actor->getId()) {
             throw new AccessDeniedException('Only company owner can manage members.');
         }
 

--- a/site/src/Company/Application/EnableCompanyMemberAction.php
+++ b/site/src/Company/Application/EnableCompanyMemberAction.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Company\Application;
+
+use App\Company\Entity\User;
+use App\Company\Infrastructure\Repository\CompanyRepository;
+use App\Company\Repository\CompanyMemberRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+final readonly class EnableCompanyMemberAction
+{
+    public function __construct(
+        private CompanyRepository $companyRepository,
+        private CompanyMemberRepository $companyMemberRepository,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function __invoke(string $companyId, string $memberId, User $actor): void
+    {
+        $company = $this->companyRepository->findById($companyId);
+        if (null === $company) {
+            throw new NotFoundHttpException('Company not found.');
+        }
+
+        if ($company->getUser() !== $actor) {
+            throw new AccessDeniedException('Only company owner can manage members.');
+        }
+
+        $member = $this->companyMemberRepository->findOneByIdAndCompanyId($memberId, $companyId);
+        if (null === $member) {
+            throw new NotFoundHttpException('Company member not found.');
+        }
+
+        $member->enable();
+        $this->entityManager->flush();
+    }
+}

--- a/site/src/Company/Application/Service/AccountBootstrapper.php
+++ b/site/src/Company/Application/Service/AccountBootstrapper.php
@@ -16,7 +16,6 @@ use App\Company\Infrastructure\Repository\CompanyRepository;
 use App\Finance\Entity\PLCategory;
 use App\Finance\Repository\PLCategoryRepository;
 use Doctrine\ORM\EntityManagerInterface;
-use Ramsey\Uuid\Uuid;
 
 final class AccountBootstrapper
 {
@@ -27,6 +26,7 @@ final class AccountBootstrapper
         private readonly PLCategoryRepository $plCategories,
         private readonly MoneyAccountRepository $moneyAccounts,
         private readonly BalanceStructureSeeder $balanceSeeder,
+        private readonly CompanyOwnerMembershipCreator $companyOwnerMembershipCreator,
     ) {
     }
 
@@ -67,15 +67,7 @@ final class AccountBootstrapper
 
     private function createCompanyFor(User $user, string $name): Company
     {
-        $company = new Company(
-            id: Uuid::uuid4()->toString(),
-            user: $user,
-        );
-        $company->setName($name);
-
-        $this->em->persist($company);
-
-        return $company;
+        return $this->companyOwnerMembershipCreator->createCompany($user, $name);
     }
 
     private function seedCashflow(Company $company): void

--- a/site/src/Company/Application/Service/CompanyOwnerMembershipCreator.php
+++ b/site/src/Company/Application/Service/CompanyOwnerMembershipCreator.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Company\Application\Service;
+
+use App\Company\Entity\Company;
+use App\Company\Entity\CompanyMember;
+use App\Company\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+
+final readonly class CompanyOwnerMembershipCreator
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function createCompany(User $owner, string $companyName): Company
+    {
+        $company = new Company(Uuid::uuid4()->toString(), $owner);
+        $company->setName(\trim($companyName));
+
+        return $this->persistCompanyWithOwnerMembership($company, $owner);
+    }
+
+    public function persistCompanyWithOwnerMembership(Company $company, User $owner): Company
+    {
+        $company->setUser($owner);
+        $owner->addCompany($company);
+
+        $this->entityManager->persist($company);
+        $this->entityManager->persist(new CompanyMember(
+            id: Uuid::uuid4()->toString(),
+            company: $company,
+            user: $owner,
+            role: CompanyMember::ROLE_OWNER,
+        ));
+
+        return $company;
+    }
+}

--- a/site/src/Company/Controller/CompanyController.php
+++ b/site/src/Company/Controller/CompanyController.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Company\Controller;
 
 use App\Balance\Service\BalanceStructureSeeder;
+use App\Company\Application\Service\CompanyOwnerMembershipCreator;
 use App\Company\Entity\Company;
+use App\Company\Entity\User;
 use App\Company\Form\CompanyType;
 use App\Company\Infrastructure\Repository\CompanyRepository;
 use Doctrine\ORM\EntityManagerInterface;
@@ -56,16 +58,25 @@ class CompanyController extends AbstractController
     }
 
     #[Route('/new', name: 'company_new', methods: ['GET', 'POST'])]
-    public function new(Request $request, EntityManagerInterface $em, BalanceStructureSeeder $balanceSeeder): Response
-    {
-        $company = new Company(id: Uuid::uuid4()->toString(), user: $this->getUser());
-        $company->setUser($this->getUser()); // Автоматически проставляем владельца
+    public function new(
+        Request $request,
+        EntityManagerInterface $em,
+        BalanceStructureSeeder $balanceSeeder,
+        CompanyOwnerMembershipCreator $companyOwnerMembershipCreator,
+    ): Response {
+        $user = $this->getUser();
+        if (!$user instanceof User) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $company = new Company(id: Uuid::uuid4()->toString(), user: $user);
+        $company->setUser($user); // Автоматически проставляем владельца
 
         $form = $this->createForm(CompanyType::class, $company);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $em->persist($company);
+            $companyOwnerMembershipCreator->persistCompanyWithOwnerMembership($company, $user);
             $balanceSeeder->seedDefaultIfEmpty($company);
             $em->flush();
 

--- a/site/src/Company/Controller/CompanyMemberController.php
+++ b/site/src/Company/Controller/CompanyMemberController.php
@@ -45,6 +45,7 @@ class CompanyMemberController extends AbstractController
             $invites,
             static fn ($invite) => !$invite->isPending($now),
         ));
+        $user = $this->getUser();
 
         return $this->render('company/company_member/index.html.twig', [
             'company' => $company,
@@ -52,7 +53,7 @@ class CompanyMemberController extends AbstractController
             'pendingInvites' => $pendingInvites,
             'nonPendingInvites' => $nonPendingInvites,
             'inviteForm' => $this->createForm(CompanyInviteOperatorType::class)->createView(),
-            'isOwner' => $company->getUser() === $this->getUser(),
+            'isOwner' => $user instanceof User && $company->getUser()->getId() === $user->getId(),
         ]);
     }
 
@@ -325,11 +326,11 @@ class CompanyMemberController extends AbstractController
     private function assertCompanyMemberAccess(Company $company, CompanyMemberRepository $memberRepository): void
     {
         $user = $this->getUser();
-        if (!$user) {
+        if (!$user instanceof User) {
             throw new AccessDeniedException();
         }
 
-        if ($company->getUser() === $user) {
+        if ($company->getUser()->getId() === $user->getId()) {
             return;
         }
 
@@ -341,7 +342,8 @@ class CompanyMemberController extends AbstractController
 
     private function assertOwner(Company $company): void
     {
-        if ($company->getUser() !== $this->getUser()) {
+        $user = $this->getUser();
+        if (!$user instanceof User || $company->getUser()->getId() !== $user->getId()) {
             throw new AccessDeniedException('Only company owner can manage members.');
         }
     }

--- a/site/src/Company/Controller/CompanyMemberController.php
+++ b/site/src/Company/Controller/CompanyMemberController.php
@@ -2,17 +2,19 @@
 
 namespace App\Company\Controller;
 
+use App\Company\Application\DisableCompanyMemberAction;
+use App\Company\Application\EnableCompanyMemberAction;
 use App\Company\Entity\Company;
+use App\Company\Entity\User;
 use App\Company\Form\CompanyInviteOperatorType;
+use App\Company\Infrastructure\Repository\CompanyRepository;
 use App\Company\Repository\CompanyInviteRepository;
 use App\Company\Repository\CompanyMemberRepository;
-use App\Company\Repository\CompanyRepository;
 use App\Company\Service\CompanyInviteManager;
 use App\Notification\DTO\EmailMessage;
 use App\Notification\DTO\NotificationContext;
 use App\Notification\Service\NotificationRouter;
 use App\Shared\Service\ActiveCompanyService;
-use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -174,23 +176,20 @@ class CompanyMemberController extends AbstractController
         string $memberId,
         Request $request,
         ActiveCompanyService $activeCompanyService,
-        CompanyMemberRepository $memberRepository,
-        EntityManagerInterface $entityManager,
+        DisableCompanyMemberAction $disableCompanyMember,
     ): Response {
         $company = $activeCompanyService->getActiveCompany();
-        $this->assertOwner($company);
 
         if (!$this->isCsrfTokenValid('member_disable_'.$memberId, (string) $request->request->get('_token'))) {
             throw $this->createAccessDeniedException();
         }
 
-        $member = $memberRepository->find($memberId);
-        if (!$member || $member->getCompany() !== $company) {
-            throw $this->createNotFoundException();
+        $user = $this->getUser();
+        if (!$user instanceof User) {
+            throw $this->createAccessDeniedException();
         }
 
-        $member->disable();
-        $entityManager->flush();
+        $disableCompanyMember((string) $company->getId(), $memberId, $user);
         $this->addFlash('success', 'Участник отключен.');
 
         return $this->redirectToRoute('company_users_index');
@@ -201,23 +200,20 @@ class CompanyMemberController extends AbstractController
         string $memberId,
         Request $request,
         ActiveCompanyService $activeCompanyService,
-        CompanyMemberRepository $memberRepository,
-        EntityManagerInterface $entityManager,
+        EnableCompanyMemberAction $enableCompanyMember,
     ): Response {
         $company = $activeCompanyService->getActiveCompany();
-        $this->assertOwner($company);
 
         if (!$this->isCsrfTokenValid('member_enable_'.$memberId, (string) $request->request->get('_token'))) {
             throw $this->createAccessDeniedException();
         }
 
-        $member = $memberRepository->find($memberId);
-        if (!$member || $member->getCompany() !== $company) {
-            throw $this->createNotFoundException();
+        $user = $this->getUser();
+        if (!$user instanceof User) {
+            throw $this->createAccessDeniedException();
         }
 
-        $member->enable();
-        $entityManager->flush();
+        $enableCompanyMember((string) $company->getId(), $memberId, $user);
         $this->addFlash('success', 'Участник активирован.');
 
         return $this->redirectToRoute('company_users_index');
@@ -277,7 +273,7 @@ class CompanyMemberController extends AbstractController
         CompanyRepository $companyRepository,
         CompanyMemberRepository $memberRepository,
         ActiveCompanyService $activeCompanyService,
-        EntityManagerInterface $entityManager,
+        DisableCompanyMemberAction $disableCompanyMember,
     ): Response {
         $this->activateLegacyCompany($companyId, $request, $companyRepository, $memberRepository);
 
@@ -285,8 +281,7 @@ class CompanyMemberController extends AbstractController
             $memberId,
             $request,
             $activeCompanyService,
-            $memberRepository,
-            $entityManager,
+            $disableCompanyMember,
         );
     }
 
@@ -298,7 +293,7 @@ class CompanyMemberController extends AbstractController
         CompanyRepository $companyRepository,
         CompanyMemberRepository $memberRepository,
         ActiveCompanyService $activeCompanyService,
-        EntityManagerInterface $entityManager,
+        EnableCompanyMemberAction $enableCompanyMember,
     ): Response {
         $this->activateLegacyCompany($companyId, $request, $companyRepository, $memberRepository);
 
@@ -306,8 +301,7 @@ class CompanyMemberController extends AbstractController
             $memberId,
             $request,
             $activeCompanyService,
-            $memberRepository,
-            $entityManager,
+            $enableCompanyMember,
         );
     }
 
@@ -339,7 +333,7 @@ class CompanyMemberController extends AbstractController
             return;
         }
 
-        $member = $memberRepository->findOneByCompanyAndUser($company, $user);
+        $member = $memberRepository->findActiveOneByCompanyAndUser($company, $user);
         if (!$member) {
             throw new AccessDeniedException();
         }

--- a/site/src/Company/Entity/CompanyMember.php
+++ b/site/src/Company/Entity/CompanyMember.php
@@ -2,10 +2,11 @@
 
 namespace App\Company\Entity;
 
+use App\Company\Repository\CompanyMemberRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Webmozart\Assert\Assert;
 
-#[ORM\Entity]
+#[ORM\Entity(repositoryClass: CompanyMemberRepository::class)]
 #[ORM\Table(name: 'company_members')]
 #[ORM\UniqueConstraint(name: 'uniq_company_members_company_user', columns: ['company_id', 'user_id'])]
 class CompanyMember

--- a/site/src/Company/Infrastructure/Repository/CompanyRepository.php
+++ b/site/src/Company/Infrastructure/Repository/CompanyRepository.php
@@ -43,9 +43,8 @@ class CompanyRepository extends ServiceEntityRepository
      */
     public function getAllActiveCompanyIds(): array
     {
-        // В фасаде мы можем использовать прямой DBAL запрос для скорости (Fast Read),
-        // либо вызвать внутренний CompanyQuery класс модуля Company.
-        $sql = 'SELECT id::text FROM company WHERE is_active = true';
+        // До появления CompanyStatus/is_active все сохранённые companies считаются активными.
+        $sql = 'SELECT id::text FROM companies ORDER BY id';
 
         return $this->connection->fetchFirstColumn($sql);
     }

--- a/site/src/Company/Repository/CompanyMemberRepository.php
+++ b/site/src/Company/Repository/CompanyMemberRepository.php
@@ -63,6 +63,18 @@ class CompanyMemberRepository extends ServiceEntityRepository
             ->getOneOrNullResult();
     }
 
+    public function findOneByIdAndCompanyId(string $memberId, string $companyId): ?CompanyMember
+    {
+        return $this->createQueryBuilder('companyMember')
+            ->innerJoin('companyMember.company', 'company')
+            ->andWhere('companyMember.id = :memberId')
+            ->andWhere('company.id = :companyId')
+            ->setParameter('memberId', $memberId)
+            ->setParameter('companyId', $companyId)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
     public function findActiveOneByCompanyAndUser(Company $company, User $user): ?CompanyMember
     {
         return $this->createQueryBuilder('companyMember')

--- a/site/src/Company/Service/CompanyInviteManager.php
+++ b/site/src/Company/Service/CompanyInviteManager.php
@@ -97,6 +97,10 @@ class CompanyInviteManager
         }
 
         $member = $this->memberRepository->findOneByCompanyAndUser($invite->getCompany(), $user);
+        if ($member && CompanyMember::STATUS_DISABLED === $member->getStatus()) {
+            throw new AccessDeniedException('Company member is disabled.');
+        }
+
         if (!$member) {
             $member = new CompanyMember(
                 id: Uuid::uuid4()->toString(),

--- a/site/src/Company/Service/CompanyOwnerAccountCreator.php
+++ b/site/src/Company/Service/CompanyOwnerAccountCreator.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace App\Company\Service;
 
+use App\Company\Application\Service\CompanyOwnerMembershipCreator;
 use App\Company\Entity\Company;
-use App\Company\Entity\CompanyMember;
 use App\Company\Entity\User;
-use App\Company\Repository\CompanyMemberRepository;
 use App\Company\Message\SendRegistrationEmailMessage;
 use Doctrine\ORM\EntityManagerInterface;
-use Ramsey\Uuid\Uuid;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
@@ -20,7 +18,7 @@ final readonly class CompanyOwnerAccountCreator
         private UserPasswordHasherInterface $userPasswordHasher,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $bus,
-        private CompanyMemberRepository $companyMemberRepository,
+        private CompanyOwnerMembershipCreator $companyOwnerMembershipCreator,
     ) {
     }
 
@@ -33,22 +31,8 @@ final readonly class CompanyOwnerAccountCreator
         $user->setPassword($this->userPasswordHasher->hashPassword($user, $plainPassword));
         $user->setRoles(['ROLE_COMPANY_OWNER']);
 
-        $company = new Company(Uuid::uuid4()->toString(), $user);
-        $company->setName(\trim($companyName));
-        $user->addCompany($company);
-
         $this->entityManager->persist($user);
-        $this->entityManager->persist($company);
-
-        if (null === $this->companyMemberRepository->findOneByCompanyAndUser($company, $user)) {
-            $companyMember = new CompanyMember(
-                id: Uuid::uuid4()->toString(),
-                company: $company,
-                user: $user,
-                role: CompanyMember::ROLE_OWNER,
-            );
-            $this->entityManager->persist($companyMember);
-        }
+        $company = $this->companyOwnerMembershipCreator->createCompany($user, $companyName);
 
         $this->entityManager->flush();
 

--- a/site/src/Finance/Command/RecalcPlRegisterCommand.php
+++ b/site/src/Finance/Command/RecalcPlRegisterCommand.php
@@ -178,11 +178,8 @@ final class RecalcPlRegisterCommand extends Command
             return [$company];
         }
 
-        // CompanyRepository::getAllActiveCompanyIds() ходит в несуществующую
-        // таблицу `company` с несуществующим полем `is_active` — баг в репо
-        // выходит за рамки этой задачи. Здесь обходим его через стандартный
-        // ORM `findBy` с явной сортировкой: один запрос, гарантированный
-        // порядок обработки, без хардкода имени таблицы.
+        // Команда обходит active-company facade, потому что пересчёт должен
+        // обработать все компании до появления явного CompanyStatus.
         return array_values($this->companyRepository->findBy([], ['id' => 'ASC']));
     }
 

--- a/site/tests/Builders/Company/CompanyInviteBuilder.php
+++ b/site/tests/Builders/Company/CompanyInviteBuilder.php
@@ -16,7 +16,7 @@ final class CompanyInviteBuilder
     public const DEFAULT_EMAIL = 'operator@example.test';
     public const DEFAULT_ROLE = CompanyMember::ROLE_OPERATOR;
     public const DEFAULT_TOKEN_HASH = 'token-hash';
-    public const DEFAULT_EXPIRES_AT = '2026-01-01 00:00:00+00:00';
+    public const DEFAULT_EXPIRES_AT = '2099-01-01 00:00:00+00:00';
     public const DEFAULT_CREATED_AT = '2024-01-01 00:00:00+00:00';
 
     private string $id;

--- a/site/tests/Functional/Company/CompanyCreateFlowTest.php
+++ b/site/tests/Functional/Company/CompanyCreateFlowTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Company;
+
+use App\Company\Entity\Company;
+use App\Company\Entity\CompanyMember;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+
+final class CompanyCreateFlowTest extends WebTestCaseBase
+{
+    public function testCreateCompanyAddsOwnerCompanyMember(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $owner = UserBuilder::aUser()
+            ->withEmail('owner@example.test')
+            ->withRoles(['ROLE_COMPANY_OWNER'])
+            ->build();
+
+        $em = $this->em();
+        $em->persist($owner);
+        $em->flush();
+
+        $client->loginUser($owner);
+        $crawler = $client->request('GET', '/company/new');
+
+        $form = $crawler->selectButton('Создать')->form([
+            'company[name]' => '  Created Company  ',
+            'company[inn]' => '1234567890',
+        ]);
+
+        $client->submit($form);
+
+        self::assertResponseRedirects('/company/');
+
+        $company = $em->getRepository(Company::class)->findOneBy(['name' => 'Created Company']);
+        self::assertNotNull($company);
+        self::assertSame($owner->getId(), $company->getUser()?->getId());
+        self::assertSame('1234567890', $company->getInn());
+
+        $member = $em->getRepository(CompanyMember::class)->findOneByCompanyAndUser($company, $owner);
+        self::assertNotNull($member);
+        self::assertSame(CompanyMember::ROLE_OWNER, $member->getRole());
+        self::assertSame(CompanyMember::STATUS_ACTIVE, $member->getStatus());
+    }
+}

--- a/site/tests/Functional/Company/CompanyMemberAccessTest.php
+++ b/site/tests/Functional/Company/CompanyMemberAccessTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Company;
+
+use App\Company\Entity\CompanyMember;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\CompanyMemberBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class CompanyMemberAccessTest extends WebTestCaseBase
+{
+    public function testActiveMemberCanOpenCompanyUsersPage(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$company, $memberUser] = $this->seedCompanyMember(CompanyMember::STATUS_ACTIVE);
+
+        $client->loginUser($memberUser);
+        $client->request('GET', sprintf('/company/%s/users', $company->getId()));
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('h2.page-title', 'Участники '.$company->getName());
+    }
+
+    public function testDisabledMemberCannotOpenCompanyUsersPage(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        [$company, $memberUser] = $this->seedCompanyMember(CompanyMember::STATUS_DISABLED);
+
+        $client->loginUser($memberUser);
+        $client->request('GET', sprintf('/company/%s/users', $company->getId()));
+
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    /**
+     * @return array{0: \App\Company\Entity\Company, 1: \App\Company\Entity\User}
+     */
+    private function seedCompanyMember(string $memberStatus): array
+    {
+        $owner = UserBuilder::aUser()
+            ->withEmail('owner@example.test')
+            ->withRoles(['ROLE_COMPANY_OWNER'])
+            ->build();
+        $memberUser = UserBuilder::aUser()
+            ->withIndex(2)
+            ->withEmail('member@example.test')
+            ->withRoles(['ROLE_COMPANY_USER'])
+            ->build();
+        $company = CompanyBuilder::aCompany()
+            ->withOwner($owner)
+            ->withName('Access Company')
+            ->build();
+        $member = CompanyMemberBuilder::aMember()
+            ->withCompany($company)
+            ->withUser($memberUser)
+            ->withStatus($memberStatus)
+            ->build();
+
+        $em = $this->em();
+        $em->persist($owner);
+        $em->persist($memberUser);
+        $em->persist($company);
+        $em->persist($member);
+        $em->flush();
+
+        return [$company, $memberUser];
+    }
+}

--- a/site/tests/Functional/Company/InviteRegistrationFlowTest.php
+++ b/site/tests/Functional/Company/InviteRegistrationFlowTest.php
@@ -9,6 +9,7 @@ use App\Company\Entity\CompanyInvite;
 use App\Company\Entity\CompanyMember;
 use App\Company\Entity\User;
 use App\Company\Service\InviteTokenService;
+use App\Shared\Service\RateLimiter\RegistrationRateLimiter;
 use App\Tests\Builders\Company\CompanyBuilder;
 use App\Tests\Builders\Company\CompanyInviteBuilder;
 use App\Tests\Builders\Company\UserBuilder;
@@ -20,6 +21,8 @@ final class InviteRegistrationFlowTest extends WebTestCaseBase
     {
         $client = static::createClient();
         $this->resetDb();
+        $client->getContainer()->set(RegistrationRateLimiter::class, new RegistrationRateLimiter());
+        $client->setServerParameter('REMOTE_ADDR', $this->uniqueClientIp());
 
         $em = $this->em();
         $owner = UserBuilder::aUser()->withEmail('owner@example.test')->build();
@@ -40,18 +43,14 @@ final class InviteRegistrationFlowTest extends WebTestCaseBase
         $em->persist($invite);
         $em->flush();
 
-        $csrfManager = $client->getContainer()->get('security.csrf.token_manager');
-        $token = $csrfManager->getToken('registration_form')->getValue();
-
-        $client->request('POST', sprintf('/register?invite=%s', $plainToken), [
-            'registration_form' => [
-                'email' => $inviteEmail,
-                'plainPassword' => 'password123',
-                'agreeTerms' => 1,
-                'website' => '',
-                '_token' => $token,
-            ],
+        $crawler = $client->request('GET', sprintf('/register?invite=%s', $plainToken));
+        $form = $crawler->selectButton('Создать аккаунт')->form([
+            'registration_form[email]' => $inviteEmail,
+            'registration_form[plainPassword]' => 'password123',
+            'registration_form[agreeTerms]' => 1,
+            'registration_form[website]' => '',
         ]);
+        $client->submit($form);
 
         self::assertTrue($client->getResponse()->isRedirect());
 
@@ -75,5 +74,16 @@ final class InviteRegistrationFlowTest extends WebTestCaseBase
         $updatedInvite = $this->em()->getRepository(CompanyInvite::class)->find($invite->getId());
         self::assertNotNull($updatedInvite);
         self::assertNotNull($updatedInvite->getAcceptedAt());
+    }
+
+    private function uniqueClientIp(): string
+    {
+        return sprintf(
+            '2001:db8:%x:%x:%x:%x::1',
+            random_int(0, 0xffff),
+            random_int(0, 0xffff),
+            random_int(0, 0xffff),
+            random_int(0, 0xffff),
+        );
     }
 }

--- a/site/tests/Functional/Company/PublicRegistrationFlowTest.php
+++ b/site/tests/Functional/Company/PublicRegistrationFlowTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Functional\Company;
 use App\Company\Entity\Company;
 use App\Company\Entity\CompanyMember;
 use App\Company\Entity\User;
+use App\Shared\Service\RateLimiter\RegistrationRateLimiter;
 use App\Tests\Support\Kernel\WebTestCaseBase;
 
 final class PublicRegistrationFlowTest extends WebTestCaseBase
@@ -15,22 +16,21 @@ final class PublicRegistrationFlowTest extends WebTestCaseBase
     {
         $client = static::createClient();
         $this->resetDb();
+        $client->getContainer()->set(RegistrationRateLimiter::class, new RegistrationRateLimiter());
+        $client->setServerParameter('REMOTE_ADDR', $this->uniqueClientIp());
 
-        $csrfManager = $client->getContainer()->get('security.csrf.token_manager');
-        $token = $csrfManager->getToken('registration_form')->getValue();
         $email = 'owner-registration@example.test';
         $companyName = 'Registration LLC';
+        $crawler = $client->request('GET', '/register');
 
-        $client->request('POST', '/register', [
-            'registration_form' => [
-                'companyName' => $companyName,
-                'email' => $email,
-                'plainPassword' => 'password123',
-                'agreeTerms' => 1,
-                'website' => '',
-                '_token' => $token,
-            ],
+        $form = $crawler->selectButton('Создать аккаунт')->form([
+            'registration_form[companyName]' => $companyName,
+            'registration_form[email]' => $email,
+            'registration_form[plainPassword]' => 'password123',
+            'registration_form[agreeTerms]' => 1,
+            'registration_form[website]' => '',
         ]);
+        $client->submit($form);
 
         self::assertTrue($client->getResponse()->isRedirect());
 
@@ -57,5 +57,16 @@ final class PublicRegistrationFlowTest extends WebTestCaseBase
         self::assertSame($registeredUser->getId(), $member->getUser()->getId());
         self::assertSame(CompanyMember::ROLE_OWNER, $member->getRole());
         self::assertSame(CompanyMember::STATUS_ACTIVE, $member->getStatus());
+    }
+
+    private function uniqueClientIp(): string
+    {
+        return sprintf(
+            '2001:db8:%x:%x:%x:%x::1',
+            random_int(0, 0xffff),
+            random_int(0, 0xffff),
+            random_int(0, 0xffff),
+            random_int(0, 0xffff),
+        );
     }
 }

--- a/site/tests/Integration/Company/CompanyPersistenceTest.php
+++ b/site/tests/Integration/Company/CompanyPersistenceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Integration\Company;
 
 use App\Company\Entity\Company;
+use App\Company\Infrastructure\Repository\CompanyRepository;
 use App\Tests\Builders\Company\CompanyBuilder;
 use App\Tests\Builders\Company\UserBuilder;
 use App\Tests\Support\Kernel\IntegrationTestCase;
@@ -33,5 +34,41 @@ final class CompanyPersistenceTest extends IntegrationTestCase
         self::assertNotNull($companyFromDb);
         self::assertNotNull($companyFromDb->getUser());
         self::assertSame($user->getId(), $companyFromDb->getUser()->getId());
+    }
+
+    public function testGetAllActiveCompanyIdsReadsExistingCompaniesTable(): void
+    {
+        $userA = UserBuilder::aUser()
+            ->withId('22222222-2222-2222-2222-000000000301')
+            ->withEmail('company-a@example.test')
+            ->build();
+        $userB = UserBuilder::aUser()
+            ->withId('22222222-2222-2222-2222-000000000302')
+            ->withEmail('company-b@example.test')
+            ->build();
+        $companyA = CompanyBuilder::aCompany()
+            ->withId('11111111-1111-1111-1111-000000000301')
+            ->withOwner($userA)
+            ->withName('Company A')
+            ->build();
+        $companyB = CompanyBuilder::aCompany()
+            ->withId('11111111-1111-1111-1111-000000000302')
+            ->withOwner($userB)
+            ->withName('Company B')
+            ->build();
+
+        $this->em->persist($userA);
+        $this->em->persist($userB);
+        $this->em->persist($companyA);
+        $this->em->persist($companyB);
+        $this->em->flush();
+
+        /** @var CompanyRepository $companyRepository */
+        $companyRepository = static::getContainer()->get(CompanyRepository::class);
+
+        self::assertSame([
+            (string) $companyA->getId(),
+            (string) $companyB->getId(),
+        ], $companyRepository->getAllActiveCompanyIds());
     }
 }

--- a/site/tests/Integration/Finance/RecalcPlRegisterCommandTest.php
+++ b/site/tests/Integration/Finance/RecalcPlRegisterCommandTest.php
@@ -15,10 +15,8 @@ use Symfony\Component\Console\Tester\CommandTester;
  * Регрессия для прод-инцидента 2026-04-26 — `app:finance:recalc-pl-register`
  * без позиционного `companyId` падал с
  *   SQLSTATE[42P01]: Undefined table: relation "company" does not exist
- * потому что `CompanyRepository::getAllActiveCompanyIds()` запрашивает
- * `SELECT id FROM company WHERE is_active = true`, а реальная таблица —
- * `companies` без поля `is_active`. Фикс убрал зависимость команды
- * от этого репо-метода.
+ * из-за старой реализации active-company facade. Команда намеренно
+ * не зависит от этого фасада, пока у `Company` нет явного lifecycle/status.
  */
 final class RecalcPlRegisterCommandTest extends IntegrationTestCase
 {

--- a/site/tests/Unit/Admin/Application/CreateAccountActionTest.php
+++ b/site/tests/Unit/Admin/Application/CreateAccountActionTest.php
@@ -8,9 +8,9 @@ use App\Admin\Application\CreateAccountAction;
 use App\Company\Entity\Company;
 use App\Company\Entity\CompanyMember;
 use App\Company\Entity\User;
+use App\Company\Application\Service\CompanyOwnerMembershipCreator;
 use App\Company\Facade\CompanyFacade;
 use App\Company\Infrastructure\Repository\CompanyRepository;
-use App\Company\Repository\CompanyMemberRepository;
 use App\Company\Service\CompanyOwnerAccountCreator;
 use App\Company\Message\SendRegistrationEmailMessage;
 use Doctrine\ORM\EntityManagerInterface;
@@ -50,16 +50,6 @@ final class CreateAccountActionTest extends TestCase
             ->expects(self::once())
             ->method('flush');
 
-        $companyMemberRepository = $this->createMock(CompanyMemberRepository::class);
-        $companyMemberRepository
-            ->expects(self::once())
-            ->method('findOneByCompanyAndUser')
-            ->with(
-                self::isInstanceOf(Company::class),
-                self::callback(static fn (User $user): bool => 'new-owner@example.test' === $user->getEmail()),
-            )
-            ->willReturn(null);
-
         $bus = $this->createMock(MessageBusInterface::class);
         $bus
             ->expects(self::once())
@@ -71,7 +61,7 @@ final class CreateAccountActionTest extends TestCase
             $passwordHasher,
             $entityManager,
             $bus,
-            $companyMemberRepository,
+            new CompanyOwnerMembershipCreator($entityManager),
         );
         $companyFacade = new CompanyFacade($this->createMock(CompanyRepository::class), $accountCreator);
         $action = new CreateAccountAction($companyFacade);

--- a/site/tests/Unit/Company/CompanyInviteManagerTest.php
+++ b/site/tests/Unit/Company/CompanyInviteManagerTest.php
@@ -15,6 +15,7 @@ use App\Tests\Builders\Company\CompanyInviteBuilder;
 use App\Tests\Builders\Company\UserBuilder;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 final class CompanyInviteManagerTest extends TestCase
 {
@@ -179,6 +180,62 @@ final class CompanyInviteManagerTest extends TestCase
 
         // user — это тот же объект, его можно сравнивать по ссылке
         self::assertSame($user, $invite->getAcceptedByUser());
+    }
+
+    public function testAcceptInviteRejectsDisabledExistingMember(): void
+    {
+        $owner = UserBuilder::aUser()->build();
+        $company = CompanyBuilder::aCompany()->withOwner($owner)->build();
+        $user = UserBuilder::aUser()->withEmail('operator@example.test')->build();
+        $plainToken = 'disabled-member-token';
+        $tokenHash = hash('sha256', $plainToken);
+        $now = new \DateTimeImmutable('2025-03-01 12:00:00+00:00');
+
+        $invite = CompanyInviteBuilder::anInvite()
+            ->withCompany($company)
+            ->withCreatedBy($owner)
+            ->withEmail($user->getEmail())
+            ->withTokenHash($tokenHash)
+            ->withExpiresAt($now->modify('+1 day'))
+            ->build();
+
+        $member = new CompanyMember(
+            id: '33333333-3333-3333-3333-333333333333',
+            company: $company,
+            user: $user,
+            role: CompanyMember::ROLE_OPERATOR,
+            createdAt: $now,
+        );
+        $member->disable();
+
+        $inviteRepository = $this->createMock(CompanyInviteRepository::class);
+        $inviteRepository
+            ->expects(self::once())
+            ->method('findOneByTokenHash')
+            ->with($tokenHash)
+            ->willReturn($invite);
+
+        $memberRepository = $this->createMock(CompanyMemberRepository::class);
+        $memberRepository
+            ->expects(self::once())
+            ->method('findOneByCompanyAndUser')
+            ->with($company, $user)
+            ->willReturn($member);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::never())->method('persist');
+        $em->expects(self::never())->method('flush');
+
+        $manager = new CompanyInviteManager(
+            $em,
+            $inviteRepository,
+            $memberRepository,
+            new InviteTokenService(),
+        );
+
+        $this->expectException(AccessDeniedException::class);
+
+        $manager->acceptInvite($plainToken, $user, $now);
     }
 
     private function makeTokenService(string $token): InviteTokenService

--- a/site/tests/Unit/Company/CompanyOwnerAccountCreatorTest.php
+++ b/site/tests/Unit/Company/CompanyOwnerAccountCreatorTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Company;
 
+use App\Company\Application\Service\CompanyOwnerMembershipCreator;
 use App\Company\Entity\Company;
 use App\Company\Entity\CompanyMember;
 use App\Company\Entity\User;
-use App\Company\Repository\CompanyMemberRepository;
 use App\Company\Service\CompanyOwnerAccountCreator;
 use App\Company\Message\SendRegistrationEmailMessage;
 use Doctrine\ORM\EntityManagerInterface;
@@ -42,13 +42,6 @@ final class CompanyOwnerAccountCreatorTest extends TestCase
             ->expects(self::once())
             ->method('flush');
 
-        $companyMemberRepository = $this->createMock(CompanyMemberRepository::class);
-        $companyMemberRepository
-            ->expects(self::once())
-            ->method('findOneByCompanyAndUser')
-            ->with(self::isInstanceOf(Company::class), $user)
-            ->willReturn(null);
-
         $bus = $this->createMock(MessageBusInterface::class);
         $bus
             ->expects(self::once())
@@ -60,7 +53,12 @@ final class CompanyOwnerAccountCreatorTest extends TestCase
             }))
             ->willReturn(new Envelope(new \stdClass()));
 
-        $creator = new CompanyOwnerAccountCreator($passwordHasher, $entityManager, $bus, $companyMemberRepository);
+        $creator = new CompanyOwnerAccountCreator(
+            $passwordHasher,
+            $entityManager,
+            $bus,
+            new CompanyOwnerMembershipCreator($entityManager),
+        );
 
         $company = $creator->create($user, 'plain-password', '  Acme LLC  ', true);
 
@@ -81,7 +79,7 @@ final class CompanyOwnerAccountCreatorTest extends TestCase
         self::assertSame(CompanyMember::ROLE_OWNER, $persisted[2]->getRole());
     }
 
-    public function testCreateDoesNotPersistDuplicateCompanyMemberWhenRelationAlreadyExists(): void
+    public function testCreateWithoutRegistrationEmailStillCreatesOwnerCompanyMember(): void
     {
         $user = new User('22222222-2222-2222-2222-222222222222');
 
@@ -95,7 +93,7 @@ final class CompanyOwnerAccountCreatorTest extends TestCase
         $persisted = [];
         $entityManager = $this->createMock(EntityManagerInterface::class);
         $entityManager
-            ->expects(self::exactly(2))
+            ->expects(self::exactly(3))
             ->method('persist')
             ->willReturnCallback(static function (object $entity) use (&$persisted): void {
                 $persisted[] = $entity;
@@ -104,31 +102,25 @@ final class CompanyOwnerAccountCreatorTest extends TestCase
             ->expects(self::once())
             ->method('flush');
 
-        $companyMemberRepository = $this->createMock(CompanyMemberRepository::class);
-        $companyMemberRepository
-            ->expects(self::once())
-            ->method('findOneByCompanyAndUser')
-            ->with(self::isInstanceOf(Company::class), $user)
-            ->willReturnCallback(static function (Company $company, User $user): CompanyMember {
-                return new CompanyMember(
-                    '33333333-3333-3333-3333-333333333333',
-                    $company,
-                    $user,
-                    CompanyMember::ROLE_OWNER,
-                );
-            });
-
         $bus = $this->createMock(MessageBusInterface::class);
         $bus
             ->expects(self::never())
             ->method('dispatch');
 
-        $creator = new CompanyOwnerAccountCreator($passwordHasher, $entityManager, $bus, $companyMemberRepository);
+        $creator = new CompanyOwnerAccountCreator(
+            $passwordHasher,
+            $entityManager,
+            $bus,
+            new CompanyOwnerMembershipCreator($entityManager),
+        );
 
         $company = $creator->create($user, 'plain-password', 'Acme LLC', false);
 
         self::assertInstanceOf(Company::class, $company);
-        self::assertSame([$user, $company], $persisted);
+        self::assertSame($user, $persisted[0]);
+        self::assertSame($company, $persisted[1]);
+        self::assertInstanceOf(CompanyMember::class, $persisted[2]);
+        self::assertSame(CompanyMember::ROLE_OWNER, $persisted[2]->getRole());
     }
 
     public function testCreateCanSkipRegistrationEmailDispatch(): void
@@ -150,19 +142,17 @@ final class CompanyOwnerAccountCreatorTest extends TestCase
             ->expects(self::once())
             ->method('flush');
 
-        $companyMemberRepository = $this->createMock(CompanyMemberRepository::class);
-        $companyMemberRepository
-            ->expects(self::once())
-            ->method('findOneByCompanyAndUser')
-            ->with(self::isInstanceOf(Company::class), $user)
-            ->willReturn(null);
-
         $bus = $this->createMock(MessageBusInterface::class);
         $bus
             ->expects(self::never())
             ->method('dispatch');
 
-        $creator = new CompanyOwnerAccountCreator($passwordHasher, $entityManager, $bus, $companyMemberRepository);
+        $creator = new CompanyOwnerAccountCreator(
+            $passwordHasher,
+            $entityManager,
+            $bus,
+            new CompanyOwnerMembershipCreator($entityManager),
+        );
 
         $company = $creator->create($user, 'plain-password', 'Acme LLC', false);
 

--- a/site/tests/Unit/Company/CompanyOwnerMembershipCreatorTest.php
+++ b/site/tests/Unit/Company/CompanyOwnerMembershipCreatorTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Company;
+
+use App\Company\Application\Service\CompanyOwnerMembershipCreator;
+use App\Company\Entity\Company;
+use App\Company\Entity\CompanyMember;
+use App\Tests\Builders\Company\UserBuilder;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+final class CompanyOwnerMembershipCreatorTest extends TestCase
+{
+    public function testCreateCompanyPersistsCompanyAndOwnerMembershipWithoutFlush(): void
+    {
+        $owner = UserBuilder::aUser()->build();
+        $persisted = [];
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager
+            ->expects(self::exactly(2))
+            ->method('persist')
+            ->willReturnCallback(static function (object $entity) use (&$persisted): void {
+                $persisted[] = $entity;
+            });
+        $entityManager
+            ->expects(self::never())
+            ->method('flush');
+
+        $creator = new CompanyOwnerMembershipCreator($entityManager);
+
+        $company = $creator->createCompany($owner, '  Acme LLC  ');
+
+        self::assertSame('Acme LLC', $company->getName());
+        self::assertSame($owner, $company->getUser());
+        self::assertTrue($owner->getCompanies()->contains($company));
+        self::assertCount(2, $persisted);
+        self::assertSame($company, $persisted[0]);
+        self::assertInstanceOf(CompanyMember::class, $persisted[1]);
+        self::assertSame($company, $persisted[1]->getCompany());
+        self::assertSame($owner, $persisted[1]->getUser());
+        self::assertSame(CompanyMember::ROLE_OWNER, $persisted[1]->getRole());
+        self::assertSame(CompanyMember::STATUS_ACTIVE, $persisted[1]->getStatus());
+        self::assertTrue(Uuid::isValid((string) $company->getId()));
+        self::assertTrue(Uuid::isValid((string) $persisted[1]->getId()));
+    }
+
+    public function testPersistCompanyWithOwnerMembershipKeepsExistingCompanyFields(): void
+    {
+        $owner = UserBuilder::aUser()->build();
+        $company = new Company('11111111-1111-1111-1111-111111111111', $owner);
+        $company->setName('Existing LLC');
+        $company->setInn('1234567890');
+
+        $persisted = [];
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager
+            ->expects(self::exactly(2))
+            ->method('persist')
+            ->willReturnCallback(static function (object $entity) use (&$persisted): void {
+                $persisted[] = $entity;
+            });
+        $entityManager
+            ->expects(self::never())
+            ->method('flush');
+
+        $creator = new CompanyOwnerMembershipCreator($entityManager);
+
+        $result = $creator->persistCompanyWithOwnerMembership($company, $owner);
+
+        self::assertSame($company, $result);
+        self::assertSame('Existing LLC', $result->getName());
+        self::assertSame('1234567890', $result->getInn());
+        self::assertSame($company, $persisted[0]);
+        self::assertInstanceOf(CompanyMember::class, $persisted[1]);
+    }
+}

--- a/site/tests/Unit/Company/DisableCompanyMemberActionTest.php
+++ b/site/tests/Unit/Company/DisableCompanyMemberActionTest.php
@@ -44,6 +44,33 @@ final class DisableCompanyMemberActionTest extends TestCase
         self::assertSame(CompanyMember::STATUS_DISABLED, $member->getStatus());
     }
 
+    public function testDisablesOperatorWhenOwnerActorIsDifferentInstanceWithSameId(): void
+    {
+        $ownerId = '22222222-2222-2222-2222-000000000401';
+        $owner = UserBuilder::aUser()->withId($ownerId)->withEmail('owner@example.test')->build();
+        $actor = UserBuilder::aUser()->withId($ownerId)->withEmail('owner-proxy@example.test')->build();
+        $operator = UserBuilder::aUser()->withIndex(2)->withRoles(['ROLE_COMPANY_USER'])->build();
+        $company = CompanyBuilder::aCompany()->withOwner($owner)->build();
+        $member = CompanyMemberBuilder::aMember()
+            ->withCompany($company)
+            ->withUser($operator)
+            ->withRole(CompanyMember::ROLE_OPERATOR)
+            ->build();
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::once())->method('flush');
+
+        $action = new DisableCompanyMemberAction(
+            $this->companyRepositoryReturning($company),
+            $this->memberRepositoryReturning($member),
+            $entityManager,
+        );
+
+        $action((string) $company->getId(), (string) $member->getId(), $actor);
+
+        self::assertSame(CompanyMember::STATUS_DISABLED, $member->getStatus());
+    }
+
     public function testRejectsNonOwnerActor(): void
     {
         $owner = UserBuilder::aUser()->withEmail('owner@example.test')->build();

--- a/site/tests/Unit/Company/DisableCompanyMemberActionTest.php
+++ b/site/tests/Unit/Company/DisableCompanyMemberActionTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Company;
+
+use App\Company\Application\DisableCompanyMemberAction;
+use App\Company\Entity\Company;
+use App\Company\Entity\CompanyMember;
+use App\Company\Infrastructure\Repository\CompanyRepository;
+use App\Company\Repository\CompanyMemberRepository;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\CompanyMemberBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+final class DisableCompanyMemberActionTest extends TestCase
+{
+    public function testDisablesOperatorMember(): void
+    {
+        $owner = UserBuilder::aUser()->withEmail('owner@example.test')->build();
+        $operator = UserBuilder::aUser()->withIndex(2)->withRoles(['ROLE_COMPANY_USER'])->build();
+        $company = CompanyBuilder::aCompany()->withOwner($owner)->build();
+        $member = CompanyMemberBuilder::aMember()
+            ->withCompany($company)
+            ->withUser($operator)
+            ->withRole(CompanyMember::ROLE_OPERATOR)
+            ->build();
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::once())->method('flush');
+
+        $action = new DisableCompanyMemberAction(
+            $this->companyRepositoryReturning($company),
+            $this->memberRepositoryReturning($member),
+            $entityManager,
+        );
+
+        $action((string) $company->getId(), (string) $member->getId(), $owner);
+
+        self::assertSame(CompanyMember::STATUS_DISABLED, $member->getStatus());
+    }
+
+    public function testRejectsNonOwnerActor(): void
+    {
+        $owner = UserBuilder::aUser()->withEmail('owner@example.test')->build();
+        $actor = UserBuilder::aUser()->withIndex(2)->withRoles(['ROLE_COMPANY_USER'])->build();
+        $memberUser = UserBuilder::aUser()->withIndex(3)->withRoles(['ROLE_COMPANY_USER'])->build();
+        $company = CompanyBuilder::aCompany()->withOwner($owner)->build();
+        $member = CompanyMemberBuilder::aMember()->withCompany($company)->withUser($memberUser)->build();
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::never())->method('flush');
+
+        $action = new DisableCompanyMemberAction(
+            $this->companyRepositoryReturning($company),
+            $this->memberRepositoryReturning($member),
+            $entityManager,
+        );
+
+        $this->expectException(AccessDeniedException::class);
+
+        $action((string) $company->getId(), (string) $member->getId(), $actor);
+    }
+
+    public function testRejectsSelfDisable(): void
+    {
+        $owner = UserBuilder::aUser()->withEmail('owner@example.test')->build();
+        $company = CompanyBuilder::aCompany()->withOwner($owner)->build();
+        $member = CompanyMemberBuilder::aMember()
+            ->withCompany($company)
+            ->withUser($owner)
+            ->withRole(CompanyMember::ROLE_OPERATOR)
+            ->build();
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::never())->method('flush');
+
+        $action = new DisableCompanyMemberAction(
+            $this->companyRepositoryReturning($company),
+            $this->memberRepositoryReturning($member),
+            $entityManager,
+        );
+
+        $this->expectException(AccessDeniedException::class);
+
+        $action((string) $company->getId(), (string) $member->getId(), $owner);
+    }
+
+    public function testRejectsOwnerRoleMember(): void
+    {
+        $owner = UserBuilder::aUser()->withEmail('owner@example.test')->build();
+        $secondOwner = UserBuilder::aUser()->withIndex(2)->withRoles(['ROLE_COMPANY_OWNER'])->build();
+        $company = CompanyBuilder::aCompany()->withOwner($owner)->build();
+        $member = CompanyMemberBuilder::aMember()
+            ->withCompany($company)
+            ->withUser($secondOwner)
+            ->withRole(CompanyMember::ROLE_OWNER)
+            ->build();
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::never())->method('flush');
+
+        $action = new DisableCompanyMemberAction(
+            $this->companyRepositoryReturning($company),
+            $this->memberRepositoryReturning($member),
+            $entityManager,
+        );
+
+        $this->expectException(AccessDeniedException::class);
+
+        $action((string) $company->getId(), (string) $member->getId(), $owner);
+    }
+
+    public function testRejectsMissingMember(): void
+    {
+        $owner = UserBuilder::aUser()->withEmail('owner@example.test')->build();
+        $company = CompanyBuilder::aCompany()->withOwner($owner)->build();
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::never())->method('flush');
+
+        $action = new DisableCompanyMemberAction(
+            $this->companyRepositoryReturning($company),
+            $this->memberRepositoryReturning(null),
+            $entityManager,
+        );
+
+        $this->expectException(NotFoundHttpException::class);
+
+        $action((string) $company->getId(), '44444444-4444-4444-4444-444444444444', $owner);
+    }
+
+    private function companyRepositoryReturning(?Company $company): CompanyRepository
+    {
+        $repository = $this->createMock(CompanyRepository::class);
+        $repository
+            ->method('findById')
+            ->willReturn($company);
+
+        return $repository;
+    }
+
+    private function memberRepositoryReturning(?CompanyMember $member): CompanyMemberRepository
+    {
+        $repository = $this->createMock(CompanyMemberRepository::class);
+        $repository
+            ->method('findOneByIdAndCompanyId')
+            ->willReturn($member);
+
+        return $repository;
+    }
+}

--- a/site/tests/Unit/Company/EnableCompanyMemberActionTest.php
+++ b/site/tests/Unit/Company/EnableCompanyMemberActionTest.php
@@ -44,6 +44,33 @@ final class EnableCompanyMemberActionTest extends TestCase
         self::assertSame(CompanyMember::STATUS_ACTIVE, $member->getStatus());
     }
 
+    public function testEnablesDisabledMemberWhenOwnerActorIsDifferentInstanceWithSameId(): void
+    {
+        $ownerId = '22222222-2222-2222-2222-000000000402';
+        $owner = UserBuilder::aUser()->withId($ownerId)->withEmail('owner@example.test')->build();
+        $actor = UserBuilder::aUser()->withId($ownerId)->withEmail('owner-proxy@example.test')->build();
+        $operator = UserBuilder::aUser()->withIndex(2)->withRoles(['ROLE_COMPANY_USER'])->build();
+        $company = CompanyBuilder::aCompany()->withOwner($owner)->build();
+        $member = CompanyMemberBuilder::aMember()
+            ->withCompany($company)
+            ->withUser($operator)
+            ->asDisabled()
+            ->build();
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::once())->method('flush');
+
+        $action = new EnableCompanyMemberAction(
+            $this->companyRepositoryReturning($company),
+            $this->memberRepositoryReturning($member),
+            $entityManager,
+        );
+
+        $action((string) $company->getId(), (string) $member->getId(), $actor);
+
+        self::assertSame(CompanyMember::STATUS_ACTIVE, $member->getStatus());
+    }
+
     public function testRejectsNonOwnerActor(): void
     {
         $owner = UserBuilder::aUser()->withEmail('owner@example.test')->build();

--- a/site/tests/Unit/Company/EnableCompanyMemberActionTest.php
+++ b/site/tests/Unit/Company/EnableCompanyMemberActionTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Company;
+
+use App\Company\Application\EnableCompanyMemberAction;
+use App\Company\Entity\Company;
+use App\Company\Entity\CompanyMember;
+use App\Company\Infrastructure\Repository\CompanyRepository;
+use App\Company\Repository\CompanyMemberRepository;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\CompanyMemberBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+final class EnableCompanyMemberActionTest extends TestCase
+{
+    public function testEnablesDisabledMember(): void
+    {
+        $owner = UserBuilder::aUser()->withEmail('owner@example.test')->build();
+        $operator = UserBuilder::aUser()->withIndex(2)->withRoles(['ROLE_COMPANY_USER'])->build();
+        $company = CompanyBuilder::aCompany()->withOwner($owner)->build();
+        $member = CompanyMemberBuilder::aMember()
+            ->withCompany($company)
+            ->withUser($operator)
+            ->asDisabled()
+            ->build();
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::once())->method('flush');
+
+        $action = new EnableCompanyMemberAction(
+            $this->companyRepositoryReturning($company),
+            $this->memberRepositoryReturning($member),
+            $entityManager,
+        );
+
+        $action((string) $company->getId(), (string) $member->getId(), $owner);
+
+        self::assertSame(CompanyMember::STATUS_ACTIVE, $member->getStatus());
+    }
+
+    public function testRejectsNonOwnerActor(): void
+    {
+        $owner = UserBuilder::aUser()->withEmail('owner@example.test')->build();
+        $actor = UserBuilder::aUser()->withIndex(2)->withRoles(['ROLE_COMPANY_USER'])->build();
+        $operator = UserBuilder::aUser()->withIndex(3)->withRoles(['ROLE_COMPANY_USER'])->build();
+        $company = CompanyBuilder::aCompany()->withOwner($owner)->build();
+        $member = CompanyMemberBuilder::aMember()->withCompany($company)->withUser($operator)->asDisabled()->build();
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::never())->method('flush');
+
+        $action = new EnableCompanyMemberAction(
+            $this->companyRepositoryReturning($company),
+            $this->memberRepositoryReturning($member),
+            $entityManager,
+        );
+
+        $this->expectException(AccessDeniedException::class);
+
+        $action((string) $company->getId(), (string) $member->getId(), $actor);
+    }
+
+    public function testRejectsMissingMember(): void
+    {
+        $owner = UserBuilder::aUser()->withEmail('owner@example.test')->build();
+        $company = CompanyBuilder::aCompany()->withOwner($owner)->build();
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::never())->method('flush');
+
+        $action = new EnableCompanyMemberAction(
+            $this->companyRepositoryReturning($company),
+            $this->memberRepositoryReturning(null),
+            $entityManager,
+        );
+
+        $this->expectException(NotFoundHttpException::class);
+
+        $action((string) $company->getId(), '44444444-4444-4444-4444-444444444444', $owner);
+    }
+
+    private function companyRepositoryReturning(?Company $company): CompanyRepository
+    {
+        $repository = $this->createMock(CompanyRepository::class);
+        $repository
+            ->method('findById')
+            ->willReturn($company);
+
+        return $repository;
+    }
+
+    private function memberRepositoryReturning(?CompanyMember $member): CompanyMemberRepository
+    {
+        $repository = $this->createMock(CompanyMemberRepository::class);
+        $repository
+            ->method('findOneByIdAndCompanyId')
+            ->willReturn($member);
+
+        return $repository;
+    }
+}


### PR DESCRIPTION
## Summary

Implements the P0 account/company hardening plan:

- adds a shared `CompanyOwnerMembershipCreator` so every new company path creates an owner `CompanyMember`
- wires the invariant into public/admin owner-account creation, `/company/new`, and `AccountBootstrapper`
- adds member enable/disable Application actions with self/owner guards
- requires active membership for invited-member company access
- rejects invite accept for an existing disabled member
- fixes `CompanyRepository::getAllActiveCompanyIds()` to read from the real `companies` table until CompanyStatus exists
- saves the plan, stage reports, and handoff under `docs/tasks/account/`

## Why

The Company module had multiple company creation paths with different invariants. Some paths created a `Company` without an owner `CompanyMember`, and disabled members could still pass parts of legacy member access checks. The active-company repository method also referenced a non-existent `company.is_active` shape.

## Validation

- `make site-test-unit` — OK, 1213 tests, 7451 assertions; existing PHPUnit output includes 1 warning and 1 deprecation
- targeted unit PHPUnit filter — OK, 23 tests, 139 assertions
- targeted DB functional/integration PHPUnit filter — OK, 17 tests, 96 assertions
- `git diff --check` on changed paths — OK

## Notes

No migrations, public route additions, `security.yaml` changes, or RBAC/voter rollout are included. P1 user blocking, company suspension, audit fields, and admin blocking UI remain separate owner-reviewed stages.