### PR TITLE
[codex] Suppress stale ingestion coverage failures

### DIFF
--- a/site/src/Ingestion/Infrastructure/Query/CoverageQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/CoverageQuery.php
@@ -197,6 +197,7 @@ final class CoverageQuery
             WITH failed_jobs AS (
                 SELECT
                     j.id,
+                    j.source,
                     j.shop_ref,
                     j.resource_type,
                     COALESCE(
@@ -221,25 +222,69 @@ final class CoverageQuery
                   AND j.status = :failedStatus
                   AND (j.kind = :incrementalKind OR j.parent_job_id IS NOT NULL)
                   {$shopFilter}
+            ),
+            failed_issue_days AS (
+                SELECT
+                    fj.id,
+                    fj.source,
+                    fj.shop_ref,
+                    fj.resource_type,
+                    GREATEST(fj.from_date, :fromDate)::date AS record_date
+                FROM failed_jobs fj
+                WHERE fj.from_date <= :toDate
+                  AND fj.to_date >= :fromDate
             )
             SELECT
-                TO_CHAR(GREATEST(fj.from_date, :fromDate)::date, 'YYYY-MM-DD') AS record_date,
-                fj.shop_ref,
-                fj.resource_type,
+                TO_CHAR(fid.record_date, 'YYYY-MM-DD') AS record_date,
+                fid.shop_ref,
+                fid.resource_type,
                 0 AS raw_count,
                 0 AS tx_count,
-                COUNT(DISTINCT fj.id) AS issue_count,
+                COUNT(DISTINCT fid.id) AS issue_count,
                 NULL AS last_fetched_at
-            FROM failed_jobs fj
-            WHERE fj.from_date <= :toDate
-              AND fj.to_date >= :fromDate
-            GROUP BY record_date, fj.shop_ref, fj.resource_type
-            ORDER BY record_date ASC, fj.shop_ref ASC, fj.resource_type ASC
+            FROM failed_issue_days fid
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM ingest_raw_records r
+                LEFT JOIN ingest_sync_jobs successful_job
+                    ON successful_job.company_id = r.company_id
+                   AND successful_job.id::text = r.sync_job_id
+                LEFT JOIN ingest_financial_transactions ft
+                    ON ft.company_id = r.company_id
+                   AND ft.raw_record_id = r.id
+                WHERE r.company_id = :companyId
+                  AND r.source = fid.source
+                  AND r.resource_type = fid.resource_type
+                  AND COALESCE(NULLIF(ft.shop_ref, ''), r.shop_ref) = fid.shop_ref
+                  AND successful_job.status = :completedStatus
+                  AND (
+                      (
+                          ft.id IS NOT NULL
+                          AND ft.occurred_at >= fid.record_date::timestamp
+                          AND ft.occurred_at < fid.record_date::timestamp + interval '1 day'
+                      )
+                      OR (
+                          ft.id IS NULL
+                          AND successful_job.window_from IS NOT NULL
+                          AND successful_job.window_from <= fid.record_date
+                          AND COALESCE(successful_job.window_to, successful_job.window_from) >= fid.record_date
+                      )
+                      OR (
+                          ft.id IS NULL
+                          AND successful_job.window_from IS NULL
+                          AND r.fetched_at >= fid.record_date::timestamp
+                          AND r.fetched_at < fid.record_date::timestamp + interval '1 day'
+                      )
+                  )
+            )
+            GROUP BY record_date, fid.shop_ref, fid.resource_type
+            ORDER BY record_date ASC, fid.shop_ref ASC, fid.resource_type ASC
             SQL;
 
         $params = [
             'companyId' => $companyId,
             'failedStatus' => SyncJobStatus::FAILED->value,
+            'completedStatus' => SyncJobStatus::COMPLETED->value,
             'incrementalKind' => SyncJobKind::INCREMENTAL->value,
             'fromDate' => $from,
             'toDate' => $to,

--- a/site/tests/Integration/Ingestion/Infrastructure/Query/VerificationQueriesTest.php
+++ b/site/tests/Integration/Ingestion/Infrastructure/Query/VerificationQueriesTest.php
@@ -319,6 +319,94 @@ final class VerificationQueriesTest extends IntegrationTestCase
         self::assertSame(1, $cells[0]->issueCount);
     }
 
