### PR TITLE
[codex] Add Ozon Performance month-to-date cron load

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2159,6 +2159,7 @@ paths:
 | `app:marketplace:wb-financial-reports:sync --mode=daily` | `03:10 daily` | Ежедневное планирование WB financial sync за рабочий день (новая date-based команда) |
 | `app:marketplace:wb-financial-reports:sync --mode=refresh14` | `04:20 daily` | Планирование пересинхронизации последних 14 дней WB financial reports |
 | `app:marketplace:wb-financial-reports:sync --mode=missing --max-days=10` | `05:30 daily` | Планирование дозагрузки пропущенных дней (до 10 дней на подключение) |
+| `app:ingestion:ozon-performance:daily-load --window=month-to-date` | `07:25 daily` | Планирование Ozon Performance ingestion с начала месяца до вчерашнего дня; HTTP-загрузка выполняется `ingest_fetch` worker'ом |
 
 **Правила для новых cron-команд:**
 - Класс в `src/{Module}/Command/`, `final class`, `#[AsCommand]`

--- a/docker/cron/app.cron
+++ b/docker/cron/app.cron
@@ -91,6 +91,11 @@
 # seed code mappings → refresh metadata for all companies/shops → discover/rebuild taxonomy → health-check.
 15 5 * * * cd /app && php -d memory_limit=1G bin/console app:ingestion:ozon-accrual:daily-maintenance --days-back=45 --execute --no-interaction --quiet >> /proc/1/fd/1 2>> /proc/1/fd/2
 
+# Ежедневная загрузка Ozon Performance ingestion с начала месяца до вчерашнего дня.
+# Команда только планирует SyncJob/chunks; HTTP-загрузка выполняется async worker'ом.
+# Запуск вынесен после ночного marketplace/inventory/accrual окна.
+25 7 * * * cd /app && php bin/console app:ingestion:ozon-performance:daily-load --window=month-to-date --execute --dispatch-spacing-seconds=120 --no-interaction --quiet >> /proc/1/fd/1 2>> /proc/1/fd/2
+
 # Ежедневно в 02:10: снапшоты остатков по счетам
 #10 2 * * * php /app/bin/console app:money-account:snapshot --no-interaction
 

--- a/site/src/Ingestion/Application/Service/OzonPerformanceLoadWindow.php
+++ b/site/src/Ingestion/Application/Service/OzonPerformanceLoadWindow.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Service;
+
+final readonly class OzonPerformanceLoadWindow
+{
+    public function __construct(
+        public \DateTimeImmutable $from,
+        public \DateTimeImmutable $to,
+        public string $label,
+    ) {
+    }
+}

