### PR TITLE
[codex] Add Ozon accrual financial projection reconciliation

### DIFF
--- a/docker/cron/app.cron
+++ b/docker/cron/app.cron
@@ -91,6 +91,12 @@
 # seed code mappings → refresh metadata for all companies/shops → discover/rebuild taxonomy → health-check.
 15 5 * * * cd /app && php -d memory_limit=1G bin/console app:ingestion:ozon-accrual:daily-maintenance --days-back=45 --execute --no-interaction --quiet >> /proc/1/fd/1 2>> /proc/1/fd/2
 
+# Ежедневная сверка Ozon accrual raw snapshot → FinancialTransaction projection.
+# Первый проход отправляет stale raw records на нормализацию; второй проход
+# после ingest_normalize workers дочищает товарное enrichment-связывание.
+45 5 * * * cd /app && php -d memory_limit=1G bin/console app:ingestion:ozon-accrual:reconcile-financial-projection --days-back=30 --execute --dispatch-normalization --summary-only --no-interaction --quiet >> /proc/1/fd/1 2>> /proc/1/fd/2
+30 6 * * * cd /app && php -d memory_limit=1G bin/console app:ingestion:ozon-accrual:reconcile-financial-projection --days-back=30 --execute --dispatch-normalization --summary-only --no-interaction --quiet >> /proc/1/fd/1 2>> /proc/1/fd/2
+
 # Ежедневная загрузка Ozon Performance ingestion с начала месяца до вчерашнего дня.
 # Команда только планирует SyncJob/chunks; HTTP-загрузка выполняется async worker'ом.
 # Запуск вынесен после ночного marketplace/inventory/accrual окна.

--- a/docker/cron/app.cron
+++ b/docker/cron/app.cron
@@ -93,9 +93,9 @@
 
 # Ежедневная сверка Ozon accrual raw snapshot → FinancialTransaction projection.
 # Первый проход отправляет stale raw records на нормализацию; второй проход
-# после ingest_normalize workers дочищает товарное enrichment-связывание.
+# после ingest_normalize workers дочищает товарное enrichment-связывание без повторного dispatch.
 45 5 * * * cd /app && php -d memory_limit=1G bin/console app:ingestion:ozon-accrual:reconcile-financial-projection --days-back=30 --execute --dispatch-normalization --summary-only --no-interaction --quiet >> /proc/1/fd/1 2>> /proc/1/fd/2
-30 6 * * * cd /app && php -d memory_limit=1G bin/console app:ingestion:ozon-accrual:reconcile-financial-projection --days-back=30 --execute --dispatch-normalization --summary-only --no-interaction --quiet >> /proc/1/fd/1 2>> /proc/1/fd/2
+30 6 * * * cd /app && php -d memory_limit=1G bin/console app:ingestion:ozon-accrual:reconcile-financial-projection --days-back=30 --execute --repair-enrichment-only --summary-only --no-interaction --quiet >> /proc/1/fd/1 2>> /proc/1/fd/2
 
 # Ежедневная загрузка Ozon Performance ingestion с начала месяца до вчерашнего дня.
 # Команда только планирует SyncJob/chunks; HTTP-загрузка выполняется async worker'ом.

--- a/site/src/Ingestion/Application/Action/UpsertFinancialTransactionAction.php
+++ b/site/src/Ingestion/Application/Action/UpsertFinancialTransactionAction.php
@@ -71,9 +71,7 @@ final readonly class UpsertFinancialTransactionAction
         // changing amount/period/source data.
         if ($this->sourceDataHasher->hash($mapped->sourceData) === $this->sourceDataHasher->hash($transaction->getSourceData())) {
             $changed = $this->updateListingEnrichment($transaction, $command->listingId, $command->listingSku);
-            if ($mapped->externalUpdatedAt >= $transaction->getExternalUpdatedAt()) {
-                $changed = $transaction->reattributeRawRecord($command->rawRecordId) || $changed;
-            }
+            $changed = $transaction->reattributeRawRecord($command->rawRecordId, $mapped->externalUpdatedAt) || $changed;
 
             if ($changed) {
                 return new UpsertResult(

--- a/site/src/Ingestion/Application/Action/UpsertFinancialTransactionAction.php
+++ b/site/src/Ingestion/Application/Action/UpsertFinancialTransactionAction.php
@@ -120,7 +120,7 @@ final readonly class UpsertFinancialTransactionAction
             return false;
         }
 
-        if ($transaction->getListingId() === $listingId && $transaction->getListingSku() === $listingSku) {
+        if (null !== $transaction->getListingId()) {
             return false;
         }
 

--- a/site/src/Ingestion/Application/Action/UpsertFinancialTransactionAction.php
+++ b/site/src/Ingestion/Application/Action/UpsertFinancialTransactionAction.php
@@ -70,7 +70,12 @@ final readonly class UpsertFinancialTransactionAction
         // allowed to converge after listing metadata appears later, without
         // changing amount/period/source data.
         if ($this->sourceDataHasher->hash($mapped->sourceData) === $this->sourceDataHasher->hash($transaction->getSourceData())) {
-            if ($this->updateListingEnrichment($transaction, $command->listingId, $command->listingSku)) {
+            $changed = $this->updateListingEnrichment($transaction, $command->listingId, $command->listingSku);
+            if ($mapped->externalUpdatedAt >= $transaction->getExternalUpdatedAt()) {
+                $changed = $transaction->reattributeRawRecord($command->rawRecordId) || $changed;
+            }
+
+            if ($changed) {
                 return new UpsertResult(
                     transactionId: $transaction->getId(),
                     oldOccurredAt: $transaction->getOccurredAt(),
@@ -96,6 +101,7 @@ final readonly class UpsertFinancialTransactionAction
                 counterpartyId: $command->counterpartyId,
                 description: $mapped->description,
                 sourceData: $mapped->sourceData,
+                rawRecordId: $command->rawRecordId,
                 listingId: $command->listingId,
                 listingSku: $command->listingSku,
             );

--- a/site/src/Ingestion/Application/Action/UpsertFinancialTransactionAction.php
+++ b/site/src/Ingestion/Application/Action/UpsertFinancialTransactionAction.php
@@ -66,11 +66,19 @@ final readonly class UpsertFinancialTransactionAction
             );
         }
 
-        // No-change short-circuit: if the canonical source content is identical
-        // to what is already stored, skip the update entirely so updated_at /
-        // externalUpdatedAt do not move and no NormalizationCompletedEvent is
-        // raised for an unchanged period. Solves P0.2 without a schema change.
+        // No-change short-circuit for financial content. Enrichment fields are
+        // allowed to converge after listing metadata appears later, without
+        // changing amount/period/source data.
         if ($this->sourceDataHasher->hash($mapped->sourceData) === $this->sourceDataHasher->hash($transaction->getSourceData())) {
+            if ($this->updateListingEnrichment($transaction, $command->listingId, $command->listingSku)) {
+                return new UpsertResult(
+                    transactionId: $transaction->getId(),
+                    oldOccurredAt: $transaction->getOccurredAt(),
+                    newOccurredAt: $transaction->getOccurredAt(),
+                    periodChanged: false,
+                );
+            }
+
             return null;
         }
 
@@ -101,5 +109,23 @@ final readonly class UpsertFinancialTransactionAction
             newOccurredAt: $mapped->occurredAt,
             periodChanged: $oldOccurredAt != $mapped->occurredAt,
         );
+    }
+
+    private function updateListingEnrichment(
+        FinancialTransaction $transaction,
+        ?string $listingId,
+        ?string $listingSku,
+    ): bool {
+        if (null === $listingId || null === $listingSku) {
+            return false;
+        }
+
+        if ($transaction->getListingId() === $listingId && $transaction->getListingSku() === $listingSku) {
+            return false;
+        }
+
+        $transaction->setListing($listingId, $listingSku);
+
+        return true;
     }
 }

--- a/site/src/Ingestion/Application/Service/OzonAccrualListingRelinker.php
+++ b/site/src/Ingestion/Application/Service/OzonAccrualListingRelinker.php
@@ -46,6 +46,7 @@ final readonly class OzonAccrualListingRelinker
         ?\DateTimeImmutable $to,
         int $limit,
         bool $execute,
+        ?string $shopRef = null,
         string $componentFilter = self::COMPONENT_FILTER_ALL,
         bool $includeRows = true,
     ): array {
@@ -53,7 +54,7 @@ final readonly class OzonAccrualListingRelinker
             throw new \InvalidArgumentException('Unsupported component filter.');
         }
 