+    public function testCoverageSuppressesFailedBackfillIssueWhenSuccessfulRawCoverageExists(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = Uuid::uuid7()->toString();
+        $failedParent = new SyncJob(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            source: IngestSource::OZON,
+            resourceType: OzonResourceType::PERFORMANCE_SEARCH_PROMO_PRODUCTS,
+            kind: SyncJobKind::BACKFILL,
+            windowFrom: new \DateTimeImmutable('2026-06-20'),
+            windowTo: new \DateTimeImmutable('2026-06-26'),
+            shopRef: $connectionRef,
+        );
+        $failedChild = new SyncJob(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            source: IngestSource::OZON,
+            resourceType: OzonResourceType::PERFORMANCE_SEARCH_PROMO_PRODUCTS,
+            kind: SyncJobKind::BACKFILL,
+            windowFrom: new \DateTimeImmutable('2026-06-20'),
+            windowTo: new \DateTimeImmutable('2026-06-26'),
+            shopRef: $connectionRef,
+            parentJobId: $failedParent->getId(),
+        );
+        $failedChild->markRunning();
+        $failedChild->markFailed('RuntimeException: stale fixed connector error.');
+
+        $successfulParent = new SyncJob(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            source: IngestSource::OZON,
+            resourceType: OzonResourceType::PERFORMANCE_SEARCH_PROMO_PRODUCTS,
+            kind: SyncJobKind::BACKFILL,
+            windowFrom: new \DateTimeImmutable('2026-06-01'),
+            windowTo: new \DateTimeImmutable('2026-06-27'),
+            shopRef: $connectionRef,
+        );
+        $successfulChild = new SyncJob(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            source: IngestSource::OZON,
+            resourceType: OzonResourceType::PERFORMANCE_SEARCH_PROMO_PRODUCTS,
+            kind: SyncJobKind::BACKFILL,
+            windowFrom: new \DateTimeImmutable('2026-06-20'),
+            windowTo: new \DateTimeImmutable('2026-06-26'),
+            shopRef: $connectionRef,
+            parentJobId: $successfulParent->getId(),
+        );
+        $successfulChild->markRunning();
+        $successfulChild->markCompleted();
+        $raw = $this->rawRecord(
+            companyId: $companyId,
+            shopRef: $connectionRef,
+            resourceType: OzonResourceType::PERFORMANCE_SEARCH_PROMO_PRODUCTS,
+            fetchedAt: new \DateTimeImmutable('2026-06-28 17:42:00+00:00'),
+            externalId: 'search-promo-products:2026-06-20:2026-06-26',
+            source: IngestSource::OZON,
+            connectionRef: $connectionRef,
+            syncJobId: $successfulChild->getId(),
+        );
+        $raw->markNormalizationSkipped();
+
+        $this->em->persist($failedParent);
+        $this->em->persist($failedChild);
+        $this->em->persist($successfulParent);
+        $this->em->persist($successfulChild);
+        $this->em->persist($raw);
+        $this->em->flush();
+
+        /** @var CoverageQuery $query */
+        $query = self::getContainer()->get(CoverageQuery::class);
+        $cells = $query->heatmap(
+            $companyId,
+            $connectionRef,
+            new \DateTimeImmutable('2026-06-20'),
+            new \DateTimeImmutable('2026-06-20'),
+        );
+
+        self::assertCount(1, $cells);
+        self::assertSame('2026-06-20', $cells[0]->date);
+        self::assertSame($connectionRef, $cells[0]->shopRef);
+        self::assertSame(OzonResourceType::PERFORMANCE_SEARCH_PROMO_PRODUCTS, $cells[0]->resourceType);
+        self::assertSame(1, $cells[0]->rawCount);
+        self::assertSame(0, $cells[0]->txCount);
+        self::assertSame(0, $cells[0]->issueCount);
+    }
+
     public function testCoverageIgnoresFailedAggregateBackfillParentIssue(): void
     {
         $companyId = Uuid::uuid7()->toString();


### PR DESCRIPTION
## What changed

- Suppress failed ingestion coverage issue rows when the same company/shop/resource/day already has successful raw coverage from a completed job.
- Keep real failed jobs visible when no successful raw coverage exists.
- Added an integration test for the Ozon Performance case where an old failed Search Promo products backfill is later covered by a successful raw load.

## Why

Users saw yellow coverage cells such as `Ozon Performance / Search Promo CPO · Search Promo products` with `1` for days that had already been successfully reloaded. The number came from an old failed job, while adjacent green cells showed raw counts. That made the coverage page look like data was still broken even after a successful month-to-date reload.

## Validation

- PHP syntax lint for changed files: passed.
- Targeted integration: new stale-failure suppression test passed, 1 test / 7 assertions.
- Coverage integration filter: passed, 8 tests / 62 assertions.
- Full `VerificationQueriesTest`: passed, 13 tests / 89 assertions.
- `git diff --check` for changed files: passed.

## Notes

- Existing unrelated deleted `docs/tasks/ingestion/*` and untracked docs/UI files are not included in this PR.