--- a/site/src/Ingestion/Application/Service/OzonPerformanceLoadWindowResolver.php
+++ b/site/src/Ingestion/Application/Service/OzonPerformanceLoadWindowResolver.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Service;
+
+use Symfony\Component\Clock\ClockInterface;
+
+final readonly class OzonPerformanceLoadWindowResolver
+{
+    public const WINDOW_ROLLING = 'rolling';
+    public const WINDOW_MONTH_TO_DATE = 'month-to-date';
+
+    public function __construct(private ClockInterface $clock)
+    {
+    }
+
+    public function resolve(string $window, int $daysBack): OzonPerformanceLoadWindow
+    {
+        return match ($window) {
+            self::WINDOW_ROLLING => $this->rolling($daysBack),
+            self::WINDOW_MONTH_TO_DATE => $this->monthToDate(),
+            default => throw new \InvalidArgumentException('Invalid --window. Allowed values: rolling, month-to-date.'),
+        };
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function allowedWindows(): array
+    {
+        return [self::WINDOW_ROLLING, self::WINDOW_MONTH_TO_DATE];
+    }
+
+    private function rolling(int $daysBack): OzonPerformanceLoadWindow
+    {
+        $today = $this->clock->now()->setTime(0, 0);
+
+        return new OzonPerformanceLoadWindow(
+            from: $today->modify(sprintf('-%d days', $daysBack)),
+            to: $today->modify('-1 day'),
+            label: sprintf('last-%d-days', $daysBack),
+        );
+    }
+
+    private function monthToDate(): OzonPerformanceLoadWindow
+    {
+        $yesterday = $this->clock->now()->setTime(0, 0)->modify('-1 day');
+
+        return new OzonPerformanceLoadWindow(
+            from: $yesterday->modify('first day of this month'),
+            to: $yesterday,
+            label: 'month-to-date',
+        );
+    }
+}

--- a/site/src/Ingestion/Command/OzonPerformanceDailyLoadCommand.php
+++ b/site/src/Ingestion/Command/OzonPerformanceDailyLoadCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Ingestion\Command;
 
 use App\Ingestion\Application\Command\StartBackfillCommand as StartBackfillApplicationCommand;
+use App\Ingestion\Application\Service\OzonPerformanceLoadWindowResolver;
 use App\Ingestion\Application\Source\Ozon\OzonResourceType;
 use App\Ingestion\Enum\IngestSource;
 use App\Ingestion\Exception\ActiveBackfillExistsException;
@@ -18,7 +19,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\Clock\ClockInterface;
 use Webmozart\Assert\Assert;
 
 #[AsCommand(
@@ -59,7 +59,7 @@ final class OzonPerformanceDailyLoadCommand extends Command
     public function __construct(
         private readonly MarketplaceFacade $marketplaceFacade,
         private readonly SyncFacade $syncFacade,
-        private readonly ClockInterface $clock,
+        private readonly OzonPerformanceLoadWindowResolver $windowResolver,
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct();
@@ -69,6 +69,7 @@ final class OzonPerformanceDailyLoadCommand extends Command
     {
         $this
             ->addOption('days-back', null, InputOption::VALUE_REQUIRED, 'Rewind depth in days, 1..62.', 14)
+            ->addOption('window', null, InputOption::VALUE_REQUIRED, 'Date window: rolling or month-to-date.', OzonPerformanceLoadWindowResolver::WINDOW_ROLLING)
             ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Optional company UUID filter.')
             ->addOption('dispatch-spacing-seconds', null, InputOption::VALUE_REQUIRED, 'Delay between campaign-backed job dispatches, 0..3600.', self::DEFAULT_DISPATCH_SPACING_SECONDS)
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Print planned jobs without dispatching them.')
@@ -102,6 +103,7 @@ final class OzonPerformanceDailyLoadCommand extends Command
             }
 
             $daysBack = $this->daysBack($input);
+            $window = $this->window($input);
             $companyId = $this->companyId($input);
             $dispatchSpacingSeconds = $this->dispatchSpacingSeconds($input);
         } catch (\Throwable $exception) {
@@ -110,17 +112,18 @@ final class OzonPerformanceDailyLoadCommand extends Command
             return Command::FAILURE;
         }
 
-        $today = $this->clock->now()->setTime(0, 0);
-        $from = $today->modify(sprintf('-%d days', $daysBack));
-        $to = $today->modify('-1 day');
+        $loadWindow = $this->windowResolver->resolve($window, $daysBack);
+        $from = $loadWindow->from;
+        $to = $loadWindow->to;
         $connections = $this->marketplaceFacade->getActiveOzonPerformanceConnections($companyId);
 
         $io->title('Ozon Performance daily load');
         $io->table(['setting', 'value'], [
             ['mode', $dryRun ? 'dry-run' : 'execute'],
+            ['window', $loadWindow->label],
             ['from', $from->format('Y-m-d')],
             ['to', $to->format('Y-m-d')],
-            ['daysBack', (string) $daysBack],
+            ['daysBack', OzonPerformanceLoadWindowResolver::WINDOW_ROLLING === $window ? (string) $daysBack : 'n/a'],
             ['companyId', $companyId ?? 'all'],
             ['connections', (string) count($connections)],
             ['dispatchSpacingSeconds', (string) $dispatchSpacingSeconds],
@@ -219,6 +222,16 @@ final class OzonPerformanceDailyLoadCommand extends Command
         }
 
         return $daysBack;
+    }
+
+    private function window(InputInterface $input): string
+    {
+        $window = trim((string) $input->getOption('window'));
+        if (!in_array($window, OzonPerformanceLoadWindowResolver::allowedWindows(), true)) {
+            throw new \InvalidArgumentException('Invalid --window. Allowed values: rolling, month-to-date.');
+        }
+
+        return $window;
     }
 
     private function dispatchSpacingSeconds(InputInterface $input): int

--- a/site/tests/Integration/Ingestion/Command/OzonPerformanceLoadCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/OzonPerformanceLoadCommandTest.php
@@ -114,6 +114,33 @@ final class OzonPerformanceLoadCommandTest extends IntegrationTestCase
         $this->assertTwoChunkSchedulePerConnection($connectionIds, $transport);
     }
 