-        $rows = $this->selectRows($companyId, $from, $to, $limit, $componentFilter);
+        $rows = $this->selectRows($companyId, $shopRef, $from, $to, $limit, $componentFilter);
         $recoveredSourceData = $this->recoverListingSourceData($rows);
         $sourceDataByCompany = [];
         foreach ($rows as $row) {
@@ -142,6 +143,7 @@ final readonly class OzonAccrualListingRelinker
      */
     private function selectRows(
         ?string $companyId,
+        ?string $shopRef,
         ?\DateTimeImmutable $from,
         ?\DateTimeImmutable $to,
         int $limit,
@@ -166,6 +168,11 @@ final readonly class OzonAccrualListingRelinker
         if (null !== $companyId) {
             $where[] = 'company_id = :company_id';
             $params['company_id'] = $companyId;
+        }
+
+        if (null !== $shopRef) {
+            $where[] = 'shop_ref = :shop_ref';
+            $params['shop_ref'] = $shopRef;
         }
 
         if (null !== $from) {

--- a/site/src/Ingestion/Application/Service/OzonAccrualListingRelinker.php
+++ b/site/src/Ingestion/Application/Service/OzonAccrualListingRelinker.php
@@ -124,6 +124,7 @@ final readonly class OzonAccrualListingRelinker
 
         if ($execute) {
             $this->entityManager->flush();
+            $this->entityManager->clear();
         }
 
         return [
@@ -244,7 +245,7 @@ final readonly class OzonAccrualListingRelinker
     }
 
     /**
-     * @param list<array<string, mixed>> $rows
+     * @param list<array<string, mixed>>                                           $rows
      * @param array<string, \App\Ingestion\Application\DTO\ListingResolution|null> $resolutions
      *
      * @return array<string, FinancialTransaction>

--- a/site/src/Ingestion/Application/Service/OzonAccrualListingRelinker.php
+++ b/site/src/Ingestion/Application/Service/OzonAccrualListingRelinker.php
@@ -1,0 +1,348 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Service;
+
+use App\Ingestion\Application\Source\Ozon\OzonAccrualByDayPreviewMapper;
+use App\Ingestion\Application\Source\Ozon\OzonAccrualPreviewTransaction;
+use App\Ingestion\Application\Source\Ozon\OzonListingResolver;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Entity\FinancialTransaction;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Facade\RawStorageFacade;
+use App\Ingestion\Repository\FinancialTransactionRepository;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class OzonAccrualListingRelinker
+{
+    public const COMPONENT_FILTER_ALL = 'all';
+    public const COMPONENT_FILTER_LINKABLE = 'linkable';
+
+    public function __construct(
+        private Connection $connection,
+        private OzonListingResolver $listingResolver,
+        private RawStorageFacade $rawStorageFacade,
+        private OzonAccrualByDayPreviewMapper $previewMapper,
+        private FinancialTransactionRepository $transactionRepository,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     selected: int,
+     *     resolved: int,
+     *     updated: int,
+     *     wouldCreateListings: int,
+     *     unresolved: int,
+     *     rows: list<array{companyId: string, occurredAt: string, externalId: string, listingSku: string, listingId: string, status: string}>
+     * }
+     */
+    public function relink(
+        ?string $companyId,
+        ?\DateTimeImmutable $from,
+        ?\DateTimeImmutable $to,
+        int $limit,
+        bool $execute,
+        string $componentFilter = self::COMPONENT_FILTER_ALL,
+        bool $includeRows = true,
+    ): array {
+        if (!in_array($componentFilter, [self::COMPONENT_FILTER_ALL, self::COMPONENT_FILTER_LINKABLE], true)) {
+            throw new \InvalidArgumentException('Unsupported component filter.');
+        }
+
+        $rows = $this->selectRows($companyId, $from, $to, $limit, $componentFilter);
+        $recoveredSourceData = $this->recoverListingSourceData($rows);
+        $sourceDataByCompany = [];
+        foreach ($rows as $row) {
+            $sourceData = $this->decodeSourceData($row['source_data'] ?? null);
+            if (!$this->hasMarketplaceSkuContext($sourceData)) {
+                $sourceData = array_merge(
+                    $sourceData,
+                    $recoveredSourceData[(string) $row['company_id']][(string) $row['raw_record_id']][(string) $row['external_id']] ?? [],
+                );
+            }
+
+            $sourceDataByCompany[(string) $row['company_id']][(string) $row['id']] = $sourceData;
+        }
+
+        $resolutions = [];
+        $wouldCreateById = [];
+        foreach ($sourceDataByCompany as $rowCompanyId => $sourceDataRows) {
+            if ($execute) {
+                $resolutions += $this->listingResolver->resolveMany($rowCompanyId, $sourceDataRows);
+                continue;
+            }
+
+            foreach ($this->listingResolver->previewMany($rowCompanyId, $sourceDataRows) as $transactionId => $preview) {
+                $resolutions[$transactionId] = $preview->resolution;
+                $wouldCreateById[$transactionId] = $preview->wouldCreate;
+            }
+        }
+
+        $tableRows = [];
+        $resolved = 0;
+        $updated = 0;
+        $wouldCreateListings = 0;
+        $transactionsById = $execute ? $this->fetchTransactionsToUpdate($rows, $resolutions) : [];
+
+        foreach ($rows as $row) {
+            $transactionId = (string) $row['id'];
+            $resolution = $resolutions[$transactionId] ?? null;
+            $status = 'unresolved';
+
+            if (null !== $resolution?->listingId && null !== $resolution->listingSku) {
+                ++$resolved;
+                $status = $execute ? 'updated' : 'would-update';
+
+                if ($execute) {
+                    $transaction = $transactionsById[$transactionId] ?? null;
+                    if ($transaction instanceof FinancialTransaction && null === $transaction->getListingId()) {
+                        $transaction->setListing($resolution->listingId, $resolution->listingSku);
+                        ++$updated;
+                    }
+                }
+            } elseif (!$execute && true === ($wouldCreateById[$transactionId] ?? false) && null !== $resolution?->listingSku) {
+                ++$resolved;
+                ++$wouldCreateListings;
+                $status = 'would-create-listing+update';
+            }
+
+            if ($includeRows) {
+                $tableRows[] = [
+                    'companyId' => (string) $row['company_id'],
+                    'occurredAt' => (string) $row['occurred_at'],
+                    'externalId' => (string) $row['external_id'],
+                    'listingSku' => $resolution?->listingSku ?? '',
+                    'listingId' => $resolution?->listingId ?? '',
+                    'status' => $status,
+                ];
+            }
+        }
+
+        if ($execute) {
+            $this->entityManager->flush();
+        }
+
+        return [
+            'selected' => count($rows),
+            'resolved' => $resolved,
+            'updated' => $updated,
+            'wouldCreateListings' => $wouldCreateListings,
+            'unresolved' => count($rows) - $resolved,
+            'rows' => $tableRows,
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function selectRows(
+        ?string $companyId,
+        ?\DateTimeImmutable $from,
+        ?\DateTimeImmutable $to,
+        int $limit,
+        string $componentFilter,
+    ): array {
+        $where = [
+            'source = :source',
+            'listing_id IS NULL',
+            "(external_id LIKE :external_id_prefix OR source_data->>'_ingestion_resource' = :resource_type)",
+        ];
+        $params = [
+            'source' => IngestSource::OZON->value,
+            'external_id_prefix' => 'ozon:accrual-by-day:%',
+            'resource_type' => OzonResourceType::ACCRUAL_BY_DAY,
+        ];
+
+        if (self::COMPONENT_FILTER_LINKABLE === $componentFilter) {
+            $where[] = "(external_id NOT LIKE :non_item_fee_prefix OR source_data->>'_ingestion_resource' = :resource_type)";
+            $params['non_item_fee_prefix'] = 'ozon:accrual-by-day:%:non_item_fee:%';
+        }
+
+        if (null !== $companyId) {
+            $where[] = 'company_id = :company_id';
+            $params['company_id'] = $companyId;
+        }
+
+        if (null !== $from) {
+            $where[] = 'occurred_at >= :from';
+            $params['from'] = $from->setTime(0, 0)->format('Y-m-d H:i:s');
+        }
+
+        if (null !== $to) {
+            $where[] = 'occurred_at < :to_exclusive';
+            $params['to_exclusive'] = $to->modify('+1 day')->setTime(0, 0)->format('Y-m-d H:i:s');
+        }
+
+        /** @var list<array<string, mixed>> $rows */
+        $rows = $this->connection->executeQuery(
+            sprintf(
+                "SELECT id, company_id, external_id, occurred_at, source_data, raw_record_id
+                 FROM ingest_financial_transactions
+                 WHERE %s
+                 ORDER BY CASE WHEN split_part(external_id, ':', 4) = 'non_item_fee' THEN 1 ELSE 0 END ASC,
+                          occurred_at ASC,
+                          id ASC
+                 LIMIT %d",
+                implode(' AND ', $where),
+                $limit,
+            ),
+            $params,
+        )->fetchAllAssociative();
+
+        return $rows;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     *
+     * @return array<string, array<string, array<string, array<string, mixed>>>>
+     */
+    private function recoverListingSourceData(array $rows): array
+    {
+        $rawRecordIdsByCompany = [];
+        foreach ($rows as $row) {
+            $sourceData = $this->decodeSourceData($row['source_data'] ?? null);
+            if ($this->hasMarketplaceSkuContext($sourceData)) {
+                continue;
+            }
+
+            $companyId = $this->stringValue($row['company_id'] ?? null);
+            $rawRecordId = $this->stringValue($row['raw_record_id'] ?? null);
+            if (null === $companyId || null === $rawRecordId) {
+                continue;
+            }
+
+            $rawRecordIdsByCompany[$companyId][$rawRecordId] = $rawRecordId;
+        }
+
+        $recovered = [];
+        foreach ($rawRecordIdsByCompany as $companyId => $rawRecordIds) {
+            foreach ($rawRecordIds as $rawRecordId) {
+                try {
+                    $rawRows = $this->rawStorageFacade->read($rawRecordId, $companyId);
+                    $previewRows = $this->previewMapper->preview($companyId, $rawRows, includeSaleRefund: true);
+                } catch (\Throwable) {
+                    continue;
+                }
+
+                foreach ($previewRows as $previewRow) {
+                    $sourceData = $this->listingSourceData($previewRow);
+                    if ([] === $sourceData) {
+                        continue;
+                    }
+
+                    $recovered[$companyId][$rawRecordId][$previewRow->sourceKey] = $sourceData;
+                }
+            }
+        }
+
+        return $recovered;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     * @param array<string, \App\Ingestion\Application\DTO\ListingResolution|null> $resolutions
+     *
+     * @return array<string, FinancialTransaction>
+     */
+    private function fetchTransactionsToUpdate(array $rows, array $resolutions): array
+    {
+        $ids = [];
+        foreach ($rows as $row) {
+            $transactionId = (string) $row['id'];
+            $resolution = $resolutions[$transactionId] ?? null;
+            if (null !== $resolution?->listingId && null !== $resolution->listingSku) {
+                $ids[$transactionId] = $transactionId;
+            }
+        }
+
+        if ([] === $ids) {
+            return [];
+        }
+
+        $transactionsById = [];
+        foreach ($this->transactionRepository->findBy(['id' => array_values($ids)]) as $transaction) {
+            if ($transaction instanceof FinancialTransaction) {
+                $transactionsById[$transaction->getId()] = $transaction;
+            }
+        }
+
+        return $transactionsById;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeSourceData(mixed $sourceData): array
+    {
+        if (is_array($sourceData)) {
+            return $sourceData;
+        }
+
+        if (!is_string($sourceData) || '' === trim($sourceData)) {
+            return [];
+        }
+
+        $decoded = json_decode($sourceData, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @param array<string, mixed> $sourceData
+     */
+    private function hasMarketplaceSkuContext(array $sourceData): bool
+    {
+        if (null !== $this->stringValue($sourceData['sku'] ?? $sourceData['marketplace_sku'] ?? $sourceData['marketplaceSku'] ?? null)) {
+            return true;
+        }
+
+        $item = $sourceData['item'] ?? null;
+        if (is_array($item) && null !== $this->stringValue($item['sku'] ?? null)) {
+            return true;
+        }
+
+        $items = $sourceData['items'] ?? null;
+        if (is_array($items) && isset($items[0]) && is_array($items[0])) {
+            return null !== $this->stringValue($items[0]['sku'] ?? null);
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function listingSourceData(OzonAccrualPreviewTransaction $row): array
+    {
+        $sourceData = [];
+        if (null !== $row->marketplaceSku) {
+            $sourceData['sku'] = $row->marketplaceSku;
+        }
+
+        if (null !== $row->supplierSku) {
+            $sourceData['offer_id'] = $row->supplierSku;
+        }
+
+        if (null !== $row->listingName) {
+            $sourceData['name'] = $row->listingName;
+        }
+
+        return $sourceData;
+    }
+
+    private function stringValue(mixed $value): ?string
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return '' === $value ? null : $value;
+    }
+}

--- a/site/src/Ingestion/Command/OzonAccrualReconcileFinancialProjectionCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualReconcileFinancialProjectionCommand.php
@@ -141,6 +141,7 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
                 $relinkDeferred = true;
             } elseif ('inline' === $normalizationMode) {
                 $normalizationResult = $this->executeInlineNormalization($staleRows);
+                $relinkDeferred = ($normalizationResult['failed'] ?? 0) > 0;
             }
         }
 
@@ -289,8 +290,55 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
                 $resultRows[] = ['rawId' => $rawRecordId, 'status' => $this->normalizationStatus($record), 'txCount' => -1, 'openIssues' => 0];
             } catch (\Throwable $exception) {
                 ++$failed;
-                $this->markInlineFailure($record, $exception);
-                $resultRows[] = ['rawId' => $rawRecordId, 'status' => 'error', 'txCount' => (int) $row['tx_count'], 'openIssues' => (int) $row['open_issues'], 'error' => $exception->getMessage()];
+                if (!$this->entityManager->isOpen()) {
+                    $this->logger->error('Ozon accrual inline normalization aborted because the entity manager is closed.', [
+                        'companyId' => $companyId,
+                        'rawRecordId' => $rawRecordId,
+                        'exceptionClass' => $exception::class,
+                        'message' => $exception->getMessage(),
+                    ]);
+                    $resultRows[] = [
+                        'rawId' => $rawRecordId,
+                        'status' => 'entity-manager-closed',
+                        'txCount' => (int) $row['tx_count'],
+                        'openIssues' => (int) $row['open_issues'],
+                        'error' => $exception->getMessage(),
+                    ];
+                    break;
+                }
+
+                try {
+                    $this->markInlineFailure($record, $exception);
+                    $resultRows[] = [
+                        'rawId' => $rawRecordId,
+                        'status' => 'error',
+                        'txCount' => (int) $row['tx_count'],
+                        'openIssues' => (int) $row['open_issues'],
+                        'error' => $exception->getMessage(),
+                    ];
+                } catch (\Throwable $failureRecordingException) {
+                    $this->logger->error('Ozon accrual inline normalization aborted because failure recording failed.', [
+                        'companyId' => $companyId,
+                        'rawRecordId' => $rawRecordId,
+                        'exceptionClass' => $exception::class,
+                        'message' => $exception->getMessage(),
+                        'failureRecordingExceptionClass' => $failureRecordingException::class,
+                        'failureRecordingMessage' => $failureRecordingException->getMessage(),
+                    ]);
+                    $status = $this->entityManager->isOpen() ? 'failure-recording-error' : 'entity-manager-closed';
+                    $resultRows[] = [
+                        'rawId' => $rawRecordId,
+                        'status' => $status,
+                        'txCount' => (int) $row['tx_count'],
+                        'openIssues' => (int) $row['open_issues'],
+                        'error' => sprintf(
+                            '%s; failure recording failed: %s',
+                            $exception->getMessage(),
+                            $failureRecordingException->getMessage(),
+                        ),
+                    ];
+                    break;
+                }
             }
         }
 
@@ -463,7 +511,7 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
     }
 
     /**
-     * @param array<string, mixed> $payload
+     * @param array<string, mixed>       $payload
      * @param list<array<string, mixed>> $rawRows
      * @param list<array<string, mixed>> $normalizationRows
      * @param list<array<string, mixed>> $relinkRows
@@ -629,9 +677,9 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
         }
 
         $daysBack = $this->intOption($input, 'days-back', 1, 365);
-        $today = \DateTimeImmutable::createFromInterface(
-            $this->clock->now()->setTimezone(new \DateTimeZone(self::BUSINESS_TIMEZONE)),
-        )->setTime(0, 0);
+        $today = $this->clock->now()
+            ->setTimezone(new \DateTimeZone(self::BUSINESS_TIMEZONE))
+            ->setTime(0, 0);
 
         return [
             $today->modify(sprintf('-%d days', $daysBack)),

--- a/site/src/Ingestion/Command/OzonAccrualReconcileFinancialProjectionCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualReconcileFinancialProjectionCommand.php
@@ -425,7 +425,7 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
             $totals['resolved'] += $result['resolved'];
             $totals['updated'] += $result['updated'];
             $totals['wouldCreateListings'] += $result['wouldCreateListings'];
-            $totals['unresolved'] = $result['unresolved'];
+            $totals['unresolved'] += $result['unresolved'];
 
             if (0 === $result['selected'] || 0 === $result['updated']) {
                 break;

--- a/site/src/Ingestion/Command/OzonAccrualReconcileFinancialProjectionCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualReconcileFinancialProjectionCommand.php
@@ -9,9 +9,11 @@ use App\Ingestion\Application\Action\RecordNormalizationIssueAction;
 use App\Ingestion\Application\Command\NormalizeRawRecordCommand;
 use App\Ingestion\Application\Command\RecordNormalizationIssueCommand;
 use App\Ingestion\Application\Service\OzonAccrualListingRelinker;
+use App\Ingestion\Application\Source\Ozon\OzonAccrualByDayPreviewMapper;
 use App\Ingestion\Entity\IngestRawRecord;
 use App\Ingestion\Enum\NormalizationIssueKind;
 use App\Ingestion\Enum\RawNormalizationStatus;
+use App\Ingestion\Facade\RawStorageFacade;
 use App\Ingestion\Infrastructure\Query\OzonAccrualProjectionHealthQuery;
 use App\Ingestion\Message\NormalizeRawRecordMessage;
 use App\Ingestion\Repository\IngestRawRecordRepository;
@@ -38,6 +40,7 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
     use LockableTrait;
 
     private const BUSINESS_TIMEZONE = 'Europe/Moscow';
+    private const MAX_RAW_PROJECTION_CANDIDATES = 500;
 
     public function __construct(
         private readonly ClockInterface $clock,
@@ -49,6 +52,8 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
         private readonly NormalizeRawRecordAction $normalizeRawRecordAction,
         private readonly RecordNormalizationIssueAction $recordNormalizationIssueAction,
         private readonly OzonAccrualListingRelinker $listingRelinker,
+        private readonly RawStorageFacade $rawStorageFacade,
+        private readonly OzonAccrualByDayPreviewMapper $previewMapper,
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct();
@@ -67,6 +72,7 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
             ->addOption('max-relink-batches', null, InputOption::VALUE_REQUIRED, 'Maximum relink batches per run, 1..50.', 20)
             ->addOption('dispatch-normalization', null, InputOption::VALUE_NONE, 'Reset stale raw records and dispatch async normalization messages.')
             ->addOption('execute-inline-normalization', null, InputOption::VALUE_NONE, 'Reset stale raw records and normalize them synchronously.')
+            ->addOption('repair-enrichment-only', null, InputOption::VALUE_NONE, 'Skip raw normalization actions and only repair listing enrichment.')
             ->addOption('summary-only', null, InputOption::VALUE_NONE, 'Print only summary tables.')
             ->addOption('json', null, InputOption::VALUE_NONE, 'Print machine-readable JSON result.')
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Inspect stale projection and planned enrichment repair without writing.')
@@ -99,6 +105,10 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
             $maxRelinkBatches = $this->intOption($input, 'max-relink-batches', 1, 50);
             $execute = $this->mode($input);
             $normalizationMode = $this->normalizationMode($input, $execute);
+            $repairEnrichmentOnly = (bool) $input->getOption('repair-enrichment-only');
+            if ($repairEnrichmentOnly && null !== $normalizationMode) {
+                throw new \InvalidArgumentException('--repair-enrichment-only cannot be combined with normalization actions.');
+            }
             $summaryOnly = (bool) $input->getOption('summary-only');
             $json = (bool) $input->getOption('json');
         } catch (\Throwable $exception) {
@@ -107,17 +117,21 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
             return Command::FAILURE;
         }
 
-        $rawRows = $this->healthQuery->rawProjectionRows($from, $to, $companyId, $shopRef, $rawLimit, problemsOnly: true);
+        $rawRows = $this->resolveNaturalProjectionCoverage(
+            $this->healthQuery->rawProjectionRows($from, $to, $companyId, $shopRef, self::MAX_RAW_PROJECTION_CANDIDATES, problemsOnly: true),
+        );
+        $rawRows = array_values(array_filter($rawRows, fn (array $row): bool => $this->needsNormalization($row)));
+        $rawRows = array_slice($rawRows, 0, $rawLimit);
         $integrityBefore = $this->healthQuery->integritySummary($from, $to, $companyId, $shopRef);
-        $staleRows = array_values(array_filter($rawRows, fn (array $row): bool => $this->needsNormalization($row)));
-        if ($execute && [] !== $staleRows && null === $normalizationMode) {
+        $staleRows = $rawRows;
+        if ($execute && [] !== $staleRows && null === $normalizationMode && !$repairEnrichmentOnly) {
             $io->error('Stale raw records were found. Use --dispatch-normalization or --execute-inline-normalization with --execute.');
 
             return Command::FAILURE;
         }
 
         $normalizationResult = [
-            'mode' => $normalizationMode ?? 'none',
+            'mode' => $repairEnrichmentOnly ? 'repair-enrichment-only' : ($normalizationMode ?? 'none'),
             'selected' => count($staleRows),
             'changed' => 0,
             'failed' => 0,
@@ -177,6 +191,7 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
         $payload = [
             'mode' => $execute ? 'execute' : 'dry-run',
             'normalizationMode' => $normalizationMode ?? 'none',
+            'repairEnrichmentOnly' => $repairEnrichmentOnly,
             'from' => $from->format('Y-m-d'),
             'to' => $to->format('Y-m-d'),
             'daysBack' => $daysBack,
@@ -287,8 +302,6 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
 
             try {
                 ($this->normalizeRawRecordAction)(new NormalizeRawRecordCommand($rawRecordId, $companyId));
-                ++$changed;
-                $resultRows[] = ['rawId' => $rawRecordId, 'status' => $this->normalizationStatus($record), 'txCount' => -1, 'openIssues' => 0];
             } catch (\Throwable $exception) {
                 ++$failed;
                 if (!$this->entityManager->isOpen()) {
@@ -340,6 +353,27 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
                     ];
                     break;
                 }
+
+                continue;
+            }
+
+            try {
+                $status = $this->normalizationStatus($record);
+            } catch (\Throwable $exception) {
+                $status = 'normalized-status-unavailable';
+                $this->logger->warning('Ozon accrual inline normalization status refresh failed after successful action.', [
+                    'companyId' => $companyId,
+                    'rawRecordId' => $rawRecordId,
+                    'exceptionClass' => $exception::class,
+                    'message' => $exception->getMessage(),
+                ]);
+            }
+
+            ++$changed;
+            $resultRows[] = ['rawId' => $rawRecordId, 'status' => $status, 'txCount' => -1, 'openIssues' => 0];
+
+            if (!$this->entityManager->isOpen()) {
+                break;
             }
         }
 
@@ -464,6 +498,89 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
     /**
      * @param list<array<string, mixed>> $rows
      *
+     * @return list<array<string, mixed>>
+     */
+    private function resolveNaturalProjectionCoverage(array $rows): array
+    {
+        foreach ($rows as $index => $row) {
+            $rows[$index]['projection_status'] = 'sql-candidate';
+            $rows[$index]['expected_tx_count'] = null;
+            $rows[$index]['projected_natural_key_count'] = null;
+            $rows[$index]['missing_natural_key_count'] = null;
+
+            if (!$this->needsNaturalProjectionCheck($row)) {
+                continue;
+            }
+
+            $companyId = (string) $row['company_id'];
+            $rawRecordId = (string) $row['raw_id'];
+
+            try {
+                $expectedSourceKeys = $this->expectedSourceKeys($companyId, $rawRecordId);
+                $expectedExternalIds = [];
+                foreach ($expectedSourceKeys as $sourceKey => $_) {
+                    $expectedExternalIds[] = $sourceKey;
+                }
+
+                $projectedSourceKeys = $this->healthQuery->projectedExternalIdSet(
+                    companyId: $companyId,
+                    shopRef: (string) $row['shop_ref'],
+                    externalIds: $expectedExternalIds,
+                );
+                $missingSourceKeys = array_diff_key($expectedSourceKeys, $projectedSourceKeys);
+
+                $rows[$index]['expected_tx_count'] = count($expectedSourceKeys);
+                $rows[$index]['projected_natural_key_count'] = count($projectedSourceKeys);
+                $rows[$index]['missing_natural_key_count'] = count($missingSourceKeys);
+
+                if ([] === $missingSourceKeys) {
+                    $rows[$index]['needs_normalization'] = 0;
+                    $rows[$index]['projection_status'] = 'natural-key-covered';
+                    continue;
+                }
+
+                $rows[$index]['projection_status'] = 'natural-key-missing';
+            } catch (\Throwable $exception) {
+                $rows[$index]['projection_status'] = 'natural-key-check-failed';
+                $this->logger->warning('Ozon accrual natural projection coverage check failed.', [
+                    'companyId' => $companyId,
+                    'rawRecordId' => $rawRecordId,
+                    'exceptionClass' => $exception::class,
+                    'message' => $exception->getMessage(),
+                ]);
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function needsNaturalProjectionCheck(array $row): bool
+    {
+        return $this->needsNormalization($row)
+            && RawNormalizationStatus::DONE->value === (string) $row['normalization_status']
+            && 0 === (int) $row['open_issues']
+            && 0 === (int) $row['direct_raw_tx_count'];
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    private function expectedSourceKeys(string $companyId, string $rawRecordId): array
+    {
+        $sourceKeys = [];
+        foreach ($this->previewMapper->preview($companyId, $this->rawStorageFacade->read($rawRecordId, $companyId), includeSaleRefund: true) as $row) {
+            $sourceKeys[$row->sourceKey] = true;
+        }
+
+        return $sourceKeys;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     *
      * @return array<string, int>
      */
     private function rawSummary(array $rows): array
@@ -471,8 +588,9 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
         $summary = [
             'notDoneRaw' => 0,
             'zeroTxRaw' => 0,
+            'zeroDirectTxRaw' => 0,
             'openIssueRaw' => 0,
-            'lateRawSnapshot' => 0,
+            'naturalKeyMissingRaw' => 0,
         ];
 
         foreach ($rows as $row) {
@@ -484,15 +602,16 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
                 ++$summary['zeroTxRaw'];
             }
 
+            if (0 === (int) $row['direct_raw_tx_count']) {
+                ++$summary['zeroDirectTxRaw'];
+            }
+
             if ((int) $row['open_issues'] > 0) {
                 ++$summary['openIssueRaw'];
             }
 
-            if (null !== $row['last_tx_updated_at']) {
-                $lastTransactionUpdatedAt = new \DateTimeImmutable((string) $row['last_tx_updated_at']);
-                if (new \DateTimeImmutable((string) $row['fetched_at']) > $lastTransactionUpdatedAt) {
-                    ++$summary['lateRawSnapshot'];
-                }
+            if ('natural-key-missing' === ($row['projection_status'] ?? null)) {
+                ++$summary['naturalKeyMissingRaw'];
             }
         }
 
@@ -512,7 +631,7 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
     }
 
     /**
-     * @param array<string, mixed>       $payload
+     * @param array<string, mixed> $payload
      * @param list<array<string, mixed>> $rawRows
      * @param list<array<string, mixed>> $normalizationRows
      * @param list<array<string, mixed>> $relinkRows
@@ -536,6 +655,7 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
                 ['daysBack', null === $payload['daysBack'] ? 'custom' : (string) $payload['daysBack']],
                 ['companyId', (string) ($payload['companyId'] ?? 'all')],
                 ['shopRef', (string) ($payload['shopRef'] ?? 'all')],
+                ['repairEnrichmentOnly', true === $payload['repairEnrichmentOnly'] ? 'yes' : 'no'],
                 ['rawLimit', (string) $payload['rawLimit']],
                 ['relinkLimit', (string) $payload['relinkLimit']],
                 ['maxRelinkBatches', (string) $payload['maxRelinkBatches']],
@@ -550,8 +670,9 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
                 ['rawNeedsNormalization', (string) $payload['rawProblems']['needsNormalization']],
                 ['notDoneRaw', (string) $payload['rawProblems']['summary']['notDoneRaw']],
                 ['zeroTxRaw', (string) $payload['rawProblems']['summary']['zeroTxRaw']],
+                ['zeroDirectTxRaw', (string) $payload['rawProblems']['summary']['zeroDirectTxRaw']],
                 ['openIssueRaw', (string) $payload['rawProblems']['summary']['openIssueRaw']],
-                ['lateRawSnapshot', (string) $payload['rawProblems']['summary']['lateRawSnapshot']],
+                ['naturalKeyMissingRaw', (string) $payload['rawProblems']['summary']['naturalKeyMissingRaw']],
                 ['relinkDeferred', true === $payload['relinkDeferred'] ? 'yes' : 'no'],
             ],
         );
@@ -559,7 +680,7 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
         if (!$summaryOnly && [] !== $rawRows) {
             $io->section('Raw projection problems');
             $io->table(
-                ['companyId', 'shopRef', 'windowFrom', 'windowTo', 'rawId', 'status', 'txCount', 'directTxCount', 'openIssues', 'fetchedAt', 'lastTxUpdatedAt'],
+                ['companyId', 'shopRef', 'windowFrom', 'windowTo', 'rawId', 'status', 'projectionStatus', 'txCount', 'directTxCount', 'expectedTx', 'projectedKeys', 'missingKeys', 'openIssues', 'fetchedAt', 'lastTxUpdatedAt'],
                 array_map(static fn (array $row): array => [
                     (string) $row['company_id'],
                     (string) $row['shop_ref'],
@@ -567,8 +688,12 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
                     (string) $row['window_to'],
                     (string) $row['raw_id'],
                     (string) $row['normalization_status'],
+                    (string) ($row['projection_status'] ?? ''),
                     (string) $row['tx_count'],
                     (string) $row['direct_raw_tx_count'],
+                    (string) ($row['expected_tx_count'] ?? ''),
+                    (string) ($row['projected_natural_key_count'] ?? ''),
+                    (string) ($row['missing_natural_key_count'] ?? ''),
                     (string) $row['open_issues'],
                     (string) $row['fetched_at'],
                     (string) ($row['last_tx_updated_at'] ?? ''),

--- a/site/src/Ingestion/Command/OzonAccrualReconcileFinancialProjectionCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualReconcileFinancialProjectionCommand.php
@@ -152,6 +152,7 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
                 to: $to,
                 limit: $relinkLimit,
                 execute: false,
+                shopRef: $shopRef,
                 componentFilter: OzonAccrualListingRelinker::COMPONENT_FILTER_LINKABLE,
                 includeRows: !$summaryOnly && !$json,
             );
@@ -166,7 +167,7 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
                 'rows' => $preview['rows'],
             ]);
         } elseif (!$relinkDeferred) {
-            $relinkResult = $this->executeRelinkBatches($companyId, $from, $to, $relinkLimit, $maxRelinkBatches);
+            $relinkResult = $this->executeRelinkBatches($companyId, $shopRef, $from, $to, $relinkLimit, $maxRelinkBatches);
         }
 
         $integrityAfter = $execute && !$relinkDeferred
@@ -356,6 +357,7 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
      */
     private function executeRelinkBatches(
         ?string $companyId,
+        ?string $shopRef,
         \DateTimeImmutable $from,
         \DateTimeImmutable $to,
         int $limit,
@@ -379,6 +381,7 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
                 to: $to,
                 limit: $limit,
                 execute: true,
+                shopRef: $shopRef,
                 componentFilter: OzonAccrualListingRelinker::COMPONENT_FILTER_LINKABLE,
                 includeRows: false,
             );
@@ -401,6 +404,7 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
             to: $to,
             limit: $limit,
             execute: false,
+            shopRef: $shopRef,
             componentFilter: OzonAccrualListingRelinker::COMPONENT_FILTER_LINKABLE,
             includeRows: false,
         );
@@ -486,10 +490,7 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
 
             if (null !== $row['last_tx_updated_at']) {
                 $lastTransactionUpdatedAt = new \DateTimeImmutable((string) $row['last_tx_updated_at']);
-                if (
-                    new \DateTimeImmutable((string) $row['fetched_at']) > $lastTransactionUpdatedAt
-                    || new \DateTimeImmutable((string) $row['raw_updated_at']) > $lastTransactionUpdatedAt
-                ) {
+                if (new \DateTimeImmutable((string) $row['fetched_at']) > $lastTransactionUpdatedAt) {
                     ++$summary['lateRawSnapshot'];
                 }
             }
@@ -558,7 +559,7 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
         if (!$summaryOnly && [] !== $rawRows) {
             $io->section('Raw projection problems');
             $io->table(
-                ['companyId', 'shopRef', 'windowFrom', 'windowTo', 'rawId', 'status', 'txCount', 'openIssues', 'fetchedAt', 'lastTxUpdatedAt'],
+                ['companyId', 'shopRef', 'windowFrom', 'windowTo', 'rawId', 'status', 'txCount', 'directTxCount', 'openIssues', 'fetchedAt', 'lastTxUpdatedAt'],
                 array_map(static fn (array $row): array => [
                     (string) $row['company_id'],
                     (string) $row['shop_ref'],
@@ -567,6 +568,7 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
                     (string) $row['raw_id'],
                     (string) $row['normalization_status'],
                     (string) $row['tx_count'],
+                    (string) $row['direct_raw_tx_count'],
                     (string) $row['open_issues'],
                     (string) $row['fetched_at'],
                     (string) ($row['last_tx_updated_at'] ?? ''),

--- a/site/src/Ingestion/Command/OzonAccrualReconcileFinancialProjectionCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualReconcileFinancialProjectionCommand.php
@@ -117,10 +117,10 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
             return Command::FAILURE;
         }
 
-        $rawRows = $this->resolveNaturalProjectionCoverage(
+        $projectionRows = $this->resolveNaturalProjectionCoverage(
             $this->healthQuery->rawProjectionRows($from, $to, $companyId, $shopRef, self::MAX_RAW_PROJECTION_CANDIDATES, problemsOnly: true),
         );
-        $rawRows = array_values(array_filter($rawRows, fn (array $row): bool => $this->needsNormalization($row)));
+        $rawRows = array_values(array_filter($projectionRows, fn (array $row): bool => $this->needsNormalization($row)));
         $rawRows = array_slice($rawRows, 0, $rawLimit);
         $integrityBefore = $this->healthQuery->integritySummary($from, $to, $companyId, $shopRef);
         $staleRows = $rawRows;
@@ -137,6 +137,12 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
             'failed' => 0,
             'rows' => [],
         ];
+        $naturalProjectionAttributionResult = [
+            'selected' => 0,
+            'changed' => 0,
+            'failed' => 0,
+            'rows' => [],
+        ];
         $relinkResult = [
             'batches' => 0,
             'selected' => 0,
@@ -148,6 +154,10 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
             'rows' => [],
         ];
         $relinkDeferred = false;
+
+        if ($execute) {
+            $naturalProjectionAttributionResult = $this->repairNaturalProjectionAttribution($projectionRows);
+        }
 
         if ($execute && [] !== $staleRows) {
             if ('dispatch' === $normalizationMode) {
@@ -206,6 +216,7 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
                 'summary' => $this->rawSummary($rawRows),
             ],
             'normalization' => $this->withoutRows($normalizationResult),
+            'naturalProjectionAttribution' => $this->withoutRows($naturalProjectionAttributionResult),
             'relink' => $this->withoutRows($relinkResult),
             'relinkDeferred' => $relinkDeferred,
             'integrityBefore' => $integrityBefore,
@@ -225,11 +236,76 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
             payload: $payload,
             rawRows: $rawRows,
             normalizationRows: $normalizationResult['rows'],
+            naturalProjectionAttributionRows: $naturalProjectionAttributionResult['rows'],
             relinkRows: $relinkResult['rows'],
             summaryOnly: $summaryOnly,
         );
 
         return $this->exitCode($payload);
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     *
+     * @return array{selected: int, changed: int, failed: int, rows: list<array<string, string|int>>}
+     */
+    private function repairNaturalProjectionAttribution(array $rows): array
+    {
+        $resultRows = [];
+        $selected = 0;
+        $changed = 0;
+        $failed = 0;
+
+        foreach ($rows as $row) {
+            if ('natural-key-covered' !== ($row['projection_status'] ?? null)) {
+                continue;
+            }
+
+            ++$selected;
+            $companyId = (string) $row['company_id'];
+            $shopRef = (string) $row['shop_ref'];
+            $rawRecordId = (string) $row['raw_id'];
+
+            try {
+                $expectedSourceKeys = $this->expectedSourceKeys($companyId, $rawRecordId);
+                $updated = $this->healthQuery->reattributeProjectedExternalIds(
+                    companyId: $companyId,
+                    shopRef: $shopRef,
+                    rawRecordId: $rawRecordId,
+                    rawFetchedAt: new \DateTimeImmutable((string) $row['fetched_at']),
+                    externalIds: array_keys($expectedSourceKeys),
+                );
+            } catch (\Throwable $exception) {
+                ++$failed;
+                $this->logger->warning('Ozon accrual natural projection attribution repair failed.', [
+                    'companyId' => $companyId,
+                    'rawRecordId' => $rawRecordId,
+                    'exceptionClass' => $exception::class,
+                    'message' => $exception->getMessage(),
+                ]);
+                $resultRows[] = [
+                    'rawId' => $rawRecordId,
+                    'status' => 'error',
+                    'updated' => 0,
+                    'error' => $exception->getMessage(),
+                ];
+                continue;
+            }
+
+            $changed += $updated;
+            $resultRows[] = [
+                'rawId' => $rawRecordId,
+                'status' => $updated > 0 ? 'updated' : 'unchanged',
+                'updated' => $updated,
+            ];
+        }
+
+        return [
+            'selected' => $selected,
+            'changed' => $changed,
+            'failed' => $failed,
+            'rows' => $resultRows,
+        ];
     }
 
     /**
@@ -634,6 +710,7 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
      * @param array<string, mixed> $payload
      * @param list<array<string, mixed>> $rawRows
      * @param list<array<string, mixed>> $normalizationRows
+     * @param list<array<string, string|int>> $naturalProjectionAttributionRows
      * @param list<array<string, mixed>> $relinkRows
      */
     private function printReport(
@@ -641,6 +718,7 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
         array $payload,
         array $rawRows,
         array $normalizationRows,
+        array $naturalProjectionAttributionRows,
         array $relinkRows,
         bool $summaryOnly,
     ): void {
@@ -716,6 +794,20 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
             );
         }
 
+        $io->section('Natural projection attribution repair');
+        $this->printMetrics($io, $payload['naturalProjectionAttribution']);
+        if (!$summaryOnly && [] !== $naturalProjectionAttributionRows) {
+            $io->table(
+                ['rawId', 'status', 'updated', 'error'],
+                array_map(static fn (array $row): array => [
+                    (string) $row['rawId'],
+                    (string) $row['status'],
+                    (string) $row['updated'],
+                    (string) ($row['error'] ?? ''),
+                ], $naturalProjectionAttributionRows),
+            );
+        }
+
         $io->section('Listing enrichment repair');
         $this->printMetrics($io, $payload['relink']);
         if (!$summaryOnly && [] !== $relinkRows) {
@@ -766,6 +858,10 @@ final class OzonAccrualReconcileFinancialProjectionCommand extends Command
     private function exitCode(array $payload): int
     {
         if (($payload['normalization']['failed'] ?? 0) > 0) {
+            return Command::FAILURE;
+        }
+
+        if (($payload['naturalProjectionAttribution']['failed'] ?? 0) > 0) {
             return Command::FAILURE;
         }
 

--- a/site/src/Ingestion/Command/OzonAccrualReconcileFinancialProjectionCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualReconcileFinancialProjectionCommand.php
@@ -1,0 +1,729 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Command;
+
+use App\Ingestion\Application\Action\NormalizeRawRecordAction;
+use App\Ingestion\Application\Action\RecordNormalizationIssueAction;
+use App\Ingestion\Application\Command\NormalizeRawRecordCommand;
+use App\Ingestion\Application\Command\RecordNormalizationIssueCommand;
+use App\Ingestion\Application\Service\OzonAccrualListingRelinker;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\NormalizationIssueKind;
+use App\Ingestion\Enum\RawNormalizationStatus;
+use App\Ingestion\Infrastructure\Query\OzonAccrualProjectionHealthQuery;
+use App\Ingestion\Message\NormalizeRawRecordMessage;
+use App\Ingestion\Repository\IngestRawRecordRepository;
+use App\Ingestion\Repository\NormalizationIssueRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\LockableTrait;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[AsCommand(
+    name: 'app:ingestion:ozon-accrual:reconcile-financial-projection',
+    description: 'Reconciles Ozon accrual raw snapshots with normalized financial transactions and repairs projection enrichment.',
+)]
+final class OzonAccrualReconcileFinancialProjectionCommand extends Command
+{
+    use LockableTrait;
+
+    private const BUSINESS_TIMEZONE = 'Europe/Moscow';
+
+    public function __construct(
+        private readonly ClockInterface $clock,
+        private readonly OzonAccrualProjectionHealthQuery $healthQuery,
+        private readonly IngestRawRecordRepository $rawRecordRepository,
+        private readonly NormalizationIssueRepository $normalizationIssueRepository,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly MessageBusInterface $messageBus,
+        private readonly NormalizeRawRecordAction $normalizeRawRecordAction,
+        private readonly RecordNormalizationIssueAction $recordNormalizationIssueAction,
+        private readonly OzonAccrualListingRelinker $listingRelinker,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('days-back', null, InputOption::VALUE_REQUIRED, 'Rolling window size. Used when --from/--to are omitted.', 30)
+            ->addOption('from', null, InputOption::VALUE_REQUIRED, 'Optional start accrual date YYYY-MM-DD. Must be paired with --to.')
+            ->addOption('to', null, InputOption::VALUE_REQUIRED, 'Optional end accrual date YYYY-MM-DD. Must be paired with --from.')
+            ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Optional company UUID filter.')
+            ->addOption('shop-ref', null, InputOption::VALUE_REQUIRED, 'Optional shop reference filter.')
+            ->addOption('raw-limit', null, InputOption::VALUE_REQUIRED, 'Maximum stale raw records to act on, 1..500.', 100)
+            ->addOption('relink-limit', null, InputOption::VALUE_REQUIRED, 'Maximum unlinked transactions per relink batch, 1..5000.', 5000)
+            ->addOption('max-relink-batches', null, InputOption::VALUE_REQUIRED, 'Maximum relink batches per run, 1..50.', 20)
+            ->addOption('dispatch-normalization', null, InputOption::VALUE_NONE, 'Reset stale raw records and dispatch async normalization messages.')
+            ->addOption('execute-inline-normalization', null, InputOption::VALUE_NONE, 'Reset stale raw records and normalize them synchronously.')
+            ->addOption('summary-only', null, InputOption::VALUE_NONE, 'Print only summary tables.')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Print machine-readable JSON result.')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Inspect stale projection and planned enrichment repair without writing.')
+            ->addOption('execute', null, InputOption::VALUE_NONE, 'Persist requested projection repair actions.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (!$this->lock()) {
+            $output->writeln('<comment>Ozon accrual financial projection reconciliation is already running.</comment>');
+
+            return Command::SUCCESS;
+        }
+
+        try {
+            return $this->runReconciliation($input, new SymfonyStyle($input, $output));
+        } finally {
+            $this->release();
+        }
+    }
+
+    private function runReconciliation(InputInterface $input, SymfonyStyle $io): int
+    {
+        try {
+            [$from, $to, $daysBack] = $this->dateWindow($input);
+            $companyId = $this->optionalUuidOption($input, 'company-id');
+            $shopRef = $this->optionalStringOption($input, 'shop-ref');
+            $rawLimit = $this->intOption($input, 'raw-limit', 1, 500);
+            $relinkLimit = $this->intOption($input, 'relink-limit', 1, 5000);
+            $maxRelinkBatches = $this->intOption($input, 'max-relink-batches', 1, 50);
+            $execute = $this->mode($input);
+            $normalizationMode = $this->normalizationMode($input, $execute);
+            $summaryOnly = (bool) $input->getOption('summary-only');
+            $json = (bool) $input->getOption('json');
+        } catch (\Throwable $exception) {
+            $io->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $rawRows = $this->healthQuery->rawProjectionRows($from, $to, $companyId, $shopRef, $rawLimit, problemsOnly: true);
+        $integrityBefore = $this->healthQuery->integritySummary($from, $to, $companyId, $shopRef);
+        $staleRows = array_values(array_filter($rawRows, fn (array $row): bool => $this->needsNormalization($row)));
+        if ($execute && [] !== $staleRows && null === $normalizationMode) {
+            $io->error('Stale raw records were found. Use --dispatch-normalization or --execute-inline-normalization with --execute.');
+
+            return Command::FAILURE;
+        }
+
+        $normalizationResult = [
+            'mode' => $normalizationMode ?? 'none',
+            'selected' => count($staleRows),
+            'changed' => 0,
+            'failed' => 0,
+            'rows' => [],
+        ];
+        $relinkResult = [
+            'batches' => 0,
+            'selected' => 0,
+            'resolved' => 0,
+            'updated' => 0,
+            'wouldCreateListings' => 0,
+            'unresolved' => 0,
+            'finalRecoverable' => 0,
+            'rows' => [],
+        ];
+        $relinkDeferred = false;
+
+        if ($execute && [] !== $staleRows) {
+            if ('dispatch' === $normalizationMode) {
+                $normalizationResult = $this->dispatchNormalization($staleRows);
+                $relinkDeferred = true;
+            } elseif ('inline' === $normalizationMode) {
+                $normalizationResult = $this->executeInlineNormalization($staleRows);
+            }
+        }
+
+        if (!$execute) {
+            $preview = $this->listingRelinker->relink(
+                companyId: $companyId,
+                from: $from,
+                to: $to,
+                limit: $relinkLimit,
+                execute: false,
+                componentFilter: OzonAccrualListingRelinker::COMPONENT_FILTER_LINKABLE,
+                includeRows: !$summaryOnly && !$json,
+            );
+            $relinkResult = array_merge($relinkResult, [
+                'batches' => 1,
+                'selected' => $preview['selected'],
+                'resolved' => $preview['resolved'],
+                'updated' => $preview['updated'],
+                'wouldCreateListings' => $preview['wouldCreateListings'],
+                'unresolved' => $preview['unresolved'],
+                'finalRecoverable' => $preview['resolved'],
+                'rows' => $preview['rows'],
+            ]);
+        } elseif (!$relinkDeferred) {
+            $relinkResult = $this->executeRelinkBatches($companyId, $from, $to, $relinkLimit, $maxRelinkBatches);
+        }
+
+        $integrityAfter = $execute && !$relinkDeferred
+            ? $this->healthQuery->integritySummary($from, $to, $companyId, $shopRef)
+            : $integrityBefore;
+
+        $payload = [
+            'mode' => $execute ? 'execute' : 'dry-run',
+            'normalizationMode' => $normalizationMode ?? 'none',
+            'from' => $from->format('Y-m-d'),
+            'to' => $to->format('Y-m-d'),
+            'daysBack' => $daysBack,
+            'companyId' => $companyId,
+            'shopRef' => $shopRef,
+            'rawLimit' => $rawLimit,
+            'relinkLimit' => $relinkLimit,
+            'maxRelinkBatches' => $maxRelinkBatches,
+            'rawProblems' => [
+                'selected' => count($rawRows),
+                'needsNormalization' => count($staleRows),
+                'summary' => $this->rawSummary($rawRows),
+            ],
+            'normalization' => $this->withoutRows($normalizationResult),
+            'relink' => $this->withoutRows($relinkResult),
+            'relinkDeferred' => $relinkDeferred,
+            'integrityBefore' => $integrityBefore,
+            'integrityAfter' => $integrityAfter,
+        ];
+
+        $this->logger->info('Ozon accrual financial projection reconciliation finished.', $payload);
+
+        if ($json) {
+            $io->writeln((string) json_encode($payload, \JSON_THROW_ON_ERROR));
+
+            return $this->exitCode($payload);
+        }
+
+        $this->printReport(
+            io: $io,
+            payload: $payload,
+            rawRows: $rawRows,
+            normalizationRows: $normalizationResult['rows'],
+            relinkRows: $relinkResult['rows'],
+            summaryOnly: $summaryOnly,
+        );
+
+        return $this->exitCode($payload);
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     *
+     * @return array{mode: string, selected: int, changed: int, failed: int, rows: list<array<string, string|int>>}
+     */
+    private function dispatchNormalization(array $rows): array
+    {
+        $resultRows = [];
+        $changed = 0;
+        $failed = 0;
+        $messages = [];
+
+        foreach ($rows as $row) {
+            $companyId = (string) $row['company_id'];
+            $rawRecordId = (string) $row['raw_id'];
+            $record = $this->rawRecordRepository->findByIdAndCompany($rawRecordId, $companyId);
+            if (!$record instanceof IngestRawRecord) {
+                ++$failed;
+                $resultRows[] = ['rawId' => $rawRecordId, 'status' => 'missing', 'txCount' => (int) $row['tx_count'], 'openIssues' => (int) $row['open_issues']];
+                continue;
+            }
+
+            $this->resetRecordToPending($record);
+            $this->resolveOpenIssues($companyId, $rawRecordId);
+            $messages[] = new NormalizeRawRecordMessage($rawRecordId, $companyId);
+            ++$changed;
+            $resultRows[] = ['rawId' => $rawRecordId, 'status' => RawNormalizationStatus::PENDING->value, 'txCount' => (int) $row['tx_count'], 'openIssues' => 0];
+        }
+
+        $this->entityManager->flush();
+        foreach ($messages as $message) {
+            $this->messageBus->dispatch($message);
+        }
+
+        return [
+            'mode' => 'dispatch',
+            'selected' => count($rows),
+            'changed' => $changed,
+            'failed' => $failed,
+            'rows' => $resultRows,
+        ];
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     *
+     * @return array{mode: string, selected: int, changed: int, failed: int, rows: list<array<string, string|int>>}
+     */
+    private function executeInlineNormalization(array $rows): array
+    {
+        $resultRows = [];
+        $changed = 0;
+        $failed = 0;
+
+        foreach ($rows as $row) {
+            $companyId = (string) $row['company_id'];
+            $rawRecordId = (string) $row['raw_id'];
+            $record = $this->rawRecordRepository->findByIdAndCompany($rawRecordId, $companyId);
+            if (!$record instanceof IngestRawRecord) {
+                ++$failed;
+                $resultRows[] = ['rawId' => $rawRecordId, 'status' => 'missing', 'txCount' => (int) $row['tx_count'], 'openIssues' => (int) $row['open_issues']];
+                continue;
+            }
+
+            $this->resetRecordToPending($record);
+            $this->resolveOpenIssues($companyId, $rawRecordId);
+            $this->entityManager->flush();
+
+            try {
+                ($this->normalizeRawRecordAction)(new NormalizeRawRecordCommand($rawRecordId, $companyId));
+                ++$changed;
+                $resultRows[] = ['rawId' => $rawRecordId, 'status' => $this->normalizationStatus($record), 'txCount' => -1, 'openIssues' => 0];
+            } catch (\Throwable $exception) {
+                ++$failed;
+                $this->markInlineFailure($record, $exception);
+                $resultRows[] = ['rawId' => $rawRecordId, 'status' => 'error', 'txCount' => (int) $row['tx_count'], 'openIssues' => (int) $row['open_issues'], 'error' => $exception->getMessage()];
+            }
+        }
+
+        return [
+            'mode' => 'inline',
+            'selected' => count($rows),
+            'changed' => $changed,
+            'failed' => $failed,
+            'rows' => $resultRows,
+        ];
+    }
+
+    /**
+     * @return array{batches: int, selected: int, resolved: int, updated: int, wouldCreateListings: int, unresolved: int, finalRecoverable: int, rows: list<array<string, string>>}
+     */
+    private function executeRelinkBatches(
+        ?string $companyId,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        int $limit,
+        int $maxBatches,
+    ): array {
+        $totals = [
+            'batches' => 0,
+            'selected' => 0,
+            'resolved' => 0,
+            'updated' => 0,
+            'wouldCreateListings' => 0,
+            'unresolved' => 0,
+            'finalRecoverable' => 0,
+            'rows' => [],
+        ];
+
+        for ($batch = 1; $batch <= $maxBatches; ++$batch) {
+            $result = $this->listingRelinker->relink(
+                companyId: $companyId,
+                from: $from,
+                to: $to,
+                limit: $limit,
+                execute: true,
+                componentFilter: OzonAccrualListingRelinker::COMPONENT_FILTER_LINKABLE,
+                includeRows: false,
+            );
+
+            ++$totals['batches'];
+            $totals['selected'] += $result['selected'];
+            $totals['resolved'] += $result['resolved'];
+            $totals['updated'] += $result['updated'];
+            $totals['wouldCreateListings'] += $result['wouldCreateListings'];
+            $totals['unresolved'] = $result['unresolved'];
+
+            if (0 === $result['selected'] || 0 === $result['updated']) {
+                break;
+            }
+        }
+
+        $preview = $this->listingRelinker->relink(
+            companyId: $companyId,
+            from: $from,
+            to: $to,
+            limit: $limit,
+            execute: false,
+            componentFilter: OzonAccrualListingRelinker::COMPONENT_FILTER_LINKABLE,
+            includeRows: false,
+        );
+        $totals['finalRecoverable'] = $preview['resolved'];
+
+        return $totals;
+    }
+
+    private function resetRecordToPending(IngestRawRecord $record): void
+    {
+        if (RawNormalizationStatus::DONE === $record->getNormalizationStatus()) {
+            $record->markNormalizationFailed();
+        }
+
+        $record->markNormalizationPending();
+    }
+
+    private function resolveOpenIssues(string $companyId, string $rawRecordId): void
+    {
+        foreach ($this->normalizationIssueRepository->findOpenByRawRecord($companyId, $rawRecordId) as $issue) {
+            $issue->markResolved();
+        }
+    }
+
+    private function markInlineFailure(IngestRawRecord $record, \Throwable $exception): void
+    {
+        $record->markNormalizationFailed();
+        ($this->recordNormalizationIssueAction)(new RecordNormalizationIssueCommand(
+            companyId: $record->getCompanyId(),
+            rawRecordId: $record->getId(),
+            operationGroupId: null,
+            kind: NormalizationIssueKind::MAPPER_FAILURE,
+            details: [
+                'exceptionClass' => $exception::class,
+                'message' => $exception->getMessage(),
+                'source' => 'ozon_accrual_reconcile_financial_projection_inline',
+            ],
+        ));
+        $this->entityManager->flush();
+    }
+
+    private function normalizationStatus(IngestRawRecord $record): string
+    {
+        $this->entityManager->refresh($record);
+
+        return $record->getNormalizationStatus()->value;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function needsNormalization(array $row): bool
+    {
+        return 1 === (int) $row['needs_normalization'];
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     *
+     * @return array<string, int>
+     */
+    private function rawSummary(array $rows): array
+    {
+        $summary = [
+            'notDoneRaw' => 0,
+            'zeroTxRaw' => 0,
+            'openIssueRaw' => 0,
+            'lateRawSnapshot' => 0,
+        ];
+
+        foreach ($rows as $row) {
+            if (RawNormalizationStatus::DONE->value !== (string) $row['normalization_status']) {
+                ++$summary['notDoneRaw'];
+            }
+
+            if (0 === (int) $row['tx_count']) {
+                ++$summary['zeroTxRaw'];
+            }
+
+            if ((int) $row['open_issues'] > 0) {
+                ++$summary['openIssueRaw'];
+            }
+
+            if (null !== $row['last_tx_updated_at']) {
+                $lastTransactionUpdatedAt = new \DateTimeImmutable((string) $row['last_tx_updated_at']);
+                if (
+                    new \DateTimeImmutable((string) $row['fetched_at']) > $lastTransactionUpdatedAt
+                    || new \DateTimeImmutable((string) $row['raw_updated_at']) > $lastTransactionUpdatedAt
+                ) {
+                    ++$summary['lateRawSnapshot'];
+                }
+            }
+        }
+
+        return $summary;
+    }
+
+    /**
+     * @param array<string, mixed> $result
+     *
+     * @return array<string, mixed>
+     */
+    private function withoutRows(array $result): array
+    {
+        unset($result['rows']);
+
+        return $result;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @param list<array<string, mixed>> $rawRows
+     * @param list<array<string, mixed>> $normalizationRows
+     * @param list<array<string, mixed>> $relinkRows
+     */
+    private function printReport(
+        SymfonyStyle $io,
+        array $payload,
+        array $rawRows,
+        array $normalizationRows,
+        array $relinkRows,
+        bool $summaryOnly,
+    ): void {
+        $io->title('Ozon accrual financial projection reconciliation');
+        $io->table(
+            ['setting', 'value'],
+            [
+                ['mode', (string) $payload['mode']],
+                ['normalizationMode', (string) $payload['normalizationMode']],
+                ['from', (string) $payload['from']],
+                ['to', (string) $payload['to']],
+                ['daysBack', null === $payload['daysBack'] ? 'custom' : (string) $payload['daysBack']],
+                ['companyId', (string) ($payload['companyId'] ?? 'all')],
+                ['shopRef', (string) ($payload['shopRef'] ?? 'all')],
+                ['rawLimit', (string) $payload['rawLimit']],
+                ['relinkLimit', (string) $payload['relinkLimit']],
+                ['maxRelinkBatches', (string) $payload['maxRelinkBatches']],
+            ],
+        );
+
+        $io->section('Projection health');
+        $io->table(
+            ['metric', 'value'],
+            [
+                ['rawProblemsSelected', (string) $payload['rawProblems']['selected']],
+                ['rawNeedsNormalization', (string) $payload['rawProblems']['needsNormalization']],
+                ['notDoneRaw', (string) $payload['rawProblems']['summary']['notDoneRaw']],
+                ['zeroTxRaw', (string) $payload['rawProblems']['summary']['zeroTxRaw']],
+                ['openIssueRaw', (string) $payload['rawProblems']['summary']['openIssueRaw']],
+                ['lateRawSnapshot', (string) $payload['rawProblems']['summary']['lateRawSnapshot']],
+                ['relinkDeferred', true === $payload['relinkDeferred'] ? 'yes' : 'no'],
+            ],
+        );
+
+        if (!$summaryOnly && [] !== $rawRows) {
+            $io->section('Raw projection problems');
+            $io->table(
+                ['companyId', 'shopRef', 'windowFrom', 'windowTo', 'rawId', 'status', 'txCount', 'openIssues', 'fetchedAt', 'lastTxUpdatedAt'],
+                array_map(static fn (array $row): array => [
+                    (string) $row['company_id'],
+                    (string) $row['shop_ref'],
+                    (string) $row['window_from'],
+                    (string) $row['window_to'],
+                    (string) $row['raw_id'],
+                    (string) $row['normalization_status'],
+                    (string) $row['tx_count'],
+                    (string) $row['open_issues'],
+                    (string) $row['fetched_at'],
+                    (string) ($row['last_tx_updated_at'] ?? ''),
+                ], $rawRows),
+            );
+        }
+
+        $io->section('Normalization action');
+        $this->printMetrics($io, $payload['normalization']);
+        if (!$summaryOnly && [] !== $normalizationRows) {
+            $io->table(
+                ['rawId', 'status', 'txCount', 'openIssues', 'error'],
+                array_map(static fn (array $row): array => [
+                    (string) $row['rawId'],
+                    (string) $row['status'],
+                    (string) $row['txCount'],
+                    (string) $row['openIssues'],
+                    (string) ($row['error'] ?? ''),
+                ], $normalizationRows),
+            );
+        }
+
+        $io->section('Listing enrichment repair');
+        $this->printMetrics($io, $payload['relink']);
+        if (!$summaryOnly && [] !== $relinkRows) {
+            $io->table(
+                ['companyId', 'occurredAt', 'externalId', 'listingSku', 'listingId', 'status'],
+                array_map(static fn (array $row): array => [
+                    (string) $row['companyId'],
+                    (string) $row['occurredAt'],
+                    (string) $row['externalId'],
+                    (string) $row['listingSku'],
+                    (string) $row['listingId'],
+                    (string) $row['status'],
+                ], $relinkRows),
+            );
+        }
+
+        $io->section('Integrity');
+        $io->table(
+            ['metric', 'before', 'after'],
+            [
+                ['txCount', (string) $payload['integrityBefore']['txCount'], (string) $payload['integrityAfter']['txCount']],
+                ['unlinkedTotal', (string) $payload['integrityBefore']['unlinkedTotal'], (string) $payload['integrityAfter']['unlinkedTotal']],
+                ['unlinkedNonItemFee', (string) $payload['integrityBefore']['unlinkedNonItemFee'], (string) $payload['integrityAfter']['unlinkedNonItemFee']],
+                ['brokenLinks', (string) $payload['integrityBefore']['brokenLinks'], (string) $payload['integrityAfter']['brokenLinks']],
+                ['skuMismatch', (string) $payload['integrityBefore']['skuMismatch'], (string) $payload['integrityAfter']['skuMismatch']],
+            ],
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $metrics
+     */
+    private function printMetrics(SymfonyStyle $io, array $metrics): void
+    {
+        $io->table(
+            ['metric', 'value'],
+            array_map(
+                static fn (string $key, mixed $value): array => [$key, is_bool($value) ? ($value ? 'yes' : 'no') : (string) $value],
+                array_keys($metrics),
+                $metrics,
+            ),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function exitCode(array $payload): int
+    {
+        if (($payload['normalization']['failed'] ?? 0) > 0) {
+            return Command::FAILURE;
+        }
+
+        if (true === $payload['relinkDeferred']) {
+            return Command::SUCCESS;
+        }
+
+        if (($payload['relink']['finalRecoverable'] ?? 0) > 0) {
+            return Command::FAILURE;
+        }
+
+        if (($payload['integrityAfter']['brokenLinks'] ?? 0) > 0 || ($payload['integrityAfter']['skuMismatch'] ?? 0) > 0) {
+            return Command::FAILURE;
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @return array{0: \DateTimeImmutable, 1: \DateTimeImmutable, 2: int|null}
+     */
+    private function dateWindow(InputInterface $input): array
+    {
+        $from = $this->optionalDateOption($input, 'from');
+        $to = $this->optionalDateOption($input, 'to');
+        if ((null === $from) !== (null === $to)) {
+            throw new \InvalidArgumentException('Options --from and --to must be provided together.');
+        }
+
+        if (null !== $from && null !== $to) {
+            if ($from > $to) {
+                throw new \InvalidArgumentException('--from cannot be later than --to.');
+            }
+
+            return [$from, $to, null];
+        }
+
+        $daysBack = $this->intOption($input, 'days-back', 1, 365);
+        $today = \DateTimeImmutable::createFromInterface(
+            $this->clock->now()->setTimezone(new \DateTimeZone(self::BUSINESS_TIMEZONE)),
+        )->setTime(0, 0);
+
+        return [
+            $today->modify(sprintf('-%d days', $daysBack)),
+            $today->modify('-1 day'),
+            $daysBack,
+        ];
+    }
+
+    private function optionalUuidOption(InputInterface $input, string $name): ?string
+    {
+        $value = trim((string) ($input->getOption($name) ?? ''));
+        if ('' === $value) {
+            return null;
+        }
+
+        if (!Uuid::isValid($value)) {
+            throw new \InvalidArgumentException(sprintf('--%s must be a valid UUID.', $name));
+        }
+
+        return $value;
+    }
+
+    private function optionalDateOption(InputInterface $input, string $name): ?\DateTimeImmutable
+    {
+        $value = trim((string) ($input->getOption($name) ?? ''));
+        if ('' === $value) {
+            return null;
+        }
+
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
+        if (!$date instanceof \DateTimeImmutable || $date->format('Y-m-d') !== $value) {
+            throw new \InvalidArgumentException(sprintf('--%s must use YYYY-MM-DD format.', $name));
+        }
+
+        return $date;
+    }
+
+    private function optionalStringOption(InputInterface $input, string $name): ?string
+    {
+        $value = trim((string) ($input->getOption($name) ?? ''));
+
+        return '' === $value ? null : $value;
+    }
+
+    private function intOption(InputInterface $input, string $name, int $min, int $max): int
+    {
+        $raw = $input->getOption($name);
+        if (!is_numeric($raw)) {
+            throw new \InvalidArgumentException(sprintf('--%s must be numeric.', $name));
+        }
+
+        $value = (int) $raw;
+        if ($value < $min || $value > $max) {
+            throw new \InvalidArgumentException(sprintf('--%s must be between %d and %d.', $name, $min, $max));
+        }
+
+        return $value;
+    }
+
+    private function mode(InputInterface $input): bool
+    {
+        $dryRun = (bool) $input->getOption('dry-run');
+        $execute = (bool) $input->getOption('execute');
+
+        if ($dryRun === $execute) {
+            throw new \InvalidArgumentException('Choose exactly one action: --dry-run or --execute.');
+        }
+
+        return $execute;
+    }
+
+    private function normalizationMode(InputInterface $input, bool $execute): ?string
+    {
+        $dispatch = (bool) $input->getOption('dispatch-normalization');
+        $inline = (bool) $input->getOption('execute-inline-normalization');
+
+        if ($dispatch && $inline) {
+            throw new \InvalidArgumentException('Choose only one normalization mode.');
+        }
+
+        if (!$execute) {
+            return null;
+        }
+
+        if ($dispatch) {
+            return 'dispatch';
+        }
+
+        if ($inline) {
+            return 'inline';
+        }
+
+        return null;
+    }
+}

--- a/site/src/Ingestion/Command/OzonAccrualRelinkListingsCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualRelinkListingsCommand.php
@@ -32,6 +32,7 @@ final class OzonAccrualRelinkListingsCommand extends Command
     {
         $this
             ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Optional company UUID filter.')
+            ->addOption('shop-ref', null, InputOption::VALUE_REQUIRED, 'Optional shop reference filter.')
             ->addOption('from', null, InputOption::VALUE_REQUIRED, 'Optional occurred_at start date YYYY-MM-DD.')
             ->addOption('to', null, InputOption::VALUE_REQUIRED, 'Optional occurred_at end date YYYY-MM-DD.')
             ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Maximum transactions to inspect, 1..5000.', 500)
@@ -61,6 +62,7 @@ final class OzonAccrualRelinkListingsCommand extends Command
     {
         try {
             $companyId = $this->optionalUuidOption($input, 'company-id');
+            $shopRef = $this->optionalStringOption($input, 'shop-ref');
             $from = $this->optionalDateOption($input, 'from');
             $to = $this->optionalDateOption($input, 'to');
             $limit = $this->intOption($input, 'limit', 1, 5000);
@@ -84,6 +86,7 @@ final class OzonAccrualRelinkListingsCommand extends Command
             to: $to,
             limit: $limit,
             execute: $execute,
+            shopRef: $shopRef,
             componentFilter: $componentFilter,
             includeRows: !$summaryOnly && !$json,
         );
@@ -92,6 +95,7 @@ final class OzonAccrualRelinkListingsCommand extends Command
             $io->writeln((string) json_encode([
                 'mode' => $execute ? 'execute' : 'dry-run',
                 'companyId' => $companyId,
+                'shopRef' => $shopRef,
                 'from' => $from?->format('Y-m-d'),
                 'to' => $to?->format('Y-m-d'),
                 'limit' => $limit,
@@ -114,6 +118,7 @@ final class OzonAccrualRelinkListingsCommand extends Command
             [
                 ['mode', $execute ? 'execute' : 'dry-run'],
                 ['companyId', $companyId ?? 'all'],
+                ['shopRef', $shopRef ?? 'all'],
                 ['from', $from?->format('Y-m-d') ?? 'any'],
                 ['to', $to?->format('Y-m-d') ?? 'any'],
                 ['limit', (string) $limit],
@@ -192,6 +197,13 @@ final class OzonAccrualRelinkListingsCommand extends Command
         }
 
         return $date;
+    }
+
+    private function optionalStringOption(InputInterface $input, string $name): ?string
+    {
+        $value = trim((string) ($input->getOption($name) ?? ''));
+
+        return '' === $value ? null : $value;
     }
 
     private function intOption(InputInterface $input, string $name, int $min, int $max): int

--- a/site/src/Ingestion/Command/OzonAccrualRelinkListingsCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualRelinkListingsCommand.php
@@ -4,16 +4,7 @@ declare(strict_types=1);
 
 namespace App\Ingestion\Command;
 
-use App\Ingestion\Application\Source\Ozon\OzonAccrualByDayPreviewMapper;
-use App\Ingestion\Application\Source\Ozon\OzonAccrualPreviewTransaction;
-use App\Ingestion\Application\Source\Ozon\OzonListingResolver;
-use App\Ingestion\Application\Source\Ozon\OzonResourceType;
-use App\Ingestion\Entity\FinancialTransaction;
-use App\Ingestion\Enum\IngestSource;
-use App\Ingestion\Facade\RawStorageFacade;
-use App\Ingestion\Repository\FinancialTransactionRepository;
-use Doctrine\DBAL\Connection;
-use Doctrine\ORM\EntityManagerInterface;
+use App\Ingestion\Application\Service\OzonAccrualListingRelinker;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -32,12 +23,7 @@ final class OzonAccrualRelinkListingsCommand extends Command
     use LockableTrait;
 
     public function __construct(
-        private readonly Connection $connection,
-        private readonly OzonListingResolver $listingResolver,
-        private readonly RawStorageFacade $rawStorageFacade,
-        private readonly OzonAccrualByDayPreviewMapper $previewMapper,
-        private readonly FinancialTransactionRepository $transactionRepository,
-        private readonly EntityManagerInterface $entityManager,
+        private readonly OzonAccrualListingRelinker $relinker,
     ) {
         parent::__construct();
     }
@@ -49,6 +35,9 @@ final class OzonAccrualRelinkListingsCommand extends Command
             ->addOption('from', null, InputOption::VALUE_REQUIRED, 'Optional occurred_at start date YYYY-MM-DD.')
             ->addOption('to', null, InputOption::VALUE_REQUIRED, 'Optional occurred_at end date YYYY-MM-DD.')
             ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Maximum transactions to inspect, 1..5000.', 500)
+            ->addOption('component-filter', null, InputOption::VALUE_REQUIRED, 'Component filter: all or linkable.', OzonAccrualListingRelinker::COMPONENT_FILTER_ALL)
+            ->addOption('summary-only', null, InputOption::VALUE_NONE, 'Print only settings and result metrics.')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Print machine-readable JSON result.')
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show planned relinks without writing.')
             ->addOption('execute', null, InputOption::VALUE_NONE, 'Persist listing links.');
     }
@@ -75,6 +64,9 @@ final class OzonAccrualRelinkListingsCommand extends Command
             $from = $this->optionalDateOption($input, 'from');
             $to = $this->optionalDateOption($input, 'to');
             $limit = $this->intOption($input, 'limit', 1, 5000);
+            $componentFilter = $this->componentFilter($input);
+            $summaryOnly = (bool) $input->getOption('summary-only');
+            $json = (bool) $input->getOption('json');
             $execute = $this->mode($input);
 
             if (null !== $from && null !== $to && $from > $to) {
@@ -86,75 +78,34 @@ final class OzonAccrualRelinkListingsCommand extends Command
             return Command::FAILURE;
         }
 
-        $rows = $this->selectRows($companyId, $from, $to, $limit);
-        $recoveredSourceData = $this->recoverListingSourceData($rows);
-        $sourceDataByCompany = [];
-        foreach ($rows as $row) {
-            $sourceData = $this->decodeSourceData($row['source_data'] ?? null);
-            if (!$this->hasMarketplaceSkuContext($sourceData)) {
-                $sourceData = array_merge(
-                    $sourceData,
-                    $recoveredSourceData[(string) $row['company_id']][(string) $row['raw_record_id']][(string) $row['external_id']] ?? [],
-                );
-            }
+        $result = $this->relinker->relink(
+            companyId: $companyId,
+            from: $from,
+            to: $to,
+            limit: $limit,
+            execute: $execute,
+            componentFilter: $componentFilter,
+            includeRows: !$summaryOnly && !$json,
+        );
 
-            $sourceDataByCompany[(string) $row['company_id']][(string) $row['id']] = $sourceData;
-        }
+        if ($json) {
+            $io->writeln((string) json_encode([
+                'mode' => $execute ? 'execute' : 'dry-run',
+                'companyId' => $companyId,
+                'from' => $from?->format('Y-m-d'),
+                'to' => $to?->format('Y-m-d'),
+                'limit' => $limit,
+                'componentFilter' => $componentFilter,
+                'result' => [
+                    'selected' => $result['selected'],
+                    'resolved' => $result['resolved'],
+                    'updated' => $result['updated'],
+                    'wouldCreateListings' => $result['wouldCreateListings'],
+                    'unresolved' => $result['unresolved'],
+                ],
+            ], \JSON_THROW_ON_ERROR));
 
-        $resolutions = [];
-        $wouldCreateById = [];
-        foreach ($sourceDataByCompany as $rowCompanyId => $sourceDataRows) {
-            if ($execute) {
-                $resolutions += $this->listingResolver->resolveMany($rowCompanyId, $sourceDataRows);
-                continue;
-            }
-
-            foreach ($this->listingResolver->previewMany($rowCompanyId, $sourceDataRows) as $transactionId => $preview) {
-                $resolutions[$transactionId] = $preview->resolution;
-                $wouldCreateById[$transactionId] = $preview->wouldCreate;
-            }
-        }
-
-        $tableRows = [];
-        $resolved = 0;
-        $updated = 0;
-        $wouldCreateListings = 0;
-        $transactionsById = $execute ? $this->fetchTransactionsToUpdate($rows, $resolutions) : [];
-
-        foreach ($rows as $row) {
-            $transactionId = (string) $row['id'];
-            $resolution = $resolutions[$transactionId] ?? null;
-            $status = 'unresolved';
-
-            if (null !== $resolution?->listingId && null !== $resolution->listingSku) {
-                ++$resolved;
-                $status = $execute ? 'updated' : 'would-update';
-
-                if ($execute) {
-                    $transaction = $transactionsById[$transactionId] ?? null;
-                    if ($transaction instanceof FinancialTransaction && null === $transaction->getListingId()) {
-                        $transaction->setListing($resolution->listingId, $resolution->listingSku);
-                        ++$updated;
-                    }
-                }
-            } elseif (!$execute && true === ($wouldCreateById[$transactionId] ?? false) && null !== $resolution?->listingSku) {
-                ++$resolved;
-                ++$wouldCreateListings;
-                $status = 'would-create-listing+update';
-            }
-
-            $tableRows[] = [
-                $row['company_id'],
-                $row['occurred_at'],
-                $row['external_id'],
-                $resolution?->listingSku ?? '',
-                $resolution?->listingId ?? '',
-                $status,
-            ];
-        }
-
-        if ($execute) {
-            $this->entityManager->flush();
+            return Command::SUCCESS;
         }
 
         $io->title('Ozon accrual listing relink');
@@ -166,23 +117,34 @@ final class OzonAccrualRelinkListingsCommand extends Command
                 ['from', $from?->format('Y-m-d') ?? 'any'],
                 ['to', $to?->format('Y-m-d') ?? 'any'],
                 ['limit', (string) $limit],
+                ['componentFilter', $componentFilter],
             ],
         );
 
-        if ([] !== $tableRows) {
+        if (!$summaryOnly && [] !== $result['rows']) {
             $io->section('Selected transactions');
-            $io->table(['companyId', 'occurredAt', 'externalId', 'listingSku', 'listingId', 'status'], $tableRows);
+            $io->table(
+                ['companyId', 'occurredAt', 'externalId', 'listingSku', 'listingId', 'status'],
+                array_map(static fn (array $row): array => [
+                    $row['companyId'],
+                    $row['occurredAt'],
+                    $row['externalId'],
+                    $row['listingSku'],
+                    $row['listingId'],
+                    $row['status'],
+                ], $result['rows']),
+            );
         }
 
         $io->section('Result');
         $io->table(
             ['metric', 'value'],
             [
-                ['selected', (string) count($rows)],
-                ['resolved', (string) $resolved],
-                ['updated', (string) $updated],
-                ['wouldCreateListings', (string) $wouldCreateListings],
-                ['unresolved', (string) (count($rows) - $resolved)],
+                ['selected', (string) $result['selected']],
+                ['resolved', (string) $result['resolved']],
+                ['updated', (string) $result['updated']],
+                ['wouldCreateListings', (string) $result['wouldCreateListings']],
+                ['unresolved', (string) $result['unresolved']],
             ],
         );
 
@@ -193,198 +155,14 @@ final class OzonAccrualRelinkListingsCommand extends Command
         return Command::SUCCESS;
     }
 
-    /**
-     * @return list<array<string, mixed>>
-     */
-    private function selectRows(?string $companyId, ?\DateTimeImmutable $from, ?\DateTimeImmutable $to, int $limit): array
+    private function componentFilter(InputInterface $input): string
     {
-        $where = [
-            'source = :source',
-            'listing_id IS NULL',
-            "(external_id LIKE :external_id_prefix OR source_data->>'_ingestion_resource' = :resource_type)",
-        ];
-        $params = [
-            'source' => IngestSource::OZON->value,
-            'external_id_prefix' => 'ozon:accrual-by-day:%',
-            'resource_type' => OzonResourceType::ACCRUAL_BY_DAY,
-        ];
-
-        if (null !== $companyId) {
-            $where[] = 'company_id = :company_id';
-            $params['company_id'] = $companyId;
+        $value = trim((string) $input->getOption('component-filter'));
+        if (in_array($value, [OzonAccrualListingRelinker::COMPONENT_FILTER_ALL, OzonAccrualListingRelinker::COMPONENT_FILTER_LINKABLE], true)) {
+            return $value;
         }
 
-        if (null !== $from) {
-            $where[] = 'occurred_at >= :from';
-            $params['from'] = $from->setTime(0, 0)->format('Y-m-d H:i:s');
-        }
-
-        if (null !== $to) {
-            $where[] = 'occurred_at < :to_exclusive';
-            $params['to_exclusive'] = $to->modify('+1 day')->setTime(0, 0)->format('Y-m-d H:i:s');
-        }
-
-        /** @var list<array<string, mixed>> $rows */
-        $rows = $this->connection->executeQuery(
-            sprintf(
-                'SELECT id, company_id, external_id, occurred_at, source_data, raw_record_id FROM ingest_financial_transactions WHERE %s ORDER BY occurred_at ASC, id ASC LIMIT %d',
-                implode(' AND ', $where),
-                $limit,
-            ),
-            $params,
-        )->fetchAllAssociative();
-
-        return $rows;
-    }
-
-    /**
-     * @param list<array<string, mixed>> $rows
-     *
-     * @return array<string, array<string, array<string, array<string, mixed>>>>
-     */
-    private function recoverListingSourceData(array $rows): array
-    {
-        $rawRecordIdsByCompany = [];
-        foreach ($rows as $row) {
-            $sourceData = $this->decodeSourceData($row['source_data'] ?? null);
-            if ($this->hasMarketplaceSkuContext($sourceData)) {
-                continue;
-            }
-
-            $companyId = $this->stringValue($row['company_id'] ?? null);
-            $rawRecordId = $this->stringValue($row['raw_record_id'] ?? null);
-            if (null === $companyId || null === $rawRecordId) {
-                continue;
-            }
-
-            $rawRecordIdsByCompany[$companyId][$rawRecordId] = $rawRecordId;
-        }
-
-        $recovered = [];
-        foreach ($rawRecordIdsByCompany as $companyId => $rawRecordIds) {
-            foreach ($rawRecordIds as $rawRecordId) {
-                try {
-                    $rawRows = $this->rawStorageFacade->read($rawRecordId, $companyId);
-                    $previewRows = $this->previewMapper->preview($companyId, $rawRows, includeSaleRefund: true);
-                } catch (\Throwable) {
-                    continue;
-                }
-
-                foreach ($previewRows as $previewRow) {
-                    $sourceData = $this->listingSourceData($previewRow);
-                    if ([] === $sourceData) {
-                        continue;
-                    }
-
-                    $recovered[$companyId][$rawRecordId][$previewRow->sourceKey] = $sourceData;
-                }
-            }
-        }
-
-        return $recovered;
-    }
-
-    /**
-     * @param list<array<string, mixed>> $rows
-     * @param array<string, \App\Ingestion\Application\DTO\ListingResolution|null> $resolutions
-     *
-     * @return array<string, FinancialTransaction>
-     */
-    private function fetchTransactionsToUpdate(array $rows, array $resolutions): array
-    {
-        $ids = [];
-        foreach ($rows as $row) {
-            $transactionId = (string) $row['id'];
-            $resolution = $resolutions[$transactionId] ?? null;
-            if (null !== $resolution?->listingId && null !== $resolution->listingSku) {
-                $ids[$transactionId] = $transactionId;
-            }
-        }
-
-        if ([] === $ids) {
-            return [];
-        }
-
-        $transactionsById = [];
-        foreach ($this->transactionRepository->findBy(['id' => array_values($ids)]) as $transaction) {
-            if ($transaction instanceof FinancialTransaction) {
-                $transactionsById[$transaction->getId()] = $transaction;
-            }
-        }
-
-        return $transactionsById;
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function decodeSourceData(mixed $sourceData): array
-    {
-        if (is_array($sourceData)) {
-            return $sourceData;
-        }
-
-        if (!is_string($sourceData) || '' === trim($sourceData)) {
-            return [];
-        }
-
-        $decoded = json_decode($sourceData, true);
-
-        return is_array($decoded) ? $decoded : [];
-    }
-
-    /**
-     * @param array<string, mixed> $sourceData
-     */
-    private function hasMarketplaceSkuContext(array $sourceData): bool
-    {
-        if (null !== $this->stringValue($sourceData['sku'] ?? $sourceData['marketplace_sku'] ?? $sourceData['marketplaceSku'] ?? null)) {
-            return true;
-        }
-
-        $item = $sourceData['item'] ?? null;
-        if (is_array($item) && null !== $this->stringValue($item['sku'] ?? null)) {
-            return true;
-        }
-
-        $items = $sourceData['items'] ?? null;
-        if (is_array($items) && isset($items[0]) && is_array($items[0])) {
-            return null !== $this->stringValue($items[0]['sku'] ?? null);
-        }
-
-        return false;
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function listingSourceData(OzonAccrualPreviewTransaction $row): array
-    {
-        $sourceData = [];
-        if (null !== $row->marketplaceSku) {
-            $sourceData['sku'] = $row->marketplaceSku;
-        }
-
-        if (null !== $row->supplierSku) {
-            $sourceData['offer_id'] = $row->supplierSku;
-        }
-
-        if (null !== $row->listingName) {
-            $sourceData['name'] = $row->listingName;
-        }
-
-        return $sourceData;
-    }
-
-    private function stringValue(mixed $value): ?string
-    {
-        if (null === $value) {
-            return null;
-        }
-
-        $value = trim((string) $value);
-
-        return '' === $value ? null : $value;
+        throw new \InvalidArgumentException('--component-filter must be "all" or "linkable".');
     }
 
     private function optionalUuidOption(InputInterface $input, string $name): ?string

--- a/site/src/Ingestion/Entity/FinancialTransaction.php
+++ b/site/src/Ingestion/Entity/FinancialTransaction.php
@@ -189,6 +189,7 @@ class FinancialTransaction implements TenantOwnedInterface
         ?string $counterpartyId,
         ?string $description,
         array $sourceData,
+        string $rawRecordId,
         ?string $listingId = null,
         ?string $listingSku = null,
     ): void {
@@ -200,6 +201,7 @@ class FinancialTransaction implements TenantOwnedInterface
             Assert::uuid($counterpartyId);
         }
 
+        Assert::uuid($rawRecordId);
         $this->assertListing($listingId, $listingSku);
 
         $this->oldOccurredAt = $this->occurredAt;
@@ -216,7 +218,22 @@ class FinancialTransaction implements TenantOwnedInterface
         $this->listingSku = $listingSku;
         $this->description = $description;
         $this->sourceData = $sourceData;
+        $this->rawRecordId = $rawRecordId;
         $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function reattributeRawRecord(string $rawRecordId): bool
+    {
+        Assert::uuid($rawRecordId);
+
+        if ($this->rawRecordId === $rawRecordId) {
+            return false;
+        }
+
+        $this->rawRecordId = $rawRecordId;
+        $this->updatedAt = new \DateTimeImmutable();
+
+        return true;
     }
 
     /**

--- a/site/src/Ingestion/Entity/FinancialTransaction.php
+++ b/site/src/Ingestion/Entity/FinancialTransaction.php
@@ -222,15 +222,29 @@ class FinancialTransaction implements TenantOwnedInterface
         $this->updatedAt = new \DateTimeImmutable();
     }
 
-    public function reattributeRawRecord(string $rawRecordId): bool
+    public function reattributeRawRecord(string $rawRecordId, \DateTimeImmutable $externalUpdatedAt): bool
     {
         Assert::uuid($rawRecordId);
 
-        if ($this->rawRecordId === $rawRecordId) {
+        if ($externalUpdatedAt < $this->externalUpdatedAt) {
             return false;
         }
 
-        $this->rawRecordId = $rawRecordId;
+        $changed = false;
+        if ($this->rawRecordId !== $rawRecordId) {
+            $this->rawRecordId = $rawRecordId;
+            $changed = true;
+        }
+
+        if ($externalUpdatedAt > $this->externalUpdatedAt) {
+            $this->externalUpdatedAt = $externalUpdatedAt;
+            $changed = true;
+        }
+
+        if (!$changed) {
+            return false;
+        }
+
         $this->updatedAt = new \DateTimeImmutable();
 
         return true;

--- a/site/src/Ingestion/Infrastructure/Query/OzonAccrualProjectionHealthQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/OzonAccrualProjectionHealthQuery.php
@@ -7,6 +7,7 @@ namespace App\Ingestion\Infrastructure\Query;
 use App\Ingestion\Application\Source\Ozon\OzonResourceType;
 use App\Ingestion\Enum\IngestSource;
 use App\Ingestion\Enum\RawNormalizationStatus;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 
 final readonly class OzonAccrualProjectionHealthQuery
@@ -58,8 +59,8 @@ final readonly class OzonAccrualProjectionHealthQuery
         $problemPredicate = '(
             r.normalization_status <> :doneStatus
             OR COALESCE(tx.tx_count, 0) = 0
+            OR COALESCE(direct_tx.direct_raw_tx_count, 0) = 0
             OR COALESCE(issues.open_issues, 0) > 0
-            OR (tx.last_tx_updated_at IS NOT NULL AND r.fetched_at > tx.last_tx_updated_at)
         )';
 
         $problemFilter = $problemsOnly ? sprintf('AND %s', $problemPredicate) : '';
@@ -97,19 +98,23 @@ final readonly class OzonAccrualProjectionHealthQuery
                     GROUP BY raw.raw_id
                 ),
                 direct_tx AS (
-                    SELECT company_id,
-                           raw_record_id,
-                           COUNT(*) AS direct_raw_tx_count
-                    FROM ingest_financial_transactions
-                    WHERE source = :source
-                    GROUP BY company_id, raw_record_id
+                    SELECT raw.raw_id,
+                           COUNT(ft.id) AS direct_raw_tx_count
+                    FROM raw
+                    LEFT JOIN ingest_financial_transactions ft
+                      ON ft.company_id = raw.company_id
+                     AND ft.raw_record_id = raw.raw_id
+                     AND ft.source = :source
+                    GROUP BY raw.raw_id
                 ),
                 issues AS (
-                    SELECT company_id,
-                           raw_record_id,
-                           COUNT(*) FILTER (WHERE resolved_at IS NULL) AS open_issues
-                    FROM ingest_normalization_issues
-                    GROUP BY company_id, raw_record_id
+                    SELECT raw.raw_id,
+                           COUNT(i.id) FILTER (WHERE i.resolved_at IS NULL) AS open_issues
+                    FROM raw
+                    LEFT JOIN ingest_normalization_issues i
+                      ON i.company_id = raw.company_id
+                     AND i.raw_record_id = raw.raw_id
+                    GROUP BY raw.raw_id
                 )
                 SELECT r.company_id,
                        r.shop_ref,
@@ -128,8 +133,8 @@ final readonly class OzonAccrualProjectionHealthQuery
                        CASE WHEN %s THEN 1 ELSE 0 END AS needs_normalization
                 FROM raw r
                 LEFT JOIN tx ON tx.raw_id = r.raw_id
-                LEFT JOIN direct_tx ON direct_tx.company_id = r.company_id AND direct_tx.raw_record_id = r.raw_id
-                LEFT JOIN issues ON issues.company_id = r.company_id AND issues.raw_record_id = r.raw_id
+                LEFT JOIN direct_tx ON direct_tx.raw_id = r.raw_id
+                LEFT JOIN issues ON issues.raw_id = r.raw_id
                 WHERE TRUE
                 %s
                 ORDER BY needs_normalization DESC,
@@ -150,6 +155,43 @@ final readonly class OzonAccrualProjectionHealthQuery
         );
 
         return $rows;
+    }
+
+    /**
+     * @param list<string> $externalIds
+     *
+     * @return array<string, true>
+     */
+    public function projectedExternalIdSet(string $companyId, string $shopRef, array $externalIds): array
+    {
+        if ([] === $externalIds) {
+            return [];
+        }
+
+        $rows = $this->connection->executeQuery(
+            'SELECT DISTINCT external_id
+             FROM ingest_financial_transactions
+             WHERE company_id = :companyId
+               AND shop_ref = :shopRef
+               AND source = :source
+               AND external_id IN (:externalIds)',
+            [
+                'companyId' => $companyId,
+                'shopRef' => $shopRef,
+                'source' => IngestSource::OZON->value,
+                'externalIds' => $externalIds,
+            ],
+            [
+                'externalIds' => ArrayParameterType::STRING,
+            ],
+        )->fetchFirstColumn();
+
+        $result = [];
+        foreach ($rows as $row) {
+            $result[(string) $row] = true;
+        }
+
+        return $result;
     }
 
     /**

--- a/site/src/Ingestion/Infrastructure/Query/OzonAccrualProjectionHealthQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/OzonAccrualProjectionHealthQuery.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Query;
+
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\RawNormalizationStatus;
+use Doctrine\DBAL\Connection;
+
+final readonly class OzonAccrualProjectionHealthQuery
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function rawProjectionRows(
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        ?string $companyId,
+        ?string $shopRef,
+        int $limit,
+        bool $problemsOnly,
+    ): array {
+        $externalWindowFrom = "substring(r.external_id from '^accrual-by-day:([0-9]{4}-[0-9]{2}-[0-9]{2}):[0-9]{4}-[0-9]{2}-[0-9]{2}$')::date";
+        $externalWindowTo = "substring(r.external_id from '^accrual-by-day:[0-9]{4}-[0-9]{2}-[0-9]{2}:([0-9]{4}-[0-9]{2}-[0-9]{2})$')::date";
+        $windowFrom = sprintf('COALESCE(j.window_from, %s, DATE(r.fetched_at))', $externalWindowFrom);
+        $windowTo = sprintf('COALESCE(j.window_to, j.window_from, %s, %s, DATE(r.fetched_at))', $externalWindowTo, $externalWindowFrom);
+
+        $conditions = [
+            'r.source = :source',
+            'r.resource_type = :resourceType',
+            sprintf('%s <= :toDate', $windowFrom),
+            sprintf('%s >= :fromDate', $windowTo),
+        ];
+        $params = [
+            'source' => IngestSource::OZON->value,
+            'resourceType' => OzonResourceType::ACCRUAL_BY_DAY,
+            'fromDate' => $from->format('Y-m-d'),
+            'toDate' => $to->format('Y-m-d'),
+            'doneStatus' => RawNormalizationStatus::DONE->value,
+        ];
+
+        if (null !== $companyId) {
+            $conditions[] = 'r.company_id = :companyId';
+            $params['companyId'] = $companyId;
+        }
+
+        if (null !== $shopRef) {
+            $conditions[] = 'r.shop_ref = :shopRef';
+            $params['shopRef'] = $shopRef;
+        }
+
+        $problemPredicate = '(
+            r.normalization_status <> :doneStatus
+            OR COALESCE(tx.tx_count, 0) = 0
+            OR COALESCE(issues.open_issues, 0) > 0
+            OR (tx.last_tx_updated_at IS NOT NULL AND r.fetched_at > tx.last_tx_updated_at)
+            OR (tx.last_tx_updated_at IS NOT NULL AND r.updated_at > tx.last_tx_updated_at)
+        )';
+
+        $problemFilter = $problemsOnly ? sprintf('AND %s', $problemPredicate) : '';
+
+        /** @var list<array<string, mixed>> $rows */
+        $rows = $this->connection->fetchAllAssociative(
+            sprintf(
+                "WITH tx AS (
+                    SELECT company_id,
+                           raw_record_id,
+                           COUNT(*) AS tx_count,
+                           MAX(updated_at) AS last_tx_updated_at
+                    FROM ingest_financial_transactions
+                    WHERE source = :source
+                    GROUP BY company_id, raw_record_id
+                ),
+                issues AS (
+                    SELECT company_id,
+                           raw_record_id,
+                           COUNT(*) FILTER (WHERE resolved_at IS NULL) AS open_issues
+                    FROM ingest_normalization_issues
+                    GROUP BY company_id, raw_record_id
+                )
+                SELECT r.company_id,
+                       r.shop_ref,
+                       r.id AS raw_id,
+                       r.external_id,
+                       r.normalization_status,
+                       r.fetched_at,
+                       r.last_seen_at,
+                       r.updated_at AS raw_updated_at,
+                       TO_CHAR(%s, 'YYYY-MM-DD') AS window_from,
+                       TO_CHAR(%s, 'YYYY-MM-DD') AS window_to,
+                       COALESCE(tx.tx_count, 0) AS tx_count,
+                       tx.last_tx_updated_at,
+                       COALESCE(issues.open_issues, 0) AS open_issues,
+                       CASE WHEN %s THEN 1 ELSE 0 END AS needs_normalization
+                FROM ingest_raw_records r
+                LEFT JOIN ingest_sync_jobs j ON j.id::text = r.sync_job_id AND j.company_id = r.company_id
+                LEFT JOIN tx ON tx.company_id = r.company_id AND tx.raw_record_id = r.id
+                LEFT JOIN issues ON issues.company_id = r.company_id AND issues.raw_record_id = r.id
+                WHERE %s
+                %s
+                ORDER BY needs_normalization DESC,
+                         %s ASC,
+                         %s ASC,
+                         r.company_id ASC,
+                         r.shop_ref ASC,
+                         r.fetched_at ASC
+                LIMIT %d",
+                $windowFrom,
+                $windowTo,
+                $problemPredicate,
+                implode(' AND ', $conditions),
+                $problemFilter,
+                $windowFrom,
+                $windowTo,
+                $limit,
+            ),
+            $params,
+        );
+
+        return $rows;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function integritySummary(
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        ?string $companyId,
+        ?string $shopRef,
+    ): array {
+        $conditions = [
+            'ft.source = :source',
+            'ft.occurred_at >= :from',
+            'ft.occurred_at < :toExclusive',
+            "ft.external_id LIKE 'ozon:accrual-by-day:%'",
+        ];
+        $params = [
+            'source' => IngestSource::OZON->value,
+            'from' => $from->setTime(0, 0)->format('Y-m-d H:i:s'),
+            'toExclusive' => $to->modify('+1 day')->setTime(0, 0)->format('Y-m-d H:i:s'),
+        ];
+
+        if (null !== $companyId) {
+            $conditions[] = 'ft.company_id = :companyId';
+            $params['companyId'] = $companyId;
+        }
+
+        if (null !== $shopRef) {
+            $conditions[] = 'ft.shop_ref = :shopRef';
+            $params['shopRef'] = $shopRef;
+        }
+
+        /** @var array<string, mixed>|false $row */
+        $row = $this->connection->fetchAssociative(
+            sprintf(
+                "SELECT
+                    COUNT(*) AS tx_count,
+                    COUNT(*) FILTER (WHERE ft.listing_id IS NULL) AS unlinked_total,
+                    COUNT(*) FILTER (
+                        WHERE ft.listing_id IS NULL
+                          AND split_part(ft.external_id, ':', 4) = 'non_item_fee'
+                    ) AS unlinked_non_item_fee,
+                    COUNT(*) FILTER (
+                        WHERE ft.listing_id IS NOT NULL
+                          AND ml.id IS NULL
+                    ) AS broken_links,
+                    COUNT(*) FILTER (
+                        WHERE ft.listing_id IS NOT NULL
+                          AND ft.listing_sku IS DISTINCT FROM ml.marketplace_sku
+                    ) AS sku_mismatch
+                 FROM ingest_financial_transactions ft
+                 LEFT JOIN marketplace_listings ml
+                   ON ml.id = ft.listing_id
+                  AND ml.company_id = ft.company_id
+                 WHERE %s",
+                implode(' AND ', $conditions),
+            ),
+            $params,
+        );
+
+        if (!is_array($row)) {
+            return [
+                'txCount' => 0,
+                'unlinkedTotal' => 0,
+                'unlinkedNonItemFee' => 0,
+                'brokenLinks' => 0,
+                'skuMismatch' => 0,
+            ];
+        }
+
+        return [
+            'txCount' => (int) $row['tx_count'],
+            'unlinkedTotal' => (int) $row['unlinked_total'],
+            'unlinkedNonItemFee' => (int) $row['unlinked_non_item_fee'],
+            'brokenLinks' => (int) $row['broken_links'],
+            'skuMismatch' => (int) $row['sku_mismatch'],
+        ];
+    }
+}

--- a/site/src/Ingestion/Infrastructure/Query/OzonAccrualProjectionHealthQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/OzonAccrualProjectionHealthQuery.php
@@ -60,7 +60,6 @@ final readonly class OzonAccrualProjectionHealthQuery
             OR COALESCE(tx.tx_count, 0) = 0
             OR COALESCE(issues.open_issues, 0) > 0
             OR (tx.last_tx_updated_at IS NOT NULL AND r.fetched_at > tx.last_tx_updated_at)
-            OR (tx.last_tx_updated_at IS NOT NULL AND r.updated_at > tx.last_tx_updated_at)
         )';
 
         $problemFilter = $problemsOnly ? sprintf('AND %s', $problemPredicate) : '';
@@ -68,11 +67,39 @@ final readonly class OzonAccrualProjectionHealthQuery
         /** @var list<array<string, mixed>> $rows */
         $rows = $this->connection->fetchAllAssociative(
             sprintf(
-                "WITH tx AS (
+                "WITH raw AS (
+                    SELECT r.company_id,
+                           r.shop_ref,
+                           r.id AS raw_id,
+                           r.external_id,
+                           r.normalization_status,
+                           r.fetched_at,
+                           r.last_seen_at,
+                           r.updated_at AS raw_updated_at,
+                           %s AS window_from,
+                           %s AS window_to
+                    FROM ingest_raw_records r
+                    LEFT JOIN ingest_sync_jobs j ON j.id::text = r.sync_job_id AND j.company_id = r.company_id
+                    WHERE %s
+                ),
+                tx AS (
+                    SELECT raw.raw_id,
+                           COUNT(ft.id) AS tx_count,
+                           MAX(ft.updated_at) AS last_tx_updated_at
+                    FROM raw
+                    LEFT JOIN ingest_financial_transactions ft
+                      ON ft.company_id = raw.company_id
+                     AND ft.shop_ref = raw.shop_ref
+                     AND ft.source = :source
+                     AND ft.external_id LIKE 'ozon:accrual-by-day:%%'
+                     AND ft.occurred_at >= raw.window_from
+                     AND ft.occurred_at < raw.window_to + INTERVAL '1 day'
+                    GROUP BY raw.raw_id
+                ),
+                direct_tx AS (
                     SELECT company_id,
                            raw_record_id,
-                           COUNT(*) AS tx_count,
-                           MAX(updated_at) AS last_tx_updated_at
+                           COUNT(*) AS direct_raw_tx_count
                     FROM ingest_financial_transactions
                     WHERE source = :source
                     GROUP BY company_id, raw_record_id
@@ -86,38 +113,37 @@ final readonly class OzonAccrualProjectionHealthQuery
                 )
                 SELECT r.company_id,
                        r.shop_ref,
-                       r.id AS raw_id,
+                       r.raw_id,
                        r.external_id,
                        r.normalization_status,
                        r.fetched_at,
                        r.last_seen_at,
-                       r.updated_at AS raw_updated_at,
-                       TO_CHAR(%s, 'YYYY-MM-DD') AS window_from,
-                       TO_CHAR(%s, 'YYYY-MM-DD') AS window_to,
+                       r.raw_updated_at,
+                       TO_CHAR(r.window_from, 'YYYY-MM-DD') AS window_from,
+                       TO_CHAR(r.window_to, 'YYYY-MM-DD') AS window_to,
                        COALESCE(tx.tx_count, 0) AS tx_count,
+                       COALESCE(direct_tx.direct_raw_tx_count, 0) AS direct_raw_tx_count,
                        tx.last_tx_updated_at,
                        COALESCE(issues.open_issues, 0) AS open_issues,
                        CASE WHEN %s THEN 1 ELSE 0 END AS needs_normalization
-                FROM ingest_raw_records r
-                LEFT JOIN ingest_sync_jobs j ON j.id::text = r.sync_job_id AND j.company_id = r.company_id
-                LEFT JOIN tx ON tx.company_id = r.company_id AND tx.raw_record_id = r.id
-                LEFT JOIN issues ON issues.company_id = r.company_id AND issues.raw_record_id = r.id
-                WHERE %s
+                FROM raw r
+                LEFT JOIN tx ON tx.raw_id = r.raw_id
+                LEFT JOIN direct_tx ON direct_tx.company_id = r.company_id AND direct_tx.raw_record_id = r.raw_id
+                LEFT JOIN issues ON issues.company_id = r.company_id AND issues.raw_record_id = r.raw_id
+                WHERE TRUE
                 %s
                 ORDER BY needs_normalization DESC,
-                         %s ASC,
-                         %s ASC,
+                         r.window_from ASC,
+                         r.window_to ASC,
                          r.company_id ASC,
                          r.shop_ref ASC,
                          r.fetched_at ASC
                 LIMIT %d",
                 $windowFrom,
                 $windowTo,
-                $problemPredicate,
                 implode(' AND ', $conditions),
+                $problemPredicate,
                 $problemFilter,
-                $windowFrom,
-                $windowTo,
                 $limit,
             ),
             $params,

--- a/site/src/Ingestion/Infrastructure/Query/OzonAccrualProjectionHealthQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/OzonAccrualProjectionHealthQuery.php
@@ -69,19 +69,27 @@ final readonly class OzonAccrualProjectionHealthQuery
         $rows = $this->connection->fetchAllAssociative(
             sprintf(
                 "WITH raw AS (
-                    SELECT r.company_id,
-                           r.shop_ref,
-                           r.id AS raw_id,
-                           r.external_id,
-                           r.normalization_status,
-                           r.fetched_at,
-                           r.last_seen_at,
-                           r.updated_at AS raw_updated_at,
-                           %s AS window_from,
-                           %s AS window_to
-                    FROM ingest_raw_records r
-                    LEFT JOIN ingest_sync_jobs j ON j.id::text = r.sync_job_id AND j.company_id = r.company_id
-                    WHERE %s
+                    SELECT *
+                    FROM (
+                        SELECT r.company_id,
+                               r.shop_ref,
+                               r.id AS raw_id,
+                               r.external_id,
+                               r.normalization_status,
+                               r.fetched_at,
+                               r.last_seen_at,
+                               r.updated_at AS raw_updated_at,
+                               %s AS window_from,
+                               %s AS window_to,
+                               ROW_NUMBER() OVER (
+                                   PARTITION BY r.company_id, r.shop_ref, r.external_id
+                                   ORDER BY r.fetched_at DESC, r.id DESC
+                               ) AS raw_rank
+                        FROM ingest_raw_records r
+                        LEFT JOIN ingest_sync_jobs j ON j.id::text = r.sync_job_id AND j.company_id = r.company_id
+                        WHERE %s
+                    ) ranked_raw
+                    WHERE raw_rank = 1
                 ),
                 tx AS (
                     SELECT raw.raw_id,
@@ -192,6 +200,45 @@ final readonly class OzonAccrualProjectionHealthQuery
         }
 
         return $result;
+    }
+
+    /**
+     * @param list<string> $externalIds
+     */
+    public function reattributeProjectedExternalIds(
+        string $companyId,
+        string $shopRef,
+        string $rawRecordId,
+        \DateTimeImmutable $rawFetchedAt,
+        array $externalIds,
+    ): int {
+        if ([] === $externalIds) {
+            return 0;
+        }
+
+        return (int) $this->connection->executeStatement(
+            'UPDATE ingest_financial_transactions
+             SET raw_record_id = :rawRecordId,
+                 external_updated_at = GREATEST(external_updated_at, CAST(:rawFetchedAt AS TIMESTAMP)),
+                 updated_at = NOW()
+             WHERE company_id = :companyId
+               AND shop_ref = :shopRef
+               AND source = :source
+               AND external_id IN (:externalIds)
+               AND external_updated_at <= CAST(:rawFetchedAt AS TIMESTAMP)
+               AND raw_record_id <> :rawRecordId',
+            [
+                'companyId' => $companyId,
+                'shopRef' => $shopRef,
+                'rawRecordId' => $rawRecordId,
+                'rawFetchedAt' => $rawFetchedAt->format('Y-m-d H:i:s.u'),
+                'source' => IngestSource::OZON->value,
+                'externalIds' => $externalIds,
+            ],
+            [
+                'externalIds' => ArrayParameterType::STRING,
+            ],
+        );
     }
 
     /**

--- a/site/tests/Integration/Ingestion/Command/OzonAccrualRelinkListingsCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/OzonAccrualRelinkListingsCommandTest.php
@@ -160,8 +160,8 @@ final class OzonAccrualRelinkListingsCommandTest extends IntegrationTestCase
         self::assertCount(1, $rows);
         self::assertSame(1, (int) $rows[0]['tx_count']);
         self::assertSame(0, (int) $rows[0]['direct_raw_tx_count']);
-        self::assertSame(0, (int) $rows[0]['needs_normalization']);
-        self::assertSame([], $query->rawProjectionRows(
+        self::assertSame(1, (int) $rows[0]['needs_normalization']);
+        self::assertCount(1, $query->rawProjectionRows(
             from: new \DateTimeImmutable('2026-06-01'),
             to: new \DateTimeImmutable('2026-06-01'),
             companyId: $companyId,
@@ -169,6 +169,20 @@ final class OzonAccrualRelinkListingsCommandTest extends IntegrationTestCase
             limit: 10,
             problemsOnly: true,
         ));
+
+        $reconcile = $this->reconcileTester();
+        $reconcileExit = $reconcile->execute([
+            '--company-id' => $companyId,
+            '--shop-ref' => $shopRef,
+            '--from' => '2026-06-01',
+            '--to' => '2026-06-01',
+            '--execute' => true,
+            '--summary-only' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $reconcileExit, $reconcile->getDisplay());
+        self::assertStringContainsString('rawNeedsNormalization', $reconcile->getDisplay());
+        self::assertStringContainsString('0', $reconcile->getDisplay());
     }
 
     private function tester(): CommandTester
@@ -176,6 +190,13 @@ final class OzonAccrualRelinkListingsCommandTest extends IntegrationTestCase
         $app = new Application(self::$kernel);
 
         return new CommandTester($app->find('app:ingestion:ozon-accrual:relink-listings'));
+    }
+
+    private function reconcileTester(): CommandTester
+    {
+        $app = new Application(self::$kernel);
+
+        return new CommandTester($app->find('app:ingestion:ozon-accrual:reconcile-financial-projection'));
     }
 
     private function createCompany(): Company

--- a/site/tests/Integration/Ingestion/Command/OzonAccrualRelinkListingsCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/OzonAccrualRelinkListingsCommandTest.php
@@ -14,6 +14,7 @@ use App\Ingestion\Enum\IngestSource;
 use App\Ingestion\Enum\TransactionDirection;
 use App\Ingestion\Enum\TransactionType;
 use App\Ingestion\Facade\RawStorageFacade;
+use App\Ingestion\Infrastructure\Query\OzonAccrualProjectionHealthQuery;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Repository\MarketplaceListingRepository;
 use App\Shared\Domain\ValueObject\Money;
@@ -70,6 +71,104 @@ final class OzonAccrualRelinkListingsCommandTest extends IntegrationTestCase
         $createdListingId = $this->listingId($companyId, '1234567890');
         self::assertNotNull($createdListingId);
         self::assertSame([$createdListingId, '1234567890'], $this->transactionListing($transaction->getId()));
+    }
+
+    public function testExecuteCanBeScopedByShopRef(): void
+    {
+        $company = $this->createCompany();
+        $companyId = (string) $company->getId();
+        $firstShopRef = Uuid::uuid7()->toString();
+        $secondShopRef = Uuid::uuid7()->toString();
+        $firstRecord = $this->storeRawRecord(
+            companyId: $companyId,
+            connectionRef: $firstShopRef,
+            rows: [$this->postingRow(53675409101, '1234567891')],
+        );
+        $secondRecord = $this->storeRawRecord(
+            companyId: $companyId,
+            connectionRef: $secondShopRef,
+            rows: [$this->postingRow(53675409102, '1234567892')],
+        );
+        $firstTransaction = $this->persistExistingTransaction(
+            companyId: $companyId,
+            connectionRef: $firstShopRef,
+            rawRecordId: $firstRecord->getId(),
+            externalId: 'ozon:accrual-by-day:53675409101:sale:product-0',
+        );
+        $secondTransaction = $this->persistExistingTransaction(
+            companyId: $companyId,
+            connectionRef: $secondShopRef,
+            rawRecordId: $secondRecord->getId(),
+            externalId: 'ozon:accrual-by-day:53675409102:sale:product-0',
+        );
+        $this->em->flush();
+
+        $execute = $this->tester();
+        $executeExit = $execute->execute([
+            '--company-id' => $companyId,
+            '--shop-ref' => $firstShopRef,
+            '--from' => '2026-06-01',
+            '--to' => '2026-06-01',
+            '--execute' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $executeExit, $execute->getDisplay());
+        $firstListingId = $this->listingId($companyId, '1234567891');
+        self::assertNotNull($firstListingId);
+        self::assertSame([$firstListingId, '1234567891'], $this->transactionListing($firstTransaction->getId()));
+        self::assertSame([null, null], $this->transactionListing($secondTransaction->getId()));
+    }
+
+    public function testProjectionHealthUsesWindowProjectionAndIgnoresRawUpdatedAt(): void
+    {
+        $company = $this->createCompany();
+        $companyId = (string) $company->getId();
+        $shopRef = Uuid::uuid7()->toString();
+        $record = $this->storeRawRecord(
+            companyId: $companyId,
+            connectionRef: $shopRef,
+            rows: [$this->postingRow(53675409103, '1234567893')],
+        );
+        $record->markNormalizationDone();
+        $transaction = $this->persistExistingTransaction(
+            companyId: $companyId,
+            connectionRef: $shopRef,
+            rawRecordId: Uuid::uuid7()->toString(),
+            externalId: 'ozon:accrual-by-day:53675409103:sale:product-0',
+        );
+        $this->em->flush();
+        $this->connection->executeStatement(
+            'UPDATE ingest_financial_transactions SET updated_at = :updatedAt WHERE id = :id',
+            ['updatedAt' => '2026-06-03 00:00:00', 'id' => $transaction->getId()],
+        );
+        $this->connection->executeStatement(
+            'UPDATE ingest_raw_records SET updated_at = :updatedAt WHERE id = :id',
+            ['updatedAt' => '2026-06-29 00:00:00', 'id' => $record->getId()],
+        );
+
+        /** @var OzonAccrualProjectionHealthQuery $query */
+        $query = self::getContainer()->get(OzonAccrualProjectionHealthQuery::class);
+        $rows = $query->rawProjectionRows(
+            from: new \DateTimeImmutable('2026-06-01'),
+            to: new \DateTimeImmutable('2026-06-01'),
+            companyId: $companyId,
+            shopRef: $shopRef,
+            limit: 10,
+            problemsOnly: false,
+        );
+
+        self::assertCount(1, $rows);
+        self::assertSame(1, (int) $rows[0]['tx_count']);
+        self::assertSame(0, (int) $rows[0]['direct_raw_tx_count']);
+        self::assertSame(0, (int) $rows[0]['needs_normalization']);
+        self::assertSame([], $query->rawProjectionRows(
+            from: new \DateTimeImmutable('2026-06-01'),
+            to: new \DateTimeImmutable('2026-06-01'),
+            companyId: $companyId,
+            shopRef: $shopRef,
+            limit: 10,
+            problemsOnly: true,
+        ));
     }
 
     private function tester(): CommandTester
@@ -147,16 +246,16 @@ final class OzonAccrualRelinkListingsCommandTest extends IntegrationTestCase
     /**
      * @return array<string, mixed>
      */
-    private function postingRow(): array
+    private function postingRow(int $accrualId = 53675409100, string $sku = '1234567890'): array
     {
         return [
-            'accrual_id' => 53675409100,
+            'accrual_id' => $accrualId,
             'date' => '2026-06-01',
             'unit_number' => '41774559-0885-1',
             'accrued_category' => 'POSTING',
             'posting' => [
                 'products' => [[
-                    'sku' => '1234567890',
+                    'sku' => $sku,
                     'offer_id' => 'old-offer',
                     'name' => 'Old Ozon Product',
                     'commission' => [

--- a/site/tests/Unit/Ingestion/Application/Action/UpsertFinancialTransactionActionTest.php
+++ b/site/tests/Unit/Ingestion/Application/Action/UpsertFinancialTransactionActionTest.php
@@ -87,4 +87,68 @@ final class UpsertFinancialTransactionActionTest extends TestCase
         self::assertSame('44444444-4444-4444-8444-444444444444', $transaction->getListingId());
         self::assertSame('286079488', $transaction->getListingSku());
     }
+
+    public function testSameSourceDataDoesNotOverwriteExistingListingEnrichment(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $rawRecordId = Uuid::uuid7()->toString();
+        $operationGroupId = Uuid::uuid7()->toString();
+        $sourceData = ['sku' => '286079488', 'amount' => '100.00'];
+        $externalUpdatedAt = new \DateTimeImmutable('2026-06-01 00:00:00');
+        $occurredAt = new \DateTimeImmutable('2026-06-01 12:00:00');
+
+        $transaction = new FinancialTransaction(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            shopRef: 'shop-1',
+            source: IngestSource::OZON,
+            externalId: 'ozon:accrual-by-day:1:sale:product-0',
+            externalUpdatedAt: $externalUpdatedAt,
+            operationGroupId: $operationGroupId,
+            type: TransactionType::SALE,
+            direction: TransactionDirection::IN,
+            money: Money::fromMinor(10000, 'RUB'),
+            occurredAt: $occurredAt,
+            rawRecordId: $rawRecordId,
+            sourceData: $sourceData,
+            listingId: '33333333-3333-4333-8333-333333333333',
+            listingSku: 'old-sku',
+        );
+
+        $repository = $this->createMock(FinancialTransactionRepository::class);
+        $repository
+            ->method('findByNaturalKey')
+            ->with($companyId, IngestSource::OZON, 'ozon:accrual-by-day:1:sale:product-0', TransactionType::SALE)
+            ->willReturn($transaction);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::never())->method('persist');
+
+        $action = new UpsertFinancialTransactionAction($repository, $entityManager);
+
+        $result = $action(new UpsertFinancialTransactionCommand(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            shopRef: 'shop-1',
+            source: IngestSource::OZON,
+            mapped: new MappedTransaction(
+                externalId: 'ozon:accrual-by-day:1:sale:product-0',
+                externalUpdatedAt: $externalUpdatedAt,
+                operationGroupId: $operationGroupId,
+                type: TransactionType::SALE,
+                direction: TransactionDirection::IN,
+                money: Money::fromMinor(10000, 'RUB'),
+                occurredAt: $occurredAt,
+                sourceData: $sourceData,
+            ),
+            rawRecordId: $rawRecordId,
+            counterpartyId: null,
+            listingId: '44444444-4444-4444-8444-444444444444',
+            listingSku: '286079488',
+        ));
+
+        self::assertNull($result);
+        self::assertSame('33333333-3333-4333-8333-333333333333', $transaction->getListingId());
+        self::assertSame('old-sku', $transaction->getListingSku());
+    }
 }

--- a/site/tests/Unit/Ingestion/Application/Action/UpsertFinancialTransactionActionTest.php
+++ b/site/tests/Unit/Ingestion/Application/Action/UpsertFinancialTransactionActionTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Application\Action;
+
+use App\Ingestion\Application\Action\UpsertFinancialTransactionAction;
+use App\Ingestion\Application\Command\UpsertFinancialTransactionCommand;
+use App\Ingestion\Application\DTO\MappedTransaction;
+use App\Ingestion\Entity\FinancialTransaction;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+use App\Ingestion\Repository\FinancialTransactionRepository;
+use App\Shared\Domain\ValueObject\Money;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+final class UpsertFinancialTransactionActionTest extends TestCase
+{
+    public function testSameSourceDataStillUpdatesMissingListingEnrichment(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $rawRecordId = Uuid::uuid7()->toString();
+        $operationGroupId = Uuid::uuid7()->toString();
+        $sourceData = ['sku' => '286079488', 'amount' => '100.00'];
+        $externalUpdatedAt = new \DateTimeImmutable('2026-06-01 00:00:00');
+        $occurredAt = new \DateTimeImmutable('2026-06-01 12:00:00');
+
+        $transaction = new FinancialTransaction(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            shopRef: 'shop-1',
+            source: IngestSource::OZON,
+            externalId: 'ozon:accrual-by-day:1:sale:product-0',
+            externalUpdatedAt: $externalUpdatedAt,
+            operationGroupId: $operationGroupId,
+            type: TransactionType::SALE,
+            direction: TransactionDirection::IN,
+            money: Money::fromMinor(10000, 'RUB'),
+            occurredAt: $occurredAt,
+            rawRecordId: $rawRecordId,
+            sourceData: $sourceData,
+        );
+
+        $repository = $this->createMock(FinancialTransactionRepository::class);
+        $repository
+            ->method('findByNaturalKey')
+            ->with($companyId, IngestSource::OZON, 'ozon:accrual-by-day:1:sale:product-0', TransactionType::SALE)
+            ->willReturn($transaction);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::never())->method('persist');
+
+        $action = new UpsertFinancialTransactionAction($repository, $entityManager);
+
+        $result = $action(new UpsertFinancialTransactionCommand(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            shopRef: 'shop-1',
+            source: IngestSource::OZON,
+            mapped: new MappedTransaction(
+                externalId: 'ozon:accrual-by-day:1:sale:product-0',
+                externalUpdatedAt: $externalUpdatedAt,
+                operationGroupId: $operationGroupId,
+                type: TransactionType::SALE,
+                direction: TransactionDirection::IN,
+                money: Money::fromMinor(10000, 'RUB'),
+                occurredAt: $occurredAt,
+                sourceData: $sourceData,
+            ),
+            rawRecordId: $rawRecordId,
+            counterpartyId: null,
+            listingId: '44444444-4444-4444-8444-444444444444',
+            listingSku: '286079488',
+        ));
+
+        self::assertNotNull($result);
+        self::assertSame($transaction->getId(), $result->transactionId);
+        self::assertFalse($result->periodChanged);
+        self::assertSame($occurredAt, $result->oldOccurredAt);
+        self::assertSame($occurredAt, $result->newOccurredAt);
+        self::assertSame(10000, $transaction->getAmountMinor());
+        self::assertSame($externalUpdatedAt, $transaction->getExternalUpdatedAt());
+        self::assertSame($sourceData, $transaction->getSourceData());
+        self::assertSame('44444444-4444-4444-8444-444444444444', $transaction->getListingId());
+        self::assertSame('286079488', $transaction->getListingSku());
+    }
+}

--- a/site/tests/Unit/Ingestion/Application/Action/UpsertFinancialTransactionActionTest.php
+++ b/site/tests/Unit/Ingestion/Application/Action/UpsertFinancialTransactionActionTest.php
@@ -213,6 +213,7 @@ final class UpsertFinancialTransactionActionTest extends TestCase
 
         self::assertNotNull($result);
         self::assertSame($newRawRecordId, $transaction->getRawRecordId());
+        self::assertSame($newExternalUpdatedAt, $transaction->getExternalUpdatedAt());
         self::assertFalse($result->periodChanged);
     }
 
@@ -277,5 +278,6 @@ final class UpsertFinancialTransactionActionTest extends TestCase
 
         self::assertNull($result);
         self::assertSame($currentRawRecordId, $transaction->getRawRecordId());
+        self::assertSame($currentExternalUpdatedAt, $transaction->getExternalUpdatedAt());
     }
 }

--- a/site/tests/Unit/Ingestion/Application/Action/UpsertFinancialTransactionActionTest.php
+++ b/site/tests/Unit/Ingestion/Application/Action/UpsertFinancialTransactionActionTest.php
@@ -151,4 +151,131 @@ final class UpsertFinancialTransactionActionTest extends TestCase
         self::assertSame('33333333-3333-4333-8333-333333333333', $transaction->getListingId());
         self::assertSame('old-sku', $transaction->getListingSku());
     }
+
+    public function testSameSourceDataStillRefreshesRawRecordAttribution(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $oldRawRecordId = Uuid::uuid7()->toString();
+        $newRawRecordId = Uuid::uuid7()->toString();
+        $operationGroupId = Uuid::uuid7()->toString();
+        $sourceData = ['sku' => '286079488', 'amount' => '100.00'];
+        $externalUpdatedAt = new \DateTimeImmutable('2026-06-01 00:00:00');
+        $newExternalUpdatedAt = new \DateTimeImmutable('2026-06-02 00:00:00');
+        $occurredAt = new \DateTimeImmutable('2026-06-01 12:00:00');
+
+        $transaction = new FinancialTransaction(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            shopRef: 'shop-1',
+            source: IngestSource::OZON,
+            externalId: 'ozon:accrual-by-day:1:sale:product-0',
+            externalUpdatedAt: $externalUpdatedAt,
+            operationGroupId: $operationGroupId,
+            type: TransactionType::SALE,
+            direction: TransactionDirection::IN,
+            money: Money::fromMinor(10000, 'RUB'),
+            occurredAt: $occurredAt,
+            rawRecordId: $oldRawRecordId,
+            sourceData: $sourceData,
+        );
+
+        $repository = $this->createMock(FinancialTransactionRepository::class);
+        $repository
+            ->method('findByNaturalKey')
+            ->with($companyId, IngestSource::OZON, 'ozon:accrual-by-day:1:sale:product-0', TransactionType::SALE)
+            ->willReturn($transaction);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::never())->method('persist');
+
+        $action = new UpsertFinancialTransactionAction($repository, $entityManager);
+
+        $result = $action(new UpsertFinancialTransactionCommand(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            shopRef: 'shop-1',
+            source: IngestSource::OZON,
+            mapped: new MappedTransaction(
+                externalId: 'ozon:accrual-by-day:1:sale:product-0',
+                externalUpdatedAt: $newExternalUpdatedAt,
+                operationGroupId: $operationGroupId,
+                type: TransactionType::SALE,
+                direction: TransactionDirection::IN,
+                money: Money::fromMinor(10000, 'RUB'),
+                occurredAt: $occurredAt,
+                sourceData: $sourceData,
+            ),
+            rawRecordId: $newRawRecordId,
+            counterpartyId: null,
+            listingId: null,
+            listingSku: null,
+        ));
+
+        self::assertNotNull($result);
+        self::assertSame($newRawRecordId, $transaction->getRawRecordId());
+        self::assertFalse($result->periodChanged);
+    }
+
+    public function testSameSourceDataDoesNotMoveRawRecordAttributionBackwards(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $currentRawRecordId = Uuid::uuid7()->toString();
+        $staleRawRecordId = Uuid::uuid7()->toString();
+        $operationGroupId = Uuid::uuid7()->toString();
+        $sourceData = ['sku' => '286079488', 'amount' => '100.00'];
+        $currentExternalUpdatedAt = new \DateTimeImmutable('2026-06-02 00:00:00');
+        $staleExternalUpdatedAt = new \DateTimeImmutable('2026-06-01 00:00:00');
+        $occurredAt = new \DateTimeImmutable('2026-06-01 12:00:00');
+
+        $transaction = new FinancialTransaction(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            shopRef: 'shop-1',
+            source: IngestSource::OZON,
+            externalId: 'ozon:accrual-by-day:1:sale:product-0',
+            externalUpdatedAt: $currentExternalUpdatedAt,
+            operationGroupId: $operationGroupId,
+            type: TransactionType::SALE,
+            direction: TransactionDirection::IN,
+            money: Money::fromMinor(10000, 'RUB'),
+            occurredAt: $occurredAt,
+            rawRecordId: $currentRawRecordId,
+            sourceData: $sourceData,
+        );
+
+        $repository = $this->createMock(FinancialTransactionRepository::class);
+        $repository
+            ->method('findByNaturalKey')
+            ->with($companyId, IngestSource::OZON, 'ozon:accrual-by-day:1:sale:product-0', TransactionType::SALE)
+            ->willReturn($transaction);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::never())->method('persist');
+
+        $action = new UpsertFinancialTransactionAction($repository, $entityManager);
+
+        $result = $action(new UpsertFinancialTransactionCommand(
+            companyId: $companyId,
+            connectionRef: 'connection-1',
+            shopRef: 'shop-1',
+            source: IngestSource::OZON,
+            mapped: new MappedTransaction(
+                externalId: 'ozon:accrual-by-day:1:sale:product-0',
+                externalUpdatedAt: $staleExternalUpdatedAt,
+                operationGroupId: $operationGroupId,
+                type: TransactionType::SALE,
+                direction: TransactionDirection::IN,
+                money: Money::fromMinor(10000, 'RUB'),
+                occurredAt: $occurredAt,
+                sourceData: $sourceData,
+            ),
+            rawRecordId: $staleRawRecordId,
+            counterpartyId: null,
+            listingId: null,
+            listingSku: null,
+        ));
+
+        self::assertNull($result);
+        self::assertSame($currentRawRecordId, $transaction->getRawRecordId());
+    }
 }

--- a/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonAccrualByDayMapperTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonAccrualByDayMapperTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Ingestion\Application\Source\Ozon;
 use App\Ingestion\Application\DTO\MappedTransaction;
 use App\Ingestion\Application\Source\Ozon\OzonAccrualByDayMapper;
 use App\Ingestion\Application\Source\Ozon\OzonAccrualByDayPreviewMapper;
+use App\Ingestion\Application\Source\Ozon\OzonAccrualPreviewTransaction;
 use App\Ingestion\Application\Source\Ozon\OzonMoneyParser;
 use App\Ingestion\Application\Source\Ozon\OzonResourceType;
 use App\Ingestion\Domain\Service\SourceDataHasher;
@@ -155,6 +156,28 @@ final class OzonAccrualByDayMapperTest extends TestCase
         self::assertSame(130502, $commission->money->amountMinor());
     }
 
+    public function testPreviewSourceKeysMatchMappedExternalIdsForCronCoverageCheck(): void
+    {
+        $companyId = '19621cff-b028-45d9-9193-11f47ad9a8b2';
+        $rawRecord = $this->rawRecord($companyId);
+        $rawRows = $this->representativeAccrualRows();
+
+        $mappedExternalIds = array_map(
+            static fn (MappedTransaction $transaction): string => $transaction->externalId,
+            $this->mapper()->map($rawRecord, $rawRows),
+        );
+        $previewSourceKeys = array_map(
+            static fn (OzonAccrualPreviewTransaction $row): string => $row->sourceKey,
+            $this->previewMapper()->preview($companyId, $rawRows, includeSaleRefund: true),
+        );
+
+        sort($mappedExternalIds);
+        sort($previewSourceKeys);
+
+        self::assertSame($mappedExternalIds, $previewSourceKeys);
+        self::assertNotEmpty($previewSourceKeys);
+    }
+
     /**
      * @param list<MappedTransaction> $transactions
      */
@@ -171,7 +194,12 @@ final class OzonAccrualByDayMapperTest extends TestCase
 
     private function mapper(): OzonAccrualByDayMapper
     {
-        return new OzonAccrualByDayMapper(new OzonAccrualByDayPreviewMapper(new OzonMoneyParser(), new SourceDataHasher()));
+        return new OzonAccrualByDayMapper($this->previewMapper());
+    }
+
+    private function previewMapper(): OzonAccrualByDayPreviewMapper
+    {
+        return new OzonAccrualByDayPreviewMapper(new OzonMoneyParser(), new SourceDataHasher());
     }
 
     private function rawRecord(string $companyId): IngestRawRecord
@@ -189,5 +217,103 @@ final class OzonAccrualByDayMapperTest extends TestCase
             fetchedAt: new \DateTimeImmutable('2026-06-20 20:35:35'),
             syncJobId: Uuid::uuid7()->toString(),
         );
+    }
+
+    /**
+     * Covers the component families that the reconciliation cron compares by natural source key.
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function representativeAccrualRows(): array
+    {
+        return [
+            [
+                'accrual_id' => 53675409100,
+                'date' => '2026-06-13',
+                'unit_number' => '41774559-0885-1',
+                'accrued_category' => 'POSTING',
+                'posting' => [
+                    'products' => [[
+                        'sku' => 'ozon-sku-1',
+                        'offer_id' => 'offer-1',
+                        'name' => 'Ozon Product 1',
+                        'delivery' => [
+                            'services' => [
+                                ['type_id' => 29, 'accrued' => ['amount' => '-7.86', 'currency' => 'RUB']],
+                                ['type_id' => 45, 'accrued' => ['amount' => '-15', 'currency' => 'RUB']],
+                            ],
+                        ],
+                        'commission' => [
+                            'bonus' => ['amount' => '12.79', 'currency' => 'RUB'],
+                            'commission' => ['amount' => '-120.05', 'currency' => 'RUB'],
+                            'sale_amount' => ['amount' => '66718', 'currency' => 'RUB'],
+                        ],
+                    ]],
+                ],
+            ],
+            [
+                'accrual_id' => 53675409104,
+                'date' => '2026-06-13',
+                'accrued_category' => 'POSTING',
+                'posting' => [
+                    'products' => [[
+                        'commission' => [
+                            'commission' => ['amount' => '1305.02', 'currency' => 'RUB'],
+                            'sale_amount' => ['amount' => '-2837.00', 'currency' => 'RUB'],
+                        ],
+                    ]],
+                ],
+            ],
+            [
+                'accrual_id' => 53675409101,
+                'date' => '2026-06-13',
+                'accrued_category' => 'ITEM',
+                'item_fees' => [
+                    'fees' => [[
+                        'sku' => 'item-sku-1',
+                        'offer_id' => 'item-offer-1',
+                        'name' => 'Item Product 1',
+                        'fees' => [
+                            ['type_id' => 1, 'accrued' => ['amount' => '18.66', 'currency' => 'RUB']],
+                        ],
+                    ]],
+                ],
+            ],
+            [
+                'accrual_id' => 53675409102,
+                'date' => '2026-06-14',
+                'accrued_category' => 'NON_ITEM',
+                'non_item_fee' => ['type_id' => 46, 'accrued' => ['amount' => '-78.28', 'currency' => 'RUB']],
+            ],
+            [
+                'accrual_id' => 53675409103,
+                'date' => '2026-06-14',
+                'accrued_category' => 'CONTAINER',
+                'container_fees' => [
+                    'fees' => [
+                        ['type_id' => 77, 'accrued' => ['amount' => '-3.50', 'currency' => 'RUB']],
+                    ],
+                ],
+            ],
+            [
+                'accrual_id' => 53675409105,
+                'date' => '2026-06-14',
+                'accrued_category' => 'POSTING',
+                'posting' => [
+                    'products' => [[
+                        'commission' => [
+                            'commission' => ['amount' => '0', 'currency' => 'RUB'],
+                            'sale_amount' => ['amount' => '0', 'currency' => 'RUB'],
+                        ],
+                    ]],
+                ],
+            ],
+            [
+                'accrual_id' => 53675409106,
+                'date' => '2026-06-14',
+                'accrued_category' => 'UNKNOWN',
+                'total_amount' => ['amount' => '99', 'currency' => 'RUB'],
+            ],
+        ];
     }
 }

--- a/site/tests/Unit/Ingestion/Entity/FinancialTransactionTest.php
+++ b/site/tests/Unit/Ingestion/Entity/FinancialTransactionTest.php
@@ -35,6 +35,7 @@ final class FinancialTransactionTest extends TestCase
         $transaction = $this->newTransaction();
         $oldOccurredAt = $transaction->getOccurredAt();
         $newOccurredAt = new \DateTimeImmutable('2026-06-03 12:00:00');
+        $newRawRecordId = Uuid::uuid7()->toString();
 
         $transaction->replaceFromNewerVersion(
             money: Money::fromMinor(15000, 'RUB'),
@@ -47,6 +48,7 @@ final class FinancialTransactionTest extends TestCase
             counterpartyId: null,
             description: 'updated',
             sourceData: ['row' => 2],
+            rawRecordId: $newRawRecordId,
             listingId: '55555555-5555-4555-8555-555555555555',
             listingSku: 'sku-2',
         );
@@ -56,6 +58,7 @@ final class FinancialTransactionTest extends TestCase
         self::assertSame($oldOccurredAt, $transaction->oldOccurredAt());
         self::assertSame('order-2', $transaction->getOrderRef());
         self::assertSame(['row' => 2], $transaction->getSourceData());
+        self::assertSame($newRawRecordId, $transaction->getRawRecordId());
         self::assertSame('55555555-5555-4555-8555-555555555555', $transaction->getListingId());
         self::assertSame('sku-2', $transaction->getListingSku());
     }
@@ -77,7 +80,18 @@ final class FinancialTransactionTest extends TestCase
             counterpartyId: null,
             description: null,
             sourceData: [],
+            rawRecordId: Uuid::uuid7()->toString(),
         );
+    }
+
+    public function testReattributesRawRecord(): void
+    {
+        $transaction = $this->newTransaction();
+        $rawRecordId = Uuid::uuid7()->toString();
+
+        self::assertTrue($transaction->reattributeRawRecord($rawRecordId));
+        self::assertSame($rawRecordId, $transaction->getRawRecordId());
+        self::assertFalse($transaction->reattributeRawRecord($rawRecordId));
     }
 
     private function newTransaction(): FinancialTransaction

--- a/site/tests/Unit/Ingestion/Entity/FinancialTransactionTest.php
+++ b/site/tests/Unit/Ingestion/Entity/FinancialTransactionTest.php
@@ -88,10 +88,14 @@ final class FinancialTransactionTest extends TestCase
     {
         $transaction = $this->newTransaction();
         $rawRecordId = Uuid::uuid7()->toString();
+        $externalUpdatedAt = new \DateTimeImmutable('2026-06-03 00:00:00');
 
-        self::assertTrue($transaction->reattributeRawRecord($rawRecordId));
+        self::assertTrue($transaction->reattributeRawRecord($rawRecordId, $externalUpdatedAt));
         self::assertSame($rawRecordId, $transaction->getRawRecordId());
-        self::assertFalse($transaction->reattributeRawRecord($rawRecordId));
+        self::assertSame($externalUpdatedAt, $transaction->getExternalUpdatedAt());
+        self::assertFalse($transaction->reattributeRawRecord($rawRecordId, $externalUpdatedAt));
+        self::assertFalse($transaction->reattributeRawRecord(Uuid::uuid7()->toString(), new \DateTimeImmutable('2026-06-02 00:00:00')));
+        self::assertSame($rawRecordId, $transaction->getRawRecordId());
     }
 
     private function newTransaction(): FinancialTransaction

--- a/site/tests/bootstrap.php
+++ b/site/tests/bootstrap.php
@@ -24,6 +24,7 @@ DG\BypassFinals::allowPaths([
     '*/src/MarketplaceAds/Repository/AdRawDocumentRepository.php',
     '*/src/Shared/Service/Storage/StorageService.php',
     '*/src/Ingestion/Repository/IngestRawRecordRepository.php',
+    '*/src/Ingestion/Repository/FinancialTransactionRepository.php',
 ]);
 
 if (method_exists(Dotenv::class, 'bootEnv')) {


### PR DESCRIPTION
## Summary

Adds an automated Ozon accrual **financial projection reconciliation** flow. The goal is to keep normalized `FinancialTransaction` rows aligned with stored raw accrual reports and listing enrichment without manually running day-by-day relink batches.

## What Changed

- Added `app:ingestion:ozon-accrual:reconcile-financial-projection` as the business-level maintenance command.
- The command detects incomplete raw-to-financial projection by raw normalization status, missing projected transactions for the raw window, missing direct raw projection diagnostics, open normalization issues, broken listing links, SKU mismatches, and unresolved linkable transactions.
- Projection health checks transaction coverage by `company_id + shop_ref + accrual window + Ozon accrual external_id`, not only by `raw_record_id`.
- Projection health now considers the latest stored raw snapshot per `company_id + shop_ref + external_id`, so superseded re-fetch snapshots do not keep producing stale candidates.
- For DONE raw snapshots with zero direct `raw_record_id` rows, the command replays the raw preview mapper and verifies expected natural `sourceKey` coverage in `FinancialTransaction`; fully covered snapshots are not re-dispatched forever.
- In execute mode, fully covered snapshots repair direct raw attribution by moving already-projected transactions to the current raw record when the raw snapshot is not older than the transaction version. This makes the expensive natural-key preview check converge after one repair pass.
- Raw operational timestamps such as `raw.updated_at` / `fetched_at > tx.updated_at` are no longer treated as projection staleness signals, because normalization itself can update raw records after transaction flush and unchanged re-fetches may not update canonical transactions.
- Supports `--dispatch-normalization` and `--execute-inline-normalization` so stale raw records can be reprocessed without manually enumerating days or batches.
- Added `--repair-enrichment-only` for the second scheduled pass: it repairs listing enrichment after workers run without re-dispatching normalization.
- Extracted Ozon accrual listing enrichment repair into `OzonAccrualListingRelinker` and made `relink-listings` automation-friendly with `--summary-only`, `--json`, `--component-filter`, and `--shop-ref`.
- Reconciliation relink repair respects `--shop-ref`, so scoped reports and scoped mutations operate on the same cabinet.
- Updated `UpsertFinancialTransactionAction` so unchanged financial `source_data` can fill missing `listing_id/listing_sku` and refresh raw attribution from newer raw snapshots, but does not overwrite an already linked transaction or move attribution backwards to stale raw data.
- Multi-batch relink now accumulates `unresolved` instead of reporting only the last batch.
- Added two daily cron passes: first dispatches stale normalization, second repairs enrichment only.
- Added regression coverage for enrichment-only upsert, no-overwrite listing enrichment, raw attribution refresh/no-backwards attribution, shop-scoped relink execution, projection health over newer raw snapshots whose transactions are already projected by natural keys, and preview-vs-normalizer source-key parity used by cron coverage checks.

## Correctness Review Items Closed

- Item 1: removed timestamp-based projection staleness (`raw.updated_at` / `fetched_at > tx.updated_at`) so unchanged re-fetched snapshots converge.
- Item 2: zero direct raw projection is now surfaced, then confirmed by natural-key coverage before reprocessing.
- Item 3: inline normalization no longer counts a successful action as both changed and failed when status refresh/reporting fails after the action.
- Item 4: second cron pass is no longer byte-identical; it uses `--repair-enrichment-only` instead of dispatching normalization again.
- Item 7: `direct_tx` and `issues` CTEs are scoped from the selected raw CTE instead of scanning whole tables.
- N1: natural-key-covered raw snapshots now converge in execute mode by reattributing existing projected transactions to the current raw record, and health only considers the latest raw snapshot for a window.
- N2: added `testPreviewSourceKeysMatchMappedExternalIdsForCronCoverageCheck` to prove the preview `sourceKey` set used by reconciliation matches the external ids produced by the real accrual mapper for representative sale/refund/commission/delivery/item/non-item/container/ignored rows.
- N3: multi-batch relink unresolved count now accumulates across batches.
- Additional correctness hardening: unchanged-source-data upsert no longer overwrites an existing non-null listing link and no longer moves raw attribution backwards from stale raw snapshots.

## Next PR Scope

- Improve report semantics for unresolved rows: separate expected `non_item_fee` / non-listing rows from real actionable problems.
- Reduce raw-storage reads further if candidate volume grows beyond the cron budget, likely via projection fingerprint/hash or a persisted projection coverage marker.
- Extract shared CLI option parsing/report helpers if more reconciliation commands adopt the same pattern.
- Tighten operational docs around cron timing, worker expectations, and what to do when stale normalization remains after the first pass.

## Best Practice Captured

Reprocessing should be driven by raw-data freshness and projection health, not only by rows currently missing `listing_id`. If raw Ozon accrual data changes or arrives late for a period, the raw snapshot must be compared against the existing normalized financial projection, including rows that do not belong to a listing. Listing repair is only one part of the financial projection reconciliation.

The health check must avoid operational timestamps that are updated by normalization itself. It should compare raw business content to projected transaction natural keys and keep direct `raw_record_id` counts as diagnostics and candidate signals, not as the only proof of projection. In execute mode, once natural-key coverage proves that the projection already exists, direct raw attribution should be repaired so the same raw snapshot is not expensive to prove again on every cron run.

## Root Cause

Existing normalization could skip persistence updates when canonical `source_data` was unchanged, leaving old `FinancialTransaction` rows without refreshed listing enrichment or raw attribution even after SKU context and newer raw snapshots became recoverable. Manual relink commands handled the incident, but there was no scheduled business-level reconciliation for the full raw-to-financial projection.

## Validation

Local checks on latest commit `9ce6e685`:

- `php -l` passed for changed runtime PHP files.
- `app:ingestion:ozon-accrual:reconcile-financial-projection --help` passed and includes `--repair-enrichment-only`.
- Targeted unit: `FinancialTransactionTest|UpsertFinancialTransactionActionTest` passed, 8 tests / 64 assertions.
- `make site-test-unit` passed: 1225 tests / 7523 assertions, with 1 existing warning and 1 existing deprecation.
- Targeted php-cs-fixer dry-run passed for changed PHP files.
- `git diff --check` passed.

GitHub CI on latest commit `9ce6e685`:

- `migrations-empty-db` passed.
- `Check API types sync` passed.
- `Unit tests` passed.
- Docker image builds passed for landing, site-nginx, site-php-cli, and site-php-fpm.
- `deploy` and production `migrations` jobs were skipped as expected for the draft PR flow.

Known check limitation:

- Latest local targeted integration run for `OzonAccrualRelinkListingsCommandTest` was blocked before test setup because the throwaway `site-php-cli` container could not resolve `site-postgres` (`SQLSTATE[08006] could not translate host name "site-postgres"`). `docker compose ps` shows `site-postgres` healthy, and direct `site-php-cli getent hosts site-postgres` also fails in this local environment.
- `make site-cs-check` still fails on existing unrelated style issues across the repository; targeted CS for changed files is clean.
- `composer lint:container` is not defined in this project.

## Notes

- No database migrations are included.
- PR remains draft for owner/reviewer review.
