### PR TITLE
[codex] Fix Ozon numeric SKU relink preview

### DIFF
--- a/site/src/Marketplace/Facade/MarketplaceListingLinkingFacade.php
+++ b/site/src/Marketplace/Facade/MarketplaceListingLinkingFacade.php
@@ -115,16 +115,18 @@ final readonly class MarketplaceListingLinkingFacade
         $result = [];
         $missingSkusWithNames = [];
         $supplierSkusBySku = [];
+        $marketplaceSkus = $this->marketplaceSkusFromSeeds($uniqueSeeds);
         $existingListingsBySku = $this->groupListingsByKey(
             $this->listingRepository->findAllByCompanyMarketplaceAndMarketplaceSkus(
                 $companyId,
                 MarketplaceType::OZON,
-                array_keys($uniqueSeeds),
+                $marketplaceSkus,
             ),
             static fn (MarketplaceListing $listing): string => $listing->getMarketplaceSku(),
         );
 
-        foreach ($uniqueSeeds as $sku => $seed) {
+        foreach ($uniqueSeeds as $seed) {
+            $sku = $seed->marketplaceSku;
             $matches = $existingListingsBySku[$sku] ?? [];
             if (1 === count($matches)) {
                 $listing = $matches[0];
@@ -166,17 +168,19 @@ final readonly class MarketplaceListingLinkingFacade
             return [];
         }
 
+        $marketplaceSkus = $this->marketplaceSkusFromSeeds($uniqueSeeds);
         $existingListingsBySku = $this->groupListingsByKey(
             $this->listingRepository->findAllByCompanyMarketplaceAndMarketplaceSkus(
                 $companyId,
                 MarketplaceType::OZON,
-                array_keys($uniqueSeeds),
+                $marketplaceSkus,
             ),
             static fn (MarketplaceListing $listing): string => $listing->getMarketplaceSku(),
         );
 
         $result = [];
-        foreach ($uniqueSeeds as $sku => $seed) {
+        foreach ($uniqueSeeds as $seed) {
+            $sku = $seed->marketplaceSku;
             $matches = $existingListingsBySku[$sku] ?? [];
             if (1 === count($matches)) {
                 $result[$sku] = new MarketplaceListingEnsurePreviewDTO(
@@ -228,7 +232,7 @@ final readonly class MarketplaceListingLinkingFacade
     /**
      * @param iterable<MarketplaceListingSeedDTO> $seeds
      *
-     * @return array<string, MarketplaceListingSeedDTO>
+     * @return list<MarketplaceListingSeedDTO>
      */
     private function uniqueSeeds(iterable $seeds): array
     {
@@ -249,7 +253,22 @@ final readonly class MarketplaceListingLinkingFacade
             }
         }
 
-        return $uniqueSeeds;
+        return array_values($uniqueSeeds);
+    }
+
+    /**
+     * @param list<MarketplaceListingSeedDTO> $seeds
+     *
+     * @return list<string>
+     */
+    private function marketplaceSkusFromSeeds(array $seeds): array
+    {
+        $skus = [];
+        foreach ($seeds as $seed) {
+            $skus[] = $seed->marketplaceSku;
+        }
+
+        return $skus;
     }
 
     /**

--- a/site/tests/Integration/Ingestion/Application/Source/Ozon/OzonListingResolverTest.php
+++ b/site/tests/Integration/Ingestion/Application/Source/Ozon/OzonListingResolverTest.php
@@ -129,6 +129,18 @@ final class OzonListingResolverTest extends IntegrationTestCase
         self::assertSame('preview-marketplace-sku', $missingPreview->resolution->listingSku);
         self::assertNull($listingRepository->findByMarketplaceSku((string) $company->getId(), MarketplaceType::OZON, 'preview-marketplace-sku'));
         self::assertFalse($ambiguousPreview->wouldCreate);
+
+        $numericSkuPreview = $resolver->previewMany((string) $company->getId(), [
+            'numeric-sku-row' => [
+                'sku' => '1234567890',
+                'name' => 'Numeric SKU Listing',
+            ],
+        ])['numeric-sku-row'];
+
+        self::assertTrue($numericSkuPreview->wouldCreate);
+        self::assertNotNull($numericSkuPreview->resolution);
+        self::assertSame('1234567890', $numericSkuPreview->resolution->listingSku);
+        self::assertNull($listingRepository->findByMarketplaceSku((string) $company->getId(), MarketplaceType::OZON, '1234567890'));
     }
 
     private function createCompany(): Company

--- a/site/tests/Integration/Ingestion/Command/OzonAccrualRelinkListingsCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/OzonAccrualRelinkListingsCommandTest.php
@@ -53,8 +53,8 @@ final class OzonAccrualRelinkListingsCommandTest extends IntegrationTestCase
 
         self::assertSame(Command::SUCCESS, $dryRunExit, $dryRun->getDisplay());
         self::assertStringContainsString('would-create-listing+update', $dryRun->getDisplay());
-        self::assertStringContainsString('old-ozon-sku', $dryRun->getDisplay());
-        self::assertNull($this->listingId($companyId, 'old-ozon-sku'));
+        self::assertStringContainsString('1234567890', $dryRun->getDisplay());
+        self::assertNull($this->listingId($companyId, '1234567890'));
         self::assertSame([null, null], $this->transactionListing($transaction->getId()));
 
         $execute = $this->tester();
@@ -67,9 +67,9 @@ final class OzonAccrualRelinkListingsCommandTest extends IntegrationTestCase
 
         self::assertSame(Command::SUCCESS, $executeExit, $execute->getDisplay());
         self::assertStringContainsString('updated', $execute->getDisplay());
-        $createdListingId = $this->listingId($companyId, 'old-ozon-sku');
+        $createdListingId = $this->listingId($companyId, '1234567890');
         self::assertNotNull($createdListingId);
-        self::assertSame([$createdListingId, 'old-ozon-sku'], $this->transactionListing($transaction->getId()));
+        self::assertSame([$createdListingId, '1234567890'], $this->transactionListing($transaction->getId()));
     }
 
     private function tester(): CommandTester
@@ -156,7 +156,7 @@ final class OzonAccrualRelinkListingsCommandTest extends IntegrationTestCase
             'accrued_category' => 'POSTING',
             'posting' => [
                 'products' => [[
-                    'sku' => 'old-ozon-sku',
+                    'sku' => '1234567890',
                     'offer_id' => 'old-offer',
                     'name' => 'Old Ozon Product',
                     'commission' => [


### PR DESCRIPTION
## What changed

- Fixed Ozon listing preview/ensure seed handling when `marketplaceSku` is a numeric string.
- Stopped relying on PHP array keys as SKU values, because numeric-string keys are cast to integers by PHP arrays.
- Added integration coverage for numeric Ozon SKU preview and the accrual relink command dry-run/execute path.

## Why

Production dry-run failed with:

`MarketplaceListingEnsurePreviewDTO::__construct(): Argument #1 ($marketplaceSku) must be of type string, int given`

The root cause was using the deduped array key as the SKU in `previewOzonListings()`. Ozon SKUs are often numeric strings, and PHP converts numeric-string array keys to integers.

## Validation

- PHP lint on changed files — passed.
- `OzonListingResolverTest|OzonAccrualRelinkListingsCommandTest` integration tests — passed.
- `make site-test-unit` — passed, with existing 1 warning / 1 deprecation.
- Targeted PHP-CS-Fixer dry-run — passed.
- `git diff --check` — passed.