+    public function testDailyLoadMonthToDateExecuteDispatchesCurrentMonthWindow(): void
+    {
+        $company = $this->seedCompany('11111111-1111-1111-1111-00000000a115', 9115);
+        $this->seedPerformanceConnection($company, '77777777-7777-7777-7777-00000000a115');
+        $this->em->flush();
+
+        $transport = $this->getIngestFetchTransport();
+        $transport->reset();
+
+        $tester = $this->tester('app:ingestion:ozon-performance:daily-load');
+        $exit = $tester->execute([
+            '--company-id' => $company->getId(),
+            '--window' => 'month-to-date',
+            '--execute' => true,
+        ]);
+
+        $yesterday = (new \DateTimeImmutable('today'))->modify('-1 day');
+        $expectedFrom = $yesterday->modify('first day of this month')->format('Y-m-d');
+        $expectedTo = $yesterday->format('Y-m-d');
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertStringContainsString('month-to-date', $tester->getDisplay());
+        self::assertStringContainsString('n/a', $tester->getDisplay());
+        self::assertSame([[$expectedFrom, $expectedTo]], $this->distinctParentWindows($company->getId()));
+        self::assertCount(count(self::RESOURCE_TYPES) * $this->expectedChunkCount($expectedFrom, $expectedTo), $transport->getSent());
+    }
+
     public function testBackfillExecuteDispatchesAllPerformanceResourcesForExplicitPeriod(): void
     {
         $company = $this->seedCompany('11111111-1111-1111-1111-00000000a103', 9103);
@@ -200,6 +227,34 @@ final class OzonPerformanceLoadCommandTest extends IntegrationTestCase
         );
 
         return array_map(static fn (mixed $value): string => (string) $value, $rows);
+    }
+
+    /**
+     * @return list<array{0: string, 1: string}>
+     */
+    private function distinctParentWindows(string $companyId): array
+    {
+        $rows = $this->connection->fetchAllAssociative(
+            "SELECT DISTINCT to_char(window_from, 'YYYY-MM-DD') AS window_from, to_char(window_to, 'YYYY-MM-DD') AS window_to
+             FROM ingest_sync_jobs
+             WHERE company_id = :companyId AND parent_job_id IS NULL
+             ORDER BY window_from, window_to",
+            ['companyId' => $companyId],
+        );
+
+        return array_map(
+            static fn (array $row): array => [(string) $row['window_from'], (string) $row['window_to']],
+            $rows,
+        );
+    }
+
+    private function expectedChunkCount(string $from, string $to): int
+    {
+        $fromDate = new \DateTimeImmutable($from);
+        $toDate = new \DateTimeImmutable($to);
+        $days = ((int) $fromDate->diff($toDate)->days) + 1;
+
+        return max(1, (int) ceil($days / 7));
     }
 
     private function syncJobCount(string $companyId): int

--- a/site/tests/Unit/Ingestion/Application/Service/OzonPerformanceLoadWindowResolverTest.php
+++ b/site/tests/Unit/Ingestion/Application/Service/OzonPerformanceLoadWindowResolverTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Application\Service;
+
+use App\Ingestion\Application\Service\OzonPerformanceLoadWindowResolver;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\MockClock;
+
+final class OzonPerformanceLoadWindowResolverTest extends TestCase
+{
+    public function testRollingWindowUsesConfiguredDaysBackUntilYesterday(): void
+    {
+        $resolver = new OzonPerformanceLoadWindowResolver(new MockClock('2026-06-28 10:00:00 UTC'));
+
+        $window = $resolver->resolve(OzonPerformanceLoadWindowResolver::WINDOW_ROLLING, 14);
+
+        self::assertSame('2026-06-14', $window->from->format('Y-m-d'));
+        self::assertSame('2026-06-27', $window->to->format('Y-m-d'));
+        self::assertSame('last-14-days', $window->label);
+    }
+
+    public function testMonthToDateStartsFromYesterdayMonthStart(): void
+    {
+        $resolver = new OzonPerformanceLoadWindowResolver(new MockClock('2026-06-28 10:00:00 UTC'));
+
+        $window = $resolver->resolve(OzonPerformanceLoadWindowResolver::WINDOW_MONTH_TO_DATE, 14);
+
+        self::assertSame('2026-06-01', $window->from->format('Y-m-d'));
+        self::assertSame('2026-06-27', $window->to->format('Y-m-d'));
+        self::assertSame('month-to-date', $window->label);
+    }
+
+    public function testMonthToDateOnFirstDayUsesPreviousMonth(): void
+    {
+        $resolver = new OzonPerformanceLoadWindowResolver(new MockClock('2026-07-01 10:00:00 UTC'));
+
+        $window = $resolver->resolve(OzonPerformanceLoadWindowResolver::WINDOW_MONTH_TO_DATE, 14);
+
+        self::assertSame('2026-06-01', $window->from->format('Y-m-d'));
+        self::assertSame('2026-06-30', $window->to->format('Y-m-d'));
+    }
+
+    public function testRejectsUnknownWindow(): void
+    {
+        $resolver = new OzonPerformanceLoadWindowResolver(new MockClock('2026-06-28 10:00:00 UTC'));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid --window');
+
+        $resolver->resolve('unknown', 14);
+    }
+}


### PR DESCRIPTION
## What changed

- Added `--window=rolling|month-to-date` to `app:ingestion:ozon-performance:daily-load`.
- Kept the default rolling 14-day behavior unchanged.
- Added month-to-date window resolution from the first day of the month that contains yesterday through yesterday.
- Added daily cron at 07:25 MSK for month-to-date Ozon Performance ingestion planning.
- Documented the new cron entry in `ARCHITECTURE.md`.

## Why

Ozon Performance ingestion needs a safe daily month-to-date load without adding a separate orchestrator. The existing command already only plans `SyncJob` chunks, uses `LockableTrait`, and lets active jobs be skipped per connection/resource.

## Validation

- PHP syntax lint for changed PHP files: passed.
- Unit: `OzonPerformanceLoadWindowResolverTest`: passed, 4 tests / 10 assertions.
- Integration: `OzonPerformanceLoadCommandTest`: passed with test DB hosts workaround, 5 tests / 119 assertions.
- `make site-test-unit`: passed, 1219 tests / 7465 assertions, existing 1 warning and 1 deprecation.
- `git diff --check`: passed.
- `make sched-test`: could not run because local compose has no running `scheduler` service.
- Fallback cron validation: `docker compose -f docker-compose.prod.yml run --rm --entrypoint /usr/local/bin/supercronic scheduler -test /etc/crontabs/app.cron`: passed; crontab is valid.

## Notes

- Existing unrelated deleted `docs/tasks/ingestion/*` and untracked docs/UI files are not included in this PR.
